### PR TITLE
circleci: migrate optimism Tier A jobs to Gen2 (same-size, 41 docker jobs across 3 files)

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -602,7 +602,7 @@ jobs:
     description: "Build a Rust workspace with target directory caching"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     parameters:
       directory:
         description: "Directory containing the Cargo workspace"
@@ -669,7 +669,7 @@ jobs:
   rust-build-vendored:
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     parameters:
       directory:
         description: "Directory containing the Cargo workspace"
@@ -762,7 +762,7 @@ jobs:
   rust-build-vendored:
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     parameters:
       directory:
         description: "Directory containing the Cargo workspace"
@@ -855,7 +855,7 @@ jobs:
   rust-lint-vendored:
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     parameters:
       directory:
         description: "Directory containing the Cargo workspace"
@@ -878,7 +878,7 @@ jobs:
   initialize:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: large
+    resource_class: large.gen2
     steps:
       - run:
           command: echo  "Initializing..."
@@ -951,7 +951,7 @@ jobs:
   contracts-bedrock-build:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: large
+    resource_class: large.gen2
     parameters:
       build_args:
         description: Forge build arguments
@@ -1018,7 +1018,7 @@ jobs:
   contracts-bedrock-tests:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: 2xlarge
+    resource_class: 2xlarge.gen2
     parameters:
       test_list:
         description: List of test files to run
@@ -1106,7 +1106,7 @@ jobs:
   contracts-bedrock-heavy-fuzz-nightly:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: 2xlarge
+    resource_class: 2xlarge.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: full
@@ -1163,7 +1163,7 @@ jobs:
   ai-contracts-test:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -1541,7 +1541,7 @@ jobs:
   required-contracts-ci:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: small
+    resource_class: small.gen2
     parameters:
       always-succeed:
         description: Force always succeed (skip API gate; for contracts-feature-tests-short)
@@ -1668,7 +1668,7 @@ jobs:
   go-binaries-for-sysgo:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -1690,7 +1690,7 @@ jobs:
   check-op-geth-version:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -1711,7 +1711,7 @@ jobs:
   prep-superchain:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -1736,7 +1736,7 @@ jobs:
   check-nut-locks:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -1792,7 +1792,7 @@ jobs:
         default: 1
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: 2xlarge
+    resource_class: 2xlarge.gen2
     parallelism: <<parameters.parallelism>>
     steps:
       - utils/checkout-with-mise:
@@ -1850,7 +1850,7 @@ jobs:
       resource_class:
         description: Machine resource class
         type: string
-        default: 2xlarge
+        default: 2xlarge.gen2
       no_output_timeout:
         description: Timeout for when CircleCI kills the job if there's no output
         type: string
@@ -1924,7 +1924,7 @@ jobs:
         default: 30m
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: 2xlarge+
+    resource_class: 2xlarge+.gen2
     steps:
       - run:
           name: Install eatmydata and disable fsync for all subprocesses
@@ -2008,7 +2008,7 @@ jobs:
   memory-all:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - run:
           name: All memory-all tests passed
@@ -2017,7 +2017,7 @@ jobs:
   sanitize-op-program:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: large
+    resource_class: large.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2070,7 +2070,7 @@ jobs:
   rust-binaries-for-sysgo:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - run:
           name: All Rust binaries ready
@@ -2079,7 +2079,7 @@ jobs:
   # ============================================================================
 
   publish-cannon-prestates:
-    resource_class: medium
+    resource_class: medium.gen2
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     steps:
@@ -2191,7 +2191,7 @@ jobs:
       SEMGREP_COMMIT: << pipeline.git.revision >>
     docker:
       - image: returntocorp/semgrep
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     steps:
       - checkout # no need to use mise here since the docker image contains the only dependency
       - unless:
@@ -2223,7 +2223,7 @@ jobs:
   bedrock-go-tests: # just a helper, that depends on all the actual test jobs
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - run: echo Done
 
@@ -2337,7 +2337,7 @@ jobs:
   publish-contract-artifacts:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: 2xlarge
+    resource_class: 2xlarge.gen2
     steps:
       - gcp-cli/install
       - gcp-oidc-authenticate:
@@ -2372,7 +2372,7 @@ jobs:
         type: string
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: large
+    resource_class: large.gen2
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
@@ -2395,7 +2395,7 @@ jobs:
   diff-fetcher-forge-artifacts:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2924,7 +2924,7 @@ workflows:
           mentions: "@proofs-team"
           no_output_timeout: 90m
           test_timeout: 480m
-          resource_class: 2xlarge
+          resource_class: 2xlarge.gen2
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -307,7 +307,7 @@ jobs:
         default: "just fmt-check"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -332,7 +332,7 @@ jobs:
         default: "cargo clippy --workspace --all-targets --all-features"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -361,7 +361,7 @@ jobs:
         default: "cargo deny check"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -386,7 +386,7 @@ jobs:
         default: "zepter run check"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -407,7 +407,7 @@ jobs:
         type: string
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -432,7 +432,7 @@ jobs:
         default: "just check-no-std"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -458,7 +458,7 @@ jobs:
         default: "just lint-docs"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -485,7 +485,7 @@ jobs:
         default: "just test-docs"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: 2xlarge
+    resource_class: 2xlarge.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -519,7 +519,7 @@ jobs:
         default: "release"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: 2xlarge
+    resource_class: 2xlarge.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -546,7 +546,7 @@ jobs:
         default: "just check-udeps"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -576,7 +576,7 @@ jobs:
         default: "--workspace"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -599,7 +599,7 @@ jobs:
         default: 1
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     parallelism: <<parameters.parallelism>>
     steps:
       - utils/checkout-with-mise:
@@ -766,7 +766,7 @@ jobs:
   kona-link-checker:
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -79,7 +79,7 @@ jobs:
         default: false
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -121,7 +121,7 @@ jobs:
   rust-restart-sysgo-tests:
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -180,7 +180,7 @@ jobs:
         type: string
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     parallelism: 4
     steps:
       - utils/checkout-with-mise:


### PR DESCRIPTION
## Summary

Migrates 41 docker jobs in `optimism`'s CircleCI continuation YAMLs from Gen1 to same-size Gen2 resource classes. Mechanical token replacement only — `<class>` → `<class>.gen2` — no resource-class dimension changes, no behavior changes outside of the Gen2 platform itself.

Part of W4 of the CircleCI cost-reduction initiative — see ethereum-optimism/core-team#2564. Builds on the green pilot at #20899 (`fuzz-golang` medium.gen2) which validated Gen2 image compatibility and medium.gen2 sizing under our matrix-fanout pattern.

## Change

41 docker job defs across 3 files. All same-size:

| Current class | → | New class | Count | Jobs (file) |
|---|---|---|---|---|
| `small` | → | `small.gen2` | 6 | required-contracts-ci, check-op-geth-version, prep-superchain, check-nut-locks, memory-all, rust-binaries-for-sysgo *(main.yml)* |
| `medium` | → | `medium.gen2` | 5 | ai-contracts-test, go-binaries-for-sysgo, publish-cannon-prestates, bedrock-go-tests, diff-fetcher-forge-artifacts *(main.yml)* + 8 rust-ci-* shared jobs *(rust-ci.yml)* + kona-link-checker *(rust-ci.yml)* |
| `large` | → | `large.gen2` | 4 | initialize, contracts-bedrock-build, sanitize-op-program, go-release *(main.yml)* |
| `xlarge` | → | `xlarge.gen2` | 4+1+3 | rust-build-binary, rust-build-vendored (×2 duplicate defs), rust-lint-vendored, semgrep-scan *(main.yml)* + rust-ci-docs, rust-ci-cargo-hack *(rust-ci.yml)* + rust-e2e-sysgo-tests, rust-restart-sysgo-tests, kona-proof-action-tests *(rust-e2e.yml)* |
| `2xlarge` | → | `2xlarge.gen2` | 4+2 | contracts-bedrock-tests (**A_forced** — pinned at 2xlarge by heavy-fuzz workload), contracts-bedrock-heavy-fuzz-nightly, go-tests, publish-contract-artifacts *(main.yml)* + rust-ci-doctest, rust-ci-cargo-tests *(rust-ci.yml)* |
| `2xlarge+` | → | `2xlarge+.gen2` | 1 | op-acceptance-tests *(main.yml)* |

Additionally:
- `go-tests-with-fault-proof-deps` parameter default: `default: 2xlarge` → `default: 2xlarge.gen2` (job is templated via `<<parameters.resource_class>>`)
- `develop-fault-proofs` workflow override for the same job updated to `2xlarge.gen2` to match

Total: **43 line changes** across 3 files (41 unique target jobs; one job has a duplicate def, one has a param+override pair).

## Rationale

Same-size Gen2 swaps are equivalent in vCPU/RAM dimensions to their Gen1 counterparts at the same advertised class, with Gen2 typically providing faster per-job wall-clock on identical workloads at parity or near-parity per-minute pricing. The migration also positions us ahead of Gen1 deprecation. The pilot PR #20899 demonstrated that Gen2 images run cleanly under our `cimg/base:2026.03` and `ci-base-clang` images and through the matrix-fanout pattern.

The 1 `A_forced` job (`contracts-bedrock-tests`) stays at 2xlarge because the heavy-fuzz workload was previously sized there; we are not changing its dimensions in this PR.

## Validation

- **Mechanical correctness**: every changed line was generated from a per-line edit plan derived from the W4 inventory. Diffs verified locally to consist exclusively of `<class>` → `<class>.gen2` token replacements — no structural changes, no other touches. Each file's size increase matches `5 bytes × N edits` exactly (rust-e2e.yml: +15, rust-ci.yml: +65, main.yml: +135).
- **Pilot precedent**: #20899 (`fuzz-golang` xlarge → medium.gen2) merged green; this PR uses the same image base.

## Held — not included in this PR

- **Machine-executor jobs** (perf benefit on Gen2 unverified per W4 plan): kona-cargo-lint, kona-publish-prestate-artifacts, kona-build-fpvm, kona-host-client-offline (in rust-ci.yml); plus cannon-prestate, todo-issues, contracts-bedrock-upload, preimage-reproducibility, generate-flaky-report, stale-check, close-issue (in main.yml). All remain on Gen1 machine.
- **`fuzz-golang`**: handled by pilot PR #20899 with the only right-size in this whole effort (xlarge → medium.gen2). Not touched here.
- **`op-reth-compact-codec`** (rust-ci.yml, xlarge): comment notes prior OOM at smaller class; not in W4 inventory. Held for separate review.
- **`op-reth-e2e-sysgo-tests`** (rust-e2e.yml, xlarge): not in W4 inventory; held for separate review.
- **Jobs not in W4 Tier A**: cannon-go-lint-and-test, analyze-op-program-client, kontrol-tests, contracts-bedrock-coverage, contracts-bedrock-tests-upgrade, contracts-bedrock-tests-l2-fork, contracts-bedrock-checks-fast, nut-provenance-verify, go-lint, op-program-compat, check-generated-mocks-*, fuzz-golang matrix others — separate review when those classes are addressed.

## Rollback

Each of the 3 file changes is independent: revert per-file (or whole PR) if any one breaks. The most likely failure mode is image incompatibility on a specific Gen2 class — would surface as a per-job failure, not a global YAML break.

## Refs

- ethereum-optimism/core-team#2564 (W4 CircleCI Gen2 migration)
- #20899 (pilot PR — fuzz-golang medium.gen2, merged)
- W3 reference style: ethereum-optimism/superchain-ops#1429