### PR TITLE
docs: update kona prestate build instructions

### DIFF
--- a/rust/kona/docker/fpvm-prestates/README.md
+++ b/rust/kona/docker/fpvm-prestates/README.md
@@ -18,15 +18,6 @@ This builds both supported variants:
 - `kona-client` into `rust/kona/prestate-artifacts-cannon`
 - `kona-client-int` into `rust/kona/prestate-artifacts-cannon-interop`
 
-### Build a single reproducible prestate variant
-
-```sh
-cd rust
-just build-kona-reproducible-prestate-variant <kona-client|kona-client-int> <artifacts_output_dir>
-```
-
-The output directory is relative to `rust/kona`.
-
 ### Build reproducible prestate artifacts for custom chains
 
 To create a reproducible kona-client prestate build that supports custom or devnet chain configurations that are not in the superchain-registry:

--- a/rust/kona/docker/fpvm-prestates/README.md
+++ b/rust/kona/docker/fpvm-prestates/README.md
@@ -6,23 +6,33 @@ Cannon is built from the local monorepo source.
 
 ## Usage
 
-### `kona-client` + `cannon` prestate artifacts
+### Build all reproducible `kona-client` + `cannon` prestate artifacts
 
 ```sh
-# Produce the prestate artifacts for `kona-client` running on `cannon` (built from local monorepo source)
-just cannon <kona|kona-int>
+# From the monorepo root
+just reproducible-prestate-kona
 ```
 
-### `kona-client` + `cannon` prestate artifacts with custom output directory
+This builds both supported variants:
+
+- `kona-client` into `rust/kona/prestate-artifacts-cannon`
+- `kona-client-int` into `rust/kona/prestate-artifacts-cannon-interop`
+
+### Build a single reproducible prestate variant
 
 ```sh
-just cannon <kona|kona-int> <artifacts_output_dir>
+cd rust
+just build-kona-reproducible-prestate-variant <kona-client|kona-client-int> <artifacts_output_dir>
 ```
 
-### `kona-client` + `cannon` prestate artifacts for custom chains
+The output directory is relative to `rust/kona`.
+
+### Build reproducible prestate artifacts for custom chains
 
 To create a reproducible kona-client prestate build that supports custom or devnet chain configurations that are not in the superchain-registry:
 
 ```sh
-just cannon <kona|kona-int> <artifacts_output_dir> <custom_config_dir>
+cd rust
+KONA_CUSTOM_CONFIGS_DIR=<custom_config_dir> \
+  just build-kona-reproducible-prestate-variant <kona-client|kona-client-int> <artifacts_output_dir>
 ```


### PR DESCRIPTION
Updates the Kona FPVM prestate README to document the current reproducible build flow