### PR TITLE
feat(proofs): update clock and air gap defaults

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -194,7 +194,7 @@ func DeploySuperchainToL1(l1Host *script.Host, opcmScripts *opcm.Scripts, superC
 		FaultGameV2MaxGameDepth:         big.NewInt(73),
 		FaultGameV2SplitDepth:           big.NewInt(30),
 		FaultGameV2ClockExtension:       big.NewInt(10800),
-		FaultGameV2MaxClockDuration:     big.NewInt(302400),
+		FaultGameV2MaxClockDuration:     big.NewInt(561600),
 		SuperchainProxyAdmin:            superDeployment.SuperchainProxyAdmin,
 		SuperchainConfigProxy:           superDeployment.SuperchainConfigProxy,
 		L1ProxyAdminOwner:               superCfg.ProxyAdminOwner,

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -298,7 +298,7 @@ func (r *InteropDevL2Recipe) build(l1ChainID uint64, addrs devkeys.Addresses) (*
 		DisputeMaxGameDepth:         73,
 		DisputeSplitDepth:           30,
 		DisputeClockExtension:       10800,  // 3 hours (input in seconds)
-		DisputeMaxClockDuration:     302400, // 3.5 days (input in seconds)
+		DisputeMaxClockDuration:     561600, // 6.5 days (input in seconds)
 		UseL2CM:                     r.UseL2CM,
 	}
 

--- a/op-deployer/pkg/deployer/opcm/implementations_test.go
+++ b/op-deployer/pkg/deployer/opcm/implementations_test.go
@@ -59,7 +59,7 @@ func TestNewDeployImplementationsScript(t *testing.T) {
 			FaultGameV2MaxGameDepth:         big.NewInt(73),
 			FaultGameV2SplitDepth:           big.NewInt(30),
 			FaultGameV2ClockExtension:       big.NewInt(10800),
-			FaultGameV2MaxClockDuration:     big.NewInt(302400),
+			FaultGameV2MaxClockDuration:     new(big.Int).SetUint64(standard.DisputeMaxClockDuration),
 			SuperchainConfigProxy:           proxyAddress,
 			SuperchainProxyAdmin:            proxyAdminAddress,
 			L1ProxyAdminOwner:               common.BigToAddress(big.NewInt(13)),

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -152,7 +152,7 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		DisputeMaxGameDepth:          new(big.Int).SetUint64(proofParams.DisputeMaxGameDepth),
 		DisputeSplitDepth:            new(big.Int).SetUint64(proofParams.DisputeSplitDepth),
 		DisputeClockExtension:        proofParams.DisputeClockExtension,   // 3 hours (input in seconds)
-		DisputeMaxClockDuration:      proofParams.DisputeMaxClockDuration, // 3.5 days (input in seconds)
+		DisputeMaxClockDuration:      proofParams.DisputeMaxClockDuration, // 6.5 days (input in seconds)
 		AllowCustomDisputeParameters: proofParams.DangerouslyAllowCustomDisputeParameters,
 		OperatorFeeScalar:            thisIntent.OperatorFeeScalar,
 		OperatorFeeConstant:          thisIntent.OperatorFeeConstant,

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -21,14 +21,14 @@ const (
 	WithdrawalDelaySeconds          uint64 = 302400
 	MinProposalSizeBytes            uint64 = 126000
 	ChallengePeriodSeconds          uint64 = 86400
-	ProofMaturityDelaySeconds       uint64 = 604800
-	DisputeGameFinalityDelaySeconds uint64 = 302400
+	ProofMaturityDelaySeconds       uint64 = 43200
+	DisputeGameFinalityDelaySeconds uint64 = 43200
 	MIPSVersion                     uint64 = 8
 	DisputeGameType                 uint32 = 1 // PERMISSIONED game type
 	DisputeMaxGameDepth             uint64 = 73
 	DisputeSplitDepth               uint64 = 30
 	DisputeClockExtension           uint64 = 10800
-	DisputeMaxClockDuration         uint64 = 302400
+	DisputeMaxClockDuration         uint64 = 561600
 	Eip1559DenominatorCanyon        uint64 = 250
 	Eip1559Denominator              uint64 = 50
 	Eip1559Elasticity               uint64 = 6

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -113,8 +113,8 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 			FaultGameWithdrawalDelay:        604800,
 			PreimageOracleMinProposalSize:   126000,
 			PreimageOracleChallengePeriod:   86400,
-			ProofMaturityDelaySeconds:       604800,
-			DisputeGameFinalityDelaySeconds: 302400,
+			ProofMaturityDelaySeconds:       43200,
+			DisputeGameFinalityDelaySeconds: 43200,
 		},
 	}
 

--- a/op-validator/pkg/validations/codes.go
+++ b/op-validator/pkg/validations/codes.go
@@ -91,7 +91,7 @@ var descriptions = map[string]string{
 	"PDDG-80":  "Permissioned dispute game clock extension not set to 10800",
 	"PDDG-90":  "Permissioned dispute game split depth not set to 30",
 	"PDDG-100": "Permissioned dispute game max game depth not set to 73",
-	"PDDG-110": "Permissioned dispute game max clock duration not set to 302400",
+	"PDDG-110": "Permissioned dispute game max clock duration not set to 561600",
 	"PDDG-120": "Permissioned dispute game challenger address mismatch",
 	"PDDG-130": "Permissioned dispute game challenger address mismatch (from game implementation)",
 	"PDDG-140": "Permissioned dispute game proposer address mismatch",
@@ -107,7 +107,7 @@ var descriptions = map[string]string{
 	"PLDG-80":  "Permissionless dispute game clock extension not set to 10800",
 	"PLDG-90":  "Permissionless dispute game split depth not set to 30",
 	"PLDG-100": "Permissionless dispute game max game depth not set to 73",
-	"PLDG-110": "Permissionless dispute game max clock duration not set to 302400",
+	"PLDG-110": "Permissionless dispute game max clock duration not set to 561600",
 
 	// Delayed WETH validations (for both PDDG and PLDG)
 	"PDDG-DWETH-10": "Permissioned dispute game delayed WETH version mismatch",
@@ -158,7 +158,7 @@ var descriptions = map[string]string{
 	"CKDG-80":         "Cannon Kona dispute game clock extension not set to 10800",
 	"CKDG-90":         "Cannon Kona dispute game split depth not set to 30",
 	"CKDG-100":        "Cannon Kona dispute game max game depth not set to 73",
-	"CKDG-110":        "Cannon Kona dispute game max clock duration not set to 302400",
+	"CKDG-110":        "Cannon Kona dispute game max clock duration not set to 561600",
 	"CKDG-120":        "Cannon Kona dispute game challenger address mismatch",
 	"CKDG-VM-10":      "Cannon Kona dispute game VM version mismatch",
 	"CKDG-VM-20":      "Cannon Kona dispute game VM implementation address mismatch",

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -198,7 +198,7 @@ contract DeployConfig is Script {
         faultGameV2MaxGameDepth = _readOr(_json, "$.faultGameV2MaxGameDepth", uint256(73));
         faultGameV2SplitDepth = _readOr(_json, "$.faultGameV2SplitDepth", uint256(30));
         faultGameV2ClockExtension = _readOr(_json, "$.faultGameV2ClockExtension", uint256(10800));
-        faultGameV2MaxClockDuration = _readOr(_json, "$.faultGameV2MaxClockDuration", uint256(302400));
+        faultGameV2MaxClockDuration = _readOr(_json, "$.faultGameV2MaxClockDuration", uint256(561600));
 
         zkDisputeGameInitBond = _readOr(_json, "$.zkDisputeGameInitBond", uint256(1 ether));
         zkDisputeGameAbsolutePrestate = bytes32(_readOr(_json, "$.zkDisputeGameAbsolutePrestate", uint256(0)));
@@ -364,13 +364,13 @@ contract DeployConfig is Script {
         faultGameMaxDepth = 73;
         faultGameSplitDepth = 30;
         faultGameClockExtension = 10800;
-        faultGameMaxClockDuration = 302400;
+        faultGameMaxClockDuration = 561600;
         faultGameWithdrawalDelay = 302400;
         preimageOracleMinProposalSize = 126000;
         preimageOracleChallengePeriod = 86400;
         systemConfigStartBlock = 0;
-        proofMaturityDelaySeconds = 604800;
-        disputeGameFinalityDelaySeconds = 302400;
+        proofMaturityDelaySeconds = 43200;
+        disputeGameFinalityDelaySeconds = 43200;
         respectedGameType = 0;
         useAltDA = false;
         daCommitmentType = "KeccakCommitment";
@@ -386,7 +386,7 @@ contract DeployConfig is Script {
         faultGameV2MaxGameDepth = 73;
         faultGameV2SplitDepth = 30;
         faultGameV2ClockExtension = 10800;
-        faultGameV2MaxClockDuration = 302400;
+        faultGameV2MaxClockDuration = 561600;
         zkDisputeGameInitBond = 1 ether;
         zkDisputeGameMaxChallengeDuration = 604800;
         zkDisputeGameMaxProveDuration = 259200;

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -1337,7 +1337,7 @@ contract VerifyOPCM is Script {
     /// @return True if delay values match expected.
     function _verifyPortalDelays(IOptimismPortal2 _portal) internal view returns (bool) {
         // nosemgrep: sol-style-vm-env-only-in-config-sol
-        uint256 expectedDelay = vm.envOr("EXPECTED_PROOF_MATURITY_DELAY_SECONDS", uint256(604800));
+        uint256 expectedDelay = vm.envOr("EXPECTED_PROOF_MATURITY_DELAY_SECONDS", uint256(43200));
         uint256 actualDelay = _portal.proofMaturityDelaySeconds();
 
         console.log("  Verifying PROOF_MATURITY_DELAY_SECONDS...");
@@ -1357,7 +1357,7 @@ contract VerifyOPCM is Script {
     /// @return True if delay values match expected.
     function _verifyAnchorStateRegistryDelays(IAnchorStateRegistry _asr) internal view returns (bool) {
         // nosemgrep: sol-style-vm-env-only-in-config-sol
-        uint256 expectedDelay = vm.envOr("EXPECTED_DISPUTE_GAME_FINALITY_DELAY_SECONDS", uint256(302400));
+        uint256 expectedDelay = vm.envOr("EXPECTED_DISPUTE_GAME_FINALITY_DELAY_SECONDS", uint256(43200));
         uint256 actualDelay = _asr.disputeGameFinalityDelaySeconds();
 
         console.log("  Verifying DISPUTE_GAME_FINALITY_DELAY_SECONDS...");

--- a/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
@@ -26,7 +26,7 @@ import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 uint256 constant EXPECTED_MAX_GAME_DEPTH = 73;
 uint256 constant EXPECTED_SPLIT_DEPTH = 30;
 uint256 constant EXPECTED_CLOCK_EXTENSION = 10800;
-uint256 constant EXPECTED_MAX_CLOCK_DURATION = 302400;
+uint256 constant EXPECTED_MAX_CLOCK_DURATION = 561600;
 string constant EXPECTED_PREIMAGE_ORACLE_VERSION = "1.1.5";
 uint256 constant EXPECTED_CHALLENGE_PERIOD = 86400;
 uint256 constant EXPECTED_MIN_PROPOSAL_SIZE = 126000;

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -61,7 +61,7 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         assertEq(output.faultDisputeGameImpl.splitDepth(), 30, "FaultDisputeGame splitDepth incorrect");
         assertEq(output.faultDisputeGameImpl.clockExtension().raw(), 10800, "FaultDisputeGame clockExtension incorrect");
         assertEq(
-            output.faultDisputeGameImpl.maxClockDuration().raw(), 302400, "FaultDisputeGame maxClockDuration incorrect"
+            output.faultDisputeGameImpl.maxClockDuration().raw(), 561600, "FaultDisputeGame maxClockDuration incorrect"
         );
 
         // Validate constructor args for PermissionedDisputeGame
@@ -76,7 +76,7 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         );
         assertEq(
             output.permissionedDisputeGameImpl.maxClockDuration().raw(),
-            302400,
+            561600,
             "PermissionedDisputeGame maxClockDuration incorrect"
         );
 
@@ -106,7 +106,7 @@ contract DeployImplementations_Test is Test, FeatureFlags {
             );
             assertEq(
                 output.superFaultDisputeGameImpl.maxClockDuration().raw(),
-                302400,
+                561600,
                 "SuperFaultDisputeGame maxClockDuration incorrect"
             );
 
@@ -128,7 +128,7 @@ contract DeployImplementations_Test is Test, FeatureFlags {
             );
             assertEq(
                 output.superPermissionedDisputeGameImpl.maxClockDuration().raw(),
-                302400,
+                561600,
                 "SuperPermissionedDisputeGame maxClockDuration incorrect"
             );
         } else {
@@ -528,7 +528,7 @@ contract DeployImplementations_Test is Test, FeatureFlags {
             73, // faultGameV2MaxGameDepth
             30, // faultGameV2SplitDepth
             10800, // faultGameV2ClockExtension
-            302400, // faultGameV2MaxClockDuration
+            561600, // faultGameV2MaxClockDuration
             superchainConfigProxy,
             superchainProxyAdmin,
             l1ProxyAdminOwner,

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -60,7 +60,7 @@ contract DeployOPChain_TestBase is Test, FeatureFlags {
     uint256 disputeMaxGameDepth = 73;
     uint256 disputeSplitDepth = 30;
     Duration disputeClockExtension = Duration.wrap(3 hours);
-    Duration disputeMaxClockDuration = Duration.wrap(3.5 days);
+    Duration disputeMaxClockDuration = Duration.wrap(6.5 days);
     address opcmAddr;
     ISuperchainConfig superchainConfig;
     bool useCustomGasToken = false;
@@ -94,7 +94,7 @@ contract DeployOPChain_TestBase is Test, FeatureFlags {
                 faultGameV2MaxGameDepth: 73,
                 faultGameV2SplitDepth: 30,
                 faultGameV2ClockExtension: 10800,
-                faultGameV2MaxClockDuration: 302400,
+                faultGameV2MaxClockDuration: 561600,
                 superchainConfigProxy: dso.superchainConfigProxy,
                 superchainProxyAdmin: dso.superchainProxyAdmin,
                 l1ProxyAdminOwner: dso.superchainProxyAdmin.owner(),


### PR DESCRIPTION
Updates the proof-game timing defaults to keep the optimistic withdrawal path at 7 days while reducing the portal and dispute-game finality air gaps to 12 hours each.

What changed:

- Set `PROOF_MATURITY_DELAY_SECONDS` defaults to 12 hours.
- Set `DISPUTE_GAME_FINALITY_DELAY_SECONDS` defaults to 12 hours.
- Increased standard dispute-game max clock duration to 6.5 days.
- Updated contracts-bedrock deploy config defaults, OPCM verification defaults, and standard validator expectations.
- Updated op-deployer defaults so generated deploy configs use the same timing values.
- Updated interopgen devnet max-clock wiring and op-validator messages that mention the expected max clock duration.

Note: this intentionally does not update superchain-registry standard params. Those values are owned by the SuperchainRegistry submodule and will be updated separately [here](https://github.com/ethereum-optimism/superchain-registry/pull/1232)

Tests were updated for the constants changes and run with:

- `forge test --match-path 'test/opcm/Deploy*.t.sol'`
- `forge test --match-path test/scripts/VerifyOPCM.t.sol`
- `go test ./op-chain-ops/interopgen ./op-validator/pkg/validations`
- `RUST_JIT_BUILD=1 go test -count=1 -timeout 30m -run '^TestInteropSystemNoop$' ./op-acceptance-tests/tests/interop/smoke/`

fixes https://github.com/ethereum-optimism/optimism/issues/20774
