### PR TITLE
[codex] Reduce interop verification wait backoff

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -26,7 +26,7 @@ import (
 var (
 	_                  activity.RunnableActivity     = (*Interop)(nil)
 	_                  activity.VerificationActivity = (*Interop)(nil)
-	backoffPeriod                                    = 1 * time.Second // backoff when chains aren't ready
+	backoffPeriod                                    = 100 * time.Millisecond // backoff when chains aren't ready
 	errorBackoffPeriod                               = 2 * time.Second // backoff on errors
 )
 


### PR DESCRIPTION
## Summary

Reduces the interop verification activity readiness backoff from 1s to 100ms when chains are not yet ready for the next timestamp.

The error backoff remains 2s so persistent failures do not hammer logs or repeatedly retry expensive error paths.

## Rationale

The wait backoff is only a throttle after a no-progress verification round. It is not part of the verification correctness model, and the previous 1s delay added avoidable latency before noticing that chain data became available.

## Tests

- go test ./op-supernode/supernode/activity/interop