### PR TITLE
fix(contracts-bedrock): only flip INTEROP runtime flag at genesis whe…

### DIFF
--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -399,7 +399,9 @@ contract L2Genesis is Script {
         } else {
             _setImplementationCode(Predeploys.L1_BLOCK_ATTRIBUTES);
         }
-        if (_input.useInterop) {
+        // Only set the runtime INTEROP feature flag at genesis if the chain is being born at or
+        // beyond the Interop fork.
+        if (_input.useInterop && _input.fork >= uint256(Fork.INTEROP)) {
             IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).setFeature(Features.INTEROP);
         }
     }

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -7,13 +7,15 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Scripts
 import { L2Genesis } from "scripts/L2Genesis.s.sol";
-import { LATEST_FORK } from "scripts/libraries/Config.sol";
+import { Fork, LATEST_FORK } from "scripts/libraries/Config.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
+import { Features } from "src/libraries/Features.sol";
 
 // Interfaces
+import { IL1Block } from "interfaces/L2/IL1Block.sol";
 import { ISequencerFeeVault } from "interfaces/L2/ISequencerFeeVault.sol";
 import { IBaseFeeVault } from "interfaces/L2/IBaseFeeVault.sol";
 import { IL1FeeVault } from "interfaces/L2/IL1FeeVault.sol";
@@ -324,5 +326,48 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
         input.devFeatureBitmap = bytes32(DevFeatures.OPTIMISM_PORTAL_INTEROP);
         vm.expectRevert("L2Genesis: useInterop and OPTIMISM_PORTAL_INTEROP devFeature bit must agree");
         genesis.run(input);
+    }
+
+    /// @notice Tests that when interop is scheduled for a later fork (genesis fork < INTEROP),
+    ///         the runtime INTEROP feature flag on L1Block is NOT set at genesis. The flag will
+    ///         instead be flipped at the activation block by op-node's setFeature deposit wrapper.
+    function test_setL1Block_interopScheduledNotActive_succeeds() external {
+        _setInputInteropEnabled();
+        input.fork = uint256(Fork.ISTHMUS);
+        genesis.run(input);
+
+        assertEq(
+            IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isFeatureEnabled(Features.INTEROP),
+            false,
+            "INTEROP runtime flag must not be set at genesis when fork < INTEROP"
+        );
+    }
+
+    /// @notice Tests that when a chain is born at or beyond the Interop fork, the runtime INTEROP
+    ///         feature flag on L1Block IS set at genesis.
+    function test_setL1Block_interopAtGenesis_succeeds() external {
+        _setInputInteropEnabled();
+        input.fork = uint256(Fork.INTEROP);
+        genesis.run(input);
+
+        assertEq(
+            IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isFeatureEnabled(Features.INTEROP),
+            true,
+            "INTEROP runtime flag must be set at genesis when fork >= INTEROP"
+        );
+    }
+
+    /// @notice Sanity check: with useInterop disabled and fork < INTEROP, the runtime INTEROP flag
+    ///         is unset.
+    function test_setL1Block_interopDisabled_succeeds() external {
+        input.useInterop = false;
+        input.fork = uint256(Fork.ISTHMUS);
+        genesis.run(input);
+
+        assertEq(
+            IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isFeatureEnabled(Features.INTEROP),
+            false,
+            "INTEROP runtime flag must not be set when useInterop is false"
+        );
     }
 }


### PR DESCRIPTION
For chains where Interop is scheduled but activates at a future timestamp, the L1Block runtime feature flag must remain off at genesis. It will be set at the activation block by op-node's setFeature deposit wrapper, which only runs for multi-chain dependency sets. The previous unconditional flip bypassed depset-based gating and caused single-chain "Interop later" chains to install Interop predeploy implementations during the L2CM activation upgrade despite having no peers.

