### PR TITLE
refactor(kona/derive): gate async pipeline behind cargo feature (phase 1/6)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -244,7 +244,7 @@ kona-client = { path = "kona/bin/client", version = "1.0.2", default-features = 
 
 # Protocol
 kona-comp = { path = "kona/crates/batcher/comp", version = "0.4.5", default-features = false }
-kona-derive = { path = "kona/crates/protocol/derive", version = "0.4.5", default-features = false }
+kona-derive = { path = "kona/crates/protocol/derive", version = "0.4.5" }
 kona-interop = { path = "kona/crates/protocol/interop", version = "0.4.5", default-features = false }
 kona-genesis = { path = "kona/crates/protocol/genesis", version = "0.4.5", default-features = false }
 kona-protocol = { path = "kona/crates/protocol/protocol", version = "0.4.5", default-features = false }

--- a/rust/kona/crates/protocol/derive/Cargo.toml
+++ b/rust/kona/crates/protocol/derive/Cargo.toml
@@ -33,7 +33,7 @@ op-alloy-consensus = { workspace = true, features = ["k256"] }
 
 # General
 tracing.workspace = true
-async-trait.workspace = true
+async-trait = { workspace = true, optional = true }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 
@@ -56,7 +56,11 @@ alloy-primitives = { workspace = true, features = ["rlp", "k256", "map", "arbitr
 op-alloy-consensus = { workspace = true, features = ["k256"] }
 
 [features]
-default = []
+default = ["async"]
+# Gates the existing async derivation pipeline (stages, sources, traits, drivers).
+# Phase 1 of the pure-derivation migration: removed in phase 6 once the async
+# surface is deleted. See plans/2026-05-06-refactor-kona-pure-derivation-plan.md.
+async = ["dep:async-trait"]
 metrics = [ "dep:metrics" ]
 serde = [
 	"alloy-consensus/serde",
@@ -72,6 +76,7 @@ serde = [
 	"tracing-subscriber?/serde",
 ]
 test-utils = [
+	"async",
 	"dep:spin",
 	"dep:tracing-subscriber",
 	"kona-interop/test-utils",

--- a/rust/kona/crates/protocol/derive/MIGRATION.md
+++ b/rust/kona/crates/protocol/derive/MIGRATION.md
@@ -1,0 +1,150 @@
+# kona-derive migration: async → pure deriver
+
+This document tracks the migration corridor opened by Phase 1 of the
+pure-derivation refactor. It exists for the duration of phases 1–6b; once
+the async pipeline is deleted in phase 6b it can be removed.
+
+See `plans/2026-05-06-refactor-kona-pure-derivation-plan.md` in op-claude
+for the full plan.
+
+## Phase 1 state (this PR)
+
+`kona-derive` now exposes two compile modes:
+
+- **`--features async`** (default) — the existing pipeline, traits, stages,
+  sources, and async test mocks. Today's behavior, byte-identical.
+- **`--no-default-features`** — only the sync surface: `PipelineError`,
+  `PipelineErrorKind`, `ResetError`, `BuilderError`, `BatchDecompressionError`,
+  `BlobDecodingError`, `BlobProviderError`, `PipelineEncodingError`,
+  `Signal`, `ResetSignal`, `ActivationSignal`, `StepResult`, `PipelineResult`,
+  `Metrics`. Nothing here pulls in `async-trait`.
+
+The workspace dep at `rust/Cargo.toml` was flipped from
+`default-features = false` to inheriting defaults, so every existing consumer
+continues to compile with `async` on. No consumer Cargo.toml needs touching
+in this PR.
+
+### Deviation from plan wording
+
+The plan lists `AttributesBuilder` (trait) and `StatefulAttributesBuilder`
+(struct) as "sync items" that stay unconditional. Both are async-trait based
+today (`AttributesBuilder::prepare_payload_attributes` is `async fn`,
+`StatefulAttributesBuilder` only exposes that trait impl). Making them
+unconditional in Phase 1 would require keeping `async-trait` as a non-optional
+dependency, defeating the gate. They're therefore behind `cfg(feature = "async")`
+here; **Phase 2** carves out the sync math into `core::attributes` and the
+trait becomes unconditional then. The plan's wording is forward-looking to
+that state.
+
+## Consumer inventory
+
+Every in-tree consumer of `kona_derive` async items. Phase column lists the
+phase that retires that site (or migrates it onto `pure::Deriver`).
+
+### `kona-derive::{Pipeline, SignalReceiver, Stage}` — pipeline-driver surface
+
+| Site | Phase |
+|------|-------|
+| `crates/node/service/src/actors/derivation/actor.rs` (step loop, signal handling) | 4 |
+| `crates/node/service/src/actors/derivation/state_machine.rs` (entire `Signal*` state machine) | 4 (collapsed) |
+| `crates/node/service/src/actors/derivation/delegated/actor.rs` | 4 |
+| `crates/node/service/src/actors/derivation/request.rs` | 4 |
+| `crates/node/service/src/actors/engine/{client.rs,engine_request_processor.rs}` (Signal forwarding) | 4 |
+| `crates/proof/driver/src/core.rs` (`Pipeline + SignalReceiver` bound on driver) | 5 |
+| `crates/proof/driver/src/pipeline.rs` (`DriverPipeline::produce_payload`) | 5 |
+
+### `kona-derive::{OnlinePipeline, OraclePipeline, EthereumDataSource}` — concrete drivers
+
+| Site | Phase |
+|------|-------|
+| `crates/providers/providers-alloy/src/pipeline.rs` (`OnlinePipeline::{new_polled,new_indexed}`) | 4 (deleted) |
+| `crates/proof/proof/src/l1/pipeline.rs` (`OraclePipeline::new`) | 5 (deleted) |
+| `crates/proof/proof/src/l1/mod.rs` re-exports (`ProviderDerivationPipeline`, `ProviderAttributesBuilder`) | 5 (deleted) |
+| `bin/client/src/single.rs` (`EthereumDataSource` use) | 5 |
+| `bin/client/src/interop/{mod.rs,transition.rs}` (`EthereumDataSource` use) | 5 |
+| `bin/host/src/interop/handler.rs` (`EthereumDataSource` use) | 5 |
+| `bin/host/src/error.rs` (`From<PipelineError>` impl for `HostError`) | 5 (stays — error type) |
+
+### `kona-derive::{BlobProvider, ChainProvider, L2ChainProvider, DataAvailabilityProvider}` — provider traits
+
+| Site (`impl` block, not call site) | Phase |
+|---|---|
+| `crates/providers/providers-alloy/src/chain_provider.rs` (`AlloyChainProvider` `impl ChainProvider`) | 6b (trait deleted; struct stays as concrete fetcher) |
+| `crates/providers/providers-alloy/src/l2_chain_provider.rs` (`AlloyL2ChainProvider` `impl L2ChainProvider`) | 6b (same) |
+| `crates/providers/providers-alloy/src/blobs.rs` (`OnlineBlobProvider` `impl BlobProvider`) | 6b (same) |
+| `crates/proof/proof/src/l1/chain_provider.rs` (`OracleL1ChainProvider` `impl ChainProvider`) | 6b |
+| `crates/proof/proof/src/l1/blob_provider.rs` (`OracleBlobProvider` `impl BlobProvider`) | 6b |
+| `crates/proof/proof/src/l2/chain_provider.rs` (`OracleL2ChainProvider` `impl L2ChainProvider`) | 6b |
+| `crates/proof/proof/src/sync.rs` (uses `ChainProvider` trait for sysconfig walkback) | 5 (migrate to direct method calls) |
+| `crates/providers/providers-local/src/buffered.rs` (`BufferedL2Provider` `impl L2ChainProvider`) | see below |
+| `bin/node/src/flags/p2p.rs` (`ChainProvider` trait bound on a fetch helper) | 4 (drop bound, use concrete `AlloyChainProvider`) |
+
+### `kona-derive::{AttributesBuilder, StatefulAttributesBuilder}` — attribute building
+
+| Site | Phase |
+|------|-------|
+| `crates/node/service/src/service/node.rs` (`StatefulAttributesBuilder` construction) | 4 → driver-owned |
+| `crates/node/service/src/service/builder.rs` (docs reference) | 4 |
+| `crates/node/service/src/actors/sequencer/{actor.rs,metrics.rs,admin_api_impl.rs}` (`AttributesBuilder` trait use for sequencing) | 4 (depends on phase 2 carve-out making the trait sync) |
+| `crates/proof/proof/src/l1/pipeline.rs` (`ProviderAttributesBuilder` alias) | 5 (deleted with `OraclePipeline`) |
+| `crates/providers/providers-alloy/src/pipeline.rs` (`OnlineAttributesBuilder` alias) | 4 (deleted with `OnlinePipeline`) |
+| `bin/client/src/single.rs` (`StatefulAttributesBuilder` doc reference) | 5 |
+
+### `kona-derive::{Signal, ResetSignal, ActivationSignal, StepResult}` — already-sync glue
+
+These stay live through phases 1–5 as the actor's coordination vocabulary
+and are deleted in **6b** when `Pipeline::signal` and `Stage::step` go away.
+
+### `kona-derive::test_utils::*` — async test mocks
+
+| Site | Phase |
+|------|-------|
+| `crates/node/service/Cargo.toml` `dev-dependencies` (`kona-derive = { features = ["test-utils"] }`) | 6b (dep dropped) |
+| `crates/node/service/src/actors/sequencer/tests/{test_util.rs,actor_test.rs}` (`TestAttributesBuilder`) | 4 (replaced with concrete sync builder or driver-level test fixtures) |
+
+### `kona-derive::Metrics` — metrics constants
+
+| Site | Phase |
+|------|-------|
+| `bin/node/src/flags/metrics.rs` (`Metrics::init`) | 6b (metrics module deleted; drivers re-emit from `DeriveTrace`) |
+
+## providers-local fate
+
+**Decision: retire.** `crates/providers/providers-local/src/buffered.rs`
+exposes a single public type, `BufferedL2Provider`, which implements
+`kona_derive::L2ChainProvider` and `kona_protocol::BatchValidationProvider`.
+Its only callers are `tests/integration.rs` inside the same crate. No other
+workspace crate depends on `providers-local`:
+
+```
+$ grep -rn 'kona-providers-local\|providers_local' --include='*.toml' --include='*.rs' rust/ | grep -v 'providers/providers-local/'
+(no matches)
+```
+
+When the async traits go away in phase 6b there is nothing to migrate the
+crate onto — its job (an in-memory mock for the async pipeline) disappears
+with the async pipeline. The pure deriver doesn't take L2 lookups via a
+trait; it requests them explicitly via `Derivation::NeedSpanBatchOverlap`,
+so caller-side caches like `BufferedL2Provider` become a driver concern, not
+a `kona-derive` concern.
+
+The crate gets **deleted** as part of phase 6b. The cargo-machete check in
+that PR confirms no remaining consumers.
+
+## Integration suites under `rust/kona/tests/{node,supervisor}`
+
+These are **Go** test suites (`*_test.go`) exercising the kona-node and
+kona-supervisor binaries end-to-end. They do not import `kona_derive`
+directly. They continue to run unchanged through phases 1–5 and act as
+black-box regression coverage for the migrated driver in phase 4.
+
+## Things that are NOT migrated
+
+Out of scope per the plan, listed here so they don't get forgotten:
+
+- `op-reth`, `kona-rbuilder`, `kona-supernode` — do not depend on
+  `kona-derive`.
+- `kona-comp` (batcher compression) — unrelated to derivation.
+- Pre-Holocene derivation paths — pinned to the async pipeline through
+  phase 6b, then deleted. No migration path for callers needing pre-Holocene
+  rules; this is a hard scope boundary in the plan.

--- a/rust/kona/crates/protocol/derive/src/errors/attributes.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/attributes.rs
@@ -5,9 +5,7 @@ use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
 use thiserror::Error;
 
-/// An [`AttributesBuilder`] Error.
-///
-/// [`AttributesBuilder`]: crate::traits::AttributesBuilder
+/// An `AttributesBuilder` Error.
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum BuilderError {
     /// Mismatched blocks.

--- a/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
@@ -152,50 +152,40 @@ pub enum PipelineError {
     /// waiting for network propagation delays.
     #[error("Not enough data")]
     NotEnoughData,
-    /// No channels are available in the [`ChannelProvider`].
+    /// No channels are available in the `ChannelProvider`.
     ///
     /// This error occurs when the channel provider stage has no assembled
     /// channels ready for reading. It typically indicates that frame assembly
     /// is still in progress or that no valid channels have been constructed
     /// from available L1 data.
-    ///
-    /// [`ChannelProvider`]: crate::stages::ChannelProvider
     #[error("The channel provider is empty")]
     ChannelProviderEmpty,
-    /// The channel has already been fully processed by the [`ChannelAssembler`] stage.
+    /// The channel has already been fully processed by the `ChannelAssembler` stage.
     ///
     /// This error indicates an attempt to reprocess a channel that has already
     /// been assembled and consumed. It suggests a logic error in channel tracking
     /// or an attempt to double-process the same channel data.
-    ///
-    /// [`ChannelAssembler`]: crate::stages::ChannelAssembler
     #[error("Channel already built")]
     ChannelAlreadyBuilt,
-    /// Failed to locate the requested channel in the [`ChannelProvider`].
+    /// Failed to locate the requested channel in the `ChannelProvider`.
     ///
     /// This error occurs when attempting to access a specific channel that
     /// is not available in the channel provider's cache or storage. It may
     /// indicate a channel ID mismatch or premature channel eviction.
-    ///
-    /// [`ChannelProvider`]: crate::stages::ChannelProvider
     #[error("Channel not found in channel provider")]
     ChannelNotFound,
-    /// No channel data returned by the [`ChannelReader`] stage.
+    /// No channel data returned by the `ChannelReader` stage.
     ///
     /// This error indicates that the channel reader stage has no channels
     /// available for reading. It typically occurs when all channels have
     /// been consumed or when no valid channels have been assembled yet.
-    ///
-    /// [`ChannelReader`]: crate::stages::ChannelReader
     #[error("The channel reader has no channel available")]
     ChannelReaderEmpty,
-    /// The [`BatchQueue`] contains no batches ready for processing.
+    /// The `BatchQueue` contains no batches ready for processing.
     ///
     /// This error occurs when the batch queue stage has no assembled batches
     /// available for attribute generation. It indicates that batch assembly
     /// is still in progress or that no valid batches have been constructed.
-    ///
-    /// [`BatchQueue`]: crate::stages::BatchQueue
     #[error("The batch queue has no batches available")]
     BatchQueueEmpty,
     /// Required L1 origin information is missing from the previous pipeline stage.
@@ -205,13 +195,11 @@ pub enum PipelineError {
     /// It suggests a configuration or sequencing issue in the pipeline setup.
     #[error("Missing L1 origin from previous stage")]
     MissingOrigin,
-    /// Required L1 data is missing from the [`L1Retrieval`] stage.
+    /// Required L1 data is missing from the `L1Retrieval` stage.
     ///
     /// This error occurs when the L1 retrieval stage cannot provide the
     /// requested L1 block data, transactions, or receipts. It may indicate
     /// network issues, data availability problems, or L1 node synchronization lag.
-    ///
-    /// [`L1Retrieval`]: crate::stages::L1Retrieval
     #[error("L1 Retrieval missing data")]
     MissingL1Data,
     /// Invalid or unsupported batch type encountered during processing.

--- a/rust/kona/crates/protocol/derive/src/lib.rs
+++ b/rust/kona/crates/protocol/derive/src/lib.rs
@@ -9,41 +9,14 @@
 
 extern crate alloc;
 
+#[cfg(feature = "async")]
 #[macro_use]
 extern crate tracing;
-
-mod attributes;
-pub use attributes::StatefulAttributesBuilder;
 
 mod errors;
 pub use errors::{
     BatchDecompressionError, BlobDecodingError, BlobProviderError, BuilderError,
     PipelineEncodingError, PipelineError, PipelineErrorKind, ResetError,
-};
-
-mod pipeline;
-pub use pipeline::{
-    AttributesQueueStage, BatchProviderStage, BatchStreamStage, ChannelProviderStage,
-    ChannelReaderStage, DerivationPipeline, FrameQueueStage, IndexedAttributesQueueStage,
-    L1RetrievalStage, PipelineBuilder, PolledAttributesQueueStage,
-};
-
-mod sources;
-pub use sources::{BlobData, BlobSource, CalldataSource, EthereumDataSource};
-
-mod stages;
-pub use stages::{
-    AttributesQueue, BatchProvider, BatchQueue, BatchStream, BatchStreamProvider, BatchValidator,
-    ChannelAssembler, ChannelBank, ChannelProvider, ChannelReader, ChannelReaderProvider,
-    FrameQueue, FrameQueueProvider, IndexedTraversal, L1Retrieval, L1RetrievalProvider,
-    NextBatchProvider, NextFrameProvider, PollingTraversal, TraversalStage,
-};
-
-mod traits;
-pub use traits::{
-    AttributesBuilder, AttributesProvider, BatchValidationProviderDerive, BlobProvider,
-    ChainProvider, DataAvailabilityProvider, L2ChainProvider, NextAttributes, OriginAdvancer,
-    OriginProvider, Pipeline, ResetProvider, SignalReceiver, Stage,
 };
 
 mod types;
@@ -52,5 +25,57 @@ pub use types::{ActivationSignal, PipelineResult, ResetSignal, Signal, StepResul
 mod metrics;
 pub use metrics::Metrics;
 
-#[cfg(any(test, feature = "test-utils"))]
+// Async derivation surface, gated behind the `async` feature.
+//
+// Phase 1 of the pure-derivation migration: the existing async pipeline
+// (`DerivationPipeline`, async stages, `Pipeline`/`Stage`/`SignalReceiver`
+// traits, IO-bound `StatefulAttributesBuilder` impl, test mocks) sits behind
+// this gate. The truly-sync surface — error types, signals, results,
+// metrics — stays unconditional and is reused by the pure deriver in phase 3.
+//
+// The plan calls out `AttributesBuilder` and `StatefulAttributesBuilder`'s
+// math as "sync items"; those become sync in phase 2's carve-out. Until then
+// they live behind the `async` gate because their current shape is async.
+//
+// See plans/2026-05-06-refactor-kona-pure-derivation-plan.md.
+
+#[cfg(feature = "async")]
+mod attributes;
+#[cfg(feature = "async")]
+pub use attributes::StatefulAttributesBuilder;
+
+#[cfg(feature = "async")]
+mod pipeline;
+#[cfg(feature = "async")]
+pub use pipeline::{
+    AttributesQueueStage, BatchProviderStage, BatchStreamStage, ChannelProviderStage,
+    ChannelReaderStage, DerivationPipeline, FrameQueueStage, IndexedAttributesQueueStage,
+    L1RetrievalStage, PipelineBuilder, PolledAttributesQueueStage,
+};
+
+#[cfg(feature = "async")]
+mod sources;
+#[cfg(feature = "async")]
+pub use sources::{BlobData, BlobSource, CalldataSource, EthereumDataSource};
+
+#[cfg(feature = "async")]
+mod stages;
+#[cfg(feature = "async")]
+pub use stages::{
+    AttributesQueue, BatchProvider, BatchQueue, BatchStream, BatchStreamProvider, BatchValidator,
+    ChannelAssembler, ChannelBank, ChannelProvider, ChannelReader, ChannelReaderProvider,
+    FrameQueue, FrameQueueProvider, IndexedTraversal, L1Retrieval, L1RetrievalProvider,
+    NextBatchProvider, NextFrameProvider, PollingTraversal, TraversalStage,
+};
+
+#[cfg(feature = "async")]
+mod traits;
+#[cfg(feature = "async")]
+pub use traits::{
+    AttributesBuilder, AttributesProvider, BatchValidationProviderDerive, BlobProvider,
+    ChainProvider, DataAvailabilityProvider, L2ChainProvider, NextAttributes, OriginAdvancer,
+    OriginProvider, Pipeline, ResetProvider, SignalReceiver, Stage,
+};
+
+#[cfg(all(any(test, feature = "test-utils"), feature = "async"))]
 pub mod test_utils;

--- a/rust/kona/crates/protocol/derive/src/types/signals.rs
+++ b/rust/kona/crates/protocol/derive/src/types/signals.rs
@@ -1,11 +1,8 @@
 //! Signal types for the `kona-derive` pipeline.
 //!
 //! Signals are the primary method of communication between the pipeline driver
-//! and the [`DerivationPipeline`]. The pipeline receives [`Signal`]s and
-//! dispatches to stages via [`Stage`] methods.
-//!
-//! [`DerivationPipeline`]: crate::DerivationPipeline
-//! [`Stage`]: crate::Stage
+//! and the `DerivationPipeline`. The pipeline receives [`Signal`]s and
+//! dispatches to stages via the `Stage` trait.
 
 use kona_protocol::{BlockInfo, L2BlockInfo};
 


### PR DESCRIPTION
**Phase 1 of 6** — opens the migration corridor for the kona pure-derivation
refactor described in `plans/2026-05-06-refactor-kona-pure-derivation-plan.md`
(op-claude). Subsequent phases build the pure deriver, migrate kona-node and
kona-client onto it, and delete the async pipeline.

## What changes

- New `async` Cargo feature on `kona-derive`, default-on. `async-trait` becomes an optional dep gated behind it.
- Async surface — `pipeline::*`, `stages::*`, `sources::*`, `traits::*`, async test mocks, and the (currently async) `AttributesBuilder` / `StatefulAttributesBuilder` — sits behind `cfg(feature = "async")`.
- Sync surface stays unconditional: `PipelineError{,Kind}`, `ResetError`, `BuilderError`, `BatchDecompressionError`, `BlobDecodingError`, `BlobProviderError`, `PipelineEncodingError`, `Signal`/`ResetSignal`/`ActivationSignal`, `StepResult`, `PipelineResult`, `Metrics`.
- Workspace `kona-derive` dep flipped from `default-features = false` to inheriting defaults so every existing consumer keeps the async surface automatically.
- A handful of doc-comment intra-crate references that pointed at now-gated items were downgraded from rustdoc links to plain `backticks` so `cargo doc --no-default-features` stays warning-free.

## What does NOT change

- **Zero behavior change.** All in-tree consumers compile and run with the async surface enabled, exactly as before.
- No code deleted. Phase 6b handles deletions.
- No consumer `Cargo.toml` touched — they inherit `async` automatically via the workspace dep.

## Deviation from the plan wording

The plan lists `AttributesBuilder` (trait) and `StatefulAttributesBuilder` (struct) as "sync items" that stay unconditional. Both are async-trait based today (`prepare_payload_attributes` is `async fn`). Keeping them unconditional in Phase 1 would require making `async-trait` non-optional, which defeats the gate. They're gated behind `async` here; Phase 2's `core::attributes` carve-out is where the math becomes sync. This is documented in `MIGRATION.md`.

## Consumer inventory

The full inventory of every consumer of `kona-derive`'s async surface — including the bin/{node,client,host} sites, the integration suites under `rust/kona/tests/{node,supervisor}` (Go), and a decision on `providers-local`'s fate — is committed at `rust/kona/crates/protocol/derive/MIGRATION.md`. Highlights:

- **`providers-local`: retire.** `BufferedL2Provider`'s only callers live inside the same crate; no other workspace crate depends on it (verified via Cargo grep). The crate gets deleted in Phase 6b.
- **`bin/node/src/flags/p2p.rs`**: the `ChainProvider` trait bound is the only async surface; Phase 4 either drops the bound or uses the concrete `AlloyChainProvider` directly.
- **`rust/kona/tests/{node,supervisor}`**: Go test suites (`*_test.go`), no direct Rust dependency on `kona-derive`. They keep working as black-box regression coverage through Phase 4.

## Verification

All four gates from the plan run clean against this PR:

- `cargo build -p kona-derive --no-default-features` — succeeds, exposes only sync items.
- `cargo build -p kona-derive --all-features --all-targets` — every existing test target still compiles.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean.
- `cargo doc -p kona-derive` and `cargo doc -p kona-derive --no-default-features` — clean (no rustdoc warnings).

`cargo test -p kona-derive --lib --all-features` reproducibly hits a single pre-existing flake (`stages::batch::batch_stream::test::test_span_batch_extraction_error_flushes_stage` panics with `SetGlobalDefaultError` because another test in the same binary already installed a tracing subscriber). The same failure reproduces verbatim on `origin/develop`; this PR does not introduce it.

🤖 *Generated by Claude Code*

Fixes https://github.com/ethereum-optimism/optimism/issues/20696
Part of https://github.com/ethereum-optimism/optimism/issues/20695
