### PR TITLE
fix(op-supernode): anchor backfill end to verifiedDB on restart

### DIFF
--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -47,10 +47,23 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 
 	firstVerifiable := i.firstVerifiable
 	if !i.firstVerifiableSet {
-		var err error
-		firstVerifiable, err = i.resolveFirstVerifiableTimestamp(i.ctx)
-		if err != nil {
-			return 0, err
+		// On a wipe-logs restart the verifiedDB persists and is the durable
+		// source of truth for the next timestamp the main loop will verify:
+		// observeRound picks NextTimestamp = LastTimestamp+1 whenever the
+		// verifiedDB is initialized. Anchor backfill's end to that same value
+		// instead of to a live SafeL2 read. The op-node's StatusTracker
+		// briefly reports SafeL2 at block 0 after a rollup.ResetEvent and
+		// before the next OnCrossSafeUpdate, and a SyncStatus call in that
+		// window would otherwise pin endTime to genesisTime and seal only
+		// block 0.
+		if lastTS, initialized := i.verifiedDB.LastTimestamp(); initialized {
+			firstVerifiable = lastTS + 1
+		} else {
+			var err error
+			firstVerifiable, err = i.resolveFirstVerifiableTimestamp(i.ctx)
+			if err != nil {
+				return 0, err
+			}
 		}
 	}
 	if firstVerifiable == i.activationTimestamp {

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -47,15 +47,10 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 
 	firstVerifiable := i.firstVerifiable
 	if !i.firstVerifiableSet {
-		// On a wipe-logs restart the verifiedDB persists and is the durable
-		// source of truth for the next timestamp the main loop will verify:
-		// observeRound picks NextTimestamp = LastTimestamp+1 whenever the
-		// verifiedDB is initialized. Anchor backfill's end to that same value
-		// instead of to a live SafeL2 read. The op-node's StatusTracker
-		// briefly reports SafeL2 at block 0 after a rollup.ResetEvent and
-		// before the next OnCrossSafeUpdate, and a SyncStatus call in that
-		// window would otherwise pin endTime to genesisTime and seal only
-		// block 0.
+		// Anchor to verifiedDB (the same source observeRound uses) rather than
+		// a live SafeL2 read. StatusTracker briefly reports SafeL2 at block 0
+		// between rollup.ResetEvent and the next OnCrossSafeUpdate; reading it
+		// in that window would truncate the backfill range to a single block.
 		if lastTS, initialized := i.verifiedDB.LastTimestamp(); initialized {
 			firstVerifiable = lastTS + 1
 		} else {

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -697,24 +697,11 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 		"backfill must start at genesis (%d), not the pre-clamp startTime (60)", genesisTime)
 }
 
-// TestLogBackfill_RestartWithStaleCrossSafe reproduces the
-// TestSupernodeLogBackfill_HappyPath flake.
-//
-// Scenario: after a wipe-logs restart, the new interop activity calls
-// runLogBackfill before the L2 op-node's StatusTracker has re-emitted its
-// cross-safe head. SafeL2 momentarily reads at block 0 (timestamp ==
-// genesisTime == activation) — the value StatusTracker installs after a
-// rollup.ResetEvent and before the next OnCrossSafeUpdate. The previous
-// runLogBackfill computed endTime from this live SafeL2 and produced a
-// degenerate one-block range covering only block 0, so the test asserting
-// "backfill produced multiple sealed blocks" failed with "0 is not greater
-// than 0".
-//
-// The verifiedDB persists across restart and is the durable source of truth
-// for the verification handoff boundary. After this fix runLogBackfill uses
-// verifiedDB.LastTimestamp() to derive endTime when the verifiedDB has
-// committed results, so a stale live SafeL2 can no longer truncate the
-// backfill range.
+// TestLogBackfill_RestartWithStaleCrossSafe simulates a post-restart state
+// where StatusTracker reports SafeL2 at block 0 (the value installed between
+// rollup.ResetEvent and the next OnCrossSafeUpdate). With a populated
+// verifiedDB, backfill must derive its end from verifiedDB.LastTimestamp()
+// rather than the stale live SafeL2.
 func TestLogBackfill_RestartWithStaleCrossSafe(t *testing.T) {
 	const (
 		act          uint64 = 100
@@ -726,9 +713,7 @@ func TestLogBackfill_RestartWithStaleCrossSafe(t *testing.T) {
 		WithActivation(act).
 		WithLogBackfillDepth(depth).
 		WithChain(10, func(m *mockChainContainer) {
-			// LocalSafe has advanced (chain has plenty of history), but SafeL2
-			// is reported as block 0 — the post-ResetEvent state of the
-			// op-node's StatusTracker before the next OnCrossSafeUpdate.
+			// LocalSafe advanced; SafeL2 still zeroed (stale post-Reset state).
 			m.syncStatusFull = &eth.SyncStatus{
 				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
 				UnsafeL2:    eth.L2BlockRef{Number: 200, Time: 200},
@@ -739,10 +724,8 @@ func TestLogBackfill_RestartWithStaleCrossSafe(t *testing.T) {
 		Build()
 	h.interop.ctx = context.Background()
 
-	// Simulate the pre-restart verifiedDB state: the previous activity verified
-	// timestamps up through `lastVerified`. The wipe-logs restart preserves this
-	// DB because verifiedDB lives in the supernode data dir, not in the
-	// per-chain logs dir the wipe deletes.
+	// Pre-restart verifiedDB state (survives wipe-logs since it lives outside
+	// the per-chain dir).
 	chain10 := h.Mock(10)
 	for ts := act + 1; ts <= lastVerified; ts++ {
 		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -696,3 +696,73 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 	require.Equal(t, int32(11), outputCalls.Load(),
 		"backfill must start at genesis (%d), not the pre-clamp startTime (60)", genesisTime)
 }
+
+// TestLogBackfill_RestartWithStaleCrossSafe reproduces the
+// TestSupernodeLogBackfill_HappyPath flake.
+//
+// Scenario: after a wipe-logs restart, the new interop activity calls
+// runLogBackfill before the L2 op-node's StatusTracker has re-emitted its
+// cross-safe head. SafeL2 momentarily reads at block 0 (timestamp ==
+// genesisTime == activation) — the value StatusTracker installs after a
+// rollup.ResetEvent and before the next OnCrossSafeUpdate. The previous
+// runLogBackfill computed endTime from this live SafeL2 and produced a
+// degenerate one-block range covering only block 0, so the test asserting
+// "backfill produced multiple sealed blocks" failed with "0 is not greater
+// than 0".
+//
+// The verifiedDB persists across restart and is the durable source of truth
+// for the verification handoff boundary. After this fix runLogBackfill uses
+// verifiedDB.LastTimestamp() to derive endTime when the verifiedDB has
+// committed results, so a stale live SafeL2 can no longer truncate the
+// backfill range.
+func TestLogBackfill_RestartWithStaleCrossSafe(t *testing.T) {
+	const (
+		act          uint64 = 100
+		lastVerified uint64 = 195
+	)
+	depth := 60 * time.Second
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(depth).
+		WithChain(10, func(m *mockChainContainer) {
+			// LocalSafe has advanced (chain has plenty of history), but SafeL2
+			// is reported as block 0 — the post-ResetEvent state of the
+			// op-node's StatusTracker before the next OnCrossSafeUpdate.
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: 200, Time: 200},
+				SafeL2:      eth.L2BlockRef{Number: 0, Time: act},
+				LocalSafeL2: eth.L2BlockRef{Number: 200, Time: 200},
+			}
+		}).
+		Build()
+	h.interop.ctx = context.Background()
+
+	// Simulate the pre-restart verifiedDB state: the previous activity verified
+	// timestamps up through `lastVerified`. The wipe-logs restart preserves this
+	// DB because verifiedDB lives in the supernode data dir, not in the
+	// per-chain logs dir the wipe deletes.
+	chain10 := h.Mock(10)
+	for ts := act + 1; ts <= lastVerified; ts++ {
+		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+			Timestamp:   ts,
+			L1Inclusion: eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chain10.id: {Number: ts, Hash: common.BigToHash(new(big.Int).SetUint64(ts))}},
+		}))
+	}
+
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	h.interop.backfillEndTimestamp = end
+
+	require.Equal(t, lastVerified, end,
+		"backfill must derive endTime from verifiedDB.LastTimestamp on restart, not from stale live SafeL2")
+
+	latest, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
+	require.True(t, has)
+	require.Greater(t, latest.Number, uint64(0),
+		"backfill must produce multiple sealed blocks; got only block %d", latest.Number)
+	require.Equal(t, lastVerified, latest.Number,
+		"backfill latest must equal verifiedDB.LastTimestamp / block height")
+}


### PR DESCRIPTION
Fixes flake in `TestSupernodeLogBackfill_HappyPath` (ethereum-optimism/optimism#20690).

`runLogBackfill` derived its end timestamp from a live `SyncStatus` read. After a `rollup.ResetEvent`, `StatusTracker.published.SafeL2` is briefly zeroed and `EngineResetConfirmedEvent` sets it back to a genesis-equivalent value via SuperAuthority's no-verifier fallback. A backfill that reads `SyncStatus` inside that window pins `endTime = activationTimestamp` and seals only block 0.

Anchor `firstVerifiable` to `verifiedDB.LastTimestamp() + 1` when the verifiedDB is initialized — the same source `observeRound` already trusts. In steady state this equals the value `resolveFirstVerifiableTimestamp` would have returned (since `SafeL2` is derived from `verifiedDB.LastTimestamp()` via `FullyVerifiedL2Head`); during the reset window it bypasses the stale cache. Cold-start path is unchanged.

Cold-start has a related (pre-existing) bug — backfill anchored to a stale/genesis cross-safe never reaches the EL's local-safe head. Filed as a follow-up; out of scope here.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>