### PR TITLE
fix(op-reth): clamp `sync_target` past `best_block` in `advance_sync`

### DIFF
--- a/rust/op-reth/crates/trie/src/engine/runner.rs
+++ b/rust/op-reth/crates/trie/src/engine/runner.rs
@@ -113,6 +113,30 @@ where
         }
 
         let block_num = current_tip + 1;
+
+        // Mitigation for upstream reth's mmap/ftruncate race
+        // (`https://github.com/paradigmxyz/reth/issues/24411`). Reading via
+        // `provider.recovered_block(...)` dereferences the static-file `Arc<DataReader>`
+        // mmap; if reth's engine tree is unwinding past the requested block at the same
+        // moment, the load can land on a kernel page reclaimed by `ftruncate(2)` and
+        // SIGBUS the process. We narrow the race window by refusing to read past the
+        // chain's current best block — blocks beyond it are the ones most likely to be
+        // mid-truncate. Remove once the upstream fix lands.
+        let best_block = self.state.provider.best_block_number()?;
+        if block_num > best_block {
+            // Clamp `sync_target` to the chain's best block so the runner doesn't
+            // busy-loop on `advance_sync`.
+            debug!(
+                target: "trie::engine::runner",
+                block_num,
+                best_block,
+                sync_target = self.state.sync_target,
+                "Clamping sync_target to best_block to avoid mmap/ftruncate race"
+            );
+            self.state.sync_target = best_block;
+            return Ok(());
+        }
+
         let block = self
             .state
             .provider


### PR DESCRIPTION
**Description**

Mitigation in the op-reth trie engine for the upstream reth static-file mmap/ftruncate race (paradigmxyz/reth#24411), which we hit in production in the proofs-history exex during deep FCU rewinds.

`provider.recovered_block(...)` from `advance_sync` dereferences a static-file mmap held inside `Arc<DataReader>`. When reth's engine tree concurrently calls `prune_*` → `set_len` (in-place `ftruncate`), the kernel reclaims pages the collector is reading from → `signal: 7/10, SIGBUS, access to undefined memory`, process exit.

This PR adds a defensive check in `advance_sync`: before each `recovered_block`, fetch `best_block_number()`. If the block we'd otherwise read is past the chain's current best block, clamp `sync_target` down to `best_block` and return without touching the mmap. The exex bumps `sync_target` back up via the next `sync_to(...)` when a new canonical tip arrives.

**Why this helps**
This narrow the race window by refusing to read past the chain's current best block.

**What this does not fix**
Reads within `[..= best_block]` can still race the writer's `set_len` on a cursor mid-loop. This solution will reduce SIGBUS probability but does not close the race.

**Tests**

All existing tests

**Additional context**

NA

**Metadata**

NA