### PR TITLE
[codex] avoid supernode p2p port collisions

### DIFF
--- a/op-supernode/README.md
+++ b/op-supernode/README.md
@@ -45,7 +45,7 @@ This allows for *roughly* 1:1 setup and behavior between Node and Supernode, wit
 - Some behaviors are expected to be configured at the `op-supernode` level and are not respected the usual way when the application starts:
   - `l1` and `l1.beacon` are used to create the shared L1 client. Any L1 configuration will not be respected by a Virtual Node.
   - Log and Metric settings are passed down to the Virtual node from the top level Log/Metric flags, and individual chain settings may not be respected.
-  - `p2p` is enabled/disabled at the top level. While enabled, listen ports default to `0` (dynamic) to prevent collisions, but `--vn.all.p2p.listen.tcp` / `--vn.all.p2p.listen.udp` and the per-chain `--vn.<chainID>.p2p.listen.tcp` / `--vn.<chainID>.p2p.listen.udp` flags are honoured when set. The user is responsible for picking distinct ports across chains. Per-chain P2P functionality will be added via a shared resource in the future.
+  - `p2p` is enabled/disabled at the top level. While enabled, listen ports default to `0` (dynamic) to prevent collisions. Non-zero `--vn.all.p2p.listen.tcp` / `--vn.all.p2p.listen.udp` values are rejected because they would be reused by every virtual node. Use the per-chain `--vn.<chainID>.p2p.listen.tcp` / `--vn.<chainID>.p2p.listen.udp` flags when fixed ports are required.
 
 Example launch of Supernode:
 

--- a/op-supernode/cmd/p2p.go
+++ b/op-supernode/cmd/p2p.go
@@ -28,12 +28,24 @@ func withNamespacedP2P(vcli *flags.VirtualCLI, datadir string, namespace string)
 	vcli.WithStringOverride(opnodeflags.PeerstorePathName, filepath.Join(p2pDir, "peerstore_db"))
 	vcli.WithStringOverride(opnodeflags.DiscoveryPathName, filepath.Join(p2pDir, "discovery_db"))
 	// Default listen ports to 0 (dynamic) to prevent collisions when the user
-	// has not pinned a port. Honour vn.all.<flag> and vn.<id>.<flag> when set.
-	if !vcli.IsSet(opnodeflags.ListenTCPPortName) {
-		vcli.WithUintOverride(opnodeflags.ListenTCPPortName, 0)
+	// has not pinned a per-chain port. A non-zero vn.all.<flag> would be reused
+	// by every virtual node, so require per-chain listen ports instead.
+	if err := withNamespacedP2PListenPort(vcli, opnodeflags.ListenTCPPortName); err != nil {
+		return err
 	}
-	if !vcli.IsSet(opnodeflags.ListenUDPPortName) {
-		vcli.WithUintOverride(opnodeflags.ListenUDPPortName, 0)
+	if err := withNamespacedP2PListenPort(vcli, opnodeflags.ListenUDPPortName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func withNamespacedP2PListenPort(vcli *flags.VirtualCLI, name string) error {
+	if !vcli.IsSet(name) {
+		vcli.WithUintOverride(name, 0)
+		return nil
+	}
+	if vcli.IsGlobalSet(name) && vcli.GlobalUint(name) != 0 {
+		return fmt.Errorf("%s%s cannot be non-zero for virtual-node P2P listen ports; use %s<chainID>.%s for fixed per-chain ports", flags.VNFlagGlobalPrefix, name, flags.VNFlagNamePrefix, name)
 	}
 	return nil
 }

--- a/op-supernode/cmd/p2p_test.go
+++ b/op-supernode/cmd/p2p_test.go
@@ -51,18 +51,26 @@ func TestWithNamespacedP2P_DefaultsListenPortsToZero(t *testing.T) {
 	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenUDPPortName))
 }
 
-func TestWithNamespacedP2P_HonoursGlobalListenPorts(t *testing.T) {
-	// A global vn.all.* port collides at bind time when more than one chain is
-	// running, but the supernode honours it as configured -- test for
-	// completeness so a single-chain deployment can pin a fixed port.
+func TestWithNamespacedP2P_ErrorsOnNonZeroGlobalListenPorts(t *testing.T) {
 	vcli := newVCLI(t, []string{
 		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenTCPPortName + "=9222",
 		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenUDPPortName + "=9223",
 	})
+
+	err := withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID))
+	require.ErrorContains(t, err, "vn.all.p2p.listen.tcp cannot be non-zero")
+	require.ErrorContains(t, err, "vn.<chainID>.p2p.listen.tcp")
+}
+
+func TestWithNamespacedP2P_HonoursZeroGlobalListenPorts(t *testing.T) {
+	vcli := newVCLI(t, []string{
+		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenTCPPortName + "=0",
+		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenUDPPortName + "=0",
+	})
 	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID)))
 
-	require.Equal(t, uint(9222), vcli.Uint(opnodeflags.ListenTCPPortName))
-	require.Equal(t, uint(9223), vcli.Uint(opnodeflags.ListenUDPPortName))
+	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenTCPPortName))
+	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenUDPPortName))
 }
 
 func TestWithNamespacedP2P_HonoursPerChainListenPorts(t *testing.T) {
@@ -78,10 +86,21 @@ func TestWithNamespacedP2P_HonoursPerChainListenPorts(t *testing.T) {
 	require.Equal(t, uint(9001), vcli.Uint(opnodeflags.ListenUDPPortName))
 }
 
-func TestWithNamespacedP2P_PerChainOverridesGlobal(t *testing.T) {
+func TestWithNamespacedP2P_ErrorsOnNonZeroGlobalListenPortEvenWhenPerChainIsSet(t *testing.T) {
 	tcpName := fmt.Sprintf("%s%d.%s", flags.VNFlagNamePrefix, testChainID, opnodeflags.ListenTCPPortName)
 	vcli := newVCLI(t, []string{
 		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenTCPPortName + "=9222",
+		"--" + tcpName + "=9000",
+	})
+
+	err := withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID))
+	require.ErrorContains(t, err, "vn.all.p2p.listen.tcp cannot be non-zero")
+}
+
+func TestWithNamespacedP2P_PerChainOverridesGlobalZero(t *testing.T) {
+	tcpName := fmt.Sprintf("%s%d.%s", flags.VNFlagNamePrefix, testChainID, opnodeflags.ListenTCPPortName)
+	vcli := newVCLI(t, []string{
+		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenTCPPortName + "=0",
 		"--" + tcpName + "=9000",
 	})
 	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID)))

--- a/op-supernode/flags/virtual_cli.go
+++ b/op-supernode/flags/virtual_cli.go
@@ -31,6 +31,18 @@ func (v *VirtualCLI) globalName(name string) string {
 	return VNFlagGlobalPrefix + name
 }
 
+func (v *VirtualCLI) IsChainSet(name string) bool {
+	return v.inner.IsSet(v.chainName(name))
+}
+
+func (v *VirtualCLI) IsGlobalSet(name string) bool {
+	return v.inner.IsSet(v.globalName(name))
+}
+
+func (v *VirtualCLI) GlobalUint(name string) uint {
+	return v.inner.Uint(v.globalName(name))
+}
+
 // IsSet satisfies the cliiface.Context interface
 // if an override is set, or if any namespaced version is set, return true
 // otherwise defer to the inner context
@@ -44,10 +56,10 @@ func (v *VirtualCLI) IsSet(name string) bool {
 	if _, ok := v.uintOverrides[name]; ok {
 		return true
 	}
-	if v.inner.IsSet(v.chainName(name)) {
+	if v.IsChainSet(name) {
 		return true
 	}
-	return v.inner.IsSet(v.globalName(name))
+	return v.IsGlobalSet(name)
 }
 
 func (v *VirtualCLI) String(name string) string {


### PR DESCRIPTION
## Summary
- keep supernode virtual-node P2P listen ports dynamic by default
- preserve explicit per-chain fixed ports
- reject non-zero vn.all P2P listen ports before virtual op-nodes hit bind collisions

## Root cause
PR #20448 changed supernode P2P setup to honor user-supplied `vn.all.p2p.listen.tcp` / `vn.all.p2p.listen.udp` values. A non-zero global listen port can be handed to multiple virtual op-nodes, which then collide at bind time.

## Behavior
- unset P2P listen ports default to dynamic `0`
- `vn.all.p2p.listen.tcp=0` / `vn.all.p2p.listen.udp=0` is accepted
- non-zero `vn.all.p2p.listen.tcp` / `vn.all.p2p.listen.udp` now returns a config error
- `vn.<chainID>.p2p.listen.tcp` / `vn.<chainID>.p2p.listen.udp` still pin fixed ports when needed

## Validation
- `go test ./op-supernode/cmd ./op-supernode/flags`
- `go test ./op-supernode/...`