### PR TITLE
fix(op-service/eth): stabilize blob fuzz targets

### DIFF
--- a/op-service/eth/blob.go
+++ b/op-service/eth/blob.go
@@ -91,7 +91,7 @@ func VerifyBlobProof(blob *Blob, commitment kzg4844.Commitment, proof kzg4844.Pr
 // of the data.
 func (b *Blob) FromData(data Data) error {
 	if len(data) > MaxBlobDataSize {
-		return fmt.Errorf("%w: len=%v", ErrBlobInputTooLarge, data)
+		return fmt.Errorf("%w: len=%d", ErrBlobInputTooLarge, len(data))
 	}
 	b.Clear()
 

--- a/op-service/eth/blob_test.go
+++ b/op-service/eth/blob_test.go
@@ -133,10 +133,12 @@ func TestTooLongDataEncoding(t *testing.T) {
 func FuzzEncodeDecodeBlob(f *testing.F) {
 	var b Blob
 	f.Fuzz(func(t *testing.T, d []byte) {
+		if len(d) > MaxBlobDataSize {
+			d = d[:MaxBlobDataSize]
+		}
 		b.Clear()
 		data := Data(d)
-		err := b.FromData(data)
-		require.NoError(t, err)
+		require.NoError(t, b.FromData(data))
 		decoded, err := b.ToData()
 		require.NoError(t, err)
 		require.Equal(t, data, decoded)

--- a/op-service/eth/blob_test.go
+++ b/op-service/eth/blob_test.go
@@ -1,6 +1,8 @@
 package eth
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -147,15 +149,19 @@ func FuzzEncodeDecodeBlob(f *testing.F) {
 
 func FuzzDetectNonBijectivity(f *testing.F) {
 	var b Blob
-	r := rand.New(rand.NewSource(99))
 	f.Fuzz(func(t *testing.T, d []byte) {
 		b.Clear()
 		data := Data(d)
 		err := b.FromData(data)
 		require.NoError(t, err)
-		// randomly flip a bit and make sure the data either fails to decode or decodes differently
-		byteToFlip := r.Intn(BlobSize)
-		bitToFlip := r.Intn(8)
+		// Derive the bit to flip from d so the fuzz function is pure;
+		// non-determinism stalls the engine during minimization.
+		h := sha256.Sum256(d)
+		byteToFlip := int(binary.BigEndian.Uint32(h[0:4])) % BlobSize
+		if byteToFlip < 0 {
+			byteToFlip += BlobSize
+		}
+		bitToFlip := int(h[4]) % 8
 		mask := byte(1 << bitToFlip)
 		b[byteToFlip] = b[byteToFlip] ^ mask
 		decoded, err := b.ToData()

--- a/op-service/eth/blob_test.go
+++ b/op-service/eth/blob_test.go
@@ -150,6 +150,9 @@ func FuzzEncodeDecodeBlob(f *testing.F) {
 func FuzzDetectNonBijectivity(f *testing.F) {
 	var b Blob
 	f.Fuzz(func(t *testing.T, d []byte) {
+		if len(d) > MaxBlobDataSize {
+			d = d[:MaxBlobDataSize]
+		}
 		b.Clear()
 		data := Data(d)
 		err := b.FromData(data)
@@ -165,7 +168,7 @@ func FuzzDetectNonBijectivity(f *testing.F) {
 		mask := byte(1 << bitToFlip)
 		b[byteToFlip] = b[byteToFlip] ^ mask
 		decoded, err := b.ToData()
-		if err != nil {
+		if err == nil {
 			require.NotEqual(t, data, decoded)
 		}
 	})

--- a/op-service/justfile
+++ b/op-service/justfile
@@ -6,13 +6,8 @@ test: (go_test "./...")
 # Generate mocks
 generate-mocks: (go_generate "./...")
 
-# Pin GOMAXPROCS to match the CI runner's vCPU budget. CircleCI Gen2 images
-# expose the full host core count to Go, so the fuzz harness spawns more
-# workers than the cgroup can schedule, which collapses throughput and
-# trips the Go fuzz coordinator-worker liveness heartbeats.
 [private]
-service_fuzz_task FUZZ TIME='60s':
-    GOMAXPROCS=8 go test -v -fuzztime {{TIME}} -fuzz {{FUZZ}} -run NOTAREALTEST ./eth
+service_fuzz_task FUZZ TIME='60s': (go_fuzz FUZZ TIME "./eth")
 
 # Run fuzzing tests
 fuzz:

--- a/op-service/justfile
+++ b/op-service/justfile
@@ -6,8 +6,13 @@ test: (go_test "./...")
 # Generate mocks
 generate-mocks: (go_generate "./...")
 
+# Pin GOMAXPROCS to match the CI runner's vCPU budget. CircleCI Gen2 images
+# expose the full host core count to Go, so the fuzz harness spawns more
+# workers than the cgroup can schedule, which collapses throughput and
+# trips the Go fuzz coordinator-worker liveness heartbeats.
 [private]
-service_fuzz_task FUZZ TIME='60s': (go_fuzz FUZZ TIME "./eth")
+service_fuzz_task FUZZ TIME='60s':
+    GOMAXPROCS=8 go test -v -fuzztime {{TIME}} -fuzz {{FUZZ}} -run NOTAREALTEST ./eth
 
 # Run fuzzing tests
 fuzz:


### PR DESCRIPTION
**Claude:** Authored by Claude on Adrian's behalf.

Two correctness fixes in the blob fuzz path that surfaced while chasing a CI flake:

- `blob.go`: format `len(data)` (`%d`) instead of the full payload (`%v`) in the `ErrBlobInputTooLarge` error. The previous form produced a ~260 KiB hex string per oversize input.
- `FuzzEncodeDecodeBlob`: truncate `d` to `MaxBlobDataSize` so every input exercises the round-trip.
- `FuzzDetectNonBijectivity`: derive the bit to flip from `sha256(d)` instead of a shared `*rand.Rand` — Go fuzz requires deterministic targets.

The original CI flake was on `fuzz-golang-op-service` running at `medium.gen2` (2 vCPU) via the W4 pilot in ethereum-optimism/optimism#20899; the runner has since been resized back to `xlarge.gen2` in ethereum-optimism/optimism#20931. This PR is rebased onto develop to pick up that resize, and verifies the remaining test changes pass on the proper runner.

Closes ethereum-optimism/optimism#20935
Closes ethereum-optimism/optimism#20936