### PR TITLE
docs(chain-operators): refocus prestate tutorials on kona-client

### DIFF
--- a/docs/public-docs/chain-operators/tutorials/absolute-prestate.mdx
+++ b/docs/public-docs/chain-operators/tutorials/absolute-prestate.mdx
@@ -1,137 +1,65 @@
 ---
 title: "Generating absolute prestate and preimage files"
-description: "Generate and verify the kona-client absolute prestate and preimage files needed for permissionless fault proofs."
+description: "Generate, verify, and configure the kona-client absolute prestate for permissionless fault proofs."
 ---
 
 # Overview
 
-Permissionless fault proofs are a critical component of the OP Stack's security model. They allow anyone to challenge invalid state proposals, ensuring the correctness of L2 to L1 withdrawals without relying on trusted third parties. To enable this functionality, chain operators must generate and maintain the necessary absolute prestate and preimage files.
-
-The absolute prestate is a commitment to the initial state of the fault proof program. The preimage is the serialized binary representation of that program state. Together, they let `op-challenger` participate in dispute games when challenging invalid claims.
+The absolute prestate is the on-chain commitment to a specific build of `kona-client`. The matching preimage (a gzipped binary) is what `op-challenger` runs at dispute time. This guide is the minimal reproducer.
 
 <Info>
-  As of [Upgrade 19](/notices/upgrade-19), `CANNON_KONA` (game type `8`, running `kona-client`) is the respected game type for permissionless fault proofs. `op-program` (game type `1`, `CANNON`) is no longer supported for new fault proofs and is retained only to resolve in-flight games created before the upgrade. This tutorial covers the canonical kona-client flow.
+  As of [Upgrade 19](/notices/upgrade-19), `CANNON_KONA` (game type `8`) is the respected game type for permissionless fault proofs. `op-program` is retained only to resolve in-flight pre-U19 `CANNON` games — see [op-program (archived)](/chain-operators/tutorials/archive/op-program-prestate). If your chain is not yet in the public Superchain Registry, follow [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate) instead.
 </Info>
 
 ## Prerequisites
 
-Before starting, ensure you have:
-
 - [Docker](https://docs.docker.com/engine/install/) running
 - [`just`](https://github.com/casey/just) installed
 
-## Official prestate hashes for superchain-registry chains
-
-The superchain-registry maintains official absolute prestate hashes for chains that are part of the registry. These prestates include the configurations of chains that were in the superchain-registry at the time the prestate was created.
-
-<Info>
-  A prestate listed in the superchain-registry may not be suitable for your chain if:
-
-  - Your chain was added to the registry after the prestate was created
-  - The configuration for your chain has been updated since the prestate was created
-
-  Before using a prestate from the registry, verify that it covers your chain by reproducing it locally (steps below). When in doubt, [generate a custom prestate](/chain-operators/tutorials/kona-custom-prestate) with your specific chain configuration.
-</Info>
-
-You can find the latest prestate tags in the [Superchain Registry standard prestates file](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml). Look for entries of type `cannon64-kona` for the standard kona-client prestate, and `cannon64-kona-interop` for the interop variant.
-
-## Generating the absolute prestate
+## Generate and verify the prestate
 
 <Steps>
-  <Step title="Clone and checkout the tagged version">
-    Clone the Optimism monorepo and check out the appropriate [release tag](https://github.com/ethereum-optimism/optimism/tags) for `kona-client`:
-
-    ```shellscript
+  <Step title="Check out the release tag">
+    ```bash
     git clone https://github.com/ethereum-optimism/optimism.git
     cd optimism
-    # Use the latest finalized release that matches your chain's kona-node deployment
     git checkout kona-node/v<VERSION>
     ```
   </Step>
-  <Step title="Generate the absolute prestate">
-    Run the following command from the root of the monorepo:
 
+  <Step title="Build the prestate">
     ```bash
     just reproducible-prestate-kona
     ```
 
-    The build runs in Docker and produces the kona-client ELF, the cannon-converted initial state, and a proof file containing the absolute prestate hash. You can read the hash with:
+    The build runs in Docker and writes artifacts to `rust/kona/prestate-artifacts-cannon/`.
+  </Step>
 
+  <Step title="Read and verify the hash">
     ```bash
     jq -r .pre rust/kona/prestate-artifacts-cannon/prestate-proof.json
     ```
 
-    Verify that the printed hash matches the corresponding `cannon64-kona` entry in [`standard-prestates.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml). A match means your build environment is honest and the prestate is the canonical one for your release tag.
-  </Step>
-  <Step title="Prepare the preimage file">
-    After generating the prestate, the preimage file is located at `rust/kona/prestate-artifacts-cannon/prestate.bin.gz`. The build also produces a hash-named copy at `rust/kona/prestate-artifacts-cannon/0x<HASH>.bin.gz`. Either way, the file you upload should be named after its hash so `op-challenger` can resolve it on demand:
-
-    ```shellscript
-    ls rust/kona/prestate-artifacts-cannon/
-    # prestate.bin.gz  0x<HASH>.bin.gz  prestate-proof.json  meta.json  kona-client-elf
-    ```
-
-    Upload the hash-named `.bin.gz` to wherever you serve preimage files for your `op-challenger` instances.
+    Match the printed hash against the `cannon64-kona` entry for your release tag in [`standard-prestates.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml). A match confirms your build environment is honest.
   </Step>
 </Steps>
 
-## Custom chain configurations
+## Configure op-challenger
 
-If your chain is **not yet in the public Superchain Registry**, the standard prestate does not embed your chain configuration and is not suitable as-is. You need a custom build with your `chainList.json` + `configs.json` baked in.
+Upload the hash-named file `rust/kona/prestate-artifacts-cannon/0x<HASH>.bin.gz` (produced by the build) to a location reachable by your `op-challenger` instances, then point `op-challenger` at it:
 
-See [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate) for the full custom-config workflow.
+```bash
+-e OP_CHALLENGER_TRACE_TYPE=cannon-kona,permissioned
+-e OP_CHALLENGER_CANNON_KONA_PRESTATES_URL=<HTTP_URL_PATH_TO_PRESTATES>
+-e OP_CHALLENGER_CANNON_KONA_ROLLUP_CONFIG=<PATH_TO_ROLLUP_CONFIG>
+-e OP_CHALLENGER_CANNON_KONA_L2_GENESIS=<PATH_TO_L2_GENESIS>
+-e OP_CHALLENGER_GAME_FACTORY_ADDRESS=<YOUR_DISPUTE_GAME_FACTORY>
+```
 
-## Deploying and configuring with the absolute prestate
-
-After generating (or sourcing) the absolute prestate and preimage files, configure `op-challenger` to use them.
-
-<Steps>
-  <Step title="Upload the preimage file">
-    Upload the hash-named `.bin.gz` to a location reachable by your `op-challenger` instances — typically a GCS bucket or HTTP endpoint. Files must be named by absolute prestate hash so the challenger can resolve them per dispute.
-  </Step>
-  <Step title="Configure op-challenger">
-    Point `op-challenger` at the prestates URL and your chain's runtime configuration. With `CANNON_KONA` as the respected game type, the relevant flags are:
-
-    ```bash
-    docker run -d --name op-challenger \
-      -e OP_CHALLENGER_TRACE_TYPE=cannon-kona,permissioned \
-      -e OP_CHALLENGER_CANNON_KONA_PRESTATES_URL=<HTTP_URL_PATH_TO_PRESTATES> \
-      -e OP_CHALLENGER_CANNON_KONA_ROLLUP_CONFIG=<PATH_TO_ROLLUP_CONFIG> \
-      -e OP_CHALLENGER_CANNON_KONA_L2_GENESIS=<PATH_TO_L2_GENESIS> \
-      -e OP_CHALLENGER_L1_ETH_RPC=<YOUR_L1_RPC_URL> \
-      -e OP_CHALLENGER_GAME_FACTORY_ADDRESS=<YOUR_DISPUTE_GAME_FACTORY> \
-      -e OP_CHALLENGER_PRIVATE_KEY=<YOUR_PRIVATE_KEY_OR_USE_WALLET_SIGNER> \
-      -e OP_CHALLENGER_NETWORK=<YOUR_NETWORK> \
-      us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger:latest
-    ```
-
-    The `*_PRESTATES_URL` is a directory URL; the challenger appends `/0x<hash>.bin.gz` automatically when a dispute references that hash. `*_ROLLUP_CONFIG` and `*_L2_GENESIS` supply your chain's configuration to `kona-client` at runtime.
-
-    <Info>
-      If you have prestate files stored locally instead of behind an HTTP URL, mount them as a Docker volume and use `file:///prestates` as the URL. Ensure files are named by hash (e.g. `0x03e548f68eca78e36554ed4f0e05629e1f30bdb2d2b108efecd40b5568d3426c.bin.gz`).
-    </Info>
-
-    <Info>
-      If you're not using the standard OP Labs `op-challenger` Docker image, also set the `kona-host` binary path:
-      ```bash
-      -e OP_CHALLENGER_CANNON_KONA_SERVER=/path/to/kona-host
-      ```
-      Build `kona-host` from the same release as your configured cannon-kona prestate.
-    </Info>
-  </Step>
-</Steps>
-
-<Info>
-  - Always use the latest `op-challenger` release — see the [release page](https://github.com/ethereum-optimism/optimism/releases).
-  - If your chain enables interop, also configure the `cannon-kona-interop` trace type and its associated prestate URL. The interop variant is built and tracked separately under `cannon64-kona-interop` entries in `standard-prestates.toml`.
-</Info>
-
-## op-program (legacy)
-
-For chains still operating an in-flight `CANNON` (game type `1`) dispute game from before Upgrade 19, the legacy op-program prestate flow is preserved at [Generating an op-program absolute prestate (archived)](/chain-operators/tutorials/archive/op-program-prestate). No new chains should configure op-program; it is retained only to allow pre-existing games to resolve cleanly.
+The challenger appends `/0x<hash>.bin.gz` to `*_PRESTATES_URL` to resolve the right binary per dispute.
 
 ## Next Steps
 
-- [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate) — the advanced flow for chains not yet in the Superchain Registry.
+- [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate) — for chains not yet in the Superchain Registry.
 - [Migrating to permissionless fault proofs](/chain-operators/tutorials/migrating-permissionless).
 - [Fault proofs explainer](/op-stack/fault-proofs/explainer).

--- a/docs/public-docs/chain-operators/tutorials/absolute-prestate.mdx
+++ b/docs/public-docs/chain-operators/tutorials/absolute-prestate.mdx
@@ -128,7 +128,7 @@ After generating (or sourcing) the absolute prestate and preimage files, configu
 
 ## op-program (legacy)
 
-For chains still operating an in-flight `CANNON` (game type `1`) dispute game from before Upgrade 19, the legacy op-program prestate flow is documented in the [archived Upgrade 18 notice](/notices/archive/upgrade-18#for-permissionless-fault-proof-enabled-chains). No new chains should configure op-program; it is retained only to allow pre-existing games to resolve cleanly.
+For chains still operating an in-flight `CANNON` (game type `1`) dispute game from before Upgrade 19, the legacy op-program prestate flow is preserved at [Generating an op-program absolute prestate (archived)](/chain-operators/tutorials/archive/op-program-prestate). No new chains should configure op-program; it is retained only to allow pre-existing games to resolve cleanly.
 
 ## Next Steps
 

--- a/docs/public-docs/chain-operators/tutorials/absolute-prestate.mdx
+++ b/docs/public-docs/chain-operators/tutorials/absolute-prestate.mdx
@@ -8,7 +8,7 @@ description: "Generate, verify, and configure the kona-client absolute prestate 
 The absolute prestate is the on-chain commitment to a specific build of `kona-client`. The matching preimage (a gzipped binary) is what `op-challenger` runs at dispute time. This guide is the minimal reproducer.
 
 <Info>
-  As of [Upgrade 19](/notices/upgrade-19), `CANNON_KONA` (game type `8`) is the respected game type for permissionless fault proofs. `op-program` is retained only to resolve in-flight pre-U19 `CANNON` games — see [op-program (archived)](/chain-operators/tutorials/archive/op-program-prestate). If your chain is not yet in the public Superchain Registry, follow [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate) instead.
+  As of [Upgrade 19](/notices/upgrade-19), `CANNON_KONA` (game type `8`) is the respected game type for permissionless fault proofs. If your chain is not yet in the public Superchain Registry, follow [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate) instead.
 </Info>
 
 ## Prerequisites
@@ -46,17 +46,14 @@ The absolute prestate is the on-chain commitment to a specific build of `kona-cl
 
 ## Configure op-challenger
 
-Upload the hash-named file `rust/kona/prestate-artifacts-cannon/0x<HASH>.bin.gz` (produced by the build) to a location reachable by your `op-challenger` instances, then point `op-challenger` at it:
+Upload the hash-named file `rust/kona/prestate-artifacts-cannon/0x<HASH>.bin.gz` (produced by the build) to a location reachable by your `op-challenger` instances, then add the kona-specific env vars to your existing challenger config:
 
 ```bash
--e OP_CHALLENGER_TRACE_TYPE=cannon-kona,permissioned
--e OP_CHALLENGER_CANNON_KONA_PRESTATES_URL=<HTTP_URL_PATH_TO_PRESTATES>
--e OP_CHALLENGER_CANNON_KONA_ROLLUP_CONFIG=<PATH_TO_ROLLUP_CONFIG>
--e OP_CHALLENGER_CANNON_KONA_L2_GENESIS=<PATH_TO_L2_GENESIS>
--e OP_CHALLENGER_GAME_FACTORY_ADDRESS=<YOUR_DISPUTE_GAME_FACTORY>
+OP_CHALLENGER_TRACE_TYPE=cannon-kona,permissioned
+OP_CHALLENGER_CANNON_KONA_PRESTATES_URL=<HTTP_URL_PATH_TO_PRESTATES>
 ```
 
-The challenger appends `/0x<hash>.bin.gz` to `*_PRESTATES_URL` to resolve the right binary per dispute.
+The challenger appends `/0x<hash>.bin.gz` to `*_PRESTATES_URL` to resolve the right binary per dispute. Your existing `OP_CHALLENGER_ROLLUP_CONFIG`, `OP_CHALLENGER_L2_GENESIS`, and `OP_CHALLENGER_GAME_FACTORY_ADDRESS` continue to apply unchanged.
 
 ## Next Steps
 

--- a/docs/public-docs/chain-operators/tutorials/absolute-prestate.mdx
+++ b/docs/public-docs/chain-operators/tutorials/absolute-prestate.mdx
@@ -1,160 +1,137 @@
 ---
 title: "Generating absolute prestate and preimage files"
-description: "A high-level guide on how to generate the absolute prestate and preimage necessary for running cannon/permissionless proofs."
+description: "Generate and verify the kona-client absolute prestate and preimage files needed for permissionless fault proofs."
 ---
 
 # Overview
 
-Permissionless fault proofs are a critical component of the OP Stack's security model. They allow anyone to challenge invalid state proposals, ensuring the correctness of L2 to L1 withdrawals without relying on trusted third parties. To enable this functionality, chain operators must generate and maintain the necessary absolute prestate and preimage files. The absolute prestate is a commitment to the initial state of the fault proof program, and the preimage is the serialized binary representation of this program state. These files are essential for the op-challenger tool to participate in dispute games when challenging invalid claims.
+Permissionless fault proofs are a critical component of the OP Stack's security model. They allow anyone to challenge invalid state proposals, ensuring the correctness of L2 to L1 withdrawals without relying on trusted third parties. To enable this functionality, chain operators must generate and maintain the necessary absolute prestate and preimage files.
+
+The absolute prestate is a commitment to the initial state of the fault proof program. The preimage is the serialized binary representation of that program state. Together, they let `op-challenger` participate in dispute games when challenging invalid claims.
+
+<Info>
+  As of [Upgrade 19](/notices/upgrade-19), `CANNON_KONA` (game type `8`, running `kona-client`) is the respected game type for permissionless fault proofs. `op-program` (game type `1`, `CANNON`) is no longer supported for new fault proofs and is retained only to resolve in-flight games created before the upgrade. This tutorial covers the canonical kona-client flow.
+</Info>
 
 ## Prerequisites
 
 Before starting, ensure you have:
 
 - [Docker](https://docs.docker.com/engine/install/) running
+- [`just`](https://github.com/casey/just) installed
 
 ## Official prestate hashes for superchain-registry chains
 
 The superchain-registry maintains official absolute prestate hashes for chains that are part of the registry. These prestates include the configurations of chains that were in the superchain-registry at the time the prestate was created.
 
 <Info>
-  Important: A prestate listed in the superchain-registry may not be suitable for your chain if:
+  A prestate listed in the superchain-registry may not be suitable for your chain if:
 
   - Your chain was added to the registry after the prestate was created
   - The configuration for your chain has been updated since the prestate was created
 
-  Before using a prestate from the registry, verify that it contains the latest configuration for your chain.
-
-  When in doubt, generating your own prestate with your specific chain configuration is the safest approach.
+  Before using a prestate from the registry, verify that it covers your chain by reproducing it locally (steps below). When in doubt, [generate a custom prestate](/chain-operators/tutorials/kona-custom-prestate) with your specific chain configuration.
 </Info>
 
-You can find the latest prestate tags in the [Superchain registry](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml).
+You can find the latest prestate tags in the [Superchain Registry standard prestates file](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml). Look for entries of type `cannon64-kona` for the standard kona-client prestate, and `cannon64-kona-interop` for the interop variant.
 
 ## Generating the absolute prestate
 
 <Steps>
   <Step title="Clone and checkout the tagged version">
-    First, clone the Optimism monorepo and check out the appropriate [release tag](https://github.com/ethereum-optimism/optimism/tags) for op-program:
+    Clone the Optimism monorepo and check out the appropriate [release tag](https://github.com/ethereum-optimism/optimism/tags) for `kona-client`:
 
     ```shellscript
     git clone https://github.com/ethereum-optimism/optimism.git
     cd optimism
-    # For production chains, use the latest finalized release (not an rc)
-    git checkout op-program/v1.6.1  # Use the latest stable version
-    
+    # Use the latest finalized release that matches your chain's kona-node deployment
+    git checkout kona-node/v<VERSION>
     ```
-  </Step>
-  <Step title="(Optional) Provide chain configuration and genesis files">
-    For chains that are not included in the superchain-registry, you'll need to provide the chain rollup configuration file and the L2 genesis file. Add the `rollup.json` and `l2-genesis.json` to the monorepo at `optimism/op-program/chainconfig/configs/<L2_CHAIN_ID>-rollup.json` and `optimism/op-program/chainconfig/configs/<L2_CHAIN_ID>-genesis-l2.json` respectively.
   </Step>
   <Step title="Generate the absolute prestate">
     Run the following command from the root of the monorepo:
 
     ```bash
-    make reproducible-prestate
+    just reproducible-prestate-kona
     ```
 
-    You should see the following logs at the end of the command’s output:
+    The build runs in Docker and produces the kona-client ELF, the cannon-converted initial state, and a proof file containing the absolute prestate hash. You can read the hash with:
 
-    ```log
-    
-    -------------------- Production Prestates --------------------
-    
-    Cannon64 Absolute prestate hash: 
-    0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b72e4fc8
-    
-    -------------------- Experimental Prestates --------------------
-    
-    CannonInterop Absolute prestate hash: 
-    0x03fc3b4d091527d53f1ff369ea8ed65e5e17cc7fc98ebf75380238151cdc949c
-    
-    Cannon64Next Absolute prestate hash: 
-    0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b72e4fc8
-    
+    ```bash
+    jq -r .pre rust/kona/prestate-artifacts-cannon/prestate-proof.json
     ```
 
-    The output will display production and experimental prestate hashes:
-
-    - **Production prestates**: Contains the `Cannon64` prestate, which is the current production absolute prestate hash for the 64-bit version of Cannon. This is the hash you should use for permissionless fault proofs.
-    - **Experimental prestates**: These contain prestates for versions that are in development and not yet ready for production use.
+    Verify that the printed hash matches the corresponding `cannon64-kona` entry in [`standard-prestates.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml). A match means your build environment is honest and the prestate is the canonical one for your release tag.
   </Step>
   <Step title="Prepare the preimage file">
-    After generating the prestate, the preimage file will be located in `op-program/bin/prestate-mt64.bin.gz`. The exact name might vary based on the version. Rename this file to include the prestate hash:
+    After generating the prestate, the preimage file is located at `rust/kona/prestate-artifacts-cannon/prestate.bin.gz`. The build also produces a hash-named copy at `rust/kona/prestate-artifacts-cannon/0x<HASH>.bin.gz`. Either way, the file you upload should be named after its hash so `op-challenger` can resolve it on demand:
 
     ```shellscript
-    cd op-program/bin
-    mv prestate-mt64.bin.gz [CANNON64_PRESTATE_HASH].bin.gz
+    ls rust/kona/prestate-artifacts-cannon/
+    # prestate.bin.gz  0x<HASH>.bin.gz  prestate-proof.json  meta.json  kona-client-elf
     ```
 
-    Replace `[CANNON64_PRESTATE_HASH]` with the actual `Cannon64` absolute prestate hash value from the output. This file needs to be uploaded to a location that's accessible by your op-challenger instances.
+    Upload the hash-named `.bin.gz` to wherever you serve preimage files for your `op-challenger` instances.
   </Step>
 </Steps>
+
+## Custom chain configurations
+
+If your chain is **not yet in the public Superchain Registry**, the standard prestate does not embed your chain configuration and is not suitable as-is. You need a custom build with your `chainList.json` + `configs.json` baked in.
+
+See [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate) for the full custom-config workflow.
 
 ## Deploying and configuring with the absolute prestate
 
-After generating the absolute prestate and preimage files, you'll need to:
+After generating (or sourcing) the absolute prestate and preimage files, configure `op-challenger` to use them.
 
 <Steps>
-  <Step title="Upload preimage file">
-    Upload the preimage file to a location accessible by your op-challenger instances
+  <Step title="Upload the preimage file">
+    Upload the hash-named `.bin.gz` to a location reachable by your `op-challenger` instances — typically a GCS bucket or HTTP endpoint. Files must be named by absolute prestate hash so the challenger can resolve them per dispute.
   </Step>
   <Step title="Configure op-challenger">
-    Configure the op-challenger to use the generated prestate. There are two ways to provide prestates:
-  </Step>
-</Steps>
-
-<Steps>
-  <Step title="Option 1: Using HTTP URL">
-    If your prestate files are hosted on a web server, you can simply provide the URL to the directory containing those files:
+    Point `op-challenger` at the prestates URL and your chain's runtime configuration. With `CANNON_KONA` as the respected game type, the relevant flags are:
 
     ```bash
     docker run -d --name op-challenger \
-     -e OP_CHALLENGER_TRACE_TYPE=permissioned,cannon \
-     -e OP_CHALLENGER_PRESTATES_URL=<HTTP_URL_PATH_TO_PRESTATE> \
-     -e OP_CHALLENGER_L1_ETH_RPC=<YOUR_L1_RPC_URL> \
-     -e OP_CHALLENGER_GAME_FACTORY_ADDRESS=<YOUR_DISPUTE_GAME_FACTORY> \
-     -e OP_CHALLENGER_PRIVATE_KEY=<YOUR_PRIVATE_KEY_OR_USE_WALLET_SIGNER> \
-     -e OP_CHALLENGER_NETWORK=<YOUR_NETWORK> \
-     -e OP_CHALLENGER_CANNON_ROLLUP_CONFIG=<PATH_TO_ROLLUP_CONFIG> \
-     -e OP_CHALLENGER_CANNON_L2_GENESIS=<PATH_TO_GENESIS_CONFIG> \
-     us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger:latest
-    ```
-
-    <Info>
-      When using an HTTP URL, no volume mount is required. The challenger will download the prestate files as needed.
-    </Info>
-  </Step>
-  <Step title="Option 2: Using local files">
-    If you have prestate files stored locally, you'll need to mount them as a volume and use the `file://` protocol:
-
-    ```bash
-    docker run -d --name op-challenger \
-      -e OP_CHALLENGER_TRACE_TYPE=permissioned,cannon \
-      -e OP_CHALLENGER_PRESTATES_URL=file:///prestates \
+      -e OP_CHALLENGER_TRACE_TYPE=cannon-kona,permissioned \
+      -e OP_CHALLENGER_CANNON_KONA_PRESTATES_URL=<HTTP_URL_PATH_TO_PRESTATES> \
+      -e OP_CHALLENGER_CANNON_KONA_ROLLUP_CONFIG=<PATH_TO_ROLLUP_CONFIG> \
+      -e OP_CHALLENGER_CANNON_KONA_L2_GENESIS=<PATH_TO_L2_GENESIS> \
       -e OP_CHALLENGER_L1_ETH_RPC=<YOUR_L1_RPC_URL> \
       -e OP_CHALLENGER_GAME_FACTORY_ADDRESS=<YOUR_DISPUTE_GAME_FACTORY> \
       -e OP_CHALLENGER_PRIVATE_KEY=<YOUR_PRIVATE_KEY_OR_USE_WALLET_SIGNER> \
       -e OP_CHALLENGER_NETWORK=<YOUR_NETWORK> \
-      -e OP_CHALLENGER_CANNON_ROLLUP_CONFIG=<PATH_TO_ROLLUP_CONFIG> \
-      -e OP_CHALLENGER_CANNON_L2_GENESIS=<PATH_TO_GENESIS_CONFIG> \
-      -v /path/to/local/prestates:/prestates \
       us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger:latest
     ```
 
+    The `*_PRESTATES_URL` is a directory URL; the challenger appends `/0x<hash>.bin.gz` automatically when a dispute references that hash. `*_ROLLUP_CONFIG` and `*_L2_GENESIS` supply your chain's configuration to `kona-client` at runtime.
+
     <Info>
-      When using local files, ensure your prestate files are in the mounted directory and properly named with their hash (e.g., `0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b72e4fc8.bin.gz`).
+      If you have prestate files stored locally instead of behind an HTTP URL, mount them as a Docker volume and use `file:///prestates` as the URL. Ensure files are named by hash (e.g. `0x03e548f68eca78e36554ed4f0e05629e1f30bdb2d2b108efecd40b5568d3426c.bin.gz`).
+    </Info>
+
+    <Info>
+      If you're not using the standard OP Labs `op-challenger` Docker image, also set the `kona-host` binary path:
+      ```bash
+      -e OP_CHALLENGER_CANNON_KONA_SERVER=/path/to/kona-host
+      ```
+      Build `kona-host` from the same release as your configured cannon-kona prestate.
     </Info>
   </Step>
 </Steps>
 
 <Info>
-  - Ensure you're using the latest op-challenger version, see the [release page](https://github.com/ethereum-optimism/optimism/release).
-  - If your chain uses interoperability features, you'll need to add a `depsets.json` file to the `op-program/chainconfig/configs` directory.
-  - This file contains dependency set configurations. Use the same dependency set definition your interop-enabled chain is already configured with.
+  - Always use the latest `op-challenger` release — see the [release page](https://github.com/ethereum-optimism/optimism/releases).
+  - If your chain enables interop, also configure the `cannon-kona-interop` trace type and its associated prestate URL. The interop variant is built and tracked separately under `cannon64-kona-interop` entries in `standard-prestates.toml`.
 </Info>
+
+## op-program (legacy)
+
+For chains still operating an in-flight `CANNON` (game type `1`) dispute game from before Upgrade 19, the legacy op-program prestate flow is documented in the [archived Upgrade 18 notice](/notices/archive/upgrade-18#for-permissionless-fault-proof-enabled-chains). No new chains should configure op-program; it is retained only to allow pre-existing games to resolve cleanly.
 
 ## Next Steps
 
-- Check out the [migrating to permissionless fault proofs guide](/chain-operators/tutorials/migrating-permissionless).
-- Read the [Fault proofs explainer](/op-stack/fault-proofs/explainer).
-- [Fault proofs explainer](/op-stack/fault-proofs/explainer)
+- [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate) — the advanced flow for chains not yet in the Superchain Registry.
+- [Migrating to permissionless fault proofs](/chain-operators/tutorials/migrating-permissionless).
+- [Fault proofs explainer](/op-stack/fault-proofs/explainer).

--- a/docs/public-docs/chain-operators/tutorials/archive/op-program-prestate.mdx
+++ b/docs/public-docs/chain-operators/tutorials/archive/op-program-prestate.mdx
@@ -9,7 +9,7 @@ description: "Archived: legacy op-program prestate generation flow for chains re
   For all current work, see [Generating absolute prestate and preimage files](/chain-operators/tutorials/absolute-prestate) (kona-client) and, if your chain is not yet in the Superchain Registry, [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate).
 </Warning>
 
-# Overview
+## Overview
 
 Permissionless fault proofs are a critical component of the OP Stack's security model. They allow anyone to challenge invalid state proposals, ensuring the correctness of L2 to L1 withdrawals without relying on trusted third parties. To enable this functionality, chain operators must generate and maintain the necessary absolute prestate and preimage files. The absolute prestate is a commitment to the initial state of the fault proof program, and the preimage is the serialized binary representation of this program state. These files are essential for the op-challenger tool to participate in dispute games when challenging invalid claims.
 
@@ -42,12 +42,12 @@ You can find the latest prestate tags in the [Superchain registry](https://githu
   <Step title="Clone and checkout the tagged version">
     First, clone the Optimism monorepo and check out the appropriate [release tag](https://github.com/ethereum-optimism/optimism/tags) for op-program:
 
-    ```shellscript
+    ```bash
     git clone https://github.com/ethereum-optimism/optimism.git
     cd optimism
-    # For production chains, use the latest finalized release (not an rc)
-    git checkout op-program/v1.6.1  # Use the latest stable version
-    
+    # Check out the op-program version that matches the in-flight CANNON game you
+    # need to resolve. Use the version the game's original prestate was generated with.
+    git checkout op-program/v1.6.1
     ```
   </Step>
   <Step title="(Optional) Provide chain configuration and genesis files">
@@ -63,7 +63,6 @@ You can find the latest prestate tags in the [Superchain registry](https://githu
     You should see the following logs at the end of the command’s output:
 
     ```log
-    
     -------------------- Production Prestates --------------------
     
     Cannon64 Absolute prestate hash: 
@@ -76,7 +75,6 @@ You can find the latest prestate tags in the [Superchain registry](https://githu
     
     Cannon64Next Absolute prestate hash: 
     0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b72e4fc8
-    
     ```
 
     The output will display production and experimental prestate hashes:
@@ -87,12 +85,12 @@ You can find the latest prestate tags in the [Superchain registry](https://githu
   <Step title="Prepare the preimage file">
     After generating the prestate, the preimage file will be located in `op-program/bin/prestate-mt64.bin.gz`. The exact name might vary based on the version. Rename this file to include the prestate hash:
 
-    ```shellscript
+    ```bash
     cd op-program/bin
-    mv prestate-mt64.bin.gz [CANNON64_PRESTATE_HASH].bin.gz
+    mv prestate-mt64.bin.gz <cannon64-prestate-hash>.bin.gz
     ```
 
-    Replace `[CANNON64_PRESTATE_HASH]` with the actual `Cannon64` absolute prestate hash value from the output. This file needs to be uploaded to a location that's accessible by your op-challenger instances.
+    Replace `<cannon64-prestate-hash>` with the actual `Cannon64` absolute prestate hash value from the output. This file needs to be uploaded to a location that's accessible by your op-challenger instances.
   </Step>
 </Steps>
 
@@ -154,12 +152,12 @@ After generating the absolute prestate and preimage files, you'll need to:
 </Steps>
 
 <Info>
-  - Ensure you're using the latest op-challenger version, see the [release page](https://github.com/ethereum-optimism/optimism/release).
+  - Ensure you're using the latest op-challenger version, see the [release page](https://github.com/ethereum-optimism/optimism/releases).
   - If your chain uses interoperability features, you'll need to add a `depsets.json` file to the `op-program/chainconfig/configs` directory.
   - This file contains dependency set configurations. Use the same dependency set definition your interop-enabled chain is already configured with.
 </Info>
 
-## Next Steps
+## Next steps
 
 - Check out the [migrating to permissionless fault proofs guide](/chain-operators/tutorials/migrating-permissionless).
 - Read the [Fault proofs explainer](/op-stack/fault-proofs/explainer).

--- a/docs/public-docs/chain-operators/tutorials/archive/op-program-prestate.mdx
+++ b/docs/public-docs/chain-operators/tutorials/archive/op-program-prestate.mdx
@@ -1,0 +1,165 @@
+---
+title: "Generating an op-program absolute prestate (archived)"
+description: "Archived: legacy op-program prestate generation flow for chains resolving in-flight CANNON game type 1 disputes."
+---
+
+<Warning>
+  **Archived.** As of [Upgrade 19](/notices/upgrade-19), `CANNON_KONA` (game type `8`) is the respected game type for permissionless fault proofs and `op-program` (game type `1`, `CANNON`) is no longer supported for new fault proofs. This page is retained only for chains that still need to resolve in-flight `CANNON` games created before Upgrade 19.
+
+  For all current work, see [Generating absolute prestate and preimage files](/chain-operators/tutorials/absolute-prestate) (kona-client) and, if your chain is not yet in the Superchain Registry, [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate).
+</Warning>
+
+# Overview
+
+Permissionless fault proofs are a critical component of the OP Stack's security model. They allow anyone to challenge invalid state proposals, ensuring the correctness of L2 to L1 withdrawals without relying on trusted third parties. To enable this functionality, chain operators must generate and maintain the necessary absolute prestate and preimage files. The absolute prestate is a commitment to the initial state of the fault proof program, and the preimage is the serialized binary representation of this program state. These files are essential for the op-challenger tool to participate in dispute games when challenging invalid claims.
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- [Docker](https://docs.docker.com/engine/install/) running
+
+## Official prestate hashes for superchain-registry chains
+
+The superchain-registry maintains official absolute prestate hashes for chains that are part of the registry. These prestates include the configurations of chains that were in the superchain-registry at the time the prestate was created.
+
+<Info>
+  Important: A prestate listed in the superchain-registry may not be suitable for your chain if:
+
+  - Your chain was added to the registry after the prestate was created
+  - The configuration for your chain has been updated since the prestate was created
+
+  Before using a prestate from the registry, verify that it contains the latest configuration for your chain.
+
+  When in doubt, generating your own prestate with your specific chain configuration is the safest approach.
+</Info>
+
+You can find the latest prestate tags in the [Superchain registry](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml).
+
+## Generating the absolute prestate
+
+<Steps>
+  <Step title="Clone and checkout the tagged version">
+    First, clone the Optimism monorepo and check out the appropriate [release tag](https://github.com/ethereum-optimism/optimism/tags) for op-program:
+
+    ```shellscript
+    git clone https://github.com/ethereum-optimism/optimism.git
+    cd optimism
+    # For production chains, use the latest finalized release (not an rc)
+    git checkout op-program/v1.6.1  # Use the latest stable version
+    
+    ```
+  </Step>
+  <Step title="(Optional) Provide chain configuration and genesis files">
+    For chains that are not included in the superchain-registry, you'll need to provide the chain rollup configuration file and the L2 genesis file. Add the `rollup.json` and `l2-genesis.json` to the monorepo at `optimism/op-program/chainconfig/configs/<L2_CHAIN_ID>-rollup.json` and `optimism/op-program/chainconfig/configs/<L2_CHAIN_ID>-genesis-l2.json` respectively.
+  </Step>
+  <Step title="Generate the absolute prestate">
+    Run the following command from the root of the monorepo:
+
+    ```bash
+    make reproducible-prestate
+    ```
+
+    You should see the following logs at the end of the command’s output:
+
+    ```log
+    
+    -------------------- Production Prestates --------------------
+    
+    Cannon64 Absolute prestate hash: 
+    0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b72e4fc8
+    
+    -------------------- Experimental Prestates --------------------
+    
+    CannonInterop Absolute prestate hash: 
+    0x03fc3b4d091527d53f1ff369ea8ed65e5e17cc7fc98ebf75380238151cdc949c
+    
+    Cannon64Next Absolute prestate hash: 
+    0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b72e4fc8
+    
+    ```
+
+    The output will display production and experimental prestate hashes:
+
+    - **Production prestates**: Contains the `Cannon64` prestate, which is the current production absolute prestate hash for the 64-bit version of Cannon. This is the hash you should use for permissionless fault proofs.
+    - **Experimental prestates**: These contain prestates for versions that are in development and not yet ready for production use.
+  </Step>
+  <Step title="Prepare the preimage file">
+    After generating the prestate, the preimage file will be located in `op-program/bin/prestate-mt64.bin.gz`. The exact name might vary based on the version. Rename this file to include the prestate hash:
+
+    ```shellscript
+    cd op-program/bin
+    mv prestate-mt64.bin.gz [CANNON64_PRESTATE_HASH].bin.gz
+    ```
+
+    Replace `[CANNON64_PRESTATE_HASH]` with the actual `Cannon64` absolute prestate hash value from the output. This file needs to be uploaded to a location that's accessible by your op-challenger instances.
+  </Step>
+</Steps>
+
+## Deploying and configuring with the absolute prestate
+
+After generating the absolute prestate and preimage files, you'll need to:
+
+<Steps>
+  <Step title="Upload preimage file">
+    Upload the preimage file to a location accessible by your op-challenger instances
+  </Step>
+  <Step title="Configure op-challenger">
+    Configure the op-challenger to use the generated prestate. There are two ways to provide prestates:
+  </Step>
+</Steps>
+
+<Steps>
+  <Step title="Option 1: Using HTTP URL">
+    If your prestate files are hosted on a web server, you can simply provide the URL to the directory containing those files:
+
+    ```bash
+    docker run -d --name op-challenger \
+     -e OP_CHALLENGER_TRACE_TYPE=permissioned,cannon \
+     -e OP_CHALLENGER_PRESTATES_URL=<HTTP_URL_PATH_TO_PRESTATE> \
+     -e OP_CHALLENGER_L1_ETH_RPC=<YOUR_L1_RPC_URL> \
+     -e OP_CHALLENGER_GAME_FACTORY_ADDRESS=<YOUR_DISPUTE_GAME_FACTORY> \
+     -e OP_CHALLENGER_PRIVATE_KEY=<YOUR_PRIVATE_KEY_OR_USE_WALLET_SIGNER> \
+     -e OP_CHALLENGER_NETWORK=<YOUR_NETWORK> \
+     -e OP_CHALLENGER_CANNON_ROLLUP_CONFIG=<PATH_TO_ROLLUP_CONFIG> \
+     -e OP_CHALLENGER_CANNON_L2_GENESIS=<PATH_TO_GENESIS_CONFIG> \
+     us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger:latest
+    ```
+
+    <Info>
+      When using an HTTP URL, no volume mount is required. The challenger will download the prestate files as needed.
+    </Info>
+  </Step>
+  <Step title="Option 2: Using local files">
+    If you have prestate files stored locally, you'll need to mount them as a volume and use the `file://` protocol:
+
+    ```bash
+    docker run -d --name op-challenger \
+      -e OP_CHALLENGER_TRACE_TYPE=permissioned,cannon \
+      -e OP_CHALLENGER_PRESTATES_URL=file:///prestates \
+      -e OP_CHALLENGER_L1_ETH_RPC=<YOUR_L1_RPC_URL> \
+      -e OP_CHALLENGER_GAME_FACTORY_ADDRESS=<YOUR_DISPUTE_GAME_FACTORY> \
+      -e OP_CHALLENGER_PRIVATE_KEY=<YOUR_PRIVATE_KEY_OR_USE_WALLET_SIGNER> \
+      -e OP_CHALLENGER_NETWORK=<YOUR_NETWORK> \
+      -e OP_CHALLENGER_CANNON_ROLLUP_CONFIG=<PATH_TO_ROLLUP_CONFIG> \
+      -e OP_CHALLENGER_CANNON_L2_GENESIS=<PATH_TO_GENESIS_CONFIG> \
+      -v /path/to/local/prestates:/prestates \
+      us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger:latest
+    ```
+
+    <Info>
+      When using local files, ensure your prestate files are in the mounted directory and properly named with their hash (e.g., `0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b72e4fc8.bin.gz`).
+    </Info>
+  </Step>
+</Steps>
+
+<Info>
+  - Ensure you're using the latest op-challenger version, see the [release page](https://github.com/ethereum-optimism/optimism/release).
+  - If your chain uses interoperability features, you'll need to add a `depsets.json` file to the `op-program/chainconfig/configs` directory.
+  - This file contains dependency set configurations. Use the same dependency set definition your interop-enabled chain is already configured with.
+</Info>
+
+## Next Steps
+
+- Check out the [migrating to permissionless fault proofs guide](/chain-operators/tutorials/migrating-permissionless).
+- Read the [Fault proofs explainer](/op-stack/fault-proofs/explainer).

--- a/docs/public-docs/chain-operators/tutorials/kona-custom-prestate.mdx
+++ b/docs/public-docs/chain-operators/tutorials/kona-custom-prestate.mdx
@@ -213,6 +213,21 @@ The compiled `kona-client` binary embeds the merged registry via `include_str!()
     The hash printed is your chain's custom kona absolute prestate. The build also writes a hash-named gzipped binary at `rust/kona/prestate-artifacts-cannon/0x<hash>.bin.gz` — this is the file `op-challenger` needs to fetch at dispute time.
   </Step>
 
+  <Step title="Verify your chain is embedded in the prestate">
+    A custom-config build that silently fails to merge your chain produces the *standard* prestate hash — and an `op-challenger` pointed at it will never agree with your games. Always confirm your chain actually made it in:
+
+    ```bash
+    # 1. The build log must list every custom chain that was merged:
+    #    cargo:warning=...: inserting new custom chain <bucket>: [chain-a,chain-b]
+    #    (or "merging custom chains <bucket>: [...]" if the bucket already exists)
+    #
+    # 2. The chain name must appear inside the prestate image itself:
+    gunzip -c rust/kona/prestate-artifacts-cannon/prestate.bin.gz | strings | grep "<chain-name>"
+    ```
+
+    Run the `grep` once per chain in your `chainList.json` and confirm at least one match for **every** chain — a build that embeds chain A but drops chain B still produces a valid-looking hash. Zero matches means `KONA_CUSTOM_CONFIGS=true` was not set in the build shell, or `KONA_CUSTOM_CONFIGS_DIR` was a relative path.
+  </Step>
+
   <Step title="Verify reproducibility">
     From a fresh checkout of the same tag with the same custom-configs files in place, repeat the build and confirm the hash is bit-identical. Anyone who wants to participate as an honest challenger on your chain must be able to reproduce this hash from the same inputs.
   </Step>
@@ -225,14 +240,30 @@ The compiled `kona-client` binary embeds the merged registry via `include_str!()
     Upload `0x<hash>.bin.gz` to wherever you serve preimage files for `op-challenger` — typically a GCS bucket or HTTP endpoint. Files must be named by their absolute prestate hash so the challenger can resolve them on demand.
   </Step>
 
-  <Step title="Deploy a new FaultDisputeGame implementation with the custom prestate">
-    The `absolutePrestate` constructor argument on `FaultDisputeGame` is immutable, so each new prestate requires a fresh implementation deployment. Once deployed, register it on your `DisputeGameFactory`:
+  <Step title="Register the custom prestate as game type 8">
+    On the current (v2.4+) dispute-game contracts the absolute prestate is **not** a constructor argument — it lives in the `DisputeGameFactory`'s per-game-type `gameArgs`, appended to each game via clones-with-immutable-args. So you do **not** deploy a new implementation for a new prestate. Reuse the existing permissionless `FaultDisputeGame` implementation (a fresh op-deployer chain deploys one but leaves it unregistered) and register it for game type 8 with `gameArgs` that carry your prestate.
 
-    ```solidity
-    DisputeGameFactory.setImplementation(GAME_TYPE_CANNON_KONA, newImpl);
+    `gameArgs` for a permissionless game is the packed encoding (124 bytes):
+
+    ```
+    abi.encodePacked(absolutePrestate, vm, anchorStateRegistry, weth, l2ChainId)
     ```
 
-    `GAME_TYPE_CANNON_KONA` is `8`.
+    Reuse `vm` / `anchorStateRegistry` / `weth` / `l2ChainId` from an existing registered game type (e.g. read `gameArgs(1)` and swap in your prestate), then register from the `DisputeGameFactory` owner:
+
+    ```solidity
+    // GAME_TYPE_CANNON_KONA == 8
+    DisputeGameFactory.setImplementation(8, faultDisputeGameImpl, gameArgs);
+    DisputeGameFactory.setInitBond(8, initBond);            // 0 is fine for a dev/test chain
+    ```
+
+    Then make game type 8 the respected type from the Guardian role — `respectedGameType` lives on the `AnchorStateRegistry`, not the `OptimismPortal` (the portal proxies to it):
+
+    ```solidity
+    AnchorStateRegistry.setRespectedGameType(8);
+    ```
+
+    See [Migrating to permissionless fault proofs](/chain-operators/tutorials/migrating-permissionless) for the full role/transaction walkthrough. (On older, pre-v2.4 contracts where `absolutePrestate` was a constructor immutable, each prestate did require a fresh implementation deployment instead.)
   </Step>
 
   <Step title="Configure op-challenger">

--- a/docs/public-docs/chain-operators/tutorials/kona-custom-prestate.mdx
+++ b/docs/public-docs/chain-operators/tutorials/kona-custom-prestate.mdx
@@ -1,0 +1,169 @@
+---
+title: "Generating a custom kona-client absolute prestate"
+description: "How to build a kona-client absolute prestate that embeds a chain configuration not yet in the public Superchain Registry."
+---
+
+# Overview
+
+For chains that are part of the public [`superchain-registry`](https://github.com/ethereum-optimism/superchain-registry), the standard `kona-client` absolute prestate published in [`standard-prestates.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml) already embeds your chain configuration. No custom build is needed.
+
+This tutorial is for the rarer case: a partner chain whose `RollupConfig` is not yet in the public registry but which still needs to run permissionless fault proofs (`cannon-kona` game type). In that case you must build a custom `kona-client` that embeds your chain's configuration, generate the absolute prestate hash from that build, and host the resulting binary at a URL `op-challenger` can fetch.
+
+<Info>
+  Most chains are in the Superchain Registry and should use the standard prestate. Only follow this tutorial if your chain is **not yet** in the registry. Once the chain is added to the public registry, future releases will cover it via the standard prestate and you can stop maintaining a custom build.
+</Info>
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- [Docker](https://docs.docker.com/engine/install/) running
+- [`just`](https://github.com/casey/just) installed
+- Push access to a private fork of [`ethereum-optimism/optimism`](https://github.com/ethereum-optimism/optimism) — the fork is where you commit your custom chain configuration
+- Your chain's `rollup.json`, L2 genesis, and deployment artifacts (typically produced by `op-deployer`)
+
+## How kona-client picks up custom chain configurations
+
+`kona-client` reads its embedded chain registry from the [`kona-registry` crate](https://github.com/ethereum-optimism/optimism/tree/develop/rust/kona/crates/protocol/registry). At build time, the crate's `build.rs` can merge additional chains on top of the canonical Superchain Registry snapshot. The merge is gated by two environment variables:
+
+```bash
+KONA_CUSTOM_CONFIGS=true
+KONA_CUSTOM_CONFIGS_DIR=/absolute/path/to/your/configs
+```
+
+When set, the build script reads two files from `KONA_CUSTOM_CONFIGS_DIR`:
+
+- `chainList.json` — light-weight `Chain` entries for your custom chains
+- `configs.json` — full `ChainConfig` + `RollupConfig` entries grouped under a `Superchain` bucket
+
+The full schema and an end-to-end example are documented in the [`kona-registry` README](https://github.com/ethereum-optimism/optimism/tree/develop/rust/kona/crates/protocol/registry#custom-chain-configurations).
+
+The compiled `kona-client` binary embeds the merged registry via `include_str!()`, so the resulting absolute prestate hash differs from the standard one. Any honest challenger participating in your chain's dispute games will need to run this same binary.
+
+## Generating the custom prestate
+
+<Steps>
+  <Step title="Branch off a kona-node release tag in your private fork">
+    Start from the same `kona-node/v<VERSION>` tag that your chain's nodes are running. Naming convention for the branch is `kona-client/<chain-name>`:
+
+    ```bash
+    git clone https://github.com/<your-org>/optimism-private.git
+    cd optimism-private
+    git fetch upstream --tags
+    git checkout -b kona-client/<chain-name> kona-node/v<VERSION>
+    ```
+  </Step>
+
+  <Step title="Stage your chain configuration">
+    Create a directory for your custom configs and add `chainList.json` and `configs.json` matching the schema documented in the [`kona-registry` README](https://github.com/ethereum-optimism/optimism/tree/develop/rust/kona/crates/protocol/registry#custom-chain-configurations).
+
+    Recommended location for traceability:
+
+    ```bash
+    mkdir -p rust/kona/crates/protocol/registry/etc/custom-configs/<chain-name>
+    # add chainList.json + configs.json here
+    ```
+
+    Source the values for `configs.json` from your chain's existing artifacts:
+
+    - `genesis.*`, `block_time`, `seq_window_size`, `max_sequencer_drift`, `batch_inbox_address`, hardfork timestamps → your chain's `rollup.json`
+    - `Addresses.*` → your `op-deployer` state (`opChainDeployments[<i>]`)
+    - `Roles.*` → your `op-deployer` state's per-chain `roles` block
+
+    Cross-check each L1 contract address onchain (`cast call`) before committing.
+  </Step>
+
+  <Step title="Wire the build to use your custom-configs directory">
+    Edit `rust/justfile`'s `build-kona-prestate` recipe so it passes your custom-configs path to the docker build automatically. The minimal change:
+
+    ```diff
+       cd "{{KONA_DIR}}/docker/fpvm-prestates"
+    -  just cannon {{VARIANT}} "{{KONA_DIR}}/{{OUTPUT_DIR}}"
+    +  just cannon {{VARIANT}} "{{KONA_DIR}}/{{OUTPUT_DIR}}" \
+    +      "{{KONA_DIR}}/crates/protocol/registry/etc/custom-configs/<chain-name>"
+    ```
+
+    With this wired, the canonical `just reproducible-prestate-kona` command picks up your custom configuration without requiring environment variables at invocation time.
+  </Step>
+
+  <Step title="Commit and push to your private fork">
+    ```bash
+    git add rust/justfile \
+            rust/kona/crates/protocol/registry/etc/custom-configs/<chain-name>/
+    git commit -m "feat(kona-registry): add <chain-name> custom chain configuration"
+    git push origin kona-client/<chain-name>
+    ```
+
+    Keep the branch private until your chain is publicly announced. Once it is, the branch can be pushed to the public monorepo as part of upstreaming.
+  </Step>
+
+  <Step title="Generate the absolute prestate">
+    From the root of the monorepo on your branch:
+
+    ```bash
+    just reproducible-prestate-kona
+    jq -r .pre rust/kona/prestate-artifacts-cannon/prestate-proof.json
+    ```
+
+    The hash printed is your chain's custom kona absolute prestate. The build also writes a hash-named gzipped binary at `rust/kona/prestate-artifacts-cannon/0x<hash>.bin.gz` — this is the file `op-challenger` needs to fetch at dispute time.
+  </Step>
+
+  <Step title="Verify reproducibility">
+    From a fresh checkout of the same branch, repeat the build and confirm the hash is bit-identical. Anyone who wants to participate as an honest challenger on your chain must be able to reproduce this hash from the same branch.
+  </Step>
+</Steps>
+
+## Deploying and configuring with the custom prestate
+
+<Steps>
+  <Step title="Host the prestate binary">
+    Upload `0x<hash>.bin.gz` to wherever you serve preimage files for `op-challenger` — typically a GCS bucket or HTTP endpoint. Files must be named by their absolute prestate hash so the challenger can resolve them on demand.
+  </Step>
+
+  <Step title="Deploy a new FaultDisputeGame implementation with the custom prestate">
+    The `absolutePrestate` constructor argument on `FaultDisputeGame` is immutable, so each new prestate requires a fresh implementation deployment. Once deployed, register it on your `DisputeGameFactory`:
+
+    ```solidity
+    DisputeGameFactory.setImplementation(GAME_TYPE_CANNON_KONA, newImpl);
+    ```
+
+    `GAME_TYPE_CANNON_KONA` is `8`.
+  </Step>
+
+  <Step title="Configure op-challenger">
+    Point `op-challenger` at your bucket and provide your chain's runtime configuration:
+
+    ```bash
+    --game-factory-address=<your-DGFProxy-address>
+    --cannon-kona-prestates-url=<bucket-base-url>
+    --cannon-kona-rollup-config=/path/to/your/rollup.json
+    --cannon-kona-l2-genesis=/path/to/your/L2-genesis.json
+    --trace-type=cannon-kona,permissioned
+    ```
+
+    The `--cannon-kona-prestates-url` is a directory URL; the challenger appends `/0x<hash>.bin.gz` automatically when a dispute references that hash. The `--cannon-kona-rollup-config` and `--cannon-kona-l2-genesis` flags supply your chain's config to `kona-client` at runtime (in addition to it being embedded in the binary).
+
+    If you're not using the standard OP Labs `op-challenger` Docker image, also set the `kona-host` binary path:
+
+    ```bash
+    --cannon-kona-server=/path/to/kona-host
+    ```
+
+    Build `kona-host` from the same release as the configured cannon-kona prestate.
+  </Step>
+</Steps>
+
+## After your chain is added to the Superchain Registry
+
+Once your chain's configuration lands in the public [`superchain-registry`](https://github.com/ethereum-optimism/superchain-registry), future `kona-client` releases will include it in the standard prestate. From that point you can:
+
+- Stop maintaining the custom branch in your private fork.
+- Switch to the standard prestate hash from `standard-prestates.toml` at the next prestate upgrade (typically a hardfork-driven event).
+- Deploy a new `FaultDisputeGame` implementation with the standard `absolutePrestate` and `setImplementation` to it.
+
+The custom-prestate branch can be removed from the private fork once no in-flight dispute games reference its absolute prestate.
+
+## Next Steps
+
+- [Upgrade 19 notice](/notices/upgrade-19) — the `cannon-kona` game type promotion and reference build commands for the standard prestate.
+- [Generating absolute prestate and preimage files](/chain-operators/tutorials/absolute-prestate) — the equivalent tutorial for `op-program` (cannon, game type 1), kept for chains still running that game type.

--- a/docs/public-docs/chain-operators/tutorials/kona-custom-prestate.mdx
+++ b/docs/public-docs/chain-operators/tutorials/kona-custom-prestate.mdx
@@ -19,7 +19,6 @@ Before starting, ensure you have:
 
 - [Docker](https://docs.docker.com/engine/install/) running
 - [`just`](https://github.com/casey/just) installed
-- Push access to a private fork of [`ethereum-optimism/optimism`](https://github.com/ethereum-optimism/optimism) — the fork is where you commit your custom chain configuration
 - Your chain's `rollup.json`, L2 genesis, and deployment artifacts (typically produced by `op-deployer`)
 
 ## How kona-client picks up custom chain configurations
@@ -43,28 +42,157 @@ The compiled `kona-client` binary embeds the merged registry via `include_str!()
 ## Generating the custom prestate
 
 <Steps>
-  <Step title="Branch off a kona-node release tag in your private fork">
-    Start from the same `kona-node/v<VERSION>` tag that your chain's nodes are running. Naming convention for the branch is `kona-client/<chain-name>`:
+  <Step title="Check out a kona-node release tag">
+    Use the same `kona-node/v<VERSION>` tag that your chain's nodes are running. The native `KONA_CUSTOM_CONFIGS_DIR` support documented below requires **`kona-node/v1.5.2` or later**; on older tags, additional justfile patches are needed.
 
     ```bash
-    git clone https://github.com/<your-org>/optimism-private.git
-    cd optimism-private
-    git fetch upstream --tags
-    git checkout -b kona-client/<chain-name> kona-node/v<VERSION>
+    git clone https://github.com/ethereum-optimism/optimism.git
+    cd optimism
+    git checkout kona-node/v<VERSION>
     ```
   </Step>
 
   <Step title="Stage your chain configuration">
-    Create a directory for your custom configs and add `chainList.json` and `configs.json` matching the schema documented in the [`kona-registry` README](https://github.com/ethereum-optimism/optimism/tree/develop/rust/kona/crates/protocol/registry#custom-chain-configurations).
-
-    Recommended location for traceability:
+    Create a directory for your custom configs:
 
     ```bash
     mkdir -p rust/kona/crates/protocol/registry/etc/custom-configs/<chain-name>
-    # add chainList.json + configs.json here
     ```
 
-    Source the values for `configs.json` from your chain's existing artifacts:
+    Add two files inside it — `chainList.json` (lightweight chain entry) and `configs.json` (full rollup config). Replace every `<PLACEHOLDER>` with your chain's value. Notes:
+
+    - **`<CHAIN_GROUP>`**: `mainnet` if your L1 is Ethereum mainnet, `sepolia` if your L1 is Sepolia. The bucket groups chains by L1 network, not by governance — your custom-chain status is expressed via `governedByOptimism: false` and `superchainLevel: 0`.
+    - **`faultProofs.status`**: `permissionless` for chains running the `cannon-kona` game type publicly, `permissioned` for chains that only allow whitelisted challengers.
+
+    <Tabs>
+      <Tab title="chainList.json">
+        ```json
+        [
+          {
+            "name": "<YOUR_CHAIN_NAME>",
+            "identifier": "<CHAIN_GROUP>/<YOUR_CHAIN_NAME>",
+            "chainId": <YOUR_L2_CHAIN_ID>,
+            "rpc": [],
+            "explorers": [],
+            "superchainLevel": 0,
+            "governedByOptimism": false,
+            "dataAvailabilityType": "eth-da",
+            "parent": { "type": "L2", "chain": "<CHAIN_GROUP>" },
+            "faultProofs": { "status": "<permissionless | permissioned>" }
+          }
+        ]
+        ```
+      </Tab>
+      <Tab title="configs.json">
+        ```json
+        {
+          "superchains": [
+            {
+              "name": "<CHAIN_GROUP>",
+              "config": {
+                "name": "<CHAIN_GROUP_DISPLAY_NAME>",
+                "l1": {
+                  "chain_id": <L1_CHAIN_ID>,
+                  "public_rpc": "<L1_PUBLIC_RPC>",
+                  "explorer": "<L1_EXPLORER>"
+                },
+                "hardforks": {
+                  "canyon_time": 0,
+                  "delta_time": 0,
+                  "ecotone_time": 0,
+                  "fjord_time": 0,
+                  "granite_time": 0,
+                  "holocene_time": 0,
+                  "isthmus_time": 0,
+                  "jovian_time": 0
+                },
+                "superchain_config_addr": null,
+                "op_contracts_manager_proxy_addr": null
+              },
+              "chains": [
+                {
+                  "Name": "<YOUR_CHAIN_NAME>",
+                  "PublicRPC": "",
+                  "SequencerRPC": "",
+                  "Explorer": "",
+                  "SuperchainLevel": 0,
+                  "GovernedByOptimism": false,
+                  "SuperchainTime": 0,
+                  "DataAvailabilityType": "eth-da",
+                  "l2_chain_id": <YOUR_L2_CHAIN_ID>,
+                  "batch_inbox_address": "<BATCH_INBOX_ADDRESS>",
+                  "block_time": 2,
+                  "seq_window_size": 3600,
+                  "max_sequencer_drift": 600,
+                  "GasPayingToken": null,
+                  "hardfork_configuration": {
+                    "canyon_time": 0,
+                    "delta_time": 0,
+                    "ecotone_time": 0,
+                    "fjord_time": 0,
+                    "granite_time": 0,
+                    "holocene_time": 0,
+                    "isthmus_time": 0,
+                    "jovian_time": 0
+                  },
+                  "optimism": {
+                    "eip1559Elasticity": 6,
+                    "eip1559Denominator": 50,
+                    "eip1559DenominatorCanyon": 250
+                  },
+                  "alt_da": null,
+                  "genesis": {
+                    "l1": {
+                      "number": <L1_GENESIS_BLOCK>,
+                      "hash": "<L1_GENESIS_HASH>"
+                    },
+                    "l2": {
+                      "number": 0,
+                      "hash": "<L2_GENESIS_HASH>"
+                    },
+                    "l2_time": <L2_GENESIS_TIMESTAMP>,
+                    "system_config": {
+                      "batcherAddr": "<BATCHER_ADDRESS>",
+                      "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                      "scalar": "<SCALAR_HEX>",
+                      "gasLimit": 60000000
+                    }
+                  },
+                  "Roles": {
+                    "SystemConfigOwner": "<SYSTEM_CONFIG_OWNER>",
+                    "ProxyAdminOwner": "<PROXY_ADMIN_OWNER>",
+                    "Guardian": "<GUARDIAN>",
+                    "Challenger": "<CHALLENGER>",
+                    "Proposer": "<PROPOSER>",
+                    "UnsafeBlockSigner": "<UNSAFE_BLOCK_SIGNER>",
+                    "BatchSubmitter": "<BATCH_SUBMITTER>"
+                  },
+                  "Addresses": {
+                    "AddressManager": "<ADDRESS_MANAGER>",
+                    "L1CrossDomainMessengerProxy": "<L1_CROSS_DOMAIN_MESSENGER_PROXY>",
+                    "L1Erc721BridgeProxy": "<L1_ERC721_BRIDGE_PROXY>",
+                    "L1StandardBridgeProxy": "<L1_STANDARD_BRIDGE_PROXY>",
+                    "L2OutputOracleProxy": "0x0000000000000000000000000000000000000000",
+                    "OptimismMintableErc20FactoryProxy": "<OPTIMISM_MINTABLE_ERC20_FACTORY_PROXY>",
+                    "OptimismPortalProxy": "<OPTIMISM_PORTAL_PROXY>",
+                    "SystemConfigProxy": "<SYSTEM_CONFIG_PROXY>",
+                    "ProxyAdmin": "<PROXY_ADMIN>",
+                    "AnchorStateRegistryProxy": "<ANCHOR_STATE_REGISTRY_PROXY>",
+                    "DelayedWethProxy": "<DELAYED_WETH_PROXY>",
+                    "DisputeGameFactoryProxy": "<DISPUTE_GAME_FACTORY_PROXY>",
+                    "FaultDisputeGame": "<FAULT_DISPUTE_GAME>",
+                    "PermissionedDisputeGame": "<PERMISSIONED_DISPUTE_GAME>"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+        ```
+      </Tab>
+    </Tabs>
+
+    Source the values from your chain's existing artifacts:
 
     - `genesis.*`, `block_time`, `seq_window_size`, `max_sequencer_drift`, `batch_inbox_address`, hardfork timestamps → your chain's `rollup.json`
     - `Addresses.*` → your `op-deployer` state (`opChainDeployments[<i>]`)
@@ -73,34 +201,11 @@ The compiled `kona-client` binary embeds the merged registry via `include_str!()
     Cross-check each L1 contract address onchain (`cast call`) before committing.
   </Step>
 
-  <Step title="Wire the build to use your custom-configs directory">
-    Edit `rust/justfile`'s `build-kona-prestate` recipe so it passes your custom-configs path to the docker build automatically. The minimal change:
-
-    ```diff
-       cd "{{KONA_DIR}}/docker/fpvm-prestates"
-    -  just cannon {{VARIANT}} "{{KONA_DIR}}/{{OUTPUT_DIR}}"
-    +  just cannon {{VARIANT}} "{{KONA_DIR}}/{{OUTPUT_DIR}}" \
-    +      "{{KONA_DIR}}/crates/protocol/registry/etc/custom-configs/<chain-name>"
-    ```
-
-    With this wired, the canonical `just reproducible-prestate-kona` command picks up your custom configuration without requiring environment variables at invocation time.
-  </Step>
-
-  <Step title="Commit and push to your private fork">
-    ```bash
-    git add rust/justfile \
-            rust/kona/crates/protocol/registry/etc/custom-configs/<chain-name>/
-    git commit -m "feat(kona-registry): add <chain-name> custom chain configuration"
-    git push origin kona-client/<chain-name>
-    ```
-
-    Keep the branch private until your chain is publicly announced. Once it is, the branch can be pushed to the public monorepo as part of upstreaming.
-  </Step>
-
   <Step title="Generate the absolute prestate">
-    From the root of the monorepo on your branch:
+    From the root of the monorepo, point `KONA_CUSTOM_CONFIGS_DIR` at the directory you created in Step 2, then run the canonical build:
 
     ```bash
+    export KONA_CUSTOM_CONFIGS_DIR="$PWD/rust/kona/crates/protocol/registry/etc/custom-configs/<chain-name>"
     just reproducible-prestate-kona
     jq -r .pre rust/kona/prestate-artifacts-cannon/prestate-proof.json
     ```
@@ -109,7 +214,7 @@ The compiled `kona-client` binary embeds the merged registry via `include_str!()
   </Step>
 
   <Step title="Verify reproducibility">
-    From a fresh checkout of the same branch, repeat the build and confirm the hash is bit-identical. Anyone who wants to participate as an honest challenger on your chain must be able to reproduce this hash from the same branch.
+    From a fresh checkout of the same tag with the same custom-configs files in place, repeat the build and confirm the hash is bit-identical. Anyone who wants to participate as an honest challenger on your chain must be able to reproduce this hash from the same inputs.
   </Step>
 </Steps>
 
@@ -131,37 +236,16 @@ The compiled `kona-client` binary embeds the merged registry via `include_str!()
   </Step>
 
   <Step title="Configure op-challenger">
-    Point `op-challenger` at your bucket and provide your chain's runtime configuration:
+    Add the kona-specific env vars to your existing challenger config:
 
     ```bash
-    --game-factory-address=<your-DGFProxy-address>
-    --cannon-kona-prestates-url=<bucket-base-url>
-    --cannon-kona-rollup-config=/path/to/your/rollup.json
-    --cannon-kona-l2-genesis=/path/to/your/L2-genesis.json
-    --trace-type=cannon-kona,permissioned
+    OP_CHALLENGER_TRACE_TYPE=cannon-kona,permissioned
+    OP_CHALLENGER_CANNON_KONA_PRESTATES_URL=<HTTP_URL_PATH_TO_PRESTATES>
     ```
 
-    The `--cannon-kona-prestates-url` is a directory URL; the challenger appends `/0x<hash>.bin.gz` automatically when a dispute references that hash. The `--cannon-kona-rollup-config` and `--cannon-kona-l2-genesis` flags supply your chain's config to `kona-client` at runtime (in addition to it being embedded in the binary).
-
-    If you're not using the standard OP Labs `op-challenger` Docker image, also set the `kona-host` binary path:
-
-    ```bash
-    --cannon-kona-server=/path/to/kona-host
-    ```
-
-    Build `kona-host` from the same release as the configured cannon-kona prestate.
+    The challenger appends `/0x<hash>.bin.gz` to `*_PRESTATES_URL` to resolve the right binary per dispute. Your existing `OP_CHALLENGER_ROLLUP_CONFIG`, `OP_CHALLENGER_L2_GENESIS`, and `OP_CHALLENGER_GAME_FACTORY_ADDRESS` continue to apply unchanged.
   </Step>
 </Steps>
-
-## After your chain is added to the Superchain Registry
-
-Once your chain's configuration lands in the public [`superchain-registry`](https://github.com/ethereum-optimism/superchain-registry), future `kona-client` releases will include it in the standard prestate. From that point you can:
-
-- Stop maintaining the custom branch in your private fork.
-- Switch to the standard prestate hash from `standard-prestates.toml` at the next prestate upgrade (typically a hardfork-driven event).
-- Deploy a new `FaultDisputeGame` implementation with the standard `absolutePrestate` and `setImplementation` to it.
-
-The custom-prestate branch can be removed from the private fork once no in-flight dispute games reference its absolute prestate.
 
 ## Next Steps
 

--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -1954,12 +1954,6 @@
               },
               "chain-operators/tutorials/absolute-prestate",
               "chain-operators/tutorials/kona-custom-prestate",
-              {
-                "group": "Archive",
-                "pages": [
-                  "chain-operators/tutorials/archive/op-program-prestate"
-                ]
-              },
               "chain-operators/tutorials/adding-derivation-attributes",
               "chain-operators/tutorials/adding-precompiles",
               "chain-operators/tutorials/dispute-games",
@@ -2021,6 +2015,12 @@
               "chain-operators/reference/architecture",
               "chain-operators/reference/opcm",
               "chain-operators/reference/standard-configuration"
+            ]
+          },
+          {
+            "group": "Archive",
+            "pages": [
+              "chain-operators/tutorials/archive/op-program-prestate"
             ]
           }
         ]

--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -1953,6 +1953,7 @@
                 ]
               },
               "chain-operators/tutorials/absolute-prestate",
+              "chain-operators/tutorials/kona-custom-prestate",
               "chain-operators/tutorials/adding-derivation-attributes",
               "chain-operators/tutorials/adding-precompiles",
               "chain-operators/tutorials/dispute-games",

--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -1954,6 +1954,12 @@
               },
               "chain-operators/tutorials/absolute-prestate",
               "chain-operators/tutorials/kona-custom-prestate",
+              {
+                "group": "Archive",
+                "pages": [
+                  "chain-operators/tutorials/archive/op-program-prestate"
+                ]
+              },
               "chain-operators/tutorials/adding-derivation-attributes",
               "chain-operators/tutorials/adding-precompiles",
               "chain-operators/tutorials/dispute-games",


### PR DESCRIPTION
Refocuses chain-operator prestate tutorials on kona-client; archives op-program. Tracks https://github.com/ethereum-optimism/solutions/issues/686.