### PR TITLE
docs: add interop prep notice for OP Sepolia and Unichain Sepolia

### DIFF
--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -2373,6 +2373,7 @@
           {
             "group": "Notices",
             "pages": [
+              "notices/interop-prep",
               "notices/upgrade-19",
               "notices/specialized-node-topology",
               "notices/stake-based-priority-ordering",

--- a/docs/public-docs/node-operators/guides/configuration/supernode.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/supernode.mdx
@@ -47,6 +47,18 @@ The `--l1.beacon-archiver` alias points at the same flag and is accepted for com
 
 For options on what to point `--l1.beacon-fallbacks` at — running your own non-pruning beacon, running `blob-archiver`, or using a third-party service — see the [blob archiver guide](/node-operators/guides/management/blobs#configure-a-blob-archiver).
 
+### Configure EL retention for supernode backfill
+
+<Info>
+  The supernode reads historical block and receipt data from each chain's execution client to backfill initiating-message logs after restarts or extended downtime.
+  ELs that aggressively prune receipts will break the backfill path.
+</Info>
+
+Configure each EL to retain at least 7 days of block and receipt history.
+A full archive is not required — see the [op-reth configuration reference](/node-operators/reference/op-reth-config) for the granular `--prune.*` flags that let you keep block and receipt history without enabling transaction indexing or world-state history.
+
+If you also run op-challenger for permissionless fault proofs, the same ELs additionally need historical proofs enabled — see [Running op-reth with Historical Proofs](/node-operators/tutorials/reth-historical-proofs).
+
 ### Pair op-supernode with a Light CL fleet
 
 For operators running more than a handful of nodes, the deployable pattern is to concentrate the expensive multi-chain derivation work on supernodes and run the rest of the fleet as op-node or kona-node instances in Light CL mode.
@@ -58,6 +70,17 @@ See the [specialized op-node topology notice](/notices/specialized-node-topology
 
 Set `--disable-p2p=true` on the supernode when the fleet handles unsafe-head P2P gossip on its own.
 Leave P2P enabled (the default) when the supernode is the only node in the topology.
+
+### Run an HA pool of supernodes behind a consensus-aware proxyd
+
+For production reliability, OP Labs recommends running an **HA pool of at least three op-supernode instances** and fronting them with a [consensus-aware `proxyd`](/chain-operators/tools/proxyd#consensus-awareness) configured with the `consensus_aware_consensus_layer` routing strategy.
+Point the Light CL fleet's `--l2.follow.source` at the proxyd endpoint rather than at a single supernode.
+This hides individual supernode failures or reorgs from the Light CL fleet and lets the supernode tier roll between releases without downtime.
+
+An individual supernode going down inside the HA pool is masked by `proxyd` — Light CLs continue following the surviving instances.
+If the entire supernode tier becomes unreachable, Light CLs keep advancing the unsafe chain over P2P gossip and resume safe-head tracking automatically once the tier is restored.
+
+A single op-supernode is acceptable for evaluation, but treat it as a single point of failure for safe-head progression on every chain it hosts.
 
 ## Example configuration
 

--- a/docs/public-docs/node-operators/guides/configuration/supernode.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/supernode.mdx
@@ -492,6 +492,7 @@ The default value is `6060`.
 
 ## Where to go next
 
+* Read the [interop prep notice](/notices/interop-prep) for the node-operator action checklist for the OP Sepolia and Unichain Sepolia activation.
 * Read the [supernode explainer](/op-stack/interop/supernode) for what op-supernode is and why it exists.
 * Read the [specialized op-node topology notice](/notices/specialized-node-topology) for the operator-facing pattern of running Light CL fleets that follow a supernode safe source.
 * Read the [interop explainer](/op-stack/interop/explainer) for how cross-chain messaging works at the protocol level.

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -1,0 +1,274 @@
+---
+title: Prepare for interop on OP Sepolia and Unichain Sepolia
+description: Node operator action checklist for the OP Sepolia and Unichain Sepolia interop activation, targeted for late June 2026.
+lang: en-US
+content_type: notice
+topic: interop-prep
+personas:
+  - node-operator
+categories:
+  - protocol
+  - infrastructure
+is_imported_content: 'false'
+audit-source:
+  - op-supernode/cmd/main.go
+  - op-supernode/flags/flags.go
+  - op-supernode/supernode/supernode.go
+  - op-supernode/supernode/activity/interop/interop.go
+  - op-node/rollup/types.go
+  - op-node/rollup/interop/config.go
+---
+
+OP Stack interop activates on **OP Sepolia** (chain ID `11155420`) and **Unichain Sepolia** (chain ID `1301`) in **late June 2026**, forming a two-chain interop dependency set on testnet.
+Node operators on either chain must change their topology before the activation timestamp: each operator runs one or more [op-supernode](/op-stack/interop/supernode) instances that derive both chains and validate the cross-chain messages between them, and the rest of the fleet runs as [Light CLs](/notices/specialized-node-topology) that follow the supernode tier's safe view.
+
+<Warning>
+  **A node that has not been migrated to the [supernode-plus-Light-CL topology](/notices/specialized-node-topology) by the activation timestamp cannot verify cross-chain dependencies.**
+  Every op-node in the fleet must run with `--l2.follow.source` (env: `OP_NODE_L2_FOLLOW_SOURCE`) pointed at an op-supernode that derives both chains.
+  Without that wiring — flag unset, or pointed at a non-supernode source — the op-node's safe head advances past the activation block without cross-chain validation, so the node cannot serve as a verifier or RPC source for the interop chain.
+  The [Specialized op-node topology notice](/notices/specialized-node-topology) describes that pattern in detail — *recommended* there, **required** here.
+  Start with that notice if your fleet hasn't moved off the homogeneous topology yet.
+</Warning>
+
+<Info>
+  The activation timestamps for OP Sepolia and Unichain Sepolia are scheduled for **late June 2026** but have not yet been finalized.
+  Final timestamps will be published in the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry) once governance approves the rollup-config update.
+  This page will be updated with the exact timestamps once they are pinned.
+  Interop on mainnet OP Stack chains is planned as a follow-up rollout after this testnet activation; mainnet activation timestamps will be announced separately.
+</Info>
+
+## What's changing
+
+At the activation timestamp, OP Sepolia and Unichain Sepolia form a two-chain dependency set.
+Every block on either chain can contain executing messages that reference initiating messages on the other; a block is only [safe](/op-stack/interop/explainer#block-safety-levels) once every initiating message it depends on has itself reached the same safety level.
+The work of tracking both chains and proving those dependencies moves to a new component, [op-supernode](/op-stack/interop/supernode), that runs every chain in the dependency set together as virtual nodes inside one process.
+The rest of the operator's fleet stops deriving locally and follows the supernode's safe view through op-node's [Light CL mode](/notices/specialized-node-topology).
+
+For how cross-chain messages and block safety work under interop, see the [interop explainer](/op-stack/interop/explainer).
+
+## Who this affects
+
+This notice applies to anyone running an op-node on OP Sepolia or Unichain Sepolia after the activation timestamp.
+
+Every op-node in the fleet — replicas, RPC nodes, or any other op-node deployment — must run as a Light CL pointed at an op-supernode that derives both chains.
+Each operator stands up at least one op-supernode for the dependency set and reconfigures every op-node in their fleet to follow it.
+
+Operators of any other OP Stack chain (mainnet, other testnets) are not affected by this rollout — interop on those chains is scheduled separately.
+
+## Required components
+
+Update or install the following components before the activation timestamp.
+Versions marked `TBD` will be pinned in this notice once the activation release candidates are finalized.
+
+| Component        | Version | Role |
+| ---------------- | ------- | ---- |
+| `op-supernode`   | `TBD`   | Runs OP Sepolia and Unichain Sepolia as virtual nodes inside one binary and verifies cross-chain messages. Required component. See the [supernode explainer](/op-stack/interop/supernode) and [configuration guide](/node-operators/guides/configuration/supernode). |
+| `op-node`        | `TBD`   | Runs as a [Light CL](/notices/specialized-node-topology) on every node in the fleet; safe and finalized views are inherited from the supernode. |
+| `op-reth`        | `TBD`   | Execution client. Run one per chain in the dependency set — an execution client cannot back two chains (op-node rejects a mismatched chain ID at startup), so a host serving both chains runs at least two execution-client processes. |
+
+<Info>
+  **op-reth is the recommended execution client.** op-geth end-of-support is **May 31, 2026** — see [End of Support for op-geth and op-program](/notices/op-geth-deprecation). Interop activation lands after that date, so plan your fleet on op-reth.
+</Info>
+
+<Info>
+  op-supernode does not yet have a stable release.
+  Pull the latest candidate from the [op-supernode releases page](https://github.com/ethereum-optimism/optimism/releases?q=op-supernode).
+  op-node and op-reth ship stable releases — track their respective release pages until this notice pins the exact activation versions.
+</Info>
+
+## Action checklist
+
+The migration has four phases.
+Complete each one and verify it on testnet before the activation timestamp.
+The order matters: the [supernode](/op-stack/interop/supernode) needs its execution clients up first, and the [Light CL fleet](/notices/specialized-node-topology) needs the supernode up before it can follow.
+Full per-flag reference for the supernode is in the [supernode configuration guide](/node-operators/guides/configuration/supernode); this notice walks through the testnet-specific setup.
+
+The command examples in each step are minimum viable configurations — they cover the flags required for the interop topology and nothing else.
+Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules, resource limits) on top as your environment requires.
+
+<Steps>
+  <Step title="Stand up execution clients for both chains">
+  Run at least one op-reth process for OP Sepolia and at least one for Unichain Sepolia.
+  Execution clients are not shared across chains; each supernode instance connects to exactly one engine-API endpoint per chain, and production fleets typically run several execution clients per chain to match the supernode tier and Light CL pool.
+  Each execution client needs its own JWT secret file (or a single shared file — see the note at the end of this step) and its own engine-API listen address.
+  Snap-sync or full-sync each client to the chain head before bringing the supernode up — the supernode cannot advance a chain whose execution client is still syncing.
+
+  ```bash
+  # OP Sepolia execution client
+  op-reth node \
+    --chain=optimism-sepolia \
+    --datadir=/var/lib/op-reth-op-sepolia \
+    --authrpc.addr=127.0.0.1 \
+    --authrpc.port=8551 \
+    --authrpc.jwtsecret=/etc/op/jwt-secret.txt
+
+  # Unichain Sepolia execution client
+  op-reth node \
+    --chain=unichain-sepolia \
+    --datadir=/var/lib/op-reth-unichain-sepolia \
+    --authrpc.addr=127.0.0.1 \
+    --authrpc.port=8561 \
+    --authrpc.jwtsecret=/etc/op/jwt-secret.txt
+  ```
+
+  Both processes can share a single JWT secret file when the supernode is the only consensus client connecting to them.
+  Use separate files only if a different consensus client also connects to one of them.
+  </Step>
+
+  <Step title="Stand up op-supernode for both chains">
+  Run op-supernode with both chains in `--chains`, a shared L1 RPC, a shared beacon endpoint, and at least one beacon archive fallback.
+  The example below uses environment variables; pass the equivalent `--flag` arguments if that fits your deployment better.
+  Fill in the placeholders before starting the binary.
+
+  ```yaml
+  # Dependency set and storage
+  OP_SUPERNODE_CHAINS: "11155420,1301"          # OP Sepolia + Unichain Sepolia
+  OP_SUPERNODE_DATA_DIR: /var/lib/op-supernode
+
+  # Shared L1 access
+  OP_SUPERNODE_L1_ETH_RPC: <your-sepolia-l1-eth-rpc>
+  OP_SUPERNODE_L1_BEACON: <your-sepolia-l1-beacon-rpc>
+  OP_SUPERNODE_L1_BEACON_FALLBACKS: <your-sepolia-l1-beacon-archiver-rpc>
+
+  # Shared JWT secret for every virtual node's engine connection
+  OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH: /etc/op/jwt-secret.txt
+
+  # Per-chain: chain identity, engine RPC, and engine kind (reth for both since the fleet runs op-reth)
+  OP_SUPERNODE_VN_11155420_NETWORK: op-sepolia
+  OP_SUPERNODE_VN_11155420_L2_ENGINE_RPC: http://127.0.0.1:8551
+  OP_SUPERNODE_VN_11155420_L2_ENGINE_KIND: reth
+  OP_SUPERNODE_VN_1301_NETWORK: unichain-sepolia
+  OP_SUPERNODE_VN_1301_L2_ENGINE_RPC: http://127.0.0.1:8561
+  OP_SUPERNODE_VN_1301_L2_ENGINE_KIND: reth
+
+  # Top-level JSON-RPC server (per-chain namespaces under /<chainID>/)
+  OP_SUPERNODE_RPC_ADDR: 0.0.0.0
+  OP_SUPERNODE_RPC_PORT: "8545"
+
+  # Observability
+  OP_SUPERNODE_LOG_LEVEL: info
+  OP_SUPERNODE_METRICS_ENABLED: "true"
+  OP_SUPERNODE_METRICS_ADDR: 0.0.0.0
+  OP_SUPERNODE_METRICS_PORT: "7300"
+
+  # Pre-activation only: override the interop activation timestamp until
+  # the chains' rollup configs include `interop_time`.
+  # Set to a future epoch-seconds value (e.g., late June 2026 once announced).
+  # Drop this line once OP Sepolia and Unichain Sepolia rollup configs ship `interop_time`.
+  OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP: "<future-unix-timestamp>"
+  ```
+
+  <Warning>
+    op-supernode defaults `--interop.log-backfill-depth` to 7 days, which requires an interop activation timestamp to be known.
+    Until OP Sepolia and Unichain Sepolia rollup configs ship `interop_time` (close to activation), the supernode exits at startup with `interop.log-backfill-depth=168h0m0s requires an interop activation timestamp`.
+    Set `OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP` (or `--interop.activation-timestamp`) to a future epoch-seconds value while testing, or set `OP_SUPERNODE_INTEROP_LOG_BACKFILL_DEPTH=0s` to disable the backfill.
+  </Warning>
+
+  Configure the beacon archive fallback from the start.
+  A supernode that has been offline past a regular beacon node's blob-prune window (about 18 days) cannot recover the missing blobs from the primary beacon alone, and chain containers will stall at the gap.
+
+  For the full flag reference and recommendations, see the [supernode configuration guide](/node-operators/guides/configuration/supernode).
+  </Step>
+
+  <Step title="Migrate every op-node in the fleet to Light CL">
+  On every op-node, set `--l2.follow.source` to your op-supernode's per-chain RPC endpoint (the `/<chainID>` path prefix).
+  This disables local derivation; the op-node becomes a Light CL and inherits its safe and finalized view from the supernode.
+
+  ```bash
+  # OP Sepolia verifier / RPC op-node
+  op-node \
+    --network=op-sepolia \
+    --l1=<your-sepolia-l1-eth-rpc> \
+    --l1.beacon=<your-sepolia-l1-beacon-rpc> \
+    --l2=http://op-sepolia-reth:8551 \
+    --l2.jwt-secret=/etc/op/jwt-secret.txt \
+    --l2.follow.source=http://op-supernode:8545/11155420 \
+    --rpc.addr=0.0.0.0 \
+    --rpc.port=9545
+
+  # Unichain Sepolia verifier / RPC op-node
+  op-node \
+    --network=unichain-sepolia \
+    --l1=<your-sepolia-l1-eth-rpc> \
+    --l1.beacon=<your-sepolia-l1-beacon-rpc> \
+    --l2=http://unichain-sepolia-reth:8561 \
+    --l2.jwt-secret=/etc/op/jwt-secret.txt \
+    --l2.follow.source=http://op-supernode:8545/1301 \
+    --rpc.addr=0.0.0.0 \
+    --rpc.port=9546
+  ```
+
+  `--l1` and `--l1.beacon` are still required at startup even in Light CL mode — op-node rejects the configuration without them.
+  The Light CL stops issuing L1 RPC calls for derivation work itself; it still keeps L1 references open for runtime config updates and engine-API book-keeping.
+  Unsafe-head progression over P2P is unchanged.
+
+  For background on the topology and why it scales, see the [specialized op-node topology notice](/notices/specialized-node-topology).
+  </Step>
+
+  <Step title="Place your supernodes behind a consensus-aware proxyd">
+  OP Labs recommends running an **HA pool of at least three op-supernode instances** and fronting them with a [consensus-aware `proxyd`](/chain-operators/tools/proxyd#consensus-awareness) configured with the `consensus_aware_consensus_layer` routing strategy.
+  Point the fleet's `--l2.follow.source` at the proxyd endpoint rather than at a single supernode.
+  This hides individual supernode failures or reorgs from the Light CL fleet and lets the supernode tier roll between releases without downtime.
+
+  An individual supernode going down inside the HA pool is masked by `proxyd` — Light CLs continue following the surviving instances.
+  If the entire supernode tier becomes unreachable, Light CLs keep advancing the unsafe chain over P2P gossip and resume safe-head tracking automatically once the tier is restored.
+
+  A single op-supernode is acceptable for evaluation, but treat it as a single point of failure for safe-head progression on both chains.
+  </Step>
+</Steps>
+
+## Verify your setup before activation
+
+Run these checks against your topology before the activation timestamp.
+None of them require interop to be active on either chain; they exercise the supernode-plus-Light-CL plumbing on its own so the activation block does not surface configuration errors for the first time.
+
+### Confirm the supernode is hosting both chains
+
+Watch the supernode's logs using whatever you already use (`docker logs -f op-supernode`, `journalctl -fu op-supernode`, `kubectl logs -f op-supernode`, etc.).
+Each chain container tags its log lines with its `chain_id`, so a healthy supernode produces interleaved derivation lines for both chains.
+The most common line during catch-up is `"Advancing bq origin"` (the batch-queue is walking forward through L1):
+
+```text
+t=2026-06-20T12:00:00+0000 lvl=info msg="Advancing bq origin" chain_id=11155420 vn_id=7754 origin=0x...:4071413 originBehind=false
+t=2026-06-20T12:00:00+0000 lvl=info msg="Advancing bq origin" chain_id=1301     vn_id=d5ca origin=0x...:6728414 originBehind=false
+```
+
+Both `chain_id=11155420` and `chain_id=1301` should appear regularly.
+If you only see one chain, the other's container failed to start or its execution client is unreachable — error-level lines tagged with the missing chain explain why.
+Once the supernode catches up and starts promoting heads, you will also see `msg="Sync progress"` lines with `l2_safe`, `l2_unsafe`, and `l2_finalized` fields tagged with the same `chain_id`.
+
+If you have Prometheus scraping the supernode, the gauge `op_node_supernode_refs_number{layer="l2",type="l2_safe"}` carries the per-chain safe head on the `virtual_node_chain_id` label — a single Grafana panel makes the per-chain progression continuously visible.
+
+### Confirm a Light CL is following the supernode
+
+Watch a Light CL's logs the same way and look for `"Follow Source: Process external refs"` and `"Follow Upstream"` lines.
+A working Light CL produces these continuously while it polls the supernode's `optimism_syncStatus`:
+
+```text
+t=2026-06-20T12:00:00+0000 lvl=info msg="Safety levels" unsafe=enabled safe=http://op-supernode:8545/11155420
+t=2026-06-20T12:00:00+0000 lvl=info msg="Follow Upstream" eSafe=0x...:12345678 eLocalSafe=0x...:12345678 eFinalized=0x...:12345670 eCurrentL1=0x...:4071600
+t=2026-06-20T12:00:00+0000 lvl=info msg="Follow Source: Process external refs" externalSafe=0x...:12345678 externalLocalSafe=0x...:12345678 externalFinalized=0x...:12345670
+```
+
+The first `"Safety levels"` line is the smoke test: if `safe=` shows your supernode URL and per-chain prefix, the wiring is right.
+Once the supernode is past initial sync and starts promoting safe heads, `eSafe` and `externalSafe` carry climbing block numbers.
+If the Light CL never advances past genesis (`eSafe=...:0`) for many minutes, `--l2.follow.source` is pointed at the wrong URL or namespace — recheck the per-chain prefix (`/11155420` for OP Sepolia, `/1301` for Unichain Sepolia).
+
+If you scrape Prometheus, the equivalent gauge on a Light CL is `op_node_default_refs_number{layer="l2",type="l2_safe"}` — one Grafana panel per Light CL plus one panel per supernode chain, side by side, makes any divergence obvious.
+
+## Troubleshooting
+
+* **Safe head advances but RPC consumers report invalid blocks.** The op-node isn't following an op-supernode — either `--l2.follow.source` is unset, or it points at a non-supernode source — so safe-head promotion skips cross-chain validation. Point `--l2.follow.source` at a supernode that derives both chains.
+* **Supernode chain container fails to start.** The most common cause is `OP_SUPERNODE_VN_<CHAINID>_L2_ENGINE_RPC` pointing at an execution client that is unreachable or still syncing. Bring the execution client up first.
+* **Blobs missing for L1 blocks older than ~18 days.** The primary beacon node has pruned them. Configure `--l1.beacon-fallbacks` against a non-pruning beacon or an archiver service. See the [blob archiver guide](/node-operators/guides/management/blobs#configure-a-blob-archiver) for options.
+* **Light CL safe head lags the supernode by more than a few blocks.** Check the network path between Light CL and supernode (or supernode `proxyd`). The Light CL polls `optimism_syncStatus` over RPC; a high-latency or rate-limited path here directly delays safe-head propagation.
+
+## Resources
+
+* [Interop explainer](/op-stack/interop/explainer) — how cross-chain messages and block safety work under interop.
+* [op-supernode explainer](/op-stack/interop/supernode) — what op-supernode is, why it exists, and how it pairs with Light CL.
+* [Supernode configuration guide](/node-operators/guides/configuration/supernode) — flag reference and starter configuration.
+* [Specialized op-node topology notice](/notices/specialized-node-topology) — operator-facing pattern for running Light CL fleets behind a safe source.
+* [Interop reorg awareness](/op-stack/interop/reorg) — how the safety model handles equivocation and L1 reorgs.
+* [Cross-chain security measures](/op-stack/security/interop-security) — how the safety level for inbound cross-chain messages is configured at the chain level.
+

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -67,7 +67,7 @@ Versions marked `TBD` will be pinned in this notice once the activation release 
 | `op-reth`        | `TBD`   | Execution client. Run one per chain in the dependency set — an execution client cannot back two chains (op-node rejects a mismatched chain ID at startup), so a host serving both chains runs at least two execution-client processes. |
 
 <Info>
-  **op-reth is the recommended execution client.** op-geth end-of-support is **May 31, 2026** — see [End of Support for op-geth and op-program](/notices/op-geth-deprecation). Interop activation lands after that date, so plan your fleet on op-reth.
+  **op-reth is the required execution client.** op-geth end-of-support is **May 31, 2026** — see [End of Support for op-geth and op-program](/notices/op-geth-deprecation). Interop activation lands after that date, so plan your fleet on op-reth.
 </Info>
 
 <Info>

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -254,7 +254,6 @@ If you scrape Prometheus, the equivalent gauge on a Light CL is `op_node_default
 ## Troubleshooting
 
 * **Safe head advances but RPC consumers report invalid blocks.** The op-node isn't following an op-supernode — either `--l2.follow.source` is unset, or it points at a non-supernode source — so safe-head promotion skips cross-chain validation. Point `--l2.follow.source` at a supernode that derives both chains.
-* **Supernode chain container fails to start.** The most common cause is `OP_SUPERNODE_VN_<CHAINID>_L2_ENGINE_RPC` pointing at an execution client that is unreachable at startup. The supernode retries engine-API calls a few times during startup, but persistent failure causes the chain container to exit. A still-syncing execution client is fine — the supernode drives it through sync.
 * **Blobs missing for L1 blocks older than ~18 days.** The primary beacon node has pruned them. Configure `--l1.beacon-fallbacks` against a non-pruning beacon or an archiver service. See the [blob archiver guide](/node-operators/guides/management/blobs#configure-a-blob-archiver) for options.
 * **Light CL safe head lags the supernode by more than a few blocks.** Check the network path between Light CL and supernode (or supernode `proxyd`). The Light CL polls `optimism_syncStatus` over RPC; a high-latency or rate-limited path here directly delays safe-head propagation.
 

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -20,13 +20,13 @@ audit-source:
 ---
 
 OP Stack interop is expected to activate on **OP Sepolia** (chain ID `11155420`) and **Unichain Sepolia** (chain ID `1301`) in **late June 2026**, forming a two-chain interop dependency set on testnet.
-Node operators on either chain must change their topology before the activation timestamp: each operator runs one or more [op-supernode](/op-stack/interop/supernode) instances that derive both chains and validate the cross-chain messages between them, and the rest of the fleet runs as [Light CLs](/notices/specialized-node-topology) that follow the supernode tier's safe view.
+Node operators on either chain must change their topology before the activation timestamp: each operator runs one or more [op-supernode](/op-stack/interop/supernode) instances that derive both chains and validate the cross-chain messages between them, and the rest of the fleet runs as [Light CLs](/notices/specialized-node-topology) that follow the supernode.
 
 <Warning>
   **A node that has not been migrated to the [supernode-plus-Light-CL topology](/notices/specialized-node-topology) by the activation timestamp cannot verify cross-chain dependencies.**
   Every op-node in the fleet must run with `--l2.follow.source` (env: `OP_NODE_L2_FOLLOW_SOURCE`) pointed at an op-supernode that derives both chains.
   Without that wiring — flag unset, or pointed at a non-supernode source — the op-node's safe head advances past the activation block without cross-chain validation, so the node cannot serve as a verifier or RPC source for the interop chain.
-  The [Specialized op-node topology notice](/notices/specialized-node-topology) describes that pattern in detail — *recommended* there, **required** here.
+  The [Specialized op-node topology notice](/notices/specialized-node-topology) describes the pattern in detail.
   Start with that notice if your fleet hasn't moved off the homogeneous topology yet.
 </Warning>
 
@@ -48,12 +48,15 @@ For how cross-chain messages and block safety work under interop, see the [inter
 
 ## Who this affects
 
-This notice applies to anyone running an op-node on OP Sepolia or Unichain Sepolia after the activation timestamp.
+This notice applies to anyone running OP Sepolia or Unichain Sepolia nodes after the activation timestamp.
 
 Every op-node in the fleet — replicas, RPC nodes, or any other op-node deployment — must run as a Light CL pointed at an op-supernode that derives both chains.
 Each operator stands up at least one op-supernode for the dependency set and reconfigures every op-node in their fleet to follow it.
 
-Operators of any other OP Stack chain (mainnet, other testnets) are not affected by this rollout — interop on those chains is scheduled separately.
+This rollout is scoped to OP Sepolia and Unichain Sepolia.
+Other OP Stack chains will activate the same Lagoon hardfork.
+With an empty dependency set there's nothing to cross-validate, so those operators can keep running plain op-node.
+Interop on OP Mainnet and Unichain follows in late July 2026, and other OP Stack chains move to the supernode topology only when they join an interop set.
 
 ## Required components
 
@@ -152,15 +155,16 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
   OP_SUPERNODE_METRICS_PORT: "7300"
 
   # Pre-activation only: override the interop activation timestamp until
-  # the chains' rollup configs include `interop_time`.
+  # the chains' rollup configs include `lagoon_time` (the field carrying the
+  # Lagoon hardfork activation — the upgrade that enables interop).
   # Set to a future epoch-seconds value (e.g., late June 2026 once announced).
-  # Drop this line once OP Sepolia and Unichain Sepolia rollup configs ship `interop_time`.
+  # Drop this line once OP Sepolia and Unichain Sepolia rollup configs ship `lagoon_time`.
   OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP: "<future-unix-timestamp>"
   ```
 
   <Warning>
     op-supernode defaults `--interop.log-backfill-depth` to 7 days, which requires an interop activation timestamp to be known.
-    Until OP Sepolia and Unichain Sepolia rollup configs ship `interop_time` (close to activation), the supernode exits at startup with `interop.log-backfill-depth=168h0m0s requires an interop activation timestamp`.
+    Until OP Sepolia and Unichain Sepolia rollup configs ship `lagoon_time` (the Lagoon hardfork activation field that lights up interop, set close to activation), the supernode exits at startup with `interop.log-backfill-depth=168h0m0s requires an interop activation timestamp`.
     Set `OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP` (or `--interop.activation-timestamp`) to a future epoch-seconds value while testing, or set `OP_SUPERNODE_INTEROP_LOG_BACKFILL_DEPTH=0s` to disable the backfill.
   </Warning>
 

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -31,7 +31,7 @@ Node operators on either chain must change their topology before the activation 
 </Warning>
 
 <Info>
-  The activation timestamps for OP Sepolia and Unichain Sepolia are scheduled for **late June 2026** but have not yet been finalized.
+  The activation timestamps for OP Sepolia and Unichain Sepolia are planned for **late June 2026** but have not yet been finalized.
   Final timestamps will be published in the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry) once governance approves the rollup-config update.
   This page will be updated with the exact timestamps once they are pinned.
   Interop on mainnet OP Stack chains is planned as a follow-up rollout after this testnet activation; mainnet activation timestamps will be announced separately.

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -254,7 +254,7 @@ If you scrape Prometheus, the equivalent gauge on a Light CL is `op_node_default
 ## Troubleshooting
 
 * **Safe head advances but RPC consumers report invalid blocks.** The op-node isn't following an op-supernode — either `--l2.follow.source` is unset, or it points at a non-supernode source — so safe-head promotion skips cross-chain validation. Point `--l2.follow.source` at a supernode that derives both chains.
-* **Supernode chain container fails to start.** The most common cause is `OP_SUPERNODE_VN_<CHAINID>_L2_ENGINE_RPC` pointing at an execution client that is unreachable or still syncing. Bring the execution client up first.
+* **Supernode chain container fails to start.** The most common cause is `OP_SUPERNODE_VN_<CHAINID>_L2_ENGINE_RPC` pointing at an execution client that is unreachable at startup. The supernode retries engine-API calls a few times during startup, but persistent failure causes the chain container to exit. A still-syncing execution client is fine — the supernode drives it through sync.
 * **Blobs missing for L1 blocks older than ~18 days.** The primary beacon node has pruned them. Configure `--l1.beacon-fallbacks` against a non-pruning beacon or an archiver service. See the [blob archiver guide](/node-operators/guides/management/blobs#configure-a-blob-archiver) for options.
 * **Light CL safe head lags the supernode by more than a few blocks.** Check the network path between Light CL and supernode (or supernode `proxyd`). The Light CL polls `optimism_syncStatus` over RPC; a high-latency or rate-limited path here directly delays safe-head propagation.
 

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -97,7 +97,7 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
   Each execution client needs its own JWT secret file (a single shared file across both ELs is fine — see the note at the end of this step) and its own engine-API listen address.
   ELs can start unsynced; they wait until the supernode connects before they know what chain head to sync to.
   The supernode then drives each EL through its initial sync via the engine API, and tolerates the common case where one chain's EL is already synced and the other isn't.
-  Configure each EL to retain block and receipt history for at least 7 days so the supernode can backfill initiating-message logs (a full archive isn't required).
+  Configure each EL to retain block and receipt history for at least 7 days so the supernode can backfill initiating-message logs (a full archive isn't required — see the [op-reth configuration reference](/node-operators/reference/op-reth-config) for the granular `--prune.*` flags).
   If you also run op-challenger for permissionless fault proofs, these ELs additionally need historical proofs enabled — see [Running op-reth with Historical Proofs](/node-operators/tutorials/reth-historical-proofs). Pure node operators (RPC, exchange, indexer) without op-challenger can skip that.
 
   ```bash

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -19,7 +19,7 @@ audit-source:
   - op-node/rollup/interop/config.go
 ---
 
-OP Stack interop activates on **OP Sepolia** (chain ID `11155420`) and **Unichain Sepolia** (chain ID `1301`) in **late June 2026**, forming a two-chain interop dependency set on testnet.
+OP Stack interop is expected to activate on **OP Sepolia** (chain ID `11155420`) and **Unichain Sepolia** (chain ID `1301`) in **late June 2026**, forming a two-chain interop dependency set on testnet.
 Node operators on either chain must change their topology before the activation timestamp: each operator runs one or more [op-supernode](/op-stack/interop/supernode) instances that derive both chains and validate the cross-chain messages between them, and the rest of the fleet runs as [Light CLs](/notices/specialized-node-topology) that follow the supernode tier's safe view.
 
 <Warning>

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -83,7 +83,8 @@ Versions marked `TBD` will be pinned in this notice once the activation release 
 
 The migration has four phases.
 Complete each one and verify it on testnet before the activation timestamp.
-The order matters: the [supernode](/op-stack/interop/supernode) needs its execution clients up first, and the [Light CL fleet](/notices/specialized-node-topology) needs the supernode up before it can follow.
+Start the execution clients first, then the supernode — the supernode drives the ELs through their sync, because an EL has no way to know what chain head to target on its own.
+Light CLs come last, since they follow the supernode.
 Full per-flag reference for the supernode is in the [supernode configuration guide](/node-operators/guides/configuration/supernode); this notice walks through the testnet-specific setup.
 
 The command examples in each step are minimum viable configurations — they cover the flags required for the interop topology and nothing else.
@@ -93,8 +94,11 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
   <Step title="Stand up execution clients for both chains">
   Run at least one op-reth process for OP Sepolia and at least one for Unichain Sepolia.
   Execution clients are not shared across chains; each supernode instance connects to exactly one engine-API endpoint per chain, and production fleets typically run several execution clients per chain to match the supernode tier and Light CL pool.
-  Each execution client needs its own JWT secret file (or a single shared file — see the note at the end of this step) and its own engine-API listen address.
-  Snap-sync or full-sync each client to the chain head before bringing the supernode up — the supernode cannot advance a chain whose execution client is still syncing.
+  Each execution client needs its own JWT secret file (a single shared file across both ELs is fine — see the note at the end of this step) and its own engine-API listen address.
+  ELs can start unsynced; they wait until the supernode connects before they know what chain head to sync to.
+  The supernode then drives each EL through its initial sync via the engine API, and tolerates the common case where one chain's EL is already synced and the other isn't.
+  Configure each EL to retain block and receipt history for at least 7 days so the supernode can backfill initiating-message logs (a full archive isn't required).
+  If you also run op-challenger for permissionless fault proofs, these ELs additionally need historical proofs enabled — see [Running op-reth with Historical Proofs](/node-operators/tutorials/reth-historical-proofs). Pure node operators (RPC, exchange, indexer) without op-challenger can skip that.
 
   ```bash
   # OP Sepolia execution client
@@ -114,12 +118,13 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
     --authrpc.jwtsecret=/etc/op/jwt-secret.txt
   ```
 
-  Both processes can share a single JWT secret file when the supernode is the only consensus client connecting to them.
-  Use separate files only if a different consensus client also connects to one of them.
+  Each EL has exactly one consensus client connected to it — the supernode's virtual node for that chain.
+  Sharing the same JWT secret file across both ELs is the simplest configuration; the supernode references it once via `OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH`.
   </Step>
 
   <Step title="Stand up op-supernode for both chains">
-  Run op-supernode with both chains in `--chains`, a shared L1 RPC, a shared beacon endpoint, and at least one beacon archive fallback.
+  Run op-supernode with both chains in `--chains`, a shared L1 RPC, and a shared beacon endpoint.
+  A beacon archive fallback is optional — only required if your primary beacon node doesn't keep the full blob history the supernode might need to backfill (Ethereum beacon nodes typically prune blob sidecars after roughly 18 days).
   The example below uses environment variables; pass the equivalent `--flag` arguments if that fits your deployment better.
   Fill in the placeholders before starting the binary.
 
@@ -131,7 +136,7 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
   # Shared L1 access
   OP_SUPERNODE_L1_ETH_RPC: <your-sepolia-l1-eth-rpc>
   OP_SUPERNODE_L1_BEACON: <your-sepolia-l1-beacon-rpc>
-  OP_SUPERNODE_L1_BEACON_FALLBACKS: <your-sepolia-l1-beacon-archiver-rpc>
+  # OP_SUPERNODE_L1_BEACON_FALLBACKS: <your-sepolia-l1-beacon-archiver-rpc>  # optional; add if your primary beacon prunes blob sidecars
 
   # Shared JWT secret for every virtual node's engine connection
   OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH: /etc/op/jwt-secret.txt
@@ -147,29 +152,12 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
   # Top-level JSON-RPC server (per-chain namespaces under /<chainID>/)
   OP_SUPERNODE_RPC_ADDR: 0.0.0.0
   OP_SUPERNODE_RPC_PORT: "8545"
-
-  # Observability
-  OP_SUPERNODE_LOG_LEVEL: info
-  OP_SUPERNODE_METRICS_ENABLED: "true"
-  OP_SUPERNODE_METRICS_ADDR: 0.0.0.0
-  OP_SUPERNODE_METRICS_PORT: "7300"
-
-  # Pre-activation only: override the interop activation timestamp until
-  # the chains' rollup configs include `lagoon_time` (the field carrying the
-  # Lagoon hardfork activation — the upgrade that enables interop).
-  # Set to a future epoch-seconds value (e.g., late June 2026 once announced).
-  # Drop this line once OP Sepolia and Unichain Sepolia rollup configs ship `lagoon_time`.
-  OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP: "<future-unix-timestamp>"
   ```
 
-  <Warning>
-    op-supernode defaults `--interop.log-backfill-depth` to 7 days, which requires an interop activation timestamp to be known.
-    Until OP Sepolia and Unichain Sepolia rollup configs ship `lagoon_time` (the Lagoon hardfork activation field that lights up interop, set close to activation), the supernode exits at startup with `interop.log-backfill-depth=168h0m0s requires an interop activation timestamp`.
-    Set `OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP` (or `--interop.activation-timestamp`) to a future epoch-seconds value while testing, or set `OP_SUPERNODE_INTEROP_LOG_BACKFILL_DEPTH=0s` to disable the backfill.
-  </Warning>
+  The supernode picks up the interop activation timestamp and the dependency set from the rollup configs once those land in the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry) — no manual override is required at this layer.
 
-  Configure the beacon archive fallback from the start.
-  A supernode that has been offline past a regular beacon node's blob-prune window (about 18 days) cannot recover the missing blobs from the primary beacon alone, and chain containers will stall at the gap.
+  If your primary beacon node prunes blob sidecars (the Ethereum default is about 18 days), configure `--l1.beacon-fallbacks` against a non-pruning beacon or an archiver service from the start.
+  A supernode that has been offline past the primary beacon's prune window cannot recover the missing blobs alone, and chain containers will stall at the gap.
 
   For the full flag reference and recommendations, see the [supernode configuration guide](/node-operators/guides/configuration/supernode).
   </Step>
@@ -275,4 +263,5 @@ If you scrape Prometheus, the equivalent gauge on a Light CL is `op_node_default
 * [Specialized op-node topology notice](/notices/specialized-node-topology) — operator-facing pattern for running Light CL fleets behind a safe source.
 * [Interop reorg awareness](/op-stack/interop/reorg) — how the safety model handles equivocation and L1 reorgs.
 * [Cross-chain security measures](/op-stack/security/interop-security) — how the safety level for inbound cross-chain messages is configured at the chain level.
+* [Running op-reth with Historical Proofs](/node-operators/tutorials/reth-historical-proofs) — only relevant if you also run op-challenger; configures the supernode's ELs to serve historical proofs.
 

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -157,7 +157,17 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
   OP_SUPERNODE_RPC_PORT: "8545"
   ```
 
-  The supernode picks up the interop activation timestamp and the dependency set from the rollup configs once those land in the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry) — no manual override is required at this layer.
+  The supernode loads the interop activation timestamp from each chain's rollup config — no manual override is required there.
+  The dependency set isn't yet loaded from the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry), so set it explicitly with `--vn.all.interop.dependency-set=<path>` (env: `OP_SUPERNODE_VN_ALL_INTEROP_DEPENDENCY_SET`), pointing at a JSON file that lists the two chains:
+
+  ```json
+  {
+    "dependencies": {
+      "11155420": {},
+      "1301": {}
+    }
+  }
+  ```
 
   If your primary beacon node prunes blob sidecars (the Ethereum default is about 18 days), configure `--l1.beacon-fallbacks` against a non-pruning beacon or an archiver service from the start.
   A supernode that has been offline past the primary beacon's prune window cannot recover the missing blobs alone, and chain containers will stall at the gap.

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -121,7 +121,7 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
 
   Each EL in the fleet has exactly one consensus client connected to it.
   The supernode drives its ELs via per-chain virtual nodes; each Light CL also gets its own EL.
-  The supernode shares one JWT secret across its internal virtual nodes via `OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH` (set the path once at the supernode level).
+  Set one JWT secret path for all of the supernode's virtual nodes via `OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH`, or override per chain with `OP_SUPERNODE_VN_<CHAINID>_L2_ENGINE_AUTH` if a chain's EL needs its own secret.
   Each Light CL connects to its EL with its own `--l2.jwt-secret` flag.
   </Step>
 

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -122,7 +122,7 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
   Each EL in the fleet has exactly one consensus client connected to it.
   The supernode drives its ELs via per-chain virtual nodes; each Light CL also gets its own EL.
   The supernode shares one JWT secret across its internal virtual nodes via `OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH` (set the path once at the supernode level).
-  Each Light CL connects to its EL with its own `--l2.jwt-secret` flag — whether you use the same secret across the fleet or scope each CL-EL pair to its own secret is an operator choice.
+  Each Light CL connects to its EL with its own `--l2.jwt-secret` flag.
   </Step>
 
   <Step title="Stand up op-supernode for both chains">

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -119,6 +119,8 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
     --authrpc.jwtsecret=/etc/op/jwt-secret.txt
   ```
 
+  The example binds the engine RPC to `127.0.0.1`. If op-reth runs in a Docker container, or on a different host from the supernode, set `--authrpc.addr=0.0.0.0` (or a specific interface IP reachable from the supernode) and restrict access at the network layer.
+
   Each EL in the fleet has exactly one consensus client connected to it.
   The supernode drives its ELs via per-chain virtual nodes; each Light CL also gets its own EL.
   Set one JWT secret path for all of the supernode's virtual nodes via `OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH`, or override per chain with `OP_SUPERNODE_VN_<CHAINID>_L2_ENGINE_AUTH` if a chain's EL needs its own secret.

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -157,18 +157,6 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
   OP_SUPERNODE_RPC_PORT: "8545"
   ```
 
-  The supernode loads the interop activation timestamp from each chain's rollup config — no manual override is required there.
-  The dependency set isn't yet loaded from the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry), so set it explicitly with `--vn.all.interop.dependency-set=<path>` (env: `OP_SUPERNODE_VN_ALL_INTEROP_DEPENDENCY_SET`), pointing at a JSON file that lists the two chains:
-
-  ```json
-  {
-    "dependencies": {
-      "11155420": {},
-      "1301": {}
-    }
-  }
-  ```
-
   If your primary beacon node prunes blob sidecars (the Ethereum default is about 18 days), configure `--l1.beacon-fallbacks` against a non-pruning beacon or an archiver service from the start.
   A supernode that has been offline past the primary beacon's prune window cannot recover the missing blobs alone, and chain containers will stall at the gap.
 

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -119,8 +119,10 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
     --authrpc.jwtsecret=/etc/op/jwt-secret.txt
   ```
 
-  Each EL has exactly one consensus client connected to it — the supernode's virtual node for that chain.
-  Sharing the same JWT secret file across both ELs is the simplest configuration; the supernode references it once via `OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH`.
+  Each EL in the fleet has exactly one consensus client connected to it.
+  The supernode drives its ELs via per-chain virtual nodes; each Light CL also gets its own EL.
+  The supernode shares one JWT secret across its internal virtual nodes via `OP_SUPERNODE_VN_ALL_L2_ENGINE_AUTH` (set the path once at the supernode level).
+  Each Light CL connects to its EL with its own `--l2.jwt-secret` flag — whether you use the same secret across the fleet or scope each CL-EL pair to its own secret is an operator choice.
   </Step>
 
   <Step title="Stand up op-supernode for both chains">

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -19,7 +19,7 @@ audit-source:
   - op-node/rollup/interop/config.go
 ---
 
-OP Stack interop is expected to activate on **OP Sepolia** (chain ID `11155420`) and **Unichain Sepolia** (chain ID `1301`) in **late June 2026**, forming a two-chain interop dependency set on testnet.
+OP Stack interop is expected to activate on **OP Sepolia** (chain ID `11155420`) and **Unichain Sepolia** (chain ID `1301`) in in **July of 2026**, forming a two-chain interop dependency set on testnet.
 Node operators on either chain must change their topology before the activation timestamp: each operator runs one or more [op-supernode](/op-stack/interop/supernode) instances that derive both chains and validate the cross-chain messages between them, and the rest of the fleet runs as [Light CLs](/notices/specialized-node-topology) that follow the supernode.
 
 <Warning>

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -99,7 +99,7 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
   ELs can start unsynced; they wait until the supernode connects before they know what chain head to sync to.
   The supernode then drives each EL through its initial sync via the engine API, and tolerates the common case where one chain's EL is already synced and the other isn't.
   Configure each EL to retain block and receipt history for at least 7 days so the supernode can backfill initiating-message logs (a full archive isn't required — see the [op-reth configuration reference](/node-operators/reference/op-reth-config) for the granular `--prune.*` flags).
-  If you also run op-challenger for permissionless fault proofs, these ELs additionally need historical proofs enabled — see [Running op-reth with Historical Proofs](/node-operators/tutorials/reth-historical-proofs). Pure node operators (RPC, exchange, indexer) without op-challenger can skip that.
+  If you also run op-challenger for permissionless fault proofs, these ELs have additional historical data requirements that go beyond the 7-day baseline above — see [Running op-reth with Historical Proofs](/node-operators/tutorials/reth-historical-proofs) for the retention window and configuration. Pure node operators without op-challenger can skip that.
 
   ```bash
   # OP Sepolia execution client

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -93,7 +93,8 @@ Layer your usual production flags (monitoring, logging, P2P tuning, RPC modules,
 <Steps>
   <Step title="Stand up execution clients for both chains">
   Run at least one op-reth process for OP Sepolia and at least one for Unichain Sepolia.
-  Execution clients are not shared across chains; each supernode instance connects to exactly one engine-API endpoint per chain, and production fleets typically run several execution clients per chain to match the supernode tier and Light CL pool.
+  Execution clients are not shared across chains.
+  For each chain, plan one EL per consensus client connecting to it — one per supernode virtual node, plus one per Light CL in your fleet.
   Each execution client needs its own JWT secret file (a single shared file across both ELs is fine — see the note at the end of this step) and its own engine-API listen address.
   ELs can start unsynced; they wait until the supernode connects before they know what chain head to sync to.
   The supernode then drives each EL through its initial sync via the engine API, and tolerates the common case where one chain's EL is already synced and the other isn't.

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prepare for interop on OP Sepolia and Unichain Sepolia
-description: Node operator action checklist for the OP Sepolia and Unichain Sepolia interop activation, targeted for late June 2026.
+description: Node operator action checklist for the OP Sepolia and Unichain Sepolia interop activation, targeted in July of 2026.
 lang: en-US
 content_type: notice
 topic: interop-prep

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -31,7 +31,7 @@ Node operators on either chain must change their topology before the activation 
 </Warning>
 
 <Info>
-  The activation timestamps for OP Sepolia and Unichain Sepolia are planned for **late June 2026** but have not yet been finalized.
+  The activation timestamps for OP Sepolia and Unichain Sepolia are planned for in **July of 2026** but have not yet been finalized.
   Final timestamps will be published in the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry) once governance approves the rollup-config update.
   This page will be updated with the exact timestamps once they are pinned.
   Interop on mainnet OP Stack chains is planned as a follow-up rollout after this testnet activation; mainnet activation timestamps will be announced separately.

--- a/docs/public-docs/notices/specialized-node-topology.mdx
+++ b/docs/public-docs/notices/specialized-node-topology.mdx
@@ -15,17 +15,17 @@ is_imported_content: 'false'
 
 Historically, every `op-node` in a fleet has independently derived the [safe chain](https://docs.optimism.io/op-stack/reference/glossary#safe-l2-block) from L1 while also consolidating [unsafe blocks](https://docs.optimism.io/op-stack/reference/glossary#unsafe-l2-block) received over gossip. As fleets grow and upcoming features like interop raise the cost of derivation, we **highly recommend** migrating to a **specialized topology** in which a small number of `op-node` instances are dedicated to L1 derivation and the rest defer to those sources.
 
-In the specialized topology, **light nodes** are started with `--l2.follow.source` pointing at a traditional `op-node` acting as the derivation source. Light nodes disable their own independent derivation and instead receive the safe chain from the source, while continuing to track the unsafe tip via gossip and the engine API.
+In the specialized topology, **light nodes** are started with `--l2.follow.source` pointing at a derivation source. The source is an `op-node` for chains without interop activation, or an [`op-supernode`](/op-stack/interop/supernode) for chains in an interop dependency set (one supernode derives every chain in the set together and adds cross-chain message verification). Light nodes disable their own independent derivation and instead receive the safe chain from the source, while continuing to track the unsafe tip via gossip and the engine API.
 
 <Warning>
-  This topology will become **required** for node operators running OP Mainnet and/or Unichain nodes in the future.
+  **Required for upcoming interop activation.** This topology is required for node operators on **OP Sepolia** and **Unichain Sepolia** once interop activates on those chains in late June 2026 — see [Prepare for interop on OP Sepolia and Unichain Sepolia](/notices/interop-prep) for the action checklist. The corresponding mainnet activation will carry the same requirement.
 </Warning>
 
 ## What this means
 
-*   **Source nodes** are traditional `op-node` instances configured to derive the full chain from L1, exactly as today.
-*   **Light nodes** are `op-node` instances started with `--l2.follow.source=<source op-node RPC>`. They stop deriving from L1 themselves and receive the safe chain from the designated source.
-*   `op-node` is **not** being deprecated, and the homogeneous topology is **not** being removed. This is a recommended operational upgrade, not a required migration.
+*   **Source nodes** derive the full chain from L1. For chains without interop, this is a traditional `op-node`. For chains in an interop dependency set, it is an `op-supernode`, which derives every chain in the set together and verifies cross-chain messages.
+*   **Light nodes** are `op-node` instances started with `--l2.follow.source=<source RPC endpoint>`. They stop deriving from L1 themselves and receive the safe chain from the designated source — an op-node RPC for non-interop chains, an op-supernode RPC (with the chain's `/<chainID>` path prefix) for interop chains.
+*   `op-node` is **not** being deprecated, and the homogeneous topology is **not** being removed. For chains where interop has not activated, this is a recommended operational upgrade rather than a required migration. For OP Sepolia and Unichain Sepolia, it becomes required at interop activation (see the Warning above).
 *   Only the derivation role changes. Light nodes continue to serve RPC, participate in gossip, and drive their connected execution client as before.
 
 ## Why this matters
@@ -52,7 +52,7 @@ Future upgrades — including interop — will require more sophisticated deriva
 
 Plan a migration from a homogeneous fleet of derivation-enabled `op-node` instances to a specialized topology:
 
-1.  Designate one or more `op-node` instances as **source** nodes. These continue to run with full L1 derivation and should be sized and monitored accordingly, including redundancy for failover.
+1.  Stand up the **source tier**. For chains without interop, designate one or more `op-node` instances as sources, configured with full L1 derivation. For chains in an interop dependency set, the source tier is one or more `op-supernode` instances covering every chain in the set. Either way, size and monitor the source tier with redundancy for failover.
 2.  Provision the remaining `op-node` instances as **light nodes** by setting `--l2.follow.source=<source op-node RPC endpoint>` (env: `OP_NODE_L2_FOLLOW_SOURCE`). Ensure light nodes can reach the source endpoint over a reliable, low-latency network path.
 3.  Validate that light nodes track the safe chain correctly against the source before shifting production traffic.
 4.  Update dashboards and alerting so the source tier's health is treated as a dependency of the light-node tier.
@@ -63,11 +63,11 @@ For production deployments, we recommend placing the derivation tier behind a [c
 
 <img src="/public/img/notices/light-node-topology.png" alt="Specialized op-node topology: three source op-nodes with EL (Reth) feed a consensus-aware proxyd via CL API, which fans out to two light op-nodes via --l2.follow.source" style={{ width: '100%', height: 'auto' }} />
 
-*   **Deriver tier** — a small, redundant set of derivation-enabled `op-node` instances (the sources). These sit behind a `proxyd` configured with routing strategy: `consensus_aware_consensus_layer`, which aggregates the mutiple op-node sources into a single highly available endpoint and hides individual failures or reorgs from downstream consumers.
+*   **Deriver tier** — a small, redundant set of source instances (`op-node` for non-interop chains, `op-supernode` for interop chains). These sit behind a `proxyd` configured with routing strategy: `consensus_aware_consensus_layer`, which aggregates the multiple sources into a single highly available endpoint and hides individual failures or reorgs from downstream consumers.
 *   **Light-node tier** — a horizontally scalable pool of light `op-node` instances started with `--l2.follow.source` pointed at the deriver-tier `proxyd` endpoint. This tier can be scaled up and down independently based on read traffic.
 *   **Edge tier** — an API gateway or user-facing `proxyd` that fronts the light-node tier and handles external RPC traffic, rate limiting, and routing.
 
-In all cases, consider your existing topology and apply node specialization in a way that works best with your deployment stack. The goal is to have a minimal, well defined set of deriving op-nodes, and a scalable collection of light nodes.
+In all cases, consider your existing topology and apply node specialization in a way that works best with your deployment stack. The goal is to have a minimal, well defined source tier (op-node or op-supernode, per chain) and a scalable collection of light nodes pointed at it.
 
 ### Chain operators
 
@@ -75,14 +75,15 @@ All guidance for Node Operators is applicable to Chain Operators. For `op-node` 
 of the Sequencer is to maintain and extend the Unsafe Chain.
 
 <Info>
-  The specialized topology is a recommendation, not a hard requirement. Existing homogeneous deployments continue to work. Migration can be done incrementally, one light node at a time.
+  On chains where interop has not activated, the specialized topology is a recommendation, not a hard requirement. Existing homogeneous deployments on those chains continue to work, and migration can be done incrementally, one light node at a time.
 </Info>
 
 <Warning>
-  `op-node` on its own may not remain sufficient to serve as a derivation source for all future features. As the stack evolves — for example with interop — the source role may need to be enhanced or replaced by additional software alongside `op-node`. Operators who keep running large fleets of derivation-enabled `op-node` instances should expect a higher operational burden over time: more L1 API cost today, and a per-node cost to upgrade every derivation-enabled instance as those changes land. Specializing the topology now minimizes the number of nodes affected by those future upgrades.
+  `op-node` is not sufficient as a derivation source for chains in an interop dependency set — those chains use [`op-supernode`](/op-stack/interop/supernode), which derives every chain in the set together and verifies cross-chain messages. Future protocol features may impose similar requirements on other chains. Operators who keep running large fleets of derivation-enabled `op-node` instances on chains where the source role is changing should expect a higher operational burden: more L1 API cost today, and a per-node cost to upgrade every derivation-enabled instance as new derivation requirements land. Specializing the topology now minimizes the number of nodes affected by those changes.
 </Warning>
 
 ## Resources
 
+*   [Interop prep notice](/notices/interop-prep) — node-operator action checklist for the OP Sepolia and Unichain Sepolia interop activation, where this topology is required rather than recommended.
 *   `--l2.follow.source` flag (env: `OP_NODE_L2_FOLLOW_SOURCE`) — configures an `op-node` as a light node pointed at a source `op-node` RPC endpoint.
 *   `--l2.follow.source.rpc-timeout` flag (env: `OP_NODE_L2_FOLLOW_SOURCE_RPC_TIMEOUT`) — tunes the RPC call timeout used when talking to the source (default `10s`).

--- a/docs/public-docs/op-stack/interop/supernode.mdx
+++ b/docs/public-docs/op-stack/interop/supernode.mdx
@@ -153,6 +153,7 @@ graph LR
 
 ## Where to go next
 
+*   Read the [interop prep notice](/notices/interop-prep) for the node-operator action checklist for the OP Sepolia and Unichain Sepolia activation.
 *   Read the [supernode configuration guide](/node-operators/guides/configuration/supernode) for the flag reference and a starter configuration.
 *   Read the [specialized op-node topology notice](/notices/specialized-node-topology) for the operator-facing pattern of running light op-nodes with `--l2.follow.source`, the fleet-side of the supernode-plus-light-CL topology.
 *   Read [interop reorg awareness](/op-stack/interop/reorg) for how the safety model handles equivocation and L1 reorgs.


### PR DESCRIPTION
## Summary

Adds [`notices/interop-prep.mdx`](docs/public-docs/notices/interop-prep.mdx) — the node-operator action checklist for the upcoming OP Sepolia + Unichain Sepolia interop activation (targeted for July 2026 via the Lagoon hardfork).

The notice walks operators through:

1. **Standing up `op-reth` execution clients per chain** (`--chain=optimism-sepolia` and `--chain=unichain-sepolia`). ELs start unsynced; the supernode drives them through their initial sync via the engine API.
2. **Standing up `op-supernode`** covering both chains, with shared L1 + beacon and per-chain virtual-node configuration.
3. **Migrating every `op-node` in the fleet to Light CL mode** via `--l2.follow.source` pointed at the supernode's per-chain RPC prefix.
4. **Placing supernodes behind a consensus-aware `proxyd`** (HA pool of at least three instances).

Also updates the existing topology and supernode pages to reflect the new reality:

- `notices/specialized-node-topology.mdx` — top Warning reframed as a concrete requirement for OP Sepolia / Unichain Sepolia at activation; descriptions throughout reflect that the source tier can be `op-node` (non-interop chains) or `op-supernode` (interop chains).
- `op-stack/interop/supernode.mdx` — added forward-link to the new interop-prep notice in "Where to go next".
- `node-operators/guides/configuration/supernode.mdx` — added forward-link to the new interop-prep notice in "Where to go next", plus two new Recommendations distilled from this work: **EL retention** (7+ days of block + receipt history is required for supernode backfill; full archive isn't) and **HA pool** (OP Labs recommends at least three op-supernode instances behind a consensus-aware proxyd). Both apply to any supernode deployment, so they belong as durable Recommendations on the config guide rather than only in this notice.
- `docs.json` — adds the new notice at the top of the Notices sidebar group.

## Verification

Every command, flag, env var, log message, metric name, and JSON-RPC method documented in the notice was verified end-to-end against running binaries:

- Built `op-supernode` and `op-node` from `develop`; pulled `op-reth:latest` from the Paradigm registry.
- Booted both `op-reth` instances (`optimism-sepolia` + `unichain-sepolia`), the supernode against public Sepolia L1/beacon endpoints, and an `op-node` Light CL pointed at the supernode's per-chain RPC prefix.
- Confirmed engine connections, RPC + metrics endpoint binds, per-chain `chain_id` log tags, the dominant log messages (`"Advancing bq origin"` on the supernode, `"Follow Source: Process external refs"` / `"Follow Upstream"` on the Light CL), the `op_node_supernode_refs_number{layer="l2",type="l2_safe",virtual_node_chain_id=...}` gauge for both chains, and the `supernode_syncStatus` JSON-RPC response shape.
- Caught and fixed during verification: missing `--l1` and `--l1.beacon` flags in the Light CL example (op-node rejects without them).

## Review feedback

Iteratively refined against feedback from @sbvegan, @ajsutton, and @jelias2. Notable changes from review:

- EL bring-up framing: ELs start unsynced; the supernode drives them. An EL has no chain head to target on its own.
- JWT wording: one CL per EL is the architectural rule; `vn.all.l2.jwt-secret` is the simple shared-secret path, `vn.<chainID>.l2.jwt-secret` is available for operators who want per-VN secrets.
- Beacon archive fallback marked optional in YAML + prose (only required if the primary beacon prunes blob sidecars before the supernode needs them).
- Conditional pointer to the historical-proofs tutorial for operators who also run op-challenger.
- op-reth is the only recommended execution client (op-geth EoS lands May 31, 2026 — before interop activation).

## Test plan

- [ ] `mintlify dev` from `docs/public-docs/` renders the new notice and the updated topology / supernode pages without build errors.
- [ ] Notice appears at the top of the Notices sidebar group.
- [ ] All internal links resolve (lint script reports 0 broken links across the modified files).
- [ ] Code blocks render with the correct language tags and syntax highlighting.
- [ ] No regression on the existing op-geth-deprecation cross-link.
- [ ] Supernode config guide's new Recommendations (EL retention, HA pool) render cleanly and don't disrupt the existing Recommendations flow.

## Notes for reviewers

- Activation timestamps and pinned binary versions remain `TBD` — the notice has callouts explaining this will be updated once the activation rollup-config update is approved.
- The op-supernode releases pointer reflects current pre-stable status; will firm up once a 1.0 ships.
- The Light CL log example uses placeholder hashes / numbers and a representative future date for clarity; operator will see real values in their environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)