### PR TITLE
fix(op-acceptance-tests): stabilize TestFollowSource_HeadsDivergeThenConverge

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
@@ -115,8 +115,10 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	dsl.CheckAll(t, divergenceChecks...)
 
 	// Freeze new block production so interop can catch cross-safe up to local-safe.
-	sys.L2ACL.StopSequencer()
-	sys.L2BCL.StopSequencer()
+	// Cross-safe only advances at timestamps where every chain has a local-safe block,
+	// so the two sequencers must end on the same unsafe height — otherwise the leader
+	// has a block at a timestamp the laggard will never produce, and cross-safe stalls.
+	dsl.StopSequencersSynced(t, sys.L2ACL, sys.L2BCL)
 	t.Cleanup(func() {
 		sys.L2ACL.StartSequencer()
 		sys.L2BCL.StartSequencer()

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -115,14 +116,37 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	dsl.CheckAll(t, divergenceChecks...)
 
 	// Freeze new block production so interop can catch cross-safe up to local-safe.
-	// Cross-safe only advances at timestamps where every chain has a local-safe block,
-	// so the two sequencers must end on the same unsafe height — otherwise the leader
-	// has a block at a timestamp the laggard will never produce, and cross-safe stalls.
-	dsl.StopSequencersSynced(t, sys.L2ACL, sys.L2BCL)
+	//
+	// Cross-safe only commits at timestamps where every chain has a local-safe
+	// block, so the chains must end at the same unsafe-head timestamp before
+	// ResumeInterop. StopSequencer is async between chains, so the chain stopped
+	// second can seal an extra block. Use the test sequencer to deterministically
+	// level the trailing chain back up to the leader.
+	sys.L2ACL.StopSequencer()
+	sys.L2BCL.StopSequencer()
 	t.Cleanup(func() {
 		sys.L2ACL.StartSequencer()
 		sys.L2BCL.StartSequencer()
 	})
+
+	require.NotNil(sys.TestSequencer, "TestSequencer required for timestamp alignment")
+	for range 10 {
+		unsafeA := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
+		unsafeB := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+		if unsafeA.Time == unsafeB.Time {
+			break
+		}
+		if unsafeA.Time < unsafeB.Time {
+			sys.TestSequencer.SequenceBlock(t, sys.L2A.ChainID(), unsafeA.Hash)
+		} else {
+			sys.TestSequencer.SequenceBlock(t, sys.L2B.ChainID(), unsafeB.Hash)
+		}
+	}
+	unsafeA := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
+	unsafeB := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	require.Equalf(unsafeA.Time, unsafeB.Time,
+		"chains must be at same unsafe timestamp before ResumeInterop; got A=%d B=%d",
+		unsafeA.Time, unsafeB.Time)
 
 	sys.Supernode.ResumeInterop()
 

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
@@ -129,7 +129,6 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 		sys.L2BCL.StartSequencer()
 	})
 
-	require.NotNil(sys.TestSequencer, "TestSequencer required for timestamp alignment")
 	for range 10 {
 		unsafeA := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
 		unsafeB := sys.L2ELB.BlockRefByLabel(eth.Unsafe)

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -136,23 +136,25 @@ func (cl *L2CLNode) StopSequencer() common.Hash {
 	return unsafeHead
 }
 
-// StopSequencersSynced stops every provided sequencer and leaves all chains at
-// the same unsafe head number (and therefore the same block timestamp, since
-// chains in the same interop set share a genesis time and block time).
+// StopSequencersSynced stops every provided sequencer and leaves all chains
+// with their unsafe head at the same L2 timestamp.
 //
 // Interop cross-safety advances one L2 timestamp at a time and waits for every
 // participating chain to have a local-safe block at that timestamp before
 // committing. If two sequencers are stopped via separate sequential RPCs, the
-// leader can sneak in an extra block (ts=N+blockTime) while the laggard is
-// still being stopped. Cross-safe then ceilings at the laggard's last
-// timestamp and never catches up to local-safe on the leader, leaving any
-// convergence wait stuck until it times out. See
+// chain stopped second can seal an extra block while the first is still being
+// stopped. Cross-safe then ceilings at the trailing chain's last timestamp and
+// never catches up to local-safe on the leader, leaving any convergence wait
+// stuck until it times out. See
 // https://github.com/ethereum-optimism/optimism/issues/19821.
 //
-// This helper stops all sequencers concurrently and then aligns them: any
-// chain whose unsafe head trails the maximum is restarted long enough to
-// produce the missing blocks and then stopped again. The loop is bounded —
-// if alignment cannot be achieved, the test fails fast rather than hanging.
+// Alignment is on unsafe-head timestamp, not block number, so the helper makes
+// no assumption about chains sharing a genesis time or block time — chains
+// with different rollup configs are tolerated. The helper stops all sequencers
+// concurrently, then restarts any chain whose unsafe-head timestamp trails the
+// maximum just long enough to produce blocks past that timestamp, then stops
+// it again. The alignment loop is bounded; if convergence cannot be reached,
+// the test fails fast rather than hanging.
 func StopSequencersSynced(t devtest.T, sequencers ...*L2CLNode) {
 	require := t.Require()
 	require.NotEmpty(sequencers, "StopSequencersSynced requires at least one sequencer")
@@ -172,31 +174,33 @@ func StopSequencersSynced(t devtest.T, sequencers ...*L2CLNode) {
 	}
 	require.NoError(g.Wait(), "concurrent StopSequencer failed")
 
-	// Bounded alignment: if any chain is behind the leader, level it up.
+	// Bounded alignment: if any chain trails the latest unsafe-head timestamp,
+	// restart it just long enough to catch up. A chain that overshoots becomes
+	// the new leader on the next iteration; convergence is bounded by maxRounds.
 	const maxRounds = 5
 	for round := range maxRounds {
 		heads := make([]eth.L2BlockRef, len(sequencers))
-		var maxNum uint64
+		var maxTime uint64
 		var leader *L2CLNode
 		for i, cl := range sequencers {
 			heads[i] = cl.HeadBlockRef(types.LocalUnsafe)
-			if heads[i].Number > maxNum {
-				maxNum = heads[i].Number
+			if heads[i].Time > maxTime {
+				maxTime = heads[i].Time
 				leader = cl
 			}
 		}
 
 		aligned := true
 		for i, cl := range sequencers {
-			if heads[i].Number == maxNum {
+			if heads[i].Time == maxTime {
 				continue
 			}
 			aligned = false
 			cl.log.Info("StopSequencersSynced: chain trails leader, levelling up",
 				"chain", cl.ChainID(),
-				"head", heads[i].Number,
+				"head_time", heads[i].Time,
 				"leader_chain", leader.ChainID(),
-				"target", maxNum,
+				"target_time", maxTime,
 				"round", round,
 			)
 			cl.StartSequencer()
@@ -208,18 +212,17 @@ func StopSequencersSynced(t devtest.T, sequencers ...*L2CLNode) {
 					if hErr != nil {
 						return hErr
 					}
-					if head.Number >= maxNum {
+					if head.Time >= maxTime {
 						return nil
 					}
-					return fmt.Errorf("waiting for chain %d to reach %d (current %d)", cl.ChainID(), maxNum, head.Number)
+					return fmt.Errorf("waiting for chain %d to reach ts %d (current %d)", cl.ChainID(), maxTime, head.Time)
 				})
-			cl.require.NoError(err, "failed to level up chain %d to target %d", cl.ChainID(), maxNum)
+			cl.require.NoError(err, "failed to level up chain %d to target ts %d", cl.ChainID(), maxTime)
 			cl.StopSequencer()
 		}
 		if aligned {
 			t.Logger().Info("StopSequencersSynced: chains aligned",
-				"unsafe_number", maxNum,
-				"unsafe_time", heads[0].Time,
+				"unsafe_time", maxTime,
 				"rounds", round,
 			)
 			return

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -8,10 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
-	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
@@ -134,102 +131,6 @@ func (cl *L2CLNode) StopSequencer() common.Hash {
 
 	cl.log.Info("Rollup node sequencer status", "chain", cl.ChainID(), "active", active, "unsafeHead", unsafeHead)
 	return unsafeHead
-}
-
-// StopSequencersSynced stops every provided sequencer and leaves all chains
-// with their unsafe head at the same L2 timestamp.
-//
-// Interop cross-safety advances one L2 timestamp at a time and waits for every
-// participating chain to have a local-safe block at that timestamp before
-// committing. If two sequencers are stopped via separate sequential RPCs, the
-// chain stopped second can seal an extra block while the first is still being
-// stopped. Cross-safe then ceilings at the trailing chain's last timestamp and
-// never catches up to local-safe on the leader, leaving any convergence wait
-// stuck until it times out. See
-// https://github.com/ethereum-optimism/optimism/issues/19821.
-//
-// Alignment is on unsafe-head timestamp, not block number, so the helper makes
-// no assumption about chains sharing a genesis time or block time — chains
-// with different rollup configs are tolerated. The helper stops all sequencers
-// concurrently, then restarts any chain whose unsafe-head timestamp trails the
-// maximum just long enough to produce blocks past that timestamp, then stops
-// it again. The alignment loop is bounded; if convergence cannot be reached,
-// the test fails fast rather than hanging.
-func StopSequencersSynced(t devtest.T, sequencers ...*L2CLNode) {
-	require := t.Require()
-	require.NotEmpty(sequencers, "StopSequencersSynced requires at least one sequencer")
-	if len(sequencers) == 1 {
-		sequencers[0].StopSequencer()
-		return
-	}
-
-	// Issue all StopSequencer RPCs concurrently to minimize the asymmetric-stop window.
-	var g errgroup.Group
-	for _, cl := range sequencers {
-		cl := cl
-		g.Go(func() error {
-			cl.StopSequencer()
-			return nil
-		})
-	}
-	require.NoError(g.Wait(), "concurrent StopSequencer failed")
-
-	// Bounded alignment: if any chain trails the latest unsafe-head timestamp,
-	// restart it just long enough to catch up. A chain that overshoots becomes
-	// the new leader on the next iteration; convergence is bounded by maxRounds.
-	const maxRounds = 5
-	for round := range maxRounds {
-		heads := make([]eth.L2BlockRef, len(sequencers))
-		var maxTime uint64
-		var leader *L2CLNode
-		for i, cl := range sequencers {
-			heads[i] = cl.HeadBlockRef(types.LocalUnsafe)
-			if heads[i].Time > maxTime {
-				maxTime = heads[i].Time
-				leader = cl
-			}
-		}
-
-		aligned := true
-		for i, cl := range sequencers {
-			if heads[i].Time == maxTime {
-				continue
-			}
-			aligned = false
-			cl.log.Info("StopSequencersSynced: chain trails leader, levelling up",
-				"chain", cl.ChainID(),
-				"head_time", heads[i].Time,
-				"leader_chain", leader.ChainID(),
-				"target_time", maxTime,
-				"round", round,
-			)
-			cl.StartSequencer()
-			// Poll faster than the block time so we stop close to the target and
-			// minimize overshoot that would force another alignment round.
-			err := retry.Do0(cl.ctx, 200, &retry.FixedStrategy{Dur: 100 * time.Millisecond},
-				func() error {
-					head, hErr := cl.headBlockRef(types.LocalUnsafe)
-					if hErr != nil {
-						return hErr
-					}
-					if head.Time >= maxTime {
-						return nil
-					}
-					return fmt.Errorf("waiting for chain %d to reach ts %d (current %d)", cl.ChainID(), maxTime, head.Time)
-				})
-			cl.require.NoError(err, "failed to level up chain %d to target ts %d", cl.ChainID(), maxTime)
-			cl.StopSequencer()
-		}
-		if aligned {
-			t.Logger().Info("StopSequencersSynced: chains aligned",
-				"unsafe_time", maxTime,
-				"rounds", round,
-			)
-			return
-		}
-	}
-	t.Logger().Error("StopSequencersSynced: chains did not converge within bounded rounds")
-	t.FailNow()
 }
 
 func (cl *L2CLNode) SetSequencerRecoverMode(b bool) error {

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
@@ -131,6 +134,99 @@ func (cl *L2CLNode) StopSequencer() common.Hash {
 
 	cl.log.Info("Rollup node sequencer status", "chain", cl.ChainID(), "active", active, "unsafeHead", unsafeHead)
 	return unsafeHead
+}
+
+// StopSequencersSynced stops every provided sequencer and leaves all chains at
+// the same unsafe head number (and therefore the same block timestamp, since
+// chains in the same interop set share a genesis time and block time).
+//
+// Interop cross-safety advances one L2 timestamp at a time and waits for every
+// participating chain to have a local-safe block at that timestamp before
+// committing. If two sequencers are stopped via separate sequential RPCs, the
+// leader can sneak in an extra block (ts=N+blockTime) while the laggard is
+// still being stopped. Cross-safe then ceilings at the laggard's last
+// timestamp and never catches up to local-safe on the leader, leaving any
+// convergence wait stuck until it times out. See
+// https://github.com/ethereum-optimism/optimism/issues/19821.
+//
+// This helper stops all sequencers concurrently and then aligns them: any
+// chain whose unsafe head trails the maximum is restarted long enough to
+// produce the missing blocks and then stopped again. The loop is bounded —
+// if alignment cannot be achieved, the test fails fast rather than hanging.
+func StopSequencersSynced(t devtest.T, sequencers ...*L2CLNode) {
+	require := t.Require()
+	require.NotEmpty(sequencers, "StopSequencersSynced requires at least one sequencer")
+	if len(sequencers) == 1 {
+		sequencers[0].StopSequencer()
+		return
+	}
+
+	// Issue all StopSequencer RPCs concurrently to minimize the asymmetric-stop window.
+	var g errgroup.Group
+	for _, cl := range sequencers {
+		cl := cl
+		g.Go(func() error {
+			cl.StopSequencer()
+			return nil
+		})
+	}
+	require.NoError(g.Wait(), "concurrent StopSequencer failed")
+
+	// Bounded alignment: if any chain is behind the leader, level it up.
+	const maxRounds = 5
+	for round := range maxRounds {
+		heads := make([]eth.L2BlockRef, len(sequencers))
+		var maxNum uint64
+		var leader *L2CLNode
+		for i, cl := range sequencers {
+			heads[i] = cl.HeadBlockRef(types.LocalUnsafe)
+			if heads[i].Number > maxNum {
+				maxNum = heads[i].Number
+				leader = cl
+			}
+		}
+
+		aligned := true
+		for i, cl := range sequencers {
+			if heads[i].Number == maxNum {
+				continue
+			}
+			aligned = false
+			cl.log.Info("StopSequencersSynced: chain trails leader, levelling up",
+				"chain", cl.ChainID(),
+				"head", heads[i].Number,
+				"leader_chain", leader.ChainID(),
+				"target", maxNum,
+				"round", round,
+			)
+			cl.StartSequencer()
+			// Poll faster than the block time so we stop close to the target and
+			// minimize overshoot that would force another alignment round.
+			err := retry.Do0(cl.ctx, 200, &retry.FixedStrategy{Dur: 100 * time.Millisecond},
+				func() error {
+					head, hErr := cl.headBlockRef(types.LocalUnsafe)
+					if hErr != nil {
+						return hErr
+					}
+					if head.Number >= maxNum {
+						return nil
+					}
+					return fmt.Errorf("waiting for chain %d to reach %d (current %d)", cl.ChainID(), maxNum, head.Number)
+				})
+			cl.require.NoError(err, "failed to level up chain %d to target %d", cl.ChainID(), maxNum)
+			cl.StopSequencer()
+		}
+		if aligned {
+			t.Logger().Info("StopSequencersSynced: chains aligned",
+				"unsafe_number", maxNum,
+				"unsafe_time", heads[0].Time,
+				"rounds", round,
+			)
+			return
+		}
+	}
+	t.Logger().Error("StopSequencersSynced: chains did not converge within bounded rounds")
+	t.FailNow()
 }
 
 func (cl *L2CLNode) SetSequencerRecoverMode(b bool) error {


### PR DESCRIPTION
## Description

The interop cross-safety verifier walks L2 timestamps one at a time and waits for every chain to have a local-safe block at that timestamp before committing. The test's two sequential `StopSequencer` RPCs are asynchronous between chains, so the chain stopped second can seal an extra block in the inter-RPC gap (~80 ms in the failing CI run). Cross-safe then permanently stalls at the trailing chain's last timestamp, the follower's cross-safe never catches up to local-safe, and the 3-minute convergence wait at `sync_test.go:127` times out.

After stopping the sequencers, deterministically align the chains to the same unsafe-head timestamp using `TestSequencer.SequenceBlock` (which builds exactly one block at `parent.Time + blockTime`) before resuming interop. No DSL changes; the fix is entirely in the test.

Refs #19821

## Test plan

- [x] Acceptance tests pass in CI (`memory-all-opn-op-reth`, `memory-all-opn-op-geth`)