### PR TITLE
fix(op-supernode): anchor startup backfill to EL finalized head

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -975,6 +975,9 @@ func (m *algoMockChain) VerifierCurrentL1s() []eth.BlockID                { retu
 func (m *algoMockChain) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
 	return eth.L2BlockRef{}, nil
 }
+func (m *algoMockChain) ELFinalizedHead(ctx context.Context) (eth.L2BlockRef, error) {
+	return eth.L2BlockRef{}, nil
+}
 func (m *algoMockChain) L1ForL2(ctx context.Context, l2Block eth.BlockID) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -37,7 +37,7 @@ var InteropActivationTimestampFlag = &cli.Uint64Flag{
 	Value:   0,
 }
 
-// InteropLogBackfillDepthFlag extends initiating-message log ingestion backward from the L2 tip by this duration (clamped to activation). Validation still starts only beyond the local safe head.
+// InteropLogBackfillDepthFlag extends initiating-message log ingestion backward from the startup boundary by this duration (clamped to activation).
 var InteropLogBackfillDepthFlag = &cli.DurationFlag{
 	Name:    "interop.log-backfill-depth",
 	Usage:   "Duration to pre-ingest logs behind the tip before interop validation (e.g. 168h). Never loads logs before interop.activation-timestamp. Requires interop.activation-timestamp.",
@@ -140,7 +140,7 @@ type Interop struct {
 	// backfillEndTimestamp represents the end of the range of timestamps that were sealed by runLogBackfill.
 	// this is used for loop handoff from log backfill to main processing.
 	// firstVerifiableTimestamp is used to determine the start of the main processing loop, which is backfillEndTimestamp + 1
-	// after backfill, or the safe-head-derived startup timestamp when backfill was not used.
+	// after backfill, or the EL-finalized-derived startup timestamp when backfill was not used.
 	backfillEndTimestamp uint64
 	firstVerifiableSet   bool
 	firstVerifiable      uint64
@@ -195,7 +195,7 @@ func (i *Interop) Name() string {
 // firstVerifiableTimestamp is the earliest timestamp the main loop will attempt
 // to verify. If verification has already committed results, the first committed
 // timestamp is the durable handoff boundary. Otherwise it is backfillEndTimestamp+1
-// after log backfill, or the safe-head-derived startup timestamp.
+// after log backfill, or the EL-finalized-derived startup timestamp.
 func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if i.verifiedDB != nil {
 		if first, initialized := i.verifiedDB.FirstTimestamp(); initialized {
@@ -294,7 +294,7 @@ func (i *Interop) Start(ctx context.Context) error {
 				i.backfillEndTimestamp = end
 				break
 			}
-			i.log.Warn("log backfill failed, retrying (virtual nodes may not be ready yet)", "err", err)
+			i.log.Warn("log backfill failed, retrying (EL finalized head or chain data may not be ready yet)", "err", err)
 			for cid := range i.chains {
 				i.metrics.LogBackfillRetries.WithLabelValues(cid.String()).Inc()
 			}
@@ -308,37 +308,48 @@ func (i *Interop) Start(ctx context.Context) error {
 	i.backfillCompleted.Store(true)
 	i.log.Info("log backfill complete", "backfillEndTimestamp", i.backfillEndTimestamp)
 
-	firstVerifiableLog := uint64(0)
-	if i.backfillEndTimestamp != 0 {
-		firstVerifiableLog = i.backfillEndTimestamp + 1
-		if firstVerifiableLog < i.activationTimestamp {
-			firstVerifiableLog = i.activationTimestamp
-		}
-	} else if lastTS, initialized := i.verifiedDB.LastTimestamp(); initialized {
-		firstVerifiableLog = lastTS + 1
-	} else {
+	waitForFirstVerifiable := func(resolve func(context.Context) (uint64, error)) (uint64, error) {
 		for {
-			first, err := i.readyFirstVerifiableTimestamp(i.ctx)
+			first, err := resolve(i.ctx)
 			if err == nil {
-				i.firstVerifiable = first
-				i.firstVerifiableSet = true
-				firstVerifiableLog = first
-				break
+				return first, nil
 			}
 			// Permanent SafeDB gap must halt normal startup cleanly. Backfill-enabled
 			// startup reaches this path only if backfill had no range to seal.
 			if errors.Is(err, cc.ErrHistoryUnavailable) {
 				i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
 					"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
-				return fmt.Errorf("interop halted due to unavailable history: %w", err)
+				return 0, fmt.Errorf("interop halted due to unavailable history: %w", err)
 			}
-			i.log.Warn("first verifiable timestamp unavailable, retrying (virtual nodes may not be ready yet)", "err", err)
+			i.log.Warn("first verifiable timestamp unavailable, retrying (EL finalized head or chain data may not be ready yet)", "err", err)
 			select {
 			case <-i.ctx.Done():
-				return fmt.Errorf("first verifiable timestamp interrupted: %w", i.ctx.Err())
+				return 0, fmt.Errorf("first verifiable timestamp interrupted: %w", i.ctx.Err())
 			case <-time.After(errorBackoffPeriod):
 			}
 		}
+	}
+
+	firstVerifiableLog := uint64(0)
+	if i.backfillEndTimestamp != 0 {
+		firstVerifiableLog = i.backfillEndTimestamp + 1
+		if firstVerifiableLog < i.activationTimestamp {
+			firstVerifiableLog = i.activationTimestamp
+		}
+	} else if _, initialized := i.verifiedDB.LastTimestamp(); initialized {
+		first, err := waitForFirstVerifiable(i.resolveFirstVerifiableTimestamp)
+		if err != nil {
+			return err
+		}
+		firstVerifiableLog = first
+	} else {
+		first, err := waitForFirstVerifiable(i.readyFirstVerifiableTimestamp)
+		if err != nil {
+			return err
+		}
+		i.firstVerifiable = first
+		i.firstVerifiableSet = true
+		firstVerifiableLog = first
 	}
 	i.log.Info("interop first verifiable timestamp resolved",
 		"activationTimestamp", i.activationTimestamp,
@@ -991,7 +1002,7 @@ func (i *Interop) CurrentL1() eth.BlockID {
 
 // VerifiedAtTimestamp returns whether the data is verified at the given timestamp.
 // Timestamps before the first verifiable timestamp are already covered by
-// pre-activation consensus or by the safe-head startup handoff.
+// pre-activation consensus or by the startup handoff.
 func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 	if ts < i.activationTimestamp {
 		return true, nil

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -189,10 +189,10 @@ func TestInteropActivationTimestampFlagEnvVar(t *testing.T) {
 /*
 Spec: firstVerifiableTimestamp is the common interop startup readiness gate.
 
-  - It returns an error while virtual-node sync status is unavailable or local
-    safe has not advanced.
+  - If verifiedDB is initialized, it returns the first committed timestamp.
+  - It returns an error while the EL finalized head is unavailable or unset.
   - Once ready, it returns activation when there are no chains, or one past the
-    minimum cross-safe timestamp across chains otherwise.
+    minimum EL finalized timestamp across chains otherwise.
   - The no-backfill startup path uses that same timestamp for its first
     verification attempt.
 */
@@ -211,34 +211,29 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			want: 100,
 		},
 		{
-			name: "sync status error blocks startup",
+			name: "EL finalized error blocks startup",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.syncStatusOverride = func() (*eth.SyncStatus, error) {
-							return nil, errors.New("virtual node not ready")
-						}
+						m.elFinalizedHeadErr = errors.New("EL finalized not ready")
 					}).
 					Build()
 			},
 			wantErr: true,
 		},
 		{
-			name: "zero local-safe blocks startup",
+			name: "zero EL finalized blocks startup",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.syncStatusFull = &eth.SyncStatus{
-							SafeL2:      eth.L2BlockRef{Number: 100, Time: 100},
-							LocalSafeL2: eth.L2BlockRef{},
-						}
+						m.elFinalizedHeadSet = true
 					}).
 					Build()
 			},
 			wantErr: true,
 		},
 		{
-			name: "cross-safe before activation returns activation",
+			name: "EL finalized before activation returns activation",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
@@ -252,7 +247,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			want: 100,
 		},
 		{
-			name: "cross-safe at activation returns timestamp after activation",
+			name: "EL finalized at activation returns timestamp after activation",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
@@ -266,7 +261,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			want: 101,
 		},
 		{
-			name: "returns timestamp after minimum cross-safe across chains",
+			name: "returns timestamp after minimum EL finalized across chains",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
@@ -279,6 +274,22 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 						m.syncStatusFull = &eth.SyncStatus{
 							SafeL2:      eth.L2BlockRef{Number: 125, Time: 125},
 							LocalSafeL2: eth.L2BlockRef{Number: 125, Time: 125},
+						}
+					}).
+					Build()
+			},
+			want: 126,
+		},
+		{
+			name: "uses EL finalized when sync status safe is stale",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithActivation(100).
+					WithChain(10, func(m *mockChainContainer) {
+						m.elFinalizedHead = eth.L2BlockRef{Number: 125, Time: 125}
+						m.elFinalizedHeadSet = true
+						m.syncStatusFull = &eth.SyncStatus{
+							SafeL2:      eth.L2BlockRef{Number: 0, Time: 100},
+							LocalSafeL2: eth.L2BlockRef{Number: 200, Time: 200},
 						}
 					}).
 					Build()
@@ -396,6 +407,78 @@ func TestStartWithoutBackfillUsesFirstVerifiableTimestamp(t *testing.T) {
 		require.Equal(t, safe+1, ts)
 	case <-time.After(5 * time.Second):
 		t.Fatal("interop did not attempt verification")
+	}
+
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestStartWithoutBackfillWaitsWhenVerifiedDBAheadOfELFinalized(t *testing.T) {
+	const (
+		activation   uint64 = 100
+		lastVerified uint64 = 195
+	)
+	origBackoff := errorBackoffPeriod
+	errorBackoffPeriod = 10 * time.Millisecond
+	t.Cleanup(func() { errorBackoffPeriod = origBackoff })
+
+	var elCaughtUp atomic.Bool
+	var elFinalizedCalls atomic.Int32
+	h := newInteropTestHarness(t).
+		WithActivation(activation).
+		WithChain(10, func(m *mockChainContainer) {
+			m.elFinalizedHeadOverride = func() (eth.L2BlockRef, error) {
+				elFinalizedCalls.Add(1)
+				if elCaughtUp.Load() {
+					return eth.L2BlockRef{Number: 200, Time: 200}, nil
+				}
+				return eth.L2BlockRef{Number: 190, Time: 190}, nil
+			}
+			m.syncStatusFull = &eth.SyncStatus{
+				SafeL2:      eth.L2BlockRef{Number: 200, Time: 200},
+				LocalSafeL2: eth.L2BlockRef{Number: 200, Time: 200},
+			}
+		}).
+		Build()
+
+	chain10 := h.Mock(10)
+	for ts := activation + 1; ts <= lastVerified; ts++ {
+		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+			Timestamp:   ts,
+			L1Inclusion: eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chain10.id: {Number: ts, Hash: common.BigToHash(new(big.Int).SetUint64(ts))}},
+		}))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	verifiedTS := make(chan uint64, 1)
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+		verifiedTS <- ts
+		cancel()
+		return Result{}, nil
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- h.interop.Start(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return elFinalizedCalls.Load() > 0
+	}, 5*time.Second, 10*time.Millisecond, "startup did not query EL finalized head")
+
+	select {
+	case ts := <-verifiedTS:
+		t.Fatalf("interop attempted verification at %d while verifiedDB was ahead of EL finalized", ts)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	elCaughtUp.Store(true)
+
+	select {
+	case ts := <-verifiedTS:
+		require.Equal(t, lastVerified+1, ts)
+	case <-time.After(5 * time.Second):
+		t.Fatal("interop did not resume after EL finalized caught up to verifiedDB")
 	}
 
 	require.ErrorIs(t, <-done, context.Canceled)
@@ -766,7 +849,7 @@ func TestProgressInterop(t *testing.T) {
 		run      func(t *testing.T, h *interopTestHarness) // override for complex cases
 	}{
 		{
-			name: "not initialized uses first timestamp after safe head",
+			name: "not initialized uses first timestamp after finalized head",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(5000).WithChain(10, func(m *mockChainContainer) {
 					m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
@@ -1056,7 +1139,7 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 			},
 		},
 		{
-			name: "safe-head handoff timestamps are verified",
+			name: "startup handoff timestamps are verified",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
@@ -1130,8 +1213,8 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 				}
 			}).
 			Build()
-		// 126 > activation and >= firstVerifiable (resolves to 101 from
-		// SafeL2.Time=100); no entry yet → ethereum.NotFound.
+			// 126 > activation and >= firstVerifiable (resolves to 101 from
+			// EL finalized time 100); no entry yet -> ethereum.NotFound.
 		_, _, err := h.interop.VerifiedResultAtTimestamp(126)
 		require.ErrorIs(t, err, ethereum.NotFound)
 		require.NotErrorIs(t, err, ErrNotActive)
@@ -1142,7 +1225,7 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 		h := newInteropTestHarness(t).
 			WithActivation(100).
 			WithChain(10, func(m *mockChainContainer) {
-				// SafeL2.Time=500 → firstVerifiable=501. ts=200 is post
+				// EL finalized time 500 -> firstVerifiable=501. ts=200 is post
 				// activation but below firstVerifiable on this node.
 				m.syncStatusFull = &eth.SyncStatus{
 					SafeL2:      eth.L2BlockRef{Number: 500, Time: 500},
@@ -1958,10 +2041,14 @@ type mockChainContainer struct {
 	optimisticAtErr error
 
 	// If set, SyncStatus returns this instead of synthesizing from currentL1 only.
-	syncStatusFull     *eth.SyncStatus
-	syncStatusOverride func() (*eth.SyncStatus, error)
-	defaultSafeTime    uint64
-	defaultSafeSet     bool
+	syncStatusFull          *eth.SyncStatus
+	syncStatusOverride      func() (*eth.SyncStatus, error)
+	defaultSafeTime         uint64
+	defaultSafeSet          bool
+	elFinalizedHead         eth.L2BlockRef
+	elFinalizedHeadSet      bool
+	elFinalizedHeadErr      error
+	elFinalizedHeadOverride func() (eth.L2BlockRef, error)
 
 	// PauseAndStopVN / Resume tracking
 	pauseAndStopVNCalls int
@@ -2025,6 +2112,30 @@ func (m *mockChainContainer) BlockNumberToTimestamp(ctx context.Context, blocknu
 		return m.blockNumberToTimestampOverride(ctx, blocknum)
 	}
 	return 0, nil
+}
+func (m *mockChainContainer) ELFinalizedHead(ctx context.Context) (eth.L2BlockRef, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.elFinalizedHeadErr != nil {
+		return eth.L2BlockRef{}, m.elFinalizedHeadErr
+	}
+	if m.elFinalizedHeadOverride != nil {
+		return m.elFinalizedHeadOverride()
+	}
+	if m.elFinalizedHeadSet {
+		return m.elFinalizedHead, nil
+	}
+	if m.syncStatusFull != nil {
+		if m.syncStatusFull.FinalizedL2 != (eth.L2BlockRef{}) {
+			return m.syncStatusFull.FinalizedL2, nil
+		}
+		return m.syncStatusFull.SafeL2, nil
+	}
+	safeNum := m.defaultSafeTime
+	if safeNum == 0 {
+		safeNum = 1
+	}
+	return eth.L2BlockRef{Number: safeNum, Time: m.defaultSafeTime}, nil
 }
 func (m *mockChainContainer) PauseAndStopVN(ctx context.Context) error {
 	m.mu.Lock()

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -10,31 +10,49 @@ import (
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 )
 
-// resolveFirstVerifiableTimestamp consults all chain sync statuses and returns
-// the first timestamp not already covered by the minimum cross-safe head.
+// resolveFirstVerifiableTimestamp returns the first timestamp not already
+// covered by durable local state, bounded by the minimum EL finalized head.
 func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if len(i.chains) == 0 {
 		return i.activationTimestamp, nil
 	}
-
-	minCrossSafeTime := uint64(math.MaxUint64)
-	for _, chain := range i.chains {
-		syncStatus, err := chain.SyncStatus(ctx)
-		if err != nil {
-			return 0, fmt.Errorf("chain %s: sync status: %w", chain.ID(), err)
-		}
-		// local safe should advance even if cross safe has nothing to work from.
-		if syncStatus.LocalSafeL2.Number == 0 {
-			return 0, fmt.Errorf("chain %s: local safe L2 number is 0", chain.ID())
-		}
-		i.log.Debug("first verifiable timestamp: sync status",
-			"chain", chain.ID(), "safe", syncStatus.SafeL2, "localSafe", syncStatus.LocalSafeL2)
-		minCrossSafeTime = min(minCrossSafeTime, syncStatus.SafeL2.Time)
+	minELFinalizedTime, err := i.minELFinalizedTime(ctx)
+	if err != nil {
+		return 0, err
 	}
-	if minCrossSafeTime < i.activationTimestamp {
+	if i.verifiedDB != nil {
+		if lastTS, initialized := i.verifiedDB.LastTimestamp(); initialized {
+			if lastTS > minELFinalizedTime {
+				return 0, fmt.Errorf("verifiedDB last timestamp %d is ahead of minimum EL finalized timestamp %d", lastTS, minELFinalizedTime)
+			}
+			return lastTS + 1, nil
+		}
+	}
+	if minELFinalizedTime < i.activationTimestamp {
 		return i.activationTimestamp, nil
 	}
-	return minCrossSafeTime + 1, nil
+	return minELFinalizedTime + 1, nil
+}
+
+func (i *Interop) minELFinalizedTime(ctx context.Context) (uint64, error) {
+	if len(i.chains) == 0 {
+		return i.activationTimestamp, nil
+	}
+
+	minELFinalizedTime := uint64(math.MaxUint64)
+	for _, chain := range i.chains {
+		elFinalized, err := chain.ELFinalizedHead(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("chain %s: EL finalized head: %w", chain.ID(), err)
+		}
+		if elFinalized.Number == 0 {
+			return 0, fmt.Errorf("chain %s: EL finalized head number is 0", chain.ID())
+		}
+		i.log.Debug("first verifiable timestamp: EL finalized head",
+			"chain", chain.ID(), "elFinalized", elFinalized)
+		minELFinalizedTime = min(minELFinalizedTime, elFinalized.Time)
+	}
+	return minELFinalizedTime, nil
 }
 
 func (i *Interop) runLogBackfill() (uint64, error) {
@@ -59,7 +77,7 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	endTime := firstVerifiable - 1
 
 	// naively, end minus depth is the ideal backfill start.
-	// guard the subtraction so a young chain (crossSafe < depth) doesn't wrap.
+	// guard the subtraction so a young chain (EL finalized < depth) doesn't wrap.
 	depthSec := uint64(i.logBackfillDepth.Seconds())
 	var idealStart uint64
 	if endTime >= depthSec {

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -34,7 +34,7 @@ func requireFirstVerifiableTimestamp(t *testing.T, i *Interop, want uint64, msgA
 
 func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	const act = uint64(100)
-	depth := 10 * time.Second // crossSafe 110, depth 10s -> T_lo 100; should seal 100..110
+	depth := 10 * time.Second // EL finalized 110, depth 10s -> T_lo 100; should seal 100..110
 
 	h := newInteropTestHarness(t).
 		WithActivation(act).
@@ -83,7 +83,7 @@ func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	require.NoError(t, err)
 	h.interop.backfillEndTimestamp = end
 	require.Equal(t, uint64(110), end,
-		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
+		"runLogBackfill must return minELFinalizedTime as the end of the sealed range")
 	requireFirstVerifiableTimestamp(t, h.interop, 111,
 		"main loop resumes at backfillEndTimestamp+1")
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
@@ -96,12 +96,12 @@ func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	require.Equal(t, int32(6), fetchCount.Load())
 }
 
-func TestLogBackfill_RetriesWhenVirtualNodesNotReady(t *testing.T) {
+func TestLogBackfill_RetriesWhenELFinalizedNotReady(t *testing.T) {
 	const act = uint64(100)
 	depth := 10 * time.Second
 
-	// Track SyncStatus call count so we can make the first N calls fail.
-	var syncStatusCalls atomic.Int32
+	// Track EL finalized head call count so we can make the first N calls fail.
+	var elFinalizedCalls atomic.Int32
 	failUntil := int32(3) // first 3 calls return error, then succeed
 
 	h := newInteropTestHarness(t).
@@ -115,18 +115,12 @@ func TestLogBackfill_RetriesWhenVirtualNodesNotReady(t *testing.T) {
 				SafeL2:      eth.L2BlockRef{Number: 110, Time: 110},
 				LocalSafeL2: eth.L2BlockRef{Number: 110, Time: 110},
 			}
-			m.currentL1Err = errors.New("virtual node not ready")
-			m.syncStatusOverride = func() (*eth.SyncStatus, error) {
-				n := syncStatusCalls.Add(1)
+			m.elFinalizedHeadOverride = func() (eth.L2BlockRef, error) {
+				n := elFinalizedCalls.Add(1)
 				if n <= failUntil {
-					return nil, errors.New("virtual node not ready")
+					return eth.L2BlockRef{}, errors.New("EL finalized not ready")
 				}
-				return &eth.SyncStatus{
-					CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
-					UnsafeL2:    eth.L2BlockRef{Number: 110, Time: 110},
-					SafeL2:      eth.L2BlockRef{Number: 110, Time: 110},
-					LocalSafeL2: eth.L2BlockRef{Number: 110, Time: 110},
-				}, nil
+				return eth.L2BlockRef{Number: 110, Time: 110}, nil
 			}
 		}).
 		Build()
@@ -148,8 +142,8 @@ func TestLogBackfill_RetriesWhenVirtualNodesNotReady(t *testing.T) {
 		return h.interop.backfillEndTimestamp > 0
 	}, 5*time.Second, 20*time.Millisecond, "backfill should eventually succeed after retries")
 
-	require.GreaterOrEqual(t, syncStatusCalls.Load(), failUntil,
-		"SyncStatus should have been called at least %d times (the failing ones)", failUntil)
+	require.GreaterOrEqual(t, elFinalizedCalls.Load(), failUntil,
+		"EL finalized head should have been called at least %d times (the failing ones)", failUntil)
 	require.Equal(t, uint64(110), h.interop.backfillEndTimestamp)
 	requireFirstVerifiableTimestamp(t, h.interop, 111)
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
@@ -272,30 +266,32 @@ func TestLogBackfill_RetriesStopOnContextCancel(t *testing.T) {
 }
 
 // TestLogBackfill_AsymmetricMultiChain asserts that every chain is backfilled
-// over the same [T_lo, minCrossSafeTime] window regardless of how far
-// individual chains' LocalSafe heads have advanced. This keeps the system
+// over the same [T_lo, minELFinalizedTime] window regardless of how far
+// individual chains' EL finalized heads have advanced. This keeps the system
 // symmetric at startup — every chain has logs sealed up to the same
 // timestamp, matching the invariant the main loop observes during normal
-// operation. Chains whose local-safe head is beyond minCrossSafeTime catch
+// operation. Chains whose EL finalized head is beyond minELFinalizedTime catch
 // up through the main loop, not eagerly during backfill.
 //
-//   - T_lo is derived from min(SafeL2.Time) across chains (cross-safe).
-//   - End of backfill for every chain is TimestampToBlockNumber(minCrossSafeTime).
-//   - backfillEndTimestamp is set to minCrossSafeTime; the main loop
+//   - T_lo is derived from min(EL finalized head time) across chains.
+//   - End of backfill for every chain is TimestampToBlockNumber(minELFinalizedTime).
+//   - backfillEndTimestamp is set to minELFinalizedTime; the main loop
 //     resumes at backfillEndTimestamp+1.
 func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 	const act = uint64(50)
-	depth := 10 * time.Second // min crossSafe 100 -> T_lo 90
+	depth := 10 * time.Second // min EL finalized 110 -> T_lo 100
 
-	// Chain 10: crossSafe/localSafe tip at 120.
-	// Chain 20: crossSafe 200, localSafe tip at 130.
-	// Chain 30: crossSafe 100 (the min, pinning T_lo), localSafe tip at 110.
-	// Every chain backfills 90..100 (the shared shape), so each seals 11
-	// blocks regardless of how far its local tip is.
+	// Chain 10: EL finalized tip at 120.
+	// Chain 20: EL finalized tip at 130.
+	// Chain 30: EL finalized 110 (the min, pinning T_lo).
+	// Every chain backfills 100..110 (the shared shape), so each seals 11
+	// blocks regardless of how far its EL finalized tip is.
 	h := newInteropTestHarness(t).
 		WithActivation(act).
 		WithLogBackfillDepth(depth).
 		WithChain(10, func(m *mockChainContainer) {
+			m.elFinalizedHead = eth.L2BlockRef{Number: 120, Time: 120}
+			m.elFinalizedHeadSet = true
 			m.syncStatusFull = &eth.SyncStatus{
 				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
 				UnsafeL2:    eth.L2BlockRef{Number: 120, Time: 120},
@@ -304,6 +300,8 @@ func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 			}
 		}).
 		WithChain(20, func(m *mockChainContainer) {
+			m.elFinalizedHead = eth.L2BlockRef{Number: 130, Time: 130}
+			m.elFinalizedHeadSet = true
 			m.syncStatusFull = &eth.SyncStatus{
 				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
 				UnsafeL2:    eth.L2BlockRef{Number: 130, Time: 130},
@@ -312,6 +310,8 @@ func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 			}
 		}).
 		WithChain(30, func(m *mockChainContainer) {
+			m.elFinalizedHead = eth.L2BlockRef{Number: 110, Time: 110}
+			m.elFinalizedHeadSet = true
 			m.syncStatusFull = &eth.SyncStatus{
 				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
 				UnsafeL2:    eth.L2BlockRef{Number: 110, Time: 110},
@@ -341,34 +341,34 @@ func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 	require.NoError(t, err)
 	h.interop.backfillEndTimestamp = end
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
-	require.Equal(t, uint64(100), end,
-		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
-	requireFirstVerifiableTimestamp(t, h.interop, 101,
+	require.Equal(t, uint64(110), end,
+		"runLogBackfill must return minELFinalizedTime as the end of the sealed range")
+	requireFirstVerifiableTimestamp(t, h.interop, 111,
 		"main loop resumes at backfillEndTimestamp+1")
 
 	chain10 := h.Mock(10)
 	chain20 := h.Mock(20)
 	chain30 := h.Mock(30)
 
-	// Every chain backfills the same 90..100 window (11 blocks each).
+	// Every chain backfills the same 100..110 window (11 blocks each).
 	require.Equal(t, int32(11), fetchCount[chain10.id].Load(),
-		"chain 10 should backfill blocks 90..100 (11 blocks)")
+		"chain 10 should backfill blocks 100..110 (11 blocks)")
 	require.Equal(t, int32(11), fetchCount[chain20.id].Load(),
-		"chain 20 should backfill blocks 90..100 (11 blocks)")
+		"chain 20 should backfill blocks 100..110 (11 blocks)")
 	require.Equal(t, int32(11), fetchCount[chain30.id].Load(),
-		"chain 30 should backfill blocks 90..100 (11 blocks)")
+		"chain 30 should backfill blocks 100..110 (11 blocks)")
 
 	latest10, has10 := h.interop.logsDBs[chain10.id].LatestSealedBlock()
 	require.True(t, has10)
-	require.Equal(t, uint64(100), latest10.Number)
+	require.Equal(t, uint64(110), latest10.Number)
 
 	latest20, has20 := h.interop.logsDBs[chain20.id].LatestSealedBlock()
 	require.True(t, has20)
-	require.Equal(t, uint64(100), latest20.Number)
+	require.Equal(t, uint64(110), latest20.Number)
 
 	latest30, has30 := h.interop.logsDBs[chain30.id].LatestSealedBlock()
 	require.True(t, has30)
-	require.Equal(t, uint64(100), latest30.Number)
+	require.Equal(t, uint64(110), latest30.Number)
 }
 
 // TestLogBackfill_MisalignedActivation asserts that backfill succeeds when
@@ -385,7 +385,7 @@ func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 // Time()=999 (the pairing anchor); block 334 is at 1002; LocalSafe is at
 // block 340, Time=1020. T_lo clamps to activation so backfill must seal
 // blocks 333..340 without error. backfillEndTimestamp is set to 1020
-// (minCrossSafeTime), so the main loop resumes at 1021.
+// (minELFinalizedTime), so the main loop resumes at 1021.
 func TestLogBackfill_MisalignedActivation(t *testing.T) {
 	const (
 		blockTime    uint64 = 3
@@ -393,7 +393,7 @@ func TestLogBackfill_MisalignedActivation(t *testing.T) {
 		localSafeNum uint64 = 340
 		localSafeTs  uint64 = 1020 // 340 * blockTime
 	)
-	depth := 60 * time.Second // crossSafe 1020 - 60 = 960 < activation → T_lo clamps to 1000
+	depth := 60 * time.Second // EL finalized 1020 - 60 = 960 < activation → T_lo clamps to 1000
 
 	blockNumToTime := func(num uint64) uint64 { return num * blockTime }
 	tsToBlockNum := func(ctx context.Context, ts uint64) (uint64, error) {
@@ -422,7 +422,7 @@ func TestLogBackfill_MisalignedActivation(t *testing.T) {
 	h.interop.backfillEndTimestamp = end
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 	require.Equal(t, localSafeTs, end,
-		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
+		"runLogBackfill must return minELFinalizedTime as the end of the sealed range")
 	requireFirstVerifiableTimestamp(t, h.interop, localSafeTs+1)
 
 	chain10 := h.Mock(10)
@@ -450,7 +450,7 @@ func TestLogBackfill_MisalignedActivation(t *testing.T) {
 
 func TestLogBackfill_AdvancesActivationAndStartsVerifyAfterCeiling(t *testing.T) {
 	const act = uint64(108)
-	depth := time.Second // crossSafe 110, depth 1s -> T_lo 109; seals 109..110; first verifiable ts = 111
+	depth := time.Second // EL finalized 110, depth 1s -> T_lo 109; seals 109..110; first verifiable ts = 111
 
 	h := newInteropTestHarness(t).
 		WithActivation(act).
@@ -484,7 +484,7 @@ func TestLogBackfill_AdvancesActivationAndStartsVerifyAfterCeiling(t *testing.T)
 	require.NoError(t, err)
 	h.interop.backfillEndTimestamp = end
 	require.Equal(t, uint64(110), end,
-		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
+		"runLogBackfill must return minELFinalizedTime as the end of the sealed range")
 	requireFirstVerifiableTimestamp(t, h.interop, 111,
 		"main loop resumes at backfillEndTimestamp+1")
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
@@ -521,6 +521,8 @@ func TestLogBackfill_NoOpWhenDepthZero(t *testing.T) {
 		WithActivation(act).
 		// no WithLogBackfillDepth → depth stays at zero-value.
 		WithChain(10, func(m *mockChainContainer) {
+			m.elFinalizedHead = eth.L2BlockRef{Number: 110, Time: 110}
+			m.elFinalizedHeadSet = true
 			m.syncStatusOverride = func() (*eth.SyncStatus, error) {
 				syncStatusCalls.Add(1)
 				return &eth.SyncStatus{
@@ -553,10 +555,10 @@ func TestLogBackfill_NoOpWhenDepthZero(t *testing.T) {
 	require.False(t, has, "logs DB must remain empty")
 
 	// Caller sets backfillEndTimestamp; with end==0 the main loop derives the
-	// first unverified timestamp from the current safe head.
+	// first unverified timestamp from the current EL finalized head.
 	h.interop.backfillEndTimestamp = end
 	requireFirstVerifiableTimestamp(t, h.interop, 111,
-		"with end==0 the main loop starts after the safe head")
+		"with end==0 the main loop starts after the finalized head")
 }
 
 // TestLogBackfill_NoOpWhenNoChains asserts that runLogBackfill short-circuits
@@ -584,9 +586,9 @@ func TestLogBackfill_NoOpWhenNoChains(t *testing.T) {
 }
 
 // TestLogBackfill_ActivationInFuture asserts the edge case where the
-// configured activation is ahead of every chain's cross-safe tip.
+// configured activation is ahead of every chain's EL finalized tip.
 // firstVerifiableTimestamp clamps to activation, and backfill must no-op
-// instead of sealing beyond the current cross-safe head.
+// instead of sealing beyond the current EL finalized head.
 func TestLogBackfill_ActivationInFuture(t *testing.T) {
 	const act = uint64(2000)
 	depth := 100 * time.Second
@@ -597,7 +599,7 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 		WithActivation(act).
 		WithLogBackfillDepth(depth).
 		WithChain(10, func(m *mockChainContainer) {
-			// Cross-safe tip at 1000 — well below activation 2000.
+			// EL finalized tip at 1000 — well below activation 2000.
 			m.syncStatusFull = &eth.SyncStatus{
 				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
 				UnsafeL2:    eth.L2BlockRef{Number: 1000, Time: 1000},
@@ -620,7 +622,7 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, end)
 	require.Zero(t, outputCalls.Load(),
-		"no blocks fetched: backfill no-ops when activation is ahead of cross-safe")
+		"no blocks fetched: backfill no-ops when activation is ahead of EL finalized")
 
 	chain10 := h.Mock(10)
 	_, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
@@ -630,7 +632,7 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 		"protocol activation must not change")
 
 	requireFirstVerifiableTimestamp(t, h.interop, act,
-		"main loop resumes at activation when cross-safe is still pre-activation")
+		"main loop resumes at activation when EL finalized is still pre-activation")
 }
 
 // TestLogBackfill_ClampsStartToGenesis asserts that when a chain's genesis
@@ -639,15 +641,15 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 // ask TimestampToBlockNumber for a pre-genesis timestamp and then try to
 // seal blocks before the chain existed.
 //
-// Setup: activation=50, depth=50s, crossSafe=110 → idealStart=60,
+// Setup: activation=50, depth=50s, EL finalized=110 → idealStart=60,
 // startTime=max(60, 50)=60. Chain's genesis time is 100, which is > 60,
 // so the clamp fires and the chain should backfill [100..110] (11 blocks)
 // instead of [60..110] (51 blocks).
 func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 	const (
-		act          uint64 = 50
-		genesisTime  uint64 = 100
-		crossSafeTip uint64 = 110
+		act            uint64 = 50
+		genesisTime    uint64 = 100
+		elFinalizedTip uint64 = 110
 	)
 	depth := 50 * time.Second // idealStart = 110-50 = 60; clamps up to genesisTime=100
 
@@ -659,9 +661,9 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 		WithChain(10, func(m *mockChainContainer) {
 			m.syncStatusFull = &eth.SyncStatus{
 				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
-				UnsafeL2:    eth.L2BlockRef{Number: crossSafeTip, Time: crossSafeTip},
-				SafeL2:      eth.L2BlockRef{Number: crossSafeTip, Time: crossSafeTip},
-				LocalSafeL2: eth.L2BlockRef{Number: crossSafeTip, Time: crossSafeTip},
+				UnsafeL2:    eth.L2BlockRef{Number: elFinalizedTip, Time: elFinalizedTip},
+				SafeL2:      eth.L2BlockRef{Number: elFinalizedTip, Time: elFinalizedTip},
+				LocalSafeL2: eth.L2BlockRef{Number: elFinalizedTip, Time: elFinalizedTip},
 			}
 			// Report genesis time strictly ahead of the pre-clamp startTime.
 			m.blockNumberToTimestampOverride = func(ctx context.Context, blocknum uint64) (uint64, error) {
@@ -684,15 +686,106 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
-	require.Equal(t, crossSafeTip, end,
-		"return value is still minCrossSafeTime regardless of the genesis clamp")
+	require.Equal(t, elFinalizedTip, end,
+		"return value is still minELFinalizedTime regardless of the genesis clamp")
 
 	chain10 := h.Mock(10)
 	latest, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
 	require.True(t, has)
-	require.Equal(t, crossSafeTip, latest.Number)
+	require.Equal(t, elFinalizedTip, latest.Number)
 
 	// 11 = blocks 100..110 (clamped at genesis=100), NOT 51 = blocks 60..110.
 	require.Equal(t, int32(11), outputCalls.Load(),
 		"backfill must start at genesis (%d), not the pre-clamp startTime (60)", genesisTime)
+}
+
+// TestLogBackfill_UsesVerifiedDBWhenInitializedAndSyncStatusStale simulates startup while
+// StatusTracker still reports a stale SafeL2 block and local-safe has moved
+// beyond the persisted EL finalized label. With an initialized verifiedDB,
+// backfill should cap at verifiedDB.LastTimestamp instead of sampling moving
+// SyncStatus state or extending past verifiedDB.
+func TestLogBackfill_UsesVerifiedDBWhenInitializedAndSyncStatusStale(t *testing.T) {
+	const (
+		act           uint64 = 100
+		staleCross    uint64 = 100
+		elFinalized   uint64 = 200
+		localSafe     uint64 = 200
+		lastVerified  uint64 = 195
+		backfillDepth        = 60 * time.Second
+	)
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(backfillDepth).
+		WithChain(10, func(m *mockChainContainer) {
+			m.elFinalizedHead = eth.L2BlockRef{Number: elFinalized, Time: elFinalized}
+			m.elFinalizedHeadSet = true
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: localSafe, Time: localSafe},
+				SafeL2:      eth.L2BlockRef{Number: 0, Time: staleCross},
+				LocalSafeL2: eth.L2BlockRef{Number: localSafe, Time: localSafe},
+			}
+		}).
+		Build()
+	h.interop.ctx = context.Background()
+
+	chain10 := h.Mock(10)
+	for ts := act + 1; ts <= lastVerified; ts++ {
+		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+			Timestamp:   ts,
+			L1Inclusion: eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chain10.id: {Number: ts, Hash: common.BigToHash(new(big.Int).SetUint64(ts))}},
+		}))
+	}
+
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	h.interop.backfillEndTimestamp = end
+
+	require.Equal(t, lastVerified, end,
+		"backfill must derive endTime from verifiedDB.LastTimestamp when verifiedDB is initialized")
+
+	latest, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
+	require.True(t, has)
+	require.Equal(t, lastVerified, latest.Number)
+}
+
+func TestLogBackfill_ErrorsWhenVerifiedDBAheadOfELFinalized(t *testing.T) {
+	const (
+		act          uint64 = 100
+		elFinalized  uint64 = 190
+		lastVerified uint64 = 195
+	)
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(60*time.Second).
+		WithChain(10, func(m *mockChainContainer) {
+			m.elFinalizedHead = eth.L2BlockRef{Number: elFinalized, Time: elFinalized}
+			m.elFinalizedHeadSet = true
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: 200, Time: 200},
+				SafeL2:      eth.L2BlockRef{Number: 0, Time: act},
+				LocalSafeL2: eth.L2BlockRef{Number: 200, Time: 200},
+			}
+		}).
+		Build()
+	h.interop.ctx = context.Background()
+
+	chain10 := h.Mock(10)
+	for ts := act + 1; ts <= lastVerified; ts++ {
+		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+			Timestamp:   ts,
+			L1Inclusion: eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chain10.id: {Number: ts, Hash: common.BigToHash(new(big.Int).SetUint64(ts))}},
+		}))
+	}
+
+	_, err := h.interop.runLogBackfill()
+	require.ErrorContains(t, err, "verifiedDB last timestamp 195 is ahead of minimum EL finalized timestamp 190")
+
+	_, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
+	require.False(t, has, "backfill must not write logs when verifiedDB is ahead of EL finalized")
 }

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -635,68 +635,124 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 		"main loop resumes at activation when EL finalized is still pre-activation")
 }
 
-// TestLogBackfill_ClampsStartToGenesis asserts that when a chain's genesis
-// timestamp is later than the computed backfill startTime, the per-chain
-// start is clamped up to genesis. Without this clamp, runLogBackfill would
-// ask TimestampToBlockNumber for a pre-genesis timestamp and then try to
-// seal blocks before the chain existed.
-//
-// Setup: activation=50, depth=50s, EL finalized=110 → idealStart=60,
-// startTime=max(60, 50)=60. Chain's genesis time is 100, which is > 60,
-// so the clamp fires and the chain should backfill [100..110] (11 blocks)
-// instead of [60..110] (51 blocks).
+// TestLogBackfill_ClampsStartToGenesis asserts that the per-chain start is
+// clamped up to the chain's genesis timestamp. Without this clamp,
+// runLogBackfill would ask TimestampToBlockNumber for a pre-genesis timestamp
+// and try to seal blocks before the chain existed. Both subcases assert the
+// same shape: backfill seals exactly the per-chain range [genesisBlock, endBlock].
 func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
-	const (
-		act            uint64 = 50
-		genesisTime    uint64 = 100
-		elFinalizedTip uint64 = 110
-	)
-	depth := 50 * time.Second // idealStart = 110-50 = 60; clamps up to genesisTime=100
+	type genesisCase struct {
+		name           string
+		act            uint64
+		depth          time.Duration
+		genesisTime    uint64
+		elFinalizedTip uint64
+		// timestampToBlockNum maps a unix timestamp back to the block number the
+		// chain would return. nil means use the harness default (identity).
+		timestampToBlockNum func(ctx context.Context, ts uint64) (uint64, error)
+		// blockNumberToTimestamp maps a block number to its unix timestamp. Only
+		// block 0 (genesis) needs to differ from the identity default.
+		blockNumberToTimestamp func(ctx context.Context, num uint64) (uint64, error)
+		// blockInfoTime keeps FetchReceipts' reported block timestamp consistent
+		// with blockNumberToTimestamp when they diverge from identity.
+		blockInfoTime    func(num uint64) uint64
+		wantEndBlock     uint64
+		wantSealedBlocks int32
+	}
 
-	var outputCalls atomic.Int32
-
-	h := newInteropTestHarness(t).
-		WithActivation(act).
-		WithLogBackfillDepth(depth).
-		WithChain(10, func(m *mockChainContainer) {
-			m.syncStatusFull = &eth.SyncStatus{
-				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
-				UnsafeL2:    eth.L2BlockRef{Number: elFinalizedTip, Time: elFinalizedTip},
-				SafeL2:      eth.L2BlockRef{Number: elFinalizedTip, Time: elFinalizedTip},
-				LocalSafeL2: eth.L2BlockRef{Number: elFinalizedTip, Time: elFinalizedTip},
-			}
-			// Report genesis time strictly ahead of the pre-clamp startTime.
-			m.blockNumberToTimestampOverride = func(ctx context.Context, blocknum uint64) (uint64, error) {
-				if blocknum == 0 {
-					return genesisTime, nil
+	cases := []genesisCase{
+		{
+			// idealStart = 110-50 = 60; startTime = max(60, act=50) = 60.
+			// Chain's genesis time is 100, which is > 60, so per-chain start
+			// clamps to genesis and seals blocks 100..110 (11 blocks).
+			name:           "activation before genesis",
+			act:            50,
+			depth:          50 * time.Second,
+			genesisTime:    100,
+			elFinalizedTip: 110,
+			blockNumberToTimestamp: func(ctx context.Context, num uint64) (uint64, error) {
+				if num == 0 {
+					return 100, nil
 				}
-				return blocknum, nil
-			}
-			m.outputV0Override = func(ctx context.Context, num uint64) (*eth.OutputV0, error) {
-				outputCalls.Add(1)
-				return &eth.OutputV0{
-					StateRoot:                eth.Bytes32(common.HexToHash("0xmockstate")),
-					MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmockmsg")),
-					BlockHash:                common.BigToHash(new(big.Int).SetUint64(num)),
-				}, nil
-			}
-		}).
-		Build()
-	h.interop.ctx = context.Background()
+				return num, nil
+			},
+			wantEndBlock:     110,
+			wantSealedBlocks: 11,
+		},
+		{
+			// activation == genesis time. idealStart = 110-60 = 50;
+			// startTime = max(50, act=100) = 100. genesisTime (100) is NOT
+			// strictly greater than startTime (100), so the per-chain clamp
+			// is a no-op and chainStartTime stays at activation=100.
+			// TimestampToBlockNumber(100) returns block 0; the seal range is
+			// blocks 0..10 (11 blocks) — the genesis block at the activation
+			// boundary is included and has no logs, which is acceptable.
+			name:           "activation equals genesis",
+			act:            100,
+			depth:          60 * time.Second,
+			genesisTime:    100,
+			elFinalizedTip: 110,
+			timestampToBlockNum: func(ctx context.Context, ts uint64) (uint64, error) {
+				return ts - 100, nil
+			},
+			blockNumberToTimestamp: func(ctx context.Context, num uint64) (uint64, error) {
+				return num + 100, nil
+			},
+			blockInfoTime:    func(num uint64) uint64 { return num + 100 },
+			wantEndBlock:     10,
+			wantSealedBlocks: 11,
+		},
+	}
 
-	end, err := h.interop.runLogBackfill()
-	require.NoError(t, err)
-	require.Equal(t, elFinalizedTip, end,
-		"return value is still minELFinalizedTime regardless of the genesis clamp")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var outputCalls atomic.Int32
 
-	chain10 := h.Mock(10)
-	latest, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
-	require.True(t, has)
-	require.Equal(t, elFinalizedTip, latest.Number)
+			h := newInteropTestHarness(t).
+				WithActivation(tc.act).
+				WithLogBackfillDepth(tc.depth).
+				WithChain(10, func(m *mockChainContainer) {
+					m.elFinalizedHead = eth.L2BlockRef{Number: tc.elFinalizedTip, Time: tc.elFinalizedTip}
+					m.elFinalizedHeadSet = true
+					m.syncStatusFull = &eth.SyncStatus{
+						CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+						UnsafeL2:    eth.L2BlockRef{Number: tc.elFinalizedTip, Time: tc.elFinalizedTip},
+						SafeL2:      eth.L2BlockRef{Number: tc.elFinalizedTip, Time: tc.elFinalizedTip},
+						LocalSafeL2: eth.L2BlockRef{Number: tc.elFinalizedTip, Time: tc.elFinalizedTip},
+					}
+					m.blockNumberToTimestampOverride = tc.blockNumberToTimestamp
+					if tc.timestampToBlockNum != nil {
+						m.timestampToBlockNumberOverride = tc.timestampToBlockNum
+					}
+					if tc.blockInfoTime != nil {
+						m.blockInfoTimeFn = tc.blockInfoTime
+					}
+					m.outputV0Override = func(ctx context.Context, num uint64) (*eth.OutputV0, error) {
+						outputCalls.Add(1)
+						return &eth.OutputV0{
+							StateRoot:                eth.Bytes32(common.HexToHash("0xmockstate")),
+							MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmockmsg")),
+							BlockHash:                common.BigToHash(new(big.Int).SetUint64(num)),
+						}, nil
+					}
+				}).
+				Build()
+			h.interop.ctx = context.Background()
 
-	// 11 = blocks 100..110 (clamped at genesis=100), NOT 51 = blocks 60..110.
-	require.Equal(t, int32(11), outputCalls.Load(),
-		"backfill must start at genesis (%d), not the pre-clamp startTime (60)", genesisTime)
+			end, err := h.interop.runLogBackfill()
+			require.NoError(t, err)
+			require.Equal(t, tc.elFinalizedTip, end,
+				"return value is still minELFinalizedTime regardless of the genesis clamp")
+
+			chain10 := h.Mock(10)
+			latest, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
+			require.True(t, has)
+			require.Equal(t, tc.wantEndBlock, latest.Number)
+
+			require.Equal(t, tc.wantSealedBlocks, outputCalls.Load(),
+				"backfill must seal exactly [genesisBlock, endBlock]")
+		})
+	}
 }
 
 // TestLogBackfill_UsesVerifiedDBWhenInitializedAndSyncStatusStale simulates startup while
@@ -788,4 +844,139 @@ func TestLogBackfill_ErrorsWhenVerifiedDBAheadOfELFinalized(t *testing.T) {
 
 	_, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
 	require.False(t, has, "backfill must not write logs when verifiedDB is ahead of EL finalized")
+}
+
+// TestLogBackfill_LeavesAheadLogsDBUnchanged asserts that when a chain's
+// logsDB already holds canonical blocks past the computed backfill endTime,
+// runLogBackfill does not rewrite, trim, or extend it. reconcileLogsDBTail
+// sees the tip hash match canonical and returns without touching state; the
+// seal loop then no-ops because startNum (latest+1) > endNum.
+//
+// Setup: cold start (empty verifiedDB), act=100, depth=60s,
+// EL finalized=110 → endTime=110. Pre-seal blocks 100..120 with canonical
+// hashes for chain 10. After backfill the logsDB tip must still be 120.
+func TestLogBackfill_LeavesAheadLogsDBUnchanged(t *testing.T) {
+	const (
+		act         uint64 = 100
+		elFinalized uint64 = 110
+		preSeedTip  uint64 = 120
+	)
+	depth := 60 * time.Second
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(depth).
+		WithChain(10, func(m *mockChainContainer) {
+			m.elFinalizedHead = eth.L2BlockRef{Number: elFinalized, Time: elFinalized}
+			m.elFinalizedHeadSet = true
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: preSeedTip, Time: preSeedTip},
+				SafeL2:      eth.L2BlockRef{Number: preSeedTip, Time: preSeedTip},
+				LocalSafeL2: eth.L2BlockRef{Number: preSeedTip, Time: preSeedTip},
+			}
+		}).
+		Build()
+	h.interop.ctx = context.Background()
+
+	chain10 := h.Mock(10)
+	db := h.interop.logsDBs[chain10.id]
+	canonicalHash := func(n uint64) common.Hash {
+		return common.BigToHash(new(big.Int).SetUint64(n))
+	}
+	require.NoError(t, db.SealBlock(common.Hash{},
+		eth.BlockID{Number: act, Hash: canonicalHash(act)}, act))
+	for n := act + 1; n <= preSeedTip; n++ {
+		require.NoError(t, db.SealBlock(canonicalHash(n-1),
+			eth.BlockID{Number: n, Hash: canonicalHash(n)}, n))
+	}
+
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	require.Equal(t, elFinalized, end,
+		"backfill end must equal minELFinalizedTime, independent of the ahead-of-end logsDB tip")
+
+	latest, has := db.LatestSealedBlock()
+	require.True(t, has)
+	require.Equal(t, preSeedTip, latest.Number,
+		"logsDB must be left untouched when it is already past endTime and canonical")
+	require.Equal(t, canonicalHash(preSeedTip), latest.Hash,
+		"logsDB tip hash must be unchanged")
+}
+
+// TestLogBackfill_TrimsNonCanonicalAheadLogsDBAndCatchesUp asserts the
+// reconcile-then-backfill behavior when a chain's logsDB sits ahead of
+// endTime but its tail has diverged from canonical (e.g. an L2 reorg landed
+// while supernode was offline). reconcileLogsDBTail must walk back to the
+// last canonical block, after which backfill seals forward up to endTime.
+//
+// Setup: cold start, act=100, depth=60s, EL finalized=110 → endTime=110.
+// Pre-seal blocks 100..108 with canonical hashes, then 109..120 with a v1
+// fork hash. Expect reconcile to rewind to 108, and the seal loop to seal
+// 109..110 with canonical hashes. Final tip is endTime (110).
+func TestLogBackfill_TrimsNonCanonicalAheadLogsDBAndCatchesUp(t *testing.T) {
+	const (
+		act          uint64 = 100
+		elFinalized  uint64 = 110
+		lastCanonNum uint64 = 108
+		preSeedTip   uint64 = 120
+	)
+	depth := 60 * time.Second
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(depth).
+		WithChain(10, func(m *mockChainContainer) {
+			m.elFinalizedHead = eth.L2BlockRef{Number: elFinalized, Time: elFinalized}
+			m.elFinalizedHeadSet = true
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: preSeedTip, Time: preSeedTip},
+				SafeL2:      eth.L2BlockRef{Number: preSeedTip, Time: preSeedTip},
+				LocalSafeL2: eth.L2BlockRef{Number: preSeedTip, Time: preSeedTip},
+			}
+		}).
+		Build()
+	h.interop.ctx = context.Background()
+
+	chain10 := h.Mock(10)
+	db := h.interop.logsDBs[chain10.id]
+	canonicalHash := func(n uint64) common.Hash {
+		return common.BigToHash(new(big.Int).SetUint64(n))
+	}
+	v1Hash := func(n uint64) common.Hash {
+		return common.BigToHash(new(big.Int).SetUint64(n | 0xdead0000))
+	}
+
+	require.NoError(t, db.SealBlock(common.Hash{},
+		eth.BlockID{Number: act, Hash: canonicalHash(act)}, act))
+	for n := act + 1; n <= lastCanonNum; n++ {
+		require.NoError(t, db.SealBlock(canonicalHash(n-1),
+			eth.BlockID{Number: n, Hash: canonicalHash(n)}, n))
+	}
+	require.NoError(t, db.SealBlock(canonicalHash(lastCanonNum),
+		eth.BlockID{Number: lastCanonNum + 1, Hash: v1Hash(lastCanonNum + 1)}, lastCanonNum+1))
+	for n := lastCanonNum + 2; n <= preSeedTip; n++ {
+		require.NoError(t, db.SealBlock(v1Hash(n-1),
+			eth.BlockID{Number: n, Hash: v1Hash(n)}, n))
+	}
+
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	require.Equal(t, elFinalized, end,
+		"backfill end must equal minELFinalizedTime, independent of the ahead-of-end logsDB tip")
+
+	latest, has := db.LatestSealedBlock()
+	require.True(t, has)
+	require.Equal(t, elFinalized, latest.Number,
+		"after reconcile + seal, logsDB tip must equal endTime")
+	require.Equal(t, canonicalHash(elFinalized), latest.Hash,
+		"final tip must hold the canonical hash, not a stale v1 hash")
+
+	for n := act; n <= elFinalized; n++ {
+		seal, err := db.FindSealedBlock(n)
+		require.NoError(t, err, "block %d must remain sealed", n)
+		require.Equal(t, canonicalHash(n), seal.Hash,
+			"block %d must hold the canonical hash after reconcile", n)
+	}
 }

--- a/op-supernode/supernode/activity/interop/reader.go
+++ b/op-supernode/supernode/activity/interop/reader.go
@@ -12,7 +12,7 @@ var ErrNotActive = errors.New("interop not active for timestamp")
 
 // ErrBeforeVerifiedDB signals that ts is post-activation but below the
 // verifier's first verifiable timestamp on this node. The timestamp is
-// already covered by the safe-head startup handoff: no VerifiedResult will
+// already covered by the startup handoff: no VerifiedResult will
 // be produced here, but callers can treat optimistic outputs as canonical.
 var ErrBeforeVerifiedDB = errors.New("timestamp below verified-db start")
 

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -29,6 +29,9 @@ func (m *mockCC) Stop(ctx context.Context) error           { return nil }
 func (m *mockCC) Pause(ctx context.Context) error          { return nil }
 func (m *mockCC) Resume(ctx context.Context) error         { return nil }
 func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }
+func (m *mockCC) ELFinalizedHead(ctx context.Context) (eth.L2BlockRef, error) {
+	return eth.L2BlockRef{}, nil
+}
 
 func (m *mockCC) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *mockCC) VerifierCurrentL1s() []eth.BlockID {

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -43,11 +43,14 @@ type mockCC struct {
 	byHashCalled   int
 }
 
-func (m *mockCC) Start(ctx context.Context) error                  { return nil }
-func (m *mockCC) Stop(ctx context.Context) error                   { return nil }
-func (m *mockCC) Pause(ctx context.Context) error                  { return nil }
-func (m *mockCC) Resume(ctx context.Context) error                 { return nil }
-func (m *mockCC) PauseAndStopVN(ctx context.Context) error         { return nil }
+func (m *mockCC) Start(ctx context.Context) error          { return nil }
+func (m *mockCC) Stop(ctx context.Context) error           { return nil }
+func (m *mockCC) Pause(ctx context.Context) error          { return nil }
+func (m *mockCC) Resume(ctx context.Context) error         { return nil }
+func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }
+func (m *mockCC) ELFinalizedHead(ctx context.Context) (eth.L2BlockRef, error) {
+	return eth.L2BlockRef{}, nil
+}
 func (m *mockCC) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *mockCC) VerifierCurrentL1s() []eth.BlockID                { return m.verifierL1s }
 func (m *mockCC) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -44,6 +44,7 @@ type ChainContainer interface {
 	Resume(ctx context.Context) error
 
 	ID() eth.ChainID
+	ELFinalizedHead(ctx context.Context) (eth.L2BlockRef, error)
 	LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error)
 	// TimestampToBlockNumber maps an L2 unix timestamp to the L2 block number (rollup derivation).
 	TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error)
@@ -405,6 +406,13 @@ func (c *simpleChainContainer) Pause(ctx context.Context) error {
 func (c *simpleChainContainer) Resume(ctx context.Context) error {
 	c.pause.Store(false)
 	return nil
+}
+
+func (c *simpleChainContainer) ELFinalizedHead(ctx context.Context) (eth.L2BlockRef, error) {
+	if c.engine == nil {
+		return eth.L2BlockRef{}, engine_controller.ErrNoEngineClient
+	}
+	return c.engine.L2BlockRefByLabel(ctx, eth.Finalized)
 }
 
 func (c *simpleChainContainer) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error) {

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -150,6 +150,10 @@ func (m *mockEngineController) L2BlockRefByNumber(ctx context.Context, num uint6
 	return m.l2BlockRefByNumberResult, m.l2BlockRefByNumberErr
 }
 
+func (m *mockEngineController) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
+	return eth.L2BlockRef{}, nil
+}
+
 func (m *mockEngineController) OutputV0AtBlockNumber(ctx context.Context, num uint64) (*eth.OutputV0, error) {
 	return nil, nil
 }

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -18,6 +18,8 @@ import (
 
 // EngineController abstracts access to the L2 execution layer
 type EngineController interface {
+	// L2BlockRefByLabel returns the L2 block reference for the given block label.
+	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
 	// L2BlockRefByNumber returns the L2 block reference for the given block number.
 	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 	// OutputV0AtBlockNumber returns the output preimage for the given L2 block number.
@@ -128,6 +130,10 @@ func (e *simpleEngineController) BlockAtTimestamp(ctx context.Context, ts uint64
 
 func (e *simpleEngineController) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
 	return e.l2.L2BlockRefByNumber(ctx, num)
+}
+
+func (e *simpleEngineController) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
+	return e.l2.L2BlockRefByLabel(ctx, label)
 }
 
 func (e *simpleEngineController) OutputV0AtBlockNumber(ctx context.Context, num uint64) (*eth.OutputV0, error) {

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -327,6 +327,10 @@ func (m *mockEngineForInvalidation) L2BlockRefByNumber(ctx context.Context, num 
 	return m.blockRef, m.blockRefErr
 }
 
+func (m *mockEngineForInvalidation) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
+	return eth.L2BlockRef{}, nil
+}
+
 // mockVNForInvalidation implements virtual_node.VirtualNode for invalidation tests
 type mockVNForInvalidation struct {
 	stopErr error


### PR DESCRIPTION
## Summary
- expose an explicit `ELFinalizedHead` chain-container query backed by `eth.Finalized` on the execution layer
- centralize startup boundary selection in `resolveFirstVerifiableTimestamp`
- when `verifiedDB` is initialized, resume from `verifiedDB.LastTimestamp() + 1` after confirming it is not ahead of the minimum EL finalized timestamp
- when `verifiedDB` is uninitialized, start from `min(EL finalized across chains) + 1`, clamped to the interop activation timestamp
- make log backfill use that same boundary, so warm-restart backfill stops at the verified DB frontier and cold-start backfill stops at the EL finalized frontier
- apply the same verifiedDB-vs-EL-finalized startup guard even when log backfill is disabled

## Rationale
`SyncStatus.SafeL2` is the SuperAuthority/cross-safe signal and can be stale or empty during Supernode startup. `SyncStatus.LocalSafeL2` can move as op-node derives new blocks. The attached EL finalized head is the explicit local checkpoint for cold-start anchoring, while an initialized `verifiedDB` is the durable local verification frontier and must not be trusted beyond what the attached EL has finalized.

This preserves Adrian's warm-restart fix: if logs are wiped but `verifiedDB` remains populated, backfill derives its end from `verifiedDB.LastTimestamp()` instead of a stale live `SafeL2` read. This PR additionally waits/retries when `verifiedDB` is ahead of the attached EL finalized frontier, including the no-backfill warm-start path.

## Tests
- `go test ./op-supernode/supernode/activity/interop`
- `go test ./op-supernode/supernode/chain_container ./op-supernode/supernode/activity/supernode ./op-supernode/supernode/activity/superroot`

## Notes
This intentionally keeps verifiedDB persistence semantics unchanged: it does not fast-forward or clear verifiedDB. It validates and caps the startup/backfill boundary against the local EL finalized frontier.
