### PR TITLE
fix(op-wheel): record block base fee metric

### DIFF
--- a/op-wheel/engine/engine.go
+++ b/op-wheel/engine/engine.go
@@ -247,7 +247,7 @@ func Auto(
 					continue
 				}
 				log.Info("status", "head", status.Head, "safe", status.Safe, "finalized", status.Finalized,
-					"head_time", status.Head.Time, "txs", status.Txs, "gas", status.Gas, "basefee", status.Gas)
+					"head_time", status.Head.Time, "txs", status.Txs, "gas", status.Gas, "basefee", status.BaseFee)
 
 				// On a mocked "beacon epoch transition", update finalization and justification checkpoints.
 				// There are no gap slots, so we just go back 32 blocks.

--- a/op-wheel/engine/metrics.go
+++ b/op-wheel/engine/metrics.go
@@ -81,7 +81,7 @@ func (r *Metrics) RecordBlockStats(hash common.Hash, num uint64, time uint64, tx
 	r.BlockTime.Set(float64(time))
 	r.BlockTxs.Set(float64(txs))
 	r.BlockGas.Set(float64(gas))
-	r.BlockGas.Set(float64(baseFee))
+	r.BlockBaseFee.Set(baseFee)
 }
 
 var _ Metricer = (*Metrics)(nil)

--- a/op-wheel/engine/metrics_test.go
+++ b/op-wheel/engine/metrics_test.go
@@ -1,0 +1,29 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordBlockStatsRecordsGasAndBaseFee(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := NewMetrics("test", registry)
+
+	metrics.RecordBlockStats(common.Hash{}, 1, 2, 3, 21, 42.5)
+
+	require.Equal(t, float64(21), gaugeValue(t, metrics.BlockGas))
+	require.Equal(t, 42.5, gaugeValue(t, metrics.BlockBaseFee))
+}
+
+func gaugeValue(t *testing.T, gauge prometheus.Gauge) float64 {
+	t.Helper()
+
+	metric := &dto.Metric{}
+	require.NoError(t, gauge.Write(metric))
+	require.NotNil(t, metric.Gauge)
+	return metric.Gauge.GetValue()
+}


### PR DESCRIPTION
Fixes #20958

## Summary

- Record the block base fee in the `BlockBaseFee` gauge instead of writing it into `BlockGas`.
- Log `status.BaseFee` for the status `basefee` field.
- Add a focused regression test for gas and base-fee gauge values.

## Testing

- `go test ./op-wheel/engine`
- `go test ./op-wheel/...`
- `just op-wheel`