### PR TITLE
fix(kona-host): verify preimage bytes hash to the requested key

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6092,6 +6092,7 @@ dependencies = [
  "async-trait",
  "rkyv",
  "serde",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/rust/kona/bin/host/Cargo.toml
+++ b/rust/kona/bin/host/Cargo.toml
@@ -19,7 +19,7 @@ kona-executor.workspace = true
 kona-std-fpvm.workspace = true
 kona-proof-interop.workspace = true
 kona-proof = { workspace = true, features = ["std"] }
-kona-preimage = { workspace = true, features = ["std"] }
+kona-preimage = { workspace = true, features = ["std", "verify"] }
 
 # Protocol
 kona-driver.workspace = true

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -16,6 +16,7 @@ use kona_genesis::{L1ChainConfig, RollupConfig};
 use kona_interop::DependencySet;
 use kona_preimage::{
     BidirectionalChannel, Channel, HintReader, HintWriter, OracleReader, OracleServer,
+    VerifyingPreimageFetcher,
 };
 use kona_proof_interop::HintType;
 use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
@@ -195,7 +196,7 @@ impl InteropHost {
                 PreimageServer::new(
                     OracleServer::new(preimage),
                     HintReader::new(hint),
-                    Arc::new(OfflineHostBackend::new(kv_store)),
+                    Arc::new(VerifyingPreimageFetcher::new(OfflineHostBackend::new(kv_store))),
                 )
                 .start()
                 .await
@@ -216,7 +217,7 @@ impl InteropHost {
                 PreimageServer::new(
                     OracleServer::new(preimage),
                     HintReader::new(hint),
-                    Arc::new(backend),
+                    Arc::new(VerifyingPreimageFetcher::new(backend)),
                 )
                 .start()
                 .await

--- a/rust/kona/bin/host/src/interop/handler.rs
+++ b/rust/kona/bin/host/src/interop/handler.rs
@@ -21,7 +21,7 @@ use kona_driver::Driver;
 use kona_executor::TrieDBProvider;
 use kona_preimage::{
     BidirectionalChannel, HintReader, HintWriter, OracleReader, OracleServer, PreimageKey,
-    PreimageKeyType,
+    PreimageKeyType, VerifyingPreimageFetcher,
 };
 use kona_proof::{
     CachingOracle, Hint,
@@ -540,7 +540,7 @@ impl HintHandler for InteropHintHandler {
                     PreimageServer::new(
                         OracleServer::new(preimage.host),
                         HintReader::new(hint.host),
-                        Arc::new(backend),
+                        Arc::new(VerifyingPreimageFetcher::new(backend)),
                     )
                     .start(),
                 );

--- a/rust/kona/bin/host/src/single/cfg.rs
+++ b/rust/kona/bin/host/src/single/cfg.rs
@@ -15,6 +15,7 @@ use kona_cli::cli_styles;
 use kona_genesis::{L1ChainConfig, RollupConfig};
 use kona_preimage::{
     BidirectionalChannel, Channel, HintReader, HintWriter, OracleReader, OracleServer,
+    VerifyingPreimageFetcher,
 };
 use kona_proof::HintType;
 use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
@@ -171,7 +172,7 @@ impl SingleChainHost {
                 PreimageServer::new(
                     OracleServer::new(preimage),
                     HintReader::new(hint),
-                    Arc::new(OfflineHostBackend::new(kv_store)),
+                    Arc::new(VerifyingPreimageFetcher::new(OfflineHostBackend::new(kv_store))),
                 )
                 .start()
                 .await
@@ -191,7 +192,7 @@ impl SingleChainHost {
                 PreimageServer::new(
                     OracleServer::new(preimage),
                     HintReader::new(hint),
-                    Arc::new(backend),
+                    Arc::new(VerifyingPreimageFetcher::new(backend)),
                 )
                 .start()
                 .await

--- a/rust/kona/crates/proof/preimage/Cargo.toml
+++ b/rust/kona/crates/proof/preimage/Cargo.toml
@@ -37,6 +37,7 @@ std = [
 	"alloy-primitives/std",
 	"dep:async-channel",
 	"serde?/std",
+	"sha2/std",
 	"thiserror/std",
 	"tracing/std",
 ]

--- a/rust/kona/crates/proof/preimage/Cargo.toml
+++ b/rust/kona/crates/proof/preimage/Cargo.toml
@@ -17,10 +17,12 @@ tracing.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
 alloy-primitives.workspace = true
-sha2.workspace = true
 
 # `std` feature dependencies
 async-channel = { workspace = true, optional = true }
+
+# `verify` feature dependencies
+sha2 = { workspace = true, optional = true }
 
 # `rkyv` feature dependencies
 rkyv = { workspace = true, optional = true }
@@ -30,6 +32,7 @@ serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
+sha2.workspace = true
 
 [features]
 default = []
@@ -37,9 +40,10 @@ std = [
 	"alloy-primitives/std",
 	"dep:async-channel",
 	"serde?/std",
-	"sha2/std",
+	"sha2?/std",
 	"thiserror/std",
 	"tracing/std",
 ]
 rkyv = [ "dep:rkyv" ]
 serde = [ "alloy-primitives/serde", "dep:serde" ]
+verify = [ "dep:sha2" ]

--- a/rust/kona/crates/proof/preimage/Cargo.toml
+++ b/rust/kona/crates/proof/preimage/Cargo.toml
@@ -17,6 +17,7 @@ tracing.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
 alloy-primitives.workspace = true
+sha2.workspace = true
 
 # `std` feature dependencies
 async-channel = { workspace = true, optional = true }

--- a/rust/kona/crates/proof/preimage/src/errors.rs
+++ b/rust/kona/crates/proof/preimage/src/errors.rs
@@ -17,6 +17,9 @@ pub enum PreimageOracleError {
     /// Key not found.
     #[error("Key not found.")]
     KeyNotFound,
+    /// The preimage returned by the fetcher does not hash to the requested key.
+    #[error("Incorrect preimage data: hash does not match requested key.")]
+    IncorrectData,
     /// Timeout while waiting for preimage.
     #[error("Timeout while waiting for preimage.")]
     Timeout,

--- a/rust/kona/crates/proof/preimage/src/errors.rs
+++ b/rust/kona/crates/proof/preimage/src/errors.rs
@@ -1,5 +1,6 @@
 //! Errors for the `kona-preimage` crate.
 
+use crate::{PreimageKey, PreimageKeyType};
 use alloc::string::String;
 use thiserror::Error;
 
@@ -18,8 +19,11 @@ pub enum PreimageOracleError {
     #[error("Key not found.")]
     KeyNotFound,
     /// The preimage returned by the fetcher does not hash to the requested key.
-    #[error("Incorrect preimage data: hash does not match requested key.")]
-    IncorrectData,
+    #[error("Incorrect preimage data: hash does not match requested key {0}.")]
+    IncorrectData(PreimageKey),
+    /// The verifier was asked to verify a key type it does not support.
+    #[error("Unsupported preimage key type: {0:?}.")]
+    UnsupportedKeyType(PreimageKeyType),
     /// Timeout while waiting for preimage.
     #[error("Timeout while waiting for preimage.")]
     Timeout,

--- a/rust/kona/crates/proof/preimage/src/lib.rs
+++ b/rust/kona/crates/proof/preimage/src/lib.rs
@@ -20,6 +20,9 @@ pub use key::{PreimageKey, PreimageKeyType};
 mod oracle;
 pub use oracle::{OracleReader, OracleServer};
 
+mod verifier;
+pub use verifier::{VerifyingPreimageFetcher, verify_preimage};
+
 mod hint;
 pub use hint::{HintReader, HintWriter};
 

--- a/rust/kona/crates/proof/preimage/src/lib.rs
+++ b/rust/kona/crates/proof/preimage/src/lib.rs
@@ -20,7 +20,9 @@ pub use key::{PreimageKey, PreimageKeyType};
 mod oracle;
 pub use oracle::{OracleReader, OracleServer};
 
+#[cfg(feature = "verify")]
 mod verifier;
+#[cfg(feature = "verify")]
 pub use verifier::{VerifyingPreimageFetcher, verify_preimage};
 
 mod hint;

--- a/rust/kona/crates/proof/preimage/src/verifier.rs
+++ b/rust/kona/crates/proof/preimage/src/verifier.rs
@@ -33,32 +33,34 @@ impl<F> VerifyingPreimageFetcher<F> {
 
 /// Verify that `data` is a valid preimage for `key`, when the key type carries a
 /// self-describing hash (Keccak256, Sha256). Other key types pass through.
+///
+/// `GlobalGeneric` is reserved and unused; observing it is treated as a programmer
+/// error and returns [`PreimageOracleError::UnsupportedKeyType`].
 pub fn verify_preimage(key: PreimageKey, data: &[u8]) -> PreimageOracleResult<()> {
     let key_bytes: [u8; 32] = key.into();
     match key.key_type() {
         PreimageKeyType::Keccak256 => {
             let digest = keccak256(data);
             if digest[1..] != key_bytes[1..] {
-                return Err(PreimageOracleError::IncorrectData);
+                return Err(PreimageOracleError::IncorrectData(key));
             }
         }
         PreimageKeyType::Sha256 => {
             let digest = Sha256::digest(data);
             if digest[1..] != key_bytes[1..] {
-                return Err(PreimageOracleError::IncorrectData);
+                return Err(PreimageOracleError::IncorrectData(key));
             }
         }
         // Pass through key types that aren't self-verifying from `(key, data)` alone:
         //   - Local: opaque local identifier, no hash relation.
         //   - Blob: individual field element; verification needs a KZG proof.
         //   - Precompile: result bytes; verification needs the precompile input.
-        //   - GlobalGeneric: reserved for future use; no defined semantics yet, and today no host
-        //     path produces it. Matching Blob/Precompile, we pass through rather than reject so
-        //     that adding any future use of this key type does not silently regress here.
-        PreimageKeyType::Local |
-        PreimageKeyType::GlobalGeneric |
-        PreimageKeyType::Blob |
-        PreimageKeyType::Precompile => {}
+        PreimageKeyType::Local | PreimageKeyType::Blob | PreimageKeyType::Precompile => {}
+        // Reserved, no defined semantics, and no host path produces it today. Reject so a
+        // future accidental use surfaces loudly rather than silently passing through.
+        PreimageKeyType::GlobalGeneric => {
+            return Err(PreimageOracleError::UnsupportedKeyType(PreimageKeyType::GlobalGeneric));
+        }
     }
     Ok(())
 }
@@ -136,7 +138,7 @@ mod test {
 
         let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
         let err = verifier.get_preimage(key).await.unwrap_err();
-        assert!(matches!(err, PreimageOracleError::IncorrectData));
+        assert!(matches!(err, PreimageOracleError::IncorrectData(_)));
     }
 
     #[tokio::test]
@@ -148,7 +150,7 @@ mod test {
 
         let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
         let err = verifier.get_preimage(key).await.unwrap_err();
-        assert!(matches!(err, PreimageOracleError::IncorrectData));
+        assert!(matches!(err, PreimageOracleError::IncorrectData(_)));
     }
 
     #[tokio::test]
@@ -174,7 +176,7 @@ mod test {
 
         let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
         let err = verifier.get_preimage(key).await.unwrap_err();
-        assert!(matches!(err, PreimageOracleError::IncorrectData));
+        assert!(matches!(err, PreimageOracleError::IncorrectData(_)));
     }
 
     #[tokio::test]
@@ -211,6 +213,35 @@ mod test {
         let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
         let got = verifier.get_preimage(key).await.unwrap();
         assert_eq!(got, data);
+    }
+
+    #[tokio::test]
+    async fn global_generic_key_rejected() {
+        let key = PreimageKey::new([0xCC; 32], PreimageKeyType::GlobalGeneric);
+        let mut map = HashMap::new();
+        map.insert(key, b"whatever".to_vec());
+
+        let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
+        let err = verifier.get_preimage(key).await.unwrap_err();
+        assert!(matches!(
+            err,
+            PreimageOracleError::UnsupportedKeyType(PreimageKeyType::GlobalGeneric)
+        ));
+    }
+
+    #[tokio::test]
+    async fn incorrect_data_error_carries_key() {
+        let data = b"hello world".to_vec();
+        let key = PreimageKey::new(*keccak256(&data), PreimageKeyType::Keccak256);
+        let mut map = HashMap::new();
+        map.insert(key, b"wrong".to_vec());
+
+        let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
+        let err = verifier.get_preimage(key).await.unwrap_err();
+        match err {
+            PreimageOracleError::IncorrectData(reported) => assert_eq!(reported, key),
+            other => panic!("expected IncorrectData, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/rust/kona/crates/proof/preimage/src/verifier.rs
+++ b/rust/kona/crates/proof/preimage/src/verifier.rs
@@ -1,0 +1,224 @@
+//! A [`PreimageFetcher`] wrapper that re-hashes returned preimages against the requested key.
+//!
+//! The wrapper catches corrupt RPC responses, hint-handler bugs, and tampered
+//! KV stores at fetch time rather than letting bad data propagate.
+
+use crate::{
+    HintRouter, PreimageFetcher, PreimageKey, PreimageKeyType,
+    errors::{PreimageOracleError, PreimageOracleResult},
+};
+use alloc::{boxed::Box, string::String, vec::Vec};
+use alloy_primitives::keccak256;
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+
+/// Wraps an inner [`PreimageFetcher`] and verifies returned preimages by re-hashing
+/// them against the requested key.
+#[derive(Debug, Clone, Copy)]
+pub struct VerifyingPreimageFetcher<F> {
+    inner: F,
+}
+
+impl<F> VerifyingPreimageFetcher<F> {
+    /// Create a new [`VerifyingPreimageFetcher`] from an inner fetcher.
+    pub const fn new(inner: F) -> Self {
+        Self { inner }
+    }
+
+    /// Returns a reference to the inner fetcher.
+    pub const fn inner(&self) -> &F {
+        &self.inner
+    }
+}
+
+/// Verify that `data` is a valid preimage for `key`, when the key type carries a
+/// self-describing hash (Keccak256, Sha256). Other key types pass through.
+pub fn verify_preimage(key: PreimageKey, data: &[u8]) -> PreimageOracleResult<()> {
+    let key_bytes: [u8; 32] = key.into();
+    match key.key_type() {
+        PreimageKeyType::Keccak256 => {
+            let digest = keccak256(data);
+            if digest[1..] != key_bytes[1..] {
+                return Err(PreimageOracleError::IncorrectData);
+            }
+        }
+        PreimageKeyType::Sha256 => {
+            let digest = Sha256::digest(data);
+            if digest[1..] != key_bytes[1..] {
+                return Err(PreimageOracleError::IncorrectData);
+            }
+        }
+        // Pass through key types that aren't self-verifying from `(key, data)` alone:
+        //   - Local: opaque local identifier, no hash relation.
+        //   - Blob: individual field element; verification needs a KZG proof.
+        //   - Precompile: result bytes; verification needs the precompile input.
+        //   - GlobalGeneric: reserved for future use; no defined semantics yet, and today no host
+        //     path produces it. Matching Blob/Precompile, we pass through rather than reject so
+        //     that adding any future use of this key type does not silently regress here.
+        PreimageKeyType::Local |
+        PreimageKeyType::GlobalGeneric |
+        PreimageKeyType::Blob |
+        PreimageKeyType::Precompile => {}
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl<F> PreimageFetcher for VerifyingPreimageFetcher<F>
+where
+    F: PreimageFetcher + Send + Sync,
+{
+    async fn get_preimage(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
+        let data = self.inner.get_preimage(key).await?;
+        verify_preimage(key, &data)?;
+        Ok(data)
+    }
+}
+
+#[async_trait]
+impl<F> HintRouter for VerifyingPreimageFetcher<F>
+where
+    F: HintRouter + Send + Sync,
+{
+    async fn route_hint(&self, hint: String) -> PreimageOracleResult<()> {
+        self.inner.route_hint(hint).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::PreimageKeyType;
+    use alloc::sync::Arc;
+    use alloy_primitives::keccak256;
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use tokio::sync::Mutex;
+
+    /// A test fetcher that returns whatever bytes are stored under each key,
+    /// regardless of whether the key actually hashes to those bytes. This is
+    /// the "corrupt source" the verifier must reject.
+    struct MockFetcher {
+        responses: Arc<Mutex<HashMap<PreimageKey, Vec<u8>>>>,
+    }
+
+    #[async_trait]
+    impl PreimageFetcher for MockFetcher {
+        async fn get_preimage(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
+            let guard = self.responses.lock().await;
+            guard.get(&key).cloned().ok_or(PreimageOracleError::KeyNotFound)
+        }
+    }
+
+    fn make_fetcher(responses: HashMap<PreimageKey, Vec<u8>>) -> MockFetcher {
+        MockFetcher { responses: Arc::new(Mutex::new(responses)) }
+    }
+
+    #[tokio::test]
+    async fn keccak256_valid_data_passes() {
+        let data = b"hello world".to_vec();
+        let key = PreimageKey::new(*keccak256(&data), PreimageKeyType::Keccak256);
+        let mut map = HashMap::new();
+        map.insert(key, data.clone());
+
+        let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
+        let got = verifier.get_preimage(key).await.unwrap();
+        assert_eq!(got, data);
+    }
+
+    #[tokio::test]
+    async fn keccak256_corrupt_data_rejected() {
+        let data = b"hello world".to_vec();
+        let key = PreimageKey::new(*keccak256(&data), PreimageKeyType::Keccak256);
+        // Map the key to *wrong* bytes, simulating a corrupt RPC/KV/hint handler.
+        let mut map = HashMap::new();
+        map.insert(key, b"goodbye".to_vec());
+
+        let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
+        let err = verifier.get_preimage(key).await.unwrap_err();
+        assert!(matches!(err, PreimageOracleError::IncorrectData));
+    }
+
+    #[tokio::test]
+    async fn keccak256_empty_data_rejected() {
+        let data = b"hello world".to_vec();
+        let key = PreimageKey::new(*keccak256(&data), PreimageKeyType::Keccak256);
+        let mut map = HashMap::new();
+        map.insert(key, Vec::new());
+
+        let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
+        let err = verifier.get_preimage(key).await.unwrap_err();
+        assert!(matches!(err, PreimageOracleError::IncorrectData));
+    }
+
+    #[tokio::test]
+    async fn sha256_valid_data_passes() {
+        let data = b"hello world".to_vec();
+        let digest: [u8; 32] = Sha256::digest(&data).into();
+        let key = PreimageKey::new(digest, PreimageKeyType::Sha256);
+        let mut map = HashMap::new();
+        map.insert(key, data.clone());
+
+        let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
+        let got = verifier.get_preimage(key).await.unwrap();
+        assert_eq!(got, data);
+    }
+
+    #[tokio::test]
+    async fn sha256_corrupt_data_rejected() {
+        let data = b"hello world".to_vec();
+        let digest: [u8; 32] = Sha256::digest(&data).into();
+        let key = PreimageKey::new(digest, PreimageKeyType::Sha256);
+        let mut map = HashMap::new();
+        map.insert(key, b"tampered".to_vec());
+
+        let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
+        let err = verifier.get_preimage(key).await.unwrap_err();
+        assert!(matches!(err, PreimageOracleError::IncorrectData));
+    }
+
+    #[tokio::test]
+    async fn local_key_pass_through() {
+        let key = PreimageKey::new_local(7);
+        let data = b"anything goes".to_vec();
+        let mut map = HashMap::new();
+        map.insert(key, data.clone());
+
+        let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
+        let got = verifier.get_preimage(key).await.unwrap();
+        assert_eq!(got, data);
+    }
+
+    #[tokio::test]
+    async fn blob_key_pass_through() {
+        let key = PreimageKey::new([0xAA; 32], PreimageKeyType::Blob);
+        let data = b"opaque blob field element".to_vec();
+        let mut map = HashMap::new();
+        map.insert(key, data.clone());
+
+        let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
+        let got = verifier.get_preimage(key).await.unwrap();
+        assert_eq!(got, data);
+    }
+
+    #[tokio::test]
+    async fn precompile_key_pass_through() {
+        let key = PreimageKey::new([0xBB; 32], PreimageKeyType::Precompile);
+        let data = b"precompile result".to_vec();
+        let mut map = HashMap::new();
+        map.insert(key, data.clone());
+
+        let verifier = VerifyingPreimageFetcher::new(make_fetcher(map));
+        let got = verifier.get_preimage(key).await.unwrap();
+        assert_eq!(got, data);
+    }
+
+    #[tokio::test]
+    async fn inner_error_propagates() {
+        let key = PreimageKey::new([0u8; 32], PreimageKeyType::Keccak256);
+        // No mapping for the key, inner returns KeyNotFound.
+        let verifier = VerifyingPreimageFetcher::new(make_fetcher(HashMap::new()));
+        let err = verifier.get_preimage(key).await.unwrap_err();
+        assert!(matches!(err, PreimageOracleError::KeyNotFound));
+    }
+}


### PR DESCRIPTION
Mirror op-program's `preimage.WithVerification` posture on the kona host side. Previously, `OracleServer::next_preimage_request` forwarded `PreimageFetcher` bytes straight to the client with no check that the returned data actually hashes to the requested key — a corrupt RPC, buggy hint handler, or tampered KV store would silently produce wrong off-chain claims and lose bonds at the cannon step instead of erroring at fetch time.

Adds `VerifyingPreimageFetcher<F>` in `kona-preimage` that re-hashes returned data for `Keccak256` and `Sha256` keys (matching the [1..32] byte comparison op-program uses) and passes through `Local`, `Blob`, `Precompile`, and the reserved `GlobalGeneric` types, which cannot be verified from `(key, data)` alone. Wraps every host backend construction site:

- bin/host/src/single/cfg.rs   (offline + online)
- bin/host/src/interop/cfg.rs  (offline + online)
- bin/host/src/interop/handler.rs (online re-execution backend)

Adds `PreimageOracleError::IncorrectData` to surface the mismatch and unit tests covering valid data, corrupt data, empty data, and pass-through for non-self-verifying key types.

This is defence-in-depth, not a consensus fix: the on-chain `PreimageOracle` already derives keys from supplied preimages, so an attacker cannot register `(K, D)` with `keccak256(D) != K` on-chain. The change closes the off-chain detection gap so kona provers fail loudly at fetch time, matching op-program.

Closes #20659