### PR TITLE
op-node: increase syncmode.offset-el-safe default to 1 week

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -134,11 +134,11 @@ var (
 	SyncModeOffsetELSafeFlag = &cli.DurationFlag{
 		Name: "syncmode.offset-el-safe",
 		Usage: "After execution-layer sync completes, set safe and finalized heads to this duration behind the synced tip " +
-			"(converted to L2 blocks via rollup block time using ceiling division). Default 0 (safe/finalized stay at the tip). " +
+			"(converted to L2 blocks via rollup block time using ceiling division). Default 168h (7d). " +
 			"Set to e.g. 168h to force derivation of the most recent 7 days of blocks before they are considered safe.",
 		EnvVars:  prefixEnvVars("SYNCMODE_OFFSET_EL_SAFE"),
 		Category: RollupCategory,
-		Value:    0,
+		Value:    168 * time.Hour,
 	}
 	RPCAdminPersistence = &cli.StringFlag{
 		Name:     "rpc.admin-state",

--- a/op-node/rollup/sync/config.go
+++ b/op-node/rollup/sync/config.go
@@ -92,9 +92,6 @@ func (c *Config) Check() error {
 	if c.OffsetELSafe < 0 {
 		return errors.New("sync.offset-el-safe must be >= 0")
 	}
-	if c.OffsetELSafe > 0 && c.SyncMode != ELSync {
-		return fmt.Errorf("sync.offset-el-safe is only supported with EL sync (syncmode=%s)", ELSyncString)
-	}
 	return nil
 }
 

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -347,6 +347,7 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 		return nil, err
 	}
 	engineKind := engine.Kind(ctx.String(flags.L2EngineKind.Name))
+	offsetELSafe := ctx.Duration(flags.SyncModeOffsetELSafeFlag.Name)
 	cfg := &sync.Config{
 		SyncMode:                       mode,
 		SyncModeReqResp:                ctx.Bool(flags.SyncModeReqRespFlag.Name),
@@ -355,10 +356,14 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 		L2FollowSourceEndpoint:         l2FollowSourceEndpoint,
 		// Sequencer needs a manual initial reset when follow source
 		NeedInitialResetEngine: ctx.Bool(flags.SequencerEnabledFlag.Name) && l2FollowSourceEndpoint != "",
-		OffsetELSafe:           ctx.Duration(flags.SyncModeOffsetELSafeFlag.Name),
+		OffsetELSafe:           offsetELSafe,
 	}
 	if ctx.Bool(flags.L2EngineSyncEnabled.Name) {
 		cfg.SyncMode = sync.ELSync
+	}
+	if cfg.OffsetELSafe > 0 && cfg.SyncMode != sync.ELSync {
+		log.Warn("syncmode.offset-el-safe is ineffective unless --syncmode=execution-layer; ignoring configured value", "syncmode", cfg.SyncMode.String(), "configured_offset", cfg.OffsetELSafe)
+		cfg.OffsetELSafe = 0
 	}
 	if err := cfg.Check(); err != nil {
 		return nil, err


### PR DESCRIPTION
Activates this mechanism https://github.com/ethereum-optimism/optimism/pull/19972 via a nonzero default. 