### PR TITLE
[codex] Retry failed EL sync unsafe payloads

### DIFF
--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
@@ -47,6 +48,13 @@ type SyncDeriver struct {
 	ManagedBySupervisor bool
 
 	StepDeriver StepDeriver
+
+	pendingELSyncPayloads []pendingELSyncPayload
+}
+
+type pendingELSyncPayload struct {
+	envelope *eth.ExecutionPayloadEnvelope
+	ref      eth.L2BlockRef
 }
 
 func (s *SyncDeriver) AttachEmitter(em event.Emitter) {
@@ -120,13 +128,76 @@ func (s *SyncDeriver) OnUnsafeL2Payload(ctx context.Context, envelope *eth.Execu
 		if ref.Number <= s.Engine.UnsafeL2Head().Number {
 			return
 		}
-		s.Log.Info("Inserting unsafe L2 execution payload to drive EL sync", "id", envelope.ExecutionPayload.ID())
-		if err := s.Engine.InsertUnsafePayload(s.Ctx, envelope, ref); err != nil {
-			s.Log.Warn("Failed to insert unsafe payload for EL sync", "id", envelope.ExecutionPayload.ID(), "err", err)
-		}
+		s.queueELSyncPayload(envelope, ref)
+		s.drainELSyncPayloads()
 		return
 	}
 
+}
+
+func (s *SyncDeriver) queueELSyncPayload(envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef) {
+	for _, pending := range s.pendingELSyncPayloads {
+		if pending.ref.Hash == ref.Hash {
+			return
+		}
+	}
+	s.pendingELSyncPayloads = append(s.pendingELSyncPayloads, pendingELSyncPayload{
+		envelope: envelope,
+		ref:      ref,
+	})
+	sort.Slice(s.pendingELSyncPayloads, func(i, j int) bool {
+		return s.pendingELSyncPayloads[i].ref.Number < s.pendingELSyncPayloads[j].ref.Number
+	})
+}
+
+func (s *SyncDeriver) drainELSyncPayloads() {
+	for {
+		unsafeHead := s.Engine.UnsafeL2Head()
+		s.dropStaleELSyncPayloads(unsafeHead)
+
+		next := s.nextELSyncPayload(unsafeHead)
+		if next == -1 {
+			return
+		}
+
+		pending := s.pendingELSyncPayloads[next]
+		s.Log.Info("Inserting unsafe L2 execution payload to drive EL sync", "id", pending.envelope.ExecutionPayload.ID())
+		if err := s.Engine.InsertUnsafePayload(s.Ctx, pending.envelope, pending.ref); err != nil {
+			s.Log.Warn("Failed to insert unsafe payload for EL sync", "id", pending.envelope.ExecutionPayload.ID(), "err", err)
+			if errors.Is(err, derive.ErrTemporary) {
+				if s.StepDeriver != nil {
+					s.StepDeriver.RequestStep(s.Ctx, false)
+				}
+				return
+			}
+		}
+		s.removeELSyncPayload(next)
+	}
+}
+
+func (s *SyncDeriver) dropStaleELSyncPayloads(unsafeHead eth.L2BlockRef) {
+	for i := 0; i < len(s.pendingELSyncPayloads); {
+		if s.pendingELSyncPayloads[i].ref.Number <= unsafeHead.Number {
+			s.removeELSyncPayload(i)
+			continue
+		}
+		i++
+	}
+}
+
+func (s *SyncDeriver) nextELSyncPayload(unsafeHead eth.L2BlockRef) int {
+	for i, pending := range s.pendingELSyncPayloads {
+		if pending.ref.Number == unsafeHead.Number+1 && pending.ref.ParentHash == unsafeHead.Hash {
+			return i
+		}
+	}
+	return -1
+}
+
+func (s *SyncDeriver) removeELSyncPayload(i int) {
+	copy(s.pendingELSyncPayloads[i:], s.pendingELSyncPayloads[i+1:])
+	s.pendingELSyncPayloads[len(s.pendingELSyncPayloads)-1] = pendingELSyncPayload{}
+	s.pendingELSyncPayloads = s.pendingELSyncPayloads[:len(s.pendingELSyncPayloads)-1]
 }
 
 func (s *SyncDeriver) onSafeDerivedBlock(ctx context.Context, x engine.SafeDerivedEvent) {
@@ -228,6 +299,7 @@ func (s *SyncDeriver) SyncStep() {
 	s.tryBackupUnsafeReorg()
 
 	if s.Engine.IsEngineInitialELSyncing() {
+		s.drainELSyncPayloads()
 		// The pipeline cannot move forwards if doing initial EL sync.
 		s.Log.Debug("Rollup driver is backing off because execution engine is performing initial EL sync.",
 			"unsafe_head", s.Engine.UnsafeL2Head())

--- a/op-node/rollup/driver/sync_deriver_test.go
+++ b/op-node/rollup/driver/sync_deriver_test.go
@@ -1,0 +1,144 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+type discardDriverEmitter struct{}
+
+func (discardDriverEmitter) Emit(context.Context, event.Event) {}
+
+func TestELSyncUnsafePayloadRetriesTemporaryInsertFailure(t *testing.T) {
+	ctx := context.Background()
+	logger := testlog.Logger(t, log.LevelError)
+	cfg, genesis := testELSyncRollupConfig()
+	syncCfg := &sync.Config{SyncMode: sync.ELSync}
+	mockEngine := &testutils.MockEngine{}
+
+	ec := engine.NewEngineController(ctx, mockEngine, logger, metrics.NoopMetrics, cfg, syncCfg, false, &testutils.MockL1Source{}, discardDriverEmitter{}, nil)
+	ec.SetUnsafeHead(genesis)
+	ec.SetLocalSafeHead(genesis)
+	ec.SetFinalizedHead(genesis)
+
+	sd := &SyncDeriver{
+		Engine:  ec,
+		SyncCfg: syncCfg,
+		Config:  cfg,
+		Ctx:     ctx,
+		Log:     logger,
+	}
+	ec.SyncDeriver = sd
+
+	ref1, payload1 := testELSyncPayload(t, cfg, genesis)
+	ref2, payload2 := testELSyncPayload(t, cfg, ref1)
+	ref3, payload3 := testELSyncPayload(t, cfg, ref2)
+	tempErr := derive.NewTemporaryError(errors.New("connection refused"))
+
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, genesis, nil)
+	mockEngine.ExpectNewPayload(payload1.ExecutionPayload, nil, &eth.PayloadStatusV1{}, tempErr)
+	sd.OnUnsafeL2Payload(ctx, payload1)
+	require.Equal(t, genesis, ec.UnsafeL2Head())
+
+	mockEngine.ExpectNewPayload(payload1.ExecutionPayload, nil, &eth.PayloadStatusV1{}, tempErr)
+	sd.OnUnsafeL2Payload(ctx, payload2)
+	require.Equal(t, genesis, ec.UnsafeL2Head())
+
+	expectELSyncInsert(t, mockEngine, genesis, ref1, payload1)
+	expectELSyncInsert(t, mockEngine, genesis, ref2, payload2)
+	expectELSyncInsert(t, mockEngine, genesis, ref3, payload3)
+	sd.OnUnsafeL2Payload(ctx, payload3)
+
+	require.Equal(t, ref3, ec.UnsafeL2Head())
+	mockEngine.AssertExpectations(t)
+}
+
+func expectELSyncInsert(t *testing.T, mockEngine *testutils.MockEngine, safe eth.L2BlockRef, ref eth.L2BlockRef, payload *eth.ExecutionPayloadEnvelope) {
+	t.Helper()
+	mockEngine.ExpectNewPayload(payload.ExecutionPayload, nil, &eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, nil)
+	mockEngine.ExpectForkchoiceUpdate(&eth.ForkchoiceState{
+		HeadBlockHash: ref.Hash,
+		SafeBlockHash: safe.Hash,
+	}, nil, &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}}, nil)
+}
+
+func testELSyncRollupConfig() (*rollup.Config, eth.L2BlockRef) {
+	l1Genesis := eth.BlockID{Hash: common.Hash{0x11}, Number: 100}
+	l2Genesis := eth.L2BlockRef{
+		Hash:       common.Hash{0x22},
+		Number:     0,
+		Time:       1_000,
+		L1Origin:   l1Genesis,
+		ParentHash: common.Hash{},
+	}
+	return &rollup.Config{
+		Genesis: rollup.Genesis{
+			L1:     l1Genesis,
+			L2:     l2Genesis.ID(),
+			L2Time: l2Genesis.Time,
+			SystemConfig: eth.SystemConfig{
+				BatcherAddr: common.Address{0x42},
+				GasLimit:    30_000_000,
+			},
+		},
+		BlockTime:     2,
+		SeqWindowSize: 2,
+	}, l2Genesis
+}
+
+func testELSyncPayload(t *testing.T, cfg *rollup.Config, parent eth.L2BlockRef) (eth.L2BlockRef, *eth.ExecutionPayloadEnvelope) {
+	t.Helper()
+	number := parent.Number + 1
+	timestamp := parent.Time + cfg.BlockTime
+	l1Origin := eth.BlockID{Hash: common.Hash{byte(number), 0xaa}, Number: cfg.Genesis.L1.Number + number}
+	l1Info := &testutils.MockBlockInfo{
+		InfoHash:        l1Origin.Hash,
+		InfoParentHash:  cfg.Genesis.L1.Hash,
+		InfoNum:         l1Origin.Number,
+		InfoTime:        timestamp,
+		InfoBaseFee:     big.NewInt(1),
+		InfoBlobBaseFee: big.NewInt(1),
+		InfoReceiptRoot: gethtypes.EmptyRootHash,
+		InfoRoot:        common.Hash{byte(number), 0xbb},
+	}
+	l1InfoTx, err := derive.L1InfoDepositBytes(cfg, params.MergedTestChainConfig, cfg.Genesis.SystemConfig, parent.SequenceNumber+1, l1Info, timestamp)
+	require.NoError(t, err)
+
+	ref := eth.L2BlockRef{
+		Hash:           common.Hash{byte(number), 0xcc},
+		Number:         number,
+		ParentHash:     parent.Hash,
+		Time:           timestamp,
+		L1Origin:       l1Origin,
+		SequenceNumber: parent.SequenceNumber + 1,
+	}
+	payload := &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockHash:    ref.Hash,
+			ParentHash:   parent.Hash,
+			BlockNumber:  hexutil.Uint64(ref.Number),
+			Timestamp:    hexutil.Uint64(ref.Time),
+			Transactions: []eth.Data{l1InfoTx},
+		},
+	}
+	return ref, payload
+}


### PR DESCRIPTION
## Summary

- Buffer unsafe payloads received during initial EL sync instead of inserting each one once and dropping it on failure.
- Drain the pending EL-sync payloads only when they are the direct child of the current unsafe head.
- Keep temporary engine/RPC failures pending and reattempt them through the existing step/backoff loop.

## Root Cause

The JNT v2 logs showed reth restart around `2026-05-13T10:16:22Z`. While the EL RPC was unavailable, `SyncDeriver.OnUnsafeL2Payload` attempted blocks `63502` through `63505`, logged temporary insert failures, and returned. Because this initial EL-sync path bypassed the normal unsafe payload queue, those failed payloads were dropped while later payloads continued to arrive. That let op-node/supernode FCU to a later unsafe head whose ancestor was not locally present in the EL, after which reth stayed in `SYNCING`.

## Validation

- `go test ./op-node/rollup/driver ./op-node/rollup/engine`
