### PR TITLE
ci(rust): remove dead kona-coverage job and orphan llvm-cov setup

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -6,7 +6,6 @@ version: 2.1
 orbs:
   utils: ethereum-optimism/circleci-utils@1.0.27
   gcp-cli: circleci/gcp-cli@3.0.1
-  codecov: codecov/codecov@5.0.3
 
 parameters:
   c-default_docker_image:
@@ -765,8 +764,6 @@ jobs:
           working_directory: rust/kona/bin/client
           no_output_timeout: 40m
           command: |
-            source <(cargo llvm-cov show-env --export-prefix)
-            mkdir -p ../../../target
             just run-client-cannon-offline \
               $BLOCK_NUMBER \
               $L2_CLAIM \
@@ -774,7 +771,6 @@ jobs:
               $L2_HEAD \
               $L1_HEAD \
               $L2_CHAIN_ID
-            cargo llvm-cov report --lcov --output-path client_host_cov.lcov
 
   # Kona Rust CI - Lint (cannon target)
   kona-cargo-lint:
@@ -825,35 +821,6 @@ jobs:
           no_output_timeout: 40m
           command: |
             just build-<<parameters.target>>
-
-  # Kona Coverage
-  kona-coverage:
-    docker:
-      - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &kona-coverage-cache
-          directory: rust
-          prefix: kona-coverage
-          version: "1"
-      - run:
-          name: Generate lockfile if needed
-          working_directory: rust
-          command: |
-            [ -f Cargo.lock ] || cargo generate-lockfile
-      - run:
-          name: Run coverage
-          working_directory: rust/kona
-          no_output_timeout: 40m
-          command: |
-            just llvm-cov-tests
-      - codecov/upload:
-          disable_search: true
-          files: rust/kona/lcov.info
-          flags: unit
-      - rust-save-build-cache: *kona-coverage-cache
 
   # Kona Link Checker
   kona-link-checker:
@@ -1057,7 +1024,7 @@ workflows:
           context: *rust-ci-context
 
       # -----------------------------------------------------------------------
-      # Kona crate-specific jobs (lint, FPVM builds, benches, coverage)
+      # Kona crate-specific jobs (lint, FPVM builds, host-client offline)
       # -----------------------------------------------------------------------
       - kona-cargo-lint:
           name: kona-lint-cannon
@@ -1068,17 +1035,6 @@ workflows:
           name: kona-build-fpvm-cannon-client
           target: "cannon-client"
           context: *rust-ci-context
-
-      # kona-coverage is temporarily disabled. The current `just llvm-cov-tests`
-      # recipe OOMs rustc while compiling reth-optimism-node under
-      # `-C instrument-coverage --all-features` on the xlarge executor and the
-      # bash script has no `set -e`, so the failure was silently swallowed and
-      # only a near-empty lcov was being uploaded to Codecov. Re-enable once the
-      # recipe is fixed (memory, cache path, stale --exclude kona-p2p).
-      # - kona-coverage:
-      #     context: *rust-ci-context
-      #     requires:
-      #       - rust-tests
 
       - kona-host-client-offline:
           name: kona-host-client-offline-cannon
@@ -1108,7 +1064,6 @@ workflows:
             - op-reth-integration-tests: terminal
             - kona-lint-cannon: terminal
             - kona-build-fpvm-cannon-client: terminal
-            # kona-coverage temporarily removed from the fan-in; see disabled invocation below.
             - kona-host-client-offline-cannon: terminal
           context:
             - circleci-api-token

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -764,6 +764,12 @@ jobs:
           working_directory: rust/kona/bin/client
           no_output_timeout: 40m
           command: |
+            # Pre-create the workspace target dir as the circleci user. Without
+            # this, `just build-cannon-client` (invoked inside run-client-cannon-offline)
+            # runs Docker as root and creates `rust/target/` with root ownership,
+            # which then breaks the subsequent native `cargo build --bin kona-host`
+            # with EACCES when it tries to create `target/debug`.
+            mkdir -p ../../../target
             just run-client-cannon-offline \
               $BLOCK_NUMBER \
               $L2_CLAIM \


### PR DESCRIPTION
## Summary

Follow-up cleanup after #20667 (now merged). That PR commented out the `kona-coverage` invocation and removed it from `required-rust-ci`'s fan-in. This PR removes the rest of the now-dead code so we don't leave a misleading commented-out block behind, and also cleans up an orphan in `kona-host-client-offline`.

## Changes

- Drop the `kona-coverage` job definition (`.circleci/continue/rust-ci.yml`).
- Drop the `codecov` orb import — `kona-coverage` was the only consumer of `codecov/upload` in this file.
- Remove the orphan `cargo llvm-cov` setup from `kona-host-client-offline`:
  - `source <(cargo llvm-cov show-env --export-prefix)` (was enabling coverage instrumentation for the host+client build)
  - `cargo llvm-cov report --lcov --output-path client_host_cov.lcov` (was producing an lcov file that nothing consumed — no `codecov/upload` step ever ingested it)

  Net effect: the job still runs the host+client offline test, just without coverage instrumentation. It should also be a bit faster.
- Keep `mkdir -p ../../../target` in the same step (with an explanatory comment): a first cleanup attempt removed it too, but it turns out it's not llvm-cov scaffolding — it pre-creates the workspace target dir as the `circleci` user so that the subsequent `just build-cannon-client` step (which runs Docker as root with a bind mount of the monorepo) doesn't end up creating `rust/target/` with root ownership. Without it, the next `cargo build --bin kona-host` fails with `EACCES` when trying to create `target/debug`. Reproduced on this PR's first CI run (CircleCI job 5017649) before adding the comment + the mkdir back.
- Strip the commented-out workflow invocation and the fan-in stub comment that #20667 left in place.

The `llvm-cov-tests` recipe in `rust/kona/justfile` is intentionally kept so coverage can still be exercised locally while the re-enable plan is worked through.

## Re-enable plan

Tracked in #20670 — includes root-cause recap (OOM, missing `set -e`, stale `--exclude kona-p2p`, cache mis-pointing, wrong `flags:` value) plus a strategy checklist for fitting the build into memory.

## Test plan

- [x] YAML parses cleanly and no workflow references `kona-coverage`.
- [x] `kona-host-client-offline` no longer mentions `llvm-cov`.
- [x] `codecov` orb is no longer imported in `rust-ci.yml` (no other consumer in this file).
- [ ] CI on this PR: `required-rust-ci` still completes without `kona-coverage`, `kona-host-client-offline-cannon` still runs the offline replay (currently being verified after the mkdir restore).

## Related

- #20667 — disable kona-coverage in CI (merged)
- #20670 — re-enable plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)