### PR TITLE
fix(op-supernode): retry RewindEngine on DeadlineExceeded

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -695,9 +695,6 @@ retryLoop:
 	for {
 		err = c.engine.Rewind(ctx, target)
 		switch {
-		case errors.Is(err, context.DeadlineExceeded):
-			c.log.Error("chain_container/RewindEngine: timeout exceeded")
-			return err
 		case isCriticalRewindError(err):
 			c.log.Error("chain_container/RewindEngine: critical error", "err", err)
 			return err
@@ -705,6 +702,11 @@ retryLoop:
 			c.log.Info("chain_container/RewindEngine: executed engine rewind")
 			break retryLoop
 		default:
+			// context.DeadlineExceeded is intentionally treated as transient here:
+			// the engine's per-call RPC deadline (e.g. a slow synthetic FCU against
+			// op-reth that takes minutes) can fire while the caller's overall
+			// transition ctx still has budget. The ctx.Done() branch below stops
+			// the loop once the caller's ctx is actually done.
 			c.log.Error("chain_container/RewindEngine: temporary error", "err", err)
 			select {
 			case <-ctx.Done():

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -702,11 +702,13 @@ retryLoop:
 			c.log.Info("chain_container/RewindEngine: executed engine rewind")
 			break retryLoop
 		default:
-			// context.DeadlineExceeded is intentionally treated as transient here:
-			// the engine's per-call RPC deadline (e.g. a slow synthetic FCU against
-			// op-reth that takes minutes) can fire while the caller's overall
-			// transition ctx still has budget. The ctx.Done() branch below stops
-			// the loop once the caller's ctx is actually done.
+			// context.DeadlineExceeded is treated as transient: the caller's ctx is
+			// the long-lived service ctx (no deadline), so a DeadlineExceeded here
+			// originates from a per-call RPC deadline inside the engine client — e.g.
+			// a slow synthetic FCU against op-reth. Keep retrying: if the EL is truly
+			// down a subsequent attempt will surface a transport error, and if it is
+			// still chewing on the rewind, waiting is the right answer. The ctx.Done()
+			// branch below stops the loop on service shutdown.
 			c.log.Error("chain_container/RewindEngine: temporary error", "err", err)
 			select {
 			case <-ctx.Done():

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -775,6 +775,62 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 		require.Equal(t, 0, mockEngine.rewindCalls, "engine.Rewind should not be called when VN stop fails")
 	})
 
+	t.Run("treats DeadlineExceeded from engine as transient when caller ctx still has budget", func(t *testing.T) {
+		// The engine's per-call RPC deadline (e.g. the slow synthetic FCU against op-reth)
+		// can fire while the caller's interop-transition ctx still has plenty of budget.
+		// In that case, engine.Rewind returns context.DeadlineExceeded but the wider rewind
+		// flow should retry rather than bail. See ethereum-optimism/optimism#21015.
+		mockVN := newMockVirtualNode()
+		mockEngine := newMockEngineController()
+		callCount := 0
+		mockEngine.rewindFunc = func(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error {
+			callCount++
+			if callCount < 3 {
+				return context.DeadlineExceeded
+			}
+			return nil
+		}
+
+		c := &simpleChainContainer{
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
+			engine:  mockEngine,
+			vn:      mockVN,
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
+		err := c.RewindEngine(ctx, makeTarget(12345), invalidatedBlock)
+		require.NoError(t, err)
+		require.Equal(t, 3, mockEngine.rewindCalls, "engine.Rewind should be retried through DeadlineExceeded errors")
+		require.False(t, c.pause.Load(), "Container should be resumed after successful rewind")
+	})
+
+	t.Run("returns ctx.Err() when caller ctx expires during DeadlineExceeded retries", func(t *testing.T) {
+		// Once the caller's own ctx is done, the retry loop must stop — otherwise it would
+		// spin forever against a permanently-broken engine.
+		mockVN := newMockVirtualNode()
+		mockEngine := newMockEngineController()
+		mockEngine.rewindErr = context.DeadlineExceeded
+
+		c := &simpleChainContainer{
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
+			engine:  mockEngine,
+			vn:      mockVN,
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+		defer cancel()
+		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
+		err := c.RewindEngine(ctx, makeTarget(12345), invalidatedBlock)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Greater(t, mockEngine.rewindCalls, 1, "engine.Rewind should be retried at least once before ctx expires")
+		require.False(t, c.pause.Load(), "Container should be resumed (not stuck paused) after ctx expiry")
+	})
+
 	t.Run("succeeds after transient error on retry", func(t *testing.T) {
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -775,11 +775,11 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 		require.Equal(t, 0, mockEngine.rewindCalls, "engine.Rewind should not be called when VN stop fails")
 	})
 
-	t.Run("treats DeadlineExceeded from engine as transient when caller ctx still has budget", func(t *testing.T) {
-		// The engine's per-call RPC deadline (e.g. the slow synthetic FCU against op-reth)
-		// can fire while the caller's interop-transition ctx still has plenty of budget.
-		// In that case, engine.Rewind returns context.DeadlineExceeded but the wider rewind
-		// flow should retry rather than bail. See ethereum-optimism/optimism#21015.
+	t.Run("treats DeadlineExceeded from engine as transient and retries", func(t *testing.T) {
+		// The caller's ctx is the long-lived service ctx with no deadline, so a
+		// DeadlineExceeded from engine.Rewind originates from a per-call RPC deadline
+		// (e.g. a slow synthetic FCU against op-reth). The retry loop must keep going.
+		// See ethereum-optimism/optimism#21015.
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()
 		callCount := 0
@@ -807,9 +807,10 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 		require.False(t, c.pause.Load(), "Container should be resumed after successful rewind")
 	})
 
-	t.Run("returns ctx.Err() when caller ctx expires during DeadlineExceeded retries", func(t *testing.T) {
-		// Once the caller's own ctx is done, the retry loop must stop — otherwise it would
-		// spin forever against a permanently-broken engine.
+	t.Run("returns ctx.Err() when caller ctx is cancelled during DeadlineExceeded retries", func(t *testing.T) {
+		// In production the caller's ctx has no deadline and is only cancelled on service
+		// shutdown. Confirm that cancellation does stop the loop — otherwise it would spin
+		// forever against a permanently-broken engine even after shutdown begins.
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()
 		mockEngine.rewindErr = context.DeadlineExceeded


### PR DESCRIPTION
The synthetic FCU in the rewind path can take minutes against a slow execution layer (op-reth in particular), long enough for the engine client's per-call RPC deadline to fire and surface as `context.DeadlineExceeded` from `engine.Rewind`. The caller's ctx is the long-lived service ctx with no deadline (only cancelled on shutdown), so `RewindEngine`'s retry loop bailing immediately on `DeadlineExceeded` was wrong — it turned a slow EL into a fatal rewind failure.

Treat `DeadlineExceeded` as transient and let the loop keep retrying. If the EL is truly down, the next attempt will surface a transport error; if it is still working on the rewind, waiting is the right answer. The existing `ctx.Done()` select still stops the loop on service shutdown.

Per ethereum-optimism/optimism#21015 (comment): https://github.com/ethereum-optimism/optimism/pull/21015#issuecomment-4538093593