### PR TITLE
docs: add op-supernode configuration guide

### DIFF
--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -2033,7 +2033,8 @@
                 "pages": [
                   "node-operators/guides/configuration/consensus-clients",
                   "node-operators/guides/configuration/execution-clients",
-                  "node-operators/guides/configuration/legacy-geth"
+                  "node-operators/guides/configuration/legacy-geth",
+                  "node-operators/guides/configuration/supernode"
                 ]
               },
               {

--- a/docs/public-docs/node-operators/guides/configuration/supernode.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/supernode.mdx
@@ -42,7 +42,7 @@ Use the per-chain form only when a chain's execution client requires its own sec
 
 Configure `--l1.beacon-fallbacks` (or `OP_SUPERNODE_L1_BEACON_FALLBACKS`) with one or more beacon-API-compatible archive endpoints.
 Set them up from the start — once a primary beacon prunes a blob the supernode needs, only an archiver can recover it.
-The shared L1 client uses the fallbacks transparently when the primary beacon node returns 404 for an expired blob.
+The shared beacon client uses the fallbacks transparently when the primary beacon node returns 404 for an expired blob.
 The `--l1.beacon-archiver` alias points at the same flag and is accepted for compatibility with older deployment scripts.
 
 ### Pair op-supernode with a Light CL fleet
@@ -131,7 +131,8 @@ The default value is `./datadir`.
 
 ### Shared L1 access
 
-The supernode runs one L1 client and one beacon client and serves every chain in the dependency set from them.
+The supernode shares one L1 client and one beacon client across every chain in the dependency set.
+These are the supernode's own in-process clients (caching layers in front of remote endpoints), not the remote L1 node and beacon node themselves — the supernode connects to existing endpoints rather than running its own.
 Configure these flags at the top level only — the per-chain namespace also includes `--vn.<chainID>.l1` and `--vn.<chainID>.l1.beacon` (because the supernode mechanically clones every op-node flag into the namespace), but the supernode discards them at startup.
 
 #### l1

--- a/docs/public-docs/node-operators/guides/configuration/supernode.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/supernode.mdx
@@ -67,7 +67,7 @@ Fill in the placeholders before starting the binary.
 
 <Info>
   The example below assumes a two-chain dependency set of OP Sepolia (chain ID `11155420`) and Unichain Sepolia (chain ID `1301`).
-  For a different dependency set, replace the chain IDs in `OP_SUPERNODE_CHAINS` and add or remove the matching `OP_SUPERNODE_VN_<CHAINID>_NETWORK` and `OP_SUPERNODE_VN_<CHAINID>_L2` pairs for each chain.
+  For a different dependency set, replace the chain IDs in `OP_SUPERNODE_CHAINS` and add or remove the matching `OP_SUPERNODE_VN_<CHAINID>_NETWORK` and `OP_SUPERNODE_VN_<CHAINID>_L2_ENGINE_RPC` pairs for each chain.
 </Info>
 
 ```yaml
@@ -328,7 +328,7 @@ Set this only when activating interop on a custom devnet whose rollup config doe
 Extends initiating-message log ingestion backward from the L2 tip by this duration, clamped to the interop activation timestamp.
 Validation still starts only beyond the local safe head; the backfill pre-ingests logs so they are available when validation needs them.
 Requires the interop activation timestamp to be known, either from the rollup config or via `--interop.activation-timestamp`.
-The default value is `0` (no backfill).
+The default value is `0s` (no backfill).
 
 <Tabs>
   <Tab title="Syntax">`--interop.log-backfill-depth=<value>`</Tab>

--- a/docs/public-docs/node-operators/guides/configuration/supernode.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/supernode.mdx
@@ -40,7 +40,8 @@ Use the per-chain form only when a chain's execution client requires its own sec
   Without an archive fallback configured, a supernode that has been offline past the prune window cannot fetch the blobs it needs to derive missed L1 blocks, and chain containers will stall at the gap.
 </Warning>
 
-Configure `--l1.beacon-fallbacks` (or `OP_SUPERNODE_L1_BEACON_FALLBACKS`) with one or more beacon-API-compatible archive endpoints before running long enough for blob expiry to matter.
+Configure `--l1.beacon-fallbacks` (or `OP_SUPERNODE_L1_BEACON_FALLBACKS`) with one or more beacon-API-compatible archive endpoints.
+Set them up from the start — once a primary beacon prunes a blob the supernode needs, only an archiver can recover it.
 The shared L1 client uses the fallbacks transparently when the primary beacon node returns 404 for an expired blob.
 The `--l1.beacon-archiver` alias points at the same flag and is accepted for compatibility with older deployment scripts.
 
@@ -131,7 +132,7 @@ The default value is `./datadir`.
 ### Shared L1 access
 
 The supernode runs one L1 client and one beacon client and serves every chain in the dependency set from them.
-Per-chain `--vn.<chainID>.l1` and `--vn.<chainID>.l1.beacon` settings are silently replaced with the top-level values below at startup.
+Per-chain `--vn.<chainID>.l1` and `--vn.<chainID>.l1.beacon` settings never take effect — the supernode always uses the top-level `--l1` and `--l1.beacon` values for every chain.
 
 #### l1
 

--- a/docs/public-docs/node-operators/guides/configuration/supernode.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/supernode.mdx
@@ -132,7 +132,7 @@ The default value is `./datadir`.
 ### Shared L1 access
 
 The supernode runs one L1 client and one beacon client and serves every chain in the dependency set from them.
-Per-chain `--vn.<chainID>.l1` and `--vn.<chainID>.l1.beacon` settings never take effect — the supernode always uses the top-level `--l1` and `--l1.beacon` values for every chain.
+Configure these flags at the top level only — the per-chain namespace also includes `--vn.<chainID>.l1` and `--vn.<chainID>.l1.beacon` (because the supernode mechanically clones every op-node flag into the namespace), but the supernode discards them at startup.
 
 #### l1
 

--- a/docs/public-docs/node-operators/guides/configuration/supernode.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/supernode.mdx
@@ -45,6 +45,8 @@ Set them up from the start — once a primary beacon prunes a blob the supernode
 The shared beacon client uses the fallbacks transparently when the primary beacon node returns 404 for an expired blob.
 The `--l1.beacon-archiver` alias points at the same flag and is accepted for compatibility with older deployment scripts.
 
+For options on what to point `--l1.beacon-fallbacks` at — running your own non-pruning beacon, running `blob-archiver`, or using a third-party service — see the [blob archiver guide](/node-operators/guides/management/blobs#configure-a-blob-archiver).
+
 ### Pair op-supernode with a Light CL fleet
 
 For operators running more than a handful of nodes, the deployable pattern is to concentrate the expensive multi-chain derivation work on supernodes and run the rest of the fleet as op-node or kona-node instances in Light CL mode.

--- a/docs/public-docs/node-operators/guides/configuration/supernode.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/supernode.mdx
@@ -210,7 +210,7 @@ The `<SUFFIX>` is the op-node flag's source-level environment-variable name (see
 
   * `--l1` and `--l1.beacon`: the shared L1 plumbing replaces any per-chain L1 setting at startup.
   * `--l1.http-poll-interval`: the shared L1 client owns the polling cadence; the supernode logs a warning if a per-chain value is set.
-  * `--log.*` and `--metrics.*`: passed down from the top-level flags; per-chain log and metrics settings may not be respected.
+  * `--log.*`: the supernode and every virtual node share one logger; top-level `--log.*` configures it. Per-chain `--vn.*.log.*` flags appear in the namespace but are silently ignored. (`--metrics.*` is different: top-level configures the supernode's own metrics service, but per-chain `--vn.*.metrics.*` configures each virtual node's own metrics, which are fanned into the same endpoint with per-chain Prometheus labels.)
   * P2P listen ports: see the [P2P](#p2p) section.
 </Info>
 
@@ -380,8 +380,8 @@ Enable this only on endpoints that are not exposed to untrusted networks.
 
 ### Logging
 
-Logging is configured at the top level for every chain.
-Per-chain log settings under the `--vn.*` namespace may not be respected.
+Logging is configured at the top level.
+The supernode and every virtual node share one logger; per-chain `--vn.*.log.*` flags appear in the namespace but are silently ignored.
 
 #### log.level
 
@@ -398,8 +398,9 @@ The default value is `info`.
 #### log.format
 
 Log output format.
-Valid values are `text`, `terminal`, `logfmt`, `json`, `json-pretty`.
+Valid values are `text`, `terminal`, `logfmt`, `logfmtms`, `json`, `jsonms` (the `*ms` variants append millisecond timestamps).
 The default value is `text`.
+Set `logfmt` or `json` when ingesting logs into a structured-log pipeline; the default `text` is for hand-reading.
 
 <Tabs>
   <Tab title="Syntax">`--log.format=<value>`</Tab>

--- a/docs/public-docs/node-operators/guides/configuration/supernode.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/supernode.mdx
@@ -29,7 +29,7 @@ The following options are from the `--help` in [op-supernode/v0.2.2-rc.8](https:
   When every chain in the dependency set uses the same secret, set it once at the supernode level and let every virtual node inherit it.
 </Info>
 
-To share a single JWT secret across every virtual node, set `--vn.all.l2.jwt-secret=<path>` (or `OP_SUPERNODE_VN_ALL_L2_JWT_SECRET`) at the supernode level.
+To share a single JWT secret across every virtual node, set `--vn.all.l2.jwt-secret=<path>` (or `OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH`) at the supernode level.
 This avoids repeating the per-chain `--vn.<chainID>.l2.jwt-secret` line for every chain in `--chains`.
 Use the per-chain form only when a chain's execution client requires its own secret.
 
@@ -66,6 +66,11 @@ The example uses environment variables; pass the equivalent `--flag` arguments i
 Fill in the placeholders before starting the binary.
 
 <Info>
+  Some `--vn.<chainID>.*` flags have an environment-variable suffix that doesn't mechanically match the CLI flag name (for example, `--vn.<id>.l2` is set by `OP_SUPERNODE_VN_<id>_L2_ENGINE_RPC`, and `--vn.all.l2.jwt-secret` is set by `OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH`).
+  The example below uses the correct environment-variable names from `--help`; copy them as shown.
+</Info>
+
+<Info>
   The example below assumes a two-chain dependency set of OP Sepolia (chain ID `11155420`) and Unichain Sepolia (chain ID `1301`).
   For a different dependency set, replace the chain IDs in `OP_SUPERNODE_CHAINS` and add or remove the matching `OP_SUPERNODE_VN_<CHAINID>_NETWORK` and `OP_SUPERNODE_VN_<CHAINID>_L2` pairs for each chain.
 </Info>
@@ -81,13 +86,13 @@ OP_SUPERNODE_L1_BEACON: <your-l1-beacon-rpc>
 OP_SUPERNODE_L1_BEACON_FALLBACKS: <your-l1-beacon-archiver-rpc>
 
 # Shared JWT secret for every virtual node's engine connection
-OP_SUPERNODE_VN_ALL_L2_JWT_SECRET: /etc/op/jwt-secret.txt
+OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH: /etc/op/jwt-secret.txt
 
 # Per-chain: chain identity and engine RPC
 OP_SUPERNODE_VN_11155420_NETWORK: op-sepolia
-OP_SUPERNODE_VN_11155420_L2: <op-sepolia-engine-rpc>
+OP_SUPERNODE_VN_11155420_L2_ENGINE_RPC: <op-sepolia-engine-rpc>
 OP_SUPERNODE_VN_1301_NETWORK: unichain-sepolia
-OP_SUPERNODE_VN_1301_L2: <unichain-sepolia-engine-rpc>
+OP_SUPERNODE_VN_1301_L2_ENGINE_RPC: <unichain-sepolia-engine-rpc>
 
 # Top-level JSON-RPC server (per-chain namespaces under /<chainID>/)
 OP_SUPERNODE_RPC_ADDR: 0.0.0.0
@@ -194,9 +199,11 @@ The supernode reproduces the full op-node flag set under two prefixes so you can
 * **`--vn.<chainID>.<flag>`** sets `<flag>` for one specific chain.
 * **`--vn.all.<flag>`** sets `<flag>` for every chain in the dependency set.
 
-The environment-variable form follows the same prefix rule: `OP_SUPERNODE_VN_<CHAINID>_<FLAG>` for one chain and `OP_SUPERNODE_VN_ALL_<FLAG>` for every chain.
-`<FLAG>` is the op-node flag name with hyphens and dots converted to underscores and uppercased.
-For example, `--vn.11155420.l2.engine-rpc-timeout` is equivalent to `OP_SUPERNODE_VN_11155420_L2_ENGINE_RPC_TIMEOUT`.
+The environment-variable form follows the same prefix rule: `OP_SUPERNODE_VN_<CHAINID>_<SUFFIX>` for one chain and `OP_SUPERNODE_VN_ALL_<SUFFIX>` for every chain.
+The `<SUFFIX>` is the op-node flag's source-level environment-variable suffix — usually but not always derivable from the CLI flag name.
+For example, `--vn.11155420.l2.engine-rpc-timeout` becomes `OP_SUPERNODE_VN_11155420_L2_ENGINE_RPC_TIMEOUT` (CLI name matches the suffix), while `--vn.11155420.l2` becomes `OP_SUPERNODE_VN_11155420_L2_ENGINE_RPC` (the CLI was renamed but the environment-variable suffix kept the original op-node spelling).
+
+Consult `op-supernode --chains=<chainIDs> --help` for the authoritative environment-variable name of any flag. The per-flag entries below list the correct environment-variable form alongside the CLI form.
 
 <Info>
   A few flags are owned by the supernode rather than by individual virtual nodes.
@@ -241,7 +248,7 @@ Each chain needs its own execution client; one execution client cannot back two 
 <Tabs>
   <Tab title="Syntax">`--vn.<chainID>.l2=<value>`</Tab>
   <Tab title="Example">`--vn.11155420.l2=http://op-sepolia-geth:8551`</Tab>
-  <Tab title="Environment Variable">`OP_SUPERNODE_VN_<CHAINID>_L2=`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_VN_<CHAINID>_L2_ENGINE_RPC=`</Tab>
 </Tabs>
 
 #### vn.all.l2.jwt-secret
@@ -253,7 +260,7 @@ Use the per-chain `--vn.<chainID>.l2.jwt-secret` form only when a chain's execut
 <Tabs>
   <Tab title="Syntax">`--vn.all.l2.jwt-secret=<value>`</Tab>
   <Tab title="Example">`--vn.all.l2.jwt-secret=/etc/op/jwt-secret.txt`</Tab>
-  <Tab title="Environment Variable">`OP_SUPERNODE_VN_ALL_L2_JWT_SECRET=`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH=`</Tab>
 </Tabs>
 
 #### vn.&lt;chainID&gt;.l2.enginekind
@@ -266,7 +273,7 @@ The default value is `geth`.
 <Tabs>
   <Tab title="Syntax">`--vn.<chainID>.l2.enginekind=<value>`</Tab>
   <Tab title="Example">`--vn.11155420.l2.enginekind=reth`</Tab>
-  <Tab title="Environment Variable">`OP_SUPERNODE_VN_<CHAINID>_L2_ENGINEKIND=`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_VN_<CHAINID>_L2_ENGINE_KIND=`</Tab>
 </Tabs>
 
 ### P2P

--- a/docs/public-docs/node-operators/guides/configuration/supernode.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/supernode.mdx
@@ -1,0 +1,488 @@
+---
+title: Supernode configuration
+description: Learn how to configure op-supernode to run every chain in an interop dependency set in one process.
+audit-source:
+  - op-supernode/flags/flags.go
+  - op-supernode/flags/virtual_flags.go
+  - op-supernode/cmd/main.go
+  - op-supernode/supernode/supernode.go
+  - op-supernode/supernode/activity/interop/interop.go
+  - op-supernode/README.md
+---
+
+<Info>
+  op-supernode is in active development.
+  This page tracks the [op-supernode/v0.2.2-rc.8](https://github.com/ethereum-optimism/optimism/releases/tag/op-supernode%2Fv0.2.2-rc.8) release candidate and the flag list may evolve before the stable release.
+  For background on what op-supernode is and why it exists, see the [supernode explainer](/op-stack/interop/supernode).
+</Info>
+
+This page lists all configuration options for op-supernode.
+op-supernode runs every chain in an interop dependency set together as virtual nodes inside one process, sharing the L1 client and beacon-chain plumbing across them.
+The following options are from the `--help` in [op-supernode/v0.2.2-rc.8](https://github.com/ethereum-optimism/optimism/releases/tag/op-supernode%2Fv0.2.2-rc.8).
+
+## Recommendations
+
+### Share the JWT secret across virtual nodes with `--vn.all.l2.jwt-secret`
+
+<Info>
+  Each chain's virtual node needs the JWT secret to authenticate with its execution client over the Engine API.
+  When every chain in the dependency set uses the same secret, set it once at the supernode level and let every virtual node inherit it.
+</Info>
+
+To share a single JWT secret across every virtual node, set `--vn.all.l2.jwt-secret=<path>` (or `OP_SUPERNODE_VN_ALL_L2_JWT_SECRET`) at the supernode level.
+This avoids repeating the per-chain `--vn.<chainID>.l2.jwt-secret` line for every chain in `--chains`.
+Use the per-chain form only when a chain's execution client requires its own secret.
+
+### Configure a beacon archiver fallback with `--l1.beacon-fallbacks`
+
+<Warning>
+  Ethereum beacon nodes prune blob sidecars after roughly 18 days.
+  Without an archive fallback configured, a supernode that has been offline past the prune window cannot fetch the blobs it needs to derive missed L1 blocks, and chain containers will stall at the gap.
+</Warning>
+
+Configure `--l1.beacon-fallbacks` (or `OP_SUPERNODE_L1_BEACON_FALLBACKS`) with one or more beacon-API-compatible archive endpoints before running long enough for blob expiry to matter.
+The shared L1 client uses the fallbacks transparently when the primary beacon node returns 404 for an expired blob.
+The `--l1.beacon-archiver` alias points at the same flag and is accepted for compatibility with older deployment scripts.
+
+### Pair op-supernode with a Light CL fleet
+
+For operators running more than a handful of nodes, the deployable pattern is to concentrate the expensive multi-chain derivation work on supernodes and run the rest of the fleet as op-node or kona-node instances in Light CL mode.
+Each supernode (or HA pool of supernodes) acts as the safe source for a fleet of Light CLs.
+The fleet points at the supernode's `optimism_syncStatus` RPC over the `--l2.follow.source` flag and inherits its safe and finalized view, while keeping its own unsafe-head progression over P2P.
+Larger operators often run several such supernode-plus-fleet groups for blast-radius isolation, regional placement, or staged rollouts.
+
+See the [specialized op-node topology notice](/notices/specialized-node-topology) for the fleet side of this pattern, and the [supernode explainer](/op-stack/interop/supernode#op-supernode-and-light-cl) for the architecture overview.
+
+Set `--disable-p2p=true` on the supernode when the fleet handles unsafe-head P2P gossip on its own.
+Leave P2P enabled (the default) when the supernode is the only node in the topology.
+
+## Example configuration
+
+This is a minimum viable configuration for an op-supernode acting as a verifier across OP Sepolia and Unichain Sepolia.
+The example uses environment variables; pass the equivalent `--flag` arguments instead if that fits your deployment better.
+Fill in the placeholders before starting the binary.
+
+<Info>
+  The example below assumes a two-chain dependency set of OP Sepolia (chain ID `11155420`) and Unichain Sepolia (chain ID `1301`).
+  For a different dependency set, replace the chain IDs in `OP_SUPERNODE_CHAINS` and add or remove the matching `OP_SUPERNODE_VN_<CHAINID>_NETWORK` and `OP_SUPERNODE_VN_<CHAINID>_L2` pairs for each chain.
+</Info>
+
+```yaml
+# Dependency set and storage
+OP_SUPERNODE_CHAINS: "11155420,1301"          # OP Sepolia + Unichain Sepolia
+OP_SUPERNODE_DATA_DIR: /var/lib/op-supernode  # default is ./datadir
+
+# Shared L1 access
+OP_SUPERNODE_L1_ETH_RPC: <your-l1-eth-rpc>
+OP_SUPERNODE_L1_BEACON: <your-l1-beacon-rpc>
+OP_SUPERNODE_L1_BEACON_FALLBACKS: <your-l1-beacon-archiver-rpc>
+
+# Shared JWT secret for every virtual node's engine connection
+OP_SUPERNODE_VN_ALL_L2_JWT_SECRET: /etc/op/jwt-secret.txt
+
+# Per-chain: chain identity and engine RPC
+OP_SUPERNODE_VN_11155420_NETWORK: op-sepolia
+OP_SUPERNODE_VN_11155420_L2: <op-sepolia-engine-rpc>
+OP_SUPERNODE_VN_1301_NETWORK: unichain-sepolia
+OP_SUPERNODE_VN_1301_L2: <unichain-sepolia-engine-rpc>
+
+# Top-level JSON-RPC server (per-chain namespaces under /<chainID>/)
+OP_SUPERNODE_RPC_ADDR: 0.0.0.0
+OP_SUPERNODE_RPC_PORT: "8545"
+
+# Observability
+OP_SUPERNODE_LOG_LEVEL: info
+OP_SUPERNODE_METRICS_ENABLED: "true"
+OP_SUPERNODE_METRICS_ADDR: 0.0.0.0
+OP_SUPERNODE_METRICS_PORT: "7300"
+```
+
+For chains that are not in op-node's built-in network registry, replace `--vn.<chainID>.network` with `--vn.<chainID>.rollup.config=<path-to-rollup-config.json>`.
+
+## All configuration variables
+
+### Dependency set and storage
+
+#### chains
+
+The list of chain IDs that this supernode hosts.
+Required.
+Accepts a comma-separated list or a repeatable flag.
+Each chain ID must have a matching set of per-chain `--vn.<chainID>.*` flags that configure the chain's network identity and execution-client connection.
+
+<Tabs>
+  <Tab title="Syntax">`--chains=<value>`</Tab>
+  <Tab title="Example">`--chains=11155420,1301`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_CHAINS=`</Tab>
+</Tabs>
+
+#### data-dir
+
+Data directory for op-supernode.
+Each chain's SafeDB and P2P state is stored in a `chain-<chainID>` subdirectory under this path so the chains cannot collide.
+The default value is `./datadir`.
+
+<Tabs>
+  <Tab title="Syntax">`--data-dir=<value>`</Tab>
+  <Tab title="Example">`--data-dir=/var/lib/op-supernode`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_DATA_DIR=`</Tab>
+</Tabs>
+
+### Shared L1 access
+
+The supernode runs one L1 client and one beacon client and serves every chain in the dependency set from them.
+Per-chain `--vn.<chainID>.l1` and `--vn.<chainID>.l1.beacon` settings are silently replaced with the top-level values below at startup.
+
+#### l1
+
+Address of the L1 user JSON-RPC endpoint.
+Required.
+The `eth` namespace must be enabled on the endpoint.
+
+<Tabs>
+  <Tab title="Syntax">`--l1=<value>`</Tab>
+  <Tab title="Example">`--l1=https://ethereum-rpc-endpoint.example.com`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_L1_ETH_RPC=`</Tab>
+</Tabs>
+
+#### l1.beacon
+
+Address of the L1 beacon-node HTTP endpoint.
+Required for any chain that depends on blob-derived L1 data, which covers every post-Ecotone OP Stack chain.
+
+<Tabs>
+  <Tab title="Syntax">`--l1.beacon=<value>`</Tab>
+  <Tab title="Example">`--l1.beacon=https://ethereum-beacon-endpoint.example.com`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_L1_BEACON=`</Tab>
+</Tabs>
+
+#### l1.beacon-fallbacks
+
+Addresses of L1 beacon-API-compatible HTTP fallback endpoints.
+Used to fetch blob sidecars not available at the primary `--l1.beacon` endpoint, including blobs that have aged past a regular beacon node's prune window.
+The `--l1.beacon-archiver` alias points at the same flag.
+Accepts a comma-separated list or a repeatable flag.
+
+<Tabs>
+  <Tab title="Syntax">`--l1.beacon-fallbacks=<value>`</Tab>
+  <Tab title="Example">`--l1.beacon-fallbacks=https://archiver-1.example.com,https://archiver-2.example.com`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_L1_BEACON_FALLBACKS=`</Tab>
+</Tabs>
+
+#### l1.http-poll-interval
+
+Polling interval for the shared L1 HTTP RPC subscription.
+The default value is `12s`.
+This flag controls the supernode's own L1 client.
+Per-chain `--vn.<chainID>.l1.http-poll-interval` settings are ignored because the shared client owns the resource.
+
+<Tabs>
+  <Tab title="Syntax">`--l1.http-poll-interval=<value>`</Tab>
+  <Tab title="Example">`--l1.http-poll-interval=12s`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_L1_HTTP_POLL_INTERVAL=`</Tab>
+</Tabs>
+
+### Per-chain virtual-node configuration
+
+Every chain in `--chains` runs as a virtual node inside the supernode.
+The supernode reproduces the full op-node flag set under two prefixes so you can configure each chain.
+
+* **`--vn.<chainID>.<flag>`** sets `<flag>` for one specific chain.
+* **`--vn.all.<flag>`** sets `<flag>` for every chain in the dependency set.
+
+The environment-variable form follows the same prefix rule: `OP_SUPERNODE_VN_<CHAINID>_<FLAG>` for one chain and `OP_SUPERNODE_VN_ALL_<FLAG>` for every chain.
+`<FLAG>` is the op-node flag name with hyphens and dots converted to underscores and uppercased.
+For example, `--vn.11155420.l2.engine-rpc-timeout` is equivalent to `OP_SUPERNODE_VN_11155420_L2_ENGINE_RPC_TIMEOUT`.
+
+<Info>
+  A few flags are owned by the supernode rather than by individual virtual nodes.
+  Setting them under `--vn.<chainID>.*` or `--vn.all.*` has no effect.
+
+  * `--l1` and `--l1.beacon`: the shared L1 plumbing replaces any per-chain L1 setting at startup.
+  * `--l1.http-poll-interval`: the shared L1 client owns the polling cadence; the supernode logs a warning if a per-chain value is set.
+  * `--log.*` and `--metrics.*`: passed down from the top-level flags; per-chain log and metrics settings may not be respected.
+  * P2P listen ports: see the [P2P](#p2p) section.
+</Info>
+
+The flags most operators need to set per chain are listed below.
+For the full set of op-node flags available under the `--vn.*` namespace, see the [op-node configuration reference](/node-operators/reference/op-node-config) and the [consensus client configuration page](/node-operators/guides/configuration/consensus-clients).
+
+#### vn.&lt;chainID&gt;.network
+
+Names the chain's known network configuration so the supernode can load the matching rollup config from op-node's built-in registry.
+Use this for any chain registered with op-node (`op-mainnet`, `op-sepolia`, `unichain-sepolia`, etc.).
+
+<Tabs>
+  <Tab title="Syntax">`--vn.<chainID>.network=<value>`</Tab>
+  <Tab title="Example">`--vn.11155420.network=op-sepolia`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_VN_<CHAINID>_NETWORK=`</Tab>
+</Tabs>
+
+#### vn.&lt;chainID&gt;.rollup.config
+
+Path to a rollup configuration JSON file for chains that are not in op-node's built-in network registry.
+Use this instead of `--vn.<chainID>.network` for custom devnets or any chain you have a rollup config file for.
+
+<Tabs>
+  <Tab title="Syntax">`--vn.<chainID>.rollup.config=<value>`</Tab>
+  <Tab title="Example">`--vn.420120037.rollup.config=/etc/op/rollup-config.json`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_VN_<CHAINID>_ROLLUP_CONFIG=`</Tab>
+</Tabs>
+
+#### vn.&lt;chainID&gt;.l2
+
+Address of the engine-API endpoint for the chain's execution client.
+Each chain needs its own execution client; one execution client cannot back two chains.
+
+<Tabs>
+  <Tab title="Syntax">`--vn.<chainID>.l2=<value>`</Tab>
+  <Tab title="Example">`--vn.11155420.l2=http://op-sepolia-geth:8551`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_VN_<CHAINID>_L2=`</Tab>
+</Tabs>
+
+#### vn.all.l2.jwt-secret
+
+Path to the JWT secret used to authenticate every virtual node's engine connection to its execution client.
+Set this at the `vn.all.*` level when every execution client in the dependency set shares one secret.
+Use the per-chain `--vn.<chainID>.l2.jwt-secret` form only when a chain's execution client requires its own secret.
+
+<Tabs>
+  <Tab title="Syntax">`--vn.all.l2.jwt-secret=<value>`</Tab>
+  <Tab title="Example">`--vn.all.l2.jwt-secret=/etc/op/jwt-secret.txt`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_VN_ALL_L2_JWT_SECRET=`</Tab>
+</Tabs>
+
+#### vn.&lt;chainID&gt;.l2.enginekind
+
+Selects the engine-client variant so the supernode can apply engine-API behavior tailored to each.
+Set to `reth` when the chain's execution client is op-reth; leave at the default for op-geth.
+Supported values are `geth` and `reth`.
+The default value is `geth`.
+
+<Tabs>
+  <Tab title="Syntax">`--vn.<chainID>.l2.enginekind=<value>`</Tab>
+  <Tab title="Example">`--vn.11155420.l2.enginekind=reth`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_VN_<CHAINID>_L2_ENGINEKIND=`</Tab>
+</Tabs>
+
+### P2P
+
+P2P is enabled at the supernode level for every chain, or disabled for every chain.
+Per-chain enable/disable is not supported.
+
+#### disable-p2p
+
+Disables P2P for every chain.
+The default value is `false`.
+Use this in topologies where unsafe-head P2P gossip is handled by other nodes in the fleet (for example, a Light CL fleet) and the supernode only needs to derive from L1.
+
+<Tabs>
+  <Tab title="Syntax">`--disable-p2p=<value>`</Tab>
+  <Tab title="Example">`--disable-p2p=true`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_DISABLE_P2P=`</Tab>
+</Tabs>
+
+#### Per-chain listen ports
+
+When P2P is enabled, each virtual node's P2P listen port defaults to `0` (dynamic) to prevent port collisions across chains.
+Setting `--vn.all.p2p.listen.tcp` or `--vn.all.p2p.listen.udp` to a non-zero value is rejected because the same port cannot be reused across virtual nodes.
+
+To pin static ports per chain, set both the TCP (RLPx) and UDP (discovery v5) ports with the per-chain form:
+
+```bash
+--vn.11155420.p2p.listen.tcp=9222 \
+--vn.11155420.p2p.listen.udp=9222 \
+--vn.1301.p2p.listen.tcp=9223 \
+--vn.1301.p2p.listen.udp=9223
+```
+
+### Interop verification
+
+The interop activity is the part of op-supernode that decides when a chain's blocks have satisfied their cross-chain dependencies.
+For background on how the activity decides between *wait*, *advance*, *invalidate*, and *rewind*, see the [supernode explainer](/op-stack/interop/supernode#cross-chain-message-safety).
+
+#### interop.activation-timestamp
+
+Overrides the interop activation timestamp derived from the loaded rollup configs.
+The default value is `0` (use the value from the rollup config).
+Set this only when activating interop on a custom devnet whose rollup config does not yet carry the activation timestamp.
+
+<Tabs>
+  <Tab title="Syntax">`--interop.activation-timestamp=<value>`</Tab>
+  <Tab title="Example">`--interop.activation-timestamp=1735689600`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP=`</Tab>
+</Tabs>
+
+#### interop.log-backfill-depth
+
+Extends initiating-message log ingestion backward from the L2 tip by this duration, clamped to the interop activation timestamp.
+Validation still starts only beyond the local safe head; the backfill pre-ingests logs so they are available when validation needs them.
+Requires the interop activation timestamp to be known, either from the rollup config or via `--interop.activation-timestamp`.
+The default value is `0` (no backfill).
+
+<Tabs>
+  <Tab title="Syntax">`--interop.log-backfill-depth=<value>`</Tab>
+  <Tab title="Example">`--interop.log-backfill-depth=168h`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_INTEROP_LOG_BACKFILL_DEPTH=`</Tab>
+</Tabs>
+
+### JSON-RPC server
+
+The supernode exposes a single JSON-RPC server that multiplexes activity methods and every chain's op-node RPC under one HTTP endpoint.
+Per-chain RPC namespaces are mounted under a `/<chainID>/` path prefix on the same server.
+For example, `POST /11155420/` reaches the OP Sepolia op-node RPC surface.
+Activity RPC methods (`superroot_atTimestamp`, `supernode_syncStatus`, `heartbeat_check`) are exposed at the root.
+For example, `POST /` with method `superroot_atTimestamp` reaches the SuperRoot activity.
+
+#### rpc.addr
+
+Address the JSON-RPC server binds to.
+The default value is `0.0.0.0`.
+
+<Tabs>
+  <Tab title="Syntax">`--rpc.addr=<value>`</Tab>
+  <Tab title="Example">`--rpc.addr=0.0.0.0`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_RPC_ADDR=`</Tab>
+</Tabs>
+
+#### rpc.port
+
+Port the JSON-RPC server listens on.
+The default value is `8545`.
+
+<Tabs>
+  <Tab title="Syntax">`--rpc.port=<value>`</Tab>
+  <Tab title="Example">`--rpc.port=8545`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_RPC_PORT=`</Tab>
+</Tabs>
+
+#### rpc.enable-admin
+
+Enables admin-namespace RPC methods.
+The default value is `false`.
+Enable this only on endpoints that are not exposed to untrusted networks.
+
+<Tabs>
+  <Tab title="Syntax">`--rpc.enable-admin=<value>`</Tab>
+  <Tab title="Example">`--rpc.enable-admin=true`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_RPC_ENABLE_ADMIN=`</Tab>
+</Tabs>
+
+### Logging
+
+Logging is configured at the top level for every chain.
+Per-chain log settings under the `--vn.*` namespace may not be respected.
+
+#### log.level
+
+Minimum log severity to emit.
+Valid values are `trace`, `debug`, `info`, `warn`, `error`, `crit`.
+The default value is `info`.
+
+<Tabs>
+  <Tab title="Syntax">`--log.level=<value>`</Tab>
+  <Tab title="Example">`--log.level=info`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_LOG_LEVEL=`</Tab>
+</Tabs>
+
+#### log.format
+
+Log output format.
+Valid values are `text`, `terminal`, `logfmt`, `json`, `json-pretty`.
+The default value is `text`.
+
+<Tabs>
+  <Tab title="Syntax">`--log.format=<value>`</Tab>
+  <Tab title="Example">`--log.format=json`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_LOG_FORMAT=`</Tab>
+</Tabs>
+
+#### log.color
+
+Forces ANSI color codes in `text` log output regardless of whether the stream is a terminal.
+The default value is `false`.
+
+<Tabs>
+  <Tab title="Syntax">`--log.color=<value>`</Tab>
+  <Tab title="Example">`--log.color=true`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_LOG_COLOR=`</Tab>
+</Tabs>
+
+### Metrics and profiling
+
+Metrics and profiling endpoints are configured at the top level.
+The metrics server fans in counters from every chain container and exposes them on one endpoint with per-chain Prometheus labels.
+
+#### metrics.enabled
+
+Enables the Prometheus metrics server.
+The default value is `false`.
+
+<Tabs>
+  <Tab title="Syntax">`--metrics.enabled=<value>`</Tab>
+  <Tab title="Example">`--metrics.enabled=true`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_METRICS_ENABLED=`</Tab>
+</Tabs>
+
+#### metrics.addr
+
+Address the metrics server binds to.
+The default value is `0.0.0.0`.
+
+<Tabs>
+  <Tab title="Syntax">`--metrics.addr=<value>`</Tab>
+  <Tab title="Example">`--metrics.addr=0.0.0.0`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_METRICS_ADDR=`</Tab>
+</Tabs>
+
+#### metrics.port
+
+Port the metrics server listens on.
+The default value is `7300`.
+
+<Tabs>
+  <Tab title="Syntax">`--metrics.port=<value>`</Tab>
+  <Tab title="Example">`--metrics.port=7300`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_METRICS_PORT=`</Tab>
+</Tabs>
+
+#### pprof.enabled
+
+Enables the pprof profiling endpoint.
+The default value is `false`.
+
+<Tabs>
+  <Tab title="Syntax">`--pprof.enabled=<value>`</Tab>
+  <Tab title="Example">`--pprof.enabled=true`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_PPROF_ENABLED=`</Tab>
+</Tabs>
+
+#### pprof.addr
+
+Address the pprof server binds to.
+The default value is `0.0.0.0`.
+
+<Tabs>
+  <Tab title="Syntax">`--pprof.addr=<value>`</Tab>
+  <Tab title="Example">`--pprof.addr=0.0.0.0`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_PPROF_ADDR=`</Tab>
+</Tabs>
+
+#### pprof.port
+
+Port the pprof server listens on.
+The default value is `6060`.
+
+<Tabs>
+  <Tab title="Syntax">`--pprof.port=<value>`</Tab>
+  <Tab title="Example">`--pprof.port=6060`</Tab>
+  <Tab title="Environment Variable">`OP_SUPERNODE_PPROF_PORT=`</Tab>
+</Tabs>
+
+## Where to go next
+
+* Read the [supernode explainer](/op-stack/interop/supernode) for what op-supernode is and why it exists.
+* Read the [specialized op-node topology notice](/notices/specialized-node-topology) for the operator-facing pattern of running Light CL fleets that follow a supernode safe source.
+* Read the [interop explainer](/op-stack/interop/explainer) for how cross-chain messaging works at the protocol level.
+* Read the [op-node configuration reference](/node-operators/reference/op-node-config) for the full set of flags available under the `--vn.*` namespace.
+* See the [op-supernode source](https://github.com/ethereum-optimism/optimism/tree/develop/op-supernode) in the monorepo for implementation detail.

--- a/docs/public-docs/node-operators/guides/configuration/supernode.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/supernode.mdx
@@ -66,11 +66,6 @@ The example uses environment variables; pass the equivalent `--flag` arguments i
 Fill in the placeholders before starting the binary.
 
 <Info>
-  Some `--vn.<chainID>.*` flags have an environment-variable suffix that doesn't mechanically match the CLI flag name (for example, `--vn.<id>.l2` is set by `OP_SUPERNODE_VN_<id>_L2_ENGINE_RPC`, and `--vn.all.l2.jwt-secret` is set by `OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH`).
-  The example below uses the correct environment-variable names from `--help`; copy them as shown.
-</Info>
-
-<Info>
   The example below assumes a two-chain dependency set of OP Sepolia (chain ID `11155420`) and Unichain Sepolia (chain ID `1301`).
   For a different dependency set, replace the chain IDs in `OP_SUPERNODE_CHAINS` and add or remove the matching `OP_SUPERNODE_VN_<CHAINID>_NETWORK` and `OP_SUPERNODE_VN_<CHAINID>_L2` pairs for each chain.
 </Info>
@@ -108,6 +103,13 @@ OP_SUPERNODE_METRICS_PORT: "7300"
 For chains that are not in op-node's built-in network registry, replace `--vn.<chainID>.network` with `--vn.<chainID>.rollup.config=<path-to-rollup-config.json>`.
 
 ## All configuration variables
+
+<Info>
+  Environment-variable names don't always derive mechanically from the CLI flag name.
+  Some env-var suffixes keep op-node's source-level spelling even when the CLI flag was renamed (for example, `--vn.<chainID>.l2` is set by `OP_SUPERNODE_VN_<chainID>_L2_ENGINE_RPC`, not `OP_SUPERNODE_VN_<chainID>_L2`).
+  The per-flag entries below show the correct env-var name alongside the CLI form.
+  When in doubt, run `op-supernode --chains=<chainIDs> --help` for the authoritative name of any flag.
+</Info>
 
 ### Dependency set and storage
 
@@ -200,10 +202,7 @@ The supernode reproduces the full op-node flag set under two prefixes so you can
 * **`--vn.all.<flag>`** sets `<flag>` for every chain in the dependency set.
 
 The environment-variable form follows the same prefix rule: `OP_SUPERNODE_VN_<CHAINID>_<SUFFIX>` for one chain and `OP_SUPERNODE_VN_ALL_<SUFFIX>` for every chain.
-The `<SUFFIX>` is the op-node flag's source-level environment-variable suffix — usually but not always derivable from the CLI flag name.
-For example, `--vn.11155420.l2.engine-rpc-timeout` becomes `OP_SUPERNODE_VN_11155420_L2_ENGINE_RPC_TIMEOUT` (CLI name matches the suffix), while `--vn.11155420.l2` becomes `OP_SUPERNODE_VN_11155420_L2_ENGINE_RPC` (the CLI was renamed but the environment-variable suffix kept the original op-node spelling).
-
-Consult `op-supernode --chains=<chainIDs> --help` for the authoritative environment-variable name of any flag. The per-flag entries below list the correct environment-variable form alongside the CLI form.
+The `<SUFFIX>` is the op-node flag's source-level environment-variable name (see the note at the top of [All configuration variables](#all-configuration-variables) for why it doesn't always match the CLI flag).
 
 <Info>
   A few flags are owned by the supernode rather than by individual virtual nodes.

--- a/docs/public-docs/node-operators/overview.mdx
+++ b/docs/public-docs/node-operators/overview.mdx
@@ -28,6 +28,9 @@ The following are the most popular implementations:
 * **[op-node](https://github.com/ethereum-optimism/optimism/tree/develop/op-node)** 
 * **[kona-node](https://github.com/ethereum-optimism/optimism/tree/develop/rust/kona/bin/node)** 
 
+For nodes running multiple chains as part of an [interop](/op-stack/interop/explainer) dependency set, deploy the consensus layer as **[op-supernode](/op-stack/interop/supernode)**, which hosts an op-node instance for every chain in one process and adds cross-chain message verification.
+See the [supernode configuration guide](/node-operators/guides/configuration/supernode) for the flag reference.
+
 ### Execution Layer 
 
 The execution layer provides the evm execution environment. 
@@ -48,3 +51,4 @@ Different node types serve different purposes:
 ## Next steps
 
 *   [**Run a Node from Docker**](/node-operators/tutorials/node-from-docker)
+*   [**Supernode configuration**](/node-operators/guides/configuration/supernode) — flag reference for running op-supernode in an interop dependency set.

--- a/docs/public-docs/op-stack/interop/supernode.mdx
+++ b/docs/public-docs/op-stack/interop/supernode.mdx
@@ -153,8 +153,9 @@ graph LR
 
 ## Where to go next
 
-*   Read the [interop explainer](/op-stack/interop/explainer) for how cross-chain messaging works at the protocol level.
+*   Read the [supernode configuration guide](/node-operators/guides/configuration/supernode) for the flag reference and a starter configuration.
+*   Read the [specialized op-node topology notice](/notices/specialized-node-topology) for the operator-facing pattern of running light op-nodes with `--l2.follow.source`, the fleet-side of the supernode-plus-light-CL topology.
 *   Read [interop reorg awareness](/op-stack/interop/reorg) for how the safety model handles equivocation and L1 reorgs.
 *   Read the [cross-chain security measures](/op-stack/security/interop-security) for how an operator can configure the safety level it requires for inbound messages.
-*   Read the [specialized op-node topology notice](/notices/specialized-node-topology) for the operator-facing pattern of running light op-nodes with `--l2.follow.source`, the fleet-side of the supernode-plus-light-CL topology.
+*   Read the [interop explainer](/op-stack/interop/explainer) for how cross-chain messaging works at the protocol level.
 *   For implementation detail, see the [op-supernode source](https://github.com/ethereum-optimism/optimism/tree/develop/op-supernode) in the monorepo.


### PR DESCRIPTION
## Summary

New configuration guide for **op-supernode** at `/node-operators/guides/configuration/supernode`, plus three companion edits to make it discoverable.

- **Audience:** node operators deploying op-supernode as the consensus layer for an interop dependency set.
- **Problem solved:** op-supernode had no public configuration reference. Operators had to read source, the README, or internal runbooks to learn the flag list, the `--vn.<chainID>.*` / `--vn.all.*` namespace rules, the supernode-owned-flag exclusions, and a working minimum viable configuration.
- **Form:** comprehensive (every flag documented), modeled after `chain-operators/guides/configuration/batcher.mdx`. 8 categories, 25 flags.
- **Tracks:** `op-supernode/v0.2.2-rc.8`. Page is explicit about its release-candidate status.

## Files changed

| File | Change |
|---|---|
| `docs/public-docs/node-operators/guides/configuration/supernode.mdx` | New page. |
| `docs/public-docs/docs.json` | Sidebar entry under Node Operators → Guides → Configuration. |
| `docs/public-docs/op-stack/interop/supernode.mdx` | Added the new guide to "Where to go next" and reordered the list with operator-actionable links first. |
| `docs/public-docs/node-operators/overview.mdx` | Referenced op-supernode in Consensus Layer and Next steps. |

## What to review

**Source-derived accuracy (highest priority — needs op-supernode context):**

1. **Flag list, defaults, env-var names, and behavior claims.** I built the op-supernode binary on this branch and validated three classes of claims against source + the binary's actual output:
   - **Env vars and default values** — via the new `check_help_env_vars.py` lint from op-claude-marketplace#89. All 26 `OP_SUPERNODE_*` references and all per-flag default values match `op-supernode --chains=11155420,1301 --help`. Corrections during this PR: four env-var names in per-flag entries, one env-var reference in an Info callout (line 70), one default-value mismatch (`interop.log-backfill-depth` `0` → `0s`). The single remaining script finding is a deliberate prose counter-example.
   - **Log/metrics propagation** — verified against `op-node/config/config.go` and `op-node/service.go:38`. op-node's Config struct has no LogConfig field; the logger is passed in from the supernode. So per-chain `--vn.*.log.*` flags are silently ignored, and top-level `--log.*` configures the one logger shared by the supernode and every virtual node. Metrics is different: each virtual node's Metrics config IS read from the VirtualCLI (`opmetrics.ReadCLIConfig(ctx)`), so per-chain `--vn.*.metrics.*` IS respected and fans into the supernode's endpoint. Initial wording collapsed log and metrics into one "passed down" claim; corrected to reflect actual behavior.
   - **`log.format` valid values** — verified against the FormatType constants in `op-service/log/cli.go`. Page now lists the actual six values (`text, terminal, logfmt, logfmtms, json, jsonms`); previously listed a non-existent `json-pretty` and was missing `logfmtms` / `jsonms`.

   Worth re-checking when a newer RC ships, since the env-var suffixes derive from op-node source-level names that can drift.
2. The \`--vn.<chainID>.*\` / \`--vn.all.*\` namespace explanation in "Per-chain virtual-node configuration" — the env-var conversion rule and the supernode-owned-flag exclusion list (\`l1\`, \`l1.beacon\`, \`l1.http-poll-interval\`, \`log.*\`, P2P listen ports). Note that \`metrics.*\` is intentionally NOT in this list: per-chain metrics are respected and fan into the supernode's endpoint with per-chain Prometheus labels.
3. The minimum viable configuration in \`## Example configuration\` — would copying this, filling placeholders, and starting the binary reach a working state? The supernode-level config fields match what `op-devstack/sysgo/multichain_supernode_runtime.go` uses to boot a supernode in CI tests, plus the operator-facing additions (JWT, network identity, engine RPC URLs, metrics) that devstack provides automatically but a CLI launch needs explicit.
4. The \`data-dir\` subdirectory scheme claim (\`chain-<chainID>\`). Verified against \`supernode_test_access.go:79\` but worth confirming.

**Open ambiguity (needs an engineering call):**

- \`interop.log-backfill-depth\`: the source flag comment says "Requires interop.activation-timestamp." but \`cmd/main.go:83\` only consumes the override flag if explicitly set; activation is otherwise derived from the rollup configs. The page is currently hedged ("either from the rollup config or via \`--interop.activation-timestamp\`"). If the strict reading is right, tighten back to "Requires \`--interop.activation-timestamp\` to be set explicitly."
- **Per-chain beacon archiver.** The op-supernode README example sets \`--vn.<id>.l1.beacon-archiver\` per chain, but the supernode has a single shared beacon client (per the explainer and per source). The MVC consolidates to top-level \`OP_SUPERNODE_L1_BEACON_FALLBACKS\`. The per-chain form isn't in \`SupernodeOwnedFlags\` (so it isn't explicitly dropped), but the shared beacon client wouldn't consult per-chain values either. Likely a stale leftover in the README from a different design. Engineering can confirm whether top-level is the only effective setting.

**Judgment calls:**

- Release tag anchor: \`op-supernode/v0.2.2-rc.8\`. Swap if a newer RC is preferred before merge.
- Three recommendations: shared JWT (\`--vn.all.l2.jwt-secret\`), beacon archiver fallback (\`--l1.beacon-fallbacks\`), Light CL fleet pairing. Open to adding or removing.
- **The README's env-var-naming caveat is real, not stale.** The supernode's env-var suffixes derive from op-node's original env-var names, which don't always match the renamed CLI flags. A single \`<Info>\` callout at the top of "All configuration variables" now spells out the caveat once, gives one concrete example, and tells readers to consult \`--help\` for the authoritative name of any flag. The per-flag entries below the callout list both forms verbatim. Previous instinct to dismiss the README caveat as stale was wrong.

## Out of scope

- Sequencer-mode supernode (verifier-only by intent for v1).
- Deployment-pattern naming like "supernode-el" (k8s concern, not flag reference).
- HA supernode pool coordination internals.
- Spec-level interop background (lives in the explainer and \`specs.optimism.io\`).

## Test plan

- [ ] \`mintlify dev\` from \`docs/public-docs/\` renders the new page and the updated sidebar without errors.
- [ ] Internal links resolve (lint script in the authoring skill: 11/11 internal links resolved at last commit).
- [ ] All 26 documented \`OP_SUPERNODE_*\` env-var references and all per-flag default values match \`op-supernode --chains=11155420,1301 --help\` exactly (verified via the new \`check_help_env_vars.py\` lint from op-claude-marketplace#89; one deliberate counter-example in prose remains as a known false-positive class).
- [ ] \`log.format\` valid-values list matches `FormatType` constants in `op-service/log/cli.go` (text, terminal, logfmt, logfmtms, json, jsonms).
- [ ] \`docs.json\` parses as valid JSON.
- [ ] The page renders correctly on the docs preview environment.
- [ ] An op-supernode engineer signs off on the source-derived content and the two open ambiguities above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)