### PR TITLE
feat(kona): build reproducible prestates with apko

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -318,6 +318,41 @@ commands:
       - apt-install:
           packages: "zstd=1.4.8*"
 
+  install-apko-melange:
+    description: "Install pinned apko and melange binaries for reproducible image builds."
+    steps:
+      - run:
+          name: Install apko and melange
+          command: |
+            set -euo pipefail
+
+            BIN_DIR=/tmp/apko-melange-bin
+            WORK_DIR=$(mktemp -d)
+            trap 'rm -rf "${WORK_DIR}"' EXIT
+
+            install_tool() {
+              local repo=$1
+              local name=$2
+              local version=$3
+              local archive="${name}_${version}_linux_amd64.tar.gz"
+              local url="https://github.com/chainguard-dev/${repo}/releases/download/v${version}"
+
+              curl -fsSLo "${WORK_DIR}/${archive}" "${url}/${archive}"
+              curl -fsSLo "${WORK_DIR}/${name}-checksums.txt" "${url}/checksums.txt"
+              (cd "${WORK_DIR}" && grep " ${archive}$" "${name}-checksums.txt" | sha256sum -c -)
+              tar -xzf "${WORK_DIR}/${archive}" -C "${BIN_DIR}" --strip-components=1 "${name}_${version}_linux_amd64/${name}"
+              chmod +x "${BIN_DIR}/${name}"
+            }
+
+            mkdir -p "${BIN_DIR}"
+            install_tool apko apko 1.2.12
+            install_tool melange melange 0.50.6
+
+            echo "export PATH=${BIN_DIR}:\${PATH}" >> "${BASH_ENV}"
+            export PATH="${BIN_DIR}:${PATH}"
+            apko version
+            melange version
+
   get-target-branch:
     description: "Determine the PR target branch and export TARGET_BRANCH for subsequent steps"
     steps:
@@ -2011,6 +2046,10 @@ jobs:
       - utils/checkout-with-mise:
           checkout-method: blobless
           enable-mise-cache: true
+      - apt-install:
+          packages: "bubblewrap rsync"
+          extra_flags: "--no-install-recommends"
+      - install-apko-melange
       - run:
           name: Build prestates
           command: just reproducible-prestate

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -130,6 +130,41 @@ commands:
             done
             sudo -E apt-get install -y << parameters.extra_flags >> << parameters.packages >>
 
+  install-apko-melange:
+    description: "Install pinned apko and melange binaries for reproducible image builds."
+    steps:
+      - run:
+          name: Install apko and melange
+          command: |
+            set -euo pipefail
+
+            BIN_DIR=/tmp/apko-melange-bin
+            WORK_DIR=$(mktemp -d)
+            trap 'rm -rf "${WORK_DIR}"' EXIT
+
+            install_tool() {
+              local repo=$1
+              local name=$2
+              local version=$3
+              local archive="${name}_${version}_linux_amd64.tar.gz"
+              local url="https://github.com/chainguard-dev/${repo}/releases/download/v${version}"
+
+              curl -fsSLo "${WORK_DIR}/${archive}" "${url}/${archive}"
+              curl -fsSLo "${WORK_DIR}/${name}-checksums.txt" "${url}/checksums.txt"
+              (cd "${WORK_DIR}" && grep " ${archive}$" "${name}-checksums.txt" | sha256sum -c -)
+              tar -xzf "${WORK_DIR}/${archive}" -C "${BIN_DIR}" --strip-components=1 "${name}_${version}_linux_amd64/${name}"
+              chmod +x "${BIN_DIR}/${name}"
+            }
+
+            mkdir -p "${BIN_DIR}"
+            install_tool apko apko 1.2.12
+            install_tool melange melange 0.50.6
+
+            echo "export PATH=${BIN_DIR}:\${PATH}" >> "${BASH_ENV}"
+            export PATH="${BIN_DIR}:${PATH}"
+            apko version
+            melange version
+
   rust-setup-env:
     description: "Fix rust mise environment variables"
     steps:
@@ -887,8 +922,9 @@ jobs:
       - utils/checkout-with-mise:
           checkout-method: blobless
       - apt-install:
-          packages: "clang llvm-dev libclang-dev"
+          packages: "bubblewrap clang llvm-dev libclang-dev rsync"
           extra_flags: "--no-install-recommends"
+      - install-apko-melange
       - rust-prepare-and-restore-cache: &kona-publish-prestate-cache
           directory: rust
           profile: release

--- a/rust/justfile
+++ b/rust/justfile
@@ -413,51 +413,19 @@ build-kona-prestate VARIANT OUTPUT_DIR:
     cp "$OUTPUT/prestate.bin.gz" "$OUTPUT/${HASH}.bin.gz"
     echo "Prestate for {{VARIANT}}: ${HASH}"
 
-# Build a single reproducible kona prestate variant via Docker.
-# Cannon is built from source as a stage within the Dockerfile.
-# Build context is the monorepo root (same pattern as op-program).
+# Build a single reproducible kona prestate variant via melange + apko.
+# Cannon is built from source inside the melange package pipeline.
 # Set KONA_CUSTOM_CONFIGS_DIR to bake custom chain configs into the prestate.
 build-kona-reproducible-prestate-variant VARIANT OUTPUT_DIR:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    MONOREPO_ROOT="{{justfile_directory()}}/.."
     OUTPUT="{{KONA_DIR}}/{{OUTPUT_DIR}}"
+    "{{KONA_DIR}}/docker/fpvm-prestates/build-apko-prestates.sh" {{VARIANT}} "$OUTPUT"
 
-    # The Dockerfile always copies from the `kona-custom-configs` named build
-    # context, so point it at an empty temp dir when no configs are requested.
-    if [[ -n "${KONA_CUSTOM_CONFIGS_DIR:-}" ]]; then
-      if [[ ! -d "${KONA_CUSTOM_CONFIGS_DIR}" ]]; then
-        echo "KONA_CUSTOM_CONFIGS_DIR=${KONA_CUSTOM_CONFIGS_DIR} is not a directory" >&2
-        exit 1
-      fi
-      CUSTOM_CONFIGS_CONTEXT="${KONA_CUSTOM_CONFIGS_DIR}"
-      CUSTOM_CONFIGS_FLAG=true
-    else
-      CUSTOM_CONFIGS_CONTEXT=$(mktemp -d)
-      trap 'rm -rf "${CUSTOM_CONFIGS_CONTEXT}"' EXIT
-      CUSTOM_CONFIGS_FLAG=false
-    fi
-
-    docker build \
-      --platform linux/amd64 \
-      --build-arg VARIANT={{VARIANT}} \
-      --build-arg KONA_CUSTOM_CONFIGS="${CUSTOM_CONFIGS_FLAG}" \
-      --build-context kona-custom-configs="${CUSTOM_CONFIGS_CONTEXT}" \
-      --output "$OUTPUT" \
-      --progress plain \
-      -f "{{KONA_DIR}}/docker/fpvm-prestates/cannon-repro.dockerfile" \
-      "$MONOREPO_ROOT"
-
-    # Add hash-named copy for challenger lookup
-    HASH=$(jq -r .pre "$OUTPUT/prestate-proof.json")
-    cp "$OUTPUT/prestate.bin.gz" "$OUTPUT/${HASH}.bin.gz"
-    echo "Prestate for {{VARIANT}}: ${HASH}"
-
-# Build all reproducible kona prestates via Docker
+# Build all reproducible kona prestates via melange + apko
 build-kona-reproducible-prestate:
-    @just build-kona-reproducible-prestate-variant kona-client prestate-artifacts-cannon
-    @just build-kona-reproducible-prestate-variant kona-client-int prestate-artifacts-cannon-interop
+    "{{KONA_DIR}}/docker/fpvm-prestates/build-apko-prestates.sh"
 
 output-kona-prestate-hash:
     @echo "-------------------- Kona Prestates --------------------"

--- a/rust/kona/docker/fpvm-prestates/README.md
+++ b/rust/kona/docker/fpvm-prestates/README.md
@@ -1,8 +1,15 @@
 # `fpvm-prestates`
 
-Images for creating reproducible `kona-client` prestate builds for supported fault proof virtual machines.
+melange and apko configuration for creating reproducible `kona-client` prestate builds for supported fault proof virtual machines.
 
-Cannon is built from the local monorepo source.
+Cannon is built from the local monorepo source inside the melange package pipeline. apko then composes a minimal image from the locally built `kona-prestates` APK, and the build script extracts the prestate artifacts back into the existing `rust/kona/prestate-artifacts-*` directories.
+
+## Prerequisites
+
+- `melange`
+- `apko`
+- `jq`
+- `rsync`
 
 ## Usage
 
@@ -10,13 +17,15 @@ Cannon is built from the local monorepo source.
 
 ```sh
 # Produce the prestate artifacts for `kona-client` running on `cannon` (built from local monorepo source)
-just cannon <kona|kona-int>
+cd ../../..
+just build-kona-reproducible-prestate
 ```
 
 ### `kona-client` + `cannon` prestate artifacts with custom output directory
 
 ```sh
-just cannon <kona|kona-int> <artifacts_output_dir>
+cd ../../..
+just build-kona-reproducible-prestate-variant <kona-client|kona-client-int> <artifacts_output_dir>
 ```
 
 ### `kona-client` + `cannon` prestate artifacts for custom chains
@@ -24,5 +33,6 @@ just cannon <kona|kona-int> <artifacts_output_dir>
 To create a reproducible kona-client prestate build that supports custom or devnet chain configurations that are not in the superchain-registry:
 
 ```sh
-just cannon <kona|kona-int> <artifacts_output_dir> <custom_config_dir>
+cd ../../..
+KONA_CUSTOM_CONFIGS_DIR=<custom_config_dir> just build-kona-reproducible-prestate
 ```

--- a/rust/kona/docker/fpvm-prestates/build-apko-prestates.sh
+++ b/rust/kona/docker/fpvm-prestates/build-apko-prestates.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 [kona-client|kona-client-int OUTPUT_DIR]" >&2
+}
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+KONA_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+RUST_ROOT=$(cd "${KONA_ROOT}/.." && pwd)
+REPO_ROOT=$(cd "${RUST_ROOT}/.." && pwd)
+
+MELANGE_CONFIG="${SCRIPT_DIR}/kona-prestates.melange.yaml"
+APKO_CONFIG="${SCRIPT_DIR}/kona-prestates.apko.yaml"
+
+case "$#" in
+  0)
+    KONA_PRESTATE_VARIANTS="kona-client,kona-client-int"
+    ;;
+  2)
+    case "$1" in
+      kona-client | kona-client-int) ;;
+      *)
+        usage
+        exit 2
+        ;;
+    esac
+    KONA_PRESTATE_VARIANTS="$1"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+for bin in melange apko tar jq rsync; do
+  if ! command -v "${bin}" >/dev/null 2>&1; then
+    echo "missing required command: ${bin}" >&2
+    exit 1
+  fi
+done
+
+TMP_DIR=$(mktemp -d)
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+export XDG_CACHE_HOME="${TMP_DIR}/cache"
+mkdir -p "${XDG_CACHE_HOME}"
+
+PACKAGES_DIR="${KONA_PRESTATE_PACKAGES_DIR:-${TMP_DIR}/packages}"
+MELANGE_KEY="${MELANGE_KEY:-${TMP_DIR}/melange.rsa}"
+if [ -z "${MELANGE_RUNNER:-}" ]; then
+  if [ "$(uname -s)" = "Linux" ]; then
+    MELANGE_RUNNER="bubblewrap"
+  else
+    MELANGE_RUNNER="docker"
+  fi
+fi
+
+SOURCE_DIR="${TMP_DIR}/source"
+mkdir -p "${SOURCE_DIR}"
+
+stage_path() {
+  local path=$1
+  local source="${REPO_ROOT}/${path}"
+  local dest="${SOURCE_DIR}/${path}"
+
+  if [ ! -e "${source}" ]; then
+    echo "required source path does not exist: ${path}" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "${dest}")"
+  rsync -a \
+    --exclude 'target/' \
+    --exclude 'prestate-artifacts-cannon/' \
+    --exclude 'prestate-artifacts-cannon-interop/' \
+    "${source}" "${dest}"
+}
+
+stage_path go.mod
+stage_path go.sum
+stage_path mise.toml
+stage_path justfiles/
+stage_path cannon/
+stage_path op-preimage/
+stage_path op-service/
+stage_path rust/
+stage_path op-core/nuts/bundles/
+
+KONA_CUSTOM_CONFIGS=false
+if [ -n "${KONA_CUSTOM_CONFIGS_DIR:-}" ]; then
+  if [ ! -d "${KONA_CUSTOM_CONFIGS_DIR}" ]; then
+    echo "KONA_CUSTOM_CONFIGS_DIR=${KONA_CUSTOM_CONFIGS_DIR} is not a directory" >&2
+    exit 1
+  fi
+
+  rsync -a "${KONA_CUSTOM_CONFIGS_DIR}/" "${SOURCE_DIR}/kona-custom-configs/"
+  KONA_CUSTOM_CONFIGS=true
+fi
+
+ENV_FILE="${TMP_DIR}/melange.env"
+{
+  printf 'KONA_CUSTOM_CONFIGS=%s\n' "${KONA_CUSTOM_CONFIGS}"
+  printf 'KONA_PRESTATE_VARIANTS=%s\n' "${KONA_PRESTATE_VARIANTS}"
+} >"${ENV_FILE}"
+
+if [ ! -f "${MELANGE_KEY}" ]; then
+  melange keygen "${MELANGE_KEY}"
+fi
+
+rm -rf "${PACKAGES_DIR}"
+mkdir -p "${PACKAGES_DIR}" "${TMP_DIR}/sbom"
+
+melange build "${MELANGE_CONFIG}" \
+  --arch x86_64 \
+  --signing-key "${MELANGE_KEY}" \
+  --source-dir "${SOURCE_DIR}" \
+  --out-dir "${PACKAGES_DIR}" \
+  --runner "${MELANGE_RUNNER}" \
+  --env-file "${ENV_FILE}"
+
+apko build "${APKO_CONFIG}" "kona-prestates:local" "${TMP_DIR}/kona-prestates.tar" \
+  --arch x86_64 \
+  --sbom-path "${TMP_DIR}/sbom" \
+  -k "${MELANGE_KEY}.pub" \
+  -r "${PACKAGES_DIR}"
+
+APK_PATH=$(find "${PACKAGES_DIR}/x86_64" -maxdepth 1 -type f -name 'kona-prestates-*.apk' | sort | tail -1)
+if [ -z "${APK_PATH}" ]; then
+  echo "kona-prestates APK was not produced under ${PACKAGES_DIR}/x86_64" >&2
+  exit 1
+fi
+
+EXTRACT_DIR="${TMP_DIR}/extract"
+mkdir -p "${EXTRACT_DIR}"
+tar -xzf "${APK_PATH}" -C "${EXTRACT_DIR}" usr/share/kona-prestates
+
+copy_variant() {
+  local variant=$1
+  local output=$2
+  local source="${EXTRACT_DIR}/usr/share/kona-prestates/${variant}"
+
+  rm -rf "${output}"
+  mkdir -p "${output}"
+  cp "${source}/prestate.bin.gz" "${output}/prestate.bin.gz"
+  cp "${source}/prestate-proof.json" "${output}/prestate-proof.json"
+  cp "${source}/meta.json" "${output}/meta.json"
+  cp "${source}/kona-client-elf" "${output}/kona-client-elf"
+
+  local hash
+  hash=$(jq -r .pre "${output}/prestate-proof.json")
+  cp "${output}/prestate.bin.gz" "${output}/${hash}.bin.gz"
+  echo "Prestate for ${variant}: ${hash}"
+}
+
+if [ "$#" -eq 2 ]; then
+  copy_variant "$1" "$2"
+else
+  copy_variant kona-client "${KONA_ROOT}/prestate-artifacts-cannon"
+  copy_variant kona-client-int "${KONA_ROOT}/prestate-artifacts-cannon-interop"
+fi

--- a/rust/kona/docker/fpvm-prestates/kona-prestates.apko.yaml
+++ b/rust/kona/docker/fpvm-prestates/kona-prestates.apko.yaml
@@ -1,0 +1,11 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - wolfi-baselayout
+    - kona-prestates
+
+archs:
+  - x86_64

--- a/rust/kona/docker/fpvm-prestates/kona-prestates.melange.yaml
+++ b/rust/kona/docker/fpvm-prestates/kona-prestates.melange.yaml
@@ -1,0 +1,136 @@
+package:
+  name: kona-prestates
+  version: 0.0.1
+  epoch: 0
+  description: Reproducible kona-client cannon prestate artifacts
+
+vars:
+  kona_custom_configs: ${KONA_CUSTOM_CONFIGS}
+  kona_prestate_variants: ${KONA_PRESTATE_VARIANTS}
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - bash
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - clang-18
+      - cmake
+      - curl
+      - git
+      - go-1.24
+      - jq
+      - just
+      - openssl-dev
+      - pkgconf
+      - rustup
+
+pipeline:
+  - name: Build cannon and kona prestate artifacts
+    runs: |
+      set -euo pipefail
+
+      export CARGO_HOME=/tmp/kona-cargo
+      export RUSTUP_HOME=/tmp/kona-rustup
+      export PATH="${CARGO_HOME}/bin:${PATH}"
+      mkdir -p "${CARGO_HOME}" "${RUSTUP_HOME}"
+
+      NIGHTLY="$(grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' "${{package.srcdir}}/mise.toml" | head -1)"
+      rustup toolchain install "${NIGHTLY}" --component rustfmt --component rust-src
+      TOOLCHAIN_BIN="${RUSTUP_HOME}/toolchains/${NIGHTLY}-x86_64-unknown-linux-gnu/bin"
+      if [ ! -x "${TOOLCHAIN_BIN}/cargo" ]; then
+        echo "cargo was not installed at ${TOOLCHAIN_BIN}/cargo" >&2
+        exit 1
+      fi
+      export PATH="${TOOLCHAIN_BIN}:${PATH}"
+      export LD_LIBRARY_PATH="${RUSTUP_HOME}/toolchains/${NIGHTLY}-x86_64-unknown-linux-gnu/lib:${LD_LIBRARY_PATH:-}"
+
+      # The existing just recipe sets CARGO_TARGET_MIPS64_UNKNOWN_NONE_LINKER
+      # to this executable. The target spec uses ld.lld flavor, so point the
+      # expected name at the pinned nightly rust-lld rather than depending on
+      # a distro-provided MIPS GNU cross linker.
+      RUST_LLD="$(find "${RUSTUP_HOME}/toolchains" -path "*/bin/rust-lld" | head -1)"
+      if [ -z "${RUST_LLD}" ]; then
+        echo "rust-lld was not installed with ${NIGHTLY}" >&2
+        exit 1
+      fi
+      {
+        printf '%s\n' '#!/usr/bin/env bash'
+        printf '%s\n' 'set -euo pipefail'
+        printf '%s\n' ''
+        printf '%s\n' 'args=()'
+        printf '%s\n' 'for arg in "$@"; do'
+        printf '%s\n' '  case "${arg}" in'
+        printf '%s\n' '    -Wl,*)'
+        printf '%s\n' '      IFS="," read -r -a linker_args <<< "${arg#-Wl,}"'
+        printf '%s\n' '      args+=("${linker_args[@]}")'
+        printf '%s\n' '      ;;'
+        printf '%s\n' '    -nodefaultlibs)'
+        printf '%s\n' '      ;;'
+        printf '%s\n' '    -no-pie)'
+        printf '%s\n' '      args+=("--no-pie")'
+        printf '%s\n' '      ;;'
+        printf '%s\n' '    *)'
+        printf '%s\n' '      args+=("${arg}")'
+        printf '%s\n' '      ;;'
+        printf '%s\n' '  esac'
+        printf '%s\n' 'done'
+        printf '%s\n' ''
+        printf '%s\n' "exec \"${RUST_LLD}\" -flavor gnu \"\${args[@]}\""
+      } > /usr/local/bin/mips64-linux-gnuabi64-gcc
+      chmod +x /usr/local/bin/mips64-linux-gnuabi64-gcc
+      ln -sf /usr/local/bin/mips64-linux-gnuabi64-gcc /usr/local/bin/mips64-linux-gnuabi64-g++
+
+      cd "${{package.srcdir}}/cannon"
+      just cannon
+      CANNON_BIN="${{package.srcdir}}/cannon/bin/cannon"
+
+      if [ "${{vars.kona_custom_configs}}" = "true" ]; then
+        export KONA_CUSTOM_CONFIGS_DIR="${{package.srcdir}}/kona-custom-configs"
+      fi
+
+      cd "${{package.srcdir}}/rust"
+      for variant in $(printf '%s' "${{vars.kona_prestate_variants}}" | tr ',' ' '); do
+        just build-kona-client-elf "${variant}"
+
+        artifact_dir="/tmp/kona-prestates/${variant}"
+        mkdir -p "${artifact_dir}"
+        elf="${{package.srcdir}}/rust/target/mips64-unknown-none/release-client-lto/${variant}"
+
+        "${CANNON_BIN}" load-elf \
+          --path="${elf}" \
+          --out="${artifact_dir}/prestate.bin.gz" \
+          --meta="${artifact_dir}/meta.json" \
+          --type multithreaded64-5
+
+        "${CANNON_BIN}" run \
+          --proof-at "=0" \
+          --stop-at "=1" \
+          --input "${artifact_dir}/prestate.bin.gz" \
+          --meta "${artifact_dir}/meta.json" \
+          --proof-fmt "${artifact_dir}/%d.json" \
+          --output ""
+
+        mv "${artifact_dir}/0.json" "${artifact_dir}/prestate-proof.json"
+        cp "${elf}" "${artifact_dir}/kona-client-elf"
+      done
+
+  - name: Install prestate artifacts
+    runs: |
+      set -euo pipefail
+
+      for variant in $(printf '%s' "${{vars.kona_prestate_variants}}" | tr ',' ' '); do
+        install -Dm644 "/tmp/kona-prestates/${variant}/prestate.bin.gz" \
+          "${{targets.destdir}}/usr/share/kona-prestates/${variant}/prestate.bin.gz"
+        install -Dm644 "/tmp/kona-prestates/${variant}/prestate-proof.json" \
+          "${{targets.destdir}}/usr/share/kona-prestates/${variant}/prestate-proof.json"
+        install -Dm644 "/tmp/kona-prestates/${variant}/meta.json" \
+          "${{targets.destdir}}/usr/share/kona-prestates/${variant}/meta.json"
+        install -Dm755 "/tmp/kona-prestates/${variant}/kona-client-elf" \
+          "${{targets.destdir}}/usr/share/kona-prestates/${variant}/kona-client-elf"
+      done


### PR DESCRIPTION
## Summary

Migrates the reproducible Kona fault proof prestate build from the Dockerfile-based flow to a melange/apko-based flow.

- Adds melange package config for building `kona-client` / `kona-client-int` prestates.
- Adds apko config for composing a minimal image containing the generated prestate artifacts.
- Replaces `just build-kona-reproducible-prestate*` Docker invocation with the new apko/melange build script.
- Preserves existing output layout under:
  - `rust/kona/prestate-artifacts-cannon`
  - `rust/kona/prestate-artifacts-cannon-interop`
- Supports `KONA_CUSTOM_CONFIGS_DIR`.
- Updates CircleCI jobs to install pinned `apko` and `melange` release binaries.
- Keeps CircleCI single-variant publishing efficient by building only the requested Kona variant.

## Verification

- Ran default reproducible Kona prestate builds successfully.
- Confirmed generated hashes match existing checked-in artifacts
- Tested prestate builds with custom configs