### PR TITLE
fix(kona-proof-interop/boot): reject future-timestamped prestate

### DIFF
--- a/rust/kona/bin/client/src/interop/mod.rs
+++ b/rust/kona/bin/client/src/interop/mod.rs
@@ -84,9 +84,10 @@ where
     // sub-problem.
     match boot.agreed_pre_state {
         PreState::SuperRoot(ref super_root) => {
-            // If the claimed L2 block timestamp is less than the super root timestamp, the
-            // post-state must be the agreed pre-state to accommodate trace extension.
-            if super_root.timestamp >= boot.claimed_l2_timestamp {
+            // At the trace-extension boundary, the post-state must equal the agreed pre-state.
+            // The strict-`>` case is guarded against in `BootInfo::load` (panics there); this
+            // arm only handles the legitimate `==` boundary.
+            if super_root.timestamp == boot.claimed_l2_timestamp {
                 if boot.agreed_pre_state_commitment == boot.claimed_post_state {
                     return Ok(());
                 } else {
@@ -101,10 +102,10 @@ where
             sub_transition(oracle, boot, evm_factory).await
         }
         PreState::TransitionState(ref transition_state) => {
-            // If the claimed L2 block timestamp is at or before the prestate timestamp, the
-            // post-state must be the agreed pre-state to accommodate trace extension. This
-            // mirrors the SuperRoot branch above.
-            if transition_state.pre_state.timestamp >= boot.claimed_l2_timestamp {
+            // At the trace-extension boundary, the post-state must equal the agreed pre-state.
+            // The strict-`>` case is guarded against in `BootInfo::load` (panics there); this
+            // arm only handles the legitimate `==` boundary, mirroring the SuperRoot arm above.
+            if transition_state.pre_state.timestamp == boot.claimed_l2_timestamp {
                 if boot.agreed_pre_state_commitment == boot.claimed_post_state {
                     return Ok(());
                 } else {

--- a/rust/kona/bin/client/tests/interop_trace_extension.rs
+++ b/rust/kona/bin/client/tests/interop_trace_extension.rs
@@ -1,5 +1,9 @@
-//! Trace-extension boundary tests for the interop `run()` dispatch on a
-//! `PreState::TransitionState` agreed prestate.
+//! Trace-extension boundary tests for the interop `run()` dispatch.
+//!
+//! Covers both `PreState::SuperRoot` and `PreState::TransitionState` agreed prestates at
+//! `prestate.timestamp == claimed_l2_timestamp` (legitimate boundary) and the strict-`>` case
+//! (invariant violation, must panic to match op-program; see
+//! `op-program/client/interop/interop.go:87-97`).
 
 use alloy_primitives::B256;
 use alloy_rlp::Encodable;
@@ -62,28 +66,35 @@ fn b256(fill: u8) -> B256 {
     B256::from([fill; 32])
 }
 
+const CHAIN_A: u64 = 9901;
+const CHAIN_B: u64 = 9902;
+const L1_CHAIN_ID: u64 = 9001;
+
+fn super_root(timestamp: u64) -> SuperRoot {
+    SuperRoot::new(
+        timestamp,
+        vec![
+            OutputRootWithChain::new(CHAIN_A, b256(0xA1)),
+            OutputRootWithChain::new(CHAIN_B, b256(0xB2)),
+        ],
+    )
+}
+
+fn transition_state_prestate(timestamp: u64) -> PreState {
+    PreState::TransitionState(TransitionState::new(super_root(timestamp), Vec::new(), 1))
+}
+
+fn super_root_prestate(timestamp: u64) -> PreState {
+    PreState::SuperRoot(super_root(timestamp))
+}
+
 // Synthetic chain IDs absent from the embedded registries, so `BootInfo::load`
 // uses the preimage-oracle fallback paths and the fixture stays self-contained.
 fn setup_interop_preimages(
-    prestate_timestamp: u64,
+    pre_state: PreState,
     claimed_l2_timestamp: u64,
     claimed_post_state: B256,
 ) -> (HashMap<PreimageKey, Vec<u8>>, B256) {
-    const CHAIN_A: u64 = 9901;
-    const CHAIN_B: u64 = 9902;
-    const L1_CHAIN_ID: u64 = 9001;
-
-    let pre_state = PreState::TransitionState(TransitionState::new(
-        SuperRoot::new(
-            prestate_timestamp,
-            vec![
-                OutputRootWithChain::new(CHAIN_A, b256(0xA1)),
-                OutputRootWithChain::new(CHAIN_B, b256(0xB2)),
-            ],
-        ),
-        Vec::new(),
-        1,
-    ));
     let mut pre_state_rlp = Vec::with_capacity(pre_state.length());
     pre_state.encode(&mut pre_state_rlp);
     let agreed_pre_state_commitment = pre_state.hash();
@@ -127,7 +138,8 @@ fn setup_interop_preimages(
 #[tokio::test(flavor = "multi_thread")]
 async fn trace_extension_transition_state_at_game_timestamp_accepts_matching_claim() {
     let t: u64 = 1000;
-    let (preimages, agreed_commit) = setup_interop_preimages(t, t, B256::ZERO);
+    let (preimages, agreed_commit) =
+        setup_interop_preimages(transition_state_prestate(t), t, B256::ZERO);
     let mut preimages = preimages;
     preimages.insert(PreimageKey::new_local(3), agreed_commit.as_slice().to_vec());
 
@@ -149,7 +161,8 @@ async fn trace_extension_transition_state_at_game_timestamp_accepts_matching_cla
 async fn trace_extension_transition_state_at_game_timestamp_rejects_mismatched_claim() {
     let t: u64 = 1000;
     let mismatched_claim = b256(0xCC);
-    let (preimages, agreed_commit) = setup_interop_preimages(t, t, mismatched_claim);
+    let (preimages, agreed_commit) =
+        setup_interop_preimages(transition_state_prestate(t), t, mismatched_claim);
 
     let oracle = MockOracle::from_preimages(preimages);
     let hints = MockHintWriter::default();
@@ -165,25 +178,43 @@ async fn trace_extension_transition_state_at_game_timestamp_rejects_mismatched_c
     }
 }
 
-// `prestate.timestamp > claimed_l2_timestamp` and `claim == prestate_commitment`: must accept
-// (covers the strict-`>` half of the `>=` arm, symmetric with the SuperRoot branch).
+// `prestate.timestamp > claimed_l2_timestamp`: invariant violation, must panic in
+// `BootInfo::load`. Matches op-program's defensive panic on the same condition.
 #[tokio::test(flavor = "multi_thread")]
-async fn trace_extension_transition_state_past_game_timestamp_accepts_matching_claim() {
-    let t: u64 = 1000;
-    let game_timestamp: u64 = t - 1;
-    let (preimages, agreed_commit) = setup_interop_preimages(t, game_timestamp, B256::ZERO);
+#[should_panic(expected = "agreed prestate timestamp")]
+async fn rejects_transition_state_with_timestamp_after_game_timestamp() {
+    let prestate_timestamp: u64 = 1000;
+    let claimed_l2_timestamp: u64 = prestate_timestamp - 1;
+    let (preimages, agreed_commit) = setup_interop_preimages(
+        transition_state_prestate(prestate_timestamp),
+        claimed_l2_timestamp,
+        B256::ZERO,
+    );
     let mut preimages = preimages;
     preimages.insert(PreimageKey::new_local(3), agreed_commit.as_slice().to_vec());
 
     let oracle = MockOracle::from_preimages(preimages);
     let hints = MockHintWriter::default();
 
-    let result = run(oracle, hints).await;
-    match result {
-        Ok(()) => {}
-        Err(FaultProofProgramError::InvalidClaim(expected, actual)) => {
-            panic!("expected Ok(()); got InvalidClaim(expected={expected}, actual={actual})");
-        }
-        Err(other) => panic!("unexpected error variant: {other:?}"),
-    }
+    let _ = run(oracle, hints).await;
+}
+
+// Mirror of the above for the `PreState::SuperRoot` arm: same invariant, same guard, same panic.
+#[tokio::test(flavor = "multi_thread")]
+#[should_panic(expected = "agreed prestate timestamp")]
+async fn rejects_super_root_with_timestamp_after_game_timestamp() {
+    let prestate_timestamp: u64 = 1000;
+    let claimed_l2_timestamp: u64 = prestate_timestamp - 1;
+    let (preimages, agreed_commit) = setup_interop_preimages(
+        super_root_prestate(prestate_timestamp),
+        claimed_l2_timestamp,
+        B256::ZERO,
+    );
+    let mut preimages = preimages;
+    preimages.insert(PreimageKey::new_local(3), agreed_commit.as_slice().to_vec());
+
+    let oracle = MockOracle::from_preimages(preimages);
+    let hints = MockHintWriter::default();
+
+    let _ = run(oracle, hints).await;
 }

--- a/rust/kona/crates/proof/proof-interop/src/boot.rs
+++ b/rust/kona/crates/proof/proof-interop/src/boot.rs
@@ -116,6 +116,20 @@ impl BootInfo {
         let agreed_pre_state =
             PreState::decode(&mut raw_pre_state.as_ref()).map_err(OracleProviderError::Rlp)?;
 
+        // INVARIANT: the honest actor never agrees to a prestate whose timestamp exceeds
+        // the dispute-game-pinned `claimed_l2_timestamp`. The oracle only verifies
+        // `key == keccak256(preimage)`, not the timestamp inside; without this guard a
+        // malicious proposer could register a future-timestamped prestate and use it as
+        // both starting and disputed claim at trace-extended bisection positions, where
+        // `claim == prestate ⇒ Ok(())` would resolve as `vmStatus = VALID`. Op-program
+        // panics on this condition (see `op-program/client/interop/interop.go:87-97`).
+        assert!(
+            agreed_pre_state.timestamp() <= l2_claim_block,
+            "agreed prestate timestamp {} is after the game timestamp {}",
+            agreed_pre_state.timestamp(),
+            l2_claim_block
+        );
+
         let chain_ids: Vec<_> = match agreed_pre_state {
             PreState::SuperRoot(ref super_root) => {
                 super_root.output_roots.iter().map(|r| r.chain_id).collect()


### PR DESCRIPTION
Add an `assert!` in `BootInfo::load` rejecting any agreed pre-state whose timestamp exceeds `claimed_l2_timestamp`. The honest actor never agrees to such a pre-state; op-program panics on the same condition (see `op-program/client/interop/interop.go:87-97`). Without this guard, a malicious proposer could register a future-timestamped SuperRoot or TransitionState preimage (the oracle only verifies `key == keccak256(preimage)`, not the timestamp inside) and commit the same hash as both starting and disputed claim at trace-extended bisection positions, where kona's `claim == prestate => Ok(())` arm would resolve as `vmStatus = VALID`.

With the guard, both arms of `interop::run` only need to handle the legitimate `==` boundary; tighten `>=` to `==` accordingly to make intent explicit.

Tests:
- Flip `trace_extension_transition_state_past_game_timestamp_accepts_matching_claim`
  to `#[should_panic]`; its previous assertion pinned the buggy lenient
  behavior. The flipped version is now the regression guard for the
  TransitionState arm.
- Add `rejects_super_root_with_timestamp_after_game_timestamp` as the symmetric guard for the SuperRoot arm.
- Refactor `setup_interop_preimages` to take a `PreState` so both arms reuse the fixture.

Resolves the "narrow both kona arms to `==`" follow-up flagged in #20717.