### PR TITLE
fix(predeploys-sot): use the single source of truth for predeploy addresses in _getTargetImpl

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -88,7 +88,7 @@
     "sourceCodeHash": "0x0a29792f3226dac84fdb44150b622a165fe65da3b678f6540acecdfe440772bb"
   },
   "src/L2/L2ProxyAdmin.sol:L2ProxyAdmin": {
-    "initCodeHash": "0x1b392652cf6009f47ed8c794c1f117ea51a626234fe419660bc273b5ad03b020",
+    "initCodeHash": "0xd9d6f7850ca2f14376b4a9c8b7693edd820803baddf42da91c0d452c207914a8",
     "sourceCodeHash": "0x43379a0ceae81d693c0fb50d3b7e8b1836e7a2cae0b7931593d2324d09e59ba3"
   },
   "src/L2/L2StandardBridge.sol:L2StandardBridge": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -72,7 +72,7 @@
     "sourceCodeHash": "0xea9fed192db1a7a1f39dd56ede98293e1bacc2275f58696e8b22f25f265be770"
   },
   "src/L2/L2ContractsManager.sol:L2ContractsManager": {
-    "initCodeHash": "0x6db74c639c2f59924f08116fca646b74162713fb19c8f5cc775c415e90ddc641",
+    "initCodeHash": "0x5ba2d02cf8f77aa5c727eb7ad3710c6bf16e6f7c974eefdd7c59d92665183521",
     "sourceCodeHash": "0x7bd1882248c144198a482f498fd34eb6f0a5381d18142e2ae3a3cf990cbdf296"
   },
   "src/L2/L2CrossDomainMessenger.sol:L2CrossDomainMessenger": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -72,7 +72,7 @@
     "sourceCodeHash": "0xea9fed192db1a7a1f39dd56ede98293e1bacc2275f58696e8b22f25f265be770"
   },
   "src/L2/L2ContractsManager.sol:L2ContractsManager": {
-    "initCodeHash": "0x5ba2d02cf8f77aa5c727eb7ad3710c6bf16e6f7c974eefdd7c59d92665183521",
+    "initCodeHash": "0x6db74c639c2f59924f08116fca646b74162713fb19c8f5cc775c415e90ddc641",
     "sourceCodeHash": "0x7bd1882248c144198a482f498fd34eb6f0a5381d18142e2ae3a3cf990cbdf296"
   },
   "src/L2/L2CrossDomainMessenger.sol:L2CrossDomainMessenger": {
@@ -88,7 +88,7 @@
     "sourceCodeHash": "0x0a29792f3226dac84fdb44150b622a165fe65da3b678f6540acecdfe440772bb"
   },
   "src/L2/L2ProxyAdmin.sol:L2ProxyAdmin": {
-    "initCodeHash": "0xd9d6f7850ca2f14376b4a9c8b7693edd820803baddf42da91c0d452c207914a8",
+    "initCodeHash": "0x1b392652cf6009f47ed8c794c1f117ea51a626234fe419660bc273b5ad03b020",
     "sourceCodeHash": "0x43379a0ceae81d693c0fb50d3b7e8b1836e7a2cae0b7931593d2324d09e59ba3"
   },
   "src/L2/L2StandardBridge.sol:L2StandardBridge": {

--- a/packages/contracts-bedrock/test/L2/L2ContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ContractsManager.t.sol
@@ -1065,16 +1065,14 @@ contract L2ContractsManager_Upgrade_Atomicity_Test is L2ContractsManager_Upgrade
         bool isCGT = Config.sysFeatureCustomGasToken();
         Predeploys.PredeployRecord[] memory records = Predeploys.getAllRecords();
         string memory fallbackName;
-        bool found;
         for (uint256 i = 0; i < records.length; i++) {
             if (records[i].proxy != _predeploy) continue;
             if (records[i].isCustomGasToken && isCGT) return _findImplByName(records[i].name);
             if (!records[i].isVariant) {
                 fallbackName = records[i].name;
-                found = true;
             }
         }
-        if (found) return _findImplByName(fallbackName);
+        if (bytes(fallbackName).length > 0) return _findImplByName(fallbackName);
         revert("L2ContractsManager_Upgrade_Atomicity_Test: unmapped predeploy");
     }
 

--- a/packages/contracts-bedrock/test/L2/L2ContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ContractsManager.t.sol
@@ -1057,49 +1057,24 @@ contract L2ContractsManager_Upgrade_Atomicity_Test is L2ContractsManager_Upgrade
         }
     }
 
-    // TODO(#19260): Refactor this when we have a proper single source of truth for the predeploys.
-    /// @dev Reverts when `_predeploy` is unmapped so new predeploys cannot slip past this test
-    ///      without the helper being extended.
+    /// @dev Reverts when `_predeploy` has no entry in the registry, so new predeploys cannot
+    ///      slip past this test without being added to `Predeploys.getAllRecords()`.
+    ///      For predeploys with CGT variants the CGT record takes priority on CGT chains;
+    ///      the non-CGT primary record is used on all other chains.
     function _getTargetImpl(address _predeploy) internal view returns (address) {
-        // Initializable predeploys (upgradeToAndCall path).
-        if (_predeploy == Predeploys.L2_CROSS_DOMAIN_MESSENGER) return _findImplByName("L2CrossDomainMessenger");
-        if (_predeploy == Predeploys.L2_STANDARD_BRIDGE) return _findImplByName("L2StandardBridge");
-        if (_predeploy == Predeploys.L2_ERC721_BRIDGE) return _findImplByName("L2ERC721Bridge");
-        if (_predeploy == Predeploys.OPTIMISM_MINTABLE_ERC20_FACTORY) {
-            return _findImplByName("OptimismMintableERC20Factory");
+        bool isCGT = Config.sysFeatureCustomGasToken();
+        Predeploys.PredeployRecord[] memory records = Predeploys.getAllRecords();
+        string memory fallbackName;
+        bool found;
+        for (uint256 i = 0; i < records.length; i++) {
+            if (records[i].proxy != _predeploy) continue;
+            if (records[i].isCustomGasToken && isCGT) return _findImplByName(records[i].name);
+            if (!records[i].isVariant) {
+                fallbackName = records[i].name;
+                found = true;
+            }
         }
-        if (_predeploy == Predeploys.OPTIMISM_MINTABLE_ERC721_FACTORY) {
-            return _findImplByName("OptimismMintableERC721Factory");
-        }
-        if (_predeploy == Predeploys.SEQUENCER_FEE_WALLET) return _findImplByName("SequencerFeeVault");
-        if (_predeploy == Predeploys.BASE_FEE_VAULT) return _findImplByName("BaseFeeVault");
-        if (_predeploy == Predeploys.L1_FEE_VAULT) return _findImplByName("L1FeeVault");
-        if (_predeploy == Predeploys.OPERATOR_FEE_VAULT) return _findImplByName("OperatorFeeVault");
-        if (_predeploy == Predeploys.LIQUIDITY_CONTROLLER) return _findImplByName("LiquidityController");
-
-        // Non-initializable predeploys (upgradeTo path).
-        if (_predeploy == Predeploys.GAS_PRICE_ORACLE) return _findImplByName("GasPriceOracle");
-        if (_predeploy == Predeploys.L1_BLOCK_ATTRIBUTES) {
-            return Config.sysFeatureCustomGasToken() ? _findImplByName("L1BlockCGT") : _findImplByName("L1Block");
-        }
-        if (_predeploy == Predeploys.L2_TO_L1_MESSAGE_PASSER) {
-            return Config.sysFeatureCustomGasToken()
-                ? _findImplByName("L2ToL1MessagePasserCGT")
-                : _findImplByName("L2ToL1MessagePasser");
-        }
-        if (_predeploy == Predeploys.PROXY_ADMIN) return _findImplByName("L2ProxyAdmin");
-        if (_predeploy == Predeploys.L2_DEV_FEATURE_FLAGS) return _findImplByName("L2DevFeatureFlags");
-        if (_predeploy == Predeploys.NATIVE_ASSET_LIQUIDITY) return _findImplByName("NativeAssetLiquidity");
-        if (_predeploy == Predeploys.SCHEMA_REGISTRY) return _findImplByName("SchemaRegistry");
-        if (_predeploy == Predeploys.EAS) return _findImplByName("EAS");
-        if (_predeploy == Predeploys.CROSS_L2_INBOX) return _findImplByName("CrossL2Inbox");
-        if (_predeploy == Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER) {
-            return _findImplByName("L2ToL2CrossDomainMessenger");
-        }
-        if (_predeploy == Predeploys.SUPERCHAIN_ETH_BRIDGE) return _findImplByName("SuperchainETHBridge");
-        if (_predeploy == Predeploys.ETH_LIQUIDITY) return _findImplByName("ETHLiquidity");
-        if (_predeploy == Predeploys.CONDITIONAL_DEPLOYER) return _findImplByName("ConditionalDeployer");
-
+        if (found) return _findImplByName(fallbackName);
         revert("L2ContractsManager_Upgrade_Atomicity_Test: unmapped predeploy");
     }
 


### PR DESCRIPTION
**Description**
Refactor _getTargetImpl to use Predeploys.getAllRecords().

**Additional context**
There was a TODO caught in the CI https://github.com/ethereum-optimism/optimism/issues/19260#issuecomment-4530604834. The single source of truth refactor updated the called functions, but did not change the logic so it didn't use the registry. 

**Metadata**

closes #19260 