### PR TITLE
fix(op-devstack): progress-aware initial sync check for ELSync verifiers

### DIFF
--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -89,6 +89,76 @@ func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context
 	}
 }
 
+// MatchedWithProgressFn returns a lambda that waits for baseNode's head at
+// matchLvl to match refNode's head at matchLvl, while requiring baseNode to
+// make progress on progressLvl. It is intended for sync checks where the
+// matchLvl head can stall behind a slow but progressing pipeline — for
+// example the CrossSafe head behind initial EL-sync, where the CL keeps
+// receiving unsafe payloads (progressLvl == LocalUnsafe) but the safe head
+// cannot advance until the EL completes its initial snap-sync.
+//
+// The check polls every 2s and succeeds as soon as the matchLvl heads match.
+// It fails when one of:
+//   - the overall maxWait elapses; or
+//   - baseNode's progressLvl head has not advanced for stallTimeout (i.e.
+//     the underlying gossip / forward sync has truly stalled).
+//
+// Using a stall detector lets the budget be generous without papering over
+// genuinely stuck systems. The first sample of progressLvl is taken on entry
+// and the stall clock resets every time the progressLvl head advances.
+func MatchedWithProgressFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, matchLvl, progressLvl types.SafetyLevel, chainID eth.ChainID, maxWait, stallTimeout time.Duration) CheckFunc {
+	return func() error {
+		logger := log.With("base_id", baseNode, "ref_id", refNode, "chain", chainID, "label", matchLvl, "progress_label", progressLvl)
+		initialBase := baseNode.ChainSyncStatus(chainID, matchLvl)
+		initialRef := refNode.ChainSyncStatus(chainID, matchLvl)
+		logger.Info("Expecting node to match with reference (progress-aware)",
+			"base", initialBase.Number, "ref", initialRef.Number,
+			"max_wait", maxWait, "stall_timeout", stallTimeout)
+
+		deadline := time.Now().Add(maxWait)
+		lastProgress := baseNode.ChainSyncStatus(chainID, progressLvl)
+		lastProgressTime := time.Now()
+
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			base := baseNode.ChainSyncStatus(chainID, matchLvl)
+			ref := refNode.ChainSyncStatus(chainID, matchLvl)
+			if ref.Hash == base.Hash && ref.Number == base.Number {
+				logger.Info("Node matched", "ref", ref.Number)
+				return nil
+			}
+
+			progress := baseNode.ChainSyncStatus(chainID, progressLvl)
+			now := time.Now()
+			if progress.Number > lastProgress.Number {
+				lastProgress = progress
+				lastProgressTime = now
+			}
+			stalledFor := now.Sub(lastProgressTime)
+			logger.Info("Node sync status",
+				"base", base.Number, "ref", ref.Number,
+				"progress", progress.Number, "stalled_for", stalledFor)
+
+			if stalledFor >= stallTimeout {
+				return fmt.Errorf("expected head to match: %s: %s stalled at %d for %s",
+					matchLvl, progressLvl, progress.Number, stalledFor)
+			}
+			if now.After(deadline) {
+				return fmt.Errorf("expected head to match: %s: timeout after %s (base=%d ref=%d progress=%d)",
+					matchLvl, maxWait, base.Number, ref.Number, progress.Number)
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-ticker.C:
+			}
+		}
+	}
+}
+
 // maxInSyncGap is the largest difference (in blocks) between two node heads
 // that InSyncFn will tolerate while still considering the nodes in sync. If
 // the heads are further apart than this the slower node has not caught up yet.

--- a/op-devstack/dsl/check_test.go
+++ b/op-devstack/dsl/check_test.go
@@ -1,0 +1,173 @@
+package dsl
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// programmableSyncProvider is a SyncStatusProvider whose returned BlockID per
+// (chainID, level) can be updated at runtime from the test goroutine.
+type programmableSyncProvider struct {
+	name string
+
+	mu   sync.Mutex
+	byID map[types.SafetyLevel]eth.BlockID
+}
+
+func newProgrammableSyncProvider(name string) *programmableSyncProvider {
+	return &programmableSyncProvider{
+		name: name,
+		byID: map[types.SafetyLevel]eth.BlockID{},
+	}
+}
+
+func (p *programmableSyncProvider) set(lvl types.SafetyLevel, num uint64, hash common.Hash) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.byID[lvl] = eth.BlockID{Number: num, Hash: hash}
+}
+
+func (p *programmableSyncProvider) ChainSyncStatus(chainID eth.ChainID, lvl types.SafetyLevel) eth.BlockID {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.byID[lvl]
+}
+
+func (p *programmableSyncProvider) String() string { return p.name }
+
+func TestMatchedWithProgressFn_SucceedsOnMatch(t *testing.T) {
+	t.Parallel()
+	base := newProgrammableSyncProvider("base")
+	ref := newProgrammableSyncProvider("ref")
+	chainID := eth.ChainIDFromUInt64(901)
+	h := common.HexToHash("0xabc")
+	base.set(types.CrossSafe, 10, h)
+	base.set(types.LocalUnsafe, 10, h)
+	ref.set(types.CrossSafe, 10, h)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	check := MatchedWithProgressFn(base, ref, testlog.Logger(t, log.LevelDebug), ctx,
+		types.CrossSafe, types.LocalUnsafe, chainID,
+		5*time.Second, 1*time.Second)
+
+	require.NoError(t, check())
+}
+
+func TestMatchedWithProgressFn_FailsOnStall(t *testing.T) {
+	t.Parallel()
+	base := newProgrammableSyncProvider("base")
+	ref := newProgrammableSyncProvider("ref")
+	chainID := eth.ChainIDFromUInt64(901)
+	h1 := common.HexToHash("0x1")
+	h2 := common.HexToHash("0x2")
+	// Base CrossSafe never matches; LocalUnsafe never advances either.
+	base.set(types.CrossSafe, 0, common.Hash{})
+	base.set(types.LocalUnsafe, 5, h1)
+	ref.set(types.CrossSafe, 10, h2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	check := MatchedWithProgressFn(base, ref, testlog.Logger(t, log.LevelDebug), ctx,
+		types.CrossSafe, types.LocalUnsafe, chainID,
+		30*time.Second, 3*time.Second)
+
+	start := time.Now()
+	err := check()
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "stalled"), "expected stall error, got: %v", err)
+	// Stall should fire well before the 30s max wait.
+	require.Less(t, time.Since(start), 8*time.Second, "stall detector took too long: %s", time.Since(start))
+}
+
+func TestMatchedWithProgressFn_KeepsWaitingWhileProgressing(t *testing.T) {
+	t.Parallel()
+	base := newProgrammableSyncProvider("base")
+	ref := newProgrammableSyncProvider("ref")
+	chainID := eth.ChainIDFromUInt64(901)
+	h := common.HexToHash("0xabc")
+	// Base CrossSafe stalls at 0; LocalUnsafe steadily advances; ref CrossSafe at 10.
+	base.set(types.CrossSafe, 0, common.Hash{})
+	base.set(types.LocalUnsafe, 5, common.HexToHash("0x5"))
+	ref.set(types.CrossSafe, 10, h)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Drive LocalUnsafe progress in the background past where a fixed-attempt
+	// budget would have given up, and then converge CrossSafe.
+	var driverWG sync.WaitGroup
+	driverWG.Add(1)
+	go func() {
+		defer driverWG.Done()
+		for i := 6; i <= 12; i++ {
+			time.Sleep(500 * time.Millisecond)
+			base.set(types.LocalUnsafe, uint64(i), common.BigToHash(common.Big1))
+		}
+		// Now let CrossSafe match.
+		base.set(types.CrossSafe, 10, h)
+	}()
+
+	// Stall timeout is short (1s) but the driver advances LocalUnsafe every
+	// 500ms, so the stall detector should never trip.
+	check := MatchedWithProgressFn(base, ref, testlog.Logger(t, log.LevelDebug), ctx,
+		types.CrossSafe, types.LocalUnsafe, chainID,
+		30*time.Second, 1*time.Second)
+	require.NoError(t, check())
+	driverWG.Wait()
+}
+
+func TestMatchedWithProgressFn_FailsOnMaxWait(t *testing.T) {
+	t.Parallel()
+	base := newProgrammableSyncProvider("base")
+	ref := newProgrammableSyncProvider("ref")
+	chainID := eth.ChainIDFromUInt64(901)
+	h := common.HexToHash("0xabc")
+	// Base CrossSafe never matches; LocalUnsafe keeps advancing so the stall
+	// detector never trips — the deadline should be the failure path.
+	base.set(types.CrossSafe, 0, common.Hash{})
+	base.set(types.LocalUnsafe, 0, common.Hash{})
+	ref.set(types.CrossSafe, 10, h)
+
+	driverCtx, driverCancel := context.WithCancel(context.Background())
+	var driverWG sync.WaitGroup
+	driverWG.Add(1)
+	go func() {
+		defer driverWG.Done()
+		var i uint64
+		for {
+			select {
+			case <-driverCtx.Done():
+				return
+			case <-time.After(200 * time.Millisecond):
+				i++
+				base.set(types.LocalUnsafe, i, common.BigToHash(common.Big1))
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	check := MatchedWithProgressFn(base, ref, testlog.Logger(t, log.LevelDebug), ctx,
+		types.CrossSafe, types.LocalUnsafe, chainID,
+		5*time.Second, 30*time.Second)
+
+	start := time.Now()
+	err := check()
+	driverCancel()
+	driverWG.Wait()
+
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "timeout"), "expected timeout error, got: %v", err)
+	require.GreaterOrEqual(t, time.Since(start), 5*time.Second)
+}

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -405,6 +405,14 @@ func (cl *L2CLNode) MatchedFn(refNode SyncStatusProvider, lvl types.SafetyLevel,
 	return MatchedFn(cl, refNode, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
 }
 
+// MatchedWithProgressFn returns a lambda that waits for cl's matchLvl head to
+// match refNode's matchLvl head while requiring cl to keep making progress on
+// progressLvl. See MatchedWithProgressFn in check.go for the precise semantics.
+// Composable with other lambdas to wait in parallel.
+func (cl *L2CLNode) MatchedWithProgressFn(refNode SyncStatusProvider, matchLvl, progressLvl types.SafetyLevel, maxWait, stallTimeout time.Duration) CheckFunc {
+	return MatchedWithProgressFn(cl, refNode, cl.log, cl.ctx, matchLvl, progressLvl, cl.ChainID(), maxWait, stallTimeout)
+}
+
 func (cl *L2CLNode) InSyncFn(other SyncStatusProvider, lvl types.SafetyLevel, attempts int) CheckFunc {
 	return InSyncFn(cl, other, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
 }

--- a/op-devstack/presets/singlechain_from_runtime.go
+++ b/op-devstack/presets/singlechain_from_runtime.go
@@ -1,6 +1,8 @@
 package presets
 
 import (
+	"time"
+
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
@@ -17,15 +19,31 @@ import (
 //   - CrossSafe (CLSync mode): requires derivation to process the first L1
 //     origin and advance safe; 60s is enough in practice.
 //   - CrossSafe (ELSync mode): the verifier must first complete EL sync over
-//     P2P (which can take tens of seconds on a cold node under CI load)
-//     before the forkchoice update that seeds safe/finalized fires; only
-//     after that does derivation start and begin advancing CrossSafe. The
-//     combined path is consistently slower than the CLSync case, so we give
-//     it a 4x budget. See issue #20334 for the failure mode this guards.
+//     P2P (which can take tens of seconds — sometimes minutes — on a cold
+//     node under CI load) before the forkchoice update that seeds
+//     safe/finalized fires; only after that does derivation start and begin
+//     advancing CrossSafe. Rather than guess a single budget large enough to
+//     absorb the worst CI run (see #20649), use a progress-aware wait that
+//     keeps polling as long as LocalUnsafe keeps advancing (the P2P gossip
+//     path is independent of EL snap-sync) and fails fast if the progress
+//     signal stalls.
 const (
-	initialSyncCheckAttemptsLocalUnsafe     = 30
-	initialSyncCheckAttemptsCrossSafe       = 30
-	initialSyncCheckAttemptsCrossSafeELSync = 120
+	initialSyncCheckAttemptsLocalUnsafe = 30
+	initialSyncCheckAttemptsCrossSafe   = 30
+
+	// initialSyncCrossSafeELSyncMaxWait caps how long we will wait for
+	// CrossSafe to match while initial EL-sync is in flight. The CL on the
+	// verifier cannot advance safe until the EL completes its initial
+	// snap-sync, which under CI load can far exceed a fixed multiple of the
+	// CLSync budget. This is a hard upper bound, not a typical case.
+	initialSyncCrossSafeELSyncMaxWait = 8 * time.Minute
+
+	// initialSyncCrossSafeELSyncStallTimeout fails fast if the verifier's
+	// LocalUnsafe head stops advancing while we're waiting for CrossSafe to
+	// match. LocalUnsafe advances every block via CL gossip independently of
+	// EL snap-sync, so a stall means the test setup is genuinely stuck and
+	// no extra waiting will help.
+	initialSyncCrossSafeELSyncStallTimeout = 30 * time.Second
 )
 
 func singleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime, runSyncChecks bool) *SingleChainMultiNode {
@@ -69,13 +87,25 @@ func singleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRunt
 		// Ensure the follower node is in sync with the sequencer before starting tests.
 		// CrossSafe requires derivation to run, which under ELSync can only begin
 		// after the EL completes P2P sync and the node emits its first forkchoice
-		// update — so size that budget by the follower's sync mode.
-		crossSafeAttempts := initialSyncCheckAttemptsCrossSafe
+		// update — so the wait strategy depends on the follower's sync mode.
+		var crossSafeCheck dsl.CheckFunc
 		if opNode, ok := nodeB.CL.(*sysgo.OpNode); ok && opNode.SyncMode() == nodeSync.ELSync {
-			crossSafeAttempts = initialSyncCheckAttemptsCrossSafeELSync
+			// EL-sync's CrossSafe wait has unpredictable duration in CI. Wait
+			// up to initialSyncCrossSafeELSyncMaxWait, but only as long as the
+			// follower's LocalUnsafe head keeps advancing — if gossip stalls
+			// for initialSyncCrossSafeELSyncStallTimeout we fail fast rather
+			// than burn the whole budget. See #20649.
+			crossSafeCheck = preset.L2CLB.MatchedWithProgressFn(
+				preset.L2CL,
+				types.CrossSafe, types.LocalUnsafe,
+				initialSyncCrossSafeELSyncMaxWait,
+				initialSyncCrossSafeELSyncStallTimeout,
+			)
+		} else {
+			crossSafeCheck = preset.L2CLB.MatchedFn(preset.L2CL, types.CrossSafe, initialSyncCheckAttemptsCrossSafe)
 		}
 		dsl.CheckAll(t,
-			preset.L2CLB.MatchedFn(preset.L2CL, types.CrossSafe, crossSafeAttempts),
+			crossSafeCheck,
 			preset.L2CLB.MatchedFn(preset.L2CL, types.LocalUnsafe, initialSyncCheckAttemptsLocalUnsafe),
 		)
 	}


### PR DESCRIPTION
Below is Claude's verbose description. TL;DR: during EL sync there can be a long time before CrossSafe progresses. The timeout has been doubled repeatedly and we still hit it. This doubles the timeout again, but adds a check to ensure that LocalUnSafe is progressing in the meantime, with a short timeout if not so we don't have to wait for the full 8 minute timeout.

----

**Description**

Replaces the fixed 120-attempt poll for the ELSync-mode CrossSafe initial sync check with a progress-aware wait. Fixes `TestNotTruncateDatabaseOnRestartWithExistingDatabase` and other ELSync setup-time flakes — closes #20649.

**Root cause**

The failure is in the ELSync preset's initial CrossSafe sync check (`op-devstack/presets/singlechain_multinode.go:22` → `singlechain_from_runtime.go:77` → `dsl/check.go:26`), not the test body. `MatchedFn(CrossSafe, 120)` polls every 2s for 240s for the verifier's CrossSafe head to match the sequencer.

For an ELSync verifier starting fresh, op-geth runs beacon-driven snap-sync via the static EL P2P peer. During that phase, every `InsertUnsafePayload` returns `SYNCING` and the CL's `syncStatus` stays at `syncStatusStartedEL` (`op-node/rollup/engine/engine_controller.go:425-697`) — `SetUnsafeHead` fires on each payload (line 686), but `SetLocalSafeHead` / `SetFinalizedHead` only advance once the EL flips to `ExecutionValid` (lines 657-660). The safe head stays at 0 until snap-sync completes.

Snap-sync wall-clock duration on a contended CI runner is non-deterministic. Under CPU/IO/network pressure from parallel test packages it can stretch past 240s. Prior PRs (#19977, #20098, #20343, #20454) bumped the budget 30 → 60 → 90 → 120 attempts. The flakes at 120 attempts show any fixed budget is a guess: the worst-case CI run can always exceed it.

**Fix**

New `dsl.MatchedWithProgressFn` helper:

- Polls every 2s for up to 8 minutes for `CrossSafe` to match.
- Tracks an independent progress signal — the verifier's `LocalUnsafe` head, which is driven by CL P2P gossip and is independent of EL state. `e.SetUnsafeHead` / `UnsafeUpdateEvent` fires unconditionally on every successful `InsertUnsafePayload`.
- Fails fast (within 30s) if `LocalUnsafe` stops advancing, because that signals the test setup is genuinely stuck (e.g. CL gossip broken, sequencer halted).
- Succeeds the moment `CrossSafe` matches.

CLSync-mode verifiers keep the old fixed-attempt path (`initialSyncCheckAttemptsCrossSafe = 30`); the change is targeted to ELSync mode where the slow phase exists.

**Tests**

- `op-devstack/dsl/check_test.go` (new) — 4 unit tests covering match, stall detection, sustained progress past what would have been a short fixed budget, and the max-wait deadline path. Stable under `-count=10 -race` across multiple runs.
- `go build ./...`, `go vet ./op-devstack/...`, `go test -c ./op-acceptance-tests/tests/safeheaddb_elsync/` all clean.

**Additional context**

Polling EL `eth_syncing` directly was considered but rejected as implementation-dependent (op-geth and op-reth report differently) — the progress-aware wait works uniformly via the CL's `ChainSyncStatus`.

The 90-day flake history shows all ELSync-related flakes appeared after PR #20381 ("only set FCU finalized after initial EL-sync") landed. The timing correlation is worth noting but the diagnosis (EL sync exceeding a fixed budget) and fix (wait as long as forward progress continues) hold regardless of whether #20381 made snap-sync slightly slower under contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)