### PR TITLE
test(supernode): wait on EL finalized before fresh-data-dir restart

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/startup_resync/startup_resync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/startup_resync/startup_resync_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
@@ -40,9 +41,15 @@ func TestSupernodeResyncResumesAtActivation_PostActivation(gt *testing.T) {
 	// genesis the post-restart cold-start backfill has a real window to
 	// populate, instead of collapsing to empty against a re-recorded
 	// genesis SafeDB entry.
+	//
+	// Wait on both the CL and the EL: the CL's safety.Finalized advances
+	// in-memory before the corresponding forkchoiceUpdated is persisted by
+	// the EL, and only the EL's view is durable across the supernode wipe.
 	dsl.CheckAll(t,
 		sys.L2ACL.AdvancedFn(safety.Finalized, preRestartFinalized, 180),
 		sys.L2BCL.AdvancedFn(safety.Finalized, preRestartFinalized, 180),
+		sys.L2ELA.AdvancedFn(eth.Finalized, preRestartFinalized, dsl.WithTimeout(180)),
+		sys.L2ELB.AdvancedFn(eth.Finalized, preRestartFinalized, dsl.WithTimeout(180)),
 	)
 
 	sys.Supernode.RestartWithFreshDataDir()

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -67,13 +67,30 @@ func (el *L2ELNode) BlockRefByHash(hash common.Hash) eth.L2BlockRef {
 	return block
 }
 
-func (el *L2ELNode) AdvancedFn(label eth.BlockLabel, block uint64) CheckFunc {
+// AdvancedOption configures an AdvancedFn call.
+type AdvancedOption func(*advancedOpts)
+
+type advancedOpts struct {
+	attempts int // number of 2-second polling attempts
+}
+
+// WithTimeout overrides AdvancedFn's default polling budget. The argument is
+// the number of attempts; each attempt polls 2 seconds apart, so attempts*2
+// is the total wall-clock timeout.
+func WithTimeout(attempts int) AdvancedOption {
+	return func(o *advancedOpts) { o.attempts = attempts }
+}
+
+func (el *L2ELNode) AdvancedFn(label eth.BlockLabel, block uint64, opts ...AdvancedOption) CheckFunc {
+	o := advancedOpts{attempts: int(block + 30)}
+	for _, opt := range opts {
+		opt(&o)
+	}
 	return func() error {
 		initial := el.BlockRefByLabel(label)
 		target := initial.Number + block
-		el.log.Info("expecting chain to advance", "chain", el.inner.ChainID(), "label", label, "target", target)
-		attempts := int(block + 3) // intentionally allow few more attempts for avoid flaking
-		return retry.Do0(el.ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
+		el.log.Info("expecting chain to advance", "chain", el.inner.ChainID(), "label", label, "target", target, "attempts", o.attempts)
+		return retry.Do0(el.ctx, o.attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
 			func() error {
 				head := el.BlockRefByLabel(label)
 				if head.Number >= target {


### PR DESCRIPTION
Closes ethereum-optimism/optimism#20944.

`TestSupernodeResyncResumesAtActivation_PostActivation` was flaking (~6 hits in CI Insights) with `first seal ts == backfill handoff ts == activationTimestamp`, breaking `Lessf(first.Timestamp, backfillHandoff)` in `AssertBackfillCovers`.

Root cause: the supernode CL's `safety.Finalized` advances in-memory before the corresponding `forkchoiceUpdated` is delivered to and persisted by the EL. The test only waited on the CL's view, so under CI scheduling pressure `RestartWithFreshDataDir` could fire inside that window. op-reth then still reported `finalized = L2 genesis` to the fresh op-node, which correctly reset the pipeline back to genesis, wrote the `L1=0 / L2=genesis` SafeDB pin in `onEngineConfirmedReset`, and collapsed the cold-start backfill window to empty.

Fix is test-only — the supernode's reset-to-genesis behaviour is correct given op-reth's persisted state:

- Wait on each EL's `eth.Finalized` label as well as the CL's `safety.Finalized` so op-reth has persisted the advance before we wipe the supernode data dir.
- `L2ELNode.AdvancedFn` now defaults to `block+30` polling attempts (was `block+3`) and takes a varargs `WithTimeout` option so callers can extend the budget. The supernode test passes `WithTimeout(180)` to match the CL wait (180 attempts × 2s = 360s).

No deterministic local repro — flake requires CI scheduling to land the restart inside the CL→EL FCU window.