### PR TITLE
fix(op-node): tolerate NotFound on Finalized lookup during ELSync (+ eth_syncing dump)

### DIFF
--- a/op-devstack/presets/singlechain_from_runtime.go
+++ b/op-devstack/presets/singlechain_from_runtime.go
@@ -1,7 +1,11 @@
 package presets
 
 import (
+	"context"
+	"encoding/json"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
@@ -89,7 +93,9 @@ func singleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRunt
 		// after the EL completes P2P sync and the node emits its first forkchoice
 		// update — so the wait strategy depends on the follower's sync mode.
 		var crossSafeCheck dsl.CheckFunc
-		if opNode, ok := nodeB.CL.(*sysgo.OpNode); ok && opNode.SyncMode() == nodeSync.ELSync {
+		opNode, hasOpNode := nodeB.CL.(*sysgo.OpNode)
+		isELSync := hasOpNode && opNode.SyncMode() == nodeSync.ELSync
+		if isELSync {
 			// EL-sync's CrossSafe wait has unpredictable duration in CI. Wait
 			// up to initialSyncCrossSafeELSyncMaxWait, but only as long as the
 			// follower's LocalUnsafe head keeps advancing — if gossip stalls
@@ -104,12 +110,48 @@ func singleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRunt
 		} else {
 			crossSafeCheck = preset.L2CLB.MatchedFn(preset.L2CL, types.CrossSafe, initialSyncCheckAttemptsCrossSafe)
 		}
-		dsl.CheckAll(t,
+		runInitialSyncChecks(t, preset.L2ELB, isELSync,
 			crossSafeCheck,
 			preset.L2CLB.MatchedFn(preset.L2CL, types.LocalUnsafe, initialSyncCheckAttemptsLocalUnsafe),
 		)
 	}
 	return preset
+}
+
+// runInitialSyncChecks runs the initial-sync DSL checks. On failure in ELSync
+// mode it captures a one-shot eth_syncing snapshot from the verifier EL to
+// give an independent confirmation of what the EL thinks its sync state is.
+// The dump is best-effort — its only purpose is diagnostics for #20649, so any
+// RPC error is logged and ignored.
+//
+// op-geth and op-reth both implement eth_syncing but with different schemas
+// (op-geth: fine-grained snap-sync counters; op-reth: alloy SyncInfo plus a
+// stages list). Dumping the raw JSON sidesteps the schema difference — the
+// human reading the CI log gets whichever shape the EL produced.
+func runInitialSyncChecks(t devtest.T, verifierEL *dsl.L2ELNode, isELSync bool, checks ...dsl.CheckFunc) {
+	var g errgroup.Group
+	for _, check := range checks {
+		check := check
+		g.Go(func() error {
+			return check()
+		})
+	}
+	err := g.Wait()
+	if err != nil && isELSync {
+		dumpVerifierELSyncing(t, verifierEL)
+	}
+	t.Require().NoError(err)
+}
+
+func dumpVerifierELSyncing(t devtest.T, verifierEL *dsl.L2ELNode) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var raw json.RawMessage
+	if err := verifierEL.EthClient().RPC().CallContext(ctx, &raw, "eth_syncing"); err != nil {
+		t.Logger().Warn("Failed to dump eth_syncing from verifier EL", "err", err)
+		return
+	}
+	t.Logger().Warn("Verifier EL eth_syncing snapshot at sync-check failure", "eth_syncing", string(raw))
 }
 
 func singleChainMultiNodeWithTestSeqFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *SingleChainMultiNodeWithTestSeq {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -500,18 +500,35 @@ func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 		var err error
 		finalizedRef, err = e.engine.L2BlockRefByLabel(ctx, eth.Finalized)
 		if err != nil {
-			return fmt.Errorf("failed to load finalized head: %w", err)
+			// In ELSync mode the engine has no finalized block until its initial
+			// snap-sync completes and the CL emits a finalized FCU. Treat
+			// NotFound as "no finalized block yet" and continue, mirroring the
+			// eth.Safe branch below. In CLSync mode the engine is expected to
+			// have a finalized block after the initial reset, so propagate
+			// the error as before.
+			if errors.Is(err, ethereum.NotFound) && e.syncCfg.SyncMode == sync.ELSync {
+				e.log.Debug("No finalized L2 block known yet, leaving finalized head unset")
+			} else {
+				return fmt.Errorf("failed to load finalized head: %w", err)
+			}
+		} else {
+			e.SetFinalizedHead(finalizedRef)
+			e.log.Info("Loaded initial finalized block ref", "finalized", finalizedRef)
 		}
-		e.SetFinalizedHead(finalizedRef)
-		e.log.Info("Loaded initial finalized block ref", "finalized", finalizedRef)
 	}
 	if e.localSafeHead == (eth.L2BlockRef{}) {
 		ref, err := e.engine.L2BlockRefByLabel(ctx, eth.Safe)
 		if err != nil {
 			if errors.Is(err, ethereum.NotFound) {
-				// If the engine doesn't have a safe head, then we can use the finalized head
-				e.SetLocalSafeHead(finalizedRef)
-				e.log.Info("Loaded initial local-safe block from finalized", "local_safe", finalizedRef)
+				if finalizedRef == (eth.L2BlockRef{}) {
+					// Neither safe nor finalized are known yet — leave local-safe
+					// unset so the next initializeUnknowns retries.
+					e.log.Debug("No safe or finalized L2 block known yet, leaving local-safe head unset")
+				} else {
+					// If the engine doesn't have a safe head, then we can use the finalized head
+					e.SetLocalSafeHead(finalizedRef)
+					e.log.Info("Loaded initial local-safe block from finalized", "local_safe", finalizedRef)
+				}
 			} else {
 				return fmt.Errorf("failed to load local-safe head: %w", err)
 			}

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -498,6 +499,111 @@ func TestInitializeUnknowns_SetsLocalSafeHead_Regression(t *testing.T) {
 	// Verify deprecatedSafeHead is also set (for backward compatibility)
 	require.Equal(t, safeRef, ec.deprecatedSafeHead,
 		"deprecatedSafeHead should also be set to match localSafeHead")
+
+	mockEngine.AssertExpectations(t)
+}
+
+// TestInitializeUnknowns_ELSync_FinalizedNotFound is a regression test for #20649.
+// During initial ELSync the engine may not yet have a finalized (or safe) block,
+// because finality is a CL-driven concept and the verifier op-node hasn't issued
+// a finalized FCU yet. Before the fix, the eth.Finalized lookup returning
+// ethereum.NotFound made initializeUnknowns fail and tryUpdateEngineInternal
+// return "Engine temporary error: ... finalized block not found" once per
+// derivation tick — hundreds of warnings per failed run, crowding out the real
+// signal. The fix treats NotFound on eth.Finalized as "no finalized block yet"
+// in ELSync mode, mirroring the existing eth.Safe NotFound fallback. CLSync
+// mode preserves the prior error behavior.
+func TestInitializeUnknowns_ELSync_FinalizedNotFound(t *testing.T) {
+	cfg := &rollup.Config{
+		Genesis:   rollup.Genesis{L2Time: 1000},
+		BlockTime: 2,
+	}
+
+	// Engine has produced an unsafe head from snap-sync, but has no finalized
+	// or safe block yet — the standard mid-ELSync state.
+	unsafeRef := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		cfg,
+		&sync.Config{SyncMode: sync.ELSync},
+		false,
+		&testutils.MockL1Source{},
+		emitter,
+		nil,
+	)
+	// Match the syncStatus the engine is in during snap-sync, so
+	// isEngineInitialELSyncing() reports true and the FCU below omits the
+	// FinalizedBlockHash.
+	ec.syncStatus = syncStatusStartedEL
+
+	mockEngine.ExpectL2BlockRefByLabel(eth.Unsafe, unsafeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, eth.L2BlockRef{}, ethereum.NotFound)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Safe, eth.L2BlockRef{}, ethereum.NotFound)
+
+	// Expect a single FCU with the unsafe head and zero safe/finalized hashes
+	// (FinalizedBlockHash is omitted because isEngineInitialELSyncing is true).
+	emitter.ExpectOnceType("ForkchoiceUpdateEvent")
+	expectedFC := eth.ForkchoiceState{
+		HeadBlockHash: unsafeRef.Hash,
+		SafeBlockHash: common.Hash{},
+	}
+	mockEngine.ExpectForkchoiceUpdate(&expectedFC, nil, &eth.ForkchoiceUpdatedResult{
+		PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing},
+	}, nil)
+
+	err := ec.tryUpdateEngineInternal(context.Background())
+	require.NoError(t, err, "ELSync + NotFound on finalized/safe should not error")
+
+	require.Equal(t, unsafeRef, ec.unsafeHead, "unsafeHead should be populated")
+	require.Equal(t, eth.L2BlockRef{}, ec.FinalizedHead(),
+		"FinalizedHead must remain zero when engine reports NotFound during ELSync")
+	require.Equal(t, eth.L2BlockRef{}, ec.localSafeHead,
+		"localSafeHead must remain zero when both finalized and safe are NotFound")
+
+	mockEngine.AssertExpectations(t)
+}
+
+// TestInitializeUnknowns_CLSync_FinalizedNotFound_StillErrors verifies the
+// NotFound fallback is scoped to ELSync mode: in CLSync the engine is expected
+// to have a valid finalized block after the initial reset, so propagating the
+// error preserves the prior behavior.
+func TestInitializeUnknowns_CLSync_FinalizedNotFound_StillErrors(t *testing.T) {
+	cfg := &rollup.Config{
+		Genesis:   rollup.Genesis{L2Time: 1000},
+		BlockTime: 2,
+	}
+
+	unsafeRef := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		cfg,
+		&sync.Config{SyncMode: sync.CLSync},
+		false,
+		&testutils.MockL1Source{},
+		emitter,
+		nil,
+	)
+
+	mockEngine.ExpectL2BlockRefByLabel(eth.Unsafe, unsafeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, eth.L2BlockRef{}, ethereum.NotFound)
+
+	err := ec.tryUpdateEngineInternal(context.Background())
+	require.Error(t, err, "CLSync mode should still return error on NotFound")
+	require.ErrorContains(t, err, "failed to load finalized head")
 
 	mockEngine.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

Two small follow-ups to #20649 / #20652 that came out of a fresh investigation
of the recurrent ELSync flake (`TestNotTruncateDatabaseOnRestartWithExistingDatabase`
and ~13 sibling tests). Both stand on their own and are independent of any
larger redesign — they reduce log noise and add diagnostics for the next
recurrence.

### 1. `op-node`: tolerate `NotFound` on `eth.Finalized` during ELSync

`initializeUnknowns` in `op-node/rollup/engine/engine_controller.go` looks up
the engine's `eth.Finalized` block. During initial ELSync the engine has no
finalized block yet (and often no safe block either) — finality is a CL-driven
concept and the verifier op-node hasn't issued a finalized FCU yet. On a
typical recurrence of #20649 the resulting error fires once per derivation
tick — ~240 `"Engine temporary error: cannot update engine until engine
forkchoice is initialized: failed to load finalized head: not found"` warnings
in a single failed run — crowding out the real signal in CI logs.

The fix mirrors the existing `eth.Safe` NotFound fallback (line 481): in
ELSync mode, treat `NotFound` on `eth.Finalized` as "no finalized block yet",
leave the head zero, and continue. The next call retries the lookup; once
snap-sync completes and the CL emits a finalized FCU, the head is populated.

CLSync preserves the prior error behavior — after the initial reset the
engine is expected to have a valid finalized block.

Also hardens the safe-fallback log: if both `finalized` and `safe` are
`NotFound`, skip the misleading `"Loaded initial local-safe block from
finalized local_safe=0x0...:0"` log line and let the next retry populate
both refs.

#### Regression test

`TestInitializeUnknowns_ELSync_FinalizedNotFound` reproduces the failure with
a mock engine returning `ethereum.NotFound` for both `eth.Finalized` and
`eth.Safe` lookups. On `develop` it fails with the exact CI error
(`failed to load finalized head: not found`); with the fix it passes.
`TestInitializeUnknowns_CLSync_FinalizedNotFound_StillErrors` pins the CLSync
behavior.

### 2. `op-devstack`: dump verifier `eth_syncing` on ELSync initial-sync check failure

When the initial-sync DSL check (the `MatchedWithProgressFn` introduced in
#20652) fails in ELSync mode, capture a one-shot `eth_syncing` snapshot from
the verifier EL before surfacing the failure to the test. This gives an
independent confirmation of what the EL itself thinks its sync state is —
independent of any CL-side state machine — at the moment the wait gives up.

op-geth and op-reth implement `eth_syncing` with different schemas (op-geth:
fine-grained snap-sync counters; op-reth: alloy `SyncInfo` plus a `stages`
list). The dump is the raw JSON, so the human reading the CI log gets
whichever shape the EL produced — no schema-specific decode logic.

The call is best-effort: any RPC error is logged and ignored. Gated on
ELSync mode to avoid adding noise to unrelated CLSync sync-check failures.

## Test plan

- [x] `go test ./op-node/rollup/engine/...` — passes
- [x] New `TestInitializeUnknowns_ELSync_FinalizedNotFound` fails on `develop`, passes on this branch
- [x] New `TestInitializeUnknowns_CLSync_FinalizedNotFound_StillErrors` pins CLSync behavior
- [x] `go build ./op-devstack/... ./op-node/... ./op-acceptance-tests/...` — clean
- [x] `go vet ./op-devstack/presets/... ./op-node/rollup/engine/...` — clean
- [ ] Wait for the next op-reth recurrence of one of the affected ELSync tests to confirm the dump lands in artifacts and gives useful signal

## Why not in #20652

Both changes are diagnostic / hardening, not the underlying fix for #20649.
The underlying snap-sync stall (engine accepts NewPayload but never returns
VALID) is still being root-caused — these PRs reduce noise so the next
recurrence is easier to diagnose.

Refs: #20649, #20652