### PR TITLE
fix(op-node): ignore non-canonical super authority safe head

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -222,7 +222,8 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		}
 		br, err := e.engine.L2BlockRefByHash(e.ctx, fvshid.Hash)
 		if err != nil {
-			panic("superAuthority supplied an identifier for the safe head which is not known to the engine")
+			e.log.Warn("superAuthority safe head is not known to the engine, using finalized head", "super_authority_safe", fvshid, "finalized", e.localFinalizedHead, "err", err)
+			return e.localFinalizedHead
 		}
 		canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
 		if err != nil {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -222,17 +222,20 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		}
 		br, err := e.engine.L2BlockRefByHash(e.ctx, fvshid.Hash)
 		if err != nil {
-			e.log.Warn("superAuthority safe head is not known to the engine, using finalized head", "super_authority_safe", fvshid, "finalized", e.localFinalizedHead, "err", err)
-			return e.localFinalizedHead
+			finalized := e.FinalizedHead()
+			e.log.Warn("superAuthority safe head is not known to the engine, using finalized head", "super_authority_safe", fvshid, "finalized", finalized, "err", err)
+			return finalized
 		}
 		canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
 		if err != nil {
-			e.log.Warn("cannot verify superAuthority safe head canonicality, using finalized head", "super_authority_safe", br, "finalized", e.localFinalizedHead, "err", err)
-			return e.localFinalizedHead
+			finalized := e.FinalizedHead()
+			e.log.Warn("cannot verify superAuthority safe head canonicality, using finalized head", "super_authority_safe", br, "finalized", finalized, "err", err)
+			return finalized
 		}
 		if canonical.Hash != br.Hash {
-			e.log.Warn("superAuthority safe head is not canonical, using finalized head", "super_authority_safe", br, "canonical", canonical, "finalized", e.localFinalizedHead)
-			return e.localFinalizedHead
+			finalized := e.FinalizedHead()
+			e.log.Warn("superAuthority safe head is not canonical, using finalized head", "super_authority_safe", br, "canonical", canonical, "finalized", finalized)
+			return finalized
 		}
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -226,12 +226,12 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		}
 		canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
 		if err != nil {
-			e.log.Warn("cannot verify superAuthority safe head canonicality, using local safe head", "super_authority_safe", br, "local_safe", e.localSafeHead, "err", err)
-			return e.localSafeHead
+			e.log.Warn("cannot verify superAuthority safe head canonicality, using finalized head", "super_authority_safe", br, "finalized", e.localFinalizedHead, "err", err)
+			return e.localFinalizedHead
 		}
 		if canonical.Hash != br.Hash {
-			e.log.Warn("superAuthority safe head is not canonical, using local safe head", "super_authority_safe", br, "canonical", canonical, "local_safe", e.localSafeHead)
-			return e.localSafeHead
+			e.log.Warn("superAuthority safe head is not canonical, using finalized head", "super_authority_safe", br, "canonical", canonical, "finalized", e.localFinalizedHead)
+			return e.localFinalizedHead
 		}
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -224,6 +224,15 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		if err != nil {
 			panic("superAuthority supplied an identifier for the safe head which is not known to the engine")
 		}
+		canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
+		if err != nil {
+			e.log.Warn("cannot verify superAuthority safe head canonicality, using local safe head", "super_authority_safe", br, "local_safe", e.localSafeHead, "err", err)
+			return e.localSafeHead
+		}
+		if canonical.Hash != br.Hash {
+			e.log.Warn("superAuthority safe head is not canonical, using local safe head", "super_authority_safe", br, "canonical", canonical, "local_safe", e.localSafeHead)
+			return e.localSafeHead
+		}
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedSafeHead

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -244,20 +244,22 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50},
 		},
 		{
-			name:              "falls back to local safe when SuperAuthority block is not canonical",
+			name:              "falls back to SuperAuthority finalized when SuperAuthority block is not canonical",
 			supervisorEnabled: true,
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
 					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					finalizedL2Head:     eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}, nil)
+				m.ExpectL2BlockRefByHash(common.Hash{0xee}, eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40}, nil)
 			},
-			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40},
 		},
 		{
 			name:              "with SuperAuthority empty BlockID returns genesis",
@@ -296,19 +298,21 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult:   &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
-			name:              "falls back to finalized when SuperAuthority block unknown to engine",
+			name:              "falls back to SuperAuthority finalized when SuperAuthority block unknown to engine",
 			supervisorEnabled: true,
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
 					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
+					finalizedL2Head:     eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
+				m.ExpectL2BlockRefByHash(common.Hash{0xee}, eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40}, nil)
 			},
-			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40},
 		},
 	}
 

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -296,7 +296,7 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult:   &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
-			name:              "panics when SuperAuthority block unknown to engine",
+			name:              "falls back to finalized when SuperAuthority block unknown to engine",
 			supervisorEnabled: true,
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
@@ -304,10 +304,11 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 			},
-			expectPanic: "superAuthority supplied an identifier for the safe head which is not known to the engine",
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 		},
 	}
 

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -222,6 +222,7 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 		supervisorEnabled bool
 		setupSuperAuth    func() *mockSuperAuthority
 		setupLocalSafe    *eth.L2BlockRef
+		setupFinalized    *eth.L2BlockRef
 		setupDeprecated   *eth.L2BlockRef
 		setupEngine       func(*testutils.MockEngine)
 		expectPanic       string
@@ -251,11 +252,12 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}, nil)
 			},
-			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 		},
 		{
 			name:              "with SuperAuthority empty BlockID returns genesis",
@@ -327,6 +329,9 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, tt.supervisorEnabled, &testutils.MockL1Source{}, emitter, superAuthority)
 			if tt.setupLocalSafe != nil {
 				ec.SetLocalSafeHead(*tt.setupLocalSafe)
+			}
+			if tt.setupFinalized != nil {
+				ec.SetFinalizedHead(*tt.setupFinalized)
 			}
 			if tt.setupDeprecated != nil {
 				ec.SetDeprecatedSafeHead(*tt.setupDeprecated)

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -238,8 +238,24 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
+				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 			},
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50},
+		},
+		{
+			name:              "falls back to local safe when SuperAuthority block is not canonical",
+			supervisorEnabled: true,
+			setupSuperAuth: func() *mockSuperAuthority {
+				return &mockSuperAuthority{
+					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+				}
+			},
+			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupEngine: func(m *testutils.MockEngine) {
+				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
+				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}, nil)
+			},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
 			name:              "with SuperAuthority empty BlockID returns genesis",
@@ -369,6 +385,7 @@ func TestEngineController_ForkchoiceUpdateUsesSuperAuthority(t *testing.T) {
 	// SafeL2Head is called multiple times during initialization and forkchoice - be generous
 	for i := 0; i < 10; i++ {
 		mockEngine.ExpectL2BlockRefByHash(verifiedRef.Hash, verifiedRef, nil)
+		mockEngine.ExpectL2BlockRefByNumber(verifiedRef.Number, verifiedRef, nil)
 	}
 	// FinalizedHead is also called and will look up the finalized block by hash
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
## Summary

Adds a defensive guard around the safe head returned by `SuperAuthority` before op-node uses it as the FCU `SafeBlockHash`.

During the L1 reorg repro, the super authority can temporarily return a cross-verified safe block from the old L2 fork while the local EL has already rewound/moved to the new canonical chain. There are two bad safe-head cases:

```text
Failed to share forkchoice-updated signal ... SafeBlockHash=<old-fork safe> ... err="Invalid forkchoice state: map[err:safe block not in canonical chain]"
```

and, during engine rewind, the safe hash may no longer be known to the local engine at all.

This PR keeps the small guard approach: resolve the super-authority safe by hash, verify that the block is canonical by checking the block at the same number, and only use it if the local EL agrees. If the hash is unknown, canonicality cannot be checked, or the hash is not canonical at its number, op-node logs a warning and falls back to `FinalizedHead()`.

In supernode mode, `FinalizedHead()` resolves through `SuperAuthority.FinalizedL2Head()`, not the raw local finalized head. That avoids mixing local-safe/finalized authority sources, but the repro below shows this is still not sufficient if super-authority finalized is stale too.

## Current Repro Status

Command used on the repro branch with this PR cherry-picked:

```sh
RUST_JIT_BUILD=1 DEVSTACK_L2EL_KIND=op-geth mise exec -- bash -lc "go test -v -count=1 -run 'TestL2ReorgAfterL1Reorg/unsafe.*local-safe.*cross' ./op-acceptance-tests/tests/interop/reorgs/ -timeout 20m 2>&1 | tee /tmp/supernode-canonical-safe-fcu-repro-superauth-finalized.log"
```

Observed:

- The original panic path is avoided: stale/non-canonical super-authority safe is detected before being used directly as FCU safe.
- The focused repro waits for cross-safe to reach the pre-reorg tip, so it relies on the batcher recovering and re-submitting post-reorg batches.
- The run hit repeated batcher sync warnings such as `sequencer currentL1 reversed` with `currentL1=0` and a higher previous current L1. In `op-batcher/batcher/sync_actions.go`, that returns `outOfSync=true`, so the batcher skips state clearing/loading and waits for a later tick.
- More importantly, the run later showed `SuperAuthority.FinalizedL2Head()` could equal the same old-fork/non-canonical block as the stale safe head in this forced reorg scenario:

```text
superAuthority safe head is not canonical, using finalized head ... super_authority_safe=<old-fork>:33 canonical=<new-fork>:33 finalized=<old-fork>:33
Failed to share forkchoice-updated signal ... SafeBlockHash=<old-fork>:33 FinalizedBlockHash=<old-fork>:33 err="Invalid forkchoice state: map[err:final block not in canonical chain]"
```

So the current fallback to super-authority finalized is useful as an experiment, but it is not a complete fix for the repro. If super-authority finalized is stale/non-canonical, the FCU is still invalid.

## Options Considered

Option A: defensive FCU guard, implemented here.

- Check that the super-authority safe is known and canonical in the local EL before using it.
- Fall back if the super-authority safe is stale relative to the local EL.
- Smallest change and directly prevents the original safe-head panic path.
- Does not fix the root stale-state race; it only prevents one stale state from poisoning forkchoice.

Option B: reset or invalidate super-authority safe/finalized state on L1 reorg / engine rewind.

- When a VN/engine rewinds, mark the super-authority fully verified safe for that chain stale until it is recomputed on the post-reorg canonical chain.
- This is the cleaner root fix because `SuperAuthority` would stop advertising old-fork heads in the first place.
- The repro suggests this may need to cover finalized state as well, at least for this forced deep-reorg test scenario.
- Requires more careful coordination between engine reset, derivation reset, and interop/super-authority state.

Option C: make super-authority track canonical L2 refs explicitly.

- Store or publish a fully verified safe as a canonical `L2BlockRef`, not just an interop-verified block ID.
- Invalidate it on canonical-chain changes, or only advance it from local canonical inputs.
- This would reduce the need for RPC validation in `SafeL2Head()` and make the source-of-truth invariant clearer: the FCU safe must be both cross-verified and canonical in the local EL.

Option D: make `SafeL2Head()` return an error.

- More explicit API, but broad and noisy because many call sites assume head access is infallible.
- Better as part of a larger cleanup if we want all engine/safe accessors to distinguish unavailable, stale, and invariant-violation cases.

## Recommended Long-Term Fix

Keep this PR as a draft while we decide the correct fallback semantics. The strongest long-term fix is Option B/C: `SuperAuthority` should invalidate or recompute its safe/finalized view when the local engine rewinds due to an L1 reorg. After a reset, it should not keep returning a head merely because that block was previously interop-verified; the head must also be canonical in the local EL's current chain.

Concretely, the long-term invariant should be:

```text
FCU safe/finalized heads must be known to and canonical in this local EL
```

The current PR enforces that for `SafeL2Head()` but the repro shows the same stale-state problem can appear through `FinalizedHead()` when using super-authority finalized as the fallback.

## Tests

```sh
mise exec -- go test ./op-node/rollup/engine -run 'TestEngineController_(SafeL2Head|FinalizedHead|ForkchoiceUpdateUsesSuperAuthority)' -count=1
mise exec -- go test ./op-node/rollup/engine -count=1
```

Repro log path from the latest run:

```text
/tmp/supernode-canonical-safe-fcu-repro-superauth-finalized.log
```
