### PR TITLE
feat(sdm): PostExec replay debug API

### DIFF
--- a/op-acceptance-tests/tests/sdm/block_test.go
+++ b/op-acceptance-tests/tests/sdm/block_test.go
@@ -134,6 +134,137 @@ func TestSDMDisabledNoRefunds(gt *testing.T) {
 	}
 }
 
+func TestSDMEnabledPayloadAndReplayMatch(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := newSDMRethSystem(t, true)
+	verifyOpReth(t, sys.L2EL)
+
+	block, included, targetBlockNum := mustFindRepeatedSlotBlock(t, sys, 2, 3)
+	postExecTx, postExecPos := findPostExecTransaction(block)
+	t.Require().NotNil(postExecTx, "SDM-enabled sequencer must include a post-exec tx")
+	t.Require().Greater(len(postExecTx.Input), 0, "post-exec tx input must not be empty")
+	t.Require().Equal(uint64(sdmpkg.SDMTxType), uint64(postExecTx.Type), "post-exec tx type must be 0x7D")
+
+	payload, err := sdmpkg.DecodePayload(postExecTx.Input)
+	t.Require().NoError(err, "post-exec payload must decode")
+	t.Require().Equal(sdmpkg.PostExecPayloadVersion, payload.Version, "post-exec payload version must be 1")
+	t.Require().NotEmpty(payload.GasRefundEntries, "post-exec payload must be non-empty for repeated-slot workload")
+
+	receiptByHash := make(map[common.Hash]*types.Receipt, len(included))
+	hasNonZeroReceiptRefund := false
+	for _, itx := range included {
+		receiptByHash[itx.receipt.TxHash] = itx.receipt
+		refund, _ := getOPGasRefund(t, sys.L2EL, itx.receipt.TxHash)
+		if refund > 0 {
+			hasNonZeroReceiptRefund = true
+		}
+	}
+	t.Require().True(hasNonZeroReceiptRefund, "at least one repeated-slot tx must have non-zero opGasRefund")
+
+	for _, entry := range payload.GasRefundEntries {
+		t.Require().Less(int(entry.Index), len(block.Transactions), "payload index must be in block range")
+		targetTx := block.Transactions[entry.Index]
+		t.Require().NotEqual(uint64(types.DepositTxType), uint64(targetTx.Type), "payload must not target deposits")
+		t.Require().NotEqual(uint64(sdmpkg.SDMTxType), uint64(targetTx.Type), "payload must not target the SDM tx itself")
+
+		refund, present := getOPGasRefund(t, sys.L2EL, targetTx.Hash)
+		t.Require().True(present, "SDM receipt must expose opGasRefund for tx index %d", entry.Index)
+		t.Require().Equal(entry.GasRefund, refund,
+			"payload refund must match receipt opGasRefund for tx index %d", entry.Index)
+	}
+
+	replay := replayBlockWithSDM(t, sys.L2EL, targetBlockNum)
+	t.Require().Equal(targetBlockNum, replay.BlockNum, "replay must target the selected block")
+	t.Require().Equal(block.Hash, replay.BlockHash, "replay block hash must match source block")
+	t.Require().True(replay.PostExecTxPresent, "replay must report the post-exec tx in the source block")
+	t.Require().NotNil(replay.PostExecTxIndex, "replay must report the post-exec tx index")
+	t.Require().Equal(uint64(postExecPos), *replay.PostExecTxIndex, "replay post-exec tx index must match source block")
+	t.Require().Equal(len(block.Transactions)-1, len(replay.Txs),
+		"replay must strip the post-exec tx and preserve the remaining tx ordering")
+	t.Require().Empty(replay.Mismatches, "canonical post-exec block should replay without mismatches")
+	t.Require().Equal(len(replay.SynthesizedPayload.GasRefundEntries), replay.Summary.PostExecPayloadEntryCount,
+		"summary payload entry count must match synthesized payload")
+
+	expectedOriginalIndexes := make([]uint64, 0, len(block.Transactions)-1)
+	for i := range block.Transactions {
+		if i == postExecPos {
+			continue
+		}
+		expectedOriginalIndexes = append(expectedOriginalIndexes, uint64(i))
+	}
+
+	replayRefundByIndex := make(map[uint64]uint64, len(replay.Txs))
+	hasReplayRefund := false
+	for i, tx := range replay.Txs {
+		t.Require().Equal(uint64(i), tx.ReplayTxIndex, "replay tx indexes must be sequential")
+		t.Require().Equal(expectedOriginalIndexes[i], tx.TxIndex,
+			"replay tx %d must preserve original block index", i)
+
+		sourceTx := block.Transactions[tx.TxIndex]
+		t.Require().Equal(sourceTx.Hash, tx.TxHash, "replay tx hash must match source tx at index %d", tx.TxIndex)
+		t.Require().Equal(uint64(sourceTx.Type), tx.TxType, "replay tx type must match source tx at index %d", tx.TxIndex)
+		t.Require().Equal(uint64(types.DepositTxType) == uint64(sourceTx.Type), tx.IsDepositTx,
+			"deposit classification must match source tx at index %d", tx.TxIndex)
+		t.Require().Equal(tx.RawGasUsed, tx.CanonicalGasUsed+tx.OPGasRefundReplay,
+			"raw gas must equal canonical gas plus refund at tx index %d", tx.TxIndex)
+
+		if tx.OPGasRefundReplay > 0 {
+			hasReplayRefund = true
+		}
+		replayRefundByIndex[tx.TxIndex] = tx.OPGasRefundReplay
+
+		if tx.OPGasRefundPayload != nil {
+			t.Require().Equal(*tx.OPGasRefundPayload, tx.OPGasRefundReplay,
+				"payload refund must match replay refund at tx index %d", tx.TxIndex)
+		}
+		if receipt, ok := receiptByHash[tx.TxHash]; ok {
+			t.Require().Equal(receipt.GasUsed, tx.CanonicalGasUsed,
+				"receipt gasUsed must already be canonical for tx %s", tx.TxHash)
+			if refund, _ := getOPGasRefund(t, sys.L2EL, tx.TxHash); refund > 0 {
+				t.Require().Greater(tx.RawGasUsed, receipt.GasUsed,
+					"raw gas must exceed receipt gas when refund is non-zero for tx %s", tx.TxHash)
+			}
+		}
+	}
+	t.Require().True(hasReplayRefund, "replay must produce non-zero refunds for repeated-slot block")
+
+	var totalReplayRefund uint64
+	for _, entry := range replay.SynthesizedPayload.GasRefundEntries {
+		sourceTx := block.Transactions[entry.Index]
+		refund, present := getOPGasRefund(t, sys.L2EL, sourceTx.Hash)
+		t.Require().True(present, "SDM receipt must expose opGasRefund for tx index %d", entry.Index)
+		t.Require().Equal(refund, entry.GasRefund,
+			"synthesized payload refund must match receipt opGasRefund for tx index %d", entry.Index)
+		t.Require().Equal(entry.GasRefund, replayRefundByIndex[entry.Index],
+			"synthesized payload refund must match replay tx refund for tx index %d", entry.Index)
+		totalReplayRefund += entry.GasRefund
+	}
+	t.Require().Equal(totalReplayRefund, replay.Summary.ReplayRefundTotal,
+		"summary replay refund total must match synthesized payload")
+	t.Require().Equal(totalReplayRefund, replay.Summary.PayloadRefundTotal,
+		"summary payload refund total must match synthesized payload")
+	t.Require().Equal(uint64(block.GasUsed), replay.Summary.BlockGasUsed,
+		"block gasUsed must already be canonical")
+	t.Require().Equal(replay.Summary.BlockRawGasUsed,
+		replay.Summary.BlockGasUsed+replay.Summary.ReplayRefundTotal,
+		"raw block gas must equal canonical block gas plus total refund")
+
+	dsl.CheckAll(t,
+		sys.L2EL.AdvancedFn(eth.Unsafe, 10),
+		sys.L2ELVerifier.AdvancedFn(eth.Unsafe, 10),
+	)
+
+	t.Logger().Info("TestSDMEnabledPayloadAndReplayMatch passed",
+		"block_num", targetBlockNum,
+		"block_hash", block.Hash,
+		"user_txs", len(included),
+		"post_exec_tx_index", postExecPos,
+		"payload_entries", len(payload.GasRefundEntries),
+		"replay_refund_total", replay.Summary.ReplayRefundTotal,
+		"block_gas_used", replay.Summary.BlockGasUsed,
+		"block_raw_gas_used", replay.Summary.BlockRawGasUsed)
+}
+
 func TestSDMPostExecBlockDerivesAndChainProgresses(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	for _, testCase := range []struct {
@@ -275,6 +406,143 @@ func testSDMPostExecBlockDerivesAndChainProgresses(t devtest.T, batchType string
 		"verifier_finalized_head", verifierFinalizedRef.ID(),
 		"l1_before_batching", l1BeforeBatching.ID(),
 		"l1_after_batching", l1AfterBatching.ID())
+}
+
+func TestSDMStorageRefundBreakdown(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := newSDMRethSystem(t, true)
+	verifyOpReth(t, sys.L2EL)
+
+	const (
+		sameSlotTouches = 100
+		manySlotTouches = 100
+		maxAttempts     = 3
+	)
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		alice := sys.FunderL2.NewFundedEOA(eth.OneEther)
+		contract := deployContract(t, alice, slotTouchBin)
+		startNonce := alice.PendingNonce()
+
+		planned := []*txplan.PlannedTx{
+			submitTxWithoutWait(
+				t,
+				alice,
+				startNonce,
+				txplan.WithTo(addrPtr(contract)),
+				txplan.WithData(encodeHitSameSlot(1)),
+				txplan.WithGasLimit(300_000),
+			),
+			submitTxWithoutWait(
+				t,
+				alice,
+				startNonce+1,
+				txplan.WithTo(addrPtr(contract)),
+				txplan.WithData(encodeHitSameSlot(sameSlotTouches)),
+				txplan.WithGasLimit(1_500_000),
+			),
+			submitTxWithoutWait(
+				t,
+				alice,
+				startNonce+2,
+				txplan.WithTo(addrPtr(contract)),
+				txplan.WithData(encodeHitManySlots(manySlotTouches)),
+				txplan.WithGasLimit(3_000_000),
+			),
+			submitTxWithoutWait(
+				t,
+				alice,
+				startNonce+3,
+				txplan.WithTo(addrPtr(contract)),
+				txplan.WithData(encodeHitManySlots(manySlotTouches)),
+				txplan.WithGasLimit(3_000_000),
+			),
+		}
+
+		receipts := make([]*types.Receipt, len(planned))
+		for i, ptx := range planned {
+			receipt, err := ptx.Included.Eval(t.Ctx())
+			t.Require().NoError(err, "attempt %d tx %d: failed to get receipt", attempt, i)
+			t.Require().Equal(types.ReceiptStatusSuccessful, receipt.Status,
+				"attempt %d tx %d: must succeed", attempt, i)
+			receipts[i] = receipt
+		}
+
+		sameWarmBlock := bigs.Uint64Strict(receipts[0].BlockNumber)
+		sameClaimBlock := bigs.Uint64Strict(receipts[1].BlockNumber)
+		manyWarmBlock := bigs.Uint64Strict(receipts[2].BlockNumber)
+		manyClaimBlock := bigs.Uint64Strict(receipts[3].BlockNumber)
+		if sameWarmBlock != sameClaimBlock || manyWarmBlock != manyClaimBlock {
+			t.Logger().Warn("slot-touch workload pairs split across blocks; retrying",
+				"attempt", attempt,
+				"sameWarmBlock", sameWarmBlock,
+				"sameClaimBlock", sameClaimBlock,
+				"manyWarmBlock", manyWarmBlock,
+				"manyClaimBlock", manyClaimBlock)
+			continue
+		}
+
+		sameRefund, sameRefundPresent := getOPGasRefund(t, sys.L2EL, receipts[1].TxHash)
+		t.Require().True(sameRefundPresent, "SDM receipt must expose opGasRefund for repeated same-slot tx")
+		sameReplay := replayBlockWithSDM(t, sys.L2EL, sameClaimBlock)
+		sameTx := mustFindReplayTxByHash(t, sameReplay, receipts[1].TxHash)
+		t.Require().Equal(sameRefund, sameTx.OPGasRefundReplay,
+			"replay refund must match receipt refund for repeated same-slot tx")
+
+		var sameSlotSstoreEvents int
+		var sameSlotSstoreRefund uint64
+		for i, event := range sameTx.RefundBreakdown {
+			if event.Kind != "warm_sstore" {
+				continue
+			}
+			t.Require().Equal(uint64(2100), event.Amount, "same-slot warm SSTORE event %d must be 2100 gas", i)
+			t.Require().NotNil(event.Slot, "same-slot warm SSTORE event %d must identify the touched slot", i)
+			sameSlotSstoreEvents++
+			sameSlotSstoreRefund += event.Amount
+		}
+		t.Require().Equal(1, sameSlotSstoreEvents,
+			"repeating the same warmed storage slot %d times should only produce one warm SSTORE refund event", sameSlotTouches)
+		t.Require().Equal(uint64(2100), sameSlotSstoreRefund,
+			"repeating the same warmed storage slot should only rebate one warm SSTORE access")
+
+		manyRefund, manyRefundPresent := getOPGasRefund(t, sys.L2EL, receipts[3].TxHash)
+		t.Require().True(manyRefundPresent, "SDM receipt must expose opGasRefund for many-slot tx")
+		manyReplay := replayBlockWithSDM(t, sys.L2EL, manyClaimBlock)
+		manyTx := mustFindReplayTxByHash(t, manyReplay, receipts[3].TxHash)
+		t.Require().Equal(manyRefund, manyTx.OPGasRefundReplay,
+			"replay refund must match receipt refund for many-slot tx")
+
+		var totalBreakdown uint64
+		var manySlotSstoreEvents int
+		var manySlotSstoreRefund uint64
+		for i, event := range manyTx.RefundBreakdown {
+			totalBreakdown += event.Amount
+			if event.Kind != "warm_sstore" {
+				continue
+			}
+			t.Require().Equal(uint64(2100), event.Amount, "warm SSTORE refund event %d must be 2100 gas", i)
+			t.Require().NotNil(event.Slot, "warm SSTORE refund event %d must identify the warmed slot", i)
+			manySlotSstoreEvents++
+			manySlotSstoreRefund += event.Amount
+		}
+		t.Require().Equal(manySlotTouches, manySlotSstoreEvents,
+			"touching %d distinct warmed slots should produce %d warm SSTORE refund events", manySlotTouches, manySlotTouches)
+		t.Require().Equal(uint64(2100*manySlotTouches), manySlotSstoreRefund,
+			"distinct warmed slots should rebate 2100 gas each")
+		t.Require().Equal(manyRefund, totalBreakdown,
+			"sum of many-slot refund events must equal the receipt-level refund")
+		t.Require().Greater(manyRefund, manyTx.RawGasUsed/5,
+			"SDM refunds are not capped at the EIP-3529 20%% rule once applied canonically")
+		t.Require().Equal(receipts[3].GasUsed, manyTx.CanonicalGasUsed,
+			"receipt gasUsed must already be canonical for many-slot tx")
+		t.Require().Equal(manyTx.RawGasUsed, manyTx.CanonicalGasUsed+manyRefund,
+			"raw gas must equal canonical gas plus SDM refund for many-slot tx")
+
+		return
+	}
+
+	t.Require().FailNowf("slot-touch workload failed",
+		"no attempt produced both same-slot and many-slot warm/claim pairs in the same block after %d attempts", maxAttempts)
 }
 
 // TestSDMMixedWorkloadSmoke submits transactions from multiple categories in a single burst,

--- a/op-acceptance-tests/tests/sdm/helpers_test.go
+++ b/op-acceptance-tests/tests/sdm/helpers_test.go
@@ -3,6 +3,7 @@ package sdm
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"strings"
 
 	sdmpkg "github.com/ethereum-optimism/optimism/op-chain-ops/pkg/sdm"
@@ -17,8 +18,13 @@ import (
 // ComputeHeavy: run(uint256 n) loops keccak256 n times (pure computation).
 const computeHeavyBin = "6080604052348015600e575f5ffd5b506101908061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610029575f3560e01c8063a444f5e91461002d575b5f5ffd5b610047600480360381019061004291906100ec565b610049565b005b5f7f66a80b61b29ec044d14c4c8c613e762ba1fb8eeb0c454d1ee00ed6dedaa5b5c590505f5f90505b828110156100b0578160405160200161008b9190610140565b6040516020818303038152906040528051906020012091508080600101915050610072565b505050565b5f5ffd5b5f819050919050565b6100cb816100b9565b81146100d5575f5ffd5b50565b5f813590506100e6816100c2565b92915050565b5f60208284031215610101576101006100b5565b5b5f61010e848285016100d8565b91505092915050565b5f819050919050565b5f819050919050565b61013a61013582610117565b610120565b82525050565b5f61014b8284610129565b6020820191508190509291505056fea264697066735822122013cd314931f1991e7797e220c9553bb73dfef407d4d266dd8b2553907d5bc14364736f6c634300081c0033"
 
+// SlotTouch: repeatedly touches either one storage slot or many distinct slots.
+const slotTouchBin = "6080604052348015600e575f5ffd5b5061010e8061001c5f395ff3fe6080604052348015600e575f5ffd5b50600436106030575f3560e01c80637ebfc845146034578063f1ac3593146045575b5f5ffd5b6043603f366004609e565b6054565b005b60436050366004609e565b6073565b5f5b81811015606f57606681600160b4565b5f556001016056565b5050565b5f5b81811015606f57608581600160b4565b5f82815260016020819052604090912091909155016075565b5f6020828403121560ad575f5ffd5b5035919050565b8082018082111560d257634e487b7160e01b5f52601160045260245ffd5b9291505056fea264697066735822122032537b9a0375aae151d7e212351ad336fe397942ba90c7fb77682efb97e309f564736f6c63430008210033"
+
 var (
-	funcEmitLog = w3.MustNewFunc("emitLog(bytes32[],bytes)", "")
+	funcEmitLog      = w3.MustNewFunc("emitLog(bytes32[],bytes)", "")
+	funcHitSameSlot  = w3.MustNewFunc("hitSameSlot(uint256)", "")
+	funcHitManySlots = w3.MustNewFunc("hitManySlots(uint256)", "")
 )
 
 // setSDMEnabled toggles the local SDM PostExec production opt-in on an L2 EL via the
@@ -80,8 +86,25 @@ func getBlockWithTxs(t devtest.T, l2EL *dsl.L2ELNode, blockNum uint64) *sdmpkg.R
 	return block
 }
 
+func replayBlockWithSDM(t devtest.T, l2EL *dsl.L2ELNode, blockNum uint64) *sdmpkg.ReplaySDMBlock {
+	replay, err := sdmpkg.ReplayBlockWithSDM(t.Ctx(), l2EL.Escape().L2EthClient().RPC(), blockNum, true)
+	t.Require().NoError(err, "debug_replaySDMBlock RPC failed for block %d", blockNum)
+	return replay
+}
+
 func findPostExecTransaction(block *sdmpkg.RPCBlock) (*sdmpkg.RPCTransaction, int) {
 	return sdmpkg.FindPostExecTransaction(block)
+}
+
+func mustFindReplayTxByHash(t devtest.T, replay *sdmpkg.ReplaySDMBlock, txHash common.Hash) *sdmpkg.ReplaySDMTx {
+	for i := range replay.Txs {
+		if replay.Txs[i].TxHash == txHash {
+			return &replay.Txs[i]
+		}
+	}
+
+	t.Require().FailNowf("replay tx missing", "tx %s not found in replay for block %d", txHash, replay.BlockNum)
+	return nil
 }
 
 func deployContract(t devtest.T, eoa *dsl.EOA, hexBytecode string) common.Address {
@@ -103,6 +126,22 @@ func encodeEmitLog(topicCount int, dataLen int) []byte {
 	data, err := funcEmitLog.EncodeArgs(topics, opaqueData)
 	if err != nil {
 		panic(fmt.Sprintf("failed to encode emitLog: %v", err))
+	}
+	return data
+}
+
+func encodeHitSameSlot(n uint64) []byte {
+	return encodeUintArg(funcHitSameSlot, "hitSameSlot", n)
+}
+
+func encodeHitManySlots(n uint64) []byte {
+	return encodeUintArg(funcHitManySlots, "hitManySlots", n)
+}
+
+func encodeUintArg(fn *w3.Func, name string, n uint64) []byte {
+	data, err := fn.EncodeArgs(new(big.Int).SetUint64(n))
+	if err != nil {
+		panic(fmt.Sprintf("failed to encode %s(%d): %v", name, n, err))
 	}
 	return data
 }

--- a/op-chain-ops/cmd/sdm-devnet/main.go
+++ b/op-chain-ops/cmd/sdm-devnet/main.go
@@ -48,6 +48,7 @@ type config struct {
 	receiptTimeout   time.Duration
 	pollInterval     time.Duration
 	skipReceipts     bool
+	skipReplay       bool
 	skipSDMOptIn     bool
 	jsonOut          bool
 }
@@ -101,6 +102,7 @@ func parseFlags() config {
 	flag.DurationVar(&cfg.receiptTimeout, "receipt-timeout", 45*time.Second, "timeout for each submitted tx receipt")
 	flag.DurationVar(&cfg.pollInterval, "poll-interval", 500*time.Millisecond, "receipt polling interval")
 	flag.BoolVar(&cfg.skipReceipts, "skip-receipts", false, "do not compare payload entries against receipt opGasRefund")
+	flag.BoolVar(&cfg.skipReplay, "skip-replay", false, "do not call debug_replaySDMBlock")
 	flag.BoolVar(&cfg.skipSDMOptIn, "skip-sdm-opt-in", false, "do not call admin_setSdmEnabled(true) before submitting workload")
 	flag.BoolVar(&cfg.jsonOut, "json", false, "print JSON result")
 	flag.Parse()
@@ -123,6 +125,7 @@ func run(cfg config) error {
 
 	validationOpts := sdm.DefaultValidationOptions()
 	validationOpts.CheckReceipts = !cfg.skipReceipts
+	validationOpts.CheckReplay = !cfg.skipReplay
 
 	if cfg.blockNum != 0 {
 		validation, err := sdm.ValidatePostExecBlock(ctx, sender.RPC, cfg.blockNum, validationOpts)
@@ -468,6 +471,9 @@ func printResult(cfg config, result workloadResult) error {
 		uint64(v.Block.Number), v.Block.Hash, v.PostExecIndex, len(v.Block.Transactions), len(v.Payload.GasRefundEntries), v.TotalPayloadRefund)
 	if result.Contract != (common.Address{}) {
 		log.Printf("workload contract=%s attempt=%d submitted_txs=%d", result.Contract, result.Attempt, result.SubmittedTxs)
+	}
+	if v.Replay != nil {
+		log.Printf("replay raw_gas=%d canonical_gas=%d replay_refund_total=%d", v.Replay.Summary.BlockRawGasUsed, v.Replay.Summary.BlockGasUsed, v.Replay.Summary.ReplayRefundTotal)
 	}
 	return nil
 }

--- a/op-chain-ops/pkg/sdm/workload.go
+++ b/op-chain-ops/pkg/sdm/workload.go
@@ -76,14 +76,77 @@ func (r *RPCReceipt) BlockNum() uint64 {
 	return bigs.Uint64Strict((*big.Int)(r.BlockNumber))
 }
 
+type ReplaySDMRefundEvent struct {
+	ClaimingReplayTxIndex      uint64         `json:"claiming_replay_tx_index"`
+	ClaimingTxIndex            uint64         `json:"claiming_tx_index"`
+	Kind                       string         `json:"kind"`
+	Amount                     uint64         `json:"amount"`
+	Address                    common.Address `json:"address"`
+	Slot                       *common.Hash   `json:"slot"`
+	FirstWarmedByReplayTxIndex uint64         `json:"first_warmed_by_replay_tx_index"`
+	FirstWarmedByTxIndex       uint64         `json:"first_warmed_by_tx_index"`
+}
+
+type ReplaySDMTx struct {
+	TxIndex            uint64                 `json:"tx_index"`
+	ReplayTxIndex      uint64                 `json:"replay_tx_index"`
+	TxHash             common.Hash            `json:"tx_hash"`
+	TxType             uint64                 `json:"tx_type"`
+	IsDepositTx        bool                   `json:"is_deposit_tx"`
+	RawGasUsed         uint64                 `json:"raw_gas_used"`
+	CanonicalGasUsed   uint64                 `json:"canonical_gas_used"`
+	OPGasRefundReplay  uint64                 `json:"op_gas_refund_replay"`
+	OPGasRefundPayload *uint64                `json:"op_gas_refund_payload"`
+	RefundBreakdown    []ReplaySDMRefundEvent `json:"refund_breakdown"`
+	Mismatch           bool                   `json:"mismatch"`
+}
+
+type ReplaySDMMismatch struct {
+	Category string  `json:"category"`
+	BlockNum uint64  `json:"block_num"`
+	TxIndex  *uint64 `json:"tx_index"`
+	Expected *uint64 `json:"expected"`
+	Actual   *uint64 `json:"actual"`
+	Message  string  `json:"message"`
+}
+
+type ReplaySDMSummary struct {
+	BlockNum                  uint64      `json:"block_num"`
+	BlockHash                 common.Hash `json:"block_hash"`
+	TxCountTotal              int         `json:"tx_count_total"`
+	TxCountUser               int         `json:"tx_count_user"`
+	PostExecTxPresent         bool        `json:"post_exec_tx_present"`
+	PostExecPayloadEntryCount int         `json:"post_exec_payload_entry_count"`
+	BlockGasUsed              uint64      `json:"block_gas_used"`
+	BlockRawGasUsed           uint64      `json:"block_raw_gas_used"`
+	ReplayRefundTotal         uint64      `json:"replay_refund_total"`
+	PayloadRefundTotal        uint64      `json:"payload_refund_total"`
+	MismatchCount             int         `json:"mismatch_count"`
+}
+
+type ReplaySDMBlock struct {
+	BlockNum                uint64              `json:"block_num"`
+	BlockHash               common.Hash         `json:"block_hash"`
+	ParentHash              common.Hash         `json:"parent_hash"`
+	PostExecTxPresent       bool                `json:"post_exec_tx_present"`
+	PostExecTxIndex         *uint64             `json:"post_exec_tx_index"`
+	EmbeddedPayload         *PostExecPayload    `json:"embedded_payload"`
+	SynthesizedPayload      PostExecPayload     `json:"synthesized_payload"`
+	SynthesizedPayloadBytes hexutil.Bytes       `json:"synthesized_payload_bytes"`
+	Txs                     []ReplaySDMTx       `json:"txs"`
+	Mismatches              []ReplaySDMMismatch `json:"mismatches"`
+	Summary                 ReplaySDMSummary    `json:"summary"`
+}
+
 // ValidationOptions controls how ValidatePostExecBlock checks the selected block.
 type ValidationOptions struct {
 	ComparePayload bool `json:"compare_payload"`
 	CheckReceipts  bool `json:"check_receipts"`
+	CheckReplay    bool `json:"check_replay"`
 }
 
 func DefaultValidationOptions() ValidationOptions {
-	return ValidationOptions{ComparePayload: true, CheckReceipts: true}
+	return ValidationOptions{ComparePayload: true, CheckReceipts: true, CheckReplay: true}
 }
 
 type ValidationResult struct {
@@ -93,6 +156,7 @@ type ValidationResult struct {
 	Payload            *PostExecPayload  `json:"payload"`
 	ReceiptRefunds     map[uint64]uint64 `json:"receipt_refunds,omitempty"`
 	TotalPayloadRefund uint64            `json:"total_payload_refund"`
+	Replay             *ReplaySDMBlock   `json:"replay,omitempty"`
 }
 
 func GetBlockWithTxs(ctx context.Context, rpcClient Caller, blockNum uint64) (*RPCBlock, error) {
@@ -119,6 +183,25 @@ func FindPostExecTransaction(block *RPCBlock) (*RPCTransaction, int) {
 		}
 	}
 	return nil, -1
+}
+
+func ReplayBlockWithSDM(ctx context.Context, rpcClient Caller, blockNum uint64, comparePayload bool) (*ReplaySDMBlock, error) {
+	var raw json.RawMessage
+	if err := rpcClient.CallContext(ctx, &raw, "debug_replaySDMBlock",
+		fmt.Sprintf("0x%x", blockNum),
+		map[string]bool{"compare_payload": comparePayload},
+	); err != nil {
+		return nil, fmt.Errorf("debug_replaySDMBlock(%d): %w", blockNum, err)
+	}
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, fmt.Errorf("nil debug_replaySDMBlock result for block %d", blockNum)
+	}
+
+	var replay ReplaySDMBlock
+	if err := json.Unmarshal(raw, &replay); err != nil {
+		return nil, fmt.Errorf("unmarshal replay result for block %d: %w", blockNum, err)
+	}
+	return &replay, nil
 }
 
 func GetOPGasRefund(ctx context.Context, rpcClient Caller, txHash common.Hash) (uint64, bool, error) {
@@ -204,6 +287,35 @@ func ValidatePostExecBlock(ctx context.Context, rpcClient Caller, blockNum uint6
 	}
 	if !opts.CheckReceipts {
 		result.ReceiptRefunds = nil
+	}
+
+	if opts.CheckReplay {
+		replay, err := ReplayBlockWithSDM(ctx, rpcClient, blockNum, opts.ComparePayload)
+		if err != nil {
+			return nil, err
+		}
+		result.Replay = replay
+		if !replay.PostExecTxPresent {
+			return nil, fmt.Errorf("replay does not report post-exec tx for block %d", blockNum)
+		}
+		if replay.PostExecTxIndex == nil {
+			return nil, fmt.Errorf("replay does not report post-exec tx index for block %d", blockNum)
+		}
+		if *replay.PostExecTxIndex != uint64(postExecPos) {
+			return nil, fmt.Errorf("replay post-exec tx index %d, want %d", *replay.PostExecTxIndex, postExecPos)
+		}
+		if len(replay.Mismatches) > 0 {
+			return nil, fmt.Errorf("replay reported %d SDM mismatch(es): %v", len(replay.Mismatches), replay.Mismatches)
+		}
+		if replay.Summary.PostExecPayloadEntryCount != len(payload.GasRefundEntries) {
+			return nil, fmt.Errorf("replay payload entry count %d, want %d", replay.Summary.PostExecPayloadEntryCount, len(payload.GasRefundEntries))
+		}
+		if replay.Summary.ReplayRefundTotal != replay.Summary.PayloadRefundTotal {
+			return nil, fmt.Errorf("replay refund total %d, payload total %d", replay.Summary.ReplayRefundTotal, replay.Summary.PayloadRefundTotal)
+		}
+		if replay.Summary.PayloadRefundTotal != result.TotalPayloadRefund {
+			return nil, fmt.Errorf("replay payload refund total %d, decoded payload total %d", replay.Summary.PayloadRefundTotal, result.TotalPayloadRefund)
+		}
 	}
 
 	return result, nil

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11532,6 +11532,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-optimism-post-exec-replay"
+version = "1.11.3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
+ "op-alloy-consensus",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-node-api",
+ "reth-optimism-evm",
+ "reth-optimism-primitives",
+ "reth-primitives-traits",
+ "revm",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reth-optimism-primitives"
 version = "1.11.3"
 dependencies = [
@@ -11605,6 +11624,7 @@ dependencies = [
  "reth-optimism-flashblocks",
  "reth-optimism-forks",
  "reth-optimism-payload-builder",
+ "reth-optimism-post-exec-replay",
  "reth-optimism-primitives",
  "reth-optimism-trie",
  "reth-optimism-txpool",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,6 +35,7 @@ members = [
   "op-reth/crates/hardforks/",
   "op-reth/crates/node/",
   "op-reth/crates/payload/",
+  "op-reth/crates/post-exec-replay/",
   "op-reth/crates/primitives/",
   "op-reth/crates/reth/",
   "op-reth/crates/rpc/",
@@ -292,6 +293,7 @@ reth-optimism-flashblocks = { path = "op-reth/crates/flashblocks/" }
 reth-optimism-forks = { path = "op-reth/crates/hardforks/", default-features = false }
 reth-optimism-node = { path = "op-reth/crates/node/" }
 reth-optimism-payload-builder = { path = "op-reth/crates/payload/" }
+reth-optimism-post-exec-replay = { path = "op-reth/crates/post-exec-replay/" }
 reth-optimism-primitives = { path = "op-reth/crates/primitives/", default-features = false }
 reth-op = { path = "op-reth/crates/reth/", default-features = false }
 reth-optimism-rpc = { path = "op-reth/crates/rpc/" }

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -49,7 +49,7 @@ use reth_optimism_rpc::{
     eth::{OpEthApiBuilder, ext::OpEthExtApi},
     historical::{HistoricalRpc, HistoricalRpcClient},
     miner::{MinerApiExtServer, OpMinerExtApi},
-    witness::{DebugExecutionWitnessApiServer, OpDebugWitnessApi},
+    witness::{DebugExecutionWitnessApiServer, OpDebugPostExecApiServer, OpDebugWitnessApi},
 };
 use reth_optimism_storage::OpStorage;
 use reth_optimism_txpool::{OpPool, OpPooledTx, supervisor::SupervisorClient};
@@ -715,6 +715,7 @@ where
                 ctx.node.provider().clone(),
                 ctx.node.task_executor().clone(),
                 builder,
+                ctx.node.evm_config().clone(),
             );
         let miner_ext = OpMinerExtApi::new(da_config, gas_limit_config);
 
@@ -746,6 +747,10 @@ where
                 modules.merge_if_module_configured(
                     RethRpcModule::Debug,
                     DebugExecutionWitnessApiServer::into_rpc(debug_ext.clone()),
+                )?;
+                modules.merge_if_module_configured(
+                    RethRpcModule::Debug,
+                    OpDebugPostExecApiServer::into_rpc(debug_ext.clone()),
                 )?;
 
                 // extend the miner namespace if configured in the regular http server

--- a/rust/op-reth/crates/post-exec-replay/Cargo.toml
+++ b/rust/op-reth/crates/post-exec-replay/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "reth-optimism-post-exec-replay"
+version = "1.11.3"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage = "https://paradigmxyz.github.io/reth"
+repository = "https://github.com/paradigmxyz/reth"
+description = "Counterfactual post-exec replay support for op-reth."
+
+[lints]
+workspace = true
+
+[dependencies]
+reth-evm.workspace = true
+reth-execution-errors.workspace = true
+reth-node-api.workspace = true
+reth-optimism-evm = { workspace = true, features = ["std"] }
+reth-primitives-traits.workspace = true
+
+revm.workspace = true
+
+alloy-consensus.workspace = true
+alloy-eips.workspace = true
+alloy-primitives.workspace = true
+op-alloy-consensus.workspace = true
+
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+alloy-primitives.workspace = true
+reth-optimism-primitives = { workspace = true, features = ["serde", "reth-codec"] }

--- a/rust/op-reth/crates/post-exec-replay/src/lib.rs
+++ b/rust/op-reth/crates/post-exec-replay/src/lib.rs
@@ -1,0 +1,14 @@
+//! Counterfactual post-exec replay support for op-reth.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod replay;
+mod types;
+
+pub use replay::{PostExecReplayError, replay_block, strip_post_exec_tx_for_replay};
+pub use types::{
+    PostExecReplayBlock, PostExecReplayConfig, PostExecReplayMismatch, PostExecReplayMismatchKind,
+    PostExecReplayPayload, PostExecReplayPayloadEntry, PostExecReplayRefundEvent,
+    PostExecReplayRefundKind, PostExecReplaySummary, PostExecReplayTx, ReplayPostExecBlockOptions,
+    ReplayPostExecBlockRequest,
+};

--- a/rust/op-reth/crates/post-exec-replay/src/replay.rs
+++ b/rust/op-reth/crates/post-exec-replay/src/replay.rs
@@ -1,0 +1,609 @@
+use crate::types::{
+    PostExecReplayBlock, PostExecReplayConfig, PostExecReplayMismatch, PostExecReplayMismatchKind,
+    PostExecReplayPayload, PostExecReplayPayloadEntry, PostExecReplayRefundEvent,
+    PostExecReplayRefundKind, PostExecReplaySummary, PostExecReplayTx,
+};
+use alloy_consensus::{
+    Block as AlloyBlock, BlockBody, BlockHeader as AlloyBlockHeader, TxReceipt, Typed2718,
+};
+use op_alloy_consensus::{
+    OpTransaction, POST_EXEC_PAYLOAD_VERSION, POST_EXEC_TX_TYPE_ID, PostExecPayload,
+    PostExecPayloadValidationError, build_post_exec_tx, parse_post_exec_payload_from_transactions,
+};
+use reth_evm::{Database, execute::BlockExecutor};
+use reth_execution_errors::BlockExecutionError;
+use reth_node_api::NodePrimitives;
+use reth_optimism_evm::{
+    ConfigurePostExecEvm, PostExecExecutorExt, WarmingRefundEvent, WarmingRefundKind,
+};
+use reth_primitives_traits::{Block, BlockHeader, RecoveredBlock, SignedTransaction};
+use revm::database::State;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Replay error.
+#[derive(Debug, thiserror::Error)]
+pub enum PostExecReplayError {
+    /// Execution failed.
+    #[error(transparent)]
+    Execution(#[from] BlockExecutionError),
+    /// Source block contains an invalid post-exec transaction structure.
+    #[error(transparent)]
+    InvalidPostExecPayload(#[from] PostExecPayloadValidationError),
+}
+
+/// Replay block with the synthetic post-exec transaction removed and original indexes retained.
+pub(crate) type StrippedPostExecBlock<Tx, Header> =
+    (RecoveredBlock<AlloyBlock<Tx, Header>>, Vec<u64>);
+
+struct NormalizedBlock<Tx, Header>
+where
+    Tx: SignedTransaction + OpTransaction + Clone,
+    Header: BlockHeader + AlloyBlockHeader + Clone,
+    AlloyBlock<Tx, Header>: Block<Header = Header, Body = BlockBody<Tx, Header>>,
+{
+    replay_block: RecoveredBlock<AlloyBlock<Tx, Header>>,
+    original_indexes: Vec<u64>,
+    embedded_payload: Option<PostExecPayload>,
+    post_exec_tx_index: Option<u64>,
+}
+
+/// Strip the synthetic post-exec tx from a block before replay while preserving original indexes.
+pub fn strip_post_exec_tx_for_replay<Tx, Header>(
+    block: &RecoveredBlock<AlloyBlock<Tx, Header>>,
+) -> Result<StrippedPostExecBlock<Tx, Header>, PostExecReplayError>
+where
+    Tx: SignedTransaction + OpTransaction + Clone,
+    Header: BlockHeader + AlloyBlockHeader + Clone,
+    AlloyBlock<Tx, Header>: Block<Header = Header, Body = BlockBody<Tx, Header>>,
+{
+    let normalized = normalize_block(block)?;
+    Ok((normalized.replay_block, normalized.original_indexes))
+}
+
+fn normalize_block<Tx, Header>(
+    block: &RecoveredBlock<AlloyBlock<Tx, Header>>,
+) -> Result<NormalizedBlock<Tx, Header>, PostExecReplayError>
+where
+    Tx: SignedTransaction + OpTransaction + Clone,
+    Header: BlockHeader + AlloyBlockHeader + Clone,
+    AlloyBlock<Tx, Header>: Block<Header = Header, Body = BlockBody<Tx, Header>>,
+{
+    let parsed_post_exec = parse_post_exec_payload_from_transactions(
+        block.body().transactions.iter(),
+        block.header().number(),
+        // Replay is a debug/counterfactual tool, so the caller decides to run post-exec even for
+        // blocks without an embedded payload. When a payload is embedded, still enforce the shared
+        // structural rules (single trailing tx, anchored block number) used by consensus parsing.
+        true,
+    )?;
+    let post_exec_tx_index = parsed_post_exec.as_ref().map(|parsed| parsed.tx_index);
+    let embedded_payload = parsed_post_exec.map(|parsed| parsed.payload);
+
+    let (raw_block, senders) = block.clone().split();
+    let (header, body) = raw_block.split();
+    let BlockBody { transactions, ommers, withdrawals } = body;
+
+    let mut replay_transactions = Vec::with_capacity(transactions.len());
+    let mut replay_senders = Vec::with_capacity(senders.len());
+    let mut original_indexes = Vec::with_capacity(transactions.len());
+
+    for (original_index, (tx, sender)) in
+        transactions.into_iter().zip(senders.into_iter()).enumerate()
+    {
+        let original_index = original_index as u64;
+        if Some(original_index) == post_exec_tx_index {
+            continue;
+        }
+
+        original_indexes.push(original_index);
+        replay_transactions.push(tx);
+        replay_senders.push(sender);
+    }
+
+    let replay_block = RecoveredBlock::new_unhashed(
+        AlloyBlock::new(
+            header,
+            BlockBody { transactions: replay_transactions, ommers, withdrawals },
+        ),
+        replay_senders,
+    );
+
+    Ok(NormalizedBlock { replay_block, original_indexes, embedded_payload, post_exec_tx_index })
+}
+
+const fn into_refund_kind(kind: WarmingRefundKind) -> PostExecReplayRefundKind {
+    match kind {
+        WarmingRefundKind::WarmAccount => PostExecReplayRefundKind::WarmAccount,
+        WarmingRefundKind::WarmSload => PostExecReplayRefundKind::WarmSload,
+        WarmingRefundKind::WarmSstore => PostExecReplayRefundKind::WarmSstore,
+    }
+}
+
+fn original_tx_index(original_indexes: &[u64], replay_tx_index: u64) -> u64 {
+    original_indexes.get(replay_tx_index as usize).copied().unwrap_or(replay_tx_index)
+}
+
+fn into_refund_event(
+    event: WarmingRefundEvent,
+    claiming_replay_tx_index: u64,
+    original_indexes: &[u64],
+) -> PostExecReplayRefundEvent {
+    let first_warmed_by_replay_tx_index = event.first_warmed_by_tx_index;
+
+    PostExecReplayRefundEvent {
+        claiming_replay_tx_index,
+        claiming_tx_index: original_tx_index(original_indexes, claiming_replay_tx_index),
+        kind: into_refund_kind(event.kind),
+        amount: event.amount,
+        address: event.address,
+        slot: event.slot,
+        first_warmed_by_replay_tx_index,
+        first_warmed_by_tx_index: original_tx_index(
+            original_indexes,
+            first_warmed_by_replay_tx_index,
+        ),
+    }
+}
+
+const fn replay_mismatch(
+    category: PostExecReplayMismatchKind,
+    block_num: u64,
+    tx_index: Option<u64>,
+    expected: Option<u64>,
+    actual: Option<u64>,
+    message: String,
+) -> PostExecReplayMismatch {
+    PostExecReplayMismatch { category, block_num, tx_index, expected, actual, message }
+}
+
+fn build_payload_map<Tx, Header>(
+    block_number: u64,
+    block: &RecoveredBlock<AlloyBlock<Tx, Header>>,
+    payload: &PostExecPayload,
+    mismatches: &mut Vec<PostExecReplayMismatch>,
+) -> BTreeMap<u64, u64>
+where
+    Tx: SignedTransaction + OpTransaction + Typed2718,
+    Header: BlockHeader,
+    AlloyBlock<Tx, Header>: Block<Header = Header, Body = BlockBody<Tx, Header>>,
+{
+    let transactions = &block.body().transactions;
+    let tx_count = transactions.len() as u64;
+    let mut refunds = BTreeMap::new();
+    let mut seen = BTreeSet::new();
+
+    for entry in &payload.gas_refund_entries {
+        let tx_index = entry.index;
+        if !seen.insert(tx_index) {
+            mismatches.push(replay_mismatch(
+                PostExecReplayMismatchKind::DuplicatePayloadIndex,
+                block_number,
+                Some(tx_index),
+                None,
+                Some(entry.gas_refund),
+                format!("duplicate payload entry for tx index {tx_index}"),
+            ));
+            continue;
+        }
+
+        if tx_index >= tx_count {
+            mismatches.push(replay_mismatch(
+                PostExecReplayMismatchKind::PayloadIndexOutOfRange,
+                block_number,
+                Some(tx_index),
+                Some(tx_count.saturating_sub(1)),
+                Some(tx_index),
+                format!("payload entry targets out-of-range tx index {tx_index}"),
+            ));
+            continue;
+        }
+
+        let tx = &transactions[tx_index as usize];
+        if tx.is_deposit() {
+            mismatches.push(replay_mismatch(
+                PostExecReplayMismatchKind::PayloadTargetsDeposit,
+                block_number,
+                Some(tx_index),
+                Some(0),
+                Some(entry.gas_refund),
+                format!("payload entry targets deposit tx index {tx_index}"),
+            ));
+            continue;
+        }
+
+        if Typed2718::ty(tx) == POST_EXEC_TX_TYPE_ID {
+            mismatches.push(replay_mismatch(
+                PostExecReplayMismatchKind::PayloadTargetsPostExec,
+                block_number,
+                Some(tx_index),
+                Some(0),
+                Some(entry.gas_refund),
+                format!("payload entry targets post-exec tx index {tx_index}"),
+            ));
+            continue;
+        }
+
+        refunds.insert(tx_index, entry.gas_refund);
+    }
+
+    refunds
+}
+
+fn into_replay_payload(payload: PostExecPayload) -> PostExecReplayPayload {
+    PostExecReplayPayload {
+        version: payload.version.into(),
+        block_number: payload.block_number,
+        gas_refund_entries: payload
+            .gas_refund_entries
+            .into_iter()
+            .map(|entry| PostExecReplayPayloadEntry {
+                index: entry.index,
+                gas_refund: entry.gas_refund,
+            })
+            .collect(),
+    }
+}
+
+struct CompareRefundsInput<'a> {
+    block_number: u64,
+    tx_index: u64,
+    raw_gas_used: u64,
+    replay_refund: u64,
+    payload_refund: Option<u64>,
+    config: &'a PostExecReplayConfig,
+}
+
+fn compare_refunds(
+    input: CompareRefundsInput<'_>,
+    mismatches: &mut Vec<PostExecReplayMismatch>,
+) -> bool {
+    let CompareRefundsInput {
+        block_number,
+        tx_index,
+        raw_gas_used,
+        replay_refund,
+        payload_refund,
+        config,
+    } = input;
+    let mismatch_count = mismatches.len();
+
+    if let Some(payload_refund) = payload_refund &&
+        payload_refund > raw_gas_used
+    {
+        mismatches.push(replay_mismatch(
+            PostExecReplayMismatchKind::PayloadRefundExceedsRawGas,
+            block_number,
+            Some(tx_index),
+            Some(raw_gas_used),
+            Some(payload_refund),
+            format!("payload refund exceeds raw gas for tx index {tx_index}"),
+        ));
+    }
+
+    if config.compare_payload && payload_refund.unwrap_or_default() != replay_refund {
+        mismatches.push(replay_mismatch(
+            PostExecReplayMismatchKind::PayloadRefundMismatch,
+            block_number,
+            Some(tx_index),
+            payload_refund,
+            Some(replay_refund),
+            format!("payload refund mismatch for tx index {tx_index}"),
+        ));
+    }
+
+    mismatches.len() != mismatch_count
+}
+
+/// Replay a historical block with post-exec enabled counterfactually.
+pub fn replay_block<DB, EvmConfig, Tx, Header>(
+    evm_config: &EvmConfig,
+    db: DB,
+    block: &RecoveredBlock<AlloyBlock<Tx, Header>>,
+    config: PostExecReplayConfig,
+) -> Result<PostExecReplayBlock, PostExecReplayError>
+where
+    DB: Database,
+    EvmConfig: ConfigurePostExecEvm,
+    EvmConfig::Primitives: NodePrimitives<
+            Block = AlloyBlock<Tx, Header>,
+            BlockBody = BlockBody<Tx, Header>,
+            BlockHeader = Header,
+            SignedTx = Tx,
+        >,
+    Tx: SignedTransaction + OpTransaction + Clone,
+    Header: BlockHeader + AlloyBlockHeader + Clone,
+    AlloyBlock<Tx, Header>: Block<Header = Header, Body = BlockBody<Tx, Header>>,
+{
+    let normalized = normalize_block(block)?;
+    let block_number = block.header().number();
+    let block_hash = block.hash();
+    let post_exec_tx_present = normalized.post_exec_tx_index.is_some();
+
+    let mut state = State::builder().with_database(db).with_bundle_update().build();
+    let mut executor = evm_config
+        .post_exec_executor_for_block(
+            &mut state,
+            normalized.replay_block.sealed_block(),
+            reth_optimism_evm::PostExecMode::Produce,
+        )
+        .map_err(BlockExecutionError::other)?;
+
+    executor.apply_pre_execution_changes()?;
+    for tx in normalized.replay_block.clone_transactions_recovered() {
+        executor.execute_transaction(tx)?;
+    }
+    let replay_entries = executor.take_post_exec_entries();
+    let warming_events_by_tx = executor.take_warming_events_by_tx();
+    let execution = executor.apply_post_execution_changes()?;
+
+    let replay_payload = PostExecPayload {
+        version: POST_EXEC_PAYLOAD_VERSION,
+        block_number,
+        gas_refund_entries: replay_entries.clone(),
+    };
+    let replay_refunds: BTreeMap<u64, u64> =
+        replay_entries.iter().map(|entry| (entry.index, entry.gas_refund)).collect();
+
+    let mut mismatches = Vec::new();
+    let payload_refunds = match (config.compare_payload, normalized.embedded_payload.as_ref()) {
+        (true, Some(payload)) => build_payload_map(block_number, block, payload, &mut mismatches),
+        _ => BTreeMap::new(),
+    };
+
+    let mut txs = Vec::with_capacity(normalized.replay_block.body().transactions.len());
+    let mut previous_cumulative_gas = 0_u64;
+
+    for (replay_idx, (tx, &tx_index)) in normalized
+        .replay_block
+        .body()
+        .transactions
+        .iter()
+        .zip(&normalized.original_indexes)
+        .enumerate()
+    {
+        let replay_tx_index = replay_idx as u64;
+        let cumulative_gas_used = execution.receipts[replay_idx].cumulative_gas_used();
+        let canonical_gas_used = cumulative_gas_used.saturating_sub(previous_cumulative_gas);
+        previous_cumulative_gas = cumulative_gas_used;
+
+        let replay_refund = replay_refunds.get(&tx_index).copied().unwrap_or_default();
+        let raw_gas_used = canonical_gas_used.saturating_add(replay_refund);
+        let payload_refund = payload_refunds.get(&tx_index).copied();
+        let refund_breakdown = warming_events_by_tx
+            .get(replay_idx)
+            .into_iter()
+            .flatten()
+            .copied()
+            .map(|event| into_refund_event(event, replay_tx_index, &normalized.original_indexes))
+            .collect();
+        let mismatch = compare_refunds(
+            CompareRefundsInput {
+                block_number,
+                tx_index,
+                raw_gas_used,
+                replay_refund,
+                payload_refund,
+                config: &config,
+            },
+            &mut mismatches,
+        );
+
+        txs.push(PostExecReplayTx {
+            tx_index,
+            replay_tx_index,
+            tx_hash: *tx.tx_hash(),
+            tx_type: tx.ty(),
+            is_deposit_tx: tx.is_deposit(),
+            raw_gas_used,
+            canonical_gas_used,
+            op_gas_refund_replay: replay_refund,
+            op_gas_refund_payload: payload_refund,
+            refund_breakdown,
+            mismatch,
+        });
+    }
+
+    let tx_count_user = txs.iter().filter(|tx| !tx.is_deposit_tx).count();
+    let replay_refund_total = txs.iter().map(|tx| tx.op_gas_refund_replay).sum::<u64>();
+    let payload_refund_total =
+        txs.iter().map(|tx| tx.op_gas_refund_payload.unwrap_or_default()).sum::<u64>();
+    let block_gas_used = txs.iter().map(|tx| tx.canonical_gas_used).sum::<u64>();
+    let block_raw_gas_used = txs.iter().map(|tx| tx.raw_gas_used).sum::<u64>();
+
+    let summary = PostExecReplaySummary {
+        block_num: block_number,
+        block_hash,
+        tx_count_total: txs.len(),
+        tx_count_user,
+        post_exec_tx_present,
+        post_exec_payload_entry_count: replay_entries.len(),
+        block_gas_used,
+        block_raw_gas_used,
+        replay_refund_total,
+        payload_refund_total,
+        mismatch_count: mismatches.len(),
+    };
+
+    Ok(PostExecReplayBlock {
+        config,
+        block_num: block_number,
+        block_hash,
+        parent_hash: block.header().parent_hash(),
+        post_exec_tx_present,
+        post_exec_tx_index: normalized.post_exec_tx_index,
+        embedded_payload: normalized.embedded_payload.map(into_replay_payload),
+        synthesized_payload_bytes: build_post_exec_tx(block_number, replay_entries)
+            .payload
+            .to_rlp_bytes(),
+        synthesized_payload: into_replay_payload(replay_payload),
+        txs,
+        mismatches,
+        summary,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CompareRefundsInput, PostExecReplayError, build_payload_map, compare_refunds,
+        normalize_block, strip_post_exec_tx_for_replay,
+    };
+    use crate::{PostExecReplayConfig, PostExecReplayMismatchKind};
+    use alloy_consensus::{BlockBody, Header, Sealable, SignableTransaction, TxLegacy};
+    use alloy_primitives::{Address, Signature, U256};
+    use op_alloy_consensus::{
+        OpTxEnvelope, POST_EXEC_PAYLOAD_VERSION, TxDeposit, build_post_exec_tx,
+    };
+    use reth_optimism_primitives::OpTransactionSigned;
+    use reth_primitives_traits::RecoveredBlock;
+
+    fn user_tx() -> OpTransactionSigned {
+        OpTxEnvelope::Legacy(TxLegacy::default().into_signed(Signature::new(
+            U256::ZERO,
+            U256::ZERO,
+            false,
+        )))
+    }
+
+    #[test]
+    fn strips_post_exec_tx_and_preserves_original_indexes() {
+        let deposit: OpTransactionSigned = OpTxEnvelope::Deposit(TxDeposit::default().seal_slow());
+        let user = user_tx();
+        let post_exec: OpTransactionSigned =
+            OpTransactionSigned::PostExec(build_post_exec_tx(0, vec![]).seal_slow());
+
+        let block = RecoveredBlock::new_unhashed(
+            alloy_consensus::Block::new(
+                Header::default(),
+                BlockBody {
+                    transactions: vec![deposit, user, post_exec],
+                    ommers: vec![],
+                    withdrawals: None,
+                },
+            ),
+            vec![Address::ZERO, Address::ZERO, Address::ZERO],
+        );
+
+        let (replay_block, original_indexes) = strip_post_exec_tx_for_replay(&block).unwrap();
+        assert_eq!(replay_block.body().transactions.len(), 2);
+        assert_eq!(original_indexes, vec![0, 1]);
+    }
+
+    #[test]
+    fn normalize_block_extracts_embedded_payload_and_post_exec_index() {
+        let deposit: OpTransactionSigned = OpTxEnvelope::Deposit(TxDeposit::default().seal_slow());
+        let user = user_tx();
+        let payload_entries = vec![op_alloy_consensus::SDMGasEntry { index: 1, gas_refund: 9 }];
+        let post_exec: OpTransactionSigned = OpTransactionSigned::PostExec(
+            build_post_exec_tx(0, payload_entries.clone()).seal_slow(),
+        );
+
+        let block = RecoveredBlock::new_unhashed(
+            alloy_consensus::Block::new(
+                Header::default(),
+                BlockBody {
+                    transactions: vec![deposit, user, post_exec],
+                    ommers: vec![],
+                    withdrawals: None,
+                },
+            ),
+            vec![Address::ZERO, Address::ZERO, Address::ZERO],
+        );
+
+        let normalized = normalize_block(&block).unwrap();
+        assert_eq!(normalized.post_exec_tx_index, Some(2));
+        assert_eq!(normalized.original_indexes, vec![0, 1]);
+        assert_eq!(normalized.embedded_payload.unwrap().gas_refund_entries, payload_entries);
+        assert_eq!(normalized.replay_block.body().transactions.len(), 2);
+    }
+
+    #[test]
+    fn normalize_block_reuses_shared_post_exec_structure_validation() {
+        let post_exec: OpTransactionSigned =
+            OpTransactionSigned::PostExec(build_post_exec_tx(0, vec![]).seal_slow());
+        let user = user_tx();
+
+        let block = RecoveredBlock::new_unhashed(
+            alloy_consensus::Block::new(
+                Header::default(),
+                BlockBody {
+                    transactions: vec![post_exec, user],
+                    ommers: vec![],
+                    withdrawals: None,
+                },
+            ),
+            vec![Address::ZERO, Address::ZERO],
+        );
+
+        let err =
+            normalize_block(&block).err().expect("non-trailing post-exec tx must fail validation");
+        assert!(matches!(err, PostExecReplayError::InvalidPostExecPayload(_)));
+    }
+
+    #[test]
+    fn build_payload_map_reports_invalid_targets_and_duplicates() {
+        let deposit: OpTransactionSigned = OpTxEnvelope::Deposit(TxDeposit::default().seal_slow());
+        let user = user_tx();
+        let post_exec: OpTransactionSigned =
+            OpTransactionSigned::PostExec(build_post_exec_tx(0, vec![]).seal_slow());
+        let block = RecoveredBlock::new_unhashed(
+            alloy_consensus::Block::new(
+                Header::default(),
+                BlockBody {
+                    transactions: vec![deposit, user, post_exec],
+                    ommers: vec![],
+                    withdrawals: None,
+                },
+            ),
+            vec![Address::ZERO, Address::ZERO, Address::ZERO],
+        );
+        let payload = op_alloy_consensus::PostExecPayload {
+            version: POST_EXEC_PAYLOAD_VERSION,
+            block_number: 100,
+            gas_refund_entries: vec![
+                op_alloy_consensus::SDMGasEntry { index: 0, gas_refund: 1 },
+                op_alloy_consensus::SDMGasEntry { index: 2, gas_refund: 2 },
+                op_alloy_consensus::SDMGasEntry { index: 8, gas_refund: 3 },
+                op_alloy_consensus::SDMGasEntry { index: 1, gas_refund: 4 },
+                op_alloy_consensus::SDMGasEntry { index: 1, gas_refund: 5 },
+            ],
+        };
+
+        let mut mismatches = Vec::new();
+        let refunds = build_payload_map(100, &block, &payload, &mut mismatches);
+
+        assert_eq!(refunds.get(&1), Some(&4));
+        assert_eq!(refunds.len(), 1);
+        assert_eq!(
+            mismatches.iter().map(|m| m.category).collect::<Vec<_>>(),
+            vec![
+                PostExecReplayMismatchKind::PayloadTargetsDeposit,
+                PostExecReplayMismatchKind::PayloadTargetsPostExec,
+                PostExecReplayMismatchKind::PayloadIndexOutOfRange,
+                PostExecReplayMismatchKind::DuplicatePayloadIndex,
+            ]
+        );
+    }
+
+    #[test]
+    fn compare_refunds_detects_tampered_payload_mismatches() {
+        let config = PostExecReplayConfig { compare_payload: true };
+        let mut mismatches = Vec::new();
+
+        let mismatch = compare_refunds(
+            CompareRefundsInput {
+                block_number: 100,
+                tx_index: 3,
+                raw_gas_used: 40,
+                replay_refund: 5,
+                payload_refund: Some(7),
+                config: &config,
+            },
+            &mut mismatches,
+        );
+
+        assert!(mismatch);
+        assert_eq!(mismatches.len(), 1);
+        assert_eq!(mismatches[0].category, PostExecReplayMismatchKind::PayloadRefundMismatch);
+    }
+}

--- a/rust/op-reth/crates/post-exec-replay/src/types.rs
+++ b/rust/op-reth/crates/post-exec-replay/src/types.rs
@@ -1,0 +1,172 @@
+#![allow(missing_docs)]
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::{Address, B256, Bytes};
+use serde::{Deserialize, Serialize};
+
+const fn compare_payload_default() -> bool {
+    true
+}
+
+/// Single-block replay request, accepting either a block tag/number or a block hash.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ReplayPostExecBlockRequest {
+    /// A block number or tag like `latest`.
+    Number(BlockNumberOrTag),
+    /// A block hash.
+    Hash(B256),
+}
+
+/// Options for `debug_replaySDMBlock`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplayPostExecBlockOptions {
+    /// Compare replay refunds against any embedded post-exec payload in the source block.
+    #[serde(default = "compare_payload_default")]
+    pub compare_payload: bool,
+}
+
+impl Default for ReplayPostExecBlockOptions {
+    fn default() -> Self {
+        Self { compare_payload: compare_payload_default() }
+    }
+}
+
+/// Replay configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayConfig {
+    /// Compare replay refunds against an embedded payload when present.
+    pub compare_payload: bool,
+}
+
+impl Default for PostExecReplayConfig {
+    fn default() -> Self {
+        Self { compare_payload: compare_payload_default() }
+    }
+}
+
+impl From<ReplayPostExecBlockOptions> for PostExecReplayConfig {
+    fn from(options: ReplayPostExecBlockOptions) -> Self {
+        Self { compare_payload: options.compare_payload }
+    }
+}
+
+/// Exact refund categories emitted by the replay engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PostExecReplayRefundKind {
+    /// Warm account rebate (+2500).
+    WarmAccount,
+    /// Warm storage read rebate (+2000).
+    WarmSload,
+    /// Warm storage write rebate (+2100).
+    WarmSstore,
+}
+
+/// Exact refund attribution event for one replayed transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayRefundEvent {
+    /// Replay-local transaction index that claimed the rebate.
+    pub claiming_replay_tx_index: u64,
+    /// Original transaction index in the source block that claimed the rebate.
+    pub claiming_tx_index: u64,
+    /// Refund kind.
+    pub kind: PostExecReplayRefundKind,
+    /// Refund amount in gas.
+    pub amount: u64,
+    /// Account touched by the rebate.
+    pub address: Address,
+    /// Storage slot touched by the rebate, when applicable.
+    pub slot: Option<B256>,
+    /// Replay-local transaction index that first warmed the account or slot.
+    pub first_warmed_by_replay_tx_index: u64,
+    /// Original transaction index in the source block that first warmed the account or slot.
+    pub first_warmed_by_tx_index: u64,
+}
+
+/// Per-transaction replay row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayTx {
+    pub tx_index: u64,
+    pub replay_tx_index: u64,
+    pub tx_hash: B256,
+    pub tx_type: u8,
+    pub is_deposit_tx: bool,
+    pub raw_gas_used: u64,
+    pub canonical_gas_used: u64,
+    pub op_gas_refund_replay: u64,
+    pub op_gas_refund_payload: Option<u64>,
+    pub refund_breakdown: Vec<PostExecReplayRefundEvent>,
+    pub mismatch: bool,
+}
+
+/// Replay mismatch category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PostExecReplayMismatchKind {
+    DuplicatePayloadIndex,
+    PayloadIndexOutOfRange,
+    PayloadTargetsDeposit,
+    PayloadTargetsPostExec,
+    PayloadRefundMismatch,
+    PayloadRefundExceedsRawGas,
+}
+
+/// Replay mismatch row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayMismatch {
+    pub category: PostExecReplayMismatchKind,
+    pub block_num: u64,
+    pub tx_index: Option<u64>,
+    pub expected: Option<u64>,
+    pub actual: Option<u64>,
+    pub message: String,
+}
+
+/// Block-level summary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplaySummary {
+    pub block_num: u64,
+    pub block_hash: B256,
+    pub tx_count_total: usize,
+    pub tx_count_user: usize,
+    pub post_exec_tx_present: bool,
+    pub post_exec_payload_entry_count: usize,
+    pub block_gas_used: u64,
+    pub block_raw_gas_used: u64,
+    pub replay_refund_total: u64,
+    pub payload_refund_total: u64,
+    pub mismatch_count: usize,
+}
+
+/// Single-block replay response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayBlock {
+    pub config: PostExecReplayConfig,
+    pub block_num: u64,
+    pub block_hash: B256,
+    pub parent_hash: B256,
+    pub post_exec_tx_present: bool,
+    pub post_exec_tx_index: Option<u64>,
+    pub embedded_payload: Option<PostExecReplayPayload>,
+    pub synthesized_payload: PostExecReplayPayload,
+    pub synthesized_payload_bytes: Bytes,
+    pub txs: Vec<PostExecReplayTx>,
+    pub mismatches: Vec<PostExecReplayMismatch>,
+    pub summary: PostExecReplaySummary,
+}
+
+/// Serializable replay payload entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayPayloadEntry {
+    pub index: u64,
+    pub gas_refund: u64,
+}
+
+/// Serializable replay payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayPayload {
+    pub version: u64,
+    pub block_number: u64,
+    pub gas_refund_entries: Vec<PostExecReplayPayloadEntry>,
+}

--- a/rust/op-reth/crates/rpc/Cargo.toml
+++ b/rust/op-reth/crates/rpc/Cargo.toml
@@ -37,6 +37,7 @@ reth-provider.workspace = true
 reth-optimism-evm.workspace = true
 reth-optimism-flashblocks.workspace = true
 reth-optimism-payload-builder.workspace = true
+reth-optimism-post-exec-replay.workspace = true
 reth-optimism-txpool.workspace = true
 # TODO remove node-builder import
 reth-optimism-primitives = { workspace = true, features = ["reth-codec", "serde-bincode-compat", "serde"] }

--- a/rust/op-reth/crates/rpc/src/witness.rs
+++ b/rust/op-reth/crates/rpc/src/witness.rs
@@ -1,5 +1,7 @@
 //! Support for optimism specific witness RPCs.
 
+use alloy_consensus::{Block as AlloyBlock, BlockHeader};
+use alloy_eips::BlockId;
 use alloy_primitives::{B256, Sealed};
 use alloy_rpc_types_debug::ExecutionWitness;
 use jsonrpsee::proc_macros::rpc;
@@ -10,8 +12,13 @@ use reth_node_api::{BuildNextEnv, NodePrimitives};
 use reth_optimism_evm::ConfigurePostExecEvm;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_payload_builder::{OpAttributes, OpPayloadBuilder, OpPayloadPrimitives};
+use reth_optimism_post_exec_replay::{
+    PostExecReplayBlock, PostExecReplayConfig, ReplayPostExecBlockOptions,
+    ReplayPostExecBlockRequest, replay_block,
+};
 use reth_optimism_txpool::OpPooledTx;
-use reth_primitives_traits::{SealedHeader, TxTy};
+use reth_primitives_traits::{RecoveredBlock, SealedHeader, TxTy};
+use reth_revm::database::StateProviderDatabase;
 use reth_rpc_server_types::{ToRpcResult, result::internal_rpc_err};
 
 /// Trait for the `debug_executePayload` endpoint, which re-executes a payload and returns the
@@ -32,13 +39,35 @@ pub trait DebugExecutionWitnessApi<Attributes> {
     ) -> RpcResult<ExecutionWitness>;
 }
 use reth_storage_api::{
-    BlockReaderIdExt, NodePrimitivesProvider, StateProviderFactory,
+    BlockReaderIdExt, NodePrimitivesProvider, StateProviderFactory, TransactionVariant,
     errors::{ProviderError, ProviderResult},
 };
 use reth_tasks::Runtime;
 use reth_transaction_pool::TransactionPool;
 use std::{fmt::Debug, sync::Arc};
 use tokio::sync::{Semaphore, oneshot};
+
+/// An extension to the `debug_` namespace for post-exec replay.
+///
+/// This trait is registered under the `debug` namespace and is intended for operator and
+/// research tooling only. Do not expose the `debug` namespace on public RPC endpoints: each
+/// call replays an entire historical block against live state and is unbounded in cost, so
+/// an unauthenticated caller can trivially saturate the node.
+#[cfg_attr(not(test), rpc(server, namespace = "debug"))]
+#[cfg_attr(test, rpc(server, client, namespace = "debug"))]
+pub trait OpDebugPostExecApi {
+    /// Counterfactually replay a historical block with post-exec enabled.
+    ///
+    /// Replays one block per call; callers driving a block range are responsible for
+    /// their own pacing and cancellation. Requires historical state for the target block
+    /// (full/archive node); on a pruned node this will fail at state lookup.
+    #[method(name = "replaySDMBlock")]
+    async fn replay_post_exec_block(
+        &self,
+        block: ReplayPostExecBlockRequest,
+        options: Option<ReplayPostExecBlockOptions>,
+    ) -> RpcResult<PostExecReplayBlock>;
+}
 
 /// An extension to the `debug_` namespace of the RPC API.
 pub struct OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs> {
@@ -51,16 +80,17 @@ impl<Pool, Provider, EvmConfig, Attrs> OpDebugWitnessApi<Pool, Provider, EvmConf
         provider: Provider,
         task_spawner: Runtime,
         builder: OpPayloadBuilder<Pool, Provider, EvmConfig, (), Attrs>,
+        evm_config: EvmConfig,
     ) -> Self {
         let semaphore = Arc::new(Semaphore::new(3));
-        let inner = OpDebugWitnessApiInner { provider, builder, task_spawner, semaphore };
+        let inner =
+            OpDebugWitnessApiInner { provider, builder, evm_config, task_spawner, semaphore };
         Self { inner: Arc::new(inner) }
     }
 }
 
 impl<Pool, Provider, EvmConfig, Attrs> OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
 where
-    EvmConfig: ConfigurePostExecEvm,
     Provider: NodePrimitivesProvider<Primitives: NodePrimitives<BlockHeader = Provider::Header>>
         + BlockReaderIdExt,
 {
@@ -73,6 +103,39 @@ where
             .provider
             .sealed_header_by_hash(parent_block_hash)?
             .ok_or_else(|| ProviderError::HeaderNotFound(parent_block_hash.into()))
+    }
+}
+
+impl<Pool, Provider, EvmConfig, Attrs> OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
+where
+    Provider: BlockReaderIdExt<
+            Block = AlloyBlock<
+                <Provider::Primitives as OpPayloadPrimitives>::_TX,
+                <Provider::Primitives as OpPayloadPrimitives>::_Header,
+            >,
+            Header = <Provider::Primitives as NodePrimitives>::BlockHeader,
+        > + NodePrimitivesProvider<Primitives: OpPayloadPrimitives>,
+{
+    fn replay_block_by_request(
+        &self,
+        request: ReplayPostExecBlockRequest,
+    ) -> ProviderResult<RecoveredBlock<Provider::Block>> {
+        let provider = &self.inner.provider;
+        match request {
+            ReplayPostExecBlockRequest::Hash(hash) => provider
+                .recovered_block(hash.into(), TransactionVariant::NoHash)?
+                .ok_or_else(|| ProviderError::HeaderNotFound(hash.into())),
+            ReplayPostExecBlockRequest::Number(number_or_tag) => provider
+                .block_with_senders_by_id(
+                    BlockId::Number(number_or_tag),
+                    TransactionVariant::NoHash,
+                )?
+                .ok_or_else(|| {
+                    ProviderError::HeaderNotFound(
+                        number_or_tag.as_number().unwrap_or_default().into(),
+                    )
+                }),
+        }
     }
 }
 
@@ -118,6 +181,73 @@ where
     }
 }
 
+#[async_trait]
+impl<Pool, Provider, EvmConfig, Attrs> OpDebugPostExecApiServer
+    for OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
+where
+    Provider::Primitives: OpPayloadPrimitives
+        + NodePrimitives<
+            Block = AlloyBlock<
+                <Provider::Primitives as OpPayloadPrimitives>::_TX,
+                <Provider::Primitives as OpPayloadPrimitives>::_Header,
+            >,
+            BlockBody = alloy_consensus::BlockBody<
+                <Provider::Primitives as OpPayloadPrimitives>::_TX,
+                <Provider::Primitives as OpPayloadPrimitives>::_Header,
+            >,
+            BlockHeader = <Provider::Primitives as OpPayloadPrimitives>::_Header,
+            SignedTx = <Provider::Primitives as OpPayloadPrimitives>::_TX,
+        >,
+    Pool: TransactionPool<
+            Transaction: OpPooledTx<Consensus = <Provider::Primitives as NodePrimitives>::SignedTx>,
+        > + 'static,
+    Provider: BlockReaderIdExt<
+            Block = AlloyBlock<
+                <Provider::Primitives as OpPayloadPrimitives>::_TX,
+                <Provider::Primitives as OpPayloadPrimitives>::_Header,
+            >,
+            Header = <Provider::Primitives as NodePrimitives>::BlockHeader,
+        > + NodePrimitivesProvider
+        + StateProviderFactory
+        + ChainSpecProvider<ChainSpec: OpHardforks>
+        + Clone
+        + 'static,
+    EvmConfig: ConfigurePostExecEvm<
+            Primitives = Provider::Primitives,
+            NextBlockEnvCtx: BuildNextEnv<Attrs, Provider::Header, Provider::ChainSpec>,
+        > + Clone
+        + 'static,
+    Attrs: OpAttributes<Transaction = TxTy<EvmConfig::Primitives>>,
+{
+    async fn replay_post_exec_block(
+        &self,
+        request: ReplayPostExecBlockRequest,
+        options: Option<ReplayPostExecBlockOptions>,
+    ) -> RpcResult<PostExecReplayBlock> {
+        let _permit = self.inner.semaphore.acquire().await;
+        let block = self.replay_block_by_request(request).to_rpc_result()?;
+        let config: PostExecReplayConfig = options.unwrap_or_default().into();
+
+        let (tx, rx) = oneshot::channel();
+        let this = self.clone();
+        self.inner.task_spawner.spawn_blocking_task(async move {
+            let res = (|| {
+                let state_provider = this
+                    .inner
+                    .provider
+                    .state_by_block_hash(block.header().parent_hash())
+                    .map_err(|err| internal_rpc_err(err.to_string()))?;
+                let db = StateProviderDatabase::new(&state_provider);
+                replay_block(&this.inner.evm_config, db, &block, config)
+                    .map_err(|err| internal_rpc_err(err.to_string()))
+            })();
+            let _ = tx.send(res);
+        });
+
+        rx.await.map_err(|err| internal_rpc_err(err.to_string()))?
+    }
+}
+
 impl<Pool, Provider, EvmConfig, Attrs> Clone
     for OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
 {
@@ -136,6 +266,7 @@ impl<Pool, Provider, EvmConfig, Attrs> Debug
 struct OpDebugWitnessApiInner<Pool, Provider, EvmConfig, Attrs> {
     provider: Provider,
     builder: OpPayloadBuilder<Pool, Provider, EvmConfig, (), Attrs>,
+    evm_config: EvmConfig,
     task_spawner: Runtime,
     semaphore: Arc<Semaphore>,
 }


### PR DESCRIPTION
Stacked on #21042.

Adds the \`reth-optimism-post-exec-replay\` crate and \`debug_replaySDMBlock\` RPC, plus the Go RPC client and replay-driven acceptance/devnet checks:
- \`TestSDMEnabledPayloadAndReplayMatch\`, \`TestSDMStorageRefundBreakdown\`
- \`sdm-devnet\` replay cross-check (\`--skip-replay\` to opt out)

No impact on consensus or production paths — pure debug RPC.

Followup:
- Flashblocks support → #21044