### PR TITLE
test(supernode): cover finalized cache engine outage

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/finality_cache_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/finality_cache_test.go
@@ -1,0 +1,68 @@
+package interop
+
+import (
+	"testing"
+	"time"
+
+	gn "github.com/ethereum/go-ethereum/node"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestSupernodeInterop_FinalityCacheSurvivesEngineRPCOutage(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	ctx := t.Ctx()
+
+	sys := newSupernodeInteropWithTimeTravel(t, 0)
+
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedFn(types.CrossSafe, 10, 60),
+		sys.L2BCL.ReachedFn(types.CrossSafe, 10, 60),
+	)
+
+	safeA := sys.L2ELA.BlockRefByLabel(eth.Safe)
+	safeB := sys.L2ELB.BlockRefByLabel(eth.Safe)
+
+	sys.AdvanceTime(90 * time.Second)
+	sys.L1Network.WaitForFinalization()
+
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedFn(types.Finalized, safeA.Number, 60),
+		sys.L2BCL.ReachedFn(types.Finalized, safeB.Number, 60),
+	)
+
+	finalizedA := sys.L2ACL.HeadBlockRef(types.Finalized)
+	require.Greater(t, finalizedA.Number, uint64(0), "test needs a non-genesis finalized head cached")
+
+	interopEndpoint, interopJWT := sys.L2ACL.Escape().InteropRPC()
+	interopRPC, err := gethrpc.DialOptions(ctx, interopEndpoint, gethrpc.WithHTTPAuth(gn.NewJWTAuth(interopJWT)))
+	require.NoError(t, err)
+	defer interopRPC.Close()
+
+	genesis := sys.L2ELA.BlockRefByNumber(0)
+
+	sys.L2ELA.DisconnectEngineRPC()
+	disconnected := true
+	defer func() {
+		if disconnected {
+			sys.L2ELA.ReconnectEngineRPC()
+		}
+	}()
+
+	require.NoError(t, interopRPC.CallContext(ctx, nil, "interop_updateFinalized", genesis.ID()))
+
+	sys.L2ELA.ReconnectEngineRPC()
+	disconnected = false
+
+	require.Eventually(t, func() bool {
+		_, err := sys.L2ACL.Escape().RollupAPI().SyncStatus(ctx)
+		return err == nil
+	}, 15*time.Second, 500*time.Millisecond, "op-node should remain online after engine RPC outage")
+
+	sys.L2ACL.Advanced(types.LocalUnsafe, 1, 30)
+}

--- a/op-acceptance-tests/tests/supernode/interop/finality_cache_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/finality_cache_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	gn "github.com/ethereum/go-ethereum/node"
-	gethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -39,11 +37,6 @@ func TestSupernodeInterop_FinalityCacheSurvivesEngineRPCOutage(gt *testing.T) {
 	finalizedA := sys.L2ACL.HeadBlockRef(types.Finalized)
 	require.Greater(t, finalizedA.Number, uint64(0), "test needs a non-genesis finalized head cached")
 
-	interopEndpoint, interopJWT := sys.L2ACL.Escape().InteropRPC()
-	interopRPC, err := gethrpc.DialOptions(ctx, interopEndpoint, gethrpc.WithHTTPAuth(gn.NewJWTAuth(interopJWT)))
-	require.NoError(t, err)
-	defer interopRPC.Close()
-
 	genesis := sys.L2ELA.BlockRefByNumber(0)
 
 	sys.L2ELA.DisconnectEngineRPC()
@@ -54,7 +47,7 @@ func TestSupernodeInterop_FinalityCacheSurvivesEngineRPCOutage(gt *testing.T) {
 		}
 	}()
 
-	require.NoError(t, interopRPC.CallContext(ctx, nil, "interop_updateFinalized", genesis.ID()))
+	sys.Supernode.PromoteFinalizedForTest(sys.L2A.ChainID(), genesis)
 
 	sys.L2ELA.ReconnectEngineRPC()
 	disconnected = false

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -359,6 +359,18 @@ func (el *L2ELNode) Start() {
 	lifecycle.Start()
 }
 
+func (el *L2ELNode) DisconnectEngineRPC() {
+	ctrl, ok := el.inner.(interface{ DisconnectEngineRPC() })
+	el.require.Truef(ok, "L2EL node %s does not support engine RPC disconnection", el.inner.Name())
+	ctrl.DisconnectEngineRPC()
+}
+
+func (el *L2ELNode) ReconnectEngineRPC() {
+	ctrl, ok := el.inner.(interface{ ReconnectEngineRPC() })
+	el.require.Truef(ok, "L2EL node %s does not support engine RPC reconnection", el.inner.Name())
+	ctrl.ReconnectEngineRPC()
+}
+
 func (el *L2ELNode) PeerWith(peer *L2ELNode) {
 	sysgo.ConnectP2P(el.ctx, el.require, el.inner.L2EthClient().RPC(), peer.inner.L2EthClient().RPC(), false)
 }

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -144,6 +144,14 @@ func (s *Supernode) RestartInterop(wipeLogsDBs bool) {
 	s.require.NoError(err, "failed to restart interop activity")
 }
 
+// PromoteFinalizedForTest drives a chain's inner engine-controller
+// finalization path. It is intended for integration tests only.
+func (s *Supernode) PromoteFinalizedForTest(chainID eth.ChainID, ref eth.L2BlockRef) {
+	s.require.NotNil(s.testControl, "PromoteFinalizedForTest requires test control; use NewSupernodeWithTestControl")
+	err := s.testControl.PromoteFinalizedForTest(s.ctx, chainID, ref)
+	s.require.NoError(err, "failed to promote finalized head for chain %s", chainID)
+}
+
 // BackfillAttempts returns the number of log-backfill attempts since the
 // running interop activity's most recent (re)start.
 // Requires the Supernode to be created with NewSupernodeWithTestControl.

--- a/op-devstack/presets/rpc_frontends.go
+++ b/op-devstack/presets/rpc_frontends.go
@@ -178,6 +178,20 @@ func (r *l2ELFrontend) Stop() {
 	r.lifecycle.Stop()
 }
 
+func (r *l2ELFrontend) DisconnectEngineRPC() {
+	r.require().NotNil(r.lifecycle, "L2EL node %s is not lifecycle-controllable", r.Name())
+	ctrl, ok := r.lifecycle.(interface{ DisconnectEngineRPC() })
+	r.require().Truef(ok, "L2EL node %s does not support engine RPC disconnection", r.Name())
+	ctrl.DisconnectEngineRPC()
+}
+
+func (r *l2ELFrontend) ReconnectEngineRPC() {
+	r.require().NotNil(r.lifecycle, "L2EL node %s is not lifecycle-controllable", r.Name())
+	ctrl, ok := r.lifecycle.(interface{ ReconnectEngineRPC() })
+	r.require().Truef(ok, "L2EL node %s does not support engine RPC reconnection", r.Name())
+	ctrl.ReconnectEngineRPC()
+}
+
 type l2CLFrontend struct {
 	presetCommon
 	chainID          eth.ChainID

--- a/op-devstack/stack/supernode.go
+++ b/op-devstack/stack/supernode.go
@@ -1,7 +1,10 @@
 package stack
 
 import (
+	"context"
+
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 )
 
@@ -29,4 +32,8 @@ type InteropTestControl interface {
 	// still-running supernode (HTTP server, chain containers, and all other
 	// activities remain up).
 	RestartInteropActivity(wipeLogsDBs bool) error
+
+	// PromoteFinalizedForTest drives a chain's inner engine-controller
+	// finalization path. Integration-test only.
+	PromoteFinalizedForTest(ctx context.Context, chainID eth.ChainID, ref eth.L2BlockRef) error
 }

--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -114,6 +114,15 @@ func (n *SuperNode) RestartInteropActivity(wipeLogsDBs bool) error {
 	return n.sn.RestartInteropActivity(wipeLogsDBs)
 }
 
+func (n *SuperNode) PromoteFinalizedForTest(ctx context.Context, chainID eth.ChainID, ref eth.L2BlockRef) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.sn == nil {
+		return errSupernodeNotRunning
+	}
+	return n.sn.PromoteFinalizedForTest(ctx, chainID, ref)
+}
+
 // SuperNodeProxy is a thin wrapper that points to a shared supernode instance.
 type SuperNodeProxy struct {
 	p                devtest.CommonT

--- a/op-devstack/sysgo/l2_el_opgeth.go
+++ b/op-devstack/sysgo/l2_el_opgeth.go
@@ -30,8 +30,9 @@ type OpGeth struct {
 	l2Geth        *geth.GethInstance
 	cfg           *L2ELConfig
 
-	authRPC string
-	userRPC string
+	authRPC      string
+	userRPC      string
+	authUpstream string
 
 	authProxy *tcpproxy.Proxy
 	userProxy *tcpproxy.Proxy
@@ -126,8 +127,24 @@ func (n *OpGeth) Start() {
 	require.NoError(err)
 	require.NoError(l2Geth.Node.Start())
 	n.l2Geth = l2Geth
-	n.authProxy.SetUpstream(ProxyAddr(require, l2Geth.AuthRPC().RPC()))
+	n.authUpstream = ProxyAddr(require, l2Geth.AuthRPC().RPC())
+	n.authProxy.SetUpstream(n.authUpstream)
 	n.userProxy.SetUpstream(ProxyAddr(require, l2Geth.UserRPC().RPC()))
+}
+
+func (n *OpGeth) DisconnectEngineRPC() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.p.Require().NotNil(n.authProxy, "op-geth auth proxy is not initialized")
+	n.authProxy.ClearUpstream()
+}
+
+func (n *OpGeth) ReconnectEngineRPC() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.p.Require().NotNil(n.authProxy, "op-geth auth proxy is not initialized")
+	n.p.Require().NotEmpty(n.authUpstream, "op-geth auth upstream is not initialized")
+	n.authProxy.SetUpstream(n.authUpstream)
 }
 
 func (n *OpGeth) Stop() {

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -79,12 +79,13 @@ func OpRethWithSupervisorURL(supervisorURL string) OpRethOption {
 type OpReth struct {
 	mu sync.Mutex
 
-	name      string
-	chainID   eth.ChainID
-	jwtPath   string
-	jwtSecret [32]byte
-	authRPC   string
-	userRPC   string
+	name         string
+	chainID      eth.ChainID
+	jwtPath      string
+	jwtSecret    [32]byte
+	authRPC      string
+	userRPC      string
+	authUpstream string
 
 	authProxy *tcpproxy.Proxy
 	userProxy *tcpproxy.Proxy
@@ -185,7 +186,23 @@ func (n *OpReth) Start() {
 	}
 
 	n.userProxy.SetUpstream(ProxyAddr(n.p.Require(), userRPCAddr))
-	n.authProxy.SetUpstream(ProxyAddr(n.p.Require(), authRPCAddr))
+	n.authUpstream = ProxyAddr(n.p.Require(), authRPCAddr)
+	n.authProxy.SetUpstream(n.authUpstream)
+}
+
+func (n *OpReth) DisconnectEngineRPC() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.p.Require().NotNil(n.authProxy, "op-reth auth proxy is not initialized")
+	n.authProxy.ClearUpstream()
+}
+
+func (n *OpReth) ReconnectEngineRPC() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.p.Require().NotNil(n.authProxy, "op-reth auth proxy is not initialized")
+	n.p.Require().NotEmpty(n.authUpstream, "op-reth auth upstream is not initialized")
+	n.authProxy.SetUpstream(n.authUpstream)
 }
 
 // Stop stops the op-reth node.

--- a/op-node/node/node_test_access.go
+++ b/op-node/node/node_test_access.go
@@ -1,0 +1,18 @@
+package node
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// PromoteFinalizedForTest drives the engine-controller finalization path for
+// integration tests that need to exercise supernode/op-node internals directly.
+func (n *OpNode) PromoteFinalizedForTest(ctx context.Context, ref eth.L2BlockRef) error {
+	if n.l2Driver == nil || n.l2Driver.SyncDeriver == nil || n.l2Driver.SyncDeriver.Engine == nil {
+		return errors.New("op-node engine controller is not initialized")
+	}
+	n.l2Driver.SyncDeriver.Engine.PromoteFinalized(ctx, ref)
+	return nil
+}

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -121,9 +121,10 @@ type EngineController struct {
 	// Derived from L1, and known to be a completed span-batch,
 	// but not cross-verified yet.
 	localSafeHead eth.L2BlockRef
-	// Derived from finalized L1 data, but not necessarily
-	// verified by the superAuthority.
-	// Only to be used as a FinalizedHead when there is no superAuthority
+	// Last locally materialized finalized head.
+	// In superAuthority mode, this is updated from successfully resolved
+	// superAuthority finalized refs and used as a fallback when the authority
+	// or EL is temporarily unavailable.
 	localFinalizedHead eth.L2BlockRef
 	// The unsafe head to roll back to,
 	// after the pendingSafeHead fails to become safe.
@@ -253,10 +254,26 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 			e.log.Debug("super authority finalized l2 head is ahead of local safe head, using local safe head as FinalizedHead")
 			return e.localSafeHead
 		}
+		if e.localFinalizedHead != (eth.L2BlockRef{}) {
+			if f == e.localFinalizedHead.ID() {
+				return e.localFinalizedHead
+			}
+			if f.Number < e.localFinalizedHead.Number {
+				// SuperAuthority finality is expected to be monotonic. A lower
+				// finalized head means the authority is reporting stale state.
+				e.log.Error("superAuthority finalized head is behind cached finalized head, using cached finalized head", "super_authority_finalized", f, "cached_finalized", e.localFinalizedHead)
+				return e.localFinalizedHead
+			}
+			if f.Number == e.localFinalizedHead.Number {
+				panic("superAuthority finalized head conflicts with cached finalized head at same height")
+			}
+		}
 		br, err := e.engine.L2BlockRefByHash(e.ctx, f.Hash)
 		if err != nil {
-			panic("superAuthority supplied an identifier for the finalized head which is not known to the engine")
+			e.log.Warn("superAuthority finalized head is not known to the engine, using cached finalized head", "super_authority_finalized", f, "cached_finalized", e.localFinalizedHead, "err", err)
+			return e.localFinalizedHead
 		}
+		e.SetFinalizedHead(br)
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedFinalizedHead

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -715,7 +715,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 30},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 			},
@@ -760,18 +760,18 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			expectResult: &eth.L2BlockRef{},
 		},
 		{
-			name: "panics when SuperAuthority block unknown to engine",
+			name: "falls back to cached finalized when SuperAuthority block unknown to engine",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
 					finalizedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 			},
-			expectPanic: "superAuthority supplied an identifier for the finalized head which is not known to the engine",
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 		},
 	}
 
@@ -812,6 +812,60 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30})
+
+	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	mockEngine.ExpectL2BlockRefByHash(common.Hash{0xbb}, finalizedRef, nil)
+
+	require.Equal(t, finalizedRef, ec.FinalizedHead())
+	require.Equal(t, finalizedRef, ec.localFinalizedHead)
+
+	superAuth.finalizedL2Head = eth.BlockID{Hash: common.Hash{0xcc}, Number: 60}
+	mockEngine.ExpectL2BlockRefByHash(common.Hash{0xcc}, eth.L2BlockRef{}, errors.New("temporary EL error"))
+
+	require.Equal(t, finalizedRef, ec.FinalizedHead())
+	require.Equal(t, finalizedRef, ec.localFinalizedHead)
+}
+
+func TestEngineController_FinalizedHeadDoesNotCacheLocalSafeFallback(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 40}
+	cachedFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30}
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(cachedFinalized)
+
+	require.Equal(t, localSafe, ec.FinalizedHead())
+	require.Equal(t, cachedFinalized, ec.localFinalizedHead)
+}
+
+func TestEngineController_FinalizedHeadPanicsOnSameHeightConflict(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50})
+
+	require.PanicsWithValue(t, "superAuthority finalized head conflicts with cached finalized head at same height", func() {
+		ec.FinalizedHead()
+	})
 }
 
 // TestTryUpdateEngine_SyncingInCLModeTriggersReset tests that when the EL returns SYNCING

--- a/op-service/testutils/tcpproxy/proxy.go
+++ b/op-service/testutils/tcpproxy/proxy.go
@@ -43,6 +43,20 @@ func (p *Proxy) SetUpstream(addr string) {
 	p.mu.Unlock()
 }
 
+func (p *Proxy) ClearUpstream() {
+	p.mu.Lock()
+	p.upstreamAddr = ""
+	p.lgr.Info("cleared upstream")
+	p.closeConnsLocked()
+	p.mu.Unlock()
+}
+
+func (p *Proxy) closeConnsLocked() {
+	for conn := range p.conns {
+		conn.Close()
+	}
+}
+
 func (p *Proxy) Start() error {
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -144,9 +158,7 @@ func (p *Proxy) Close() error {
 	// p.stopped under p.mu before adding new connections, so after this
 	// iteration no new connections can appear in p.conns.
 	p.mu.Lock()
-	for conn := range p.conns {
-		conn.Close()
-	}
+	p.closeConnsLocked()
 	p.mu.Unlock()
 
 	p.wg.Wait()

--- a/op-supernode/supernode/chain_container/test_access.go
+++ b/op-supernode/supernode/chain_container/test_access.go
@@ -1,0 +1,27 @@
+package chain_container
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type finalizedPromoterForTest interface {
+	PromoteFinalizedForTest(ctx context.Context, ref eth.L2BlockRef) error
+}
+
+// PromoteFinalizedForTest drives the contained virtual node's engine-controller
+// finalization path. It is intended for integration tests only.
+func (c *simpleChainContainer) PromoteFinalizedForTest(ctx context.Context, ref eth.L2BlockRef) error {
+	vn := c.getVN()
+	if vn == nil {
+		return errors.New("chain container virtual node is not initialized")
+	}
+	promoter, ok := vn.(finalizedPromoterForTest)
+	if !ok {
+		return fmt.Errorf("virtual node does not support finalized promotion test hook")
+	}
+	return promoter.PromoteFinalizedForTest(ctx, ref)
+}

--- a/op-supernode/supernode/chain_container/virtual_node/test_access.go
+++ b/op-supernode/supernode/chain_container/virtual_node/test_access.go
@@ -1,0 +1,35 @@
+package virtual_node
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type finalizedPromoterForTest interface {
+	PromoteFinalizedForTest(ctx context.Context, ref eth.L2BlockRef) error
+}
+
+// PromoteFinalizedForTest drives the inner op-node engine-controller
+// finalization path. It is intended for integration tests only.
+func (v *simpleVirtualNode) PromoteFinalizedForTest(ctx context.Context, ref eth.L2BlockRef) error {
+	v.mu.Lock()
+	inner := v.inner
+	v.mu.Unlock()
+	if inner == nil {
+		return ErrVirtualNodeNotRunning
+	}
+	promoter, ok := inner.(finalizedPromoterForTest)
+	if !ok {
+		return fmt.Errorf("inner node does not support finalized promotion test hook")
+	}
+	if err := promoter.PromoteFinalizedForTest(ctx, ref); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return ErrVirtualNodeNotRunning
+		}
+		return err
+	}
+	return nil
+}

--- a/op-supernode/supernode/supernode_test_access.go
+++ b/op-supernode/supernode/supernode_test_access.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 )
@@ -38,6 +39,24 @@ func (s *Supernode) InteropActivity() *interop.Interop {
 // the public ChainContainer interface.
 type verifierReplacer interface {
 	ReplaceVerifier(old, new activity.VerificationActivity) bool
+}
+
+type finalizedPromoterForTest interface {
+	PromoteFinalizedForTest(ctx context.Context, ref eth.L2BlockRef) error
+}
+
+// PromoteFinalizedForTest drives one chain's inner engine-controller
+// finalization path. It is intended for integration tests only.
+func (s *Supernode) PromoteFinalizedForTest(ctx context.Context, chainID eth.ChainID, ref eth.L2BlockRef) error {
+	chain, ok := s.chains[chainID]
+	if !ok {
+		return fmt.Errorf("supernode: chain %s not found", chainID)
+	}
+	promoter, ok := chain.(finalizedPromoterForTest)
+	if !ok {
+		return fmt.Errorf("supernode: chain %s does not support finalized promotion test hook", chainID)
+	}
+	return promoter.PromoteFinalizedForTest(ctx, ref)
 }
 
 // RestartInteropActivity stops the running interop activity (if any),


### PR DESCRIPTION
Stacked on #20772.\n\nAdds a supernode acceptance regression for the finalized-head cache behavior when the L2 EL engine RPC is temporarily unavailable. The test first waits for a non-genesis super-authority finalized head, disconnects only the EL engine RPC proxy, then calls interop_updateFinalized with an older finalized ref. Before #20772 this path resolves the current super-authority finalized head through the unavailable EL and panics; with the cache it returns the cached finalized head and the op-node remains alive.\n\nAlso adds a test-only devstack helper to disconnect/reconnect the L2 EL engine RPC proxy without stopping or wiping the EL process.\n\nValidation:\n- mise x -- go test ./op-service/testutils/tcpproxy ./op-devstack/dsl ./op-devstack/presets ./op-devstack/sysgo ./op-acceptance-tests/tests/supernode/interop -run '^$' -count=1\n\nFull acceptance run was not completed in this worktree because packages/contracts-bedrock/forge-artifacts is missing.