### PR TITLE
[codex] Keep EL sync targets out of unsafe head

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -681,6 +681,9 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 	if !e.isEngineInitialELSyncing() {
 		fc.FinalizedBlockHash = e.FinalizedHead().Hash
 	}
+	elSyncFinalizing := false
+	var safeRef eth.L2BlockRef
+	var finalizedRef eth.L2BlockRef
 	if e.syncStatus == syncStatusFinishedELButNotFinalized {
 		offsetRef := ref
 		if target := sync.OffsetBlockNum(e.syncCfg.OffsetELSafe, e.rollupCfg.BlockTime, ref.Number, e.rollupCfg.Genesis.L2.Number); target < ref.Number {
@@ -693,22 +696,17 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 		// With SupportsPostFinalizationELSync, EL sync can start even when
 		// there is already a finalized head. Never retract finalized or safe
 		// behind their prior values.
-		finalizedRef := offsetRef
+		finalizedRef = offsetRef
 		if finalizedRef.Number < e.FinalizedHead().Number {
 			finalizedRef = e.FinalizedHead()
 		}
-		safeRef := offsetRef
+		safeRef = offsetRef
 		if safeRef.Number < e.SafeL2Head().Number {
 			safeRef = e.SafeL2Head()
 		}
 		fc.SafeBlockHash = safeRef.Hash
 		fc.FinalizedBlockHash = finalizedRef.Hash
-		e.SetUnsafeHead(ref)
-		e.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
-		e.SetLocalSafeHead(safeRef)
-		e.SetDeprecatedSafeHead(safeRef)
-		e.onSafeUpdate(ctx, safeRef, safeRef)
-		e.SetFinalizedHead(finalizedRef)
+		elSyncFinalizing = true
 	}
 	logFn := e.logSyncProgressMaybe()
 	defer logFn()
@@ -734,9 +732,23 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 			payload.ID(), payload.ParentID(), eth.ForkchoiceUpdateErr(fcRes.PayloadStatus)))
 	}
 	fcu2Finish := time.Now()
+	if e.syncCfg.SyncMode == sync.ELSync && fcRes.PayloadStatus.Status != eth.ExecutionValid {
+		if elSyncFinalizing {
+			e.syncStatus = syncStatusStartedEL
+		}
+		e.log.Info("EL sync payload accepted as sync target, but not promoted to unsafe head",
+			"ref", ref, "status", fcRes.PayloadStatus.Status)
+		return nil
+	}
 	e.SetUnsafeHead(ref)
 	e.lastForkchoice = fc
 	e.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
+	if elSyncFinalizing {
+		e.SetLocalSafeHead(safeRef)
+		e.SetDeprecatedSafeHead(safeRef)
+		e.onSafeUpdate(ctx, safeRef, safeRef)
+		e.SetFinalizedHead(finalizedRef)
+	}
 
 	if e.syncStatus == syncStatusFinishedELButNotFinalized {
 		e.log.Info("Finished EL sync", "sync_duration", e.clock.Since(e.elStart),

--- a/op-node/rollup/engine/engine_el_sync_offset_test.go
+++ b/op-node/rollup/engine/engine_el_sync_offset_test.go
@@ -162,3 +162,50 @@ func TestInsertUnsafePayload_ELSync_offsetDerived(t *testing.T) {
 		})
 	}
 }
+
+func TestInsertUnsafePayload_ELSyncSyncingDoesNotPromoteUnsafe(t *testing.T) {
+	cfg, refA0, _, _, refA3, payload := buildELSyncTipChain(t)
+
+	mockEngine := &testutils.MockEngine{}
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, refA0, nil)
+	mockEngine.ExpectNewPayload(payload.ExecutionPayload, nil, &eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, nil)
+	mockEngine.ExpectForkchoiceUpdate(&eth.ForkchoiceState{
+		HeadBlockHash: refA3.Hash,
+		SafeBlockHash: common.Hash{},
+	}, nil, &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}}, nil)
+
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg,
+		&sync.Config{SyncMode: sync.ELSync}, &testutils.MockL1Source{}, discardEmitter{}, nil)
+	ec.SyncDeriver = noopSyncDeriver{}
+
+	err := ec.InsertUnsafePayload(context.Background(), payload, refA3)
+	require.NoError(t, err)
+	require.Equal(t, eth.L2BlockRef{}, ec.unsafeHead)
+	require.Equal(t, eth.L2BlockRef{}, ec.localSafeHead)
+	require.Equal(t, eth.L2BlockRef{}, ec.FinalizedHead())
+	mockEngine.AssertExpectations(t)
+}
+
+func TestInsertUnsafePayload_ELSyncValidNewPayloadSyncingFCUDoesNotPromoteUnsafe(t *testing.T) {
+	cfg, refA0, _, _, refA3, payload := buildELSyncTipChain(t)
+
+	mockEngine := &testutils.MockEngine{}
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, refA0, nil)
+	mockEngine.ExpectNewPayload(payload.ExecutionPayload, nil, &eth.PayloadStatusV1{Status: eth.ExecutionValid}, nil)
+	mockEngine.ExpectForkchoiceUpdate(&eth.ForkchoiceState{
+		HeadBlockHash:      refA3.Hash,
+		SafeBlockHash:      refA3.Hash,
+		FinalizedBlockHash: refA3.Hash,
+	}, nil, &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}}, nil)
+
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg,
+		&sync.Config{SyncMode: sync.ELSync}, &testutils.MockL1Source{}, discardEmitter{}, nil)
+	ec.SyncDeriver = noopSyncDeriver{}
+
+	err := ec.InsertUnsafePayload(context.Background(), payload, refA3)
+	require.NoError(t, err)
+	require.Equal(t, eth.L2BlockRef{}, ec.unsafeHead)
+	require.Equal(t, eth.L2BlockRef{}, ec.localSafeHead)
+	require.Equal(t, eth.L2BlockRef{}, ec.FinalizedHead())
+	mockEngine.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary

Prevent EL-sync targets from polluting op-node's derivation-facing unsafe head before the execution engine has validated the forkchoice.

This keeps the EL-sync direct insertion path able to submit future/non-contiguous payloads to reth as sync targets, but only promotes the payload into op-node's `unsafeHead` after the FCU response is `VALID`.

## Root Cause

The EL-sync path can legitimately submit future payloads to the execution engine. Reth may return `SYNCING`, which means the payload is useful as a sync target but is not yet a validated canonical head.

Previously op-node could treat that accepted sync target as its local unsafe head. Safe derivation then interpreted `pending_safe < unsafe` as evidence that reth had a contiguous, queryable unsafe chain and attempted to look up `pending_safe + 1`; if reth was still canonical at the pending safe block, this produced a `not found` reset and could truncate SafeDB.

## Impact

A future EL-sync target can still be sent to reth, but it will not advance op-node's local unsafe head unless reth returns `VALID` from FCU. EL-sync completion head updates are now delayed until after that validated FCU response, so `NewPayload=VALID` followed by `FCU=SYNCING` also cannot mutate the unsafe/safe/finalized heads.

## Validation

- `go test ./op-node/rollup/engine ./op-node/rollup/driver`
- `go test ./op-node/rollup/...`

Added regression coverage for both:

- `NewPayload=SYNCING`, `FCU=SYNCING` does not promote unsafe/local-safe/finalized.
- `NewPayload=VALID`, `FCU=SYNCING` does not promote unsafe/local-safe/finalized.
---

## JNT v2 Supernode Incident RCA

Network/context:
- `chain_id=420120103`
- JNT v2 supernodes, especially `bn-interop-jnt-v2-supernode-2`
- Same broad failure pattern was visible on multiple supernodes, so this did not look like an sn2-only local disk/db glitch.

### Observed Timeline

At `2026-05-22T07:57:31Z`, op-node logged an L1 head discontinuity / possible reorg warning:

```text
lvl=warn msg="L1 head signal indicates a possible L1 re-org"
chain_id=420120103
old_l1_head        =0x684de4c7...:10896552
new_l1_head_parent =0x1b6ea503...
new_l1_head        =0xfaff40a5...:10896554
```

A similar warning followed around `07:58:19Z` for the `10896556 -> 10896558` head movement. Later parent checks suggested the intermediate L1 blocks existed canonically, so I would treat these logs as evidence of L1-head discontinuity / possible reorg handling pressure, not as sole proof of a canonical L1 reorg. The fix here does not depend on proving that part either way.

At about `07:57:42Z`, local L2 derivation was still around `825802` and had consolidated that block against L1:

```text
msg="Inserted new L2 unsafe block" hash=0x61ca5389... number=825802
msg="Sync progress" reason="consolidated block with L1"
l2_pending_safe=0x61ca5389...:825802 l2_unsafe=0x61ca5389...:825802
```

The L1 origin for that local derived block was around `0xa36f3de7...:10896544`, i.e. before the later L1-head warning area.

Immediately after, from about `07:57:42Z` to `07:57:44Z`, the node received far-future unsafe payloads via the unsafe / EL-sync path:

```text
msg="Inserting unsafe L2 execution payload to drive EL sync" id=0x6166718...:832736
... 832738, 832744, 832746, 832747, 832756, 832767, 832770, 832772
msg="Inserted new L2 unsafe block (synchronous)" hash=0x6166718... number=832736
```

Then the deriver started resetting because it could not reconcile the op-node unsafe-head view with what reth could actually serve canonically:

```text
t=2026-05-22T07:57:44Z lvl=warn
msg="Deriver system is resetting"
chain_id=420120103
err="expected engine was synced and had unsafe block to reconcile, but cannot find the block: not found"
```

The important state mismatch was:
- op-node/supernode local safe was around `825802`
- op-node had been driven toward an EL-sync unsafe target around `832736+`
- reth did not have canonical/queryable block `825803`

That combination is invalid for derivation-facing unsafe-head bookkeeping. If op-node says unsafe is far ahead of safe, derivation assumes there is a contiguous unsafe chain it can reconcile through. In this incident, that assumption was false.

### Code Path That Matched The Logs

The relevant code path is `EngineController.insertUnsafePayload` in `op-node/rollup/engine/engine_controller.go`.

Before this PR, an EL-sync payload could be sent to reth and then promoted into op-node's derivation-facing state even when FCU had not returned `VALID`. In particular, when completing EL sync / setting the offset-derived safe+finalized hashes, the old code mutated op-node state before the FCU result was known:

```go
e.SetUnsafeHead(ref)
e.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
e.SetLocalSafeHead(safeRef)
e.SetDeprecatedSafeHead(safeRef)
e.onSafeUpdate(ctx, safeRef, safeRef)
e.SetFinalizedHead(finalizedRef)
```

Then after FCU, it also unconditionally set unsafe head again on the accepted statuses. That meant a payload could be usable as an EL-sync target for reth without being safe to expose as op-node's contiguous unsafe head.

The failure loop was therefore:

1. Local safe/pending safe is around `825802`.
2. A far-future unsafe payload, e.g. `832736`, arrives.
3. op-node sends it to reth with `engine_newPayload` / FCU to drive EL sync.
4. reth can respond in a way that is acceptable for EL sync progress, e.g. `SYNCING`, without having canonical block `825803` queryable.
5. Old op-node code still promoted the payload into `unsafeHead` / emitted unsafe updates.
6. Derivation sees `safe=825802`, `unsafe=832736`, and tries to reconcile `825803`.
7. reth returns `not found` for canonical `825803`.
8. The deriver resets/truncates SafeDB and retries against the same poisoned unsafe-head state.
9. Local safe stalls, so cross-safe/finalized also appear pinned.

### Why This Looked Like Op-Node Logic, Not Supernode Authority Logic

The supernode verifier/cross-safe symptoms were downstream of local op-node safe progress getting stuck. The decisive mismatch was between op-node's derivation-facing `unsafeHead` and reth's canonical/queryable chain. Supernode did not need to invent an invalid cross-safe decision to cause this; it was enough for embedded op-node state to say "unsafe is 832736" while reth could not serve canonical `825803`.

So the bug fixed here is in op-node engine-controller bookkeeping under EL sync. Supernode exposed the issue because it runs the op-node logic and depends on local safe/SafeDB for cross-safe verification.

### What This PR Changes

This PR keeps the EL-sync behavior but prevents the unsafe-head poisoning:

- op-node may still send a far-future payload to reth as an EL-sync target.
- op-node only promotes that payload into derivation-facing `unsafeHead` after FCU returns `VALID`.
- if `SyncMode == ELSync` and FCU status is not `VALID`, op-node logs and returns without mutating unsafe/safe/finalized state:

```text
EL sync payload accepted as sync target, but not promoted to unsafe head
```

This preserves the useful EL-sync target behavior while avoiding the false local invariant that there is a contiguous unsafe chain available from local safe to that target.

### Tests Added

The PR adds regression coverage for the two cases that matter for this incident:

- `TestInsertUnsafePayload_ELSyncSyncingDoesNotPromoteUnsafe`
  - `NewPayload=SYNCING`, `FCU=SYNCING`
  - asserts `unsafeHead`, local safe, and finalized are not advanced

- `TestInsertUnsafePayload_ELSyncValidNewPayloadSyncingFCUDoesNotPromoteUnsafe`
  - `NewPayload=VALID`, `FCU=SYNCING`
  - asserts `unsafeHead`, local safe, and finalized are not advanced

The second case is important: `NewPayload=VALID` alone is not enough. The derivation-facing state should not move unless FCU says the engine accepted that forkchoice as `VALID`.

### Local Validation

Local test runs performed on this branch:

```text
go test ./op-node/rollup/engine ./op-node/rollup/driver
go test ./op-node/rollup/...
```

Both passed before publishing the test image.

Ad hoc `op-supernode` image built from this commit:

```text
us-docker.pkg.dev/oplabs-tools-artifacts/dev-images/op-supernode:c93edd8bca89107c727f8e90f81ea24722d43ac7
sha256:9ef10a0a4daf9c15af3ada18b91fe671b4069f8c58ed20ab82da53f9035e054a
```

Binary version check:

```text
op-supernode version c93edd8bca89107c727f8e90f81ea24722d43ac7-c93edd8b-1779483099
```