### PR TITLE
[codex] supernode: quiet expected tip lookup misses

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -508,12 +508,20 @@ func (c *simpleChainContainer) safeDBAtL2(ctx context.Context, l2 eth.BlockID) (
 func (c *simpleChainContainer) OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error) {
 	l2Block, err := c.LocalSafeBlockAtTimestamp(ctx, ts)
 	if err != nil {
-		c.log.Error("error determining l2 block at given timestamp", "error", err)
+		if errors.Is(err, ethereum.NotFound) {
+			c.log.Debug("l2 block at timestamp is not local safe yet", "timestamp", ts, "err", err)
+		} else {
+			c.log.Error("error determining l2 block at given timestamp", "timestamp", ts, "err", err)
+		}
 		return eth.BlockID{}, eth.BlockID{}, err
 	}
 	l1Block, err := c.safeDBAtL2(ctx, l2Block.ID())
 	if err != nil {
-		c.log.Error("error determining l1 block number at which l2 block became safe", "error", err)
+		if errors.Is(err, ethereum.NotFound) {
+			c.log.Debug("l1 block at which l2 block became safe is not available yet", "l2", l2Block.ID(), "err", err)
+		} else {
+			c.log.Error("error determining l1 block number at which l2 block became safe", "l2", l2Block.ID(), "err", err)
+		}
 		return eth.BlockID{}, eth.BlockID{}, err
 	}
 

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -3,6 +3,7 @@ package chain_container
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"path/filepath"
@@ -949,7 +950,7 @@ func TestChainContainer_OptimisticAt_ErrL1AtSafeHeadNotFound(t *testing.T) {
 	vncfg := createTestVNConfig()
 	vncfg.Rollup.Genesis.L2Time = 1000
 	vncfg.Rollup.BlockTime = 2
-	log := createTestLogger(t)
+	log, logs := testlog.CaptureLogger(t, gethlog.LevelDebug)
 	cfg := createTestCLIConfig(t.TempDir())
 	initOverload := &rollupNode.InitializationOverrides{}
 
@@ -984,6 +985,50 @@ func TestChainContainer_OptimisticAt_ErrL1AtSafeHeadNotFound(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ethereum.NotFound),
 		"ErrL1AtSafeHeadNotFound should be mapped to ethereum.NotFound, got: %v", err)
+	require.Nil(t, logs.FindLog(
+		testlog.NewLevelFilter(slog.LevelError),
+		testlog.NewMessageFilter("error determining l1 block number at which l2 block became safe"),
+	))
+	require.NotNil(t, logs.FindLog(
+		testlog.NewLevelFilter(slog.LevelDebug),
+		testlog.NewMessageFilter("l1 block at which l2 block became safe is not available yet"),
+	))
+}
+
+func TestChainContainer_OptimisticAt_LocalSafeTipNotFoundLogsDebug(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	vncfg := createTestVNConfig()
+	vncfg.Rollup.Genesis.L2Time = 1000
+	vncfg.Rollup.BlockTime = 2
+	log, logs := testlog.CaptureLogger(t, gethlog.LevelDebug)
+	cfg := createTestCLIConfig(t.TempDir())
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	impl, ok := container.(*simpleChainContainer)
+	require.True(t, ok)
+
+	impl.engine = &mockEngineController{}
+	impl.vn = &mockVNForL1AtSafeHeadError{
+		syncStatusResult: &eth.SyncStatus{
+			CurrentL1:   eth.L1BlockRef{Hash: common.Hash{0x10}, Number: 50},
+			LocalSafeL2: eth.L2BlockRef{Hash: common.Hash{0x20}, Number: 100},
+		},
+	}
+
+	_, _, err := container.OptimisticAt(context.Background(), 2000)
+
+	require.ErrorIs(t, err, ethereum.NotFound)
+	require.Nil(t, logs.FindLog(
+		testlog.NewLevelFilter(slog.LevelError),
+		testlog.NewMessageFilter("error determining l2 block at given timestamp"),
+	))
+	require.NotNil(t, logs.FindLog(
+		testlog.NewLevelFilter(slog.LevelDebug),
+		testlog.NewMessageFilter("l2 block at timestamp is not local safe yet"),
+	))
 }
 
 // mockVNForL1AtSafeHeadError is a VN mock that returns valid SyncStatus


### PR DESCRIPTION
## Summary

- Downgrades expected `ethereum.NotFound` results in `OptimisticAt` from error logs to debug logs.
- Keeps unexpected L2 timestamp lookup and SafeDB lookup failures at error level.
- Adds log-capture tests for the two expected lag paths: timestamp beyond the local-safe L2 tip, and SafeDB not yet having the L1 inclusion for a local-safe L2 block.

## Motivation

When cross-safe verification reaches the current tip, the verifier asks for data that may not exist yet. That condition is surfaced as `ethereum.NotFound` so callers can back off and retry. Logging those expected misses at error level makes healthy tip-following look like a stream of failures.

## Testing

- `go test ./op-supernode/supernode/chain_container`