### PR TITLE
fix(kona/client): bump FPVM precompile oracle gas for Glamsterdam (EIP-7904)

### DIFF
--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g1_add.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g1_add.rs
@@ -28,6 +28,9 @@ where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
+    /// Oracle/L1 staticcall gas required by [EIP-7904](https://eips.ethereum.org/EIPS/eip-7904).
+    const G1_ADD_ORACLE_GAS: u64 = 643;
+
     if G1_ADD_BASE_GAS_FEE > gas_limit {
         return Err(PrecompileHalt::OutOfGas);
     }
@@ -47,7 +50,7 @@ where
     let result_data = kona_proof::block_on(precompile_run! {
         hint_writer,
         oracle_reader,
-        &[precompile.address().as_slice(), &G1_ADD_BASE_GAS_FEE.to_be_bytes(), input]
+        &[precompile.address().as_slice(), &G1_ADD_ORACLE_GAS.to_be_bytes(), input]
     })
     .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
@@ -59,6 +62,7 @@ mod test {
     use super::*;
     use crate::fpvm_evm::precompiles::test_utils::{
         execute_native_precompile, test_accelerated_precompile,
+        test_accelerated_precompile_capture_hint,
     };
 
     #[tokio::test(flavor = "multi_thread")]
@@ -99,5 +103,26 @@ mod test {
             assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_accelerated_bls12_381_g1_add_oracle_gas_carries_l1_cost() {
+        let recorded_gas_used: std::sync::Arc<std::sync::Mutex<Option<u64>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
+        let recorded_gas_used_in = recorded_gas_used.clone();
+
+        let captured =
+            test_accelerated_precompile_capture_hint(move |hint_writer, oracle_reader| {
+                let input = [0u8; G1_ADD_INPUT_LENGTH];
+                let result =
+                    fpvm_bls12_g1_add(&input, u64::MAX, hint_writer, oracle_reader).unwrap();
+                *recorded_gas_used_in.lock().unwrap() = Some(result.gas_used);
+            })
+            .await;
+
+        // Oracle hint must carry the current L1 G1Add cost (EIP-7904: 643).
+        assert_eq!(captured.oracle_gas(), 643);
+        // L2 charge must remain unchanged (G1_ADD_BASE_GAS_FEE = 375).
+        assert_eq!(recorded_gas_used.lock().unwrap().unwrap(), G1_ADD_BASE_GAS_FEE);
     }
 }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g2_add.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g2_add.rs
@@ -28,6 +28,9 @@ where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
+    /// Oracle/L1 staticcall gas required by [EIP-7904](https://eips.ethereum.org/EIPS/eip-7904).
+    const G2_ADD_ORACLE_GAS: u64 = 765;
+
     if G2_ADD_BASE_GAS_FEE > gas_limit {
         return Err(PrecompileHalt::OutOfGas);
     }
@@ -47,7 +50,7 @@ where
     let result_data = kona_proof::block_on(precompile_run! {
         hint_writer,
         oracle_reader,
-        &[precompile.address().as_slice(), &G2_ADD_BASE_GAS_FEE.to_be_bytes(), input]
+        &[precompile.address().as_slice(), &G2_ADD_ORACLE_GAS.to_be_bytes(), input]
     })
     .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
@@ -59,6 +62,7 @@ mod test {
     use super::*;
     use crate::fpvm_evm::precompiles::test_utils::{
         execute_native_precompile, test_accelerated_precompile,
+        test_accelerated_precompile_capture_hint,
     };
 
     #[tokio::test(flavor = "multi_thread")]
@@ -99,5 +103,26 @@ mod test {
             assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_accelerated_bls12_381_g2_add_oracle_gas_carries_l1_cost() {
+        let recorded_gas_used: std::sync::Arc<std::sync::Mutex<Option<u64>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
+        let recorded_gas_used_in = recorded_gas_used.clone();
+
+        let captured =
+            test_accelerated_precompile_capture_hint(move |hint_writer, oracle_reader| {
+                let input = [0u8; G2_ADD_INPUT_LENGTH];
+                let result =
+                    fpvm_bls12_g2_add(&input, u64::MAX, hint_writer, oracle_reader).unwrap();
+                *recorded_gas_used_in.lock().unwrap() = Some(result.gas_used);
+            })
+            .await;
+
+        // Oracle hint must carry the current L1 G2Add cost (EIP-7904: 765).
+        assert_eq!(captured.oracle_gas(), 765);
+        // L2 charge must remain unchanged (G2_ADD_BASE_GAS_FEE = 600).
+        assert_eq!(recorded_gas_used.lock().unwrap().unwrap(), G2_ADD_BASE_GAS_FEE);
     }
 }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bn128_pair.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bn128_pair.rs
@@ -15,6 +15,10 @@ const BN256_MAX_PAIRING_SIZE_GRANITE: usize = 112_687;
 const BN256_MAX_PAIRING_SIZE_JOVIAN: usize = 81_984;
 const BN256_MAX_PAIRING_SIZE_KARST: usize = 57_600;
 
+/// Per-pair oracle/L1 gas required by [EIP-7904](https://eips.ethereum.org/EIPS/eip-7904).
+/// `ISTANBUL_PAIR_BASE` (45_000) is unchanged; only the per-pair rate differs (34_000 → 34_103).
+const GLAMSTERDAM_PAIR_PER_POINT: u64 = 34_103;
+
 /// Runs the FPVM-accelerated `ecpairing` precompile call.
 pub(crate) fn fpvm_bn128_pair<H, O>(
     input: &[u8],
@@ -26,8 +30,9 @@ where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
-    let gas_used =
-        (input.len() / PAIR_ELEMENT_LEN) as u64 * ISTANBUL_PAIR_PER_POINT + ISTANBUL_PAIR_BASE;
+    let pairs = (input.len() / PAIR_ELEMENT_LEN) as u64;
+    let gas_used = pairs * ISTANBUL_PAIR_PER_POINT + ISTANBUL_PAIR_BASE;
+    let oracle_gas = pairs * GLAMSTERDAM_PAIR_PER_POINT + ISTANBUL_PAIR_BASE;
 
     if gas_used > gas_limit {
         return Err(PrecompileHalt::OutOfGas);
@@ -42,7 +47,7 @@ where
     let result_data = kona_proof::block_on(precompile_run! {
         hint_writer,
         oracle_reader,
-        &[precompile.address().as_slice(), &gas_used.to_be_bytes(), input]
+        &[precompile.address().as_slice(), &oracle_gas.to_be_bytes(), input]
     })
     .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
@@ -111,6 +116,7 @@ mod test {
     use super::*;
     use crate::fpvm_evm::precompiles::test_utils::{
         execute_native_precompile, test_accelerated_precompile,
+        test_accelerated_precompile_capture_hint,
     };
     use alloy_primitives::hex;
 
@@ -255,5 +261,96 @@ mod test {
             assert!(matches!(accelerated_result, PrecompileHalt::Bn254PairLength));
         })
         .await;
+    }
+
+    /// Helper: capture the oracle hint and the recorded `gas_used` from a single
+    /// `fpvm_bn128_pair*` invocation, so the assertion site can compare both halves of the
+    /// L2-charge / oracle-gas split.
+    async fn capture_bn128_pair_hint(
+        run: impl Fn(
+            &[u8],
+            &kona_preimage::HintWriter<kona_preimage::NativeChannel>,
+            &kona_preimage::OracleReader<kona_preimage::NativeChannel>,
+        ) -> EthPrecompileResult
+        + Send
+        + Sync
+        + 'static,
+        input: Vec<u8>,
+    ) -> (crate::fpvm_evm::precompiles::test_utils::CapturedHint, u64) {
+        let recorded_gas_used: std::sync::Arc<std::sync::Mutex<Option<u64>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
+        let recorded_gas_used_in = recorded_gas_used.clone();
+
+        let captured =
+            test_accelerated_precompile_capture_hint(move |hint_writer, oracle_reader| {
+                let result = run(input.as_slice(), hint_writer, oracle_reader).unwrap();
+                *recorded_gas_used_in.lock().unwrap() = Some(result.gas_used);
+            })
+            .await;
+
+        let gas_used = recorded_gas_used.lock().unwrap().unwrap();
+        (captured, gas_used)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_accelerated_bn128_pairing_oracle_gas_carries_l1_cost_two_pairs() {
+        // 2 pairs (existing TEST_INPUT, 384 bytes).
+        let (captured, gas_used) = capture_bn128_pair_hint(
+            |input, hw, or| fpvm_bn128_pair(input, u64::MAX, hw, or),
+            TEST_INPUT.to_vec(),
+        )
+        .await;
+
+        // Oracle hint at current L1 per-pair rate (EIP-7904): 2 * 34_103 + 45_000 = 113_206
+        assert_eq!(captured.oracle_gas(), 2 * GLAMSTERDAM_PAIR_PER_POINT + ISTANBUL_PAIR_BASE);
+        assert_eq!(captured.oracle_gas(), 113_206);
+        // L2 charge unchanged at Istanbul rate: 2 * 34_000 + 45_000 = 113_000
+        assert_eq!(gas_used, 2 * ISTANBUL_PAIR_PER_POINT + ISTANBUL_PAIR_BASE);
+        assert_eq!(gas_used, 113_000);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_accelerated_bn128_pairing_oracle_gas_carries_l1_cost_three_pairs() {
+        // 3 pairs of zero-byte input (576 bytes). Empty pairs are valid input.
+        let input = vec![0u8; 3 * PAIR_ELEMENT_LEN];
+        let (captured, gas_used) = capture_bn128_pair_hint(
+            |input, hw, or| fpvm_bn128_pair(input, u64::MAX, hw, or),
+            input,
+        )
+        .await;
+
+        // Current L1 per-pair rate (EIP-7904): 3 * 34_103 + 45_000 = 147_309
+        assert_eq!(captured.oracle_gas(), 3 * GLAMSTERDAM_PAIR_PER_POINT + ISTANBUL_PAIR_BASE);
+        assert_eq!(captured.oracle_gas(), 147_309);
+        // 3 * 34_000 + 45_000 = 147_000
+        assert_eq!(gas_used, 3 * ISTANBUL_PAIR_PER_POINT + ISTANBUL_PAIR_BASE);
+        assert_eq!(gas_used, 147_000);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_accelerated_bn128_pairing_oracle_gas_carries_l1_cost_zero_pairs() {
+        // Empty input is valid (0 % PAIR_ELEMENT_LEN == 0). Locks the BASE summand.
+        let (captured, gas_used) = capture_bn128_pair_hint(
+            |input, hw, or| fpvm_bn128_pair(input, u64::MAX, hw, or),
+            Vec::new(),
+        )
+        .await;
+
+        assert_eq!(captured.oracle_gas(), ISTANBUL_PAIR_BASE);
+        assert_eq!(captured.oracle_gas(), 45_000);
+        assert_eq!(gas_used, ISTANBUL_PAIR_BASE);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_accelerated_bn128_pairing_granite_oracle_gas_carries_l1_cost() {
+        // Locks wrapper-inheritance: `fpvm_bn128_pair_granite` must delegate to
+        // `fpvm_bn128_pair`, so the oracle hint carries the current L1 cost.
+        let (captured, _) = capture_bn128_pair_hint(
+            |input, hw, or| fpvm_bn128_pair_granite(input, u64::MAX, hw, or),
+            TEST_INPUT.to_vec(),
+        )
+        .await;
+
+        assert_eq!(captured.oracle_gas(), 113_206);
     }
 }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/kzg_point_eval.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/kzg_point_eval.rs
@@ -21,6 +21,8 @@ where
     O: PreimageOracleClient + Send + Sync,
 {
     const GAS_COST: u64 = 50_000;
+    /// Oracle/L1 staticcall gas required by [EIP-7904](https://eips.ethereum.org/EIPS/eip-7904).
+    const KZG_ORACLE_GAS: u64 = 89_363;
 
     if gas_limit < GAS_COST {
         return Err(PrecompileHalt::OutOfGas);
@@ -33,7 +35,7 @@ where
     let result_data = kona_proof::block_on(precompile_run! {
         hint_writer,
         oracle_reader,
-        &[KZG_POINT_EVAL_ADDR.as_slice(), &GAS_COST.to_be_bytes(), input]
+        &[KZG_POINT_EVAL_ADDR.as_slice(), &KZG_ORACLE_GAS.to_be_bytes(), input]
     })
     .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
@@ -45,22 +47,26 @@ mod test {
     use super::*;
     use crate::fpvm_evm::precompiles::test_utils::{
         execute_native_precompile, test_accelerated_precompile,
+        test_accelerated_precompile_capture_hint,
     };
     use alloy_eips::eip4844::VERSIONED_HASH_VERSION_KZG;
     use alloy_primitives::hex;
     use sha2::{Digest, Sha256};
 
+    fn valid_kzg_input() -> Vec<u8> {
+        let commitment = hex!("8f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7").to_vec();
+        let mut versioned_hash = Sha256::digest(&commitment).to_vec();
+        versioned_hash[0] = VERSIONED_HASH_VERSION_KZG;
+        let z = hex!("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000").to_vec();
+        let y = hex!("1522a4a7f34e1ea350ae07c29c96c7e79655aa926122e95fe69fcbd932ca49e9").to_vec();
+        let proof = hex!("a62ad71d14c5719385c0686f1871430475bf3a00f0aa3f7b8dd99a9abc2160744faf0070725e00b60ad9a026a15b1a8c").to_vec();
+        [versioned_hash, z, y, commitment, proof].concat()
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_accelerated_kzg_point_eval() {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
-            let commitment = hex!("8f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7").to_vec();
-            let mut versioned_hash = Sha256::digest(&commitment).to_vec();
-            versioned_hash[0] = VERSIONED_HASH_VERSION_KZG;
-            let z = hex!("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000").to_vec();
-            let y = hex!("1522a4a7f34e1ea350ae07c29c96c7e79655aa926122e95fe69fcbd932ca49e9").to_vec();
-            let proof = hex!("a62ad71d14c5719385c0686f1871430475bf3a00f0aa3f7b8dd99a9abc2160744faf0070725e00b60ad9a026a15b1a8c").to_vec();
-
-            let input = [versioned_hash, z, y, commitment, proof].concat();
+            let input = valid_kzg_input();
 
             let expected_result = hex!("000000000000000000000000000000000000000000000000000000000000100073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");
 
@@ -70,6 +76,38 @@ mod test {
             assert_eq!(accelerated_result.bytes.as_ref(), expected_result.as_ref());
             assert_eq!(accelerated_result.bytes, native_result.bytes);
             assert_eq!(accelerated_result.gas_used, native_result.gas_used);
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_accelerated_kzg_point_eval_oracle_gas_carries_l1_cost() {
+        let recorded_gas_used: std::sync::Arc<std::sync::Mutex<Option<u64>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
+        let recorded_gas_used_in = recorded_gas_used.clone();
+
+        let captured =
+            test_accelerated_precompile_capture_hint(move |hint_writer, oracle_reader| {
+                let input = valid_kzg_input();
+                let result =
+                    fpvm_kzg_point_eval(&input, u64::MAX, hint_writer, oracle_reader).unwrap();
+                *recorded_gas_used_in.lock().unwrap() = Some(result.gas_used);
+            })
+            .await;
+
+        // Oracle hint must carry the current L1 KZG cost (EIP-7904: 89_363).
+        assert_eq!(captured.oracle_gas(), 89_363);
+        // L2 charge must remain unchanged (Cancun KZG = 50_000).
+        assert_eq!(recorded_gas_used.lock().unwrap().unwrap(), 50_000);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_accelerated_kzg_point_eval_at_l2_gas_boundary() {
+        // OOG guard is `<` not `<=`, so gas_limit == GAS_COST must succeed.
+        test_accelerated_precompile(|hint_writer, oracle_reader| {
+            let input = valid_kzg_input();
+            let result = fpvm_kzg_point_eval(&input, 50_000, hint_writer, oracle_reader);
+            assert!(result.is_ok(), "expected Ok at gas_limit == GAS_COST, got {result:?}");
         })
         .await;
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
@@ -575,6 +575,88 @@ mod test {
         .await;
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_provider_dispatches_l1_precompile_gas() {
+        use alloy_eips::eip4844::VERSIONED_HASH_VERSION_KZG;
+        use alloy_primitives::hex;
+        use revm::precompile::{
+            bls12_381_const::{G1_ADD_INPUT_LENGTH, G2_ADD_INPUT_LENGTH},
+            bn254::PAIR_ELEMENT_LEN,
+        };
+        use sha2::{Digest, Sha256};
+
+        // For each of the four precompiles whose L1 cost diverges from the L2 charge, drive
+        // `OpFpvmPrecompiles::run` at JOVIAN and assert the hint payload carries the L1 cost.
+        // This locks the production call site (provider-level dispatch), not just the leaf
+        // function — a future provider rewrite that swaps in a stale leaf would fail here even
+        // if the per-leaf tests still pass. Current L1 values reflect EIP-7904.
+
+        // KZG: 0x0a, valid input → expect 89_363
+        let kzg_input: Bytes = {
+            let commitment = hex!("8f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7").to_vec();
+            let mut versioned_hash = Sha256::digest(&commitment).to_vec();
+            versioned_hash[0] = VERSIONED_HASH_VERSION_KZG;
+            let z =
+                hex!("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000").to_vec();
+            let y =
+                hex!("1522a4a7f34e1ea350ae07c29c96c7e79655aa926122e95fe69fcbd932ca49e9").to_vec();
+            let proof = hex!("a62ad71d14c5719385c0686f1871430475bf3a00f0aa3f7b8dd99a9abc2160744faf0070725e00b60ad9a026a15b1a8c").to_vec();
+            [versioned_hash, z, y, commitment, proof].concat().into()
+        };
+        run_dispatch_and_assert_oracle_gas(
+            super::super::kzg_point_eval::KZG_POINT_EVAL_ADDR,
+            kzg_input,
+            89_363,
+        )
+        .await;
+
+        // bn254 pair: 0x08, 2 valid pairs of zero bytes → expect 113_206
+        let bn128_input: Bytes = vec![0u8; 2 * PAIR_ELEMENT_LEN].into();
+        run_dispatch_and_assert_oracle_gas(bn254::pair::ADDRESS, bn128_input, 113_206).await;
+
+        // BLS12-381 G1Add: 0x0b, 256-byte zero input → expect 643
+        let g1_input: Bytes = vec![0u8; G1_ADD_INPUT_LENGTH].into();
+        run_dispatch_and_assert_oracle_gas(bls12_381_const::G1_ADD_ADDRESS, g1_input, 643).await;
+
+        // BLS12-381 G2Add: 0x0d, 512-byte zero input → expect 765
+        let g2_input: Bytes = vec![0u8; G2_ADD_INPUT_LENGTH].into();
+        run_dispatch_and_assert_oracle_gas(bls12_381_const::G2_ADD_ADDRESS, g2_input, 765).await;
+    }
+
+    /// Helper: drive `OpFpvmPrecompiles::run` at JOVIAN for the given precompile address,
+    /// capture the L1Precompile hint, and assert its 8-byte gas word equals `expected_gas`.
+    async fn run_dispatch_and_assert_oracle_gas(address: Address, input: Bytes, expected_gas: u64) {
+        use crate::fpvm_evm::precompiles::test_utils::test_accelerated_precompile_capture_hint;
+
+        let captured =
+            test_accelerated_precompile_capture_hint(move |hint_writer, oracle_reader| {
+                let mut ctx = create_test_context();
+                let mut precompiles = OpFpvmPrecompiles::new_with_spec(
+                    OpSpecId::JOVIAN,
+                    hint_writer.clone(),
+                    oracle_reader.clone(),
+                );
+                let call_inputs = create_call_inputs(address, input.clone(), u64::MAX);
+                let result = precompiles
+                    .run(&mut ctx, &call_inputs)
+                    .expect("provider run errored")
+                    .expect("provider returned None for accelerated address");
+                assert_eq!(
+                    result.result,
+                    InstructionResult::Return,
+                    "expected successful precompile result, got {:?}",
+                    result.result
+                );
+            })
+            .await;
+
+        assert_eq!(
+            captured.oracle_gas(),
+            expected_gas,
+            "oracle gas mismatch at address {address:?}",
+        );
+    }
+
     #[test]
     fn test_run_with_shared_buffer_empty() {
         let (hint_chan, preimage_chan) = (

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/test_utils.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/test_utils.rs
@@ -18,12 +18,49 @@ use tokio::sync::{Mutex, RwLock};
 pub(crate) async fn test_accelerated_precompile(
     f: impl Fn(&HintWriter<NativeChannel>, &OracleReader<NativeChannel>) + Send + Sync + 'static,
 ) {
+    test_accelerated_precompile_inner(Arc::new(RwLock::new(None)), f).await;
+}
+
+/// The most recent `L1Precompile` hint payload captured by the mock host.
+#[derive(Debug, Clone)]
+pub(crate) struct CapturedHint {
+    /// Raw hint payload: `address[20] || gas[8] || input[..]`.
+    pub(crate) data: Vec<u8>,
+}
+
+impl CapturedHint {
+    /// The 8-byte oracle-gas value the client embedded in the hint.
+    pub(crate) fn oracle_gas(&self) -> u64 {
+        u64::from_be_bytes(self.data[20..28].try_into().unwrap())
+    }
+}
+
+/// Variant of [`test_accelerated_precompile`] that returns the most recent `L1Precompile` hint
+/// payload after the closure completes. Tests use this to assert oracle-gas bytes at offset
+/// 20..28 without reading the lock from inside the (sync) closure.
+pub(crate) async fn test_accelerated_precompile_capture_hint(
+    f: impl Fn(&HintWriter<NativeChannel>, &OracleReader<NativeChannel>) + Send + Sync + 'static,
+) -> CapturedHint {
+    let last_hint = Arc::new(RwLock::new(None));
+    test_accelerated_precompile_inner(last_hint.clone(), f).await;
+
+    let guard = last_hint.read().await;
+    let raw = guard.as_ref().expect("client did not emit an L1Precompile hint");
+    let parsed: Hint<HintType> = raw.parse().expect("failed to parse captured hint");
+    CapturedHint { data: parsed.data.as_ref().to_vec() }
+}
+
+async fn test_accelerated_precompile_inner(
+    last_hint: Arc<RwLock<Option<String>>>,
+    f: impl Fn(&HintWriter<NativeChannel>, &OracleReader<NativeChannel>) + Send + Sync + 'static,
+) {
     let (hint_chan, preimage_chan) =
         (BidirectionalChannel::new().unwrap(), BidirectionalChannel::new().unwrap());
 
     let host = tokio::task::spawn(precompile_host(
         OracleServer::new(preimage_chan.host),
         HintReader::new(hint_chan.host),
+        last_hint,
     ));
     let client = tokio::task::spawn(async move {
         let oracle_reader = OracleReader::new(preimage_chan.client);
@@ -52,14 +89,18 @@ pub(crate) fn execute_native_precompile<T: Into<Bytes>>(
 }
 
 /// Starts a mock host thread that serves [`HintType::L1Precompile`] hints and preimages.
+///
+/// `last_hint` is shared with the caller so tests using
+/// [`test_accelerated_precompile_capture_hint`] can read the most recently routed hint
+/// after the client closure completes.
 async fn precompile_host(
     oracle_server: OracleServer<NativeChannel>,
     hint_reader: HintReader<NativeChannel>,
+    last_hint: Arc<RwLock<Option<String>>>,
 ) {
-    let last_hint = Arc::new(RwLock::new(None));
     let preimage_fetcher =
         PrecompilePreimageFetcher { map: Default::default(), last_hint: last_hint.clone() };
-    let hint_router = PrecompileHintRouter { last_hint: last_hint.clone() };
+    let hint_router = PrecompileHintRouter { last_hint };
 
     let server = tokio::task::spawn(async move {
         loop {


### PR DESCRIPTION
Split the single gas constant in each FPVM-accelerated precompile into two named values: the L2 gas charge (unchanged) and the oracle/L1 staticcall gas required by EIP-7904, sent in the L1Precompile preimage hint.

Without this fix, once Glamsterdam activates on L1, the `loadPrecompilePreimagePart` staticcall would silently OOG for KZG, BLS12-381 G1Add, G2Add, and bn256 pairing because the requiredGas embedded in the preimage key would be below the post-7904 L1 cost. Higher-than-needed oracle gas is always safe, so this can deploy proactively.

L2 gas charging (`EthPrecompileOutput::gas_used`) and the OOG guards continue to use the existing values, preserving state-root agreement with op-reth pre-revm-bump.

Affected (EIP-7904 L1 cost → embedded in oracle hint):
- KZG point eval (0x0a): 89_363
- BLS12-381 G1Add (0x0b): 643
- BLS12-381 G2Add (0x0d): 765
- bn256 pairing (0x08): 45_000 + 34_103 × k

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/19381

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes  https://github.com/ethereum-optimism/optimism/issues/19381
-->
