### PR TITLE
perf(ci): make rust skip jobs trivial

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1178,38 +1178,14 @@ workflows:
   # =====================================
 
   # ==========================================================================
-  # Required Rust CI gate (skip) — runs when no rust changes and no dispatch
-  # Just runs the rust cargo tests for the different packages in the repo and try to build the fpvm-prestates
+  # Required Rust CI gate (skip) — runs when no rust changes and no dispatch.
+  # This path must complete quickly (e.g., docs-only PRs), so it should avoid
+  # expensive Rust build/test work while still satisfying required check names.
   # ==========================================================================
   rust-ci-gate-short:
     when: << pipeline.parameters.c-run_rust_ci_gate_short >>
     jobs:
-      - rust-ci-cargo-tests:
-          name: rust-tests
-          directory: rust
-          context: *rust-ci-context
-
-      - rust-ci-cargo-tests:
-          name: op-reth-integration-tests
-          directory: rust
-          command: "--justfile op-reth/justfile test-integration"
-          cache_profile: debug
-          context: *rust-ci-context
-
-      - kona-build-fpvm:
-          name: kona-build-fpvm-cannon-client
-          target: "cannon-client"
-          context: *rust-ci-context
-
-      - kona-registry-snapshot-check:
-          context: *rust-ci-context
-
       - required-rust-ci:
-          requires:
-            - rust-tests: terminal
-            - op-reth-integration-tests: terminal
-            - kona-build-fpvm-cannon-client: terminal
-            - kona-registry-snapshot-check: terminal
           context:
             - circleci-api-token
 

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -290,29 +290,6 @@ workflows:
   rust-e2e-gate-skip:
     when: << pipeline.parameters.c-run_rust_e2e_gate_skip >>
     jobs:
-      - contracts-bedrock-build:
-          build_args: --skip test
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-      - rust-build-binary:
-          name: rust-workspace-release
-          directory: rust
-          profile: release
-          persist_to_workspace: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-      # Proof tests - single kind only, interop excluded per original config
-      - kona-proof-action-tests:
-          name: kona-proof-action-single
-          kind: single
-          requires:
-            - rust-workspace-release
-            - contracts-bedrock-build
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-
       - required-rust-e2e:
-          requires:
-            - kona-proof-action-single: terminal
           context:
             - circleci-api-token


### PR DESCRIPTION


For docs-only / no-rust-change PRs, both Rust fast paths now complete essentially immediately:

- `rust-ci-gate-short` → only `required-rust-ci`
- `rust-e2e-gate-skip` → only `required-rust-e2e`

This keeps required check signaling intact while removing expensive work from the skip routes.