### PR TITLE
[codex] add op-reth runtime cross-unsafe head

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11333,6 +11333,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "kona-interop",
  "metrics",
  "op-alloy-consensus",
  "op-alloy-network",

--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -59,6 +59,13 @@ pub struct RollupArgs {
     #[arg(long = "rollup.supervisor-http", value_name = "SUPERVISOR_HTTP_URL")]
     pub supervisor_http: Option<String>,
 
+    /// Remote execution RPCs used to validate initiating message existence for `eth_crossUnsafeHead`.
+    ///
+    /// Each value is a `CHAIN_ID=RPC_URL` mapping. Repeat the flag to configure multiple source
+    /// chains.
+    #[arg(long = "rollup.cross-unsafe-head-source-rpc", value_name = "CHAIN_ID=RPC_URL")]
+    pub cross_unsafe_head_source_rpcs: Vec<String>,
+
     /// Safety level for the supervisor
     #[arg(
         long = "rollup.supervisor-safety-level",
@@ -181,6 +188,7 @@ impl Default for RollupArgs {
             enable_tx_conditional: false,
             sdm_enabled: false,
             supervisor_http: None,
+            cross_unsafe_head_source_rpcs: Vec::new(),
             supervisor_safety_level: SafetyLevel::CrossUnsafe,
             sequencer_headers: Vec::new(),
             historical_rpc: None,
@@ -251,6 +259,26 @@ mod tests {
         let args =
             CommandParser::<RollupArgs>::parse_from(["reth", "--rollup.disable-tx-pool-gossip"])
                 .args;
+        assert_eq!(args, expected_args);
+    }
+
+    #[test]
+    fn test_parse_cross_unsafe_head_source_rpc_args() {
+        let expected_args = RollupArgs {
+            cross_unsafe_head_source_rpcs: vec![
+                "901=http://chain-a:8545".into(),
+                "902=http://chain-b:8545".into(),
+            ],
+            ..Default::default()
+        };
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--rollup.cross-unsafe-head-source-rpc",
+            "901=http://chain-a:8545",
+            "--rollup.cross-unsafe-head-source-rpc",
+            "902=http://chain-b:8545",
+        ])
+        .args;
         assert_eq!(args, expected_args);
     }
 

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -46,6 +46,7 @@ use reth_optimism_payload_builder::{
 use reth_optimism_primitives::{DepositReceipt, OpPrimitives};
 use reth_optimism_rpc::{
     SequencerClient,
+    cross_unsafe::{CrossUnsafeHeadApiServer, CrossUnsafeHeadExt},
     eth::{OpEthApiBuilder, ext::OpEthExtApi},
     historical::{HistoricalRpc, HistoricalRpcClient},
     miner::{MinerApiExtServer, OpMinerExtApi},
@@ -54,7 +55,7 @@ use reth_optimism_rpc::{
 use reth_optimism_storage::OpStorage;
 use reth_optimism_txpool::{OpPool, OpPooledTx, supervisor::SupervisorClient};
 use reth_primitives_traits::header::HeaderMut;
-use reth_provider::{CanonStateSubscriptions, providers::ProviderFactoryBuilder};
+use reth_provider::{BlockReaderIdExt, CanonStateSubscriptions, providers::ProviderFactoryBuilder};
 use reth_rpc_api::{
     DebugApiServer, EthConfigApiServer, L2EthApiExtServer,
     eth::{RpcTypes, helpers::config::EthConfigHandler},
@@ -266,6 +267,7 @@ impl OpNode {
             .with_enable_tx_conditional(self.args.enable_tx_conditional)
             .with_min_suggested_priority_fee(self.args.min_suggested_priority_fee)
             .with_historical_rpc(self.args.historical_rpc.clone())
+            .with_cross_unsafe_head_source_rpcs(self.args.cross_unsafe_head_source_rpcs.clone())
             .with_flashblocks(self.args.flashblocks_url.clone())
             .with_flashblock_consensus(self.args.flashblock_consensus)
     }
@@ -393,6 +395,8 @@ pub struct OpAddOns<
     ///
     /// This can be used to forward pre-bedrock rpc requests (op-mainnet).
     pub historical_rpc: Option<String>,
+    /// Remote execution RPCs used by the runtime cross-unsafe head extension.
+    pub cross_unsafe_head_source_rpcs: Vec<String>,
     /// Whether SDM is explicitly enabled for integration tests.
     sdm_enabled: bool,
     /// Enable transaction conditionals.
@@ -414,6 +418,7 @@ where
         sequencer_url: Option<String>,
         sequencer_headers: Vec<String>,
         historical_rpc: Option<String>,
+        cross_unsafe_head_source_rpcs: Vec<String>,
         sdm_enabled: bool,
         enable_tx_conditional: bool,
         min_suggested_priority_fee: u64,
@@ -425,6 +430,7 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
@@ -477,6 +483,7 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
@@ -489,6 +496,7 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
@@ -510,6 +518,7 @@ where
             enable_tx_conditional,
             min_suggested_priority_fee,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             ..
         } = self;
         OpAddOns::new(
@@ -519,6 +528,7 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
@@ -540,6 +550,7 @@ where
             enable_tx_conditional,
             min_suggested_priority_fee,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             ..
         } = self;
         OpAddOns::new(
@@ -549,6 +560,7 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
@@ -573,6 +585,7 @@ where
             enable_tx_conditional,
             min_suggested_priority_fee,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             ..
         } = self;
         OpAddOns::new(
@@ -582,6 +595,7 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
@@ -628,6 +642,7 @@ where
             Pool: TransactionPool<Transaction: OpPooledTx<Consensus = TxTy<N::Types>>>,
         >,
     TxTy<N::Types>: From<Sealed<TxPostExec>>,
+    N::Provider: BlockReaderIdExt + Clone + Send + Sync + 'static,
     EthB: EthApiBuilder<N>,
     PVB: Send,
     EB: EngineApiBuilder<N>,
@@ -648,6 +663,7 @@ where
             sequencer_headers,
             enable_tx_conditional,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             ..
         } = self;
 
@@ -701,6 +717,12 @@ where
             ctx.node.pool().clone(),
             ctx.node.provider().clone(),
         );
+        let cross_unsafe_head_ext = (!cross_unsafe_head_source_rpcs.is_empty())
+            .then(|| {
+                CrossUnsafeHeadExt::new(ctx.node.provider().clone(), cross_unsafe_head_source_rpcs)
+            })
+            .transpose()
+            .map_err(eyre::Report::msg)?;
 
         rpc_add_ons
             .launch_add_ons_with(ctx, move |container| {
@@ -735,6 +757,14 @@ where
                     modules.merge_if_module_configured(
                         RethRpcModule::Eth,
                         tx_conditional_ext.into_rpc(),
+                    )?;
+                }
+
+                if let Some(cross_unsafe_head_ext) = cross_unsafe_head_ext {
+                    debug!(target: "reth::cli", "Installing runtime cross-unsafe head rpc endpoint");
+                    modules.merge_if_module_configured(
+                        RethRpcModule::Eth,
+                        cross_unsafe_head_ext.into_rpc(),
                     )?;
                 }
 
@@ -805,6 +835,8 @@ pub struct OpAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     sequencer_headers: Vec<String>,
     /// RPC endpoint for historical data.
     historical_rpc: Option<String>,
+    /// Remote execution RPCs used by the runtime cross-unsafe head extension.
+    cross_unsafe_head_source_rpcs: Vec<String>,
     /// Data availability configuration for the OP builder.
     da_config: Option<OpDAConfig>,
     /// Gas limit configuration for the OP builder.
@@ -833,6 +865,7 @@ impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
             sequencer_url: None,
             sequencer_headers: Vec::new(),
             historical_rpc: None,
+            cross_unsafe_head_source_rpcs: Vec::new(),
             da_config: None,
             gas_limit_config: None,
             sdm_enabled: false,
@@ -897,6 +930,15 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
         self
     }
 
+    /// Configures the source RPC used by the runtime cross-unsafe head extension.
+    pub fn with_cross_unsafe_head_source_rpcs(
+        mut self,
+        cross_unsafe_head_source_rpcs: Vec<String>,
+    ) -> Self {
+        self.cross_unsafe_head_source_rpcs = cross_unsafe_head_source_rpcs;
+        self
+    }
+
     /// Configures a custom tokio runtime for the RPC server.
     ///
     /// Caution: This runtime must not be created from within asynchronous context.
@@ -911,6 +953,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             sequencer_url,
             sequencer_headers,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             da_config,
             gas_limit_config,
             sdm_enabled,
@@ -926,6 +969,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             sequencer_url,
             sequencer_headers,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             da_config,
             gas_limit_config,
             sdm_enabled,
@@ -973,6 +1017,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             enable_tx_conditional,
             min_suggested_priority_fee,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             rpc_middleware,
             tokio_runtime,
             flashblocks_url,
@@ -1001,6 +1046,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             sequencer_url,
             sequencer_headers,
             historical_rpc,
+            cross_unsafe_head_source_rpcs,
             sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,

--- a/rust/op-reth/crates/rpc/Cargo.toml
+++ b/rust/op-reth/crates/rpc/Cargo.toml
@@ -64,6 +64,7 @@ op-alloy-consensus.workspace = true
 alloy-op-evm.workspace = true
 revm.workspace = true
 op-revm.workspace = true
+kona-interop.workspace = true
 
 # async
 serde.workspace = true

--- a/rust/op-reth/crates/rpc/src/cross_unsafe.rs
+++ b/rust/op-reth/crates/rpc/src/cross_unsafe.rs
@@ -1,0 +1,468 @@
+//! Runtime cross-unsafe head RPC support.
+
+use alloy_consensus::{BlockHeader, TxReceipt};
+use alloy_eips::BlockHashOrNumber;
+use alloy_primitives::{B256, U64, keccak256};
+use alloy_rpc_client::RpcClient;
+use alloy_rpc_types_eth::{Filter, Log as RpcLog};
+use jsonrpsee::proc_macros::rpc;
+use jsonrpsee_core::{RpcResult, async_trait};
+use kona_interop::{RawMessagePayload, parse_log_to_executing_message};
+use reth_provider::BlockReaderIdExt;
+use reth_rpc_server_types::result::internal_rpc_err;
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, sync::Arc};
+use tokio::sync::Mutex;
+use tracing::{debug, warn};
+
+/// A block head returned by `eth_crossUnsafeHead`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CrossUnsafeHead {
+    /// Block number.
+    pub number: U64,
+    /// Block hash.
+    pub hash: B256,
+}
+
+#[cfg_attr(not(test), rpc(server, namespace = "eth"))]
+#[cfg_attr(test, rpc(server, client, namespace = "eth"))]
+pub trait CrossUnsafeHeadApi {
+    /// Returns the latest runtime-validated cross-unsafe head.
+    #[method(name = "crossUnsafeHead")]
+    async fn cross_unsafe_head(&self) -> RpcResult<CrossUnsafeHead>;
+
+    /// Alias for callers that prefer a getter-style method name.
+    #[method(name = "getCrossUnsafeHead")]
+    async fn get_cross_unsafe_head(&self) -> RpcResult<CrossUnsafeHead>;
+}
+
+/// RPC extension that computes a simplified cross-unsafe head on demand.
+#[derive(Debug, Clone)]
+pub struct CrossUnsafeHeadExt<Provider> {
+    inner: Arc<CrossUnsafeHeadExtInner<Provider>>,
+}
+
+#[derive(Debug)]
+struct CrossUnsafeHeadExtInner<Provider> {
+    provider: Provider,
+    source_clients: SourceLogClients,
+    state: Mutex<CrossUnsafeState>,
+}
+
+impl<Provider> CrossUnsafeHeadExt<Provider> {
+    /// Creates a new runtime cross-unsafe head extension.
+    pub fn new(
+        provider: Provider,
+        source_rpcs: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            inner: Arc::new(CrossUnsafeHeadExtInner {
+                provider,
+                source_clients: SourceLogClients::new(source_rpcs)?,
+                state: Mutex::new(CrossUnsafeState::default()),
+            }),
+        })
+    }
+}
+
+#[async_trait]
+impl<Provider> CrossUnsafeHeadApiServer for CrossUnsafeHeadExt<Provider>
+where
+    Provider: BlockReaderIdExt + Clone + Send + Sync + 'static,
+{
+    async fn cross_unsafe_head(&self) -> RpcResult<CrossUnsafeHead> {
+        self.compute_cross_unsafe_head().await
+    }
+
+    async fn get_cross_unsafe_head(&self) -> RpcResult<CrossUnsafeHead> {
+        self.compute_cross_unsafe_head().await
+    }
+}
+
+impl<Provider> CrossUnsafeHeadExt<Provider>
+where
+    Provider: BlockReaderIdExt + Clone + Send + Sync + 'static,
+{
+    async fn compute_cross_unsafe_head(&self) -> RpcResult<CrossUnsafeHead> {
+        let safe = self.safe_anchor()?;
+        let latest = self
+            .inner
+            .provider
+            .latest_header()
+            .map_err(|err| internal_rpc_err(format!("failed to read latest header: {err}")))?
+            .ok_or_else(|| internal_rpc_err("latest header not found"))?;
+
+        let latest_number = latest.number();
+        let latest_hash = latest.hash();
+
+        let mut state = self.inner.state.lock().await;
+        state.prune_before(safe.number);
+        state.seed_safe(safe);
+        self.rewind_cached_head_to_canonical(&mut state, safe.number)?;
+
+        if latest_number <= state.head.number {
+            return Ok(state.head.into());
+        }
+
+        let mut expected_parent = state.head.hash;
+        for number in state.head.number.saturating_add(1)..=latest_number {
+            let header = self
+                .inner
+                .provider
+                .sealed_header(number)
+                .map_err(|err| internal_rpc_err(format!("failed to read header {number}: {err}")))?
+                .ok_or_else(|| internal_rpc_err(format!("header {number} not found")))?;
+
+            let hash = header.hash();
+            let parent_hash = header.parent_hash();
+            if parent_hash != expected_parent {
+                debug!(
+                    target: "rpc::cross_unsafe",
+                    number,
+                    %hash,
+                    %parent_hash,
+                    expected = %expected_parent,
+                    "stopping cross-unsafe walk at non-contiguous block"
+                );
+                state.remove_from(number);
+                break;
+            }
+
+            if state.is_validated(number, hash, parent_hash) {
+                expected_parent = hash;
+                continue;
+            }
+
+            if !self.validate_block(number, header.timestamp()).await? {
+                debug!(
+                    target: "rpc::cross_unsafe",
+                    number,
+                    %hash,
+                    "stopping cross-unsafe walk at unvalidated block"
+                );
+                state.remove_from(number);
+                break;
+            }
+
+            state.insert(CachedBlock { number, hash, parent_hash });
+            expected_parent = hash;
+        }
+
+        if latest_number == state.head.number && latest_hash != state.head.hash {
+            state.remove_from(latest_number);
+        }
+
+        Ok(state.head.into())
+    }
+
+    fn rewind_cached_head_to_canonical(
+        &self,
+        state: &mut CrossUnsafeState,
+        safe_number: u64,
+    ) -> RpcResult<()> {
+        while state.head.number > safe_number {
+            let number = state.head.number;
+            let Some(header) = self.inner.provider.sealed_header(number).map_err(|err| {
+                internal_rpc_err(format!("failed to read cached head header {number}: {err}"))
+            })?
+            else {
+                state.remove_from(number);
+                continue;
+            };
+
+            if header.hash() == state.head.hash {
+                break;
+            }
+
+            state.remove_from(number);
+        }
+
+        Ok(())
+    }
+
+    fn safe_anchor(&self) -> RpcResult<CachedBlock> {
+        if let Some(safe) = self
+            .inner
+            .provider
+            .safe_block_num_hash()
+            .map_err(|err| internal_rpc_err(format!("failed to read safe block: {err}")))?
+        {
+            return Ok(CachedBlock {
+                number: safe.number,
+                hash: safe.hash,
+                parent_hash: B256::ZERO,
+            });
+        }
+
+        let genesis = self
+            .inner
+            .provider
+            .sealed_header(0)
+            .map_err(|err| internal_rpc_err(format!("failed to read genesis header: {err}")))?
+            .ok_or_else(|| internal_rpc_err("safe block unavailable and genesis not found"))?;
+
+        Ok(CachedBlock { number: 0, hash: genesis.hash(), parent_hash: genesis.parent_hash() })
+    }
+
+    async fn validate_block(&self, number: u64, executing_timestamp: u64) -> RpcResult<bool> {
+        let receipts = self
+            .inner
+            .provider
+            .receipts_by_block(BlockHashOrNumber::Number(number))
+            .map_err(|err| {
+                internal_rpc_err(format!("failed to read receipts for block {number}: {err}"))
+            })?
+            .ok_or_else(|| internal_rpc_err(format!("receipts for block {number} not found")))?;
+
+        for receipt in receipts {
+            for log in receipt.logs() {
+                let Some(message) = parse_log_to_executing_message(log) else { continue };
+
+                let initiating_timestamp = message.identifier.timestamp.saturating_to::<u64>();
+                if initiating_timestamp > executing_timestamp {
+                    debug!(
+                        target: "rpc::cross_unsafe",
+                        number,
+                        initiating_timestamp,
+                        executing_timestamp,
+                        "executing message points to a future initiating timestamp"
+                    );
+                    return Ok(false);
+                }
+
+                let source_chain_id = message.identifier.chainId.saturating_to::<u64>();
+                let source_block = message.identifier.blockNumber.saturating_to::<u64>();
+                let source_log_index = message.identifier.logIndex.saturating_to::<u64>();
+                let exists = self
+                    .inner
+                    .source_clients
+                    .initiating_message_exists(
+                        source_chain_id,
+                        source_block,
+                        source_log_index,
+                        message.identifier.origin,
+                        message.payloadHash,
+                    )
+                    .await;
+
+                if !exists {
+                    return Ok(false);
+                }
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SourceLogClients {
+    clients: BTreeMap<u64, SourceLogClient>,
+}
+
+impl SourceLogClients {
+    fn new(source_rpcs: impl IntoIterator<Item = impl Into<String>>) -> Result<Self, String> {
+        let mut clients = BTreeMap::new();
+        for source_rpc in source_rpcs {
+            let source_rpc = source_rpc.into();
+            let (chain_id, endpoint) = source_rpc.split_once('=').ok_or_else(|| {
+                format!("invalid source RPC mapping {source_rpc:?}: expected CHAIN_ID=RPC_URL")
+            })?;
+            let chain_id = chain_id
+                .parse::<u64>()
+                .map_err(|err| format!("invalid source chain ID {chain_id:?}: {err}"))?;
+            if clients.insert(chain_id, SourceLogClient::new(endpoint.to_string())?).is_some() {
+                return Err(format!("duplicate source RPC for chain ID {chain_id}"));
+            }
+        }
+
+        Ok(Self { clients })
+    }
+
+    async fn initiating_message_exists(
+        &self,
+        chain_id: u64,
+        block_number: u64,
+        log_index: u64,
+        origin: alloy_primitives::Address,
+        payload_hash: B256,
+    ) -> bool {
+        let Some(client) = self.clients.get(&chain_id) else {
+            warn!(
+                target: "rpc::cross_unsafe",
+                chain_id,
+                block_number,
+                log_index,
+                "missing source RPC for initiating message chain"
+            );
+            return false;
+        };
+
+        client
+            .initiating_message_exists(chain_id, block_number, log_index, origin, payload_hash)
+            .await
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SourceLogClient {
+    endpoint: String,
+    client: RpcClient,
+}
+
+impl SourceLogClient {
+    fn new(endpoint: String) -> Result<Self, String> {
+        let url = endpoint
+            .parse()
+            .map_err(|err| format!("invalid cross unsafe head source RPC URL: {err}"))?;
+        Ok(Self { client: RpcClient::new_http(url), endpoint })
+    }
+
+    async fn initiating_message_exists(
+        &self,
+        chain_id: u64,
+        block_number: u64,
+        log_index: u64,
+        origin: alloy_primitives::Address,
+        payload_hash: B256,
+    ) -> bool {
+        let filter = Filter::new().select(block_number);
+        let logs = match self.client.request::<_, Vec<RpcLog>>("eth_getLogs", (filter,)).await {
+            Ok(logs) => logs,
+            Err(err) => {
+                warn!(
+                    target: "rpc::cross_unsafe",
+                    %err,
+                    endpoint = %self.endpoint,
+                    chain_id,
+                    block_number,
+                    "failed to fetch source logs"
+                );
+                return false;
+            }
+        };
+
+        let Some(log) = logs.into_iter().find(|log| log.log_index == Some(log_index)) else {
+            debug!(
+                target: "rpc::cross_unsafe",
+                chain_id,
+                block_number,
+                log_index,
+                "source log not found"
+            );
+            return false;
+        };
+
+        if log.address() != origin {
+            debug!(
+                target: "rpc::cross_unsafe",
+                chain_id,
+                block_number,
+                log_index,
+                expected = %origin,
+                actual = %log.address(),
+                "source log origin mismatch"
+            );
+            return false;
+        }
+
+        let remote_payload = RawMessagePayload::from(&log.inner);
+        let remote_payload_hash = keccak256(remote_payload.as_ref());
+        if remote_payload_hash != payload_hash {
+            debug!(
+                target: "rpc::cross_unsafe",
+                chain_id,
+                block_number,
+                log_index,
+                expected = %payload_hash,
+                actual = %remote_payload_hash,
+                "source log payload hash mismatch"
+            );
+            return false;
+        }
+
+        true
+    }
+}
+
+#[derive(Debug, Default)]
+struct CrossUnsafeState {
+    head: CachedBlock,
+    validated: BTreeMap<u64, CachedBlock>,
+}
+
+impl CrossUnsafeState {
+    fn seed_safe(&mut self, safe: CachedBlock) {
+        if self.head.number <= safe.number {
+            self.head = safe;
+        }
+        self.validated.insert(safe.number, safe);
+    }
+
+    fn prune_before(&mut self, safe_number: u64) {
+        self.validated.retain(|number, _| *number >= safe_number);
+    }
+
+    fn is_validated(&self, number: u64, hash: B256, parent_hash: B256) -> bool {
+        self.validated
+            .get(&number)
+            .is_some_and(|block| block.hash == hash && block.parent_hash == parent_hash)
+    }
+
+    fn insert(&mut self, block: CachedBlock) {
+        self.head = block;
+        self.validated.insert(block.number, block);
+    }
+
+    fn remove_from(&mut self, number: u64) {
+        self.validated.split_off(&number);
+        if self.head.number >= number {
+            self.head = self.validated.values().next_back().copied().unwrap_or_default();
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct CachedBlock {
+    number: u64,
+    hash: B256,
+    parent_hash: B256,
+}
+
+impl From<CachedBlock> for CrossUnsafeHead {
+    fn from(value: CachedBlock) -> Self {
+        Self { number: U64::from(value.number), hash: value.hash }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_source_rpc_mappings_by_chain_id() {
+        let clients = SourceLogClients::new([
+            "901=http://chain-a:8545".to_string(),
+            "902=http://chain-b:8545".to_string(),
+        ])
+        .unwrap();
+
+        assert!(clients.clients.contains_key(&901));
+        assert!(clients.clients.contains_key(&902));
+    }
+
+    #[test]
+    fn rejects_invalid_source_rpc_mappings() {
+        assert!(SourceLogClients::new(["http://chain-a:8545".to_string()]).is_err());
+        assert!(SourceLogClients::new(["chain-a=http://chain-a:8545".to_string()]).is_err());
+        assert!(SourceLogClients::new(["901=not a url".to_string()]).is_err());
+        assert!(
+            SourceLogClients::new([
+                "901=http://chain-a:8545".to_string(),
+                "901=http://chain-b:8545".to_string(),
+            ])
+            .is_err()
+        );
+    }
+}

--- a/rust/op-reth/crates/rpc/src/lib.rs
+++ b/rust/op-reth/crates/rpc/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+pub mod cross_unsafe;
 pub mod debug;
 pub mod engine;
 pub mod error;


### PR DESCRIPTION
## Summary
- adds an opt-in, repeatable `--rollup.cross-unsafe-head-source-rpc CHAIN_ID=RPC_URL` flag for op-reth
- exposes `eth_crossUnsafeHead` and `eth_getCrossUnsafeHead` when at least one source RPC mapping is configured and the `eth` RPC module is enabled
- computes a runtime cross-unsafe head from local safe toward local latest, backed by an in-memory validation cache
- starts a lightweight 5s background poller to keep the cache warm using the same validation path as user RPC calls

## How it works

### Startup
When source RPC mappings are configured, op-reth builds a `CrossUnsafeHeadExt` RPC extension. Each mapping is parsed as `CHAIN_ID=RPC_URL`, rejects malformed values and duplicate chain IDs, and creates one remote execution RPC client per source chain.

The extension is merged into the `eth` namespace and exposes both `eth_crossUnsafeHead` and `eth_getCrossUnsafeHead`. If the `eth` RPC module is configured, a background poller is also spawned to precompute the same head every 5 seconds.

### Cache lifecycle
The extension keeps an in-memory cache of validated local blocks:

- `head`: the latest runtime-validated cross-unsafe block
- `validated`: a `BTreeMap` from block number to `{ number, hash, parent_hash }`

Each computation starts from the local safe head. Cached entries below safe are pruned, and safe is re-seeded as the minimum valid anchor. If the cached head no longer matches canonical local headers, the cache rewinds until it reaches a canonical cached block at or above safe.

The cache is not capped above safe. Previously validated blocks remain useful as long as they are still canonical. This avoids revalidating long safe-to-unsafe ranges when the node has already checked them.

### Head computation
On each RPC call, and on each poller tick, the extension walks forward from the cached head toward local latest:

1. read the local header for the next block
2. require it to be contiguous with the current cached head via parent hash
3. skip full validation if the exact `{ number, hash, parent_hash }` is already cached
4. otherwise validate every executing message in that block's receipts
5. cache the block and continue if validation succeeds
6. stop at the first invalid, missing, non-contiguous, or unavailable block and return the last cached head

Concurrent RPC calls and the poller share the same mutex-protected cache, so only one validation walk mutates state at a time.

### Message validation
For each executing message found in the candidate block receipts, the validator:

- rejects messages whose initiating timestamp is after the executing block timestamp
- selects the source RPC by the initiating message chain ID
- fetches logs from the claimed source block with remote `eth_getLogs`
- finds the claimed global log index
- fetches the source block with remote `eth_getBlockByNumber`
- requires the source block timestamp to match the claimed initiating timestamp
- requires the remote log origin to match the identifier origin
- recomputes the remote initiating payload hash and requires it to match `payloadHash`

Missing source RPC mappings, source RPC errors, missing logs, timestamp mismatches, origin mismatches, and payload-hash mismatches all fail closed for the candidate block.

## Scope
This is intentionally a simplified runtime gate. It validates existence and basic consistency of initiating messages, but it does not implement the full supervisor dependency graph. In particular, it does not model dependency graph hazards/cycles, message expiry, dependency-set activation rules, or cross-chain frontier semantics.

The endpoint reports the latest locally cached block that passed this simplified runtime validation, seeded from local safe.

## Validation
- `/Users/karl/.cargo/bin/cargo check -p reth-optimism-rpc -p reth-optimism-node`
- `/Users/karl/.cargo/bin/cargo test -p reth-optimism-rpc cross_unsafe::tests --lib`
- `/Users/karl/.cargo/bin/cargo test -p reth-optimism-node args::tests::test_parse_cross_unsafe_head_source_rpc_args -- --exact`
- `/Users/karl/.cargo/bin/cargo test -p reth-optimism-node args::tests --lib`
