### PR TITLE
fix(op-devstack): eliminate rollup-boost RPC port-bind race

### DIFF
--- a/op-devstack/sysgo/rollup_boost.go
+++ b/op-devstack/sysgo/rollup_boost.go
@@ -72,8 +72,11 @@ func (r *RollupBoostNode) Start() {
 
 	args, env := cfg.LaunchSpec(r.p)
 
-	// Create channel for discovering flashblocks WS port from process logs.
-	// When using port 0, the OS assigns the port at bind time and the process logs it.
+	// Channels for bound-port discovery via log parsing. rollup-boost is launched with
+	// port=0 so the OS atomically picks ports at bind time; pre-allocating in Go would
+	// close the listener before the subprocess could bind it, opening a race window.
+	rpcChan := make(chan string, 1)
+	defer close(rpcChan)
 	flashblocksWSChan := make(chan string, 1)
 	defer close(flashblocksWSChan)
 
@@ -84,9 +87,16 @@ func (r *RollupBoostNode) Start() {
 	// Log parsing callback to extract bound addresses from process output
 	onLogEntry := func(e logpipe.LogEntry) {
 		msg := e.LogMessage()
+		// RPC server - log message from cli.rs after Server::build()
+		if addr, ok := strings.CutPrefix(msg, "RPC server listening on "); ok {
+			select {
+			case rpcChan <- "http://" + addr:
+			default:
+			}
+			return
+		}
 		// Flashblocks WS - custom log message from outbound.rs
-		if strings.HasPrefix(msg, "Flashblocks WebSocketPublisher listening on ") {
-			addr := strings.TrimPrefix(msg, "Flashblocks WebSocketPublisher listening on ")
+		if addr, ok := strings.CutPrefix(msg, "Flashblocks WebSocketPublisher listening on "); ok {
 			select {
 			case flashblocksWSChan <- "ws://" + addr:
 			default:
@@ -116,11 +126,9 @@ func (r *RollupBoostNode) Start() {
 	err = r.sub.Start(execPath, args, env)
 	r.p.Require().NoError(err, "start rollup-boost")
 
-	// RPC port: still uses pre-allocation because rollup-boost doesn't log the actual
-	// bound RPC address when using port 0. This requires a Rust change to fix.
-	// TODO: Update rollup-boost to log "RPC server listening on {addr}" and parse it here.
-	rpcUpstreamURL := "http://" + cfg.RPCHost + ":" + strconv.Itoa(int(cfg.RPCPort))
-	waitTCPReady(r.p, rpcUpstreamURL, 5*time.Second)
+	// RPC: bound address comes from rollup-boost's "RPC server listening on …" log.
+	var rpcUpstreamURL string
+	r.p.Require().NoError(tasks.Await(r.p.Ctx(), rpcChan, &rpcUpstreamURL), "need RPC address from rollup-boost logs")
 	r.logger.Info("rollup-boost upstream RPC ready", "rpc", rpcUpstreamURL)
 	r.rpcProxy.SetUpstream(ProxyAddr(r.p.Require(), rpcUpstreamURL))
 	waitTCPReady(r.p, r.rpcProxyURL, 10*time.Second)
@@ -231,14 +239,7 @@ func (cfg *RollupBoostConfig) LaunchSpec(p devtest.CommonT) (args []string, env 
 		}
 	}
 
-	if cfg.RPCPort <= 0 {
-		portStr, err := getAvailableLocalPort()
-		p.Require().NoError(err, "allocate rollup-boost rpc port")
-		portVal, err := strconv.ParseUint(portStr, 10, 16)
-		p.Require().NoError(err, "parse rollup-boost rpc port")
-		cfg.RPCPort = uint16(portVal)
-	}
-	p.Require().True(cfg.RPCPort > 0, "RPCPort must be > 0")
+	// RPCPort=0 ⇒ kernel-atomic bind; bound address is parsed from logs in Start().
 	args = append(args, "--rpc-host="+cfg.RPCHost, "--rpc-port="+strconv.Itoa(int(cfg.RPCPort)))
 
 	if cfg.L2EngineURL != "" {

--- a/op-devstack/sysgo/rollup_boost.go
+++ b/op-devstack/sysgo/rollup_boost.go
@@ -75,10 +75,13 @@ func (r *RollupBoostNode) Start() {
 	// Channels for bound-port discovery via log parsing. rollup-boost is launched with
 	// port=0 so the OS atomically picks ports at bind time; pre-allocating in Go would
 	// close the listener before the subprocess could bind it, opening a race window.
+	//
+	// Buffered so a stray duplicate emit is dropped by the select-default below rather
+	// than blocking the parser goroutine. Channels are not closed: the parser callback
+	// outlives this function (it stays wired into r.sub), so closing would risk a
+	// send-on-closed panic on any late or repeat log line.
 	rpcChan := make(chan string, 1)
-	defer close(rpcChan)
 	flashblocksWSChan := make(chan string, 1)
-	defer close(flashblocksWSChan)
 
 	// Parse Rust-structured logs and forward into Go logger with attributes
 	logOut := logpipe.ToLoggerWithMinLevel(r.logger.New("stream", "stdout"), log.LevelWarn)

--- a/rust/rollup-boost/crates/rollup-boost/src/cli.rs
+++ b/rust/rollup-boost/crates/rollup-boost/src/cli.rs
@@ -156,6 +156,7 @@ impl RollupBoostServiceArgs {
             .set_http_middleware(http_middleware)
             .build(format!("{}:{}", self.rpc_host, self.rpc_port).parse::<SocketAddr>()?)
             .await?;
+        info!("RPC server listening on {}", server.local_addr()?);
         let handle = server.start(rpc_module);
 
         let stop_handle = handle.clone();


### PR DESCRIPTION
## Summary

- The rollup-boost **RPC** port is pre-allocated in Go (`net.Listen(":0")` → `Close()` → return the port number) and then handed to the Rust subprocess via `--rpc-port=N`. Between the Go-side `Close()` and the Rust-side `bind()` (hundreds of ms later, after Tokio init), any other `net.Listen(":0")` in the same test process can be handed the same port. Result: intermittent `EADDRINUSE` on `memory-all-opn-op-{reth,geth}`, surfacing as either fast-fail (`TestFlashblocksStream`, `TestFlashblocksTransfer` with "TCP endpoint not ready within 5s") or slow-hang (`TestFlashblocksTransfer` with 30-minute context timeout terminating at `op-devstack/sysgo/rollup_boost.go:132`).
- This binary's other ports (flashblocks WS, debug server) already avoid the race by passing `0` and logging the bound address. The RPC port was the lone outlier; the existing block comment at `op-devstack/sysgo/rollup_boost.go:119–122` flagged exactly this gap as a TODO.
- This PR closes the gap by adopting the same pattern for RPC. **Pre-allocation is removed entirely.**

Closes #19883
Closes #19934