### PR TITLE
feat(op-service/clock): make AdvancingClock continuous

### DIFF
--- a/op-challenger/game/fault/preimages/large_test.go
+++ b/op-challenger/game/fault/preimages/large_test.go
@@ -348,7 +348,7 @@ func TestLargePreimageUploader_UploadPreimage_Succeeds(t *testing.T) {
 
 func newTestLargePreimageUploader(t *testing.T) (*LargePreimageUploader, *clock.AdvancingClock, *mockTxSender, *mockPreimageOracleContract) {
 	logger := testlog.Logger(t, log.LevelError)
-	cl := clock.NewAdvancingClock(time.Second)
+	cl := clock.NewAdvancingClock()
 	cl.Start()
 	txSender := &mockTxSender{}
 	contract := &mockPreimageOracleContract{

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -150,7 +150,7 @@ func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 	l1Clock := clock.SystemClock
 	var timeTravelClock *clock.AdvancingClock
 	if cfg.EnableTimeTravel {
-		timeTravelClock = clock.NewAdvancingClock(100 * time.Millisecond)
+		timeTravelClock = clock.NewAdvancingClock()
 		l1Clock = timeTravelClock
 	}
 	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
@@ -216,7 +216,7 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 	l1Clock := clock.SystemClock
 	var timeTravelClock *clock.AdvancingClock
 	if cfg.EnableTimeTravel {
-		timeTravelClock = clock.NewAdvancingClock(100 * time.Millisecond)
+		timeTravelClock = clock.NewAdvancingClock()
 		l1Clock = timeTravelClock
 	}
 	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -97,7 +97,7 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 	l1Clock := clock.SystemClock
 	var timeTravelClock *clock.AdvancingClock
 	if cfg.EnableTimeTravel {
-		timeTravelClock = clock.NewAdvancingClock(100 * time.Millisecond)
+		timeTravelClock = clock.NewAdvancingClock()
 		l1Clock = timeTravelClock
 	}
 	l1EL, l1CL := startInProcessL1WithClockConfig(t, world.L1Network, jwtPath, l1Clock, cfg)

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -103,7 +103,7 @@ func setupMonitorTest(t *testing.T) (*gameMonitor, *mockExtractor, *mockForecast
 		return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
 	}
 	monitorInterval := 100 * time.Millisecond
-	cl := clock.NewAdvancingClock(10 * time.Millisecond)
+	cl := clock.NewAdvancingClock()
 	cl.Start()
 	extractor := &mockExtractor{}
 	forecast := &mockForecast{}
@@ -168,7 +168,7 @@ func TestMonitor_NodeEndpointErrorsMonitorIntegration(t *testing.T) {
 			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
 		}
 		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl := clock.NewAdvancingClock()
 		cl.Start()
 
 		// Create games with endpoint errors
@@ -215,7 +215,7 @@ func TestMonitor_NodeEndpointErrorCountMonitorIntegration(t *testing.T) {
 			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
 		}
 		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl := clock.NewAdvancingClock()
 		cl.Start()
 
 		// Create games with endpoint error counts
@@ -269,7 +269,7 @@ func TestMonitor_MixedAvailabilityMonitorIntegration(t *testing.T) {
 			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
 		}
 		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl := clock.NewAdvancingClock()
 		cl.Start()
 
 		// Create games with mixed availability scenarios
@@ -335,7 +335,7 @@ func TestMonitor_MixedSafetyMonitorIntegration(t *testing.T) {
 			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
 		}
 		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl := clock.NewAdvancingClock()
 		cl.Start()
 
 		// Create games with mixed safety scenarios
@@ -389,7 +389,7 @@ func TestMonitor_MixedSafetyMonitorIntegration(t *testing.T) {
 			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
 		}
 		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl := clock.NewAdvancingClock()
 		cl.Start()
 
 		// Create games without mixed safety
@@ -432,7 +432,7 @@ func TestMonitor_MixedSafetyMonitorIntegration(t *testing.T) {
 			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
 		}
 		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl := clock.NewAdvancingClock()
 		cl.Start()
 
 		// Create a game with minimal mixed safety (1 safe, 1 unsafe)
@@ -478,7 +478,7 @@ func TestMonitor_DifferentOutputRootMonitorIntegration(t *testing.T) {
 			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
 		}
 		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl := clock.NewAdvancingClock()
 		cl.Start()
 
 		// Create games with different output root scenarios
@@ -523,7 +523,7 @@ func TestMonitor_DifferentOutputRootMonitorIntegration(t *testing.T) {
 			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
 		}
 		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl := clock.NewAdvancingClock()
 		cl.Start()
 
 		// Create games without different output roots
@@ -563,7 +563,7 @@ func TestMonitor_DifferentOutputRootMonitorIntegration(t *testing.T) {
 			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
 		}
 		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl := clock.NewAdvancingClock()
 		cl.Start()
 
 		// Create games where all have different output roots
@@ -603,7 +603,7 @@ func TestMonitor_DifferentOutputRootMonitorIntegration(t *testing.T) {
 			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
 		}
 		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl := clock.NewAdvancingClock()
 		cl.Start()
 
 		// Create empty games list

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -211,7 +211,7 @@ func (s *interopE2ESystem) prepareL1() (*fakebeacon.FakeBeacon, *geth.GethInstan
 	l1FinalizedDistance := uint64(3)
 	l1Clock := clock.SystemClock
 	if s.config.SupportTimeTravel {
-		s.timeTravelClock = clock.NewAdvancingClock(100 * time.Millisecond)
+		s.timeTravelClock = clock.NewAdvancingClock()
 		l1Clock = s.timeTravelClock
 	}
 	// Start the L1 chain

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -619,7 +619,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 
 	clk := clock.SystemClock
 	if cfg.SupportL1TimeTravel {
-		sys.TimeTravelClock = clock.NewAdvancingClock(100 * time.Millisecond)
+		sys.TimeTravelClock = clock.NewAdvancingClock()
 		clk = sys.TimeTravelClock
 	}
 

--- a/op-service/clock/advancing.go
+++ b/op-service/clock/advancing.go
@@ -28,9 +28,10 @@ type AdvancingClock struct {
 }
 
 // pendingAction is one scheduled event. advTimer / advTicker wrap it to
-// adapt the differing Timer / Ticker Stop signatures.
+// adapt the differing Timer / Ticker Stop signatures. All mutable fields
+// are guarded by the owning AdvancingClock's mu; ch and callback are
+// immutable after construction.
 type pendingAction struct {
-	mu       sync.Mutex
 	clock    *AdvancingClock
 	due      time.Time
 	period   time.Duration // zero for one-shot, non-zero for ticker
@@ -233,14 +234,10 @@ func (c *AdvancingClock) run() {
 		var nextDue time.Time
 		hasPending := false
 		for _, a := range c.pending {
-			a.mu.Lock()
-			stopped := a.stopped
-			due := a.due
-			a.mu.Unlock()
-			if stopped {
+			if a.stopped {
 				continue
 			}
-			nextDue = due
+			nextDue = a.due
 			hasPending = true
 			break
 		}
@@ -280,14 +277,10 @@ func (c *AdvancingClock) fireDue() {
 		c.mu.Lock()
 		var due *pendingAction
 		for _, a := range c.pending {
-			a.mu.Lock()
-			stopped := a.stopped
-			aDue := a.due
-			a.mu.Unlock()
-			if stopped {
+			if a.stopped {
 				continue
 			}
-			if aDue.After(now) {
+			if a.due.After(now) {
 				break
 			}
 			due = a
@@ -299,59 +292,56 @@ func (c *AdvancingClock) fireDue() {
 			return
 		}
 		c.removeLocked(due)
+		rearm := c.fireLocked(due, now)
+		if rearm {
+			c.insertLocked(due)
+		}
 		c.mu.Unlock()
 
-		rearm := due.fire(now)
-		if rearm {
-			c.mu.Lock()
-			c.insertLocked(due)
-			c.mu.Unlock()
-		}
+		c.deliver(due, now)
 	}
 }
 
 func (c *AdvancingClock) purgeStoppedLocked() {
 	kept := c.pending[:0]
 	for _, a := range c.pending {
-		a.mu.Lock()
-		stopped := a.stopped
-		a.mu.Unlock()
-		if !stopped {
+		if !a.stopped {
 			kept = append(kept, a)
 		}
 	}
 	c.pending = kept
 }
 
-// fire delivers one event. Returns true if the action should be re-armed (ticker).
-func (a *pendingAction) fire(now time.Time) bool {
-	a.mu.Lock()
+// fireLocked updates action state for firing. Returns true if the action
+// should be re-armed (ticker). Caller must hold c.mu.
+func (c *AdvancingClock) fireLocked(a *pendingAction, now time.Time) bool {
 	if a.stopped {
-		a.mu.Unlock()
 		return false
 	}
-	period := a.period
-	ch := a.ch
-	cb := a.callback
 	a.run = true
-	if period > 0 {
-		a.due = now.Add(period)
+	if a.period > 0 {
+		a.due = now.Add(a.period)
+		return true
 	}
-	a.mu.Unlock()
+	return false
+}
 
-	if ch != nil {
+// deliver sends the event to the channel and/or invokes the callback.
+// Called without holding c.mu so a slow consumer or callback cannot stall
+// the scheduler.
+func (c *AdvancingClock) deliver(a *pendingAction, now time.Time) {
+	if a.ch != nil {
 		// Non-blocking send: matches stdlib time.Ticker semantics.
 		select {
-		case ch <- now:
+		case a.ch <- now:
 		default:
 		}
 	}
-	if cb != nil {
+	if a.callback != nil {
 		// Run on its own goroutine so a slow callback cannot stall the
 		// scheduler. Matches stdlib time.AfterFunc semantics.
-		go cb()
+		go a.callback()
 	}
-	return period > 0
 }
 
 type advTimer struct {
@@ -382,17 +372,19 @@ func (t *advTicker) Reset(d time.Duration) {
 }
 
 func (a *pendingAction) stopExternal() bool {
-	a.mu.Lock()
+	c := a.clock
+	c.mu.Lock()
 	wasActive := !a.stopped && !a.run
 	a.stopped = true
-	a.mu.Unlock()
-	a.clock.signal()
+	c.mu.Unlock()
+	c.signal()
 	return wasActive
 }
 
 func (a *pendingAction) reset(d time.Duration) bool {
-	due := a.clock.Now().Add(d)
-	a.mu.Lock()
+	c := a.clock
+	c.mu.Lock()
+	due := c.wallClock.Now().Add(c.offset).Add(d)
 	wasActive := !a.stopped && !a.run
 	a.stopped = false
 	a.run = false
@@ -400,13 +392,10 @@ func (a *pendingAction) reset(d time.Duration) bool {
 	if a.period > 0 {
 		a.period = d
 	}
-	a.mu.Unlock()
-
-	a.clock.mu.Lock()
-	a.clock.removeLocked(a)
-	a.clock.insertLocked(a)
-	a.clock.mu.Unlock()
-	a.clock.signal()
+	c.removeLocked(a)
+	c.insertLocked(a)
+	c.mu.Unlock()
+	c.signal()
 	return wasActive
 }
 

--- a/op-service/clock/advancing.go
+++ b/op-service/clock/advancing.go
@@ -1,72 +1,415 @@
 package clock
 
 import (
+	"context"
+	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 )
 
+// AdvancingClock tracks wall time and can be jumped forward via AdvanceTime.
+// Now() is lazy (wall + offset) so it always reads the current time.
+// A single scheduler goroutine fires pending timers when due; AdvanceTime
+// signals it so jumped-past timers fire immediately.
 type AdvancingClock struct {
-	*DeterministicClock
-	systemTime   Clock
-	ticker       Ticker
-	advanceEvery time.Duration
-	quit         chan interface{}
-	running      atomic.Bool
+	wallClock Clock
 
-	lastTick time.Time
+	mu sync.Mutex
+	// offset is the manual time-travel delta added on top of wallClock.Now().
+	// Guarded by mu.
+	offset       time.Duration
+	pending      []*pendingAction // sorted ascending by due
+	wakeup       chan struct{}    // buffer 1; signals the scheduler to re-evaluate
+	newPendingCh chan struct{}    // buffer 1; signals WaitForNewPendingAction
+	quit         chan struct{}    // closed by Stop
+	running      atomic.Bool
+	wg           sync.WaitGroup
 }
 
-// NewAdvancingClock creates a clock that, when started, advances at the same rate as the system clock but
-// can also be advanced arbitrary amounts using the AdvanceTime method.
-// Unlike the system clock, time does not progress smoothly but only increments when AdvancedTime is called or
-// approximately after advanceEvery duration has elapsed. When advancing based on the system clock, the total time
-// the system clock has advanced is added to the current time, preventing time differences from building up over time.
-func NewAdvancingClock(advanceEvery time.Duration) *AdvancingClock {
-	now := SystemClock.Now()
+// pendingAction is one scheduled event. advTimer / advTicker wrap it to
+// adapt the differing Timer / Ticker Stop signatures.
+type pendingAction struct {
+	mu       sync.Mutex
+	clock    *AdvancingClock
+	due      time.Time
+	period   time.Duration // zero for one-shot, non-zero for ticker
+	ch       chan time.Time
+	callback func()
+	stopped  bool
+	run      bool
+}
+
+// NewAdvancingClock creates a clock that advances continuously with the
+// system clock and can also be jumped forward by arbitrary amounts via
+// AdvanceTime. Now() always reflects the latest wall time plus any
+// accumulated manual jumps. Scheduled actions (Timer, Ticker, After,
+// AfterFunc) fire when due in logical time; a manual AdvanceTime that
+// jumps past a due time fires the action immediately.
+func NewAdvancingClock() *AdvancingClock {
+	return newAdvancingClock(SystemClock)
+}
+
+func newAdvancingClock(wall Clock) *AdvancingClock {
 	return &AdvancingClock{
-		DeterministicClock: NewDeterministicClock(now),
-		systemTime:         SystemClock,
-		advanceEvery:       advanceEvery,
-		quit:               make(chan interface{}),
-		lastTick:           now,
+		wallClock:    wall,
+		wakeup:       make(chan struct{}, 1),
+		newPendingCh: make(chan struct{}, 1),
+		quit:         make(chan struct{}),
 	}
 }
 
 func (c *AdvancingClock) Start() {
 	if !c.running.CompareAndSwap(false, true) {
-		// Already running
 		return
 	}
-	c.ticker = c.systemTime.NewTicker(c.advanceEvery)
-	go func() {
-		for {
-			select {
-			case now := <-c.ticker.Ch():
-				c.onTick(now)
-			case <-c.quit:
-				return
-			}
-		}
-	}()
+	c.mu.Lock()
+	c.quit = make(chan struct{})
+	c.mu.Unlock()
+	c.wg.Add(1)
+	go c.run()
+	c.signal()
 }
 
 func (c *AdvancingClock) Stop() {
 	if !c.running.CompareAndSwap(true, false) {
-		// Already stopped
 		return
 	}
-	c.ticker.Stop()
-	c.quit <- nil
+	c.mu.Lock()
+	close(c.quit)
+	c.mu.Unlock()
+	c.wg.Wait()
 }
 
-func (c *AdvancingClock) onTick(now time.Time) {
-	if !now.After(c.lastTick) {
-		// Time hasn't progressed for some reason, so do nothing
+func (c *AdvancingClock) Now() time.Time {
+	c.mu.Lock()
+	offset := c.offset
+	c.mu.Unlock()
+	return c.wallClock.Now().Add(offset)
+}
+
+func (c *AdvancingClock) Since(t time.Time) time.Duration {
+	return c.Now().Sub(t)
+}
+
+func (c *AdvancingClock) Until(t time.Time) time.Duration {
+	return t.Sub(c.Now())
+}
+
+// AdvanceTime jumps time forward by d. Overdue actions fire when the
+// scheduler next iterates (signalled below).
+func (c *AdvancingClock) AdvanceTime(d time.Duration) {
+	if d == 0 {
 		return
 	}
-	// Advance time by however long it has been since the last update.
-	// Ensures we don't drift from system time by more and more over time
-	advanceBy := now.Sub(c.lastTick)
-	c.AdvanceTime(advanceBy)
-	c.lastTick = now
+	c.mu.Lock()
+	c.offset += d
+	c.mu.Unlock()
+	c.signal()
 }
+
+func (c *AdvancingClock) signal() {
+	select {
+	case c.wakeup <- struct{}{}:
+	default:
+	}
+}
+
+func (c *AdvancingClock) After(d time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+	if d <= 0 {
+		ch <- c.Now()
+		return ch
+	}
+	c.addAction(&pendingAction{
+		clock: c,
+		due:   c.Now().Add(d),
+		ch:    ch,
+	})
+	return ch
+}
+
+func (c *AdvancingClock) AfterFunc(d time.Duration, f func()) Timer {
+	a := &pendingAction{
+		clock:    c,
+		due:      c.Now().Add(d),
+		callback: f,
+	}
+	if d <= 0 {
+		a.run = true
+		go f()
+		return &advTimer{a: a}
+	}
+	c.addAction(a)
+	return &advTimer{a: a}
+}
+
+func (c *AdvancingClock) NewTicker(d time.Duration) Ticker {
+	if d <= 0 {
+		panic("Continuously firing tickers are a really bad idea")
+	}
+	ch := make(chan time.Time, 1)
+	a := &pendingAction{
+		clock:  c,
+		due:    c.Now().Add(d),
+		period: d,
+		ch:     ch,
+	}
+	c.addAction(a)
+	return &advTicker{a: a}
+}
+
+func (c *AdvancingClock) NewTimer(d time.Duration) Timer {
+	ch := make(chan time.Time, 1)
+	a := &pendingAction{
+		clock: c,
+		due:   c.Now().Add(d),
+		ch:    ch,
+	}
+	if d <= 0 {
+		a.run = true
+		select {
+		case ch <- c.Now():
+		default:
+		}
+		return &advTimer{a: a}
+	}
+	c.addAction(a)
+	return &advTimer{a: a}
+}
+
+func (c *AdvancingClock) SleepCtx(ctx context.Context, d time.Duration) error {
+	return sleepCtx(ctx, d, c)
+}
+
+func (c *AdvancingClock) addAction(a *pendingAction) {
+	c.mu.Lock()
+	c.insertLocked(a)
+	c.mu.Unlock()
+	select {
+	case c.newPendingCh <- struct{}{}:
+	default:
+	}
+	c.signal()
+}
+
+// WaitForNewPendingAction blocks until a new action is scheduled since the
+// last call to this method, or ctx is done. Intended for tests that need to
+// synchronise with goroutines that schedule timers asynchronously.
+func (c *AdvancingClock) WaitForNewPendingAction(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-c.newPendingCh:
+		return true
+	}
+}
+
+func (c *AdvancingClock) insertLocked(a *pendingAction) {
+	idx := sort.Search(len(c.pending), func(i int) bool {
+		return c.pending[i].due.After(a.due)
+	})
+	c.pending = append(c.pending, nil)
+	copy(c.pending[idx+1:], c.pending[idx:])
+	c.pending[idx] = a
+}
+
+func (c *AdvancingClock) removeLocked(a *pendingAction) {
+	for i, item := range c.pending {
+		if item == a {
+			c.pending = append(c.pending[:i], c.pending[i+1:]...)
+			return
+		}
+	}
+}
+
+// run sleeps until the next due item (or a wakeup/quit signal), then fires
+// anything overdue.
+func (c *AdvancingClock) run() {
+	defer c.wg.Done()
+	for {
+		c.mu.Lock()
+		quit := c.quit
+		var nextDue time.Time
+		hasPending := false
+		for _, a := range c.pending {
+			a.mu.Lock()
+			stopped := a.stopped
+			due := a.due
+			a.mu.Unlock()
+			if stopped {
+				continue
+			}
+			nextDue = due
+			hasPending = true
+			break
+		}
+		c.mu.Unlock()
+
+		if !hasPending {
+			select {
+			case <-c.wakeup:
+				continue
+			case <-quit:
+				return
+			}
+		}
+
+		now := c.Now()
+		if !nextDue.After(now) {
+			c.fireDue()
+			continue
+		}
+		wallSleep := nextDue.Sub(now)
+		timer := c.wallClock.NewTimer(wallSleep)
+		select {
+		case <-timer.Ch():
+		case <-c.wakeup:
+			timer.Stop()
+		case <-quit:
+			timer.Stop()
+			return
+		}
+	}
+}
+
+// fireDue fires every action due at or before Now(); tickers re-arm.
+func (c *AdvancingClock) fireDue() {
+	for {
+		now := c.Now()
+		c.mu.Lock()
+		var due *pendingAction
+		for _, a := range c.pending {
+			a.mu.Lock()
+			stopped := a.stopped
+			aDue := a.due
+			a.mu.Unlock()
+			if stopped {
+				continue
+			}
+			if aDue.After(now) {
+				break
+			}
+			due = a
+			break
+		}
+		if due == nil {
+			c.purgeStoppedLocked()
+			c.mu.Unlock()
+			return
+		}
+		c.removeLocked(due)
+		c.mu.Unlock()
+
+		rearm := due.fire(now)
+		if rearm {
+			c.mu.Lock()
+			c.insertLocked(due)
+			c.mu.Unlock()
+		}
+	}
+}
+
+func (c *AdvancingClock) purgeStoppedLocked() {
+	kept := c.pending[:0]
+	for _, a := range c.pending {
+		a.mu.Lock()
+		stopped := a.stopped
+		a.mu.Unlock()
+		if !stopped {
+			kept = append(kept, a)
+		}
+	}
+	c.pending = kept
+}
+
+// fire delivers one event. Returns true if the action should be re-armed (ticker).
+func (a *pendingAction) fire(now time.Time) bool {
+	a.mu.Lock()
+	if a.stopped {
+		a.mu.Unlock()
+		return false
+	}
+	period := a.period
+	ch := a.ch
+	cb := a.callback
+	a.run = true
+	if period > 0 {
+		a.due = now.Add(period)
+	}
+	a.mu.Unlock()
+
+	if ch != nil {
+		// Non-blocking send: matches stdlib time.Ticker semantics.
+		select {
+		case ch <- now:
+		default:
+		}
+	}
+	if cb != nil {
+		// Run on its own goroutine so a slow callback cannot stall the
+		// scheduler. Matches stdlib time.AfterFunc semantics.
+		go cb()
+	}
+	return period > 0
+}
+
+type advTimer struct {
+	a *pendingAction
+}
+
+func (t *advTimer) Ch() <-chan time.Time { return t.a.ch }
+
+func (t *advTimer) Stop() bool {
+	return t.a.stopExternal()
+}
+
+type advTicker struct {
+	a *pendingAction
+}
+
+func (t *advTicker) Ch() <-chan time.Time { return t.a.ch }
+
+func (t *advTicker) Stop() {
+	t.a.stopExternal()
+}
+
+func (t *advTicker) Reset(d time.Duration) {
+	if d <= 0 {
+		panic("Continuously firing tickers are a really bad idea")
+	}
+	t.a.reset(d)
+}
+
+func (a *pendingAction) stopExternal() bool {
+	a.mu.Lock()
+	wasActive := !a.stopped && !a.run
+	a.stopped = true
+	a.mu.Unlock()
+	a.clock.signal()
+	return wasActive
+}
+
+func (a *pendingAction) reset(d time.Duration) bool {
+	due := a.clock.Now().Add(d)
+	a.mu.Lock()
+	wasActive := !a.stopped && !a.run
+	a.stopped = false
+	a.run = false
+	a.due = due
+	if a.period > 0 {
+		a.period = d
+	}
+	a.mu.Unlock()
+
+	a.clock.mu.Lock()
+	a.clock.removeLocked(a)
+	a.clock.insertLocked(a)
+	a.clock.mu.Unlock()
+	a.clock.signal()
+	return wasActive
+}
+
+var _ Clock = (*AdvancingClock)(nil)
+var _ Timer = (*advTimer)(nil)
+var _ Ticker = (*advTicker)(nil)

--- a/op-service/clock/advancing_test.go
+++ b/op-service/clock/advancing_test.go
@@ -1,6 +1,7 @@
 package clock
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,7 +9,7 @@ import (
 )
 
 func TestAdvancingClock_AdvancesByTimeBetweenTicks(t *testing.T) {
-	clock, realTime := newTestAdvancingClock(1 * time.Second)
+	clock, realTime := newTestAdvancingClock()
 	clock.Start()
 	defer clock.Stop()
 	eventTicker := clock.NewTicker(1 * time.Second)
@@ -25,34 +26,252 @@ func TestAdvancingClock_AdvancesByTimeBetweenTicks(t *testing.T) {
 }
 
 func TestAdvancingClock_Stop(t *testing.T) {
-	clock, realTime := newTestAdvancingClock(1 * time.Second)
+	clock, realTime := newTestAdvancingClock()
 	clock.Start()
 	defer clock.Stop()
 	eventTicker := clock.NewTicker(1 * time.Second)
 
-	// Stop the clock again
 	clock.Stop()
 
 	start := clock.Now()
+	// Wall time still advances while stopped (Now() is lazy), but the
+	// ticker must not fire.
 	realTime.AdvanceTime(15 * time.Second)
+	require.Equal(t, start.Add(15*time.Second), clock.Now(),
+		"Now() should keep tracking wall time even while the scheduler is stopped")
+	select {
+	case <-eventTicker.Ch():
+		t.Fatal("ticker fired while scheduler was stopped")
+	default:
+	}
 
 	clock.Start()
-	// Trigger the next tick
 	realTime.AdvanceTime(1 * time.Second)
-	// Time advances by the whole time the clock was stopped
-	// Note: if events were triggered while the clock was stopped, this event would be for the wrong time
-	require.Equal(t, start.Add(16*time.Second), <-eventTicker.Ch(), "should trigger events again after restarting")
-	require.Equal(t, start.Add(16*time.Second), clock.Now(), "Should advance by time between ticks after restarting")
+
+	tick := <-eventTicker.Ch()
+	// Reported time depends on whether the scheduler saw the second
+	// AdvanceTime before firing; just bound it.
+	require.GreaterOrEqual(t, tick.UnixNano(), start.Add(15*time.Second).UnixNano(),
+		"ticker should report a time at or after the restart point")
+	require.LessOrEqual(t, tick.UnixNano(), start.Add(16*time.Second).UnixNano(),
+		"ticker should not report a time beyond Now()")
+	require.Equal(t, start.Add(16*time.Second), clock.Now(),
+		"Now() should reflect the total wall progression after restart")
 }
 
-func newTestAdvancingClock(advanceEvery time.Duration) (*AdvancingClock, *DeterministicClock) {
-	systemTime := NewDeterministicClock(time.UnixMilli(1000))
-	clock := &AdvancingClock{
-		DeterministicClock: NewDeterministicClock(time.UnixMilli(5000)),
-		systemTime:         systemTime,
-		advanceEvery:       advanceEvery,
-		quit:               make(chan interface{}),
-		lastTick:           systemTime.Now(),
+// Now() returns a fresh time on every call, with no tick quantisation.
+func TestAdvancingClock_NowIsContinuous(t *testing.T) {
+	clock, realTime := newTestAdvancingClock()
+	defer clock.Stop()
+	start := clock.Now()
+
+	realTime.AdvanceTime(123 * time.Microsecond)
+	require.Equal(t, start.Add(123*time.Microsecond), clock.Now(),
+		"Now() should reflect sub-tick wall-time progression immediately")
+
+	realTime.AdvanceTime(7 * time.Nanosecond)
+	require.Equal(t, start.Add(123*time.Microsecond+7*time.Nanosecond), clock.Now(),
+		"Now() should not be quantized to any tick boundary")
+}
+
+// AdvanceTime jumps Now() and fires jumped-past actions without waiting.
+func TestAdvancingClock_AdvanceTimeFiresImmediately(t *testing.T) {
+	clock, _ := newTestAdvancingClock()
+	clock.Start()
+	defer clock.Stop()
+
+	ch := clock.After(1 * time.Hour)
+	start := clock.Now()
+	clock.AdvanceTime(2 * time.Hour)
+
+	select {
+	case got := <-ch:
+		require.False(t, got.Before(start.Add(2*time.Hour)),
+			"After channel should fire with the new (jumped) logical time, got %v", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("After channel did not fire after AdvanceTime jumped past its due")
 	}
-	return clock, systemTime
+	require.Equal(t, start.Add(2*time.Hour), clock.Now(),
+		"Now() should reflect the manual jump immediately")
+}
+
+// Ticker fires when its period is jumped past.
+func TestAdvancingClock_TickerFiresAfterJump(t *testing.T) {
+	clock, _ := newTestAdvancingClock()
+	clock.Start()
+	defer clock.Stop()
+
+	ticker := clock.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	clock.AdvanceTime(10 * time.Second)
+	// Channel buffer is 1; extra ticks coalesce, per stdlib Ticker semantics.
+	select {
+	case <-ticker.Ch():
+	case <-time.After(2 * time.Second):
+		t.Fatal("ticker did not fire after 10s jump")
+	}
+}
+
+// One AdvanceTime fires every action it jumped past.
+func TestAdvancingClock_MultiplePending(t *testing.T) {
+	clock, _ := newTestAdvancingClock()
+	clock.Start()
+	defer clock.Stop()
+
+	a := clock.After(1 * time.Second)
+	b := clock.After(2 * time.Second)
+	c := clock.After(3 * time.Second)
+
+	clock.AdvanceTime(5 * time.Second)
+
+	deadline := time.After(2 * time.Second)
+	for i, ch := range []<-chan time.Time{a, b, c} {
+		select {
+		case <-ch:
+		case <-deadline:
+			t.Fatalf("After channel %d did not fire", i)
+		}
+	}
+}
+
+// AfterFunc callback runs when AdvanceTime jumps past its due.
+func TestAdvancingClock_AfterFuncCallback(t *testing.T) {
+	clock, _ := newTestAdvancingClock()
+	clock.Start()
+	defer clock.Stop()
+
+	done := make(chan struct{})
+	clock.AfterFunc(1*time.Hour, func() { close(done) })
+	clock.AdvanceTime(1 * time.Hour)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AfterFunc callback did not run after AdvanceTime jumped past due")
+	}
+}
+
+// A stopped timer never fires.
+func TestAdvancingClock_TimerStop(t *testing.T) {
+	clock, _ := newTestAdvancingClock()
+	clock.Start()
+	defer clock.Stop()
+
+	timer := clock.NewTimer(1 * time.Hour)
+	require.True(t, timer.Stop(), "Stop should report active")
+	require.False(t, timer.Stop(), "Stop is idempotent")
+
+	clock.AdvanceTime(2 * time.Hour)
+	select {
+	case <-timer.Ch():
+		t.Fatal("stopped timer must not fire")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// SleepCtx wakes when wall time advances past its duration.
+func TestAdvancingClock_SleepCtx(t *testing.T) {
+	clock, realTime := newTestAdvancingClock()
+	clock.Start()
+	defer clock.Stop()
+
+	done := make(chan error, 1)
+	go func() { done <- clock.SleepCtx(context.Background(), 5*time.Second) }()
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.True(t, clock.WaitForNewPendingAction(waitCtx),
+		"SleepCtx should register a pending timer")
+
+	realTime.AdvanceTime(5 * time.Second)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("SleepCtx did not return after wall time advanced")
+	}
+}
+
+// Concurrent AdvanceTime calls accumulate correctly.
+func TestAdvancingClock_AdvanceTimeConcurrent(t *testing.T) {
+	clock, _ := newTestAdvancingClock()
+	defer clock.Stop()
+
+	start := clock.Now()
+	const goroutines = 32
+	const perGoroutine = 100
+
+	done := make(chan struct{}, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			for j := 0; j < perGoroutine; j++ {
+				clock.AdvanceTime(time.Millisecond)
+			}
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+	require.Equal(t, start.Add(goroutines*perGoroutine*time.Millisecond), clock.Now())
+}
+
+// Ticker.Reset(d) must update the period used for subsequent re-arms, not
+// just the next due time. Matches stdlib time.Ticker.Reset.
+func TestAdvancingClock_TickerResetUpdatesPeriod(t *testing.T) {
+	clock, realTime := newTestAdvancingClock()
+	clock.Start()
+	defer clock.Stop()
+
+	ticker := clock.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+
+	ticker.Reset(1 * time.Second)
+
+	// First tick at the new period.
+	realTime.AdvanceTime(1 * time.Second)
+	select {
+	case <-ticker.Ch():
+	case <-time.After(2 * time.Second):
+		t.Fatal("ticker did not fire at new period after Reset")
+	}
+
+	// Re-arm must also use the new period, not the original 1h.
+	realTime.AdvanceTime(1 * time.Second)
+	select {
+	case <-ticker.Ch():
+	case <-time.After(2 * time.Second):
+		t.Fatal("ticker did not re-arm at new period — Reset failed to update period")
+	}
+}
+
+// AfterFunc must run f in its own goroutine so a slow/blocking callback does
+// not stall other timers on the same clock. Matches stdlib time.AfterFunc.
+func TestAdvancingClock_AfterFuncDoesNotBlockScheduler(t *testing.T) {
+	clock, _ := newTestAdvancingClock()
+	clock.Start()
+	defer clock.Stop()
+
+	block := make(chan struct{})
+	defer close(block)
+
+	clock.AfterFunc(10*time.Millisecond, func() { <-block })
+
+	second := make(chan struct{})
+	clock.AfterFunc(20*time.Millisecond, func() { close(second) })
+
+	clock.AdvanceTime(1 * time.Second)
+
+	select {
+	case <-second:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second AfterFunc did not fire — first callback blocked the scheduler")
+	}
+}
+
+func newTestAdvancingClock() (*AdvancingClock, *DeterministicClock) {
+	systemTime := NewDeterministicClock(time.UnixMilli(1000))
+	return newAdvancingClock(systemTime), systemTime
 }


### PR DESCRIPTION
Replaces the tick-pumped `AdvancingClock` (a `DeterministicClock` advanced by a fixed wall-clock ticker) with a lazy implementation:

- `Now()` = `wallClock.Now() + offset`, with no tick quantisation. Wall time progresses continuously and `AdvanceTime` jumps are visible immediately.
- A single scheduler goroutine sleeps until the next due action and fires everything overdue when woken. `AdvanceTime` signals the scheduler so jumped-past timers fire without waiting.
- `Timer`, `Ticker`, `After`, `AfterFunc`, and `SleepCtx` honour both wall progression and manual jumps. Stop/Reset semantics match the stdlib `time` package — including `Ticker.Reset(d)` updating the period and `AfterFunc` running its callback in its own goroutine.

All callers drop the now-unused `advanceEvery` argument from `NewAdvancingClock`.

While this is more code than the old version which reused DeterministicClock implementations, it is much more realistic so is better suited to being used to enable time travelling sequencers.