### PR TITLE
chore: remove ai contracts test CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,6 @@ parameters:
   heavy_fuzz_dispatch:
     type: boolean
     default: false
-  ai_contracts_test_dispatch:
-    type: boolean
-    default: false
   rust_ci_dispatch:
     type: boolean
     default: false
@@ -106,7 +103,6 @@ workflows:
             .* c-stale_check_dispatch << pipeline.parameters.stale_check_dispatch >> .circleci/continue/main.yml
             .* c-contracts_coverage_dispatch << pipeline.parameters.contracts_coverage_dispatch >> .circleci/continue/main.yml
             .* c-heavy_fuzz_dispatch << pipeline.parameters.heavy_fuzz_dispatch >> .circleci/continue/main.yml
-            .* c-ai_contracts_test_dispatch << pipeline.parameters.ai_contracts_test_dispatch >> .circleci/continue/main.yml
             .* c-l2_fork_test_dispatch << pipeline.parameters.l2_fork_test_dispatch >> .circleci/continue/main.yml
             .* c-github-event-type << pipeline.parameters.github-event-type >> .circleci/continue/main.yml
             .* c-github-event-action << pipeline.parameters.github-event-action >> .circleci/continue/main.yml

--- a/.circleci/continue/docs-ci.yml
+++ b/.circleci/continue/docs-ci.yml
@@ -56,9 +56,6 @@ parameters:
   sync_test_op_node_dispatch:
     type: boolean
     default: false
-  ai_contracts_test_dispatch:
-    type: boolean
-    default: false
   rust_ci_dispatch:
     type: boolean
     default: false

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -47,9 +47,6 @@ parameters:
   c-heavy_fuzz_dispatch:
     type: boolean
     default: false
-  c-ai_contracts_test_dispatch:
-    type: boolean
-    default: false
   c-l2_fork_test_dispatch:
     type: boolean
     default: false
@@ -124,9 +121,6 @@ parameters:
     type: boolean
     default: false
   sync_test_op_node_dispatch:
-    type: boolean
-    default: false
-  ai_contracts_test_dispatch:
     type: boolean
     default: false
   l2_fork_test_dispatch:
@@ -1130,39 +1124,6 @@ jobs:
       - store_test_results:
           path: packages/contracts-bedrock/results
           when: always
-      - notify-failures-on-develop:
-          mentions: "@security-oncall"
-
-  # AI Contracts Test Maintenance System
-  # Runbook: https://github.com/ethereum-optimism/optimism/blob/develop/ops/ai-eng/contracts-test-maintenance/docs/runbook.md
-  ai-contracts-test:
-    docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-          enable-mise-cache: true
-      - run:
-          name: Check Python version
-          command: python3 --version
-      - run:
-          name: Run AI Contracts Test System
-          command: just ai-contracts-test
-          working_directory: ops/ai-eng
-          no_output_timeout: 60m
-      - store_artifacts:
-          path: ops/ai-eng/contracts-test-maintenance/log.json
-          destination: log.json
-      - run:
-          name: Build Slack notification
-          command: just build-slack-notification >> $BASH_ENV
-          working_directory: ops/ai-eng
-          when: always
-      - slack/notify:
-          channel: C050F1GUHDG
-          event: always
-          template: AI_PR_SLACK_TEMPLATE
       - notify-failures-on-develop:
           mentions: "@security-oncall"
 
@@ -3002,19 +2963,6 @@ workflows:
             This issue will be closed now."
           context:
             - circleci-repo-optimism
-
-  ai-contracts-test-workflow:
-    when:
-      or:
-        - equal: [build_mon_thu, <<pipeline.schedule.name>>]
-        - equal: [true, << pipeline.parameters.c-ai_contracts_test_dispatch >>]
-    jobs:
-      - ai-contracts-test:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - circleci-api-token
-            - devin-api
-            - slack
 
   l2-fork-test-workflow:
     when:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -76,9 +76,6 @@ parameters:
   sync_test_op_node_dispatch:
     type: boolean
     default: false
-  ai_contracts_test_dispatch:
-    type: boolean
-    default: false
   rust_ci_dispatch:
     type: boolean
     default: false

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -70,9 +70,6 @@ parameters:
   sync_test_op_node_dispatch:
     type: boolean
     default: false
-  ai_contracts_test_dispatch:
-    type: boolean
-    default: false
   rust_ci_dispatch:
     type: boolean
     default: false


### PR DESCRIPTION
Removes the AI contracts test CircleCI job, workflow, and stale dispatch parameters.