### PR TITLE
supernode: harden direct rewind around op-reth restart

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -685,6 +685,10 @@ retryLoop:
 		}
 	}
 
+	if err := c.resetSafeDBAfterEngineRewind(ctx, timestamp); err != nil {
+		return err
+	}
+
 	// Notify activities about the reset
 	if c.onReset != nil {
 		c.onReset(c.chainID, timestamp, invalidatedBlock)
@@ -697,6 +701,30 @@ retryLoop:
 	}
 	c.log.Info("chain_container/RewindEngine: resumed container")
 
+	return nil
+}
+
+func (c *simpleChainContainer) resetSafeDBAfterEngineRewind(ctx context.Context, timestamp uint64) error {
+	if c.vncfg == nil || c.vncfg.SafeDBPath == "" {
+		return nil
+	}
+	target, err := c.engine.BlockAtTimestamp(ctx, timestamp, eth.Unsafe)
+	if err != nil {
+		return fmt.Errorf("determine safe-db rewind target at timestamp %d: %w", timestamp, err)
+	}
+	db, err := safedb.NewSafeDB(c.log, c.vncfg.SafeDBPath)
+	if err != nil {
+		return fmt.Errorf("open safe-db for rewind: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			c.log.Error("failed to close safe-db after rewind", "err", err)
+		}
+	}()
+	if err := db.SafeHeadReset(target); err != nil {
+		return fmt.Errorf("rewind safe-db to %s: %w", target, err)
+	}
+	c.log.Info("chain_container/RewindEngine: rewound safe-db", "target", target)
 	return nil
 }
 

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -22,6 +22,9 @@ type EngineController interface {
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
 	// L2BlockRefByNumber returns the L2 block reference for the given block number.
 	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
+	// BlockAtTimestamp returns the L2 block reference for the block at or before
+	// the given timestamp, clamped to the head of the specified label.
+	BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error)
 	// OutputV0AtBlockNumber returns the output preimage for the given L2 block number.
 	OutputV0AtBlockNumber(ctx context.Context, num uint64) (*eth.OutputV0, error)
 	// OutputV0ByBlockHash returns the output preimage for the given L2 block

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -331,6 +331,10 @@ func (m *mockEngineForInvalidation) L2BlockRefByLabel(ctx context.Context, label
 	return eth.L2BlockRef{}, nil
 }
 
+func (m *mockEngineForInvalidation) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
+	return m.blockRef, m.blockRefErr
+}
+
 // mockVNForInvalidation implements virtual_node.VirtualNode for invalidation tests
 type mockVNForInvalidation struct {
 	stopErr error

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -78,6 +78,7 @@ type simpleVirtualNode struct {
 	mu     sync.Mutex         // Protects state transitions
 	state  VNState            // Current lifecycle state
 	cancel context.CancelFunc // Cancels the running context
+	done   chan struct{}      // Closed when Start has completed shutdown
 }
 
 func generateVirtualNodeID() string {
@@ -132,7 +133,10 @@ func (v *simpleVirtualNode) Start(ctx context.Context) error {
 	}
 	v.inner = n
 	v.state = VNStateRunning
+	done := make(chan struct{})
+	v.done = done
 	v.mu.Unlock()
+	defer close(done)
 
 	// Run inner node in goroutine
 	// and await any signal to exit (Stop(), parent ctx, or inner error)
@@ -142,22 +146,21 @@ func (v *simpleVirtualNode) Start(ctx context.Context) error {
 	}()
 	<-runCtx.Done()
 
-	// Update state under lock, but do NOT hold the lock during inner.Stop().
-	// inner.Stop() drains the op-node event system, which may call back into
-	// this VirtualNode (e.g. SyncStatus via EngineController.FinalizedHead).
-	// SyncStatus needs v.mu, so holding it here would deadlock.
-	v.mu.Lock()
-	v.state = VNStateStopped
-	v.cancel = nil
-	v.mu.Unlock()
-
-	// Stop the inner node outside the lock. Use n which is the local reference
-	// to the inner node created at the top of this function.
+	// Stop the inner node outside the lock. inner.Stop() drains the op-node event
+	// system, which may call back into this VirtualNode (e.g. SyncStatus via
+	// EngineController.FinalizedHead). SyncStatus needs v.mu, so holding it here
+	// would deadlock.
 	stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer stopCancel()
 	if err := n.Stop(stopCtx); err != nil {
 		v.log.Error("error stopping inner node", "err", err)
 	}
+
+	v.mu.Lock()
+	v.state = VNStateStopped
+	v.cancel = nil
+	v.done = nil
+	v.mu.Unlock()
 
 	// Return inner error if that's what caused the cancellation, otherwise context error
 	if cancelErr != nil {
@@ -178,9 +181,8 @@ func (v *simpleVirtualNode) Start(ctx context.Context) error {
 
 func (v *simpleVirtualNode) Stop(ctx context.Context) error {
 	v.mu.Lock()
-	defer v.mu.Unlock()
-
 	if v.state != VNStateRunning {
+		v.mu.Unlock()
 		return nil // Already stopped or not started
 	}
 
@@ -188,7 +190,16 @@ func (v *simpleVirtualNode) Stop(ctx context.Context) error {
 	if v.cancel != nil {
 		v.cancel()
 	}
+	done := v.done
+	v.mu.Unlock()
 
+	if done != nil {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Draft follow-up to #20956. This tries the simplest CL/supernode-side recovery hardening for the op-reth proofs-history reorg repro:

- make `VirtualNode.Stop` wait until the embedded op-node has actually stopped before `RewindEngine` rewinds the EL
- reset the op-node SafeDB to the same target block after the direct engine rewind, matching the rewind target used by the EL
- expose `BlockAtTimestamp` on the chain-container engine-controller interface so the chain container can resolve that SafeDB target

## Local result

This does **not** fully recover the repro yet. It improves the sequence enough that, after the first op-reth restart, chain 901 is driven forward again, but op-reth then crashes a second time from the proofs-history ExEx while ingesting the replacement chain. That suggests the remaining failure is still in EL/ExEx state handling, not just supernode reset bookkeeping.

Relevant local acceptance run:

```
LOG_LEVEL=info mise exec -- go test -v ./op-acceptance-tests/tests/interop/reorgs \
  -run '^TestReorgInvalidExecMsgOpRethProofsHistoryTinyWindow$' \
  -count=1 -timeout=8m 2>&1 | tee /tmp/op-reth-reorg-recovery-attempt.log
```

Important signals from `/tmp/op-reth-reorg-recovery-attempt.log`:

- `chain_container/RewindEngine: rewound safe-db target=415c48..f9f0b7:14`
- first op-reth exit: `ExEx proofs-history crashed: Attempted to unwind to block 14 beyond earliest stored block 20`
- restart occurred: `restarting op-reth after proofs-history unwind exit`
- after restart, chain 901 progressed to `UnsafeL2 ... :27`, with `PendingSafeL2`/`LocalSafeL2 ... :15`
- second op-reth exit: `ExEx proofs-history crashed: Parent hash mismatch at block 22`
- final repro assertion: `repro observed`

## Tests

- `go test ./op-supernode/supernode/chain_container/...`
- `go test ./op-supernode/supernode/activity/interop -run 'TestApplyPendingTransition|TestReset|TestRewind'`
- focused acceptance repro above, still failing with the repro assertion
