### PR TITLE
test(acceptance): raise short context timeouts

### DIFF
--- a/op-acceptance-tests/tests/custom_gas_token/cgt_l1_portal_introspection_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_l1_portal_introspection_test.go
@@ -3,7 +3,6 @@ package custom_gas_token
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 
@@ -25,7 +24,7 @@ func TestCGT_L1PortalIntrospection(gt *testing.T) {
 	l1c := sys.L1EL.EthClient()
 	portal := sys.L2Chain.DepositContractAddr()
 
-	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(t.Ctx(), cgtCallTimeout)
 	defer cancel()
 
 	// Portal exposes systemConfig() -> address

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_portal_reverts_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_portal_reverts_test.go
@@ -3,7 +3,6 @@ package custom_gas_token
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum/go-ethereum"
@@ -21,7 +20,7 @@ func TestCGT_PortalReceiveReverts(gt *testing.T) {
 	portal := sys.L2Chain.DepositContractAddr()
 
 	// Try to send 1 wei to the Portal (receive() -> depositTransaction); should revert in CGT mode.
-	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(t.Ctx(), cgtCallTimeout)
 	defer cancel()
 	_, err := l1c.EstimateGas(ctx, ethereum.CallMsg{
 		To:    &portal,

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_systemconfig_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_systemconfig_test.go
@@ -3,7 +3,6 @@ package custom_gas_token
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 
@@ -26,7 +25,7 @@ func TestCGT_SystemConfigFlagOnL1(gt *testing.T) {
 	systemConfigFunc := w3.MustNewFunc("systemConfig()", "address")
 	isCustomGasTokenFunc := w3.MustNewFunc("isCustomGasToken()", "bool")
 
-	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(t.Ctx(), cgtCallTimeout)
 	defer cancel()
 
 	// Resolve SystemConfig via Portal.systemConfig()
@@ -70,7 +69,7 @@ func TestCGT_SystemConfigFeatureFlag(gt *testing.T) {
 	l1c := sys.L1EL.EthClient()
 	portal := sys.L2Chain.DepositContractAddr()
 
-	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(t.Ctx(), cgtCallTimeout)
 	defer cancel()
 
 	// Resolve SystemConfig via Portal.systemConfig()

--- a/op-acceptance-tests/tests/custom_gas_token/helpers.go
+++ b/op-acceptance-tests/tests/custom_gas_token/helpers.go
@@ -25,6 +25,8 @@ var (
 	l2BridgeAddr = common.HexToAddress("0x4200000000000000000000000000000000000010")
 )
 
+const cgtCallTimeout = 30 * time.Second
+
 func cgtOpts() []presets.Option {
 	// Create a CGT-enabled devnet with 1M tokens of liquidity.
 	liq := new(big.Int).Mul(big.NewInt(1_000_000), big.NewInt(1e18))
@@ -45,7 +47,7 @@ func isCGTEnabled(t devtest.T, sys *presets.Minimal) bool {
 	l2 := sys.L2EL.Escape().L2EthClient()
 	isCustomGasTokenFunc := w3.MustNewFunc("isCustomGasToken()", "bool")
 
-	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(t.Ctx(), cgtCallTimeout)
 	defer cancel()
 
 	data, _ := isCustomGasTokenFunc.EncodeArgs()
@@ -69,7 +71,7 @@ func getCGTMetadata(t devtest.T, sys *presets.Minimal) (string, string) {
 	gasPayingTokenNameFunc := w3.MustNewFunc("gasPayingTokenName()", "string")
 	gasPayingTokenSymbolFunc := w3.MustNewFunc("gasPayingTokenSymbol()", "string")
 
-	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(t.Ctx(), cgtCallTimeout)
 	defer cancel()
 
 	// Read name

--- a/op-acceptance-tests/tests/interop/filter/interop_filter_test.go
+++ b/op-acceptance-tests/tests/interop/filter/interop_filter_test.go
@@ -67,7 +67,7 @@ func TestInteropFilter_IngressRejectsInvalid(gt *testing.T) {
 	// Send a transaction with the fabricated access list.
 	// The interop filter should reject this because the inbox entry doesn't
 	// correspond to any real cross-chain message.
-	ctx, cancel := context.WithTimeout(gt.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(gt.Context(), 30*time.Second)
 	defer cancel()
 
 	bobAddr := bob.Address()
@@ -135,7 +135,7 @@ func TestInteropFilter_FailsafeLifecycle(gt *testing.T) {
 	initMsg2 := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, 1, 5))
 	sys.L2B.WaitForBlock()
 
-	ctx, cancel := context.WithTimeout(gt.Context(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(gt.Context(), 30*time.Second)
 	defer cancel()
 
 	// During failsafe, even valid access lists should be rejected

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -267,7 +267,7 @@ func marshalTransition(superRoot eth.SuperV1, step uint64, progress ...interopTy
 // in-progress L1 block.
 func awaitFullyProcessedL1(t devtest.T, queryAPI apis.SupernodeQueryAPI, targetL1 uint64) {
 	t.Require().Eventually(func() bool {
-		ctx, cancel := context.WithTimeout(t.Ctx(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Ctx(), dsl.DefaultTimeout)
 		defer cancel()
 		resp, err := queryAPI.SuperRootAtTimestamp(ctx, uint64(time.Now().Unix()))
 		if err != nil {


### PR DESCRIPTION
This cleanup raises the remaining sub-30s acceptance-test context timeouts that would be flagged by `flake-short-test-timeout` in #20784.

The custom gas token tests now share a 30s RPC call timeout, the interop filter tests use 30s contexts for rejection checks, and the super fault proofs helper uses the devstack default timeout while polling supernode state. No behavior is otherwise changed; this just removes brittle short per-call budgets before enabling the Semgrep rule.