### PR TITLE
feat(op-node): load dependency set from superchain-registry

### DIFF
--- a/op-node/service.go
+++ b/op-node/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/superchain"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
@@ -49,7 +50,7 @@ func NewConfig(ctx cliiface.Context, log log.Logger) (*config.Config, error) {
 		return nil, err
 	}
 
-	depSet, err := NewDependencySetFromCLI(ctx)
+	depSet, err := NewDependencySetFromCLI(ctx, eth.ChainIDFromBig(rollupConfig.L2ChainID))
 	if err != nil {
 		return nil, err
 	}
@@ -311,12 +312,22 @@ func NewL1ChainConfigFromCLI(log log.Logger, ctx cliiface.Context) (*params.Chai
 	return jsonutil.LoadJSONFieldStrict[params.ChainConfig](l1ChainConfigPath, "config")
 }
 
-func NewDependencySetFromCLI(cli cliiface.Context) (depset.DependencySet, error) {
-	if !cli.IsSet(flags.InteropDependencySet.Name) {
-		return nil, nil
+// NewDependencySetFromCLI returns the dep set from --interop.dependency-set if
+// set, otherwise from the superchain-registry. An unknown chain yields
+// (nil, nil); config.Check then errors iff InteropTime is set.
+func NewDependencySetFromCLI(cli cliiface.Context, chainID eth.ChainID) (depset.DependencySet, error) {
+	if cli.IsSet(flags.InteropDependencySet.Name) {
+		loader := &depset.JSONDependencySetLoader{Path: cli.Path(flags.InteropDependencySet.Name)}
+		return loader.LoadDependencySet()
 	}
-	loader := &depset.JSONDependencySetLoader{Path: cli.Path(flags.InteropDependencySet.Name)}
-	return loader.LoadDependencySet()
+	ds, err := depset.FromRegistry(chainID)
+	if err != nil {
+		if errors.Is(err, superchain.ErrUnknownChain) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load dependency set from superchain-registry: %w", err)
+	}
+	return ds, nil
 }
 
 func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {

--- a/op-node/service_depset_test.go
+++ b/op-node/service_depset_test.go
@@ -1,0 +1,70 @@
+package opnode
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/flags"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func newDepsetCtx(t *testing.T, args ...string) *cli.Context {
+	t.Helper()
+	app := &cli.App{Flags: []cli.Flag{flags.InteropDependencySet}}
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	require.NoError(t, flags.InteropDependencySet.Apply(set))
+	require.NoError(t, set.Parse(args))
+	return cli.NewContext(app, set, nil)
+}
+
+func TestNewDependencySetFromCLI_ExplicitJSONOverridesRegistry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "depset.json")
+	// Fictional chain ID so the JSON contents are distinguishable from registry output.
+	payload := []byte(`{"dependencies":{"4242":{}}}`)
+	require.NoError(t, os.WriteFile(path, payload, 0o600))
+
+	ctx := newDepsetCtx(t, "--"+flags.InteropDependencySet.Name+"="+path)
+	ds, err := NewDependencySetFromCLI(ctx, eth.ChainIDFromUInt64(10))
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+	require.True(t, ds.HasChain(eth.ChainIDFromUInt64(4242)))
+	require.False(t, ds.HasChain(eth.ChainIDFromUInt64(10)),
+		"explicit JSON must win over the registry fallback")
+}
+
+func TestNewDependencySetFromCLI_RegistryFallback_KnownChain(t *testing.T) {
+	ctx := newDepsetCtx(t)
+	ds, err := NewDependencySetFromCLI(ctx, eth.ChainIDFromUInt64(10))
+	require.NoError(t, err)
+	require.NotNil(t, ds, "registry-known chain must yield a depset")
+	require.True(t, ds.HasChain(eth.ChainIDFromUInt64(10)),
+		"registry depset must at minimum contain the chain itself")
+}
+
+func TestNewDependencySetFromCLI_RegistryFallback_UnknownChain_Nil(t *testing.T) {
+	ctx := newDepsetCtx(t)
+	ds, err := NewDependencySetFromCLI(ctx, eth.ChainIDFromUInt64(999_999))
+	require.NoError(t, err, "unknown chain must not error here; config.Check gates this")
+	require.Nil(t, ds)
+}
+
+func TestNewDependencySetFromCLI_RegistryFallback_RoundTripsViaJSON(t *testing.T) {
+	ctx := newDepsetCtx(t)
+	ds, err := NewDependencySetFromCLI(ctx, eth.ChainIDFromUInt64(10))
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+
+	raw, err := json.Marshal(ds)
+	require.NoError(t, err)
+
+	var roundTripped depset.StaticConfigDependencySet
+	require.NoError(t, json.Unmarshal(raw, &roundTripped))
+	require.Equal(t, ds.Chains(), roundTripped.Chains())
+}

--- a/op-node/service_depset_test.go
+++ b/op-node/service_depset_test.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-node/flags"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )


### PR DESCRIPTION
When `--interop.dependency-set` is not set, fall back to `depset.FromRegistry` using the rollup config's L2 chain ID, mirroring how the rollup config itself is loaded from the superchain-registry. The registry synthesises a self-only depset for chains without explicit interop info, so any registry-known chain produces a usable value; unknown chains return nil and the existing `config.Check` still errors iff `InteropTime` is set.

Fixes ethereum-optimism/protocol-team#95