### PR TITLE
docs(flakes): add flake-prevention catalogue + semgrep rules for op-acceptance-tests

### DIFF
--- a/.semgrep/rules/go-acceptance-test-flakes.yaml
+++ b/.semgrep/rules/go-acceptance-test-flakes.yaml
@@ -1,7 +1,7 @@
 # Static checks for recurring flake patterns in op-acceptance-tests / op-devstack.
 #
 # Scoped narrowly to test code; do not enable for production code paths.
-# Each rule maps to a numbered entry (F1..F14) in docs/ai/flake-prevention.md.
+# Each rule maps to a numbered entry (F1..F15) in docs/ai/flake-prevention.md.
 #
 # Run locally:
 #   semgrep scan --config .semgrep/rules/go-acceptance-test-flakes.yaml \
@@ -36,9 +36,21 @@ rules:
                 ...
               }, ...)
           - pattern: |
+              require.Eventually($T, func(...) bool {
+                ...
+                assert.$F(...)
+                ...
+              }, ...)
+          - pattern: |
               require.EventuallyWithT($T, func(...) {
                 ...
                 require.$F(...)
+                ...
+              }, ...)
+          - pattern: |
+              require.EventuallyWithT($T, func(...) {
+                ...
+                assert.$F(...)
                 ...
               }, ...)
           - pattern: |
@@ -129,8 +141,11 @@ rules:
       `time.Sleep` in tests or DSL methods masks a missing wait. Replace with an
       explicit `WaitFor*` on the actual postcondition. See docs/ai/flake-prevention.md#f8.
       If you genuinely need to pace a polling loop, do it inside `wait.For` / `retry.Do`
-      backoff configuration, not as a free-standing Sleep.
-    pattern: time.Sleep(...)
+      backoff configuration, not as a free-standing Sleep. Use `// nosemgrep: flake-sleep-in-test`
+      with an explanatory comment for the rare cases where no chain event exists to wait on.
+    patterns:
+      - pattern: time.Sleep(...)
+      - pattern: clock.SystemClock.SleepCtx(...)
 
   # NOTE: a `<-time.After(d)`-as-sleep rule was prototyped here but dropped.
   # Semgrep's Go pattern parser doesn't accept `case <-... :` / `select {...}`

--- a/.semgrep/rules/go-acceptance-test-flakes.yaml
+++ b/.semgrep/rules/go-acceptance-test-flakes.yaml
@@ -1,0 +1,268 @@
+# Static checks for recurring flake patterns in op-acceptance-tests / op-devstack.
+#
+# Scoped narrowly to test code; do not enable for production code paths.
+# Each rule maps to a numbered entry (F1..F14) in docs/ai/flake-prevention.md.
+#
+# Run locally:
+#   semgrep scan --config .semgrep/rules/go-acceptance-test-flakes.yaml \
+#                op-acceptance-tests/ op-devstack/
+#
+# To skip a true-positive intentionally (rare — use only after discussing in review):
+#   // nosemgrep: <rule-id>
+
+rules:
+  # ----- F1: fatal assertion inside a polling/retry callback -----
+  # require.NoError / require.Equal / etc. inside require.Eventually / assert.Eventually
+  # callbacks turns a transient error into a permanent test failure on first hiccup
+  # and often leaves the system in an unrecoverable state.
+  - id: flake-require-in-eventually
+    languages: [go]
+    severity: ERROR
+    paths:
+      include:
+        - "op-acceptance-tests/"
+        - "op-devstack/"
+    message: |
+      `require.*` / `assert.*` calls inside a polling callback (Eventually, EventuallyWithT,
+      EventuallyFn, retry.Do) make the first transient failure fatal — the retry loop
+      cannot recover. Convert to `if err != nil { return false }` (or `t.Logf` + return).
+      See docs/ai/flake-prevention.md#f1.
+    patterns:
+      - pattern-either:
+          - pattern: |
+              require.Eventually($T, func(...) bool {
+                ...
+                require.$F(...)
+                ...
+              }, ...)
+          - pattern: |
+              require.EventuallyWithT($T, func(...) {
+                ...
+                require.$F(...)
+                ...
+              }, ...)
+          - pattern: |
+              assert.Eventually($T, func(...) bool {
+                ...
+                assert.$F(...)
+                ...
+              }, ...)
+          - pattern: |
+              retry.Do($CTX, $N, $STRAT, func() (...) {
+                ...
+                require.$F(...)
+                ...
+              })
+      - metavariable-pattern:
+          metavariable: $F
+          patterns:
+            - pattern-either:
+                - pattern: NoError
+                - pattern: NoErrorf
+                - pattern: Equal
+                - pattern: Equalf
+                - pattern: "True"
+                - pattern: "False"
+                - pattern: NotNil
+                - pattern: Nil
+
+  # ----- F2: require.* inside a non-test goroutine -----
+  # require.* calls FailNow which only exits the current goroutine. The test then
+  # hangs until package timeout instead of failing with the underlying error.
+  - id: flake-require-in-goroutine
+    languages: [go]
+    severity: ERROR
+    paths:
+      include:
+        - "op-acceptance-tests/"
+        - "op-devstack/"
+    message: |
+      `require.*` inside a spawned goroutine calls FailNow, which only exits the
+      goroutine. The main test will hang until package timeout. Send errors back to
+      the test via a channel or use `t.Errorf` (non-fatal). See docs/ai/flake-prevention.md#f2.
+    patterns:
+      - pattern-either:
+          - pattern: |
+              go func(...) {
+                ...
+                require.$F(...)
+                ...
+              }(...)
+          - pattern: |
+              go func(...) {
+                ...
+                t.Fatal(...)
+                ...
+              }(...)
+          - pattern: |
+              go func(...) {
+                ...
+                t.FailNow(...)
+                ...
+              }(...)
+      - metavariable-pattern:
+          metavariable: $F
+          patterns:
+            - pattern-either:
+                - pattern: NoError
+                - pattern: NoErrorf
+                - pattern: Equal
+                - pattern: Equalf
+                - pattern: "True"
+                - pattern: "False"
+                - pattern: NotNil
+                - pattern: Nil
+                - pattern: Fail
+                - pattern: FailNow
+
+  # ----- F8: time.Sleep in test code -----
+  # Already banned by writing-acceptance-tests.md; enforce it.
+  - id: flake-sleep-in-test
+    languages: [go]
+    severity: ERROR
+    paths:
+      include:
+        - "op-acceptance-tests/tests/"
+        - "op-devstack/dsl/"
+        - "op-devstack/presets/"
+    message: |
+      `time.Sleep` in tests or DSL methods masks a missing wait. Replace with an
+      explicit `WaitFor*` on the actual postcondition. See docs/ai/flake-prevention.md#f8.
+      If you genuinely need to pace a polling loop, do it inside `wait.For` / `retry.Do`
+      backoff configuration, not as a free-standing Sleep.
+    pattern: time.Sleep(...)
+
+  # NOTE: a `<-time.After(d)`-as-sleep rule was prototyped here but dropped.
+  # Semgrep's Go pattern parser doesn't accept `case <-... :` / `select {...}`
+  # as a `pattern-not-inside` argument cleanly, and the bare `<-time.After(...)`
+  # pattern fires on every legitimate `select { case <-time.After(d): ... }`
+  # timeout — 100% false-positive in the current tree. Re-introduce only with
+  # a working select exclusion.
+
+  # ----- F6: hand-rolled sync check bypassing the preset's auto-budget -----
+  # Calling NewSingleChainMultiNodeWithoutCheck (or the *WithoutCheck variants)
+  # then running a manual MatchedFn / ReachedFn defeats the preset's auto-detected
+  # ELSync budget extension. Use the auto-budgeted entry point.
+  - id: flake-without-check-with-manual-budget
+    languages: [go]
+    severity: ERROR
+    paths:
+      include:
+        - "op-acceptance-tests/"
+    message: |
+      `*WithoutCheck` paired with a hand-rolled `MatchedFn`/`ReachedFn` typically
+      undoes the preset's automatic ELSync budget extension (4x). Use the matching
+      `New*MultiNode` / `New*` entry point that runs the auto-budgeted check.
+      See docs/ai/flake-prevention.md#f6.
+    patterns:
+      - pattern-either:
+          - pattern: |
+              $SYS := presets.$NEW(...)
+              ...
+              dsl.MatchedFn(...)
+          - pattern: |
+              $SYS := presets.$NEW(...)
+              ...
+              dsl.ReachedFn(...)
+      - metavariable-pattern:
+          metavariable: $NEW
+          pattern-regex: ".*WithoutCheck.*"
+
+  # ----- F10: defer ordering deadlock (cancel before Wait) -----
+  # Defers run LIFO. `defer cancel()` written BEFORE `defer wg.Wait()` registers
+  # cancel first → Wait pops first → Wait blocks because cancel hasn't fired.
+  # $CANCEL is regex-restricted to common cancellation-function names; otherwise
+  # this rule false-fires on every `defer wg.Wait(); ... defer wg.Done()` pair.
+  - id: flake-defer-cancel-before-wait
+    languages: [go]
+    severity: ERROR
+    paths:
+      include:
+        - "op-acceptance-tests/"
+        - "op-devstack/"
+    message: |
+      `defer $CANCEL()` written BEFORE `defer $WG.Wait()` deadlocks at cleanup —
+      defers run LIFO, so Wait pops first and blocks waiting on a goroutine that
+      is itself waiting on a context that cancel hasn't fired yet.
+      Collapse to a single deferred closure: `defer func() { cancel(); wg.Wait() }()`.
+      See docs/ai/flake-prevention.md#f10.
+    patterns:
+      - pattern: |
+          defer $CANCEL()
+          ...
+          defer $WG.Wait()
+      - metavariable-regex:
+          metavariable: $CANCEL
+          regex: "^(cancel|cancelCtx|cancelFn|stop|stopFn|cleanup|close|shutdown)[A-Za-z0-9_]*$"
+
+  # ----- F14: MarkFlaky must reference a tracking issue -----
+  # MarkFlaky without a citation becomes invisible debt; require the call (or
+  # an adjacent comment) to mention an issue/PR number. We exempt the devtest
+  # package because it contains unit tests *of* the MarkFlaky feature itself,
+  # and the sysgo runtime helpers that wrap MarkFlaky for runtime-conditional
+  # skips (callers supply the reason, including the #NNNN citation).
+  - id: flake-markflaky-without-issue
+    languages: [go]
+    severity: WARNING
+    paths:
+      include:
+        - "op-acceptance-tests/"
+        - "op-devstack/"
+      exclude:
+        - "op-devstack/devtest/"
+        - "op-devstack/sysgo/mixed_runtime.go"
+    message: |
+      `MarkFlaky` is acceptable only as a documented band-aid. Add an inline
+      comment citing the GitHub issue tracking the root-cause fix (`// flake: #12345`).
+      Lint considers any `#NNNN` token in the call or the immediately preceding
+      comment line sufficient. See docs/ai/flake-prevention.md#f14.
+    patterns:
+      - pattern: $X.MarkFlaky(...)
+      - pattern-not-regex: '#[0-9]{3,}'
+
+  # ----- F3 partial: TOCTOU on UnsafeHead -> StartSequencer -----
+  # Reads UnsafeHead, then immediately uses the hash in StartSequencer. The head
+  # can advance between calls. Should be wrapped in a retry on "stale head" error.
+  - id: flake-toctou-start-sequencer
+    languages: [go]
+    severity: WARNING
+    paths:
+      include:
+        - "op-acceptance-tests/"
+        - "op-devstack/"
+    message: |
+      Reading the unsafe head and immediately passing its hash to StartSequencer
+      is a TOCTOU race — the head may advance between the two RPCs. Wrap in a
+      retry loop that re-reads on "block hash does not match" errors.
+      See docs/ai/flake-prevention.md#f3.
+    pattern-either:
+      - pattern: |
+          $H, $E := $N.UnsafeHead(...)
+          ...
+          $N.StartSequencer(..., $H.Hash, ...)
+      - pattern: |
+          $H, $E := $N.HeadBlockRef(...)
+          ...
+          $N.StartSequencer(..., $H.Hash, ...)
+
+  # ----- Short hardcoded test timeout -----
+  # context.WithTimeout(..., D) where D is a string literal under 30s in test code
+  # is a frequent flake source under CI load. Not a hard error; flag for review.
+  - id: flake-short-test-timeout
+    languages: [go]
+    severity: INFO
+    paths:
+      include:
+        - "op-acceptance-tests/tests/"
+    message: |
+      Short context timeout (<30s) in acceptance test code is brittle under CI
+      load. Either use the preset's default timeout, or budget more generously
+      (the cost of overshooting is small; the cost of flaking is high).
+    pattern-either:
+      - pattern: context.WithTimeout($CTX, 1*time.Second)
+      - pattern: context.WithTimeout($CTX, 2*time.Second)
+      - pattern: context.WithTimeout($CTX, 3*time.Second)
+      - pattern: context.WithTimeout($CTX, 5*time.Second)
+      - pattern: context.WithTimeout($CTX, 10*time.Second)
+      - pattern: context.WithTimeout($CTX, 15*time.Second)
+      - pattern: context.WithTimeout($CTX, 20*time.Second)

--- a/.semgrep/rules/go-acceptance-test-flakes.yaml
+++ b/.semgrep/rules/go-acceptance-test-flakes.yaml
@@ -1,7 +1,7 @@
 # Static checks for recurring flake patterns in op-acceptance-tests / op-devstack.
 #
 # Scoped narrowly to test code; do not enable for production code paths.
-# Each rule maps to a numbered entry (F1..F15) in docs/ai/flake-prevention.md.
+# Each rule maps to a numbered entry (F1..F14) in docs/ai/flake-prevention.md.
 #
 # Run locally:
 #   semgrep scan --config .semgrep/rules/go-acceptance-test-flakes.yaml \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ More detailed guidance for AI agents can be found in:
 
 - [docs/ai/ci-ops.md](docs/ai/ci-ops.md) - CI/CD operations
 - [docs/ai/contract-dev.md](docs/ai/contract-dev.md) - Smart contract development
+- [docs/ai/flake-prevention.md](docs/ai/flake-prevention.md) - Guidance for preventing flaky tests
 - [docs/ai/go-dev.md](docs/ai/go-dev.md) - Go service development
 - [docs/ai/rust-dev.md](docs/ai/rust-dev.md) - Rust development (kona, op-reth, alloy crates)
 - [docs/ai/acceptance-tests.md](docs/ai/acceptance-tests.md) - Building and running acceptance tests locally

--- a/docs/ai/flake-prevention.md
+++ b/docs/ai/flake-prevention.md
@@ -1,0 +1,338 @@
+# Flake Prevention — op-acceptance-tests & op-devstack
+
+Companion to [writing-acceptance-tests.md](writing-acceptance-tests.md). That doc tells you how to write a test cleanly; this doc names the *recurring* anti-patterns that have caused flakes in CI, the static checks that catch them, and the review questions that catch the ones a linter can't.
+
+If you are reviewing a PR that touches `op-acceptance-tests/` or `op-devstack/`, run through the [Reviewer checklist](#reviewer-checklist) at the bottom.
+
+## Why flakes keep landing
+
+Education ("don't use short timeouts, don't sleep") has not closed the gap because the patterns that actually flake are *subtle in a diff*: they look like reasonable Go.
+
+| Surface form | What flakes about it |
+|---|---|
+| `require.NoError(x.RPC(...))` inside `require.Eventually(...)` | A transient RPC error becomes a fatal `FailNow` *inside the callback*, killing the test on the first hiccup instead of letting the retry loop absorb it. |
+| `WaitForStall(unsafe)` then `WaitForStall(safe)` | The two waits independently succeed but the *invariant `safe == unsafe`* downstream code assumes is not enforced. |
+| `head := node.Head(); WaitForOther(head)` | TOCTOU — `head` is stale by the time the second call uses it. |
+| `Sleep(2s); SequenceBlock()` | Looks like "give the system a moment"; actually a missing wait on a precondition. |
+| `NewMultiNodeWithoutCheck(); WaitForBudget(60)` | Bypasses the preset's auto-detected sync budget. The preset would have used the correct 240s budget for ELSync; the test hard-codes 120s. |
+| `defer wg.Wait(); defer cancel()` | LIFO: `Wait` runs first and blocks forever because `cancel` hasn't fired yet. |
+| `go func(){ require.NoError(...) }()` | `FailNow` in a non-test goroutine only exits *the goroutine*; the test hangs until package timeout. |
+
+If you have written one of these, you have probably also written it in another test. Lint catches the ones with a syntactic signature; the rest are reviewer responsibility.
+
+## Anti-pattern catalogue
+
+Each entry is grounded in an actual fix from the past month. The PR link is the canonical example of what the fix looks like.
+
+### F1 — Fatal assertion inside a polling/retry callback
+
+```go
+// BAD — first transient error fails the test; sequencer's currentJob is left
+// non-nil, so every subsequent retry hits ErrConflictingJob and the test hangs.
+require.Eventually(t, func() bool {
+    head := ts.New(parent)
+    require.NoError(t, ts.Next(head))   // <-- this kills the test on first stall
+    return condition(head)
+}, 30*time.Second, 200*time.Millisecond)
+
+// GOOD — let the loop absorb transient errors.
+require.Eventually(t, func() bool {
+    head := ts.New(parent)
+    if err := ts.Next(head); err != nil {
+        log.Warn("transient ts.Next error", "err", err)
+        return false
+    }
+    return condition(head)
+}, 30*time.Second, 200*time.Millisecond)
+```
+
+Same shape applies to `assert.NoError`, `t.Fatal`, `Require()` chains. Anything that calls `FailNow` inside a closure that the runtime expects to be re-called.
+
+**Examples:** [#20651](https://github.com/ethereum-optimism/optimism/pull/20651), [#20255](https://github.com/ethereum-optimism/optimism/pull/20255), [#20209](https://github.com/ethereum-optimism/optimism/pull/20209), [#19976](https://github.com/ethereum-optimism/optimism/pull/19976). **Lint:** rule `flake-require-in-eventually` (catches this exactly).
+
+### F2 — `require.*` inside a goroutine
+
+```go
+// BAD — FailNow only exits this goroutine; the main test hangs until package timeout.
+go func() {
+    for evt := range stream {
+        require.NoError(t, evt.Err)
+    }
+}()
+
+// GOOD — surface the error to the test via t.Errorf (non-fatal) or a channel.
+errCh := make(chan error, 1)
+go func() {
+    for evt := range stream {
+        if evt.Err != nil {
+            errCh <- evt.Err
+            return
+        }
+    }
+}()
+```
+
+**Examples:** [#19976](https://github.com/ethereum-optimism/optimism/pull/19976), [#20255](https://github.com/ethereum-optimism/optimism/pull/20255). **Lint:** `flake-require-in-goroutine`.
+
+### F3 — TOCTOU between two RPCs that depend on each other
+
+```go
+// BAD — head may advance between the two calls.
+head, err := node.UnsafeHead(ctx)
+require.NoError(t, err)
+err = node.StartSequencer(ctx, head.Hash)
+require.NoError(t, err)   // "block hash does not match"
+
+// GOOD — retry the read+use pair on the documented "stale head" error.
+retry.Do(ctx, func() error {
+    head, err := node.UnsafeHead(ctx)
+    if err != nil { return err }
+    return node.StartSequencer(ctx, head.Hash)
+})
+```
+
+**Examples:** [#20204](https://github.com/ethereum-optimism/optimism/pull/20204). **Lint:** partial (`flake-toctou-start-sequencer`).
+
+### F4 — Wait on the wrong post-condition (or no post-condition at all)
+
+```go
+// BAD — ReorgTriggered guarantees the reorg-target block was rewritten, NOT that
+// the sequencer has extended past the verifier's frozen height. Assertion races
+// post-reorg block production.
+chain.ReorgTriggered()
+require.Greater(t, seq.Number(), ver.Number())
+
+// GOOD — explicit wait on the actual condition being asserted.
+frozen := ver.Head().Number
+chain.ReorgTriggered()
+seq.WaitForBlockNumber(frozen + 1)
+require.Greater(t, seq.Number(), ver.Number())
+```
+
+```go
+// BAD — proveWithdrawal reverts until block.timestamp > game.createdAt. The
+// retry loop burns its 30s budget on guaranteed-revert estimateGas calls.
+retryProve(ctx, 30*time.Second)
+
+// GOOD — wait deterministically for the static precondition first.
+require.Eventuallyf(t, func() bool {
+    head, _ := l1.HeadBlock(ctx)
+    return head.Time > gameCreatedAt
+}, 60*time.Second, 1*time.Second, "L1 head past game createdAt")
+retryProve(ctx, 30*time.Second)   // now scoped to transient submit/confirm errors only
+```
+
+**Examples:** [#20199](https://github.com/ethereum-optimism/optimism/pull/20199), [#20677](https://github.com/ethereum-optimism/optimism/pull/20677), [#20482](https://github.com/ethereum-optimism/optimism/pull/20482). **Lint:** no (semantic — needs a reviewer).
+
+### F5 — "Done" signal that doesn't entail "work happened"
+
+```go
+// BAD — AwaitBackfillCompleted resolves when runLogBackfill returns OR is
+// skipped (e.g. nil-range when L1 head was briefly behind). Test asserts that
+// blocks were sealed; gets `latest.Number == first.Number == 0`.
+chain.RestartInterop(wipeLogsDBs=true)
+chain.AwaitBackfillCompleted()
+require.Greater(t, chain.LatestBlock(), chain.FirstBlock())
+
+// GOOD — wait on the actual user-visible postcondition (sealed blocks),
+// or strengthen AwaitBackfillCompleted to require non-empty backfill.
+chain.RestartInterop(wipeLogsDBs=true)
+chain.WaitForBackfillToSeal(types.MinBlocks(2))
+```
+
+**Examples:** [#20690](https://github.com/ethereum-optimism/optimism/issues/20690). **Lint:** no.
+
+### F6 — Hand-rolled sync check that bypasses the preset's auto-budget
+
+```go
+// BAD — preset's NewSingleChainMultiNode auto-detects ELSync and applies a 4x
+// budget. WithoutCheck plus a manual 120-attempt loop undoes that fix.
+sys := presets.NewSingleChainMultiNodeWithoutCheck(t, opts)
+require.NoError(t, dsl.MatchedFn(sys, types.CrossSafe, 60, 2*time.Second)(ctx))
+
+// GOOD — use the auto-budgeted entry point.
+sys := presets.NewSingleChainMultiNode(t, opts)
+```
+
+**Examples:** [#20454](https://github.com/ethereum-optimism/optimism/pull/20454), [#20343](https://github.com/ethereum-optimism/optimism/pull/20343). **Lint:** `flake-without-check-with-manual-budget`.
+
+### F7 — Snapshot-once sync check that holds a stale target across reorgs
+
+```go
+// BAD — target is captured once outside the loop. If the reference node reorgs
+// out that block, the predicate is stuck waiting for a hash that no longer exists.
+target := ref.Head()
+require.Eventually(t, func() bool {
+    return base.Head().Number >= target.Number
+}, 60*time.Second, 1*time.Second)
+
+// GOOD — re-sample both sides every attempt, allow a small bounded gap, and
+// verify hash agreement at the lower height.
+require.Eventually(t, func() bool {
+    a, b := ref.Head(), base.Head()
+    if absDiff(a.Number, b.Number) > 5 { return false }
+    return base.HashAt(min(a.Number, b.Number)) == ref.HashAt(min(a.Number, b.Number))
+}, 60*time.Second, 1*time.Second)
+```
+
+**Examples:** [#20405](https://github.com/ethereum-optimism/optimism/pull/20405). **Lint:** partial.
+
+### F8 — `time.Sleep` between async-driven operations
+
+```go
+// BAD — sequencing a block is async; sleeping 2s is "usually enough" until CI is loaded.
+ts.SequenceBlock(parent)
+time.Sleep(2 * time.Second)
+ts.SequenceBlock(child)
+
+// GOOD — wait on the block being visible at the consumer.
+ts.SequenceBlock(parent)
+chain.WaitForBlockNumber(parent.Number + 1)
+ts.SequenceBlock(child)
+```
+
+The existing `writing-acceptance-tests.md` already bans `time.Sleep`. Lint enforces it now.
+
+**Examples:** [#20198](https://github.com/ethereum-optimism/optimism/issues/20198). **Lint:** `flake-sleep-in-test`.
+
+### F9 — Invariants between two parallel waits not enforced
+
+```go
+// BAD — sequencers and batchers stopped in parallel. WaitForStall returns when
+// each independently quiesces, but `safe < unsafe` can persist. Downstream code
+// that assumes `safe == unsafe` (timestamp arithmetic) computes nonsense.
+stopAllSequencers()
+stopAllBatchers()
+waitForStall(LocalUnsafe)
+waitForStall(LocalSafe)
+// ... safe may still be < unsafe here
+
+// GOOD — order the stops and *converge* the invariant before exit.
+stopAllSequencers()
+waitForStall(LocalUnsafe)
+unsafeNumber := head(LocalUnsafe).Number
+cl.Reached(LocalSafe, unsafeNumber, 30*time.Second)
+stopAllBatchers()
+require.Equal(t, head(LocalSafe).Number, head(LocalUnsafe).Number)
+```
+
+**Examples:** [#20580](https://github.com/ethereum-optimism/optimism/pull/20580). **Lint:** no.
+
+### F10 — Defer ordering that deadlocks cleanup
+
+```go
+// BAD — source order: cancel deferred first, Wait deferred second.
+// Defers are LIFO: the *later*-deferred Wait pops first, blocking on a
+// goroutine that is itself waiting on the context — which cancel hasn't
+// fired yet. Deadlock until package timeout.
+ctx, cancel := context.WithCancel(t.Context())
+defer cancel()       // registered first → runs LAST
+wg.Add(1)
+go collector(ctx, &wg)
+defer wg.Wait()      // registered last → runs FIRST → blocks → deadlock
+
+// GOOD — single defer, explicit order.
+ctx, cancel := context.WithCancel(t.Context())
+wg.Add(1)
+go collector(ctx, &wg)
+defer func() { cancel(); wg.Wait() }()
+```
+
+**Examples:** [#20600](https://github.com/ethereum-optimism/optimism/pull/20600). **Lint:** `flake-defer-cancel-before-wait`.
+
+### F11 — Background test fixture races with the test on shared resources
+
+The honest proposer and the test both try to create dispute games at the same factory timestamp. Game UUIDs are deterministic in `(gameType, rootClaim, extraData)`, so concurrent creation collides with `GameAlreadyExists`.
+
+```go
+// BAD — preset starts a real proposer that runs concurrently with the test's game creation.
+sys := presets.NewSuperFaultProofs(t)
+sys.DGF.CreateGame(...)   // races with proposer's autonomous game creation
+
+// GOOD — opt out of the background actor the test doesn't need.
+sys := presets.NewSuperFaultProofs(t, presets.WithoutHonestProposer())
+sys.DGF.CreateGame(...)
+```
+
+The general lesson: **a preset should be a minimal universe**. If your test does not exercise a component, the preset should not run it. Add an opt-out, don't try to coexist with the racing background actor.
+
+**Examples:** [#20575](https://github.com/ethereum-optimism/optimism/pull/20575), [#20574](https://github.com/ethereum-optimism/optimism/issues/20574). **Lint:** no.
+
+### F12 — Speculative event treated as final
+
+```go
+// BAD — first flashblock containing tx may be superseded; tx lands in next block.
+fb := stream.WaitFor(func(fb Flashblock) bool {
+    return fb.Contains(txHash)
+})
+require.Equal(t, expectedBlock, fb.BlockNumber)
+
+// GOOD — collect candidates, filter on confirmed inclusion block.
+flashes := stream.Collect(20*time.Second)
+receipt := tx.WaitForReceipt()
+matching := filterByBlock(flashes, receipt.BlockNumber)
+require.NotEmpty(t, matching)
+```
+
+**Examples:** [#20066](https://github.com/ethereum-optimism/optimism/pull/20066), [#19976](https://github.com/ethereum-optimism/optimism/pull/19976). **Lint:** no.
+
+### F13 — Concurrent tx submissions sharing a nonce source
+
+```go
+// BAD — alice submits two txs concurrently without nonce coordination; second
+// gets stale nonce 0 while first already used nonce 0.
+go alice.Transfer(bob, amount)
+go alice.Transfer(carol, amount)
+
+// GOOD — serialize, or use distinct funded EOAs.
+g, _ := errgroup.WithContext(t.Context())
+g.Go(func() error { return sys.NewFundedEOA().Transfer(bob, amount) })
+g.Go(func() error { return sys.NewFundedEOA().Transfer(carol, amount) })
+require.NoError(t, g.Wait())
+```
+
+**Examples:** [#20345](https://github.com/ethereum-optimism/optimism/issues/20345). **Lint:** no (semantic).
+
+### F14 — `MarkFlaky` as a band-aid instead of a fix
+
+`MarkFlaky` is an *escalation*, not a resolution. Mark a test flaky **only** when:
+
+1. A `C-flake` GitHub issue exists with a reproducible failure log.
+2. The mark cites the issue number in a comment.
+3. The team owning the test acknowledged ownership.
+
+`MarkFlaky` without an owning issue is invisible debt. Lint flags `MarkFlaky` calls that don't reference an issue.
+
+**Examples:** [#20200](https://github.com/ethereum-optimism/optimism/pull/20200). **Lint:** `flake-markflaky-without-issue`.
+
+## Reviewer checklist
+
+When reviewing a PR that touches `op-acceptance-tests/` or `op-devstack/`, ask:
+
+- [ ] **F1**: Any `require.*` / `assert.*` calls inside a `Eventually`/`Until`/`retry.Do` callback? They should be `if err != nil { return false }` instead.
+- [ ] **F2**: Any `require.*` inside `go func(){...}()`? Goroutine assertions hang the test on failure.
+- [ ] **F3**: Any "read X, then use X in next RPC" pattern? Could X be stale?
+- [ ] **F4**: Every assertion in the test has a preceding wait on its *exact* postcondition (not a proxy like "sequencer started").
+- [ ] **F5**: `Await*`/`*Completed`/`*Done` methods — do they guarantee the *work* happened, or just that the *signal* fired?
+- [ ] **F6**: Manual sync checks: any `WithoutCheck` followed by a hand-rolled budget? Use the auto-budgeted preset.
+- [ ] **F7**: Sync checks: is the reference value sampled *inside* the retry loop, or captured once outside?
+- [ ] **F8**: Any `time.Sleep` in test code? Replace with `WaitFor*`.
+- [ ] **F9**: Two independent waits — is the invariant between them asserted on exit?
+- [ ] **F10**: Multiple defers — does the LIFO order produce a deadlock? Collapse to one closure.
+- [ ] **F11**: Does the preset run components the test does not exercise? Consider an opt-out.
+- [ ] **F12**: Any "first matching event" logic on a stream that can supersede entries?
+- [ ] **F13**: Concurrent operations sharing nonces, ports, or other unique resources?
+- [ ] **F14**: New `MarkFlaky` → linked C-flake issue and owner?
+
+## When a flake report comes in
+
+1. **File a `C-flake` issue** with the CircleCI link, the failing assertion, and the surrounding log context. Include CircleCI Insights flake-history if available.
+2. **Search this doc** for the failure shape — most flakes are recurrences. If you find one, tag the issue with the F-number.
+3. **If new shape**: after the fix lands, **add a new F-entry** to this doc with the PR number. The catalogue is the institutional memory.
+4. **If recurring**: ask whether the existing lint rule should be tightened, or whether the catalogue entry needs a sharper example. The point of the catalogue is to make the next occurrence catchable.
+
+## Static enforcement
+
+Lint rules for the catchable patterns live in [`.semgrep/rules/go-acceptance-test-flakes.yaml`](../../.semgrep/rules/go-acceptance-test-flakes.yaml) and run in CI under the `semgrep-scan-local` job. Failing rules block merge.
+
+The rules are *deliberately scoped* to `op-acceptance-tests/` and `op-devstack/` paths — they encode test-specific conventions, not generic Go style.

--- a/docs/ai/flake-prevention.md
+++ b/docs/ai/flake-prevention.md
@@ -15,7 +15,7 @@ Education ("don't use short timeouts, don't sleep") has not closed the gap becau
 | `head := node.Head(); WaitForOther(head)` | TOCTOU — `head` is stale by the time the second call uses it. |
 | `Sleep(2s); SequenceBlock()` | Looks like "give the system a moment"; actually a missing wait on a precondition. |
 | `NewMultiNodeWithoutCheck(); WaitForBudget(60)` | Bypasses the preset's auto-detected sync budget. The preset would have used the correct 240s budget for ELSync; the test hard-codes 120s. |
-| `defer wg.Wait(); defer cancel()` | LIFO: `Wait` runs first and blocks forever because `cancel` hasn't fired yet. |
+| `defer cancel(); ... defer wg.Wait()` | LIFO: `Wait` runs first and blocks forever because `cancel` hasn't fired yet. |
 | `go func(){ require.NoError(...) }()` | `FailNow` in a non-test goroutine only exits *the goroutine*; the test hangs until package timeout. |
 
 If you have written one of these, you have probably also written it in another test. Lint catches the ones with a syntactic signature; the rest are reviewer responsibility.
@@ -122,7 +122,31 @@ require.Eventuallyf(t, func() bool {
 retryProve(ctx, 30*time.Second)   // now scoped to transient submit/confirm errors only
 ```
 
-**Examples:** [#20199](https://github.com/ethereum-optimism/optimism/pull/20199), [#20677](https://github.com/ethereum-optimism/optimism/pull/20677), [#20482](https://github.com/ethereum-optimism/optimism/pull/20482). **Lint:** no (semantic — needs a reviewer).
+```go
+// BAD — CL/supervisor state reached the target, but the EL label/content is
+// updated through an async forkchoice/reorg path. A synchronous EL read can
+// still observe the previous safe label or old block contents.
+cl.Reached(types.CrossSafe, target, 30)
+safe := el.BlockRefByLabel(eth.Safe)
+require.GreaterOrEqual(t, safe.Number, target)
+
+// GOOD — wait on the component and observable state the assertion actually
+// reads. If the assertion is about EL labels or block contents, include an
+// EL-side wait before the synchronous assertion.
+dsl.CheckAll(t,
+    cl.ReachedFn(types.CrossSafe, target, 30),
+    el.ReachedFn(eth.Safe, target, 30),
+)
+safe = el.BlockRefByLabel(eth.Safe)
+require.GreaterOrEqual(t, safe.Number, target)
+```
+
+The same shape appears when a supervisor or CL validation wait is followed by
+an EL block-content assertion. `AwaitValidatedTimestamp` and `Reached(CrossSafe)`
+prove the control-plane view advanced; they do not automatically prove the EL
+has exposed the replacement canonical block or historical proof state.
+
+**Examples:** [#20199](https://github.com/ethereum-optimism/optimism/pull/20199), [#20677](https://github.com/ethereum-optimism/optimism/pull/20677), [#20482](https://github.com/ethereum-optimism/optimism/pull/20482), [#20852](https://github.com/ethereum-optimism/optimism/pull/20852), [#20782](https://github.com/ethereum-optimism/optimism/pull/20782). **Lint:** no (semantic — needs a reviewer).
 
 ### F5 — "Done" signal that doesn't entail "work happened"
 
@@ -141,6 +165,15 @@ chain.WaitForBackfillToSeal(types.MinBlocks(2))
 ```
 
 **Examples:** [#20690](https://github.com/ethereum-optimism/optimism/issues/20690). **Lint:** no.
+
+The same trap applies to `Stop`, `Reset`, and `Restart` helpers: the call
+returning does not necessarily mean every background producer is quiesced or
+that every hidden cache has been cleared. If the next assertion depends on
+empty session state, drained queues, or no more payloads arriving, the helper
+must either guarantee that stronger postcondition or the test must wait/assert
+on it directly.
+
+**Related:** [#20783](https://github.com/ethereum-optimism/optimism/pull/20783).
 
 ### F6 — Hand-rolled sync check that bypasses the preset's auto-budget
 
@@ -312,8 +345,8 @@ When reviewing a PR that touches `op-acceptance-tests/` or `op-devstack/`, ask:
 - [ ] **F1**: Any `require.*` / `assert.*` calls inside a `Eventually`/`Until`/`retry.Do` callback? They should be `if err != nil { return false }` instead.
 - [ ] **F2**: Any `require.*` inside `go func(){...}()`? Goroutine assertions hang the test on failure.
 - [ ] **F3**: Any "read X, then use X in next RPC" pattern? Could X be stale?
-- [ ] **F4**: Every assertion in the test has a preceding wait on its *exact* postcondition (not a proxy like "sequencer started").
-- [ ] **F5**: `Await*`/`*Completed`/`*Done` methods — do they guarantee the *work* happened, or just that the *signal* fired?
+- [ ] **F4**: Every assertion in the test has a preceding wait on its *exact* postcondition (not a proxy like "sequencer started", "CL reached CrossSafe", or "supervisor validated timestamp" when the assertion reads EL state).
+- [ ] **F5**: `Await*`/`*Completed`/`*Done`/`Stop`/`Reset` methods — do they guarantee the *work* happened and hidden state is drained, or just that the signal/API call returned?
 - [ ] **F6**: Manual sync checks: any `WithoutCheck` followed by a hand-rolled budget? Use the auto-budgeted preset.
 - [ ] **F7**: Sync checks: is the reference value sampled *inside* the retry loop, or captured once outside?
 - [ ] **F8**: Any `time.Sleep` in test code? Replace with `WaitFor*`.

--- a/docs/ai/writing-acceptance-tests.md
+++ b/docs/ai/writing-acceptance-tests.md
@@ -159,6 +159,8 @@ bob.WaitForBalance(expected)
 
 If the DSL lacks a wait for the condition you care about, add one — don't sprinkle `time.Sleep` into the test. If a test only passes on rerun, it is broken, not "flaky"; treat the retry as a missing post-condition somewhere upstream and find it.
 
+For the catalogue of recurring flake patterns observed in CI — with the static lint rules that catch them and the reviewer checklist for the ones that lint can't — see [flake-prevention.md](flake-prevention.md).
+
 ## No Test-Only Branches in Production Code
 
 Production code paths and test code paths must be the same paths. The only acceptable variation points are explicit, observable seams — preset selection, DSL-injected doubles, launch flags read once at startup.


### PR DESCRIPTION
## Summary

- Catalogues 14 recurring flake-causing patterns observed in `op-acceptance-tests/` and `op-devstack/` PRs over the past month (F1 through F14, each grounded in a real fix PR). New file `docs/ai/flake-prevention.md`.
- Adds 8 semgrep rules under `.semgrep/rules/go-acceptance-test-flakes.yaml` that enforce the 5 syntactically-catchable patterns in CI. Reuses the existing `semgrep-scan-local` job in `.circleci/continue/main.yml`, so no new pipeline plumbing.
- Cross-links from `docs/ai/writing-acceptance-tests.md` so engineers reading the DSL guide find the new doc.

## Motivation

Engineers have flagged a sustained rise in flaky CI failures concentrated in `op-acceptance-tests/` and `op-devstack/`. The team already maintains the `C-flake` GitHub label and the "No Sleeps, No Retries, No Flakes" section in `writing-acceptance-tests.md`, but the same anti-patterns keep recurring because they are subtle in a diff. `require.NoError` inside an `Eventually` callback looks like reasonable Go.

This PR codifies the recurring patterns into reviewer-actionable form (the catalogue) and an enforceable form (lint).

## What's in the catalogue

| #   | Pattern                                                       | Lint?              |
| --- | ------------------------------------------------------------- | ------------------ |
| F1  | `require.*` inside polling/retry callback                     | yes                |
| F2  | `require.*` inside spawned goroutine                          | yes                |
| F3  | TOCTOU read-then-use of head/state                            | partial            |
| F4  | Wait on wrong post-condition / missing wait                   | no (semantic)      |
| F5  | "Done" signal that doesn't entail work happened               | no (semantic)      |
| F6  | Hand-rolled sync budget that bypasses preset auto-budget      | yes                |
| F7  | Snapshot-once sync target stale after reorg                   | partial            |
| F8  | `time.Sleep` between async-driven operations                  | yes                |
| F9  | Invariants between two parallel waits not enforced            | no (semantic)      |
| F10 | Defer LIFO deadlock (`defer cancel(); ... defer wg.Wait()`)   | yes                |
| F11 | Background fixture races with test on shared state            | no (preset design) |
| F12 | Speculative event treated as final                            | no (semantic)      |
| F13 | Concurrent tx submissions sharing a nonce                     | no (semantic)      |
| F14 | `MarkFlaky` band-aid without tracking issue                   | yes                |

Each F-entry in the doc has: a real failing-code example, the corrected fix, and a link to the merged PR it was extracted from. The bottom of the doc has a 14-item reviewer checklist intended to be skim-readable during PR review.

## Lint rules

| Rule                                    | Severity | Catches                                                                                                                                              |
| --------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
| `flake-require-in-eventually`           | ERROR    | `require.*` inside `Eventually` / `EventuallyWithT` / `retry.Do` callbacks                                                                            |
| `flake-require-in-goroutine`            | ERROR    | `require.*` inside `go func(){...}()` (FailNow only exits the goroutine)                                                                              |
| `flake-sleep-in-test`                   | ERROR    | `time.Sleep` in tests / DSL (already banned by writing-acceptance-tests.md; now enforced)                                                             |
| `flake-without-check-with-manual-budget`| ERROR    | `presets.*WithoutCheck` paired with a hand-rolled `MatchedFn` / `ReachedFn` that undoes the auto-detected ELSync budget                               |
| `flake-defer-cancel-before-wait`        | ERROR    | `defer cancel(); ... defer wg.Wait()` (LIFO order: Wait pops first, deadlocks). `$CANCEL` regex-pinned to cancellation-like names.                    |
| `flake-markflaky-without-issue`         | WARNING  | `MarkFlaky(...)` calls with no `#NNNN` issue reference                                                                                                |
| `flake-toctou-start-sequencer`          | WARNING  | `UnsafeHead -> StartSequencer(head.Hash)` two-call pattern                                                                                            |
| `flake-short-test-timeout`              | INFO     | Hardcoded sub-30s `context.WithTimeout` in test code                                                                                                  |

Rules are path-scoped to `op-acceptance-tests/` and `op-devstack/`. The `semgrep-scan-local` job already runs `semgrep scan --config .semgrep/rules/ --error .`, so failing rules block merge automatically once this lands.

## Validation

The rule set was backtested before landing. Two measurements:

**False-positive rate on current `develop`**: 21 findings, **0 confirmed false positives**. Breakdown:

- 10 x `flake-sleep-in-test`: all real `time.Sleep` calls already in violation of the existing guideline.
- 9 x `flake-short-test-timeout` (INFO): all real sub-30s timeouts; reviewer nudge.
- 2 x `flake-defer-cancel-before-wait`: **two real deadlock bugs** (`op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go:102`, `schedule.go:203`). Worth fixing as a follow-up.

The initial draft produced 49 findings with about 55% FPs. Tuning fixed: (a) an unconstrained `$CANCEL` metavariable, (b) a path-exclude gap for `op-devstack/devtest/testing_test.go` (the unit test of the MarkFlaky feature itself), (c) a 100%-FP `<-time.After()` rule whose `pattern-not-inside: select {...}` could not be expressed in semgrep's current Go parser. Dropped with a comment explaining why and how to re-introduce.

**Holdout backtest**: 5 closed `C-flake` issues from before the analysis-window cutoff, none of whose fix diffs were used to derive the taxonomy:

| Issue  | Test                                                          | Caught?                                              |
| ------ | ------------------------------------------------------------- | ---------------------------------------------------- |
| #19611 | TestUnsafeChainNotStalling_ELSync                             | Strong TP (Sleep replaced with WaitForStall)         |
| #19610 | TestSupernodeInteropChainLag                                  | Strong TP (Sleep replaced with explicit head wait)   |
| #19884 | TestUnsafeGapFillAfterSafeReorg                               | FN-by-design (semantic F4)                           |
| #19836 | TestEthSimulateV1                                             | FN-by-design (semantic F4: waited on wrong network)  |
| #19656 | TestInteropFaultProofs_ConsolidateValidCrossChainMessage      | Out of scope (subprocess pipe mgmt)                  |

Restricted to syntactic root causes: **2/2 caught (100%)**. Across all flakes: **2/5 (40%)**. The rest are semantic and live in the reviewer checklist as F4 / F5 / F11.

A correctness bug in the catalogue's own F10 example (the LIFO reasoning was reversed) was caught and fixed by this backtest. Full methodology, raw findings, and reproduction commands: see attached gist / report.

## What this PR does NOT do

- Does not fix existing violations. The 2 deadlock bugs and 10 `time.Sleep` sites that the rules flag on `develop` are left for follow-up PRs so this one stays scoped to "policy". CI on this PR will surface them.
- Does not introduce an LLM-based reviewer. The semantic patterns F4 / F5 / F11 (which dominate by volume) are out of static-lint reach; a Claude-powered GitHub reviewer is the natural next step but separate from this change.
- Does not clean up existing violations on `develop`. Because PR Semgrep runs in baseline mode, those existing findings will not fail this PR's `semgrep-scan-local` job. A full non-baseline scan, or a post-merge `develop` run, is needed to surface them unless the cleanup lands first.

## Test plan

- [ ] CI's `semgrep-scan-local` job runs with the new rules and validates that the config parses and produces no new findings in PR-changed files. Note: PR CI sets `SEMGREP_BASELINE_REF=develop`, so existing findings already present on `develop` are filtered out and will not light up on this PR.
- [ ] One reviewer reads `docs/ai/flake-prevention.md` cold and reports whether the F-numbering and PR links land as intended.
- [ ] Spot-check one rule by running locally:
  ```bash
  docker run --rm -v "$PWD":/src -w /src returntocorp/semgrep \
    semgrep --config .semgrep/rules/go-acceptance-test-flakes.yaml \
    --metrics=off --no-git-ignore --quiet op-acceptance-tests/ op-devstack/
  ```

## Follow-ups

1. **Cleanup sweep PR**: fix the 21 findings the new rules raise on `develop` (2 real deadlocks, 10 sleeps, 9 short-timeout reviews).
2. **Path-prefix migration**: update `paths.include` prefixes to `/op-acceptance-tests/...` or `**/op-acceptance-tests/...` before semgrep's gitignore-anchoring migration makes the current substring form a hard error.
3. **Re-introduce `flake-time-after-as-sleep`** once a `pattern-not-inside: select {...}` form parses cleanly.
4. **LLM PR reviewer** for the F4 / F5 / F11 patterns that dominate by volume and are syntactically uncatchable. Likely the highest-leverage extension of this work.
