### PR TITLE
op-interop-filter: remove execTimestamp from validateMessageTiming

### DIFF
--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -256,11 +256,11 @@ func (v *LockstepCrossValidator) runValidationLoop() {
 	defer ticker.Stop()
 
 	for {
+		v.advanceValidation()
 		select {
 		case <-v.ctx.Done():
 			return
 		case <-ticker.C:
-			v.advanceValidation()
 		}
 	}
 }

--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -127,9 +127,11 @@ func (v *LockstepCrossValidator) CrossValidatedTimestamp() (uint64, bool) {
 //   - timeout: optional max execution delay (0 = disabled)
 //   - execTimestamp: execution timestamp (only used if timeout > 0)
 func validateMessageTiming(
-	initTimestamp, inclusionTimestamp, messageExpiryWindow, timeout, execTimestamp uint64,
+	initTimestamp, inclusionTimestamp, messageExpiryWindow, timeout uint64,
 ) error {
 	// Rule 1: init must be strictly before inclusion
+	// geoknee: seems like we won't allow it in the mempool even if it would be invalid
+	// now, even if it were to become valid before the timeout
 	if initTimestamp >= inclusionTimestamp {
 		return fmt.Errorf("initiating message timestamp %d not before inclusion timestamp %d: %w",
 			initTimestamp, inclusionTimestamp, types.ErrConflict)
@@ -142,26 +144,21 @@ func validateMessageTiming(
 			initTimestamp, messageExpiryWindow, types.ErrConflict)
 	}
 
-	// Rule 3: message must not be expired at inclusion
-	if expiresAt < inclusionTimestamp {
-		return fmt.Errorf("initiating message expired: init %d + expiry window %d = %d < inclusion %d: %w",
-			initTimestamp, messageExpiryWindow, expiresAt, inclusionTimestamp, types.ErrConflict)
+	// We want to allow for the message to be included any time from (now) to (now + timeout)
+	// So compute the max inclusion time and rerun the checks against the expiry window
+	maxInclusionTimestamp := inclusionTimestamp + timeout
+	if maxInclusionTimestamp < inclusionTimestamp {
+		return fmt.Errorf("overflow in max exec timestamp calculation: timestamp %d + timeout %d: %w",
+			inclusionTimestamp, timeout, types.ErrConflict)
 	}
 
-	// Rule 4: if timeout set, message must not expire before timeout deadline
-	if timeout > 0 {
-		maxExecTimestamp := execTimestamp + timeout
-		if maxExecTimestamp < execTimestamp {
-			return fmt.Errorf("overflow in max exec timestamp calculation: timestamp %d + timeout %d: %w",
-				execTimestamp, timeout, types.ErrConflict)
-		}
-		if expiresAt < maxExecTimestamp {
-			return fmt.Errorf("initiating message will expire before timeout: "+
-				"init %d + expiry %d = %d < exec %d + timeout %d = %d: %w",
-				initTimestamp, messageExpiryWindow, expiresAt,
-				execTimestamp, timeout, maxExecTimestamp,
-				types.ErrConflict)
-		}
+	// Rule 3: message must not be expired at inclusion
+	if expiresAt < maxInclusionTimestamp {
+		return fmt.Errorf("initiating message will expire before timeout: "+
+			"init %d + expiry %d = %d < exec %d + timeout %d = %d: %w",
+			initTimestamp, messageExpiryWindow, expiresAt,
+			inclusionTimestamp, timeout, maxInclusionTimestamp,
+			types.ErrConflict)
 	}
 
 	return nil
@@ -199,7 +196,6 @@ func (v *LockstepCrossValidator) ValidateAccessEntry(
 		execDescriptor.Timestamp,
 		v.messageExpiryWindow,
 		execDescriptor.Timeout,
-		execDescriptor.Timestamp,
 	); err != nil {
 		return err
 	}
@@ -234,7 +230,7 @@ func (v *LockstepCrossValidator) validateExecutingMessage(
 		execMsg.Timestamp,
 		inclusionTimestamp,
 		v.messageExpiryWindow,
-		0, 0, // no timeout
+		0, // no timeout
 	); err != nil {
 		return err
 	}

--- a/op-interop-filter/filter/lockstep_cross_validator_test.go
+++ b/op-interop-filter/filter/lockstep_cross_validator_test.go
@@ -430,7 +430,6 @@ func TestValidateMessageTiming(t *testing.T) {
 		inclusionTimestamp  uint64
 		messageExpiryWindow uint64
 		timeout             uint64
-		execTimestamp       uint64
 		wantErr             bool
 		errContains         string
 	}{
@@ -440,7 +439,6 @@ func TestValidateMessageTiming(t *testing.T) {
 			inclusionTimestamp:  150,
 			messageExpiryWindow: 100,
 			timeout:             0,
-			execTimestamp:       0,
 			wantErr:             false,
 		},
 		{
@@ -449,17 +447,15 @@ func TestValidateMessageTiming(t *testing.T) {
 			inclusionTimestamp:  200,
 			messageExpiryWindow: 100, // expiresAt = 200
 			timeout:             0,
-			execTimestamp:       0,
 			wantErr:             false,
 		},
 		{
 			name:                "valid: with timeout, message expires after deadline",
 			initTimestamp:       100,
 			inclusionTimestamp:  150,
-			messageExpiryWindow: 100, // expiresAt = 200
-			timeout:             40,  // maxExecTs = 150 + 40 = 190
-			execTimestamp:       150, // 200 >= 190, valid
-			wantErr:             false,
+			messageExpiryWindow: 100,   // expiresAt = 200
+			timeout:             40,    // maxExecTs = 150 + 40 = 190
+			wantErr:             false, // 200 >= 190, valid
 		},
 		{
 			name:                "invalid: init timestamp equals inclusion",
@@ -467,7 +463,6 @@ func TestValidateMessageTiming(t *testing.T) {
 			inclusionTimestamp:  100,
 			messageExpiryWindow: 100,
 			timeout:             0,
-			execTimestamp:       0,
 			wantErr:             true,
 			errContains:         "not before inclusion",
 		},
@@ -477,7 +472,6 @@ func TestValidateMessageTiming(t *testing.T) {
 			inclusionTimestamp:  100,
 			messageExpiryWindow: 100,
 			timeout:             0,
-			execTimestamp:       0,
 			wantErr:             true,
 			errContains:         "not before inclusion",
 		},
@@ -487,7 +481,6 @@ func TestValidateMessageTiming(t *testing.T) {
 			inclusionTimestamp:  ^uint64(0),
 			messageExpiryWindow: 100, // will overflow
 			timeout:             0,
-			execTimestamp:       0,
 			wantErr:             true,
 			errContains:         "overflow in expiry calculation",
 		},
@@ -497,17 +490,15 @@ func TestValidateMessageTiming(t *testing.T) {
 			inclusionTimestamp:  250,
 			messageExpiryWindow: 100, // expiresAt = 200 < 250
 			timeout:             0,
-			execTimestamp:       0,
 			wantErr:             true,
-			errContains:         "expired",
+			errContains:         "expire before timeout",
 		},
 		{
 			name:                "invalid: timeout overflow",
 			initTimestamp:       100,
-			inclusionTimestamp:  150,
+			inclusionTimestamp:  ^uint64(0) - 10, // will overflow when added to timeout
 			messageExpiryWindow: 100,
-			timeout:             ^uint64(0),      // max uint64
-			execTimestamp:       ^uint64(0) - 10, // will overflow when added to timeout
+			timeout:             ^uint64(0), // max uint64
 			wantErr:             true,
 			errContains:         "overflow in max exec timestamp",
 		},
@@ -515,20 +506,18 @@ func TestValidateMessageTiming(t *testing.T) {
 			name:                "invalid: expires before timeout deadline",
 			initTimestamp:       100,
 			inclusionTimestamp:  150,
-			messageExpiryWindow: 100, // expiresAt = 200
-			timeout:             51,  // maxExecTs = 150 + 51 = 201
-			execTimestamp:       150, // 200 < 201, invalid
-			wantErr:             true,
+			messageExpiryWindow: 100,  // expiresAt = 200
+			timeout:             51,   // maxExecTs = 150 + 51 = 201
+			wantErr:             true, // 200 < 201, invalid
 			errContains:         "expire before timeout",
 		},
 		{
 			name:                "valid: expires exactly at timeout deadline",
 			initTimestamp:       100,
 			inclusionTimestamp:  150,
-			messageExpiryWindow: 100, // expiresAt = 200
-			timeout:             50,  // maxExecTs = 150 + 50 = 200
-			execTimestamp:       150, // 200 >= 200, valid (equal is ok)
-			wantErr:             false,
+			messageExpiryWindow: 100,   // expiresAt = 200
+			timeout:             50,    // maxExecTs = 150 + 50 = 200
+			wantErr:             false, // 200 >= 200, valid (equal is ok)
 		},
 	}
 
@@ -539,7 +528,6 @@ func TestValidateMessageTiming(t *testing.T) {
 				tt.inclusionTimestamp,
 				tt.messageExpiryWindow,
 				tt.timeout,
-				tt.execTimestamp,
 			)
 			if tt.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
Towards https://github.com/ethereum-optimism/optimism-private/issues/532