### PR TITLE
fix(op-interop-filter): stop ingestion when fatal error state is set

### DIFF
--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -643,8 +643,8 @@ func (c *LogsDBChainIngester) ingestBlock(blockNum uint64) error {
 }
 
 func (c *LogsDBChainIngester) ingestBlockRange(startBlock, endBlock uint64, lastLogTime time.Time) (uint64, time.Time, error) {
-	if c.Error() != nil {
-		return startBlock, lastLogTime, nil
+	if errState := c.Error(); errState != nil {
+		return startBlock, lastLogTime, errState
 	}
 	if startBlock > endBlock {
 		return startBlock, lastLogTime, nil
@@ -729,8 +729,8 @@ func (c *LogsDBChainIngester) ingestBlockRange(startBlock, endBlock uint64, last
 }
 
 func (c *LogsDBChainIngester) writeFetchedBlock(fetched blockFetch) error {
-	if c.Error() != nil {
-		return nil
+	if errState := c.Error(); errState != nil {
+		return errState
 	}
 
 	blockInfo := fetched.blockInfo
@@ -754,7 +754,7 @@ func (c *LogsDBChainIngester) writeFetchedBlock(fetched blockFetch) error {
 				"expected_parent", latestBlock.Hash,
 				"actual_parent", blockInfo.ParentHash())
 			c.SetError(ErrorReorg, fmt.Sprintf("parent hash mismatch at block %d", blockNum))
-			return nil
+			return c.Error()
 		}
 	}
 
@@ -762,15 +762,15 @@ func (c *LogsDBChainIngester) writeFetchedBlock(fetched blockFetch) error {
 	if err != nil {
 		if errors.Is(err, types.ErrConflict) {
 			c.SetError(ErrorConflict, fmt.Sprintf("database conflict at block %d", blockNum))
-			return nil
+			return c.Error()
 		}
 		if errors.Is(err, types.ErrDataCorruption) {
 			c.SetError(ErrorDataCorruption, fmt.Sprintf("data corruption at block %d: %v", blockNum, err))
-			return nil
+			return c.Error()
 		}
 		if errors.Is(err, ErrInvalidLog) {
 			c.SetError(ErrorInvalidExecutingMessage, fmt.Sprintf("invalid log at block %d: %v", blockNum, err))
-			return nil
+			return c.Error()
 		}
 		return err
 	}

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -592,12 +592,52 @@ func TestLogsDBChainIngester_ReorgDetection(t *testing.T) {
 	mockClient.AddBlock(reorgBlock, createTestReceipts(101, 1))
 
 	err = ingester.ingestBlock(101)
-	require.NoError(t, err) // ingestBlock doesn't return error, it sets error state
+	require.Error(t, err)
 
 	// Check that error state was set
 	ingesterErr := ingester.Error()
 	require.NotNil(t, ingesterErr)
 	require.Equal(t, ErrorReorg, ingesterErr.Reason)
+}
+
+func TestLogsDBChainIngester_IngestBlockRangeStopsAtErrorState(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := NewMockEthClient()
+
+	parentBlock := createTestBlock(99, 1198, common.Hash{})
+	block100 := createTestBlock(100, 1200, parentBlock.Hash())
+	reorgBlock101 := createTestBlock(101, 1202, common.Hash{0xDE, 0xAD})
+	block102 := createTestBlock(102, 1204, reorgBlock101.Hash())
+	mockClient.AddBlock(parentBlock, nil)
+	mockClient.AddBlock(block100, createTestReceipts(100, 1))
+	mockClient.AddBlock(reorgBlock101, createTestReceipts(101, 1))
+	mockClient.AddBlock(block102, createTestReceipts(102, 1))
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+	ingester.fetchConcurrency = 2
+
+	require.NoError(t, ingester.initLogsDB())
+	t.Cleanup(func() { ingester.logsDB.Close() })
+	require.NoError(t, ingester.sealParentBlock(99))
+
+	nextBlock, _, err := ingester.ingestBlockRange(100, 102, clock.SystemClock.Now())
+	require.Error(t, err)
+	require.Equal(t, uint64(101), nextBlock)
+
+	ingesterErr := ingester.Error()
+	require.NotNil(t, ingesterErr)
+	require.Equal(t, ErrorReorg, ingesterErr.Reason)
+
+	latestBlock, ok := ingester.LatestBlock()
+	require.True(t, ok)
+	require.Equal(t, uint64(100), latestBlock.Number)
 }
 
 func TestLogsDBChainIngester_RewindToFinalized(t *testing.T) {
@@ -1083,9 +1123,9 @@ func TestLogsDBChainIngester_IngestBlock_ErrorStateSkipsIngestion(t *testing.T) 
 	// Set error state before ingestion
 	ingester.SetError(ErrorReorg, "test error")
 
-	// ingestBlock should return nil without doing anything
+	// ingestBlock should return the existing error without doing anything
 	err = ingester.ingestBlock(100)
-	require.NoError(t, err)
+	require.Error(t, err)
 
 	// Block 100 should NOT have been ingested
 	latestBlock, ok := ingester.LatestBlock()


### PR DESCRIPTION
Closes ethereum-optimism/optimism-private#540.

## Summary

- return the ingester error immediately when a fatal ingestion condition is detected
- keep `ingestBlockRange` pinned to the failing block instead of advancing `nextBlock` past an uningested block
- update tests to assert direct ingestion calls surface the fatal state

## Validation

- `go test ./op-interop-filter/filter`
