### PR TITLE
fix(op-supernode): skip gap check for already sealed timestamp

### DIFF
--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -207,8 +207,8 @@ func (i *Interop) verifyCanAddTimestamp(chainID eth.ChainID, db LogsDB, ts uint6
 		return eth.BlockID{}, hasBlocks, fmt.Errorf("chain %s: failed to find sealed block %d: %w", chainID, latestBlock.Number, err)
 	}
 
-	// if the last sealed block is already after the timestamp in question, return success
-	if seal.Timestamp > ts {
+	// if the last sealed block is already at or after the timestamp in question, return success
+	if seal.Timestamp >= ts {
 		return latestBlock, hasBlocks, nil
 	}
 


### PR DESCRIPTION
Closes ethereum-optimism/optimism-private#544.

## Summary

- treat `seal.Timestamp == ts` as already sealed in `verifyCanAddTimestamp`
- avoid running the gap/debug-message path when retrying a timestamp that is already present

## Validation

- `go test ./op-supernode/supernode/activity/interop`
