### PR TITLE
fix(sync-tester): clear WindowSyncPolicy cache on session reset

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
@@ -28,7 +28,6 @@ func TestSyncTesterELSync(gt *testing.T) {
 	sys := presets.NewSimpleWithSyncTester(t, simpleWithSyncTesterOpts()...)
 	require := t.Require()
 	logger := t.Logger()
-	ctx := t.Ctx()
 
 	startDelta := uint64(5)
 	attempts := 30
@@ -40,13 +39,12 @@ func TestSyncTesterELSync(gt *testing.T) {
 	// Stop L2CL2 attached to Sync Tester EL Endpoint
 	sys.L2CL2.Stop()
 
-	// Reset Sync Tester EL
+	// Reset Sync Tester EL. SimpleWithSyncTester wires one SyncTesterEL → one session.
 	sessionIDs := sys.SyncTester.ListSessions()
-	require.GreaterOrEqual(len(sessionIDs), 1, "at least one session")
+	require.Len(sessionIDs, 1, "preset creates exactly one session")
 	sessionID := sessionIDs[0]
 	logger.Info("SyncTester EL", "sessionID", sessionID)
-	syncTesterClient := sys.SyncTester.Escape().APIWithSession(sessionID)
-	require.NoError(syncTesterClient.ResetSession(ctx))
+	sys.SyncTester.ResetSession(sessionID)
 
 	// Reseted and L2CL2 not connected to sync tester session so unsafe head will not advance
 	require.Equal(uint64(0), sys.SyncTesterL2EL.BlockRefByLabel(eth.Unsafe).Number)
@@ -56,8 +54,7 @@ func TestSyncTesterELSync(gt *testing.T) {
 	sys.L2CL.Advanced(types.LocalUnsafe, startDelta+delta, attempts)
 
 	// EL Sync active
-	session, err := syncTesterClient.GetSession(ctx)
-	require.NoError(err)
+	session := sys.SyncTester.GetSession(sessionID)
 	require.True(session.ELSyncActive)
 
 	// Restarting will trigger EL sync since unsafe head payload will arrive to L2CL2 via P2P

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/sync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/sync_test.go
@@ -36,6 +36,10 @@ func TestMultiELSync(gt *testing.T) {
 	// Stop L2CL2 to control SyncTesterL2EL manually
 	sys.L2CL2.Stop()
 
+	// Clear any payloads L2CL2 pushed before Stop completed — a leftover policy
+	// cache entry can flip SYNCING to VALID one step early and flake the test.
+	sys.SyncTester.ResetAllSessions()
+
 	// Advance few blocks to make sure reference node advanced
 	sys.L2CL.Advanced(types.LocalUnsafe, 10, 30)
 

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/sync_tester_hfs_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/sync_tester_hfs_test.go
@@ -48,7 +48,6 @@ func TestSyncTesterHardforks(gt *testing.T) {
 	sys := presets.NewSimpleWithSyncTester(t, simpleWithSyncTesterOpts()...)
 	require := t.Require()
 	logger := t.Logger()
-	ctx := t.Ctx()
 
 	// Check the L2CL passed configured hardforks
 	jovianTime := sys.L2Chain.Escape().ChainConfig().JovianTime
@@ -74,13 +73,8 @@ func TestSyncTesterHardforks(gt *testing.T) {
 	sys.L2CL2.DisconnectPeer(sys.L2CL)
 	sys.L2CL.DisconnectPeer(sys.L2CL2)
 	sys.L2CL2.Stop()
-	sessionIDs := sys.SyncTester.ListSessions()
-	require.GreaterOrEqual(len(sessionIDs), 1, "at least one session")
-	sessionID := sessionIDs[0]
-	logger.Info("SyncTester EL", "sessionID", sessionID)
-	syncTesterClient := sys.SyncTester.Escape().APIWithSession(sessionID)
 	// Resync starting from genesis
-	require.NoError(syncTesterClient.ResetSession(ctx))
+	sys.SyncTester.ResetAllSessions()
 	sys.SyncTesterL2EL.UnsafeHead().NumEqualTo(0)
 
 	// Wait until safe head reached Jovian

--- a/op-devstack/dsl/sync_tester.go
+++ b/op-devstack/dsl/sync_tester.go
@@ -41,6 +41,17 @@ func (s *SyncTester) DeleteSession(sessionID string) {
 	s.t.Require().NoError(err)
 }
 
+func (s *SyncTester) ResetSession(sessionID string) {
+	err := s.inner.APIWithSession(sessionID).ResetSession(s.ctx)
+	s.t.Require().NoError(err)
+}
+
+func (s *SyncTester) ResetAllSessions() {
+	for _, id := range s.ListSessions() {
+		s.ResetSession(id)
+	}
+}
+
 func (s *SyncTester) ChainID(sessionID string) eth.ChainID {
 	chainID, err := s.inner.APIWithSession(sessionID).ChainID(s.ctx)
 	s.t.Require().NoError(err, "should be able to get chain ID from SyncTester")

--- a/op-service/eth/synctester_session.go
+++ b/op-service/eth/synctester_session.go
@@ -26,6 +26,8 @@ type FCUState struct {
 // needs to be emulated.
 type ELSyncPolicy interface {
 	ELSyncStatus(num uint64) ExecutePayloadStatus
+	// Reset returns the policy to its freshly-constructed state.
+	Reset()
 }
 
 type SyncTesterSession struct {
@@ -62,6 +64,9 @@ func (s *SyncTesterSession) ResetSession() {
 	s.CurrentState = s.InitialState
 	s.Validated = s.InitialState.Latest
 	s.Payloads = make(map[PayloadID]*ExecutionPayloadEnvelope)
+	if s.ELSyncPolicy != nil {
+		s.ELSyncPolicy.Reset()
+	}
 }
 
 func (s *SyncTesterSession) IsELSyncActive() bool {

--- a/op-sync-tester/synctester/backend/elsync/el_sync.go
+++ b/op-sync-tester/synctester/backend/elsync/el_sync.go
@@ -72,6 +72,10 @@ func (e *WindowSyncPolicy) insertNum(num uint64) {
 	// Invariant: cache is sorted, no duplicates and size not larger than maxSize
 }
 
+func (e *WindowSyncPolicy) Reset() {
+	e.cache = nil
+}
+
 func (e *WindowSyncPolicy) ELSyncStatus(num uint64) eth.ExecutePayloadStatus {
 	e.insertNum(num)
 	if uint64(len(e.cache)) < e.cnt {

--- a/op-sync-tester/synctester/backend/elsync/el_sync_test.go
+++ b/op-sync-tester/synctester/backend/elsync/el_sync_test.go
@@ -87,6 +87,19 @@ func TestWindowSyncPolicy_GapThenFill_Cnt3(t *testing.T) {
 	}, got)
 }
 
+func TestWindowSyncPolicy_Reset(t *testing.T) {
+	p := NewWindowSyncPolicy(2, 5)
+
+	// Prime the cache with a leftover entry.
+	require.Equal(t, eth.ExecutionSyncing, p.ELSyncStatus(2))
+
+	p.Reset()
+
+	// Cache is empty: 3 alone is SYNCING, then [3,4] is VALID — [2,3,4] would not have applied.
+	require.Equal(t, eth.ExecutionSyncing, p.ELSyncStatus(3))
+	require.Equal(t, eth.ExecutionValid, p.ELSyncStatus(4))
+}
+
 func TestWindowSyncPolicy_Reorg_DropGreaterOrEqual_Current(t *testing.T) {
 	p := NewWindowSyncPolicy(2, 5)
 


### PR DESCRIPTION
`TestMultiELSync` flakes when L2CL2's verifier op-node manages to push a NewPayload + FCU to the SyncTester before `sys.L2CL2.Stop()` returns. `SyncTesterSession.ResetSession` was clearing `Validated`, `CurrentState`, and `Payloads`, but not the `WindowSyncPolicy` cache — so a leftover entry (commonly `2`) made the test's first `FCU(3)` form the consecutive run `[2,3]`, flip the policy to Valid, and advance `Validated` to 3. The next `NewPayload(4)` then returned VALID instead of SYNCING.

Add `Reset()` to the `ELSyncPolicy` interface, implement it on `WindowSyncPolicy` by zeroing the cache, and call it from `ResetSession`. A new unit test primes the cache with `2`, calls `Reset`, then observes `3` and `4` — it fails deterministically against a no-op `Reset` with the exact CI symptom (expected SYNCING, actual VALID), confirming the root cause. `TestMultiELSync` now also resets the session after stopping L2CL2.

Adds `SyncTester.ResetSession` / `ResetAllSessions` to the devstack DSL and migrates the two existing call sites (`TestSyncTesterELSync`, `sync_tester_hfs`) off the `Escape().APIWithSession(...)` pattern.

Fixes ethereum-optimism/optimism#20780