### PR TITLE
chore: remove non-Go op-supervisor build and architecture-doc references

### DIFF
--- a/.github/images.json
+++ b/.github/images.json
@@ -87,14 +87,6 @@
       "target": "da-server",
       "paths": ["op-alt-da/**"]
     },
-    "op-supervisor": {
-      "type": "go",
-      "check": "go",
-      "mode": "bake",
-      "bake_file": "docker-bake.hcl",
-      "target": "op-supervisor",
-      "paths": ["op-supervisor/**"]
-    },
     "op-supernode": {
       "type": "go",
       "check": "go",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ The rollup node software and associated services, including:
 - **op-proposer**: L2 output submitter
 - **op-challenger**: Dispute game challenge agent
 - **op-conductor**: High-availability sequencer service
-- **op-supervisor**: Cross-chain message safety monitor (DEPRECATED)
+- **op-supernode**: Multi-chain consensus-layer host that runs multiple OP Stack chains in a single process and performs in-process cross-chain safety verification
 
 ### Smart Contracts (`packages/contracts-bedrock`)
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -57,10 +57,6 @@ variable "OP_PROGRAM_VERSION" {
   default = "${GIT_VERSION}"
 }
 
-variable "OP_SUPERVISOR_VERSION" {
-  default = "${GIT_VERSION}"
-}
-
 variable "OP_SUPERNODE_VERSION" {
   default = "${GIT_VERSION}"
 }
@@ -199,19 +195,6 @@ target "op-program" {
   target = "op-program-target"
   platforms = split(",", PLATFORMS)
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-program:${tag}"]
-}
-
-target "op-supervisor" {
-  dockerfile = "ops/docker/op-stack-go/Dockerfile"
-  context = "."
-  args = {
-    GIT_COMMIT = "${GIT_COMMIT}"
-    GIT_DATE = "${GIT_DATE}"
-    OP_SUPERVISOR_VERSION = "${OP_SUPERVISOR_VERSION}"
-  }
-  target = "op-supervisor-target"
-  platforms = split(",", PLATFORMS)
-  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-supervisor:${tag}"]
 }
 
 target "op-supernode" {

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ PYTHON := env('PYTHON', 'python3')
 
 TEST_TIMEOUT := env('TEST_TIMEOUT', '10m')
 
-TEST_PKGS := "./op-alt-da/... ./op-batcher/... ./op-chain-ops/... ./op-core/... ./op-node/... ./op-proposer/... ./op-challenger/... ./op-faucet/... ./op-dispute-mon/... ./op-conductor/... ./op-program/... ./op-service/... ./op-supervisor/... ./op-test-sequencer/... ./op-fetcher/... ./op-e2e/system/... ./op-e2e/e2eutils/... ./op-e2e/opgeth/... ./op-e2e/interop/... ./op-e2e/actions/altda ./op-e2e/actions/batcher ./op-e2e/actions/derivation ./op-e2e/actions/helpers ./op-e2e/actions/proofs ./op-e2e/actions/proposer ./op-e2e/actions/safedb ./op-e2e/actions/sequencer ./op-e2e/actions/sync ./op-e2e/actions/upgrades ./packages/contracts-bedrock/scripts/checks/... ./ops/scripts/... ./op-dripper/... ./op-devstack/... ./op-deployer/pkg/deployer/artifacts/... ./op-deployer/pkg/deployer/broadcaster/... ./op-deployer/pkg/deployer/clean/... ./op-deployer/pkg/deployer/integration_test/ ./op-deployer/pkg/deployer/integration_test/cli/... ./op-deployer/pkg/deployer/standard/... ./op-deployer/pkg/deployer/state/... ./op-deployer/pkg/deployer/verify/... ./op-sync-tester/... ./op-supernode/..."
+TEST_PKGS := "./op-alt-da/... ./op-batcher/... ./op-chain-ops/... ./op-core/... ./op-node/... ./op-proposer/... ./op-challenger/... ./op-faucet/... ./op-dispute-mon/... ./op-conductor/... ./op-program/... ./op-service/... ./op-test-sequencer/... ./op-fetcher/... ./op-e2e/system/... ./op-e2e/e2eutils/... ./op-e2e/opgeth/... ./op-e2e/interop/... ./op-e2e/actions/altda ./op-e2e/actions/batcher ./op-e2e/actions/derivation ./op-e2e/actions/helpers ./op-e2e/actions/proofs ./op-e2e/actions/proposer ./op-e2e/actions/safedb ./op-e2e/actions/sequencer ./op-e2e/actions/sync ./op-e2e/actions/upgrades ./packages/contracts-bedrock/scripts/checks/... ./ops/scripts/... ./op-dripper/... ./op-devstack/... ./op-deployer/pkg/deployer/artifacts/... ./op-deployer/pkg/deployer/broadcaster/... ./op-deployer/pkg/deployer/clean/... ./op-deployer/pkg/deployer/integration_test/ ./op-deployer/pkg/deployer/integration_test/cli/... ./op-deployer/pkg/deployer/standard/... ./op-deployer/pkg/deployer/state/... ./op-deployer/pkg/deployer/verify/... ./op-sync-tester/... ./op-supernode/..."
 
 FRAUD_PROOF_TEST_PKGS := "./op-e2e/faultproofs/..."
 
@@ -63,7 +63,7 @@ golang-docker:
       --progress plain \
       --load \
       -f docker-bake.hcl \
-      op-node op-batcher op-proposer op-challenger op-dispute-mon op-supervisor
+      op-node op-batcher op-proposer op-challenger op-dispute-mon
 
 # Removes the Docker buildx builder.
 docker-builder-clean:

--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -48,7 +48,6 @@ Available components:
   - `L2Proposer`: op-proposer, or equivalent
   - `L2Challenger`: op-challenger, or equivalent
   - `L2MetricsDashboard`: runs prometheus and grafana instances if any component registers metrics endpoints
-- `Supervisor`: op-supervisor service, or equivalent
 - `Faucet`: util to fund eth to test accounts
 
 ### DSL-only components

--- a/op-node/README.md
+++ b/op-node/README.md
@@ -142,25 +142,6 @@ The op-node is changing in two ways:
 - Event tests: [Issue 13163](https://github.com/ethereum-optimism/optimism/issues/13163)
 - Improving P2P sync: [Issue 11779](https://github.com/ethereum-optimism/optimism/issues/11779)
 
-#### Interoperability
-
-The OP Stack makes chains natively interoperable:
-messages between chains form safety dependencies, and verified asynchronously.
-Asynchronous verification entails that the op-node reorgs away a block
-if and when the block is determined to be invalid.
-
-The [op-supervisor] specializes in this dependency verification work.
-
-The op-node encapsulates all the single-chain concerns:
-it prepares the local safety data-points (DA confirmation and block contents) for the op-supervisor.
-
-The op-supervisor then verifies the cross-chain safety, and promotes the block safety level accordingly,
-which the op-node then follows.
-
-See [Interop specs] and [Interop design-docs] for more information about interoperability.
-
-[op-supervisor]: ../op-supervisor/README.md
-
 ### User stories
 
 <!-- As a **actor** I want **achievement** so that I **benefit** -->

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -156,11 +156,6 @@ FROM --platform=$BUILDPLATFORM builder AS da-server-builder
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   cd op-alt-da && GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE just da-server
 
-FROM --platform=$BUILDPLATFORM builder AS op-supervisor-builder
-ARG OP_SUPERVISOR_VERSION=v0.0.0
-RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
-  cd op-supervisor && GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_SUPERVISOR_VERSION" just op-supervisor
-
 FROM --platform=$BUILDPLATFORM builder AS op-supernode-builder
 ARG OP_SUPERNODE_VERSION=v0.0.0
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
@@ -313,9 +308,6 @@ FROM $TARGET_BASE_IMAGE AS da-server-target
 COPY --from=da-server-builder /app/op-alt-da/bin/da-server /usr/local/bin/
 CMD ["da-server"]
 
-FROM $TARGET_BASE_IMAGE AS op-supervisor-target
-COPY --from=op-supervisor-builder /app/op-supervisor/bin/op-supervisor /usr/local/bin/
-CMD ["op-supervisor"]
 
 FROM $TARGET_BASE_IMAGE AS op-supernode-target
 COPY --from=op-supernode-builder /app/op-supernode/bin/op-supernode /usr/local/bin/


### PR DESCRIPTION
Drops op-supervisor from the build/publish surfaces and architecture docs that describe it as a live component:

Build / publish:
- `justfile` — `TEST_PKGS` and the docker bake build target list
- `docker-bake.hcl` — `OP_SUPERVISOR_VERSION` variable and `op-supervisor` target
- `ops/docker/op-stack-go/Dockerfile` — `op-supervisor-builder` and `op-supervisor-target` stages
- `.github/images.json` — image publish entry

Docs:
- `AGENTS.md` — replace the op-supervisor entry with op-supernode, with a description that reflects what op-supernode actually does (multi-chain CL host with in-process cross-chain safety verification)
- `op-node/README.md` — drop the entire `Interoperability` subsection
- `op-devstack/README.md` — drop the `Supervisor` component line

Left in place: the top-level `README.md` directory listing, the Go package and docs inside `op-supervisor/`, the public-docs redirects in `docs.json`, the `opgeth-decoupling.md` deprecation note, and the dockerignore allowlists (still needed while op-program imports `op-supervisor/.../cross`).