### PR TITLE
fix(op-chain-ops): fix check-prestate after kona monorepo merge

### DIFF
--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -116,8 +116,8 @@ func main() {
 	}
 
 	knownChains := make(map[string]bool)
-	supportedChains := make([]string, 0) // Not null for json serialization
-	outdatedChains := make(map[string]types.OutdatedChain)
+	supportedChains := make([]string, 0)             // Not null for json serialization
+	outdatedChains := make([]types.OutdatedChain, 0) // Not null for json serialization
 	for _, name := range prestateNames {
 		if !chainFilter(name) {
 			continue
@@ -128,10 +128,10 @@ func main() {
 			log.Crit("Failed to check config", "chain", name, "err", err)
 		}
 		if diff != nil {
-			outdatedChains[name] = types.OutdatedChain{
+			outdatedChains = append(outdatedChains, types.OutdatedChain{
 				Name: name,
 				Diff: diff,
-			}
+			})
 		} else {
 			supportedChains = append(supportedChains, name)
 		}
@@ -159,7 +159,7 @@ func main() {
 		ExecutionClient:    elCommitInfo,
 		SuperchainRegistry: commitInfo("superchain-registry", commit, "main", "superchain"),
 		UpToDateChains:     supportedChains,
-		OutdatedChains:     slices.Collect(maps.Values(outdatedChains)),
+		OutdatedChains:     outdatedChains,
 		MissingChains:      missingChains,
 	}
 	encoder := json.NewEncoder(os.Stdout)

--- a/op-chain-ops/cmd/check-prestate/prestate/kona.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/kona.go
@@ -1,10 +1,12 @@
 package prestate
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/registry"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/types"
@@ -27,7 +29,7 @@ func (p *KonaPrestate) FindVersions(log log.Logger, prestateVersion string) (
 
 	prestateTag := fmt.Sprintf("kona-client/v%s", prestateVersion)
 	log.Info("Found prestate tag", "tag", prestateTag)
-	fppCommitInfo = types.NewCommitInfo("op-rs", "kona", prestateTag, "main", "")
+	fppCommitInfo = types.NewCommitInfo("ethereum-optimism", "optimism", prestateTag, "develop", "rust/kona")
 
 	superChainRegistryCommit, err := fetchSuperchainRegistryCommit(prestateTag)
 	if err != nil {
@@ -51,9 +53,16 @@ func (p *KonaPrestate) FindVersions(log log.Logger, prestateVersion string) (
 	return
 }
 
+// fetchSuperchainRegistryCommit returns the superchain-registry commit SHA that the
+// kona-client release identified by ref was built against, by reading the pinned
+// commit file from the optimism monorepo at that tag.
+//
+// Only kona-client tags that have op-core/superchain/superchain-registry-commit.txt
+// are supported (v1.5.1 and later); older tags will return a 404 error.
 func fetchSuperchainRegistryCommit(ref string) (string, error) {
-	endpoint := "https://api.github.com/repos/op-rs/kona/contents/crates/protocol/registry/superchain-registry?ref=" +
-		url.QueryEscape(ref)
+	const path = "op-core/superchain/superchain-registry-commit.txt"
+	endpoint := "https://api.github.com/repos/ethereum-optimism/optimism/contents/" + path +
+		"?ref=" + url.QueryEscape(ref)
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -67,21 +76,31 @@ func fetchSuperchainRegistryCommit(ref string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	// Parse error payloads from GitHub if status != 200.
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to fetch superchain-registry version, http status: %s", resp.Status)
+		return "", fmt.Errorf("failed to fetch superchain-registry version at %s@%s, http status: %s", path, ref, resp.Status)
 	}
 
-	// Success path: expect a single "submodule" content object with "sha".
 	var content struct {
-		Type string `json:"type"` // should be "submodule"
-		SHA  string `json:"sha"`
+		Type     string `json:"type"`
+		Encoding string `json:"encoding"`
+		Content  string `json:"content"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&content); err != nil {
 		return "", fmt.Errorf("decode response: %w", err)
 	}
-	if content.Type != "submodule" {
-		return "", fmt.Errorf("expected a submodule got type %q", content.Type)
+	if content.Type != "file" {
+		return "", fmt.Errorf("expected a file at %s@%s, got type %q", path, ref, content.Type)
 	}
-	return content.SHA, nil
+	if content.Encoding != "base64" {
+		return "", fmt.Errorf("unexpected content encoding %q at %s@%s", content.Encoding, path, ref)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(content.Content)
+	if err != nil {
+		return "", fmt.Errorf("decode base64 content at %s@%s: %w", path, ref, err)
+	}
+	sha := strings.TrimSpace(string(decoded))
+	if sha == "" {
+		return "", fmt.Errorf("empty commit SHA at %s@%s", path, ref)
+	}
+	return sha, nil
 }

--- a/op-chain-ops/cmd/check-prestate/prestate/kona.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/kona.go
@@ -1,11 +1,9 @@
 package prestate
 
 import (
-	"encoding/base64"
-	"encoding/json"
+	"bytes"
 	"fmt"
-	"net/http"
-	"net/url"
+	"os/exec"
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/registry"
@@ -53,54 +51,57 @@ func (p *KonaPrestate) FindVersions(log log.Logger, prestateVersion string) (
 	return
 }
 
-// fetchSuperchainRegistryCommit returns the superchain-registry commit SHA that the
-// kona-client release identified by ref was built against, by reading the pinned
-// commit file from the optimism monorepo at that tag.
+// fetchSuperchainRegistryCommit returns the superchain-registry commit SHA that
+// the kona-client release identified by ref was built against, by reading the
+// pinned commit file from the local optimism monorepo checkout at that tag.
 //
 // Only kona-client tags that have op-core/superchain/superchain-registry-commit.txt
-// are supported (v1.5.1 and later); older tags will return a 404 error.
+// are supported (v1.5.1 and later). If the tag isn't present locally, the
+// function fetches it from origin before giving up.
 func fetchSuperchainRegistryCommit(ref string) (string, error) {
 	const path = "op-core/superchain/superchain-registry-commit.txt"
-	endpoint := "https://api.github.com/repos/ethereum-optimism/optimism/contents/" + path +
-		"?ref=" + url.QueryEscape(ref)
 
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err := ensureRefAvailable(ref); err != nil {
+		return "", err
+	}
+
+	stdout, stderr, err := runGit("show", fmt.Sprintf("%s:%s", ref, path))
 	if err != nil {
-		return "", fmt.Errorf("build request: %w", err)
+		return "", fmt.Errorf("git show %s:%s failed: %w (%s)", ref, path, err, strings.TrimSpace(stderr))
 	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("http request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to fetch superchain-registry version at %s@%s, http status: %s", path, ref, resp.Status)
-	}
-
-	var content struct {
-		Type     string `json:"type"`
-		Encoding string `json:"encoding"`
-		Content  string `json:"content"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&content); err != nil {
-		return "", fmt.Errorf("decode response: %w", err)
-	}
-	if content.Type != "file" {
-		return "", fmt.Errorf("expected a file at %s@%s, got type %q", path, ref, content.Type)
-	}
-	if content.Encoding != "base64" {
-		return "", fmt.Errorf("unexpected content encoding %q at %s@%s", content.Encoding, path, ref)
-	}
-	decoded, err := base64.StdEncoding.DecodeString(content.Content)
-	if err != nil {
-		return "", fmt.Errorf("decode base64 content at %s@%s: %w", path, ref, err)
-	}
-	sha := strings.TrimSpace(string(decoded))
+	sha := strings.TrimSpace(stdout)
 	if sha == "" {
 		return "", fmt.Errorf("empty commit SHA at %s@%s", path, ref)
 	}
 	return sha, nil
+}
+
+// ensureRefAvailable verifies that ref resolves in the local repo; if not, it
+// attempts to fetch the tag from origin.
+func ensureRefAvailable(ref string) error {
+	if refExists(ref) {
+		return nil
+	}
+	refspec := fmt.Sprintf("refs/tags/%s:refs/tags/%s", ref, ref)
+	if _, stderr, err := runGit("fetch", "--quiet", "origin", refspec); err != nil {
+		return fmt.Errorf("ref %q not found locally and git fetch origin %s failed: %w (%s)", ref, refspec, err, strings.TrimSpace(stderr))
+	}
+	if !refExists(ref) {
+		return fmt.Errorf("ref %q still not found after git fetch origin %s", ref, refspec)
+	}
+	return nil
+}
+
+func refExists(ref string) bool {
+	_, _, err := runGit("rev-parse", "--verify", "--quiet", ref+"^{commit}")
+	return err == nil
+}
+
+func runGit(args ...string) (string, string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
 }


### PR DESCRIPTION
The kona project was merged into the optimism monorepo, breaking `check-prestate` for `cannon64-kona` prestates from v1.5.1 onward.

- Look up the superchain-registry commit from `op-core/superchain/superchain-registry-commit.txt` in the optimism monorepo (the file the Go-side build pins), and report the fpp-program diff URL against the monorepo too.
- Initialize `outdated-chains` as an empty slice so reports with no diffs serialize as `[]` not `null` — the latter broke `diff-check.zsh`'s `sort_by`.