### PR TITLE
[codex] Add legacy supervisor RPC namespace flag

### DIFF
--- a/op-interop-filter/filter/config.go
+++ b/op-interop-filter/filter/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	ReorgRecoveryEnabled        bool          // If true, automatically rewinds reorg-triggered failsafe to finalized
 	Passthrough                 bool          // If true, all transactions pass through without filtering
 	LegacyCheckAccessListFormat bool          // If true, allows access list requests that omit executing chainID
+	LegacySupervisorNamespace   bool          // If true, exposes query RPC methods under the legacy supervisor namespace
 	RPCConcurrency              int           // Max concurrent RPC requests per chain (default: 100)
 	FetchConcurrency            int           // Number of blocks to fetch concurrently (default: 64)
 
@@ -147,6 +148,7 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 		ReorgRecoveryEnabled:        ctx.Bool(flags.ReorgRecoveryEnabledFlag.Name),
 		Passthrough:                 ctx.Bool(flags.DangerouslyEnablePassthroughFlag.Name),
 		LegacyCheckAccessListFormat: ctx.Bool(flags.SupportLegacyCheckAccessListFormatFlag.Name),
+		LegacySupervisorNamespace:   ctx.Bool(flags.SupportLegacySupervisorRPCNamespaceFlag.Name),
 		RPCConcurrency:              rpcConcurrency,
 		FetchConcurrency:            fetchConcurrency,
 		LogConfig:                   oplog.ReadCLIConfig(ctx),

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-// QueryFrontend handles supervisor query RPC methods
+// QueryFrontend handles interop query RPC methods.
 type QueryFrontend struct {
 	backend *Backend
 }

--- a/op-interop-filter/filter/jwt_auth_test.go
+++ b/op-interop-filter/filter/jwt_auth_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// testSupervisorAPI is a mock supervisor API for testing
-type testSupervisorAPI struct{}
+// testQueryAPI is a mock query API for testing.
+type testQueryAPI struct{}
 
-func (t *testSupervisorAPI) Ping(_ context.Context) string {
+func (t *testQueryAPI) Ping(_ context.Context) string {
 	return "pong"
 }
 
@@ -50,7 +50,7 @@ func TestDedicatedAdminRPCServer(t *testing.T) {
 	)
 	filterServer.AddAPI(rpc.API{
 		Namespace: "interop",
-		Service:   new(testSupervisorAPI),
+		Service:   new(testQueryAPI),
 	})
 
 	// Create admin server (JWT-protected)
@@ -133,7 +133,7 @@ func TestPublicAdminGetFailsafe(t *testing.T) {
 	)
 	filterServer.AddAPI(rpc.API{
 		Namespace: "interop",
-		Service:   new(testSupervisorAPI),
+		Service:   new(testQueryAPI),
 	})
 	filterServer.AddAPI(rpc.API{
 		Namespace: "admin",
@@ -157,7 +157,7 @@ func TestPublicAdminGetFailsafe(t *testing.T) {
 		require.Equal(t, false, res)
 	})
 
-	t.Run("supervisor API still works alongside public admin", func(t *testing.T) {
+	t.Run("interop API still works alongside public admin", func(t *testing.T) {
 		var res string
 		err := filterClient.Call(&res, "interop_ping")
 		require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestFilterAPIWithoutAdminServer(t *testing.T) {
 	)
 	filterServer.AddAPI(rpc.API{
 		Namespace: "interop",
-		Service:   new(testSupervisorAPI),
+		Service:   new(testQueryAPI),
 	})
 
 	require.NoError(t, filterServer.Start())

--- a/op-interop-filter/filter/rpc_test.go
+++ b/op-interop-filter/filter/rpc_test.go
@@ -11,42 +11,11 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
 func TestQueryFrontendGetBlockHashByNumberRPC(t *testing.T) {
-	logger := testlog.Logger(t, log.LevelInfo)
-	mock := newMockChainIngester()
-	mock.AddBlock(eth.BlockID{Hash: common.HexToHash("0x01"), Number: 100})
-	mock.AddBlock(eth.BlockID{Hash: common.HexToHash("0x02"), Number: 200})
-
-	backend := NewBackend(context.Background(), BackendParams{
-		Logger:         logger,
-		Metrics:        metrics.NoopMetrics,
-		Chains:         map[eth.ChainID]ChainIngester{eth.ChainIDFromUInt64(testChainA): mock},
-		CrossValidator: &mockCrossValidator{},
-	})
-
-	server := oprpc.NewServer(
-		"127.0.0.1",
-		0,
-		"test",
-		oprpc.WithLogger(logger),
-	)
-	server.AddAPI(rpc.API{
-		Namespace: "interop",
-		Service:   &QueryFrontend{backend: backend},
-	})
-
-	require.NoError(t, server.Start())
-	t.Cleanup(func() {
-		_ = server.Stop()
-	})
-
-	client, err := rpc.Dial("http://" + server.Endpoint())
-	require.NoError(t, err)
-	t.Cleanup(client.Close)
+	client := newTestQueryRPCClient(t, false)
 
 	t.Run("latest selector", func(t *testing.T) {
 		var result common.Hash
@@ -79,4 +48,55 @@ func TestQueryFrontendGetBlockHashByNumberRPC(t *testing.T) {
 		err := client.Call(&result, "interop_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), "safe")
 		require.ErrorContains(t, err, "unsupported block tag")
 	})
+
+	t.Run("legacy supervisor namespace unavailable by default", func(t *testing.T) {
+		var result common.Hash
+		err := client.Call(&result, "supervisor_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), "latest")
+		require.ErrorContains(t, err, "method supervisor_getBlockHashByNumber does not exist")
+	})
+}
+
+func TestQueryFrontendLegacySupervisorRPCNamespace(t *testing.T) {
+	client := newTestQueryRPCClient(t, true)
+
+	var result common.Hash
+	err := client.Call(&result, "supervisor_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), "latest")
+	require.NoError(t, err)
+	require.Equal(t, common.HexToHash("0x02"), result)
+
+	err = client.Call(&result, "interop_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), "latest")
+	require.NoError(t, err)
+	require.Equal(t, common.HexToHash("0x02"), result)
+}
+
+func newTestQueryRPCClient(t *testing.T, legacySupervisorNamespace bool) *rpc.Client {
+	t.Helper()
+
+	logger := testlog.Logger(t, log.LevelInfo)
+	mock := newMockChainIngester()
+	mock.AddBlock(eth.BlockID{Hash: common.HexToHash("0x01"), Number: 100})
+	mock.AddBlock(eth.BlockID{Hash: common.HexToHash("0x02"), Number: 200})
+
+	backend := NewBackend(context.Background(), BackendParams{
+		Logger:         logger,
+		Metrics:        metrics.NoopMetrics,
+		Chains:         map[eth.ChainID]ChainIngester{eth.ChainIDFromUInt64(testChainA): mock},
+		CrossValidator: &mockCrossValidator{},
+	})
+
+	service := &Service{log: logger, version: "test", backend: backend}
+	require.NoError(t, service.initRPCServer(&Config{
+		RPCAddr:                   "127.0.0.1",
+		RPCPort:                   0,
+		LegacySupervisorNamespace: legacySupervisorNamespace,
+	}))
+	require.NoError(t, service.rpcServer.Start())
+	t.Cleanup(func() {
+		_ = service.rpcServer.Stop()
+	})
+
+	client, err := rpc.Dial("http://" + service.rpcServer.Endpoint())
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+	return client
 }

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -34,7 +34,7 @@ type Service struct {
 
 	pprofService   *oppprof.Service
 	metricsSrv     *httputil.HTTPServer
-	rpcServer      *oprpc.Server // Main RPC server (public supervisor API)
+	rpcServer      *oprpc.Server // Main RPC server (public query API)
 	adminRPCServer *oprpc.Server // Admin RPC server (JWT-protected, separate port)
 
 	backend *Backend
@@ -70,6 +70,9 @@ func Main(version string) cliapp.LifecycleAction {
 		}
 		if cfg.LegacyCheckAccessListFormat {
 			l.Warn("LEGACY CHECK ACCESS LIST FORMAT ENABLED: interop_checkAccessList will not reject missing executing chain IDs")
+		}
+		if cfg.LegacySupervisorNamespace {
+			l.Warn("LEGACY SUPERVISOR RPC NAMESPACE ENABLED: query RPC methods are temporarily available as supervisor_* in addition to canonical interop_* methods")
 		}
 
 		if !cfg.MessageExpiryWindowExplicit {
@@ -239,7 +242,7 @@ func (s *Service) initBackend(ctx context.Context, cfg *Config) error {
 }
 
 func (s *Service) initRPCServer(cfg *Config) error {
-	// Create server without JWT - public supervisor API
+	// Create server without JWT - public API
 	server := oprpc.NewServer(
 		cfg.RPCAddr,
 		cfg.RPCPort,
@@ -247,11 +250,19 @@ func (s *Service) initRPCServer(cfg *Config) error {
 		oprpc.WithLogger(s.log),
 	)
 
+	queryFrontend := &QueryFrontend{backend: s.backend}
 	server.AddAPI(rpc.API{
 		Namespace:     "interop",
-		Service:       &QueryFrontend{backend: s.backend},
+		Service:       queryFrontend,
 		Authenticated: false,
 	})
+	if cfg.LegacySupervisorNamespace {
+		server.AddAPI(rpc.API{
+			Namespace:     "supervisor",
+			Service:       queryFrontend,
+			Authenticated: false,
+		})
+	}
 
 	server.AddAPI(rpc.API{
 		Namespace:     "admin",
@@ -306,7 +317,7 @@ func (s *Service) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start backend: %w", err)
 	}
 
-	// Start main RPC server (supervisor API)
+	// Start main RPC server (query API)
 	if err := s.rpcServer.Start(); err != nil {
 		// Rollback: stop backend if RPC server fails to start
 		stopErr := s.backend.Stop(ctx)

--- a/op-interop-filter/flags/flags.go
+++ b/op-interop-filter/flags/flags.go
@@ -126,6 +126,11 @@ var (
 		Usage:   "Support legacy interop_checkAccessList requests that omit executing chainID. DANGEROUS: intended only for compatibility with legacy clients; access-list source-chain validation still runs.",
 		EnvVars: prefixEnvVars("SUPPORT_LEGACY_CHECK_ACCESS_LIST_FORMAT"),
 	}
+	SupportLegacySupervisorRPCNamespaceFlag = &cli.BoolFlag{
+		Name:    "support-legacy-supervisor-rpc-namespace",
+		Usage:   "Temporarily expose query RPC methods under the legacy supervisor_* namespace in addition to canonical interop_* methods. Intended only for compatibility with legacy clients.",
+		EnvVars: prefixEnvVars("SUPPORT_LEGACY_SUPERVISOR_RPC_NAMESPACE"),
+	}
 	DangerouslyEnablePassthroughFlag = &cli.BoolFlag{
 		Name:    "dangerously-enable-passthrough",
 		Usage:   "Allow all transactions through without interop filtering. DANGEROUS: disables all executing message validation.",
@@ -154,6 +159,7 @@ var optionalFlags = []cli.Flag{
 	RPCConcurrencyFlag,
 	FetchConcurrencyFlag,
 	SupportLegacyCheckAccessListFormatFlag,
+	SupportLegacySupervisorRPCNamespaceFlag,
 	DangerouslyEnablePassthroughFlag,
 }
 


### PR DESCRIPTION
## Summary

Adds an off-by-default compatibility flag for `op-interop-filter`:

- `--support-legacy-supervisor-rpc-namespace`
- `OP_INTEROP_FILTER_SUPPORT_LEGACY_SUPERVISOR_RPC_NAMESPACE`

When unset, the filter continues to register `QueryFrontend` only under the canonical `interop` namespace. When set, it also registers the same query frontend under the legacy `supervisor` namespace so legacy `supervisor_*` clients can migrate without reverting the default namespace cutover.

The existing legacy check-access-list-format flag is unchanged.

## Validation

- `go test -count=1 ./op-interop-filter/...`

## Notes

This is intended as temporary backwards compatibility only; new callers should continue to use `interop_*` methods.
