### PR TITLE
chore(rust): log level in proofs exex

### DIFF
--- a/rust/op-reth/crates/trie/src/engine/tasks/execute_block.rs
+++ b/rust/op-reth/crates/trie/src/engine/tasks/execute_block.rs
@@ -12,7 +12,7 @@ use reth_provider::{
 };
 use reth_revm::database::StateProviderDatabase;
 use std::time::Instant;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 pub(crate) struct ExecuteBlockTask<Block: reth_primitives_traits::Block> {
     pub(crate) block: RecoveredBlock<Block>,
@@ -93,8 +93,7 @@ where
             // Likely a transient reorg race: reth no longer has state for what we believe is the
             // parent. Skip gracefully; subsequent ChainCommitted/ChainReorged notifications will
             // resync us.
-            warn!(
-                block_number = block.number(),
+            debug!(block_number = block.number(),
                 parent_hash = ?hash,
                 "Parent state not available in reth; skipping execute_block",
             );


### PR DESCRIPTION
## Description

Reduce log level in proofs exex. This warn log fires constantly during initial node sync