### PR TITLE
refactor(interop): move SafetyLevel into op-service/eth/safety

### DIFF
--- a/op-acceptance-tests/tests/base/deposit/deposit_test.go
+++ b/op-acceptance-tests/tests/base/deposit/deposit_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
-	supervisorTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestL1ToL2Deposit(gt *testing.T) {
@@ -64,7 +65,7 @@ func TestL1ToL2Deposit(gt *testing.T) {
 
 	// Wait for the sequencer to process the deposit
 	t.Require().Eventually(func() bool {
-		head := sys.L2CL.HeadBlockRef(supervisorTypes.LocalUnsafe)
+		head := sys.L2CL.HeadBlockRef(safety.LocalUnsafe)
 		return head.L1Origin.Number >= bigs.Uint64Strict(receipt.BlockNumber)
 	}, sys.L1EL.TransactionTimeout(), time.Second, "awaiting deposit to be processed by L2")
 

--- a/op-acceptance-tests/tests/batcher/batcher_test.go
+++ b/op-acceptance-tests/tests/batcher/batcher_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -68,7 +69,7 @@ func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
 			sequenceBlockWithL1Origin(t, ts_L2, parent, l1Origin, cathrine, alice, nonce)
 			nonce++
 
-			parent = sys.L2CL.HeadBlockRef(types.LocalUnsafe).Hash
+			parent = sys.L2CL.HeadBlockRef(safety.LocalUnsafe).Hash
 
 			sys.L2EL.WaitForPendingNonceMatch(cathrine.Address(), nonce, 10, 1*time.Second)
 

--- a/op-acceptance-tests/tests/depreqres/common/common.go
+++ b/op-acceptance-tests/tests/depreqres/common/common.go
@@ -10,7 +10,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -79,8 +80,8 @@ func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, advanc
 	l.Info("Confirm that the CL nodes are progressing the unsafe chain")
 	target := uint64(3)
 	dsl.CheckAll(t,
-		sys.L2CL.AdvancedFn(types.LocalUnsafe, target, 30),
-		sys.L2CLB.AdvancedFn(types.LocalUnsafe, target, 30),
+		sys.L2CL.AdvancedFn(safety.LocalUnsafe, target, 30),
+		sys.L2CLB.AdvancedFn(safety.LocalUnsafe, target, 30),
 	)
 
 	logPeerState(l, "L2CLB", sys.L2CLB)
@@ -93,7 +94,7 @@ func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, advanc
 	sys.L2CLB.WaitForPeerDisconnected(sys.L2CL)
 	sys.L2CL.WaitForPeerDisconnected(sys.L2CLB)
 
-	sys.L2CLB.WaitForStall(types.LocalUnsafe)
+	sys.L2CLB.WaitForStall(safety.LocalUnsafe)
 	ssB_before := sys.L2CLB.SyncStatus()
 
 	l.Info("L2CLB stalled", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())
@@ -101,7 +102,7 @@ func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, advanc
 	l.Info("Wait for sequencer to advance while verifier is disconnected", "advanceBlocks", advanceBlocks)
 	// Allow generous time: advanceBlocks * ~2s block time, plus buffer for CI pressure.
 	advanceAttempts := int(advanceBlocks*2 + 30)
-	sys.L2CL.Advanced(types.LocalUnsafe, advanceBlocks, advanceAttempts)
+	sys.L2CL.Advanced(safety.LocalUnsafe, advanceBlocks, advanceAttempts)
 
 	ssA_after := sys.L2CL.SyncStatus()
 	ssB_after := sys.L2CLB.SyncStatus()
@@ -119,7 +120,7 @@ func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, advanc
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
 	l.Info("Confirm that the unsafe chain for L2CLB is not stalled")
-	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 30)
+	sys.L2CLB.Reached(safety.LocalUnsafe, ssA_after.UnsafeL2.Number, 30)
 	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 30)
 }
 
@@ -132,8 +133,8 @@ func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, adv
 	l.Info("Confirm that the CL nodes are progressing the unsafe chain")
 	target := uint64(3)
 	dsl.CheckAll(t,
-		sys.L2CL.AdvancedFn(types.LocalUnsafe, target, 30),
-		sys.L2CLB.AdvancedFn(types.LocalUnsafe, target, 30),
+		sys.L2CL.AdvancedFn(safety.LocalUnsafe, target, 30),
+		sys.L2CLB.AdvancedFn(safety.LocalUnsafe, target, 30),
 	)
 
 	logPeerState(l, "L2CLB", sys.L2CLB)
@@ -146,7 +147,7 @@ func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, adv
 	sys.L2CLB.WaitForPeerDisconnected(sys.L2CL)
 	sys.L2CL.WaitForPeerDisconnected(sys.L2CLB)
 
-	sys.L2CLB.WaitForStall(types.LocalUnsafe)
+	sys.L2CLB.WaitForStall(safety.LocalUnsafe)
 	ssB_before := sys.L2CLB.SyncStatus()
 
 	l.Info("L2CLB stalled", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())
@@ -155,7 +156,7 @@ func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, adv
 
 	l.Info("Wait for sequencer to advance while verifier is stopped", "advanceBlocks", advanceBlocks)
 	advanceAttempts := int(advanceBlocks*2 + 30)
-	sys.L2CL.Advanced(types.LocalUnsafe, advanceBlocks, advanceAttempts)
+	sys.L2CL.Advanced(safety.LocalUnsafe, advanceBlocks, advanceAttempts)
 
 	sys.L2CLB.Start()
 
@@ -175,7 +176,7 @@ func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, adv
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
 	l.Info("Confirm that the unsafe chain for L2CLB is not stalled")
-	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 30)
+	sys.L2CLB.Reached(safety.LocalUnsafe, ssA_after.UnsafeL2.Number, 30)
 	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 30)
 }
 

--- a/op-acceptance-tests/tests/depreqres/reqressyncdisabled/depreqres_test.go
+++ b/op-acceptance-tests/tests/depreqres/reqressyncdisabled/depreqres_test.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestUnsafeChainNotStalling_DisabledReqRespSync(gt *testing.T) {
@@ -20,8 +21,8 @@ func TestUnsafeChainNotStalling_DisabledReqRespSync(gt *testing.T) {
 	l.Info("Confirm that the CL nodes are progressing the unsafe chain")
 	delta := uint64(3)
 	dsl.CheckAll(t,
-		sys.L2CL.AdvancedFn(types.LocalUnsafe, delta, 30),
-		sys.L2CLB.AdvancedFn(types.LocalUnsafe, delta, 30),
+		sys.L2CL.AdvancedFn(safety.LocalUnsafe, delta, 30),
+		sys.L2CLB.AdvancedFn(safety.LocalUnsafe, delta, 30),
 	)
 
 	l.Info("Disconnect L2CL from L2CLB, and vice versa")
@@ -33,7 +34,7 @@ func TestUnsafeChainNotStalling_DisabledReqRespSync(gt *testing.T) {
 	sys.L2CLB.WaitForPeerDisconnected(sys.L2CL)
 
 	l.Info("Wait for L2CLB unsafe head to stall after disconnect")
-	sys.L2CLB.WaitForStall(types.LocalUnsafe)
+	sys.L2CLB.WaitForStall(safety.LocalUnsafe)
 
 	l.Info("Confirm that the unsafe chain for L2CL advances while L2CLB remains stalled")
 	sys.L2CL.AdvancedUnsafe(delta, 30)
@@ -44,6 +45,6 @@ func TestUnsafeChainNotStalling_DisabledReqRespSync(gt *testing.T) {
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
 	l.Info("Confirm that the unsafe chain for L2CLB can advance")
-	sys.L2CLB.Reached(types.LocalUnsafe, ssA.UnsafeL2.Number, 30)
+	sys.L2CLB.Reached(safety.LocalUnsafe, ssA.UnsafeL2.Number, 30)
 	sys.L2ELB.Reached(eth.Unsafe, ssA.UnsafeL2.Number, 30)
 }

--- a/op-acceptance-tests/tests/depreqres/reqressyncdisabled/divergence/divergence_test.go
+++ b/op-acceptance-tests/tests/depreqres/reqressyncdisabled/divergence/divergence_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum"
 )
 
@@ -33,10 +34,10 @@ func TestCLELDivergence(gt *testing.T) {
 	require := t.Require()
 	l := t.Logger()
 
-	startNum := sys.L2CLB.HeadBlockRef(types.LocalUnsafe).Number
+	startNum := sys.L2CLB.HeadBlockRef(safety.LocalUnsafe).Number
 
 	// Wait for the sequencer to produce the next block so the verifier initial EL sync can complete.
-	sys.L2CL.Reached(types.LocalUnsafe, startNum+1, 30)
+	sys.L2CL.Reached(safety.LocalUnsafe, startNum+1, 30)
 
 	// Complete initial EL sync by providing the first missing block.
 	// At this point, the EL has sufficient state to validate block startNum+1.
@@ -50,7 +51,7 @@ func TestCLELDivergence(gt *testing.T) {
 	// Choose a future EL sync target for which the EL lacks state to validate.
 	delta := uint64(5)
 	targetNumber := startNum + delta
-	sys.L2CL.Advanced(types.LocalUnsafe, targetNumber, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, targetNumber, 30)
 	targetBlock := sys.L2EL.BlockRefByNumber(targetNumber)
 
 	// The CL advances its unsafe head to the target block, even though there is a gap.

--- a/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // TestInteropHappyTx is testing that a valid init message, followed by a valid exec message are correctly
@@ -41,10 +42,10 @@ func TestInteropHappyTx(gt *testing.T) {
 
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
-		sys.L2ACL.ReachedRefFn(stypes.CrossSafe, initMsg.BlockID(),
+		sys.L2ACL.ReachedRefFn(safety.CrossSafe, initMsg.BlockID(),
 			// TODO(#16598): Make this relative to the block time
 			500),
-		sys.L2BCL.ReachedRefFn(stypes.CrossSafe, execMsg.BlockID(),
+		sys.L2BCL.ReachedRefFn(safety.CrossSafe, execMsg.BlockID(),
 			// TODO(#16598): Make this relative to the block time
 			500),
 	)

--- a/op-acceptance-tests/tests/interop/proofs/challenger_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/challenger_test.go
@@ -5,21 +5,22 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/proofs"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestChallengerPlaysGame(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t, presets.WithoutHonestProposer())
 	dsl.CheckAll(t,
-		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
-		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),
+		sys.L2CLA.AdvancedFn(safety.CrossSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(safety.CrossSafe, 1, 30),
 	)
 
 	badClaim := common.HexToHash("0xdeadbeef00000000000000000000000000000000000000000000000000000000")
@@ -40,8 +41,8 @@ func TestChallengerRespondsToMultipleInvalidClaims(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t, presets.WithoutHonestProposer())
 	dsl.CheckAll(t,
-		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
-		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),
+		sys.L2CLA.AdvancedFn(safety.CrossSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(safety.CrossSafe, 1, 30),
 	)
 
 	attacker := sys.FunderL1.NewFundedEOA(eth.TenEther)
@@ -63,8 +64,8 @@ func TestChallengerRespondsToMultipleInvalidClaimsEOA(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t, presets.WithoutHonestProposer())
 	dsl.CheckAll(t,
-		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
-		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),
+		sys.L2CLA.AdvancedFn(safety.CrossSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(safety.CrossSafe, 1, 30),
 	)
 
 	dgf := sys.DisputeGameFactory()

--- a/op-acceptance-tests/tests/interop/proofs/fpp/fpp_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/fpp/fpp_test.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestFPP(gt *testing.T) {
@@ -40,7 +41,7 @@ func TestNextSuperRootNotFound(gt *testing.T) {
 	sys.SuperRoots.AwaitValidatedTimestamp(chainBLastBlock.Time)
 
 	// Wait for safe head to advance on first chain to be sure the next block is also safe.
-	sys.L2CLA.Advanced(types.LocalSafe, 1, 10)
+	sys.L2CLA.Advanced(safety.LocalSafe, 1, 10)
 
 	startTimestamp := chainBLastBlock.Time
 	endTimestamp := startTimestamp + blockTime

--- a/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -77,7 +78,7 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preEarlyChecks, preChecks, po
 	// Build a stable cross-safe foundation before we stop the L1 CL and manually sequence.
 	// This ensures the supernode has verified state that references canonical L1 blocks,
 	// so after the reorg it doesn't need to rewind all the way back to genesis.
-	sys.L2ACL.Advanced(types.CrossSafe, 20, 100)
+	sys.L2ACL.Advanced(safety.CrossSafe, 20, 100)
 
 	preEarlyChecks(t, sys)
 

--- a/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
+++ b/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // TestSequencingWindowExpiry tests that the sequencing window may expire,
@@ -148,8 +149,8 @@ func TestSequencingWindowExpiry(gt *testing.T) {
 
 	// Build the missing blocks, catch up on local-safe chain
 	dsl.CheckAll(t,
-		sys.L2ACL.AdvancedFn(types.LocalSafe, 20, 100),
-		sys.L2ACL.AdvancedFn(types.LocalUnsafe, 20, 100),
+		sys.L2ACL.AdvancedFn(safety.LocalSafe, 20, 100),
+		sys.L2ACL.AdvancedFn(safety.LocalUnsafe, 20, 100),
 	)
 
 	syncStatus = sys.L2ACL.SyncStatus()

--- a/op-acceptance-tests/tests/interop/upgrade/post_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/post_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -89,9 +90,9 @@ func testActivationCrossSafe(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
 
 		// Wait for the corresponding CL to reach cross-safe past activation
 		if net.ChainID() == sys.L2A.ChainID() {
-			sys.L2ACL.Reached(stypes.CrossSafe, activationBlock.Number, 60)
+			sys.L2ACL.Reached(safety.CrossSafe, activationBlock.Number, 60)
 		} else {
-			sys.L2BCL.Reached(stypes.CrossSafe, activationBlock.Number, 60)
+			sys.L2BCL.Reached(safety.CrossSafe, activationBlock.Number, 60)
 		}
 
 		logger.Info("Validating activation block timing",
@@ -110,17 +111,17 @@ func testSafetyProgression(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
 
 	delta := uint64(3) // Minimum blocks of progression expected
 	dsl.CheckAll(t,
-		sys.L2ACL.AdvancedFn(stypes.LocalUnsafe, delta, 30),
-		sys.L2BCL.AdvancedFn(stypes.LocalUnsafe, delta, 30),
+		sys.L2ACL.AdvancedFn(safety.LocalUnsafe, delta, 30),
+		sys.L2BCL.AdvancedFn(safety.LocalUnsafe, delta, 30),
 
-		sys.L2ACL.AdvancedFn(stypes.LocalSafe, delta, 30),
-		sys.L2BCL.AdvancedFn(stypes.LocalSafe, delta, 30),
+		sys.L2ACL.AdvancedFn(safety.LocalSafe, delta, 30),
+		sys.L2BCL.AdvancedFn(safety.LocalSafe, delta, 30),
 
-		sys.L2ACL.AdvancedFn(stypes.CrossUnsafe, delta, 30),
-		sys.L2BCL.AdvancedFn(stypes.CrossUnsafe, delta, 30),
+		sys.L2ACL.AdvancedFn(safety.CrossUnsafe, delta, 30),
+		sys.L2BCL.AdvancedFn(safety.CrossUnsafe, delta, 30),
 
-		sys.L2ACL.AdvancedFn(stypes.CrossSafe, delta, 60),
-		sys.L2BCL.AdvancedFn(stypes.CrossSafe, delta, 60),
+		sys.L2ACL.AdvancedFn(safety.CrossSafe, delta, 60),
+		sys.L2BCL.AdvancedFn(safety.CrossSafe, delta, 60),
 	)
 
 	logger.Info("Safety progression validation completed successfully")
@@ -146,8 +147,8 @@ func testInteropMessageInclusion(t devtest.T, sys *presets.TwoL2SupernodeInterop
 
 	// Verify cross-safe progression for both messages
 	dsl.CheckAll(t,
-		sys.L2ACL.ReachedRefFn(stypes.CrossSafe, initMsg.BlockID(), 60),
-		sys.L2BCL.ReachedRefFn(stypes.CrossSafe, execMsg.BlockID(), 60),
+		sys.L2ACL.ReachedRefFn(safety.CrossSafe, initMsg.BlockID(), 60),
+		sys.L2BCL.ReachedRefFn(safety.CrossSafe, execMsg.BlockID(), 60),
 	)
 
 	logger.Info("Interop message inclusion test completed successfully")

--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -18,7 +18,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // preInteropExecError returns true if err matches a known pre-interop
@@ -73,12 +74,12 @@ func TestPreNoInbox(gt *testing.T) {
 	// interop verifier and must instead fall through to local-safe /
 	// local-finalized. See issue #20191.
 	dsl.CheckAll(t,
-		sys.L2ACL.AdvancedFn(types.LocalSafe, 5, 100),
-		sys.L2BCL.AdvancedFn(types.LocalSafe, 5, 100),
-		sys.L2ACL.AdvancedFn(types.CrossSafe, 5, 100),
-		sys.L2BCL.AdvancedFn(types.CrossSafe, 5, 100),
-		sys.L2ACL.AdvancedFn(types.Finalized, 1, 100),
-		sys.L2BCL.AdvancedFn(types.Finalized, 1, 100),
+		sys.L2ACL.AdvancedFn(safety.LocalSafe, 5, 100),
+		sys.L2BCL.AdvancedFn(safety.LocalSafe, 5, 100),
+		sys.L2ACL.AdvancedFn(safety.CrossSafe, 5, 100),
+		sys.L2BCL.AdvancedFn(safety.CrossSafe, 5, 100),
+		sys.L2ACL.AdvancedFn(safety.Finalized, 1, 100),
+		sys.L2BCL.AdvancedFn(safety.Finalized, 1, 100),
 	)
 
 	// Phase 3: Try interop before the upgrade, confirm that messages do not get included

--- a/op-acceptance-tests/tests/isthmus/preinterop/challenger_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/challenger_test.go
@@ -5,19 +5,20 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/proofs"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestChallengerPlaysGame(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := newSimpleInteropPreinterop(t)
 	dsl.CheckAll(t,
-		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
-		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),
+		sys.L2CLA.AdvancedFn(safety.CrossSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(safety.CrossSafe, 1, 30),
 	)
 
 	badClaim := common.HexToHash("0xdeadbeef00000000000000000000000000000000000000000000000000000000")

--- a/op-acceptance-tests/tests/proofs/cannon/step_test.go
+++ b/op-acceptance-tests/tests/proofs/cannon/step_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/proofs"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestExecuteStep_Cannon(gt *testing.T) {
@@ -17,7 +18,7 @@ func TestExecuteStep_Cannon(gt *testing.T) {
 
 	l1User := sys.FunderL1.NewFundedEOA(eth.ThousandEther)
 	blockNum := uint64(3)
-	sys.L2CL.Reached(types.LocalSafe, blockNum, 30)
+	sys.L2CL.Reached(safety.LocalSafe, blockNum, 30)
 
 	game := sys.DisputeGameFactory().StartCannonGame(l1User, proofs.WithL2SequenceNumber(blockNum))
 	claim := game.DisputeL2SequenceNumber(l1User, game.RootClaim(), blockNum)
@@ -47,7 +48,7 @@ func TestExecuteStep_CannonKona(gt *testing.T) {
 
 	l1User := sys.FunderL1.NewFundedEOA(eth.ThousandEther)
 	blockNum := uint64(3)
-	sys.L2CL.Reached(types.LocalSafe, blockNum, 30)
+	sys.L2CL.Reached(safety.LocalSafe, blockNum, 30)
 
 	game := sys.DisputeGameFactory().StartCannonKonaGame(l1User, proofs.WithL2SequenceNumber(blockNum))
 	claim := game.DisputeL2SequenceNumber(l1User, game.RootClaim(), blockNum)

--- a/op-acceptance-tests/tests/safeheaddb_clsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_clsync/safeheaddb_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestPreserveDatabaseOnCLResync(gt *testing.T) {
@@ -35,10 +36,10 @@ func TestPreserveDatabaseOnCLResync(gt *testing.T) {
 
 	startSafeBlock := sys.L2CLB.SafeL2BlockRef().Number
 	dsl.CheckAll(t,
-		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
-		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
+		sys.L2CL.AdvancedFn(safety.LocalSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(safety.LocalSafe, 1, 30))
 
-	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, safety.LocalSafe, 30)
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 
 	// Stop the verifier node. Since the sysgo EL uses in-memory storage this also wipes its database.
@@ -47,14 +48,14 @@ func TestPreserveDatabaseOnCLResync(gt *testing.T) {
 	sys.L2ELB.Stop()
 	sys.L2CLB.Stop()
 
-	sys.L2CL.Advanced(types.LocalSafe, 3, 30)
+	sys.L2CL.Advanced(safety.LocalSafe, 3, 30)
 
 	sys.L2ELB.Start()
 	sys.L2CLB.Start()
 	sys.L2ELB.PeerWith(sys.L2EL)
 
-	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
-	sys.L2CLB.Advanced(types.LocalSafe, 1, 30) // At least one safe head db update after resync
+	sys.L2CLB.InSync(sys.L2CL, safety.LocalSafe, 30)
+	sys.L2CLB.Advanced(safety.LocalSafe, 1, 30) // At least one safe head db update after resync
 
 	// Safe head db should not have been reset
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(startSafeBlock))

--- a/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func newSingleChainMultiNodeELSync(t devtest.T) *presets.SingleChainMultiNode {
@@ -40,10 +41,10 @@ func TestTruncateDatabaseOnELResync(gt *testing.T) {
 	sys := newSingleChainMultiNodeELSync(t)
 
 	dsl.CheckAll(t,
-		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
-		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
+		sys.L2CL.AdvancedFn(safety.LocalSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(safety.LocalSafe, 1, 30))
 
-	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, safety.LocalSafe, 30)
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 
 	// Stop the verifier node. Since the sysgo EL uses in-memory storage this also wipes its database.
@@ -52,7 +53,7 @@ func TestTruncateDatabaseOnELResync(gt *testing.T) {
 	sys.L2ELB.Stop()
 	sys.L2CLB.Stop()
 
-	sys.L2CL.Advanced(types.LocalSafe, 3, 30)
+	sys.L2CL.Advanced(safety.LocalSafe, 3, 30)
 
 	sys.L2ELB.Start()
 	sys.L2CLB.Start()
@@ -65,8 +66,8 @@ func TestTruncateDatabaseOnELResync(gt *testing.T) {
 	// EL Sync after a full database wipe requires more time than the initial sync:
 	// the EL must re-download all blocks via P2P before the CL can begin derivation,
 	// and node A keeps advancing LocalSafe in the meantime.
-	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 90)
-	sys.L2CLB.Advanced(types.LocalSafe, 1, 90) // At least one safe head db update after resync
+	sys.L2CLB.InSync(sys.L2CL, safety.LocalSafe, 90)
+	sys.L2CLB.Advanced(safety.LocalSafe, 1, 90) // At least one safe head db update after resync
 
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 }
@@ -86,9 +87,9 @@ func TestNotTruncateDatabaseOnRestartWithExistingDatabase(gt *testing.T) {
 	sys := newSingleChainMultiNodeELSync(t)
 
 	dsl.CheckAll(t,
-		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
-		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
-	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
+		sys.L2CL.AdvancedFn(safety.LocalSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(safety.LocalSafe, 1, 30))
+	sys.L2CLB.InSync(sys.L2CL, safety.LocalSafe, 30)
 
 	preRestartSafeBlock := sys.L2CLB.SafeL2BlockRef().Number
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(preRestartSafeBlock))
@@ -96,12 +97,12 @@ func TestNotTruncateDatabaseOnRestartWithExistingDatabase(gt *testing.T) {
 	// Restart the verifier op-node, but not the EL so the existing chain data is not deleted.
 	sys.L2CLB.Stop()
 
-	sys.L2CL.Advanced(types.LocalSafe, 3, 30)
+	sys.L2CL.Advanced(safety.LocalSafe, 3, 30)
 
 	sys.L2CLB.Start()
 
-	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 60)
-	sys.L2CLB.Advanced(types.LocalSafe, 1, 60) // At least one safe head db update after resync
+	sys.L2CLB.InSync(sys.L2CL, safety.LocalSafe, 60)
+	sys.L2CLB.Advanced(safety.LocalSafe, 1, 60) // At least one safe head db update after resync
 
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(preRestartSafeBlock))
 }

--- a/op-acceptance-tests/tests/superfaultproofs/optimistic_pairing.go
+++ b/op-acceptance-tests/tests/superfaultproofs/optimistic_pairing.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
-	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -97,7 +98,7 @@ func RunOptimisticPairingTest(t devtest.T, sys *presets.SimpleInterop, withRepla
 		sys.TestSequencer.SequenceBlock(t, chains[1].ID, unsafeB.Hash)
 		t.Require().Equal(endTimestamp, sys.L2ELB.BlockRefByLabel(eth.Unsafe).Time)
 		advanceSafeToCurrentUnsafe(t, chains[1])
-		sys.L2CLA.Reached(suptypes.CrossSafe, newHeadA.Number, 60)
+		sys.L2CLA.Reached(safety.CrossSafe, newHeadA.Number, 60)
 	}
 
 	// The super root at startTimestamp must be fully verifiable at gameL1Head;

--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -6,7 +6,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -34,7 +35,7 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 
 	// Stop batch submission so safe head stalls, then we have a known boundary.
 	c.Batcher.Stop()
-	sys.L2CLA.WaitForStall(types.CrossSafe)
+	sys.L2CLA.WaitForStall(safety.CrossSafe)
 
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -26,7 +26,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -62,11 +63,11 @@ func freezeChains(chains []*chain) {
 		c.CLNode.StopSequencer()
 	}
 	for _, c := range chains {
-		c.CLNode.WaitForStall(types.LocalUnsafe)
+		c.CLNode.WaitForStall(safety.LocalUnsafe)
 	}
 	for _, c := range chains {
-		unsafeNumber := c.CLNode.HeadBlockRef(types.LocalUnsafe).Number
-		c.CLNode.Reached(types.LocalSafe, unsafeNumber, 30)
+		unsafeNumber := c.CLNode.HeadBlockRef(safety.LocalUnsafe).Number
+		c.CLNode.Reached(safety.LocalSafe, unsafeNumber, 30)
 	}
 	for _, c := range chains {
 		c.Batcher.Stop()
@@ -111,7 +112,7 @@ func advanceUnsafeToTimestamp(t devtest.T, sys *presets.SimpleInterop, chains []
 func advanceSafeToCurrentUnsafe(t devtest.T, c *chain) {
 	target := c.EL.BlockRefByLabel(eth.Unsafe).Number
 	c.Batcher.Start()
-	c.CLNode.Reached(types.LocalSafe, target, 60)
+	c.CLNode.Reached(safety.LocalSafe, target, 60)
 	c.Batcher.Stop()
 }
 
@@ -775,7 +776,7 @@ func RunUnsafeProposalTest(t devtest.T, sys *presets.SimpleInterop) {
 	//     that timestamp maps to a block at or below every chain's safe head.
 	chains[0].Batcher.Stop()
 	defer chains[0].Batcher.Start()
-	chains[0].CLNode.WaitForStall(types.LocalSafe)
+	chains[0].CLNode.WaitForStall(safety.LocalSafe)
 
 	stalledStatus, err := chains[0].Rollup.SyncStatus(t.Ctx())
 	t.Require().NoError(err)
@@ -792,7 +793,7 @@ func RunUnsafeProposalTest(t devtest.T, sys *presets.SimpleInterop) {
 
 	chains[1].Batcher.Stop()
 	defer chains[1].Batcher.Start()
-	chains[1].CLNode.WaitForStall(types.LocalSafe)
+	chains[1].CLNode.WaitForStall(safety.LocalSafe)
 
 	endTimestamp := chains[0].Cfg.TimestampForBlock(stalledSafeHead + 1)
 	agreedTimestamp := endTimestamp - 1
@@ -1149,7 +1150,7 @@ func RunInvalidBlockTest(t devtest.T, sys *presets.SimpleInterop) {
 	startTimestamp := endTimestamp - 1
 
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
-	sys.L2CLB.Reached(types.CrossSafe, bigs.Uint64Strict(execMsg.BlockNumber()), 10)
+	sys.L2CLB.Reached(safety.CrossSafe, bigs.Uint64Strict(execMsg.BlockNumber()), 10)
 	sys.L2ELB.AssertExecMessageNotInBlock(execMsg)
 
 	l1HeadCurrent := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp))
@@ -1374,7 +1375,7 @@ func RunMessageExpiryTest(t devtest.T, sys *presets.SimpleInterop, msgExpiryWind
 
 	// Wait for cross-safe validation, which should replace the invalid block.
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
-	sys.L2CLB.Reached(types.CrossSafe, execBlockNum, 30)
+	sys.L2CLB.Reached(safety.CrossSafe, execBlockNum, 30)
 
 	// Verify the expired exec tx was reorged out during consolidation.
 	sys.L2ELB.AssertTxNotInBlock(execBlockNum, execTxHash)
@@ -1528,7 +1529,7 @@ func RunDepositMessageInvalidExecutionTest(t devtest.T, sys *presets.SimpleInter
 	startTimestamp := endTimestamp - 1
 
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
-	sys.L2CLB.Reached(types.CrossSafe, bigs.Uint64Strict(execMsg.BlockNumber()), 10)
+	sys.L2CLB.Reached(safety.CrossSafe, bigs.Uint64Strict(execMsg.BlockNumber()), 10)
 	sys.L2ELB.AssertExecMessageNotInBlock(execMsg)
 
 	l1HeadCurrent := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp))

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/p2p_sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/p2p_sync_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // TestFollowSource_P2PSync checks that a follower CL syncs unsafe blocks from the
@@ -21,8 +22,8 @@ func TestFollowSource_P2PSync(gt *testing.T) {
 
 	logger.Info("Make sure sequencer and follower unsafe head advances")
 	dsl.CheckAll(t,
-		sys.L2ACL.AdvancedFn(types.LocalUnsafe, 5, 30),
-		sys.L2AFollowCL.AdvancedFn(types.LocalUnsafe, 5, 30),
+		sys.L2ACL.AdvancedFn(safety.LocalUnsafe, 5, 30),
+		sys.L2AFollowCL.AdvancedFn(safety.LocalUnsafe, 5, 30),
 	)
 
 	logger.Info("Stop follower CL")
@@ -39,10 +40,10 @@ func TestFollowSource_P2PSync(gt *testing.T) {
 
 	logger.Info("Make sure both advance")
 	dsl.CheckAll(t,
-		sys.L2ACL.AdvancedFn(types.LocalUnsafe, 10, 30),
-		sys.L2AFollowCL.AdvancedFn(types.LocalUnsafe, 10, 30),
+		sys.L2ACL.AdvancedFn(safety.LocalUnsafe, 10, 30),
+		sys.L2AFollowCL.AdvancedFn(safety.LocalUnsafe, 10, 30),
 	)
 
 	logger.Info("Check sequencer and follower converged on the same canonical chain")
-	sys.L2AFollowCL.InSync(sys.L2ACL, types.LocalUnsafe, 30)
+	sys.L2AFollowCL.InSync(sys.L2ACL, safety.LocalUnsafe, 30)
 }

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
@@ -40,8 +41,8 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	initialChecks := make([]dsl.CheckFunc, 0, len(chains)*2)
 	for _, chain := range chains {
 		initialChecks = append(initialChecks,
-			chain.follower.InSyncFn(chain.source, types.LocalSafe, 20),
-			chain.follower.InSyncFn(chain.source, types.CrossSafe, 20),
+			chain.follower.InSyncFn(chain.source, safety.LocalSafe, 20),
+			chain.follower.InSyncFn(chain.source, safety.CrossSafe, 20),
 		)
 	}
 	dsl.CheckAll(t, initialChecks...)
@@ -108,9 +109,9 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	divergenceChecks := make([]dsl.CheckFunc, 0, len(chains)*3)
 	for _, chain := range chains {
 		divergenceChecks = append(divergenceChecks,
-			chain.follower.InSyncFn(chain.source, types.LocalUnsafe, 20),
-			chain.follower.InSyncFn(chain.source, types.LocalSafe, 20),
-			chain.follower.InSyncFn(chain.source, types.CrossSafe, 20),
+			chain.follower.InSyncFn(chain.source, safety.LocalUnsafe, 20),
+			chain.follower.InSyncFn(chain.source, safety.LocalSafe, 20),
+			chain.follower.InSyncFn(chain.source, safety.CrossSafe, 20),
 		)
 	}
 	dsl.CheckAll(t, divergenceChecks...)
@@ -163,9 +164,9 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	finalChecks := make([]dsl.CheckFunc, 0, len(chains)*3)
 	for _, chain := range chains {
 		finalChecks = append(finalChecks,
-			chain.follower.InSyncFn(chain.source, types.LocalUnsafe, 20),
-			chain.follower.InSyncFn(chain.source, types.LocalSafe, 20),
-			chain.follower.InSyncFn(chain.source, types.CrossSafe, 20),
+			chain.follower.InSyncFn(chain.source, safety.LocalUnsafe, 20),
+			chain.follower.InSyncFn(chain.source, safety.LocalSafe, 20),
+			chain.follower.InSyncFn(chain.source, safety.CrossSafe, 20),
 		)
 	}
 	dsl.CheckAll(t, finalChecks...)

--- a/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // TestSupernodeInterop_SafeHeadProgression tests that the cross-safe head
@@ -49,19 +50,19 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	// check safe heads get to at least that height,
 	// let local safe heads run ahead
 	dsl.CheckAll(t,
-		sys.L2ACL.ReachedFn(types.LocalSafe, finalTargetBlockNum, attempts),
-		sys.L2BCL.ReachedFn(types.LocalSafe, finalTargetBlockNum, attempts),
-		sys.L2ACL.ReachedFn(types.CrossSafe, initialTargetBlockNumA-1, attempts),
-		sys.L2BCL.ReachedFn(types.CrossSafe, initialTargetBlockNumB-1, attempts),
+		sys.L2ACL.ReachedFn(safety.LocalSafe, finalTargetBlockNum, attempts),
+		sys.L2BCL.ReachedFn(safety.LocalSafe, finalTargetBlockNum, attempts),
+		sys.L2ACL.ReachedFn(safety.CrossSafe, initialTargetBlockNumA-1, attempts),
+		sys.L2BCL.ReachedFn(safety.CrossSafe, initialTargetBlockNumB-1, attempts),
 	)
 
 	// Expect cross safe and finalized to stall since we paused the interop activity
 	numAttempts := 2 // implies a 4s wait
 	dsl.CheckAll(t,
-		sys.L2ACL.NotAdvancedFn(types.CrossSafe, numAttempts),
-		sys.L2BCL.NotAdvancedFn(types.CrossSafe, numAttempts),
-		sys.L2ACL.NotAdvancedFn(types.Finalized, numAttempts),
-		sys.L2BCL.NotAdvancedFn(types.Finalized, numAttempts),
+		sys.L2ACL.NotAdvancedFn(safety.CrossSafe, numAttempts),
+		sys.L2BCL.NotAdvancedFn(safety.CrossSafe, numAttempts),
+		sys.L2ACL.NotAdvancedFn(safety.Finalized, numAttempts),
+		sys.L2BCL.NotAdvancedFn(safety.Finalized, numAttempts),
 	)
 
 	// Check EL labels - cross-safeand finalized should be
@@ -79,8 +80,8 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	// expect cross safe to catch up on both CL and EL
 	sys.Supernode.ResumeInterop()
 	dsl.CheckAll(t,
-		sys.L2ACL.ReachedFn(types.CrossSafe, finalTargetBlockNum, attempts),
-		sys.L2BCL.ReachedFn(types.CrossSafe, finalTargetBlockNum, attempts),
+		sys.L2ACL.ReachedFn(safety.CrossSafe, finalTargetBlockNum, attempts),
+		sys.L2BCL.ReachedFn(safety.CrossSafe, finalTargetBlockNum, attempts),
 		sys.L2ELA.ReachedFn(eth.Safe, finalTargetBlockNum, attempts),
 		sys.L2ELB.ReachedFn(eth.Safe, finalTargetBlockNum, attempts),
 	)
@@ -116,8 +117,8 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	// safe heads. Finalized advancement depends on L1 finality, so use more attempts.
 	finalizedAttempts := 30
 	dsl.CheckAll(t,
-		sys.L2ACL.ReachedFn(types.Finalized, snapshotSafeA, finalizedAttempts),
-		sys.L2BCL.ReachedFn(types.Finalized, snapshotSafeB, finalizedAttempts),
+		sys.L2ACL.ReachedFn(safety.Finalized, snapshotSafeA, finalizedAttempts),
+		sys.L2BCL.ReachedFn(safety.Finalized, snapshotSafeB, finalizedAttempts),
 		sys.L2ELA.ReachedFn(eth.Finalized, snapshotSafeA, finalizedAttempts),
 		sys.L2ELB.ReachedFn(eth.Finalized, snapshotSafeB, finalizedAttempts),
 	)
@@ -165,8 +166,8 @@ func TestSupernodeInterop_SafeHeadWithUnevenProgress(gt *testing.T) {
 
 	// Wait for initial sync
 	dsl.CheckAll(t,
-		sys.L2ACL.ReachedFn(types.LocalSafe, initialTargetBlockNum, attempts),
-		sys.L2BCL.ReachedFn(types.LocalSafe, initialTargetBlockNum, attempts),
+		sys.L2ACL.ReachedFn(safety.LocalSafe, initialTargetBlockNum, attempts),
+		sys.L2BCL.ReachedFn(safety.LocalSafe, initialTargetBlockNum, attempts),
 	)
 
 	baselineLocalSafeB := sys.L2BCL.SyncStatus().LocalSafeL2.Number
@@ -176,7 +177,7 @@ func TestSupernodeInterop_SafeHeadWithUnevenProgress(gt *testing.T) {
 
 	// Chain A advances while B is frozen
 	dsl.CheckAll(t,
-		sys.L2ACL.ReachedFn(types.LocalSafe, finalTargetBlockNum, attempts),
+		sys.L2ACL.ReachedFn(safety.LocalSafe, finalTargetBlockNum, attempts),
 	)
 
 	unevenStatusA := sys.L2ACL.SyncStatus()
@@ -197,13 +198,13 @@ func TestSupernodeInterop_SafeHeadWithUnevenProgress(gt *testing.T) {
 
 	// Chain B catches up
 	dsl.CheckAll(t,
-		sys.L2BCL.ReachedFn(types.LocalSafe, finalTargetBlockNum, attempts),
+		sys.L2BCL.ReachedFn(safety.LocalSafe, finalTargetBlockNum, attempts),
 	)
 
 	// Cross-safe heads advance after chain B catches up
 	dsl.CheckAll(t,
-		sys.L2ACL.ReachedFn(types.CrossSafe, snapshotCrossSafeA+5, attempts),
-		sys.L2BCL.ReachedFn(types.CrossSafe, snapshotCrossSafeA+5, attempts),
+		sys.L2ACL.ReachedFn(safety.CrossSafe, snapshotCrossSafeA+5, attempts),
+		sys.L2BCL.ReachedFn(safety.CrossSafe, snapshotCrossSafeA+5, attempts),
 	)
 
 	// Check EL labels

--- a/op-acceptance-tests/tests/supernode/interop/startup_resync/startup_resync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/startup_resync/startup_resync_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 const (
@@ -40,16 +41,16 @@ func TestSupernodeResyncResumesAtActivation_PostActivation(gt *testing.T) {
 	// populate, instead of collapsing to empty against a re-recorded
 	// genesis SafeDB entry.
 	dsl.CheckAll(t,
-		sys.L2ACL.AdvancedFn(types.Finalized, preRestartFinalized, 180),
-		sys.L2BCL.AdvancedFn(types.Finalized, preRestartFinalized, 180),
+		sys.L2ACL.AdvancedFn(safety.Finalized, preRestartFinalized, 180),
+		sys.L2BCL.AdvancedFn(safety.Finalized, preRestartFinalized, 180),
 	)
 
 	sys.Supernode.RestartWithFreshDataDir()
 	sys.Supernode.AwaitBackfillCompleted()
 
 	dsl.CheckAll(t,
-		sys.L2ACL.AdvancedFn(types.CrossSafe, 1, 60),
-		sys.L2BCL.AdvancedFn(types.CrossSafe, 1, 60),
+		sys.L2ACL.AdvancedFn(safety.CrossSafe, 1, 60),
+		sys.L2BCL.AdvancedFn(safety.CrossSafe, 1, 60),
 	)
 
 	// Verify the cold-start backfill repopulated the logs DB.
@@ -77,15 +78,15 @@ func TestSupernodeResyncSchedulesAtActivation_PreActivation(gt *testing.T) {
 	// Setup: let local-safe accumulate enough that op-node's SafeDB has
 	// entries to serve to the post-restart cold-start init.
 	dsl.CheckAll(t,
-		sys.L2ACL.AdvancedFn(types.LocalSafe, 2, 30),
-		sys.L2BCL.AdvancedFn(types.LocalSafe, 2, 30),
+		sys.L2ACL.AdvancedFn(safety.LocalSafe, 2, 30),
+		sys.L2BCL.AdvancedFn(safety.LocalSafe, 2, 30),
 	)
 
 	sys.Supernode.RestartWithFreshDataDir()
 	sys.Supernode.AwaitVerificationStartsAt(activation)
 
 	dsl.CheckAll(t,
-		sys.L2ACL.AdvancedFn(types.CrossSafe, 1, 60),
-		sys.L2BCL.AdvancedFn(types.CrossSafe, 1, 60),
+		sys.L2ACL.AdvancedFn(safety.CrossSafe, 1, 60),
+		sys.L2BCL.AdvancedFn(safety.CrossSafe, 1, 60),
 	)
 }

--- a/op-acceptance-tests/tests/sync/clsync/gap_clp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/clsync/gap_clp2p/sync_test.go
@@ -6,7 +6,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // TestSyncAfterInitialELSync tests that blocks received out of order would be processed in order when running in CL sync mode. Note that this is not going to happen when running in EL sync mode, which relies on healthy ELP2P, something that is disabled in this test.
@@ -27,13 +28,13 @@ func TestSyncAfterInitialELSync(gt *testing.T) {
 	sys := newGapCLP2PSystem(t)
 	require := t.Require()
 
-	sys.L2CL.Advanced(types.LocalUnsafe, 7, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, 7, 30)
 
 	// batcher down so safe not advanced
-	require.Zero(sys.L2CL.HeadBlockRef(types.LocalSafe).Number)
-	require.Zero(sys.L2CLB.HeadBlockRef(types.LocalSafe).Number)
+	require.Zero(sys.L2CL.HeadBlockRef(safety.LocalSafe).Number)
+	require.Zero(sys.L2CLB.HeadBlockRef(safety.LocalSafe).Number)
 
-	startNum := sys.L2CLB.HeadBlockRef(types.LocalUnsafe).Number
+	startNum := sys.L2CLB.HeadBlockRef(safety.LocalUnsafe).Number
 
 	// Finish EL sync by supplying the first block
 	// EL Sync finished because underlying EL has states to validate the payload for block startNum+1

--- a/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestReachUnsafeTipByAppendingUnsafePayload(gt *testing.T) {
@@ -15,13 +16,13 @@ func TestReachUnsafeTipByAppendingUnsafePayload(gt *testing.T) {
 	sys := newGapCLP2PSystem(t)
 	logger := t.Logger()
 
-	sys.L2CL.Advanced(types.LocalUnsafe, 7, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, 7, 30)
 
 	// First make verifier reach unsafe tip
 	logger.Info("Initial trial for appending payload until tip")
 	sys.L2CLB.AppendUnsafePayloadUntilTip(sys.L2ELB, sys.L2EL, 400)
 
-	sys.L2CL.Advanced(types.LocalUnsafe, 7, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, 7, 30)
 
 	// Try once more to check that filling in the gap works again
 	logger.Info("Second trial for appending payload until tip")
@@ -62,7 +63,7 @@ func TestCLUnsafeNotRewoundOnInvalidDuringELSync(gt *testing.T) {
 	require := t.Require()
 
 	// Advance few blocks to make sure reference node advanced
-	sys.L2CL.Advanced(types.LocalUnsafe, 7, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, 7, 30)
 
 	// Restart L2CLB to always trigger an EL Sync
 	sys.L2CLB.Stop()
@@ -104,7 +105,7 @@ func TestCLUnsafeNotRewoundOnInvalidDuringELSync(gt *testing.T) {
 	_, ok = payload.CheckBlockHash()
 	require.True(ok)
 	sys.L2CLB.PostUnsafePayload(payload)
-	sys.L2CLB.NotAdvanced(types.LocalUnsafe, attempts)
+	sys.L2CLB.NotAdvanced(safety.LocalUnsafe, attempts)
 	sys.L2ELB.NotAdvanced(eth.Unsafe, attempts)
 	// EL did not advance
 	sys.L2ELB.UnsafeHead().NumEqualTo(startNum)

--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -6,7 +6,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -72,7 +73,7 @@ func TestL2ELP2PCanonicalChainAdvancedByFCU(gt *testing.T) {
 	logger := t.Logger()
 
 	// Advance few blocks to make sure reference node advanced
-	sys.L2CL.Advanced(types.LocalUnsafe, 10, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, 10, 30)
 
 	sys.L2CLB.Stop()
 
@@ -267,7 +268,7 @@ func TestELP2PFCUUnavailableHash(gt *testing.T) {
 	genesis := sys.L2ELB.BlockRefByNumber(0)
 
 	// Advance few blocks to make sure reference node advanced
-	sys.L2CL.Advanced(types.LocalUnsafe, 10, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, 10, 30)
 
 	sys.L2CLB.Stop()
 
@@ -322,7 +323,7 @@ func TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P(gt *testing.T) {
 	logger := t.Logger()
 
 	// Advance few blocks to make sure reference node advanced
-	sys.L2CL.Advanced(types.LocalUnsafe, 10, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, 10, 30)
 
 	sys.L2CLB.Stop()
 
@@ -419,7 +420,7 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	ctx := t.Ctx()
 
 	// Advance few blocks to make sure reference node advanced
-	sys.L2CL.Advanced(types.LocalUnsafe, 4, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, 4, 30)
 
 	// At this point, L2ELB has no ELP2P, and L2CL connection
 	startNum := sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number
@@ -463,7 +464,7 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	// Post invalid payload with the fault that can be only checked at the EL side
 	sys.L2CLB.PostUnsafePayload(payload)
 	// ex) op-geth error msg: "ignoring bad block: invalid merkle root"
-	sys.L2CLB.NotAdvanced(types.LocalUnsafe, attempts)
+	sys.L2CLB.NotAdvanced(safety.LocalUnsafe, attempts)
 	sys.L2ELB.NotAdvanced(eth.Unsafe, attempts)
 	// EL did not advance
 	sys.L2ELB.UnsafeHead().NumEqualTo(startNum + 1)
@@ -484,7 +485,7 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	// Post invalid payload with the fault that can be only checked at the EL side
 	sys.L2CLB.PostUnsafePayload(payload)
 	// ex) op-geth error msg: "ignoring bad block: links to previously rejected block"
-	sys.L2CLB.NotAdvanced(types.LocalUnsafe, attempts)
+	sys.L2CLB.NotAdvanced(safety.LocalUnsafe, attempts)
 	sys.L2ELB.NotAdvanced(eth.Unsafe, attempts)
 	// EL did not advance
 	sys.L2ELB.UnsafeHead().NumEqualTo(startNum + 1)

--- a/op-acceptance-tests/tests/sync/elsync/offset_el_safe/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/offset_el_safe/sync_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // TestELSyncSafeRetractedByOffset verifies that when OffsetELSafe is configured on
@@ -32,9 +33,9 @@ func TestELSyncSafeRetractedByOffset(gt *testing.T) {
 	// Advance both CLs to LocalSafe so the verifier CL has valid finalized state
 	// before we stop it (prevents "forkchoice not initialized" after EL wipe).
 	dsl.CheckAll(t,
-		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
-		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
-	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
+		sys.L2CL.AdvancedFn(safety.LocalSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(safety.LocalSafe, 1, 30))
+	sys.L2CLB.InSync(sys.L2CL, safety.LocalSafe, 30)
 
 	// Stop verifier and wipe its EL to force a full EL sync on restart.
 	sys.L2ELB.Stop()
@@ -46,7 +47,7 @@ func TestELSyncSafeRetractedByOffset(gt *testing.T) {
 	sys.L2Batcher.Stop()
 
 	// Advance sequencer further while verifier is down (unsafe only, no batches).
-	sys.L2CL.Advanced(types.LocalUnsafe, 3, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, 3, 30)
 
 	sys.L2ELB.Start()
 	sys.L2CLB.Start()
@@ -58,7 +59,7 @@ func TestELSyncSafeRetractedByOffset(gt *testing.T) {
 	//  - Derivation began processing old batched data
 	// Because the batcher is stopped, derivation can only reach the last batched
 	// block — the gap between safe and unsafe is permanent.
-	sys.L2CLB.Advanced(types.LocalSafe, 1, 30)
+	sys.L2CLB.Advanced(safety.LocalSafe, 1, 30)
 
 	unsafeHead := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
 	safeHead := sys.L2ELB.SafeHead().BlockRef

--- a/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
 
@@ -104,7 +105,7 @@ func TestUnsafeGapFillAfterSafeReorg(gt *testing.T) {
 	// Reconnect CLP2P so verifier can backfill the unsafe gap
 	sys.L2CLB.ConnectPeer(sys.L2CL)
 	sys.L2CL.ConnectPeer(sys.L2CLB)
-	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 50)
+	sys.L2ELB.InSync(sys.L2EL, safety.LocalUnsafe, 50)
 }
 
 // TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL demonstrates the flow where:
@@ -164,7 +165,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
 	}, 120*time.Second, 2*time.Second)
 
-	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 30)
+	sys.L2ELB.InSync(sys.L2EL, safety.LocalUnsafe, 30)
 
 	// Pick reorg block
 	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
@@ -172,7 +173,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 
 	// Make few more unsafe blocks which will be reorged out
 	sys.L2EL.Advanced(eth.Unsafe, 4)
-	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 30)
+	sys.L2ELB.InSync(sys.L2EL, safety.LocalUnsafe, 30)
 
 	// Stop Verifier CL
 	sys.L2CLB.Stop()
@@ -246,7 +247,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
 
 	// Verifier converged with sequencer's canonical unsafe chain
-	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 50)
+	sys.L2ELB.InSync(sys.L2EL, safety.LocalUnsafe, 50)
 
 	seqUnsafe = sys.L2EL.BlockRefByLabel(eth.Unsafe)
 	verUnsafe = sys.L2ELB.BlockRefByLabel(eth.Unsafe)
@@ -308,7 +309,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
 	}, 120*time.Second, 2*time.Second)
 
-	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 5)
+	sys.L2ELB.InSync(sys.L2EL, safety.LocalUnsafe, 5)
 
 	// Pick reorg block
 	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
@@ -316,7 +317,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 
 	// Make few more unsafe blocks which will be reorged out
 	sys.L2EL.Advanced(eth.Unsafe, 4)
-	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 5)
+	sys.L2ELB.InSync(sys.L2EL, safety.LocalUnsafe, 5)
 
 	// Disconnect CLP2P
 	sys.L2CLB.DisconnectPeer(sys.L2CL)
@@ -367,7 +368,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 	logger.Info("Verifier diverged", "rewindTo", rewindTo)
 
 	// Wait until verifier reset and dropped all reorg blocks
-	sys.L2CLB.Reset(types.LocalUnsafe, rewindTo)
+	sys.L2CLB.Reset(safety.LocalUnsafe, rewindTo)
 	logger.Info("Verifier rewind done", "rewindTo", rewindTo)
 
 	// Make sure CLP2P is connected
@@ -379,7 +380,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
 
 	// Verifier converged with sequencer's canonical unsafe chain
-	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 50)
+	sys.L2ELB.InSync(sys.L2EL, safety.LocalUnsafe, 50)
 
 	seqUnsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
 	verUnsafe = sys.L2ELB.BlockRefByLabel(eth.Unsafe)

--- a/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
 
@@ -38,7 +39,7 @@ func TestFollowL2_Safe_Finalized_CurrentL1(gt *testing.T) {
 	// L2CLB is the verifier without follow source, derivation enabled
 	// L2CLC is the verifier with CL follow source, derivation disabled
 	// All verifiers must eventually advance unsafe, safe, finalized
-	checkMatchedAll := func(lvl types.SafetyLevel) {
+	checkMatchedAll := func(lvl safety.SafetyLevel) {
 		dsl.CheckAll(t,
 			sys.L2CL.ReachedFn(lvl, target, attempts),
 			sys.L2CLB.ReachedFn(lvl, target, attempts),
@@ -50,13 +51,13 @@ func TestFollowL2_Safe_Finalized_CurrentL1(gt *testing.T) {
 		)
 	}
 
-	checkMatchedAll(types.LocalUnsafe)
+	checkMatchedAll(safety.LocalUnsafe)
 	logger.Info("Unsafe head advanced due to CLP2P", "target", target)
 
-	checkMatchedAll(types.LocalSafe)
+	checkMatchedAll(safety.LocalSafe)
 	logger.Info("Safe head followed source", "target", target)
 
-	checkMatchedAll(types.Finalized)
+	checkMatchedAll(safety.Finalized)
 	logger.Info("Finalized head followed source", "target", target)
 
 	attempts = 10
@@ -159,10 +160,10 @@ func TestFollowL2_ReorgRecovery(gt *testing.T) {
 
 	attempts := 30
 	dsl.CheckAll(t,
-		sys.L2CL.InSyncFn(sys.L2CLB, types.LocalUnsafe, attempts),
-		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalUnsafe, attempts),
-		sys.L2CL.InSyncFn(sys.L2CLB, types.LocalSafe, attempts),
-		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalSafe, attempts),
+		sys.L2CL.InSyncFn(sys.L2CLB, safety.LocalUnsafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, safety.LocalUnsafe, attempts),
+		sys.L2CL.InSyncFn(sys.L2CLB, safety.LocalSafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, safety.LocalSafe, attempts),
 	)
 }
 
@@ -188,7 +189,7 @@ func TestFollowL2_WithoutCLP2P(gt *testing.T) {
 	target := uint64(3)
 
 	// L2CLB is the verifier without follow source, derivation enabled
-	sys.L2CLB.Advanced(types.LocalUnsafe, target, attempts)
+	sys.L2CLB.Advanced(safety.LocalUnsafe, target, attempts)
 
 	// The test's primary target is the L2CLC, with follow source and derivation disabled
 	// There is often a gap between safe and unsafe before disconnect, but the
@@ -206,24 +207,24 @@ func TestFollowL2_WithoutCLP2P(gt *testing.T) {
 	sys.L2CL.DisconnectPeer(sys.L2CLC)
 
 	// Advance few safe blocks
-	sys.L2CLC.Advanced(types.LocalSafe, target, attempts)
-	sys.L2CLC.ReachedRef(types.LocalSafe, sys.L2CLB.HeadBlockRef(types.LocalSafe).ID(), attempts)
+	sys.L2CLC.Advanced(safety.LocalSafe, target, attempts)
+	sys.L2CLC.ReachedRef(safety.LocalSafe, sys.L2CLB.HeadBlockRef(safety.LocalSafe).ID(), attempts)
 
 	// Make sure the safe head reaches non-moving unsafe head
-	sys.L2CLC.Reached(types.LocalSafe, sys.L2CLC.UnsafeHead().BlockRef.Number, attempts)
+	sys.L2CLC.Reached(safety.LocalSafe, sys.L2CLC.UnsafeHead().BlockRef.Number, attempts)
 	// The only data source for L2CLC is the follow source.
 	// L2CLC unsafe head will only be advancing with safe head together
 	status = sys.L2CLC.SyncStatus()
 	require.Equal(status.LocalSafeL2, status.UnsafeL2)
-	sys.L2CLC.Advanced(types.LocalSafe, target, attempts)
+	sys.L2CLC.Advanced(safety.LocalSafe, target, attempts)
 
 	// Advance few safe blocks
-	sys.L2CLC.Advanced(types.LocalSafe, target, attempts)
+	sys.L2CLC.Advanced(safety.LocalSafe, target, attempts)
 
 	// Check once again that the unsafe head is moving together with safe head
 	status = sys.L2CLC.SyncStatus()
 	require.Equal(status.LocalSafeL2, status.UnsafeL2)
-	sys.L2CLC.Advanced(types.LocalSafe, target, attempts)
+	sys.L2CLC.Advanced(safety.LocalSafe, target, attempts)
 
 	// Recover CLP2P
 	logger.Info("Recover CLP2P")
@@ -235,11 +236,11 @@ func TestFollowL2_WithoutCLP2P(gt *testing.T) {
 	// Sequencer unsafe payload will arrive to the verifier, triggering EL sync and filling in the unsafe gap
 	dsl.CheckAll(t,
 		// In sync with sequencer, with derivation disabled
-		sys.L2CLC.InSyncFn(sys.L2CL, types.LocalSafe, attempts),
-		sys.L2CLC.InSyncFn(sys.L2CL, types.LocalUnsafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CL, safety.LocalSafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CL, safety.LocalUnsafe, attempts),
 		// In sync with other verifier, with derivation enabled
-		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalSafe, attempts),
-		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalUnsafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, safety.LocalSafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, safety.LocalUnsafe, attempts),
 	)
 
 	t.Cleanup(func() {

--- a/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
@@ -39,7 +39,7 @@ func TestFollowL2_Safe_Finalized_CurrentL1(gt *testing.T) {
 	// L2CLB is the verifier without follow source, derivation enabled
 	// L2CLC is the verifier with CL follow source, derivation disabled
 	// All verifiers must eventually advance unsafe, safe, finalized
-	checkMatchedAll := func(lvl safety.SafetyLevel) {
+	checkMatchedAll := func(lvl safety.Level) {
 		dsl.CheckAll(t,
 			sys.L2CL.ReachedFn(lvl, target, attempts),
 			sys.L2CLB.ReachedFn(lvl, target, attempts),

--- a/op-acceptance-tests/tests/sync/manual/sync_test.go
+++ b/op-acceptance-tests/tests/sync/manual/sync_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum"
 )
 
@@ -36,7 +37,7 @@ func TestVerifierManualSync(gt *testing.T) {
 	logger := t.Logger()
 
 	delta := uint64(7)
-	sys.L2CL.Advanced(types.LocalUnsafe, delta, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, delta, 30)
 
 	// Disable Derivation
 	sys.L2CLB.Stop()

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_e2e/sync_tester_e2e_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_e2e/sync_tester_e2e_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestSyncTesterE2E(gt *testing.T) {
@@ -47,8 +48,8 @@ func TestSyncTesterE2E(gt *testing.T) {
 
 	target := uint64(5)
 	dsl.CheckAll(t,
-		sys.L2CL.AdvancedFn(types.LocalUnsafe, target, 30),
-		sys.L2CL2.AdvancedFn(types.LocalUnsafe, target, 30),
+		sys.L2CL.AdvancedFn(safety.LocalUnsafe, target, 30),
+		sys.L2CL2.AdvancedFn(safety.LocalUnsafe, target, 30),
 	)
 
 	// Test that we can get chain ID from SyncTester

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func simpleWithSyncTesterOpts() []presets.Option {
@@ -32,8 +33,8 @@ func TestSyncTesterELSync(gt *testing.T) {
 	startDelta := uint64(5)
 	attempts := 30
 	dsl.CheckAll(t,
-		sys.L2CL.AdvancedFn(types.LocalUnsafe, startDelta, attempts),
-		sys.L2CL2.AdvancedFn(types.LocalUnsafe, startDelta, attempts),
+		sys.L2CL.AdvancedFn(safety.LocalUnsafe, startDelta, attempts),
+		sys.L2CL2.AdvancedFn(safety.LocalUnsafe, startDelta, attempts),
 	)
 
 	// Stop L2CL2 attached to Sync Tester EL Endpoint
@@ -51,7 +52,7 @@ func TestSyncTesterELSync(gt *testing.T) {
 
 	// Wait for L2CL to advance more unsafe blocks
 	delta := uint64(5)
-	sys.L2CL.Advanced(types.LocalUnsafe, startDelta+delta, attempts)
+	sys.L2CL.Advanced(safety.LocalUnsafe, startDelta+delta, attempts)
 
 	// EL Sync active
 	session := sys.SyncTester.GetSession(sessionID)
@@ -66,7 +67,7 @@ func TestSyncTesterELSync(gt *testing.T) {
 	// Sequencer EL and SyncTester EL advances together
 	target := sys.L2EL.BlockRefByLabel(eth.Unsafe).Number + 5
 	dsl.CheckAll(t,
-		sys.L2CL2.ReachedFn(types.LocalUnsafe, target, attempts),
+		sys.L2CL2.ReachedFn(safety.LocalUnsafe, target, attempts),
 		// EL Sync complete
 		sys.SyncTesterL2EL.ReachedFn(eth.Unsafe, target, attempts),
 	)

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/sync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/sync_test.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func simpleWithSyncTesterOpts() []presets.Option {
@@ -41,7 +42,7 @@ func TestMultiELSync(gt *testing.T) {
 	sys.SyncTester.ResetAllSessions()
 
 	// Advance few blocks to make sure reference node advanced
-	sys.L2CL.Advanced(types.LocalUnsafe, 10, 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, 10, 30)
 
 	// Manually trigger multiple EL Syncs using the engine API
 	startNum := sys.SyncTesterL2EL.BlockRefByLabel(eth.Unsafe).Number

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/sync_tester_hfs_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/sync_tester_hfs_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func ptrToUint64(v uint64) *uint64 {
@@ -59,11 +60,11 @@ func TestSyncTesterHardforks(gt *testing.T) {
 
 	// Unsafe advancement: NewPayload -> ForkchoiceUpdated(no attr)
 	dsl.CheckAll(t,
-		sys.L2CL.AdvancedFn(types.LocalUnsafe, uint64(targetNum), targetNum+10),
-		sys.L2CL2.AdvancedFn(types.LocalUnsafe, uint64(targetNum), targetNum+10),
+		sys.L2CL.AdvancedFn(safety.LocalUnsafe, uint64(targetNum), targetNum+10),
+		sys.L2CL2.AdvancedFn(safety.LocalUnsafe, uint64(targetNum), targetNum+10),
 	)
 
-	current := sys.L2CL2.HeadBlockRef(types.LocalUnsafe)
+	current := sys.L2CL2.HeadBlockRef(safety.LocalUnsafe)
 	require.Greater(current.Time, *jovianTime, "must pass jovian block")
 	// Check block hash state from L2CL2 which was synced using the sync tester
 	require.Equal(sys.L2EL.BlockRefByNumber(current.Number).Hash, current.Hash, "hash mismatch")
@@ -78,15 +79,15 @@ func TestSyncTesterHardforks(gt *testing.T) {
 	sys.SyncTesterL2EL.UnsafeHead().NumEqualTo(0)
 
 	// Wait until safe head reached Jovian
-	sys.L2CL.Reached(types.LocalSafe, current.Number, 20)
+	sys.L2CL.Reached(safety.LocalSafe, current.Number, 20)
 
 	// Check safe head advancement can solely rely on derivation reaching Jovian
 	// Safe advancement: ForkchoiceUpdated(with attr) -> GetPayload -> NewPayload -> ForkchoiceUpdated(no attr)
 	sys.L2CL2.Start()
-	sys.L2CL2.Reached(types.LocalSafe, current.Number, 20)
+	sys.L2CL2.Reached(safety.LocalSafe, current.Number, 20)
 	sys.SyncTesterL2EL.Reached(eth.Safe, current.Number, 10)
 
-	current = sys.L2CL2.HeadBlockRef(types.LocalSafe)
+	current = sys.L2CL2.HeadBlockRef(safety.LocalSafe)
 	require.Greater(current.Time, *jovianTime, "must pass jovian block")
 	// Check block hash state from L2CL2 which was synced using the sync tester
 	require.Equal(sys.L2EL.BlockRefByNumber(current.Number).Hash, current.Hash, "hash mismatch")

--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -29,7 +29,7 @@ func CheckAll(t devtest.T, checks ...CheckFunc) {
 }
 
 type SyncStatusProvider interface {
-	ChainSyncStatus(chainID eth.ChainID, lvl safety.SafetyLevel) eth.BlockID
+	ChainSyncStatus(chainID eth.ChainID, lvl safety.Level) eth.BlockID
 	String() string
 }
 
@@ -41,7 +41,7 @@ var _ SyncStatusProvider = (*L2CLNode)(nil)
 
 // LaggedFn returns a lambda that checks the baseNode head with given safety level is lagged with the refNode chain sync status provider
 // Composable with other lambdas to wait in parallel
-func LaggedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl safety.SafetyLevel, chainID eth.ChainID, attempts int, allowMatch bool) CheckFunc {
+func LaggedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl safety.Level, chainID eth.ChainID, attempts int, allowMatch bool) CheckFunc {
 	return func() error {
 		base := baseNode.ChainSyncStatus(chainID, lvl)
 		ref := refNode.ChainSyncStatus(chainID, lvl)
@@ -72,7 +72,7 @@ func LaggedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.
 
 // MatchedFn returns a lambda that checks the baseNode head with given safety level is matched with the refNode chain sync status provider
 // Composable with other lambdas to wait in parallel
-func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl safety.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
+func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl safety.Level, chainID eth.ChainID, attempts int) CheckFunc {
 	return func() error {
 		base := baseNode.ChainSyncStatus(chainID, lvl)
 		ref := refNode.ChainSyncStatus(chainID, lvl)
@@ -109,7 +109,7 @@ func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context
 // Using a stall detector lets the budget be generous without papering over
 // genuinely stuck systems. The first sample of progressLvl is taken on entry
 // and the stall clock resets every time the progressLvl head advances.
-func MatchedWithProgressFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, matchLvl, progressLvl safety.SafetyLevel, chainID eth.ChainID, maxWait, stallTimeout time.Duration) CheckFunc {
+func MatchedWithProgressFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, matchLvl, progressLvl safety.Level, chainID eth.ChainID, maxWait, stallTimeout time.Duration) CheckFunc {
 	return func() error {
 		logger := log.With("base_id", baseNode, "ref_id", refNode, "chain", chainID, "label", matchLvl, "progress_label", progressLvl)
 		initialBase := baseNode.ChainSyncStatus(chainID, matchLvl)
@@ -181,7 +181,7 @@ const maxInSyncGap = 5
 // Unlike MatchedFn this does not require both live heads to be equal in the
 // same polling tick. Unlike a single-snapshot approach it tolerates either side
 // reorging during the wait, since both heads are re-sampled every attempt.
-func InSyncFn(node1, node2 SyncStatusProvider, log log.Logger, ctx context.Context, lvl safety.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
+func InSyncFn(node1, node2 SyncStatusProvider, log log.Logger, ctx context.Context, lvl safety.Level, chainID eth.ChainID, attempts int) CheckFunc {
 	return func() error {
 		logger := log.With("node1_id", node1, "node2_id", node2, "chain", chainID, "label", lvl)
 		provider1, canLookup1 := node1.(ChainBlockProvider)

--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum/log"
 	"golang.org/x/sync/errgroup"
 )
@@ -28,7 +29,7 @@ func CheckAll(t devtest.T, checks ...CheckFunc) {
 }
 
 type SyncStatusProvider interface {
-	ChainSyncStatus(chainID eth.ChainID, lvl types.SafetyLevel) eth.BlockID
+	ChainSyncStatus(chainID eth.ChainID, lvl safety.SafetyLevel) eth.BlockID
 	String() string
 }
 
@@ -40,7 +41,7 @@ var _ SyncStatusProvider = (*L2CLNode)(nil)
 
 // LaggedFn returns a lambda that checks the baseNode head with given safety level is lagged with the refNode chain sync status provider
 // Composable with other lambdas to wait in parallel
-func LaggedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl types.SafetyLevel, chainID eth.ChainID, attempts int, allowMatch bool) CheckFunc {
+func LaggedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl safety.SafetyLevel, chainID eth.ChainID, attempts int, allowMatch bool) CheckFunc {
 	return func() error {
 		base := baseNode.ChainSyncStatus(chainID, lvl)
 		ref := refNode.ChainSyncStatus(chainID, lvl)
@@ -71,7 +72,7 @@ func LaggedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.
 
 // MatchedFn returns a lambda that checks the baseNode head with given safety level is matched with the refNode chain sync status provider
 // Composable with other lambdas to wait in parallel
-func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl types.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
+func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl safety.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
 	return func() error {
 		base := baseNode.ChainSyncStatus(chainID, lvl)
 		ref := refNode.ChainSyncStatus(chainID, lvl)
@@ -108,7 +109,7 @@ func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context
 // Using a stall detector lets the budget be generous without papering over
 // genuinely stuck systems. The first sample of progressLvl is taken on entry
 // and the stall clock resets every time the progressLvl head advances.
-func MatchedWithProgressFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, matchLvl, progressLvl types.SafetyLevel, chainID eth.ChainID, maxWait, stallTimeout time.Duration) CheckFunc {
+func MatchedWithProgressFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, matchLvl, progressLvl safety.SafetyLevel, chainID eth.ChainID, maxWait, stallTimeout time.Duration) CheckFunc {
 	return func() error {
 		logger := log.With("base_id", baseNode, "ref_id", refNode, "chain", chainID, "label", matchLvl, "progress_label", progressLvl)
 		initialBase := baseNode.ChainSyncStatus(chainID, matchLvl)
@@ -180,7 +181,7 @@ const maxInSyncGap = 5
 // Unlike MatchedFn this does not require both live heads to be equal in the
 // same polling tick. Unlike a single-snapshot approach it tolerates either side
 // reorging during the wait, since both heads are re-sampled every attempt.
-func InSyncFn(node1, node2 SyncStatusProvider, log log.Logger, ctx context.Context, lvl types.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
+func InSyncFn(node1, node2 SyncStatusProvider, log log.Logger, ctx context.Context, lvl safety.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
 	return func() error {
 		logger := log.With("node1_id", node1, "node2_id", node2, "chain", chainID, "label", lvl)
 		provider1, canLookup1 := node1.(ChainBlockProvider)

--- a/op-devstack/dsl/check_test.go
+++ b/op-devstack/dsl/check_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -22,23 +23,23 @@ type programmableSyncProvider struct {
 	name string
 
 	mu   sync.Mutex
-	byID map[types.SafetyLevel]eth.BlockID
+	byID map[safety.SafetyLevel]eth.BlockID
 }
 
 func newProgrammableSyncProvider(name string) *programmableSyncProvider {
 	return &programmableSyncProvider{
 		name: name,
-		byID: map[types.SafetyLevel]eth.BlockID{},
+		byID: map[safety.SafetyLevel]eth.BlockID{},
 	}
 }
 
-func (p *programmableSyncProvider) set(lvl types.SafetyLevel, num uint64, hash common.Hash) {
+func (p *programmableSyncProvider) set(lvl safety.SafetyLevel, num uint64, hash common.Hash) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.byID[lvl] = eth.BlockID{Number: num, Hash: hash}
 }
 
-func (p *programmableSyncProvider) ChainSyncStatus(chainID eth.ChainID, lvl types.SafetyLevel) eth.BlockID {
+func (p *programmableSyncProvider) ChainSyncStatus(chainID eth.ChainID, lvl safety.SafetyLevel) eth.BlockID {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.byID[lvl]
@@ -52,14 +53,14 @@ func TestMatchedWithProgressFn_SucceedsOnMatch(t *testing.T) {
 	ref := newProgrammableSyncProvider("ref")
 	chainID := eth.ChainIDFromUInt64(901)
 	h := common.HexToHash("0xabc")
-	base.set(types.CrossSafe, 10, h)
-	base.set(types.LocalUnsafe, 10, h)
-	ref.set(types.CrossSafe, 10, h)
+	base.set(safety.CrossSafe, 10, h)
+	base.set(safety.LocalUnsafe, 10, h)
+	ref.set(safety.CrossSafe, 10, h)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	check := MatchedWithProgressFn(base, ref, testlog.Logger(t, log.LevelDebug), ctx,
-		types.CrossSafe, types.LocalUnsafe, chainID,
+		safety.CrossSafe, safety.LocalUnsafe, chainID,
 		5*time.Second, 1*time.Second)
 
 	require.NoError(t, check())
@@ -73,14 +74,14 @@ func TestMatchedWithProgressFn_FailsOnStall(t *testing.T) {
 	h1 := common.HexToHash("0x1")
 	h2 := common.HexToHash("0x2")
 	// Base CrossSafe never matches; LocalUnsafe never advances either.
-	base.set(types.CrossSafe, 0, common.Hash{})
-	base.set(types.LocalUnsafe, 5, h1)
-	ref.set(types.CrossSafe, 10, h2)
+	base.set(safety.CrossSafe, 0, common.Hash{})
+	base.set(safety.LocalUnsafe, 5, h1)
+	ref.set(safety.CrossSafe, 10, h2)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	check := MatchedWithProgressFn(base, ref, testlog.Logger(t, log.LevelDebug), ctx,
-		types.CrossSafe, types.LocalUnsafe, chainID,
+		safety.CrossSafe, safety.LocalUnsafe, chainID,
 		30*time.Second, 3*time.Second)
 
 	start := time.Now()
@@ -98,9 +99,9 @@ func TestMatchedWithProgressFn_KeepsWaitingWhileProgressing(t *testing.T) {
 	chainID := eth.ChainIDFromUInt64(901)
 	h := common.HexToHash("0xabc")
 	// Base CrossSafe stalls at 0; LocalUnsafe steadily advances; ref CrossSafe at 10.
-	base.set(types.CrossSafe, 0, common.Hash{})
-	base.set(types.LocalUnsafe, 5, common.HexToHash("0x5"))
-	ref.set(types.CrossSafe, 10, h)
+	base.set(safety.CrossSafe, 0, common.Hash{})
+	base.set(safety.LocalUnsafe, 5, common.HexToHash("0x5"))
+	ref.set(safety.CrossSafe, 10, h)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -115,16 +116,16 @@ func TestMatchedWithProgressFn_KeepsWaitingWhileProgressing(t *testing.T) {
 			if err := clock.SystemClock.SleepCtx(ctx, 500*time.Millisecond); err != nil {
 				return
 			}
-			base.set(types.LocalUnsafe, uint64(i), common.BigToHash(common.Big1))
+			base.set(safety.LocalUnsafe, uint64(i), common.BigToHash(common.Big1))
 		}
 		// Now let CrossSafe match.
-		base.set(types.CrossSafe, 10, h)
+		base.set(safety.CrossSafe, 10, h)
 	}()
 
 	// Stall timeout is short (1s) but the driver advances LocalUnsafe every
 	// 500ms, so the stall detector should never trip.
 	check := MatchedWithProgressFn(base, ref, testlog.Logger(t, log.LevelDebug), ctx,
-		types.CrossSafe, types.LocalUnsafe, chainID,
+		safety.CrossSafe, safety.LocalUnsafe, chainID,
 		30*time.Second, 1*time.Second)
 	require.NoError(t, check())
 	driverWG.Wait()
@@ -138,9 +139,9 @@ func TestMatchedWithProgressFn_FailsOnMaxWait(t *testing.T) {
 	h := common.HexToHash("0xabc")
 	// Base CrossSafe never matches; LocalUnsafe keeps advancing so the stall
 	// detector never trips — the deadline should be the failure path.
-	base.set(types.CrossSafe, 0, common.Hash{})
-	base.set(types.LocalUnsafe, 0, common.Hash{})
-	ref.set(types.CrossSafe, 10, h)
+	base.set(safety.CrossSafe, 0, common.Hash{})
+	base.set(safety.LocalUnsafe, 0, common.Hash{})
+	ref.set(safety.CrossSafe, 10, h)
 
 	driverCtx, driverCancel := context.WithCancel(context.Background())
 	var driverWG sync.WaitGroup
@@ -154,7 +155,7 @@ func TestMatchedWithProgressFn_FailsOnMaxWait(t *testing.T) {
 				return
 			case <-time.After(200 * time.Millisecond):
 				i++
-				base.set(types.LocalUnsafe, i, common.BigToHash(common.Big1))
+				base.set(safety.LocalUnsafe, i, common.BigToHash(common.Big1))
 			}
 		}
 	}()
@@ -162,7 +163,7 @@ func TestMatchedWithProgressFn_FailsOnMaxWait(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	check := MatchedWithProgressFn(base, ref, testlog.Logger(t, log.LevelDebug), ctx,
-		types.CrossSafe, types.LocalUnsafe, chainID,
+		safety.CrossSafe, safety.LocalUnsafe, chainID,
 		5*time.Second, 30*time.Second)
 
 	start := time.Now()

--- a/op-devstack/dsl/check_test.go
+++ b/op-devstack/dsl/check_test.go
@@ -23,23 +23,23 @@ type programmableSyncProvider struct {
 	name string
 
 	mu   sync.Mutex
-	byID map[safety.SafetyLevel]eth.BlockID
+	byID map[safety.Level]eth.BlockID
 }
 
 func newProgrammableSyncProvider(name string) *programmableSyncProvider {
 	return &programmableSyncProvider{
 		name: name,
-		byID: map[safety.SafetyLevel]eth.BlockID{},
+		byID: map[safety.Level]eth.BlockID{},
 	}
 }
 
-func (p *programmableSyncProvider) set(lvl safety.SafetyLevel, num uint64, hash common.Hash) {
+func (p *programmableSyncProvider) set(lvl safety.Level, num uint64, hash common.Hash) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.byID[lvl] = eth.BlockID{Number: num, Hash: hash}
 }
 
-func (p *programmableSyncProvider) ChainSyncStatus(chainID eth.ChainID, lvl safety.SafetyLevel) eth.BlockID {
+func (p *programmableSyncProvider) ChainSyncStatus(chainID eth.ChainID, lvl safety.Level) eth.BlockID {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.byID[lvl]

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -16,7 +16,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -50,7 +51,7 @@ func (cl *L2CLNode) Escape() stack.L2CLNode {
 }
 
 func (cl *L2CLNode) SafeL2BlockRef() eth.L2BlockRef {
-	return cl.HeadBlockRef(types.CrossSafe)
+	return cl.HeadBlockRef(safety.CrossSafe)
 }
 
 func (cl *L2CLNode) Start() {
@@ -88,7 +89,7 @@ func (cl *L2CLNode) StartSequencer() {
 	var err error
 loop:
 	for range maxAttempts {
-		unsafe := cl.HeadBlockRef(types.LocalUnsafe)
+		unsafe := cl.HeadBlockRef(safety.LocalUnsafe)
 		cl.log.Info("Continue sequencing with consensus node (op-node)", "chain", cl.ChainID(), "unsafe", unsafe)
 		err = cl.inner.RollupAPI().StartSequencer(cl.ctx, unsafe.Hash)
 		if err == nil {
@@ -155,21 +156,21 @@ func (cl *L2CLNode) SyncStatus() *eth.SyncStatus {
 
 // headBlockRef is the error-returning variant of HeadBlockRef, for use inside
 // retry/eventually loops.
-func (cl *L2CLNode) headBlockRef(lvl types.SafetyLevel) (eth.L2BlockRef, error) {
+func (cl *L2CLNode) headBlockRef(lvl safety.SafetyLevel) (eth.L2BlockRef, error) {
 	syncStatus, err := cl.syncStatus()
 	if err != nil {
 		return eth.L2BlockRef{}, err
 	}
 	switch lvl {
-	case types.Finalized:
+	case safety.Finalized:
 		return syncStatus.FinalizedL2, nil
-	case types.CrossSafe:
+	case safety.CrossSafe:
 		return syncStatus.SafeL2, nil
-	case types.LocalSafe:
+	case safety.LocalSafe:
 		return syncStatus.LocalSafeL2, nil
-	case types.CrossUnsafe:
+	case safety.CrossUnsafe:
 		return syncStatus.CrossUnsafeL2, nil
-	case types.LocalUnsafe:
+	case safety.LocalUnsafe:
 		return syncStatus.UnsafeL2, nil
 	default:
 		return eth.L2BlockRef{}, fmt.Errorf("invalid safety level: %v", lvl)
@@ -177,7 +178,7 @@ func (cl *L2CLNode) headBlockRef(lvl types.SafetyLevel) (eth.L2BlockRef, error) 
 }
 
 // HeadBlockRef fetches L2CL sync status and returns block ref with given safety level
-func (cl *L2CLNode) HeadBlockRef(lvl types.SafetyLevel) eth.L2BlockRef {
+func (cl *L2CLNode) HeadBlockRef(lvl safety.SafetyLevel) eth.L2BlockRef {
 	blockRef, err := cl.headBlockRef(lvl)
 	cl.require.NoError(err)
 	return blockRef
@@ -204,7 +205,7 @@ func (cl *L2CLNode) AwaitMinL1Processed(minL1 uint64) {
 
 // AdvancedFn returns a lambda that checks the L2CL chain head with given safety level advanced more than delta block number
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) AdvancedFn(lvl types.SafetyLevel, delta uint64, attempts int) CheckFunc {
+func (cl *L2CLNode) AdvancedFn(lvl safety.SafetyLevel, delta uint64, attempts int) CheckFunc {
 	return func() error {
 		initial := cl.HeadBlockRef(lvl)
 		target := initial.Number + delta
@@ -213,7 +214,7 @@ func (cl *L2CLNode) AdvancedFn(lvl types.SafetyLevel, delta uint64, attempts int
 	}
 }
 
-func (cl *L2CLNode) NotAdvancedFn(lvl types.SafetyLevel, attempts int) CheckFunc {
+func (cl *L2CLNode) NotAdvancedFn(lvl safety.SafetyLevel, attempts int) CheckFunc {
 	return func() error {
 		initial := cl.HeadBlockRef(lvl)
 		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "target", initial.Number)
@@ -247,7 +248,7 @@ func (cl *L2CLNode) NotAdvancedFn(lvl types.SafetyLevel, attempts int) CheckFunc
 
 // awaitSafeHeadsStalled waits until every node's safe head has stopped advancing
 // for at least 10 seconds.
-func (cl *L2CLNode) WaitForStall(lvl types.SafetyLevel) {
+func (cl *L2CLNode) WaitForStall(lvl safety.SafetyLevel) {
 	var last eth.BlockID
 	var stableSince time.Time
 	cl.require.Eventuallyf(func() bool {
@@ -271,7 +272,7 @@ func (cl *L2CLNode) WaitForStall(lvl types.SafetyLevel) {
 
 // ReachedFn returns a lambda that checks the L2CL chain head with given safety level reaches the target block number
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) ReachedFn(lvl types.SafetyLevel, target uint64, attempts int) CheckFunc {
+func (cl *L2CLNode) ReachedFn(lvl safety.SafetyLevel, target uint64, attempts int) CheckFunc {
 	return func() error {
 		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "target", target)
 		logger.Info("Expecting chain to reach")
@@ -294,7 +295,7 @@ func (cl *L2CLNode) ReachedFn(lvl types.SafetyLevel, target uint64, attempts int
 
 // ReachedRefFn is same as Reached, but has an additional check to ensure that the block referenced is not reorged
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) ReachedRefFn(lvl types.SafetyLevel, target eth.BlockID, attempts int) CheckFunc {
+func (cl *L2CLNode) ReachedRefFn(lvl safety.SafetyLevel, target eth.BlockID, attempts int) CheckFunc {
 	return func() error {
 		err := cl.ReachedFn(lvl, target.Number, attempts)()
 		if err != nil {
@@ -315,7 +316,7 @@ func (cl *L2CLNode) ReachedRefFn(lvl types.SafetyLevel, target eth.BlockID, atte
 
 // RewindedFn returns a lambda that checks the L2CL chain head with given safety level rewinded more than the delta block number
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) RewindedFn(lvl types.SafetyLevel, delta uint64, attempts int) CheckFunc {
+func (cl *L2CLNode) RewindedFn(lvl safety.SafetyLevel, delta uint64, attempts int) CheckFunc {
 	return func() error {
 		initial := cl.HeadBlockRef(lvl)
 		cl.require.GreaterOrEqual(initial.Number, delta, "cannot rewind before genesis")
@@ -340,40 +341,40 @@ func (cl *L2CLNode) RewindedFn(lvl types.SafetyLevel, delta uint64, attempts int
 	}
 }
 
-func (cl *L2CLNode) Advanced(lvl types.SafetyLevel, delta uint64, attempts int) {
+func (cl *L2CLNode) Advanced(lvl safety.SafetyLevel, delta uint64, attempts int) {
 	cl.require.NoError(cl.AdvancedFn(lvl, delta, attempts)())
 }
 
 func (cl *L2CLNode) AdvancedUnsafe(delta uint64, attempts int) {
-	cl.Advanced(types.LocalUnsafe, delta, attempts)
+	cl.Advanced(safety.LocalUnsafe, delta, attempts)
 }
 
-func (cl *L2CLNode) NotAdvanced(lvl types.SafetyLevel, attempts int) {
+func (cl *L2CLNode) NotAdvanced(lvl safety.SafetyLevel, attempts int) {
 	cl.require.NoError(cl.NotAdvancedFn(lvl, attempts)())
 }
 
 func (cl *L2CLNode) NotAdvancedUnsafe(attempts int) {
-	cl.NotAdvanced(types.LocalUnsafe, attempts)
+	cl.NotAdvanced(safety.LocalUnsafe, attempts)
 }
 
-func (cl *L2CLNode) Reached(lvl types.SafetyLevel, target uint64, attempts int) {
+func (cl *L2CLNode) Reached(lvl safety.SafetyLevel, target uint64, attempts int) {
 	cl.require.NoError(cl.ReachedFn(lvl, target, attempts)())
 }
 
 func (cl *L2CLNode) ReachedUnsafe(target uint64, attempts int) {
-	cl.Reached(types.LocalUnsafe, target, attempts)
+	cl.Reached(safety.LocalUnsafe, target, attempts)
 }
 
-func (cl *L2CLNode) ReachedRef(lvl types.SafetyLevel, target eth.BlockID, attempts int) {
+func (cl *L2CLNode) ReachedRef(lvl safety.SafetyLevel, target eth.BlockID, attempts int) {
 	cl.require.NoError(cl.ReachedRefFn(lvl, target, attempts)())
 }
 
-func (cl *L2CLNode) Rewinded(lvl types.SafetyLevel, delta uint64, attempts int) {
+func (cl *L2CLNode) Rewinded(lvl safety.SafetyLevel, delta uint64, attempts int) {
 	cl.require.NoError(cl.RewindedFn(lvl, delta, attempts)())
 }
 
 // ChainSyncStatus satisfies that the L2CLNode can provide sync status per chain
-func (cl *L2CLNode) ChainSyncStatus(chainID eth.ChainID, lvl types.SafetyLevel) eth.BlockID {
+func (cl *L2CLNode) ChainSyncStatus(chainID eth.ChainID, lvl safety.SafetyLevel) eth.BlockID {
 	cl.require.Equal(chainID, cl.inner.ChainID(), "chain ID mismatch")
 	return cl.HeadBlockRef(lvl).ID()
 }
@@ -398,13 +399,13 @@ func (cl *L2CLNode) safeHeadAtL1Block(l1BlockNum uint64) *eth.SafeHeadResponse {
 
 // LaggedFn returns a lambda that checks the L2CL chain head with given safety level is lagged with the reference chain sync status provider
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) LaggedFn(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int, allowMatch bool) CheckFunc {
+func (cl *L2CLNode) LaggedFn(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int, allowMatch bool) CheckFunc {
 	return LaggedFn(cl, refNode, cl.log, cl.ctx, lvl, cl.ChainID(), attempts, allowMatch)
 }
 
 // MatchedFn returns a lambda that checks the L2CLNode head with given safety level is matched with the refNode chain sync status provider
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) MatchedFn(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) CheckFunc {
+func (cl *L2CLNode) MatchedFn(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int) CheckFunc {
 	return MatchedFn(cl, refNode, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
 }
 
@@ -412,28 +413,28 @@ func (cl *L2CLNode) MatchedFn(refNode SyncStatusProvider, lvl types.SafetyLevel,
 // match refNode's matchLvl head while requiring cl to keep making progress on
 // progressLvl. See MatchedWithProgressFn in check.go for the precise semantics.
 // Composable with other lambdas to wait in parallel.
-func (cl *L2CLNode) MatchedWithProgressFn(refNode SyncStatusProvider, matchLvl, progressLvl types.SafetyLevel, maxWait, stallTimeout time.Duration) CheckFunc {
+func (cl *L2CLNode) MatchedWithProgressFn(refNode SyncStatusProvider, matchLvl, progressLvl safety.SafetyLevel, maxWait, stallTimeout time.Duration) CheckFunc {
 	return MatchedWithProgressFn(cl, refNode, cl.log, cl.ctx, matchLvl, progressLvl, cl.ChainID(), maxWait, stallTimeout)
 }
 
-func (cl *L2CLNode) InSyncFn(other SyncStatusProvider, lvl types.SafetyLevel, attempts int) CheckFunc {
+func (cl *L2CLNode) InSyncFn(other SyncStatusProvider, lvl safety.SafetyLevel, attempts int) CheckFunc {
 	return InSyncFn(cl, other, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
 }
 
-func (cl *L2CLNode) Lagged(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int, allowMatch bool) {
+func (cl *L2CLNode) Lagged(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int, allowMatch bool) {
 	cl.require.NoError(cl.LaggedFn(refNode, lvl, attempts, allowMatch)())
 }
 
-func (cl *L2CLNode) Matched(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) {
+func (cl *L2CLNode) Matched(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int) {
 	cl.require.NoError(cl.MatchedFn(refNode, lvl, attempts)())
 }
 
-func (cl *L2CLNode) InSync(other SyncStatusProvider, lvl types.SafetyLevel, attempts int) {
+func (cl *L2CLNode) InSync(other SyncStatusProvider, lvl safety.SafetyLevel, attempts int) {
 	cl.require.NoError(cl.InSyncFn(other, lvl, attempts)())
 }
 
 func (cl *L2CLNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {
-	cl.Matched(refNode, types.LocalUnsafe, attempts)
+	cl.Matched(refNode, safety.LocalUnsafe, attempts)
 }
 
 func (cl *L2CLNode) PeerInfo() *apis.PeerInfo {
@@ -562,7 +563,7 @@ func (cl *L2CLNode) PostUnsafePayload(payload *eth.ExecutionPayloadEnvelope) {
 	cl.require.NoErrorf(err, "failed to post unsafe payload via admin API: target %d", payload.ExecutionPayload.BlockNumber)
 }
 
-func (cl *L2CLNode) Reset(lvl types.SafetyLevel, target eth.L2BlockRef) {
+func (cl *L2CLNode) Reset(lvl safety.SafetyLevel, target eth.L2BlockRef) {
 	cl.require.NoError(retry.Do0(cl.ctx, 5, &retry.FixedStrategy{Dur: 2 * time.Second},
 		func() error {
 			res := cl.HeadBlockRef(lvl)
@@ -592,11 +593,11 @@ func (cl *L2CLNode) AppendUnsafePayloadUntilTip(verEL, seqEL *L2ELNode, maxAttem
 }
 
 func (cl *L2CLNode) UnsafeHead() *BlockRefResult {
-	return &BlockRefResult{T: cl.t, BlockRef: cl.HeadBlockRef(types.LocalUnsafe)}
+	return &BlockRefResult{T: cl.t, BlockRef: cl.HeadBlockRef(safety.LocalUnsafe)}
 }
 
 func (cl *L2CLNode) SafeHead() *BlockRefResult {
-	return &BlockRefResult{T: cl.t, BlockRef: cl.HeadBlockRef(types.CrossSafe)}
+	return &BlockRefResult{T: cl.t, BlockRef: cl.HeadBlockRef(safety.CrossSafe)}
 }
 
 func (cl *L2CLNode) CurrentL1MatchedFn(refNode *L2CLNode, attempts int) CheckFunc {
@@ -616,7 +617,7 @@ func (cl *L2CLNode) CurrentL1MatchedFn(refNode *L2CLNode, attempts int) CheckFun
 }
 
 func (cl *L2CLNode) LocalGameInputs(agreedBlock, claimBlock uint64) *utils.LocalGameInputs {
-	cl.Reached(types.LocalSafe, claimBlock, 60)
+	cl.Reached(safety.LocalSafe, claimBlock, 60)
 
 	rollupAPI := cl.Escape().RollupAPI()
 

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -156,7 +156,7 @@ func (cl *L2CLNode) SyncStatus() *eth.SyncStatus {
 
 // headBlockRef is the error-returning variant of HeadBlockRef, for use inside
 // retry/eventually loops.
-func (cl *L2CLNode) headBlockRef(lvl safety.SafetyLevel) (eth.L2BlockRef, error) {
+func (cl *L2CLNode) headBlockRef(lvl safety.Level) (eth.L2BlockRef, error) {
 	syncStatus, err := cl.syncStatus()
 	if err != nil {
 		return eth.L2BlockRef{}, err
@@ -178,7 +178,7 @@ func (cl *L2CLNode) headBlockRef(lvl safety.SafetyLevel) (eth.L2BlockRef, error)
 }
 
 // HeadBlockRef fetches L2CL sync status and returns block ref with given safety level
-func (cl *L2CLNode) HeadBlockRef(lvl safety.SafetyLevel) eth.L2BlockRef {
+func (cl *L2CLNode) HeadBlockRef(lvl safety.Level) eth.L2BlockRef {
 	blockRef, err := cl.headBlockRef(lvl)
 	cl.require.NoError(err)
 	return blockRef
@@ -205,7 +205,7 @@ func (cl *L2CLNode) AwaitMinL1Processed(minL1 uint64) {
 
 // AdvancedFn returns a lambda that checks the L2CL chain head with given safety level advanced more than delta block number
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) AdvancedFn(lvl safety.SafetyLevel, delta uint64, attempts int) CheckFunc {
+func (cl *L2CLNode) AdvancedFn(lvl safety.Level, delta uint64, attempts int) CheckFunc {
 	return func() error {
 		initial := cl.HeadBlockRef(lvl)
 		target := initial.Number + delta
@@ -214,7 +214,7 @@ func (cl *L2CLNode) AdvancedFn(lvl safety.SafetyLevel, delta uint64, attempts in
 	}
 }
 
-func (cl *L2CLNode) NotAdvancedFn(lvl safety.SafetyLevel, attempts int) CheckFunc {
+func (cl *L2CLNode) NotAdvancedFn(lvl safety.Level, attempts int) CheckFunc {
 	return func() error {
 		initial := cl.HeadBlockRef(lvl)
 		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "target", initial.Number)
@@ -248,7 +248,7 @@ func (cl *L2CLNode) NotAdvancedFn(lvl safety.SafetyLevel, attempts int) CheckFun
 
 // awaitSafeHeadsStalled waits until every node's safe head has stopped advancing
 // for at least 10 seconds.
-func (cl *L2CLNode) WaitForStall(lvl safety.SafetyLevel) {
+func (cl *L2CLNode) WaitForStall(lvl safety.Level) {
 	var last eth.BlockID
 	var stableSince time.Time
 	cl.require.Eventuallyf(func() bool {
@@ -272,7 +272,7 @@ func (cl *L2CLNode) WaitForStall(lvl safety.SafetyLevel) {
 
 // ReachedFn returns a lambda that checks the L2CL chain head with given safety level reaches the target block number
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) ReachedFn(lvl safety.SafetyLevel, target uint64, attempts int) CheckFunc {
+func (cl *L2CLNode) ReachedFn(lvl safety.Level, target uint64, attempts int) CheckFunc {
 	return func() error {
 		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "target", target)
 		logger.Info("Expecting chain to reach")
@@ -295,7 +295,7 @@ func (cl *L2CLNode) ReachedFn(lvl safety.SafetyLevel, target uint64, attempts in
 
 // ReachedRefFn is same as Reached, but has an additional check to ensure that the block referenced is not reorged
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) ReachedRefFn(lvl safety.SafetyLevel, target eth.BlockID, attempts int) CheckFunc {
+func (cl *L2CLNode) ReachedRefFn(lvl safety.Level, target eth.BlockID, attempts int) CheckFunc {
 	return func() error {
 		err := cl.ReachedFn(lvl, target.Number, attempts)()
 		if err != nil {
@@ -316,7 +316,7 @@ func (cl *L2CLNode) ReachedRefFn(lvl safety.SafetyLevel, target eth.BlockID, att
 
 // RewindedFn returns a lambda that checks the L2CL chain head with given safety level rewinded more than the delta block number
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) RewindedFn(lvl safety.SafetyLevel, delta uint64, attempts int) CheckFunc {
+func (cl *L2CLNode) RewindedFn(lvl safety.Level, delta uint64, attempts int) CheckFunc {
 	return func() error {
 		initial := cl.HeadBlockRef(lvl)
 		cl.require.GreaterOrEqual(initial.Number, delta, "cannot rewind before genesis")
@@ -341,7 +341,7 @@ func (cl *L2CLNode) RewindedFn(lvl safety.SafetyLevel, delta uint64, attempts in
 	}
 }
 
-func (cl *L2CLNode) Advanced(lvl safety.SafetyLevel, delta uint64, attempts int) {
+func (cl *L2CLNode) Advanced(lvl safety.Level, delta uint64, attempts int) {
 	cl.require.NoError(cl.AdvancedFn(lvl, delta, attempts)())
 }
 
@@ -349,7 +349,7 @@ func (cl *L2CLNode) AdvancedUnsafe(delta uint64, attempts int) {
 	cl.Advanced(safety.LocalUnsafe, delta, attempts)
 }
 
-func (cl *L2CLNode) NotAdvanced(lvl safety.SafetyLevel, attempts int) {
+func (cl *L2CLNode) NotAdvanced(lvl safety.Level, attempts int) {
 	cl.require.NoError(cl.NotAdvancedFn(lvl, attempts)())
 }
 
@@ -357,7 +357,7 @@ func (cl *L2CLNode) NotAdvancedUnsafe(attempts int) {
 	cl.NotAdvanced(safety.LocalUnsafe, attempts)
 }
 
-func (cl *L2CLNode) Reached(lvl safety.SafetyLevel, target uint64, attempts int) {
+func (cl *L2CLNode) Reached(lvl safety.Level, target uint64, attempts int) {
 	cl.require.NoError(cl.ReachedFn(lvl, target, attempts)())
 }
 
@@ -365,16 +365,16 @@ func (cl *L2CLNode) ReachedUnsafe(target uint64, attempts int) {
 	cl.Reached(safety.LocalUnsafe, target, attempts)
 }
 
-func (cl *L2CLNode) ReachedRef(lvl safety.SafetyLevel, target eth.BlockID, attempts int) {
+func (cl *L2CLNode) ReachedRef(lvl safety.Level, target eth.BlockID, attempts int) {
 	cl.require.NoError(cl.ReachedRefFn(lvl, target, attempts)())
 }
 
-func (cl *L2CLNode) Rewinded(lvl safety.SafetyLevel, delta uint64, attempts int) {
+func (cl *L2CLNode) Rewinded(lvl safety.Level, delta uint64, attempts int) {
 	cl.require.NoError(cl.RewindedFn(lvl, delta, attempts)())
 }
 
 // ChainSyncStatus satisfies that the L2CLNode can provide sync status per chain
-func (cl *L2CLNode) ChainSyncStatus(chainID eth.ChainID, lvl safety.SafetyLevel) eth.BlockID {
+func (cl *L2CLNode) ChainSyncStatus(chainID eth.ChainID, lvl safety.Level) eth.BlockID {
 	cl.require.Equal(chainID, cl.inner.ChainID(), "chain ID mismatch")
 	return cl.HeadBlockRef(lvl).ID()
 }
@@ -399,13 +399,13 @@ func (cl *L2CLNode) safeHeadAtL1Block(l1BlockNum uint64) *eth.SafeHeadResponse {
 
 // LaggedFn returns a lambda that checks the L2CL chain head with given safety level is lagged with the reference chain sync status provider
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) LaggedFn(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int, allowMatch bool) CheckFunc {
+func (cl *L2CLNode) LaggedFn(refNode SyncStatusProvider, lvl safety.Level, attempts int, allowMatch bool) CheckFunc {
 	return LaggedFn(cl, refNode, cl.log, cl.ctx, lvl, cl.ChainID(), attempts, allowMatch)
 }
 
 // MatchedFn returns a lambda that checks the L2CLNode head with given safety level is matched with the refNode chain sync status provider
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) MatchedFn(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int) CheckFunc {
+func (cl *L2CLNode) MatchedFn(refNode SyncStatusProvider, lvl safety.Level, attempts int) CheckFunc {
 	return MatchedFn(cl, refNode, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
 }
 
@@ -413,23 +413,23 @@ func (cl *L2CLNode) MatchedFn(refNode SyncStatusProvider, lvl safety.SafetyLevel
 // match refNode's matchLvl head while requiring cl to keep making progress on
 // progressLvl. See MatchedWithProgressFn in check.go for the precise semantics.
 // Composable with other lambdas to wait in parallel.
-func (cl *L2CLNode) MatchedWithProgressFn(refNode SyncStatusProvider, matchLvl, progressLvl safety.SafetyLevel, maxWait, stallTimeout time.Duration) CheckFunc {
+func (cl *L2CLNode) MatchedWithProgressFn(refNode SyncStatusProvider, matchLvl, progressLvl safety.Level, maxWait, stallTimeout time.Duration) CheckFunc {
 	return MatchedWithProgressFn(cl, refNode, cl.log, cl.ctx, matchLvl, progressLvl, cl.ChainID(), maxWait, stallTimeout)
 }
 
-func (cl *L2CLNode) InSyncFn(other SyncStatusProvider, lvl safety.SafetyLevel, attempts int) CheckFunc {
+func (cl *L2CLNode) InSyncFn(other SyncStatusProvider, lvl safety.Level, attempts int) CheckFunc {
 	return InSyncFn(cl, other, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
 }
 
-func (cl *L2CLNode) Lagged(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int, allowMatch bool) {
+func (cl *L2CLNode) Lagged(refNode SyncStatusProvider, lvl safety.Level, attempts int, allowMatch bool) {
 	cl.require.NoError(cl.LaggedFn(refNode, lvl, attempts, allowMatch)())
 }
 
-func (cl *L2CLNode) Matched(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int) {
+func (cl *L2CLNode) Matched(refNode SyncStatusProvider, lvl safety.Level, attempts int) {
 	cl.require.NoError(cl.MatchedFn(refNode, lvl, attempts)())
 }
 
-func (cl *L2CLNode) InSync(other SyncStatusProvider, lvl safety.SafetyLevel, attempts int) {
+func (cl *L2CLNode) InSync(other SyncStatusProvider, lvl safety.Level, attempts int) {
 	cl.require.NoError(cl.InSyncFn(other, lvl, attempts)())
 }
 
@@ -563,7 +563,7 @@ func (cl *L2CLNode) PostUnsafePayload(payload *eth.ExecutionPayloadEnvelope) {
 	cl.require.NoErrorf(err, "failed to post unsafe payload via admin API: target %d", payload.ExecutionPayload.BlockNumber)
 }
 
-func (cl *L2CLNode) Reset(lvl safety.SafetyLevel, target eth.L2BlockRef) {
+func (cl *L2CLNode) Reset(lvl safety.Level, target eth.L2BlockRef) {
 	cl.require.NoError(retry.Do0(cl.ctx, 5, &retry.FixedStrategy{Dur: 2 * time.Second},
 		func() error {
 			res := cl.HeadBlockRef(lvl)

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -16,7 +16,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
-	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -448,15 +449,15 @@ func (el *L2ELNode) FinishedELSync(refNode *L2ELNode, unsafe, safe, finalized ui
 	}))
 }
 
-func (el *L2ELNode) ChainSyncStatus(chainID eth.ChainID, lvl suptypes.SafetyLevel) eth.BlockID {
+func (el *L2ELNode) ChainSyncStatus(chainID eth.ChainID, lvl safety.SafetyLevel) eth.BlockID {
 	el.require.Equal(chainID, el.inner.ChainID(), "chain ID mismatch")
 	var blockRef eth.L2BlockRef
 	switch lvl {
-	case suptypes.Finalized:
+	case safety.Finalized:
 		blockRef = el.BlockRefByLabel(eth.Finalized)
-	case suptypes.CrossSafe, suptypes.LocalSafe:
+	case safety.CrossSafe, safety.LocalSafe:
 		blockRef = el.BlockRefByLabel(eth.Safe)
-	case suptypes.CrossUnsafe, suptypes.LocalUnsafe:
+	case safety.CrossUnsafe, safety.LocalUnsafe:
 		blockRef = el.BlockRefByLabel(eth.Unsafe)
 	default:
 		el.require.NoError(errors.New("invalid safety level"))
@@ -488,24 +489,24 @@ func (el *L2ELNode) WaitForReceipt(txHash common.Hash) *types.Receipt {
 	return receipt
 }
 
-func (el *L2ELNode) MatchedFn(refNode SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) CheckFunc {
+func (el *L2ELNode) MatchedFn(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int) CheckFunc {
 	return MatchedFn(el, refNode, el.log, el.ctx, lvl, el.ChainID(), attempts)
 }
 
-func (el *L2ELNode) InSyncFn(other SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) CheckFunc {
+func (el *L2ELNode) InSyncFn(other SyncStatusProvider, lvl safety.SafetyLevel, attempts int) CheckFunc {
 	return InSyncFn(el, other, el.log, el.ctx, lvl, el.ChainID(), attempts)
 }
 
-func (el *L2ELNode) Matched(refNode SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) {
+func (el *L2ELNode) Matched(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int) {
 	el.require.NoError(el.MatchedFn(refNode, lvl, attempts)())
 }
 
-func (el *L2ELNode) InSync(other SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) {
+func (el *L2ELNode) InSync(other SyncStatusProvider, lvl safety.SafetyLevel, attempts int) {
 	el.require.NoError(el.InSyncFn(other, lvl, attempts)())
 }
 
 func (el *L2ELNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {
-	el.Matched(refNode, suptypes.LocalUnsafe, attempts)
+	el.Matched(refNode, safety.LocalUnsafe, attempts)
 }
 
 // WaitForPendingNonceMatchFn returns a lambda that waits for the pending nonce of an account to match the provided reference nonce

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -449,7 +449,7 @@ func (el *L2ELNode) FinishedELSync(refNode *L2ELNode, unsafe, safe, finalized ui
 	}))
 }
 
-func (el *L2ELNode) ChainSyncStatus(chainID eth.ChainID, lvl safety.SafetyLevel) eth.BlockID {
+func (el *L2ELNode) ChainSyncStatus(chainID eth.ChainID, lvl safety.Level) eth.BlockID {
 	el.require.Equal(chainID, el.inner.ChainID(), "chain ID mismatch")
 	var blockRef eth.L2BlockRef
 	switch lvl {
@@ -489,19 +489,19 @@ func (el *L2ELNode) WaitForReceipt(txHash common.Hash) *types.Receipt {
 	return receipt
 }
 
-func (el *L2ELNode) MatchedFn(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int) CheckFunc {
+func (el *L2ELNode) MatchedFn(refNode SyncStatusProvider, lvl safety.Level, attempts int) CheckFunc {
 	return MatchedFn(el, refNode, el.log, el.ctx, lvl, el.ChainID(), attempts)
 }
 
-func (el *L2ELNode) InSyncFn(other SyncStatusProvider, lvl safety.SafetyLevel, attempts int) CheckFunc {
+func (el *L2ELNode) InSyncFn(other SyncStatusProvider, lvl safety.Level, attempts int) CheckFunc {
 	return InSyncFn(el, other, el.log, el.ctx, lvl, el.ChainID(), attempts)
 }
 
-func (el *L2ELNode) Matched(refNode SyncStatusProvider, lvl safety.SafetyLevel, attempts int) {
+func (el *L2ELNode) Matched(refNode SyncStatusProvider, lvl safety.Level, attempts int) {
 	el.require.NoError(el.MatchedFn(refNode, lvl, attempts)())
 }
 
-func (el *L2ELNode) InSync(other SyncStatusProvider, lvl safety.SafetyLevel, attempts int) {
+func (el *L2ELNode) InSync(other SyncStatusProvider, lvl safety.Level, attempts int) {
 	el.require.NoError(el.InSyncFn(other, lvl, attempts)())
 }
 

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -22,7 +22,7 @@ import (
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	safetyTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
@@ -431,7 +432,7 @@ func (f *DisputeGameFactory) startOutputRootGameOfType(
 func (f *DisputeGameFactory) createOutputGameExtraData(blockNum uint64, cfg *GameCfg) []byte {
 	f.require.NotNil(f.l2CL, "L2 CL is required create output games")
 	if !cfg.allowFuture {
-		f.l2CL.Reached(safetyTypes.LocalSafe, blockNum, 30)
+		f.l2CL.Reached(safety.LocalSafe, blockNum, 30)
 	}
 	extraData := make([]byte, 32)
 	binary.BigEndian.PutUint64(extraData[24:], blockNum)

--- a/op-devstack/presets/singlechain_from_runtime.go
+++ b/op-devstack/presets/singlechain_from_runtime.go
@@ -13,7 +13,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // Initial-sync-check budgets for singleChainMultiNodeFromRuntime. Attempts are
@@ -103,16 +104,16 @@ func singleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRunt
 			// than burn the whole budget. See #20649.
 			crossSafeCheck = preset.L2CLB.MatchedWithProgressFn(
 				preset.L2CL,
-				types.CrossSafe, types.LocalUnsafe,
+				safety.CrossSafe, safety.LocalUnsafe,
 				initialSyncCrossSafeELSyncMaxWait,
 				initialSyncCrossSafeELSyncStallTimeout,
 			)
 		} else {
-			crossSafeCheck = preset.L2CLB.MatchedFn(preset.L2CL, types.CrossSafe, initialSyncCheckAttemptsCrossSafe)
+			crossSafeCheck = preset.L2CLB.MatchedFn(preset.L2CL, safety.CrossSafe, initialSyncCheckAttemptsCrossSafe)
 		}
 		runInitialSyncChecks(t, preset.L2ELB, isELSync,
 			crossSafeCheck,
-			preset.L2CLB.MatchedFn(preset.L2CL, types.LocalUnsafe, initialSyncCheckAttemptsLocalUnsafe),
+			preset.L2CLB.MatchedFn(preset.L2CL, safety.LocalUnsafe, initialSyncCheckAttemptsLocalUnsafe),
 		)
 	}
 	return preset

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -157,7 +157,7 @@ func (b *Backend) Ready() bool {
 }
 
 // supportedSafetyLevel returns true if the safety level is supported for access list checks.
-func supportedSafetyLevel(level safety.SafetyLevel) bool {
+func supportedSafetyLevel(level safety.Level) bool {
 	return level == safety.LocalUnsafe || level == safety.CrossUnsafe
 }
 
@@ -177,7 +177,7 @@ func classifyRejectionReason(err error) string {
 
 // CheckAccessList validates the given access list entries.
 func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety safety.SafetyLevel, execDescriptor messages.ExecutingDescriptor) error {
+	minSafety safety.Level, execDescriptor messages.ExecutingDescriptor) error {
 
 	start := time.Now()
 	defer func() {

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // Backend coordinates chain ingesters and handles CheckAccessList requests.
@@ -156,8 +157,8 @@ func (b *Backend) Ready() bool {
 }
 
 // supportedSafetyLevel returns true if the safety level is supported for access list checks.
-func supportedSafetyLevel(level types.SafetyLevel) bool {
-	return level == types.LocalUnsafe || level == types.CrossUnsafe
+func supportedSafetyLevel(level safety.SafetyLevel) bool {
+	return level == safety.LocalUnsafe || level == safety.CrossUnsafe
 }
 
 // classifyRejectionReason categorizes an error from CheckAccessList into a rejection reason label.
@@ -176,7 +177,7 @@ func classifyRejectionReason(err error) string {
 
 // CheckAccessList validates the given access list entries.
 func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, execDescriptor messages.ExecutingDescriptor) error {
+	minSafety safety.SafetyLevel, execDescriptor messages.ExecutingDescriptor) error {
 
 	start := time.Now()
 	defer func() {
@@ -205,7 +206,7 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 		b.metrics.RecordCheckAccessList(false)
 		b.metrics.RecordCheckAccessListRejection("invalid_executing_message")
 		return fmt.Errorf("unsupported safety level %s: only %s and %s are supported",
-			minSafety, types.LocalUnsafe, types.CrossUnsafe)
+			minSafety, safety.LocalUnsafe, safety.CrossUnsafe)
 	}
 
 	if _, ok := b.chains[execDescriptor.ChainID]; !ok {

--- a/op-interop-filter/filter/backend_test.go
+++ b/op-interop-filter/filter/backend_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // Test constants
@@ -178,6 +178,6 @@ func TestBackend_CheckAccessList_SupportLegacyCheckAccessListFormat(t *testing.T
 	mock.SetReady(true)
 	mock.SetLatestTimestamp(200)
 
-	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(0, 150, 0))
+	err := backend.CheckAccessList(context.Background(), nil, safety.LocalUnsafe, makeExecDescriptor(0, 150, 0))
 	require.NoError(t, err)
 }

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -21,7 +21,7 @@ type QueryFrontend struct {
 
 // CheckAccessList validates interop executing messages
 func (f *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety safety.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
+	minSafety safety.Level, executingDescriptor messages.ExecutingDescriptor) error {
 
 	err := f.backend.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
 	if err != nil {

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // QueryFrontend handles supervisor query RPC methods
@@ -20,7 +21,7 @@ type QueryFrontend struct {
 
 // CheckAccessList validates interop executing messages
 func (f *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
+	minSafety safety.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
 
 	err := f.backend.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
 	if err != nil {

--- a/op-interop-filter/filter/interfaces.go
+++ b/op-interop-filter/filter/interfaces.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // LogsDB is the subset of an op-supervisor logs DB that
@@ -89,7 +89,7 @@ type CrossValidator interface {
 	Stop() error
 
 	// ValidateAccessEntry validates a single access list entry.
-	ValidateAccessEntry(access messages.Access, minSafety types.SafetyLevel, execDescriptor messages.ExecutingDescriptor) error
+	ValidateAccessEntry(access messages.Access, minSafety safety.SafetyLevel, execDescriptor messages.ExecutingDescriptor) error
 
 	// CrossValidatedTimestamp returns the global cross-validated timestamp.
 	CrossValidatedTimestamp() (uint64, bool)

--- a/op-interop-filter/filter/interfaces.go
+++ b/op-interop-filter/filter/interfaces.go
@@ -89,7 +89,7 @@ type CrossValidator interface {
 	Stop() error
 
 	// ValidateAccessEntry validates a single access list entry.
-	ValidateAccessEntry(access messages.Access, minSafety safety.SafetyLevel, execDescriptor messages.ExecutingDescriptor) error
+	ValidateAccessEntry(access messages.Access, minSafety safety.Level, execDescriptor messages.ExecutingDescriptor) error
 
 	// CrossValidatedTimestamp returns the global cross-validated timestamp.
 	CrossValidatedTimestamp() (uint64, bool)

--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -188,7 +188,7 @@ func validateMessageTiming(
 // ValidateAccessEntry validates a single access list entry against all message validity rules.
 func (v *LockstepCrossValidator) ValidateAccessEntry(
 	access messages.Access,
-	minSafety safety.SafetyLevel,
+	minSafety safety.Level,
 	execDescriptor messages.ExecutingDescriptor,
 ) error {
 	// Check that we have ingested data for the requested timestamp

--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // LockstepCrossValidator validates cross-chain executing messages and tracks
@@ -187,7 +188,7 @@ func validateMessageTiming(
 // ValidateAccessEntry validates a single access list entry against all message validity rules.
 func (v *LockstepCrossValidator) ValidateAccessEntry(
 	access messages.Access,
-	minSafety types.SafetyLevel,
+	minSafety safety.SafetyLevel,
 	execDescriptor messages.ExecutingDescriptor,
 ) error {
 	// Check that we have ingested data for the requested timestamp
@@ -198,7 +199,7 @@ func (v *LockstepCrossValidator) ValidateAccessEntry(
 	}
 
 	// Check cross-unsafe timestamp
-	if minSafety == types.CrossUnsafe {
+	if minSafety == safety.CrossUnsafe {
 		crossValidatedTs, ok := v.CrossValidatedTimestamp()
 		if !ok {
 			return fmt.Errorf("cross-validated timestamp not available: %w", types.ErrOutOfScope)

--- a/op-interop-filter/filter/lockstep_cross_validator_test.go
+++ b/op-interop-filter/filter/lockstep_cross_validator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // Note: Test helpers (newTestCrossValidator, makeAccess, makeExecDescriptor) and
@@ -40,7 +41,7 @@ func TestCrossValidator_TimeoutExceedsExpiry(t *testing.T) {
 	// 200 < 201, so should fail
 	exec := makeExecDescriptor(testChainA, 150, 51)
 
-	err := cv.ValidateAccessEntry(access, types.LocalUnsafe, exec)
+	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
 	require.ErrorIs(t, err, types.ErrConflict)
 	require.Contains(t, err.Error(), "expire before timeout")
@@ -68,12 +69,12 @@ func TestCrossValidator_CrossUnsafe_Boundary(t *testing.T) {
 	// At boundary: access at timestamp 100 == crossValidatedTs=100 should pass
 	access := makeAccess(testChainA, 100, 10, 0, checksum)
 	exec := makeExecDescriptor(testChainA, 150, 0)
-	err := cv.ValidateAccessEntry(access, types.CrossUnsafe, exec)
+	err := cv.ValidateAccessEntry(access, safety.CrossUnsafe, exec)
 	require.NoError(t, err)
 
 	// Beyond boundary: access at timestamp 101 > crossValidatedTs=100 should fail
 	access = makeAccess(testChainA, 101, 10, 0, checksum)
-	err = cv.ValidateAccessEntry(access, types.CrossUnsafe, exec)
+	err = cv.ValidateAccessEntry(access, safety.CrossUnsafe, exec)
 	require.Error(t, err)
 	require.ErrorIs(t, err, types.ErrOutOfScope)
 }
@@ -96,7 +97,7 @@ func TestCrossValidator_KnownChain(t *testing.T) {
 	access := makeAccess(testChainA, 100, 10, 0, checksum)
 	exec := makeExecDescriptor(testChainA, 150, 0)
 
-	err := cv.ValidateAccessEntry(access, types.LocalUnsafe, exec)
+	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.NoError(t, err)
 }
 
@@ -114,7 +115,7 @@ func TestCrossValidator_UnknownChain(t *testing.T) {
 	access := makeAccess(unknownChainID, 100, 10, 0, messages.MessageChecksum{0x01})
 	exec := makeExecDescriptor(testChainA, 150, 0)
 
-	err := cv.ValidateAccessEntry(access, types.LocalUnsafe, exec)
+	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
 	require.ErrorIs(t, err, types.ErrUnknownChain)
 }
@@ -133,7 +134,7 @@ func TestCrossValidator_InitiatingMessageNotFound(t *testing.T) {
 	access := makeAccess(testChainA, 100, 10, 0, messages.MessageChecksum{0x01})
 	exec := makeExecDescriptor(testChainA, 150, 0)
 
-	err := cv.ValidateAccessEntry(access, types.LocalUnsafe, exec)
+	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
 	require.ErrorIs(t, err, types.ErrConflict)
 }
@@ -267,7 +268,7 @@ func TestValidateAccessEntry_TimestampNotIngested(t *testing.T) {
 	access := makeAccess(testChainA, 150, 10, 0, checksum)
 	exec := makeExecDescriptor(testChainA, 200, 0)
 
-	err := cv.ValidateAccessEntry(access, types.LocalUnsafe, exec)
+	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
 	require.ErrorIs(t, err, types.ErrOutOfScope)
 	require.Contains(t, err.Error(), "not yet ingested")
@@ -292,7 +293,7 @@ func TestValidateExecMsg_InitBeforeInclusion(t *testing.T) {
 	access := makeAccess(testChainA, 100, 10, 0, checksum)
 	exec := makeExecDescriptor(testChainA, 100, 0) // Same as init timestamp
 
-	err := cv.ValidateAccessEntry(access, types.LocalUnsafe, exec)
+	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
 	require.ErrorIs(t, err, types.ErrConflict)
 	require.Contains(t, err.Error(), "not before inclusion")
@@ -314,7 +315,7 @@ func TestValidateExecMsg_MessageExpired(t *testing.T) {
 	access := makeAccess(testChainA, 100, 10, 0, checksum)
 	exec := makeExecDescriptor(testChainA, 250, 0)
 
-	err := cv.ValidateAccessEntry(access, types.LocalUnsafe, exec)
+	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
 	require.ErrorIs(t, err, types.ErrConflict)
 	require.Contains(t, err.Error(), "expired")

--- a/op-interop-filter/filter/logsdb_integration_backend_test.go
+++ b/op-interop-filter/filter/logsdb_integration_backend_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestIntegration_Backend_NoChains_FailsafeOn(t *testing.T) {
@@ -31,7 +32,7 @@ func TestIntegration_Backend_NoChains_FailsafeOn(t *testing.T) {
 	})
 
 	require.False(t, bk.Ready(), "empty chain map -> Backend.Ready() is false")
-	err := bk.CheckAccessList(ctx, nil, types.LocalUnsafe, messages.ExecutingDescriptor{ChainID: executingChain()})
+	err := bk.CheckAccessList(ctx, nil, safety.LocalUnsafe, messages.ExecutingDescriptor{ChainID: executingChain()})
 	require.ErrorIs(t, err, types.ErrUninitialized)
 }
 
@@ -85,7 +86,7 @@ func TestIntegration_Backend_UnsupportedSafetyLevel_Rejected(t *testing.T) {
 	t.Parallel()
 
 	bk := twoChainBackend(t, 1)
-	err := bk.CheckAccessList(context.Background(), nil, types.Finalized,
+	err := bk.CheckAccessList(context.Background(), nil, safety.Finalized,
 		messages.ExecutingDescriptor{ChainID: executingChain(), Timestamp: inclusionTs})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported safety level")
@@ -95,7 +96,7 @@ func TestIntegration_Backend_EmptyAccessList_LocalUnsafe_Accepted(t *testing.T) 
 	t.Parallel()
 
 	bk := twoChainBackend(t, 1)
-	require.NoError(t, bk.CheckAccessList(context.Background(), nil, types.LocalUnsafe,
+	require.NoError(t, bk.CheckAccessList(context.Background(), nil, safety.LocalUnsafe,
 		messages.ExecutingDescriptor{ChainID: executingChain(), Timestamp: inclusionTs}))
 }
 
@@ -114,7 +115,7 @@ func TestIntegration_Backend_Ready_FalseUntilAllChainsReady(t *testing.T) {
 
 	require.False(t, bk.Ready(), "Backend.Ready requires all ingesters Ready")
 
-	err := bk.CheckAccessList(context.Background(), nil, types.LocalUnsafe,
+	err := bk.CheckAccessList(context.Background(), nil, safety.LocalUnsafe,
 		messages.ExecutingDescriptor{ChainID: executingChain(), Timestamp: inclusionTs})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, types.ErrUninitialized) || errors.Is(err, types.ErrFailsafeEnabled),

--- a/op-interop-filter/filter/logsdb_integration_helpers_test.go
+++ b/op-interop-filter/filter/logsdb_integration_helpers_test.go
@@ -18,9 +18,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 const (
@@ -463,7 +463,7 @@ func newSeededBackend(t *testing.T, opts backendOpts) *seededBackend {
 // CheckAccessList expects and forwards the call.
 func (sb *seededBackend) checkAccessList(execChain eth.ChainID, execTs uint64, accesses ...messages.Access) error {
 	entries := messages.EncodeAccessList(accesses)
-	return sb.CheckAccessList(context.Background(), entries, types.LocalUnsafe,
+	return sb.CheckAccessList(context.Background(), entries, safety.LocalUnsafe,
 		messages.ExecutingDescriptor{Timestamp: execTs, ChainID: execChain})
 }
 

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 // mockChainIngester is an in-memory implementation of ChainIngester for testing.
@@ -266,7 +267,7 @@ type mockCrossValidator struct {
 
 func (m *mockCrossValidator) Start() error { return nil }
 func (m *mockCrossValidator) Stop() error  { return nil }
-func (m *mockCrossValidator) ValidateAccessEntry(access messages.Access, minSafety types.SafetyLevel, execDescriptor messages.ExecutingDescriptor) error {
+func (m *mockCrossValidator) ValidateAccessEntry(access messages.Access, minSafety safety.SafetyLevel, execDescriptor messages.ExecutingDescriptor) error {
 	return m.validateErr
 }
 func (m *mockCrossValidator) CrossValidatedTimestamp() (uint64, bool) { return 0, false }

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -267,7 +267,7 @@ type mockCrossValidator struct {
 
 func (m *mockCrossValidator) Start() error { return nil }
 func (m *mockCrossValidator) Stop() error  { return nil }
-func (m *mockCrossValidator) ValidateAccessEntry(access messages.Access, minSafety safety.SafetyLevel, execDescriptor messages.ExecutingDescriptor) error {
+func (m *mockCrossValidator) ValidateAccessEntry(access messages.Access, minSafety safety.Level, execDescriptor messages.ExecutingDescriptor) error {
 	return m.validateErr
 }
 func (m *mockCrossValidator) CrossValidatedTimestamp() (uint64, bool) { return 0, false }

--- a/op-service/apis/interop_filter.go
+++ b/op-service/apis/interop_filter.go
@@ -8,11 +8,11 @@ import (
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 type InteropFilterQueryAPI interface {
 	CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-		minSafety types.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error
+		minSafety safety.Level, executingDescriptor messages.ExecutingDescriptor) error
 	GetBlockHashByNumber(ctx context.Context, chainID eth.ChainID, blockNum rpc.BlockNumber) (common.Hash, error)
 }

--- a/op-service/apis/supervisor.go
+++ b/op-service/apis/supervisor.go
@@ -29,7 +29,7 @@ type SupervisorAdminAPI interface {
 
 type SupervisorQueryAPI interface {
 	CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-		minSafety safety.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error
+		minSafety safety.Level, executingDescriptor messages.ExecutingDescriptor) error
 	CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
 	LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	LocalSafe(ctx context.Context, chainID eth.ChainID) (result types.DerivedIDPair, err error)

--- a/op-service/apis/supervisor.go
+++ b/op-service/apis/supervisor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 type SupervisorAPI interface {
@@ -28,7 +29,7 @@ type SupervisorAdminAPI interface {
 
 type SupervisorQueryAPI interface {
 	CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-		minSafety types.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error
+		minSafety safety.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error
 	CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
 	LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	LocalSafe(ctx context.Context, chainID eth.ChainID) (result types.DerivedIDPair, err error)

--- a/op-service/eth/safety/safety.go
+++ b/op-service/eth/safety/safety.go
@@ -10,14 +10,14 @@ var (
 	errUnrecognizedSafetyLevel = errors.New("unrecognized safety level")
 )
 
-type SafetyLevel string
+type Level string
 
-func (lvl SafetyLevel) String() string {
+func (lvl Level) String() string {
 	return string(lvl)
 }
 
-// Validate returns true if the SafetyLevel is one of the recognized levels
-func (lvl SafetyLevel) Validate() bool {
+// Validate returns true if the Level is one of the recognized levels
+func (lvl Level) Validate() bool {
 	switch lvl {
 	case Invalid, Finalized, CrossSafe, LocalSafe, CrossUnsafe, LocalUnsafe:
 		return true
@@ -26,15 +26,15 @@ func (lvl SafetyLevel) Validate() bool {
 	}
 }
 
-func (lvl SafetyLevel) MarshalText() ([]byte, error) {
+func (lvl Level) MarshalText() ([]byte, error) {
 	return []byte(lvl), nil
 }
 
-func (lvl *SafetyLevel) UnmarshalText(text []byte) error {
+func (lvl *Level) UnmarshalText(text []byte) error {
 	if lvl == nil {
 		return errNilSafetyLevel
 	}
-	x := SafetyLevel(text)
+	x := Level(text)
 	if !x.Validate() {
 		return fmt.Errorf("%w: %q", errUnrecognizedSafetyLevel, text)
 	}
@@ -46,21 +46,21 @@ const (
 	// Finalized is CrossSafe, with the additional constraint that every
 	// dependency is derived only from finalized L1 input data.
 	// This matches RPC label "finalized".
-	Finalized SafetyLevel = "finalized"
+	Finalized Level = "finalized"
 	// CrossSafe is as safe as LocalSafe, with all its dependencies
 	// also fully verified to be reproducible from L1.
 	// This matches RPC label "safe".
-	CrossSafe SafetyLevel = "safe"
+	CrossSafe Level = "safe"
 	// LocalSafe is verified to be reproducible from L1,
 	// without any verified cross-L2 dependencies.
 	// This does not have an RPC label.
-	LocalSafe SafetyLevel = "local-safe"
+	LocalSafe Level = "local-safe"
 	// CrossUnsafe is as safe as LocalUnsafe,
 	// but with verified cross-L2 dependencies that are at least CrossUnsafe.
 	// This does not have an RPC label.
-	CrossUnsafe SafetyLevel = "cross-unsafe"
+	CrossUnsafe Level = "cross-unsafe"
 	// LocalUnsafe is the safety of the tip of the chain. This matches RPC label "unsafe".
-	LocalUnsafe SafetyLevel = "unsafe"
+	LocalUnsafe Level = "unsafe"
 	// Invalid is the safety of when the message or block is not matching the expected data.
-	Invalid SafetyLevel = "invalid"
+	Invalid Level = "invalid"
 )

--- a/op-service/eth/safety/safety.go
+++ b/op-service/eth/safety/safety.go
@@ -1,0 +1,66 @@
+package safety
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errNilSafetyLevel          = errors.New("nil safety level")
+	errUnrecognizedSafetyLevel = errors.New("unrecognized safety level")
+)
+
+type SafetyLevel string
+
+func (lvl SafetyLevel) String() string {
+	return string(lvl)
+}
+
+// Validate returns true if the SafetyLevel is one of the recognized levels
+func (lvl SafetyLevel) Validate() bool {
+	switch lvl {
+	case Invalid, Finalized, CrossSafe, LocalSafe, CrossUnsafe, LocalUnsafe:
+		return true
+	default:
+		return false
+	}
+}
+
+func (lvl SafetyLevel) MarshalText() ([]byte, error) {
+	return []byte(lvl), nil
+}
+
+func (lvl *SafetyLevel) UnmarshalText(text []byte) error {
+	if lvl == nil {
+		return errNilSafetyLevel
+	}
+	x := SafetyLevel(text)
+	if !x.Validate() {
+		return fmt.Errorf("%w: %q", errUnrecognizedSafetyLevel, text)
+	}
+	*lvl = x
+	return nil
+}
+
+const (
+	// Finalized is CrossSafe, with the additional constraint that every
+	// dependency is derived only from finalized L1 input data.
+	// This matches RPC label "finalized".
+	Finalized SafetyLevel = "finalized"
+	// CrossSafe is as safe as LocalSafe, with all its dependencies
+	// also fully verified to be reproducible from L1.
+	// This matches RPC label "safe".
+	CrossSafe SafetyLevel = "safe"
+	// LocalSafe is verified to be reproducible from L1,
+	// without any verified cross-L2 dependencies.
+	// This does not have an RPC label.
+	LocalSafe SafetyLevel = "local-safe"
+	// CrossUnsafe is as safe as LocalUnsafe,
+	// but with verified cross-L2 dependencies that are at least CrossUnsafe.
+	// This does not have an RPC label.
+	CrossUnsafe SafetyLevel = "cross-unsafe"
+	// LocalUnsafe is the safety of the tip of the chain. This matches RPC label "unsafe".
+	LocalUnsafe SafetyLevel = "unsafe"
+	// Invalid is the safety of when the message or block is not matching the expected data.
+	Invalid SafetyLevel = "invalid"
+)

--- a/op-service/eth/safety/safety_test.go
+++ b/op-service/eth/safety/safety_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSafetyLevel(t *testing.T) {
-	for _, lvl := range []SafetyLevel{
+	for _, lvl := range []Level{
 		Finalized,
 		CrossSafe,
 		LocalSafe,
@@ -19,14 +19,14 @@ func TestSafetyLevel(t *testing.T) {
 		Invalid,
 	} {
 		upper := strings.ToUpper(lvl.String())
-		var x SafetyLevel
+		var x Level
 		require.ErrorContains(t, json.Unmarshal([]byte(fmt.Sprintf("%q", upper)), &x), "unrecognized", "case sensitive")
 		require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf("%q", lvl.String())), &x))
 		dat, err := json.Marshal(x)
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprintf("%q", lvl.String()), string(dat))
 	}
-	var x SafetyLevel
+	var x Level
 	require.ErrorContains(t, json.Unmarshal([]byte(`""`), &x), "unrecognized", "empty")
 	require.ErrorContains(t, json.Unmarshal([]byte(`"foobar"`), &x), "unrecognized", "other")
 }

--- a/op-service/eth/safety/safety_test.go
+++ b/op-service/eth/safety/safety_test.go
@@ -1,0 +1,32 @@
+package safety
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafetyLevel(t *testing.T) {
+	for _, lvl := range []SafetyLevel{
+		Finalized,
+		CrossSafe,
+		LocalSafe,
+		CrossUnsafe,
+		LocalUnsafe,
+		Invalid,
+	} {
+		upper := strings.ToUpper(lvl.String())
+		var x SafetyLevel
+		require.ErrorContains(t, json.Unmarshal([]byte(fmt.Sprintf("%q", upper)), &x), "unrecognized", "case sensitive")
+		require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf("%q", lvl.String())), &x))
+		dat, err := json.Marshal(x)
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("%q", lvl.String()), string(dat))
+	}
+	var x SafetyLevel
+	require.ErrorContains(t, json.Unmarshal([]byte(`""`), &x), "unrecognized", "empty")
+	require.ErrorContains(t, json.Unmarshal([]byte(`"foobar"`), &x), "unrecognized", "other")
+}

--- a/op-service/sources/interop_filter_client.go
+++ b/op-service/sources/interop_filter_client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 type InteropFilterClient struct {
@@ -29,7 +29,7 @@ func NewInteropFilterClient(client client.RPC) *InteropFilterClient {
 }
 
 func (cl *InteropFilterClient) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
+	minSafety safety.Level, executingDescriptor messages.ExecutingDescriptor) error {
 	return cl.client.CallContext(ctx, nil, "interop_checkAccessList", inboxEntries, minSafety, executingDescriptor)
 }
 

--- a/op-service/sources/interop_filter_client_test.go
+++ b/op-service/sources/interop_filter_client_test.go
@@ -13,7 +13,7 @@ import (
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestInteropFilterClient_CheckAccessList(t *testing.T) {
@@ -23,7 +23,7 @@ func TestInteropFilterClient_CheckAccessList(t *testing.T) {
 	client := NewInteropFilterClient(rpcClient)
 
 	inboxEntries := []common.Hash{common.HexToHash("0x01")}
-	minSafety := types.CrossUnsafe
+	minSafety := safety.CrossUnsafe
 	execDescriptor := messages.ExecutingDescriptor{
 		ChainID:   eth.ChainIDFromUInt64(900),
 		Timestamp: 123,

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -77,7 +77,7 @@ func (cl *SupervisorClient) GetFailsafeEnabled(ctx context.Context) (bool, error
 }
 
 func (cl *SupervisorClient) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety safety.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
+	minSafety safety.Level, executingDescriptor messages.ExecutingDescriptor) error {
 	return cl.client.CallContext(ctx, nil, "supervisor_checkAccessList", inboxEntries, minSafety, executingDescriptor)
 }
 

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 type SupervisorClient struct {
@@ -76,7 +77,7 @@ func (cl *SupervisorClient) GetFailsafeEnabled(ctx context.Context) (bool, error
 }
 
 func (cl *SupervisorClient) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
+	minSafety safety.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
 	return cl.client.CallContext(ctx, nil, "supervisor_checkAccessList", inboxEntries, minSafety, executingDescriptor)
 }
 

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -553,7 +553,7 @@ func (su *SupervisorBackend) checkAccessWithRPC(ctx context.Context, acc message
 
 // checkSafety is a helper method to check if a block has the given safety level.
 // It is already assumed to exist in the canonical unsafe chain.
-func (su *SupervisorBackend) checkSafety(chainID eth.ChainID, blockID eth.BlockID, safetyLevel safety.SafetyLevel) error {
+func (su *SupervisorBackend) checkSafety(chainID eth.ChainID, blockID eth.BlockID, safetyLevel safety.Level) error {
 	switch safetyLevel {
 	case safety.LocalUnsafe:
 		return nil // msg exists, nothing more to check
@@ -571,7 +571,7 @@ func (su *SupervisorBackend) checkSafety(chainID eth.ChainID, blockID eth.BlockI
 }
 
 func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety safety.SafetyLevel, execDescr messages.ExecutingDescriptor) error {
+	minSafety safety.Level, execDescr messages.ExecutingDescriptor) error {
 	// Check if failsafe is enabled
 	if su.isFailsafeEnabled() {
 		su.logger.Debug("Failsafe is enabled, rejecting access-list check")

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 type SupervisorBackend struct {
@@ -552,17 +553,17 @@ func (su *SupervisorBackend) checkAccessWithRPC(ctx context.Context, acc message
 
 // checkSafety is a helper method to check if a block has the given safety level.
 // It is already assumed to exist in the canonical unsafe chain.
-func (su *SupervisorBackend) checkSafety(chainID eth.ChainID, blockID eth.BlockID, safetyLevel types.SafetyLevel) error {
+func (su *SupervisorBackend) checkSafety(chainID eth.ChainID, blockID eth.BlockID, safetyLevel safety.SafetyLevel) error {
 	switch safetyLevel {
-	case types.LocalUnsafe:
+	case safety.LocalUnsafe:
 		return nil // msg exists, nothing more to check
-	case types.CrossUnsafe:
+	case safety.CrossUnsafe:
 		return su.chainDBs.IsCrossUnsafe(chainID, blockID)
-	case types.LocalSafe:
+	case safety.LocalSafe:
 		return su.chainDBs.IsLocalSafe(chainID, blockID)
-	case types.CrossSafe:
+	case safety.CrossSafe:
 		return su.chainDBs.IsCrossSafe(chainID, blockID)
-	case types.Finalized:
+	case safety.Finalized:
 		return su.chainDBs.IsFinalized(chainID, blockID)
 	default:
 		return types.ErrConflict
@@ -570,7 +571,7 @@ func (su *SupervisorBackend) checkSafety(chainID eth.ChainID, blockID eth.BlockI
 }
 
 func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, execDescr messages.ExecutingDescriptor) error {
+	minSafety safety.SafetyLevel, execDescr messages.ExecutingDescriptor) error {
 	// Check if failsafe is enabled
 	if su.isFailsafeEnabled() {
 		su.logger.Debug("Failsafe is enabled, rejecting access-list check")
@@ -578,7 +579,7 @@ func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries [
 	}
 
 	switch minSafety {
-	case types.LocalUnsafe, types.CrossUnsafe, types.LocalSafe, types.CrossSafe, types.Finalized:
+	case safety.LocalUnsafe, safety.CrossUnsafe, safety.LocalSafe, safety.CrossSafe, safety.Finalized:
 		// valid safety level
 	default:
 		return ErrUnexpectedMinSafetyLevel

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 const testChainIDOffset = 900
@@ -634,7 +635,7 @@ func TestFailsafeEnabled(t *testing.T) {
 	require.False(t, enabled, "failsafe should be disabled by default")
 
 	// Test that CheckAccessList works normally in initial state
-	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, messages.ExecutingDescriptor{})
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, safety.LocalUnsafe, messages.ExecutingDescriptor{})
 	require.NoError(t, err, "CheckAccessList should work normally when failsafe is disabled")
 
 	// Test setting failsafe to true
@@ -645,7 +646,7 @@ func TestFailsafeEnabled(t *testing.T) {
 	require.True(t, enabled, "failsafe should be enabled after setting to true")
 
 	// Test that CheckAccessList returns ErrFailsafeEnabled when failsafe is enabled
-	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, messages.ExecutingDescriptor{})
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, safety.LocalUnsafe, messages.ExecutingDescriptor{})
 	require.ErrorIs(t, err, types.ErrFailsafeEnabled, "CheckAccessList should return ErrFailsafeEnabled when failsafe is enabled")
 
 	// Test setting failsafe to false
@@ -656,7 +657,7 @@ func TestFailsafeEnabled(t *testing.T) {
 	require.False(t, enabled, "failsafe should be disabled after setting to false")
 
 	// Test that CheckAccessList works normally when failsafe is disabled
-	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, messages.ExecutingDescriptor{})
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, safety.LocalUnsafe, messages.ExecutingDescriptor{})
 	require.NoError(t, err, "CheckAccessList should work normally when failsafe is disabled")
 }
 

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -49,7 +49,7 @@ func (m *MockBackend) AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.By
 }
 
 func (m *MockBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety safety.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
+	minSafety safety.Level, executingDescriptor messages.ExecutingDescriptor) error {
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -7,6 +7,7 @@ import (
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/frontend"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -48,7 +49,7 @@ func (m *MockBackend) AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.By
 }
 
 func (m *MockBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
+	minSafety safety.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
 	return nil
 }
 

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -27,7 +27,7 @@ type QueryFrontend struct {
 var _ apis.SupervisorQueryAPI = (*QueryFrontend)(nil)
 
 func (q *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety safety.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
+	minSafety safety.Level, executingDescriptor messages.ExecutingDescriptor) error {
 	err := q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
 	if err != nil {
 		return &rpc.JsonError{

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 type Backend interface {
@@ -26,7 +27,7 @@ type QueryFrontend struct {
 var _ apis.SupervisorQueryAPI = (*QueryFrontend)(nil)
 
 func (q *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
+	minSafety safety.SafetyLevel, executingDescriptor messages.ExecutingDescriptor) error {
 	err := q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
 	if err != nil {
 		return &rpc.JsonError{

--- a/op-supervisor/supervisor/service_test.go
+++ b/op-supervisor/supervisor/service_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/config"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestSupervisorService(t *testing.T) {
@@ -74,7 +74,7 @@ func TestSupervisorService(t *testing.T) {
 		require.NoError(t, err)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		err = cl.CallContext(ctx, nil, "supervisor_checkAccessList",
-			[]common.Hash{}, types.CrossUnsafe, messages.ExecutingDescriptor{
+			[]common.Hash{}, safety.CrossUnsafe, messages.ExecutingDescriptor{
 				Timestamp: 1234568, ChainID: eth.ChainIDFromUInt64(123)})
 		cancel()
 		require.NoError(t, err)

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -1,18 +1,12 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 
 	interopmsgs "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-)
-
-var (
-	errNilSafetyLevel          = errors.New("nil safety level")
-	errUnrecognizedSafetyLevel = errors.New("unrecognized safety level")
 )
 
 type Revision uint64
@@ -57,61 +51,6 @@ func (r Revision) Cmp(blockNum uint64) int {
 	}
 	return -1
 }
-
-type SafetyLevel string
-
-func (lvl SafetyLevel) String() string {
-	return string(lvl)
-}
-
-// Validate returns true if the SafetyLevel is one of the recognized levels
-func (lvl SafetyLevel) Validate() bool {
-	switch lvl {
-	case Invalid, Finalized, CrossSafe, LocalSafe, CrossUnsafe, LocalUnsafe:
-		return true
-	default:
-		return false
-	}
-}
-
-func (lvl SafetyLevel) MarshalText() ([]byte, error) {
-	return []byte(lvl), nil
-}
-
-func (lvl *SafetyLevel) UnmarshalText(text []byte) error {
-	if lvl == nil {
-		return errNilSafetyLevel
-	}
-	x := SafetyLevel(text)
-	if !x.Validate() {
-		return fmt.Errorf("%w: %q", errUnrecognizedSafetyLevel, text)
-	}
-	*lvl = x
-	return nil
-}
-
-const (
-	// Finalized is CrossSafe, with the additional constraint that every
-	// dependency is derived only from finalized L1 input data.
-	// This matches RPC label "finalized".
-	Finalized SafetyLevel = "finalized"
-	// CrossSafe is as safe as LocalSafe, with all its dependencies
-	// also fully verified to be reproducible from L1.
-	// This matches RPC label "safe".
-	CrossSafe SafetyLevel = "safe"
-	// LocalSafe is verified to be reproducible from L1,
-	// without any verified cross-L2 dependencies.
-	// This does not have an RPC label.
-	LocalSafe SafetyLevel = "local-safe"
-	// CrossUnsafe is as safe as LocalUnsafe,
-	// but with verified cross-L2 dependencies that are at least CrossUnsafe.
-	// This does not have an RPC label.
-	CrossUnsafe SafetyLevel = "cross-unsafe"
-	// LocalUnsafe is the safety of the tip of the chain. This matches RPC label "unsafe".
-	LocalUnsafe SafetyLevel = "unsafe"
-	// Invalid is the safety of when the message or block is not matching the expected data.
-	Invalid SafetyLevel = "invalid"
-)
 
 // DerivedBlockRefPair is a pair of block refs, where Derived (L2) is derived from Source (L1).
 type DerivedBlockRefPair struct {

--- a/op-supervisor/supervisor/types/types_test.go
+++ b/op-supervisor/supervisor/types/types_test.go
@@ -1,35 +1,10 @@
 package types
 
 import (
-	"encoding/json"
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestSafetyLevel(t *testing.T) {
-	for _, lvl := range []SafetyLevel{
-		Finalized,
-		CrossSafe,
-		LocalSafe,
-		CrossUnsafe,
-		LocalUnsafe,
-		Invalid,
-	} {
-		upper := strings.ToUpper(lvl.String())
-		var x SafetyLevel
-		require.ErrorContains(t, json.Unmarshal([]byte(fmt.Sprintf("%q", upper)), &x), "unrecognized", "case sensitive")
-		require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf("%q", lvl.String())), &x))
-		dat, err := json.Marshal(x)
-		require.NoError(t, err)
-		require.Equal(t, fmt.Sprintf("%q", lvl.String()), string(dat))
-	}
-	var x SafetyLevel
-	require.ErrorContains(t, json.Unmarshal([]byte(`""`), &x), "unrecognized", "empty")
-	require.ErrorContains(t, json.Unmarshal([]byte(`"foobar"`), &x), "unrecognized", "other")
-}
 
 func TestRevision(t *testing.T) {
 	require.True(t, RevisionAny.Any())

--- a/rust/kona/tests/node/common/engine_test.go
+++ b/rust/kona/tests/node/common/engine_test.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	node_utils "github.com/ethereum-optimism/optimism/rust/kona/tests/node/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +30,7 @@ func TestEngine(gt *testing.T) {
 			go func() {
 				defer close(done)
 				// Wait for 40 unsafe blocks to be produced.
-				node.Advanced(types.LocalUnsafe, 40, 100)
+				node.Advanced(safety.LocalUnsafe, 40, 100)
 			}()
 
 			queueLens := node_utils.GetDevWS(t, node, "engine_queue_size", done)

--- a/rust/kona/tests/node/common/p2p_test.go
+++ b/rust/kona/tests/node/common/p2p_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
@@ -67,7 +68,7 @@ func TestP2PMinimal(gt *testing.T) {
 	konaNodeId := secondNode.PeerInfo().PeerID
 
 	// Wait for a few blocks to be produced.
-	dsl.CheckAll(t, secondNode.ReachedFn(types.LocalUnsafe, 40, 80), firstNode.ReachedFn(types.LocalUnsafe, 40, 80))
+	dsl.CheckAll(t, secondNode.ReachedFn(safety.LocalUnsafe, 40, 80), firstNode.ReachedFn(safety.LocalUnsafe, 40, 80))
 
 	// Check that the nodes are connected to each other.
 	arePeers(t, &firstNode, konaNodeId)

--- a/rust/kona/tests/node/common/sync_test.go
+++ b/rust/kona/tests/node/common/sync_test.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	node_utils "github.com/ethereum-optimism/optimism/rust/kona/tests/node/utils"
 )
 
@@ -21,8 +22,8 @@ func TestL2SafeSync(gt *testing.T) {
 	checkFuns := make([]dsl.CheckFunc, 0, 2*len(nodes))
 
 	for _, node := range nodes {
-		checkFuns = append(checkFuns, node.ReachedFn(types.LocalSafe, 20, 40))
-		checkFuns = append(checkFuns, node_utils.MatchedWithinRange(t, node, sequencer, 5, types.LocalSafe, 100))
+		checkFuns = append(checkFuns, node.ReachedFn(safety.LocalSafe, 20, 40))
+		checkFuns = append(checkFuns, node_utils.MatchedWithinRange(t, node, sequencer, 5, safety.LocalSafe, 100))
 	}
 
 	dsl.CheckAll(t, checkFuns...)
@@ -39,7 +40,7 @@ func TestL2UnsafeSync(gt *testing.T) {
 	checkFuns := make([]dsl.CheckFunc, 0, len(nodes))
 
 	for _, node := range nodes {
-		checkFuns = append(checkFuns, node.ReachedFn(types.LocalUnsafe, 40, 80))
+		checkFuns = append(checkFuns, node.ReachedFn(safety.LocalUnsafe, 40, 80))
 	}
 
 	dsl.CheckAll(t, checkFuns...)
@@ -57,7 +58,7 @@ func TestL2FinalizedSync(gt *testing.T) {
 	checkFuns := make([]dsl.CheckFunc, 0, len(nodes))
 
 	for _, node := range nodes {
-		checkFuns = append(checkFuns, node.ReachedFn(types.Finalized, 10, 600))
+		checkFuns = append(checkFuns, node.ReachedFn(safety.Finalized, 10, 600))
 	}
 
 	dsl.CheckAll(t, checkFuns...)

--- a/rust/kona/tests/node/common/sync_ws_test.go
+++ b/rust/kona/tests/node/common/sync_ws_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	node_utils "github.com/ethereum-optimism/optimism/rust/kona/tests/node/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -31,8 +32,8 @@ func TestSyncUnsafeBecomesSafe(gt *testing.T) {
 	// Ensure that all the nodes advance the unsafe and safe head
 	advancedFns := make([]dsl.CheckFunc, 0, len(nodes))
 	for _, node := range nodes {
-		advancedFns = append(advancedFns, node.AdvancedFn(types.LocalSafe, 20, 80))
-		advancedFns = append(advancedFns, node.AdvancedFn(types.LocalUnsafe, 20, 80))
+		advancedFns = append(advancedFns, node.AdvancedFn(safety.LocalSafe, 20, 80))
+		advancedFns = append(advancedFns, node.AdvancedFn(safety.LocalUnsafe, 20, 80))
 	}
 	dsl.CheckAll(t, advancedFns...)
 
@@ -85,7 +86,7 @@ func TestSyncUnsafe(gt *testing.T) {
 	// Ensure that all the nodes advance the unsafe head
 	advancedFns := make([]dsl.CheckFunc, 0, len(nodes))
 	for _, node := range nodes {
-		advancedFns = append(advancedFns, node.AdvancedFn(types.LocalUnsafe, 20, 80))
+		advancedFns = append(advancedFns, node.AdvancedFn(safety.LocalUnsafe, 20, 80))
 	}
 	dsl.CheckAll(t, advancedFns...)
 
@@ -103,7 +104,7 @@ func TestSyncUnsafe(gt *testing.T) {
 			for _, block := range output {
 				for _, node := range nodes {
 					otherCLNode := node.Escape().Name()
-					otherCLSyncStatus := node.ChainSyncStatus(out.L2Chain.ChainID(), types.LocalUnsafe)
+					otherCLSyncStatus := node.ChainSyncStatus(out.L2Chain.ChainID(), safety.LocalUnsafe)
 
 					if otherCLSyncStatus.Number < block.Number {
 						t.Log("✗ peer too far behind!", otherCLNode, block.Number, otherCLSyncStatus.Number)
@@ -136,7 +137,7 @@ func TestSyncSafe(gt *testing.T) {
 	// Ensure that all the nodes advance the safe head
 	advancedFns := make([]dsl.CheckFunc, 0, len(nodes))
 	for _, node := range nodes {
-		advancedFns = append(advancedFns, node.AdvancedFn(types.LocalSafe, 20, 80))
+		advancedFns = append(advancedFns, node.AdvancedFn(safety.LocalSafe, 20, 80))
 	}
 	dsl.CheckAll(t, advancedFns...)
 
@@ -155,7 +156,7 @@ func TestSyncSafe(gt *testing.T) {
 			for _, block := range output {
 				for _, node := range nodes {
 					otherCLNode := node.Escape().Name()
-					otherCLSyncStatus := node.ChainSyncStatus(out.L2Chain.ChainID(), types.LocalSafe)
+					otherCLSyncStatus := node.ChainSyncStatus(out.L2Chain.ChainID(), safety.LocalSafe)
 
 					if otherCLSyncStatus.Number < block.Number {
 						t.Log("✗ peer too far behind!", otherCLNode, block.Number, otherCLSyncStatus.Number)
@@ -202,7 +203,7 @@ func TestSyncFinalized(gt *testing.T) {
 			for _, block := range output {
 				for _, node := range nodes {
 					otherCLNode := node.Escape().Name()
-					otherCLSyncStatus := node.ChainSyncStatus(out.L2Chain.ChainID(), types.Finalized)
+					otherCLSyncStatus := node.ChainSyncStatus(out.L2Chain.ChainID(), safety.Finalized)
 
 					if otherCLSyncStatus.Number < block.Number {
 						t.Log("✗ peer too far behind!", otherCLNode, block.Number, otherCLSyncStatus.Number)

--- a/rust/kona/tests/node/reorgs/l2_reorg_after_l1_reorgs_test.go
+++ b/rust/kona/tests/node/reorgs/l2_reorg_after_l1_reorgs_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 	node_utils "github.com/ethereum-optimism/optimism/rust/kona/tests/node/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -106,7 +107,7 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	// wait until L2 chain cross-safe ref caught up to where it was before the reorg
 	var waitFunc []dsl.CheckFunc
 	for _, clNode := range sys.L2CLNodes() {
-		waitFunc = append(waitFunc, clNode.ReachedFn(types.CrossSafe, tipL2_preReorg.Number, 200))
+		waitFunc = append(waitFunc, clNode.ReachedFn(safety.CrossSafe, tipL2_preReorg.Number, 200))
 	}
 
 	dsl.CheckAll(t, waitFunc...)

--- a/rust/kona/tests/node/reorgs/l2_reorg_test.go
+++ b/rust/kona/tests/node/reorgs/l2_reorg_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 	node_utils "github.com/ethereum-optimism/optimism/rust/kona/tests/node/utils"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,7 @@ func TestL2Reorg(gt *testing.T) {
 
 	// Wait for the nodes to advance a little bit
 	for _, node := range out.L2CLNodes() {
-		advancedFnsPreReorg = append(advancedFnsPreReorg, node.AdvancedFn(types.LocalUnsafe, 20, 40))
+		advancedFnsPreReorg = append(advancedFnsPreReorg, node.AdvancedFn(safety.LocalUnsafe, 20, 40))
 	}
 
 	dsl.CheckAll(t, advancedFnsPreReorg...)
@@ -42,7 +43,7 @@ func TestL2Reorg(gt *testing.T) {
 	advancedFnsReorgedBlocks := make([]dsl.CheckFunc, 0, len(out.L2CLNodes()))
 	// Wait for the nodes to advance a little bit more ahead the unsafe head
 	for _, node := range out.L2CLNodes() {
-		advancedFnsReorgedBlocks = append(advancedFnsReorgedBlocks, node.AdvancedFn(types.LocalUnsafe, NUM_BLOCKS_TO_REORG, 2*NUM_BLOCKS_TO_REORG))
+		advancedFnsReorgedBlocks = append(advancedFnsReorgedBlocks, node.AdvancedFn(safety.LocalUnsafe, NUM_BLOCKS_TO_REORG, 2*NUM_BLOCKS_TO_REORG))
 	}
 	dsl.CheckAll(t, advancedFnsReorgedBlocks...)
 
@@ -56,7 +57,7 @@ func TestL2Reorg(gt *testing.T) {
 
 	// Ensure that all the nodes still advance even after the reorg
 	for _, node := range out.L2CLNodes() {
-		checksPostReorg = append(checksPostReorg, node.AdvancedFn(types.LocalUnsafe, 20, 40))
+		checksPostReorg = append(checksPostReorg, node.AdvancedFn(safety.LocalUnsafe, 20, 40))
 	}
 
 	reorgFun := func() error {
@@ -133,7 +134,7 @@ func TestL2Reorg(gt *testing.T) {
 
 	// Ensure the current unsafe head is ahead of the reorg head
 	for _, node := range out.L2CLNodes() {
-		require.Greater(t, node.HeadBlockRef(types.LocalUnsafe).Number, unsafeHead.Number)
+		require.Greater(t, node.HeadBlockRef(safety.LocalUnsafe).Number, unsafeHead.Number)
 	}
 
 	// Ensure that bob has the funds

--- a/rust/kona/tests/node/restart/conn_drop_test.go
+++ b/rust/kona/tests/node/restart/conn_drop_test.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	node_utils "github.com/ethereum-optimism/optimism/rust/kona/tests/node/utils"
 )
 
@@ -24,7 +25,7 @@ func TestConnDropSync(gt *testing.T) {
 	// Ensure that the nodes are advancing.
 	var preCheckFuns []dsl.CheckFunc
 	for _, node := range out.L2CLNodes() {
-		preCheckFuns = append(preCheckFuns, node.AdvancedFn(types.LocalSafe, 20, 100), node.AdvancedFn(types.LocalUnsafe, 20, 100))
+		preCheckFuns = append(preCheckFuns, node.AdvancedFn(safety.LocalSafe, 20, 100), node.AdvancedFn(safety.LocalUnsafe, 20, 100))
 	}
 	dsl.CheckAll(t, preCheckFuns...)
 
@@ -48,7 +49,7 @@ func TestConnDropSync(gt *testing.T) {
 			t.Require().NotEqual(peer.PeerID, sequencer.PeerInfo().PeerID, "expected node %s to be disconnected from sequencer %s", clName, sequencer.Escape().Name())
 		}
 
-		currentUnsafeHead := node.ChainSyncStatus(node.ChainID(), types.LocalUnsafe)
+		currentUnsafeHead := node.ChainSyncStatus(node.ChainID(), safety.LocalUnsafe)
 
 		endSignal := make(chan struct{})
 
@@ -83,10 +84,10 @@ func TestConnDropSync(gt *testing.T) {
 		// - the node's unsafe head is advancing (through consolidation)
 		// - the node's safe head's number is catching up with the unsafe head's number
 		// - the node's unsafe head is strictly lagging behind the sequencer's unsafe head
-		postDisconnectCheckFuns = append(postDisconnectCheckFuns, node.AdvancedFn(types.LocalSafe, 50, 200), node.AdvancedFn(types.LocalUnsafe, 50, 200), check)
+		postDisconnectCheckFuns = append(postDisconnectCheckFuns, node.AdvancedFn(safety.LocalSafe, 50, 200), node.AdvancedFn(safety.LocalUnsafe, 50, 200), check)
 	}
 
-	postDisconnectCheckFuns = append(postDisconnectCheckFuns, sequencer.AdvancedFn(types.LocalUnsafe, 50, 200))
+	postDisconnectCheckFuns = append(postDisconnectCheckFuns, sequencer.AdvancedFn(safety.LocalUnsafe, 50, 200))
 
 	dsl.CheckAll(t, postDisconnectCheckFuns...)
 
@@ -113,7 +114,7 @@ func TestConnDropSync(gt *testing.T) {
 		t.Require().True(found, "expected node %s to be connected to reference node %s", clName, sequencer.Escape().Name())
 
 		// Check that the node is resyncing with the unsafe head network
-		postReconnectCheckFuns = append(postReconnectCheckFuns, node_utils.MatchedWithinRange(t, node, sequencer, 3, types.LocalSafe, 50), node.AdvancedFn(types.LocalUnsafe, 50, 100), node_utils.MatchedWithinRange(t, node, sequencer, 3, types.LocalUnsafe, 100))
+		postReconnectCheckFuns = append(postReconnectCheckFuns, node_utils.MatchedWithinRange(t, node, sequencer, 3, safety.LocalSafe, 50), node.AdvancedFn(safety.LocalUnsafe, 50, 100), node_utils.MatchedWithinRange(t, node, sequencer, 3, safety.LocalUnsafe, 100))
 	}
 
 	dsl.CheckAll(t, postReconnectCheckFuns...)

--- a/rust/kona/tests/node/restart/restart_test.go
+++ b/rust/kona/tests/node/restart/restart_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	node_utils "github.com/ethereum-optimism/optimism/rust/kona/tests/node/utils"
 )
 
@@ -30,7 +31,7 @@ func TestRestartSync(gt *testing.T) {
 	// Ensure that the nodes are advancing.
 	var preCheckFuns []dsl.CheckFunc
 	for _, node := range out.L2CLNodes() {
-		preCheckFuns = append(preCheckFuns, node.AdvancedFn(types.LocalSafe, 20, 100), node.AdvancedFn(types.LocalUnsafe, 20, 100))
+		preCheckFuns = append(preCheckFuns, node.AdvancedFn(safety.LocalSafe, 20, 100), node.AdvancedFn(safety.LocalUnsafe, 20, 100))
 	}
 	dsl.CheckAll(t, preCheckFuns...)
 
@@ -64,7 +65,7 @@ func TestRestartSync(gt *testing.T) {
 		t.Require().Error(err, "expected node %s to be stopped", clName)
 	}
 
-	sequencer.Advanced(types.LocalUnsafe, 50, 200)
+	sequencer.Advanced(safety.LocalUnsafe, 50, 200)
 
 	var postStartCheckFuns []dsl.CheckFunc
 	for _, node := range nodes {
@@ -75,7 +76,7 @@ func TestRestartSync(gt *testing.T) {
 		node.ConnectPeer(&sequencer)
 
 		// Check that the node is resyncing with the network
-		postStartCheckFuns = append(postStartCheckFuns, node_utils.MatchedWithinRange(t, node, sequencer, 3, types.LocalSafe, 100), node_utils.MatchedWithinRange(t, node, sequencer, 3, types.LocalUnsafe, 100))
+		postStartCheckFuns = append(postStartCheckFuns, node_utils.MatchedWithinRange(t, node, sequencer, 3, safety.LocalSafe, 100), node_utils.MatchedWithinRange(t, node, sequencer, 3, safety.LocalUnsafe, 100))
 
 		// Check that the node is connected to the reference node
 		peers := node.Peers()

--- a/rust/kona/tests/node/restart/sequencer_restart_test.go
+++ b/rust/kona/tests/node/restart/sequencer_restart_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 func TestSequencerRestart(gt *testing.T) {
@@ -27,7 +28,7 @@ func TestSequencerRestart(gt *testing.T) {
 	// Let's ensure that all the nodes are properly advancing.
 	var preCheckFuns []dsl.CheckFunc
 	for _, node := range nodes {
-		preCheckFuns = append(preCheckFuns, node.LaggedFn(&sequencer, types.CrossUnsafe, 20, true), node.AdvancedFn(types.LocalSafe, 20, 40))
+		preCheckFuns = append(preCheckFuns, node.LaggedFn(&sequencer, safety.CrossUnsafe, 20, true), node.AdvancedFn(safety.LocalSafe, 20, 40))
 	}
 	dsl.CheckAll(t, preCheckFuns...)
 
@@ -51,7 +52,7 @@ func TestSequencerRestart(gt *testing.T) {
 
 		// Ensure that the other nodes are not advancing.
 		// The local safe head may advance (for the next l1 block to be processed), but the unsafe head should not.
-		stopCheckFuns = append(stopCheckFuns, node.NotAdvancedFn(types.LocalUnsafe, 20))
+		stopCheckFuns = append(stopCheckFuns, node.NotAdvancedFn(safety.LocalUnsafe, 20))
 	}
 
 	dsl.CheckAll(t, stopCheckFuns...)
@@ -71,7 +72,7 @@ func TestSequencerRestart(gt *testing.T) {
 	t.Logf("Waiting for nodes to advance")
 	var postCheckFuns []dsl.CheckFunc
 	for _, node := range nodes {
-		postCheckFuns = append(postCheckFuns, node.AdvancedFn(types.LocalSafe, 10, 100), node.AdvancedFn(types.LocalUnsafe, 10, 100))
+		postCheckFuns = append(postCheckFuns, node.AdvancedFn(safety.LocalSafe, 10, 100), node.AdvancedFn(safety.LocalUnsafe, 10, 100))
 	}
 
 	dsl.CheckAll(t, postCheckFuns...)

--- a/rust/kona/tests/node/utils/mod.go
+++ b/rust/kona/tests/node/utils/mod.go
@@ -36,7 +36,7 @@ func SendRPCRequest[T any](clientRPC client.RPC, method string, resOutput *T, pa
 	return clientRPC.CallContext(ctx, &resOutput, method, params...)
 }
 
-func MatchedWithinRange(t devtest.T, baseNode, refNode dsl.L2CLNode, delta uint64, lvl safety.SafetyLevel, attempts int) dsl.CheckFunc {
+func MatchedWithinRange(t devtest.T, baseNode, refNode dsl.L2CLNode, delta uint64, lvl safety.Level, attempts int) dsl.CheckFunc {
 	logger := t.Logger()
 	chainID := baseNode.ChainID()
 

--- a/rust/kona/tests/node/utils/mod.go
+++ b/rust/kona/tests/node/utils/mod.go
@@ -10,7 +10,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
 const DefaultL1ID = 900
@@ -35,7 +36,7 @@ func SendRPCRequest[T any](clientRPC client.RPC, method string, resOutput *T, pa
 	return clientRPC.CallContext(ctx, &resOutput, method, params...)
 }
 
-func MatchedWithinRange(t devtest.T, baseNode, refNode dsl.L2CLNode, delta uint64, lvl types.SafetyLevel, attempts int) dsl.CheckFunc {
+func MatchedWithinRange(t devtest.T, baseNode, refNode dsl.L2CLNode, delta uint64, lvl safety.SafetyLevel, attempts int) dsl.CheckFunc {
 	logger := t.Logger()
 	chainID := baseNode.ChainID()
 


### PR DESCRIPTION
Stacked on #20887. Pulls the interop safety lattice — type and its 6 constants (`Finalized`, `CrossSafe`, `LocalSafe`, `CrossUnsafe`, `LocalUnsafe`, `Invalid`) — out of `op-supervisor/supervisor/types` into a new `op-service/eth/safety` sub-package, and renames the type from `SafetyLevel` to just `Level` since the package qualifies it (`safety.Level` at call sites). SafetyLevel is the canonical interop safety vocabulary — spoken by op-node, op-supernode, RPC clients, and the entire test tree — and shouldn't live inside a deprecated component.

**Why a sub-package, not top-level `op-service/eth`:** `eth/label.go` already declares an untyped `Finalized = "finalized"` for the `BlockLabel` namespace (`"latest"`/`"safe"`/`"finalized"`). Putting the safety lattice at the top level would either collide on the `Finalized` name or force a `BlockLabel = Level` type alias that conflates the RPC-block-tag namespace with the safety-lattice namespace — those overlap on `"safe"`/`"finalized"` strings but mean different things. A `safety` sub-package keeps them cleanly separated; `eth/label.go` is untouched.

**Caller sweep:** ~66 files across op-acceptance-tests, op-supervisor internals, op-supernode, op-interop-filter, op-service, op-devstack, and rust/kona tests rewritten to import `safety` and qualify references as `safety.Level`, `safety.Finalized`, etc.