### PR TITLE
op-interop-filter: log ingested blocks at info

### DIFF
--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -812,7 +812,12 @@ func (c *LogsDBChainIngester) writeFetchedBlock(fetched blockFetch) error {
 	c.metrics.RecordBlocksSealed(chainIDUint64, 1)
 	c.metrics.RecordLogsAdded(chainIDUint64, int64(logCount))
 
-	c.log.Debug("Ingested block", "block", blockNum, "hash", blockID.Hash, "timestamp", blockInfo.Time(), "logs", logCount)
+	c.log.Info("Ingested block",
+		"block", blockNum,
+		"hash", blockID.Hash,
+		"timestamp", blockInfo.Time(),
+		"ingested_at", time.Now().UTC(),
+		"logs", logCount)
 
 	// Set earliest block on first successful ingestion (fresh start case).
 	// On restart, findAndSetEarliestBlock handles this instead.


### PR DESCRIPTION
## Summary

Promote the interop filter per-block ingestion log from debug to info and include an explicit UTC `ingested_at` wall-clock timestamp.

This lets benchmark post-processing query Loki for `Ingested block` entries and compare the ingestion wall-clock time against Contender/block timestamp data without relying on debug logging.

## Validation

- `go test ./op-interop-filter/filter`
