### PR TITLE
feat: validate inputs in OptimismPortal2.migrateToSharedDisputeGame

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -37,6 +37,8 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     error OptimismPortal_Unproven();
     error OptimismPortal_InvalidInteropState();
     error OptimismPortal_InvalidLockboxState();
+    error OptimismPortal_ZeroAddress();
+    error OptimismPortal_LockboxNotAuthorizedForPortal();
     error OutOfGas();
     error UnexpectedList();
     error UnexpectedString();

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
@@ -906,6 +906,11 @@
   },
   {
     "inputs": [],
+    "name": "OptimismPortal_LockboxNotAuthorizedForPortal",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OptimismPortal_MigratingToSameRegistry",
     "type": "error"
   },
@@ -932,6 +937,11 @@
   {
     "inputs": [],
     "name": "OptimismPortal_Unproven",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OptimismPortal_ZeroAddress",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0x8a2409bb3f08ead8a9619a7f54a995aca224f17fc96121cac0e0f2f8531d3cf6"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0x02f8cfb0213d614c34c12904f0d06b4f8fad14f7d127b3b780f9d5cc5ebba72a",
-    "sourceCodeHash": "0xcaa24914e2599295be1336a66434de208b637d5db1e8af03279c0b2ac92112b5"
+    "initCodeHash": "0xc51514dad81c8e0fc7237bb482bc9128f09ce5036e5b06af9493ae2c293180c1",
+    "sourceCodeHash": "0xcb94b974ed60007d85e7f05aca2c49ed2b78e204b6daccc6b398e6ac9e1c3fa4"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x68f3fa110e1509bd841932feab438df5b5995ee222fc69a4dd6fcd48428e06f5",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0x8a2409bb3f08ead8a9619a7f54a995aca224f17fc96121cac0e0f2f8531d3cf6"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0xc51514dad81c8e0fc7237bb482bc9128f09ce5036e5b06af9493ae2c293180c1",
-    "sourceCodeHash": "0xcb94b974ed60007d85e7f05aca2c49ed2b78e204b6daccc6b398e6ac9e1c3fa4"
+    "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",
+    "sourceCodeHash": "0x6f754eee67b9e8b9a8a46db304f695d381b63fdf2c48b540fd0cb39aed9daaa9"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x68f3fa110e1509bd841932feab438df5b5995ee222fc69a4dd6fcd48428e06f5",

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -241,9 +241,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     error OptimismPortal_LockboxNotAuthorizedForPortal();
 
     /// @notice Semantic version.
-    /// @custom:semver 5.7.0
+    /// @custom:semver 5.8.0
     function version() public pure virtual returns (string memory) {
-        return "5.7.0";
+        return "5.8.0";
     }
 
     /// @param _proofMaturityDelaySeconds The proof maturity delay in seconds.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -26,6 +26,7 @@ import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol"
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 /// @custom:proxied true
@@ -232,6 +233,12 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
 
     /// @notice Thrown when ETHLockbox is set/unset incorrectly depending on the feature flag.
     error OptimismPortal_InvalidLockboxState();
+
+    /// @notice Thrown when migrateToSharedDisputeGame is called with a zero address.
+    error OptimismPortal_ZeroAddress();
+
+    /// @notice Thrown when the new lockbox has not authorized this portal.
+    error OptimismPortal_LockboxNotAuthorizedForPortal();
 
     /// @notice Semantic version.
     /// @custom:semver 5.7.0
@@ -522,6 +529,16 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         // accidentally misused.
         if (anchorStateRegistry == _newAnchorStateRegistry) {
             revert OptimismPortal_MigratingToSameRegistry();
+        }
+
+        // Defense-in-depth: reject obvious operator footguns. The ProxyAdmin owner is fully
+        // trusted (can upgrade the portal), but these checks make it harder to brick the portal by
+        // installing zero / non-contract / unauthorized / mis-wired addresses.
+        if (address(_newLockbox) == address(0) || address(_newAnchorStateRegistry) == address(0)) {
+            revert OptimismPortal_ZeroAddress();
+        }
+        if (!_newLockbox.authorizedPortals(IOptimismPortal2(payable(address(this))))) {
+            revert OptimismPortal_LockboxNotAuthorizedForPortal();
         }
 
         // Update the ETHLockbox.

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -31,6 +31,7 @@ import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPort
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 
 import { IProxy } from "interfaces/universal/IProxy.sol";
+import { Proxy } from "src/universal/Proxy.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
@@ -728,19 +729,46 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
         forceEnableInterop();
     }
 
-    /// @notice Etches a single byte at `_addr` and mocks accessors so it passes the new
-    ///         lockbox+registry wiring checks in `migrateToSharedDisputeGame`.
-    function _mockValidLockbox(address _addr) internal {
-        vm.etch(_addr, hex"00");
-        vm.mockCall(
-            _addr,
-            abi.encodeCall(IETHLockbox.authorizedPortals, (IOptimismPortal(payable(address(optimismPortal2))))),
-            abi.encode(true)
-        );
+    /// @notice Deploys a fresh ETHLockbox proxy pointed at the same implementation as the existing
+    ///         `ethLockbox` and initializes it with `optimismPortal2` optionally authorized.
+    function _deployRealLockbox(bool _authorizePortal) internal returns (IETHLockbox lockbox_) {
+        address proxyAdminAddr = address(proxyAdmin);
+
+        vm.prank(proxyAdminAddr);
+        address impl = Proxy(payable(address(ethLockbox))).implementation();
+
+        address newProxy = address(new Proxy(proxyAdminAddr));
+        IOptimismPortal[] memory portals = new IOptimismPortal[](_authorizePortal ? 1 : 0);
+        if (_authorizePortal) portals[0] = IOptimismPortal(payable(address(optimismPortal2)));
+
+        vm.prank(proxyAdminAddr);
+        Proxy(payable(newProxy)).upgradeToAndCall(impl, abi.encodeCall(IETHLockbox.initialize, (systemConfig, portals)));
+
+        lockbox_ = IETHLockbox(payable(newProxy));
     }
 
-    function _mockValidRegistry(address _addr) internal {
-        vm.etch(_addr, hex"00");
+    /// @notice Deploys a fresh AnchorStateRegistry proxy pointed at the same implementation as the
+    ///         existing `anchorStateRegistry` and initializes it with a dummy anchor root.
+    function _deployRealRegistry() internal returns (IAnchorStateRegistry registry_) {
+        address proxyAdminAddr = address(proxyAdmin);
+
+        vm.prank(proxyAdminAddr);
+        address impl = Proxy(payable(address(anchorStateRegistry))).implementation();
+
+        address newProxy = address(new Proxy(proxyAdminAddr));
+        Proposal memory startingAnchorRoot =
+            Proposal({ root: Hash.wrap(keccak256("starting-anchor-root")), l2SequenceNumber: 1 });
+
+        vm.prank(proxyAdminAddr);
+        Proxy(payable(newProxy)).upgradeToAndCall(
+            impl,
+            abi.encodeCall(
+                IAnchorStateRegistry.initialize,
+                (systemConfig, disputeGameFactory, startingAnchorRoot, GameTypes.SUPER_PERMISSIONED)
+            )
+        );
+
+        registry_ = IAnchorStateRegistry(newProxy);
     }
 
     /// @notice Tests that `migrateToSharedDisputeGame` reverts if the caller is not the proxy admin
@@ -775,79 +803,56 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
     ///         address.
     function test_migrateToSharedDisputeGame_zeroLockbox_reverts() external {
         address caller = optimismPortal2.proxyAdminOwner();
-        address registry = address(0x1234);
-        _mockValidRegistry(registry);
+        IAnchorStateRegistry registry = _deployRealRegistry();
         vm.expectRevert(IOptimismPortal.OptimismPortal_ZeroAddress.selector);
         vm.prank(caller);
-        optimismPortal2.migrateToSharedDisputeGame(IETHLockbox(address(0)), IAnchorStateRegistry(registry));
+        optimismPortal2.migrateToSharedDisputeGame(IETHLockbox(address(0)), registry);
     }
 
     /// @notice Tests that `migrateToSharedDisputeGame` reverts when the new registry is the zero
     ///         address.
     function test_migrateToSharedDisputeGame_zeroRegistry_reverts() external {
         address caller = optimismPortal2.proxyAdminOwner();
-        address lockbox = address(0x1234);
-        _mockValidLockbox(lockbox);
+        IETHLockbox lockbox = _deployRealLockbox({ _authorizePortal: true });
         vm.expectRevert(IOptimismPortal.OptimismPortal_ZeroAddress.selector);
         vm.prank(caller);
-        optimismPortal2.migrateToSharedDisputeGame(IETHLockbox(lockbox), IAnchorStateRegistry(address(0)));
+        optimismPortal2.migrateToSharedDisputeGame(lockbox, IAnchorStateRegistry(address(0)));
     }
 
     /// @notice Tests that `migrateToSharedDisputeGame` reverts when the new lockbox has not
     ///         authorized this portal.
     function test_migrateToSharedDisputeGame_lockboxNotAuthorizingPortal_reverts() external {
         address caller = optimismPortal2.proxyAdminOwner();
-        address lockbox = address(0x1234);
-        address registry = address(0x5678);
-        // Etch code but mock authorizedPortals -> false.
-        vm.etch(lockbox, hex"00");
-        vm.mockCall(
-            lockbox,
-            abi.encodeCall(IETHLockbox.authorizedPortals, (IOptimismPortal(payable(address(optimismPortal2))))),
-            abi.encode(false)
-        );
-        _mockValidRegistry(registry);
+        IETHLockbox lockbox = _deployRealLockbox({ _authorizePortal: false });
+        IAnchorStateRegistry registry = _deployRealRegistry();
 
         vm.expectRevert(IOptimismPortal.OptimismPortal_LockboxNotAuthorizedForPortal.selector);
         vm.prank(caller);
-        optimismPortal2.migrateToSharedDisputeGame(IETHLockbox(lockbox), IAnchorStateRegistry(registry));
+        optimismPortal2.migrateToSharedDisputeGame(lockbox, registry);
     }
 
-    /// @notice Tests that `migrateToSharedDisputeGame` updates the ETHLockbox contract, updates the
-    ///         AnchorStateRegistry, and sets the superRootsActive flag to true.
-    /// @param _newLockbox The new ETHLockbox to migrate to.
-    /// @param _newAnchorStateRegistry The new AnchorStateRegistry to migrate to.
-    function testFuzz_migrateToSharedDisputeGame_succeeds(
-        address _newLockbox,
-        address _newAnchorStateRegistry
-    )
-        external
-    {
+    /// @notice Tests that `migrateToSharedDisputeGame` updates the ETHLockbox and
+    ///         AnchorStateRegistry references on the portal when given real, freshly-deployed and
+    ///         initialized lockbox + registry proxies (mirroring the OPCM migrator setup).
+    function test_migrateToSharedDisputeGame_succeeds() external {
         address oldLockbox = address(optimismPortal2.ethLockbox());
         address oldAnchorStateRegistry = address(optimismPortal2.anchorStateRegistry());
-        vm.assume(_newLockbox != oldLockbox);
-        vm.assume(_newAnchorStateRegistry != oldAnchorStateRegistry);
-        vm.assume(_newLockbox != _newAnchorStateRegistry);
-        vm.assume(_newLockbox != address(0) && _newAnchorStateRegistry != address(0));
-        // Avoid colliding with precompiles / existing contracts in the test harness.
-        assumeNotPrecompile(_newLockbox);
-        assumeNotPrecompile(_newAnchorStateRegistry);
-        vm.assume(_newLockbox.code.length == 0);
-        vm.assume(_newAnchorStateRegistry.code.length == 0);
 
-        _mockValidLockbox(_newLockbox);
-        _mockValidRegistry(_newAnchorStateRegistry);
-
-        vm.expectEmit(address(optimismPortal2));
-        emit PortalMigrated(oldLockbox, _newLockbox, oldAnchorStateRegistry, _newAnchorStateRegistry);
-
-        vm.prank(optimismPortal2.proxyAdminOwner());
-        optimismPortal2.migrateToSharedDisputeGame(
-            IETHLockbox(_newLockbox), IAnchorStateRegistry(_newAnchorStateRegistry)
+        IETHLockbox newLockbox = _deployRealLockbox({ _authorizePortal: true });
+        IAnchorStateRegistry newAnchorStateRegistry = _deployRealRegistry();
+        assertTrue(
+            newLockbox.authorizedPortals(IOptimismPortal(payable(address(optimismPortal2)))),
+            "test setup: portal not authorized on new lockbox"
         );
 
-        assertEq(address(optimismPortal2.ethLockbox()), _newLockbox);
-        assertEq(address(optimismPortal2.anchorStateRegistry()), _newAnchorStateRegistry);
+        vm.expectEmit(address(optimismPortal2));
+        emit PortalMigrated(oldLockbox, address(newLockbox), oldAnchorStateRegistry, address(newAnchorStateRegistry));
+
+        vm.prank(optimismPortal2.proxyAdminOwner());
+        optimismPortal2.migrateToSharedDisputeGame(newLockbox, newAnchorStateRegistry);
+
+        assertEq(address(optimismPortal2.ethLockbox()), address(newLockbox));
+        assertEq(address(optimismPortal2.anchorStateRegistry()), address(newAnchorStateRegistry));
         assertTrue(systemConfig.isFeatureEnabled(Features.INTEROP));
     }
 

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -731,7 +731,7 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
 
     /// @notice Deploys a fresh ETHLockbox proxy pointed at the same implementation as the existing
     ///         `ethLockbox` and initializes it with `optimismPortal2` optionally authorized.
-    function _deployRealLockbox(bool _authorizePortal) internal returns (IETHLockbox lockbox_) {
+    function _deployLockbox(bool _authorizePortal) internal returns (IETHLockbox lockbox_) {
         address proxyAdminAddr = address(proxyAdmin);
 
         vm.prank(proxyAdminAddr);
@@ -749,7 +749,7 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
 
     /// @notice Deploys a fresh AnchorStateRegistry proxy pointed at the same implementation as the
     ///         existing `anchorStateRegistry` and initializes it with a dummy anchor root.
-    function _deployRealRegistry() internal returns (IAnchorStateRegistry registry_) {
+    function _deployAnchorStateRegistry() internal returns (IAnchorStateRegistry registry_) {
         address proxyAdminAddr = address(proxyAdmin);
 
         vm.prank(proxyAdminAddr);
@@ -803,7 +803,7 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
     ///         address.
     function test_migrateToSharedDisputeGame_zeroLockbox_reverts() external {
         address caller = optimismPortal2.proxyAdminOwner();
-        IAnchorStateRegistry registry = _deployRealRegistry();
+        IAnchorStateRegistry registry = _deployAnchorStateRegistry();
         vm.expectRevert(IOptimismPortal.OptimismPortal_ZeroAddress.selector);
         vm.prank(caller);
         optimismPortal2.migrateToSharedDisputeGame(IETHLockbox(address(0)), registry);
@@ -813,7 +813,7 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
     ///         address.
     function test_migrateToSharedDisputeGame_zeroRegistry_reverts() external {
         address caller = optimismPortal2.proxyAdminOwner();
-        IETHLockbox lockbox = _deployRealLockbox({ _authorizePortal: true });
+        IETHLockbox lockbox = _deployLockbox({ _authorizePortal: true });
         vm.expectRevert(IOptimismPortal.OptimismPortal_ZeroAddress.selector);
         vm.prank(caller);
         optimismPortal2.migrateToSharedDisputeGame(lockbox, IAnchorStateRegistry(address(0)));
@@ -823,8 +823,8 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
     ///         authorized this portal.
     function test_migrateToSharedDisputeGame_lockboxNotAuthorizingPortal_reverts() external {
         address caller = optimismPortal2.proxyAdminOwner();
-        IETHLockbox lockbox = _deployRealLockbox({ _authorizePortal: false });
-        IAnchorStateRegistry registry = _deployRealRegistry();
+        IETHLockbox lockbox = _deployLockbox({ _authorizePortal: false });
+        IAnchorStateRegistry registry = _deployAnchorStateRegistry();
 
         vm.expectRevert(IOptimismPortal.OptimismPortal_LockboxNotAuthorizedForPortal.selector);
         vm.prank(caller);
@@ -838,8 +838,8 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
         address oldLockbox = address(optimismPortal2.ethLockbox());
         address oldAnchorStateRegistry = address(optimismPortal2.anchorStateRegistry());
 
-        IETHLockbox newLockbox = _deployRealLockbox({ _authorizePortal: true });
-        IAnchorStateRegistry newAnchorStateRegistry = _deployRealRegistry();
+        IETHLockbox newLockbox = _deployLockbox({ _authorizePortal: true });
+        IAnchorStateRegistry newAnchorStateRegistry = _deployAnchorStateRegistry();
         assertTrue(
             newLockbox.authorizedPortals(IOptimismPortal(payable(address(optimismPortal2)))),
             "test setup: portal not authorized on new lockbox"

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -728,6 +728,21 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
         forceEnableInterop();
     }
 
+    /// @notice Etches a single byte at `_addr` and mocks accessors so it passes the new
+    ///         lockbox+registry wiring checks in `migrateToSharedDisputeGame`.
+    function _mockValidLockbox(address _addr) internal {
+        vm.etch(_addr, hex"00");
+        vm.mockCall(
+            _addr,
+            abi.encodeCall(IETHLockbox.authorizedPortals, (IOptimismPortal(payable(address(optimismPortal2))))),
+            abi.encode(true)
+        );
+    }
+
+    function _mockValidRegistry(address _addr) internal {
+        vm.etch(_addr, hex"00");
+    }
+
     /// @notice Tests that `migrateToSharedDisputeGame` reverts if the caller is not the proxy admin
     ///         owner.
     function testFuzz_migrateToSharedDisputeGame_notProxyAdminOwner_reverts(address _caller) external {
@@ -756,6 +771,48 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
         optimismPortal2.migrateToSharedDisputeGame(IETHLockbox(_newLockbox), newAnchorStateRegistry);
     }
 
+    /// @notice Tests that `migrateToSharedDisputeGame` reverts when the new lockbox is the zero
+    ///         address.
+    function test_migrateToSharedDisputeGame_zeroLockbox_reverts() external {
+        address caller = optimismPortal2.proxyAdminOwner();
+        address registry = address(0x1234);
+        _mockValidRegistry(registry);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_ZeroAddress.selector);
+        vm.prank(caller);
+        optimismPortal2.migrateToSharedDisputeGame(IETHLockbox(address(0)), IAnchorStateRegistry(registry));
+    }
+
+    /// @notice Tests that `migrateToSharedDisputeGame` reverts when the new registry is the zero
+    ///         address.
+    function test_migrateToSharedDisputeGame_zeroRegistry_reverts() external {
+        address caller = optimismPortal2.proxyAdminOwner();
+        address lockbox = address(0x1234);
+        _mockValidLockbox(lockbox);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_ZeroAddress.selector);
+        vm.prank(caller);
+        optimismPortal2.migrateToSharedDisputeGame(IETHLockbox(lockbox), IAnchorStateRegistry(address(0)));
+    }
+
+    /// @notice Tests that `migrateToSharedDisputeGame` reverts when the new lockbox has not
+    ///         authorized this portal.
+    function test_migrateToSharedDisputeGame_lockboxNotAuthorizingPortal_reverts() external {
+        address caller = optimismPortal2.proxyAdminOwner();
+        address lockbox = address(0x1234);
+        address registry = address(0x5678);
+        // Etch code but mock authorizedPortals -> false.
+        vm.etch(lockbox, hex"00");
+        vm.mockCall(
+            lockbox,
+            abi.encodeCall(IETHLockbox.authorizedPortals, (IOptimismPortal(payable(address(optimismPortal2))))),
+            abi.encode(false)
+        );
+        _mockValidRegistry(registry);
+
+        vm.expectRevert(IOptimismPortal.OptimismPortal_LockboxNotAuthorizedForPortal.selector);
+        vm.prank(caller);
+        optimismPortal2.migrateToSharedDisputeGame(IETHLockbox(lockbox), IAnchorStateRegistry(registry));
+    }
+
     /// @notice Tests that `migrateToSharedDisputeGame` updates the ETHLockbox contract, updates the
     ///         AnchorStateRegistry, and sets the superRootsActive flag to true.
     /// @param _newLockbox The new ETHLockbox to migrate to.
@@ -770,6 +827,16 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
         address oldAnchorStateRegistry = address(optimismPortal2.anchorStateRegistry());
         vm.assume(_newLockbox != oldLockbox);
         vm.assume(_newAnchorStateRegistry != oldAnchorStateRegistry);
+        vm.assume(_newLockbox != _newAnchorStateRegistry);
+        vm.assume(_newLockbox != address(0) && _newAnchorStateRegistry != address(0));
+        // Avoid colliding with precompiles / existing contracts in the test harness.
+        assumeNotPrecompile(_newLockbox);
+        assumeNotPrecompile(_newAnchorStateRegistry);
+        vm.assume(_newLockbox.code.length == 0);
+        vm.assume(_newAnchorStateRegistry.code.length == 0);
+
+        _mockValidLockbox(_newLockbox);
+        _mockValidRegistry(_newAnchorStateRegistry);
 
         vm.expectEmit(address(optimismPortal2));
         emit PortalMigrated(oldLockbox, _newLockbox, oldAnchorStateRegistry, _newAnchorStateRegistry);


### PR DESCRIPTION
## Description

Add sanity checks to `OptimismPortal2.migrateToSharedDisputeGame` for zero-address and unauthorized lockbox. 

This is a defense-in-depth addition. The conventional `OPContractsManagerMigrator.migrate` path already calls `_newLockbox.authorizePortal(portal)` before `migrateToSharedDisputeGame` and prevents these input errors

fixes https://github.com/ethereum-optimism/optimism/issues/20881