### PR TITLE
chore(ci): use ci-base-clang as default_docker_image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ version: 2.1
 setup: true
 
 parameters:
+  # ci-base-clang (cimg/base + clang/llvm-dev/libclang-dev) is used as both the
+  # default and Rust base image. Provenance is verified by .github/workflows/security.yml.
   default_docker_image:
     type: string
-    default: cimg/base:2026.03
-  # Pinned ci-base-clang image (cimg/base + clang/llvm-dev/libclang-dev) for Rust jobs.
-  # Provenance is verified by .github/workflows/security.yml.
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:00f641689576d7393d83f6fd49fe1592006148305999f1ba2fc4f1f9d2e8a342
   rust_base_image:
     type: string
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:00f641689576d7393d83f6fd49fe1592006148305999f1ba2fc4f1f9d2e8a342

--- a/.circleci/continue/docs-ci.yml
+++ b/.circleci/continue/docs-ci.yml
@@ -6,7 +6,7 @@ version: 2.1
 parameters:
   c-default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:00f641689576d7393d83f6fd49fe1592006148305999f1ba2fc4f1f9d2e8a342
   c-docs_changes_detected:
     type: boolean
     default: false
@@ -16,7 +16,7 @@ parameters:
   # These are not referenced by any job — the c- prefixed versions above are used instead.
   default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:00f641689576d7393d83f6fd49fe1592006148305999f1ba2fc4f1f9d2e8a342
   base_image:
     type: string
     default: default

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   c-default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:00f641689576d7393d83f6fd49fe1592006148305999f1ba2fc4f1f9d2e8a342
   c-rust_base_image:
     type: string
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105
@@ -86,7 +86,7 @@ parameters:
   # These are not referenced by any job — the c- prefixed versions above are used instead.
   default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:00f641689576d7393d83f6fd49fe1592006148305999f1ba2fc4f1f9d2e8a342
   rust_base_image:
     type: string
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -10,7 +10,7 @@ orbs:
 parameters:
   c-default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:00f641689576d7393d83f6fd49fe1592006148305999f1ba2fc4f1f9d2e8a342
   c-rust_base_image:
     type: string
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105
@@ -35,7 +35,7 @@ parameters:
   # These are not referenced by any job — the c- prefixed versions above are used instead.
   default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:00f641689576d7393d83f6fd49fe1592006148305999f1ba2fc4f1f9d2e8a342
   rust_base_image:
     type: string
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -11,7 +11,7 @@ parameters:
   # Required parameters (also in main.yml, merged during continuation)
   c-default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:00f641689576d7393d83f6fd49fe1592006148305999f1ba2fc4f1f9d2e8a342
   c-rust_base_image:
     type: string
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105
@@ -30,7 +30,7 @@ parameters:
   # These are not referenced by any job — the c- prefixed versions above are used instead.
   default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:00f641689576d7393d83f6fd49fe1592006148305999f1ba2fc4f1f9d2e8a342
   rust_base_image:
     type: string
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105


### PR DESCRIPTION
Experiment: switch the default CircleCI Docker executor image from `cimg/base:2026.03` to the pinned `ci-base-clang` digest. `ci-base-clang` is `FROM cimg/base:2026.03` plus clang/llvm-dev/libclang-dev, so it should be a drop-in superset. Unifies the base image and is a stepping stone toward enabling `eatmydata` in a single place (see ethereum-optimism/optimism#20787).

## Test plan

- [ ] Compare CI run times against latest develop run — confirm no significant regression on Go, contracts, and acceptance jobs
- [ ] Spot-check a handful of jobs to ensure the image pulls and executes correctly