### PR TITLE
fix(op-devstack): retry eth_getProof while L2 EL persists state

### DIFF
--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -441,8 +441,15 @@ func (w *Withdrawal) proveWithdrawalParametersForEvent(ev *nodebindings.L2ToL1Me
 	w.require.Equal(withdrawalHash[:], ev.WithdrawalHash[:], "computed withdrawal hash incorrectly")
 	slot := withdrawals.StorageSlotOfWithdrawalHash(withdrawalHash)
 
-	p, err := w.bridge.l2Client.GetProof(w.ctx, predeploys.L2ToL1MessagePasserAddr, []common.Hash{slot}, hexutil.Uint64(l2Header.NumberU64()).String())
-	w.require.NoErrorf(err, "failed to fetch proof for withdrawal %v", ev)
+	// op-reth persists state asynchronously, so eth_getProof can briefly fail
+	// after the dispute game for the block exists. Retry until it succeeds.
+	blockTag := hexutil.Uint64(l2Header.NumberU64()).String()
+	var p *eth.AccountResult
+	w.require.Eventuallyf(func() bool {
+		var err error
+		p, err = w.bridge.l2Client.GetProof(w.ctx, predeploys.L2ToL1MessagePasserAddr, []common.Hash{slot}, blockTag)
+		return err == nil
+	}, 60*time.Second, 500*time.Millisecond, "failed to fetch proof for withdrawal at block %d: %v", l2Header.NumberU64(), ev)
 	w.require.Len(p.StorageProof, 1, "invalid amount of storage proofs")
 
 	err = verifyProof(l2Header.Root(), p)


### PR DESCRIPTION
Fixes the `no state found for block number N` flake in `TestWithdrawal_CannonKona` (and any other test that proves withdrawals against an op-reth L2 EL). Reopens ethereum-optimism/optimism#19964 with a new failure mode.

**Root cause.** op-reth in `op-devstack` runs with `--proofs-history --proofs-history.window=10000` (not archive mode). Historical `eth_getProof` is served from a proofs-history index populated by the asynchronous persistence service, which flushes in batches of 5 blocks. `StandardBridge.forGamePublished` only waits on L1 (`DisputeGameFactory`), so the proposer can publish a dispute game for L2 block N while op-reth still has block N's state in memory and not yet indexed for historical proofs. The failing CI run shows this exactly: `Persistence threshold reached ... count=5 start_block=26 end_block=30` was logged ~90ms after the failed `GetProof(26)`.

**Fix.** Wrap the `GetProof` call in `proveWithdrawalParametersForEvent` in an `Eventuallyf` (60s budget, 500ms poll) and retry on any error. On timeout the test fails with the original `failed to fetch proof for withdrawal` message.