### PR TITLE
fix(op-e2e/config): return fully independent DeployConfig per call

### DIFF
--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -81,8 +81,13 @@ var (
 	l1DeploymentsByType = make(map[AllocType]*genesis.L1Deployments)
 	// l2Allocs represents the L2 allocs, by hardfork/mode (e.g. delta, ecotone, interop, other)
 	l2AllocsByType = make(map[AllocType]genesis.L2AllocsModeMap)
-	// DeployConfig represents the deploy config used by the system.
-	deployConfigsByType = make(map[AllocType]*genesis.DeployConfig)
+	// deployConfigBytesByType stores the canonical JSON encoding of the deploy
+	// config for each alloc type. We cache the bytes rather than the parsed
+	// *genesis.DeployConfig so each caller of DeployConfig() unmarshals a
+	// completely independent value. No shared pointers or maps survive between
+	// callers, so tests cannot mutate state another test depends on, and
+	// concurrent calls cannot race on a shared json.Marshal source.
+	deployConfigBytesByType = make(map[AllocType][]byte)
 	// EthNodeVerbosity is the (legacy geth) level of verbosity to output
 	EthNodeVerbosity int = 3
 
@@ -125,14 +130,22 @@ func L2Allocs(allocType AllocType, mode genesis.L2AllocsMode) *foundry.ForgeAllo
 	return allocs.Copy()
 }
 
+// DeployConfig returns a fresh, fully-independent *genesis.DeployConfig for
+// the given alloc type. Each call unmarshals from the cached JSON bytes, so
+// the returned value shares no maps, slices or pointers with any other call.
+// Callers can freely mutate the result without affecting any other test.
 func DeployConfig(allocType AllocType) *genesis.DeployConfig {
 	mtx.RLock()
-	defer mtx.RUnlock()
-	dc, ok := deployConfigsByType[allocType]
+	raw, ok := deployConfigBytesByType[allocType]
+	mtx.RUnlock()
 	if !ok {
 		panic(fmt.Errorf("unknown deploy config type: %q", allocType))
 	}
-	return dc.Copy()
+	dc := &genesis.DeployConfig{}
+	if err := json.Unmarshal(raw, dc); err != nil {
+		panic(fmt.Errorf("failed to unmarshal cached deploy config for %q: %w", allocType, err))
+	}
+	return dc
 }
 
 func init() {
@@ -323,8 +336,14 @@ func initAllocType(root string, allocType AllocType) {
 				dc.L1BlockTime = 2
 				dc.L2BlockTime = 1
 				dc.SetContracts(l1Contracts)
+				// Serialize the deploy config once now; callers will unmarshal
+				// a fresh copy from these bytes on every DeployConfig() call.
+				dcBytes, err := json.Marshal(dc)
+				if err != nil {
+					panic(fmt.Errorf("failed to marshal deploy config: %w", err))
+				}
 				mtx.Lock()
-				deployConfigsByType[allocType] = dc
+				deployConfigBytesByType[allocType] = dcBytes
 				l1AllocsByType[allocType] = st.L1StateDump.Data
 
 				l1Deployments := genesis.CreateL1DeploymentsFromContracts(l1Contracts)

--- a/op-e2e/config/init_test.go
+++ b/op-e2e/config/init_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+)
+
+// TestDeployConfigConcurrentMutationIsolated stresses DeployConfig() from many
+// goroutines that each mutate the returned value. Each call must return an
+// independent *genesis.DeployConfig: mutations made by one goroutine must not
+// be observable by any other, and the cached source must remain unchanged.
+//
+// Run with -race to catch any shared state that might be silently aliased.
+//
+// This is the regression guard for CircleCI failures where the matrix runner
+// for op-e2e/actions/proofs.TestOperatorFeeConsistency crashed inside
+// (*DeployConfig).Copy with "concurrent map writes". The previous
+// implementation handed out copies via a json.Marshal of a single shared
+// *DeployConfig; the new implementation snapshots the JSON once at init and
+// each caller unmarshals its own value, so no state is shared.
+func TestDeployConfigConcurrentMutationIsolated(t *testing.T) {
+	const testType AllocType = "test-race"
+
+	src := &genesis.DeployConfig{}
+	src.L1ChainID = 900
+	src.L2ChainID = 901
+	src.L2BlockTime = 1
+	originalIsthmus := hexutil.Uint64(42)
+	src.L2GenesisIsthmusTimeOffset = &originalIsthmus
+
+	raw, err := json.Marshal(src)
+	require.NoError(t, err)
+
+	mtx.Lock()
+	deployConfigBytesByType[testType] = raw
+	mtx.Unlock()
+	t.Cleanup(func() {
+		mtx.Lock()
+		delete(deployConfigBytesByType, testType)
+		mtx.Unlock()
+	})
+
+	const goroutines = 64
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				dc := DeployConfig(testType)
+				// Mutate scalar and pointer fields. If any state is shared
+				// across callers, -race will flag this or a later read will
+				// observe an unexpected value.
+				dc.L1ChainID = uint64(g*iterations + i)
+				v := hexutil.Uint64(uint64(g*iterations + i))
+				dc.L2GenesisIsthmusTimeOffset = &v
+
+				require.Equal(t, uint64(901), dc.L2ChainID)
+				require.NotNil(t, dc.L2GenesisIsthmusTimeOffset)
+				require.Equal(t, v, *dc.L2GenesisIsthmusTimeOffset)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// The cached source must be untouched: a fresh read should still see the
+	// original L1ChainID and Isthmus offset.
+	dc := DeployConfig(testType)
+	require.Equal(t, uint64(900), dc.L1ChainID)
+	require.NotNil(t, dc.L2GenesisIsthmusTimeOffset)
+	require.Equal(t, originalIsthmus, *dc.L2GenesisIsthmusTimeOffset)
+}


### PR DESCRIPTION
Cache the marshaled JSON for each alloc type at init and unmarshal a fresh `*genesis.DeployConfig` on every `DeployConfig()` call, instead of handing out `json.Marshal`-based copies of a single shared `*genesis.DeployConfig`.

The parallel matrix in `op-e2e/actions/proofs.TestOperatorFeeConsistency` was crashing inside `(*DeployConfig).Copy` with `fatal error: concurrent map writes` (e.g. CircleCI job 5023105). Many goroutines were marshalling the same shared source simultaneously. The new path has no shared mutable state — each caller gets a fully independent value with no aliased pointers/maps/slices, so tests can freely mutate without affecting other tests.

Includes a `-race` regression test that runs 64×200 goroutines mutating returned configs and asserts independence + cached-source stability.