### PR TITLE
circleci: migrate fuzz-golang to medium.gen2 (W4 pilot)

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1614,7 +1614,7 @@ jobs:
         default: false
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless


### PR DESCRIPTION
## Summary

Migrates the `fuzz-golang` job definition in `.circleci/continue/main.yml` from `xlarge` (Gen1) to `medium.gen2`. First W4 PR — see ethereum-optimism/core-team#2564.

## Change

| Job | Workflows | Current | Proposed |
|---|---|---|---|
| `fuzz-golang` | `main` (6 matrix variants) | `xlarge` (8 vCPU / 16 GB, Gen1) | `medium.gen2` (2 vCPU / 4 GB, Gen2) |

All six matrix variants — `op-challenger`, `op-node`, `op-service`, `op-chain-ops`, `cannon`, `op-e2e` — share this job def and inherit the new class.

## Rationale

Cost-perf model and CircleCI's utilization analysis agree on `medium.gen2`. Across all six matrix variants, peak CPU translates to **~0.95 vCPU absolute** and peak RAM to **~0.40 GB absolute** (CircleCI telemetry × 1.5 safety factor). `medium.gen2` (2 vCPU / 4 GB) clears both constraints with substantial headroom; Gen2 speedup (~1.4×) further offsets the per-minute rate difference.

## Validation

- Image base `cimg/base:2026.03` confirmed Gen2-compatible by CircleCI — any existing Docker image works on Gen2.
- Not heavy-fuzz-exposed: `fuzz-golang` is a distinct job def from `contracts-bedrock-heavy-fuzz-nightly`, which remains at `2xlarge`.
- `no_output_timeout: 15m` per matrix run is preserved; any regression past that window will surface as a clean timeout rather than a silent slowdown.

## Rollback

Single-line revert (`resource_class: medium.gen2` → `resource_class: xlarge`). If any variant fails for resource reasons we'll see it in CI and revert.

## Refs

- ethereum-optimism/core-team#2564 (W4 plan)
- W3 audit-style precedent: ethereum-optimism/superchain-ops#1429