### PR TITLE
fix(op-node): cache super authority finalized head

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -121,9 +121,10 @@ type EngineController struct {
 	// Derived from L1, and known to be a completed span-batch,
 	// but not cross-verified yet.
 	localSafeHead eth.L2BlockRef
-	// Derived from finalized L1 data, but not necessarily
-	// verified by the superAuthority.
-	// Only to be used as a FinalizedHead when there is no superAuthority
+	// Last locally materialized finalized head.
+	// In superAuthority mode, this is updated from successfully resolved
+	// superAuthority finalized refs and used as a fallback when the authority
+	// or EL is temporarily unavailable.
 	localFinalizedHead eth.L2BlockRef
 	// The unsafe head to roll back to,
 	// after the pendingSafeHead fails to become safe.
@@ -253,10 +254,26 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 			e.log.Debug("super authority finalized l2 head is ahead of local safe head, using local safe head as FinalizedHead")
 			return e.localSafeHead
 		}
+		if e.localFinalizedHead != (eth.L2BlockRef{}) {
+			if f == e.localFinalizedHead.ID() {
+				return e.localFinalizedHead
+			}
+			if f.Number < e.localFinalizedHead.Number {
+				// SuperAuthority finality is expected to be monotonic. A lower
+				// finalized head means the authority is reporting stale state.
+				e.log.Error("superAuthority finalized head is behind cached finalized head, using cached finalized head", "super_authority_finalized", f, "cached_finalized", e.localFinalizedHead)
+				return e.localFinalizedHead
+			}
+			if f.Number == e.localFinalizedHead.Number {
+				panic("superAuthority finalized head conflicts with cached finalized head at same height")
+			}
+		}
 		br, err := e.engine.L2BlockRefByHash(e.ctx, f.Hash)
 		if err != nil {
-			panic("superAuthority supplied an identifier for the finalized head which is not known to the engine")
+			e.log.Warn("superAuthority finalized head is not known to the engine, using cached finalized head", "super_authority_finalized", f, "cached_finalized", e.localFinalizedHead, "err", err)
+			return e.localFinalizedHead
 		}
+		e.SetFinalizedHead(br)
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedFinalizedHead

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -715,7 +715,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 30},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 			},
@@ -760,18 +760,18 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			expectResult: &eth.L2BlockRef{},
 		},
 		{
-			name: "panics when SuperAuthority block unknown to engine",
+			name: "falls back to cached finalized when SuperAuthority block unknown to engine",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
 					finalizedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 			},
-			expectPanic: "superAuthority supplied an identifier for the finalized head which is not known to the engine",
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 		},
 	}
 
@@ -812,6 +812,60 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30})
+
+	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	mockEngine.ExpectL2BlockRefByHash(common.Hash{0xbb}, finalizedRef, nil)
+
+	require.Equal(t, finalizedRef, ec.FinalizedHead())
+	require.Equal(t, finalizedRef, ec.localFinalizedHead)
+
+	superAuth.finalizedL2Head = eth.BlockID{Hash: common.Hash{0xcc}, Number: 60}
+	mockEngine.ExpectL2BlockRefByHash(common.Hash{0xcc}, eth.L2BlockRef{}, errors.New("temporary EL error"))
+
+	require.Equal(t, finalizedRef, ec.FinalizedHead())
+	require.Equal(t, finalizedRef, ec.localFinalizedHead)
+}
+
+func TestEngineController_FinalizedHeadDoesNotCacheLocalSafeFallback(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 40}
+	cachedFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30}
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(cachedFinalized)
+
+	require.Equal(t, localSafe, ec.FinalizedHead())
+	require.Equal(t, cachedFinalized, ec.localFinalizedHead)
+}
+
+func TestEngineController_FinalizedHeadPanicsOnSameHeightConflict(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50})
+
+	require.PanicsWithValue(t, "superAuthority finalized head conflicts with cached finalized head at same height", func() {
+		ec.FinalizedHead()
+	})
 }
 
 // TestTryUpdateEngine_SyncingInCLModeTriggersReset tests that when the EL returns SYNCING


### PR DESCRIPTION
## Summary

- cache the last locally materialized super-authority finalized `L2BlockRef` in `localFinalizedHead`
- reuse the cached finalized head when resolving a newer super-authority finalized `BlockID` fails against the EL
- avoid regressing finalized head when the super-authority result conflicts with the cached finalized ref

Fixes #20771.

## Testing

- `go test ./op-node/rollup/engine`
- `git diff --check`
