### PR TITLE
op-supernode: fix backfill startup handoff

### DIFF
--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -43,6 +43,7 @@ type driverClient interface {
 }
 
 type SafeDBReader interface {
+	FirstSafeHead(ctx context.Context) (l1 eth.BlockID, l2 eth.BlockID, err error)
 	SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (l1 eth.BlockID, l2 eth.BlockID, err error)
 }
 

--- a/op-node/node/safedb/disabled.go
+++ b/op-node/node/safedb/disabled.go
@@ -22,6 +22,11 @@ func (d *DisabledDB) SafeHeadUpdated(_ eth.L2BlockRef, _ eth.BlockID) error {
 	return nil
 }
 
+func (d *DisabledDB) FirstSafeHead(_ context.Context) (l1 eth.BlockID, safeHead eth.BlockID, err error) {
+	err = ErrNotEnabled
+	return
+}
+
 func (d *DisabledDB) SafeHeadAtL1(_ context.Context, _ uint64) (l1 eth.BlockID, safeHead eth.BlockID, err error) {
 	err = ErrNotEnabled
 	return

--- a/op-node/node/safedb/safedb.go
+++ b/op-node/node/safedb/safedb.go
@@ -171,6 +171,30 @@ func (d *SafeDB) SafeHeadReset(safeHead eth.L2BlockRef) error {
 	}
 }
 
+func (d *SafeDB) FirstSafeHead(ctx context.Context) (l1Block eth.BlockID, safeHead eth.BlockID, err error) {
+	d.m.RLock()
+	defer d.m.RUnlock()
+	if d.closed {
+		err = ErrClosed
+		return
+	}
+	iter, err := d.db.NewIterWithContext(ctx, safeByL1BlockNumKey.IterRange())
+	if err != nil {
+		return
+	}
+	defer iter.Close()
+	if valid := iter.First(); !valid {
+		err = ErrNotFound
+		return
+	}
+	val, err := iter.ValueAndErr()
+	if err != nil {
+		return
+	}
+	l1Block, safeHead, err = decodeSafeByL1BlockNum(iter.Key(), val)
+	return
+}
+
 func (d *SafeDB) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (l1Block eth.BlockID, safeHead eth.BlockID, err error) {
 	d.m.RLock()
 	defer d.m.RUnlock()

--- a/op-node/node/safedb/safedb_test.go
+++ b/op-node/node/safedb/safedb_test.go
@@ -61,6 +61,11 @@ func TestStoreSafeHeads(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, l1b, actualL1)
 		require.Equal(t, l2b.ID(), actualL2)
+
+		actualL1, actualL2, err = db.FirstSafeHead(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, l1a, actualL1)
+		require.Equal(t, l2a.ID(), actualL2)
 	}
 	// Verify loading the safe heads with the already open DB
 	verifySafeHeads(db)
@@ -80,6 +85,8 @@ func TestSafeHeadAtL1_EmptyDatabase(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 	_, _, err = db.SafeHeadAtL1(context.Background(), 100)
+	require.ErrorIs(t, err, ErrNotFound)
+	_, _, err = db.FirstSafeHead(context.Background())
 	require.ErrorIs(t, err, ErrNotFound)
 }
 

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -341,6 +341,11 @@ func (m *mockSafeDBReader) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) 
 	return r[0].(eth.BlockID), r[1].(eth.BlockID), *r[2].(*error)
 }
 
+func (m *mockSafeDBReader) FirstSafeHead(ctx context.Context) (l1Hash eth.BlockID, l2Hash eth.BlockID, err error) {
+	r := m.Mock.MethodCalled("FirstSafeHead")
+	return r[0].(eth.BlockID), r[1].(eth.BlockID), *r[2].(*error)
+}
+
 func (m *mockSafeDBReader) ExpectSafeHeadAtL1(l1BlockNum uint64, l1 eth.BlockID, safeHead eth.BlockID, err error) {
 	m.Mock.On("SafeHeadAtL1", l1BlockNum).Return(l1, safeHead, &err)
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -146,7 +146,7 @@ type Interop struct {
 	// backfillEndTimestamp represents the end of the range of timestamps that were sealed by runLogBackfill.
 	// this is used for loop handoff from log backfill to main processing.
 	// firstVerifiableTimestamp is used to determine the start of the main processing loop, which is backfillEndTimestamp + 1
-	// after backfill, or the EL-finalized-derived startup timestamp when backfill was not used.
+	// after backfill, or the latched local-safe startup handoff when backfill was not used.
 	backfillEndTimestamp uint64
 	firstVerifiableSet   bool
 	firstVerifiable      uint64
@@ -202,7 +202,7 @@ func (i *Interop) Name() string {
 // to verify. If verification has already committed results, the first committed
 // timestamp is the durable handoff boundary. Otherwise it is backfillEndTimestamp+1
 // after log backfill, or — on cold start with no committed results and no
-// backfill range — the EL-finalized-derived startup timestamp.
+// backfill range — the latched local-safe startup handoff.
 func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if i.verifiedDB != nil {
 		if first, initialized := i.verifiedDB.FirstTimestamp(); initialized {
@@ -301,7 +301,12 @@ func (i *Interop) Start(ctx context.Context) error {
 				i.backfillEndTimestamp = end
 				break
 			}
-			i.log.Warn("log backfill failed, retrying (EL finalized head or chain data may not be ready yet)", "err", err)
+			if errors.Is(err, cc.ErrHistoryUnavailable) {
+				i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
+					"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
+				return fmt.Errorf("interop halted due to unavailable history: %w", err)
+			}
+			i.log.Warn("log backfill failed, retrying (startup handoff or chain data may not be ready yet)", "err", err)
 			for cid := range i.chains {
 				i.metrics.LogBackfillRetries.WithLabelValues(cid.String()).Inc()
 			}
@@ -340,7 +345,7 @@ func (i *Interop) Start(ctx context.Context) error {
 					"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
 				return fmt.Errorf("interop halted due to unavailable history: %w", err)
 			}
-			i.log.Warn("first verifiable timestamp unavailable, retrying (EL finalized head or chain data may not be ready yet)", "err", err)
+			i.log.Warn("first verifiable timestamp unavailable, retrying (startup handoff or chain data may not be ready yet)", "err", err)
 			select {
 			case <-i.ctx.Done():
 				return fmt.Errorf("first verifiable timestamp interrupted: %w", i.ctx.Err())

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -146,7 +146,7 @@ type Interop struct {
 	// backfillEndTimestamp represents the end of the range of timestamps that were sealed by runLogBackfill.
 	// this is used for loop handoff from log backfill to main processing.
 	// firstVerifiableTimestamp is used to determine the start of the main processing loop, which is backfillEndTimestamp + 1
-	// after backfill, or the latched local-safe startup handoff when backfill was not used.
+	// after backfill, or the latched SafeDB startup handoff when backfill was not used.
 	backfillEndTimestamp uint64
 	firstVerifiableSet   bool
 	firstVerifiable      uint64
@@ -202,7 +202,7 @@ func (i *Interop) Name() string {
 // to verify. If verification has already committed results, the first committed
 // timestamp is the durable handoff boundary. Otherwise it is backfillEndTimestamp+1
 // after log backfill, or — on cold start with no committed results and no
-// backfill range — the latched local-safe startup handoff.
+// backfill range — the latched SafeDB startup handoff.
 func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if i.verifiedDB != nil {
 		if first, initialized := i.verifiedDB.FirstTimestamp(); initialized {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -143,10 +143,9 @@ type Interop struct {
 	chains              map[eth.ChainID]cc.InteropChain
 	activationTimestamp uint64 // immutable protocol activation timestamp
 
-	// backfillEndTimestamp represents the end of the range of timestamps that were sealed by runLogBackfill.
-	// this is used for loop handoff from log backfill to main processing.
-	// firstVerifiableTimestamp is used to determine the start of the main processing loop, which is backfillEndTimestamp + 1
-	// after backfill, or the latched SafeDB startup handoff when backfill was not used.
+	// backfillEndTimestamp is the inclusive end of the cold-start log range
+	// sealed before normal verification starts. It is only set when verifiedDB
+	// is empty and SafeDB coverage begins after activation.
 	backfillEndTimestamp uint64
 	firstVerifiableSet   bool
 	firstVerifiable      uint64
@@ -198,11 +197,10 @@ func (i *Interop) Name() string {
 	return "interop"
 }
 
-// firstVerifiableTimestamp is the earliest timestamp the main loop will attempt
-// to verify. If verification has already committed results, the first committed
-// timestamp is the durable handoff boundary. Otherwise it is backfillEndTimestamp+1
-// after log backfill, or — on cold start with no committed results and no
-// backfill range — the latched SafeDB startup handoff.
+// firstVerifiableTimestamp is the earliest timestamp covered by this node's
+// verifier state. With an initialized verifiedDB this is the first committed
+// timestamp. On cold start it is the post-activation handoff chosen by startup
+// backfill, or activation if no backfill range is needed.
 func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if i.verifiedDB != nil {
 		if first, initialized := i.verifiedDB.FirstTimestamp(); initialized {
@@ -292,7 +290,7 @@ func (i *Interop) Start(ctx context.Context) error {
 	i.started = true
 	i.mu.Unlock()
 
-	if i.logBackfillDepth > 0 {
+	if i.shouldRunStartupLogBackfill() {
 		i.log.Info("interop log backfill depth configured", "duration", i.logBackfillDepth.String())
 		for {
 			i.backfillAttempts.Add(1)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -290,66 +290,12 @@ func (i *Interop) Start(ctx context.Context) error {
 	i.started = true
 	i.mu.Unlock()
 
-	if i.shouldRunStartupLogBackfill() {
-		i.log.Info("interop log backfill depth configured", "duration", i.logBackfillDepth.String())
-		for {
-			i.backfillAttempts.Add(1)
-			end, err := i.runLogBackfill()
-			if err == nil {
-				i.backfillEndTimestamp = end
-				break
-			}
-			if errors.Is(err, cc.ErrHistoryUnavailable) {
-				i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
-					"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
-				return fmt.Errorf("interop halted due to unavailable history: %w", err)
-			}
-			i.log.Warn("log backfill failed, retrying (startup handoff or chain data may not be ready yet)", "err", err)
-			for cid := range i.chains {
-				i.metrics.LogBackfillRetries.WithLabelValues(cid.String()).Inc()
-			}
-			select {
-			case <-i.ctx.Done():
-				return fmt.Errorf("log backfill interrupted: %w", i.ctx.Err())
-			case <-time.After(errorBackoffPeriod):
-			}
-		}
+	if err := i.runStartupLogBackfill(); err != nil {
+		return err
 	}
-	i.backfillCompleted.Store(true)
-	i.log.Info("log backfill complete", "backfillEndTimestamp", i.backfillEndTimestamp)
-
-	firstVerifiableLog := uint64(0)
-	if i.backfillEndTimestamp != 0 {
-		firstVerifiableLog = i.backfillEndTimestamp + 1
-		if firstVerifiableLog < i.activationTimestamp {
-			firstVerifiableLog = i.activationTimestamp
-		}
-	} else if lastTS, initialized := i.verifiedDB.LastTimestamp(); initialized {
-		// Resume from the last commit to keep verifiedDB gap-free.
-		firstVerifiableLog = lastTS + 1
-	} else {
-		for {
-			first, err := i.readyFirstVerifiableTimestamp(i.ctx)
-			if err == nil {
-				i.firstVerifiable = first
-				i.firstVerifiableSet = true
-				firstVerifiableLog = first
-				break
-			}
-			// Permanent SafeDB gap must halt normal startup cleanly. Backfill-enabled
-			// startup reaches this path only if backfill had no range to seal.
-			if errors.Is(err, cc.ErrHistoryUnavailable) {
-				i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
-					"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
-				return fmt.Errorf("interop halted due to unavailable history: %w", err)
-			}
-			i.log.Warn("first verifiable timestamp unavailable, retrying (startup handoff or chain data may not be ready yet)", "err", err)
-			select {
-			case <-i.ctx.Done():
-				return fmt.Errorf("first verifiable timestamp interrupted: %w", i.ctx.Err())
-			case <-time.After(errorBackoffPeriod):
-			}
-		}
+	firstVerifiableLog, err := i.startupFirstVerifiableTimestamp()
+	if err != nil {
+		return err
 	}
 	i.log.Info("interop first verifiable timestamp resolved",
 		"activationTimestamp", i.activationTimestamp,
@@ -365,9 +311,7 @@ func (i *Interop) Start(ctx context.Context) error {
 				// Permanent SafeDB gap: log once and halt — retrying cannot fix it.
 				if errors.Is(err, cc.ErrHistoryUnavailable) {
 					i.metrics.ActivityErrors.WithLabelValues("interop", "history_unavailable").Inc()
-					i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
-						"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
-					return fmt.Errorf("interop halted due to unavailable history: %w", err)
+					return i.haltOnUnavailableHistory(err)
 				}
 				i.metrics.ActivityErrors.WithLabelValues("interop", "progress").Inc()
 				i.log.Error("failed to progress and record interop", "err", err)
@@ -381,6 +325,78 @@ func (i *Interop) Start(ctx context.Context) error {
 			// Otherwise: immediately ready for next iteration (aggressive catch-up)
 		}
 	}
+}
+
+// runStartupLogBackfill seals the cold-start log window when the verifier has
+// no committed state yet. Warm restarts skip this phase and resume directly
+// from verifiedDB.
+func (i *Interop) runStartupLogBackfill() error {
+	if !i.shouldRunStartupLogBackfill() {
+		i.backfillCompleted.Store(true)
+		return nil
+	}
+
+	i.log.Info("interop log backfill starting", "duration", i.logBackfillDepth.String())
+	for {
+		i.backfillAttempts.Add(1)
+		end, err := i.runLogBackfill()
+		if err == nil {
+			i.backfillEndTimestamp = end
+			i.backfillCompleted.Store(true)
+			i.log.Info("interop log backfill complete", "backfillEndTimestamp", end)
+			return nil
+		}
+		if errors.Is(err, cc.ErrHistoryUnavailable) {
+			return i.haltOnUnavailableHistory(err)
+		}
+		i.log.Warn("log backfill failed, retrying (startup handoff or chain data may not be ready yet)", "err", err)
+		for cid := range i.chains {
+			i.metrics.LogBackfillRetries.WithLabelValues(cid.String()).Inc()
+		}
+		select {
+		case <-i.ctx.Done():
+			return fmt.Errorf("log backfill interrupted: %w", i.ctx.Err())
+		case <-time.After(errorBackoffPeriod):
+		}
+	}
+}
+
+// startupFirstVerifiableTimestamp returns the first timestamp the main loop
+// should try after startup has completed any required backfill.
+func (i *Interop) startupFirstVerifiableTimestamp() (uint64, error) {
+	if i.backfillEndTimestamp != 0 {
+		return max(i.activationTimestamp, i.backfillEndTimestamp+1), nil
+	}
+	if lastTS, initialized := i.verifiedDBLastTimestamp(); initialized {
+		return lastTS + 1, nil
+	}
+	return i.waitForReadyFirstVerifiableTimestamp()
+}
+
+func (i *Interop) waitForReadyFirstVerifiableTimestamp() (uint64, error) {
+	for {
+		first, err := i.readyFirstVerifiableTimestamp(i.ctx)
+		if err == nil {
+			i.firstVerifiable = first
+			i.firstVerifiableSet = true
+			return first, nil
+		}
+		if errors.Is(err, cc.ErrHistoryUnavailable) {
+			return 0, i.haltOnUnavailableHistory(err)
+		}
+		i.log.Warn("first verifiable timestamp unavailable, retrying (startup handoff or chain data may not be ready yet)", "err", err)
+		select {
+		case <-i.ctx.Done():
+			return 0, fmt.Errorf("first verifiable timestamp interrupted: %w", i.ctx.Err())
+		case <-time.After(errorBackoffPeriod):
+		}
+	}
+}
+
+func (i *Interop) haltOnUnavailableHistory(err error) error {
+	i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
+		"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
+	return fmt.Errorf("interop halted due to unavailable history: %w", err)
 }
 
 // readyFirstVerifiableTimestamp resolves the first timestamp that still needs

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -189,9 +189,9 @@ func TestInteropActivationTimestampFlagEnvVar(t *testing.T) {
 Spec: firstVerifiableTimestamp is the common interop startup readiness gate.
 
   - If verifiedDB is initialized, it returns the first committed timestamp.
-  - It returns an error while the EL finalized head is unavailable or unset.
+  - It returns an error while sync status or local-safe progress is unavailable.
   - Once ready, it returns activation when there are no chains, or one past the
-    minimum EL finalized timestamp across chains otherwise.
+    newest local-safe timestamp across chains otherwise.
   - The no-backfill startup path uses that same timestamp for its first
     verification attempt.
 */
@@ -210,41 +210,44 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			want: 100,
 		},
 		{
-			name: "EL finalized error blocks startup",
+			name: "sync status error blocks startup",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.elFinalizedHeadErr = errors.New("EL finalized not ready")
+						m.syncStatusOverride = func() (*eth.SyncStatus, error) {
+							return nil, errors.New("sync status not ready")
+						}
 					}).
 					Build()
 			},
 			wantErr: true,
 		},
 		{
-			name: "empty EL finalized response blocks startup",
+			name: "empty local safe response blocks startup",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.elFinalizedHeadSet = true
+						m.syncStatusFull = &eth.SyncStatus{}
 					}).
 					Build()
 			},
 			wantErr: true,
 		},
 		{
-			name: "EL finalized at genesis with a real hash is accepted",
+			name: "local safe at genesis with a real hash is accepted",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.elFinalizedHead = eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123")}
-						m.elFinalizedHeadSet = true
+						m.syncStatusFull = &eth.SyncStatus{
+							LocalSafeL2: eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123")},
+						}
 					}).
 					Build()
 			},
 			want: 100,
 		},
 		{
-			name: "EL finalized before activation returns activation",
+			name: "local safe before activation returns activation",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
@@ -258,7 +261,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			want: 100,
 		},
 		{
-			name: "EL finalized at activation returns timestamp after activation",
+			name: "local safe at activation returns timestamp after activation",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
@@ -272,7 +275,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			want: 101,
 		},
 		{
-			name: "returns timestamp after minimum EL finalized across chains",
+			name: "returns timestamp after newest local safe across chains",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
@@ -289,15 +292,13 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 					}).
 					Build()
 			},
-			want: 126,
+			want: 141,
 		},
 		{
-			name: "uses EL finalized when sync status safe is stale",
+			name: "uses local safe when sync status safe is stale",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.elFinalizedHead = eth.L2BlockRef{Number: 125, Time: 125}
-						m.elFinalizedHeadSet = true
 						m.syncStatusFull = &eth.SyncStatus{
 							SafeL2:      eth.L2BlockRef{Number: 0, Time: 100},
 							LocalSafeL2: eth.L2BlockRef{Number: 200, Time: 200},
@@ -305,7 +306,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 					}).
 					Build()
 			},
-			want: 126,
+			want: 201,
 		},
 	}
 
@@ -481,7 +482,7 @@ func TestStartWithoutBackfillResumesFromVerifiedDBIgnoringELFinalized(t *testing
 		"warm-restart startup must not consult EL finalized when verifiedDB is initialized")
 }
 
-func TestStartWithBackfillRunsBeforeSafeDBReadyCheck(t *testing.T) {
+func TestStartWithBackfillHaltsWhenStartupHandoffHistoryUnavailable(t *testing.T) {
 	const activation = uint64(100)
 	const safe = uint64(125)
 
@@ -509,20 +510,11 @@ func TestStartWithBackfillRunsBeforeSafeDBReadyCheck(t *testing.T) {
 	}
 	require.ErrorIs(t, err, cc.ErrHistoryUnavailable)
 	require.Equal(t, int32(1), h.interop.BackfillAttempts())
-	require.Equal(t, safe, h.interop.BackfillEndTimestamp())
+	require.Zero(t, h.interop.BackfillEndTimestamp())
 
-	first, err := h.interop.FirstSealedBlock(eth.ChainIDFromUInt64(10))
+	_, ok, err := h.interop.LatestSealedBlock(eth.ChainIDFromUInt64(10))
 	require.NoError(t, err)
-	// The first real backfilled block is 120, and the logs DB records its
-	// virtual parent as the first sealed block.
-	require.Equal(t, uint64(119), first.Number)
-	require.Equal(t, uint64(120), first.Timestamp)
-
-	latest, ok, err := h.interop.LatestSealedBlock(eth.ChainIDFromUInt64(10))
-	require.NoError(t, err)
-	require.True(t, ok)
-	require.Equal(t, safe, latest.Number)
-	require.Equal(t, safe, latest.Timestamp)
+	require.False(t, ok, "logs must not be sealed when startup handoff SafeDB history is unavailable")
 }
 
 // =============================================================================
@@ -846,7 +838,7 @@ func TestProgressInterop(t *testing.T) {
 		run      func(t *testing.T, h *interopTestHarness) // override for complex cases
 	}{
 		{
-			name: "not initialized uses first timestamp after finalized head",
+			name: "not initialized uses activation timestamp",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(5000).WithChain(10, func(m *mockChainContainer) {
 					m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
@@ -1211,7 +1203,7 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 			}).
 			Build()
 			// 126 > activation and >= firstVerifiable (resolves to 101 from
-			// EL finalized time 100); no entry yet -> ethereum.NotFound.
+			// local safe time 100); no entry yet -> ethereum.NotFound.
 		_, _, err := h.interop.VerifiedResultAtTimestamp(126)
 		require.ErrorIs(t, err, ethereum.NotFound)
 		require.NotErrorIs(t, err, ErrNotActive)
@@ -1222,7 +1214,7 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 		h := newInteropTestHarness(t).
 			WithActivation(100).
 			WithChain(10, func(m *mockChainContainer) {
-				// EL finalized time 500 -> firstVerifiable=501. ts=200 is post
+				// Local safe time 500 -> firstVerifiable=501. ts=200 is post
 				// activation but below firstVerifiable on this node.
 				m.syncStatusFull = &eth.SyncStatus{
 					SafeL2:      eth.L2BlockRef{Number: 500, Time: 500},
@@ -1294,7 +1286,7 @@ func TestNoopVerifiedResultReader(t *testing.T) {
 	var r VerifiedResultReader = NoopVerifiedResultReader{}
 	for _, ts := range []uint64{0, 1, 1000, 1 << 60} {
 		_, _, err := r.VerifiedResultAtTimestamp(ts)
-		require.ErrorIs(t, err, ErrNotActive)
+		require.ErrorIs(t, err, ErrInteropDisabled)
 	}
 }
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -189,9 +189,9 @@ func TestInteropActivationTimestampFlagEnvVar(t *testing.T) {
 Spec: firstVerifiableTimestamp is the common interop startup readiness gate.
 
   - If verifiedDB is initialized, it returns the first committed timestamp.
-  - It returns an error while sync status or local-safe progress is unavailable.
-  - Once ready, it returns activation when there are no chains, or one past the
-    newest local-safe timestamp across chains otherwise.
+  - It returns an error while SafeDB coverage is unavailable.
+  - Once ready, it returns activation when there are no chains, or the newest
+    first-SafeDB-covered timestamp across chains otherwise.
   - The no-backfill startup path uses that same timestamp for its first
     verification attempt.
 */
@@ -210,95 +210,92 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			want: 100,
 		},
 		{
-			name: "sync status error blocks startup",
+			name: "SafeDB first entry error blocks startup",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.syncStatusOverride = func() (*eth.SyncStatus, error) {
-							return nil, errors.New("sync status not ready")
-						}
+						m.firstSafeHeadErr = errors.New("safedb not ready")
 					}).
 					Build()
 			},
 			wantErr: true,
 		},
 		{
-			name: "empty local safe response blocks startup",
+			name: "empty first SafeDB entry blocks startup",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.syncStatusFull = &eth.SyncStatus{}
+						m.firstSafeHeadSet = true
 					}).
 					Build()
 			},
 			wantErr: true,
 		},
 		{
-			name: "local safe at genesis with a real hash is accepted",
+			name: "first SafeDB entry at genesis with a real hash is accepted",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.syncStatusFull = &eth.SyncStatus{
-							LocalSafeL2: eth.L2BlockRef{Number: 0, Hash: common.HexToHash("0xabc123")},
-						}
+						m.firstSafeHeadSet = true
+						m.firstSafeL1 = eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")}
+						m.firstSafeL2 = eth.BlockID{Number: 0, Hash: common.HexToHash("0xabc123")}
 					}).
 					Build()
 			},
 			want: 100,
 		},
 		{
-			name: "local safe before activation returns activation",
+			name: "first SafeDB entry before activation returns activation",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.syncStatusFull = &eth.SyncStatus{
-							SafeL2:      eth.L2BlockRef{Number: 99, Time: 99},
-							LocalSafeL2: eth.L2BlockRef{Number: 99, Time: 99},
-						}
+						m.firstSafeHeadSet = true
+						m.firstSafeL1 = eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")}
+						m.firstSafeL2 = eth.BlockID{Number: 99, Hash: common.BigToHash(big.NewInt(99))}
 					}).
 					Build()
 			},
 			want: 100,
 		},
 		{
-			name: "local safe at activation returns timestamp after activation",
+			name: "first SafeDB entry at activation returns timestamp after activation",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.syncStatusFull = &eth.SyncStatus{
-							SafeL2:      eth.L2BlockRef{Number: 100, Time: 100},
-							LocalSafeL2: eth.L2BlockRef{Number: 100, Time: 100},
-						}
+						m.firstSafeHeadSet = true
+						m.firstSafeL1 = eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")}
+						m.firstSafeL2 = eth.BlockID{Number: 100, Hash: common.BigToHash(big.NewInt(100))}
 					}).
 					Build()
 			},
 			want: 101,
 		},
 		{
-			name: "returns timestamp after newest local safe across chains",
+			name: "returns newest first SafeDB-covered timestamp across chains",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
-						m.syncStatusFull = &eth.SyncStatus{
-							SafeL2:      eth.L2BlockRef{Number: 140, Time: 140},
-							LocalSafeL2: eth.L2BlockRef{Number: 140, Time: 140},
-						}
+						m.firstSafeHeadSet = true
+						m.firstSafeL1 = eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")}
+						m.firstSafeL2 = eth.BlockID{Number: 140, Hash: common.BigToHash(big.NewInt(140))}
 					}).
 					WithChain(20, func(m *mockChainContainer) {
-						m.syncStatusFull = &eth.SyncStatus{
-							SafeL2:      eth.L2BlockRef{Number: 125, Time: 125},
-							LocalSafeL2: eth.L2BlockRef{Number: 125, Time: 125},
-						}
+						m.firstSafeHeadSet = true
+						m.firstSafeL1 = eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")}
+						m.firstSafeL2 = eth.BlockID{Number: 125, Hash: common.BigToHash(big.NewInt(125))}
 					}).
 					Build()
 			},
 			want: 141,
 		},
 		{
-			name: "uses local safe when sync status safe is stale",
+			name: "uses SafeDB when sync status is stale",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
+						m.firstSafeHeadSet = true
+						m.firstSafeL1 = eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")}
+						m.firstSafeL2 = eth.BlockID{Number: 180, Hash: common.BigToHash(big.NewInt(180))}
 						m.syncStatusFull = &eth.SyncStatus{
 							SafeL2:      eth.L2BlockRef{Number: 0, Time: 100},
 							LocalSafeL2: eth.L2BlockRef{Number: 200, Time: 200},
@@ -306,7 +303,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 					}).
 					Build()
 			},
-			want: 201,
+			want: 181,
 		},
 	}
 
@@ -1203,7 +1200,7 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 			}).
 			Build()
 			// 126 > activation and >= firstVerifiable (resolves to 101 from
-			// local safe time 100); no entry yet -> ethereum.NotFound.
+			// first SafeDB timestamp 100); no entry yet -> ethereum.NotFound.
 		_, _, err := h.interop.VerifiedResultAtTimestamp(126)
 		require.ErrorIs(t, err, ethereum.NotFound)
 		require.NotErrorIs(t, err, ErrNotActive)
@@ -1214,7 +1211,7 @@ func TestVerifiedResultAtTimestamp(t *testing.T) {
 		h := newInteropTestHarness(t).
 			WithActivation(100).
 			WithChain(10, func(m *mockChainContainer) {
-				// Local safe time 500 -> firstVerifiable=501. ts=200 is post
+				// First SafeDB timestamp 500 -> firstVerifiable=501. ts=200 is post
 				// activation but below firstVerifiable on this node.
 				m.syncStatusFull = &eth.SyncStatus{
 					SafeL2:      eth.L2BlockRef{Number: 500, Time: 500},
@@ -1290,7 +1287,7 @@ func TestNoopVerifiedResultReader(t *testing.T) {
 	}
 }
 
-func TestFirstVerifiableTimestampRestoresSafeHeadHandoffAfterRestart(t *testing.T) {
+func TestFirstVerifiableTimestampRestoresSafeDBHandoffAfterRestart(t *testing.T) {
 	t.Parallel()
 
 	dataDir := t.TempDir()
@@ -2029,6 +2026,12 @@ type mockChainContainer struct {
 	optimisticL1    eth.BlockID
 	optimisticAtErr error
 
+	firstSafeL1       eth.BlockID
+	firstSafeL2       eth.BlockID
+	firstSafeHeadSet  bool
+	firstSafeHeadErr  error
+	firstSafeOverride func(context.Context) (eth.BlockID, eth.BlockID, error)
+
 	// If set, SyncStatus returns this instead of synthesizing from currentL1 only.
 	syncStatusFull          *eth.SyncStatus
 	syncStatusOverride      func() (*eth.SyncStatus, error)
@@ -2100,7 +2103,30 @@ func (m *mockChainContainer) BlockNumberToTimestamp(ctx context.Context, blocknu
 	if m.blockNumberToTimestampOverride != nil {
 		return m.blockNumberToTimestampOverride(ctx, blocknum)
 	}
-	return 0, nil
+	return blocknum, nil
+}
+
+func (m *mockChainContainer) FirstSafeHead(ctx context.Context) (eth.BlockID, eth.BlockID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.firstSafeHeadErr != nil {
+		return eth.BlockID{}, eth.BlockID{}, m.firstSafeHeadErr
+	}
+	if m.firstSafeOverride != nil {
+		return m.firstSafeOverride(ctx)
+	}
+	if m.firstSafeHeadSet {
+		return m.firstSafeL1, m.firstSafeL2, nil
+	}
+	if m.syncStatusFull != nil && m.syncStatusFull.LocalSafeL2 != (eth.L2BlockRef{}) {
+		return eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")}, m.syncStatusFull.LocalSafeL2.ID(), nil
+	}
+	safeNum := m.defaultSafeTime
+	if safeNum == 0 {
+		safeNum = 1
+	}
+	return eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")},
+		eth.BlockID{Number: safeNum, Hash: common.BigToHash(new(big.Int).SetUint64(safeNum))}, nil
 }
 func (m *mockChainContainer) ELFinalizedHead(ctx context.Context) (eth.L2BlockRef, error) {
 	m.mu.Lock()

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -186,12 +186,13 @@ func TestInteropActivationTimestampFlagEnvVar(t *testing.T) {
 }
 
 /*
-Spec: firstVerifiableTimestamp is the common interop startup readiness gate.
+Spec: firstVerifiableTimestamp is the common cold-start readiness gate.
 
-  - If verifiedDB is initialized, it returns the first committed timestamp.
+  - If verifiedDB is initialized, verifier state already exists and this returns
+    the first committed timestamp.
   - It returns an error while SafeDB coverage is unavailable.
   - Once ready, it returns activation when there are no chains, or the newest
-    first-SafeDB-covered timestamp across chains otherwise.
+    first-SafeDB-covered timestamp plus one across chains otherwise.
   - The no-backfill startup path uses that same timestamp for its first
     verification attempt.
 */
@@ -421,9 +422,9 @@ func TestStartWithoutBackfillUsesFirstVerifiableTimestamp(t *testing.T) {
 	require.ErrorIs(t, <-done, context.Canceled)
 }
 
-// Warm restart with no backfill must resume from verifiedDB without consulting
-// EL finalized.
-func TestStartWithoutBackfillResumesFromVerifiedDBIgnoringELFinalized(t *testing.T) {
+// Warm restart must resume from verifiedDB without consulting EL finalized or
+// running startup backfill, even when backfill is configured.
+func TestStartWithVerifiedDBResumesWithoutBackfillOrELFinalized(t *testing.T) {
 	const (
 		activation   uint64 = 100
 		lastVerified uint64 = 195
@@ -432,6 +433,7 @@ func TestStartWithoutBackfillResumesFromVerifiedDBIgnoringELFinalized(t *testing
 	var elFinalizedCalls atomic.Int32
 	h := newInteropTestHarness(t).
 		WithActivation(activation).
+		WithLogBackfillDepth(60*time.Second).
 		WithChain(10, func(m *mockChainContainer) {
 			m.elFinalizedHeadOverride = func() (eth.L2BlockRef, error) {
 				elFinalizedCalls.Add(1)
@@ -475,6 +477,8 @@ func TestStartWithoutBackfillResumesFromVerifiedDBIgnoringELFinalized(t *testing
 	}
 
 	require.ErrorIs(t, <-done, context.Canceled)
+	require.Zero(t, h.interop.BackfillAttempts(),
+		"warm-restart startup must not run log backfill when verifiedDB is initialized")
 	require.Zero(t, elFinalizedCalls.Load(),
 		"warm-restart startup must not consult EL finalized when verifiedDB is initialized")
 }

--- a/op-supernode/supernode/activity/interop/interop_test_access.go
+++ b/op-supernode/supernode/activity/interop/interop_test_access.go
@@ -64,15 +64,14 @@ func (i *Interop) ActivationTimestamp() uint64 {
 }
 
 // BackfillEndTimestamp returns the inclusive last timestamp whose logs were
-// sealed by runLogBackfill, or 0 if backfill has not run. The main loop
-// starts verification at BackfillEndTimestamp()+1 (or ActivationTimestamp()
-// when backfill was skipped).
+// sealed by runLogBackfill, or 0 if startup backfill was skipped or had no
+// post-activation range.
 func (i *Interop) BackfillEndTimestamp() uint64 {
 	return i.backfillEndTimestamp
 }
 
-// FirstVerifiableTimestamp returns the timestamp at which the main loop begins
-// verification. It is intended for tests after startup has completed.
+// FirstVerifiableTimestamp returns the first timestamp covered by this node's
+// verifier state. It is intended for tests after startup has completed.
 func (i *Interop) FirstVerifiableTimestamp() uint64 {
 	ts, err := i.firstVerifiableTimestamp(context.Background())
 	if err != nil {

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -3,7 +3,6 @@ package interop
 import (
 	"context"
 	"fmt"
-	"math"
 	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -12,7 +11,8 @@ import (
 
 // resolveFirstVerifiableTimestamp returns the first timestamp not yet covered
 // by durable local state: verifiedDB.LastTimestamp+1 when initialized,
-// otherwise the minimum EL finalized head + 1 (clamped to activation).
+// otherwise a latched cold-start handoff derived from the newest local-safe
+// progress across all chains (clamped to activation).
 func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if len(i.chains) == 0 {
 		return i.activationTimestamp, nil
@@ -22,37 +22,41 @@ func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, 
 			return lastTS + 1, nil
 		}
 	}
-	minELFinalizedTime, err := i.minELFinalizedTime(ctx)
+	if i.firstVerifiableSet {
+		return i.firstVerifiable, nil
+	}
+	maxLocalSafeTime, err := i.maxLocalSafeTime(ctx)
 	if err != nil {
 		return 0, err
 	}
-	if minELFinalizedTime < i.activationTimestamp {
-		return i.activationTimestamp, nil
+	first := i.activationTimestamp
+	if maxLocalSafeTime >= i.activationTimestamp {
+		first = maxLocalSafeTime + 1
 	}
-	return minELFinalizedTime + 1, nil
+	i.firstVerifiable = first
+	i.firstVerifiableSet = true
+	return first, nil
 }
 
-func (i *Interop) minELFinalizedTime(ctx context.Context) (uint64, error) {
-	if len(i.chains) == 0 {
-		return i.activationTimestamp, nil
-	}
-
-	minELFinalizedTime := uint64(math.MaxUint64)
+func (i *Interop) maxLocalSafeTime(ctx context.Context) (uint64, error) {
+	maxLocalSafeTime := uint64(0)
 	for _, chain := range i.chains {
-		elFinalized, err := chain.ELFinalizedHead(ctx)
+		status, err := chain.SyncStatus(ctx)
 		if err != nil {
-			return 0, fmt.Errorf("chain %s: EL finalized head: %w", chain.ID(), err)
+			return 0, fmt.Errorf("chain %s: sync status: %w", chain.ID(), err)
 		}
-		// Genesis (Number == 0) with a real hash is a legitimate finalized head;
-		// only reject the zero-value response from an EL that isn't ready yet.
-		if elFinalized == (eth.L2BlockRef{}) {
-			return 0, fmt.Errorf("chain %s: EL finalized head not yet available", chain.ID())
+		if status == nil {
+			return 0, fmt.Errorf("chain %s: sync status unavailable", chain.ID())
 		}
-		i.log.Debug("first verifiable timestamp: EL finalized head",
-			"chain", chain.ID(), "elFinalized", elFinalized)
-		minELFinalizedTime = min(minELFinalizedTime, elFinalized.Time)
+		localSafe := status.LocalSafeL2
+		if localSafe == (eth.L2BlockRef{}) {
+			return 0, fmt.Errorf("chain %s: local safe head not yet available", chain.ID())
+		}
+		i.log.Debug("first verifiable timestamp: local safe handoff",
+			"chain", chain.ID(), "localSafe", localSafe)
+		maxLocalSafeTime = max(maxLocalSafeTime, localSafe.Time)
 	}
-	return minELFinalizedTime, nil
+	return maxLocalSafeTime, nil
 }
 
 func (i *Interop) runLogBackfill() (uint64, error) {
@@ -66,7 +70,7 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	firstVerifiable := i.firstVerifiable
 	if !i.firstVerifiableSet {
 		var err error
-		firstVerifiable, err = i.resolveFirstVerifiableTimestamp(i.ctx)
+		firstVerifiable, err = i.readyFirstVerifiableTimestamp(i.ctx)
 		if err != nil {
 			return 0, err
 		}
@@ -77,7 +81,7 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	endTime := firstVerifiable - 1
 
 	// naively, end minus depth is the ideal backfill start.
-	// guard the subtraction so a young chain (EL finalized < depth) doesn't wrap.
+	// guard the subtraction so a young handoff timestamp doesn't wrap.
 	depthSec := uint64(i.logBackfillDepth.Seconds())
 	var idealStart uint64
 	if endTime >= depthSec {

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -14,10 +14,11 @@ import (
 //
 // Startup has three cases:
 //   - with an initialized verifiedDB, resume at LastTimestamp+1;
-//   - with no post-activation SafeDB gap, begin at activation;
-//   - with an empty verifiedDB and post-activation SafeDB coverage, latch a
-//     cold-start handoff from the first SafeDB-covered timestamp across all
-//     chains.
+//   - with an empty verifiedDB and SafeDB coverage before activation, begin
+//     at activation;
+//   - with an empty verifiedDB and SafeDB coverage after activation, latch a
+//     cold-start handoff from the newest first SafeDB-covered timestamp across
+//     all chains.
 //
 // Starting after the first SafeDB entry leaves the entry itself available as
 // the frontier block when persisting the first verified timestamp.
@@ -25,17 +26,20 @@ func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, 
 	if lastTS, initialized := i.verifiedDBLastTimestamp(); initialized {
 		return lastTS + 1, nil
 	}
-	if len(i.chains) == 0 || i.firstVerifiableSet {
-		return max(i.activationTimestamp, i.firstVerifiable), nil
+	if i.firstVerifiableSet {
+		return i.firstVerifiable, nil
+	}
+	if len(i.chains) == 0 {
+		return i.activationTimestamp, nil
 	}
 
-	firstSafeDBTime, err := i.firstSafeDBCoveredTime(ctx)
+	safeDBHandoffTime, err := i.safeDBHandoffTimestamp(ctx)
 	if err != nil {
 		return 0, err
 	}
 	first := i.activationTimestamp
-	if firstSafeDBTime >= i.activationTimestamp {
-		first = firstSafeDBTime + 1
+	if safeDBHandoffTime >= i.activationTimestamp {
+		first = safeDBHandoffTime + 1
 	}
 	i.firstVerifiable = first
 	i.firstVerifiableSet = true
@@ -46,8 +50,11 @@ type firstSafeHeadReader interface {
 	FirstSafeHead(ctx context.Context) (eth.BlockID, eth.BlockID, error)
 }
 
-func (i *Interop) firstSafeDBCoveredTime(ctx context.Context) (uint64, error) {
-	firstSafeDBTime := uint64(0)
+// safeDBHandoffTimestamp returns the newest first SafeDB-covered timestamp
+// across all chains. Starting verification after this timestamp guarantees that
+// every chain has at least one SafeDB-backed frontier block.
+func (i *Interop) safeDBHandoffTimestamp(ctx context.Context) (uint64, error) {
+	handoffTime := uint64(0)
 	for _, chain := range i.chains {
 		reader, ok := chain.(firstSafeHeadReader)
 		if !ok {
@@ -66,9 +73,9 @@ func (i *Interop) firstSafeDBCoveredTime(ctx context.Context) (uint64, error) {
 		}
 		i.log.Debug("first verifiable timestamp: SafeDB handoff",
 			"chain", chain.ID(), "l1", l1, "l2", l2, "timestamp", ts)
-		firstSafeDBTime = max(firstSafeDBTime, ts)
+		handoffTime = max(handoffTime, ts)
 	}
-	return firstSafeDBTime, nil
+	return handoffTime, nil
 }
 
 // shouldRunStartupLogBackfill keeps log backfill on the cold-start path only.
@@ -98,22 +105,11 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if firstVerifiable == i.activationTimestamp {
+	startTime, endTime, ok := i.logBackfillTimeRange(firstVerifiable)
+	if !ok {
 		return 0, nil
 	}
-	endTime := firstVerifiable - 1
 
-	// naively, end minus depth is the ideal backfill start.
-	// guard the subtraction so a young handoff timestamp doesn't wrap.
-	depthSec := uint64(i.logBackfillDepth.Seconds())
-	var idealStart uint64
-	if endTime >= depthSec {
-		idealStart = endTime - depthSec
-	}
-	// clamp to the activation timestamp: never backfill before activation.
-	startTime := max(idealStart, i.activationTimestamp)
-
-	// backfill every chain in parallel over [startTime, endTime]
 	errCh := make(chan error, len(i.chains))
 	wg := sync.WaitGroup{}
 	wg.Add(len(i.chains))
@@ -129,7 +125,7 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 			}
 			startNum, err := chain.TimestampToBlockNumber(i.ctx, chainStartTime)
 			if err != nil {
-				errCh <- fmt.Errorf("chain %s: timestamp to block number for start %d: %w", chain.ID(), startTime, err)
+				errCh <- fmt.Errorf("chain %s: timestamp to block number for start %d: %w", chain.ID(), chainStartTime, err)
 				i.log.Error("log backfill: timestamp to block number for start", "chain", chain.ID(), "err", err)
 				return
 			}
@@ -155,6 +151,21 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	return endTime, nil
 }
 
+// logBackfillTimeRange returns the inclusive timestamp range to seal before
+// normal verification starts.
+func (i *Interop) logBackfillTimeRange(firstVerifiable uint64) (startTime, endTime uint64, ok bool) {
+	if firstVerifiable <= i.activationTimestamp {
+		return 0, 0, false
+	}
+	endTime = firstVerifiable - 1
+	depthSec := uint64(i.logBackfillDepth.Seconds())
+	if endTime >= depthSec {
+		startTime = endTime - depthSec
+	}
+	startTime = max(startTime, i.activationTimestamp)
+	return startTime, endTime, true
+}
+
 func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.ChainContainer, startNum, endNum uint64) error {
 	db := i.logsDBs[cid]
 	// This is a startup best-effort repair for pre-existing logsDB reorg drift,
@@ -168,6 +179,9 @@ func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.C
 	}
 	if latest, has := db.LatestSealedBlock(); has {
 		startNum = latest.Number + 1
+	}
+	if startNum > endNum {
+		return nil
 	}
 	totalBlocks := endNum - startNum + 1
 	for num := startNum; num <= endNum; num++ {

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -9,24 +9,26 @@ import (
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 )
 
-// resolveFirstVerifiableTimestamp returns the first timestamp not yet covered
-// by durable local state: verifiedDB.LastTimestamp+1 when initialized,
-// otherwise a latched cold-start handoff derived from the first timestamp after
-// the earliest SafeDB coverage available across all chains (clamped to
-// activation). Starting after the first SafeDB entry leaves the entry itself
-// available as the frontier block when persisting the first verified timestamp.
+// resolveFirstVerifiableTimestamp returns the next timestamp that normal
+// interop verification should process.
+//
+// Startup has three cases:
+//   - with an initialized verifiedDB, resume at LastTimestamp+1;
+//   - with no post-activation SafeDB gap, begin at activation;
+//   - with an empty verifiedDB and post-activation SafeDB coverage, latch a
+//     cold-start handoff from the first SafeDB-covered timestamp across all
+//     chains.
+//
+// Starting after the first SafeDB entry leaves the entry itself available as
+// the frontier block when persisting the first verified timestamp.
 func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, error) {
-	if len(i.chains) == 0 {
-		return i.activationTimestamp, nil
+	if lastTS, initialized := i.verifiedDBLastTimestamp(); initialized {
+		return lastTS + 1, nil
 	}
-	if i.verifiedDB != nil {
-		if lastTS, initialized := i.verifiedDB.LastTimestamp(); initialized {
-			return lastTS + 1, nil
-		}
+	if len(i.chains) == 0 || i.firstVerifiableSet {
+		return max(i.activationTimestamp, i.firstVerifiable), nil
 	}
-	if i.firstVerifiableSet {
-		return i.firstVerifiable, nil
-	}
+
 	firstSafeDBTime, err := i.firstSafeDBCoveredTime(ctx)
 	if err != nil {
 		return 0, err
@@ -69,21 +71,32 @@ func (i *Interop) firstSafeDBCoveredTime(ctx context.Context) (uint64, error) {
 	return firstSafeDBTime, nil
 }
 
-func (i *Interop) runLogBackfill() (uint64, error) {
-	if i.logBackfillDepth <= 0 {
-		return 0, nil
+// shouldRunStartupLogBackfill keeps log backfill on the cold-start path only.
+// If verifiedDB already has results, normal verification resumes from
+// LastTimestamp+1 and the log backfill phase is skipped.
+func (i *Interop) shouldRunStartupLogBackfill() bool {
+	if i.logBackfillDepth <= 0 || len(i.chains) == 0 {
+		return false
 	}
-	if len(i.chains) == 0 {
+	_, initialized := i.verifiedDBLastTimestamp()
+	return !initialized
+}
+
+func (i *Interop) verifiedDBLastTimestamp() (uint64, bool) {
+	if i.verifiedDB == nil {
+		return 0, false
+	}
+	return i.verifiedDB.LastTimestamp()
+}
+
+func (i *Interop) runLogBackfill() (uint64, error) {
+	if !i.shouldRunStartupLogBackfill() {
 		return 0, nil
 	}
 
-	firstVerifiable := i.firstVerifiable
-	if !i.firstVerifiableSet {
-		var err error
-		firstVerifiable, err = i.readyFirstVerifiableTimestamp(i.ctx)
-		if err != nil {
-			return 0, err
-		}
+	firstVerifiable, err := i.readyFirstVerifiableTimestamp(i.ctx)
+	if err != nil {
+		return 0, err
 	}
 	if firstVerifiable == i.activationTimestamp {
 		return 0, nil

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -11,8 +11,10 @@ import (
 
 // resolveFirstVerifiableTimestamp returns the first timestamp not yet covered
 // by durable local state: verifiedDB.LastTimestamp+1 when initialized,
-// otherwise a latched cold-start handoff derived from the newest local-safe
-// progress across all chains (clamped to activation).
+// otherwise a latched cold-start handoff derived from the first timestamp after
+// the earliest SafeDB coverage available across all chains (clamped to
+// activation). Starting after the first SafeDB entry leaves the entry itself
+// available as the frontier block when persisting the first verified timestamp.
 func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, error) {
 	if len(i.chains) == 0 {
 		return i.activationTimestamp, nil
@@ -25,38 +27,46 @@ func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, 
 	if i.firstVerifiableSet {
 		return i.firstVerifiable, nil
 	}
-	maxLocalSafeTime, err := i.maxLocalSafeTime(ctx)
+	firstSafeDBTime, err := i.firstSafeDBCoveredTime(ctx)
 	if err != nil {
 		return 0, err
 	}
 	first := i.activationTimestamp
-	if maxLocalSafeTime >= i.activationTimestamp {
-		first = maxLocalSafeTime + 1
+	if firstSafeDBTime >= i.activationTimestamp {
+		first = firstSafeDBTime + 1
 	}
 	i.firstVerifiable = first
 	i.firstVerifiableSet = true
 	return first, nil
 }
 
-func (i *Interop) maxLocalSafeTime(ctx context.Context) (uint64, error) {
-	maxLocalSafeTime := uint64(0)
+type firstSafeHeadReader interface {
+	FirstSafeHead(ctx context.Context) (eth.BlockID, eth.BlockID, error)
+}
+
+func (i *Interop) firstSafeDBCoveredTime(ctx context.Context) (uint64, error) {
+	firstSafeDBTime := uint64(0)
 	for _, chain := range i.chains {
-		status, err := chain.SyncStatus(ctx)
+		reader, ok := chain.(firstSafeHeadReader)
+		if !ok {
+			return 0, fmt.Errorf("chain %s: first safe head reader unavailable", chain.ID())
+		}
+		l1, l2, err := reader.FirstSafeHead(ctx)
 		if err != nil {
-			return 0, fmt.Errorf("chain %s: sync status: %w", chain.ID(), err)
+			return 0, fmt.Errorf("chain %s: first safe head: %w", chain.ID(), err)
 		}
-		if status == nil {
-			return 0, fmt.Errorf("chain %s: sync status unavailable", chain.ID())
+		if l2 == (eth.BlockID{}) {
+			return 0, fmt.Errorf("chain %s: first safe head not yet available", chain.ID())
 		}
-		localSafe := status.LocalSafeL2
-		if localSafe == (eth.L2BlockRef{}) {
-			return 0, fmt.Errorf("chain %s: local safe head not yet available", chain.ID())
+		ts, err := chain.BlockNumberToTimestamp(ctx, l2.Number)
+		if err != nil {
+			return 0, fmt.Errorf("chain %s: first safe head timestamp: %w", chain.ID(), err)
 		}
-		i.log.Debug("first verifiable timestamp: local safe handoff",
-			"chain", chain.ID(), "localSafe", localSafe)
-		maxLocalSafeTime = max(maxLocalSafeTime, localSafe.Time)
+		i.log.Debug("first verifiable timestamp: SafeDB handoff",
+			"chain", chain.ID(), "l1", l1, "l2", l2, "timestamp", ts)
+		firstSafeDBTime = max(firstSafeDBTime, ts)
 	}
-	return maxLocalSafeTime, nil
+	return firstSafeDBTime, nil
 }
 
 func (i *Interop) runLogBackfill() (uint64, error) {

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -96,12 +96,12 @@ func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	require.Equal(t, int32(6), fetchCount.Load())
 }
 
-func TestLogBackfill_RetriesWhenSyncStatusNotReady(t *testing.T) {
+func TestLogBackfill_RetriesWhenFirstSafeHeadNotReady(t *testing.T) {
 	const act = uint64(100)
 	depth := 10 * time.Second
 
-	// Track sync status call count so we can make the first N calls fail.
-	var syncStatusCalls atomic.Int32
+	// Track first SafeDB entry call count so we can make the first N calls fail.
+	var firstSafeCalls atomic.Int32
 	failUntil := int32(3) // first 3 calls return error, then succeed
 
 	h := newInteropTestHarness(t).
@@ -109,18 +109,19 @@ func TestLogBackfill_RetriesWhenSyncStatusNotReady(t *testing.T) {
 		WithLogBackfillDepth(depth).
 		WithChain(10, func(m *mockChainContainer) {
 			m.currentL1 = eth.BlockRef{Number: 1, Hash: common.HexToHash("0xL1")}
+			localSafe := eth.L2BlockRef{Number: 110, Time: 110, Hash: common.BigToHash(big.NewInt(110))}
 			m.syncStatusFull = &eth.SyncStatus{
 				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
-				UnsafeL2:    eth.L2BlockRef{Number: 110, Time: 110},
-				SafeL2:      eth.L2BlockRef{Number: 110, Time: 110},
-				LocalSafeL2: eth.L2BlockRef{Number: 110, Time: 110},
+				UnsafeL2:    localSafe,
+				SafeL2:      localSafe,
+				LocalSafeL2: localSafe,
 			}
-			m.syncStatusOverride = func() (*eth.SyncStatus, error) {
-				n := syncStatusCalls.Add(1)
+			m.firstSafeOverride = func(context.Context) (eth.BlockID, eth.BlockID, error) {
+				n := firstSafeCalls.Add(1)
 				if n <= failUntil {
-					return nil, errors.New("sync status not ready")
+					return eth.BlockID{}, eth.BlockID{}, errors.New("safedb not ready")
 				}
-				return m.syncStatusFull, nil
+				return eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")}, localSafe.ID(), nil
 			}
 		}).
 		Build()
@@ -142,8 +143,8 @@ func TestLogBackfill_RetriesWhenSyncStatusNotReady(t *testing.T) {
 		return h.interop.backfillEndTimestamp > 0
 	}, 5*time.Second, 20*time.Millisecond, "backfill should eventually succeed after retries")
 
-	require.GreaterOrEqual(t, syncStatusCalls.Load(), failUntil,
-		"sync status should have been called at least %d times (the failing ones)", failUntil)
+	require.GreaterOrEqual(t, firstSafeCalls.Load(), failUntil,
+		"first SafeDB entry should have been called at least %d times (the failing ones)", failUntil)
 	require.Equal(t, uint64(110), h.interop.backfillEndTimestamp)
 	requireFirstVerifiableTimestamp(t, h.interop, 111)
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
@@ -266,23 +267,23 @@ func TestLogBackfill_RetriesStopOnContextCancel(t *testing.T) {
 }
 
 // TestLogBackfill_AsymmetricMultiChain asserts that every chain is backfilled
-// over the same [T_lo, newestLocalSafeTime] window. This keeps the system
-// symmetric at startup and chooses a handoff above every chain's local-safe
-// progress instead of anchoring to an execution-layer finalized label.
+// over the same [T_lo, newestFirstSafeDBTime] window. This keeps the system
+// symmetric at startup and chooses a handoff above every chain's first SafeDB
+// entry instead of anchoring to an execution-layer finalized label.
 //
-//   - T_lo is derived from max(local-safe time) across chains.
-//   - End of backfill for every chain is TimestampToBlockNumber(newestLocalSafeTime).
-//   - backfillEndTimestamp is set to newestLocalSafeTime; the main loop
+//   - T_lo is derived from max(first SafeDB timestamp) across chains.
+//   - End of backfill for every chain is TimestampToBlockNumber(newestFirstSafeDBTime).
+//   - backfillEndTimestamp is set to newestFirstSafeDBTime; the main loop
 //     resumes at backfillEndTimestamp+1.
 func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 	const act = uint64(50)
-	depth := 10 * time.Second // newest local safe 130 -> T_lo 120
+	depth := 10 * time.Second // newest first SafeDB timestamp 130 -> T_lo 120
 
-	// Chain 10: local safe at 120.
-	// Chain 20: local safe at 130 (the newest, pinning T_lo).
-	// Chain 30: local safe at 110.
+	// Chain 10: first SafeDB entry at 120.
+	// Chain 20: first SafeDB entry at 130 (the newest, pinning T_lo).
+	// Chain 30: first SafeDB entry at 110.
 	// Every chain backfills 120..130 (the shared shape), so each seals 11
-	// blocks regardless of each chain's local-safe timestamp.
+	// blocks regardless of each chain's first SafeDB timestamp.
 	h := newInteropTestHarness(t).
 		WithActivation(act).
 		WithLogBackfillDepth(depth).
@@ -339,7 +340,7 @@ func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 	h.interop.backfillEndTimestamp = end
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 	require.Equal(t, uint64(130), end,
-		"runLogBackfill must return newestLocalSafeTime as the end of the sealed range")
+		"runLogBackfill must return newestFirstSafeDBTime as the end of the sealed range")
 	requireFirstVerifiableTimestamp(t, h.interop, 131,
 		"main loop resumes at backfillEndTimestamp+1")
 
@@ -404,6 +405,9 @@ func TestLogBackfill_MisalignedActivation(t *testing.T) {
 			m.blockTimeOverride = blockTime
 			m.blockInfoTimeFn = blockNumToTime
 			m.timestampToBlockNumberOverride = tsToBlockNum
+			m.blockNumberToTimestampOverride = func(ctx context.Context, num uint64) (uint64, error) {
+				return blockNumToTime(num), nil
+			}
 			m.syncStatusFull = &eth.SyncStatus{
 				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
 				UnsafeL2:    eth.L2BlockRef{Number: localSafeNum, Time: localSafeTs},
@@ -520,6 +524,9 @@ func TestLogBackfill_NoOpWhenDepthZero(t *testing.T) {
 		WithChain(10, func(m *mockChainContainer) {
 			m.elFinalizedHead = eth.L2BlockRef{Number: 110, Time: 110}
 			m.elFinalizedHeadSet = true
+			m.firstSafeHeadSet = true
+			m.firstSafeL1 = eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")}
+			m.firstSafeL2 = eth.BlockID{Number: 110, Hash: common.BigToHash(big.NewInt(110))}
 			m.syncStatusOverride = func() (*eth.SyncStatus, error) {
 				syncStatusCalls.Add(1)
 				return &eth.SyncStatus{
@@ -711,11 +718,15 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 				WithChain(10, func(m *mockChainContainer) {
 					m.elFinalizedHead = eth.L2BlockRef{Number: tc.localSafeTip, Time: tc.localSafeTip}
 					m.elFinalizedHeadSet = true
+					firstSafeNum := tc.wantEndBlock
+					m.firstSafeHeadSet = true
+					m.firstSafeL1 = eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")}
+					m.firstSafeL2 = eth.BlockID{Number: firstSafeNum, Hash: common.BigToHash(new(big.Int).SetUint64(firstSafeNum))}
 					m.syncStatusFull = &eth.SyncStatus{
 						CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
-						UnsafeL2:    eth.L2BlockRef{Number: tc.localSafeTip, Time: tc.localSafeTip},
-						SafeL2:      eth.L2BlockRef{Number: tc.localSafeTip, Time: tc.localSafeTip},
-						LocalSafeL2: eth.L2BlockRef{Number: tc.localSafeTip, Time: tc.localSafeTip},
+						UnsafeL2:    eth.L2BlockRef{Number: firstSafeNum, Time: tc.localSafeTip},
+						SafeL2:      eth.L2BlockRef{Number: firstSafeNum, Time: tc.localSafeTip},
+						LocalSafeL2: eth.L2BlockRef{Number: firstSafeNum, Time: tc.localSafeTip},
 					}
 					m.blockNumberToTimestampOverride = tc.blockNumberToTimestamp
 					if tc.timestampToBlockNum != nil {
@@ -855,7 +866,7 @@ func TestLogBackfill_UsesVerifiedDBWhenAheadOfELFinalized(t *testing.T) {
 // seal loop then no-ops because startNum (latest+1) > endNum.
 //
 // Setup: cold start (empty verifiedDB), act=100, depth=60s,
-// local safe=120 -> endTime=120. Pre-seal blocks 100..120 with canonical
+// first SafeDB entry=120 -> endTime=120. Pre-seal blocks 100..120 with canonical
 // hashes for chain 10. After backfill the logsDB tip must still be 120.
 func TestLogBackfill_LeavesAheadLogsDBUnchanged(t *testing.T) {
 	const (
@@ -896,7 +907,7 @@ func TestLogBackfill_LeavesAheadLogsDBUnchanged(t *testing.T) {
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
 	require.Equal(t, preSeedTip, end,
-		"backfill end must equal newest local safe time")
+		"backfill end must equal newest first SafeDB timestamp")
 
 	latest, has := db.LatestSealedBlock()
 	require.True(t, has)
@@ -912,7 +923,7 @@ func TestLogBackfill_LeavesAheadLogsDBUnchanged(t *testing.T) {
 // while supernode was offline). reconcileLogsDBTail must walk back to the
 // last canonical block, after which backfill seals forward up to endTime.
 //
-// Setup: cold start, act=100, depth=60s, local safe=120 → endTime=120.
+// Setup: cold start, act=100, depth=60s, first SafeDB entry=120 -> endTime=120.
 // Pre-seal blocks 100..108 with canonical hashes, then 109..120 with a v1
 // fork hash. Expect reconcile to rewind to 108, and the seal loop to seal
 // 109..120 with canonical hashes. Final tip is endTime (120).
@@ -966,7 +977,7 @@ func TestLogBackfill_TrimsNonCanonicalAheadLogsDBAndCatchesUp(t *testing.T) {
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
 	require.Equal(t, preSeedTip, end,
-		"backfill end must equal newest local safe time")
+		"backfill end must equal newest first SafeDB timestamp")
 
 	latest, has := db.LatestSealedBlock()
 	require.True(t, has)

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -763,12 +763,12 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 	}
 }
 
-// TestLogBackfill_UsesVerifiedDBWhenInitializedAndSyncStatusStale simulates startup while
-// StatusTracker still reports a stale SafeL2 block and local-safe has moved
-// beyond the persisted EL-finalized label. With an initialized verifiedDB,
-// backfill should cap at verifiedDB.LastTimestamp instead of sampling moving
-// SyncStatus state or extending past verifiedDB.
-func TestLogBackfill_UsesVerifiedDBWhenInitializedAndSyncStatusStale(t *testing.T) {
+// TestLogBackfill_SkipsWhenVerifiedDBInitializedAndSyncStatusStale simulates
+// startup while StatusTracker still reports a stale SafeL2 block and local-safe
+// has moved beyond the persisted EL-finalized label. With an initialized
+// verifiedDB, startup should resume from verifiedDB.LastTimestamp+1 and skip
+// log backfill entirely.
+func TestLogBackfill_SkipsWhenVerifiedDBInitializedAndSyncStatusStale(t *testing.T) {
 	const (
 		act           uint64 = 100
 		staleCross    uint64 = 100
@@ -805,19 +805,21 @@ func TestLogBackfill_UsesVerifiedDBWhenInitializedAndSyncStatusStale(t *testing.
 
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
-	h.interop.backfillEndTimestamp = end
 
-	require.Equal(t, lastVerified, end,
-		"backfill must derive endTime from verifiedDB.LastTimestamp when verifiedDB is initialized")
+	require.Equal(t, uint64(0), end,
+		"startup backfill must be skipped when verifiedDB is initialized")
 
 	latest, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
-	require.True(t, has)
-	require.Equal(t, lastVerified, latest.Number)
+	require.False(t, has)
+	require.Equal(t, eth.BlockID{}, latest)
+	next, err := h.interop.resolveFirstVerifiableTimestamp(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, lastVerified+1, next)
 }
 
 // verifiedDB.LastTimestamp may exceed the local node's persisted EL-finalized
-// label; backfill must still resume from verifiedDB.
-func TestLogBackfill_UsesVerifiedDBWhenAheadOfELFinalized(t *testing.T) {
+// label; startup must still resume from verifiedDB without running backfill.
+func TestLogBackfill_SkipsWhenVerifiedDBAheadOfELFinalized(t *testing.T) {
 	const (
 		act          uint64 = 100
 		elFinalized  uint64 = 190
@@ -851,12 +853,15 @@ func TestLogBackfill_UsesVerifiedDBWhenAheadOfELFinalized(t *testing.T) {
 
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
-	require.Equal(t, lastVerified, end,
-		"backfill end derives from verifiedDB.LastTimestamp regardless of startup handoff state")
+	require.Equal(t, uint64(0), end,
+		"startup backfill must be skipped when verifiedDB is initialized")
 
 	latest, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
-	require.True(t, has)
-	require.Equal(t, lastVerified, latest.Number)
+	require.False(t, has)
+	require.Equal(t, eth.BlockID{}, latest)
+	next, err := h.interop.resolveFirstVerifiableTimestamp(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, lastVerified+1, next)
 }
 
 // TestLogBackfill_LeavesAheadLogsDBUnchanged asserts that when a chain's

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -34,7 +34,7 @@ func requireFirstVerifiableTimestamp(t *testing.T, i *Interop, want uint64, msgA
 
 func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	const act = uint64(100)
-	depth := 10 * time.Second // EL finalized 110, depth 10s -> T_lo 100; should seal 100..110
+	depth := 10 * time.Second // local safe 110, depth 10s -> T_lo 100; should seal 100..110
 
 	h := newInteropTestHarness(t).
 		WithActivation(act).
@@ -83,7 +83,7 @@ func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	require.NoError(t, err)
 	h.interop.backfillEndTimestamp = end
 	require.Equal(t, uint64(110), end,
-		"runLogBackfill must return minELFinalizedTime as the end of the sealed range")
+		"runLogBackfill must return the startup handoff - 1 as the end of the sealed range")
 	requireFirstVerifiableTimestamp(t, h.interop, 111,
 		"main loop resumes at backfillEndTimestamp+1")
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
@@ -96,12 +96,12 @@ func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	require.Equal(t, int32(6), fetchCount.Load())
 }
 
-func TestLogBackfill_RetriesWhenELFinalizedNotReady(t *testing.T) {
+func TestLogBackfill_RetriesWhenSyncStatusNotReady(t *testing.T) {
 	const act = uint64(100)
 	depth := 10 * time.Second
 
-	// Track EL finalized head call count so we can make the first N calls fail.
-	var elFinalizedCalls atomic.Int32
+	// Track sync status call count so we can make the first N calls fail.
+	var syncStatusCalls atomic.Int32
 	failUntil := int32(3) // first 3 calls return error, then succeed
 
 	h := newInteropTestHarness(t).
@@ -115,12 +115,12 @@ func TestLogBackfill_RetriesWhenELFinalizedNotReady(t *testing.T) {
 				SafeL2:      eth.L2BlockRef{Number: 110, Time: 110},
 				LocalSafeL2: eth.L2BlockRef{Number: 110, Time: 110},
 			}
-			m.elFinalizedHeadOverride = func() (eth.L2BlockRef, error) {
-				n := elFinalizedCalls.Add(1)
+			m.syncStatusOverride = func() (*eth.SyncStatus, error) {
+				n := syncStatusCalls.Add(1)
 				if n <= failUntil {
-					return eth.L2BlockRef{}, errors.New("EL finalized not ready")
+					return nil, errors.New("sync status not ready")
 				}
-				return eth.L2BlockRef{Number: 110, Time: 110}, nil
+				return m.syncStatusFull, nil
 			}
 		}).
 		Build()
@@ -142,8 +142,8 @@ func TestLogBackfill_RetriesWhenELFinalizedNotReady(t *testing.T) {
 		return h.interop.backfillEndTimestamp > 0
 	}, 5*time.Second, 20*time.Millisecond, "backfill should eventually succeed after retries")
 
-	require.GreaterOrEqual(t, elFinalizedCalls.Load(), failUntil,
-		"EL finalized head should have been called at least %d times (the failing ones)", failUntil)
+	require.GreaterOrEqual(t, syncStatusCalls.Load(), failUntil,
+		"sync status should have been called at least %d times (the failing ones)", failUntil)
 	require.Equal(t, uint64(110), h.interop.backfillEndTimestamp)
 	requireFirstVerifiableTimestamp(t, h.interop, 111)
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
@@ -266,26 +266,23 @@ func TestLogBackfill_RetriesStopOnContextCancel(t *testing.T) {
 }
 
 // TestLogBackfill_AsymmetricMultiChain asserts that every chain is backfilled
-// over the same [T_lo, minELFinalizedTime] window regardless of how far
-// individual chains' EL finalized heads have advanced. This keeps the system
-// symmetric at startup — every chain has logs sealed up to the same
-// timestamp, matching the invariant the main loop observes during normal
-// operation. Chains whose EL finalized head is beyond minELFinalizedTime catch
-// up through the main loop, not eagerly during backfill.
+// over the same [T_lo, newestLocalSafeTime] window. This keeps the system
+// symmetric at startup and chooses a handoff above every chain's local-safe
+// progress instead of anchoring to an execution-layer finalized label.
 //
-//   - T_lo is derived from min(EL finalized head time) across chains.
-//   - End of backfill for every chain is TimestampToBlockNumber(minELFinalizedTime).
-//   - backfillEndTimestamp is set to minELFinalizedTime; the main loop
+//   - T_lo is derived from max(local-safe time) across chains.
+//   - End of backfill for every chain is TimestampToBlockNumber(newestLocalSafeTime).
+//   - backfillEndTimestamp is set to newestLocalSafeTime; the main loop
 //     resumes at backfillEndTimestamp+1.
 func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 	const act = uint64(50)
-	depth := 10 * time.Second // min EL finalized 110 -> T_lo 100
+	depth := 10 * time.Second // newest local safe 130 -> T_lo 120
 
-	// Chain 10: EL finalized tip at 120.
-	// Chain 20: EL finalized tip at 130.
-	// Chain 30: EL finalized 110 (the min, pinning T_lo).
-	// Every chain backfills 100..110 (the shared shape), so each seals 11
-	// blocks regardless of how far its EL finalized tip is.
+	// Chain 10: local safe at 120.
+	// Chain 20: local safe at 130 (the newest, pinning T_lo).
+	// Chain 30: local safe at 110.
+	// Every chain backfills 120..130 (the shared shape), so each seals 11
+	// blocks regardless of each chain's local-safe timestamp.
 	h := newInteropTestHarness(t).
 		WithActivation(act).
 		WithLogBackfillDepth(depth).
@@ -341,34 +338,34 @@ func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 	require.NoError(t, err)
 	h.interop.backfillEndTimestamp = end
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
-	require.Equal(t, uint64(110), end,
-		"runLogBackfill must return minELFinalizedTime as the end of the sealed range")
-	requireFirstVerifiableTimestamp(t, h.interop, 111,
+	require.Equal(t, uint64(130), end,
+		"runLogBackfill must return newestLocalSafeTime as the end of the sealed range")
+	requireFirstVerifiableTimestamp(t, h.interop, 131,
 		"main loop resumes at backfillEndTimestamp+1")
 
 	chain10 := h.Mock(10)
 	chain20 := h.Mock(20)
 	chain30 := h.Mock(30)
 
-	// Every chain backfills the same 100..110 window (11 blocks each).
+	// Every chain backfills the same 120..130 window (11 blocks each).
 	require.Equal(t, int32(11), fetchCount[chain10.id].Load(),
-		"chain 10 should backfill blocks 100..110 (11 blocks)")
+		"chain 10 should backfill blocks 120..130 (11 blocks)")
 	require.Equal(t, int32(11), fetchCount[chain20.id].Load(),
-		"chain 20 should backfill blocks 100..110 (11 blocks)")
+		"chain 20 should backfill blocks 120..130 (11 blocks)")
 	require.Equal(t, int32(11), fetchCount[chain30.id].Load(),
-		"chain 30 should backfill blocks 100..110 (11 blocks)")
+		"chain 30 should backfill blocks 120..130 (11 blocks)")
 
 	latest10, has10 := h.interop.logsDBs[chain10.id].LatestSealedBlock()
 	require.True(t, has10)
-	require.Equal(t, uint64(110), latest10.Number)
+	require.Equal(t, uint64(130), latest10.Number)
 
 	latest20, has20 := h.interop.logsDBs[chain20.id].LatestSealedBlock()
 	require.True(t, has20)
-	require.Equal(t, uint64(110), latest20.Number)
+	require.Equal(t, uint64(130), latest20.Number)
 
 	latest30, has30 := h.interop.logsDBs[chain30.id].LatestSealedBlock()
 	require.True(t, has30)
-	require.Equal(t, uint64(110), latest30.Number)
+	require.Equal(t, uint64(130), latest30.Number)
 }
 
 // TestLogBackfill_MisalignedActivation asserts that backfill succeeds when
@@ -384,8 +381,8 @@ func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 // Concrete setup: blockTime=3, genesis=0, activation=1000. Block 333 has
 // Time()=999 (the pairing anchor); block 334 is at 1002; LocalSafe is at
 // block 340, Time=1020. T_lo clamps to activation so backfill must seal
-// blocks 333..340 without error. backfillEndTimestamp is set to 1020
-// (minELFinalizedTime), so the main loop resumes at 1021.
+// blocks 333..340 without error. backfillEndTimestamp is set to 1020, so
+// the main loop resumes at 1021.
 func TestLogBackfill_MisalignedActivation(t *testing.T) {
 	const (
 		blockTime    uint64 = 3
@@ -393,7 +390,7 @@ func TestLogBackfill_MisalignedActivation(t *testing.T) {
 		localSafeNum uint64 = 340
 		localSafeTs  uint64 = 1020 // 340 * blockTime
 	)
-	depth := 60 * time.Second // EL finalized 1020 - 60 = 960 < activation → T_lo clamps to 1000
+	depth := 60 * time.Second // local safe 1020 - 60 = 960 < activation -> T_lo clamps to 1000
 
 	blockNumToTime := func(num uint64) uint64 { return num * blockTime }
 	tsToBlockNum := func(ctx context.Context, ts uint64) (uint64, error) {
@@ -422,7 +419,7 @@ func TestLogBackfill_MisalignedActivation(t *testing.T) {
 	h.interop.backfillEndTimestamp = end
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 	require.Equal(t, localSafeTs, end,
-		"runLogBackfill must return minELFinalizedTime as the end of the sealed range")
+		"runLogBackfill must return the startup handoff - 1 as the end of the sealed range")
 	requireFirstVerifiableTimestamp(t, h.interop, localSafeTs+1)
 
 	chain10 := h.Mock(10)
@@ -450,7 +447,7 @@ func TestLogBackfill_MisalignedActivation(t *testing.T) {
 
 func TestLogBackfill_AdvancesActivationAndStartsVerifyAfterCeiling(t *testing.T) {
 	const act = uint64(108)
-	depth := time.Second // EL finalized 110, depth 1s -> T_lo 109; seals 109..110; first verifiable ts = 111
+	depth := time.Second // local safe 110, depth 1s -> T_lo 109; seals 109..110; first verifiable ts = 111
 
 	h := newInteropTestHarness(t).
 		WithActivation(act).
@@ -484,7 +481,7 @@ func TestLogBackfill_AdvancesActivationAndStartsVerifyAfterCeiling(t *testing.T)
 	require.NoError(t, err)
 	h.interop.backfillEndTimestamp = end
 	require.Equal(t, uint64(110), end,
-		"runLogBackfill must return minELFinalizedTime as the end of the sealed range")
+		"runLogBackfill must return the startup handoff - 1 as the end of the sealed range")
 	requireFirstVerifiableTimestamp(t, h.interop, 111,
 		"main loop resumes at backfillEndTimestamp+1")
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
@@ -555,10 +552,10 @@ func TestLogBackfill_NoOpWhenDepthZero(t *testing.T) {
 	require.False(t, has, "logs DB must remain empty")
 
 	// Caller sets backfillEndTimestamp; with end==0 the main loop derives the
-	// first unverified timestamp from the current EL finalized head.
+	// first unverified timestamp from the latched startup handoff.
 	h.interop.backfillEndTimestamp = end
 	requireFirstVerifiableTimestamp(t, h.interop, 111,
-		"with end==0 the main loop starts after the finalized head")
+		"with end==0 the main loop starts after the startup handoff")
 }
 
 // TestLogBackfill_NoOpWhenNoChains asserts that runLogBackfill short-circuits
@@ -586,9 +583,9 @@ func TestLogBackfill_NoOpWhenNoChains(t *testing.T) {
 }
 
 // TestLogBackfill_ActivationInFuture asserts the edge case where the
-// configured activation is ahead of every chain's EL finalized tip.
+// configured activation is ahead of every chain's local-safe tip.
 // firstVerifiableTimestamp clamps to activation, and backfill must no-op
-// instead of sealing beyond the current EL finalized head.
+// instead of sealing beyond the current local-safe handoff.
 func TestLogBackfill_ActivationInFuture(t *testing.T) {
 	const act = uint64(2000)
 	depth := 100 * time.Second
@@ -599,7 +596,7 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 		WithActivation(act).
 		WithLogBackfillDepth(depth).
 		WithChain(10, func(m *mockChainContainer) {
-			// EL finalized tip at 1000 — well below activation 2000.
+			// Local-safe tip at 1000, well below activation 2000.
 			m.syncStatusFull = &eth.SyncStatus{
 				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
 				UnsafeL2:    eth.L2BlockRef{Number: 1000, Time: 1000},
@@ -622,7 +619,7 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, end)
 	require.Zero(t, outputCalls.Load(),
-		"no blocks fetched: backfill no-ops when activation is ahead of EL finalized")
+		"no blocks fetched: backfill no-ops when activation is ahead of local safe")
 
 	chain10 := h.Mock(10)
 	_, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
@@ -632,7 +629,7 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 		"protocol activation must not change")
 
 	requireFirstVerifiableTimestamp(t, h.interop, act,
-		"main loop resumes at activation when EL finalized is still pre-activation")
+		"main loop resumes at activation when local safe is still pre-activation")
 }
 
 // TestLogBackfill_ClampsStartToGenesis asserts that the per-chain start is
@@ -642,11 +639,11 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 // same shape: backfill seals exactly the per-chain range [genesisBlock, endBlock].
 func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 	type genesisCase struct {
-		name           string
-		act            uint64
-		depth          time.Duration
-		genesisTime    uint64
-		elFinalizedTip uint64
+		name         string
+		act          uint64
+		depth        time.Duration
+		genesisTime  uint64
+		localSafeTip uint64
 		// timestampToBlockNum maps a unix timestamp back to the block number the
 		// chain would return. nil means use the harness default (identity).
 		timestampToBlockNum func(ctx context.Context, ts uint64) (uint64, error)
@@ -665,11 +662,11 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 			// idealStart = 110-50 = 60; startTime = max(60, act=50) = 60.
 			// Chain's genesis time is 100, which is > 60, so per-chain start
 			// clamps to genesis and seals blocks 100..110 (11 blocks).
-			name:           "activation before genesis",
-			act:            50,
-			depth:          50 * time.Second,
-			genesisTime:    100,
-			elFinalizedTip: 110,
+			name:         "activation before genesis",
+			act:          50,
+			depth:        50 * time.Second,
+			genesisTime:  100,
+			localSafeTip: 110,
 			blockNumberToTimestamp: func(ctx context.Context, num uint64) (uint64, error) {
 				if num == 0 {
 					return 100, nil
@@ -687,11 +684,11 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 			// TimestampToBlockNumber(100) returns block 0; the seal range is
 			// blocks 0..10 (11 blocks) — the genesis block at the activation
 			// boundary is included and has no logs, which is acceptable.
-			name:           "activation equals genesis",
-			act:            100,
-			depth:          60 * time.Second,
-			genesisTime:    100,
-			elFinalizedTip: 110,
+			name:         "activation equals genesis",
+			act:          100,
+			depth:        60 * time.Second,
+			genesisTime:  100,
+			localSafeTip: 110,
 			timestampToBlockNum: func(ctx context.Context, ts uint64) (uint64, error) {
 				return ts - 100, nil
 			},
@@ -712,13 +709,13 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 				WithActivation(tc.act).
 				WithLogBackfillDepth(tc.depth).
 				WithChain(10, func(m *mockChainContainer) {
-					m.elFinalizedHead = eth.L2BlockRef{Number: tc.elFinalizedTip, Time: tc.elFinalizedTip}
+					m.elFinalizedHead = eth.L2BlockRef{Number: tc.localSafeTip, Time: tc.localSafeTip}
 					m.elFinalizedHeadSet = true
 					m.syncStatusFull = &eth.SyncStatus{
 						CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
-						UnsafeL2:    eth.L2BlockRef{Number: tc.elFinalizedTip, Time: tc.elFinalizedTip},
-						SafeL2:      eth.L2BlockRef{Number: tc.elFinalizedTip, Time: tc.elFinalizedTip},
-						LocalSafeL2: eth.L2BlockRef{Number: tc.elFinalizedTip, Time: tc.elFinalizedTip},
+						UnsafeL2:    eth.L2BlockRef{Number: tc.localSafeTip, Time: tc.localSafeTip},
+						SafeL2:      eth.L2BlockRef{Number: tc.localSafeTip, Time: tc.localSafeTip},
+						LocalSafeL2: eth.L2BlockRef{Number: tc.localSafeTip, Time: tc.localSafeTip},
 					}
 					m.blockNumberToTimestampOverride = tc.blockNumberToTimestamp
 					if tc.timestampToBlockNum != nil {
@@ -741,8 +738,8 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 
 			end, err := h.interop.runLogBackfill()
 			require.NoError(t, err)
-			require.Equal(t, tc.elFinalizedTip, end,
-				"return value is still minELFinalizedTime regardless of the genesis clamp")
+			require.Equal(t, tc.localSafeTip, end,
+				"return value is still the handoff end regardless of the genesis clamp")
 
 			chain10 := h.Mock(10)
 			latest, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
@@ -757,7 +754,7 @@ func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
 
 // TestLogBackfill_UsesVerifiedDBWhenInitializedAndSyncStatusStale simulates startup while
 // StatusTracker still reports a stale SafeL2 block and local-safe has moved
-// beyond the persisted EL finalized label. With an initialized verifiedDB,
+// beyond the persisted EL-finalized label. With an initialized verifiedDB,
 // backfill should cap at verifiedDB.LastTimestamp instead of sampling moving
 // SyncStatus state or extending past verifiedDB.
 func TestLogBackfill_UsesVerifiedDBWhenInitializedAndSyncStatusStale(t *testing.T) {
@@ -807,8 +804,8 @@ func TestLogBackfill_UsesVerifiedDBWhenInitializedAndSyncStatusStale(t *testing.
 	require.Equal(t, lastVerified, latest.Number)
 }
 
-// verifiedDB.LastTimestamp typically exceeds min EL finalized; backfill must
-// still resume from verifiedDB.
+// verifiedDB.LastTimestamp may exceed the local node's persisted EL-finalized
+// label; backfill must still resume from verifiedDB.
 func TestLogBackfill_UsesVerifiedDBWhenAheadOfELFinalized(t *testing.T) {
 	const (
 		act          uint64 = 100
@@ -844,7 +841,7 @@ func TestLogBackfill_UsesVerifiedDBWhenAheadOfELFinalized(t *testing.T) {
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
 	require.Equal(t, lastVerified, end,
-		"backfill end derives from verifiedDB.LastTimestamp regardless of EL finalized")
+		"backfill end derives from verifiedDB.LastTimestamp regardless of startup handoff state")
 
 	latest, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
 	require.True(t, has)
@@ -858,7 +855,7 @@ func TestLogBackfill_UsesVerifiedDBWhenAheadOfELFinalized(t *testing.T) {
 // seal loop then no-ops because startNum (latest+1) > endNum.
 //
 // Setup: cold start (empty verifiedDB), act=100, depth=60s,
-// EL finalized=110 → endTime=110. Pre-seal blocks 100..120 with canonical
+// local safe=120 -> endTime=120. Pre-seal blocks 100..120 with canonical
 // hashes for chain 10. After backfill the logsDB tip must still be 120.
 func TestLogBackfill_LeavesAheadLogsDBUnchanged(t *testing.T) {
 	const (
@@ -898,8 +895,8 @@ func TestLogBackfill_LeavesAheadLogsDBUnchanged(t *testing.T) {
 
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
-	require.Equal(t, elFinalized, end,
-		"backfill end must equal minELFinalizedTime, independent of the ahead-of-end logsDB tip")
+	require.Equal(t, preSeedTip, end,
+		"backfill end must equal newest local safe time")
 
 	latest, has := db.LatestSealedBlock()
 	require.True(t, has)
@@ -915,10 +912,10 @@ func TestLogBackfill_LeavesAheadLogsDBUnchanged(t *testing.T) {
 // while supernode was offline). reconcileLogsDBTail must walk back to the
 // last canonical block, after which backfill seals forward up to endTime.
 //
-// Setup: cold start, act=100, depth=60s, EL finalized=110 → endTime=110.
+// Setup: cold start, act=100, depth=60s, local safe=120 → endTime=120.
 // Pre-seal blocks 100..108 with canonical hashes, then 109..120 with a v1
 // fork hash. Expect reconcile to rewind to 108, and the seal loop to seal
-// 109..110 with canonical hashes. Final tip is endTime (110).
+// 109..120 with canonical hashes. Final tip is endTime (120).
 func TestLogBackfill_TrimsNonCanonicalAheadLogsDBAndCatchesUp(t *testing.T) {
 	const (
 		act          uint64 = 100
@@ -968,17 +965,17 @@ func TestLogBackfill_TrimsNonCanonicalAheadLogsDBAndCatchesUp(t *testing.T) {
 
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
-	require.Equal(t, elFinalized, end,
-		"backfill end must equal minELFinalizedTime, independent of the ahead-of-end logsDB tip")
+	require.Equal(t, preSeedTip, end,
+		"backfill end must equal newest local safe time")
 
 	latest, has := db.LatestSealedBlock()
 	require.True(t, has)
-	require.Equal(t, elFinalized, latest.Number,
+	require.Equal(t, preSeedTip, latest.Number,
 		"after reconcile + seal, logsDB tip must equal endTime")
-	require.Equal(t, canonicalHash(elFinalized), latest.Hash,
+	require.Equal(t, canonicalHash(preSeedTip), latest.Hash,
 		"final tip must hold the canonical hash, not a stale v1 hash")
 
-	for n := act; n <= elFinalized; n++ {
+	for n := act; n <= preSeedTip; n++ {
 		seal, err := db.FindSealedBlock(n)
 		require.NoError(t, err, "block %d must remain sealed", n)
 		require.Equal(t, canonicalHash(n), seal.Hash,

--- a/op-supernode/supernode/activity/interop/reader.go
+++ b/op-supernode/supernode/activity/interop/reader.go
@@ -26,8 +26,9 @@ var ErrNotStarted = errors.New("interop activity not started")
 // activities. Errors discriminate the regime:
 //   - nil:                  verified entry returned
 //   - ErrInteropDisabled:   interop not configured; compose from optimistic outputs
-//   - ErrNotActive:         pre-activation; do not query interop superroots
-//   - ErrBeforeVerifiedDB:  post-activation but below firstVerifiable
+//   - ErrNotActive:         pre-activation; compose from optimistic outputs
+//   - ErrBeforeVerifiedDB:  post-activation but below firstVerifiable; compose
+//     from optimistic outputs
 //   - ethereum.NotFound:    verifier may eventually produce a result but has
 //     not yet — return Data = nil and let CurrentL1 communicate progress
 //

--- a/op-supernode/supernode/activity/interop/reader.go
+++ b/op-supernode/supernode/activity/interop/reader.go
@@ -6,14 +6,16 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// ErrNotActive signals that ts is before interop activation. Callers compose
-// the super root from per-chain optimistic outputs.
+// ErrNotActive signals that ts is before interop activation.
 var ErrNotActive = errors.New("interop not active for timestamp")
 
+// ErrInteropDisabled signals that the interop verifier is not configured.
+// Callers may use the pre-interop optimistic composition path.
+var ErrInteropDisabled = errors.New("interop verifier disabled")
+
 // ErrBeforeVerifiedDB signals that ts is post-activation but below the
-// verifier's first verifiable timestamp on this node. The timestamp is
-// already covered by the startup handoff: no VerifiedResult will
-// be produced here, but callers can treat optimistic outputs as canonical.
+// verifier's first verifiable timestamp on this node. No VerifiedResult will
+// be produced here.
 var ErrBeforeVerifiedDB = errors.New("timestamp below verified-db start")
 
 // ErrNotStarted signals that Start has not yet populated i.ctx. Callers
@@ -23,9 +25,9 @@ var ErrNotStarted = errors.New("interop activity not started")
 // VerifiedResultReader exposes committed VerifiedResults to non-interop
 // activities. Errors discriminate the regime:
 //   - nil:                  verified entry returned
-//   - ErrNotActive:         pre-activation; compose from optimistic outputs
-//   - ErrBeforeVerifiedDB:  post-activation but below firstVerifiable; the
-//     handoff covers ts, so compose from optimistic outputs
+//   - ErrInteropDisabled:   interop not configured; compose from optimistic outputs
+//   - ErrNotActive:         pre-activation; do not query interop superroots
+//   - ErrBeforeVerifiedDB:  post-activation but below firstVerifiable
 //   - ethereum.NotFound:    verifier may eventually produce a result but has
 //     not yet — return Data = nil and let CurrentL1 communicate progress
 //
@@ -37,10 +39,9 @@ type VerifiedResultReader interface {
 	VerifiedResultAtTimestamp(ts uint64) (result VerifiedResult, currentL1 eth.BlockID, err error)
 }
 
-// NoopVerifiedResultReader is used when interop is not configured: every
-// call returns ErrNotActive.
+// NoopVerifiedResultReader is used when interop is not configured.
 type NoopVerifiedResultReader struct{}
 
 func (NoopVerifiedResultReader) VerifiedResultAtTimestamp(uint64) (VerifiedResult, eth.BlockID, error) {
-	return VerifiedResult{}, eth.BlockID{}, ErrNotActive
+	return VerifiedResult{}, eth.BlockID{}, ErrInteropDisabled
 }

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -57,21 +57,11 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 
 	result, verifierL1, vrErr := s.verified.VerifiedResultAtTimestamp(timestamp)
 
-	// Any chain-level error building the optimistic branch must fail the
-	// call: op-challenger reads OptimisticAtTimestamp at step>0 and a silent
-	// partial map would produce permanent InvalidTransition commitments on
-	// chain. The pre-interop regime also relies on this map for Data.
-	optimisticBranch, err := s.buildOptimisticBranch(ctx, timestamp)
-	if err != nil {
-		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("build optimistic branch at %d: %w", timestamp, err)
-	}
-
 	response := eth.SuperRootAtTimestampResponse{
 		CurrentL1:                 aggregate.CurrentL1,
 		CurrentSafeTimestamp:      aggregate.SafeTimestamp,
 		CurrentLocalSafeTimestamp: aggregate.LocalSafeTimestamp,
 		CurrentFinalizedTimestamp: aggregate.FinalizedTimestamp,
-		OptimisticAtTimestamp:     optimisticBranch,
 		ChainIDs:                  aggregate.ChainIDs,
 	}
 
@@ -84,6 +74,11 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 	// value).
 	switch {
 	case vrErr == nil:
+		optimisticBranch, err := s.buildOptimisticBranch(ctx, timestamp)
+		if err != nil {
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("build optimistic branch at %d: %w", timestamp, err)
+		}
+		response.OptimisticAtTimestamp = optimisticBranch
 		if verifierL1.Number < response.CurrentL1.Number {
 			response.CurrentL1 = verifierL1
 		}
@@ -94,6 +89,11 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		response.Data = data
 		return response, nil
 	case errors.Is(vrErr, ethereum.NotFound):
+		optimisticBranch, err := s.buildOptimisticBranch(ctx, timestamp)
+		if err != nil {
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("build optimistic branch at %d: %w", timestamp, err)
+		}
+		response.OptimisticAtTimestamp = optimisticBranch
 		// Interop active at T but no VerifiedResult yet. Leave Data nil;
 		// the verifiedDB write gate guarantees CurrentL1 has not reached
 		// VerifiedRequiredL1(T).
@@ -101,10 +101,20 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 			response.CurrentL1 = verifierL1
 		}
 		return response, nil
-	case errors.Is(vrErr, interop.ErrNotActive), errors.Is(vrErr, interop.ErrBeforeVerifiedDB), errors.Is(vrErr, interop.ErrNotStarted):
-		// Optimistic outputs are canonical: pre-interop consensus,
-		// safe-head handoff, or pre-Start retry path.
+	case errors.Is(vrErr, interop.ErrInteropDisabled), errors.Is(vrErr, interop.ErrNotStarted):
+		optimisticBranch, err := s.buildOptimisticBranch(ctx, timestamp)
+		if err != nil {
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("build optimistic branch at %d: %w", timestamp, err)
+		}
+		response.OptimisticAtTimestamp = optimisticBranch
+		// Optimistic outputs are canonical: interop is disabled, or the verifier
+		// has not started yet and the caller is on the pre-start retry path.
 		response.Data = composeHandoffDataFromOptimistic(timestamp, s.chains, optimisticBranch)
+		return response, nil
+	case errors.Is(vrErr, interop.ErrNotActive), errors.Is(vrErr, interop.ErrBeforeVerifiedDB):
+		// Be pessimistic for historical timestamps outside the verifier's local
+		// coverage. Building an optimistic branch here may require SafeDB history
+		// that this node does not have.
 		return response, nil
 	default:
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("read verifiedDB at %d: %w", timestamp, vrErr)

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -101,20 +101,17 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 			response.CurrentL1 = verifierL1
 		}
 		return response, nil
-	case errors.Is(vrErr, interop.ErrInteropDisabled), errors.Is(vrErr, interop.ErrNotStarted):
+	case errors.Is(vrErr, interop.ErrInteropDisabled), errors.Is(vrErr, interop.ErrNotStarted),
+		errors.Is(vrErr, interop.ErrNotActive), errors.Is(vrErr, interop.ErrBeforeVerifiedDB):
 		optimisticBranch, err := s.buildOptimisticBranch(ctx, timestamp)
 		if err != nil {
 			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("build optimistic branch at %d: %w", timestamp, err)
 		}
 		response.OptimisticAtTimestamp = optimisticBranch
-		// Optimistic outputs are canonical: interop is disabled, or the verifier
-		// has not started yet and the caller is on the pre-start retry path.
+		// Optimistic outputs are canonical before verifier coverage, or when the
+		// verifier is unavailable for this timestamp. Preserve historical superroot
+		// queries independently of the interop verifiedDB backfill boundary.
 		response.Data = composeHandoffDataFromOptimistic(timestamp, s.chains, optimisticBranch)
-		return response, nil
-	case errors.Is(vrErr, interop.ErrNotActive), errors.Is(vrErr, interop.ErrBeforeVerifiedDB):
-		// Be pessimistic for historical timestamps outside the verifier's local
-		// coverage. Building an optimistic branch here may require SafeDB history
-		// that this node does not have.
 		return response, nil
 	default:
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("read verifiedDB at %d: %w", timestamp, vrErr)

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -115,9 +115,9 @@ var _ cc.ChainContainer = (*mockCC)(nil)
 
 // mockVerifiedReader is a test fake for interop.VerifiedResultReader.
 // Set result to return a VerifiedResult; set err to return an error
-// (ethereum.NotFound for "active but not yet verified", interop.ErrNotActive
-// for pre-interop fallback, interop.ErrBeforeVerifiedDB for the
-// hard-error regime, or any other error for the default branch).
+// (ethereum.NotFound for "active but not yet verified", interop.ErrInteropDisabled
+// for the no-interop fallback, interop.ErrNotActive / interop.ErrBeforeVerifiedDB
+// for pessimistic historical responses, or any other error for the default branch).
 type mockVerifiedReader struct {
 	result    interop.VerifiedResult
 	currentL1 eth.BlockID
@@ -128,7 +128,7 @@ func (m *mockVerifiedReader) VerifiedResultAtTimestamp(ts uint64) (interop.Verif
 	return m.result, m.currentL1, m.err
 }
 
-// preInteropReader always reports the pre-interop fallback regime.
+// preInteropReader always reports the interop-disabled fallback regime.
 func preInteropReader() interop.VerifiedResultReader {
 	return interop.NoopVerifiedResultReader{}
 }
@@ -558,7 +558,8 @@ func TestSuperroot_AtTimestamp_PreInteropFallback_BelowActivation(t *testing.T) 
 	s := newSuperroot(chains, reader)
 	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
-	require.NotNil(t, resp.Data)
+	require.Nil(t, resp.Data)
+	require.Empty(t, resp.OptimisticAtTimestamp)
 }
 
 func TestSuperroot_AtTimestamp_PreInteropFallback_NoSecondFetch(t *testing.T) {
@@ -601,10 +602,9 @@ func TestSuperroot_AtTimestamp_InteropNotStarted_ComposesFromOptimistic(t *testi
 
 // ------ Below-verified-db handoff tests ------
 
-// Below firstVerifiable, the safe-head startup handoff guarantees the
-// optimistic outputs are canonical, so Data is composed from them rather
-// than returning an error.
-func TestSuperroot_AtTimestamp_BelowVerifiedDB_ComposesFromOptimistic(t *testing.T) {
+// Below firstVerifiable, this node may not have SafeDB provenance for the
+// requested timestamp. The RPC response is deliberately pessimistic.
+func TestSuperroot_AtTimestamp_BelowVerifiedDB_ReturnsNoData(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
@@ -618,7 +618,8 @@ func TestSuperroot_AtTimestamp_BelowVerifiedDB_ComposesFromOptimistic(t *testing
 	s := newSuperroot(chains, reader)
 	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
-	require.NotNil(t, resp.Data)
+	require.Nil(t, resp.Data)
+	require.Empty(t, resp.OptimisticAtTimestamp)
 }
 
 // assertErr returns a generic error instance used to signal mock failures.

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -558,8 +558,8 @@ func TestSuperroot_AtTimestamp_PreInteropFallback_BelowActivation(t *testing.T) 
 	s := newSuperroot(chains, reader)
 	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
-	require.Nil(t, resp.Data)
-	require.Empty(t, resp.OptimisticAtTimestamp)
+	require.NotNil(t, resp.Data)
+	require.Contains(t, resp.OptimisticAtTimestamp, chainA)
 }
 
 func TestSuperroot_AtTimestamp_PreInteropFallback_NoSecondFetch(t *testing.T) {
@@ -602,12 +602,14 @@ func TestSuperroot_AtTimestamp_InteropNotStarted_ComposesFromOptimistic(t *testi
 
 // ------ Below-verified-db handoff tests ------
 
-// Below firstVerifiable, this node may not have SafeDB provenance for the
-// requested timestamp. The RPC response is deliberately pessimistic.
-func TestSuperroot_AtTimestamp_BelowVerifiedDB_ReturnsNoData(t *testing.T) {
+// Below firstVerifiable, preserve the historical optimistic superroot path.
+// The verifier's backfill boundary is separate from whether the EL can still
+// serve historical output roots and SafeDB provenance for the requested time.
+func TestSuperroot_AtTimestamp_BelowVerifiedDB_ComposesFromOptimistic(t *testing.T) {
 	t.Parallel()
+	chainA := eth.ChainIDFromUInt64(10)
 	chains := map[eth.ChainID]cc.ChainContainer{
-		eth.ChainIDFromUInt64(10): &mockCC{
+		chainA: &mockCC{
 			optL2:     eth.BlockID{Number: 100, Hash: common.HexToHash("0x01")},
 			optL1:     eth.BlockID{Number: 900},
 			optOutput: &eth.OutputV0{StateRoot: eth.Bytes32{0x01}},
@@ -618,8 +620,8 @@ func TestSuperroot_AtTimestamp_BelowVerifiedDB_ReturnsNoData(t *testing.T) {
 	s := newSuperroot(chains, reader)
 	resp, err := (&superrootAPI{s: s}).AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
-	require.Nil(t, resp.Data)
-	require.Empty(t, resp.OptimisticAtTimestamp)
+	require.NotNil(t, resp.Data)
+	require.Contains(t, resp.OptimisticAtTimestamp, chainA)
 }
 
 // assertErr returns a generic error instance used to signal mock failures.

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -474,6 +474,14 @@ func (c *simpleChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus,
 	return st, nil
 }
 
+func (c *simpleChainContainer) FirstSafeHead(ctx context.Context) (eth.BlockID, eth.BlockID, error) {
+	vn := c.getVN()
+	if vn == nil {
+		return eth.BlockID{}, eth.BlockID{}, virtual_node.ErrVirtualNodeNotRunning
+	}
+	return vn.FirstSafeHead(ctx)
+}
+
 func (c *simpleChainContainer) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
 	if c.engine == nil {
 		return eth.Bytes32{}, engine_controller.ErrNoEngineClient

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -106,6 +106,11 @@ func (m *mockVirtualNode) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (
 	return m.safeHeadL1, m.safeHeadL2, m.safeHeadErr
 }
 
+// FirstSafeHead implements virtual_node.VirtualNode FirstSafeHead
+func (m *mockVirtualNode) FirstSafeHead(ctx context.Context) (eth.BlockID, eth.BlockID, error) {
+	return m.safeHeadL1, m.safeHeadL2, m.safeHeadErr
+}
+
 // L1AtSafeHead implements virtual_node.VirtualNode L1AtSafeHead
 func (m *mockVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID) (eth.BlockID, error) {
 	return m.safeHeadL1, m.safeHeadErr
@@ -1045,6 +1050,9 @@ type mockVNForL1AtSafeHeadError struct {
 func (m *mockVNForL1AtSafeHeadError) Start(ctx context.Context) error { return nil }
 func (m *mockVNForL1AtSafeHeadError) Stop(ctx context.Context) error  { return nil }
 func (m *mockVNForL1AtSafeHeadError) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, nil
+}
+func (m *mockVNForL1AtSafeHeadError) FirstSafeHead(ctx context.Context) (eth.BlockID, eth.BlockID, error) {
 	return eth.BlockID{}, eth.BlockID{}, nil
 }
 func (m *mockVNForL1AtSafeHeadError) L1AtSafeHead(ctx context.Context, target eth.BlockID) (eth.BlockID, error) {

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -344,6 +344,9 @@ func (m *mockVNForInvalidation) LatestSafe(ctx context.Context) (eth.BlockID, er
 func (m *mockVNForInvalidation) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (eth.BlockID, eth.BlockID, error) {
 	return eth.BlockID{}, eth.BlockID{}, nil
 }
+func (m *mockVNForInvalidation) FirstSafeHead(ctx context.Context) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, nil
+}
 func (m *mockVNForInvalidation) L1AtSafeHead(ctx context.Context, target eth.BlockID) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -40,6 +40,7 @@ type VirtualNode interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
 
+	FirstSafeHead(ctx context.Context) (eth.BlockID, eth.BlockID, error)
 	SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (eth.BlockID, eth.BlockID, error)
 	// L1AtSafeHead returns the earliest L1 block at which the given L2 block became safe.
 	L1AtSafeHead(ctx context.Context, target eth.BlockID) (eth.BlockID, error)
@@ -195,6 +196,21 @@ func (v *simpleVirtualNode) State() VNState {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	return v.state
+}
+
+// FirstSafeHead returns the earliest recorded SafeDB mapping.
+func (v *simpleVirtualNode) FirstSafeHead(ctx context.Context) (eth.BlockID, eth.BlockID, error) {
+	v.mu.Lock()
+	inner := v.inner
+	v.mu.Unlock()
+	if inner == nil {
+		return eth.BlockID{}, eth.BlockID{}, ErrVirtualNodeNotRunning
+	}
+	db := inner.SafeDB()
+	if db == nil {
+		return eth.BlockID{}, eth.BlockID{}, ErrVirtualNodeNotRunning
+	}
+	return db.FirstSafeHead(ctx)
 }
 
 // SafeHeadAtL1 returns the recorded mapping of L1 block -> L2 safe head at or before the given L1 block number.

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
@@ -111,6 +111,22 @@ func (m *mockSafeDBReader) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) 
 	return entry.l1, entry.l2, nil
 }
 
+func (m *mockSafeDBReader) FirstSafeHead(ctx context.Context) (eth.BlockID, eth.BlockID, error) {
+	var first uint64
+	found := false
+	for num := range m.entries {
+		if !found || num < first {
+			first = num
+			found = true
+		}
+	}
+	if !found {
+		return eth.BlockID{}, eth.BlockID{}, safedb.ErrNotFound
+	}
+	entry := m.entries[first]
+	return entry.l1, entry.l2, nil
+}
+
 // Test helpers
 func createTestConfig() *opnodecfg.Config {
 	return &opnodecfg.Config{


### PR DESCRIPTION
## Summary
- replace the cold-start EL-finalized backfill anchor with a latched newest-local-safe handoff
- require the handoff timestamp to be available through OptimisticAt before sealing backfill logs
- make historical superroot queries below local verifier coverage pessimistic instead of composing optimistic data
- halt startup backfill immediately on permanent SafeDB history gaps

## Validation
- go test ./op-supernode/supernode/activity/interop ./op-supernode/supernode/activity/superroot -count=1
- mise exec -- env JUST_UNSTABLE=1 just build-contracts

Note: contract build completed with existing Solidity warnings around payable fallback without receive.