### PR TITLE
fix(kona/registry): embed superchain-registry depsets

### DIFF
--- a/rust/kona/crates/protocol/registry/build.rs
+++ b/rust/kona/crates/protocol/registry/build.rs
@@ -13,17 +13,24 @@ use kona_genesis::{
 use serde::de::DeserializeOwned;
 
 fn main() {
-    // Always reset `etc/depsets.json` to the empty list before deriving the embedded
-    // depsets from KONA_BIND / KONA_CUSTOM_CONFIGS, so the file content is deterministic
-    // for the configured inputs and never carries stale entries from a prior build.
+    // The three committed snapshots under `etc/` are `include_str!`d at compile time,
+    // but `include_str!` does not register file dependencies with cargo. Declare them
+    // here so a hand-edit, a `KONA_BIND=true` regeneration, or a custom-config merge
+    // busts the cache instead of silently reusing a stale compilation of `lib.rs`.
+    println!("cargo:rerun-if-changed=etc/chainList.json");
+    println!("cargo:rerun-if-changed=etc/configs.json");
+    println!("cargo:rerun-if-changed=etc/depsets.json");
+
     let etc_dir = std::path::Path::new("etc");
     if !etc_dir.exists() {
         std::fs::create_dir_all(etc_dir).unwrap();
     }
     let depsets_path = std::path::Path::new("etc/depsets.json");
-    write_depsets(depsets_path, &[]);
 
     // If the `KONA_BIND` environment variable is _not_ set, then return early.
+    // The committed `etc/depsets.json` snapshot is the authoritative input in this
+    // mode; do not touch it. (Custom-config merges, if enabled, additively layer
+    // on top of the committed snapshot.)
     let kona_bind: bool =
         std::env::var("KONA_BIND").unwrap_or_else(|_| "false".to_string()) == "true";
     println!("cargo:rerun-if-env-changed=KONA_BIND");
@@ -31,6 +38,11 @@ fn main() {
         merge_custom_configs();
         return;
     }
+
+    // Reset `etc/depsets.json` to the empty list before re-deriving from the
+    // superchain-registry submodule, so the file content is deterministic for the
+    // configured inputs and never carries stale entries from a prior build.
+    write_depsets(depsets_path, &[]);
 
     // Resolve the monorepo root via `git rev-parse --show-toplevel` so we don't
     // depend on this crate's location inside the workspace.
@@ -128,14 +140,6 @@ fn merge_custom_configs() {
         std::env::var("KONA_CUSTOM_CONFIGS").unwrap_or_else(|_| "false".to_string()) == "true";
     println!("cargo:rerun-if-env-changed=KONA_CUSTOM_CONFIGS");
     println!("cargo:rerun-if-env-changed=KONA_CUSTOM_CONFIGS_TEST");
-
-    // if we're running tests, bust the cache if the base etc configs are updated. This ensures that
-    // the test build can be repeated after modifying the base configs
-    if std::env::var("KONA_CUSTOM_CONFIGS_TEST") == Ok("true".to_string()) {
-        println!("cargo:rerun-if-changed=etc/chainList.json");
-        println!("cargo:rerun-if-changed=etc/configs.json");
-        println!("cargo:rerun-if-changed=etc/depsets.json");
-    }
 
     if !kona_custom_configs {
         return;

--- a/rust/kona/crates/protocol/registry/etc/configs.json
+++ b/rust/kona/crates/protocol/registry/etc/configs.json
@@ -2848,7 +2848,7 @@
         "name": "rehearsal-0-bn",
         "l1": {
           "chain_id": 11155111,
-          "public_rpc": "https://ethereum-sepolia-rpc.publicnode.com",
+          "public_rpc": "https://ci-sepolia-l1-archive.optimism.io",
           "explorer": ""
         },
         "hardforks": {
@@ -2942,6 +2942,12 @@
             "PermissionedDisputeGame": null,
             "PreimageOracle": null,
             "DataAvailabilityChallenge": null
+          },
+          "interop": {
+            "dependencies": {
+              "420120009": {},
+              "420120010": {}
+            }
           }
         },
         {
@@ -3028,6 +3034,12 @@
             "PermissionedDisputeGame": null,
             "PreimageOracle": null,
             "DataAvailabilityChallenge": null
+          },
+          "interop": {
+            "dependencies": {
+              "420120009": {},
+              "420120010": {}
+            }
           }
         }
       ]

--- a/rust/kona/crates/protocol/registry/etc/depsets.json
+++ b/rust/kona/crates/protocol/registry/etc/depsets.json
@@ -1,1 +1,9 @@
-[]
+[
+  {
+    "dependencies": {
+      "420120009": {},
+      "420120010": {}
+    },
+    "overrideMessageExpiryWindow": null
+  }
+]

--- a/rust/kona/crates/protocol/registry/src/lib.rs
+++ b/rust/kona/crates/protocol/registry/src/lib.rs
@@ -209,13 +209,52 @@ mod tests {
         assert_eq!(DEPENDENCY_SETS.get(&test1_chain_id), DEPENDENCY_SETS.get(&test2_chain_id));
     }
 
+    /// Pins the registry-derived interop cluster against the committed
+    /// `etc/depsets.json` snapshot. The snapshot is regenerated from
+    /// `packages/contracts-bedrock/lib/superchain-registry` via
+    /// `KONA_BIND=true cargo build -p kona-registry`.
+    ///
+    /// Today the registry defines a single `[interop]` cluster — `rehearsal-0-bn`
+    /// (chain ids 420120009, 420120010). If the rehearsal TOMLs change upstream,
+    /// regenerate the snapshot and update the expected set below.
     #[test]
-    fn embedded_depsets_empty_by_default() {
-        // Without KONA_CUSTOM_CONFIGS or KONA_BIND, etc/depsets.json is `[]`.
-        if CUSTOM_CONFIGS_TEST_ENABLED == Some("true") {
-            // The custom test path embeds the fixture; skip.
-            return;
-        }
-        assert!(DEPENDENCY_SETS.is_empty(), "default build should not embed any depsets");
+    fn embedded_depset_for_rehearsal_0_bn_cluster() {
+        const REHEARSAL_0: u64 = 420120009;
+        const REHEARSAL_1: u64 = 420120010;
+
+        let depset = DEPENDENCY_SETS.get(&REHEARSAL_0).unwrap_or_else(|| {
+            panic!(
+                "rehearsal-0-bn-0 (chain id {REHEARSAL_0}) missing from embedded DEPENDENCY_SETS",
+            )
+        });
+
+        // Both peers must resolve to the SAME cluster value (cluster identity).
+        assert_eq!(
+            DEPENDENCY_SETS.get(&REHEARSAL_0),
+            DEPENDENCY_SETS.get(&REHEARSAL_1),
+            "rehearsal-0-bn peers must map to the same DependencySet",
+        );
+
+        // The cluster's dependency map must contain exactly the two rehearsal chain ids.
+        let expected: alloc::collections::BTreeSet<u64> =
+            [REHEARSAL_0, REHEARSAL_1].into_iter().collect();
+        let actual: alloc::collections::BTreeSet<u64> =
+            depset.dependencies.keys().copied().collect();
+        assert_eq!(
+            actual, expected,
+            "rehearsal-0-bn cluster membership mismatch (got {actual:?}, want {expected:?})",
+        );
+
+        // Registry-derived clusters never carry an expiry-window override (the chain
+        // TOML schema has no field for it; see `aggregate_clusters`).
+        assert!(
+            depset.override_message_expiry_window.is_none(),
+            "registry-derived depset must not carry an expiry-window override",
+        );
+        assert_eq!(
+            depset.get_message_expiry_window(),
+            MESSAGE_EXPIRY_WINDOW,
+            "registry-derived depset must use the default message expiry window",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Make the committed `etc/depsets.json` snapshot load-bearing so `BootInfo::load`'s embedded-first dependency-set lookup actually engages in default builds (kona prestates included), instead of always hitting the "insecure in production" preimage-oracle fallback.

- **Build script**: move the unconditional `write_depsets(..., &[])` inside the `KONA_BIND=true` branch so default builds stop clobbering the committed snapshot. Add `cargo:rerun-if-changed=etc/{chainList,configs,depsets}.json` unconditionally (`include_str!` doesn't register file deps with cargo).
- **Snapshot refresh** against current submodule pin (`cc07e96d`): `etc/depsets.json` gains the rehearsal-0-bn cluster `{420120009, 420120010}`; `etc/configs.json` gains the corresponding `[interop]` blocks plus an upstream L1 `public_rpc` URL change.

## Heads-up

- **Custom-devnet builds** now layer their `depsets.json` additively on top of the registry-derived snapshot (previously they wrote a custom-only file). Overlapping chain ids with differing contents panic at build time via `merge_custom_depsets`, surfacing what would have been a runtime crash in `lib.rs`'s reverse-index.

## Test plan

- [x] `cargo nextest run -p kona-registry`
- [x] `KONA_BIND=true cargo build -p kona-registry` byte-idempotent against the committed snapshots.
- [x] `just test-custom-embeds` passes; merged depset is rehearsal + fixture.
- [x] `cargo nextest run -p kona-proof-interop -p kona-genesis -p kona-interop`