### PR TITLE
fix(op-supernode): retry engine controller init in Start loop

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -206,18 +206,6 @@ func NewChainContainer(
 	} else {
 		c.denyList = denyList
 	}
-	// Initialize engine controller (separate connection, not an op-node override) with a short setup timeout
-	if vncfg.L2 != nil {
-		setupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		// Provide contextual logger to engine controller
-		engLog := log.New("chain_id", chainID.String(), "component", "engine_controller")
-		if eng, err := engine_controller.NewEngineControllerFromConfig(setupCtx, engLog, vncfg); err != nil {
-			log.Error("failed to setup engine controller", "err", err)
-		} else {
-			c.engine = eng
-		}
-	}
 	return c
 }
 
@@ -318,6 +306,18 @@ func (c *simpleChainContainer) Start(ctx context.Context) error {
 		}
 		if c.stop.Load() {
 			break
+		}
+
+		// Initialize engine controller if not yet connected (retries on each VN restart)
+		if c.engine == nil && c.vncfg.L2 != nil {
+			setupCtx, setupCancel := context.WithTimeout(ctx, 10*time.Second)
+			engLog := c.log.New("chain_id", c.chainID.String(), "component", "engine_controller")
+			if eng, engErr := engine_controller.NewEngineControllerFromConfig(setupCtx, engLog, c.vncfg); engErr != nil {
+				c.log.Error("failed to setup engine controller", "err", engErr)
+			} else {
+				c.engine = eng
+			}
+			setupCancel()
 		}
 
 		// start the virtual node

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -343,6 +343,24 @@ func TestChainContainer_Constructor(t *testing.T) {
 	})
 }
 
+// TestChainContainer_EngineControllerNotInitInConstructor verifies that the
+// engine controller is NOT initialized in NewChainContainer (it is deferred to
+// the Start loop so that transient EL unavailability at startup is retried).
+func TestChainContainer_EngineControllerNotInitInConstructor(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	vncfg := createTestVNConfig()
+	log := createTestLogger(t)
+	cfg := createTestCLIConfig(t.TempDir())
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	impl, ok := container.(*simpleChainContainer)
+	require.True(t, ok)
+	require.Nil(t, impl.engine, "engine should not be initialized in constructor; it is deferred to Start loop")
+}
+
 // TestChainContainer_Lifecycle tests Start/Stop behavior
 func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- Moved engine controller initialization from `NewChainContainer()` into the `Start()` restart loop so it retries on each VN restart iteration when `c.engine` is still nil
- Previously, if the EL was unreachable at startup, `c.engine` stayed nil permanently, causing persistent `ErrNoEngineClient` errors that blocked interop activity
- Added a test verifying the engine is not initialized in the constructor

## Test plan
- [x] `go build ./op-supernode/...` passes
- [x] `go test ./op-supernode/supernode/chain_container/...` passes (all 3 sub-packages)
- [x] `go vet ./op-supernode/supernode/chain_container/...` clean
- [ ] CI passes