### PR TITLE
fix(kona-host): bound get_preimage retries to stop hot-spin on RPC failure

### DIFF
--- a/rust/kona/bin/host/src/backend/online.rs
+++ b/rust/kona/bin/host/src/backend/online.rs
@@ -9,8 +9,29 @@ use kona_preimage::{
 };
 use kona_proof::{Hint, errors::HintParsingError};
 use std::{collections::HashSet, hash::Hash, str::FromStr, sync::Arc};
-use tokio::sync::RwLock;
+use tokio::{sync::RwLock, time::Duration};
 use tracing::{debug, error, trace};
+
+/// Bounded retry policy for `OnlineHostBackend::get_preimage`. Private to the `online` module.
+#[allow(dead_code)]
+struct RetryPolicy {
+    /// Maximum number of `fetch_hint` invocations per `get_preimage` call.
+    max_attempts: usize,
+    /// Initial backoff between retry attempts.
+    initial_backoff: Duration,
+    /// Maximum backoff between retry attempts.
+    max_backoff: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 5,
+            initial_backoff: Duration::from_millis(50),
+            max_backoff: Duration::from_secs(2),
+        }
+    }
+}
 
 /// The [`OnlineHostBackendCfg`] trait is used to define the type configuration for the
 /// [`OnlineHostBackend`].
@@ -85,6 +106,14 @@ where
         self.proactive_hints.insert(hint_type);
         self
     }
+
+    /// Override the default retry policy. Test-only seam.
+    #[cfg(test)]
+    #[allow(clippy::missing_const_for_fn)]
+    fn with_retry_policy(self, _policy: RetryPolicy) -> Self {
+        // Commit 1 (red): no-op stub. Commit 2 replaces the body with the real assignment.
+        self
+    }
 }
 
 #[async_trait]
@@ -148,5 +177,211 @@ where
         }
 
         preimage.ok_or(PreimageOracleError::KeyNotFound)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kv::MemoryKeyValueStore;
+    use alloy_primitives::{B256, Bytes};
+    use kona_preimage::{PreimageKey, PreimageKeyType};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Mutex;
+
+    #[derive(Clone, Hash, Eq, PartialEq, Debug)]
+    struct TestHintType;
+
+    impl FromStr for TestHintType {
+        type Err = HintParsingError;
+
+        fn from_str(_: &str) -> Result<Self, Self::Err> {
+            Ok(Self)
+        }
+    }
+
+    enum TestBehavior {
+        AlwaysErr,
+        AlwaysOkNoWrite,
+        FlakyThenWrite { failures_remaining: usize, kv_key: B256, value: Vec<u8> },
+    }
+
+    #[derive(Clone)]
+    struct TestCfg {
+        behavior: Arc<Mutex<TestBehavior>>,
+        fetch_count: Arc<AtomicUsize>,
+    }
+
+    impl OnlineHostBackendCfg for TestCfg {
+        type HintType = TestHintType;
+        type Providers = ();
+    }
+
+    struct TestHintHandler;
+
+    #[async_trait]
+    impl HintHandler for TestHintHandler {
+        type Cfg = TestCfg;
+
+        async fn fetch_hint(
+            _hint: Hint<TestHintType>,
+            cfg: &Self::Cfg,
+            _providers: &(),
+            kv: SharedKeyValueStore,
+        ) -> Result<()> {
+            cfg.fetch_count.fetch_add(1, Ordering::SeqCst);
+            let mut behavior = cfg.behavior.lock().await;
+            match &mut *behavior {
+                TestBehavior::AlwaysErr => Err(anyhow::anyhow!("simulated rpc failure")),
+                TestBehavior::AlwaysOkNoWrite => Ok(()),
+                TestBehavior::FlakyThenWrite { failures_remaining, kv_key, value } => {
+                    if *failures_remaining > 0 {
+                        *failures_remaining -= 1;
+                        Err(anyhow::anyhow!("flaky"))
+                    } else {
+                        kv.write().await.set(*kv_key, value.clone())?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+
+    fn tiny_policy(max_attempts: usize) -> RetryPolicy {
+        RetryPolicy {
+            max_attempts,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(2),
+        }
+    }
+
+    fn shared_mem_kv() -> SharedKeyValueStore {
+        Arc::new(RwLock::new(MemoryKeyValueStore::new()))
+    }
+
+    fn make_backend(
+        behavior: TestBehavior,
+        max_attempts: usize,
+    ) -> (OnlineHostBackend<TestCfg, TestHintHandler>, TestCfg) {
+        let cfg = TestCfg {
+            behavior: Arc::new(Mutex::new(behavior)),
+            fetch_count: Arc::new(AtomicUsize::new(0)),
+        };
+        let kv = shared_mem_kv();
+        let backend = OnlineHostBackend::<TestCfg, TestHintHandler>::new(
+            cfg.clone(),
+            kv,
+            (),
+            TestHintHandler,
+        )
+        .with_retry_policy(tiny_policy(max_attempts));
+        (backend, cfg)
+    }
+
+    async fn set_hint(backend: &OnlineHostBackend<TestCfg, TestHintHandler>) {
+        *backend.last_hint.write().await = Some(Hint { ty: TestHintType, data: Bytes::new() });
+    }
+
+    #[tokio::test]
+    async fn no_hint_returns_key_not_found_immediately() {
+        let (backend, cfg) = make_backend(TestBehavior::AlwaysOkNoWrite, 3);
+        // Intentionally leave last_hint as None.
+        let preimage_key = PreimageKey::new([0xFFu8; 32], PreimageKeyType::Keccak256);
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(500), backend.get_preimage(preimage_key))
+                .await;
+
+        assert!(
+            result.is_ok(),
+            "call should return immediately when last_hint is None; baseline spins forever in the no-hint case"
+        );
+        let inner = result.unwrap();
+        assert!(
+            matches!(inner, Err(PreimageOracleError::KeyNotFound)),
+            "expected KeyNotFound, got {inner:?}"
+        );
+        assert_eq!(
+            cfg.fetch_count.load(Ordering::SeqCst),
+            0,
+            "fetch_hint must not be invoked when last_hint is None"
+        );
+    }
+
+    #[tokio::test]
+    async fn permanent_fetch_failure_returns_other_after_budget() {
+        let (backend, cfg) = make_backend(TestBehavior::AlwaysErr, 3);
+        set_hint(&backend).await;
+        let preimage_key = PreimageKey::new([0xFFu8; 32], PreimageKeyType::Keccak256);
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(500), backend.get_preimage(preimage_key))
+                .await;
+
+        assert!(
+            result.is_ok(),
+            "call should return Other after exhausting budget; baseline spins forever on permanent fetch failure"
+        );
+        let inner = result.unwrap();
+        assert!(
+            matches!(inner, Err(PreimageOracleError::Other(_))),
+            "expected Other(_), got {inner:?}"
+        );
+        assert_eq!(cfg.fetch_count.load(Ordering::SeqCst), 3, "budget must be consumed exactly");
+    }
+
+    #[tokio::test]
+    async fn fetch_ok_but_key_missing_counts_against_budget() {
+        let (backend, cfg) = make_backend(TestBehavior::AlwaysOkNoWrite, 3);
+        set_hint(&backend).await;
+        let preimage_key = PreimageKey::new([0xFFu8; 32], PreimageKeyType::Keccak256);
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(500), backend.get_preimage(preimage_key))
+                .await;
+
+        assert!(
+            result.is_ok(),
+            "Ok-but-missing case should be retry-bounded; baseline spins forever"
+        );
+        let inner = result.unwrap();
+        assert!(
+            matches!(inner, Err(PreimageOracleError::Other(_))),
+            "expected Other(_), got {inner:?}"
+        );
+        assert_eq!(
+            cfg.fetch_count.load(Ordering::SeqCst),
+            3,
+            "Ok-but-missing must count one attempt per call"
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_failure_then_success_returns_preimage() {
+        let preimage_key = PreimageKey::new([0xFFu8; 32], PreimageKeyType::Keccak256);
+        let kv_key: B256 = preimage_key.into();
+        let expected_preimage: Vec<u8> = b"the preimage bytes".to_vec();
+
+        let (backend, cfg) = make_backend(
+            TestBehavior::FlakyThenWrite {
+                failures_remaining: 2,
+                kv_key,
+                value: expected_preimage.clone(),
+            },
+            5,
+        );
+        set_hint(&backend).await;
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(500), backend.get_preimage(preimage_key))
+                .await
+                .expect("timeout: transient-then-success should resolve quickly");
+
+        assert_eq!(result.expect("expected Ok(preimage), got error"), expected_preimage);
+        assert_eq!(
+            cfg.fetch_count.load(Ordering::SeqCst),
+            3,
+            "two failures + one success = three attempts"
+        );
     }
 }

--- a/rust/kona/bin/host/src/backend/online.rs
+++ b/rust/kona/bin/host/src/backend/online.rs
@@ -9,11 +9,13 @@ use kona_preimage::{
 };
 use kona_proof::{Hint, errors::HintParsingError};
 use std::{collections::HashSet, hash::Hash, str::FromStr, sync::Arc};
-use tokio::{sync::RwLock, time::Duration};
+use tokio::{
+    sync::RwLock,
+    time::{Duration, sleep},
+};
 use tracing::{debug, error, trace};
 
 /// Bounded retry policy for `OnlineHostBackend::get_preimage`. Private to the `online` module.
-#[allow(dead_code)]
 struct RetryPolicy {
     /// Maximum number of `fetch_hint` invocations per `get_preimage` call.
     max_attempts: usize,
@@ -79,6 +81,8 @@ where
     proactive_hints: HashSet<C::HintType>,
     /// The last hint that was received.
     last_hint: Arc<RwLock<Option<Hint<C::HintType>>>>,
+    /// Retry policy for preimage prefetches in `get_preimage`.
+    retry_policy: RetryPolicy,
     /// Phantom marker for the [`HintHandler`].
     _hint_handler: std::marker::PhantomData<H>,
 }
@@ -97,6 +101,7 @@ where
             providers,
             proactive_hints: HashSet::default(),
             last_hint: Arc::new(RwLock::new(None)),
+            retry_policy: RetryPolicy::default(),
             _hint_handler: std::marker::PhantomData,
         }
     }
@@ -109,9 +114,8 @@ where
 
     /// Override the default retry policy. Test-only seam.
     #[cfg(test)]
-    #[allow(clippy::missing_const_for_fn)]
-    fn with_retry_policy(self, _policy: RetryPolicy) -> Self {
-        // Commit 1 (red): no-op stub. Commit 2 replaces the body with the real assignment.
+    const fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.retry_policy = policy;
         self
     }
 }
@@ -153,30 +157,52 @@ where
     async fn get_preimage(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
         trace!(target: "host_backend", "Pre-image requested. Key: {key}");
 
-        // Acquire a read lock on the key-value store.
-        let kv_lock = self.kv.read().await;
-        let mut preimage = kv_lock.get(key.into());
+        // Fast path: preimage already cached.
+        if let Some(preimage) = self.kv.read().await.get(key.into()) {
+            return Ok(preimage);
+        }
 
-        // Drop the read lock before beginning the retry loop.
-        drop(kv_lock);
+        // Snapshot the hint once. If no hint has been routed, the client must request a hint
+        // before requesting this key; matches op-program's `for ... && p.lastHint != ""` guard.
+        let hint = match self.last_hint.read().await.as_ref() {
+            Some(h) => h.clone(),
+            None => return Err(PreimageOracleError::KeyNotFound),
+        };
 
-        // Use a loop to keep retrying the prefetch as long as the key is not found
-        while preimage.is_none() {
-            if let Some(hint) = self.last_hint.read().await.as_ref() {
-                let value =
-                    H::fetch_hint(hint.clone(), &self.cfg, &self.providers, self.kv.clone()).await;
+        let policy = &self.retry_policy;
+        let mut backoff = policy.initial_backoff;
 
-                if let Err(e) = value {
-                    error!(target: "host_backend", "Failed to prefetch hint: {e}");
-                    continue;
+        for attempt in 1..=policy.max_attempts {
+            match H::fetch_hint(hint.clone(), &self.cfg, &self.providers, self.kv.clone()).await {
+                Ok(()) => {
+                    if let Some(preimage) = self.kv.read().await.get(key.into()) {
+                        return Ok(preimage);
+                    }
+                    debug!(
+                        target: "host_backend",
+                        "Prefetch attempt {attempt}/{} for key {key} succeeded but key still missing; retrying",
+                        policy.max_attempts
+                    );
                 }
+                Err(e) => {
+                    error!(
+                        target: "host_backend",
+                        "Prefetch attempt {attempt}/{} for key {key} failed: {e}",
+                        policy.max_attempts
+                    );
+                }
+            }
 
-                let kv_lock = self.kv.read().await;
-                preimage = kv_lock.get(key.into());
+            if attempt < policy.max_attempts {
+                sleep(backoff).await;
+                backoff = (backoff * 2).min(policy.max_backoff);
             }
         }
 
-        preimage.ok_or(PreimageOracleError::KeyNotFound)
+        Err(PreimageOracleError::Other(format!(
+            "prefetch failed after {} attempts for key {key}; see prior error logs for per-attempt failures",
+            policy.max_attempts
+        )))
     }
 }
 


### PR DESCRIPTION
## Summary

`OnlineHostBackend::get_preimage` (in `rust/kona/bin/host/src/backend/online.rs`) ran an unbounded `while preimage.is_none()` loop with no termination condition, hot-spinning at 100% CPU on three distinct paths:

1. **No-hint spin** — when `self.last_hint` is `None`, the inner `if let Some(hint) = ...` block is skipped, `preimage` stays `None`, and the loop iterates with no progress.
2. **Permanent fetch-failure spin** — when `fetch_hint` returns `Err` every iteration (RPC down, malformed payload, expired auth, network partition), `continue` retries instantly at full CPU.
3. **Fetch-Ok-but-key-missing spin** — when `fetch_hint` returns `Ok(())` but the kv entry for the requested key is still absent, the loop body completes and re-iterates immediately.

Operational impact: a prover whose L1/blob/L2 RPC fails mid-dispute saturates a CPU, propagates no error, and never recovers. If the spin coincides with a dispute-game bisection deadline, the prover loses by timeout. Also a bond-griefing vector for attackers who can disrupt a known prover's RPC during critical windows.

## Fix

Replace the unbounded loop with a bounded retry budget (`RetryPolicy`) plus exponential backoff. Default: 5 attempts, 50 ms initial → 2 s max. On budget exhaustion the call returns `Err(PreimageOracleError::Other(...))`; the no-hint case returns `Err(KeyNotFound)` immediately, matching op-program's `for ... && p.lastHint != ""` guard in `op-program/host/prefetcher/prefetcher.go:115-138`.

### Caller-visible behavior change

`get_preimage` can now return `Err` where on baseline it would hang. The error propagates via `VerifyingPreimageFetcher` → `PreimageOracleServer` → `start_oracle_server`, which exits the host process with `PreimageRequestFailed` — matching op-program's "exit on prefetch error" behavior. Operators get a real exit code and error logs to alert on instead of a silent 100%-CPU hang.

### Scope

- One file modified: `rust/kona/bin/host/src/backend/online.rs`.
- No trait signature changes. `HintHandler::fetch_hint` and `OnlineHostBackend::new` signatures unchanged → all three production call sites (`single/cfg.rs:183`, `interop/cfg.rs:207`, `interop/handler.rs:538`) compile and pass tests unchanged.
- No new variants on `PreimageOracleError`. No changes to `rust/kona/crates/proof/preimage/`.
- No new dependencies (`tokio` already pulled in with `full` features, giving `time::sleep` + `time::Duration`).
- No new public API surface: `RetryPolicy`, `with_retry_policy`, and the new `retry_policy` field are all private to the `online` module. `with_retry_policy` is `#[cfg(test)]`-gated as a test-only seam.

## Two-commit Red/Green sequencing

The fix lands as two commits to keep the bug-reproduction artifact in the tree:

- **Commit 1 (red)**: `test(kona-host): reproduce get_preimage hot-spin` — adds four `#[cfg(test)] mod tests` cases plus fixtures (`TestCfg`, `TestHintHandler`, `TestBehavior`), a private `RetryPolicy` struct, and a no-op `#[cfg(test)] with_retry_policy` stub. No production changes. Tests 1–3 time out on baseline `b44d62fefccdc94b014aba43241518baf0b9787b` (the timeout firing IS the proof that the bug exists); test 4 (transient-then-success regression guard) passes.
- **Commit 2 (green)**: `fix(kona-host): bound get_preimage retries` — adds the `retry_policy` field, makes `with_retry_policy` store the policy, rewrites `get_preimage` with the bounded retry loop. All four tests pass.

### Red baseline (Commit 1 only)

```
running 4 tests
test backend::online::tests::transient_failure_then_success_returns_preimage ... ok
test backend::online::tests::no_hint_returns_key_not_found_immediately ... FAILED
test backend::online::tests::fetch_ok_but_key_missing_counts_against_budget ... FAILED
test backend::online::tests::permanent_fetch_failure_returns_other_after_budget ... FAILED

thread 'backend::online::tests::no_hint_returns_key_not_found_immediately' panicked:
  call should return immediately when last_hint is None; baseline spins forever in the no-hint case
thread 'backend::online::tests::fetch_ok_but_key_missing_counts_against_budget' panicked:
  Ok-but-missing case should be retry-bounded; baseline spins forever
thread 'backend::online::tests::permanent_fetch_failure_returns_other_after_budget' panicked:
  call should return Other after exhausting budget; baseline spins forever on permanent fetch failure

test result: FAILED. 1 passed; 3 failed; finished in 0.50s
```

### Green fix (Commit 2)

```
running 4 tests
test backend::online::tests::no_hint_returns_key_not_found_immediately ... ok
test backend::online::tests::transient_failure_then_success_returns_preimage ... ok
test backend::online::tests::fetch_ok_but_key_missing_counts_against_budget ... ok
test backend::online::tests::permanent_fetch_failure_returns_other_after_budget ... ok

test result: ok. 4 passed; 0 failed; finished in 0.01s
```

## Test plan

- [x] Red baseline reproduced on `b44d62fefc` + Commit 1 only — tests 1, 2, 3 time out with the expected assertion messages; test 4 passes.
- [x] All four tests pass on the fix branch within 10 ms.
- [x] `mise exec -- cargo test -p kona-host` — 29/29 pass.
- [x] `mise exec -- just lint` (workspace clippy + fmt-check + rustdoc) — exit 0.
- [x] `mise exec -- cargo fmt --check` — clean.
- [x] `git diff origin/develop --name-only` shows only `rust/kona/bin/host/src/backend/online.rs` modified.

## Notes for reviewers

- **Structural termination proof**: the new loop is `for attempt in 1..=policy.max_attempts` over a `usize` with no `continue`-bypass — the compiler enforces termination. Future maintainers cannot reintroduce an unbounded loop without explicitly changing the construct (`for` → `while` / `loop`), which would be obvious in review.
- **Worst-case latency**: default policy bounds total wall time at ~3 seconds before failure — well below typical dispute-game bisection windows but enough to absorb genuine transient RPC blips. If telemetry post-ship motivates tuning, `RetryPolicy` can be promoted to a CLI/config knob in a follow-up; for now it stays a module-private implementation detail.
- Metrics integration was considered but skipped: kona-host has no metrics infrastructure today and wiring one in for a single counter would expand the diff significantly. Tracked as a follow-up.