### PR TITLE
refactor(interop): move shared interop error sentinels into op-core/interop

### DIFF
--- a/op-core/interop/interop.go
+++ b/op-core/interop/interop.go
@@ -1,4 +1,4 @@
-package types
+package interop
 
 import "errors"
 

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
@@ -164,11 +164,11 @@ func supportedSafetyLevel(level safety.Level) bool {
 // classifyRejectionReason categorizes an error from CheckAccessList into a rejection reason label.
 func classifyRejectionReason(err error) string {
 	switch {
-	case errors.Is(err, types.ErrFailsafeEnabled):
+	case errors.Is(err, interop.ErrFailsafeEnabled):
 		return "failsafe"
-	case errors.Is(err, types.ErrUnknownChain):
+	case errors.Is(err, interop.ErrUnknownChain):
 		return "unknown_chain"
-	case errors.Is(err, types.ErrConflict):
+	case errors.Is(err, interop.ErrConflict):
 		return "expired_message"
 	default:
 		return "invalid_executing_message"
@@ -192,14 +192,14 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 	if b.FailsafeEnabled() {
 		b.metrics.RecordCheckAccessList(false)
 		b.metrics.RecordCheckAccessListRejection("failsafe")
-		return types.ErrFailsafeEnabled
+		return interop.ErrFailsafeEnabled
 	}
 
 	if !b.Ready() {
 		b.metrics.RecordCheckAccessList(false)
 		b.metrics.RecordCheckAccessListRejection("failsafe")
 		b.log.Debug("Backend not ready; rejecting access list check")
-		return types.ErrUninitialized
+		return interop.ErrUninitialized
 	}
 
 	if !supportedSafetyLevel(minSafety) {
@@ -213,7 +213,7 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 		if !b.legacyCheckAccessListFormat {
 			b.metrics.RecordCheckAccessList(false)
 			b.metrics.RecordCheckAccessListRejection("unknown_chain")
-			return fmt.Errorf("executing chain %s: %w", execDescriptor.ChainID, types.ErrUnknownChain)
+			return fmt.Errorf("executing chain %s: %w", execDescriptor.ChainID, interop.ErrUnknownChain)
 		}
 		b.log.Debug("Supporting legacy check access list format", "executing_chain", execDescriptor.ChainID)
 	}
@@ -245,7 +245,7 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 func (b *Backend) GetBlockHashByNumber(chainID eth.ChainID, blockNum rpc.BlockNumber) (common.Hash, error) {
 	ingester, ok := b.chains[chainID]
 	if !ok {
-		return common.Hash{}, fmt.Errorf("chain %s: %w", chainID, types.ErrUnknownChain)
+		return common.Hash{}, fmt.Errorf("chain %s: %w", chainID, interop.ErrUnknownChain)
 	}
 
 	if blockNum == rpc.LatestBlockNumber {

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
@@ -26,7 +26,7 @@ func (f *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []comm
 	err := f.backend.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
 	if err != nil {
 		return &rpc.JsonError{
-			Code:    types.GetErrorCode(err),
+			Code:    interop.GetErrorCode(err),
 			Message: err.Error(),
 		}
 	}

--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
@@ -150,20 +150,20 @@ func validateMessageTiming(
 	// Rule 1: init must be strictly before inclusion
 	if initTimestamp >= inclusionTimestamp {
 		return fmt.Errorf("initiating message timestamp %d not before inclusion timestamp %d: %w",
-			initTimestamp, inclusionTimestamp, types.ErrConflict)
+			initTimestamp, inclusionTimestamp, interop.ErrConflict)
 	}
 
 	// Rule 2: compute expiry with overflow check
 	expiresAt := initTimestamp + messageExpiryWindow
 	if expiresAt < initTimestamp {
 		return fmt.Errorf("overflow in expiry calculation: timestamp %d + window %d: %w",
-			initTimestamp, messageExpiryWindow, types.ErrConflict)
+			initTimestamp, messageExpiryWindow, interop.ErrConflict)
 	}
 
 	// Rule 3: message must not be expired at inclusion
 	if expiresAt < inclusionTimestamp {
 		return fmt.Errorf("initiating message expired: init %d + expiry window %d = %d < inclusion %d: %w",
-			initTimestamp, messageExpiryWindow, expiresAt, inclusionTimestamp, types.ErrConflict)
+			initTimestamp, messageExpiryWindow, expiresAt, inclusionTimestamp, interop.ErrConflict)
 	}
 
 	// Rule 4: if timeout set, message must not expire before timeout deadline
@@ -171,14 +171,14 @@ func validateMessageTiming(
 		maxExecTimestamp := execTimestamp + timeout
 		if maxExecTimestamp < execTimestamp {
 			return fmt.Errorf("overflow in max exec timestamp calculation: timestamp %d + timeout %d: %w",
-				execTimestamp, timeout, types.ErrConflict)
+				execTimestamp, timeout, interop.ErrConflict)
 		}
 		if expiresAt < maxExecTimestamp {
 			return fmt.Errorf("initiating message will expire before timeout: "+
 				"init %d + expiry %d = %d < exec %d + timeout %d = %d: %w",
 				initTimestamp, messageExpiryWindow, expiresAt,
 				execTimestamp, timeout, maxExecTimestamp,
-				types.ErrConflict)
+				interop.ErrConflict)
 		}
 	}
 
@@ -195,19 +195,19 @@ func (v *LockstepCrossValidator) ValidateAccessEntry(
 	minIngestedTs, ok := v.getMinIngestedTimestamp()
 	if !ok || access.Timestamp > minIngestedTs {
 		return fmt.Errorf("timestamp %d not yet ingested (min ingested: %d): %w",
-			access.Timestamp, minIngestedTs, types.ErrOutOfScope)
+			access.Timestamp, minIngestedTs, interop.ErrOutOfScope)
 	}
 
 	// Check cross-unsafe timestamp
 	if minSafety == safety.CrossUnsafe {
 		crossValidatedTs, ok := v.CrossValidatedTimestamp()
 		if !ok {
-			return fmt.Errorf("cross-validated timestamp not available: %w", types.ErrOutOfScope)
+			return fmt.Errorf("cross-validated timestamp not available: %w", interop.ErrOutOfScope)
 		}
 		if access.Timestamp > crossValidatedTs {
 			return fmt.Errorf("message at timestamp %d not yet cross-unsafe validated "+
 				"(current cross-validated timestamp: %d): %w",
-				access.Timestamp, crossValidatedTs, types.ErrOutOfScope)
+				access.Timestamp, crossValidatedTs, interop.ErrOutOfScope)
 		}
 	}
 
@@ -225,7 +225,7 @@ func (v *LockstepCrossValidator) ValidateAccessEntry(
 	// Check that the log exists on the source chain
 	ingester, ok := v.chains[access.ChainID]
 	if !ok {
-		return fmt.Errorf("source chain %s: %w", access.ChainID, types.ErrUnknownChain)
+		return fmt.Errorf("source chain %s: %w", access.ChainID, interop.ErrUnknownChain)
 	}
 
 	query := messages.ContainsQuery{
@@ -244,7 +244,7 @@ func (v *LockstepCrossValidator) validateExecutingMessage(
 ) error {
 	ingester, ok := v.chains[execMsg.ChainID]
 	if !ok {
-		return fmt.Errorf("source chain %s: %w", execMsg.ChainID, types.ErrUnknownChain)
+		return fmt.Errorf("source chain %s: %w", execMsg.ChainID, interop.ErrUnknownChain)
 	}
 
 	// Validate timing constraints (no timeout for background validation)

--- a/op-interop-filter/filter/lockstep_cross_validator_test.go
+++ b/op-interop-filter/filter/lockstep_cross_validator_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
@@ -43,7 +43,7 @@ func TestCrossValidator_TimeoutExceedsExpiry(t *testing.T) {
 
 	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 	require.Contains(t, err.Error(), "expire before timeout")
 }
 
@@ -76,7 +76,7 @@ func TestCrossValidator_CrossUnsafe_Boundary(t *testing.T) {
 	access = makeAccess(testChainA, 101, 10, 0, checksum)
 	err = cv.ValidateAccessEntry(access, safety.CrossUnsafe, exec)
 	require.Error(t, err)
-	require.ErrorIs(t, err, types.ErrOutOfScope)
+	require.ErrorIs(t, err, interop.ErrOutOfScope)
 }
 
 // =============================================================================
@@ -117,7 +117,7 @@ func TestCrossValidator_UnknownChain(t *testing.T) {
 
 	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
-	require.ErrorIs(t, err, types.ErrUnknownChain)
+	require.ErrorIs(t, err, interop.ErrUnknownChain)
 }
 
 func TestCrossValidator_InitiatingMessageNotFound(t *testing.T) {
@@ -136,7 +136,7 @@ func TestCrossValidator_InitiatingMessageNotFound(t *testing.T) {
 
 	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 }
 
 // =============================================================================
@@ -270,7 +270,7 @@ func TestValidateAccessEntry_TimestampNotIngested(t *testing.T) {
 
 	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
-	require.ErrorIs(t, err, types.ErrOutOfScope)
+	require.ErrorIs(t, err, interop.ErrOutOfScope)
 	require.Contains(t, err.Error(), "not yet ingested")
 }
 
@@ -295,7 +295,7 @@ func TestValidateExecMsg_InitBeforeInclusion(t *testing.T) {
 
 	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 	require.Contains(t, err.Error(), "not before inclusion")
 }
 
@@ -317,7 +317,7 @@ func TestValidateExecMsg_MessageExpired(t *testing.T) {
 
 	err := cv.ValidateAccessEntry(access, safety.LocalUnsafe, exec)
 	require.Error(t, err)
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 	require.Contains(t, err.Error(), "expired")
 }
 
@@ -547,7 +547,7 @@ func TestValidateMessageTiming(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errContains)
-				require.ErrorIs(t, err, types.ErrConflict)
+				require.ErrorIs(t, err, interop.ErrConflict)
 			} else {
 				require.NoError(t, err)
 			}

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -22,8 +22,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop/raftwallogdb"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -229,7 +229,7 @@ func (c *LogsDBChainIngester) Contains(query messages.ContainsQuery) (messages.B
 
 	if c.logsDB == nil {
 		c.log.Warn("Contains called but logs DB not initialized")
-		return messages.BlockSeal{}, types.ErrUninitialized
+		return messages.BlockSeal{}, interop.ErrUninitialized
 	}
 
 	return c.logsDB.Contains(query)
@@ -298,7 +298,7 @@ func (c *LogsDBChainIngester) GetExecMsgsAtTimestamp(timestamp uint64) ([]Includ
 
 	if c.logsDB == nil {
 		c.log.Warn("GetExecMsgsAtTimestamp called but logs DB not initialized")
-		return nil, types.ErrUninitialized
+		return nil, interop.ErrUninitialized
 	}
 
 	blockNum, err := c.rollupCfg.TargetBlockNumber(timestamp)
@@ -314,7 +314,7 @@ func (c *LogsDBChainIngester) GetExecMsgsAtTimestamp(timestamp uint64) ([]Includ
 	if !c.earliestIngestedBlockSet.Load() {
 		// We have not yet ingested any block with log data. Backfill is in progress
 		// (or hasn't started); we must not silently report "no executing messages".
-		return nil, types.ErrUninitialized
+		return nil, interop.ErrUninitialized
 	}
 	if blockNum < c.earliestIngestedBlock.Load() {
 		return nil, nil
@@ -618,7 +618,7 @@ func (c *LogsDBChainIngester) RewindToFinalized(ctx context.Context) (eth.BlockI
 	defer c.mu.Unlock()
 
 	if c.logsDB == nil {
-		return eth.BlockID{}, 0, types.ErrUninitialized
+		return eth.BlockID{}, 0, interop.ErrUninitialized
 	}
 
 	// Recovery is intentionally fail-closed: finalized should already be in
@@ -630,7 +630,7 @@ func (c *LogsDBChainIngester) RewindToFinalized(ctx context.Context) (eth.BlockI
 	}
 	if storedSeal.Hash != targetID.Hash {
 		return eth.BlockID{}, 0, fmt.Errorf("finalized block %d hash mismatch: db has %s, chain has %s: %w",
-			targetID.Number, storedSeal.Hash, targetID.Hash, types.ErrConflict)
+			targetID.Number, storedSeal.Hash, targetID.Hash, interop.ErrConflict)
 	}
 
 	if err := c.logsDB.Rewind(targetID); err != nil {
@@ -792,11 +792,11 @@ func (c *LogsDBChainIngester) writeFetchedBlock(fetched blockFetch) error {
 
 	logCount, err := c.processBlockLogs(blockInfo, blockID, fetched.receipts, blockNum)
 	if err != nil {
-		if errors.Is(err, types.ErrConflict) {
+		if errors.Is(err, interop.ErrConflict) {
 			c.SetError(ErrorConflict, fmt.Sprintf("database conflict at block %d", blockNum))
 			return c.Error()
 		}
-		if errors.Is(err, types.ErrDataCorruption) {
+		if errors.Is(err, interop.ErrDataCorruption) {
 			c.SetError(ErrorDataCorruption, fmt.Sprintf("data corruption at block %d: %v", blockNum, err))
 			return c.Error()
 		}

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -439,7 +439,7 @@ func TestLogsDBChainIngester_Contains(t *testing.T) {
 
 	// Contains should fail when logsDB not initialized
 	_, err := ingester.Contains(messages.ContainsQuery{})
-	require.ErrorIs(t, err, types.ErrUninitialized)
+	require.ErrorIs(t, err, interop.ErrUninitialized)
 
 	err = ingester.initLogsDB()
 	require.NoError(t, err)
@@ -459,7 +459,7 @@ func TestLogsDBChainIngester_Contains(t *testing.T) {
 		LogIdx:    99, // Doesn't exist
 		Checksum:  messages.MessageChecksum{0xFF},
 	})
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 }
 
 func TestLogsDBChainIngester_CalculateStartingBlock_BackfillUnderflow(t *testing.T) {

--- a/op-interop-filter/filter/logsdb_dispatch_test.go
+++ b/op-interop-filter/filter/logsdb_dispatch_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -94,22 +94,22 @@ func TestWriteFetchedBlock_WriteErrorDispatch(t *testing.T) {
 	}{
 		{
 			name:       "AddLog_ErrConflict",
-			setup:      func(f *fakeLogsDB) { f.addLogErr = fmt.Errorf("add: %w", types.ErrConflict) },
+			setup:      func(f *fakeLogsDB) { f.addLogErr = fmt.Errorf("add: %w", interop.ErrConflict) },
 			wantReason: ErrorConflict,
 		},
 		{
 			name:       "AddLog_ErrDataCorruption",
-			setup:      func(f *fakeLogsDB) { f.addLogErr = fmt.Errorf("add: %w", types.ErrDataCorruption) },
+			setup:      func(f *fakeLogsDB) { f.addLogErr = fmt.Errorf("add: %w", interop.ErrDataCorruption) },
 			wantReason: ErrorDataCorruption,
 		},
 		{
 			name:       "SealBlock_ErrConflict",
-			setup:      func(f *fakeLogsDB) { f.sealBlockErr = fmt.Errorf("seal: %w", types.ErrConflict) },
+			setup:      func(f *fakeLogsDB) { f.sealBlockErr = fmt.Errorf("seal: %w", interop.ErrConflict) },
 			wantReason: ErrorConflict,
 		},
 		{
 			name:       "SealBlock_ErrDataCorruption",
-			setup:      func(f *fakeLogsDB) { f.sealBlockErr = fmt.Errorf("seal: %w", types.ErrDataCorruption) },
+			setup:      func(f *fakeLogsDB) { f.sealBlockErr = fmt.Errorf("seal: %w", interop.ErrDataCorruption) },
 			wantReason: ErrorDataCorruption,
 		},
 	}
@@ -141,9 +141,9 @@ func TestWriteFetchedBlock_WriteErrorPassthrough(t *testing.T) {
 		name string
 		err  error
 	}{
-		{"AddLog_ErrFuture", fmt.Errorf("add: %w", types.ErrFuture)},
-		{"AddLog_ErrSkipped", fmt.Errorf("add: %w", types.ErrSkipped)},
-		{"AddLog_ErrOutOfOrder", fmt.Errorf("add: %w", types.ErrOutOfOrder)},
+		{"AddLog_ErrFuture", fmt.Errorf("add: %w", interop.ErrFuture)},
+		{"AddLog_ErrSkipped", fmt.Errorf("add: %w", interop.ErrSkipped)},
+		{"AddLog_ErrOutOfOrder", fmt.Errorf("add: %w", interop.ErrOutOfOrder)},
 		{"AddLog_Generic", errors.New("transient i/o")},
 	}
 	for _, tc := range cases {

--- a/op-interop-filter/filter/logsdb_integration_backend_test.go
+++ b/op-interop-filter/filter/logsdb_integration_backend_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
@@ -33,7 +33,7 @@ func TestIntegration_Backend_NoChains_FailsafeOn(t *testing.T) {
 
 	require.False(t, bk.Ready(), "empty chain map -> Backend.Ready() is false")
 	err := bk.CheckAccessList(ctx, nil, safety.LocalUnsafe, messages.ExecutingDescriptor{ChainID: executingChain()})
-	require.ErrorIs(t, err, types.ErrUninitialized)
+	require.ErrorIs(t, err, interop.ErrUninitialized)
 }
 
 func TestIntegration_Backend_ManualFailsafe_RejectsAll(t *testing.T) {
@@ -118,6 +118,6 @@ func TestIntegration_Backend_Ready_FalseUntilAllChainsReady(t *testing.T) {
 	err := bk.CheckAccessList(context.Background(), nil, safety.LocalUnsafe,
 		messages.ExecutingDescriptor{ChainID: executingChain(), Timestamp: inclusionTs})
 	require.Error(t, err)
-	require.True(t, errors.Is(err, types.ErrUninitialized) || errors.Is(err, types.ErrFailsafeEnabled),
+	require.True(t, errors.Is(err, interop.ErrUninitialized) || errors.Is(err, interop.ErrFailsafeEnabled),
 		"expected ErrUninitialized or ErrFailsafeEnabled, got %v", err)
 }

--- a/op-interop-filter/filter/logsdb_integration_contains_test.go
+++ b/op-interop-filter/filter/logsdb_integration_contains_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -106,7 +106,7 @@ func TestIntegration_Contains_BeforeInit_Uninitialized(t *testing.T) {
 	si.logsDB = nil
 
 	_, err := si.Contains(messages.ContainsQuery{BlockNum: 100, Timestamp: 1200})
-	require.ErrorIs(t, err, types.ErrUninitialized)
+	require.ErrorIs(t, err, interop.ErrUninitialized)
 }
 
 func TestIntegration_Contains_FailsafeAlreadyEnabled_Rejected(t *testing.T) {

--- a/op-interop-filter/filter/logsdb_integration_execmsgs_test.go
+++ b/op-interop-filter/filter/logsdb_integration_execmsgs_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 // remoteExecMsg constructs a seedLog declaring an executing message that
@@ -80,7 +80,7 @@ func TestIntegration_GetExecMsgsAtTimestamp_BeforeInit_Uninitialized(t *testing.
 	si.logsDB = nil
 
 	_, err := si.GetExecMsgsAtTimestamp(1200)
-	require.ErrorIs(t, err, types.ErrUninitialized)
+	require.ErrorIs(t, err, interop.ErrUninitialized)
 }
 
 func TestIntegration_GetExecMsgsAtTimestamp_AnchorOnly_Uninitialized(t *testing.T) {
@@ -93,7 +93,7 @@ func TestIntegration_GetExecMsgsAtTimestamp_AnchorOnly_Uninitialized(t *testing.
 	})
 
 	_, err := si.GetExecMsgsAtTimestamp(1198)
-	require.ErrorIs(t, err, types.ErrUninitialized)
+	require.ErrorIs(t, err, interop.ErrUninitialized)
 }
 
 func TestIntegration_GetExecMsgsAtTimestamp_BelowEarliest_ReturnsEmpty(t *testing.T) {
@@ -158,7 +158,7 @@ func TestIntegration_GetExecMsgsAtTimestamp_NonexistentTimestamp_ReturnsEmpty(t 
 
 	// Future timestamp beyond latest also returns empty (no error).
 	msgs, err = si.GetExecMsgsAtTimestamp(9999)
-	require.False(t, errors.Is(err, types.ErrUninitialized))
+	require.False(t, errors.Is(err, interop.ErrUninitialized))
 	require.NoError(t, err)
 	require.Empty(t, msgs)
 }

--- a/op-interop-filter/filter/logsdb_integration_reorg_recovery_test.go
+++ b/op-interop-filter/filter/logsdb_integration_reorg_recovery_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 // putIntoReorg forces the ingester into ErrorReorg by ingesting a block whose
@@ -71,7 +71,7 @@ func TestIntegration_RecoverReorg_BeforeInit_Uninitialized(t *testing.T) {
 	si.logsDB = nil
 
 	_, _, err := si.RewindToFinalized(context.Background())
-	require.ErrorIs(t, err, types.ErrUninitialized)
+	require.ErrorIs(t, err, interop.ErrUninitialized)
 }
 
 func TestIntegration_RecoverReorg_FinalizedBlockNotInDB_StaysInFailsafe(t *testing.T) {
@@ -87,7 +87,7 @@ func TestIntegration_RecoverReorg_FinalizedBlockNotInDB_StaysInFailsafe(t *testi
 
 	_, _, err := bk.recoverChainReorg(context.Background(), si.chainID, si.LogsDBChainIngester)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, types.ErrFuture), "expected ErrFuture, got %v", err)
+	require.True(t, errors.Is(err, interop.ErrFuture), "expected ErrFuture, got %v", err)
 	require.NotNil(t, si.Error())
 	require.Equal(t, ErrorReorg, si.Error().Reason)
 }
@@ -105,7 +105,7 @@ func TestIntegration_RecoverReorg_FinalizedHashMismatch_StaysInFailsafe(t *testi
 
 	_, _, err := bk.recoverChainReorg(context.Background(), si.chainID, si.LogsDBChainIngester)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, types.ErrConflict), "expected ErrConflict, got %v", err)
+	require.True(t, errors.Is(err, interop.ErrConflict), "expected ErrConflict, got %v", err)
 	require.NotNil(t, si.Error())
 	require.Equal(t, ErrorReorg, si.Error().Reason)
 }

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
@@ -141,7 +141,7 @@ func (m *mockChainIngester) Contains(query messages.ContainsQuery) (messages.Blo
 
 	seal, ok := m.logs[key]
 	if !ok {
-		return messages.BlockSeal{}, types.ErrConflict
+		return messages.BlockSeal{}, interop.ErrConflict
 	}
 	return seal, nil
 }

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"
@@ -13,7 +14,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/cross"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
-	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -214,7 +214,7 @@ func singleRoundConsolidation(
 }
 
 func isInvalidMessageError(err error) bool {
-	return errors.Is(err, supervisortypes.ErrConflict) || errors.Is(err, supervisortypes.ErrUnknownChain)
+	return errors.Is(err, interop.ErrConflict) || errors.Is(err, interop.ErrUnknownChain)
 }
 
 type ConsolidateCheckDeps interface {
@@ -295,7 +295,7 @@ func (d *consolidateCheckDeps) Contains(chain eth.ChainID, query messages.Contai
 		return messages.BlockSeal{}, err
 	}
 	if block.Time() != query.Timestamp {
-		return messages.BlockSeal{}, fmt.Errorf("block timestamp mismatch: %d != %d: %w", block.Time(), query.Timestamp, supervisortypes.ErrConflict)
+		return messages.BlockSeal{}, fmt.Errorf("block timestamp mismatch: %d != %d: %w", block.Time(), query.Timestamp, interop.ErrConflict)
 	}
 	_, receipts := d.oracle.ReceiptsByBlockHash(block.Hash(), chain)
 	var current uint32
@@ -310,7 +310,7 @@ func (d *consolidateCheckDeps) Contains(chain eth.ChainID, query messages.Contai
 					LogHash:     logToLogHash(log),
 				}.Checksum()
 				if checksum != query.Checksum {
-					return messages.BlockSeal{}, fmt.Errorf("checksum mismatch: %s != %s: %w", checksum, query.Checksum, supervisortypes.ErrConflict)
+					return messages.BlockSeal{}, fmt.Errorf("checksum mismatch: %s != %s: %w", checksum, query.Checksum, interop.ErrConflict)
 				} else {
 					return messages.BlockSeal{
 						Hash:      block.Hash(),
@@ -322,7 +322,7 @@ func (d *consolidateCheckDeps) Contains(chain eth.ChainID, query messages.Contai
 		}
 		current += uint32(len(receipt.Logs))
 	}
-	return messages.BlockSeal{}, fmt.Errorf("log not found: %w", supervisortypes.ErrConflict)
+	return messages.BlockSeal{}, fmt.Errorf("log not found: %w", interop.ErrConflict)
 }
 
 func logToLogHash(l *ethtypes.Log) common.Hash {
@@ -379,7 +379,7 @@ func (d *consolidateCheckDeps) OpenBlock(
 func (d *consolidateCheckDeps) CanonBlockByNumber(oracle l2.Oracle, blockNum uint64, chainID eth.ChainID) (*ethtypes.Block, error) {
 	head := d.canonBlocks[chainID].GetHeaderByNumber(blockNum)
 	if head == nil {
-		return nil, fmt.Errorf("head not found for chain %v: %w", chainID, supervisortypes.ErrConflict)
+		return nil, fmt.Errorf("head not found for chain %v: %w", chainID, interop.ErrConflict)
 	}
 	return d.oracle.BlockByHash(head.Hash(), chainID), nil
 }

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -7,8 +7,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -23,7 +24,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/cross"
-	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -715,7 +715,7 @@ func TestHazardSet_ExpiredMessageShortCircuitsInclusionCheck(t *testing.T) {
 
 		mockConsolidateDeps := &mockConsolidateDeps{consolidateCheckDeps: consolidateDeps}
 		mockConsolidateDeps.
-			On("Contains", mock.Anything, mock.Anything).Return(messages.BlockSeal{}, supervisortypes.ErrConflict).
+			On("Contains", mock.Anything, mock.Anything).Return(messages.BlockSeal{}, interop.ErrConflict).
 			Maybe()
 
 		linker := depset.LinkCheckFn(func(execInChain eth.ChainID, execInTimestamp uint64, initChainID eth.ChainID, initTimestamp uint64) bool {
@@ -729,7 +729,7 @@ func TestHazardSet_ExpiredMessageShortCircuitsInclusionCheck(t *testing.T) {
 			Timestamp: block2A.Time(),
 		}
 		_, err = cross.NewHazardSet(deps, linker, logger, eth.ChainIDFromBig(configA.L2ChainID), candidate)
-		require.ErrorIs(t, err, supervisortypes.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 
 		if expectInclusionCheck {
 			mockConsolidateDeps.AssertCalled(t, "Contains", mock.Anything, mock.Anything)

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -103,7 +103,7 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 			if err != nil {
 				// OpenBlock fails for the first block in the DB because it tries to find the parent.
 				// Handle this by checking if this is the first sealed block and using FirstSealedBlock instead.
-				if errors.Is(err, types.ErrSkipped) {
+				if errors.Is(err, interop.ErrSkipped) {
 					firstBlock, firstErr := db.FirstSealedBlock()
 					if firstErr != nil {
 						return Result{}, fmt.Errorf("chain %s: failed to open block %d and failed to get first block: %w", chainID, expectedBlock.Number, err)

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
-	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -661,7 +661,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				sourceDB := &algoMockLogsDB{
-					containsErr: suptypes.ErrConflict, // Message not found
+					containsErr: interop.ErrConflict, // Message not found
 				}
 
 				destDB := &algoMockLogsDB{

--- a/op-supernode/supernode/activity/interop/raftwallogdb/db.go
+++ b/op-supernode/supernode/activity/interop/raftwallogdb/db.go
@@ -17,8 +17,8 @@ import (
 	wal "github.com/hashicorp/raft-wal"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -109,7 +109,7 @@ func (r *blockRecord) ExecMsg(i uint32) (uint32, *messages.ExecutingMessage) {
 // header's declared counts.
 func decodeBlockRecord(buf []byte) (blockRecord, error) {
 	if len(buf) < blockRecordSize {
-		return blockRecord{}, fmt.Errorf("%w: blockRecord: short buffer %d", types.ErrDataCorruption, len(buf))
+		return blockRecord{}, fmt.Errorf("%w: blockRecord: short buffer %d", interop.ErrDataCorruption, len(buf))
 	}
 	var r blockRecord
 	copy(r.Hash[:], buf[0:32])
@@ -120,7 +120,7 @@ func decodeBlockRecord(buf []byte) (blockRecord, error) {
 
 	expected := blockRecordSize + int(r.LogCount)*logHashSize + int(r.ExecMsgCount)*execMsgRecordSize
 	if len(buf) != expected {
-		return blockRecord{}, fmt.Errorf("%w: entry length %d, expected %d", types.ErrDataCorruption, len(buf), expected)
+		return blockRecord{}, fmt.Errorf("%w: entry length %d, expected %d", interop.ErrDataCorruption, len(buf), expected)
 	}
 	hashesEnd := hashesOffset + int(r.LogCount)*logHashSize
 	r.hashes = buf[hashesOffset:hashesEnd]
@@ -217,7 +217,7 @@ func (d *DB) FirstSealedBlock() (messages.BlockSeal, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	if !d.hasBlocks {
-		return messages.BlockSeal{}, types.ErrFuture
+		return messages.BlockSeal{}, interop.ErrFuture
 	}
 	rec, err := d.readBlockAt(indexFor(d.firstBlock))
 	if err != nil {
@@ -230,13 +230,13 @@ func (d *DB) FindSealedBlock(number uint64) (messages.BlockSeal, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	if !d.hasBlocks {
-		return messages.BlockSeal{}, types.ErrFuture
+		return messages.BlockSeal{}, interop.ErrFuture
 	}
 	if number > d.latest.Number {
-		return messages.BlockSeal{}, types.ErrFuture
+		return messages.BlockSeal{}, interop.ErrFuture
 	}
 	if number < d.firstBlock {
-		return messages.BlockSeal{}, types.ErrSkipped
+		return messages.BlockSeal{}, interop.ErrSkipped
 	}
 	rec, err := d.readBlockAt(indexFor(number))
 	if err != nil {
@@ -249,17 +249,17 @@ func (d *DB) OpenBlock(blockNum uint64) (eth.BlockRef, uint32, map[uint32]*messa
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	if !d.hasBlocks {
-		return eth.BlockRef{}, 0, nil, types.ErrFuture
+		return eth.BlockRef{}, 0, nil, interop.ErrFuture
 	}
 	if blockNum > d.latest.Number {
-		return eth.BlockRef{}, 0, nil, types.ErrFuture
+		return eth.BlockRef{}, 0, nil, interop.ErrFuture
 	}
 	// Matches the old op-supervisor logs DB: the first sealed block is an
 	// anchor with no resolvable parent state, so OpenBlock on it returns
 	// ErrSkipped. Genesis (firstBlock == 0) is exempt since it is its own
 	// anchor. Callers retrieve the anchor via FirstSealedBlock.
 	if blockNum < d.firstBlock || (blockNum == d.firstBlock && d.firstBlock > 0) {
-		return eth.BlockRef{}, 0, nil, types.ErrSkipped
+		return eth.BlockRef{}, 0, nil, interop.ErrSkipped
 	}
 	var log raft.Log
 	if err := d.w.GetLog(indexFor(blockNum), &log); err != nil {
@@ -287,16 +287,16 @@ func (d *DB) Contains(query messages.ContainsQuery) (messages.BlockSeal, error) 
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	if !d.hasBlocks {
-		return messages.BlockSeal{}, types.ErrFuture
+		return messages.BlockSeal{}, interop.ErrFuture
 	}
 	if query.BlockNum > d.latest.Number {
 		if d.latestTS > query.Timestamp {
-			return messages.BlockSeal{}, types.ErrConflict
+			return messages.BlockSeal{}, interop.ErrConflict
 		}
-		return messages.BlockSeal{}, types.ErrFuture
+		return messages.BlockSeal{}, interop.ErrFuture
 	}
 	if query.BlockNum < d.firstBlock {
-		return messages.BlockSeal{}, types.ErrSkipped
+		return messages.BlockSeal{}, interop.ErrSkipped
 	}
 
 	var log raft.Log
@@ -308,10 +308,10 @@ func (d *DB) Contains(query messages.ContainsQuery) (messages.BlockSeal, error) 
 		return messages.BlockSeal{}, err
 	}
 	if query.LogIdx >= rec.LogCount {
-		return messages.BlockSeal{}, types.ErrConflict
+		return messages.BlockSeal{}, interop.ErrConflict
 	}
 	if rec.Timestamp != query.Timestamp {
-		return messages.BlockSeal{}, fmt.Errorf("timestamp mismatch: expected %d, got %d: %w", query.Timestamp, rec.Timestamp, types.ErrConflict)
+		return messages.BlockSeal{}, fmt.Errorf("timestamp mismatch: expected %d, got %d: %w", query.Timestamp, rec.Timestamp, interop.ErrConflict)
 	}
 
 	logHash := rec.LogHash(query.LogIdx)
@@ -323,7 +323,7 @@ func (d *DB) Contains(query messages.ContainsQuery) (messages.BlockSeal, error) 
 		LogHash:     logHash,
 	}.Checksum()
 	if expectedChecksum != query.Checksum {
-		return messages.BlockSeal{}, fmt.Errorf("checksum mismatch: %w", types.ErrConflict)
+		return messages.BlockSeal{}, fmt.Errorf("checksum mismatch: %w", interop.ErrConflict)
 	}
 	return messages.BlockSeal{Hash: rec.Hash, Number: query.BlockNum, Timestamp: rec.Timestamp}, nil
 }
@@ -335,24 +335,24 @@ func (d *DB) AddLog(logHash common.Hash, parentBlock eth.BlockID, logIdx uint32,
 	// Genesis cannot carry logs: the EVM never executes the genesis block, so a
 	// log against the zero BlockID is invalid from any legitimate writer.
 	if parentBlock == (eth.BlockID{}) {
-		return fmt.Errorf("%w: genesis does not have logs", types.ErrOutOfOrder)
+		return fmt.Errorf("%w: genesis does not have logs", interop.ErrOutOfOrder)
 	}
 
 	if d.hasBlocks {
 		if parentBlock != d.latest {
-			return fmt.Errorf("%w: AddLog parent %s does not match latest sealed %s", types.ErrOutOfOrder, parentBlock, d.latest)
+			return fmt.Errorf("%w: AddLog parent %s does not match latest sealed %s", interop.ErrOutOfOrder, parentBlock, d.latest)
 		}
 	}
 	if d.hasPending {
 		if parentBlock != d.pendingParent {
-			return fmt.Errorf("%w: AddLog parent %s does not match pending parent %s", types.ErrOutOfOrder, parentBlock, d.pendingParent)
+			return fmt.Errorf("%w: AddLog parent %s does not match pending parent %s", interop.ErrOutOfOrder, parentBlock, d.pendingParent)
 		}
 		if logIdx != uint32(len(d.pendingLogs)) {
-			return fmt.Errorf("%w: AddLog index %d does not match expected %d", types.ErrOutOfOrder, logIdx, len(d.pendingLogs))
+			return fmt.Errorf("%w: AddLog index %d does not match expected %d", interop.ErrOutOfOrder, logIdx, len(d.pendingLogs))
 		}
 	} else {
 		if logIdx != 0 {
-			return fmt.Errorf("%w: first AddLog of a block must have index 0, got %d", types.ErrOutOfOrder, logIdx)
+			return fmt.Errorf("%w: first AddLog of a block must have index 0, got %d", interop.ErrOutOfOrder, logIdx)
 		}
 		d.pendingParent = parentBlock
 		d.hasPending = true
@@ -367,19 +367,19 @@ func (d *DB) SealBlock(parentHash common.Hash, block eth.BlockID, timestamp uint
 
 	if d.hasBlocks {
 		if block.Number != d.latest.Number+1 {
-			return fmt.Errorf("%w: SealBlock expected number %d, got %d", types.ErrConflict, d.latest.Number+1, block.Number)
+			return fmt.Errorf("%w: SealBlock expected number %d, got %d", interop.ErrConflict, d.latest.Number+1, block.Number)
 		}
 		if parentHash != d.latest.Hash {
-			return fmt.Errorf("%w: SealBlock parent %s does not match latest %s", types.ErrConflict, parentHash, d.latest.Hash)
+			return fmt.Errorf("%w: SealBlock parent %s does not match latest %s", interop.ErrConflict, parentHash, d.latest.Hash)
 		}
 		if timestamp < d.latestTS {
-			return fmt.Errorf("%w: SealBlock timestamp %d before latest %d", types.ErrConflict, timestamp, d.latestTS)
+			return fmt.Errorf("%w: SealBlock timestamp %d before latest %d", interop.ErrConflict, timestamp, d.latestTS)
 		}
 	}
 	if d.hasPending {
 		expectedParent := eth.BlockID{Hash: parentHash, Number: block.Number - 1}
 		if d.pendingParent != expectedParent {
-			return fmt.Errorf("%w: SealBlock parent %s does not match pending logs' parent %s", types.ErrConflict, expectedParent, d.pendingParent)
+			return fmt.Errorf("%w: SealBlock parent %s does not match pending logs' parent %s", interop.ErrConflict, expectedParent, d.pendingParent)
 		}
 	}
 
@@ -441,7 +441,7 @@ func (d *DB) Rewind(newHead eth.BlockID) error {
 		return d.clearLocked()
 	}
 	if newHead.Number > d.latest.Number {
-		return fmt.Errorf("%w: cannot rewind to %s, latest is %s", types.ErrFuture, newHead, d.latest)
+		return fmt.Errorf("%w: cannot rewind to %s, latest is %s", interop.ErrFuture, newHead, d.latest)
 	}
 
 	rec, err := d.readBlockAt(indexFor(newHead.Number))
@@ -449,7 +449,7 @@ func (d *DB) Rewind(newHead eth.BlockID) error {
 		return err
 	}
 	if rec.Hash != newHead.Hash {
-		return fmt.Errorf("%w: rewind target %s does not match stored hash %s", types.ErrConflict, newHead.Hash, rec.Hash)
+		return fmt.Errorf("%w: rewind target %s does not match stored hash %s", interop.ErrConflict, newHead.Hash, rec.Hash)
 	}
 
 	if newHead.Number < d.latest.Number {

--- a/op-supernode/supernode/activity/interop/raftwallogdb/db_test.go
+++ b/op-supernode/supernode/activity/interop/raftwallogdb/db_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -51,13 +51,13 @@ func TestEmpty(t *testing.T) {
 	_, ok := db.LatestSealedBlock()
 	require.False(t, ok)
 	_, err := db.FirstSealedBlock()
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 	_, err = db.FindSealedBlock(0)
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 	_, _, _, err = db.OpenBlock(1)
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 	_, err = db.Contains(messages.ContainsQuery{BlockNum: 1, Timestamp: 1})
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 }
 
 func TestSealAndOpenBlock(t *testing.T) {
@@ -104,18 +104,18 @@ func TestSealBlock_Validation(t *testing.T) {
 
 	// Wrong parent hash.
 	err := db.SealBlock(hash(0xFF), blockID(1, 0x11), 200)
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 
 	// Wrong block number. Matches old logs DB: state desync on SealBlock is
 	// ErrConflict so op-interop-filter's failsafe (logsdb_chain_ingester.go:793)
 	// trips rather than silently retrying.
 	err = db.SealBlock(parent.Hash, blockID(2, 0x22), 200)
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 
 	// Timestamp regression. Same rationale: regressing timestamps indicate
 	// upstream desync, not a transient out-of-order condition.
 	err = db.SealBlock(parent.Hash, blockID(1, 0x11), 50)
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 }
 
 func TestAddLog_Validation(t *testing.T) {
@@ -125,22 +125,22 @@ func TestAddLog_Validation(t *testing.T) {
 
 	// First log must have index 0.
 	err := db.AddLog(hash(0x01), parent, 1, nil)
-	require.ErrorIs(t, err, types.ErrOutOfOrder)
+	require.ErrorIs(t, err, interop.ErrOutOfOrder)
 
 	// Wrong parent for the first AddLog establishes pendingParent;
 	// subsequent calls must match. Matches old logs DB: parent identity
 	// mismatch in AddLog is ErrOutOfOrder, not ErrConflict.
 	require.NoError(t, db.AddLog(hash(0x01), parent, 0, nil))
 	err = db.AddLog(hash(0x02), blockID(99, 0xFF), 1, nil)
-	require.ErrorIs(t, err, types.ErrOutOfOrder)
+	require.ErrorIs(t, err, interop.ErrOutOfOrder)
 
 	// Duplicate index.
 	err = db.AddLog(hash(0x02), parent, 0, nil)
-	require.ErrorIs(t, err, types.ErrOutOfOrder)
+	require.ErrorIs(t, err, interop.ErrOutOfOrder)
 
 	// Skipping an index.
 	err = db.AddLog(hash(0x02), parent, 2, nil)
-	require.ErrorIs(t, err, types.ErrOutOfOrder)
+	require.ErrorIs(t, err, interop.ErrOutOfOrder)
 }
 
 // TestAddLog_RejectsGenesisParent ensures AddLog refuses logs whose parent is
@@ -151,7 +151,7 @@ func TestAddLog_Validation(t *testing.T) {
 func TestAddLog_RejectsGenesisParent(t *testing.T) {
 	db := tempDB(t)
 	err := db.AddLog(hash(0xAA), eth.BlockID{}, 0, nil)
-	require.ErrorIs(t, err, types.ErrOutOfOrder)
+	require.ErrorIs(t, err, interop.ErrOutOfOrder)
 }
 
 func TestAddLog_WrongParentAgainstLatest(t *testing.T) {
@@ -161,7 +161,7 @@ func TestAddLog_WrongParentAgainstLatest(t *testing.T) {
 	parent := blockID(0, 0xA0)
 	require.NoError(t, db.SealBlock(common.Hash{}, parent, 0))
 	err := db.AddLog(hash(0xAA), blockID(99, 0xFF), 0, nil)
-	require.ErrorIs(t, err, types.ErrOutOfOrder)
+	require.ErrorIs(t, err, interop.ErrOutOfOrder)
 }
 
 func TestContains(t *testing.T) {
@@ -185,23 +185,23 @@ func TestContains(t *testing.T) {
 
 	// Wrong checksum.
 	_, err = db.Contains(messages.ContainsQuery{BlockNum: 1, LogIdx: 0, Timestamp: 200, Checksum: messages.MessageChecksum(hash(0xDE))})
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 
 	// Wrong timestamp for the block.
 	_, err = db.Contains(messages.ContainsQuery{BlockNum: 1, LogIdx: 0, Timestamp: 999, Checksum: good})
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 
 	// LogIdx out of range for an existing block.
 	_, err = db.Contains(messages.ContainsQuery{BlockNum: 1, LogIdx: 5, Timestamp: 200, Checksum: good})
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 
 	// Future block (timestamp consistent with growth): ErrFuture.
 	_, err = db.Contains(messages.ContainsQuery{BlockNum: 10, LogIdx: 0, Timestamp: 999, Checksum: good})
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 
 	// Future block but past timestamp: ErrConflict (cannot be in the future).
 	_, err = db.Contains(messages.ContainsQuery{BlockNum: 10, LogIdx: 0, Timestamp: 50, Checksum: good})
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 }
 
 func TestContains_Block0(t *testing.T) {
@@ -213,7 +213,7 @@ func TestContains_Block0(t *testing.T) {
 
 	// Empty DB → ErrFuture, regardless of block number.
 	_, err := db.Contains(messages.ContainsQuery{BlockNum: 0, LogIdx: 0, Timestamp: 0})
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 
 	// Seal block 0 as a logless genesis.
 	genesis := blockID(0, 0xA0)
@@ -232,7 +232,7 @@ func TestContains_Block0(t *testing.T) {
 	// Contains on block 0 with logIdx 0 hits the "logIdx >= logCount" check (not
 	// a hard-coded block-0 reject) and returns ErrConflict.
 	_, err = db.Contains(messages.ContainsQuery{BlockNum: 0, LogIdx: 0, Timestamp: 0})
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 }
 
 func TestFindSealedBlock(t *testing.T) {
@@ -253,11 +253,11 @@ func TestFindSealedBlock(t *testing.T) {
 
 	// Below first block.
 	_, err = db.FindSealedBlock(50)
-	require.True(t, errors.Is(err, types.ErrSkipped))
+	require.True(t, errors.Is(err, interop.ErrSkipped))
 
 	// Past the latest block.
 	_, err = db.FindSealedBlock(999)
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 }
 
 func TestOpenBlock_Boundaries(t *testing.T) {
@@ -267,11 +267,11 @@ func TestOpenBlock_Boundaries(t *testing.T) {
 
 	// Below first block.
 	_, _, _, err := db.OpenBlock(50)
-	require.ErrorIs(t, err, types.ErrSkipped)
+	require.ErrorIs(t, err, interop.ErrSkipped)
 
 	// Above latest block.
 	_, _, _, err = db.OpenBlock(999)
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 
 	// Block 0 only valid if DB anchors at 0.
 	db2 := tempDB(t)
@@ -295,7 +295,7 @@ func TestOpenBlock_FirstBlockReturnsSkipped(t *testing.T) {
 	sealRange(t, db, first, 101, 103)
 
 	_, _, _, err := db.OpenBlock(100)
-	require.ErrorIs(t, err, types.ErrSkipped, "OpenBlock(firstBlock) must return ErrSkipped when firstBlock > 0")
+	require.ErrorIs(t, err, interop.ErrSkipped, "OpenBlock(firstBlock) must return ErrSkipped when firstBlock > 0")
 
 	seal, err := db.FirstSealedBlock()
 	require.NoError(t, err)
@@ -366,13 +366,13 @@ func TestRewind(t *testing.T) {
 
 	// Read-after-rewind: deleted blocks are gone, target survives.
 	_, err := db.FindSealedBlock(5)
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 	_, err = db.FindSealedBlock(4)
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 	_, err = db.FindSealedBlock(3)
 	require.NoError(t, err)
 	_, _, _, err = db.OpenBlock(5)
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 }
 
 func TestRewind_HashMismatch(t *testing.T) {
@@ -383,7 +383,7 @@ func TestRewind_HashMismatch(t *testing.T) {
 
 	bogus := eth.BlockID{Hash: hash(0xFF), Number: 2}
 	err := db.Rewind(bogus)
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 }
 
 func TestRewind_Empty(t *testing.T) {
@@ -415,7 +415,7 @@ func TestRewind_AboveLatest(t *testing.T) {
 	_, err := db.FindSealedBlock(0)
 	require.NoError(t, err)
 	err = db.Rewind(blockID(99, 0x99))
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 }
 
 func TestRewind_BeforeFirstClears(t *testing.T) {
@@ -439,7 +439,7 @@ func TestRewind_AtFirstKeepsIt(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, first, latest)
 	_, err := db.FindSealedBlock(101)
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 }
 
 func TestRewind_DropsPendingLogs(t *testing.T) {
@@ -463,9 +463,9 @@ func TestClear_Populated(t *testing.T) {
 	_, ok := db.LatestSealedBlock()
 	require.False(t, ok)
 	_, err := db.FirstSealedBlock()
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 	_, err = db.FindSealedBlock(2)
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 }
 
 func TestClear_Empty(t *testing.T) {
@@ -519,7 +519,7 @@ func TestPreSealCrashLosesPending(t *testing.T) {
 
 	// Block 6 must not exist.
 	_, err = db2.FindSealedBlock(6)
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 }
 
 func TestRecordEncoding_Roundtrip(t *testing.T) {
@@ -650,7 +650,7 @@ func TestContains_LastIndexBoundary(t *testing.T) {
 
 	// logIdx == n is one past the end and must be ErrConflict.
 	_, err = db.Contains(messages.ContainsQuery{BlockNum: 1, LogIdx: n, Timestamp: 200, Checksum: good})
-	require.ErrorIs(t, err, types.ErrConflict)
+	require.ErrorIs(t, err, interop.ErrConflict)
 }
 
 func TestPersistence_AfterRewind(t *testing.T) {
@@ -684,7 +684,7 @@ func TestPersistence_AfterRewind(t *testing.T) {
 
 	// Trimmed blocks are gone.
 	_, err = db2.FindSealedBlock(103)
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 
 	// Surviving blocks are intact.
 	for n := uint64(100); n <= 102; n++ {
@@ -712,7 +712,7 @@ func TestPersistence_AfterClear(t *testing.T) {
 	_, ok := db2.LatestSealedBlock()
 	require.False(t, ok)
 	_, err = db2.FirstSealedBlock()
-	require.ErrorIs(t, err, types.ErrFuture)
+	require.ErrorIs(t, err, interop.ErrFuture)
 
 	// And we can seal fresh blocks after reopen.
 	fresh := blockID(42, 0x2A)

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 
-	coredepset "github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	coredepset "github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	coredepset "github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
@@ -376,7 +377,7 @@ func (su *SupervisorBackend) AttachSyncNode(ctx context.Context, src syncnode.Sy
 		return nil, fmt.Errorf("failed to identify chain ID of sync source: %w", err)
 	}
 	if !su.cfgSet.HasChain(chainID) {
-		return nil, fmt.Errorf("chain %s is not part of the interop dependency set: %w", chainID, types.ErrUnknownChain)
+		return nil, fmt.Errorf("chain %s is not part of the interop dependency set: %w", chainID, interop.ErrUnknownChain)
 	}
 	err = su.AttachProcessorSource(chainID, src)
 	if err != nil {
@@ -515,7 +516,7 @@ func (su *SupervisorBackend) asyncVerifyAccessWithRPC(ctx context.Context, acc m
 	timeoutCtx, cancel := context.WithTimeout(ctx, verifyAccessWithRPCTimeout)
 	defer cancel()
 	msgBlockFromRPC, err := su.checkAccessWithRPC(timeoutCtx, acc)
-	if errors.Is(err, types.ErrConflict) {
+	if errors.Is(err, interop.ErrConflict) {
 		su.logger.Error("RPC access checksum failed", "err", err, "access", acc)
 		su.m.RecordAccessListVerifyFailure(acc.ChainID)
 	} else {
@@ -535,7 +536,7 @@ func (su *SupervisorBackend) asyncVerifyAccessWithRPC(ctx context.Context, acc m
 func (su *SupervisorBackend) checkAccessWithRPC(ctx context.Context, acc messages.Access) (eth.BlockID, error) {
 	src, ok := su.syncSources.Get(acc.ChainID)
 	if !ok {
-		return eth.BlockID{}, fmt.Errorf("%w: %v", types.ErrUnknownChain, acc.ChainID)
+		return eth.BlockID{}, fmt.Errorf("%w: %v", interop.ErrUnknownChain, acc.ChainID)
 	}
 
 	blockSeal, err := src.Contains(ctx, messages.ContainsQuery{
@@ -566,7 +567,7 @@ func (su *SupervisorBackend) checkSafety(chainID eth.ChainID, blockID eth.BlockI
 	case safety.Finalized:
 		return su.chainDBs.IsFinalized(chainID, blockID)
 	default:
-		return types.ErrConflict
+		return interop.ErrConflict
 	}
 }
 
@@ -575,7 +576,7 @@ func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries [
 	// Check if failsafe is enabled
 	if su.isFailsafeEnabled() {
 		su.logger.Debug("Failsafe is enabled, rejecting access-list check")
-		return types.ErrFailsafeEnabled
+		return interop.ErrFailsafeEnabled
 	}
 
 	switch minSafety {
@@ -613,20 +614,20 @@ func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries [
 		// If not specified, assume the same chain as the initiating side.
 		if !su.linker.CanExecute(execChainID, execDescr.Timestamp, acc.ChainID, acc.Timestamp) {
 			su.logger.Debug("Access-list link check failed")
-			return types.ErrConflict
+			return interop.ErrConflict
 		}
 		if execDescr.Timeout != 0 {
 			maxTimestamp := safemath.SaturatingAdd(execDescr.Timestamp, execDescr.Timeout)
 			if !su.linker.CanExecute(execChainID, maxTimestamp, acc.ChainID, acc.Timestamp) {
 				su.logger.Debug("Access-list link check at timeout time failed")
-				return types.ErrConflict
+				return interop.ErrConflict
 			}
 		}
 
 		msgBlockFromDB, err := su.checkAccessWithDB(acc)
 		if err != nil {
 			su.logger.Debug("Access-list inclusion check failed", "err", err)
-			return types.ErrConflict
+			return interop.ErrConflict
 		}
 
 		// Optional & additional, not part of the check-accesslist result. So not protected by the same read-handle.
@@ -636,7 +637,7 @@ func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries [
 
 		if err := su.checkSafety(acc.ChainID, msgBlockFromDB, minSafety); err != nil {
 			su.logger.Debug("Access-list safety check failed", "err", err)
-			return types.ErrConflict
+			return interop.ErrConflict
 		}
 	}
 	return h.Err()
@@ -795,7 +796,7 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 		source, err := su.chainDBs.CrossDerivedToSource(chainID, ref.ID())
 		if err != nil {
 			// Transform error to ethereum.NotFound at RPC boundary so that the challenger can detect this case
-			if errors.Is(err, types.ErrFuture) {
+			if errors.Is(err, interop.ErrFuture) {
 				err = errors.Join(err, ethereum.NotFound)
 			}
 			return eth.SuperRootResponse{}, fmt.Errorf("cross-derived-to-source failed for chain %s: %w", chainID, err)

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -13,8 +13,8 @@ import (
 	types2 "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
-	coredepset "github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	coredepset "github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	coredepset "github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -120,7 +121,7 @@ func TestBackendLifetime_InteropAtGenesis(t *testing.T) {
 	t.Log("started!")
 
 	_, err = b.LocalUnsafe(context.Background(), chainA)
-	require.ErrorIs(t, err, types.ErrFuture, "no data yet, need local-unsafe")
+	require.ErrorIs(t, err, interop.ErrFuture, "no data yet, need local-unsafe")
 
 	require.NoError(t, ex.Drain())
 	// The database is initialized from the genesis interop block at startup.
@@ -248,14 +249,14 @@ func TestBackendLifetime_InteropPostGenesis(t *testing.T) {
 	t.Log("started!")
 
 	_, err = b.LocalUnsafe(context.Background(), chainA)
-	require.ErrorIs(t, err, types.ErrFuture, "no data yet, need local-unsafe")
+	require.ErrorIs(t, err, interop.ErrFuture, "no data yet, need local-unsafe")
 
 	require.NoError(t, ex.Drain())
 	// The database is not initialized from non-Interop genesis
 	xunsafe, err := b.CrossUnsafe(context.Background(), chainA)
-	require.ErrorIs(t, err, types.ErrFuture, "got xunsafe %v", xunsafe)
+	require.ErrorIs(t, err, interop.ErrFuture, "got xunsafe %v", xunsafe)
 	xsafe, err := b.CrossSafe(context.Background(), chainA)
-	require.ErrorIs(t, err, types.ErrFuture, "got xsafe %v", xsafe)
+	require.ErrorIs(t, err, interop.ErrFuture, "got xsafe %v", xsafe)
 
 	// Receive unsafe block X, interop activation block, from node
 
@@ -275,7 +276,7 @@ func TestBackendLifetime_InteropPostGenesis(t *testing.T) {
 	require.Equal(t, blockX.ID(), xunsafe)
 	// cross-safe still undefined
 	_, err = b.CrossSafe(context.Background(), chainA)
-	require.ErrorIs(t, err, types.ErrFuture, err)
+	require.ErrorIs(t, err, interop.ErrFuture, err)
 
 	// Receive unsafe block Y from node
 
@@ -573,7 +574,7 @@ func TestAsyncVerifyAccessWithRPC(t *testing.T) {
 			// 3. When seal.ID() != dbBlock: Logs "DB access check result did not match" and calls RecordAccessListVerifyFailure
 
 			// Set expectations for the actual behavior observed
-			if errors.Is(stubErr, types.ErrConflict) {
+			if errors.Is(stubErr, interop.ErrConflict) {
 				// Error for checksum failure
 				mockMetrics.Mock.On("RecordAccessListVerifyFailure", chainID).Return()
 			}
@@ -601,11 +602,11 @@ func TestAsyncVerifyAccessWithRPC(t *testing.T) {
 	idB := sealB.ID()
 
 	// ErrConflict + mismatch => 2 failures (checksum + mismatch)
-	runScenario("ErrConflict_mismatch", sealA, types.ErrConflict, idB)
+	runScenario("ErrConflict_mismatch", sealA, interop.ErrConflict, idB)
 	// ErrConflict + match    => 1 failure  (checksum only)
-	runScenario("ErrConflict_match", sealA, types.ErrConflict, idA)
+	runScenario("ErrConflict_match", sealA, interop.ErrConflict, idA)
 	// Other non-conflict error + mismatch => 1 failure (mismatch only)
-	runScenario("OtherErr_mismatch", sealA, types.ErrFuture, idB)
+	runScenario("OtherErr_mismatch", sealA, interop.ErrFuture, idB)
 	// No error + match         => 0 failures
 	runScenario("NoErr_match", sealA, nil, idA)
 }
@@ -647,7 +648,7 @@ func TestFailsafeEnabled(t *testing.T) {
 
 	// Test that CheckAccessList returns ErrFailsafeEnabled when failsafe is enabled
 	err = b.CheckAccessList(context.Background(), []common.Hash{}, safety.LocalUnsafe, messages.ExecutingDescriptor{})
-	require.ErrorIs(t, err, types.ErrFailsafeEnabled, "CheckAccessList should return ErrFailsafeEnabled when failsafe is enabled")
+	require.ErrorIs(t, err, interop.ErrFailsafeEnabled, "CheckAccessList should return ErrFailsafeEnabled when failsafe is enabled")
 
 	// Test setting failsafe to false
 	err = b.SetFailsafeEnabled(context.Background(), false)

--- a/op-supervisor/supervisor/backend/cross/cycle.go
+++ b/op-supervisor/supervisor/backend/cross/cycle.go
@@ -6,16 +6,16 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
 // These error must be considered as ErrConflict to trigger a reorg.
 var (
-	ErrCycle                  = fmt.Errorf("%w: cycle detected", types.ErrConflict)
-	ErrExecMsgHasInvalidIndex = fmt.Errorf("%w: executing message has invalid log index", types.ErrConflict)
-	ErrExecMsgUnknownChain    = fmt.Errorf("%w: executing message references unknown chain", types.ErrConflict)
+	ErrCycle                  = fmt.Errorf("%w: cycle detected", interop.ErrConflict)
+	ErrExecMsgHasInvalidIndex = fmt.Errorf("%w: executing message has invalid log index", interop.ErrConflict)
+	ErrExecMsgUnknownChain    = fmt.Errorf("%w: executing message references unknown chain", interop.ErrConflict)
 
 	errInconsistentBlockSeal = errors.New("inconsistent block seal")
 )
@@ -175,7 +175,7 @@ func buildGraph(d CycleCheckDeps, inTimestamp uint64, hazards *HazardSet) (*grap
 
 			// Check if the init message exists
 			if logCount, ok := logCounts[m.ChainID]; !ok || m.LogIdx >= logCount {
-				return nil, fmt.Errorf("%w: initiating message log index out of bounds", types.ErrConflict)
+				return nil, fmt.Errorf("%w: initiating message log index out of bounds", interop.ErrConflict)
 			}
 
 			initKey := node{
@@ -190,7 +190,7 @@ func buildGraph(d CycleCheckDeps, inTimestamp uint64, hazards *HazardSet) (*grap
 			// Disallow self-referencing messages
 			// This should not be possible since the executing message contains the hash of the initiating message.
 			if initKey == execKey {
-				return nil, fmt.Errorf("%w: self referential message", types.ErrConflict)
+				return nil, fmt.Errorf("%w: self referential message", interop.ErrConflict)
 			}
 
 			// Add the edge

--- a/op-supervisor/supervisor/backend/cross/cycle_test.go
+++ b/op-supervisor/supervisor/backend/cross/cycle_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -214,7 +214,7 @@ func TestHazardCycleChecksFailures(t *testing.T) {
 					},
 				},
 			},
-			expectErr: types.ErrConflict,
+			expectErr: interop.ErrConflict,
 			msg:       "expected self reference detection error",
 		},
 		{

--- a/op-supervisor/supervisor/backend/cross/hazard_set.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
@@ -59,7 +59,7 @@ type potentialHazard struct {
 func (h *HazardSet) checkChainCanExecute(linker depset.LinkChecker, chainID eth.ChainID, block messages.BlockSeal, execMsgs map[uint32]*messages.ExecutingMessage) error {
 	for i, msg := range execMsgs {
 		if !linker.CanExecute(chainID, block.Timestamp, msg.ChainID, msg.Timestamp) {
-			return fmt.Errorf("executing message %d in block %s (chain %s) may not execute %s: %w", i, block, chainID, msg, types.ErrConflict)
+			return fmt.Errorf("executing message %d in block %s (chain %s) may not execute %s: %w", i, block, chainID, msg, interop.ErrConflict)
 		}
 	}
 	return nil
@@ -85,7 +85,7 @@ func (h *HazardSet) checkMessageWithCurrentTimestamp(initChainID eth.ChainID, in
 	existing, ok := h.entries[initChainID]
 	if ok {
 		if existing.ID() != includedIn.ID() {
-			return true, fmt.Errorf("found dependency on %s (chain %s), but already depend on %s: %w", includedIn, initChainID, existing, types.ErrConflict)
+			return true, fmt.Errorf("found dependency on %s (chain %s), but already depend on %s: %w", includedIn, initChainID, existing, interop.ErrConflict)
 		}
 	}
 	return ok, nil
@@ -114,7 +114,7 @@ func (h *HazardSet) build(deps HazardDeps, linker depset.LinkChecker, logger log
 			return fmt.Errorf("failed to open block: %w", err)
 		}
 		if opened.ID() != candidate.ID() {
-			return fmt.Errorf("unsafe L2 DB has %s, but candidate cross-safe was %s: %w", opened, candidate, types.ErrConflict)
+			return fmt.Errorf("unsafe L2 DB has %s, but candidate cross-safe was %s: %w", opened, candidate, interop.ErrConflict)
 		}
 		// Performance & safety: check all executing messages can exist (chain ID linking, timestamp invariants) first.
 		if err := h.checkChainCanExecute(linker, destChainID, candidate, execMsgs); err != nil {
@@ -153,7 +153,7 @@ func (h *HazardSet) build(deps HazardDeps, linker depset.LinkChecker, logger log
 					})
 				}
 			} else {
-				return fmt.Errorf("executing message %s in %s breaks timestamp invariant: %w", msg, candidate, types.ErrConflict)
+				return fmt.Errorf("executing message %s in %s breaks timestamp invariant: %w", msg, candidate, interop.ErrConflict)
 			}
 		}
 	}

--- a/op-supervisor/supervisor/backend/cross/hazard_set.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"

--- a/op-supervisor/supervisor/backend/cross/hazard_set_test.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
@@ -81,7 +81,7 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(1, 100, 1),
 				makeBlock(1, 100, 2),
 			},
-			expectErr: types.ErrConflict,
+			expectErr: interop.ErrConflict,
 		},
 		{
 			name: "Hazards Across Multiple Chains",
@@ -114,7 +114,7 @@ func TestHazardSet_Build(t *testing.T) {
 				// Block 1 in Chain 1 is missing
 				makeBlock(2, 100, 1),
 			},
-			expectErr: types.ErrFuture,
+			expectErr: interop.ErrFuture,
 		},
 		{
 			name: "Invalid Timestamp - Future Message",
@@ -130,14 +130,14 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(0, 100, 1, makeMessage(1, 0, 1, 1)),
 				makeBlock(1, 100, 1),
 			},
-			expectErr: types.ErrFuture,
+			expectErr: interop.ErrFuture,
 		},
 		{
 			name: "Missing Block - Message References Non-existent Block",
 			blocks: []blockDef{
 				makeBlock(0, 100, 1, makeMessage(1, 100, 999, 1)), // Block 999 doesn't exist
 			},
-			expectErr: types.ErrFuture,
+			expectErr: interop.ErrFuture,
 		},
 		{
 			name: "Missing Block - Chain Break",
@@ -145,14 +145,14 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(0, 100, 1, makeMessage(1, 100, 1, 1)),
 				makeBlock(1, 100, 1, makeMessage(2, 100, 1, 1)), // Message references block in chain 2 that doesn't exist
 			},
-			expectErr: types.ErrFuture,
+			expectErr: interop.ErrFuture,
 		},
 		{
 			name: "Invalid Block Number - Zero",
 			blocks: []blockDef{
 				makeBlock(0, 100, 1, makeMessage(1, 100, 0, 1)), // Invalid block number
 			},
-			expectErr: types.ErrFuture,
+			expectErr: interop.ErrFuture,
 		},
 		{
 			name: "Recursive Hazards - Diamond Pattern",
@@ -643,7 +643,7 @@ func (m *mockHazardDeps) Contains(chain eth.ChainID, query messages.ContainsQuer
 
 	// Validate timestamp is greater than 0
 	if query.Timestamp == 0 {
-		return messages.BlockSeal{}, fmt.Errorf("failed to check if message exists: block not found: %w", types.ErrFuture)
+		return messages.BlockSeal{}, fmt.Errorf("failed to check if message exists: block not found: %w", interop.ErrFuture)
 	}
 
 	key := blockKey{
@@ -661,7 +661,7 @@ func (m *mockHazardDeps) Contains(chain eth.ChainID, query messages.ContainsQuer
 			Hash:      block.hash,
 		}, nil
 	}
-	return messages.BlockSeal{}, fmt.Errorf("failed to check if message exists: block not found: %w", types.ErrFuture)
+	return messages.BlockSeal{}, fmt.Errorf("failed to check if message exists: block not found: %w", interop.ErrFuture)
 }
 
 func (m *mockHazardDeps) IsCrossValidBlock(chainID eth.ChainID, block eth.BlockID) error {
@@ -699,7 +699,7 @@ func (m *mockHazardDeps) OpenBlock(chainID eth.ChainID, blockNum uint64) (ref et
 			Time:   block.timestamp,
 		}, uint32(len(block.messages)), msgMap, nil
 	}
-	return eth.BlockRef{}, 0, nil, types.ErrFuture
+	return eth.BlockRef{}, 0, nil, interop.ErrFuture
 }
 
 func (m *mockHazardDeps) Logger() log.Logger {

--- a/op-supervisor/supervisor/backend/cross/hazard_set_test.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 

--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -24,29 +25,29 @@ func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1Source eth.BlockID, h
 	for hazardChainID, hazardBlock := range hazards.Entries() {
 		initSource, err := d.CrossDerivedToSource(hazardChainID, hazardBlock.ID())
 		if err != nil {
-			if errors.Is(err, types.ErrFuture) {
+			if errors.Is(err, interop.ErrFuture) {
 				// If not in cross-safe scope, then check if it's the candidate cross-safe block.
 				candidate, err := d.CandidateCrossSafe(hazardChainID)
 				// ErrOutOfScope should be translated to an ErrFuture, since the dependency being out of scope does not warrant a Scope Bump of this chain.
-				if errors.Is(err, types.ErrOutOfScope) {
-					return fmt.Errorf("hazard dependency %s (chain %s) is out of scope: %w", hazardBlock, hazardChainID, types.ErrFuture)
+				if errors.Is(err, interop.ErrOutOfScope) {
+					return fmt.Errorf("hazard dependency %s (chain %s) is out of scope: %w", hazardBlock, hazardChainID, interop.ErrFuture)
 				} else if err != nil {
 					return fmt.Errorf("failed to determine cross-safe candidate block of hazard dependency %s (chain %s): %w", hazardBlock, hazardChainID, err)
 				}
 				if candidate.Derived.Number == hazardBlock.Number && candidate.Derived.ID() != hazardBlock.ID() {
 					return fmt.Errorf("expected block %s (chain %s) does not match candidate local-safe block %s: %w",
-						hazardBlock, hazardChainID, candidate.Derived, types.ErrConflict)
+						hazardBlock, hazardChainID, candidate.Derived, interop.ErrConflict)
 				}
 				if candidate.Source.Number > inL1Source.Number {
 					return fmt.Errorf("local-safe hazard block %s derived from L1 block %s is after scope %s: %w",
-						hazardBlock.ID(), initSource, inL1Source, types.ErrOutOfScope)
+						hazardBlock.ID(), initSource, inL1Source, interop.ErrOutOfScope)
 				}
 			} else {
 				return fmt.Errorf("failed to determine cross-derived of hazard block %s (chain %s): %w", hazardBlock, hazardChainID, err)
 			}
 		} else if initSource.Number > inL1Source.Number {
 			return fmt.Errorf("cross-safe hazard block %s derived from L1 block %s is after scope %s: %w",
-				hazardBlock.ID(), initSource, inL1Source, types.ErrOutOfScope)
+				hazardBlock.ID(), initSource, inL1Source, interop.ErrOutOfScope)
 		}
 	}
 	return nil

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -47,12 +48,12 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		// (ie the hazard's block number is greater than the source block number),
 		// an error is returned as a ErrOutOfScope
 		err := HazardSafeFrontierChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
-		require.ErrorIs(t, err, types.ErrOutOfScope)
+		require.ErrorIs(t, err, interop.ErrOutOfScope)
 	})
 	t.Run("errFuture: candidate cross safe failure", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
 		sfcd.crossSourceFn = func() (messages.BlockSeal, error) {
-			return messages.BlockSeal{Number: 3}, types.ErrFuture
+			return messages.BlockSeal{Number: 3}, interop.ErrFuture
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
@@ -72,7 +73,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 	t.Run("errFuture: expected block does not match candidate", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
 		sfcd.crossSourceFn = func() (messages.BlockSeal, error) {
-			return messages.BlockSeal{}, types.ErrFuture
+			return messages.BlockSeal{}, interop.ErrFuture
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
@@ -87,12 +88,12 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		// (ie the candidate's block number is the same as the hazard's block number, but the hashes are different),
 		// an error is returned as a ErrConflict
 		err := HazardSafeFrontierChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
-		require.ErrorIs(t, err, types.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 	})
 	t.Run("errFuture: local-safe hazard out of scope", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
 		sfcd.crossSourceFn = func() (messages.BlockSeal, error) {
-			return messages.BlockSeal{}, types.ErrFuture
+			return messages.BlockSeal{}, interop.ErrFuture
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
@@ -107,7 +108,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		// and the initSource is out of scope,
 		// an error is returned as a ErrOutOfScope
 		err := HazardSafeFrontierChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
-		require.ErrorIs(t, err, types.ErrOutOfScope)
+		require.ErrorIs(t, err, interop.ErrOutOfScope)
 	})
 	t.Run("CrossSource Error", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
@@ -131,13 +132,13 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 	t.Run("Hazard Chain Out of Scope is translated to ErrFuture", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
 		sfcd.crossSourceFn = func() (messages.BlockSeal, error) {
-			return messages.BlockSeal{}, types.ErrFuture
+			return messages.BlockSeal{}, interop.ErrFuture
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
 				Source:  eth.BlockRef{Number: 9},
 				Derived: eth.BlockRef{},
-			}, types.ErrOutOfScope
+			}, interop.ErrOutOfScope
 		}
 		l1Source := eth.BlockID{Number: 8}
 		hazards := map[eth.ChainID]messages.BlockSeal{eth.ChainIDFromUInt64(123): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
@@ -145,7 +146,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		// and the initSource is out of scope,
 		// an error is returned as a ErrOutOfScope
 		err := HazardSafeFrontierChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
-		require.ErrorIs(t, err, types.ErrFuture)
+		require.ErrorIs(t, err, interop.ErrFuture)
 	})
 }
 

--- a/op-supervisor/supervisor/backend/cross/safe_start.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start.go
@@ -3,8 +3,8 @@ package cross
 import (
 	"fmt"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"

--- a/op-supervisor/supervisor/backend/cross/safe_start.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -38,7 +38,7 @@ func (d *SafeHazardDeps) IsCrossValidBlock(chainID eth.ChainID, derived eth.Bloc
 	}
 	if initSource.Number > d.inL1Source.Number {
 		return fmt.Errorf("block %s derived from %s which is not in cross-safe scope %s: %w",
-			derived, initSource, d.inL1Source, types.ErrOutOfScope)
+			derived, initSource, d.inL1Source, interop.ErrOutOfScope)
 	}
 	return nil
 }

--- a/op-supervisor/supervisor/backend/cross/safe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
@@ -46,7 +46,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			Timestamp: 42,
 		})
 		hazards, err := CrossSafeHazards(ssd, linker, newTestLogger(t), chainID, inL1Source, candidate)
-		require.ErrorIs(t, err, types.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 		require.Empty(t, hazards)
 		require.True(t, done)
 	})
@@ -206,7 +206,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		// and DerivedToSource returns a BlockSeal with a greater Number than the inL1Source,
 		// an error is returned as a ErrOutOfScope
 		hazards, err := CrossSafeHazards(ssd, linkerAny{}, logger, chainID, inL1Source, candidate)
-		require.ErrorIs(t, err, types.ErrOutOfScope)
+		require.ErrorIs(t, err, interop.ErrOutOfScope)
 		require.Empty(t, hazards)
 	})
 	t.Run("timestamp is less, DerivedToSource Number less", func(t *testing.T) {

--- a/op-supervisor/supervisor/backend/cross/safe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
@@ -50,16 +51,16 @@ func CrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps, li
 		// if we made progress, and no errors, then there is no need to bump the L1 scope yet.
 		return h.Err() // make sure the read-consistency is still translated into an error
 	}
-	if errors.Is(err, types.ErrAwaitReplacementBlock) {
+	if errors.Is(err, interop.ErrAwaitReplacementBlock) {
 		logger.Info("Awaiting replacement block", "err", err)
 		return err
 	}
-	if errors.Is(err, types.ErrConflict) {
+	if errors.Is(err, interop.ErrConflict) {
 		logger.Warn("Found a conflicting local-safe block that cannot be promoted to cross-safe",
 			"scope", candidate.Source, "invalidated", candidate, "err", err)
 		return d.InvalidateLocalSafe(chainID, candidate)
 	}
-	if !errors.Is(err, types.ErrOutOfScope) {
+	if !errors.Is(err, interop.ErrOutOfScope) {
 		return fmt.Errorf("failed to determine cross-safe update scope of chain %s: %w", chainID, err)
 	}
 	// candidate scope is expected to be set if ErrOutOfScope is returned.
@@ -95,7 +96,7 @@ func CrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps, li
 	// don't attempt to proceed with an update, as the reasoning for the update may be wrong.
 	if !h.IsValid() {
 		logger.Warn("Cross-safe reads were inconsistent, aborting scope-bump", "aborted", newScope)
-		return types.ErrInvalidatedRead
+		return interop.ErrInvalidatedRead
 	}
 	logger.Debug("Bumping cross-safe scope", "scope", newScope, "crossSafe", crossSafeRef)
 	if err := d.UpdateCrossSafe(chainID, newScope, crossSafeRef); err != nil {
@@ -106,7 +107,7 @@ func CrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps, li
 
 // scopedCrossSafeUpdate runs through the cross-safe update checks.
 // If no L2 cross-safe progress can be made without additional L1 input data,
-// then a types.ErrOutOfScope error is returned,
+// then a interop.ErrOutOfScope error is returned,
 // with the current scope that will need to be expanded for further progress.
 func scopedCrossSafeUpdate(h reads.Handle, logger log.Logger, chainID eth.ChainID, d CrossSafeDeps, linker depset.LinkChecker) (update types.DerivedBlockRefPair, err error) {
 	candidate, err := d.CandidateCrossSafe(chainID)
@@ -150,7 +151,7 @@ func (c *CrossSafeWorker) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch ev.(type) {
 	case superevents.UpdateCrossSafeRequestEvent:
 		if err := CrossSafeUpdate(c.logger, c.chainID, c.d, c.linker); err != nil {
-			if errors.Is(err, types.ErrFuture) {
+			if errors.Is(err, interop.ErrFuture) {
 				c.logger.Debug("Worker awaits additional blocks", "err", err)
 			} else {
 				c.logger.Warn("Failed to process work", "err", err)

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -75,10 +76,10 @@ func TestCrossSafeUpdate(t *testing.T) {
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*messages.ExecutingMessage, err error) {
-			return eth.BlockRef{}, 0, nil, types.ErrAwaitReplacementBlock
+			return eth.BlockRef{}, 0, nil, interop.ErrAwaitReplacementBlock
 		}
 		err := CrossSafeUpdate(logger, chainID, csd, linkerAny{})
-		require.ErrorIs(t, err, types.ErrAwaitReplacementBlock)
+		require.ErrorIs(t, err, interop.ErrAwaitReplacementBlock)
 	})
 	t.Run("scopedCrossSafeUpdate returns ErrConflict and triggers invalidate-local-safe", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -93,7 +94,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*messages.ExecutingMessage, err error) {
-			return eth.BlockRef{}, 0, nil, types.ErrConflict
+			return eth.BlockRef{}, 0, nil, interop.ErrConflict
 		}
 		invalidated := false
 		csd.invalidateLocalSafeFn = func(id eth.ChainID, p types.DerivedBlockRefPair) error {
@@ -120,7 +121,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*messages.ExecutingMessage, err error) {
-			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
+			return eth.BlockRef{}, 0, nil, interop.ErrOutOfScope
 		}
 		newScope := eth.BlockRef{Number: 3}
 		csd.nextSourceFn = func(chain eth.ChainID, source eth.BlockID) (after eth.BlockRef, err error) {
@@ -167,7 +168,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*messages.ExecutingMessage, err error) {
-			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
+			return eth.BlockRef{}, 0, nil, interop.ErrOutOfScope
 		}
 		csd.nextSourceFn = func(chain eth.ChainID, source eth.BlockID) (after eth.BlockRef, err error) {
 			return eth.BlockRef{}, errors.New("some error")
@@ -191,7 +192,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*messages.ExecutingMessage, err error) {
-			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
+			return eth.BlockRef{}, 0, nil, interop.ErrOutOfScope
 		}
 		csd.previousDerivedFn = func(chain eth.ChainID, derived eth.BlockID) (prevDerived messages.BlockSeal, err error) {
 			return messages.BlockSeal{}, errors.New("some error")
@@ -215,7 +216,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*messages.ExecutingMessage, err error) {
-			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
+			return eth.BlockRef{}, 0, nil, interop.ErrOutOfScope
 		}
 		csd.updateCrossSafeFn = func(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
 			return errors.New("some error")
@@ -273,7 +274,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		// when OpenBlock and CandidateCrossSafe return different blocks,
 		// an ErrConflict is returned
 		pair, err := scopedCrossSafeUpdate(reads.NoopHandle{}, logger, chainID, csd, linkerAny{})
-		require.ErrorIs(t, err, types.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 		require.Equal(t, eth.BlockRef{}, pair.Source)
 	})
 	t.Run("CrossSafeHazards returns error", func(t *testing.T) {
@@ -414,7 +415,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		// when OpenBlock and CandidateCrossSafe return different blocks,
 		// an ErrConflict is returned
 		pair, err := scopedCrossSafeUpdate(reads.NoopHandle{}, logger, chainID, csd, linkerNone{})
-		require.ErrorIs(t, err, types.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 		require.Equal(t, eth.BlockRef{}, pair.Source)
 	})
 	t.Run("successful update", func(t *testing.T) {

--- a/op-supervisor/supervisor/backend/cross/unsafe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_frontier.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 type UnsafeFrontierCheckDeps interface {
@@ -24,7 +24,7 @@ func HazardUnsafeFrontierChecks(d UnsafeFrontierCheckDeps, hazards *HazardSet) e
 		// Anything we depend on in this timestamp must be cross-unsafe already, or the first block after.
 		err := d.IsCrossUnsafe(hazardChainID, hazardBlock.ID())
 		if err != nil {
-			if errors.Is(err, types.ErrFuture) {
+			if errors.Is(err, interop.ErrFuture) {
 				// Not already cross-unsafe, so we check if the block is local-unsafe
 				// (a sanity check if part of the canonical chain).
 				err = d.IsLocalUnsafe(hazardChainID, hazardBlock.ID())

--- a/op-supervisor/supervisor/backend/cross/unsafe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_frontier_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +32,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	t.Run("errFuture: is not local unsafe", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
 		hazards := map[eth.ChainID]messages.BlockSeal{eth.ChainIDFromUInt64(123): {Number: 0}}
-		ufcd.isCrossUnsafe = types.ErrFuture
+		ufcd.isCrossUnsafe = interop.ErrFuture
 		ufcd.isLocalUnsafe = errors.New("some error")
 		// when there is one hazard, and IsCrossUnsafe returns an ErrFuture,
 		// and IsLocalUnsafe returns an error,
@@ -43,7 +43,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	t.Run("errFuture: genesis block", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
 		hazards := map[eth.ChainID]messages.BlockSeal{eth.ChainIDFromUInt64(123): {Number: 0}}
-		ufcd.isCrossUnsafe = types.ErrFuture
+		ufcd.isCrossUnsafe = interop.ErrFuture
 		// when there is one hazard, and IsCrossUnsafe returns an ErrFuture,
 		// BUT the hazard's block number is 0,
 		// no error is returned
@@ -53,7 +53,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	t.Run("errFuture: error getting parent block", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
 		hazards := map[eth.ChainID]messages.BlockSeal{eth.ChainIDFromUInt64(123): {Number: 3}}
-		ufcd.isCrossUnsafe = types.ErrFuture
+		ufcd.isCrossUnsafe = interop.ErrFuture
 		ufcd.findBlockIDFn = func() (parent eth.BlockID, err error) {
 			return eth.BlockID{}, errors.New("some error")
 		}
@@ -66,7 +66,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	t.Run("errFuture: parent block is not cross unsafe", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
 		hazards := map[eth.ChainID]messages.BlockSeal{eth.ChainIDFromUInt64(123): {Number: 3}}
-		ufcd.isCrossUnsafe = types.ErrFuture
+		ufcd.isCrossUnsafe = interop.ErrFuture
 		ufcd.findBlockIDFn = func() (parent eth.BlockID, err error) {
 			// when getting the parent block, prep isCrossSafe to be err
 			ufcd.isCrossUnsafe = errors.New("not cross unsafe!")

--- a/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
@@ -33,7 +33,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		// when there is one execMsg, and CanExecuteAt returns false,
 		// no work is done and an error is returned
 		hazards, err := CrossUnsafeHazards(usd, linkerNone{}, newTestLogger(t), chainID, candidate)
-		require.ErrorIs(t, err, types.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 		require.Empty(t, hazards.Entries())
 	})
 	t.Run("executing msg does bad link", func(t *testing.T) {
@@ -57,7 +57,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		// when there is one execMsg, and CanInitiateAt returns false,
 		// the error is returned as a ErrConflict
 		hazards, err := CrossUnsafeHazards(usd, linker, newTestLogger(t), chainID, candidate)
-		require.ErrorIs(t, err, types.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 		require.Empty(t, hazards.Entries())
 		require.True(t, done)
 	})

--- a/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"

--- a/op-supervisor/supervisor/backend/cross/unsafe_update.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update.go
@@ -8,11 +8,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
@@ -38,7 +38,7 @@ func CrossUnsafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossUnsafeDeps
 
 	// fetch cross-head to determine next cross-unsafe candidate
 	if crossUnsafe, err := d.CrossUnsafe(chainID); err != nil {
-		if errors.Is(err, types.ErrFuture) {
+		if errors.Is(err, interop.ErrFuture) {
 			// If genesis / no cross-safe block yet, then defer update
 			logger.Debug("No cross-unsafe starting point yet")
 			return nil
@@ -53,7 +53,7 @@ func CrossUnsafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossUnsafeDeps
 			return fmt.Errorf("failed to open block %d: %w", crossUnsafe.Number+1, err)
 		}
 		if bl.ParentHash != crossUnsafe.Hash {
-			return fmt.Errorf("cannot use block %s, it does not build on cross-unsafe block %s: %w", bl, crossUnsafe, types.ErrConflict)
+			return fmt.Errorf("cannot use block %s, it does not build on cross-unsafe block %s: %w", bl, crossUnsafe, interop.ErrConflict)
 		}
 		candidate = messages.BlockSealFromRef(bl)
 	}
@@ -73,7 +73,7 @@ func CrossUnsafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossUnsafeDeps
 
 	if !h.IsValid() {
 		logger.Warn("Reads were inconsistent, aborting cross-unsafe update", "aborted", candidate)
-		return types.ErrInvalidatedRead
+		return interop.ErrInvalidatedRead
 	}
 
 	// promote the candidate block to cross-unsafe
@@ -94,7 +94,7 @@ func (c *CrossUnsafeWorker) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch ev.(type) {
 	case superevents.UpdateCrossUnsafeRequestEvent:
 		if err := CrossUnsafeUpdate(c.logger, c.chainID, c.d, c.linker); err != nil {
-			if errors.Is(err, types.ErrFuture) {
+			if errors.Is(err, interop.ErrFuture) {
 				c.logger.Debug("Worker awaits additional blocks", "err", err)
 			} else {
 				c.logger.Warn("Failed to process work", "err", err)

--- a/op-supervisor/supervisor/backend/cross/unsafe_update.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"

--- a/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -32,7 +32,7 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 		chainID := eth.ChainIDFromUInt64(123)
 		usd := &mockCrossUnsafeDeps{}
 		usd.crossUnsafeFn = func(chainID eth.ChainID) (messages.BlockSeal, error) {
-			return messages.BlockSeal{}, types.ErrFuture
+			return messages.BlockSeal{}, interop.ErrFuture
 		}
 		// when a ErrFuture is returned by CrossUnsafe,
 		// no error is returned
@@ -66,7 +66,7 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 		// when the parent hash of the opened block does not match the cross-unsafe block,
 		// an ErrConflict is returned
 		err := CrossUnsafeUpdate(logger, chainID, usd, linkerAny{})
-		require.ErrorIs(t, err, types.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 	})
 	t.Run("CrossUnsafeHazards returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)

--- a/op-supervisor/supervisor/backend/db/anchor.go
+++ b/op-supervisor/supervisor/backend/db/anchor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -52,10 +53,10 @@ func (db *ChainsDB) maybeInitSafeDB(id eth.ChainID, anchor types.DerivedBlockRef
 	logger := db.logger.New("chain", id, "derived", anchor.Derived, "source", anchor.Source)
 	localDB, ok := db.localDBs.Get(id)
 	if !ok {
-		return types.ErrUnknownChain
+		return interop.ErrUnknownChain
 	}
 	first, err := localDB.First()
-	if errors.Is(err, types.ErrFuture) {
+	if errors.Is(err, interop.ErrFuture) {
 		logger.Info("local database is empty, initializing")
 		if err := db.initializedUpdateCrossSafe(id, anchor.Source, anchor.Derived); err != nil {
 			return err
@@ -71,7 +72,7 @@ func (db *ChainsDB) maybeInitSafeDB(id eth.ChainID, anchor types.DerivedBlockRef
 			return fmt.Errorf("local database (%s) does not match anchor point (%s): %w",
 				first,
 				anchor,
-				types.ErrConflict)
+				interop.ErrConflict)
 		}
 	}
 	return nil
@@ -80,7 +81,7 @@ func (db *ChainsDB) maybeInitSafeDB(id eth.ChainID, anchor types.DerivedBlockRef
 func (db *ChainsDB) maybeInitFromUnsafe(id eth.ChainID, anchor eth.BlockRef) error {
 	logger := db.logger.New("chain", id, "anchor", anchor)
 	seal, err := db.FindSealedBlock(id, anchor.Number)
-	if errors.Is(err, types.ErrFuture) {
+	if errors.Is(err, interop.ErrFuture) {
 		logger.Debug("initializing events database")
 		err := db.sealBlock(id, anchor, true)
 		if err != nil {
@@ -99,7 +100,7 @@ func (db *ChainsDB) maybeInitFromUnsafe(id eth.ChainID, anchor eth.BlockRef) err
 			return fmt.Errorf("events database (%s) does not match anchor point (%s): %w",
 				seal,
 				anchor,
-				types.ErrConflict)
+				interop.ErrConflict)
 		}
 	}
 	return nil

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-service/locks"
@@ -275,7 +276,7 @@ func (db *ChainsDB) ResumeFromLastSealedBlock() error {
 		}
 		db.logger.Info("Resuming, starting from last sealed block", "chain", chain, "head", head)
 		if err := logStore.Rewind(db.readRegistry, head); err != nil {
-			result = fmt.Errorf("%w: failed to rewind chain %s to sealed block %d", types.ErrRewindFailed, chain, head)
+			result = fmt.Errorf("%w: failed to rewind chain %s to sealed block %d", interop.ErrRewindFailed, chain, head)
 			return false
 		}
 		return true

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-service/locks"

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -75,7 +76,7 @@ func (db *DB) First() (pair types.DerivedBlockSealPair, err error) {
 	defer db.rwLock.RUnlock()
 	lastIndex := db.store.LastEntryIdx()
 	if lastIndex < 0 {
-		return types.DerivedBlockSealPair{}, types.ErrFuture
+		return types.DerivedBlockSealPair{}, interop.ErrFuture
 	}
 	last, err := db.readAt(0)
 	if err != nil {
@@ -103,7 +104,7 @@ func (db *DB) PreviousDerived(derived eth.BlockID, revision types.Revision) (pre
 	// The first entry might not match, since it may have been invalidated with a later L1 scope.
 	// But the last entry should always match.
 	if lastCanonical.derived.ID() != derived {
-		return messages.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.derived, derived, types.ErrConflict)
+		return messages.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.derived, derived, interop.ErrConflict)
 	}
 	if selfIndex == 0 { // genesis block has a zeroed block as parent block
 		return messages.BlockSeal{}, nil
@@ -118,7 +119,7 @@ func (db *DB) PreviousDerived(derived eth.BlockID, revision types.Revision) (pre
 // Last returns the last known values:
 // source: the L1 block that the L2 block is safe for (not necessarily the first, multiple L2 blocks may be derived from the same L1 block).
 // derived: the L2 block that was derived (not necessarily the first, the L1 block may have been empty and repeated the last safe L2 block).
-// If the last entry is invalidated, this returns a types.ErrAwaitReplacementBlock error.
+// If the last entry is invalidated, this returns a interop.ErrAwaitReplacementBlock error.
 func (db *DB) Last() (pair types.DerivedBlockSealPair, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
@@ -143,7 +144,7 @@ func (db *DB) LastRevision() (revision types.Revision, err error) {
 func (db *DB) latest() (link LinkEntry, err error) {
 	lastIndex := db.store.LastEntryIdx()
 	if lastIndex < 0 {
-		return LinkEntry{}, types.ErrFuture
+		return LinkEntry{}, interop.ErrFuture
 	}
 	last, err := db.readAt(lastIndex)
 	if err != nil {
@@ -160,7 +161,7 @@ func (db *DB) Invalidated() (pair types.DerivedBlockSealPair, err error) {
 		return types.DerivedBlockSealPair{}, err
 	}
 	if !link.invalidated {
-		return types.DerivedBlockSealPair{}, fmt.Errorf("last entry %s is not invalidated: %w", link, types.ErrConflict)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("last entry %s is not invalidated: %w", link, interop.ErrConflict)
 	}
 	return types.DerivedBlockSealPair{
 		Source:  link.source,
@@ -169,7 +170,7 @@ func (db *DB) Invalidated() (pair types.DerivedBlockSealPair, err error) {
 }
 
 // SourceToLastDerived returns the last L2 block derived from the given L1 block.
-// This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
+// This may return interop.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
 func (db *DB) SourceToLastDerived(source eth.BlockID) (derived messages.BlockSeal, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
@@ -179,16 +180,16 @@ func (db *DB) SourceToLastDerived(source eth.BlockID) (derived messages.BlockSea
 	}
 	if link.source.ID() != source {
 		return messages.BlockSeal{}, fmt.Errorf("searched for last derived-from %s but found %s: %w",
-			source, link.source, types.ErrConflict)
+			source, link.source, interop.ErrConflict)
 	}
 	if link.invalidated {
-		return messages.BlockSeal{}, types.ErrAwaitReplacementBlock
+		return messages.BlockSeal{}, interop.ErrAwaitReplacementBlock
 	}
 	return link.derived, nil
 }
 
 // NextDerived finds the next L2 block after derived, and what it was derived from.
-// This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
+// This may return interop.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
 // This will prioritize the last time the input L2 block number was seen, and consistency-checks it against the hash.
 // Older occurrences of the same number with different hash cannot be iterated from, and are non-canonical.
 func (db *DB) NextDerived(derived eth.BlockID, revision types.Revision) (pair types.DerivedBlockSealPair, err error) {
@@ -200,7 +201,7 @@ func (db *DB) NextDerived(derived eth.BlockID, revision types.Revision) (pair ty
 		return types.DerivedBlockSealPair{}, fmt.Errorf("failed to find derived %d: %w", derived.Number, err)
 	}
 	if self.derived.ID() != derived {
-		return types.DerivedBlockSealPair{}, fmt.Errorf("found %s, but expected %s: %w", self.derived, derived, types.ErrConflict)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("found %s, but expected %s: %w", self.derived, derived, interop.ErrConflict)
 	}
 	next, err := db.readAt(selfIndex + 1)
 	if err != nil {
@@ -211,7 +212,7 @@ func (db *DB) NextDerived(derived eth.BlockID, revision types.Revision) (pair ty
 
 // Candidate returns the candidate block for cross-safe promotion after the given
 // (maxSource, afterDerived) pair (the cross-safe block).
-// It may return types.ErrOutOfScope with a pair value, to request the source to increase.
+// It may return interop.ErrOutOfScope with a pair value, to request the source to increase.
 func (db *DB) Candidate(maxSource eth.BlockID, afterDerived eth.BlockID, revision types.Revision) (pair types.DerivedBlockRefPair, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
@@ -220,14 +221,14 @@ func (db *DB) Candidate(maxSource eth.BlockID, afterDerived eth.BlockID, revisio
 		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to get last derived block from %s: %w", maxSource, err)
 	}
 	if lastOffered.source.ID() != maxSource {
-		return types.DerivedBlockRefPair{}, fmt.Errorf("expected source %s, but got %s: %w", maxSource, afterDerived, types.ErrConflict)
+		return types.DerivedBlockRefPair{}, fmt.Errorf("expected source %s, but got %s: %w", maxSource, afterDerived, interop.ErrConflict)
 	}
 	maxSourceSeal := lastOffered.source
 
 	// attach the parent (or zero-block) to the cross-safe source
 	var sourceRef eth.BlockRef
 	parentSource, err := db.PreviousSource(maxSource)
-	if errors.Is(err, types.ErrPreviousToFirst) {
+	if errors.Is(err, interop.ErrPreviousToFirst) {
 		// if we are working with the first item in the database, PreviousSource will return ErrPreviousToFirst
 		// in which case we can attach a zero parent to the block, as the parent block is unknown
 		// ForceWithParent will not panic if the parent is not as expected (like a zero-block)
@@ -244,10 +245,10 @@ func (db *DB) Candidate(maxSource eth.BlockID, afterDerived eth.BlockID, revisio
 		// keep source, just find the next canonical entry.
 		// That entry can be attached to an older source however.
 		_, link, err := db.derivedNumToLastSource(afterDerived.Number+1, revision)
-		if errors.Is(err, types.ErrNotExact) {
+		if errors.Is(err, interop.ErrNotExact) {
 			_, link, err = db.derivedNumToLastSource(afterDerived.Number+1, types.Revision(afterDerived.Number+1))
 			if err != nil {
-				return types.DerivedBlockRefPair{}, fmt.Errorf("cannot find derived block %d: %w", afterDerived.Number+1, types.ErrDataCorruption)
+				return types.DerivedBlockRefPair{}, fmt.Errorf("cannot find derived block %d: %w", afterDerived.Number+1, interop.ErrDataCorruption)
 			}
 		}
 		derivedRef, err := link.derived.WithParent(afterDerived)
@@ -263,7 +264,7 @@ func (db *DB) Candidate(maxSource eth.BlockID, afterDerived eth.BlockID, revisio
 		return types.DerivedBlockRefPair{
 			Source:  sourceRef,
 			Derived: eth.BlockRef{},
-		}, types.ErrOutOfScope
+		}, interop.ErrOutOfScope
 	}
 }
 
@@ -278,7 +279,7 @@ func (db *DB) DerivedToRevision(derived eth.BlockID) (types.Revision, error) {
 		return types.Revision(0), fmt.Errorf("failed to get link entry: %w", err)
 	}
 	if id := link.derived.ID(); id != derived {
-		return types.Revision(0), fmt.Errorf("cannot determine revision, db entry %s does not match query %s: %w", id, derived, types.ErrConflict)
+		return types.Revision(0), fmt.Errorf("cannot determine revision, db entry %s does not match query %s: %w", id, derived, interop.ErrConflict)
 	}
 	return link.revision, nil
 }
@@ -299,7 +300,7 @@ func (db *DB) SourceToRevision(source eth.BlockID) (types.Revision, error) {
 		return types.Revision(0), err
 	}
 	if link.source.ID() != source {
-		return types.Revision(0), fmt.Errorf("expected %s, got %s: %w", source, link.source, types.ErrConflict)
+		return types.Revision(0), fmt.Errorf("expected %s, got %s: %w", source, link.source, interop.ErrConflict)
 	}
 	return link.revision, nil
 }
@@ -320,10 +321,10 @@ func (db *DB) ContainsDerived(derived eth.BlockID, revision types.Revision) erro
 	}
 	if link.derived.ID() != derived {
 		return fmt.Errorf("searched if derived %s but found %s: %w",
-			derived, link.derived, types.ErrConflict)
+			derived, link.derived, interop.ErrConflict)
 	}
 	if link.invalidated {
-		return fmt.Errorf("derived %s, but invalidated it: %w", derived, types.ErrAwaitReplacementBlock)
+		return fmt.Errorf("derived %s, but invalidated it: %w", derived, interop.ErrAwaitReplacementBlock)
 	}
 	return nil
 }
@@ -341,7 +342,7 @@ func (db *DB) DerivedToFirstSource(derived eth.BlockID, revision types.Revision)
 	}
 	if link.derived.ID() != derived {
 		return messages.BlockSeal{}, fmt.Errorf("searched for first derived %s but found %s: %w",
-			derived, link.derived, types.ErrConflict)
+			derived, link.derived, interop.ErrConflict)
 	}
 	return link.source, nil
 }
@@ -359,7 +360,7 @@ func (db *DB) previousSource(source eth.BlockID) (messages.BlockSeal, error) {
 		return messages.BlockSeal{}, fmt.Errorf("failed to find derived %d: %w", source.Number, err)
 	}
 	if self.source.ID() != source {
-		return messages.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.source, source, types.ErrConflict)
+		return messages.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.source, source, interop.ErrConflict)
 	}
 	if selfIndex == 0 {
 		// genesis block has a zeroed block as parent block
@@ -367,7 +368,7 @@ func (db *DB) previousSource(source eth.BlockID) (messages.BlockSeal, error) {
 			return messages.BlockSeal{}, nil
 		} else {
 			return messages.BlockSeal{},
-				fmt.Errorf("cannot find previous derived before start of database: %s (%w)", source, types.ErrPreviousToFirst)
+				fmt.Errorf("cannot find previous derived before start of database: %s (%w)", source, interop.ErrPreviousToFirst)
 		}
 	}
 	prev, err := db.readAt(selfIndex - 1)
@@ -387,7 +388,7 @@ func (db *DB) NextSource(source eth.BlockID) (messages.BlockSeal, error) {
 		return messages.BlockSeal{}, fmt.Errorf("failed to find derived-from %d: %w", source.Number, err)
 	}
 	if self.source.ID() != source {
-		return messages.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.source, source, types.ErrConflict)
+		return messages.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.source, source, interop.ErrConflict)
 	}
 	next, err := db.readAt(selfIndex + 1)
 	if err != nil {
@@ -397,7 +398,7 @@ func (db *DB) NextSource(source eth.BlockID) (messages.BlockSeal, error) {
 }
 
 // Next returns the next Derived Block Pair after the given pair.
-// This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
+// This may return interop.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
 func (db *DB) Next(pair types.DerivedIDPair) (types.DerivedBlockSealPair, error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
@@ -406,10 +407,10 @@ func (db *DB) Next(pair types.DerivedIDPair) (types.DerivedBlockSealPair, error)
 		return types.DerivedBlockSealPair{}, err
 	}
 	if selfLink.source.ID() != pair.Source {
-		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived-from %s but expected %s: %w", selfLink.source, pair.Source, types.ErrConflict)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived-from %s but expected %s: %w", selfLink.source, pair.Source, interop.ErrConflict)
 	}
 	if selfLink.derived.ID() != pair.Derived {
-		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived %s but expected %s: %w", selfLink.derived, pair.Derived, types.ErrConflict)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived %s but expected %s: %w", selfLink.derived, pair.Derived, interop.ErrConflict)
 	}
 	next, err := db.readAt(selfIndex + 1)
 	if err != nil {
@@ -501,7 +502,7 @@ func (db *DB) lookupOrAfter(source, derived uint64) (entrydb.EntryIdx, LinkEntry
 func (db *DB) find(reverse bool, acceptClosest bool, cmpFn func(link LinkEntry) int) (entrydb.EntryIdx, LinkEntry, error) {
 	n := db.store.Size()
 	if n == 0 {
-		return -1, LinkEntry{}, types.ErrFuture
+		return -1, LinkEntry{}, interop.ErrFuture
 	}
 
 	// binary-search for the smallest index i for which cmp(i) >= 0
@@ -525,11 +526,11 @@ func (db *DB) find(reverse bool, acceptClosest bool, cmpFn func(link LinkEntry) 
 		if reverse {
 			// If searching in reverse, then the last entry is the start.
 			// I.e. the needle must be before the db start.
-			return -1, LinkEntry{}, fmt.Errorf("no entry found: %w", types.ErrSkipped)
+			return -1, LinkEntry{}, fmt.Errorf("no entry found: %w", interop.ErrSkipped)
 		} else {
 			// If searing regularly, then the last entry is the end.
 			// I.e. the needle must be after the db end.
-			return -1, LinkEntry{}, fmt.Errorf("no entry found: %w", types.ErrFuture)
+			return -1, LinkEntry{}, fmt.Errorf("no entry found: %w", interop.ErrFuture)
 		}
 	}
 	// If the very first entry matched, then we might be missing prior data.
@@ -547,12 +548,12 @@ func (db *DB) find(reverse bool, acceptClosest bool, cmpFn func(link LinkEntry) 
 	if cmpFn(link) != 0 {
 		if firstTry { // if the first found entry already is bigger, then we are missing the real data.
 			if reverse {
-				return -1, LinkEntry{}, fmt.Errorf("query is past last entry %s: %w", link, types.ErrFuture)
+				return -1, LinkEntry{}, fmt.Errorf("query is past last entry %s: %w", link, interop.ErrFuture)
 			} else {
-				return -1, LinkEntry{}, fmt.Errorf("query is before first entry %s: %w", link, types.ErrSkipped)
+				return -1, LinkEntry{}, fmt.Errorf("query is before first entry %s: %w", link, interop.ErrSkipped)
 			}
 		} else if !acceptClosest {
-			return -1, LinkEntry{}, fmt.Errorf("traversed data, no exact match found, but hit %s: %w", link, types.ErrNotExact)
+			return -1, LinkEntry{}, fmt.Errorf("traversed data, no exact match found, but hit %s: %w", link, interop.ErrNotExact)
 		}
 	}
 	return entrydb.EntryIdx(result), link, nil
@@ -562,7 +563,7 @@ func (db *DB) readAt(i entrydb.EntryIdx) (LinkEntry, error) {
 	entry, err := db.store.Read(i)
 	if err != nil {
 		if err == io.EOF {
-			return LinkEntry{}, types.ErrFuture
+			return LinkEntry{}, interop.ErrFuture
 		}
 		return LinkEntry{}, err
 	}

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -76,33 +77,33 @@ func TestEmptyDB(t *testing.T) {
 		func(t *testing.T, db *DB, m *stubMetrics) {},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			_, err := db.Last()
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			_, err = db.First()
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			_, err = db.SourceToLastDerived(eth.BlockID{})
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			_, err = db.DerivedToFirstSource(eth.BlockID{}, types.RevisionAny)
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			_, err = db.PreviousDerived(eth.BlockID{}, types.RevisionAny)
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			_, err = db.NextDerived(eth.BlockID{}, types.RevisionAny)
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			_, err = db.PreviousSource(eth.BlockID{})
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			_, err = db.NextSource(eth.BlockID{})
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			_, err = db.Next(types.DerivedIDPair{
 				Source:  eth.BlockID{},
 				Derived: eth.BlockID{}})
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 		})
 }
 
@@ -179,7 +180,7 @@ func TestSingleEntryDB(t *testing.T) {
 			_, err = db.Next(types.DerivedIDPair{
 				Source:  pair.Source.ID(),
 				Derived: pair.Derived.ID()})
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			// Last Derived
 			derived, err := db.SourceToLastDerived(expectedSource.ID())
@@ -188,17 +189,17 @@ func TestSingleEntryDB(t *testing.T) {
 
 			// Last Derived with a non-existent Source
 			_, err = db.SourceToLastDerived(eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedSource.Number})
-			require.ErrorIs(t, err, types.ErrConflict)
+			require.ErrorIs(t, err, interop.ErrConflict)
 
 			// Next with a non-existent block (derived and source)
 			_, err = db.Next(types.DerivedIDPair{
 				Source:  eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedSource.Number},
 				Derived: expectedDerived.ID()})
-			require.ErrorIs(t, err, types.ErrConflict)
+			require.ErrorIs(t, err, interop.ErrConflict)
 			_, err = db.Next(types.DerivedIDPair{
 				Source:  expectedSource.ID(),
 				Derived: eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedDerived.Number}})
-			require.ErrorIs(t, err, types.ErrConflict)
+			require.ErrorIs(t, err, interop.ErrConflict)
 
 			// First Source
 			source, err := db.DerivedToFirstSource(expectedDerived.ID(), types.RevisionAny)
@@ -207,7 +208,7 @@ func TestSingleEntryDB(t *testing.T) {
 
 			// Source with a non-existent Derived
 			_, err = db.DerivedToFirstSource(eth.BlockID{Hash: common.Hash{0xbb}, Number: expectedDerived.Number}, types.RevisionAny)
-			require.ErrorIs(t, err, types.ErrConflict)
+			require.ErrorIs(t, err, interop.ErrConflict)
 
 			// PreviousDerived
 			prev, err := db.PreviousDerived(expectedDerived.ID(), types.RevisionAny)
@@ -221,17 +222,17 @@ func TestSingleEntryDB(t *testing.T) {
 
 			// NextDerived
 			_, err = db.NextDerived(expectedDerived.ID(), types.RevisionAny)
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			// NextSource
 			_, err = db.NextSource(expectedSource.ID())
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			// Next
 			_, err = db.Next(types.DerivedIDPair{
 				Source:  expectedSource.ID(),
 				Derived: expectedDerived.ID()})
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 		})
 }
 
@@ -246,10 +247,10 @@ func TestGap(t *testing.T) {
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			_, err := db.NextDerived(mockL2(0).ID(), types.RevisionAny)
-			require.ErrorIs(t, err, types.ErrSkipped)
+			require.ErrorIs(t, err, interop.ErrSkipped)
 
 			_, err = db.NextSource(mockL1(0).ID())
-			require.ErrorIs(t, err, types.ErrSkipped)
+			require.ErrorIs(t, err, interop.ErrSkipped)
 		})
 }
 
@@ -285,14 +286,14 @@ func TestThreeBlocksDB(t *testing.T) {
 		require.Equal(t, l2Block2, derived)
 
 		_, err = db.SourceToLastDerived(eth.BlockID{Hash: common.Hash{0xaa}, Number: l1Block2.Number})
-		require.ErrorIs(t, err, types.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 
 		source, err := db.DerivedToFirstSource(l2Block2.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block2, source)
 
 		_, err = db.DerivedToFirstSource(eth.BlockID{Hash: common.Hash{0xbb}, Number: l2Block2.Number}, types.RevisionAny)
-		require.ErrorIs(t, err, types.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 
 		derived, err = db.SourceToLastDerived(l1Block1.ID())
 		require.NoError(t, err)
@@ -333,7 +334,7 @@ func TestThreeBlocksDB(t *testing.T) {
 		require.Equal(t, l1Block2, next.Source)
 
 		_, err = db.NextDerived(l2Block2.ID(), types.RevisionAny)
-		require.ErrorIs(t, err, types.ErrFuture)
+		require.ErrorIs(t, err, interop.ErrFuture)
 
 		source, err = db.PreviousSource(l1Block0.ID())
 		require.NoError(t, err)
@@ -356,12 +357,12 @@ func TestThreeBlocksDB(t *testing.T) {
 		require.Equal(t, l1Block2, source)
 
 		_, err = db.NextSource(l1Block2.ID())
-		require.ErrorIs(t, err, types.ErrFuture)
+		require.ErrorIs(t, err, interop.ErrFuture)
 
 		_, err = db.Next(types.DerivedIDPair{
 			Source:  l1Block2.ID(),
 			Derived: l2Block2.ID()})
-		require.ErrorIs(t, err, types.ErrFuture)
+		require.ErrorIs(t, err, interop.ErrFuture)
 
 		next, err = db.Next(types.DerivedIDPair{
 			Source:  l1Block0.ID(),
@@ -485,7 +486,7 @@ func TestFastL2Batcher(t *testing.T) {
 		require.Equal(t, l1Block2, next.Source) // derived from later L1 block
 		require.Equal(t, l2Block5, next.Derived)
 		_, err = db.NextDerived(l2Block5.ID(), types.RevisionAny)
-		require.ErrorIs(t, err, types.ErrFuture)
+		require.ErrorIs(t, err, interop.ErrFuture)
 
 		source, err = db.PreviousSource(l1Block2.ID())
 		require.NoError(t, err)
@@ -501,7 +502,7 @@ func TestFastL2Batcher(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, l1Block2, source)
 		_, err = db.NextSource(l1Block2.ID())
-		require.ErrorIs(t, err, types.ErrFuture)
+		require.ErrorIs(t, err, interop.ErrFuture)
 
 		next, err = db.Next(types.DerivedIDPair{
 			Source:  l1Block1.ID(),
@@ -580,7 +581,7 @@ func TestSlowL2Batcher(t *testing.T) {
 		require.Equal(t, l1Block5, next.Source)
 		require.Equal(t, l2Block2, next.Derived)
 		_, err = db.NextDerived(l2Block2.ID(), types.RevisionAny)
-		require.ErrorIs(t, err, types.ErrFuture)
+		require.ErrorIs(t, err, interop.ErrFuture)
 
 		source, err = db.PreviousSource(l1Block5.ID())
 		require.NoError(t, err)
@@ -611,7 +612,7 @@ func TestSlowL2Batcher(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, l1Block5, source)
 		_, err = db.NextSource(l1Block5.ID())
-		require.ErrorIs(t, err, types.ErrFuture)
+		require.ErrorIs(t, err, interop.ErrFuture)
 
 		next, err = db.Next(types.DerivedIDPair{
 			Source:  l1Block2.ID(),
@@ -695,17 +696,17 @@ func testManyEntryDB(t *testing.T, offsetL1 uint64, offsetL2 uint64) {
 		// if not started at genesis, try to read older data, assert it's unavailable.
 		if offsetL1 > 0 {
 			_, err := db.SourceToLastDerived(mockL1(0).ID())
-			require.ErrorIs(t, err, types.ErrSkipped)
+			require.ErrorIs(t, err, interop.ErrSkipped)
 
 			_, err = db.SourceToLastDerived(mockL1(offsetL1 - 1).ID())
-			require.ErrorIs(t, err, types.ErrSkipped)
+			require.ErrorIs(t, err, interop.ErrSkipped)
 		}
 		if offsetL2 > 0 {
 			_, err := db.DerivedToFirstSource(mockL2(0).ID(), types.RevisionAny)
-			require.ErrorIs(t, err, types.ErrSkipped)
+			require.ErrorIs(t, err, interop.ErrSkipped)
 
 			_, err = db.DerivedToFirstSource(mockL2(offsetL2-1).ID(), types.RevisionAny)
-			require.ErrorIs(t, err, types.ErrSkipped)
+			require.ErrorIs(t, err, interop.ErrSkipped)
 		}
 	})
 }
@@ -745,7 +746,7 @@ func TestRewindToSourceEmptied(t *testing.T) {
 		require.Equal(t, uint64(0), inv.InvalidatedSourceNum)
 		require.Equal(t, uint64(0), inv.InvalidatedDerivedTimestamp)
 		pair, err = db.Last()
-		require.ErrorIs(t, err, types.ErrFuture)
+		require.ErrorIs(t, err, interop.ErrFuture)
 		require.True(t, db.IsEmpty())
 
 		// Test that we can add a new starting point
@@ -796,7 +797,7 @@ func TestRewindToSource(t *testing.T) {
 
 		inv := &reads.TestInvalidator{}
 		// Rewind to the future
-		require.ErrorIs(t, db.RewindToSource(inv, l1Block6.ID()), types.ErrFuture)
+		require.ErrorIs(t, db.RewindToSource(inv, l1Block6.ID()), interop.ErrFuture)
 		require.False(t, inv.Invalidated)
 
 		inv = &reads.TestInvalidator{}
@@ -880,7 +881,7 @@ func TestRewindToFirstDerived(t *testing.T) {
 
 		inv := &reads.TestInvalidator{}
 		// Rewind to the future
-		require.ErrorIs(t, db.RewindToFirstDerived(inv, l2Block3.ID(), types.RevisionAny), types.ErrFuture)
+		require.ErrorIs(t, db.RewindToFirstDerived(inv, l2Block3.ID(), types.RevisionAny), interop.ErrFuture)
 
 		// Rewind to the exact block we're at
 		require.NoError(t, db.RewindToFirstDerived(inv, l2Block2.ID(), types.RevisionAny))
@@ -941,7 +942,7 @@ func TestInvalidateAndReplace(t *testing.T) {
 		require.Equal(t, l1Block1.ID(), pair.Source.ID())
 
 		_, err = db.Invalidated()
-		require.ErrorIs(t, err, types.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 
 		replacement := l2Ref2
 		replacement.Hash = common.Hash{0xff, 0xff, 0xff}
@@ -949,7 +950,7 @@ func TestInvalidateAndReplace(t *testing.T) {
 
 		inv := &reads.TestInvalidator{}
 		_, err = db.ReplaceInvalidatedBlock(inv, replacement, l2Ref2.Hash)
-		require.ErrorIs(t, err, types.ErrConflict, "cannot replace what has not been invalidated")
+		require.ErrorIs(t, err, interop.ErrConflict, "cannot replace what has not been invalidated")
 
 		invalidated := types.DerivedBlockRefPair{
 			Source:  l1Ref1,
@@ -957,7 +958,7 @@ func TestInvalidateAndReplace(t *testing.T) {
 		}
 		require.NoError(t, db.RewindAndInvalidate(inv, invalidated))
 		_, err = db.Last()
-		require.ErrorIs(t, err, types.ErrAwaitReplacementBlock)
+		require.ErrorIs(t, err, interop.ErrAwaitReplacementBlock)
 
 		pair, err = db.Invalidated()
 		require.NoError(t, err)
@@ -965,7 +966,7 @@ func TestInvalidateAndReplace(t *testing.T) {
 		require.Equal(t, invalidated.Derived.ID(), pair.Derived.ID())
 
 		_, err = db.ReplaceInvalidatedBlock(inv, replacement, common.Hash{0xba, 0xd})
-		require.ErrorIs(t, err, types.ErrConflict, "must point at the right invalidated block")
+		require.ErrorIs(t, err, interop.ErrConflict, "must point at the right invalidated block")
 
 		result, err := db.ReplaceInvalidatedBlock(inv, replacement, invalidated.Derived.Hash)
 		require.NoError(t, err)
@@ -1020,7 +1021,7 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		require.Equal(t, l1Block2.ID(), pair.Source.ID())
 
 		_, err = db.Invalidated()
-		require.ErrorIs(t, err, types.ErrConflict)
+		require.ErrorIs(t, err, interop.ErrConflict)
 
 		inv := &reads.TestInvalidator{}
 		invalidated := types.DerivedBlockRefPair{
@@ -1029,7 +1030,7 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		}
 		require.NoError(t, db.RewindAndInvalidate(inv, invalidated))
 		_, err = db.Last()
-		require.ErrorIs(t, err, types.ErrAwaitReplacementBlock)
+		require.ErrorIs(t, err, interop.ErrAwaitReplacementBlock)
 
 		pair, err = db.Invalidated()
 		require.NoError(t, err)
@@ -1078,7 +1079,7 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		// Check if canonical chain is represented accurately
 		require.NoError(t, db.ContainsDerived(l2Ref2.ID(), types.RevisionAny), "common block 2 is valid part of canonical chain")
 		require.NoError(t, db.ContainsDerived(replacement.ID(), types.RevisionAny), "replacement is valid part of canonical chain")
-		require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), types.RevisionAny), types.ErrConflict, "invalidated block is not valid in canonical chain")
+		require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), types.RevisionAny), interop.ErrConflict, "invalidated block is not valid in canonical chain")
 	})
 }
 
@@ -1088,7 +1089,7 @@ func TestNoInvalidatedFirst(t *testing.T) {
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			l1Block20 := toRef(mockL1(20), mockL1(19).Hash)
 			l2Block100 := toRef(mockL1(100), mockL2(99).Hash)
-			require.ErrorIs(t, db.addLink(l1Block20, l2Block100, l2Block100.Hash, FirstRevision), types.ErrConflict)
+			require.ErrorIs(t, db.addLink(l1Block20, l2Block100, l2Block100.Hash, FirstRevision), interop.ErrConflict)
 		},
 	)
 }
@@ -1101,7 +1102,7 @@ func TestNoReplaceFirst(t *testing.T) {
 			l2Ref0 := toRef(l2Block0, common.Hash{})
 			inv := &reads.TestInvalidator{}
 			_, err := db.ReplaceInvalidatedBlock(inv, l2Ref0, common.Hash{0xff})
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 			require.True(t, inv.Invalidated)
 			require.Equal(t, l2Ref0.Time, inv.InvalidatedDerivedTimestamp)
 			require.Equal(t, uint64(0), inv.InvalidatedSourceNum, "source not affected")
@@ -1146,7 +1147,7 @@ func TestNotOntoInvalidated(t *testing.T) {
 			require.Equal(t, l2Ref2.Time, inv.InvalidatedDerivedTimestamp)
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref2, l2Ref3), types.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref2, l2Ref3), interop.ErrAwaitReplacementBlock)
 		},
 	)
 }
@@ -1187,12 +1188,12 @@ func TestMismatchedInvalidate(t *testing.T) {
 			require.ErrorIs(t, db.RewindAndInvalidate(inv, types.DerivedBlockRefPair{
 				Source:  l1Ref2,
 				Derived: l2Ref2Alt,
-			}), types.ErrConflict)
+			}), interop.ErrConflict)
 			require.True(t, inv.Invalidated) // even though no effect, we still pick up the signal as clue something is wrong.
 			require.Equal(t, l1Ref2.Number, inv.InvalidatedSourceNum)
 			require.Equal(t, l2Ref2Alt.Time, inv.InvalidatedDerivedTimestamp)
 			// This will detect the issue upon insertion of the new invalidated-entry
-			require.ErrorIs(t, db.addLink(l1Ref3, l2Ref2Alt, l2Ref2Alt.Hash, FirstRevision), types.ErrConflict)
+			require.ErrorIs(t, db.addLink(l1Ref3, l2Ref2Alt, l2Ref2Alt.Hash, FirstRevision), interop.ErrConflict)
 		},
 	)
 }
@@ -1216,7 +1217,7 @@ func TestNoParallelBump(t *testing.T) {
 			require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref1, l2Ref1), types.ErrOutOfOrder)
+			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref1, l2Ref1), interop.ErrOutOfOrder)
 		},
 	)
 }
@@ -1250,11 +1251,11 @@ func TestLookupDetectIfCorruptDB(t *testing.T) {
 
 			// Look for L1 block 1
 			_, err := db.SourceToLastDerived(l1Block1.ID())
-			require.ErrorIs(t, err, types.ErrNotExact)
+			require.ErrorIs(t, err, interop.ErrNotExact)
 
 			// Look for L2 block 1
 			_, err = db.DerivedToFirstSource(l2Block1.ID(), types.RevisionAny)
-			require.ErrorIs(t, err, types.ErrNotExact)
+			require.ErrorIs(t, err, interop.ErrNotExact)
 
 			inv := &reads.TestInvalidator{}
 			// Rewind, corrupt data cannot be left at end of test, otherwise invariant checks fail
@@ -1303,7 +1304,7 @@ func TestRewindToDifferent(t *testing.T) {
 			t.Run("Bad derived target", func(t *testing.T) {
 				inv := &reads.TestInvalidator{}
 				// try to rewind, but towards a mismatching block
-				require.ErrorIs(t, db.RewindToFirstDerived(inv, l2ID1Alt, types.RevisionAny), types.ErrConflict)
+				require.ErrorIs(t, db.RewindToFirstDerived(inv, l2ID1Alt, types.RevisionAny), interop.ErrConflict)
 				require.False(t, inv.Invalidated)
 				last, err := db.Last()
 				require.NoError(t, err)
@@ -1315,7 +1316,7 @@ func TestRewindToDifferent(t *testing.T) {
 			t.Run("Bad source target", func(t *testing.T) {
 				inv := &reads.TestInvalidator{}
 				// try to rewind, but towards a mismatching block
-				require.ErrorIs(t, db.RewindToSource(inv, l1ID1Alt), types.ErrConflict)
+				require.ErrorIs(t, db.RewindToSource(inv, l1ID1Alt), interop.ErrConflict)
 				require.False(t, inv.Invalidated)
 				last, err := db.Last()
 				require.NoError(t, err)
@@ -1403,7 +1404,7 @@ func TestDeepInvalidate(t *testing.T) {
 			require.NoError(t, dbAddDerivedAny(db, l1Ref6, l2Ref9))
 
 			_, _, err := db.lookup(6, 3) // 3 was never derived from 6 at this point, we didn't apply the invalidation yet
-			require.ErrorIs(t, err, types.ErrNotExact)
+			require.ErrorIs(t, err, interop.ErrNotExact)
 
 			// If we scan for the first thing at or after (6, 3) we should find (6, 8)
 			_, v, err := db.lookupOrAfter(6, 3)
@@ -1430,17 +1431,17 @@ func TestDeepInvalidate(t *testing.T) {
 			// Invalidated, but with old revision before invalidation, is considered valid
 			require.NoError(t, db.ContainsDerived(l2Ref3.ID(), FirstRevision))
 			// Invalidated entries are not considered by ContainsDerived as valid
-			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision), types.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision), interop.ErrAwaitReplacementBlock)
 			// Older non-invalidated entries are considered valid still
 			require.NoError(t, db.ContainsDerived(l2Ref2.ID(), FirstRevision))
 
 			// We cannot invalidate what is already invalidated
-			require.ErrorIs(t, db.RewindAndInvalidate(inv, invalidated), types.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, db.RewindAndInvalidate(inv, invalidated), interop.ErrAwaitReplacementBlock)
 
 			// we cannot proceed in any way until actually replacing the invalidated placeholder block
-			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref6, l2Ref4p), types.ErrAwaitReplacementBlock)
-			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref7, l2Ref3p), types.ErrAwaitReplacementBlock)
-			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref7, l2Ref4p), types.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref6, l2Ref4p), interop.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref7, l2Ref3p), interop.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref7, l2Ref4p), interop.ErrAwaitReplacementBlock)
 
 			replacement, err := db.ReplaceInvalidatedBlock(inv, l2Ref3p, l2Ref3.Hash)
 			require.NoError(t, err)
@@ -1454,8 +1455,8 @@ func TestDeepInvalidate(t *testing.T) {
 			require.Equal(t, l2Ref3p.ID(), v.derived.ID())
 			require.Equal(t, secondRevision, v.revision) // replacement matches invalidated-placeholder revision
 
-			require.NoError(t, db.ContainsDerived(l2Ref3.ID(), FirstRevision), types.ErrConflict)
-			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision), types.ErrConflict)
+			require.NoError(t, db.ContainsDerived(l2Ref3.ID(), FirstRevision), interop.ErrConflict)
+			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision), interop.ErrConflict)
 			require.NoError(t, db.ContainsDerived(l2Ref3p.ID(), secondRevision))
 
 			require.NoError(t, dbAddDerivedAny(db, l1Ref7, l2Ref3p)) // scope bump
@@ -1473,7 +1474,7 @@ func TestDeepInvalidate(t *testing.T) {
 			require.Equal(t, l2Ref7.ID(), link.derived.ID()) // not canonical in L2, but available, attached to older L1 scope
 
 			_, link, err = db.lookup(5, 3) // block 3 was passed already in scope 5, but returned back to in scope 6, and should thus not be a valid lookup
-			require.ErrorIs(t, err, types.ErrNotExact)
+			require.ErrorIs(t, err, interop.ErrNotExact)
 
 			_, link, err = db.lookup(6, 3)
 			require.NoError(t, err)
@@ -1594,13 +1595,13 @@ func TestDeepInvalidate(t *testing.T) {
 			require.Equal(t, l2Ref5pp.ID(), v.derived.ID())
 
 			require.NoError(t, db.ContainsDerived(l2Ref2.ID(), FirstRevision))
-			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision), types.ErrConflict)
+			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision), interop.ErrConflict)
 			require.NoError(t, db.ContainsDerived(l2Ref3p.ID(), secondRevision))
 
 			require.NoError(t, db.ContainsDerived(l2Ref5.ID(), FirstRevision))
-			require.ErrorIs(t, db.ContainsDerived(l2Ref5p.ID(), FirstRevision), types.ErrConflict)
+			require.ErrorIs(t, db.ContainsDerived(l2Ref5p.ID(), FirstRevision), interop.ErrConflict)
 			require.NoError(t, db.ContainsDerived(l2Ref5p.ID(), secondRevision))
-			require.ErrorIs(t, db.ContainsDerived(l2Ref5p.ID(), thirdRevision), types.ErrConflict)
+			require.ErrorIs(t, db.ContainsDerived(l2Ref5p.ID(), thirdRevision), interop.ErrConflict)
 			require.NoError(t, db.ContainsDerived(l2Ref5pp.ID(), thirdRevision))
 		})
 }
@@ -1627,7 +1628,7 @@ func TestDerivedToRevision(t *testing.T) {
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			_, err := db.DerivedToRevision(l2Ref0.ID())
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 
 			require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
 
@@ -1642,7 +1643,7 @@ func TestDerivedToRevision(t *testing.T) {
 			require.NoError(t, dbAddDerivedAny(db, l1Ref3, l2Ref4)) // scope bump
 			require.NoError(t, dbAddDerivedAny(db, l1Ref3, l2Ref4))
 			// when something is revised, the number of the revised data is used as revision number
-			require.ErrorIs(t, db.AddDerived(l1Ref3, l2Ref5, 6), types.ErrDataCorruption)
+			require.ErrorIs(t, db.AddDerived(l1Ref3, l2Ref5, 6), interop.ErrDataCorruption)
 			require.NoError(t, db.AddDerived(l1Ref3, l2Ref5, 5))
 
 			require.NoError(t, dbAddDerivedAny(db, l1Ref4, l2Ref5)) // scope bump
@@ -1678,6 +1679,6 @@ func TestDerivedToRevision(t *testing.T) {
 			require.Equal(t, types.Revision(5), v)
 
 			_, err = db.DerivedToRevision(l2Ref7.ID())
-			require.ErrorIs(t, err, types.ErrFuture)
+			require.ErrorIs(t, err, interop.ErrFuture)
 		})
 }

--- a/op-supervisor/supervisor/backend/db/fromda/entry.go
+++ b/op-supervisor/supervisor/backend/db/fromda/entry.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -74,10 +75,10 @@ func (d LinkEntry) String() string {
 
 func (d *LinkEntry) decode(e Entry) error {
 	if t := e.Type(); t != SourceV0 && t != InvalidatedFromV0 {
-		return fmt.Errorf("%w: unexpected entry type: %s", types.ErrDataCorruption, e.Type())
+		return fmt.Errorf("%w: unexpected entry type: %s", interop.ErrDataCorruption, e.Type())
 	}
 	if [3]byte(e[1:4]) != ([3]byte{}) {
-		return fmt.Errorf("%w: expected empty data, to pad entry size to round number: %x", types.ErrDataCorruption, e[1:4])
+		return fmt.Errorf("%w: expected empty data, to pad entry size to round number: %x", interop.ErrDataCorruption, e[1:4])
 	}
 	d.invalidated = e.Type() == InvalidatedFromV0
 	// Format:
@@ -91,7 +92,7 @@ func (d *LinkEntry) decode(e Entry) error {
 	d.revision = types.Revision(binary.BigEndian.Uint64(e[offset : offset+8]))
 	offset += 8
 	if d.revision&(1<<63) != 0 {
-		return fmt.Errorf("%w: upper bit of revision may not be set: %b", types.ErrDataCorruption, d.revision)
+		return fmt.Errorf("%w: upper bit of revision may not be set: %b", interop.ErrDataCorruption, d.revision)
 	}
 	d.derived.Number = binary.BigEndian.Uint64(e[offset : offset+8])
 	offset += 8
@@ -132,7 +133,7 @@ func (d *LinkEntry) encode() Entry {
 
 func (d *LinkEntry) sealOrErr() (types.DerivedBlockSealPair, error) {
 	if d.invalidated {
-		return types.DerivedBlockSealPair{}, types.ErrAwaitReplacementBlock
+		return types.DerivedBlockSealPair{}, interop.ErrAwaitReplacementBlock
 	}
 	return types.DerivedBlockSealPair{
 		Source:  d.source,

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -49,17 +50,17 @@ func (db *DB) ReplaceInvalidatedBlock(inv reads.Invalidator, replacementDerived 
 	// and where we thus stopped building additional entries for it.
 	lastIndex := db.store.LastEntryIdx()
 	if lastIndex < 0 {
-		return types.DerivedBlockRefPair{}, types.ErrFuture
+		return types.DerivedBlockRefPair{}, interop.ErrFuture
 	}
 	last, err := db.readAt(lastIndex)
 	if err != nil {
 		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to read last derivation data: %w", err)
 	}
 	if !last.invalidated {
-		return types.DerivedBlockRefPair{}, fmt.Errorf("cannot replace block %d, that was not invalidated, with block %s: %w", last.derived, replacementDerived, types.ErrConflict)
+		return types.DerivedBlockRefPair{}, fmt.Errorf("cannot replace block %d, that was not invalidated, with block %s: %w", last.derived, replacementDerived, interop.ErrConflict)
 	}
 	if last.derived.Hash != invalidated {
-		return types.DerivedBlockRefPair{}, fmt.Errorf("cannot replace invalidated %s, DB contains %s: %w", invalidated, last.derived, types.ErrConflict)
+		return types.DerivedBlockRefPair{}, fmt.Errorf("cannot replace invalidated %s, DB contains %s: %w", invalidated, last.derived, interop.ErrConflict)
 	}
 	// Find the parent-block of derived-from.
 	// We need this to build a block-ref, so the DB can be consistency-checked when the next entry is added.
@@ -108,12 +109,12 @@ func (db *DB) RewindAndInvalidate(inv reads.Invalidator, invalidated types.Deriv
 		return err
 	}
 	if link.invalidated {
-		return fmt.Errorf("cannot invalidate already invalidated block %s with %s: %w", link, invalidated, types.ErrAwaitReplacementBlock)
+		return fmt.Errorf("cannot invalidate already invalidated block %s with %s: %w", link, invalidated, interop.ErrAwaitReplacementBlock)
 	}
 	// We must have an exact match for the source, this is where and when we decide to invalidate
 	if link.source.Hash != t.Source.Hash {
 		return fmt.Errorf("found derived-from %s, but expected %s: %w",
-			link.source, t.Source, types.ErrConflict)
+			link.source, t.Source, interop.ErrConflict)
 	}
 	// If we optimistically derived some block already for a previous source,
 	// and only invalidated because of a later view of newer source data,
@@ -121,7 +122,7 @@ func (db *DB) RewindAndInvalidate(inv reads.Invalidator, invalidated types.Deriv
 	if link.derived.Hash != t.Derived.Hash {
 		if link.derived.Number <= t.Derived.Number {
 			return fmt.Errorf("found derived %s, but expected %s: %w",
-				link.derived, t.Derived, types.ErrConflict)
+				link.derived, t.Derived, interop.ErrConflict)
 		} else {
 			db.log.Warn("Invalidating block that was previously optimistically assumed as canonical with previous source",
 				"invalidated_source", invalidated.Source, "invalidated_derived", invalidated.Derived,
@@ -184,7 +185,7 @@ func (db *DB) RewindToSource(inv reads.Invalidator, source eth.BlockID) error {
 	_, link, err := db.sourceNumToLastDerived(source.Number)
 	if err != nil {
 		// If the rewind-point is before the first block in the DB, then drop all content of the DB.
-		if errors.Is(err, types.ErrSkipped) || errors.Is(err, types.ErrPreviousToFirst) {
+		if errors.Is(err, interop.ErrSkipped) || errors.Is(err, interop.ErrPreviousToFirst) {
 			if err := db.Clear(inv); err != nil {
 				return fmt.Errorf("failed to clear DA DB, upon rewinding to source block %s before first block: %w", source, err)
 			}
@@ -193,7 +194,7 @@ func (db *DB) RewindToSource(inv reads.Invalidator, source eth.BlockID) error {
 		return fmt.Errorf("failed to find last derived %d: %w", source.Number, err)
 	}
 	if link.source.ID() != source {
-		return fmt.Errorf("found derived-from %s but expected %s: %w", link.source, source, types.ErrConflict)
+		return fmt.Errorf("found derived-from %s but expected %s: %w", link.source, source, interop.ErrConflict)
 	}
 	return db.rewindLocked(inv, types.DerivedBlockSealPair{
 		Source:  link.source,
@@ -211,7 +212,7 @@ func (db *DB) RewindToFirstDerived(inv reads.Invalidator, v eth.BlockID, revisio
 		return fmt.Errorf("failed to find when %d was first derived: %w", v.Number, err)
 	}
 	if link.derived.ID() != v {
-		return fmt.Errorf("found derived %s but expected %s: %w", link.derived, v, types.ErrConflict)
+		return fmt.Errorf("found derived %s but expected %s: %w", link.derived, v, interop.ErrConflict)
 	}
 	return db.rewindLocked(inv, types.DerivedBlockSealPair{
 		Source:  link.source,
@@ -239,11 +240,11 @@ func (db *DB) rewindLocked(inv reads.Invalidator, t types.DerivedBlockSealPair, 
 	}
 	if link.source.Hash != t.Source.Hash {
 		return fmt.Errorf("found derived-from %s, but expected %s: %w",
-			link.source, t.Source, types.ErrConflict)
+			link.source, t.Source, interop.ErrConflict)
 	}
 	if link.derived.Hash != t.Derived.Hash {
 		return fmt.Errorf("found derived %s, but expected %s: %w",
-			link.derived, t.Derived, types.ErrConflict)
+			link.derived, t.Derived, interop.ErrConflict)
 	}
 	// adjust the target index to include the block seal pair itself if requested
 	target := i
@@ -282,7 +283,7 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 	// If we don't have any entries yet, allow any block to start things off
 	if db.store.Size() == 0 {
 		if link.invalidated {
-			return fmt.Errorf("first DB entry %s cannot be an invalidated entry: %w", link, types.ErrConflict)
+			return fmt.Errorf("first DB entry %s cannot be an invalidated entry: %w", link, interop.ErrConflict)
 		}
 		if revision.Any() {
 			link.revision = FirstRevision
@@ -301,7 +302,7 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 		return err
 	}
 	if last.invalidated {
-		return fmt.Errorf("cannot build %s on top of invalidated entry %s: %w", link, last, types.ErrAwaitReplacementBlock)
+		return fmt.Errorf("cannot build %s on top of invalidated entry %s: %w", link, last, interop.ErrAwaitReplacementBlock)
 	}
 	lastSource := last.source
 	lastDerived := last.derived
@@ -315,16 +316,16 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 			if last.revision != revision {
 				if derived.Number != revision.Number() {
 					return fmt.Errorf("cannot insert entry %s with revision %s, after %s with revision %s: %w",
-						derived, revision, last.derived, last.revision, types.ErrDataCorruption)
+						derived, revision, last.derived, last.revision, interop.ErrDataCorruption)
 				}
 				db.log.Warn("New revision", "revision", revision, "source", source, "derived", derived)
 			}
 		} else if derived.Hash == invalidated {
 			if last.revision == revision {
-				return fmt.Errorf("invalidated link %s should change revision: %w", link, types.ErrConflict)
+				return fmt.Errorf("invalidated link %s should change revision: %w", link, interop.ErrConflict)
 			}
 			if derived.Number != revision.Number() {
-				return fmt.Errorf("expecting invalidated/replaced entry %s to match revision %s: %w", derived, revision, types.ErrDataCorruption)
+				return fmt.Errorf("expecting invalidated/replaced entry %s to match revision %s: %w", derived, revision, interop.ErrDataCorruption)
 			}
 			db.log.Debug("Invalidating entry", "revision", revision, "source", source, "derived", derived)
 		}
@@ -332,7 +333,7 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 
 	if (lastSource.Number+1 == source.Number) && (lastDerived.Number+1 == derived.Number) {
 		return fmt.Errorf("cannot add source:%s derived:%s on top of last entry source:%s derived:%s, must increment source or derived, not both: %w",
-			source, derived, last.source, last.derived, types.ErrOutOfOrder)
+			source, derived, last.source, last.derived, interop.ErrOutOfOrder)
 	}
 
 	if lastDerived.ID() == derived.ID() && lastSource.ID() == source.ID() {
@@ -357,24 +358,24 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 		// I.e. we encountered an empty L1 block, and the same L2 block continues to be the last block that was derived from it.
 		if invalidated != (common.Hash{}) {
 			if lastDerived.Hash != invalidated {
-				return fmt.Errorf("inserting block %s that invalidates %s at height %d, but expected %s: %w", derived.Hash, invalidated, lastDerived.Number, lastDerived.Hash, types.ErrConflict)
+				return fmt.Errorf("inserting block %s that invalidates %s at height %d, but expected %s: %w", derived.Hash, invalidated, lastDerived.Number, lastDerived.Hash, interop.ErrConflict)
 			}
 		} else {
 			if lastDerived.Hash != derived.Hash {
 				return fmt.Errorf("derived block %s conflicts with known derived block %s at same height: %w",
-					derived, lastDerived, types.ErrConflict)
+					derived, lastDerived, interop.ErrConflict)
 			}
 		}
 	} else if lastDerived.Number+1 == derived.Number {
 		if lastDerived.Hash != derived.ParentHash {
 			return fmt.Errorf("derived block %s (parent %s) does not build on %s: %w",
-				derived, derived.ParentHash, lastDerived, types.ErrConflict)
+				derived, derived.ParentHash, lastDerived, interop.ErrConflict)
 		}
 	} else if lastDerived.Number+1 < derived.Number {
 		return fmt.Errorf("cannot add block (%s derived from %s), last block (%s derived from %s) is too far behind: (%w)",
 			derived, source,
 			lastDerived, lastSource,
-			types.ErrFuture)
+			interop.ErrFuture)
 	} else {
 		if invalidated != (common.Hash{}) {
 			// Invalidated blocks or replacement blocks may be reverting back to an older derived block.
@@ -386,7 +387,7 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 			}
 		} else {
 			return fmt.Errorf("derived block %s is older than current derived block %s: %w",
-				derived, lastDerived, types.ErrOutOfOrder)
+				derived, lastDerived, interop.ErrOutOfOrder)
 		}
 	}
 
@@ -395,20 +396,20 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 		// Same block height? Then it must be the same block.
 		if lastSource.Hash != source.Hash {
 			return fmt.Errorf("cannot add block %s as derived from %s, expected to be derived from %s at this block height: %w",
-				derived, source, lastSource, types.ErrConflict)
+				derived, source, lastSource, interop.ErrConflict)
 		}
 	} else if lastSource.Number+1 == source.Number {
 		// parent hash check
 		if lastSource.Hash != source.ParentHash {
 			return fmt.Errorf("cannot add block %s as derived from %s (parent %s) derived on top of %s: %w",
-				derived, source, source.ParentHash, lastSource, types.ErrConflict)
+				derived, source, source.ParentHash, lastSource, interop.ErrConflict)
 		}
 	} else if lastSource.Number+1 < source.Number {
 		// adding block that is derived from something too far into the future
 		return fmt.Errorf("cannot add block (%s derived from %s), last block (%s derived from %s) is too far behind: (%w)",
 			derived, source,
 			lastDerived, lastSource,
-			types.ErrFuture)
+			interop.ErrFuture)
 	} else {
 		if lastDerived.Hash == derived.Hash {
 			// we might see L1 blocks repeat,
@@ -422,14 +423,14 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 			}
 			if got.source.Hash != source.Hash {
 				return fmt.Errorf("cannot add block %s that matches latest derived since it is derived from non-canonical source %s, expected %s: %w",
-					derived, source, got.source, types.ErrConflict)
+					derived, source, got.source, interop.ErrConflict)
 			}
 			return fmt.Errorf("received latest block %s, derived from known old source %s, latest source is %s: %w",
-				derived, source, lastSource, types.ErrIneffective)
+				derived, source, lastSource, interop.ErrIneffective)
 		}
 		// Adding a newer block that is derived from an older source, that cannot be right
 		return fmt.Errorf("cannot add block %s as derived from %s, deriving already at %s: %w",
-			derived, source, lastSource, types.ErrOutOfOrder)
+			derived, source, lastSource, interop.ErrOutOfOrder)
 	}
 
 	e := link.encode()

--- a/op-supervisor/supervisor/backend/db/fromda/update_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update_test.go
@@ -8,8 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
-
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -48,7 +47,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, dbAddDerivedAny(db,
 					toRef(bSource, aSource.Hash), // b is before c
-					toRef(dDerived, cDerived.Hash)), types.ErrSkipped)
+					toRef(dDerived, cDerived.Hash)), interop.ErrSkipped)
 			},
 			assertFn: noChange,
 		},
@@ -58,7 +57,7 @@ func TestBadUpdates(t *testing.T) {
 				require.ErrorIs(t, dbAddDerivedAny(db,
 					toRef(cSource, bSource.Hash),
 					toRef(cDerived, bDerived.Hash),
-				), types.ErrOutOfOrder)
+				), interop.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
@@ -82,7 +81,7 @@ func TestBadUpdates(t *testing.T) {
 				require.ErrorIs(t, dbAddDerivedAny(db,
 					toRef(dSource, cSource.Hash),   // d is old, but was canonically linked like this before
 					toRef(dDerived, cDerived.Hash), // same L2 block
-				), types.ErrIneffective)
+				), interop.ErrIneffective)
 			},
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				pair, err := db.Last()
@@ -101,7 +100,7 @@ func TestBadUpdates(t *testing.T) {
 				require.ErrorIs(t, dbAddDerivedAny(db,
 					toRef(dAltSource, cSource.Hash), // conflicting old block
 					toRef(dDerived, cDerived.Hash),  // same L2 block
-				), types.ErrConflict)
+				), interop.ErrConflict)
 			},
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				pair, err := db.Last()
@@ -120,7 +119,7 @@ func TestBadUpdates(t *testing.T) {
 				require.ErrorIs(t, dbAddDerivedAny(db,
 					toRef(dSource, cSource.Hash),   // old L1 block
 					toRef(eDerived, dDerived.Hash), // new L2 block
-				), types.ErrOutOfOrder)
+				), interop.ErrOutOfOrder)
 			},
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				pair, err := db.Last()
@@ -138,7 +137,7 @@ func TestBadUpdates(t *testing.T) {
 						Number:    dSource.Number,
 						Timestamp: dSource.Timestamp,
 					}, cSource.Hash),
-					toRef(eDerived, dDerived.Hash)), types.ErrConflict)
+					toRef(eDerived, dDerived.Hash)), interop.ErrConflict)
 			},
 			assertFn: noChange,
 		},
@@ -147,7 +146,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.NoError(t, dbAddDerivedAny(db,
 					toRef(dSource, common.Hash{0x42}),
-					toRef(eDerived, dDerived.Hash)), types.ErrConflict)
+					toRef(eDerived, dDerived.Hash)), interop.ErrConflict)
 			},
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				pair, err := db.Last()
@@ -162,7 +161,7 @@ func TestBadUpdates(t *testing.T) {
 				require.ErrorIs(t,
 					dbAddDerivedAny(db,
 						toRef(eSource, common.Hash{0x42}),
-						toRef(dDerived, cDerived.Hash)), types.ErrConflict)
+						toRef(dDerived, cDerived.Hash)), interop.ErrConflict)
 			},
 			assertFn: noChange,
 		},
@@ -171,7 +170,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t,
 					dbAddDerivedAny(db, toRef(fSource, dSource.Hash),
-						toRef(eDerived, dDerived.Hash)), types.ErrFuture)
+						toRef(eDerived, dDerived.Hash)), interop.ErrFuture)
 			},
 			assertFn: noChange,
 		},
@@ -180,7 +179,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, dbAddDerivedAny(db,
 					toRef(cSource, bSource.Hash),
-					toRef(cDerived, dDerived.Hash)), types.ErrOutOfOrder)
+					toRef(cDerived, dDerived.Hash)), interop.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
@@ -189,7 +188,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, dbAddDerivedAny(db,
 					toRef(bSource, aSource.Hash),
-					toRef(dDerived, cDerived.Hash)), types.ErrSkipped)
+					toRef(dDerived, cDerived.Hash)), interop.ErrSkipped)
 			},
 			assertFn: noChange,
 		},
@@ -202,7 +201,7 @@ func TestBadUpdates(t *testing.T) {
 						Hash:      common.Hash{0x42},
 						Number:    dDerived.Number,
 						Timestamp: dDerived.Timestamp,
-					}, cDerived.Hash)), types.ErrConflict)
+					}, cDerived.Hash)), interop.ErrConflict)
 			},
 			assertFn: noChange,
 		},
@@ -211,7 +210,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.NoError(t, dbAddDerivedAny(db,
 					toRef(eSource, dSource.Hash),
-					toRef(dDerived, common.Hash{0x42})), types.ErrConflict)
+					toRef(dDerived, common.Hash{0x42})), interop.ErrConflict)
 			},
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				pair, err := db.Last()
@@ -225,7 +224,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, dbAddDerivedAny(db,
 					toRef(dSource, cSource.Hash),
-					toRef(eDerived, common.Hash{0x42})), types.ErrConflict)
+					toRef(eDerived, common.Hash{0x42})), interop.ErrConflict)
 			},
 			assertFn: noChange,
 		},
@@ -234,7 +233,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, dbAddDerivedAny(db,
 					toRef(dSource, cSource.Hash),
-					toRef(fDerived, dDerived.Hash)), types.ErrFuture)
+					toRef(fDerived, dDerived.Hash)), interop.ErrFuture)
 			},
 			assertFn: noChange,
 		},
@@ -243,7 +242,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, dbAddDerivedAny(db,
 					toRef(dSource, cSource.Hash),
-					toRef(cDerived, bDerived.Hash)), types.ErrOutOfOrder)
+					toRef(cDerived, bDerived.Hash)), interop.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
@@ -252,7 +251,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, dbAddDerivedAny(db,
 					toRef(dSource, cSource.Hash),
-					toRef(bDerived, aDerived.Hash)), types.ErrOutOfOrder)
+					toRef(bDerived, aDerived.Hash)), interop.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
@@ -262,7 +261,7 @@ func TestBadUpdates(t *testing.T) {
 				pre := m.DBDerivedEntryCount
 				require.NoError(t, dbAddDerivedAny(db,
 					toRef(dSource, cSource.Hash),
-					toRef(dDerived, cDerived.Hash)), types.ErrOutOfOrder)
+					toRef(dDerived, cDerived.Hash)), interop.ErrOutOfOrder)
 				require.Equal(t, pre, m.DBDerivedEntryCount)
 			},
 			assertFn: noChange,

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -156,8 +156,8 @@ func (db *DB) FindSealedBlock(number uint64) (seal messages.BlockSeal, err error
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	iter, err := db.newIteratorAt(number, 0)
-	if errors.Is(err, types.ErrFuture) {
-		return messages.BlockSeal{}, fmt.Errorf("block %d is not known yet: %w", number, types.ErrFuture)
+	if errors.Is(err, interop.ErrFuture) {
+		return messages.BlockSeal{}, fmt.Errorf("block %d is not known yet: %w", number, interop.ErrFuture)
 	} else if err != nil {
 		return messages.BlockSeal{}, fmt.Errorf("failed to find sealed block %d: %w", number, err)
 	}
@@ -211,7 +211,7 @@ func (db *DB) OpenBlock(blockNum uint64) (ref eth.BlockRef, logCount uint32, exe
 			return
 		}
 		if seal.Number != 0 {
-			return eth.BlockRef{}, 0, nil, fmt.Errorf("looked for block 0 but got %s: %w", seal, types.ErrSkipped)
+			return eth.BlockRef{}, 0, nil, fmt.Errorf("looked for block 0 but got %s: %w", seal, interop.ErrSkipped)
 		}
 		ref = eth.BlockRef{
 			Hash:       seal.Hash,
@@ -254,14 +254,14 @@ func (db *DB) OpenBlock(blockNum uint64) (ref eth.BlockRef, logCount uint32, exe
 			ref.Number = n
 			ref.Hash = h
 			ref.Time, _ = state.SealedTimestamp()
-			return types.ErrStop
+			return interop.ErrStop
 		}
 		if n > blockNum {
-			return fmt.Errorf("expected to run into block %d, but did not find it, found %d: %w", blockNum, n, types.ErrDataCorruption)
+			return fmt.Errorf("expected to run into block %d, but did not find it, found %d: %w", blockNum, n, interop.ErrDataCorruption)
 		}
 		return nil
 	})
-	if errors.Is(retErr, types.ErrStop) {
+	if errors.Is(retErr, interop.ErrStop) {
 		retErr = nil
 	}
 	return
@@ -305,16 +305,16 @@ func (db *DB) Contains(query messages.ContainsQuery) (messages.BlockSeal, error)
 		// the included timestamp is within the database. In this case we know the request is not just a ErrFuture,
 		// but a ErrConflict, as we know the request will not be included in the future.
 		if db.lastEntryContext.timestamp > timestamp {
-			return messages.BlockSeal{}, types.ErrConflict
+			return messages.BlockSeal{}, interop.ErrConflict
 		}
-		return messages.BlockSeal{}, types.ErrFuture
+		return messages.BlockSeal{}, interop.ErrFuture
 	}
 
 	entryLogHash, iter, err := db.findLogInfo(blockNum, logIdx)
 	if err != nil {
 		// if we get an ErrFuture but have a complete block, then we really have a conflict
-		if errors.Is(err, types.ErrFuture) && db.lastEntryContext.hasCompleteBlock() {
-			return messages.BlockSeal{}, types.ErrConflict
+		if errors.Is(err, interop.ErrFuture) && db.lastEntryContext.hasCompleteBlock() {
+			return messages.BlockSeal{}, interop.ErrConflict
 		}
 		return messages.BlockSeal{}, err // may be ErrConflict if the block does not have as many logs
 	}
@@ -326,10 +326,10 @@ func (db *DB) Contains(query messages.ContainsQuery) (messages.BlockSeal, error)
 			return nil
 		}
 		if n == blockNum {
-			return types.ErrStop
+			return interop.ErrStop
 		}
 		if n > blockNum {
-			return types.ErrDataCorruption
+			return interop.ErrDataCorruption
 		}
 		return nil
 	})
@@ -337,7 +337,7 @@ func (db *DB) Contains(query messages.ContainsQuery) (messages.BlockSeal, error)
 		panic("expected iterator to stop with error")
 	}
 	// ErrStop indicates we've found the block, and the iterator is positioned at it.
-	if errors.Is(err, types.ErrStop) {
+	if errors.Is(err, interop.ErrStop) {
 		h, n, ok := iter.SealedBlock()
 		if !ok {
 			return messages.BlockSeal{}, errIteratorStoppedButNoSealedBlock
@@ -345,7 +345,7 @@ func (db *DB) Contains(query messages.ContainsQuery) (messages.BlockSeal, error)
 		t, _ := iter.SealedTimestamp()
 		// check the timestamp invariant on the result
 		if t != timestamp {
-			return messages.BlockSeal{}, fmt.Errorf("timestamp mismatch: expected %d, got %d %w", timestamp, t, types.ErrConflict)
+			return messages.BlockSeal{}, fmt.Errorf("timestamp mismatch: expected %d, got %d %w", timestamp, t, interop.ErrConflict)
 		}
 		entryChecksum := messages.ChecksumArgs{
 			BlockNumber: n,
@@ -356,7 +356,7 @@ func (db *DB) Contains(query messages.ContainsQuery) (messages.BlockSeal, error)
 		}.Checksum()
 		// Found the requested block and log index, check if the hash matches
 		if entryChecksum != query.Checksum {
-			return messages.BlockSeal{}, fmt.Errorf("payload hash mismatch: expected %s, got %s %w", query.Checksum, entryChecksum, types.ErrConflict)
+			return messages.BlockSeal{}, fmt.Errorf("payload hash mismatch: expected %s, got %s %w", query.Checksum, entryChecksum, interop.ErrConflict)
 		}
 		// construct a block seal with the found data now that we know it's correct
 		return messages.BlockSeal{
@@ -372,12 +372,12 @@ func (db *DB) Contains(query messages.ContainsQuery) (messages.BlockSeal, error)
 // If a log isn't found at the index we return an ErrFuture, even if the block is complete.
 func (db *DB) findLogInfo(blockNum uint64, logIdx uint32) (common.Hash, Iterator, error) {
 	if blockNum == 0 {
-		return common.Hash{}, nil, types.ErrConflict // no logs in block 0
+		return common.Hash{}, nil, interop.ErrConflict // no logs in block 0
 	}
 	// blockNum-1, such that we find a log that came after the parent num-1 was sealed.
 	// logIdx, such that all entries before logIdx can be skipped, but logIdx itself is still readable.
 	iter, err := db.newIteratorAt(blockNum-1, logIdx)
-	if errors.Is(err, types.ErrFuture) {
+	if errors.Is(err, interop.ErrFuture) {
 		db.log.Trace("Could not find log yet", "blockNum", blockNum, "logIdx", logIdx)
 		return common.Hash{}, nil, err
 	} else if err != nil {
@@ -392,7 +392,7 @@ func (db *DB) findLogInfo(blockNum uint64, logIdx uint32) (common.Hash, Iterator
 	} else if x < blockNum-1 {
 		panic(fmt.Sprintf("bug in newIteratorAt, expected to have found parent block %d but got %d", blockNum-1, x))
 	} else if x > blockNum-1 {
-		return common.Hash{}, nil, fmt.Errorf("log does not exist, found next block already: %w", types.ErrConflict)
+		return common.Hash{}, nil, fmt.Errorf("log does not exist, found next block already: %w", interop.ErrConflict)
 	}
 	logHash, x, ok := iter.InitMessage()
 	if !ok {
@@ -413,7 +413,7 @@ func (db *DB) newIteratorAt(blockNum uint64, logIndex uint32) (*iterator, error)
 	searchCheckpointIndex, err := db.searchCheckpoint(blockNum, logIndex)
 	if errors.Is(err, io.EOF) {
 		// Did not find a checkpoint to start reading from so the log cannot be present.
-		return nil, types.ErrFuture
+		return nil, interop.ErrFuture
 	} else if err != nil {
 		return nil, err
 	}
@@ -429,9 +429,9 @@ func (db *DB) newIteratorAt(blockNum uint64, logIndex uint32) (*iterator, error)
 		if _, n, ok := iter.SealedBlock(); ok && n == blockNum { // we may already have it exactly
 			break
 		}
-		if err := iter.NextBlock(); errors.Is(err, types.ErrFuture) {
+		if err := iter.NextBlock(); errors.Is(err, interop.ErrFuture) {
 			db.log.Trace("ran out of data, could not find block", "nextIndex", iter.NextIndex(), "target", blockNum)
-			return nil, types.ErrFuture
+			return nil, interop.ErrFuture
 		} else if err != nil {
 			db.log.Error("failed to read next block", "nextIndex", iter.NextIndex(), "target", blockNum, "err", err)
 			return nil, err
@@ -445,7 +445,7 @@ func (db *DB) newIteratorAt(blockNum uint64, logIndex uint32) (*iterator, error)
 			continue
 		}
 		if num != blockNum { // block does not contain
-			return nil, fmt.Errorf("looking for %d, but already at %d: %w", blockNum, num, types.ErrConflict)
+			return nil, fmt.Errorf("looking for %d, but already at %d: %w", blockNum, num, interop.ErrConflict)
 		}
 		break
 	}
@@ -454,7 +454,7 @@ func (db *DB) newIteratorAt(blockNum uint64, logIndex uint32) (*iterator, error)
 	// so two logs before quitting (and not 3 to then quit after).
 	for iter.current.logsSince < logIndex {
 		if err := iter.NextInitMsg(); err == io.EOF {
-			return nil, types.ErrFuture
+			return nil, interop.ErrFuture
 		} else if err != nil {
 			return nil, err
 		}
@@ -464,7 +464,7 @@ func (db *DB) newIteratorAt(blockNum uint64, logIndex uint32) (*iterator, error)
 		}
 		if num > blockNum {
 			// we overshot, the block did not contain as many seen log events as requested
-			return nil, types.ErrConflict
+			return nil, interop.ErrConflict
 		}
 		_, idx, ok := iter.InitMessage()
 		if !ok {
@@ -498,7 +498,7 @@ func (db *DB) newIterator(index entrydb.EntryIdx) *iterator {
 // Returns the index of the searchCheckpoint to begin reading from or an error.
 func (db *DB) searchCheckpoint(sealedBlockNum uint64, logsSince uint32) (entrydb.EntryIdx, error) {
 	if db.lastEntryContext.nextEntryIndex == 0 {
-		return 0, types.ErrFuture // empty DB, everything is in the future
+		return 0, interop.ErrFuture // empty DB, everything is in the future
 	}
 	n := (db.lastEntryIdx() / searchCheckpointFrequency) + 1
 	// Define: x is the array of known checkpoints
@@ -535,7 +535,7 @@ func (db *DB) searchCheckpoint(sealedBlockNum uint64, logsSince uint32) (entrydb
 	if checkpoint.blockNum > sealedBlockNum ||
 		(checkpoint.blockNum == sealedBlockNum && checkpoint.logsSince > logsSince) {
 		return 0, fmt.Errorf("missing data, earliest search checkpoint is %d with %d logs, cannot find something before or at %d with %d logs: %w",
-			checkpoint.blockNum, checkpoint.logsSince, sealedBlockNum, logsSince, types.ErrSkipped)
+			checkpoint.blockNum, checkpoint.logsSince, sealedBlockNum, logsSince, interop.ErrSkipped)
 	}
 	return result, nil
 }
@@ -618,7 +618,7 @@ func (db *DB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 	// we might still have trailing log events to get rid of.
 	iter, err := db.newIteratorAt(newHead.Number, 0)
 	if err != nil {
-		if errors.Is(err, types.ErrPreviousToFirst) || errors.Is(err, types.ErrSkipped) {
+		if errors.Is(err, interop.ErrPreviousToFirst) || errors.Is(err, interop.ErrSkipped) {
 			if err := db.Clear(inv); err != nil {
 				return fmt.Errorf("failed to clear logs DB, upon rewinding to log block %s before first block: %w", newHead, err)
 			}
@@ -627,9 +627,9 @@ func (db *DB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 		return err
 	}
 	if hash, num, ok := iter.SealedBlock(); !ok {
-		return fmt.Errorf("expected sealed block for rewind reference-point: %w", types.ErrDataCorruption)
+		return fmt.Errorf("expected sealed block for rewind reference-point: %w", interop.ErrDataCorruption)
 	} else if hash != newHead.Hash {
-		return fmt.Errorf("cannot rewind to %s, have %s: %w", newHead, eth.BlockID{Hash: hash, Number: num}, types.ErrConflict)
+		return fmt.Errorf("cannot rewind to %s, have %s: %w", newHead, eth.BlockID{Hash: hash, Number: num}, interop.ErrConflict)
 	}
 	t, ok := iter.SealedTimestamp()
 	if !ok {

--- a/op-supervisor/supervisor/backend/db/logs/db_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/db_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -101,8 +101,8 @@ func TestLatestSealedBlockNum(t *testing.T) {
 				require.False(t, ok, "empty db expected")
 				require.Equal(t, eth.BlockID{}, head)
 				idx, err := db.searchCheckpoint(0, 0)
-				require.ErrorIs(t, err, types.ErrFuture, "no checkpoint in empty db")
-				require.ErrorIs(t, err, types.ErrFuture, "no checkpoint in empty db")
+				require.ErrorIs(t, err, interop.ErrFuture, "no checkpoint in empty db")
+				require.ErrorIs(t, err, interop.ErrFuture, "no checkpoint in empty db")
 				require.Zero(t, idx)
 			})
 	})
@@ -143,8 +143,8 @@ func TestLatestSealedBlockNum(t *testing.T) {
 				require.NoError(t, err)
 				require.Zero(t, idx, "anchor block as checkpoint 0")
 				_, err = db.searchCheckpoint(0, 0)
-				require.ErrorIs(t, err, types.ErrSkipped, "no checkpoint before genesis")
-				require.ErrorIs(t, err, types.ErrSkipped, "no checkpoint before genesis")
+				require.ErrorIs(t, err, interop.ErrSkipped, "no checkpoint before genesis")
+				require.ErrorIs(t, err, interop.ErrSkipped, "no checkpoint before genesis")
 
 				// Test if we can open the starting block
 				_, _, _, err = db.OpenBlock(genesis.Number)
@@ -152,7 +152,7 @@ func TestLatestSealedBlockNum(t *testing.T) {
 				// OpenBlock cannot start from the first entry, when not 0.
 				// To start at a non-zero block, index the seal of the parent-block block before it,
 				// and then that parent-hash will be available.
-				require.ErrorIs(t, err, types.ErrSkipped)
+				require.ErrorIs(t, err, interop.ErrSkipped)
 			})
 	})
 	t.Run("Block 1 case", func(t *testing.T) {
@@ -228,8 +228,8 @@ func TestAddLog(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				genesis := eth.BlockID{Hash: createHash(15), Number: 0}
 				err := db.AddLog(createHash(1), genesis, 0, nil)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
 			})
 	})
 
@@ -338,8 +338,8 @@ func TestAddLog(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl14 := eth.BlockID{Hash: createHash(14), Number: 14}
 				err := db.SealBlock(createHash(13), bl14, 5000)
-				require.ErrorIs(t, err, types.ErrConflict)
-				require.ErrorIs(t, err, types.ErrConflict)
+				require.ErrorIs(t, err, interop.ErrConflict)
+				require.ErrorIs(t, err, interop.ErrConflict)
 			})
 	})
 
@@ -356,8 +356,8 @@ func TestAddLog(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				onto := eth.BlockID{Hash: createHash(14), Number: 14}
 				err := db.AddLog(createHash(1), onto, 0, nil)
-				require.ErrorIs(t, err, types.ErrOutOfOrder, "cannot build logs on 14 when 15 is already sealed")
-				require.ErrorIs(t, err, types.ErrOutOfOrder, "cannot build logs on 14 when 15 is already sealed")
+				require.ErrorIs(t, err, interop.ErrOutOfOrder, "cannot build logs on 14 when 15 is already sealed")
+				require.ErrorIs(t, err, interop.ErrOutOfOrder, "cannot build logs on 14 when 15 is already sealed")
 			})
 	})
 
@@ -373,8 +373,8 @@ func TestAddLog(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
 				err := db.AddLog(createHash(1), bl15, 0, nil)
-				require.ErrorIs(t, err, types.ErrOutOfOrder, "already at log index 2")
-				require.ErrorIs(t, err, types.ErrOutOfOrder, "already at log index 2")
+				require.ErrorIs(t, err, interop.ErrOutOfOrder, "already at log index 2")
+				require.ErrorIs(t, err, interop.ErrOutOfOrder, "already at log index 2")
 			})
 	})
 
@@ -389,8 +389,8 @@ func TestAddLog(t *testing.T) {
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(16), Number: 16}, 0, nil)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
 			})
 	})
 
@@ -406,8 +406,8 @@ func TestAddLog(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
 				err := db.AddLog(createHash(1), bl15, 1, nil)
-				require.ErrorIs(t, err, types.ErrOutOfOrder, "already at log index 2")
-				require.ErrorIs(t, err, types.ErrOutOfOrder, "already at log index 2")
+				require.ErrorIs(t, err, interop.ErrOutOfOrder, "already at log index 2")
+				require.ErrorIs(t, err, interop.ErrOutOfOrder, "already at log index 2")
 			})
 	})
 
@@ -423,8 +423,8 @@ func TestAddLog(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(16), Number: 16}
 				err := db.AddLog(createHash(1), bl15, 2, nil)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
 			})
 	})
 
@@ -439,8 +439,8 @@ func TestAddLog(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
 				err := db.AddLog(createHash(1), bl15, 2, nil)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
 			})
 	})
 
@@ -453,8 +453,8 @@ func TestAddLog(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
 				err := db.AddLog(createHash(1), bl15, 5, nil)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
 			})
 	})
 
@@ -475,8 +475,8 @@ func TestAddLog(t *testing.T) {
 				err = db.SealBlock(bl15.Hash, bl16, 5001)
 				require.NoError(t, err)
 				err = db.AddLog(createHash(1), bl16, 1, nil)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
 			})
 	})
 
@@ -882,9 +882,9 @@ func TestGetBlockInfo(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {},
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				_, err := db.FindSealedBlock(10)
-				require.ErrorIs(t, err, types.ErrFuture)
+				require.ErrorIs(t, err, interop.ErrFuture)
 				_, err = db.FindSealedBlock(10)
-				require.ErrorIs(t, err, types.ErrFuture)
+				require.ErrorIs(t, err, interop.ErrFuture)
 			})
 	})
 
@@ -899,9 +899,9 @@ func TestGetBlockInfo(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				// if the DB starts at 11, then shouldn't find 10
 				_, err := db.FindSealedBlock(10)
-				require.ErrorIs(t, err, types.ErrSkipped)
+				require.ErrorIs(t, err, interop.ErrSkipped)
 				_, err = db.FindSealedBlock(10)
-				require.ErrorIs(t, err, types.ErrSkipped)
+				require.ErrorIs(t, err, interop.ErrSkipped)
 			})
 	})
 
@@ -958,7 +958,7 @@ func requireConflicts(t *testing.T, db *DB, blockNum uint64, logIdx uint32, time
 		LogHash:     logHash,
 	}.Query()
 	_, err := db.Contains(q)
-	require.ErrorIs(t, err, types.ErrConflict, "canonical chain must not include this log")
+	require.ErrorIs(t, err, interop.ErrConflict, "canonical chain must not include this log")
 	require.LessOrEqual(t, m.entriesReadForSearch, int64(searchCheckpointFrequency*2), "Should not need to read more than between two checkpoints")
 }
 
@@ -973,7 +973,7 @@ func requireFuture(t *testing.T, db *DB, blockNum uint64, logIdx uint32, timesta
 		LogHash:     logHash,
 	}.Query()
 	_, err := db.Contains(q)
-	require.ErrorIs(t, err, types.ErrFuture, "canonical chain does not yet include this log")
+	require.ErrorIs(t, err, interop.ErrFuture, "canonical chain does not yet include this log")
 	require.LessOrEqual(t, m.entriesReadForSearch, int64(searchCheckpointFrequency*2), "Should not need to read more than between two checkpoints")
 }
 
@@ -1163,12 +1163,12 @@ func TestRewind(t *testing.T) {
 		runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {},
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				inv := &reads.TestInvalidator{}
-				require.ErrorIs(t, db.Rewind(inv, createID(100)), types.ErrFuture)
+				require.ErrorIs(t, db.Rewind(inv, createID(100)), interop.ErrFuture)
 				require.False(t, inv.Invalidated)
-				require.ErrorIs(t, db.Rewind(inv, createID(100)), types.ErrFuture)
+				require.ErrorIs(t, db.Rewind(inv, createID(100)), interop.ErrFuture)
 				// Genesis is a block to, not present in an empty DB
-				require.ErrorIs(t, db.Rewind(inv, createID(0)), types.ErrFuture)
-				require.ErrorIs(t, db.Rewind(inv, createID(0)), types.ErrFuture)
+				require.ErrorIs(t, db.Rewind(inv, createID(0)), interop.ErrFuture)
+				require.ErrorIs(t, db.Rewind(inv, createID(0)), interop.ErrFuture)
 			})
 	})
 
@@ -1188,8 +1188,8 @@ func TestRewind(t *testing.T) {
 				require.NoError(t, db.AddLog(createHash(4), bl52, 0, nil))
 				// cannot rewind to a block that is not sealed yet
 				inv := &reads.TestInvalidator{}
-				require.ErrorIs(t, db.Rewind(inv, createID(53)), types.ErrFuture)
-				require.ErrorIs(t, db.Rewind(inv, createID(53)), types.ErrFuture)
+				require.ErrorIs(t, db.Rewind(inv, createID(53)), interop.ErrFuture)
+				require.ErrorIs(t, db.Rewind(inv, createID(53)), interop.ErrFuture)
 				require.False(t, inv.Invalidated)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -1379,14 +1379,14 @@ func TestRewind(t *testing.T) {
 				bl29 := eth.BlockID{Hash: createHash(29), Number: 29}
 				// 29 was deleted
 				err := db.AddLog(createHash(2), bl29, 1, nil)
-				require.ErrorIs(t, err, types.ErrOutOfOrder, "Cannot add log on removed block")
-				require.ErrorIs(t, err, types.ErrOutOfOrder, "Cannot add log on removed block")
+				require.ErrorIs(t, err, interop.ErrOutOfOrder, "Cannot add log on removed block")
+				require.ErrorIs(t, err, interop.ErrOutOfOrder, "Cannot add log on removed block")
 				// 15 is older, we have up to 16
 				bl15 := eth.BlockID{Hash: createHash(15), Number: 15}
 				// try to add a third log to 15
 				err = db.AddLog(createHash(10), bl15, 2, nil)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
-				require.ErrorIs(t, err, types.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
+				require.ErrorIs(t, err, interop.ErrOutOfOrder)
 				bl16 := eth.BlockID{Hash: createHash(16), Number: 16}
 				// try to add a log to 17, on top of 16
 				err = db.AddLog(createHash(42), bl16, 0, nil)

--- a/op-supervisor/supervisor/backend/db/logs/entries.go
+++ b/op-supervisor/supervisor/backend/db/logs/entries.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -31,7 +31,7 @@ func newSearchCheckpoint(blockNum uint64, logsSince uint32, timestamp uint64) se
 
 func newSearchCheckpointFromEntry(data Entry) (searchCheckpoint, error) {
 	if data.Type() != TypeSearchCheckpoint {
-		return searchCheckpoint{}, fmt.Errorf("%w: attempting to decode search checkpoint but was type %s", types.ErrDataCorruption, data.Type())
+		return searchCheckpoint{}, fmt.Errorf("%w: attempting to decode search checkpoint but was type %s", interop.ErrDataCorruption, data.Type())
 	}
 	return searchCheckpoint{
 		blockNum:  binary.LittleEndian.Uint64(data[1:9]),
@@ -61,7 +61,7 @@ func newCanonicalHash(hash common.Hash) canonicalHash {
 
 func newCanonicalHashFromEntry(data Entry) (canonicalHash, error) {
 	if data.Type() != TypeCanonicalHash {
-		return canonicalHash{}, fmt.Errorf("%w: attempting to decode canonical hash but was type %s", types.ErrDataCorruption, data.Type())
+		return canonicalHash{}, fmt.Errorf("%w: attempting to decode canonical hash but was type %s", interop.ErrDataCorruption, data.Type())
 	}
 	return newCanonicalHash(common.Hash(data[1:33])), nil
 }
@@ -80,7 +80,7 @@ type initiatingEvent struct {
 
 func newInitiatingEventFromEntry(data Entry) (initiatingEvent, error) {
 	if data.Type() != TypeInitiatingEvent {
-		return initiatingEvent{}, fmt.Errorf("%w: attempting to decode initiating event but was type %s", types.ErrDataCorruption, data.Type())
+		return initiatingEvent{}, fmt.Errorf("%w: attempting to decode initiating event but was type %s", interop.ErrDataCorruption, data.Type())
 	}
 	flags := data[1]
 	return initiatingEvent{
@@ -122,7 +122,7 @@ func newExecChainID(msg messages.ExecutingMessage) (execChainID, error) {
 
 func newExecChainIDFromEntry(data Entry) (execChainID, error) {
 	if data.Type() != TypeExecChainID {
-		return execChainID{}, fmt.Errorf("%w: attempting to decode execChainID but was type %s", types.ErrDataCorruption, data.Type())
+		return execChainID{}, fmt.Errorf("%w: attempting to decode execChainID but was type %s", interop.ErrDataCorruption, data.Type())
 	}
 	return execChainID{
 		chainID: eth.ChainIDFromBytes32([32]byte(data[1:33])),
@@ -155,7 +155,7 @@ func newExecPosition(msg messages.ExecutingMessage) (execPosition, error) {
 
 func newExecPositionFromEntry(data Entry) (execPosition, error) {
 	if data.Type() != TypeExecPosition {
-		return execPosition{}, fmt.Errorf("%w: attempting to decode execPosition but was type %s", types.ErrDataCorruption, data.Type())
+		return execPosition{}, fmt.Errorf("%w: attempting to decode execPosition but was type %s", interop.ErrDataCorruption, data.Type())
 	}
 	return execPosition{
 		blockNum:  binary.LittleEndian.Uint64(data[1:9]),
@@ -185,7 +185,7 @@ func newExecChecksum(checksum messages.MessageChecksum) execChecksum {
 
 func newExecChecksumFromEntry(data Entry) (execChecksum, error) {
 	if data.Type() != TypeExecChecksum {
-		return execChecksum{}, fmt.Errorf("%w: attempting to decode execChecksum but was type %s", types.ErrDataCorruption, data.Type())
+		return execChecksum{}, fmt.Errorf("%w: attempting to decode execChecksum but was type %s", interop.ErrDataCorruption, data.Type())
 	}
 	return newExecChecksum(messages.MessageChecksum(data[1:33])), nil
 }

--- a/op-supervisor/supervisor/backend/db/logs/iterator.go
+++ b/op-supervisor/supervisor/backend/db/logs/iterator.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -43,7 +43,7 @@ type traverseConditionalFn func(state IteratorState) error
 func (i *iterator) End() error {
 	for {
 		_, err := i.next()
-		if errors.Is(err, types.ErrFuture) {
+		if errors.Is(err, interop.ErrFuture) {
 			return nil
 		} else if err != nil {
 			return err
@@ -124,7 +124,7 @@ func (i *iterator) TraverseConditional(fn traverseConditionalFn) error {
 		}
 		if err := fn(&i.current); err != nil {
 			// don't rewind to the snapshot if the error is ErrStop
-			if errors.Is(err, types.ErrStop) {
+			if errors.Is(err, interop.ErrStop) {
 				return err
 			}
 			i.current = snapshot
@@ -139,7 +139,7 @@ func (i *iterator) next() (EntryType, error) {
 	entry, err := i.db.store.Read(index)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			return 0, types.ErrFuture
+			return 0, interop.ErrFuture
 		}
 		return 0, fmt.Errorf("failed to read entry %d: %w", index, err)
 	}

--- a/op-supervisor/supervisor/backend/db/logs/state.go
+++ b/op-supervisor/supervisor/backend/db/logs/state.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -407,13 +407,13 @@ func (l *logContext) SealBlock(parent common.Hash, upd eth.BlockID, timestamp ui
 			return err
 		}
 		if l.blockHash != parent {
-			return fmt.Errorf("%w: cannot apply block %s (parent %s) on top of %s", types.ErrConflict, upd, parent, l.blockHash)
+			return fmt.Errorf("%w: cannot apply block %s (parent %s) on top of %s", interop.ErrConflict, upd, parent, l.blockHash)
 		}
 		if l.blockHash != (common.Hash{}) && l.blockNum+1 != upd.Number {
-			return fmt.Errorf("%w: cannot apply block %d on top of %d", types.ErrConflict, upd.Number, l.blockNum)
+			return fmt.Errorf("%w: cannot apply block %d on top of %d", interop.ErrConflict, upd.Number, l.blockNum)
 		}
 		if l.timestamp > timestamp {
-			return fmt.Errorf("%w: block timestamp %d must be equal or larger than current timestamp %d", types.ErrConflict, timestamp, l.timestamp)
+			return fmt.Errorf("%w: block timestamp %d must be equal or larger than current timestamp %d", interop.ErrConflict, timestamp, l.timestamp)
 		}
 	}
 	l.blockHash = upd.Hash
@@ -430,28 +430,28 @@ func (l *logContext) SealBlock(parent common.Hash, upd eth.BlockID, timestamp ui
 // The parent-block that the log comes after must be applied with ApplyBlock first.
 func (l *logContext) ApplyLog(parentBlock eth.BlockID, logIdx uint32, logHash common.Hash, execMsg *messages.ExecutingMessage) error {
 	if parentBlock == (eth.BlockID{}) {
-		return fmt.Errorf("genesis does not have logs: %w", types.ErrOutOfOrder)
+		return fmt.Errorf("genesis does not have logs: %w", interop.ErrOutOfOrder)
 	}
 	if err := l.inferFull(); err != nil { // ensure we can start applying
 		return err
 	}
 	if !l.hasCompleteBlock() {
 		if l.blockNum == 0 {
-			return fmt.Errorf("%w: should not have logs in block 0", types.ErrOutOfOrder)
+			return fmt.Errorf("%w: should not have logs in block 0", interop.ErrOutOfOrder)
 		} else {
 			return fmt.Errorf("%w: cannot append log before last known block is sealed", errIncompleteBlock)
 		}
 	}
 	// check parent block
 	if l.blockHash != parentBlock.Hash {
-		return fmt.Errorf("%w: log builds on top of block %s, but have block %s", types.ErrOutOfOrder, parentBlock, l.blockHash)
+		return fmt.Errorf("%w: log builds on top of block %s, but have block %s", interop.ErrOutOfOrder, parentBlock, l.blockHash)
 	}
 	if l.blockNum != parentBlock.Number {
-		return fmt.Errorf("%w: log builds on top of block %d, but have block %d", types.ErrOutOfOrder, parentBlock.Number, l.blockNum)
+		return fmt.Errorf("%w: log builds on top of block %d, but have block %d", interop.ErrOutOfOrder, parentBlock.Number, l.blockNum)
 	}
 	// check if log fits on top. The length so far == the index of the next log.
 	if logIdx != l.logsSince {
-		return fmt.Errorf("%w: expected event index %d, cannot append %d", types.ErrOutOfOrder, l.logsSince, logIdx)
+		return fmt.Errorf("%w: expected event index %d, cannot append %d", interop.ErrOutOfOrder, l.logsSince, logIdx)
 	}
 	l.logHash = logHash
 	l.execMsg = execMsg

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -8,13 +8,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
 func (db *ChainsDB) FindSealedBlock(chain eth.ChainID, number uint64) (seal messages.BlockSeal, err error) {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
-		return messages.BlockSeal{}, fmt.Errorf("%w: %v", types.ErrUnknownChain, chain)
+		return messages.BlockSeal{}, fmt.Errorf("%w: %v", interop.ErrUnknownChain, chain)
 	}
 	return logDB.FindSealedBlock(number)
 }
@@ -44,27 +45,27 @@ func (db *ChainsDB) LatestBlockNum(chain eth.ChainID) (num uint64, ok bool) {
 func (db *ChainsDB) IsCrossUnsafe(chainID eth.ChainID, block eth.BlockID) error {
 	xU, ok := db.crossUnsafe.Get(chainID)
 	if !ok {
-		return types.ErrUnknownChain
+		return interop.ErrUnknownChain
 	}
 	crossUnsafe := xU.Get()
 	if crossUnsafe == (messages.BlockSeal{}) {
-		return types.ErrFuture
+		return interop.ErrFuture
 	}
 	if block.Number > crossUnsafe.Number {
-		return types.ErrFuture
+		return interop.ErrFuture
 	}
 	// now we know it's within the cross-unsafe range
 	// check if it's consistent with unsafe data
 	lU, ok := db.logDBs.Get(chainID)
 	if !ok {
-		return types.ErrUnknownChain
+		return interop.ErrUnknownChain
 	}
 	unsafeBlock, err := lU.FindSealedBlock(block.Number)
 	if err != nil {
 		return fmt.Errorf("failed to find sealed block %d: %w", block.Number, err)
 	}
 	if unsafeBlock.ID() != block {
-		return fmt.Errorf("found %s but was looking for unsafe block %s: %w", unsafeBlock.ID(), block, types.ErrConflict)
+		return fmt.Errorf("found %s but was looking for unsafe block %s: %w", unsafeBlock.ID(), block, interop.ErrConflict)
 	}
 	return nil
 }
@@ -72,14 +73,14 @@ func (db *ChainsDB) IsCrossUnsafe(chainID eth.ChainID, block eth.BlockID) error 
 func (db *ChainsDB) IsLocalUnsafe(chainID eth.ChainID, block eth.BlockID) error {
 	logDB, ok := db.logDBs.Get(chainID)
 	if !ok {
-		return types.ErrUnknownChain
+		return interop.ErrUnknownChain
 	}
 	got, err := logDB.FindSealedBlock(block.Number)
 	if err != nil {
 		return err
 	}
 	if got.ID() != block {
-		return fmt.Errorf("found %s but was looking for unsafe block %s: %w", got, block, types.ErrConflict)
+		return fmt.Errorf("found %s but was looking for unsafe block %s: %w", got, block, interop.ErrConflict)
 	}
 	return nil
 }
@@ -87,7 +88,7 @@ func (db *ChainsDB) IsLocalUnsafe(chainID eth.ChainID, block eth.BlockID) error 
 func (db *ChainsDB) IsCrossSafe(chainID eth.ChainID, block eth.BlockID) error {
 	xdb, ok := db.crossDBs.Get(chainID)
 	if !ok {
-		return types.ErrUnknownChain
+		return interop.ErrUnknownChain
 	}
 	return xdb.ContainsDerived(block, types.RevisionAny)
 }
@@ -99,17 +100,17 @@ func (db *ChainsDB) IsCrossSafe(chainID eth.ChainID, block eth.BlockID) error {
 func (db *ChainsDB) findRevision(chainID eth.ChainID, block eth.BlockID) (types.Revision, error) {
 	xdb, ok := db.crossDBs.Get(chainID)
 	if !ok {
-		return types.Revision(0), types.ErrUnknownChain
+		return types.Revision(0), interop.ErrUnknownChain
 	}
 	rev, err := xdb.DerivedToRevision(block)
-	if errors.Is(err, types.ErrFuture) {
+	if errors.Is(err, interop.ErrFuture) {
 		ldb, ok := db.localDBs.Get(chainID)
 		if !ok {
-			return types.Revision(0), types.ErrUnknownChain
+			return types.Revision(0), interop.ErrUnknownChain
 		}
 		rev, err := ldb.LastRevision()
 		// During non-Genesis Interop activation, there may not be any safe data yet.
-		if errors.Is(err, types.ErrFuture) {
+		if errors.Is(err, interop.ErrFuture) {
 			return types.Revision(0), nil
 		}
 		return rev, err
@@ -120,7 +121,7 @@ func (db *ChainsDB) findRevision(chainID eth.ChainID, block eth.BlockID) (types.
 func (db *ChainsDB) IsLocalSafe(chainID eth.ChainID, block eth.BlockID) error {
 	ldb, ok := db.localDBs.Get(chainID)
 	if !ok {
-		return types.ErrUnknownChain
+		return interop.ErrUnknownChain
 	}
 	revision, err := db.findRevision(chainID, block)
 	if err != nil {
@@ -132,7 +133,7 @@ func (db *ChainsDB) IsLocalSafe(chainID eth.ChainID, block eth.BlockID) error {
 func (db *ChainsDB) IsFinalized(chainID eth.ChainID, block eth.BlockID) error {
 	finL1 := db.FinalizedL1()
 	if finL1 == (eth.BlockRef{}) {
-		return types.ErrUninitialized
+		return interop.ErrUninitialized
 	}
 	source, err := db.CrossDerivedToSource(chainID, block)
 	if err != nil {
@@ -141,13 +142,13 @@ func (db *ChainsDB) IsFinalized(chainID eth.ChainID, block eth.BlockID) error {
 	if finL1.Number >= source.Number {
 		return nil
 	}
-	return fmt.Errorf("cross-safe source block is not finalized: %w", types.ErrFuture)
+	return fmt.Errorf("cross-safe source block is not finalized: %w", interop.ErrFuture)
 }
 
 func (db *ChainsDB) LocalSafeDerivedAt(chainID eth.ChainID, source eth.BlockID) (messages.BlockSeal, error) {
 	lDB, ok := db.localDBs.Get(chainID)
 	if !ok {
-		return messages.BlockSeal{}, types.ErrUnknownChain
+		return messages.BlockSeal{}, interop.ErrUnknownChain
 	}
 	derived, err := lDB.SourceToLastDerived(source)
 	if err != nil {
@@ -159,11 +160,11 @@ func (db *ChainsDB) LocalSafeDerivedAt(chainID eth.ChainID, source eth.BlockID) 
 func (db *ChainsDB) LocalUnsafe(chainID eth.ChainID) (messages.BlockSeal, error) {
 	eventsDB, ok := db.logDBs.Get(chainID)
 	if !ok {
-		return messages.BlockSeal{}, types.ErrUnknownChain
+		return messages.BlockSeal{}, interop.ErrUnknownChain
 	}
 	head, ok := eventsDB.LatestSealedBlock()
 	if !ok {
-		return messages.BlockSeal{}, types.ErrFuture
+		return messages.BlockSeal{}, interop.ErrFuture
 	}
 	return eventsDB.FindSealedBlock(head.Number)
 }
@@ -171,7 +172,7 @@ func (db *ChainsDB) LocalUnsafe(chainID eth.ChainID) (messages.BlockSeal, error)
 func (db *ChainsDB) CrossUnsafe(chainID eth.ChainID) (messages.BlockSeal, error) {
 	result, ok := db.crossUnsafe.Get(chainID)
 	if !ok {
-		return messages.BlockSeal{}, types.ErrUnknownChain
+		return messages.BlockSeal{}, interop.ErrUnknownChain
 	}
 	crossUnsafe := result.Get()
 	// Fall back to cross-safe if cross-unsafe is not known yet
@@ -188,7 +189,7 @@ func (db *ChainsDB) CrossUnsafe(chainID eth.ChainID) (messages.BlockSeal, error)
 func (db *ChainsDB) AcceptedBlock(chainID eth.ChainID, id eth.BlockID) error {
 	localDB, ok := db.localDBs.Get(chainID)
 	if !ok {
-		return types.ErrUnknownChain
+		return interop.ErrUnknownChain
 	}
 	revision, err := db.findRevision(chainID, id)
 	if err != nil {
@@ -198,9 +199,9 @@ func (db *ChainsDB) AcceptedBlock(chainID eth.ChainID, id eth.BlockID) error {
 	// If the block is not cross-safe, then the revision will be the latest
 	// (assuming the trailing local-safe data only has 1 revision;
 	//  the same or something net-new exactly starting after cross-safe).
-	// If the block was invalidated, then ContainsDerived will error with types.ErrAwaitReplacementBlock.
+	// If the block was invalidated, then ContainsDerived will error with interop.ErrAwaitReplacementBlock.
 	if err := localDB.ContainsDerived(id, revision); err != nil {
-		if errors.Is(err, types.ErrFuture) {
+		if errors.Is(err, interop.ErrFuture) {
 			return nil // Optimistically accept blocks that we haven't seen as local-derived yet.
 		}
 		return fmt.Errorf("failed to check older local-safe db entry %s: %w", revision, err)
@@ -211,7 +212,7 @@ func (db *ChainsDB) AcceptedBlock(chainID eth.ChainID, id eth.BlockID) error {
 func (db *ChainsDB) LocalSafe(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
 	localDB, ok := db.localDBs.Get(chainID)
 	if !ok {
-		return types.DerivedBlockSealPair{}, types.ErrUnknownChain
+		return types.DerivedBlockSealPair{}, interop.ErrUnknownChain
 	}
 	return localDB.Last()
 }
@@ -219,7 +220,7 @@ func (db *ChainsDB) LocalSafe(chainID eth.ChainID) (pair types.DerivedBlockSealP
 func (db *ChainsDB) CrossSafe(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
 	crossDB, ok := db.crossDBs.Get(chainID)
 	if !ok {
-		return types.DerivedBlockSealPair{}, types.ErrUnknownChain
+		return types.DerivedBlockSealPair{}, interop.ErrUnknownChain
 	}
 	return crossDB.Last()
 }
@@ -231,13 +232,13 @@ func (db *ChainsDB) FinalizedL1() eth.BlockRef {
 func (db *ChainsDB) Finalized(chainID eth.ChainID) (messages.BlockSeal, error) {
 	finalizedL1 := db.finalizedL1.Get()
 	if finalizedL1 == (eth.L1BlockRef{}) {
-		return messages.BlockSeal{}, fmt.Errorf("no finalized L1 signal, cannot determine L2 finality of chain %s yet: %w", chainID, types.ErrFuture)
+		return messages.BlockSeal{}, fmt.Errorf("no finalized L1 signal, cannot determine L2 finality of chain %s yet: %w", chainID, interop.ErrFuture)
 	}
 
 	// compare the finalized L1 block with the last derived block in the cross DB
 	xDB, ok := db.crossDBs.Get(chainID)
 	if !ok {
-		return messages.BlockSeal{}, types.ErrUnknownChain
+		return messages.BlockSeal{}, interop.ErrUnknownChain
 	}
 	latest, err := xDB.Last()
 	if err != nil {
@@ -267,7 +268,7 @@ func (db *ChainsDB) Finalized(chainID eth.ChainID) (messages.BlockSeal, error) {
 func (db *ChainsDB) CrossDerivedToSourceRef(chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error) {
 	xdb, ok := db.crossDBs.Get(chainID)
 	if !ok {
-		return eth.BlockRef{}, types.ErrUnknownChain
+		return eth.BlockRef{}, interop.ErrUnknownChain
 	}
 	res, err := xdb.DerivedToFirstSource(derived, types.RevisionAny)
 	if err != nil {
@@ -276,7 +277,7 @@ func (db *ChainsDB) CrossDerivedToSourceRef(chainID eth.ChainID, derived eth.Blo
 	parent, err := xdb.PreviousSource(res.ID())
 	// if we are working with the first item in the database, PreviousSource will return ErrPreviousToFirst
 	// in which case we can attach a zero parent to the block, as the parent block is unknown
-	if errors.Is(err, types.ErrPreviousToFirst) {
+	if errors.Is(err, interop.ErrPreviousToFirst) {
 		return res.ForceWithParent(eth.BlockID{}), nil
 	} else if err != nil {
 		return eth.BlockRef{}, err
@@ -289,7 +290,7 @@ func (db *ChainsDB) CrossDerivedToSourceRef(chainID eth.ChainID, derived eth.Blo
 func (db *ChainsDB) Contains(chain eth.ChainID, q messages.ContainsQuery) (includedIn messages.BlockSeal, err error) {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
-		return messages.BlockSeal{}, fmt.Errorf("%w: %v", types.ErrUnknownChain, chain)
+		return messages.BlockSeal{}, fmt.Errorf("%w: %v", interop.ErrUnknownChain, chain)
 	}
 	return logDB.Contains(q)
 }
@@ -299,7 +300,7 @@ func (db *ChainsDB) Contains(chain eth.ChainID, q messages.ContainsQuery) (inclu
 func (db *ChainsDB) OpenBlock(chainID eth.ChainID, blockNum uint64) (seal eth.BlockRef, logCount uint32, execMsgs map[uint32]*messages.ExecutingMessage, err error) {
 	logDB, ok := db.logDBs.Get(chainID)
 	if !ok {
-		return eth.BlockRef{}, 0, nil, types.ErrUnknownChain
+		return eth.BlockRef{}, 0, nil, interop.ErrUnknownChain
 	}
 	return logDB.OpenBlock(blockNum)
 }
@@ -309,7 +310,7 @@ func (db *ChainsDB) OpenBlock(chainID eth.ChainID, blockNum uint64) (seal eth.Bl
 func (db *ChainsDB) LocalDerivedToSource(chain eth.ChainID, derived eth.BlockID) (source messages.BlockSeal, err error) {
 	lDB, ok := db.localDBs.Get(chain)
 	if !ok {
-		return messages.BlockSeal{}, types.ErrUnknownChain
+		return messages.BlockSeal{}, interop.ErrUnknownChain
 	}
 	revision, err := db.findRevision(chain, derived)
 	if err != nil {
@@ -323,7 +324,7 @@ func (db *ChainsDB) LocalDerivedToSource(chain eth.ChainID, derived eth.BlockID)
 func (db *ChainsDB) CrossDerivedToSource(chain eth.ChainID, derived eth.BlockID) (source messages.BlockSeal, err error) {
 	xDB, ok := db.crossDBs.Get(chain)
 	if !ok {
-		return messages.BlockSeal{}, types.ErrUnknownChain
+		return messages.BlockSeal{}, interop.ErrUnknownChain
 	}
 	return xDB.DerivedToFirstSource(derived, types.RevisionAny)
 }
@@ -340,16 +341,16 @@ func (db *ChainsDB) CrossDerivedToSource(chain eth.ChainID, derived eth.BlockID)
 func (db *ChainsDB) CandidateCrossSafe(chain eth.ChainID) (result types.DerivedBlockRefPair, err error) {
 	xDB, ok := db.crossDBs.Get(chain)
 	if !ok {
-		return types.DerivedBlockRefPair{}, types.ErrUnknownChain
+		return types.DerivedBlockRefPair{}, interop.ErrUnknownChain
 	}
 
 	lDB, ok := db.localDBs.Get(chain)
 	if !ok {
-		return types.DerivedBlockRefPair{}, types.ErrUnknownChain
+		return types.DerivedBlockRefPair{}, interop.ErrUnknownChain
 	}
 	crossSafe, err := xDB.Last()
 	if err != nil {
-		if errors.Is(err, types.ErrFuture) {
+		if errors.Is(err, interop.ErrFuture) {
 			// If we do not have any cross-safe block yet, then return the first local-safe block.
 			first, err := lDB.First()
 			if err != nil {
@@ -385,7 +386,7 @@ func (db *ChainsDB) CandidateCrossSafe(chain eth.ChainID) (result types.DerivedB
 
 	if candidate.Source.Number < crossSafe.Source.Number {
 		db.logger.Error("Candidate block has lower source", "crossSafe", crossSafe, "candidate", candidate)
-		return candidate, types.ErrDataCorruption
+		return candidate, interop.ErrDataCorruption
 	}
 	return candidate, nil
 }
@@ -393,7 +394,7 @@ func (db *ChainsDB) CandidateCrossSafe(chain eth.ChainID) (result types.DerivedB
 func (db *ChainsDB) PreviousCrossDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived messages.BlockSeal, err error) {
 	xDB, ok := db.crossDBs.Get(chain)
 	if !ok {
-		return messages.BlockSeal{}, types.ErrUnknownChain
+		return messages.BlockSeal{}, interop.ErrUnknownChain
 	}
 	revision, err := db.findRevision(chain, derived)
 	if err != nil {
@@ -405,7 +406,7 @@ func (db *ChainsDB) PreviousCrossDerived(chain eth.ChainID, derived eth.BlockID)
 func (db *ChainsDB) PreviousSource(chain eth.ChainID, source eth.BlockID) (prevSource messages.BlockSeal, err error) {
 	lDB, ok := db.localDBs.Get(chain)
 	if !ok {
-		return messages.BlockSeal{}, types.ErrUnknownChain
+		return messages.BlockSeal{}, interop.ErrUnknownChain
 	}
 	return lDB.PreviousSource(source)
 }
@@ -413,7 +414,7 @@ func (db *ChainsDB) PreviousSource(chain eth.ChainID, source eth.BlockID) (prevS
 func (db *ChainsDB) NextSource(chain eth.ChainID, source eth.BlockID) (after eth.BlockRef, err error) {
 	lDB, ok := db.localDBs.Get(chain)
 	if !ok {
-		return eth.BlockRef{}, types.ErrUnknownChain
+		return eth.BlockRef{}, interop.ErrUnknownChain
 	}
 	v, err := lDB.NextSource(source)
 	if err != nil {
@@ -425,7 +426,7 @@ func (db *ChainsDB) NextSource(chain eth.ChainID, source eth.BlockID) (after eth
 func (db *ChainsDB) IteratorStartingAt(chain eth.ChainID, sealedNum uint64, logIndex uint32) (logs.Iterator, error) {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
-		return nil, fmt.Errorf("%w: %v", types.ErrUnknownChain, chain)
+		return nil, fmt.Errorf("%w: %v", interop.ErrUnknownChain, chain)
 	}
 	return logDB.IteratorStartingAt(sealedNum, logIndex)
 }
@@ -434,7 +435,7 @@ func (db *ChainsDB) IteratorStartingAt(chain eth.ChainID, sealedNum uint64, logI
 func (db *ChainsDB) AnchorPoint(chainID eth.ChainID) (types.DerivedBlockSealPair, error) {
 	xdb, ok := db.crossDBs.Get(chainID)
 	if !ok {
-		return types.DerivedBlockSealPair{}, types.ErrUnknownChain
+		return types.DerivedBlockSealPair{}, interop.ErrUnknownChain
 	}
 	return xdb.First()
 }

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -22,7 +23,7 @@ func (db *ChainsDB) AddLog(
 ) error {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
-		return fmt.Errorf("cannot AddLog: %w: %v", types.ErrUnknownChain, chain)
+		return fmt.Errorf("cannot AddLog: %w: %v", interop.ErrUnknownChain, chain)
 	}
 	return logDB.AddLog(logHash, parentBlock, logIdx, execMsg)
 }
@@ -36,10 +37,10 @@ func (db *ChainsDB) SealBlock(chain eth.ChainID, block eth.BlockRef) error {
 func (db *ChainsDB) sealBlock(chain eth.ChainID, block eth.BlockRef, mayInit bool) error {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
-		return fmt.Errorf("cannot SealBlock: %w: %v", types.ErrUnknownChain, chain)
+		return fmt.Errorf("cannot SealBlock: %w: %v", interop.ErrUnknownChain, chain)
 	}
 	if !mayInit && logDB.IsEmpty() {
-		return fmt.Errorf("cannot SealBlock on uninitialized database: %w", types.ErrUninitialized)
+		return fmt.Errorf("cannot SealBlock on uninitialized database: %w", interop.ErrUninitialized)
 	}
 	err := logDB.SealBlock(block.ParentHash, block.ID(), block.Time)
 	if err != nil {
@@ -58,7 +59,7 @@ func (db *ChainsDB) Rewind(chain eth.ChainID, headBlock eth.BlockID) error {
 	// Rewind the logDB
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
-		return fmt.Errorf("cannot Rewind: %w: %s", types.ErrUnknownChain, chain)
+		return fmt.Errorf("cannot Rewind: %w: %s", interop.ErrUnknownChain, chain)
 	}
 	if err := logDB.Rewind(db.readRegistry, headBlock); err != nil {
 		return fmt.Errorf("failed to rewind to block %v: %w", headBlock, err)
@@ -66,11 +67,11 @@ func (db *ChainsDB) Rewind(chain eth.ChainID, headBlock eth.BlockID) error {
 
 	localDB, ok := db.localDBs.Get(chain)
 	if !ok {
-		return fmt.Errorf("cannot Rewind (localDB not found): %w: %s", types.ErrUnknownChain, chain)
+		return fmt.Errorf("cannot Rewind (localDB not found): %w: %s", interop.ErrUnknownChain, chain)
 	}
 	crossDB, ok := db.crossDBs.Get(chain)
 	if !ok {
-		return fmt.Errorf("cannot Rewind (crossDB not found): %w: %s", types.ErrUnknownChain, chain)
+		return fmt.Errorf("cannot Rewind (crossDB not found): %w: %s", interop.ErrUnknownChain, chain)
 	}
 
 	revision, err := crossDB.DerivedToRevision(headBlock)
@@ -108,11 +109,11 @@ func (db *ChainsDB) initializedUpdateLocalSafe(chain eth.ChainID, source eth.Blo
 	}
 	logger.Debug("Updating local safe DB")
 	if err := localDB.AddDerived(source, lastDerived, types.RevisionAny); err != nil {
-		if errors.Is(err, types.ErrIneffective) {
+		if errors.Is(err, interop.ErrIneffective) {
 			logger.Info("Node is syncing known source blocks on known latest local-safe block", "err", err)
 			return
 		}
-		if errors.Is(err, types.ErrDataCorruption) {
+		if errors.Is(err, interop.ErrDataCorruption) {
 			logger.Error("DB coruption occurred", "err", err)
 			return
 		}
@@ -139,7 +140,7 @@ func (db *ChainsDB) initializedUpdateLocalSafe(chain eth.ChainID, source eth.Blo
 func (db *ChainsDB) UpdateCrossUnsafe(chain eth.ChainID, crossUnsafe messages.BlockSeal) error {
 	v, ok := db.crossUnsafe.Get(chain)
 	if !ok {
-		return fmt.Errorf("cannot UpdateCrossUnsafe: %w: %s", types.ErrUnknownChain, chain)
+		return fmt.Errorf("cannot UpdateCrossUnsafe: %w: %s", interop.ErrUnknownChain, chain)
 	}
 	// Cross unsafe is stateless, fine to always update to latest value.
 	// Also allows to already track it during Interop activation phase when the safe chain hasn't
@@ -156,7 +157,7 @@ func (db *ChainsDB) UpdateCrossUnsafe(chain eth.ChainID, crossUnsafe messages.Bl
 
 func (db *ChainsDB) UpdateCrossSafe(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
 	if !db.isInitialized(chain) {
-		return fmt.Errorf("cannot UpdateCrossSafe on uninitialized database: %w", types.ErrUninitialized)
+		return fmt.Errorf("cannot UpdateCrossSafe on uninitialized database: %w", interop.ErrUninitialized)
 	}
 	return db.initializedUpdateCrossSafe(chain, l1View, lastCrossDerived)
 }
@@ -164,11 +165,11 @@ func (db *ChainsDB) UpdateCrossSafe(chain eth.ChainID, l1View eth.BlockRef, last
 func (db *ChainsDB) initializedUpdateCrossSafe(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
 	crossDB, ok := db.crossDBs.Get(chain)
 	if !ok {
-		return fmt.Errorf("cannot UpdateCrossSafe, no cross-safe DB: %w: %s", types.ErrUnknownChain, chain)
+		return fmt.Errorf("cannot UpdateCrossSafe, no cross-safe DB: %w: %s", interop.ErrUnknownChain, chain)
 	}
 	localDB, ok := db.localDBs.Get(chain)
 	if !ok {
-		return fmt.Errorf("cannot UpdateCrossSafe, no local-safe DB: %w: %s", types.ErrUnknownChain, chain)
+		return fmt.Errorf("cannot UpdateCrossSafe, no local-safe DB: %w: %s", interop.ErrUnknownChain, chain)
 	}
 	// local DB here already has the new block, incl. replacement data, to sync with the cross-db
 	revision, err := localDB.SourceToRevision(l1View.ID())
@@ -248,11 +249,11 @@ func (db *ChainsDB) InvalidateLocalSafe(chainID eth.ChainID, candidate types.Der
 	// Get databases to invalidate data in.
 	eventsDB, ok := db.logDBs.Get(chainID)
 	if !ok {
-		return fmt.Errorf("cannot find events DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
+		return fmt.Errorf("cannot find events DB of chain %s for invalidation: %w", chainID, interop.ErrUnknownChain)
 	}
 	localSafeDB, ok := db.localDBs.Get(chainID)
 	if !ok {
-		return fmt.Errorf("cannot find local-safe DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
+		return fmt.Errorf("cannot find local-safe DB of chain %s for invalidation: %w", chainID, interop.ErrUnknownChain)
 	}
 
 	// Now invalidate the local-safe data.
@@ -290,7 +291,7 @@ func (db *ChainsDB) InvalidateLocalSafe(chainID eth.ChainID, candidate types.Der
 func (db *ChainsDB) RewindLocalSafeSource(chainID eth.ChainID, source eth.BlockID) error {
 	localSafeDB, ok := db.localDBs.Get(chainID)
 	if !ok {
-		return fmt.Errorf("cannot find local-safe DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
+		return fmt.Errorf("cannot find local-safe DB of chain %s for invalidation: %w", chainID, interop.ErrUnknownChain)
 	}
 	if err := localSafeDB.RewindToSource(db.readRegistry, source); err != nil {
 		return fmt.Errorf("failed to rewind local-safe: %w", err)
@@ -305,7 +306,7 @@ func (db *ChainsDB) RewindLocalSafeSource(chainID eth.ChainID, source eth.BlockI
 func (db *ChainsDB) RewindCrossSafeSource(chainID eth.ChainID, source eth.BlockID) error {
 	crossSafeDB, ok := db.crossDBs.Get(chainID)
 	if !ok {
-		return fmt.Errorf("cannot find cross-safe DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
+		return fmt.Errorf("cannot find cross-safe DB of chain %s for invalidation: %w", chainID, interop.ErrUnknownChain)
 	}
 	if err := crossSafeDB.RewindToSource(db.readRegistry, source); err != nil {
 		return fmt.Errorf("failed to rewind cross-safe: %w", err)
@@ -316,7 +317,7 @@ func (db *ChainsDB) RewindCrossSafeSource(chainID eth.ChainID, source eth.BlockI
 func (db *ChainsDB) RewindLogs(chainID eth.ChainID, newHead messages.BlockSeal) error {
 	eventsDB, ok := db.logDBs.Get(chainID)
 	if !ok {
-		return fmt.Errorf("cannot find events DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
+		return fmt.Errorf("cannot find events DB of chain %s for invalidation: %w", chainID, interop.ErrUnknownChain)
 	}
 	if err := eventsDB.Rewind(db.readRegistry, newHead.ID()); err != nil {
 		return fmt.Errorf("failed to rewind logs of chain %s: %w", chainID, err)
@@ -333,7 +334,7 @@ func (db *ChainsDB) ResetCrossUnsafeIfNewerThan(chainID eth.ChainID, number uint
 
 	crossSafeDB, ok := db.crossDBs.Get(chainID)
 	if !ok {
-		return fmt.Errorf("cannot find cross-safe DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
+		return fmt.Errorf("cannot find cross-safe DB of chain %s for invalidation: %w", chainID, interop.ErrUnknownChain)
 	}
 	crossSafe, err := crossSafeDB.Last()
 	if err != nil {

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -14,10 +14,10 @@ import (
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 type Source interface {
@@ -156,7 +156,7 @@ func (s *ChainProcessor) index() {
 	if err != nil {
 		if errors.Is(err, ethereum.NotFound) {
 			s.log.Debug("indexer cannot find next block yet", "target", target, "err", err)
-		} else if errors.Is(err, types.ErrNoRPCSource) {
+		} else if errors.Is(err, interop.ErrNoRPCSource) {
 			s.log.Warn("No RPC source configured, cannot process new blocks")
 		} else {
 			s.log.Error("Failed to index blocks", "err", err)
@@ -214,7 +214,7 @@ func (s *ChainProcessor) rangeUpdate(target uint64) (int, error) {
 	s.clientLock.Lock()
 	defer s.clientLock.Unlock()
 	if len(s.clients) == 0 {
-		return 0, types.ErrNoRPCSource
+		return 0, interop.ErrNoRPCSource
 	}
 
 	// define the range of blocks to fetch

--- a/op-supervisor/supervisor/backend/reads/full.go
+++ b/op-supervisor/supervisor/backend/reads/full.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum/go-ethereum/log"
-
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 // readHandle maintains a lower and upper range view over a chain.
@@ -84,12 +83,12 @@ func (h *readHandle) invalidateSource(blockNum uint64) {
 
 var _ Handle = (*readHandle)(nil)
 
-// Err is a convenience method to return a types.ErrInvalidatedRead whenever the read handle is not valid
+// Err is a convenience method to return a interop.ErrInvalidatedRead whenever the read handle is not valid
 func (h *readHandle) Err() error {
 	if h.IsValid() {
 		return nil
 	}
-	return types.ErrInvalidatedRead
+	return interop.ErrInvalidatedRead
 }
 
 // IsValid inspects the dependencies we have seen so far, and the invalidations we have seen,
@@ -163,7 +162,7 @@ func (r *Registry) TryInvalidate(rule InvalidationRule) (release func(), err err
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.invalidating != nil {
-		return nil, types.ErrAlreadyInvalidatingRead
+		return nil, interop.ErrAlreadyInvalidatingRead
 	}
 	r.invalidating = rule
 	for handle := range r.activeHandles { // invalidate all existing handles

--- a/op-supervisor/supervisor/backend/reads/full_test.go
+++ b/op-supervisor/supervisor/backend/reads/full_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 func TestReadHandles(t *testing.T) {
@@ -64,7 +64,7 @@ func TestReadHandles(t *testing.T) {
 		require.False(t, h.IsValid(), "affected by invalidation before release")
 		h.Release()
 		require.False(t, h.IsValid(), "still considered invalid after release")
-		require.ErrorIs(t, h.Err(), types.ErrInvalidatedRead, "err helper works")
+		require.ErrorIs(t, h.Err(), interop.ErrInvalidatedRead, "err helper works")
 	})
 	t.Run("invalidated two", func(t *testing.T) {
 		reg := newRegistry(t)
@@ -135,7 +135,7 @@ func TestReadHandles(t *testing.T) {
 		release1, err := reg.TryInvalidate(SourceInvalidation{100})
 		require.NoError(t, err)
 		_, err = reg.TryInvalidate(SourceInvalidation{200})
-		require.ErrorIs(t, err, types.ErrAlreadyInvalidatingRead)
+		require.ErrorIs(t, err, interop.ErrAlreadyInvalidatingRead)
 		release1()
 	})
 	t.Run("no valid reads while invalidating", func(t *testing.T) {

--- a/op-supervisor/supervisor/backend/reads/iface.go
+++ b/op-supervisor/supervisor/backend/reads/iface.go
@@ -9,7 +9,7 @@ type Handle interface {
 	// updating the current range if needed.
 	DependOnSourceBlock(blockNum uint64)
 
-	// Err is a convenience method to return a types.ErrInvalidatedRead whenever the read handle is not valid
+	// Err is a convenience method to return a interop.ErrInvalidatedRead whenever the read handle is not valid
 	Err() error
 
 	// IsValid inspects the dependencies we have seen so far, and the invalidations we have seen,

--- a/op-supervisor/supervisor/backend/reads/noop.go
+++ b/op-supervisor/supervisor/backend/reads/noop.go
@@ -1,8 +1,6 @@
 package reads
 
-import (
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
-)
+import "github.com/ethereum-optimism/optimism/op-core/interop"
 
 // NoopHandle implements Handle without offering actual protection.
 // This can be used when access is known to be synchronous and safe.
@@ -64,7 +62,7 @@ func (i InvalidHandle) invalidateSource(blockNum uint64) {
 }
 
 func (i InvalidHandle) Err() error {
-	return types.ErrInvalidatedRead
+	return interop.ErrInvalidatedRead
 }
 
 func (i InvalidHandle) IsValid() bool {

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
@@ -113,7 +114,7 @@ func (r *Rewinder) handleLocalDerivedEvent(ev superevents.LocalSafeUpdateEvent) 
 	// until we find a common ancestor or reach the finalized block
 	finalized, err := r.db.Finalized(ev.ChainID)
 	if err != nil {
-		if errors.Is(err, types.ErrFuture) {
+		if errors.Is(err, interop.ErrFuture) {
 			finalized = messages.BlockSeal{Number: 0}
 		} else {
 			r.log.Error("failed to get finalized block", "chain", ev.ChainID, "err", err)
@@ -131,7 +132,7 @@ func (r *Rewinder) handleLocalDerivedEvent(ev superevents.LocalSafeUpdateEvent) 
 
 		_, err := r.db.LocalDerivedToSource(ev.ChainID, target.ID())
 		if err != nil {
-			if errors.Is(err, types.ErrConflict) || errors.Is(err, types.ErrFuture) {
+			if errors.Is(err, interop.ErrConflict) || errors.Is(err, interop.ErrFuture) {
 				continue
 			}
 
@@ -176,7 +177,7 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 	finalized, err := r.db.Finalized(chainID)
 	if err != nil {
 		// If we don't have a finalized block, use the genesis block
-		if errors.Is(err, types.ErrFuture) {
+		if errors.Is(err, interop.ErrFuture) {
 			finalized, err = r.db.FindSealedBlock(chainID, 0)
 			if err != nil {
 				return fmt.Errorf("failed to get index 0 block for chain %s: %w", chainID, err)
@@ -215,7 +216,7 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 		prevSource, err := r.db.PreviousSource(chainID, currentL1)
 		if err != nil {
 			// If we hit the first block, use it as common ancestor
-			if errors.Is(err, types.ErrPreviousToFirst) {
+			if errors.Is(err, interop.ErrPreviousToFirst) {
 				// Still need to verify this block is canonical
 				remoteFirst, err := r.l1Node.L1BlockRefByNumber(context.Background(), currentL1.Number)
 				if err != nil {
@@ -238,7 +239,7 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 
 	// Rewind LocalSafe to not include data derived from the old L1 chain
 	if err := r.db.RewindLocalSafeSource(chainID, commonL1Ancestor); err != nil {
-		if errors.Is(err, types.ErrFuture) {
+		if errors.Is(err, interop.ErrFuture) {
 			r.log.Warn("Rewinding on L1 reorg, but local-safe DB does not have L1 block", "block", commonL1Ancestor, "err", err)
 		} else {
 			return fmt.Errorf("failed to rewind local-safe for chain %s: %w", chainID, err)
@@ -247,7 +248,7 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 
 	// Rewind CrossSafe to not include data derived from the old L1 chain
 	if err := r.db.RewindCrossSafeSource(chainID, commonL1Ancestor); err != nil {
-		if errors.Is(err, types.ErrFuture) {
+		if errors.Is(err, interop.ErrFuture) {
 			r.log.Warn("Rewinding on L1 reorg, but cross-safe DB does not have L1 block", "block", commonL1Ancestor, "err", err)
 		} else {
 			return fmt.Errorf("failed to rewind cross-safe for chain %s: %w", chainID, err)

--- a/op-supervisor/supervisor/backend/syncnode/controller.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-service/locks"

--- a/op-supervisor/supervisor/backend/syncnode/controller.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-service/locks"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 // SyncNodesController manages a collection of active sync nodes.
@@ -67,7 +67,7 @@ func (snc *SyncNodesController) Close() error {
 // If noSubscribe, the node is not actively polled/subscribed to, and requires manual ManagedNode.PullEvents calls.
 func (snc *SyncNodesController) AttachNodeController(chainID eth.ChainID, ctrl SyncControl, noSubscribe bool) (Node, error) {
 	if !snc.depSet.HasChain(chainID) {
-		return nil, fmt.Errorf("chain %v not in dependency set: %w", chainID, types.ErrUnknownChain)
+		return nil, fmt.Errorf("chain %v not in dependency set: %w", chainID, interop.ErrUnknownChain)
 	}
 	// lazy init the controllers map for this chain
 	snc.controllers.CreateIfMissing(chainID, func() *locks.RWMap[*ManagedNode, struct{}] {

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
@@ -284,10 +285,10 @@ func (m *ManagedNode) onResetEvent(errStr string) {
 
 func (m *ManagedNode) onUpdateLocalSafeFailed(ev superevents.UpdateLocalSafeFailedEvent) {
 	switch {
-	case errors.Is(ev.Err, types.ErrConflict):
+	case errors.Is(ev.Err, interop.ErrConflict):
 		m.log.Warn("DB indicated a conflict with this node, checking if node is inconsistent")
 		m.resetIfInconsistent()
-	case errors.Is(ev.Err, types.ErrFuture):
+	case errors.Is(ev.Err, interop.ErrFuture):
 		m.log.Warn("DB indicated this node provided an update from the future, checking if node is ahead")
 		m.resetIfAhead()
 	}
@@ -449,7 +450,7 @@ func (m *ManagedNode) resetIfInconsistent() {
 	if localSafeMatchErr == nil {
 		return
 	}
-	if errors.Is(localSafeMatchErr, types.ErrFuture) {
+	if errors.Is(localSafeMatchErr, interop.ErrFuture) {
 		m.log.Debug("node is ahead of op-supervisor local-safe data")
 		return // resetIfAhead will handle this
 	}
@@ -473,7 +474,7 @@ func (m *ManagedNode) resetIfAhead() {
 
 	// get the last local safe block
 	lastDBLocalSafe, err := m.backend.LocalSafe(ctx, m.chainID)
-	if errors.Is(err, types.ErrFuture) {
+	if errors.Is(err, interop.ErrFuture) {
 		m.log.Info("no activation block yet, initiating pre-Interop reset")
 		m.emitter.Emit(m.ctx, superevents.ResetPreInteropRequestEvent{ChainID: m.chainID})
 		return
@@ -500,7 +501,7 @@ func (m *ManagedNode) resetFullRange() {
 	internalCtx, iCancel := context.WithTimeout(m.ctx, internalTimeout)
 	defer iCancel()
 	dbLast, err := m.backend.LocalSafe(internalCtx, m.chainID)
-	if errors.Is(err, types.ErrFuture) {
+	if errors.Is(err, interop.ErrFuture) {
 		m.log.Info("no activation block yet, initiating pre-Interop reset")
 		m.emitter.Emit(m.ctx, superevents.ResetPreInteropRequestEvent{
 			ChainID: m.chainID})

--- a/op-supervisor/supervisor/backend/syncnode/reset.go
+++ b/op-supervisor/supervisor/backend/syncnode/reset.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 // managedNodeResetBackend is a shim to pass to the resetTracker to let it
@@ -58,7 +58,7 @@ func (m *ManagedNode) initiateReset(z eth.BlockID) {
 	defer m.resetCancel()
 
 	start, err := m.backend.ActivationBlock(ctx, m.chainID)
-	if errors.Is(err, types.ErrFuture) {
+	if errors.Is(err, interop.ErrFuture) {
 		m.log.Info("no activation block yet, initiating pre-Interop reset", "err", err)
 		m.emitter.Emit(m.ctx, superevents.ResetPreInteropRequestEvent{ChainID: m.chainID})
 		return
@@ -129,7 +129,7 @@ func (t *ManagedNode) resetHeadsFromTarget(ctx context.Context, target eth.Block
 
 	// finalized
 	lastFinalized, err := t.backend.Finalized(iCtx, t.chainID)
-	if errors.Is(err, types.ErrFuture) {
+	if errors.Is(err, interop.ErrFuture) {
 		t.log.Warn("finalized block is not yet known", "err", err)
 		lastFinalized = eth.BlockID{}
 	} else if err != nil {

--- a/op-supervisor/supervisor/backend/syncnode/reset_tracker.go
+++ b/op-supervisor/supervisor/backend/syncnode/reset_tracker.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/binary"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -115,7 +115,7 @@ func (t *resetTracker) bisect(ctx context.Context) error {
 	}
 
 	// Check if the block at i is consistent with the local-safe DB,
-	if err = t.backend.IsLocalSafe(internalCtx, nodeI); errors.Is(err, types.ErrFuture) || errors.Is(err, types.ErrConflict) {
+	if err = t.backend.IsLocalSafe(internalCtx, nodeI); errors.Is(err, interop.ErrFuture) || errors.Is(err, interop.ErrConflict) {
 		// TODO: do we need to add more sentinel errors here?
 		t.log.Debug("midpoint of range is inconsistent. pulling back end of range", "i", i)
 		t.z = nodeI

--- a/op-supervisor/supervisor/backend/syncnode/reset_tracker_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/reset_tracker_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -47,9 +47,9 @@ func (m *mockResetBackend) IsLocalSafe(ctx context.Context, block eth.BlockID) e
 		if safeBlock == block {
 			return nil
 		}
-		return types.ErrConflict
+		return interop.ErrConflict
 	}
-	return types.ErrFuture
+	return interop.ErrFuture
 }
 
 func (m *mockResetBackend) L2BlockRefByNumber(ctx context.Context, n uint64) (eth.L2BlockRef, error) {

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -161,7 +162,7 @@ func (rs *RPCSyncNode) AnchorPoint(ctx context.Context) (types.DerivedBlockRefPa
 	// -39003 is the RPC error code op-node previously used to signal interop-inactive.
 	// op-node no longer serves this endpoint; op-supervisor is slated for removal.
 	if errors.As(err, &jsonErr) && jsonErr.ErrorCode() == -39003 {
-		return types.DerivedBlockRefPair{}, types.ErrFuture
+		return types.DerivedBlockRefPair{}, interop.ErrFuture
 	}
 	return out, err
 }
@@ -181,13 +182,13 @@ func (rs *RPCSyncNode) Contains(ctx context.Context, query messages.ContainsQuer
 
 	l2BlockRef, err := rs.L2BlockRefByNumber(ctx, query.BlockNum)
 	if err != nil {
-		return messages.BlockSeal{}, types.ErrFuture
+		return messages.BlockSeal{}, interop.ErrFuture
 	}
 	blockRef := l2BlockRef.BlockRef()
 
 	log, err := rs.getLogAtIndex(ctx, blockRef.Hash, query.LogIdx)
 	if err != nil {
-		return messages.BlockSeal{}, types.ErrConflict
+		return messages.BlockSeal{}, interop.ErrConflict
 	}
 
 	logHash := processors.LogToLogHash(log)
@@ -199,7 +200,7 @@ func (rs *RPCSyncNode) Contains(ctx context.Context, query messages.ContainsQuer
 		LogHash:     logHash,
 	}.Checksum()
 	if entryChecksum != query.Checksum {
-		return messages.BlockSeal{}, types.ErrConflict
+		return messages.BlockSeal{}, interop.ErrConflict
 	}
 
 	return messages.BlockSeal{

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
@@ -31,7 +32,7 @@ func (q *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []comm
 	err := q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
 	if err != nil {
 		return &rpc.JsonError{
-			Code:    types.GetErrorCode(err),
+			Code:    interop.GetErrorCode(err),
 			Message: err.Error(),
 		}
 	}


### PR DESCRIPTION
Moves the interop result vocabulary (`ErrFuture`, `ErrConflict`, `ErrSkipped`, `ErrOutOfOrder`, `ErrDataCorruption`, `ErrAwaitReplacementBlock`, `GetErrorCode`, …) out of `op-supervisor/supervisor/types` into the top-level `op-core/interop` package. These sentinels are used across op-supervisor, op-interop-filter, op-supernode (activity tracker and raftwallogdb), and op-program (FPP consolidation), so they don't belong in op-supervisor.

`op-supervisor/supervisor/types/error.go` is deleted; the content lives inline in `op-core/interop/interop.go`.

Net result: `op-supernode/.../raftwallogdb` no longer imports any op-supervisor package.