### PR TITLE
docs(ai/acceptance-tests): note native kona prestate build option

### DIFF
--- a/docs/ai/acceptance-tests.md
+++ b/docs/ai/acceptance-tests.md
@@ -50,19 +50,21 @@ This runs only packages listed in `gates/base.txt`.
 
 Some tests (e.g. superfaultproofs, interop fault proofs) require a kona prestate. This is **not** handled by `build-deps` or `RUST_JIT_BUILD`. There are two ways to build it:
 
-**Native build** (no Docker required):
-
-```bash
-cd rust && mise exec -- just build-kona-prestates
-```
-
-**Reproducible build** (Docker required; needed when the prestate hash must match CI/release):
+**Reproducible build** (preferred when Docker is available):
 
 ```bash
 mise exec -- just reproducible-prestate-kona
 ```
 
-For local test runs, the native build is sufficient. Use the reproducible build only when you need a hash that matches a deployed release. If Docker is unavailable, ask the user to run the reproducible build for you.
+This produces a prestate whose hash matches CI/release builds. It works on any host with Docker installed.
+
+**Native build** (fallback when Docker is not available):
+
+```bash
+cd rust && mise exec -- just build-kona-prestates
+```
+
+Only works on **Linux** with the **MIPS cross-compile toolchain** installed. The produced hash will not match release builds, so this is only suitable for local test runs where the hash doesn't need to match a deployed release. If neither Docker nor the MIPS toolchain is available, ask the user to build the prestate for you.
 
 ## What `build-deps` Does
 

--- a/docs/ai/acceptance-tests.md
+++ b/docs/ai/acceptance-tests.md
@@ -46,15 +46,23 @@ RUST_JIT_BUILD=1 cd op-acceptance-tests && mise exec -- just acceptance-test bas
 
 This runs only packages listed in `gates/base.txt`.
 
-### Kona Reproducible Prestate
+### Kona Prestate
 
-Some tests (e.g. superfaultproofs, interop fault proofs) require a reproducible kona prestate. This is **not** handled by `build-deps` or `RUST_JIT_BUILD`:
+Some tests (e.g. superfaultproofs, interop fault proofs) require a kona prestate. This is **not** handled by `build-deps` or `RUST_JIT_BUILD`. There are two ways to build it:
+
+**Native build** (no Docker required):
+
+```bash
+cd rust && mise exec -- just build-kona-prestates
+```
+
+**Reproducible build** (Docker required; needed when the prestate hash must match CI/release):
 
 ```bash
 mise exec -- just reproducible-prestate-kona
 ```
 
-**Requires Docker.** If Docker is not available in your environment, ask the user to run this command for you.
+For local test runs, the native build is sufficient. Use the reproducible build only when you need a hash that matches a deployed release. If Docker is unavailable, ask the user to run the reproducible build for you.
 
 ## What `build-deps` Does
 


### PR DESCRIPTION
The agent guide currently documents only `just reproducible-prestate-kona`, which requires Docker. The repo also has a native recipe (`cd rust && just build-kona-prestates`) that works on Linux when the MIPS cross-compile toolchain is installed and produces a non-matching hash.

Document both, with the reproducible build preferred when Docker is available and the native build called out as a constrained Linux-only fallback.