### PR TITLE
fix(op-reth): use `RoInconsistent` for `op_proofs` CLI subcommands

### DIFF
--- a/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
@@ -55,8 +55,12 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitCommand<C> {
         info!(target: "reth::cli", "reth {} starting", version_metadata().short_version);
         info!(target: "reth::cli", "Initializing OP proofs storage at: {:?}", self.storage_path);
 
-        // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
+        // Initialize the environment with read-only access. We use `RoInconsistent` to skip the
+        // static-file/database consistency check: this command only reads trie tables from MDBX
+        // and never touches static files, so a mid-write or partially-committed static-file state
+        // (e.g. node running concurrently, or an unclean prior shutdown) must not abort init.
+        let Environment { provider_factory, .. } =
+            self.env.init::<N>(AccessRights::RoInconsistent, runtime)?;
 
         // Create the proofs storage without the metrics wrapper.
         // During initialization we write billions of entries; the metrics layer's

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
@@ -56,9 +56,7 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitCommand<C> {
         info!(target: "reth::cli", "Initializing OP proofs storage at: {:?}", self.storage_path);
 
         // Initialize the environment with read-only access. We use `RoInconsistent` to skip the
-        // static-file/database consistency check: this command only reads trie tables from MDBX
-        // and never touches static files, so a mid-write or partially-committed static-file state
-        // (e.g. node running concurrently, or an unclean prior shutdown) must not abort init.
+        // static-file/database consistency check.
         let Environment { provider_factory, .. } =
             self.env.init::<N>(AccessRights::RoInconsistent, runtime)?;
 

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
@@ -64,8 +64,12 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> PruneCommand<C> {
         info!(target: "reth::cli", "reth {} starting", version_metadata().short_version);
         info!(target: "reth::cli", "Pruning OP proofs storage at: {:?}", self.storage_path);
 
-        // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
+        // Initialize the environment with read-only access. We use `RoInconsistent` to skip the
+        // static-file/database consistency check: this command only uses `provider_factory` as a
+        // `BlockHashReader`, and pruning happens against the proofs storage — so a mid-write or
+        // partially-committed static-file state must not abort prune.
+        let Environment { provider_factory, .. } =
+            self.env.init::<N>(AccessRights::RoInconsistent, runtime)?;
 
         match self.storage_version {
             ProofsStorageVersion::V1 => {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
@@ -65,9 +65,7 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> PruneCommand<C> {
         info!(target: "reth::cli", "Pruning OP proofs storage at: {:?}", self.storage_path);
 
         // Initialize the environment with read-only access. We use `RoInconsistent` to skip the
-        // static-file/database consistency check: this command only uses `provider_factory` as a
-        // `BlockHashReader`, and pruning happens against the proofs storage — so a mid-write or
-        // partially-committed static-file state must not abort prune.
+        // static-file/database consistency check.
         let Environment { provider_factory, .. } =
             self.env.init::<N>(AccessRights::RoInconsistent, runtime)?;
 

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
@@ -84,7 +84,12 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> UnwindCommand<C> {
         info!(target: "reth::cli", "Unwinding OP proofs storage at: {:?}", self.storage_path);
 
         // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
+        // Initialize the environment with read-only access. We use `RoInconsistent` to skip the
+        // static-file/database consistency check: this command only looks up a single target
+        // block via `provider_factory.recovered_block(...)` and unwinds the proofs storage — so a
+        // mid-write or partially-committed static-file state must not abort unwind.
+        let Environment { provider_factory, .. } =
+            self.env.init::<N>(AccessRights::RoInconsistent, runtime)?;
 
         match self.storage_version {
             ProofsStorageVersion::V1 => {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
@@ -83,11 +83,8 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> UnwindCommand<C> {
         info!(target: "reth::cli", "reth {} starting", version_metadata().short_version);
         info!(target: "reth::cli", "Unwinding OP proofs storage at: {:?}", self.storage_path);
 
-        // Initialize the environment with read-only access
         // Initialize the environment with read-only access. We use `RoInconsistent` to skip the
-        // static-file/database consistency check: this command only looks up a single target
-        // block via `provider_factory.recovered_block(...)` and unwinds the proofs storage — so a
-        // mid-write or partially-committed static-file state must not abort unwind.
+        // static-file/database consistency check.
         let Environment { provider_factory, .. } =
             self.env.init::<N>(AccessRights::RoInconsistent, runtime)?;
 


### PR DESCRIPTION
**Description**

`op-reth proofs init|prune|unwind` failed with `File is in an inconsistent state.` when run against a datadir whose static files were mid-write or in a partially-committed state

Root cause: opening with `AccessRights::RO` makes reth's `create_provider_factory` run a `check_consistency` over static files, which throws on any mid-write or partial-commit state. 

None of these subcommands actually read from static files:
- `init`
- `prune`
- `unwind`

So they don't need a consistent static-file view. Switching to `AccessRights::RoInconsistent` skips the check.

**Tests**

- All existing unit and e2e tests

**Additional context**

NA

**Metadata**

NA