### PR TITLE
fix(kona-node): carry L2 hash through finalization

### DIFF
--- a/rust/kona/crates/node/engine/src/lib.rs
+++ b/rust/kona/crates/node/engine/src/lib.rs
@@ -42,8 +42,8 @@ mod task_queue;
 pub use task_queue::{
     BuildTask, BuildTaskError, ConsolidateInput, ConsolidateTask, ConsolidateTaskError, Engine,
     EngineBuildError, EngineResetError, EngineTask, EngineTaskError, EngineTaskErrorSeverity,
-    EngineTaskErrors, EngineTaskExt, FinalizeTask, FinalizeTaskError, InsertTask, InsertTaskError,
-    SealTask, SealTaskError, SynchronizeTask, SynchronizeTaskError,
+    EngineTaskErrors, EngineTaskExt, FinalizeBlockId, FinalizeTask, FinalizeTaskError, InsertTask,
+    InsertTaskError, SealTask, SealTaskError, SynchronizeTask, SynchronizeTaskError,
 };
 
 mod attributes;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/finalize/id.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/finalize/id.rs
@@ -1,0 +1,36 @@
+//! Identifier for the L2 block that a [`crate::FinalizeTask`] should finalize.
+
+use alloy_eips::BlockNumHash;
+
+/// Identifies the L2 block to finalize.
+///
+/// Two semantic regimes drive finalization in kona-node:
+///
+/// - [`FinalizeBlockId::ByNumber`] is used when the engine's own canonical chain is the
+///   authoritative source for the block at a given height (e.g. local L1-finality driven by
+///   `L2Finalizer`). The number is sufficient because there is only one chain to consult.
+/// - [`FinalizeBlockId::ByHash`] is used when an upstream supplies `(number, hash)` and the engine
+///   must finalize the specific block identified by hash. If the engine does not have that hash,
+///   the task must error rather than silently finalize the engine's canonical block at the same
+///   height.
+///
+/// EL finalization is irreversible, so finalizing the wrong block is unrecoverable. Forcing every
+/// caller to pick a variant prevents accidental hash-loss at the boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FinalizeBlockId {
+    /// Finalize whatever block the engine has at the given L2 block number.
+    ByNumber(u64),
+    /// Finalize the block matching the given `(number, hash)` pair. The task fails if the engine
+    /// does not have that hash.
+    ByHash(BlockNumHash),
+}
+
+impl FinalizeBlockId {
+    /// Returns the L2 block number identified by this id.
+    pub const fn number(&self) -> u64 {
+        match self {
+            Self::ByNumber(n) => *n,
+            Self::ByHash(id) => id.number,
+        }
+    }
+}

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/finalize/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/finalize/mod.rs
@@ -5,3 +5,9 @@ pub use task::FinalizeTask;
 
 mod error;
 pub use error::FinalizeTaskError;
+
+mod id;
+pub use id::FinalizeBlockId;
+
+#[cfg(test)]
+mod task_test;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/finalize/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/finalize/task.rs
@@ -1,25 +1,26 @@
 //! A task for finalizing an L2 block.
 
 use crate::{
-    EngineClient, EngineState, EngineTaskExt, FinalizeTaskError, SynchronizeTask,
+    EngineClient, EngineState, EngineTaskExt, FinalizeBlockId, FinalizeTaskError, SynchronizeTask,
     state::EngineSyncStateUpdate,
 };
+use alloy_eips::BlockId;
 use async_trait::async_trait;
 use derive_more::Constructor;
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
 use std::{sync::Arc, time::Instant};
 
-/// The [`FinalizeTask`] fetches the [`L2BlockInfo`] at `block_number`, updates the [`EngineState`],
-/// and dispatches a forkchoice update to finalize the block.
+/// The [`FinalizeTask`] fetches the [`L2BlockInfo`] identified by `block_id`, updates the
+/// [`EngineState`], and dispatches a forkchoice update to finalize the block.
 #[derive(Debug, Clone, Constructor)]
 pub struct FinalizeTask<EngineClient_: EngineClient> {
     /// The engine client.
     pub client: Arc<EngineClient_>,
     /// The rollup config.
     pub cfg: Arc<RollupConfig>,
-    /// The number of the L2 block to finalize.
-    pub block_number: u64,
+    /// Identifier of the L2 block to finalize.
+    pub block_id: FinalizeBlockId,
 }
 
 #[async_trait]
@@ -29,22 +30,44 @@ impl<EngineClient_: EngineClient> EngineTaskExt for FinalizeTask<EngineClient_> 
     type Error = FinalizeTaskError;
 
     async fn execute(&self, state: &mut EngineState) -> Result<(), FinalizeTaskError> {
+        let block_number = self.block_id.number();
+
         // Sanity check that the block that is being finalized is at least safe.
-        if state.sync_state.safe_head().block_info.number < self.block_number {
+        if state.sync_state.safe_head().block_info.number < block_number {
             return Err(FinalizeTaskError::BlockNotSafe);
         }
+
+        // Look up by hash when the caller pinned a specific hash (delegated polling supplies
+        // `(number, hash)`); otherwise look up by number. Finalization is irreversible, so a stale
+        // hash must produce a hard error, not silently finalize whatever the engine has at the
+        // same height.
+        let lookup: BlockId = match self.block_id {
+            FinalizeBlockId::ByHash(id) => id.hash.into(),
+            FinalizeBlockId::ByNumber(n) => n.into(),
+        };
 
         let block_fetch_start = Instant::now();
         let block = self
             .client
-            .get_l2_block(self.block_number.into())
+            .get_l2_block(lookup)
             .full()
             .await
             .map_err(FinalizeTaskError::TransportError)?
-            .ok_or(FinalizeTaskError::BlockNotFound(self.block_number))?
+            .ok_or(FinalizeTaskError::BlockNotFound(block_number))?
             .into_consensus();
         let block_info = L2BlockInfo::from_block_and_genesis(&block, &self.client.cfg().genesis)
             .map_err(FinalizeTaskError::FromBlock)?;
+
+        // For ByHash, also assert the returned block's height matches the caller's claim. The
+        // engine should never serve a block at a different height for a given hash, but a height
+        // mismatch indicates either an upstream protocol bug or a misuse of the API and must
+        // never lead to silent finalization.
+        if let FinalizeBlockId::ByHash(id) = self.block_id &&
+            block_info.block_info.number != id.number
+        {
+            return Err(FinalizeTaskError::BlockNotFound(id.number));
+        }
+
         let block_fetch_duration = block_fetch_start.elapsed();
 
         // Dispatch a forkchoice update.

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/finalize/task_test.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/finalize/task_test.rs
@@ -1,0 +1,87 @@
+//! Tests for [`FinalizeTask::execute`].
+
+use crate::{
+    EngineTaskExt, FinalizeBlockId, FinalizeTask, FinalizeTaskError,
+    test_utils::{TestEngineStateBuilder, test_engine_client_builder},
+};
+use alloy_eips::{BlockId, BlockNumHash};
+use alloy_primitives::b256;
+use kona_genesis::RollupConfig;
+use kona_protocol::{BlockInfo, L2BlockInfo};
+use std::sync::Arc;
+
+/// When the engine receives a `ByHash` finalize request for a block hash it doesn't have,
+/// [`FinalizeTask`] must fail with [`FinalizeTaskError::BlockNotFound`] rather than silently
+/// finalize whatever it happens to have at the same height.
+///
+/// Reproduces the bug at [`crate::FinalizeTask`]: with the old `block_number: u64` field, the task
+/// looked up the block by number, so an upstream-driven `(N, H_b)` request would silently finalize
+/// `H_a` if the engine's canonical chain disagrees. EL finalization is irreversible, so this is
+/// unrecoverable.
+///
+/// Baseline (Phase 1, by-number lookup still in place): the task finds the engine's stale block at
+/// number `N` and returns a different error (or `Ok`), never [`FinalizeTaskError::BlockNotFound`].
+/// Post-fix (Phase 2, by-hash lookup): the lookup of `H_b` returns `None` and the task fails
+/// loudly.
+#[tokio::test]
+async fn finalize_task_by_hash_errors_when_engine_lacks_hash() {
+    const N: u64 = 10;
+    let hash_a = b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    let hash_b = b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+    // The engine has H_a at height N. Register the block under its number key so a by-number
+    // lookup finds it; do *not* register it under any hash key so a by-hash lookup of H_b returns
+    // None.
+    let block: alloy_rpc_types_eth::Block<op_alloy_rpc_types::Transaction> =
+        alloy_rpc_types_eth::Block {
+            header: alloy_rpc_types_eth::Header {
+                hash: hash_a,
+                inner: alloy_consensus::Header {
+                    number: N,
+                    parent_hash: b256!(
+                        "0202020202020202020202020202020202020202020202020202020202020202"
+                    ),
+                    timestamp: N * 2,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+    let cfg = Arc::new(RollupConfig::default());
+    let engine_client = test_engine_client_builder()
+        .with_config(cfg.clone())
+        .with_l2_block(BlockId::Number(N.into()), block)
+        .build();
+
+    // Place the safe head at N so the sanity check (`safe_head.number >= block_id.number`) passes
+    // and `execute()` reaches the lookup we care about.
+    let safe_head = L2BlockInfo {
+        block_info: BlockInfo {
+            number: N,
+            hash: hash_a,
+            parent_hash: Default::default(),
+            timestamp: N * 2,
+        },
+        l1_origin: BlockNumHash::default(),
+        seq_num: 0,
+    };
+    let mut state =
+        TestEngineStateBuilder::new().with_unsafe_head(safe_head).with_safe_head(safe_head).build();
+
+    let task = FinalizeTask::new(
+        Arc::new(engine_client),
+        cfg,
+        FinalizeBlockId::ByHash(BlockNumHash { number: N, hash: hash_b }),
+    );
+
+    let result = task.execute(&mut state).await;
+
+    assert!(
+        matches!(result, Err(FinalizeTaskError::BlockNotFound(n)) if n == N),
+        "expected BlockNotFound({N}) — got {result:?}. The by-hash lookup must fail loudly when \
+         the engine lacks the requested hash; instead, the task either succeeded (finalizing the \
+         wrong block) or surfaced a different error."
+    );
+}

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
@@ -21,7 +21,7 @@ mod consolidate;
 pub use consolidate::{ConsolidateInput, ConsolidateTask, ConsolidateTaskError};
 
 mod finalize;
-pub use finalize::{FinalizeTask, FinalizeTaskError};
+pub use finalize::{FinalizeBlockId, FinalizeTask, FinalizeTaskError};
 
 mod util;
 pub(super) use util::{BuildAndSealError, build_and_seal};

--- a/rust/kona/crates/node/service/src/actors/derivation/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/derivation/actor.rs
@@ -10,6 +10,7 @@ use kona_derive::{
     ActivationSignal, Pipeline, PipelineError, PipelineErrorKind, ResetError, Signal,
     SignalReceiver, StepResult,
 };
+use kona_engine::FinalizeBlockId;
 use kona_protocol::OpAttributesWithParent;
 use thiserror::Error;
 use tokio::{select, sync::mpsc};
@@ -189,8 +190,10 @@ where
                 // Attempt to finalize the block. If successful, notify engine.
                 if let Some(l2_block_number) = self.finalizer.try_finalize_next(*finalized_l1_block)
                 {
+                    // Local L1-finality: the engine's own canonical chain is the authoritative
+                    // source at this height, so finalize by number.
                     self.engine_client
-                        .send_finalized_l2_block(l2_block_number)
+                        .send_finalized_l2_block(FinalizeBlockId::ByNumber(l2_block_number))
                         .await
                         .map_err(|e| DerivationError::Sender(Box::new(e)))?;
                 }

--- a/rust/kona/crates/node/service/src/actors/derivation/delegated/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/derivation/delegated/actor.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use alloy_primitives::BlockHash;
 use async_trait::async_trait;
+use kona_engine::FinalizeBlockId;
 use kona_protocol::{L2BlockInfo, SyncStatus};
 use kona_providers_alloy::AlloyChainProvider;
 use thiserror::Error;
@@ -172,8 +173,13 @@ where
             .await
             .map_err(|e| DerivationError::Sender(Box::new(e)))?;
 
+        // Delegated polling supplies `(number, hash)`. Carry the hash through so the engine
+        // finalizes the specific block we were asked to, not whatever it happens to have at the
+        // same height.
         self.engine_client
-            .send_finalized_l2_block(sync_status.finalized_l2.block_info.number)
+            .send_finalized_l2_block(FinalizeBlockId::ByHash(
+                sync_status.finalized_l2.block_info.id(),
+            ))
             .await
             .map_err(|e| DerivationError::Sender(Box::new(e)))?;
 

--- a/rust/kona/crates/node/service/src/actors/derivation/engine_client.rs
+++ b/rust/kona/crates/node/service/src/actors/derivation/engine_client.rs
@@ -1,7 +1,7 @@
 use crate::{EngineActorRequest, EngineClientError, EngineClientResult, ResetRequest};
 use async_trait::async_trait;
 use derive_more::Constructor;
-use kona_engine::ConsolidateInput;
+use kona_engine::{ConsolidateInput, FinalizeBlockId};
 use std::fmt::Debug;
 use tokio::sync::mpsc;
 
@@ -12,9 +12,9 @@ pub trait DerivationEngineClient: Debug + Send + Sync {
     /// Resets the engine's forkchoice.
     async fn reset_engine_forkchoice(&self) -> EngineClientResult<()>;
 
-    /// Sends a request to finalize the L2 block at the provided block number.
+    /// Sends a request to finalize the L2 block identified by the provided [`FinalizeBlockId`].
     /// Note: This does not wait for the engine to process it.
-    async fn send_finalized_l2_block(&self, block_number: u64) -> EngineClientResult<()>;
+    async fn send_finalized_l2_block(&self, block_id: FinalizeBlockId) -> EngineClientResult<()>;
 
     /// Sends a consolidation signal to the engine.
     ///
@@ -54,10 +54,10 @@ impl DerivationEngineClient for QueuedDerivationEngineClient {
             })?
     }
 
-    async fn send_finalized_l2_block(&self, block_number: u64) -> EngineClientResult<()> {
-        trace!(target: "derivation", block_number, "Sending finalized L2 block number to engine.");
+    async fn send_finalized_l2_block(&self, block_id: FinalizeBlockId) -> EngineClientResult<()> {
+        trace!(target: "derivation", ?block_id, "Sending finalized L2 block id to engine.");
         self.engine_actor_request_tx
-            .send(EngineActorRequest::ProcessFinalizedL2BlockNumberRequest(Box::new(block_number)))
+            .send(EngineActorRequest::ProcessFinalizedL2BlockRequest(Box::new(block_id)))
             .await
             .map_err(|_| EngineClientError::RequestError("request channel closed.".to_string()))?;
 

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -143,8 +143,8 @@ where
                         EngineActorRequest::ProcessSafeL2SignalRequest(signal) => {
                             send_engine_processing_request(EngineProcessingRequest::ProcessSafeL2Signal(signal)).await?;
                         }
-                        EngineActorRequest::ProcessFinalizedL2BlockNumberRequest(block_number) => {
-                            send_engine_processing_request(EngineProcessingRequest::ProcessFinalizedL2BlockNumber(block_number)).await?;
+                        EngineActorRequest::ProcessFinalizedL2BlockRequest(block_id) => {
+                            send_engine_processing_request(EngineProcessingRequest::ProcessFinalizedL2Block(block_id)).await?;
                         }
                         EngineActorRequest::ProcessUnsafeL2BlockRequest(envelope) => {
                             send_engine_processing_request(EngineProcessingRequest::ProcessUnsafeL2Block(envelope)).await?;

--- a/rust/kona/crates/node/service/src/actors/engine/engine_request_processor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/engine_request_processor.rs
@@ -4,7 +4,7 @@ use crate::{
 use kona_derive::{ResetSignal, Signal};
 use kona_engine::{
     BuildTask, ConsolidateInput, ConsolidateTask, Engine, EngineClient, EngineTask,
-    EngineTaskError, EngineTaskErrorSeverity, FinalizeTask, InsertTask, SealTask,
+    EngineTaskError, EngineTaskErrorSeverity, FinalizeBlockId, FinalizeTask, InsertTask, SealTask,
 };
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
@@ -33,8 +33,8 @@ pub enum EngineProcessingRequest {
     Build(Box<BuildRequest>),
     /// Request to process a Safe signal, which can be derived attributes or delegated block info.
     ProcessSafeL2Signal(ConsolidateInput),
-    /// Request to process the finalized L2 block with the provided block number.
-    ProcessFinalizedL2BlockNumber(Box<u64>),
+    /// Request to process the finalized L2 block identified by the provided [`FinalizeBlockId`].
+    ProcessFinalizedL2Block(Box<FinalizeBlockId>),
     /// Request to process a received unsafe L2 block.
     ProcessUnsafeL2Block(Box<OpExecutionPayloadEnvelope>),
     /// Request to reset the forkchoice.
@@ -261,14 +261,12 @@ where
                         )));
                         self.engine.enqueue(task);
                     }
-                    EngineProcessingRequest::ProcessFinalizedL2BlockNumber(
-                        finalized_l2_block_number,
-                    ) => {
-                        // Finalize the L2 block at the provided block number.
+                    EngineProcessingRequest::ProcessFinalizedL2Block(finalized_l2_block_id) => {
+                        // Finalize the L2 block identified by the provided [`FinalizeBlockId`].
                         let task = EngineTask::Finalize(Box::new(FinalizeTask::new(
                             self.client.clone(),
                             self.rollup.clone(),
-                            *finalized_l2_block_number,
+                            *finalized_l2_block_id,
                         )));
                         self.engine.enqueue(task);
                     }

--- a/rust/kona/crates/node/service/src/actors/engine/request.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/request.rs
@@ -1,5 +1,7 @@
 use alloy_rpc_types_engine::PayloadId;
-use kona_engine::{BuildTaskError, ConsolidateInput, EngineQueries, SealTaskError};
+use kona_engine::{
+    BuildTaskError, ConsolidateInput, EngineQueries, FinalizeBlockId, SealTaskError,
+};
 use kona_protocol::OpAttributesWithParent;
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use thiserror::Error;
@@ -41,8 +43,8 @@ pub enum EngineActorRequest {
     /// Request to consolidate using a safe L2 signal from attributes or delegated safe-block
     /// derivation
     ProcessSafeL2SignalRequest(ConsolidateInput),
-    /// Request to finalize the L2 block at the provided block number.
-    ProcessFinalizedL2BlockNumberRequest(Box<u64>),
+    /// Request to finalize the L2 block identified by the provided [`FinalizeBlockId`].
+    ProcessFinalizedL2BlockRequest(Box<FinalizeBlockId>),
     /// Request to insert the provided unsafe block.
     ProcessUnsafeL2BlockRequest(Box<OpExecutionPayloadEnvelope>),
     /// Request to reset engine forkchoice.


### PR DESCRIPTION
`FinalizeTask` dropped the L2 block hash and finalized by number only. In delegated derivation mode the upstream supplies `(number, hash)` on every sync-status poll. If the upstream and the local engine disagree at that height (e.g. upstream reorg observed before our pipeline catches up), the engine silently finalized the wrong block. EL finalization is irreversible, so this is unrecoverable.

Fix: carry the hash end-to-end. New `FinalizeBlockId` enum with `ByHash(BlockNumHash)` / `ByNumber(u64)` variants threaded from the derivation actor through `EngineActorRequest` → `EngineProcessingRequest` → `FinalizeTask`. The delegated path switches to `ByHash`. When the engine lacks the requested hash, `FinalizeTask` now fails loudly with `FinalizeTaskError::BlockNotFound` instead of finalizing whatever it has at that height.

The local L1-finality path keeps `ByNumber`. Two reasons:
1. The derivation pipeline is the sole source of truth at that height; no second source can disagree.
2. `L2Finalizer` enqueues attributes *before* they're built, so the canonical L2 hash doesn't exist at enqueue time. Synthesizing one at finalize time would just be a by-number lookup with extra steps.

The two-variant enum encodes that semantic distinction.

## Test plan

- [x] New `finalize_task_by_hash_errors_when_engine_lacks_hash` reproduces
      the bug: registers block `hash_a` at height `N`, requests finalize of
      `ByHash(N, hash_b)`. Confirmed to **fail** on the pre-fix code path
      (by-number lookup silently fetched `hash_a` and proceeded
      downstream) and **pass** after the fix (`BlockNotFound(N)`).
- [x] `cargo nextest run --package kona-engine --package kona-node-service`:
      170/170 pass.

## Notes for reviewers

- Local-finality keeping `ByNumber` is deliberate. 
- `FinalizeTask::execute` also asserts the engine-returned block's height matches the caller's claim under `ByHash`. The engine shouldn't ever serve a block at a different height for a given hash, but a mismatch would indicate an upstream protocol bug or API misuse and must never lead to silent finalization.

Closes #20811