### PR TITLE
fix(docs): Fix PNPM build allowlist

### DIFF
--- a/docs/public-docs/package.json
+++ b/docs/public-docs/package.json
@@ -19,15 +19,5 @@
     "ts-morph": "^21.0.0",
     "tsx": "^4.7.0",
     "typescript": "^5.0.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@reown/appkit",
-      "bigint-buffer",
-      "bufferutil",
-      "esbuild",
-      "sharp",
-      "utf-8-validate"
-    ]
   }
 }

--- a/docs/public-docs/pnpm-workspace.yaml
+++ b/docs/public-docs/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+packages:
+  - .
+
+onlyBuiltDependencies:
+  - "@reown/appkit"
+  - bigint-buffer
+  - bufferutil
+  - esbuild
+  - sharp
+  - utf-8-validate


### PR DESCRIPTION
## Summary

- moves the docs PNPM dependency build-script allowlist from `package.json` to `pnpm-workspace.yaml`
- keeps the same approved build-script package list while matching current PNPM 10 settings behavior

Found due to docs-ci failure in #20866 [here](https://app.circleci.com/pipelines/gh/ethereum-optimism/optimism/125613/workflows/122b37d5-9738-4587-81b8-f2402d633323/jobs/5069548)

## Root cause

`docs-ci` installs the latest PNPM globally before running `pnpm install`. Current PNPM no longer reads the `pnpm.onlyBuiltDependencies` setting from `package.json`, so the install step ignored the allowlist and failed with `ERR_PNPM_IGNORED_BUILDS`.

## Test plan

- `cd docs/public-docs && pnpm install --frozen-lockfile`
- `cd docs/public-docs && npx mintlify validate`
