### PR TITLE
fix(op-supervisor/logs): atomic operations and crash-safe recovery

### DIFF
--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -912,10 +912,12 @@ func TestLogsDBChainIngester_InitIngestion_ResumeFromExistingDB(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { ingester2.logsDB.Close() })
 
-	// Call initIngestion - should resume from block 102
+	// Call initIngestion - logs.DB drops the last sealed block on reopen
+	// (it cannot prove the prior Sync return value was observed), so the
+	// recovered tail is block 100 and ingestion resumes from block 101.
 	nextBlock, err := ingester2.initIngestion()
 	require.NoError(t, err)
-	require.Equal(t, uint64(102), nextBlock) // Should resume after block 101
+	require.Equal(t, uint64(101), nextBlock)
 
 	// Verify earliest block was found
 	require.True(t, ingester2.earliestIngestedBlockSet.Load())

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -50,7 +50,11 @@ func TestLogsDB_Persistence(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		// Reopen and verify persistence
+		// Reopen and verify persistence. Under the logs.DB drop-last-block
+		// recovery rule, the most recently sealed block is discarded on
+		// reopen (we cannot prove its Sync return value was observed). The
+		// parent block (sealed earlier with post-boundary entries proving
+		// durability) survives.
 		{
 			db, err := openLogsDB(gethlog.New(), chainID, dataDir)
 			require.NoError(t, err)
@@ -58,8 +62,8 @@ func TestLogsDB_Persistence(t *testing.T) {
 
 			latestBlock, ok := db.LatestSealedBlock()
 			require.True(t, ok)
-			require.Equal(t, uint64(100), latestBlock.Number)
-			require.Equal(t, common.Hash{0x03}, latestBlock.Hash)
+			require.Equal(t, uint64(99), latestBlock.Number)
+			require.Equal(t, common.Hash{0x01}, latestBlock.Hash)
 		}
 	})
 

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
@@ -15,6 +15,17 @@ type EntryStore[T EntryType, E Entry[T]] interface {
 	Read(idx EntryIdx) (E, error)
 	Append(entries ...E) error
 	Truncate(idx EntryIdx) error
+	// Sync forces any buffered data and metadata to disk. On Linux this calls
+	// fsync(2). On macOS it does NOT issue F_FULLFSYNC, so the device write
+	// cache is not flushed; developers running locally on macOS get weaker
+	// durability than production Linux.
+	Sync() error
+	// PrepareForMutation drains any outstanding deferred cleanup so that the
+	// store is in a known-good state before the caller mutates its own
+	// in-memory invariants. If the drain itself fails, the cleanup remains
+	// outstanding and the returned error must be propagated; the caller MUST
+	// NOT proceed with the mutation.
+	PrepareForMutation() error
 	Close() error
 }
 
@@ -39,22 +50,35 @@ type Binary[T EntryType, E Entry[T]] interface {
 	EntrySize() int
 }
 
-// dataAccess defines a minimal API required to manipulate the actual stored data.
-// It is a subset of the os.File API but could (theoretically) be satisfied by an in-memory implementation for testing.
-type dataAccess interface {
+// DataAccess defines a minimal API required to manipulate the actual stored
+// data. It is a subset of the os.File API but could (theoretically) be
+// satisfied by an in-memory implementation for testing.
+type DataAccess interface {
 	io.ReaderAt
 	io.Writer
 	io.Closer
 	Truncate(size int64) error
+	// Sync forces any buffered data and metadata to disk. Mirrors *os.File.Sync.
+	Sync() error
+}
+
+// pendingCleanup tracks an outstanding logical upper bound enforced because a
+// prior Truncate (either a rollback after a partial Write or an explicit
+// caller-issued Truncate) failed and left the on-disk file longer than the
+// logical end of the database. While active, reads must be bounded by
+// truncateTo and the next mutation drains by retrying the Truncate.
+type pendingCleanup struct {
+	active     bool
+	truncateTo EntryIdx
 }
 
 type EntryDB[T EntryType, E Entry[T], B Binary[T, E]] struct {
-	data         dataAccess
+	data         DataAccess
 	lastEntryIdx EntryIdx
 
 	b B
 
-	cleanupFailedWrite bool
+	pendingCleanup pendingCleanup
 }
 
 // NewEntryDB creates an EntryDB. A new file will be created if the specified path does not exist,
@@ -87,20 +111,41 @@ func NewEntryDB[T EntryType, E Entry[T], B Binary[T, E]](logger log.Logger, path
 	return db, nil
 }
 
+// NewEntryDBFromDataAccess constructs an EntryDB around an existing
+// DataAccess implementation. Intended for tests that wrap *os.File with
+// fault-injection shims. lastEntryIdx must already reflect the current size
+// of the underlying data, in entries.
+func NewEntryDBFromDataAccess[T EntryType, E Entry[T], B Binary[T, E]](data DataAccess, lastEntryIdx EntryIdx) *EntryDB[T, E, B] {
+	return &EntryDB[T, E, B]{
+		data:         data,
+		lastEntryIdx: lastEntryIdx,
+	}
+}
+
+// effectiveLastEntryIdx returns the logical upper bound for reads. When
+// pendingCleanup is active, the on-disk file is longer than the logical end of
+// the database; readers must observe the smaller of the two.
+func (e *EntryDB[T, E, B]) effectiveLastEntryIdx() EntryIdx {
+	if e.pendingCleanup.active && e.pendingCleanup.truncateTo < e.lastEntryIdx {
+		return e.pendingCleanup.truncateTo
+	}
+	return e.lastEntryIdx
+}
+
 func (e *EntryDB[T, E, B]) Size() int64 {
-	return int64(e.lastEntryIdx) + 1
+	return int64(e.effectiveLastEntryIdx()) + 1
 }
 
 // LastEntryIdx returns the index of the last entry in the DB.
 // This returns -1 if the DB is empty.
 func (e *EntryDB[T, E, B]) LastEntryIdx() EntryIdx {
-	return e.lastEntryIdx
+	return e.effectiveLastEntryIdx()
 }
 
 // Read an entry from the database by index. Returns io.EOF iff idx is after the last entry.
 func (e *EntryDB[T, E, B]) Read(idx EntryIdx) (E, error) {
 	var out E
-	if idx > e.lastEntryIdx {
+	if idx > e.effectiveLastEntryIdx() {
 		return out, io.EOF
 	}
 	read, err := e.b.ReadAt(&out, e.data, int64(idx)*int64(e.b.EntrySize()))
@@ -111,15 +156,38 @@ func (e *EntryDB[T, E, B]) Read(idx EntryIdx) (E, error) {
 	return out, nil
 }
 
+// drainCleanup retries the pending Truncate. On success, pendingCleanup is
+// cleared and lastEntryIdx is updated.
+func (e *EntryDB[T, E, B]) drainCleanup() error {
+	if !e.pendingCleanup.active {
+		return nil
+	}
+	target := e.pendingCleanup.truncateTo
+	if err := e.data.Truncate((int64(target) + 1) * int64(e.b.EntrySize())); err != nil {
+		return fmt.Errorf("failed to drain pending cleanup truncate to %v: %w", target, err)
+	}
+	e.lastEntryIdx = target
+	e.pendingCleanup = pendingCleanup{}
+	return nil
+}
+
+// PrepareForMutation drains any deferred cleanup. Callers invoke this before
+// mutating in-memory state they want kept consistent with disk: if the drain
+// fails the store stays in its current (cleanup-active) state, the caller
+// receives the error, and no in-memory state has been advanced.
+func (e *EntryDB[T, E, B]) PrepareForMutation() error {
+	return e.drainCleanup()
+}
+
 // Append entries to the database.
 // The entries are combined in memory and passed to a single Write invocation.
 // If the write fails, it will attempt to truncate any partially written data.
-// Subsequent writes to this instance will fail until partially written data is truncated.
+// If pending cleanup from a prior failure exists, it is drained first; on
+// drain failure the same typed error is returned without touching state.
 func (e *EntryDB[T, E, B]) Append(entries ...E) error {
-	if e.cleanupFailedWrite {
-		// Try to rollback partially written data from a previous Append
-		if truncateErr := e.Truncate(e.lastEntryIdx); truncateErr != nil {
-			return fmt.Errorf("failed to recover from previous write error: %w", truncateErr)
+	if e.pendingCleanup.active {
+		if err := e.drainCleanup(); err != nil {
+			return err
 		}
 	}
 	data := make([]byte, 0, len(entries)*e.b.EntrySize())
@@ -131,13 +199,12 @@ func (e *EntryDB[T, E, B]) Append(entries ...E) error {
 			// Didn't write any data, so no recovery required
 			return err
 		}
-		// Try to rollback the partially written data
-		if truncateErr := e.Truncate(e.lastEntryIdx); truncateErr != nil {
-			// Failed to rollback, set a flag to attempt the clean up on the next write
-			e.cleanupFailedWrite = true
-			return errors.Join(err, fmt.Errorf("failed to remove partially written data: %w", truncateErr))
+		// Stage a rollback of the partial write and let drainCleanup execute it.
+		// On drain failure, pendingCleanup stays active and the next mutation retries.
+		e.pendingCleanup = pendingCleanup{active: true, truncateTo: e.lastEntryIdx}
+		if drainErr := e.drainCleanup(); drainErr != nil {
+			return errors.Join(err, fmt.Errorf("failed to remove partially written data: %w", drainErr))
 		}
-		// Successfully rolled back the changes, still report the failed write
 		return err
 	}
 	e.lastEntryIdx += EntryIdx(len(entries))
@@ -145,20 +212,34 @@ func (e *EntryDB[T, E, B]) Append(entries ...E) error {
 }
 
 // Truncate the database so that the last retained entry is idx. Any entries after idx are deleted.
+// On failure, pendingCleanup is left active so that the next mutation will retry the truncate while
+// reads continue to observe the smaller logical bound.
 func (e *EntryDB[T, E, B]) Truncate(idx EntryIdx) error {
-	if err := e.data.Truncate((int64(idx) + 1) * int64(e.b.EntrySize())); err != nil {
-		return fmt.Errorf("failed to truncate to entry %v: %w", idx, err)
+	// If pendingCleanup is active, its truncateTo is the strictest known target;
+	// Truncate can only shrink further, never relax it. Take the stricter of the
+	// two, install it as the pending target, and let drainCleanup do the work
+	// (file truncate + lastEntryIdx update + clear-on-success).
+	if e.pendingCleanup.active && idx > e.pendingCleanup.truncateTo {
+		idx = e.pendingCleanup.truncateTo
 	}
-	// Update the lastEntryIdx cache
-	e.lastEntryIdx = idx
-	e.cleanupFailedWrite = false
-	return nil
+	e.pendingCleanup = pendingCleanup{active: true, truncateTo: idx}
+	return e.drainCleanup()
 }
 
-// recover an invalid database by truncating back to the last complete event.
+// Sync forces any buffered data and metadata to disk. On Linux this is fsync(2).
+// On macOS this does NOT issue F_FULLFSYNC; the device write cache is not flushed.
+func (e *EntryDB[T, E, B]) Sync() error {
+	return e.data.Sync()
+}
+
+// recover an invalid database by truncating back to the last complete event,
+// then fsyncs so the recovery truncate is durable.
 func (e *EntryDB[T, E, B]) recover() error {
 	if err := e.data.Truncate(e.Size() * int64(e.b.EntrySize())); err != nil {
 		return fmt.Errorf("failed to truncate trailing partial entries: %w", err)
+	}
+	if err := e.data.Sync(); err != nil {
+		return fmt.Errorf("failed to sync after recovery truncate: %w", err)
 	}
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
@@ -243,6 +243,8 @@ type stubDataAccess struct {
 	writeErr           error
 	writeErrAfterBytes int
 	truncateErr        error
+	syncErr            error
+	syncCalls          int
 }
 
 func (s *stubDataAccess) ReadAt(p []byte, off int64) (n int, err error) {
@@ -270,4 +272,9 @@ func (s *stubDataAccess) Truncate(size int64) error {
 	return nil
 }
 
-var _ dataAccess = (*stubDataAccess)(nil)
+func (s *stubDataAccess) Sync() error {
+	s.syncCalls++
+	return s.syncErr
+}
+
+var _ DataAccess = (*stubDataAccess)(nil)

--- a/op-supervisor/supervisor/backend/db/entrydb/memdb.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/memdb.go
@@ -34,6 +34,17 @@ func (s *MemEntryStore[T, E]) Truncate(idx EntryIdx) error {
 	return nil
 }
 
+// Sync is a no-op for the in-memory store. Durability is not exercised here;
+// MemEntryStore is used by unit tests that don't crash-test.
+func (s *MemEntryStore[T, E]) Sync() error {
+	return nil
+}
+
+// PrepareForMutation is a no-op: the in-memory store never has deferred cleanup.
+func (s *MemEntryStore[T, E]) PrepareForMutation() error {
+	return nil
+}
+
 func (s *MemEntryStore[T, E]) Close() error {
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/logs/crash_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/crash_test.go
@@ -163,4 +163,3 @@ func TestCrashInjection_PeriodicCheckpointBoundary(t *testing.T) {
 		require.NoError(t, db.Close())
 	}
 }
-

--- a/op-supervisor/supervisor/backend/db/logs/crash_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/crash_test.go
@@ -1,0 +1,166 @@
+package logs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
+)
+
+// crashInjector wraps an *os.File and can fail Write/Truncate/Sync to simulate
+// crash scenarios at different points in a commit. It tracks call counts so
+// tests can assert syscall count invariants alongside atomicity.
+type crashInjector struct {
+	f             *os.File
+	writeFail     bool
+	writeFailHead int // bytes written before Write returns the error (0 = whole write rejected)
+	truncateFail  bool
+	syncFail      bool
+
+	writeCalls    int
+	truncateCalls int
+	syncCalls     int
+}
+
+func newCrashInjector(t *testing.T, path string) *crashInjector {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o644)
+	require.NoError(t, err)
+	return &crashInjector{f: f}
+}
+
+func (c *crashInjector) ReadAt(p []byte, off int64) (int, error) {
+	return c.f.ReadAt(p, off)
+}
+
+func (c *crashInjector) Write(p []byte) (int, error) {
+	c.writeCalls++
+	if c.writeFail {
+		// Optionally let part of the write land on disk, then fail.
+		n := c.writeFailHead
+		if n > len(p) {
+			n = len(p)
+		}
+		if n > 0 {
+			if _, err := c.f.Write(p[:n]); err != nil {
+				return 0, err
+			}
+		}
+		return n, errors.New("injected write failure")
+	}
+	return c.f.Write(p)
+}
+
+func (c *crashInjector) Truncate(size int64) error {
+	c.truncateCalls++
+	if c.truncateFail {
+		return errors.New("injected truncate failure")
+	}
+	return c.f.Truncate(size)
+}
+
+func (c *crashInjector) Sync() error {
+	c.syncCalls++
+	if c.syncFail {
+		return errors.New("injected sync failure")
+	}
+	return c.f.Sync()
+}
+
+func (c *crashInjector) Close() error {
+	return c.f.Close()
+}
+
+// openDBWithInjector wires a crashInjector behind an EntryDB and constructs a
+// logs.DB on top of it.
+func openDBWithInjector(t *testing.T, dir string) (*DB, *crashInjector, *stubMetrics) {
+	t.Helper()
+	path := filepath.Join(dir, "test.db")
+	inj := newCrashInjector(t, path)
+	stat, err := inj.f.Stat()
+	require.NoError(t, err)
+	var b EntryBinary
+	size := stat.Size() / int64(b.EntrySize())
+	store := entrydb.NewEntryDBFromDataAccess[EntryType, Entry, EntryBinary](inj, entrydb.EntryIdx(size-1))
+	m := &stubMetrics{}
+	db, err := NewFromEntryStore(testlog.Logger(t, log.LvlInfo), m, eth.ChainIDFromUInt64(1), store, true)
+	require.NoError(t, err)
+	return db, inj, m
+}
+
+// TestCrashInjection_SyncFailureDoesNotAdvanceCommitted verifies that when
+// fsync fails during SealBlock, the in-memory committed state is not advanced
+// and the on-disk bytes are rolled back via Truncate.
+func TestCrashInjection_SyncFailureDoesNotAdvanceCommitted(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seal a base block cleanly.
+	db, inj, _ := openDBWithInjector(t, dir)
+	bl0 := eth.BlockID{Hash: createHash(0), Number: 0}
+	require.NoError(t, db.SealBlock(common.Hash{}, bl0, 100))
+	beforeIdx := db.lastEntryContext.nextEntryIndex
+
+	// Inject a sync failure for the next SealBlock.
+	inj.syncFail = true
+	bl1 := eth.BlockID{Hash: createHash(1), Number: 1}
+	err := db.SealBlock(bl0.Hash, bl1, 101)
+	require.Error(t, err)
+
+	// Committed state unchanged.
+	require.Equal(t, beforeIdx, db.lastEntryContext.nextEntryIndex)
+	require.Equal(t, bl0.Hash, db.lastEntryContext.blockHash)
+	require.Nil(t, db.working, "working clone should be discarded on sync failure")
+}
+
+// TestCrashInjection_PeriodicCheckpointBoundary asserts that recovery walks
+// back to a true closing-block boundary (logsSince==0) and does not mistake a
+// periodic search-checkpoint (logsSince>0) for one.
+func TestCrashInjection_PeriodicCheckpointBoundary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	// Build a file with enough logs that a periodic search-checkpoint falls
+	// mid-block.
+	{
+		store, err := entrydb.NewEntryDB[EntryType, Entry, EntryBinary](testlog.Logger(t, log.LvlInfo), path)
+		require.NoError(t, err)
+		m := &stubMetrics{}
+		db, err := NewFromEntryStore(testlog.Logger(t, log.LvlInfo), m, eth.ChainIDFromUInt64(1), store, true)
+		require.NoError(t, err)
+		bl0 := eth.BlockID{Hash: createHash(0), Number: 0}
+		require.NoError(t, db.SealBlock(common.Hash{}, bl0, 100))
+		// Seed enough logs to span >256 entries within a single block (so a
+		// periodic search-checkpoint is emitted while the block is still
+		// open). Use forceBlock to set up cleanly, then AddLog × N + SealBlock.
+		bl1 := eth.BlockID{Hash: createHash(1), Number: 1}
+		require.NoError(t, db.SealBlock(bl0.Hash, bl1, 101))
+		bl2 := eth.BlockID{Hash: createHash(2), Number: 2}
+		for i := uint32(0); db.pendingNextIndex() < searchCheckpointFrequency+10; i++ {
+			require.NoError(t, db.AddLog(createHash(int(i)), bl1, i, nil))
+		}
+		require.NoError(t, db.SealBlock(bl1.Hash, bl2, 102))
+		require.NoError(t, db.Close())
+	}
+
+	// Reopen: drop-last-block rule should drop block 2, leaving block 1's
+	// closing seal as the new tail. logsSince must be 0; this confirms
+	// recovery did not land on the periodic search-checkpoint mid-block.
+	{
+		store, err := entrydb.NewEntryDB[EntryType, Entry, EntryBinary](testlog.Logger(t, log.LvlInfo), path)
+		require.NoError(t, err)
+		m := &stubMetrics{}
+		db, err := NewFromEntryStore(testlog.Logger(t, log.LvlInfo), m, eth.ChainIDFromUInt64(1), store, true)
+		require.NoError(t, err)
+		require.Zero(t, db.lastEntryContext.logsSince, "recovery must land at a true closing boundary, not a periodic checkpoint")
+		require.NoError(t, db.Close())
+	}
+}
+

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -1,3 +1,31 @@
+// Package logs implements an append-only entry database with two crash-safety
+// invariants:
+//
+//  1. fsync at the end of every successful commit (SealBlock, Rewind,
+//     Clear). After a commit returns nil, all bytes written by that commit
+//     are durable. This is the only barrier that establishes prefix
+//     durability: the Linux page cache and device write cache may otherwise
+//     reorder writes freely across non-FLUSH boundaries, and ext4 delayed
+//     allocation may advance i_size before data blocks are durable.
+//
+//  2. On startup, any block whose fsync return value we cannot prove is
+//     discarded. Concretely: after entry-aligned recover() and trim to the
+//     last closing-block boundary, if the file ends exactly at that boundary
+//     (nothing post-boundary), the last block is dropped. Post-boundary
+//     entries are proof that the prior SealBlock returned, and therefore
+//     its fsync returned. The cost is one re-fetched block per startup; the
+//     gain is that no edge case in the recovery path can mistake a
+//     half-written commit for a complete one.
+//
+// File-system assumptions:
+//
+//   - ftruncate(2) atomicity: the file size is updated atomically with
+//     respect to crash recovery. True on ext4 and xfs.
+//   - fsync(2) actually flushes the device write cache. True on modern
+//     Linux block layers with default FUA/FLUSH support; true on AWS EBS gp3
+//     and GCP pd-ssd. macOS *os.File.Sync() does NOT flush the device cache
+//     (it would need F_FULLFSYNC); developers running on macOS get weaker
+//     durability than production Linux. Not addressed by this package.
 package logs
 
 import (
@@ -38,6 +66,12 @@ type Metrics interface {
 // Use a fixed 24 bytes per entry.
 //
 // Data is an append-only log, that can be binary searched for any necessary event data.
+//
+// Commit model: mutating operations follow a working-clone pattern. AddLog
+// accumulates entries into a separate logContext clone with no I/O; SealBlock
+// does one Write + Sync + atomic swap. On any failure the working clone is
+// discarded and the committed lastEntryContext is unchanged. Reads observe
+// only lastEntryContext, never the working clone.
 type DB struct {
 	log    log.Logger
 	m      Metrics
@@ -46,7 +80,14 @@ type DB struct {
 
 	chainID eth.ChainID
 
+	// lastEntryContext is the committed state. After every successful
+	// commit, lastEntryContext.out is nil.
 	lastEntryContext logContext
+
+	// working holds an in-progress clone accumulating uncommitted AddLog
+	// entries between SealBlock commits. Nil when no buffered mutations
+	// exist. Never observed by reads.
+	working *logContext
 }
 
 func NewFromFile(logger log.Logger, m Metrics, chainID eth.ChainID, path string, trimToLastSealed bool) (*DB, error) {
@@ -77,8 +118,23 @@ func (db *DB) lastEntryIdx() entrydb.EntryIdx {
 func (db *DB) init(trimToLastSealed bool) error {
 	defer db.updateEntryCountMetric() // Always update the entry count metric after init completes
 	if trimToLastSealed {
+		preIdx := db.lastEntryIdx()
 		if err := db.trimToLastSealed(); err != nil {
 			return fmt.Errorf("failed to trim invalid trailing entries: %w", err)
+		}
+		// Drop-last-block rule: if the file ends exactly at a closing boundary
+		// (no entries were trimmed past it), we cannot prove that the prior
+		// SealBlock's Sync return value was observed. Walk back one more
+		// closing boundary and truncate. Post-boundary entries elsewhere serve
+		// as proof that the prior commit returned; without them, drop. The
+		// cost is one re-fetched block per startup.
+		if preIdx == db.lastEntryIdx() && db.lastEntryIdx() >= 0 {
+			if err := db.dropLastClosingBlock(); err != nil {
+				return fmt.Errorf("failed to drop last block on recovery: %w", err)
+			}
+		}
+		if err := db.store.Sync(); err != nil {
+			return fmt.Errorf("failed to sync after recovery truncate: %w", err)
 		}
 	}
 	if db.lastEntryIdx() < 0 {
@@ -110,24 +166,76 @@ func (db *DB) init(trimToLastSealed bool) error {
 	return nil
 }
 
+// trimToLastSealed walks back to the last closing-block boundary — a
+// SearchCheckpoint with logsSince==0 immediately followed by a CanonicalHash —
+// and truncates anything past it. A periodic SearchCheckpoint emitted every
+// 256 entries also has a CanonicalHash following it, but its logsSince is
+// non-zero; we must skip those.
 func (db *DB) trimToLastSealed() error {
-	i := db.lastEntryIdx()
-	for ; i >= 0; i-- {
-		entry, err := db.store.Read(i)
-		if err != nil {
-			return fmt.Errorf("failed to read %v to check for trailing entries: %w", i, err)
-		}
-		if entry.Type() == TypeCanonicalHash {
-			// only an executing hash, indicating a sealed block, is a valid point for restart
-			break
-		}
+	i, err := db.findLastClosingBoundary(db.lastEntryIdx())
+	if err != nil {
+		return err
 	}
 	if i < db.lastEntryIdx() {
 		db.log.Warn("Truncating unexpected trailing entries", "prev", db.lastEntryIdx(), "new", i)
-		// trim such that the last entry is the canonical-hash we identified
 		return db.store.Truncate(i)
 	}
 	return nil
+}
+
+// dropLastClosingBlock walks past the current closing boundary and truncates
+// to the previous one. Used to enforce the "drop last block on recovery" rule
+// when nothing exists past the current tail boundary.
+func (db *DB) dropLastClosingBlock() error {
+	// Skip the current closing pair (CanonicalHash + preceding SearchCheckpoint)
+	// and find the previous closing boundary.
+	start := db.lastEntryIdx() - 2
+	if start < 0 {
+		db.log.Info("Dropping last block on recovery (only block in DB)", "prev", db.lastEntryIdx())
+		return db.store.Truncate(-1)
+	}
+	prev, err := db.findLastClosingBoundary(start)
+	if err != nil {
+		return err
+	}
+	db.log.Info("Dropping last block on recovery (cannot prove durability)", "prev", db.lastEntryIdx(), "new", prev)
+	return db.store.Truncate(prev)
+}
+
+// findLastClosingBoundary walks down from start looking for a
+// CanonicalHash entry whose preceding SearchCheckpoint has logsSince==0
+// (the closing seal of a block). Returns the index of the CanonicalHash;
+// returns -1 if no closing boundary exists.
+func (db *DB) findLastClosingBoundary(start entrydb.EntryIdx) (entrydb.EntryIdx, error) {
+	for i := start; i >= 0; i-- {
+		entry, err := db.store.Read(i)
+		if err != nil {
+			return 0, fmt.Errorf("failed to read %v to check for trailing entries: %w", i, err)
+		}
+		if entry.Type() != TypeCanonicalHash {
+			continue
+		}
+		if i == 0 {
+			// CanonicalHash at idx 0 cannot have a preceding SearchCheckpoint;
+			// not a valid closing boundary and no further entries available.
+			return -1, nil
+		}
+		prev, err := db.store.Read(i - 1)
+		if err != nil {
+			return 0, fmt.Errorf("failed to read %v to check checkpoint: %w", i-1, err)
+		}
+		if prev.Type() != TypeSearchCheckpoint {
+			continue
+		}
+		cp, err := newSearchCheckpointFromEntry(prev)
+		if err != nil {
+			return 0, fmt.Errorf("failed to decode search checkpoint at %v: %w", i-1, err)
+		}
+		if cp.logsSince == 0 {
+			return i, nil
+		}
+	}
+	return -1, nil
 }
 
 func (db *DB) updateEntryCountMetric() {
@@ -552,44 +660,147 @@ func (db *DB) debugTip() {
 	}
 }
 
-func (db *DB) flush() error {
-	for i, e := range db.lastEntryContext.out {
-		db.log.Trace("appending entry", "type", e.Type(), "entry", hexutil.Bytes(e[:]),
-			"next", int(db.lastEntryContext.nextEntryIndex)-len(db.lastEntryContext.out)+i)
+// pendingNextIndex returns the next entry index the DB will write to,
+// including any uncommitted entries in the working clone. Test-only.
+func (db *DB) pendingNextIndex() entrydb.EntryIdx {
+	db.rwLock.RLock()
+	defer db.rwLock.RUnlock()
+	if db.working != nil {
+		return db.working.nextEntryIndex
 	}
-	if err := db.store.Append(db.lastEntryContext.out...); err != nil {
-		return fmt.Errorf("failed to append entries: %w", err)
+	return db.lastEntryContext.nextEntryIndex
+}
+
+// forceBlock seeds the DB with a starting sealed block, committing the
+// resulting entries to disk in a single Write + Sync just like SealBlock.
+// Test-only: production code uses SealBlock. The underlying
+// logContext.forceBlock requires nextEntryIndex == 0, so this method is only
+// valid on a fresh DB.
+func (db *DB) forceBlock(upd eth.BlockID, timestamp uint64) error {
+	db.rwLock.Lock()
+	defer db.rwLock.Unlock()
+
+	if err := db.store.PrepareForMutation(); err != nil {
+		return fmt.Errorf("store not ready for mutation: %w", err)
 	}
-	db.lastEntryContext.out = db.lastEntryContext.out[:0]
+
+	db.working = nil
+	w := db.lastEntryContext.cloneForWrite()
+	db.working = &w
+	if err := w.forceBlock(upd, timestamp); err != nil {
+		db.working = nil
+		return fmt.Errorf("failed to force block: %w", err)
+	}
+	if err := db.store.Append(w.out...); err != nil {
+		db.working = nil
+		return fmt.Errorf("failed to append force-block entries: %w", err)
+	}
+	if err := db.store.Sync(); err != nil {
+		if truncErr := db.store.Truncate(db.lastEntryContext.nextEntryIndex - 1); truncErr != nil {
+			// Safe to continue: entrydb.Truncate records the target in
+			// pendingCleanup before attempting the file truncate, so reads are
+			// already bounded by the rolled-back size and the next mutation
+			// will retry the truncate.
+			db.log.Warn("rollback truncate after sync failure deferred; will retry on next mutation", "err", truncErr)
+		}
+		db.working = nil
+		return fmt.Errorf("failed to sync after forcing block: %w", err)
+	}
+	db.lastEntryContext = *db.working
+	db.lastEntryContext.out = nil
+	db.working = nil
 	db.updateEntryCountMetric()
 	return nil
 }
 
+// ensureWorking returns the working clone, lazily creating it from
+// lastEntryContext on first use.
+func (db *DB) ensureWorking() *logContext {
+	if db.working == nil {
+		w := db.lastEntryContext.cloneForWrite()
+		db.working = &w
+	}
+	return db.working
+}
+
+// SealBlock commits all pending AddLog entries (if any) plus the block-closing
+// seal in a single Write + Sync. On any failure the working clone is discarded
+// and the committed state is unchanged.
 func (db *DB) SealBlock(parentHash common.Hash, block eth.BlockID, timestamp uint64) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 
-	if err := db.lastEntryContext.SealBlock(parentHash, block, timestamp); err != nil {
+	w := db.ensureWorking()
+	if err := w.SealBlock(parentHash, block, timestamp); err != nil {
+		// Apply failed on the clone; discard.
+		db.working = nil
 		return fmt.Errorf("failed to seal block: %w", err)
 	}
 	db.log.Trace("Sealed block", "parent", parentHash, "block", block, "timestamp", timestamp)
-	return db.flush()
+	out := w.out
+	for i, e := range out {
+		db.log.Trace("appending entry", "type", e.Type(), "entry", hexutil.Bytes(e[:]),
+			"next", int(w.nextEntryIndex)-len(out)+i)
+	}
+	if err := db.store.Append(out...); err != nil {
+		db.working = nil
+		return fmt.Errorf("failed to append entries: %w", err)
+	}
+	if err := db.store.Sync(); err != nil {
+		// Bytes are on disk but we cannot confirm durability. Roll back
+		// rather than commit unflushed state.
+		if truncErr := db.store.Truncate(db.lastEntryContext.nextEntryIndex - 1); truncErr != nil {
+			// Safe to continue: entrydb.Truncate records the target in
+			// pendingCleanup before attempting the file truncate, so reads are
+			// already bounded by the rolled-back size and the next mutation
+			// will retry the truncate.
+			db.log.Warn("rollback truncate after sync failure deferred; will retry on next mutation", "err", truncErr)
+		}
+		db.working = nil
+		return fmt.Errorf("failed to sync after sealing block: %w", err)
+	}
+	// Atomic swap: working clone becomes the new committed state.
+	db.lastEntryContext = *db.working
+	db.lastEntryContext.out = nil
+	db.working = nil
+	db.updateEntryCountMetric()
+	return nil
 }
 
+// AddLog accumulates a log into the working clone with no I/O. Bytes hit disk
+// only when the enclosing SealBlock commits.
 func (db *DB) AddLog(logHash common.Hash, parentBlock eth.BlockID, logIdx uint32, execMsg *types.ExecutingMessage) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 
-	if err := db.lastEntryContext.ApplyLog(parentBlock, logIdx, logHash, execMsg); err != nil {
+	// Drain any pending cleanup before mutating in-memory state — if the
+	// store is in a bad state we want to surface that here, not when the
+	// caller eventually calls SealBlock.
+	if err := db.store.PrepareForMutation(); err != nil {
+		return fmt.Errorf("store not ready for mutation: %w", err)
+	}
+
+	w := db.ensureWorking()
+	if err := w.ApplyLog(parentBlock, logIdx, logHash, execMsg); err != nil {
+		db.working = nil
 		return fmt.Errorf("failed to apply log: %w", err)
 	}
 	db.log.Trace("Applied log", "parentBlock", parentBlock, "logIndex", logIdx, "logHash", logHash, "executing", execMsg != nil)
-	return db.flush()
+	return nil
 }
 
 // Clear clears the DB such that there is no data left.
 // An invalidator is required as argument, to force users to invalidate any current open reads.
 func (db *DB) Clear(inv reads.Invalidator) error {
+	db.rwLock.Lock()
+	defer db.rwLock.Unlock()
+	return db.clearLocked(inv)
+}
+
+// clearLocked is Clear without acquiring the write lock; caller must hold it.
+// Used by Rewind when the rewind target is before the start of the DB.
+func (db *DB) clearLocked(inv reads.Invalidator) error {
+	defer db.updateEntryCountMetric()
 	release, invalidateErr := inv.TryInvalidate(reads.InvalidationRules{
 		reads.DerivedInvalidation{Timestamp: 0},
 	})
@@ -597,11 +808,17 @@ func (db *DB) Clear(inv reads.Invalidator) error {
 		return invalidateErr
 	}
 	defer release()
-	defer db.updateEntryCountMetric()
+	// Discard any working clone and swap committed state first, so readers
+	// under the held lock observe the empty DB even if the truncate fails.
+	db.working = nil
+	db.lastEntryContext = logContext{}
 	if truncateErr := db.store.Truncate(-1); truncateErr != nil {
+		// pendingCleanup picks up; return the error.
 		return fmt.Errorf("failed to empty DB: %w", truncateErr)
 	}
-	db.lastEntryContext = logContext{}
+	if syncErr := db.store.Sync(); syncErr != nil {
+		return fmt.Errorf("failed to sync after clear: %w", syncErr)
+	}
 	return nil
 }
 
@@ -612,12 +829,16 @@ func (db *DB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 	defer db.updateEntryCountMetric()
+
+	// Discard any working clone — Rewind invalidates pending block-in-progress.
+	db.working = nil
+
 	// Even if the last fully-processed block matches headBlockNum,
 	// we might still have trailing log events to get rid of.
 	iter, err := db.newIteratorAt(newHead.Number, 0)
 	if err != nil {
 		if errors.Is(err, types.ErrPreviousToFirst) || errors.Is(err, types.ErrSkipped) {
-			if err := db.Clear(inv); err != nil {
+			if err := db.clearLocked(inv); err != nil {
 				return fmt.Errorf("failed to clear logs DB, upon rewinding to log block %s before first block: %w", newHead, err)
 			}
 			return nil
@@ -638,13 +859,22 @@ func (db *DB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 		return err
 	}
 	defer release()
-	// Truncate to contain idx entries. The Truncate func keeps the given index as last index.
-	if err := db.store.Truncate(iter.NextIndex() - 1); err != nil {
+
+	// Save the iterator's hydrated logContext as the target committed state.
+	target := iter.current
+
+	// Swap in-memory committed state to the rewound view first. The entrydb
+	// Truncate that follows physically removes the trailing bytes; if it
+	// fails, pendingCleanup pins the logical upper bound so reads cannot
+	// observe data past the new logical end.
+	db.lastEntryContext = target
+	db.lastEntryContext.out = nil
+
+	if err := db.store.Truncate(target.NextIndex() - 1); err != nil {
 		return fmt.Errorf("failed to truncate to block %s: %w", newHead, err)
 	}
-	// Use db.init() to find the log context for the new latest log entry
-	if err := db.init(true); err != nil {
-		return fmt.Errorf("failed to find new last entry context: %w", err)
+	if err := db.store.Sync(); err != nil {
+		return fmt.Errorf("failed to sync after rewind: %w", err)
 	}
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/logs/db_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/db_test.go
@@ -344,7 +344,7 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenBeforeCurrentBlockButAfterLastCheckpoint", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.lastEntryContext.forceBlock(eth.BlockID{Hash: createHash(13), Number: 13}, 5000)
+				err := db.forceBlock(eth.BlockID{Hash: createHash(13), Number: 13}, 5000)
 				require.NoError(t, err)
 				err = db.SealBlock(createHash(13), eth.BlockID{Hash: createHash(14), Number: 14}, 5001)
 				require.NoError(t, err)
@@ -360,16 +360,19 @@ func TestAddLog(t *testing.T) {
 	})
 
 	t.Run("ErrorWhenBeforeCurrentLogEvent", func(t *testing.T) {
+		// Under deferred-I/O semantics, AddLog buffers do not survive Close
+		// without an enclosing SealBlock. The buffered-log setup is moved
+		// into the assertion phase so both "New" and "Existing" runDBTest
+		// variants reach the same logical pre-assertion state.
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				err := db.lastEntryContext.forceBlock(bl15, 5000)
-				require.NoError(t, err)
-				require.NoError(t, db.AddLog(createHash(1), bl15, 0, nil))
-				require.NoError(t, db.AddLog(createHash(1), bl15, 1, nil))
+				require.NoError(t, db.forceBlock(bl15, 5000))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
+				require.NoError(t, db.AddLog(createHash(1), bl15, 0, nil))
+				require.NoError(t, db.AddLog(createHash(1), bl15, 1, nil))
 				err := db.AddLog(createHash(1), bl15, 0, nil)
 				require.ErrorIs(t, err, types.ErrOutOfOrder, "already at log index 2")
 				require.ErrorIs(t, err, types.ErrOutOfOrder, "already at log index 2")
@@ -380,12 +383,12 @@ func TestAddLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				err := db.lastEntryContext.forceBlock(bl15, 5000)
-				require.NoError(t, err)
-				require.NoError(t, db.AddLog(createHash(1), bl15, 0, nil))
-				require.NoError(t, db.AddLog(createHash(1), bl15, 1, nil))
+				require.NoError(t, db.forceBlock(bl15, 5000))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
+				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
+				require.NoError(t, db.AddLog(createHash(1), bl15, 0, nil))
+				require.NoError(t, db.AddLog(createHash(1), bl15, 1, nil))
 				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(16), Number: 16}, 0, nil)
 				require.ErrorIs(t, err, types.ErrOutOfOrder)
 				require.ErrorIs(t, err, types.ErrOutOfOrder)
@@ -396,13 +399,12 @@ func TestAddLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				err := db.lastEntryContext.forceBlock(bl15, 5000)
-				require.NoError(t, err)
-				require.NoError(t, db.AddLog(createHash(1), bl15, 0, nil))
-				require.NoError(t, db.AddLog(createHash(1), bl15, 1, nil))
+				require.NoError(t, db.forceBlock(bl15, 5000))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
+				require.NoError(t, db.AddLog(createHash(1), bl15, 0, nil))
+				require.NoError(t, db.AddLog(createHash(1), bl15, 1, nil))
 				err := db.AddLog(createHash(1), bl15, 1, nil)
 				require.ErrorIs(t, err, types.ErrOutOfOrder, "already at log index 2")
 				require.ErrorIs(t, err, types.ErrOutOfOrder, "already at log index 2")
@@ -413,14 +415,14 @@ func TestAddLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				err := db.lastEntryContext.forceBlock(bl15, 5000)
-				require.NoError(t, err)
-				require.NoError(t, db.AddLog(createHash(1), bl15, 0, nil))
-				require.NoError(t, db.AddLog(createHash(1), bl15, 1, nil))
+				require.NoError(t, db.forceBlock(bl15, 5000))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				bl15 := eth.BlockID{Hash: createHash(16), Number: 16}
-				err := db.AddLog(createHash(1), bl15, 2, nil)
+				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
+				require.NoError(t, db.AddLog(createHash(1), bl15, 0, nil))
+				require.NoError(t, db.AddLog(createHash(1), bl15, 1, nil))
+				wrong := eth.BlockID{Hash: createHash(16), Number: 16}
+				err := db.AddLog(createHash(1), wrong, 2, nil)
 				require.ErrorIs(t, err, types.ErrOutOfOrder)
 				require.ErrorIs(t, err, types.ErrOutOfOrder)
 			})
@@ -430,12 +432,11 @@ func TestAddLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				err := db.lastEntryContext.forceBlock(bl15, 5000)
-				require.NoError(t, err)
-				require.NoError(t, db.AddLog(createHash(1), bl15, 0, nil))
+				require.NoError(t, db.forceBlock(bl15, 5000))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
+				require.NoError(t, db.AddLog(createHash(1), bl15, 0, nil))
 				err := db.AddLog(createHash(1), bl15, 2, nil)
 				require.ErrorIs(t, err, types.ErrOutOfOrder)
 				require.ErrorIs(t, err, types.ErrOutOfOrder)
@@ -445,7 +446,7 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenFirstLogIsNotLogIdxZero", func(t *testing.T) {
 		runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {
 			bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-			err := db.lastEntryContext.forceBlock(bl15, 5000)
+			err := db.forceBlock(bl15, 5000)
 			require.NoError(t, err)
 		},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -460,19 +461,15 @@ func TestAddLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				err := db.lastEntryContext.forceBlock(bl15, 5000)
-				require.NoError(t, err)
-				err = db.AddLog(createHash(1), bl15, 0, nil)
-				require.NoError(t, err)
+				require.NoError(t, db.forceBlock(bl15, 5000))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				err := db.AddLog(createHash(1), bl15, 1, nil)
-				require.NoError(t, err)
+				require.NoError(t, db.AddLog(createHash(1), bl15, 0, nil))
+				require.NoError(t, db.AddLog(createHash(1), bl15, 1, nil))
 				bl16 := eth.BlockID{Hash: createHash(16), Number: 16}
-				err = db.SealBlock(bl15.Hash, bl16, 5001)
-				require.NoError(t, err)
-				err = db.AddLog(createHash(1), bl16, 1, nil)
+				require.NoError(t, db.SealBlock(bl15.Hash, bl16, 5001))
+				err := db.AddLog(createHash(1), bl16, 1, nil)
 				require.ErrorIs(t, err, types.ErrOutOfOrder)
 				require.ErrorIs(t, err, types.ErrOutOfOrder)
 			})
@@ -497,7 +494,7 @@ func TestAddLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				// force in block 0
-				require.NoError(t, db.lastEntryContext.forceBlock(block0, t0))
+				require.NoError(t, db.forceBlock(block0, t0))
 				expectedIndex := entrydb.EntryIdx(2)
 				t.Logf("block 0 complete, at entry %d", db.lastEntryContext.NextIndex())
 				require.Equal(t, expectedIndex, db.lastEntryContext.NextIndex())
@@ -591,7 +588,7 @@ func TestAddDependentLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				require.NoError(t, db.lastEntryContext.forceBlock(bl15, 5000))
+				require.NoError(t, db.forceBlock(bl15, 5000))
 				err := db.AddLog(createHash(1), bl15, 0, &execMsg)
 				require.NoError(t, err)
 				bl16 := eth.BlockID{Hash: createHash(16), Number: 16}
@@ -606,8 +603,8 @@ func TestAddDependentLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				require.NoError(t, db.lastEntryContext.forceBlock(bl15, 5000))
-				for i := uint32(0); m.entryCount < searchCheckpointFrequency-1; i++ {
+				require.NoError(t, db.forceBlock(bl15, 5000))
+				for i := uint32(0); db.pendingNextIndex() < searchCheckpointFrequency-1; i++ {
 					require.NoError(t, db.AddLog(createHash(9), bl15, i, nil))
 				}
 				bl16 := eth.BlockID{Hash: createHash(16), Number: 16}
@@ -629,7 +626,7 @@ func TestAddDependentLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				require.NoError(t, db.lastEntryContext.forceBlock(bl15, 5000))
+				require.NoError(t, db.forceBlock(bl15, 5000))
 				// we add 256 - 2 (start) - 3 (init msg, execChainID, execPosition) = 251 entries
 				for i := uint32(0); i < 251; i++ {
 					require.NoError(t, db.AddLog(createHash(9), bl15, i, nil))
@@ -648,7 +645,7 @@ func TestAddDependentLog(t *testing.T) {
 				// 259 = executing message chainID
 				// 260 = executing message position
 				// 261 = executing message checksum
-				require.Equal(t, int64(262), m.entryCount)
+				require.Equal(t, entrydb.EntryIdx(262), db.pendingNextIndex())
 				db.debugTip()
 				bl16 := eth.BlockID{Hash: createHash(16), Number: 16}
 				require.NoError(t, db.SealBlock(bl15.Hash, bl16, 5001))
@@ -663,7 +660,7 @@ func TestAddDependentLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				require.NoError(t, db.lastEntryContext.forceBlock(bl15, 5000))
+				require.NoError(t, db.forceBlock(bl15, 5000))
 				// we add 256 - 2 (start) - 2 (init msg, execPosition) = 252 entries
 				for i := uint32(0); i < 252; i++ {
 					require.NoError(t, db.AddLog(createHash(9), bl15, i, nil))
@@ -682,7 +679,7 @@ func TestAddDependentLog(t *testing.T) {
 				// 260 = executing message position
 				// 261 = executing message checksum
 				db.debugTip()
-				require.Equal(t, int64(262), m.entryCount)
+				require.Equal(t, entrydb.EntryIdx(262), db.pendingNextIndex())
 				bl16 := eth.BlockID{Hash: createHash(16), Number: 16}
 				require.NoError(t, db.SealBlock(bl15.Hash, bl16, 5001))
 			},
@@ -696,7 +693,7 @@ func TestAddDependentLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
-				require.NoError(t, db.lastEntryContext.forceBlock(bl15, 5000))
+				require.NoError(t, db.forceBlock(bl15, 5000))
 				// we add 256 - 2 (start) - 1 (init msg) = 253 entries
 				for i := uint32(0); i < 253; i++ {
 					require.NoError(t, db.AddLog(createHash(9), bl15, i, nil))
@@ -714,7 +711,7 @@ func TestAddDependentLog(t *testing.T) {
 				// 260 = executing message position
 				// 261 = executing message checksum
 				db.debugTip()
-				require.Equal(t, int64(262), m.entryCount)
+				require.Equal(t, entrydb.EntryIdx(262), db.pendingNextIndex())
 				bl16 := eth.BlockID{Hash: createHash(16), Number: 16}
 				require.NoError(t, db.SealBlock(bl15.Hash, bl16, 5001))
 			},
@@ -731,7 +728,7 @@ func TestContains(t *testing.T) {
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			bl50 := eth.BlockID{Hash: createHash(50), Number: 50}
-			require.NoError(t, db.lastEntryContext.forceBlock(bl50, t50))
+			require.NoError(t, db.forceBlock(bl50, t50))
 			require.NoError(t, db.AddLog(createHash(1), bl50, 0, nil))
 			require.NoError(t, db.AddLog(createHash(3), bl50, 1, nil))
 			require.NoError(t, db.AddLog(createHash(2), bl50, 2, nil))
@@ -776,7 +773,7 @@ func TestContainsOutOfRangeLogIndex(t *testing.T) {
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			bl10 := eth.BlockID{Hash: createHash(10), Number: 10}
-			require.NoError(t, db.lastEntryContext.forceBlock(bl10, 5000))
+			require.NoError(t, db.forceBlock(bl10, 5000))
 
 			// Create a block with 2 logs
 			require.NoError(t, db.AddLog(createHash(1), bl10, 0, nil))
@@ -834,7 +831,7 @@ func TestExecutes(t *testing.T) {
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			bl50 := eth.BlockID{Hash: createHash(50), Number: 50}
-			require.NoError(t, db.lastEntryContext.forceBlock(bl50, t50))
+			require.NoError(t, db.forceBlock(bl50, t50))
 			require.NoError(t, db.AddLog(createHash(1), bl50, 0, nil))
 			require.NoError(t, db.AddLog(createHash(3), bl50, 1, &execMsg1))
 			require.NoError(t, db.AddLog(createHash(2), bl50, 2, nil))
@@ -844,6 +841,11 @@ func TestExecutes(t *testing.T) {
 			require.NoError(t, db.SealBlock(bl51.Hash, bl52, t52))
 			require.NoError(t, db.AddLog(createHash(1), bl52, 0, &execMsg2))
 			require.NoError(t, db.AddLog(createHash(3), bl52, 1, &execMsg3))
+			// Under deferred-I/O semantics, AddLog buffers do not become
+			// queryable until the enclosing SealBlock commits. Seal block 53
+			// so the executing-message assertions below observe disk state.
+			bl53 := eth.BlockID{Hash: createHash(53), Number: 53}
+			require.NoError(t, db.SealBlock(bl52.Hash, bl53, t53))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			// Should find added logs
@@ -856,8 +858,8 @@ func TestExecutes(t *testing.T) {
 			// 52 was sealed without logs
 			requireConflicts(t, db, 52, 0, t52, createHash(1))
 
-			// 53 only contained 2 logs, not 3, and is not sealed yet
-			requireFuture(t, db, 53, 2, t53, createHash(3))
+			// 53 only contained 2 logs, not 3 — the third index is a conflict.
+			requireConflicts(t, db, 53, 2, t53, createHash(3))
 			// 54 doesn't exist yet
 			requireFuture(t, db, 54, 0, t54, createHash(3))
 
@@ -890,7 +892,7 @@ func TestGetBlockInfo(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl11 := eth.BlockID{Hash: createHash(11), Number: 11}
-				require.NoError(t, db.lastEntryContext.forceBlock(bl11, 500))
+				require.NoError(t, db.forceBlock(bl11, 500))
 				err := db.AddLog(createHash(1), bl11, 0, nil)
 				require.NoError(t, err)
 			},
@@ -1005,7 +1007,12 @@ func TestRecoverOnCreate(t *testing.T) {
 		_ = store.Append(evts...)
 		return store
 	}
-	t.Run("NoTruncateWhenLastEntryIsLogWithNoExecMessageSealed", func(t *testing.T) {
+	// Note: these subtests assert the drop-last-block recovery rule. When the
+	// file ends exactly at a closing-block boundary, we cannot prove the prior
+	// Sync return value was observed, and the last block is discarded on
+	// recovery (one re-fetched block per startup). When post-boundary entries
+	// exist they prove durability and the last block survives.
+	t.Run("DropsLastBlock_WhenLogWithoutExecMessageJustSealed", func(t *testing.T) {
 		store := storeWithEvents(
 			// seal 0, 1, 2, 3
 			newSearchCheckpoint(0, 0, 100).encode(),
@@ -1021,13 +1028,15 @@ func TestRecoverOnCreate(t *testing.T) {
 			newSearchCheckpoint(4, 0, 104).encode(),
 			newCanonicalHash(createHash(304)).encode(),
 		)
-		db, m, err := createDb(t, store)
+		// File ends exactly at block 4's closing boundary. Drop block 4
+		// (and its preceding init event). Tail boundary moves to block 3's
+		// closing pair at idx 6-7; truncate-to-7 → 8 entries remain.
+		_, m, err := createDb(t, store)
 		require.NoError(t, err)
-		require.EqualValues(t, int64(4*2+3), m.entryCount)
-		requireContains(t, db, 4, 0, 104, createHash(1))
+		require.EqualValues(t, int64(8), m.entryCount)
 	})
 
-	t.Run("NoTruncateWhenLastEntryIsExecChecksumSealed", func(t *testing.T) {
+	t.Run("DropsLastBlock_WhenExecChecksumJustSealed", func(t *testing.T) {
 		execMsg := types.ExecutingMessage{
 			ChainID:   eth.ChainIDFromUInt64(4),
 			BlockNum:  10,
@@ -1053,10 +1062,11 @@ func TestRecoverOnCreate(t *testing.T) {
 			newSearchCheckpoint(3, 0, 103).encode(),
 			newCanonicalHash(createHash(303)).encode(),
 		)
-		db, m, err := createDb(t, store)
+		// File ends at block 3's closing boundary. Drop block 3 (entries
+		// idx 6-11). Previous boundary is block 2 at idx 4-5; truncate-to-5.
+		_, m, err := createDb(t, store)
 		require.NoError(t, err)
-		require.EqualValues(t, int64(3*2+6), m.entryCount)
-		requireContains(t, db, 3, 0, 103, createHash(1111), execMsg)
+		require.EqualValues(t, int64(6), m.entryCount)
 	})
 
 	t.Run("TruncateWhenLastEntrySearchCheckpoint", func(t *testing.T) {
@@ -1068,20 +1078,21 @@ func TestRecoverOnCreate(t *testing.T) {
 		require.EqualValues(t, int64(0), m.entryCount)
 	})
 
-	t.Run("NoTruncateWhenLastEntryCanonicalHash", func(t *testing.T) {
-		// A completed seal is fine to have as last entry.
+	t.Run("DropsLoneBlock", func(t *testing.T) {
+		// A single closing pair: file ends exactly at the boundary, drop it.
 		store := storeWithEvents(
 			newSearchCheckpoint(0, 0, 100).encode(),
 			newCanonicalHash(createHash(344)).encode(),
 		)
 		_, m, err := createDb(t, store)
 		require.NoError(t, err)
-		require.EqualValues(t, int64(2), m.entryCount)
+		require.EqualValues(t, int64(0), m.entryCount)
 	})
 
 	t.Run("TruncateWhenLastEntryInitEventWithExecMsg", func(t *testing.T) {
-		// An initiating event that claims an executing message,
-		// without said executing message, is dropped.
+		// Init events past block 0's seal are dropped by trimToLastSealed.
+		// Since trimming actually removes entries (post-boundary data
+		// existed), the block 0 closing pair survives.
 		store := storeWithEvents(
 			newSearchCheckpoint(0, 0, 100).encode(),
 			newCanonicalHash(createHash(344)).encode(),
@@ -1094,20 +1105,21 @@ func TestRecoverOnCreate(t *testing.T) {
 		require.EqualValues(t, int64(2), m.entryCount)
 	})
 
-	t.Run("NoTruncateWhenLastEntrySealed", func(t *testing.T) {
-		// An initiating event that claims an executing message,
-		// without said executing message, is dropped.
+	t.Run("DropsLastBlock_WhenPartialInitEventThenClosingSeal", func(t *testing.T) {
+		// Partial init event between blocks 0 and 1, then block 1's seal.
+		// trimToLastSealed walks back to block 1's closing pair at idx 3-4.
+		// File ends exactly there → drop block 1. Previous boundary is
+		// block 0 at idx 0-1; truncate-to-1.
 		store := storeWithEvents(
 			newSearchCheckpoint(0, 0, 100).encode(),
 			newCanonicalHash(createHash(300)).encode(),
-			// pruned because we go back to a seal
 			newInitiatingEvent(createHash(0), false).encode(),
 			newSearchCheckpoint(1, 0, 100).encode(),
 			newCanonicalHash(createHash(301)).encode(),
 		)
 		_, m, err := createDb(t, store)
 		require.NoError(t, err)
-		require.EqualValues(t, int64(5), m.entryCount)
+		require.EqualValues(t, int64(2), m.entryCount)
 	})
 
 	t.Run("TruncateWhenLastEntryInitEventWithExecChainID", func(t *testing.T) {
@@ -1271,17 +1283,19 @@ func TestRewind(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl50 := eth.BlockID{Hash: createHash(50), Number: 50}
 				require.NoError(t, db.SealBlock(createHash(49), bl50, t50))
-				for i := uint32(0); m.entryCount < searchCheckpointFrequency; i++ {
+				for i := uint32(0); db.pendingNextIndex() < searchCheckpointFrequency; i++ {
 					require.NoError(t, db.AddLog(createHash(1), bl50, i, nil))
 				}
 				// The checkpoint is added automatically,
 				// it will be there as soon as it reaches 255 with log events.
-				// Thus add 2 for the checkpoint.
-				require.EqualValues(t, searchCheckpointFrequency+2, m.entryCount)
+				// Thus add 2 for the checkpoint. Under deferred-I/O semantics
+				// the entry count only updates on commit, so check pending
+				// index (in-memory) instead of on-disk entryCount.
+				require.EqualValues(t, searchCheckpointFrequency+2, db.pendingNextIndex())
 				bl51 := eth.BlockID{Hash: createHash(51), Number: 51}
 				require.NoError(t, db.SealBlock(bl50.Hash, bl51, t51))
 				require.NoError(t, db.AddLog(createHash(1), bl51, 0, nil))
-				require.EqualValues(t, searchCheckpointFrequency+2+3, m.entryCount, "Should have inserted new checkpoint and extra log")
+				require.EqualValues(t, searchCheckpointFrequency+2+3, db.pendingNextIndex(), "Should have inserted new checkpoint and extra log")
 				require.NoError(t, db.AddLog(createHash(2), bl51, 1, nil))
 				bl52 := eth.BlockID{Hash: createHash(52), Number: 52}
 				require.NoError(t, db.SealBlock(bl51.Hash, bl52, t52))

--- a/op-supervisor/supervisor/backend/db/logs/db_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/db_test.go
@@ -360,9 +360,9 @@ func TestAddLog(t *testing.T) {
 	})
 
 	t.Run("ErrorWhenBeforeCurrentLogEvent", func(t *testing.T) {
-		// Under deferred-I/O semantics, AddLog buffers do not survive Close
-		// without an enclosing SealBlock. The buffered-log setup is moved
-		// into the assertion phase so both "New" and "Existing" runDBTest
+		// Note: Under deferred-I/O semantics, AddLog buffers do not survive Close
+		// without an enclosing SealBlock. The buffered-log setup must be in
+		// the assertion phase so both "New" and "Existing" runDBTest
 		// variants reach the same logical pre-assertion state.
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {

--- a/op-supervisor/supervisor/backend/db/logs/state.go
+++ b/op-supervisor/supervisor/backend/db/logs/state.go
@@ -106,10 +106,6 @@ type logContext struct {
 // The returned value is decoupled from the receiver: appending to clone.out
 // allocates a fresh backing array, and clone.execMsg points to a freshly allocated
 // copy when l.execMsg is non-nil.
-//
-// MAINTAIN: if you add a field to logContext, update this method. The
-// TestLogContextCloneForWrite_Isolation test will fail if a new field shares state
-// between original and clone.
 func (l logContext) cloneForWrite() logContext {
 	c := logContext{
 		nextEntryIndex: l.nextEntryIndex,

--- a/op-supervisor/supervisor/backend/db/logs/state.go
+++ b/op-supervisor/supervisor/backend/db/logs/state.go
@@ -94,7 +94,38 @@ type logContext struct {
 	// E.g. you can build multiple hypothetical blocks with log events on top of the state,
 	// before flushing the entries to a DB.
 	// However, no entries can be read from the DB while objects are being applied.
+	//
+	// Note: this field is only meaningful on a working clone produced by cloneForWrite.
+	// After a successful commit, db.lastEntryContext.out is always nil.
 	out []Entry
+}
+
+// cloneForWrite returns an independent copy of l suitable for accumulating
+// uncommitted mutations (AddLog, SealBlock) without affecting the committed state.
+//
+// The returned value is decoupled from the receiver: appending to clone.out
+// allocates a fresh backing array, and clone.execMsg points to a freshly allocated
+// copy when l.execMsg is non-nil.
+//
+// MAINTAIN: if you add a field to logContext, update this method. The
+// TestLogContextCloneForWrite_Isolation test will fail if a new field shares state
+// between original and clone.
+func (l logContext) cloneForWrite() logContext {
+	c := logContext{
+		nextEntryIndex: l.nextEntryIndex,
+		blockHash:      l.blockHash,
+		blockNum:       l.blockNum,
+		timestamp:      l.timestamp,
+		logsSince:      l.logsSince,
+		logHash:        l.logHash,
+		need:           l.need,
+		out:            nil,
+	}
+	if l.execMsg != nil {
+		em := *l.execMsg
+		c.execMsg = &em
+	}
+	return c
 }
 
 func (l *logContext) NextIndex() entrydb.EntryIdx {

--- a/op-supervisor/supervisor/backend/db/logs/state_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/state_test.go
@@ -1,0 +1,108 @@
+package logs
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// TestLogContextCloneForWrite_Isolation asserts that mutating any field on the
+// clone produced by cloneForWrite never affects the original. The test walks
+// every field of logContext via reflection so adding a new field without
+// updating cloneForWrite causes a deterministic failure.
+func TestLogContextCloneForWrite_Isolation(t *testing.T) {
+	original := logContext{
+		nextEntryIndex: 42,
+		blockHash:      common.HexToHash("0xdeadbeef"),
+		blockNum:       7,
+		timestamp:      1234,
+		logsSince:      3,
+		logHash:        common.HexToHash("0xfeedface"),
+		execMsg: &types.ExecutingMessage{
+			ChainID:   eth.ChainIDFromUInt64(99),
+			BlockNum:  8,
+			LogIdx:    2,
+			Timestamp: 5678,
+			Checksum:  types.MessageChecksum(common.HexToHash("0xcafebabe")),
+		},
+		need: FlagCanonicalHash,
+		out:  []Entry{{0x01}, {0x02}},
+	}
+
+	// Snapshot the original via reflection.
+	originalSnapshot := original
+	originalExecMsgSnapshot := *original.execMsg
+	originalOutSnapshot := make([]Entry, len(original.out))
+	copy(originalOutSnapshot, original.out)
+
+	clone := original.cloneForWrite()
+
+	// Verify struct types match (so reflection walks the right shape).
+	origType := reflect.TypeOf(original)
+	cloneType := reflect.TypeOf(clone)
+	require.Equal(t, origType, cloneType)
+
+	origVal := reflect.ValueOf(&originalSnapshot).Elem()
+	cloneVal := reflect.ValueOf(&clone).Elem()
+	require.Equal(t, origVal.NumField(), cloneVal.NumField())
+
+	// For each field, mutate the clone in a type-appropriate way and assert the
+	// original is unchanged.
+	for i := 0; i < cloneVal.NumField(); i++ {
+		field := cloneVal.Field(i)
+		name := cloneType.Field(i).Name
+
+		// Use unsafe to get a settable handle even for unexported fields.
+		settable := reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
+
+		switch name {
+		case "nextEntryIndex":
+			settable.SetInt(settable.Int() + 100)
+		case "blockHash":
+			settable.Set(reflect.ValueOf(common.HexToHash("0x1234")))
+		case "blockNum":
+			settable.SetUint(settable.Uint() + 100)
+		case "timestamp":
+			settable.SetUint(settable.Uint() + 100)
+		case "logsSince":
+			settable.SetUint(settable.Uint() + 100)
+		case "logHash":
+			settable.Set(reflect.ValueOf(common.HexToHash("0xabcd")))
+		case "execMsg":
+			// Mutate through the pointer the clone holds. Because cloneForWrite
+			// allocates a fresh ExecutingMessage, this must not propagate.
+			clone.execMsg.BlockNum = 9999
+			clone.execMsg.LogIdx = 9999
+			clone.execMsg.Timestamp = 9999
+			clone.execMsg.Checksum = types.MessageChecksum(common.HexToHash("0xbad"))
+			clone.execMsg.ChainID = eth.ChainIDFromUInt64(9999)
+		case "need":
+			settable.SetUint(settable.Uint() ^ 0xff)
+		case "out":
+			// Mutate an existing entry in the clone's slice. If the backing
+			// array were shared, the original would see the change.
+			if len(clone.out) > 0 {
+				clone.out[0] = Entry{0xff}
+			}
+			// Also append, to catch the case where the backing array has
+			// spare capacity shared with the original.
+			clone.out = append(clone.out, Entry{0xee})
+		default:
+			t.Fatalf("unhandled field %q in cloneForWrite isolation test — update both cloneForWrite and this test", name)
+		}
+	}
+
+	// The original struct and its referenced data must be untouched.
+	require.True(t, reflect.DeepEqual(originalSnapshot, original),
+		"original logContext changed: clone mutation leaked. original=%+v snapshot=%+v", original, originalSnapshot)
+	require.Equal(t, originalExecMsgSnapshot, *original.execMsg,
+		"original.execMsg changed: clone mutation leaked through pointer")
+	require.Equal(t, originalOutSnapshot, original.out,
+		"original.out changed: clone mutation leaked through slice backing array")
+}


### PR DESCRIPTION
Closes ethereum-optimism/optimism-private#539.

Makes every mutating `logs.DB` operation atomic — in-memory `lastEntryContext` and on-disk state always advance together, or neither does. Errors never require app-level close/reopen; the next mutation drains pending cleanup and either succeeds or returns the same typed error indefinitely without corruption.

Mechanism:
- Working-clone pattern: `AddLog` accumulates into a clone with no I/O; `SealBlock` does one Write + fsync + atomic swap. Collapses N+2 syscalls per block to 1 Write + 1 fsync.
- `entrydb` `pendingCleanup` carries an explicit truncate-to target. All rollback/cleanup paths converge on `drainCleanup`. The store's `PrepareForMutation` is the single drain entry point for callers.
- `Rewind`/`Clear` use the same shape: swap committed state first, then truncate + fsync. Pending cleanup makes reads observe the smaller bound even if truncate fails.
- Startup recovery requires `logsSince==0` on the SearchCheckpoint preceding a CanonicalHash (skipping periodic checkpoints). If the file ends exactly at a closing boundary, drop that block — its fsync return cannot be proven; post-boundary entries are proof the prior `SealBlock` returned.

Per-block fsync is required: Linux page cache + device write cache reorder freely across non-FLUSH boundaries on NVMe/EBS/pd-ssd, and ext4 delayed allocation can advance `i_disksize` before data blocks are durable.

Crash-injection tests cover the sync-failure and periodic-checkpoint recovery paths; `TestRecoverOnCreate` subtests updated under the new drop-last-block rule.

Plan: \`plans/2026-05-11-fix-logsdb-atomic-operations-plan.md\` (op-claude).