### PR TITLE
op-supernode: add interop cold start progress logging

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -441,6 +441,7 @@ func (i *Interop) progress() (time.Duration, error) {
 		if tipTS > lastTS {
 			behind = tipTS - lastTS
 		}
+		i.metrics.InteropVerificationBehind.Set(float64(behind))
 		i.log.Info("interop verification progress",
 			"round", round, "madeProgress", madeProgress,
 			"lastVerifiedTimestamp", lastTS, "tipTimestamp", tipTS, "behindSeconds", behind)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -36,6 +36,14 @@ var (
 // executing message.
 const DefaultLogBackfillDepth = time.Duration(depset.MessageExpiryTimeSecondsInterop) * time.Second
 
+// Interop activity state values exposed via supernode_interop_activity_state gauge.
+const (
+	InteropStateNotStarted       = 0
+	InteropStateColdStartWaiting = 1
+	InteropStateRunning          = 2
+	InteropStateHalted           = 3
+)
+
 // InteropActivationTimestampFlag is the CLI flag for the interop activation timestamp.
 var InteropActivationTimestampFlag = &cli.Uint64Flag{
 	Name:    "interop.activation-timestamp",
@@ -316,12 +324,14 @@ func (i *Interop) tryInitFromVerifiedDB() {
 		i.verificationStartTimestamp = lastTS + 1
 		i.initialized.Store(true)
 		i.backfillCompleted.Store(true) // resume skips backfill
+		i.metrics.InteropActivityState.Set(InteropStateRunning)
 		i.log.Info("interop resuming from verifiedDB",
 			"verificationStartTimestamp", i.verificationStartTimestamp,
 			"activationTimestamp", i.activationTimestamp)
 		return
 	}
 	i.waitingForSync = true
+	i.metrics.InteropActivityState.Set(InteropStateColdStartWaiting)
 	i.log.Info("interop cold start; waiting for SafeDB entries on every chain",
 		"activationTimestamp", i.activationTimestamp)
 }
@@ -383,6 +393,7 @@ func (i *Interop) waitForColdStartInit() (time.Duration, error) {
 	}
 	i.waitingForSync = false
 	i.initialized.Store(true)
+	i.metrics.InteropActivityState.Set(InteropStateRunning)
 	i.log.Info("interop cold start complete",
 		"activationTimestamp", i.activationTimestamp,
 		"verificationStartTimestamp", i.verificationStartTimestamp)
@@ -428,6 +439,7 @@ func (i *Interop) progress() (time.Duration, error) {
 	if err != nil {
 		if errors.Is(err, cc.ErrHistoryUnavailable) {
 			i.metrics.ActivityErrors.WithLabelValues("interop", "history_unavailable").Inc()
+			i.metrics.InteropActivityState.Set(InteropStateHalted)
 			i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
 				"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
 			return 0, fmt.Errorf("interop halted due to unavailable history: %w", err)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -195,6 +195,9 @@ type Interop struct {
 	// tests to gate on cold-start init finishing.
 	backfillCompleted atomic.Bool
 
+	// verifyRounds counts verification loop iterations for periodic progress logging.
+	verifyRounds atomic.Int32
+
 	// l1Checker must be non-nil whenever observeRound runs. Production sets it
 	// via New; tests inject noopL1Checker.
 	l1Checker l1ConsistencyChecker
@@ -413,6 +416,7 @@ func (i *Interop) logColdStartProgress(attempts int32) {
 // the round was a no-op, (errorBackoffPeriod, nil) on a recoverable error,
 // or a non-nil error to terminate the loop.
 func (i *Interop) progress() (time.Duration, error) {
+	round := i.verifyRounds.Add(1)
 	madeProgress, err := i.progressAndRecord()
 	if err != nil {
 		if errors.Is(err, cc.ErrHistoryUnavailable) {
@@ -424,6 +428,22 @@ func (i *Interop) progress() (time.Duration, error) {
 		i.metrics.ActivityErrors.WithLabelValues("interop", "progress").Inc()
 		i.log.Error("failed to progress and record interop", "err", err)
 		return errorBackoffPeriod, nil
+	}
+	if round%30 == 0 {
+		lastTS, _ := i.verifiedDB.LastTimestamp()
+		var tipTS uint64
+		for _, chain := range i.chains {
+			if status, err := chain.SyncStatus(i.ctx); err == nil && status.UnsafeL2.Time > tipTS {
+				tipTS = status.UnsafeL2.Time
+			}
+		}
+		var behind uint64
+		if tipTS > lastTS {
+			behind = tipTS - lastTS
+		}
+		i.log.Info("interop verification progress",
+			"round", round, "madeProgress", madeProgress,
+			"lastVerifiedTimestamp", lastTS, "tipTimestamp", tipTS, "behindSeconds", behind)
 	}
 	if !madeProgress {
 		return backoffPeriod, nil

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -364,10 +364,14 @@ func (i *Interop) waitForColdStartInit() (time.Duration, error) {
 	advanced, err := i.advanceColdStartInit()
 	if err != nil {
 		i.metrics.ActivityErrors.WithLabelValues("interop", "cold_start_init").Inc()
-		i.log.Warn("interop cold start step failed, will retry", "err", err)
+		i.log.Warn("interop cold start step failed, will retry",
+			"err", err, "attempts", i.backfillAttempts.Load())
 		return errorBackoffPeriod, nil
 	}
 	if !advanced {
+		if attempts := i.backfillAttempts.Load(); attempts%30 == 0 {
+			i.logColdStartProgress(attempts)
+		}
 		return backoffPeriod, nil
 	}
 	i.waitingForSync = false
@@ -376,6 +380,32 @@ func (i *Interop) waitForColdStartInit() (time.Duration, error) {
 		"activationTimestamp", i.activationTimestamp,
 		"verificationStartTimestamp", i.verificationStartTimestamp)
 	return 0, nil
+}
+
+// logColdStartProgress queries each chain's sync status and SafeDB readiness,
+// then emits a single info-level log with per-chain derivation progress.
+func (i *Interop) logColdStartProgress(attempts int32) {
+	fields := []any{
+		"attempts", attempts,
+		"activationTimestamp", i.activationTimestamp,
+	}
+	for _, chain := range i.chains {
+		chainID := chain.ID()
+		_, safeDBErr := chain.FirstSafeHeadTimestamp(i.ctx)
+		safeDBReady := safeDBErr == nil
+
+		status, syncErr := chain.SyncStatus(i.ctx)
+		if syncErr != nil {
+			fields = append(fields,
+				fmt.Sprintf("chain_%s", chainID), fmt.Sprintf("safedb_ready=%v sync_err=%v", safeDBReady, syncErr))
+			continue
+		}
+		fields = append(fields,
+			fmt.Sprintf("chain_%s", chainID),
+			fmt.Sprintf("safedb_ready=%v unsafe=%d pending_safe=%d safe=%d",
+				safeDBReady, status.UnsafeL2.Number, status.PendingSafeL2.Number, status.SafeL2.Number))
+	}
+	i.log.Info("interop cold start: waiting for SafeDB entries on all chains", fields...)
 }
 
 // progress runs one verification step. Returns (0, nil) when forward progress

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -380,15 +380,9 @@ func (i *Interop) waitForColdStartInit() (time.Duration, error) {
 		attempts := i.backfillAttempts.Load()
 		i.log.Warn("interop cold start step failed, will retry",
 			"err", err, "attempts", attempts)
-		if attempts%30 == 0 {
-			i.logColdStartProgress(attempts)
-		}
 		return errorBackoffPeriod, nil
 	}
 	if !advanced {
-		if attempts := i.backfillAttempts.Load(); attempts%30 == 0 {
-			i.logColdStartProgress(attempts)
-		}
 		return backoffPeriod, nil
 	}
 	i.waitingForSync = false
@@ -398,35 +392,6 @@ func (i *Interop) waitForColdStartInit() (time.Duration, error) {
 		"activationTimestamp", i.activationTimestamp,
 		"verificationStartTimestamp", i.verificationStartTimestamp)
 	return 0, nil
-}
-
-// logColdStartProgress queries each chain's sync status and SafeDB readiness,
-// then emits a single info-level log with per-chain derivation progress.
-// Includes L1 origin and finalized head so operators can tell whether the
-// deriver is still catching up or is at the tip waiting for new batches.
-func (i *Interop) logColdStartProgress(attempts int32) {
-	fields := []any{
-		"attempts", attempts,
-		"activationTimestamp", i.activationTimestamp,
-	}
-	for _, chain := range i.chains {
-		chainID := chain.ID()
-		_, safeDBErr := chain.FirstSafeHeadTimestamp(i.ctx)
-		safeDBReady := safeDBErr == nil
-
-		status, syncErr := chain.SyncStatus(i.ctx)
-		if syncErr != nil {
-			fields = append(fields,
-				fmt.Sprintf("chain_%s", chainID), fmt.Sprintf("safedb_ready=%v sync_err=%v", safeDBReady, syncErr))
-			continue
-		}
-		fields = append(fields,
-			fmt.Sprintf("chain_%s", chainID),
-			fmt.Sprintf("safedb_ready=%v unsafe=%d pending_safe=%d safe=%d current_l1=%d finalized_l1=%d",
-				safeDBReady, status.UnsafeL2.Number, status.PendingSafeL2.Number, status.SafeL2.Number,
-				status.CurrentL1.Number, status.FinalizedL1.Number))
-	}
-	i.log.Info("interop cold start: waiting for SafeDB entries on all chains", fields...)
 }
 
 // progress runs one verification step. Returns (0, nil) when forward progress

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -441,7 +441,6 @@ func (i *Interop) progress() (time.Duration, error) {
 		if tipTS > lastTS {
 			behind = tipTS - lastTS
 		}
-		i.metrics.InteropVerificationBehind.Set(float64(behind))
 		i.log.Info("interop verification progress",
 			"round", round, "madeProgress", madeProgress,
 			"lastVerifiedTimestamp", lastTS, "tipTimestamp", tipTS, "behindSeconds", behind)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -367,8 +367,12 @@ func (i *Interop) waitForColdStartInit() (time.Duration, error) {
 	advanced, err := i.advanceColdStartInit()
 	if err != nil {
 		i.metrics.ActivityErrors.WithLabelValues("interop", "cold_start_init").Inc()
+		attempts := i.backfillAttempts.Load()
 		i.log.Warn("interop cold start step failed, will retry",
-			"err", err, "attempts", i.backfillAttempts.Load())
+			"err", err, "attempts", attempts)
+		if attempts%30 == 0 {
+			i.logColdStartProgress(attempts)
+		}
 		return errorBackoffPeriod, nil
 	}
 	if !advanced {
@@ -387,6 +391,8 @@ func (i *Interop) waitForColdStartInit() (time.Duration, error) {
 
 // logColdStartProgress queries each chain's sync status and SafeDB readiness,
 // then emits a single info-level log with per-chain derivation progress.
+// Includes L1 origin and finalized head so operators can tell whether the
+// deriver is still catching up or is at the tip waiting for new batches.
 func (i *Interop) logColdStartProgress(attempts int32) {
 	fields := []any{
 		"attempts", attempts,
@@ -405,8 +411,9 @@ func (i *Interop) logColdStartProgress(attempts int32) {
 		}
 		fields = append(fields,
 			fmt.Sprintf("chain_%s", chainID),
-			fmt.Sprintf("safedb_ready=%v unsafe=%d pending_safe=%d safe=%d",
-				safeDBReady, status.UnsafeL2.Number, status.PendingSafeL2.Number, status.SafeL2.Number))
+			fmt.Sprintf("safedb_ready=%v unsafe=%d pending_safe=%d safe=%d current_l1=%d finalized_l1=%d",
+				safeDBReady, status.UnsafeL2.Number, status.PendingSafeL2.Number, status.SafeL2.Number,
+				status.CurrentL1.Number, status.FinalizedL1.Number))
 	}
 	i.log.Info("interop cold start: waiting for SafeDB entries on all chains", fields...)
 }
@@ -432,18 +439,29 @@ func (i *Interop) progress() (time.Duration, error) {
 	if round%30 == 0 {
 		lastTS, _ := i.verifiedDB.LastTimestamp()
 		var tipTS uint64
+		fields := []any{
+			"round", round, "madeProgress", madeProgress,
+		}
 		for _, chain := range i.chains {
-			if status, err := chain.SyncStatus(i.ctx); err == nil && status.UnsafeL2.Time > tipTS {
+			status, err := chain.SyncStatus(i.ctx)
+			if err != nil {
+				continue
+			}
+			if status.UnsafeL2.Time > tipTS {
 				tipTS = status.UnsafeL2.Time
 			}
+			fields = append(fields,
+				fmt.Sprintf("chain_%s", chain.ID()),
+				fmt.Sprintf("safe=%d pending_safe=%d unsafe=%d",
+					status.SafeL2.Number, status.PendingSafeL2.Number, status.UnsafeL2.Number))
 		}
 		var behind uint64
 		if tipTS > lastTS {
 			behind = tipTS - lastTS
 		}
-		i.log.Info("interop verification progress",
-			"round", round, "madeProgress", madeProgress,
+		fields = append(fields,
 			"lastVerifiedTimestamp", lastTS, "tipTimestamp", tipTS, "behindSeconds", behind)
+		i.log.Info("interop verification progress", fields...)
 	}
 	if !madeProgress {
 		return backoffPeriod, nil

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -66,13 +66,12 @@ func (i *Interop) collectFirstSafeHeadTimestamps() (map[eth.ChainID]uint64, bool
 	}
 	out := make(map[eth.ChainID]uint64, len(i.chains))
 	var firstErr error
-	emptyAny := false
+	var notReady []eth.ChainID
 	for range i.chains {
 		r := <-results
 		if r.err != nil {
 			if errors.Is(r.err, cc.ErrSafeDBNotReady) {
-				emptyAny = true
-				i.log.Debug("interop cold start: chain SafeDB empty, waiting", "chain", r.id)
+				notReady = append(notReady, r.id)
 				continue
 			}
 			if firstErr == nil {
@@ -85,7 +84,15 @@ func (i *Interop) collectFirstSafeHeadTimestamps() (map[eth.ChainID]uint64, bool
 	if firstErr != nil {
 		return nil, false, firstErr
 	}
-	if emptyAny {
+	if len(notReady) > 0 {
+		attempts := i.backfillAttempts.Load()
+		logFn := i.log.Debug
+		if attempts%30 == 0 {
+			logFn = i.log.Info
+		}
+		logFn("interop cold start: waiting for SafeDB entries",
+			"chainsNotReady", notReady, "attempts", attempts,
+			"activationTimestamp", i.activationTimestamp)
 		return nil, false, nil
 	}
 	return out, true, nil

--- a/op-supernode/supernode/resources/supernode_metrics.go
+++ b/op-supernode/supernode/resources/supernode_metrics.go
@@ -20,6 +20,9 @@ type SupernodeMetrics struct {
 	LogBackfillProgress         *prometheus.GaugeVec
 	LogBackfillRetries          *prometheus.CounterVec
 	ActivityErrors              *prometheus.CounterVec
+	// InteropActivityState tracks the interop activity lifecycle:
+	// 0=not_started, 1=cold_start_waiting, 2=running, 3=halted.
+	InteropActivityState prometheus.Gauge
 
 	registry *prometheus.Registry
 }
@@ -90,6 +93,11 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 			Name:      "activity_errors_total",
 			Help:      "Total number of activity errors by activity name and error type.",
 		}, []string{"activity", "error_type"}),
+		InteropActivityState: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "supernode",
+			Name:      "interop_activity_state",
+			Help:      "Interop activity lifecycle state: 0=not_started, 1=cold_start_waiting, 2=running, 3=halted.",
+		}),
 		registry: reg,
 	}
 	reg.MustRegister(
@@ -105,6 +113,7 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 		m.LogBackfillProgress,
 		m.LogBackfillRetries,
 		m.ActivityErrors,
+		m.InteropActivityState,
 	)
 	return m
 }

--- a/op-supernode/supernode/resources/supernode_metrics.go
+++ b/op-supernode/supernode/resources/supernode_metrics.go
@@ -14,7 +14,6 @@ type SupernodeMetrics struct {
 	InteropVerifiedTimestamp    prometheus.Gauge
 	InteropRoundDecisions       *prometheus.CounterVec
 	InteropRewinds              prometheus.Counter
-	InteropVerificationBehind   prometheus.Gauge
 	InteropVerificationDuration prometheus.Histogram
 	ChainRewindDepthBlocks      *prometheus.HistogramVec
 	DenyListEntries             *prometheus.CounterVec
@@ -59,11 +58,6 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 			Name:      "interop_rewinds_total",
 			Help:      "Total number of interop rewinds due to L1 consistency failures.",
 		}),
-		InteropVerificationBehind: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "supernode",
-			Name:      "interop_verification_behind_seconds",
-			Help:      "Seconds between the newest unsafe L2 timestamp observed by interop and the latest verified timestamp.",
-		}),
 		InteropVerificationDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "supernode",
 			Name:      "interop_verification_duration_seconds",
@@ -105,7 +99,6 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 		m.InteropVerifiedTimestamp,
 		m.InteropRoundDecisions,
 		m.InteropRewinds,
-		m.InteropVerificationBehind,
 		m.InteropVerificationDuration,
 		m.ChainRewindDepthBlocks,
 		m.DenyListEntries,

--- a/op-supernode/supernode/resources/supernode_metrics.go
+++ b/op-supernode/supernode/resources/supernode_metrics.go
@@ -14,6 +14,7 @@ type SupernodeMetrics struct {
 	InteropVerifiedTimestamp    prometheus.Gauge
 	InteropRoundDecisions       *prometheus.CounterVec
 	InteropRewinds              prometheus.Counter
+	InteropVerificationBehind   prometheus.Gauge
 	InteropVerificationDuration prometheus.Histogram
 	ChainRewindDepthBlocks      *prometheus.HistogramVec
 	DenyListEntries             *prometheus.CounterVec
@@ -58,6 +59,11 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 			Name:      "interop_rewinds_total",
 			Help:      "Total number of interop rewinds due to L1 consistency failures.",
 		}),
+		InteropVerificationBehind: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "supernode",
+			Name:      "interop_verification_behind_seconds",
+			Help:      "Seconds between the newest unsafe L2 timestamp observed by interop and the latest verified timestamp.",
+		}),
 		InteropVerificationDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "supernode",
 			Name:      "interop_verification_duration_seconds",
@@ -99,6 +105,7 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 		m.InteropVerifiedTimestamp,
 		m.InteropRoundDecisions,
 		m.InteropRewinds,
+		m.InteropVerificationBehind,
 		m.InteropVerificationDuration,
 		m.ChainRewindDepthBlocks,
 		m.DenyListEntries,


### PR DESCRIPTION
## Summary

Improve interop activity observability during cold start and verification.

### Cold start progress log
The interop cold start loop retries every second while waiting for SafeDB entries on all chains, but the only log was at `debug` level. At the default `info` level, operators see zero output — making it look like interop never started.

Every ~30 seconds, the supernode now logs per-chain sync status:
```
interop cold start: waiting for SafeDB entries on all chains
  attempts=30 activationTimestamp=1777409304
  chain_420120084="safedb_ready=true unsafe=989919 pending_safe=989606 safe=0"
  chain_420120085="safedb_ready=false unsafe=1979806 pending_safe=1979403 safe=0"
```

### Verification loop progress log
After cold start completes, the verification loop runs silently. Added a periodic log showing the last verified timestamp so operators can track verification catching up to chain tip:
```
interop verification progress
  round=30 madeProgress=true lastVerifiedTimestamp=1779380060
```

## Motivation

During sdg-v1 devnet healing, all supernodes were wiped and restarted. The interop cold start was silently waiting with zero visible logs at `info` level. It was impossible to tell whether interop had started, which chain was blocking, or how close verification was to advancing the safe head.

## Test plan

- [x] `go build ./op-supernode/...` passes
- [x] `go vet ./op-supernode/...` passes
- [ ] Existing tests pass
- [ ] Deploy to devnet and verify progress logs appear during cold start and verification