### PR TITLE
circleci: make implicit-medium optimism jobs explicit (12 jobs, mixed gen2 sizes)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
   prepare-continuation-config:
     docker:
       - image: << pipeline.parameters.default_docker_image >>
+    resource_class: medium.gen2
     environment:
       BASE_REVISION: devlop
     steps:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -588,6 +588,7 @@ jobs:
   ci-gate:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small.gen2
     parameters:
       always-succeed:
         description: Force always succeed (skip API gate; for contracts-feature-tests-short)
@@ -1550,6 +1551,7 @@ jobs:
   l2-chains-sync-check:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small.gen2
     steps:
       - utils/checkout-with-mise:
           enable-mise-cache: false
@@ -1563,7 +1565,8 @@ jobs:
         type: boolean
         default: true
     machine:
-      image: <<pipeline.parameters.c-base_image>>
+      image: ubuntu-2204:current
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2013,7 +2016,9 @@ jobs:
 
   cannon-prestate:
     machine:
+      image: ubuntu-2204:current
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2137,6 +2142,7 @@ jobs:
   cannon-stf-verify:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2267,6 +2273,7 @@ jobs:
   op-deployer-forge-version:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2399,6 +2406,7 @@ jobs:
   stale-check:
     machine:
       image: ubuntu-2204:2024.08.1
+    resource_class: medium.gen2
     steps:
       - utils/github-stale:
           stale-issue-message: "This issue has been automatically marked as stale and will be closed in 5 days if no updates"
@@ -2413,6 +2421,7 @@ jobs:
   close-issue:
     machine:
       image: ubuntu-2204:2024.08.1
+    resource_class: medium.gen2
     parameters:
       label_name:
         type: string

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -901,6 +901,7 @@ jobs:
   required-rust-ci:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small.gen2
     parameters:
       always-succeed:
         description: Force always succeed (skip API gate)

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -208,6 +208,7 @@ jobs:
   required-rust-e2e:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small.gen2
     parameters:
       always-succeed:
         description: Force always succeed (skip API gate)

--- a/.circleci/rust-nightly-bump.yml
+++ b/.circleci/rust-nightly-bump.yml
@@ -7,6 +7,7 @@ jobs:
   bump-nightly:
     docker:
       - image: cimg/base:2026.03
+    resource_class: small.gen2
     steps:
       - checkout
 


### PR DESCRIPTION
## Summary

Removes the last 12 jobs in this repo that declared no `resource_class:` field. Post-#20917 / #20927 every other job is on an explicit Gen2 class; these were the remaining stragglers running on Gen1 medium by CircleCI default. Each is set to an explicit Gen2 class right-sized to its workload, plus two machine-image pins to preserve the Gen1 OS where it would otherwise have silently upgraded jammy → noble.

This completes the optimism repo's Gen2 migration. No further `resource_class` work is planned here.

## Why Gen2, not Gen1

Post-#20927 the whole repo is on Gen2. Mixing Gen1 in for these last 12 jobs would create two-class drift we'd just have to clean up later.

## Why one PR, not two phases

The original handoff (and #20917's pattern) anticipated ~110 implicit-medium jobs, which would have justified splitting "make explicit" (Phase A) from "right-size" (Phase B). The actual scope is 12 jobs — small enough that per-job rationale fits in one audit-grade PR.

## Per-job rationale

| File | Job | Executor | Class | Image change | Why this class |
|------|-----|----------|-------|---|---|
| `.circleci/config.yml` | `prepare-continuation-config` | docker | `medium.gen2` | — | Setup-pipeline job at the start of every CI run. Does a full monorepo `checkout`. Conservative: blast radius if it OOMs is every pipeline. |
| `.circleci/continue/main.yml` | `ci-gate` | docker | `small.gen2` | — | Single `utils/ci-gate` call. Pure API gate, deterministic workload. |
| `.circleci/continue/main.yml` | `l2-chains-sync-check` | docker | `small.gen2` | — | One bash script (`check-l2-chains-sync.sh`) verifying two files are in sync. |
| `.circleci/continue/main.yml` | `todo-issues` | machine | `medium.gen2` | **+ `image: ubuntu-2204:current`** | Machine executor minimum is `medium`. Image param `c-base_image` resolves to the literal string `"default"`, so swapping class would silently switch host from jammy to noble. Pin preserves Gen1 OS. |
| `.circleci/continue/main.yml` | `cannon-prestate` | machine | `medium.gen2` | **+ `image: ubuntu-2204:current`** | Machine, build job (`just reproducible-prestate`), and no `machine.image` declared today — so the highest-risk job for the Gen1→Gen2 OS-default change. Pin first; broader right-sizing question left for a follow-up. |
| `.circleci/continue/main.yml` | `cannon-stf-verify` | docker | `medium.gen2` | — | Has `setup_remote_docker`, which is not supported on `small.gen2`, plus a cannon build step. |
| `.circleci/continue/main.yml` | `op-deployer-forge-version` | docker | `small.gen2` | — | Single `just check-forge-version` call. |
| `.circleci/continue/main.yml` | `stale-check` | machine | `medium.gen2` | — | Machine minimum is `medium`. Image already pinned to `ubuntu-2204:2024.08.1` — no OS-default risk. |
| `.circleci/continue/main.yml` | `close-issue` | machine | `medium.gen2` | — | Same as `stale-check`: machine minimum, image already pinned. |
| `.circleci/continue/rust-ci.yml` | `required-rust-ci` | docker | `small.gen2` | — | Pure aggregator gate (`utils/ci-gate` only). |
| `.circleci/continue/rust-e2e.yml` | `required-rust-e2e` | docker | `small.gen2` | — | Pure aggregator gate (`utils/ci-gate` only). |
| `.circleci/rust-nightly-bump.yml` | `bump-nightly` | docker | `small.gen2` | — | Daily-scheduled shell + git + `gh pr create`. Pure version bump. |

**Totals**: 6 → `small.gen2`, 6 → `medium.gen2`, 2 image pins.

## Methodology for picking `small.gen2`

Bias toward determinism-of-workload, not just utilization numbers. From the #20899 / #20931 fuzz lesson: telemetry doesn't capture outlier-seed spikes for distribution-tailed workloads, so a job that averages low but is non-deterministic should stay larger than the averages suggest.

Applied here as a checklist — `small.gen2` only if **all** of these are true:
- Job name pattern fits (`*-gate`, `*-check`, `version-bump`, `*-aggregator`, prepare/setup)
- Steps contain no `go test` / `cargo test` / `forge test` / build commands
- No `setup_remote_docker` (CircleCI does not support it on `small.gen2`)
- No `parallelism: N` (none of the 12 declare this anyway)
- Executor is `docker` (machine has no `small` tier)

Of the 12 jobs, 6 cleared every condition.

## Machine-executor image-pin notes

Per the #20927 zstd lesson: machine jobs that don't explicitly pin `machine.image` inherit the class default (Gen1 → `ubuntu-2204:current` / jammy, Gen2 → `ubuntu-2404:current` / noble). Swapping `<class>` → `<class>.gen2` therefore silently upgrades the host OS.

Two of the four machine jobs in this PR were exposed to that:
- `cannon-prestate` declared no `image:` at all.
- `todo-issues` referenced `<<pipeline.parameters.c-base_image>>`, which defaults to the literal string `"default"` — CircleCI's sentinel for "use the class default".

Both now pin `image: ubuntu-2204:current` to preserve the Gen1 OS. `stale-check` and `close-issue` were already on pinned `ubuntu-2204:2024.08.1` and need no image change.

## Validation gate

- 14 insertions, 1 deletion across 5 files (`git diff --stat`)
- 12 jobs that previously had no `resource_class:` field now have one
- 0 implicit-class jobs remain in any of the 5 CI YAML files (re-run of the enumerator)
- All 5 modified YAMLs still parse with `yaml.safe_load`
- No other diff content: nothing reordered, no unrelated edits

## Refs

- #20899 (W4 pilot, reverted)
- #20917 (Tier A: 41 same-size docker swaps)
- #20927 (Final: 22 same-size docker + machine swaps)
- #20931 (fuzz-golang resize back to xlarge.gen2)
