### PR TITLE
fix(op-interop-filter): fix backfill progress metric never emitting

### DIFF
--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -197,7 +197,7 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 
 	if !b.Ready() {
 		b.metrics.RecordCheckAccessList(false)
-		b.metrics.RecordCheckAccessListRejection("failsafe")
+		b.metrics.RecordCheckAccessListRejection("not_ready")
 		b.log.Debug("Backend not ready; rejecting access list check")
 		return types.ErrUninitialized
 	}

--- a/op-interop-filter/filter/backend_reorg_recovery.go
+++ b/op-interop-filter/filter/backend_reorg_recovery.go
@@ -40,6 +40,7 @@ func (b *Backend) tryResolveReorgs(ctx context.Context) {
 
 		b.crossValidator.ResetCrossValidatedTimestamp(timestamp)
 		ingester.ClearError()
+		b.metrics.RecordFailsafeEnabled(b.FailsafeEnabled())
 		b.log.Info("Auto-resolved reorg-triggered failsafe",
 			"chain", chainID,
 			"target", eth.Finalized,

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -830,15 +830,22 @@ func (c *LogsDBChainIngester) writeFetchedBlock(fetched blockFetch) error {
 }
 
 func (c *LogsDBChainIngester) recordIngestionProgress(blockNum, head uint64) {
-	startingBlock := c.calculateStartingBlock()
-	if blockNum <= startingBlock {
-		earliest := c.earliestIngestedBlock.Load()
-		progress := float64(blockNum-earliest+1) / float64(startingBlock-earliest+1)
+	chainIDUint64, _ := c.chainID.Uint64()
+	if !c.Ready() {
+		startingBlock := c.calculateStartingBlock()
+		total := head - startingBlock
+		if total == 0 {
+			total = 1
+		}
+		done := blockNum - startingBlock
+		progress := float64(done) / float64(total)
+		if progress > 1.0 {
+			progress = 1.0
+		}
 		c.log.Info("Ingestion progress",
 			"block", blockNum,
-			"target", startingBlock,
+			"target", head,
 			"progress", fmt.Sprintf("%.0f%%", progress*100))
-		chainIDUint64, _ := c.chainID.Uint64()
 		c.metrics.RecordBackfillProgress(chainIDUint64, progress)
 	} else {
 		c.log.Debug("Ingestion progress", "block", blockNum, "head", head)

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -319,7 +319,7 @@ func TestLogsDBChainIngester_IngestBlockRange_FetchFailureReturnsFailingBlock(t 
 	require.Equal(t, uint64(101), latestBlock.Number)
 }
 
-func TestLogsDBChainIngester_RecordIngestionProgressCountsCompletedBlock(t *testing.T) {
+func TestLogsDBChainIngester_RecordIngestionProgressDuringBackfill(t *testing.T) {
 	chainID := eth.ChainIDFromUInt64(901)
 	recorder := &backfillProgressMetrics{Metricer: metrics.NoopMetrics}
 
@@ -331,13 +331,17 @@ func TestLogsDBChainIngester_RecordIngestionProgressCountsCompletedBlock(t *test
 	})
 	ingester.metrics = recorder
 	ingester.startTimestamp = 400
-	ingester.backfillDuration = 0
-	ingester.earliestIngestedBlock.Store(100)
-	ingester.earliestIngestedBlockSet.Store(true)
+	ingester.backfillDuration = 200 * time.Second // backfill starts at timestamp 200 → block 100
 
-	ingester.recordIngestionProgress(200, 200)
+	// Ingestion is at block 150 out of head=200 (startingBlock=100)
+	// Progress = (150-100)/(200-100) = 50/100 = 0.5
+	ingester.recordIngestionProgress(150, 200)
 
 	require.Equal(t, uint64(901), recorder.chainID)
+	require.Equal(t, 0.5, recorder.progress)
+
+	// At head: progress should be 1.0
+	ingester.recordIngestionProgress(200, 200)
 	require.Equal(t, 1.0, recorder.progress)
 }
 


### PR DESCRIPTION
## Summary

- The `backfill_progress` gauge and `Ingestion progress` info log were gated by `blockNum <= startingBlock`, but ingestion runs **forward** from `startingBlock` toward head — so `blockNum` is always `>= startingBlock` and the condition was never true
- Switches the gate to `!c.Ready()` which correctly identifies the backfill phase
- Computes progress as `(blockNum - startingBlock) / (head - startingBlock)` instead of the inverted calculation

## Context

Discovered while investigating why `op_interop_filter_default_backfill_progress` was missing from Grafana metrics for interop-jnt-v2. The filter was actively backfilling for 30+ minutes with `Ingested block` logs flowing, but neither the progress metric nor the `Ingestion progress` info log ever fired.

## Test plan

- [x] Updated `TestLogsDBChainIngester_RecordIngestionProgressDuringBackfill` to verify progress at 50% and 100%
- [x] All `op-interop-filter` tests pass