### PR TITLE
chore(ci): redirect test temp dirs to /mnt/ramdisk

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1876,6 +1876,12 @@ jobs:
           command: |
             <<parameters.environment_overrides>>
             export TEST_TIMEOUT=<<parameters.test_timeout>>
+            # Redirect temp dirs to the CircleCI ramdisk so test data files
+            # (geth chaindata, op-reth mdbx, etc.) avoid fsync stalls on the
+            # shared overlay disk.
+            mkdir -p /mnt/ramdisk/tmp
+            export TMPDIR=/mnt/ramdisk/tmp
+            export GOTMPDIR=/mnt/ramdisk/tmp
             # set to less than number CPUs (xlarge Docker is 16 CPU) so there's some buffer for things
             # like Geth
             export PARALLEL=12
@@ -2030,6 +2036,12 @@ jobs:
           working_directory: op-acceptance-tests
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |
+            # Redirect temp dirs to the CircleCI ramdisk so devnet state
+            # (op-reth mdbx, op-geth chaindata, supernode logsdb, ...) avoids
+            # fsync stalls on the shared overlay disk.
+            mkdir -p /mnt/ramdisk/tmp
+            export TMPDIR=/mnt/ramdisk/tmp
+            export GOTMPDIR=/mnt/ramdisk/tmp
             LOG_LEVEL=info just acceptance-test
       - run:
           name: Print results (summary)


### PR DESCRIPTION
Set `TMPDIR` (and `GOTMPDIR`) to `/mnt/ramdisk/tmp` for the `go-tests` job (covers `go-tests-short` and `go-tests-full`) and `op-acceptance-tests`. CircleCI's Docker executor provides a tmpfs at `/mnt/ramdisk` by default, so `t.TempDir()` output (geth chaindata, op-reth mdbx, supernode logsdb, etc.) lands on RAM-backed storage where fsync is a no-op.

Motivation: same flakes that motivated #20785 — mdbx commit_duration spiking from ~6ms to 60–125s under fsync contention on the shared overlay disk. This is an alternative/complementary approach that doesn't rely on `LD_PRELOAD` and naturally covers statically-linked Go/Rust binaries.

The workspace, checkout, and build cache are untouched — only test temp output moves. RAM budget: `2xlarge`+ classes should comfortably hold the test data, but worth watching for OOMs on the heavier acceptance variants.