### PR TITLE
fix(op-e2e): stabilise TestSequenceWindowExpired by pinning Bob's L2 nonce

### DIFF
--- a/op-e2e/actions/helpers/user.go
+++ b/op-e2e/actions/helpers/user.go
@@ -218,6 +218,14 @@ func (s *BasicUser[B]) ActSetGasFeeCap(feeCap *big.Int) Action {
 	}
 }
 
+// ActSetTxNonce pins the nonce for the next MakeTransaction/ActMakeTx,
+// bypassing PendingNonceAt for callers that need a deterministic sequence.
+func (s *BasicUser[B]) ActSetTxNonce(nonce uint64) Action {
+	return func(t Testing) {
+		s.txOpts.Nonce = new(big.Int).SetUint64(nonce)
+	}
+}
+
 func (s *BasicUser[B]) ActRandomTxData(t Testing) {
 	t.Helper()
 	dataLen := s.rng.Intn(128_000)

--- a/op-e2e/actions/proofs/sequence_window_expiry_test.go
+++ b/op-e2e/actions/proofs/sequence_window_expiry_test.go
@@ -104,6 +104,12 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	numL1Blocks := 0
 	timeout := tp.SequencerWindowSize * 50
 
+	// Track Bob's nonce locally. RecoverMode means his txs are never included,
+	// so the on-chain nonce never advances; relying on PendingNonceAt across
+	// chain-head events has been observed to flake with "already known".
+	bobL2PoolNonce, err := env.Engine.EthClient().PendingNonceAt(t.Ctx(), env.Bob.Address())
+	require.NoError(t, err, "must read Bob's initial L2 pool nonce")
+
 	for numL1Blocks < int(timeout) {
 		for range 100 * tp.L1BlockTime / env.Sd.RollupCfg.BlockTime { // go at 100x real time
 			err := env.Sequencer.ActMaybeL2StartBlock(t)
@@ -111,7 +117,9 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 				break
 			}
 			env.Bob.L2.ActResetTxOpts(t)
+			env.Bob.L2.ActSetTxNonce(bobL2PoolNonce)(t)
 			env.Bob.L2.ActMakeTx(t)
+			bobL2PoolNonce++
 			env.Engine.ActL2IncludeTx(env.Bob.Address())(t)
 			// RecoverMode (enabled above) should prevent this
 			// transaction from being included in the block, which


### PR DESCRIPTION
Fixes ethereum-optimism/optimism#20941.

## Summary
`TestSequenceWindowExpired` has flaked 16+ times in the last ~2 weeks across matrix variants with `must send tx: already known` from `BasicUser.ActMakeTx` (`op-e2e/actions/helpers/user.go:288`). The RecoverMode inner loop sends one Bob tx per block while RecoverMode forces the engine to skip including it, so Bob's on-chain nonce never advances. Each iteration derives the next nonce from `eth_getTransactionCount(pending)`. Under chain-head churn fired by `ActL2EndBlock`, the pool-reported nonce can fail to advance; once basefee has stabilised (nothing being included), all other tx fields are identical iteration-to-iteration, so identical nonce produces an identical hash and the second `SendTransaction` returns `already known`.

This PR sidesteps the dependency on the txpool's pending-nonce bookkeeping by tracking Bob's L2 pool nonce locally in the test. Each iteration uses a unique nonce by construction, so identical hashes are structurally impossible regardless of how the pool's pending-nonce table evolves under chain-head churn.

- Adds `BasicUser.ActSetTxNonce(nonce uint64) Action` — pins `txOpts.Nonce`. `MakeTransaction` already short-circuits `PendingNonce` when `txOpts.Nonce` is non-nil.
- Test reads Bob's initial pool nonce once before the loop, calls `ActSetTxNonce` after each `ActResetTxOpts`, and increments after each `ActMakeTx`. The cleanup loop after RecoverMode is disabled still uses `PendingNonceAt` (correct — Bob's prior txs have left the pool by then).

## Caveats
- **No local repro.** 120+ baseline runs (`-count=30` full matrix, `-count=20` single variant) did not reproduce. The fix is not validated against a before/after failure-rate delta; confidence rests on the structural argument that the loop no longer depends on `PendingNonceAt`. Per-run failure rate in CI is well under 1%, consistent with a narrow scheduling race that only fires under CI CPU contention.
- **Follow-up:** other tests in `op-e2e/actions/proofs/` use the same `ActResetTxOpts` + `ActMakeTx` pattern in unincluded-tx loops. They could plausibly flake the same way. Out of scope here; noted on the tracking issue.

## Test plan
- [x] `go build ./op-e2e/actions/proofs/... ./op-e2e/actions/helpers/...` clean
- [x] `go vet ./op-e2e/actions/proofs/... ./op-e2e/actions/helpers/...` clean
- [x] `go test ./op-e2e/actions/proofs/ -run 'TestSequenceWindowExpired' -count=30 -timeout 60m` — 120/120 pass with fix applied
- [ ] CI green