### PR TITLE
fix(op-supernode): wait on stale frontier L1 heads

### DIFF
--- a/op-supernode/supernode/activity/interop/checker_test.go
+++ b/op-supernode/supernode/activity/interop/checker_test.go
@@ -31,11 +31,22 @@ func (noopL1Checker) SameL1Chain(context.Context, []eth.BlockID) (bool, error) {
 }
 
 // inconsistentL1Checker always reports that heads disagree on the canonical L1
-// chain. Tests use it to drive observeRound into a rewind decision.
+// chain. Tests use it to drive observeRound into an L1 inconsistency decision.
 type inconsistentL1Checker struct{}
 
 func (inconsistentL1Checker) SameL1Chain(context.Context, []eth.BlockID) (bool, error) {
 	return false, nil
+}
+
+// staleFrontierL1Checker treats the accepted L1 head as canonical on the first
+// check, then reports the frontier L1 heads as stale on the second check.
+type staleFrontierL1Checker struct {
+	calls int
+}
+
+func (s *staleFrontierL1Checker) SameL1Chain(context.Context, []eth.BlockID) (bool, error) {
+	s.calls++
+	return s.calls == 1, nil
 }
 
 func TestL1ConsistencyChecker_SameL1Chain(t *testing.T) {

--- a/op-supernode/supernode/activity/interop/decide_test.go
+++ b/op-supernode/supernode/activity/interop/decide_test.go
@@ -33,12 +33,21 @@ func TestCheckPreconditions(t *testing.T) {
 			want: ptrDecision(DecisionWait),
 		},
 		{
-			name: "rewind when L1 inconsistent",
+			name: "rewind when accepted L1 needs rewind",
+			obs: RoundObservation{
+				ChainsReady:   true,
+				L1Consistent:  false,
+				L1NeedsRewind: true,
+			},
+			want: ptrDecision(DecisionRewind),
+		},
+		{
+			name: "wait when frontier L1 inconsistent",
 			obs: RoundObservation{
 				ChainsReady:  true,
 				L1Consistent: false,
 			},
-			want: ptrDecision(DecisionRewind),
+			want: ptrDecision(DecisionWait),
 		},
 		{
 			name: "proceed when preconditions are satisfied",

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -65,6 +65,7 @@ type RoundObservation struct {
 	BlocksAtTS     map[eth.ChainID]eth.BlockID
 	L1Heads        map[eth.ChainID]eth.BlockID
 	L1Consistent   bool
+	L1NeedsRewind  bool
 	Paused         bool
 }
 
@@ -416,8 +417,12 @@ func checkPreconditions(obs RoundObservation) *StepOutput {
 		output := StepOutput{Decision: DecisionWait}
 		return &output
 	}
-	if !obs.L1Consistent {
+	if obs.L1NeedsRewind {
 		output := StepOutput{Decision: DecisionRewind}
+		return &output
+	}
+	if !obs.L1Consistent {
+		output := StepOutput{Decision: DecisionWait}
 		return &output
 	}
 	return nil
@@ -547,11 +552,22 @@ func (i *Interop) observeRound() (RoundObservation, error) {
 	obs.BlocksAtTS = ready.blocks
 	obs.L1Heads = ready.l1Heads
 
-	// Check that all frontier L1 heads AND the accepted L1 head are on the same canonical fork.
-	heads := make([]eth.BlockID, 0, len(obs.L1Heads)+1)
 	if obs.LastVerified != nil {
-		heads = append(heads, obs.LastVerified.L1Inclusion)
+		same, err := i.l1Checker.SameL1Chain(i.ctx, []eth.BlockID{obs.LastVerified.L1Inclusion})
+		if err != nil {
+			return obs, fmt.Errorf("L1 consistency check: %w", err)
+		}
+		if !same {
+			obs.L1Consistent = false
+			obs.L1NeedsRewind = true
+			return obs, nil
+		}
 	}
+
+	// Check the new frontier independently from the accepted L1 head. If the
+	// accepted head is still canonical but a frontier L1 head is stale, waiting
+	// gives the L2 nodes time to catch up to the L1 reorg.
+	heads := make([]eth.BlockID, 0, len(obs.L1Heads))
 	for _, l1 := range obs.L1Heads {
 		heads = append(heads, l1)
 	}

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1691,6 +1691,50 @@ func TestInterop_ProgressAndRecord_L1InconsistencyTriggersRewind(t *testing.T) {
 	require.Empty(t, mock.rewindEngineCalls, "L1 drift rewinds accepted Supernode state only")
 }
 
+func TestInterop_ProgressAndRecord_StaleFrontierL1Waits(t *testing.T) {
+	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
+					WithActivation(100).
+					WithChain(10, func(m *mockChainContainer) {
+			m.currentL1 = eth.BlockRef{Number: 1000, Hash: common.HexToHash("0xL1")}
+			m.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
+		}).
+		Build()
+
+	mock := h.Mock(10)
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")}, L2Heads: blocks}, nil
+	}
+	h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+		return Result{}, nil
+	}
+
+	made, err := h.interop.progressAndRecord()
+	require.NoError(t, err)
+	require.True(t, made)
+
+	lastTS, ok := h.interop.verifiedDB.LastTimestamp()
+	require.True(t, ok)
+	require.Equal(t, uint64(101), lastTS)
+
+	// The accepted L1 head is still canonical, but the frontier L1 heads are
+	// stale. This should wait for the L2 node to catch up instead of rewinding
+	// already accepted Supernode state.
+	h.interop.l1Checker = &staleFrontierL1Checker{}
+
+	made, err = h.interop.progressAndRecord()
+	require.NoError(t, err)
+	require.False(t, made)
+
+	lastTS, ok = h.interop.verifiedDB.LastTimestamp()
+	require.True(t, ok)
+	require.Equal(t, uint64(101), lastTS)
+
+	pending, err := h.interop.verifiedDB.GetPendingTransition()
+	require.NoError(t, err)
+	require.Nil(t, pending)
+	require.Empty(t, mock.rewindEngineCalls)
+}
+
 // =============================================================================
 // TestResult_IsEmpty
 // =============================================================================


### PR DESCRIPTION
Closes ethereum-optimism/optimism-private#542.

## Summary

- check the previously accepted L1 inclusion head separately from the new frontier L1 heads
- keep rewinding when the accepted L1 head is no longer canonical
- wait, rather than rewind, when the accepted L1 head is still canonical but the frontier L1 heads are stale

## Validation

- `go test ./op-supernode/supernode/activity/interop`
