### PR TITLE
fix(op-supernode/interop): stop FinalizedL2 regressing to genesis across activation

### DIFF
--- a/op-acceptance-tests/tests/interop/upgrade/finalized_activation_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/finalized_activation_test.go
@@ -59,11 +59,8 @@ func TestFinalizedL2DoesNotRegressAcrossActivation(gt *testing.T) {
 	// +1 so the head must be strictly past activation, not merely at the
 	// activation block. Stopping at the activation block could miss the
 	// regression window that opens once LocalSafeL2 crosses the boundary.
-	// Poll interval is 100ms (see ReachedTimeWithoutRegressionFn); 6000 attempts
-	// gives a 10-minute observation window, comfortably exceeding the FakePoS
-	// L1 finality lag plus the activation delay.
 	dsl.CheckAll(t,
-		sys.L2ACL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeA+1, 6000),
-		sys.L2BCL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeB+1, 6000),
+		sys.L2ACL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeA+1),
+		sys.L2BCL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeB+1),
 	)
 }

--- a/op-acceptance-tests/tests/interop/upgrade/finalized_activation_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/finalized_activation_test.go
@@ -13,34 +13,8 @@ import (
 )
 
 // TestFinalizedL2DoesNotRegressAcrossActivation reproduces #20365.
-//
-// During interop activation, `optimism_syncStatus.finalized_l2` could briefly
-// snap back to genesis (block 0) before recovering. Once LocalSafeL2 crosses
-// activation, super_authority stops falling back to local-finalized, but the
-// verifier has nothing useful to say about finalization until its first
-// post-activation entry is both written and L1-finalized. In that gap, the
-// layer above interprets the verifier's empty answer as "no information" and
-// resolves FinalizedL2 to genesis.
-//
-// The test trap, also documented in #20365: the FakePoS preset finalizes L1
-// with a 20-block lag (~120s at the default 6s L1 block time). If the
-// activation delay sits inside that lag, the pre-activation FinalizedL2
-// snapshot is itself 0, and a naive `now >= before` monotonicity check passes
-// vacuously even when FinalizedL2 regresses to genesis — 0 >= 0. To avoid this:
-//
-//  1. Use an activation delay (240s) that comfortably exceeds the FakePoS L1
-//     finality lag (120s), so a real post-genesis block becomes L1-finalized
-//     before activation lands. A future preset change that shrinks the
-//     activation delay back into the finality window would re-vacuum the
-//     assertion; the explicit value here is the load-bearing precondition.
-//  2. Wait for FinalizedL2 > 0 on every chain before snapshotting the
-//     baseline. This guarantees the monotonicity check has something real to
-//     compare against.
-//  3. Drive monitoring with the interop activation timestamp as the explicit
-//     target. ReachedTimeWithoutRegressionFn refuses to run with a zero
-//     baseline, refuses to run if the head is already past the boundary, and
-//     fails immediately on any regression below the baseline while waiting
-//     for the head to cross activation.
+// The 240s activation delay must exceed the FakePoS L1 finality lag (~120s)
+// so the pre-activation FinalizedL2 baseline is non-zero.
 func TestFinalizedL2DoesNotRegressAcrossActivation(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := presets.NewTwoL2SupernodeInterop(t, 240)
@@ -56,9 +30,7 @@ func TestFinalizedL2DoesNotRegressAcrossActivation(gt *testing.T) {
 		sys.L2BCL.ReachedFn(safety.Finalized, 1, 120),
 	)
 
-	// +1 so the head must be strictly past activation, not merely at the
-	// activation block. Stopping at the activation block could miss the
-	// regression window that opens once LocalSafeL2 crosses the boundary.
+	// +1 so the head must be strictly past activation.
 	dsl.CheckAll(t,
 		sys.L2ACL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeA+1),
 		sys.L2BCL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeB+1),

--- a/op-acceptance-tests/tests/interop/upgrade/finalized_activation_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/finalized_activation_test.go
@@ -1,0 +1,69 @@
+//go:build !ci
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
+)
+
+// TestFinalizedL2DoesNotRegressAcrossActivation reproduces #20365.
+//
+// During interop activation, `optimism_syncStatus.finalized_l2` could briefly
+// snap back to genesis (block 0) before recovering. Once LocalSafeL2 crosses
+// activation, super_authority stops falling back to local-finalized, but the
+// verifier has nothing useful to say about finalization until its first
+// post-activation entry is both written and L1-finalized. In that gap, the
+// layer above interprets the verifier's empty answer as "no information" and
+// resolves FinalizedL2 to genesis.
+//
+// The test trap, also documented in #20365: the FakePoS preset finalizes L1
+// with a 20-block lag (~120s at the default 6s L1 block time). If the
+// activation delay sits inside that lag, the pre-activation FinalizedL2
+// snapshot is itself 0, and a naive `now >= before` monotonicity check passes
+// vacuously even when FinalizedL2 regresses to genesis — 0 >= 0. To avoid this:
+//
+//  1. Use an activation delay (240s) that comfortably exceeds the FakePoS L1
+//     finality lag (120s), so a real post-genesis block becomes L1-finalized
+//     before activation lands. A future preset change that shrinks the
+//     activation delay back into the finality window would re-vacuum the
+//     assertion; the explicit value here is the load-bearing precondition.
+//  2. Wait for FinalizedL2 > 0 on every chain before snapshotting the
+//     baseline. This guarantees the monotonicity check has something real to
+//     compare against.
+//  3. Drive monitoring with the interop activation timestamp as the explicit
+//     target. ReachedTimeWithoutRegressionFn refuses to run with a zero
+//     baseline, refuses to run if the head is already past the boundary, and
+//     fails immediately on any regression below the baseline while waiting
+//     for the head to cross activation.
+func TestFinalizedL2DoesNotRegressAcrossActivation(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewTwoL2SupernodeInterop(t, 240)
+	require := t.Require()
+
+	interopTimeA := sys.L2A.Escape().ChainConfig().InteropTime
+	interopTimeB := sys.L2B.Escape().ChainConfig().InteropTime
+	require.NotNil(interopTimeA, "L2A must have InteropTime configured")
+	require.NotNil(interopTimeB, "L2B must have InteropTime configured")
+
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedFn(safety.Finalized, 1, 120),
+		sys.L2BCL.ReachedFn(safety.Finalized, 1, 120),
+	)
+
+	// +1 so the head must be strictly past activation, not merely at the
+	// activation block. Stopping at the activation block could miss the
+	// regression window that opens once LocalSafeL2 crosses the boundary.
+	// Poll interval is 100ms (see ReachedTimeWithoutRegressionFn); 6000 attempts
+	// gives a 10-minute observation window, comfortably exceeding the FakePoS
+	// L1 finality lag plus the activation delay.
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeA+1, 6000),
+		sys.L2BCL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeB+1, 6000),
+	)
+}

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -314,26 +314,10 @@ func (cl *L2CLNode) ReachedRefFn(lvl safety.Level, target eth.BlockID, attempts 
 	}
 }
 
-// ReachedTimeWithoutRegressionFn watches the given safety head until its block
-// timestamp reaches targetTime, failing immediately if the head's block number
-// ever drops below its starting value during the wait.
-//
-// The initial head must be non-zero. A zero baseline makes a regression to
-// genesis indistinguishable from "head never advanced" — a `now >= before`
-// check against a baseline of 0 always passes (0 >= 0), which is the failure
-// mode that motivated this helper. Callers must wait for the head to advance
-// past genesis before invoking, e.g. via ReachedFn(lvl, 1, ...).
-//
-// The initial head's timestamp must also be strictly before targetTime,
-// otherwise the check completes immediately and observes nothing across the
-// boundary. Callers should pick targetTime as a value the head has not yet
-// reached at snapshot time (e.g. a fork activation timestamp).
-//
-// Poll interval is 100ms so a brief regression cannot slip between polls.
-// The total wait is derived from targetTime: enough wall-clock time for the
-// head to reach targetTime plus a generous buffer that absorbs the L1 finality
-// lag (relevant for safety.Finalized) and ordinary test-runner slowness. The
-// helper also honours cl.ctx, so the surrounding test timeout still applies.
+// ReachedTimeWithoutRegressionFn waits for the head's block timestamp to reach
+// targetTime, failing on any regression. Requires a non-zero baseline behind
+// targetTime so a regression to genesis isn't vacuous (0 >= 0). Polls every
+// 100ms; deadline is targetTime + 5min.
 func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime uint64) CheckFunc {
 	return func() error {
 		initial, err := cl.headBlockRef(lvl)
@@ -346,15 +330,11 @@ func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime 
 		if initial.Time >= targetTime {
 			return fmt.Errorf("initial %s head time %d already at or past target %d; nothing to observe across the boundary", lvl, initial.Time, targetTime)
 		}
-		// Deadline is the target wall-clock time plus a 5-minute buffer that
-		// absorbs the L1 finality lag and ordinary test-runner slowness.
 		const buffer = 5 * time.Minute
 		deadline := time.Unix(int64(targetTime), 0).Add(buffer)
 		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "initial", initial.Number, "initial_time", initial.Time, "target_time", targetTime, "deadline", deadline)
 		logger.Info("Watching head for regression until target time reached")
-		// Tight 100ms poll so a brief regression cannot slip between
-		// observations. Capture any regression in regressionErr and end the
-		// wait early by returning true; the post-Eventuallyf check surfaces it.
+		// End the wait early on regression by returning true; surfaced below.
 		var regressionErr error
 		cl.require.Eventuallyf(func() bool {
 			head, err := cl.headBlockRef(lvl)

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -352,30 +352,26 @@ func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime 
 		deadline := time.Unix(int64(targetTime), 0).Add(buffer)
 		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "initial", initial.Number, "initial_time", initial.Time, "target_time", targetTime, "deadline", deadline)
 		logger.Info("Watching head for regression until target time reached")
-		for {
-			if cl.ctx.Err() != nil {
-				return cl.ctx.Err()
-			}
-			if time.Now().After(deadline) {
-				return fmt.Errorf("%s head did not reach target time %d before deadline %s (initial=%d)",
-					lvl, targetTime, deadline, initial.Number)
-			}
-			time.Sleep(100 * time.Millisecond) // nosemgrep: flake-sleep-in-test -- tight poll deliberately chosen so a brief FinalizedL2 regression cannot slip between observations
+		// Tight 100ms poll so a brief regression cannot slip between
+		// observations. Capture any regression in regressionErr and end the
+		// wait early by returning true; the post-Eventuallyf check surfaces it.
+		var regressionErr error
+		cl.require.Eventuallyf(func() bool {
 			head, err := cl.headBlockRef(lvl)
 			if err != nil {
 				logger.Warn("SyncStatus RPC failed; will retry", "err", err)
-				continue
+				return false
 			}
 			if head.Number < initial.Number {
-				return fmt.Errorf("%s head regressed: was %d (%s, t=%d), observed %d (%s, t=%d)",
+				regressionErr = fmt.Errorf("%s head regressed: was %d (%s, t=%d), observed %d (%s, t=%d)",
 					lvl, initial.Number, initial.Hash, initial.Time, head.Number, head.Hash, head.Time)
+				return true
 			}
 			logger.Info("Chain sync status", "current", head.Number, "current_time", head.Time)
-			if head.Time >= targetTime {
-				logger.Info("Head reached target time without regression", "final", head.Number, "final_time", head.Time)
-				return nil
-			}
-		}
+			return head.Time >= targetTime
+		}, time.Until(deadline), 100*time.Millisecond,
+			"%s head did not reach target time %d (initial=%d)", lvl, targetTime, initial.Number)
+		return regressionErr
 	}
 }
 

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -346,15 +346,10 @@ func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime 
 		if initial.Time >= targetTime {
 			return fmt.Errorf("initial %s head time %d already at or past target %d; nothing to observe across the boundary", lvl, initial.Time, targetTime)
 		}
-		// Wall-clock budget: long enough for the head to reach targetTime,
-		// plus 5 minutes to absorb the L1 finality lag and slow runners.
-		now := time.Now().Unix()
+		// Deadline is the target wall-clock time plus a 5-minute buffer that
+		// absorbs the L1 finality lag and ordinary test-runner slowness.
 		const buffer = 5 * time.Minute
-		var remainingToTarget time.Duration
-		if int64(targetTime) > now {
-			remainingToTarget = time.Duration(int64(targetTime)-now) * time.Second
-		}
-		deadline := time.Now().Add(remainingToTarget + buffer)
+		deadline := time.Unix(int64(targetTime), 0).Add(buffer)
 		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "initial", initial.Number, "initial_time", initial.Time, "target_time", targetTime, "deadline", deadline)
 		logger.Info("Watching head for regression until target time reached")
 		for {

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -329,9 +329,12 @@ func (cl *L2CLNode) ReachedRefFn(lvl safety.Level, target eth.BlockID, attempts 
 // boundary. Callers should pick targetTime as a value the head has not yet
 // reached at snapshot time (e.g. a fork activation timestamp).
 //
-// Poll interval is 100ms so a brief regression cannot slip between polls;
-// total observation window is bounded by attempts*100ms.
-func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime uint64, attempts int) CheckFunc {
+// Poll interval is 100ms so a brief regression cannot slip between polls.
+// The total wait is derived from targetTime: enough wall-clock time for the
+// head to reach targetTime plus a generous buffer that absorbs the L1 finality
+// lag (relevant for safety.Finalized) and ordinary test-runner slowness. The
+// helper also honours cl.ctx, so the surrounding test timeout still applies.
+func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime uint64) CheckFunc {
 	return func() error {
 		initial, err := cl.headBlockRef(lvl)
 		if err != nil {
@@ -343,11 +346,24 @@ func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime 
 		if initial.Time >= targetTime {
 			return fmt.Errorf("initial %s head time %d already at or past target %d; nothing to observe across the boundary", lvl, initial.Time, targetTime)
 		}
-		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "initial", initial.Number, "initial_time", initial.Time, "target_time", targetTime)
+		// Wall-clock budget: long enough for the head to reach targetTime,
+		// plus 5 minutes to absorb the L1 finality lag and slow runners.
+		now := time.Now().Unix()
+		const buffer = 5 * time.Minute
+		var remainingToTarget time.Duration
+		if int64(targetTime) > now {
+			remainingToTarget = time.Duration(int64(targetTime)-now) * time.Second
+		}
+		deadline := time.Now().Add(remainingToTarget + buffer)
+		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "initial", initial.Number, "initial_time", initial.Time, "target_time", targetTime, "deadline", deadline)
 		logger.Info("Watching head for regression until target time reached")
-		for range attempts {
+		for {
 			if cl.ctx.Err() != nil {
 				return cl.ctx.Err()
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("%s head did not reach target time %d before deadline %s (initial=%d)",
+					lvl, targetTime, deadline, initial.Number)
 			}
 			time.Sleep(100 * time.Millisecond) // nosemgrep: flake-sleep-in-test -- tight poll deliberately chosen so a brief FinalizedL2 regression cannot slip between observations
 			head, err := cl.headBlockRef(lvl)
@@ -365,8 +381,6 @@ func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime 
 				return nil
 			}
 		}
-		return fmt.Errorf("%s head did not reach target time %d within %d attempts (initial=%d)",
-			lvl, targetTime, attempts, initial.Number)
 	}
 }
 

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -314,6 +314,62 @@ func (cl *L2CLNode) ReachedRefFn(lvl safety.Level, target eth.BlockID, attempts 
 	}
 }
 
+// ReachedTimeWithoutRegressionFn watches the given safety head until its block
+// timestamp reaches targetTime, failing immediately if the head's block number
+// ever drops below its starting value during the wait.
+//
+// The initial head must be non-zero. A zero baseline makes a regression to
+// genesis indistinguishable from "head never advanced" — a `now >= before`
+// check against a baseline of 0 always passes (0 >= 0), which is the failure
+// mode that motivated this helper. Callers must wait for the head to advance
+// past genesis before invoking, e.g. via ReachedFn(lvl, 1, ...).
+//
+// The initial head's timestamp must also be strictly before targetTime,
+// otherwise the check completes immediately and observes nothing across the
+// boundary. Callers should pick targetTime as a value the head has not yet
+// reached at snapshot time (e.g. a fork activation timestamp).
+//
+// Poll interval is 100ms so a brief regression cannot slip between polls;
+// total observation window is bounded by attempts*100ms.
+func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime uint64, attempts int) CheckFunc {
+	return func() error {
+		initial, err := cl.headBlockRef(lvl)
+		if err != nil {
+			return fmt.Errorf("read initial %s head: %w", lvl, err)
+		}
+		if initial.Number == 0 {
+			return fmt.Errorf("initial %s head is at genesis; cannot detect regression below zero — wait for the head to advance past genesis before snapshotting", lvl)
+		}
+		if initial.Time >= targetTime {
+			return fmt.Errorf("initial %s head time %d already at or past target %d; nothing to observe across the boundary", lvl, initial.Time, targetTime)
+		}
+		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "initial", initial.Number, "initial_time", initial.Time, "target_time", targetTime)
+		logger.Info("Watching head for regression until target time reached")
+		for range attempts {
+			if cl.ctx.Err() != nil {
+				return cl.ctx.Err()
+			}
+			time.Sleep(100 * time.Millisecond) // nosemgrep: flake-sleep-in-test -- tight poll deliberately chosen so a brief FinalizedL2 regression cannot slip between observations
+			head, err := cl.headBlockRef(lvl)
+			if err != nil {
+				logger.Warn("SyncStatus RPC failed; will retry", "err", err)
+				continue
+			}
+			if head.Number < initial.Number {
+				return fmt.Errorf("%s head regressed: was %d (%s, t=%d), observed %d (%s, t=%d)",
+					lvl, initial.Number, initial.Hash, initial.Time, head.Number, head.Hash, head.Time)
+			}
+			logger.Info("Chain sync status", "current", head.Number, "current_time", head.Time)
+			if head.Time >= targetTime {
+				logger.Info("Head reached target time without regression", "final", head.Number, "final_time", head.Time)
+				return nil
+			}
+		}
+		return fmt.Errorf("%s head did not reach target time %d within %d attempts (initial=%d)",
+			lvl, targetTime, attempts, initial.Number)
+	}
+}
+
 // RewindedFn returns a lambda that checks the L2CL chain head with given safety level rewinded more than the delta block number
 // Composable with other lambdas to wait in parallel
 func (cl *L2CLNode) RewindedFn(lvl safety.Level, delta uint64, attempts int) CheckFunc {

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -71,9 +71,11 @@ func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
 		return eth.BlockID{}, true
 	}
 
-	// FinalizedL2 <= LocalSafeL2; if local-safe is pre-activation, so is finalized.
-	if c.allVerifiersPreActivationAt(ss.LocalSafeL2.Time) {
-		c.log.Debug("FinalizedL2Head: all verifiers pre-activation, signaling local-finalized fallback", "localSafeTime", ss.LocalSafeL2.Time)
+	// While FinalizedL2 is pre-activation, no verifier yet has authority over
+	// finalization. Gating on LocalSafeL2 stops firing once it crosses
+	// activation, regressing FinalizedL2 to genesis (#20365).
+	if c.allVerifiersPreActivationAt(ss.FinalizedL2.Time) {
+		c.log.Debug("FinalizedL2Head: all verifiers pre-activation, signaling local-finalized fallback", "finalizedL2Time", ss.FinalizedL2.Time)
 		return eth.BlockID{}, true
 	}
 

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -494,6 +494,7 @@ func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierNoFallback(t
 	setSyncStatus(t, cc, &eth.SyncStatus{
 		FinalizedL1: eth.L1BlockRef{Number: 400},
 		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
+		FinalizedL2: eth.L2BlockRef{Number: 550, Hash: [32]byte{0xee}, Time: 1400},
 	})
 
 	verifier := &mockVerificationActivityForSuperAuthority{
@@ -515,6 +516,7 @@ func TestChainContainer_FinalizedL2Head_PostActivation_FinalizedBlockReturned(t 
 	setSyncStatus(t, cc, &eth.SyncStatus{
 		FinalizedL1: eth.L1BlockRef{Number: 400},
 		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
+		FinalizedL2: eth.L2BlockRef{Number: 550, Hash: [32]byte{0xee}, Time: 1400},
 	})
 
 	finalizedBlock := eth.BlockID{Hash: [32]byte{0x22}, Number: 100}
@@ -550,6 +552,30 @@ func TestChainContainer_FinalizedL2Head_AllPreActivation_FallsBackToLocalFinaliz
 	require.True(t, useLocalFinalized, "all-pre-activation should signal fallback to local-finalized")
 }
 
+// TestChainContainer_FinalizedL2Head_FinalizedPreActivationButLocalSafePost
+// covers #20365: once LocalSafeL2 has crossed activation but FinalizedL2 is
+// still pre-activation, the verifier has nothing to say about finalization
+// yet and the fallback to local-finalized must remain active.
+func TestChainContainer_FinalizedL2Head_FinalizedPreActivationButLocalSafePost(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
+		FinalizedL2: eth.L2BlockRef{Number: 100, Hash: [32]byte{0xaa}, Time: 999},
+	})
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, eth.BlockID{}, result)
+	require.True(t, useLocalFinalized, "pre-activation FinalizedL2 must keep the local-finalized fallback active")
+}
+
 func TestChainContainer_FinalizedL2Head_VerifierError_SignalsLocalFinalizedFallback(t *testing.T) {
 	t.Parallel()
 
@@ -557,6 +583,7 @@ func TestChainContainer_FinalizedL2Head_VerifierError_SignalsLocalFinalizedFallb
 	setSyncStatus(t, cc, &eth.SyncStatus{
 		FinalizedL1: eth.L1BlockRef{Number: 400},
 		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
+		FinalizedL2: eth.L2BlockRef{Number: 550, Hash: [32]byte{0xee}, Time: 1400},
 	})
 
 	verifier := &mockVerificationActivityForSuperAuthority{


### PR DESCRIPTION
Fixes ethereum-optimism/optimism#20365.

`FinalizedL2Head` fell back to local-finalized only while `LocalSafeL2` was pre-activation. Once `LocalSafeL2` crossed activation but the verifier had no L1-finalized post-activation entry yet, `FinalizedL2` regressed to genesis until the verifier caught up.

Gating on the currently-published `FinalizedL2` timestamp keeps the fallback active until the verifier actually has authoritative finalized data. Self-correcting: a spurious genesis observation is itself pre-activation and re-fires the fallback on the next forkchoice update.

Includes an acceptance test that crosses the activation boundary with a 240s activation delay (so the pre-activation `FinalizedL2` baseline is non-zero and a regression to genesis can't pass vacuously) and a new `ReachedTimeWithoutRegressionFn` DSL helper.