### PR TITLE
fix(op-node): split super authority finalized cache

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -121,10 +121,9 @@ type EngineController struct {
 	// Derived from L1, and known to be a completed span-batch,
 	// but not cross-verified yet.
 	localSafeHead eth.L2BlockRef
-	// Last locally materialized finalized head.
-	// In superAuthority mode, this is updated from successfully resolved
-	// superAuthority finalized refs and used as a fallback when the authority
-	// or EL is temporarily unavailable.
+	// Derived from finalized L1 data, but not necessarily
+	// verified by the superAuthority.
+	// Only to be used as a FinalizedHead when there is no superAuthority
 	localFinalizedHead eth.L2BlockRef
 	// The unsafe head to roll back to,
 	// after the pendingSafeHead fails to become safe.
@@ -267,26 +266,10 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 			e.log.Debug("super authority finalized l2 head is ahead of local safe head, using local safe head as FinalizedHead")
 			return e.localSafeHead
 		}
-		if e.localFinalizedHead != (eth.L2BlockRef{}) {
-			if f == e.localFinalizedHead.ID() {
-				return e.localFinalizedHead
-			}
-			if f.Number < e.localFinalizedHead.Number {
-				// SuperAuthority finality is expected to be monotonic. A lower
-				// finalized head means the authority is reporting stale state.
-				e.log.Error("superAuthority finalized head is behind cached finalized head, using cached finalized head", "super_authority_finalized", f, "cached_finalized", e.localFinalizedHead)
-				return e.localFinalizedHead
-			}
-			if f.Number == e.localFinalizedHead.Number {
-				panic("superAuthority finalized head conflicts with cached finalized head at same height")
-			}
-		}
 		br, err := e.engine.L2BlockRefByHash(e.ctx, f.Hash)
 		if err != nil {
-			e.log.Warn("superAuthority finalized head is not known to the engine, using cached finalized head", "super_authority_finalized", f, "cached_finalized", e.localFinalizedHead, "err", err)
-			return e.localFinalizedHead
+			panic("superAuthority supplied an identifier for the finalized head which is not known to the engine")
 		}
-		e.SetFinalizedHead(br)
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedFinalizedHead

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -125,6 +125,9 @@ type EngineController struct {
 	// verified by the superAuthority.
 	// Only to be used as a FinalizedHead when there is no superAuthority
 	localFinalizedHead eth.L2BlockRef
+	// Last successfully materialized superAuthority finalized head,
+	// used as a fallback when the authority or EL is temporarily unavailable.
+	superAuthorityFinalizedHead eth.L2BlockRef
 	// The unsafe head to roll back to,
 	// after the pendingSafeHead fails to become safe.
 	// This is changing in the Holocene fork.
@@ -266,10 +269,30 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 			e.log.Debug("super authority finalized l2 head is ahead of local safe head, using local safe head as FinalizedHead")
 			return e.localSafeHead
 		}
+		if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+			if f == e.superAuthorityFinalizedHead.ID() {
+				return e.superAuthorityFinalizedHead
+			}
+			if f.Number < e.superAuthorityFinalizedHead.Number {
+				// SuperAuthority finality is expected to be monotonic. A lower
+				// finalized head means the authority is reporting stale state.
+				e.log.Warn("superAuthority finalized head is behind cached superAuthority finalized head, using cached superAuthority finalized head", "super_authority_finalized", f, "cached_super_authority_finalized", e.superAuthorityFinalizedHead)
+				return e.superAuthorityFinalizedHead
+			}
+			if f.Number == e.superAuthorityFinalizedHead.Number {
+				panic("superAuthority finalized head conflicts with cached superAuthority finalized head at same height")
+			}
+		}
 		br, err := e.engine.L2BlockRefByHash(e.ctx, f.Hash)
 		if err != nil {
-			panic("superAuthority supplied an identifier for the finalized head which is not known to the engine")
+			if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+				e.log.Warn("superAuthority finalized head is not known to the engine, using cached superAuthority finalized head", "super_authority_finalized", f, "cached_super_authority_finalized", e.superAuthorityFinalizedHead, "err", err)
+				return e.superAuthorityFinalizedHead
+			}
+			e.log.Warn("superAuthority finalized head is not known to the engine and no cached superAuthority finalized head is available", "super_authority_finalized", f, "err", err)
+			return eth.L2BlockRef{}
 		}
+		e.superAuthorityFinalizedHead = br
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedFinalizedHead

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -848,7 +848,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 30},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 			},
@@ -893,18 +893,18 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			expectResult: &eth.L2BlockRef{},
 		},
 		{
-			name: "falls back to cached finalized when SuperAuthority block unknown to engine",
+			name: "panics when SuperAuthority block unknown to engine",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
 					finalizedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 			},
-			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			expectPanic: "superAuthority supplied an identifier for the finalized head which is not known to the engine",
 		},
 	}
 
@@ -945,60 +945,6 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) {
-	superAuth := &mockSuperAuthority{
-		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
-	}
-	mockEngine := &testutils.MockEngine{}
-	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
-	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
-	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30})
-
-	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
-	mockEngine.ExpectL2BlockRefByHash(common.Hash{0xbb}, finalizedRef, nil)
-
-	require.Equal(t, finalizedRef, ec.FinalizedHead())
-	require.Equal(t, finalizedRef, ec.localFinalizedHead)
-
-	superAuth.finalizedL2Head = eth.BlockID{Hash: common.Hash{0xcc}, Number: 60}
-	mockEngine.ExpectL2BlockRefByHash(common.Hash{0xcc}, eth.L2BlockRef{}, errors.New("temporary EL error"))
-
-	require.Equal(t, finalizedRef, ec.FinalizedHead())
-	require.Equal(t, finalizedRef, ec.localFinalizedHead)
-}
-
-func TestEngineController_FinalizedHeadDoesNotCacheLocalSafeFallback(t *testing.T) {
-	superAuth := &mockSuperAuthority{
-		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
-	}
-	mockEngine := &testutils.MockEngine{}
-	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
-	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 40}
-	cachedFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30}
-	ec.SetLocalSafeHead(localSafe)
-	ec.SetFinalizedHead(cachedFinalized)
-
-	require.Equal(t, localSafe, ec.FinalizedHead())
-	require.Equal(t, cachedFinalized, ec.localFinalizedHead)
-}
-
-func TestEngineController_FinalizedHeadPanicsOnSameHeightConflict(t *testing.T) {
-	superAuth := &mockSuperAuthority{
-		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
-	}
-	mockEngine := &testutils.MockEngine{}
-	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
-	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
-	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50})
-
-	require.PanicsWithValue(t, "superAuthority finalized head conflicts with cached finalized head at same height", func() {
-		ec.FinalizedHead()
-	})
 }
 
 // TestTryUpdateEngine_SyncingInCLModeTriggersReset tests that when the EL returns SYNCING

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -836,6 +836,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 		setupSuperAuth  func() *mockSuperAuthority
 		setupLocalSafe  *eth.L2BlockRef
 		setupLocalFinal *eth.L2BlockRef
+		setupSACache    *eth.L2BlockRef
 		setupEngine     func(*testutils.MockEngine)
 		expectPanic     string
 		expectResult    *eth.L2BlockRef
@@ -848,7 +849,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 30},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 			},
@@ -893,18 +894,33 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			expectResult: &eth.L2BlockRef{},
 		},
 		{
-			name: "panics when SuperAuthority block unknown to engine",
+			name: "returns empty when SuperAuthority block unknown to engine and no SuperAuthority cache exists",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
 					finalizedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 			},
-			expectPanic: "superAuthority supplied an identifier for the finalized head which is not known to the engine",
+			expectResult: &eth.L2BlockRef{},
+		},
+		{
+			name: "falls back to cached SuperAuthority finalized when SuperAuthority block unknown to engine",
+			setupSuperAuth: func() *mockSuperAuthority {
+				return &mockSuperAuthority{
+					finalizedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 60},
+				}
+			},
+			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			setupSACache:    &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 50},
+			setupEngine: func(m *testutils.MockEngine) {
+				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
+			},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 50},
 		},
 	}
 
@@ -930,6 +946,9 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			if tt.setupLocalFinal != nil {
 				ec.SetFinalizedHead(*tt.setupLocalFinal)
 			}
+			if tt.setupSACache != nil {
+				ec.superAuthorityFinalizedHead = *tt.setupSACache
+			}
 
 			if tt.setupEngine != nil {
 				tt.setupEngine(mockEngine)
@@ -945,6 +964,79 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30}
+	ec.SetFinalizedHead(localFinalized)
+
+	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	mockEngine.ExpectL2BlockRefByHash(common.Hash{0xbb}, finalizedRef, nil)
+
+	require.Equal(t, finalizedRef, ec.FinalizedHead())
+	require.Equal(t, localFinalized, ec.localFinalizedHead)
+	require.Equal(t, finalizedRef, ec.superAuthorityFinalizedHead)
+
+	superAuth.finalizedL2Head = eth.BlockID{Hash: common.Hash{0xcc}, Number: 60}
+	mockEngine.ExpectL2BlockRefByHash(common.Hash{0xcc}, eth.L2BlockRef{}, errors.New("temporary EL error"))
+
+	require.Equal(t, finalizedRef, ec.FinalizedHead())
+	require.Equal(t, localFinalized, ec.localFinalizedHead)
+	require.Equal(t, finalizedRef, ec.superAuthorityFinalizedHead)
+}
+
+func TestEngineController_FinalizedHeadDoesNotCacheLocalSafeFallback(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 40}
+	cachedFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30}
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(cachedFinalized)
+
+	require.Equal(t, localSafe, ec.FinalizedHead())
+	require.Equal(t, cachedFinalized, ec.localFinalizedHead)
+	require.Equal(t, eth.L2BlockRef{}, ec.superAuthorityFinalizedHead)
+}
+
+func TestEngineController_FinalizedHeadUsesCachedSuperAuthorityFinalizedWhenAuthorityRegresses(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 40},
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	cachedSuperAuthority := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50}
+	ec.superAuthorityFinalizedHead = cachedSuperAuthority
+
+	require.Equal(t, cachedSuperAuthority, ec.FinalizedHead())
+	require.Equal(t, cachedSuperAuthority, ec.superAuthorityFinalizedHead)
+}
+
+func TestEngineController_FinalizedHeadPanicsOnCachedSuperAuthoritySameHeightConflict(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuth)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	ec.superAuthorityFinalizedHead = eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50}
+
+	require.PanicsWithValue(t, "superAuthority finalized head conflicts with cached superAuthority finalized head at same height", func() {
+		ec.FinalizedHead()
+	})
 }
 
 // TestTryUpdateEngine_SyncingInCLModeTriggersReset tests that when the EL returns SYNCING


### PR DESCRIPTION
## Summary

This PR is split into two commits so the relationship to #20772 is explicit:

1. `revert op-node finalized cache`
   - mechanically reverts #20772's finalized-cache behavior
   - restores `localFinalizedHead` to its pre-cache meaning
   - removes the `SetFinalizedHead(br)` update that #20772 added in the superAuthority path

2. `fix(op-node): cache super authority finalized head separately`
   - adds a net-new `superAuthorityFinalizedHead` cache
   - uses that cache for superAuthority finalized regression / EL lookup fallback
   - leaves `localFinalizedHead` untouched when materializing a superAuthority finalized ref
   - updates tests to cover the dedicated cache path

## Motivation

#20772 added caching in `FinalizedHead()`, but it reused `localFinalizedHead`. That field is also written by startup, reset, follow-source, and promotion paths, so it can look like superAuthority produced a value that actually came from local engine/controller state.

This PR first backs out that reuse, then reintroduces the cache as a dedicated superAuthority-specific value.

## Testing

- `go test ./op-node/rollup/engine`
- `git diff --check`
