### PR TITLE
fix(e2e/proofs): copy AllocParams in StateRefund to prevent concurrent map writes

### DIFF
--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -57,7 +57,12 @@ func TestOperatorFeeConsistency(gt *testing.T) {
 		}
 
 		if testCfg.Custom == StateRefund {
-			testCfg.Allocs = actionsHelpers.DefaultAlloc
+			// Copy DefaultAlloc rather than using the shared pointer directly.
+			// Multiple StateRefund fork variants run in parallel; sharing the pointer
+			// causes concurrent writes to the same L2Alloc map, triggering
+			// "fatal error: concurrent map writes" (confirmed: CI job 5075301 shard 1).
+			allocsCopy := *actionsHelpers.DefaultAlloc
+			testCfg.Allocs = &allocsCopy
 			testCfg.Allocs.L2Alloc = make(map[common.Address]types.Account)
 			testCfg.Allocs.L2Alloc[testStorageUpdateContractAddress] = types.Account{
 				Code:    testStorageUpdateContractCode,


### PR DESCRIPTION
## Summary

- `TestOperatorFeeConsistency` spawns four `StateRefund` subtests in parallel (HonestClaim/JunkClaim × isthmus/jovian fork variants). All four shared the same `*AllocParams` pointer (`actionsHelpers.DefaultAlloc`) and raced to write `DefaultAlloc.L2Alloc` concurrently — crashing the test binary with `fatal error: concurrent map writes`.
- Fix: shallow-copy `DefaultAlloc` before mutating `L2Alloc`, so each subtest has its own independent struct and map.
- This eliminates ~294 of the ~916 weekly flakes recorded in CircleCI Insights (32% of total).

## Root cause

`DefaultAlloc` is a shared global `var DefaultAlloc = &e2eutils.AllocParams{PrefundTestUsers: true}`. The `StateRefund` path previously did:

```go
testCfg.Allocs = actionsHelpers.DefaultAlloc          // shared pointer
testCfg.Allocs.L2Alloc = make(map[common.Address]...)  // concurrent write to same field
testCfg.Allocs.L2Alloc[addr] = ...                     // concurrent write to same map
```

When four parallel goroutines all raced through this code, two ended up writing to the same map — triggering `fatal error: concurrent map writes` and killing the entire test binary. All in-flight/paused tests were recorded as failed with `duration: 0s`.

Confirmed from CI artifact analysis: job 5075301 shard 1 (`go-tests-short`), `log-1.json` line 14521–14535:
```
fatal error: concurrent map writes
goroutine 3122594 [running]:
internal/runtime/maps.fatal(...)
    runtime/panic.go:1058
TestOperatorFeeConsistency.func1(...)
    operator_fee_test.go:62
```

## Why a shallow copy is sufficient

`AllocParams` has three fields: `L1Alloc` (nil in DefaultAlloc, never touched by StateRefund), `L2Alloc` (nil in DefaultAlloc, immediately replaced by `make(...)` on the copy), and `PrefundTestUsers bool` (scalar). No deep copy needed.

## Test plan

- [ ] `go build ./op-e2e/actions/proofs/...` — passes
- [ ] `go vet ./op-e2e/actions/proofs/...` — passes
- [ ] CI `go-tests-short` — `TestOperatorFeeConsistency` should no longer crash the shard

🤖 Generated with [Claude Code](https://claude.com/claude-code)