### PR TITLE
feat(portal): verify dispute game l2ChainId for non-super games

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -37,6 +37,7 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     error OptimismPortal_Unproven();
     error OptimismPortal_InvalidInteropState();
     error OptimismPortal_InvalidLockboxState();
+    error OptimismPortal_UnknownChainId();
     error OutOfGas();
     error UnexpectedList();
     error UnexpectedString();

--- a/packages/contracts-bedrock/interfaces/dispute/IDisputeGame.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IDisputeGame.sol
@@ -14,6 +14,7 @@ interface IDisputeGame is IInitializable {
     function gameCreator() external pure returns (address creator_);
     function rootClaim() external pure returns (Claim rootClaim_);
     function rootClaimByChainId(uint256 _chainId) external pure returns (Claim rootClaim_);
+    function l2ChainId() external view returns (uint256 l2ChainId_);
     function l1Head() external pure returns (Hash l1Head_);
     function l2SequenceNumber() external pure returns (uint256 l2SequenceNumber_);
     function extraData() external pure returns (bytes memory extraData_);

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
@@ -931,6 +931,11 @@
   },
   {
     "inputs": [],
+    "name": "OptimismPortal_UnknownChainId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OptimismPortal_Unproven",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xa5a0bc860652e85b7a4102c458d1bb27e203141db0faa41db0fccb3ac86ae4ea"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0xf09c4037bec1e0fbf679f1250e8d21d4a208829be24e16a83711e94c9b4b1004",
-    "sourceCodeHash": "0x58224f9b9403ca597a9aa649757c667396838eee89db2e7553aab755dd5fba26"
+    "initCodeHash": "0x4ef3bd0a05e97cb08100ab67c8a8eb12136c048ce56620686367c4170366063b",
+    "sourceCodeHash": "0xef3553c7cfd85f103566a0e915feb728b214a47d110777e528bacc68d1d0eabf"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0xd747690ea1ee01828050e55ad358d443535452a7050dba9d67e419a86798802e",

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -233,10 +233,14 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Thrown when ETHLockbox is set/unset incorrectly depending on the feature flag.
     error OptimismPortal_InvalidLockboxState();
 
+    /// @notice Thrown when the dispute game's L2 chain ID does not match the portal's configured
+    ///         L2 chain ID.
+    error OptimismPortal_UnknownChainId();
+
     /// @notice Semantic version.
-    /// @custom:semver 5.6.1
+    /// @custom:semver 5.6.2
     function version() public pure virtual returns (string memory) {
-        return "5.6.1";
+        return "5.6.2";
     }
 
     /// @param _proofMaturityDelaySeconds The proof maturity delay in seconds.
@@ -413,12 +417,16 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         }
 
         // Extract the output root claim. Super game types use rootClaimByChainId to extract
-        // the per-chain output root from the super root. Legacy game types use rootClaim directly.
+        // the per-chain output root from the super root. Legacy game types use rootClaim directly
+        // and we explicitly verify that the game's L2 chain ID matches this portal's.
         // TODO(#19816): Post interop clean up the legacy rootClaim() usage in OptimismPortal2.
         Claim outputRootClaim;
         if (GameTypes.isSuperGame(disputeGameProxy.gameType())) {
             outputRootClaim = disputeGameProxy.rootClaimByChainId(systemConfig.l2ChainId());
         } else {
+            if (disputeGameProxy.l2ChainId() != systemConfig.l2ChainId()) {
+                revert OptimismPortal_UnknownChainId();
+            }
             outputRootClaim = disputeGameProxy.rootClaim();
         }
 

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -101,6 +101,11 @@ abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
 
         depositor = makeAddr("depositor");
 
+        // Ensure the dispute game implementation is deployed with the same L2 chain ID that the
+        // portal's SystemConfig is configured for, so proveWithdrawalTransaction's chain ID check
+        // passes.
+        l2ChainId = systemConfig.l2ChainId();
+
         setupFaultDisputeGame(Claim.wrap(_outputRoot));
 
         // Warp forward in time to ensure that the game is created after the retirement timestamp.
@@ -939,6 +944,19 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
     function test_proveWithdrawalTransaction_legacyGame_reverts() external {
         vm.mockCallRevert(address(game), abi.encodeCall(game.wasRespectedGameTypeWhenCreated, ()), "");
         vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
+        optimismPortal2.proveWithdrawalTransaction({
+            _tx: _defaultTx,
+            _disputeGameIndex: _proposedGameIndex,
+            _outputRootProof: _outputRootProof,
+            _withdrawalProof: _withdrawalProof
+        });
+    }
+
+    /// @notice Tests that `proveWithdrawalTransaction` reverts when a non-super dispute game's
+    ///         `l2ChainId()` does not match the portal's configured L2 chain ID.
+    function test_proveWithdrawalTransaction_wrongChainIdNonSuperGame_reverts() external {
+        vm.mockCall(address(game), abi.encodeCall(game.l2ChainId, ()), abi.encode(systemConfig.l2ChainId() + 1));
+        vm.expectRevert(IOptimismPortal.OptimismPortal_UnknownChainId.selector);
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex,

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -957,7 +957,7 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
     ///         configured L2 chain ID. Forces the non-super branch by mocking `gameType`, so the
     ///         check is exercised regardless of which game type is respected in the environment.
     function test_proveWithdrawalTransaction_wrongChainIdNonSuperGame_reverts() external {
-        vm.mockCall(address(game), abi.encodeCall(game.gameType, ()), abi.encode(GameTypes.CANNON));
+        vm.mockCall(address(game), abi.encodeCall(game.gameType, ()), abi.encode(GameTypes.CANNON_KONA));
         vm.mockCall(address(game), abi.encodeCall(game.l2ChainId, ()), abi.encode(systemConfig.l2ChainId() + 1));
         vm.expectRevert(IOptimismPortal.OptimismPortal_UnknownChainId.selector);
         optimismPortal2.proveWithdrawalTransaction({

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -952,16 +952,12 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
         });
     }
 
-    /// @notice Tests that `proveWithdrawalTransaction` reverts when a non-super dispute game's
-    ///         `l2ChainId()` does not match the portal's configured L2 chain ID.
+    /// @notice Tests that `proveWithdrawalTransaction` reverts when the dispute game takes the
+    ///         non-super branch and the game's `l2ChainId()` does not match the portal's
+    ///         configured L2 chain ID. Forces the non-super branch by mocking `gameType`, so the
+    ///         check is exercised regardless of which game type is respected in the environment.
     function test_proveWithdrawalTransaction_wrongChainIdNonSuperGame_reverts() external {
-        // Only relevant for non-super games — the super game path enforces the chain ID via
-        // `rootClaimByChainId`. Skip when the respected game type is a super game (e.g. after the
-        // super-root games migration).
-        if (DisputeGames.isSuperGame(respectedGameType)) {
-            vm.skip(true, "Skipping: respected game type is a super game");
-        }
-
+        vm.mockCall(address(game), abi.encodeCall(game.gameType, ()), abi.encode(GameTypes.CANNON));
         vm.mockCall(address(game), abi.encodeCall(game.l2ChainId, ()), abi.encode(systemConfig.l2ChainId() + 1));
         vm.expectRevert(IOptimismPortal.OptimismPortal_UnknownChainId.selector);
         optimismPortal2.proveWithdrawalTransaction({

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -955,6 +955,13 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
     /// @notice Tests that `proveWithdrawalTransaction` reverts when a non-super dispute game's
     ///         `l2ChainId()` does not match the portal's configured L2 chain ID.
     function test_proveWithdrawalTransaction_wrongChainIdNonSuperGame_reverts() external {
+        // Only relevant for non-super games — the super game path enforces the chain ID via
+        // `rootClaimByChainId`. Skip when the respected game type is a super game (e.g. after the
+        // super-root games migration).
+        if (DisputeGames.isSuperGame(respectedGameType)) {
+            vm.skip(true, "Skipping: respected game type is a super game");
+        }
+
         vm.mockCall(address(game), abi.encodeCall(game.l2ChainId, ()), abi.encode(systemConfig.l2ChainId() + 1));
         vm.expectRevert(IOptimismPortal.OptimismPortal_UnknownChainId.selector);
         optimismPortal2.proveWithdrawalTransaction({

--- a/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
@@ -133,6 +133,11 @@ contract OptimismPortal2_Invariant_Harness is DisputeGameFactory_TestInit {
         // Warp forward in time to ensure that the game is created after the retirement timestamp.
         vm.warp(anchorStateRegistry.retirementTimestamp() + 1);
 
+        // Ensure the dispute game implementation is deployed with the same L2 chain ID that the
+        // portal's SystemConfig is configured for, so proveWithdrawalTransaction's chain ID check
+        // passes.
+        l2ChainId = systemConfig.l2ChainId();
+
         setupFaultDisputeGame(Claim.wrap(bytes32(0)));
 
         // Create a dispute game with the output root we've proposed.


### PR DESCRIPTION
## Summary

`OptimismPortal2.proveWithdrawalTransaction` binds super-game roots to the portal's L2 chain ID via `rootClaimByChainId(systemConfig.l2ChainId())`, but the non-super branch called `rootClaim()` directly with no chain-ID check. A non-super dispute game implementation misconfigured (via OPCM, migration, or owner upgrade) for a different L2 could let a proposer prove a withdrawal against another chain's output root and finalize through this portal.

## Changes

- Add fail-closed check in the non-super branch: revert `OptimismPortal_UnknownChainId()` when `disputeGameProxy.l2ChainId() != systemConfig.l2ChainId()`. Super-game path is untouched.
- Add `l2ChainId()` to the base `IDisputeGame` interface (already implemented by all concrete game types).
- Bump `OptimismPortal2` semver 5.6.1 → 5.6.2 and regenerate snapshots.
- Add `test_proveWithdrawalTransaction_wrongChainIdNonSuperGame_reverts`. Align existing portal/invariant test fixtures so the deployed `FaultDisputeGame` impl uses the same L2 chain ID as `SystemConfig`

fixes https://github.com/ethereum-optimism/optimism/issues/20883