### PR TITLE
fix(op-supernode): ignore interop.log-backfill-depth when no activation is configured

### DIFF
--- a/op-supernode/supernode/interop_config_test.go
+++ b/op-supernode/supernode/interop_config_test.go
@@ -2,56 +2,12 @@ package supernode
 
 import (
 	"testing"
-	"time"
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 )
-
-func TestInteropLogBackfillEnabled(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		depth    time.Duration
-		resolved *uint64
-		want     bool
-	}{
-		{
-			name:     "depth and activation: enabled",
-			depth:    time.Hour,
-			resolved: uint64Ptr(100),
-			want:     true,
-		},
-		{
-			name:     "depth without activation: disabled, not an error",
-			depth:    time.Hour,
-			resolved: nil,
-			want:     false,
-		},
-		{
-			name:     "zero depth with activation: disabled",
-			depth:    0,
-			resolved: uint64Ptr(100),
-			want:     false,
-		},
-		{
-			name:     "zero depth without activation: disabled",
-			depth:    0,
-			resolved: nil,
-			want:     false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tt.want, interopLogBackfillEnabled(tt.depth, tt.resolved))
-		})
-	}
-}
 
 func TestResolveInteropActivationTimestamp(t *testing.T) {
 	t.Parallel()

--- a/op-supernode/supernode/interop_config_test.go
+++ b/op-supernode/supernode/interop_config_test.go
@@ -10,55 +10,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCheckLogBackfillRequiresInteropActivation(t *testing.T) {
+func TestInteropLogBackfillEnabled(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name     string
 		depth    time.Duration
 		resolved *uint64
-		wantErr  string
+		want     bool
 	}{
 		{
-			name:     "depth disabled is always fine",
-			depth:    0,
-			resolved: nil,
-		},
-		{
-			name:     "negative depth treated as disabled here; config.Check() rejects negatives",
-			depth:    -time.Second,
-			resolved: nil,
-		},
-		{
-			name:     "depth with CLI-resolved activation",
+			name:     "depth and activation: enabled",
 			depth:    time.Hour,
 			resolved: uint64Ptr(100),
+			want:     true,
 		},
 		{
-			// This is the case config.Check() used to reject outright: the
-			// CLI override is nil, but a rollup-derived activation is a valid
-			// source. checkLogBackfillRequiresInteropActivation doesn't care
-			// which source produced the timestamp — only that one exists.
-			name:     "depth with rollup-derived activation",
+			name:     "depth without activation: disabled, not an error",
 			depth:    time.Hour,
-			resolved: uint64Ptr(200),
+			resolved: nil,
+			want:     false,
 		},
 		{
-			name:    "depth without any activation source is rejected",
-			depth:   time.Hour,
-			wantErr: "requires an interop activation timestamp",
+			name:     "zero depth with activation: disabled",
+			depth:    0,
+			resolved: uint64Ptr(100),
+			want:     false,
+		},
+		{
+			name:     "zero depth without activation: disabled",
+			depth:    0,
+			resolved: nil,
+			want:     false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := checkLogBackfillRequiresInteropActivation(tt.depth, tt.resolved)
-			if tt.wantErr == "" {
-				require.NoError(t, err)
-				return
-			}
-			require.ErrorContains(t, err, tt.wantErr)
+			require.Equal(t, tt.want, interopLogBackfillEnabled(tt.depth, tt.resolved))
 		})
 	}
 }

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -156,13 +156,6 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	return s, nil
 }
 
-// interopLogBackfillEnabled reports whether interop log backfill will run.
-// Without a resolved activation timestamp the interop activity is never
-// constructed, so the depth flag is ignored rather than rejected.
-func interopLogBackfillEnabled(depth time.Duration, resolved *uint64) bool {
-	return depth > 0 && resolved != nil
-}
-
 func resolveInteropActivationTimestamp(override *uint64, vnCfgs map[eth.ChainID]*opnodecfg.Config) (*uint64, error) {
 	if override != nil {
 		return override, nil

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -108,10 +108,6 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		return nil, fmt.Errorf("resolve interop activation timestamp: %w", err)
 	}
 
-	if err := checkLogBackfillRequiresInteropActivation(cfg.InteropLogBackfillDepth, interopActivationTimestamp); err != nil {
-		return nil, err
-	}
-
 	log.Info("initializing interop activity", "enabled", interopActivationTimestamp != nil)
 
 	var verifiedReader interop.VerifiedResultReader = interop.NoopVerifiedResultReader{}
@@ -160,19 +156,11 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	return s, nil
 }
 
-// checkLogBackfillRequiresInteropActivation enforces that interop log
-// backfill can only run when an activation timestamp is known. Runs after
-// resolveInteropActivationTimestamp so a rollup-derived activation counts
-// as a valid source, not only the CLI override. config.Check() can't see
-// rollup configs and therefore can't do this check itself.
-func checkLogBackfillRequiresInteropActivation(depth time.Duration, resolved *uint64) error {
-	if depth <= 0 {
-		return nil
-	}
-	if resolved != nil {
-		return nil
-	}
-	return fmt.Errorf("interop.log-backfill-depth=%s requires an interop activation timestamp (set --interop.activation-timestamp or configure rollup InteropTime on every chain)", depth)
+// interopLogBackfillEnabled reports whether interop log backfill will run.
+// Without a resolved activation timestamp the interop activity is never
+// constructed, so the depth flag is ignored rather than rejected.
+func interopLogBackfillEnabled(depth time.Duration, resolved *uint64) bool {
+	return depth > 0 && resolved != nil
 }
 
 func resolveInteropActivationTimestamp(override *uint64, vnCfgs map[eth.ChainID]*opnodecfg.Config) (*uint64, error) {


### PR DESCRIPTION
Closes ethereum-optimism/optimism#20892

`--interop.log-backfill-depth` defaults to a non-zero value, but the interop activity (and its backfill) is only constructed when an activation timestamp is resolved. Previously `supernode.New` rejected that combination, forcing operators to explicitly set the flag to 0 before interop activation — for no functional benefit. With the gate removed, the depth is silently ignored until interop is active.