### PR TITLE
Preserve SafeDB during supernode cold-start backfill

### DIFF
--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -144,10 +144,15 @@ func (s *SyncDeriver) onSafeDerivedBlock(ctx context.Context, x engine.SafeDeriv
 
 func (s *SyncDeriver) OnELSyncStarted() {
 	// The EL sync may progress the safe head in the EL without deriving those blocks from L1
-	// which means the safe head db will miss entries so we need to remove all entries to avoid returning bad data
-	s.Log.Warn("Clearing safe head db because EL sync started")
+	// which means the safe head db will miss entries. Preserve entries up to the current
+	// pending safe head and remove anything after it to avoid returning data for the EL-sync gap.
+	resetSafeHead := eth.L2BlockRef{}
+	if s.Engine != nil {
+		resetSafeHead = s.Engine.PendingSafeL2Head()
+	}
+	s.Log.Warn("Truncating safe head db because EL sync started", "safe", resetSafeHead.ID())
 	if s.SafeHeadNotifs != nil {
-		if err := s.SafeHeadNotifs.SafeHeadReset(eth.L2BlockRef{}); err != nil {
+		if err := s.SafeHeadNotifs.SafeHeadReset(resetSafeHead); err != nil {
 			s.Log.Error("Failed to notify safe-head reset when optimistically syncing")
 		}
 	}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -336,6 +336,11 @@ func (i *Interop) Start(ctx context.Context) error {
 				i.backfillEndTimestamp = end
 				break
 			}
+			if errors.Is(err, cc.ErrHistoryUnavailable) {
+				i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
+					"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
+				return fmt.Errorf("interop halted due to unavailable history: %w", err)
+			}
 			i.log.Warn("log backfill failed, retrying (EL finalized head or chain data may not be ready yet)", "err", err)
 			for cid := range i.chains {
 				i.metrics.LogBackfillRetries.WithLabelValues(cid.String()).Inc()

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
+	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
@@ -144,12 +145,17 @@ type Interop struct {
 	activationTimestamp uint64 // immutable protocol activation timestamp
 
 	// backfillEndTimestamp represents the end of the range of timestamps that were sealed by runLogBackfill.
+	// backfillStartTimestamp represents the beginning of that sealed range. It is
+	// the lower bound of the startup handoff window; timestamps below it are not
+	// served as optimistic superroots because this node may not have SafeDB
+	// history for them.
 	// this is used for loop handoff from log backfill to main processing.
 	// firstVerifiableTimestamp is used to determine the start of the main processing loop, which is backfillEndTimestamp + 1
 	// after backfill, or the EL-finalized-derived startup timestamp when backfill was not used.
-	backfillEndTimestamp uint64
-	firstVerifiableSet   bool
-	firstVerifiable      uint64
+	backfillStartTimestamp uint64
+	backfillEndTimestamp   uint64
+	firstVerifiableSet     bool
+	firstVerifiable        uint64
 
 	dataDir string
 
@@ -202,7 +208,7 @@ func (i *Interop) Name() string {
 // to verify. If verification has already committed results, the first committed
 // timestamp is the durable handoff boundary. Otherwise it is backfillEndTimestamp+1
 // after log backfill, or — on cold start with no committed results and no
-// backfill range — the startup handoff timestamp derived from EL-finalized,
+// backfill range — the startup handoff timestamp derived from EL-finalized
 // or recent local-safe progress when finalized is still pre-activation.
 func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if i.verifiedDB != nil {
@@ -221,6 +227,34 @@ func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) 
 		return i.firstVerifiable, nil
 	}
 	return i.resolveFirstVerifiableTimestamp(ctx)
+}
+
+// handoffStartTimestamp is the lower bound of the startup handoff window. The
+// verifier will not write VerifiedDB entries before firstVerifiableTimestamp;
+// only timestamps in [handoffStartTimestamp, firstVerifiableTimestamp) are safe
+// to serve from optimistic outputs. Older post-activation timestamps would
+// require SafeDB history that this node intentionally did not backfill.
+func (i *Interop) handoffStartTimestamp() (uint64, bool, error) {
+	if i.backfillStartTimestamp != 0 {
+		return i.backfillStartTimestamp, true, nil
+	}
+	if len(i.logsDBs) == 0 {
+		return 0, false, nil
+	}
+	start := i.activationTimestamp
+	for cid, db := range i.logsDBs {
+		first, err := db.FirstSealedBlock()
+		if err != nil {
+			if errors.Is(err, suptypes.ErrFuture) {
+				return 0, false, nil
+			}
+			return 0, false, fmt.Errorf("chain %s: first sealed logs block: %w", cid, err)
+		}
+		if first.Timestamp > start {
+			start = first.Timestamp
+		}
+	}
+	return start, true, nil
 }
 
 // New constructs a new Interop activity.
@@ -1010,7 +1044,11 @@ func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 		return false, err
 	}
 	if ts < firstVerifiable {
-		return true, nil
+		handoffStart, ok, err := i.handoffStartTimestamp()
+		if err != nil {
+			return false, err
+		}
+		return ok && ts >= handoffStart, nil
 	}
 	return i.verifiedDB.Has(ts)
 }
@@ -1018,6 +1056,7 @@ func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 // VerifiedResultAtTimestamp returns the committed VerifiedResult for ts plus
 // the verifier's CurrentL1 captured atomically with the verifiedDB read.
 //   - ts < activationTimestamp           → ErrNotActive
+//   - ts < handoffStartTimestamp         → ErrBeforeHandoff
 //   - ts < firstVerifiableTimestamp      → ErrBeforeVerifiedDB
 //   - verifiedDB.Get returns ErrNotFound → ethereum.NotFound
 //   - else                               → the stored VerifiedResult
@@ -1045,6 +1084,13 @@ func (i *Interop) VerifiedResultAtTimestamp(ts uint64) (VerifiedResult, eth.Bloc
 		return VerifiedResult{}, eth.BlockID{}, fmt.Errorf("resolve first verifiable: %w", err)
 	}
 	if ts < firstVerifiable {
+		handoffStart, ok, err := i.handoffStartTimestamp()
+		if err != nil {
+			return VerifiedResult{}, eth.BlockID{}, fmt.Errorf("resolve handoff start: %w", err)
+		}
+		if !ok || ts < handoffStart {
+			return VerifiedResult{}, eth.BlockID{}, ErrBeforeHandoff
+		}
 		return VerifiedResult{}, eth.BlockID{}, ErrBeforeVerifiedDB
 	}
 	i.mu.RLock()

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -202,7 +202,8 @@ func (i *Interop) Name() string {
 // to verify. If verification has already committed results, the first committed
 // timestamp is the durable handoff boundary. Otherwise it is backfillEndTimestamp+1
 // after log backfill, or — on cold start with no committed results and no
-// backfill range — the EL-finalized-derived startup timestamp.
+// backfill range — the startup handoff timestamp derived from EL-finalized,
+// or recent local-safe progress when finalized is still pre-activation.
 func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if i.verifiedDB != nil {
 		if first, initialized := i.verifiedDB.FirstTimestamp(); initialized {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -502,7 +502,7 @@ func TestStartWithoutBackfillResumesFromVerifiedDBIgnoringELFinalized(t *testing
 		"warm-restart startup must not consult EL finalized when verifiedDB is initialized")
 }
 
-func TestStartWithBackfillRunsBeforeSafeDBReadyCheck(t *testing.T) {
+func TestStartWithBackfillChecksSafeDBBeforeSealing(t *testing.T) {
 	const activation = uint64(100)
 	const safe = uint64(125)
 
@@ -526,24 +526,14 @@ func TestStartWithBackfillRunsBeforeSafeDBReadyCheck(t *testing.T) {
 	select {
 	case err = <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("interop did not halt after post-backfill SafeDB readiness failure")
+		t.Fatal("interop did not halt after SafeDB readiness failure")
 	}
 	require.ErrorIs(t, err, cc.ErrHistoryUnavailable)
 	require.Equal(t, int32(1), h.interop.BackfillAttempts())
-	require.Equal(t, safe, h.interop.BackfillEndTimestamp())
+	require.Zero(t, h.interop.BackfillEndTimestamp())
 
-	first, err := h.interop.FirstSealedBlock(eth.ChainIDFromUInt64(10))
-	require.NoError(t, err)
-	// The first real backfilled block is 120, and the logs DB records its
-	// virtual parent as the first sealed block.
-	require.Equal(t, uint64(119), first.Number)
-	require.Equal(t, uint64(120), first.Timestamp)
-
-	latest, ok, err := h.interop.LatestSealedBlock(eth.ChainIDFromUInt64(10))
-	require.NoError(t, err)
-	require.True(t, ok)
-	require.Equal(t, safe, latest.Number)
-	require.Equal(t, safe, latest.Timestamp)
+	_, err = h.interop.FirstSealedBlock(eth.ChainIDFromUInt64(10))
+	require.Error(t, err, "backfill must not seal logs before SafeDB readiness is proven")
 }
 
 // =============================================================================

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -279,6 +279,32 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			want: 126,
 		},
 		{
+			name: "EL finalized before activation uses newest local safe handoff across chains",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithActivation(100).
+					WithChain(10, func(m *mockChainContainer) {
+						m.elFinalizedHead = eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0}
+						m.elFinalizedHeadSet = true
+						m.syncStatusFull = &eth.SyncStatus{
+							FinalizedL2: eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0},
+							SafeL2:      eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0},
+							LocalSafeL2: eth.L2BlockRef{Number: 125, Hash: common.HexToHash("0xdef456"), Time: 125},
+						}
+					}).
+					WithChain(20, func(m *mockChainContainer) {
+						m.elFinalizedHead = eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0}
+						m.elFinalizedHeadSet = true
+						m.syncStatusFull = &eth.SyncStatus{
+							FinalizedL2: eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0},
+							SafeL2:      eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0},
+							LocalSafeL2: eth.L2BlockRef{Number: 140, Hash: common.HexToHash("0xdef456"), Time: 140},
+						}
+					}).
+					Build()
+			},
+			want: 141,
+		},
+		{
 			name: "EL finalized at activation returns timestamp after activation",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -258,7 +258,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			want: 100,
 		},
 		{
-			name: "EL finalized before activation ignores local safe handoff",
+			name: "EL finalized before activation uses local safe handoff when available",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
@@ -276,7 +276,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 					}).
 					Build()
 			},
-			want: 100,
+			want: 126,
 		},
 		{
 			name: "EL finalized at activation returns timestamp after activation",
@@ -1169,6 +1169,8 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 					Build()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
+				h.interop.backfillStartTimestamp = 120
+				h.interop.backfillEndTimestamp = 125
 				verified, err := h.interop.VerifiedAtTimestamp(125)
 				require.NoError(t, err)
 				require.True(t, verified)
@@ -1239,7 +1241,25 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 		require.NotErrorIs(t, err, ErrBeforeVerifiedDB)
 	})
 
-	t.Run("post-activation but below firstVerifiable returns ErrBeforeVerifiedDB", func(t *testing.T) {
+	t.Run("post-activation but below handoff returns ErrBeforeHandoff", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithActivation(100).
+			WithChain(10, func(m *mockChainContainer) {
+				m.syncStatusFull = &eth.SyncStatus{
+					SafeL2:      eth.L2BlockRef{Number: 500, Time: 500},
+					LocalSafeL2: eth.L2BlockRef{Number: 500, Time: 500},
+				}
+			}).
+			Build()
+		h.interop.backfillStartTimestamp = 300
+		_, _, err := h.interop.VerifiedResultAtTimestamp(200)
+		require.ErrorIs(t, err, ErrBeforeHandoff)
+		require.NotErrorIs(t, err, ErrBeforeVerifiedDB)
+		require.NotErrorIs(t, err, ErrNotActive)
+		require.NotErrorIs(t, err, ethereum.NotFound)
+	})
+
+	t.Run("post-activation handoff range below firstVerifiable returns ErrBeforeVerifiedDB", func(t *testing.T) {
 		h := newInteropTestHarness(t).
 			WithActivation(100).
 			WithChain(10, func(m *mockChainContainer) {
@@ -1251,8 +1271,10 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 				}
 			}).
 			Build()
+		h.interop.backfillStartTimestamp = 150
 		_, _, err := h.interop.VerifiedResultAtTimestamp(200)
 		require.ErrorIs(t, err, ErrBeforeVerifiedDB)
+		require.NotErrorIs(t, err, ErrBeforeHandoff)
 		require.NotErrorIs(t, err, ErrNotActive)
 		require.NotErrorIs(t, err, ethereum.NotFound)
 	})
@@ -1315,7 +1337,7 @@ func TestNoopVerifiedResultReader(t *testing.T) {
 	var r VerifiedResultReader = NoopVerifiedResultReader{}
 	for _, ts := range []uint64{0, 1, 1000, 1 << 60} {
 		_, _, err := r.VerifiedResultAtTimestamp(ts)
-		require.ErrorIs(t, err, ErrNotActive)
+		require.ErrorIs(t, err, ErrInteropDisabled)
 	}
 }
 
@@ -1347,7 +1369,7 @@ func TestFirstVerifiableTimestampRestoresSafeHeadHandoffAfterRestart(t *testing.
 
 	verified, err := interop.VerifiedAtTimestamp(125)
 	require.NoError(t, err)
-	require.True(t, verified, "timestamp before first committed result remains covered by the startup handoff")
+	require.False(t, verified, "timestamp before first committed result needs a persisted handoff lower bound")
 
 	verified, err = interop.VerifiedAtTimestamp(150)
 	require.NoError(t, err)

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -258,6 +258,27 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			want: 100,
 		},
 		{
+			name: "EL finalized before activation uses local safe handoff when available",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithActivation(100).
+					WithChain(10, func(m *mockChainContainer) {
+						m.elFinalizedHead = eth.L2BlockRef{
+							Number: 0,
+							Hash:   common.HexToHash("0xabc123"),
+							Time:   0,
+						}
+						m.elFinalizedHeadSet = true
+						m.syncStatusFull = &eth.SyncStatus{
+							FinalizedL2: eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0},
+							SafeL2:      eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0},
+							LocalSafeL2: eth.L2BlockRef{Number: 125, Hash: common.HexToHash("0xdef456"), Time: 125},
+						}
+					}).
+					Build()
+			},
+			want: 126,
+		},
+		{
 			name: "EL finalized at activation returns timestamp after activation",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -258,7 +258,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			want: 100,
 		},
 		{
-			name: "EL finalized before activation uses local safe handoff when available",
+			name: "EL finalized before activation ignores local safe handoff",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
@@ -276,7 +276,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 					}).
 					Build()
 			},
-			want: 126,
+			want: 100,
 		},
 		{
 			name: "EL finalized at activation returns timestamp after activation",
@@ -2300,6 +2300,9 @@ func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64,
 	return m.invalidateBlockRet, m.invalidateBlockErr
 }
 func (m *mockChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+	if m.callLog != nil {
+		m.callLog.record(m.id, "OutputV0AtBlockNumber")
+	}
 	if m.outputV0Override != nil {
 		return m.outputV0Override(ctx, l2BlockNum)
 	}

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -12,7 +12,9 @@ import (
 
 // resolveFirstVerifiableTimestamp returns the first timestamp not yet covered
 // by durable local state: verifiedDB.LastTimestamp+1 when initialized,
-// otherwise the minimum EL finalized head + 1 (clamped to activation).
+// otherwise the minimum EL finalized head + 1. If finalized is still
+// pre-activation, it falls back to recent local-safe progress before clamping
+// to activation.
 func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if len(i.chains) == 0 {
 		return i.activationTimestamp, nil
@@ -27,6 +29,16 @@ func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, 
 		return 0, err
 	}
 	if minELFinalizedTime < i.activationTimestamp {
+		minLocalSafeTime, err := i.minLocalSafeTime(ctx)
+		if err != nil {
+			return 0, err
+		}
+		// Break the cold-start bootstrap cycle where supernode finalized stays at
+		// genesis until the verifier commits, but the verifier cannot start from
+		// activation because SafeDB only contains recent local-safe history.
+		if minLocalSafeTime > i.activationTimestamp {
+			return minLocalSafeTime + 1, nil
+		}
 		return i.activationTimestamp, nil
 	}
 	return minELFinalizedTime + 1, nil
@@ -53,6 +65,27 @@ func (i *Interop) minELFinalizedTime(ctx context.Context) (uint64, error) {
 		minELFinalizedTime = min(minELFinalizedTime, elFinalized.Time)
 	}
 	return minELFinalizedTime, nil
+}
+
+func (i *Interop) minLocalSafeTime(ctx context.Context) (uint64, error) {
+	minLocalSafeTime := uint64(math.MaxUint64)
+	for _, chain := range i.chains {
+		status, err := chain.SyncStatus(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("chain %s: sync status: %w", chain.ID(), err)
+		}
+		if status == nil {
+			return 0, fmt.Errorf("chain %s: sync status unavailable", chain.ID())
+		}
+		localSafe := status.LocalSafeL2
+		if localSafe == (eth.L2BlockRef{}) {
+			return 0, fmt.Errorf("chain %s: local safe head not yet available", chain.ID())
+		}
+		i.log.Debug("first verifiable timestamp: local safe handoff",
+			"chain", chain.ID(), "localSafe", localSafe)
+		minLocalSafeTime = min(minLocalSafeTime, localSafe.Time)
+	}
+	return minLocalSafeTime, nil
 }
 
 func (i *Interop) runLogBackfill() (uint64, error) {

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -96,10 +96,12 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	firstVerifiable := i.firstVerifiable
 	if !i.firstVerifiableSet {
 		var err error
-		firstVerifiable, err = i.resolveFirstVerifiableTimestamp(i.ctx)
+		firstVerifiable, err = i.readyFirstVerifiableTimestamp(i.ctx)
 		if err != nil {
 			return 0, err
 		}
+		i.firstVerifiable = firstVerifiable
+		i.firstVerifiableSet = true
 	}
 	if firstVerifiable == i.activationTimestamp {
 		return 0, nil
@@ -115,12 +117,6 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	}
 	// clamp to the activation timestamp: never backfill before activation.
 	startTime := max(idealStart, i.activationTimestamp)
-
-	resume, err := i.pauseChainsForBackfill(i.ctx)
-	if err != nil {
-		return 0, err
-	}
-	defer resume()
 
 	// backfill every chain in parallel over [startTime, endTime]
 	errCh := make(chan error, len(i.chains))
@@ -163,28 +159,6 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	}
 	i.backfillStartTimestamp = startTime
 	return endTime, nil
-}
-
-func (i *Interop) pauseChainsForBackfill(ctx context.Context) (func(), error) {
-	paused := make([]cc.ChainContainer, 0, len(i.chains))
-	for _, chain := range i.chains {
-		if err := chain.PauseAndStopVN(ctx); err != nil {
-			for _, p := range paused {
-				if resumeErr := p.Resume(context.Background()); resumeErr != nil {
-					i.log.Error("failed to resume chain after backfill pause failure", "chain", p.ID(), "err", resumeErr)
-				}
-			}
-			return nil, fmt.Errorf("pause chain %s for log backfill: %w", chain.ID(), err)
-		}
-		paused = append(paused, chain)
-	}
-	return func() {
-		for _, chain := range paused {
-			if err := chain.Resume(context.Background()); err != nil {
-				i.log.Error("failed to resume chain after log backfill", "chain", chain.ID(), "err", err)
-			}
-		}
-	}, nil
 }
 
 func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.ChainContainer, startNum, endNum uint64) error {

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -12,9 +12,9 @@ import (
 
 // resolveFirstVerifiableTimestamp returns the first timestamp not yet covered
 // by durable local state: verifiedDB.LastTimestamp+1 when initialized,
-// otherwise the minimum EL finalized head + 1. If finalized is still
-// pre-activation, it falls back to recent local-safe progress before clamping
-// to activation.
+// otherwise the minimum EL finalized head + 1, clamped to activation. If
+// finalized is still pre-activation, there is no interop log history to
+// backfill yet.
 func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if len(i.chains) == 0 {
 		return i.activationTimestamp, nil
@@ -29,16 +29,6 @@ func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, 
 		return 0, err
 	}
 	if minELFinalizedTime < i.activationTimestamp {
-		minLocalSafeTime, err := i.minLocalSafeTime(ctx)
-		if err != nil {
-			return 0, err
-		}
-		// Break the cold-start bootstrap cycle where supernode finalized stays at
-		// genesis until the verifier commits, but the verifier cannot start from
-		// activation because SafeDB only contains recent local-safe history.
-		if minLocalSafeTime > i.activationTimestamp {
-			return minLocalSafeTime + 1, nil
-		}
 		return i.activationTimestamp, nil
 	}
 	return minELFinalizedTime + 1, nil
@@ -119,6 +109,12 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	// clamp to the activation timestamp: never backfill before activation.
 	startTime := max(idealStart, i.activationTimestamp)
 
+	resume, err := i.pauseChainsForBackfill(i.ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer resume()
+
 	// backfill every chain in parallel over [startTime, endTime]
 	errCh := make(chan error, len(i.chains))
 	wg := sync.WaitGroup{}
@@ -159,6 +155,28 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 		return 0, err
 	}
 	return endTime, nil
+}
+
+func (i *Interop) pauseChainsForBackfill(ctx context.Context) (func(), error) {
+	paused := make([]cc.ChainContainer, 0, len(i.chains))
+	for _, chain := range i.chains {
+		if err := chain.PauseAndStopVN(ctx); err != nil {
+			for _, p := range paused {
+				if resumeErr := p.Resume(context.Background()); resumeErr != nil {
+					i.log.Error("failed to resume chain after backfill pause failure", "chain", p.ID(), "err", resumeErr)
+				}
+			}
+			return nil, fmt.Errorf("pause chain %s for log backfill: %w", chain.ID(), err)
+		}
+		paused = append(paused, chain)
+	}
+	return func() {
+		for _, chain := range paused {
+			if err := chain.Resume(context.Background()); err != nil {
+				i.log.Error("failed to resume chain after log backfill", "chain", chain.ID(), "err", err)
+			}
+		}
+	}, nil
 }
 
 func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.ChainContainer, startNum, endNum uint64) error {

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -98,12 +98,10 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	firstVerifiable := i.firstVerifiable
 	if !i.firstVerifiableSet {
 		var err error
-		firstVerifiable, err = i.readyFirstVerifiableTimestamp(i.ctx)
+		firstVerifiable, err = i.resolveFirstVerifiableTimestamp(i.ctx)
 		if err != nil {
 			return 0, err
 		}
-		i.firstVerifiable = firstVerifiable
-		i.firstVerifiableSet = true
 	}
 	if firstVerifiable == i.activationTimestamp {
 		return 0, nil
@@ -119,6 +117,17 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	}
 	// clamp to the activation timestamp: never backfill before activation.
 	startTime := max(idealStart, i.activationTimestamp)
+
+	if _, err := i.checkChainsReady(startTime); err != nil {
+		return 0, err
+	}
+	if endTime != startTime {
+		if _, err := i.checkChainsReady(endTime); err != nil {
+			return 0, err
+		}
+	}
+	i.firstVerifiable = firstVerifiable
+	i.firstVerifiableSet = true
 
 	// backfill every chain in parallel over [startTime, endTime]
 	errCh := make(chan error, len(i.chains))

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -13,8 +13,10 @@ import (
 // resolveFirstVerifiableTimestamp returns the first timestamp not yet covered
 // by durable local state: verifiedDB.LastTimestamp+1 when initialized,
 // otherwise the minimum EL finalized head + 1. If finalized is still
-// pre-activation, it uses recent local-safe progress as the cold-start
-// handoff point. The result is clamped to activation.
+// pre-activation, it uses the newest local-safe progress as the cold-start
+// handoff point, then the caller waits until every chain can serve it. This
+// avoids selecting a timestamp below a chain's first SafeDB entry after an
+// execution-layer sync reset. The result is clamped to activation.
 func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if len(i.chains) == 0 {
 		return i.activationTimestamp, nil
@@ -29,12 +31,12 @@ func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, 
 		return 0, err
 	}
 	if minELFinalizedTime < i.activationTimestamp {
-		minLocalSafeTime, err := i.minLocalSafeTime(ctx)
+		maxLocalSafeTime, err := i.maxLocalSafeTime(ctx)
 		if err != nil {
 			return 0, err
 		}
-		if minLocalSafeTime > i.activationTimestamp {
-			return minLocalSafeTime + 1, nil
+		if maxLocalSafeTime > i.activationTimestamp {
+			return maxLocalSafeTime + 1, nil
 		}
 		return i.activationTimestamp, nil
 	}
@@ -64,8 +66,8 @@ func (i *Interop) minELFinalizedTime(ctx context.Context) (uint64, error) {
 	return minELFinalizedTime, nil
 }
 
-func (i *Interop) minLocalSafeTime(ctx context.Context) (uint64, error) {
-	minLocalSafeTime := uint64(math.MaxUint64)
+func (i *Interop) maxLocalSafeTime(ctx context.Context) (uint64, error) {
+	maxLocalSafeTime := uint64(0)
 	for _, chain := range i.chains {
 		status, err := chain.SyncStatus(ctx)
 		if err != nil {
@@ -80,9 +82,9 @@ func (i *Interop) minLocalSafeTime(ctx context.Context) (uint64, error) {
 		}
 		i.log.Debug("first verifiable timestamp: local safe handoff",
 			"chain", chain.ID(), "localSafe", localSafe)
-		minLocalSafeTime = min(minLocalSafeTime, localSafe.Time)
+		maxLocalSafeTime = max(maxLocalSafeTime, localSafe.Time)
 	}
-	return minLocalSafeTime, nil
+	return maxLocalSafeTime, nil
 }
 
 func (i *Interop) runLogBackfill() (uint64, error) {

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -12,9 +12,9 @@ import (
 
 // resolveFirstVerifiableTimestamp returns the first timestamp not yet covered
 // by durable local state: verifiedDB.LastTimestamp+1 when initialized,
-// otherwise the minimum EL finalized head + 1, clamped to activation. If
-// finalized is still pre-activation, there is no interop log history to
-// backfill yet.
+// otherwise the minimum EL finalized head + 1. If finalized is still
+// pre-activation, it uses recent local-safe progress as the cold-start
+// handoff point. The result is clamped to activation.
 func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if len(i.chains) == 0 {
 		return i.activationTimestamp, nil
@@ -29,6 +29,13 @@ func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, 
 		return 0, err
 	}
 	if minELFinalizedTime < i.activationTimestamp {
+		minLocalSafeTime, err := i.minLocalSafeTime(ctx)
+		if err != nil {
+			return 0, err
+		}
+		if minLocalSafeTime > i.activationTimestamp {
+			return minLocalSafeTime + 1, nil
+		}
 		return i.activationTimestamp, nil
 	}
 	return minELFinalizedTime + 1, nil
@@ -154,6 +161,7 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	for err := range errCh {
 		return 0, err
 	}
+	i.backfillStartTimestamp = startTime
 	return endTime, nil
 }
 

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -635,6 +635,43 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 		"main loop resumes at activation when EL finalized is still pre-activation")
 }
 
+func TestLogBackfill_UsesLocalSafeHandoffWhenFinalizedPreActivation(t *testing.T) {
+	const act = uint64(1000)
+	depth := 60 * time.Second
+
+	var outputCalls atomic.Int32
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(depth).
+		WithChain(10, func(m *mockChainContainer) {
+			m.elFinalizedHead = eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0}
+			m.elFinalizedHeadSet = true
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: 1061, Time: 1061},
+				SafeL2:      eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0},
+				LocalSafeL2: eth.L2BlockRef{Number: 1060, Hash: common.HexToHash("0xdef456"), Time: 1060},
+			}
+			m.outputV0Override = func(ctx context.Context, num uint64) (*eth.OutputV0, error) {
+				outputCalls.Add(1)
+				return &eth.OutputV0{
+					StateRoot:                eth.Bytes32(common.HexToHash("0xmockstate")),
+					MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmockmsg")),
+					BlockHash:                common.BigToHash(new(big.Int).SetUint64(num)),
+				}, nil
+			}
+		}).
+		Build()
+	h.interop.ctx = context.Background()
+
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1060), end)
+	require.Positive(t, outputCalls.Load(), "backfill should seal the recent local-safe handoff range")
+	requireFirstVerifiableTimestamp(t, h.interop, 1061)
+}
+
 // TestLogBackfill_ClampsStartToGenesis asserts that the per-chain start is
 // clamped up to the chain's genesis timestamp. Without this clamp,
 // runLogBackfill would ask TimestampToBlockNumber for a pre-genesis timestamp

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -675,6 +675,33 @@ func TestLogBackfill_UsesLocalSafeHandoffWhenFinalizedPreActivation(t *testing.T
 	require.Zero(t, h.Mock(10).resumeCalls, "backfill must not restart VNs")
 }
 
+func TestLogBackfill_ReadinessChecksBackfillWindowNotFirstVerifiable(t *testing.T) {
+	const act = uint64(1000)
+	depth := 60 * time.Second
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(depth).
+		WithChain(10, func(m *mockChainContainer) {
+			m.elFinalizedHead = eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0}
+			m.elFinalizedHeadSet = true
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: 1061, Time: 1061},
+				SafeL2:      eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123"), Time: 0},
+				LocalSafeL2: eth.L2BlockRef{Number: 1060, Hash: common.HexToHash("0xdef456"), Time: 1060},
+			}
+		}).
+		Build()
+	h.interop.ctx = context.Background()
+
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1060), end)
+	require.Equal(t, uint64(1060), h.Mock(10).lastRequestedTimestamp,
+		"backfill readiness must stop at endTime; firstVerifiable is intentionally one past local safe")
+}
+
 func TestLogBackfill_DoesNotPauseChainsWhileSealing(t *testing.T) {
 	const act = uint64(100)
 	cl := &callLog{}

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -635,7 +635,7 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 		"main loop resumes at activation when EL finalized is still pre-activation")
 }
 
-func TestLogBackfill_NoOpWhenFinalizedPreActivation(t *testing.T) {
+func TestLogBackfill_UsesLocalSafeHandoffWhenFinalizedPreActivation(t *testing.T) {
 	const act = uint64(1000)
 	depth := 60 * time.Second
 
@@ -667,11 +667,12 @@ func TestLogBackfill_NoOpWhenFinalizedPreActivation(t *testing.T) {
 
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
-	require.Zero(t, end)
-	require.Zero(t, outputCalls.Load(), "pre-activation finalized head should not backfill a local-safe handoff range")
-	requireFirstVerifiableTimestamp(t, h.interop, act)
-	require.Zero(t, h.Mock(10).pauseAndStopVNCalls, "no-op backfill should not pause chains")
-	require.Zero(t, h.Mock(10).resumeCalls, "no-op backfill should not resume chains")
+	require.Equal(t, uint64(1060), end)
+	require.Equal(t, uint64(1000), h.interop.backfillStartTimestamp)
+	require.Positive(t, outputCalls.Load(), "backfill should seal the local-safe handoff range")
+	requireFirstVerifiableTimestamp(t, h.interop, 1061)
+	require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls, "backfill should pause chains")
+	require.Equal(t, 1, h.Mock(10).resumeCalls, "backfill should resume chains")
 }
 
 func TestLogBackfill_PausesChainsWhileSealing(t *testing.T) {

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -671,11 +671,11 @@ func TestLogBackfill_UsesLocalSafeHandoffWhenFinalizedPreActivation(t *testing.T
 	require.Equal(t, uint64(1000), h.interop.backfillStartTimestamp)
 	require.Positive(t, outputCalls.Load(), "backfill should seal the local-safe handoff range")
 	requireFirstVerifiableTimestamp(t, h.interop, 1061)
-	require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls, "backfill should pause chains")
-	require.Equal(t, 1, h.Mock(10).resumeCalls, "backfill should resume chains")
+	require.Zero(t, h.Mock(10).pauseAndStopVNCalls, "backfill must not restart VNs")
+	require.Zero(t, h.Mock(10).resumeCalls, "backfill must not restart VNs")
 }
 
-func TestLogBackfill_PausesChainsWhileSealing(t *testing.T) {
+func TestLogBackfill_DoesNotPauseChainsWhileSealing(t *testing.T) {
 	const act = uint64(100)
 	cl := &callLog{}
 
@@ -706,35 +706,24 @@ func TestLogBackfill_PausesChainsWhileSealing(t *testing.T) {
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
 	require.Equal(t, uint64(110), end)
-	require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls)
-	require.Equal(t, 1, h.Mock(20).pauseAndStopVNCalls)
-	require.Equal(t, 1, h.Mock(10).resumeCalls)
-	require.Equal(t, 1, h.Mock(20).resumeCalls)
+	require.Zero(t, h.Mock(10).pauseAndStopVNCalls)
+	require.Zero(t, h.Mock(20).pauseAndStopVNCalls)
+	require.Zero(t, h.Mock(10).resumeCalls)
+	require.Zero(t, h.Mock(20).resumeCalls)
 
 	entries := cl.snapshot()
 	firstSealIdx := -1
-	firstResumeIdx := -1
 	for i, e := range entries {
-		switch e.method {
-		case "OutputV0AtBlockNumber":
+		if e.method == "OutputV0AtBlockNumber" {
 			if firstSealIdx == -1 {
 				firstSealIdx = i
-			}
-		case "Resume":
-			if firstResumeIdx == -1 {
-				firstResumeIdx = i
 			}
 		}
 	}
 	require.NotEqual(t, -1, firstSealIdx, "backfill should seal blocks")
-	require.NotEqual(t, -1, firstResumeIdx, "backfill should resume chains")
-	for i, e := range entries {
-		if e.method == "PauseAndStopVN" {
-			require.Less(t, i, firstSealIdx, "chains must pause before sealing")
-		}
-		if e.method == "OutputV0AtBlockNumber" {
-			require.Less(t, i, firstResumeIdx, "sealing must finish before resume")
-		}
+	for _, e := range entries {
+		require.NotEqual(t, "PauseAndStopVN", e.method, "backfill must not restart VNs")
+		require.NotEqual(t, "Resume", e.method, "backfill must not restart VNs")
 	}
 }
 

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -635,7 +635,7 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 		"main loop resumes at activation when EL finalized is still pre-activation")
 }
 
-func TestLogBackfill_UsesLocalSafeHandoffWhenFinalizedPreActivation(t *testing.T) {
+func TestLogBackfill_NoOpWhenFinalizedPreActivation(t *testing.T) {
 	const act = uint64(1000)
 	depth := 60 * time.Second
 
@@ -667,9 +667,74 @@ func TestLogBackfill_UsesLocalSafeHandoffWhenFinalizedPreActivation(t *testing.T
 
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
-	require.Equal(t, uint64(1060), end)
-	require.Positive(t, outputCalls.Load(), "backfill should seal the recent local-safe handoff range")
-	requireFirstVerifiableTimestamp(t, h.interop, 1061)
+	require.Zero(t, end)
+	require.Zero(t, outputCalls.Load(), "pre-activation finalized head should not backfill a local-safe handoff range")
+	requireFirstVerifiableTimestamp(t, h.interop, act)
+	require.Zero(t, h.Mock(10).pauseAndStopVNCalls, "no-op backfill should not pause chains")
+	require.Zero(t, h.Mock(10).resumeCalls, "no-op backfill should not resume chains")
+}
+
+func TestLogBackfill_PausesChainsWhileSealing(t *testing.T) {
+	const act = uint64(100)
+	cl := &callLog{}
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(5*time.Second).
+		WithChain(10, func(m *mockChainContainer) {
+			m.callLog = cl
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: 110, Time: 110},
+				SafeL2:      eth.L2BlockRef{Number: 110, Time: 110},
+				LocalSafeL2: eth.L2BlockRef{Number: 110, Time: 110},
+			}
+		}).
+		WithChain(20, func(m *mockChainContainer) {
+			m.callLog = cl
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: 110, Time: 110},
+				SafeL2:      eth.L2BlockRef{Number: 110, Time: 110},
+				LocalSafeL2: eth.L2BlockRef{Number: 110, Time: 110},
+			}
+		}).
+		Build()
+	h.interop.ctx = context.Background()
+
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	require.Equal(t, uint64(110), end)
+	require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls)
+	require.Equal(t, 1, h.Mock(20).pauseAndStopVNCalls)
+	require.Equal(t, 1, h.Mock(10).resumeCalls)
+	require.Equal(t, 1, h.Mock(20).resumeCalls)
+
+	entries := cl.snapshot()
+	firstSealIdx := -1
+	firstResumeIdx := -1
+	for i, e := range entries {
+		switch e.method {
+		case "OutputV0AtBlockNumber":
+			if firstSealIdx == -1 {
+				firstSealIdx = i
+			}
+		case "Resume":
+			if firstResumeIdx == -1 {
+				firstResumeIdx = i
+			}
+		}
+	}
+	require.NotEqual(t, -1, firstSealIdx, "backfill should seal blocks")
+	require.NotEqual(t, -1, firstResumeIdx, "backfill should resume chains")
+	for i, e := range entries {
+		if e.method == "PauseAndStopVN" {
+			require.Less(t, i, firstSealIdx, "chains must pause before sealing")
+		}
+		if e.method == "OutputV0AtBlockNumber" {
+			require.Less(t, i, firstResumeIdx, "sealing must finish before resume")
+		}
+	}
 }
 
 // TestLogBackfill_ClampsStartToGenesis asserts that the per-chain start is

--- a/op-supernode/supernode/activity/interop/reader.go
+++ b/op-supernode/supernode/activity/interop/reader.go
@@ -6,14 +6,24 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// ErrNotActive signals that ts is before interop activation. Callers compose
-// the super root from per-chain optimistic outputs.
+// ErrNotActive signals that ts is before interop activation.
 var ErrNotActive = errors.New("interop not active for timestamp")
 
+// ErrInteropDisabled signals that the interop verifier is not configured.
+// Callers may use the pre-interop optimistic composition path.
+var ErrInteropDisabled = errors.New("interop verifier disabled")
+
+// ErrBeforeHandoff signals that ts is post-activation but older than the
+// local startup handoff window. This node intentionally does not serve
+// optimistic superroots for the timestamp because doing so would require
+// SafeDB history that the startup backfill did not cover.
+var ErrBeforeHandoff = errors.New("timestamp below startup handoff")
+
 // ErrBeforeVerifiedDB signals that ts is post-activation but below the
-// verifier's first verifiable timestamp on this node. The timestamp is
-// already covered by the startup handoff: no VerifiedResult will
-// be produced here, but callers can treat optimistic outputs as canonical.
+// verifier's first verifiable timestamp on this node but within the startup
+// handoff window. The timestamp is covered by backfilled logs and available
+// SafeDB history: no VerifiedResult will be produced here, but callers can
+// treat optimistic outputs as canonical.
 var ErrBeforeVerifiedDB = errors.New("timestamp below verified-db start")
 
 // ErrNotStarted signals that Start has not yet populated i.ctx. Callers
@@ -23,9 +33,11 @@ var ErrNotStarted = errors.New("interop activity not started")
 // VerifiedResultReader exposes committed VerifiedResults to non-interop
 // activities. Errors discriminate the regime:
 //   - nil:                  verified entry returned
-//   - ErrNotActive:         pre-activation; compose from optimistic outputs
-//   - ErrBeforeVerifiedDB:  post-activation but below firstVerifiable; the
-//     handoff covers ts, so compose from optimistic outputs
+//   - ErrInteropDisabled:   interop not configured; compose from optimistic outputs
+//   - ErrNotActive:         pre-activation; do not query interop superroots
+//   - ErrBeforeHandoff:     post-activation but below local backfill coverage
+//   - ErrBeforeVerifiedDB:  post-activation and inside startup handoff; compose
+//     from optimistic outputs
 //   - ethereum.NotFound:    verifier may eventually produce a result but has
 //     not yet — return Data = nil and let CurrentL1 communicate progress
 //
@@ -37,10 +49,9 @@ type VerifiedResultReader interface {
 	VerifiedResultAtTimestamp(ts uint64) (result VerifiedResult, currentL1 eth.BlockID, err error)
 }
 
-// NoopVerifiedResultReader is used when interop is not configured: every
-// call returns ErrNotActive.
+// NoopVerifiedResultReader is used when interop is not configured.
 type NoopVerifiedResultReader struct{}
 
 func (NoopVerifiedResultReader) VerifiedResultAtTimestamp(uint64) (VerifiedResult, eth.BlockID, error) {
-	return VerifiedResult{}, eth.BlockID{}, ErrNotActive
+	return VerifiedResult{}, eth.BlockID{}, ErrInteropDisabled
 }

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -57,21 +57,11 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 
 	result, verifierL1, vrErr := s.verified.VerifiedResultAtTimestamp(timestamp)
 
-	// Any chain-level error building the optimistic branch must fail the
-	// call: op-challenger reads OptimisticAtTimestamp at step>0 and a silent
-	// partial map would produce permanent InvalidTransition commitments on
-	// chain. The pre-interop regime also relies on this map for Data.
-	optimisticBranch, err := s.buildOptimisticBranch(ctx, timestamp)
-	if err != nil {
-		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("build optimistic branch at %d: %w", timestamp, err)
-	}
-
 	response := eth.SuperRootAtTimestampResponse{
 		CurrentL1:                 aggregate.CurrentL1,
 		CurrentSafeTimestamp:      aggregate.SafeTimestamp,
 		CurrentLocalSafeTimestamp: aggregate.LocalSafeTimestamp,
 		CurrentFinalizedTimestamp: aggregate.FinalizedTimestamp,
-		OptimisticAtTimestamp:     optimisticBranch,
 		ChainIDs:                  aggregate.ChainIDs,
 	}
 
@@ -84,6 +74,11 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 	// value).
 	switch {
 	case vrErr == nil:
+		optimisticBranch, err := s.buildOptimisticBranch(ctx, timestamp)
+		if err != nil {
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("build optimistic branch at %d: %w", timestamp, err)
+		}
+		response.OptimisticAtTimestamp = optimisticBranch
 		if verifierL1.Number < response.CurrentL1.Number {
 			response.CurrentL1 = verifierL1
 		}
@@ -94,6 +89,11 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		response.Data = data
 		return response, nil
 	case errors.Is(vrErr, ethereum.NotFound):
+		optimisticBranch, err := s.buildOptimisticBranch(ctx, timestamp)
+		if err != nil {
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("build optimistic branch at %d: %w", timestamp, err)
+		}
+		response.OptimisticAtTimestamp = optimisticBranch
 		// Interop active at T but no VerifiedResult yet. Leave Data nil;
 		// the verifiedDB write gate guarantees CurrentL1 has not reached
 		// VerifiedRequiredL1(T).
@@ -101,10 +101,20 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 			response.CurrentL1 = verifierL1
 		}
 		return response, nil
-	case errors.Is(vrErr, interop.ErrNotActive), errors.Is(vrErr, interop.ErrBeforeVerifiedDB), errors.Is(vrErr, interop.ErrNotStarted):
+	case errors.Is(vrErr, interop.ErrInteropDisabled), errors.Is(vrErr, interop.ErrBeforeVerifiedDB), errors.Is(vrErr, interop.ErrNotStarted):
+		optimisticBranch, err := s.buildOptimisticBranch(ctx, timestamp)
+		if err != nil {
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("build optimistic branch at %d: %w", timestamp, err)
+		}
+		response.OptimisticAtTimestamp = optimisticBranch
 		// Optimistic outputs are canonical: pre-interop consensus,
 		// safe-head handoff, or pre-Start retry path.
 		response.Data = composeHandoffDataFromOptimistic(timestamp, s.chains, optimisticBranch)
+		return response, nil
+	case errors.Is(vrErr, interop.ErrNotActive), errors.Is(vrErr, interop.ErrBeforeHandoff):
+		// Do not build an optimistic branch here. These timestamps are outside
+		// this node's interop/backfill coverage, and attempting optimistic
+		// composition would require SafeDB history that may not exist.
 		return response, nil
 	default:
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("read verifiedDB at %d: %w", timestamp, vrErr)

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -41,6 +41,8 @@ type mockCC struct {
 	status         *eth.SyncStatus
 	verifierL1s    []eth.BlockID
 	byHashCalled   int
+	optimisticAt   int
+	optimisticOut  int
 }
 
 func (m *mockCC) Start(ctx context.Context) error          { return nil }
@@ -63,6 +65,7 @@ func (m *mockCC) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
 	return m.status, nil
 }
 func (m *mockCC) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
+	m.optimisticAt++
 	if m.optimisticErr != nil {
 		return eth.BlockID{}, eth.BlockID{}, m.optimisticErr
 	}
@@ -79,6 +82,7 @@ func (m *mockCC) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.H
 	return m.byHashFallback, nil
 }
 func (m *mockCC) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputV0, error) {
+	m.optimisticOut++
 	if m.optimisticErr != nil {
 		return nil, m.optimisticErr
 	}
@@ -128,7 +132,8 @@ func (m *mockVerifiedReader) VerifiedResultAtTimestamp(ts uint64) (interop.Verif
 	return m.result, m.currentL1, m.err
 }
 
-// preInteropReader always reports the pre-interop fallback regime.
+// preInteropReader reports that interop is disabled, so superroot should use
+// the pre-interop optimistic-composition fallback.
 func preInteropReader() interop.VerifiedResultReader {
 	return interop.NoopVerifiedResultReader{}
 }
@@ -546,19 +551,23 @@ func TestSuperroot_AtTimestamp_PreInteropFallback_OptimisticMapShort(t *testing.
 func TestSuperroot_AtTimestamp_PreInteropFallback_BelowActivation(t *testing.T) {
 	t.Parallel()
 	chainA := eth.ChainIDFromUInt64(10)
+	chain := &mockCC{
+		optL2:     eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
+		optL1:     eth.BlockID{Number: 900},
+		optOutput: &eth.OutputV0{StateRoot: eth.Bytes32{0x01}},
+		status:    &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+	}
 	chains := map[eth.ChainID]cc.ChainContainer{
-		chainA: &mockCC{
-			optL2:     eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
-			optL1:     eth.BlockID{Number: 900},
-			optOutput: &eth.OutputV0{StateRoot: eth.Bytes32{0x01}},
-			status:    &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
-		},
+		chainA: chain,
 	}
 	reader := &mockVerifiedReader{err: interop.ErrNotActive}
 	s := newSuperroot(chains, reader)
 	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
-	require.NotNil(t, resp.Data)
+	require.Nil(t, resp.Data)
+	require.Empty(t, resp.OptimisticAtTimestamp)
+	require.Zero(t, chain.optimisticOut)
+	require.Zero(t, chain.optimisticAt)
 }
 
 func TestSuperroot_AtTimestamp_PreInteropFallback_NoSecondFetch(t *testing.T) {
@@ -599,11 +608,45 @@ func TestSuperroot_AtTimestamp_InteropNotStarted_ComposesFromOptimistic(t *testi
 	require.NotNil(t, resp.Data)
 }
 
+func TestSuperroot_AtTimestamp_BeforeActivation_DoesNotBuildOptimistic(t *testing.T) {
+	t.Parallel()
+	chain := &mockCC{
+		optimisticErr: cc.ErrHistoryUnavailable,
+		status:        &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+	}
+	chains := map[eth.ChainID]cc.ChainContainer{eth.ChainIDFromUInt64(10): chain}
+	reader := &mockVerifiedReader{err: interop.ErrNotActive}
+	s := newSuperroot(chains, reader)
+	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.Nil(t, resp.Data)
+	require.Empty(t, resp.OptimisticAtTimestamp)
+	require.Zero(t, chain.optimisticOut)
+	require.Zero(t, chain.optimisticAt)
+}
+
 // ------ Below-verified-db handoff tests ------
 
-// Below firstVerifiable, the safe-head startup handoff guarantees the
-// optimistic outputs are canonical, so Data is composed from them rather
-// than returning an error.
+func TestSuperroot_AtTimestamp_BeforeHandoff_DoesNotBuildOptimistic(t *testing.T) {
+	t.Parallel()
+	chain := &mockCC{
+		optimisticErr: cc.ErrHistoryUnavailable,
+		status:        &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
+	}
+	chains := map[eth.ChainID]cc.ChainContainer{eth.ChainIDFromUInt64(10): chain}
+	reader := &mockVerifiedReader{err: interop.ErrBeforeHandoff}
+	s := newSuperroot(chains, reader)
+	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.Nil(t, resp.Data)
+	require.Empty(t, resp.OptimisticAtTimestamp)
+	require.Zero(t, chain.optimisticOut)
+	require.Zero(t, chain.optimisticAt)
+}
+
+// Below firstVerifiable but inside the handoff window, startup backfill
+// guarantees the optimistic outputs are canonical, so Data is composed from
+// them rather than returning an error.
 func TestSuperroot_AtTimestamp_BelowVerifiedDB_ComposesFromOptimistic(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{


### PR DESCRIPTION
## Summary
- gate log backfill readiness on the actual backfill window instead of the first post-handoff timestamp
- preserve SafeDB entries up to the current pending safe head when EL sync starts, truncating only data after that point
- add coverage for the backfill readiness boundary

## Testing
- mise exec -- go test ./op-supernode/supernode/activity/interop ./op-node/rollup/driver -count=1

## Rollout note
SN3 still needs a pullable CI-published image from this PR. A locally pushed dev image was rejected by the node service account, and local credentials cannot upload directly to the production images repo.