### PR TITLE
refactor(op-reth/proofs): strict proof-window semantics + ProofWindowRange API

### DIFF
--- a/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
@@ -9,7 +9,8 @@ use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::args::ProofsStorageVersion;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
-    InitializationJob, OpProofsProviderRO, OpProofsStore, RethTrieStorageLayout,
+    InitializationJob, OpProofsProviderRO, OpProofsStorageError, OpProofsStore,
+    RethTrieStorageLayout,
     db::{MdbxProofsStorage, MdbxProofsStorageV2},
 };
 use reth_provider::{BlockNumReader, DBProvider, DatabaseProviderFactory, StorageSettingsCache};
@@ -90,16 +91,18 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitCommand<C> {
         F::Provider: DBProvider,
     {
         // Check if already initialized
-        if let Some((block_number, block_hash)) =
-            storage.provider_ro()?.get_earliest_block_number()?
-        {
-            info!(
-                target: "reth::cli",
-                block_number = block_number,
-                block_hash = ?block_hash,
-                "Proofs storage already initialized"
-            );
-            return Ok(());
+        match storage.provider_ro()?.get_earliest_block() {
+            Ok(anchor) => {
+                info!(
+                    target: "reth::cli",
+                    block_number = anchor.number,
+                    block_hash = ?anchor.hash,
+                    "Proofs storage already initialized"
+                );
+                return Ok(());
+            }
+            Err(OpProofsStorageError::NoBlocksFound) => {}
+            Err(err) => return Err(err.into()),
         }
 
         // Get the current chain state

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
@@ -15,7 +15,7 @@ use reth_optimism_trie::{
 };
 use reth_provider::{BlockNumReader, DBProvider, DatabaseProviderFactory, StorageSettingsCache};
 use std::{path::PathBuf, sync::Arc};
-use tracing::info;
+use tracing::{debug, info};
 
 /// Initializes the proofs storage with the current state of the chain.
 ///
@@ -101,7 +101,9 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitCommand<C> {
                 );
                 return Ok(());
             }
-            Err(OpProofsStorageError::NoBlocksFound) => {}
+            Err(OpProofsStorageError::NoBlocksFound) => {
+                debug!(target: "reth::cli", "Proofs storage is empty; starting initialization");
+            }
             Err(err) => return Err(err.into()),
         }
 

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
@@ -104,16 +104,13 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> PruneCommand<C> {
         proofs_history_window: u64,
         prune_batch_size: u64,
     ) -> eyre::Result<()> {
-        let provider_ro = storage.provider_ro()?;
-        let earliest_block = provider_ro.get_earliest_block().ok();
-        let latest_block = provider_ro.get_latest_block().ok();
+        let window = storage.provider_ro()?.get_proof_window()?;
         info!(
             target: "reth::cli",
-            ?earliest_block,
-            ?latest_block,
+            earliest_block = ?window.earliest,
+            latest_block = ?window.latest,
             "Current proofs storage block range"
         );
-        drop(provider_ro);
 
         let pruner = OpProofStoragePruner::new(storage, block_hash_reader, proofs_history_window)
             .with_batch_size(prune_batch_size);

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
@@ -105,8 +105,8 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> PruneCommand<C> {
         prune_batch_size: u64,
     ) -> eyre::Result<()> {
         let provider_ro = storage.provider_ro()?;
-        let earliest_block = provider_ro.get_earliest_block_number()?;
-        let latest_block = provider_ro.get_latest_block_number()?;
+        let earliest_block = provider_ro.get_earliest_block().ok();
+        let latest_block = provider_ro.get_latest_block().ok();
         info!(
             target: "reth::cli",
             ?earliest_block,

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
@@ -9,7 +9,7 @@ use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::args::ProofsStorageVersion;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
-    OpProofsProviderRO, OpProofsProviderRw, OpProofsStore,
+    OpProofsProviderRO, OpProofsProviderRw, OpProofsStorageError, OpProofsStore,
     db::{MdbxProofsStorage, MdbxProofsStorageV2},
 };
 use reth_provider::{BlockReader, TransactionVariant};
@@ -51,9 +51,13 @@ impl<C: ChainSpecParser> UnwindCommand<C> {
     /// Validates that the target block number is within a valid range for unwinding.
     fn validate_unwind_range<Store: OpProofsStore>(&self, storage: Store) -> eyre::Result<bool> {
         let provider_ro = storage.provider_ro()?;
-        let Ok(window) = provider_ro.get_proof_window() else {
-            warn!(target: "reth::cli", "No blocks found in proofs storage. Nothing to unwind.");
-            return Ok(false);
+        let window = match provider_ro.get_proof_window() {
+            Ok(w) => w,
+            Err(OpProofsStorageError::NoBlocksFound) => {
+                warn!(target: "reth::cli", "No blocks found in proofs storage. Nothing to unwind.");
+                return Ok(false);
+            }
+            Err(err) => return Err(err.into()),
         };
 
         if self.target <= window.earliest.number {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
@@ -51,20 +51,18 @@ impl<C: ChainSpecParser> UnwindCommand<C> {
     /// Validates that the target block number is within a valid range for unwinding.
     fn validate_unwind_range<Store: OpProofsStore>(&self, storage: Store) -> eyre::Result<bool> {
         let provider_ro = storage.provider_ro()?;
-        let (Some((earliest, _)), Some((latest, _))) =
-            (provider_ro.get_earliest_block_number()?, provider_ro.get_latest_block_number()?)
-        else {
+        let Ok(window) = provider_ro.get_proof_window() else {
             warn!(target: "reth::cli", "No blocks found in proofs storage. Nothing to unwind.");
             return Ok(false);
         };
 
-        if self.target <= earliest {
-            warn!(target: "reth::cli", unwind_target = ?self.target, ?earliest, "Target block is less than the earliest block in proofs storage. Nothing to unwind.");
+        if self.target <= window.earliest.number {
+            warn!(target: "reth::cli", unwind_target = ?self.target, earliest = window.earliest.number, "Target block is less than the earliest block in proofs storage. Nothing to unwind.");
             return Ok(false);
         }
 
-        if self.target > latest {
-            warn!(target: "reth::cli", unwind_target = ?self.target, ?latest, "Target block is not less than the latest block in proofs storage. Nothing to unwind.");
+        if self.target > window.latest.number {
+            warn!(target: "reth::cli", unwind_target = ?self.target, latest = window.latest.number, "Target block is not less than the latest block in proofs storage. Nothing to unwind.");
             return Ok(false);
         }
 

--- a/rust/op-reth/crates/exex/src/lib.rs
+++ b/rust/op-reth/crates/exex/src/lib.rs
@@ -468,8 +468,7 @@ mod tests {
     fn init_storage<S: OpProofsStore>(storage: S) {
         let genesis = NumHash::new(0, b256(0x00));
         let init = storage.initialization_provider().expect("init");
-        init.set_initial_state_anchor(genesis)
-            .expect("anchor");
+        init.set_initial_state_anchor(genesis).expect("anchor");
         init.commit_initial_state().expect("commit init");
         OpProofsInitProvider::commit(init).expect("commit");
     }

--- a/rust/op-reth/crates/exex/src/lib.rs
+++ b/rust/op-reth/crates/exex/src/lib.rs
@@ -224,25 +224,13 @@ where
 
     /// Ensure proofs storage is initialized
     fn ensure_initialized(&self) -> eyre::Result<()> {
-        // Check if proofs storage is initialized
+        // Check if proofs storage is initialized. An empty proof window returns NoBlocksFound;
         let provider_ro = self.storage.provider_ro()?;
-        let earliest_block_number = match provider_ro.get_earliest_block_number()? {
-            Some((n, _)) => n,
-            None => {
-                return Err(eyre::eyre!(
-                    "Proofs storage not initialized. Please run 'op-reth initialize-op-proofs --proofs-history.storage-path <PATH>' first."
-                ));
-            }
-        };
-
-        let latest_block_number = match provider_ro.get_latest_block_number()? {
-            Some((n, _)) => n,
-            None => {
-                return Err(eyre::eyre!(
-                    "Proofs storage not initialized. Please run 'op-reth initialize-op-proofs --proofs-history.storage-path <PATH>' first."
-                ));
-            }
-        };
+        let window = provider_ro.get_proof_window().map_err(|_| eyre::eyre!(
+            "Proofs storage not initialized. Please run 'op-reth initialize-op-proofs --proofs-history.storage-path <PATH>' first."
+        ))?;
+        let earliest_block_number = window.earliest.number;
+        let latest_block_number = window.latest.number;
 
         // Check if we have accumulated too much history for the configured window.
         // If the gap between what we have and what we want to keep is too large, the auto-pruner
@@ -411,8 +399,8 @@ mod tests {
     use reth_ethereum_primitives::{Block, Receipt};
     use reth_execution_types::{Chain, ExecutionOutcome};
     use reth_optimism_trie::{
-        BlockStateDiff, OpProofsProviderRO, OpProofsProviderRw, OpProofsStore,
-        db::MdbxProofsStorageV2, engine::EngineHandle,
+        BlockStateDiff, OpProofsInitProvider, OpProofsProviderRO, OpProofsProviderRw,
+        OpProofsStore, db::MdbxProofsStorageV2, engine::EngineHandle,
     };
     use reth_primitives_traits::RecoveredBlock;
     use reth_trie::{HashedPostStateSorted, LazyTrieData, updates::TrieUpdatesSorted};
@@ -476,18 +464,14 @@ mod tests {
         Chain::new(blocks, execution_outcome, trie_data)
     }
 
-    // Init_storage to the genesis block
+    // Bootstrap storage to the genesis block via the init flow (sets earliest = latest = genesis).
     fn init_storage<S: OpProofsStore>(storage: S) {
-        let genesis_block = NumHash::new(0, b256(0x00));
-        let rw = storage.provider_rw().expect("provider rw");
-        rw.set_earliest_block_number(genesis_block.number, genesis_block.hash)
-            .expect("set earliest");
-        rw.store_trie_updates(
-            BlockWithParent::new(genesis_block.hash, genesis_block),
-            BlockStateDiff::default(),
-        )
-        .expect("store trie update");
-        rw.commit().expect("commit");
+        let genesis = NumHash::new(0, b256(0x00));
+        let init = storage.initialization_provider().expect("init");
+        init.set_initial_state_anchor(genesis)
+            .expect("anchor");
+        init.commit_initial_state().expect("commit init");
+        OpProofsInitProvider::commit(init).expect("commit");
     }
 
     // Initialize exex with config
@@ -537,10 +521,9 @@ mod tests {
         let latest = store
             .provider_ro()
             .expect("provider ro")
-            .get_latest_block_number()
+            .get_latest_block()
             .expect("get latest block")
-            .expect("ok")
-            .0;
+            .number;
         assert_eq!(latest, 1);
     }
 
@@ -578,10 +561,9 @@ mod tests {
         let latest = store
             .provider_ro()
             .expect("provider ro")
-            .get_latest_block_number()
+            .get_latest_block()
             .expect("get latest block")
-            .expect("ok")
-            .0;
+            .number;
         assert_eq!(latest, 5);
 
         // Try to handle already processed notification
@@ -589,14 +571,10 @@ mod tests {
         let notif = ExExNotification::ChainCommitted { new: new_chain };
         exex.handle_notification(notif, &engine_handle).expect("handle chain commit");
         engine_handle.flush();
-        let latest = store
-            .provider_ro()
-            .expect("provider ro")
-            .get_latest_block_number()
-            .expect("get latest block")
-            .expect("ok");
-        assert_eq!(latest.0, 5);
-        assert_eq!(latest.1, hash_for_num(5)); // block was not updated
+        let latest =
+            store.provider_ro().expect("provider ro").get_latest_block().expect("get latest block");
+        assert_eq!(latest.number, 5);
+        assert_eq!(latest.hash, hash_for_num(5)); // block was not updated
     }
 
     #[tokio::test]
@@ -632,10 +610,9 @@ mod tests {
         let latest = store
             .provider_ro()
             .expect("provider ro")
-            .get_latest_block_number()
+            .get_latest_block()
             .expect("get latest block")
-            .expect("ok")
-            .0;
+            .number;
         assert_eq!(latest, 10);
 
         // Now the tip is 10, and we want to reorg from block 6..12
@@ -650,10 +627,9 @@ mod tests {
         let latest = store
             .provider_ro()
             .expect("provider ro")
-            .get_latest_block_number()
+            .get_latest_block()
             .expect("get latest block")
-            .expect("ok")
-            .0;
+            .number;
         assert_eq!(latest, 12);
     }
 
@@ -691,10 +667,9 @@ mod tests {
         let latest = store
             .provider_ro()
             .expect("provider ro")
-            .get_latest_block_number()
+            .get_latest_block()
             .expect("get latest block")
-            .expect("ok")
-            .0;
+            .number;
         assert_eq!(latest, 10);
 
         // Now the tip is 10, and we want to reorg starting at block 12 (beyond stored tip).
@@ -711,10 +686,9 @@ mod tests {
         let latest = store
             .provider_ro()
             .expect("provider ro")
-            .get_latest_block_number()
+            .get_latest_block()
             .expect("get latest block")
-            .expect("ok")
-            .0;
+            .number;
         assert_eq!(latest, 10);
     }
 
@@ -752,10 +726,9 @@ mod tests {
         let latest = store
             .provider_ro()
             .expect("provider ro")
-            .get_latest_block_number()
+            .get_latest_block()
             .expect("get latest block")
-            .expect("ok")
-            .0;
+            .number;
         assert_eq!(latest, 10);
 
         // Now the tip is 10, and we want to revert from block 9..10
@@ -769,10 +742,9 @@ mod tests {
         let latest = store
             .provider_ro()
             .expect("provider ro")
-            .get_latest_block_number()
+            .get_latest_block()
             .expect("get latest block")
-            .expect("ok")
-            .0;
+            .number;
         assert_eq!(latest, 8);
     }
 
@@ -810,10 +782,9 @@ mod tests {
         let latest = store
             .provider_ro()
             .expect("provider ro")
-            .get_latest_block_number()
+            .get_latest_block()
             .expect("get latest block")
-            .expect("ok")
-            .0;
+            .number;
         assert_eq!(latest, 5);
 
         // Now the tip is 10, and we want to revert from block 9..10
@@ -827,10 +798,9 @@ mod tests {
         let latest = store
             .provider_ro()
             .expect("provider ro")
-            .get_latest_block_number()
+            .get_latest_block()
             .expect("get latest block")
-            .expect("ok")
-            .0;
+            .number;
         assert_eq!(latest, 5);
     }
 
@@ -862,7 +832,7 @@ mod tests {
                 BlockStateDiff::default(),
             )
             .expect("store trie update");
-            rw.commit().expect("commit");
+            OpProofsProviderRw::commit(rw).expect("commit");
         }
 
         let (ctx, _handle) =
@@ -952,13 +922,8 @@ mod tests {
         // The engine has a sync target set but no blocks in the provider, so its catch-up
         // will error out without writing anything. Storage stays at block 0.
         engine_handle.flush();
-        let latest = store
-            .provider_ro()
-            .expect("provider ro")
-            .get_latest_block_number()
-            .expect("get")
-            .expect("ok")
-            .0;
+        let latest =
+            store.provider_ro().expect("provider ro").get_latest_block().expect("get").number;
         assert_eq!(latest, 0, "Main thread should not have processed the blocks synchronously");
     }
 }

--- a/rust/op-reth/crates/rpc/src/debug.rs
+++ b/rust/op-reth/crates/rpc/src/debug.rs
@@ -5,7 +5,7 @@ use crate::{
     state::OpStateProviderFactory,
 };
 use alloy_consensus::BlockHeader;
-use alloy_eips::{BlockId, BlockNumberOrTag, NumHash};
+use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{B256, Sealed};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_debug::ExecutionWitness;
@@ -23,8 +23,7 @@ use reth_optimism_payload_builder::{
     builder::{OpBuilder, OpPayloadBuilderCtx},
 };
 use reth_optimism_trie::{
-    OpProofsStorage, OpProofsStorageError, OpProofsStorageResult, OpProofsStore,
-    api::OpProofsProviderRO,
+    OpProofsStorage, OpProofsStorageError, OpProofsStore, api::OpProofsProviderRO,
 };
 use reth_optimism_txpool::OpPooledTransaction as OpPooledTx2;
 use reth_payload_util::NoopPayloadTransactions;
@@ -324,17 +323,15 @@ where
         let provider_ro =
             self.inner.storage.provider_ro().map_err(|err| internal_rpc_err(err.to_string()))?;
 
-        // NoBlocksFound is the uninitialized-store sentinel; surface it as `None` so the RPC
-        // contract (Option fields) keeps the same shape it had before the API change.
-        let to_option = |result: OpProofsStorageResult<NumHash>| match result {
-            Ok(NumHash { number, .. }) => Ok(Some(number)),
-            Err(OpProofsStorageError::NoBlocksFound) => Ok(None),
+        match provider_ro.get_proof_window() {
+            Ok(window) => Ok(ProofsSyncStatus {
+                earliest: Some(window.earliest.number),
+                latest: Some(window.latest.number),
+            }),
+            Err(OpProofsStorageError::NoBlocksFound) => {
+                Ok(ProofsSyncStatus { earliest: None, latest: None })
+            }
             Err(err) => Err(internal_rpc_err(err.to_string())),
-        };
-
-        Ok(ProofsSyncStatus {
-            earliest: to_option(provider_ro.get_earliest_block())?,
-            latest: to_option(provider_ro.get_latest_block())?,
-        })
+        }
     }
 }

--- a/rust/op-reth/crates/rpc/src/debug.rs
+++ b/rust/op-reth/crates/rpc/src/debug.rs
@@ -5,7 +5,7 @@ use crate::{
     state::OpStateProviderFactory,
 };
 use alloy_consensus::BlockHeader;
-use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_eips::{BlockId, BlockNumberOrTag, NumHash};
 use alloy_primitives::{B256, Sealed};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_debug::ExecutionWitness;
@@ -22,7 +22,10 @@ use reth_optimism_payload_builder::{
     OpAttributes, OpPayloadPrimitives,
     builder::{OpBuilder, OpPayloadBuilderCtx},
 };
-use reth_optimism_trie::{OpProofsStorage, OpProofsStore, api::OpProofsProviderRO};
+use reth_optimism_trie::{
+    OpProofsStorage, OpProofsStorageError, OpProofsStorageResult, OpProofsStore,
+    api::OpProofsProviderRO,
+};
 use reth_optimism_txpool::OpPooledTransaction as OpPooledTx2;
 use reth_payload_util::NoopPayloadTransactions;
 use reth_primitives_traits::{SealedHeader, TxTy};
@@ -320,16 +323,18 @@ where
     async fn proofs_sync_status(&self) -> RpcResult<ProofsSyncStatus> {
         let provider_ro =
             self.inner.storage.provider_ro().map_err(|err| internal_rpc_err(err.to_string()))?;
-        let earliest = provider_ro
-            .get_earliest_block_number()
-            .map_err(|err| internal_rpc_err(err.to_string()))?;
-        let latest = provider_ro
-            .get_latest_block_number()
-            .map_err(|err| internal_rpc_err(err.to_string()))?;
+
+        // NoBlocksFound is the uninitialized-store sentinel; surface it as `None` so the RPC
+        // contract (Option fields) keeps the same shape it had before the API change.
+        let to_option = |result: OpProofsStorageResult<NumHash>| match result {
+            Ok(NumHash { number, .. }) => Ok(Some(number)),
+            Err(OpProofsStorageError::NoBlocksFound) => Ok(None),
+            Err(err) => Err(internal_rpc_err(err.to_string())),
+        };
 
         Ok(ProofsSyncStatus {
-            earliest: earliest.map(|(block_number, _)| block_number),
-            latest: latest.map(|(block_number, _)| block_number),
+            earliest: to_option(provider_ro.get_earliest_block())?,
+            latest: to_option(provider_ro.get_latest_block())?,
         })
     }
 }

--- a/rust/op-reth/crates/rpc/src/state.rs
+++ b/rust/op-reth/crates/rpc/src/state.rs
@@ -42,15 +42,13 @@ where
 
         let provider_ro = self.preimage_store.provider_ro().map_err(ProviderError::from)?;
 
-        let (Some((latest_block_number, _)), Some((earliest_block_number, _))) = (
-            provider_ro.get_latest_block_number().map_err(ProviderError::from)?,
-            provider_ro.get_earliest_block_number().map_err(ProviderError::from)?,
-        ) else {
-            // if no earliest block, db is empty, return error
-            return Err(ProviderError::StateForNumberNotFound(block_number));
-        };
+        // Map an empty proof window (NoBlocksFound) to the same outcome as an out-of-window
+        // block lookup: the RPC can't serve a proof for that number.
+        let window = provider_ro
+            .get_proof_window()
+            .map_err(|_| ProviderError::StateForNumberNotFound(block_number))?;
 
-        if block_number < earliest_block_number || block_number > latest_block_number {
+        if block_number < window.earliest.number || block_number > window.latest.number {
             return Err(ProviderError::StateForNumberNotFound(block_number));
         }
 

--- a/rust/op-reth/crates/rpc/src/state.rs
+++ b/rust/op-reth/crates/rpc/src/state.rs
@@ -4,7 +4,8 @@ use alloy_eips::BlockId;
 use derive_more::Constructor;
 use jsonrpsee_types::error::ErrorObject;
 use reth_optimism_trie::{
-    OpProofsStorage, OpProofsStore, api::OpProofsProviderRO, provider::OpProofsStateProviderRef,
+    OpProofsStorage, OpProofsStorageError, OpProofsStore, api::OpProofsProviderRO,
+    provider::OpProofsStateProviderRef,
 };
 use reth_provider::{BlockIdReader, ProviderError, ProviderResult, StateProvider};
 use reth_rpc_api::eth::helpers::FullEthApi;
@@ -42,11 +43,16 @@ where
 
         let provider_ro = self.preimage_store.provider_ro().map_err(ProviderError::from)?;
 
-        // Map an empty proof window (NoBlocksFound) to the same outcome as an out-of-window
-        // block lookup: the RPC can't serve a proof for that number.
-        let window = provider_ro
-            .get_proof_window()
-            .map_err(|_| ProviderError::StateForNumberNotFound(block_number))?;
+        // An empty proof window is semantically equivalent to an out-of-window lookup for
+        // the proofs RPC: there's no proof for that block. Any other storage error is real
+        // and propagates up.
+        let window = match provider_ro.get_proof_window() {
+            Ok(w) => w,
+            Err(OpProofsStorageError::NoBlocksFound) => {
+                return Err(ProviderError::StateForNumberNotFound(block_number));
+            }
+            Err(err) => return Err(ProviderError::from(err)),
+        };
 
         if block_number < window.earliest.number || block_number > window.latest.number {
             return Err(ProviderError::StateForNumberNotFound(block_number));

--- a/rust/op-reth/crates/trie/src/api.rs
+++ b/rust/op-reth/crates/trie/src/api.rs
@@ -4,7 +4,7 @@ use crate::{
     OpProofsStorageResult,
     db::{HashedStorageKey, StorageTrieKey},
 };
-use alloy_eips::{BlockNumHash, eip1898::BlockWithParent};
+use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256};
 use auto_impl::auto_impl;
 use derive_more::{AddAssign, Constructor};
@@ -48,6 +48,16 @@ impl BlockStateDiff {
     }
 }
 
+/// The block range covered by the proof window: earliest persisted block and latest persisted
+/// block. Both endpoints are inclusive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProofWindowRange {
+    /// Earliest block stored.
+    pub earliest: NumHash,
+    /// Latest block stored.
+    pub latest: NumHash,
+}
+
 /// Counts of trie updates written to storage.
 #[derive(Debug, Clone, Default, AddAssign, Constructor, Eq, PartialEq)]
 pub struct WriteCounts {
@@ -84,11 +94,19 @@ pub trait OpProofsProviderRO: Send + Sync + Debug {
     where
         Self: 'tx;
 
-    /// Get the earliest block number and hash that has been stored
-    fn get_earliest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>>;
+    /// Get the earliest block number and hash that has been stored. Returns
+    /// [`crate::OpProofsStorageError::NoBlocksFound`] if the proof window is empty.
+    fn get_earliest_block(&self) -> OpProofsStorageResult<NumHash>;
 
-    /// Get the latest block number and hash that has been stored
-    fn get_latest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>>;
+    /// Get the latest block number and hash that has been stored. Returns
+    /// [`crate::OpProofsStorageError::NoBlocksFound`] if the proof window is empty.
+    fn get_latest_block(&self) -> OpProofsStorageResult<NumHash>;
+
+    /// Get the proof window range — earliest and latest persisted blocks — in a single read.
+    /// Prefer this over calling [`Self::get_earliest_block`] and [`Self::get_latest_block`]
+    /// separately when you need both. Returns [`crate::OpProofsStorageError::NoBlocksFound`] if the
+    /// proof window is empty.
+    fn get_proof_window(&self) -> OpProofsStorageResult<ProofWindowRange>;
 
     /// Get a trie cursor for the storage backend
     fn storage_trie_cursor<'tx>(
@@ -152,10 +170,6 @@ pub trait OpProofsProviderRw: OpProofsProviderRO {
         latest_common_block: BlockNumHash,
         blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
     ) -> OpProofsStorageResult<()>;
-
-    /// Set the earliest block number and hash that has been stored
-    fn set_earliest_block_number(&self, block_number: u64, hash: B256)
-    -> OpProofsStorageResult<()>;
 
     /// Commit the changes to the database.
     /// Consumes the provider.

--- a/rust/op-reth/crates/trie/src/db/mod.rs
+++ b/rust/op-reth/crates/trie/src/db/mod.rs
@@ -21,10 +21,3 @@ pub use store_v2::{
     MdbxProofsProviderV2, MdbxProofsStorageV2, V2AccountCursor, V2AccountTrieCursor,
     V2StorageCursor, V2StorageTrieCursor,
 };
-
-use alloy_eips::NumHash;
-
-pub(crate) struct ProofWindowValue {
-    pub earliest: NumHash,
-    pub latest: NumHash,
-}

--- a/rust/op-reth/crates/trie/src/db/store.rs
+++ b/rust/op-reth/crates/trie/src/db/store.rs
@@ -1,11 +1,11 @@
-use super::{BlockNumberHash, ProofWindow, ProofWindowKey, ProofWindowValue, Tables};
+use super::{BlockNumberHash, ProofWindow, ProofWindowKey, Tables};
 use crate::{
     BlockStateDiff, OpProofsStorageError,
     OpProofsStorageError::NoBlocksFound,
     OpProofsStorageResult,
     api::{
         InitialStateAnchor, InitialStateStatus, OpProofsInitProvider, OpProofsProviderRO,
-        OpProofsProviderRw, OpProofsStore, WriteCounts,
+        OpProofsProviderRw, OpProofsStore, ProofWindowRange, WriteCounts,
     },
     db::{
         MdbxAccountCursor, MdbxStorageCursor, MdbxTrieCursor,
@@ -90,13 +90,6 @@ impl<TX: DbTx> MdbxProofsProvider<TX> {
         let mut cursor = self.tx.cursor_read::<ProofWindow>()?;
         let value = cursor.seek_exact(key)?;
         Ok(value.map(|(_, val)| (val.number(), *val.hash())))
-    }
-
-    fn get_latest_block_number_hash_inner(&self) -> OpProofsStorageResult<(u64, B256)> {
-        if let Some(block) = self.get_block_number_hash_inner(ProofWindowKey::LatestBlock)? {
-            return Ok(block);
-        }
-        self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock)?.ok_or(NoBlocksFound)
     }
 
     /// Phase 1 of pruning: Calculate survivors.
@@ -528,7 +521,8 @@ impl<TX: DbTxMut + DbTx> MdbxProofsProvider<TX> {
     ) -> OpProofsStorageResult<WriteCounts> {
         let block_number = block_ref.block.number;
 
-        let (_num, latest_block_hash) = self.get_latest_block_number_hash_inner()?;
+        let (_, latest_block_hash) =
+            self.get_block_number_hash_inner(ProofWindowKey::LatestBlock)?.ok_or(NoBlocksFound)?;
 
         if latest_block_hash != block_ref.parent {
             return Err(OpProofsStorageError::OutOfOrder {
@@ -552,22 +546,6 @@ impl<TX: DbTxMut + DbTx> MdbxProofsProvider<TX> {
             hashed_accounts_written_total: change_set.hashed_account_keys.len() as u64,
             hashed_storages_written_total: change_set.hashed_storage_keys.len() as u64,
         })
-    }
-
-    fn get_proof_window_inner(&self) -> OpProofsStorageResult<ProofWindowValue> {
-        let mut cursor = self.tx.cursor_read::<ProofWindow>()?;
-
-        let earliest = match cursor.seek_exact(ProofWindowKey::EarliestBlock)? {
-            Some((_, val)) => NumHash::new(val.number(), *val.hash()),
-            None => return Err(NoBlocksFound),
-        };
-
-        let latest = match cursor.seek_exact(ProofWindowKey::LatestBlock)? {
-            Some((_, val)) => NumHash::new(val.number(), *val.hash()),
-            None => earliest,
-        };
-
-        Ok(ProofWindowValue { earliest, latest })
     }
 
     fn get_initial_state_anchor_inner(&self) -> OpProofsStorageResult<Option<BlockNumHash>> {
@@ -609,21 +587,33 @@ impl<TX: DbTx + Send + Sync + Debug + 'static> OpProofsProviderRO for MdbxProofs
         Self: 'tx,
         TX: 'tx;
 
-    fn get_earliest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    fn get_earliest_block(&self) -> OpProofsStorageResult<NumHash> {
         let mut cursor = self.tx.cursor_read::<ProofWindow>()?;
-        let value = cursor.seek_exact(ProofWindowKey::EarliestBlock)?;
-        Ok(value.map(|(_, val)| (val.number(), *val.hash())))
+        cursor
+            .seek_exact(ProofWindowKey::EarliestBlock)?
+            .map(|(_, val)| NumHash::new(val.number(), *val.hash()))
+            .ok_or(NoBlocksFound)
     }
 
-    fn get_latest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    fn get_latest_block(&self) -> OpProofsStorageResult<NumHash> {
         let mut cursor = self.tx.cursor_read::<ProofWindow>()?;
-        // Try latest first
-        if let Some((_, val)) = cursor.seek_exact(ProofWindowKey::LatestBlock)? {
-            return Ok(Some((val.number(), *val.hash())));
-        }
-        // Fallback to earliest if latest not set (or database empty-ish)
-        let earliest = cursor.seek_exact(ProofWindowKey::EarliestBlock)?;
-        Ok(earliest.map(|(_, val)| (val.number(), *val.hash())))
+        cursor
+            .seek_exact(ProofWindowKey::LatestBlock)?
+            .map(|(_, val)| NumHash::new(val.number(), *val.hash()))
+            .ok_or(NoBlocksFound)
+    }
+
+    fn get_proof_window(&self) -> OpProofsStorageResult<ProofWindowRange> {
+        let mut cursor = self.tx.cursor_read::<ProofWindow>()?;
+        let earliest = cursor
+            .seek_exact(ProofWindowKey::EarliestBlock)?
+            .map(|(_, val)| NumHash::new(val.number(), *val.hash()))
+            .ok_or(NoBlocksFound)?;
+        let latest = cursor
+            .seek_exact(ProofWindowKey::LatestBlock)?
+            .map(|(_, val)| NumHash::new(val.number(), *val.hash()))
+            .ok_or(NoBlocksFound)?;
+        Ok(ProofWindowRange { earliest, latest })
     }
 
     fn storage_trie_cursor<'tx>(
@@ -832,7 +822,7 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsProviderRw
     fn unwind_history(&self, to: BlockWithParent) -> OpProofsStorageResult<()> {
         let history_to_delete = self.collect_history_ranged(to.block.number..)?;
 
-        let proof_window = self.get_proof_window_inner()?;
+        let proof_window = self.get_proof_window()?;
 
         if to.block.number > proof_window.latest.number {
             return Ok(());
@@ -859,7 +849,7 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsProviderRw
         latest_common_block: BlockNumHash,
         mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
     ) -> OpProofsStorageResult<()> {
-        let proof_window = self.get_proof_window_inner()?;
+        let proof_window = self.get_proof_window()?;
 
         if latest_common_block.number <= proof_window.earliest.number ||
             latest_common_block.number > proof_window.latest.number
@@ -882,14 +872,6 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsProviderRw
             self.store_trie_updates_append_only_inner(block_with_parent, diff)?;
         }
         Ok(())
-    }
-
-    fn set_earliest_block_number(
-        &self,
-        block_number: u64,
-        hash: B256,
-    ) -> OpProofsStorageResult<()> {
-        self.set_earliest_block_number_inner(block_number, hash)
     }
 
     fn commit(self) -> OpProofsStorageResult<()> {
@@ -985,6 +967,7 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsInitProvider
     fn commit_initial_state(&self) -> OpProofsStorageResult<BlockNumHash> {
         let anchor = self.get_initial_state_anchor_inner()?.ok_or(NoBlocksFound)?;
         self.set_earliest_block_number_inner(anchor.number, anchor.hash)?;
+        self.set_latest_block_number_inner(anchor.number, anchor.hash)?;
         Ok(anchor)
     }
 
@@ -1177,22 +1160,16 @@ mod tests {
             Ok(counts)
         }
 
+        /// Test-only: set both earliest and latest to the same `(block_number, hash)`.
         fn set_earliest_block_number(
             &self,
             block_number: u64,
             hash: B256,
         ) -> OpProofsStorageResult<()> {
             let provider = self.provider_rw()?;
-            provider.set_earliest_block_number(block_number, hash)?;
+            provider.set_earliest_block_number_inner(block_number, hash)?;
+            provider.set_latest_block_number_inner(block_number, hash)?;
             OpProofsProviderRw::commit(provider)
-        }
-
-        fn set_earliest_block_number_hash(
-            &self,
-            block_number: u64,
-            hash: B256,
-        ) -> OpProofsStorageResult<()> {
-            self.set_earliest_block_number(block_number, hash)
         }
 
         fn prune_earliest_state(
@@ -1210,14 +1187,14 @@ mod tests {
             provider.fetch_trie_updates(block_number)
         }
 
-        fn get_earliest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+        fn get_earliest_block(&self) -> OpProofsStorageResult<NumHash> {
             let provider = self.provider_ro()?;
-            provider.get_earliest_block_number()
+            provider.get_earliest_block()
         }
 
-        fn get_latest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+        fn get_latest_block(&self) -> OpProofsStorageResult<NumHash> {
             let provider = self.provider_ro()?;
-            provider.get_latest_block_number()
+            provider.get_latest_block()
         }
 
         fn replace_updates(
@@ -1845,8 +1822,8 @@ mod tests {
         let res = store.store_trie_updates(bad_block, diff);
         assert!(matches!(res, Err(OpProofsStorageError::OutOfOrder { .. })));
         // verify nothing written: proof window still unchanged
-        let latest = store.get_latest_block_number().expect("get latest");
-        assert_eq!(latest.unwrap().1, existing_block.block.hash);
+        let latest = store.get_latest_block().expect("get latest");
+        assert_eq!(latest.hash, existing_block.block.hash);
     }
 
     #[test]
@@ -2320,8 +2297,8 @@ mod tests {
         assert!(pruning_cur.seek_exact(block.block.number).unwrap().is_none());
 
         // Verify earliest block was updated
-        let earliest = store.get_earliest_block_number().unwrap();
-        assert_eq!(earliest, Some((2, next_block.block.hash)));
+        let earliest = store.get_earliest_block().unwrap();
+        assert_eq!(earliest, NumHash::new(2, next_block.block.hash));
     }
 
     #[test]
@@ -2496,8 +2473,8 @@ mod tests {
         assert!(pruning_cur.seek_exact(2).unwrap().is_none());
 
         // Verify earliest block was updated
-        let earliest = store.get_earliest_block_number().unwrap();
-        assert_eq!(earliest, Some((3, block_3.block.hash)));
+        let earliest = store.get_earliest_block().unwrap();
+        assert_eq!(earliest, NumHash::new(3, block_3.block.hash));
     }
 
     #[test]
@@ -2861,8 +2838,8 @@ mod tests {
         // Prune empty
         store.prune_earliest_state(target).unwrap();
 
-        let earliest = store.get_earliest_block_number().unwrap();
-        assert_eq!(earliest, Some((5, target.block.hash)));
+        let earliest = store.get_earliest_block().unwrap();
+        assert_eq!(earliest, NumHash::new(5, target.block.hash));
     }
 
     #[test]
@@ -3209,35 +3186,29 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let store = MdbxProofsStorage::new(dir.path()).expect("env");
 
-        // Test initial state (no values set)
-        let initial_value = store.get_earliest_block_number().expect("get earliest");
-        assert_eq!(initial_value, None);
+        // Empty proof window: both endpoints surface NoBlocksFound.
+        assert!(matches!(store.get_earliest_block(), Err(NoBlocksFound)));
+        assert!(matches!(store.get_latest_block(), Err(NoBlocksFound)));
 
-        // Test setting the value
+        // Set both anchors via the test helper.
         let block_number = 42u64;
         let hash = B256::random();
         store.set_earliest_block_number(block_number, hash).expect("set earliest");
 
-        // Verify value was stored correctly
-        let retrieved = store.get_earliest_block_number().expect("get earliest");
-        assert_eq!(retrieved, Some((block_number, hash)));
+        let retrieved = store.get_earliest_block().expect("get earliest");
+        assert_eq!(retrieved, NumHash::new(block_number, hash));
 
-        // Test updating with new values
+        // Update both anchors to a new value.
         let new_block_number = 100u64;
         let new_hash = B256::random();
         store.set_earliest_block_number(new_block_number, new_hash).expect("update earliest");
 
-        // Verify update worked
-        let updated = store.get_earliest_block_number().expect("get updated earliest");
-        assert_eq!(updated, Some((new_block_number, new_hash)));
+        let updated = store.get_earliest_block().expect("get updated earliest");
+        assert_eq!(updated, NumHash::new(new_block_number, new_hash));
 
-        // Verify that latest_block falls back to earliest when not set
-        let latest = store.get_latest_block_number().expect("get latest");
-        assert_eq!(
-            latest,
-            Some((new_block_number, new_hash)),
-            "Latest block should fall back to earliest when not explicitly set"
-        );
+        // The test helper bootstraps both anchors, so latest matches the new earliest.
+        let latest = store.get_latest_block().expect("get latest");
+        assert_eq!(latest, NumHash::new(new_block_number, new_hash));
     }
 
     #[test]
@@ -3511,7 +3482,7 @@ mod tests {
         let b3 = BlockWithParent::new(b2.block.hash, NumHash::new(3, B256::random()));
         let b4 = BlockWithParent::new(b3.block.hash, NumHash::new(4, B256::random()));
 
-        store.set_earliest_block_number_hash(b0.number, b0.hash).expect("set earliest");
+        store.set_earliest_block_number(b0.number, b0.hash).expect("set earliest");
         store.store_trie_updates(b1, make_diff(10)).expect("store b1");
         store.store_trie_updates(b2, make_diff(20)).expect("store b2");
         store.store_trie_updates(b3, make_diff(30)).expect("store b3");
@@ -3559,7 +3530,7 @@ mod tests {
         let b2 = BlockWithParent::new(b1.block.hash, NumHash::new(2, B256::random()));
         let b3 = BlockWithParent::new(b2.block.hash, NumHash::new(3, B256::random()));
 
-        store.set_earliest_block_number_hash(b1.block.number, b1.block.hash).expect("set earliest");
+        store.set_earliest_block_number(b1.block.number, b1.block.hash).expect("set earliest");
         store.store_trie_updates(b2, make_diff(20)).expect("store b2");
         store.store_trie_updates(b3, make_diff(30)).expect("store b3");
 
@@ -3596,7 +3567,7 @@ mod tests {
         let b2 = BlockWithParent::new(b1.block.hash, NumHash::new(2, B256::random()));
         let b3 = BlockWithParent::new(b2.block.hash, NumHash::new(3, B256::random()));
 
-        store.set_earliest_block_number_hash(b0.block.number, b0.block.hash).expect("set earliest");
+        store.set_earliest_block_number(b0.block.number, b0.block.hash).expect("set earliest");
         store.store_trie_updates(b1, make_diff(10, 100)).expect("store b1");
         store.store_trie_updates(b2, make_diff(20, 200)).expect("store b2");
         store.store_trie_updates(b3, make_diff(30, 300)).expect("store b3");
@@ -3659,7 +3630,7 @@ mod tests {
         let b2 = BlockWithParent::new(b1.block.hash, NumHash::new(2, B256::random()));
         let b3 = BlockWithParent::new(b2.block.hash, NumHash::new(3, B256::random()));
 
-        store.set_earliest_block_number_hash(b0.number, b0.hash).expect("set earliest");
+        store.set_earliest_block_number(b0.number, b0.hash).expect("set earliest");
         store.store_trie_updates(b1, make_diff(path1, node1)).expect("store b1");
         store.store_trie_updates(b2, make_diff(path2, node2.clone())).expect("store b2");
         store.store_trie_updates(b3, make_diff(path1, node2)).expect("store b3");
@@ -3707,7 +3678,7 @@ mod tests {
 
         // Block 0: Set earliest block
         let b0 = NumHash::new(0, B256::random());
-        store.set_earliest_block_number_hash(b0.number, b0.hash).expect("set earliest");
+        store.set_earliest_block_number(b0.number, b0.hash).expect("set earliest");
 
         // Block 1: Insert multiple types of data
         let b1 = BlockWithParent::new(b0.hash, NumHash::new(1, B256::random()));
@@ -3847,7 +3818,7 @@ mod tests {
         let b2 = BlockWithParent::new(b1.block.hash, NumHash::new(2, B256::random()));
         let b3 = BlockWithParent::new(b2.block.hash, NumHash::new(3, B256::random()));
 
-        store.set_earliest_block_number_hash(b0.number, b0.hash).expect("set earliest");
+        store.set_earliest_block_number(b0.number, b0.hash).expect("set earliest");
         store.store_trie_updates(b1, make_diff(10)).expect("store b1");
         store.store_trie_updates(b2, make_diff(20)).expect("store b2");
         store.store_trie_updates(b3, make_diff(30)).expect("store b3");
@@ -3890,7 +3861,7 @@ mod tests {
         let b4 = BlockWithParent::new(b3.block.hash, NumHash::new(4, B256::random()));
         let b5 = BlockWithParent::new(b4.block.hash, NumHash::new(5, B256::random()));
 
-        store.set_earliest_block_number_hash(b0.number, b0.hash).expect("set earliest");
+        store.set_earliest_block_number(b0.number, b0.hash).expect("set earliest");
         store.store_trie_updates(b1, make_diff(10)).expect("store b1");
         store.store_trie_updates(b2, make_diff(20)).expect("store b2");
         store.store_trie_updates(b3, make_diff(30)).expect("store b3");

--- a/rust/op-reth/crates/trie/src/db/store.rs
+++ b/rust/op-reth/crates/trie/src/db/store.rs
@@ -83,23 +83,18 @@ impl<TX> MdbxProofsProvider<TX> {
 }
 
 impl<TX: DbTx> MdbxProofsProvider<TX> {
-    fn get_block_number_hash_inner(
-        &self,
-        key: ProofWindowKey,
-    ) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    fn get_block_number_hash_inner(&self, key: ProofWindowKey) -> OpProofsStorageResult<NumHash> {
         let mut cursor = self.tx.cursor_read::<ProofWindow>()?;
-        let value = cursor.seek_exact(key)?;
-        Ok(value.map(|(_, val)| (val.number(), *val.hash())))
+        cursor
+            .seek_exact(key)?
+            .map(|(_, val)| NumHash::new(val.number(), *val.hash()))
+            .ok_or(NoBlocksFound)
     }
 
     /// Phase 1 of pruning: Calculate survivors.
     /// Scans change sets to find the LATEST update for every key in the range.
     fn calculate_prune_plan(&self, target_block: u64) -> OpProofsStorageResult<Option<PrunePlan>> {
-        let Some((earliest, _)) =
-            self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock)?
-        else {
-            return Err(NoBlocksFound);
-        };
+        let earliest = self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock)?.number;
         if earliest >= target_block {
             return Err(OpProofsStorageError::PruneBeyondEarliest {
                 target_block_number: target_block,
@@ -521,8 +516,7 @@ impl<TX: DbTxMut + DbTx> MdbxProofsProvider<TX> {
     ) -> OpProofsStorageResult<WriteCounts> {
         let block_number = block_ref.block.number;
 
-        let (_, latest_block_hash) =
-            self.get_block_number_hash_inner(ProofWindowKey::LatestBlock)?.ok_or(NoBlocksFound)?;
+        let latest_block_hash = self.get_block_number_hash_inner(ProofWindowKey::LatestBlock)?.hash;
 
         if latest_block_hash != block_ref.parent {
             return Err(OpProofsStorageError::OutOfOrder {
@@ -588,19 +582,11 @@ impl<TX: DbTx + Send + Sync + Debug + 'static> OpProofsProviderRO for MdbxProofs
         TX: 'tx;
 
     fn get_earliest_block(&self) -> OpProofsStorageResult<NumHash> {
-        let mut cursor = self.tx.cursor_read::<ProofWindow>()?;
-        cursor
-            .seek_exact(ProofWindowKey::EarliestBlock)?
-            .map(|(_, val)| NumHash::new(val.number(), *val.hash()))
-            .ok_or(NoBlocksFound)
+        self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock)
     }
 
     fn get_latest_block(&self) -> OpProofsStorageResult<NumHash> {
-        let mut cursor = self.tx.cursor_read::<ProofWindow>()?;
-        cursor
-            .seek_exact(ProofWindowKey::LatestBlock)?
-            .map(|(_, val)| NumHash::new(val.number(), *val.hash()))
-            .ok_or(NoBlocksFound)
+        self.get_block_number_hash_inner(ProofWindowKey::LatestBlock)
     }
 
     fn get_proof_window(&self) -> OpProofsStorageResult<ProofWindowRange> {
@@ -888,15 +874,15 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsInitProvider
             return Ok(InitialStateAnchor::default());
         };
 
-        let completed = self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock)?.is_some();
+        let status = match self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock) {
+            Ok(_) => InitialStateStatus::Completed,
+            Err(NoBlocksFound) => InitialStateStatus::InProgress,
+            Err(err) => return Err(err),
+        };
 
         Ok(InitialStateAnchor {
             block: Some(block),
-            status: if completed {
-                InitialStateStatus::Completed
-            } else {
-                InitialStateStatus::InProgress
-            },
+            status,
             latest_account_trie_key: self.get_latest_key_inner::<AccountTrieHistory>()?,
             latest_storage_trie_key: self.get_latest_key_inner::<StorageTrieHistory>()?,
             latest_hashed_account_key: self.get_latest_key_inner::<HashedAccountHistory>()?,

--- a/rust/op-reth/crates/trie/src/db/store_v2/init.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/init.rs
@@ -145,6 +145,7 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsInitProvider
         let anchor =
             self.get_initial_state_anchor_inner()?.ok_or(OpProofsStorageError::NoBlocksFound)?;
         self.set_earliest_block_number_inner(anchor.number, anchor.hash)?;
+        self.set_latest_block_number_inner(anchor.number, anchor.hash)?;
         Ok(anchor)
     }
 

--- a/rust/op-reth/crates/trie/src/db/store_v2/init.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/init.rs
@@ -27,10 +27,10 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsInitProvider
             return Ok(InitialStateAnchor::default());
         };
 
-        let status = if self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock)?.is_some() {
-            InitialStateStatus::Completed
-        } else {
-            InitialStateStatus::InProgress
+        let status = match self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock) {
+            Ok(_) => InitialStateStatus::Completed,
+            Err(OpProofsStorageError::NoBlocksFound) => InitialStateStatus::InProgress,
+            Err(err) => return Err(err),
         };
 
         // Scan the last entry in each current-state table to determine resume

--- a/rust/op-reth/crates/trie/src/db/store_v2/provider_ro.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/provider_ro.rs
@@ -5,10 +5,10 @@ use super::{
     cursor::{V2AccountCursor, V2AccountTrieCursor, V2StorageCursor, V2StorageTrieCursor},
 };
 use crate::{
-    BlockStateDiff, OpProofsStorageResult,
-    api::OpProofsProviderRO,
+    BlockStateDiff, OpProofsStorageError, OpProofsStorageResult,
+    api::{OpProofsProviderRO, ProofWindowRange},
     db::{
-        ProofWindowKey, V2ProofWindow,
+        ProofWindowKey,
         models::{
             V2AccountTrieChangeSets, V2AccountsTrie, V2AccountsTrieHistory,
             V2HashedAccountChangeSets, V2HashedAccounts, V2HashedAccountsHistory,
@@ -17,8 +17,9 @@ use crate::{
         },
     },
 };
+use alloy_eips::NumHash;
 use alloy_primitives::B256;
-use reth_db::{cursor::DbCursorRO, transaction::DbTx};
+use reth_db::transaction::DbTx;
 use std::fmt::Debug;
 
 impl<TX: DbTx + Send + Sync + Debug + 'static> OpProofsProviderRO for MdbxProofsProviderV2<TX> {
@@ -62,17 +63,20 @@ impl<TX: DbTx + Send + Sync + Debug + 'static> OpProofsProviderRO for MdbxProofs
         Self: 'tx,
         TX: 'tx;
 
-    fn get_earliest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
-        self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock)
+    fn get_earliest_block(&self) -> OpProofsStorageResult<NumHash> {
+        self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock)?
+            .map(|(number, hash)| NumHash::new(number, hash))
+            .ok_or(OpProofsStorageError::NoBlocksFound)
     }
 
-    fn get_latest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
-        let mut cursor = self.tx.cursor_read::<V2ProofWindow>()?;
-        if let Some((_, val)) = cursor.seek_exact(ProofWindowKey::LatestBlock)? {
-            return Ok(Some((val.number(), *val.hash())));
-        }
-        let earliest = cursor.seek_exact(ProofWindowKey::EarliestBlock)?;
-        Ok(earliest.map(|(_, val)| (val.number(), *val.hash())))
+    fn get_latest_block(&self) -> OpProofsStorageResult<NumHash> {
+        self.get_block_number_hash_inner(ProofWindowKey::LatestBlock)?
+            .map(|(number, hash)| NumHash::new(number, hash))
+            .ok_or(OpProofsStorageError::NoBlocksFound)
+    }
+
+    fn get_proof_window(&self) -> OpProofsStorageResult<ProofWindowRange> {
+        self.get_proof_window_inner()
     }
 
     fn storage_trie_cursor<'tx>(

--- a/rust/op-reth/crates/trie/src/db/store_v2/provider_ro.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/provider_ro.rs
@@ -5,7 +5,7 @@ use super::{
     cursor::{V2AccountCursor, V2AccountTrieCursor, V2StorageCursor, V2StorageTrieCursor},
 };
 use crate::{
-    BlockStateDiff, OpProofsStorageError, OpProofsStorageResult,
+    BlockStateDiff, OpProofsStorageResult,
     api::{OpProofsProviderRO, ProofWindowRange},
     db::{
         ProofWindowKey,
@@ -64,15 +64,11 @@ impl<TX: DbTx + Send + Sync + Debug + 'static> OpProofsProviderRO for MdbxProofs
         TX: 'tx;
 
     fn get_earliest_block(&self) -> OpProofsStorageResult<NumHash> {
-        self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock)?
-            .map(|(number, hash)| NumHash::new(number, hash))
-            .ok_or(OpProofsStorageError::NoBlocksFound)
+        self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock)
     }
 
     fn get_latest_block(&self) -> OpProofsStorageResult<NumHash> {
-        self.get_block_number_hash_inner(ProofWindowKey::LatestBlock)?
-            .map(|(number, hash)| NumHash::new(number, hash))
-            .ok_or(OpProofsStorageError::NoBlocksFound)
+        self.get_block_number_hash_inner(ProofWindowKey::LatestBlock)
     }
 
     fn get_proof_window(&self) -> OpProofsStorageResult<ProofWindowRange> {

--- a/rust/op-reth/crates/trie/src/db/store_v2/provider_rw.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/provider_rw.rs
@@ -185,14 +185,6 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsProviderRw
         Ok(())
     }
 
-    fn set_earliest_block_number(
-        &self,
-        block_number: u64,
-        hash: B256,
-    ) -> OpProofsStorageResult<()> {
-        self.set_earliest_block_number_inner(block_number, hash)
-    }
-
     fn commit(self) -> OpProofsStorageResult<()> {
         self.tx.commit()?;
         Ok(())

--- a/rust/op-reth/crates/trie/src/db/store_v2/read.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/read.rs
@@ -3,8 +3,9 @@
 use super::MdbxProofsProviderV2;
 use crate::{
     OpProofsStorageError, OpProofsStorageResult,
+    api::ProofWindowRange,
     db::{
-        ProofWindowKey, ProofWindowValue, V2ProofWindow,
+        ProofWindowKey, V2ProofWindow,
         models::{
             BlockNumberHashedAddress, V2AccountTrieChangeSets, V2AccountsTrie,
             V2HashedAccountChangeSets, V2HashedAccounts, V2HashedStorageChangeSets,
@@ -29,41 +30,28 @@ impl<TX: DbTx> MdbxProofsProviderV2<TX> {
         Ok(cursor.seek_exact(key)?.map(|(_, val)| (val.number(), *val.hash())))
     }
 
-    pub(super) fn get_latest_block_number_hash_inner(
-        &self,
-    ) -> OpProofsStorageResult<Option<(u64, B256)>> {
-        let block = self.get_block_number_hash_inner(ProofWindowKey::LatestBlock)?;
-        if block.is_some() {
-            return Ok(block);
-        }
-        self.get_block_number_hash_inner(ProofWindowKey::EarliestBlock)
-    }
-
     /// Returns `true` when `max_block_number` is >= the latest stored block,
     /// meaning the current-state tables are authoritative and history/changeset
     /// lookups can be skipped entirely.
     pub(super) fn is_latest_block(&self, max_block_number: u64) -> OpProofsStorageResult<bool> {
-        match self.get_latest_block_number_hash_inner()? {
+        match self.get_block_number_hash_inner(ProofWindowKey::LatestBlock)? {
             Some((latest, _)) => Ok(max_block_number >= latest),
             // No blocks stored yet → current state is empty but correct.
             None => Ok(true),
         }
     }
 
-    pub(super) fn get_proof_window_inner(&self) -> OpProofsStorageResult<ProofWindowValue> {
+    pub(super) fn get_proof_window_inner(&self) -> OpProofsStorageResult<ProofWindowRange> {
         let mut cursor = self.tx.cursor_read::<V2ProofWindow>()?;
-
         let earliest = match cursor.seek_exact(ProofWindowKey::EarliestBlock)? {
             Some((_, val)) => NumHash::new(val.number(), *val.hash()),
             None => return Err(OpProofsStorageError::NoBlocksFound),
         };
-
         let latest = match cursor.seek_exact(ProofWindowKey::LatestBlock)? {
             Some((_, val)) => NumHash::new(val.number(), *val.hash()),
-            None => earliest,
+            None => return Err(OpProofsStorageError::NoBlocksFound),
         };
-
-        Ok(ProofWindowValue { earliest, latest })
+        Ok(ProofWindowRange { earliest, latest })
     }
 
     pub(super) fn get_initial_state_anchor_inner(

--- a/rust/op-reth/crates/trie/src/db/store_v2/read.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/read.rs
@@ -25,19 +25,23 @@ impl<TX: DbTx> MdbxProofsProviderV2<TX> {
     pub(super) fn get_block_number_hash_inner(
         &self,
         key: ProofWindowKey,
-    ) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    ) -> OpProofsStorageResult<NumHash> {
         let mut cursor = self.tx.cursor_read::<V2ProofWindow>()?;
-        Ok(cursor.seek_exact(key)?.map(|(_, val)| (val.number(), *val.hash())))
+        cursor
+            .seek_exact(key)?
+            .map(|(_, val)| NumHash::new(val.number(), *val.hash()))
+            .ok_or(OpProofsStorageError::NoBlocksFound)
     }
 
     /// Returns `true` when `max_block_number` is >= the latest stored block,
     /// meaning the current-state tables are authoritative and history/changeset
     /// lookups can be skipped entirely.
     pub(super) fn is_latest_block(&self, max_block_number: u64) -> OpProofsStorageResult<bool> {
-        match self.get_block_number_hash_inner(ProofWindowKey::LatestBlock)? {
-            Some((latest, _)) => Ok(max_block_number >= latest),
+        match self.get_block_number_hash_inner(ProofWindowKey::LatestBlock) {
+            Ok(latest) => Ok(max_block_number >= latest.number),
             // No blocks stored yet → current state is empty but correct.
-            None => Ok(true),
+            Err(OpProofsStorageError::NoBlocksFound) => Ok(true),
+            Err(err) => Err(err),
         }
     }
 

--- a/rust/op-reth/crates/trie/src/db/store_v2/tests.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/tests.rs
@@ -907,42 +907,28 @@ fn fetch_trie_updates_empty_changeset() {
 fn test_proof_window() {
     let db = setup_db();
 
-    // Initial state: no values set
+    // Empty store: both endpoints are None.
     {
         let provider = MdbxProofsProviderV2::new(db.tx().expect("ro"));
-        assert_eq!(provider.get_earliest_block_number().expect("get"), None);
+        assert!(matches!(provider.get_earliest_block(), Err(OpProofsStorageError::NoBlocksFound)));
+        assert!(matches!(provider.get_latest_block(), Err(OpProofsStorageError::NoBlocksFound)));
     }
 
-    // Set earliest
+    // Bootstrap via the init flow: commit_initial_state sets both earliest and latest.
+    let anchor_hash = B256::repeat_byte(0x42);
     {
         let provider = MdbxProofsProviderV2::new(db.tx_mut().expect("rw"));
-        provider.set_earliest_block_number(42, B256::repeat_byte(0x42)).expect("set");
-        OpProofsProviderRw::commit(provider).expect("commit");
+        provider
+            .set_initial_state_anchor(BlockNumHash { number: 42, hash: anchor_hash })
+            .expect("anchor");
+        provider.commit_initial_state().expect("commit init");
+        OpProofsInitProvider::commit(provider).expect("commit");
     }
 
-    // Verify
     {
         let provider = MdbxProofsProviderV2::new(db.tx().expect("ro"));
-        let earliest = provider.get_earliest_block_number().expect("get");
-        assert_eq!(earliest, Some((42, B256::repeat_byte(0x42))));
-
-        // Latest should fall back to earliest when not set
-        let latest = provider.get_latest_block_number().expect("get");
-        assert_eq!(latest, Some((42, B256::repeat_byte(0x42))));
-    }
-
-    // Update earliest
-    {
-        let provider = MdbxProofsProviderV2::new(db.tx_mut().expect("rw"));
-        provider.set_earliest_block_number(100, B256::repeat_byte(0x64)).expect("set");
-        OpProofsProviderRw::commit(provider).expect("commit");
-    }
-
-    // Verify update
-    {
-        let provider = MdbxProofsProviderV2::new(db.tx().expect("ro"));
-        let earliest = provider.get_earliest_block_number().expect("get");
-        assert_eq!(earliest, Some((100, B256::repeat_byte(0x64))));
+        assert_eq!(provider.get_earliest_block().expect("get"), NumHash::new(42, anchor_hash));
+        assert_eq!(provider.get_latest_block().expect("get"), NumHash::new(42, anchor_hash));
     }
 }
 

--- a/rust/op-reth/crates/trie/src/engine/state.rs
+++ b/rust/op-reth/crates/trie/src/engine/state.rs
@@ -237,6 +237,6 @@ where
             return Ok(tip);
         }
 
-        self.storage.provider_ro()?.get_latest_block().map_err(Into::into)
+        Ok(self.storage.provider_ro()?.get_latest_block()?)
     }
 }

--- a/rust/op-reth/crates/trie/src/engine/state.rs
+++ b/rust/op-reth/crates/trie/src/engine/state.rs
@@ -8,7 +8,7 @@ use super::{
     error::EngineError,
     persistence::{PersistenceHandle, error::PersistenceError},
 };
-use crate::{OpProofStoragePruner, OpProofsProviderRO, OpProofsStorageError, OpProofsStore};
+use crate::{OpProofStoragePruner, OpProofsProviderRO, OpProofsStore};
 use alloy_eips::{NumHash, eip1898::BlockWithParent};
 use crossbeam_channel::{Receiver, RecvError, RecvTimeoutError, bounded};
 use reth_evm::ConfigureEvm;
@@ -237,11 +237,6 @@ where
             return Ok(tip);
         }
 
-        self.storage
-            .provider_ro()?
-            .get_latest_block_number()?
-            .map(|(n, h)| NumHash::new(n, h))
-            .ok_or(OpProofsStorageError::NoBlocksFound)
-            .map_err(Into::into)
+        self.storage.provider_ro()?.get_latest_block().map_err(Into::into)
     }
 }

--- a/rust/op-reth/crates/trie/src/in_memory.rs
+++ b/rust/op-reth/crates/trie/src/in_memory.rs
@@ -4,7 +4,7 @@ use crate::{
     BlockStateDiff, OpProofsStorageError, OpProofsStorageResult, OpProofsStore,
     api::{
         InitialStateAnchor, InitialStateStatus, OpProofsInitProvider, OpProofsProviderRO,
-        OpProofsProviderRw, WriteCounts,
+        OpProofsProviderRw, ProofWindowRange, WriteCounts,
     },
     db::{HashedStorageKey, StorageTrieKey},
 };
@@ -57,6 +57,11 @@ struct InMemoryStorageInner {
 
     /// Earliest block number and hash
     earliest_block: Option<(u64, B256)>,
+
+    /// Latest block number and hash. Mirrors `MdbxProofsStorage*`'s explicit `LatestBlock`
+    /// entry — set by `commit_initial_state`, `store_trie_updates`, `unwind_history`,
+    /// `replace_updates`. Left untouched by `prune_earliest_state`.
+    latest_block: Option<(u64, B256)>,
 
     /// The anchor block (initial state) of the store.
     anchor_block: Option<(u64, B256)>,
@@ -565,15 +570,33 @@ impl OpProofsProviderRO for InMemoryProofsProvider {
     type StorageCursor<'tx> = InMemoryStorageCursor;
     type AccountHashedCursor<'tx> = InMemoryAccountCursor;
 
-    fn get_earliest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    fn get_earliest_block(&self) -> OpProofsStorageResult<NumHash> {
         let inner = self.inner.read();
-        Ok(inner.earliest_block)
+        inner
+            .earliest_block
+            .map(|(number, hash)| NumHash::new(number, hash))
+            .ok_or(OpProofsStorageError::NoBlocksFound)
     }
 
-    fn get_latest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    fn get_latest_block(&self) -> OpProofsStorageResult<NumHash> {
         let inner = self.inner.read();
-        let latest_block = inner.trie_updates.keys().max().copied();
-        latest_block.map_or_else(|| Ok(inner.earliest_block), |block| Ok(Some((block, B256::ZERO))))
+        inner
+            .latest_block
+            .map(|(number, hash)| NumHash::new(number, hash))
+            .ok_or(OpProofsStorageError::NoBlocksFound)
+    }
+
+    fn get_proof_window(&self) -> OpProofsStorageResult<ProofWindowRange> {
+        let inner = self.inner.read();
+        let earliest = inner
+            .earliest_block
+            .map(|(number, hash)| NumHash::new(number, hash))
+            .ok_or(OpProofsStorageError::NoBlocksFound)?;
+        let latest = inner
+            .latest_block
+            .map(|(number, hash)| NumHash::new(number, hash))
+            .ok_or(OpProofsStorageError::NoBlocksFound)?;
+        Ok(ProofWindowRange { earliest, latest })
     }
 
     fn storage_trie_cursor<'tx>(
@@ -622,7 +645,9 @@ impl OpProofsProviderRw for InMemoryProofsProvider {
         block_state_diff: BlockStateDiff,
     ) -> OpProofsStorageResult<WriteCounts> {
         let mut inner = self.inner.write();
-        Ok(inner.store_trie_updates(block_ref.block.number, block_state_diff))
+        let counts = inner.store_trie_updates(block_ref.block.number, block_state_diff);
+        inner.latest_block = Some((block_ref.block.number, block_ref.block.hash));
+        Ok(counts)
     }
 
     fn store_trie_updates_batch(
@@ -631,8 +656,13 @@ impl OpProofsProviderRw for InMemoryProofsProvider {
     ) -> OpProofsStorageResult<WriteCounts> {
         let mut inner = self.inner.write();
         let mut total_write_count = WriteCounts::default();
+        let mut last_block_ref = None;
         for (block_ref, block_state_diff) in updates {
             total_write_count += inner.store_trie_updates(block_ref.block.number, block_state_diff);
+            last_block_ref = Some(block_ref);
+        }
+        if let Some(block_ref) = last_block_ref {
+            inner.latest_block = Some((block_ref.block.number, block_ref.block.hash));
         }
         Ok(total_write_count)
     }
@@ -736,6 +766,9 @@ impl OpProofsProviderRw for InMemoryProofsProvider {
         inner.hashed_accounts.retain(|(block, _), _| *block <= unwind_upto_block_number);
         inner.hashed_storages.retain(|(block, _, _), _| *block <= unwind_upto_block_number);
 
+        // After unwind the new tip is `unwind_upto_block`'s parent.
+        inner.latest_block = Some((unwind_upto_block_number, unwind_upto_block.parent));
+
         Ok(())
     }
 
@@ -755,20 +788,13 @@ impl OpProofsProviderRw for InMemoryProofsProvider {
         inner.hashed_accounts.retain(|(block, _), _| *block <= latest_common_block_number);
         inner.hashed_storages.retain(|(block, _, _), _| *block <= latest_common_block_number);
 
+        let mut new_tip = (latest_common_block.number, latest_common_block.hash);
         for (block, block_state_diff) in blocks_to_add {
             inner.store_trie_updates(block.block.number, block_state_diff);
+            new_tip = (block.block.number, block.block.hash);
         }
+        inner.latest_block = Some(new_tip);
 
-        Ok(())
-    }
-
-    fn set_earliest_block_number(
-        &self,
-        block_number: u64,
-        hash: B256,
-    ) -> OpProofsStorageResult<()> {
-        let mut inner = self.inner.write();
-        inner.earliest_block = Some((block_number, hash));
         Ok(())
     }
 
@@ -865,6 +891,7 @@ impl OpProofsInitProvider for InMemoryProofsProvider {
         let mut inner = self.inner.write();
         let anchor = inner.anchor_block.ok_or(OpProofsStorageError::NoBlocksFound)?;
         inner.earliest_block = Some(anchor);
+        inner.latest_block = Some(anchor);
         Ok(BlockNumHash::new(anchor.0, anchor.1))
     }
 
@@ -885,11 +912,15 @@ mod tests {
     fn test_in_memory_storage_basic_operations() -> Result<(), OpProofsStorageError> {
         let storage = InMemoryProofsStorage::new();
 
-        // Test setting earliest block
+        // Bootstrap the chain anchor via the init flow.
         let block_hash = B256::random();
-        storage.provider_rw()?.set_earliest_block_number(1, block_hash)?;
-        let earliest = storage.provider_ro()?.get_earliest_block_number()?;
-        assert_eq!(earliest, Some((1, block_hash)));
+        let init = storage.initialization_provider()?;
+        init.set_initial_state_anchor(BlockNumHash { number: 1, hash: block_hash })?;
+        init.commit_initial_state()?;
+        OpProofsInitProvider::commit(init)?;
+
+        let earliest = storage.provider_ro()?.get_earliest_block()?;
+        assert_eq!(earliest, NumHash::new(1, block_hash));
 
         // Test storing and retrieving accounts
         let account = Account { nonce: 1, balance: U256::from(100), bytecode_hash: None };

--- a/rust/op-reth/crates/trie/src/initialize.rs
+++ b/rust/op-reth/crates/trie/src/initialize.rs
@@ -658,6 +658,7 @@ impl<C> InitTable for StoragesTrieInitLegacy<C> {
 mod tests {
     use super::*;
     use crate::{MdbxProofsStorage, OpProofsProviderRO};
+    use alloy_eips::NumHash;
     use alloy_primitives::{Address, U256, keccak256};
     use reth_db::{
         Database, cursor::DbCursorRW, test_utils::create_test_rw_db, transaction::DbTxMut,
@@ -976,14 +977,17 @@ mod tests {
             storage.initialization_provider().unwrap().initial_state_anchor().unwrap().block,
             None
         );
-        assert_eq!(storage.provider_ro().unwrap().get_earliest_block_number().unwrap(), None);
+        assert!(matches!(
+            storage.provider_ro().unwrap().get_earliest_block(),
+            Err(OpProofsStorageError::NoBlocksFound)
+        ));
 
         job.run(best_number, best_hash).unwrap();
 
         // Should be set after initialization
         assert_eq!(
-            storage.provider_ro().unwrap().get_earliest_block_number().unwrap(),
-            Some((best_number, best_hash))
+            storage.provider_ro().unwrap().get_earliest_block().unwrap(),
+            NumHash::new(best_number, best_hash)
         );
 
         // Verify data was initialized
@@ -1037,8 +1041,8 @@ mod tests {
 
         // Should still have the old earliest block
         assert_eq!(
-            storage.provider_ro().unwrap().get_earliest_block_number().unwrap(),
-            Some((50, B256::repeat_byte(0x01)))
+            storage.provider_ro().unwrap().get_earliest_block().unwrap(),
+            NumHash::new(50, B256::repeat_byte(0x01))
         );
     }
 

--- a/rust/op-reth/crates/trie/src/lib.rs
+++ b/rust/op-reth/crates/trie/src/lib.rs
@@ -19,6 +19,7 @@ use reth_ethereum_primitives as _;
 pub mod api;
 pub use api::{
     BlockStateDiff, OpProofsInitProvider, OpProofsProviderRO, OpProofsProviderRw, OpProofsStore,
+    ProofWindowRange,
 };
 
 pub mod initialize;

--- a/rust/op-reth/crates/trie/src/metrics.rs
+++ b/rust/op-reth/crates/trie/src/metrics.rs
@@ -4,11 +4,11 @@ use crate::{
     BlockStateDiff, OpProofsStorageResult, OpProofsStore,
     api::{
         InitialStateAnchor, OpProofsInitProvider, OpProofsProviderRO, OpProofsProviderRw,
-        WriteCounts,
+        ProofWindowRange, WriteCounts,
     },
     cursor,
 };
-use alloy_eips::{BlockNumHash, eip1898::BlockWithParent};
+use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256, map::HashMap};
 use derive_more::Constructor;
 use metrics::{Gauge, Histogram};
@@ -378,20 +378,24 @@ impl<P: OpProofsProviderRO> OpProofsProviderRO for OpProofsProviderROWithMetrics
         Self: 'tx;
 
     #[inline]
-    fn get_earliest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
-        let result = self.provider.get_earliest_block_number()?;
-        if let Some((number, _)) = result {
-            self.metrics.proof_window.earliest.set(number as f64);
-        }
+    fn get_earliest_block(&self) -> OpProofsStorageResult<NumHash> {
+        let result = self.provider.get_earliest_block()?;
+        self.metrics.proof_window.earliest.set(result.number as f64);
         Ok(result)
     }
 
     #[inline]
-    fn get_latest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
-        let result = self.provider.get_latest_block_number()?;
-        if let Some((number, _)) = result {
-            self.metrics.proof_window.latest.set(number as f64);
-        }
+    fn get_latest_block(&self) -> OpProofsStorageResult<NumHash> {
+        let result = self.provider.get_latest_block()?;
+        self.metrics.proof_window.latest.set(result.number as f64);
+        Ok(result)
+    }
+
+    #[inline]
+    fn get_proof_window(&self) -> OpProofsStorageResult<ProofWindowRange> {
+        let result = self.provider.get_proof_window()?;
+        self.metrics.proof_window.earliest.set(result.earliest.number as f64);
+        self.metrics.proof_window.latest.set(result.latest.number as f64);
         Ok(result)
     }
 
@@ -465,20 +469,24 @@ impl<P: OpProofsProviderRw> OpProofsProviderRO for OpProofsProviderRwWithMetrics
         Self: 'tx;
 
     #[inline]
-    fn get_earliest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
-        let result = self.provider.get_earliest_block_number()?;
-        if let Some((number, _)) = result {
-            self.metrics.proof_window.earliest.set(number as f64);
-        }
+    fn get_earliest_block(&self) -> OpProofsStorageResult<NumHash> {
+        let result = self.provider.get_earliest_block()?;
+        self.metrics.proof_window.earliest.set(result.number as f64);
         Ok(result)
     }
 
     #[inline]
-    fn get_latest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
-        let result = self.provider.get_latest_block_number()?;
-        if let Some((number, _)) = result {
-            self.metrics.proof_window.latest.set(number as f64);
-        }
+    fn get_latest_block(&self) -> OpProofsStorageResult<NumHash> {
+        let result = self.provider.get_latest_block()?;
+        self.metrics.proof_window.latest.set(result.number as f64);
+        Ok(result)
+    }
+
+    #[inline]
+    fn get_proof_window(&self) -> OpProofsStorageResult<ProofWindowRange> {
+        let result = self.provider.get_proof_window()?;
+        self.metrics.proof_window.earliest.set(result.earliest.number as f64);
+        self.metrics.proof_window.latest.set(result.latest.number as f64);
         Ok(result)
     }
 
@@ -571,16 +579,6 @@ impl<P: OpProofsProviderRw> OpProofsProviderRw for OpProofsProviderRwWithMetrics
         blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
     ) -> OpProofsStorageResult<()> {
         self.provider.replace_updates(latest_common_block, blocks_to_add)
-    }
-
-    #[inline]
-    fn set_earliest_block_number(
-        &self,
-        block_number: u64,
-        hash: B256,
-    ) -> OpProofsStorageResult<()> {
-        self.metrics.proof_window.earliest.set(block_number as f64);
-        self.provider.set_earliest_block_number(block_number, hash)
     }
 
     #[inline]

--- a/rust/op-reth/crates/trie/src/provider.rs
+++ b/rust/op-reth/crates/trie/src/provider.rs
@@ -251,7 +251,7 @@ mod tests {
 
         assert_eq!(
             format!("{:?}", provider),
-            "OpProofsStateProviderRef { provider: InMemoryProofsProvider { inner: RwLock { data: InMemoryStorageInner { account_branches: {}, storage_branches: {}, hashed_accounts: {}, hashed_storages: {}, trie_updates: {}, post_states: {}, earliest_block: None, anchor_block: None } } }, block_number: 42 }"
+            "OpProofsStateProviderRef { provider: InMemoryProofsProvider { inner: RwLock { data: InMemoryStorageInner { account_branches: {}, storage_branches: {}, hashed_accounts: {}, hashed_storages: {}, trie_updates: {}, post_states: {}, earliest_block: None, latest_block: None, anchor_block: None } } }, block_number: 42 }"
         );
     }
 }

--- a/rust/op-reth/crates/trie/src/prune/pruner.rs
+++ b/rust/op-reth/crates/trie/src/prune/pruner.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "metrics")]
 use crate::prune::metrics::Metrics;
 use crate::{
-    OpProofsProviderRO, OpProofsProviderRw, OpProofsStore,
+    OpProofsProviderRO, OpProofsProviderRw, OpProofsStorageError, OpProofsStore,
     prune::error::{OpProofStoragePrunerResult, PrunerError, PrunerOutput},
 };
 
@@ -141,15 +141,15 @@ where
         &self,
         provider: &P,
     ) -> Result<Option<(u64, u64, PrunerOutput)>, PrunerError> {
-        let Some(latest) = provider.get_latest_block_number()? else {
-            trace!(target: "trie::pruner", "No latest blocks in the proof storage");
-            return Ok(None);
+        let window = match provider.get_proof_window() {
+            Ok(w) => w,
+            Err(OpProofsStorageError::NoBlocksFound) => {
+                trace!(target: "trie::pruner", "Proof storage is empty");
+                return Ok(None);
+            }
+            Err(err) => return Err(err.into()),
         };
-        let Some(earliest) = provider.get_earliest_block_number()? else {
-            trace!(target: "trie::pruner", "No earliest blocks in the proof storage");
-            return Ok(None);
-        };
-        let (latest_block, earliest_block) = (latest.0, earliest.0);
+        let (latest_block, earliest_block) = (window.latest.number, window.earliest.number);
         if latest_block.saturating_sub(earliest_block) <= self.min_block_interval {
             trace!(target: "trie::pruner", "Nothing to prune");
             return Ok(None);
@@ -234,8 +234,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{BlockStateDiff, OpProofsStorage, db::MdbxProofsStorage};
-    use alloy_eips::{BlockHashOrNumber, NumHash};
+    use crate::{BlockStateDiff, OpProofsInitProvider, OpProofsStorage, db::MdbxProofsStorage};
+    use alloy_eips::{BlockHashOrNumber, BlockNumHash, NumHash};
     use alloy_primitives::{B256, BlockNumber, U256};
     use mockall::mock;
     use reth_primitives_traits::Account;
@@ -286,9 +286,11 @@ mod tests {
         let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
 
         {
-            let provider = store.provider_rw().expect("provider_rw");
-            provider.set_earliest_block_number(0, B256::ZERO).expect("set earliest");
-            provider.commit().expect("commit");
+            let init = store.initialization_provider().expect("init");
+            init.set_initial_state_anchor(BlockNumHash { number: 0, hash: B256::ZERO })
+                .expect("anchor");
+            init.commit_initial_state().expect("commit init");
+            OpProofsInitProvider::commit(init).expect("commit");
         }
 
         // --- entities ---
@@ -354,7 +356,7 @@ mod tests {
             };
             let provider = store.provider_rw().expect("provider_rw");
             provider.store_trie_updates(b1, d).expect("b1");
-            provider.commit().expect("commit");
+            OpProofsProviderRw::commit(provider).expect("commit");
             parent = b256(1);
         }
 
@@ -389,7 +391,7 @@ mod tests {
             };
             let provider = store.provider_rw().expect("provider_rw");
             provider.store_trie_updates(b2, d).expect("b2");
-            provider.commit().expect("commit");
+            OpProofsProviderRw::commit(provider).expect("commit");
             parent = b256(2);
         }
 
@@ -417,7 +419,7 @@ mod tests {
             };
             let provider = store.provider_rw().expect("provider_rw");
             provider.store_trie_updates(b3, d).expect("b3");
-            provider.commit().expect("commit");
+            OpProofsProviderRw::commit(provider).expect("commit");
             parent = b256(3);
         }
 
@@ -446,7 +448,7 @@ mod tests {
             };
             let provider = store.provider_rw().expect("provider_rw");
             provider.store_trie_updates(b4, d).expect("b4");
-            provider.commit().expect("commit");
+            OpProofsProviderRw::commit(provider).expect("commit");
             parent = b256(4);
         }
 
@@ -471,16 +473,16 @@ mod tests {
             };
             let provider = store.provider_rw().expect("provider_rw");
             provider.store_trie_updates(b5, d).expect("b5");
-            provider.commit().expect("commit");
+            OpProofsProviderRw::commit(provider).expect("commit");
         }
 
         // sanity: earliest=0, latest=5
         {
             let provider = store.provider_ro().expect("provider_ro");
-            let e = provider.get_earliest_block_number().expect("earliest").expect("some");
-            let l = provider.get_latest_block_number().expect("latest").expect("some");
-            assert_eq!(e.0, 0);
-            assert_eq!(l.0, 5);
+            let e = provider.get_earliest_block().expect("earliest");
+            let l = provider.get_latest_block().expect("latest");
+            assert_eq!(e.number, 0);
+            assert_eq!(l.number, 5);
         }
 
         // --- prune: remove the first 3 blocks, keep 4 and 5
@@ -504,12 +506,10 @@ mod tests {
         // proof window moved: earliest=4, latest=5
         {
             let provider = store.provider_ro().expect("provider_ro");
-            let e = provider.get_earliest_block_number().expect("earliest").expect("some");
-            let l = provider.get_latest_block_number().expect("latest").expect("some");
-            assert_eq!(e.0, 4);
-            assert_eq!(e.1, b256(4));
-            assert_eq!(l.0, 5);
-            assert_eq!(l.1, b256(5));
+            let e = provider.get_earliest_block().expect("earliest");
+            let l = provider.get_latest_block().expect("latest");
+            assert_eq!(e, NumHash::new(4, b256(4)));
+            assert_eq!(l, NumHash::new(5, b256(5)));
         }
 
         // --- DB checks
@@ -592,11 +592,11 @@ mod tests {
 
         {
             let provider = store.provider_ro().unwrap();
-            let earliest = provider.get_earliest_block_number().unwrap();
-            let latest = provider.get_latest_block_number().unwrap();
+            let earliest = provider.get_earliest_block();
+            let latest = provider.get_latest_block();
             println!("{:?} {:?}", earliest, latest);
-            assert!(earliest.is_none());
-            assert!(latest.is_none());
+            assert!(matches!(earliest, Err(OpProofsStorageError::NoBlocksFound)));
+            assert!(matches!(latest, Err(OpProofsStorageError::NoBlocksFound)));
         }
 
         let block_hash_reader = MockBlockHashReader::new();
@@ -613,19 +613,22 @@ mod tests {
         let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
             OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
 
-        // Set earliest only. In V2, get_latest_block_number() falls back to earliest.
+        // Bootstrap the chain anchor via the init flow; commit_initial_state sets both
+        // earliest and latest.
         {
-            let provider = store.provider_rw().expect("provider_rw");
-            provider.set_earliest_block_number(3, b256(3)).expect("set earliest");
-            provider.commit().expect("commit");
+            let init = store.initialization_provider().expect("init");
+            init.set_initial_state_anchor(BlockNumHash { number: 3, hash: b256(3) })
+                .expect("anchor");
+            init.commit_initial_state().expect("commit init");
+            OpProofsInitProvider::commit(init).expect("commit");
         }
 
         {
             let provider = store.provider_ro().unwrap();
-            let earliest = provider.get_earliest_block_number().unwrap();
-            let latest = provider.get_latest_block_number().unwrap();
-            assert_eq!(earliest.unwrap().0, 3);
-            assert_eq!(latest.unwrap().0, 3, "latest should fall back to earliest");
+            let earliest = provider.get_earliest_block().unwrap();
+            let latest = provider.get_latest_block().unwrap();
+            assert_eq!(earliest.number, 3);
+            assert_eq!(latest.number, 3, "commit_initial_state bootstraps both anchors");
         }
 
         let block_hash_reader = MockBlockHashReader::new();
@@ -643,26 +646,32 @@ mod tests {
         let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
             OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
 
-        // Set earliest=4 explicitly
+        // Bootstrap earliest=4 via the init flow.
         let earliest_num = 4u64;
         let h4 = b256(4);
         {
-            let provider = store.provider_rw().expect("provider_rw");
-            provider.set_earliest_block_number(earliest_num, h4).expect("set earliest");
+            let init = store.initialization_provider().expect("init");
+            init.set_initial_state_anchor(BlockNumHash { number: earliest_num, hash: h4 })
+                .expect("anchor");
+            init.commit_initial_state().expect("commit init");
+            OpProofsInitProvider::commit(init).expect("commit");
+        }
 
-            // Set latest=5 by storing block 5
+        // Set latest=5 by storing block 5.
+        {
+            let provider = store.provider_rw().expect("provider_rw");
             let b5 = block(5, h4);
             provider.store_trie_updates(b5, BlockStateDiff::default()).expect("store b5");
-            provider.commit().expect("commit");
+            OpProofsProviderRw::commit(provider).expect("commit");
         }
 
         // Sanity: earliest=4, latest=5 => interval=1
         {
             let provider = store.provider_ro().unwrap();
-            let e = provider.get_earliest_block_number().unwrap().unwrap();
-            let l = provider.get_latest_block_number().unwrap().unwrap();
-            assert_eq!(e.0, 4);
-            assert_eq!(l.0, 5);
+            let e = provider.get_earliest_block().unwrap();
+            let l = provider.get_latest_block().unwrap();
+            assert_eq!(e.number, 4);
+            assert_eq!(l.number, 5);
         }
 
         // Require min_block_interval=2 (or greater) so interval < min

--- a/rust/op-reth/crates/trie/tests/lib.rs
+++ b/rust/op-reth/crates/trie/tests/lib.rs
@@ -72,45 +72,48 @@ fn create_test_account_with_values(nonce: u64, balance: u64, code_hash_byte: u8)
     }
 }
 
+/// Bootstrap a fresh store via the init flow. Equivalent to running the initial-state
+/// preparation step in production.
+fn bootstrap_anchor<S: OpProofsStore>(storage: &S, anchor: BlockNumHash) {
+    let init = storage.initialization_provider().expect("init provider");
+    init.set_initial_state_anchor(anchor).expect("set anchor");
+    init.commit_initial_state().expect("commit initial state");
+    OpProofsInitProvider::commit(init).expect("commit tx");
+}
+
 fn create_mdbx_proofs_storage() -> MdbxProofsStorage {
     let path = TempDir::new().unwrap();
     let storage = MdbxProofsStorage::new(path.path()).unwrap();
-    let provider = storage.provider_rw().unwrap();
-    provider.set_earliest_block_number(0, B256::ZERO).unwrap();
-    OpProofsProviderRw::commit(provider).unwrap();
+    bootstrap_anchor(&storage, BlockNumHash { number: 0, hash: B256::ZERO });
     storage
 }
 
 fn create_mdbx_proofs_storage_v2() -> MdbxProofsStorageV2 {
     let path = TempDir::new().unwrap();
     let storage = MdbxProofsStorageV2::new(path.path()).unwrap();
-    let provider = storage.provider_rw().unwrap();
-    provider.set_earliest_block_number(0, B256::ZERO).unwrap();
-    OpProofsProviderRw::commit(provider).unwrap();
+    bootstrap_anchor(&storage, BlockNumHash { number: 0, hash: B256::ZERO });
     storage
 }
 
-/// Test basic storage and retrieval of earliest block number
+/// Test bootstrap via `commit_initial_state` populates both earliest and latest.
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(MdbxProofsStorage::new(TempDir::new().unwrap().path()).unwrap(); "Mdbx")]
 #[test_case(MdbxProofsStorageV2::new(TempDir::new().unwrap().path()).unwrap(); "MdbxV2")]
 #[serial]
-fn test_earliest_block_operations<S: OpProofsStore>(
-    storage: S,
-) -> Result<(), OpProofsStorageError> {
-    // Initially should be None
-    let earliest = storage.provider_ro().expect("provider ro").get_earliest_block_number()?;
-    assert!(earliest.is_none());
+fn test_bootstrap_initial_state<S: OpProofsStore>(storage: S) -> Result<(), OpProofsStorageError> {
+    // Initially both endpoints surface NoBlocksFound.
+    let provider = storage.provider_ro().expect("provider ro");
+    assert!(matches!(provider.get_earliest_block(), Err(OpProofsStorageError::NoBlocksFound)));
+    assert!(matches!(provider.get_latest_block(), Err(OpProofsStorageError::NoBlocksFound)));
 
-    // Set earliest block
+    // Run the init flow.
     let block_hash = B256::repeat_byte(0x42);
-    let provider_rw = storage.provider_rw().expect("provider rw");
-    provider_rw.set_earliest_block_number(100, block_hash)?;
-    provider_rw.commit()?;
+    bootstrap_anchor(&storage, BlockNumHash { number: 100, hash: block_hash });
 
-    // Should retrieve the same values
-    let earliest = storage.provider_ro().expect("provider ro").get_earliest_block_number()?;
-    assert_eq!(earliest, Some((100, block_hash)));
+    // Both endpoints point at the anchor.
+    let provider = storage.provider_ro().expect("provider ro");
+    assert_eq!(provider.get_earliest_block()?, NumHash::new(100, block_hash));
+    assert_eq!(provider.get_latest_block()?, NumHash::new(100, block_hash));
 
     Ok(())
 }


### PR DESCRIPTION
**Description**

Improvements

- `commit_initial_state` was the bootstrap entry point for the proofs storage, but it was only setting `EarliestBlock`. To handle over the missing `LatestBlock`, reader silently was falling back to the earliest. Updated `commit_initial_state` to set the `LatestBlock` as well.
- `get_earliest_block_number() -> Option<(u64, B256)>` → `get_earliest_block() -> NumHash`
- `get_latest_block_number() -> Option<(u64, B256)>`  → `get_latest_block() -> NumHash`
- **`get_proof_window` trait method** returning a new public `ProofWindowRange`
  (`{ earliest: NumHash, latest: NumHash }`) — one cursor read for callers that
  need both endpoints.

**Tests**

Unit test case updated

**Additional context**

NA

**Metadata**

NA