### PR TITLE
fix(op-acceptance-tests): stop wedging test sequencer on transient L1 EL stalls

### DIFF
--- a/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // TestUnsafeGapFillAfterSafeReorg demonstrates the sequence:
@@ -43,9 +42,19 @@ func TestUnsafeGapFillAfterSafeReorg(gt *testing.T) {
 	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 
 	require.Eventually(func() bool {
-		// Advance single L1 block
-		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
-		require.NoError(ts.Next(ctx))
+		// Advance a single L1 block. Sequencer.Next internally calls New with
+		// empty BuildOpts and tolerates ErrConflictingJob, so we do not call
+		// ts.New here — that would fail with ErrConflictingJob if a previous
+		// Next attempt timed out and left the job state wedged.
+		//
+		// We must not use require.NoError inside this polling callback: a
+		// single transient engine-API stall (CPU starvation under CI load)
+		// would otherwise mark the test failed on the first error. Instead we
+		// log and return false so Eventually retries until the L1 EL recovers.
+		if err := ts.Next(ctx); err != nil {
+			logger.Warn("ts.Next failed, will retry", "err", err)
+			return false
+		}
 		l1head := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 		l2Safe := sys.L2EL.BlockRefByLabel(eth.Safe)
 		logger.Info("l1 info", "l1_head", l1head, "l1_origin", l2Safe.L1Origin, "l2Safe", l2Safe)
@@ -141,9 +150,13 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 
 	require.Eventually(func() bool {
-		// Advance single L1 block
-		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
-		require.NoError(ts.Next(ctx))
+		// Advance a single L1 block. See the comment on the matching loop in
+		// TestUnsafeGapFillAfterSafeReorg for why we use ts.Next alone and do
+		// not require.NoError inside the polling callback.
+		if err := ts.Next(ctx); err != nil {
+			logger.Warn("ts.Next failed, will retry", "err", err)
+			return false
+		}
 		l1head := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
 		logger.Info("l1 info", "l1_head", l1head, "l1_origin", l2Unsafe.L1Origin, "l2Unsafe", l2Unsafe)
@@ -281,9 +294,13 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 
 	require.Eventually(func() bool {
-		// Advance single L1 block
-		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
-		require.NoError(ts.Next(ctx))
+		// Advance a single L1 block. See the comment on the matching loop in
+		// TestUnsafeGapFillAfterSafeReorg for why we use ts.Next alone and do
+		// not require.NoError inside the polling callback.
+		if err := ts.Next(ctx); err != nil {
+			logger.Warn("ts.Next failed, will retry", "err", err)
+			return false
+		}
 		l1head := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
 		logger.Info("l1 info", "l1_head", l1head, "l1_origin", l2Unsafe.L1Origin, "l2Unsafe", l2Unsafe)

--- a/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 func TestFollowL2_Safe_Finalized_CurrentL1(gt *testing.T) {
@@ -99,9 +98,19 @@ func TestFollowL2_ReorgRecovery(gt *testing.T) {
 	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 
 	require.Eventually(func() bool {
-		// Advance single L1 block
-		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
-		require.NoError(ts.Next(ctx))
+		// Advance a single L1 block. Sequencer.Next internally calls New with
+		// empty BuildOpts and tolerates ErrConflictingJob, so we do not call
+		// ts.New here — that would fail with ErrConflictingJob if a previous
+		// Next attempt timed out and left the job state wedged.
+		//
+		// We must not use require.NoError inside this polling callback: a
+		// single transient engine-API stall (CPU starvation under CI load)
+		// would otherwise mark the test failed on the first error. Instead we
+		// log and return false so Eventually retries until the L1 EL recovers.
+		if err := ts.Next(ctx); err != nil {
+			logger.Warn("ts.Next failed, will retry", "err", err)
+			return false
+		}
 		l1head := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 		l2Safe := sys.L2ELB.BlockRefByLabel(eth.Safe)
 


### PR DESCRIPTION
**Description**

Fixes four flaky acceptance tests that wedge for the full 120s `Eventually` budget on a single transient (~10s) stall of the in-process L1 EL engine API:

- `TestUnsafeGapFillAfterSafeReorg` — closes #19884
- `TestFollowL2_ReorgRecovery` — closes #19967
- `TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL` (same pattern, preemptive fix)
- `TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P` (same pattern, preemptive fix)

**Root cause**

All four tests use the same polling closure:

```go
require.Eventually(func() bool {
    require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
    require.NoError(ts.Next(ctx))
    ...
}, 120*time.Second, 2*time.Second)
```

Three things compound to produce the observed failure:

1. **10s outer call timeout.** `op-service/client/rpc.go:148` applies a default 10s timeout to every JSON-RPC `CallContext`. Under CI contention the test sequencer's internal engine call chain (`engine_forkchoiceUpdatedV3` + `engine_getPayloadV4` + `engine_newPayloadV4` + FCU) can cumulatively exceed 10s, busting the outer deadline. The CI log shows this as `Post "http://127.0.0.1:.../sequencers/test-seq-900": context deadline exceeded`.

2. **Testify `Eventually` wedges on `Goexit`.** `assert.Eventually` (`stretchr/testify@v1.11.1/assert/assertions.go:1988-2021`) launches each tick via `go checkCond()` and only re-arms its ticker after receiving on an unbuffered channel. `require.NoError` → `t.FailNow()` → `runtime.Goexit()` kills the condition goroutine without sending — the ticker stays nil, no more iterations spawn, `Eventually` blocks for the remaining ~110s until its `waitFor` timer fires. That produces the second symptom seen in CI: `Condition never satisfied`.

3. **Non-idempotent retry path.** The explicit `ts.New(BuildOpts{Parent: common.Hash{}})` returns `ErrConflictingJob` (`op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer.go:79-98`) when a prior `ts.Next` left `currentJob` set — and `Sequencer.Next` does leave it set if its internal `s.Open(ctx)` fails (line 214-215, no `lockingReset` on partial failure).

**Fix**

In each affected `Eventually` closure:

- Drop the redundant `require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))`. `Sequencer.Next` already calls `s.New(BuildOpts{})` internally and tolerates `ErrConflictingJob`, so removing the explicit call lets `Next` self-heal from a wedged `currentJob`.
- Replace `require.NoError(ts.Next(ctx))` with `if err := ts.Next(ctx); err != nil { logger.Warn(...); return false }`. A transient stall now returns `false` from the condition, allowing `Eventually` to re-arm the ticker and try again on the next 2s tick. The 120s `waitFor` budget is the natural backstop.

No `t.Skip`, no `time.Sleep`, no resource scaling, no timeout bump. The convergence invariants (`l2Safe.L1Origin.Number > startL1Block.Number`, etc.) are unchanged.

**Tests**

Test-only change; no new tests added. The convergence assertions in each test are preserved exactly. Local build / vet / compile are clean. End-to-end exercise is via CI.

**Additional context**

Underlying bug not fixed here: `Sequencer.Next` (`op-test-sequencer/.../fullseq/sequencer.go:208-231`) should call `lockingReset` when an intermediate step fails. The test-layer fix relies on `Next`'s internal `New(BuildOpts{})` to self-heal, which works but papers over the real bug. Worth a follow-up issue.

Adversarial review noted that the same closures still call `sys.L1EL.BlockRefByLabel` / `sys.L2EL.BlockRefByLabel`, whose internal `require.NoError` with 30s timeout could re-introduce the wedge under a more severe stall. The 30s headroom makes this much less likely, but a follow-up converting those to fallible variants would close the residual race completely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)