### PR TITLE
docs: fix duplicate 'in' typo in interop-prep notice

### DIFF
--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -19,7 +19,7 @@ audit-source:
   - op-node/rollup/interop/config.go
 ---
 
-OP Stack interop is expected to activate on **OP Sepolia** (chain ID `11155420`) and **Unichain Sepolia** (chain ID `1301`) in in **July of 2026**, forming a two-chain interop dependency set on testnet.
+OP Stack interop is expected to activate on **OP Sepolia** (chain ID `11155420`) and **Unichain Sepolia** (chain ID `1301`) in **July of 2026**, forming a two-chain interop dependency set on testnet.
 Node operators on either chain must change their topology before the activation timestamp: each operator runs one or more [op-supernode](/op-stack/interop/supernode) instances that derive both chains and validate the cross-chain messages between them, and the rest of the fleet runs as [Light CLs](/notices/specialized-node-topology) that follow the supernode.
 
 <Warning>


### PR DESCRIPTION
## Summary
- Fixes a small typo in `docs/public-docs/notices/interop-prep.mdx` — the first sentence read "in in **July of 2026**". Removed the duplicated "in".

Renders at https://docs.optimism.io/notices/interop-prep.

## Test plan
- [x] No-op text change; visually verified the sentence reads correctly.