### PR TITLE
feat(kona): compose prestates from per-component melange packages

### DIFF
--- a/rust/justfile
+++ b/rust/justfile
@@ -413,51 +413,19 @@ build-kona-prestate VARIANT OUTPUT_DIR:
     cp "$OUTPUT/prestate.bin.gz" "$OUTPUT/${HASH}.bin.gz"
     echo "Prestate for {{VARIANT}}: ${HASH}"
 
-# Build a single reproducible kona prestate variant via Docker.
-# Cannon is built from source as a stage within the Dockerfile.
-# Build context is the monorepo root (same pattern as op-program).
+# Build a single reproducible kona prestate variant via melange + apko.
+# Cannon and the kona-client MIPS64 ELF are built from source as separate
+# composed melange packages (see rust/kona/docker/fpvm-prestates/).
 # Set KONA_CUSTOM_CONFIGS_DIR to bake custom chain configs into the prestate.
 build-kona-reproducible-prestate-variant VARIANT OUTPUT_DIR:
     #!/usr/bin/env bash
     set -euo pipefail
-
-    MONOREPO_ROOT="{{justfile_directory()}}/.."
     OUTPUT="{{KONA_DIR}}/{{OUTPUT_DIR}}"
+    "{{KONA_DIR}}/docker/fpvm-prestates/build-apko-prestates.sh" {{VARIANT}} "$OUTPUT"
 
-    # The Dockerfile always copies from the `kona-custom-configs` named build
-    # context, so point it at an empty temp dir when no configs are requested.
-    if [[ -n "${KONA_CUSTOM_CONFIGS_DIR:-}" ]]; then
-      if [[ ! -d "${KONA_CUSTOM_CONFIGS_DIR}" ]]; then
-        echo "KONA_CUSTOM_CONFIGS_DIR=${KONA_CUSTOM_CONFIGS_DIR} is not a directory" >&2
-        exit 1
-      fi
-      CUSTOM_CONFIGS_CONTEXT="${KONA_CUSTOM_CONFIGS_DIR}"
-      CUSTOM_CONFIGS_FLAG=true
-    else
-      CUSTOM_CONFIGS_CONTEXT=$(mktemp -d)
-      trap 'rm -rf "${CUSTOM_CONFIGS_CONTEXT}"' EXIT
-      CUSTOM_CONFIGS_FLAG=false
-    fi
-
-    docker build \
-      --platform linux/amd64 \
-      --build-arg VARIANT={{VARIANT}} \
-      --build-arg KONA_CUSTOM_CONFIGS="${CUSTOM_CONFIGS_FLAG}" \
-      --build-context kona-custom-configs="${CUSTOM_CONFIGS_CONTEXT}" \
-      --output "$OUTPUT" \
-      --progress plain \
-      -f "{{KONA_DIR}}/docker/fpvm-prestates/cannon-repro.dockerfile" \
-      "$MONOREPO_ROOT"
-
-    # Add hash-named copy for challenger lookup
-    HASH=$(jq -r .pre "$OUTPUT/prestate-proof.json")
-    cp "$OUTPUT/prestate.bin.gz" "$OUTPUT/${HASH}.bin.gz"
-    echo "Prestate for {{VARIANT}}: ${HASH}"
-
-# Build all reproducible kona prestates via Docker
+# Build all reproducible kona prestates via melange + apko
 build-kona-reproducible-prestate:
-    @just build-kona-reproducible-prestate-variant kona-client prestate-artifacts-cannon
-    @just build-kona-reproducible-prestate-variant kona-client-int prestate-artifacts-cannon-interop
+    "{{KONA_DIR}}/docker/fpvm-prestates/build-apko-prestates.sh"
 
 output-kona-prestate-hash:
     @echo "-------------------- Kona Prestates --------------------"

--- a/rust/kona/docker/fpvm-prestates/README.md
+++ b/rust/kona/docker/fpvm-prestates/README.md
@@ -1,28 +1,53 @@
 # `fpvm-prestates`
 
-Images for creating reproducible `kona-client` prestate builds for supported fault proof virtual machines.
+Composed melange + apko configs for building reproducible `kona-client`
+prestates for the cannon fault proof VM.
 
-Cannon is built from the local monorepo source.
+The build is split into four melange packages so each component's recipe
+uses stock `uses:` pipelines and any one component can be rebuilt without
+recompiling the others:
+
+| Package | Pipeline | Purpose |
+| --- | --- | --- |
+| `rust-nightly-2026-02-20` | `uses: fetch` | Pinned Rust nightly toolchain + `rust-src` (hash-pinned tarballs from `static.rust-lang.org`) |
+| `cannon` | `uses: go/build` (x2) | MIPS64 FPVM emulator. `cannon64-impl` is built first and embedded into `multicannon`. |
+| `kona-client-elf` | `uses: cargo/build-no-auditable` (x2) | `kona-client` and `kona-client-int` MIPS64 ELFs |
+| `kona-prestates` | composed; depends on `cannon` + `kona-client-elf` | Runs cannon over each ELF to generate `prestate.bin.gz` + `prestate-proof.json` |
+
+apko then composes the final image from `kona-prestates` alone.
+
+`cargo/build-no-auditable` is a local pipeline definition under
+`melange-pipelines/cargo/`. It vendors stock `cargo/build` and swaps
+`cargo auditable build` for plain `cargo build`. cargo-auditable panics
+on `-Zjson-target-spec` builds, and the resulting MIPS64 no_std binary
+could not carry the auditable section anyway. See the file for details.
+
+## Prerequisites
+
+- `melange` and `apko`
+- `bubblewrap` (Linux) or `docker` (macOS) for the melange runner
+- `jq` and `rsync`
 
 ## Usage
 
-### `kona-client` + `cannon` prestate artifacts
+Generate both `kona-client` and `kona-client-int` prestates into the
+existing checked-in output directories:
 
 ```sh
-# Produce the prestate artifacts for `kona-client` running on `cannon` (built from local monorepo source)
-just cannon <kona|kona-int>
+cd ../../..
+just build-kona-reproducible-prestate
 ```
 
-### `kona-client` + `cannon` prestate artifacts with custom output directory
+Build a single variant into a custom output dir:
 
 ```sh
-just cannon <kona|kona-int> <artifacts_output_dir>
+cd ../../..
+just build-kona-reproducible-prestate-variant <kona-client|kona-client-int> <output_dir>
 ```
 
-### `kona-client` + `cannon` prestate artifacts for custom chains
-
-To create a reproducible kona-client prestate build that supports custom or devnet chain configurations that are not in the superchain-registry:
+Build a prestate that bakes in custom chain configs:
 
 ```sh
-just cannon <kona|kona-int> <artifacts_output_dir> <custom_config_dir>
+cd ../../..
+KONA_CUSTOM_CONFIGS_DIR=<custom_config_dir> just build-kona-reproducible-prestate
 ```

--- a/rust/kona/docker/fpvm-prestates/build-apko-prestates.sh
+++ b/rust/kona/docker/fpvm-prestates/build-apko-prestates.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Build reproducible kona-client cannon prestates as composed apko/melange
+# packages:
+#
+#   rust-nightly-2026-02-20  (pinned nightly toolchain APK, hash-pinned fetch)
+#   cannon                   (Go MIPS64 emulator; uses: go/build)
+#   kona-client-elf          (Rust MIPS64 ELFs; uses: cargo/build-no-auditable,
+#                             local pipeline override; depends rust-nightly)
+#   kona-prestates           (cannon-runs-over-ELFs glue; depends cannon +
+#                             kona-client-elf)
+#
+# apko then composes the final image from kona-prestates alone. The script
+# extracts the prestate artifacts back into the existing checked-in output
+# directories so downstream tooling does not need to change.
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 [kona-client|kona-client-int OUTPUT_DIR]" >&2
+}
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+KONA_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+RUST_ROOT=$(cd "${KONA_ROOT}/.." && pwd)
+REPO_ROOT=$(cd "${RUST_ROOT}/.." && pwd)
+
+CANNON_CONFIG="${SCRIPT_DIR}/cannon.melange.yaml"
+NIGHTLY_CONFIG="${SCRIPT_DIR}/rust-nightly-2026-02-20.melange.yaml"
+ELF_CONFIG="${SCRIPT_DIR}/kona-client-elf.melange.yaml"
+PRESTATES_MELANGE="${SCRIPT_DIR}/kona-prestates.melange.yaml"
+APKO_CONFIG="${SCRIPT_DIR}/kona-prestates.apko.yaml"
+PIPELINES_DIR="${SCRIPT_DIR}/melange-pipelines"
+
+case "$#" in
+  0)
+    KONA_PRESTATE_VARIANTS="kona-client,kona-client-int"
+    ;;
+  2)
+    case "$1" in
+      kona-client | kona-client-int) ;;
+      *) usage; exit 2 ;;
+    esac
+    KONA_PRESTATE_VARIANTS="$1"
+    ;;
+  *) usage; exit 2 ;;
+esac
+
+for bin in melange apko tar jq; do
+  command -v "${bin}" >/dev/null 2>&1 || { echo "missing required command: ${bin}" >&2; exit 1; }
+done
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+PACKAGES_DIR="${KONA_PRESTATE_PACKAGES_DIR:-${TMP_DIR}/packages}"
+MELANGE_KEY="${MELANGE_KEY:-${TMP_DIR}/melange.rsa}"
+CACHE_DIR="${KONA_PRESTATE_CACHE_DIR:-${TMP_DIR}/cache}"
+if [ -z "${MELANGE_RUNNER:-}" ]; then
+  if [ "$(uname -s)" = "Linux" ]; then MELANGE_RUNNER="bubblewrap"; else MELANGE_RUNNER="docker"; fi
+fi
+
+mkdir -p "${PACKAGES_DIR}" "${CACHE_DIR}"
+if [ ! -f "${MELANGE_KEY}" ]; then
+  melange keygen "${MELANGE_KEY}"
+fi
+
+# stage_paths SOURCE_DIR PATH...
+# rsync each PATH (relative to REPO_ROOT) into SOURCE_DIR, excluding build
+# output directories.
+stage_paths() {
+  local src_dir=$1; shift
+  for path in "$@"; do
+    local source="${REPO_ROOT}/${path}"
+    local dest_parent="${src_dir}/$(dirname "${path}")"
+    if [ ! -e "${source}" ]; then echo "missing source path: ${path}" >&2; exit 1; fi
+    mkdir -p "${dest_parent}"
+    rsync -a \
+      --exclude 'target/' \
+      --exclude 'prestate-artifacts-cannon/' \
+      --exclude 'prestate-artifacts-cannon-interop/' \
+      "${source}" "${dest_parent}/"
+  done
+}
+
+run_melange() {
+  local config=$1; shift
+  melange build "${config}" \
+    --arch x86_64 \
+    --runner "${MELANGE_RUNNER}" \
+    --signing-key "${MELANGE_KEY}" \
+    --out-dir "${PACKAGES_DIR}" \
+    --cache-dir "${CACHE_DIR}" \
+    --keyring-append "${MELANGE_KEY}.pub" \
+    --repository-append "${PACKAGES_DIR}" \
+    --pipeline-dir "${PIPELINES_DIR}" \
+    "$@"
+}
+
+# 1. Cannon (Go).
+CANNON_SRC="${TMP_DIR}/cannon-src"
+mkdir -p "${CANNON_SRC}"
+stage_paths "${CANNON_SRC}" go.mod go.sum cannon op-service op-preimage
+run_melange "${CANNON_CONFIG}" --source-dir "${CANNON_SRC}"
+
+# 2. Rust nightly toolchain. No source required; the package fetches signed
+#    tarballs from static.rust-lang.org by hash.
+run_melange "${NIGHTLY_CONFIG}"
+
+# 3. kona-client-elf (Rust MIPS64).
+ELF_SRC="${TMP_DIR}/kona-src"
+mkdir -p "${ELF_SRC}"
+stage_paths "${ELF_SRC}" rust op-core/nuts/bundles
+
+if [ -n "${KONA_CUSTOM_CONFIGS_DIR:-}" ]; then
+  if [ ! -d "${KONA_CUSTOM_CONFIGS_DIR}" ]; then
+    echo "KONA_CUSTOM_CONFIGS_DIR=${KONA_CUSTOM_CONFIGS_DIR} is not a directory" >&2
+    exit 1
+  fi
+  rsync -a "${KONA_CUSTOM_CONFIGS_DIR}/" "${ELF_SRC}/kona-custom-configs/"
+fi
+run_melange "${ELF_CONFIG}" --source-dir "${ELF_SRC}"
+
+# 4. Compose prestate artifacts. No source dir; runs cannon over installed ELFs.
+ENV_FILE="${TMP_DIR}/melange.env"
+printf 'KONA_PRESTATE_VARIANTS=%s\n' "${KONA_PRESTATE_VARIANTS}" >"${ENV_FILE}"
+run_melange "${PRESTATES_MELANGE}" --env-file "${ENV_FILE}"
+
+# 5. Build the apko image bundling kona-prestates only.
+apko build "${APKO_CONFIG}" "kona-prestates:local" "${TMP_DIR}/kona-prestates.tar" \
+  --arch x86_64 \
+  -k "${MELANGE_KEY}.pub" \
+  -r "${PACKAGES_DIR}"
+
+# 6. Extract prestate artifacts from the kona-prestates apk into the existing
+#    checked-in output layout.
+APK_PATH=$(find "${PACKAGES_DIR}/x86_64" -maxdepth 1 -type f -name 'kona-prestates-*.apk' | sort | tail -1)
+if [ -z "${APK_PATH}" ]; then
+  echo "kona-prestates APK was not produced under ${PACKAGES_DIR}/x86_64" >&2
+  exit 1
+fi
+EXTRACT_DIR="${TMP_DIR}/extract"
+mkdir -p "${EXTRACT_DIR}"
+tar -xzf "${APK_PATH}" -C "${EXTRACT_DIR}" usr/share/kona-prestates
+
+copy_variant() {
+  local variant=$1 output=$2
+  local source="${EXTRACT_DIR}/usr/share/kona-prestates/${variant}"
+  rm -rf "${output}"; mkdir -p "${output}"
+  cp "${source}/prestate.bin.gz" "${output}/prestate.bin.gz"
+  cp "${source}/prestate-proof.json" "${output}/prestate-proof.json"
+  cp "${source}/meta.json" "${output}/meta.json"
+  cp "${source}/kona-client-elf" "${output}/kona-client-elf"
+  local hash
+  hash=$(jq -r .pre "${output}/prestate-proof.json")
+  cp "${output}/prestate.bin.gz" "${output}/${hash}.bin.gz"
+  echo "Prestate for ${variant}: ${hash}"
+}
+
+if [ "$#" -eq 2 ]; then
+  copy_variant "$1" "$2"
+else
+  copy_variant kona-client "${KONA_ROOT}/prestate-artifacts-cannon"
+  copy_variant kona-client-int "${KONA_ROOT}/prestate-artifacts-cannon-interop"
+fi

--- a/rust/kona/docker/fpvm-prestates/cannon.melange.yaml
+++ b/rust/kona/docker/fpvm-prestates/cannon.melange.yaml
@@ -1,0 +1,50 @@
+package:
+  name: cannon
+  version: 0.0.1
+  epoch: 0
+  description: MIPS64 fault proof VM emulator (multicannon dispatcher with cannon64-impl embedded)
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - go-1.24
+
+# Reproducibility: the source tree is staged without `.git`, so the justfile's
+# `git rev-parse HEAD` / `git show -s` resolve empty and VERSION resolves to
+# "untagged". We reproduce that here via static ldflags so the build is
+# deterministic without invoking the justfile.
+pipeline:
+  - uses: go/build
+    with:
+      go-package: go-1.24
+      modroot: .
+      packages: ./cannon
+      output: cannon64-impl
+      install-dir: lib/cannon
+      ldflags: -X main.GitCommit= -X main.GitDate= -X github.com/ethereum-optimism/optimism/cannon/multicannon/version.Version=untagged -X github.com/ethereum-optimism/optimism/cannon/multicannon/version.Meta=
+
+  # Stage cannon64-impl into the multicannon embeds directory so the second
+  # build picks it up via go:embed. This is a single file-movement step; no
+  # network, no fetched code, no privilege beyond moving a freshly built
+  # artifact between known paths in the sandbox.
+  - name: Embed cannon64-impl into multicannon
+    runs: |
+      install -Dm755 \
+        "${{targets.contextdir}}/usr/lib/cannon/cannon64-impl" \
+        "${{package.srcdir}}/cannon/multicannon/embeds/cannon-8"
+      rm -rf "${{targets.contextdir}}/usr/lib/cannon"
+
+  - uses: go/build
+    with:
+      go-package: go-1.24
+      modroot: .
+      packages: ./cannon/multicannon
+      output: cannon
+      ldflags: -X main.GitCommit= -X main.GitDate= -X github.com/ethereum-optimism/optimism/cannon/multicannon/version.Version=untagged -X github.com/ethereum-optimism/optimism/cannon/multicannon/version.Meta=

--- a/rust/kona/docker/fpvm-prestates/kona-client-elf.melange.yaml
+++ b/rust/kona/docker/fpvm-prestates/kona-client-elf.melange.yaml
@@ -1,0 +1,56 @@
+package:
+  name: kona-client-elf
+  version: 0.0.1
+  epoch: 0
+  description: kona-client MIPS64 ELF binaries for cannon prestate generation
+  dependencies:
+    runtime:
+      - rust-nightly-2026-02-20
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - bash
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - clang-18
+      - cmake
+      - libclang-cpp-18
+      - openssl-dev
+      - perl
+      - pkgconf
+      - rust-nightly-2026-02-20
+  environment:
+    CARGO_NET_OFFLINE: "false"
+    # Force cargo to pick up our pinned nightly even when invoked without
+    # `cargo +nightly` (stock cargo/build pipeline shells out to `cargo`).
+    # Our rust-nightly package installs cargo/rustc at /usr/bin which
+    # supersedes rustup proxies.
+    RUST_BACKTRACE: "1"
+
+pipeline:
+  # Build kona-client (cannon variant) for MIPS64.
+  - uses: cargo/build-no-auditable
+    with:
+      modroot: rust
+      output: kona-client
+      output-dir: target/mips64-unknown-none/release-client-lto
+      install-dir: share/kona-prestate-elfs
+      rustflags: -Clink-arg=-e_start -Cllvm-args=-mno-check-zero-division
+      opts: --target kona/docker/cannon/mips64-unknown-none.json -Zbuild-std=core,alloc -Zjson-target-spec -p kona-client --bin kona-client --locked --profile release-client-lto
+
+  # Build kona-client-int (interop cannon variant) for MIPS64.
+  # Reuses the cargo build cache from the previous step.
+  - uses: cargo/build-no-auditable
+    with:
+      modroot: rust
+      output: kona-client-int
+      output-dir: target/mips64-unknown-none/release-client-lto
+      install-dir: share/kona-prestate-elfs
+      rustflags: -Clink-arg=-e_start -Cllvm-args=-mno-check-zero-division
+      opts: --target kona/docker/cannon/mips64-unknown-none.json -Zbuild-std=core,alloc -Zjson-target-spec -p kona-client --bin kona-client-int --locked --profile release-client-lto

--- a/rust/kona/docker/fpvm-prestates/kona-prestates.apko.yaml
+++ b/rust/kona/docker/fpvm-prestates/kona-prestates.apko.yaml
@@ -1,0 +1,11 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - wolfi-baselayout
+    - kona-prestates
+
+archs:
+  - x86_64

--- a/rust/kona/docker/fpvm-prestates/kona-prestates.melange.yaml
+++ b/rust/kona/docker/fpvm-prestates/kona-prestates.melange.yaml
@@ -1,0 +1,52 @@
+package:
+  name: kona-prestates
+  version: 0.0.1
+  epoch: 0
+  description: Reproducible kona-client cannon prestate artifacts (composed from cannon + kona-client-elf)
+
+# Composed package: depends on cannon (Go) and kona-client-elf (Rust nightly
+# MIPS64) APKs built as separate melange packages. The pipeline here is the
+# minimum it has to be: invoking cannon over the installed ELFs. There is no
+# language compilation in this package, hence no stock pipeline applies.
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - bash
+      - busybox
+      - cannon
+      - kona-client-elf
+
+vars:
+  variants: ${KONA_PRESTATE_VARIANTS}
+
+pipeline:
+  - name: Generate prestate artifacts for each variant
+    runs: |
+      set -euo pipefail
+
+      for variant in $(printf '%s' "${{vars.variants}}" | tr ',' ' '); do
+        elf="/usr/share/kona-prestate-elfs/${variant}"
+        out="${{targets.destdir}}/usr/share/kona-prestates/${variant}"
+        mkdir -p "${out}"
+
+        /usr/bin/cannon load-elf \
+          --path="${elf}" \
+          --out="${out}/prestate.bin.gz" \
+          --meta="${out}/meta.json" \
+          --type multithreaded64-5
+
+        /usr/bin/cannon run \
+          --proof-at "=0" \
+          --stop-at "=1" \
+          --input "${out}/prestate.bin.gz" \
+          --meta "${out}/meta.json" \
+          --proof-fmt "${out}/%d.json" \
+          --output ""
+
+        mv "${out}/0.json" "${out}/prestate-proof.json"
+        install -Dm755 "${elf}" "${out}/kona-client-elf"
+      done

--- a/rust/kona/docker/fpvm-prestates/melange-pipelines/cargo/build-no-auditable.yaml
+++ b/rust/kona/docker/fpvm-prestates/melange-pipelines/cargo/build-no-auditable.yaml
@@ -1,0 +1,89 @@
+name: Compile a rust binary with Cargo (without cargo-auditable wrapping)
+
+# Vendored from the stock melange `cargo/build` pipeline, with the
+# `cargo auditable build` invocation replaced by plain `cargo build`.
+#
+# cargo-auditable panics on `.json` target specs (it shells out to
+# `cargo metadata` which does not inherit `-Zjson-target-spec`). The
+# kona-client MIPS64 prestate build uses a custom JSON target spec, so
+# the stock pipeline fails. The resulting binary is a bare-metal no_std
+# ELF that `rust-audit-info` could not parse anyway, so dropping the
+# auditable section here loses nothing in practice.
+#
+# Every other behaviour (output paths, install step, flags) matches the
+# stock pipeline byte-for-byte so future stock-pipeline changes can be
+# rebased onto this file by diff.
+
+needs:
+  packages:
+    - build-base
+    - busybox
+    - rust
+
+inputs:
+  output:
+    description: |
+      Filename to use when writing the binary. The final install location inside
+      the apk will be in prefix / install-dir / output
+
+  opts:
+    default: --release
+    description: |
+      Options to pass to cargo build. Defaults to release
+
+  modroot:
+    default: "."
+    required: false
+    description: |
+      Top directory of the rust package, this is where the target package lives.
+      Before building, the cargo pipeline wil cd into this directory. Defaults
+      to current working directory
+
+  rustflags:
+    default: ""
+    required: false
+    description: |
+      Rustc flags to be passed to pass to all compiler invocations that Cargo performs.
+      In contrast with cargo rustc, this is useful for passing a flag to all compiler instances.
+      This string is split by whitespace.
+
+  prefix:
+    default: usr
+    description: |
+      Installation prefix. Defaults to usr
+
+  install-dir:
+    description: |
+      Directory where binaries will be installed
+    default: bin
+
+  output-dir:
+    description: |
+      Directory where the binaris will be placed after building. Defaults to target/release
+    default: target/release
+
+  jobs:
+    description: |
+      Override the number of parallel jobs. It defaults to the number of CPUs.
+
+pipeline:
+  - runs: |
+      # Installation directory should always be bin as we are producing a binary
+      INSTALL_PATH="${{targets.contextdir}}/${{inputs.prefix}}/${{inputs.install-dir}}"
+      OUTPUT_PATH="${{inputs.output-dir}}"
+
+      # Enter target package directory
+      cd "${{inputs.modroot}}"
+
+      jobs_flag=""
+      if [[ ! -z "${{inputs.jobs}}" ]]; then
+        jobs_flag="--jobs ${{inputs.jobs}}"
+      fi
+
+      # Build and install package(s)
+      RUSTFLAGS="${{inputs.rustflags}}" cargo build --target-dir target ${{inputs.opts}} $jobs_flag
+      if [[ ! -z "${{inputs.output}}" ]]; then
+        install -Dm755 "${OUTPUT_PATH}/${{inputs.output}}" "${INSTALL_PATH}/${{inputs.output}}"
+      else
+        install -Dm755 "${OUTPUT_PATH}"/* -t "${INSTALL_PATH}"
+      fi

--- a/rust/kona/docker/fpvm-prestates/rust-nightly-2026-02-20.melange.yaml
+++ b/rust/kona/docker/fpvm-prestates/rust-nightly-2026-02-20.melange.yaml
@@ -1,0 +1,52 @@
+package:
+  name: rust-nightly-2026-02-20
+  version: 1.99.0_alpha20260220
+  epoch: 0
+  description: Pinned Rust nightly toolchain (2026-02-20) for reproducible MIPS64 prestate builds
+  # Satisfies `needs.packages: rust` in stock melange cargo/build pipeline,
+  # so downstream packages can use `uses: cargo/build` without depending on
+  # the moving Wolfi stable `rust-N.NN` package.
+  dependencies:
+    provides:
+      - rust=1.99.0-r0
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - bash
+      - busybox
+      - xz
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://static.rust-lang.org/dist/2026-02-20/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
+      expected-sha256: bda49d109c835651724b4180262bc868af7cbca4ff30bdf241dff6231f0c73ac
+      strip-components: 1
+
+  - name: Install rustc, cargo, host rust-std
+    runs: |
+      ./install.sh \
+        --prefix=${{targets.destdir}}/usr \
+        --components=rustc,cargo,rust-std-x86_64-unknown-linux-gnu \
+        --disable-ldconfig
+      mkdir -p rust-src-staging
+
+  - uses: fetch
+    with:
+      uri: https://static.rust-lang.org/dist/2026-02-20/rust-src-nightly.tar.gz
+      expected-sha256: e5c216b3c0619fac01d966660e798d38bf5f86e0551e1d38a441ec02f55d0247
+      strip-components: 1
+      directory: rust-src-staging
+
+  - name: Install rust-src component
+    runs: |
+      cd rust-src-staging
+      ./install.sh \
+        --prefix=${{targets.destdir}}/usr \
+        --components=rust-src \
+        --disable-ldconfig


### PR DESCRIPTION
## Summary

Builds on #20635. Splits the single `kona-prestates` melange package into four composable packages so each piece uses stock melange `uses:` pipelines and decouples toolchain from app code:

| Package | Pipeline | Purpose |
| --- | --- | --- |
| `rust-nightly-2026-02-20` | `uses: fetch` | Hash-pinned nightly toolchain + `rust-src` from `static.rust-lang.org` |
| `cannon` | `uses: go/build` (x2) | MIPS64 FPVM emulator (`cannon64-impl` embedded into `multicannon`) |
| `kona-client-elf` | `uses: cargo/build-no-auditable` (x2) | `kona-client` + `kona-client-int` MIPS64 ELFs |
| `kona-prestates` | composed | Runs cannon over installed ELFs to emit `prestate.bin.gz` + `prestate-proof.json` |

`apko` composes the final image from `kona-prestates` alone.

### Why split

- Touch only Go side → `cannon` rebuilds, `kona-client-elf` APK reused.
- Touch only Rust side → `kona-client-elf` rebuilds, `cannon` APK reused.
- Nightly toolchain provenance lives in its own auditable package; app builds depend on it as a normal Wolfi-style APK rather than calling `rustup` inline.

### cargo/build-no-auditable

Local pipeline override at `melange-pipelines/cargo/build-no-auditable.yaml`. Identical to stock `cargo/build` except it invokes `cargo build` instead of `cargo auditable build`. `cargo-auditable` panics on `-Zjson-target-spec` builds (it shells out to `cargo metadata` without that flag) and the resulting MIPS64 no_std ELF cannot carry the auditable section anyway.

## Test plan

- [x] Built all four melange packages locally (docker runner on macOS).
- [x] `apko build` composes `kona-prestates:local` image successfully.
- [x] Prestate hash reproducible across two independent dispatcher runs: `0x03cd85cd8eab0a4dd63b10d91b6a630906c6468d4d6a708701a49031a875d340` (kona-client).
- [ ] CircleCI reproduces same hash.
- [ ] Hash matches expected on-chain prestate (or matches the hash #20635 produces).