### PR TITLE
test(op-acceptance-tests): speed up depreqres tests to make CI faster

### DIFF
--- a/op-acceptance-tests/tests/depreqres/common/common.go
+++ b/op-acceptance-tests/tests/depreqres/common/common.go
@@ -59,6 +59,7 @@ func ReqRespSyncDisabledOpts(syncMode sync.Mode) []presets.Option {
 		reqRespSyncDisabledOpt(),
 		noDiscoveryOpt(),
 		batcherStoppedOpt(),
+		presets.WithUniformL2BlockTimes(1),
 	}
 }
 
@@ -68,6 +69,7 @@ func SyncModeReqRespSyncOpts(syncMode sync.Mode) []presets.Option {
 		syncModeReqRespSyncOpt(),
 		noDiscoveryOpt(),
 		batcherStoppedOpt(),
+		presets.WithUniformL2BlockTimes(1),
 	}
 }
 

--- a/op-acceptance-tests/tests/depreqres/reqressyncdisabled/clsync/clsync_test.go
+++ b/op-acceptance-tests/tests/depreqres/reqressyncdisabled/clsync/clsync_test.go
@@ -7,14 +7,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
-func TestUnsafeChainNotStalling_CLSync_Short(gt *testing.T) {
-	common.UnsafeChainNotStalling_Disconnect(gt, sync.CLSync, 10, common.ReqRespSyncDisabledOpts(sync.CLSync)...)
+func TestUnsafeChainNotStalling_CLSync(gt *testing.T) {
+	common.UnsafeChainNotStalling_Disconnect(gt, sync.CLSync, 20, common.ReqRespSyncDisabledOpts(sync.CLSync)...)
 }
 
-func TestUnsafeChainNotStalling_CLSync_Long(gt *testing.T) {
-	common.UnsafeChainNotStalling_Disconnect(gt, sync.CLSync, 47, common.ReqRespSyncDisabledOpts(sync.CLSync)...)
-}
-
-func TestUnsafeChainNotStalling_CLSync_RestartOpNode_Long(gt *testing.T) {
-	common.UnsafeChainNotStalling_RestartOpNode(gt, sync.CLSync, 47, common.ReqRespSyncDisabledOpts(sync.CLSync)...)
+func TestUnsafeChainNotStalling_CLSync_RestartOpNode(gt *testing.T) {
+	common.UnsafeChainNotStalling_RestartOpNode(gt, sync.CLSync, 20, common.ReqRespSyncDisabledOpts(sync.CLSync)...)
 }

--- a/op-acceptance-tests/tests/depreqres/reqressyncdisabled/elsync/elsync_test.go
+++ b/op-acceptance-tests/tests/depreqres/reqressyncdisabled/elsync/elsync_test.go
@@ -7,14 +7,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
-func TestUnsafeChainNotStalling_ELSync_Short(gt *testing.T) {
-	common.UnsafeChainNotStalling_Disconnect(gt, sync.ELSync, 10, common.ReqRespSyncDisabledOpts(sync.ELSync)...)
+func TestUnsafeChainNotStalling_ELSync(gt *testing.T) {
+	common.UnsafeChainNotStalling_Disconnect(gt, sync.ELSync, 20, common.ReqRespSyncDisabledOpts(sync.ELSync)...)
 }
 
-func TestUnsafeChainNotStalling_ELSync_Long(gt *testing.T) {
-	common.UnsafeChainNotStalling_Disconnect(gt, sync.ELSync, 47, common.ReqRespSyncDisabledOpts(sync.ELSync)...)
-}
-
-func TestUnsafeChainNotStalling_ELSync_RestartOpNode_Long(gt *testing.T) {
-	common.UnsafeChainNotStalling_RestartOpNode(gt, sync.ELSync, 47, common.ReqRespSyncDisabledOpts(sync.ELSync)...)
+func TestUnsafeChainNotStalling_ELSync_RestartOpNode(gt *testing.T) {
+	common.UnsafeChainNotStalling_RestartOpNode(gt, sync.ELSync, 20, common.ReqRespSyncDisabledOpts(sync.ELSync)...)
 }

--- a/op-acceptance-tests/tests/depreqres/syncmodereqressync/clsync/clsync_test.go
+++ b/op-acceptance-tests/tests/depreqres/syncmodereqressync/clsync/clsync_test.go
@@ -7,14 +7,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
-func TestUnsafeChainNotStalling_CLSync_Short(gt *testing.T) {
-	common.UnsafeChainNotStalling_Disconnect(gt, sync.CLSync, 10, common.SyncModeReqRespSyncOpts(sync.CLSync)...)
+func TestUnsafeChainNotStalling_CLSync(gt *testing.T) {
+	common.UnsafeChainNotStalling_Disconnect(gt, sync.CLSync, 20, common.SyncModeReqRespSyncOpts(sync.CLSync)...)
 }
 
-func TestUnsafeChainNotStalling_CLSync_Long(gt *testing.T) {
-	common.UnsafeChainNotStalling_Disconnect(gt, sync.CLSync, 47, common.SyncModeReqRespSyncOpts(sync.CLSync)...)
-}
-
-func TestUnsafeChainNotStalling_CLSync_RestartOpNode_Long(gt *testing.T) {
-	common.UnsafeChainNotStalling_RestartOpNode(gt, sync.CLSync, 47, common.SyncModeReqRespSyncOpts(sync.CLSync)...)
+func TestUnsafeChainNotStalling_CLSync_RestartOpNode(gt *testing.T) {
+	common.UnsafeChainNotStalling_RestartOpNode(gt, sync.CLSync, 20, common.SyncModeReqRespSyncOpts(sync.CLSync)...)
 }

--- a/op-acceptance-tests/tests/depreqres/syncmodereqressync/elsync/elsync_test.go
+++ b/op-acceptance-tests/tests/depreqres/syncmodereqressync/elsync/elsync_test.go
@@ -7,14 +7,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
-func TestUnsafeChainNotStalling_ELSync_Short(gt *testing.T) {
-	common.UnsafeChainNotStalling_Disconnect(gt, sync.ELSync, 10, common.SyncModeReqRespSyncOpts(sync.ELSync)...)
+func TestUnsafeChainNotStalling_ELSync(gt *testing.T) {
+	common.UnsafeChainNotStalling_Disconnect(gt, sync.ELSync, 20, common.SyncModeReqRespSyncOpts(sync.ELSync)...)
 }
 
-func TestUnsafeChainNotStalling_ELSync_Long(gt *testing.T) {
-	common.UnsafeChainNotStalling_Disconnect(gt, sync.ELSync, 47, common.SyncModeReqRespSyncOpts(sync.ELSync)...)
-}
-
-func TestUnsafeChainNotStalling_ELSync_RestartOpNode_Long(gt *testing.T) {
-	common.UnsafeChainNotStalling_RestartOpNode(gt, sync.ELSync, 47, common.SyncModeReqRespSyncOpts(sync.ELSync)...)
+func TestUnsafeChainNotStalling_ELSync_RestartOpNode(gt *testing.T) {
+	common.UnsafeChainNotStalling_RestartOpNode(gt, sync.ELSync, 20, common.SyncModeReqRespSyncOpts(sync.ELSync)...)
 }


### PR DESCRIPTION
Collapse the `Short`/`Long` variants of the `UnsafeChainNotStalling` tests into a single 20-block run and set a uniform 1s L2 block time via `WithUniformL2BlockTimes(1)`. The previous `Long` variants ran for 47 blocks at the default block time, which dominated CI runtime; the consolidated configuration exercises the same sync paths in a fraction of the time.