### PR TITLE
perf(rust-e2e): consolidate rust build and tighten restart-suite timing

### DIFF
--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -306,30 +306,14 @@ workflows:
       - cannon-prestate: &rust-e2e-job-base
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - rust-build-binary: &cannon-kona-host
-          name: cannon-kona-host
-          directory: rust
-          profile: release
-          binary: "kona-host"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       # kona-build-release builds the whole rust workspace (no binary filter),
-      # so it produces kona-host, kona-node, op-reth, and the rest. It is the
-      # sole persister of release binaries — cannon-kona-host and op-reth-build
-      # still build in parallel to prime caches, but their outputs overlap with
-      # this job's persist glob and would conflict if persisted concurrently.
+      # so it produces kona-host, kona-node, op-reth, and the rest. Downstream
+      # e2e jobs attach the workspace and consume the binaries directly.
       - rust-build-binary: &kona-build-release
           name: kona-build-release
           directory: rust
           profile: release
           persist_to_workspace: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-      - rust-build-binary:
-          name: op-reth-build
-          directory: rust
-          profile: release
-          binary: "op-reth"
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-e2e-sysgo-tests:
@@ -343,21 +327,18 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate
-            - cannon-kona-host
             - kona-build-release
-            - op-reth-build
       - op-reth-e2e-sysgo-tests:
           <<: *rust-e2e-job-base
           requires:
             - contracts-bedrock-build
-            - op-reth-build
+            - kona-build-release
       - rust-restart-sysgo-tests:
           name: rust-e2e-restart
           <<: *rust-e2e-job-base
           requires:
             - contracts-bedrock-build
             - cannon-prestate
-            - cannon-kona-host
             - kona-build-release
       # Proof tests - single kind only, interop excluded per original config
       - kona-proof-action-tests:

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -306,11 +306,11 @@ workflows:
       - cannon-prestate: &rust-e2e-job-base
           context:
             - circleci-repo-readonly-authenticated-github-token
-      # kona-build-release builds the whole rust workspace (no binary filter),
+      # rust-workspace-release builds the whole rust workspace (no binary filter),
       # so it produces kona-host, kona-node, op-reth, and the rest. Downstream
       # e2e jobs attach the workspace and consume the binaries directly.
-      - rust-build-binary: &kona-build-release
-          name: kona-build-release
+      - rust-build-binary: &rust-workspace-release
+          name: rust-workspace-release
           directory: rust
           profile: release
           persist_to_workspace: true
@@ -327,25 +327,25 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate
-            - kona-build-release
+            - rust-workspace-release
       - op-reth-e2e-sysgo-tests:
           <<: *rust-e2e-job-base
           requires:
             - contracts-bedrock-build
-            - kona-build-release
+            - rust-workspace-release
       - rust-restart-sysgo-tests:
           name: rust-e2e-restart
           <<: *rust-e2e-job-base
           requires:
             - contracts-bedrock-build
             - cannon-prestate
-            - kona-build-release
+            - rust-workspace-release
       # Proof tests - single kind only, interop excluded per original config
       - kona-proof-action-tests:
           name: kona-proof-action-single
           kind: single
           requires:
-            - kona-build-release
+            - rust-workspace-release
             - contracts-bedrock-build
           context:
             - circleci-repo-readonly-authenticated-github-token
@@ -372,7 +372,7 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary:
-          name: kona-build-release
+          name: rust-workspace-release
           directory: rust
           profile: release
           persist_to_workspace: true
@@ -383,7 +383,7 @@ workflows:
           name: kona-proof-action-single
           kind: single
           requires:
-            - kona-build-release
+            - rust-workspace-release
             - contracts-bedrock-build
           context:
             - circleci-repo-readonly-authenticated-github-token

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -154,10 +154,6 @@ jobs:
           at: .
       - go-restore-cache:
           namespace: kona-ci
-      - rust-build: &kona-rust-build-release
-          directory: rust
-          profile: release
-          binary: "kona-node"
       - run:
           name: Run common tests for node with sysgo orchestrator
           no_output_timeout: 60m
@@ -200,8 +196,6 @@ jobs:
           at: .
       - go-restore-cache:
           namespace: kona-ci
-      - rust-build:
-          <<: *kona-rust-build-release
       - run:
           name: Run restart tests for node with sysgo orchestrator
           no_output_timeout: 60m
@@ -230,10 +224,6 @@ jobs:
           at: .
       - go-restore-cache:
           namespace: op-reth-e2e
-      - rust-build:
-          directory: rust
-          profile: release
-          binary: "op-reth"
       - run:
           name: Run op-reth E2E tests with sysgo orchestrator
           working_directory: rust/op-reth/tests
@@ -266,9 +256,6 @@ jobs:
           at: .
       - go-restore-cache:
           namespace: kona-ci
-      - rust-build:
-          <<: *kona-rust-build-release
-          binary: "kona-host"
       - run:
           name: Build kona and run action tests
           working_directory: rust/kona
@@ -324,12 +311,14 @@ workflows:
           directory: rust
           profile: release
           binary: "kona-host"
+          persist_to_workspace: true
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary: &kona-build-release
           name: kona-build-release
           directory: rust
           profile: release
+          persist_to_workspace: true
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary:
@@ -337,6 +326,7 @@ workflows:
           directory: rust
           profile: release
           binary: "op-reth"
+          persist_to_workspace: true
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-e2e-sysgo-tests:
@@ -401,6 +391,7 @@ workflows:
           name: kona-build-release
           directory: rust
           profile: release
+          persist_to_workspace: true
           context:
             - circleci-repo-readonly-authenticated-github-token
       # Proof tests - single kind only, interop excluded per original config

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -311,9 +311,13 @@ workflows:
           directory: rust
           profile: release
           binary: "kona-host"
-          persist_to_workspace: true
           context:
             - circleci-repo-readonly-authenticated-github-token
+      # kona-build-release builds the whole rust workspace (no binary filter),
+      # so it produces kona-host, kona-node, op-reth, and the rest. It is the
+      # sole persister of release binaries — cannon-kona-host and op-reth-build
+      # still build in parallel to prime caches, but their outputs overlap with
+      # this job's persist glob and would conflict if persisted concurrently.
       - rust-build-binary: &kona-build-release
           name: kona-build-release
           directory: rust
@@ -326,7 +330,6 @@ workflows:
           directory: rust
           profile: release
           binary: "op-reth"
-          persist_to_workspace: true
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-e2e-sysgo-tests:

--- a/rust/kona/tests/node/restart/sequencer_restart_test.go
+++ b/rust/kona/tests/node/restart/sequencer_restart_test.go
@@ -51,7 +51,7 @@ func TestSequencerRestart(gt *testing.T) {
 
 		// Ensure that the other nodes are not advancing.
 		// The local safe head may advance (for the next l1 block to be processed), but the unsafe head should not.
-		stopCheckFuns = append(stopCheckFuns, node.NotAdvancedFn(types.LocalUnsafe, 50))
+		stopCheckFuns = append(stopCheckFuns, node.NotAdvancedFn(types.LocalUnsafe, 20))
 	}
 
 	dsl.CheckAll(t, stopCheckFuns...)

--- a/rust/kona/tests/node/restart/setup_test.go
+++ b/rust/kona/tests/node/restart/setup_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	node_utils "github.com/ethereum-optimism/optimism/rust/kona/tests/node/utils"
 )
@@ -42,7 +43,9 @@ func TestMain(m *testing.M) {
 		sharedRestartRuntime = node_utils.NewSharedMixedOpKonaRuntimeForConfig(pkg, node_utils.L2NodeConfig{
 			KonaSequencerNodesWithGeth: 1,
 			KonaNodesWithGeth:          1,
-		})
+		}, sysgo.WithL2BlockTimes(map[eth.ChainID]uint64{
+			sysgo.DefaultL2AID: 1,
+		}))
 		code = m.Run()
 	}()
 

--- a/rust/kona/tests/node/utils/package_scope.go
+++ b/rust/kona/tests/node/utils/package_scope.go
@@ -162,8 +162,9 @@ func NewSharedMixedOpKonaRuntime(pkg devtest.P) *sysgo.MixedSingleChainRuntime {
 	return NewSharedMixedOpKonaRuntimeForConfig(pkg, ParseL2NodeConfigFromEnv())
 }
 
-func NewSharedMixedOpKonaRuntimeForConfig(pkg devtest.P, cfg L2NodeConfig) *sysgo.MixedSingleChainRuntime {
+func NewSharedMixedOpKonaRuntimeForConfig(pkg devtest.P, cfg L2NodeConfig, deployerOpts ...sysgo.DeployerOption) *sysgo.MixedSingleChainRuntime {
 	return sysgo.NewMixedSingleChainRuntime(newPackageScopeT(pkg), sysgo.MixedSingleChainPresetConfig{
-		NodeSpecs: mixedOpKonaNodeSpecs(cfg),
+		NodeSpecs:       mixedOpKonaNodeSpecs(cfg),
+		DeployerOptions: deployerOpts,
 	})
 }


### PR DESCRIPTION
Speeds up the rust-e2e CI jobs. Two independent changes:

**Restart suite test timing**
- Drop L2 block time for the kona node-restart sysgo devnet from the default (2s) to 1s.
- Trim `TestSequencerRestart`'s `NotAdvancedFn(LocalUnsafe, 50)` window to `20`. 20 empty slots is sufficient signal that the validator's unsafe head is not advancing while the sequencer is down.
- Threads `DeployerOption` through `NewSharedMixedOpKonaRuntimeForConfig` so the restart suite can set the block time without affecting other callers.

**Stop rebuilding rust binaries**
The rust-e2e workflow was running three parallel rust builds: `cannon-kona-host` (kona-host), `kona-build-release` (whole workspace), and `op-reth-build` (op-reth). The latter two built strict subsets of the workspace build. Downstream e2e jobs then re-ran `rust-build` again (~9m of cache restore + relink) before running tests, because none of the builders persisted to the workspace.

- Drop `cannon-kona-host` and `op-reth-build` — both are subsets of the workspace build.
- Rename the remaining build to `rust-workspace-release` (it produces every release binary, not just kona).
- Set `persist_to_workspace: true` on it so downstream jobs pick up the binaries from the workspace.
- Remove the redundant `rust-build` step from `rust-e2e-sysgo-tests`, `rust-restart-sysgo-tests`, `op-reth-e2e-sysgo-tests`, and `kona-proof-action-tests`.

Test-timing-only baseline was 24m → 22m on the restart job. Skipping the per-job rebuild should drop another ~9m.

Draft until CI confirms.