### PR TITLE
op-supernode: skip log backfill during CL sync

### DIFF
--- a/op-supernode/supernode/interop_config_test.go
+++ b/op-supernode/supernode/interop_config_test.go
@@ -2,12 +2,82 @@ package supernode
 
 import (
 	"testing"
+	"time"
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	nodesync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 )
+
+func TestEffectiveInteropLogBackfillDepth(t *testing.T) {
+	t.Parallel()
+
+	depth := time.Hour
+	tests := []struct {
+		name         string
+		depth        time.Duration
+		vnCfgs       map[eth.ChainID]*opnodecfg.Config
+		wantDepth    time.Duration
+		wantDisabled bool
+	}{
+		{
+			name:         "disabled depth stays disabled",
+			depth:        0,
+			wantDepth:    0,
+			wantDisabled: false,
+		},
+		{
+			name:  "keeps backfill when all chains use EL sync",
+			depth: depth,
+			vnCfgs: map[eth.ChainID]*opnodecfg.Config{
+				eth.ChainIDFromUInt64(10):   {Sync: nodesync.Config{SyncMode: nodesync.ELSync}},
+				eth.ChainIDFromUInt64(8453): {Sync: nodesync.Config{SyncMode: nodesync.ELSync}},
+			},
+			wantDepth:    depth,
+			wantDisabled: false,
+		},
+		{
+			name:  "disables backfill when any chain uses CL sync",
+			depth: depth,
+			vnCfgs: map[eth.ChainID]*opnodecfg.Config{
+				eth.ChainIDFromUInt64(10):   {Sync: nodesync.Config{SyncMode: nodesync.ELSync}},
+				eth.ChainIDFromUInt64(8453): {Sync: nodesync.Config{SyncMode: nodesync.CLSync}},
+			},
+			wantDepth:    0,
+			wantDisabled: true,
+		},
+		{
+			name:  "default sync mode is CL sync",
+			depth: depth,
+			vnCfgs: map[eth.ChainID]*opnodecfg.Config{
+				eth.ChainIDFromUInt64(10): {},
+			},
+			wantDepth:    0,
+			wantDisabled: true,
+		},
+		{
+			name:  "nil configs are ignored",
+			depth: depth,
+			vnCfgs: map[eth.ChainID]*opnodecfg.Config{
+				eth.ChainIDFromUInt64(10): nil,
+			},
+			wantDepth:    depth,
+			wantDisabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotDepth, gotDisabled := effectiveInteropLogBackfillDepth(tt.depth, tt.vnCfgs)
+			require.Equal(t, tt.wantDepth, gotDepth)
+			require.Equal(t, tt.wantDisabled, gotDisabled)
+		})
+	}
+}
 
 func TestResolveInteropActivationTimestamp(t *testing.T) {
 	t.Parallel()

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -10,6 +10,7 @@ import (
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
+	nodesync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -113,6 +114,10 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	var verifiedReader interop.VerifiedResultReader = interop.NoopVerifiedResultReader{}
 	var interopActivity *interop.Interop
 	if interopActivationTimestamp != nil {
+		logBackfillDepth, logBackfillDisabledForCLSync := effectiveInteropLogBackfillDepth(cfg.InteropLogBackfillDepth, vnCfgs)
+		if logBackfillDisabledForCLSync {
+			log.Warn("disabling interop log backfill because at least one virtual node is configured for consensus-layer sync", "configured_depth", cfg.InteropLogBackfillDepth)
+		}
 		var msgExpiryWindow uint64
 		for _, vnCfg := range vnCfgs {
 			if vnCfg.DependencySet != nil {
@@ -120,7 +125,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 				break
 			}
 		}
-		interopActivity = interop.New(log.New("activity", "interop"), *interopActivationTimestamp, msgExpiryWindow, s.chains, cfg.DataDir, s.l1Client, cfg.InteropLogBackfillDepth, s.supernodeMetrics)
+		interopActivity = interop.New(log.New("activity", "interop"), *interopActivationTimestamp, msgExpiryWindow, s.chains, cfg.DataDir, s.l1Client, logBackfillDepth, s.supernodeMetrics)
 		verifiedReader = interopActivity
 	}
 
@@ -154,6 +159,21 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		s.metrics = resources.NewMetricsService(log, cfg.MetricsConfig.ListenAddr, cfg.MetricsConfig.ListenPort, s.metricsFanIn)
 	}
 	return s, nil
+}
+
+func effectiveInteropLogBackfillDepth(depth time.Duration, vnCfgs map[eth.ChainID]*opnodecfg.Config) (time.Duration, bool) {
+	if depth <= 0 {
+		return depth, false
+	}
+	for _, vnCfg := range vnCfgs {
+		if vnCfg == nil {
+			continue
+		}
+		if vnCfg.Sync.SyncMode == nodesync.CLSync {
+			return 0, true
+		}
+	}
+	return depth, false
 }
 
 func resolveInteropActivationTimestamp(override *uint64, vnCfgs map[eth.ChainID]*opnodecfg.Config) (*uint64, error) {


### PR DESCRIPTION
## Summary

Skips interop log backfill whenever any configured supernode virtual node is running in consensus-layer sync mode. The configured backfill depth is left intact, but the effective depth passed into the interop activity is set to zero for CL-sync setups.

## Motivation

During a fresh CL-sync recovery, SafeDB can have a startup boundary that is ahead of what the local EL has derived/imported. Cold-start log backfill then asks the local EL for blocks in that window and can pin interop startup on missing blocks. CL sync should be allowed to derive/import those blocks before interop validation advances.

## Testing

- go test ./op-supernode/supernode
- go test ./op-supernode/...
