### PR TITLE
fix(op-supernode): stabilize superroot_atTimestamp Data field

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -975,9 +975,6 @@ func (m *algoMockChain) VerifierCurrentL1s() []eth.BlockID                { retu
 func (m *algoMockChain) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
 	return eth.L2BlockRef{}, nil
 }
-func (m *algoMockChain) VerifiedAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
-	return eth.BlockID{}, eth.BlockID{}, nil
-}
 func (m *algoMockChain) L1ForL2(ctx context.Context, l2Block eth.BlockID) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }
@@ -987,7 +984,7 @@ func (m *algoMockChain) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockI
 	}
 	return m.optimisticL2, m.optimisticL1, nil
 }
-func (m *algoMockChain) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
+func (m *algoMockChain) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
 	return eth.Bytes32{}, nil
 }
 func (m *algoMockChain) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputV0, error) {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1001,7 +1001,8 @@ func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 	return i.verifiedDB.Has(ts)
 }
 
-// VerifiedResultAtTimestamp returns the committed VerifiedResult for ts.
+// VerifiedResultAtTimestamp returns the committed VerifiedResult for ts plus
+// the verifier's CurrentL1 captured atomically with the verifiedDB read.
 //   - ts < activationTimestamp           → ErrNotActive
 //   - ts < firstVerifiableTimestamp      → ErrBeforeVerifiedDB
 //   - verifiedDB.Get returns ErrNotFound → ethereum.NotFound
@@ -1010,25 +1011,37 @@ func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 // The local ErrNotFound is translated to the standard ethereum.NotFound at the
 // public boundary so consumers can errors.Is against the standard sentinel
 // without taking a dependency on this package's private error.
-func (i *Interop) VerifiedResultAtTimestamp(ts uint64) (VerifiedResult, error) {
+//
+// The atomic (verifiedDB, currentL1) snapshot lets callers report a
+// CurrentL1 that cannot disagree with the verifiedDB observation:
+//   - Commit ordering writes the entry before advancing currentL1, so a
+//     snapshot showing NotFound necessarily sees currentL1 from before the
+//     advance.
+//   - Rewind ordering zeros currentL1 before deleting entries, so a
+//     snapshot showing an entry mid-rewind sees currentL1=0 and the
+//     downstream rewind-race coupling check fails the call.
+func (i *Interop) VerifiedResultAtTimestamp(ts uint64) (VerifiedResult, eth.BlockID, error) {
 	if ts < i.activationTimestamp {
-		return VerifiedResult{}, ErrNotActive
+		return VerifiedResult{}, eth.BlockID{}, ErrNotActive
 	}
 	firstVerifiable, err := i.firstVerifiableTimestamp(i.ctx)
 	if err != nil {
-		return VerifiedResult{}, fmt.Errorf("resolve first verifiable: %w", err)
+		return VerifiedResult{}, eth.BlockID{}, fmt.Errorf("resolve first verifiable: %w", err)
 	}
 	if ts < firstVerifiable {
-		return VerifiedResult{}, ErrBeforeVerifiedDB
+		return VerifiedResult{}, eth.BlockID{}, ErrBeforeVerifiedDB
 	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	currentL1 := i.currentL1
 	result, err := i.verifiedDB.Get(ts)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			return VerifiedResult{}, ethereum.NotFound
+			return VerifiedResult{}, currentL1, ethereum.NotFound
 		}
-		return VerifiedResult{}, err
+		return VerifiedResult{}, currentL1, err
 	}
-	return result, nil
+	return result, currentL1, nil
 }
 
 // IsActiveAt reports whether the interop verifier is responsible for verifying

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1013,13 +1013,11 @@ func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 // without taking a dependency on this package's private error.
 //
 // The atomic (verifiedDB, currentL1) snapshot lets callers report a
-// CurrentL1 that cannot disagree with the verifiedDB observation:
-//   - Commit ordering writes the entry before advancing currentL1, so a
-//     snapshot showing NotFound necessarily sees currentL1 from before the
-//     advance.
-//   - Rewind ordering zeros currentL1 before deleting entries, so a
-//     snapshot showing an entry mid-rewind sees currentL1=0 and the
-//     downstream rewind-race coupling check fails the call.
+// CurrentL1 that cannot overstate verifier progress relative to the
+// verifiedDB observation. The verifier holds i.mu when mutating currentL1
+// (commit advances currentL1 after writing the entry; rewind zeros
+// currentL1 before deleting entries), so a snapshot taken under RLock is
+// consistent with one side or the other of those transitions.
 func (i *Interop) VerifiedResultAtTimestamp(ts uint64) (VerifiedResult, eth.BlockID, error) {
 	if ts < i.activationTimestamp {
 		return VerifiedResult{}, eth.BlockID{}, ErrNotActive

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1002,11 +1002,10 @@ func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 }
 
 // VerifiedResultAtTimestamp returns the committed VerifiedResult for ts.
-// Mirrors the regime gating of VerifiedAtTimestamp:
-//   - ts < activationTimestamp                → ErrNotActive
-//   - ts < firstVerifiableTimestamp           → ErrNotActive
-//   - verifiedDB.Get returns ErrNotFound      → ethereum.NotFound
-//   - else                                    → the stored VerifiedResult
+//   - ts < activationTimestamp           → ErrNotActive
+//   - ts < firstVerifiableTimestamp      → ErrBeforeVerifiedDB
+//   - verifiedDB.Get returns ErrNotFound → ethereum.NotFound
+//   - else                               → the stored VerifiedResult
 //
 // The local ErrNotFound is translated to the standard ethereum.NotFound at the
 // public boundary so consumers can errors.Is against the standard sentinel
@@ -1020,7 +1019,7 @@ func (i *Interop) VerifiedResultAtTimestamp(ts uint64) (VerifiedResult, error) {
 		return VerifiedResult{}, fmt.Errorf("resolve first verifiable: %w", err)
 	}
 	if ts < firstVerifiable {
-		return VerifiedResult{}, ErrNotActive
+		return VerifiedResult{}, ErrBeforeVerifiedDB
 	}
 	result, err := i.verifiedDB.Get(ts)
 	if err != nil {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1022,10 +1022,7 @@ func (i *Interop) VerifiedResultAtTimestamp(ts uint64) (VerifiedResult, eth.Bloc
 	if ts < i.activationTimestamp {
 		return VerifiedResult{}, eth.BlockID{}, ErrNotActive
 	}
-	// Supernode registers RPC APIs before scheduling each activity's Start
-	// goroutine, so VerifiedResultAtTimestamp can be reached before Start has
-	// populated i.ctx. Surface a dedicated error so the superroot handler
-	// can fall back to optimistic composition instead of dereferencing nil.
+	// RPC is registered before Start runs; guard against a nil i.ctx.
 	if i.ctx == nil {
 		return VerifiedResult{}, eth.BlockID{}, ErrNotStarted
 	}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1022,6 +1022,13 @@ func (i *Interop) VerifiedResultAtTimestamp(ts uint64) (VerifiedResult, eth.Bloc
 	if ts < i.activationTimestamp {
 		return VerifiedResult{}, eth.BlockID{}, ErrNotActive
 	}
+	// Supernode registers RPC APIs before scheduling each activity's Start
+	// goroutine, so VerifiedResultAtTimestamp can be reached before Start has
+	// populated i.ctx. Surface a dedicated error so the superroot handler
+	// can fall back to optimistic composition instead of dereferencing nil.
+	if i.ctx == nil {
+		return VerifiedResult{}, eth.BlockID{}, ErrNotStarted
+	}
 	firstVerifiable, err := i.firstVerifiableTimestamp(i.ctx)
 	if err != nil {
 		return VerifiedResult{}, eth.BlockID{}, fmt.Errorf("resolve first verifiable: %w", err)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1001,6 +1001,37 @@ func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 	return i.verifiedDB.Has(ts)
 }
 
+// VerifiedResultAtTimestamp returns the committed VerifiedResult for ts.
+// Mirrors the regime gating of VerifiedAtTimestamp:
+//   - ts < activationTimestamp                → ErrNotActive
+//   - ts < firstVerifiableTimestamp           → ErrNotActive
+//   - verifiedDB.Get returns ErrNotFound      → ethereum.NotFound
+//   - else                                    → the stored VerifiedResult
+//
+// The local ErrNotFound is translated to the standard ethereum.NotFound at the
+// public boundary so consumers can errors.Is against the standard sentinel
+// without taking a dependency on this package's private error.
+func (i *Interop) VerifiedResultAtTimestamp(ts uint64) (VerifiedResult, error) {
+	if ts < i.activationTimestamp {
+		return VerifiedResult{}, ErrNotActive
+	}
+	firstVerifiable, err := i.firstVerifiableTimestamp(i.ctx)
+	if err != nil {
+		return VerifiedResult{}, fmt.Errorf("resolve first verifiable: %w", err)
+	}
+	if ts < firstVerifiable {
+		return VerifiedResult{}, ErrNotActive
+	}
+	result, err := i.verifiedDB.Get(ts)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return VerifiedResult{}, ethereum.NotFound
+		}
+		return VerifiedResult{}, err
+	}
+	return result, nil
+}
+
 // IsActiveAt reports whether the interop verifier is responsible for verifying
 // L2 content at the given timestamp. Returns false for timestamps strictly
 // before the configured activation timestamp.

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1111,6 +1111,87 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 	}
 }
 
+func TestVerifiedResultAtTimestamp(t *testing.T) {
+	t.Parallel()
+
+	t.Run("before activation returns ErrNotActive", func(t *testing.T) {
+		h := newInteropTestHarness(t).Build()
+		_, err := h.interop.VerifiedResultAtTimestamp(999)
+		require.ErrorIs(t, err, ErrNotActive)
+	})
+
+	t.Run("interop active but not yet verified returns ethereum.NotFound", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithActivation(100).
+			WithChain(10, func(m *mockChainContainer) {
+				m.syncStatusFull = &eth.SyncStatus{
+					SafeL2:      eth.L2BlockRef{Number: 100, Time: 100},
+					LocalSafeL2: eth.L2BlockRef{Number: 100, Time: 100},
+				}
+			}).
+			Build()
+		// 125 > activation; firstVerifiableTimestamp resolves via safe-head
+		// handoff to <= 125, so this should NOT be ErrNotActive — it should
+		// be ethereum.NotFound (active but no entry yet).
+		_, err := h.interop.VerifiedResultAtTimestamp(126)
+		require.ErrorIs(t, err, ethereum.NotFound)
+		require.NotErrorIs(t, err, ErrNotActive)
+	})
+
+	t.Run("returns committed VerifiedResult", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100}
+			}).
+			Build()
+		h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+			return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
+		}
+		result, err := progressInteropCompat(h.interop)
+		require.NoError(t, err)
+		require.NoError(t, applyResultCompat(h.interop, result))
+
+		got, err := h.interop.VerifiedResultAtTimestamp(1001)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1001), got.Timestamp)
+		require.NotEmpty(t, got.L2Heads)
+	})
+
+	t.Run("returns ethereum.NotFound after Rewind", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100}
+			}).
+			Build()
+		h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+			return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
+		}
+		result, err := progressInteropCompat(h.interop)
+		require.NoError(t, err)
+		require.NoError(t, applyResultCompat(h.interop, result))
+
+		// Pre-rewind: present.
+		_, err = h.interop.VerifiedResultAtTimestamp(1001)
+		require.NoError(t, err)
+
+		// Rewind erases the entry.
+		_, err = h.interop.verifiedDB.Rewind(1001)
+		require.NoError(t, err)
+
+		_, err = h.interop.VerifiedResultAtTimestamp(1001)
+		require.ErrorIs(t, err, ethereum.NotFound)
+	})
+}
+
+func TestNoopVerifiedResultReader(t *testing.T) {
+	t.Parallel()
+	var r VerifiedResultReader = NoopVerifiedResultReader{}
+	for _, ts := range []uint64{0, 1, 1000, 1 << 60} {
+		_, err := r.VerifiedResultAtTimestamp(ts)
+		require.ErrorIs(t, err, ErrNotActive)
+	}
+}
+
 func TestFirstVerifiableTimestampRestoresSafeHeadHandoffAfterRestart(t *testing.T) {
 	t.Parallel()
 
@@ -1951,9 +2032,6 @@ func (m *mockChainContainer) LocalSafeBlockAtTimestamp(ctx context.Context, ts u
 	ref.Hash = common.BigToHash(big.NewInt(int64(ts)))
 	return ref, nil
 }
-func (m *mockChainContainer) VerifiedAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
-	return eth.BlockID{}, eth.BlockID{}, nil
-}
 func (m *mockChainContainer) L1ForL2(ctx context.Context, l2Block eth.BlockID) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }
@@ -1986,7 +2064,7 @@ func (m *mockChainContainer) OptimisticAt(ctx context.Context, ts uint64) (eth.B
 	ref.Hash = common.BigToHash(big.NewInt(int64(ts)))
 	return ref.ID(), eth.BlockID{}, nil
 }
-func (m *mockChainContainer) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
+func (m *mockChainContainer) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
 	return eth.Bytes32{}, nil
 }
 func (m *mockChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputV0, error) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1116,7 +1116,7 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 
 	t.Run("before activation returns ErrNotActive", func(t *testing.T) {
 		h := newInteropTestHarness(t).Build()
-		_, err := h.interop.VerifiedResultAtTimestamp(999)
+		_, _, err := h.interop.VerifiedResultAtTimestamp(999)
 		require.ErrorIs(t, err, ErrNotActive)
 	})
 
@@ -1132,7 +1132,7 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 			Build()
 		// 126 > activation and >= firstVerifiable (resolves to 101 from
 		// SafeL2.Time=100); no entry yet → ethereum.NotFound.
-		_, err := h.interop.VerifiedResultAtTimestamp(126)
+		_, _, err := h.interop.VerifiedResultAtTimestamp(126)
 		require.ErrorIs(t, err, ethereum.NotFound)
 		require.NotErrorIs(t, err, ErrNotActive)
 		require.NotErrorIs(t, err, ErrBeforeVerifiedDB)
@@ -1150,7 +1150,7 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 				}
 			}).
 			Build()
-		_, err := h.interop.VerifiedResultAtTimestamp(200)
+		_, _, err := h.interop.VerifiedResultAtTimestamp(200)
 		require.ErrorIs(t, err, ErrBeforeVerifiedDB)
 		require.NotErrorIs(t, err, ErrNotActive)
 		require.NotErrorIs(t, err, ethereum.NotFound)
@@ -1169,10 +1169,11 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, applyResultCompat(h.interop, result))
 
-		got, err := h.interop.VerifiedResultAtTimestamp(1001)
+		got, currentL1, err := h.interop.VerifiedResultAtTimestamp(1001)
 		require.NoError(t, err)
 		require.Equal(t, uint64(1001), got.Timestamp)
 		require.NotEmpty(t, got.L2Heads)
+		require.Equal(t, h.interop.CurrentL1(), currentL1, "snapshot CurrentL1 must match the verifier's current L1")
 	})
 
 	t.Run("returns ethereum.NotFound after Rewind", func(t *testing.T) {
@@ -1189,14 +1190,14 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 		require.NoError(t, applyResultCompat(h.interop, result))
 
 		// Pre-rewind: present.
-		_, err = h.interop.VerifiedResultAtTimestamp(1001)
+		_, _, err = h.interop.VerifiedResultAtTimestamp(1001)
 		require.NoError(t, err)
 
 		// Rewind erases the entry.
 		_, err = h.interop.verifiedDB.Rewind(1001)
 		require.NoError(t, err)
 
-		_, err = h.interop.VerifiedResultAtTimestamp(1001)
+		_, _, err = h.interop.VerifiedResultAtTimestamp(1001)
 		require.ErrorIs(t, err, ethereum.NotFound)
 	})
 }
@@ -1205,7 +1206,7 @@ func TestNoopVerifiedResultReader(t *testing.T) {
 	t.Parallel()
 	var r VerifiedResultReader = NoopVerifiedResultReader{}
 	for _, ts := range []uint64{0, 1, 1000, 1 << 60} {
-		_, err := r.VerifiedResultAtTimestamp(ts)
+		_, _, err := r.VerifiedResultAtTimestamp(ts)
 		require.ErrorIs(t, err, ErrNotActive)
 	}
 }

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1130,12 +1130,30 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 				}
 			}).
 			Build()
-		// 125 > activation; firstVerifiableTimestamp resolves via safe-head
-		// handoff to <= 125, so this should NOT be ErrNotActive — it should
-		// be ethereum.NotFound (active but no entry yet).
+		// 126 > activation and >= firstVerifiable (resolves to 101 from
+		// SafeL2.Time=100); no entry yet → ethereum.NotFound.
 		_, err := h.interop.VerifiedResultAtTimestamp(126)
 		require.ErrorIs(t, err, ethereum.NotFound)
 		require.NotErrorIs(t, err, ErrNotActive)
+		require.NotErrorIs(t, err, ErrBeforeVerifiedDB)
+	})
+
+	t.Run("post-activation but below firstVerifiable returns ErrBeforeVerifiedDB", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithActivation(100).
+			WithChain(10, func(m *mockChainContainer) {
+				// SafeL2.Time=500 → firstVerifiable=501. ts=200 is post
+				// activation but below firstVerifiable on this node.
+				m.syncStatusFull = &eth.SyncStatus{
+					SafeL2:      eth.L2BlockRef{Number: 500, Time: 500},
+					LocalSafeL2: eth.L2BlockRef{Number: 500, Time: 500},
+				}
+			}).
+			Build()
+		_, err := h.interop.VerifiedResultAtTimestamp(200)
+		require.ErrorIs(t, err, ErrBeforeVerifiedDB)
+		require.NotErrorIs(t, err, ErrNotActive)
+		require.NotErrorIs(t, err, ethereum.NotFound)
 	})
 
 	t.Run("returns committed VerifiedResult", func(t *testing.T) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1156,6 +1156,16 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 		require.NotErrorIs(t, err, ethereum.NotFound)
 	})
 
+	t.Run("returns ErrNotStarted when Start has not populated i.ctx", func(t *testing.T) {
+		h := newInteropTestHarness(t).Build()
+		// Supernode registers the RPC API before scheduling Start, so a
+		// caller can reach this method between AddAPI and the Start
+		// goroutine running. Simulate that window by clearing i.ctx.
+		h.interop.ctx = nil
+		_, _, err := h.interop.VerifiedResultAtTimestamp(h.interop.activationTimestamp + 1)
+		require.ErrorIs(t, err, ErrNotStarted)
+	})
+
 	t.Run("returns committed VerifiedResult", func(t *testing.T) {
 		h := newInteropTestHarness(t).
 			WithChain(10, func(m *mockChainContainer) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1158,9 +1158,6 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 
 	t.Run("returns ErrNotStarted when Start has not populated i.ctx", func(t *testing.T) {
 		h := newInteropTestHarness(t).Build()
-		// Supernode registers the RPC API before scheduling Start, so a
-		// caller can reach this method between AddAPI and the Start
-		// goroutine running. Simulate that window by clearing i.ctx.
 		h.interop.ctx = nil
 		_, _, err := h.interop.VerifiedResultAtTimestamp(h.interop.activationTimestamp + 1)
 		require.ErrorIs(t, err, ErrNotStarted)

--- a/op-supernode/supernode/activity/interop/reader.go
+++ b/op-supernode/supernode/activity/interop/reader.go
@@ -2,29 +2,31 @@ package interop
 
 import "errors"
 
-// ErrNotActive signals that the verifier has not produced — and will not
-// produce — a VerifiedResult for the requested timestamp. Two cases:
-//   - ts < activationTimestamp: interop is genuinely inactive for ts.
-//   - ts < firstVerifiableTimestamp: interop is active but the verifier's
-//     bootstrap floor has not reached ts and never will.
-//
-// Callers interpret this as "fall back to pre-interop composition" — distinct
-// from ethereum.NotFound which means "interop IS active for ts and the
-// verifier may eventually produce a result, but has not yet."
+// ErrNotActive signals that ts is before interop activation. Callers compose
+// the super root from per-chain optimistic outputs.
 var ErrNotActive = errors.New("interop not active for timestamp")
 
-// VerifiedResultReader exposes a read-only view of committed VerifiedResults
-// so non-interop activities can decide whether a timestamp falls into the
-// strict (verified) regime, the active-but-not-yet-verified regime
-// (returns ethereum.NotFound), or the pre-interop regime (returns
-// ErrNotActive).
+// ErrBeforeVerifiedDB signals that ts is post-activation but below the
+// verifier's first verifiable timestamp on this node. No VerifiedResult will
+// ever be produced for ts here, and the deny-list state needed to reproduce
+// the canonical super root from optimistic data is not available either. The
+// supernode cannot answer the call.
+var ErrBeforeVerifiedDB = errors.New("timestamp below verified-db start")
+
+// VerifiedResultReader exposes committed VerifiedResults to non-interop
+// activities. Errors discriminate the regime:
+//   - nil:                  verified entry returned
+//   - ErrNotActive:         pre-activation; compose from optimistic outputs
+//   - ErrBeforeVerifiedDB:  post-activation but below firstVerifiable; not
+//     answerable on this node
+//   - ethereum.NotFound:    verifier may eventually produce a result but has
+//     not yet — return Data = nil and let CurrentL1 communicate progress
 type VerifiedResultReader interface {
 	VerifiedResultAtTimestamp(ts uint64) (VerifiedResult, error)
 }
 
-// NoopVerifiedResultReader is used when the supernode is wired without an
-// interop activity. Every call reports ErrNotActive, routing consumers into
-// the pre-interop fallback.
+// NoopVerifiedResultReader is used when interop is not configured: every
+// call returns ErrNotActive.
 type NoopVerifiedResultReader struct{}
 
 func (NoopVerifiedResultReader) VerifiedResultAtTimestamp(uint64) (VerifiedResult, error) {

--- a/op-supernode/supernode/activity/interop/reader.go
+++ b/op-supernode/supernode/activity/interop/reader.go
@@ -1,0 +1,32 @@
+package interop
+
+import "errors"
+
+// ErrNotActive signals that the verifier has not produced — and will not
+// produce — a VerifiedResult for the requested timestamp. Two cases:
+//   - ts < activationTimestamp: interop is genuinely inactive for ts.
+//   - ts < firstVerifiableTimestamp: interop is active but the verifier's
+//     bootstrap floor has not reached ts and never will.
+//
+// Callers interpret this as "fall back to pre-interop composition" — distinct
+// from ethereum.NotFound which means "interop IS active for ts and the
+// verifier may eventually produce a result, but has not yet."
+var ErrNotActive = errors.New("interop not active for timestamp")
+
+// VerifiedResultReader exposes a read-only view of committed VerifiedResults
+// so non-interop activities can decide whether a timestamp falls into the
+// strict (verified) regime, the active-but-not-yet-verified regime
+// (returns ethereum.NotFound), or the pre-interop regime (returns
+// ErrNotActive).
+type VerifiedResultReader interface {
+	VerifiedResultAtTimestamp(ts uint64) (VerifiedResult, error)
+}
+
+// NoopVerifiedResultReader is used when the supernode is wired without an
+// interop activity. Every call reports ErrNotActive, routing consumers into
+// the pre-interop fallback.
+type NoopVerifiedResultReader struct{}
+
+func (NoopVerifiedResultReader) VerifiedResultAtTimestamp(uint64) (VerifiedResult, error) {
+	return VerifiedResult{}, ErrNotActive
+}

--- a/op-supernode/supernode/activity/interop/reader.go
+++ b/op-supernode/supernode/activity/interop/reader.go
@@ -16,6 +16,13 @@ var ErrNotActive = errors.New("interop not active for timestamp")
 // be produced here, but callers can treat optimistic outputs as canonical.
 var ErrBeforeVerifiedDB = errors.New("timestamp below verified-db start")
 
+// ErrNotStarted signals that the interop activity has been constructed and
+// its RPC registered, but its Start goroutine has not yet populated the
+// internal context. Callers should retry after startup completes. Until then,
+// this is routed to the same fallback as ErrNotActive so the response is
+// composed from optimistic outputs rather than panicking on a nil context.
+var ErrNotStarted = errors.New("interop activity not started")
+
 // VerifiedResultReader exposes committed VerifiedResults to non-interop
 // activities. Errors discriminate the regime:
 //   - nil:                  verified entry returned

--- a/op-supernode/supernode/activity/interop/reader.go
+++ b/op-supernode/supernode/activity/interop/reader.go
@@ -16,11 +16,8 @@ var ErrNotActive = errors.New("interop not active for timestamp")
 // be produced here, but callers can treat optimistic outputs as canonical.
 var ErrBeforeVerifiedDB = errors.New("timestamp below verified-db start")
 
-// ErrNotStarted signals that the interop activity has been constructed and
-// its RPC registered, but its Start goroutine has not yet populated the
-// internal context. Callers should retry after startup completes. Until then,
-// this is routed to the same fallback as ErrNotActive so the response is
-// composed from optimistic outputs rather than panicking on a nil context.
+// ErrNotStarted signals that Start has not yet populated i.ctx. Callers
+// should retry after startup completes.
 var ErrNotStarted = errors.New("interop activity not started")
 
 // VerifiedResultReader exposes committed VerifiedResults to non-interop

--- a/op-supernode/supernode/activity/interop/reader.go
+++ b/op-supernode/supernode/activity/interop/reader.go
@@ -11,18 +11,17 @@ import (
 var ErrNotActive = errors.New("interop not active for timestamp")
 
 // ErrBeforeVerifiedDB signals that ts is post-activation but below the
-// verifier's first verifiable timestamp on this node. No VerifiedResult will
-// ever be produced for ts here, and the deny-list state needed to reproduce
-// the canonical super root from optimistic data is not available either. The
-// supernode cannot answer the call.
+// verifier's first verifiable timestamp on this node. The timestamp is
+// already covered by the safe-head startup handoff: no VerifiedResult will
+// be produced here, but callers can treat optimistic outputs as canonical.
 var ErrBeforeVerifiedDB = errors.New("timestamp below verified-db start")
 
 // VerifiedResultReader exposes committed VerifiedResults to non-interop
 // activities. Errors discriminate the regime:
 //   - nil:                  verified entry returned
 //   - ErrNotActive:         pre-activation; compose from optimistic outputs
-//   - ErrBeforeVerifiedDB:  post-activation but below firstVerifiable; not
-//     answerable on this node
+//   - ErrBeforeVerifiedDB:  post-activation but below firstVerifiable; the
+//     handoff covers ts, so compose from optimistic outputs
 //   - ethereum.NotFound:    verifier may eventually produce a result but has
 //     not yet — return Data = nil and let CurrentL1 communicate progress
 //

--- a/op-supernode/supernode/activity/interop/reader.go
+++ b/op-supernode/supernode/activity/interop/reader.go
@@ -1,6 +1,10 @@
 package interop
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
 
 // ErrNotActive signals that ts is before interop activation. Callers compose
 // the super root from per-chain optimistic outputs.
@@ -21,14 +25,19 @@ var ErrBeforeVerifiedDB = errors.New("timestamp below verified-db start")
 //     answerable on this node
 //   - ethereum.NotFound:    verifier may eventually produce a result but has
 //     not yet — return Data = nil and let CurrentL1 communicate progress
+//
+// currentL1 is the verifier's CurrentL1 observed atomically with the
+// verifiedDB read. Callers must combine it with their own CurrentL1 view
+// (via min) so the response cannot report a CurrentL1 that is inconsistent
+// with the verifiedDB observation.
 type VerifiedResultReader interface {
-	VerifiedResultAtTimestamp(ts uint64) (VerifiedResult, error)
+	VerifiedResultAtTimestamp(ts uint64) (result VerifiedResult, currentL1 eth.BlockID, err error)
 }
 
 // NoopVerifiedResultReader is used when interop is not configured: every
 // call returns ErrNotActive.
 type NoopVerifiedResultReader struct{}
 
-func (NoopVerifiedResultReader) VerifiedResultAtTimestamp(uint64) (VerifiedResult, error) {
-	return VerifiedResult{}, ErrNotActive
+func (NoopVerifiedResultReader) VerifiedResultAtTimestamp(uint64) (VerifiedResult, eth.BlockID, error) {
+	return VerifiedResult{}, eth.BlockID{}, ErrNotActive
 }

--- a/op-supernode/supernode/activity/interop/reader_test.go
+++ b/op-supernode/supernode/activity/interop/reader_test.go
@@ -1,0 +1,9 @@
+package interop
+
+// Compile-time interface conformance assertions. If *Interop or
+// NoopVerifiedResultReader stops satisfying VerifiedResultReader (e.g. because
+// the method signature drifts), this file fails to compile.
+var (
+	_ VerifiedResultReader = (*Interop)(nil)
+	_ VerifiedResultReader = NoopVerifiedResultReader{}
+)

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -57,18 +57,11 @@ func (m *mockCC) L1AtSafeHead(ctx context.Context, l2 eth.BlockID) (eth.BlockID,
 	return eth.BlockID{}, nil
 }
 
-func (m *mockCC) VerifiedAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
-	if m.verifiedErr != nil {
-		return eth.BlockID{}, eth.BlockID{}, m.verifiedErr
-	}
-	return eth.BlockID{}, eth.BlockID{}, nil
-}
-
 func (m *mockCC) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
 	return eth.BlockID{}, eth.BlockID{}, nil
 }
 
-func (m *mockCC) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
+func (m *mockCC) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
 	if m.outputErr != nil {
 		return eth.Bytes32{}, m.outputErr
 	}

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -102,11 +102,8 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		}
 		return response, nil
 	case errors.Is(vrErr, interop.ErrNotActive), errors.Is(vrErr, interop.ErrBeforeVerifiedDB), errors.Is(vrErr, interop.ErrNotStarted):
-		// Pre-activation, post-activation but below the verifier's first
-		// verifiable timestamp on this node, or interop activity not yet
-		// started. All three regimes are already covered by pre-interop
-		// consensus, the safe-head startup handoff, or a subsequent retry
-		// once Start has run, so the optimistic outputs are canonical.
+		// Optimistic outputs are canonical: pre-interop consensus,
+		// safe-head handoff, or pre-Start retry path.
 		response.Data = composeHandoffDataFromOptimistic(timestamp, s.chains, optimisticBranch)
 		return response, nil
 	default:

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -101,17 +101,13 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 			response.CurrentL1 = verifierL1
 		}
 		return response, nil
-	case errors.Is(vrErr, interop.ErrNotActive):
-		// Pre-interop: local-safe outputs cannot be invalidated, so the
-		// optimistic outputs are canonical.
-		response.Data = composePreInteropDataFromOptimistic(timestamp, s.chains, optimisticBranch)
+	case errors.Is(vrErr, interop.ErrNotActive), errors.Is(vrErr, interop.ErrBeforeVerifiedDB):
+		// Pre-activation or post-activation but below the verifier's
+		// first verifiable timestamp on this node. Both regimes are
+		// already covered by pre-interop consensus or by the safe-head
+		// startup handoff, so the optimistic outputs are canonical.
+		response.Data = composeHandoffDataFromOptimistic(timestamp, s.chains, optimisticBranch)
 		return response, nil
-	case errors.Is(vrErr, interop.ErrBeforeVerifiedDB):
-		// Post-activation but below the verifier's first verifiable
-		// timestamp on this node. No entry will ever be written for T,
-		// and we have no deny-list data to reconstruct the canonical
-		// output from optimistic state — the call cannot be answered.
-		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("timestamp %d is below verified-db start on this node: %w", timestamp, vrErr)
 	default:
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("read verifiedDB at %d: %w", timestamp, vrErr)
 	}
@@ -176,9 +172,11 @@ func (s *Superroot) composeVerifiedData(ctx context.Context, timestamp uint64, r
 	}, nil
 }
 
-// composePreInteropDataFromOptimistic builds Data from the optimistic map.
-// Returns nil if any chain is missing from the map (chain hasn't derived T).
-func composePreInteropDataFromOptimistic(timestamp uint64, chains map[eth.ChainID]cc.ChainContainer, optimisticBranch map[eth.ChainID]eth.OutputWithRequiredL1) *eth.SuperRootResponseData {
+// composeHandoffDataFromOptimistic builds Data from the optimistic map. Used
+// for pre-activation and below-firstVerifiable regimes, where the safe-head
+// handoff guarantees the optimistic outputs are canonical. Returns nil if
+// any chain is missing from the map (chain hasn't derived T).
+func composeHandoffDataFromOptimistic(timestamp uint64, chains map[eth.ChainID]cc.ChainContainer, optimisticBranch map[eth.ChainID]eth.OutputWithRequiredL1) *eth.SuperRootResponseData {
 	if len(optimisticBranch) != len(chains) {
 		return nil
 	}

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -101,11 +101,12 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 			response.CurrentL1 = verifierL1
 		}
 		return response, nil
-	case errors.Is(vrErr, interop.ErrNotActive), errors.Is(vrErr, interop.ErrBeforeVerifiedDB):
-		// Pre-activation or post-activation but below the verifier's
-		// first verifiable timestamp on this node. Both regimes are
-		// already covered by pre-interop consensus or by the safe-head
-		// startup handoff, so the optimistic outputs are canonical.
+	case errors.Is(vrErr, interop.ErrNotActive), errors.Is(vrErr, interop.ErrBeforeVerifiedDB), errors.Is(vrErr, interop.ErrNotStarted):
+		// Pre-activation, post-activation but below the verifier's first
+		// verifiable timestamp on this node, or interop activity not yet
+		// started. All three regimes are already covered by pre-interop
+		// consensus, the safe-head startup handoff, or a subsequent retry
+		// once Start has run, so the optimistic outputs are canonical.
 		response.Data = composeHandoffDataFromOptimistic(timestamp, s.chains, optimisticBranch)
 		return response, nil
 	default:

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -14,20 +14,25 @@ import (
 	gethlog "github.com/ethereum/go-ethereum/log"
 )
 
-// Superroot satisfies the RPC Activity interface. It composes the super-root
-// at a given timestamp across the configured dep set, returning aggregated
-// sync status and the per-chain optimistic outputs alongside.
+// Superroot composes the super-root at a given timestamp across the
+// configured dep set, returning aggregated sync status and the per-chain
+// optimistic outputs alongside.
 //
-// Two regimes coexist in atTimestamp:
-//   - Post-interop (T past activation and firstVerifiable): Data sourced
-//     strictly from interop.VerifiedResultReader + EL-by-hash reads. Bound by
-//     the cross-safe write gate; satisfies the invariant in §1/§2 of the
-//     superroot_atTimestamp design docs.
-//   - Pre-interop (T before activation, or interop not configured): Data
-//     composed directly from the per-chain optimistic outputs. Pre-interop,
-//     local-safe blocks cannot be invalidated, so the optimistic outputs ARE
-//     the canonical outputs at T. Consistency matches the legacy two-call
-//     client pattern.
+// Four regimes coexist in atTimestamp, distinguished by the error returned
+// from interop.VerifiedResultReader:
+//   - Pre-activation (ErrNotActive): Data is composed from per-chain
+//     optimistic outputs. Pre-interop, local-safe blocks cannot be
+//     invalidated, so the optimistic outputs are canonical.
+//   - Post-activation but below firstVerifiable (ErrBeforeVerifiedDB): the
+//     verifier will not produce a result for this T on this node, and the
+//     deny-list state needed to reconstruct the canonical output from
+//     optimistic data is not available. Fail the call.
+//   - Verified entry available: Data is sourced from the VerifiedResult plus
+//     EL-by-hash reads. The answer for a given T is bound to the verifiedDB
+//     entry and cannot drift.
+//   - Active but not yet committed (ethereum.NotFound): Data == nil; the
+//     response's CurrentL1 communicates verifier progress so op-challenger
+//     can distinguish "may appear later" from a final answer.
 type Superroot struct {
 	log      gethlog.Logger
 	chains   map[eth.ChainID]cc.ChainContainer
@@ -66,17 +71,12 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		return eth.SuperRootAtTimestampResponse{}, err
 	}
 
-	// Resolve regime first: a single in-memory check plus at most one bbolt
-	// View. Does not call into any chain container.
 	result, vrErr := s.verified.VerifiedResultAtTimestamp(timestamp)
 
-	// Build the optimistic branch. Matches the existing semantics: chains
-	// that hit NotFound on either OptimisticOutputAtTimestamp or OptimisticAt
-	// are omitted; any other chain-level error fails the call. This is
-	// load-bearing for the pre-interop regime (Data is built from this map)
-	// and important for the post-interop regimes too — op-challenger reads
-	// the OptimisticAtTimestamp map at step>0 and a silent partial map would
-	// produce permanent InvalidTransition commitments on chain.
+	// Any chain-level error building the optimistic branch must fail the
+	// call: op-challenger reads OptimisticAtTimestamp at step>0 and a silent
+	// partial map would produce permanent InvalidTransition commitments on
+	// chain. The pre-interop regime also relies on this map for Data.
 	optimisticBranch, err := s.buildOptimisticBranch(ctx, timestamp)
 	if err != nil {
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("build optimistic branch at %d: %w", timestamp, err)
@@ -100,27 +100,29 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		response.Data = data
 		return response, nil
 	case errors.Is(vrErr, ethereum.NotFound):
-		// Interop is active at T but the verifier has not committed a
-		// VerifiedResult yet. Data == nil — by construction of the
-		// verifiedDB write gate plus the CurrentL1 cap, entry absence
-		// implies CurrentL1 < VerifiedRequiredL1(T).
+		// Interop active at T but no VerifiedResult yet. Leave Data nil;
+		// the verifiedDB write gate guarantees CurrentL1 has not reached
+		// VerifiedRequiredL1(T).
 		return response, nil
 	case errors.Is(vrErr, interop.ErrNotActive):
-		// Pre-interop fallback. Reuse the optimistic map: pre-interop,
-		// local-safe outputs cannot be invalidated, so the optimistic
-		// outputs are canonical.
+		// Pre-interop: local-safe outputs cannot be invalidated, so the
+		// optimistic outputs are canonical.
 		response.Data = composePreInteropDataFromOptimistic(timestamp, s.chains, optimisticBranch)
 		return response, nil
+	case errors.Is(vrErr, interop.ErrBeforeVerifiedDB):
+		// Post-activation but below the verifier's first verifiable
+		// timestamp on this node. No entry will ever be written for T,
+		// and we have no deny-list data to reconstruct the canonical
+		// output from optimistic state — the call cannot be answered.
+		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("timestamp %d is below verified-db start on this node: %w", timestamp, vrErr)
 	default:
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("read verifiedDB at %d: %w", timestamp, vrErr)
 	}
 }
 
-// buildOptimisticBranch iterates s.chains and gathers per-chain optimistic
-// outputs. Chains whose OptimisticOutputAtTimestamp or OptimisticAt returned
-// NotFound are silently omitted (legacy "chain hasn't derived T yet"). Any
-// other error is returned immediately so the caller can surface it as a
-// transport error to the RPC client.
+// buildOptimisticBranch gathers per-chain optimistic outputs. Chains that
+// return NotFound on OptimisticOutputAtTimestamp or OptimisticAt are omitted
+// (chain hasn't derived T yet); any other error fails the call.
 func (s *Superroot) buildOptimisticBranch(ctx context.Context, timestamp uint64) (map[eth.ChainID]eth.OutputWithRequiredL1, error) {
 	out := make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
 	for chainID, chain := range s.chains {
@@ -147,14 +149,12 @@ func (s *Superroot) buildOptimisticBranch(ctx context.Context, timestamp uint64)
 	return out, nil
 }
 
-// composeVerifiedData composes the strict (post-interop) Data from a
-// VerifiedResult. The verifiedDB entry pins per-chain canonical block hashes;
-// per-chain output roots come from a by-hash read against the L2 EL.
+// composeVerifiedData composes the post-interop Data from a VerifiedResult.
+// The verifiedDB entry pins per-chain canonical block hashes; per-chain output
+// roots come from a by-hash read against the L2 EL.
 func (s *Superroot) composeVerifiedData(ctx context.Context, timestamp uint64, result interop.VerifiedResult, aggregate eth.SuperNodeSyncStatusResponse) (*eth.SuperRootResponseData, error) {
-	// Dep-set sanity. Either direction is a configuration divergence:
-	// - missing chain (s.chains has key not in L2Heads): partial answer.
-	// - extra chain (L2Heads has key not in s.chains): peers with the full
-	//   dep set would compute a different super root → §2 Agreement violation.
+	// Reject a dep-set mismatch: either side would yield a super root that
+	// disagrees with peers running the full dep set.
 	if len(result.L2Heads) != len(s.chains) {
 		return nil, fmt.Errorf("dep-set size mismatch at %d: verifiedDB=%d chains, boot view=%d chains", timestamp, len(result.L2Heads), len(s.chains))
 	}
@@ -178,19 +178,18 @@ func (s *Superroot) composeVerifiedData(ctx context.Context, timestamp uint64, r
 		SuperRoot:          eth.SuperRoot(super),
 	}
 
-	// Rewind-race coupling check. Verifier rewind drops i.currentL1 to zero
-	// (interop.go:649) before deleting verifiedDB rows. If we read
-	// verifiedDB before the rewind got to the delete step, the aggregate
-	// CurrentL1 will reflect the post-currentL1=0 value. Catch that here.
+	// Detect a verifier rewind in flight: rewind drops the aggregate
+	// CurrentL1 to zero before deleting verifiedDB rows, so a stale
+	// verifiedDB entry can briefly outlive a CurrentL1 that has already
+	// fallen below VerifiedRequiredL1.
 	if aggregate.CurrentL1.Number < data.VerifiedRequiredL1.Number {
 		return nil, fmt.Errorf("rewind in flight at %d: CurrentL1=%d < VerifiedRequiredL1=%d", timestamp, aggregate.CurrentL1.Number, data.VerifiedRequiredL1.Number)
 	}
 	return data, nil
 }
 
-// composePreInteropDataFromOptimistic builds Data by reusing the optimistic
-// map. Returns nil if the optimistic map is short (any chain in s.chains is
-// missing — legacy "chain hasn't derived" → Data == nil).
+// composePreInteropDataFromOptimistic builds Data from the optimistic map.
+// Returns nil if any chain is missing from the map (chain hasn't derived T).
 func composePreInteropDataFromOptimistic(timestamp uint64, chains map[eth.ChainID]cc.ChainContainer, optimisticBranch map[eth.ChainID]eth.OutputWithRequiredL1) *eth.SuperRootResponseData {
 	if len(optimisticBranch) != len(chains) {
 		return nil

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -71,7 +71,7 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		return eth.SuperRootAtTimestampResponse{}, err
 	}
 
-	result, vrErr := s.verified.VerifiedResultAtTimestamp(timestamp)
+	result, verifierL1, vrErr := s.verified.VerifiedResultAtTimestamp(timestamp)
 
 	// Any chain-level error building the optimistic branch must fail the
 	// call: op-challenger reads OptimisticAtTimestamp at step>0 and a silent
@@ -91,9 +91,19 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		ChainIDs:                  aggregate.ChainIDs,
 	}
 
+	// When interop is engaged (verified entry or active-but-not-yet-verified
+	// regimes), use the lower of aggregate.CurrentL1 and the verifier's
+	// CurrentL1 observed atomically with the verifiedDB read. Reporting the
+	// snapshot L1 closes the race where aggregate's read happens to straddle
+	// a commit (entry-now-present but currentL1 not yet observed) or a
+	// rewind (currentL1 already dropped but aggregate captured a stale high
+	// value).
 	switch {
 	case vrErr == nil:
-		data, derr := s.composeVerifiedData(ctx, timestamp, result, aggregate)
+		if verifierL1.Number < response.CurrentL1.Number {
+			response.CurrentL1 = verifierL1
+		}
+		data, derr := s.composeVerifiedData(ctx, timestamp, result, response.CurrentL1)
 		if derr != nil {
 			return eth.SuperRootAtTimestampResponse{}, derr
 		}
@@ -103,6 +113,9 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		// Interop active at T but no VerifiedResult yet. Leave Data nil;
 		// the verifiedDB write gate guarantees CurrentL1 has not reached
 		// VerifiedRequiredL1(T).
+		if verifierL1.Number < response.CurrentL1.Number {
+			response.CurrentL1 = verifierL1
+		}
 		return response, nil
 	case errors.Is(vrErr, interop.ErrNotActive):
 		// Pre-interop: local-safe outputs cannot be invalidated, so the
@@ -152,7 +165,7 @@ func (s *Superroot) buildOptimisticBranch(ctx context.Context, timestamp uint64)
 // composeVerifiedData composes the post-interop Data from a VerifiedResult.
 // The verifiedDB entry pins per-chain canonical block hashes; per-chain output
 // roots come from a by-hash read against the L2 EL.
-func (s *Superroot) composeVerifiedData(ctx context.Context, timestamp uint64, result interop.VerifiedResult, aggregate eth.SuperNodeSyncStatusResponse) (*eth.SuperRootResponseData, error) {
+func (s *Superroot) composeVerifiedData(ctx context.Context, timestamp uint64, result interop.VerifiedResult, currentL1 eth.BlockID) (*eth.SuperRootResponseData, error) {
 	// Reject a dep-set mismatch: either side would yield a super root that
 	// disagrees with peers running the full dep set.
 	if len(result.L2Heads) != len(s.chains) {
@@ -178,12 +191,14 @@ func (s *Superroot) composeVerifiedData(ctx context.Context, timestamp uint64, r
 		SuperRoot:          eth.SuperRoot(super),
 	}
 
-	// Detect a verifier rewind in flight: rewind drops the aggregate
+	// Detect a verifier rewind in flight: rewind drops the verifier's
 	// CurrentL1 to zero before deleting verifiedDB rows, so a stale
 	// verifiedDB entry can briefly outlive a CurrentL1 that has already
-	// fallen below VerifiedRequiredL1.
-	if aggregate.CurrentL1.Number < data.VerifiedRequiredL1.Number {
-		return nil, fmt.Errorf("rewind in flight at %d: CurrentL1=%d < VerifiedRequiredL1=%d", timestamp, aggregate.CurrentL1.Number, data.VerifiedRequiredL1.Number)
+	// fallen below VerifiedRequiredL1. currentL1 here is the
+	// min(aggregate, snapshot) — both views must agree the entry is
+	// reachable.
+	if currentL1.Number < data.VerifiedRequiredL1.Number {
+		return nil, fmt.Errorf("rewind in flight at %d: CurrentL1=%d < VerifiedRequiredL1=%d", timestamp, currentL1.Number, data.VerifiedRequiredL1.Number)
 	}
 	return data, nil
 }

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -28,11 +28,12 @@ import (
 //     deny-list state needed to reconstruct the canonical output from
 //     optimistic data is not available. Fail the call.
 //   - Verified entry available: Data is sourced from the VerifiedResult plus
-//     EL-by-hash reads. The answer for a given T is bound to the verifiedDB
-//     entry and cannot drift.
-//   - Active but not yet committed (ethereum.NotFound): Data == nil; the
-//     response's CurrentL1 communicates verifier progress so op-challenger
-//     can distinguish "may appear later" from a final answer.
+//     EL-by-hash reads. Callers gate trust on CurrentL1 >= VerifiedRequiredL1.
+//   - Active but not yet committed (ethereum.NotFound): Data == nil.
+//
+// CurrentL1 in the response is the lower of aggregate.CurrentL1 and the
+// verifier's CurrentL1 captured atomically with the verifiedDB read, so it
+// never overstates verifier progress.
 type Superroot struct {
 	log      gethlog.Logger
 	chains   map[eth.ChainID]cc.ChainContainer
@@ -103,7 +104,7 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		if verifierL1.Number < response.CurrentL1.Number {
 			response.CurrentL1 = verifierL1
 		}
-		data, derr := s.composeVerifiedData(ctx, timestamp, result, response.CurrentL1)
+		data, derr := s.composeVerifiedData(ctx, timestamp, result)
 		if derr != nil {
 			return eth.SuperRootAtTimestampResponse{}, derr
 		}
@@ -165,7 +166,7 @@ func (s *Superroot) buildOptimisticBranch(ctx context.Context, timestamp uint64)
 // composeVerifiedData composes the post-interop Data from a VerifiedResult.
 // The verifiedDB entry pins per-chain canonical block hashes; per-chain output
 // roots come from a by-hash read against the L2 EL.
-func (s *Superroot) composeVerifiedData(ctx context.Context, timestamp uint64, result interop.VerifiedResult, currentL1 eth.BlockID) (*eth.SuperRootResponseData, error) {
+func (s *Superroot) composeVerifiedData(ctx context.Context, timestamp uint64, result interop.VerifiedResult) (*eth.SuperRootResponseData, error) {
 	// Reject a dep-set mismatch: either side would yield a super root that
 	// disagrees with peers running the full dep set.
 	if len(result.L2Heads) != len(s.chains) {
@@ -185,22 +186,11 @@ func (s *Superroot) composeVerifiedData(ctx context.Context, timestamp uint64, r
 		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: outRoot})
 	}
 	super := eth.NewSuperV1(timestamp, chainOutputs...)
-	data := &eth.SuperRootResponseData{
+	return &eth.SuperRootResponseData{
 		VerifiedRequiredL1: result.L1Inclusion,
 		Super:              super,
 		SuperRoot:          eth.SuperRoot(super),
-	}
-
-	// Detect a verifier rewind in flight: rewind drops the verifier's
-	// CurrentL1 to zero before deleting verifiedDB rows, so a stale
-	// verifiedDB entry can briefly outlive a CurrentL1 that has already
-	// fallen below VerifiedRequiredL1. currentL1 here is the
-	// min(aggregate, snapshot) — both views must agree the entry is
-	// reachable.
-	if currentL1.Number < data.VerifiedRequiredL1.Number {
-		return nil, fmt.Errorf("rewind in flight at %d: CurrentL1=%d < VerifiedRequiredL1=%d", timestamp, currentL1.Number, data.VerifiedRequiredL1.Number)
-	}
-	return data, nil
+	}, nil
 }
 
 // composePreInteropDataFromOptimistic builds Data from the optimistic map.

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -17,23 +17,6 @@ import (
 // Superroot composes the super-root at a given timestamp across the
 // configured dep set, returning aggregated sync status and the per-chain
 // optimistic outputs alongside.
-//
-// Four regimes coexist in atTimestamp, distinguished by the error returned
-// from interop.VerifiedResultReader:
-//   - Pre-activation (ErrNotActive): Data is composed from per-chain
-//     optimistic outputs. Pre-interop, local-safe blocks cannot be
-//     invalidated, so the optimistic outputs are canonical.
-//   - Post-activation but below firstVerifiable (ErrBeforeVerifiedDB): the
-//     verifier will not produce a result for this T on this node, and the
-//     deny-list state needed to reconstruct the canonical output from
-//     optimistic data is not available. Fail the call.
-//   - Verified entry available: Data is sourced from the VerifiedResult plus
-//     EL-by-hash reads. Callers gate trust on CurrentL1 >= VerifiedRequiredL1.
-//   - Active but not yet committed (ethereum.NotFound): Data == nil.
-//
-// CurrentL1 in the response is the lower of aggregate.CurrentL1 and the
-// verifier's CurrentL1 captured atomically with the verifiedDB read, so it
-// never overstates verifier progress.
 type Superroot struct {
 	log      gethlog.Logger
 	chains   map[eth.ChainID]cc.ChainContainer

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -7,24 +7,38 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/internal/syncstatus"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	gethlog "github.com/ethereum/go-ethereum/log"
 )
 
-// Superroot satisfies the RPC Activity interface
-// it provides the superroot at a given timestamp for all chains
-// along with the current L1s and the verified and optimistic L1:L2 pairs
+// Superroot satisfies the RPC Activity interface. It composes the super-root
+// at a given timestamp across the configured dep set, returning aggregated
+// sync status and the per-chain optimistic outputs alongside.
+//
+// Two regimes coexist in atTimestamp:
+//   - Post-interop (T past activation and firstVerifiable): Data sourced
+//     strictly from interop.VerifiedResultReader + EL-by-hash reads. Bound by
+//     the cross-safe write gate; satisfies the invariant in §1/§2 of the
+//     superroot_atTimestamp design docs.
+//   - Pre-interop (T before activation, or interop not configured): Data
+//     composed directly from the per-chain optimistic outputs. Pre-interop,
+//     local-safe blocks cannot be invalidated, so the optimistic outputs ARE
+//     the canonical outputs at T. Consistency matches the legacy two-call
+//     client pattern.
 type Superroot struct {
-	log    gethlog.Logger
-	chains map[eth.ChainID]cc.ChainContainer
+	log      gethlog.Logger
+	chains   map[eth.ChainID]cc.ChainContainer
+	verified interop.VerifiedResultReader
 }
 
-func New(log gethlog.Logger, chains map[eth.ChainID]cc.ChainContainer) *Superroot {
+func New(log gethlog.Logger, chains map[eth.ChainID]cc.ChainContainer, verified interop.VerifiedResultReader) *Superroot {
 	return &Superroot{
-		log:    log,
-		chains: chains,
+		log:      log,
+		chains:   chains,
+		verified: verified,
 	}
 }
 
@@ -52,61 +66,20 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		return eth.SuperRootAtTimestampResponse{}, err
 	}
 
-	var (
-		optimistic         = make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
-		verifiedRequiredL1 eth.BlockID
-		chainOutputs       = make([]eth.ChainIDAndOutput, 0, len(s.chains))
-	)
+	// Resolve regime first: a single in-memory check plus at most one bbolt
+	// View. Does not call into any chain container.
+	result, vrErr := s.verified.VerifiedResultAtTimestamp(timestamp)
 
-	notFound := false
-	// Collect verified L2 and L1 blocks at the given timestamp
-	for chainID, chain := range s.chains {
-		// verifiedAt returns the L2 block which is fully verified at the given timestamp, and the minimum L1 block at which verification is possible
-		verifiedL2, verifiedL1, err := chain.VerifiedAt(ctx, timestamp)
-		if errors.Is(err, ethereum.NotFound) {
-			notFound = true
-			continue
-		} else if err != nil {
-			s.log.Warn("failed to get verified block", "chain_id", chainID.String(), "err", err)
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get verified block: %w", err)
-		}
-		// Verified data is available: track the L1 block that includes the data
-		// for every chain — i.e. the MAX of per-chain minimum-required L1s.
-		if verifiedL1.Number > verifiedRequiredL1.Number {
-			verifiedRequiredL1 = verifiedL1
-		}
-		// Compute output root at or before timestamp using the verified L2 block number
-		outRoot, err := chain.OutputRootAtL2BlockNumber(ctx, verifiedL2.Number)
-		if err != nil {
-			s.log.Warn("failed to compute output root at L2 block", "chain_id", chainID.String(), "l2_number", verifiedL2.Number, "err", err)
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to compute output root at L2 block %d for chain ID %v: %w", verifiedL2.Number, chainID, err)
-		}
-		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: outRoot})
-	}
-
-	// Collect optimistic data for all chains regardless of whether verified data is available.
-	for chainID, chain := range s.chains {
-		optimisticOut, err := chain.OptimisticOutputAtTimestamp(ctx, timestamp)
-		if errors.Is(err, ethereum.NotFound) {
-			// If optimistic data is also absent, the chain is simply excluded from OptimisticAtTimestamp.
-			continue
-		} else if err != nil {
-			s.log.Warn("failed to get optimistic block", "chain_id", chainID.String(), "err", err)
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get optimistic block at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
-		}
-		// Also include the source L1 for context
-		_, optimisticL1, err := chain.OptimisticAt(ctx, timestamp)
-		if errors.Is(err, ethereum.NotFound) {
-			continue
-		} else if err != nil {
-			s.log.Warn("failed to get optimistic source L1", "chain_id", chainID.String(), "err", err)
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get optimistic source L1 at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
-		}
-		optimistic[chainID] = eth.OutputWithRequiredL1{
-			Output:     optimisticOut,
-			OutputRoot: eth.OutputRoot(optimisticOut),
-			RequiredL1: optimisticL1,
-		}
+	// Build the optimistic branch. Matches the existing semantics: chains
+	// that hit NotFound on either OptimisticOutputAtTimestamp or OptimisticAt
+	// are omitted; any other chain-level error fails the call. This is
+	// load-bearing for the pre-interop regime (Data is built from this map)
+	// and important for the post-interop regimes too — op-challenger reads
+	// the OptimisticAtTimestamp map at step>0 and a silent partial map would
+	// produce permanent InvalidTransition commitments on chain.
+	optimisticBranch, err := s.buildOptimisticBranch(ctx, timestamp)
+	if err != nil {
+		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("build optimistic branch at %d: %w", timestamp, err)
 	}
 
 	response := eth.SuperRootAtTimestampResponse{
@@ -114,18 +87,130 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		CurrentSafeTimestamp:      aggregate.SafeTimestamp,
 		CurrentLocalSafeTimestamp: aggregate.LocalSafeTimestamp,
 		CurrentFinalizedTimestamp: aggregate.FinalizedTimestamp,
-		OptimisticAtTimestamp:     optimistic,
+		OptimisticAtTimestamp:     optimisticBranch,
 		ChainIDs:                  aggregate.ChainIDs,
 	}
-	if !notFound {
-		// Build super root from collected outputs
-		superV1 := eth.NewSuperV1(timestamp, chainOutputs...)
-		superRoot := eth.SuperRoot(superV1)
-		response.Data = &eth.SuperRootResponseData{
-			VerifiedRequiredL1: verifiedRequiredL1,
-			Super:              superV1,
-			SuperRoot:          superRoot,
+
+	switch {
+	case vrErr == nil:
+		data, derr := s.composeVerifiedData(ctx, timestamp, result, aggregate)
+		if derr != nil {
+			return eth.SuperRootAtTimestampResponse{}, derr
+		}
+		response.Data = data
+		return response, nil
+	case errors.Is(vrErr, ethereum.NotFound):
+		// Interop is active at T but the verifier has not committed a
+		// VerifiedResult yet. Data == nil — by construction of the
+		// verifiedDB write gate plus the CurrentL1 cap, entry absence
+		// implies CurrentL1 < VerifiedRequiredL1(T).
+		return response, nil
+	case errors.Is(vrErr, interop.ErrNotActive):
+		// Pre-interop fallback. Reuse the optimistic map: pre-interop,
+		// local-safe outputs cannot be invalidated, so the optimistic
+		// outputs are canonical.
+		response.Data = composePreInteropDataFromOptimistic(timestamp, s.chains, optimisticBranch)
+		return response, nil
+	default:
+		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("read verifiedDB at %d: %w", timestamp, vrErr)
+	}
+}
+
+// buildOptimisticBranch iterates s.chains and gathers per-chain optimistic
+// outputs. Chains whose OptimisticOutputAtTimestamp or OptimisticAt returned
+// NotFound are silently omitted (legacy "chain hasn't derived T yet"). Any
+// other error is returned immediately so the caller can surface it as a
+// transport error to the RPC client.
+func (s *Superroot) buildOptimisticBranch(ctx context.Context, timestamp uint64) (map[eth.ChainID]eth.OutputWithRequiredL1, error) {
+	out := make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
+	for chainID, chain := range s.chains {
+		optimisticOut, err := chain.OptimisticOutputAtTimestamp(ctx, timestamp)
+		if errors.Is(err, ethereum.NotFound) {
+			continue
+		} else if err != nil {
+			s.log.Warn("failed to get optimistic block", "chain_id", chainID.String(), "err", err)
+			return nil, fmt.Errorf("failed to get optimistic block at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
+		}
+		_, optimisticL1, err := chain.OptimisticAt(ctx, timestamp)
+		if errors.Is(err, ethereum.NotFound) {
+			continue
+		} else if err != nil {
+			s.log.Warn("failed to get optimistic source L1", "chain_id", chainID.String(), "err", err)
+			return nil, fmt.Errorf("failed to get optimistic source L1 at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
+		}
+		out[chainID] = eth.OutputWithRequiredL1{
+			Output:     optimisticOut,
+			OutputRoot: eth.OutputRoot(optimisticOut),
+			RequiredL1: optimisticL1,
 		}
 	}
-	return response, nil
+	return out, nil
+}
+
+// composeVerifiedData composes the strict (post-interop) Data from a
+// VerifiedResult. The verifiedDB entry pins per-chain canonical block hashes;
+// per-chain output roots come from a by-hash read against the L2 EL.
+func (s *Superroot) composeVerifiedData(ctx context.Context, timestamp uint64, result interop.VerifiedResult, aggregate eth.SuperNodeSyncStatusResponse) (*eth.SuperRootResponseData, error) {
+	// Dep-set sanity. Either direction is a configuration divergence:
+	// - missing chain (s.chains has key not in L2Heads): partial answer.
+	// - extra chain (L2Heads has key not in s.chains): peers with the full
+	//   dep set would compute a different super root → §2 Agreement violation.
+	if len(result.L2Heads) != len(s.chains) {
+		return nil, fmt.Errorf("dep-set size mismatch at %d: verifiedDB=%d chains, boot view=%d chains", timestamp, len(result.L2Heads), len(s.chains))
+	}
+
+	chainOutputs := make([]eth.ChainIDAndOutput, 0, len(s.chains))
+	for chainID, chain := range s.chains {
+		head, ok := result.L2Heads[chainID]
+		if !ok {
+			return nil, fmt.Errorf("verifiedDB entry at %d missing chain %s — dep-set mismatch", timestamp, chainID)
+		}
+		outRoot, err := chain.OutputRootAtL2BlockHash(ctx, head.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("output root for chain %s at block %s: %w", chainID, head.Hash, err)
+		}
+		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: outRoot})
+	}
+	super := eth.NewSuperV1(timestamp, chainOutputs...)
+	data := &eth.SuperRootResponseData{
+		VerifiedRequiredL1: result.L1Inclusion,
+		Super:              super,
+		SuperRoot:          eth.SuperRoot(super),
+	}
+
+	// Rewind-race coupling check. Verifier rewind drops i.currentL1 to zero
+	// (interop.go:649) before deleting verifiedDB rows. If we read
+	// verifiedDB before the rewind got to the delete step, the aggregate
+	// CurrentL1 will reflect the post-currentL1=0 value. Catch that here.
+	if aggregate.CurrentL1.Number < data.VerifiedRequiredL1.Number {
+		return nil, fmt.Errorf("rewind in flight at %d: CurrentL1=%d < VerifiedRequiredL1=%d", timestamp, aggregate.CurrentL1.Number, data.VerifiedRequiredL1.Number)
+	}
+	return data, nil
+}
+
+// composePreInteropDataFromOptimistic builds Data by reusing the optimistic
+// map. Returns nil if the optimistic map is short (any chain in s.chains is
+// missing — legacy "chain hasn't derived" → Data == nil).
+func composePreInteropDataFromOptimistic(timestamp uint64, chains map[eth.ChainID]cc.ChainContainer, optimisticBranch map[eth.ChainID]eth.OutputWithRequiredL1) *eth.SuperRootResponseData {
+	if len(optimisticBranch) != len(chains) {
+		return nil
+	}
+	chainOutputs := make([]eth.ChainIDAndOutput, 0, len(chains))
+	var maxL1 eth.BlockID
+	for chainID := range chains {
+		entry, ok := optimisticBranch[chainID]
+		if !ok {
+			return nil
+		}
+		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: entry.OutputRoot})
+		if entry.RequiredL1.Number > maxL1.Number {
+			maxL1 = entry.RequiredL1
+		}
+	}
+	super := eth.NewSuperV1(timestamp, chainOutputs...)
+	return &eth.SuperRootResponseData{
+		VerifiedRequiredL1: maxL1,
+		Super:              super,
+		SuperRoot:          eth.SuperRoot(super),
+	}
 }

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -115,12 +115,13 @@ var _ cc.ChainContainer = (*mockCC)(nil)
 // for pre-interop fallback, interop.ErrBeforeVerifiedDB for the
 // hard-error regime, or any other error for the default branch).
 type mockVerifiedReader struct {
-	result interop.VerifiedResult
-	err    error
+	result    interop.VerifiedResult
+	currentL1 eth.BlockID
+	err       error
 }
 
-func (m *mockVerifiedReader) VerifiedResultAtTimestamp(ts uint64) (interop.VerifiedResult, error) {
-	return m.result, m.err
+func (m *mockVerifiedReader) VerifiedResultAtTimestamp(ts uint64) (interop.VerifiedResult, eth.BlockID, error) {
+	return m.result, m.currentL1, m.err
 }
 
 // preInteropReader always reports the pre-interop fallback regime.
@@ -265,6 +266,7 @@ func TestSuperroot_AtTimestamp_VerifiedFromDB(t *testing.T) {
 				chainB: {Number: 200, Hash: hashB},
 			},
 		},
+		currentL1: eth.BlockID{Number: 2000},
 	}
 	s := newSuperroot(chains, reader)
 	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
@@ -312,6 +314,7 @@ func TestSuperroot_AtTimestamp_OutputRootByHashFails(t *testing.T) {
 			L1Inclusion: eth.BlockID{Number: 1000},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainA: {Number: 100, Hash: hashA}},
 		},
+		currentL1: eth.BlockID{Number: 2000},
 	}
 	s := newSuperroot(chains, reader)
 	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
@@ -341,6 +344,7 @@ func TestSuperroot_AtTimestamp_DepSetSizeMismatch(t *testing.T) {
 			L1Inclusion: eth.BlockID{Number: 1000},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainA: {Number: 100, Hash: common.HexToHash("0x01")}},
 		},
+		currentL1: eth.BlockID{Number: 2000},
 	}
 	s := newSuperroot(chains, reader)
 	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
@@ -375,6 +379,7 @@ func TestSuperroot_AtTimestamp_DepSetKeyMismatch(t *testing.T) {
 				chainC: {Number: 200, Hash: common.HexToHash("0x02")},
 			},
 		},
+		currentL1: eth.BlockID{Number: 2000},
 	}
 	s := newSuperroot(chains, reader)
 	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
@@ -392,8 +397,8 @@ func TestSuperroot_AtTimestamp_RewindRaceCouplingCheck(t *testing.T) {
 			optL1:          eth.BlockID{Number: 900},
 			byHashOutputs:  map[common.Hash]eth.Bytes32{hashA: {0xaa}},
 			byHashFallback: eth.Bytes32{0xee},
-			// Simulate the mid-rewind state: i.currentL1 has been dropped to zero
-			// while verifiedDB still has the entry.
+			// Simulate the mid-rewind state via the chain's CurrentL1:
+			// aggregate.CurrentL1=500 below VerifiedRequiredL1=1000.
 			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 500}},
 		},
 	}
@@ -403,6 +408,42 @@ func TestSuperroot_AtTimestamp_RewindRaceCouplingCheck(t *testing.T) {
 			L1Inclusion: eth.BlockID{Number: 1000},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainA: {Number: 100, Hash: hashA}},
 		},
+		currentL1: eth.BlockID{Number: 2000},
+	}
+	s := newSuperroot(chains, reader)
+	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rewind in flight")
+}
+
+// Simulates the rewind race detected via the verifier's snapshot CurrentL1:
+// chain CurrentL1 still reflects a stale pre-rewind value (race window
+// between syncstatus.Aggregate and the verifiedDB read), but the
+// VerifiedResultAtTimestamp snapshot caught currentL1 already dropped to zero.
+// The min(aggregate, snapshot) used by composeVerifiedData must trip the
+// coupling check.
+func TestSuperroot_AtTimestamp_RewindRaceViaSnapshotL1(t *testing.T) {
+	t.Parallel()
+	hashA := common.HexToHash("0x0a")
+	chainA := eth.ChainIDFromUInt64(10)
+	chains := map[eth.ChainID]cc.ChainContainer{
+		chainA: &mockCC{
+			optL2:          eth.BlockID{Number: 100, Hash: hashA},
+			optL1:          eth.BlockID{Number: 900},
+			byHashOutputs:  map[common.Hash]eth.Bytes32{hashA: {0xaa}},
+			byHashFallback: eth.Bytes32{0xee},
+			// Stale pre-rewind aggregate.
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+	}
+	reader := &mockVerifiedReader{
+		result: interop.VerifiedResult{
+			Timestamp:   123,
+			L1Inclusion: eth.BlockID{Number: 1000},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chainA: {Number: 100, Hash: hashA}},
+		},
+		// Atomic snapshot caught currentL1 already at zero.
+		currentL1: eth.BlockID{Number: 0},
 	}
 	s := newSuperroot(chains, reader)
 	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
@@ -443,6 +484,7 @@ func TestSuperroot_AtTimestamp_OptimisticErrorFailsRPC_VerifiedHit(t *testing.T)
 			L1Inclusion: eth.BlockID{Number: 1000},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainA: {Number: 100, Hash: hashA}},
 		},
+		currentL1: eth.BlockID{Number: 2000},
 	}
 	s := newSuperroot(chains, reader)
 	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -387,7 +387,11 @@ func TestSuperroot_AtTimestamp_DepSetKeyMismatch(t *testing.T) {
 	require.Contains(t, err.Error(), "missing chain")
 }
 
-func TestSuperroot_AtTimestamp_RewindRaceCouplingCheck(t *testing.T) {
+// Data is returned even when CurrentL1 sits below VerifiedRequiredL1 (e.g.
+// mid-rewind, where the verifier has rolled CurrentL1 back below T's
+// required L1 but the entry has not yet been deleted). Callers gate trust
+// on CurrentL1 themselves.
+func TestSuperroot_AtTimestamp_VerifiedDataReturnedBelowRequiredL1(t *testing.T) {
 	t.Parallel()
 	hashA := common.HexToHash("0x0a")
 	chainA := eth.ChainIDFromUInt64(10)
@@ -397,9 +401,7 @@ func TestSuperroot_AtTimestamp_RewindRaceCouplingCheck(t *testing.T) {
 			optL1:          eth.BlockID{Number: 900},
 			byHashOutputs:  map[common.Hash]eth.Bytes32{hashA: {0xaa}},
 			byHashFallback: eth.Bytes32{0xee},
-			// Simulate the mid-rewind state via the chain's CurrentL1:
-			// aggregate.CurrentL1=500 below VerifiedRequiredL1=1000.
-			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 500}},
+			status:         &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
 		},
 	}
 	reader := &mockVerifiedReader{
@@ -408,47 +410,16 @@ func TestSuperroot_AtTimestamp_RewindRaceCouplingCheck(t *testing.T) {
 			L1Inclusion: eth.BlockID{Number: 1000},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainA: {Number: 100, Hash: hashA}},
 		},
-		currentL1: eth.BlockID{Number: 2000},
-	}
-	s := newSuperroot(chains, reader)
-	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "rewind in flight")
-}
-
-// Simulates the rewind race detected via the verifier's snapshot CurrentL1:
-// chain CurrentL1 still reflects a stale pre-rewind value (race window
-// between syncstatus.Aggregate and the verifiedDB read), but the
-// VerifiedResultAtTimestamp snapshot caught currentL1 already dropped to zero.
-// The min(aggregate, snapshot) used by composeVerifiedData must trip the
-// coupling check.
-func TestSuperroot_AtTimestamp_RewindRaceViaSnapshotL1(t *testing.T) {
-	t.Parallel()
-	hashA := common.HexToHash("0x0a")
-	chainA := eth.ChainIDFromUInt64(10)
-	chains := map[eth.ChainID]cc.ChainContainer{
-		chainA: &mockCC{
-			optL2:          eth.BlockID{Number: 100, Hash: hashA},
-			optL1:          eth.BlockID{Number: 900},
-			byHashOutputs:  map[common.Hash]eth.Bytes32{hashA: {0xaa}},
-			byHashFallback: eth.Bytes32{0xee},
-			// Stale pre-rewind aggregate.
-			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
-		},
-	}
-	reader := &mockVerifiedReader{
-		result: interop.VerifiedResult{
-			Timestamp:   123,
-			L1Inclusion: eth.BlockID{Number: 1000},
-			L2Heads:     map[eth.ChainID]eth.BlockID{chainA: {Number: 100, Hash: hashA}},
-		},
-		// Atomic snapshot caught currentL1 already at zero.
+		// Snapshot caught currentL1 already at zero (mid-rewind).
 		currentL1: eth.BlockID{Number: 0},
 	}
 	s := newSuperroot(chains, reader)
-	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "rewind in flight")
+	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Data)
+	require.Equal(t, uint64(1000), resp.Data.VerifiedRequiredL1.Number)
+	require.Equal(t, uint64(0), resp.CurrentL1.Number,
+		"response CurrentL1 must be min(aggregate, snapshot) so it doesn't overstate verifier progress")
 }
 
 func TestSuperroot_AtTimestamp_VerifiedReaderError(t *testing.T) {

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -43,13 +43,13 @@ type mockCC struct {
 	byHashCalled   int
 }
 
-func (m *mockCC) Start(ctx context.Context) error          { return nil }
-func (m *mockCC) Stop(ctx context.Context) error           { return nil }
-func (m *mockCC) Pause(ctx context.Context) error          { return nil }
-func (m *mockCC) Resume(ctx context.Context) error         { return nil }
-func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }
+func (m *mockCC) Start(ctx context.Context) error                  { return nil }
+func (m *mockCC) Stop(ctx context.Context) error                   { return nil }
+func (m *mockCC) Pause(ctx context.Context) error                  { return nil }
+func (m *mockCC) Resume(ctx context.Context) error                 { return nil }
+func (m *mockCC) PauseAndStopVN(ctx context.Context) error         { return nil }
 func (m *mockCC) RegisterVerifier(v activity.VerificationActivity) {}
-func (m *mockCC) VerifierCurrentL1s() []eth.BlockID                 { return m.verifierL1s }
+func (m *mockCC) VerifierCurrentL1s() []eth.BlockID                { return m.verifierL1s }
 func (m *mockCC) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
 	return eth.L2BlockRef{}, nil
 }
@@ -87,8 +87,8 @@ func (m *mockCC) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*e
 func (m *mockCC) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
 	return nil, nil, nil
 }
-func (m *mockCC) ID() eth.ChainID                                                { return eth.ChainIDFromUInt64(10) }
-func (m *mockCC) BlockTime() uint64                                              { return 1 }
+func (m *mockCC) ID() eth.ChainID   { return eth.ChainIDFromUInt64(10) }
+func (m *mockCC) BlockTime() uint64 { return 1 }
 func (m *mockCC) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
 	return &eth.OutputV0{}, nil
 }
@@ -106,6 +106,7 @@ func (m *mockCC) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64,
 func (m *mockCC) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
 	return 0, nil
 }
+func (m *mockCC) Generation() uint64 { return 0 }
 
 var _ cc.ChainContainer = (*mockCC)(nil)
 
@@ -577,9 +578,12 @@ func TestSuperroot_AtTimestamp_PreInteropFallback_NoSecondFetch(t *testing.T) {
 	require.NotNil(t, resp.Data)
 }
 
-// ------ Below-verified-db hard-error tests ------
+// ------ Below-verified-db handoff tests ------
 
-func TestSuperroot_AtTimestamp_BelowVerifiedDB_FailsRPC(t *testing.T) {
+// Below firstVerifiable, the safe-head startup handoff guarantees the
+// optimistic outputs are canonical, so Data is composed from them rather
+// than returning an error.
+func TestSuperroot_AtTimestamp_BelowVerifiedDB_ComposesFromOptimistic(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
@@ -591,9 +595,9 @@ func TestSuperroot_AtTimestamp_BelowVerifiedDB_FailsRPC(t *testing.T) {
 	}
 	reader := &mockVerifiedReader{err: interop.ErrBeforeVerifiedDB}
 	s := newSuperroot(chains, reader)
-	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
-	require.Error(t, err)
-	require.ErrorIs(t, err, interop.ErrBeforeVerifiedDB)
+	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Data)
 }
 
 // assertErr returns a generic error instance used to signal mock failures.

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -578,6 +578,27 @@ func TestSuperroot_AtTimestamp_PreInteropFallback_NoSecondFetch(t *testing.T) {
 	require.NotNil(t, resp.Data)
 }
 
+// ErrNotStarted is returned during the startup window after AddAPI has
+// registered the RPC but before the interop activity's Start goroutine has
+// populated its context. Route it to the same optimistic fallback so the
+// response is composed rather than failing the call.
+func TestSuperroot_AtTimestamp_InteropNotStarted_ComposesFromOptimistic(t *testing.T) {
+	t.Parallel()
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): &mockCC{
+			optL2:     eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:     eth.BlockID{Number: 900},
+			optOutput: &eth.OutputV0{StateRoot: eth.Bytes32{0x01}},
+			status:    &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+	}
+	reader := &mockVerifiedReader{err: interop.ErrNotStarted}
+	s := newSuperroot(chains, reader)
+	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Data)
+}
+
 // ------ Below-verified-db handoff tests ------
 
 // Below firstVerifiable, the safe-head startup handoff guarantees the

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -112,7 +112,8 @@ var _ cc.ChainContainer = (*mockCC)(nil)
 // mockVerifiedReader is a test fake for interop.VerifiedResultReader.
 // Set result to return a VerifiedResult; set err to return an error
 // (ethereum.NotFound for "active but not yet verified", interop.ErrNotActive
-// for pre-interop fallback, or any other error for the default branch).
+// for pre-interop fallback, interop.ErrBeforeVerifiedDB for the
+// hard-error regime, or any other error for the default branch).
 type mockVerifiedReader struct {
 	result interop.VerifiedResult
 	err    error
@@ -561,6 +562,25 @@ func TestSuperroot_AtTimestamp_PreInteropFallback_NoSecondFetch(t *testing.T) {
 	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
 	require.NotNil(t, resp.Data)
+}
+
+// ------ Below-verified-db hard-error tests ------
+
+func TestSuperroot_AtTimestamp_BelowVerifiedDB_FailsRPC(t *testing.T) {
+	t.Parallel()
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): &mockCC{
+			optL2:     eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:     eth.BlockID{Number: 900},
+			optOutput: &eth.OutputV0{StateRoot: eth.Bytes32{0x01}},
+			status:    &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+	}
+	reader := &mockVerifiedReader{err: interop.ErrBeforeVerifiedDB}
+	s := newSuperroot(chains, reader)
+	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.Error(t, err)
+	require.ErrorIs(t, err, interop.ErrBeforeVerifiedDB)
 }
 
 // assertErr returns a generic error instance used to signal mock failures.

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -578,10 +578,7 @@ func TestSuperroot_AtTimestamp_PreInteropFallback_NoSecondFetch(t *testing.T) {
 	require.NotNil(t, resp.Data)
 }
 
-// ErrNotStarted is returned during the startup window after AddAPI has
-// registered the RPC but before the interop activity's Start goroutine has
-// populated its context. Route it to the same optimistic fallback so the
-// response is composed rather than failing the call.
+// ErrNotStarted routes to the optimistic-composition fallback.
 func TestSuperroot_AtTimestamp_InteropNotStarted_ComposesFromOptimistic(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -2,33 +2,45 @@ package superroot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
+// mockCC is a ChainContainer test fake. Field semantics:
+//   - optL2/optL1: returned from OptimisticAt.
+//   - optOutput:   the OutputV0 returned by OptimisticOutputAtTimestamp.
+//   - byHashOutputs: per-block-hash output roots returned by OutputRootAtL2BlockHash.
+//     If a hash is missing, byHashFallback is returned.
+//   - byHashFallback: default OutputRoot.
+//   - byHashErr:     if set, OutputRootAtL2BlockHash returns this error.
+//   - optimisticErr: if set, both OptimisticOutputAtTimestamp and OptimisticAt return it.
+//   - syncStatusErr: if set, SyncStatus returns it.
+//   - status: returned from SyncStatus.
+//   - verifierL1s: returned from VerifierCurrentL1s.
+//   - byHashCalled: incremented per OutputRootAtL2BlockHash call (for assertion).
 type mockCC struct {
-	verL2       eth.BlockID
-	verL1       eth.BlockID
-	optL2       eth.BlockID
-	optL1       eth.BlockID
-	output      eth.Bytes32
-	status      *eth.SyncStatus
-	verifierL1s []eth.BlockID
-
-	verifiedErr   error
-	outputErr     error
-	optimisticErr error
-	syncStatusErr error
+	optL2          eth.BlockID
+	optL1          eth.BlockID
+	optOutput      *eth.OutputV0
+	byHashOutputs  map[common.Hash]eth.Bytes32
+	byHashFallback eth.Bytes32
+	byHashErr      error
+	optimisticErr  error
+	syncStatusErr  error
+	status         *eth.SyncStatus
+	verifierL1s    []eth.BlockID
+	byHashCalled   int
 }
 
 func (m *mockCC) Start(ctx context.Context) error          { return nil }
@@ -36,12 +48,8 @@ func (m *mockCC) Stop(ctx context.Context) error           { return nil }
 func (m *mockCC) Pause(ctx context.Context) error          { return nil }
 func (m *mockCC) Resume(ctx context.Context) error         { return nil }
 func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }
-
 func (m *mockCC) RegisterVerifier(v activity.VerificationActivity) {}
-func (m *mockCC) VerifierCurrentL1s() []eth.BlockID {
-	return m.verifierL1s
-}
-
+func (m *mockCC) VerifierCurrentL1s() []eth.BlockID                 { return m.verifierL1s }
 func (m *mockCC) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
 	return eth.L2BlockRef{}, nil
 }
@@ -49,22 +57,7 @@ func (m *mockCC) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
 	if m.syncStatusErr != nil {
 		return nil, m.syncStatusErr
 	}
-	if m.status == nil {
-		return &eth.SyncStatus{}, nil
-	}
 	return m.status, nil
-}
-func (m *mockCC) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (eth.BlockID, eth.BlockID, error) {
-	return eth.BlockID{}, eth.BlockID{}, nil
-}
-func (m *mockCC) L1AtSafeHead(ctx context.Context, l2 eth.BlockID) (eth.BlockID, error) {
-	return eth.BlockID{}, nil
-}
-func (m *mockCC) VerifiedAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
-	if m.verifiedErr != nil {
-		return eth.BlockID{}, eth.BlockID{}, m.verifiedErr
-	}
-	return m.verL2, m.verL1, nil
 }
 func (m *mockCC) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
 	if m.optimisticErr != nil {
@@ -72,31 +65,30 @@ func (m *mockCC) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockID, eth.
 	}
 	return m.optL2, m.optL1, nil
 }
-func (m *mockCC) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
-	if m.outputErr != nil {
-		return eth.Bytes32{}, m.outputErr
+func (m *mockCC) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
+	m.byHashCalled++
+	if m.byHashErr != nil {
+		return eth.Bytes32{}, m.byHashErr
 	}
-	return m.output, nil
+	if out, ok := m.byHashOutputs[blockHash]; ok {
+		return out, nil
+	}
+	return m.byHashFallback, nil
 }
 func (m *mockCC) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputV0, error) {
 	if m.optimisticErr != nil {
 		return nil, m.optimisticErr
 	}
+	if m.optOutput != nil {
+		return m.optOutput, nil
+	}
 	return &eth.OutputV0{}, nil
 }
-func (m *mockCC) L1ForL2(ctx context.Context, l2Block eth.BlockID) (eth.BlockID, error) {
-	return eth.BlockID{}, nil
-}
-
 func (m *mockCC) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
 	return nil, nil, nil
 }
-
-func (m *mockCC) ID() eth.ChainID {
-	return eth.ChainIDFromUInt64(10)
-}
-
-func (m *mockCC) BlockTime() uint64 { return 1 }
+func (m *mockCC) ID() eth.ChainID                                                { return eth.ChainIDFromUInt64(10) }
+func (m *mockCC) BlockTime() uint64                                              { return 1 }
 func (m *mockCC) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
 	return &eth.OutputV0{}, nil
 }
@@ -106,30 +98,58 @@ func (m *mockCC) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.O
 func (m *mockCC) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {
 	return nil, nil
 }
-func (m *mockCC) IsDenied(height uint64, payloadHash common.Hash) (bool, error) {
-	return false, nil
-}
-func (m *mockCC) SetResetCallback(cb cc.ResetCallback) {}
-
+func (m *mockCC) IsDenied(height uint64, payloadHash common.Hash) (bool, error) { return false, nil }
+func (m *mockCC) SetResetCallback(cb cc.ResetCallback)                          {}
 func (m *mockCC) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error) {
 	return ts, nil
 }
-
 func (m *mockCC) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
 	return 0, nil
 }
 
 var _ cc.ChainContainer = (*mockCC)(nil)
 
-func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {
+// mockVerifiedReader is a test fake for interop.VerifiedResultReader.
+// Set result to return a VerifiedResult; set err to return an error
+// (ethereum.NotFound for "active but not yet verified", interop.ErrNotActive
+// for pre-interop fallback, or any other error for the default branch).
+type mockVerifiedReader struct {
+	result interop.VerifiedResult
+	err    error
+}
+
+func (m *mockVerifiedReader) VerifiedResultAtTimestamp(ts uint64) (interop.VerifiedResult, error) {
+	return m.result, m.err
+}
+
+// preInteropReader always reports the pre-interop fallback regime.
+func preInteropReader() interop.VerifiedResultReader {
+	return interop.NoopVerifiedResultReader{}
+}
+
+// activeUnverifiedReader reports the active-but-not-yet-verified regime
+// (handler returns Data == nil but a successful response).
+func activeUnverifiedReader() interop.VerifiedResultReader {
+	return &mockVerifiedReader{err: ethereum.NotFound}
+}
+
+func newSuperroot(chains map[eth.ChainID]cc.ChainContainer, reader interop.VerifiedResultReader) *Superroot {
+	if reader == nil {
+		reader = preInteropReader()
+	}
+	return New(gethlog.New(), chains, reader)
+}
+
+// ------ Aggregate sync-status tests (regime-agnostic) ------
+
+func TestSuperroot_AtTimestamp_AggregatesSyncStatus(t *testing.T) {
 	t.Parallel()
+	hashA := common.HexToHash("0xaaaa")
+	hashB := common.HexToHash("0xbbbb")
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
-			verL2:  eth.BlockID{Number: 100},
-			verL1:  eth.BlockID{Number: 1000},
-			optL2:  eth.BlockID{Number: 100},
-			optL1:  eth.BlockID{Number: 1000},
-			output: eth.Bytes32{},
+			optL2: eth.BlockID{Number: 100, Hash: hashA},
+			optL1: eth.BlockID{Number: 1000},
 			status: &eth.SyncStatus{
 				CurrentL1:   eth.L1BlockRef{Number: 2000},
 				SafeL2:      eth.L2BlockRef{Time: 190},
@@ -138,11 +158,8 @@ func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {
 			},
 		},
 		eth.ChainIDFromUInt64(420): &mockCC{
-			verL2:  eth.BlockID{Number: 200},
-			verL1:  eth.BlockID{Number: 1100},
-			optL2:  eth.BlockID{Number: 200},
-			optL1:  eth.BlockID{Number: 1100},
-			output: eth.Bytes32{},
+			optL2: eth.BlockID{Number: 200, Hash: hashB},
+			optL1: eth.BlockID{Number: 1100},
 			status: &eth.SyncStatus{
 				CurrentL1:   eth.L1BlockRef{Number: 2100},
 				SafeL2:      eth.L2BlockRef{Time: 170},
@@ -151,213 +168,39 @@ func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {
 			},
 		},
 	}
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	out, err := api.AtTimestamp(context.Background(), 123)
+	s := newSuperroot(chains, preInteropReader())
+	out, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
-	require.Len(t, out.OptimisticAtTimestamp, 2)
-	// min values
 	require.Equal(t, uint64(2000), out.CurrentL1.Number)
 	require.Equal(t, uint64(170), out.CurrentSafeTimestamp)
 	require.Equal(t, uint64(180), out.CurrentLocalSafeTimestamp)
 	require.Equal(t, uint64(140), out.CurrentFinalizedTimestamp)
-	// VerifiedRequiredL1 is the MAX of per-chain required L1s — the L1 block
-	// that includes data for every chain.
-	require.Equal(t, uint64(1100), out.Data.VerifiedRequiredL1.Number)
-	// With zero outputs, the superroot will be deterministic, just ensure it's set
-	_ = out.Data.SuperRoot
-}
-
-func TestSuperroot_AtTimestamp_ComputesSuperRoot(t *testing.T) {
-	t.Parallel()
-	out1 := eth.Bytes32{1}
-	out2 := eth.Bytes32{2}
-	chains := map[eth.ChainID]cc.ChainContainer{
-		eth.ChainIDFromUInt64(10): &mockCC{
-			verL2:  eth.BlockID{Number: 100},
-			verL1:  eth.BlockID{Number: 1000},
-			optL2:  eth.BlockID{Number: 100},
-			optL1:  eth.BlockID{Number: 1000},
-			output: out1,
-			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
-		},
-		eth.ChainIDFromUInt64(420): &mockCC{
-			verL2:  eth.BlockID{Number: 200},
-			verL1:  eth.BlockID{Number: 1100},
-			optL2:  eth.BlockID{Number: 200},
-			optL1:  eth.BlockID{Number: 1100},
-			output: out2,
-			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
-		},
-	}
-	ts := uint64(123)
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	resp, err := api.AtTimestamp(context.Background(), hexutil.Uint64(ts))
-	require.NoError(t, err)
-
-	// Compute expected super root
-	chainOutputs := []eth.ChainIDAndOutput{
-		{ChainID: eth.ChainIDFromUInt64(10), Output: out1},
-		{ChainID: eth.ChainIDFromUInt64(420), Output: out2},
-	}
-	expected := eth.SuperRoot(eth.NewSuperV1(ts, chainOutputs...))
-	require.Equal(t, expected, resp.Data.SuperRoot)
+	require.Len(t, out.OptimisticAtTimestamp, 2)
 }
 
 func TestSuperroot_AtTimestamp_ErrorOnCurrentL1(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
-		eth.ChainIDFromUInt64(10): &mockCC{
-			syncStatusErr: assertErr(),
-		},
+		eth.ChainIDFromUInt64(10): &mockCC{syncStatusErr: assertErr()},
 	}
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	_, err := api.AtTimestamp(context.Background(), 123)
+	s := newSuperroot(chains, preInteropReader())
+	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
 	require.Error(t, err)
-}
-
-func TestSuperroot_AtTimestamp_ErrorOnVerifiedAt(t *testing.T) {
-	t.Parallel()
-	chains := map[eth.ChainID]cc.ChainContainer{
-		eth.ChainIDFromUInt64(10): &mockCC{
-			verifiedErr: assertErr(),
-		},
-	}
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	_, err := api.AtTimestamp(context.Background(), 123)
-	require.Error(t, err)
-}
-
-func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAt(t *testing.T) {
-	t.Parallel()
-	chains := map[eth.ChainID]cc.ChainContainer{
-		eth.ChainIDFromUInt64(10): &mockCC{
-			verifiedErr: fmt.Errorf("nope: %w", ethereum.NotFound),
-			optL2:       eth.BlockID{Number: 100},
-			optL1:       eth.BlockID{Number: 1000},
-		},
-		eth.ChainIDFromUInt64(11): &mockCC{
-			verL2:  eth.BlockID{Number: 200},
-			verL1:  eth.BlockID{Number: 1100},
-			optL2:  eth.BlockID{Number: 200},
-			optL1:  eth.BlockID{Number: 1100},
-			output: eth.Bytes32{0x12},
-			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
-		},
-	}
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	actual, err := api.AtTimestamp(context.Background(), 123)
-	require.NoError(t, err)
-	require.Nil(t, actual.Data)
-	// Chain 10 has no verified data but optimistic data is available, so it should be present
-	require.Contains(t, actual.OptimisticAtTimestamp, eth.ChainIDFromUInt64(10))
-	require.Contains(t, actual.OptimisticAtTimestamp, eth.ChainIDFromUInt64(11))
-}
-
-func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAtAndOptimisticAt(t *testing.T) {
-	t.Parallel()
-	chains := map[eth.ChainID]cc.ChainContainer{
-		eth.ChainIDFromUInt64(10): &mockCC{
-			verifiedErr:   fmt.Errorf("nope: %w", ethereum.NotFound),
-			optimisticErr: ethereum.NotFound,
-		},
-		eth.ChainIDFromUInt64(11): &mockCC{
-			verL2:  eth.BlockID{Number: 200},
-			verL1:  eth.BlockID{Number: 1100},
-			optL2:  eth.BlockID{Number: 200},
-			optL1:  eth.BlockID{Number: 1100},
-			output: eth.Bytes32{0x12},
-			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
-		},
-	}
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	actual, err := api.AtTimestamp(context.Background(), 123)
-	require.NoError(t, err)
-	require.Nil(t, actual.Data)
-	// Chain 10 has neither verified nor optimistic data, so it should be absent
-	require.NotContains(t, actual.OptimisticAtTimestamp, eth.ChainIDFromUInt64(10))
-	require.Contains(t, actual.OptimisticAtTimestamp, eth.ChainIDFromUInt64(11))
-}
-
-func TestSuperroot_AtTimestamp_ErrorOnOptimisticAtWhenVerifiedNotFound(t *testing.T) {
-	t.Parallel()
-	chains := map[eth.ChainID]cc.ChainContainer{
-		eth.ChainIDFromUInt64(10): &mockCC{
-			verifiedErr:   fmt.Errorf("nope: %w", ethereum.NotFound),
-			optimisticErr: assertErr(),
-		},
-	}
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	_, err := api.AtTimestamp(context.Background(), 123)
-	require.Error(t, err)
-}
-
-func TestSuperroot_AtTimestamp_ErrorOnOutputRoot(t *testing.T) {
-	t.Parallel()
-	chains := map[eth.ChainID]cc.ChainContainer{
-		eth.ChainIDFromUInt64(10): &mockCC{
-			verL2:     eth.BlockID{Number: 100},
-			outputErr: assertErr(),
-		},
-	}
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	_, err := api.AtTimestamp(context.Background(), 123)
-	require.Error(t, err)
-}
-
-func TestSuperroot_AtTimestamp_ErrorOnOptimisticAt(t *testing.T) {
-	t.Parallel()
-	chains := map[eth.ChainID]cc.ChainContainer{
-		eth.ChainIDFromUInt64(10): &mockCC{
-			verL2:         eth.BlockID{Number: 100},
-			output:        eth.Bytes32{1},
-			optimisticErr: assertErr(),
-		},
-	}
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	_, err := api.AtTimestamp(context.Background(), 123)
-	require.Error(t, err)
-}
-
-func TestSuperroot_AtTimestamp_EmptyChains(t *testing.T) {
-	t.Parallel()
-	chains := map[eth.ChainID]cc.ChainContainer{}
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	out, err := api.AtTimestamp(context.Background(), 123)
-	require.NoError(t, err)
-	require.Len(t, out.OptimisticAtTimestamp, 0)
 }
 
 func TestSuperroot_AtTimestamp_VerifierL1ReducesCurrentL1(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
-			verL2:  eth.BlockID{Number: 100},
-			verL1:  eth.BlockID{Number: 1000},
-			optL2:  eth.BlockID{Number: 100},
-			optL1:  eth.BlockID{Number: 1000},
-			output: eth.Bytes32{},
-			status: &eth.SyncStatus{
-				CurrentL1: eth.L1BlockRef{Number: 2000},
-			},
-			// Verifier has only processed up to L1 block 1500, which is less than derivation's 2000
+			optL2:       eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:       eth.BlockID{Number: 1000},
+			status:      &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
 			verifierL1s: []eth.BlockID{{Number: 1500}},
 		},
 	}
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	out, err := api.AtTimestamp(context.Background(), 123)
+	s := newSuperroot(chains, preInteropReader())
+	out, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
-	// CurrentL1 should be 1500 (verifier), not 2000 (derivation)
 	require.Equal(t, uint64(1500), out.CurrentL1.Number)
 }
 
@@ -365,24 +208,359 @@ func TestSuperroot_AtTimestamp_VerifierL1HigherThanDerivationDoesNotIncrease(t *
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
-			verL2:  eth.BlockID{Number: 100},
-			verL1:  eth.BlockID{Number: 1000},
-			optL2:  eth.BlockID{Number: 100},
-			optL1:  eth.BlockID{Number: 1000},
-			output: eth.Bytes32{},
-			status: &eth.SyncStatus{
-				CurrentL1: eth.L1BlockRef{Number: 2000},
-			},
-			// Verifier is ahead of derivation — should not increase the minimum
+			optL2:       eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:       eth.BlockID{Number: 1000},
+			status:      &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
 			verifierL1s: []eth.BlockID{{Number: 3000}},
 		},
 	}
-	s := New(gethlog.New(), chains)
-	api := &superrootAPI{s: s}
-	out, err := api.AtTimestamp(context.Background(), 123)
+	s := newSuperroot(chains, preInteropReader())
+	out, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
-	// CurrentL1 should still be 2000 (derivation), since verifier is ahead
 	require.Equal(t, uint64(2000), out.CurrentL1.Number)
+}
+
+func TestSuperroot_AtTimestamp_EmptyChains(t *testing.T) {
+	t.Parallel()
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	s := newSuperroot(chains, preInteropReader())
+	out, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.Len(t, out.OptimisticAtTimestamp, 0)
+}
+
+// ------ Post-interop verified-branch tests ------
+
+func TestSuperroot_AtTimestamp_VerifiedFromDB(t *testing.T) {
+	t.Parallel()
+	hashA := common.HexToHash("0x000000000000000000000000000000000000000000000000000000000000000a")
+	hashB := common.HexToHash("0x000000000000000000000000000000000000000000000000000000000000000b")
+	chainA := eth.ChainIDFromUInt64(10)
+	chainB := eth.ChainIDFromUInt64(420)
+	outA := eth.Bytes32{0xaa}
+	outB := eth.Bytes32{0xbb}
+	chains := map[eth.ChainID]cc.ChainContainer{
+		chainA: &mockCC{
+			optL2:          eth.BlockID{Number: 100, Hash: hashA},
+			optL1:          eth.BlockID{Number: 900},
+			byHashOutputs:  map[common.Hash]eth.Bytes32{hashA: outA},
+			byHashFallback: eth.Bytes32{0xee},
+			status:         &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+		chainB: &mockCC{
+			optL2:          eth.BlockID{Number: 200, Hash: hashB},
+			optL1:          eth.BlockID{Number: 950},
+			byHashOutputs:  map[common.Hash]eth.Bytes32{hashB: outB},
+			byHashFallback: eth.Bytes32{0xee},
+			status:         &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
+		},
+	}
+	reader := &mockVerifiedReader{
+		result: interop.VerifiedResult{
+			Timestamp:   123,
+			L1Inclusion: eth.BlockID{Number: 1100},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chainA: {Number: 100, Hash: hashA},
+				chainB: {Number: 200, Hash: hashB},
+			},
+		},
+	}
+	s := newSuperroot(chains, reader)
+	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Data)
+	expected := eth.SuperRoot(eth.NewSuperV1(123,
+		eth.ChainIDAndOutput{ChainID: chainA, Output: outA},
+		eth.ChainIDAndOutput{ChainID: chainB, Output: outB}))
+	require.Equal(t, expected, resp.Data.SuperRoot)
+	require.Equal(t, uint64(1100), resp.Data.VerifiedRequiredL1.Number)
+}
+
+func TestSuperroot_AtTimestamp_VerifiedDBMiss(t *testing.T) {
+	t.Parallel()
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): &mockCC{
+			optL2:  eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:  eth.BlockID{Number: 900},
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+	}
+	mock := chains[eth.ChainIDFromUInt64(10)].(*mockCC)
+	s := newSuperroot(chains, activeUnverifiedReader())
+	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.Nil(t, resp.Data, "Data must be nil for active-but-not-yet-verified")
+	require.Equal(t, 0, mock.byHashCalled, "OutputRootAtL2BlockHash must not be called when Data is nil")
+}
+
+func TestSuperroot_AtTimestamp_OutputRootByHashFails(t *testing.T) {
+	t.Parallel()
+	hashA := common.HexToHash("0x0a")
+	chainA := eth.ChainIDFromUInt64(10)
+	chains := map[eth.ChainID]cc.ChainContainer{
+		chainA: &mockCC{
+			optL2:     eth.BlockID{Number: 100, Hash: hashA},
+			optL1:     eth.BlockID{Number: 900},
+			byHashErr: ethereum.NotFound,
+			status:    &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+	}
+	reader := &mockVerifiedReader{
+		result: interop.VerifiedResult{
+			Timestamp:   123,
+			L1Inclusion: eth.BlockID{Number: 1000},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chainA: {Number: 100, Hash: hashA}},
+		},
+	}
+	s := newSuperroot(chains, reader)
+	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.Error(t, err, "transient EL-by-hash failure must surface as transport error")
+}
+
+func TestSuperroot_AtTimestamp_DepSetSizeMismatch(t *testing.T) {
+	t.Parallel()
+	chainA := eth.ChainIDFromUInt64(10)
+	chainB := eth.ChainIDFromUInt64(420)
+	chains := map[eth.ChainID]cc.ChainContainer{
+		chainA: &mockCC{
+			optL2:  eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:  eth.BlockID{Number: 900},
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+		chainB: &mockCC{
+			optL2:  eth.BlockID{Number: 200, Hash: common.HexToHash("0x02")},
+			optL1:  eth.BlockID{Number: 950},
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
+		},
+	}
+	// VerifiedResult covers only one of the two chains in s.chains.
+	reader := &mockVerifiedReader{
+		result: interop.VerifiedResult{
+			Timestamp:   123,
+			L1Inclusion: eth.BlockID{Number: 1000},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chainA: {Number: 100, Hash: common.HexToHash("0x01")}},
+		},
+	}
+	s := newSuperroot(chains, reader)
+	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dep-set size mismatch")
+}
+
+func TestSuperroot_AtTimestamp_DepSetKeyMismatch(t *testing.T) {
+	t.Parallel()
+	chainA := eth.ChainIDFromUInt64(10)
+	chainB := eth.ChainIDFromUInt64(420)
+	chainC := eth.ChainIDFromUInt64(999)
+	chains := map[eth.ChainID]cc.ChainContainer{
+		chainA: &mockCC{
+			optL2:  eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:  eth.BlockID{Number: 900},
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+		chainB: &mockCC{
+			optL2:  eth.BlockID{Number: 200, Hash: common.HexToHash("0x02")},
+			optL1:  eth.BlockID{Number: 950},
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
+		},
+	}
+	// Same length as s.chains, but a different chain ID.
+	reader := &mockVerifiedReader{
+		result: interop.VerifiedResult{
+			Timestamp:   123,
+			L1Inclusion: eth.BlockID{Number: 1000},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chainA: {Number: 100, Hash: common.HexToHash("0x01")},
+				chainC: {Number: 200, Hash: common.HexToHash("0x02")},
+			},
+		},
+	}
+	s := newSuperroot(chains, reader)
+	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing chain")
+}
+
+func TestSuperroot_AtTimestamp_RewindRaceCouplingCheck(t *testing.T) {
+	t.Parallel()
+	hashA := common.HexToHash("0x0a")
+	chainA := eth.ChainIDFromUInt64(10)
+	chains := map[eth.ChainID]cc.ChainContainer{
+		chainA: &mockCC{
+			optL2:          eth.BlockID{Number: 100, Hash: hashA},
+			optL1:          eth.BlockID{Number: 900},
+			byHashOutputs:  map[common.Hash]eth.Bytes32{hashA: {0xaa}},
+			byHashFallback: eth.Bytes32{0xee},
+			// Simulate the mid-rewind state: i.currentL1 has been dropped to zero
+			// while verifiedDB still has the entry.
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 500}},
+		},
+	}
+	reader := &mockVerifiedReader{
+		result: interop.VerifiedResult{
+			Timestamp:   123,
+			L1Inclusion: eth.BlockID{Number: 1000},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chainA: {Number: 100, Hash: hashA}},
+		},
+	}
+	s := newSuperroot(chains, reader)
+	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rewind in flight")
+}
+
+func TestSuperroot_AtTimestamp_VerifiedReaderError(t *testing.T) {
+	t.Parallel()
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): &mockCC{
+			optL2:  eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:  eth.BlockID{Number: 900},
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+	}
+	reader := &mockVerifiedReader{err: errors.New("verifiedDB bbolt corrupted")}
+	s := newSuperroot(chains, reader)
+	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.Error(t, err)
+}
+
+func TestSuperroot_AtTimestamp_OptimisticErrorFailsRPC_VerifiedHit(t *testing.T) {
+	t.Parallel()
+	hashA := common.HexToHash("0x0a")
+	chainA := eth.ChainIDFromUInt64(10)
+	chains := map[eth.ChainID]cc.ChainContainer{
+		chainA: &mockCC{
+			optimisticErr:  fmt.Errorf("EL transient: %w", context.DeadlineExceeded),
+			byHashOutputs:  map[common.Hash]eth.Bytes32{hashA: {0xaa}},
+			byHashFallback: eth.Bytes32{0xee},
+			status:         &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+	}
+	reader := &mockVerifiedReader{
+		result: interop.VerifiedResult{
+			Timestamp:   123,
+			L1Inclusion: eth.BlockID{Number: 1000},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chainA: {Number: 100, Hash: hashA}},
+		},
+	}
+	s := newSuperroot(chains, reader)
+	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.Error(t, err, "optimistic-branch transport error must fail the RPC even with a verified hit (silently emitting a partial map would corrupt op-challenger step>0 logic)")
+}
+
+func TestSuperroot_AtTimestamp_OptimisticErrorFailsRPC_UnverifiedMiss(t *testing.T) {
+	t.Parallel()
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): &mockCC{
+			optimisticErr: fmt.Errorf("EL transient: %w", context.DeadlineExceeded),
+			status:        &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+	}
+	s := newSuperroot(chains, activeUnverifiedReader())
+	_, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.Error(t, err)
+}
+
+// ------ Pre-interop fallback tests ------
+
+func TestSuperroot_AtTimestamp_PreInteropFallback_NoopReader(t *testing.T) {
+	t.Parallel()
+	chainA := eth.ChainIDFromUInt64(10)
+	chainB := eth.ChainIDFromUInt64(420)
+	chains := map[eth.ChainID]cc.ChainContainer{
+		chainA: &mockCC{
+			optL2:     eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:     eth.BlockID{Number: 900},
+			optOutput: &eth.OutputV0{StateRoot: eth.Bytes32{0x01}},
+			status:    &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+		chainB: &mockCC{
+			optL2:     eth.BlockID{Number: 200, Hash: common.HexToHash("0x02")},
+			optL1:     eth.BlockID{Number: 950},
+			optOutput: &eth.OutputV0{StateRoot: eth.Bytes32{0x02}},
+			status:    &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
+		},
+	}
+	mockA := chains[chainA].(*mockCC)
+	mockB := chains[chainB].(*mockCC)
+	s := newSuperroot(chains, preInteropReader())
+	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Data)
+	// VerifiedRequiredL1 is max(optL1).
+	require.Equal(t, uint64(950), resp.Data.VerifiedRequiredL1.Number)
+	// Data.Super.Chains[c].Output must byte-equal OptimisticAtTimestamp[c].OutputRoot
+	// because the pre-interop path reuses the optimistic map.
+	for _, c := range resp.Data.Super.(*eth.SuperV1).Chains {
+		require.Equal(t, resp.OptimisticAtTimestamp[c.ChainID].OutputRoot, c.Output,
+			"pre-interop Data.Super.Chains[c].Output must byte-equal OptimisticAtTimestamp[c].OutputRoot")
+	}
+	// No second per-chain by-hash fetch — pre-interop reuses optimistic data.
+	require.Equal(t, 0, mockA.byHashCalled)
+	require.Equal(t, 0, mockB.byHashCalled)
+}
+
+func TestSuperroot_AtTimestamp_PreInteropFallback_OptimisticMapShort(t *testing.T) {
+	t.Parallel()
+	chainA := eth.ChainIDFromUInt64(10)
+	chainB := eth.ChainIDFromUInt64(420)
+	chains := map[eth.ChainID]cc.ChainContainer{
+		chainA: &mockCC{
+			optL2:     eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:     eth.BlockID{Number: 900},
+			optOutput: &eth.OutputV0{StateRoot: eth.Bytes32{0x01}},
+			status:    &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+		chainB: &mockCC{
+			// Chain B hasn't derived T yet.
+			optimisticErr: ethereum.NotFound,
+			status:        &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
+		},
+	}
+	s := newSuperroot(chains, preInteropReader())
+	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.Nil(t, resp.Data, "Data must be nil when at least one chain hasn't derived T")
+	require.Contains(t, resp.OptimisticAtTimestamp, chainA)
+	require.NotContains(t, resp.OptimisticAtTimestamp, chainB)
+}
+
+func TestSuperroot_AtTimestamp_PreInteropFallback_BelowActivation(t *testing.T) {
+	t.Parallel()
+	chainA := eth.ChainIDFromUInt64(10)
+	chains := map[eth.ChainID]cc.ChainContainer{
+		chainA: &mockCC{
+			optL2:     eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:     eth.BlockID{Number: 900},
+			optOutput: &eth.OutputV0{StateRoot: eth.Bytes32{0x01}},
+			status:    &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+	}
+	reader := &mockVerifiedReader{err: interop.ErrNotActive}
+	s := newSuperroot(chains, reader)
+	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Data)
+}
+
+func TestSuperroot_AtTimestamp_PreInteropFallback_NoSecondFetch(t *testing.T) {
+	t.Parallel()
+	chainA := eth.ChainIDFromUInt64(10)
+	chains := map[eth.ChainID]cc.ChainContainer{
+		chainA: &mockCC{
+			optL2:     eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+			optL1:     eth.BlockID{Number: 900},
+			optOutput: &eth.OutputV0{StateRoot: eth.Bytes32{0x01}},
+			// Setting byHashErr proves the pre-interop fallback does NOT call
+			// OutputRootAtL2BlockHash — otherwise the test would fail.
+			byHashErr: fmt.Errorf("BUG: pre-interop fallback must not call by-hash"),
+			status:    &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+		},
+	}
+	s := newSuperroot(chains, preInteropReader())
+	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Data)
 }
 
 // assertErr returns a generic error instance used to signal mock failures.

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -49,9 +49,14 @@ type ChainContainer interface {
 	TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error)
 	BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error)
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
-	VerifiedAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
 	OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
-	OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error)
+	// OutputRootAtL2BlockHash returns the L2 output root for the canonical block
+	// at the given hash. Reading by hash binds the answer to a consensus-determined
+	// block payload; the same hash always yields the same OutputV0 (post-Isthmus
+	// from header alone; pre-Isthmus via eth_getProof on state at that block).
+	// If the EL does not have that hash on its canonical chain, returns
+	// ethereum.NotFound or a transport-level error.
+	OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error)
 	OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputV0, error)
 	RegisterVerifier(v activity.VerificationActivity)
 	// VerifierCurrentL1s returns the CurrentL1 from each registered verifier.
@@ -462,12 +467,15 @@ func (c *simpleChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus,
 	return st, nil
 }
 
-// OutputRootAtL2BlockNumber computes the L2 output root for the specified L2 block number.
-func (c *simpleChainContainer) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
+// OutputRootAtL2BlockHash computes the L2 output root for the specified L2 block hash.
+// Reading by hash pins the answer to a consensus-determined block payload — the same
+// hash always yields the same OutputV0 — eliminating the per-call drift the by-number
+// variant could exhibit when the EL reorgs at the requested height.
+func (c *simpleChainContainer) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
 	if c.engine == nil {
 		return eth.Bytes32{}, engine_controller.ErrNoEngineClient
 	}
-	out, err := c.engine.OutputV0AtBlockNumber(ctx, l2BlockNum)
+	out, err := c.engine.OutputV0ByBlockHash(ctx, blockHash)
 	if err != nil {
 		return eth.Bytes32{}, err
 	}
@@ -499,38 +507,6 @@ func (c *simpleChainContainer) safeDBAtL2(ctx context.Context, l2 eth.BlockID) (
 		return eth.BlockID{}, err
 	}
 	return l1, nil
-}
-
-// VerifiedAt returns the verified L2 and L1 blocks for the given L2 timestamp.
-// Must return ethereum.NotFound if there is no safe block at the specified timestamp.
-func (c *simpleChainContainer) VerifiedAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error) {
-	l2Block, err := c.LocalSafeBlockAtTimestamp(ctx, ts)
-	if err != nil {
-		c.log.Error("error determining l2 block at given timestamp", "error", err)
-		return eth.BlockID{}, eth.BlockID{}, err
-	}
-	l1Block, err := c.safeDBAtL2(ctx, l2Block.ID())
-	if err != nil {
-		c.log.Error("error determining l1 block number at which l2 block became safe", "error", err)
-		return eth.BlockID{}, eth.BlockID{}, err
-	}
-
-	c.verifiersMu.RLock()
-	verifiers := append([]activity.VerificationActivity(nil), c.verifiers...)
-	c.verifiersMu.RUnlock()
-	for _, verifier := range verifiers {
-		verified, err := verifier.VerifiedAtTimestamp(ts)
-		if err != nil {
-			c.log.Error("error checking if data could be verified at this L1", "error", err)
-			return eth.BlockID{}, eth.BlockID{}, err
-		}
-		if !verified {
-			c.log.Error("verifier does not have data at this timestamp. cannot supply block at this timestamp as verified", "verifier", verifier.Name())
-			return eth.BlockID{}, eth.BlockID{}, fmt.Errorf("verifier %s does not have data at this timestamp: %w", verifier.Name(), ethereum.NotFound)
-		}
-	}
-
-	return l2Block.ID(), l1Block, nil
 }
 
 // OptimisticAt returns the optimistic (pre-verified) L2 and L1 blocks for the given L2 timestamp.

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -50,12 +50,11 @@ type ChainContainer interface {
 	BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error)
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
-	// OutputRootAtL2BlockHash returns the L2 output root for the canonical block
-	// at the given hash. Reading by hash binds the answer to a consensus-determined
-	// block payload; the same hash always yields the same OutputV0 (post-Isthmus
-	// from header alone; pre-Isthmus via eth_getProof on state at that block).
-	// If the EL does not have that hash on its canonical chain, returns
-	// ethereum.NotFound or a transport-level error.
+	// OutputRootAtL2BlockHash returns the L2 output root for the canonical
+	// block at the given hash. Post-Isthmus the root is derived from the
+	// header alone; pre-Isthmus it falls back to eth_getProof on state at
+	// that block. Returns ethereum.NotFound if the EL no longer has the
+	// block at that hash on its canonical chain.
 	OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error)
 	OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputV0, error)
 	RegisterVerifier(v activity.VerificationActivity)
@@ -467,10 +466,6 @@ func (c *simpleChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus,
 	return st, nil
 }
 
-// OutputRootAtL2BlockHash computes the L2 output root for the specified L2 block hash.
-// Reading by hash pins the answer to a consensus-determined block payload — the same
-// hash always yields the same OutputV0 — eliminating the per-call drift the by-number
-// variant could exhibit when the EL reorgs at the requested height.
 func (c *simpleChainContainer) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
 	if c.engine == nil {
 		return eth.Bytes32{}, engine_controller.ErrNoEngineClient

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -168,36 +168,6 @@ func (m *mockEngineController) Close() error {
 
 var _ engine_controller.EngineController = (*mockEngineController)(nil)
 
-// mockVerificationActivity is a mock implementation of activity.VerificationActivity
-type mockVerificationActivity struct {
-	name                      string
-	currentL1Result           eth.BlockID
-	verifiedAtTimestampResult bool
-	verifiedAtTimestampErr    error
-}
-
-func (m *mockVerificationActivity) Name() string {
-	return m.name
-}
-
-func (m *mockVerificationActivity) CurrentL1() eth.BlockID {
-	return m.currentL1Result
-}
-
-func (m *mockVerificationActivity) VerifiedAtTimestamp(ts uint64) (bool, error) {
-	return m.verifiedAtTimestampResult, m.verifiedAtTimestampErr
-}
-
-func (m *mockVerificationActivity) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
-	return eth.BlockID{}, 0
-}
-func (m *mockVerificationActivity) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock eth.BlockRef) {
-}
-func (m *mockVerificationActivity) VerifiedBlockAtL1(chainID eth.ChainID, l1BlockRef eth.L1BlockRef) (eth.BlockID, uint64) {
-	return eth.BlockID{}, 0
-}
-func (m *mockVerificationActivity) IsActiveAt(ts uint64) bool { return true }
-
 // Test helpers
 func createTestVNConfig() *opnodecfg.Config {
 	return &opnodecfg.Config{

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -154,6 +154,10 @@ func (m *mockEngineController) OutputV0AtBlockNumber(ctx context.Context, num ui
 	return nil, nil
 }
 
+func (m *mockEngineController) OutputV0ByBlockHash(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
+	return nil, nil
+}
+
 func (m *mockEngineController) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
 	return nil, nil, nil
 }
@@ -962,57 +966,6 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return setHandlerCalled && calledChainID == "420"
 		}, 1*time.Second, 10*time.Millisecond)
-	})
-}
-
-// TestChainContainer_VerifiedAt tests the VerifiedAt method
-func TestChainContainer_VerifiedAt(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	vncfg := createTestVNConfig()
-	log := createTestLogger(t)
-	cfg := createTestCLIConfig(t.TempDir())
-	initOverload := &rollupNode.InitializationOverrides{}
-
-	t.Run("returns error when verification activity reports not verified", func(t *testing.T) {
-		// Create a mock verification activity that returns verified=false
-		mockVerifier := &mockVerificationActivity{
-			name:                      "test-verifier",
-			verifiedAtTimestampResult: false, // not verified
-			verifiedAtTimestampErr:    nil,
-		}
-
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
-		impl, ok := container.(*simpleChainContainer)
-		require.True(t, ok)
-
-		container.RegisterVerifier(mockVerifier)
-
-		// Set up mock engine controller
-		mockEngine := &mockEngineController{
-			l2BlockRefByNumberResult: eth.L2BlockRef{
-				Hash:   [32]byte{1},
-				Number: 100,
-			},
-			l2BlockRefByNumberErr: nil,
-		}
-		impl.engine = mockEngine
-
-		// Set up mock virtual node for safeDBAtL2
-		mockVN := newMockVirtualNode()
-		mockVN.safeHeadL1 = eth.BlockID{Hash: [32]byte{2}, Number: 50}
-		mockVN.safeHeadErr = nil
-		impl.vn = mockVN
-
-		ctx := context.Background()
-		l2, l1, err := container.VerifiedAt(ctx, 1000)
-
-		// Should return an error when verification fails
-		require.Error(t, err)
-		require.ErrorIs(t, err, ethereum.NotFound)
-		require.Equal(t, eth.BlockID{}, l2)
-		require.Equal(t, eth.BlockID{}, l1)
 	})
 }
 

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -22,12 +22,9 @@ type EngineController interface {
 	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 	// OutputV0AtBlockNumber returns the output preimage for the given L2 block number.
 	OutputV0AtBlockNumber(ctx context.Context, num uint64) (*eth.OutputV0, error)
-	// OutputV0ByBlockHash returns the output preimage for the given L2 block hash.
-	// Locking the read to a hash (rather than a number) yields a consensus-bound
-	// answer: the same hash always maps to the same canonical block, so the
-	// returned OutputV0 cannot drift across calls. If the EL no longer has the
-	// block at the requested hash on its canonical chain, the underlying RPCs
-	// return ethereum.NotFound or a transport error.
+	// OutputV0ByBlockHash returns the output preimage for the given L2 block
+	// hash. Returns ethereum.NotFound if the EL no longer has the block at
+	// that hash on its canonical chain.
 	OutputV0ByBlockHash(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error)
 	// RewindToTimestamp rewinds the L2 execution layer to block at or before the given timestamp.
 	RewindToTimestamp(ctx context.Context, timestamp uint64) error

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -22,6 +22,13 @@ type EngineController interface {
 	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 	// OutputV0AtBlockNumber returns the output preimage for the given L2 block number.
 	OutputV0AtBlockNumber(ctx context.Context, num uint64) (*eth.OutputV0, error)
+	// OutputV0ByBlockHash returns the output preimage for the given L2 block hash.
+	// Locking the read to a hash (rather than a number) yields a consensus-bound
+	// answer: the same hash always maps to the same canonical block, so the
+	// returned OutputV0 cannot drift across calls. If the EL no longer has the
+	// block at the requested hash on its canonical chain, the underlying RPCs
+	// return ethereum.NotFound or a transport error.
+	OutputV0ByBlockHash(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error)
 	// RewindToTimestamp rewinds the L2 execution layer to block at or before the given timestamp.
 	RewindToTimestamp(ctx context.Context, timestamp uint64) error
 	// FetchReceipts fetches the receipts for a given block by hash.
@@ -35,7 +42,9 @@ type l2Provider interface {
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
 	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 	OutputV0AtBlockNumber(ctx context.Context, blockNum uint64) (*eth.OutputV0, error)
+	OutputV0AtBlock(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error)
 	PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error)
+	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
 	ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
 	NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
@@ -155,6 +164,22 @@ func (e *simpleEngineController) OutputV0AtBlockNumber(ctx context.Context, num 
 		e.log.Debug("engine_controller: falling back to proof-based OutputV0", "blockNumber", num)
 	}
 	return e.l2.OutputV0AtBlockNumber(ctx, num)
+}
+
+func (e *simpleEngineController) OutputV0ByBlockHash(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
+	if e.l2 == nil {
+		return nil, ErrNoEngineClient
+	}
+	env, err := e.l2.PayloadByHash(ctx, blockHash)
+	if err == nil && env != nil && env.ExecutionPayload != nil && env.ExecutionPayload.WithdrawalsRoot != nil {
+		p := env.ExecutionPayload
+		return &eth.OutputV0{
+			StateRoot:                p.StateRoot,
+			MessagePasserStorageRoot: eth.Bytes32(*p.WithdrawalsRoot),
+			BlockHash:                p.BlockHash,
+		}, nil
+	}
+	return e.l2.OutputV0AtBlock(ctx, blockHash)
 }
 
 func (e *simpleEngineController) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
@@ -2,10 +2,12 @@ package engine_controller
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
@@ -46,6 +48,86 @@ func TestOutputV0AtBlockNumber_FallsBackWithoutWithdrawalsRoot(t *testing.T) {
 	require.NotNil(t, out)
 	require.Equal(t, 1, l2.payloadCalls)
 	require.Equal(t, 1, l2.outputCalls)
+}
+
+func TestOutputV0ByBlockHash_PostIsthmus(t *testing.T) {
+	t.Parallel()
+	hash := common.Hash{0xaa}
+	l2 := &mockL2{
+		payload: &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{
+			StateRoot:       eth.Bytes32{0xaa},
+			WithdrawalsRoot: func() *common.Hash { h := common.Hash{0xbb}; return &h }(),
+			BlockHash:       hash,
+		}},
+	}
+	ec := &simpleEngineController{l2: l2, rollup: &rollup.Config{}, log: gethlog.New()}
+	out, err := ec.OutputV0ByBlockHash(context.Background(), hash)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.Equal(t, hash, out.BlockHash)
+	require.Equal(t, 1, l2.payloadCalls)
+	require.Equal(t, 0, l2.outputCalls) // post-Isthmus: no eth_getProof fallback
+}
+
+func TestOutputV0ByBlockHash_PreIsthmus(t *testing.T) {
+	t.Parallel()
+	hash := common.Hash{0xaa}
+	l2 := &mockL2{
+		// pre-Isthmus: payload has nil WithdrawalsRoot, forces fallback to eth_getProof
+		payload: &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{BlockHash: hash}},
+		output:  &eth.OutputV0{StateRoot: eth.Bytes32{0x01}, MessagePasserStorageRoot: eth.Bytes32{0x02}, BlockHash: hash},
+	}
+	ec := &simpleEngineController{l2: l2, rollup: &rollup.Config{}, log: gethlog.New()}
+	out, err := ec.OutputV0ByBlockHash(context.Background(), hash)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.Equal(t, 1, l2.payloadCalls)
+	require.Equal(t, 1, l2.outputCalls)
+}
+
+func TestOutputV0ByBlockHash_PayloadError(t *testing.T) {
+	t.Parallel()
+	hash := common.Hash{0xaa}
+	l2 := &mockL2{
+		payloadErr: fmt.Errorf("payload fetch failed"),
+		output:     &eth.OutputV0{BlockHash: hash},
+	}
+	ec := &simpleEngineController{l2: l2, rollup: &rollup.Config{}, log: gethlog.New()}
+	out, err := ec.OutputV0ByBlockHash(context.Background(), hash)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.Equal(t, 1, l2.payloadCalls)
+	require.Equal(t, 1, l2.outputCalls) // fell back when PayloadByHash errored
+}
+
+func TestOutputV0ByBlockHash_NotFound(t *testing.T) {
+	t.Parallel()
+	hash := common.Hash{0xaa}
+	l2 := &mockL2{
+		payloadErr: ethereum.NotFound,
+		outputErr:  ethereum.NotFound,
+	}
+	ec := &simpleEngineController{l2: l2, rollup: &rollup.Config{}, log: gethlog.New()}
+	out, err := ec.OutputV0ByBlockHash(context.Background(), hash)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ethereum.NotFound)
+	require.Nil(t, out)
+}
+
+func TestOutputV0ByBlockHash_PreIsthmus_StatePruned(t *testing.T) {
+	t.Parallel()
+	hash := common.Hash{0xaa}
+	// Pre-Isthmus payload (nil WithdrawalsRoot) → falls through to
+	// l2.OutputV0AtBlock, which errors because the EL has pruned state.
+	// The transport error must propagate; it must NOT be silently swallowed.
+	l2 := &mockL2{
+		payload:   &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{BlockHash: hash}},
+		outputErr: fmt.Errorf("eth_getProof: missing trie node"),
+	}
+	ec := &simpleEngineController{l2: l2, rollup: &rollup.Config{}, log: gethlog.New()}
+	_, err := ec.OutputV0ByBlockHash(context.Background(), hash)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "eth_getProof")
 }
 
 type mockL2 struct {
@@ -137,6 +219,10 @@ func (m *mockL2) OutputV0AtBlockNumber(ctx context.Context, blockNum uint64) (*e
 	m.outputCalls++
 	return m.output, m.outputErr
 }
+func (m *mockL2) OutputV0AtBlock(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
+	m.outputCalls++
+	return m.output, m.outputErr
+}
 func (m *mockL2) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
 	m.payloadCalls++
 	if m.payloadsByNumber != nil {
@@ -144,6 +230,10 @@ func (m *mockL2) PayloadByNumber(ctx context.Context, number uint64) (*eth.Execu
 			return payload, nil
 		}
 	}
+	return m.payload, m.payloadErr
+}
+func (m *mockL2) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	m.payloadCalls++
 	return m.payload, m.payloadErr
 }
 func (m *mockL2) ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, payloadAttributes *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -305,6 +305,10 @@ func (m *mockEngineForInvalidation) OutputV0AtBlockNumber(ctx context.Context, n
 	return nil, nil
 }
 
+func (m *mockEngineForInvalidation) OutputV0ByBlockHash(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
+	return nil, nil
+}
+
 func (m *mockEngineForInvalidation) RewindToTimestamp(ctx context.Context, timestamp uint64) error {
 	m.rewindCalled = true
 	m.rewindTimestamp = timestamp

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -112,13 +112,10 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		narrowChains[id] = c
 	}
 
-	// Initialize fixed activities
-	s.activities = []activity.Activity{
-		heartbeat.New(log.New("activity", "heartbeat"), 10*time.Second),
-		supernodeactivity.New(log.New("activity", "supernode"), narrowChains),
-		superroot.New(log.New("activity", "superroot"), narrowChains),
-	}
-
+	// Resolve interop activation first so the verified-result reader is available
+	// before Superroot is constructed. Superroot now requires an
+	// interop.VerifiedResultReader; when interop is not configured, the no-op
+	// reader routes every call into the pre-interop fallback.
 	interopActivationTimestamp, err := resolveInteropActivationTimestamp(cfg.InteropActivationTimestamp, vnCfgs)
 	if err != nil {
 		return nil, fmt.Errorf("resolve interop activation timestamp: %w", err)
@@ -129,10 +126,10 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	}
 
 	log.Info("initializing interop activity", "enabled", interopActivationTimestamp != nil)
-	// Initialize interop activity if the activation timestamp is known (non-nil).
-	// If it's nil, don't start interop. If it's non-nil (including 0), do start it.
+
+	var verifiedReader interop.VerifiedResultReader = interop.NoopVerifiedResultReader{}
+	var interopActivity *interop.Interop
 	if interopActivationTimestamp != nil {
-		// Extract the message expiry window from the first virtual node's dependency set.
 		var msgExpiryWindow uint64
 		for _, vnCfg := range vnCfgs {
 			if vnCfg.DependencySet != nil {
@@ -140,13 +137,25 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 				break
 			}
 		}
-		interopActivity := interop.New(log.New("activity", "interop"), *interopActivationTimestamp, msgExpiryWindow, s.chains, cfg.DataDir, s.l1Client, cfg.InteropLogBackfillDepth, s.supernodeMetrics)
+		interopActivity = interop.New(log.New("activity", "interop"), *interopActivationTimestamp, msgExpiryWindow, s.chains, cfg.DataDir, s.l1Client, cfg.InteropLogBackfillDepth, s.supernodeMetrics)
+		verifiedReader = interopActivity
+		s.interopActivationTs = interopActivationTimestamp
+		s.interopMsgExpiryWindow = msgExpiryWindow
+	}
+
+	// Initialize fixed activities. Order in this slice governs Start/Stop
+	// ordering; interop is appended below so it starts after the RPC servers.
+	s.activities = []activity.Activity{
+		heartbeat.New(log.New("activity", "heartbeat"), 10*time.Second),
+		supernodeactivity.New(log.New("activity", "supernode"), narrowChains),
+		superroot.New(log.New("activity", "superroot"), narrowChains, verifiedReader),
+	}
+
+	if interopActivity != nil {
 		s.activities = append(s.activities, interopActivity)
 		for _, chain := range s.chains {
 			chain.RegisterVerifier(interopActivity)
 		}
-		s.interopActivationTs = interopActivationTimestamp
-		s.interopMsgExpiryWindow = msgExpiryWindow
 	}
 
 	// Set up reset callbacks on all chain containers

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -112,10 +112,9 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		narrowChains[id] = c
 	}
 
-	// Resolve interop activation first so the verified-result reader is available
-	// before Superroot is constructed. Superroot now requires an
-	// interop.VerifiedResultReader; when interop is not configured, the no-op
-	// reader routes every call into the pre-interop fallback.
+	// Resolve interop activation before constructing Superroot so the
+	// verified-result reader is available. When interop is not configured,
+	// the no-op reader routes every call into the pre-interop fallback.
 	interopActivationTimestamp, err := resolveInteropActivationTimestamp(cfg.InteropActivationTimestamp, vnCfgs)
 	if err != nil {
 		return nil, fmt.Errorf("resolve interop activation timestamp: %w", err)
@@ -143,8 +142,8 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		s.interopMsgExpiryWindow = msgExpiryWindow
 	}
 
-	// Initialize fixed activities. Order in this slice governs Start/Stop
-	// ordering; interop is appended below so it starts after the RPC servers.
+	// Order in this slice governs Start/Stop ordering; interop is appended
+	// below so it starts after the RPC servers.
 	s.activities = []activity.Activity{
 		heartbeat.New(log.New("activity", "heartbeat"), 10*time.Second),
 		supernodeactivity.New(log.New("activity", "supernode"), narrowChains),


### PR DESCRIPTION
Closes #18667.

Reworks `superroot_atTimestamp` so the `Data` field is stable for a given timestamp and consistent with `CurrentL1`:

- **Stability** — verified-branch `Data` is sourced from verifiedDB-pinned `(chainID, blockHash)` plus EL-by-hash reads, so subsequent calls for the same T return byte-identical `SuperRoot` and `VerifiedRequiredL1` regardless of EL churn.
- **Regime split** — pre-activation falls back to optimistic outputs (always canonical pre-interop); `T ∈ [activation, firstVerifiable)` falls back to optimistic outputs as well, since the safe-head startup handoff covers ts; `T ≥ firstVerifiable` either returns the verified entry or `Data=nil` with `CurrentL1` communicating verifier progress.
- **Race fix** — `VerifiedResultReader.VerifiedResultAtTimestamp` now returns the verifier's `CurrentL1` captured atomically with the verifiedDB read. The handler reports `min(aggregate.CurrentL1, snapshotL1)` so the response's \`CurrentL1\` cannot overstate verifier progress relative to the verifiedDB observation, closing the window where a rewind or commit between the two reads produced a \`{CurrentL1: high, Data: nil}\` answer that callers would interpret as final.
- **Mid-rewind Data is returned, not errored** — when an entry exists but \`CurrentL1\` has fallen below its \`VerifiedRequiredL1\` (verifier rolled back, entry not yet deleted) the call returns the entry rather than erroring. Callers gate trust on \`CurrentL1 >= VerifiedRequiredL1\` themselves, so returning the preview is more useful than refusing.
- **Pre-Start nil-ctx guard** — Supernode registers each activity's RPC API before scheduling its Start goroutine, so a `superroot_atTimestamp` call can reach the interop reader before `i.ctx` is populated. Added an `ErrNotStarted` sentinel routed to the same optimistic-composition fallback used for `ErrNotActive` / `ErrBeforeVerifiedDB`, so callers get a valid response and can retry once startup completes.

A follow-up bug surfaced during review (optimistic-branch \`RequiredL1\` pairs the original pre-replacement output with the replacement block's L1) is filed separately as #20657; it requires a deny-list schema change and is out of scope here. (Edit: this turned out to not be a bug)