### PR TITLE
supernode: try native engine reset for invalidation rewinds

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -803,6 +803,13 @@ func (n *OpNode) RuntimeConfig() runcfg.ReadonlyRuntimeConfig {
 	return n.runCfg
 }
 
+func (n *OpNode) ForceEngineReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) error {
+	if n.l2Driver == nil {
+		return errors.New("l2 driver not initialized")
+	}
+	return n.l2Driver.ForceEngineReset(ctx, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized)
+}
+
 // Stop stops the node and closes all resources.
 // If the provided ctx is expired, the node will accelerate the stop where possible, but still fully close.
 func (n *OpNode) Stop(ctx context.Context) error {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -135,6 +135,7 @@ func NewDriver(
 		drain:                drain,
 		stateReq:             make(chan chan struct{}),
 		forceReset:           make(chan chan struct{}, 10),
+		forceEngineReset:     make(chan forceEngineResetRequest, 10),
 		driverConfig:         driverCfg,
 		syncConfig:           syncCfg,
 		driverCtx:            driverCtx,
@@ -167,6 +168,11 @@ type Driver struct {
 	// It tells the caller that the reset occurred by closing the passed in channel.
 	forceReset chan chan struct{}
 
+	// Upon receiving a request in this channel, the engine is force-reset to
+	// the supplied heads from inside the driver event loop. This preserves the
+	// native EngineResetConfirmedEvent side effects, including SafeDB reset.
+	forceEngineReset chan forceEngineResetRequest
+
 	// Driver config: verifier and sequencer settings.
 	// May not be modified after starting the Driver.
 	driverConfig *Config
@@ -187,6 +193,15 @@ type Driver struct {
 	driverCancel context.CancelFunc
 
 	upstreamFollowSource UpstreamFollowSource
+}
+
+type forceEngineResetRequest struct {
+	localUnsafe eth.L2BlockRef
+	crossUnsafe eth.L2BlockRef
+	localSafe   eth.L2BlockRef
+	crossSafe   eth.L2BlockRef
+	finalized   eth.L2BlockRef
+	resp        chan error
 }
 
 // Start starts up the state loop.
@@ -346,6 +361,16 @@ func (s *Driver) eventLoop() {
 			s.SyncDeriver.Derivation.Reset()
 			s.metrics.RecordPipelineReset()
 			close(respCh)
+		case req := <-s.forceEngineReset:
+			s.log.Warn("Engine is manually force-reset",
+				"local_unsafe", req.localUnsafe,
+				"cross_unsafe", req.crossUnsafe,
+				"local_safe", req.localSafe,
+				"cross_safe", req.crossSafe,
+				"finalized", req.finalized,
+			)
+			s.SyncDeriver.Engine.ForceReset(s.driverCtx, req.localUnsafe, req.crossUnsafe, req.localSafe, req.crossSafe, req.finalized)
+			req.resp <- s.drain.Drain()
 		case <-s.drain.Await():
 			if err := s.drain.Drain(); err != nil {
 				if s.driverCtx.Err() != nil {
@@ -377,6 +402,31 @@ func (s *Driver) ResetDerivationPipeline(ctx context.Context) error {
 			return ctx.Err()
 		case <-respCh:
 			return nil
+		}
+	}
+}
+
+// ForceEngineReset resets the engine controller to the supplied heads through
+// the normal op-node event path. It waits until events emitted by the reset,
+// including EngineResetConfirmedEvent, have been drained.
+func (s *Driver) ForceEngineReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) error {
+	req := forceEngineResetRequest{
+		localUnsafe: localUnsafe,
+		crossUnsafe: crossUnsafe,
+		localSafe:   localSafe,
+		crossSafe:   crossSafe,
+		finalized:   finalized,
+		resp:        make(chan error, 1),
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s.forceEngineReset <- req:
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-req.resp:
+			return err
 		}
 	}
 }

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -644,60 +644,94 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, timestamp uint6
 		return fmt.Errorf("engine not initialized")
 	}
 
-	// Pause the container to stop it restarting the vn when we kill it
-	err := c.Pause(ctx)
+	target, targetSafe, targetFinalized, err := c.nativeEngineResetTargets(ctx, timestamp)
 	if err != nil {
 		return err
 	}
-	// Always resume the container on return, even if we exit early due to context cancellation
-	// or an error mid-rewind. Without this, a cancelled ctx leaves pause=true permanently,
-	// causing the Start() loop to spin forever and block Supernode.Stop()'s wg.Wait().
-	defer c.Resume(context.Background()) //nolint:errcheck
-	c.log.Info("chain_container/RewindEngine: paused container")
 
-	// stop the vn
-	err = vn.Stop(ctx)
-	if err != nil {
-		return err
+	if err := c.forceNativeEngineReset(ctx, vn, target, targetSafe, targetFinalized); err != nil {
+		return fmt.Errorf("force native engine reset: %w", err)
 	}
-	c.log.Info("chain_container/RewindEngine: stopped vn")
-
-retryLoop:
-	for {
-		err = c.engine.RewindToTimestamp(ctx, timestamp)
-		switch {
-		case errors.Is(err, context.DeadlineExceeded):
-			c.log.Error("chain_container/RewindEngine: timeout exceeded")
-			return err
-		case isCriticalRewindError(err):
-			c.log.Error("chain_container/RewindEngine: critical error", "err", err)
-			return err
-		case err == nil:
-			c.log.Info("chain_container/RewindEngine: executed engine rewind")
-			break retryLoop
-		default:
-			c.log.Error("chain_container/RewindEngine: temporary error", "err", err)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(time.Second):
-			}
-		}
-	}
+	c.log.Info("chain_container/RewindEngine: executed native engine reset",
+		"unsafe", target,
+		"safe", targetSafe,
+		"finalized", targetFinalized,
+	)
 
 	// Notify activities about the reset
 	if c.onReset != nil {
 		c.onReset(c.chainID, timestamp, invalidatedBlock)
 	}
 
-	// resume the chain container to trigger a new vn to be started
-	err = c.Resume(ctx)
-	if err != nil {
+	return nil
+}
+
+func (c *simpleChainContainer) forceNativeEngineReset(ctx context.Context, vn virtual_node.VirtualNode, target, safe, finalized eth.L2BlockRef) error {
+	err := vn.ForceEngineReset(ctx, target, target, safe, safe, finalized)
+	if !errors.Is(err, virtual_node.ErrVirtualNodeNotRunning) {
 		return err
 	}
-	c.log.Info("chain_container/RewindEngine: resumed container")
 
-	return nil
+	c.log.Info("virtual node not running; resuming before native engine reset")
+	if err := c.Resume(ctx); err != nil {
+		return err
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-waitCtx.Done():
+			return waitCtx.Err()
+		case <-ticker.C:
+			vn := c.getVN()
+			if vn == nil {
+				continue
+			}
+			err := vn.ForceEngineReset(waitCtx, target, target, safe, safe, finalized)
+			if err == nil {
+				return nil
+			}
+			if errors.Is(err, virtual_node.ErrVirtualNodeNotRunning) {
+				continue
+			}
+			return err
+		}
+	}
+}
+
+func (c *simpleChainContainer) nativeEngineResetTargets(ctx context.Context, timestamp uint64) (target, safe, finalized eth.L2BlockRef, err error) {
+	targetNum, err := c.TimestampToBlockNumber(ctx, timestamp)
+	if err != nil {
+		return eth.L2BlockRef{}, eth.L2BlockRef{}, eth.L2BlockRef{}, fmt.Errorf("%w: %w", engine_controller.ErrRewindTimestampToBlockConversion, err)
+	}
+	target, err = c.engine.L2BlockRefByNumber(ctx, targetNum)
+	if err != nil {
+		return eth.L2BlockRef{}, eth.L2BlockRef{}, eth.L2BlockRef{}, fmt.Errorf("%w %d: %w", engine_controller.ErrRewindTargetBlockNotFound, timestamp, err)
+	}
+	currentSafe, err := c.engine.L2BlockRefByLabel(ctx, eth.Safe)
+	if err != nil {
+		return eth.L2BlockRef{}, eth.L2BlockRef{}, eth.L2BlockRef{}, fmt.Errorf("%w: failed to get current safe block: %w", engine_controller.ErrRewindComputeTargetsFailed, err)
+	}
+	currentFinalized, err := c.engine.L2BlockRefByLabel(ctx, eth.Finalized)
+	if err != nil {
+		return eth.L2BlockRef{}, eth.L2BlockRef{}, eth.L2BlockRef{}, fmt.Errorf("%w: failed to get current finalized block: %w", engine_controller.ErrRewindComputeTargetsFailed, err)
+	}
+	if target.Number < currentFinalized.Number {
+		return eth.L2BlockRef{}, eth.L2BlockRef{}, eth.L2BlockRef{}, engine_controller.ErrRewindOverFinalizedHead
+	}
+	return target, earliestL2Ref(currentSafe, target), earliestL2Ref(currentFinalized, target), nil
+}
+
+func earliestL2Ref(a, b eth.L2BlockRef) eth.L2BlockRef {
+	if a.Number < b.Number {
+		return a
+	}
+	return b
 }
 
 // PauseAndStopVN pauses the container restart loop and stops the running virtual node.

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -35,10 +35,13 @@ type mockVirtualNode struct {
 	mu           sync.Mutex
 	startCalled  int
 	stopCalled   int
+	resetCalled  int
 	startErr     error
 	stopErr      error
+	resetErr     error
 	startFunc    func(ctx context.Context) error
 	stopFunc     func(ctx context.Context) error
+	resetFunc    func(ctx context.Context) error
 	blockOnStart bool
 	startSignal  chan struct{}
 	// latest safe mock behavior
@@ -104,6 +107,16 @@ func (m *mockVirtualNode) Stop(ctx context.Context) error {
 	return m.stopErr
 }
 
+func (m *mockVirtualNode) ForceEngineReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) error {
+	m.mu.Lock()
+	m.resetCalled++
+	m.mu.Unlock()
+	if m.resetFunc != nil {
+		return m.resetFunc(ctx)
+	}
+	return m.resetErr
+}
+
 // SafeTimestamp implements virtual_node.VirtualNode SafeTimestamp
 func (m *mockVirtualNode) LatestSafe(ctx context.Context) (eth.BlockID, error) {
 	return m.latestSafe, m.latestErr
@@ -163,6 +176,8 @@ type mockEngineController struct {
 	rewindFunc               func(ctx context.Context, timestamp uint64) error // optional custom behavior
 	l2BlockRefByNumberResult eth.L2BlockRef
 	l2BlockRefByNumberErr    error
+	l2SafeResult             eth.L2BlockRef
+	l2FinalizedResult        eth.L2BlockRef
 }
 
 func (m *mockEngineController) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
@@ -174,6 +189,12 @@ func (m *mockEngineController) L2BlockRefByNumber(ctx context.Context, num uint6
 }
 
 func (m *mockEngineController) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
+	switch label {
+	case eth.Safe:
+		return m.l2SafeResult, nil
+	case eth.Finalized:
+		return m.l2FinalizedResult, nil
+	}
 	return eth.L2BlockRef{}, nil
 }
 
@@ -610,10 +631,13 @@ func TestChainContainer_PauseResume(t *testing.T) {
 
 // TestChainContainer_RewindEngine tests the RewindEngine method
 func TestChainContainer_RewindEngine(t *testing.T) {
-	t.Run("calls RewindToTimestamp on engine controller and stops VN", func(t *testing.T) {
+	t.Run("force resets running VN through native op-node reset path", func(t *testing.T) {
 		// Setup
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()
+		mockEngine.l2BlockRefByNumberResult = eth.L2BlockRef{Number: 4, Hash: common.Hash{0x4}}
+		mockEngine.l2SafeResult = eth.L2BlockRef{Number: 6, Hash: common.Hash{0x6}}
+		mockEngine.l2FinalizedResult = eth.L2BlockRef{Number: 2, Hash: common.Hash{0x2}}
 
 		chainID := eth.ChainIDFromUInt64(420)
 		log := createTestLogger(t)
@@ -624,141 +648,70 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 			log:     log,
 			engine:  mockEngine,
 			vn:      mockVN,
+			vncfg: &opnodecfg.Config{Rollup: rollup.Config{
+				BlockTime: 2,
+				Genesis:   rollup.Genesis{L2Time: 10},
+			}},
 		}
 
 		// Call RewindEngine
 		ctx := context.Background()
-		rewindTimestamp := uint64(1234567890)
+		rewindTimestamp := uint64(18)
 		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: rewindTimestamp + 2}
 		err := c.RewindEngine(ctx, rewindTimestamp, invalidatedBlock)
 		require.NoError(t, err)
 
-		// Verify RewindToTimestamp was called with correct timestamp
-		require.Equal(t, 1, mockEngine.rewindToTimestampCalled, "RewindToTimestamp should be called once")
-		require.Equal(t, rewindTimestamp, mockEngine.rewindTimestamp, "RewindToTimestamp should be called with correct timestamp")
-
-		// Verify the virtual node was stopped
 		mockVN.mu.Lock()
-		require.Equal(t, 1, mockVN.stopCalled, "Virtual node should be stopped once")
+		require.Equal(t, 1, mockVN.resetCalled, "Virtual node should be force-reset once")
+		require.Equal(t, 0, mockVN.stopCalled, "Virtual node should not be stopped")
 		mockVN.mu.Unlock()
+		require.Equal(t, 0, mockEngine.rewindToTimestampCalled, "direct EL rewind should not be used")
 
-		// Verify container state: paused should be false (resumed), allowing new VN to start
-		require.False(t, c.pause.Load(), "Container should be resumed after rewind")
+		require.False(t, c.pause.Load(), "Container should not be left paused after native reset")
 	})
 
-	t.Run("retries transient errors and eventually fails", func(t *testing.T) {
-		// Setup - transient error should be retried
+	t.Run("resumes a stopped VN before native reset", func(t *testing.T) {
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()
-		mockEngine.rewindErr = engine_controller.ErrRewindFCUSyntheticFailed
+		mockEngine.l2BlockRefByNumberResult = eth.L2BlockRef{Number: 4, Hash: common.Hash{0x4}}
+		mockEngine.l2SafeResult = eth.L2BlockRef{Number: 6, Hash: common.Hash{0x6}}
+		mockEngine.l2FinalizedResult = eth.L2BlockRef{Number: 2, Hash: common.Hash{0x2}}
 
-		chainID := eth.ChainIDFromUInt64(420)
-		log := createTestLogger(t)
-
-		c := &simpleChainContainer{
-			chainID: chainID,
-			log:     log,
-			engine:  mockEngine,
-			vn:      mockVN,
-		}
-
-		// Call RewindEngine - should retry and eventually fail
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second) // this will prevent infinite retries
-		defer cancel()
-		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
-		err := c.RewindEngine(ctx, 12345, invalidatedBlock)
-		require.Error(t, err)
-		require.ErrorIs(t, err, context.DeadlineExceeded)
-
-		// Verify RewindToTimestamp was called multiple times (retry attempts)
-		require.Greater(t, mockEngine.rewindToTimestampCalled, 1, "RewindToTimestamp should be retried at least once")
-
-		// Container should be resumed even after a failed rewind, so the Start() loop
-		// can detect the stop flag and exit cleanly instead of spinning forever.
-		require.False(t, c.pause.Load(), "Container should be resumed (not stuck paused) after failed rewind")
-	})
-
-	t.Run("does not retry critical errors", func(t *testing.T) {
-		criticalErrors := []struct {
-			name string
-			err  error
-		}{
-			{"ErrNoEngineClient", engine_controller.ErrNoEngineClient},
-			{"ErrNoRollupConfig", engine_controller.ErrNoRollupConfig},
-			{"ErrRewindComputeTargetsFailed", engine_controller.ErrRewindComputeTargetsFailed},
-			{"ErrRewindTimestampToBlockConversion", engine_controller.ErrRewindTimestampToBlockConversion},
-		}
-
-		for _, tc := range criticalErrors {
-			t.Run(tc.name, func(t *testing.T) {
-				// Setup - critical error should not be retried
-				mockVN := newMockVirtualNode()
-				mockEngine := newMockEngineController()
-				mockEngine.rewindErr = tc.err
-
-				chainID := eth.ChainIDFromUInt64(420)
-				log := createTestLogger(t)
-
-				c := &simpleChainContainer{
-					chainID: chainID,
-					log:     log,
-					engine:  mockEngine,
-					vn:      mockVN,
-				}
-
-				// Call RewindEngine - should fail immediately without retry
-				ctx := context.Background()
-				invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
-				err := c.RewindEngine(ctx, 12345, invalidatedBlock)
-				require.Error(t, err)
-				require.ErrorIs(t, err, tc.err)
-
-				// Verify RewindToTimestamp was called only once (no retry for critical errors)
-				require.Equal(t, 1, mockEngine.rewindToTimestampCalled, "RewindToTimestamp should not be retried for critical errors")
-			})
-		}
-	})
-
-	t.Run("returns error when VN stop fails", func(t *testing.T) {
-		// Setup
-		mockVN := newMockVirtualNode()
-		mockVN.stopErr = context.DeadlineExceeded
-		mockEngine := newMockEngineController()
-
-		chainID := eth.ChainIDFromUInt64(420)
-		log := createTestLogger(t)
-
-		c := &simpleChainContainer{
-			chainID: chainID,
-			log:     log,
-			engine:  mockEngine,
-			vn:      mockVN,
-		}
-
-		// Call RewindEngine - should fail on VN stop
-		ctx := context.Background()
-		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
-		err := c.RewindEngine(ctx, 12345, invalidatedBlock)
-		require.Error(t, err)
-		require.ErrorIs(t, err, context.DeadlineExceeded)
-
-		// Verify RewindToTimestamp was NOT called since VN stop failed
-		require.Equal(t, 0, mockEngine.rewindToTimestampCalled, "RewindToTimestamp should not be called when VN stop fails")
-	})
-
-	t.Run("succeeds after transient error on retry", func(t *testing.T) {
-		// Setup - fail first 2 attempts, succeed on 3rd
-		mockVN := newMockVirtualNode()
-		mockEngine := newMockEngineController()
-		failCount := 0
-		mockEngine.rewindFunc = func(ctx context.Context, timestamp uint64) error {
-			failCount++
-			if failCount < 3 {
-				return engine_controller.ErrRewindFCUTargetFailed
+		resetAttempts := 0
+		mockVN.resetFunc = func(ctx context.Context) error {
+			resetAttempts++
+			if resetAttempts == 1 {
+				return virtual_node.ErrVirtualNodeNotRunning
 			}
 			return nil
 		}
 
+		c := &simpleChainContainer{
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
+			engine:  mockEngine,
+			vn:      mockVN,
+			vncfg: &opnodecfg.Config{Rollup: rollup.Config{
+				BlockTime: 2,
+				Genesis:   rollup.Genesis{L2Time: 10},
+			}},
+		}
+		c.pause.Store(true)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		err := c.RewindEngine(ctx, 18, eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, Time: 20})
+		require.NoError(t, err)
+		require.False(t, c.pause.Load(), "RewindEngine should resume the chain before native reset")
+		require.GreaterOrEqual(t, mockVN.resetCalled, 2)
+	})
+
+	t.Run("returns error when target lookup fails", func(t *testing.T) {
+		mockVN := newMockVirtualNode()
+		mockEngine := newMockEngineController()
+		mockEngine.l2BlockRefByNumberErr = ethereum.NotFound
+
 		chainID := eth.ChainIDFromUInt64(420)
 		log := createTestLogger(t)
 
@@ -767,19 +720,69 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 			log:     log,
 			engine:  mockEngine,
 			vn:      mockVN,
+			vncfg: &opnodecfg.Config{Rollup: rollup.Config{
+				BlockTime: 2,
+				Genesis:   rollup.Genesis{L2Time: 10},
+			}},
 		}
 
-		// Call RewindEngine - should succeed after retries
+		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
+		err := c.RewindEngine(context.Background(), 18, invalidatedBlock)
+		require.Error(t, err)
+		require.ErrorIs(t, err, engine_controller.ErrRewindTargetBlockNotFound)
+	})
+
+	t.Run("returns error when VN native reset fails", func(t *testing.T) {
+		mockVN := newMockVirtualNode()
+		mockVN.resetErr = context.DeadlineExceeded
+		mockEngine := newMockEngineController()
+		mockEngine.l2BlockRefByNumberResult = eth.L2BlockRef{Number: 4, Hash: common.Hash{0x4}}
+
+		chainID := eth.ChainIDFromUInt64(420)
+		log := createTestLogger(t)
+
+		c := &simpleChainContainer{
+			chainID: chainID,
+			log:     log,
+			engine:  mockEngine,
+			vn:      mockVN,
+			vncfg: &opnodecfg.Config{Rollup: rollup.Config{
+				BlockTime: 2,
+				Genesis:   rollup.Genesis{L2Time: 10},
+			}},
+		}
+
 		ctx := context.Background()
 		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
-		err := c.RewindEngine(ctx, 12345, invalidatedBlock)
-		require.NoError(t, err)
+		err := c.RewindEngine(ctx, 18, invalidatedBlock)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
 
-		// Verify RewindToTimestamp was called 3 times (2 failures + 1 success)
-		require.Equal(t, 3, mockEngine.rewindToTimestampCalled, "RewindToTimestamp should be called 3 times")
+	t.Run("rejects reset over finalized head", func(t *testing.T) {
+		mockVN := newMockVirtualNode()
+		mockEngine := newMockEngineController()
+		mockEngine.l2BlockRefByNumberResult = eth.L2BlockRef{Number: 4, Hash: common.Hash{0x4}}
+		mockEngine.l2FinalizedResult = eth.L2BlockRef{Number: 5, Hash: common.Hash{0x5}}
 
-		// Container should be resumed after successful rewind
-		require.False(t, c.pause.Load(), "Container should be resumed after successful rewind")
+		chainID := eth.ChainIDFromUInt64(420)
+		log := createTestLogger(t)
+
+		c := &simpleChainContainer{
+			chainID: chainID,
+			log:     log,
+			engine:  mockEngine,
+			vn:      mockVN,
+			vncfg: &opnodecfg.Config{Rollup: rollup.Config{
+				BlockTime: 2,
+				Genesis:   rollup.Genesis{L2Time: 10},
+			}},
+		}
+
+		ctx := context.Background()
+		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
+		err := c.RewindEngine(ctx, 18, invalidatedBlock)
+		require.ErrorIs(t, err, engine_controller.ErrRewindOverFinalizedHead)
 	})
 }
 
@@ -1066,6 +1069,9 @@ type mockVNForL1AtSafeHeadError struct {
 
 func (m *mockVNForL1AtSafeHeadError) Start(ctx context.Context) error { return nil }
 func (m *mockVNForL1AtSafeHeadError) Stop(ctx context.Context) error  { return nil }
+func (m *mockVNForL1AtSafeHeadError) ForceEngineReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) error {
+	return nil
+}
 func (m *mockVNForL1AtSafeHeadError) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (eth.BlockID, eth.BlockID, error) {
 	return eth.BlockID{}, eth.BlockID{}, nil
 }

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -333,11 +333,17 @@ func (m *mockEngineForInvalidation) L2BlockRefByLabel(ctx context.Context, label
 
 // mockVNForInvalidation implements virtual_node.VirtualNode for invalidation tests
 type mockVNForInvalidation struct {
-	stopErr error
+	stopErr     error
+	resetCalled bool
+	resetErr    error
 }
 
 func (m *mockVNForInvalidation) Start(ctx context.Context) error { return nil }
 func (m *mockVNForInvalidation) Stop(ctx context.Context) error  { return m.stopErr }
+func (m *mockVNForInvalidation) ForceEngineReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) error {
+	m.resetCalled = true
+	return m.resetErr
+}
 func (m *mockVNForInvalidation) LatestSafe(ctx context.Context) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }
@@ -536,11 +542,12 @@ func TestInvalidateBlock(t *testing.T) {
 			}
 
 			// Create container with minimal config
+			mockVN := &mockVNForInvalidation{}
 			c := &simpleChainContainer{
 				denyList: dl,
 				log:      testLogger(),
 				vncfg:    &opnodecfg.Config{},
-				vn:       &mockVNForInvalidation{},
+				vn:       mockVN,
 			}
 			c.vncfg.Rollup.Genesis.L2Time = genesisTime
 			c.vncfg.Rollup.Genesis.L2.Number = tt.genesisBlock
@@ -564,8 +571,7 @@ func TestInvalidateBlock(t *testing.T) {
 			require.Equal(t, tt.expectRewind, rewound, "rewind triggered mismatch")
 
 			if tt.expectRewind {
-				require.True(t, mockEng.rewindCalled, "RewindToTimestamp should have been called")
-				require.Equal(t, tt.expectRewindTs, mockEng.rewindTimestamp, "rewind timestamp mismatch")
+				require.True(t, mockVN.resetCalled, "native engine reset should have been requested")
 			}
 
 			// Verify hash was added to denylist regardless

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -38,6 +38,7 @@ var (
 type VirtualNode interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
+	ForceEngineReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) error
 
 	SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (eth.BlockID, eth.BlockID, error)
 	// L1AtSafeHead returns the earliest L1 block at which the given L2 block became safe.
@@ -51,6 +52,7 @@ type VirtualNode interface {
 type innerNode interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
+	ForceEngineReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) error
 	SafeDB() rollupNode.SafeDBReader
 	SyncStatus() *eth.SyncStatus
 }
@@ -190,6 +192,17 @@ func (v *simpleVirtualNode) Stop(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (v *simpleVirtualNode) ForceEngineReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) error {
+	v.mu.Lock()
+	inner := v.inner
+	running := v.state == VNStateRunning
+	v.mu.Unlock()
+	if !running || inner == nil {
+		return ErrVirtualNodeNotRunning
+	}
+	return inner.ForceEngineReset(ctx, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized)
 }
 
 // State returns the current state of the virtual node (for testing and monitoring)

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
@@ -57,6 +57,10 @@ func (m *mockInnerNode) Stop(ctx context.Context) error {
 	return m.stopErr
 }
 
+func (m *mockInnerNode) ForceEngineReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) error {
+	return nil
+}
+
 // SafeL2Timestamp implements the innerNode interface method used by VirtualNode for safety checks
 func (m *mockInnerNode) SafeL2Timestamp() (uint64, bool) {
 	return m.safeTs, m.haveSafe


### PR DESCRIPTION
## Summary

Experimental recovery branch on top of `karl/op-reth-reorg-repro`. Instead of manually rewinding the EL and recreating the virtual node, invalidation rewinds now route through the op-node engine reset path.

Changes:
- add an op-node `ForceEngineReset` entrypoint that runs `EngineController.ForceReset` on the driver event loop
- expose that through the supernode virtual node abstraction
- update `ChainContainer.RewindEngine` to compute reset targets and issue the native reset
- if the existing interop freeze protocol has stopped the target VN, resume that chain and wait briefly for the live driver before issuing the reset
- keep the existing SafeDB reset behavior by draining the engine reset confirmation event

## Local Validation

Passing:

```
go test ./op-supernode/supernode/chain_container/...
go test ./op-node/rollup/driver ./op-node/node
go test ./op-supernode/supernode/activity/interop -run 'TestApplyPendingTransition|TestReset|TestRewind|TestInvalidateBlock'\n```\n\nFocused repro run:\n\n```\nLOG_LEVEL=info mise exec -- go test -v ./op-acceptance-tests/tests/interop/reorgs \\\n  -run '^TestReorgInvalidExecMsgOpRethProofsHistoryTinyWindow$' \\\n  -count=1 -timeout=8m\n```\n\nResult: the repro test fails with `unexpected recovery`, which is the expected signal for this branch. Relevant local log points from `/tmp/op-reth-reorg-native-reset-rerun.log`:\n\n- native reset fired: `Engine is manually force-reset` for chain 901 at unsafe 14 / safe 6 / finalized 0\n- supernode SafeDB reset followed: `Resetting safe head db` to safe block 6\n- op-reth still reproduced the proofs-history crash: `ExEx proofs-history crashed: Attempted to unwind to block 15 beyond earliest stored block 20`\n- test restarted op-reth after the RPC failure\n- after restart, the repro assertion failed because EL unsafe advanced to block 22 instead of staying stuck\n\n## Notes\n\nThis is intentionally separate from #20962. It is a cleaner-looking direction because the reset goes through op-node’s existing engine reset event/confirmation path rather than manually clearing SafeDB from the chain container.\n