### PR TITLE
feat(op-node): add follow source success metric

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -83,7 +83,7 @@ type Metrics struct {
 	L1SourceCache *metrics.CacheMetrics
 	L2SourceCache *metrics.CacheMetrics
 
-	L2FollowSourceCache *metrics.CacheMetrics
+	L2FollowSourceCache   *metrics.CacheMetrics
 	FollowSourceErrors    *prometheus.CounterVec
 	FollowSourceSuccesses prometheus.Counter
 

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -84,7 +84,8 @@ type Metrics struct {
 	L2SourceCache *metrics.CacheMetrics
 
 	L2FollowSourceCache *metrics.CacheMetrics
-	FollowSourceErrors  *prometheus.CounterVec
+	FollowSourceErrors    *prometheus.CounterVec
+	FollowSourceSuccesses prometheus.Counter
 
 	DerivationIdle prometheus.Gauge
 
@@ -194,6 +195,11 @@ func NewMetrics(procName string, labels prometheus.Labels) *Metrics {
 			Name:      "follow_source_errors_total",
 			Help:      "Count of follow source errors by reason",
 		}, []string{"reason"}),
+		FollowSourceSuccesses: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "follow_source_successes_total",
+			Help:      "Count of successful follow source updates",
+		}),
 
 		DerivationIdle: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
@@ -485,6 +491,10 @@ func (m *Metrics) RecordFollowSourceError(reason string) {
 	m.FollowSourceErrors.WithLabelValues(reason).Inc()
 }
 
+func (m *Metrics) RecordFollowSourceSuccess() {
+	m.FollowSourceSuccesses.Inc()
+}
+
 func (m *Metrics) RecordSequencerReset() {
 	m.SequencerResets.Record()
 }
@@ -649,6 +659,9 @@ func (n *noopMetricer) RecordPipelineReset() {
 }
 
 func (n *noopMetricer) RecordFollowSourceError(reason string) {
+}
+
+func (n *noopMetricer) RecordFollowSourceSuccess() {
 }
 
 func (n *noopMetricer) RecordSequencingError() {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -577,5 +577,6 @@ func (s *Driver) followUpstream() {
 		s.emitter.Emit(s.driverCtx, derive.DeriverL1StatusEvent{Origin: status.CurrentL1})
 	}
 	// Only reach this point if all L1 checks passed
+	s.metrics.RecordFollowSourceSuccess()
 	s.SyncDeriver.Engine.FollowSource(status.SafeL2, status.LocalSafeL2, status.FinalizedL2)
 }

--- a/op-node/rollup/driver/interfaces.go
+++ b/op-node/rollup/driver/interfaces.go
@@ -17,6 +17,7 @@ import (
 type Metrics interface {
 	RecordPipelineReset()
 	RecordFollowSourceError(reason string)
+	RecordFollowSourceSuccess()
 	RecordPublishingError()
 	RecordDerivationError()
 


### PR DESCRIPTION
## Summary
- Adds `follow_source_successes_total` prometheus counter to track successful follow source updates
- Complements existing `follow_source_errors_total` metric for full observability of the follow source path
- Metric is recorded at the end of `followUpstream()` after all validation checks pass

## Test plan
- [ ] Verify `op-node` builds cleanly
- [ ] Confirm metric appears in `/metrics` endpoint when follow source is enabled
- [ ] Check Grafana dashboards can query `follow_source_successes_total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)