### PR TITLE
chore(docker): switch kona runtime base for smaller runtime

### DIFF
--- a/rust/kona/docker/apps/kona_app_generic.dockerfile
+++ b/rust/kona/docker/apps/kona_app_generic.dockerfile
@@ -90,8 +90,7 @@ COPY --from=app-setup /workspace .
 RUN RUSTFLAGS="-C target-cpu=generic" cargo auditable build --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}"
 
 # Export stage
-FROM ubuntu:22.04 AS export-stage
-SHELL ["/bin/bash", "-c"]
+FROM chainguard/wolfi-base:latest AS export-stage
 
 ARG BIN_TARGET
 ARG BUILD_PROFILE
@@ -100,11 +99,15 @@ ARG BUILD_PROFILE
 ARG UID=10001
 ARG GID=10001
 
-# Install ca-certificates and libssl-dev for TLS support.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install ca-certificates, openssl, libstdc++ for TLS + C++ runtime support.
+RUN apk add --no-cache \
   ca-certificates \
-  libssl-dev \
-  && rm -rf /var/lib/apt/lists/*
+  openssl \
+  libstdc++ \
+  bash \
+  shadow
+
+RUN update-ca-certificates
 
 # Create non-root runtime user
 RUN groupadd --gid ${GID} app \


### PR DESCRIPTION
Switch the kona runtime base image to `chainguard/wolfi-base:latest` for a smaller, more minimal runtime layer.

- Replaces `ubuntu:22.04` with `chainguard/wolfi-base:latest` in the export stage of `kona_app_generic.dockerfile`.
- Drops `apt-get`/`libssl-dev` install in favor of `apk add --no-cache ca-certificates openssl libstdc++ bash shadow`.
- Runs `update-ca-certificates` at build time so `/etc/ssl/certs` keeps the per-certificate pem + hash-link layout that the previous ubuntu base provided.

Non-root user setup (UID/GID 10001) is preserved.
