### PR TITLE
fix(op-supernode): stabilize first SafeDB snapshot in interop cold-start

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -1074,7 +1074,7 @@ func (m *algoMockChain) BlockNumberToTimestamp(ctx context.Context, blocknum uin
 	return 0, nil
 }
 func (m *algoMockChain) FirstSafeHeadTimestamp(ctx context.Context) (uint64, error) {
-	return 0, cc.ErrSafeDBEmpty
+	return 0, cc.ErrSafeDBNotReady
 }
 func (m *algoMockChain) ID() eth.ChainID                                  { return m.id }
 func (m *algoMockChain) Start(ctx context.Context) error                  { return nil }

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1752,7 +1752,7 @@ type mockChainContainer struct {
 	blockNumberToTimestampOverride func(ctx context.Context, blocknum uint64) (uint64, error)
 
 	// firstSafeHeadTimestamp lets tests stub FirstSafeHeadTimestamp.
-	// firstSafeHeadTimestampErr defaults to chain_container.ErrSafeDBEmpty
+	// firstSafeHeadTimestampErr defaults to chain_container.ErrSafeDBNotReady
 	// when neither field is set so the cold-start init loop keeps waiting.
 	firstSafeHeadTimestamp    uint64
 	firstSafeHeadTimestampSet bool
@@ -1799,7 +1799,7 @@ func (m *mockChainContainer) FirstSafeHeadTimestamp(ctx context.Context) (uint64
 	if m.firstSafeHeadTimestampSet {
 		return m.firstSafeHeadTimestamp, nil
 	}
-	return 0, cc.ErrSafeDBEmpty
+	return 0, cc.ErrSafeDBNotReady
 }
 func (m *mockChainContainer) ELFinalizedHead(ctx context.Context) (eth.L2BlockRef, error) {
 	m.mu.Lock()

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -70,7 +70,7 @@ func (i *Interop) collectFirstSafeHeadTimestamps() (map[eth.ChainID]uint64, bool
 	for range i.chains {
 		r := <-results
 		if r.err != nil {
-			if errors.Is(r.err, cc.ErrSafeDBEmpty) {
+			if errors.Is(r.err, cc.ErrSafeDBNotReady) {
 				emptyAny = true
 				i.log.Debug("interop cold start: chain SafeDB empty, waiting", "chain", r.id)
 				continue

--- a/op-supernode/supernode/activity/interop/startup_test.go
+++ b/op-supernode/supernode/activity/interop/startup_test.go
@@ -92,7 +92,7 @@ func TestAdvanceColdStartInit_WaitsWhenAnyChainEmpty(t *testing.T) {
 			m.firstSafeHeadTimestampSet = true
 		}).
 		WithChain(20, func(m *mockChainContainer) {
-			// Default: returns ErrSafeDBEmpty.
+			// Default: returns ErrSafeDBNotReady.
 		}).
 		Build()
 	// Harness pre-sets initialized=true for tests that drive the verify
@@ -102,7 +102,7 @@ func TestAdvanceColdStartInit_WaitsWhenAnyChainEmpty(t *testing.T) {
 
 	advanced, err := h.interop.advanceColdStartInit()
 	require.NoError(t, err)
-	require.False(t, advanced, "must wait when any chain reports ErrSafeDBEmpty")
+	require.False(t, advanced, "must wait when any chain reports ErrSafeDBNotReady")
 	require.False(t, h.interop.initialized.Load())
 }
 
@@ -150,7 +150,7 @@ func TestAdvanceColdStartInit_PicksMaxClampedToActivation(t *testing.T) {
 }
 
 // TestAdvanceColdStartInit_PropagatesNonEmptyErrors confirms that
-// FirstSafeHeadTimestamp errors other than ErrSafeDBEmpty are fatal.
+// FirstSafeHeadTimestamp errors other than ErrSafeDBNotReady are fatal.
 func TestAdvanceColdStartInit_PropagatesNonEmptyErrors(t *testing.T) {
 
 	fault := errors.New("vn not running")
@@ -568,4 +568,4 @@ func TestFirstVerifiableTimestamp_ErrNotStartedBeforeInit(t *testing.T) {
 }
 
 // _ ensures the cc import is retained even if helpers shift.
-var _ = cc.ErrSafeDBEmpty
+var _ = cc.ErrSafeDBNotReady

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -115,7 +115,7 @@ func (m *mockCC) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (u
 }
 
 func (m *mockCC) FirstSafeHeadTimestamp(ctx context.Context) (uint64, error) {
-	return 0, cc.ErrSafeDBEmpty
+	return 0, cc.ErrSafeDBNotReady
 }
 
 var _ cc.ChainContainer = (*mockCC)(nil)

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -110,7 +110,7 @@ func (m *mockCC) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (u
 	return 0, nil
 }
 func (m *mockCC) FirstSafeHeadTimestamp(ctx context.Context) (uint64, error) {
-	return 0, cc.ErrSafeDBEmpty
+	return 0, cc.ErrSafeDBNotReady
 }
 func (m *mockCC) Generation() uint64 { return 0 }
 

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -38,10 +38,12 @@ const virtualNodeVersion = "0.1.0"
 // retrying; recovery requires operator intervention.
 var ErrHistoryUnavailable = errors.New("safedb history unavailable on this node")
 
-// ErrSafeDBEmpty is returned by FirstSafeHeadTimestamp when SafeDB has no
-// entries yet. This is a transient condition during cold start while the VN
-// derives its first safe head; callers should back off and retry.
-var ErrSafeDBEmpty = errors.New("safedb has no entries yet")
+// ErrSafeDBNotReady is returned by FirstSafeHeadTimestamp when SafeDB does not
+// yet have a stable first entry: either it has no entries at all, or the
+// deriver has not advanced past the first entry's L1 (so SafeHeadUpdated may
+// still overwrite the L2 value at that L1 key). This is a transient condition
+// during cold start; callers should back off and retry.
+var ErrSafeDBNotReady = errors.New("safedb not ready: no stable first entry yet")
 
 type ChainContainer interface {
 	Start(ctx context.Context) error
@@ -56,8 +58,8 @@ type ChainContainer interface {
 	TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error)
 	BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error)
 	// FirstSafeHeadTimestamp returns the L2 block timestamp of the first
-	// entry in this chain's SafeDB. Returns ErrSafeDBEmpty when the chain
-	// has not yet derived a safe head.
+	// entry in this chain's SafeDB. Returns ErrSafeDBNotReady when the chain
+	// has not yet derived a stable first safe head.
 	FirstSafeHeadTimestamp(ctx context.Context) (uint64, error)
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
@@ -440,14 +442,14 @@ func (c *simpleChainContainer) FirstSafeHeadTimestamp(ctx context.Context) (uint
 	l1, l2, err := vn.FirstSafeHeadEntry(ctx)
 	if err != nil {
 		if errors.Is(err, safedb.ErrNotFound) {
-			return 0, ErrSafeDBEmpty
+			return 0, ErrSafeDBNotReady
 		}
 		return 0, fmt.Errorf("first safedb entry: %w", err)
 	}
 	if status.CurrentL1.Number <= l1.Number {
 		c.log.Debug("first SafeDB entry not yet stable: deriver still on its L1",
 			"first_l1", l1.Number, "current_l1", status.CurrentL1.Number)
-		return 0, ErrSafeDBEmpty
+		return 0, ErrSafeDBNotReady
 	}
 	return c.BlockNumberToTimestamp(ctx, l2.Number)
 }

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -422,17 +422,32 @@ func (c *simpleChainContainer) BlockNumberToTimestamp(ctx context.Context, block
 	return c.vncfg.Rollup.TimestampForBlock(blocknum), nil
 }
 
+// FirstSafeHeadTimestamp returns the timestamp of SafeDB's first entry, but
+// only once the deriver has moved past that entry's L1. SafeHeadUpdated
+// overwrites entries at the same L1 key, so until then the L2 value is still
+// in flight and snapshots can go stale. Sample SyncStatus before
+// FirstSafeHeadEntry so firstEntry.L1 < capturedCurrentL1 implies the writes
+// at that L1 had already completed.
 func (c *simpleChainContainer) FirstSafeHeadTimestamp(ctx context.Context) (uint64, error) {
 	vn := c.getVN()
 	if vn == nil {
 		return 0, virtual_node.ErrVirtualNodeNotRunning
 	}
-	_, l2, err := vn.FirstSafeHeadEntry(ctx)
+	status, err := vn.SyncStatus(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("sync status: %w", err)
+	}
+	l1, l2, err := vn.FirstSafeHeadEntry(ctx)
 	if err != nil {
 		if errors.Is(err, safedb.ErrNotFound) {
 			return 0, ErrSafeDBEmpty
 		}
 		return 0, fmt.Errorf("first safedb entry: %w", err)
+	}
+	if status.CurrentL1.Number <= l1.Number {
+		c.log.Debug("first SafeDB entry not yet stable: deriver still on its L1",
+			"first_l1", l1.Number, "current_l1", status.CurrentL1.Number)
+		return 0, ErrSafeDBEmpty
 	}
 	return c.BlockNumberToTimestamp(ctx, l2.Number)
 }

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -1401,7 +1401,7 @@ func TestChainContainer_BlockNumberToTimestamp_RespectsGenesisBlockNumber(t *tes
 	require.Contains(t, err.Error(), "before genesis 100")
 }
 
-// Returns ErrSafeDBEmpty until the deriver's currentL1 has moved past
+// Returns ErrSafeDBNotReady until the deriver's currentL1 has moved past
 // firstEntry.L1; only then is the entry's L2 final.
 func TestChainContainer_FirstSafeHeadTimestamp_StableSnapshot(t *testing.T) {
 	t.Parallel()
@@ -1418,34 +1418,34 @@ func TestChainContainer_FirstSafeHeadTimestamp_StableSnapshot(t *testing.T) {
 	}
 	for _, c := range []tc{
 		{
-			name: "empty SafeDB -> ErrSafeDBEmpty",
+			name: "empty SafeDB -> ErrSafeDBNotReady",
 			firstEntry: func() (eth.BlockID, eth.BlockID, error) {
 				return eth.BlockID{}, eth.BlockID{}, safedb.ErrNotFound
 			},
 			syncStatus: func() (*eth.SyncStatus, error) {
 				return &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 5}}, nil
 			},
-			wantErr: ErrSafeDBEmpty,
+			wantErr: ErrSafeDBNotReady,
 		},
 		{
-			name: "deriver still on firstEntry's L1 -> ErrSafeDBEmpty",
+			name: "deriver still on firstEntry's L1 -> ErrSafeDBNotReady",
 			firstEntry: func() (eth.BlockID, eth.BlockID, error) {
 				return eth.BlockID{Number: 4}, eth.BlockID{Number: 23}, nil
 			},
 			syncStatus: func() (*eth.SyncStatus, error) {
 				return &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 4}}, nil
 			},
-			wantErr: ErrSafeDBEmpty,
+			wantErr: ErrSafeDBNotReady,
 		},
 		{
-			name: "deriver below firstEntry's L1 (impossible but defensive) -> ErrSafeDBEmpty",
+			name: "deriver below firstEntry's L1 (impossible but defensive) -> ErrSafeDBNotReady",
 			firstEntry: func() (eth.BlockID, eth.BlockID, error) {
 				return eth.BlockID{Number: 4}, eth.BlockID{Number: 23}, nil
 			},
 			syncStatus: func() (*eth.SyncStatus, error) {
 				return &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 3}}, nil
 			},
-			wantErr: ErrSafeDBEmpty,
+			wantErr: ErrSafeDBNotReady,
 		},
 		{
 			name: "deriver past firstEntry's L1 -> returns timestamp",

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -13,6 +13,7 @@ import (
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
@@ -54,6 +55,13 @@ type mockVirtualNode struct {
 	// instead of the synthesised default built from safeHeadL1/safeHeadL2.
 	// When nil, the default synthesis below is used.
 	syncStatusOverride func() (*eth.SyncStatus, error)
+
+	// Decouples FirstSafeHeadEntry's result from safeHeadL1/L2 (read by
+	// SyncStatus, SafeHeadAtL1, etc.).
+	firstSafeHeadEntryOverride func() (eth.BlockID, eth.BlockID, error)
+
+	// Order in which mock methods were invoked.
+	methodCalls []string
 }
 
 func newMockVirtualNode() *mockVirtualNode {
@@ -113,6 +121,12 @@ func (m *mockVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID) 
 
 // FirstSafeHeadEntry implements virtual_node.VirtualNode FirstSafeHeadEntry
 func (m *mockVirtualNode) FirstSafeHeadEntry(ctx context.Context) (eth.BlockID, eth.BlockID, error) {
+	m.mu.Lock()
+	m.methodCalls = append(m.methodCalls, "FirstSafeHeadEntry")
+	m.mu.Unlock()
+	if m.firstSafeHeadEntryOverride != nil {
+		return m.firstSafeHeadEntryOverride()
+	}
 	return m.safeHeadL1, m.safeHeadL2, m.safeHeadErr
 }
 
@@ -123,6 +137,9 @@ func (m *mockVirtualNode) LastL1(ctx context.Context) (eth.BlockID, error) {
 
 // SyncStatus implements virtual_node.VirtualNode SyncStatus
 func (m *mockVirtualNode) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	m.mu.Lock()
+	m.methodCalls = append(m.methodCalls, "SyncStatus")
+	m.mu.Unlock()
 	if m.syncStatusOverride != nil {
 		return m.syncStatusOverride()
 	}
@@ -1382,4 +1399,153 @@ func TestChainContainer_BlockNumberToTimestamp_RespectsGenesisBlockNumber(t *tes
 	_, err = impl.BlockNumberToTimestamp(context.Background(), 99)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "before genesis 100")
+}
+
+// Returns ErrSafeDBEmpty until the deriver's currentL1 has moved past
+// firstEntry.L1; only then is the entry's L2 final.
+func TestChainContainer_FirstSafeHeadTimestamp_StableSnapshot(t *testing.T) {
+	t.Parallel()
+
+	const blockTime = 2
+	const genesisL2Time = 1000
+
+	type tc struct {
+		name       string
+		firstEntry func() (eth.BlockID, eth.BlockID, error)
+		syncStatus func() (*eth.SyncStatus, error)
+		wantErr    error
+		wantTS     uint64
+	}
+	for _, c := range []tc{
+		{
+			name: "empty SafeDB -> ErrSafeDBEmpty",
+			firstEntry: func() (eth.BlockID, eth.BlockID, error) {
+				return eth.BlockID{}, eth.BlockID{}, safedb.ErrNotFound
+			},
+			syncStatus: func() (*eth.SyncStatus, error) {
+				return &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 5}}, nil
+			},
+			wantErr: ErrSafeDBEmpty,
+		},
+		{
+			name: "deriver still on firstEntry's L1 -> ErrSafeDBEmpty",
+			firstEntry: func() (eth.BlockID, eth.BlockID, error) {
+				return eth.BlockID{Number: 4}, eth.BlockID{Number: 23}, nil
+			},
+			syncStatus: func() (*eth.SyncStatus, error) {
+				return &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 4}}, nil
+			},
+			wantErr: ErrSafeDBEmpty,
+		},
+		{
+			name: "deriver below firstEntry's L1 (impossible but defensive) -> ErrSafeDBEmpty",
+			firstEntry: func() (eth.BlockID, eth.BlockID, error) {
+				return eth.BlockID{Number: 4}, eth.BlockID{Number: 23}, nil
+			},
+			syncStatus: func() (*eth.SyncStatus, error) {
+				return &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 3}}, nil
+			},
+			wantErr: ErrSafeDBEmpty,
+		},
+		{
+			name: "deriver past firstEntry's L1 -> returns timestamp",
+			firstEntry: func() (eth.BlockID, eth.BlockID, error) {
+				return eth.BlockID{Number: 4}, eth.BlockID{Number: 23}, nil
+			},
+			syncStatus: func() (*eth.SyncStatus, error) {
+				return &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 5}}, nil
+			},
+			wantTS: genesisL2Time + 23*blockTime,
+		},
+		{
+			name: "SyncStatus error propagates",
+			firstEntry: func() (eth.BlockID, eth.BlockID, error) {
+				return eth.BlockID{Number: 4}, eth.BlockID{Number: 23}, nil
+			},
+			syncStatus: func() (*eth.SyncStatus, error) {
+				return nil, errors.New("rpc down")
+			},
+			wantErr: nil, // checked via Contains below
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			vncfg := createTestVNConfig()
+			vncfg.Rollup.Genesis.L2Time = genesisL2Time
+			vncfg.Rollup.BlockTime = blockTime
+			log := createTestLogger(t)
+
+			mockVN := newMockVirtualNode()
+			mockVN.firstSafeHeadEntryOverride = c.firstEntry
+			mockVN.syncStatusOverride = c.syncStatus
+
+			impl := &simpleChainContainer{
+				chainID: eth.ChainIDFromUInt64(420),
+				log:     log,
+				vncfg:   vncfg,
+				vn:      mockVN,
+			}
+
+			ts, err := impl.FirstSafeHeadTimestamp(context.Background())
+			if c.wantErr != nil {
+				require.ErrorIs(t, err, c.wantErr)
+				require.Zero(t, ts)
+				return
+			}
+			if c.name == "SyncStatus error propagates" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "sync status")
+				require.Contains(t, err.Error(), "rpc down")
+				require.Zero(t, ts)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.wantTS, ts)
+		})
+	}
+}
+
+// SyncStatus must be sampled before FirstSafeHeadEntry; the reverse order
+// admits a race where the deriver finishes firstEntry.L1 between reads.
+func TestChainContainer_FirstSafeHeadTimestamp_SamplesSyncStatusFirst(t *testing.T) {
+	t.Parallel()
+
+	vncfg := createTestVNConfig()
+	vncfg.Rollup.Genesis.L2Time = 1000
+	vncfg.Rollup.BlockTime = 2
+	log := createTestLogger(t)
+
+	mockVN := newMockVirtualNode()
+	mockVN.firstSafeHeadEntryOverride = func() (eth.BlockID, eth.BlockID, error) {
+		return eth.BlockID{Number: 4}, eth.BlockID{Number: 23}, nil
+	}
+	mockVN.syncStatusOverride = func() (*eth.SyncStatus, error) {
+		return &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 5}}, nil
+	}
+
+	impl := &simpleChainContainer{
+		chainID: eth.ChainIDFromUInt64(420),
+		log:     log,
+		vncfg:   vncfg,
+		vn:      mockVN,
+	}
+
+	_, err := impl.FirstSafeHeadTimestamp(context.Background())
+	require.NoError(t, err)
+
+	mockVN.mu.Lock()
+	defer mockVN.mu.Unlock()
+	require.GreaterOrEqual(t, len(mockVN.methodCalls), 2)
+	syncIdx, firstIdx := -1, -1
+	for i, name := range mockVN.methodCalls {
+		if name == "SyncStatus" && syncIdx == -1 {
+			syncIdx = i
+		}
+		if name == "FirstSafeHeadEntry" && firstIdx == -1 {
+			firstIdx = i
+		}
+	}
+	require.NotEqual(t, -1, syncIdx, "SyncStatus should have been called")
+	require.NotEqual(t, -1, firstIdx, "FirstSafeHeadEntry should have been called")
+	require.Less(t, syncIdx, firstIdx,
+		"SyncStatus must be sampled before FirstSafeHeadEntry — the reverse order admits a race; methodCalls=%v", mockVN.methodCalls)
 }


### PR DESCRIPTION
`SafeDB.SafeHeadUpdated` keys entries by L1 block number and overwrites on every safe-head advancement at the same L1, so `FirstEntry`'s L2 value is unstable while the deriver is still on that L1. Cold-start was snapshotting an in-flight L2 as `verificationStartTimestamp`; by the time the verifier issued its first `OptimisticAt`, `firstEntry.L2` had advanced past the target. `L1AtSafeHead` then returned `ErrL1AtSafeHeadUnavailable` and the activity halted (`op-supernode/supernode/activity/interop/interop.go:388`).

Sample `SyncStatus` before `FirstSafeHeadEntry` and require `capturedCurrentL1 > firstEntry.L1` before treating the snapshot as ready. With that order, any subsequent `firstEntry.L1 < capturedCurrentL1` definitionally means writes at that L1 had already completed. Otherwise return `ErrSafeDBNotReady`, which cold-start already retries on.

Hard to reproduce in acceptance tests because devstack's catch-up replay collapses each L1 window to milliseconds — cold-start's 1 s poll interval almost never lands mid-window. On a real network with mostly-idle ~12 s L1 blocks (or a long backlog batch covering many L2s) the race fires.

## Tests

Two new tests in `chain_container_test.go`:

- `TestChainContainer_FirstSafeHeadTimestamp_StableSnapshot` — covers empty SafeDB, deriver still on / below / past firstEntry's L1, and SyncStatus error propagation.
- `TestChainContainer_FirstSafeHeadTimestamp_SamplesSyncStatusFirst` — guards the sample-order invariant by recording mock call order and asserting SyncStatus precedes FirstSafeHeadEntry.