### PR TITLE
op-service: add op-service interop filter client

### DIFF
--- a/op-service/apis/interop_filter.go
+++ b/op-service/apis/interop_filter.go
@@ -1,0 +1,17 @@
+package apis
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type InteropFilterQueryAPI interface {
+	CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
+		minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error
+	GetBlockHashByNumber(ctx context.Context, chainID eth.ChainID, blockNum rpc.BlockNumber) (common.Hash, error)
+}

--- a/op-service/sources/interop_filter_client.go
+++ b/op-service/sources/interop_filter_client.go
@@ -2,7 +2,9 @@ package sources
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 
@@ -33,6 +35,10 @@ func (cl *InteropFilterClient) CheckAccessList(ctx context.Context, inboxEntries
 func (cl *InteropFilterClient) GetBlockHashByNumber(ctx context.Context, chainID eth.ChainID, blockNum rpc.BlockNumber) (common.Hash, error) {
 	var result common.Hash
 	err := cl.client.CallContext(ctx, &result, "interop_getBlockHashByNumber", chainID, blockNum)
+	if isNotFound(err) {
+		err = fmt.Errorf("%w: %v", ethereum.NotFound, err.Error())
+		return result, err
+	}
 	return result, err
 }
 

--- a/op-service/sources/interop_filter_client.go
+++ b/op-service/sources/interop_filter_client.go
@@ -1,0 +1,41 @@
+package sources
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type InteropFilterClient struct {
+	client client.RPC
+}
+
+// This type-check keeps the Interop Filter server API and client API in sync.
+var _ apis.InteropFilterQueryAPI = (*InteropFilterClient)(nil)
+
+func NewInteropFilterClient(client client.RPC) *InteropFilterClient {
+	return &InteropFilterClient{
+		client: client,
+	}
+}
+
+func (cl *InteropFilterClient) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
+	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
+	return cl.client.CallContext(ctx, nil, "interop_checkAccessList", inboxEntries, minSafety, executingDescriptor)
+}
+
+func (cl *InteropFilterClient) GetBlockHashByNumber(ctx context.Context, chainID eth.ChainID, blockNum rpc.BlockNumber) (common.Hash, error) {
+	var result common.Hash
+	err := cl.client.CallContext(ctx, &result, "interop_getBlockHashByNumber", chainID, blockNum)
+	return result, err
+}
+
+func (cl *InteropFilterClient) Close() {
+	cl.client.Close()
+}

--- a/op-service/sources/interop_filter_client_test.go
+++ b/op-service/sources/interop_filter_client_test.go
@@ -1,0 +1,63 @@
+package sources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestInteropFilterClient_CheckAccessList(t *testing.T) {
+	ctx := context.Background()
+	rpcClient := new(mockRPC)
+	defer rpcClient.AssertExpectations(t)
+	client := NewInteropFilterClient(rpcClient)
+
+	inboxEntries := []common.Hash{common.HexToHash("0x01")}
+	minSafety := types.CrossUnsafe
+	execDescriptor := types.ExecutingDescriptor{
+		ChainID:   eth.ChainIDFromUInt64(900),
+		Timestamp: 123,
+	}
+
+	rpcClient.On(
+		"CallContext",
+		ctx,
+		nil,
+		"interop_checkAccessList",
+		[]any{inboxEntries, minSafety, execDescriptor},
+	).Return([]error{nil})
+
+	require.NoError(t, client.CheckAccessList(ctx, inboxEntries, minSafety, execDescriptor))
+}
+
+func TestInteropFilterClient_GetBlockHashByNumber(t *testing.T) {
+	ctx := context.Background()
+	rpcClient := new(mockRPC)
+	defer rpcClient.AssertExpectations(t)
+	client := NewInteropFilterClient(rpcClient)
+
+	chainID := eth.ChainIDFromUInt64(900)
+	blockNum := rpc.BlockNumber(123)
+	expected := common.HexToHash("0x1234")
+
+	rpcClient.On(
+		"CallContext",
+		ctx,
+		new(common.Hash),
+		"interop_getBlockHashByNumber",
+		[]any{chainID, blockNum},
+	).Run(func(args mock.Arguments) {
+		*args[1].(*common.Hash) = expected
+	}).Return([]error{nil})
+
+	actual, err := client.GetBlockHashByNumber(ctx, chainID, blockNum)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}

--- a/op-service/sources/interop_filter_client_test.go
+++ b/op-service/sources/interop_filter_client_test.go
@@ -2,8 +2,10 @@ package sources
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/mock"
@@ -60,4 +62,25 @@ func TestInteropFilterClient_GetBlockHashByNumber(t *testing.T) {
 	actual, err := client.GetBlockHashByNumber(ctx, chainID, blockNum)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
+}
+
+func TestInteropFilterClient_GetBlockHashByNumber_NotFound(t *testing.T) {
+	ctx := context.Background()
+	rpcClient := new(mockRPC)
+	defer rpcClient.AssertExpectations(t)
+	client := NewInteropFilterClient(rpcClient)
+
+	chainID := eth.ChainIDFromUInt64(900)
+	blockNum := rpc.BlockNumber(123)
+
+	rpcClient.On(
+		"CallContext",
+		ctx,
+		new(common.Hash),
+		"interop_getBlockHashByNumber",
+		[]any{chainID, blockNum},
+	).Return([]error{errors.New("block 123 for chain 900: not found")})
+
+	_, err := client.GetBlockHashByNumber(ctx, chainID, blockNum)
+	require.ErrorIs(t, err, ethereum.NotFound)
 }


### PR DESCRIPTION
## Summary

Adds a dedicated `op-service/sources.InteropFilterClient` for the op-interop-filter query RPC surface. The new client calls the `interop_*` namespace methods exposed by the filter:

- `interop_checkAccessList`
- `interop_getBlockHashByNumber`

It also adds an `apis.InteropFilterQueryAPI` interface for the query methods and focused source-client tests.

## Context

`SupervisorClient` is for the `supervisor_*` RPC surface. `op-interop-filter` now exposes its query API under `interop_*`, so it needs its own typed client.

This PR adds that client in `op-service/sources`.

## Validation

- `go test ./op-service/sources -run TestInteropFilterClient -count=1`
- `go test ./op-service/apis ./op-service/sources -run TestInteropFilterClient -count=1`
- `go test ./op-service/sources`
