### PR TITLE
op-supernode: pipeline log backfill fetches

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -35,6 +35,10 @@ var (
 // executing message.
 const DefaultLogBackfillDepth = time.Duration(params.MessageExpiryTimeSecondsInterop) * time.Second
 
+// DefaultLogBackfillFetchConcurrency matches op-interop-filter's startup
+// ingestion pipeline width. Writes still happen in block-number order.
+const DefaultLogBackfillFetchConcurrency = 64
+
 // InteropActivationTimestampFlag is the CLI flag for the interop activation timestamp.
 var InteropActivationTimestampFlag = &cli.Uint64Flag{
 	Name:    "interop.activation-timestamp",
@@ -191,7 +195,10 @@ type Interop struct {
 	l1Checker l1ConsistencyChecker
 
 	logBackfillDepth time.Duration
-	metrics          *resources.SupernodeMetrics
+	// logBackfillFetchConcurrency bounds per-chain concurrent block/receipt
+	// fetches during startup backfill. DB writes stay sequential.
+	logBackfillFetchConcurrency uint64
+	metrics                     *resources.SupernodeMetrics
 }
 
 func (i *Interop) Name() string {
@@ -262,15 +269,16 @@ func New(
 		metrics = resources.NewSupernodeMetrics()
 	}
 	i := &Interop{
-		log:                 log,
-		chains:              chains,
-		verifiedDB:          verifiedDB,
-		logsDBs:             logsDBs,
-		dataDir:             dataDir,
-		activationTimestamp: activationTimestamp,
-		messageExpiryWindow: messageExpiryWindow,
-		logBackfillDepth:    logBackfillDepth,
-		metrics:             metrics,
+		log:                         log,
+		chains:                      chains,
+		verifiedDB:                  verifiedDB,
+		logsDBs:                     logsDBs,
+		dataDir:                     dataDir,
+		activationTimestamp:         activationTimestamp,
+		messageExpiryWindow:         messageExpiryWindow,
+		logBackfillDepth:            logBackfillDepth,
+		logBackfillFetchConcurrency: DefaultLogBackfillFetchConcurrency,
+		metrics:                     metrics,
 	}
 	// default to using the verifyInteropMessages function
 	// (can be overridden by tests)

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -232,6 +232,14 @@ func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.C
 		progress := float64(num-startNum+1) / float64(totalBlocks)
 		i.metrics.LogBackfillProgress.WithLabelValues(cid.String()).Set(progress)
 	}
+	if err := i.reconcileLogsDBTail(ctx, cid, chain, db); err != nil {
+		return err
+	}
+	if latest, has := db.LatestSealedBlock(); !has {
+		return fmt.Errorf("chain %s: logsDB empty after post-backfill canonical reconcile", cid)
+	} else if latest.Number < endNum {
+		return fmt.Errorf("chain %s: logsDB tip rewound below backfill end after canonical reconcile: tip %d, end %d", cid, latest.Number, endNum)
+	}
 	return nil
 }
 

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -6,9 +6,19 @@ import (
 	"math"
 	"sync"
 
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 )
+
+type logBackfillFetch struct {
+	blockNum  uint64
+	bid       eth.BlockID
+	blockInfo eth.BlockInfo
+	receipts  gethTypes.Receipts
+	err       error
+}
 
 // resolveFirstVerifiableTimestamp returns the first timestamp not yet covered
 // by durable local state: verifiedDB.LastTimestamp+1 when initialized,
@@ -142,26 +152,85 @@ func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.C
 	if latest, has := db.LatestSealedBlock(); has {
 		startNum = latest.Number + 1
 	}
+	if startNum > endNum {
+		i.metrics.LogBackfillProgress.WithLabelValues(cid.String()).Set(1)
+		return nil
+	}
+
 	totalBlocks := endNum - startNum + 1
+	concurrency := i.logBackfillFetchConcurrency
+	if concurrency == 0 {
+		concurrency = 1
+	}
+	if concurrency > totalBlocks {
+		concurrency = totalBlocks
+	}
+
+	rangeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	slots := make([]chan logBackfillFetch, concurrency)
+	for idx := range slots {
+		slots[idx] = make(chan logBackfillFetch, 1)
+	}
+
+	startFetch := func(num uint64) {
+		slot := slots[num%concurrency]
+		go func() {
+			out, err := chain.OutputV0AtBlockNumber(rangeCtx, num)
+			var bid eth.BlockID
+			var blockInfo eth.BlockInfo
+			var receipts gethTypes.Receipts
+			if err != nil {
+				err = fmt.Errorf("output at block %d: %w", num, err)
+			} else {
+				bid = eth.BlockID{Hash: out.BlockHash, Number: num}
+				blockInfo, receipts, err = chain.FetchReceipts(rangeCtx, bid)
+				if err != nil {
+					err = fmt.Errorf("fetch receipts %d: %w", num, err)
+				}
+			}
+			select {
+			case slot <- logBackfillFetch{blockNum: num, bid: bid, blockInfo: blockInfo, receipts: receipts, err: err}:
+			case <-rangeCtx.Done():
+			}
+		}()
+	}
+
+	nextFetch := startNum
+	for idx := uint64(0); idx < concurrency; idx++ {
+		startFetch(nextFetch)
+		nextFetch++
+	}
+
 	for num := startNum; num <= endNum; num++ {
-		out, err := chain.OutputV0AtBlockNumber(ctx, num)
-		if err != nil {
-			return fmt.Errorf("chain %s: output at block %d: %w", cid, num, err)
-		}
-		bid := eth.BlockID{Hash: out.BlockHash, Number: num}
-		blockInfo, receipts, err := chain.FetchReceipts(ctx, bid)
-		if err != nil {
-			return fmt.Errorf("chain %s: fetch receipts %d: %w", cid, num, err)
+		var fetched logBackfillFetch
+		select {
+		case <-rangeCtx.Done():
+			return rangeCtx.Err()
+		case fetched = <-slots[num%concurrency]:
 		}
 
-		if err := i.sealBlockDataIntoLogsDB(cid, bid, blockInfo, receipts, blockInfo.Time(), true); err != nil {
+		if fetched.blockNum != num {
+			cancel()
+			return fmt.Errorf("chain %s: expected fetched block %d but got %d", cid, num, fetched.blockNum)
+		}
+		if fetched.err != nil {
+			cancel()
+			return fmt.Errorf("chain %s: %w", cid, fetched.err)
+		}
+		if nextFetch <= endNum {
+			startFetch(nextFetch)
+			nextFetch++
+		}
+
+		if err := i.sealBlockDataIntoLogsDB(cid, fetched.bid, fetched.blockInfo, fetched.receipts, fetched.blockInfo.Time(), true); err != nil {
+			cancel()
 			return err
 		}
 
-		if totalBlocks > 0 {
-			progress := float64(num-startNum+1) / float64(totalBlocks)
-			i.metrics.LogBackfillProgress.WithLabelValues(cid.String()).Set(progress)
-		}
+		progress := float64(num-startNum+1) / float64(totalBlocks)
+		i.metrics.LogBackfillProgress.WithLabelValues(cid.String()).Set(progress)
 	}
 	return nil
 }

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -92,8 +92,8 @@ func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	require.True(t, has)
 	require.Equal(t, uint64(110), latest.Number)
 
-	// 5 fetches for blocks 106..110 + 1 reconcile probe at block 105.
-	require.Equal(t, int32(6), fetchCount.Load())
+	// 5 fetches for blocks 106..110 + reconcile probes at block 105 and 110.
+	require.Equal(t, int32(7), fetchCount.Load())
 }
 
 func TestLogBackfill_FetchesBlocksConcurrentlyAndWritesInOrder(t *testing.T) {
@@ -142,6 +142,44 @@ func TestLogBackfill_FetchesBlocksConcurrentlyAndWritesInOrder(t *testing.T) {
 	latest, has := h.interop.logsDBs[chain.id].LatestSealedBlock()
 	require.True(t, has)
 	require.Equal(t, uint64(115), latest.Number, "ordered DB writes should seal through the end block")
+}
+
+func TestLogBackfill_PostBackfillReconcileRetriesIfPrefetchedBlocksGoStale(t *testing.T) {
+	const (
+		start       uint64 = 100
+		commonTip   uint64 = 105
+		end         uint64 = 110
+		totalBlocks        = end - start + 1
+	)
+
+	var outputCalls atomic.Int32
+	h := newInteropTestHarness(t).
+		WithActivation(start).
+		WithChain(10, func(m *mockChainContainer) {
+			m.outputV0Override = func(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+				call := outputCalls.Add(1)
+				hashNum := l2BlockNum
+				if call > int32(totalBlocks) && l2BlockNum > commonTip {
+					hashNum += 1000
+				}
+				return &eth.OutputV0{
+					StateRoot:                eth.Bytes32(common.HexToHash("0xmockstate")),
+					MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmockmsg")),
+					BlockHash:                common.BigToHash(new(big.Int).SetUint64(hashNum)),
+				}, nil
+			}
+		}).
+		Build()
+
+	chain := h.Mock(10)
+	h.interop.logBackfillFetchConcurrency = 4
+
+	err := h.interop.backfillChain(context.Background(), chain.id, chain, start, end)
+	require.ErrorContains(t, err, "logsDB tip rewound below backfill end after canonical reconcile")
+
+	latest, has := h.interop.logsDBs[chain.id].LatestSealedBlock()
+	require.True(t, has)
+	require.Equal(t, commonTip, latest.Number)
 }
 
 func TestLogBackfill_RetriesWhenELFinalizedNotReady(t *testing.T) {
@@ -398,13 +436,14 @@ func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 	chain20 := h.Mock(20)
 	chain30 := h.Mock(30)
 
-	// Every chain backfills the same 100..110 window (11 blocks each).
-	require.Equal(t, int32(11), fetchCount[chain10.id].Load(),
-		"chain 10 should backfill blocks 100..110 (11 blocks)")
-	require.Equal(t, int32(11), fetchCount[chain20.id].Load(),
-		"chain 20 should backfill blocks 100..110 (11 blocks)")
-	require.Equal(t, int32(11), fetchCount[chain30.id].Load(),
-		"chain 30 should backfill blocks 100..110 (11 blocks)")
+	// Every chain backfills the same 100..110 window (11 blocks each) and
+	// probes the tip once after backfill to catch stale prefetched blocks.
+	require.Equal(t, int32(12), fetchCount[chain10.id].Load(),
+		"chain 10 should backfill blocks 100..110 and post-reconcile the tip")
+	require.Equal(t, int32(12), fetchCount[chain20.id].Load(),
+		"chain 20 should backfill blocks 100..110 and post-reconcile the tip")
+	require.Equal(t, int32(12), fetchCount[chain30.id].Load(),
+		"chain 30 should backfill blocks 100..110 and post-reconcile the tip")
 
 	latest10, has10 := h.interop.logsDBs[chain10.id].LatestSealedBlock()
 	require.True(t, has10)
@@ -797,8 +836,8 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 			require.True(t, has)
 			require.Equal(t, tc.wantEndBlock, latest.Number)
 
-			require.Equal(t, tc.wantSealedBlocks, outputCalls.Load(),
-				"backfill must seal exactly [genesisBlock, endBlock]")
+			require.Equal(t, tc.wantSealedBlocks+1, outputCalls.Load(),
+				"backfill must seal exactly [genesisBlock, endBlock] plus one post-reconcile tip probe")
 		})
 	}
 }

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -96,6 +96,54 @@ func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	require.Equal(t, int32(6), fetchCount.Load())
 }
 
+func TestLogBackfill_FetchesBlocksConcurrentlyAndWritesInOrder(t *testing.T) {
+	const fetchConcurrency = uint64(4)
+
+	var active atomic.Int32
+	var maxActive atomic.Int32
+
+	h := newInteropTestHarness(t).
+		WithActivation(100).
+		WithChain(10, func(m *mockChainContainer) {
+			m.outputV0Override = func(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+				now := active.Add(1)
+				for {
+					maxSeen := maxActive.Load()
+					if now <= maxSeen || maxActive.CompareAndSwap(maxSeen, now) {
+						break
+					}
+				}
+				defer active.Add(-1)
+
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(20 * time.Millisecond):
+				}
+
+				return &eth.OutputV0{
+					StateRoot:                eth.Bytes32(common.HexToHash("0xmockstate")),
+					MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmockmsg")),
+					BlockHash:                common.BigToHash(new(big.Int).SetUint64(l2BlockNum)),
+				}, nil
+			}
+		}).
+		Build()
+
+	chain := h.Mock(10)
+	h.interop.logBackfillFetchConcurrency = fetchConcurrency
+
+	err := h.interop.backfillChain(context.Background(), chain.id, chain, 100, 115)
+	require.NoError(t, err)
+
+	require.Greater(t, maxActive.Load(), int32(1), "backfill should fetch more than one block at a time")
+	require.LessOrEqual(t, maxActive.Load(), int32(fetchConcurrency), "backfill must respect the concurrency bound")
+
+	latest, has := h.interop.logsDBs[chain.id].LatestSealedBlock()
+	require.True(t, has)
+	require.Equal(t, uint64(115), latest.Number, "ordered DB writes should seal through the end block")
+}
+
 func TestLogBackfill_RetriesWhenELFinalizedNotReady(t *testing.T) {
 	const act = uint64(100)
 	depth := 10 * time.Second


### PR DESCRIPTION
## Summary

Adds an ordered fetch pipeline to op-supernode interop log backfill, mirroring the op-interop-filter ingestion shape: each chain fetches block outputs and receipts concurrently, while writes to LogsDB remain sequential by block number.

This should reduce startup backfill time without changing LogsDB ordering, parent-hash validation, or reorg reconciliation behavior.

## Validation

- `go test ./op-supernode/supernode/activity/interop`
