### PR TITLE
fix: correct grammar and spelling in comments

### DIFF
--- a/op-acceptance-tests/tests/jovian/bpo2/joviantest/cases.go
+++ b/op-acceptance-tests/tests/jovian/bpo2/joviantest/cases.go
@@ -180,7 +180,7 @@ func (mbf *minBaseFeeEnv) waitForMinBaseFeeConfigChangeOnL2(t devtest.T, expecte
 		return got == expected
 	}, 2*time.Minute, 5*time.Second, "L2 min base fee in block header did not sync within timeout")
 
-	t.Require().Equal(expectedExtraData, eth.BytesMax32(actualBlockExtraData), "block header extradata doesnt match")
+	t.Require().Equal(expectedExtraData, eth.BytesMax32(actualBlockExtraData), "block header extradata doesn't match")
 }
 
 func RunDAFootprint(gt *testing.T, setup SetupFn) {

--- a/op-acceptance-tests/tests/jovian/min_base_fee.go
+++ b/op-acceptance-tests/tests/jovian/min_base_fee.go
@@ -101,7 +101,7 @@ func (mbf *minBaseFeeEnv) waitForMinBaseFeeConfigChangeOnL2(t devtest.T, expecte
 		return got == expected
 	}, 2*time.Minute, 5*time.Second, "L2 min base fee in block header did not sync within timeout")
 
-	t.Require().Equal(expectedExtraData, eth.BytesMax32(actualBlockExtraData), "block header extradata doesnt match")
+	t.Require().Equal(expectedExtraData, eth.BytesMax32(actualBlockExtraData), "block header extradata doesn't match")
 }
 
 // TestMinBaseFee verifies configurable minimum base fee using devstack presets.

--- a/op-service/endpoint/rpc.go
+++ b/op-service/endpoint/rpc.go
@@ -120,7 +120,7 @@ func (url WsURL) WsRPC() string {
 }
 
 // WsOrHttpRPC provides optionality between
-// a websocket RPC endpoint and a HTTP RPC endpoint.
+// a WebSocket RPC endpoint and an HTTP RPC endpoint.
 // The default is the websocket endpoint.
 type WsOrHttpRPC struct {
 	WsURL   string

--- a/op-service/eth/blobs_api_test.go
+++ b/op-service/eth/blobs_api_test.go
@@ -17,7 +17,7 @@ type dataJson struct {
 }
 
 // TestAPIGenesisResponse tests that json unmarshalling a json response from a
-// eth/v1/beacon/genesis beacon node call into a APIGenesisResponse object
+// eth/v1/beacon/genesis beacon node call into an APIGenesisResponse object
 // fills all existing fields with the expected values, thereby confirming that
 // APIGenesisResponse is compatible with the current beacon node API.
 // This also confirms that the [sources.L1BeaconClient] correctly parses
@@ -42,7 +42,7 @@ func TestAPIGenesisResponse(t *testing.T) {
 }
 
 // TestAPIConfigResponse tests that json unmarshalling a json response from a
-// eth/v1/config/spec beacon node call into a APIConfigResponse object
+// eth/v1/config/spec beacon node call into an APIConfigResponse object
 // fills all existing fields with the expected values, thereby confirming that
 // APIGenesisResponse is compatible with the current beacon node API.
 // This also confirms that the [sources.L1BeaconClient] correctly parses
@@ -67,7 +67,7 @@ func TestAPIConfigResponse(t *testing.T) {
 }
 
 // TestAPIGetBlobSidecarsResponse tests that json unmarshalling a json response from a
-// eth/v1/beacon/blob_sidecars/<X> beacon node call into a APIGetBlobSidecarsResponse object
+// eth/v1/beacon/blob_sidecars/<X> beacon node call into an APIGetBlobSidecarsResponse object
 // fills all existing fields with the expected values, thereby confirming that
 // APIGenesisResponse is compatible with the current beacon node API.
 // This also confirms that the [sources.L1BeaconClient] correctly parses

--- a/op-service/rpc/handler.go
+++ b/op-service/rpc/handler.go
@@ -30,7 +30,7 @@ var wildcardHosts = []string{"*"}
 //
 // Custom routes can also be added with AddHandler, these are registered to the underlying http.ServeMux.
 //
-// If more customization is needed, this Handler can be composed in a HTTP stack of your own.
+// If more customization is needed, this Handler can be composed in an HTTP stack of your own.
 // Use http.StripPrefix to clean the URL route prefix that this Handler is registered on (leave no prefix).
 type Handler struct {
 	appVersion     string

--- a/op-service/signer/cli.go
+++ b/op-service/signer/cli.go
@@ -35,7 +35,7 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 		},
 		&cli.StringSliceFlag{
 			Name:    HeadersFlagName,
-			Usage:   "Headers to pass to the remote signer. Format `key=value`. Value can contain any character allowed in a HTTP header. When using env vars, split with commas. When using flags one key value pair per flag.",
+			Usage:   "Headers to pass to the remote signer. Format `key=value`. Value can contain any character allowed in an HTTP header. When using env vars, split with commas. When using flags one key value pair per flag.",
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "HEADER"),
 		},
 	}


### PR DESCRIPTION
## Description
Fixed grammar and spelling errors in code comments and documentation.

## Changes
- Fixed article usage: `a API` → `an API` (3 occurrences)
- Fixed article usage: `a HTTP` → `an HTTP` (3 occurrences)
- Fixed contraction: `doesnt` → `doesn't` (2 occurrences)

## Files Modified
- `op-service/eth/blobs_api_test.go`
- `op-service/endpoint/rpc.go`
- `op-service/rpc/handler.go`
- `op-service/signer/cli.go`
- `op-acceptance-tests/tests/jovian/min_base_fee.go`
- `op-acceptance-tests/tests/jovian/bpo2/joviantest/cases.go`

## Testing
- All changes are in comments/documentation only
- No functional code modified