### PR TITLE
fix(op-supervisor/logs): make logsdb mutations publish after storage success

### DIFF
--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
@@ -15,6 +15,7 @@ type EntryStore[T EntryType, E Entry[T]] interface {
 	Read(idx EntryIdx) (E, error)
 	Append(entries ...E) error
 	Truncate(idx EntryIdx) error
+	Sync() error
 	Close() error
 }
 
@@ -46,6 +47,7 @@ type dataAccess interface {
 	io.Writer
 	io.Closer
 	Truncate(size int64) error
+	Sync() error
 }
 
 type EntryDB[T EntryType, E Entry[T], B Binary[T, E]] struct {
@@ -153,6 +155,10 @@ func (e *EntryDB[T, E, B]) Truncate(idx EntryIdx) error {
 	e.lastEntryIdx = idx
 	e.cleanupFailedWrite = false
 	return nil
+}
+
+func (e *EntryDB[T, E, B]) Sync() error {
+	return e.data.Sync()
 }
 
 // recover an invalid database by truncating back to the last complete event.

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -53,10 +56,12 @@ type dataAccess interface {
 type EntryDB[T EntryType, E Entry[T], B Binary[T, E]] struct {
 	data         dataAccess
 	lastEntryIdx EntryIdx
+	cleanupPath  string
 
 	b B
 
 	cleanupFailedWrite bool
+	pendingCleanup     *EntryIdx
 }
 
 // NewEntryDB creates an EntryDB. A new file will be created if the specified path does not exist,
@@ -79,7 +84,20 @@ func NewEntryDB[T EntryType, E Entry[T], B Binary[T, E]](logger log.Logger, path
 	db := &EntryDB[T, E, B]{
 		data:         file,
 		lastEntryIdx: EntryIdx(size - 1),
+		cleanupPath:  path + ".cleanup",
 	}
+	if err := db.loadCleanup(); err != nil {
+		return nil, fmt.Errorf("failed to load pending cleanup at %v: %w", path, err)
+	}
+	if err := db.drainCleanup(); err != nil {
+		return nil, fmt.Errorf("failed to drain pending cleanup at %v: %w", path, err)
+	}
+	info, err = file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat database after cleanup at %v: %w", path, err)
+	}
+	size = info.Size() / int64(b.EntrySize())
+	db.lastEntryIdx = EntryIdx(size - 1)
 	if size*int64(b.EntrySize()) != info.Size() {
 		logger.Warn("File size is not a multiple of entry size. Truncating to last complete entry", "fileSize", size, "entrySize", b.EntrySize())
 		if err := db.recover(); err != nil {
@@ -89,20 +107,27 @@ func NewEntryDB[T EntryType, E Entry[T], B Binary[T, E]](logger log.Logger, path
 	return db, nil
 }
 
+func (e *EntryDB[T, E, B]) effectiveLastEntryIdx() EntryIdx {
+	if e.pendingCleanup != nil && *e.pendingCleanup < e.lastEntryIdx {
+		return *e.pendingCleanup
+	}
+	return e.lastEntryIdx
+}
+
 func (e *EntryDB[T, E, B]) Size() int64 {
-	return int64(e.lastEntryIdx) + 1
+	return int64(e.effectiveLastEntryIdx()) + 1
 }
 
 // LastEntryIdx returns the index of the last entry in the DB.
 // This returns -1 if the DB is empty.
 func (e *EntryDB[T, E, B]) LastEntryIdx() EntryIdx {
-	return e.lastEntryIdx
+	return e.effectiveLastEntryIdx()
 }
 
 // Read an entry from the database by index. Returns io.EOF iff idx is after the last entry.
 func (e *EntryDB[T, E, B]) Read(idx EntryIdx) (E, error) {
 	var out E
-	if idx > e.lastEntryIdx {
+	if idx > e.effectiveLastEntryIdx() {
 		return out, io.EOF
 	}
 	read, err := e.b.ReadAt(&out, e.data, int64(idx)*int64(e.b.EntrySize()))
@@ -118,6 +143,9 @@ func (e *EntryDB[T, E, B]) Read(idx EntryIdx) (E, error) {
 // If the write fails, it will attempt to truncate any partially written data.
 // Subsequent writes to this instance will fail until partially written data is truncated.
 func (e *EntryDB[T, E, B]) Append(entries ...E) error {
+	if err := e.drainCleanup(); err != nil {
+		return fmt.Errorf("failed to drain pending cleanup before append: %w", err)
+	}
 	if e.cleanupFailedWrite {
 		// Try to rollback partially written data from a previous Append
 		if truncateErr := e.Truncate(e.lastEntryIdx); truncateErr != nil {
@@ -148,6 +176,12 @@ func (e *EntryDB[T, E, B]) Append(entries ...E) error {
 
 // Truncate the database so that the last retained entry is idx. Any entries after idx are deleted.
 func (e *EntryDB[T, E, B]) Truncate(idx EntryIdx) error {
+	if e.pendingCleanup != nil && idx > *e.pendingCleanup {
+		idx = *e.pendingCleanup
+	}
+	if err := e.recordCleanup(idx); err != nil {
+		return fmt.Errorf("failed to record cleanup to entry %v: %w", idx, err)
+	}
 	if err := e.data.Truncate((int64(idx) + 1) * int64(e.b.EntrySize())); err != nil {
 		return fmt.Errorf("failed to truncate to entry %v: %w", idx, err)
 	}
@@ -158,17 +192,119 @@ func (e *EntryDB[T, E, B]) Truncate(idx EntryIdx) error {
 }
 
 func (e *EntryDB[T, E, B]) Sync() error {
-	return e.data.Sync()
-}
-
-// recover an invalid database by truncating back to the last complete event.
-func (e *EntryDB[T, E, B]) recover() error {
-	if err := e.data.Truncate(e.Size() * int64(e.b.EntrySize())); err != nil {
-		return fmt.Errorf("failed to truncate trailing partial entries: %w", err)
+	if err := e.data.Sync(); err != nil {
+		return err
+	}
+	if e.pendingCleanup != nil {
+		if err := e.clearCleanup(); err != nil {
+			return fmt.Errorf("failed to clear pending cleanup: %w", err)
+		}
 	}
 	return nil
 }
 
+// recover an invalid database by truncating back to the last complete event.
+func (e *EntryDB[T, E, B]) recover() error {
+	if err := e.Truncate(EntryIdx(e.Size() - 1)); err != nil {
+		return fmt.Errorf("failed to truncate trailing partial entries: %w", err)
+	}
+	return e.Sync()
+}
+
 func (e *EntryDB[T, E, B]) Close() error {
 	return e.data.Close()
+}
+
+func (e *EntryDB[T, E, B]) loadCleanup() error {
+	if e.cleanupPath == "" {
+		return nil
+	}
+	data, err := os.ReadFile(e.cleanupPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	target, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return fmt.Errorf("decode cleanup target: %w", err)
+	}
+	idx := EntryIdx(target)
+	e.pendingCleanup = &idx
+	return nil
+}
+
+func (e *EntryDB[T, E, B]) recordCleanup(idx EntryIdx) error {
+	if e.cleanupPath == "" {
+		target := idx
+		e.pendingCleanup = &target
+		return nil
+	}
+	tmpPath := e.cleanupPath + ".tmp"
+	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "%d\n", idx); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, e.cleanupPath); err != nil {
+		return err
+	}
+	if err := syncDir(filepath.Dir(e.cleanupPath)); err != nil {
+		return err
+	}
+	target := idx
+	e.pendingCleanup = &target
+	return nil
+}
+
+func (e *EntryDB[T, E, B]) clearCleanup() error {
+	if e.cleanupPath != "" {
+		if err := os.Remove(e.cleanupPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := syncDir(filepath.Dir(e.cleanupPath)); err != nil {
+			return err
+		}
+	}
+	e.pendingCleanup = nil
+	e.cleanupFailedWrite = false
+	return nil
+}
+
+func (e *EntryDB[T, E, B]) drainCleanup() error {
+	if e.pendingCleanup == nil {
+		return nil
+	}
+	target := *e.pendingCleanup
+	if target > e.lastEntryIdx {
+		target = e.lastEntryIdx
+	}
+	if err := e.data.Truncate((int64(target) + 1) * int64(e.b.EntrySize())); err != nil {
+		return fmt.Errorf("failed to truncate to pending cleanup entry %v: %w", target, err)
+	}
+	e.lastEntryIdx = target
+	if err := e.data.Sync(); err != nil {
+		return fmt.Errorf("failed to sync pending cleanup truncate: %w", err)
+	}
+	return e.clearCleanup()
+}
+
+func syncDir(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
 }

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
@@ -139,6 +139,88 @@ func TestTruncate(t *testing.T) {
 	})
 }
 
+func TestTruncateCleanupWAL(t *testing.T) {
+	t.Run("ReopenDrainsPendingCleanup", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "entries.db")
+		db := openEntryDB(t, file)
+		require.NoError(t, db.Append(createEntry(1), createEntry(2), createEntry(3)))
+		require.NoError(t, db.Sync())
+
+		require.NoError(t, db.Truncate(0))
+		require.FileExists(t, file+".cleanup")
+		require.NoError(t, db.Close())
+
+		db = openEntryDB(t, file)
+		require.EqualValues(t, 1, db.Size())
+		requireRead(t, db, 0, createEntry(1))
+		_, err := db.Read(1)
+		require.ErrorIs(t, err, io.EOF)
+		require.NoFileExists(t, file+".cleanup")
+		stat, err := os.Stat(file)
+		require.NoError(t, err)
+		require.EqualValues(t, TestEntrySize, stat.Size())
+		require.NoError(t, db.Close())
+	})
+
+	t.Run("AppendDrainsPendingCleanupBeforeWriting", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "entries.db")
+		db := openEntryDB(t, file)
+		require.NoError(t, db.Append(createEntry(1), createEntry(2), createEntry(3)))
+		require.NoError(t, db.Sync())
+
+		require.NoError(t, db.Truncate(0))
+		require.FileExists(t, file+".cleanup")
+		require.NoError(t, db.Append(createEntry(4)))
+
+		require.EqualValues(t, 2, db.Size())
+		requireRead(t, db, 0, createEntry(1))
+		requireRead(t, db, 1, createEntry(4))
+		_, err := db.Read(2)
+		require.ErrorIs(t, err, io.EOF)
+		require.NoFileExists(t, file+".cleanup")
+		stat, err := os.Stat(file)
+		require.NoError(t, err)
+		require.EqualValues(t, 2*TestEntrySize, stat.Size())
+		require.NoError(t, db.Close())
+	})
+
+	t.Run("SyncClearsPendingCleanup", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "entries.db")
+		db := openEntryDB(t, file)
+		require.NoError(t, db.Append(createEntry(1), createEntry(2)))
+		require.NoError(t, db.Sync())
+
+		require.NoError(t, db.Truncate(0))
+		require.FileExists(t, file+".cleanup")
+		require.NoError(t, db.Sync())
+		require.NoFileExists(t, file+".cleanup")
+		require.NoError(t, db.Close())
+
+		db = openEntryDB(t, file)
+		require.EqualValues(t, 1, db.Size())
+		requireRead(t, db, 0, createEntry(1))
+		require.NoError(t, db.Close())
+	})
+
+	t.Run("PendingCleanupDoesNotExpandFile", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "entries.db")
+		entry := createEntry(1)
+		require.NoError(t, os.WriteFile(file, entry[:], 0o644))
+		require.NoError(t, os.WriteFile(file+".cleanup", []byte("100\n"), 0o644))
+
+		db := openEntryDB(t, file)
+		require.EqualValues(t, 1, db.Size())
+		requireRead(t, db, 0, createEntry(1))
+		_, err := db.Read(1)
+		require.ErrorIs(t, err, io.EOF)
+		stat, err := os.Stat(file)
+		require.NoError(t, err)
+		require.EqualValues(t, TestEntrySize, stat.Size())
+		require.NoFileExists(t, file+".cleanup")
+		require.NoError(t, db.Close())
+	})
+}
+
 func TestTruncateTrailingPartialEntries(t *testing.T) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	file := filepath.Join(t.TempDir(), "entries.db")
@@ -223,12 +305,17 @@ func createEntry(i byte) TestEntry {
 }
 
 func createEntryDB(t *testing.T) *TestEntryDB {
-	logger := testlog.Logger(t, log.LvlInfo)
-	db, err := NewEntryDB[TestEntryType, TestEntry, TestEntryBinary](logger, filepath.Join(t.TempDir(), "entries.db"))
-	require.NoError(t, err)
+	db := openEntryDB(t, filepath.Join(t.TempDir(), "entries.db"))
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())
 	})
+	return db
+}
+
+func openEntryDB(t *testing.T, file string) *TestEntryDB {
+	logger := testlog.Logger(t, log.LvlInfo)
+	db, err := NewEntryDB[TestEntryType, TestEntry, TestEntryBinary](logger, file)
+	require.NoError(t, err)
 	return db
 }
 

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
@@ -243,6 +243,7 @@ type stubDataAccess struct {
 	writeErr           error
 	writeErrAfterBytes int
 	truncateErr        error
+	syncErr            error
 }
 
 func (s *stubDataAccess) ReadAt(p []byte, off int64) (n int, err error) {
@@ -268,6 +269,10 @@ func (s *stubDataAccess) Truncate(size int64) error {
 	}
 	s.data = s.data[:size]
 	return nil
+}
+
+func (s *stubDataAccess) Sync() error {
+	return s.syncErr
 }
 
 var _ dataAccess = (*stubDataAccess)(nil)

--- a/op-supervisor/supervisor/backend/db/entrydb/memdb.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/memdb.go
@@ -34,6 +34,10 @@ func (s *MemEntryStore[T, E]) Truncate(idx EntryIdx) error {
 	return nil
 }
 
+func (s *MemEntryStore[T, E]) Sync() error {
+	return nil
+}
+
 func (s *MemEntryStore[T, E]) Close() error {
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -552,16 +552,14 @@ func (db *DB) debugTip() {
 	}
 }
 
-func (db *DB) flush() error {
-	for i, e := range db.lastEntryContext.out {
+func (db *DB) appendEntries(out []Entry, nextEntryIndex entrydb.EntryIdx) error {
+	for i, e := range out {
 		db.log.Trace("appending entry", "type", e.Type(), "entry", hexutil.Bytes(e[:]),
-			"next", int(db.lastEntryContext.nextEntryIndex)-len(db.lastEntryContext.out)+i)
+			"next", int(nextEntryIndex)-len(out)+i)
 	}
-	if err := db.store.Append(db.lastEntryContext.out...); err != nil {
+	if err := db.store.Append(out...); err != nil {
 		return fmt.Errorf("failed to append entries: %w", err)
 	}
-	db.lastEntryContext.out = db.lastEntryContext.out[:0]
-	db.updateEntryCountMetric()
 	return nil
 }
 
@@ -569,27 +567,58 @@ func (db *DB) SealBlock(parentHash common.Hash, block eth.BlockID, timestamp uin
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 
-	if err := db.lastEntryContext.SealBlock(parentHash, block, timestamp); err != nil {
+	next := db.lastEntryContext
+	if err := next.SealBlock(parentHash, block, timestamp); err != nil {
 		return fmt.Errorf("failed to seal block: %w", err)
 	}
 	db.log.Trace("Sealed block", "parent", parentHash, "block", block, "timestamp", timestamp)
-	return db.flush()
+	prevIdx := db.lastEntryContext.nextEntryIndex - 1
+	if err := db.appendEntries(next.out, next.nextEntryIndex); err != nil {
+		return err
+	}
+	if err := db.store.Sync(); err != nil {
+		if truncateErr := db.store.Truncate(prevIdx); truncateErr != nil {
+			return errors.Join(
+				fmt.Errorf("failed to sync sealed block: %w", err),
+				fmt.Errorf("failed to roll back unsynced seal entries: %w", truncateErr),
+			)
+		}
+		return fmt.Errorf("failed to sync sealed block: %w", err)
+	}
+	next.out = next.out[:0]
+	db.lastEntryContext = next
+	db.updateEntryCountMetric()
+	return nil
 }
 
 func (db *DB) AddLog(logHash common.Hash, parentBlock eth.BlockID, logIdx uint32, execMsg *types.ExecutingMessage) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 
-	if err := db.lastEntryContext.ApplyLog(parentBlock, logIdx, logHash, execMsg); err != nil {
+	next := db.lastEntryContext
+	if err := next.ApplyLog(parentBlock, logIdx, logHash, execMsg); err != nil {
 		return fmt.Errorf("failed to apply log: %w", err)
 	}
 	db.log.Trace("Applied log", "parentBlock", parentBlock, "logIndex", logIdx, "logHash", logHash, "executing", execMsg != nil)
-	return db.flush()
+	if err := db.appendEntries(next.out, next.nextEntryIndex); err != nil {
+		return err
+	}
+	next.out = next.out[:0]
+	db.lastEntryContext = next
+	db.updateEntryCountMetric()
+	return nil
 }
 
 // Clear clears the DB such that there is no data left.
 // An invalidator is required as argument, to force users to invalidate any current open reads.
 func (db *DB) Clear(inv reads.Invalidator) error {
+	db.rwLock.Lock()
+	defer db.rwLock.Unlock()
+	defer db.updateEntryCountMetric()
+	return db.clearLocked(inv)
+}
+
+func (db *DB) clearLocked(inv reads.Invalidator) error {
 	release, invalidateErr := inv.TryInvalidate(reads.InvalidationRules{
 		reads.DerivedInvalidation{Timestamp: 0},
 	})
@@ -597,9 +626,11 @@ func (db *DB) Clear(inv reads.Invalidator) error {
 		return invalidateErr
 	}
 	defer release()
-	defer db.updateEntryCountMetric()
 	if truncateErr := db.store.Truncate(-1); truncateErr != nil {
 		return fmt.Errorf("failed to empty DB: %w", truncateErr)
+	}
+	if syncErr := db.store.Sync(); syncErr != nil {
+		return fmt.Errorf("failed to sync empty DB: %w", syncErr)
 	}
 	db.lastEntryContext = logContext{}
 	return nil
@@ -617,7 +648,7 @@ func (db *DB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 	iter, err := db.newIteratorAt(newHead.Number, 0)
 	if err != nil {
 		if errors.Is(err, types.ErrPreviousToFirst) || errors.Is(err, types.ErrSkipped) {
-			if err := db.Clear(inv); err != nil {
+			if err := db.clearLocked(inv); err != nil {
 				return fmt.Errorf("failed to clear logs DB, upon rewinding to log block %s before first block: %w", newHead, err)
 			}
 			return nil
@@ -638,14 +669,17 @@ func (db *DB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 		return err
 	}
 	defer release()
+	target := iter.current
+
 	// Truncate to contain idx entries. The Truncate func keeps the given index as last index.
-	if err := db.store.Truncate(iter.NextIndex() - 1); err != nil {
+	if err := db.store.Truncate(target.NextIndex() - 1); err != nil {
 		return fmt.Errorf("failed to truncate to block %s: %w", newHead, err)
 	}
-	// Use db.init() to find the log context for the new latest log entry
-	if err := db.init(true); err != nil {
-		return fmt.Errorf("failed to find new last entry context: %w", err)
+	if err := db.store.Sync(); err != nil {
+		return fmt.Errorf("failed to sync rewind to block %s: %w", newHead, err)
 	}
+	db.lastEntryContext = target
+	db.lastEntryContext.out = nil
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/logs/db_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/db_test.go
@@ -2,6 +2,8 @@ package logs
 
 import (
 	"encoding/binary"
+	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -42,6 +44,126 @@ func TestErrorOpeningDatabase(t *testing.T) {
 	chainID := eth.ChainIDFromUInt64(123)
 	_, err := NewFromFile(testlog.Logger(t, log.LvlInfo), &stubMetrics{}, chainID, filepath.Join(dir, "missing-dir", "file.db"), false)
 	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+type faultEntryStore struct {
+	entries []Entry
+
+	appendErr   error
+	syncErr     error
+	truncateErr error
+}
+
+func (s *faultEntryStore) Size() int64 {
+	return int64(len(s.entries))
+}
+
+func (s *faultEntryStore) LastEntryIdx() entrydb.EntryIdx {
+	return entrydb.EntryIdx(len(s.entries) - 1)
+}
+
+func (s *faultEntryStore) Read(idx entrydb.EntryIdx) (Entry, error) {
+	if idx < entrydb.EntryIdx(len(s.entries)) {
+		return s.entries[idx], nil
+	}
+	return Entry{}, io.EOF
+}
+
+func (s *faultEntryStore) Append(entries ...Entry) error {
+	if s.appendErr != nil {
+		return s.appendErr
+	}
+	s.entries = append(s.entries, entries...)
+	return nil
+}
+
+func (s *faultEntryStore) Truncate(idx entrydb.EntryIdx) error {
+	if s.truncateErr != nil {
+		return s.truncateErr
+	}
+	s.entries = s.entries[:idx+1]
+	return nil
+}
+
+func (s *faultEntryStore) Sync() error {
+	return s.syncErr
+}
+
+func (s *faultEntryStore) Close() error {
+	return nil
+}
+
+var _ entrydb.EntryStore[EntryType, Entry] = (*faultEntryStore)(nil)
+
+func TestMutationAtomicity(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	chainID := eth.ChainIDFromUInt64(123)
+
+	t.Run("AddLogAppendFailureDoesNotAdvanceState", func(t *testing.T) {
+		store := &faultEntryStore{}
+		db, err := NewFromEntryStore(logger, &stubMetrics{}, chainID, store, false)
+		require.NoError(t, err)
+		bl0 := eth.BlockID{Hash: createHash(0), Number: 0}
+		require.NoError(t, db.SealBlock(common.Hash{}, bl0, 100))
+		before := db.lastEntryContext
+
+		expectedErr := errors.New("append failed")
+		store.appendErr = expectedErr
+		err = db.AddLog(createHash(1), bl0, 0, nil)
+		require.ErrorIs(t, err, expectedErr)
+		require.Equal(t, before, db.lastEntryContext)
+		require.Equal(t, before.nextEntryIndex, db.lastEntryContext.nextEntryIndex)
+	})
+
+	t.Run("SealBlockSyncFailureDoesNotAdvanceState", func(t *testing.T) {
+		store := &faultEntryStore{}
+		db, err := NewFromEntryStore(logger, &stubMetrics{}, chainID, store, false)
+		require.NoError(t, err)
+		bl0 := eth.BlockID{Hash: createHash(0), Number: 0}
+		require.NoError(t, db.SealBlock(common.Hash{}, bl0, 100))
+		before := db.lastEntryContext
+		beforeEntries := len(store.entries)
+
+		expectedErr := errors.New("sync failed")
+		store.syncErr = expectedErr
+		bl1 := eth.BlockID{Hash: createHash(1), Number: 1}
+		err = db.SealBlock(bl0.Hash, bl1, 101)
+		require.ErrorIs(t, err, expectedErr)
+		require.Equal(t, before, db.lastEntryContext)
+		require.Len(t, store.entries, beforeEntries)
+	})
+
+	t.Run("RewindSyncFailureDoesNotAdvanceState", func(t *testing.T) {
+		store := &faultEntryStore{}
+		db, err := NewFromEntryStore(logger, &stubMetrics{}, chainID, store, false)
+		require.NoError(t, err)
+		bl0 := eth.BlockID{Hash: createHash(0), Number: 0}
+		bl1 := eth.BlockID{Hash: createHash(1), Number: 1}
+		require.NoError(t, db.SealBlock(common.Hash{}, bl0, 100))
+		require.NoError(t, db.SealBlock(bl0.Hash, bl1, 101))
+		before := db.lastEntryContext
+
+		expectedErr := errors.New("sync failed")
+		store.syncErr = expectedErr
+		err = db.Rewind(reads.NoopRegistry{}, bl0)
+		require.ErrorIs(t, err, expectedErr)
+		require.Equal(t, before, db.lastEntryContext)
+	})
+
+	t.Run("ClearSyncFailureDoesNotAdvanceState", func(t *testing.T) {
+		store := &faultEntryStore{}
+		db, err := NewFromEntryStore(logger, &stubMetrics{}, chainID, store, false)
+		require.NoError(t, err)
+		bl0 := eth.BlockID{Hash: createHash(0), Number: 0}
+		require.NoError(t, db.SealBlock(common.Hash{}, bl0, 100))
+		before := db.lastEntryContext
+
+		expectedErr := errors.New("sync failed")
+		store.syncErr = expectedErr
+		err = db.Clear(reads.NoopRegistry{})
+		require.ErrorIs(t, err, expectedErr)
+		require.Equal(t, before, db.lastEntryContext)
+	})
 }
 
 func runDBTest(t *testing.T, setup func(t *testing.T, db *DB, m *stubMetrics), assert func(t *testing.T, db *DB, m *stubMetrics)) {


### PR DESCRIPTION
## Summary

Makes logsDB mutation state updates line up with storage success:

- apply `AddLog` and `SealBlock` to a copy of `lastEntryContext`, then publish the copied state only after append succeeds
- require `SealBlock` to `Sync` before publishing the new sealed block, rolling back appended seal entries on sync failure
- require `Clear` and `Rewind` truncates to `Sync` before publishing the cleared/rewound state
- add locking to `Clear` and share a locked helper with `Rewind`
- add focused fault-injection tests for append/sync failure paths

## Why

Supernode retry logic relies on logsDB not reporting advanced, cleared, or rewound state after a mutation returns an error. In particular, pending rewind replay can skip a logsDB rewind when `LatestSealedBlock` already appears to equal the target. Publishing `lastEntryContext` only after the storage operation succeeds keeps failed mutations visible as failed.

This is a narrow fix against `develop`; it does not adopt the larger deferred-`AddLog` buffering design.

## Validation

```
go test ./op-supervisor/supervisor/backend/db/entrydb ./op-supervisor/supervisor/backend/db/logs ./op-supernode/supernode/activity/interop
```
