### PR TITLE
fix(op-supernode/interop): propagate verifier read errors to super_authority

### DIFF
--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -52,12 +52,14 @@ type VerificationActivity interface {
 	// data at or before that timestamp as safe without consulting this activity.
 	IsActiveAt(ts uint64) bool
 
-	// LatestVerifiedL2Block returns the latest L2 block which has been verified,
-	// along with the timestamp at which it was verified.
-	LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64)
+	// LatestVerifiedL2Block returns the latest verified L2 block and its
+	// timestamp. (empty, 0, nil) means nothing verified yet; a non-nil error
+	// means the verifier is transiently unavailable.
+	LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error)
 
-	// VerifiedBlockAtL1 returns the verified L2 block and timestamp
-	// which guarantees that the verified data at that timestamp
-	// originates from or before the supplied L1 block.
-	VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64)
+	// VerifiedBlockAtL1 returns the latest verified L2 block whose data was
+	// derived from or before the supplied L1 block. (empty, 0, nil) means no
+	// such entry yet; a non-nil error means the verifier is transiently
+	// unavailable.
+	VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64, error)
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1073,65 +1073,65 @@ func (i *Interop) IsActiveAt(ts uint64) bool {
 	return ts >= i.activationTimestamp
 }
 
-// LatestVerifiedL2Block returns the latest L2 block which has been verified,
-// along with the timestamp at which it was verified.
-func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
+// LatestVerifiedL2Block returns the latest verified L2 block for chainID and
+// its timestamp. (empty, 0, nil) means nothing verified yet; a non-nil error
+// means verifiedDB could not be read.
+func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error) {
 	emptyBlock := eth.BlockID{}
 	ts, ok := i.verifiedDB.LastTimestamp()
 	if !ok {
-		return emptyBlock, 0
+		return emptyBlock, 0, nil
 	}
 	res, err := i.verifiedDB.Get(ts)
 	if err != nil {
-		return emptyBlock, 0
+		if errors.Is(err, ErrNotFound) {
+			return emptyBlock, 0, nil
+		}
+		return emptyBlock, 0, fmt.Errorf("LatestVerifiedL2Block: read verifiedDB at %d: %w", ts, err)
 	}
 	head, ok := res.L2Heads[chainID]
 	if !ok {
-		return emptyBlock, 0
+		return emptyBlock, 0, nil
 	}
-	return head, ts
+	return head, ts, nil
 }
 
-// VerifiedBlockAtL1 returns the verified L2 block and timestamp
-// which guarantees that the verified data at that timestamp
-// originates from or before the supplied L1 block.
-func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64) {
-	// If L1 block is empty/zero (e.g. during startup before FinalizedL1 is set),
-	// no verified result can match, so return early.
+// VerifiedBlockAtL1 returns the latest verified L2 block for chainID whose
+// L1 inclusion is at or below l1Block. (empty, 0, nil) means no match;
+// a non-nil error means verifiedDB could not be read.
+func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64, error) {
 	if l1Block == (eth.L1BlockRef{}) {
-		return eth.BlockID{}, 0
+		return eth.BlockID{}, 0, nil
 	}
 
-	// Get the last verified timestamp
 	lastTs, ok := i.verifiedDB.LastTimestamp()
 	if !ok {
-		return eth.BlockID{}, 0
+		return eth.BlockID{}, 0, nil
 	}
 
-	// Search backwards from the last timestamp to find the latest result
-	// where the L1 inclusion block is at or below the supplied L1 block number.
-	// Stop at activationTimestamp — no verified results exist before that.
+	// activationTimestamp is the floor: no verified results exist before activation.
 	lowerBound := i.activationTimestamp
 	for ts := lastTs; ts >= lowerBound && ts <= lastTs; ts-- {
 		result, err := i.verifiedDB.Get(ts)
 		if err != nil {
-			// Timestamp might not exist (due to gaps or rewinds), continue searching
-			continue
+			// Gaps and rewinds produce ErrNotFound; any other error is a
+			// real read failure and must not be treated as no-match.
+			if errors.Is(err, ErrNotFound) {
+				continue
+			}
+			return eth.BlockID{}, 0, fmt.Errorf("VerifiedBlockAtL1: read verifiedDB at %d: %w", ts, err)
 		}
 
-		// Check if this result's L1 inclusion is at or below the supplied L1 block number
 		if result.L1Inclusion.Number <= l1Block.Number {
-			// Found a finalized result, return the L2 head for this chain
 			head, ok := result.L2Heads[chainID]
 			if !ok {
-				return eth.BlockID{}, 0
+				return eth.BlockID{}, 0, nil
 			}
-			return head, ts
+			return head, ts, nil
 		}
 	}
 
-	// No verified block found
-	return eth.BlockID{}, 0
+	return eth.BlockID{}, 0, nil
 }
 
 // Reset is intentionally a no-op for interop.

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -2704,8 +2704,8 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		// Call with zero L1BlockRef — should return empty without scanning the DB
-		blockID, ts := h.interop.VerifiedBlockAtL1(h.Mock(10).id, eth.L1BlockRef{})
+		blockID, ts, err := h.interop.VerifiedBlockAtL1(h.Mock(10).id, eth.L1BlockRef{})
+		require.NoError(t, err)
 		require.Equal(t, eth.BlockID{}, blockID)
 		require.Equal(t, uint64(0), ts)
 	})
@@ -2716,7 +2716,6 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 			Build()
 
 		chainID := h.Mock(10).id
-		// Use timestamps at/above activation (1000) so VerifiedBlockAtL1 scan finds them
 		expectedL2 := eth.BlockID{Hash: common.Hash{0xaa}, Number: 1005}
 
 		for ts := uint64(1000); ts <= 1010; ts++ {
@@ -2726,30 +2725,79 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 			}
 			err := h.interop.verifiedDB.Commit(VerifiedResult{
 				Timestamp:   ts,
-				L1Inclusion: eth.BlockID{Number: ts * 10}, // L1 inclusion grows with timestamp
+				L1Inclusion: eth.BlockID{Number: ts * 10},
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: l2Head},
 			})
 			require.NoError(t, err)
 		}
 
-		// Query for L1 block 10059 — should match timestamp 1005 (L1Inclusion.Number=10050 <= 10059)
-		// but not timestamp 1006 (L1Inclusion.Number=10060 > 10059)
+		// L1 block 10059 matches ts=1005 (L1Inclusion=10050) but not ts=1006 (L1Inclusion=10060).
 		l1Block := eth.L1BlockRef{Hash: common.Hash{0x01}, Number: 10059, Time: 999}
-		blockID, ts := h.interop.VerifiedBlockAtL1(chainID, l1Block)
+		blockID, ts, err := h.interop.VerifiedBlockAtL1(chainID, l1Block)
+		require.NoError(t, err)
 		require.Equal(t, expectedL2, blockID)
 		require.Equal(t, uint64(1005), ts)
 	})
 
-	t.Run("empty DB returns empty", func(t *testing.T) {
+	t.Run("empty DB returns empty without error", func(t *testing.T) {
 		h := newInteropTestHarness(t).
 			WithChain(10, nil).
 			Build()
 
 		l1Block := eth.L1BlockRef{Hash: common.Hash{0x01}, Number: 1000, Time: 999}
-		blockID, ts := h.interop.VerifiedBlockAtL1(h.Mock(10).id, l1Block)
+		blockID, ts, err := h.interop.VerifiedBlockAtL1(h.Mock(10).id, l1Block)
+		require.NoError(t, err)
 		require.Equal(t, eth.BlockID{}, blockID)
 		require.Equal(t, uint64(0), ts)
 	})
+
+	t.Run("closed verifiedDB surfaces error", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, nil).
+			Build()
+
+		chainID := h.Mock(10).id
+		// LastTimestamp is cached, so the scan still enters the loop after Close.
+		for tsCommit := uint64(1000); tsCommit <= 1003; tsCommit++ {
+			err := h.interop.verifiedDB.Commit(VerifiedResult{
+				Timestamp:   tsCommit,
+				L1Inclusion: eth.BlockID{Number: 5},
+				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.Hash{byte(tsCommit)}, Number: tsCommit}},
+			})
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, h.interop.verifiedDB.Close())
+
+		l1Block := eth.L1BlockRef{Hash: common.Hash{0x01}, Number: 100, Time: 999}
+		blockID, ts, err := h.interop.VerifiedBlockAtL1(chainID, l1Block)
+		require.Error(t, err)
+		require.Equal(t, eth.BlockID{}, blockID)
+		require.Equal(t, uint64(0), ts)
+	})
+}
+
+func TestLatestVerifiedL2Block_ClosedDBSurfacesError(t *testing.T) {
+	h := newInteropTestHarness(t).
+		WithChain(10, nil).
+		Build()
+
+	chainID := h.Mock(10).id
+	for tsCommit := uint64(1000); tsCommit <= 1003; tsCommit++ {
+		err := h.interop.verifiedDB.Commit(VerifiedResult{
+			Timestamp:   tsCommit,
+			L1Inclusion: eth.BlockID{Number: 5},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.Hash{byte(tsCommit)}, Number: tsCommit}},
+		})
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, h.interop.verifiedDB.Close())
+
+	blockID, ts, err := h.interop.LatestVerifiedL2Block(chainID)
+	require.Error(t, err)
+	require.Equal(t, eth.BlockID{}, blockID)
+	require.Equal(t, uint64(0), ts)
 }
 
 // =============================================================================

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -11,25 +11,19 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// FullyVerifiedL2Head returns the fully verified L2 head block identifier.
-// The second return value indicates whether the caller should fall back to local-safe.
-// Returns (empty, true) when no verifiers are registered, or when every
-// registered verifier reports it is not yet active at the current local-safe
-// L2 timestamp (i.e. interop is scheduled but not yet activated).
-// Returns (empty, false) when verifiers are registered, at least one is active,
-// but none has verified anything yet.
-// Panics if verifiers disagree on the block hash for the same timestamp.
+// FullyVerifiedL2Head returns the oldest fully-verified L2 head across all
+// verifiers. The bool is true to signal use-local-safe (no verifiers, all
+// pre-activation, or transient verifier error); false carries the verifier
+// result (block, or empty when verifiers are operational but have nothing
+// verified yet). Panics if verifiers disagree at the same timestamp.
 func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
-	// If no verifiers registered, signal fallback to local-safe
 	if len(c.verifiers) == 0 {
 		c.log.Debug("FullyVerifiedL2Head: no verifiers registered, signaling local-safe fallback")
 		return eth.BlockID{}, true
 	}
 
-	// If every registered verifier is still pre-activation at the current
-	// local-safe timestamp, fall back to local-safe. Pre-activation L2 content
-	// is verified by consensus alone; gating it on an interop verifier that
-	// has not started yet would stall the head at genesis (see #20191).
+	// Pre-activation L2 content is verified by consensus alone; gating it on
+	// a not-yet-active interop verifier would stall the head at genesis (#20191).
 	if activeTS, ok := c.localSafeTimestamp(); ok && c.allVerifiersPreActivationAt(activeTS) {
 		c.log.Debug("FullyVerifiedL2Head: all verifiers pre-activation, signaling local-safe fallback", "localSafeTime", activeTS)
 		return eth.BlockID{}, true
@@ -38,9 +32,12 @@ func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
 	timestamp := uint64(math.MaxUint64)
 	oldestVerifiedBlock := eth.BlockID{}
 	for _, v := range c.verifiers {
-		bId, ts := v.LatestVerifiedL2Block(c.chainID)
-		// If any verifier returns empty, return empty but don't signal fallback
-		// The verifier exists but hasn't verified anything yet
+		bId, ts, err := v.LatestVerifiedL2Block(c.chainID)
+		if err != nil {
+			c.log.Warn("FullyVerifiedL2Head: verifier read failed, signaling local-safe fallback",
+				"verifier", v.Name(), "err", err)
+			return eth.BlockID{}, true
+		}
 		if (bId == eth.BlockID{} || ts == 0) {
 			c.log.Debug("FullyVerifiedL2Head: verifier returned empty, returning empty without fallback", "verifier", v.Name())
 			return eth.BlockID{}, false
@@ -57,17 +54,12 @@ func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
 	return oldestVerifiedBlock, false
 }
 
-// FinalizedL2Head returns the finalized L2 head block identifier.
-// The second return value indicates whether the caller should fall back to local-finalized.
-// Returns (empty, true) when no verifiers are registered, or when every
-// registered verifier reports it is not yet active at the current local-safe
-// L2 timestamp (i.e. interop is scheduled but not yet activated; FinalizedL2
-// <= LocalSafeL2, so if local-safe is pre-activation, so is finalized).
-// Returns (empty, false) when verifiers are registered, at least one is active,
-// but none has finalized anything yet.
-// Panics if verifiers disagree on the block hash for the same timestamp.
+// FinalizedL2Head returns the oldest finalized L2 head across all verifiers.
+// The bool is true to signal use-local-finalized (no verifiers, all
+// pre-activation, sync status unavailable, or transient verifier error);
+// false carries the verifier result. Panics if verifiers disagree at the
+// same timestamp.
 func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
-	// If no verifiers registered, signal fallback to local-finalized
 	if len(c.verifiers) == 0 {
 		c.log.Debug("FinalizedL2Head: no verifiers registered, signaling local-finalized fallback")
 		return eth.BlockID{}, true
@@ -79,9 +71,7 @@ func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
 		return eth.BlockID{}, true
 	}
 
-	// If every registered verifier is still pre-activation at the current
-	// local-safe timestamp, fall back to local-finalized. See #20191 and the
-	// matching guard in FullyVerifiedL2Head.
+	// FinalizedL2 <= LocalSafeL2; if local-safe is pre-activation, so is finalized.
 	if c.allVerifiersPreActivationAt(ss.LocalSafeL2.Time) {
 		c.log.Debug("FinalizedL2Head: all verifiers pre-activation, signaling local-finalized fallback", "localSafeTime", ss.LocalSafeL2.Time)
 		return eth.BlockID{}, true
@@ -90,9 +80,12 @@ func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
 	timestamp := uint64(math.MaxUint64)
 	oldestFinalizedBlock := eth.BlockID{}
 	for _, v := range c.verifiers {
-		bId, ts := v.VerifiedBlockAtL1(c.chainID, ss.FinalizedL1)
-		// If any verifier returns empty, return empty but don't signal fallback
-		// The verifier exists but hasn't finalized anything yet
+		bId, ts, err := v.VerifiedBlockAtL1(c.chainID, ss.FinalizedL1)
+		if err != nil {
+			c.log.Warn("FinalizedL2Head: verifier read failed, signaling local-finalized fallback",
+				"verifier", v.Name(), "err", err)
+			return eth.BlockID{}, true
+		}
 		if (bId == eth.BlockID{} || ts == 0) {
 			c.log.Debug("FinalizedL2Head: verifier returned empty, returning empty without fallback", "verifier", v.Name())
 			return eth.BlockID{}, false

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -2,6 +2,7 @@ package chain_container
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -15,8 +16,10 @@ import (
 type mockVerificationActivityForSuperAuthority struct {
 	latestVerifiedBlock  eth.BlockID
 	latestVerifiedTS     uint64
+	latestVerifiedErr    error
 	latestFinalizedBlock eth.BlockID
 	latestFinalizedTS    uint64
+	latestFinalizedErr   error
 	// isActiveAtFn drives IsActiveAt for pre-activation fallback tests.
 	// When nil, IsActiveAt returns true (active for all timestamps), matching
 	// the default "always-active" semantics the existing tests assume.
@@ -32,12 +35,12 @@ func (m *mockVerificationActivityForSuperAuthority) CurrentL1() eth.BlockID {
 func (m *mockVerificationActivityForSuperAuthority) VerifiedAtTimestamp(ts uint64) (bool, error) {
 	return false, nil
 }
-func (m *mockVerificationActivityForSuperAuthority) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
-	return m.latestVerifiedBlock, m.latestVerifiedTS
+func (m *mockVerificationActivityForSuperAuthority) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error) {
+	return m.latestVerifiedBlock, m.latestVerifiedTS, m.latestVerifiedErr
 }
 func (m *mockVerificationActivityForSuperAuthority) Reset(eth.ChainID, uint64, eth.BlockRef) {}
-func (m *mockVerificationActivityForSuperAuthority) VerifiedBlockAtL1(chainID eth.ChainID, l1BlockRef eth.L1BlockRef) (eth.BlockID, uint64) {
-	return m.latestFinalizedBlock, m.latestFinalizedTS
+func (m *mockVerificationActivityForSuperAuthority) VerifiedBlockAtL1(chainID eth.ChainID, l1BlockRef eth.L1BlockRef) (eth.BlockID, uint64, error) {
+	return m.latestFinalizedBlock, m.latestFinalizedTS, m.latestFinalizedErr
 }
 func (m *mockVerificationActivityForSuperAuthority) IsActiveAt(ts uint64) bool {
 	if m.isActiveAtFn != nil {
@@ -545,4 +548,43 @@ func TestChainContainer_FinalizedL2Head_AllPreActivation_FallsBackToLocalFinaliz
 	result, useLocalFinalized := cc.FinalizedL2Head()
 	require.Equal(t, eth.BlockID{}, result)
 	require.True(t, useLocalFinalized, "all-pre-activation should signal fallback to local-finalized")
+}
+
+func TestChainContainer_FinalizedL2Head_VerifierError_SignalsLocalFinalizedFallback(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
+	})
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn:       preActivationFn(1000),
+		latestFinalizedErr: errors.New("database not open"),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, eth.BlockID{}, result)
+	require.True(t, useLocalFinalized)
+}
+
+func TestChainContainer_FullyVerifiedL2Head_VerifierError_SignalsLocalSafeFallback(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
+	})
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn:      preActivationFn(1000),
+		latestVerifiedErr: errors.New("database not open"),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalSafe := cc.FullyVerifiedL2Head()
+	require.Equal(t, eth.BlockID{}, result)
+	require.True(t, useLocalSafe)
 }


### PR DESCRIPTION
**Claude:** Drafted by Claude on behalf of @ajsutton.

`VerifiedBlockAtL1` and `LatestVerifiedL2Block` previously swallowed `verifiedDB` read errors and returned `(empty, 0)`, indistinguishable from "nothing verified yet". During supernode shutdown, the interop activity closes `verifiedDB` while in-flight `PayloadSuccessEvent`s are still being drained through the op-node engine controller. The subsequent `Get` calls returned `"database not open"`, the loop silently `continue`d, and `super_authority.FinalizedL2Head` / `FullyVerifiedL2Head` answered `(empty, false)` — telling op-node "no value yet, use genesis". The dying op-node then emitted an FCU with `finalized=genesis`, regressing op-reth's finalized tag. The fresh op-node booted, read genesis from the EL, pinned SafeDB at L2 genesis, the cold-start backfill window collapsed to empty, and `AssertBackfillCovers` failed with `first seal ts == backfill handoff ts`.

`VerifiedBlockAtL1` and `LatestVerifiedL2Block` now return an error distinct from `ErrNotFound`, and the chain container signals use-local fallback (`(empty, true)`) on a verifier error instead of cold-start (`(empty, false)`).

Fixes ethereum-optimism/optimism#20944