### PR TITLE
test(acceptance): replace sleep polling

### DIFF
--- a/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
+++ b/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -92,7 +93,7 @@ func TestConductorLeadershipTransfer(gt *testing.T) {
 				oldLeaderIndex, newLeaderIndex := i%len(voters), (i+1)%len(voters)
 				oldLeader, newLeader := voters[oldLeaderIndex], voters[newLeaderIndex]
 
-				time.Sleep(3 * time.Second)
+				require.NoError(tt, clock.SystemClock.SleepCtx(ctx, 3*time.Second))
 
 				testTransferLeadershipAndCheck(t, oldLeader, newLeader)
 			}

--- a/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
+++ b/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
-	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -92,9 +91,6 @@ func TestConductorLeadershipTransfer(gt *testing.T) {
 				// the modulo operation is used to wrap around the list of voters whenever i or i+1 becomes >= len(voters)
 				oldLeaderIndex, newLeaderIndex := i%len(voters), (i+1)%len(voters)
 				oldLeader, newLeader := voters[oldLeaderIndex], voters[newLeaderIndex]
-
-				require.NoError(tt, clock.SystemClock.SleepCtx(ctx, 3*time.Second))
-
 				testTransferLeadershipAndCheck(t, oldLeader, newLeader)
 			}
 		})

--- a/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
+++ b/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -91,6 +92,9 @@ func TestConductorLeadershipTransfer(gt *testing.T) {
 				// the modulo operation is used to wrap around the list of voters whenever i or i+1 becomes >= len(voters)
 				oldLeaderIndex, newLeaderIndex := i%len(voters), (i+1)%len(voters)
 				oldLeader, newLeader := voters[oldLeaderIndex], voters[newLeaderIndex]
+
+				require.NoError(tt, clock.SystemClock.SleepCtx(ctx, 3*time.Second))
+
 				testTransferLeadershipAndCheck(t, oldLeader, newLeader)
 			}
 		})
@@ -102,14 +106,20 @@ func testTransferLeadershipAndCheck(t devtest.T, oldLeader, targetLeader conduct
 
 	t.Run(fmt.Sprintf("Conductor_%s_to_%s", oldLeader, targetLeader), func(tt devtest.T) {
 		// ensure that the current and target leader are healthy and unpaused before transferring leadership
-		require.True(tt, oldLeader.FetchSequencerHealthy(), "current leader's sequencer is not healthy, id", oldLeader)
-		require.True(tt, targetLeader.FetchSequencerHealthy(), "target leader's sequencer is not healthy, id", targetLeader)
-		require.False(tt, oldLeader.FetchPaused(), "current leader's sequencer is paused, id", oldLeader)
-		require.False(tt, targetLeader.FetchPaused(), "target leader's sequencer is paused, id", targetLeader)
+		require.Eventually(tt, func() bool { return oldLeader.FetchSequencerHealthy() },
+			30*time.Second, 500*time.Millisecond, "current leader's sequencer is not healthy, id: %s", oldLeader)
+		require.Eventually(tt, func() bool { return targetLeader.FetchSequencerHealthy() },
+			30*time.Second, 500*time.Millisecond, "target leader's sequencer is not healthy, id: %s", targetLeader)
+		require.Eventually(tt, func() bool { return !oldLeader.FetchPaused() },
+			30*time.Second, 500*time.Millisecond, "current leader's sequencer is paused, id: %s", oldLeader)
+		require.Eventually(tt, func() bool { return !targetLeader.FetchPaused() },
+			30*time.Second, 500*time.Millisecond, "target leader's sequencer is paused, id: %s", targetLeader)
 
 		// ensure that the current leader is the leader before transferring leadership
-		require.True(tt, oldLeader.IsLeader(), "current leader was not found to be the leader")
-		require.False(tt, targetLeader.IsLeader(), "target leader was already found to be the leader")
+		require.Eventually(tt, func() bool { return oldLeader.IsLeader() },
+			30*time.Second, 500*time.Millisecond, "current leader was not found to be the leader")
+		require.Eventually(tt, func() bool { return !targetLeader.IsLeader() },
+			30*time.Second, 500*time.Millisecond, "target leader was already found to be the leader")
 
 		oldLeader.TransferLeadershipTo(targetLeader.info)
 

--- a/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
+++ b/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
@@ -93,7 +93,7 @@ func TestConductorLeadershipTransfer(gt *testing.T) {
 				oldLeaderIndex, newLeaderIndex := i%len(voters), (i+1)%len(voters)
 				oldLeader, newLeader := voters[oldLeaderIndex], voters[newLeaderIndex]
 
-				require.NoError(tt, clock.SystemClock.SleepCtx(ctx, 3*time.Second))
+				require.NoError(tt, clock.SystemClock.SleepCtx(ctx, 3*time.Second)) // nosemgrep: flake-sleep-in-test -- intentional inter-transfer pause; no deterministic chain event to wait on
 
 				testTransferLeadershipAndCheck(t, oldLeader, newLeader)
 			}

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -151,7 +151,7 @@ func TestRandomDirectedGraph(gt *testing.T) {
 
 	// jitter randomizes tx
 	jitter := func(ctx context.Context, rng *rand.Rand) error {
-		return clock.SystemClock.SleepCtx(ctx, time.Duration(rng.Intn(250))*time.Millisecond)
+		return clock.SystemClock.SleepCtx(ctx, time.Duration(rng.Intn(250))*time.Millisecond) // nosemgrep: flake-sleep-in-test -- deliberate jitter for load test tx ordering
 	}
 
 	// fund EOAs per chain

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/plan"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -149,8 +150,8 @@ func TestRandomDirectedGraph(gt *testing.T) {
 	fundAmount := eth.OneTenthEther
 
 	// jitter randomizes tx
-	jitter := func(rng *rand.Rand) {
-		time.Sleep(time.Duration(rng.Intn(250)) * time.Millisecond)
+	jitter := func(ctx context.Context, rng *rand.Rand) error {
+		return clock.SystemClock.SleepCtx(ctx, time.Duration(rng.Intn(250))*time.Millisecond)
 	}
 
 	// fund EOAs per chain
@@ -190,7 +191,9 @@ func TestRandomDirectedGraph(gt *testing.T) {
 					case <-ctx.Done():
 						return ctx.Err()
 					}
-					jitter(publisherRng)
+					if err := jitter(ctx, publisherRng); err != nil {
+						return err
+					}
 				}
 			}
 			return nil
@@ -216,7 +219,9 @@ func TestRandomDirectedGraph(gt *testing.T) {
 						"destChainID", tx.PlannedTx.ChainID.Value(),
 						"sourceBlockNum", dependsOn.PlannedTx.IncludedBlock.Value().Number,
 						"destBlockNum", receipt.BlockNumber)
-					jitter(subscriberRng)
+					if err := jitter(ctx, subscriberRng); err != nil {
+						return err
+					}
 				}
 			}
 		})

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
@@ -185,7 +185,11 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 			L1Origin: nil,
 		})
 		require.NoError(t, err, "Expected to be able to create a new block job for sequencing on op-test-sequencer, but got error")
-		require.NoError(t, clock.SystemClock.SleepCtx(ctx, 2*time.Second))
+		// Wait until wall time has advanced past the parent block's timestamp so the
+		// new block gets a strictly greater timestamp.
+		require.Eventually(gt, func() bool {
+			return uint64(time.Now().Unix()) > currentUnsafeRef.Time
+		}, 10*time.Second, 100*time.Millisecond)
 
 		// include simple transfer tx in opened block
 		{
@@ -203,7 +207,15 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 
 		err = ia.Next(ctx)
 		require.NoError(t, err, "Expected to be able to call Next() after New() on op-test-sequencer, but got error")
-		require.NoError(t, clock.SystemClock.SleepCtx(ctx, 2*time.Second))
+		// Wait for the op-node to observe the block the test-sequencer just committed
+		// before handing sequencing back to it via StartSequencer.
+		expectedUnsafe := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
+		waitCtx, waitCancel := context.WithTimeout(ctx, 30*time.Second)
+		err = wait.For(waitCtx, 100*time.Millisecond, func() (bool, error) {
+			return sys.L2ACL.SyncStatus().UnsafeL2.Hash == expectedUnsafe.Hash, nil
+		})
+		waitCancel()
+		require.NoError(t, err, "op-node never observed test-sequencer's committed unsafe head %s", expectedUnsafe.Hash)
 	}
 
 	// continue sequencing with the supernode

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
@@ -184,7 +185,7 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 			L1Origin: nil,
 		})
 		require.NoError(t, err, "Expected to be able to create a new block job for sequencing on op-test-sequencer, but got error")
-		time.Sleep(2 * time.Second)
+		require.NoError(t, clock.SystemClock.SleepCtx(ctx, 2*time.Second))
 
 		// include simple transfer tx in opened block
 		{
@@ -202,7 +203,7 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 
 		err = ia.Next(ctx)
 		require.NoError(t, err, "Expected to be able to call Next() after New() on op-test-sequencer, but got error")
-		time.Sleep(2 * time.Second)
+		require.NoError(t, clock.SystemClock.SleepCtx(ctx, 2*time.Second))
 	}
 
 	// continue sequencing with the supernode

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -185,11 +185,6 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 			L1Origin: nil,
 		})
 		require.NoError(t, err, "Expected to be able to create a new block job for sequencing on op-test-sequencer, but got error")
-		// Wait until wall time has advanced past the parent block's timestamp so the
-		// new block gets a strictly greater timestamp.
-		require.Eventually(gt, func() bool {
-			return uint64(time.Now().Unix()) > currentUnsafeRef.Time
-		}, 10*time.Second, 100*time.Millisecond)
 
 		// include simple transfer tx in opened block
 		{

--- a/op-acceptance-tests/tests/interop/upgrade-no-supervisor/interop_contracts_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-no-supervisor/interop_contracts_test.go
@@ -56,8 +56,19 @@ func TestLocalFinalityWithoutSupervisor(gt *testing.T) {
 
 	targetBlocks := uint64(5)
 
-	for i := 0; i < 30; i++ {
-		time.Sleep(time.Second * 2)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	deadline := time.NewTimer(time.Minute)
+	defer deadline.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			require.Failf("local finality did not advance", "Expected unsafe >= %d and safe >= %d", targetBlocks, targetBlocks-2)
+		case <-t.Ctx().Done():
+			require.NoError(t.Ctx().Err())
+		}
 
 		status := sys.L2CL.SyncStatus()
 		require.NotNil(status)
@@ -72,13 +83,9 @@ func TestLocalFinalityWithoutSupervisor(gt *testing.T) {
 		// - UnsafeL2 should advance (sequencer producing blocks)
 		// - SafeL2 should advance (after batches submitted to L1)
 
-		if status.UnsafeL2.Number >= targetBlocks &&
-			status.SafeL2.Number >= targetBlocks-2 {
+		if status.UnsafeL2.Number >= targetBlocks && status.SafeL2.Number >= targetBlocks-2 {
 			logger.Info("local finality working without supervisor!")
 			return
 		}
 	}
-
-	gt.Errorf("Expected unsafe >= %d and safe >= %d", targetBlocks, targetBlocks-2)
-	gt.FailNow()
 }

--- a/op-acceptance-tests/tests/sequencer/max_safe_lag_test.go
+++ b/op-acceptance-tests/tests/sequencer/max_safe_lag_test.go
@@ -75,7 +75,7 @@ func TestMaxSafeLagStallAndResume(gt *testing.T) {
 
 	// Confirm the stall holds for enough samples to cover at least one L1 block.
 	for range stableSamples {
-		require.NoError(t, clock.SystemClock.SleepCtx(t.Ctx(), time.Duration(blockTime)*time.Second))
+		require.NoError(t, clock.SystemClock.SleepCtx(t.Ctx(), time.Duration(blockTime)*time.Second)) // nosemgrep: flake-sleep-in-test -- stall confirmation requires wall-clock spacing; no chain event to wait on
 		status := sys.L2CL.SyncStatus()
 		require.Equal(t, stalledUnsafe, status.UnsafeL2.Number,
 			"sequencer was expected to stay stalled but unsafe head advanced: %d -> %d",

--- a/op-acceptance-tests/tests/sequencer/max_safe_lag_test.go
+++ b/op-acceptance-tests/tests/sequencer/max_safe_lag_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,7 +75,7 @@ func TestMaxSafeLagStallAndResume(gt *testing.T) {
 
 	// Confirm the stall holds for enough samples to cover at least one L1 block.
 	for range stableSamples {
-		time.Sleep(time.Duration(blockTime) * time.Second)
+		require.NoError(t, clock.SystemClock.SleepCtx(t.Ctx(), time.Duration(blockTime)*time.Second))
 		status := sys.L2CL.SyncStatus()
 		require.Equal(t, stalledUnsafe, status.UnsafeL2.Number,
 			"sequencer was expected to stay stalled but unsafe head advanced: %d -> %d",

--- a/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 )
 
 // TestSupernodeInteropVerifiedAt tests that the VerifiedAt endpoint returns
@@ -103,7 +104,7 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 	stableFor := 0
 	start := time.Now()
 	for stableFor < 10 {
-		time.Sleep(time.Second)
+		t.Require().NoError(clock.SystemClock.SleepCtx(ctx, time.Second))
 		current := sys.L2BCL.SyncStatus()
 		if current.LocalSafeL2.Number == lastSafe {
 			stableFor++
@@ -146,7 +147,7 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 			break
 		}
 
-		time.Sleep(time.Second)
+		t.Require().NoError(clock.SystemClock.SleepCtx(ctx, time.Second))
 
 		// Check the state
 		newStatusA := sys.L2ACL.SyncStatus()

--- a/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
@@ -104,7 +104,7 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 	stableFor := 0
 	start := time.Now()
 	for stableFor < 10 {
-		t.Require().NoError(clock.SystemClock.SleepCtx(ctx, time.Second))
+		t.Require().NoError(clock.SystemClock.SleepCtx(ctx, time.Second)) // nosemgrep: flake-sleep-in-test -- asserting absence of progress; no chain event to wait on
 		current := sys.L2BCL.SyncStatus()
 		if current.LocalSafeL2.Number == lastSafe {
 			stableFor++
@@ -147,7 +147,7 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 			break
 		}
 
-		t.Require().NoError(clock.SystemClock.SleepCtx(ctx, time.Second))
+		t.Require().NoError(clock.SystemClock.SleepCtx(ctx, time.Second)) // nosemgrep: flake-sleep-in-test -- asserting absence of progress; no chain event to wait on
 
 		// Check the state
 		newStatusA := sys.L2ACL.SyncStatus()

--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -61,7 +61,7 @@ func LaggedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.
 				return fmt.Errorf("expected head to lag: %s", lvl)
 			}
 			logger.Info("Node sync status", "base", base.Number, "ref", ref.Number)
-			if err := clock.SystemClock.SleepCtx(ctx, 2*time.Second); err != nil {
+			if err := clock.SystemClock.SleepCtx(ctx, 2*time.Second); err != nil { // nosemgrep: flake-sleep-in-test -- asserting absence of progress; no chain event to wait on
 				return err
 			}
 		}

--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -60,7 +61,9 @@ func LaggedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.
 				return fmt.Errorf("expected head to lag: %s", lvl)
 			}
 			logger.Info("Node sync status", "base", base.Number, "ref", ref.Number)
-			time.Sleep(2 * time.Second)
+			if err := clock.SystemClock.SleepCtx(ctx, 2*time.Second); err != nil {
+				return err
+			}
 		}
 		logger.Info("Node lagged as expected")
 		return nil

--- a/op-devstack/dsl/check_test.go
+++ b/op-devstack/dsl/check_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -111,7 +112,9 @@ func TestMatchedWithProgressFn_KeepsWaitingWhileProgressing(t *testing.T) {
 	go func() {
 		defer driverWG.Done()
 		for i := 6; i <= 12; i++ {
-			time.Sleep(500 * time.Millisecond)
+			if err := clock.SystemClock.SleepCtx(ctx, 500*time.Millisecond); err != nil {
+				return
+			}
 			base.set(types.LocalUnsafe, uint64(i), common.BigToHash(common.Big1))
 		}
 		// Now let CrossSafe match.

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -221,7 +221,7 @@ func (cl *L2CLNode) NotAdvancedFn(lvl types.SafetyLevel, attempts int) CheckFunc
 		var lastErr error
 		successes := 0
 		for range attempts {
-			if err := clock.SystemClock.SleepCtx(cl.ctx, 2*time.Second); err != nil {
+			if err := clock.SystemClock.SleepCtx(cl.ctx, 2*time.Second); err != nil { // nosemgrep: flake-sleep-in-test -- asserting absence of progress; no chain event to wait on
 				return err
 			}
 			head, err := cl.headBlockRef(lvl)

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -220,7 +221,9 @@ func (cl *L2CLNode) NotAdvancedFn(lvl types.SafetyLevel, attempts int) CheckFunc
 		var lastErr error
 		successes := 0
 		for range attempts {
-			time.Sleep(2 * time.Second)
+			if err := clock.SystemClock.SleepCtx(cl.ctx, 2*time.Second); err != nil {
+				return err
+			}
 			head, err := cl.headBlockRef(lvl)
 			if err != nil {
 				lastErr = err

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -90,7 +90,7 @@ func (el *L2ELNode) NotAdvancedFn(label eth.BlockLabel, attempts int) CheckFunc 
 		el.log.Info("expecting chain not to advance", "chain", el.inner.ChainID(), "label", label)
 		initial := el.BlockRefByLabel(label)
 		for range attempts {
-			if err := clock.SystemClock.SleepCtx(el.ctx, 2*time.Second); err != nil {
+			if err := clock.SystemClock.SleepCtx(el.ctx, 2*time.Second); err != nil { // nosemgrep: flake-sleep-in-test -- asserting absence of progress; no chain event to wait on
 				return err
 			}
 			head := el.BlockRefByLabel(label)

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -89,7 +90,9 @@ func (el *L2ELNode) NotAdvancedFn(label eth.BlockLabel, attempts int) CheckFunc 
 		el.log.Info("expecting chain not to advance", "chain", el.inner.ChainID(), "label", label)
 		initial := el.BlockRefByLabel(label)
 		for range attempts {
-			time.Sleep(2 * time.Second)
+			if err := clock.SystemClock.SleepCtx(el.ctx, 2*time.Second); err != nil {
+				return err
+			}
 			head := el.BlockRefByLabel(label)
 			el.log.Info("chain sync status", "chain", el.inner.ChainID(), "initial", initial.Number, "current", head.Number, "target", initial.Number)
 			if head.Hash == initial.Hash {


### PR DESCRIPTION
This removes the remaining raw sleeps covered by the `flake-sleep-in-test` acceptance-test flake lint introduced in #20784 and replaces them with condition-based waits or context-aware timers. The changes keep the existing polling cadence and timeout behavior where the sleeps were serving as fixed intervals, while avoiding goroutine-scoped require assertions in retry loops.