### PR TITLE
chore(interop): Rename supervisor wording to interop in more places

### DIFF
--- a/docs/public-docs/node-operators/reference/op-reth-config.mdx
+++ b/docs/public-docs/node-operators/reference/op-reth-config.mdx
@@ -2038,21 +2038,20 @@ Enable transaction conditional support on sequencer.
   <Tab title="Syntax">`--rollup.enable-tx-conditional`</Tab>
 </Tabs>
 
-### rollup.supervisor-http
+### rollup.interop-http
 
-HTTP endpoint for the supervisor.
+HTTP endpoint for the interop filter, used to validate the interop messages referenced by incoming transactions. When not set, interop transaction validation is disabled: a node that builds blocks will then include transactions carrying invalid interop messages, producing invalid blocks. It is only safe to leave this unset on nodes that do not build blocks.
 
 <Tabs>
-  <Tab title="Syntax">`--rollup.supervisor-http <SUPERVISOR_HTTP_URL>`</Tab>
-  <Tab title="Default">`http://localhost:1337/`</Tab>
+  <Tab title="Syntax">`--rollup.interop-http <INTEROP_HTTP_URL>`</Tab>
 </Tabs>
 
-### rollup.supervisor-safety-level
+### rollup.interop-safety-level
 
-Safety level for the supervisor.
+Safety level for interop filter validation.
 
 <Tabs>
-  <Tab title="Syntax">`--rollup.supervisor-safety-level <SUPERVISOR_SAFETY_LEVEL>`</Tab>
+  <Tab title="Syntax">`--rollup.interop-safety-level <INTEROP_SAFETY_LEVEL>`</Tab>
   <Tab title="Default">`CrossUnsafe`</Tab>
 </Tabs>
 

--- a/docs/public-docs/rust/op-reth/cli/op-reth/node.mdx
+++ b/docs/public-docs/rust/op-reth/cli/op-reth/node.mdx
@@ -1101,13 +1101,11 @@ Rollup:
       --rollup.enable-tx-conditional
           Enable transaction conditional support on sequencer
 
-      --rollup.supervisor-http <SUPERVISOR_HTTP_URL>
-          HTTP endpoint for the supervisor
+      --rollup.interop-http <INTEROP_HTTP_URL>
+          HTTP endpoint for the interop filter, used to validate the interop messages referenced by incoming transactions. When not set, interop transaction validation is disabled: a node that builds blocks will then include transactions carrying invalid interop messages, producing invalid blocks. It is only safe to leave this unset on nodes that do not build blocks.
 
-          [default: http://localhost:1337/]
-
-      --rollup.supervisor-safety-level <SUPERVISOR_SAFETY_LEVEL>
-          Safety level for the supervisor
+      --rollup.interop-safety-level <INTEROP_SAFETY_LEVEL>
+          Safety level for interop filter validation
 
           [default: CrossUnsafe]
 

--- a/docs/public-docs/rust/op-reth/run/opstack.mdx
+++ b/docs/public-docs/rust/op-reth/run/opstack.mdx
@@ -65,8 +65,8 @@ op-reth supports additional OP Stack specific CLI arguments:
 1. `--rollup.discovery.v4` - Enables the discovery v4 protocol for peer discovery. By default, op-reth, similar to op-geth, has discovery v5 enabled and discovery v4 disabled, whereas regular reth has discovery v4 enabled and discovery v5 disabled.
 1. `--rollup.compute-pending-block` - Enables computing of the pending block from the tx-pool instead of using the latest block. By default the pending block equals the latest block to save resources and not leak txs from the tx-pool.
 1. `--rollup.enable-tx-conditional` - Enable transaction conditional support on sequencer.
-1. `--rollup.supervisor-http <url>` - HTTP endpoint for the interop supervisor.
-1. `--rollup.supervisor-safety-level <level>` - Safety level for the supervisor (default: `CrossUnsafe`).
+1. `--rollup.interop-http <url>` - HTTP endpoint for the interop filter.
+1. `--rollup.interop-safety-level <level>` - Safety level for interop filter validation (default: `CrossUnsafe`).
 1. `--rollup.sequencer-headers <headers>` - Optional headers to use when connecting to the sequencer. Requires `--rollup.sequencer`.
 1. `--rollup.historicalrpc <url>` - RPC endpoint for historical data. Alias: `--rollup.historical-rpc`.
 1. `--min-suggested-priority-fee <wei>` - Minimum suggested priority fee (tip) in wei (default: `1000000`).

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -65,14 +65,14 @@ func OpRethWithSDMEnabled() OpRethOption {
 	return OpRethWithExtraArgs("--rollup.sdm-enabled")
 }
 
-// OpRethWithSupervisorURL wires the op-reth node to the given supervisor HTTP endpoint.
-// An empty supervisorURL is a no-op so callers can pass the value unconditionally.
-func OpRethWithSupervisorURL(supervisorURL string) OpRethOption {
+// OpRethWithInteropURL wires the op-reth node to the given interop filter HTTP endpoint.
+// An empty interopURL is a no-op so callers can pass the value unconditionally.
+func OpRethWithInteropURL(interopURL string) OpRethOption {
 	return OpRethOptionFn(func(p devtest.T, _ ComponentTarget, cfg *OpRethConfig) {
-		if supervisorURL == "" {
+		if interopURL == "" {
 			return
 		}
-		cfg.ExtraArgs = append(cfg.ExtraArgs, "--rollup.supervisor-http="+supervisorURL)
+		cfg.ExtraArgs = append(cfg.ExtraArgs, "--rollup.interop-http="+interopURL)
 	})
 }
 

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -412,23 +412,23 @@ func startMixedOpRethNode(
 	return node
 }
 
-// startMixedOpRethNodeWithSupervisorURL builds and starts an OpReth node
-// with --rollup.supervisor-http pointing at the given URL.
-func startMixedOpRethNodeWithSupervisorURL(
+// startMixedOpRethNodeWithInteropURL builds and starts an OpReth node
+// with --rollup.interop-http pointing at the given URL.
+func startMixedOpRethNodeWithInteropURL(
 	t devtest.T,
 	l2Net *L2Network,
 	key string,
 	jwtPath string,
 	jwtSecret [32]byte,
 	metricsRegistrar L2MetricsRegistrar,
-	supervisorURL string,
+	interopURL string,
 	storageVersion string,
 	opts ...OpRethOption,
 ) *OpReth {
-	opts = append(opts, OpRethWithSupervisorURL(supervisorURL))
+	opts = append(opts, OpRethWithInteropURL(interopURL))
 	node := buildMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, metricsRegistrar, storageVersion, opts...)
-	t.Logger().Info("Starting op-reth with supervisor URL",
-		"name", key, "chain", l2Net.ChainID(), "supervisorURL", supervisorURL)
+	t.Logger().Info("Starting op-reth with interop filter URL",
+		"name", key, "chain", l2Net.ChainID(), "interopURL", interopURL)
 	node.Start()
 	t.Cleanup(node.Stop)
 	t.Logger().Info("op-reth is ready", "name", key, "chain", l2Net.ChainID(), "userRPC", node.userRPC, "authRPC", node.authRPC)

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -122,16 +122,16 @@ func startSupernodeEL(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [
 	return startL2ELForKey(t, l2Net, jwtPath, jwtSecret, "sequencer", NewELNodeIdentity(0))
 }
 
-// startSupernodeELWithSupervisorURL starts an L2 EL node with --rollup.supervisor-http
+// startSupernodeELWithInteropURL starts an L2 EL node with --rollup.interop-http
 // pointing at the given URL. Used by supernode interop presets to connect ELs
 // to the interop filter for tx pool validation.
-func startSupernodeELWithSupervisorURL(
+func startSupernodeELWithInteropURL(
 	t devtest.T,
 	l2Net *L2Network,
 	key string,
 	jwtPath string,
 	jwtSecret [32]byte,
-	supervisorURL string,
+	interopURL string,
 ) L2ELNode {
 	switch devstackL2ELKind() {
 	case MixedL2ELOpGeth:
@@ -143,15 +143,15 @@ func startSupernodeELWithSupervisorURL(
 			l2Net:         l2Net,
 			jwtPath:       jwtPath,
 			jwtSecret:     jwtSecret,
-			supervisorRPC: supervisorURL,
+			supervisorRPC: interopURL,
 			cfg:           cfg,
 		}
 		l2EL.Start()
 		t.Cleanup(l2EL.Stop)
 		return l2EL
 	default: // op-reth
-		return startMixedOpRethNodeWithSupervisorURL(
-			t, l2Net, key, jwtPath, jwtSecret, nil, supervisorURL, "v1")
+		return startMixedOpRethNodeWithInteropURL(
+			t, l2Net, key, jwtPath, jwtSecret, nil, interopURL, "v1")
 	}
 }
 
@@ -257,8 +257,8 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 		filterRPC := "http://" + filterProxy.Addr()
 
 		// Start ELs with filter proxy URL
-		l2AEL = startSupernodeELWithSupervisorURL(t, l2ANet, "sequencer", jwtPath, jwtSecret, filterRPC)
-		l2BEL = startSupernodeELWithSupervisorURL(t, l2BNet, "sequencer", jwtPath, jwtSecret, filterRPC)
+		l2AEL = startSupernodeELWithInteropURL(t, l2ANet, "sequencer", jwtPath, jwtSecret, filterRPC)
+		l2BEL = startSupernodeELWithInteropURL(t, l2BNet, "sequencer", jwtPath, jwtSecret, filterRPC)
 
 		// Build rollup config map from L2 networks (Go structs, no file I/O)
 		rollupConfigs := map[eth.ChainID]*rollup.Config{
@@ -274,7 +274,7 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 		// Connect proxy to the filter's actual RPC endpoint
 		filterProxy.SetUpstream(ProxyAddr(require, interopFilter.HTTPEndpoint()))
 	} else {
-		// No interop filter — ELs start without supervisor/filter URL (existing behavior)
+		// No interop filter — ELs start without an interop filter URL (existing behavior)
 		l2AEL = startSupernodeEL(t, l2ANet, jwtPath, jwtSecret)
 		l2BEL = startSupernodeEL(t, l2BNet, jwtPath, jwtSecret)
 	}

--- a/op-interop-filter/filter/config.go
+++ b/op-interop-filter/filter/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 )
 
-// DefaultMessageExpiryWindow is 7 days, matching op-supervisor's default
+// DefaultMessageExpiryWindow is 7 days, matching the interop message expiry default.
 const DefaultMessageExpiryWindow = 7 * 24 * time.Hour
 
 type Config struct {

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -14,7 +14,7 @@ import (
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
-// QueryFrontend handles supervisor query RPC methods
+// QueryFrontend handles interop query RPC methods.
 type QueryFrontend struct {
 	backend *Backend
 }

--- a/op-interop-filter/filter/interfaces.go
+++ b/op-interop-filter/filter/interfaces.go
@@ -11,7 +11,7 @@ import (
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
-// LogsDB is the subset of an op-supervisor logs DB that
+// LogsDB is the subset of an interop logs DB that
 // LogsDBChainIngester depends on. Capturing it as an interface lets tests
 // substitute a fake when exercising dispatch paths the real DB cannot
 // produce under correct ingester control flow.

--- a/op-interop-filter/filter/jwt_auth_test.go
+++ b/op-interop-filter/filter/jwt_auth_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// testSupervisorAPI is a mock supervisor API for testing
-type testSupervisorAPI struct{}
+// testInteropAPI is a mock interop API for testing.
+type testInteropAPI struct{}
 
-func (t *testSupervisorAPI) Ping(_ context.Context) string {
+func (t *testInteropAPI) Ping(_ context.Context) string {
 	return "pong"
 }
 
@@ -50,7 +50,7 @@ func TestDedicatedAdminRPCServer(t *testing.T) {
 	)
 	filterServer.AddAPI(rpc.API{
 		Namespace: "interop",
-		Service:   new(testSupervisorAPI),
+		Service:   new(testInteropAPI),
 	})
 
 	// Create admin server (JWT-protected)
@@ -133,7 +133,7 @@ func TestPublicAdminGetFailsafe(t *testing.T) {
 	)
 	filterServer.AddAPI(rpc.API{
 		Namespace: "interop",
-		Service:   new(testSupervisorAPI),
+		Service:   new(testInteropAPI),
 	})
 	filterServer.AddAPI(rpc.API{
 		Namespace: "admin",
@@ -157,7 +157,7 @@ func TestPublicAdminGetFailsafe(t *testing.T) {
 		require.Equal(t, false, res)
 	})
 
-	t.Run("supervisor API still works alongside public admin", func(t *testing.T) {
+	t.Run("interop API still works alongside public admin", func(t *testing.T) {
 		var res string
 		err := filterClient.Call(&res, "interop_ping")
 		require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestFilterAPIWithoutAdminServer(t *testing.T) {
 	)
 	filterServer.AddAPI(rpc.API{
 		Namespace: "interop",
-		Service:   new(testSupervisorAPI),
+		Service:   new(testInteropAPI),
 	})
 
 	require.NoError(t, filterServer.Start())

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -34,7 +34,7 @@ type Service struct {
 
 	pprofService   *oppprof.Service
 	metricsSrv     *httputil.HTTPServer
-	rpcServer      *oprpc.Server // Main RPC server (public supervisor API)
+	rpcServer      *oprpc.Server // Main RPC server (public interop API)
 	adminRPCServer *oprpc.Server // Admin RPC server (JWT-protected, separate port)
 
 	backend *Backend
@@ -239,7 +239,7 @@ func (s *Service) initBackend(ctx context.Context, cfg *Config) error {
 }
 
 func (s *Service) initRPCServer(cfg *Config) error {
-	// Create server without JWT - public supervisor API
+	// Create server without JWT - public interop API
 	server := oprpc.NewServer(
 		cfg.RPCAddr,
 		cfg.RPCPort,
@@ -306,7 +306,7 @@ func (s *Service) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start backend: %w", err)
 	}
 
-	// Start main RPC server (supervisor API)
+	// Start main RPC server (interop API)
 	if err := s.rpcServer.Start(); err != nil {
 		// Rollback: stop backend if RPC server fails to start
 		stopErr := s.backend.Stop(ctx)

--- a/op-interop-filter/flags/flags.go
+++ b/op-interop-filter/flags/flags.go
@@ -56,7 +56,7 @@ var (
 		Name:    "message-expiry-window",
 		Usage:   "Message expiry window duration (e.g., 168h for 7 days). Messages older than this are considered expired.",
 		EnvVars: prefixEnvVars("MESSAGE_EXPIRY_WINDOW"),
-		Value:   168 * time.Hour, // 7 days default, matching op-supervisor
+		Value:   168 * time.Hour, // 7 days default for interop message expiry
 	}
 	JWTSecretFlag = &cli.StringFlag{
 		Name: "admin.jwt-secret",

--- a/rust/kona/crates/protocol/interop/src/message.rs
+++ b/rust/kona/crates/protocol/interop/src/message.rs
@@ -27,9 +27,7 @@ sol! {
     /// @param payloadHash Hash of message payload being executed.
     /// @param identifier Encoded Identifier of the message.
     ///
-    /// Parameter names are derived from the `op-supervisor` JSON field names.
-    /// See the relevant definition in the Optimism repository:
-    /// [Ethereum-Optimism/op-supervisor](https://github.com/ethereum-optimism/optimism/blob/4ba2eb00eafc3d7de2c8ceb6fd83913a8c0a2c0d/op-supervisor/supervisor/types/types.go#L61-L64).
+    /// Parameter names match the interop RPC JSON field names.
     #[derive(Default, Debug, PartialEq, Eq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     event ExecutingMessage(bytes32 indexed payloadHash, MessageIdentifier identifier);
@@ -72,8 +70,8 @@ impl From<executeMessageCall> for ExecutingMessage {
     }
 }
 
-/// An [`ExecutingDescriptor`] is a part of the payload to `supervisor_checkAccessList`
-/// Spec: <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#executingdescriptor>
+/// An [`ExecutingDescriptor`] is a part of the payload to `interop_checkAccessList`
+/// Interop RPC request descriptor.
 #[derive(Default, Debug, PartialEq, Eq, Clone, Constructor)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExecutingDescriptor {

--- a/rust/op-rbuilder/crates/op-rbuilder/src/launcher.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/launcher.rs
@@ -139,9 +139,9 @@ where
                                 rollup_args.enable_tx_conditional
                                     || builder_args.enable_revert_protection,
                             )
-                            .with_supervisor(
-                                rollup_args.supervisor_http.clone(),
-                                rollup_args.supervisor_safety_level,
+                            .with_interop(
+                                rollup_args.interop_http.clone(),
+                                rollup_args.interop_safety_level,
                             ),
                     )
                     .payload(B::new_service(builder_config)?),

--- a/rust/op-rbuilder/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -368,9 +368,9 @@ fn pool_component(args: &OpRbuilderArgs) -> OpPoolBuilder<FBPooledTransaction> {
             // to garbage collect transactions out of the bundle range.
             rollup_args.enable_tx_conditional || args.enable_revert_protection,
         )
-        .with_supervisor(
-            rollup_args.supervisor_http.clone(),
-            rollup_args.supervisor_safety_level,
+        .with_interop(
+            rollup_args.interop_http.clone(),
+            rollup_args.interop_safety_level,
         )
 }
 

--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -55,16 +55,20 @@ pub struct RollupArgs {
     #[arg(long = "rollup.sdm-enabled", default_value = "false")]
     pub sdm_enabled: bool,
 
-    /// HTTP endpoint for the supervisor. When not set, interop transaction validation is disabled.
-    #[arg(long = "rollup.supervisor-http", value_name = "SUPERVISOR_HTTP_URL")]
-    pub supervisor_http: Option<String>,
+    /// HTTP endpoint for the interop filter, used to validate the interop messages referenced by
+    /// incoming transactions. When not set, interop transaction validation is disabled: a node
+    /// that builds blocks will then include transactions carrying invalid interop messages,
+    /// producing invalid blocks. It is only safe to leave this unset on nodes that do not build
+    /// blocks.
+    #[arg(long = "rollup.interop-http", value_name = "INTEROP_HTTP_URL")]
+    pub interop_http: Option<String>,
 
-    /// Safety level for the supervisor
+    /// Safety level for interop filter validation.
     #[arg(
-        long = "rollup.supervisor-safety-level",
+        long = "rollup.interop-safety-level",
         default_value_t = SafetyLevel::CrossUnsafe,
     )]
-    pub supervisor_safety_level: SafetyLevel,
+    pub interop_safety_level: SafetyLevel,
 
     /// Optional headers to use when connecting to the sequencer.
     #[arg(long = "rollup.sequencer-headers", requires = "sequencer")]
@@ -161,8 +165,8 @@ impl Default for RollupArgs {
             discovery_v4: false,
             enable_tx_conditional: false,
             sdm_enabled: false,
-            supervisor_http: None,
-            supervisor_safety_level: SafetyLevel::CrossUnsafe,
+            interop_http: None,
+            interop_safety_level: SafetyLevel::CrossUnsafe,
             sequencer_headers: Vec::new(),
             historical_rpc: None,
             min_suggested_priority_fee: 1_000_000,

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -52,7 +52,7 @@ use reth_optimism_rpc::{
     witness::{DebugExecutionWitnessApiServer, OpDebugWitnessApi},
 };
 use reth_optimism_storage::OpStorage;
-use reth_optimism_txpool::{OpPool, OpPooledTx, supervisor::SupervisorClient};
+use reth_optimism_txpool::{OpPool, OpPooledTx, interop_filter::InteropFilterClient};
 use reth_primitives_traits::header::HeaderMut;
 use reth_provider::{CanonStateSubscriptions, providers::ProviderFactoryBuilder};
 use reth_rpc_api::{
@@ -240,10 +240,7 @@ impl OpNode {
             .pool(
                 OpPoolBuilder::default()
                     .with_enable_tx_conditional(self.args.enable_tx_conditional)
-                    .with_supervisor(
-                        self.args.supervisor_http.clone(),
-                        self.args.supervisor_safety_level,
-                    ),
+                    .with_interop(self.args.interop_http.clone(), self.args.interop_safety_level),
             )
             .payload(BasicPayloadServiceBuilder::new(
                 OpPayloadBuilder::new(compute_pending_block)
@@ -1050,11 +1047,11 @@ pub struct OpPoolBuilder<T = crate::txpool::OpPooledTransaction> {
     pub pool_config_overrides: PoolBuilderConfigOverrides,
     /// Enable transaction conditionals.
     pub enable_tx_conditional: bool,
-    /// Supervisor client URL for txpool-level interop validation (deprecated; supernode is
-    /// preferred). When None, interop transaction validation in the txpool is disabled.
-    pub supervisor_http: Option<String>,
-    /// Supervisor safety level
-    pub supervisor_safety_level: SafetyLevel,
+    /// Interop filter URL for txpool-level interop validation. When None, interop transaction
+    /// validation in the txpool is disabled.
+    pub interop_http: Option<String>,
+    /// Safety level for interop filter validation.
+    pub interop_safety_level: SafetyLevel,
     /// Marker for the pooled transaction type.
     _pd: core::marker::PhantomData<T>,
 }
@@ -1064,8 +1061,8 @@ impl<T> Default for OpPoolBuilder<T> {
         Self {
             pool_config_overrides: Default::default(),
             enable_tx_conditional: false,
-            supervisor_http: None,
-            supervisor_safety_level: SafetyLevel::CrossUnsafe,
+            interop_http: None,
+            interop_safety_level: SafetyLevel::CrossUnsafe,
             _pd: Default::default(),
         }
     }
@@ -1076,8 +1073,8 @@ impl<T> Clone for OpPoolBuilder<T> {
         Self {
             pool_config_overrides: self.pool_config_overrides.clone(),
             enable_tx_conditional: self.enable_tx_conditional,
-            supervisor_http: self.supervisor_http.clone(),
-            supervisor_safety_level: self.supervisor_safety_level,
+            interop_http: self.interop_http.clone(),
+            interop_safety_level: self.interop_safety_level,
             _pd: core::marker::PhantomData,
         }
     }
@@ -1099,14 +1096,14 @@ impl<T> OpPoolBuilder<T> {
         self
     }
 
-    /// Sets the supervisor client URL. Pass None to disable interop transaction validation.
-    pub fn with_supervisor(
+    /// Sets the interop filter URL. Pass None to disable interop transaction validation.
+    pub fn with_interop(
         mut self,
-        supervisor_client: Option<String>,
-        supervisor_safety_level: SafetyLevel,
+        interop_client: Option<String>,
+        interop_safety_level: SafetyLevel,
     ) -> Self {
-        self.supervisor_http = supervisor_client;
-        self.supervisor_safety_level = supervisor_safety_level;
+        self.interop_http = interop_client;
+        self.interop_safety_level = interop_safety_level;
         self
     }
 }
@@ -1126,18 +1123,18 @@ where
     ) -> eyre::Result<Self::Pool> {
         let Self { pool_config_overrides, .. } = self;
 
-        // supervisor used for interop txpool validation
-        let supervisor_client = if let Some(url) = self.supervisor_http.clone() {
+        // Interop filter used for txpool validation.
+        let interop_client = if let Some(url) = self.interop_http.clone() {
             Some(
-                SupervisorClient::builder(url, ctx.chain_spec().chain_id())
-                    .minimum_safety(self.supervisor_safety_level)
+                InteropFilterClient::builder(url, ctx.chain_spec().chain_id())
+                    .minimum_safety(self.interop_safety_level)
                     .build()
                     .await,
             )
         } else {
             if ctx.chain_spec().is_interop_active_at_timestamp(ctx.head().timestamp) {
                 info!(target: "reth::cli",
-                    "No supervisor URL configured (--rollup.supervisor-http), interop transaction validation disabled."
+                    "No interop filter URL configured (--rollup.interop-http), interop transaction validation disabled."
                 );
             }
             None
@@ -1163,8 +1160,8 @@ where
                         // In --dev mode we can't require gas fees because we're unable to decode
                         // the L1 block info
                         .require_l1_data_gas_fee(!ctx.config().dev.dev);
-                    if let Some(client) = supervisor_client.clone() {
-                        v.with_supervisor(client)
+                    if let Some(client) = interop_client.clone() {
+                        v.with_interop(client)
                     } else {
                         v
                     }
@@ -1190,16 +1187,16 @@ where
         info!(target: "reth::cli", "Transaction pool initialized (interop filter enabled = {interop_filter_enabled})");
         debug!(target: "reth::cli", "Spawned txpool maintenance task");
 
-        // The Op txpool maintenance task is only spawned when interop is scheduled/active and a
-        // supervisor is configured
+        // The Op txpool maintenance task is only spawned when interop is scheduled/active and an
+        // interop filter is configured.
         if ctx.chain_spec().op_fork_activation(OpHardfork::Interop) != ForkCondition::Never &&
-            let Some(ref supervisor) = supervisor_client
+            let Some(ref interop) = interop_client
         {
-            // Spawn failsafe polling task (shares supervisor client via clone)
+            // Spawn failsafe polling task (shares interop filter client via clone).
             ctx.task_executor().spawn_critical_task(
                 "Op txpool failsafe polling task",
                 reth_optimism_txpool::maintain::poll_failsafe_future(
-                    supervisor.clone(),
+                    interop.clone(),
                     transaction_pool.clone(),
                 ),
             );
@@ -1212,7 +1209,7 @@ where
                 reth_optimism_txpool::maintain::maintain_transaction_pool_interop_future(
                     transaction_pool.clone(),
                     chain_events,
-                    supervisor.clone(),
+                    interop.clone(),
                 ),
             );
             debug!(target: "reth::cli", "Spawned Op interop txpool maintenance task");

--- a/rust/op-reth/crates/txpool/src/error.rs
+++ b/rust/op-reth/crates/txpool/src/error.rs
@@ -1,11 +1,11 @@
-use crate::supervisor::InteropTxValidatorError;
+use crate::interop_filter::InteropTxValidatorError;
 use reth_transaction_pool::error::PoolTransactionError;
 use std::any::Any;
 
 /// Wrapper for [`InteropTxValidatorError`] to implement [`PoolTransactionError`] for it.
 #[derive(thiserror::Error, Debug)]
 pub enum InvalidCrossTx {
-    /// Errors produced by supervisor validation
+    /// Errors produced by interop filter validation.
     #[error(transparent)]
     ValidationError(#[from] InteropTxValidatorError),
     /// Error cause by cross chain tx during not active interop hardfork

--- a/rust/op-reth/crates/txpool/src/interop.rs
+++ b/rust/op-reth/crates/txpool/src/interop.rs
@@ -3,7 +3,7 @@
 use alloy_consensus::Transaction;
 use reth_transaction_pool::PoolTransaction;
 
-use crate::supervisor::CROSS_L2_INBOX_ADDRESS;
+use crate::interop_filter::CROSS_L2_INBOX_ADDRESS;
 
 /// Returns true if the transaction's access list targets `CROSS_L2_INBOX_ADDRESS`
 /// with at least one storage key.

--- a/rust/op-reth/crates/txpool/src/interop_filter/access_list.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/access_list.rs
@@ -15,7 +15,7 @@
 // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-use crate::supervisor::CROSS_L2_INBOX_ADDRESS;
+use crate::interop_filter::CROSS_L2_INBOX_ADDRESS;
 use alloy_eips::eip2930::AccessListItem;
 use alloy_primitives::B256;
 
@@ -32,7 +32,7 @@ pub fn parse_access_list_items_to_inbox_entries<'a>(
 /// Max 3 inbox entries can exist per [`AccessListItem`] that points to [`CROSS_L2_INBOX_ADDRESS`].
 ///
 /// Returns `Vec::new()` if [`AccessListItem`] address doesn't point to [`CROSS_L2_INBOX_ADDRESS`].
-// Access-list spec: <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#access-list-contents>
+// Access-list contents follow the interop checkAccessList RPC format.
 fn parse_access_list_item_to_inbox_entries(
     access_list_item: &AccessListItem,
 ) -> Option<impl Iterator<Item = &B256>> {

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     InvalidCrossTx,
-    supervisor::{
-        ExecutingDescriptor, InteropTxValidatorError, metrics::SupervisorMetrics,
+    interop_filter::{
+        ExecutingDescriptor, InteropTxValidatorError, metrics::InteropMetrics,
         parse_access_list_items_to_inbox_entries,
     },
 };
@@ -29,27 +29,23 @@ use std::{
 };
 use tracing::trace;
 
-/// Supervisor hosted by op-labs
-// TODO: This should be changed to actual supervisor url
-pub const DEFAULT_SUPERVISOR_URL: &str = "http://localhost:1337/";
-
 /// The default request timeout to use
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// Implementation of the supervisor trait for the interop.
+/// Client for interop filter RPC requests.
 #[derive(Debug, Clone)]
-pub struct SupervisorClient {
+pub struct InteropFilterClient {
     /// Stores type's data.
-    inner: Arc<SupervisorClientInner>,
+    inner: Arc<InteropFilterClientInner>,
 }
 
-impl SupervisorClient {
-    /// Returns a new [`SupervisorClientBuilder`].
+impl InteropFilterClient {
+    /// Returns a new [`InteropFilterClientBuilder`].
     pub fn builder(
-        supervisor_endpoint: impl Into<String>,
+        interop_endpoint: impl Into<String>,
         chain_id: u64,
-    ) -> SupervisorClientBuilder {
-        SupervisorClientBuilder::new(supervisor_endpoint, chain_id)
+    ) -> InteropFilterClientBuilder {
+        InteropFilterClientBuilder::new(interop_endpoint, chain_id)
     }
 
     /// Returns the configured request timeout.
@@ -57,7 +53,7 @@ impl SupervisorClient {
         self.inner.timeout
     }
 
-    /// Returns configured minimum safety level. See [`SupervisorClient`].
+    /// Returns configured minimum safety level. See [`InteropFilterClient`].
     pub fn safety(&self) -> SafetyLevel {
         self.inner.safety
     }
@@ -78,8 +74,8 @@ impl SupervisorClient {
         }
     }
 
-    /// Extracts commitment from access list entries, pointing to 0x420..022 and validates them
-    /// against supervisor.
+    /// Extracts commitments from access list entries pointing to the cross-L2 inbox and validates
+    /// them against the interop filter.
     ///
     /// If commitment present pre-interop tx rejected.
     ///
@@ -150,15 +146,15 @@ impl SupervisorClient {
         Ok(result)
     }
 
-    /// Creates a stream that revalidates interop transactions against the supervisor.
+    /// Creates a stream that revalidates interop transactions against the interop filter.
     /// Returns
     /// An implementation of `Stream` that is `Send`-able and tied to the lifetime `'a` of `self`.
     /// Each item yielded by the stream is a tuple `(TItem, Option<Result<(), InvalidCrossTx>>)`.
     ///   - The first element is the original `TItem` that was revalidated.
     ///   - The second element is the `Option<Result<(), InvalidCrossTx>>` describes the outcome
     ///     - `None`: Transaction was not identified as a cross-chain candidate by initial checks.
-    ///     - `Some(Ok(()))`: Supervisor confirmed the transaction is valid.
-    ///     - `Some(Err(InvalidCrossTx))`: Supervisor indicated the transaction is invalid.
+    ///     - `Some(Ok(()))`: Interop filter confirmed the transaction is valid.
+    ///     - `Some(Err(InvalidCrossTx))`: Interop filter indicated the transaction is invalid.
     pub fn revalidate_interop_txs_stream<'a, TItem, InputIter>(
         &'a self,
         txs_to_revalidate: InputIter,
@@ -193,9 +189,9 @@ impl SupervisorClient {
     }
 }
 
-/// Holds supervisor data. Inner type of [`SupervisorClient`].
+/// Holds interop RPC data. Inner type of [`InteropFilterClient`].
 #[derive(Debug)]
-pub(crate) struct SupervisorClientInner {
+pub(crate) struct InteropFilterClientInner {
     client: ReqwestClient,
     /// The chain ID of the executing chain
     chain_id: u64,
@@ -203,16 +199,16 @@ pub(crate) struct SupervisorClientInner {
     safety: SafetyLevel,
     /// The default request timeout
     timeout: Duration,
-    /// Metrics for tracking supervisor operations
-    metrics: SupervisorMetrics,
+    /// Metrics for tracking interop RPC operations.
+    metrics: InteropMetrics,
     /// Cached failsafe state, polled by the background failsafe task.
     failsafe_enabled: AtomicBool,
 }
 
-/// Builds [`SupervisorClient`].
+/// Builds [`InteropFilterClient`].
 #[derive(Debug)]
-pub struct SupervisorClientBuilder {
-    /// Supervisor server's socket.
+pub struct InteropFilterClientBuilder {
+    /// Interop filter RPC endpoint.
     endpoint: String,
     /// The chain ID of the executing chain.
     chain_id: u64,
@@ -225,11 +221,11 @@ pub struct SupervisorClientBuilder {
     safety: SafetyLevel,
 }
 
-impl SupervisorClientBuilder {
+impl InteropFilterClientBuilder {
     /// Creates a new builder.
-    pub fn new(supervisor_endpoint: impl Into<String>, chain_id: u64) -> Self {
+    pub fn new(interop_endpoint: impl Into<String>, chain_id: u64) -> Self {
         Self {
-            endpoint: supervisor_endpoint.into(),
+            endpoint: interop_endpoint.into(),
             chain_id,
             timeout: DEFAULT_REQUEST_TIMEOUT,
             safety: SafetyLevel::CrossUnsafe,
@@ -248,22 +244,22 @@ impl SupervisorClientBuilder {
         self
     }
 
-    /// Creates a new supervisor validator.
-    pub async fn build(self) -> SupervisorClient {
+    /// Creates a new interop RPC client.
+    pub async fn build(self) -> InteropFilterClient {
         let Self { endpoint, chain_id, timeout, safety } = self;
 
         let client = ReqwestClient::builder()
             .connect(endpoint.as_str())
             .await
-            .expect("building supervisor client");
+            .expect("building interop filter client");
 
-        SupervisorClient {
-            inner: Arc::new(SupervisorClientInner {
+        InteropFilterClient {
+            inner: Arc::new(InteropFilterClientInner {
                 client,
                 chain_id,
                 safety,
                 timeout,
-                metrics: SupervisorMetrics::default(),
+                metrics: InteropMetrics::default(),
                 failsafe_enabled: AtomicBool::new(false),
             }),
         }
@@ -278,7 +274,7 @@ pub struct CheckAccessListRequest<'a> {
     executing_descriptor: ExecutingDescriptor,
     timeout: Duration,
     safety: SafetyLevel,
-    metrics: SupervisorMetrics,
+    metrics: InteropMetrics,
 }
 
 impl<'a> CheckAccessListRequest<'a> {
@@ -312,7 +308,7 @@ impl<'a> IntoFuture for CheckAccessListRequest<'a> {
                 ),
             )
             .await;
-            metrics.record_supervisor_query(start.elapsed());
+            metrics.record_interop_query(start.elapsed());
 
             result
                 .map_err(|_| InteropTxValidatorError::Timeout(timeout.as_secs()))?

--- a/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
@@ -5,7 +5,7 @@ use op_alloy_rpc_types::SuperchainDAError;
 /// Failures occurring during validation of inbox entries.
 #[derive(thiserror::Error, Debug)]
 pub enum InteropTxValidatorError {
-    /// Inbox entry validation against the Supervisor took longer than allowed.
+    /// Inbox entry validation against the interop filter took longer than allowed.
     #[error("inbox entry validation timed out, timeout: {0} secs")]
     Timeout(u64),
 
@@ -14,7 +14,7 @@ pub enum InteropTxValidatorError {
     InvalidEntry(#[from] SuperchainDAError),
 
     /// Catch-all variant.
-    #[error("supervisor server error: {0}")]
+    #[error("interop filter server error: {0}")]
     Other(Box<dyn error::Error + Send + Sync>),
 }
 
@@ -28,7 +28,7 @@ impl InteropTxValidatorError {
     }
 
     /// This function will parse the error code to determine if it matches
-    /// one of the known Supervisor errors, and return the corresponding
+    /// one of the known interop filter errors, and return the corresponding
     /// error variant. Otherwise, it returns a generic [`Other`](Self::Other) error.
     pub fn from_json_rpc<E>(err: RpcError<E>) -> Self
     where

--- a/rust/op-reth/crates/txpool/src/interop_filter/message.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/message.rs
@@ -17,7 +17,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /// An [`ExecutingDescriptor`] is a part of the payload to `interop_checkAccessList`
-/// Spec: <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#executingdescriptor>
+/// Interop RPC request descriptor.
 #[derive(Default, Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExecutingDescriptor {
     /// The chain ID of the executing chain.

--- a/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
@@ -1,6 +1,6 @@
-//! Optimism supervisor metrics
+//! Optimism interop txpool metrics.
 
-use crate::supervisor::InteropTxValidatorError;
+use crate::interop_filter::InteropTxValidatorError;
 use op_alloy_rpc_types::SuperchainDAError;
 use reth_metrics::{
     Metrics,
@@ -8,12 +8,12 @@ use reth_metrics::{
 };
 use std::time::Duration;
 
-/// Optimism supervisor metrics
+/// Optimism interop txpool metrics.
 #[derive(Metrics, Clone)]
-#[metrics(scope = "optimism_transaction_pool.supervisor")]
-pub struct SupervisorMetrics {
-    /// How long it takes to query the supervisor in the Optimism transaction pool
-    pub(crate) supervisor_query_latency: Histogram,
+#[metrics(scope = "optimism_transaction_pool.interop")]
+pub struct InteropMetrics {
+    /// How long it takes to query the interop filter in the Optimism transaction pool.
+    pub(crate) interop_query_latency: Histogram,
 
     /// Counter for the number of times data was skipped
     pub(crate) skipped_data_count: Counter,
@@ -39,11 +39,11 @@ pub struct SupervisorMetrics {
     pub(crate) data_corruption_count: Counter,
 }
 
-impl SupervisorMetrics {
-    /// Records the duration of supervisor queries
+impl InteropMetrics {
+    /// Records the duration of interop filter queries.
     #[inline]
-    pub fn record_supervisor_query(&self, duration: Duration) {
-        self.supervisor_query_latency.record(duration.as_secs_f64());
+    pub fn record_interop_query(&self, duration: Duration) {
+        self.interop_query_latency.record(duration.as_secs_f64());
     }
 
     /// Increments the metrics for the given error

--- a/rust/op-reth/crates/txpool/src/interop_filter/mod.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/mod.rs
@@ -1,10 +1,10 @@
-//! Supervisor support for interop
+//! Interop filter RPC support.
 mod access_list;
 pub use access_list::parse_access_list_items_to_inbox_entries;
 pub use op_alloy_consensus::interop::*;
 
 pub mod client;
-pub use client::{DEFAULT_SUPERVISOR_URL, SupervisorClient, SupervisorClientBuilder};
+pub use client::{InteropFilterClient, InteropFilterClientBuilder};
 mod errors;
 pub use errors::InteropTxValidatorError;
 mod message;

--- a/rust/op-reth/crates/txpool/src/lib.rs
+++ b/rust/op-reth/crates/txpool/src/lib.rs
@@ -14,7 +14,7 @@ pub use validator::{OpL1BlockInfo, OpTransactionValidator};
 pub mod conditional;
 mod pool;
 pub use pool::OpPool;
-pub mod supervisor;
+pub mod interop_filter;
 mod transaction;
 pub use transaction::{OpPooledTransaction, OpPooledTx};
 mod error;

--- a/rust/op-reth/crates/txpool/src/maintain.rs
+++ b/rust/op-reth/crates/txpool/src/maintain.rs
@@ -2,13 +2,13 @@
 
 /// Offset before deadline expiry at which a tx becomes "stale" and triggers revalidation.
 const OFFSET_TIME: u64 = 60;
-/// Maximum number of supervisor requests at the same time
-const MAX_SUPERVISOR_QUERIES: usize = 10;
+/// Maximum number of interop filter requests at the same time.
+const MAX_INTEROP_QUERIES: usize = 10;
 
 use crate::{
     conditional::MaybeConditionalTransaction,
     interop::{MaybeInteropTransaction, is_interop_tx, is_stale_interop, is_valid_interop},
-    supervisor::SupervisorClient,
+    interop_filter::InteropFilterClient,
     validator::CHECK_ACCESS_LIST_TIMEOUT_SECS,
 };
 use alloy_consensus::{BlockHeader, conditional::BlockConditionalAttributes};
@@ -50,8 +50,8 @@ struct MaintainPoolInteropMetrics {
     /// Counter for interop transactions that became stale and need revalidation
     stale_interop_transactions: Counter,
     // TODO: we also should add metric for (hash, counter) to check number of validation per tx
-    /// Histogram for measuring supervisor revalidation duration (congestion metric)
-    supervisor_revalidation_duration_seconds: Histogram,
+    /// Histogram for measuring interop revalidation duration (congestion metric).
+    interop_revalidation_duration_seconds: Histogram,
 }
 
 impl MaintainPoolInteropMetrics {
@@ -69,10 +69,10 @@ impl MaintainPoolInteropMetrics {
         self.stale_interop_transactions.increment(count as u64);
     }
 
-    /// Record supervisor revalidation duration
+    /// Records interop revalidation duration.
     #[inline]
-    fn record_supervisor_duration(&self, duration: std::time::Duration) {
-        self.supervisor_revalidation_duration_seconds.record(duration.as_secs_f64());
+    fn record_interop_duration(&self, duration: std::time::Duration) {
+        self.interop_revalidation_duration_seconds.record(duration.as_secs_f64());
     }
 }
 /// Returns a spawnable future for maintaining the state of the conditional txs in the transaction
@@ -131,7 +131,7 @@ where
 pub fn maintain_transaction_pool_interop_future<N, Pool, St>(
     pool: Pool,
     events: St,
-    supervisor_client: SupervisorClient,
+    interop_client: InteropFilterClient,
 ) -> BoxFuture<'static, ()>
 where
     N: NodePrimitives,
@@ -140,7 +140,7 @@ where
     St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
 {
     async move {
-        maintain_transaction_pool_interop(pool, events, supervisor_client).await;
+        maintain_transaction_pool_interop(pool, events, interop_client).await;
     }
     .boxed()
 }
@@ -152,7 +152,7 @@ where
 pub async fn maintain_transaction_pool_interop<N, Pool, St>(
     pool: Pool,
     mut events: St,
-    supervisor_client: SupervisorClient,
+    interop_client: InteropFilterClient,
 ) where
     N: NodePrimitives,
     Pool: TransactionPool,
@@ -172,7 +172,7 @@ pub async fn maintain_transaction_pool_interop<N, Pool, St>(
             // If failsafe is active, evict ALL interop txs and skip revalidation.
             // Belt-and-suspenders with poll_failsafe: catches any tx that raced past
             // the ingress check or was added between poll_failsafe transition ticks.
-            if supervisor_client.is_failsafe_enabled() {
+            if interop_client.is_failsafe_enabled() {
                 let interop_hashes: Vec<_> = pool
                     .pooled_transactions()
                     .iter()
@@ -209,11 +209,11 @@ pub async fn maintain_transaction_pool_interop<N, Pool, St>(
                 metrics.inc_stale_tx_interop(to_revalidate.len());
 
                 let revalidation_start = Instant::now();
-                let revalidation_stream = supervisor_client.revalidate_interop_txs_stream(
+                let revalidation_stream = interop_client.revalidate_interop_txs_stream(
                     to_revalidate,
                     timestamp,
                     CHECK_ACCESS_LIST_TIMEOUT_SECS,
-                    MAX_SUPERVISOR_QUERIES,
+                    MAX_INTEROP_QUERIES,
                 );
 
                 futures_util::pin_mut!(revalidation_stream);
@@ -242,7 +242,7 @@ pub async fn maintain_transaction_pool_interop<N, Pool, St>(
                     }
                 }
 
-                metrics.record_supervisor_duration(revalidation_start.elapsed());
+                metrics.record_interop_duration(revalidation_start.elapsed());
             }
 
             if !to_remove.is_empty() {
@@ -253,11 +253,11 @@ pub async fn maintain_transaction_pool_interop<N, Pool, St>(
     }
 }
 
-/// Background task that polls the supervisor for failsafe state every second.
+/// Background task that polls the interop filter for failsafe state every second.
 /// When failsafe transitions from disabled to enabled, evicts all interop txs
 /// from the pool immediately (does not wait for the next block event).
 /// Matches op-geth's `startBackgroundInteropFailsafeDetection` (miner/miner.go:140-165).
-pub async fn poll_failsafe<Pool>(supervisor_client: SupervisorClient, pool: Pool)
+pub async fn poll_failsafe<Pool>(interop_client: InteropFilterClient, pool: Pool)
 where
     Pool: TransactionPool,
     Pool::Transaction: MaybeInteropTransaction,
@@ -267,7 +267,7 @@ where
     let mut was_enabled = false;
     loop {
         interval.tick().await;
-        match supervisor_client.query_failsafe().await {
+        match interop_client.query_failsafe().await {
             Ok(enabled) => {
                 // On transition to enabled: evict all interop txs immediately
                 if enabled && !was_enabled {
@@ -302,12 +302,12 @@ where
 
 /// Creates a boxed future for the failsafe polling task.
 pub fn poll_failsafe_future<Pool>(
-    supervisor_client: SupervisorClient,
+    interop_client: InteropFilterClient,
     pool: Pool,
 ) -> BoxFuture<'static, ()>
 where
     Pool: TransactionPool + 'static,
     Pool::Transaction: MaybeInteropTransaction,
 {
-    Box::pin(poll_failsafe(supervisor_client, pool))
+    Box::pin(poll_failsafe(interop_client, pool))
 }

--- a/rust/op-reth/crates/txpool/src/pool.rs
+++ b/rust/op-reth/crates/txpool/src/pool.rs
@@ -380,7 +380,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::supervisor::CROSS_L2_INBOX_ADDRESS;
+    use crate::interop_filter::CROSS_L2_INBOX_ADDRESS;
     use alloy_eips::eip2930::{AccessList, AccessListItem};
     use alloy_primitives::address;
     use reth_transaction_pool::test_utils::MockTransaction;

--- a/rust/op-reth/crates/txpool/src/validator.rs
+++ b/rust/op-reth/crates/txpool/src/validator.rs
@@ -1,4 +1,4 @@
-use crate::{InvalidCrossTx, OpPooledTx, supervisor::SupervisorClient};
+use crate::{InvalidCrossTx, OpPooledTx, interop_filter::InteropFilterClient};
 use alloy_consensus::{BlockHeader, Transaction};
 use op_revm::L1BlockInfo;
 use parking_lot::RwLock;
@@ -20,7 +20,7 @@ use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
-/// The timeout for cross-chain transaction validation against the supervisor/interop-filter.
+/// The timeout for cross-chain transaction validation against the interop filter.
 pub(crate) const CHECK_ACCESS_LIST_TIMEOUT_SECS: u64 = 7200;
 
 /// Tracks additional infos for the current block.
@@ -50,8 +50,8 @@ pub struct OpTransactionValidator<Client, Tx, Evm> {
     /// derived from the tracked L1 block info that is extracted from the first transaction in the
     /// L2 block.
     require_l1_data_gas_fee: bool,
-    /// Client used to check transaction validity with op-supervisor
-    supervisor_client: Option<SupervisorClient>,
+    /// Client used to check transaction validity with the interop filter.
+    interop_client: Option<InteropFilterClient>,
     /// tracks activated forks relevant for transaction validation
     fork_tracker: Arc<OpForkTracker>,
 }
@@ -122,14 +122,14 @@ where
             inner: Arc::new(inner),
             block_info: Arc::new(block_info),
             require_l1_data_gas_fee: true,
-            supervisor_client: None,
+            interop_client: None,
             fork_tracker: Arc::new(OpForkTracker { interop: AtomicBool::from(false) }),
         }
     }
 
-    /// Set the supervisor client and safety level
-    pub fn with_supervisor(mut self, supervisor_client: SupervisorClient) -> Self {
-        self.supervisor_client = Some(supervisor_client);
+    /// Sets the interop filter client and safety level.
+    pub fn with_interop(mut self, interop_client: InteropFilterClient) -> Self {
+        self.interop_client = Some(interop_client);
         self
     }
 
@@ -277,7 +277,7 @@ where
     pub async fn is_valid_cross_tx(&self, tx: &Tx) -> Option<Result<(), InvalidCrossTx>> {
         // We don't need to check for deposit transaction in here, because they won't come from
         // txpool
-        self.supervisor_client
+        self.interop_client
             .as_ref()?
             .is_valid_cross_tx(
                 tx.access_list(),


### PR DESCRIPTION
## Summary

- updates op-interop-filter comments/tests to refer to the interop API instead of the old supervisor wording
- renames op-reth txpool validation naming from supervisor to interop, including `InteropFilterClient`, `--rollup.interop-http`, safety flag names, metrics, docs, and devstack wiring
- migrates op-rbuilder's txpool wiring to the renamed interop API (`with_interop` / `interop_http` / `interop_safety_level`); op-rbuilder builds against the local op-reth crates by path, so it must track the rename
- removes the now-unused `DEFAULT_INTEROP_URL` constant (`http://localhost:1337/`) — it was only exported, never wired as the flag's default; `--rollup.interop-http` is an `Option` that disables interop validation when unset
- updates related Kona/op-reth comments that referenced supervisor-era RPC names
- clarifies in the `--rollup.interop-http` docs (arg help + the two hand-maintained mdx pages) that omitting it disables interop transaction validation, so a block-building node will include transactions carrying invalid interop messages and produce invalid blocks; only safe to leave unset on nodes that do not build blocks

Rebased onto the latest `develop` and squashed into a single commit (the original #20778 stack has since merged, and the changes it already carried upstream dropped out of the rebase).

## Test plan

- `cd op-interop-filter && mise exec -- just test`
- `cd rust && mise exec -- just f`
- `cd rust && mise exec -- just lint`
- `mise exec -- go test ./op-devstack/sysgo/...`
- `cd rust/op-rbuilder && make tester` (op-rbuilder compiles against the renamed op-reth interop API)