### PR TITLE
fix(interop): make the op-node resilient to L1 reorgs beyond the cross-safe head

### DIFF
--- a/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
@@ -17,10 +17,15 @@ type checksFunc func(t devtest.T, sys *presets.TwoL2SupernodeInterop)
 func TestL2ReorgAfterL1Reorg(gt *testing.T) {
 	gt.Run("unsafe reorg", func(gt *testing.T) {
 		var crossSafeRef, localSafeRef, unsafeRef eth.BlockID
-		pre := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
+		// Capture refs that must remain canonical before the manual L1 sequencing loop runs,
+		// so their L1 origins are in the pre-divergence prefix.
+		preEarly := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
 			ss := sys.L2ACL.SyncStatus()
 			crossSafeRef = ss.SafeL2.ID()
 			localSafeRef = ss.LocalSafeL2.ID()
+		}
+		pre := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
+			ss := sys.L2ACL.SyncStatus()
 			unsafeRef = ss.UnsafeL2.ID()
 		}
 		post := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
@@ -28,7 +33,7 @@ func TestL2ReorgAfterL1Reorg(gt *testing.T) {
 			require.True(t, sys.L2ELA.IsCanonical(localSafeRef), "Previous local-safe block should still be canonical")
 			require.False(t, sys.L2ELA.IsCanonical(unsafeRef), "Previous unsafe block should have been reorged")
 		}
-		testL2ReorgAfterL1Reorg(gt, 3, pre, post)
+		testL2ReorgAfterL1Reorg(gt, 3, preEarly, pre, post)
 	})
 
 	gt.Run("unsafe, local-safe, cross-unsafe, cross-safe reorgs", func(gt *testing.T) {
@@ -46,7 +51,8 @@ func TestL2ReorgAfterL1Reorg(gt *testing.T) {
 			require.False(t, sys.L2ELA.IsCanonical(localSafeRef), "Previous local-safe block should have been reorged")
 			require.False(t, sys.L2ELA.IsCanonical(unsafeRef), "Previous unsafe block should have been reorged")
 		}
-		testL2ReorgAfterL1Reorg(gt, 10, pre, post)
+		preEarly := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {}
+		testL2ReorgAfterL1Reorg(gt, 10, preEarly, pre, post)
 	})
 }
 
@@ -54,8 +60,13 @@ func TestL2ReorgAfterL1Reorg(gt *testing.T) {
 // for unsafe reorgs - n must be at least >= confDepth, which is 2 in our test deployments
 // for cross-safe reorgs - n must be at least >= safe distance, which is 10 in our test deployments (set in
 // op-e2e/e2eutils/geth/geth.go when initialising FakePoS)
-// pre- and post-checks are sanity checks to ensure that the blocks we expected to be reorged were indeed reorged or not
-func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksFunc) {
+// preEarlyChecks runs before the L1 CL is stopped, so refs captured there have L1 origins in
+// the pre-divergence prefix (anything visible before Stop has L1Origin.Number <= T0, and the
+// reorg's alternative chain branches at T0's child).
+// preChecks runs after the manual L1 sequencing loop, so refs captured there can land in the
+// to-be-reorged window.
+// postChecks runs after the reorg has been recovered.
+func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preEarlyChecks, preChecks, postChecks checksFunc) {
 	t := devtest.ParallelT(gt)
 	ctx := t.Ctx()
 
@@ -67,6 +78,8 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	// This ensures the supernode has verified state that references canonical L1 blocks,
 	// so after the reorg it doesn't need to rewind all the way back to genesis.
 	sys.L2ACL.Advanced(types.CrossSafe, 20, 100)
+
+	preEarlyChecks(t, sys)
 
 	sys.L1CL.Stop()
 

--- a/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
@@ -12,20 +12,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type checksFunc func(t devtest.T, sys *presets.SimpleInterop)
+type checksFunc func(t devtest.T, sys *presets.TwoL2SupernodeInterop)
 
 func TestL2ReorgAfterL1Reorg(gt *testing.T) {
-	gt.Skip("Skipping Interop Acceptance Test")
-
 	gt.Run("unsafe reorg", func(gt *testing.T) {
 		var crossSafeRef, localSafeRef, unsafeRef eth.BlockID
-		pre := func(t devtest.T, sys *presets.SimpleInterop) {
-			ss := sys.Supervisor.FetchSyncStatus()
-			crossSafeRef = ss.Chains[sys.L2ChainA.ChainID()].CrossSafe
-			localSafeRef = ss.Chains[sys.L2ChainA.ChainID()].LocalSafe
-			unsafeRef = ss.Chains[sys.L2ChainA.ChainID()].LocalUnsafe.ID()
+		pre := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
+			ss := sys.L2ACL.SyncStatus()
+			crossSafeRef = ss.SafeL2.ID()
+			localSafeRef = ss.LocalSafeL2.ID()
+			unsafeRef = ss.UnsafeL2.ID()
 		}
-		post := func(t devtest.T, sys *presets.SimpleInterop) {
+		post := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
 			require.True(t, sys.L2ELA.IsCanonical(crossSafeRef), "Previous cross-safe block should still be canonical")
 			require.True(t, sys.L2ELA.IsCanonical(localSafeRef), "Previous local-safe block should still be canonical")
 			require.False(t, sys.L2ELA.IsCanonical(unsafeRef), "Previous unsafe block should have been reorged")
@@ -35,14 +33,14 @@ func TestL2ReorgAfterL1Reorg(gt *testing.T) {
 
 	gt.Run("unsafe, local-safe, cross-unsafe, cross-safe reorgs", func(gt *testing.T) {
 		var crossSafeRef, crossUnsafeRef, localSafeRef, unsafeRef eth.BlockID
-		pre := func(t devtest.T, sys *presets.SimpleInterop) {
-			ss := sys.Supervisor.FetchSyncStatus()
-			crossUnsafeRef = ss.Chains[sys.L2ChainA.ChainID()].CrossUnsafe
-			crossSafeRef = ss.Chains[sys.L2ChainA.ChainID()].CrossSafe
-			localSafeRef = ss.Chains[sys.L2ChainA.ChainID()].LocalSafe
-			unsafeRef = ss.Chains[sys.L2ChainA.ChainID()].LocalUnsafe.ID()
+		pre := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
+			ss := sys.L2ACL.SyncStatus()
+			crossUnsafeRef = ss.CrossUnsafeL2.ID()
+			crossSafeRef = ss.SafeL2.ID()
+			localSafeRef = ss.LocalSafeL2.ID()
+			unsafeRef = ss.UnsafeL2.ID()
 		}
-		post := func(t devtest.T, sys *presets.SimpleInterop) {
+		post := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
 			require.False(t, sys.L2ELA.IsCanonical(crossSafeRef), "Previous cross-safe block should have been reorged")
 			require.False(t, sys.L2ELA.IsCanonical(crossUnsafeRef), "Previous cross-unsafe block should have been reorged")
 			require.False(t, sys.L2ELA.IsCanonical(localSafeRef), "Previous local-safe block should have been reorged")
@@ -61,9 +59,14 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	t := devtest.ParallelT(gt)
 	ctx := t.Ctx()
 
-	sys := presets.NewSimpleInterop(t)
+	sys := presets.NewTwoL2SupernodeInterop(t, 0)
 
 	sys.L1Network.WaitForBlock()
+
+	// Build a stable cross-safe foundation before we stop the L1 CL and manually sequence.
+	// This ensures the supernode has verified state that references canonical L1 blocks,
+	// so after the reorg it doesn't need to rewind all the way back to genesis.
+	sys.L2ACL.Advanced(types.CrossSafe, 20, 100)
 
 	sys.L1CL.Stop()
 
@@ -71,8 +74,8 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	for range n + 1 {
 		sys.TestSequencer.SequenceBlock(t, sys.L1Network.ChainID(), common.Hash{})
 
-		sys.L2ChainA.WaitForBlock()
-		sys.L2ChainA.WaitForBlock()
+		sys.L2A.WaitForBlock()
+		sys.L2A.WaitForBlock()
 	}
 
 	// select a divergence block to reorg from
@@ -85,7 +88,7 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	}
 
 	// print the chains before sequencing an alternative L1 block
-	sys.L2ChainA.PrintChain()
+	sys.L2A.PrintChain()
 	sys.L1Network.PrintChain()
 
 	// pre reorg trigger validations and checks
@@ -102,8 +105,21 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	// confirm L1 reorged
 	sys.L1EL.ReorgTriggered(divergence, 5)
 
-	// wait until L2 chain A cross-safe ref caught up to where it was before the reorg
-	sys.L2CLA.Reached(types.CrossSafe, tipL2_preReorg.Number, 50)
+	// Wait until L2 chain A cross-safe ref caught up to where it was before the reorg.
+	// Use require.Eventually instead of sys.L2ACL.Reached because the supernode rewinds
+	// one timestamp at a time after an L1 reorg, stopping and restarting VNs each cycle.
+	// During these rewinds the CL RPC is temporarily unavailable, and Reached() would
+	// fatally fail via require.NoError on the transient RPC error.
+	require.Eventually(t, func() bool {
+		ss, err := sys.L2ACL.Escape().RollupAPI().SyncStatus(ctx)
+		if err != nil {
+			sys.Log.Info("SyncStatus unavailable during rewind, retrying", "err", err)
+			return false
+		}
+		sys.Log.Info("waiting for cross-safe to reach pre-reorg tip",
+			"cross_safe", ss.SafeL2.Number, "target", tipL2_preReorg.Number)
+		return ss.SafeL2.Number >= tipL2_preReorg.Number
+	}, 10*time.Minute, 5*time.Second, "L2 chain A cross-safe should reach pre-reorg tip %d", tipL2_preReorg.Number)
 
 	// test that latest chain A unsafe is not referencing a reorged L1 block (through the L1Origin field)
 	require.Eventually(t, func() bool {
@@ -118,7 +134,7 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 		sys.Log.Info("current unsafe ref", "tip", unsafe, "tip_origin", unsafe.L1Origin, "l1blk", eth.InfoToL1BlockRef(block))
 
 		// print the chains so we have information to debug if the test fails
-		sys.L2ChainA.PrintChain()
+		sys.L2A.PrintChain()
 		sys.L1Network.PrintChain()
 
 		return block.Hash() == unsafe.L1Origin.Hash

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -222,7 +222,8 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		}
 		br, err := e.engine.L2BlockRefByHash(e.ctx, fvshid.Hash)
 		if err != nil {
-			panic("superAuthority supplied an identifier for the safe head which is not known to the engine")
+			e.log.Warn("superAuthority safe head is not known to the engine, using finalized head", "super_authority_safe", fvshid, "finalized", e.localFinalizedHead, "err", err)
+			return e.localFinalizedHead
 		}
 		canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
 		if err != nil {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -222,17 +222,20 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		}
 		br, err := e.engine.L2BlockRefByHash(e.ctx, fvshid.Hash)
 		if err != nil {
-			e.log.Warn("superAuthority safe head is not known to the engine, using finalized head", "super_authority_safe", fvshid, "finalized", e.localFinalizedHead, "err", err)
-			return e.localFinalizedHead
+			finalized := e.FinalizedHead()
+			e.log.Warn("superAuthority safe head is not known to the engine, using finalized head", "super_authority_safe", fvshid, "finalized", finalized, "err", err)
+			return finalized
 		}
 		canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
 		if err != nil {
-			e.log.Warn("cannot verify superAuthority safe head canonicality, using finalized head", "super_authority_safe", br, "finalized", e.localFinalizedHead, "err", err)
-			return e.localFinalizedHead
+			finalized := e.FinalizedHead()
+			e.log.Warn("cannot verify superAuthority safe head canonicality, using finalized head", "super_authority_safe", br, "finalized", finalized, "err", err)
+			return finalized
 		}
 		if canonical.Hash != br.Hash {
-			e.log.Warn("superAuthority safe head is not canonical, using finalized head", "super_authority_safe", br, "canonical", canonical, "finalized", e.localFinalizedHead)
-			return e.localFinalizedHead
+			finalized := e.FinalizedHead()
+			e.log.Warn("superAuthority safe head is not canonical, using finalized head", "super_authority_safe", br, "canonical", canonical, "finalized", finalized)
+			return finalized
 		}
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -226,12 +226,12 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		}
 		canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
 		if err != nil {
-			e.log.Warn("cannot verify superAuthority safe head canonicality, using local safe head", "super_authority_safe", br, "local_safe", e.localSafeHead, "err", err)
-			return e.localSafeHead
+			e.log.Warn("cannot verify superAuthority safe head canonicality, using finalized head", "super_authority_safe", br, "finalized", e.localFinalizedHead, "err", err)
+			return e.localFinalizedHead
 		}
 		if canonical.Hash != br.Hash {
-			e.log.Warn("superAuthority safe head is not canonical, using local safe head", "super_authority_safe", br, "canonical", canonical, "local_safe", e.localSafeHead)
-			return e.localSafeHead
+			e.log.Warn("superAuthority safe head is not canonical, using finalized head", "super_authority_safe", br, "canonical", canonical, "finalized", e.localFinalizedHead)
+			return e.localFinalizedHead
 		}
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -224,6 +224,15 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		if err != nil {
 			panic("superAuthority supplied an identifier for the safe head which is not known to the engine")
 		}
+		canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
+		if err != nil {
+			e.log.Warn("cannot verify superAuthority safe head canonicality, using local safe head", "super_authority_safe", br, "local_safe", e.localSafeHead, "err", err)
+			return e.localSafeHead
+		}
+		if canonical.Hash != br.Hash {
+			e.log.Warn("superAuthority safe head is not canonical, using local safe head", "super_authority_safe", br, "canonical", canonical, "local_safe", e.localSafeHead)
+			return e.localSafeHead
+		}
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedSafeHead

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -244,20 +244,22 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50},
 		},
 		{
-			name:              "falls back to local safe when SuperAuthority block is not canonical",
+			name:              "falls back to SuperAuthority finalized when SuperAuthority block is not canonical",
 			supervisorEnabled: true,
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
 					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					finalizedL2Head:     eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}, nil)
+				m.ExpectL2BlockRefByHash(common.Hash{0xee}, eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40}, nil)
 			},
-			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40},
 		},
 		{
 			name:              "with SuperAuthority empty BlockID returns genesis",
@@ -296,19 +298,21 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult:   &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
-			name:              "falls back to finalized when SuperAuthority block unknown to engine",
+			name:              "falls back to SuperAuthority finalized when SuperAuthority block unknown to engine",
 			supervisorEnabled: true,
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
 					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
+					finalizedL2Head:     eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
+				m.ExpectL2BlockRefByHash(common.Hash{0xee}, eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40}, nil)
 			},
-			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40},
 		},
 	}
 

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -296,7 +296,7 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult:   &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
-			name:              "panics when SuperAuthority block unknown to engine",
+			name:              "falls back to finalized when SuperAuthority block unknown to engine",
 			supervisorEnabled: true,
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
@@ -304,10 +304,11 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 			},
-			expectPanic: "superAuthority supplied an identifier for the safe head which is not known to the engine",
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 		},
 	}
 

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -222,6 +222,7 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 		supervisorEnabled bool
 		setupSuperAuth    func() *mockSuperAuthority
 		setupLocalSafe    *eth.L2BlockRef
+		setupFinalized    *eth.L2BlockRef
 		setupDeprecated   *eth.L2BlockRef
 		setupEngine       func(*testutils.MockEngine)
 		expectPanic       string
@@ -251,11 +252,12 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}, nil)
 			},
-			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 		},
 		{
 			name:              "with SuperAuthority empty BlockID returns genesis",
@@ -327,6 +329,9 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, tt.supervisorEnabled, &testutils.MockL1Source{}, emitter, superAuthority)
 			if tt.setupLocalSafe != nil {
 				ec.SetLocalSafeHead(*tt.setupLocalSafe)
+			}
+			if tt.setupFinalized != nil {
+				ec.SetFinalizedHead(*tt.setupFinalized)
 			}
 			if tt.setupDeprecated != nil {
 				ec.SetDeprecatedSafeHead(*tt.setupDeprecated)

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -238,8 +238,24 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
+				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 			},
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50},
+		},
+		{
+			name:              "falls back to local safe when SuperAuthority block is not canonical",
+			supervisorEnabled: true,
+			setupSuperAuth: func() *mockSuperAuthority {
+				return &mockSuperAuthority{
+					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+				}
+			},
+			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupEngine: func(m *testutils.MockEngine) {
+				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
+				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}, nil)
+			},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
 			name:              "with SuperAuthority empty BlockID returns genesis",
@@ -369,6 +385,7 @@ func TestEngineController_ForkchoiceUpdateUsesSuperAuthority(t *testing.T) {
 	// SafeL2Head is called multiple times during initialization and forkchoice - be generous
 	for i := 0; i < 10; i++ {
 		mockEngine.ExpectL2BlockRefByHash(verifiedRef.Hash, verifiedRef, nil)
+		mockEngine.ExpectL2BlockRefByNumber(verifiedRef.Number, verifiedRef, nil)
 	}
 	// FinalizedHead is also called and will look up the finalized block by hash
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
Fixes https://github.com/ethereum-optimism/optimism/issues/20134