### PR TITLE
ci(rust): temporarily disable kona-coverage

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1069,10 +1069,16 @@ workflows:
           target: "cannon-client"
           context: *rust-ci-context
 
-      - kona-coverage:
-          context: *rust-ci-context
-          requires:
-            - rust-tests
+      # kona-coverage is temporarily disabled. The current `just llvm-cov-tests`
+      # recipe OOMs rustc while compiling reth-optimism-node under
+      # `-C instrument-coverage --all-features` on the xlarge executor and the
+      # bash script has no `set -e`, so the failure was silently swallowed and
+      # only a near-empty lcov was being uploaded to Codecov. Re-enable once the
+      # recipe is fixed (memory, cache path, stale --exclude kona-p2p).
+      # - kona-coverage:
+      #     context: *rust-ci-context
+      #     requires:
+      #       - rust-tests
 
       - kona-host-client-offline:
           name: kona-host-client-offline-cannon
@@ -1102,7 +1108,7 @@ workflows:
             - op-reth-integration-tests: terminal
             - kona-lint-cannon: terminal
             - kona-build-fpvm-cannon-client: terminal
-            - kona-coverage: terminal
+            # kona-coverage temporarily removed from the fan-in; see disabled invocation below.
             - kona-host-client-offline-cannon: terminal
           context:
             - circleci-api-token


### PR DESCRIPTION
## Summary

Temporarily detach the `kona-coverage` CircleCI job from the `rust-ci` workflow and from the `required-rust-ci` fan-in. The job definition itself is preserved so we can re-enable cleanly once the underlying recipe is fixed.

## Why

`kona-coverage` has been silently broken for a while:

- rustc gets OOM-killed (SIGKILL) while compiling `reth-optimism-node` with `-C instrument-coverage --all-features` on the xlarge executor (8 vCPU / 16 GB).
- `rust/kona/justfile`'s `llvm-cov-tests` recipe uses `#!/usr/bin/env bash` with no `set -e`. The failing `cargo llvm-cov nextest --workspace --all-features` is followed by a single-test invocation against `kona-registry`, and `cargo llvm-cov report` then produces an `lcov.info` covering only that one test. Codecov receives that near-empty report and the step exits 0, so the job appears green while uploading useless coverage data.
- When rustc doesn't OOM cleanly, the workflow instead trips `no_output_timeout: 40m` and the job times out (e.g. job 5016137 on pipeline 124848).
- The exclude list in the recipe also still references `kona-p2p`, which no longer exists in the workspace (split into `kona-gossip` / `kona-disc` / `kona-peers` / `kona-node-service`). Harmless on its own but a marker that the recipe has drifted.
- The build cache wired up for this job saves/restores `rust/target/debug`, but `cargo llvm-cov` writes to `rust/target/llvm-cov-target`, so every run is cold.

Net effect right now: `kona-coverage` either fails after 40+ minutes (blocking `required-rust-ci` via the workflow fan-in) or "passes" with garbage data. Disabling buys us time to fix the recipe properly.

Reference: failed job `5016137`, fake-green job `5016311` (both on workflow `86d8b027-2bcf-4176-947a-735f432d0c7a` of pipeline 124868).

## What this PR does

- Comments out the `kona-coverage` invocation in the `rust-ci` workflow.
- Removes `kona-coverage: terminal` from `required-rust-ci`'s `requires:` list.
- Leaves the `kona-coverage` job definition (and its supporting cache config) in place so re-enabling is a one-line revert.

## Follow-up (separate PR)

When re-enabling, address at minimum:

- Move to `2xlarge` (or pass `CARGO_BUILD_JOBS` / `-C codegen-units` / a leaner feature set) so rustc doesn't OOM under coverage instrumentation.
- Add `set -euo pipefail` to `llvm-cov-tests` so failures surface.
- Drop the stale `--exclude kona-p2p` and audit the exclude list against the current workspace.
- Cache `rust/target/llvm-cov-target` instead of `rust/target/debug`, and align the cache `version` with the other rust jobs so the registry cache is shared.

## Test plan

- [x] YAML validates and `kona-coverage` no longer appears in any workflow's `jobs` or in any `requires:` list.
- [ ] CI on this PR: confirm `required-rust-ci` runs and completes without waiting on `kona-coverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)