### PR TITLE
fix(op-acceptance-tests): wait for EL labels in SafeHeadProgression

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
@@ -76,11 +76,13 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	require.Less(t, finalizedB.Number, initialTargetBlockNumB)
 
 	// Resume interop verification
-	// expect cross safe to catch up
+	// expect cross safe to catch up on both CL and EL
 	sys.Supernode.ResumeInterop()
 	dsl.CheckAll(t,
 		sys.L2ACL.ReachedFn(types.CrossSafe, finalTargetBlockNum, attempts),
 		sys.L2BCL.ReachedFn(types.CrossSafe, finalTargetBlockNum, attempts),
+		sys.L2ELA.ReachedFn(eth.Safe, finalTargetBlockNum, attempts),
+		sys.L2ELB.ReachedFn(eth.Safe, finalTargetBlockNum, attempts),
 	)
 
 	// check EL labels
@@ -110,12 +112,14 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	sys.AdvanceTime(90 * time.Second)
 	sys.L1Network.WaitForFinalization()
 
-	// Wait for finalized heads to catch up to or past the snapshotted safe heads
-	// Finalized advancement depends on L1 finality, so use more attempts
+	// Wait for finalized heads (CL and EL) to catch up to or past the snapshotted
+	// safe heads. Finalized advancement depends on L1 finality, so use more attempts.
 	finalizedAttempts := 30
 	dsl.CheckAll(t,
 		sys.L2ACL.ReachedFn(types.Finalized, snapshotSafeA, finalizedAttempts),
 		sys.L2BCL.ReachedFn(types.Finalized, snapshotSafeB, finalizedAttempts),
+		sys.L2ELA.ReachedFn(eth.Finalized, snapshotSafeA, finalizedAttempts),
+		sys.L2ELB.ReachedFn(eth.Finalized, snapshotSafeB, finalizedAttempts),
 	)
 
 	// Verify finalized heads on EL


### PR DESCRIPTION
Fixes the flake in `TestSupernodeInterop_SafeHeadProgression` (ethereum-optimism/optimism#20851).

The test polled the CL until `CrossSafe` / `Finalized` reached the target, then synchronously read the corresponding EL label. The EL label is updated by an engine-API `ForkchoiceUpdated` dispatched asynchronously after the CL advances, so a synchronous read can lag the CL by an FCU-propagation window — long enough under CI scheduling pressure to fail the `>= finalTargetBlockNum` assertion. Failing run had the CL at target=10 and the EL still at 9 ~9ms later.

Include the EL `ReachedFn` polls in the same `dsl.CheckAll` as the CL polls so each block waits for both CL and EL to reach the target before the synchronous `BlockRefByLabel` + `GreaterOrEqual` assertions run.