### PR TITLE
fix(ctb): increase cost of l2ProxyAdmin.upgradeExecution()

### DIFF
--- a/packages/contracts-bedrock/scripts/libraries/UpgradeUtils.sol
+++ b/packages/contracts-bedrock/scripts/libraries/UpgradeUtils.sol
@@ -33,7 +33,7 @@ library UpgradeUtils {
     /// @dev Calibration: see `_buildImplementationDeploymentConfigs` in GenerateNUTBundle.s.sol.
     /// @return Gas limits struct.
     function gasLimits() internal pure returns (GasLimits memory) {
-        return GasLimits({ l2cmDeployment: 8_700_000, upgradeExecution: 3_500_000 });
+        return GasLimits({ l2cmDeployment: 8_700_000, upgradeExecution: 3_700_000 });
     }
 
     /// @notice Computes the intrinsic gas cost for a NUT bundle transaction.

--- a/packages/contracts-bedrock/snapshots/upgrades/current-upgrade-bundle.json
+++ b/packages/contracts-bedrock/snapshots/upgrades/current-upgrade-bundle.json
@@ -195,7 +195,7 @@
     {
       "data": "0x7c36f37e0000000000000000000000000bd19461a312b27816bd479dbc92eb04600275f1",
       "from": "0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001",
-      "gasLimit": 3500000,
+      "gasLimit": 3700000,
       "intent": "L2ProxyAdmin Upgrade Predeploys",
       "to": "0x4200000000000000000000000000000000000018"
     }


### PR DESCRIPTION
**Description**

Fixes this CI failure with a bit of buffer on top: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/126088/workflows/bc59c603-2634-46fc-945f-82a319e9672d/jobs/5103776