### PR TITLE
fix: filter prerelease OPCM release tags (cherry-pick of #20617)

### DIFF
--- a/op-chain-ops/opcmregistry/registry.go
+++ b/op-chain-ops/opcmregistry/registry.go
@@ -342,9 +342,13 @@ func GetOPCMsForChain(chainID uint64) ([]OPCMInfo, error) {
 		return nil, err
 	}
 
+	return opcmsFromVersions(chainID, versions), nil
+}
+
+func opcmsFromVersions(chainID uint64, versions Versions) []OPCMInfo {
 	var opcms []OPCMInfo
 
-	for _, versionConfig := range versions {
+	for releaseTag, versionConfig := range versions {
 		if versionConfig.OPContractsManager == nil {
 			continue
 		}
@@ -352,7 +356,10 @@ func GetOPCMsForChain(chainID uint64) ([]OPCMInfo, error) {
 			continue
 		}
 
-		releaseVersion := versionConfig.OPContractsManager.Version
+		releaseVersion, err := releaseVersionFromTag(releaseTag)
+		if err != nil {
+			continue
+		}
 
 		// Skip prerelease versions (rc, beta, alpha, etc.)
 		sv, err := ParseSemver(releaseVersion)
@@ -387,7 +394,15 @@ func GetOPCMsForChain(chainID uint64) ([]OPCMInfo, error) {
 		}
 	}
 
-	return result, nil
+	return result
+}
+
+func releaseVersionFromTag(releaseTag string) (string, error) {
+	const prefix = "op-contracts/v"
+	if strings.HasPrefix(releaseTag, prefix) {
+		return strings.TrimPrefix(releaseTag, prefix), nil
+	}
+	return "", fmt.Errorf("invalid release tag: %s", releaseTag)
 }
 
 // FilterOPCMsByReleaseVersion filters OPCMs to only include those with release version > lastVersion.

--- a/op-chain-ops/opcmregistry/registry_test.go
+++ b/op-chain-ops/opcmregistry/registry_test.go
@@ -370,6 +370,28 @@ func TestFilterOPCMsByReleaseVersion(t *testing.T) {
 	})
 }
 
+func TestOPCMsFromVersionsSkipsPrereleaseReleaseTags(t *testing.T) {
+	versions := Versions{
+		"op-contracts/v7.0.0-rc.2": {
+			OPContractsManager: &ContractData{
+				Version: "7.1.17",
+				Address: addrPtr("0x9999999999999999999999999999999999999999"),
+			},
+		},
+		"op-contracts/v6.0.0": {
+			OPContractsManager: &ContractData{
+				Version: "6.0.0",
+				Address: addrPtr("0x6666666666666666666666666666666666666666"),
+			},
+		},
+	}
+
+	opcms := opcmsFromVersions(MainnetChainID, versions)
+	require.Len(t, opcms, 1)
+	require.Equal(t, common.HexToAddress("0x6666666666666666666666666666666666666666"), opcms[0].Address)
+	require.Equal(t, "6.0.0", opcms[0].ReleaseVersion)
+}
+
 func TestFilterByLastUsedOPCMVersion(t *testing.T) {
 	sv6, _ := ParseSemver("6.0.0")
 	sv61, _ := ParseSemver("6.1.0")

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -399,7 +399,9 @@ contract L2Genesis is Script {
         } else {
             _setImplementationCode(Predeploys.L1_BLOCK_ATTRIBUTES);
         }
-        if (_input.useInterop) {
+        // Only set the runtime INTEROP feature flag at genesis if the chain is being born at or
+        // beyond the Interop fork.
+        if (_input.useInterop && _input.fork >= uint256(Fork.INTEROP)) {
             IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).setFeature(Features.INTEROP);
         }
     }

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -7,13 +7,15 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Scripts
 import { L2Genesis } from "scripts/L2Genesis.s.sol";
-import { LATEST_FORK } from "scripts/libraries/Config.sol";
+import { Fork, LATEST_FORK } from "scripts/libraries/Config.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
+import { Features } from "src/libraries/Features.sol";
 
 // Interfaces
+import { IL1Block } from "interfaces/L2/IL1Block.sol";
 import { ISequencerFeeVault } from "interfaces/L2/ISequencerFeeVault.sol";
 import { IBaseFeeVault } from "interfaces/L2/IBaseFeeVault.sol";
 import { IL1FeeVault } from "interfaces/L2/IL1FeeVault.sol";
@@ -324,5 +326,48 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
         input.devFeatureBitmap = bytes32(DevFeatures.OPTIMISM_PORTAL_INTEROP);
         vm.expectRevert("L2Genesis: useInterop and OPTIMISM_PORTAL_INTEROP devFeature bit must agree");
         genesis.run(input);
+    }
+
+    /// @notice Tests that when interop is scheduled for a later fork (genesis fork < INTEROP),
+    ///         the runtime INTEROP feature flag on L1Block is NOT set at genesis. The flag will
+    ///         instead be flipped at the activation block by op-node's setFeature deposit wrapper.
+    function test_setL1Block_interopScheduledNotActive_succeeds() external {
+        _setInputInteropEnabled();
+        input.fork = uint256(Fork.ISTHMUS);
+        genesis.run(input);
+
+        assertEq(
+            IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isFeatureEnabled(Features.INTEROP),
+            false,
+            "INTEROP runtime flag must not be set at genesis when fork < INTEROP"
+        );
+    }
+
+    /// @notice Tests that when a chain is born at or beyond the Interop fork, the runtime INTEROP
+    ///         feature flag on L1Block IS set at genesis.
+    function test_setL1Block_interopAtGenesis_succeeds() external {
+        _setInputInteropEnabled();
+        input.fork = uint256(Fork.INTEROP);
+        genesis.run(input);
+
+        assertEq(
+            IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isFeatureEnabled(Features.INTEROP),
+            true,
+            "INTEROP runtime flag must be set at genesis when fork >= INTEROP"
+        );
+    }
+
+    /// @notice Sanity check: with useInterop disabled and fork < INTEROP, the runtime INTEROP flag
+    ///         is unset.
+    function test_setL1Block_interopDisabled_succeeds() external {
+        input.useInterop = false;
+        input.fork = uint256(Fork.ISTHMUS);
+        genesis.run(input);
+
+        assertEq(
+            IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isFeatureEnabled(Features.INTEROP),
+            false,
+            "INTEROP runtime flag must not be set when useInterop is false"
+        );
     }
 }


### PR DESCRIPTION
Cherry-pick of #20617 onto `proposal/op-contracts/v7.0.0`.

## Why

The OPCM registry parser derives the release version from `OPContractsManager.Version` (e.g. `7.1.17`), which has no prerelease suffix. This caused the v7.1.17 OPCM — listed in the live `superchain-registry` under section `[op-contracts/v7.0.0-rc.2]` — to be picked up as a stable release and applied during `PastUpgrades.runPastUpgrades`.

The OPCM expects `SystemConfig.delayedWETH()` to be non-zero on the forked chain, which it isn't at the current weekly-pinned op-mainnet block, so every L1 upgrade test fails in `setUp()` with `OPContractsManagerUtils_ProxyMustLoad("DelayedWETH")`. See #20813 CI failures.

The fix uses the release tag (e.g. `op-contracts/v7.0.0-rc.2`) as the version source, so `IsPrerelease()` correctly skips RC entries.


Stacked below https://github.com/ethereum-optimism/optimism/pull/20813