### PR TITLE
docs: clarify permissioned vs permissionless lookback for op-reth historical proofs

### DIFF
--- a/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
+++ b/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
@@ -6,6 +6,13 @@ description: Learn how to initialize and run op-reth with the historical proof s
 As part of the op-geth deprecation, all existing op-geth services are migrating to op-reth. This guide covers how to set up an op-reth node with the **proofs-history** historical proof store, using storage format **v2**, to efficiently compute historical proofs within a configurable retention window.
 
 <Info>
+**Do you need this tutorial?** Withdrawal proving on op-reth uses `eth_getProof` against historical L2 state, so both permissioned and permissionless chains need historical state exposed — but the required lookback differs sharply:
+
+- **Permissioned chains** only need a few hours of lookback (covering your dispute-game publishing cadence with margin). The lighter `--rpc.eth-proof-window <num_blocks>` flag is sufficient on its own — no separate proofs database is needed, and **this tutorial does not apply**. See the [op-reth configuration reference](/node-operators/reference/op-reth-config#rpc-eth-proof-window) for that flag.
+- **Permissionless chains** need ~28 days of lookback. `--rpc.eth-proof-window` becomes too slow and memory-hungry at that range, so follow this tutorial to set up `--proofs-history` (v2).
+</Info>
+
+<Info>
 Use historical proofs storage format v2 by setting `--proofs-history.storage-version=v2` when running `op-reth node`.
 </Info>
 
@@ -97,7 +104,7 @@ Initialize the separate storage used by the historical proof store to persist hi
 ```
 
 <Info>
-The first time `proofs init` runs, it takes minutes to hours to complete. Subsequent invocations should only take seconds. It does **not** backfill historical proofs — it simply marks the current chain tip as the starting point of the proofs database. Once the node is running with `--proofs-history`, the proofs database fills forward as new blocks are committed. To serve proofs across the full retention window (e.g., 30 days for fault proofs at default settings), the node must run continuously for at least that long after initialization. For that reason it is recommended to start from a snapshot whose tip is old enough to cover the required time window, so that when the node starts syncing from the snapshot's tip, the full window is covered.
+The first time `proofs init` runs, it takes minutes to hours to complete. Subsequent invocations should only take seconds. It does **not** backfill historical proofs — it simply marks the current chain tip as the starting point of the proofs database. Once the node is running with `--proofs-history`, the proofs database fills forward as new blocks are committed. To serve proofs across the full retention window (e.g., 30 days for permissionless fault proofs at default settings), the node must run continuously for at least that long after initialization. For that reason it is recommended to start from a snapshot whose tip is old enough to cover the required time window, so that when the node starts syncing from the snapshot's tip, the full window is covered.
 </Info>
 
 ## Running op-reth

--- a/docs/public-docs/notices/op-geth-deprecation.mdx
+++ b/docs/public-docs/notices/op-geth-deprecation.mdx
@@ -55,7 +55,7 @@ Syncing an op-reth node as soon as possible helps ensure a snapshot is available
 
 Historical L2 state on op-reth is required for **permissioned chains as well**, not just permissionless. Withdrawal proving calls `eth_getProof` on the L2 block where the withdrawal was included regardless of your dispute-game model — op-geth handled this via archive state, and op-reth needs equivalent configuration. Permissioned chains need only a few hours of lookback (covered by option 1 below, without a historical proofs database); permissionless chains need ~28 days. Two options:
 
-- `--rpc.eth-proof-window <num_blocks>` — no historical proofs database, but performance and memory cost grow the further back you query. Size to cover your dispute-game publishing cadence with margin.
+- `--rpc.eth-proof-window <num_blocks>` — no historical proofs database (ExEx), but performance and memory cost grow the further back you query. Size to cover your dispute-game publishing cadence with margin.
 - `--proofs-history` — bounded memory, but storage-heavy. The default `--proofs-history.window` is 1,296,000 blocks (~30 days at 2s block time); adjust if your chain's block time differs.
 
 See [how to run historical proofs with op-reth](https://docs.optimism.io/node-operators/tutorials/reth-historical-proofs) for sizing guidance and configuration details.

--- a/docs/public-docs/notices/op-geth-deprecation.mdx
+++ b/docs/public-docs/notices/op-geth-deprecation.mdx
@@ -53,9 +53,9 @@ For OP Mainnet snapshots, you can find [snapshots here](https://datadirs.optimis
 As soon as op-reth is fully synced, take a snapshot. Refresh it regularly as Glamsterdam approaches.
 Syncing an op-reth node as soon as possible helps ensure a snapshot is available for other validators on your chain so they do not need to sync from scratch.
 
-Historical L2 state on op-reth is required for **permissioned chains as well**, not just permissionless. Withdrawal proving calls `eth_getProof` on the L2 block where the withdrawal was included regardless of your dispute-game model — op-geth handled this via archive state, and op-reth needs equivalent configuration. Two options:
+Historical L2 state on op-reth is required for **permissioned chains as well**, not just permissionless. Withdrawal proving calls `eth_getProof` on the L2 block where the withdrawal was included regardless of your dispute-game model — op-geth handled this via archive state, and op-reth needs equivalent configuration. Permissioned chains need only a few hours of lookback (covered by option 1 below, without a historical proofs database); permissionless chains need ~28 days. Two options:
 
-- `--rpc.eth-proof-window <num_blocks>` — no ExEx, but performance and memory cost grow the further back you query. Size to cover your dispute-game publishing cadence with margin.
+- `--rpc.eth-proof-window <num_blocks>` — no historical proofs database, but performance and memory cost grow the further back you query. Size to cover your dispute-game publishing cadence with margin.
 - `--proofs-history` — bounded memory, but storage-heavy. The default `--proofs-history.window` is 1,296,000 blocks (~30 days at 2s block time); adjust if your chain's block time differs.
 
 See [how to run historical proofs with op-reth](https://docs.optimism.io/node-operators/tutorials/reth-historical-proofs) for sizing guidance and configuration details.


### PR DESCRIPTION
## Summary

- Adds the clarification from the partner Slack thread: permissioned chains only need a few hours of historical-state lookback (covered by `--rpc.eth-proof-window` alone, no proofs DB), while permissionless chains need ~28 days.
- Replaces "no ExEx" with "no historical proofs database" so the bullet reads without prior knowledge of reth ExEx terminology.

Aligns the [op-geth deprecation notice](https://docs.optimism.io/notices/op-geth-deprecation) with the comms posted to partners. Existing "required for permissioned chains as well" line stays — the change is purely additive clarification.

## Test plan

- [ ] Mintlify dev preview renders the updated paragraph and bullets correctly (`/notices/op-geth-deprecation`)
- [ ] Linked [historical proofs tutorial](https://docs.optimism.io/node-operators/tutorials/reth-historical-proofs) still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)