### PR TITLE
fix(kona/client): validate output-root version word in fetch_safe_head_hash / fetch_output_block_hash

### DIFF
--- a/rust/kona/bin/client/src/interop/mod.rs
+++ b/rust/kona/bin/client/src/interop/mod.rs
@@ -21,7 +21,7 @@ use alloy_op_evm::post_exec::PostExecEvmFactoryAdapter;
 
 pub(crate) mod consolidate;
 pub(crate) mod transition;
-pub(crate) mod util;
+pub mod util;
 
 /// An error that can occur when running the fault proof program.
 #[derive(Error, Debug)]

--- a/rust/kona/bin/client/src/interop/util.rs
+++ b/rust/kona/bin/client/src/interop/util.rs
@@ -24,7 +24,7 @@ where
 }
 
 /// Fetches the block hash that the passed output root commits to.
-pub(crate) async fn fetch_output_block_hash<O>(
+pub async fn fetch_output_block_hash<O>(
     caching_oracle: &O,
     output_root: B256,
     chain_id: u64,
@@ -41,7 +41,14 @@ where
         .await
         .map_err(OracleProviderError::Preimage)?;
 
-    if output_preimage.len() >= 32 && output_preimage[..32] != [0u8; 32] {
+    if output_preimage.len() != 128 {
+        return Err(OracleProviderError::Preimage(PreimageOracleError::BufferLengthMismatch(
+            128,
+            output_preimage.len(),
+        )));
+    }
+
+    if output_preimage[..32] != [0u8; 32] {
         return Err(OracleProviderError::UnknownOutputVersion(B256::from_slice(
             &output_preimage[..32],
         )));

--- a/rust/kona/bin/client/src/interop/util.rs
+++ b/rust/kona/bin/client/src/interop/util.rs
@@ -41,5 +41,11 @@ where
         .await
         .map_err(OracleProviderError::Preimage)?;
 
+    if output_preimage.len() >= 32 && output_preimage[..32] != [0u8; 32] {
+        return Err(OracleProviderError::UnknownOutputVersion(B256::from_slice(
+            &output_preimage[..32],
+        )));
+    }
+
     output_preimage[96..128].try_into().map_err(OracleProviderError::SliceConversion)
 }

--- a/rust/kona/bin/client/src/single.rs
+++ b/rust/kona/bin/client/src/single.rs
@@ -206,5 +206,11 @@ where
         .get_exact(PreimageKey::new_keccak256(*agreed_l2_output_root), output_preimage.as_mut())
         .await?;
 
+    if output_preimage[..32] != [0u8; 32] {
+        return Err(OracleProviderError::UnknownOutputVersion(B256::from_slice(
+            &output_preimage[..32],
+        )));
+    }
+
     output_preimage[96..128].try_into().map_err(OracleProviderError::SliceConversion)
 }

--- a/rust/kona/bin/client/tests/common/mod.rs
+++ b/rust/kona/bin/client/tests/common/mod.rs
@@ -1,0 +1,51 @@
+//! Shared helpers for integration tests under `tests/`.
+
+#![allow(dead_code)]
+
+use async_trait::async_trait;
+use kona_preimage::{
+    HintWriterClient, PreimageKey, PreimageOracleClient,
+    errors::{PreimageOracleError, PreimageOracleResult},
+};
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::Mutex;
+
+#[derive(Clone, Debug, Default)]
+pub struct MockOracle {
+    preimages: Arc<Mutex<HashMap<PreimageKey, Vec<u8>>>>,
+}
+
+impl MockOracle {
+    pub fn from_preimages(preimages: HashMap<PreimageKey, Vec<u8>>) -> Self {
+        Self { preimages: Arc::new(Mutex::new(preimages)) }
+    }
+
+    pub fn single(key: PreimageKey, value: Vec<u8>) -> Self {
+        let mut preimages = HashMap::new();
+        preimages.insert(key, value);
+        Self::from_preimages(preimages)
+    }
+}
+
+#[async_trait]
+impl PreimageOracleClient for MockOracle {
+    async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
+        self.preimages.lock().await.get(&key).cloned().ok_or(PreimageOracleError::KeyNotFound)
+    }
+
+    async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
+        let data = self.get(key).await?;
+        if data.len() != buf.len() {
+            return Err(PreimageOracleError::BufferLengthMismatch(buf.len(), data.len()));
+        }
+        buf.copy_from_slice(&data);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl HintWriterClient for MockOracle {
+    async fn write(&self, _hint: &str) -> PreimageOracleResult<()> {
+        Ok(())
+    }
+}

--- a/rust/kona/bin/client/tests/output_root.rs
+++ b/rust/kona/bin/client/tests/output_root.rs
@@ -1,0 +1,97 @@
+//! Tests for the output-root preimage validation in the helpers that decode
+//! an L2 output root into the safe head block hash.
+//!
+//! Two parallel helpers are covered:
+//!   * `single::fetch_safe_head_hash` (non-interop fault proof path, uses `get_exact` with a `[u8;
+//!     128]` buffer).
+//!   * `interop::util::fetch_output_block_hash` (interop path, uses `.get()` and validates the
+//!     length explicitly).
+//!
+//! For each helper we assert that both the version-word and the preimage-
+//! length guard reject malformed inputs, so refactors to either function are
+//! caught independently.
+
+use alloy_primitives::B256;
+use kona_client::{interop, single};
+use kona_preimage::{PreimageKey, errors::PreimageOracleError};
+use kona_proof::errors::OracleProviderError;
+
+mod common;
+use common::MockOracle;
+
+fn b256(fill: u8) -> B256 {
+    B256::from([fill; 32])
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_safe_head_hash_rejects_unknown_output_version() {
+    let agreed_root = b256(0xAA);
+    let mut bad_preimage = [0u8; 128];
+    bad_preimage[0] = 0x01; // non-V0 version word; [96..128] stays zero
+    let oracle =
+        MockOracle::single(PreimageKey::new_keccak256(*agreed_root), bad_preimage.to_vec());
+
+    let err = single::fetch_safe_head_hash(&oracle, agreed_root).await.unwrap_err();
+    match err {
+        OracleProviderError::UnknownOutputVersion(version) => {
+            assert_eq!(version[0], 0x01);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_safe_head_hash_rejects_wrong_preimage_length() {
+    // `get_exact` with a `[u8; 128]` buffer is what enforces the length here;
+    // this test guards against a future refactor swapping to `get`.
+    let agreed_root = b256(0xAA);
+    let oracle = MockOracle::single(PreimageKey::new_keccak256(*agreed_root), vec![0u8; 127]);
+
+    let err = single::fetch_safe_head_hash(&oracle, agreed_root).await.unwrap_err();
+    match err {
+        OracleProviderError::Preimage(PreimageOracleError::BufferLengthMismatch(
+            expected,
+            actual,
+        )) => {
+            assert_eq!(expected, 128);
+            assert_eq!(actual, 127);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_output_block_hash_rejects_unknown_output_version() {
+    let output_root = b256(0xAA);
+    let mut bad_preimage = vec![0u8; 128];
+    bad_preimage[0] = 0x01; // non-V0 version word
+    let oracle = MockOracle::single(PreimageKey::new_keccak256(*output_root), bad_preimage);
+
+    let err = interop::util::fetch_output_block_hash(&oracle, output_root, 10).await.unwrap_err();
+    match err {
+        OracleProviderError::UnknownOutputVersion(version) => {
+            assert_eq!(version[0], 0x01);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_output_block_hash_rejects_wrong_preimage_length() {
+    // 127-byte preimage with a V0 version word; without the length guard this
+    // slips past the version check and then panics on the [96..128] slice.
+    let output_root = b256(0xAA);
+    let oracle = MockOracle::single(PreimageKey::new_keccak256(*output_root), vec![0u8; 127]);
+
+    let err = interop::util::fetch_output_block_hash(&oracle, output_root, 10).await.unwrap_err();
+    match err {
+        OracleProviderError::Preimage(PreimageOracleError::BufferLengthMismatch(
+            expected,
+            actual,
+        )) => {
+            assert_eq!(expected, 128);
+            assert_eq!(actual, 127);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}

--- a/rust/kona/bin/client/tests/trace_extension.rs
+++ b/rust/kona/bin/client/tests/trace_extension.rs
@@ -6,6 +6,7 @@ use kona_preimage::{
     HintWriterClient, PreimageKey, PreimageOracleClient,
     errors::{PreimageOracleError, PreimageOracleResult},
 };
+use kona_proof::errors::OracleProviderError;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 
@@ -32,6 +33,13 @@ impl PreimageOracleClient for MockOracle {
             return Err(PreimageOracleError::BufferLengthMismatch(buf.len(), data.len()));
         }
         buf.copy_from_slice(&data);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl HintWriterClient for MockOracle {
+    async fn write(&self, _hint: &str) -> PreimageOracleResult<()> {
         Ok(())
     }
 }
@@ -147,4 +155,23 @@ async fn does_not_short_circuit_on_root_match_at_different_block() {
     let hints = MockHintWriter::default();
 
     assert!(run(oracle, hints).await.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_safe_head_hash_rejects_unknown_output_version() {
+    let agreed_root = b256(0xAA);
+    let mut bad_preimage = [0u8; 128];
+    bad_preimage[0] = 0x01; // non-V0 version word; [96..128] stays zero
+
+    let mut preimages = HashMap::new();
+    preimages.insert(PreimageKey::new_keccak256(*agreed_root), bad_preimage.to_vec());
+    let oracle = MockOracle::from_preimages(preimages);
+
+    let err = kona_client::single::fetch_safe_head_hash(&oracle, agreed_root).await.unwrap_err();
+    match err {
+        OracleProviderError::UnknownOutputVersion(version) => {
+            assert_eq!(version[0], 0x01);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
 }

--- a/rust/kona/bin/client/tests/trace_extension.rs
+++ b/rust/kona/bin/client/tests/trace_extension.rs
@@ -2,47 +2,12 @@ use alloy_consensus::Header;
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use kona_client::single::{FaultProofProgramError, run};
-use kona_preimage::{
-    HintWriterClient, PreimageKey, PreimageOracleClient,
-    errors::{PreimageOracleError, PreimageOracleResult},
-};
-use kona_proof::errors::OracleProviderError;
+use kona_preimage::{HintWriterClient, PreimageKey, errors::PreimageOracleResult};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 
-#[derive(Clone, Debug, Default)]
-struct MockOracle {
-    preimages: Arc<Mutex<HashMap<PreimageKey, Vec<u8>>>>,
-}
-
-impl MockOracle {
-    fn from_preimages(preimages: HashMap<PreimageKey, Vec<u8>>) -> Self {
-        Self { preimages: Arc::new(Mutex::new(preimages)) }
-    }
-}
-
-#[async_trait]
-impl PreimageOracleClient for MockOracle {
-    async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
-        self.preimages.lock().await.get(&key).cloned().ok_or(PreimageOracleError::KeyNotFound)
-    }
-
-    async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
-        let data = self.get(key).await?;
-        if data.len() != buf.len() {
-            return Err(PreimageOracleError::BufferLengthMismatch(buf.len(), data.len()));
-        }
-        buf.copy_from_slice(&data);
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl HintWriterClient for MockOracle {
-    async fn write(&self, _hint: &str) -> PreimageOracleResult<()> {
-        Ok(())
-    }
-}
+mod common;
+use common::MockOracle;
 
 #[derive(Clone, Debug, Default)]
 struct MockHintWriter {
@@ -155,23 +120,4 @@ async fn does_not_short_circuit_on_root_match_at_different_block() {
     let hints = MockHintWriter::default();
 
     assert!(run(oracle, hints).await.is_err());
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn fetch_safe_head_hash_rejects_unknown_output_version() {
-    let agreed_root = b256(0xAA);
-    let mut bad_preimage = [0u8; 128];
-    bad_preimage[0] = 0x01; // non-V0 version word; [96..128] stays zero
-
-    let mut preimages = HashMap::new();
-    preimages.insert(PreimageKey::new_keccak256(*agreed_root), bad_preimage.to_vec());
-    let oracle = MockOracle::from_preimages(preimages);
-
-    let err = kona_client::single::fetch_safe_head_hash(&oracle, agreed_root).await.unwrap_err();
-    match err {
-        OracleProviderError::UnknownOutputVersion(version) => {
-            assert_eq!(version[0], 0x01);
-        }
-        other => panic!("unexpected error: {other:?}"),
-    }
 }

--- a/rust/kona/crates/proof/proof/src/errors.rs
+++ b/rust/kona/crates/proof/proof/src/errors.rs
@@ -5,6 +5,7 @@
 //! context about failures during proof generation and data retrieval.
 
 use alloc::string::{String, ToString};
+use alloy_primitives::B256;
 use kona_derive::{PipelineError, PipelineErrorKind};
 use kona_mpt::{OrderedListWalkerError, TrieNodeError};
 use kona_preimage::errors::PreimageOracleError;
@@ -102,6 +103,10 @@ pub enum OracleProviderError {
     /// * `0` - The unknown chain ID that was encountered
     #[error("Unknown chain ID: {0}")]
     UnknownChainId(u64),
+    /// Output-root preimage carries an unrecognized version word.
+    /// Only `OutputVersionV0` (the zero word) is currently defined.
+    #[error("Unknown L2 output version: {0}")]
+    UnknownOutputVersion(B256),
 }
 
 impl From<OracleProviderError> for PipelineErrorKind {


### PR DESCRIPTION
## Summary

- Both `fetch_safe_head_hash` (`rust/kona/bin/client/src/single.rs`) and `fetch_output_block_hash` (`rust/kona/bin/client/src/interop/util.rs`) sliced `output_preimage[96..128]` as the L2 block hash without checking the version word at `[0..32]`.
- Only `OutputVersionV0` (the zero word) is currently defined; op-program's `UnmarshalOutput` already rejects any non-V0 word. This brings kona to parity.
- Adds `OracleProviderError::UnknownOutputVersion(B256)` and inlines the version check at both call sites.
- **Length validation:** `fetch_output_block_hash` additionally rejects any preimage whose length is not exactly 128 bytes, returning `Preimage(BufferLengthMismatch(128, n))`. This matches the implicit guarantee that `fetch_safe_head_hash` already gets from `get_exact` against a fixed `[u8; 128]` buffer — without it, a short preimage would silently fall past the version check and panic on the `[96..128]` slice, and an oversize preimage would be read past its meaningful payload.

## Op-program parity

`op-service/eth/output.go` defines `OutputVersionV0 = Bytes32{}` (the zero word) and `ErrInvalidOutputVersion`. `UnmarshalOutput` (`op-service/eth/output.go:65-77`) checks the leading 32 bytes:

```go
ver := Bytes32(data[:32])
switch ver {
case OutputVersionV0:
    return unmarshalOutputV0(data)
default:
    return nil, fmt.Errorf("%w: %s", ErrInvalidOutputVersion, ver)
}
```

`OutputByRoot` (`op-program/host/prefetcher/prefetcher.go`) calls `UnmarshalOutput` and surfaces `ErrInvalidOutputVersion` as a fatal error. Kona's equivalent call sites previously skipped this check; this PR adds the same predicate, with `OracleProviderError::UnknownOutputVersion(B256)` as the explicit forensic signal.

## Why this is not a consensus fix

The existing defense-in-depth chain (downstream `KeyNotFound` or final output-root mismatch) already refuses a hypothetical V1 claim. The residual is forensic: today's kona masks "unknown output version" as a generic `InvalidClaim` deeper in the pipeline, eroding incident-response signal. Folding the consumer side onto `kona_protocol::OutputRoot` (which already exists with `VERSION: u8 = 0`) is the principled refactor and is deliberately deferred to keep this diff narrow (i.e. adding a proper `decode` method to `kona_protocol::OutputRoot` and using it everywhere).

## Test plan

Tests live in `rust/kona/bin/client/tests/output_root.rs`, with the shared `MockOracle` factored into `rust/kona/bin/client/tests/common/mod.rs`:

- [x] `fetch_safe_head_hash_rejects_unknown_output_version` — non-V0 version word returns `UnknownOutputVersion`.
- [x] `fetch_safe_head_hash_rejects_wrong_preimage_length` — 127-byte preimage returns `BufferLengthMismatch(128, 127)` from `get_exact`. Regression guard against a refactor swapping `get_exact` for `get`.
- [x] `fetch_output_block_hash_rejects_unknown_output_version` — symmetric to the above.
- [x] `fetch_output_block_hash_rejects_wrong_preimage_length` — symmetric to the above; explicit length guard in the function body (since this site uses `.get()` returning `Vec<u8>`, not `get_exact`).
- [x] Red/green TDD verified on the length tests: removing the new length guard makes the test fail with `range end index 128 out of range for slice of length 127`.
- [x] `cargo nextest run -p kona-client` — 69/69 pass (4 new tests).
- [x] `just l` (fmt-check + clippy `--workspace --all-features --all-targets -- -D warnings` + lint-docs) clean.
- [x] `just check-no-std` clean (errors.rs lives in a `no_std`-capable crate; new test code is std-gated).

## Visibility

`interop::util` and `fetch_output_block_hash` are promoted from `pub(crate)` to `pub` so the integration tests in `tests/output_root.rs` can reach them. This mirrors `single::fetch_safe_head_hash`, which has been `pub` since the original refactor for the same reason. `kona-client` is `publish = false` and has no external consumers beyond these integration tests.

## Notes (out of scope)

- **ELF / Cannon prestate.** ELF binary changes → prestate hashes change. Regen of `prestate-artifacts-cannon{,-interop}/` and `version.json` happens on the standard kona release cadence, not in this PR.
- **FPVM stderr.** `#[client_entry]` prints errors with `{:?}` (Debug), so the FPVM stderr shows `OracleProviderError(UnknownOutputVersion(0x01…))` rather than the crafted Display string. Off-chain only (Cannon discards fd 2); the variant *name* is the actionable forensic signal.