### PR TITLE
chore: remove stale TODOs for closed issues

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -163,9 +163,6 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		Ctx:         ctx,
 		StepDeriver: stepDeriver,
 	}
-	// TODO(#16917) Remove Event System Refactor Comments
-	//  Couple SyncDeriver and EngineController for event refactoring
-	//  Couple EngDeriver and NewAttributesHandler for event refactoring
 	ec.SyncDeriver = syncDeriver
 	sys.Register("sync", syncDeriver, opts)
 	sys.Register("engine", ec, opts)

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -341,8 +341,6 @@ func initL1Handlers(cfg *config.Config, node *OpNode) (ethereum.Subscription, et
 		return nil, nil, nil, errors.New("l2 driver must be initialized")
 	}
 	onL1Head := func(ctx context.Context, sig eth.L1BlockRef) {
-		// TODO(#16917) Remove Event System Refactor Comments
-		//  L1UnsafeEvent fan out is updated to procedural method calls
 		if node.cfg.Tracer != nil {
 			node.cfg.Tracer.OnNewL1Head(ctx, sig)
 		}
@@ -354,8 +352,6 @@ func initL1Handlers(cfg *config.Config, node *OpNode) (ethereum.Subscription, et
 		node.l2Driver.StatusTracker.OnL1Safe(sig)
 	}
 	onL1Finalized := func(ctx context.Context, sig eth.L1BlockRef) {
-		// TODO(#16917) Remove Event System Refactor Comments
-		//  FinalizeL1Event fan out is updated to procedural method calls
 		node.l2Driver.StatusTracker.OnL1Finalized(sig)
 		node.l2Driver.Finalizer.OnL1Finalized(sig)
 		node.l2Driver.SyncDeriver.OnL1Finalized(ctx)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -100,9 +100,6 @@ func NewDriver(
 		Ctx:            driverCtx,
 		StepDeriver:    schedDeriv,
 	}
-	// TODO(#16917) Remove Event System Refactor Comments
-	//  Couple SyncDeriver and EngineController for event refactoring
-	//  Couple EngDeriver and NewAttributesHandler for event refactoring
 	ec.SyncDeriver = syncDeriver
 	sys.Register("sync", syncDeriver)
 	sys.Register("engine", ec)

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -61,11 +61,6 @@ func (s *SyncDeriver) OnL1Finalized(ctx context.Context) {
 }
 
 func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
-	// TODO(#16917) Remove Event System Refactor Comments
-	//  ELSyncStartedEvent is removed and OnELSyncStarted is synchronously called at EngineController
-	//  ReceivedBlockEvent is removed and OnUnsafeL2Payload is synchronously called at NewBlockReceiver
-	//  L1UnsafeEvent is removed and OnL1Unsafe is synchronously called at L1Handler
-	//  FinalizeL1Event is removed and OnL1Finalized is synchronously called at L1Handler
 	switch x := ev.(type) {
 	case StepEvent:
 		s.SyncStep()

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -857,9 +857,6 @@ func (e *EngineController) localSafeIsFullySafe(timestamp uint64) bool {
 func (e *EngineController) OnEvent(ctx context.Context, ev event.Event) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	// TODO(#16917) Remove Event System Refactor Comments
-	//  PromoteUnsafeEvent, PromotePendingSafeEvent, PromoteLocalSafeEvent fan out is updated to procedural
-	//  PromoteSafeEvent fan out is updated to procedural PromoteSafe method call
 	switch x := ev.(type) {
 	case UnsafeUpdateEvent:
 		if e.localSafeIsFullySafe(x.Ref.Time) {

--- a/op-node/rollup/finality/altda.go
+++ b/op-node/rollup/finality/altda.go
@@ -50,8 +50,6 @@ func NewAltDAFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config, 
 }
 
 func (fi *AltDAFinalizer) OnEvent(ctx context.Context, ev event.Event) bool {
-	// TODO(#16917) Remove Event System Refactor Comments
-	//  FinalizeL1Event is removed and OnL1Finalized is synchronously called at L1Handler
 	return fi.Finalizer.OnEvent(ctx, ev)
 }
 

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -172,8 +172,6 @@ func (ev TryFinalizeEvent) String() string {
 }
 
 func (fi *Finalizer) OnEvent(ctx context.Context, ev event.Event) bool {
-	// TODO(#16917) Remove Event System Refactor Comments
-	//  FinalizeL1Event is removed and OnL1Finalized is synchronously called at L1Handler
 	switch x := ev.(type) {
 	case engine.SafeDerivedEvent:
 		fi.onDerivedSafeBlock(x.Safe, x.Source)

--- a/op-node/rollup/sequencing/sequencer_chaos_test.go
+++ b/op-node/rollup/sequencing/sequencer_chaos_test.go
@@ -322,7 +322,6 @@ func testSequencerChaosWithSeed(t *testing.T, seed int64) {
 	require.NoError(t, seq.Init(context.Background(), true))
 	require.NoError(t, ex.Drain(), "initial forkchoice update etc. completes")
 
-	// TODO(#16917): direct call used now; no ForkchoiceRequestEvent expected
 	// Provide initial forkchoice so the sequencer has a prestate to build on
 	testEm.Emit(context.Background(), engine.ForkchoiceUpdateEvent{
 		UnsafeL2Head:    genesisRef,

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -186,7 +186,6 @@ func TestSequencer_StartStop(t *testing.T) {
 	deps.conductor.leader = true
 
 	testCtx := context.Background()
-	// TODO(#16917): direct call used now; no ForkchoiceRequestEvent expected
 	require.NoError(t, seq.Init(testCtx, false))
 	emitter.AssertExpectations(t)
 	require.False(t, deps.conductor.closed, "conductor is ready")
@@ -276,7 +275,6 @@ func TestSequencer_StaleBuild(t *testing.T) {
 	deps.conductor.leader = true
 
 	testCtx := context.Background()
-	// TODO(#16917): direct call used now; no ForkchoiceRequestEvent expected
 	require.NoError(t, seq.Init(testCtx, false))
 	emitter.AssertExpectations(t)
 	require.False(t, deps.conductor.closed, "conductor is ready")
@@ -486,13 +484,11 @@ func TestSequencerBuild(t *testing.T) {
 
 	testCtx := context.Background()
 	// Init will request a forkchoice update
-	// TODO(#16917): direct call used now; no ForkchoiceRequestEvent expected
 	require.NoError(t, seq.Init(testCtx, true))
 	emitter.AssertExpectations(t)
 	require.True(t, seq.Active(), "started in active mode")
 
 	// It will request a forkchoice update, it needs the head before being able to build on top of it
-	// TODO(#16917): direct call used now; no ForkchoiceRequestEvent expected
 	seq.OnEvent(context.Background(), SequencerActionEvent{})
 	emitter.AssertExpectations(t)
 

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -45,9 +45,6 @@ func NewStatusTracker(log log.Logger, metrics Metrics) *StatusTracker {
 }
 
 func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
-	// TODO(#16917) Remove Event System Refactor Comments
-	//  L1UnsafeEvent, L1SafeEvent is removed and OnL1Unsafe is synchronously called at L1Handler
-	//  FinalizeL1Event is removed and OnL1Finalized is synchronously called at L1Handler
 	st.mu.Lock()
 	defer st.mu.Unlock()
 

--- a/op-node/rollup/sync/start.go
+++ b/op-node/rollup/sync/start.go
@@ -201,8 +201,6 @@ func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain
 	// Once we pass the previous safe head and we have seen enough canonical L1 origins to fill a sequence window worth of data,
 	// then we return the last L2 block of the epoch before that as safe head.
 	// Each loop iteration we traverse a single L2 block, and we check if the L1 origins are consistent.
-	// TODO(#16141): maybe check inside here not to go over Interop activation, this should be handled by supervisor
-	// Fine to keep unsafe chain. Safe chain should be capped to stay pre-Interop.
 	for {
 		// Fetch L1 information if we never had it, or if we do not have it for the current origin.
 		// Optimization: as soon as we have a previous L1 block, try to traverse L1 by hash instead of by number, to fill the cache.

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -249,7 +249,7 @@ func newConsolidateCheckDeps(
 	oracle l2.Oracle,
 	consolidateState *consolidateState,
 ) (*consolidateCheckDeps, error) {
-	// TODO(#14415): handle case where dep set changes in a given timestamp
+	// Note: This does not handle the dep set changing in a given timestamp. That is currently unsupported.
 	canonBlocks := make(map[eth.ChainID]*l2.FastCanonicalBlockHeaderOracle)
 	for i, chain := range chains {
 		progress := transitionState.PendingProgress[i]

--- a/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/config.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/config.go
@@ -35,13 +35,10 @@ type Config struct {
 }
 
 func (c *Config) Start(ctx context.Context, id seqtypes.SequencerID, opts *work.ServiceOpts) (work.Sequencer, error) {
-
 	builder := opts.Services.Builder(c.Builder)
 	signer := opts.Services.Signer(c.Signer)
 	committer := opts.Services.Committer(c.Committer)
 	publisher := opts.Services.Publisher(c.Publisher)
-
-	// TODO(#14129) load persisted sequencer state (add config var for persistence path + use op-node persistence code)
 
 	seq := &Sequencer{
 		id: id,
@@ -57,11 +54,5 @@ func (c *Config) Start(ctx context.Context, id seqtypes.SequencerID, opts *work.
 		publisher: publisher,
 	}
 
-	// TODO(#14129) check persisted state, to determine if we should really start or stop
-	//if c.SequencerEnabled && !c.SequencerStopped {
-	//	if err := seq.forceStart(); err != nil {
-	//		return nil, fmt.Errorf("failed to start sequencer at startup phase: %w", err)
-	//	}
-	//}
 	return seq, nil
 }

--- a/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer.go
@@ -260,7 +260,6 @@ func (s *Sequencer) Start(ctx context.Context, head common.Hash) error {
 }
 
 func (s *Sequencer) forceStart() error {
-	// TODO(#14129) start schedule
 	s.reset()
 
 	return seqtypes.ErrNotImplemented
@@ -276,12 +275,6 @@ func (s *Sequencer) Stop(ctx context.Context) (hash common.Hash, err error) {
 
 	s.active = false
 	return common.Hash{}, seqtypes.ErrNotImplemented
-	/*
-		// TODO(#14129) stop schedule
-		var last common.Hash
-		s.reset()
-		return last, nil
-	*/
 }
 
 func (s *Sequencer) Active() bool {


### PR DESCRIPTION
Removes TODO comments referencing issues where the planned work is no longer intended.

Closes ethereum-optimism/optimism#16917
Closes ethereum-optimism/optimism#16141
Closes ethereum-optimism/optimism#14415
Closes ethereum-optimism/optimism#14129