### PR TITLE
docs(node-operators): op-geth deprecation pass on overview, consensus-clients, legacy-geth, archive-node

### DIFF
--- a/docs/public-docs/node-operators/guides/configuration/consensus-clients.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/consensus-clients.mdx
@@ -31,7 +31,6 @@ Choose the consensus client that best fits your needs:
       --l1.beacon=https://ethereum-beacon-endpoint.example.com \
       --l2=http://localhost:8551 \
       --l2.jwt-secret=/path/to/jwt-secret.txt \
-      --l2.enginekind=reth \
       --network=op-mainnet \
       --rpc.addr=0.0.0.0 \
       --rpc.port=9545
@@ -57,10 +56,10 @@ Choose the consensus client that best fits your needs:
 
     Controls op-node's engine-API behavior to match the connected execution client. Supported values:
 
-    * `reth` — for op-reth (recommended).
-    * `geth` — current default; for op-geth (*deprecated*, see the [op-geth deprecation notice](/notices/op-geth-deprecation)).
+    * `reth` — default; for op-reth.
+    * `geth` — for op-geth (*deprecated*, see the [op-geth deprecation notice](/notices/op-geth-deprecation)).
 
-    Operators running op-reth **must** set `--l2.enginekind=reth` explicitly. The default will change in a future release.
+    The default is `reth`, so op-reth operators do not need to set this flag. Set `--l2.enginekind=geth` only if you are running op-geth.
 
     ### Complete reference
 

--- a/docs/public-docs/node-operators/guides/configuration/consensus-clients.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/consensus-clients.mdx
@@ -31,6 +31,7 @@ Choose the consensus client that best fits your needs:
       --l1.beacon=https://ethereum-beacon-endpoint.example.com \
       --l2=http://localhost:8551 \
       --l2.jwt-secret=/path/to/jwt-secret.txt \
+      --l2.enginekind=reth \
       --network=op-mainnet \
       --rpc.addr=0.0.0.0 \
       --rpc.port=9545
@@ -41,8 +42,6 @@ Choose the consensus client that best fits your needs:
     If you're running a sequencer node, use these additional flags:
 
     ```bash
-    --rpc.addr=0.0.0.0 \
-    --rpc.port=9545 \
     --rpc.enable-admin \
     --sequencer.enabled \
     --sequencer.l1-confs=4 \
@@ -54,10 +53,14 @@ Choose the consensus client that best fits your needs:
     Use environment variables or secure key management systems in production.
     </Warning>
 
-    ### l2.enginekind 
+    ### l2.enginekind
 
-    The kind of engine client, used to control the behavior of optimism in respect to different types of engine clients. 
-    Supported values are `geth` (default) and `reth`.
+    Controls op-node's engine-API behavior to match the connected execution client. Supported values:
+
+    * `reth` — for op-reth (recommended).
+    * `geth` — current default; for op-geth (*deprecated*, see the [op-geth deprecation notice](/notices/op-geth-deprecation)).
+
+    Operators running op-reth **must** set `--l2.enginekind=reth` explicitly. The default will change in a future release.
 
     ### Complete reference
 
@@ -67,7 +70,7 @@ Choose the consensus client that best fits your needs:
   <Tab title="kona-node">
     ## kona-node configuration
 
-    [kona-node](https://github.com/op-rs/kona/tree/main/bin/node) is an experimental Rust-based implementation of the OP Stack consensus client.
+    [kona-node](https://github.com/ethereum-optimism/optimism/tree/develop/rust/kona/bin/node) is an experimental Rust-based implementation of the OP Stack consensus client.
 
     <Warning>
     kona-node is experimental and may not be production-ready. Use with caution.
@@ -85,18 +88,10 @@ Choose the consensus client that best fits your needs:
       --network=op-mainnet
     ```
 
-    ### JWT secret
-
-    Generate the JWT secret using:
-
-    ```bash
-    openssl rand -hex 32 > jwt-secret.txt
-    ```
-
     ### Additional resources
 
     For more details on kona-node configuration, see:
-    - [kona-node GitHub repository](https://github.com/op-rs/kona/tree/main/bin/node)
+    - [kona-node GitHub repository](https://github.com/ethereum-optimism/optimism/tree/develop/rust/kona/bin/node)
     - [kona documentation](https://op-rs.github.io/kona/)
   </Tab>
 </Tabs>

--- a/docs/public-docs/node-operators/guides/configuration/legacy-geth.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/legacy-geth.mdx
@@ -6,10 +6,18 @@ description: Learn how to configure Legacy Geth for serving historical execution
 Legacy Geth (`l2geth`) is required only for upgraded networks like OP Mainnet to serve historical execution traces from before the Bedrock upgrade.
 If you're running a node that had a chain genesis after the Bedrock upgrade, you do not need Legacy Geth.
 
+<Info>
+Legacy Geth (`l2geth`) is the pre-Bedrock OVM client and is unrelated to op-geth's deprecation. l2geth is required on OP Mainnet archive nodes regardless of which post-Bedrock execution client you run (op-reth or op-geth).
+</Info>
+
+<Info>
+If you need state proofs for post-Bedrock blocks (for example, for withdrawal proving), see the [historical proofs config](/node-operators/reference/op-reth-historical-proof-config) — that's a different feature.
+</Info>
+
 ## Historical execution vs. historical data routing
 
 Only requests for historical execution will be routed to Legacy Geth.
-Everything else will be served by `op-geth` directly.
+Everything else will be served by your execution client directly.
 The term *historical execution* refers to RPC methods that need to execute transactions prior to bedrock (not just read data from the database):
 
 *   `eth_call`
@@ -61,18 +69,35 @@ It is imperative that you specify the `USING_OVM=true` environment variable.
 Failing to specify this will cause `l2geth` to return invalid execution traces or panic at startup.
 </Warning>
 
-### 3. Configure op-geth to route to Legacy Geth
+### 3. Configure your execution client to route to Legacy Geth
 
-Update your op-geth configuration to route historical requests to Legacy Geth:
+Both op-reth and op-geth use the same `--rollup.historicalrpc` flag to route pre-Bedrock execution requests to Legacy Geth.
 
-```bash
-geth \
-  --datadir=/data/optimism \
-  --rollup.historicalrpc=http://localhost:8545 \
-  # ... other flags
-```
+<Tabs>
+  <Tab title="op-reth">
+    ```bash
+    op-reth node \
+      --datadir=/data/optimism \
+      --rollup.historicalrpc=http://localhost:8545 \
+      # ... other flags
+    ```
+  </Tab>
 
-The `--rollup.historicalrpc` flag tells op-geth where to route requests for historical execution.
+  <Tab title="op-geth">
+    <Warning>
+      **op-geth reaches end-of-support on 2026-05-31.** New deployments should use op-reth. See the [op-geth deprecation notice](/notices/op-geth-deprecation).
+    </Warning>
+
+    ```bash
+    geth \
+      --datadir=/data/optimism \
+      --rollup.historicalrpc=http://localhost:8545 \
+      # ... other flags
+    ```
+  </Tab>
+</Tabs>
+
+The `--rollup.historicalrpc` flag tells your execution client where to route requests for historical execution.
 
 ## Environment variables
 
@@ -92,7 +117,7 @@ Legacy Geth accepts the following environment variables:
 ## Historical execution vs. historical data
 
 Only requests for **historical execution** will be routed to Legacy Geth.
-Everything else will be served by op-geth directly.
+Everything else will be served by your execution client directly.
 
 ### Historical execution RPC methods
 
@@ -107,7 +132,7 @@ These methods require transaction execution and are routed to Legacy Geth for pr
 
 ### Historical data RPC methods
 
-These methods only read data from the database and are served by op-geth:
+These methods only read data from the database and are served by your execution client:
 
 - `eth_getBlockByNumber`
 - `eth_getBlockByHash`
@@ -134,8 +159,8 @@ These methods only read data from the database and are served by op-geth:
 
 **Solution**: Verify that `USING_OVM=true` is set and the data directory is complete and uncorrupted
 
-### op-geth not routing to Legacy Geth
+### Execution client not routing to Legacy Geth
 
 **Problem**: Historical execution requests are not being routed to Legacy Geth
 
-**Solution**: Check that `--rollup.historicalrpc` is set on op-geth with the correct URL to Legacy Geth
+**Solution**: Check that `--rollup.historicalrpc` is set on your execution client (op-reth or op-geth) with the correct URL to Legacy Geth

--- a/docs/public-docs/node-operators/guides/management/archive-node.mdx
+++ b/docs/public-docs/node-operators/guides/management/archive-node.mdx
@@ -39,7 +39,6 @@ Set on `op-node`:
 
 ```shell
 --syncmode=execution-layer
---l2.enginekind=reth
 ```
 
 Do not pass any `--prune.*` flags to op-reth.
@@ -61,17 +60,6 @@ Enable archive mode on Nethermind using the archive network configuration:
 <Info>
   Replace `op-mainnet_archive` with the appropriate archive configuration for your network (e.g., `op-sepolia_archive` for OP Sepolia).
 </Info>
-
-### op-erigon
-
-Set on `op-node`:
-
-```shell
---syncmode=execution-layer
---l2.enginekind=erigon
-```
-
-op-erigon operates as an archive node by default; no additional EL flags are required.
 
 ### op-geth
 

--- a/docs/public-docs/node-operators/guides/management/archive-node.mdx
+++ b/docs/public-docs/node-operators/guides/management/archive-node.mdx
@@ -16,6 +16,10 @@ Archive nodes maintain the entire state history of the blockchain, allowing you 
 
 Archive nodes use execution-layer sync but configure the execution client to retain all historical state data instead of pruning it.
 
+<Info>
+Historical proofs are a lighter-weight alternative to a full archive node when you only need cryptographic state proofs (`eth_getProof`) at historical blocks — the typical case is withdrawal proving and fault proof workloads. If you need historical execution (`eth_call`, `debug_trace*`) or arbitrary historical state queries, you still need a full archive node. See the [historical proofs config](/node-operators/reference/op-reth-historical-proof-config).
+</Info>
+
 ## Requirements
 
 *   **OP Mainnet**: Requires the [bedrock datadir](/node-operators/guides/management/snapshots)
@@ -25,34 +29,30 @@ Archive nodes use execution-layer sync but configure the execution client to ret
 
 ## Configuration
 
-### Configuration for op-node
+Each section below shows the full set of flags needed on both `op-node` and your chosen execution client to run as an archive node. The `op-node` flag `--syncmode=execution-layer` is required in all cases and is not the default — it must be explicitly configured.
 
-Set the following flag on `op-node`:
+### op-reth
+
+op-reth retains full state when run without pruning flags, so the standard op-node + op-reth configuration already produces an archive node.
+
+Set on `op-node`:
+
+```shell
+--syncmode=execution-layer
+--l2.enginekind=reth
+```
+
+Do not pass any `--prune.*` flags to op-reth.
+
+### Nethermind
+
+Set on `op-node`:
 
 ```shell
 --syncmode=execution-layer
 ```
 
-<Info>
-  The `--syncmode=execution-layer` flag is not the default setting and must be explicitly configured.
-</Info>
-
-### Configuration for op-geth
-
-Set the following flags on `op-geth`:
-
-```shell
---syncmode=full
---gcmode=archive
-```
-
-<Info>
-  Both flags are not the default settings and must be explicitly configured. The `--syncmode=full` flag ensures every block is executed, and `--gcmode=archive` disables state pruning.
-</Info>
-
-### Configuration for Nethermind
-
-Archive sync can be enabled by using the archive configuration for your network (configurations with `_archive` suffix):
+Enable archive mode on Nethermind using the archive network configuration:
 
 ```shell
 --config op-mainnet_archive
@@ -62,34 +62,38 @@ Archive sync can be enabled by using the archive configuration for your network 
   Replace `op-mainnet_archive` with the appropriate archive configuration for your network (e.g., `op-sepolia_archive` for OP Sepolia).
 </Info>
 
-## Archive mode with alternative clients
+### op-erigon
 
-Alternative execution clients such as `reth` and `op-erigon` are designed as archive nodes by default, which means they always maintain the complete history of the chain. When using these clients with execution-layer sync, they will automatically operate in archive mode.
-
-### Configuration for op-node with reth
-
-Set the following flags on `op-node`:
-
-```shell
---syncmode=execution-layer
---l2.enginekind=reth
-```
-
-<Info>
-  Both flags are not the default setting and must be explicitly configured on `op-node`. `reth` operates as an archive node by default.
-</Info>
-
-### Configuration for op-node with op-erigon
-
-Set the following flags on `op-node`:
+Set on `op-node`:
 
 ```shell
 --syncmode=execution-layer
 --l2.enginekind=erigon
 ```
 
+op-erigon operates as an archive node by default; no additional EL flags are required.
+
+### op-geth
+
+<Warning>
+  **op-geth reaches end-of-support on 2026-05-31 and will not support the L1 Glamsterdam hardfork.** New deployments should use op-reth. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
+</Warning>
+
+Set on `op-node`:
+
+```shell
+--syncmode=execution-layer
+```
+
+Set on `op-geth`:
+
+```shell
+--syncmode=full
+--gcmode=archive
+```
+
 <Info>
-  Both flags are not the default setting and must be explicitly configured on `op-node`. `op-erigon` operates as an archive node by default.
+  Both flags are not the default settings and must be explicitly configured. The `--syncmode=full` flag ensures every block is executed, and `--gcmode=archive` disables state pruning.
 </Info>
 
 ## How archive sync works

--- a/docs/public-docs/node-operators/overview.mdx
+++ b/docs/public-docs/node-operators/overview.mdx
@@ -31,14 +31,18 @@ The following are the most popular implementations:
 For nodes running multiple chains as part of an [interop](/op-stack/interop/explainer) dependency set, deploy the consensus layer as **[op-supernode](/op-stack/interop/supernode)**, which hosts an op-node instance for every chain in one process and adds cross-chain message verification.
 See the [supernode configuration guide](/node-operators/guides/configuration/supernode) for the flag reference.
 
-### Execution Layer 
+### Execution Layer
 
-The execution layer provides the evm execution environment. 
-The following are the most popular implementations:
+The execution layer provides the EVM execution environment.
+The following are the supported implementations:
 
-* **[op-geth](https://github.com/ethereum-optimism/op-geth)** 
-* **[op-reth](https://github.com/ethereum-optimism/optimism/tree/develop/rust/op-reth)**
-* **[Nethermind](https://github.com/NethermindEth/nethermind)** 
+* **[op-reth](https://github.com/ethereum-optimism/optimism/tree/develop/rust/op-reth)** — primary supported execution client.
+* **[Nethermind](https://github.com/NethermindEth/nethermind)** — alternative execution client.
+* **[op-geth](https://github.com/ethereum-optimism/op-geth)** — *deprecated*, end-of-support **2026-05-31**.
+
+<Warning>
+  **op-geth reaches end-of-support on 2026-05-31 and will not support the L1 Glamsterdam hardfork.** New deployments should use op-reth. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
+</Warning>
 
 ## Node Types
 
@@ -50,5 +54,7 @@ Different node types serve different purposes:
 
 ## Next steps
 
-*   [**Run a Node from Docker**](/node-operators/tutorials/node-from-docker)
+*   [**Run a node with Docker**](/node-operators/tutorials/node-from-docker) — recommended path; uses the official op-reth + op-node images.
+*   [**Build and run a node from source**](/node-operators/tutorials/run-node-from-source) — covers op-reth and Nethermind.
 *   [**Supernode configuration**](/node-operators/guides/configuration/supernode) — flag reference for running op-supernode in an interop dependency set.
+*   [**Architecture reference**](/node-operators/reference/architecture/architecture) — deeper detail on the two-client architecture.


### PR DESCRIPTION
Brings four node-operator pages onto the op-reth-first narrative:

Tracks https://github.com/ethereum-optimism/solutions/issues/700.