### PR TITLE
[codex] avoid supernode p2p port collisions

### DIFF
--- a/op-supernode/README.md
+++ b/op-supernode/README.md
@@ -45,7 +45,7 @@ This allows for *roughly* 1:1 setup and behavior between Node and Supernode, wit
 - Some behaviors are expected to be configured at the `op-supernode` level and are not respected the usual way when the application starts:
   - `l1` and `l1.beacon` are used to create the shared L1 client. Any L1 configuration will not be respected by a Virtual Node.
   - Log and Metric settings are passed down to the Virtual node from the top level Log/Metric flags, and individual chain settings may not be respected.
-  - `p2p` is enabled/disabled at the top level. While enabled, listen ports default to `0` (dynamic) to prevent collisions, but `--vn.all.p2p.listen.tcp` / `--vn.all.p2p.listen.udp` and the per-chain `--vn.<chainID>.p2p.listen.tcp` / `--vn.<chainID>.p2p.listen.udp` flags are honoured when set. The user is responsible for picking distinct ports across chains. Per-chain P2P functionality will be added via a shared resource in the future.
+  - `p2p` is enabled/disabled at the top level. While enabled, listen ports default to `0` (dynamic) to prevent collisions. Single-chain deployments may pin ports with `--vn.all.p2p.listen.tcp` / `--vn.all.p2p.listen.udp`; multi-chain deployments should use the per-chain `--vn.<chainID>.p2p.listen.tcp` / `--vn.<chainID>.p2p.listen.udp` flags when fixed ports are required. Per-chain P2P functionality will be added via a shared resource in the future.
 
 Example launch of Supernode:
 

--- a/op-supernode/cmd/main.go
+++ b/op-supernode/cmd/main.go
@@ -109,6 +109,7 @@ func main() {
 
 func createVirtualNodeConfigs(cliCtx *cli.Context, cfg *config.CLIConfig, l log.Logger) (map[eth.ChainID]*opnodecfg.Config, error) {
 	vnCfgs := make(map[eth.ChainID]*opnodecfg.Config)
+	multiChain := len(cfg.Chains) > 1
 	for _, chainID := range cfg.Chains {
 		// Create a new VirtualCLI for the chain which will serve as an opnode config
 		vcli := flags.NewVirtualCLI(cliCtx, chainID)
@@ -118,7 +119,7 @@ func createVirtualNodeConfigs(cliCtx *cli.Context, cfg *config.CLIConfig, l log.
 				return nil, fmt.Errorf("failed to disable P2P for chain %d: %w", chainID, err)
 			}
 		} else {
-			if err := withNamespacedP2P(vcli, cfg.DataDir, strconv.FormatUint(chainID, 10)); err != nil {
+			if err := withNamespacedP2P(vcli, cfg.DataDir, strconv.FormatUint(chainID, 10), multiChain); err != nil {
 				return nil, fmt.Errorf("failed to configure P2P for chain %d: %w", chainID, err)
 			}
 		}

--- a/op-supernode/cmd/p2p.go
+++ b/op-supernode/cmd/p2p.go
@@ -19,7 +19,7 @@ func withNoP2P(vcli *flags.VirtualCLI) error {
 	return nil
 }
 
-func withNamespacedP2P(vcli *flags.VirtualCLI, datadir string, namespace string) error {
+func withNamespacedP2P(vcli *flags.VirtualCLI, datadir string, namespace string, multiChain bool) error {
 	p2pDir := filepath.Join(datadir, namespace, "p2p")
 	if err := os.MkdirAll(p2pDir, 0o700); err != nil {
 		return fmt.Errorf("failed creating p2p dir for chain %s: %w", namespace, err)
@@ -28,12 +28,19 @@ func withNamespacedP2P(vcli *flags.VirtualCLI, datadir string, namespace string)
 	vcli.WithStringOverride(opnodeflags.PeerstorePathName, filepath.Join(p2pDir, "peerstore_db"))
 	vcli.WithStringOverride(opnodeflags.DiscoveryPathName, filepath.Join(p2pDir, "discovery_db"))
 	// Default listen ports to 0 (dynamic) to prevent collisions when the user
-	// has not pinned a port. Honour vn.all.<flag> and vn.<id>.<flag> when set.
-	if !vcli.IsSet(opnodeflags.ListenTCPPortName) {
-		vcli.WithUintOverride(opnodeflags.ListenTCPPortName, 0)
-	}
-	if !vcli.IsSet(opnodeflags.ListenUDPPortName) {
-		vcli.WithUintOverride(opnodeflags.ListenUDPPortName, 0)
-	}
+	// has not pinned a port. In multi-chain mode, a non-zero vn.all.<flag>
+	// would be reused by every virtual node, so require per-chain ports instead.
+	withNamespacedP2PListenPort(vcli, opnodeflags.ListenTCPPortName, multiChain)
+	withNamespacedP2PListenPort(vcli, opnodeflags.ListenUDPPortName, multiChain)
 	return nil
+}
+
+func withNamespacedP2PListenPort(vcli *flags.VirtualCLI, name string, multiChain bool) {
+	if !vcli.IsSet(name) {
+		vcli.WithUintOverride(name, 0)
+		return
+	}
+	if multiChain && !vcli.IsChainSet(name) && vcli.IsGlobalSet(name) && vcli.Uint(name) != 0 {
+		vcli.WithUintOverride(name, 0)
+	}
 }

--- a/op-supernode/cmd/p2p_test.go
+++ b/op-supernode/cmd/p2p_test.go
@@ -45,24 +45,34 @@ func newVCLI(t *testing.T, args []string) *flags.VirtualCLI {
 
 func TestWithNamespacedP2P_DefaultsListenPortsToZero(t *testing.T) {
 	vcli := newVCLI(t, nil)
-	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID)))
+	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID), true))
 
 	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenTCPPortName))
 	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenUDPPortName))
 }
 
-func TestWithNamespacedP2P_HonoursGlobalListenPorts(t *testing.T) {
+func TestWithNamespacedP2P_HonoursGlobalListenPortsForSingleChain(t *testing.T) {
 	// A global vn.all.* port collides at bind time when more than one chain is
-	// running, but the supernode honours it as configured -- test for
-	// completeness so a single-chain deployment can pin a fixed port.
+	// running, but a single-chain deployment can pin a fixed port.
 	vcli := newVCLI(t, []string{
 		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenTCPPortName + "=9222",
 		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenUDPPortName + "=9223",
 	})
-	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID)))
+	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID), false))
 
 	require.Equal(t, uint(9222), vcli.Uint(opnodeflags.ListenTCPPortName))
 	require.Equal(t, uint(9223), vcli.Uint(opnodeflags.ListenUDPPortName))
+}
+
+func TestWithNamespacedP2P_DefaultsNonZeroGlobalListenPortsToZeroForMultiChain(t *testing.T) {
+	vcli := newVCLI(t, []string{
+		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenTCPPortName + "=9222",
+		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenUDPPortName + "=9223",
+	})
+	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID), true))
+
+	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenTCPPortName))
+	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenUDPPortName))
 }
 
 func TestWithNamespacedP2P_HonoursPerChainListenPorts(t *testing.T) {
@@ -72,7 +82,7 @@ func TestWithNamespacedP2P_HonoursPerChainListenPorts(t *testing.T) {
 		"--" + tcpName + "=9000",
 		"--" + udpName + "=9001",
 	})
-	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID)))
+	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID), true))
 
 	require.Equal(t, uint(9000), vcli.Uint(opnodeflags.ListenTCPPortName))
 	require.Equal(t, uint(9001), vcli.Uint(opnodeflags.ListenUDPPortName))
@@ -84,7 +94,7 @@ func TestWithNamespacedP2P_PerChainOverridesGlobal(t *testing.T) {
 		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenTCPPortName + "=9222",
 		"--" + tcpName + "=9000",
 	})
-	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID)))
+	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID), true))
 
 	require.Equal(t, uint(9000), vcli.Uint(opnodeflags.ListenTCPPortName))
 	// UDP fell through to the default-zero override.
@@ -94,7 +104,7 @@ func TestWithNamespacedP2P_PerChainOverridesGlobal(t *testing.T) {
 func TestWithNamespacedP2P_CreatesP2PDir(t *testing.T) {
 	dataDir := t.TempDir()
 	ns := fmt.Sprintf("%d", testChainID)
-	require.NoError(t, withNamespacedP2P(newVCLI(t, nil), dataDir, ns))
+	require.NoError(t, withNamespacedP2P(newVCLI(t, nil), dataDir, ns, true))
 
 	expected := filepath.Join(dataDir, ns, "p2p")
 	info, err := os.Stat(expected)

--- a/op-supernode/flags/virtual_cli.go
+++ b/op-supernode/flags/virtual_cli.go
@@ -31,6 +31,14 @@ func (v *VirtualCLI) globalName(name string) string {
 	return VNFlagGlobalPrefix + name
 }
 
+func (v *VirtualCLI) IsChainSet(name string) bool {
+	return v.inner.IsSet(v.chainName(name))
+}
+
+func (v *VirtualCLI) IsGlobalSet(name string) bool {
+	return v.inner.IsSet(v.globalName(name))
+}
+
 // IsSet satisfies the cliiface.Context interface
 // if an override is set, or if any namespaced version is set, return true
 // otherwise defer to the inner context
@@ -44,10 +52,10 @@ func (v *VirtualCLI) IsSet(name string) bool {
 	if _, ok := v.uintOverrides[name]; ok {
 		return true
 	}
-	if v.inner.IsSet(v.chainName(name)) {
+	if v.IsChainSet(name) {
 		return true
 	}
-	return v.inner.IsSet(v.globalName(name))
+	return v.IsGlobalSet(name)
 }
 
 func (v *VirtualCLI) String(name string) string {


### PR DESCRIPTION
## Summary
- keep supernode virtual-node P2P listen ports dynamic by default
- preserve explicit per-chain fixed ports
- avoid reusing a non-zero vn.all P2P listen port across every virtual node in multi-chain mode

## Root cause
PR #20448 changed supernode P2P setup to honor user-supplied `vn.all.p2p.listen.tcp` / `vn.all.p2p.listen.udp` values. That is fine for a single-chain supernode, but in multi-chain mode the same non-zero global port is handed to every virtual op-node and they collide at bind time.

## Validation
- `go test ./op-supernode/cmd ./op-supernode/flags`
- `go test ./op-supernode/...`