### PR TITLE
ci(docs): allowlist pnpm build scripts for mintlify-docs-build

### DIFF
--- a/docs/public-docs/package.json
+++ b/docs/public-docs/package.json
@@ -19,5 +19,15 @@
     "ts-morph": "^21.0.0",
     "tsx": "^4.7.0",
     "typescript": "^5.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@reown/appkit",
+      "bigint-buffer",
+      "bufferutil",
+      "esbuild",
+      "sharp",
+      "utf-8-validate"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds a `pnpm.onlyBuiltDependencies` allowlist to `docs/public-docs/package.json` so that pnpm 10+ stops failing the `mintlify-docs-build` CI job with `[ERR_PNPM_IGNORED_BUILDS]`.

## Why

`mintlify-docs-build` installs pnpm globally on every run via `sudo npm install -g pnpm` ([.circleci/continue/docs-ci.yml](https://github.com/ethereum-optimism/optimism/blob/develop/.circleci/continue/docs-ci.yml#L94-L104)), which always grabs the latest version. pnpm 10 changed the default to **reject** any package with install scripts unless it is explicitly approved, which is now breaking `pnpm install`:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @reown/appkit@1.8.9, bigint-buffer@1.1.5,
  bufferutil@4.0.9, esbuild@0.25.12, sharp@0.33.5, utf-8-validate@5.0.10
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
Exited with code exit status 1
```

This blocks every docs PR — example: [#20672](https://github.com/ethereum-optimism/optimism/pull/20672), CircleCI job [5019948](https://circleci.com/gh/ethereum-optimism/optimism/5019948).

## The fix

Add the exact list of packages pnpm flagged to `pnpm.onlyBuiltDependencies` in the docs sub-package. No CI config change required.

## Notes / follow-ups

- This allowlist is scoped to `docs/public-docs/` only — the monorepo has no root `package.json`, so nothing else is affected.
- It will need to be updated if new dependencies with install scripts are added to `docs/public-docs/`. A more durable alternative would be to pin pnpm in the CI step (e.g. `npm install -g pnpm@9`) or adopt Corepack with `"packageManager"` in `package.json` — happy to follow up with either if preferred.

## Test plan

- [ ] `mintlify-docs-build` passes on this PR
- [ ] `mintlify-docs-build` passes on a rebased #20672 once this lands