### PR TITLE
op-program: include required gas in L1 precompile cache keys

### DIFF
--- a/op-program/client/l1/cache.go
+++ b/op-program/client/l1/cache.go
@@ -95,7 +95,7 @@ func (o *CachingOracle) GetBlob(ref eth.L1BlockRef, blobHash common.Hash) *eth.B
 }
 
 func (o *CachingOracle) Precompile(address common.Address, input []byte, requiredGas uint64) ([]byte, bool) {
-	cacheKey := crypto.Keccak256Hash(append(address.Bytes(), input...))
+	cacheKey := crypto.Keccak256Hash(precompileKeyInput(address, input, requiredGas))
 	if val, ok := o.pcmps.Get(cacheKey); ok {
 		return val.result, val.ok
 	}

--- a/op-program/client/l1/cache_test.go
+++ b/op-program/client/l1/cache_test.go
@@ -1,7 +1,6 @@
 package l1
 
 import (
-	"encoding/binary"
 	"math/rand"
 	"testing"
 
@@ -101,20 +100,33 @@ func TestCachingOracle_Precompile(t *testing.T) {
 
 	input := []byte{0x01, 0x02, 0x03, 0x04}
 	requiredGas := uint64(100)
+	alternateRequiredGas := uint64(200)
 	output := []byte{0x0a, 0x0b, 0x0c, 0x0d}
+	alternateOutput := []byte{0x0e, 0x0f, 0x10, 0x11}
 	addr := common.Address{0x1}
 
-	key := crypto.Keccak256Hash(append(append(addr.Bytes(), binary.BigEndian.AppendUint64(nil, requiredGas)...), input...))
+	key := crypto.Keccak256Hash(precompileKeyInput(addr, input, requiredGas))
+	alternateKey := crypto.Keccak256Hash(precompileKeyInput(addr, input, alternateRequiredGas))
 
 	// Initial call retrieves from the stub
 	stub.PcmpResults[key] = output
+	stub.PcmpResults[alternateKey] = alternateOutput
 	actualResult, actualStatus := oracle.Precompile(addr, input, requiredGas)
 	require.True(t, actualStatus)
 	require.EqualValues(t, output, actualResult)
 
+	actualResult, actualStatus = oracle.Precompile(addr, input, alternateRequiredGas)
+	require.True(t, actualStatus)
+	require.EqualValues(t, alternateOutput, actualResult)
+
 	// Later calls should retrieve from cache
 	delete(stub.PcmpResults, key)
+	delete(stub.PcmpResults, alternateKey)
 	actualResult, actualStatus = oracle.Precompile(addr, input, requiredGas)
 	require.True(t, actualStatus)
 	require.EqualValues(t, output, actualResult)
+
+	actualResult, actualStatus = oracle.Precompile(addr, input, alternateRequiredGas)
+	require.True(t, actualStatus)
+	require.EqualValues(t, alternateOutput, actualResult)
 }

--- a/op-program/client/l1/oracle.go
+++ b/op-program/client/l1/oracle.go
@@ -119,8 +119,7 @@ func (p *PreimageOracle) GetBlob(ref eth.L1BlockRef, blobHash common.Hash) *eth.
 }
 
 func (p *PreimageOracle) Precompile(address common.Address, input []byte, requiredGas uint64) ([]byte, bool) {
-	hintBytes := append(address.Bytes(), binary.BigEndian.AppendUint64(nil, requiredGas)...)
-	hintBytes = append(hintBytes, input...)
+	hintBytes := precompileKeyInput(address, input, requiredGas)
 	p.hint.Hint(PrecompileHintV2(hintBytes))
 	key := preimage.PrecompileKey(crypto.Keccak256Hash(hintBytes))
 	result := p.oracle.Get(key)
@@ -128,6 +127,14 @@ func (p *PreimageOracle) Precompile(address common.Address, input []byte, requir
 		panic(fmt.Sprintf("unexpected precompile oracle behavior, got result: %x", result))
 	}
 	return result[1:], result[0] == 1
+}
+
+func precompileKeyInput(address common.Address, input []byte, requiredGas uint64) []byte {
+	keyInput := make([]byte, 0, common.AddressLength+8+len(input))
+	keyInput = append(keyInput, address.Bytes()...)
+	keyInput = binary.BigEndian.AppendUint64(keyInput, requiredGas)
+	keyInput = append(keyInput, input...)
+	return keyInput
 }
 
 var RootsOfUnity *[4096]fr.Element


### PR DESCRIPTION
**Description**

The L1 caching oracle now keys precompile results with the same `address || requiredGas || input` payload used by `PreimageOracle`. This avoids reusing a cached result across calls that share the same address and input but require different oracle gas.

**Tests**

Added coverage in `TestCachingOracle_Precompile` for two calls with identical address/input and different `requiredGas`, and ran `go test ./op-program/client/l1/...`.