### PR TITLE
chore(ci): stabilize memory-all — bound concurrency, shard across 2 runners, verbose go-test streaming

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1898,9 +1898,18 @@ jobs:
         description: Timeout for when CircleCI kills the job if there's no output
         type: string
         default: 30m
+      parallelism:
+        description: Number of machines to distribute the tests across
+        type: integer
+        default: 1
+      acceptance_test_jobs:
+        description: "Override ACCEPTANCE_TEST_JOBS (go test -p) for this run; empty leaves the justfile default in place"
+        type: string
+        default: ""
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge+.gen2
+    parallelism: <<parameters.parallelism>>
     steps:
       - run:
           name: Install eatmydata and disable fsync for all subprocesses
@@ -1944,6 +1953,9 @@ jobs:
           working_directory: op-acceptance-tests
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |
+            if [ -n "<<parameters.acceptance_test_jobs>>" ]; then
+              export ACCEPTANCE_TEST_JOBS="<<parameters.acceptance_test_jobs>>"
+            fi
             LOG_LEVEL=info just acceptance-test
       - run:
           name: Print results (summary)
@@ -2690,6 +2702,8 @@ workflows:
       # IN-MEMORY (all) - op-node/op-geth
       - op-acceptance-tests:
           name: memory-all-opn-op-geth
+          parallelism: 2
+          acceptance_test_jobs: "8"
           no_output_timeout: 120m
           context:
             - circleci-repo-readonly-authenticated-github-token
@@ -2704,6 +2718,8 @@ workflows:
       - op-acceptance-tests:
           name: memory-all-opn-op-reth
           l2_el_kind: op-reth
+          parallelism: 2
+          acceptance_test_jobs: "8"
           no_output_timeout: 120m
           context:
             - circleci-repo-readonly-authenticated-github-token
@@ -2719,6 +2735,8 @@ workflows:
           name: memory-all-kona-op-reth
           l2_cl_kind: kona-node
           l2_el_kind: op-reth
+          parallelism: 2
+          acceptance_test_jobs: "8"
           no_output_timeout: 120m
           context:
             - circleci-repo-readonly-authenticated-github-token

--- a/justfile
+++ b/justfile
@@ -283,7 +283,7 @@ _go-tests-ci-internal go_test_flags="": sync-superchain
       PARALLEL_PACKAGES=$(echo "$ALL_PACKAGES" | tr ' ' '\n' | awk -v idx="$NODE_INDEX" -v total="$NODE_TOTAL" 'NR % total == idx' | tr '\n' ' ')
       if [ -n "$PARALLEL_PACKAGES" ]; then
           echo "Node $NODE_INDEX/$NODE_TOTAL running packages: $PARALLEL_PACKAGES"
-          ./ops/scripts/gotestsum-split.sh --format=testname \
+          ./ops/scripts/gotestsum-split.sh --format=standard-verbose \
               --junitfile=./tmp/test-results/results-"$NODE_INDEX".xml \
               --jsonfile=./tmp/testlogs/log-"$NODE_INDEX".json \
               --rerun-fails=3 \
@@ -295,7 +295,7 @@ _go-tests-ci-internal go_test_flags="": sync-superchain
           exit 1
       fi
   else
-      ./ops/scripts/gotestsum-split.sh --format=testname \
+      ./ops/scripts/gotestsum-split.sh --format=standard-verbose \
           --junitfile=./tmp/test-results/results.xml \
           --jsonfile=./tmp/testlogs/log.json \
           --rerun-fails=3 \
@@ -328,7 +328,7 @@ go-tests-fraud-proofs-ci:
   source ./ops/scripts/source-ci-archive-rpcs.sh
   export NAT_INTEROP_LOADTEST_TARGET=10
   export NAT_INTEROP_LOADTEST_TIMEOUT=30s
-  ./ops/scripts/gotestsum-split.sh --format=testname \
+  ./ops/scripts/gotestsum-split.sh --format=standard-verbose \
       --junitfile=./tmp/test-results/results.xml \
       --jsonfile=./tmp/testlogs/log.json \
       --rerun-fails=3 \

--- a/justfile
+++ b/justfile
@@ -289,7 +289,7 @@ _go-tests-ci-internal go_test_flags="": sync-superchain
               --rerun-fails=3 \
               --rerun-fails-max-failures=50 \
               --packages="$PARALLEL_PACKAGES" \
-              -- -parallel="$PARALLEL" -coverprofile=coverage-"$NODE_INDEX".out {{go_test_flags}} -timeout={{TEST_TIMEOUT}} -tags="ci"
+              -- -p=4 -parallel="$PARALLEL" -coverprofile=coverage-"$NODE_INDEX".out {{go_test_flags}} -timeout={{TEST_TIMEOUT}} -tags="ci"
       else
           echo "ERROR: Node $NODE_INDEX/$NODE_TOTAL has no packages to run! Perhaps parallelism is set too high? (ALL_TEST_PACKAGES has $(echo "$ALL_PACKAGES" | wc -w) packages)"
           exit 1
@@ -301,7 +301,7 @@ _go-tests-ci-internal go_test_flags="": sync-superchain
           --rerun-fails=3 \
           --rerun-fails-max-failures=50 \
           --packages="$ALL_PACKAGES" \
-          -- -parallel="$PARALLEL" -coverprofile=coverage.out {{go_test_flags}} -timeout={{TEST_TIMEOUT}} -tags="ci"
+          -- -p=4 -parallel="$PARALLEL" -coverprofile=coverage.out {{go_test_flags}} -timeout={{TEST_TIMEOUT}} -tags="ci"
   fi
 
 # Runs short Go tests with gotestsum for CI.

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -73,15 +73,17 @@ acceptance-test:
         CPU_COUNT=1
     fi
 
-    # Cap concurrent test packages: each package spins a full devstack
-    # (L1 geth + op-node + op-reth/op-geth + batcher + proposer + challenger).
-    # Unbounded -p saturated CPU+RAM and caused mass "context deadline exceeded"
-    # failures across the runner. See ethereum-optimism/optimism#20966.
-    DEFAULT_JOBS=3
-    DEFAULT_TEST_PARALLEL="$(( CPU_COUNT / 2 ))"
-    if [[ "$DEFAULT_TEST_PARALLEL" -lt 1 ]]; then
-        DEFAULT_TEST_PARALLEL=1
-    fi
+    # Each acceptance test package spins a full devstack (L1 geth + op-node +
+    # op-reth/op-geth + batcher + proposer + challenger). Unbounded -p (defaulted
+    # to CPU_COUNT ~= 20) saturated CPU+RAM and caused mass "context deadline
+    # exceeded" failures across the runner — see ethereum-optimism/optimism#20966.
+    #
+    # Only ~13 of 177 acceptance tests use t.Parallel(), so -parallel is nearly
+    # a no-op and the total concurrency budget is dominated by -p. Bound them
+    # explicitly: max ~8 concurrent devstacks (well below the crash threshold)
+    # with intra-package parallelism kept low for the few tests that opt in.
+    DEFAULT_JOBS=8
+    DEFAULT_TEST_PARALLEL=2
 
     JOBS="${ACCEPTANCE_TEST_JOBS:-$DEFAULT_JOBS}"
     TEST_PARALLEL="${ACCEPTANCE_TEST_PARALLEL:-$DEFAULT_TEST_PARALLEL}"

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -73,17 +73,20 @@ acceptance-test:
         CPU_COUNT=1
     fi
 
-    # Each acceptance test package spins a full devstack (L1 geth + op-node +
-    # op-reth/op-geth + batcher + proposer + challenger). Unbounded -p (defaulted
-    # to CPU_COUNT ~= 20) saturated CPU+RAM and caused mass "context deadline
-    # exceeded" failures across the runner — see ethereum-optimism/optimism#20966.
+    # Each ParallelT acceptance test spins its own full devstack (L1 geth +
+    # op-node + op-reth/op-geth + batcher + proposer + challenger), so the real
+    # cost driver is concurrent ParallelT goroutines, bounded by -p * -parallel.
+    # The previous unbounded default (-p = CPU_COUNT ~= 20, -parallel = ~10)
+    # saturated CPU+RAM and triggered mass "context deadline exceeded" failures
+    # across the runner — see ethereum-optimism/optimism#20966.
     #
-    # Only ~13 of 177 acceptance tests use t.Parallel(), so -parallel is nearly
-    # a no-op and the total concurrency budget is dominated by -p. Bound them
-    # explicitly: max ~8 concurrent devstacks (well below the crash threshold)
-    # with intra-package parallelism kept low for the few tests that opt in.
-    DEFAULT_JOBS=8
-    DEFAULT_TEST_PARALLEL=2
+    # Collapse to a single concurrency axis: -parallel=1 disables intra-package
+    # parallelism so each package binary runs one test at a time, and -p directly
+    # caps concurrent test devstacks across the runner. 12 is well under the
+    # observed ~30-effective-devstack crash threshold and lands wall time near
+    # the pre-cap baseline.
+    DEFAULT_JOBS=12
+    DEFAULT_TEST_PARALLEL=1
 
     JOBS="${ACCEPTANCE_TEST_JOBS:-$DEFAULT_JOBS}"
     TEST_PARALLEL="${ACCEPTANCE_TEST_PARALLEL:-$DEFAULT_TEST_PARALLEL}"

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -73,7 +73,11 @@ acceptance-test:
         CPU_COUNT=1
     fi
 
-    DEFAULT_JOBS="$CPU_COUNT"
+    # Cap concurrent test packages: each package spins a full devstack
+    # (L1 geth + op-node + op-reth/op-geth + batcher + proposer + challenger).
+    # Unbounded -p saturated CPU+RAM and caused mass "context deadline exceeded"
+    # failures across the runner. See ethereum-optimism/optimism#20966.
+    DEFAULT_JOBS=3
     DEFAULT_TEST_PARALLEL="$(( CPU_COUNT / 2 ))"
     if [[ "$DEFAULT_TEST_PARALLEL" -lt 1 ]]; then
         DEFAULT_TEST_PARALLEL=1

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -118,16 +118,53 @@ acceptance-test:
 
     TEST_PACKAGES=("./op-acceptance-tests/tests/...")
 
+    # CircleCI test-level splitting: when running under `parallelism: N > 1`,
+    # split the test set across CIRCLE_NODE_TOTAL nodes using historical timings
+    # so each node runs a balanced subset. Falls back to running everything when
+    # CIRCLE_NODE_TOTAL is unset (local runs, single-node CI).
+    RUN_FLAG=""
+    JUNIT_FILE="$RESULTS_DIR/results.xml"
+    JSON_FILE="$LOG_DIR/raw_go_events.log"
+    if [ -n "${CIRCLE_NODE_TOTAL:-}" ] && [ "$CIRCLE_NODE_TOTAL" -gt 1 ]; then
+        NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
+        NODE_TOTAL=${CIRCLE_NODE_TOTAL:-1}
+
+        go test -list '^Test' "${TEST_PACKAGES[@]}" 2>/dev/null | grep -E '^Test' > /tmp/tests.txt
+
+        TOTAL_TESTS=$(wc -l < /tmp/tests.txt | tr -d ' ')
+        if [ "$TOTAL_TESTS" -eq 0 ]; then
+            echo "ERROR: no tests found in packages: ${TEST_PACKAGES[*]}"
+            exit 1
+        fi
+        echo "Found $TOTAL_TESTS tests to split across $NODE_TOTAL nodes"
+
+        circleci tests split --split-by=timings --timings-type=testname /tmp/tests.txt > /tmp/tests_shard.txt
+
+        SHARD_COUNT=$(wc -l < /tmp/tests_shard.txt | tr -d ' ')
+        echo "Node $NODE_INDEX/$NODE_TOTAL running $SHARD_COUNT tests:"
+        cat /tmp/tests_shard.txt
+
+        if [ "$SHARD_COUNT" -eq 0 ]; then
+            echo "No tests assigned to this node, skipping."
+            exit 0
+        fi
+
+        RUN_FLAG="-run=^($(paste -sd '|' /tmp/tests_shard.txt))$"
+        JUNIT_FILE="$RESULTS_DIR/results-${NODE_INDEX}.xml"
+        JSON_FILE="$LOG_DIR/raw_go_events-${NODE_INDEX}.log"
+    fi
+
     set +e
     LOG_LEVEL="${LOG_LEVEL}" {{REPO_ROOT}}/ops/scripts/gotestsum-split.sh \
         --format testname \
-        --junitfile "$RESULTS_DIR/results.xml" \
-        --jsonfile "$LOG_DIR/raw_go_events.log" \
+        --junitfile "$JUNIT_FILE" \
+        --jsonfile "$JSON_FILE" \
         -- \
         -count=1 \
         -p "${JOBS}" \
         -parallel "${TEST_PARALLEL}" \
         -timeout "${TEST_TIMEOUT}" \
+        ${RUN_FLAG:+"$RUN_FLAG"} \
         "${TEST_PACKAGES[@]}" \
         2>&1 | tee "$LOG_DIR/all.log"
     TEST_STATUS=${PIPESTATUS[0]}


### PR DESCRIPTION
Bundle of fixes aimed at the elevated flake rate currently blocking merges (ethereum-optimism/optimism#20966 and the recent wave of mass `context deadline exceeded` failures on `memory-all-*` jobs, e.g. job 5097460 with 24 simultaneous failures and 100% CPU/RAM on the resources tab).

1. **Switch gotestsum to `--format=standard-verbose`** on `go-tests-{short,full,fraud-proofs}` so each test's `=== RUN` / `--- PASS` events stream to the CircleCI log as they happen. With `testname` formatting, the streamed log truncated at the same buffered package boundary every time, so we never saw which test was running when the runner died. Standard-verbose makes the in-flight test visible even when no artifacts are produced (which is exactly what happens when the runner agent itself dies — `store_artifacts` never runs). Log volume stays well under CircleCI's 4MB-per-step cap.

2. **Bound `go test` concurrency on heavy shards** so the runner doesn't get saturated by concurrent devstacks.

   - **`go-tests-{short,full,fraud-proofs}`**: add `-p=4`. Previously unbounded (defaulted to GOMAXPROCS = 16–20), so all heavy `op-e2e/system/*` packages on a single shard could run simultaneously. Intra-package `t.Parallel()` is rare in these suites, so `-parallel` is left at the existing `PARALLEL=12` env override.
   - **`op-acceptance-tests`**: each ParallelT test (`op-devstack/devtest/testing.go:409`) spins its own full devstack, and ~83% of acceptance tests are ParallelT (127/153 non-helper test funcs). Collapse to a single concurrency axis by setting `-parallel=1` (disable intra-package parallelism) and `-p=12` directly. 12 is well below the observed ~30-effective-devstack crash threshold.

3. **Shard the memory-all matrix across 2 runners** to recover wall time and cut per-box devstack pressure. Restores the test-level splitting from ethereum-optimism/optimism#19832: enumerate tests with `go test -list`, split via `circleci tests split --split-by=timings`, run the assigned subset via `-run`. Each sharded job uses `-p=8` per shard (down from 12 single-box), so per-box concurrent devstacks drop from 12 → 8 while wall time drops below the pre-cap baseline. Local runs and any single-node caller are unaffected because the recipe falls back to running everything when `CIRCLE_NODE_TOTAL` is unset.

### Runtime comparison

`go-tests-full` doesn't run on PRs, so its post-change data will land when this merges.

| Job | Develop baseline (median) | Single-box `-p=12 -parallel=1` | **Final: 2-way shard `-p=8 -parallel=1`** | Δ vs baseline |
|---|---:|---:|---:|---:|
| `go-tests-short` (`-p=4`) | 392s (6m32s)¹ | 386s (6m26s) | **388s (6m28s)** | ~0% |
| `memory-all-opn-op-geth` | 1243s (20m43s) | 1372s (22m52s) | **1041s (17m21s)** | **−16%** ✅ |
| `memory-all-opn-op-reth` | 1270s (21m10s) | 1465s (24m25s) (1 pre-existing flake) | **1151s (19m11s)** | **−9%** ✅ |
| `memory-all-kona-op-reth` | 1243s (20m43s) | 1380s (23m00s) | **1055s (17m35s)** | **−15%** ✅ |

All three sharded memory-all variants finished below the pre-cap develop baseline while also halving per-box concurrent devstack pressure (~20 unbounded → 8 capped).

¹ `go-tests-short` doesn't run on develop's `main` workflow; baseline taken from this PR's pre-cap run (job 5097444).