### PR TITLE
fix(op-node): stall consolidate on NotFound during EL sync

### DIFF
--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -26,6 +26,7 @@ type EngineController interface {
 	TryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
 	RequestForkchoiceUpdate(ctx context.Context)
 	RequestPendingSafeUpdate(ctx context.Context)
+	IsEngineInitialELSyncing() bool
 }
 
 type L2 interface {
@@ -203,6 +204,17 @@ func (eq *AttributesHandler) consolidateNextSafeAttributes(attributes *derive.At
 	envelope, err := eq.l2.PayloadByNumber(ctx, attributes.Parent.Number+1)
 	if err != nil {
 		if errors.Is(err, ethereum.NotFound) {
+			if eq.engineController.IsEngineInitialELSyncing() {
+				// The EL has accepted a future EL-sync target but hasn't filled in
+				// pending_safe+1 yet. Resetting now would issue a forkchoice update
+				// that re-targets the EL away from its sync target and prevents EL
+				// sync from ever completing. Stall consolidation and retry once
+				// the EL catches up.
+				eq.emitter.Emit(eq.ctx, rollup.EngineTemporaryErrorEvent{
+					Err: fmt.Errorf("waiting for EL sync to fill in block %d for consolidation: %w", attributes.Parent.Number+1, err),
+				})
+				return
+			}
 			// engine may have restarted, or inconsistent safe head. We need to reset
 			eq.emitter.Emit(eq.ctx, rollup.ResetEvent{
 				Err: fmt.Errorf("expected engine was synced and had unsafe block to reconcile, but cannot find the block: %w", err),

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -338,6 +339,63 @@ func TestAttributesHandler(t *testing.T) {
 			t.Run("is not last span", func(t *testing.T) {
 				fn(t, false)
 			})
+		})
+		t.Run("not found during EL sync stalls without reset", func(t *testing.T) {
+			logger := testlog.Logger(t, log.LevelInfo)
+			l2 := &testutils.MockL2Client{}
+			emitter := &testutils.MockEmitter{}
+			engDeriver := &MockEngineController{}
+			ah := NewAttributesHandler(logger, cfg, context.Background(), l2, engDeriver)
+			ah.AttachEmitter(emitter)
+
+			emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
+			engDeriver.On("RequestPendingSafeUpdate", context.Background()).Once()
+			ah.OnEvent(context.Background(), derive.DerivedAttributesEvent{Attributes: attrA1})
+			engDeriver.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+			require.NotNil(t, ah.attributes, "queued up derived attributes")
+
+			// EL has accepted a future EL-sync target but hasn't filled in
+			// block refA1.Number yet, so the consolidate lookup returns NotFound.
+			l2.ExpectPayloadByNumber(refA1.Number, nil, ethereum.NotFound)
+			engDeriver.On("IsEngineInitialELSyncing").Return(true).Once()
+
+			emitter.ExpectOnceType("EngineTemporaryErrorEvent")
+			ah.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
+				PendingSafe: refA0,
+				Unsafe:      refA1,
+			})
+			engDeriver.AssertExpectations(t)
+			l2.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+			require.NotNil(t, ah.attributes,
+				"attributes stay queued so consolidation retries once EL sync fills in the block")
+		})
+		t.Run("not found without EL sync resets", func(t *testing.T) {
+			logger := testlog.Logger(t, log.LevelInfo)
+			l2 := &testutils.MockL2Client{}
+			emitter := &testutils.MockEmitter{}
+			engDeriver := &MockEngineController{}
+			ah := NewAttributesHandler(logger, cfg, context.Background(), l2, engDeriver)
+			ah.AttachEmitter(emitter)
+
+			emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
+			engDeriver.On("RequestPendingSafeUpdate", context.Background()).Once()
+			ah.OnEvent(context.Background(), derive.DerivedAttributesEvent{Attributes: attrA1})
+			engDeriver.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+
+			l2.ExpectPayloadByNumber(refA1.Number, nil, ethereum.NotFound)
+			engDeriver.On("IsEngineInitialELSyncing").Return(false).Once()
+
+			emitter.ExpectOnceType("ResetEvent")
+			ah.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
+				PendingSafe: refA0,
+				Unsafe:      refA1,
+			})
+			engDeriver.AssertExpectations(t)
+			l2.AssertExpectations(t)
+			emitter.AssertExpectations(t)
 		})
 	})
 

--- a/op-node/rollup/attributes/testutils.go
+++ b/op-node/rollup/attributes/testutils.go
@@ -28,3 +28,8 @@ func (m *MockEngineController) RequestForkchoiceUpdate(ctx context.Context) {
 func (m *MockEngineController) RequestPendingSafeUpdate(ctx context.Context) {
 	m.Mock.MethodCalled("RequestPendingSafeUpdate", ctx)
 }
+
+func (m *MockEngineController) IsEngineInitialELSyncing() bool {
+	out := m.Mock.MethodCalled("IsEngineInitialELSyncing")
+	return out.Bool(0)
+}

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -173,6 +173,8 @@ func (fakeEngController) TryUpdateLocalSafe(ctx context.Context, ref eth.L2Block
 
 func (fakeEngController) RequestPendingSafeUpdate(ctx context.Context) {}
 
+func (fakeEngController) IsEngineInitialELSyncing() bool { return false }
+
 // TestSequencer_StartStop runs through start/stop state back and forth to test state changes.
 func TestSequencer_StartStop(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelError)


### PR DESCRIPTION
When op-node receives a future unsafe payload via gossip during EL sync, the EL accepts it as a sync target and returns `SYNCING`. Derivation then tries to consolidate the next safe block against the unsafe chain, but the EL doesn't have `pending_safe+1` yet, so `PayloadByNumber` returns `NotFound`.

Previously this triggered a derivation pipeline reset. The reset's `forkchoiceUpdated` re-targets the EL away from its in-flight sync target, and the next gossiped payload moves it back — producing a thrash loop where EL sync never finishes and local safe never advances.

When the engine reports `IsEngineInitialELSyncing`, this PR treats `NotFound` at `pending_safe+1` as a transient condition and emits `EngineTemporaryErrorEvent` instead of `ResetEvent`. The attributes stay queued; consolidation retries on the next pending-safe poke, by which point EL sync should have filled in the block. Outside EL sync, `NotFound` still triggers the existing reset.

## Risk

One thing I'm still worried about with this is that if we _are_ the sequencer and there's been a reset that affects the network as a whole (e.g. invalid interop message) then it's possible that we got a gossip message from before we reset echo'd back to us but the EL sync won't be able to complete because all nodes have reorged and discarded the chain we're trying to sync. And since we are the sequencer and are stuck in sync mode, we'll never produce a block on the new chain that lets EL sync switch to it and complete.  If EL sync can't complete we wind up in a temporary error forever.

## Notes

This is an alternative to ethereum-optimism/optimism#20990, which addressed the same incident by changing `insertUnsafePayload` to not promote EL-sync targets into `unsafeHead`. That approach removed the bogus future `unsafeHead` that was causing consolidate to enter this branch — but left a separate risk: once consolidate's pre-state aligned with reality, derivation would freely issue a new-payload FCU with the derived block as Head, again interrupting EL sync. Fixing the reset directly is the root cause and avoids that risk.