### PR TITLE
feat(contracts-bedrock): scale ResourceConfig to fit smaller gasLimits (v7.0.0)

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -13,6 +13,7 @@ import { Types } from "scripts/libraries/Types.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
+import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
@@ -213,7 +214,7 @@ contract DeployOPChain is Script {
             blobBasefeeScalar: _input.blobBaseFeeScalar,
             gasLimit: _input.gasLimit,
             l2ChainId: _input.l2ChainId,
-            resourceConfig: Constants.DEFAULT_RESOURCE_CONFIG(),
+            resourceConfig: _resourceConfigForGasLimit(_input.gasLimit),
             disputeGameConfigs: disputeGameConfigs,
             useCustomGasToken: _input.useCustomGasToken
         });
@@ -248,6 +249,42 @@ contract DeployOPChain is Script {
             delayedWETHPermissionedGameProxy: _chainContracts.delayedWETH,
             delayedWETHPermissionlessGameProxy: IDelayedWETH(payable(_chainContracts.delayedWETH))
         });
+    }
+
+    /// @notice Derives a ResourceConfig sized to fit the requested L2 gas limit.
+    ///
+    ///         For gasLimit >= the default's reserved gas (maxResourceLimit + systemTxMaxGas),
+    ///         returns DEFAULT_RESOURCE_CONFIG unchanged. Every existing production chain takes
+    ///         this branch.
+    ///
+    ///         For smaller gasLimits, shrinks maxResourceLimit to fit while preserving
+    ///         systemTxMaxGas and the EIP-1559 parameters, so the L1 attributes deposit
+    ///         reservation stays constant and deposit throughput scales with chain size.
+    ///         maxResourceLimit is rounded down to a multiple of elasticityMultiplier to
+    ///         satisfy SystemConfig._setResourceConfig's precision-loss check.
+    /// @param _gasLimit The requested L2 gas limit.
+    /// @return cfg_ A ResourceConfig that satisfies maxResourceLimit + systemTxMaxGas <= _gasLimit.
+    function _resourceConfigForGasLimit(uint64 _gasLimit)
+        internal
+        pure
+        returns (IResourceMetering.ResourceConfig memory cfg_)
+    {
+        cfg_ = Constants.DEFAULT_RESOURCE_CONFIG();
+        uint64 reserved = uint64(cfg_.maxResourceLimit) + uint64(cfg_.systemTxMaxGas);
+        if (_gasLimit >= reserved) {
+            return cfg_;
+        }
+
+        require(_gasLimit > uint64(cfg_.systemTxMaxGas), "DeployOPChain: gasLimit must exceed systemTxMaxGas");
+        // Branch is only reached for _gasLimit < reserved (~21M for the current default), well
+        // within uint32, so the downcast on assignment cannot truncate.
+        uint64 available = _gasLimit - uint64(cfg_.systemTxMaxGas);
+        uint64 mult = uint64(cfg_.elasticityMultiplier);
+
+        // Satisfy the SystemConfig._setResourceConfig requirement that the maxResourceLimit is
+        // a multiple of the elasticityMultiplier.
+        cfg_.maxResourceLimit = uint32((available / mult) * mult);
+        require(cfg_.maxResourceLimit > 0, "DeployOPChain: gasLimit too small for any deposit budget");
     }
 
     // -------- Validations --------

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -13,12 +13,14 @@ import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
 import { Types } from "scripts/libraries/Types.sol";
 
 // Libraries
+import { Constants } from "src/libraries/Constants.sol";
 import { Features } from "src/libraries/Features.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 
 // Interfaces
 import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
 import { IOPContractsManagerContainer } from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
+import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { Claim, Duration, GameType, GameTypes } from "src/dispute/lib/Types.sol";
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
@@ -436,5 +438,78 @@ contract DeployOPChain_TestFail is DeployOPChain_TestBase {
         bytes memory emptyInput = "";
         vm.expectRevert("DeployOPChain: input cannot be empty");
         deployOPChain.runWithBytes(emptyInput);
+    }
+}
+
+contract DeployOPChain_GasLimit_Test is DeployOPChain_TestBase {
+    /// @notice A gasLimit large enough to fit the default reserved gas should produce the
+    ///         unchanged DEFAULT_RESOURCE_CONFIG. The boundary value is the sum of
+    ///         default maxResourceLimit and systemTxMaxGas (currently 21M).
+    function test_run_gasLimitAtDefaultThreshold_succeeds() public {
+        IResourceMetering.ResourceConfig memory expected = Constants.DEFAULT_RESOURCE_CONFIG();
+        deployOPChainInput.gasLimit = uint64(expected.maxResourceLimit) + uint64(expected.systemTxMaxGas);
+
+        DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
+        IResourceMetering.ResourceConfig memory actual = doo.systemConfigProxy.resourceConfig();
+
+        assertEq(actual.maxResourceLimit, expected.maxResourceLimit, "maxResourceLimit");
+        assertEq(actual.systemTxMaxGas, expected.systemTxMaxGas, "systemTxMaxGas");
+        assertEq(actual.elasticityMultiplier, expected.elasticityMultiplier, "elasticityMultiplier");
+        assertEq(
+            actual.baseFeeMaxChangeDenominator, expected.baseFeeMaxChangeDenominator, "baseFeeMaxChangeDenominator"
+        );
+        assertEq(actual.minimumBaseFee, expected.minimumBaseFee, "minimumBaseFee");
+        assertEq(actual.maximumBaseFee, expected.maximumBaseFee, "maximumBaseFee");
+    }
+
+    /// @notice A 5M gasLimit (below the 21M default-reserved threshold) should produce a
+    ///         scaled-down ResourceConfig where maxResourceLimit + systemTxMaxGas == gasLimit.
+    function test_run_gasLimitFiveMillion_succeeds() public {
+        deployOPChainInput.gasLimit = 5_000_000;
+
+        DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
+        IResourceMetering.ResourceConfig memory actual = doo.systemConfigProxy.resourceConfig();
+        IResourceMetering.ResourceConfig memory defaults = Constants.DEFAULT_RESOURCE_CONFIG();
+
+        assertEq(actual.maxResourceLimit, 4_000_000, "maxResourceLimit scaled");
+        assertEq(actual.systemTxMaxGas, defaults.systemTxMaxGas, "systemTxMaxGas preserved");
+        assertEq(actual.elasticityMultiplier, defaults.elasticityMultiplier, "elasticityMultiplier preserved");
+        assertEq(
+            actual.baseFeeMaxChangeDenominator,
+            defaults.baseFeeMaxChangeDenominator,
+            "baseFeeMaxChangeDenominator preserved"
+        );
+        assertEq(actual.minimumBaseFee, defaults.minimumBaseFee, "minimumBaseFee preserved");
+        assertEq(actual.maximumBaseFee, defaults.maximumBaseFee, "maximumBaseFee preserved");
+        assertEq(doo.systemConfigProxy.gasLimit(), 5_000_000, "SystemConfig gasLimit");
+        // Sanity: reserved gas exactly equals the requested gasLimit at the small-chain floor.
+        assertEq(
+            uint64(actual.maxResourceLimit) + uint64(actual.systemTxMaxGas),
+            deployOPChainInput.gasLimit,
+            "reserved gas == gasLimit"
+        );
+    }
+}
+
+contract DeployOPChain_GasLimit_TestFail is DeployOPChain_TestBase {
+    /// @notice A gasLimit at or below the default systemTxMaxGas leaves no room for any
+    ///         deposit budget and must revert at the deploy script with a clear message,
+    ///         rather than failing deeper inside SystemConfig.
+    function test_run_gasLimitBelowSystemTxMaxGas_reverts() public {
+        IResourceMetering.ResourceConfig memory defaults = Constants.DEFAULT_RESOURCE_CONFIG();
+        deployOPChainInput.gasLimit = uint64(defaults.systemTxMaxGas);
+        vm.expectRevert("DeployOPChain: gasLimit must exceed systemTxMaxGas");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    /// @notice A gasLimit only marginally above systemTxMaxGas rounds maxResourceLimit
+    ///         down to zero (because of the elasticityMultiplier divisibility constraint)
+    ///         and must revert before reaching SystemConfig.
+    function test_run_gasLimitTooSmallForDeposits_reverts() public {
+        IResourceMetering.ResourceConfig memory defaults = Constants.DEFAULT_RESOURCE_CONFIG();
+        // available = 5 gas, which rounds down to 0 under elasticityMultiplier = 10.
+        deployOPChainInput.gasLimit = uint64(defaults.systemTxMaxGas) + 5;
+        vm.expectRevert("DeployOPChain: gasLimit too small for any deposit budget");
+        deployOPChain.run(deployOPChainInput);
     }
 }


### PR DESCRIPTION
Backport of #20919 to `proposal/op-contracts/v7.0.0`.

`DeployOPChain.s.sol` now derives the `ResourceConfig` from `_input.gasLimit` via a `_resourceConfigForGasLimit(uint64)` helper instead of hardcoding `Constants.DEFAULT_RESOURCE_CONFIG()`. For `gasLimit >= 21M` the default is returned unchanged (every production chain), and below that `maxResourceLimit` is scaled down to fit while preserving `systemTxMaxGas` and the EIP-1559 parameters. Enables small-chain deploys (e.g. 5M) without adding any new inputs to op-deployer.

Cherry-pick was a clean auto-merge with no conflicts.