### PR TITLE
feat(op-supernode): add top-level --dependency-set flag

### DIFF
--- a/op-supernode/cmd/depset.go
+++ b/op-supernode/cmd/depset.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/config"
+)
+
+// applySupernodeDependencySet loads the supernode-level dependency set (if a
+// path is configured) and assigns it to every virtual node config, replacing
+// any value previously derived from per-VN flags or the registry fallback.
+// The dependency set is a global property of the supernode and must be the
+// same for all chains it manages.
+func applySupernodeDependencySet(cfg *config.CLIConfig, vnCfgs map[eth.ChainID]*opnodecfg.Config) error {
+	if cfg.DependencySetPath == "" {
+		return nil
+	}
+	loader := &depset.JSONDependencySetLoader{Path: cfg.DependencySetPath}
+	ds, err := loader.LoadDependencySet()
+	if err != nil {
+		return fmt.Errorf("failed to load supernode dependency set %q: %w", cfg.DependencySetPath, err)
+	}
+	for _, vnCfg := range vnCfgs {
+		vnCfg.DependencySet = ds
+	}
+	return nil
+}

--- a/op-supernode/cmd/depset_test.go
+++ b/op-supernode/cmd/depset_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplySupernodeDependencySet_NoPath_LeavesVnCfgsUntouched(t *testing.T) {
+	vnCfgs := map[eth.ChainID]*opnodecfg.Config{
+		eth.ChainIDFromUInt64(10): {},
+		eth.ChainIDFromUInt64(20): {},
+	}
+	require.NoError(t, applySupernodeDependencySet(&config.CLIConfig{}, vnCfgs))
+	for _, vn := range vnCfgs {
+		require.Nil(t, vn.DependencySet)
+	}
+}
+
+func TestApplySupernodeDependencySet_LoadsAndAppliesToAllChains(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "depset.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"dependencies":{"4242":{}}}`), 0o600))
+
+	vnCfgs := map[eth.ChainID]*opnodecfg.Config{
+		eth.ChainIDFromUInt64(10): {},
+		eth.ChainIDFromUInt64(20): {},
+	}
+
+	require.NoError(t, applySupernodeDependencySet(&config.CLIConfig{DependencySetPath: path}, vnCfgs))
+
+	for chainID, vn := range vnCfgs {
+		require.NotNilf(t, vn.DependencySet, "chain %s missing depset", chainID)
+		require.True(t, vn.DependencySet.HasChain(eth.ChainIDFromUInt64(4242)),
+			"depset for chain %s does not contain the loaded chain", chainID)
+	}
+}
+
+func TestApplySupernodeDependencySet_FileMissing_ReturnsError(t *testing.T) {
+	vnCfgs := map[eth.ChainID]*opnodecfg.Config{
+		eth.ChainIDFromUInt64(10): {},
+	}
+	err := applySupernodeDependencySet(&config.CLIConfig{DependencySetPath: "/no/such/file.json"}, vnCfgs)
+	require.Error(t, err)
+}

--- a/op-supernode/cmd/main.go
+++ b/op-supernode/cmd/main.go
@@ -138,6 +138,9 @@ func createVirtualNodeConfigs(cliCtx *cli.Context, cfg *config.CLIConfig, l log.
 		}
 		vnCfgs[eth.ChainIDFromUInt64(chainID)] = cfg
 	}
+	if err := applySupernodeDependencySet(cfg, vnCfgs); err != nil {
+		return nil, err
+	}
 	return vnCfgs, nil
 }
 

--- a/op-supernode/config/config.go
+++ b/op-supernode/config/config.go
@@ -29,6 +29,9 @@ type CLIConfig struct {
 	// InteropLogBackfillDepth is the duration (e.g. 168h) to extend initiating-message log ingestion
 	// backward from the tip before interop message validation runs. Set to zero to disable.
 	InteropLogBackfillDepth time.Duration
+	// DependencySetPath is the path to a JSON dependency-set file shared by every chain
+	// managed by the supernode. Empty means fall back to per-chain registry lookup.
+	DependencySetPath string
 }
 
 func (c *CLIConfig) Check() error {
@@ -73,6 +76,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		PprofConfig:             oppprof.ReadCLIConfig(ctx),
 		RawCtx:                  ctx,
 		InteropLogBackfillDepth: ctx.Duration("interop.log-backfill-depth"),
+		DependencySetPath:       ctx.Path(flags.DependencySet.Name),
 	}
 	if ctx.IsSet("interop.activation-timestamp") {
 		ts := ctx.Uint64("interop.activation-timestamp")

--- a/op-supernode/flags/flags.go
+++ b/op-supernode/flags/flags.go
@@ -68,6 +68,12 @@ var (
 		Value:    false,
 		Required: false,
 	}
+	DependencySet = &cli.PathFlag{
+		Name:      "dependency-set",
+		Usage:     "Dependency-set configuration shared by all chains, point at JSON file. Overrides the registry fallback and any per-VN interop.dependency-set flag.",
+		EnvVars:   prefixEnvVars("DEPENDENCY_SET"),
+		TakesFile: true,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -78,6 +84,7 @@ var requiredFlags = []cli.Flag{
 var optionalFlags = []cli.Flag{
 	L1HTTPPollInterval,
 	DisableP2P,
+	DependencySet,
 }
 
 // activityFlags holds flags registered by activity packages via RegisterActivityFlags.
@@ -111,7 +118,8 @@ var Flags []cli.Flag
 //
 // Extend this list when new shared resources are added to the supernode.
 var SupernodeOwnedFlags = []string{
-	opnodeflags.L1HTTPPollInterval.Name, // "l1.http-poll-interval"
+	opnodeflags.L1HTTPPollInterval.Name,   // "l1.http-poll-interval"
+	opnodeflags.InteropDependencySet.Name, // "interop.dependency-set"
 }
 
 func CheckRequired(ctx *cli.Context) error {


### PR DESCRIPTION
The dependency set is a global property shared by every chain a supernode manages, but it was previously only reachable via the per-VN `--interop.dependency-set` flag inherited from op-node. Add a supernode-level `--dependency-set` flag (env `OP_SUPERNODE_DEPENDENCY_SET`), load it once, and override each virtual node config's `DependencySet`. The per-VN flag is added to `SupernodeOwnedFlags` so setting it logs a warning.

Closes ethereum-optimism/protocol-team#96