### PR TITLE
fix(op-reth,kona-node): Add version info build support 

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -93,6 +93,10 @@ variable "OP_RETH_VERSION" {
   default = "${GIT_VERSION}"
 }
 
+variable "KONA_NODE_VERSION" {
+  default = "${GIT_VERSION}"
+}
+
 variable "OP_FAUCET_VERSION" {
   default = "${GIT_VERSION}"
 }
@@ -345,6 +349,7 @@ target "kona-node" {
     REPO_LOCATION = "local"
     BIN_TARGET = "kona-node"
     BUILD_PROFILE = "release"
+    KONA_NODE_VERSION = "${KONA_NODE_VERSION}"
   }
   platforms = split(",", PLATFORMS)
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/kona-node:${tag}"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -89,6 +89,10 @@ variable "OP_DRIPPER_VERSION" {
   default = "${GIT_VERSION}"
 }
 
+variable "OP_RETH_VERSION" {
+  default = "${GIT_VERSION}"
+}
+
 variable "OP_FAUCET_VERSION" {
   default = "${GIT_VERSION}"
 }
@@ -382,6 +386,7 @@ target "op-reth" {
   args = {
     BUILD_PROFILE = "maxperf"
     FEATURES = ""
+    OP_RETH_VERSION = "${OP_RETH_VERSION}"
   }
   platforms = split(",", PLATFORMS)
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-reth:${tag}"]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7836,6 +7836,8 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-optimism-rpc",
  "tracing",
+ "vergen",
+ "vergen-git2",
 ]
 
 [[package]]

--- a/rust/kona/bin/node/build.rs
+++ b/rust/kona/bin/node/build.rs
@@ -9,6 +9,20 @@ use vergen::{BuildBuilder, CargoBuilder, Emitter};
 use vergen_git2::Git2Builder;
 
 fn main() -> Result<(), Box<dyn Error>> {
+    // If KONA_NODE_VERSION is set at Docker build time (injected via --build-arg),
+    // use it as the canonical version so the reported version matches the git tag
+    // (e.g. "kona-node/v1.2.3" -> "v1.2.3"). Otherwise fall back to the semver
+    // string in Cargo.toml.
+    println!("cargo:rerun-if-env-changed=KONA_NODE_VERSION");
+    let pkg_version = env::var("KONA_NODE_VERSION")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_owned());
+
+    // Override CARGO_PKG_VERSION so any downstream crate calling env!("CARGO_PKG_VERSION")
+    // in this build unit also picks up the injected tag.
+    println!("cargo:rustc-env=CARGO_PKG_VERSION={pkg_version}");
+
     let mut emitter = Emitter::default();
 
     let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
@@ -36,7 +50,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     // if not on a tag: v0.2.0-beta.3-82-g1939939b
     // if on a tag: v0.2.0-beta.3
     let not_on_tag = env::var("VERGEN_GIT_DESCRIBE")?.ends_with(&format!("-g{sha_short}"));
-    let version_suffix = if is_dirty || not_on_tag { "-dev" } else { "" };
+    // When KONA_NODE_VERSION is explicitly provided (i.e. a release build), treat the
+    // binary as "on tag" regardless of what git describe says about the monorepo.
+    let version_suffix = if env::var("KONA_NODE_VERSION").ok().filter(|v| !v.is_empty()).is_some() {
+        ""
+    } else if is_dirty || not_on_tag {
+        "-dev"
+    } else {
+        ""
+    };
     println!("cargo:rustc-env=KONA_NODE_VERSION_SUFFIX={version_suffix}");
 
     // Set short SHA
@@ -47,8 +69,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
     println!("cargo:rustc-env=KONA_NODE_BUILD_PROFILE={profile}");
 
-    // Set formatted version strings
-    let pkg_version = env!("CARGO_PKG_VERSION");
+    // Set formatted version strings — use the version resolved at the top of main().
 
     // The short version information for kona-node.
     // - The latest version from Cargo.toml

--- a/rust/kona/docker/apps/kona_app_generic.dockerfile
+++ b/rust/kona/docker/apps/kona_app_generic.dockerfile
@@ -80,6 +80,12 @@ FROM build-entrypoint AS builder
 # Since we only copy recipe.json, if the dependencies don't change, this step and the next one will be cached.
 COPY --from=planner /app/recipe.json recipe.json
 
+# Version override: allows CI to inject the git tag (e.g. kona-node/v1.2.3 -> v1.2.3)
+# so that reported metrics/CLI versions match the release tag, just like Go services do
+# via ldflags. Each kona binary has its own ARG name to avoid cross-contamination.
+ARG KONA_NODE_VERSION=""
+ENV KONA_NODE_VERSION=$KONA_NODE_VERSION
+
 # Build dependencies - this is the caching Docker layer!
 RUN RUSTFLAGS="-C target-cpu=generic" cargo chef cook --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}" --recipe-path recipe.json
 

--- a/rust/op-reth/DockerfileOp
+++ b/rust/op-reth/DockerfileOp
@@ -24,6 +24,9 @@ ENV RUSTFLAGS="$RUSTFLAGS"
 ARG FEATURES=""
 ENV FEATURES=$FEATURES
 
+ARG OP_RETH_VERSION=""
+ENV OP_RETH_VERSION=$OP_RETH_VERSION
+
 # Allow cook to fail on patched crates (op-alloy-network) whose crates.io
 # version conflicts with alloy 1.8.  All other dependencies are still cached.
 # The real build below uses the workspace [patch.crates-io] sources.

--- a/rust/op-reth/bin/Cargo.toml
+++ b/rust/op-reth/bin/Cargo.toml
@@ -26,6 +26,10 @@ clap = { workspace = true, features = ["derive", "env"] }
 tracing.workspace = true
 eyre.workspace = true
 
+[build-dependencies]
+vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }
+vergen-git2 = { workspace = true }
+
 [lints]
 workspace = true
 

--- a/rust/op-reth/bin/build.rs
+++ b/rust/op-reth/bin/build.rs
@@ -1,5 +1,47 @@
-// Adapted from reth [https://github.com/paradigmxyz/reth/blob/main/crates/node/core/build.rs]
-// and op-rbuilder [https://github.com/flashbots/op-rbuilder/blob/main/crates/op-rbuilder/build.rs]
+//! Build script for the `op-reth` binary crate.
+//!
+//! Adapted from [reth](https://github.com/paradigmxyz/reth/blob/main/crates/node/core/build.rs)
+//! and [op-rbuilder](https://github.com/flashbots/op-rbuilder/blob/main/crates/op-rbuilder/build.rs).
+//!
+//! This script performs three jobs at compile time:
+//!
+//! ## 1. Version override (`OP_RETH_VERSION`)
+//!
+//! If the `OP_RETH_VERSION` environment variable is set (e.g. injected as a
+//! Docker `--build-arg` during a release build), its value is used as
+//! `CARGO_PKG_VERSION` for the entire build unit.  This ensures that the
+//! version string reported by `op-reth --version` matches the published git
+//! tag (e.g. `v1.14.0`) rather than whatever semver is written in
+//! `Cargo.toml`.
+//!
+//! ## 2. Build-time metadata via `vergen`
+//!
+//! [`vergen`] is used to emit a set of `cargo:rustc-env` variables that are
+//! available to the binary at runtime through `env!(...)`:
+//!
+//! | Variable | Content |
+//! |---|---|
+//! | `VERGEN_BUILD_TIMESTAMP` | RFC 3339 timestamp of the build |
+//! | `VERGEN_CARGO_FEATURES` | Comma-separated list of active Cargo features |
+//! | `VERGEN_CARGO_TARGET_TRIPLE` | Target triple (e.g. `x86_64-unknown-linux-gnu`) |
+//! | `VERGEN_GIT_SHA` | Full 40-character commit SHA |
+//! | `VERGEN_GIT_SHA_SHORT` | First 8 characters of the commit SHA |
+//! | `VERGEN_GIT_DIRTY` | `true` when the working tree has uncommitted changes |
+//! | `VERGEN_GIT_DESCRIBE` | Output of `git describe --always --tags` |
+//!
+//! ## 3. Short version string (`RETH_SHORT_VERSION`)
+//!
+//! A human-readable short version string is assembled and exposed as
+//! `RETH_SHORT_VERSION`, for example:
+//!
+//! ```text
+//! v1.14.0 (1939939)
+//! v1.14.0-dev (1939939)
+//! ```
+//!
+//! A `-dev` suffix is appended when the working tree is dirty **or** when the
+//! current commit is not directly on a tag, unless `OP_RETH_VERSION` was
+//! explicitly provided (release builds are always treated as "on tag").
 
 use std::{env, error::Error};
 use vergen::{BuildBuilder, CargoBuilder, Emitter};

--- a/rust/op-reth/bin/build.rs
+++ b/rust/op-reth/bin/build.rs
@@ -1,0 +1,62 @@
+// Adapted from reth [https://github.com/paradigmxyz/reth/blob/main/crates/node/core/build.rs]
+// and op-rbuilder [https://github.com/flashbots/op-rbuilder/blob/main/crates/op-rbuilder/build.rs]
+
+use std::{env, error::Error};
+use vergen::{BuildBuilder, CargoBuilder, Emitter};
+use vergen_git2::Git2Builder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // If OP_RETH_VERSION is set at Docker build time (injected via --build-arg),
+    // use it as the canonical version so the reported version matches the git tag
+    // (e.g. "op-reth/v1.14.0" → "v1.14.0"). Otherwise fall back to the semver
+    // string in Cargo.toml.
+    println!("cargo:rerun-if-env-changed=OP_RETH_VERSION");
+    let pkg_version = env::var("OP_RETH_VERSION")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_owned());
+
+    // Override CARGO_PKG_VERSION for all crates that call env!("CARGO_PKG_VERSION")
+    // within this build unit so that reth's version machinery picks up the tag.
+    println!("cargo:rustc-env=CARGO_PKG_VERSION={pkg_version}");
+
+    let mut emitter = Emitter::default();
+
+    let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
+    emitter.add_instructions(&build_builder)?;
+
+    let cargo_builder = CargoBuilder::default().features(true).target_triple(true).build()?;
+    emitter.add_instructions(&cargo_builder)?;
+
+    let git_builder =
+        Git2Builder::default().describe(false, true, None).dirty(true).sha(false).build()?;
+    emitter.add_instructions(&git_builder)?;
+
+    emitter.emit_and_set()?;
+
+    let sha = env::var("VERGEN_GIT_SHA")?;
+    let sha_short = &sha[0..7];
+
+    // Set short SHA
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha[..8]);
+
+    let is_dirty = env::var("VERGEN_GIT_DIRTY")? == "true";
+    // > git describe --always --tags
+    // if not on a tag: v0.2.0-beta.3-82-g1939939b
+    // if on a tag:     v0.2.0-beta.3
+    let not_on_tag = env::var("VERGEN_GIT_DESCRIBE")?.ends_with(&format!("-g{sha_short}"));
+
+    // When OP_RETH_VERSION is explicitly provided (i.e. a release build), treat the
+    // binary as "on tag" regardless of what git describe says about the monorepo.
+    let version_suffix = if env::var("OP_RETH_VERSION").ok().filter(|v| !v.is_empty()).is_some() {
+        ""
+    } else if is_dirty || not_on_tag {
+        "-dev"
+    } else {
+        ""
+    };
+
+    println!("cargo:rustc-env=RETH_SHORT_VERSION={pkg_version}{version_suffix} ({sha_short})");
+
+    Ok(())
+}


### PR DESCRIPTION
For both op-reth and kona-node, allows the embedded version (exposed in metrics) to reflect the git tag at build time (not the version information in `Cargo.toml`). 

Closes https://github.com/ethereum-optimism/optimism/issues/20832 
⚠️ Generated with Claude.