### PR TITLE
docs: add --proofs-history.storage-version=v2 to op-reth examples

### DIFF
--- a/docs/public-docs/node-operators/reference/op-reth-historical-proof-config.mdx
+++ b/docs/public-docs/node-operators/reference/op-reth-historical-proof-config.mdx
@@ -110,7 +110,7 @@ The `op-reth proofs` command provides these maintenance operations.
 Initialize the proofs storage with the current state of the chain.
 
 ```bash
-op-reth proofs init --chain <CHAIN> --datadir <DATA_DIR> --proofs-history.storage-path <PROOFS_HISTORY_STORAGE_PATH>
+op-reth proofs init --chain <CHAIN> --datadir <DATA_DIR> --proofs-history.storage-path <PROOFS_HISTORY_STORAGE_PATH> --proofs-history.storage-version=v2
 ```
 
 <Info>

--- a/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
+++ b/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
@@ -92,7 +92,8 @@ Initialize the separate storage used by the historical proof store to persist hi
 ./target/release/op-reth proofs init \
   --datadir="/path/to/datadir" \
   --chain="optimism" \
-  --proofs-history.storage-path="/path/to/proofs-db"
+  --proofs-history.storage-path="/path/to/proofs-db" \
+  --proofs-history.storage-version=v2
 ```
 
 <Info>
@@ -109,6 +110,7 @@ Once initialized, you can start the execution client with the `--proofs-history`
   --chain="optimism" \
   --proofs-history \
   --proofs-history.storage-path="/path/to/proofs-db" \
+  --proofs-history.storage-version=v2 \
   --http \
   --http.port=8545 \
   --http.addr=0.0.0.0 \


### PR DESCRIPTION
Without the flag, init silently defaults to v1; a v2-configured node then panics on startup with "Proofs storage not initialized". Reported by @donoso-eth in #20846 after reproducing with a customer.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
