### PR TITLE
chore(docker): switch op-reth runtime base for smaller runtime

### DIFF
--- a/rust/op-reth/DockerfileOp
+++ b/rust/op-reth/DockerfileOp
@@ -35,11 +35,9 @@ RUN cargo auditable build --profile $BUILD_PROFILE --features "$FEATURES" --bin 
 RUN ls -la /app/target/$BUILD_PROFILE/op-reth
 RUN cp /app/target/$BUILD_PROFILE/op-reth /app/op-reth
 
-FROM ubuntu AS runtime
+FROM chainguard/wolfi-base:latest AS runtime
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates libssl-dev pkg-config strace && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates openssl libstdc++ strace
 
 WORKDIR /app
 COPY --from=builder /app/op-reth /usr/local/bin/


### PR DESCRIPTION
Switch the op-reth runtime base image to `chainguard/wolfi-base:latest` for a smaller, more minimal runtime layer.

- Replaces `ubuntu` with `chainguard/wolfi-base:latest` in the runtime stage of `rust/op-reth/DockerfileOp`.
- Drops `apt-get`/`libssl-dev` install in favor of `apk add --no-cache ca-certificates openssl libstdc++ strace`.
