### PR TITLE
feat(op-supernode): drive invalidation reorg via safe-head cap on reset

### DIFF
--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -49,6 +49,19 @@ type AttributesHandler struct {
 	sentAttributes bool
 
 	engineController EngineController
+
+	// superAuthority is consulted during consolidation: if the existing unsafe
+	// block at the height we're about to promote to safe is on the deny list,
+	// emit DepositsOnlyPayloadAttributesRequestEvent instead of letting
+	// derivation silently re-match the denied block. May be nil.
+	superAuthority rollup.SuperAuthority
+}
+
+// SetSuperAuthority attaches a SuperAuthority used to check whether existing
+// unsafe blocks are on the deny list during consolidation. Optional; if nil
+// (or never called), consolidation behaves as before.
+func (eq *AttributesHandler) SetSuperAuthority(sa rollup.SuperAuthority) {
+	eq.superAuthority = sa
 }
 
 func NewAttributesHandler(log log.Logger, cfg *rollup.Config, ctx context.Context, l2 L2, engController EngineController) *AttributesHandler {
@@ -213,6 +226,41 @@ func (eq *AttributesHandler) consolidateNextSafeAttributes(attributes *derive.At
 			Err: fmt.Errorf("failed to get existing unsafe payload to compare against derived attributes from L1: %w", err),
 		})
 		return
+	}
+	// If the existing unsafe block at this height is on the deny list and the
+	// derived attributes are NOT already deposits-only, request a deposits-only
+	// rebuild. Derivation reproduces the bad block deterministically from its
+	// L1 batch, so without this guard AttributesMatchBlock would succeed and
+	// the denied block would silently advance back into the safe chain.
+	//
+	// The deposits-only guard prevents an infinite loop: once derivation has
+	// produced deposits-only attributes for this height, those attributes will
+	// no longer match the (still-canonical) denied unsafe block's transactions
+	// — AttributesMatchBlock fails below and emits BuildStartEvent, which
+	// builds the replacement block and reorgs the chain.
+	if eq.superAuthority != nil && !attributes.Attributes.IsDepositsOnly() {
+		blockNum := uint64(envelope.ExecutionPayload.BlockNumber)
+		denied, err := eq.superAuthority.IsDenied(blockNum, envelope.ExecutionPayload.BlockHash)
+		if err != nil {
+			eq.log.Error("Failed to check SuperAuthority denylist during consolidation, proceeding with match check",
+				"blockNumber", blockNum,
+				"blockHash", envelope.ExecutionPayload.BlockHash,
+				"err", err,
+			)
+		} else if denied {
+			eq.log.Warn("Existing unsafe block is on the deny list, requesting deposits-only replacement",
+				"blockNumber", blockNum,
+				"blockHash", envelope.ExecutionPayload.BlockHash,
+				"parent", attributes.Parent,
+				"derivedFrom", attributes.DerivedFrom,
+			)
+			eq.sentAttributes = true
+			eq.emitter.Emit(eq.ctx, derive.DepositsOnlyPayloadAttributesRequestEvent{
+				Parent:      attributes.Parent.ID(),
+				DerivedFrom: attributes.DerivedFrom,
+			})
+			return
+		}
 	}
 	if err := AttributesMatchBlock(eq.cfg, attributes.Attributes, onto.Hash, envelope, eq.log); err != nil {
 		eq.log.Warn("L2 reorg: existing unsafe block does not match derived attributes from L1",

--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -242,12 +242,16 @@ func (eq *AttributesHandler) consolidateNextSafeAttributes(attributes *derive.At
 		blockNum := uint64(envelope.ExecutionPayload.BlockNumber)
 		denied, err := eq.superAuthority.IsDenied(blockNum, envelope.ExecutionPayload.BlockHash)
 		if err != nil {
-			eq.log.Error("Failed to check SuperAuthority denylist during consolidation, proceeding with match check",
-				"blockNumber", blockNum,
-				"blockHash", envelope.ExecutionPayload.BlockHash,
-				"err", err,
-			)
-		} else if denied {
+			// Fail closed: advancing pending-safe without the deny check
+			// risks silently promoting a denied block. Surface a temporary
+			// error so the caller retries on the next pipeline step.
+			eq.emitter.Emit(eq.ctx, rollup.EngineTemporaryErrorEvent{
+				Err: fmt.Errorf("deny-list check failed for unsafe block %s at height %d: %w",
+					envelope.ExecutionPayload.BlockHash, blockNum, err),
+			})
+			return
+		}
+		if denied {
 			eq.log.Warn("Existing unsafe block is on the deny list, requesting deposits-only replacement",
 				"blockNumber", blockNum,
 				"blockHash", envelope.ExecutionPayload.BlockHash,

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -339,6 +339,110 @@ func TestAttributesHandler(t *testing.T) {
 				fn(t, false)
 			})
 		})
+		t.Run("existing unsafe block is denied by SuperAuthority", func(t *testing.T) {
+			// Derivation deterministically reproduces the bad block's bytes, so
+			// without the deny check, AttributesMatchBlock would succeed and
+			// silently promote the denied block to safe. The check must emit
+			// DepositsOnlyPayloadAttributesRequestEvent instead.
+			//
+			// The test uses attrs whose payload contains at least one
+			// non-deposit tx so the IsDepositsOnly() short-circuit doesn't fire
+			// (that path is exercised by the next subtest).
+			logger := testlog.Logger(t, log.LevelInfo)
+			l2 := &testutils.MockL2Client{}
+			emitter := &testutils.MockEmitter{}
+			engDeriver := &MockEngineController{}
+			sa := &denyAuthority{
+				denied: map[uint64]common.Hash{
+					refA1.Number: payloadA1.ExecutionPayload.BlockHash, // mark the matching block denied
+				},
+			}
+			ah := NewAttributesHandler(logger, cfg, context.Background(), l2, engDeriver)
+			ah.AttachEmitter(emitter)
+			ah.SetSuperAuthority(sa)
+
+			// Clone attrA1's attributes and append a non-deposit tx so
+			// IsDepositsOnly() returns false and our check fires.
+			attrsCopy := *attrA1.Attributes
+			attrsCopy.Transactions = append([]eth.Data{}, attrA1.Attributes.Transactions...)
+			attrsCopy.Transactions = append(attrsCopy.Transactions, eth.Data{0x02, 0xff}) // EIP-1559 type byte, not a deposit
+			attr := &derive.AttributesWithParent{
+				Attributes:  &attrsCopy,
+				Parent:      attrA1.Parent,
+				Concluding:  true,
+				DerivedFrom: refB,
+			}
+			emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
+			engDeriver.On("RequestPendingSafeUpdate", context.Background()).Once()
+			ah.OnEvent(context.Background(), derive.DerivedAttributesEvent{Attributes: attr})
+			engDeriver.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+
+			// During consolidation: l2 returns the matching payload, but the
+			// deny check fires first and we request deposits-only attrs
+			// instead of advancing pending-safe.
+			l2.ExpectPayloadByNumber(refA1.Number, payloadA1, nil)
+			emitter.ExpectOnce(derive.DepositsOnlyPayloadAttributesRequestEvent{
+				Parent:      attr.Parent.ID(),
+				DerivedFrom: refB,
+			})
+			ah.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
+				PendingSafe: refA0,
+				Unsafe:      refA1,
+			})
+			// Critically: no TryUpdatePendingSafe / TryUpdateLocalSafe calls.
+			engDeriver.AssertExpectations(t)
+			l2.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+		})
+		t.Run("denied unsafe block + deposits-only attrs falls through to match check", func(t *testing.T) {
+			// Once derivation has produced deposits-only attributes for the
+			// denied height, we must NOT re-request another deposits-only
+			// rebuild (which would loop forever). Instead, fall through to
+			// AttributesMatchBlock — which fails because the deposits-only
+			// attrs don't match the bad block's transactions — emitting
+			// BuildStartEvent so the replacement block is built.
+			logger := testlog.Logger(t, log.LevelInfo)
+			l2 := &testutils.MockL2Client{}
+			emitter := &testutils.MockEmitter{}
+			engDeriver := &MockEngineController{}
+			sa := &denyAuthority{
+				denied: map[uint64]common.Hash{
+					refA1.Number: payloadA1.ExecutionPayload.BlockHash,
+				},
+			}
+			ah := NewAttributesHandler(logger, cfg, context.Background(), l2, engDeriver)
+			ah.AttachEmitter(emitter)
+			ah.SetSuperAuthority(sa)
+
+			// attrA1.Attributes only contains the L1 info deposit → IsDepositsOnly() = true.
+			attr := &derive.AttributesWithParent{
+				Attributes:  attrA1.Attributes,
+				Parent:      attrA1.Parent,
+				Concluding:  true,
+				DerivedFrom: refB,
+			}
+			emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
+			engDeriver.On("RequestPendingSafeUpdate", context.Background()).Once()
+			ah.OnEvent(context.Background(), derive.DerivedAttributesEvent{Attributes: attr})
+			engDeriver.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+
+			// payloadA1Alt has different content (different fee recipient), so
+			// the match check will fail and trigger BuildStartEvent. (We re-use
+			// payloadA1Alt from the parent scope so the deposits-only attrs
+			// genuinely differ from the unsafe block.)
+			l2.ExpectPayloadByNumber(refA1.Number, payloadA1Alt, nil)
+			emitter.ExpectOnce(engine.BuildStartEvent{Attributes: attr})
+			ah.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
+				PendingSafe: refA0,
+				Unsafe:      refA1,
+			})
+			// No TryUpdatePendingSafe and no DepositsOnlyPayloadAttributesRequestEvent.
+			engDeriver.AssertExpectations(t)
+			l2.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+		})
 	})
 
 	t.Run("pending equals unsafe", func(t *testing.T) {
@@ -416,4 +520,20 @@ func TestAttributesHandler(t *testing.T) {
 		l2.AssertExpectations(t)
 		emitter.AssertExpectations(t)
 	})
+}
+
+// denyAuthority is a minimal SuperAuthority stub for consolidation tests.
+// Only IsDenied is exercised — other methods return zero values.
+type denyAuthority struct {
+	denied map[uint64]common.Hash
+}
+
+func (d *denyAuthority) FullyVerifiedL2Head() (eth.BlockID, bool) { return eth.BlockID{}, false }
+func (d *denyAuthority) FinalizedL2Head() (eth.BlockID, bool)     { return eth.BlockID{}, false }
+func (d *denyAuthority) IsDenied(blockNumber uint64, payloadHash common.Hash) (bool, error) {
+	h, ok := d.denied[blockNumber]
+	return ok && h == payloadHash, nil
+}
+func (d *denyAuthority) CanonicalDeniedHeight(_ context.Context, _ rollup.CanonicalChain) (uint64, bool, error) {
+	return 0, false, nil
 }

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -2,6 +2,7 @@ package attributes
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"math/rand" // nosemgrep
 	"testing"
@@ -395,6 +396,50 @@ func TestAttributesHandler(t *testing.T) {
 			l2.AssertExpectations(t)
 			emitter.AssertExpectations(t)
 		})
+		t.Run("deny check error emits temporary error and aborts consolidation", func(t *testing.T) {
+			// Failing closed: if SuperAuthority can't tell us whether the
+			// unsafe block is denied, we must NOT advance pending-safe via
+			// AttributesMatchBlock — that risks silently promoting a denied
+			// block. Surface EngineTemporaryErrorEvent so the caller retries.
+			logger := testlog.Logger(t, log.LevelInfo)
+			l2 := &testutils.MockL2Client{}
+			emitter := &testutils.MockEmitter{}
+			engDeriver := &MockEngineController{}
+			sa := &denyAuthority{err: errors.New("boom")}
+			ah := NewAttributesHandler(logger, cfg, context.Background(), l2, engDeriver)
+			ah.AttachEmitter(emitter)
+			ah.SetSuperAuthority(sa)
+
+			// Use non-deposits-only attrs so the IsDepositsOnly short-circuit
+			// doesn't skip the check.
+			attrsCopy := *attrA1.Attributes
+			attrsCopy.Transactions = append([]eth.Data{}, attrA1.Attributes.Transactions...)
+			attrsCopy.Transactions = append(attrsCopy.Transactions, eth.Data{0x02, 0xff})
+			attr := &derive.AttributesWithParent{
+				Attributes:  &attrsCopy,
+				Parent:      attrA1.Parent,
+				Concluding:  true,
+				DerivedFrom: refB,
+			}
+			emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
+			engDeriver.On("RequestPendingSafeUpdate", context.Background()).Once()
+			ah.OnEvent(context.Background(), derive.DerivedAttributesEvent{Attributes: attr})
+			engDeriver.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+
+			// During consolidation: l2 returns the payload, deny check errors,
+			// no AttributesMatchBlock call, no TryUpdatePendingSafe — just an
+			// EngineTemporaryErrorEvent.
+			l2.ExpectPayloadByNumber(refA1.Number, payloadA1, nil)
+			emitter.ExpectOnceType("EngineTemporaryErrorEvent")
+			ah.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
+				PendingSafe: refA0,
+				Unsafe:      refA1,
+			})
+			engDeriver.AssertExpectations(t)
+			l2.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+		})
 		t.Run("denied unsafe block + deposits-only attrs falls through to match check", func(t *testing.T) {
 			// Once derivation has produced deposits-only attributes for the
 			// denied height, we must NOT re-request another deposits-only
@@ -526,11 +571,15 @@ func TestAttributesHandler(t *testing.T) {
 // Only IsDenied is exercised — other methods return zero values.
 type denyAuthority struct {
 	denied map[uint64]common.Hash
+	err    error // if non-nil, IsDenied returns this error
 }
 
 func (d *denyAuthority) FullyVerifiedL2Head() (eth.BlockID, bool) { return eth.BlockID{}, false }
 func (d *denyAuthority) FinalizedL2Head() (eth.BlockID, bool)     { return eth.BlockID{}, false }
 func (d *denyAuthority) IsDenied(blockNumber uint64, payloadHash common.Hash) (bool, error) {
+	if d.err != nil {
+		return false, d.err
+	}
 	h, ok := d.denied[blockNumber]
 	return ok && h == payloadHash, nil
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -73,6 +73,7 @@ func NewDriver(
 	sys.Register("finalizer", finalizer)
 
 	attrHandler := attributes.NewAttributesHandler(log, cfg, driverCtx, l2, ec)
+	attrHandler.SetSuperAuthority(superAuthority)
 	sys.Register("attributes-handler", attrHandler)
 
 	derivationPipeline := derive.NewDerivationPipeline(log, cfg, depSet, verifConfDepth, l1Blobs, altDA, l2, metrics, l1ChainConfig)

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -550,6 +550,40 @@ func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 		e.SetCrossUnsafeHead(e.SafeL2Head()) // preserve cross-safety, don't fall back to a non-cross safety level
 		e.log.Info("Set initial cross-unsafe block ref to match cross-safe", "cross_unsafe", e.SafeL2Head())
 	}
+	// Apply deny-list cap to the values just loaded from the EL. This ensures
+	// local-safe (and finalized) are strictly below any still-canonical denied
+	// block before any FCU is issued; the downstream consolidation path then
+	// re-derives the denied block as deposits-only and reorgs unsafe.
+	// Idempotent: re-entry via tryUpdateEngineInternal is a no-op once heads
+	// are already capped.
+	if e.superAuthority != nil && e.localSafeHead != (eth.L2BlockRef{}) {
+		result := &sync.FindHeadsResult{
+			Unsafe:    e.unsafeHead,
+			Safe:      e.localSafeHead,
+			Finalized: e.FinalizedHead(),
+		}
+		if err := sync.ApplyDenyCap(ctx, e.engine, e.superAuthority, result); err != nil {
+			return fmt.Errorf("apply deny-list cap during init: %w", err)
+		}
+		if result.Safe != e.localSafeHead {
+			e.log.Warn("Applied deny-list cap to initial local-safe head",
+				"prev_safe", e.localSafeHead, "capped_safe", result.Safe)
+			e.SetLocalSafeHead(result.Safe)
+			// deprecatedSafeHead may have just been initialised from the uncapped
+			// localSafeHead a few lines above; keep it consistent.
+			if e.deprecatedSafeHead.Number > result.Safe.Number {
+				e.SetDeprecatedSafeHead(result.Safe)
+			}
+			if e.crossUnsafeHead.Number > result.Safe.Number {
+				e.SetCrossUnsafeHead(result.Safe)
+			}
+		}
+		if result.Finalized != e.FinalizedHead() {
+			e.log.Warn("Applied deny-list cap to initial finalized head",
+				"prev_finalized", e.FinalizedHead(), "capped_finalized", result.Finalized)
+			e.SetFinalizedHead(result.Finalized)
+		}
+	}
 	return nil
 }
 
@@ -1196,7 +1230,7 @@ func (e *EngineController) AddUnsafePayload(ctx context.Context, envelope *eth.E
 
 // onResetEngineRequest handles the ResetEngineRequestEvent by finding L2 heads and performing a force reset
 func (e *EngineController) onResetEngineRequest(ctx context.Context) {
-	result, err := sync.FindL2Heads(e.ctx, e.rollupCfg, e.l1, e.engine, e.log, e.syncCfg)
+	result, err := sync.FindL2Heads(e.ctx, e.rollupCfg, e.l1, e.engine, e.log, e.syncCfg, e.superAuthority)
 	if err != nil {
 		e.emitter.Emit(ctx, rollup.ResetEvent{
 			Err: fmt.Errorf("failed to find the L2 Heads to start from: %w", err),
@@ -1217,7 +1251,7 @@ func (e *EngineController) TryInitialResetEngineForSequencer(ctx context.Context
 		return
 	}
 	e.log.Info("EngineController Unsafe head was not initialized at the start of the reset")
-	result, err := sync.FindL2Heads(e.ctx, e.rollupCfg, e.l1, e.engine, e.log, e.syncCfg)
+	result, err := sync.FindL2Heads(e.ctx, e.rollupCfg, e.l1, e.engine, e.log, e.syncCfg, e.superAuthority)
 	if err != nil {
 		e.log.Warn("Failed to find L2 Heads to start from while initial reset: %w", err)
 		// Do not emit ResetEvent because it will end propagating ForkchoiceUpdateEvent

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -485,11 +485,16 @@ func (e *EngineController) checkForkchoiceUpdatedStatus(status eth.ExecutePayloa
 	return status == eth.ExecutionValid
 }
 
-// initializeUnknowns is important to give the op-node EngineController engine state.
-// Pre-interop, the initial reset triggered a find-sync-start, and filled the forkchoice.
-// This still happens, but now overrides what may be initialized here.
-// Post-interop, the op-supervisor may diff the forkchoice state against the supervisor DB,
-// to determine where to perform the initial reset to.
+// initializeUnknowns gives the EngineController its initial forkchoice state by
+// reading the EL labels (unsafe/safe/finalized) for any head fields that haven't
+// already been set. Pre-interop, the initial reset still triggers FindL2Heads
+// which can lower these further. When running under a SuperAuthority (interop),
+// the deny-list cap is then applied to local-safe and finalized so that any
+// still-canonical denied block is excluded before any FCU is issued: derivation
+// will re-derive the denied block, payload_process.go's IsDenied check will
+// trigger deposits-only attributes, and consolidation will reorg the unsafe
+// chain via BuildStartEvent. Re-entry from tryUpdateEngineInternal is safe
+// because ApplyDenyCap is idempotent once heads are already at or below the cap.
 func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 	if e.unsafeHead == (eth.L2BlockRef{}) {
 		ref, err := e.engine.L2BlockRefByLabel(ctx, eth.Unsafe)

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -505,6 +505,7 @@ func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 		e.log.Info("Loaded initial local-unsafe block ref", "local_unsafe", ref)
 	}
 	var finalizedRef eth.L2BlockRef
+	finalizedJustLoaded := false
 	if e.FinalizedHead() == (eth.L2BlockRef{}) {
 		var err error
 		finalizedRef, err = e.engine.L2BlockRefByLabel(ctx, eth.Finalized)
@@ -522,9 +523,11 @@ func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 			}
 		} else {
 			e.SetFinalizedHead(finalizedRef)
+			finalizedJustLoaded = true
 			e.log.Info("Loaded initial finalized block ref", "finalized", finalizedRef)
 		}
 	}
+	safeJustLoaded := false
 	if e.localSafeHead == (eth.L2BlockRef{}) {
 		ref, err := e.engine.L2BlockRefByLabel(ctx, eth.Safe)
 		if err != nil {
@@ -536,6 +539,7 @@ func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 				} else {
 					// If the engine doesn't have a safe head, then we can use the finalized head
 					e.SetLocalSafeHead(finalizedRef)
+					safeJustLoaded = true
 					e.log.Info("Loaded initial local-safe block from finalized", "local_safe", finalizedRef)
 				}
 			} else {
@@ -543,6 +547,7 @@ func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 			}
 		} else {
 			e.SetLocalSafeHead(ref)
+			safeJustLoaded = true
 			e.log.Info("Loaded initial local-safe block ref", "local_safe", ref)
 		}
 	}
@@ -555,13 +560,16 @@ func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 		e.SetCrossUnsafeHead(e.SafeL2Head()) // preserve cross-safety, don't fall back to a non-cross safety level
 		e.log.Info("Set initial cross-unsafe block ref to match cross-safe", "cross_unsafe", e.SafeL2Head())
 	}
-	// Apply deny-list cap to the values just loaded from the EL. This ensures
-	// local-safe (and finalized) are strictly below any still-canonical denied
-	// block before any FCU is issued; the downstream consolidation path then
-	// re-derives the denied block as deposits-only and reorgs unsafe.
-	// Idempotent: re-entry via tryUpdateEngineInternal is a no-op once heads
-	// are already capped.
-	if e.superAuthority != nil && e.localSafeHead != (eth.L2BlockRef{}) {
+	// Apply deny-list cap to the values just loaded from the EL in this call.
+	// This is strictly a one-shot at initial head load: subsequent calls (the
+	// common case via tryUpdateEngineInternal) MUST NOT re-cap, because by then
+	// the build-driven reorg path may have advanced localSafeHead to the
+	// replacement block while op-reth's canonical chain still briefly reports
+	// the bad block at that height — re-running the cap would roll safe back
+	// over the just-built replacement and turn the reorg into an oscillation
+	// loop. The explicit reset path (onResetEngineRequest → FindL2Heads) still
+	// applies the cap when heads are freshly read from EL labels.
+	if e.superAuthority != nil && (safeJustLoaded || finalizedJustLoaded) && e.localSafeHead != (eth.L2BlockRef{}) {
 		result := &sync.FindHeadsResult{
 			Unsafe:    e.unsafeHead,
 			Safe:      e.localSafeHead,

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -2,8 +2,10 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -27,6 +29,19 @@ func (ev PayloadSuccessEvent) String() string {
 func (e *EngineController) onPayloadSuccess(ctx context.Context, ev PayloadSuccessEvent) {
 	if ev.DerivedFrom == ReplaceBlockSource {
 		e.log.Warn("Successfully built replacement block, resetting chain to continue now", "replacement", ev.Ref)
+		// Invariant: the replacement block we just built must not itself be on
+		// the deny list. The replacement is produced by deposits-only derivation
+		// in response to a denied payload at the same height — if the result is
+		// somehow denied too, forceReset would re-cap on the next reset and the
+		// chain would loop. Fail loudly rather than silently corrupting state.
+		if e.superAuthority != nil {
+			if denied, err := e.superAuthority.IsDenied(ev.Ref.Number, ev.Ref.Hash); err == nil && denied {
+				critErr := fmt.Errorf("replacement block %s is itself on the deny list — refusing to forceReset", ev.Ref)
+				e.log.Error("replacement block on deny list, surfacing critical error", "replacement", ev.Ref)
+				e.emitter.Emit(ctx, rollup.CriticalErrorEvent{Err: critErr}) // make the node exit, things are very wrong.
+				return
+			}
+		}
 		// Change the engine state to make the replacement block the cross-safe head of the chain,
 		// And continue syncing from there.
 		e.forceReset(ctx, ev.Ref, ev.Ref, ev.Ref, ev.Ref, e.Finalized(), false)

--- a/op-node/rollup/engine/payload_success_deny_test.go
+++ b/op-node/rollup/engine/payload_success_deny_test.go
@@ -1,0 +1,58 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+// TestOnPayloadSuccess_ReplacementBlockNotDenied verifies the defensive check
+// at payload_success.go:onPayloadSuccess that refuses to forceReset to a
+// replacement block whose hash is itself on the deny list. Without the check,
+// the next reset would re-apply the cap and the chain would loop.
+func TestOnPayloadSuccess_ReplacementBlockNotDenied(t *testing.T) {
+	cfg, _, _, payload := buildSimpleCfgAndPayload(t)
+
+	ref := eth.L2BlockRef{
+		Hash:       payload.ExecutionPayload.BlockHash,
+		Number:     uint64(payload.ExecutionPayload.BlockNumber),
+		ParentHash: payload.ExecutionPayload.ParentHash,
+		Time:       uint64(payload.ExecutionPayload.Timestamp),
+	}
+
+	sa := newMockSuperAuthority()
+	sa.denyBlock(ref.Number, ref.Hash)
+
+	engine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	// The defensive check must surface a CriticalErrorEvent (which the
+	// supernode handles as a process-exit signal) and must NOT proceed to
+	// forceReset / tryUpdateEngine. No engine RPCs are expected.
+	emitter.ExpectOnceType("CriticalErrorEvent")
+
+	ec := NewEngineController(
+		context.Background(),
+		engine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		cfg,
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+
+	ec.onPayloadSuccess(context.Background(), PayloadSuccessEvent{
+		DerivedFrom: ReplaceBlockSource,
+		Envelope:    payload,
+		Ref:         ref,
+	})
+
+	engine.AssertExpectations(t)
+	emitter.AssertExpectations(t)
+}

--- a/op-node/rollup/engine/super_authority_mock_test.go
+++ b/op-node/rollup/engine/super_authority_mock_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -43,6 +44,43 @@ func (m *mockSuperAuthority) FullyVerifiedL2Head() (eth.BlockID, bool) {
 
 func (m *mockSuperAuthority) FinalizedL2Head() (eth.BlockID, bool) {
 	return m.finalizedL2Head, false
+}
+
+// CanonicalDeniedHeight walks the in-memory denied-blocks map from highest to
+// lowest block number and returns the lowest height whose denied hash matches
+// the canonical hash reported by `canonical`. Mirrors the contract of
+// DenyList.CanonicalDeniedHeight for testing.
+func (m *mockSuperAuthority) CanonicalDeniedHeight(ctx context.Context, canonical rollup.CanonicalChain) (uint64, bool, error) {
+	if m.shouldError {
+		return 0, false, fmt.Errorf("superauthority check failed")
+	}
+	if len(m.deniedBlocks) == 0 {
+		return 0, false, nil
+	}
+	heights := make([]uint64, 0, len(m.deniedBlocks))
+	for h := range m.deniedBlocks {
+		heights = append(heights, h)
+	}
+	// Sort descending.
+	for i := 1; i < len(heights); i++ {
+		for j := i; j > 0 && heights[j] > heights[j-1]; j-- {
+			heights[j], heights[j-1] = heights[j-1], heights[j]
+		}
+	}
+	var lowestCanonical uint64
+	var found bool
+	for _, h := range heights {
+		ref, err := canonical.L2BlockRefByNumber(ctx, h)
+		if err != nil {
+			return lowestCanonical, found, nil
+		}
+		if ref.Hash != m.deniedBlocks[h] {
+			return lowestCanonical, found, nil
+		}
+		lowestCanonical = h
+		found = true
+	}
+	return lowestCanonical, found, nil
 }
 
 var _ rollup.SuperAuthority = (*mockSuperAuthority)(nil)

--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -1,10 +1,20 @@
 package rollup
 
 import (
+	"context"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
+
+// CanonicalChain is the minimal probe used by SuperAuthority.CanonicalDeniedHeight
+// to ask "what is the canonical block at this L2 height?". Implementations are
+// expected to return the EL's view of the canonical chain (e.g. via
+// eth_getBlockByNumber).
+type CanonicalChain interface {
+	L2BlockRefByNumber(ctx context.Context, number uint64) (eth.L2BlockRef, error)
+}
 
 // SuperAuthority provides payload validation functionality from a supernode.
 // When running inside a supernode, this allows the engine controller to check
@@ -24,6 +34,20 @@ type SuperAuthority interface {
 	// Returns true if the payload should not be applied.
 	// The error indicates if the check could not be performed (should be logged but not fatal).
 	IsDenied(blockNumber uint64, payloadHash common.Hash) (bool, error)
+	// CanonicalDeniedHeight returns the lowest L2 block height with a deny-list
+	// entry whose payload hash matches the canonical hash at that height,
+	// walking the deny list from highest to lowest. Iteration stops at the
+	// first height where no denied entry is canonical (assuming monotone
+	// canonicality: once a denied block has been reorged out, lower entries
+	// that are parents of the still-canonical chain are also reorged out).
+	//
+	// Returns (height, true, nil) when a canonical denied entry is found.
+	// Returns (0, false, nil) when the deny list is empty or no entries are canonical.
+	//
+	// Used at reset time to cap the safe head to (height - 1) so that derivation
+	// re-derives the denied block, hits the IsDenied check, and emits
+	// deposits-only attributes that replace the block via consolidation.
+	CanonicalDeniedHeight(ctx context.Context, canonical CanonicalChain) (uint64, bool, error)
 }
 
 // SafeHeadListener is called when the safe head is updated.

--- a/op-node/rollup/sync/start.go
+++ b/op-node/rollup/sync/start.go
@@ -74,7 +74,11 @@ type FindHeadsResult struct {
 // currentHeads returns the current finalized, safe and unsafe heads of the execution engine.
 // If nothing has been marked finalized yet, the finalized head defaults to the genesis block.
 // If nothing has been marked safe yet, the safe head defaults to the finalized block.
-func currentHeads(ctx context.Context, cfg *rollup.Config, l2 L2Chain) (*FindHeadsResult, error) {
+//
+// When `authority` is non-nil, the deny-list cap is applied (see ApplyDenyCap)
+// before the result is returned, so callers always see a safe/finalized that is
+// strictly below any still-canonical denied block.
+func currentHeads(ctx context.Context, cfg *rollup.Config, l2 L2Chain, authority rollup.SuperAuthority) (*FindHeadsResult, error) {
 	finalized, err := l2.L2BlockRefByLabel(ctx, eth.Finalized)
 	if errors.Is(err, ethereum.NotFound) {
 		// default to genesis if we have not finalized anything before.
@@ -95,11 +99,57 @@ func currentHeads(ctx context.Context, cfg *rollup.Config, l2 L2Chain) (*FindHea
 	if err != nil {
 		return nil, fmt.Errorf("failed to find the L2 head block: %w", err)
 	}
-	return &FindHeadsResult{
+	result := &FindHeadsResult{
 		Unsafe:    unsafe,
 		Safe:      safe,
 		Finalized: finalized,
-	}, nil
+	}
+	if err := ApplyDenyCap(ctx, l2, authority, result); err != nil {
+		return nil, fmt.Errorf("failed to apply deny-list cap: %w", err)
+	}
+	return result, nil
+}
+
+// ApplyDenyCap lowers result.Safe and result.Finalized to (height - 1) when
+// the supplied authority reports a canonical denied block. Unsafe is intentionally
+// left untouched so the downstream consolidation path detects a mismatch and
+// reorgs the unsafe chain to the deposits-only replacement block.
+//
+// Idempotent: a second call on an already-capped result is a no-op. Safe to
+// call with authority == nil (returns nil without consulting the EL).
+//
+// Finalized is capped defensively. By construction (interop finalization is
+// gated on cross-chain verification having passed for every block up to it),
+// a denied block cannot have a finalized height that exceeds the cap; capping
+// finalized locally keeps the `finalized <= safe` invariant obvious to callers
+// and to the engine controller.
+func ApplyDenyCap(ctx context.Context, l2 L2Chain, authority rollup.SuperAuthority, result *FindHeadsResult) error {
+	if authority == nil || result == nil {
+		return nil
+	}
+	height, found, err := authority.CanonicalDeniedHeight(ctx, l2)
+	if err != nil {
+		return fmt.Errorf("query canonical denied height: %w", err)
+	}
+	if !found || height == 0 {
+		return nil
+	}
+	target := height - 1
+	if result.Safe.Number > target {
+		ref, err := l2.L2BlockRefByNumber(ctx, target)
+		if err != nil {
+			return fmt.Errorf("fetch deny-cap safe target at %d: %w", target, err)
+		}
+		result.Safe = ref
+	}
+	if result.Finalized.Number > target {
+		ref, err := l2.L2BlockRefByNumber(ctx, target)
+		if err != nil {
+			return fmt.Errorf("fetch deny-cap finalized target at %d: %w", target, err)
+		}
+		result.Finalized = ref
+	}
+	return nil
 }
 
 // DurationToBlocks returns ceil(offset / blockTime) as a block count.
@@ -130,7 +180,10 @@ func OffsetBlockNum(offset time.Duration, blockTime uint64, head uint64, genesis
 
 // L2HeadsForELSyncWithOffset returns the heads for an EL-sync tip: unsafe stays at tip,
 // safe and finalized retract by ceil(offset / blockTime) blocks (clamped at genesis).
-func L2HeadsForELSyncWithOffset(ctx context.Context, cfg *rollup.Config, l2 L2Chain, syncCfg *Config, tip eth.L2BlockRef) (*FindHeadsResult, error) {
+//
+// The deny-list cap (if any) is composed with the offset: whichever is lower
+// wins. Both can only lower safe/finalized, never raise them.
+func L2HeadsForELSyncWithOffset(ctx context.Context, cfg *rollup.Config, l2 L2Chain, syncCfg *Config, tip eth.L2BlockRef, authority rollup.SuperAuthority) (*FindHeadsResult, error) {
 	target := OffsetBlockNum(syncCfg.OffsetELSafe, cfg.BlockTime, tip.Number, cfg.Genesis.L2.Number)
 	derived := tip
 	if target < tip.Number {
@@ -140,7 +193,11 @@ func L2HeadsForELSyncWithOffset(ctx context.Context, cfg *rollup.Config, l2 L2Ch
 		}
 		derived = ref
 	}
-	return &FindHeadsResult{Unsafe: tip, Safe: derived, Finalized: derived}, nil
+	result := &FindHeadsResult{Unsafe: tip, Safe: derived, Finalized: derived}
+	if err := ApplyDenyCap(ctx, l2, authority, result); err != nil {
+		return nil, fmt.Errorf("failed to apply deny-list cap to EL-sync heads: %w", err)
+	}
+	return result, nil
 }
 
 // FindL2Heads walks back from `start` (the previous unsafe L2 block) and finds
@@ -156,9 +213,9 @@ func L2HeadsForELSyncWithOffset(ctx context.Context, cfg *rollup.Config, l2 L2Ch
 // Plausible: meaning that the blockhash of the L2 block's L1 origin
 // (as reported in the L1 Attributes deposit within the L2 block) is not canonical at another height in the L1 chain,
 // and the same holds for all its ancestors.
-func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain, lgr log.Logger, syncCfg *Config) (result *FindHeadsResult, err error) {
-	// Fetch current L2 forkchoice state
-	result, err = currentHeads(ctx, cfg, l2)
+func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain, lgr log.Logger, syncCfg *Config, authority rollup.SuperAuthority) (result *FindHeadsResult, err error) {
+	// Fetch current L2 forkchoice state (deny-list cap applied inside currentHeads).
+	result, err = currentHeads(ctx, cfg, l2, authority)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch current L2 forkchoice state: %w", err)
 	}
@@ -173,7 +230,7 @@ func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain
 		result.Unsafe.Number > cfg.Genesis.L2.Number &&
 		result.Unsafe.L1Origin.Number > cfg.Genesis.L1.Number+(RecoverMinSeqWindows*cfg.SeqWindowSize) {
 		lgr.Warn("Attempting recovery from sync state without finality.", "head", result.Unsafe)
-		return L2HeadsForELSyncWithOffset(ctx, cfg, l2, syncCfg, result.Unsafe)
+		return L2HeadsForELSyncWithOffset(ctx, cfg, l2, syncCfg, result.Unsafe, authority)
 	}
 
 	// Check if the execution engine corrupted, and forkchoice is ahead of the remaining chain:
@@ -181,7 +238,7 @@ func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain
 	if result.Unsafe.Number < result.Finalized.Number || result.Unsafe.Number < result.Safe.Number {
 		lgr.Error("Unsafe head is behind known finalized/safe blocks, execution-engine chain must have been rewound without forkchoice update. Attempting recovery now.",
 			"unsafe_head", result.Unsafe, "safe_head", result.Safe, "finalized_head", result.Finalized)
-		return L2HeadsForELSyncWithOffset(ctx, cfg, l2, syncCfg, result.Unsafe)
+		return L2HeadsForELSyncWithOffset(ctx, cfg, l2, syncCfg, result.Unsafe, authority)
 	}
 
 	// Remember original unsafe block to determine reorg depth

--- a/op-node/rollup/sync/start_deny_cap_test.go
+++ b/op-node/rollup/sync/start_deny_cap_test.go
@@ -1,0 +1,202 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// stubL2 is a minimal L2Chain stub for cap-helper tests. Only L2BlockRefByNumber
+// is exercised — the other methods panic so accidental use is loud.
+type stubL2 struct {
+	byNumber map[uint64]eth.L2BlockRef
+	err      error
+}
+
+func newStubL2(refs ...eth.L2BlockRef) *stubL2 {
+	s := &stubL2{byNumber: make(map[uint64]eth.L2BlockRef, len(refs))}
+	for _, r := range refs {
+		s.byNumber[r.Number] = r
+	}
+	return s
+}
+
+func (s *stubL2) L2BlockRefByHash(ctx context.Context, h common.Hash) (eth.L2BlockRef, error) {
+	panic("stubL2.L2BlockRefByHash should not be called")
+}
+
+func (s *stubL2) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
+	panic("stubL2.L2BlockRefByLabel should not be called")
+}
+
+func (s *stubL2) L2BlockRefByNumber(ctx context.Context, number uint64) (eth.L2BlockRef, error) {
+	if s.err != nil {
+		return eth.L2BlockRef{}, s.err
+	}
+	ref, ok := s.byNumber[number]
+	if !ok {
+		return eth.L2BlockRef{}, fmt.Errorf("no block at number %d", number)
+	}
+	return ref, nil
+}
+
+// stubAuthority implements rollup.SuperAuthority for cap tests. It only
+// implements CanonicalDeniedHeight non-trivially; the other methods return
+// empty values.
+type stubAuthority struct {
+	canonicalDeniedHeight uint64
+	canonicalDeniedFound  bool
+	canonicalDeniedErr    error
+}
+
+func (s *stubAuthority) FullyVerifiedL2Head() (eth.BlockID, bool) { return eth.BlockID{}, false }
+func (s *stubAuthority) FinalizedL2Head() (eth.BlockID, bool)     { return eth.BlockID{}, false }
+func (s *stubAuthority) IsDenied(uint64, common.Hash) (bool, error) {
+	return false, nil
+}
+func (s *stubAuthority) CanonicalDeniedHeight(_ context.Context, _ rollup.CanonicalChain) (uint64, bool, error) {
+	return s.canonicalDeniedHeight, s.canonicalDeniedFound, s.canonicalDeniedErr
+}
+
+func makeRef(n uint64, hash common.Hash) eth.L2BlockRef {
+	return eth.L2BlockRef{Number: n, Hash: hash}
+}
+
+func TestApplyDenyCap(t *testing.T) {
+	t.Parallel()
+
+	hashAt := func(n uint64) common.Hash {
+		return common.BigToHash(common.Big1.Add(common.Big1, common.Big1.SetUint64(n)))
+	}
+
+	t.Run("nil authority is a no-op", func(t *testing.T) {
+		t.Parallel()
+		result := &FindHeadsResult{
+			Unsafe:    makeRef(100, hashAt(100)),
+			Safe:      makeRef(80, hashAt(80)),
+			Finalized: makeRef(60, hashAt(60)),
+		}
+		before := *result
+		require.NoError(t, ApplyDenyCap(context.Background(), newStubL2(), nil, result))
+		require.Equal(t, before, *result)
+	})
+
+	t.Run("no canonical denied block is a no-op", func(t *testing.T) {
+		t.Parallel()
+		result := &FindHeadsResult{
+			Unsafe:    makeRef(100, hashAt(100)),
+			Safe:      makeRef(80, hashAt(80)),
+			Finalized: makeRef(60, hashAt(60)),
+		}
+		before := *result
+		auth := &stubAuthority{canonicalDeniedFound: false}
+		require.NoError(t, ApplyDenyCap(context.Background(), newStubL2(), auth, result))
+		require.Equal(t, before, *result)
+	})
+
+	t.Run("safe above cap is lowered; finalized below stays put", func(t *testing.T) {
+		t.Parallel()
+		// cap = 50, target = 49
+		result := &FindHeadsResult{
+			Unsafe:    makeRef(100, hashAt(100)),
+			Safe:      makeRef(80, hashAt(80)),
+			Finalized: makeRef(30, hashAt(30)), // below target
+		}
+		l2 := newStubL2(makeRef(49, hashAt(49)))
+		auth := &stubAuthority{canonicalDeniedHeight: 50, canonicalDeniedFound: true}
+
+		require.NoError(t, ApplyDenyCap(context.Background(), l2, auth, result))
+
+		require.Equal(t, uint64(49), result.Safe.Number, "safe lowered to cap-1")
+		require.Equal(t, hashAt(49), result.Safe.Hash)
+		require.Equal(t, uint64(30), result.Finalized.Number, "finalized below target unchanged")
+		require.Equal(t, uint64(100), result.Unsafe.Number, "unsafe must not be capped")
+	})
+
+	t.Run("safe and finalized both above cap both lowered", func(t *testing.T) {
+		t.Parallel()
+		result := &FindHeadsResult{
+			Unsafe:    makeRef(100, hashAt(100)),
+			Safe:      makeRef(80, hashAt(80)),
+			Finalized: makeRef(70, hashAt(70)),
+		}
+		l2 := newStubL2(makeRef(49, hashAt(49)))
+		auth := &stubAuthority{canonicalDeniedHeight: 50, canonicalDeniedFound: true}
+
+		require.NoError(t, ApplyDenyCap(context.Background(), l2, auth, result))
+
+		require.Equal(t, uint64(49), result.Safe.Number)
+		require.Equal(t, uint64(49), result.Finalized.Number)
+		require.Equal(t, uint64(100), result.Unsafe.Number)
+	})
+
+	t.Run("idempotent: second call on capped result is a no-op", func(t *testing.T) {
+		t.Parallel()
+		result := &FindHeadsResult{
+			Unsafe:    makeRef(100, hashAt(100)),
+			Safe:      makeRef(49, hashAt(49)),
+			Finalized: makeRef(49, hashAt(49)),
+		}
+		before := *result
+		l2 := newStubL2(makeRef(49, hashAt(49)))
+		auth := &stubAuthority{canonicalDeniedHeight: 50, canonicalDeniedFound: true}
+
+		require.NoError(t, ApplyDenyCap(context.Background(), l2, auth, result))
+		require.Equal(t, before, *result, "already at target, nothing to lower")
+	})
+
+	t.Run("cap target lookup error surfaces", func(t *testing.T) {
+		t.Parallel()
+		result := &FindHeadsResult{
+			Unsafe:    makeRef(100, hashAt(100)),
+			Safe:      makeRef(80, hashAt(80)),
+			Finalized: makeRef(70, hashAt(70)),
+		}
+		l2 := &stubL2{err: errors.New("EL unavailable")}
+		auth := &stubAuthority{canonicalDeniedHeight: 50, canonicalDeniedFound: true}
+
+		err := ApplyDenyCap(context.Background(), l2, auth, result)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "EL unavailable")
+	})
+
+	t.Run("authority error surfaces", func(t *testing.T) {
+		t.Parallel()
+		result := &FindHeadsResult{
+			Unsafe:    makeRef(100, hashAt(100)),
+			Safe:      makeRef(80, hashAt(80)),
+			Finalized: makeRef(70, hashAt(70)),
+		}
+		auth := &stubAuthority{canonicalDeniedErr: errors.New("bbolt corruption")}
+		err := ApplyDenyCap(context.Background(), newStubL2(), auth, result)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bbolt corruption")
+	})
+
+	t.Run("cap at height 1 lowers safe to genesis (target 0)", func(t *testing.T) {
+		t.Parallel()
+		result := &FindHeadsResult{
+			Unsafe:    makeRef(10, hashAt(10)),
+			Safe:      makeRef(5, hashAt(5)),
+			Finalized: makeRef(0, hashAt(0)),
+		}
+		l2 := newStubL2(makeRef(0, hashAt(0)))
+		auth := &stubAuthority{canonicalDeniedHeight: 1, canonicalDeniedFound: true}
+
+		require.NoError(t, ApplyDenyCap(context.Background(), l2, auth, result))
+		require.Equal(t, uint64(0), result.Safe.Number)
+	})
+
+	t.Run("nil result is a no-op (defensive)", func(t *testing.T) {
+		t.Parallel()
+		auth := &stubAuthority{canonicalDeniedHeight: 50, canonicalDeniedFound: true}
+		require.NoError(t, ApplyDenyCap(context.Background(), newStubL2(), auth, nil))
+	})
+}

--- a/op-node/rollup/sync/start_test.go
+++ b/op-node/rollup/sync/start_test.go
@@ -76,7 +76,7 @@ func (c *syncStartTestCase) Run(t *testing.T) {
 		SeqWindowSize: c.SeqWindowSize,
 	}
 	lgr := log.NewLogger(log.DiscardHandler())
-	result, err := FindL2Heads(context.Background(), cfg, chain, chain, lgr, &Config{})
+	result, err := FindL2Heads(context.Background(), cfg, chain, chain, lgr, &Config{}, nil)
 	if c.ExpectedErr != nil {
 		require.ErrorIs(t, err, c.ExpectedErr, "expected error")
 		return
@@ -464,7 +464,7 @@ func TestL2HeadsForELSyncWithOffset(t *testing.T) {
 			m := &testutils.MockL2Client{}
 			tt.stub(m)
 			syncCfg := &Config{OffsetELSafe: tt.offset}
-			result, err := L2HeadsForELSyncWithOffset(ctx, cfg, m, syncCfg, tt.tip)
+			result, err := L2HeadsForELSyncWithOffset(ctx, cfg, m, syncCfg, tt.tip, nil)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -1125,8 +1125,8 @@ func (m *algoMockChain) BlockTime() uint64 {
 	}
 	return 1
 }
-func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
-	return false, nil
+func (m *algoMockChain) RecordInvalidation(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
+	return nil
 }
 func (m *algoMockChain) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
 	out := &eth.OutputV0{}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -708,22 +708,22 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		sort.Slice(invalidations, func(i, j int) bool {
 			return invalidations[i].ChainID.Cmp(invalidations[j].ChainID) < 0
 		})
-		// Freeze ALL chains' VNs before rewinding any. Without this, a non-invalidated
-		// chain's still-running VN can observe the interop state change from onReset and
-		// issue a ForkchoiceUpdate that advances its safe head. If that chain is later
-		// invalidated (e.g. transitive invalidation across multiple rounds), its rewind
-		// will be rejected because the safe head was already advanced.
-		// This is broader than freezing only invalid chains because transitive invalidation
-		// requires multiple verification rounds — a chain valid in round N may become
-		// invalid in round N+1 after its dependency is replaced.
+		// Freeze ALL chains' VNs before recording any invalidation. Without this,
+		// a non-invalidated chain's still-running VN can read the invalidated
+		// chain's cross-chain verified state via FullyVerifiedL2Head and advance
+		// its own LocalSafeL2 onto blocks built on the now-denied state before
+		// the deny-list write completes. This is broader than freezing only the
+		// invalidated chains because transitive invalidation may produce
+		// additional invalidations in a later verification round that depend on
+		// the current ones having taken effect.
 		for chainID, chain := range i.chains {
 			if err := chain.PauseAndStopVN(i.ctx); err != nil {
-				i.log.Error("failed to freeze chain before rewind", "chainID", chainID, "err", err)
+				i.log.Error("failed to freeze chain before invalidation", "chainID", chainID, "err", err)
 			}
 		}
 		var failedAny bool
 		for _, p := range invalidations {
-			if err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp, p.StateRoot, p.MessagePasserStorageRoot); err != nil {
+			if err := i.recordInvalidation(p.ChainID, p.BlockID, p.Timestamp, p.StateRoot, p.MessagePasserStorageRoot); err != nil {
 				i.log.Error("invalidation failed, transition preserved for retry on restart",
 					"chain", p.ChainID, "block", p.BlockID, "err", err)
 				failedAny = true
@@ -731,11 +731,20 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 				i.metrics.InteropInvalidations.WithLabelValues(p.ChainID.String()).Inc()
 			}
 		}
-		// Resume non-invalidated chains. Invalidated chains are resumed by RewindEngine.
+		// Resume invalidated chains first so their VNs restart and apply the
+		// safe-head cap (which drives the deposits-only reorg) before
+		// non-invalidated chains observe their post-reorg cross-chain state.
+		for chainID, chain := range i.chains {
+			if _, isInvalid := pending.Result.InvalidHeads[chainID]; isInvalid {
+				if err := chain.Resume(i.ctx); err != nil {
+					i.log.Error("failed to resume invalidated chain", "chainID", chainID, "err", err)
+				}
+			}
+		}
 		for chainID, chain := range i.chains {
 			if _, isInvalid := pending.Result.InvalidHeads[chainID]; !isInvalid {
 				if err := chain.Resume(i.ctx); err != nil {
-					i.log.Error("failed to resume chain after rewind", "chainID", chainID, "err", err)
+					i.log.Error("failed to resume non-invalidated chain", "chainID", chainID, "err", err)
 				}
 			}
 		}
@@ -1141,13 +1150,14 @@ func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef)
 func (i *Interop) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock eth.BlockRef) {
 }
 
-// invalidateBlock notifies the chain container to add the block to the denylist
-// and potentially rewind if the chain is currently using that block.
-func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
+// recordInvalidation notifies the chain container to add the block to the
+// deny list. The chain reorg itself is driven by the safe-head cap that
+// op-node applies during the next VN reset (see SuperAuthority.CanonicalDeniedHeight
+// and sync.ApplyDenyCap); callers must restart the VN after this returns.
+func (i *Interop) recordInvalidation(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
 	chain, ok := i.chains[chainID]
 	if !ok {
 		return fmt.Errorf("chain %s not found", chainID)
 	}
-	_, err := chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp, stateRoot, messagePasserStorageRoot)
-	return err
+	return chain.RecordInvalidation(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp, stateRoot, messagePasserStorageRoot)
 }

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1134,12 +1134,12 @@ func TestApplyResultCompat(t *testing.T) {
 }
 
 // =============================================================================
-// TestInvalidateBlock
+// TestRecordInvalidation
 // =============================================================================
 
-// TestInvalidateBlock verifies the invalidateBlock method correctly calls
+// TestRecordInvalidation verifies the invalidateBlock method correctly calls
 // ChainContainer.InvalidateBlock with the right parameters and handles errors.
-func TestInvalidateBlock(t *testing.T) {
+func TestRecordInvalidation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -1148,14 +1148,14 @@ func TestInvalidateBlock(t *testing.T) {
 		run   func(t *testing.T, h *interopTestHarness)
 	}{
 		{
-			name: "calls chain.InvalidateBlock with correct args",
+			name: "calls chain.RecordInvalidation with correct args",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithChain(10, nil).Build()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
+				err := h.interop.recordInvalidation(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
 				require.NoError(t, err)
 
 				require.Len(t, mock.invalidateBlockCalls, 1)
@@ -1172,7 +1172,7 @@ func TestInvalidateBlock(t *testing.T) {
 				mock := h.Mock(10)
 				unknownChain := eth.ChainIDFromUInt64(999)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(unknownChain, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
+				err := h.interop.recordInvalidation(unknownChain, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "not found")
@@ -1180,7 +1180,7 @@ func TestInvalidateBlock(t *testing.T) {
 			},
 		},
 		{
-			name: "returns error when chain.InvalidateBlock fails",
+			name: "returns error when chain.RecordInvalidation fails",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithChain(10, func(m *mockChainContainer) {
 					m.invalidateBlockErr = errors.New("engine failure")
@@ -1189,7 +1189,7 @@ func TestInvalidateBlock(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
+				err := h.interop.recordInvalidation(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "engine failure")
@@ -1697,9 +1697,8 @@ type mockChainContainer struct {
 	lastRequestedTimestamp uint64
 	mu                     sync.Mutex
 
-	// InvalidateBlock tracking
+	// recordInvalidation tracking
 	invalidateBlockCalls []invalidateBlockCall
-	invalidateBlockRet   bool
 	invalidateBlockErr   error
 	pruneDeniedResult    map[uint64][]common.Hash
 	rewindEngineCalls    []uint64
@@ -1958,16 +1957,16 @@ func (m *mockChainContainer) BlockTime() uint64 {
 	}
 	return 1
 }
-func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
+func (m *mockChainContainer) RecordInvalidation(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
 	m.mu.Lock()
 	m.invalidateBlockCalls = append(m.invalidateBlockCalls, invalidateBlockCall{
 		height: height, payloadHash: payloadHash, stateRoot: stateRoot, messagePasserStorageRoot: messagePasserStorageRoot,
 	})
 	m.mu.Unlock()
 	if m.callLog != nil {
-		m.callLog.record(m.id, "InvalidateBlock")
+		m.callLog.record(m.id, "RecordInvalidation")
 	}
-	return m.invalidateBlockRet, m.invalidateBlockErr
+	return m.invalidateBlockErr
 }
 func (m *mockChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
 	if m.outputV0Override != nil {
@@ -2018,7 +2017,7 @@ func TestWAL_PreservedOnInvalidationFailure(t *testing.T) {
 	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
 					WithChain(10, func(m *mockChainContainer) {
 			m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
-			m.invalidateBlockErr = errors.New("engine failure") // InvalidateBlock will fail
+			m.invalidateBlockErr = errors.New("engine failure") // RecordInvalidation will fail
 		}).
 		Build()
 
@@ -2759,9 +2758,10 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 // TestFreezeAllBeforeRewind verifies the freeze-all-then-resume behavior
 // introduced in applyPendingTransition for DecisionInvalidate:
 //   - All chains (not just invalidated ones) are frozen via PauseAndStopVN
-//     before any invalidateBlock call
-//   - Only non-invalidated chains are resumed after the invalidation loop
-//   - Invalidated chains are NOT resumed (RewindEngine handles that internally)
+//     before any RecordInvalidation call
+//   - After the invalidation loop, ALL chains are resumed: invalidated chains
+//     first (so their VNs restart and apply the deny-list cap before
+//     non-invalidated chains observe the post-reorg state), then the rest.
 func TestFreezeAllBeforeRewind(t *testing.T) {
 	t.Parallel()
 
@@ -2814,21 +2814,21 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 		require.Equal(t, 1, h.Mock(8453).pauseAndStopVNCalls, "chain 8453 should be frozen")
 		require.Equal(t, 1, h.Mock(42).pauseAndStopVNCalls, "chain 42 should be frozen")
 
-		// Find the index of the first InvalidateBlock call.
+		// Find the index of the first RecordInvalidation call.
 		firstInvalidateIdx := -1
 		for i, e := range entries {
-			if e.method == "InvalidateBlock" {
+			if e.method == "RecordInvalidation" {
 				firstInvalidateIdx = i
 				break
 			}
 		}
 		require.NotEqual(t, -1, firstInvalidateIdx, "should have at least one InvalidateBlock call")
 
-		// Every PauseAndStopVN must come before the first InvalidateBlock.
+		// Every PauseAndStopVN must come before the first RecordInvalidation.
 		for i, e := range entries {
 			if e.method == "PauseAndStopVN" {
 				require.Less(t, i, firstInvalidateIdx,
-					"PauseAndStopVN on chain %s (index %d) must precede first InvalidateBlock (index %d)",
+					"PauseAndStopVN on chain %s (index %d) must precede first RecordInvalidation (index %d)",
 					e.chainID, i, firstInvalidateIdx)
 			}
 		}
@@ -2879,10 +2879,33 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 		_, err = h.interop.applyPendingTransition(pending)
 		require.NoError(t, err)
 
-		// Only chain 42 (non-invalidated) should have Resume called.
-		require.Equal(t, 0, h.Mock(10).resumeCalls, "invalidated chain 10 should NOT be resumed")
-		require.Equal(t, 0, h.Mock(8453).resumeCalls, "invalidated chain 8453 should NOT be resumed")
-		require.Equal(t, 1, h.Mock(42).resumeCalls, "non-invalidated chain 42 should be resumed")
+		// Every chain — invalidated or not — should have Resume called once
+		// so its VN restarts. Invalidated chains restart so the deny-list cap
+		// fires during their reset; non-invalidated chains restart so they
+		// resume normal operation after the freeze.
+		require.Equal(t, 1, h.Mock(10).resumeCalls, "invalidated chain 10 must be resumed (cap fires on restart)")
+		require.Equal(t, 1, h.Mock(8453).resumeCalls, "invalidated chain 8453 must be resumed")
+		require.Equal(t, 1, h.Mock(42).resumeCalls, "non-invalidated chain 42 must be resumed")
+
+		// Invalidated chains must be resumed before non-invalidated ones.
+		invalidated := map[eth.ChainID]bool{chain10: true, chain8453: true}
+		entries := cl.snapshot()
+		lastInvalidatedResumeIdx := -1
+		firstNonInvalidatedResumeIdx := -1
+		for i, e := range entries {
+			if e.method != "Resume" {
+				continue
+			}
+			if invalidated[e.chainID] {
+				lastInvalidatedResumeIdx = i
+			} else if firstNonInvalidatedResumeIdx == -1 {
+				firstNonInvalidatedResumeIdx = i
+			}
+		}
+		require.NotEqual(t, -1, lastInvalidatedResumeIdx)
+		require.NotEqual(t, -1, firstNonInvalidatedResumeIdx)
+		require.Less(t, lastInvalidatedResumeIdx, firstNonInvalidatedResumeIdx,
+			"all invalidated-chain Resumes must precede non-invalidated Resumes")
 	})
 
 	t.Run("resume happens after all invalidations", func(t *testing.T) {
@@ -2925,26 +2948,26 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 
 		entries := cl.snapshot()
 
-		// Find the last InvalidateBlock index.
+		// Find the last RecordInvalidation index.
 		lastInvalidateIdx := -1
 		for i, e := range entries {
-			if e.method == "InvalidateBlock" {
+			if e.method == "RecordInvalidation" {
 				lastInvalidateIdx = i
 			}
 		}
 		require.NotEqual(t, -1, lastInvalidateIdx)
 
-		// Every Resume must come after the last InvalidateBlock.
+		// Every Resume must come after the last RecordInvalidation.
 		for i, e := range entries {
 			if e.method == "Resume" {
 				require.Greater(t, i, lastInvalidateIdx,
-					"Resume on chain %s (index %d) must follow last InvalidateBlock (index %d)",
+					"Resume on chain %s (index %d) must follow last RecordInvalidation (index %d)",
 					e.chainID, i, lastInvalidateIdx)
 			}
 		}
 	})
 
-	t.Run("single chain invalidated freezes and does not resume", func(t *testing.T) {
+	t.Run("single chain invalidated is frozen then resumed", func(t *testing.T) {
 		cl := &callLog{}
 		h := newInteropTestHarness(t).
 			WithChain(10, func(m *mockChainContainer) {
@@ -2955,7 +2978,8 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 
 		chain10 := h.Mock(10).id
 
-		// The only chain is invalidated — no chain should be resumed.
+		// The only chain is invalidated and should still be resumed so its VN
+		// restarts and applies the deny-list cap.
 		invalidResult := Result{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
@@ -2977,11 +3001,6 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls, "chain should be frozen")
-		require.Equal(t, 0, h.Mock(10).resumeCalls, "invalidated chain should NOT be resumed")
-
-		entries := cl.snapshot()
-		for _, e := range entries {
-			require.NotEqual(t, "Resume", e.method, "no Resume calls expected when all chains are invalidated")
-		}
+		require.Equal(t, 1, h.Mock(10).resumeCalls, "invalidated chain must be resumed so its VN restarts and the cap fires")
 	})
 }

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -99,7 +99,7 @@ type ChainContainer interface {
 }
 
 // WARNING: InteropChain exposes the reorg-triggering operations (RewindEngine,
-// InvalidateBlock) that bypass the interop WAL model when invoked outside of
+// RecordInvalidation) that bypass the interop WAL model when invoked outside of
 // interop transition application. ONLY the interop activity should accept or
 // hold a value of this interface. Every other caller must take the narrower
 // ChainContainer above so the misuse is caught at compile time.
@@ -110,12 +110,16 @@ type InteropChain interface {
 	HasDeniedAtOrAfterTimestamp(timestamp uint64) (bool, error)
 	// RewindEngine rewinds the engine to the highest block with timestamp less than
 	// or equal to the given timestamp. invalidatedBlock is the block that triggered
-	// the rewind and is passed to reset callbacks.
+	// the rewind and is passed to reset callbacks. Used by the DecisionRewind path
+	// for whole-chain rewinds (not the deny-list-driven invalidation path; see
+	// RecordInvalidation).
 	RewindEngine(ctx context.Context, timestamp uint64, invalidatedBlock eth.BlockRef) error
-	// InvalidateBlock adds a block to the deny list and triggers a rewind if the
-	// chain currently uses that block at the specified height. Returns true if a
-	// rewind was triggered, false otherwise.
-	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error)
+	// RecordInvalidation persists a denied payload hash (and its OutputV0
+	// preimages) at the given height. The chain reorg is driven by the cap
+	// applied during the next VN reset (see SuperAuthority.CanonicalDeniedHeight
+	// and sync.ApplyDenyCap), not by this call. Callers must therefore restart
+	// the VN after RecordInvalidation completes.
+	RecordInvalidation(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error
 }
 
 type virtualNodeFactory func(cfg *opnodecfg.Config, log gethlog.Logger, initOverrides *rollupNode.InitializationOverrides, appVersion string, superAuthority rollup.SuperAuthority) virtual_node.VirtualNode

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum/go-ethereum/common"
 	bolt "go.etcd.io/bbolt"
 )
@@ -254,6 +253,77 @@ func (d *DenyList) GetDeniedHashes(height uint64) ([]common.Hash, error) {
 	return hashes, err
 }
 
+// CanonicalDeniedHeight walks denied heights from highest to lowest and returns
+// the lowest height whose denied payload hash matches the canonical hash at
+// that height (as reported by `canonical`). Iteration stops at the first height
+// where no denied entry is canonical, assuming canonical-vs-denied status is
+// monotone in height (lower heights are parents of higher ones, so once we hit
+// a non-canonical entry while walking down, lower entries are expected to have
+// already been reorged out by an earlier remediation cycle).
+//
+// Returns (height, true, nil) when a canonical denied entry is found.
+// Returns (0, false, nil) when the deny list is empty or no entries are canonical.
+//
+// `canonical` returns the canonical block hash at the given height. If it
+// returns an error (e.g. the EL hasn't synced that far yet), that height is
+// treated as non-canonical and iteration stops.
+func (d *DenyList) CanonicalDeniedHeight(ctx context.Context, canonical func(ctx context.Context, height uint64) (common.Hash, error)) (uint64, bool, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var (
+		lowestCanonical uint64
+		found           bool
+	)
+
+	err := d.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(denyListBucketName)
+		c := b.Cursor()
+
+		// Reverse iteration: highest height first.
+		for k, v := c.Last(); k != nil; k, v = c.Prev() {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			height := binary.BigEndian.Uint64(k)
+
+			records, decErr := decodeDenyRecords(v)
+			if decErr != nil {
+				return decErr
+			}
+			if len(records) == 0 {
+				continue
+			}
+
+			canonHash, cErr := canonical(ctx, height)
+			if cErr != nil {
+				// Canonical probe failed — treat as non-canonical and stop.
+				return nil
+			}
+
+			var match bool
+			for _, r := range records {
+				if r.PayloadHash == canonHash {
+					match = true
+					break
+				}
+			}
+			if !match {
+				// First non-canonical entry — stop iteration.
+				return nil
+			}
+			lowestCanonical = height
+			found = true
+		}
+		return nil
+	})
+
+	if err != nil {
+		return 0, false, err
+	}
+	return lowestCanonical, found, nil
+}
+
 // GetDeniedRecords returns all denied records at the given block height.
 func (d *DenyList) GetDeniedRecords(height uint64) ([]DenyRecord, error) {
 	d.mu.RLock()
@@ -360,28 +430,42 @@ func (d *DenyList) Close() error {
 	return d.db.Close()
 }
 
-// InvalidateBlock is part of the InteropChain interface — callers must hold
+// RecordInvalidation is part of the InteropChain interface — callers must hold
 // that wider interface (only interop transition application does) to invoke it.
-// Adds a block to the deny list and triggers a rewind if the chain currently
-// uses that block at the specified height.
-// Returns true if a rewind was triggered, false otherwise.
-// Note: Genesis block (height=0) cannot be invalidated as there is no prior block to rewind to.
-func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
+//
+// Persists a denied payload hash (plus its OutputV0 preimages) at the given
+// L2 block height. The actual chain reorg is driven separately: when the
+// virtual node restarts, op-node's reset path consults
+// SuperAuthority.CanonicalDeniedHeight and caps the safe head to (height - 1).
+// Derivation then re-derives the denied block, sees it on the deny list via
+// payload_process.go IsDenied, and emits deposits-only attributes that replace
+// the block via consolidation; the unsafe chain is reorged by op-reth on the
+// resulting FCU.
+//
+// Genesis block (height=0) cannot be invalidated as there is no prior block to
+// cap to. StateRoot and MessagePasserStorageRoot must be non-zero: downstream
+// optimistic-output-root computation depends on them, and zero values would
+// silently produce incorrect output roots.
+func (c *simpleChainContainer) RecordInvalidation(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
 	if c.denyList == nil {
-		return false, fmt.Errorf("deny list not initialized")
+		return fmt.Errorf("deny list not initialized")
 	}
-
-	// Cannot invalidate genesis block - there is no prior block to rewind to
 	if height == 0 {
-		return false, fmt.Errorf("cannot invalidate genesis block (height=0)")
+		return fmt.Errorf("cannot invalidate genesis block (height=0)")
+	}
+	var zero eth.Bytes32
+	if stateRoot == zero {
+		return fmt.Errorf("refusing to record invalidation with zero state root at height %d", height)
+	}
+	if messagePasserStorageRoot == zero {
+		return fmt.Errorf("refusing to record invalidation with zero message-passer storage root at height %d", height)
 	}
 
-	// Add to deny list with the output preimage fields
 	if err := c.denyList.Add(height, payloadHash, decisionTimestamp, stateRoot, messagePasserStorageRoot); err != nil {
-		return false, fmt.Errorf("failed to add block to deny list: %w", err)
+		return fmt.Errorf("failed to add block to deny list: %w", err)
 	}
 
-	c.log.Info("added block to deny list",
+	c.log.Info("recorded invalidation in deny list",
 		"height", height,
 		"payloadHash", payloadHash,
 	)
@@ -390,54 +474,7 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Inc()
 	}
 
-	// Errors here propagate so the caller preserves the pending transition for
-	// retry on restart; the deny list entry above is already durable.
-	if c.engine == nil {
-		return false, fmt.Errorf("cannot check current block at height %d: %w", height, engine_controller.ErrNoEngineClient)
-	}
-
-	currentBlock, err := c.engine.L2BlockRefByNumber(ctx, height)
-	if err != nil {
-		return false, fmt.Errorf("failed to get current block at height %d: %w", height, err)
-	}
-
-	// Compare the current block hash with the invalidated hash
-	if currentBlock.Hash != payloadHash {
-		c.log.Info("current block differs from invalidated block, no rewind needed",
-			"height", height,
-			"currentHash", currentBlock.Hash,
-			"invalidatedHash", payloadHash,
-		)
-		return false, nil
-	}
-
-	c.log.Warn("current block matches invalidated block, initiating rewind",
-		"height", height,
-		"hash", payloadHash,
-	)
-
-	invalidatedBlock := currentBlock.BlockRef()
-
-	// Rewind to the prior block's timestamp
-	priorTimestamp, err := c.BlockNumberToTimestamp(ctx, height-1)
-	if err != nil {
-		return false, fmt.Errorf("failed to compute rewind timestamp: %w", err)
-	}
-	if err := c.RewindEngine(ctx, priorTimestamp, invalidatedBlock); err != nil {
-		return false, fmt.Errorf("failed to rewind engine: %w", err)
-	}
-
-	c.log.Info("rewind completed after block invalidation",
-		"invalidatedHeight", height,
-		"rewindToTimestamp", priorTimestamp,
-	)
-
-	// Record rewind depth: invalidated block was at `height`, rewound to height-1.
-	if c.metrics != nil {
-		c.metrics.ChainRewindDepthBlocks.WithLabelValues(c.chainID.String()).Observe(1)
-	}
-
-	return true, nil
+	return nil
 }
 
 func (c *simpleChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -7,12 +7,9 @@ import (
 	"sync"
 	"testing"
 
-	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -293,44 +290,6 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 	}
 }
 
-// mockEngineForInvalidation implements engine_controller.EngineController for invalidation tests
-type mockEngineForInvalidation struct {
-	blockRef        eth.L2BlockRef
-	blockRefErr     error
-	rewindCalled    bool
-	rewindTimestamp uint64
-}
-
-func (m *mockEngineForInvalidation) OutputV0AtBlockNumber(ctx context.Context, num uint64) (*eth.OutputV0, error) {
-	return nil, nil
-}
-
-func (m *mockEngineForInvalidation) OutputV0ByBlockHash(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
-	return nil, nil
-}
-
-func (m *mockEngineForInvalidation) RewindToTimestamp(ctx context.Context, timestamp uint64) error {
-	m.rewindCalled = true
-	m.rewindTimestamp = timestamp
-	return nil
-}
-
-func (m *mockEngineForInvalidation) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
-	return nil, nil, nil
-}
-
-func (m *mockEngineForInvalidation) Close() error {
-	return nil
-}
-
-func (m *mockEngineForInvalidation) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
-	return m.blockRef, m.blockRefErr
-}
-
-func (m *mockEngineForInvalidation) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
-	return eth.L2BlockRef{}, nil
-}
-
 // mockVNForInvalidation implements virtual_node.VirtualNode for invalidation tests
 type mockVNForInvalidation struct {
 	stopErr error
@@ -356,228 +315,99 @@ func (m *mockVNForInvalidation) SyncStatus(ctx context.Context) (*eth.SyncStatus
 
 var _ virtual_node.VirtualNode = (*mockVNForInvalidation)(nil)
 
-func TestInvalidateBlock(t *testing.T) {
+func TestRecordInvalidation(t *testing.T) {
 	t.Parallel()
 
-	genesisTime := uint64(1000)
-	blockTime := uint64(2)
+	stateRoot := eth.Bytes32(common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111"))
+	msgPasserRoot := eth.Bytes32(common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222"))
+	payloadHash := common.HexToHash("0xbad")
 
-	tests := []struct {
-		name             string
-		genesisBlock     uint64
-		height           uint64
-		payloadHash      common.Hash
-		currentBlockHash common.Hash
-		expectRewind     bool
-		expectRewindTs   uint64
-	}{
-		{
-			name:             "current block matches triggers rewind",
-			genesisBlock:     0,
-			height:           5,
-			payloadHash:      common.HexToHash("0xdead"),
-			currentBlockHash: common.HexToHash("0xdead"), // Same hash
-			expectRewind:     true,
-			expectRewindTs:   genesisTime + (4 * blockTime), // height-1 timestamp
-		},
-		{
-			name:             "current block differs no rewind",
-			genesisBlock:     0,
-			height:           5,
-			payloadHash:      common.HexToHash("0xdead"),
-			currentBlockHash: common.HexToHash("0xbeef"), // Different hash
-			expectRewind:     false,
-		},
-		{
-			name:             "rewind to height-1 timestamp calculated correctly",
-			genesisBlock:     0,
-			height:           10,
-			payloadHash:      common.HexToHash("0xabcd"),
-			currentBlockHash: common.HexToHash("0xabcd"),
-			expectRewind:     true,
-			expectRewindTs:   genesisTime + (9 * blockTime), // height 9
-		},
-		{
-			name:             "rewind timestamp respects nonzero genesis block number",
-			genesisBlock:     100,
-			height:           105,
-			payloadHash:      common.HexToHash("0xcafe"),
-			currentBlockHash: common.HexToHash("0xcafe"),
-			expectRewind:     true,
-			expectRewindTs:   genesisTime + (4 * blockTime), // block 104 relative to genesis block 100
-		},
-	}
-
-	// Separate test for genesis block (height=0) which should error
-	t.Run("genesis block invalidation returns error", func(t *testing.T) {
-		t.Parallel()
+	newContainer := func(t *testing.T) (*simpleChainContainer, *DenyList) {
+		t.Helper()
 		dir := t.TempDir()
-
 		dl, err := OpenDenyList(filepath.Join(dir, "denylist"))
 		require.NoError(t, err)
-		defer dl.Close()
-
-		c := &simpleChainContainer{
+		t.Cleanup(func() { dl.Close() })
+		return &simpleChainContainer{
 			denyList: dl,
 			log:      testLogger(),
-		}
+		}, dl
+	}
 
-		ctx := context.Background()
-		rewound, err := c.InvalidateBlock(ctx, 0, common.HexToHash("0xgenesis"), 0, eth.Bytes32{}, eth.Bytes32{})
+	t.Run("happy path persists deny-list entry with preimages", func(t *testing.T) {
+		t.Parallel()
+		c, dl := newContainer(t)
 
+		err := c.RecordInvalidation(context.Background(), 5, payloadHash, 100, stateRoot, msgPasserRoot)
+		require.NoError(t, err)
+
+		found, err := dl.Contains(5, payloadHash)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		stored, err := dl.GetOutputV0(5, payloadHash)
+		require.NoError(t, err)
+		require.Equal(t, &eth.OutputV0{
+			StateRoot:                stateRoot,
+			MessagePasserStorageRoot: msgPasserRoot,
+			BlockHash:                payloadHash,
+		}, stored)
+	})
+
+	t.Run("genesis block (height 0) rejected", func(t *testing.T) {
+		t.Parallel()
+		c, dl := newContainer(t)
+
+		err := c.RecordInvalidation(context.Background(), 0, payloadHash, 0, stateRoot, msgPasserRoot)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot invalidate genesis block")
-		require.False(t, rewound)
 
-		// Genesis hash should NOT be added to denylist
-		found, err := dl.Contains(0, common.HexToHash("0xgenesis"))
+		found, err := dl.Contains(0, payloadHash)
 		require.NoError(t, err)
-		require.False(t, found, "genesis block should not be added to denylist")
+		require.False(t, found, "genesis must not be persisted")
 	})
 
-	t.Run("missing engine returns error and persists denylist entry", func(t *testing.T) {
+	t.Run("zero state root rejected", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
+		c, dl := newContainer(t)
 
-		dl, err := OpenDenyList(filepath.Join(dir, "denylist"))
-		require.NoError(t, err)
-		defer dl.Close()
-
-		c := &simpleChainContainer{
-			denyList: dl,
-			log:      testLogger(),
-			vn:       &mockVNForInvalidation{},
-		}
-
-		hash := common.HexToHash("0xdead")
-		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{})
-
+		err := c.RecordInvalidation(context.Background(), 5, payloadHash, 0, eth.Bytes32{}, msgPasserRoot)
 		require.Error(t, err)
-		require.ErrorIs(t, err, engine_controller.ErrNoEngineClient)
-		require.False(t, rewound)
+		require.Contains(t, err.Error(), "zero state root")
 
-		found, err := dl.Contains(5, hash)
+		found, err := dl.Contains(5, payloadHash)
 		require.NoError(t, err)
-		require.True(t, found, "denylist entry must persist so rewind can retry on restart")
+		require.False(t, found, "must not persist when preimages are missing")
 	})
 
-	t.Run("L2BlockRefByNumber failure returns error and persists denylist entry", func(t *testing.T) {
+	t.Run("zero message-passer storage root rejected", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
+		c, dl := newContainer(t)
 
-		dl, err := OpenDenyList(filepath.Join(dir, "denylist"))
-		require.NoError(t, err)
-		defer dl.Close()
-
-		fetchErr := errors.New("transient RPC failure")
-		mockEng := &mockEngineForInvalidation{blockRefErr: fetchErr}
-
-		c := &simpleChainContainer{
-			denyList: dl,
-			log:      testLogger(),
-			engine:   mockEng,
-			vn:       &mockVNForInvalidation{},
-		}
-
-		hash := common.HexToHash("0xdead")
-		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{})
-
+		err := c.RecordInvalidation(context.Background(), 5, payloadHash, 0, stateRoot, eth.Bytes32{})
 		require.Error(t, err)
-		require.ErrorIs(t, err, fetchErr)
-		require.False(t, rewound)
-		require.False(t, mockEng.rewindCalled, "rewind should not be attempted when current block lookup fails")
+		require.Contains(t, err.Error(), "zero message-passer storage root")
 
-		found, err := dl.Contains(5, hash)
+		found, err := dl.Contains(5, payloadHash)
 		require.NoError(t, err)
-		require.True(t, found, "hash should be in denylist even when current block lookup fails")
+		require.False(t, found, "must not persist when preimages are missing")
 	})
 
-	t.Run("missing rollup config returns error before rewind", func(t *testing.T) {
+	t.Run("nil deny list returns error", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-
-		dl, err := OpenDenyList(filepath.Join(dir, "denylist"))
-		require.NoError(t, err)
-		defer dl.Close()
-
-		mockEng := &mockEngineForInvalidation{
-			blockRef: eth.L2BlockRef{Hash: common.HexToHash("0xdead")},
-		}
-
-		c := &simpleChainContainer{
-			denyList: dl,
-			log:      testLogger(),
-			engine:   mockEng,
-			vn:       &mockVNForInvalidation{},
-		}
-
-		rewound, err := c.InvalidateBlock(context.Background(), 5, common.HexToHash("0xdead"), 0, eth.Bytes32{}, eth.Bytes32{})
-
+		c := &simpleChainContainer{log: testLogger()}
+		err := c.RecordInvalidation(context.Background(), 5, payloadHash, 0, stateRoot, msgPasserRoot)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to compute rewind timestamp")
-		require.Contains(t, err.Error(), "rollup config not available")
-		require.False(t, rewound)
-		require.False(t, mockEng.rewindCalled, "rewind should not be attempted without rollup config")
+		require.Contains(t, err.Error(), "deny list not initialized")
 	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			dir := t.TempDir()
-
-			// Create deny list
-			dl, err := OpenDenyList(filepath.Join(dir, "denylist"))
-			require.NoError(t, err)
-			defer dl.Close()
-
-			// Create mock engine
-			mockEng := &mockEngineForInvalidation{
-				blockRef: eth.L2BlockRef{Hash: tt.currentBlockHash},
-			}
-
-			// Create container with minimal config
-			c := &simpleChainContainer{
-				denyList: dl,
-				log:      testLogger(),
-				vncfg:    &opnodecfg.Config{},
-				vn:       &mockVNForInvalidation{},
-			}
-			c.vncfg.Rollup.Genesis.L2Time = genesisTime
-			c.vncfg.Rollup.Genesis.L2.Number = tt.genesisBlock
-			c.vncfg.Rollup.BlockTime = blockTime
-
-			c.engine = mockEng
-
-			testStateRoot := eth.Bytes32(common.HexToHash("0xstate"))
-			testMsgPasserRoot := eth.Bytes32(common.HexToHash("0xmsgpasser"))
-			testOut := &eth.OutputV0{
-				StateRoot:                testStateRoot,
-				MessagePasserStorageRoot: testMsgPasserRoot,
-				BlockHash:                tt.payloadHash,
-			}
-
-			ctx := context.Background()
-			rewound, err := c.InvalidateBlock(ctx, tt.height, tt.payloadHash, 0, testStateRoot, testMsgPasserRoot)
-			require.NoError(t, err)
-
-			// Verify rewind behavior
-			require.Equal(t, tt.expectRewind, rewound, "rewind triggered mismatch")
-
-			if tt.expectRewind {
-				require.True(t, mockEng.rewindCalled, "RewindToTimestamp should have been called")
-				require.Equal(t, tt.expectRewindTs, mockEng.rewindTimestamp, "rewind timestamp mismatch")
-			}
-
-			// Verify hash was added to denylist regardless
-			found, err := dl.Contains(tt.height, tt.payloadHash)
-			require.NoError(t, err)
-			require.True(t, found, "hash should be in denylist after InvalidateBlock")
-
-			storedOutput, err := dl.GetOutputV0(tt.height, tt.payloadHash)
-			require.NoError(t, err)
-			require.Equal(t, testOut, storedOutput, "OutputV0 should be stored in denylist after InvalidateBlock")
-		})
-	}
+	t.Run("does not depend on engine — no rewind, no engine RPC", func(t *testing.T) {
+		t.Parallel()
+		c, _ := newContainer(t)
+		// Explicitly leave c.engine and c.vn as nil. A successful call here
+		// is the regression guard: today's rewind branch required both.
+		require.NoError(t, c.RecordInvalidation(context.Background(), 7, payloadHash, 0, stateRoot, msgPasserRoot))
+	})
 }
 
 func TestGetDeniedOutput(t *testing.T) {
@@ -690,6 +520,173 @@ func TestIsDenied(t *testing.T) {
 
 func testLogger() gethlog.Logger {
 	return gethlog.New()
+}
+
+func TestDenyList_CanonicalDeniedHeight(t *testing.T) {
+	t.Parallel()
+
+	canonicalAt := func(m map[uint64]common.Hash) func(context.Context, uint64) (common.Hash, error) {
+		return func(_ context.Context, h uint64) (common.Hash, error) {
+			hash, ok := m[h]
+			if !ok {
+				return common.Hash{}, errors.New("no canonical at height")
+			}
+			return hash, nil
+		}
+	}
+
+	t.Run("empty deny list returns not found", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dl, err := OpenDenyList(dir)
+		require.NoError(t, err)
+		defer dl.Close()
+
+		height, found, err := dl.CanonicalDeniedHeight(context.Background(), canonicalAt(map[uint64]common.Hash{}))
+		require.NoError(t, err)
+		require.False(t, found)
+		require.Zero(t, height)
+	})
+
+	t.Run("single canonical denied returns that height", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dl, err := OpenDenyList(dir)
+		require.NoError(t, err)
+		defer dl.Close()
+
+		bad := common.HexToHash("0xbad")
+		require.NoError(t, dl.Add(100, bad, 0, eth.Bytes32{}, eth.Bytes32{}))
+
+		height, found, err := dl.CanonicalDeniedHeight(context.Background(), canonicalAt(map[uint64]common.Hash{100: bad}))
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(100), height)
+	})
+
+	t.Run("denied but not canonical returns not found", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dl, err := OpenDenyList(dir)
+		require.NoError(t, err)
+		defer dl.Close()
+
+		bad := common.HexToHash("0xbad")
+		good := common.HexToHash("0xgood")
+		require.NoError(t, dl.Add(100, bad, 0, eth.Bytes32{}, eth.Bytes32{}))
+
+		height, found, err := dl.CanonicalDeniedHeight(context.Background(), canonicalAt(map[uint64]common.Hash{100: good}))
+		require.NoError(t, err)
+		require.False(t, found)
+		require.Zero(t, height)
+	})
+
+	t.Run("multiple denied heights all canonical returns lowest", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dl, err := OpenDenyList(dir)
+		require.NoError(t, err)
+		defer dl.Close()
+
+		h50 := common.HexToHash("0x50bad")
+		h100 := common.HexToHash("0x100bad")
+		h150 := common.HexToHash("0x150bad")
+		require.NoError(t, dl.Add(50, h50, 0, eth.Bytes32{}, eth.Bytes32{}))
+		require.NoError(t, dl.Add(100, h100, 0, eth.Bytes32{}, eth.Bytes32{}))
+		require.NoError(t, dl.Add(150, h150, 0, eth.Bytes32{}, eth.Bytes32{}))
+
+		canon := canonicalAt(map[uint64]common.Hash{50: h50, 100: h100, 150: h150})
+		height, found, err := dl.CanonicalDeniedHeight(context.Background(), canon)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(50), height, "lowest still-canonical denied height wins")
+	})
+
+	t.Run("highest non-canonical stops iteration (returns not found)", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dl, err := OpenDenyList(dir)
+		require.NoError(t, err)
+		defer dl.Close()
+
+		h50 := common.HexToHash("0x50bad")
+		h150 := common.HexToHash("0x150bad")
+		require.NoError(t, dl.Add(50, h50, 0, eth.Bytes32{}, eth.Bytes32{}))
+		require.NoError(t, dl.Add(150, h150, 0, eth.Bytes32{}, eth.Bytes32{}))
+
+		// 150 is no longer canonical; 50 still is. By the monotonicity contract
+		// we stop at 150 and report not found.
+		canon := canonicalAt(map[uint64]common.Hash{50: h50, 150: common.HexToHash("0xreorged")})
+		height, found, err := dl.CanonicalDeniedHeight(context.Background(), canon)
+		require.NoError(t, err)
+		require.False(t, found)
+		require.Zero(t, height)
+	})
+
+	t.Run("highest canonical lower non-canonical returns highest", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dl, err := OpenDenyList(dir)
+		require.NoError(t, err)
+		defer dl.Close()
+
+		h50 := common.HexToHash("0x50bad")
+		h150 := common.HexToHash("0x150bad")
+		require.NoError(t, dl.Add(50, h50, 0, eth.Bytes32{}, eth.Bytes32{}))
+		require.NoError(t, dl.Add(150, h150, 0, eth.Bytes32{}, eth.Bytes32{}))
+
+		// 150 canonical, 50 reorged out (replaced by a non-denied hash). Stop at 50,
+		// return 150 as the lowest canonical found.
+		canon := canonicalAt(map[uint64]common.Hash{50: common.HexToHash("0xnew50"), 150: h150})
+		height, found, err := dl.CanonicalDeniedHeight(context.Background(), canon)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(150), height)
+	})
+
+	t.Run("canonical probe error stops iteration after recording prior matches", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dl, err := OpenDenyList(dir)
+		require.NoError(t, err)
+		defer dl.Close()
+
+		h100 := common.HexToHash("0x100bad")
+		h200 := common.HexToHash("0x200bad")
+		require.NoError(t, dl.Add(100, h100, 0, eth.Bytes32{}, eth.Bytes32{}))
+		require.NoError(t, dl.Add(200, h200, 0, eth.Bytes32{}, eth.Bytes32{}))
+
+		// 200 canonical; probe for 100 fails (e.g. EL not yet at that height).
+		// We record 200 then stop on the error and return what we have.
+		probe := func(_ context.Context, h uint64) (common.Hash, error) {
+			switch h {
+			case 200:
+				return h200, nil
+			default:
+				return common.Hash{}, errors.New("EL not synced")
+			}
+		}
+		height, found, err := dl.CanonicalDeniedHeight(context.Background(), probe)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(200), height)
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dl, err := OpenDenyList(dir)
+		require.NoError(t, err)
+		defer dl.Close()
+
+		require.NoError(t, dl.Add(100, common.HexToHash("0xbad"), 0, eth.Bytes32{}, eth.Bytes32{}))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, _, err = dl.CanonicalDeniedHeight(ctx, canonicalAt(map[uint64]common.Hash{100: common.HexToHash("0xbad")}))
+		require.ErrorIs(t, err, context.Canceled)
+	})
 }
 
 // TestDenyList_ConcurrentAccess verifies the DenyList is safe for concurrent use.

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -152,6 +152,22 @@ func (c *simpleChainContainer) GetDeniedOutput(height uint64, payloadHash common
 	return c.denyList.GetOutputV0(height, payloadHash)
 }
 
+// CanonicalDeniedHeight returns the lowest deny-list-entry height that is
+// currently canonical according to the provided L2 chain probe. See the
+// rollup.SuperAuthority interface for the full contract.
+func (c *simpleChainContainer) CanonicalDeniedHeight(ctx context.Context, canonical rollup.CanonicalChain) (uint64, bool, error) {
+	if c.denyList == nil {
+		return 0, false, nil
+	}
+	return c.denyList.CanonicalDeniedHeight(ctx, func(ctx context.Context, h uint64) (common.Hash, error) {
+		ref, err := canonical.L2BlockRefByNumber(ctx, h)
+		if err != nil {
+			return common.Hash{}, err
+		}
+		return ref.Hash, nil
+	})
+}
+
 // OutputV0AtBlockNumber returns the full OutputV0 for the block at the given number.
 func (c *simpleChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
 	if c.engine == nil {


### PR DESCRIPTION
## Summary
Replaces today's synchronous op-reth rewind (FCU + synthetic ExtraData payload + retry loop) with a deny-list-only invalidation path. On `DecisionInvalidate`, op-supernode persists the deny entry only; when the VN restarts, op-node's reset path consults `SuperAuthority.CanonicalDeniedHeight` and caps the safe (and finalized) head to `denyHeight - 1` before any FCU is issued. Derivation re-derives the denied block, the deny check fires in `consolidateNextSafeAttributes`, deposits-only attributes replace the block, and op-reth reorgs the unsafe chain on the resulting FCU.

- `SuperAuthority.CanonicalDeniedHeight` + `DenyList.CanonicalDeniedHeight` walk denied heights top-down, return the lowest still-canonical entry.
- `sync.ApplyDenyCap` is wired into `currentHeads`, `initializeUnknowns`, and the `L2HeadsForELSyncWithOffset` recovery branch. Unsafe is intentionally not capped — the mismatch against the still-canonical denied block is what drives consolidation to issue `BuildStartEvent`. In `initializeUnknowns` the cap is **strictly one-shot at initial head load** (gated on `safeJustLoaded || finalizedJustLoaded`): subsequent `tryUpdateEngineInternal` iterations skip it. Without that gate the cap fires while op-reth's canonical chain still briefly reports the bad block during a build, rolling `localSafeHead` back over the just-built replacement and turning the reorg into an oscillation loop. The explicit-reset path (`onResetEngineRequest` → `FindL2Heads`) still applies the cap on freshly-read EL labels.
- `consolidateNextSafeAttributes` consults `SuperAuthority.IsDenied` on the existing unsafe block before `AttributesMatchBlock`. Without this, derivation deterministically reproduces the bad block's bytes and silently promotes it back to safe via `TryUpdatePendingSafe` (the consolidation-match path bypasses `PayloadProcessEvent` where `IsDenied` normally fires). A `!IsDepositsOnly()` guard on the derived attributes prevents an infinite loop once the deposits-only rebuild lands. **Fails closed on IsDenied error**: surfaces `EngineTemporaryErrorEvent` so the caller retries, rather than logging and proceeding with the match check (which could silently promote a denied block).
- `InvalidateBlock` → `RecordInvalidation`: drops the rewind branch and the `L2BlockRefByNumber` canonicality probe, refuses zero `StateRoot`/`MessagePasserStorageRoot` at the boundary.
- `applyPendingTransition` now resumes invalidated chains before non-invalidated ones so the cap fires before peer chains observe the post-reorg cross-chain state.
- `onPayloadSuccess`'s replacement-block path emits `CriticalErrorEvent` if the replacement is itself on the deny list — preventing a reorg loop.

Finalized is capped defensively even though `verifiedDB` only records `DecisionAdvance` (so a denied block cannot be finalized); capping locally keeps `finalized <= safe` obvious in code.

## Test plan
- [x] `go test ./op-supernode/... ./op-node/...` green.
- [x] `just lint-go` clean.
- [x] New unit tests: `TestDenyList_CanonicalDeniedHeight` (8 cases), `TestApplyDenyCap` (9 cases), `TestRecordInvalidation` (6 cases incl. zero-preimage guard + no-engine path), `TestOnPayloadSuccess_ReplacementBlockNotDenied`, `TestAttributesHandler/existing_unsafe_block_is_denied_by_SuperAuthority`, `TestAttributesHandler/deny_check_error_emits_temporary_error_and_aborts_consolidation`, `TestAttributesHandler/denied_unsafe_block_+_deposits-only_attrs_falls_through_to_match_check`.
- [x] Existing `TestFreezeAllBeforeRewind` updated for the new "resume invalidated chains too" behaviour with strict ordering assertion (invalidated chains resumed before non-invalidated).
- [x] Existing `TestSuperAuthority` deny-payload scenarios still pass.
- [x] Acceptance tests verified locally with `DEVSTACK_L2EL_KIND=op-reth`: `TestReorgInvalidExecMsgs/{invalid_log_index,invalid_block_number,invalid_chain_id}`, `TestReorgInitExecMsg`, `TestSupernodeInteropInvalidMessageReplacement`, `TestSupernodeSameTimestampInvalidTransitive`, `TestInteropSystemSupernode`, `TestInteropFaultProofs_SuperrootOptimisticPairing`. All previously failed in CI; all now pass.

Design doc: also added to https://www.notion.so/oplabs/Interop-Reset-Loop-36bf153ee16280eaaf54f0b4fd39349a