### PR TITLE
docs: historical proofs: recommend old snapshots

### DIFF
--- a/docs/public-docs/node-operators/reference/op-reth-historical-proof-config.mdx
+++ b/docs/public-docs/node-operators/reference/op-reth-historical-proof-config.mdx
@@ -35,7 +35,7 @@ The path to the storage DB for proofs history.
 
 ### proofs-history.window
 
-The window to span blocks for proofs history. Value is the number of blocks. 
+The window to span blocks for proofs history. Value is the number of blocks.
 Default is 1 month of blocks based on 2 seconds block time (`30 * 24 * 60 * 60 / 2 = 1,296,000`).
 
 <Tabs>
@@ -82,8 +82,12 @@ The `op-reth proofs` command allows you to manage the storage of historical proo
 Initialize the proofs storage with the current state of the chain.
 
 ```bash
-op-reth proofs init --chain <CHAIN> --datadir <DATA_DIR> --proofs-history.storage-path <PROOFS_HISTORY_STORAGE_PATH> 
+op-reth proofs init --chain <CHAIN> --datadir <DATA_DIR> --proofs-history.storage-path <PROOFS_HISTORY_STORAGE_PATH>
 ```
+
+<Info>
+The first time `proofs init` runs, it takes minutes to hours to complete. Subsequent invocations should only take seconds. It does **not** backfill historical proofs — it simply marks the current chain tip as the starting point of the proofs database. Once the node is running with `--proofs-history`, the proofs database fills forward as new blocks are committed. To serve proofs across the full retention window (e.g., 30 days for fault proofs at default settings), the node must run continuously for at least that long after initialization. For that reason it is recommended to start from a snapshot whose tip is old enough to cover the required time window, so that when the node starts syncing from the snapshot's tip, the full window is covered.
+</Info>
 
 ### prune
 

--- a/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
+++ b/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
@@ -92,7 +92,7 @@ Initialize the separate storage used by the ExEx to store historical proofs. Thi
 ```
 
 <Info>
-`proofs init` completes in seconds. It does **not** backfill historical proofs — it simply marks the current chain tip as the starting point of the proofs database. Once the node is running with `--proofs-history`, the proofs database fills forward as new blocks are committed. To serve proofs across the full retention window (e.g., 30 days for fault proofs at default settings), the node must run continuously for at least that long after initialization.
+The first time `proofs init` runs, it takes minutes to hours to complete. Subsequent invocations should only take seconds. It does **not** backfill historical proofs — it simply marks the current chain tip as the starting point of the proofs database. Once the node is running with `--proofs-history`, the proofs database fills forward as new blocks are committed. To serve proofs across the full retention window (e.g., 30 days for fault proofs at default settings), the node must run continuously for at least that long after initialization. For that reason it is recommended to start from a snapshot whose tip is old enough to cover the required time window, so that when the node starts syncing from the snapshot's tip, the full window is covered.
 </Info>
 
 ## Running op-reth


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Updating docs to recommend using older snapshots to cover full proofs window.
