### PR TITLE
op-interop-filter: support legacy check access list format

### DIFF
--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -36,6 +36,9 @@ type Backend struct {
 	// Passthrough mode: all transactions pass without filtering
 	passthrough bool
 
+	// Compatibility mode for legacy clients that omit executing chainID.
+	legacyCheckAccessListFormat bool
+
 	ctx    context.Context
 	cancel context.CancelFunc
 
@@ -45,11 +48,12 @@ type Backend struct {
 
 // BackendParams contains parameters for creating a Backend.
 type BackendParams struct {
-	Logger         log.Logger
-	Metrics        metrics.Metricer
-	Chains         map[eth.ChainID]ChainIngester
-	CrossValidator CrossValidator
-	Passthrough    bool
+	Logger                      log.Logger
+	Metrics                     metrics.Metricer
+	Chains                      map[eth.ChainID]ChainIngester
+	CrossValidator              CrossValidator
+	Passthrough                 bool
+	LegacyCheckAccessListFormat bool
 
 	ReorgRecoveryEnabled bool
 }
@@ -59,14 +63,15 @@ func NewBackend(parentCtx context.Context, params BackendParams) *Backend {
 	ctx, cancel := context.WithCancel(parentCtx)
 
 	return &Backend{
-		log:                  params.Logger,
-		metrics:              params.Metrics,
-		chains:               params.Chains,
-		crossValidator:       params.CrossValidator,
-		passthrough:          params.Passthrough,
-		ctx:                  ctx,
-		cancel:               cancel,
-		reorgRecoveryEnabled: params.ReorgRecoveryEnabled,
+		log:                         params.Logger,
+		metrics:                     params.Metrics,
+		chains:                      params.Chains,
+		crossValidator:              params.CrossValidator,
+		passthrough:                 params.Passthrough,
+		legacyCheckAccessListFormat: params.LegacyCheckAccessListFormat,
+		ctx:                         ctx,
+		cancel:                      cancel,
+		reorgRecoveryEnabled:        params.ReorgRecoveryEnabled,
 	}
 }
 
@@ -202,9 +207,12 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 	}
 
 	if _, ok := b.chains[execDescriptor.ChainID]; !ok {
-		b.metrics.RecordCheckAccessList(false)
-		b.metrics.RecordCheckAccessListRejection("unknown_chain")
-		return fmt.Errorf("executing chain %s: %w", execDescriptor.ChainID, types.ErrUnknownChain)
+		if !b.legacyCheckAccessListFormat {
+			b.metrics.RecordCheckAccessList(false)
+			b.metrics.RecordCheckAccessListRejection("unknown_chain")
+			return fmt.Errorf("executing chain %s: %w", execDescriptor.ChainID, types.ErrUnknownChain)
+		}
+		b.log.Debug("Supporting legacy check access list format", "executing_chain", execDescriptor.ChainID)
 	}
 
 	remaining := inboxEntries

--- a/op-interop-filter/filter/backend_test.go
+++ b/op-interop-filter/filter/backend_test.go
@@ -275,3 +275,13 @@ func TestBackend_CheckAccessList(t *testing.T) {
 	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0))
 	require.NoError(t, err)
 }
+
+func TestBackend_CheckAccessList_SupportLegacyCheckAccessListFormat(t *testing.T) {
+	backend, mock := newTestBackendWithMockChain(testChainA)
+	backend.legacyCheckAccessListFormat = true
+	mock.SetReady(true)
+	mock.SetLatestTimestamp(200)
+
+	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(0, 150, 0))
+	require.NoError(t, err)
+}

--- a/op-interop-filter/filter/config.go
+++ b/op-interop-filter/filter/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	ValidationInterval          time.Duration // Interval for cross-chain validation (default: 500ms)
 	ReorgRecoveryEnabled        bool          // If true, automatically rewinds reorg-triggered failsafe to finalized
 	Passthrough                 bool          // If true, all transactions pass through without filtering
+	LegacyCheckAccessListFormat bool          // If true, allows access list requests that omit executing chainID
 	RPCConcurrency              int           // Max concurrent RPC requests per chain (default: 100)
 	FetchConcurrency            int           // Number of blocks to fetch concurrently (default: 64)
 
@@ -145,6 +146,7 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 		ValidationInterval:          validationInterval,
 		ReorgRecoveryEnabled:        ctx.Bool(flags.ReorgRecoveryEnabledFlag.Name),
 		Passthrough:                 ctx.Bool(flags.DangerouslyEnablePassthroughFlag.Name),
+		LegacyCheckAccessListFormat: ctx.Bool(flags.SupportLegacyCheckAccessListFormatFlag.Name),
 		RPCConcurrency:              rpcConcurrency,
 		FetchConcurrency:            fetchConcurrency,
 		LogConfig:                   oplog.ReadCLIConfig(ctx),

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -68,6 +68,9 @@ func Main(version string) cliapp.LifecycleAction {
 		if cfg.Passthrough {
 			l.Warn("PASSTHROUGH MODE ENABLED: all transactions will bypass interop filtering")
 		}
+		if cfg.LegacyCheckAccessListFormat {
+			l.Warn("LEGACY CHECK ACCESS LIST FORMAT ENABLED: supervisor_checkAccessList will not reject missing executing chain IDs")
+		}
 
 		if !cfg.MessageExpiryWindowExplicit {
 			l.Debug("Using default message expiry window", "window", DefaultMessageExpiryWindow)
@@ -221,11 +224,12 @@ func (s *Service) initBackend(ctx context.Context, cfg *Config) error {
 	)
 
 	s.backend = NewBackend(ctx, BackendParams{
-		Logger:         s.log,
-		Metrics:        s.metrics,
-		Chains:         chains,
-		CrossValidator: crossValidator,
-		Passthrough:    cfg.Passthrough,
+		Logger:                      s.log,
+		Metrics:                     s.metrics,
+		Chains:                      chains,
+		CrossValidator:              crossValidator,
+		Passthrough:                 cfg.Passthrough,
+		LegacyCheckAccessListFormat: cfg.LegacyCheckAccessListFormat,
 
 		ReorgRecoveryEnabled: cfg.ReorgRecoveryEnabled,
 	})

--- a/op-interop-filter/flags/flags.go
+++ b/op-interop-filter/flags/flags.go
@@ -121,6 +121,11 @@ var (
 		EnvVars: prefixEnvVars("FETCH_CONCURRENCY"),
 		Value:   DefaultFetchConcurrency,
 	}
+	SupportLegacyCheckAccessListFormatFlag = &cli.BoolFlag{
+		Name:    "support-legacy-check-access-list-format",
+		Usage:   "Support legacy supervisor_checkAccessList requests that omit executing chainID. DANGEROUS: intended only for compatibility with legacy clients; access-list source-chain validation still runs.",
+		EnvVars: prefixEnvVars("SUPPORT_LEGACY_CHECK_ACCESS_LIST_FORMAT"),
+	}
 	DangerouslyEnablePassthroughFlag = &cli.BoolFlag{
 		Name:    "dangerously-enable-passthrough",
 		Usage:   "Allow all transactions through without interop filtering. DANGEROUS: disables all executing message validation.",
@@ -148,6 +153,7 @@ var optionalFlags = []cli.Flag{
 	ReorgRecoveryEnabledFlag,
 	RPCConcurrencyFlag,
 	FetchConcurrencyFlag,
+	SupportLegacyCheckAccessListFormatFlag,
 	DangerouslyEnablePassthroughFlag,
 }
 


### PR DESCRIPTION
## Summary
- add a default-off compatibility flag for legacy supervisor_checkAccessList callers that omit executing chainID
- preserve access-list parsing and source-chain validation when the flag is enabled
- warn at startup when legacy format support is enabled

## Tests
- go test ./op-interop-filter/...