### PR TITLE
docs: add reth dependency update guide

### DIFF
--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -148,6 +148,18 @@ Run these checks from `rust/`. Fix all issues — CI enforces zero warnings.
 
 Op-reth requires `clang` / `libclang-dev` for reth-mdbx-sys bindgen. CI installs this automatically — if you see bindgen errors locally, install clang.
 
+## Updating the reth dependency
+
+The full guide lives at [`rust/UPDATING-RETH.md`](../../rust/UPDATING-RETH.md). Read it before bumping the reth rev in `rust/Cargo.toml`.
+
+Agent-specific tips beyond what's in the guide:
+
+- The bump is iterative — run `cargo check --workspace --tests`, fix the first batch of errors, re-run, repeat. Don't try to enumerate every API change up front and don't ask the user to confirm every line of adaptation; just iterate to a green compile and report the diff at the end.
+- If you have a local checkout of `paradigmxyz/reth`, use it to look up upstream trait signatures and run `git log <old-rev>..<new-rev>` to find the commit that changed any given symbol — much faster and more reliable than hand-fetching raw GitHub URLs. If you don't know whether one is available, ask the user. Don't assume a path.
+- For trait methods that gained an ignored parameter, prefix the new param with `_` (e.g. `_block_access_list_hash: Option<B256>`) so it doesn't generate an unused-variable warning. Don't invent a meaningful name unless you're actually plumbing the value through.
+- If upstream removed a trait or re-export that op-reth still uses, vendor it locally with a comment pointing at the upstream removal PR — don't try to refactor op-reth to do without it without first confirming the consumer is actually unused. The "stale" label upstream doesn't mean unused downstream.
+- When the new rev pulls in new transitive deps (visible as `Adding <crate>` lines from `cargo update`), check whether they're from upstream reth's own deps or from a misconfiguration on our side. `cargo tree -i <crate>` traces the path.
+
 ## Skills
 
 - **Fix Rust Formatting** ([`.claude/skills/fix-rust-fmt/SKILL.md`](../../.claude/skills/fix-rust-fmt/SKILL.md)): Fixes `rust-fmt` CI failures by installing the pinned nightly toolchain and running `just fmt-fix`. Invoke with `/fix-rust-fmt`.

--- a/rust/UPDATING-RETH.md
+++ b/rust/UPDATING-RETH.md
@@ -1,0 +1,123 @@
+# Updating the reth dependency
+
+The Rust workspace pins ~70 `reth-*` crates from `paradigmxyz/reth` to a single
+git rev in [`rust/Cargo.toml`](Cargo.toml). This guide describes how to bump
+that rev safely.
+
+## When to update
+
+- Picking up a fix or feature merged upstream that op-reth depends on.
+- Periodic catch-up to limit drift before it becomes painful.
+- After your own reth-side change has merged upstream.
+
+Prefer the latest upstream release tag when one exists that contains the
+changes you need. Tags are stable artifacts with corresponding upstream
+releases and the most predictable downstream behavior. Fall back to a merge
+commit on `main` only when no tagged release covers the needed change yet
+(e.g. urgently picking up a fix). Avoid pinning to an unmerged PR branch for
+anything we want to land — the merge commit on `main` is at least the version
+main's CI actually validated.
+
+## Procedure
+
+1. Pick the new rev. For a specific upstream PR, take its merge commit (see
+   `gh pr view <N> --repo paradigmxyz/reth --json mergeCommit`). Otherwise take
+   the current head of `paradigmxyz/reth` `main`.
+
+2. Update the rev. All ~70 references share a single rev string, so a single
+   replacement covers them:
+
+   ```bash
+   cd rust
+   sed -i 's/rev = "<OLD_REV>"/rev = "<NEW_REV>"/g' Cargo.toml
+   ```
+
+3. Refresh `Cargo.lock`. `cargo update -p reth` does **not** work — there is no
+   top-level crate literally named `reth` in the dep graph; the workspace
+   depends on `reth-*` subcrates. Pass any real reth subcrate; cargo cascades
+   to every git dep sharing the same source:
+
+   ```bash
+   mise exec -- cargo update reth-chainspec
+   ```
+
+4. Compile and adapt:
+
+   ```bash
+   mise exec -- cargo check --workspace --tests
+   ```
+
+   Fix each compile error, then re-run. Don't try to predict the full set of
+   breakages in advance — let the compiler walk the dep graph. Each pass
+   surfaces the next crate's errors.
+
+5. Build, format, and test before pushing:
+
+   ```bash
+   mise exec -- cargo build -p op-reth
+   just fmt-fix && just lint
+   just test-unit
+   ```
+
+## Expect upstream churn beyond your target change
+
+A rev bump is rarely "just a rev change." Upstream reth iterates trait
+signatures, struct fields, re-exports, and feature flags between commits, and
+any of them can require op-reth-side adaptation. Recent examples observed in
+the wild:
+
+- Trait methods gaining new parameters (e.g. `FullConsensus::validate_block_post_execution`
+  gained `block_access_list_hash: Option<B256>`; `PayloadTypes::block_to_payload`
+  gained `bal: Option<Bytes>`).
+- Associated-type bounds (e.g. `PayloadTypes::ExecutionData` gaining a
+  `From<Self::BuiltPayload>` bound, requiring a new `From` impl).
+- Provider trait additions (e.g. `BalProvider` becoming a required bound on
+  the engine API's `Provider`).
+- Struct destructuring (e.g. `BlockBuilderOutcome` gaining a
+  `block_access_list` field; `BuiltPayloadExecutedBlock.hashed_state` /
+  `trie_updates` losing their `Either<Arc<...>, _>` wrappers).
+- Renames (e.g. `ComputedTrieData::without_trie_input` → `::new`).
+- Removed re-exports — sometimes the trait itself is deleted upstream while
+  op-reth (and the wider OP Stack) still relies on it. In that case the
+  smallest correct fix is to vendor the trait locally in the consuming crate
+  (with a comment pointing at the upstream PR that removed it). See
+  `rust/op-reth/crates/rpc/src/witness.rs` for an example.
+- Type changes in test fixtures (e.g. struct fields flipping from `u16` to
+  `Option<u16>`).
+
+None of these are deep redesigns — most fixes are one to three lines — but
+they need to be done before CI will pass.
+
+## Picking the right target commit
+
+In order of preference:
+
+1. **Latest upstream release tag** that contains the change you need. Tags
+   correspond to actual upstream releases and have the most predictable
+   downstream behavior. List them with `git -C <reth-checkout> tag --sort=-v:refname | head`
+   (or `gh release list --repo paradigmxyz/reth`).
+
+2. **Merge commit on `main`** of a specific PR — for cases where the needed
+   change has been merged but isn't in a release yet (e.g. urgent fix). Find
+   it via `gh pr view <N> --repo paradigmxyz/reth --json mergeCommit`. The
+   merge commit is stable (PR rebases no longer affect it) and is the version
+   main's CI actually validated.
+
+3. **Current `main` HEAD** — for periodic catch-up bumps when no specific PR
+   is the trigger.
+
+Avoid pinning to an unmerged PR branch tip for anything we want to land. It
+moves under us when the PR rebases, may sit on a much newer main than our
+current pin, and isn't a version any upstream CI has signed off on as a
+release artifact.
+
+If the only upstream change you need is a single PR but the PR branch is based
+on much newer main than our pin, consider asking the upstream author to rebase
+onto an older base, or accept the broader catch-up work as part of the bump.
+
+## See also
+
+- `docs/ai/rust-dev.md` — broader Rust workflow (build, test, lint).
+- `rust/Cargo.toml` — where the rev string lives (~70 occurrences).
+- `rust/op-reth/crates/rpc/src/witness.rs` — example of vendoring a trait that
+  upstream removed.

--- a/rust/op-reth/crates/payload/src/lib.rs
+++ b/rust/op-reth/crates/payload/src/lib.rs
@@ -78,6 +78,14 @@ where
     type BuiltPayload = OpBuiltPayload<N>;
     type PayloadAttributes = crate::payload::OpPayloadAttrs;
 
+    // `block_to_payload` and `From<OpBuiltPayload<N>> for OpExecData` are two
+    // separate conversion paths to the same `ExecutionData` type — kept parallel
+    // (not delegating to each other) to mirror upstream `EthPayloadTypes`. The
+    // BAL travels differently in each: here as a separate `bal` arg supplied by
+    // the caller, in `From` as a field of the built payload itself. Once OP
+    // gains BAL support, dropping it on either path would be silent corruption,
+    // so each path threads its own source through to the shared lower-level
+    // helper.
     fn block_to_payload(
         block: SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,

--- a/rust/op-reth/crates/payload/src/payload.rs
+++ b/rust/op-reth/crates/payload/src/payload.rs
@@ -464,6 +464,10 @@ impl<N: NodePrimitives> BuiltPayload for OpBuiltPayload<N> {
     }
 }
 
+// Counterpart to `OpPayloadTypes::block_to_payload`. The two are intentionally
+// parallel: this path receives the BAL via the payload's own field once OP
+// gains BAL support, while `block_to_payload` receives it as a separate arg.
+// See the comment on `OpPayloadTypes::block_to_payload` in `lib.rs`.
 impl<T, N> From<OpBuiltPayload<N>> for OpExecData
 where
     T: SignedTransaction,


### PR DESCRIPTION
## Summary

- Adds `rust/UPDATING-RETH.md` — how to bump the reth git rev pinned in `rust/Cargo.toml` safely. Covers picking the target (prefer upstream release tags → merge commits on `main` → main HEAD → never PR branch tips), the practical procedure (`cargo update reth-chainspec`, not `-p reth`), and the common upstream-churn categories to expect.
- Links the guide from `docs/ai/rust-dev.md` with a short *Updating the reth dependency* section containing agent-specific tips (iterative compile-and-adapt, optional local reth checkout, `_`-prefix ignored new params, vendor removed traits, trace transitive deps).
- Adds code comments at `OpPayloadTypes::block_to_payload` (`rust/op-reth/crates/payload/src/lib.rs:81`) and `From<OpBuiltPayload<N>> for OpExecData` (`rust/op-reth/crates/payload/src/payload.rs:467`) explaining why they're kept as parallel conversion paths rather than delegating — the BAL travels differently in each and silent drops would corrupt payloads once OP gains BAL support.

Captured from the experience of #20704 (reth rev bump for the FCU backfill-target fix).

## Test plan

- [x] `cargo check -p reth-optimism-payload-builder` clean (only comment additions touch code).
- [x] Markdown renders correctly.

🤖 *Generated by Claude Code*