### PR TITLE
refactor(op-node): unify follow source metrics into single counter

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -83,7 +83,7 @@ type Metrics struct {
 	L1SourceCache *metrics.CacheMetrics
 	L2SourceCache *metrics.CacheMetrics
 
-	L2FollowSourceCache   *metrics.CacheMetrics
+	L2FollowSourceCache  *metrics.CacheMetrics
 	FollowSourceRequests *prometheus.CounterVec
 
 	DerivationIdle prometheus.Gauge

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -32,7 +32,7 @@ type Metricer interface {
 	SetDerivationIdle(status bool)
 	SetSequencerState(active bool)
 	RecordPipelineReset()
-	RecordFollowSourceError(reason string)
+	RecordFollowSourceRequest(result string)
 	RecordSequencingError()
 	RecordPublishingError()
 	RecordDerivationError()
@@ -84,8 +84,7 @@ type Metrics struct {
 	L2SourceCache *metrics.CacheMetrics
 
 	L2FollowSourceCache   *metrics.CacheMetrics
-	FollowSourceErrors    *prometheus.CounterVec
-	FollowSourceSuccesses prometheus.Counter
+	FollowSourceRequests *prometheus.CounterVec
 
 	DerivationIdle prometheus.Gauge
 
@@ -190,16 +189,11 @@ func NewMetrics(procName string, labels prometheus.Labels) *Metrics {
 		L2SourceCache: metrics.NewCacheMetrics(factory, ns, "l2_source_cache", "L2 Source cache"),
 
 		L2FollowSourceCache: metrics.NewCacheMetrics(factory, ns, "l2_follow_source_cache", "L2 Follow source cache"),
-		FollowSourceErrors: factory.NewCounterVec(prometheus.CounterOpts{
+		FollowSourceRequests: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: ns,
-			Name:      "follow_source_errors_total",
-			Help:      "Count of follow source errors by reason",
-		}, []string{"reason"}),
-		FollowSourceSuccesses: factory.NewCounter(prometheus.CounterOpts{
-			Namespace: ns,
-			Name:      "follow_source_successes_total",
-			Help:      "Count of successful follow source updates",
-		}),
+			Name:      "follow_source_requests_total",
+			Help:      "Count of follow source requests by result",
+		}, []string{"result"}),
 
 		DerivationIdle: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
@@ -487,12 +481,8 @@ func (m *Metrics) RecordSequencerInconsistentL1Origin(from eth.BlockID, to eth.B
 	m.RecordRef("l1_origin", "inconsistent_to", to.Number, 0, to.Hash)
 }
 
-func (m *Metrics) RecordFollowSourceError(reason string) {
-	m.FollowSourceErrors.WithLabelValues(reason).Inc()
-}
-
-func (m *Metrics) RecordFollowSourceSuccess() {
-	m.FollowSourceSuccesses.Inc()
+func (m *Metrics) RecordFollowSourceRequest(result string) {
+	m.FollowSourceRequests.WithLabelValues(result).Inc()
 }
 
 func (m *Metrics) RecordSequencerReset() {
@@ -658,10 +648,7 @@ func (m *noopMetricer) SetSequencerState(active bool) {
 func (n *noopMetricer) RecordPipelineReset() {
 }
 
-func (n *noopMetricer) RecordFollowSourceError(reason string) {
-}
-
-func (n *noopMetricer) RecordFollowSourceSuccess() {
+func (n *noopMetricer) RecordFollowSourceRequest(result string) {
 }
 
 func (n *noopMetricer) RecordSequencingError() {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -490,26 +490,26 @@ func (s *Driver) followUpstream() {
 	status, err := s.upstreamFollowSource.GetFollowStatus(s.driverCtx)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to fetch status", "err", err)
-		s.metrics.RecordFollowSourceRequest("fetch_status")
+		s.metrics.RecordFollowSourceRequest("error_fetch_status")
 		return
 	}
 	s.log.Info("Follow Upstream", "eSafe", status.SafeL2, "eLocalSafe", status.LocalSafeL2, "eFinalized", status.FinalizedL2, "eCurrentL1", status.CurrentL1)
 	if status.SafeL2.Number > status.LocalSafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, safe is ahead of local safe",
 			"safe", status.SafeL2.Number, "localSafe", status.LocalSafeL2.Number)
-		s.metrics.RecordFollowSourceRequest("invalid_state")
+		s.metrics.RecordFollowSourceRequest("error_invalid_state")
 		return
 	}
 	if status.FinalizedL2.Number > status.SafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, finalized is ahead of safe", "safe", status.SafeL2.Number, "finalized", status.FinalizedL2.Number)
-		s.metrics.RecordFollowSourceRequest("invalid_state")
+		s.metrics.RecordFollowSourceRequest("error_invalid_state")
 		return
 	}
 
 	eLocalSafeL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.LocalSafeL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external local safe head", "err", err)
-		s.metrics.RecordFollowSourceRequest("l1_lookup")
+		s.metrics.RecordFollowSourceRequest("error_l1_lookup")
 		return
 	}
 	if eLocalSafeL1Origin.Hash != status.LocalSafeL2.L1Origin.Hash {
@@ -518,14 +518,14 @@ func (s *Driver) followUpstream() {
 			"actual", eLocalSafeL1Origin,
 			"expected", status.LocalSafeL2.L1Origin,
 		)
-		s.metrics.RecordFollowSourceRequest("l1_mismatch")
+		s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
 		return
 	}
 
 	eSafeL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.SafeL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external safe head", "err", err)
-		s.metrics.RecordFollowSourceRequest("l1_lookup")
+		s.metrics.RecordFollowSourceRequest("error_l1_lookup")
 		return
 	}
 	if eSafeL1Origin.Hash != status.SafeL2.L1Origin.Hash {
@@ -534,14 +534,14 @@ func (s *Driver) followUpstream() {
 			"actual", eSafeL1Origin,
 			"expected", status.SafeL2.L1Origin,
 		)
-		s.metrics.RecordFollowSourceRequest("l1_mismatch")
+		s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
 		return
 	}
 
 	eFinalizedL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.FinalizedL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external finalized head", "err", err)
-		s.metrics.RecordFollowSourceRequest("l1_lookup")
+		s.metrics.RecordFollowSourceRequest("error_l1_lookup")
 		return
 	}
 	if eFinalizedL1Origin.Hash != status.FinalizedL2.L1Origin.Hash {
@@ -550,7 +550,7 @@ func (s *Driver) followUpstream() {
 			"actual", eFinalizedL1Origin,
 			"expected", status.FinalizedL2.L1Origin,
 		)
-		s.metrics.RecordFollowSourceRequest("l1_mismatch")
+		s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
 		return
 	}
 
@@ -560,7 +560,7 @@ func (s *Driver) followUpstream() {
 		eCurrentL1, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.CurrentL1.Number)
 		if err != nil {
 			s.log.Warn("Follow Upstream: Failed to look up external currentL1", "err", err)
-			s.metrics.RecordFollowSourceRequest("l1_lookup")
+			s.metrics.RecordFollowSourceRequest("error_l1_lookup")
 			return
 		}
 		if eCurrentL1.Hash != status.CurrentL1.Hash {
@@ -569,7 +569,7 @@ func (s *Driver) followUpstream() {
 				"actual", eCurrentL1,
 				"expected", status.CurrentL1,
 			)
-			s.metrics.RecordFollowSourceRequest("l1_mismatch")
+			s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
 			return
 		}
 

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -490,26 +490,26 @@ func (s *Driver) followUpstream() {
 	status, err := s.upstreamFollowSource.GetFollowStatus(s.driverCtx)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to fetch status", "err", err)
-		s.metrics.RecordFollowSourceError("fetch_status")
+		s.metrics.RecordFollowSourceRequest("fetch_status")
 		return
 	}
 	s.log.Info("Follow Upstream", "eSafe", status.SafeL2, "eLocalSafe", status.LocalSafeL2, "eFinalized", status.FinalizedL2, "eCurrentL1", status.CurrentL1)
 	if status.SafeL2.Number > status.LocalSafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, safe is ahead of local safe",
 			"safe", status.SafeL2.Number, "localSafe", status.LocalSafeL2.Number)
-		s.metrics.RecordFollowSourceError("invalid_state")
+		s.metrics.RecordFollowSourceRequest("invalid_state")
 		return
 	}
 	if status.FinalizedL2.Number > status.SafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, finalized is ahead of safe", "safe", status.SafeL2.Number, "finalized", status.FinalizedL2.Number)
-		s.metrics.RecordFollowSourceError("invalid_state")
+		s.metrics.RecordFollowSourceRequest("invalid_state")
 		return
 	}
 
 	eLocalSafeL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.LocalSafeL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external local safe head", "err", err)
-		s.metrics.RecordFollowSourceError("l1_lookup")
+		s.metrics.RecordFollowSourceRequest("l1_lookup")
 		return
 	}
 	if eLocalSafeL1Origin.Hash != status.LocalSafeL2.L1Origin.Hash {
@@ -518,14 +518,14 @@ func (s *Driver) followUpstream() {
 			"actual", eLocalSafeL1Origin,
 			"expected", status.LocalSafeL2.L1Origin,
 		)
-		s.metrics.RecordFollowSourceError("l1_mismatch")
+		s.metrics.RecordFollowSourceRequest("l1_mismatch")
 		return
 	}
 
 	eSafeL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.SafeL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external safe head", "err", err)
-		s.metrics.RecordFollowSourceError("l1_lookup")
+		s.metrics.RecordFollowSourceRequest("l1_lookup")
 		return
 	}
 	if eSafeL1Origin.Hash != status.SafeL2.L1Origin.Hash {
@@ -534,14 +534,14 @@ func (s *Driver) followUpstream() {
 			"actual", eSafeL1Origin,
 			"expected", status.SafeL2.L1Origin,
 		)
-		s.metrics.RecordFollowSourceError("l1_mismatch")
+		s.metrics.RecordFollowSourceRequest("l1_mismatch")
 		return
 	}
 
 	eFinalizedL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.FinalizedL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external finalized head", "err", err)
-		s.metrics.RecordFollowSourceError("l1_lookup")
+		s.metrics.RecordFollowSourceRequest("l1_lookup")
 		return
 	}
 	if eFinalizedL1Origin.Hash != status.FinalizedL2.L1Origin.Hash {
@@ -550,7 +550,7 @@ func (s *Driver) followUpstream() {
 			"actual", eFinalizedL1Origin,
 			"expected", status.FinalizedL2.L1Origin,
 		)
-		s.metrics.RecordFollowSourceError("l1_mismatch")
+		s.metrics.RecordFollowSourceRequest("l1_mismatch")
 		return
 	}
 
@@ -560,7 +560,7 @@ func (s *Driver) followUpstream() {
 		eCurrentL1, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.CurrentL1.Number)
 		if err != nil {
 			s.log.Warn("Follow Upstream: Failed to look up external currentL1", "err", err)
-			s.metrics.RecordFollowSourceError("l1_lookup")
+			s.metrics.RecordFollowSourceRequest("l1_lookup")
 			return
 		}
 		if eCurrentL1.Hash != status.CurrentL1.Hash {
@@ -569,7 +569,7 @@ func (s *Driver) followUpstream() {
 				"actual", eCurrentL1,
 				"expected", status.CurrentL1,
 			)
-			s.metrics.RecordFollowSourceError("l1_mismatch")
+			s.metrics.RecordFollowSourceRequest("l1_mismatch")
 			return
 		}
 
@@ -577,6 +577,6 @@ func (s *Driver) followUpstream() {
 		s.emitter.Emit(s.driverCtx, derive.DeriverL1StatusEvent{Origin: status.CurrentL1})
 	}
 	// Only reach this point if all L1 checks passed
-	s.metrics.RecordFollowSourceSuccess()
+	s.metrics.RecordFollowSourceRequest("success")
 	s.SyncDeriver.Engine.FollowSource(status.SafeL2, status.LocalSafeL2, status.FinalizedL2)
 }

--- a/op-node/rollup/driver/interfaces.go
+++ b/op-node/rollup/driver/interfaces.go
@@ -16,8 +16,7 @@ import (
 
 type Metrics interface {
 	RecordPipelineReset()
-	RecordFollowSourceError(reason string)
-	RecordFollowSourceSuccess()
+	RecordFollowSourceRequest(result string)
 	RecordPublishingError()
 	RecordDerivationError()
 


### PR DESCRIPTION
## Summary
- Consolidates `follow_source_errors_total` (CounterVec) and `follow_source_successes_total` (Counter) into a single `follow_source_requests_total` CounterVec with a `result` label
- Enables percentage-based alerting: `rate(follow_source_requests_total{result="success"}[5m]) / sum(rate(follow_source_requests_total[5m]))` 
- Supersedes #20763 and the error metrics PR

Result label values: `success`, `fetch_status`, `invalid_state`, `l1_lookup`, `l1_mismatch`

## Test plan
- [x] `go build ./op-node/...` passes
- [x] `go vet ./op-node/...` passes
- [ ] Verify metric appears in `/metrics` endpoint with result labels
- [ ] Confirm Grafana queries can compute success rate from single metric