### PR TITLE
feat(op-node): default syncmode.offset-el-safe to 12h

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -134,11 +134,10 @@ var (
 	SyncModeOffsetELSafeFlag = &cli.DurationFlag{
 		Name: "syncmode.offset-el-safe",
 		Usage: "After execution-layer sync completes, set safe and finalized heads to this duration behind the synced tip " +
-			"(converted to L2 blocks via rollup block time using ceiling division). Default 0 (safe/finalized stay at the tip). " +
-			"Set to e.g. 168h to force derivation of the most recent 7 days of blocks before they are considered safe.",
+			"(converted to L2 blocks via rollup block time using ceiling division). Default 12h, matching the OP Mainnet sequencing window.",
 		EnvVars:  prefixEnvVars("SYNCMODE_OFFSET_EL_SAFE"),
 		Category: RollupCategory,
-		Value:    0,
+		Value:    12 * time.Hour,
 	}
 	RPCAdminPersistence = &cli.StringFlag{
 		Name:     "rpc.admin-state",

--- a/op-node/rollup/sync/config.go
+++ b/op-node/rollup/sync/config.go
@@ -92,9 +92,6 @@ func (c *Config) Check() error {
 	if c.OffsetELSafe < 0 {
 		return errors.New("sync.offset-el-safe must be >= 0")
 	}
-	if c.OffsetELSafe > 0 && c.SyncMode != ELSync {
-		return fmt.Errorf("sync.offset-el-safe is only supported with EL sync (syncmode=%s)", ELSyncString)
-	}
 	return nil
 }
 

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -347,6 +347,7 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 		return nil, err
 	}
 	engineKind := engine.Kind(ctx.String(flags.L2EngineKind.Name))
+	offsetELSafe := ctx.Duration(flags.SyncModeOffsetELSafeFlag.Name)
 	cfg := &sync.Config{
 		SyncMode:                       mode,
 		SyncModeReqResp:                ctx.Bool(flags.SyncModeReqRespFlag.Name),
@@ -355,10 +356,14 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 		L2FollowSourceEndpoint:         l2FollowSourceEndpoint,
 		// Sequencer needs a manual initial reset when follow source
 		NeedInitialResetEngine: ctx.Bool(flags.SequencerEnabledFlag.Name) && l2FollowSourceEndpoint != "",
-		OffsetELSafe:           ctx.Duration(flags.SyncModeOffsetELSafeFlag.Name),
+		OffsetELSafe:           offsetELSafe,
 	}
 	if ctx.Bool(flags.L2EngineSyncEnabled.Name) {
 		cfg.SyncMode = sync.ELSync
+	}
+	if cfg.OffsetELSafe > 0 && cfg.SyncMode != sync.ELSync {
+		log.Warn("syncmode.offset-el-safe is ineffective unless --syncmode=execution-layer; ignoring configured value", "syncmode", cfg.SyncMode.String(), "configured_offset", cfg.OffsetELSafe)
+		cfg.OffsetELSafe = 0
 	}
 	if err := cfg.Check(); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Default `--syncmode.offset-el-safe` from `0` to `12h`, matching the OP Mainnet sequencing window (`SeqWindowSize = 3600` L1 blocks × 12s). Activates the offset mechanism from #19972.
- Drop the `Check()` rejection of a nonzero offset under non-EL sync modes; `NewSyncConfig` now warns and zeros the offset instead, so the new default is non-breaking for CL-sync deployments.

## Background

After EL sync completes, op-node sets `safe = finalized = unsafe tip` without any derivation having validated that range — a correctness bug raised in #17631. #19972 added `--syncmode.offset-el-safe` to retract safe/finalized by a configurable duration and let derivation forward-validate, but it shipped with a `0` default, leaving the bug latent.

## Why 12h

Refer https://github.com/ethereum-optimism/optimism/issues/17631#issuecomment-4090971857

## Related

- Builds on #19972 (offset mechanism)
- Supersedes #20978 (which proposed 168h)
- Fixes #17631