### PR TITLE
fix(op-service/eth): make FuzzDetectNonBijectivity deterministic

### DIFF
--- a/op-service/eth/blob_test.go
+++ b/op-service/eth/blob_test.go
@@ -1,6 +1,8 @@
 package eth
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -145,15 +147,19 @@ func FuzzEncodeDecodeBlob(f *testing.F) {
 
 func FuzzDetectNonBijectivity(f *testing.F) {
 	var b Blob
-	r := rand.New(rand.NewSource(99))
 	f.Fuzz(func(t *testing.T, d []byte) {
 		b.Clear()
 		data := Data(d)
 		err := b.FromData(data)
 		require.NoError(t, err)
-		// randomly flip a bit and make sure the data either fails to decode or decodes differently
-		byteToFlip := r.Intn(BlobSize)
-		bitToFlip := r.Intn(8)
+		// Derive the bit to flip from d so the fuzz function is pure;
+		// non-determinism stalls the engine during minimization.
+		h := sha256.Sum256(d)
+		byteToFlip := int(binary.BigEndian.Uint32(h[0:4])) % BlobSize
+		if byteToFlip < 0 {
+			byteToFlip += BlobSize
+		}
+		bitToFlip := int(h[4]) % 8
 		mask := byte(1 << bitToFlip)
 		b[byteToFlip] = b[byteToFlip] ^ mask
 		decoded, err := b.ToData()


### PR DESCRIPTION
**Claude:** Authored by Claude on Adrian's behalf.

The shared `*rand.Rand` advanced state between calls, so the fuzz target was not a pure function of its input. Go's fuzz engine stalls when re-execution of an input differs, producing `process hung ... while minimizing: EOF`. Replace with `sha256(d)`-derived bit selection.

Closes ethereum-optimism/optimism#20936