### PR TITLE
Resize Fuzz-golang job to xlarge.gen2

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1614,7 +1614,7 @@ jobs:
         default: false
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: medium.gen2
+    resource_class: xlarge.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless


### PR DESCRIPTION
Updates the fuzz-golang job definition medium.gen2 to xlarge.gen2 

Rel: https://github.com/ethereum-optimism/optimism/pull/20927, ethereum-optimism/core-team#2564.

