### PR TITLE
op-challenger: validate named run prestate URL

### DIFF
--- a/op-challenger/cmd/run_trace.go
+++ b/op-challenger/cmd/run_trace.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/flags"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/runner"
@@ -43,6 +44,9 @@ func RunTrace(ctx *cli.Context, _ context.CancelCauseFunc) (cliapp.Lifecycle, er
 		for _, gameType := range cfg.GameTypes {
 			runConfigs = append(runConfigs, runner.RunConfig{GameType: gameType})
 		}
+	}
+	if err := validateRunPrestateUrls(runConfigs, cfg); err != nil {
+		return nil, err
 	}
 	vmTimeout := ctx.Duration(VMTimeoutFlag.Name)
 	ageGameInputs := ctx.Bool(AgeGameInputsFlag.Name)
@@ -126,4 +130,30 @@ func parseRunArg(arg string) (runner.RunConfig, error) {
 		}
 	}
 	return cfg, nil
+}
+
+func validateRunPrestateUrls(runConfigs []runner.RunConfig, cfg *config.Config) error {
+	for _, runConfig := range runConfigs {
+		if runConfig.PrestateFilename == "" || strings.HasPrefix(runConfig.PrestateFilename, "file:") {
+			continue
+		}
+		flagName, configured := runPrestateURLConfig(cfg, runConfig.GameType)
+		if configured {
+			continue
+		}
+		return fmt.Errorf("%w for named prestate %q in run %q; set --%s or use file:<path>",
+			config.ErrMissingPrestateBaseURL, runConfig.PrestateFilename, runConfig.Name, flagName)
+	}
+	return nil
+}
+
+func runPrestateURLConfig(cfg *config.Config, gameType gameTypes.GameType) (string, bool) {
+	switch gameType {
+	case gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+		return flags.PreStatesURLFlag.EitherFlagName(gameTypes.CannonGameType), cfg.CannonAbsolutePreStateBaseURL != nil
+	case gameTypes.CannonKonaGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+		return flags.PreStatesURLFlag.EitherFlagName(gameTypes.CannonKonaGameType), cfg.CannonKonaAbsolutePreStateBaseURL != nil
+	default:
+		return "", true
+	}
 }

--- a/op-challenger/cmd/run_trace_test.go
+++ b/op-challenger/cmd/run_trace_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/runner"
 	"github.com/ethereum/go-ethereum/common"
@@ -33,4 +35,104 @@ func TestParseRunArg(t *testing.T) {
 			require.Equal(t, test.expected, actual)
 		})
 	}
+}
+
+func TestValidateRunPrestateUrls(t *testing.T) {
+	cannonPrestatesURL := mustParseURL(t, "http://localhost/cannon")
+	konaPrestatesURL := mustParseURL(t, "http://localhost/kona")
+
+	tests := []struct {
+		name       string
+		cfg        *config.Config
+		runConfigs []runner.RunConfig
+		err        error
+		errMsg     string
+	}{
+		{
+			name: "NoPrestateFilename",
+			cfg:  &config.Config{},
+			runConfigs: []runner.RunConfig{{
+				GameType: gameTypes.CannonGameType,
+				Name:     "cannon",
+			}},
+		},
+		{
+			name: "SpecificPrestateHash",
+			cfg:  &config.Config{},
+			runConfigs: []runner.RunConfig{{
+				GameType: gameTypes.CannonGameType,
+				Name:     "cannon",
+				Prestate: common.Hash{0xaa},
+			}},
+		},
+		{
+			name: "LocalPrestateFile",
+			cfg:  &config.Config{},
+			runConfigs: []runner.RunConfig{{
+				GameType:         gameTypes.CannonGameType,
+				Name:             "local",
+				PrestateFilename: "file:/tmp/prestate.bin.gz",
+			}},
+		},
+		{
+			name: "CannonNamedPrestateRequiresBaseURL",
+			cfg:  &config.Config{},
+			runConfigs: []runner.RunConfig{{
+				GameType:         gameTypes.CannonGameType,
+				Name:             "develop",
+				PrestateFilename: "develop.bin.gz",
+			}},
+			err:    config.ErrMissingPrestateBaseURL,
+			errMsg: "--prestates-url/cannon-prestates-url",
+		},
+		{
+			name: "CannonNamedPrestateWithBaseURL",
+			cfg: &config.Config{
+				CannonAbsolutePreStateBaseURL: cannonPrestatesURL,
+			},
+			runConfigs: []runner.RunConfig{{
+				GameType:         gameTypes.CannonGameType,
+				Name:             "develop",
+				PrestateFilename: "develop.bin.gz",
+			}},
+		},
+		{
+			name: "KonaNamedPrestateRequiresBaseURL",
+			cfg:  &config.Config{},
+			runConfigs: []runner.RunConfig{{
+				GameType:         gameTypes.CannonKonaGameType,
+				Name:             "develop",
+				PrestateFilename: "develop.bin.gz",
+			}},
+			err:    config.ErrMissingPrestateBaseURL,
+			errMsg: "--prestates-url/cannon-kona-prestates-url",
+		},
+		{
+			name: "SuperKonaNamedPrestateWithBaseURL",
+			cfg: &config.Config{
+				CannonKonaAbsolutePreStateBaseURL: konaPrestatesURL,
+			},
+			runConfigs: []runner.RunConfig{{
+				GameType:         gameTypes.SuperCannonKonaGameType,
+				Name:             "develop",
+				PrestateFilename: "develop.bin.gz",
+			}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateRunPrestateUrls(test.runConfigs, test.cfg)
+			require.ErrorIs(t, err, test.err)
+			if test.errMsg != "" {
+				require.ErrorContains(t, err, test.errMsg)
+			}
+		})
+	}
+}
+
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return parsed
 }

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -33,6 +33,7 @@ var (
 	ErrMissingCannonKonaSnapshotFreq     = errors.New("missing cannon kona snapshot freq")
 	ErrMissingCannonKonaInfoFreq         = errors.New("missing cannon kona info freq")
 	ErrMissingDepsetConfig               = errors.New("missing network or depset config path")
+	ErrMissingPrestateBaseURL            = errors.New("missing prestate base url")
 
 	ErrMissingRollupRpc = errors.New("missing rollup rpc url")
 	ErrMissingSuperRpc  = errors.New("missing super rpc url")

--- a/op-challenger/runner/prestates.go
+++ b/op-challenger/runner/prestates.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/prestates"
@@ -75,6 +76,9 @@ type NamedPrestateFetcher struct {
 }
 
 func (f *NamedPrestateFetcher) getPrestate(ctx context.Context, logger log.Logger, prestateBaseUrl *url.URL, _ string, dataDir string, stateConverter vm.StateConverter) (string, error) {
+	if prestateBaseUrl == nil {
+		return "", config.ErrMissingPrestateBaseURL
+	}
 	targetDir := filepath.Join(dataDir, "prestates")
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		return "", fmt.Errorf("error creating prestate dir: %w", err)
@@ -119,6 +123,9 @@ func (f *NamedPrestateFetcher) getPrestate(ctx context.Context, logger log.Logge
 }
 
 func (f *NamedPrestateFetcher) getPrestateMetadata(ctx context.Context, prestateBaseUrl *url.URL) (string, error) {
+	if prestateBaseUrl == nil {
+		return "", config.ErrMissingPrestateBaseURL
+	}
 	gitInfoUrl := prestateBaseUrl.JoinPath(f.filename + ".txt")
 	req, err := http.NewRequestWithContext(ctx, "GET", gitInfoUrl.String(), nil)
 	if err != nil {

--- a/op-challenger/runner/prestates_test.go
+++ b/op-challenger/runner/prestates_test.go
@@ -1,0 +1,18 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamedPrestateFetcherRequiresBaseURL(t *testing.T) {
+	fetcher := &NamedPrestateFetcher{filename: "develop.bin.gz"}
+
+	_, err := fetcher.getPrestate(context.Background(), log.New(), nil, "", t.TempDir(), nil)
+
+	require.ErrorIs(t, err, config.ErrMissingPrestateBaseURL)
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Validate run-trace configs that use a named prestate file before creating the runner. Named prestates are downloaded from the prestate base URL, so `--run .../develop.bin.gz` without `--prestates-url` or a VM-specific prestates URL could otherwise reach `NamedPrestateFetcher` with a nil base URL and panic when joining the filename.

This returns a configuration error that points to the required URL flag, keeps `file:<path>` runs local, and adds a fetcher-level guard for non-CLI callers.

**Tests**

- go test ./op-challenger/cmd ./op-challenger/runner

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
