### PR TITLE
docs(notices): add Upgrade 19 activation dates for Sepolia and Mainnet

### DIFF
--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -10,7 +10,9 @@ Upgrade 19 is a proposed network upgrade for OP Stack chains. It **introduces th
 </Warning>
 
 <Info>
-  Upgrade 19 includes hard fork changes (Osaka on L2, Glamsterdam Defense and hard fork activated L2 Contract upgrades). Node operators must upgrade before the activation timestamp. Activation timestamps for each network will be communicated once finalized.
+  The Upgrade 19 protocol upgrade on **Sepolia OP Stack chains** will be executed on **Wed, Jun 17, 2026 at 16:00:01 UTC** (Unix `1781712001`). On **Mainnet OP Stack chains** the upgrade is planned to optimistically activate on **Wed, Jul 8, 2026 at 16:00:01 UTC** (Unix `1783526401`), depending on Optimism Governance's approval.
+  The upgrade will be executed on the following chains: `OP`, `Soneium`, `Ink`, `Unichain`, `Mode`, `Metal`, and `Zora`.
+  Upgrade 19 includes hard fork changes (Osaka on L2, Glamsterdam Defense and hard fork activated L2 Contract upgrades). Node operators must upgrade before the activation timestamp.
 </Info>
 
 ## What's included in Upgrade 19

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -10,7 +10,7 @@ Upgrade 19 is a proposed network upgrade for OP Stack chains. It **introduces th
 </Warning>
 
 <Info>
-  The Upgrade 19 protocol upgrade on Optimism Governed **Sepolia OP Stack chains** will be activate on **Wed, Jun 17, 2026 at 16:00:01 UTC** (Unix `1781712001`). On **Mainnet OP Stack chains** the upgrade is planned to optimistically activate on **Wed, Jul 8, 2026 at 16:00:01 UTC** (Unix `1783526401`), depending on Optimism Governance's approval.
+  The Upgrade 19 protocol upgrade on Optimism Governed **Sepolia OP Stack chains** will be activated on **Wed, Jun 17, 2026 at 16:00:01 UTC** (`1781712001`). On **Mainnet OP Stack chains** the upgrade is planned to optimistically activate on **Wed, Jul 8, 2026 at 16:00:01 UTC** (`1783526401`), depending on Optimism Governance's approval. The smart contract upgrades are expected to happen the week prior to activation. 
   The upgrade will be executed on the following chains: `OP`, `Soneium`, `Ink`, `Unichain`, `Mode`, `Metal`, and `Zora`.
   Upgrade 19 includes hard fork changes (Osaka on L2, Glamsterdam Defense and hard fork activated L2 Contract upgrades). Node operators must upgrade before the activation timestamp.
 </Info>

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -10,7 +10,7 @@ Upgrade 19 is a proposed network upgrade for OP Stack chains. It **introduces th
 </Warning>
 
 <Info>
-  The Upgrade 19 protocol upgrade on **Sepolia OP Stack chains** will be executed on **Wed, Jun 17, 2026 at 16:00:01 UTC** (Unix `1781712001`). On **Mainnet OP Stack chains** the upgrade is planned to optimistically activate on **Wed, Jul 8, 2026 at 16:00:01 UTC** (Unix `1783526401`), depending on Optimism Governance's approval.
+  The Upgrade 19 protocol upgrade on Optimism Governed **Sepolia OP Stack chains** will be activate on **Wed, Jun 17, 2026 at 16:00:01 UTC** (Unix `1781712001`). On **Mainnet OP Stack chains** the upgrade is planned to optimistically activate on **Wed, Jul 8, 2026 at 16:00:01 UTC** (Unix `1783526401`), depending on Optimism Governance's approval.
   The upgrade will be executed on the following chains: `OP`, `Soneium`, `Ink`, `Unichain`, `Mode`, `Metal`, and `Zora`.
   Upgrade 19 includes hard fork changes (Osaka on L2, Glamsterdam Defense and hard fork activated L2 Contract upgrades). Node operators must upgrade before the activation timestamp.
 </Info>

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -1,16 +1,16 @@
 ---
-title: Upgrade 19 - L2 Contract Manager, Osaka on L2, and Kona Respected Game Type
-description: Learn how to prepare for Upgrade 19.
+title: Upgrade 19 - Karst Hard Fork
+description: Learn how to prepare for the Karst hard fork.
 ---
 
-Upgrade 19 is a proposed network upgrade for OP Stack chains. It **introduces the L2 Contract Manager (L2CM)** enabling governance-approved L2 smart contract upgrades through a new consensus layer mechanism, **promotes `CANNON_KONA` to the respected game type** making the Rust-based `kona-client` the primary fault proof program used for withdrawals, **activates Osaka EIPs on L2** including the EIP-7825 transaction gas limit, and **adds a preemptive Glamsterdam Defense change** reducing the BN256 pairing precompile maximum input size.
+The Karst hard fork is a proposed network upgrade for OP Stack chains. It **introduces the L2 Contract Manager (L2CM)** enabling governance-approved L2 smart contract upgrades through a new consensus layer mechanism, **promotes `CANNON_KONA` to the respected game type** making the Rust-based `kona-client` the primary fault proof program used for withdrawals, **activates Osaka EIPs on L2** including the EIP-7825 transaction gas limit, and **adds a preemptive Glamsterdam Defense change** reducing the BN256 pairing precompile maximum input size.
 
 <Warning>
   **`op-geth` and `op-program` will not support Upgrade 19 / Karst.** Migrate to **`op-reth`** (and **`kona-client`** for fault proofs) before activation. End of Support is **May 31, 2026** — see [End of Support for op-geth and op-program](/notices/op-geth-deprecation).
 </Warning>
 
 <Info>
-  The Upgrade 19 protocol upgrade on Optimism Governed **Sepolia OP Stack chains** will be activated on **Wed, Jun 17, 2026 at 16:00:01 UTC** (`1781712001`). On **Mainnet OP Stack chains** the upgrade is planned to optimistically activate on **Wed, Jul 8, 2026 at 16:00:01 UTC** (`1783526401`), depending on Optimism Governance's approval. The smart contract upgrades are expected to happen the week prior to activation. 
+  The Karst hard fork on Optimism Governed **Sepolia OP Stack chains** will be activated on **Wed, Jun 17, 2026 at 16:00:01 UTC** (`1781712001`). On **Mainnet OP Stack chains** the upgrade is planned to optimistically activate on **Wed, Jul 8, 2026 at 16:00:01 UTC** (`1783526401`), depending on Optimism Governance's approval. The smart contract upgrades are expected to happen the week prior to activation. 
   The upgrade will be executed on the following chains: `OP`, `Soneium`, `Ink`, `Unichain`, `Mode`, `Metal`, and `Zora`.
 </Info>
 

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -12,7 +12,6 @@ Upgrade 19 is a proposed network upgrade for OP Stack chains. It **introduces th
 <Info>
   The Upgrade 19 protocol upgrade on Optimism Governed **Sepolia OP Stack chains** will be activated on **Wed, Jun 17, 2026 at 16:00:01 UTC** (`1781712001`). On **Mainnet OP Stack chains** the upgrade is planned to optimistically activate on **Wed, Jul 8, 2026 at 16:00:01 UTC** (`1783526401`), depending on Optimism Governance's approval. The smart contract upgrades are expected to happen the week prior to activation. 
   The upgrade will be executed on the following chains: `OP`, `Soneium`, `Ink`, `Unichain`, `Mode`, `Metal`, and `Zora`.
-  Upgrade 19 includes hard fork changes (Osaka on L2, Glamsterdam Defense and hard fork activated L2 Contract upgrades). Node operators must upgrade before the activation timestamp.
 </Info>
 
 ## What's included in Upgrade 19


### PR DESCRIPTION
Fills in the Upgrade 19 activation timestamps in `/notices/upgrade-19`: Sepolia on Wed, Jun 17, 2026; Mainnet on Wed, Jul 8, 2026. Lists chains in scope (`OP`, `Soneium`, `Ink`, `Unichain`). Format follows the Upgrade 16a notice.

Component release versions and the cannon64-kona absolute prestate hash remain `TBD` in the same file, pending separate updates as data lands.