### PR TITLE
feat(op-reth/proofs): snapshot hashed-leaf tables for backfill

### DIFF
--- a/rust/op-reth/crates/trie/src/api.rs
+++ b/rust/op-reth/crates/trie/src/api.rs
@@ -335,6 +335,16 @@ pub trait OpProofsSnapshotProviderRO: OpProofsProviderRO {
     where
         Self: 'tx;
 
+    /// Cursor over the snapshot's hashed-account leaf table.
+    type SnapshotHashedAccountCursor<'tx>: HashedCursor<Value = Account> + Send + 'tx
+    where
+        Self: 'tx;
+
+    /// Cursor over the snapshot's hashed-storage leaf table.
+    type SnapshotHashedStorageCursor<'tx>: HashedStorageCursor<Value = U256> + Send + 'tx
+    where
+        Self: 'tx;
+
     /// Anchor block of a `Ready` snapshot. Errors with
     /// [`OpProofsStorageError::SnapshotNotReady`](crate::OpProofsStorageError::SnapshotNotReady)
     /// otherwise.
@@ -350,18 +360,34 @@ pub trait OpProofsSnapshotProviderRO: OpProofsProviderRO {
         &self,
         hashed_address: B256,
     ) -> OpProofsStorageResult<Self::SnapshotStorageTrieCursor<'tx>>;
+
+    /// Open a cursor over the snapshot's hashed-account leaf table.
+    fn snapshot_hashed_account_cursor<'tx>(
+        &self,
+    ) -> OpProofsStorageResult<Self::SnapshotHashedAccountCursor<'tx>>;
+
+    /// Open a cursor over the snapshot's hashed-storage leaf table for `hashed_address`.
+    fn snapshot_hashed_storage_cursor<'tx>(
+        &self,
+        hashed_address: B256,
+    ) -> OpProofsStorageResult<Self::SnapshotHashedStorageCursor<'tx>>;
 }
 
 /// Write access to the trie-state snapshot. Snapshot writes share the
 /// underlying tx with the provider's other writer surfaces, so they commit
 /// atomically.
 pub trait OpProofsSnapshotProviderRW: OpProofsSnapshotProviderRO {
-    /// Wipe both snapshot tables and the meta row.
+    /// Wipe all snapshot tables and the meta row.
     fn clear_snapshot(&self) -> OpProofsStorageResult<()>;
 
-    /// Project `trie_updates` onto the snapshot and advance the anchor to
-    /// `new_anchor` atomically. Direction is implicit in the diff:
-    /// `(path, Some(node))` sets, `(path, None)` deletes.
+    /// Project `diff` onto the snapshot and advance the anchor to
+    /// `new_anchor` atomically. Trie direction is implicit:
+    /// `(path, Some(node))` sets, `(path, None)` deletes. Leaf direction
+    /// follows the same convention: `Some(value)` upserts the leaf, `None`
+    /// deletes it.
+    ///
+    /// The returned [`WriteCounts`] reports per-table row counts (mirrors
+    /// [`OpProofsBackfillProvider::prepend_block`]'s return shape).
     ///
     /// Requires status `Ready`; errors with
     /// [`OpProofsStorageError::SnapshotUpdateNotReady`](crate::OpProofsStorageError::SnapshotUpdateNotReady)
@@ -369,8 +395,8 @@ pub trait OpProofsSnapshotProviderRW: OpProofsSnapshotProviderRO {
     fn update_snapshot(
         &self,
         new_anchor: BlockNumHash,
-        trie_updates: &TrieUpdatesSorted,
-    ) -> OpProofsStorageResult<u64>;
+        diff: &BlockStateDiff,
+    ) -> OpProofsStorageResult<WriteCounts>;
 
     /// Commit the transaction. Consumes the provider.
     fn commit(self) -> OpProofsStorageResult<()>;
@@ -400,6 +426,11 @@ pub struct SnapshotInitAnchor {
     pub last_account_trie_key: Option<StoredNibbles>,
     /// Last entry in [`crate::db::V2StoragesTrieSnapshot`]; resumes the storage-trie phase.
     pub last_storage_trie_key: Option<StorageTrieKey>,
+    /// Last key in [`crate::db::V2HashedAccountsSnapshot`]; resumes the hashed-accounts phase.
+    pub last_hashed_account_key: Option<B256>,
+    /// Last entry in [`crate::db::V2HashedStoragesSnapshot`]; resumes the
+    /// hashed-storages phase.
+    pub last_hashed_storage_key: Option<HashedStorageKey>,
 }
 
 /// Init-time read + write surface for the trie-state snapshot. Mirrors
@@ -428,6 +459,23 @@ pub trait OpProofsSnapshotInitProvider: Send + Sync + Debug {
         &self,
         hashed_address: B256,
         storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> OpProofsStorageResult<()>;
+
+    /// Append a chunk to [`crate::db::V2HashedAccountsSnapshot`]. Entries must
+    /// be sorted by `hashed_address` and strictly greater than the table's
+    /// current last key.
+    fn store_hashed_accounts_snapshot(
+        &self,
+        entries: Vec<(B256, Account)>,
+    ) -> OpProofsStorageResult<()>;
+
+    /// Append a chunk to [`crate::db::V2HashedStoragesSnapshot`] for
+    /// `hashed_address`. Entries must be sorted by storage key and strictly
+    /// greater than the table's current last entry for this address.
+    fn store_hashed_storages_snapshot(
+        &self,
+        hashed_address: B256,
+        entries: Vec<(B256, U256)>,
     ) -> OpProofsStorageResult<()>;
 
     /// Transition the meta row from `Building` to `Ready`. Errors if no meta

--- a/rust/op-reth/crates/trie/src/backfill/job.rs
+++ b/rust/op-reth/crates/trie/src/backfill/job.rs
@@ -5,7 +5,8 @@ use crate::{
     BlockStateDiff, OpProofsBackfillProvider, OpProofsHashedAccountCursorFactory,
     OpProofsProviderRO, OpProofsSnapshotInitProvider, OpProofsSnapshotProviderRO,
     OpProofsSnapshotProviderRW, OpProofsSnapshotStore, OpProofsStore, OpProofsTrieCursorFactory,
-    SnapshotInitJob, SnapshotInitStatus, SnapshotTrieCursorFactory, proof::DatabaseStateRoot,
+    SnapshotHashedCursorFactory, SnapshotInitJob, SnapshotInitStatus, SnapshotTrieCursorFactory,
+    proof::DatabaseStateRoot,
 };
 use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::BlockNumber;
@@ -16,7 +17,6 @@ use reth_provider::{
     StageCheckpointReader, StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_trie::{HashedPostState, StateRoot, hashed_cursor::HashedPostStateCursorFactory};
-use reth_trie_common::{HashedPostStateSorted, updates::TrieUpdatesSorted};
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -354,7 +354,7 @@ where
         block_number: BlockNumber,
     ) -> Result<PhaseTimings, BackfillError> {
         let block_ref = self.resolve_block_ref(block_number)?;
-        let (trie_updates, post_state, compute) = self.compute_diff_with_snapshot(block_number)?;
+        let (diff, compute) = self.compute_diff_with_snapshot(block_number)?;
 
         // After this iteration the proofs window's earliest moves from E to
         // E-1, so the snapshot anchor advances to the parent block.
@@ -363,11 +363,8 @@ where
 
         // Step 1+2: advance both the proofs window and the snapshot anchor in one tx.
         let (_, prepend) = timed(|| -> Result<(), BackfillError> {
-            bp.update_snapshot(new_anchor, &trie_updates)?;
-            bp.prepend_block(
-                block_ref,
-                BlockStateDiff { sorted_trie_updates: trie_updates, sorted_post_state: post_state },
-            )?;
+            bp.update_snapshot(new_anchor, &diff)?;
+            bp.prepend_block(block_ref, diff)?;
             Ok(())
         })?;
 
@@ -382,31 +379,29 @@ where
         Ok(PhaseTimings { compute, prepend, validate, commit })
     }
 
-    /// Compute the per-block backfill diff using snapshot trie cursors.
-    ///
-    /// Returns the trie reverts and the leaf post-state separately so the
-    /// caller can pass `&trie_updates` to `update_snapshot` and then move the
-    /// diff into `prepend_block` without an extra clone.
+    /// Compute the per-block backfill diff using snapshot trie + leaf cursors.
     fn compute_diff_with_snapshot(
         &self,
         block_number: BlockNumber,
-    ) -> Result<(TrieUpdatesSorted, HashedPostStateSorted, Duration), BackfillError> {
+    ) -> Result<(BlockStateDiff, Duration), BackfillError> {
+        // `block_number` is unused on the snapshot path: the snapshot reflects
+        // state at its anchor, which the caller guaranteed equals
+        // `block_number` via `ensure_snapshot_ready`.
+        let _ = block_number;
         timed(|| {
             // Read-only snapshot provider — both cursor factories can share it
-            // via cheap `Clone` (no Arc wrapping needed here; the RO assoc-type
-            // bound requires `Clone`).
+            // via cheap `Clone`.
             let sp = self.storage.snapshot_provider_ro()?;
             let trie_factory = SnapshotTrieCursorFactory::new(sp.clone());
-            let hashed_factory = OpProofsHashedAccountCursorFactory::new(sp, block_number);
-            let (trie_updates, post_state) = compute_block_backfill_diff(
+            let hashed_factory = SnapshotHashedCursorFactory::new(sp);
+            let (sorted_trie_updates, sorted_post_state) = compute_block_backfill_diff(
                 &self.provider,
                 trie_factory,
                 hashed_factory,
                 block_number,
             )?;
-            Ok((trie_updates, post_state))
+            Ok(BlockStateDiff { sorted_trie_updates, sorted_post_state })
         })
-        .map(|((trie_updates, post_state), elapsed)| (trie_updates, post_state, elapsed))
     }
 
     /// Validate the just-prepended state at `block_number - 1` using snapshot
@@ -431,7 +426,7 @@ where
             let computed_root = StateRoot::new(
                 SnapshotTrieCursorFactory::new(Arc::clone(sp)),
                 HashedPostStateCursorFactory::new(
-                    OpProofsHashedAccountCursorFactory::new(Arc::clone(sp), block_number - 1),
+                    SnapshotHashedCursorFactory::new(Arc::clone(sp)),
                     &state_sorted,
                 ),
             )

--- a/rust/op-reth/crates/trie/src/cursor_factory.rs
+++ b/rust/op-reth/crates/trie/src/cursor_factory.rs
@@ -149,3 +149,48 @@ where
         ))
     }
 }
+
+/// Factory for creating hashed leaf cursors backed by the snapshot tables.
+///
+/// Mirrors [`SnapshotTrieCursorFactory`]'s role for hashed leaves: reads
+/// directly from [`crate::db::V2HashedAccountsSnapshot`] and
+/// [`crate::db::V2HashedStoragesSnapshot`] without history merges. Valid only
+/// when the snapshot is `Ready` at the anchor the caller is reading.
+#[derive(Debug, Clone)]
+pub struct SnapshotHashedCursorFactory<P> {
+    reader: P,
+}
+
+impl<P: OpProofsSnapshotProviderRO> SnapshotHashedCursorFactory<P> {
+    /// Create a new snapshot-backed hashed cursor factory.
+    pub const fn new(reader: P) -> Self {
+        Self { reader }
+    }
+}
+
+impl<P> HashedCursorFactory for SnapshotHashedCursorFactory<P>
+where
+    P: OpProofsSnapshotProviderRO,
+{
+    type AccountCursor<'a>
+        = P::SnapshotHashedAccountCursor<'a>
+    where
+        Self: 'a;
+    type StorageCursor<'a>
+        = P::SnapshotHashedStorageCursor<'a>
+    where
+        Self: 'a;
+
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
+        self.reader.snapshot_hashed_account_cursor().map_err(Into::<DatabaseError>::into)
+    }
+
+    fn hashed_storage_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
+        self.reader
+            .snapshot_hashed_storage_cursor(hashed_address)
+            .map_err(Into::<DatabaseError>::into)
+    }
+}

--- a/rust/op-reth/crates/trie/src/db/mod.rs
+++ b/rust/op-reth/crates/trie/src/db/mod.rs
@@ -19,5 +19,6 @@ pub use cursor::{
 mod store_v2;
 pub use store_v2::{
     MdbxProofsProviderV2, MdbxProofsStorageV2, V2AccountCursor, V2AccountTrieCursor,
-    V2AccountTrieSnapshotCursor, V2StorageCursor, V2StorageTrieCursor, V2StorageTrieSnapshotCursor,
+    V2AccountTrieSnapshotCursor, V2HashedAccountSnapshotCursor, V2HashedStorageSnapshotCursor,
+    V2StorageCursor, V2StorageTrieCursor, V2StorageTrieSnapshotCursor,
 };

--- a/rust/op-reth/crates/trie/src/db/models/mod.rs
+++ b/rust/op-reth/crates/trie/src/db/models/mod.rs
@@ -255,6 +255,21 @@ tables! {
         type SubKey = StoredNibblesSubKey;
     }
 
+    /// Snapshot of [`V2HashedAccounts`] reflecting hashed-account leaves at the
+    /// snapshot anchor block.
+    table V2HashedAccountsSnapshot {
+        type Key = B256;
+        type Value = Account;
+    }
+
+    /// Snapshot of [`V2HashedStorages`] reflecting hashed-storage leaves at the
+    /// snapshot anchor block. Same shape as [`V2HashedStorages`].
+    table V2HashedStoragesSnapshot {
+        type Key = B256;
+        type Value = StorageEntry;
+        type SubKey = B256;
+    }
+
     /// Single-row metadata for the snapshot: which block its trie state
     /// reflects, and whether it's [`SnapshotStatus::Ready`] for reads.
     table V2SnapshotMeta {

--- a/rust/op-reth/crates/trie/src/db/store.rs
+++ b/rust/op-reth/crates/trie/src/db/store.rs
@@ -977,6 +977,16 @@ impl<TX: DbTx + Send + Sync + Debug + 'static> OpProofsSnapshotProviderRO
     where
         Self: 'tx,
         TX: 'tx;
+    type SnapshotHashedAccountCursor<'tx>
+        = MdbxAccountCursor<TX::DupCursor<HashedAccountHistory>>
+    where
+        Self: 'tx,
+        TX: 'tx;
+    type SnapshotHashedStorageCursor<'tx>
+        = MdbxStorageCursor<TX::DupCursor<HashedStorageHistory>>
+    where
+        Self: 'tx,
+        TX: 'tx;
 
     fn snapshot_anchor(&self) -> OpProofsStorageResult<BlockNumHash> {
         unimplemented!("Not supported in V1 storage")
@@ -994,6 +1004,19 @@ impl<TX: DbTx + Send + Sync + Debug + 'static> OpProofsSnapshotProviderRO
     ) -> OpProofsStorageResult<Self::SnapshotStorageTrieCursor<'tx>> {
         unimplemented!("Not supported in V1 storage")
     }
+
+    fn snapshot_hashed_account_cursor<'tx>(
+        &self,
+    ) -> OpProofsStorageResult<Self::SnapshotHashedAccountCursor<'tx>> {
+        unimplemented!("Not supported in V1 storage")
+    }
+
+    fn snapshot_hashed_storage_cursor<'tx>(
+        &self,
+        _hashed_address: B256,
+    ) -> OpProofsStorageResult<Self::SnapshotHashedStorageCursor<'tx>> {
+        unimplemented!("Not supported in V1 storage")
+    }
 }
 
 impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsSnapshotProviderRW
@@ -1006,8 +1029,8 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsSnapshotProvide
     fn update_snapshot(
         &self,
         _new_anchor: BlockNumHash,
-        _trie_updates: &reth_trie_common::updates::TrieUpdatesSorted,
-    ) -> OpProofsStorageResult<u64> {
+        _diff: &BlockStateDiff,
+    ) -> OpProofsStorageResult<WriteCounts> {
         unimplemented!("Not supported in V1 storage")
     }
 

--- a/rust/op-reth/crates/trie/src/db/store_v2/cursor/mod.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/cursor/mod.rs
@@ -33,7 +33,10 @@ mod storage_trie;
 
 pub use account::V2AccountCursor;
 pub use account_trie::V2AccountTrieCursor;
-pub use snapshot::{V2AccountTrieSnapshotCursor, V2StorageTrieSnapshotCursor};
+pub use snapshot::{
+    V2AccountTrieSnapshotCursor, V2HashedAccountSnapshotCursor, V2HashedStorageSnapshotCursor,
+    V2StorageTrieSnapshotCursor,
+};
 pub use storage::V2StorageCursor;
 pub use storage_trie::V2StorageTrieCursor;
 

--- a/rust/op-reth/crates/trie/src/db/store_v2/cursor/snapshot.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/cursor/snapshot.rs
@@ -1,27 +1,32 @@
-//! Plain (non-history-aware) cursors over the snapshot trie tables.
+//! Plain (non-history-aware) cursors over the snapshot tables.
 //!
-//! Unlike the V2 history-aware cursors (see [`super::account_trie`] and
-//! [`super::storage_trie`]), these read directly from
-//! [`V2AccountsTrieSnapshot`] / [`V2StoragesTrieSnapshot`] without any merge
-//! walk: the snapshot tables already reflect trie state at the snapshot's
-//! `earliest` boundary, so a single current-state read is authoritative.
+//! Unlike the V2 history-aware cursors (see [`super::account_trie`],
+//! [`super::storage_trie`], [`super::account`], [`super::storage`]), these
+//! read directly from the snapshot tables without any merge walk: the
+//! snapshot already reflects state at the snapshot anchor, so a single
+//! current-state read is authoritative.
 //!
 //! Used by the backfill job when a [`SnapshotStatus::Ready`] snapshot is
 //! available — see `crate::backfill` for the rationale.
 //!
 //! [`SnapshotStatus::Ready`]: crate::db::models::SnapshotStatus::Ready
 
-use alloy_primitives::B256;
+use alloy_primitives::{B256, U256};
 use reth_db::{
     DatabaseError,
     cursor::{DbCursorRO, DbDupCursorRO},
 };
+use reth_primitives_traits::Account;
 use reth_trie::{
     BranchNodeCompact, Nibbles, StoredNibbles, StoredNibblesSubKey,
+    hashed_cursor::{HashedCursor, HashedStorageCursor},
     trie_cursor::{TrieCursor, TrieStorageCursor},
 };
 
-use crate::db::models::{V2AccountsTrieSnapshot, V2StoragesTrieSnapshot};
+use crate::db::models::{
+    V2AccountsTrieSnapshot, V2HashedAccountsSnapshot, V2HashedStoragesSnapshot,
+    V2StoragesTrieSnapshot,
+};
 
 /// Plain account-trie cursor over [`V2AccountsTrieSnapshot`].
 #[derive(Debug)]
@@ -170,6 +175,113 @@ where
     fn set_hashed_address(&mut self, hashed_address: B256) {
         self.hashed_address = hashed_address;
         self.last_key = None;
+        self.seeked = false;
+    }
+}
+
+/// Plain hashed-account leaf cursor over [`V2HashedAccountsSnapshot`].
+#[derive(Debug)]
+pub struct V2HashedAccountSnapshotCursor<C> {
+    cursor: C,
+    /// Whether `seek*` has positioned the underlying cursor at least once.
+    /// Guards `next` against undefined mdbx behavior on an unpositioned cursor.
+    seeked: bool,
+}
+
+impl<C> V2HashedAccountSnapshotCursor<C> {
+    /// Create a new hashed-account snapshot cursor wrapping `cursor`.
+    pub const fn new(cursor: C) -> Self {
+        Self { cursor, seeked: false }
+    }
+}
+
+impl<C> HashedCursor for V2HashedAccountSnapshotCursor<C>
+where
+    C: DbCursorRO<V2HashedAccountsSnapshot> + Send,
+{
+    type Value = Account;
+
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        self.seeked = true;
+        self.cursor.seek(key)
+    }
+
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        if !self.seeked {
+            return self.seek(B256::ZERO);
+        }
+        self.cursor.next()
+    }
+
+    fn reset(&mut self) {
+        self.seeked = false;
+    }
+}
+
+/// Plain hashed-storage leaf cursor over [`V2HashedStoragesSnapshot`] (a
+/// `DupSort` table). Yields `(storage_key, U256)` pairs, skipping any
+/// zero-valued entries defensively (the snapshot writer never inserts zeros,
+/// but the cursor mirrors the live [`super::storage::V2StorageCursor`]
+/// invariant).
+#[derive(Debug)]
+pub struct V2HashedStorageSnapshotCursor<C> {
+    cursor: C,
+    hashed_address: B256,
+    seeked: bool,
+}
+
+impl<C> V2HashedStorageSnapshotCursor<C> {
+    /// Create a new hashed-storage snapshot cursor scoped to `hashed_address`.
+    pub const fn new(cursor: C, hashed_address: B256) -> Self {
+        Self { cursor, hashed_address, seeked: false }
+    }
+}
+
+impl<C> HashedCursor for V2HashedStorageSnapshotCursor<C>
+where
+    C: DbCursorRO<V2HashedStoragesSnapshot> + DbDupCursorRO<V2HashedStoragesSnapshot> + Send,
+{
+    type Value = U256;
+
+    fn seek(&mut self, subkey: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        self.seeked = true;
+        let mut entry = self.cursor.seek_by_key_subkey(self.hashed_address, subkey)?;
+        while let Some(ref e) = entry {
+            if !e.value.is_zero() {
+                return Ok(Some((e.key, e.value)));
+            }
+            entry = self.cursor.next_dup_val()?;
+        }
+        Ok(None)
+    }
+
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        if !self.seeked {
+            return self.seek(B256::ZERO);
+        }
+        while let Some(e) = self.cursor.next_dup_val()? {
+            if !e.value.is_zero() {
+                return Ok(Some((e.key, e.value)));
+            }
+        }
+        Ok(None)
+    }
+
+    fn reset(&mut self) {
+        self.seeked = false;
+    }
+}
+
+impl<C> HashedStorageCursor for V2HashedStorageSnapshotCursor<C>
+where
+    C: DbCursorRO<V2HashedStoragesSnapshot> + DbDupCursorRO<V2HashedStoragesSnapshot> + Send,
+{
+    fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
+        Ok(self.seek(B256::ZERO)?.is_none())
+    }
+
+    fn set_hashed_address(&mut self, hashed_address: B256) {
+        self.hashed_address = hashed_address;
         self.seeked = false;
     }
 }

--- a/rust/op-reth/crates/trie/src/db/store_v2/mod.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/mod.rs
@@ -23,7 +23,8 @@ mod snapshot_write;
 mod write;
 
 pub use cursor::{
-    V2AccountCursor, V2AccountTrieCursor, V2AccountTrieSnapshotCursor, V2StorageCursor,
+    V2AccountCursor, V2AccountTrieCursor, V2AccountTrieSnapshotCursor,
+    V2HashedAccountSnapshotCursor, V2HashedStorageSnapshotCursor, V2StorageCursor,
     V2StorageTrieCursor, V2StorageTrieSnapshotCursor,
 };
 

--- a/rust/op-reth/crates/trie/src/db/store_v2/snapshot_init.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/snapshot_init.rs
@@ -10,16 +10,20 @@ use crate::{
     OpProofsStorageError, OpProofsStorageResult,
     api::{OpProofsSnapshotInitProvider, SnapshotInitAnchor, SnapshotInitStatus},
     db::{
-        SnapshotMeta, SnapshotMetaKey, SnapshotStatus, StorageTrieKey,
-        models::{V2AccountsTrieSnapshot, V2SnapshotMeta, V2StoragesTrieSnapshot},
+        HashedStorageKey, SnapshotMeta, SnapshotMetaKey, SnapshotStatus, StorageTrieKey,
+        models::{
+            V2AccountsTrieSnapshot, V2HashedAccountsSnapshot, V2HashedStoragesSnapshot,
+            V2SnapshotMeta, V2StoragesTrieSnapshot,
+        },
     },
 };
 use alloy_eips::BlockNumHash;
-use alloy_primitives::B256;
+use alloy_primitives::{B256, U256};
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRW},
     transaction::{DbTx, DbTxMut},
 };
+use reth_primitives_traits::{Account, StorageEntry};
 use reth_trie::{BranchNodeCompact, Nibbles, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey};
 use std::fmt::Debug;
 
@@ -49,7 +53,23 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsSnapshotInitPro
             .last()?
             .map(|(addr, entry)| StorageTrieKey::new(addr, StoredNibbles(entry.nibbles.0)));
 
-        Ok(SnapshotInitAnchor { block, status, last_account_trie_key, last_storage_trie_key })
+        let last_hashed_account_key =
+            self.tx.cursor_read::<V2HashedAccountsSnapshot>()?.last()?.map(|(k, _)| k);
+
+        let last_hashed_storage_key = self
+            .tx
+            .cursor_dup_read::<V2HashedStoragesSnapshot>()?
+            .last()?
+            .map(|(addr, entry)| HashedStorageKey::new(addr, entry.key));
+
+        Ok(SnapshotInitAnchor {
+            block,
+            status,
+            last_account_trie_key,
+            last_storage_trie_key,
+            last_hashed_account_key,
+            last_hashed_storage_key,
+        })
     }
 
     fn set_snapshot_init_anchor(&self, anchor: BlockNumHash) -> OpProofsStorageResult<()> {
@@ -90,6 +110,37 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsSnapshotInitPro
                     hashed_address,
                     StorageTrieEntry { nibbles: StoredNibblesSubKey(nibbles), node },
                 )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn store_hashed_accounts_snapshot(
+        &self,
+        entries: Vec<(B256, Account)>,
+    ) -> OpProofsStorageResult<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let mut cur = self.tx.cursor_write::<V2HashedAccountsSnapshot>()?;
+        for (key, account) in entries {
+            cur.append(key, &account)?;
+        }
+        Ok(())
+    }
+
+    fn store_hashed_storages_snapshot(
+        &self,
+        hashed_address: B256,
+        entries: Vec<(B256, U256)>,
+    ) -> OpProofsStorageResult<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let mut cur = self.tx.cursor_dup_write::<V2HashedStoragesSnapshot>()?;
+        for (key, value) in entries {
+            if !value.is_zero() {
+                cur.append_dup(hashed_address, StorageEntry { key, value })?;
             }
         }
         Ok(())

--- a/rust/op-reth/crates/trie/src/db/store_v2/snapshot_read.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/snapshot_read.rs
@@ -2,14 +2,20 @@
 
 use super::{
     MdbxProofsProviderV2,
-    cursor::{V2AccountTrieSnapshotCursor, V2StorageTrieSnapshotCursor},
+    cursor::{
+        V2AccountTrieSnapshotCursor, V2HashedAccountSnapshotCursor, V2HashedStorageSnapshotCursor,
+        V2StorageTrieSnapshotCursor,
+    },
 };
 use crate::{
     OpProofsStorageError, OpProofsStorageResult,
     api::{OpProofsSnapshotProviderRO, SnapshotInitStatus},
     db::{
         SnapshotMeta, SnapshotMetaKey, SnapshotStatus,
-        models::{V2AccountsTrieSnapshot, V2SnapshotMeta, V2StoragesTrieSnapshot},
+        models::{
+            V2AccountsTrieSnapshot, V2HashedAccountsSnapshot, V2HashedStoragesSnapshot,
+            V2SnapshotMeta, V2StoragesTrieSnapshot,
+        },
     },
 };
 use alloy_eips::BlockNumHash;
@@ -48,6 +54,18 @@ impl<TX: DbTx + Send + Sync + Debug + 'static> OpProofsSnapshotProviderRO
         Self: 'tx,
         TX: 'tx;
 
+    type SnapshotHashedAccountCursor<'tx>
+        = V2HashedAccountSnapshotCursor<TX::Cursor<V2HashedAccountsSnapshot>>
+    where
+        Self: 'tx,
+        TX: 'tx;
+
+    type SnapshotHashedStorageCursor<'tx>
+        = V2HashedStorageSnapshotCursor<TX::DupCursor<V2HashedStoragesSnapshot>>
+    where
+        Self: 'tx,
+        TX: 'tx;
+
     fn snapshot_anchor(&self) -> OpProofsStorageResult<BlockNumHash> {
         match self.read_snapshot_meta() {
             Ok(SnapshotMeta { anchor, status: SnapshotStatus::Ready }) => Ok(anchor),
@@ -77,6 +95,22 @@ impl<TX: DbTx + Send + Sync + Debug + 'static> OpProofsSnapshotProviderRO
     ) -> OpProofsStorageResult<Self::SnapshotStorageTrieCursor<'tx>> {
         Ok(V2StorageTrieSnapshotCursor::new(
             self.tx.cursor_dup_read::<V2StoragesTrieSnapshot>()?,
+            hashed_address,
+        ))
+    }
+
+    fn snapshot_hashed_account_cursor<'tx>(
+        &self,
+    ) -> OpProofsStorageResult<Self::SnapshotHashedAccountCursor<'tx>> {
+        Ok(V2HashedAccountSnapshotCursor::new(self.tx.cursor_read::<V2HashedAccountsSnapshot>()?))
+    }
+
+    fn snapshot_hashed_storage_cursor<'tx>(
+        &self,
+        hashed_address: B256,
+    ) -> OpProofsStorageResult<Self::SnapshotHashedStorageCursor<'tx>> {
+        Ok(V2HashedStorageSnapshotCursor::new(
+            self.tx.cursor_dup_read::<V2HashedStoragesSnapshot>()?,
             hashed_address,
         ))
     }

--- a/rust/op-reth/crates/trie/src/db/store_v2/snapshot_tests.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/snapshot_tests.rs
@@ -2,7 +2,7 @@
 
 use super::MdbxProofsProviderV2;
 use crate::{
-    OpProofsStorageError,
+    BlockStateDiff, OpProofsStorageError,
     api::{
         OpProofsSnapshotInitProvider, OpProofsSnapshotProviderRO, OpProofsSnapshotProviderRW,
         SnapshotInitStatus,
@@ -21,7 +21,7 @@ use reth_db::{
     transaction::DbTx,
 };
 use reth_trie::{
-    BranchNodeCompact, Nibbles, StoredNibbles, StoredNibblesSubKey,
+    BranchNodeCompact, HashedPostStateSorted, Nibbles, StoredNibbles, StoredNibblesSubKey,
     updates::{StorageTrieUpdates, TrieUpdates},
 };
 use tempfile::TempDir;
@@ -316,10 +316,16 @@ fn write_update_snapshot_applies_diff_and_advances_anchor() {
         let mut st = StorageTrieUpdates::default();
         st.storage_nodes.insert(stor_path, stor_node.clone());
         updates.storage_tries.insert(addr, st);
-        let sorted = updates.into_sorted();
+        let diff = BlockStateDiff {
+            sorted_trie_updates: updates.into_sorted(),
+            sorted_post_state: HashedPostStateSorted::default(),
+        };
 
-        let n = provider.update_snapshot(new_anchor, &sorted).expect("update");
-        assert_eq!(n, 2, "account + storage node = 2");
+        let counts = provider.update_snapshot(new_anchor, &diff).expect("update");
+        assert_eq!(counts.account_trie_updates_written_total, 1);
+        assert_eq!(counts.storage_trie_updates_written_total, 1);
+        assert_eq!(counts.hashed_accounts_written_total, 0);
+        assert_eq!(counts.hashed_storages_written_total, 0);
         OpProofsSnapshotProviderRW::commit(provider).expect("commit");
     }
 
@@ -368,8 +374,11 @@ fn write_update_snapshot_handles_removals() {
         let provider = MdbxProofsProviderV2::new(db.tx_mut().expect("rw"));
         let mut updates = TrieUpdates::default();
         updates.removed_nodes.insert(acc_path);
-        let sorted = updates.into_sorted();
-        provider.update_snapshot(new_anchor, &sorted).expect("update");
+        let diff = BlockStateDiff {
+            sorted_trie_updates: updates.into_sorted(),
+            sorted_post_state: HashedPostStateSorted::default(),
+        };
+        provider.update_snapshot(new_anchor, &diff).expect("update");
         OpProofsSnapshotProviderRW::commit(provider).expect("commit");
     }
 
@@ -392,8 +401,11 @@ fn write_update_snapshot_errors_when_building() {
     }
 
     let provider = MdbxProofsProviderV2::new(db.tx_mut().expect("rw"));
-    let sorted = TrieUpdates::default().into_sorted();
-    let err = provider.update_snapshot(anchor(9, 0x09), &sorted).unwrap_err();
+    let diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdates::default().into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+    let err = provider.update_snapshot(anchor(9, 0x09), &diff).unwrap_err();
     match err {
         OpProofsStorageError::SnapshotUpdateNotReady { status } => {
             assert_eq!(status, SnapshotStatus::Building);
@@ -406,7 +418,10 @@ fn write_update_snapshot_errors_when_building() {
 fn write_update_snapshot_errors_when_missing() {
     let db = setup_db();
     let provider = MdbxProofsProviderV2::new(db.tx_mut().expect("rw"));
-    let sorted = TrieUpdates::default().into_sorted();
-    let err = provider.update_snapshot(anchor(9, 0x09), &sorted).unwrap_err();
+    let diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdates::default().into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+    let err = provider.update_snapshot(anchor(9, 0x09), &diff).unwrap_err();
     assert!(matches!(err, OpProofsStorageError::SnapshotNotInitialized), "got {err:?}");
 }

--- a/rust/op-reth/crates/trie/src/db/store_v2/snapshot_write.rs
+++ b/rust/op-reth/crates/trie/src/db/store_v2/snapshot_write.rs
@@ -6,19 +6,26 @@
 
 use super::MdbxProofsProviderV2;
 use crate::{
-    OpProofsStorageError, OpProofsStorageResult,
-    api::OpProofsSnapshotProviderRW,
+    BlockStateDiff, OpProofsStorageError, OpProofsStorageResult,
+    api::{OpProofsSnapshotProviderRW, WriteCounts},
     db::{
         SnapshotMeta, SnapshotMetaKey, SnapshotStatus,
-        models::{V2AccountsTrieSnapshot, V2SnapshotMeta, V2StoragesTrieSnapshot},
+        models::{
+            V2AccountsTrieSnapshot, V2HashedAccountsSnapshot, V2HashedStoragesSnapshot,
+            V2SnapshotMeta, V2StoragesTrieSnapshot,
+        },
     },
 };
 use alloy_eips::BlockNumHash;
 use reth_db::{
-    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
+    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
     transaction::{DbTx, DbTxMut},
 };
-use reth_trie::{StorageTrieEntry, StoredNibbles, StoredNibblesSubKey, updates::TrieUpdatesSorted};
+use reth_primitives_traits::StorageEntry;
+use reth_trie::{
+    HashedPostStateSorted, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey,
+    updates::TrieUpdatesSorted,
+};
 use std::fmt::Debug;
 
 impl<TX: DbTxMut> MdbxProofsProviderV2<TX> {
@@ -36,59 +43,59 @@ impl<TX: DbTxMut> MdbxProofsProviderV2<TX> {
     }
 }
 
-impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsSnapshotProviderRW
-    for MdbxProofsProviderV2<TX>
-{
-    fn clear_snapshot(&self) -> OpProofsStorageResult<()> {
-        self.tx.clear::<V2AccountsTrieSnapshot>()?;
-        self.tx.clear::<V2StoragesTrieSnapshot>()?;
-        self.tx.clear::<V2SnapshotMeta>()?;
-        Ok(())
-    }
-
-    fn update_snapshot(
+/// Per-phase projection helpers behind
+/// [`OpProofsSnapshotProviderRW::update_snapshot`]. Each method projects one
+/// table's worth of diff onto the snapshot and returns the row count it
+/// applied (`upsert + delete`).
+impl<TX: DbTxMut> MdbxProofsProviderV2<TX> {
+    /// Project the account-trie portion of `trie_updates` onto
+    /// [`V2AccountsTrieSnapshot`]. `(path, Some)` upserts, `(path, None)`
+    /// deletes if present.
+    fn write_account_trie_snapshot(
         &self,
-        new_anchor: BlockNumHash,
         trie_updates: &TrieUpdatesSorted,
     ) -> OpProofsStorageResult<u64> {
-        // Refuse to mutate a Building snapshot: its rows are still being
-        // populated, so applying a diff against it would corrupt the result.
-        let SnapshotMeta { status, .. } = self.read_snapshot_meta()?;
-        if status != SnapshotStatus::Ready {
-            return Err(OpProofsStorageError::SnapshotUpdateNotReady { status });
-        }
-
         let mut count = 0u64;
-
-        // Account trie diff.
-        let mut acc = self.tx.cursor_write::<V2AccountsTrieSnapshot>()?;
+        let mut cur = self.tx.cursor_write::<V2AccountsTrieSnapshot>()?;
         for (nibbles, maybe_node) in trie_updates.account_nodes_ref() {
             let key = StoredNibbles(*nibbles);
             match maybe_node {
-                Some(node) => acc.upsert(key, node)?,
+                Some(node) => cur.upsert(key, node)?,
                 None => {
-                    if acc.seek_exact(key)?.is_some() {
-                        acc.delete_current()?;
+                    if cur.seek_exact(key)?.is_some() {
+                        cur.delete_current()?;
                     }
                 }
             }
             count += 1;
         }
+        Ok(count)
+    }
 
-        // Storage trie diff.
-        let mut stor = self.tx.cursor_dup_write::<V2StoragesTrieSnapshot>()?;
+    /// Project the storage-trie portion of `trie_updates` onto
+    /// [`V2StoragesTrieSnapshot`].
+    fn write_storage_trie_snapshot(
+        &self,
+        trie_updates: &TrieUpdatesSorted,
+    ) -> OpProofsStorageResult<u64> {
+        let mut count = 0u64;
+        let mut cur = self.tx.cursor_dup_write::<V2StoragesTrieSnapshot>()?;
         for (hashed_address, nodes) in trie_updates.storage_tries_ref() {
+            if nodes.is_deleted && cur.seek_exact(*hashed_address)?.is_some() {
+                cur.delete_current_duplicates()?;
+                count += 1;
+            }
             for (nibbles, maybe_node) in nodes.storage_nodes_ref() {
                 let subkey = StoredNibblesSubKey(*nibbles);
-                let existing = stor
+                let existing = cur
                     .seek_by_key_subkey(*hashed_address, subkey.clone())?
                     .filter(|e| e.nibbles == subkey)
                     .is_some();
                 if existing {
-                    stor.delete_current()?;
+                    cur.delete_current()?;
                 }
                 if let Some(node) = maybe_node {
-                    stor.upsert(
+                    cur.upsert(
                         *hashed_address,
                         &StorageTrieEntry { nibbles: subkey, node: node.clone() },
                     )?;
@@ -96,11 +103,101 @@ impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsSnapshotProvide
                 count += 1;
             }
         }
+        Ok(count)
+    }
+
+    /// Project the account-leaf portion of `hashed_post_state` onto
+    /// [`V2HashedAccountsSnapshot`].
+    fn write_hashed_accounts_snapshot(
+        &self,
+        hashed_post_state: &HashedPostStateSorted,
+    ) -> OpProofsStorageResult<u64> {
+        let mut count = 0u64;
+        let mut cur = self.tx.cursor_write::<V2HashedAccountsSnapshot>()?;
+        for (hashed_addr, maybe_acct) in hashed_post_state.accounts() {
+            match maybe_acct {
+                Some(acct) => cur.upsert(*hashed_addr, acct)?,
+                None => {
+                    if cur.seek_exact(*hashed_addr)?.is_some() {
+                        cur.delete_current()?;
+                    }
+                }
+            }
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// Project the storage-leaf portion of `hashed_post_state` onto
+    /// [`V2HashedStoragesSnapshot`].
+    fn write_hashed_storages_snapshot(
+        &self,
+        hashed_post_state: &HashedPostStateSorted,
+    ) -> OpProofsStorageResult<u64> {
+        let mut count = 0u64;
+        let mut cur = self.tx.cursor_dup_write::<V2HashedStoragesSnapshot>()?;
+        for (hashed_addr, storage) in hashed_post_state.account_storages() {
+            if storage.wiped && cur.seek_exact(*hashed_addr)?.is_some() {
+                cur.delete_current_duplicates()?;
+                count += 1;
+            }
+            for (slot, value) in &storage.storage_slots {
+                let existing = cur
+                    .seek_by_key_subkey(*hashed_addr, *slot)?
+                    .filter(|e| e.key == *slot)
+                    .is_some();
+                if existing {
+                    cur.delete_current()?;
+                }
+                if !value.is_zero() {
+                    cur.upsert(*hashed_addr, &StorageEntry { key: *slot, value: *value })?;
+                }
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+}
+
+impl<TX: DbTxMut + DbTx + Send + Sync + Debug + 'static> OpProofsSnapshotProviderRW
+    for MdbxProofsProviderV2<TX>
+{
+    fn clear_snapshot(&self) -> OpProofsStorageResult<()> {
+        self.tx.clear::<V2AccountsTrieSnapshot>()?;
+        self.tx.clear::<V2StoragesTrieSnapshot>()?;
+        self.tx.clear::<V2HashedAccountsSnapshot>()?;
+        self.tx.clear::<V2HashedStoragesSnapshot>()?;
+        self.tx.clear::<V2SnapshotMeta>()?;
+        Ok(())
+    }
+
+    fn update_snapshot(
+        &self,
+        new_anchor: BlockNumHash,
+        diff: &BlockStateDiff,
+    ) -> OpProofsStorageResult<WriteCounts> {
+        // Refuse to mutate a Building snapshot: its rows are still being
+        // populated, so applying a diff against it would corrupt the result.
+        let SnapshotMeta { status, .. } = self.read_snapshot_meta()?;
+        if status != SnapshotStatus::Ready {
+            return Err(OpProofsStorageError::SnapshotUpdateNotReady { status });
+        }
+
+        let counts = WriteCounts {
+            account_trie_updates_written_total: self
+                .write_account_trie_snapshot(&diff.sorted_trie_updates)?,
+            storage_trie_updates_written_total: self
+                .write_storage_trie_snapshot(&diff.sorted_trie_updates)?,
+            hashed_accounts_written_total: self
+                .write_hashed_accounts_snapshot(&diff.sorted_post_state)?,
+            hashed_storages_written_total: self
+                .write_hashed_storages_snapshot(&diff.sorted_post_state)?,
+        };
 
         // Advance the anchor atomically with the diff (status stays Ready).
         self.write_snapshot_meta(SnapshotMeta::new(new_anchor, SnapshotStatus::Ready))?;
 
-        Ok(count)
+        Ok(counts)
     }
 
     fn commit(self) -> OpProofsStorageResult<()> {

--- a/rust/op-reth/crates/trie/src/in_memory.rs
+++ b/rust/op-reth/crates/trie/src/in_memory.rs
@@ -915,6 +915,14 @@ impl OpProofsSnapshotProviderRO for InMemoryProofsProvider {
         = InMemoryTrieCursor
     where
         Self: 'tx;
+    type SnapshotHashedAccountCursor<'tx>
+        = InMemoryAccountCursor
+    where
+        Self: 'tx;
+    type SnapshotHashedStorageCursor<'tx>
+        = InMemoryStorageCursor
+    where
+        Self: 'tx;
 
     fn snapshot_anchor(&self) -> OpProofsStorageResult<BlockNumHash> {
         unimplemented!("Not supported in Inmemory storage")
@@ -932,6 +940,19 @@ impl OpProofsSnapshotProviderRO for InMemoryProofsProvider {
     ) -> OpProofsStorageResult<Self::SnapshotStorageTrieCursor<'tx>> {
         unimplemented!("Not supported in Inmemory storage")
     }
+
+    fn snapshot_hashed_account_cursor<'tx>(
+        &self,
+    ) -> OpProofsStorageResult<Self::SnapshotHashedAccountCursor<'tx>> {
+        unimplemented!("Not supported in Inmemory storage")
+    }
+
+    fn snapshot_hashed_storage_cursor<'tx>(
+        &self,
+        _hashed_address: B256,
+    ) -> OpProofsStorageResult<Self::SnapshotHashedStorageCursor<'tx>> {
+        unimplemented!("Not supported in Inmemory storage")
+    }
 }
 
 impl OpProofsSnapshotProviderRW for InMemoryProofsProvider {
@@ -942,8 +963,8 @@ impl OpProofsSnapshotProviderRW for InMemoryProofsProvider {
     fn update_snapshot(
         &self,
         _new_anchor: BlockNumHash,
-        _trie_updates: &TrieUpdatesSorted,
-    ) -> OpProofsStorageResult<u64> {
+        _diff: &BlockStateDiff,
+    ) -> OpProofsStorageResult<WriteCounts> {
         unimplemented!("Not supported in Inmemory storage")
     }
 

--- a/rust/op-reth/crates/trie/src/initialize.rs
+++ b/rust/op-reth/crates/trie/src/initialize.rs
@@ -184,6 +184,14 @@ impl CompletionEstimatable for crate::db::StorageTrieKey {
     }
 }
 
+impl CompletionEstimatable for crate::db::HashedStorageKey {
+    /// Address dominates ordering, so progress along the hashed-storage scan
+    /// tracks the hashed address.
+    fn estimate_progress(&self) -> f64 {
+        self.hashed_address.estimate_progress()
+    }
+}
+
 impl<Tx: DbTx + Sync, S: OpProofsStore + Send> InitializationJob<Tx, S> {
     /// Initialize a table from a source iterator to a storage function. Handles batching and
     /// logging.

--- a/rust/op-reth/crates/trie/src/lib.rs
+++ b/rust/op-reth/crates/trie/src/lib.rs
@@ -68,7 +68,8 @@ pub use cursor::{OpProofsHashedAccountCursor, OpProofsHashedStorageCursor, OpPro
 
 pub mod cursor_factory;
 pub use cursor_factory::{
-    OpProofsHashedAccountCursorFactory, OpProofsTrieCursorFactory, SnapshotTrieCursorFactory,
+    OpProofsHashedAccountCursorFactory, OpProofsTrieCursorFactory, SnapshotHashedCursorFactory,
+    SnapshotTrieCursorFactory,
 };
 
 pub mod error;

--- a/rust/op-reth/crates/trie/src/snapshot/job.rs
+++ b/rust/op-reth/crates/trie/src/snapshot/job.rs
@@ -2,14 +2,15 @@
 
 use super::SnapshotError;
 use crate::{
-    OpProofsHashedAccountCursorFactory, OpProofsProviderRO, OpProofsSnapshotInitProvider,
-    SnapshotInitAnchor, SnapshotInitStatus, SnapshotTrieCursorFactory, db::StorageTrieKey,
+    OpProofsProviderRO, OpProofsSnapshotInitProvider, SnapshotHashedCursorFactory,
+    SnapshotInitAnchor, SnapshotInitStatus, SnapshotTrieCursorFactory,
+    db::{HashedStorageKey, StorageTrieKey},
     initialize::CompletionEstimatable,
 };
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{B256, BlockNumber};
+use alloy_primitives::{B256, BlockNumber, U256};
 use derive_more::Constructor;
-use reth_primitives_traits::AlloyBlockHeader;
+use reth_primitives_traits::{Account, AlloyBlockHeader};
 use reth_provider::{BlockHashReader, HeaderProvider, ProviderError};
 use reth_trie::{
     BranchNodeCompact, HashedPostState, Nibbles, StateRoot, StoredNibbles,
@@ -27,6 +28,11 @@ const SNAPSHOT_INIT_CHUNK_SIZE: usize = 50_000;
 /// [`OpProofsSnapshotInitProvider::store_storage_trie_snapshot_branches`].
 type StorageChunk = Vec<(B256, Vec<(Nibbles, Option<BranchNodeCompact>)>)>;
 
+/// Hashed-storage chunk grouped by hashed address. Each inner vec is the
+/// per-address payload accepted by
+/// [`OpProofsSnapshotInitProvider::store_hashed_storages_snapshot`].
+type HashedStorageChunk = Vec<(B256, Vec<(B256, U256)>)>;
+
 /// Output of a successful [`SnapshotInitJob::run`] call.
 ///
 /// Shape mirrors [`crate::api::SnapshotInitAnchor`]: the anchor `block` plus
@@ -43,6 +49,10 @@ pub struct SnapshotInitOutcome {
     pub account_nodes_copied: u64,
     /// Number of storage trie nodes copied during this run.
     pub storage_nodes_copied: u64,
+    /// Number of hashed account leaves copied during this run.
+    pub hashed_accounts_copied: u64,
+    /// Number of hashed storage leaves copied during this run.
+    pub hashed_storages_copied: u64,
 }
 
 /// Builds the one-time trie-state snapshot.
@@ -82,6 +92,10 @@ where
             self.drain_account_trie(target_block, init_anchor.last_account_trie_key)?;
         let storage_nodes_copied =
             self.drain_storage_trie(target_block, init_anchor.last_storage_trie_key)?;
+        let hashed_accounts_copied =
+            self.drain_hashed_accounts(target_block, init_anchor.last_hashed_account_key)?;
+        let hashed_storages_copied =
+            self.drain_hashed_storages(target_block, init_anchor.last_hashed_storage_key)?;
         let copy_elapsed = copy_start.elapsed();
 
         let validate_start = Instant::now();
@@ -95,6 +109,8 @@ where
             block = target_block,
             account_nodes_copied,
             storage_nodes_copied,
+            hashed_accounts_copied,
+            hashed_storages_copied,
             copy_elapsed = ?copy_elapsed,
             validate_elapsed = ?validate_elapsed,
             total_elapsed = ?start.elapsed(),
@@ -106,6 +122,8 @@ where
             status: SnapshotInitStatus::Completed,
             account_nodes_copied,
             storage_nodes_copied,
+            hashed_accounts_copied,
+            hashed_storages_copied,
         })
     }
 
@@ -274,6 +292,92 @@ where
         Ok(copied)
     }
 
+    /// Drain the history-aware hashed-account cursor at `target_block` into
+    /// [`crate::db::V2HashedAccountsSnapshot`], one chunk per rw-tx.
+    fn drain_hashed_accounts(
+        &self,
+        target_block: BlockNumber,
+        mut resume_after: Option<B256>,
+    ) -> Result<u64, SnapshotError> {
+        let phase_start = Instant::now();
+        let mut initial_progress: Option<f64> = None;
+        let mut copied = 0u64;
+
+        loop {
+            let chunk = {
+                let ro = self.storage.provider_ro()?;
+                let mut cursor = ro.account_hashed_cursor(target_block)?;
+                collect_hashed_account_chunk(&mut cursor, resume_after, SNAPSHOT_INIT_CHUNK_SIZE)?
+            };
+            if chunk.is_empty() {
+                break;
+            }
+            let n = chunk.len() as u64;
+            let last_key = chunk.last().expect("non-empty").0;
+            let sp = self.storage.snapshot_initialization_provider()?;
+            sp.store_hashed_accounts_snapshot(chunk)?;
+            OpProofsSnapshotInitProvider::commit(sp)?;
+            copied += n;
+            log_phase_progress(
+                "hashed_accounts",
+                &last_key,
+                &mut initial_progress,
+                phase_start,
+                copied,
+            );
+            resume_after = Some(last_key);
+        }
+        Ok(copied)
+    }
+
+    /// Drain hashed storage leaves at `target_block` into
+    /// [`crate::db::V2HashedStoragesSnapshot`], one chunk per rw-tx. Walks
+    /// accounts via the history-aware account cursor; for each account, drains
+    /// its history-aware storage cursor.
+    fn drain_hashed_storages(
+        &self,
+        target_block: BlockNumber,
+        mut resume_after: Option<HashedStorageKey>,
+    ) -> Result<u64, SnapshotError> {
+        let phase_start = Instant::now();
+        let mut initial_progress: Option<f64> = None;
+        let mut copied = 0u64;
+
+        loop {
+            let chunk = {
+                let ro = self.storage.provider_ro()?;
+                collect_hashed_storage_chunk(
+                    &ro,
+                    target_block,
+                    resume_after.clone(),
+                    SNAPSHOT_INIT_CHUNK_SIZE,
+                )?
+            };
+            if chunk.is_empty() {
+                break;
+            }
+            let n: u64 = chunk.iter().map(|(_, entries)| entries.len() as u64).sum();
+            let (last_addr, last_group) = chunk.last().expect("non-empty");
+            let last_key =
+                HashedStorageKey::new(*last_addr, last_group.last().expect("non-empty group").0);
+            let sp = self.storage.snapshot_initialization_provider()?;
+            for (addr, entries) in chunk {
+                sp.store_hashed_storages_snapshot(addr, entries)?;
+            }
+            OpProofsSnapshotInitProvider::commit(sp)?;
+            copied += n;
+            log_phase_progress(
+                "hashed_storages",
+                &last_key,
+                &mut initial_progress,
+                phase_start,
+                copied,
+            );
+            resume_after = Some(last_key);
+        }
+        Ok(copied)
+    }
+
     /// Compute the state root from the snapshot tables and the live hashed
     /// leaves and compare against `expected_root`.
     ///
@@ -289,7 +393,7 @@ where
         let computed_root = StateRoot::new(
             SnapshotTrieCursorFactory::new(sp.clone()),
             HashedPostStateCursorFactory::new(
-                OpProofsHashedAccountCursorFactory::new(sp.clone(), target_block),
+                SnapshotHashedCursorFactory::new(sp.clone()),
                 &state_sorted,
             ),
         )
@@ -403,6 +507,100 @@ where
                 return Ok(out);
             }
             group.push((path, Some(node)));
+            total += 1;
+            next_stor = stor_cursor.next()?;
+        }
+        if !group.is_empty() {
+            out.push((addr, group));
+        }
+
+        next_account = acc_cursor.next()?;
+    }
+
+    Ok(out)
+}
+
+/// Drain up to `max_entries` rows from a [`HashedCursor<Value = Account>`]
+/// strictly after `resume_after`.
+fn collect_hashed_account_chunk<C>(
+    cursor: &mut C,
+    resume_after: Option<B256>,
+    max_entries: usize,
+) -> Result<Vec<(B256, Account)>, SnapshotError>
+where
+    C: HashedCursor<Value = Account>,
+{
+    if max_entries == 0 {
+        return Ok(Vec::new());
+    }
+    let mut next = match resume_after {
+        None => cursor.seek(B256::ZERO)?,
+        Some(after) => match cursor.seek(after)? {
+            Some((k, _)) if k == after => cursor.next()?,
+            other => other,
+        },
+    };
+    let mut out = Vec::with_capacity(max_entries);
+    while let Some((k, v)) = next {
+        if out.len() >= max_entries {
+            break;
+        }
+        out.push((k, v));
+        next = cursor.next()?;
+    }
+    Ok(out)
+}
+
+/// Collect a chunk of hashed-storage entries grouped by hashed address.
+///
+/// Mirrors [`collect_storage_chunk`] for leaves: walks hashed accounts at
+/// `target_block` and drains each account's storage cursor up to
+/// `max_entries` total entries. The returned vec carries the per-address
+/// payload accepted by
+/// [`OpProofsSnapshotInitProvider::store_hashed_storages_snapshot`].
+fn collect_hashed_storage_chunk<P>(
+    proofs_ro: &P,
+    target_block: BlockNumber,
+    resume_after: Option<HashedStorageKey>,
+    max_entries: usize,
+) -> Result<HashedStorageChunk, SnapshotError>
+where
+    P: OpProofsProviderRO,
+{
+    if max_entries == 0 {
+        return Ok(Vec::new());
+    }
+    let mut out: HashedStorageChunk = Vec::new();
+    let mut total = 0usize;
+
+    let (start_addr, mut subkey_resume) =
+        resume_after.map_or((B256::ZERO, None), |k| (k.hashed_address, Some(k.hashed_storage_key)));
+
+    let mut acc_cursor = proofs_ro.account_hashed_cursor(target_block)?;
+    let mut next_account = acc_cursor.seek(start_addr)?;
+
+    while let Some((addr, _account)) = next_account {
+        let mut stor_cursor = proofs_ro.storage_hashed_cursor(addr, target_block)?;
+
+        // Position past any pending subkey resume (only applies to the first
+        // account on this call).
+        let mut next_stor = match subkey_resume.take() {
+            None => stor_cursor.seek(B256::ZERO)?,
+            Some(p) => match stor_cursor.seek(p)? {
+                Some((k, _)) if k == p => stor_cursor.next()?,
+                other => other,
+            },
+        };
+
+        let mut group: Vec<(B256, U256)> = Vec::new();
+        while let Some((slot, value)) = next_stor {
+            if total >= max_entries {
+                if !group.is_empty() {
+                    out.push((addr, group));
+                }
+                return Ok(out);
+            }
+            group.push((slot, value));
             total += 1;
             next_stor = stor_cursor.next()?;
         }


### PR DESCRIPTION
**Description**

**Why**
Snapshot-accelerated backfill was still bottlenecked on hashed-leaf reads. The trie snapshot replaced the V2-trie merge walk, but `compute_block_backfill_diff` were still constructing `OpProofsHashedAccountCursorFactory` at `block_number`, which does the full `V2HashedAccounts + History + ChangeSets` merge at each block. With the trie diff dominated by leaf reads under `StateRoot::root_with_updates`, the per-block cost stayed high.

**What**
Extend the snapshot to cache hashed leaves alongside trie nodes, so the snapshot read path for backfill is fully history-merge-free.

**Tests**

- [x] backfill tests covers the change as well.
- [ ] op-mainnet test run in progress 

**Additional context**

NA

**Metadata**

NA