### PR TITLE
fix(op-supernode): WAL reset rewind payloads

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -1128,6 +1128,15 @@ func (m *algoMockChain) PayloadByHash(ctx context.Context, hash common.Hash) (*e
 	}
 	return nil, nil
 }
+func (m *algoMockChain) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	return &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: eth.Uint64Quantity(number),
+			Timestamp:   eth.Uint64Quantity(number),
+			BlockHash:   common.BigToHash(new(big.Int).SetUint64(number)),
+		},
+	}, nil
+}
 func (m *algoMockChain) BlockTime() uint64 {
 	if m.blockTimeOverride > 0 {
 		return m.blockTimeOverride

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -862,6 +862,13 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 		return RewindPlan{}, err
 	}
 	if lastTS <= first {
+		if plan.ResetAllChainsTo != nil {
+			payloads, err := i.captureRewindPayloadsAtTimestamp(*plan.ResetAllChainsTo)
+			if err != nil {
+				return RewindPlan{}, fmt.Errorf("capture reset target payloads at %d: %w", *plan.ResetAllChainsTo, err)
+			}
+			plan.TargetPayloads = payloads
+		}
 		return plan, nil
 	}
 
@@ -875,22 +882,78 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 	// Capture each chain's target payload while it is still canonical. Any failure aborts
 	// the build; the decision will be re-evaluated next round.
 	if len(plan.TargetHeads) > 0 {
-		plan.TargetPayloads = make(map[eth.ChainID]*eth.ExecutionPayloadEnvelope, len(plan.TargetHeads))
-		for chainID, head := range plan.TargetHeads {
-			chain, ok := i.chains[chainID]
-			if !ok {
-				return RewindPlan{}, fmt.Errorf("chain %s referenced in target heads but not configured", chainID)
-			}
-			envelope, err := chain.PayloadByHash(i.ctx, head.Hash)
-			if err != nil {
-				return RewindPlan{}, fmt.Errorf("chain %s: fetch target payload %s for rewind to ts=%d: %w",
-					chainID, head.Hash, rewindTargetTS, err)
-			}
-			plan.TargetPayloads[chainID] = envelope
+		payloads, err := i.captureRewindPayloadsForHeads(plan.TargetHeads, rewindTargetTS)
+		if err != nil {
+			return RewindPlan{}, err
 		}
+		plan.TargetPayloads = payloads
 	}
 
 	return plan, nil
+}
+
+func (i *Interop) captureRewindPayloadsForHeads(heads map[eth.ChainID]eth.BlockID, timestamp uint64) (map[eth.ChainID]*eth.ExecutionPayloadEnvelope, error) {
+	if len(heads) == 0 {
+		return nil, nil
+	}
+	payloads := make(map[eth.ChainID]*eth.ExecutionPayloadEnvelope, len(heads))
+	for chainID, head := range heads {
+		chain, ok := i.chains[chainID]
+		if !ok {
+			return nil, fmt.Errorf("chain %s referenced in target heads but not configured", chainID)
+		}
+		envelope, err := chain.PayloadByHash(i.ctx, head.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("chain %s: fetch target payload %s for rewind to ts=%d: %w",
+				chainID, head.Hash, timestamp, err)
+		}
+		if err := validateRewindPayload(chainID, envelope, head.Number, timestamp); err != nil {
+			return nil, err
+		}
+		if envelope.ExecutionPayload.BlockHash != head.Hash {
+			return nil, fmt.Errorf("chain %s: rewind payload hash mismatch: got %s, want %s",
+				chainID, envelope.ExecutionPayload.BlockHash, head.Hash)
+		}
+		payloads[chainID] = envelope
+	}
+	return payloads, nil
+}
+
+func (i *Interop) captureRewindPayloadsAtTimestamp(timestamp uint64) (map[eth.ChainID]*eth.ExecutionPayloadEnvelope, error) {
+	payloads := make(map[eth.ChainID]*eth.ExecutionPayloadEnvelope, len(i.chains))
+	for chainID, chain := range i.chains {
+		number, err := chain.TimestampToBlockNumber(i.ctx, timestamp)
+		if err != nil {
+			return nil, fmt.Errorf("chain %s: compute rewind target number for timestamp %d: %w", chainID, timestamp, err)
+		}
+		envelope, err := chain.PayloadByNumber(i.ctx, number)
+		if err != nil {
+			return nil, fmt.Errorf("chain %s: fetch reset target payload number %d for timestamp %d: %w",
+				chainID, number, timestamp, err)
+		}
+		if err := validateRewindPayload(chainID, envelope, number, timestamp); err != nil {
+			return nil, err
+		}
+		payloads[chainID] = envelope
+	}
+	return payloads, nil
+}
+
+func validateRewindPayload(chainID eth.ChainID, envelope *eth.ExecutionPayloadEnvelope, number uint64, timestamp uint64) error {
+	if envelope == nil || envelope.ExecutionPayload == nil {
+		return fmt.Errorf("chain %s: nil rewind target payload for block %d at timestamp %d",
+			chainID, number, timestamp)
+	}
+	payload := envelope.ExecutionPayload
+	if uint64(payload.BlockNumber) != number {
+		return fmt.Errorf("chain %s: rewind payload number mismatch: got %d, want %d",
+			chainID, uint64(payload.BlockNumber), number)
+	}
+	if uint64(payload.Timestamp) != timestamp {
+		return fmt.Errorf("chain %s: rewind payload timestamp mismatch: got %d, want %d",
+			chainID, uint64(payload.Timestamp), timestamp)
+	}
+	return nil
 }
 
 func (i *Interop) shouldResetEnginesOnRewind(timestamp uint64) (bool, error) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1747,6 +1747,8 @@ type mockChainContainer struct {
 	payloadsByHash        map[common.Hash]*eth.ExecutionPayloadEnvelope
 	payloadByHashErr      error
 	payloadByHashOverride func(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
+	payloadsByNumber      map[uint64]*eth.ExecutionPayloadEnvelope
+	payloadByNumberErr    error
 
 	// OptimisticAt fields
 	optimisticL2    eth.BlockID
@@ -2013,13 +2015,31 @@ func (m *mockChainContainer) PayloadByHash(ctx context.Context, hash common.Hash
 		return nil, m.payloadByHashErr
 	}
 	// Default synthesized payload — satisfies the build path's structural checks
-	// (non-nil envelope, BlockHash matches request) without requiring tests to
-	// populate payloadsByHash for every hash they touch. Tests that need a specific
-	// envelope can set payloadsByHash or payloadByHashOverride.
+	// without requiring tests to populate payloadsByHash for every hash they touch.
+	// Tests often use common.BigToHash(timestamp) as the block hash, so derive the
+	// number and timestamp from the hash value.
+	number := hash.Big().Uint64()
 	return &eth.ExecutionPayloadEnvelope{
 		ExecutionPayload: &eth.ExecutionPayload{
-			BlockHash:  hash,
-			ParentHash: hash, // self-loop is fine for tests that don't inspect parent
+			BlockHash:   hash,
+			ParentHash:  hash, // self-loop is fine for tests that don't inspect parent
+			BlockNumber: eth.Uint64Quantity(number),
+			Timestamp:   eth.Uint64Quantity(number),
+		},
+	}, nil
+}
+func (m *mockChainContainer) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	if env, ok := m.payloadsByNumber[number]; ok {
+		return env, nil
+	}
+	if m.payloadByNumberErr != nil {
+		return nil, m.payloadByNumberErr
+	}
+	return &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: eth.Uint64Quantity(number),
+			Timestamp:   eth.Uint64Quantity(number),
+			BlockHash:   common.BigToHash(new(big.Int).SetUint64(number)),
 		},
 	}, nil
 }
@@ -2552,6 +2572,44 @@ func TestRewindAccepted(t *testing.T) {
 
 		// logsDB should be cleared (no previous frontier to rewind to)
 		require.True(t, trackingDB.clearCalled > 0, "logsDB should be cleared when rewinding to empty")
+	})
+
+	t.Run("full rewind captures reset payloads before clearing verified frontier", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.pruneDeniedResult = map[uint64][]common.Hash{
+					1000: {common.HexToHash("0xdenied")},
+				}
+			}).
+			Build()
+
+		mock := h.Mock(10)
+		chainID := mock.id
+
+		require.NoError(t, h.commitVerified(VerifiedResult{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 50},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Number: 1000, Hash: common.BigToHash(big.NewInt(1000))}},
+		}))
+
+		trackingDB := &mockLogsDBWithState{
+			latestBlock: eth.BlockID{Number: 1000},
+			hasBlocks:   true,
+		}
+		h.interop.logsDBs[chainID] = trackingDB
+
+		plan, err := h.interop.buildRewindPlan(1000)
+		require.NoError(t, err)
+		require.NotNil(t, plan.ResetAllChainsTo)
+		require.Equal(t, uint64(999), *plan.ResetAllChainsTo)
+		require.NotNil(t, plan.TargetPayloads[chainID])
+		require.Equal(t, uint64(999), uint64(plan.TargetPayloads[chainID].ExecutionPayload.Timestamp))
+
+		err = h.interop.applyRewindPlan(plan)
+		require.NoError(t, err)
+		require.True(t, trackingDB.clearCalled > 0, "logsDB should be cleared when rewinding to empty")
+		require.Equal(t, []uint64{999}, mock.rewindEngineCalls)
+		require.Same(t, plan.TargetPayloads[chainID], mock.lastRewindEngineTarget)
 	})
 }
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
@@ -2018,7 +2019,7 @@ func (m *mockChainContainer) PayloadByHash(ctx context.Context, hash common.Hash
 	// without requiring tests to populate payloadsByHash for every hash they touch.
 	// Tests often use common.BigToHash(timestamp) as the block hash, so derive the
 	// number and timestamp from the hash value.
-	number := hash.Big().Uint64()
+	number := bigs.Uint64Strict(hash.Big())
 	return &eth.ExecutionPayloadEnvelope{
 		ExecutionPayload: &eth.ExecutionPayload{
 			BlockHash:   hash,

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -87,6 +87,10 @@ func (m *mockCC) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.Exec
 	return nil, nil
 }
 
+func (m *mockCC) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	return nil, nil
+}
+
 func (m *mockCC) ID() eth.ChainID {
 	return eth.ChainIDFromUInt64(10)
 }

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -93,6 +93,9 @@ func (m *mockCC) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.Bl
 func (m *mockCC) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
 	return nil, nil
 }
+func (m *mockCC) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	return nil, nil
+}
 func (m *mockCC) ID() eth.ChainID   { return eth.ChainIDFromUInt64(10) }
 func (m *mockCC) BlockTime() uint64 { return 1 }
 func (m *mockCC) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -96,6 +96,9 @@ type ChainContainer interface {
 	// PayloadByHash returns the canonical execution payload envelope for the given block hash.
 	// Used by interop build paths to capture canonical payloads for WAL'd rewind operations.
 	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
+	// PayloadByNumber returns the canonical execution payload envelope for the given block number.
+	// Used by interop build paths when the rewind target is below the verified frontier.
+	PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error)
 	// SetResetCallback sets a callback that is invoked when the chain resets.
 	// The supernode uses this to notify activities about chain resets.
 	SetResetCallback(cb ResetCallback)
@@ -596,6 +599,13 @@ func (c *simpleChainContainer) PayloadByHash(ctx context.Context, hash common.Ha
 		return nil, engine_controller.ErrNoEngineClient
 	}
 	return c.engine.PayloadByHash(ctx, hash)
+}
+
+func (c *simpleChainContainer) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	if c.engine == nil {
+		return nil, engine_controller.ErrNoEngineClient
+	}
+	return c.engine.PayloadByNumber(ctx, number)
 }
 
 func (c *simpleChainContainer) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -165,6 +165,8 @@ type mockEngineController struct {
 	l2BlockRefByNumberErr    error
 	payloadByHashResult      *eth.ExecutionPayloadEnvelope
 	payloadByHashErr         error
+	payloadByNumberResult    *eth.ExecutionPayloadEnvelope
+	payloadByNumberErr       error
 }
 
 func (m *mockEngineController) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
@@ -234,6 +236,10 @@ func (m *mockEngineController) Rewind(ctx context.Context, target *eth.Execution
 
 func (m *mockEngineController) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
 	return m.payloadByHashResult, m.payloadByHashErr
+}
+
+func (m *mockEngineController) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	return m.payloadByNumberResult, m.payloadByNumberErr
 }
 
 // Interface conformance assertion

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -31,6 +31,8 @@ type EngineController interface {
 	// build paths to capture the canonical target payload before recording a rewind operation
 	// in the WAL.
 	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
+	// PayloadByNumber returns the canonical execution payload envelope for the given block number.
+	PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error)
 	// Rewind rewinds the L2 execution layer to the supplied target block. The target payload
 	// must come from durable storage (the supernode WAL) — the engine controller does not
 	// consult the live EL to discover the target.
@@ -179,6 +181,13 @@ func (e *simpleEngineController) PayloadByHash(ctx context.Context, hash common.
 		return nil, ErrNoEngineClient
 	}
 	return e.l2.PayloadByHash(ctx, hash)
+}
+
+func (e *simpleEngineController) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	if e.l2 == nil {
+		return nil, ErrNoEngineClient
+	}
+	return e.l2.PayloadByNumber(ctx, number)
 }
 
 func (e *simpleEngineController) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -322,6 +322,10 @@ func (m *mockEngineForInvalidation) PayloadByHash(ctx context.Context, hash comm
 	return nil, nil
 }
 
+func (m *mockEngineForInvalidation) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	return nil, nil
+}
+
 func (m *mockEngineForInvalidation) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
 	return nil, nil, nil
 }


### PR DESCRIPTION
## Summary

- capture WAL rewind payloads when a deny-list rewind has to reset engines past the first verified timestamp
- centralize rewind payload capture/validation for verified heads and timestamp-derived reset targets
- expose payload-by-number through the chain container so reset targets can be captured before apply mutates state

## Validation

- go test ./op-supernode/supernode/activity/interop ./op-supernode/supernode/chain_container/...
- go test ./op-supernode/...
- git diff --check

Stacked on #21015.