### PR TITLE
DO NOT MERGE: test contract compiler failure

### DIFF
--- a/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
@@ -20,6 +20,6 @@ contract SequencerFeeVault is FeeVault, ISemver {
     /// @notice Legacy getter for the recipient address.
     /// @return The recipient address.
     function l1FeeWallet() public view returns (address) {
-        return recipient;
+        return missingRecipient;
     }
 }


### PR DESCRIPTION
## Summary
- Intentionally references a missing Solidity identifier in SequencerFeeVault.
- This PR exists only to observe CI failure behavior.

## Verification
- Expected failure: `just build-source` fails with `Error (7576): Undeclared identifier` at `src/L2/SequencerFeeVault.sol:23`.