### PR TITLE
ci(rust): publish kona prestates on kona-client/v* tag push

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1159,3 +1159,21 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - oplabs-network-optimism-io-bucket
+
+  # Kona publish prestate artifacts - on kona-client/v* tag push
+  kona-publish-prestates-on-tag:
+    when: << pipeline.parameters.c-run_release >>
+    jobs:
+      - kona-publish-prestate-artifacts:
+          name: kona-publish-<<matrix.version>>
+          matrix:
+            parameters:
+              version: ["kona-client", "kona-client-int"]
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - oplabs-network-optimism-io-bucket
+          filters:
+            tags:
+              only: /^kona-client\/v.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
Adds a `kona-publish-prestates-on-tag` workflow that runs on `kona-client/v*` tag pushes and uploads hash-named kona prestates to GCS, mirroring the existing op-program tag-publish flow.

- Reuses the existing `kona-publish-prestate-artifacts` matrix job — no script changes; the existing upload code already takes the hash-named path when `<< pipeline.git.branch >>` is empty.
- Workflow is gated by `c-run_release` (already set on every tag push) with a job-level tag filter `^kona-client\/v.*` and `branches: ignore: /.*/` so it no-ops on PR/develop/merge-queue pushes.

**Testing**: since tags can't be deleted I can't easily test by creating a throwaway tag on this branch. I recommend just testing it with the next kona-client tag. If it fails we can still manually upload the prestate.