### PR TITLE
fix(op-node): batch SafeHeadUpdated to one call per L1 source

### DIFF
--- a/op-node/node/safedb/safedb_test.go
+++ b/op-node/node/safedb/safedb_test.go
@@ -73,6 +73,45 @@ func TestStoreSafeHeads(t *testing.T) {
 	verifySafeHeads(newDB)
 }
 
+// TestSafeHeadAtL1_OnePerL1Invariant documents the post-fix invariant: in the
+// normal flow, SafeHeadUpdated is called at most once per L1 source block, with
+// the highest L2 reached during that L1. Under that invariant, every recorded
+// entry is final and SafeHeadAtL1 always returns the highest L2 derived from
+// each L1 — never an intermediate value that downstream callers could observe
+// and snapshot.
+//
+// This is a regression guard: if the deriver ever reintroduces per-event
+// SafeHeadUpdated calls, the higher layer test in op-node/rollup/driver will
+// catch it, but this test pins the SafeDB invariant the deriver relies on.
+func TestSafeHeadAtL1_OnePerL1Invariant(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	dir := t.TempDir()
+	db, err := NewSafeDB(logger, dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// One entry per L1, each carrying the final (highest) L2 derived from that L1.
+	l1A := eth.BlockID{Hash: common.Hash{0x01, 0xaa}, Number: 100}
+	l1B := eth.BlockID{Hash: common.Hash{0x01, 0xbb}, Number: 101}
+	finalL2A := eth.L2BlockRef{Hash: common.Hash{0x02, 0xa3}, Number: 202}
+	finalL2B := eth.L2BlockRef{Hash: common.Hash{0x02, 0xb2}, Number: 204}
+
+	require.NoError(t, db.SafeHeadUpdated(finalL2A, l1A))
+	require.NoError(t, db.SafeHeadUpdated(finalL2B, l1B))
+
+	// SafeHeadAtL1 always returns the final L2 for each L1 — no intermediate
+	// values are ever observable.
+	gotL1, gotL2, err := db.SafeHeadAtL1(context.Background(), l1A.Number)
+	require.NoError(t, err)
+	require.Equal(t, l1A, gotL1)
+	require.Equal(t, finalL2A.ID(), gotL2)
+
+	gotL1, gotL2, err = db.SafeHeadAtL1(context.Background(), l1B.Number)
+	require.NoError(t, err)
+	require.Equal(t, l1B, gotL1)
+	require.Equal(t, finalL2B.ID(), gotL2)
+}
+
 func TestSafeHeadAtL1_EmptyDatabase(t *testing.T) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	dir := t.TempDir()

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -47,6 +47,19 @@ type SyncDeriver struct {
 	ManagedBySupervisor bool
 
 	StepDeriver StepDeriver
+
+	// pendingSafeHead batches SafeHeadUpdated notifications by L1 source block.
+	// SafeDB keys by L1 block number, so emitting once per L2 advance overwrites
+	// the entry repeatedly within the same L1 and races downstream callers
+	// (notably the supernode cold-start path) that snapshot SafeDB mid-derivation.
+	// Instead we accumulate the highest L2 reached during the current L1 source
+	// and emit a single SafeHeadUpdated when the source advances or derivation
+	// idles. On crash, the in-memory pending entry is lost but the deriver
+	// re-derives the in-progress L1 from scratch on restart, so no half-written
+	// state can be persisted.
+	pendingSafeHead   eth.L2BlockRef
+	pendingSafeSource eth.L1BlockRef
+	hasPendingSafe    bool
 }
 
 func (s *SyncDeriver) AttachEmitter(em event.Emitter) {
@@ -74,6 +87,10 @@ func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	case StepEvent:
 		s.SyncStep()
 	case rollup.ResetEvent:
+		// Drop any pending batched safe-head update: the pipeline is restarting
+		// from a known-good point and will re-derive the in-progress L1 from
+		// scratch.
+		s.dropPendingSafeHead()
 		s.onResetEvent(ctx, x)
 	case rollup.L1TemporaryErrorEvent:
 		s.Log.Warn("L1 temporary error", "err", x.Err)
@@ -86,6 +103,10 @@ func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	case engine.EngineResetConfirmedEvent:
 		s.onEngineConfirmedReset(ctx, x)
 	case derive.DeriverIdleEvent:
+		// Derivation has caught up to L1; flush the final pending safe-head
+		// for the current L1 source. No further L2 blocks will be derived from
+		// it until a new L1 block arrives.
+		s.flushPendingSafeHead(ctx)
 		// Once derivation is idle the system is healthy
 		// and we can wait for new inputs. No backoff necessary.
 		s.StepDeriver.ResetStepBackoff(ctx)
@@ -130,22 +151,65 @@ func (s *SyncDeriver) OnUnsafeL2Payload(ctx context.Context, envelope *eth.Execu
 }
 
 func (s *SyncDeriver) onSafeDerivedBlock(ctx context.Context, x engine.SafeDerivedEvent) {
-	if s.SafeHeadNotifs != nil && s.SafeHeadNotifs.Enabled() {
-		if err := s.SafeHeadNotifs.SafeHeadUpdated(x.Safe, x.Source.ID()); err != nil {
-			// At this point our state is in a potentially inconsistent state as we've updated the safe head
-			// in the execution client but failed to post process it. Reset the pipeline so the safe head rolls back
-			// a little (it always rolls back at least 1 block) and then it will retry storing the entry
-			s.Emitter.Emit(ctx, rollup.ResetEvent{
-				Err: fmt.Errorf("safe head notifications failed: %w", err),
-			})
+	if s.SafeHeadNotifs == nil || !s.SafeHeadNotifs.Enabled() {
+		return
+	}
+	// Batch by L1 source. If the source advances, flush the pending entry for
+	// the prior L1 first — that L1 is now final because L2 advancement to a
+	// later L1 origin cannot revert back. Then start a new pending entry for
+	// the current L1.
+	if s.hasPendingSafe && x.Source.Number != s.pendingSafeSource.Number {
+		if x.Source.Number < s.pendingSafeSource.Number {
+			// Out-of-order source: shouldn't happen in the normal flow. Log and
+			// reset the batching window to the new source so we don't silently
+			// hold a stale pending entry forever.
+			s.Log.Warn("safe-derived event source went backwards",
+				"prev_source", s.pendingSafeSource, "new_source", x.Source)
+			s.dropPendingSafeHead()
+		} else {
+			s.flushPendingSafeHead(ctx)
 		}
 	}
+	s.pendingSafeHead = x.Safe
+	s.pendingSafeSource = x.Source
+	s.hasPendingSafe = true
+}
+
+// flushPendingSafeHead emits a single SafeHeadUpdated for the current pending
+// L1 source with the highest L2 safe head reached during that L1, then clears
+// the pending entry. Idempotent: a no-op if no pending entry exists.
+func (s *SyncDeriver) flushPendingSafeHead(ctx context.Context) {
+	if !s.hasPendingSafe {
+		return
+	}
+	if s.SafeHeadNotifs == nil || !s.SafeHeadNotifs.Enabled() {
+		s.hasPendingSafe = false
+		return
+	}
+	safe := s.pendingSafeHead
+	source := s.pendingSafeSource
+	s.hasPendingSafe = false
+	if err := s.SafeHeadNotifs.SafeHeadUpdated(safe, source.ID()); err != nil {
+		// At this point our state is in a potentially inconsistent state as we've updated the safe head
+		// in the execution client but failed to post process it. Reset the pipeline so the safe head rolls back
+		// a little (it always rolls back at least 1 block) and then it will retry storing the entry
+		s.Emitter.Emit(ctx, rollup.ResetEvent{
+			Err: fmt.Errorf("safe head notifications failed: %w", err),
+		})
+	}
+}
+
+// dropPendingSafeHead discards the in-memory pending entry without flushing.
+// Used when the pipeline resets and the in-progress L1 will be re-derived.
+func (s *SyncDeriver) dropPendingSafeHead() {
+	s.hasPendingSafe = false
 }
 
 func (s *SyncDeriver) OnELSyncStarted() {
 	// The EL sync may progress the safe head in the EL without deriving those blocks from L1
 	// which means the safe head db will miss entries so we need to remove all entries to avoid returning bad data
 	s.Log.Warn("Clearing safe head db because EL sync started")
+	s.dropPendingSafeHead()
 	if s.SafeHeadNotifs != nil {
 		if err := s.SafeHeadNotifs.SafeHeadReset(eth.L2BlockRef{}); err != nil {
 			s.Log.Error("Failed to notify safe-head reset when optimistically syncing")
@@ -154,6 +218,10 @@ func (s *SyncDeriver) OnELSyncStarted() {
 }
 
 func (s *SyncDeriver) onEngineConfirmedReset(ctx context.Context, x engine.EngineResetConfirmedEvent) {
+	// Drop any pending batched safe-head update before applying the reset.
+	// The engine is repositioning; the in-progress L1 will be re-derived from
+	// the new safe head.
+	s.dropPendingSafeHead()
 	// If the listener update fails, we return,
 	// and don't confirm the engine-reset with the derivation pipeline.
 	// The pipeline will re-trigger a reset as necessary.

--- a/op-node/rollup/driver/sync_deriver_test.go
+++ b/op-node/rollup/driver/sync_deriver_test.go
@@ -1,0 +1,149 @@
+package driver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+// safeHeadCall captures a single SafeHeadUpdated call.
+type safeHeadCall struct {
+	Safe eth.L2BlockRef
+	L1   eth.BlockID
+}
+
+// recordingSafeHeadListener records every SafeHeadUpdated call.
+type recordingSafeHeadListener struct {
+	enabled bool
+	calls   []safeHeadCall
+	resets  []eth.L2BlockRef
+}
+
+func (r *recordingSafeHeadListener) Enabled() bool {
+	return r.enabled
+}
+
+func (r *recordingSafeHeadListener) SafeHeadUpdated(newSafeHead eth.L2BlockRef, l1Block eth.BlockID) error {
+	r.calls = append(r.calls, safeHeadCall{Safe: newSafeHead, L1: l1Block})
+	return nil
+}
+
+func (r *recordingSafeHeadListener) SafeHeadReset(resetSafeHead eth.L2BlockRef) error {
+	r.resets = append(r.resets, resetSafeHead)
+	return nil
+}
+
+func newTestSyncDeriver(t *testing.T, listener *recordingSafeHeadListener) *SyncDeriver {
+	emitter := event.EmitterFunc(func(ctx context.Context, ev event.Event) {})
+	logger := testlog.Logger(t, log.LevelError)
+	sched := NewStepSchedulingDeriver(logger)
+	sched.AttachEmitter(emitter)
+	s := &SyncDeriver{
+		SafeHeadNotifs: listener,
+		Emitter:        emitter,
+		Log:            logger,
+		Ctx:            context.Background(),
+		StepDeriver:    sched,
+	}
+	return s
+}
+
+// TestSyncDeriver_SafeHeadUpdatedOncePerL1 asserts that multiple L2 safe-head
+// advancements within a single L1 source block result in exactly one
+// SafeHeadUpdated call per L1 source, carrying the highest L2 reached.
+//
+// Today's behavior calls SafeHeadUpdated on every SafeDerivedEvent which
+// overwrites the per-L1 SafeDB entry repeatedly and races downstream callers
+// that snapshot the value mid-derivation.
+func TestSyncDeriver_SafeHeadUpdatedOncePerL1(t *testing.T) {
+	listener := &recordingSafeHeadListener{enabled: true}
+	s := newTestSyncDeriver(t, listener)
+	ctx := context.Background()
+
+	l1A := eth.L1BlockRef{Hash: common.Hash{0x01, 0xaa}, Number: 100}
+	l1B := eth.L1BlockRef{Hash: common.Hash{0x01, 0xbb}, Number: 101}
+
+	l2A1 := eth.L2BlockRef{Hash: common.Hash{0x02, 0xa1}, Number: 200, L1Origin: l1A.ID()}
+	l2A2 := eth.L2BlockRef{Hash: common.Hash{0x02, 0xa2}, Number: 201, L1Origin: l1A.ID()}
+	l2A3 := eth.L2BlockRef{Hash: common.Hash{0x02, 0xa3}, Number: 202, L1Origin: l1A.ID()}
+	l2B1 := eth.L2BlockRef{Hash: common.Hash{0x02, 0xb1}, Number: 203, L1Origin: l1B.ID()}
+	l2B2 := eth.L2BlockRef{Hash: common.Hash{0x02, 0xb2}, Number: 204, L1Origin: l1B.ID()}
+
+	// Three advancements within L1=A.
+	s.OnEvent(ctx, engine.SafeDerivedEvent{Safe: l2A1, Source: l1A})
+	s.OnEvent(ctx, engine.SafeDerivedEvent{Safe: l2A2, Source: l1A})
+	s.OnEvent(ctx, engine.SafeDerivedEvent{Safe: l2A3, Source: l1A})
+
+	// No SafeHeadUpdated should have fired yet for L1=A: we don't know yet
+	// whether more L2 blocks will be derived from the same L1.
+	require.Empty(t, listener.calls,
+		"SafeHeadUpdated must not fire mid-L1; it should be batched per L1 source")
+
+	// L1 advances. This triggers the flush for L1=A with the final L2 reached.
+	s.OnEvent(ctx, engine.SafeDerivedEvent{Safe: l2B1, Source: l1B})
+
+	require.Len(t, listener.calls, 1, "exactly one SafeHeadUpdated for L1=A")
+	require.Equal(t, l2A3, listener.calls[0].Safe, "must carry the highest L2 reached during L1=A")
+	require.Equal(t, l1A.ID(), listener.calls[0].L1)
+
+	// Another advancement within L1=B; still no extra flush yet.
+	s.OnEvent(ctx, engine.SafeDerivedEvent{Safe: l2B2, Source: l1B})
+	require.Len(t, listener.calls, 1, "still batching L1=B until a terminator")
+
+	// Derivation idles (caught up). This flushes the pending L1=B entry.
+	s.OnEvent(ctx, derive.DeriverIdleEvent{Origin: l1B})
+	require.Len(t, listener.calls, 2)
+	require.Equal(t, l2B2, listener.calls[1].Safe)
+	require.Equal(t, l1B.ID(), listener.calls[1].L1)
+}
+
+// TestSyncDeriver_PendingSafeHeadDroppedOnReset asserts that a pipeline reset
+// drops the pending in-memory batch without flushing — the engine will
+// re-derive the in-progress L1 from scratch after the reset.
+func TestSyncDeriver_PendingSafeHeadDroppedOnReset(t *testing.T) {
+	listener := &recordingSafeHeadListener{enabled: true}
+	s := newTestSyncDeriver(t, listener)
+	ctx := context.Background()
+
+	l1A := eth.L1BlockRef{Hash: common.Hash{0x01, 0xaa}, Number: 100}
+	l2A1 := eth.L2BlockRef{Hash: common.Hash{0x02, 0xa1}, Number: 200, L1Origin: l1A.ID()}
+
+	s.OnEvent(ctx, engine.SafeDerivedEvent{Safe: l2A1, Source: l1A})
+	require.Empty(t, listener.calls)
+
+	// Trigger an ELSync start which clears the safe head DB; pending must be dropped.
+	s.OnELSyncStarted()
+	require.Empty(t, listener.calls, "pending must not be flushed after reset/elsync")
+
+	// A subsequent idle event must not flush a stale pending entry.
+	s.OnEvent(ctx, derive.DeriverIdleEvent{Origin: l1A})
+	require.Empty(t, listener.calls, "idle event after drop must not flush stale pending")
+}
+
+// TestSyncDeriver_DisabledListenerNoCalls asserts that when the listener is
+// disabled, no calls are batched or made.
+func TestSyncDeriver_DisabledListenerNoCalls(t *testing.T) {
+	listener := &recordingSafeHeadListener{enabled: false}
+	s := newTestSyncDeriver(t, listener)
+	ctx := context.Background()
+
+	l1A := eth.L1BlockRef{Hash: common.Hash{0x01, 0xaa}, Number: 100}
+	l1B := eth.L1BlockRef{Hash: common.Hash{0x01, 0xbb}, Number: 101}
+	l2A := eth.L2BlockRef{Hash: common.Hash{0x02, 0xa1}, Number: 200, L1Origin: l1A.ID()}
+	l2B := eth.L2BlockRef{Hash: common.Hash{0x02, 0xb1}, Number: 201, L1Origin: l1B.ID()}
+
+	s.OnEvent(ctx, engine.SafeDerivedEvent{Safe: l2A, Source: l1A})
+	s.OnEvent(ctx, engine.SafeDerivedEvent{Safe: l2B, Source: l1B})
+	s.OnEvent(ctx, derive.DeriverIdleEvent{Origin: l1B})
+	require.Empty(t, listener.calls)
+}


### PR DESCRIPTION
**Claude:** *This PR was authored by Claude (op-claude workstream-manager) on Adrian's behalf.*

`SafeDB` keys by L1 block number, so calling `SafeHeadUpdated` on every `SafeDerivedEvent` overwrote the per-L1 entry repeatedly as L2 advanced within a single L1 source block. Downstream callers that snapshot `SafeDB` mid-derivation — notably the supernode cold-start path in `op-supernode/supernode/activity/interop/log_backfill.go` (`firstSafeDB_ts`) — could observe an intermediate L2 and then a later, higher L2 for the same L1 key, a real race.

This change batches in the deriver: `SyncDeriver` accumulates the highest L2 safe head reached for the current L1 source and flushes exactly once when:

- a later L1 source arrives via the next `SafeDerivedEvent`, or
- derivation reaches the L1 tip (`DeriverIdleEvent`)

I chose `DeriverIdleEvent` as the L1-tip terminator because it is already emitted by `PipelineDeriver` on EOF when the pipeline catches up to L1, alongside `ExhaustedL1Event`. It's the cleanest existing signal: no new event type needed, and it fires exactly when no further L2 will be derived from the current L1 until a new L1 block arrives.

Pending state is dropped without flushing on `ResetEvent`, `EngineResetConfirmedEvent`, and `OnELSyncStarted` — the pipeline is restarting and will re-derive the in-progress L1 from scratch. On crash, the in-memory pending entry is lost, but the deriver re-derives the in-progress L1 on restart, so no half-written state can be persisted. The on-disk SafeDB format and `SafeHeadUpdated` signature are unchanged, and the genesis fast-path in `onEngineConfirmedReset` is preserved.

Tests:
- `op-node/rollup/driver/sync_deriver_test.go` — multiple L2 advances within one L1 produce exactly one `SafeHeadUpdated` call carrying the highest L2; resets drop pending without flushing; disabled listener never sees calls.
- `op-node/node/safedb/safedb_test.go` — regression guard for the one-entry-per-L1 invariant the deriver now enforces.