### PR TITLE
test: reproduce supernode L1 reorg cross-safe stall

### DIFF
--- a/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
@@ -12,20 +12,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type checksFunc func(t devtest.T, sys *presets.SimpleInterop)
+type checksFunc func(t devtest.T, sys *presets.TwoL2SupernodeInterop)
 
 func TestL2ReorgAfterL1Reorg(gt *testing.T) {
-	gt.Skip("Skipping Interop Acceptance Test")
-
 	gt.Run("unsafe reorg", func(gt *testing.T) {
 		var crossSafeRef, localSafeRef, unsafeRef eth.BlockID
-		pre := func(t devtest.T, sys *presets.SimpleInterop) {
-			ss := sys.Supervisor.FetchSyncStatus()
-			crossSafeRef = ss.Chains[sys.L2ChainA.ChainID()].CrossSafe
-			localSafeRef = ss.Chains[sys.L2ChainA.ChainID()].LocalSafe
-			unsafeRef = ss.Chains[sys.L2ChainA.ChainID()].LocalUnsafe.ID()
+		pre := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
+			ss := sys.L2ACL.SyncStatus()
+			crossSafeRef = ss.SafeL2.ID()
+			localSafeRef = ss.LocalSafeL2.ID()
+			unsafeRef = ss.UnsafeL2.ID()
 		}
-		post := func(t devtest.T, sys *presets.SimpleInterop) {
+		post := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
 			require.True(t, sys.L2ELA.IsCanonical(crossSafeRef), "Previous cross-safe block should still be canonical")
 			require.True(t, sys.L2ELA.IsCanonical(localSafeRef), "Previous local-safe block should still be canonical")
 			require.False(t, sys.L2ELA.IsCanonical(unsafeRef), "Previous unsafe block should have been reorged")
@@ -35,14 +33,14 @@ func TestL2ReorgAfterL1Reorg(gt *testing.T) {
 
 	gt.Run("unsafe, local-safe, cross-unsafe, cross-safe reorgs", func(gt *testing.T) {
 		var crossSafeRef, crossUnsafeRef, localSafeRef, unsafeRef eth.BlockID
-		pre := func(t devtest.T, sys *presets.SimpleInterop) {
-			ss := sys.Supervisor.FetchSyncStatus()
-			crossUnsafeRef = ss.Chains[sys.L2ChainA.ChainID()].CrossUnsafe
-			crossSafeRef = ss.Chains[sys.L2ChainA.ChainID()].CrossSafe
-			localSafeRef = ss.Chains[sys.L2ChainA.ChainID()].LocalSafe
-			unsafeRef = ss.Chains[sys.L2ChainA.ChainID()].LocalUnsafe.ID()
+		pre := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
+			ss := sys.L2ACL.SyncStatus()
+			crossUnsafeRef = ss.CrossUnsafeL2.ID()
+			crossSafeRef = ss.SafeL2.ID()
+			localSafeRef = ss.LocalSafeL2.ID()
+			unsafeRef = ss.UnsafeL2.ID()
 		}
-		post := func(t devtest.T, sys *presets.SimpleInterop) {
+		post := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
 			require.False(t, sys.L2ELA.IsCanonical(crossSafeRef), "Previous cross-safe block should have been reorged")
 			require.False(t, sys.L2ELA.IsCanonical(crossUnsafeRef), "Previous cross-unsafe block should have been reorged")
 			require.False(t, sys.L2ELA.IsCanonical(localSafeRef), "Previous local-safe block should have been reorged")
@@ -61,9 +59,14 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	t := devtest.ParallelT(gt)
 	ctx := t.Ctx()
 
-	sys := presets.NewSimpleInterop(t)
+	sys := presets.NewTwoL2SupernodeInterop(t, 0)
 
 	sys.L1Network.WaitForBlock()
+
+	// Build a stable cross-safe foundation before we stop the L1 CL and manually sequence.
+	// This ensures the supernode has verified state that references canonical L1 blocks,
+	// so after the reorg it doesn't need to rewind all the way back to genesis.
+	sys.L2ACL.Advanced(types.CrossSafe, 20, 100)
 
 	sys.L1CL.Stop()
 
@@ -71,8 +74,8 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	for range n + 1 {
 		sys.TestSequencer.SequenceBlock(t, sys.L1Network.ChainID(), common.Hash{})
 
-		sys.L2ChainA.WaitForBlock()
-		sys.L2ChainA.WaitForBlock()
+		sys.L2A.WaitForBlock()
+		sys.L2A.WaitForBlock()
 	}
 
 	// select a divergence block to reorg from
@@ -85,7 +88,7 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	}
 
 	// print the chains before sequencing an alternative L1 block
-	sys.L2ChainA.PrintChain()
+	sys.L2A.PrintChain()
 	sys.L1Network.PrintChain()
 
 	// pre reorg trigger validations and checks
@@ -102,8 +105,21 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	// confirm L1 reorged
 	sys.L1EL.ReorgTriggered(divergence, 5)
 
-	// wait until L2 chain A cross-safe ref caught up to where it was before the reorg
-	sys.L2CLA.Reached(types.CrossSafe, tipL2_preReorg.Number, 50)
+	// Wait until L2 chain A cross-safe ref caught up to where it was before the reorg.
+	// Use require.Eventually instead of sys.L2ACL.Reached because the supernode rewinds
+	// one timestamp at a time after an L1 reorg, stopping and restarting VNs each cycle.
+	// During these rewinds the CL RPC is temporarily unavailable, and Reached() would
+	// fatally fail via require.NoError on the transient RPC error.
+	require.Eventually(t, func() bool {
+		ss, err := sys.L2ACL.Escape().RollupAPI().SyncStatus(ctx)
+		if err != nil {
+			sys.Log.Info("SyncStatus unavailable during rewind, retrying", "err", err)
+			return false
+		}
+		sys.Log.Info("waiting for cross-safe to reach pre-reorg tip",
+			"cross_safe", ss.SafeL2.Number, "target", tipL2_preReorg.Number)
+		return ss.SafeL2.Number >= tipL2_preReorg.Number
+	}, 10*time.Minute, 5*time.Second, "L2 chain A cross-safe should reach pre-reorg tip %d", tipL2_preReorg.Number)
 
 	// test that latest chain A unsafe is not referencing a reorged L1 block (through the L1Origin field)
 	require.Eventually(t, func() bool {
@@ -118,7 +134,7 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 		sys.Log.Info("current unsafe ref", "tip", unsafe, "tip_origin", unsafe.L1Origin, "l1blk", eth.InfoToL1BlockRef(block))
 
 		// print the chains so we have information to debug if the test fails
-		sys.L2ChainA.PrintChain()
+		sys.L2A.PrintChain()
 		sys.L1Network.PrintChain()
 
 		return block.Hash() == unsafe.L1Origin.Hash


### PR DESCRIPTION
## Summary

Migrates `TestL2ReorgAfterL1Reorg` to `NewTwoL2SupernodeInterop` so the L1 reorg case runs through supernode. This reproduces the supernode cross-safe stall / invalid FCU behavior after a deeper L1 reorg.

## Repro command

```sh
RUST_JIT_BUILD=1 DEVSTACK_L2EL_KIND=op-geth mise exec -- go test -v -count=1 -run 'TestL2ReorgAfterL1Reorg/unsafe.*local-safe.*cross' ./op-acceptance-tests/tests/interop/reorgs/ -timeout 20m
```

## Repro log excerpt

The `codex:` lines below came from temporary local instrumentation in `EngineController.SafeL2Head()` and are not committed in this PR. They show that the rejected FCU safe hash is sourced directly from `superAuthority.FullyVerifiedL2Head()`.

Chain 901:

```text
12:50:23.208 L2 reorg: existing unsafe block does not match derived attributes from L1 component=supernode chain_id=901 vn_id=cd13 unsafe=ca8f7d..c644d1:51 pending_safe=bf3b7f..367397:50
12:50:23.208 codex: SafeL2Head superAuthority result component=supernode chain_id=901 vn_id=cd13 fvshid=288f1f..ae1444:41 useLocalSafe=false local_safe=bf3b7f..367397:50
12:50:23.208 codex: SafeL2Head returning superAuthority block component=supernode chain_id=901 vn_id=cd13 safe=288f1f..ae1444:41 fvshid=288f1f..ae1444:41 local_safe=bf3b7f..367397:50
12:50:23.208 Failed to share forkchoice-updated signal component=supernode chain_id=901 vn_id=cd13 state="&{HeadBlockHash:0xbf3b7f17a30be2526de54e931270ecf5bc194f016d2b273ae16f0668be367397 SafeBlockHash:0x288f1fb44a319b67e9d98cede080e37b1eba67f2f1d27804a1ce7a4389ae1444 FinalizedBlockHash:0x5706e12554941bc44df1b56f99639c7448c88ca5133e9ccfa3de057ce5717578}" err="Invalid forkchoice state: map[err:safe block not in canonical chain]"
12:50:23.209 Loaded current L2 heads component=supernode chain_id=901 vn_id=cd13 unsafe=8b82b7..2cecb5:62 safe=f69547..73fb11:27 finalized=5706e1..717578:0 unsafe_origin=949c09..7e1464:20 safe_origin=640050..ba5196:7
```

Chain 902:

```text
12:50:23.234 L2 reorg: existing unsafe block does not match derived attributes from L1 component=supernode chain_id=902 vn_id=2b04 unsafe=ae3369..f33502:51 pending_safe=d792fe..cc74d2:50
12:50:23.234 codex: SafeL2Head superAuthority result component=supernode chain_id=902 vn_id=2b04 fvshid=043dd1..638427:41 useLocalSafe=false local_safe=d792fe..cc74d2:50
12:50:23.234 codex: SafeL2Head returning superAuthority block component=supernode chain_id=902 vn_id=2b04 safe=043dd1..638427:41 fvshid=043dd1..638427:41 local_safe=d792fe..cc74d2:50
12:50:23.234 Failed to share forkchoice-updated signal component=supernode chain_id=902 vn_id=2b04 state="&{HeadBlockHash:0xd792fe3cd921f81757d83a9d07b33e342229207b2666c148aa640a3f4dcc74d2 SafeBlockHash:0x043dd11026f193179ef4df5a49c66acd58ede5996ad32deb29947de1c7638427 FinalizedBlockHash:0xe837abaadbe59d378befff14778e520ccda8bc7e960497f8650fce46b0555378}" err="Invalid forkchoice state: map[err:safe block not in canonical chain]"
12:50:23.235 Loaded current L2 heads component=supernode chain_id=902 vn_id=2b04 unsafe=af17fb..933de1:62 safe=5209e6..f5d34b:27 finalized=e837ab..555378:0 unsafe_origin=949c09..7e1464:20 safe_origin=640050..ba5196:7
```

## Notes

The key observation is that the FCU `SafeBlockHash` exactly matches the super-authority `fvshid`, while the EL rejects it as `safe block not in canonical chain` after the L1 reorg.