### PR TITLE
check-karst: wire EIP-7934 and EIP-7825-deposit checks into CheckAll

### DIFF
--- a/op-chain-ops/cmd/check-karst/karsttest/checks.go
+++ b/op-chain-ops/cmd/check-karst/karsttest/checks.go
@@ -386,13 +386,13 @@ type LatestBlockFetcher interface {
 // Tx data size is a strict lower bound on RLP-encoded block size, so observing
 // txData > MaxBlockSize proves the block exceeds the limit. The check is
 // contingent on chain traffic — on a quiet chain it will block forever, so
-// it is not wired into `CheckAll`; callers control the deadline via `ctx`.
-// Returns the L2 block number where the oversized block was observed.
+// callers must bound the wait via `ctx`. Returns the L2 block number where
+// the oversized block was observed.
 func CheckEIP7934BlockSizeDisabled(
 	ctx context.Context,
 	logger log.Logger,
 	l2 LatestBlockFetcher,
-	pollInterval time.Duration,
+	blockTime time.Duration,
 ) error {
 	for {
 		info, txs, err := l2.InfoAndTxsByLabel(ctx, eth.Unsafe)
@@ -418,15 +418,29 @@ func CheckEIP7934BlockSizeDisabled(
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(pollInterval):
+		case <-time.After(blockTime):
 		}
 	}
+}
+
+type L2 interface {
+	apis.EthCode
+	apis.ReceiptFetcher
+	InfoAndTxsByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, types.Transactions, error)
 }
 
 // CheckAll runs every implemented post-Karst check in sequence. It is intended
 // for the CLI; the acceptance test invokes individual Check functions per
 // sub-test so each can run in parallel and gate its own kona-host cross-check.
-func CheckAll(ctx context.Context, logger log.Logger, l2 apis.EthCode, basePlan txplan.Option) error {
+func CheckAll(
+	ctx context.Context,
+	logger log.Logger,
+	l2 L2,
+	basePlan txplan.Option,
+	portalAddr, l1Sender common.Address,
+	l1Plan txplan.Option,
+	depositAmount eth.ETH,
+) error {
 	logger.Info("starting Karst checks")
 	if _, _, err := CheckEIP7823(ctx, logger, basePlan); err != nil {
 		return fmt.Errorf("EIP-7823: %w", err)
@@ -442,6 +456,12 @@ func CheckAll(ctx context.Context, logger log.Logger, l2 apis.EthCode, basePlan 
 	}
 	if err := CheckEIP7825(ctx, logger, basePlan); err != nil {
 		return fmt.Errorf("EIP-7825: %w", err)
+	}
+	if _, err := CheckEIP7825DepositBypass(ctx, logger, l2, portalAddr, l1Sender, l1Plan, depositAmount); err != nil {
+		return fmt.Errorf("EIP-7825-deposit: %w", err)
+	}
+	if err := CheckEIP7934BlockSizeDisabled(ctx, logger, l2, 2*time.Second); err != nil {
+		return fmt.Errorf("EIP-7934: %w", err)
 	}
 	logger.Info("completed all Karst checks successfully")
 	return nil

--- a/op-chain-ops/cmd/check-karst/main.go
+++ b/op-chain-ops/cmd/check-karst/main.go
@@ -129,16 +129,42 @@ func makeCommand(name string, fn CheckAction) *cli.Command {
 }
 
 func makeAllCommand() *cli.Command {
+	flags := append(makeFlags(), EndpointL1, L1AccountKey, PortalAddress)
 	return &cli.Command{
 		Name:  "all",
-		Flags: cliapp.ProtectFlags(makeFlags()),
+		Flags: cliapp.ProtectFlags(flags),
 		Action: func(c *cli.Context) error {
 			env, err := resolveEnv(c)
 			if err != nil {
 				return err
 			}
 			defer env.close()
-			if err := karsttest.CheckAll(env.ctx, env.logger, env.l2, env.basePlan); err != nil {
+
+			l1Cl, err := ethclient.DialContext(env.ctx, c.String(EndpointL1.Name))
+			if err != nil {
+				return fmt.Errorf("dial L1: %w", err)
+			}
+			defer l1Cl.Close()
+
+			l1Key, err := crypto.HexToECDSA(strings.TrimPrefix(c.String(L1AccountKey.Name), "0x"))
+			if err != nil {
+				return fmt.Errorf("parse L1 account: %w", err)
+			}
+
+			portalHex := c.String(PortalAddress.Name)
+			if !common.IsHexAddress(portalHex) {
+				return fmt.Errorf("--portal must be a hex address, got %q", portalHex)
+			}
+
+			if err := karsttest.CheckAll(
+				env.ctx, env.logger,
+				&ethclientLatestBlockAdapter{env.l2},
+				env.basePlan,
+				common.HexToAddress(portalHex),
+				crypto.PubkeyToAddress(l1Key.PublicKey),
+				karsttest.NewBasePlan(l1Cl, l1Key),
+				eth.OneHundredthEther,
+			); err != nil {
 				return fmt.Errorf("command error: %w", err)
 			}
 			return nil
@@ -164,19 +190,12 @@ func (a *ethclientLatestBlockAdapter) InfoAndTxsByLabel(ctx context.Context, lab
 
 // makeBlockSizeCommand wires up the EIP-7934 block-size-disabled check.
 // Unlike the EVM-level checks, it polls latest blocks for one whose tx data
-// exceeds MaxBlockSize, so it gets a configurable poll interval. Callers
-// control the deadline via Ctrl+C (which cancels the interrupt-aware ctx).
+// exceeds MaxBlockSize. Callers control the deadline via Ctrl+C
+// (which cancels the interrupt-aware ctx).
 func makeBlockSizeCommand() *cli.Command {
-	pollInterval := &cli.DurationFlag{
-		Name:    "poll-interval",
-		Usage:   "How often to fetch the latest L2 block",
-		EnvVars: op_service.PrefixEnvVar(prefix, "POLL_INTERVAL"),
-		Value:   2 * time.Second,
-	}
-	flags := append(makeFlags(), pollInterval)
 	return &cli.Command{
 		Name:  "eip-7934",
-		Flags: cliapp.ProtectFlags(flags),
+		Flags: cliapp.ProtectFlags(makeFlags()),
 		Action: func(c *cli.Context) error {
 			env, err := resolveEnv(c)
 			if err != nil {
@@ -186,7 +205,7 @@ func makeBlockSizeCommand() *cli.Command {
 			if err := karsttest.CheckEIP7934BlockSizeDisabled(
 				env.ctx, env.logger,
 				&ethclientLatestBlockAdapter{env.l2},
-				c.Duration(pollInterval.Name),
+				2*time.Second,
 			); err != nil {
 				return fmt.Errorf("command error: %w", err)
 			}


### PR DESCRIPTION
CheckAll now invokes every post-Karst check in sequence, including the block-size-disabled poll and the deposit-bypass check that previously existed only as dedicated subcommands. The `all` subcommand now requires the L1 flags (--l1, --l1-account, --portal) since the deposit check needs L1 access; the L2 interface gains apis.ReceiptFetcher for the deposit-receipt poll. The osaka_on_l2_test caller is updated for the 3-arg CheckEIP7934BlockSizeDisabled signature.