### PR TITLE
fix(txplan): Handle nonce-too-low errors in tx submission retry loop

### DIFF
--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -260,14 +260,20 @@ func WithTransactionSubmitter(cl TransactionSubmitter) Option {
 
 func WithRetrySubmission(cl TransactionSubmitter, maxAttempts int, strategy retry.Strategy) Option {
 	return func(tx *PlannedTx) {
-		tx.Submitted.DependOn(&tx.Signed)
+		// Intentionally no DependOn(&tx.Signed) here.
+		//
+		// The Lazy DAG evaluates a node's fn while holding read-locks on all of
+		// its upstream dependencies. If tx.Submitted declared tx.Signed as an
+		// upstream dep, the fn would run with tx.Signed's mutex read-locked.
+		// Calling tx.Signed.Eval or tx.Nonce.Invalidate (which cascades down to
+		// tx.Submitted) from inside that fn would then deadlock trying to
+		// acquire those same mutexes. Instead we hold no upstream locks and
+		// drive the full eval+submit cycle ourselves on each retry attempt.
 		tx.Submitted.Fn(func(ctx context.Context) (struct{}, error) {
 			return struct{}{}, retry.Do0(ctx, maxAttempts, strategy, func() error {
-				// Re-evaluate the signed tx on each attempt. On the first call
-				// this simply returns the already-evaluated value. On subsequent
-				// retries after a nonce-too-low error (see below) Nonce has been
-				// invalidated, so Eval will re-fetch the pending nonce and
-				// rebuild + re-sign the transaction.
+				// Evaluate (or re-evaluate after a nonce-too-low invalidation)
+				// the signed transaction. No upstream locks are held here, so
+				// Eval acquires the necessary mutexes safely.
 				signed, err := tx.Signed.Eval(ctx)
 				if err != nil {
 					return fmt.Errorf("re-evaluating signed tx: %w", err)

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
@@ -262,7 +263,25 @@ func WithRetrySubmission(cl TransactionSubmitter, maxAttempts int, strategy retr
 		tx.Submitted.DependOn(&tx.Signed)
 		tx.Submitted.Fn(func(ctx context.Context) (struct{}, error) {
 			return struct{}{}, retry.Do0(ctx, maxAttempts, strategy, func() error {
-				return cl.SendTransaction(ctx, tx.Signed.Value())
+				// Re-evaluate the signed tx on each attempt. On the first call
+				// this simply returns the already-evaluated value. On subsequent
+				// retries after a nonce-too-low error (see below) Nonce has been
+				// invalidated, so Eval will re-fetch the pending nonce and
+				// rebuild + re-sign the transaction.
+				signed, err := tx.Signed.Eval(ctx)
+				if err != nil {
+					return fmt.Errorf("re-evaluating signed tx: %w", err)
+				}
+				err = cl.SendTransaction(ctx, signed)
+				// If the nonce is stale (e.g. a deposit tx on L2 advanced the
+				// account nonce before we fetched it), invalidate the Nonce node
+				// so it is re-fetched on the next attempt. Because Nonce is
+				// upstream of Unsigned which is upstream of Signed, invalidating
+				// Nonce cascades through the whole signing pipeline.
+				if errors.Is(err, core.ErrNonceTooLow) {
+					tx.Nonce.Invalidate()
+				}
+				return err
 			})
 		})
 	}


### PR DESCRIPTION
When SendTransaction fails with ErrNonceTooLow (e.g., a deposit tx advanced the account nonce), invalidate the Nonce node to trigger re-evaluation of the entire signing pipeline on the next retry attempt.