### PR TITLE
ci(docker): move deps for op-rbuilder and rollup-boost from CI to docker

### DIFF
--- a/ops/docker/ci-base-clang/Dockerfile
+++ b/ops/docker/ci-base-clang/Dockerfile
@@ -11,9 +11,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
+      build-essential \
       clang \
+      llvm \
       llvm-dev \
       libclang-dev \
+      libsqlite3-dev \
+      libtss2-dev \
+      pkg-config
  && rm -rf /var/lib/apt/lists/*
 
 USER circleci

--- a/ops/docker/ci-base-clang/Dockerfile
+++ b/ops/docker/ci-base-clang/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
       libclang-dev \
       libsqlite3-dev \
       libtss2-dev \
-      pkg-config
+      pkg-config \
  && rm -rf /var/lib/apt/lists/*
 
 USER circleci


### PR DESCRIPTION
This is expected to save us ~20-30sec pr. run.

@nonsense @falcorocks 