### PR TITLE
  feat(contracts-bedrock): parametrize NUT bundle generator for Interop

### DIFF
--- a/packages/contracts-bedrock/scripts/libraries/UpgradeUtils.sol
+++ b/packages/contracts-bedrock/scripts/libraries/UpgradeUtils.sol
@@ -38,7 +38,7 @@ library UpgradeUtils {
         uint64 upgradeExecution;
     }
 
-    /// @notice Returns the total number of transactions for the current upgrade.
+    /// @notice Returns the total number of transactions for the named upgrade.
     /// @dev Total count:
     ///      - IMPLEMENTATION_COUNT implementation deployments
     ///      - 1 L2CM deployment

--- a/packages/contracts-bedrock/test/scripts/GenerateNUTBundle.t.sol
+++ b/packages/contracts-bedrock/test/scripts/GenerateNUTBundle.t.sol
@@ -72,7 +72,7 @@ contract GenerateNUTBundleTest is Test {
         assertEq(output.fork, script.upgradeName(), "fork mismatch");
     }
 
-    /// @notice Tests that transactions have correct structure.
+    /// @notice Tests that transactions have correct structure for the Interop upgrade.
     function test_run_transactionStructure_succeeds() public {
         GenerateNUTBundle.Output memory output = script.run();
 


### PR DESCRIPTION
Parametrizes the NUT bundle generator to support multiple forks (`UPGRADE_NAME`
  selects Karst or Interop) and regenerates the in-repo
  `packages/contracts-bedrock/snapshots/upgrades/current-upgrade-bundle.json`
  snapshot for Interop.

  First in a 3-PR stack for the Interop NUT bundle migration:

  1. **This PR** — generator parametrization + regenerated
  `current-upgrade-bundle.json`
  2. #20497 — embed the regenerated bundle into `op-core/nuts` and update
  `fork_lock.toml`
  3. #20397 — op-node + kona Interop activation migration (pending rebase onto
  #20497)