### PR TITLE
fix(kona-client/interop): align trace-extension boundary with op-program

### DIFF
--- a/rust/kona/bin/client/src/interop/mod.rs
+++ b/rust/kona/bin/client/src/interop/mod.rs
@@ -84,9 +84,10 @@ where
     // sub-problem.
     match boot.agreed_pre_state {
         PreState::SuperRoot(ref super_root) => {
-            // If the claimed L2 block timestamp is less than the super root timestamp, the
-            // post-state must be the agreed pre-state to accommodate trace extension.
-            if super_root.timestamp >= boot.claimed_l2_timestamp {
+            // At the trace-extension boundary, the post-state must equal the agreed pre-state.
+            // The strict-`>` case is guarded against in `BootInfo::load` (panics there); this
+            // arm only handles the legitimate `==` boundary.
+            if super_root.timestamp == boot.claimed_l2_timestamp {
                 if boot.agreed_pre_state_commitment == boot.claimed_post_state {
                     return Ok(());
                 } else {
@@ -101,10 +102,10 @@ where
             sub_transition(oracle, boot, evm_factory).await
         }
         PreState::TransitionState(ref transition_state) => {
-            // If the claimed L2 block timestamp is at or before the prestate timestamp, the
-            // post-state must be the agreed pre-state to accommodate trace extension. This
-            // mirrors the SuperRoot branch above.
-            if transition_state.pre_state.timestamp >= boot.claimed_l2_timestamp {
+            // At the trace-extension boundary, the post-state must equal the agreed pre-state.
+            // The strict-`>` case is guarded against in `BootInfo::load` (panics there); this
+            // arm only handles the legitimate `==` boundary, mirroring the SuperRoot arm above.
+            if transition_state.pre_state.timestamp == boot.claimed_l2_timestamp {
                 if boot.agreed_pre_state_commitment == boot.claimed_post_state {
                     return Ok(());
                 } else {

--- a/rust/kona/bin/client/src/interop/mod.rs
+++ b/rust/kona/bin/client/src/interop/mod.rs
@@ -101,13 +101,18 @@ where
             sub_transition(oracle, boot, evm_factory).await
         }
         PreState::TransitionState(ref transition_state) => {
-            // If the claimed L2 block timestamp is less than the prestate timestamp, the
-            // claim must be invalid.
+            // If the claimed L2 block timestamp is at or before the prestate timestamp, the
+            // post-state must be the agreed pre-state to accommodate trace extension. This
+            // mirrors the SuperRoot branch above.
             if transition_state.pre_state.timestamp >= boot.claimed_l2_timestamp {
-                return Err(FaultProofProgramError::InvalidClaim(
-                    boot.agreed_pre_state_commitment,
-                    boot.claimed_post_state,
-                ));
+                if boot.agreed_pre_state_commitment == boot.claimed_post_state {
+                    return Ok(());
+                } else {
+                    return Err(FaultProofProgramError::InvalidClaim(
+                        boot.agreed_pre_state_commitment,
+                        boot.claimed_post_state,
+                    ));
+                }
             }
 
             // If the pre-state is a transition state, the sub-problem is selected based on the

--- a/rust/kona/bin/client/tests/interop_trace_extension.rs
+++ b/rust/kona/bin/client/tests/interop_trace_extension.rs
@@ -81,7 +81,7 @@ fn super_root(timestamp: u64) -> SuperRoot {
 }
 
 fn transition_state_prestate(timestamp: u64) -> PreState {
-    PreState::TransitionState(TransitionState::new(super_root(timestamp), Vec::new(), 1))
+    PreState::TransitionState(TransitionState::new(super_root(timestamp), Vec::new(), 0))
 }
 
 fn super_root_prestate(timestamp: u64) -> PreState {

--- a/rust/kona/bin/client/tests/interop_trace_extension.rs
+++ b/rust/kona/bin/client/tests/interop_trace_extension.rs
@@ -178,6 +178,53 @@ async fn trace_extension_transition_state_at_game_timestamp_rejects_mismatched_c
     }
 }
 
+// Mirror of `..._transition_state_at_game_timestamp_accepts_matching_claim` for the
+// `PreState::SuperRoot` arm: `prestate.timestamp == claimed_l2_timestamp` and
+// `claim == prestate_commitment`: must accept (trace extension, `Ok(())`).
+#[tokio::test(flavor = "multi_thread")]
+async fn trace_extension_super_root_at_game_timestamp_accepts_matching_claim() {
+    let t: u64 = 1000;
+    let (preimages, agreed_commit) = setup_interop_preimages(super_root_prestate(t), t, B256::ZERO);
+    let mut preimages = preimages;
+    preimages.insert(PreimageKey::new_local(3), agreed_commit.as_slice().to_vec());
+
+    let oracle = MockOracle::from_preimages(preimages);
+    let hints = MockHintWriter::default();
+
+    let result = run(oracle, hints).await;
+    match result {
+        Ok(()) => {}
+        Err(FaultProofProgramError::InvalidClaim(expected, actual)) => {
+            panic!("expected Ok(()); got InvalidClaim(expected={expected}, actual={actual})");
+        }
+        Err(other) => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+// Mirror of `..._transition_state_at_game_timestamp_rejects_mismatched_claim` for the
+// `PreState::SuperRoot` arm: `prestate.timestamp == claimed_l2_timestamp` but
+// `claim != prestate_commitment`: must reject with `InvalidClaim`.
+#[tokio::test(flavor = "multi_thread")]
+async fn trace_extension_super_root_at_game_timestamp_rejects_mismatched_claim() {
+    let t: u64 = 1000;
+    let mismatched_claim = b256(0xCC);
+    let (preimages, agreed_commit) =
+        setup_interop_preimages(super_root_prestate(t), t, mismatched_claim);
+
+    let oracle = MockOracle::from_preimages(preimages);
+    let hints = MockHintWriter::default();
+
+    let err = run(oracle, hints).await.unwrap_err();
+    match err {
+        FaultProofProgramError::InvalidClaim(expected, actual) => {
+            assert_eq!(expected, agreed_commit);
+            assert_eq!(actual, mismatched_claim);
+            assert_ne!(expected, actual);
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
 // `prestate.timestamp > claimed_l2_timestamp`: invariant violation, must panic in
 // `BootInfo::load`. Matches op-program's defensive panic on the same condition.
 #[tokio::test(flavor = "multi_thread")]

--- a/rust/kona/bin/client/tests/interop_trace_extension.rs
+++ b/rust/kona/bin/client/tests/interop_trace_extension.rs
@@ -1,0 +1,217 @@
+//! Integration tests for the interop client's trace-extension boundary on a
+//! `PreState::TransitionState` agreed prestate. Mirrors the single-proof
+//! `trace_extension.rs` tests but exercises the interop `run()` dispatch.
+
+use alloy_primitives::B256;
+use alloy_rlp::Encodable;
+use async_trait::async_trait;
+use kona_client::interop::{FaultProofProgramError, run};
+use kona_genesis::{DependencySet, L1ChainConfig, RollupConfig};
+use kona_interop::{OutputRootWithChain, SuperRoot};
+use kona_preimage::{
+    HintWriterClient, PreimageKey, PreimageOracleClient,
+    errors::{PreimageOracleError, PreimageOracleResult},
+};
+use kona_proof_interop::{PreState, TransitionState};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
+use tokio::sync::Mutex;
+
+#[derive(Clone, Debug, Default)]
+struct MockOracle {
+    preimages: Arc<Mutex<HashMap<PreimageKey, Vec<u8>>>>,
+}
+
+impl MockOracle {
+    fn from_preimages(preimages: HashMap<PreimageKey, Vec<u8>>) -> Self {
+        Self { preimages: Arc::new(Mutex::new(preimages)) }
+    }
+}
+
+#[async_trait]
+impl PreimageOracleClient for MockOracle {
+    async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
+        self.preimages.lock().await.get(&key).cloned().ok_or(PreimageOracleError::KeyNotFound)
+    }
+
+    async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
+        let data = self.get(key).await?;
+        if data.len() != buf.len() {
+            return Err(PreimageOracleError::BufferLengthMismatch(buf.len(), data.len()));
+        }
+        buf.copy_from_slice(&data);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct MockHintWriter {
+    _hints: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl HintWriterClient for MockHintWriter {
+    async fn write(&self, hint: &str) -> PreimageOracleResult<()> {
+        self._hints.lock().await.push(hint.to_string());
+        Ok(())
+    }
+}
+
+fn b256(fill: u8) -> B256 {
+    B256::from([fill; 32])
+}
+
+/// Builds a synthetic interop boot fixture with a `PreState::TransitionState` agreed prestate
+/// whose embedded `SuperRoot.timestamp == prestate_timestamp`.
+///
+/// Chain IDs `9901` and `9902` are intentionally absent from the embedded
+/// `ROLLUP_CONFIGS`, `L1_CONFIGS`, and `DEPENDENCY_SETS` registries, forcing
+/// `BootInfo::load` down the preimage-oracle fallback paths (keys 6, 7, 8).
+fn setup_interop_preimages(
+    prestate_timestamp: u64,
+    claimed_l2_timestamp: u64,
+    claimed_post_state: B256,
+) -> (HashMap<PreimageKey, Vec<u8>>, B256) {
+    const CHAIN_A: u64 = 9901;
+    const CHAIN_B: u64 = 9902;
+    const L1_CHAIN_ID: u64 = 9001;
+
+    // Build the TransitionState prestate. `step = 1` is a plausible mid-transition value;
+    // `PreState::decode` dispatches purely on the leading version byte, so any `step` in
+    // `[0, TRANSITION_STATE_MAX_STEPS]` reaches the `TransitionState` arm.
+    let pre_state = PreState::TransitionState(TransitionState::new(
+        SuperRoot::new(
+            prestate_timestamp,
+            vec![
+                OutputRootWithChain::new(CHAIN_A, b256(0xA1)),
+                OutputRootWithChain::new(CHAIN_B, b256(0xB2)),
+            ],
+        ),
+        Vec::new(),
+        1,
+    ));
+    let mut pre_state_rlp = Vec::with_capacity(pre_state.length());
+    pre_state.encode(&mut pre_state_rlp);
+    let agreed_pre_state_commitment = pre_state.hash();
+
+    let mut preimages = HashMap::new();
+
+    // Local keys consumed by BootInfo::load.
+    preimages.insert(PreimageKey::new_local(1), b256(0x11).as_slice().to_vec());
+    preimages.insert(PreimageKey::new_local(2), agreed_pre_state_commitment.as_slice().to_vec());
+    preimages.insert(PreimageKey::new_local(3), claimed_post_state.as_slice().to_vec());
+    preimages.insert(PreimageKey::new_local(4), claimed_l2_timestamp.to_be_bytes().to_vec());
+
+    // RollupConfig fallback (key 6): chain IDs absent from ROLLUP_CONFIGS, so JSON deserialization
+    // path is exercised. Default values are fine — `run()` short-circuits before any config field
+    // is consumed.
+    let mut rollup_configs: HashMap<u64, RollupConfig> = HashMap::new();
+    for chain_id in [CHAIN_A, CHAIN_B] {
+        let cfg = RollupConfig { l1_chain_id: L1_CHAIN_ID, ..RollupConfig::default() };
+        rollup_configs.insert(chain_id, cfg);
+    }
+    preimages.insert(
+        PreimageKey::new_local(6),
+        serde_json::to_vec(&rollup_configs).expect("serialize rollup configs"),
+    );
+
+    // L1ChainConfig fallback (key 7): synthetic L1 chain ID 9001 is absent from L1_CONFIGS.
+    let l1_config = L1ChainConfig { chain_id: L1_CHAIN_ID, ..L1ChainConfig::default() };
+    preimages.insert(
+        PreimageKey::new_local(7),
+        serde_json::to_vec(&l1_config).expect("serialize l1 config"),
+    );
+
+    // DependencySet fallback (key 8): the two synthetic chain IDs are absent from
+    // DEPENDENCY_SETS.
+    let mut dependencies = BTreeMap::new();
+    dependencies.insert(CHAIN_A, kona_genesis::ChainDependency {});
+    dependencies.insert(CHAIN_B, kona_genesis::ChainDependency {});
+    let depset = DependencySet { dependencies, override_message_expiry_window: None };
+    preimages
+        .insert(PreimageKey::new_local(8), serde_json::to_vec(&depset).expect("serialize depset"));
+
+    // Keccak preimage for the agreed pre-state commitment (consumed by `read_raw_pre_state`).
+    preimages.insert(PreimageKey::new_keccak256(*agreed_pre_state_commitment), pre_state_rlp);
+
+    (preimages, agreed_pre_state_commitment)
+}
+
+/// Sub-case A: `T == GT AND C == P`.
+///
+/// Baseline (`fbbf9089d0`) returns `Err(InvalidClaim(expected, actual))` with
+/// `expected == actual == agreed_pre_state_commitment`. After the fix, returns `Ok(())`,
+/// matching the existing `PreState::SuperRoot` arm at `mod.rs:86-98`.
+#[tokio::test(flavor = "multi_thread")]
+async fn trace_extension_transition_state_at_game_timestamp_accepts_matching_claim() {
+    let t: u64 = 1000;
+    let (preimages, agreed_commit) = setup_interop_preimages(t, t, B256::ZERO);
+    // Overwrite key 3 with the matching commitment (sub-case A: C == P).
+    let mut preimages = preimages;
+    preimages.insert(PreimageKey::new_local(3), agreed_commit.as_slice().to_vec());
+
+    let oracle = MockOracle::from_preimages(preimages);
+    let hints = MockHintWriter::default();
+
+    let result = run(oracle, hints).await;
+    match result {
+        Ok(()) => {}
+        Err(FaultProofProgramError::InvalidClaim(expected, actual)) => {
+            panic!(
+                "expected Ok(()); got InvalidClaim(expected={expected}, actual={actual}) — \
+                 trace-extension parity bug not yet fixed"
+            );
+        }
+        Err(other) => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+/// Sub-case B: `T == GT AND C != P`. Must remain a fail-closed `InvalidClaim` on baseline and
+/// after the fix.
+#[tokio::test(flavor = "multi_thread")]
+async fn trace_extension_transition_state_at_game_timestamp_rejects_mismatched_claim() {
+    let t: u64 = 1000;
+    let mismatched_claim = b256(0xCC);
+    let (preimages, agreed_commit) = setup_interop_preimages(t, t, mismatched_claim);
+
+    let oracle = MockOracle::from_preimages(preimages);
+    let hints = MockHintWriter::default();
+
+    let err = run(oracle, hints).await.unwrap_err();
+    match err {
+        FaultProofProgramError::InvalidClaim(expected, actual) => {
+            assert_eq!(expected, agreed_commit);
+            assert_eq!(actual, mismatched_claim);
+            assert_ne!(expected, actual);
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+/// Sub-case C-eq: `T > GT AND C == P`. Baseline returns `Err(InvalidClaim)`; after the fix the
+/// symmetric `>=` arm accepts and returns `Ok(())`.
+#[tokio::test(flavor = "multi_thread")]
+async fn trace_extension_transition_state_past_game_timestamp_accepts_matching_claim() {
+    let t: u64 = 1000;
+    let game_timestamp: u64 = t - 1; // T > GT
+    let (preimages, agreed_commit) = setup_interop_preimages(t, game_timestamp, B256::ZERO);
+    let mut preimages = preimages;
+    preimages.insert(PreimageKey::new_local(3), agreed_commit.as_slice().to_vec());
+
+    let oracle = MockOracle::from_preimages(preimages);
+    let hints = MockHintWriter::default();
+
+    let result = run(oracle, hints).await;
+    match result {
+        Ok(()) => {}
+        Err(FaultProofProgramError::InvalidClaim(expected, actual)) => {
+            panic!(
+                "expected Ok(()); got InvalidClaim(expected={expected}, actual={actual}) — \
+                 symmetric `>=` arm not yet covering the strict-`>` half"
+            );
+        }
+        Err(other) => panic!("unexpected error variant: {other:?}"),
+    }
+}

--- a/rust/kona/bin/client/tests/interop_trace_extension.rs
+++ b/rust/kona/bin/client/tests/interop_trace_extension.rs
@@ -1,5 +1,9 @@
-//! Trace-extension boundary tests for the interop `run()` dispatch on a
-//! `PreState::TransitionState` agreed prestate.
+//! Trace-extension boundary tests for the interop `run()` dispatch.
+//!
+//! Covers both `PreState::SuperRoot` and `PreState::TransitionState` agreed prestates at
+//! `prestate.timestamp == claimed_l2_timestamp` (legitimate boundary) and the strict-`>` case
+//! (invariant violation, must panic to match op-program; see
+//! `op-program/client/interop/interop.go:87-97`).
 
 use alloy_primitives::B256;
 use alloy_rlp::Encodable;
@@ -62,28 +66,35 @@ fn b256(fill: u8) -> B256 {
     B256::from([fill; 32])
 }
 
+const CHAIN_A: u64 = 9901;
+const CHAIN_B: u64 = 9902;
+const L1_CHAIN_ID: u64 = 9001;
+
+fn super_root(timestamp: u64) -> SuperRoot {
+    SuperRoot::new(
+        timestamp,
+        vec![
+            OutputRootWithChain::new(CHAIN_A, b256(0xA1)),
+            OutputRootWithChain::new(CHAIN_B, b256(0xB2)),
+        ],
+    )
+}
+
+fn transition_state_prestate(timestamp: u64) -> PreState {
+    PreState::TransitionState(TransitionState::new(super_root(timestamp), Vec::new(), 1))
+}
+
+fn super_root_prestate(timestamp: u64) -> PreState {
+    PreState::SuperRoot(super_root(timestamp))
+}
+
 // Synthetic chain IDs absent from the embedded registries, so `BootInfo::load`
 // uses the preimage-oracle fallback paths and the fixture stays self-contained.
 fn setup_interop_preimages(
-    prestate_timestamp: u64,
+    pre_state: PreState,
     claimed_l2_timestamp: u64,
     claimed_post_state: B256,
 ) -> (HashMap<PreimageKey, Vec<u8>>, B256) {
-    const CHAIN_A: u64 = 9901;
-    const CHAIN_B: u64 = 9902;
-    const L1_CHAIN_ID: u64 = 9001;
-
-    let pre_state = PreState::TransitionState(TransitionState::new(
-        SuperRoot::new(
-            prestate_timestamp,
-            vec![
-                OutputRootWithChain::new(CHAIN_A, b256(0xA1)),
-                OutputRootWithChain::new(CHAIN_B, b256(0xB2)),
-            ],
-        ),
-        Vec::new(),
-        1,
-    ));
     let mut pre_state_rlp = Vec::with_capacity(pre_state.length());
     pre_state.encode(&mut pre_state_rlp);
     let agreed_pre_state_commitment = pre_state.hash();
@@ -127,7 +138,8 @@ fn setup_interop_preimages(
 #[tokio::test(flavor = "multi_thread")]
 async fn trace_extension_transition_state_at_game_timestamp_accepts_matching_claim() {
     let t: u64 = 1000;
-    let (preimages, agreed_commit) = setup_interop_preimages(t, t, B256::ZERO);
+    let (preimages, agreed_commit) =
+        setup_interop_preimages(transition_state_prestate(t), t, B256::ZERO);
     let mut preimages = preimages;
     preimages.insert(PreimageKey::new_local(3), agreed_commit.as_slice().to_vec());
 
@@ -149,7 +161,8 @@ async fn trace_extension_transition_state_at_game_timestamp_accepts_matching_cla
 async fn trace_extension_transition_state_at_game_timestamp_rejects_mismatched_claim() {
     let t: u64 = 1000;
     let mismatched_claim = b256(0xCC);
-    let (preimages, agreed_commit) = setup_interop_preimages(t, t, mismatched_claim);
+    let (preimages, agreed_commit) =
+        setup_interop_preimages(transition_state_prestate(t), t, mismatched_claim);
 
     let oracle = MockOracle::from_preimages(preimages);
     let hints = MockHintWriter::default();
@@ -165,25 +178,43 @@ async fn trace_extension_transition_state_at_game_timestamp_rejects_mismatched_c
     }
 }
 
-// `prestate.timestamp > claimed_l2_timestamp` and `claim == prestate_commitment`: must accept
-// (covers the strict-`>` half of the `>=` arm, symmetric with the SuperRoot branch).
+// `prestate.timestamp > claimed_l2_timestamp`: invariant violation, must panic in
+// `BootInfo::load`. Matches op-program's defensive panic on the same condition.
 #[tokio::test(flavor = "multi_thread")]
-async fn trace_extension_transition_state_past_game_timestamp_accepts_matching_claim() {
-    let t: u64 = 1000;
-    let game_timestamp: u64 = t - 1;
-    let (preimages, agreed_commit) = setup_interop_preimages(t, game_timestamp, B256::ZERO);
+#[should_panic(expected = "agreed prestate timestamp")]
+async fn rejects_transition_state_with_timestamp_after_game_timestamp() {
+    let prestate_timestamp: u64 = 1000;
+    let claimed_l2_timestamp: u64 = prestate_timestamp - 1;
+    let (preimages, agreed_commit) = setup_interop_preimages(
+        transition_state_prestate(prestate_timestamp),
+        claimed_l2_timestamp,
+        B256::ZERO,
+    );
     let mut preimages = preimages;
     preimages.insert(PreimageKey::new_local(3), agreed_commit.as_slice().to_vec());
 
     let oracle = MockOracle::from_preimages(preimages);
     let hints = MockHintWriter::default();
 
-    let result = run(oracle, hints).await;
-    match result {
-        Ok(()) => {}
-        Err(FaultProofProgramError::InvalidClaim(expected, actual)) => {
-            panic!("expected Ok(()); got InvalidClaim(expected={expected}, actual={actual})");
-        }
-        Err(other) => panic!("unexpected error variant: {other:?}"),
-    }
+    let _ = run(oracle, hints).await;
+}
+
+// Mirror of the above for the `PreState::SuperRoot` arm: same invariant, same guard, same panic.
+#[tokio::test(flavor = "multi_thread")]
+#[should_panic(expected = "agreed prestate timestamp")]
+async fn rejects_super_root_with_timestamp_after_game_timestamp() {
+    let prestate_timestamp: u64 = 1000;
+    let claimed_l2_timestamp: u64 = prestate_timestamp - 1;
+    let (preimages, agreed_commit) = setup_interop_preimages(
+        super_root_prestate(prestate_timestamp),
+        claimed_l2_timestamp,
+        B256::ZERO,
+    );
+    let mut preimages = preimages;
+    preimages.insert(PreimageKey::new_local(3), agreed_commit.as_slice().to_vec());
+
+    let oracle = MockOracle::from_preimages(preimages);
+    let hints = MockHintWriter::default();
+
+    let _ = run(oracle, hints).await;
 }

--- a/rust/kona/bin/client/tests/interop_trace_extension.rs
+++ b/rust/kona/bin/client/tests/interop_trace_extension.rs
@@ -1,6 +1,5 @@
-//! Integration tests for the interop client's trace-extension boundary on a
-//! `PreState::TransitionState` agreed prestate. Mirrors the single-proof
-//! `trace_extension.rs` tests but exercises the interop `run()` dispatch.
+//! Trace-extension boundary tests for the interop `run()` dispatch on a
+//! `PreState::TransitionState` agreed prestate.
 
 use alloy_primitives::B256;
 use alloy_rlp::Encodable;
@@ -63,12 +62,8 @@ fn b256(fill: u8) -> B256 {
     B256::from([fill; 32])
 }
 
-/// Builds a synthetic interop boot fixture with a `PreState::TransitionState` agreed prestate
-/// whose embedded `SuperRoot.timestamp == prestate_timestamp`.
-///
-/// Chain IDs `9901` and `9902` are intentionally absent from the embedded
-/// `ROLLUP_CONFIGS`, `L1_CONFIGS`, and `DEPENDENCY_SETS` registries, forcing
-/// `BootInfo::load` down the preimage-oracle fallback paths (keys 6, 7, 8).
+// Synthetic chain IDs absent from the embedded registries, so `BootInfo::load`
+// uses the preimage-oracle fallback paths and the fixture stays self-contained.
 fn setup_interop_preimages(
     prestate_timestamp: u64,
     claimed_l2_timestamp: u64,
@@ -78,9 +73,6 @@ fn setup_interop_preimages(
     const CHAIN_B: u64 = 9902;
     const L1_CHAIN_ID: u64 = 9001;
 
-    // Build the TransitionState prestate. `step = 1` is a plausible mid-transition value;
-    // `PreState::decode` dispatches purely on the leading version byte, so any `step` in
-    // `[0, TRANSITION_STATE_MAX_STEPS]` reaches the `TransitionState` arm.
     let pre_state = PreState::TransitionState(TransitionState::new(
         SuperRoot::new(
             prestate_timestamp,
@@ -98,15 +90,11 @@ fn setup_interop_preimages(
 
     let mut preimages = HashMap::new();
 
-    // Local keys consumed by BootInfo::load.
     preimages.insert(PreimageKey::new_local(1), b256(0x11).as_slice().to_vec());
     preimages.insert(PreimageKey::new_local(2), agreed_pre_state_commitment.as_slice().to_vec());
     preimages.insert(PreimageKey::new_local(3), claimed_post_state.as_slice().to_vec());
     preimages.insert(PreimageKey::new_local(4), claimed_l2_timestamp.to_be_bytes().to_vec());
 
-    // RollupConfig fallback (key 6): chain IDs absent from ROLLUP_CONFIGS, so JSON deserialization
-    // path is exercised. Default values are fine — `run()` short-circuits before any config field
-    // is consumed.
     let mut rollup_configs: HashMap<u64, RollupConfig> = HashMap::new();
     for chain_id in [CHAIN_A, CHAIN_B] {
         let cfg = RollupConfig { l1_chain_id: L1_CHAIN_ID, ..RollupConfig::default() };
@@ -117,15 +105,12 @@ fn setup_interop_preimages(
         serde_json::to_vec(&rollup_configs).expect("serialize rollup configs"),
     );
 
-    // L1ChainConfig fallback (key 7): synthetic L1 chain ID 9001 is absent from L1_CONFIGS.
     let l1_config = L1ChainConfig { chain_id: L1_CHAIN_ID, ..L1ChainConfig::default() };
     preimages.insert(
         PreimageKey::new_local(7),
         serde_json::to_vec(&l1_config).expect("serialize l1 config"),
     );
 
-    // DependencySet fallback (key 8): the two synthetic chain IDs are absent from
-    // DEPENDENCY_SETS.
     let mut dependencies = BTreeMap::new();
     dependencies.insert(CHAIN_A, kona_genesis::ChainDependency {});
     dependencies.insert(CHAIN_B, kona_genesis::ChainDependency {});
@@ -133,22 +118,16 @@ fn setup_interop_preimages(
     preimages
         .insert(PreimageKey::new_local(8), serde_json::to_vec(&depset).expect("serialize depset"));
 
-    // Keccak preimage for the agreed pre-state commitment (consumed by `read_raw_pre_state`).
     preimages.insert(PreimageKey::new_keccak256(*agreed_pre_state_commitment), pre_state_rlp);
 
     (preimages, agreed_pre_state_commitment)
 }
 
-/// Sub-case A: `T == GT AND C == P`.
-///
-/// Baseline (`fbbf9089d0`) returns `Err(InvalidClaim(expected, actual))` with
-/// `expected == actual == agreed_pre_state_commitment`. After the fix, returns `Ok(())`,
-/// matching the existing `PreState::SuperRoot` arm at `mod.rs:86-98`.
+// `prestate.timestamp == claimed_l2_timestamp` and `claim == prestate_commitment`: must accept.
 #[tokio::test(flavor = "multi_thread")]
 async fn trace_extension_transition_state_at_game_timestamp_accepts_matching_claim() {
     let t: u64 = 1000;
     let (preimages, agreed_commit) = setup_interop_preimages(t, t, B256::ZERO);
-    // Overwrite key 3 with the matching commitment (sub-case A: C == P).
     let mut preimages = preimages;
     preimages.insert(PreimageKey::new_local(3), agreed_commit.as_slice().to_vec());
 
@@ -159,17 +138,13 @@ async fn trace_extension_transition_state_at_game_timestamp_accepts_matching_cla
     match result {
         Ok(()) => {}
         Err(FaultProofProgramError::InvalidClaim(expected, actual)) => {
-            panic!(
-                "expected Ok(()); got InvalidClaim(expected={expected}, actual={actual}) — \
-                 trace-extension parity bug not yet fixed"
-            );
+            panic!("expected Ok(()); got InvalidClaim(expected={expected}, actual={actual})");
         }
         Err(other) => panic!("unexpected error variant: {other:?}"),
     }
 }
 
-/// Sub-case B: `T == GT AND C != P`. Must remain a fail-closed `InvalidClaim` on baseline and
-/// after the fix.
+// `prestate.timestamp == claimed_l2_timestamp` but `claim != prestate_commitment`: must reject.
 #[tokio::test(flavor = "multi_thread")]
 async fn trace_extension_transition_state_at_game_timestamp_rejects_mismatched_claim() {
     let t: u64 = 1000;
@@ -190,12 +165,12 @@ async fn trace_extension_transition_state_at_game_timestamp_rejects_mismatched_c
     }
 }
 
-/// Sub-case C-eq: `T > GT AND C == P`. Baseline returns `Err(InvalidClaim)`; after the fix the
-/// symmetric `>=` arm accepts and returns `Ok(())`.
+// `prestate.timestamp > claimed_l2_timestamp` and `claim == prestate_commitment`: must accept
+// (covers the strict-`>` half of the `>=` arm, symmetric with the SuperRoot branch).
 #[tokio::test(flavor = "multi_thread")]
 async fn trace_extension_transition_state_past_game_timestamp_accepts_matching_claim() {
     let t: u64 = 1000;
-    let game_timestamp: u64 = t - 1; // T > GT
+    let game_timestamp: u64 = t - 1;
     let (preimages, agreed_commit) = setup_interop_preimages(t, game_timestamp, B256::ZERO);
     let mut preimages = preimages;
     preimages.insert(PreimageKey::new_local(3), agreed_commit.as_slice().to_vec());
@@ -207,10 +182,7 @@ async fn trace_extension_transition_state_past_game_timestamp_accepts_matching_c
     match result {
         Ok(()) => {}
         Err(FaultProofProgramError::InvalidClaim(expected, actual)) => {
-            panic!(
-                "expected Ok(()); got InvalidClaim(expected={expected}, actual={actual}) — \
-                 symmetric `>=` arm not yet covering the strict-`>` half"
-            );
+            panic!("expected Ok(()); got InvalidClaim(expected={expected}, actual={actual})");
         }
         Err(other) => panic!("unexpected error variant: {other:?}"),
     }

--- a/rust/kona/crates/proof/proof-interop/src/boot.rs
+++ b/rust/kona/crates/proof/proof-interop/src/boot.rs
@@ -116,6 +116,20 @@ impl BootInfo {
         let agreed_pre_state =
             PreState::decode(&mut raw_pre_state.as_ref()).map_err(OracleProviderError::Rlp)?;
 
+        // INVARIANT: the honest actor never agrees to a prestate whose timestamp exceeds
+        // the dispute-game-pinned `claimed_l2_timestamp`. The oracle only verifies
+        // `key == keccak256(preimage)`, not the timestamp inside; without this guard a
+        // malicious proposer could register a future-timestamped prestate and use it as
+        // both starting and disputed claim at trace-extended bisection positions, where
+        // `claim == prestate ⇒ Ok(())` would resolve as `vmStatus = VALID`. Op-program
+        // panics on this condition (see `op-program/client/interop/interop.go:87-97`).
+        assert!(
+            agreed_pre_state.timestamp() <= l2_claim_block,
+            "agreed prestate timestamp {} is after the game timestamp {}",
+            agreed_pre_state.timestamp(),
+            l2_claim_block
+        );
+
         let chain_ids: Vec<_> = match agreed_pre_state {
             PreState::SuperRoot(ref super_root) => {
                 super_root.output_roots.iter().map(|r| r.chain_id).collect()


### PR DESCRIPTION
## Summary

Aligns kona-client's interop fault-proof program with op-program at the trace-extension timestamp boundary. Closes the consensus gap where the SuperRoot arm of `run()` accepted a malicious future-timestamped prestate as `vmStatus = VALID` while op-program would panic, and the TransitionState arm rejected a legitimate `T == GT` trace-extension that op-program accepts.

Closes #20721.

## Changes

**1. Input-boundary invariant in `BootInfo::load`** (`crates/proof/proof-interop/src/boot.rs`)

Adds an `assert!` rejecting any agreed pre-state whose timestamp exceeds `claimed_l2_timestamp`. The preimage oracle only self-verifies `key == keccak256(preimage)`, not the timestamp inside; without this guard a proposer can register a future-timestamped prestate and commit the same hash at both the trace-extended bisection position and its child, where `claim == prestate ⇒ Ok(())` resolves as VALID. The assert applies uniformly to both `PreState` variants via `PreState::timestamp()`, structurally matching op-program's `parseAgreedState` (`interop.go:130-147`), which funnels both shapes through one `superRoot.Timestamp` check. Panic message is identical to op-program's at `interop.go:96`.

**2. Tighten trace-extension boundary in both arms** (`bin/client/src/interop/mod.rs`)

With the strict-`>` case now unreachable, both `PreState::SuperRoot` and `PreState::TransitionState` arms drop the previous `>=` and only handle the legitimate `==` boundary: `claim == prestate ⇒ Ok(())`, else `Err(InvalidClaim)`. The TransitionState arm now mirrors the SuperRoot arm, matching op-program's unified `ValidateClaim` semantics at `interop.go:75,87-97`.

## Behavior matrix (both arms)

| Case | Op-program | Kona (this PR) |
|---|---|---|
| `T < GT` | derivation / consolidate | unchanged |
| `T == GT ∧ claim == prestate` | exit 0 (trace extension) | exit 0 ✅ |
| `T == GT ∧ claim != prestate` | exit 1 (`InvalidClaim`) | exit 1 ✅ |
| `T > GT` (any claim) | exit 2 (panic) | exit 2 ✅ |

## Tests

`bin/client/tests/interop_trace_extension.rs` — six integration tests, one per consensus-relevant cell × `PreState` variant:

- `trace_extension_{super_root,transition_state}_at_game_timestamp_accepts_matching_claim`
- `trace_extension_{super_root,transition_state}_at_game_timestamp_rejects_mismatched_claim`
- `rejects_{super_root,transition_state}_with_timestamp_after_game_timestamp` (`#[should_panic]`)

Fixture uses synthetic chain IDs (`9901`/`9902`, L1 `9001`) absent from the embedded `ROLLUP_CONFIGS` / `L1_CONFIGS` / `DEPENDENCY_SETS`, so `BootInfo::load` exercises the preimage-oracle fallback paths and the tests stay self-contained.

## Verification

```
cd rust && just f                                            # rustfmt clean
cd rust && just l                                            # clippy + rustdoc clean (-D warnings)
cargo nextest run -p kona-client --test interop_trace_extension   # 6/6 pass
```

## Notes

- No production callers change; the `match` on `PreState` in `run()` remains exhaustive.
- Pre-fix, kona's TransitionState arm was strictly stricter than op-program (rejected the `==`-trace-extension case op-program accepts). The fix aligns to op-program for spec-conformance; no on-chain regression because the accepted case is a legitimate same-hash trace extension that the cannon resolves as defense-wins by construction.
