### PR TITLE
op-reth: spawn payload service on Tokio task to avoid teardown

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11444,6 +11444,7 @@ dependencies = [
  "op-alloy-network",
  "op-alloy-rpc-types-engine",
  "op-revm",
+ "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-consensus",
  "reth-db",

--- a/rust/op-reth/crates/node/Cargo.toml
+++ b/rust/op-reth/crates/node/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 reth-chainspec.workspace = true
 ## ensure secp256k1 recovery with rayon support is activated
 reth-primitives-traits = { workspace = true, features = ["secp256k1", "rayon"] }
+reth-basic-payload-builder.workspace = true
 reth-payload-builder.workspace = true
 reth-consensus.workspace = true
 reth-node-api.workspace = true

--- a/rust/op-reth/crates/node/src/lib.rs
+++ b/rust/op-reth/crates/node/src/lib.rs
@@ -25,6 +25,9 @@ pub use engine::OpEngineTypes;
 pub mod node;
 pub use node::*;
 
+pub mod payload_service;
+pub use payload_service::OpPayloadServiceBuilder;
+
 pub mod rpc;
 pub use rpc::OpEngineApiBuilder;
 

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -4,6 +4,7 @@ use crate::{
     OpEngineApiBuilder, OpEngineTypes,
     args::RollupArgs,
     engine::OpEngineValidator,
+    payload_service::OpPayloadServiceBuilder,
     txpool::{OpTransactionPool, OpTransactionValidator},
 };
 use alloy_primitives::Sealed;
@@ -23,9 +24,8 @@ use reth_node_api::{
 use reth_node_builder::{
     BuilderContext, DebugNode, Node, NodeAdapter, NodeComponentsBuilder,
     components::{
-        BasicPayloadServiceBuilder, ComponentsBuilder, ConsensusBuilder, ExecutorBuilder,
-        NetworkBuilder, PayloadBuilderBuilder, PoolBuilder, PoolBuilderConfigOverrides,
-        TxPoolBuilder,
+        ComponentsBuilder, ConsensusBuilder, ExecutorBuilder, NetworkBuilder,
+        PayloadBuilderBuilder, PoolBuilder, PoolBuilderConfigOverrides, TxPoolBuilder,
     },
     node::{FullNodeTypes, NodeTypes},
     rpc::{
@@ -199,7 +199,7 @@ pub struct OpNode {
 pub type OpNodeComponentBuilder<Node, Payload = OpPayloadBuilder> = ComponentsBuilder<
     Node,
     OpPoolBuilder,
-    BasicPayloadServiceBuilder<Payload>,
+    OpPayloadServiceBuilder<Payload>,
     OpNetworkBuilder,
     OpExecutorBuilder,
     OpConsensusBuilder,
@@ -245,7 +245,7 @@ impl OpNode {
                         self.args.supervisor_safety_level,
                     ),
             )
-            .payload(BasicPayloadServiceBuilder::new(
+            .payload(OpPayloadServiceBuilder::new(
                 OpPayloadBuilder::new(compute_pending_block)
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone())
@@ -317,7 +317,7 @@ where
     type ComponentsBuilder = ComponentsBuilder<
         N,
         OpPoolBuilder,
-        BasicPayloadServiceBuilder<OpPayloadBuilder>,
+        OpPayloadServiceBuilder<OpPayloadBuilder>,
         OpNetworkBuilder,
         OpExecutorBuilder,
         OpConsensusBuilder,

--- a/rust/op-reth/crates/node/src/payload_service.rs
+++ b/rust/op-reth/crates/node/src/payload_service.rs
@@ -1,0 +1,84 @@
+//! Op-reth payload service builder.
+//!
+//! Mirrors upstream
+//! [`reth_node_builder::components::BasicPayloadServiceBuilder`] but spawns
+//! the [`PayloadBuilderService`] via [`spawn_critical_task`] (a managed Tokio
+//! task) rather than [`spawn_critical_os_thread`] (a raw OS thread parked in
+//! `handle.block_on`).
+//!
+//! Upstream paradigmxyz/reth#24038 switched the payload builder to a named
+//! OS thread, but `spawn_critical_os_thread` returns a `std::thread::JoinHandle`
+//! that the upstream builder discards, and `reth_tasks::RuntimeInner` does not
+//! track those handles or join them on drop. The OS thread can therefore
+//! outlive its owning Tokio runtime and touch Tokio internals during teardown,
+//! which manifests as a SIGSEGV in `peers_negotiate_eth_69` (issue #20973).
+//!
+//! Until upstream manages OS-thread lifecycles, op-reth keeps the payload
+//! service on the Tokio runtime via this builder.
+//!
+//! [`spawn_critical_task`]: reth_tasks::TaskExecutor::spawn_critical_task
+//! [`spawn_critical_os_thread`]: reth_tasks::TaskExecutor::spawn_critical_os_thread
+
+use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
+use reth_node_builder::{
+    BuilderContext,
+    components::{PayloadBuilderBuilder, PayloadServiceBuilder},
+    node::{FullNodeTypes, NodeTypes},
+};
+use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
+use reth_provider::CanonStateSubscriptions;
+use reth_transaction_pool::TransactionPool;
+
+/// Op-reth replacement for
+/// [`reth_node_builder::components::BasicPayloadServiceBuilder`] that spawns
+/// the payload service as a Tokio task.
+#[derive(Debug, Default, Clone)]
+pub struct OpPayloadServiceBuilder<PB>(PB);
+
+impl<PB> OpPayloadServiceBuilder<PB> {
+    /// Wrap `payload_builder_builder` in a new [`OpPayloadServiceBuilder`].
+    pub const fn new(payload_builder_builder: PB) -> Self {
+        Self(payload_builder_builder)
+    }
+}
+
+impl<Node, Pool, PB, EvmConfig> PayloadServiceBuilder<Node, Pool, EvmConfig>
+    for OpPayloadServiceBuilder<PB>
+where
+    Node: FullNodeTypes,
+    Pool: TransactionPool,
+    EvmConfig: Send,
+    PB: PayloadBuilderBuilder<Node, Pool, EvmConfig>,
+{
+    async fn spawn_payload_builder_service(
+        self,
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+        evm_config: EvmConfig,
+    ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
+        let payload_builder = self.0.build_payload_builder(ctx, pool, evm_config).await?;
+
+        let conf = ctx.config().builder.clone();
+
+        let payload_job_config = BasicPayloadJobGeneratorConfig::default()
+            .interval(conf.interval)
+            .deadline(conf.deadline)
+            .max_payload_tasks(conf.max_payload_tasks);
+
+        let payload_generator = BasicPayloadJobGenerator::with_builder(
+            ctx.provider().clone(),
+            ctx.task_executor().clone(),
+            payload_job_config,
+            payload_builder,
+        );
+        let (payload_service, payload_service_handle) =
+            PayloadBuilderService::<_, _, <Node::Types as NodeTypes>::Payload>::new(
+                payload_generator,
+                ctx.provider().canonical_state_stream(),
+            );
+
+        ctx.task_executor().spawn_critical_task("payload builder service", payload_service);
+
+        Ok(payload_service_handle)
+    }
+}

--- a/rust/op-reth/crates/node/tests/it/priority.rs
+++ b/rust/op-reth/crates/node/tests/it/priority.rs
@@ -11,13 +11,12 @@ use reth_e2e_test_utils::{
 };
 use reth_node_api::FullNodeTypes;
 use reth_node_builder::{
-    EngineNodeLauncher, Node, NodeBuilder, NodeConfig,
-    components::{BasicPayloadServiceBuilder, ComponentsBuilder},
+    EngineNodeLauncher, Node, NodeBuilder, NodeConfig, components::ComponentsBuilder,
 };
 use reth_node_core::args::DatadirArgs;
 use reth_optimism_chainspec::OpChainSpecBuilder;
 use reth_optimism_node::{
-    OpNode,
+    OpNode, OpPayloadServiceBuilder,
     args::RollupArgs,
     node::{
         OpConsensusBuilder, OpExecutorBuilder, OpNetworkBuilder, OpNodeComponentBuilder,
@@ -98,7 +97,7 @@ where
         .node_types::<Node>()
         .pool(OpPoolBuilder::default())
         .executor(OpExecutorBuilder::default())
-        .payload(BasicPayloadServiceBuilder::new(
+        .payload(OpPayloadServiceBuilder::new(
             OpPayloadBuilder::new(compute_pending_block)
                 .with_transactions(CustomTxPriority { chain_id }),
         ))


### PR DESCRIPTION
Adds OpPayloadServiceBuilder, a local replacement for upstream's BasicPayloadServiceBuilder that spawns the PayloadBuilderService via TaskExecutor::spawn_critical_task instead of spawn_critical_os_thread, and routes OpNode's component builder through it.

Upstream paradigmxyz/reth#24038 switched the payload builder to a named OS thread. spawn_critical_os_thread returns a std::thread::JoinHandle that the upstream builder discards, and reth_tasks::RuntimeInner does not track or join those handles before the Tokio runtime is dropped, so the OS thread can outlive its owning runtime and touch Tokio internals during teardown. On Linux this manifests as a SIGSEGV in peers_negotiate_eth_69. Until upstream manages OS-thread lifecycles, op-reth keeps the payload service on the Tokio runtime.

Also adds an integration test (orphan_payload_builder_thread.rs) with a structural reproducer of the upstream pattern and a stress loop that serves as a regression marker against reintroducing BasicPayloadServiceBuilder at op-reth callsites.

Full reproduction effort at: https://gist.github.com/nonsense/5ca1bd87a206e14e15839a70663bcf83