### PR TITLE
fix(devstack): tolerate "batcher is already running" in DSL Start()

### DIFF
--- a/op-devstack/dsl/l2_batcher.go
+++ b/op-devstack/dsl/l2_batcher.go
@@ -50,7 +50,11 @@ func (b *L2Batcher) Stop() {
 
 func (b *L2Batcher) Start() {
 	err := retry.Do0(b.ctx, 3, retry.Exponential(), func() error {
-		return b.inner.ActivityAPI().StartBatcher(b.ctx)
+		err := b.inner.ActivityAPI().StartBatcher(b.ctx)
+		if err != nil && strings.Contains(err.Error(), "batcher is already running") {
+			return nil
+		}
+		return err
 	})
 	require.NoError(b.t, err, fmt.Sprintf("Expected to be able to call StartBatcher API on chain %s, but got error", b.inner.ChainID()))
 }


### PR DESCRIPTION
`L2Batcher.Start()` retries the `StartBatcher` RPC up to 3 times. If the first call actually starts the batcher but the client sees a transient error, retries 2 and 3 hit `"batcher is already running"` and the helper fails permanently.

Mirror the existing symmetric tolerance in `Stop()` (which already ignores `"batcher is not running"`) so a transient RPC error doesn't fail the test when the batcher is in the desired state.

Observed as a flake in `TestInteropFaultProofs_VariedBlockTimes`.