### PR TITLE
fix(op-batcher): treat empty syncStatus.currentL1 as a special case (not "currentL1 reversed")

### DIFF
--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -74,13 +74,15 @@ func computeSyncActions[T channelStatuser](
 	// PART 1: Initial checks on the sync status (on fields which should never be empty)
 	if isZero(safeL2) ||
 		isZero(newSyncStatus.UnsafeL2) ||
-		isZero(newSyncStatus.HeadL1) {
+		isZero(newSyncStatus.HeadL1) ||
+		isZero(newSyncStatus.CurrentL1) {
 		m.Warn("empty BlockRef in sync status")
 		return syncActions{}, true
 	}
 
 	if newSyncStatus.CurrentL1.Number < prevCurrentL1.Number {
-		// This can happen when the sequencer restarts
+		// This can happen when the sequencer restarts or when there is an L1 reorg
+		// It should eventually catch back up.
 		m.Warn("sequencer currentL1 reversed", "prevCurrentL1", prevCurrentL1.TerminalString())
 		return syncActions{}, true
 	}

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -79,6 +79,17 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			expectedSeqOutOfSync: true,
 			expectedLogs:         []string{"empty BlockRef in sync status"},
 		},
+		{name: "empty currentL1",
+			newSyncStatus: eth.SyncStatus{
+				HeadL1:      eth.BlockRef{Number: 2},
+				CurrentL1:   eth.BlockRef{},
+				LocalSafeL2: eth.L2BlockRef{Number: 100},
+				UnsafeL2:    eth.L2BlockRef{Number: 101},
+			},
+			expected:             syncActions{},
+			expectedSeqOutOfSync: true,
+			expectedLogs:         []string{"empty BlockRef in sync status"},
+		},
 		{name: "current l1 reversed",
 			// This can happen when the sequencer restarts or is switched
 			// to a backup sequencer:


### PR DESCRIPTION
gives clearer semantics and prevents, no change in behaviour other than logging

