### PR TITLE
test(loadtest): fix deferred cleanup order

### DIFF
--- a/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
@@ -99,9 +99,11 @@ func TestRelayWithInvalidMessagesSteady(gt *testing.T) {
 	validInitMsg := out.Entries[0]
 
 	ctxInvalid, cancelInvalid := context.WithCancel(t.Ctx())
-	defer cancelInvalid()
 	var wg sync.WaitGroup
-	defer wg.Wait()
+	defer func() {
+		cancelInvalid()
+		wg.Wait()
+	}()
 
 	// Spam a fixed number of invalid messages per block time.
 	wg.Add(1)

--- a/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
@@ -99,11 +99,8 @@ func TestRelayWithInvalidMessagesSteady(gt *testing.T) {
 	validInitMsg := out.Entries[0]
 
 	ctxInvalid, cancelInvalid := context.WithCancel(t.Ctx())
+	defer cancelInvalid()
 	var wg sync.WaitGroup
-	defer func() {
-		cancelInvalid()
-		wg.Wait()
-	}()
 
 	// Spam a fixed number of invalid messages per block time.
 	wg.Add(1)
@@ -127,4 +124,11 @@ func TestRelayWithInvalidMessagesSteady(gt *testing.T) {
 		s := NewSteady(l2B.EL.Escape().EthClient(), l2B.Config.ElasticityMultiplier(), l2B.BlockTime, WithAIMDObserver(observer))
 		s.Run(t, NewRelaySpammer(l2A, l2B))
 	}()
+
+	// Block until the goroutines exit (when t.Ctx() expires after the setupLoadTest
+	// timeout). Using an explicit Wait — rather than defer wg.Wait() — keeps the
+	// goroutines' ctxInvalid alive for the full test duration. A deferred closure
+	// that cancels ctxInvalid before waiting would race with the goroutine's
+	// startup, since the test body returns immediately after spawning them.
+	wg.Wait()
 }

--- a/op-acceptance-tests/tests/interop/loadtest/schedule.go
+++ b/op-acceptance-tests/tests/interop/loadtest/schedule.go
@@ -200,13 +200,15 @@ func NewBurst(blockTime time.Duration, opts ...AIMDOption) *Burst {
 // encountered.
 func (b *Burst) Run(t devtest.T, spammer Spammer) {
 	ctx, cancel := context.WithCancel(t.Ctx())
-	defer cancel()
 	t = t.WithCtx(ctx)
 
 	aimd := setupAIMD(t, b.blockTime, b.opts...)
 
 	var wg sync.WaitGroup
-	defer wg.Wait()
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
 	for range aimd.Ready() {
 		wg.Add(1)
 		go func() {


### PR DESCRIPTION
This cleanup fixes the two defer-order patterns that would be flagged by flake-defer-cancel-before-wait in #20784.

Both loadtest sites now use a single deferred cleanup closure that cancels the context before waiting on the worker group. That preserves the intended shutdown order explicitly and avoids cleanup deadlocks where wg.Wait() runs before cancellation.