### PR TITLE
chore(ci): disable fsync in acceptance tests via eatmydata

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1994,6 +1994,12 @@ jobs:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge+
     steps:
+      - run:
+          name: Install eatmydata and disable fsync for all subprocesses
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends eatmydata
+            echo 'export LD_PRELOAD=libeatmydata.so' >> "$BASH_ENV"
       - utils/checkout-with-mise:
           checkout-method: blobless
           enable-mise-cache: true


### PR DESCRIPTION
Acceptance tests run many in-process devnets in parallel and persist state to `/tmp` on the runner's real disk. Under load, op-reth's mdbx commit blocks on `fsync` and stalls — a recent merge-queue run on `memory-all-opn-op-reth` had `commit_duration` jump from ~6ms to 60–125s, which cascaded into `context deadline exceeded` failures across ~36 unrelated tests in a single 1–2 second window.

Durability has no meaning for a CI job that's wiped at the end, so this preloads `libeatmydata.so` for the entire `op-acceptance-tests` job. The `LD_PRELOAD` export is written to `$BASH_ENV`, so every subsequent step and every subprocess (op-reth, op-node, op-geth, supernode, go test, just, ...) inherits it and `fsync`/`fdatasync`/`msync` become no-ops.

Applies to all three callers of the job: `memory-all-opn-op-geth`, `memory-all-opn-op-reth`, `memory-all-kona-op-reth`.