### PR TITLE
fix(op-devstack): wait for L1 head past dispute game createdAt before prove

### DIFF
--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -376,9 +376,30 @@ func (w *Withdrawal) Prove(user *EOA) {
 		Data:     params.Data,
 	}
 
+	// OptimismPortal2.proveWithdrawalTransaction reverts with
+	// OptimismPortal_InvalidProofTimestamp (selector 0xb4caa4e5) when
+	// block.timestamp <= disputeGameProxy.createdAt(). estimateGas evaluates
+	// against the current L1 head, so any attempt before the head advances past
+	// the game's createdAt is guaranteed to revert. Wait for that precondition
+	// explicitly instead of burning the prove-tx retry budget on guaranteed-revert
+	// estimateGas calls; under CI load L1 block production can stall and the
+	// prior retry-only approach exhausted its 30s budget before the head moved
+	// (#19963).
+	gameContract := bindings.NewBindings[bindings.FaultDisputeGame](
+		bindings.WithClient(w.bridge.l1Client.EthClient()),
+		bindings.WithTo(params.DisputeGameAddress),
+		bindings.WithTest(w.t))
+	gameCreatedAt, err := contractio.Read(gameContract.CreatedAt(), w.ctx)
+	w.require.NoError(err, "failed to read dispute game createdAt")
+	w.require.Eventuallyf(func() bool {
+		head, err := w.bridge.l1Client.EthClient().InfoByLabel(w.ctx, eth.Unsafe)
+		if err != nil {
+			return false
+		}
+		return head.Time() > gameCreatedAt
+	}, 60*time.Second, 500*time.Millisecond, "L1 head did not advance past dispute game createdAt %d", gameCreatedAt)
+
 	call := w.bridge.l1Portal.ProveWithdrawalTransaction(tx, params.DisputeGameIndex, params.OutputRootProof, params.WithdrawalProof)
-	// Retry as withdrawals can't be proven in the same block as the game is created.
-	// estimateGas works against the current head so we may need to retry until it has progressed enough.
 	w.require.Eventually(func() bool {
 		proveReceipt, err := contractio.Write(call, w.ctx, user.Plan())
 		if err != nil {

--- a/op-service/txintent/bindings/FaultDisputeGame.go
+++ b/op-service/txintent/bindings/FaultDisputeGame.go
@@ -46,6 +46,7 @@ type FaultDisputeGame struct {
 	L2SequenceNumber func() TypedCall[*big.Int]    `sol:"l2SequenceNumber"`
 	Status           func() TypedCall[uint8]       `sol:"status"`
 	GameType         func() TypedCall[uint32]      `sol:"gameType"`
+	CreatedAt        func() TypedCall[uint64]      `sol:"createdAt"`
 
 	// IFaultDisputeGame.sol read methods
 	AbsolutePrestate       func() TypedCall[common.Hash]                                              `sol:"absolutePrestate"`


### PR DESCRIPTION
## Summary

Fixes #19963 (and likely #19964 / #19965 / #19966, which use the same helper).

`OptimismPortal2.proveWithdrawalTransaction` reverts with `OptimismPortal_InvalidProofTimestamp()` (selector `0xb4caa4e5`) when `block.timestamp <= disputeGameProxy.createdAt()` ([`OptimismPortal2.sol:411`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OptimismPortal2.sol#L411)). `estimateGas` evaluates against the current L1 head, so any prove attempt issued before the head's timestamp advances past the game's `createdAt` is guaranteed to revert.

`(*Withdrawal).Prove` in `op-devstack/dsl/bridge.go` relied on a 30s / 1s `Eventually` retry to "catch" these reverts and try again as the L1 head advanced. Under loaded CI, L1 block production stalls (the linked CI run saw a ~6 s gap between L1 blocks 13 and 14), and the retry budget was burnt on guaranteed-revert `estimateGas` calls before the head moved, leaving too little remaining budget to confirm the actual prove transaction.

Wait deterministically for `l1.head.Time() > game.createdAt()` (60 s budget, 500 ms tick) before entering the existing 30 s prove-tx retry. The retry is now correctly scoped to transient submission/confirmation; the timestamp precondition is observable and is waited on explicitly.

Also adds the missing `CreatedAt() -> uint64` accessor to the `FaultDisputeGame` binding (the Solidity getter exists on `FaultDisputeGame.sol:156`).

## Evidence (from the per-test artifact of pipeline 124730 / job 5005124)

| time | event |
|------|-------|
| 18:08:37.133 | Proposer tx confirmed in L1 block 13 → dispute game `index=0` created here |
| 18:08:37.248 | `forGamePublished` returns the game |
| 18:08:37.287 | Prove attempt 1: revert `0xb4caa4e5` |
| 18:08:38 – 18:08:42 | Attempts 2–6, all revert with same selector; L1 head still at block 13 |
| 18:08:43.267 | L1 block 14 appears — **6 s after block 13** (normal cadence ~2 s) |
| 18:08:43 → 18:09:07 | Eventually's 30 s budget exhausts |
| ~18:11:00 | Devstack teardown completes (`--- FAIL: TestWithdrawal_Cannon (221.93s)`) |

The mass `context deadline exceeded` errors at 18:10:59–18:11:00 are post-failure devstack shutdown, not the trigger of the failure.

The CI run in question had 26 failures in 1089 s — the box was thrashed, which is why L1 block 13→14 took 6 s instead of the usual 2 s. Under normal CI load, attempts 2–3 see the new head and `estimateGas` succeeds well inside the 30 s budget.

## Test plan

- [ ] CI: `memory-all-opn-op-reth`, `memory-all-kona-op-reth` (the jobs in which the test has flaked)
- [ ] Verify `TestWithdrawal_Cannon`, `TestWithdrawal_CannonKona`, `TestExecuteStep_Cannon`, `TestExecuteStep_CannonKona` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)