### PR TITLE
fix(op-node): record safeDB by local-safe derivation L1

### DIFF
--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -93,8 +93,8 @@ func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 		// If there is more data to process,
 		// continue derivation quickly
 		s.StepDeriver.RequestStep(ctx, true)
-	case engine.SafeDerivedEvent:
-		s.onSafeDerivedBlock(ctx, x)
+	case engine.LocalSafeUpdateEvent:
+		s.onLocalSafeUpdate(ctx, x)
 	case derive.ProvideL1Traversal:
 		s.StepDeriver.RequestStep(ctx, false)
 	default:
@@ -129,16 +129,28 @@ func (s *SyncDeriver) OnUnsafeL2Payload(ctx context.Context, envelope *eth.Execu
 
 }
 
-func (s *SyncDeriver) onSafeDerivedBlock(ctx context.Context, x engine.SafeDerivedEvent) {
-	if s.SafeHeadNotifs != nil && s.SafeHeadNotifs.Enabled() {
-		if err := s.SafeHeadNotifs.SafeHeadUpdated(x.Safe, x.Source.ID()); err != nil {
-			// At this point our state is in a potentially inconsistent state as we've updated the safe head
-			// in the execution client but failed to post process it. Reset the pipeline so the safe head rolls back
-			// a little (it always rolls back at least 1 block) and then it will retry storing the entry
-			s.Emitter.Emit(ctx, rollup.ResetEvent{
-				Err: fmt.Errorf("safe head notifications failed: %w", err),
-			})
-		}
+// onLocalSafeUpdate records the local-safe head in the safeDB keyed by the L1
+// block from which it was derived. The safeDB serves dispute-game lookups of
+// "what L2 was safe at this L1 block", which requires the local-safe L1 (the
+// L1 block that includes the last piece of batch data needed to derive this
+// L2 block) rather than the cross-safe-promotion L1.
+//
+// Replacement blocks have no derivation L1; the prior local-safe entry is
+// re-keyed correctly by SafeHeadReset on engine-reset confirmation.
+func (s *SyncDeriver) onLocalSafeUpdate(ctx context.Context, x engine.LocalSafeUpdateEvent) {
+	if s.SafeHeadNotifs == nil || !s.SafeHeadNotifs.Enabled() {
+		return
+	}
+	if x.Source == engine.ReplaceBlockSource {
+		return
+	}
+	if err := s.SafeHeadNotifs.SafeHeadUpdated(x.Ref, x.Source.ID()); err != nil {
+		// At this point our state is in a potentially inconsistent state as we've updated the safe head
+		// in the execution client but failed to post process it. Reset the pipeline so the safe head rolls back
+		// a little (it always rolls back at least 1 block) and then it will retry storing the entry
+		s.Emitter.Emit(ctx, rollup.ResetEvent{
+			Err: fmt.Errorf("safe head notifications failed: %w", err),
+		})
 	}
 }
 


### PR DESCRIPTION
**Claude:** This PR was prepared by Claude on Adrian's behalf.

Re-keys safeDB writes from the cross-safe-promotion L1 (via \`engine.SafeDerivedEvent\`) to the local-safe derivation L1 (via \`engine.LocalSafeUpdateEvent\`, \`x.Source\`). For non-interop this is identical to today (local-safe and cross-safe coincide); for interop it's the change op-challenger needs for dispute-game safeDB lookups. Replacement blocks (\`engine.ReplaceBlockSource\`) are skipped — \`SafeHeadReset\` on engine-reset confirmation already re-keys the prior local-safe entry.

Stacks on #20662 (the reproducer tests). Fixes #20657.

### Verification status

- \`go build ./op-node/... ./op-acceptance-tests/...\` — clean.
- \`just lint-go\` — 0 issues.
- Unit tests in \`op-node/rollup/{driver,engine,finality,interop/indexing}\` and \`op-node/node/safedb\` — all pass.
- Acceptance tests \`TestInteropFaultProofs_SuperrootOptimisticPairing\` and \`TestInteropFaultProofs_SuperrootOptimisticPairing_NoReplacement\` (the two \`gt.Skip\`'d reproducers from #20662) — **still FAIL** after this change. The \`-fpp\` (kona) subtests pass; the \`-challenger\` subtests fail. The \`gt.Skip\` lines are intentionally left in place so as not to push known-failing tests.
  - \`TestInteropFaultProofs_SuperrootOptimisticPairing/FirstChainOptimisticBlock-challenger\` — \`valid claim mismatch\`; trace provider returns \`InvalidTransition\` (7 bytes \`"invalid"\`) where it should return the 213-byte transition state.
  - \`TestInteropFaultProofs_SuperrootOptimisticPairing/SecondChainOptimisticBlock-Invalid-challenger\` — \`agreed prestate mismatch\`; same \`InvalidTransition\` from \`GetPreimageBytes\` at step 1.
  - \`TestInteropFaultProofs_SuperrootOptimisticPairing_NoReplacement/FirstChainOptimisticBlock-challenger\` — \`not found\` from \`SuperRootAtTimestamp\` (supernode has no local-safe block for chain B at \`endTimestamp\`, as expected since chain B's at-T batch never lands).
  - \`TestInteropFaultProofs_SuperrootOptimisticPairing_NoReplacement/SecondChainOptimisticBlock-Invalid-challenger\` — \`local node too far behind\` (\`prevRoot.CurrentL1.Number < gameL1Head.Number\`).

The fix is correct in concept and matches the brief — supernode safeDB now logs \`Record local safe head\` entries keyed by the derivation L1 (visible in test logs). The remaining \`-challenger\` failures suggest the test expectations need additional work in the supernode \`atTimestamp\` aggregation (\`VerifiedRequiredL1\` reflecting per-chain optimistic L1s) or in how \`gameL1Head\` is selected by the test relative to chain B's batch landing pattern. Surfacing for review rather than continuing — the brief described the fix as small and self-contained.