### PR TITLE
fix(op-supernode): guard executing-message verifier against interop activation block

### DIFF
--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -25,6 +25,14 @@ var (
 	// ErrMessageExpired is returned when an executing message references
 	// an initiating message that has expired (older than the message expiry window).
 	ErrMessageExpired = errors.New("initiating message has expired")
+
+	// ErrExecutedTooEarly is returned when an executing message is in the executing chain's
+	// pre-activation or activation block.
+	ErrExecutedTooEarly = errors.New("interop is not active for at least one block on the executing chain")
+
+	// ErrInitiatedTooEarly is returned when an executing message references an initiating
+	// message in the initiating chain's pre-activation or activation block.
+	ErrInitiatedTooEarly = errors.New("interop is not active for at least one block on the initiating chain")
 )
 
 type blockPerChain = map[eth.ChainID]eth.BlockID
@@ -176,6 +184,30 @@ func (i *Interop) verifyExecutingMessage(executingChain eth.ChainID, executingTi
 	sourceDB, ok := i.logsDBs[execMsg.ChainID]
 	if !ok {
 		return fmt.Errorf("source chain %s not found: %w", execMsg.ChainID, ErrUnknownChain)
+	}
+
+	// Activation invariant: interop must be active for at least one full block on both
+	// the executing chain and the initiating chain. Mirrors kona's
+	// MessageGraph::check_single_dependency at
+	// rust/kona/crates/protocol/interop/src/graph.rs:367-401, and op-program's
+	// cross.CrossUnsafeHazards → depset.LinkChecker.CanExecute path
+	// (op-program/client/interop/consolidate.go:178 → 225).
+	execChain, ok := i.chains[executingChain]
+	if !ok {
+		return fmt.Errorf("executing chain %s not registered: %w", executingChain, ErrUnknownChain)
+	}
+	if executingTimestamp < i.activationTimestamp+execChain.BlockTime() {
+		return fmt.Errorf("executing chain %s timestamp %d < activation %d + blockTime: %w",
+			executingChain, executingTimestamp, i.activationTimestamp, ErrExecutedTooEarly)
+	}
+
+	initChain, ok := i.chains[execMsg.ChainID]
+	if !ok {
+		return fmt.Errorf("initiating chain %s not registered: %w", execMsg.ChainID, ErrUnknownChain)
+	}
+	if execMsg.Timestamp < i.activationTimestamp+initChain.BlockTime() {
+		return fmt.Errorf("initiating chain %s timestamp %d < activation %d + blockTime: %w",
+			execMsg.ChainID, execMsg.Timestamp, i.activationTimestamp, ErrInitiatedTooEarly)
 	}
 
 	// Verify timestamp ordering: initiating message timestamp must be <= executing block timestamp.

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -179,6 +179,8 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 //  1. The initiating message exists in the source chain's database
 //  2. The initiating message's timestamp is not greater than the executing block's timestamp
 //  3. The initiating message hasn't expired (timestamp + messageExpiryWindow >= executing timestamp)
+//  4. Neither the executing block nor the initiating block falls in its chain's interop
+//     activation block (interop must be active for at least one full block on both sides)
 func (i *Interop) verifyExecutingMessage(executingChain eth.ChainID, executingTimestamp uint64, logIdx uint32, execMsg *types.ExecutingMessage, view *frontierVerificationView) error {
 	// Get the source chain's logsDB
 	sourceDB, ok := i.logsDBs[execMsg.ChainID]

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -186,12 +186,8 @@ func (i *Interop) verifyExecutingMessage(executingChain eth.ChainID, executingTi
 		return fmt.Errorf("source chain %s not found: %w", execMsg.ChainID, ErrUnknownChain)
 	}
 
-	// Activation invariant: interop must be active for at least one full block on both
-	// the executing chain and the initiating chain. Mirrors kona's
-	// MessageGraph::check_single_dependency at
-	// rust/kona/crates/protocol/interop/src/graph.rs:367-401, and op-program's
-	// cross.CrossUnsafeHazards → depset.LinkChecker.CanExecute path
-	// (op-program/client/interop/consolidate.go:178 → 225).
+	// Activation invariant: interop must be active for at least one full block on
+	// both the executing chain and the initiating chain. Matches kona and op-program.
 	execChain, ok := i.chains[executingChain]
 	if !ok {
 		return fmt.Errorf("executing chain %s not registered: %w", executingChain, ErrUnknownChain)

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -912,7 +912,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 			},
 		},
 		// Interop activation-block boundary cases. Mirrors the equivalent kona
-		// MessageGraph tests (see PR description).
+		// MessageGraph tests.
 		newActivationBoundaryCase(
 			"ActivationBoundary/ExecutingSide",
 			1000, 0, 1000, 999, false,

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -911,11 +911,8 @@ func TestVerifyInteropMessages(t *testing.T) {
 				require.Contains(t, result.InvalidHeads, invalidChainID)
 			},
 		},
-		// Interop activation-block boundary cases. Mirrors kona's
-		// MessageGraph::check_single_dependency at
-		// rust/kona/crates/protocol/interop/src/graph.rs:367-401 and op-program's
-		// depset.LinkChecker.CanExecute (op-supervisor/supervisor/backend/depset/links.go).
-		// See issue #20684 and PR #20550.
+		// Interop activation-block boundary cases. Mirrors the equivalent kona
+		// MessageGraph tests (see PR description).
 		newActivationBoundaryCase(
 			"ActivationBoundary/ExecutingSide",
 			1000, 0, 1000, 999, false,

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -64,6 +64,89 @@ func runVerifyInteropTest(t *testing.T, tc verifyInteropTestCase) {
 	}
 }
 
+// newActivationBoundaryCase builds a two-chain verifyInteropTestCase that exercises the
+// interop activation-block guard inside verifyExecutingMessage. The destination chain is
+// the executing chain; the source chain is the initiating chain. Both chains share the
+// same activationTimestamp and blockTime, matching supernode's invariant that all chains
+// in the dependency set share an InteropTime.
+//
+// blockTimeOverride == 0 leaves algoMockChain.BlockTime() at its default (1). All
+// guard-firing cases use init ts <= exec ts so the pre-existing ErrTimestampViolation
+// cannot fire — leaving the activation guard as the only thing that can reject baseline
+// once these tests are wired with a non-zero activationTimestamp.
+func newActivationBoundaryCase(name string, activationTs, blockTimeOverride, execTs, initTs uint64, expectValid bool) verifyInteropTestCase {
+	return verifyInteropTestCase{
+		name: name,
+		setup: func() (*Interop, uint64, map[eth.ChainID]eth.BlockID) {
+			sourceChainID := eth.ChainIDFromUInt64(10)
+			destChainID := eth.ChainIDFromUInt64(8453)
+
+			sourceBlockHash := common.HexToHash("0xSource")
+			destBlockHash := common.HexToHash("0xDest")
+
+			sourceBlock := eth.BlockID{Number: 50, Hash: sourceBlockHash}
+			destBlock := eth.BlockID{Number: 100, Hash: destBlockHash}
+			l1Block := eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}
+
+			execMsg := &suptypes.ExecutingMessage{
+				ChainID:   sourceChainID,
+				BlockNum:  50,
+				LogIdx:    0,
+				Timestamp: initTs,
+				Checksum:  suptypes.MessageChecksum{0x01},
+			}
+
+			sourceDB := &algoMockLogsDB{
+				openBlockRef: eth.BlockRef{Hash: sourceBlockHash, Number: 50, Time: initTs},
+				containsSeal: suptypes.BlockSeal{Number: 50, Timestamp: initTs},
+			}
+
+			destDB := &algoMockLogsDB{
+				openBlockRef: eth.BlockRef{Hash: destBlockHash, Number: 100, Time: execTs},
+				openBlockExecMsg: map[uint32]*suptypes.ExecutingMessage{
+					0: execMsg,
+				},
+			}
+
+			sourceChain := newMockChainWithL1(sourceChainID, l1Block, sourceBlock)
+			sourceChain.blockTimeOverride = blockTimeOverride
+			destChain := newMockChainWithL1(destChainID, l1Block, destBlock)
+			destChain.blockTimeOverride = blockTimeOverride
+
+			interop := &Interop{
+				activationTimestamp: activationTs,
+				messageExpiryWindow: defaultMessageExpiryWindow,
+				log:                 gethlog.New(),
+				logsDBs: map[eth.ChainID]LogsDB{
+					sourceChainID: sourceDB,
+					destChainID:   destDB,
+				},
+				chains: map[eth.ChainID]cc.InteropChain{
+					sourceChainID: sourceChain,
+					destChainID:   destChain,
+				},
+			}
+
+			return interop, execTs, map[eth.ChainID]eth.BlockID{
+				sourceChainID: sourceBlock,
+				destChainID:   destBlock,
+			}
+		},
+		validate: func(t *testing.T, result Result) {
+			destChainID := eth.ChainIDFromUInt64(8453)
+			if expectValid {
+				require.True(t, result.IsValid(),
+					"executing-msg outside activation block must be accepted by verifyExecutingMessage")
+				require.Empty(t, result.InvalidHeads)
+				return
+			}
+			require.False(t, result.IsValid(),
+				"executing-msg-in-activation-block must be rejected by verifyExecutingMessage")
+			require.Contains(t, result.InvalidHeads, destChainID)
+		},
+	}
+}
+
 // l1HeadsFromMocks builds the snapshot observeRound would produce, by reading optimisticL1
 // from each mock. Mocks tagged with optimisticAtErr are omitted to simulate a missing entry.
 func l1HeadsFromMocks(chains map[eth.ChainID]cc.InteropChain, blocks map[eth.ChainID]eth.BlockID) map[eth.ChainID]eth.BlockID {
@@ -828,6 +911,35 @@ func TestVerifyInteropMessages(t *testing.T) {
 				require.Contains(t, result.InvalidHeads, invalidChainID)
 			},
 		},
+		// Interop activation-block boundary cases. Mirrors kona's
+		// MessageGraph::check_single_dependency at
+		// rust/kona/crates/protocol/interop/src/graph.rs:367-401 and op-program's
+		// depset.LinkChecker.CanExecute (op-supervisor/supervisor/backend/depset/links.go).
+		// See issue #20684 and PR #20550.
+		newActivationBoundaryCase(
+			"ActivationBoundary/ExecutingSide",
+			1000, 0, 1000, 999, false,
+		),
+		newActivationBoundaryCase(
+			"ActivationBoundary/InitiatingSide",
+			1000, 0, 1001, 1000, false,
+		),
+		newActivationBoundaryCase(
+			"ActivationBoundary/PreActivationInitiating",
+			1000, 0, 1001, 999, false,
+		),
+		newActivationBoundaryCase(
+			"ActivationBoundary/UnalignedActivation",
+			1, 2, 2, 2, false,
+		),
+		newActivationBoundaryCase(
+			"ActivationBoundary/PositiveControlOneBlockPastActivation",
+			1000, 0, 1002, 1001, true,
+		),
+		newActivationBoundaryCase(
+			"ActivationBoundary/PositiveControlExactlyAtBoundary",
+			1000, 0, 1001, 1001, true,
+		),
 		// Error cases
 		{
 			name: "Errors/OpenBlockError",
@@ -954,11 +1066,12 @@ var _ eth.BlockInfo = (*testBlockInfo)(nil)
 
 // algoMockChain is a simplified mock chain container for algo tests
 type algoMockChain struct {
-	id              eth.ChainID
-	optimisticL2    eth.BlockID
-	optimisticL1    eth.BlockID
-	optimisticAtErr error
-	blockHashes     map[uint64]common.Hash
+	id                eth.ChainID
+	optimisticL2      eth.BlockID
+	optimisticL1      eth.BlockID
+	optimisticAtErr   error
+	blockHashes       map[uint64]common.Hash
+	blockTimeOverride uint64
 }
 
 func (m *algoMockChain) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
@@ -1002,7 +1115,12 @@ func (m *algoMockChain) TimestampToBlockNumber(ctx context.Context, ts uint64) (
 func (m *algoMockChain) RewindEngine(ctx context.Context, timestamp uint64, invalidatedBlock eth.BlockRef) error {
 	return nil
 }
-func (m *algoMockChain) BlockTime() uint64 { return 1 }
+func (m *algoMockChain) BlockTime() uint64 {
+	if m.blockTimeOverride > 0 {
+		return m.blockTimeOverride
+	}
+	return 1
+}
 func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
## Summary

- `verifyExecutingMessage` in `op-supernode/supernode/activity/interop/algo.go` previously checked timestamp ordering and expiry only, never consulting `i.activationTimestamp`. Both canonical fault-proof verifiers reject executing messages whose executing or initiating block is pre-activation or in the activation block of the relevant chain:
  - **kona** (Rust, used by kona-client / kona-proof): `MessageGraph::check_single_dependency`. Both guards added in PR #20550.
  - **op-program** (Go, used by cannon traces): `cross.CrossUnsafeHazards` → `depset.LinkChecker.CanExecute`, imported as library code from `op-program/client/interop/consolidate.go`.
- Supernode is becoming the live interop verifier; this divergence at the activation boundary means a supernode-derived super-root can include a withdrawal-bearing output that fault-proof execution would replace with a deposits-only block. See [#20684](https://github.com/ethereum-optimism/optimism/issues/20684).
- This PR adds the symmetric pair of guards inside `verifyExecutingMessage`, matching kona PR #20550's scope. Each guard uses a single inlined check `ts < activationTimestamp + chain.BlockTime()` covering both pre-activation and activation-block in one expression (the same shape kona / op-program use). Two new sentinels `ErrExecutedTooEarly` / `ErrInitiatedTooEarly` mirror kona's `MessageGraphError` vocabulary.

## Why two guards: `executingTimestamp` vs `execMsg.Timestamp`

`verifyExecutingMessage` receives two distinct timestamps:

- `executingTimestamp` — the timestamp of the block on the **executing** chain that contains the executing message (the destination block's `Time`, supplied by `verifyInteropMessages` from the opened block ref).
- `execMsg.Timestamp` — the timestamp of the **initiating** message on the source chain (recorded in the executing message's identifier as a commitment to the initiating event's block time).

The activation timestamp is a single global protocol parameter (supernode enforces a uniform `InteropTime` across all chains in the dependency set), but each chain has its own `BlockTime()`. The two guards are therefore independent:

1. **Executing-side**: rejects when the executing chain hasn't progressed past its own activation block — `executingTimestamp < activationTimestamp + execChain.BlockTime()`.
2. **Initiating-side**: rejects when the message being referenced lived in (or before) the initiating chain's activation block — `execMsg.Timestamp < activationTimestamp + initChain.BlockTime()`.

Either side being in its activation block invalidates the executing message, matching kona's two-arm `if`/`else if` in `check_single_dependency` (one `is_first_interop_block` call per chain) and op-program's `LinkChecker.CanExecute` (two `IsInteropActivationBlock` calls).

## Upstream kona tests this PR mirrors

The six `ActivationBoundary/*` sub-tests correspond to the kona `MessageGraph` tests in `rust/kona/crates/protocol/interop/src/graph.rs`:

| Supernode sub-test | Kona test |
|---|---|
| `ExecutingSide` | `test_derive_and_resolve_graph_executing_at_interop_activation` |
| `InitiatingSide` | `test_derive_and_resolve_graph_initiating_at_interop_activation` |
| `PreActivationInitiating` | `test_derive_and_resolve_graph_initiating_before_interop` |
| `UnalignedActivation` | `test_derive_and_resolve_graph_executing_before_interop_unaligned_activation` (also `..._initiating_before_interop_unaligned_activation`) |
| `PositiveControlOneBlockPastActivation` | (no direct kona equivalent — over-rejection regression guard) |
| `PositiveControlExactlyAtBoundary` | (no direct kona equivalent — locks down `<` vs `<=` on the new inequality) |

## Scope

- `op-supernode/supernode/activity/interop/algo.go`: two new sentinel errors, two guard branches inside `verifyExecutingMessage` (with two chain-map lookups).
- `op-supernode/supernode/activity/interop/algo_test.go`: six new `ActivationBoundary/*` sub-tests (four guard-firing, two positive controls) plus a `blockTimeOverride` field on `algoMockChain`.
- No other production files touched. No `LinkCheckerImpl` adoption, no helper method outside the function, no super-root recomputation, no contract changes.

Out of scope (separate work items): monitor/challenger configuration changes recommended by #20684, and the contract-side flaw demonstrated by the Solidity PoC — both dissolve once dispute-input verifiers converge, which is what this PR enables.

## Test plan

- [x] Wrote six failing repro sub-tests on baseline. Four guard-firing rows fail with `executing-msg-in-activation-block must be rejected by verifyExecutingMessage`; two positive controls (`PositiveControlOneBlockPastActivation`, `PositiveControlExactlyAtBoundary`) pass on baseline as well as on the fix — they catch over-rejection regressions and lock down `<` vs `<=` on the new inequality.
- [x] After implementing the guards, all six sub-tests pass with `-count=10`:
  ```
  go test ./op-supernode/supernode/activity/interop/ -run 'TestVerifyInteropMessages/ActivationBoundary' -count=10
  ```
- [x] Whole-package regression: `go test ./op-supernode/supernode/activity/interop/... -count=1` — green.
- [x] Wider supernode regression: `go test ./op-supernode/... -count=1` — all green.
- [x] `go vet ./op-supernode/...`, `go build ./op-supernode/...` — clean.

## Sub-test parameters

| Sub-test | activationTs | blockTime | exec ts | init ts | Expectation |
|---|---|---|---|---|---|
| `ActivationBoundary/ExecutingSide` | 1000 | 1 | 1000 (=activation) | 999 | reject (exec-side, `ErrExecutedTooEarly`) |
| `ActivationBoundary/InitiatingSide` | 1000 | 1 | 1001 | 1000 (=activation) | reject (init-side, `ErrInitiatedTooEarly`) |
| `ActivationBoundary/PreActivationInitiating` | 1000 | 1 | 1001 | 999 (pre-activation) | reject (init-side) |
| `ActivationBoundary/UnalignedActivation` | 1 | 2 | 2 | 2 | reject (exec-side under unaligned activation) |
| `ActivationBoundary/PositiveControlOneBlockPastActivation` | 1000 | 1 | 1002 | 1001 | accept |
| `ActivationBoundary/PositiveControlExactlyAtBoundary` | 1000 | 1 | 1001 (=activation+blockTime) | 1001 | accept |

Every guard-firing sub-test sets `init ts <= exec ts` so the pre-existing `ErrTimestampViolation` cannot fire — leaving the new activation guard as the only thing that can make baseline reject.

Closes #20684.