### PR TITLE
feat(op-reth/payload): expose per-call committed transactions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11262,6 +11262,7 @@ dependencies = [
  "reth-chainspec",
  "reth-evm",
  "reth-execution-types",
+ "reth-optimism-chainspec",
  "reth-optimism-evm",
  "reth-optimism-forks",
  "reth-optimism-primitives",

--- a/rust/op-reth/crates/payload/Cargo.toml
+++ b/rust/op-reth/crates/payload/Cargo.toml
@@ -52,3 +52,7 @@ thiserror.workspace = true
 sha2.workspace = true
 serde.workspace = true
 either.workspace = true
+
+[dev-dependencies]
+reth-optimism-chainspec.workspace = true
+reth-revm = { workspace = true, features = ["test-utils"] }

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -443,7 +443,10 @@ impl<Txs> OpBuilder<'_, Txs> {
         // 3. if mem pool transactions are requested we execute them
         if !ctx.attributes().no_tx_pool() {
             let best_txs = best(ctx.best_transaction_attributes(builder.evm_mut().block()));
-            if ctx.execute_best_transactions(&mut info, &mut builder, best_txs, None, None)?.is_some() {
+            if ctx
+                .execute_best_transactions(&mut info, &mut builder, best_txs, None, None)?
+                .is_some()
+            {
                 return Ok(BuildOutcomeKind::Cancelled);
             }
 

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -438,12 +438,12 @@ impl<Txs> OpBuilder<'_, Txs> {
         })?;
 
         // 2. execute sequencer transactions
-        let mut info = ctx.execute_sequencer_transactions(&mut builder)?;
+        let mut info = ctx.execute_sequencer_transactions(&mut builder, None)?;
 
         // 3. if mem pool transactions are requested we execute them
         if !ctx.attributes().no_tx_pool() {
             let best_txs = best(ctx.best_transaction_attributes(builder.evm_mut().block()));
-            if ctx.execute_best_transactions(&mut info, &mut builder, best_txs, None)?.is_some() {
+            if ctx.execute_best_transactions(&mut info, &mut builder, best_txs, None, None)?.is_some() {
                 return Ok(BuildOutcomeKind::Cancelled);
             }
 
@@ -519,7 +519,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         let mut builder = ctx.block_builder(&mut db)?;
 
         builder.apply_pre_execution_changes()?;
-        ctx.execute_sequencer_transactions(&mut builder)?;
+        ctx.execute_sequencer_transactions(&mut builder, None)?;
         builder.into_executor().apply_post_execution_changes()?;
 
         if ctx.chain_spec.is_isthmus_active_at_timestamp(ctx.attributes().timestamp()) {
@@ -721,9 +721,15 @@ where
     }
 
     /// Executes all sequencer transactions that are included in the payload attributes.
+    ///
+    /// When `committed_txs` is `Some(vec)`, each successfully committed sequencer
+    /// transaction is appended to `vec` in commit order. `None` skips the
+    /// recording. The function never reads or clears the vec; the caller controls
+    /// capacity and lifecycle.
     pub fn execute_sequencer_transactions(
         &self,
         builder: &mut impl BlockBuilder<Primitives = Evm::Primitives>,
+        mut committed_txs: Option<&mut Vec<Recovered<TxTy<Evm::Primitives>>>>,
     ) -> Result<ExecutionInfo, PayloadBuilderError> {
         let mut info = ExecutionInfo::new();
 
@@ -760,6 +766,12 @@ where
 
             // add gas used by the transaction to cumulative gas used, before creating the receipt
             info.cumulative_gas_used += gas_used.tx_gas_used();
+
+            // Record the successfully committed transaction for callers that want per-call
+            // visibility.
+            if let Some(sink) = committed_txs.as_deref_mut() {
+                sink.push(sequencer_tx);
+            }
         }
 
         Ok(info)
@@ -771,6 +783,11 @@ where
     ///   - `None`: effective limit is `min(block_gas_limit, gas_limit_config)`.
     ///   - `Some(g)`: effective limit is `min(g, block_gas_limit, gas_limit_config)`
     ///
+    /// When `committed_txs` is `Some(vec)`, each successfully committed transaction
+    /// is appended to `vec` in commit order. `None` skips the recording. The
+    /// function never reads or clears the vec; the caller controls capacity and
+    /// lifecycle.
+    ///
     /// Returns `Ok(Some(()))` if the job was cancelled.
     pub fn execute_best_transactions<Builder>(
         &self,
@@ -780,6 +797,7 @@ where
             Transaction: PoolTransaction<Consensus = TxTy<Evm::Primitives>> + OpPooledTx,
         >,
         gas_limit_cap: Option<u64>,
+        mut committed_txs: Option<&mut Vec<Recovered<TxTy<Evm::Primitives>>>>,
     ) -> Result<Option<()>, PayloadBuilderError>
     where
         Builder: BlockBuilder<Primitives = Evm::Primitives>,
@@ -882,6 +900,12 @@ where
                 .effective_tip_per_gas(base_fee)
                 .expect("fee is always valid; execution succeeded");
             info.total_fees += U256::from(miner_fee) * U256::from(tx_gas_used);
+
+            // Record the successfully committed transaction for callers that want per-call
+            // visibility.
+            if let Some(sink) = committed_txs.as_deref_mut() {
+                sink.push(tx);
+            }
         }
 
         Ok(None)

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -1,13 +1,32 @@
-use super::{OpPayloadBuilder, build_post_exec_recovered_tx, try_include_post_exec_tx};
-use crate::config::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig};
-use alloy_consensus::{Typed2718, transaction::Recovered};
+use super::{
+    ExecutionInfo, OpPayloadBuilder, OpPayloadBuilderCtx, build_post_exec_recovered_tx,
+    try_include_post_exec_tx,
+};
+use crate::{
+    OpPayloadBuilderAttributes,
+    config::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig},
+};
+use alloy_consensus::{
+    Header, SignableTransaction, TxEip1559, Typed2718,
+    transaction::{Recovered, TxHashRef},
+};
+use alloy_eips::eip2718::Encodable2718;
 use alloy_evm::RecoveredTx;
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256, Signature, TxHash, TxKind, U256};
 use op_alloy_consensus::SDMGasEntry;
-use reth_evm::execute::BlockExecutionError;
-use reth_optimism_primitives::OpTransactionSigned;
+use reth_basic_payload_builder::PayloadConfig;
+use reth_chainspec::MIN_TRANSACTION_GAS;
+use reth_evm::execute::{BlockBuilder, BlockExecutionError};
+use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
+use reth_optimism_evm::OpEvmConfig;
+use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
+use reth_optimism_txpool::OpPooledTransaction;
 use reth_payload_builder_primitives::PayloadBuilderError;
-use std::cell::Cell;
+use reth_payload_util::PayloadTransactionsFixed;
+use reth_primitives_traits::{Account, SealedHeader};
+use reth_revm::{database::StateProviderDatabase, db::State, test_utils::StateProviderTest};
+use reth_transaction_pool::PoolTransaction;
+use std::{cell::Cell, sync::Arc};
 
 fn entries(specs: &[(u64, u64)]) -> Vec<SDMGasEntry> {
     specs.iter().map(|&(index, gas_refund)| SDMGasEntry { index, gas_refund }).collect()
@@ -19,6 +38,116 @@ fn unwrap_post_exec(tx: Recovered<OpTransactionSigned>) -> (u8, u64, Vec<SDMGasE
         panic!("expected post-exec transaction");
     };
     (ty, signed.inner().payload.block_number, signed.inner().payload.gas_refund_entries.clone())
+}
+
+fn payload_builder_ctx(
+    chain_spec: Arc<OpChainSpec>,
+    gas_limit: u64,
+) -> OpPayloadBuilderCtx<
+    OpEvmConfig<OpChainSpec, OpPrimitives>,
+    OpChainSpec,
+    OpPayloadBuilderAttributes<OpTransactionSigned>,
+> {
+    let parent = SealedHeader::seal_slow(Header {
+        gas_limit,
+        number: 0,
+        timestamp: 0,
+        ..Default::default()
+    });
+    let attributes = OpPayloadBuilderAttributes {
+        timestamp: 1,
+        gas_limit: Some(gas_limit),
+        ..Default::default()
+    };
+
+    OpPayloadBuilderCtx {
+        evm_config: OpEvmConfig::optimism(chain_spec.clone()),
+        builder_config: OpBuilderConfig::default(),
+        chain_spec,
+        config: PayloadConfig {
+            parent_header: Arc::new(parent),
+            payload_id: attributes.id,
+            attributes,
+        },
+        cancel: Default::default(),
+        best_payload: None,
+    }
+}
+
+fn op_pooled_tx(nonce: u64, signer: Address, recipient: Address) -> OpPooledTransaction {
+    let tx: OpTransactionSigned = TxEip1559 {
+        chain_id: 8453,
+        nonce,
+        gas_limit: MIN_TRANSACTION_GAS,
+        max_fee_per_gas: 1,
+        max_priority_fee_per_gas: 1,
+        to: TxKind::Call(recipient),
+        value: U256::ZERO,
+        ..Default::default()
+    }
+    .into_signed(Signature::test_signature())
+    .into();
+    let encoded_len = tx.encode_2718_len();
+
+    OpPooledTransaction::new(Recovered::new_unchecked(tx, signer), encoded_len)
+}
+
+fn tx_hashes<'a>(txs: impl IntoIterator<Item = &'a Recovered<OpTransactionSigned>>) -> Vec<TxHash> {
+    txs.into_iter().map(|tx| *TxHashRef::tx_hash(tx)).collect()
+}
+
+fn run_execute_best_transactions(
+    signer: Address,
+    txs: Vec<OpPooledTransaction>,
+    gas_limit_cap: Option<u64>,
+    committed_txs: Option<&mut Vec<Recovered<OpTransactionSigned>>>,
+) -> (ExecutionInfo, Vec<TxHash>) {
+    let gas_limit = 1_000_000;
+    let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().regolith_activated().build());
+    let ctx = payload_builder_ctx(chain_spec, gas_limit);
+
+    let mut state_provider = StateProviderTest::default();
+    state_provider.insert_account(
+        signer,
+        Account { balance: U256::MAX, ..Default::default() },
+        None,
+        Default::default(),
+    );
+
+    let best_txs = PayloadTransactionsFixed::new(txs);
+
+    let mut db = State::builder()
+        .with_database(StateProviderDatabase::new(&state_provider))
+        .with_bundle_update()
+        .build();
+    let mut builder = ctx.block_builder(&mut db).expect("block builder can be created");
+    let mut info = ExecutionInfo::new();
+
+    assert!(
+        ctx.execute_best_transactions(
+            &mut info,
+            &mut builder,
+            best_txs,
+            gas_limit_cap,
+            committed_txs
+        )
+        .expect("best transactions execute")
+        .is_none()
+    );
+
+    let outcome = builder
+        .finish(state_provider.clone(), Some((B256::ZERO, Default::default())))
+        .expect("builder finishes");
+    let included_tx_hashes = outcome
+        .block
+        .into_block()
+        .body
+        .transactions
+        .iter()
+        .map(|tx| *TxHashRef::tx_hash(tx))
+        .collect();
+
+    (info, included_tx_hashes)
 }
 
 // Ensures the payload builder keeps SDM disabled by default and preserves the explicit
@@ -37,6 +166,48 @@ fn payload_builder_preserves_sdm_config() {
     .with_transactions(42u64);
     assert!(builder.config.sdm_enabled);
     assert_eq!(builder.best_transactions, 42);
+}
+
+#[test]
+fn execute_best_transactions_committed_txs_preserves_execution() {
+    let mut committed_txs = Vec::new();
+    let signer = Address::repeat_byte(0x11);
+    let tx0 = op_pooled_tx(0, signer, Address::repeat_byte(0x22));
+    let nonce_too_low = tx0.clone();
+    let tx1 = op_pooled_tx(1, signer, Address::repeat_byte(0x33));
+    let expected_committed = vec![*tx0.hash(), *tx1.hash()];
+    let txs = vec![tx0, nonce_too_low, tx1];
+
+    let (committed_info, committed_block_tx_hashes) =
+        run_execute_best_transactions(signer, txs.clone(), None, Some(&mut committed_txs));
+    let (none_info, none_block_tx_hashes) = run_execute_best_transactions(signer, txs, None, None);
+
+    assert_eq!(tx_hashes(&committed_txs), expected_committed);
+    assert_eq!(committed_block_tx_hashes, expected_committed);
+    assert_eq!(none_block_tx_hashes, expected_committed);
+    assert_eq!(committed_info.cumulative_gas_used, none_info.cumulative_gas_used);
+    assert_eq!(committed_info.cumulative_da_bytes_used, none_info.cumulative_da_bytes_used);
+    assert_eq!(committed_info.total_fees, none_info.total_fees);
+}
+
+#[test]
+fn execute_best_transactions_respects_gas_limit_cap() {
+    let mut committed_txs = Vec::new();
+    let signer = Address::repeat_byte(0x11);
+    let tx0 = op_pooled_tx(0, signer, Address::repeat_byte(0x22));
+    let tx1 = op_pooled_tx(1, signer, Address::repeat_byte(0x33));
+    let expected_committed = vec![*tx0.hash()];
+    let txs = vec![tx0, tx1];
+
+    let (_info, block_tx_hashes) = run_execute_best_transactions(
+        signer,
+        txs,
+        Some(MIN_TRANSACTION_GAS),
+        Some(&mut committed_txs),
+    );
+
+    assert_eq!(tx_hashes(&committed_txs), expected_committed);
+    assert_eq!(block_tx_hashes, expected_committed);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds an optional `committed_txs: Option<&mut Vec<Recovered<TxTy<...>>>>` parameter to `OpPayloadBuilderCtx::execute_best_transactions` and `OpPayloadBuilderCtx::execute_sequencer_transactions`. When `Some(vec)`, each successfully committed transaction is appended in commit order. `None` reproduces today's behaviour byte-for-byte.

## Motivation

`BlockExecutor::receipts()` already exposes the per-call receipt delta on the executor side. The corresponding committed transactions live on `BasicBlockBuilder.transactions` and are unreachable through the trait surface returned by `OpPayloadBuilderCtx::block_builder()`. This PR fills the symmetric gap on the transaction side: callers that want per-call visibility into commits can now opt in by passing a sink.

The vanilla payload path passes `None` and incurs zero overhead — the new branch short-circuits before any allocation or push.

## What changed

- `execute_best_transactions` and `execute_sequencer_transactions` each gain one new optional parameter (`committed_txs`).
- The three in-tree call sites in `OpBuilder::build` / `OpBuilder::witness` are updated to pass `None`.
- Doc comments updated.

Per-tx cost on the `Some` path is one `Vec.push` of `Recovered<TxTy<...>>` after the existing fee accounting.

## Design note: bare parameters vs. struct

I considered bundling `gas_limit_cap` + `committed_txs` into an `ExecuteOptions` struct, but rejected it: `gas_limit_cap` doesn't apply to `execute_sequencer_transactions`, so a shared struct would either silently ignore the field on that path (footgun) or split into two structs (over-engineered for two fields). Bare parameters keep each function's signature literal about what it accepts. If we hit 3+ options later, a `Default`-derived struct can replace `(None, None, ...)` non-breakingly.