### PR TITLE
Add op-reth proofs-history reorg crash repro

### DIFF
--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
@@ -118,15 +119,147 @@ func TestReorgInvalidExecMsgOpRethCrashRestart(gt *testing.T) {
 		})
 }
 
+func TestReorgInvalidExecMsgOpRethProofsHistoryTinyWindow(gt *testing.T) {
+	testReorgInvalidExecMsgWithOptionsAndHooks(gt,
+		[]presets.Option{
+			presets.WithOpRethOption(sysgo.OpRethWithProofsHistoryWindow(1)),
+		},
+		func(msg *messages.Message) {
+			msg.Identifier.LogIndex = 1024
+		},
+		func(t devtest.T, sys *presets.TwoL2SupernodeInterop, original eth.L2BlockRef) {
+			sys.Log.Info("waiting for tiny proofs-history window to flush before CL-driven reorg",
+				"number", original.Number,
+				"hash", original.Hash)
+			select {
+			case <-t.Ctx().Done():
+				t.Require().NoError(t.Ctx().Err())
+			case <-time.After(12 * time.Second):
+			}
+		},
+		func(t devtest.T, sys *presets.TwoL2SupernodeInterop, original eth.L2BlockRef) {
+			ctx := t.Ctx()
+			sys.Log.Info("waiting for op-reth to exit after proofs-history reorg unwind",
+				"number", original.Number,
+				"hash", original.Hash)
+			require.Eventually(t, func() bool {
+				_, err := sys.L2ELA.Escape().L2EthClient().L2BlockRefByLabel(ctx, eth.Unsafe)
+				if err == nil {
+					return false
+				}
+				sys.Log.Info("observed op-reth RPC failure after proofs-history unwind", "err", err)
+				return true
+			}, time.Minute, 200*time.Millisecond, "expected op-reth to exit during proofs-history reorg unwind")
+			failAfterSustainedTinyProofWindowStall(t, sys, original, 30*time.Second)
+		},
+		false)
+}
+
+func failAfterSustainedTinyProofWindowStall(
+	t devtest.T,
+	sys *presets.TwoL2SupernodeInterop,
+	original eth.L2BlockRef,
+	duration time.Duration,
+) {
+	ctx := t.Ctx()
+	l := sys.Log
+	el := sys.L2ELA.Escape().L2EthClient()
+	supernode := sys.SuperNodeClient()
+	chainID := sys.L2A.ChainID()
+
+	baseline, baselineErr := supernode.SyncStatus(ctx)
+	start := time.Now()
+	var lastEL any
+	var lastSupernode any
+	var lastLog time.Time
+
+	for time.Since(start) < duration {
+		unsafe, elErr := el.L2BlockRefByLabel(ctx, eth.Unsafe)
+		status, statusErr := supernode.SyncStatus(ctx)
+		chainStatus, chainStatusOK := status.Chains[chainID]
+
+		if elErr != nil {
+			lastEL = elErr
+		} else {
+			lastEL = unsafe
+		}
+		if statusErr != nil {
+			lastSupernode = statusErr
+		} else if !chainStatusOK {
+			lastSupernode = fmt.Errorf("supernode_syncStatus missing chain %s", chainID)
+		} else {
+			lastSupernode = chainStatus
+		}
+
+		if elErr == nil && statusErr == nil && chainStatusOK && chainStatus.SafeL2.Number > original.Number {
+			require.Failf(t,
+				"unexpected recovery",
+				"op-reth RPC recovered and supernode chain A safe advanced past reorg point: original=%s el_unsafe=%s supernode_safe=%s supernode_unsafe=%s",
+				original, unsafe, chainStatus.SafeL2, chainStatus.UnsafeL2)
+		}
+
+		if lastLog.IsZero() || time.Since(lastLog) >= 5*time.Second {
+			lastLog = time.Now()
+			l.Info("observing tiny proofs-history repro non-recovery",
+				"elapsed", time.Since(start),
+				"duration", duration,
+				"original", original,
+				"baseline_supernode_status", supernodeChainStatusOrErr(baseline, chainID, baselineErr),
+				"el_unsafe", blockRefOrErr(unsafe, elErr),
+				"supernode_status", supernodeChainStatusOrErr(status, chainID, statusErr))
+		}
+
+		select {
+		case <-ctx.Done():
+			require.NoError(t, ctx.Err())
+		case <-time.After(time.Second):
+		}
+	}
+
+	require.Failf(t,
+		"repro observed",
+		"op-reth exited during proofs-history reorg unwind and supernode did not recover for %s: original=%s baseline_supernode_status=%v last_el_unsafe=%v last_supernode_status=%v",
+		duration, original, supernodeChainStatusOrErr(baseline, chainID, baselineErr), lastEL, lastSupernode)
+}
+
+func blockRefOrErr(ref eth.L2BlockRef, err error) any {
+	if err != nil {
+		return err
+	}
+	return ref
+}
+
+func supernodeChainStatusOrErr(status eth.SuperNodeSyncStatusResponse, chainID eth.ChainID, err error) any {
+	if err != nil {
+		return err
+	}
+	chainStatus, ok := status.Chains[chainID]
+	if !ok {
+		return fmt.Errorf("supernode_syncStatus missing chain %s", chainID)
+	}
+	return chainStatus
+}
+
 func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *messages.Message)) {
 	testReorgInvalidExecMsgWithHook(gt, txModifierFn, nil)
 }
 
 func testReorgInvalidExecMsgWithHook(gt *testing.T, txModifierFn func(msg *messages.Message), afterReorgStarted func(devtest.T, *presets.TwoL2SupernodeInterop, eth.L2BlockRef)) {
+	testReorgInvalidExecMsgWithOptionsAndHooks(gt, nil, txModifierFn, nil, afterReorgStarted, true)
+}
+
+func testReorgInvalidExecMsgWithOptionsAndHooks(
+	gt *testing.T,
+	opts []presets.Option,
+	txModifierFn func(msg *messages.Message),
+	beforeSequencerRestart func(devtest.T, *presets.TwoL2SupernodeInterop, eth.L2BlockRef),
+	afterReorgStarted func(devtest.T, *presets.TwoL2SupernodeInterop, eth.L2BlockRef),
+	expectRecovery bool,
+) {
 	t := devtest.ParallelT(gt)
 	ctx := t.Ctx()
 
-	sys := presets.NewTwoL2SupernodeInterop(t, 0)
+	sys := presets.NewTwoL2SupernodeInterop(t, 0, opts...)
 	l := sys.Log
 
 	ia := sys.TestSequencer.Escape().ControlAPI(sys.L2A.ChainID())
@@ -290,19 +423,27 @@ func testReorgInvalidExecMsgWithHook(gt *testing.T, txModifierFn func(msg *messa
 		require.NoError(t, err, "op-node never observed test-sequencer's committed unsafe head %s", expectedUnsafe.Hash)
 	}
 
+	originalRef_A := eth.L2BlockRef{
+		Number:     divergenceBlockNumber_A,
+		Hash:       originalHash_A,
+		ParentHash: originalParentHash_A,
+	}
+	if beforeSequencerRestart != nil {
+		beforeSequencerRestart(t, sys, originalRef_A)
+	}
+
 	// continue sequencing with the supernode
 	sys.L2ACL.StartSequencer()
 
 	// start batcher on chain A
 	sys.L2BatcherA.Start()
 
-	originalRef_A := eth.L2BlockRef{
-		Number:     divergenceBlockNumber_A,
-		Hash:       originalHash_A,
-		ParentHash: originalParentHash_A,
-	}
 	if afterReorgStarted != nil {
 		afterReorgStarted(t, sys, originalRef_A)
+	}
+
+	if !expectRecovery {
+		return
 	}
 
 	// wait for reorg on chain A

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -70,12 +70,12 @@ func TestReorgInvalidExecMsgOpRethCrashRestart(gt *testing.T) {
 					l.Info("waiting for divergence block to be replaced", "number", original.Number, "hash", ref.Hash)
 					return false
 				}
-				t.Require().Equal(original.ParentHash, ref.ParentHash, "replacement block has unexpected parent")
 				replacement = ref
 				return true
 			}, 2*time.Minute, 200*time.Millisecond, "expected replacement block at divergence height %d", original.Number)
+			require.Equal(t, original.ParentHash, replacement.ParentHash, "replacement block has unexpected parent")
 
-			l.Info("crashing op-reth after replacement ancestor import",
+			l.Info("crashing op-reth after replacement divergence block import",
 				"number", replacement.Number,
 				"replacement", replacement.Hash,
 				"original", original.Hash)

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -118,11 +118,18 @@ func failAfterSustainedTinyProofWindowStall(
 			lastSupernode = chainStatus
 		}
 
-		if elErr == nil && statusErr == nil && chainStatusOK && chainStatus.SafeL2.Number > original.Number {
+		if elErr == nil && unsafe.Number > original.Number {
 			require.Failf(t,
 				"unexpected recovery",
-				"op-reth RPC recovered and supernode chain A safe advanced past reorg point: original=%s el_unsafe=%s supernode_safe=%s supernode_unsafe=%s",
-				original, unsafe, chainStatus.SafeL2, chainStatus.UnsafeL2)
+				"chain A op-reth RPC recovered and EL unsafe advanced past reorg point: original=%s el_unsafe=%s supernode_status=%v",
+				original, unsafe, supernodeChainStatusOrErr(status, chainID, statusErr))
+		}
+		if statusErr == nil && chainStatusOK &&
+			(chainStatus.LocalSafeL2.Number > original.Number || chainStatus.SafeL2.Number > original.Number) {
+			require.Failf(t,
+				"unexpected supernode recovery",
+				"supernode chain A advanced past reorg point: original=%s local_safe=%s cross_safe=%s unsafe=%s el_unsafe=%v",
+				original, chainStatus.LocalSafeL2, chainStatus.SafeL2, chainStatus.UnsafeL2, blockRefOrErr(unsafe, elErr))
 		}
 
 		if lastLog.IsZero() || time.Since(lastLog) >= 5*time.Second {
@@ -145,7 +152,7 @@ func failAfterSustainedTinyProofWindowStall(
 
 	require.Failf(t,
 		"repro observed",
-		"op-reth exited during proofs-history reorg unwind and supernode did not recover for %s: original=%s baseline_supernode_status=%v last_el_unsafe=%v last_supernode_status=%v",
+		"op-reth exited during proofs-history reorg unwind, chain A EL did not advance, and supernode did not advance chain A safe past the reorg point for %s: original=%s baseline_supernode_status=%v last_el_unsafe=%v last_supernode_status=%v",
 		duration, original, supernodeChainStatusOrErr(baseline, chainID, baselineErr), lastEL, lastSupernode)
 }
 

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +46,83 @@ func TestReorgInvalidExecMsgs(gt *testing.T) {
 	})
 }
 
+func TestReorgInvalidExecMsgOpRethCrashRestart(gt *testing.T) {
+	testReorgInvalidExecMsgWithHook(gt,
+		func(msg *messages.Message) {
+			msg.Identifier.LogIndex = 1024
+		},
+		func(t devtest.T, sys *presets.TwoL2SupernodeInterop, original eth.L2BlockRef) {
+			if _, ok := sys.L2ELA.Escape().(interface{ Crash() }); !ok {
+				t.Skipf("L2A EL %s does not support forced crash control", sys.L2ELA.String())
+			}
+
+			ctx := t.Ctx()
+			l := sys.Log
+
+			var replacement eth.L2BlockRef
+			require.Eventually(t, func() bool {
+				ref, err := sys.L2ELA.Escape().L2EthClient().L2BlockRefByNumber(ctx, original.Number)
+				if err != nil {
+					l.Info("waiting for replacement divergence block", "number", original.Number, "err", err)
+					return false
+				}
+				if ref.Hash == original.Hash {
+					l.Info("waiting for divergence block to be replaced", "number", original.Number, "hash", ref.Hash)
+					return false
+				}
+				t.Require().Equal(original.ParentHash, ref.ParentHash, "replacement block has unexpected parent")
+				replacement = ref
+				return true
+			}, 2*time.Minute, 200*time.Millisecond, "expected replacement block at divergence height %d", original.Number)
+
+			l.Info("crashing op-reth after replacement ancestor import",
+				"number", replacement.Number,
+				"replacement", replacement.Hash,
+				"original", original.Hash)
+			sys.L2ELA.Crash()
+			sys.L2ELA.Start()
+
+			require.Eventually(t, func() bool {
+				ref, err := sys.L2ELA.Escape().L2EthClient().L2BlockRefByNumber(ctx, replacement.Number)
+				if err != nil {
+					l.Info("waiting for replacement block after restart", "number", replacement.Number, "err", err)
+					return false
+				}
+				return ref.Hash == replacement.Hash
+			}, 2*time.Minute, 200*time.Millisecond, "replacement block should remain available after op-reth restart")
+
+			targetChild := replacement.Number + 1
+			require.Eventually(t, func() bool {
+				child, err := sys.L2ELA.Escape().L2EthClient().L2BlockRefByNumber(ctx, targetChild)
+				if err != nil {
+					l.Info("waiting for replacement child after restart", "number", targetChild, "err", err)
+					return false
+				}
+				if child.ParentHash != replacement.Hash {
+					l.Info("replacement child not derived yet",
+						"number", child.Number,
+						"hash", child.Hash,
+						"parent", child.ParentHash,
+						"want_parent", replacement.Hash)
+					return false
+				}
+
+				var rawHeader hexutil.Bytes
+				err = sys.L2ELA.Escape().L2EthClient().RPC().CallContext(ctx, &rawHeader, "debug_getRawHeader", child.Hash)
+				if err != nil {
+					l.Info("debug_getRawHeader missing replacement child", "hash", child.Hash, "err", err)
+					return false
+				}
+				return len(rawHeader) > 0
+			}, 3*time.Minute, 500*time.Millisecond, "replacement child should be available by number and raw header after restart")
+		})
+}
+
 func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *messages.Message)) {
+	testReorgInvalidExecMsgWithHook(gt, txModifierFn, nil)
+}
+
+func testReorgInvalidExecMsgWithHook(gt *testing.T, txModifierFn func(msg *messages.Message), afterReorgStarted func(devtest.T, *presets.TwoL2SupernodeInterop, eth.L2BlockRef)) {
 	t := devtest.ParallelT(gt)
 	ctx := t.Ctx()
 
@@ -219,12 +296,17 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *messages.Mess
 	// start batcher on chain A
 	sys.L2BatcherA.Start()
 
-	// wait for reorg on chain A
-	sys.L2ELA.ReorgExact(eth.L2BlockRef{
+	originalRef_A := eth.L2BlockRef{
 		Number:     divergenceBlockNumber_A,
 		Hash:       originalHash_A,
 		ParentHash: originalParentHash_A,
-	}, 30)
+	}
+	if afterReorgStarted != nil {
+		afterReorgStarted(t, sys, originalRef_A)
+	}
+
+	// wait for reorg on chain A
+	sys.L2ELA.ReorgExact(originalRef_A, 30)
 
 	// Wait for the supernode to validate the replacement block's timestamp.
 	divergenceTimestamp_A := sys.L2A.TimestampForBlockNum(divergenceBlockNumber_A)

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -77,12 +77,22 @@ func TestReorgInvalidExecMsgOpRethProofsHistoryTinyWindow(gt *testing.T) {
 				sys.Log.Info("observed op-reth RPC failure after proofs-history unwind", "err", err)
 				return true
 			}, time.Minute, 200*time.Millisecond, "expected op-reth to exit during proofs-history reorg unwind")
-			failAfterSustainedTinyProofWindowStall(t, sys, original, 30*time.Second)
+			sys.Log.Info("restarting op-reth after proofs-history unwind exit",
+				"number", original.Number,
+				"hash", original.Hash)
+			sys.L2ELA.Stop()
+			if err := sys.L2ELA.StartWithTimeout(15 * time.Second); err != nil {
+				require.Failf(t,
+					"repro observed",
+					"after exiting during proofs-history reorg unwind, op-reth did not become RPC-ready within 15s of restart: original=%s err=%v",
+					original, err)
+			}
+			failAfterRestartedTinyProofWindowStall(t, sys, original, 30*time.Second)
 		},
 		false)
 }
 
-func failAfterSustainedTinyProofWindowStall(
+func failAfterRestartedTinyProofWindowStall(
 	t devtest.T,
 	sys *presets.TwoL2SupernodeInterop,
 	original eth.L2BlockRef,
@@ -134,7 +144,7 @@ func failAfterSustainedTinyProofWindowStall(
 
 		if lastLog.IsZero() || time.Since(lastLog) >= 5*time.Second {
 			lastLog = time.Now()
-			l.Info("observing tiny proofs-history repro non-recovery",
+			l.Info("observing tiny proofs-history repro non-recovery after op-reth restart",
 				"elapsed", time.Since(start),
 				"duration", duration,
 				"original", original,
@@ -152,7 +162,7 @@ func failAfterSustainedTinyProofWindowStall(
 
 	require.Failf(t,
 		"repro observed",
-		"op-reth exited during proofs-history reorg unwind, chain A EL did not advance, and supernode did not advance chain A safe past the reorg point for %s: original=%s baseline_supernode_status=%v last_el_unsafe=%v last_supernode_status=%v",
+		"after restarting op-reth from the proofs-history reorg-unwind exit, chain A EL did not advance and supernode did not advance chain A safe past the reorg point for %s: original=%s baseline_supernode_status=%v last_el_unsafe=%v last_supernode_status=%v",
 		duration, original, supernodeChainStatusOrErr(baseline, chainID, baselineErr), lastEL, lastSupernode)
 }
 

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
@@ -45,78 +44,6 @@ func TestReorgInvalidExecMsgs(gt *testing.T) {
 			msg.Identifier.ChainID = eth.ChainIDFromUInt64(1024)
 		})
 	})
-}
-
-func TestReorgInvalidExecMsgOpRethCrashRestart(gt *testing.T) {
-	testReorgInvalidExecMsgWithHook(gt,
-		func(msg *messages.Message) {
-			msg.Identifier.LogIndex = 1024
-		},
-		func(t devtest.T, sys *presets.TwoL2SupernodeInterop, original eth.L2BlockRef) {
-			if _, ok := sys.L2ELA.Escape().(interface{ Crash() }); !ok {
-				t.Skipf("L2A EL %s does not support forced crash control", sys.L2ELA.String())
-			}
-
-			ctx := t.Ctx()
-			l := sys.Log
-
-			var replacement eth.L2BlockRef
-			require.Eventually(t, func() bool {
-				ref, err := sys.L2ELA.Escape().L2EthClient().L2BlockRefByNumber(ctx, original.Number)
-				if err != nil {
-					l.Info("waiting for replacement divergence block", "number", original.Number, "err", err)
-					return false
-				}
-				if ref.Hash == original.Hash {
-					l.Info("waiting for divergence block to be replaced", "number", original.Number, "hash", ref.Hash)
-					return false
-				}
-				replacement = ref
-				return true
-			}, 2*time.Minute, 200*time.Millisecond, "expected replacement block at divergence height %d", original.Number)
-			require.Equal(t, original.ParentHash, replacement.ParentHash, "replacement block has unexpected parent")
-
-			l.Info("crashing op-reth after replacement divergence block import",
-				"number", replacement.Number,
-				"replacement", replacement.Hash,
-				"original", original.Hash)
-			sys.L2ELA.Crash()
-			sys.L2ELA.Start()
-
-			require.Eventually(t, func() bool {
-				ref, err := sys.L2ELA.Escape().L2EthClient().L2BlockRefByNumber(ctx, replacement.Number)
-				if err != nil {
-					l.Info("waiting for replacement block after restart", "number", replacement.Number, "err", err)
-					return false
-				}
-				return ref.Hash == replacement.Hash
-			}, 2*time.Minute, 200*time.Millisecond, "replacement block should remain available after op-reth restart")
-
-			targetChild := replacement.Number + 1
-			require.Eventually(t, func() bool {
-				child, err := sys.L2ELA.Escape().L2EthClient().L2BlockRefByNumber(ctx, targetChild)
-				if err != nil {
-					l.Info("waiting for replacement child after restart", "number", targetChild, "err", err)
-					return false
-				}
-				if child.ParentHash != replacement.Hash {
-					l.Info("replacement child not derived yet",
-						"number", child.Number,
-						"hash", child.Hash,
-						"parent", child.ParentHash,
-						"want_parent", replacement.Hash)
-					return false
-				}
-
-				var rawHeader hexutil.Bytes
-				err = sys.L2ELA.Escape().L2EthClient().RPC().CallContext(ctx, &rawHeader, "debug_getRawHeader", child.Hash)
-				if err != nil {
-					l.Info("debug_getRawHeader missing replacement child", "hash", child.Hash, "err", err)
-					return false
-				}
-				return len(rawHeader) > 0
-			}, 3*time.Minute, 500*time.Millisecond, "replacement child should be available by number and raw header after restart")
-		})
 }
 
 func TestReorgInvalidExecMsgOpRethProofsHistoryTinyWindow(gt *testing.T) {
@@ -241,11 +168,7 @@ func supernodeChainStatusOrErr(status eth.SuperNodeSyncStatusResponse, chainID e
 }
 
 func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *messages.Message)) {
-	testReorgInvalidExecMsgWithHook(gt, txModifierFn, nil)
-}
-
-func testReorgInvalidExecMsgWithHook(gt *testing.T, txModifierFn func(msg *messages.Message), afterReorgStarted func(devtest.T, *presets.TwoL2SupernodeInterop, eth.L2BlockRef)) {
-	testReorgInvalidExecMsgWithOptionsAndHooks(gt, nil, txModifierFn, nil, afterReorgStarted, true)
+	testReorgInvalidExecMsgWithOptionsAndHooks(gt, nil, txModifierFn, nil, nil, true)
 }
 
 func testReorgInvalidExecMsgWithOptionsAndHooks(

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -357,13 +357,6 @@ func (el *L2ELNode) Stop() {
 	lifecycle.Stop()
 }
 
-func (el *L2ELNode) Crash() {
-	el.log.Info("Crashing", "name", el.inner.Name())
-	crashable, ok := el.inner.(interface{ Crash() })
-	el.require.Truef(ok, "L2EL node %s is not crash-controllable", el.inner.Name())
-	crashable.Crash()
-}
-
 func (el *L2ELNode) Start() {
 	lifecycle, ok := el.inner.(stack.Lifecycle)
 	el.require.Truef(ok, "L2EL node %s is not lifecycle-controllable", el.inner.Name())

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -357,6 +357,13 @@ func (el *L2ELNode) Stop() {
 	lifecycle.Stop()
 }
 
+func (el *L2ELNode) Crash() {
+	el.log.Info("Crashing", "name", el.inner.Name())
+	crashable, ok := el.inner.(interface{ Crash() })
+	el.require.Truef(ok, "L2EL node %s is not crash-controllable", el.inner.Name())
+	crashable.Crash()
+}
+
 func (el *L2ELNode) Start() {
 	lifecycle, ok := el.inner.(stack.Lifecycle)
 	el.require.Truef(ok, "L2EL node %s is not lifecycle-controllable", el.inner.Name())

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -363,6 +363,16 @@ func (el *L2ELNode) Start() {
 	lifecycle.Start()
 }
 
+func (el *L2ELNode) StartWithTimeout(timeout time.Duration) error {
+	lifecycle, ok := el.inner.(interface {
+		StartWithTimeout(time.Duration) error
+	})
+	if !ok {
+		return fmt.Errorf("L2EL node %s does not support timed start", el.inner.Name())
+	}
+	return lifecycle.StartWithTimeout(timeout)
+}
+
 func (el *L2ELNode) PeerWith(peer *L2ELNode) {
 	sysgo.ConnectP2P(el.ctx, el.require, el.inner.L2EthClient().RPC(), peer.inner.L2EthClient().RPC(), false)
 }

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -17,6 +17,7 @@ const (
 	optionKindOPRBuilder
 	optionKindGlobalL2CL
 	optionKindGlobalSyncTesterEL
+	optionKindOpReth
 	optionKindL1EL
 	optionKindAddedGameType
 	optionKindRespectedGameType
@@ -38,6 +39,7 @@ const allOptionKinds = optionKindDeployer |
 	optionKindOPRBuilder |
 	optionKindGlobalL2CL |
 	optionKindGlobalSyncTesterEL |
+	optionKindOpReth |
 	optionKindL1EL |
 	optionKindAddedGameType |
 	optionKindRespectedGameType |
@@ -62,6 +64,7 @@ var optionKindLabels = []struct {
 	{kind: optionKindOPRBuilder, label: "builder options"},
 	{kind: optionKindGlobalL2CL, label: "L2 CL options"},
 	{kind: optionKindGlobalSyncTesterEL, label: "sync tester EL options"},
+	{kind: optionKindOpReth, label: "op-reth options"},
 	{kind: optionKindL1EL, label: "L1 EL options"},
 	{kind: optionKindAddedGameType, label: "added game types"},
 	{kind: optionKindRespectedGameType, label: "respected game types"},
@@ -151,6 +154,7 @@ const twoL2SupernodePresetSupportedOptionKinds = optionKindDeployer |
 const twoL2SupernodeInteropPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindBatcher |
 	optionKindTimeTravel |
+	optionKindOpReth |
 	optionKindL1EL |
 	optionKindInteropLogBackfill |
 	optionKindInteropFilter |

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -170,6 +170,22 @@ func WithGlobalSyncTesterELOption(opt sysgo.SyncTesterELOption) Option {
 	}
 }
 
+func WithOpRethOption(opt sysgo.OpRethOption) Option {
+	var kinds optionKinds
+	if opt != nil {
+		kinds = optionKindOpReth
+	}
+	return option{
+		kinds: kinds,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			if opt == nil {
+				return
+			}
+			cfg.OpRethOptions = append(cfg.OpRethOptions, opt)
+		},
+	}
+}
+
 func WithL1Geth(execPath string) Option {
 	return option{
 		kinds: optionKindL1EL,

--- a/op-devstack/presets/rpc_frontends.go
+++ b/op-devstack/presets/rpc_frontends.go
@@ -2,6 +2,7 @@ package presets
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -177,6 +178,17 @@ func (r *l2ELFrontend) L2EngineClient() apis.EngineClient {
 func (r *l2ELFrontend) Start() {
 	r.require().NotNil(r.lifecycle, "L2EL node %s is not lifecycle-controllable", r.Name())
 	r.lifecycle.Start()
+}
+
+func (r *l2ELFrontend) StartWithTimeout(timeout time.Duration) error {
+	r.require().NotNil(r.lifecycle, "L2EL node %s is not lifecycle-controllable", r.Name())
+	lifecycle, ok := r.lifecycle.(interface {
+		StartWithTimeout(time.Duration) error
+	})
+	if !ok {
+		return fmt.Errorf("L2EL node %s does not support timed start", r.Name())
+	}
+	return lifecycle.StartWithTimeout(timeout)
 }
 
 func (r *l2ELFrontend) Stop() {

--- a/op-devstack/presets/rpc_frontends.go
+++ b/op-devstack/presets/rpc_frontends.go
@@ -184,13 +184,6 @@ func (r *l2ELFrontend) Stop() {
 	r.lifecycle.Stop()
 }
 
-func (r *l2ELFrontend) Crash() {
-	r.require().NotNil(r.lifecycle, "L2EL node %s is not lifecycle-controllable", r.Name())
-	crashable, ok := r.lifecycle.(interface{ Crash() })
-	r.require().Truef(ok, "L2EL node %s is not crash-controllable", r.Name())
-	crashable.Crash()
-}
-
 type l2CLFrontend struct {
 	presetCommon
 	chainID          eth.ChainID

--- a/op-devstack/presets/rpc_frontends.go
+++ b/op-devstack/presets/rpc_frontends.go
@@ -184,6 +184,13 @@ func (r *l2ELFrontend) Stop() {
 	r.lifecycle.Stop()
 }
 
+func (r *l2ELFrontend) Crash() {
+	r.require().NotNil(r.lifecycle, "L2EL node %s is not lifecycle-controllable", r.Name())
+	crashable, ok := r.lifecycle.(interface{ Crash() })
+	r.require().Truef(ok, "L2EL node %s is not crash-controllable", r.Name())
+	crashable.Crash()
+}
+
 type l2CLFrontend struct {
 	presetCommon
 	chainID          eth.ChainID

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -18,6 +18,8 @@ import (
 type OpRethConfig struct {
 	// ExtraArgs are appended to the generated CLI args.
 	ExtraArgs []string
+	// ProofsHistoryWindow overrides the default proofs-history retention window when non-zero.
+	ProofsHistoryWindow uint64
 }
 
 // DefaultOpRethConfig returns a zero-valued OpRethConfig that callers can mutate via OpRethOptions.
@@ -57,6 +59,14 @@ func (b OpRethOptionBundle) Apply(p devtest.T, target ComponentTarget, cfg *OpRe
 func OpRethWithExtraArgs(args ...string) OpRethOption {
 	return OpRethOptionFn(func(p devtest.T, _ ComponentTarget, cfg *OpRethConfig) {
 		cfg.ExtraArgs = append(cfg.ExtraArgs, args...)
+	})
+}
+
+// OpRethWithProofsHistoryWindow overrides the proofs-history retention window.
+func OpRethWithProofsHistoryWindow(window uint64) OpRethOption {
+	return OpRethOptionFn(func(p devtest.T, _ ComponentTarget, cfg *OpRethConfig) {
+		p.Require().Greater(window, uint64(0), "proofs-history window must be non-zero")
+		cfg.ProofsHistoryWindow = window
 	})
 }
 

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -203,24 +203,8 @@ func (n *OpReth) Start() {
 func (n *OpReth) Stop() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	if n.sub == nil {
-		n.p.Logger().Warn("op-reth already stopped")
-		return
-	}
 	err := n.sub.Stop(true)
 	n.p.Require().NoError(err, "Must stop")
-	n.sub = nil
-}
-
-func (n *OpReth) Crash() {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	if n.sub == nil {
-		n.p.Logger().Warn("op-reth already stopped")
-		return
-	}
-	err := n.sub.Kill()
-	n.p.Require().NoError(err, "Must kill")
 	n.sub = nil
 }
 

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -198,6 +198,18 @@ func (n *OpReth) Stop() {
 	n.sub = nil
 }
 
+func (n *OpReth) Crash() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.sub == nil {
+		n.p.Logger().Warn("op-reth already stopped")
+		return
+	}
+	err := n.sub.Kill()
+	n.p.Require().NoError(err, "Must kill")
+	n.sub = nil
+}
+
 func (n *OpReth) UserRPC() string {
 	return n.userRPC
 }

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -193,6 +193,10 @@ func (n *OpReth) Start() {
 func (n *OpReth) Stop() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	if n.sub == nil {
+		n.p.Logger().Warn("op-reth already stopped")
+		return
+	}
 	err := n.sub.Stop(true)
 	n.p.Require().NoError(err, "Must stop")
 	n.sub = nil

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -1,10 +1,12 @@
 package sysgo
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -114,15 +116,31 @@ type OpReth struct {
 var _ L2ELNode = (*OpReth)(nil)
 
 func (n *OpReth) Start() {
+	n.p.Require().NoError(n.start(n.p.Ctx()), "Must start")
+}
+
+func (n *OpReth) StartWithTimeout(timeout time.Duration) error {
+	ctx := n.p.Ctx()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	return n.start(ctx)
+}
+
+func (n *OpReth) start(ctx context.Context) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	if n.sub != nil {
 		n.p.Logger().Warn("op-reth already started")
-		return
+		return nil
 	}
 	if n.authProxy == nil {
 		n.authProxy = tcpproxy.New(n.p.Logger())
-		n.p.Require().NoError(n.authProxy.Start())
+		if err := n.authProxy.Start(); err != nil {
+			return fmt.Errorf("start auth proxy: %w", err)
+		}
 		n.p.Cleanup(func() {
 			n.authProxy.Close()
 		})
@@ -130,7 +148,9 @@ func (n *OpReth) Start() {
 	}
 	if n.userProxy == nil {
 		n.userProxy = tcpproxy.New(n.p.Logger())
-		n.p.Require().NoError(n.userProxy.Start())
+		if err := n.userProxy.Start(); err != nil {
+			return fmt.Errorf("start user proxy: %w", err)
+		}
 		n.p.Cleanup(func() {
 			n.userProxy.Close()
 		})
@@ -182,20 +202,29 @@ func (n *OpReth) Start() {
 	n.sub = NewSubProcess(n.p, stdOutLogs, stdErrLogs)
 
 	err := n.sub.Start(n.execPath, n.args, n.env)
-	n.p.Require().NoError(err, "Must start")
+	if err != nil {
+		return fmt.Errorf("start op-reth subprocess: %w", err)
+	}
 
 	var userRPCAddr, authRPCAddr string
-	n.p.Require().NoError(tasks.Await(n.p.Ctx(), userRPCChan, &userRPCAddr), "need user RPC")
-	n.p.Require().NoError(tasks.Await(n.p.Ctx(), authRPCChan, &authRPCAddr), "need auth RPC")
+	if err := tasks.Await(ctx, userRPCChan, &userRPCAddr); err != nil {
+		return fmt.Errorf("need user RPC: %w", err)
+	}
+	if err := tasks.Await(ctx, authRPCChan, &authRPCAddr); err != nil {
+		return fmt.Errorf("need auth RPC: %w", err)
+	}
 
 	if areMetricsEnabled() {
 		var metricsTarget PrometheusMetricsTarget
-		n.p.Require().NoError(tasks.Await(n.p.Ctx(), metricsTargetChan, &metricsTarget), "need metrics endpoint")
+		if err := tasks.Await(ctx, metricsTargetChan, &metricsTarget); err != nil {
+			return fmt.Errorf("need metrics endpoint: %w", err)
+		}
 		n.l2MetricsRegistrar.RegisterL2MetricsTargets(n.name, metricsTarget)
 	}
 
 	n.userProxy.SetUpstream(ProxyAddr(n.p.Require(), userRPCAddr))
 	n.authProxy.SetUpstream(ProxyAddr(n.p.Require(), authRPCAddr))
+	return nil
 }
 
 // Stop stops the op-reth node.

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -367,16 +368,21 @@ func buildMixedOpRethNode(
 	initOut, initErr := exec.Command(execPath, initProofsArgs...).CombinedOutput()
 	t.Require().NoError(initErr, "must init op-reth proof history: %s", string(initOut))
 
+	opRethCfg := DefaultOpRethConfig()
+	OpRethOptionBundle(opts).Apply(t, NewComponentTarget(key, l2Net.ChainID()), opRethCfg)
+	proofsHistoryWindow := opRethCfg.ProofsHistoryWindow
+	if proofsHistoryWindow == 0 {
+		proofsHistoryWindow = 10000
+	}
+
 	args = append(
 		args,
 		"--proofs-history",
-		"--proofs-history.window=10000",
+		"--proofs-history.window="+strconv.FormatUint(proofsHistoryWindow, 10),
 		"--proofs-history.storage-path="+proofHistoryDir,
 		"--proofs-history.storage-version="+storageVersion,
 	)
 
-	opRethCfg := DefaultOpRethConfig()
-	OpRethOptionBundle(opts).Apply(t, NewComponentTarget(key, l2Net.ChainID()), opRethCfg)
 	args = append(args, opRethCfg.ExtraArgs...)
 
 	return &OpReth{

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -100,8 +100,21 @@ func NewTwoL2SupernodeRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiCha
 
 // startSupernodeEL starts an L2 EL node for the supernode runtime,
 // respecting DEVSTACK_L2EL_KIND (defaults to op-reth when unset).
-func startSupernodeEL(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte) L2ELNode {
-	return startL2ELForKey(t, l2Net, jwtPath, jwtSecret, "sequencer", NewELNodeIdentity(0))
+func startSupernodeEL(
+	t devtest.T,
+	l2Net *L2Network,
+	jwtPath string,
+	jwtSecret [32]byte,
+	opts ...OpRethOption,
+) L2ELNode {
+	switch devstackL2ELKind() {
+	case MixedL2ELOpGeth:
+		return startL2ELNode(t, l2Net, jwtPath, jwtSecret, "sequencer", NewELNodeIdentity(0))
+	case MixedL2ELOpRethV2:
+		return startMixedOpRethNode(t, l2Net, "sequencer", jwtPath, jwtSecret, nil, "v2", opts...)
+	default: // op-reth v1
+		return startMixedOpRethNode(t, l2Net, "sequencer", jwtPath, jwtSecret, nil, "v1", opts...)
+	}
 }
 
 // startSupernodeELWithSupervisorURL starts an L2 EL node with --rollup.supervisor-http
@@ -114,6 +127,7 @@ func startSupernodeELWithSupervisorURL(
 	jwtPath string,
 	jwtSecret [32]byte,
 	supervisorURL string,
+	opts ...OpRethOption,
 ) L2ELNode {
 	switch devstackL2ELKind() {
 	case MixedL2ELOpGeth:
@@ -133,7 +147,7 @@ func startSupernodeELWithSupervisorURL(
 		return l2EL
 	default: // op-reth
 		return startMixedOpRethNodeWithSupervisorURL(
-			t, l2Net, key, jwtPath, jwtSecret, nil, supervisorURL, "v1")
+			t, l2Net, key, jwtPath, jwtSecret, nil, supervisorURL, "v1", opts...)
 	}
 }
 
@@ -154,7 +168,7 @@ func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 		l1Clock = timeTravelClock
 	}
 	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
-	l2EL := startSupernodeEL(t, l2Net, jwtPath, jwtSecret)
+	l2EL := startSupernodeEL(t, l2Net, jwtPath, jwtSecret, cfg.OpRethOptions...)
 
 	var depSetStatic *depset.StaticConfigDependencySet
 	if depSet != nil {
@@ -235,8 +249,8 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 		filterRPC := "http://" + filterProxy.Addr()
 
 		// Start ELs with filter proxy URL
-		l2AEL = startSupernodeELWithSupervisorURL(t, l2ANet, "sequencer", jwtPath, jwtSecret, filterRPC)
-		l2BEL = startSupernodeELWithSupervisorURL(t, l2BNet, "sequencer", jwtPath, jwtSecret, filterRPC)
+		l2AEL = startSupernodeELWithSupervisorURL(t, l2ANet, "sequencer", jwtPath, jwtSecret, filterRPC, cfg.OpRethOptions...)
+		l2BEL = startSupernodeELWithSupervisorURL(t, l2BNet, "sequencer", jwtPath, jwtSecret, filterRPC, cfg.OpRethOptions...)
 
 		// Build rollup config map from L2 networks (Go structs, no file I/O)
 		rollupConfigs := map[eth.ChainID]*rollup.Config{
@@ -253,8 +267,8 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 		filterProxy.SetUpstream(ProxyAddr(require, interopFilter.HTTPEndpoint()))
 	} else {
 		// No interop filter — ELs start without supervisor/filter URL (existing behavior)
-		l2AEL = startSupernodeEL(t, l2ANet, jwtPath, jwtSecret)
-		l2BEL = startSupernodeEL(t, l2BNet, jwtPath, jwtSecret)
+		l2AEL = startSupernodeEL(t, l2ANet, jwtPath, jwtSecret, cfg.OpRethOptions...)
+		l2BEL = startSupernodeEL(t, l2BNet, jwtPath, jwtSecret, cfg.OpRethOptions...)
 	}
 
 	var activationTime uint64

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -21,6 +21,7 @@ type PresetConfig struct {
 	OPRBuilderOptions          []OPRBuilderNodeOption
 	GlobalL2CLOptions          []L2CLOption
 	GlobalSyncTesterELOptions  []SyncTesterELOption
+	OpRethOptions              []OpRethOption
 	L1ELKind                   string
 	L1GethExecPath             string
 	AddedGameTypes             []gameTypes.GameType

--- a/op-devstack/sysgo/subproc.go
+++ b/op-devstack/sysgo/subproc.go
@@ -105,3 +105,38 @@ func (sp *SubProcess) Stop(interrupt bool) error {
 	sp.cmd = nil
 	return nil
 }
+
+// Kill forcefully terminates the subprocess and waits for stdio to flush.
+func (sp *SubProcess) Kill() error {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	if sp.cmd == nil {
+		return nil // already stopped
+	}
+
+	if sp.cmd.ProcessState == nil {
+		sp.p.Logger().Info("Killing subprocess")
+		if err := sp.cmd.Process.Kill(); err != nil {
+			return err
+		}
+	}
+
+	waitErr := sp.cmd.Wait()
+	var exitErr *exec.ExitError
+	if waitErr != nil && !errors.As(waitErr, &exitErr) {
+		sp.p.Logger().Warn("Sub-process exited with error", "err", waitErr)
+	} else {
+		sp.p.Logger().Info("Sub-process killed")
+	}
+
+	if sp.stdOutProc != nil {
+		_ = sp.stdOutProc.Close()
+		sp.stdOutProc = nil
+	}
+	if sp.stdErrProc != nil {
+		_ = sp.stdErrProc.Close()
+		sp.stdErrProc = nil
+	}
+	sp.cmd = nil
+	return nil
+}

--- a/op-devstack/sysgo/subproc.go
+++ b/op-devstack/sysgo/subproc.go
@@ -105,38 +105,3 @@ func (sp *SubProcess) Stop(interrupt bool) error {
 	sp.cmd = nil
 	return nil
 }
-
-// Kill forcefully terminates the subprocess and waits for stdio to flush.
-func (sp *SubProcess) Kill() error {
-	sp.mu.Lock()
-	defer sp.mu.Unlock()
-	if sp.cmd == nil {
-		return nil // already stopped
-	}
-
-	if sp.cmd.ProcessState == nil {
-		sp.p.Logger().Info("Killing subprocess")
-		if err := sp.cmd.Process.Kill(); err != nil {
-			return err
-		}
-	}
-
-	waitErr := sp.cmd.Wait()
-	var exitErr *exec.ExitError
-	if waitErr != nil && !errors.As(waitErr, &exitErr) {
-		sp.p.Logger().Warn("Sub-process exited with error", "err", waitErr)
-	} else {
-		sp.p.Logger().Info("Sub-process killed")
-	}
-
-	if sp.stdOutProc != nil {
-		_ = sp.stdOutProc.Close()
-		sp.stdOutProc = nil
-	}
-	if sp.stdErrProc != nil {
-		_ = sp.stdErrProc.Close()
-		sp.stdErrProc = nil
-	}
-	sp.cmd = nil
-	return nil
-}


### PR DESCRIPTION
## Summary

Adds a minimal draft interop acceptance repro for op-reth `proofs-history` during a CL-driven invalid executing-message reorg.

The repro path is `TestReorgInvalidExecMsgOpRethProofsHistoryTinyWindow`. It is intentionally a negative/failing test right now: a failure with `repro observed` means the repro worked.

## Test Flow

1. Start a two-L2 supernode interop devstack using op-reth with proofs-history enabled and `--proofs-history.window=1`.
2. Reuse the existing invalid executing-message flow: chain B emits the initiating message, chain A force-includes an executing message with an invalid `LogIndex`.
3. Build the invalid chain A divergence block and one child block with `op-test-sequencer`.
4. Wait 12s before restarting the real chain A sequencer. This gives proofs-history time to flush and prune with the tiny retention window.
5. Restart chain A sequencing and batching so the supernode detects the invalid exec message and initiates the CL-driven rewind/reorg.
6. During the rewind, op-reth proofs-history receives the reorg notification and attempts to unwind past retained proof history.
7. The test waits until chain A op-reth RPC fails, proving op-reth exited during the proofs-history unwind path.
8. The test explicitly reaps and restarts chain A op-reth against the same data directory.
9. If op-reth does not become RPC-ready within 15s of restart, the test intentionally fails with `repro observed`.
10. If op-reth does restart, the test polls both chain A op-reth RPC and shared `supernode_syncStatus` for sustained post-restart non-recovery.
11. If chain A op-reth RPC recovers and the EL unsafe head advances past the reorg point, the test fails with `unexpected recovery`.
12. If supernode chain A local-safe or cross-safe advances past the reorg point, the test fails with `unexpected supernode recovery`.
13. If chain A EL does not advance and supernode chain A safe does not advance for the observation window, the test intentionally fails with `repro observed`.

## Observed Repro

Latest focused restart run showed:

- chain A included invalid block `24d174..7c1ebb:15` and child `ebbd92..01431b:16`
- proofs-history pruned chain A proof storage through block 20 with `--proofs-history.window=1`
- supernode invalidated block 15 and drove the CL rewind/reorg
- op-reth received the reorg notification and exited with `ExEx proofs-history crashed: Attempted to unwind to block 14 beyond earliest stored block 20`
- the test restarted op-reth against the same data directory
- after restart, op-reth crashed again with `ExEx proofs-history crashed: Parent hash mismatch at block 22`
- supernode stayed unable to derive chain A at the reorg point, including `chain 901 not ready for timestamp ... failed to determine L2BlockRef of height 15`
- for the observation window, chain A EL RPC did not advance and supernode chain A safe stayed at/pinned around the reorg point, then the test failed intentionally with `repro observed`

## Repro Confidence

This now proves the restart shape we care about in devstack: `proofs-history` can kill op-reth during a CL-driven rewind, op-reth can fail again after restart against the same data directory, and the supernode does not recover automatically during the observation window.

Important caveat: this is still a forced-retention repro. It does not prove the full production state under normal proof retention, and the restarted node currently crashes again rather than remaining live with forkchoice pinned while serving partial RPC.

## Review Notes / Follow-ups

- Removed the earlier explicit op-reth crash/restart repro and devstack crash-control plumbing.
- Added devstack option plumbing for op-reth proofs-history window overrides.
- Added a timed op-reth restart path so a failed restart becomes a bounded repro result instead of waiting for the global test timeout.
- Added a deliberately failing tiny-window proofs-history repro that waits for sustained chain A EL and supernode non-recovery after restart before failing.
- Remaining: decide whether this PR should keep the negative repro as skipped/manual-only before merge, or whether it should be used only while developing the fix.
- Remaining: a stronger prod-faithful repro would need normal proof retention plus a deterministic way to hit the inconsistent post-restart block availability state without forcing the ExEx to crash again.

## Validation

- `mise exec -- go test ./op-acceptance-tests/tests/interop/reorgs -run '^$' -count=0`
- `mise exec -- go test ./op-devstack/dsl ./op-devstack/presets ./op-devstack/sysgo -run '^$' -count=0`
- Focused restart run after commit `9658dedaab`: `LOG_LEVEL=info mise exec -- go test -v ./op-acceptance-tests/tests/interop/reorgs -run '^TestReorgInvalidExecMsgOpRethProofsHistoryTinyWindow$' -count=1 -timeout=8m`
  - Result: failed as intended after op-reth restart and sustained chain A/supernode non-recovery.
  - Log saved locally at `/tmp/op-reth-reorg-tiny-proof-window-restart-bounded.log`.
- Earlier full build context: `cd op-acceptance-tests && mise exec -- just build-deps` built contracts forge artifacts, op-program/cannon prestates, and release Rust binaries for `kona-node`, `kona-host`, and `op-reth`; it then stopped at the later `op-rbuilder` step because this worktree has no root `op-rbuilder/` directory.
