### PR TITLE
ci: harden docs-only fast path and produce ci-gate skip status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,15 @@ jobs:
             c-contracts_changed: "^(packages/contracts-bedrock|\\.circleci|\\.github|ops/check-changed)/|^(package\\.json|mise\\.toml)$"
             c-docs_changes_detected: "^docs/public-docs/"
             c-rust_changes_detected: "^(rust|op-e2e|\\.circleci)/"
+      # Safer "docs-only" detection: true iff EVERY changed file is under docs/public-docs/.
+      # Using an inclusion (all-match) check instead of an exclusion of known code categories
+      # makes the fast path safe-by-default — any path not enumerated by the patterns above
+      # still falls through to the full main workflow.
+      - run:
+          name: Detect docs-only changes (all-match)
+          command: .circleci/scripts/collect-params.sh detect_all
+          environment:
+            c-only_docs_changes: "^docs/public-docs/"
       # Decision tree: determines which workflows to enable based on trigger, branch, and params.
       #
       # Helpers (defined in workflow-helpers.sh):
@@ -229,7 +238,8 @@ jobs:
                 #    Docs-only changes skip main/release entirely.
                 # ---------------------------------------------------------
                 elif [[ "${BRANCH}" != "develop" && ! "${BRANCH}" =~ ^gh-readonly-queue/ ]]; then
-                  if is_true docs_changes_detected && ! is_true contracts_changed && ! is_true rust_changes_detected; then
+                  if is_true only_docs_changes; then
+                    run ci_gate_skip
                     run contracts_feature_tests_short
                     run rust_ci_gate_short
                     run rust_e2e_gate_skip

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -69,6 +69,9 @@ parameters:
   c-run_contracts_feature_tests_short:
     type: boolean
     default: false
+  c-run_ci_gate_skip:
+    type: boolean
+    default: false
 
 orbs:
   utils: ethereum-optimism/circleci-utils@1.0.27
@@ -3196,6 +3199,20 @@ workflows:
     when: << pipeline.parameters.c-run_contracts_feature_tests_short >>
     jobs:
       - required-contracts-ci:
+          always-succeed: true
+          context:
+            - circleci-api-token
+
+  # ============================================================================
+  # ci-gate (skip) — runs only on the docs-only fast path.
+  # Produces the ci-gate required status check with always-succeed so docs-only
+  # PRs (which skip the full `main` workflow) aren't blocked by a missing check.
+  # The real ci-gate still runs in `main` for every other path.
+  # ============================================================================
+  ci-gate-skip:
+    when: << pipeline.parameters.c-run_ci_gate_skip >>
+    jobs:
+      - ci-gate:
           always-succeed: true
           context:
             - circleci-api-token

--- a/.circleci/scripts/collect-params.sh
+++ b/.circleci/scripts/collect-params.sh
@@ -2,9 +2,10 @@
 # Collects pipeline parameters from the environment and writes them to a JSON file.
 #
 # Called once per type with a mode argument:
-#   collect-params.sh str    — emit all c-* env vars as JSON strings
-#   collect-params.sh bool   — emit all c-* env vars as JSON booleans (normalizes 0/1)
-#   collect-params.sh detect — treat c-* env var values as ERE patterns, match against git diff
+#   collect-params.sh str        — emit all c-* env vars as JSON strings
+#   collect-params.sh bool       — emit all c-* env vars as JSON booleans (normalizes 0/1)
+#   collect-params.sh detect     — treat c-* env var values as ERE patterns; true iff ANY changed file matches
+#   collect-params.sh detect_all — treat c-* env var values as ERE patterns; true iff EVERY changed file matches (and there is at least one)
 #
 # Each invocation appends to /tmp/pipeline-parameters.json.
 # Env vars whose name starts with c- are processed; all others are ignored.
@@ -38,7 +39,7 @@ case "${MODE}" in
     done < <(env | sort)
     ;;
 
-  detect)
+  detect|detect_all)
     CHANGED=$(git diff --name-only "origin/${BASE_REVISION}...HEAD" 2>/dev/null \
       || git diff --name-only HEAD~1 HEAD || true)
     echo "=== Changed files ==="
@@ -47,13 +48,25 @@ case "${MODE}" in
 
     while IFS='=' read -r key pattern; do
       [[ "${key}" == c-* ]] || continue
-      if [ -n "${CHANGED}" ] && echo "${CHANGED}" | grep -qE "${pattern}"; then
-        result=true
-      else
+      if [ -z "${CHANGED}" ]; then
         result=false
+      elif [[ "${MODE}" == "detect_all" ]]; then
+        # True iff every changed file matches the pattern (i.e., no file fails to match).
+        if echo "${CHANGED}" | grep -qvE "${pattern}"; then
+          result=false
+        else
+          result=true
+        fi
+      else
+        # detect: true iff at least one changed file matches the pattern.
+        if echo "${CHANGED}" | grep -qE "${pattern}"; then
+          result=true
+        else
+          result=false
+        fi
       fi
       json=$(echo "${json}" | jq --argjson v "${result}" '. + {"'"${key}"'": $v}')
-      echo "  [detect] ${key} = ${result}  (pattern: ${pattern})"
+      echo "  [${MODE}] ${key} = ${result}  (pattern: ${pattern})"
     done < <(env | sort)
     ;;
 

--- a/.circleci/scripts/test-decision-tree.sh
+++ b/.circleci/scripts/test-decision-tree.sh
@@ -109,19 +109,28 @@ run_scenario \
 run_scenario \
   "PR (feature branch), docs only" \
   "webhook" "feat/my-thing" "" "" \
-  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": true}' \
-  contracts_feature_tests_short rust_ci_gate_short rust_e2e_gate_skip
+  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": true, "c-only_docs_changes": true}' \
+  ci_gate_skip contracts_feature_tests_short rust_ci_gate_short rust_e2e_gate_skip
 
 run_scenario \
   "PR (feature branch), docs + rust changed" \
   "webhook" "feat/my-thing" "" "" \
-  '{"c-rust_changes_detected": true, "c-contracts_changed": false, "c-docs_changes_detected": true}' \
+  '{"c-rust_changes_detected": true, "c-contracts_changed": false, "c-docs_changes_detected": true, "c-only_docs_changes": false}' \
   main release contracts_feature_tests_short rust_ci rust_e2e_ci
+
+# Footgun guard: a docs PR that also touches code outside the detection regexes
+# (e.g., op-node/, op-batcher/, any new top-level dir) MUST run main. Without
+# the all-match check, this scenario previously hit the docs-only fast path.
+run_scenario \
+  "PR (feature branch), docs + undetected code (footgun guard)" \
+  "webhook" "feat/my-thing" "" "" \
+  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": true, "c-only_docs_changes": false}' \
+  main release contracts_feature_tests_short rust_ci_gate_short rust_e2e_gate_skip
 
 run_scenario \
   "PR (feature branch), nothing changed" \
   "webhook" "feat/my-thing" "" "" \
-  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": false}' \
+  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": false, "c-only_docs_changes": false}' \
   main release contracts_feature_tests_short rust_ci_gate_short rust_e2e_gate_skip
 
 run_scenario \


### PR DESCRIPTION
## Summary

Two related fixes for the docs-only fast path in the CircleCI decision tree:

1. **Close a footgun** in path detection. The current docs-only condition is an *exclusion* across known code categories (`docs && !contracts && !rust`). The regexes for `contracts` and `rust` don't cover Go paths (`op-node/`, `op-batcher/`, `op-proposer/`, `cannon/`, `op-program/`, …), so a PR touching both `docs/public-docs/` and any Go file currently routes to the docs-only fast path and silently skips `go-tests-short`, `go-lint`, `shell-check`, `semgrep-scan-local`, and the `memory-all-*` acceptance tests.

   Replace with an *all-match* check: `c-only_docs_changes` is true iff **every** changed file is under `docs/public-docs/`. Any path not enumerated by the existing regexes — new top-level dirs, Go files, etc. — falls through to the full `main` workflow by default. Safe-by-default for anything that isn't explicitly docs.

2. **Produce the missing `ci-gate` required status check** on the docs-only path. The `enforce-ci-checks-develop` ruleset requires `ci/circleci: ci-gate`, but that job only lives in the `main` workflow. With docs-only PRs skipping `main`, the required check is missing and PRs are unmergeable (e.g. #20510). Add a new `ci-gate-skip` workflow that invokes the existing parameterized `ci-gate` job with `always-succeed: true` — mirroring the existing `*-feature-tests-short` / `*-gate-skip` skip-producer pattern that already exists for the other three required checks.

These two changes are coupled: fix 1 alone makes the "ci-gate missing" symptom worse (more PRs correctly route to `main`); fix 2 alone re-introduces the original concern that a code+docs PR could mark `ci-gate` SUCCESS via always-succeed without ever running Go tests. Together they decouple docs cleanly *and* safely.

## Test plan

- [x] `bash .circleci/scripts/test-decision-tree.sh` → 17 passed, 0 failed (includes a new "docs + undetected code (footgun guard)" scenario that asserts `main release contracts_feature_tests_short rust_ci_gate_short rust_e2e_gate_skip` for the docs+Go case)
- [x] Smoke test the new `detect_all` mode on synthetic diffs:
  - docs-only diff (one file under `docs/public-docs/`) → `c-only_docs_changes = true` ✓
  - docs + `op-node/foo.go` diff → `c-only_docs_changes = false` ✓
- [ ] After merge: open a docs-only PR, confirm `ci/circleci: ci-gate` reports SUCCESS via `ci-gate-skip` and the PR is mergeable
- [ ] After merge: open a docs + Go file PR, confirm full `main` workflow runs (go-tests-short, go-lint, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)