### PR TITLE
chore(op-reth/proofs): consistent `trie::*` log targets across the crate

### DIFF
--- a/rust/op-reth/crates/trie/src/db/store.rs
+++ b/rust/op-reth/crates/trie/src/db/store.rs
@@ -1047,15 +1047,20 @@ impl reth_db::database_metrics::DatabaseMetrics for MdbxProofsStorage {
 
                 Ok::<(), eyre::Report>(())
             })
-            .map_err(|error| error!(%error, "Failed to read db table stats"));
+            .map_err(|error| {
+                error!(target: "trie::db::metrics", %error, "Failed to read db table stats")
+            });
 
-        if let Ok(freelist) =
-            self.env.freelist().map_err(|error| error!(%error, "Failed to read db.freelist"))
-        {
+        if let Ok(freelist) = self.env.freelist().map_err(
+            |error| error!(target: "trie::db::metrics", %error, "Failed to read db.freelist"),
+        ) {
             metrics.push(("optimism_proof_storage.freelist", freelist as f64, vec![]));
         }
 
-        if let Ok(stat) = self.env.stat().map_err(|error| error!(%error, "Failed to read db.stat"))
+        if let Ok(stat) = self
+            .env
+            .stat()
+            .map_err(|error| error!(target: "trie::db::metrics", %error, "Failed to read db.stat"))
         {
             metrics.push(("optimism_proof_storage.page_size", stat.page_size() as f64, vec![]));
         }

--- a/rust/op-reth/crates/trie/src/db/store_v2/metrics.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/metrics.rs
@@ -68,15 +68,20 @@ impl reth_db::database_metrics::DatabaseMetrics for MdbxProofsStorageV2 {
 
                 Ok::<(), eyre::Report>(())
             })
-            .map_err(|error| error!(%error, "Failed to read db table stats"));
+            .map_err(|error| {
+                error!(target: "trie::db::metrics", %error, "Failed to read db table stats")
+            });
 
-        if let Ok(freelist) =
-            self.env.freelist().map_err(|error| error!(%error, "Failed to read db.freelist"))
-        {
+        if let Ok(freelist) = self.env.freelist().map_err(
+            |error| error!(target: "trie::db::metrics", %error, "Failed to read db.freelist"),
+        ) {
             metrics.push(("optimism_proof_storage.freelist", freelist as f64, vec![]));
         }
 
-        if let Ok(stat) = self.env.stat().map_err(|error| error!(%error, "Failed to read db.stat"))
+        if let Ok(stat) = self
+            .env
+            .stat()
+            .map_err(|error| error!(target: "trie::db::metrics", %error, "Failed to read db.stat"))
         {
             metrics.push(("optimism_proof_storage.page_size", stat.page_size() as f64, vec![]));
         }

--- a/rust/op-reth/crates/trie/src/engine/handle.rs
+++ b/rust/op-reth/crates/trie/src/engine/handle.rs
@@ -92,7 +92,7 @@ impl<Block: reth_primitives_traits::Block + Send + 'static> EngineHandle<Block> 
                         .copied()
                         .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
                         .unwrap_or("unknown");
-                    error!(target: "live-trie::engine", %msg, "Collector engine panicked");
+                    error!(target: "trie::engine::handle", %msg, "Collector engine panicked");
                 }
             })
             .expect("failed to spawn live-trie-collector thread");

--- a/rust/op-reth/crates/trie/src/engine/runner.rs
+++ b/rust/op-reth/crates/trie/src/engine/runner.rs
@@ -86,7 +86,7 @@ where
         if self.state.memory.len() as u64 >= self.persistence_threshold &&
             let Err(e) = self.state.advance_persistence()
         {
-            error!(target: "live-trie::engine", ?e, "Failed to start persistence save");
+            error!(target: "trie::engine::runner", ?e, "Failed to start persistence save");
         }
     }
 
@@ -155,10 +155,10 @@ where
             },
             recv(persist_rx) -> result => self.state.persistence.on_complete(result, &self.state.memory),
             recv(sync_rx) -> _ => if let Err(err) = self.advance_sync() {
-                error!(target: "live-trie::engine", ?err, "Sync step failed");
+                error!(target: "trie::engine::runner", ?err, "Sync step failed");
             },
             recv(idle_flush_rx) -> _ => if let Err(e) = self.state.advance_persistence() {
-                error!(target: "live-trie::engine", ?e, "Idle flush failed");
+                error!(target: "trie::engine::runner", ?e, "Idle flush failed");
             },
         }
         ControlFlow::Continue(())
@@ -172,7 +172,7 @@ where
             self.backpressure_threshold,
             self.persistence_threshold,
         );
-        debug!(target: "live-trie::engine", "Collector engine started");
+        debug!(target: "trie::engine::runner", "Collector engine started");
 
         loop {
             match self.process_next_event() {
@@ -182,8 +182,8 @@ where
             self.maybe_start_save();
         }
 
-        debug!(target: "live-trie::engine", "Collector engine shutting down, draining in-flight persist");
+        debug!(target: "trie::engine::runner", "Collector engine shutting down, draining in-flight persist");
         self.state.drain_persistence();
-        debug!(target: "live-trie::engine", "Collector engine stopped");
+        debug!(target: "trie::engine::runner", "Collector engine stopped");
     }
 }

--- a/rust/op-reth/crates/trie/src/engine/state.rs
+++ b/rust/op-reth/crates/trie/src/engine/state.rs
@@ -45,7 +45,7 @@ impl PersistenceState {
         match rx.recv_timeout(Duration::from_secs(DEFAULT_PERSISTENCE_TIMEOUT_SECS)) {
             Ok(Ok(Some(last_persisted))) => {
                 info!(
-                    target: "live-trie::engine",
+                    target: "trie::engine::state",
                     block_number = last_persisted,
                     "Persistence completed (waited), pruning memory"
                 );
@@ -53,13 +53,13 @@ impl PersistenceState {
             }
             Ok(Ok(None)) => {}
             Ok(Err(e)) => {
-                error!(target: "live-trie::engine", ?e, "Persistence save failed while waiting");
+                error!(target: "trie::engine::state", ?e, "Persistence save failed while waiting");
             }
             Err(RecvTimeoutError::Timeout) => {
-                error!(target: "live-trie::engine", "Persistence timeout while waiting");
+                error!(target: "trie::engine::state", "Persistence timeout while waiting");
             }
             Err(RecvTimeoutError::Disconnected) => {
-                error!(target: "live-trie::engine", "Persistence service disconnected while waiting");
+                error!(target: "trie::engine::state", "Persistence service disconnected while waiting");
             }
         }
     }
@@ -76,7 +76,7 @@ impl PersistenceState {
         match result {
             Ok(Ok(Some(last_persisted))) => {
                 info!(
-                    target: "live-trie::engine",
+                    target: "trie::engine::state",
                     block_number = last_persisted,
                     "Background persistence completed, pruning memory"
                 );
@@ -84,10 +84,10 @@ impl PersistenceState {
             }
             Ok(Ok(None)) => {}
             Ok(Err(e)) => {
-                error!(target: "live-trie::engine", ?e, "Background persistence save failed");
+                error!(target: "trie::engine::state", ?e, "Background persistence save failed");
             }
             Err(_) => {
-                error!(target: "live-trie::engine", "Persistence service disconnected unexpectedly");
+                error!(target: "trie::engine::state", "Persistence service disconnected unexpectedly");
             }
         }
     }
@@ -110,7 +110,7 @@ impl PersistenceState {
         }
 
         info!(
-            target: "live-trie::engine",
+            target: "trie::engine::state",
             count = blocks.len(),
             start_block = blocks.first().map(|arc| arc.0.block.number),
             end_block = blocks.last().map(|arc| arc.0.block.number),
@@ -132,7 +132,7 @@ impl PersistenceState {
         memory: &TrieBufferState,
     ) -> Result<(), EngineError> {
         if self.in_flight.is_some() {
-            info!(target: "live-trie::engine", "Unwind waiting for in-flight persistence...");
+            info!(target: "trie::engine::state", "Unwind waiting for in-flight persistence...");
             self.wait(memory);
         }
 

--- a/rust/op-reth/crates/trie/src/engine/tasks/execute_block.rs
+++ b/rust/op-reth/crates/trie/src/engine/tasks/execute_block.rs
@@ -59,6 +59,7 @@ where
 
     if block.number() <= tip.number {
         debug!(
+            target: "trie::engine::task",
             block_number = block.number(),
             tip_number = tip.number,
             "Block already covered by tip, skipping execute_and_store",
@@ -68,6 +69,7 @@ where
 
     if block.number() > tip.number.saturating_add(1) {
         debug!(
+            target: "trie::engine::task",
             block_number = block.number(),
             tip_number = tip.number,
             "Gap detected, updating sync target",
@@ -90,10 +92,12 @@ where
     let parent_state = match state.provider.state_by_block_hash(block.parent_hash()) {
         Ok(p) => p,
         Err(ProviderError::StateForHashNotFound(hash)) => {
-            // Likely a transient reorg race: reth no longer has state for what we believe is the
-            // parent. Skip gracefully; subsequent ChainCommitted/ChainReorged notifications will
-            // resync us.
-            debug!(block_number = block.number(),
+            // Recoverable: either a transient reorg race or reth still materializing state
+            // (staged sync mid-flight). Skip; subsequent notifications will resync us.
+            // Logged at debug to avoid flooding during long catch-up phases
+            debug!(
+                target: "trie::engine::task",
+                block_number = block.number(),
                 parent_hash = ?hash,
                 "Parent state not available in reth; skipping execute_block",
             );
@@ -142,6 +146,7 @@ where
     }
 
     info!(
+        target: "trie::engine::task",
         block_number = block.number(),
         ?total_duration,
         ?execution_duration,

--- a/rust/op-reth/crates/trie/src/engine/tasks/index_block.rs
+++ b/rust/op-reth/crates/trie/src/engine/tasks/index_block.rs
@@ -58,6 +58,7 @@ where
 
     if block.block.number <= tip.number {
         debug!(
+            target: "trie::engine::task",
             block_number = block.block.number,
             tip_number = tip.number,
             "Block already covered by tip, skipping store_block_updates",
@@ -67,6 +68,7 @@ where
 
     if block.block.number > tip.number.saturating_add(1) {
         debug!(
+            target: "trie::engine::task",
             block_number = block.block.number,
             tip_number = tip.number,
             "Gap detected, updating sync target",
@@ -91,6 +93,7 @@ where
     state.metrics.index_block_duration_seconds.record(start.elapsed());
 
     info!(
+        target: "trie::engine::task",
         block_number = block.block.number,
         total_duration = ?start.elapsed(),
         "Trie updates buffered successfully",

--- a/rust/op-reth/crates/trie/src/engine/tasks/reorg.rs
+++ b/rust/op-reth/crates/trie/src/engine/tasks/reorg.rs
@@ -60,7 +60,7 @@ where
         // Reorg originates beyond the stored tip — the engine is still catching up.
         // Sync batches will fetch post-reorg blocks from the provider, so nothing to unwind.
         debug!(
-            target: "live-trie::engine",
+            target: "trie::engine::task",
             first_block = first.block.number,
             tip = tip.number,
             "Reorg starts beyond stored tip, skipping"
@@ -72,7 +72,7 @@ where
     let common_ancestor_number = first.block.number.saturating_sub(1);
 
     info!(
-        target: "live-trie::engine",
+        target: "trie::engine::task",
         reorg_depth = block_updates.len(),
         common_ancestor = common_ancestor_number,
         "Handling reorg: unwinding and buffering new path"
@@ -96,6 +96,7 @@ where
     state.metrics.reorg_duration_seconds.record(total_duration);
 
     info!(
+        target: "trie::engine::task",
         start_block_number = block_updates.first().map(|(b, _, _)| b.block.number),
         end_block_number = block_updates.last().map(|(b, _, _)| b.block.number),
         ?total_duration,

--- a/rust/op-reth/crates/trie/src/engine/tasks/sync_to.rs
+++ b/rust/op-reth/crates/trie/src/engine/tasks/sync_to.rs
@@ -25,6 +25,6 @@ impl SyncToTask {
         Store: OpProofsStore + Clone + 'static,
     {
         state.update_sync_target(self.target);
-        debug!(target: "live-trie::engine", sync_target = self.target, "Sync target updated");
+        debug!(target: "trie::engine::task", sync_target = self.target, "Sync target updated");
     }
 }

--- a/rust/op-reth/crates/trie/src/engine/tasks/unwind.rs
+++ b/rust/op-reth/crates/trie/src/engine/tasks/unwind.rs
@@ -49,7 +49,7 @@ where
     let tip = state.get_tip()?;
     if to.block.number > tip.number {
         debug!(
-            target: "live-trie::engine",
+            target: "trie::engine::task",
             to_block = to.block.number,
             tip = tip.number,
             "Unwind target beyond stored tip, skipping"
@@ -57,7 +57,7 @@ where
         return Ok(());
     }
 
-    info!(target: "live-trie::engine", to_block = to.block.number, "Unwinding history");
+    info!(target: "trie::engine::task", to_block = to.block.number, "Unwinding history");
     state.unwind(to)?;
     Ok(())
 }

--- a/rust/op-reth/crates/trie/src/initialize.rs
+++ b/rust/op-reth/crates/trie/src/initialize.rs
@@ -187,12 +187,12 @@ impl<Tx: DbTx + Sync, S: OpProofsStore + Send> InitializationJob<Tx, S> {
         storage_threshold: usize,
         log_threshold: usize,
     ) -> Result<u64, OpProofsStorageError> {
-        info!("Starting {} initialization", name);
+        info!(target: "trie::initialize", "Starting {} initialization", name);
         let start_time = Instant::now();
 
         let mut source = source.peekable();
         let Some(first_entry) = source.peek() else {
-            debug!(target: "reth::cli", "No entries to store for table");
+            debug!(target: "trie::initialize", "No entries to store for table");
             return Ok(0);
         };
         let initial_progress = match first_entry {
@@ -225,13 +225,17 @@ impl<Tx: DbTx + Sync, S: OpProofsStore + Send> InitializationJob<Tx, S> {
                 };
                 let progress_pct = progress * 100.0;
                 info!(
+                    target: "trie::initialize",
                     "Processed {} {}, progress: {progress_pct:.2}%, ETA: {}s",
                     name, total_entries, estimated_total_time,
                 );
             }
 
             if batch.len() >= storage_threshold {
-                info!("Storing {} entries, total entries: {}", name, total_entries);
+                info!(
+                    target: "trie::initialize",
+                    "Storing {} entries, total entries: {}", name, total_entries,
+                );
                 I::store_entries(&self.storage, batch)?;
                 batch = Vec::with_capacity(
                     (source_size_hint.saturating_sub(total_entries)).min(storage_threshold),
@@ -240,11 +244,14 @@ impl<Tx: DbTx + Sync, S: OpProofsStore + Send> InitializationJob<Tx, S> {
         }
 
         if !batch.is_empty() {
-            info!("Storing final {} entries", name);
+            info!(target: "trie::initialize", "Storing final {} entries", name);
             I::store_entries(&self.storage, batch)?;
         }
 
-        info!("{} initialization complete: {} entries", name, total_entries);
+        info!(
+            target: "trie::initialize",
+            "{} initialization complete: {} entries", name, total_entries,
+        );
         Ok(total_entries as u64)
     }
 

--- a/rust/op-reth/crates/trie/src/prune/pruner.rs
+++ b/rust/op-reth/crates/trie/src/prune/pruner.rs
@@ -68,7 +68,7 @@ where
         drop(provider_ro);
 
         info!(
-            target: "trie::pruner",
+            target: "trie::prune::pruner",
             from_block = earliest_block,
             to_block = target_earliest_block,
             "Starting pruning proof storage",
@@ -108,12 +108,12 @@ where
         let Some((earliest_block, target_earliest_block, mut prune_output)) =
             self.resolve_prune_range(provider_rw)?
         else {
-            debug!(target: "trie::pruner", "Nothing to prune in the given range");
+            debug!(target: "trie::prune::pruner", "Nothing to prune in the given range");
             return Ok(PrunerOutput::default());
         };
 
         info!(
-            target: "trie::pruner",
+            target: "trie::prune::pruner",
             from_block = earliest_block,
             to_block = target_earliest_block,
             "Starting pruning proof storage (in-tx)",
@@ -144,14 +144,14 @@ where
         let window = match provider.get_proof_window() {
             Ok(w) => w,
             Err(OpProofsStorageError::NoBlocksFound) => {
-                trace!(target: "trie::pruner", "Proof storage is empty");
+                trace!(target: "trie::prune::pruner", "Proof storage is empty");
                 return Ok(None);
             }
             Err(err) => return Err(err.into()),
         };
         let (latest_block, earliest_block) = (window.latest.number, window.earliest.number);
         if latest_block.saturating_sub(earliest_block) <= self.min_block_interval {
-            trace!(target: "trie::pruner", "Nothing to prune");
+            trace!(target: "trie::prune::pruner", "Nothing to prune");
             return Ok(None);
         }
         let target_earliest_block = latest_block - self.min_block_interval;
@@ -177,7 +177,7 @@ where
             .block_hash(end_block)
             .inspect_err(|err| {
                 error!(
-                    target: "trie::pruner",
+                    target: "trie::prune::pruner",
                     block = end_block,
                     ?err,
                     "Failed to fetch block hash for new earliest block during pruning"
@@ -191,7 +191,7 @@ where
             .block_hash(parent_block_num)
             .inspect_err(|err| {
                 error!(
-                    target: "trie::pruner",
+                    target: "trie::prune::pruner",
                     block = parent_block_num,
                     ?err,
                     "Failed to fetch block hash for parent block during pruning"
@@ -213,7 +213,7 @@ where
         self.metrics.record_prune_result(batch_output.clone());
 
         info!(
-            target: "trie::pruner",
+            target: "trie::prune::pruner",
             ?batch_output,
             "Finished pruning batch of proof storage",
         );
@@ -224,10 +224,10 @@ where
     pub fn run(&self) {
         let res = self.run_inner();
         if let Err(e) = res {
-            error!(target: "trie::pruner", err=%e, "Pruner failed");
+            error!(target: "trie::prune::pruner", err=%e, "Pruner failed");
             return;
         }
-        info!(target: "trie::pruner", result = %res.unwrap(), "Finished pruning proof storage");
+        info!(target: "trie::prune::pruner", result = %res.unwrap(), "Finished pruning proof storage");
     }
 }
 

--- a/rust/op-reth/crates/trie/src/prune/task.rs
+++ b/rust/op-reth/crates/trie/src/prune/task.rs
@@ -34,7 +34,7 @@ where
     /// Run forever (until `cancel`), executing one prune pass per `task_run_interval`.
     pub async fn run(self, mut signal: GracefulShutdown) {
         info!(
-            target: "trie::pruner::task",
+            target: "trie::prune::task",
             min_block_interval = self.min_block_interval,
             interval_secs = self.task_run_interval.as_secs(),
             "Starting pruner task"
@@ -47,7 +47,7 @@ where
         loop {
             tokio::select! {
                 _ = &mut signal => {
-                    info!(target: "trie::pruner::task", "Pruner task cancelled; exiting");
+                    info!(target: "trie::prune::task", "Pruner task cancelled; exiting");
                     break;
                 }
                 _ = interval.tick() => {
@@ -56,6 +56,6 @@ where
             }
         }
 
-        info!(target: "trie::pruner::task", "Pruner task stopped");
+        info!(target: "trie::prune::task", "Pruner task stopped");
     }
 }

--- a/rust/op-reth/crates/trie/src/prune/task.rs
+++ b/rust/op-reth/crates/trie/src/prune/task.rs
@@ -34,7 +34,7 @@ where
     /// Run forever (until `cancel`), executing one prune pass per `task_run_interval`.
     pub async fn run(self, mut signal: GracefulShutdown) {
         info!(
-            target: "trie::pruner_task",
+            target: "trie::pruner::task",
             min_block_interval = self.min_block_interval,
             interval_secs = self.task_run_interval.as_secs(),
             "Starting pruner task"
@@ -47,7 +47,7 @@ where
         loop {
             tokio::select! {
                 _ = &mut signal => {
-                    info!(target: "trie::pruner_task", "Pruner task cancelled; exiting");
+                    info!(target: "trie::pruner::task", "Pruner task cancelled; exiting");
                     break;
                 }
                 _ = interval.tick() => {
@@ -56,6 +56,6 @@ where
             }
         }
 
-        info!(target: "trie::pruner_task", "Pruner task stopped");
+        info!(target: "trie::pruner::task", "Pruner task stopped");
     }
 }


### PR DESCRIPTION
**Description**

Log targets in the trie crate had drifted to four conventions:

| Convention | Files |
|---|---|
| `live-trie::engine` | engine handle, runner, state |
| `trie::engine::task` / `trie::engine::persistence` | tasks/, persistence service (recently migrated) |
| `trie::pruner` / `trie::pruner_task` | prune/ (underscore-separated, broke filter hierarchy) |
| `reth::cli` | one accidentally-misnamed line in `initialize.rs` |
| *(no target)* | DB metric reporting (`store.rs`, `store_v2/metrics.rs`), most of `initialize.rs` |

This made `RUST_LOG` filtering inconsistent.

This PR improves the logging in the trie crate.

**Tests**

NA

**Additional context**

NA

**Metadata**

NA