### PR TITLE
feat(op-supernode): WAL canonical payloads for rewind / invalidate operations

### DIFF
--- a/op-e2e/actions/supernode/rewind_test.go
+++ b/op-e2e/actions/supernode/rewind_test.go
@@ -67,11 +67,6 @@ func (env *rewindTestEnv) buildUnsafeBlocks(numL1Blocks int) {
 	env.sequencer.ActBuildToL1Head(env.t)
 }
 
-// timestampForBlock returns the timestamp for a given L2 block number.
-func (env *rewindTestEnv) timestampForBlock(blockNum uint64) uint64 {
-	return env.sd.RollupCfg.Genesis.L2Time + (env.sd.RollupCfg.BlockTime * blockNum)
-}
-
 // batchSubmitAndSync submits L2 blocks to L1 and syncs the sequencer to advance safe head.
 func (env *rewindTestEnv) batchSubmitAndSync() {
 	env.batcher.ActSubmitAll(env.t)
@@ -97,9 +92,21 @@ func (env *rewindTestEnv) getHeads() (unsafe, safe, finalized eth.L2BlockRef) {
 
 // rewindToBlock rewinds the engine to the given block number and returns the resulting heads.
 func (env *rewindTestEnv) rewindToBlock(blockNum uint64) (unsafe, safe, finalized eth.L2BlockRef) {
-	err := env.ec.RewindToTimestamp(context.Background(), env.timestampForBlock(blockNum))
+	target := env.canonicalPayload(blockNum)
+	err := env.ec.Rewind(context.Background(), target)
 	require.NoError(env.t, err)
 	return env.getHeads()
+}
+
+// canonicalPayload fetches the canonical execution payload for the given block number from
+// the live engine — emulating the WAL-captured payload that production callers would supply.
+func (env *rewindTestEnv) canonicalPayload(blockNum uint64) *eth.ExecutionPayloadEnvelope {
+	ref, err := env.engCl.L2BlockRefByNumber(context.Background(), blockNum)
+	require.NoError(env.t, err)
+	envelope, err := env.engCl.PayloadByHash(context.Background(), ref.Hash)
+	require.NoError(env.t, err)
+	require.NotNil(env.t, envelope)
+	return envelope
 }
 
 func TestRewindToTimestamp(gt *testing.T) {
@@ -265,6 +272,7 @@ func RewindFinalizedHeadBackward(gt *testing.T) {
 	require.Greater(gt, rewindTarget, uint64(0), "rewind target should be past genesis")
 	require.Less(gt, rewindTarget, finalizedBefore.Number, "rewind target should be behind finalized")
 
-	err := env.ec.RewindToTimestamp(context.Background(), env.timestampForBlock(rewindTarget))
+	target := env.canonicalPayload(rewindTarget)
+	err := env.ec.Rewind(context.Background(), target)
 	require.ErrorIs(gt, err, engine_controller.ErrRewindOverFinalizedHead)
 }

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -1070,6 +1070,7 @@ type algoMockChain struct {
 	optimisticAtErr   error
 	blockHashes       map[uint64]common.Hash
 	blockTimeOverride uint64
+	payloadsByHash    map[common.Hash]*eth.ExecutionPayloadEnvelope
 }
 
 func (m *algoMockChain) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
@@ -1116,8 +1117,16 @@ func (m *algoMockChain) SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 func (m *algoMockChain) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error) {
 	return ts, nil
 }
-func (m *algoMockChain) RewindEngine(ctx context.Context, timestamp uint64, invalidatedBlock eth.BlockRef) error {
+func (m *algoMockChain) RewindEngine(ctx context.Context, target *eth.ExecutionPayloadEnvelope, invalidatedBlock eth.BlockRef) error {
 	return nil
+}
+func (m *algoMockChain) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	if m.payloadsByHash != nil {
+		if env, ok := m.payloadsByHash[hash]; ok {
+			return env, nil
+		}
+	}
+	return nil, nil
 }
 func (m *algoMockChain) BlockTime() uint64 {
 	if m.blockTimeOverride > 0 {
@@ -1125,7 +1134,7 @@ func (m *algoMockChain) BlockTime() uint64 {
 	}
 	return 1
 }
-func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
+func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) (bool, error) {
 	return false, nil
 }
 func (m *algoMockChain) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -1128,6 +1128,15 @@ func (m *algoMockChain) PayloadByHash(ctx context.Context, hash common.Hash) (*e
 	}
 	return nil, nil
 }
+func (m *algoMockChain) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	return &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: eth.Uint64Quantity(number),
+			Timestamp:   eth.Uint64Quantity(number),
+			BlockHash:   common.BigToHash(new(big.Int).SetUint64(number)),
+		},
+	}, nil
+}
 func (m *algoMockChain) BlockTime() uint64 {
 	if m.blockTimeOverride > 0 {
 		return m.blockTimeOverride

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -881,7 +881,7 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 
 	// Capture each chain's target payload while it is still canonical. Any failure aborts
 	// the build; the decision will be re-evaluated next round.
-	if len(plan.TargetHeads) > 0 {
+	if plan.ResetAllChainsTo != nil && len(plan.TargetHeads) > 0 {
 		payloads, err := i.captureRewindPayloadsForHeads(plan.TargetHeads, rewindTargetTS)
 		if err != nil {
 			return RewindPlan{}, err

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -907,13 +907,6 @@ func (i *Interop) captureRewindPayloadsForHeads(heads map[eth.ChainID]eth.BlockI
 			return nil, fmt.Errorf("chain %s: fetch target payload %s for rewind to ts=%d: %w",
 				chainID, head.Hash, timestamp, err)
 		}
-		if err := validateRewindPayload(chainID, envelope, head.Number, timestamp); err != nil {
-			return nil, err
-		}
-		if envelope.ExecutionPayload.BlockHash != head.Hash {
-			return nil, fmt.Errorf("chain %s: rewind payload hash mismatch: got %s, want %s",
-				chainID, envelope.ExecutionPayload.BlockHash, head.Hash)
-		}
 		payloads[chainID] = envelope
 	}
 	return payloads, nil
@@ -931,29 +924,9 @@ func (i *Interop) captureRewindPayloadsAtTimestamp(timestamp uint64) (map[eth.Ch
 			return nil, fmt.Errorf("chain %s: fetch reset target payload number %d for timestamp %d: %w",
 				chainID, number, timestamp, err)
 		}
-		if err := validateRewindPayload(chainID, envelope, number, timestamp); err != nil {
-			return nil, err
-		}
 		payloads[chainID] = envelope
 	}
 	return payloads, nil
-}
-
-func validateRewindPayload(chainID eth.ChainID, envelope *eth.ExecutionPayloadEnvelope, number uint64, timestamp uint64) error {
-	if envelope == nil || envelope.ExecutionPayload == nil {
-		return fmt.Errorf("chain %s: nil rewind target payload for block %d at timestamp %d",
-			chainID, number, timestamp)
-	}
-	payload := envelope.ExecutionPayload
-	if uint64(payload.BlockNumber) != number {
-		return fmt.Errorf("chain %s: rewind payload number mismatch: got %d, want %d",
-			chainID, uint64(payload.BlockNumber), number)
-	}
-	if uint64(payload.Timestamp) != timestamp {
-		return fmt.Errorf("chain %s: rewind payload timestamp mismatch: got %d, want %d",
-			chainID, uint64(payload.Timestamp), timestamp)
-	}
-	return nil
 }
 
 func (i *Interop) shouldResetEnginesOnRewind(timestamp uint64) (bool, error) {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -650,11 +650,22 @@ func (i *Interop) newInvalidHead(chainID eth.ChainID, blockID eth.BlockID) (Inva
 
 func (i *Interop) buildPendingTransition(output StepOutput, obs RoundObservation) (PendingTransition, error) {
 	switch output.Decision {
-	case DecisionAdvance, DecisionInvalidate:
+	case DecisionAdvance:
 		result := output.Result
 		return PendingTransition{
 			Decision: output.Decision,
 			Result:   &result,
+		}, nil
+	case DecisionInvalidate:
+		result := output.Result
+		parentPayloads, err := i.captureInvalidationParentPayloads(result.InvalidHeads)
+		if err != nil {
+			return PendingTransition{}, fmt.Errorf("capture invalidation parent payloads: %w", err)
+		}
+		return PendingTransition{
+			Decision:                   output.Decision,
+			Result:                     &result,
+			InvalidationParentPayloads: parentPayloads,
 		}, nil
 	case DecisionRewind:
 		rewindPlan, err := i.buildRewindPlan(*obs.LastVerifiedTS)
@@ -668,6 +679,48 @@ func (i *Interop) buildPendingTransition(output StepOutput, obs RoundObservation
 	default:
 		return PendingTransition{}, fmt.Errorf("unsupported transition decision: %v", output.Decision)
 	}
+}
+
+// captureInvalidationParentPayloads fetches, for every invalidated chain, the canonical
+// parent payload (height-1) that the rewind will restore as the new unsafe head. The
+// payloads are captured at decision time — while they are still canonical — and persisted
+// in the WAL so the apply path does not depend on the live EL still having them. Any
+// fetch failure aborts the build; the decision will be re-evaluated next round.
+func (i *Interop) captureInvalidationParentPayloads(invalidHeads map[eth.ChainID]InvalidHead) (map[eth.ChainID]*eth.ExecutionPayloadEnvelope, error) {
+	if len(invalidHeads) == 0 {
+		return nil, nil
+	}
+	parents := make(map[eth.ChainID]*eth.ExecutionPayloadEnvelope, len(invalidHeads))
+	for chainID, head := range invalidHeads {
+		if head.BlockID.Number == 0 {
+			return nil, fmt.Errorf("chain %s: cannot invalidate genesis block (height=0)", chainID)
+		}
+		chain, ok := i.chains[chainID]
+		if !ok {
+			return nil, fmt.Errorf("chain %s: not configured", chainID)
+		}
+		// Fetch the invalidated block by hash so we know which parent to load. Looking it up
+		// by hash (rather than by number) protects against any concurrent reorg at the
+		// invalidated height — we want the parent of the specific block the decision rejected.
+		invalidatedRef, err := chain.PayloadByHash(i.ctx, head.BlockID.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("chain %s: fetch invalidated block %s: %w", chainID, head.BlockID.Hash, err)
+		}
+		if invalidatedRef == nil || invalidatedRef.ExecutionPayload == nil {
+			return nil, fmt.Errorf("chain %s: empty payload for invalidated block %s", chainID, head.BlockID.Hash)
+		}
+		parentEnvelope, err := chain.PayloadByHash(i.ctx, invalidatedRef.ExecutionPayload.ParentHash)
+		if err != nil {
+			return nil, fmt.Errorf("chain %s: fetch parent payload %s: %w",
+				chainID, invalidatedRef.ExecutionPayload.ParentHash, err)
+		}
+		if parentEnvelope == nil || parentEnvelope.ExecutionPayload == nil {
+			return nil, fmt.Errorf("chain %s: empty parent payload for invalidated block %s",
+				chainID, head.BlockID.Hash)
+		}
+		parents[chainID] = parentEnvelope
+	}
+	return parents, nil
 }
 
 func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error) {
@@ -723,7 +776,17 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		}
 		var failedAny bool
 		for _, p := range invalidations {
-			if err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp, p.StateRoot, p.MessagePasserStorageRoot); err != nil {
+			parentPayload, ok := pending.InvalidationParentPayloads[p.ChainID]
+			if !ok || parentPayload == nil {
+				// Build path guarantees a parent payload for every invalidated chain.
+				// Missing here means a malformed (older-format / corrupted) WAL record —
+				// surface and preserve the transition for operator intervention.
+				i.log.Error("invalidation parent payload missing from WAL — invalidation cannot proceed",
+					"chain", p.ChainID, "block", p.BlockID)
+				failedAny = true
+				continue
+			}
+			if err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp, p.StateRoot, p.MessagePasserStorageRoot, parentPayload); err != nil {
 				i.log.Error("invalidation failed, transition preserved for retry on restart",
 					"chain", p.ChainID, "block", p.BlockID, "err", err)
 				failedAny = true
@@ -819,6 +882,34 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 		return RewindPlan{}, fmt.Errorf("read previous verified result at %d: %w", rewindTargetTS, err)
 	}
 	plan.TargetHeads = prevResult.L2Heads
+
+	// Capture each chain's target payload by hash while it is still canonical. Any failure
+	// here aborts the build — we never persist a rewind we can't safely complete; the
+	// decision will be re-evaluated next round.
+	if len(plan.TargetHeads) > 0 {
+		plan.TargetPayloads = make(map[eth.ChainID]*eth.ExecutionPayloadEnvelope, len(plan.TargetHeads))
+		for chainID, head := range plan.TargetHeads {
+			chain, ok := i.chains[chainID]
+			if !ok {
+				return RewindPlan{}, fmt.Errorf("chain %s referenced in target heads but not configured", chainID)
+			}
+			envelope, err := chain.PayloadByHash(i.ctx, head.Hash)
+			if err != nil {
+				return RewindPlan{}, fmt.Errorf("chain %s: fetch target payload %s for rewind to ts=%d: %w",
+					chainID, head.Hash, rewindTargetTS, err)
+			}
+			if envelope == nil || envelope.ExecutionPayload == nil {
+				return RewindPlan{}, fmt.Errorf("chain %s: empty target payload %s for rewind to ts=%d",
+					chainID, head.Hash, rewindTargetTS)
+			}
+			if envelope.ExecutionPayload.BlockHash != head.Hash {
+				return RewindPlan{}, fmt.Errorf("chain %s: target payload hash %s does not match expected %s",
+					chainID, envelope.ExecutionPayload.BlockHash, head.Hash)
+			}
+			plan.TargetPayloads[chainID] = envelope
+		}
+	}
+
 	return plan, nil
 }
 
@@ -907,9 +998,20 @@ func (i *Interop) resetChainEnginesIfNeeded(plan RewindPlan, sortedChainIDs []et
 		return
 	}
 	for _, chainID := range sortedChainIDs {
+		target, ok := plan.TargetPayloads[chainID]
+		if !ok {
+			// The build path guarantees a TargetPayloads entry for every chain in TargetHeads.
+			// If we get here, the WAL record is malformed (older format or corruption) — surface
+			// it rather than re-deriving from the live EL, which could pick up a stale synthetic
+			// block from a prior crashed attempt.
+			recordErr(fmt.Errorf("chain %s: missing target payload in WAL'd rewind plan (rewindToTimestamp=%d)",
+				chainID, *plan.ResetAllChainsTo))
+			continue
+		}
 		i.log.Warn("rewinding chain engine after pruning deny-list entries",
-			"chain", chainID, "rewindToTimestamp", *plan.ResetAllChainsTo)
-		if err := i.chains[chainID].RewindEngine(i.ctx, *plan.ResetAllChainsTo, eth.BlockRef{}); err != nil {
+			"chain", chainID, "rewindToTimestamp", *plan.ResetAllChainsTo,
+			"targetHash", target.ExecutionPayload.BlockHash)
+		if err := i.chains[chainID].RewindEngine(i.ctx, target, eth.BlockRef{}); err != nil {
 			i.log.Error("failed to reset chain engine after pruning deny-list entries", "chain", chainID, "err", err)
 			recordErr(fmt.Errorf("chain %s: reset chain engine after pruning deny-list entries: %w", chainID, err))
 		}
@@ -1142,12 +1244,13 @@ func (i *Interop) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock 
 }
 
 // invalidateBlock notifies the chain container to add the block to the denylist
-// and potentially rewind if the chain is currently using that block.
-func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
+// and potentially rewind if the chain is currently using that block. parentPayload
+// is the canonical payload at the rewind destination (height-1), captured from the WAL.
+func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) error {
 	chain, ok := i.chains[chainID]
 	if !ok {
 		return fmt.Errorf("chain %s not found", chainID)
 	}
-	_, err := chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp, stateRoot, messagePasserStorageRoot)
+	_, err := chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp, stateRoot, messagePasserStorageRoot, parentPayload)
 	return err
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -682,10 +682,9 @@ func (i *Interop) buildPendingTransition(output StepOutput, obs RoundObservation
 }
 
 // captureInvalidationParentPayloads fetches, for every invalidated chain, the canonical
-// parent payload (height-1) that the rewind will restore as the new unsafe head. The
-// payloads are captured at decision time — while they are still canonical — and persisted
-// in the WAL so the apply path does not depend on the live EL still having them. Any
-// fetch failure aborts the build; the decision will be re-evaluated next round.
+// parent payload (height-1) the rewind will restore as the new unsafe head. The payloads
+// are persisted in the WAL so apply does not depend on the live EL still having them.
+// Any fetch failure aborts the build; the decision will be re-evaluated next round.
 func (i *Interop) captureInvalidationParentPayloads(invalidHeads map[eth.ChainID]InvalidHead) (map[eth.ChainID]*eth.ExecutionPayloadEnvelope, error) {
 	if len(invalidHeads) == 0 {
 		return nil, nil
@@ -699,24 +698,14 @@ func (i *Interop) captureInvalidationParentPayloads(invalidHeads map[eth.ChainID
 		if !ok {
 			return nil, fmt.Errorf("chain %s: not configured", chainID)
 		}
-		// Fetch the invalidated block by hash so we know which parent to load. Looking it up
-		// by hash (rather than by number) protects against any concurrent reorg at the
-		// invalidated height — we want the parent of the specific block the decision rejected.
 		invalidatedRef, err := chain.PayloadByHash(i.ctx, head.BlockID.Hash)
 		if err != nil {
 			return nil, fmt.Errorf("chain %s: fetch invalidated block %s: %w", chainID, head.BlockID.Hash, err)
-		}
-		if invalidatedRef == nil || invalidatedRef.ExecutionPayload == nil {
-			return nil, fmt.Errorf("chain %s: empty payload for invalidated block %s", chainID, head.BlockID.Hash)
 		}
 		parentEnvelope, err := chain.PayloadByHash(i.ctx, invalidatedRef.ExecutionPayload.ParentHash)
 		if err != nil {
 			return nil, fmt.Errorf("chain %s: fetch parent payload %s: %w",
 				chainID, invalidatedRef.ExecutionPayload.ParentHash, err)
-		}
-		if parentEnvelope == nil || parentEnvelope.ExecutionPayload == nil {
-			return nil, fmt.Errorf("chain %s: empty parent payload for invalidated block %s",
-				chainID, head.BlockID.Hash)
 		}
 		parents[chainID] = parentEnvelope
 	}
@@ -883,9 +872,8 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 	}
 	plan.TargetHeads = prevResult.L2Heads
 
-	// Capture each chain's target payload by hash while it is still canonical. Any failure
-	// here aborts the build — we never persist a rewind we can't safely complete; the
-	// decision will be re-evaluated next round.
+	// Capture each chain's target payload while it is still canonical. Any failure aborts
+	// the build; the decision will be re-evaluated next round.
 	if len(plan.TargetHeads) > 0 {
 		plan.TargetPayloads = make(map[eth.ChainID]*eth.ExecutionPayloadEnvelope, len(plan.TargetHeads))
 		for chainID, head := range plan.TargetHeads {
@@ -897,14 +885,6 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 			if err != nil {
 				return RewindPlan{}, fmt.Errorf("chain %s: fetch target payload %s for rewind to ts=%d: %w",
 					chainID, head.Hash, rewindTargetTS, err)
-			}
-			if envelope == nil || envelope.ExecutionPayload == nil {
-				return RewindPlan{}, fmt.Errorf("chain %s: empty target payload %s for rewind to ts=%d",
-					chainID, head.Hash, rewindTargetTS)
-			}
-			if envelope.ExecutionPayload.BlockHash != head.Hash {
-				return RewindPlan{}, fmt.Errorf("chain %s: target payload hash %s does not match expected %s",
-					chainID, envelope.ExecutionPayload.BlockHash, head.Hash)
 			}
 			plan.TargetPayloads[chainID] = envelope
 		}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -862,6 +862,13 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 		return RewindPlan{}, err
 	}
 	if lastTS <= first {
+		if plan.ResetAllChainsTo != nil {
+			payloads, err := i.captureRewindPayloadsAtTimestamp(*plan.ResetAllChainsTo)
+			if err != nil {
+				return RewindPlan{}, fmt.Errorf("capture reset target payloads at %d: %w", *plan.ResetAllChainsTo, err)
+			}
+			plan.TargetPayloads = payloads
+		}
 		return plan, nil
 	}
 
@@ -875,22 +882,78 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 	// Capture each chain's target payload while it is still canonical. Any failure aborts
 	// the build; the decision will be re-evaluated next round.
 	if len(plan.TargetHeads) > 0 {
-		plan.TargetPayloads = make(map[eth.ChainID]*eth.ExecutionPayloadEnvelope, len(plan.TargetHeads))
-		for chainID, head := range plan.TargetHeads {
-			chain, ok := i.chains[chainID]
-			if !ok {
-				return RewindPlan{}, fmt.Errorf("chain %s referenced in target heads but not configured", chainID)
-			}
-			envelope, err := chain.PayloadByHash(i.ctx, head.Hash)
-			if err != nil {
-				return RewindPlan{}, fmt.Errorf("chain %s: fetch target payload %s for rewind to ts=%d: %w",
-					chainID, head.Hash, rewindTargetTS, err)
-			}
-			plan.TargetPayloads[chainID] = envelope
+		payloads, err := i.captureRewindPayloadsForHeads(plan.TargetHeads, rewindTargetTS)
+		if err != nil {
+			return RewindPlan{}, err
 		}
+		plan.TargetPayloads = payloads
 	}
 
 	return plan, nil
+}
+
+func (i *Interop) captureRewindPayloadsForHeads(heads map[eth.ChainID]eth.BlockID, timestamp uint64) (map[eth.ChainID]*eth.ExecutionPayloadEnvelope, error) {
+	if len(heads) == 0 {
+		return nil, nil
+	}
+	payloads := make(map[eth.ChainID]*eth.ExecutionPayloadEnvelope, len(heads))
+	for chainID, head := range heads {
+		chain, ok := i.chains[chainID]
+		if !ok {
+			return nil, fmt.Errorf("chain %s referenced in target heads but not configured", chainID)
+		}
+		envelope, err := chain.PayloadByHash(i.ctx, head.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("chain %s: fetch target payload %s for rewind to ts=%d: %w",
+				chainID, head.Hash, timestamp, err)
+		}
+		if err := validateRewindPayload(chainID, envelope, head.Number, timestamp); err != nil {
+			return nil, err
+		}
+		if envelope.ExecutionPayload.BlockHash != head.Hash {
+			return nil, fmt.Errorf("chain %s: rewind payload hash mismatch: got %s, want %s",
+				chainID, envelope.ExecutionPayload.BlockHash, head.Hash)
+		}
+		payloads[chainID] = envelope
+	}
+	return payloads, nil
+}
+
+func (i *Interop) captureRewindPayloadsAtTimestamp(timestamp uint64) (map[eth.ChainID]*eth.ExecutionPayloadEnvelope, error) {
+	payloads := make(map[eth.ChainID]*eth.ExecutionPayloadEnvelope, len(i.chains))
+	for chainID, chain := range i.chains {
+		number, err := chain.TimestampToBlockNumber(i.ctx, timestamp)
+		if err != nil {
+			return nil, fmt.Errorf("chain %s: compute rewind target number for timestamp %d: %w", chainID, timestamp, err)
+		}
+		envelope, err := chain.PayloadByNumber(i.ctx, number)
+		if err != nil {
+			return nil, fmt.Errorf("chain %s: fetch reset target payload number %d for timestamp %d: %w",
+				chainID, number, timestamp, err)
+		}
+		if err := validateRewindPayload(chainID, envelope, number, timestamp); err != nil {
+			return nil, err
+		}
+		payloads[chainID] = envelope
+	}
+	return payloads, nil
+}
+
+func validateRewindPayload(chainID eth.ChainID, envelope *eth.ExecutionPayloadEnvelope, number uint64, timestamp uint64) error {
+	if envelope == nil || envelope.ExecutionPayload == nil {
+		return fmt.Errorf("chain %s: nil rewind target payload for block %d at timestamp %d",
+			chainID, number, timestamp)
+	}
+	payload := envelope.ExecutionPayload
+	if uint64(payload.BlockNumber) != number {
+		return fmt.Errorf("chain %s: rewind payload number mismatch: got %d, want %d",
+			chainID, uint64(payload.BlockNumber), number)
+	}
+	if uint64(payload.Timestamp) != timestamp {
+		return fmt.Errorf("chain %s: rewind payload timestamp mismatch: got %d, want %d",
+			chainID, uint64(payload.Timestamp), timestamp)
+	}
+	return nil
 }
 
 func (i *Interop) shouldResetEnginesOnRewind(timestamp uint64) (bool, error) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1747,6 +1747,8 @@ type mockChainContainer struct {
 	payloadsByHash        map[common.Hash]*eth.ExecutionPayloadEnvelope
 	payloadByHashErr      error
 	payloadByHashOverride func(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
+	payloadsByNumber      map[uint64]*eth.ExecutionPayloadEnvelope
+	payloadByNumberErr    error
 
 	// OptimisticAt fields
 	optimisticL2    eth.BlockID
@@ -2013,13 +2015,31 @@ func (m *mockChainContainer) PayloadByHash(ctx context.Context, hash common.Hash
 		return nil, m.payloadByHashErr
 	}
 	// Default synthesized payload — satisfies the build path's structural checks
-	// (non-nil envelope, BlockHash matches request) without requiring tests to
-	// populate payloadsByHash for every hash they touch. Tests that need a specific
-	// envelope can set payloadsByHash or payloadByHashOverride.
+	// without requiring tests to populate payloadsByHash for every hash they touch.
+	// Tests often use common.BigToHash(timestamp) as the block hash, so derive the
+	// number and timestamp from the hash value.
+	number := hash.Big().Uint64()
 	return &eth.ExecutionPayloadEnvelope{
 		ExecutionPayload: &eth.ExecutionPayload{
-			BlockHash:  hash,
-			ParentHash: hash, // self-loop is fine for tests that don't inspect parent
+			BlockHash:   hash,
+			ParentHash:  hash, // self-loop is fine for tests that don't inspect parent
+			BlockNumber: eth.Uint64Quantity(number),
+			Timestamp:   eth.Uint64Quantity(number),
+		},
+	}, nil
+}
+func (m *mockChainContainer) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	if env, ok := m.payloadsByNumber[number]; ok {
+		return env, nil
+	}
+	if m.payloadByNumberErr != nil {
+		return nil, m.payloadByNumberErr
+	}
+	return &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: eth.Uint64Quantity(number),
+			Timestamp:   eth.Uint64Quantity(number),
+			BlockHash:   common.BigToHash(new(big.Int).SetUint64(number)),
 		},
 	}, nil
 }
@@ -2552,6 +2572,44 @@ func TestRewindAccepted(t *testing.T) {
 
 		// logsDB should be cleared (no previous frontier to rewind to)
 		require.True(t, trackingDB.clearCalled > 0, "logsDB should be cleared when rewinding to empty")
+	})
+
+	t.Run("full rewind captures reset payloads before clearing verified frontier", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.pruneDeniedResult = map[uint64][]common.Hash{
+					1000: {common.HexToHash("0xdenied")},
+				}
+			}).
+			Build()
+
+		mock := h.Mock(10)
+		chainID := mock.id
+
+		require.NoError(t, h.commitVerified(VerifiedResult{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 50},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Number: 1000, Hash: common.BigToHash(big.NewInt(1000))}},
+		}))
+
+		trackingDB := &mockLogsDBWithState{
+			latestBlock: eth.BlockID{Number: 1000},
+			hasBlocks:   true,
+		}
+		h.interop.logsDBs[chainID] = trackingDB
+
+		plan, err := h.interop.buildRewindPlan(1000)
+		require.NoError(t, err)
+		require.NotNil(t, plan.ResetAllChainsTo)
+		require.Equal(t, uint64(999), *plan.ResetAllChainsTo)
+		require.NotNil(t, plan.TargetPayloads[chainID])
+		require.Equal(t, uint64(999), uint64(plan.TargetPayloads[chainID].ExecutionPayload.Timestamp))
+
+		err = h.interop.applyRewindPlan(plan)
+		require.NoError(t, err)
+		require.True(t, trackingDB.clearCalled > 0, "logsDB should be cleared when rewinding to empty")
+		require.Equal(t, []uint64{999}, mock.rewindEngineCalls)
+		require.Same(t, plan.TargetPayloads[chainID], mock.lastRewindEngineTarget)
 	})
 }
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
@@ -2018,7 +2019,7 @@ func (m *mockChainContainer) PayloadByHash(ctx context.Context, hash common.Hash
 	// without requiring tests to populate payloadsByHash for every hash they touch.
 	// Tests often use common.BigToHash(timestamp) as the block hash, so derive the
 	// number and timestamp from the hash value.
-	number := hash.Big().Uint64()
+	number := bigs.Uint64Strict(hash.Big())
 	return &eth.ExecutionPayloadEnvelope{
 		ExecutionPayload: &eth.ExecutionPayload{
 			BlockHash:   hash,

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -134,6 +134,36 @@ func (h *interopTestHarness) Mock(id uint64) *mockChainContainer {
 	return h.mocks[eth.ChainIDFromUInt64(id)]
 }
 
+// commitVerified commits a VerifiedResult to the verifiedDB and additionally registers a
+// canonical payload on each referenced chain's mock keyed by the verified head's hash.
+// The new rewind data model requires the build path to fetch each chain's canonical payload
+// by hash from the chain at decision time; routing all test commits through this helper
+// keeps tests concise and lets the synthesized envelopes carry the expected timestamp.
+func (h *interopTestHarness) commitVerified(vr VerifiedResult) error {
+	if err := h.interop.verifiedDB.Commit(vr); err != nil {
+		return err
+	}
+	for chainID, blockID := range vr.L2Heads {
+		mock := h.mocks[chainID]
+		if mock == nil {
+			continue
+		}
+		mock.mu.Lock()
+		if mock.payloadsByHash == nil {
+			mock.payloadsByHash = map[common.Hash]*eth.ExecutionPayloadEnvelope{}
+		}
+		mock.payloadsByHash[blockID.Hash] = &eth.ExecutionPayloadEnvelope{
+			ExecutionPayload: &eth.ExecutionPayload{
+				BlockHash:   blockID.Hash,
+				BlockNumber: eth.Uint64Quantity(blockID.Number),
+				Timestamp:   eth.Uint64Quantity(vr.Timestamp),
+			},
+		}
+		mock.mu.Unlock()
+	}
+	return nil
+}
+
 // =============================================================================
 // TestNew
 // =============================================================================
@@ -1137,6 +1167,14 @@ func TestApplyResultCompat(t *testing.T) {
 // TestInvalidateBlock
 // =============================================================================
 
+func dummyParentPayload(invalid eth.BlockID) *eth.ExecutionPayloadEnvelope {
+	return &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: eth.Uint64Quantity(invalid.Number - 1),
+		},
+	}
+}
+
 // TestInvalidateBlock verifies the invalidateBlock method correctly calls
 // ChainContainer.InvalidateBlock with the right parameters and handles errors.
 func TestInvalidateBlock(t *testing.T) {
@@ -1155,7 +1193,7 @@ func TestInvalidateBlock(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
+				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
 				require.NoError(t, err)
 
 				require.Len(t, mock.invalidateBlockCalls, 1)
@@ -1172,7 +1210,7 @@ func TestInvalidateBlock(t *testing.T) {
 				mock := h.Mock(10)
 				unknownChain := eth.ChainIDFromUInt64(999)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(unknownChain, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
+				err := h.interop.invalidateBlock(unknownChain, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "not found")
@@ -1189,7 +1227,7 @@ func TestInvalidateBlock(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
+				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "engine failure")
@@ -1698,12 +1736,17 @@ type mockChainContainer struct {
 	mu                     sync.Mutex
 
 	// InvalidateBlock tracking
-	invalidateBlockCalls []invalidateBlockCall
-	invalidateBlockRet   bool
-	invalidateBlockErr   error
-	pruneDeniedResult    map[uint64][]common.Hash
-	rewindEngineCalls    []uint64
-	rewindEngineErr      error
+	invalidateBlockCalls   []invalidateBlockCall
+	invalidateBlockRet     bool
+	invalidateBlockErr     error
+	pruneDeniedResult      map[uint64][]common.Hash
+	rewindEngineCalls      []uint64
+	rewindEngineErr        error
+	lastRewindEngineTarget *eth.ExecutionPayloadEnvelope
+
+	payloadsByHash        map[common.Hash]*eth.ExecutionPayloadEnvelope
+	payloadByHashErr      error
+	payloadByHashOverride func(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
 
 	// OptimisticAt fields
 	optimisticL2    eth.BlockID
@@ -1764,6 +1807,7 @@ type invalidateBlockCall struct {
 	payloadHash              common.Hash
 	stateRoot                eth.Bytes32
 	messagePasserStorageRoot eth.Bytes32
+	parentPayload            *eth.ExecutionPayloadEnvelope
 }
 
 func newMockChainContainer(id uint64) *mockChainContainer {
@@ -1946,11 +1990,38 @@ func (m *mockChainContainer) TimestampToBlockNumber(ctx context.Context, ts uint
 	}
 	return ts, nil
 }
-func (m *mockChainContainer) RewindEngine(ctx context.Context, timestamp uint64, invalidatedBlock eth.BlockRef) error {
+func (m *mockChainContainer) RewindEngine(ctx context.Context, target *eth.ExecutionPayloadEnvelope, invalidatedBlock eth.BlockRef) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.rewindEngineCalls = append(m.rewindEngineCalls, timestamp)
+	var ts uint64
+	if target != nil && target.ExecutionPayload != nil {
+		ts = uint64(target.ExecutionPayload.Timestamp)
+	}
+	m.rewindEngineCalls = append(m.rewindEngineCalls, ts)
+	m.lastRewindEngineTarget = target
 	return m.rewindEngineErr
+}
+
+func (m *mockChainContainer) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	if m.payloadByHashOverride != nil {
+		return m.payloadByHashOverride(ctx, hash)
+	}
+	if env, ok := m.payloadsByHash[hash]; ok {
+		return env, nil
+	}
+	if m.payloadByHashErr != nil {
+		return nil, m.payloadByHashErr
+	}
+	// Default synthesized payload — satisfies the build path's structural checks
+	// (non-nil envelope, BlockHash matches request) without requiring tests to
+	// populate payloadsByHash for every hash they touch. Tests that need a specific
+	// envelope can set payloadsByHash or payloadByHashOverride.
+	return &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockHash:  hash,
+			ParentHash: hash, // self-loop is fine for tests that don't inspect parent
+		},
+	}, nil
 }
 func (m *mockChainContainer) BlockTime() uint64 {
 	if m.blockTimeOverride > 0 {
@@ -1958,10 +2029,11 @@ func (m *mockChainContainer) BlockTime() uint64 {
 	}
 	return 1
 }
-func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
+func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) (bool, error) {
 	m.mu.Lock()
 	m.invalidateBlockCalls = append(m.invalidateBlockCalls, invalidateBlockCall{
 		height: height, payloadHash: payloadHash, stateRoot: stateRoot, messagePasserStorageRoot: messagePasserStorageRoot,
+		parentPayload: parentPayload,
 	})
 	m.mu.Unlock()
 	if m.callLog != nil {
@@ -2113,12 +2185,12 @@ func TestPendingTransition_RecoverRewindPreservedOnFailure(t *testing.T) {
 
 	mock := h.Mock(10)
 
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, h.commitVerified(VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100, Hash: common.HexToHash("0x1")}},
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, h.commitVerified(VerifiedResult{
 		Timestamp:   1001,
 		L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 101, Hash: common.HexToHash("0x2")}},
@@ -2161,7 +2233,7 @@ func TestPendingTransition_RewindReplaysAfterFailure(t *testing.T) {
 	mockA := h.Mock(10)
 	mockB := h.Mock(8453)
 
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, h.commitVerified(VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2169,7 +2241,7 @@ func TestPendingTransition_RewindReplaysAfterFailure(t *testing.T) {
 			mockB.id: {Number: 200, Hash: common.HexToHash("0xb1")},
 		},
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, h.commitVerified(VerifiedResult{
 		Timestamp:   1001,
 		L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2228,7 +2300,7 @@ func TestPendingTransition_RecoverRewindReportsAllFailures(t *testing.T) {
 	mockA := h.Mock(10)
 	mockB := h.Mock(8453)
 
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, h.commitVerified(VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2236,7 +2308,7 @@ func TestPendingTransition_RecoverRewindReportsAllFailures(t *testing.T) {
 			mockB.id: {Number: 200, Hash: common.HexToHash("0x2")},
 		},
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, h.commitVerified(VerifiedResult{
 		Timestamp:   1001,
 		L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2276,7 +2348,7 @@ func TestPendingTransition_RecoverAdvanceAfterCommitClearsPendingTransition(t *t
 		Decision: DecisionAdvance,
 		Result:   &result,
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(result.ToVerifiedResult()))
+	require.NoError(t, h.commitVerified(result.ToVerifiedResult()))
 
 	madeProgress, err := h.interop.progressAndRecord()
 	require.NoError(t, err)
@@ -2303,7 +2375,7 @@ func TestL1CanonicalityCheckErrorPropagates(t *testing.T) {
 	mock := h.Mock(10)
 
 	// Commit a verified result so observeRound has a LastVerified to check
-	err := h.interop.verifiedDB.Commit(VerifiedResult{
+	err := h.commitVerified(VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1")},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100, Hash: common.HexToHash("0x1")}},
@@ -2342,13 +2414,13 @@ func TestRewindAccepted(t *testing.T) {
 		}
 
 		// Commit two verified results: T=1000 and T=1001
-		err := h.interop.verifiedDB.Commit(VerifiedResult{
+		err := h.commitVerified(VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Number: 100, Hash: common.HexToHash("0x1")}},
 		})
 		require.NoError(t, err)
-		err = h.interop.verifiedDB.Commit(VerifiedResult{
+		err = h.commitVerified(VerifiedResult{
 			Timestamp:   1001,
 			L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Number: 101, Hash: common.HexToHash("0x2")}},
@@ -2397,7 +2469,7 @@ func TestRewindAccepted(t *testing.T) {
 		mockA := h.Mock(10)
 		mockB := h.Mock(8453)
 
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, h.commitVerified(VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 			L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2405,7 +2477,7 @@ func TestRewindAccepted(t *testing.T) {
 				mockB.id: {Number: 200, Hash: common.HexToHash("0xb1")},
 			},
 		}))
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, h.commitVerified(VerifiedResult{
 			Timestamp:   1001,
 			L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 			L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2435,12 +2507,12 @@ func TestRewindAccepted(t *testing.T) {
 			Build()
 
 		mock := h.Mock(10)
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, h.commitVerified(VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100, Hash: common.HexToHash("0xa1")}},
 		}))
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, h.commitVerified(VerifiedResult{
 			Timestamp:   1001,
 			L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 101, Hash: common.HexToHash("0xa2")}},
@@ -2459,7 +2531,7 @@ func TestRewindAccepted(t *testing.T) {
 		chainID := h.Mock(10).id
 
 		// Commit one result at activation timestamp
-		err := h.interop.verifiedDB.Commit(VerifiedResult{
+		err := h.commitVerified(VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Number: 100}},
@@ -2660,7 +2732,7 @@ func TestResetIsNoOp(t *testing.T) {
 		Build()
 
 	mock := h.Mock(10)
-	err := h.interop.verifiedDB.Commit(VerifiedResult{
+	err := h.commitVerified(VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100}},
@@ -2696,7 +2768,7 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 
 		// Commit some verified results so the DB is non-empty
 		for ts := uint64(100); ts <= 110; ts++ {
-			err := h.interop.verifiedDB.Commit(VerifiedResult{
+			err := h.commitVerified(VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Number: ts + 1000},
 				L2Heads:     map[eth.ChainID]eth.BlockID{h.Mock(10).id: {Number: ts}},
@@ -2723,7 +2795,7 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 			if ts == 1005 {
 				l2Head = expectedL2
 			}
-			err := h.interop.verifiedDB.Commit(VerifiedResult{
+			err := h.commitVerified(VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Number: ts * 10},
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: l2Head},
@@ -2759,7 +2831,7 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		chainID := h.Mock(10).id
 		// LastTimestamp is cached, so the scan still enters the loop after Close.
 		for tsCommit := uint64(1000); tsCommit <= 1003; tsCommit++ {
-			err := h.interop.verifiedDB.Commit(VerifiedResult{
+			err := h.commitVerified(VerifiedResult{
 				Timestamp:   tsCommit,
 				L1Inclusion: eth.BlockID{Number: 5},
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.Hash{byte(tsCommit)}, Number: tsCommit}},
@@ -2784,7 +2856,7 @@ func TestLatestVerifiedL2Block_ClosedDBSurfacesError(t *testing.T) {
 
 	chainID := h.Mock(10).id
 	for tsCommit := uint64(1000); tsCommit <= 1003; tsCommit++ {
-		err := h.interop.verifiedDB.Commit(VerifiedResult{
+		err := h.commitVerified(VerifiedResult{
 			Timestamp:   tsCommit,
 			L1Inclusion: eth.BlockID{Number: 5},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.Hash{byte(tsCommit)}, Number: tsCommit}},

--- a/op-supernode/supernode/activity/interop/types.go
+++ b/op-supernode/supernode/activity/interop/types.go
@@ -38,19 +38,31 @@ type Result struct {
 // - advance/invalidate carry their Result directly
 // - rewind carries the accepted frontier to rewind from
 // Later phases can expand this into a richer explicit transition plan.
+//
+// InvalidationParentPayloads is populated only for DecisionInvalidate transitions. It carries
+// the canonical parent payload (height-1) for each invalidated chain, captured at build time
+// and used at apply time to drive the rewind. Storing the full payload means a crash mid-rewind
+// can be recovered without consulting the live EL — the canonical block may already have been
+// pruned by the EL once it left the canonical chain.
 type PendingTransition struct {
-	Decision Decision    `json:"decision"`
-	Result   *Result     `json:"result,omitempty"`
-	Rewind   *RewindPlan `json:"rewind,omitempty"`
+	Decision                   Decision                                      `json:"decision"`
+	Result                     *Result                                       `json:"result,omitempty"`
+	Rewind                     *RewindPlan                                   `json:"rewind,omitempty"`
+	InvalidationParentPayloads map[eth.ChainID]*eth.ExecutionPayloadEnvelope `json:"invalidationParentPayloads,omitempty"`
 }
 
 // RewindPlan is the explicit rewind transition persisted in the WAL.
 // It captures the target verified frontier and engine reset decision so recovery
 // can apply the same rewind path without recomputing it from live state.
+//
+// TargetPayloads carries the canonical payload at each chain's rewind target, captured at
+// build time. The apply path uses it to drive the engine rewind without consulting the live
+// EL — see the InvalidationParentPayloads comment on PendingTransition for the rationale.
 type RewindPlan struct {
-	RewindAtOrAfter  uint64                      `json:"rewindAtOrAfter"`
-	ResetAllChainsTo *uint64                     `json:"resetAllChainsTo,omitempty"`
-	TargetHeads      map[eth.ChainID]eth.BlockID `json:"targetHeads,omitempty"`
+	RewindAtOrAfter  uint64                                        `json:"rewindAtOrAfter"`
+	ResetAllChainsTo *uint64                                       `json:"resetAllChainsTo,omitempty"`
+	TargetHeads      map[eth.ChainID]eth.BlockID                   `json:"targetHeads,omitempty"`
+	TargetPayloads   map[eth.ChainID]*eth.ExecutionPayloadEnvelope `json:"targetPayloads,omitempty"`
 }
 
 func (r *Result) IsValid() bool {

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -87,6 +87,10 @@ func (m *mockCC) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.Exec
 	return nil, nil
 }
 
+func (m *mockCC) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	return nil, nil
+}
+
 func (m *mockCC) ID() eth.ChainID {
 	return eth.ChainIDFromUInt64(10)
 }

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -83,6 +83,10 @@ func (m *mockCC) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.Bl
 	return nil, nil, nil
 }
 
+func (m *mockCC) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	return nil, nil
+}
+
 func (m *mockCC) ID() eth.ChainID {
 	return eth.ChainIDFromUInt64(10)
 }

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -93,6 +93,9 @@ func (m *mockCC) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.Bl
 func (m *mockCC) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
 	return nil, nil
 }
+func (m *mockCC) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	return nil, nil
+}
 func (m *mockCC) ID() eth.ChainID   { return eth.ChainIDFromUInt64(10) }
 func (m *mockCC) BlockTime() uint64 { return 1 }
 func (m *mockCC) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -90,6 +90,9 @@ func (m *mockCC) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*e
 func (m *mockCC) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
 	return nil, nil, nil
 }
+func (m *mockCC) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	return nil, nil
+}
 func (m *mockCC) ID() eth.ChainID   { return eth.ChainIDFromUInt64(10) }
 func (m *mockCC) BlockTime() uint64 { return 1 }
 func (m *mockCC) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -93,6 +93,9 @@ type ChainContainer interface {
 	GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error)
 	// OutputV0AtBlockNumber returns the full OutputV0 for the block at the given number.
 	OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error)
+	// PayloadByHash returns the canonical execution payload envelope for the given block hash.
+	// Used by interop build paths to capture canonical payloads for WAL'd rewind operations.
+	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
 	// SetResetCallback sets a callback that is invoked when the chain resets.
 	// The supernode uses this to notify activities about chain resets.
 	SetResetCallback(cb ResetCallback)
@@ -108,14 +111,17 @@ type InteropChain interface {
 	// HasDeniedAtOrAfterTimestamp returns true if any deny-list entry has
 	// DecisionTimestamp >= timestamp, without mutating the deny list.
 	HasDeniedAtOrAfterTimestamp(timestamp uint64) (bool, error)
-	// RewindEngine rewinds the engine to the highest block with timestamp less than
-	// or equal to the given timestamp. invalidatedBlock is the block that triggered
-	// the rewind and is passed to reset callbacks.
-	RewindEngine(ctx context.Context, timestamp uint64, invalidatedBlock eth.BlockRef) error
-	// InvalidateBlock adds a block to the deny list and triggers a rewind if the
-	// chain currently uses that block at the specified height. Returns true if a
-	// rewind was triggered, false otherwise.
-	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error)
+	// RewindEngine rewinds the engine to the supplied target block. target is the canonical
+	// payload at the rewind destination, loaded from durable WAL storage by the caller —
+	// not re-derived from the live engine. invalidatedBlock is the block that triggered the
+	// rewind and is passed to reset callbacks (it is purely informational).
+	RewindEngine(ctx context.Context, target *eth.ExecutionPayloadEnvelope, invalidatedBlock eth.BlockRef) error
+	// InvalidateBlock adds a block to the deny list and triggers a rewind if the chain
+	// currently uses that block at the specified height. parentPayload is the canonical
+	// payload at height-1 (the rewind destination) loaded from durable WAL storage —
+	// callers must capture it at build time, before the rewind starts. Returns true if
+	// a rewind was triggered, false otherwise.
+	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) (bool, error)
 }
 
 type virtualNodeFactory func(cfg *opnodecfg.Config, log gethlog.Logger, initOverrides *rollupNode.InitializationOverrides, appVersion string, superAuthority rollup.SuperAuthority) virtual_node.VirtualNode
@@ -585,6 +591,13 @@ func (c *simpleChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, 
 }
 
 // FetchReceipts fetches the receipts for a given block by hash.
+func (c *simpleChainContainer) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	if c.engine == nil {
+		return nil, engine_controller.ErrNoEngineClient
+	}
+	return c.engine.PayloadByHash(ctx, hash)
+}
+
 func (c *simpleChainContainer) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
 	if c.engine == nil {
 		return nil, nil, engine_controller.ErrNoEngineClient
@@ -623,6 +636,8 @@ func (c *simpleChainContainer) attachInProcRollupClient() error {
 func isCriticalRewindError(err error) bool {
 	return errors.Is(err, engine_controller.ErrNoEngineClient) ||
 		errors.Is(err, engine_controller.ErrNoRollupConfig) ||
+		errors.Is(err, engine_controller.ErrRewindNilTarget) ||
+		errors.Is(err, engine_controller.ErrRewindTargetMismatch) ||
 		errors.Is(err, engine_controller.ErrRewindComputeTargetsFailed) ||
 		errors.Is(err, engine_controller.ErrRewindTimestampToBlockConversion) ||
 		errors.Is(err, engine_controller.ErrRewindOverFinalizedHead)
@@ -630,7 +645,11 @@ func isCriticalRewindError(err error) bool {
 
 // RewindEngine is part of the InteropChain interface — callers must hold that
 // wider interface (only interop transition application does) to invoke it.
-func (c *simpleChainContainer) RewindEngine(ctx context.Context, timestamp uint64, invalidatedBlock eth.BlockRef) error {
+func (c *simpleChainContainer) RewindEngine(ctx context.Context, target *eth.ExecutionPayloadEnvelope, invalidatedBlock eth.BlockRef) error {
+	if target == nil || target.ExecutionPayload == nil {
+		return engine_controller.ErrRewindNilTarget
+	}
+	timestamp := uint64(target.ExecutionPayload.Timestamp)
 	if !c.resetting.CompareAndSwap(false, true) {
 		return fmt.Errorf("reset already in progress")
 	}
@@ -664,7 +683,7 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, timestamp uint6
 
 retryLoop:
 	for {
-		err = c.engine.RewindToTimestamp(ctx, timestamp)
+		err = c.engine.Rewind(ctx, target)
 		switch {
 		case errors.Is(err, context.DeadlineExceeded):
 			c.log.Error("chain_container/RewindEngine: timeout exceeded")

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -96,6 +96,9 @@ type ChainContainer interface {
 	// PayloadByHash returns the canonical execution payload envelope for the given block hash.
 	// Used by interop build paths to capture canonical payloads for WAL'd rewind operations.
 	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
+	// PayloadByNumber returns the canonical execution payload envelope for the given block number.
+	// Used by interop build paths when the rewind target is below the verified frontier.
+	PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error)
 	// SetResetCallback sets a callback that is invoked when the chain resets.
 	// The supernode uses this to notify activities about chain resets.
 	SetResetCallback(cb ResetCallback)
@@ -596,6 +599,13 @@ func (c *simpleChainContainer) PayloadByHash(ctx context.Context, hash common.Ha
 		return nil, engine_controller.ErrNoEngineClient
 	}
 	return c.engine.PayloadByHash(ctx, hash)
+}
+
+func (c *simpleChainContainer) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	if c.engine == nil {
+		return nil, engine_controller.ErrNoEngineClient
+	}
+	return c.engine.PayloadByNumber(ctx, number)
 }
 
 func (c *simpleChainContainer) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -157,12 +157,14 @@ func (m *mockVirtualNode) SyncStatus(ctx context.Context) (*eth.SyncStatus, erro
 
 // mockEngineController is a mock implementation of engine_controller.EngineController
 type mockEngineController struct {
-	rewindToTimestampCalled  int
-	rewindTimestamp          uint64
+	rewindCalls              int
+	rewindTarget             *eth.ExecutionPayloadEnvelope
 	rewindErr                error
-	rewindFunc               func(ctx context.Context, timestamp uint64) error // optional custom behavior
+	rewindFunc               func(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error // optional custom behavior
 	l2BlockRefByNumberResult eth.L2BlockRef
 	l2BlockRefByNumberErr    error
+	payloadByHashResult      *eth.ExecutionPayloadEnvelope
+	payloadByHashErr         error
 }
 
 func (m *mockEngineController) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
@@ -221,13 +223,17 @@ func newMockEngineController() *mockEngineController {
 func (m *mockEngineController) SafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
 	return eth.L2BlockRef{}, nil
 }
-func (m *mockEngineController) RewindToTimestamp(ctx context.Context, timestamp uint64) error {
-	m.rewindToTimestampCalled++
-	m.rewindTimestamp = timestamp
+func (m *mockEngineController) Rewind(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error {
+	m.rewindCalls++
+	m.rewindTarget = target
 	if m.rewindFunc != nil {
-		return m.rewindFunc(ctx, timestamp)
+		return m.rewindFunc(ctx, target)
 	}
 	return m.rewindErr
+}
+
+func (m *mockEngineController) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	return m.payloadByHashResult, m.payloadByHashErr
 }
 
 // Interface conformance assertion
@@ -628,15 +634,24 @@ func TestChainContainer_PauseResume(t *testing.T) {
 
 // TestChainContainer_RewindEngine tests the RewindEngine method
 func TestChainContainer_RewindEngine(t *testing.T) {
-	t.Run("calls RewindToTimestamp on engine controller and stops VN", func(t *testing.T) {
-		// Setup
+	makeTarget := func(timestamp uint64) *eth.ExecutionPayloadEnvelope {
+		return &eth.ExecutionPayloadEnvelope{
+			ExecutionPayload: &eth.ExecutionPayload{
+				BlockNumber: eth.Uint64Quantity(99),
+				Timestamp:   eth.Uint64Quantity(timestamp),
+				BlockHash:   common.Hash{0xaa},
+				ParentHash:  common.Hash{0xab},
+			},
+		}
+	}
+
+	t.Run("calls engine Rewind with the supplied target and stops VN", func(t *testing.T) {
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()
 
 		chainID := eth.ChainIDFromUInt64(420)
 		log := createTestLogger(t)
 
-		// Create container with mocks directly injected (no Start loop needed)
 		c := &simpleChainContainer{
 			chainID: chainID,
 			log:     log,
@@ -644,55 +659,59 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 			vn:      mockVN,
 		}
 
-		// Call RewindEngine
 		ctx := context.Background()
 		rewindTimestamp := uint64(1234567890)
+		target := makeTarget(rewindTimestamp)
 		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: rewindTimestamp + 2}
-		err := c.RewindEngine(ctx, rewindTimestamp, invalidatedBlock)
+		err := c.RewindEngine(ctx, target, invalidatedBlock)
 		require.NoError(t, err)
 
-		// Verify RewindToTimestamp was called with correct timestamp
-		require.Equal(t, 1, mockEngine.rewindToTimestampCalled, "RewindToTimestamp should be called once")
-		require.Equal(t, rewindTimestamp, mockEngine.rewindTimestamp, "RewindToTimestamp should be called with correct timestamp")
+		require.Equal(t, 1, mockEngine.rewindCalls, "engine.Rewind should be called once")
+		require.Same(t, target, mockEngine.rewindTarget, "engine.Rewind should receive the supplied target envelope")
 
-		// Verify the virtual node was stopped
 		mockVN.mu.Lock()
 		require.Equal(t, 1, mockVN.stopCalled, "Virtual node should be stopped once")
 		mockVN.mu.Unlock()
 
-		// Verify container state: paused should be false (resumed), allowing new VN to start
 		require.False(t, c.pause.Load(), "Container should be resumed after rewind")
 	})
 
-	t.Run("retries transient errors and eventually fails", func(t *testing.T) {
-		// Setup - transient error should be retried
+	t.Run("rejects nil target without touching the engine", func(t *testing.T) {
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()
-		mockEngine.rewindErr = engine_controller.ErrRewindFCUSyntheticFailed
-
-		chainID := eth.ChainIDFromUInt64(420)
-		log := createTestLogger(t)
 
 		c := &simpleChainContainer{
-			chainID: chainID,
-			log:     log,
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
 			engine:  mockEngine,
 			vn:      mockVN,
 		}
 
-		// Call RewindEngine - should retry and eventually fail
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second) // this will prevent infinite retries
+		err := c.RewindEngine(context.Background(), nil, eth.BlockRef{})
+		require.ErrorIs(t, err, engine_controller.ErrRewindNilTarget)
+		require.Equal(t, 0, mockEngine.rewindCalls)
+	})
+
+	t.Run("retries transient errors and eventually fails", func(t *testing.T) {
+		mockVN := newMockVirtualNode()
+		mockEngine := newMockEngineController()
+		mockEngine.rewindErr = engine_controller.ErrRewindFCUSyntheticFailed
+
+		c := &simpleChainContainer{
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
+			engine:  mockEngine,
+			vn:      mockVN,
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
-		err := c.RewindEngine(ctx, 12345, invalidatedBlock)
+		err := c.RewindEngine(ctx, makeTarget(12345), invalidatedBlock)
 		require.Error(t, err)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 
-		// Verify RewindToTimestamp was called multiple times (retry attempts)
-		require.Greater(t, mockEngine.rewindToTimestampCalled, 1, "RewindToTimestamp should be retried at least once")
-
-		// Container should be resumed even after a failed rewind, so the Start() loop
-		// can detect the stop flag and exit cleanly instead of spinning forever.
+		require.Greater(t, mockEngine.rewindCalls, 1, "engine.Rewind should be retried at least once")
 		require.False(t, c.pause.Load(), "Container should be resumed (not stuck paused) after failed rewind")
 	})
 
@@ -705,71 +724,56 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 			{"ErrNoRollupConfig", engine_controller.ErrNoRollupConfig},
 			{"ErrRewindComputeTargetsFailed", engine_controller.ErrRewindComputeTargetsFailed},
 			{"ErrRewindTimestampToBlockConversion", engine_controller.ErrRewindTimestampToBlockConversion},
+			{"ErrRewindNilTarget", engine_controller.ErrRewindNilTarget},
+			{"ErrRewindTargetMismatch", engine_controller.ErrRewindTargetMismatch},
 		}
 
 		for _, tc := range criticalErrors {
 			t.Run(tc.name, func(t *testing.T) {
-				// Setup - critical error should not be retried
 				mockVN := newMockVirtualNode()
 				mockEngine := newMockEngineController()
 				mockEngine.rewindErr = tc.err
 
-				chainID := eth.ChainIDFromUInt64(420)
-				log := createTestLogger(t)
-
 				c := &simpleChainContainer{
-					chainID: chainID,
-					log:     log,
+					chainID: eth.ChainIDFromUInt64(420),
+					log:     createTestLogger(t),
 					engine:  mockEngine,
 					vn:      mockVN,
 				}
 
-				// Call RewindEngine - should fail immediately without retry
-				ctx := context.Background()
 				invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
-				err := c.RewindEngine(ctx, 12345, invalidatedBlock)
+				err := c.RewindEngine(context.Background(), makeTarget(12345), invalidatedBlock)
 				require.Error(t, err)
 				require.ErrorIs(t, err, tc.err)
-
-				// Verify RewindToTimestamp was called only once (no retry for critical errors)
-				require.Equal(t, 1, mockEngine.rewindToTimestampCalled, "RewindToTimestamp should not be retried for critical errors")
+				require.Equal(t, 1, mockEngine.rewindCalls, "engine.Rewind should not be retried for critical errors")
 			})
 		}
 	})
 
 	t.Run("returns error when VN stop fails", func(t *testing.T) {
-		// Setup
 		mockVN := newMockVirtualNode()
 		mockVN.stopErr = context.DeadlineExceeded
 		mockEngine := newMockEngineController()
 
-		chainID := eth.ChainIDFromUInt64(420)
-		log := createTestLogger(t)
-
 		c := &simpleChainContainer{
-			chainID: chainID,
-			log:     log,
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
 			engine:  mockEngine,
 			vn:      mockVN,
 		}
 
-		// Call RewindEngine - should fail on VN stop
-		ctx := context.Background()
 		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
-		err := c.RewindEngine(ctx, 12345, invalidatedBlock)
+		err := c.RewindEngine(context.Background(), makeTarget(12345), invalidatedBlock)
 		require.Error(t, err)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
-
-		// Verify RewindToTimestamp was NOT called since VN stop failed
-		require.Equal(t, 0, mockEngine.rewindToTimestampCalled, "RewindToTimestamp should not be called when VN stop fails")
+		require.Equal(t, 0, mockEngine.rewindCalls, "engine.Rewind should not be called when VN stop fails")
 	})
 
 	t.Run("succeeds after transient error on retry", func(t *testing.T) {
-		// Setup - fail first 2 attempts, succeed on 3rd
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()
 		failCount := 0
-		mockEngine.rewindFunc = func(ctx context.Context, timestamp uint64) error {
+		mockEngine.rewindFunc = func(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error {
 			failCount++
 			if failCount < 3 {
 				return engine_controller.ErrRewindFCUTargetFailed
@@ -777,26 +781,17 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 			return nil
 		}
 
-		chainID := eth.ChainIDFromUInt64(420)
-		log := createTestLogger(t)
-
 		c := &simpleChainContainer{
-			chainID: chainID,
-			log:     log,
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
 			engine:  mockEngine,
 			vn:      mockVN,
 		}
 
-		// Call RewindEngine - should succeed after retries
-		ctx := context.Background()
 		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
-		err := c.RewindEngine(ctx, 12345, invalidatedBlock)
+		err := c.RewindEngine(context.Background(), makeTarget(12345), invalidatedBlock)
 		require.NoError(t, err)
-
-		// Verify RewindToTimestamp was called 3 times (2 failures + 1 success)
-		require.Equal(t, 3, mockEngine.rewindToTimestampCalled, "RewindToTimestamp should be called 3 times")
-
-		// Container should be resumed after successful rewind
+		require.Equal(t, 3, mockEngine.rewindCalls, "engine.Rewind should be called 3 times (2 failures + 1 success)")
 		require.False(t, c.pause.Load(), "Container should be resumed after successful rewind")
 	})
 }

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -165,6 +165,8 @@ type mockEngineController struct {
 	l2BlockRefByNumberErr    error
 	payloadByHashResult      *eth.ExecutionPayloadEnvelope
 	payloadByHashErr         error
+	payloadByNumberResult    *eth.ExecutionPayloadEnvelope
+	payloadByNumberErr       error
 }
 
 func (m *mockEngineController) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
@@ -234,6 +236,10 @@ func (m *mockEngineController) Rewind(ctx context.Context, target *eth.Execution
 
 func (m *mockEngineController) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
 	return m.payloadByHashResult, m.payloadByHashErr
+}
+
+func (m *mockEngineController) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	return m.payloadByNumberResult, m.payloadByNumberErr
 }
 
 // Interface conformance assertion

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -3,7 +3,6 @@ package engine_controller
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -28,8 +27,14 @@ type EngineController interface {
 	// hash. Returns ethereum.NotFound if the EL no longer has the block at
 	// that hash on its canonical chain.
 	OutputV0ByBlockHash(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error)
-	// RewindToTimestamp rewinds the L2 execution layer to block at or before the given timestamp.
-	RewindToTimestamp(ctx context.Context, timestamp uint64) error
+	// PayloadByHash returns the execution payload envelope for the given block hash. Used by
+	// build paths to capture the canonical target payload before recording a rewind operation
+	// in the WAL.
+	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
+	// Rewind rewinds the L2 execution layer to the supplied target block. The target payload
+	// must come from durable storage (the supernode WAL) — the engine controller does not
+	// consult the live EL to discover the target.
+	Rewind(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error
 	// FetchReceipts fetches the receipts for a given block by hash.
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
 	// Close releases any underlying RPC resources.
@@ -83,22 +88,6 @@ var (
 	ErrNoEngineClient = errors.New("engine client not initialized")
 	ErrNoRollupConfig = errors.New("rollup config not available")
 )
-
-func (e *simpleEngineController) blockNumberAtTimestamp(ts uint64) (uint64, error) {
-	if e.rollup == nil {
-		return 0, ErrNoRollupConfig
-	}
-	// Compute the target block directly from rollup config
-	return e.rollup.TargetBlockNumber(ts)
-}
-
-func (e *simpleEngineController) blockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
-	num, err := e.blockNumberAtTimestamp(ts)
-	if err != nil {
-		return eth.L2BlockRef{}, fmt.Errorf("failed to convert timestamp to block number: %w :%w ", err, ErrRewindTimestampToBlockConversion)
-	}
-	return e.l2.L2BlockRefByNumber(ctx, num)
-}
 
 // BlockAtTimestamp returns the L2 block ref for the block at or before the given timestamp,
 // clamped to the head of the specified label. Must return ethereum.NotFound if no block is available at the timestamp.
@@ -183,6 +172,13 @@ func (e *simpleEngineController) OutputV0ByBlockHash(ctx context.Context, blockH
 		}, nil
 	}
 	return e.l2.OutputV0AtBlock(ctx, blockHash)
+}
+
+func (e *simpleEngineController) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	if e.l2 == nil {
+		return nil, ErrNoEngineClient
+	}
+	return e.l2.PayloadByHash(ctx, hash)
 }
 
 func (e *simpleEngineController) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -31,6 +31,8 @@ type EngineController interface {
 	// build paths to capture the canonical target payload before recording a rewind operation
 	// in the WAL.
 	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
+	// PayloadByNumber returns the canonical execution payload envelope for the given block number.
+	PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error)
 	// Rewind rewinds the L2 execution layer to the supplied target block. The target payload
 	// must come from durable storage (the supernode WAL) — the engine controller does not
 	// consult the live EL to discover the target.
@@ -179,6 +181,13 @@ func (e *simpleEngineController) PayloadByHash(ctx context.Context, hash common.
 		return nil, ErrNoEngineClient
 	}
 	return e.l2.PayloadByHash(ctx, hash)
+}
+
+func (e *simpleEngineController) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	if e.l2 == nil {
+		return nil, ErrNoEngineClient
+	}
+	return e.l2.PayloadByNumber(ctx, number)
 }
 
 func (e *simpleEngineController) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
@@ -159,10 +159,11 @@ type mockL2 struct {
 	payloadsByNumber map[uint64]*eth.ExecutionPayloadEnvelope
 
 	// NewPayload tracking
-	newPayloadCalls  int
-	newPayloadStatus *eth.PayloadStatusV1
-	newPayloadErr    error
-	lastNewPayload   *eth.ExecutionPayload
+	newPayloadCalls    int
+	newPayloadStatus   *eth.PayloadStatusV1
+	newPayloadStatuses []*eth.PayloadStatusV1 // per-call status overrides; entry i is used for the i-th call (1-indexed) when present and non-nil
+	newPayloadErr      error
+	lastNewPayload     *eth.ExecutionPayload
 
 	// ForkchoiceUpdate tracking
 	fcuCalls     int
@@ -257,6 +258,9 @@ func (m *mockL2) NewPayload(ctx context.Context, payload *eth.ExecutionPayload, 
 	m.lastNewPayload = payload
 	if m.newPayloadErr != nil {
 		return nil, m.newPayloadErr
+	}
+	if idx := m.newPayloadCalls - 1; idx < len(m.newPayloadStatuses) && m.newPayloadStatuses[idx] != nil {
+		return m.newPayloadStatuses[idx], nil
 	}
 	if m.newPayloadStatus != nil {
 		return m.newPayloadStatus, nil

--- a/op-supernode/supernode/chain_container/engine_controller/rewind.go
+++ b/op-supernode/supernode/chain_container/engine_controller/rewind.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -60,21 +61,25 @@ func (e *simpleEngineController) RewindToTimestamp(ctx context.Context, timestam
 	// [n-1,parent] <-- [n,target] <-- [m>n,unsafe]
 	targetBlock, err := e.blockAtTimestamp(ctx, timestamp)
 	if err != nil {
+		// If the EL does not have a block at the target height, the chain is strictly
+		// shorter than the requested rewind target — there is nothing to rewind.
+		if errors.Is(err, ethereum.NotFound) {
+			e.log.Info("rewind skipped: chain shorter than rewind target",
+				"timestamp", timestamp)
+			return nil
+		}
 		return fmt.Errorf("%w %d: %w", ErrRewindTargetBlockNotFound, timestamp, err)
 	}
 
-	// Step 0a: skip the rewind entirely if the chain is not ahead of the target. This allows
-	// callers to invoke RewindToTimestamp idempotently and avoids unnecessary payload churn
-	// when the EL is already at or before the requested height.
+	// Step 0a: skip the rewind entirely if the unsafe head already matches the target.
+	// (We cannot be strictly behind the target here — step 0 would have returned NotFound.)
 	unsafe, err := e.l2.L2BlockRefByLabel(ctx, eth.Unsafe)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrRewindCurrentUnsafeFailed, err)
 	}
-	if unsafe.Number < targetBlock.Number || unsafe.Hash == targetBlock.Hash {
-		e.log.Info("rewind skipped: chain already at or before target",
-			"unsafeHead", unsafe.Number, "unsafeHash", unsafe.Hash,
-			"target", targetBlock.Number, "targetHash", targetBlock.Hash,
-			"timestamp", timestamp)
+	if unsafe.Hash == targetBlock.Hash {
+		e.log.Info("rewind skipped: unsafe head already at target",
+			"unsafeHash", unsafe.Hash, "targetHash", targetBlock.Hash, "timestamp", timestamp)
 		return nil
 	}
 

--- a/op-supernode/supernode/chain_container/engine_controller/rewind.go
+++ b/op-supernode/supernode/chain_container/engine_controller/rewind.go
@@ -65,18 +65,16 @@ func (e *simpleEngineController) Rewind(ctx context.Context, target *eth.Executi
 
 	payload := target.ExecutionPayload
 	targetNumber := uint64(payload.BlockNumber)
-	targetTime := uint64(payload.Timestamp)
 	targetHash := payload.BlockHash
 
-	// Sanity-check the WAL'd payload against the rollup config: number and timestamp must agree.
 	if e.rollup != nil {
-		expectedNumber, err := e.rollup.TargetBlockNumber(targetTime)
+		expectedNumber, err := e.rollup.TargetBlockNumber(uint64(payload.Timestamp))
 		if err != nil {
 			return fmt.Errorf("%w: %w", ErrRewindTimestampToBlockConversion, err)
 		}
 		if expectedNumber != targetNumber {
-			return fmt.Errorf("%w: payload number=%d timestamp=%d (rollup expects %d at that timestamp)",
-				ErrRewindTargetMismatch, targetNumber, targetTime, expectedNumber)
+			return fmt.Errorf("%w: payload number=%d timestamp=%d (rollup expects %d)",
+				ErrRewindTargetMismatch, targetNumber, uint64(payload.Timestamp), expectedNumber)
 		}
 	}
 
@@ -84,20 +82,20 @@ func (e *simpleEngineController) Rewind(ctx context.Context, target *eth.Executi
 		Hash:       targetHash,
 		Number:     targetNumber,
 		ParentHash: payload.ParentHash,
-		Time:       targetTime,
+		Time:       uint64(payload.Timestamp),
 	}
 
-	// No-op if the unsafe head already matches the target hash. After step 0 we cannot be
-	// strictly *behind* the target in a well-formed run (the WAL only records targets that
-	// were canonical when the plan was built); if we are, the safe/finalized clamp below
-	// would be wrong, so we don't allow it.
 	unsafe, err := e.l2.L2BlockRefByLabel(ctx, eth.Unsafe)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrRewindCurrentUnsafeFailed, err)
 	}
-	if unsafe.Hash == targetHash {
-		e.log.Info("rewind skipped: unsafe head already at target",
-			"unsafeHash", unsafe.Hash, "targetHash", targetHash, "targetNumber", targetNumber)
+	// No-op if the chain is already at or behind the target. The chain state may have moved
+	// between when the WAL'd target was captured and now, so the unsafe head may legitimately
+	// be below the recorded target.
+	if unsafe.Hash == targetHash || unsafe.Number < targetNumber {
+		e.log.Info("rewind skipped: chain already at or behind target",
+			"unsafeHash", unsafe.Hash, "unsafeNumber", unsafe.Number,
+			"targetHash", targetHash, "targetNumber", targetNumber)
 		return nil
 	}
 

--- a/op-supernode/supernode/chain_container/engine_controller/rewind.go
+++ b/op-supernode/supernode/chain_container/engine_controller/rewind.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -21,7 +20,8 @@ const (
 )
 
 var (
-	ErrRewindTargetBlockNotFound        = errors.New("failed to get target block at timestamp")
+	ErrRewindNilTarget                  = errors.New("rewind requires a non-nil target payload")
+	ErrRewindTargetMismatch             = errors.New("rewind target payload inconsistent with rollup config")
 	ErrRewindComputeTargetsFailed       = errors.New("failed to compute rewind targets")
 	ErrRewindInsertSyntheticFailed      = errors.New("failed to insert synthetic payload")
 	ErrRewindSyntheticPayloadRejected   = errors.New("synthetic payload rejected by engine")
@@ -29,91 +29,102 @@ var (
 	ErrRewindCanonicalPayloadRejected   = errors.New("canonical payload rejected by engine on re-insert")
 	ErrRewindFCUSyntheticFailed         = errors.New("failed to FCU to synthetic block")
 	ErrRewindFCUTargetFailed            = errors.New("failed to FCU to target block")
-	ErrRewindVerificationFailed         = errors.New("rewind state verification failed")
 	ErrRewindFCURejected                = errors.New("forkchoice update rejected by engine")
 	ErrRewindTimestampToBlockConversion = errors.New("failed to convert timestamp to block number")
-	ErrRewindPayloadNotFound            = errors.New("failed to get payload for block")
 	ErrRewindOverFinalizedHead          = errors.New("cannot rewind over finalized head")
 	ErrRewindFCUHeadMismatch            = errors.New("FCU head did not converge to expected value")
 	ErrRewindCurrentUnsafeFailed        = errors.New("failed to get current unsafe block")
 )
 
-// RewindToTimestamp rewinds the L2 execution layer to the block at or before the given timestamp.
+// Rewind rewinds the L2 execution layer to the supplied target block.
+//
+// The target payload is authoritative — it must be loaded from durable storage (the supernode
+// WAL operation record) by the caller. The engine controller does not consult the live EL to
+// discover the target, because after a crash mid-rewind the EL's canonical chain at the target
+// height may be a synthetic block from the previous attempt rather than the original.
 //
 // The rewind is performed by:
 //  1. Inserting a synthetic block (modified extra data) sharing the target's parent and FCU-ing
-//     to it. This makes the original target block non-canonical.
-//  2. Re-inserting the original target payload via engine_newPayload. This guarantees the EL
-//     still has the block available even if its pruner has discarded the non-canonical block
-//     since step 1 (op-reth, for example, will prune blocks dropped from the canonical chain).
-//  3. FCU-ing back to the target block, which restores it as the canonical head.
+//     to it. This makes the original target block non-canonical in the EL's view.
+//  2. Re-inserting the supplied target payload via engine_newPayload. This guarantees the EL
+//     has the block durably stored before we ask it to become the head — pruners (op-reth in
+//     particular) may have removed the block while it sat non-canonical after step 1.
+//  3. FCU-ing to the target block, which restores it as the canonical head.
 //
-// If the chain is not actually ahead of the target block, the call is a no-op.
+// If the unsafe head already matches the target hash the call is a no-op.
 //
-// TODO: in future, we could push the implementation into the engine itself which would reduce the
-// number of RPC calls required and remove the need for the synthetic block to be inserted.
-func (e *simpleEngineController) RewindToTimestamp(ctx context.Context, timestamp uint64) error {
+// TODO: in future, we could push the implementation into the engine itself which would reduce
+// the number of RPC calls required and remove the need for the synthetic block to be inserted.
+func (e *simpleEngineController) Rewind(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error {
 	if e.l2 == nil {
 		return ErrNoEngineClient
 	}
-
-	// Step 0: infer the target block:
-	// [n-1,parent] <-- [n,target] <-- [m>n,unsafe]
-	targetBlock, err := e.blockAtTimestamp(ctx, timestamp)
-	if err != nil {
-		// If the EL does not have a block at the target height, the chain is strictly
-		// shorter than the requested rewind target — there is nothing to rewind.
-		if errors.Is(err, ethereum.NotFound) {
-			e.log.Info("rewind skipped: chain shorter than rewind target",
-				"timestamp", timestamp)
-			return nil
-		}
-		return fmt.Errorf("%w %d: %w", ErrRewindTargetBlockNotFound, timestamp, err)
+	if target == nil || target.ExecutionPayload == nil {
+		return ErrRewindNilTarget
 	}
 
-	// Step 0a: skip the rewind entirely if the unsafe head already matches the target.
-	// (We cannot be strictly behind the target here — step 0 would have returned NotFound.)
+	payload := target.ExecutionPayload
+	targetNumber := uint64(payload.BlockNumber)
+	targetTime := uint64(payload.Timestamp)
+	targetHash := payload.BlockHash
+
+	// Sanity-check the WAL'd payload against the rollup config: number and timestamp must agree.
+	if e.rollup != nil {
+		expectedNumber, err := e.rollup.TargetBlockNumber(targetTime)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrRewindTimestampToBlockConversion, err)
+		}
+		if expectedNumber != targetNumber {
+			return fmt.Errorf("%w: payload number=%d timestamp=%d (rollup expects %d at that timestamp)",
+				ErrRewindTargetMismatch, targetNumber, targetTime, expectedNumber)
+		}
+	}
+
+	targetRef := eth.L2BlockRef{
+		Hash:       targetHash,
+		Number:     targetNumber,
+		ParentHash: payload.ParentHash,
+		Time:       targetTime,
+	}
+
+	// No-op if the unsafe head already matches the target hash. After step 0 we cannot be
+	// strictly *behind* the target in a well-formed run (the WAL only records targets that
+	// were canonical when the plan was built); if we are, the safe/finalized clamp below
+	// would be wrong, so we don't allow it.
 	unsafe, err := e.l2.L2BlockRefByLabel(ctx, eth.Unsafe)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrRewindCurrentUnsafeFailed, err)
 	}
-	if unsafe.Hash == targetBlock.Hash {
+	if unsafe.Hash == targetHash {
 		e.log.Info("rewind skipped: unsafe head already at target",
-			"unsafeHash", unsafe.Hash, "targetHash", targetBlock.Hash, "timestamp", timestamp)
+			"unsafeHash", unsafe.Hash, "targetHash", targetHash, "targetNumber", targetNumber)
 		return nil
 	}
 
-	// Step 0b: fetch the canonical payload at the target height once. We use it both
-	// to derive the synthetic block and to re-insert the canonical block after the reorg.
-	targetEnvelope, err := e.l2.PayloadByNumber(ctx, targetBlock.Number)
-	if err != nil || targetEnvelope == nil || targetEnvelope.ExecutionPayload == nil {
-		return fmt.Errorf("%w for block %d: %w", ErrRewindPayloadNotFound, targetBlock.Number, err)
-	}
-
-	// Step 1: Insert a synthetic block (modified extra data) which
-	// is built on the parent of the target block:
+	// Step 1: Insert a synthetic block (modified extra data) which is built on the parent of
+	// the target block:
 	// [n-1,parent] <-- [n,target] <--...<-- [m>n,unsafe]
 	//
 	//                 [n,synthetic]
-	syntheticBlockHash, err := e.insertSyntheticPayload(ctx, targetEnvelope)
+	syntheticBlockHash, err := e.insertSyntheticPayload(ctx, target)
 	if err != nil {
 		return err
 	}
 
-	// Step 2: compute rewind targets for safe and finalized heads, ensuring they do not go forwards:
-	targetSafeBlock, targetFinalizedBlock, err := e.computeRewindTargets(ctx, targetBlock)
+	// Step 2: compute rewind targets for safe and finalized heads, ensuring they do not move
+	// forward.
+	targetSafeBlock, targetFinalizedBlock, err := e.computeRewindTargets(ctx, targetRef)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrRewindComputeTargetsFailed, err)
 	}
 
-	// Step 3: FCU to the synthetic block to trigger a reorg, removing the target block
-	// from the canonical chain.
-	// We use the parent hash of the target block as the safe and finalized block
-	// in the FCU since these are guaranteed to be in the canonical chain of the synthetic block.
+	// Step 3: FCU to the synthetic block to trigger a reorg, removing the target block from
+	// the canonical chain. The parent of the target block is used as safe and finalized in
+	// the FCU since it is guaranteed to be in the canonical chain of the synthetic block.
 	// [n-1,parent]   [n,target]
 	//      |\
 	//       \_______ [n,synthetic,unsafe]
-	parentHash := targetBlock.ParentHash
+	parentHash := targetRef.ParentHash
 	if err := e.forkchoiceUpdateWithRetry(ctx, syntheticBlockHash, parentHash, parentHash); err != nil {
 		return fmt.Errorf("%w: %w", ErrRewindFCUSyntheticFailed, err)
 	}
@@ -122,23 +133,19 @@ func (e *simpleEngineController) RewindToTimestamp(ctx context.Context, timestam
 	// Step 4: re-insert the canonical target payload via engine_newPayload. The previous FCU
 	// to the synthetic block made the target block non-canonical, which means the EL is free
 	// to prune it (op-reth's pruner does so eagerly). Calling NewPayload again forces the EL
-	// to re-import the block and persist it before we ask it to become the head in step 5.
-	if err := e.reinsertCanonicalPayload(ctx, targetEnvelope); err != nil {
+	// to re-import the block before we ask it to become the head in step 5.
+	if err := e.reinsertCanonicalPayload(ctx, target); err != nil {
 		return err
 	}
 
-	// Step 5: FCU to the actual target block
+	// Step 5: FCU to the actual target block.
 	// [n-1,parent] <-- [n,target, unsafe]
 	//
 	//                  [n,synthetic]
-	if err := e.forkchoiceUpdateWithRetry(ctx, targetBlock.Hash, targetSafeBlock.Hash, targetFinalizedBlock.Hash); err != nil {
+	if err := e.forkchoiceUpdateWithRetry(ctx, targetHash, targetSafeBlock.Hash, targetFinalizedBlock.Hash); err != nil {
 		return fmt.Errorf("%w: %w", ErrRewindFCUTargetFailed, err)
 	}
-	e.log.Info("executed FCU to target block", "head", targetBlock.Hash, "safe", targetSafeBlock.Hash, "finalized", targetFinalizedBlock.Hash)
-
-	// Note: forkchoiceUpdateWithRetry calls verifyRewindState with the expected
-	// arguments, so if execution reaches here, we're done and there's no error
-	// to report
+	e.log.Info("executed FCU to target block", "head", targetHash, "safe", targetSafeBlock.Hash, "finalized", targetFinalizedBlock.Hash)
 
 	return nil
 }

--- a/op-supernode/supernode/chain_container/engine_controller/rewind.go
+++ b/op-supernode/supernode/chain_container/engine_controller/rewind.go
@@ -24,6 +24,8 @@ var (
 	ErrRewindComputeTargetsFailed       = errors.New("failed to compute rewind targets")
 	ErrRewindInsertSyntheticFailed      = errors.New("failed to insert synthetic payload")
 	ErrRewindSyntheticPayloadRejected   = errors.New("synthetic payload rejected by engine")
+	ErrRewindReinsertCanonicalFailed    = errors.New("failed to re-insert canonical payload")
+	ErrRewindCanonicalPayloadRejected   = errors.New("canonical payload rejected by engine on re-insert")
 	ErrRewindFCUSyntheticFailed         = errors.New("failed to FCU to synthetic block")
 	ErrRewindFCUTargetFailed            = errors.New("failed to FCU to target block")
 	ErrRewindVerificationFailed         = errors.New("rewind state verification failed")
@@ -32,14 +34,20 @@ var (
 	ErrRewindPayloadNotFound            = errors.New("failed to get payload for block")
 	ErrRewindOverFinalizedHead          = errors.New("cannot rewind over finalized head")
 	ErrRewindFCUHeadMismatch            = errors.New("FCU head did not converge to expected value")
+	ErrRewindCurrentUnsafeFailed        = errors.New("failed to get current unsafe block")
 )
 
 // RewindToTimestamp rewinds the L2 execution layer to the block at or before the given timestamp.
 //
-// The rewind is performed in two steps:
-//  1. Insert a synthetic block (modified fee recipient) and FCU to it, which triggers a reorg
-//     that orphans all blocks after the target.
-//  2. FCU back to the original target block, completing the rewind.
+// The rewind is performed by:
+//  1. Inserting a synthetic block (modified extra data) sharing the target's parent and FCU-ing
+//     to it. This makes the original target block non-canonical.
+//  2. Re-inserting the original target payload via engine_newPayload. This guarantees the EL
+//     still has the block available even if its pruner has discarded the non-canonical block
+//     since step 1 (op-reth, for example, will prune blocks dropped from the canonical chain).
+//  3. FCU-ing back to the target block, which restores it as the canonical head.
+//
+// If the chain is not actually ahead of the target block, the call is a no-op.
 //
 // TODO: in future, we could push the implementation into the engine itself which would reduce the
 // number of RPC calls required and remove the need for the synthetic block to be inserted.
@@ -55,12 +63,34 @@ func (e *simpleEngineController) RewindToTimestamp(ctx context.Context, timestam
 		return fmt.Errorf("%w %d: %w", ErrRewindTargetBlockNotFound, timestamp, err)
 	}
 
-	// Step 1: Insert a synthetic block (modified fee recipient) which
+	// Step 0a: skip the rewind entirely if the chain is not ahead of the target. This allows
+	// callers to invoke RewindToTimestamp idempotently and avoids unnecessary payload churn
+	// when the EL is already at or before the requested height.
+	unsafe, err := e.l2.L2BlockRefByLabel(ctx, eth.Unsafe)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrRewindCurrentUnsafeFailed, err)
+	}
+	if unsafe.Number < targetBlock.Number || unsafe.Hash == targetBlock.Hash {
+		e.log.Info("rewind skipped: chain already at or before target",
+			"unsafeHead", unsafe.Number, "unsafeHash", unsafe.Hash,
+			"target", targetBlock.Number, "targetHash", targetBlock.Hash,
+			"timestamp", timestamp)
+		return nil
+	}
+
+	// Step 0b: fetch the canonical payload at the target height once. We use it both
+	// to derive the synthetic block and to re-insert the canonical block after the reorg.
+	targetEnvelope, err := e.l2.PayloadByNumber(ctx, targetBlock.Number)
+	if err != nil || targetEnvelope == nil || targetEnvelope.ExecutionPayload == nil {
+		return fmt.Errorf("%w for block %d: %w", ErrRewindPayloadNotFound, targetBlock.Number, err)
+	}
+
+	// Step 1: Insert a synthetic block (modified extra data) which
 	// is built on the parent of the target block:
 	// [n-1,parent] <-- [n,target] <--...<-- [m>n,unsafe]
 	//
 	//                 [n,synthetic]
-	syntheticBlockHash, err := e.insertSyntheticPayload(ctx, targetBlock.Number)
+	syntheticBlockHash, err := e.insertSyntheticPayload(ctx, targetEnvelope)
 	if err != nil {
 		return err
 	}
@@ -84,7 +114,15 @@ func (e *simpleEngineController) RewindToTimestamp(ctx context.Context, timestam
 	}
 	e.log.Info("executed FCU to synthetic block", "syntheticHead", syntheticBlockHash, "safe", parentHash, "finalized", parentHash)
 
-	// Step 4: FCU to the actual target block
+	// Step 4: re-insert the canonical target payload via engine_newPayload. The previous FCU
+	// to the synthetic block made the target block non-canonical, which means the EL is free
+	// to prune it (op-reth's pruner does so eagerly). Calling NewPayload again forces the EL
+	// to re-import the block and persist it before we ask it to become the head in step 5.
+	if err := e.reinsertCanonicalPayload(ctx, targetEnvelope); err != nil {
+		return err
+	}
+
+	// Step 5: FCU to the actual target block
 	// [n-1,parent] <-- [n,target, unsafe]
 	//
 	//                  [n,synthetic]
@@ -120,16 +158,13 @@ func (e *simpleEngineController) computeRewindTargets(ctx context.Context, targe
 	return earliest(currentSafe, targetBlock), earliest(currentFinalized, targetBlock), nil
 }
 
-// insertSyntheticPayload creates and inserts a synthetic block derived from the block at the given number.
-// The synthetic block has a modified fee recipient to produce a different block hash.
+// insertSyntheticPayload derives a synthetic block from the supplied canonical envelope and
+// submits it via engine_newPayload. The synthetic block shares the canonical block's parent
+// but has modified ExtraData to produce a different block hash.
 // Returns the hash of the synthetic block.
-func (e *simpleEngineController) insertSyntheticPayload(ctx context.Context, blockNumber uint64) (common.Hash, error) {
-	envelope, err := e.l2.PayloadByNumber(ctx, blockNumber)
-	if err != nil || envelope == nil || envelope.ExecutionPayload == nil {
-		return common.Hash{}, fmt.Errorf("failed to get payload for block %d: %w, err: %w", blockNumber, ErrRewindPayloadNotFound, err)
-	}
-
-	// Deep clone the envelope and payload
+func (e *simpleEngineController) insertSyntheticPayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) (common.Hash, error) {
+	// Deep clone the envelope and payload so we can mutate fields without affecting the
+	// canonical envelope, which is reused by reinsertCanonicalPayload later in the rewind.
 	newEnvelope := *envelope
 	newPayload := *(envelope.ExecutionPayload)
 	newEnvelope.ExecutionPayload = &newPayload
@@ -150,7 +185,8 @@ func (e *simpleEngineController) insertSyntheticPayload(ctx context.Context, blo
 	syntheticHash, _ := newEnvelope.CheckBlockHash() // ignore "ok" since we know it won't match
 	newPayload.BlockHash = syntheticHash
 
-	e.log.Info("inserting synthetic payload", "blockNumber", blockNumber, "parentHash", newPayload.ParentHash, "syntheticHash", syntheticHash)
+	e.log.Info("inserting synthetic payload",
+		"blockNumber", uint64(newPayload.BlockNumber), "parentHash", newPayload.ParentHash, "syntheticHash", syntheticHash)
 	status, err := e.l2.NewPayload(ctx, &newPayload, envelope.ParentBeaconBlockRoot)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("%w: %w", ErrRewindInsertSyntheticFailed, err)
@@ -161,10 +197,33 @@ func (e *simpleEngineController) insertSyntheticPayload(ctx context.Context, blo
 			validationErr = *status.ValidationError
 		}
 		return common.Hash{}, fmt.Errorf("%w: status=%s validationError=%q blockNumber=%d parentHash=%s syntheticHash=%s",
-			ErrRewindSyntheticPayloadRejected, status.Status, validationErr, blockNumber, newPayload.ParentHash, syntheticHash)
+			ErrRewindSyntheticPayloadRejected, status.Status, validationErr, uint64(newPayload.BlockNumber), newPayload.ParentHash, syntheticHash)
 	}
 
 	return syntheticHash, nil
+}
+
+// reinsertCanonicalPayload re-submits the canonical target envelope via engine_newPayload.
+// It exists to guarantee the EL has the canonical block durably stored after the synthetic
+// FCU has made it non-canonical (and therefore potentially prune-eligible) but before we
+// FCU back to it.
+func (e *simpleEngineController) reinsertCanonicalPayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error {
+	payload := envelope.ExecutionPayload
+	e.log.Info("re-inserting canonical payload",
+		"blockNumber", uint64(payload.BlockNumber), "hash", payload.BlockHash, "parentHash", payload.ParentHash)
+	status, err := e.l2.NewPayload(ctx, payload, envelope.ParentBeaconBlockRoot)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrRewindReinsertCanonicalFailed, err)
+	}
+	if status.Status != eth.ExecutionValid {
+		validationErr := ""
+		if status.ValidationError != nil {
+			validationErr = *status.ValidationError
+		}
+		return fmt.Errorf("%w: status=%s validationError=%q blockNumber=%d hash=%s",
+			ErrRewindCanonicalPayloadRejected, status.Status, validationErr, uint64(payload.BlockNumber), payload.BlockHash)
+	}
+	return nil
 }
 
 // verifyRewindState checks that the engine's unsafe, safe, and finalized heads match the

--- a/op-supernode/supernode/chain_container/engine_controller/rewind_test.go
+++ b/op-supernode/supernode/chain_container/engine_controller/rewind_test.go
@@ -9,45 +9,48 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
-// TestEngineController_RewindToTimestamp tests the rewind functionality of the engine controller
-// under various error conditions simulated by embedding a mock L2 which can misbehave in multiple ways.
-// The test ensures the method translates thos errors,
-// sometimes originating on the other side of an RPC connection
-// into the correct sentinel errors to enable handling by the caller of the method.
-func TestEngineController_RewindToTimestamp(t *testing.T) {
-
+// TestEngineController_Rewind tests the rewind functionality of the engine controller
+// under various error conditions simulated by embedding a mock L2 which can misbehave in
+// multiple ways. The test ensures the method translates those errors — sometimes originating
+// on the other side of an RPC connection — into the correct sentinel errors to enable handling
+// by the caller of the method.
+func TestEngineController_Rewind(t *testing.T) {
 	type testCase struct {
 		name          string
 		expectedError error
 
 		// Below are various ways an error condition can be declared.
-		// The test strategy is to first construct a mock would
-		// pass the test (no error), and then install up to one error
-		// condition in the mock L2, When an error condition is installed
+		// The test strategy is to first construct a mock that passes the test (no error),
+		// and then install up to one error condition. When an error condition is installed
 		// the test case should declare the appropriate expected sentinel error.
 
-		missingEngineClient, missingRollupConfig bool
+		missingEngineClient bool
+		nilTarget           bool
 
-		refErr, newPayloadErr, fcuErr error
-		newPayloadStatus              *eth.PayloadStatusV1
-		fcuResult                     *eth.ForkchoiceUpdatedResult
+		newPayloadErr, fcuErr error
+		newPayloadStatus      *eth.PayloadStatusV1
+		fcuResult             *eth.ForkchoiceUpdatedResult
+		labelErr              error
 
 		incorrectUnsafe, incorrectSafe, incorrectFinalized bool
 
-		targetBeforeGenesis   bool
-		targetBeforeFinalized bool
+		// finalizedAheadOfTarget puts the finalized head ahead of the target — rewind must refuse.
+		finalizedAheadOfTarget bool
+
+		// payloadTimestampMismatch sabotages the target envelope so its timestamp does not
+		// correspond to its block number per the rollup config.
+		payloadTimestampMismatch bool
 
 		// unsafeMatchesTarget causes the mock to report the unsafe head at the target
 		// block (same hash), exercising the no-op path.
 		unsafeMatchesTarget bool
-		// canonicalReinsertBadStatus simulates the EL rejecting the re-inserted
-		// canonical payload after the synthetic FCU.
+		// canonicalReinsertBadStatus simulates the EL rejecting the re-inserted canonical
+		// payload after the synthetic FCU.
 		canonicalReinsertBadStatus bool
 
 		// expectedNewPayloadCalls overrides the default count of NewPayload calls
@@ -58,8 +61,7 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:          "successful rewind",
-			expectedError: nil,
+			name: "successful rewind",
 		},
 		{
 			name:                "nil engine client",
@@ -67,20 +69,14 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 			expectedError:       ErrNoEngineClient,
 		},
 		{
-			name:                "nil rollup config",
-			missingRollupConfig: true,
-			expectedError:       ErrNoRollupConfig,
+			name:          "nil target",
+			nilTarget:     true,
+			expectedError: ErrRewindNilTarget,
 		},
 		{
-			name:                    "target not found is a no-op",
-			refErr:                  ethereum.NotFound,
-			expectedNewPayloadCalls: intPtr(0),
-			expectedFCUCalls:        intPtr(0),
-		},
-		{
-			name:          "reference error",
-			refErr:        errors.New("transient RPC error"),
-			expectedError: ErrRewindTargetBlockNotFound,
+			name:                     "target payload inconsistent with rollup config",
+			payloadTimestampMismatch: true,
+			expectedError:            ErrRewindTargetMismatch,
 		},
 		{
 			name:          "new payload error",
@@ -122,14 +118,9 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 			expectedError:      ErrRewindFCUHeadMismatch,
 		},
 		{
-			name:                "target before genesis",
-			targetBeforeGenesis: true,
-			expectedError:       ErrRewindTimestampToBlockConversion,
-		},
-		{
-			name:                  "target before finalized",
-			targetBeforeFinalized: true,
-			expectedError:         ErrRewindOverFinalizedHead,
+			name:                   "target before finalized",
+			finalizedAheadOfTarget: true,
+			expectedError:          ErrRewindOverFinalizedHead,
 		},
 		{
 			name:                    "no-op when unsafe head matches target",
@@ -142,47 +133,42 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 			canonicalReinsertBadStatus: true,
 			expectedError:              ErrRewindCanonicalPayloadRejected,
 		},
+		{
+			name:          "current unsafe label fetch fails",
+			labelErr:      errors.New("transient RPC error"),
+			expectedError: ErrRewindCurrentUnsafeFailed,
+		},
 	}
 
-	// Setup: chain is at block 10, we want to rewind to block 5
-	// Block 5 is at timestamp 1000 + 5*2 = 1010 (2s block time)
+	// Setup: chain is at block 10, we want to rewind to block 5.
+	// Block 5 is at timestamp 1000 + 5*2 = 1010 (2s block time).
 	genesisTime := uint64(1000)
 	targetBlockNum, targetTimestamp, parentHash := uint64(5), genesisTime+(5*2), common.Hash{0x04}
-	targetRef := eth.L2BlockRef{
-		Number:     targetBlockNum,
-		Hash:       common.Hash{byte(targetBlockNum)},
-		ParentHash: parentHash,
-		Time:       targetTimestamp,
-	}
-	payloadEnvelope := eth.ExecutionPayloadEnvelope{
-		ExecutionPayload: &eth.ExecutionPayload{
-			ParentHash:   parentHash,
-			BlockNumber:  eth.Uint64Quantity(targetRef.BlockRef().Number),
-			Timestamp:    eth.Uint64Quantity(targetRef.BlockRef().Time),
-			BlockHash:    targetRef.Hash,
-			FeeRecipient: common.Address{0x01},
-		},
+	targetHash := common.Hash{byte(targetBlockNum)}
+	canonicalPayload := func() *eth.ExecutionPayloadEnvelope {
+		return &eth.ExecutionPayloadEnvelope{
+			ExecutionPayload: &eth.ExecutionPayload{
+				ParentHash:   parentHash,
+				BlockNumber:  eth.Uint64Quantity(targetBlockNum),
+				Timestamp:    eth.Uint64Quantity(targetTimestamp),
+				BlockHash:    targetHash,
+				FeeRecipient: common.Address{0x01},
+			},
+		}
 	}
 
 	createMockL2 := func() mockL2 {
 		return mockL2{
-			refsByNumber: map[uint64]eth.L2BlockRef{
-				targetBlockNum: targetRef,
-			},
-			// Initial state before rewind — used by computeRewindTargets
 			refsByLabel: map[eth.BlockLabel]eth.L2BlockRef{
+				eth.Unsafe:    {Number: 10, Hash: common.Hash{0xee}},
 				eth.Safe:      {Number: 10, Hash: common.Hash{0x0a}},
 				eth.Finalized: {Number: 2, Hash: common.Hash{0x08}},
-			},
-			payloadsByNumber: map[uint64]*eth.ExecutionPayloadEnvelope{
-				targetBlockNum: &payloadEnvelope,
 			},
 		}
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// First, get a "good mock" which would pass the test with no error:
 			rollupConfig := rollup.Config{
 				Genesis:   rollup.Genesis{L2: eth.BlockID{Number: 0}, L2Time: genesisTime},
 				BlockTime: 2,
@@ -190,10 +176,6 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 			}
 			l2 := createMockL2()
 
-			// Next, apply the sabotage(s):
-			if tc.refErr != nil {
-				l2.refErr = tc.refErr
-			}
 			if tc.newPayloadErr != nil {
 				l2.newPayloadErr = tc.newPayloadErr
 			}
@@ -207,6 +189,9 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 				l2.fcuResult = tc.fcuResult
 			}
 			l2.labelOverrides = make(map[eth.BlockLabel]eth.L2BlockRef)
+			if tc.labelErr != nil {
+				l2.refByLabelErr = tc.labelErr
+			}
 			if tc.incorrectUnsafe {
 				l2.labelOverrides[eth.Unsafe] = eth.L2BlockRef{Number: targetBlockNum, Hash: common.Hash{0xff}}
 			}
@@ -216,38 +201,32 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 			if tc.incorrectFinalized {
 				l2.labelOverrides[eth.Finalized] = eth.L2BlockRef{Number: targetBlockNum, Hash: common.Hash{0xff}}
 			}
-			if tc.targetBeforeGenesis {
-				rollupConfig.Genesis = rollup.Genesis{L2Time: 2000}
-			}
-			if tc.targetBeforeFinalized {
+			if tc.finalizedAheadOfTarget {
 				l2.refsByLabel[eth.Finalized] = eth.L2BlockRef{Number: targetBlockNum + 1, Hash: common.Hash{0xff}}
 			}
 			if tc.unsafeMatchesTarget {
-				l2.labelOverrides[eth.Unsafe] = targetRef
+				l2.refsByLabel[eth.Unsafe] = eth.L2BlockRef{Number: targetBlockNum, Hash: targetHash}
 			}
 			if tc.canonicalReinsertBadStatus {
-				// Synthetic NewPayload (call 1) succeeds; canonical re-insert (call 2) is rejected.
-				l2.newPayloadStatuses = []*eth.PayloadStatusV1{
-					nil,
-					{Status: eth.ExecutionInvalid},
-				}
+				l2.newPayloadStatuses = []*eth.PayloadStatusV1{nil, {Status: eth.ExecutionInvalid}}
 			}
 
-			// Make a "good" engine controller, using a potentially sabotaged mock L2
 			ec := &simpleEngineController{l2: &l2, rollup: &rollupConfig, log: testlog.Logger(t, log.LvlDebug)}
-
-			// Apply a couple of potential sabotages directly to the engine controller:
 			if tc.missingEngineClient {
 				ec.l2 = nil
 			}
-			if tc.missingRollupConfig {
-				ec.rollup = nil
+
+			var target *eth.ExecutionPayloadEnvelope
+			if !tc.nilTarget {
+				target = canonicalPayload()
+			}
+			if tc.payloadTimestampMismatch {
+				// Shift block number while keeping timestamp; rollup-derived expected number won't match.
+				target.ExecutionPayload.BlockNumber = eth.Uint64Quantity(targetBlockNum + 1)
 			}
 
-			// Execute the method call under test:
-			err := ec.RewindToTimestamp(context.Background(), targetTimestamp)
+			err := ec.Rewind(context.Background(), target)
 
-			// Make the assertions declared in the test case:
 			if tc.expectedError != nil {
 				require.ErrorIs(t, err, tc.expectedError)
 			} else {
@@ -264,13 +243,9 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 					"NewPayload call count mismatch (synthetic + canonical re-insert)")
 				require.Equal(t, wantFCUCalls, l2.fcuCalls,
 					"ForkchoiceUpdate call count mismatch (synthetic + target)")
-
-				// For the standard successful rewind, verify the last NewPayload is
-				// the canonical payload (matching the original ExtraData), and that the
-				// synthetic block was inserted at some point with mutated ExtraData.
 				if wantNewPayloadCalls == 2 {
 					require.NotNil(t, l2.lastNewPayload)
-					require.Equal(t, payloadEnvelope.ExecutionPayload.ExtraData, l2.lastNewPayload.ExtraData,
+					require.Equal(t, canonicalPayload().ExecutionPayload.ExtraData, l2.lastNewPayload.ExtraData,
 						"final NewPayload should be the canonical re-insert with original ExtraData")
 				}
 			}

--- a/op-supernode/supernode/chain_container/engine_controller/rewind_test.go
+++ b/op-supernode/supernode/chain_container/engine_controller/rewind_test.go
@@ -46,9 +46,6 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 		// unsafeMatchesTarget causes the mock to report the unsafe head at the target
 		// block (same hash), exercising the no-op path.
 		unsafeMatchesTarget bool
-		// unsafeBelowTarget causes the mock to report the unsafe head before the target,
-		// also exercising the no-op path.
-		unsafeBelowTarget bool
 		// canonicalReinsertBadStatus simulates the EL rejecting the re-inserted
 		// canonical payload after the synthetic FCU.
 		canonicalReinsertBadStatus bool
@@ -75,8 +72,14 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 			expectedError:       ErrNoRollupConfig,
 		},
 		{
+			name:                    "target not found is a no-op",
+			refErr:                  ethereum.NotFound,
+			expectedNewPayloadCalls: intPtr(0),
+			expectedFCUCalls:        intPtr(0),
+		},
+		{
 			name:          "reference error",
-			refErr:        ethereum.NotFound,
+			refErr:        errors.New("transient RPC error"),
 			expectedError: ErrRewindTargetBlockNotFound,
 		},
 		{
@@ -131,12 +134,6 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 		{
 			name:                    "no-op when unsafe head matches target",
 			unsafeMatchesTarget:     true,
-			expectedNewPayloadCalls: intPtr(0),
-			expectedFCUCalls:        intPtr(0),
-		},
-		{
-			name:                    "no-op when unsafe head is below target",
-			unsafeBelowTarget:       true,
 			expectedNewPayloadCalls: intPtr(0),
 			expectedFCUCalls:        intPtr(0),
 		},
@@ -227,9 +224,6 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 			}
 			if tc.unsafeMatchesTarget {
 				l2.labelOverrides[eth.Unsafe] = targetRef
-			}
-			if tc.unsafeBelowTarget {
-				l2.labelOverrides[eth.Unsafe] = eth.L2BlockRef{Number: targetBlockNum - 1, Hash: common.Hash{0xaa}}
 			}
 			if tc.canonicalReinsertBadStatus {
 				// Synthetic NewPayload (call 1) succeeds; canonical re-insert (call 2) is rejected.

--- a/op-supernode/supernode/chain_container/engine_controller/rewind_test.go
+++ b/op-supernode/supernode/chain_container/engine_controller/rewind_test.go
@@ -42,6 +42,21 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 
 		targetBeforeGenesis   bool
 		targetBeforeFinalized bool
+
+		// unsafeMatchesTarget causes the mock to report the unsafe head at the target
+		// block (same hash), exercising the no-op path.
+		unsafeMatchesTarget bool
+		// unsafeBelowTarget causes the mock to report the unsafe head before the target,
+		// also exercising the no-op path.
+		unsafeBelowTarget bool
+		// canonicalReinsertBadStatus simulates the EL rejecting the re-inserted
+		// canonical payload after the synthetic FCU.
+		canonicalReinsertBadStatus bool
+
+		// expectedNewPayloadCalls overrides the default count of NewPayload calls
+		// expected on a successful run.
+		expectedNewPayloadCalls *int
+		expectedFCUCalls        *int
 	}
 
 	testCases := []testCase{
@@ -112,6 +127,23 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 			name:                  "target before finalized",
 			targetBeforeFinalized: true,
 			expectedError:         ErrRewindOverFinalizedHead,
+		},
+		{
+			name:                    "no-op when unsafe head matches target",
+			unsafeMatchesTarget:     true,
+			expectedNewPayloadCalls: intPtr(0),
+			expectedFCUCalls:        intPtr(0),
+		},
+		{
+			name:                    "no-op when unsafe head is below target",
+			unsafeBelowTarget:       true,
+			expectedNewPayloadCalls: intPtr(0),
+			expectedFCUCalls:        intPtr(0),
+		},
+		{
+			name:                       "canonical re-insert bad status",
+			canonicalReinsertBadStatus: true,
+			expectedError:              ErrRewindCanonicalPayloadRejected,
 		},
 	}
 
@@ -193,6 +225,19 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 			if tc.targetBeforeFinalized {
 				l2.refsByLabel[eth.Finalized] = eth.L2BlockRef{Number: targetBlockNum + 1, Hash: common.Hash{0xff}}
 			}
+			if tc.unsafeMatchesTarget {
+				l2.labelOverrides[eth.Unsafe] = targetRef
+			}
+			if tc.unsafeBelowTarget {
+				l2.labelOverrides[eth.Unsafe] = eth.L2BlockRef{Number: targetBlockNum - 1, Hash: common.Hash{0xaa}}
+			}
+			if tc.canonicalReinsertBadStatus {
+				// Synthetic NewPayload (call 1) succeeds; canonical re-insert (call 2) is rejected.
+				l2.newPayloadStatuses = []*eth.PayloadStatusV1{
+					nil,
+					{Status: eth.ExecutionInvalid},
+				}
+			}
 
 			// Make a "good" engine controller, using a potentially sabotaged mock L2
 			ec := &simpleEngineController{l2: &l2, rollup: &rollupConfig, log: testlog.Logger(t, log.LvlDebug)}
@@ -213,15 +258,30 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 				require.ErrorIs(t, err, tc.expectedError)
 			} else {
 				require.NoError(t, err)
-				// Verify NewPayload was called (for synthetic block)
-				require.Equal(t, 1, l2.newPayloadCalls, "NewPayload should be called once for synthetic block")
-				require.NotNil(t, l2.lastNewPayload)
-				// The synthetic payload should have modified ExtraData to change the block hash
-				require.NotEqual(t, payloadEnvelope.ExecutionPayload.ExtraData, l2.lastNewPayload.ExtraData, "Synthetic payload should have modified ExtraData")
+				wantNewPayloadCalls := 2
+				if tc.expectedNewPayloadCalls != nil {
+					wantNewPayloadCalls = *tc.expectedNewPayloadCalls
+				}
+				wantFCUCalls := 2
+				if tc.expectedFCUCalls != nil {
+					wantFCUCalls = *tc.expectedFCUCalls
+				}
+				require.Equal(t, wantNewPayloadCalls, l2.newPayloadCalls,
+					"NewPayload call count mismatch (synthetic + canonical re-insert)")
+				require.Equal(t, wantFCUCalls, l2.fcuCalls,
+					"ForkchoiceUpdate call count mismatch (synthetic + target)")
 
-				// Verify ForkchoiceUpdate was called twice (once for synthetic, once for target)
-				require.Equal(t, 2, l2.fcuCalls, "ForkchoiceUpdate should be called twice")
+				// For the standard successful rewind, verify the last NewPayload is
+				// the canonical payload (matching the original ExtraData), and that the
+				// synthetic block was inserted at some point with mutated ExtraData.
+				if wantNewPayloadCalls == 2 {
+					require.NotNil(t, l2.lastNewPayload)
+					require.Equal(t, payloadEnvelope.ExecutionPayload.ExtraData, l2.lastNewPayload.ExtraData,
+						"final NewPayload should be the canonical re-insert with original ExtraData")
+				}
 			}
 		})
 	}
 }
+
+func intPtr(v int) *int { return &v }

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -366,9 +366,15 @@ func (d *DenyList) Close() error {
 // that wider interface (only interop transition application does) to invoke it.
 // Adds a block to the deny list and triggers a rewind if the chain currently
 // uses that block at the specified height.
+//
+// parentPayload is the canonical payload at height-1 (the rewind destination) captured
+// at build time by the caller and persisted in the WAL. The engine controller uses it
+// to drive the rewind without consulting the live EL, which protects against partial
+// reorg state left by a crash mid-rewind.
+//
 // Returns true if a rewind was triggered, false otherwise.
 // Note: Genesis block (height=0) cannot be invalidated as there is no prior block to rewind to.
-func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
+func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) (bool, error) {
 	if c.denyList == nil {
 		return false, fmt.Errorf("deny list not initialized")
 	}
@@ -376,6 +382,14 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	// Cannot invalidate genesis block - there is no prior block to rewind to
 	if height == 0 {
 		return false, fmt.Errorf("cannot invalidate genesis block (height=0)")
+	}
+
+	if parentPayload == nil || parentPayload.ExecutionPayload == nil {
+		return false, fmt.Errorf("invalidate block at height %d: %w", height, engine_controller.ErrRewindNilTarget)
+	}
+	if expectedParentNumber := height - 1; uint64(parentPayload.ExecutionPayload.BlockNumber) != expectedParentNumber {
+		return false, fmt.Errorf("invalidate block at height %d: parent payload block number %d does not match expected %d",
+			height, uint64(parentPayload.ExecutionPayload.BlockNumber), expectedParentNumber)
 	}
 
 	// Add to deny list with the output preimage fields
@@ -429,15 +443,17 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 
 	invalidatedBlock := currentBlock.BlockRef()
 
-	// Rewind to the prior block's timestamp
-	priorTimestamp, err := c.BlockNumberToTimestamp(ctx, height-1)
-	if err != nil {
-		return false, fmt.Errorf("failed to compute rewind timestamp: %w", err)
+	// Cross-check the WAL'd parent payload against what the live chain sees as the parent.
+	if invalidatedBlock.ParentHash != parentPayload.ExecutionPayload.BlockHash {
+		return false, fmt.Errorf("parent payload hash %s does not match invalidated block's parent %s",
+			parentPayload.ExecutionPayload.BlockHash, invalidatedBlock.ParentHash)
 	}
-	if err := c.RewindEngine(ctx, priorTimestamp, invalidatedBlock); err != nil {
+
+	if err := c.RewindEngine(ctx, parentPayload, invalidatedBlock); err != nil {
 		return false, fmt.Errorf("failed to rewind engine: %w", err)
 	}
 
+	priorTimestamp := uint64(parentPayload.ExecutionPayload.Timestamp)
 	c.log.Info("rewind completed after block invalidation",
 		"invalidatedHeight", height,
 		"rewindToTimestamp", priorTimestamp,

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -364,16 +364,11 @@ func (d *DenyList) Close() error {
 
 // InvalidateBlock is part of the InteropChain interface — callers must hold
 // that wider interface (only interop transition application does) to invoke it.
-// Adds a block to the deny list and triggers a rewind if the chain currently
-// uses that block at the specified height.
-//
-// parentPayload is the canonical payload at height-1 (the rewind destination) captured
-// at build time by the caller and persisted in the WAL. The engine controller uses it
-// to drive the rewind without consulting the live EL, which protects against partial
-// reorg state left by a crash mid-rewind.
-//
-// Returns true if a rewind was triggered, false otherwise.
-// Note: Genesis block (height=0) cannot be invalidated as there is no prior block to rewind to.
+// Adds a block to the deny list and triggers a rewind to parentPayload if the
+// chain currently uses the invalidated block (or has partial rewind state) at
+// the specified height. parentPayload is the WAL-captured canonical payload at
+// height-1. Returns true if a rewind was triggered. Genesis (height=0) cannot
+// be invalidated.
 func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) (bool, error) {
 	if c.denyList == nil {
 		return false, fmt.Errorf("deny list not initialized")
@@ -412,42 +407,29 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		return false, fmt.Errorf("cannot check current block at height %d: %w", height, engine_controller.ErrNoEngineClient)
 	}
 
+	// Only skip the rewind when the engine reports a block at this height that is not the
+	// invalidated one. A NotFound result is not safe to skip: a prior crashed attempt may
+	// have left the synthetic block at this height with no canonical entry visible by
+	// number, and we need to drive the rewind to completion.
+	var invalidatedBlock eth.BlockRef
 	currentBlock, err := c.engine.L2BlockRefByNumber(ctx, height)
-	if err != nil {
-		// If the engine has no block at this height the chain is already strictly
-		// shorter than the invalidated block: there is nothing to rewind. The deny
-		// list entry above is durable, so any future attempt to extend the chain
-		// past this height with the denied hash will still be rejected.
-		if errors.Is(err, ethereum.NotFound) {
-			c.log.Info("invalidated block height is beyond current chain head; nothing to rewind",
-				"height", height, "payloadHash", payloadHash)
+	switch {
+	case err == nil:
+		if currentBlock.Hash != payloadHash {
+			c.log.Info("current block differs from invalidated block, no rewind needed",
+				"height", height, "currentHash", currentBlock.Hash, "invalidatedHash", payloadHash)
 			return false, nil
 		}
+		invalidatedBlock = currentBlock.BlockRef()
+	case errors.Is(err, ethereum.NotFound):
+		c.log.Warn("no canonical block at invalidated height; assuming partial rewind state and retrying",
+			"height", height, "payloadHash", payloadHash)
+		invalidatedBlock = eth.BlockRef{Number: height, Hash: payloadHash}
+	default:
 		return false, fmt.Errorf("failed to get current block at height %d: %w", height, err)
 	}
 
-	// Compare the current block hash with the invalidated hash
-	if currentBlock.Hash != payloadHash {
-		c.log.Info("current block differs from invalidated block, no rewind needed",
-			"height", height,
-			"currentHash", currentBlock.Hash,
-			"invalidatedHash", payloadHash,
-		)
-		return false, nil
-	}
-
-	c.log.Warn("current block matches invalidated block, initiating rewind",
-		"height", height,
-		"hash", payloadHash,
-	)
-
-	invalidatedBlock := currentBlock.BlockRef()
-
-	// Cross-check the WAL'd parent payload against what the live chain sees as the parent.
-	if invalidatedBlock.ParentHash != parentPayload.ExecutionPayload.BlockHash {
-		return false, fmt.Errorf("parent payload hash %s does not match invalidated block's parent %s",
-			parentPayload.ExecutionPayload.BlockHash, invalidatedBlock.ParentHash)
-	}
+	c.log.Warn("initiating rewind after block invalidation", "height", height, "hash", payloadHash)
 
 	if err := c.RewindEngine(ctx, parentPayload, invalidatedBlock); err != nil {
 		return false, fmt.Errorf("failed to rewind engine: %w", err)

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	bolt "go.etcd.io/bbolt"
 )
@@ -398,6 +400,15 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 
 	currentBlock, err := c.engine.L2BlockRefByNumber(ctx, height)
 	if err != nil {
+		// If the engine has no block at this height the chain is already strictly
+		// shorter than the invalidated block: there is nothing to rewind. The deny
+		// list entry above is durable, so any future attempt to extend the chain
+		// past this height with the denied hash will still be rejected.
+		if errors.Is(err, ethereum.NotFound) {
+			c.log.Info("invalidated block height is beyond current chain head; nothing to rewind",
+				"height", height, "payloadHash", payloadHash)
+			return false, nil
+		}
 		return false, fmt.Errorf("failed to get current block at height %d: %w", height, err)
 	}
 

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -322,6 +322,10 @@ func (m *mockEngineForInvalidation) PayloadByHash(ctx context.Context, hash comm
 	return nil, nil
 }
 
+func (m *mockEngineForInvalidation) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	return nil, nil
+}
+
 func (m *mockEngineForInvalidation) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
 	return nil, nil, nil
 }

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -310,10 +310,16 @@ func (m *mockEngineForInvalidation) OutputV0ByBlockHash(ctx context.Context, blo
 	return nil, nil
 }
 
-func (m *mockEngineForInvalidation) RewindToTimestamp(ctx context.Context, timestamp uint64) error {
+func (m *mockEngineForInvalidation) Rewind(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error {
 	m.rewindCalled = true
-	m.rewindTimestamp = timestamp
+	if target != nil && target.ExecutionPayload != nil {
+		m.rewindTimestamp = uint64(target.ExecutionPayload.Timestamp)
+	}
 	return nil
+}
+
+func (m *mockEngineForInvalidation) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	return nil, nil
 }
 
 func (m *mockEngineForInvalidation) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
@@ -362,6 +368,16 @@ func TestInvalidateBlock(t *testing.T) {
 
 	genesisTime := uint64(1000)
 	blockTime := uint64(2)
+
+	makeParentPayload := func(parentNum, parentTime uint64, parentHash common.Hash) *eth.ExecutionPayloadEnvelope {
+		return &eth.ExecutionPayloadEnvelope{
+			ExecutionPayload: &eth.ExecutionPayload{
+				BlockNumber: eth.Uint64Quantity(parentNum),
+				Timestamp:   eth.Uint64Quantity(parentTime),
+				BlockHash:   parentHash,
+			},
+		}
+	}
 
 	tests := []struct {
 		name             string
@@ -424,7 +440,7 @@ func TestInvalidateBlock(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		rewound, err := c.InvalidateBlock(ctx, 0, common.HexToHash("0xgenesis"), 0, eth.Bytes32{}, eth.Bytes32{})
+		rewound, err := c.InvalidateBlock(ctx, 0, common.HexToHash("0xgenesis"), 0, eth.Bytes32{}, eth.Bytes32{}, makeParentPayload(0, 0, common.Hash{}))
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot invalidate genesis block")
@@ -451,7 +467,7 @@ func TestInvalidateBlock(t *testing.T) {
 		}
 
 		hash := common.HexToHash("0xdead")
-		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{})
+		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{}, makeParentPayload(4, 0, common.Hash{0xaa}))
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, engine_controller.ErrNoEngineClient)
@@ -460,6 +476,26 @@ func TestInvalidateBlock(t *testing.T) {
 		found, err := dl.Contains(5, hash)
 		require.NoError(t, err)
 		require.True(t, found, "denylist entry must persist so rewind can retry on restart")
+	})
+
+	t.Run("nil parent payload returns error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dl, err := OpenDenyList(filepath.Join(dir, "denylist"))
+		require.NoError(t, err)
+		defer dl.Close()
+
+		c := &simpleChainContainer{
+			denyList: dl,
+			log:      testLogger(),
+			engine:   &mockEngineForInvalidation{},
+			vn:       &mockVNForInvalidation{},
+		}
+
+		hash := common.HexToHash("0xdead")
+		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{}, nil)
+		require.ErrorIs(t, err, engine_controller.ErrRewindNilTarget)
+		require.False(t, rewound)
 	})
 
 	t.Run("L2BlockRefByNumber failure returns error and persists denylist entry", func(t *testing.T) {
@@ -481,7 +517,7 @@ func TestInvalidateBlock(t *testing.T) {
 		}
 
 		hash := common.HexToHash("0xdead")
-		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{})
+		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{}, makeParentPayload(4, 0, common.Hash{0xaa}))
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, fetchErr)
@@ -511,7 +547,7 @@ func TestInvalidateBlock(t *testing.T) {
 		}
 
 		hash := common.HexToHash("0xdead")
-		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{})
+		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{}, makeParentPayload(4, 0, common.Hash{0xaa}))
 
 		require.NoError(t, err)
 		require.False(t, rewound)
@@ -523,7 +559,7 @@ func TestInvalidateBlock(t *testing.T) {
 		require.True(t, found)
 	})
 
-	t.Run("missing rollup config returns error before rewind", func(t *testing.T) {
+	t.Run("parent payload number mismatch returns error", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 
@@ -542,13 +578,13 @@ func TestInvalidateBlock(t *testing.T) {
 			vn:       &mockVNForInvalidation{},
 		}
 
-		rewound, err := c.InvalidateBlock(context.Background(), 5, common.HexToHash("0xdead"), 0, eth.Bytes32{}, eth.Bytes32{})
-
+		// parent payload claims block number 99 but height=5 expects parent at 4
+		rewound, err := c.InvalidateBlock(context.Background(), 5, common.HexToHash("0xdead"), 0,
+			eth.Bytes32{}, eth.Bytes32{}, makeParentPayload(99, 0, common.Hash{0xaa}))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to compute rewind timestamp")
-		require.Contains(t, err.Error(), "rollup config not available")
+		require.Contains(t, err.Error(), "parent payload block number")
 		require.False(t, rewound)
-		require.False(t, mockEng.rewindCalled, "rewind should not be attempted without rollup config")
+		require.False(t, mockEng.rewindCalled, "rewind should not be attempted with a mismatched parent payload")
 	})
 
 	for _, tt := range tests {
@@ -561,9 +597,10 @@ func TestInvalidateBlock(t *testing.T) {
 			require.NoError(t, err)
 			defer dl.Close()
 
-			// Create mock engine
+			parentHash := common.Hash{0x01, byte(tt.height)}
+			// Create mock engine — set ParentHash on the BlockRef so it matches the parent payload.
 			mockEng := &mockEngineForInvalidation{
-				blockRef: eth.L2BlockRef{Hash: tt.currentBlockHash},
+				blockRef: eth.L2BlockRef{Hash: tt.currentBlockHash, ParentHash: parentHash},
 			}
 
 			// Create container with minimal config
@@ -587,8 +624,9 @@ func TestInvalidateBlock(t *testing.T) {
 				BlockHash:                tt.payloadHash,
 			}
 
+			parentPayload := makeParentPayload(tt.height-1, tt.expectRewindTs, parentHash)
 			ctx := context.Background()
-			rewound, err := c.InvalidateBlock(ctx, tt.height, tt.payloadHash, 0, testStateRoot, testMsgPasserRoot)
+			rewound, err := c.InvalidateBlock(ctx, tt.height, tt.payloadHash, 0, testStateRoot, testMsgPasserRoot, parentPayload)
 			require.NoError(t, err)
 
 			// Verify rewind behavior

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
@@ -490,6 +491,36 @@ func TestInvalidateBlock(t *testing.T) {
 		found, err := dl.Contains(5, hash)
 		require.NoError(t, err)
 		require.True(t, found, "hash should be in denylist even when current block lookup fails")
+	})
+
+	t.Run("L2BlockRefByNumber returns NotFound treats chain as already rewound", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		dl, err := OpenDenyList(filepath.Join(dir, "denylist"))
+		require.NoError(t, err)
+		defer dl.Close()
+
+		mockEng := &mockEngineForInvalidation{blockRefErr: ethereum.NotFound}
+
+		c := &simpleChainContainer{
+			denyList: dl,
+			log:      testLogger(),
+			engine:   mockEng,
+			vn:       &mockVNForInvalidation{},
+		}
+
+		hash := common.HexToHash("0xdead")
+		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{})
+
+		require.NoError(t, err)
+		require.False(t, rewound)
+		require.False(t, mockEng.rewindCalled, "rewind should not be attempted when the block is not present")
+
+		// The denylist entry must still be recorded so a future re-extension can be rejected.
+		found, err := dl.Contains(5, hash)
+		require.NoError(t, err)
+		require.True(t, found)
 	})
 
 	t.Run("missing rollup config returns error before rewind", func(t *testing.T) {

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -529,7 +529,7 @@ func TestInvalidateBlock(t *testing.T) {
 		require.True(t, found, "hash should be in denylist even when current block lookup fails")
 	})
 
-	t.Run("L2BlockRefByNumber returns NotFound treats chain as already rewound", func(t *testing.T) {
+	t.Run("L2BlockRefByNumber returns NotFound still drives rewind to handle partial recovery", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 
@@ -550,10 +550,9 @@ func TestInvalidateBlock(t *testing.T) {
 		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{}, makeParentPayload(4, 0, common.Hash{0xaa}))
 
 		require.NoError(t, err)
-		require.False(t, rewound)
-		require.False(t, mockEng.rewindCalled, "rewind should not be attempted when the block is not present")
+		require.True(t, rewound, "rewind must be attempted: a prior crashed attempt may have left a synthetic block at this height")
+		require.True(t, mockEng.rewindCalled)
 
-		// The denylist entry must still be recorded so a future re-extension can be rejected.
 		found, err := dl.Contains(5, hash)
 		require.NoError(t, err)
 		require.True(t, found)


### PR DESCRIPTION
Previously, when the supernode rewound the engine for `DecisionRewind` / `DecisionInvalidate`, it:
1. Inserted a synthetic block and FCU'd to it (making the original target non-canonical), then
2. FCU'd back to the original target.

Between (1) and (2) the original target sat non-canonical, where op-reth's pruner is free to discard it. A crash mid-rewind left the supernode unable to recover: looking the target up again by number would return the synthetic, and looking it up by hash could return NotFound.

This PR makes the supernode WAL the authoritative source for the rewind target — at build time, while the block is still canonical — so apply / recovery never needs the live EL to still have it.

## Data model

- `RewindPlan` gains `TargetPayloads map[ChainID]*eth.ExecutionPayloadEnvelope`.
- `PendingTransition` gains `InvalidationParentPayloads map[ChainID]*eth.ExecutionPayloadEnvelope` (sibling of `Result`, not embedded in `InvalidHead` to keep that struct lean for API consumers).

## Build / apply / engine APIs

- `buildRewindPlan` and `buildPendingTransition(DecisionInvalidate)` fetch each chain's canonical payload before recording the WAL entry. Any fetch failure aborts the build; the decision is re-evaluated next round.
  - Normal rewinds (above the verified frontier) capture by hash from the previous verified result's heads.
  - Deny-list-driven engine resets at or below the verified frontier (`ResetAllChainsTo` with no previous verified frontier) capture by number, resolved from the reset timestamp via `TimestampToBlockNumber` / `PayloadByNumber`.
- Apply paths (`resetChainEnginesIfNeeded`, the invalidate loop in `applyPendingTransition`) use only the WAL'd payloads and surface a malformed-WAL error if any expected entry is missing — they never fall back to the live EL.
- `engine.Rewind(ctx, target)` replaces `RewindToTimestamp`. The synthetic block is derived from the supplied target, and the same target is re-inserted via `engine_newPayload` between the synthetic and target FCUs to guarantee EL durability across pruning.
- `InvalidateBlock` and `RewindEngine` take the target envelope explicitly so the WAL contract reaches all the way down to the engine controller.

## Other behavioral notes

- `engine.Rewind` no-ops when the unsafe head matches the target hash *or* is below the target number (the chain state may have moved since the WAL'd target was captured).
- `InvalidateBlock` only skips the rewind when the canonical block at the height exists and is not the invalidated hash. A `NotFound` result still drives the rewind so partial state from a prior crashed attempt (synthetic block, no canonical entry visible by number) gets cleaned up.
- Engine controller cross-checks the envelope's number/timestamp against the rollup config.

## Test plan

- [x] `go test ./op-supernode/...` passes (chain_container, engine_controller, activity/interop, supernode, superroot, virtual_node, raftwallogdb, resources).
- [x] `just lint-go` clean.
- [ ] Manual / e2e validation across a crash mid-rewind on a devnet.