### PR TITLE
fix(justfile): correct paths to vendored Rust workspaces in build-rust-release

### DIFF
--- a/justfile
+++ b/justfile
@@ -346,8 +346,8 @@ update-op-geth:
 # Build all Rust binaries (release) for sysgo tests.
 build-rust-release:
   cd rust && cargo build --release --bin kona-node --bin kona-host --bin op-reth
-  cd op-rbuilder && cargo build --release -p op-rbuilder --bin op-rbuilder
-  cd rollup-boost && cargo build --release -p rollup-boost --bin rollup-boost
+  cd rust/op-rbuilder && cargo build --release -p op-rbuilder --bin op-rbuilder
+  cd rust/rollup-boost && cargo build --release -p rollup-boost --bin rollup-boost
 
 # Checks that locked NUT bundles have not been modified.
 check-nut-locks:


### PR DESCRIPTION
`op-rbuilder` and `rollup-boost` live under `rust/`, so the existing `cd op-rbuilder` / `cd rollup-boost` lines fail with *No such file or directory* and `just build-deps` in op-acceptance-tests never produces the op-rbuilder or rollup-boost binaries. Updates the paths to `rust/op-rbuilder` and `rust/rollup-boost`.

Verified locally by running `just build-deps` in `op-acceptance-tests/` to completion against `origin/develop`; all five Rust binaries are produced.