### PR TITLE
op-supernode: redefine superroot_atTimestamp CurrentL1 as block being processed

### DIFF
--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -2,6 +2,7 @@ package superfaultproofs
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"math/rand"
 	"os"
@@ -260,6 +261,22 @@ func marshalTransition(superRoot eth.SuperV1, step uint64, progress ...interopTy
 	}).Marshal()
 }
 
+// awaitFullyProcessedL1 polls the supernode until it has fully processed targetL1
+// (CurrentL1.Number > targetL1). Required before driving the challenger trace
+// provider, whose gate rejects an l1Head not strictly below the supernode's
+// in-progress L1 block.
+func awaitFullyProcessedL1(t devtest.T, queryAPI apis.SupernodeQueryAPI, targetL1 uint64) {
+	t.Require().Eventually(func() bool {
+		ctx, cancel := context.WithTimeout(t.Ctx(), 10*time.Second)
+		defer cancel()
+		resp, err := queryAPI.SuperRootAtTimestamp(ctx, uint64(time.Now().Unix()))
+		if err != nil {
+			return false
+		}
+		return resp.CurrentL1.Number > targetL1
+	}, 5*time.Minute, 1*time.Second, fmt.Sprintf("supernode did not fully process L1 block %d in time", targetL1))
+}
+
 // latestRequiredL1 returns the latest RequiredL1 across all optimistic outputs,
 // i.e. the earliest L1 block at which all chains' data is derivable.
 func latestRequiredL1(resp eth.SuperRootAtTimestampResponse) eth.BlockID {
@@ -312,6 +329,12 @@ func runKonaInteropProgram(t devtest.T, cfg vm.Config, l1Head common.Hash, agree
 
 // runChallengerProviderTest verifies the challenger trace provider agrees with the test expectations.
 func runChallengerProviderTest(t devtest.T, queryAPI apis.SupernodeQueryAPI, gameDepth challengerTypes.Depth, startTimestamp, claimTimestamp uint64, test *transitionTest) {
+	// SuperRootAtTimestamp's CurrentL1 names the block currently being processed
+	// (L1[<CurrentL1] is fully processed). The trace provider's gate requires
+	// supernode CurrentL1 > test.L1Head, so wait for the supernode to advance
+	// past test.L1Head before driving the provider.
+	awaitFullyProcessedL1(t, queryAPI, test.L1Head.Number)
+
 	prestateProvider := super.NewSuperNodePrestateProvider(queryAPI, startTimestamp)
 	traceProvider := super.NewSuperNodeTraceProvider(
 		t.Logger().New("role", "challenger-provider"),

--- a/op-challenger/game/fault/trace/super/provider_supernode.go
+++ b/op-challenger/game/fault/trace/super/provider_supernode.go
@@ -54,8 +54,10 @@ func (s *SuperNodeTraceProvider) getPreimageBytesAtTimestampBoundary(ctx context
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve super root at timestamp %v: %w", timestamp, err)
 	}
-	if root.CurrentL1.Number < s.l1Head.Number {
-		// Node has not processed the game's L1 head so it is not safe to play until it syncs further.
+	if root.CurrentL1.Number <= s.l1Head.Number {
+		// CurrentL1 is the L1 block currently being processed; L1[<CurrentL1] is
+		// fully verified. We need the game's l1Head fully verified, so require
+		// CurrentL1 > l1Head — otherwise wait for further sync.
 		return nil, types2.ErrNotInSync
 	}
 	if root.Data == nil {
@@ -83,7 +85,7 @@ func (s *SuperNodeTraceProvider) GetPreimageBytes(ctx context.Context, pos types
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve previous super root at timestamp %v: %w", timestamp, err)
 	}
-	if prevRoot.CurrentL1.Number < s.l1Head.Number {
+	if prevRoot.CurrentL1.Number <= s.l1Head.Number {
 		return nil, types2.ErrNotInSync
 	}
 	if prevRoot.Data == nil {
@@ -100,7 +102,7 @@ func (s *SuperNodeTraceProvider) GetPreimageBytes(ctx context.Context, pos types
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve next super root at timestamp %v: %w", nextTimestamp, err)
 	}
-	if nextRoot.CurrentL1.Number < s.l1Head.Number {
+	if nextRoot.CurrentL1.Number <= s.l1Head.Number {
 		return nil, types2.ErrNotInSync
 	}
 

--- a/op-challenger/game/fault/trace/super/provider_supernode_test.go
+++ b/op-challenger/game/fault/trace/super/provider_supernode_test.go
@@ -26,7 +26,7 @@ func TestSuperNodeProvider_Get(t *testing.T) {
 			Output:  eth.Bytes32{0xbb},
 		})
 		response := eth.SuperRootAtTimestampResponse{
-			CurrentL1: l1Head,
+			CurrentL1: inSyncCurrentL1(l1Head),
 			ChainIDs:  []eth.ChainID{eth.ChainIDFromUInt64(1), eth.ChainIDFromUInt64(2)},
 			Data: &eth.SuperRootResponseData{
 				VerifiedRequiredL1: l1Head,
@@ -47,7 +47,7 @@ func TestSuperNodeProvider_Get(t *testing.T) {
 			Output:  eth.Bytes32{0xbb},
 		})
 		response := eth.SuperRootAtTimestampResponse{
-			CurrentL1: l1Head,
+			CurrentL1: inSyncCurrentL1(l1Head),
 			ChainIDs:  []eth.ChainID{eth.ChainIDFromUInt64(1), eth.ChainIDFromUInt64(2)},
 			Data: &eth.SuperRootResponseData{
 				VerifiedRequiredL1: l1Head,
@@ -77,7 +77,7 @@ func TestSuperNodeProvider_Get(t *testing.T) {
 			Output:  eth.Bytes32{0xbb},
 		})
 		response := eth.SuperRootAtTimestampResponse{
-			CurrentL1: l1Head,
+			CurrentL1: inSyncCurrentL1(l1Head),
 			ChainIDs:  []eth.ChainID{eth.ChainIDFromUInt64(1), eth.ChainIDFromUInt64(2)},
 			Data: &eth.SuperRootResponseData{
 				VerifiedRequiredL1: eth.BlockID{Number: l1Head.Number - 10, Hash: common.Hash{0xcc}},
@@ -98,7 +98,7 @@ func TestSuperNodeProvider_Get(t *testing.T) {
 			Output:  eth.Bytes32{0xbb},
 		})
 		response := eth.SuperRootAtTimestampResponse{
-			CurrentL1: l1Head,
+			CurrentL1: inSyncCurrentL1(l1Head),
 			ChainIDs:  []eth.ChainID{eth.ChainIDFromUInt64(1), eth.ChainIDFromUInt64(2)},
 			Data: &eth.SuperRootResponseData{
 				VerifiedRequiredL1: eth.BlockID{Number: l1Head.Number + 1, Hash: common.Hash{0xcc}},
@@ -202,7 +202,7 @@ func TestSuperNodeProvider_Get(t *testing.T) {
 	t.Run("Step0ForTimestampBeyondChainHead", func(t *testing.T) {
 		provider, stubSuperNode, l1Head := createSuperNodeProvider(t)
 		stubSuperNode.AddAtTimestamp(poststateTimestamp, eth.SuperRootAtTimestampResponse{
-			CurrentL1: l1Head,
+			CurrentL1: inSyncCurrentL1(l1Head),
 			ChainIDs:  []eth.ChainID{eth.ChainIDFromUInt64(1), eth.ChainIDFromUInt64(2)},
 			Data:      nil,
 		})
@@ -217,7 +217,7 @@ func TestSuperNodeProvider_Get(t *testing.T) {
 		prev, _ := createValidSuperNodeSuperRoots(l1Head)
 		stubSuperNode.Add(prev)
 		stubSuperNode.AddAtTimestamp(prestateTimestamp+1, eth.SuperRootAtTimestampResponse{
-			CurrentL1: l1Head,
+			CurrentL1: inSyncCurrentL1(l1Head),
 			ChainIDs:  prev.ChainIDs,
 			Data:      nil,
 		})
@@ -235,7 +235,7 @@ func TestSuperNodeProvider_Get(t *testing.T) {
 		prev, next := createValidSuperNodeSuperRoots(l1Head)
 		stubSuperNode.Add(prev)
 		stubSuperNode.AddAtTimestamp(prestateTimestamp+1, eth.SuperRootAtTimestampResponse{
-			CurrentL1: l1Head,
+			CurrentL1: inSyncCurrentL1(l1Head),
 			ChainIDs:  prev.ChainIDs,
 			OptimisticAtTimestamp: map[eth.ChainID]eth.OutputWithRequiredL1{
 				eth.ChainIDFromUInt64(2): next.OptimisticAtTimestamp[eth.ChainIDFromUInt64(2)],
@@ -255,7 +255,7 @@ func TestSuperNodeProvider_Get(t *testing.T) {
 		prev, next := createValidSuperNodeSuperRoots(l1Head)
 		stubSuperNode.Add(prev)
 		stubSuperNode.AddAtTimestamp(prestateTimestamp+1, eth.SuperRootAtTimestampResponse{
-			CurrentL1: l1Head,
+			CurrentL1: inSyncCurrentL1(l1Head),
 			ChainIDs:  next.ChainIDs,
 			OptimisticAtTimestamp: map[eth.ChainID]eth.OutputWithRequiredL1{
 				eth.ChainIDFromUInt64(1): next.OptimisticAtTimestamp[eth.ChainIDFromUInt64(1)],
@@ -278,12 +278,12 @@ func TestSuperNodeProvider_Get(t *testing.T) {
 	t.Run("PreviousSuperRootTimestampBeyondChainHead", func(t *testing.T) {
 		provider, stubSuperNode, l1Head := createSuperNodeProvider(t)
 		stubSuperNode.AddAtTimestamp(prestateTimestamp, eth.SuperRootAtTimestampResponse{
-			CurrentL1: l1Head,
+			CurrentL1: inSyncCurrentL1(l1Head),
 			ChainIDs:  []eth.ChainID{eth.ChainIDFromUInt64(1), eth.ChainIDFromUInt64(2)},
 			Data:      nil,
 		})
 		stubSuperNode.AddAtTimestamp(prestateTimestamp+1, eth.SuperRootAtTimestampResponse{
-			CurrentL1: l1Head,
+			CurrentL1: inSyncCurrentL1(l1Head),
 			ChainIDs:  []eth.ChainID{eth.ChainIDFromUInt64(1), eth.ChainIDFromUInt64(2)},
 			Data:      nil,
 		})
@@ -424,6 +424,14 @@ func createSuperNodeProvider(t *testing.T) (*SuperNodeTraceProvider, *stubSuperN
 	return provider, stubSuperNode, l1Head
 }
 
+// inSyncCurrentL1 returns a CurrentL1 value that signals the supernode has
+// processed past the game's l1Head. CurrentL1 names the block currently being
+// processed, so any value strictly greater than l1Head means l1Head is fully
+// verified.
+func inSyncCurrentL1(l1Head eth.BlockID) eth.BlockID {
+	return eth.BlockID{Number: l1Head.Number + 1, Hash: common.Hash{0xee}}
+}
+
 func createValidSuperNodeSuperRoots(l1Head eth.BlockID) (eth.SuperRootAtTimestampResponse, eth.SuperRootAtTimestampResponse) {
 	rng := rand.New(rand.NewSource(1))
 	outputA1 := testutils.RandomOutputV0(rng)
@@ -441,7 +449,7 @@ func createValidSuperNodeSuperRoots(l1Head eth.BlockID) (eth.SuperRootAtTimestam
 		eth.ChainIDAndOutput{ChainID: chainID2, Output: eth.OutputRoot(outputB2)})
 
 	prevResponse := eth.SuperRootAtTimestampResponse{
-		CurrentL1: l1Head,
+		CurrentL1: inSyncCurrentL1(l1Head),
 		ChainIDs:  []eth.ChainID{chainID1, chainID2},
 		OptimisticAtTimestamp: map[eth.ChainID]eth.OutputWithRequiredL1{
 			chainID1: {
@@ -462,7 +470,7 @@ func createValidSuperNodeSuperRoots(l1Head eth.BlockID) (eth.SuperRootAtTimestam
 		},
 	}
 	nextResponse := eth.SuperRootAtTimestampResponse{
-		CurrentL1: l1Head,
+		CurrentL1: inSyncCurrentL1(l1Head),
 		ChainIDs:  []eth.ChainID{chainID1, chainID2},
 		OptimisticAtTimestamp: map[eth.ChainID]eth.OutputWithRequiredL1{
 			chainID1: {

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -491,6 +491,10 @@ func (f *DisputeGameFactory) RunFPP(startTimestamp uint64, endTimestamp uint64) 
 	superRootResp, err := f.superNode.QueryAPI().SuperRootAtTimestamp(f.t.Ctx(), endTimestamp)
 	f.require.NoError(err, "Failed to fetch super root at timestamp")
 	l1Head := superRootResp.CurrentL1
+	// SuperRootAtTimestamp's CurrentL1 names the block currently being processed.
+	// The trace provider's gate requires supernode CurrentL1 > l1Head, so wait
+	// until the supernode advances past this block before invoking it.
+	f.superNode.AwaitFullyProcessedL1(l1Head.Number)
 
 	prestateProvider := super.NewSuperNodePrestateProvider(f.superNode.QueryAPI(), startTimestamp)
 	traceProvider := super.NewSuperNodeTraceProvider(

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -72,6 +72,23 @@ func (s *Supernode) AssertSuperRootAtTimestamp(l2SequenceNumber uint64, rootClai
 	s.require.Equal(superRoot[:], rootClaim[:])
 }
 
+// AwaitFullyProcessedL1 waits until the supernode has fully processed the given L1
+// block number. SuperRootAtTimestamp's CurrentL1 names the block currently being
+// processed (L1[<CurrentL1] is fully processed), so this returns once
+// CurrentL1.Number > targetL1.
+func (s *Supernode) AwaitFullyProcessedL1(targetL1 uint64) {
+	ctx, cancel := context.WithTimeout(s.ctx, 5*DefaultTimeout)
+	defer cancel()
+	err := wait.For(ctx, 1*time.Second, func() (bool, error) {
+		resp, err := s.inner.QueryAPI().SuperRootAtTimestamp(ctx, uint64(time.Now().Unix()))
+		if err != nil {
+			return false, nil // Ignore transient errors.
+		}
+		return resp.CurrentL1.Number > targetL1, nil
+	})
+	s.require.NoError(err, "supernode did not fully process L1 block %d in time", targetL1)
+}
+
 // AwaitValidatedTimestamp waits for the super-root at the given timestamp to be fully validated
 func (s *Supernode) AwaitValidatedTimestamp(timestamp uint64) {
 	ctx, cancel := context.WithTimeout(s.ctx, 5*DefaultTimeout)

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -302,7 +302,10 @@ func (l *L2OutputSubmitter) waitNodeSync() error {
 		return fmt.Errorf("failed to retrieve current L1 block number: %w", err)
 	}
 
-	return dial.WaitL1Sync(l.ctx, l.Log, l1head, time.Second*12, func(ctx context.Context) (eth.BlockID, error) {
+	// CurrentL1 names the L1 block currently being processed: only blocks strictly
+	// below it are fully derived. Wait until the source reports CurrentL1 > l1head
+	// by setting the target one above l1head.
+	return dial.WaitL1Sync(l.ctx, l.Log, l1head+1, time.Second*12, func(ctx context.Context) (eth.BlockID, error) {
 		status, err := l.ProposalSource.SyncStatus(ctx)
 		if err != nil {
 			return eth.BlockID{}, err

--- a/op-service/eth/supernode_status.go
+++ b/op-service/eth/supernode_status.go
@@ -8,8 +8,12 @@ type SuperNodeSyncStatusResponse struct {
 	// ChainIDs are the chain IDs in the dependency set, sorted ascending.
 	ChainIDs []ChainID `json:"chain_ids"`
 
-	// CurrentL1 is the highest L1 block ID that has been fully derived and verified by all chains.
-	// This value is derived from the minimum per-chain current L1 block IDs, including validators.
+	// CurrentL1 is the L1 block currently being processed by the slowest L1
+	// processor (op-node or verifier) in the supernode. Every L1 block strictly
+	// below CurrentL1.Number has been fully processed by all chains; data at
+	// CurrentL1 itself may still be incomplete. Consumers gating on
+	// "L1[≤X] is fully processed" must require CurrentL1.Number > X.
+	// Aggregated as the minimum of per-chain current L1 block IDs, including verifiers.
 	CurrentL1 BlockID `json:"current_l1"`
 
 	// SafeTimestamp is the highest L2 timestamp that is safe across the dependency set at the CurrentL1.

--- a/op-service/eth/superroot_at_timestamp.go
+++ b/op-service/eth/superroot_at_timestamp.go
@@ -52,7 +52,10 @@ func (d *SuperRootResponseData) UnmarshalJSON(input []byte) error {
 
 // AtTimestampResponse is the response superroot_atTimestamp
 type SuperRootAtTimestampResponse struct {
-	// CurrentL1 is the highest L1 block that has been fully derived and verified by all chains.
+	// CurrentL1 is the L1 block currently being processed by the slowest L1
+	// processor in the supernode. Every L1 block strictly below CurrentL1.Number
+	// has been fully processed; data at CurrentL1 itself may still be incomplete.
+	// Consumers gating on "L1[≤X] is fully processed" must require CurrentL1.Number > X.
 	CurrentL1 BlockID `json:"current_l1"`
 
 	// CurrentSafeTimestamp is the highest L2 timestamp that is safe across the dependency set at the CurrentL1.

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -976,8 +976,13 @@ func (i *Interop) commitVerifiedResult(timestamp uint64, verifiedResult Verified
 	return i.verifiedDB.Commit(verifiedResult)
 }
 
-// CurrentL1 returns the L1 block which has been fully considered for interop,
-// whether or not it advanced the verified timestamp.
+// CurrentL1 returns the L1 block currently being processed by the interop
+// verifier. Every L1 block strictly below CurrentL1.Number has been fully
+// considered for interop (i.e. used to verify every L2 timestamp whose source
+// is at or below it); data at CurrentL1 itself may still be unverified, since
+// L1Inclusion is monotonic in L2 timestamp and the next unverified timestamp
+// can share the same L1 source. Consumers must require CurrentL1.Number > X
+// to treat L1[≤X] as fully verified.
 func (i *Interop) CurrentL1() eth.BlockID {
 	i.mu.RLock()
 	defer i.mu.RUnlock()


### PR DESCRIPTION
Alternative to ethereum-optimism/optimism#20664. Instead of under-claiming `i.currentL1` by one L1 block on Advance, redefine the `superroot_atTimestamp` response's `CurrentL1` to mean "the L1 block currently being processed by the slowest L1 processor in the supernode" — matching op-node's sync-status semantics. L1 blocks strictly below `CurrentL1` are fully processed; data at `CurrentL1` itself may still be incomplete.

Consumers gating on "L1[≤X] fully processed" now require `CurrentL1 > X`, so op-challenger's three `ErrNotInSync` gates in `provider_supernode.go` flip from `<` to `<=`, and op-proposer's `waitNodeSync` bumps its target by one so the shared `dial.WaitL1Sync >=` gate also matches. The supernode needs no logic change — `i.currentL1 = L1Inclusion(T_v)` after Advance is correct under the new meaning, and `collectCurrentL1`'s min over op-node `CurrentL1` (also "being processed") stays consistent.

Tests that fed an `l1Head` from the live L1 chain or `SuperRootAtTimestamp.CurrentL1` into the trace provider now wait until the supernode has fully processed that L1 block; the wait is centralized in `runChallengerProviderTest` and mirrored as a DSL helper used by `DisputeGameFactory.RunFPP`. `l1Head` values themselves are unchanged so no required data is dropped.

op-node's `optimism_syncStatus` semantics are unchanged. `op-challenger/runner/game_inputs.go` is left as-is — its downstream logic compensates for an `l1Head` one block high.

Part of ethereum-optimism/optimism#18667.