### PR TITLE
feat(op-node): add follow source error counter metric

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -32,6 +32,7 @@ type Metricer interface {
 	SetDerivationIdle(status bool)
 	SetSequencerState(active bool)
 	RecordPipelineReset()
+	RecordFollowSourceError(reason string)
 	RecordSequencingError()
 	RecordPublishingError()
 	RecordDerivationError()
@@ -83,6 +84,7 @@ type Metrics struct {
 	L2SourceCache *metrics.CacheMetrics
 
 	L2FollowSourceCache *metrics.CacheMetrics
+	FollowSourceErrors  *prometheus.CounterVec
 
 	DerivationIdle prometheus.Gauge
 
@@ -187,6 +189,11 @@ func NewMetrics(procName string, labels prometheus.Labels) *Metrics {
 		L2SourceCache: metrics.NewCacheMetrics(factory, ns, "l2_source_cache", "L2 Source cache"),
 
 		L2FollowSourceCache: metrics.NewCacheMetrics(factory, ns, "l2_follow_source_cache", "L2 Follow source cache"),
+		FollowSourceErrors: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "follow_source_errors_total",
+			Help:      "Count of follow source errors by reason",
+		}, []string{"reason"}),
 
 		DerivationIdle: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
@@ -474,6 +481,10 @@ func (m *Metrics) RecordSequencerInconsistentL1Origin(from eth.BlockID, to eth.B
 	m.RecordRef("l1_origin", "inconsistent_to", to.Number, 0, to.Hash)
 }
 
+func (m *Metrics) RecordFollowSourceError(reason string) {
+	m.FollowSourceErrors.WithLabelValues(reason).Inc()
+}
+
 func (m *Metrics) RecordSequencerReset() {
 	m.SequencerResets.Record()
 }
@@ -635,6 +646,9 @@ func (m *noopMetricer) SetSequencerState(active bool) {
 }
 
 func (n *noopMetricer) RecordPipelineReset() {
+}
+
+func (n *noopMetricer) RecordFollowSourceError(reason string) {
 }
 
 func (n *noopMetricer) RecordSequencingError() {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -490,22 +490,26 @@ func (s *Driver) followUpstream() {
 	status, err := s.upstreamFollowSource.GetFollowStatus(s.driverCtx)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to fetch status", "err", err)
+		s.metrics.RecordFollowSourceError("fetch_status")
 		return
 	}
 	s.log.Info("Follow Upstream", "eSafe", status.SafeL2, "eLocalSafe", status.LocalSafeL2, "eFinalized", status.FinalizedL2, "eCurrentL1", status.CurrentL1)
 	if status.SafeL2.Number > status.LocalSafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, safe is ahead of local safe",
 			"safe", status.SafeL2.Number, "localSafe", status.LocalSafeL2.Number)
+		s.metrics.RecordFollowSourceError("invalid_state")
 		return
 	}
 	if status.FinalizedL2.Number > status.SafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, finalized is ahead of safe", "safe", status.SafeL2.Number, "finalized", status.FinalizedL2.Number)
+		s.metrics.RecordFollowSourceError("invalid_state")
 		return
 	}
 
 	eLocalSafeL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.LocalSafeL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external local safe head", "err", err)
+		s.metrics.RecordFollowSourceError("l1_lookup")
 		return
 	}
 	if eLocalSafeL1Origin.Hash != status.LocalSafeL2.L1Origin.Hash {
@@ -514,12 +518,14 @@ func (s *Driver) followUpstream() {
 			"actual", eLocalSafeL1Origin,
 			"expected", status.LocalSafeL2.L1Origin,
 		)
+		s.metrics.RecordFollowSourceError("l1_mismatch")
 		return
 	}
 
 	eSafeL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.SafeL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external safe head", "err", err)
+		s.metrics.RecordFollowSourceError("l1_lookup")
 		return
 	}
 	if eSafeL1Origin.Hash != status.SafeL2.L1Origin.Hash {
@@ -528,12 +534,14 @@ func (s *Driver) followUpstream() {
 			"actual", eSafeL1Origin,
 			"expected", status.SafeL2.L1Origin,
 		)
+		s.metrics.RecordFollowSourceError("l1_mismatch")
 		return
 	}
 
 	eFinalizedL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.FinalizedL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external finalized head", "err", err)
+		s.metrics.RecordFollowSourceError("l1_lookup")
 		return
 	}
 	if eFinalizedL1Origin.Hash != status.FinalizedL2.L1Origin.Hash {
@@ -542,6 +550,7 @@ func (s *Driver) followUpstream() {
 			"actual", eFinalizedL1Origin,
 			"expected", status.FinalizedL2.L1Origin,
 		)
+		s.metrics.RecordFollowSourceError("l1_mismatch")
 		return
 	}
 
@@ -551,6 +560,7 @@ func (s *Driver) followUpstream() {
 		eCurrentL1, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.CurrentL1.Number)
 		if err != nil {
 			s.log.Warn("Follow Upstream: Failed to look up external currentL1", "err", err)
+			s.metrics.RecordFollowSourceError("l1_lookup")
 			return
 		}
 		if eCurrentL1.Hash != status.CurrentL1.Hash {
@@ -559,6 +569,7 @@ func (s *Driver) followUpstream() {
 				"actual", eCurrentL1,
 				"expected", status.CurrentL1,
 			)
+			s.metrics.RecordFollowSourceError("l1_mismatch")
 			return
 		}
 

--- a/op-node/rollup/driver/interfaces.go
+++ b/op-node/rollup/driver/interfaces.go
@@ -16,6 +16,7 @@ import (
 
 type Metrics interface {
 	RecordPipelineReset()
+	RecordFollowSourceError(reason string)
 	RecordPublishingError()
 	RecordDerivationError()
 


### PR DESCRIPTION
## Summary
- Adds `op_node_default_follow_source_errors_total` Prometheus counter with `reason` label to `followUpstream()`
- Reason values: `fetch_status`, `invalid_state`, `l1_lookup`, `l1_mismatch`
- Previously all follow source errors were only logged — no Prometheus signal existed for alerting

## Motivation
Light nodes using `OP_NODE_L2_FOLLOW_SOURCE` silently fail when the external source is unreachable or returning mismatched L1 origins. This counter enables alerting on follow source health before safe head stall alerts fire (which have a 30m detection window).

## Test plan
- [ ] `go build ./op-node/...` passes
- [ ] Deploy to a light node and verify counter increments on simulated follow source failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)