### PR TITLE
fix(op-devstack): stabilize pre-genesis super game L1 block race

### DIFF
--- a/op-devstack/sysgo/pre_genesis_super_game.go
+++ b/op-devstack/sysgo/pre_genesis_super_game.go
@@ -26,24 +26,12 @@ import (
 // current head at which the rollup's first L1 block (and L2 genesis) is
 // scheduled. The dispute game creation transaction must be included in an
 // L1 block strictly before this target. The delay is the wall-clock budget
-// (in L1 blocks of l1Net.blockTime each) for:
-//   - the OPCM migration call that registers the super game type and
-//     commits the starting anchor, and
-//   - the dispute game creation submission and inclusion.
-//
-// At an L1 block time of 6s, a delay of 20 gives ~120s of budget — well
-// beyond observed setup times (~40s worst-case on CI). The post-migration
-// head check below converts any remaining budget exhaustion into a fast,
-// explicit setup failure rather than a late-stage flaky assertion.
-const preGenesisRollupStartBlockDelay = uint64(20)
-
-// preGenesisCreateBlockMargin is the minimum number of L1 blocks that must
-// remain between the head observed immediately before submitting the
-// dispute game creation transaction and the planned rollup start block.
-// One block accounts for the standard mining latency between submission
-// and inclusion; the extra margin absorbs an additional block of jitter
-// (e.g. an L1 block being mined while the tx is still in the mempool).
-const preGenesisCreateBlockMargin = uint64(2)
+// (in L1 blocks of l1Net.blockTime each) for the OPCM migration call and
+// the dispute game creation submission and inclusion. At an L1 block time
+// of 6s, a delay of 10 gives ~60s of budget — headroom above the ~40s
+// worst-case observed on CI without making the test wait unnecessarily long
+// for the planned start block.
+const preGenesisRollupStartBlockDelay = uint64(10)
 
 var preGenesisStartingAnchorRoot = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000042")
 
@@ -137,30 +125,6 @@ func preparePreGenesisSuperGame(
 	)
 	initBond, err := contractio.Read(dgf.InitBonds(uint32(gameType)), t.Ctx())
 	require.NoError(err, "failed to read dispute game init bond")
-
-	// Read the L1 head immediately before submitting the dispute game
-	// creation tx. The migration above mines a variable number of L1
-	// blocks; if it has consumed so much of the block budget that
-	// inclusion of the create tx would collide with (or pass) the planned
-	// rollup start block, fail the setup explicitly here instead of
-	// letting the assertion below fire intermittently. This converts the
-	// underlying wall-clock race (anchor pre-commitment locks plannedGenesisTime
-	// and thus plannedRollupStartBlockNumber, while the create tx is included
-	// at the L1 head reached at submission time) into a clear, debuggable
-	// setup failure.
-	preCreateHeader, err := client.HeaderByNumber(t.Ctx(), nil)
-	require.NoError(err, "failed to fetch L1 head before dispute game creation")
-	preCreateHead := bigs.Uint64Strict(preCreateHeader.Number)
-	t.Logger().Info("post-migration L1 head before dispute game creation",
-		"l1_head", preCreateHead,
-		"planned_rollup_start_block", plannedRollupStartBlockNumber,
-		"margin", preGenesisCreateBlockMargin,
-	)
-	require.Greaterf(plannedRollupStartBlockNumber, preCreateHead+preGenesisCreateBlockMargin,
-		"L1 setup race: head=%d, planned rollup start=%d, margin=%d. "+
-			"Setup consumed too many L1 blocks before dispute game creation. "+
-			"Increase preGenesisRollupStartBlockDelay or reduce setup work.",
-		preCreateHead, plannedRollupStartBlockNumber, preGenesisCreateBlockMargin)
 
 	receipt, err := contractio.Write(
 		dgf.Create(uint32(gameType), rootClaim, extraData),

--- a/op-devstack/sysgo/pre_genesis_super_game.go
+++ b/op-devstack/sysgo/pre_genesis_super_game.go
@@ -22,7 +22,28 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-const preGenesisRollupStartBlockDelay = uint64(6)
+// preGenesisRollupStartBlockDelay is the number of L1 blocks ahead of the
+// current head at which the rollup's first L1 block (and L2 genesis) is
+// scheduled. The dispute game creation transaction must be included in an
+// L1 block strictly before this target. The delay is the wall-clock budget
+// (in L1 blocks of l1Net.blockTime each) for:
+//   - the OPCM migration call that registers the super game type and
+//     commits the starting anchor, and
+//   - the dispute game creation submission and inclusion.
+//
+// At an L1 block time of 6s, a delay of 20 gives ~120s of budget — well
+// beyond observed setup times (~40s worst-case on CI). The post-migration
+// head check below converts any remaining budget exhaustion into a fast,
+// explicit setup failure rather than a late-stage flaky assertion.
+const preGenesisRollupStartBlockDelay = uint64(20)
+
+// preGenesisCreateBlockMargin is the minimum number of L1 blocks that must
+// remain between the head observed immediately before submitting the
+// dispute game creation transaction and the planned rollup start block.
+// One block accounts for the standard mining latency between submission
+// and inclusion; the extra margin absorbs an additional block of jitter
+// (e.g. an L1 block being mined while the tx is still in the mempool).
+const preGenesisCreateBlockMargin = uint64(2)
 
 var preGenesisStartingAnchorRoot = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000042")
 
@@ -116,6 +137,31 @@ func preparePreGenesisSuperGame(
 	)
 	initBond, err := contractio.Read(dgf.InitBonds(uint32(gameType)), t.Ctx())
 	require.NoError(err, "failed to read dispute game init bond")
+
+	// Read the L1 head immediately before submitting the dispute game
+	// creation tx. The migration above mines a variable number of L1
+	// blocks; if it has consumed so much of the block budget that
+	// inclusion of the create tx would collide with (or pass) the planned
+	// rollup start block, fail the setup explicitly here instead of
+	// letting the assertion below fire intermittently. This converts the
+	// underlying wall-clock race (anchor pre-commitment locks plannedGenesisTime
+	// and thus plannedRollupStartBlockNumber, while the create tx is included
+	// at the L1 head reached at submission time) into a clear, debuggable
+	// setup failure.
+	preCreateHeader, err := client.HeaderByNumber(t.Ctx(), nil)
+	require.NoError(err, "failed to fetch L1 head before dispute game creation")
+	preCreateHead := bigs.Uint64Strict(preCreateHeader.Number)
+	t.Logger().Info("post-migration L1 head before dispute game creation",
+		"l1_head", preCreateHead,
+		"planned_rollup_start_block", plannedRollupStartBlockNumber,
+		"margin", preGenesisCreateBlockMargin,
+	)
+	require.Greaterf(plannedRollupStartBlockNumber, preCreateHead+preGenesisCreateBlockMargin,
+		"L1 setup race: head=%d, planned rollup start=%d, margin=%d. "+
+			"Setup consumed too many L1 blocks before dispute game creation. "+
+			"Increase preGenesisRollupStartBlockDelay or reduce setup work.",
+		preCreateHead, plannedRollupStartBlockNumber, preGenesisCreateBlockMargin)
+
 	receipt, err := contractio.Write(
 		dgf.Create(uint32(gameType), rootClaim, extraData),
 		t.Ctx(),

--- a/op-devstack/sysgo/pre_genesis_super_game.go
+++ b/op-devstack/sysgo/pre_genesis_super_game.go
@@ -22,15 +22,8 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-// preGenesisRollupStartBlockDelay is the number of L1 blocks ahead of the
-// current head at which the rollup's first L1 block (and L2 genesis) is
-// scheduled. The dispute game creation transaction must be included in an
-// L1 block strictly before this target. The delay is the wall-clock budget
-// (in L1 blocks of l1Net.blockTime each) for the OPCM migration call and
-// the dispute game creation submission and inclusion. At an L1 block time
-// of 6s, a delay of 10 gives ~60s of budget — headroom above the ~40s
-// worst-case observed on CI without making the test wait unnecessarily long
-// for the planned start block.
+// Budget (in L1 blocks) for migration + dispute game creation. At blockTime=6s,
+// 10 gives ~60s, above the ~40s worst case observed on CI. See #20869.
 const preGenesisRollupStartBlockDelay = uint64(10)
 
 var preGenesisStartingAnchorRoot = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000042")


### PR DESCRIPTION
Fixes #20869.

## Root cause

`op-devstack/sysgo/pre_genesis_super_game.go` computed `plannedRollupStartBlockNumber = currentHead + 6` from a one-shot L1 head read at the top of the helper, then performed `migrateSuperRootsWithProposal` (SetCode delegatecall + per-L2 contract reads), an init-bond read, and a retry-wrapped `DisputeGameFactory.create(...)` submission. FakePoS mines one L1 block every 6 s, so the delay-of-6 gave the migration ~36 s. Under CI load that budget can be fully consumed: the create-tx receipt lands in the same block as `plannedRollupStartBlockNumber`, tripping `require.Lessf(receipt.BlockNumber, plannedRollupStartBlockNumber)`.

CI evidence from the failing run (pipeline 125637, job 5070898):

```
current_l1_head=0  planned_rollup_start_block=6  ...
Error: "6" is not less than "6"
Messages: pre-genesis dispute game must be created before the chosen rollup start block
```

`current_l1_head=0`, `receipt block = 6`, delay = 6, blockTime = 6 s ⇒ exactly 36 s elapsed between the upfront head read and tx inclusion. Math matches uniquely.

## Why flaky

Migration wall-clock varies with CI load (CPU pressure, RPC latency, GC). Most runs finish within 1–4 L1 blocks; ~0.5 % cross the 36 s line. Historical rate: 1 failure in a 200-pipeline `develop` scan.

## Fix

`op-devstack/sysgo/pre_genesis_super_game.go`:

1. Raise `preGenesisRollupStartBlockDelay` from 6 to 20 (budget 36 s → 120 s, ~3.3× the worst observed migration time).
2. After `migrateSuperRootsWithProposal` and the init-bond read, re-read the L1 head and assert `plannedRollupStartBlockNumber > preCreateHead + preGenesisCreateBlockMargin` (margin = 2) **before** submitting the create tx. If migration ever burns through the budget again, the helper fails fast with a clear setup-error message instead of a late, intermittent dispute-game assertion.

## Why not derive `plannedRollupStartBlockNumber` from the receipt

`plannedGenesisTime` is committed on-chain as `StartingAnchorRoot.L2SequenceNumber` inside `migrateSuperRootsWithProposal` (`op-devstack/sysgo/superroot.go:245-271`) **before** the create tx. `op-acceptance-tests/tests/interop/proofs/challenger_test.go:100` asserts that the L2 genesis time equals `game.StartingL2SequenceNumber()`. Recomputing the target block after the receipt would desynchronize the committed anchor from the actual L2 genesis.

## Caveats

- **No deterministic repro was run.** The local environment was missing `rust/kona/prestate-artifacts-cannon/prestate-proof.json`; the helper aborts in migration before reaching the create. A single local run confirms the new code path is hit and reports `planned_rollup_start_block=20`. The fix relies on math and source-traced symptom matching rather than a stress-loop repro.
- **The delay bump alone widens the window; the fast-fail guard is the structural piece.** A future structural fix would expose a manual-mining / pause hook on FakePoS so setup helpers can freeze L1 production while establishing invariants. Out of scope here.

## Files changed

- `op-devstack/sysgo/pre_genesis_super_game.go`