### PR TITLE
feat(interop): add interop_ RPC namespace, migrate op-reth

### DIFF
--- a/op-devstack/presets/twol2.go
+++ b/op-devstack/presets/twol2.go
@@ -103,8 +103,14 @@ func (s *TwoL2SupernodeInterop) SuperNodeClient() apis.SupernodeQueryAPI {
 
 // NewTwoL2SupernodeInterop creates a fresh TwoL2SupernodeInterop target for the current
 // test.
+//
+// When WithInteropFilter() is set the test is skipped on op-geth: the interop filter
+// is only supported with op-reth, since op-geth does not call the interop_ namespace.
 func NewTwoL2SupernodeInterop(t devtest.T, delaySeconds uint64, opts ...Option) *TwoL2SupernodeInterop {
 	presetCfg, _ := collectSupportedPresetConfig(t, "NewTwoL2SupernodeInterop", opts, twoL2SupernodeInteropPresetSupportedOptionKinds)
+	if presetCfg.UseInteropFilter {
+		sysgo.SkipOnOpGeth(t, "interop filter is only supported with op-reth")
+	}
 	return twoL2SupernodeInteropFromRuntime(t, sysgo.NewTwoL2SupernodeInteropRuntimeWithConfig(t, delaySeconds, presetCfg))
 }
 

--- a/op-interop-filter/filter/jwt_auth_test.go
+++ b/op-interop-filter/filter/jwt_auth_test.go
@@ -49,7 +49,7 @@ func TestDedicatedAdminRPCServer(t *testing.T) {
 		oprpc.WithLogger(logger),
 	)
 	filterServer.AddAPI(rpc.API{
-		Namespace: "supervisor",
+		Namespace: "interop",
 		Service:   new(testSupervisorAPI),
 	})
 
@@ -103,7 +103,7 @@ func TestDedicatedAdminRPCServer(t *testing.T) {
 
 	t.Run("filter API works without JWT on its dedicated port", func(t *testing.T) {
 		var res string
-		err := filterClient.Call(&res, "supervisor_ping")
+		err := filterClient.Call(&res, "interop_ping")
 		require.NoError(t, err)
 		require.Equal(t, "pong", res)
 	})
@@ -132,7 +132,7 @@ func TestPublicAdminGetFailsafe(t *testing.T) {
 		oprpc.WithLogger(logger),
 	)
 	filterServer.AddAPI(rpc.API{
-		Namespace: "supervisor",
+		Namespace: "interop",
 		Service:   new(testSupervisorAPI),
 	})
 	filterServer.AddAPI(rpc.API{
@@ -159,7 +159,7 @@ func TestPublicAdminGetFailsafe(t *testing.T) {
 
 	t.Run("supervisor API still works alongside public admin", func(t *testing.T) {
 		var res string
-		err := filterClient.Call(&res, "supervisor_ping")
+		err := filterClient.Call(&res, "interop_ping")
 		require.NoError(t, err)
 		require.Equal(t, "pong", res)
 	})
@@ -176,7 +176,7 @@ func TestFilterAPIWithoutAdminServer(t *testing.T) {
 		oprpc.WithLogger(logger),
 	)
 	filterServer.AddAPI(rpc.API{
-		Namespace: "supervisor",
+		Namespace: "interop",
 		Service:   new(testSupervisorAPI),
 	})
 
@@ -192,7 +192,7 @@ func TestFilterAPIWithoutAdminServer(t *testing.T) {
 
 	t.Run("filter API works without admin server configured", func(t *testing.T) {
 		var res string
-		err := filterClient.Call(&res, "supervisor_ping")
+		err := filterClient.Call(&res, "interop_ping")
 		require.NoError(t, err)
 		require.Equal(t, "pong", res)
 	})

--- a/op-interop-filter/filter/rpc_test.go
+++ b/op-interop-filter/filter/rpc_test.go
@@ -80,3 +80,44 @@ func TestQueryFrontendGetBlockHashByNumberRPC(t *testing.T) {
 		require.ErrorContains(t, err, "unsupported block tag")
 	})
 }
+
+// TestQueryFrontendDualNamespace verifies the query frontend is reachable under
+// both the new "interop" namespace and the deprecated "supervisor" namespace.
+func TestQueryFrontendDualNamespace(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	mock := newMockChainIngester()
+	mock.AddBlock(eth.BlockID{Hash: common.HexToHash("0x01"), Number: 100})
+
+	backend := NewBackend(context.Background(), BackendParams{
+		Logger:         logger,
+		Metrics:        metrics.NoopMetrics,
+		Chains:         map[eth.ChainID]ChainIngester{eth.ChainIDFromUInt64(testChainA): mock},
+		CrossValidator: &mockCrossValidator{},
+	})
+
+	server := oprpc.NewServer(
+		"127.0.0.1",
+		0,
+		"test",
+		oprpc.WithLogger(logger),
+	)
+	frontend := &QueryFrontend{backend: backend}
+	server.AddAPI(rpc.API{Namespace: "interop", Service: frontend})
+	server.AddAPI(rpc.API{Namespace: "supervisor", Service: frontend})
+
+	require.NoError(t, server.Start())
+	t.Cleanup(func() { _ = server.Stop() })
+
+	client, err := rpc.Dial("http://" + server.Endpoint())
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	for _, ns := range []string{"interop", "supervisor"} {
+		t.Run(ns, func(t *testing.T) {
+			var result common.Hash
+			err := client.Call(&result, ns+"_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), rpc.BlockNumber(100))
+			require.NoError(t, err)
+			require.Equal(t, common.HexToHash("0x01"), result)
+		})
+	}
+}

--- a/op-interop-filter/filter/rpc_test.go
+++ b/op-interop-filter/filter/rpc_test.go
@@ -35,7 +35,7 @@ func TestQueryFrontendGetBlockHashByNumberRPC(t *testing.T) {
 		oprpc.WithLogger(logger),
 	)
 	server.AddAPI(rpc.API{
-		Namespace: "supervisor",
+		Namespace: "interop",
 		Service:   &QueryFrontend{backend: backend},
 	})
 
@@ -50,74 +50,33 @@ func TestQueryFrontendGetBlockHashByNumberRPC(t *testing.T) {
 
 	t.Run("latest selector", func(t *testing.T) {
 		var result common.Hash
-		err := client.Call(&result, "supervisor_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), "latest")
+		err := client.Call(&result, "interop_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), "latest")
 		require.NoError(t, err)
 		require.Equal(t, common.HexToHash("0x02"), result)
 	})
 
 	t.Run("numeric selector", func(t *testing.T) {
 		var result common.Hash
-		err := client.Call(&result, "supervisor_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), rpc.BlockNumber(100))
+		err := client.Call(&result, "interop_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), rpc.BlockNumber(100))
 		require.NoError(t, err)
 		require.Equal(t, common.HexToHash("0x01"), result)
 	})
 
 	t.Run("missing block", func(t *testing.T) {
 		var result common.Hash
-		err := client.Call(&result, "supervisor_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), rpc.BlockNumber(999))
+		err := client.Call(&result, "interop_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), rpc.BlockNumber(999))
 		require.ErrorContains(t, err, "not found")
 	})
 
 	t.Run("unknown chain", func(t *testing.T) {
 		var result common.Hash
-		err := client.Call(&result, "supervisor_getBlockHashByNumber", eth.ChainIDFromUInt64(999), rpc.BlockNumber(100))
+		err := client.Call(&result, "interop_getBlockHashByNumber", eth.ChainIDFromUInt64(999), rpc.BlockNumber(100))
 		require.ErrorContains(t, err, "unknown chain")
 	})
 
 	t.Run("unsupported tag", func(t *testing.T) {
 		var result common.Hash
-		err := client.Call(&result, "supervisor_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), "safe")
+		err := client.Call(&result, "interop_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), "safe")
 		require.ErrorContains(t, err, "unsupported block tag")
 	})
-}
-
-// TestQueryFrontendDualNamespace verifies the query frontend is reachable under
-// both the new "interop" namespace and the deprecated "supervisor" namespace.
-func TestQueryFrontendDualNamespace(t *testing.T) {
-	logger := testlog.Logger(t, log.LevelInfo)
-	mock := newMockChainIngester()
-	mock.AddBlock(eth.BlockID{Hash: common.HexToHash("0x01"), Number: 100})
-
-	backend := NewBackend(context.Background(), BackendParams{
-		Logger:         logger,
-		Metrics:        metrics.NoopMetrics,
-		Chains:         map[eth.ChainID]ChainIngester{eth.ChainIDFromUInt64(testChainA): mock},
-		CrossValidator: &mockCrossValidator{},
-	})
-
-	server := oprpc.NewServer(
-		"127.0.0.1",
-		0,
-		"test",
-		oprpc.WithLogger(logger),
-	)
-	frontend := &QueryFrontend{backend: backend}
-	server.AddAPI(rpc.API{Namespace: "interop", Service: frontend})
-	server.AddAPI(rpc.API{Namespace: "supervisor", Service: frontend})
-
-	require.NoError(t, server.Start())
-	t.Cleanup(func() { _ = server.Stop() })
-
-	client, err := rpc.Dial("http://" + server.Endpoint())
-	require.NoError(t, err)
-	t.Cleanup(client.Close)
-
-	for _, ns := range []string{"interop", "supervisor"} {
-		t.Run(ns, func(t *testing.T) {
-			var result common.Hash
-			err := client.Call(&result, ns+"_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), rpc.BlockNumber(100))
-			require.NoError(t, err)
-			require.Equal(t, common.HexToHash("0x01"), result)
-		})
-	}
 }

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -69,7 +69,7 @@ func Main(version string) cliapp.LifecycleAction {
 			l.Warn("PASSTHROUGH MODE ENABLED: all transactions will bypass interop filtering")
 		}
 		if cfg.LegacyCheckAccessListFormat {
-			l.Warn("LEGACY CHECK ACCESS LIST FORMAT ENABLED: supervisor_checkAccessList will not reject missing executing chain IDs")
+			l.Warn("LEGACY CHECK ACCESS LIST FORMAT ENABLED: interop_checkAccessList will not reject missing executing chain IDs")
 		}
 
 		if !cfg.MessageExpiryWindowExplicit {
@@ -247,20 +247,9 @@ func (s *Service) initRPCServer(cfg *Config) error {
 		oprpc.WithLogger(s.log),
 	)
 
-	queryFrontend := &QueryFrontend{backend: s.backend}
-
 	server.AddAPI(rpc.API{
 		Namespace:     "interop",
-		Service:       queryFrontend,
-		Authenticated: false,
-	})
-
-	// Deprecated: the "supervisor" namespace is retained for backwards
-	// compatibility with execution clients that pre-date the interop filter
-	// replacing op-supervisor. New callers should use the "interop" namespace.
-	server.AddAPI(rpc.API{
-		Namespace:     "supervisor",
-		Service:       queryFrontend,
+		Service:       &QueryFrontend{backend: s.backend},
 		Authenticated: false,
 	})
 

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -247,10 +247,20 @@ func (s *Service) initRPCServer(cfg *Config) error {
 		oprpc.WithLogger(s.log),
 	)
 
-	// Register supervisor query API (public, no auth)
+	queryFrontend := &QueryFrontend{backend: s.backend}
+
+	server.AddAPI(rpc.API{
+		Namespace:     "interop",
+		Service:       queryFrontend,
+		Authenticated: false,
+	})
+
+	// Deprecated: the "supervisor" namespace is retained for backwards
+	// compatibility with execution clients that pre-date the interop filter
+	// replacing op-supervisor. New callers should use the "interop" namespace.
 	server.AddAPI(rpc.API{
 		Namespace:     "supervisor",
-		Service:       &QueryFrontend{backend: s.backend},
+		Service:       queryFrontend,
 		Authenticated: false,
 	})
 

--- a/op-interop-filter/flags/flags.go
+++ b/op-interop-filter/flags/flags.go
@@ -123,7 +123,7 @@ var (
 	}
 	SupportLegacyCheckAccessListFormatFlag = &cli.BoolFlag{
 		Name:    "support-legacy-check-access-list-format",
-		Usage:   "Support legacy supervisor_checkAccessList requests that omit executing chainID. DANGEROUS: intended only for compatibility with legacy clients; access-list source-chain validation still runs.",
+		Usage:   "Support legacy interop_checkAccessList requests that omit executing chainID. DANGEROUS: intended only for compatibility with legacy clients; access-list source-chain validation still runs.",
 		EnvVars: prefixEnvVars("SUPPORT_LEGACY_CHECK_ACCESS_LIST_FORMAT"),
 	}
 	DangerouslyEnablePassthroughFlag = &cli.BoolFlag{

--- a/rust/op-reth/crates/txpool/src/supervisor/client.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/client.rs
@@ -62,7 +62,7 @@ impl SupervisorClient {
         self.inner.safety
     }
 
-    /// Executes a `supervisor_checkAccessList` with the configured safety level.
+    /// Executes an `interop_checkAccessList` with the configured safety level.
     pub fn check_access_list<'a>(
         &self,
         inbox_entries: &'a [B256],
@@ -270,7 +270,7 @@ impl SupervisorClientBuilder {
     }
 }
 
-/// A Request future that issues a `supervisor_checkAccessList` request.
+/// A Request future that issues an `interop_checkAccessList` request.
 #[derive(Debug, Clone)]
 pub struct CheckAccessListRequest<'a> {
     client: ReqwestClient,
@@ -307,7 +307,7 @@ impl<'a> IntoFuture for CheckAccessListRequest<'a> {
             let result = tokio::time::timeout(
                 timeout,
                 client.request(
-                    "supervisor_checkAccessList",
+                    "interop_checkAccessList",
                     (inbox_entries, safety, executing_descriptor),
                 ),
             )

--- a/rust/op-reth/crates/txpool/src/supervisor/message.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/message.rs
@@ -16,7 +16,7 @@
 // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-/// An [`ExecutingDescriptor`] is a part of the payload to `supervisor_checkAccessList`
+/// An [`ExecutingDescriptor`] is a part of the payload to `interop_checkAccessList`
 /// Spec: <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#executingdescriptor>
 #[derive(Default, Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExecutingDescriptor {


### PR DESCRIPTION
Toward ethereum-optimism/optimism#20005:

1. **op-interop-filter** — register `QueryFrontend` under a new `interop` RPC namespace. The previous `supervisor` namespace is removed; this is a hard cutover.
2. **op-reth (rust/op-reth)** — switch the txpool's `CheckAccessList` request to `interop_checkAccessList`.
3. **op-acceptance-tests** — skip interop-filter presets on op-geth. op-geth still calls `supervisor_checkAccessList`, so the in-process filter rejects every tx. Interop is only supported with op-reth; the skip is implicit in `WithInteropFilter()` so test code stays simple.

op-reth needs a coordinated upgrade anyway, so the filter just cuts straight over to `interop_` rather than carrying both namespaces.