### PR TITLE
feat(sdm): op-rbuilder + rollup-boost flashblocks support

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/flashblocks_sdm_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_sdm_test.go
@@ -1,0 +1,277 @@
+package flashblocks
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/pkg/sdm"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type flashblocksIncludedTx struct {
+	receipt  *types.Receipt
+	blockNum uint64
+}
+
+type observedSdmFlashblock struct {
+	index      uint64
+	postExecTx []byte
+	payload    *sdm.PostExecPayload
+}
+
+// TestFlashblocksSDMMaterializesPostExecBlock proves that op-rbuilder publishes the current SDM
+// PostExec transaction in flashblocks and rollup-boost materializes exactly that trailing tx in
+// the final execution payload.
+func TestFlashblocksSDMMaterializesPostExecBlock(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sysgo.SkipOnKonaNode(t, "flashblocks acceptance preset requires user RPC")
+	sysgo.SkipOnOpGeth(t, "SDM flashblocks require op-reth post-exec support")
+
+	// SDM rides Interop: activating Interop at genesis turns SDM on for op-reth execution
+	// and the op-rbuilder payload builder consistently with op-node derivation. The preset
+	// also provisions the DependencySet required by op-node whenever Interop is scheduled.
+	sys := presets.NewSingleChainWithFlashblocks(t, presets.WithInteropAtGenesis())
+
+	driveViaTestSequencer(t, sys, 2)
+
+	// SDM PostExec production is gated by an in-memory operator flag that starts
+	// disabled on every process boot — protocol activation alone is not enough.
+	// Opt in on both the sequencer EL (op-reth fallback) and op-rbuilder (the
+	// flashblocks producer), since rollup-boost may route to either.
+	//
+	// Unlike op-node (which persists SdmEnabled in its config file — see
+	// op-node/config/config_persistence.go), op-reth and op-rbuilder hold the
+	// flag in a process-local Arc<AtomicBool> with no disk backing (see the
+	// "persistence is deliberately out of scope" notes in
+	// rust/op-reth/crates/rpc/src/sdm_admin.rs and
+	// rust/op-rbuilder/crates/op-rbuilder/src/sdm_admin.rs). Any restart of
+	// either Rust process drops the opt-in, so callers — tests here, operators
+	// in prod — must re-issue admin_setSdmEnabled after every boot.
+	setFlashblocksSDMEnabled(t, sys.L2EL.Escape().L2EthClient().RPC(), true)
+	setFlashblocksSDMEnabled(t, sys.L2OPRBuilder.Escape().L2EthClient().RPC(), true)
+
+	fbClient := sources.NewFlashblockClient(
+		sys.L2OPRBuilder.FlashblocksClient(),
+		t.Logger().With("stream_source", "op-rbuilder"),
+		200,
+	)
+	startClient(t, fbClient)
+
+	alice := sys.FunderL2.NewFundedEOA(eth.OneEther)
+	stateBloatAddr := flashblocksDeployContract(t, alice, sdm.StateBloatBin)
+
+	const batchSize = 50
+	const slotCount = 20
+	startNonce := alice.PendingNonce()
+	plannedTxs := make([]*txplan.PlannedTx, 0, batchSize)
+	for i := 0; i < batchSize; i++ {
+		plannedTxs = append(plannedTxs, flashblocksSubmitTxWithoutWait(
+			t,
+			alice,
+			startNonce+uint64(i),
+			txplan.WithTo(&stateBloatAddr),
+			txplan.WithData(sdm.EncodeRun(slotCount)),
+			txplan.WithGasLimit(1_000_000),
+		))
+	}
+
+	type receiptResult struct {
+		idx     int
+		receipt *types.Receipt
+		err     error
+	}
+	receiptCh := make(chan receiptResult, batchSize)
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(receiptCh)
+		for i, ptx := range plannedTxs {
+			receipt, err := ptx.Included.Eval(t.Ctx())
+			receiptCh <- receiptResult{idx: i, receipt: receipt, err: err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	observedByBlock := make(map[uint64]observedSdmFlashblock)
+	includedByBlock := make(map[uint64][]flashblocksIncludedTx)
+	var targetBlockNum uint64
+	var postReceiptTimer *time.Timer
+	var postReceiptDeadline <-chan time.Time
+	defer func() {
+		if postReceiptTimer != nil {
+			postReceiptTimer.Stop()
+		}
+	}()
+
+	for targetBlockNum == 0 {
+		select {
+		case fb, ok := <-fbClient.Next():
+			t.Require().True(ok, "flashblock client closed before observing SDM post_exec_tx")
+			t.Require().NotNil(fb)
+			if fb.Diff.PostExecTx == nil {
+				continue
+			}
+			t.Require().False(flashblockTransactionsContainPostExec(fb),
+				"SDM post-exec tx must be carried in diff.post_exec_tx, not diff.transactions")
+			payload, raw := decodeFlashblockPostExecTx(t, fb)
+			blockNum := uint64(fb.Metadata.BlockNumber)
+			observedByBlock[blockNum] = observedSdmFlashblock{
+				index:      uint64(fb.Index),
+				postExecTx: raw,
+				payload:    payload,
+			}
+			if len(includedByBlock[blockNum]) >= 2 {
+				targetBlockNum = blockNum
+			}
+		case result, ok := <-receiptCh:
+			if !ok {
+				receiptCh = nil
+				postReceiptTimer = time.NewTimer(15 * time.Second)
+				postReceiptDeadline = postReceiptTimer.C
+				continue
+			}
+			t.Require().NoError(result.err, "workload tx %d failed before inclusion", result.idx)
+			t.Require().Equal(types.ReceiptStatusSuccessful, result.receipt.Status,
+				"workload tx %d must succeed", result.idx)
+			blockNum := bigs.Uint64Strict(result.receipt.BlockNumber)
+			includedByBlock[blockNum] = append(includedByBlock[blockNum], flashblocksIncludedTx{
+				receipt:  result.receipt,
+				blockNum: blockNum,
+			})
+			if len(includedByBlock[blockNum]) >= 2 {
+				if _, ok := observedByBlock[blockNum]; ok {
+					targetBlockNum = blockNum
+				}
+			}
+		case <-postReceiptDeadline:
+			t.Require().Fail("post-receipt wait expired", "all workload receipts arrived but no matching SDM flashblock post_exec_tx was observed")
+		case <-t.Ctx().Done():
+			t.Require().NoError(t.Ctx().Err(), "never found a multi-tx workload block with SDM flashblock post_exec_tx")
+		}
+	}
+
+	observed := observedByBlock[targetBlockNum]
+	t.Require().NotEmpty(includedByBlock[targetBlockNum], "target block must include workload txs")
+
+	block := getFlashblocksBlockWithTxs(t, sys.L2EL, targetBlockNum)
+	t.Require().NotEmpty(block.Transactions, "final materialized block must have transactions")
+
+	postExecTx, postExecPos := sdm.FindPostExecTransaction(block)
+	t.Require().NotNil(postExecTx, "final materialized block must contain one PostExec tx")
+	t.Require().Equal(len(block.Transactions)-1, postExecPos, "PostExec tx must be last in the final block")
+	secondPostExecTx, _ := sdm.FindPostExecTransaction(&sdm.RPCBlock{Transactions: block.Transactions[:postExecPos]})
+	t.Require().Nil(secondPostExecTx, "final materialized block must contain exactly one PostExec tx")
+
+	payload, err := sdm.DecodePayload(postExecTx.Input)
+	t.Require().NoError(err, "final PostExec tx input must decode")
+	t.Require().Equal(targetBlockNum, payload.BlockNumber, "final payload must target selected block")
+	t.Require().NotEmpty(payload.GasRefundEntries, "final payload must contain SDM refund entries")
+	t.Require().Equal(observed.payload, payload, "observed flashblock payload must match final payload")
+	t.Require().Equal(observed.postExecTx[1:], []byte(postExecTx.Input),
+		"final PostExec tx input must match latest observed flashblock post_exec_tx")
+
+	validation, err := sdm.ValidatePostExecBlock(
+		t.Ctx(),
+		sys.L2EL.Escape().L2EthClient().RPC(),
+		targetBlockNum,
+		sdm.DefaultValidationOptions(),
+	)
+	t.Require().NoError(err, "final post-exec block must validate")
+	replay := validation.Replay
+	t.Require().NotNil(replay, "SDM validation must include replay result")
+
+	t.Logger().Info("TestFlashblocksSDMMaterializesPostExecBlock passed",
+		"block_num", targetBlockNum,
+		"block_hash", block.Hash,
+		"flashblock_index", observed.index,
+		"workload_txs", len(includedByBlock[targetBlockNum]),
+		"payload_entries", len(payload.GasRefundEntries),
+		"post_exec_tx_index", postExecPos)
+}
+
+func decodeFlashblockPostExecTx(t devtest.T, fb *sources.Flashblock) (*sdm.PostExecPayload, []byte) {
+	t.Helper()
+	t.Require().NotNil(fb.Diff.PostExecTx, "flashblock must include post_exec_tx")
+	raw := append([]byte(nil), (*fb.Diff.PostExecTx)...)
+	t.Require().NotEmpty(raw, "post_exec_tx must not be empty")
+	t.Require().Equal(byte(sdm.SDMTxType), raw[0], "post_exec_tx must use type 0x7d")
+	payload, err := sdm.DecodePayload(raw[1:])
+	t.Require().NoError(err, "post_exec_tx payload must decode")
+	t.Require().Equal(uint64(fb.Metadata.BlockNumber), payload.BlockNumber,
+		"post_exec_tx payload block number must match flashblock metadata")
+	t.Require().NotEmpty(payload.GasRefundEntries, "SDM flashblock payload must contain refund entries")
+	return payload, raw
+}
+
+func flashblockTransactionsContainPostExec(fb *sources.Flashblock) bool {
+	for _, tx := range fb.Diff.Transactions {
+		switch value := tx.(type) {
+		case string:
+			if strings.HasPrefix(strings.ToLower(value), "0x7d") {
+				return true
+			}
+		case map[string]any:
+			if ty, ok := value["type"].(string); ok && strings.EqualFold(ty, "0x7d") {
+				return true
+			}
+		default:
+			encoded, err := json.Marshal(value)
+			if err == nil && strings.Contains(strings.ToLower(string(encoded)), "\"type\":\"0x7d\"") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func getFlashblocksBlockWithTxs(t devtest.T, l2EL *dsl.L2ELNode, blockNum uint64) *sdm.RPCBlock {
+	t.Helper()
+	block, err := sdm.GetBlockWithTxs(t.Ctx(), l2EL.Escape().L2EthClient().RPC(), blockNum)
+	t.Require().NoError(err, "eth_getBlockByNumber RPC failed for block %d", blockNum)
+	return block
+}
+
+func flashblocksSubmitTxWithoutWait(
+	t devtest.T,
+	alice *dsl.EOA,
+	nonce uint64,
+	opts ...txplan.Option,
+) *txplan.PlannedTx {
+	t.Helper()
+	combined := append([]txplan.Option{alice.Plan(), txplan.WithNonce(nonce)}, opts...)
+	ptx := txplan.NewPlannedTx(combined...)
+	_, err := ptx.Submitted.Eval(t.Ctx())
+	t.Require().NoError(err, "failed to submit tx with nonce %d", nonce)
+	return ptx
+}
+
+func flashblocksDeployContract(t devtest.T, eoa *dsl.EOA, hexBytecode string) common.Address {
+	t.Helper()
+	tx := txplan.NewPlannedTx(eoa.Plan(), txplan.WithData(common.FromHex(hexBytecode)))
+	res, err := tx.Included.Eval(t.Ctx())
+	t.Require().NoError(err, "failed to deploy contract")
+	return res.ContractAddress
+}
+
+func setFlashblocksSDMEnabled(t devtest.T, rpcClient client.RPC, enabled bool) {
+	t.Helper()
+	err := rpcClient.CallContext(t.Ctx(), nil, "admin_setSdmEnabled", enabled)
+	t.Require().NoError(err, "admin_setSdmEnabled(%v) RPC failed", enabled)
+}

--- a/op-chain-ops/cmd/sdm-devnet/main.go
+++ b/op-chain-ops/cmd/sdm-devnet/main.go
@@ -37,6 +37,8 @@ type config struct {
 	portal           string
 	fundAmount       string
 	fundGasLimit     uint64
+	flashblocksURL   string
+	txsPerFlashblock int
 	txSpacing        time.Duration
 	batchSize        int
 	slotCount        uint64
@@ -54,13 +56,14 @@ type config struct {
 }
 
 type workloadResult struct {
-	RPCURL          string                `json:"rpc_url"`
-	From            common.Address        `json:"from"`
-	Contract        common.Address        `json:"contract"`
-	Attempt         int                   `json:"attempt"`
-	SubmittedTxs    int                   `json:"submitted_txs"`
-	IncludedByBlock map[uint64]int        `json:"included_by_block"`
-	Validation      *sdm.ValidationResult `json:"validation"`
+	RPCURL          string                  `json:"rpc_url"`
+	From            common.Address          `json:"from"`
+	Contract        common.Address          `json:"contract"`
+	Attempt         int                     `json:"attempt"`
+	SubmittedTxs    int                     `json:"submitted_txs"`
+	IncludedByBlock map[uint64]int          `json:"included_by_block"`
+	Validation      *sdm.ValidationResult   `json:"validation"`
+	Flashblocks     []sdm.FlashblockSummary `json:"flashblocks,omitempty"`
 }
 
 func main() {
@@ -91,7 +94,9 @@ func parseFlags() config {
 	flag.StringVar(&cfg.portal, "portal", "", "OptimismPortalProxy address for -fund-l2")
 	flag.StringVar(&cfg.fundAmount, "fund-amount", "1000000000000000000", "wei to deposit with -fund-l2")
 	flag.Uint64Var(&cfg.fundGasLimit, "fund-gas-limit", 200_000, "L1 gas limit for OptimismPortal deposit")
-	flag.DurationVar(&cfg.txSpacing, "tx-spacing", 0, "delay between tx submissions")
+	flag.StringVar(&cfg.flashblocksURL, "flashblocks-url", os.Getenv("FLASHBLOCKS_WS_URL"), "op-rbuilder flashblocks websocket URL; enables per-flashblock tx counts")
+	flag.IntVar(&cfg.txsPerFlashblock, "txs-per-flashblock", 0, "when -flashblocks-url is set, submit this many txs after each observed flashblock to spread workload across flashblocks")
+	flag.DurationVar(&cfg.txSpacing, "tx-spacing", 0, "delay between tx submissions when not using -txs-per-flashblock")
 	flag.IntVar(&cfg.batchSize, "batch-size", 12, "number of run(uint256) txs to submit per attempt; keep below per-account txpool limits")
 	flag.Uint64Var(&cfg.slotCount, "slot-count", 20, "storage slots touched by each run(uint256) tx")
 	flag.IntVar(&cfg.minUserTxs, "min-user-txs", 2, "minimum submitted tx receipts in a block before validation")
@@ -126,6 +131,15 @@ func run(cfg config) error {
 	validationOpts := sdm.DefaultValidationOptions()
 	validationOpts.CheckReceipts = !cfg.skipReceipts
 	validationOpts.CheckReplay = !cfg.skipReplay
+
+	var flashblocks *sdm.FlashblockCollector
+	if cfg.flashblocksURL != "" && cfg.blockNum == 0 {
+		flashblocks, err = sdm.StartFlashblockCollector(ctx, cfg.flashblocksURL)
+		if err != nil {
+			return err
+		}
+		log.Printf("connected flashblocks websocket=%s", cfg.flashblocksURL)
+	}
 
 	if cfg.blockNum != 0 {
 		validation, err := sdm.ValidatePostExecBlock(ctx, sender.RPC, cfg.blockNum, validationOpts)
@@ -171,7 +185,7 @@ func run(cfg config) error {
 
 	var lastErr error
 	for attempt := 1; attempt <= cfg.attempts; attempt++ {
-		result, err := submitAttempt(ctx, cfg, sender, contract, attempt, validationOpts)
+		result, err := submitAttempt(ctx, cfg, sender, contract, attempt, validationOpts, flashblocks)
 		if err == nil {
 			return printResult(cfg, *result)
 		}
@@ -374,7 +388,7 @@ func resolveContract(ctx context.Context, cfg config, sender *sdm.TxSender) (com
 	return *receipt.ContractAddress, nil
 }
 
-func submitAttempt(ctx context.Context, cfg config, sender *sdm.TxSender, contract common.Address, attempt int, validationOpts sdm.ValidationOptions) (*workloadResult, error) {
+func submitAttempt(ctx context.Context, cfg config, sender *sdm.TxSender, contract common.Address, attempt int, validationOpts sdm.ValidationOptions, flashblocks *sdm.FlashblockCollector) (*workloadResult, error) {
 	startNonce, err := sender.Eth.PendingNonceAt(ctx, sender.From)
 	if err != nil {
 		return nil, fmt.Errorf("pending nonce: %w", err)
@@ -382,7 +396,7 @@ func submitAttempt(ctx context.Context, cfg config, sender *sdm.TxSender, contra
 	log.Printf("attempt=%d submitting %d txs contract=%s start_nonce=%d slot_count=%d", attempt, cfg.batchSize, contract, startNonce, cfg.slotCount)
 
 	calldata := sdm.EncodeRun(cfg.slotCount)
-	txs, err := submitWorkloadTxs(ctx, cfg, sender, contract, startNonce, calldata)
+	txs, err := submitWorkloadTxs(ctx, cfg, sender, contract, startNonce, calldata, flashblocks)
 	if err != nil {
 		return nil, err
 	}
@@ -423,6 +437,7 @@ func submitAttempt(ctx context.Context, cfg config, sender *sdm.TxSender, contra
 			SubmittedTxs:    len(txs),
 			IncludedByBlock: includedByBlock,
 			Validation:      validation,
+			Flashblocks:     flashblocks.WaitSummaries(ctx, blockNum, 2*time.Second),
 		}, nil
 	}
 	if len(validationErrs) > 0 {
@@ -438,8 +453,51 @@ func submitWorkloadTxs(
 	contract common.Address,
 	startNonce uint64,
 	calldata []byte,
+	flashblocks *sdm.FlashblockCollector,
 ) ([]*types.Transaction, error) {
 	txs := make([]*types.Transaction, 0, cfg.batchSize)
+	if flashblocks != nil && cfg.txsPerFlashblock > 0 {
+		latest, err := sender.Eth.BlockNumber(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("latest block before flashblock-paced submit: %w", err)
+		}
+		drained := flashblocks.DrainPending()
+		log.Printf("flashblock-paced submit enabled txs_per_flashblock=%d waiting_after_block=%d drained_pending_flashblocks=%d", cfg.txsPerFlashblock, latest, drained)
+
+		var targetBlock uint64
+		for len(txs) < cfg.batchSize {
+			fb, ok := flashblocks.WaitNext(ctx)
+			if !ok {
+				return txs, ctx.Err()
+			}
+			if fb.BlockNumber <= latest {
+				continue
+			}
+			if targetBlock == 0 {
+				if fb.Index != 0 {
+					log.Printf("skipping already-started flashblock block=%d index=%d; waiting for next block index=0", fb.BlockNumber, fb.Index)
+					latest = fb.BlockNumber
+					continue
+				}
+				targetBlock = fb.BlockNumber
+				log.Printf("flashblock-paced submit target_block=%d", targetBlock)
+			}
+			if fb.BlockNumber != targetBlock {
+				if len(txs) >= cfg.minUserTxs {
+					log.Printf("target block ended before full batch was submitted sent=%d requested=%d next_block=%d", len(txs), cfg.batchSize, fb.BlockNumber)
+					return txs, nil
+				}
+				targetBlock = fb.BlockNumber
+			}
+
+			log.Printf("submitting workload chunk after flashblock block=%d index=%d sent_before=%d", fb.BlockNumber, fb.Index, len(txs))
+			if err := sendWorkloadChunk(ctx, cfg, sender, contract, startNonce, calldata, &txs); err != nil {
+				return txs, err
+			}
+		}
+		return txs, nil
+	}
+
 	for i := 0; i < cfg.batchSize; i++ {
 		if i > 0 && cfg.txSpacing > 0 {
 			select {
@@ -455,6 +513,34 @@ func submitWorkloadTxs(
 		txs = append(txs, tx)
 	}
 	return txs, nil
+}
+
+func sendWorkloadChunk(
+	ctx context.Context,
+	cfg config,
+	sender *sdm.TxSender,
+	contract common.Address,
+	startNonce uint64,
+	calldata []byte,
+	txs *[]*types.Transaction,
+) error {
+	remaining := cfg.batchSize - len(*txs)
+	if remaining <= 0 {
+		return nil
+	}
+	chunk := cfg.txsPerFlashblock
+	if chunk <= 0 || chunk > remaining {
+		chunk = remaining
+	}
+	for i := 0; i < chunk; i++ {
+		nonce := startNonce + uint64(len(*txs))
+		tx, err := sender.SendCall(ctx, nonce, contract, calldata, cfg.gasLimit)
+		if err != nil {
+			return err
+		}
+		*txs = append(*txs, tx)
+	}
+	return nil
 }
 
 func printResult(cfg config, result workloadResult) error {
@@ -474,6 +560,11 @@ func printResult(cfg config, result workloadResult) error {
 	}
 	if v.Replay != nil {
 		log.Printf("replay raw_gas=%d canonical_gas=%d replay_refund_total=%d", v.Replay.Summary.BlockRawGasUsed, v.Replay.Summary.BlockGasUsed, v.Replay.Summary.ReplayRefundTotal)
+	}
+	log.Printf("flashblocks observed=%d", len(result.Flashblocks))
+	for _, fb := range result.Flashblocks {
+		log.Printf("flashblock block=%d index=%d txs=%d has_post_exec_tx=%t post_exec_tx_bytes=%d",
+			fb.BlockNumber, fb.Index, fb.TxCount, fb.HasPostExecTx, fb.PostExecTxBytes)
 	}
 	return nil
 }

--- a/op-chain-ops/pkg/sdm/flashblocks.go
+++ b/op-chain-ops/pkg/sdm/flashblocks.go
@@ -1,0 +1,160 @@
+package sdm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+)
+
+// FlashblockSummary captures the per-flashblock fields useful when comparing a final block
+// against the flashblocks that were streamed while it was being built.
+type FlashblockSummary struct {
+	BlockNumber     uint64 `json:"block_number"`
+	Index           int    `json:"index"`
+	TxCount         int    `json:"tx_count"`
+	HasPostExecTx   bool   `json:"has_post_exec_tx"`
+	PostExecTxBytes int    `json:"post_exec_tx_bytes,omitempty"`
+}
+
+// FlashblockCollector records flashblocks observed from an op-rbuilder flashblocks websocket.
+type FlashblockCollector struct {
+	mu      sync.Mutex
+	byBlock map[uint64][]FlashblockSummary
+	next    chan FlashblockSummary
+	err     error
+}
+
+// StartFlashblockCollector dials url and records every flashblock until ctx is canceled.
+func StartFlashblockCollector(ctx context.Context, url string) (*FlashblockCollector, error) {
+	conn, _, err := websocket.Dial(ctx, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("dial flashblocks websocket %s: %w", url, err)
+	}
+
+	collector := &FlashblockCollector{
+		byBlock: make(map[uint64][]FlashblockSummary),
+		next:    make(chan FlashblockSummary, 1024),
+	}
+	go func() {
+		defer conn.Close(websocket.StatusNormalClosure, "sdm-devnet done")
+		for {
+			_, msg, err := conn.Read(ctx)
+			if err != nil {
+				if ctx.Err() == nil {
+					collector.setErr(err)
+				}
+				return
+			}
+
+			var fb sources.Flashblock
+			if err := json.Unmarshal(msg, &fb); err != nil {
+				collector.setErr(fmt.Errorf("unmarshal flashblock: %w", err))
+				continue
+			}
+
+			summary := FlashblockSummary{
+				BlockNumber:   uint64(fb.Metadata.BlockNumber),
+				Index:         fb.Index,
+				TxCount:       len(fb.Diff.Transactions),
+				HasPostExecTx: fb.Diff.PostExecTx != nil,
+			}
+			if fb.Diff.PostExecTx != nil {
+				summary.PostExecTxBytes = len(*fb.Diff.PostExecTx)
+			}
+
+			collector.mu.Lock()
+			collector.byBlock[summary.BlockNumber] = append(collector.byBlock[summary.BlockNumber], summary)
+			collector.mu.Unlock()
+			select {
+			case collector.next <- summary:
+			default:
+			}
+		}
+	}()
+	return collector, nil
+}
+
+func (c *FlashblockCollector) setErr(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.err = err
+}
+
+func (c *FlashblockCollector) Err() error {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.err
+}
+
+func (c *FlashblockCollector) WaitNext(ctx context.Context) (FlashblockSummary, bool) {
+	if c == nil {
+		return FlashblockSummary{}, false
+	}
+	select {
+	case summary := <-c.next:
+		return summary, true
+	case <-ctx.Done():
+		return FlashblockSummary{}, false
+	}
+}
+
+func (c *FlashblockCollector) DrainPending() int {
+	if c == nil {
+		return 0
+	}
+	drained := 0
+	for {
+		select {
+		case <-c.next:
+			drained++
+		default:
+			return drained
+		}
+	}
+}
+
+func (c *FlashblockCollector) Summaries(blockNum uint64) []FlashblockSummary {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := append([]FlashblockSummary(nil), c.byBlock[blockNum]...)
+	sort.Slice(out, func(i, j int) bool { return out[i].Index < out[j].Index })
+	return out
+}
+
+// WaitSummaries waits briefly for at least one flashblock for blockNum. It returns an empty slice
+// if none arrives before the timeout, so callers can report "0 observed" without failing the SDM
+// validation itself.
+func (c *FlashblockCollector) WaitSummaries(ctx context.Context, blockNum uint64, timeout time.Duration) []FlashblockSummary {
+	if c == nil {
+		return nil
+	}
+	if summaries := c.Summaries(blockNum); len(summaries) > 0 {
+		return summaries
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-waitCtx.Done():
+			return c.Summaries(blockNum)
+		case <-ticker.C:
+			if summaries := c.Summaries(blockNum); len(summaries) > 0 {
+				return summaries
+			}
+		}
+	}
+}

--- a/op-devstack/sysgo/singlechain_flashblocks.go
+++ b/op-devstack/sysgo/singlechain_flashblocks.go
@@ -27,14 +27,26 @@ func startFlashblocksSingleChainPrimary(
 	sequencerIdentity := NewELNodeIdentity(0)
 	builderIdentity := NewELNodeIdentity(0)
 
-	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, sequencerIdentity)
+	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, sequencerIdentity, cfg.OpRethOptions...)
 	l2Builder := startBuilderEL(t, world.L2Network, jwtPath, builderIdentity, cfg.OPRBuilderOptions...)
 
 	connectL2ELPeers(t, logger, l2EL.UserRPC(), l2Builder.UserRPC(), false)
 	connectL2ELPeers(t, logger, l2Builder.UserRPC(), l2EL.UserRPC(), true)
 
 	rollupBoost := startRollupBoostNode(t, world.L2Network.ChainID(), l2EL, l2Builder)
-	l2CL := startSequencerCL(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, rollupBoost, jwtSecret, nil)
+	var l2CL L2CLNode
+	if world.Interop != nil {
+		l2CL = startL2CLNode(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, rollupBoost, jwtSecret, l2CLNodeStartConfig{
+			Key:           "sequencer",
+			IsSequencer:   true,
+			NoDiscovery:   true,
+			EnableReqResp: true,
+			UseReqResp:    true,
+			DependencySet: world.Interop.DependencySet,
+		})
+	} else {
+		l2CL = startSequencerCL(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, rollupBoost, jwtSecret, nil)
+	}
 
 	return singleChainPrimaryRuntime{
 		EL: l2EL,

--- a/op-service/sources/flashblock_client.go
+++ b/op-service/sources/flashblock_client.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/coder/websocket"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -14,13 +15,14 @@ type Flashblock struct {
 	PayloadID string `json:"payload_id"`
 	Index     int    `json:"index"`
 	Diff      struct {
-		StateRoot    string `json:"state_root"`
-		ReceiptsRoot string `json:"receipts_root"`
-		LogsBloom    string `json:"logs_bloom"`
-		GasUsed      string `json:"gas_used"`
-		BlockHash    string `json:"block_hash"`
-		Transactions []any  `json:"transactions"`
-		Withdrawals  []any  `json:"withdrawals"`
+		StateRoot    string         `json:"state_root"`
+		ReceiptsRoot string         `json:"receipts_root"`
+		LogsBloom    string         `json:"logs_bloom"`
+		GasUsed      string         `json:"gas_used"`
+		BlockHash    string         `json:"block_hash"`
+		Transactions []any          `json:"transactions"`
+		PostExecTx   *hexutil.Bytes `json:"post_exec_tx"`
+		Withdrawals  []any          `json:"withdrawals"`
 	} `json:"diff"`
 	Metadata struct {
 		BlockNumber        int                    `json:"block_number"`

--- a/rust/op-rbuilder/Cargo.lock
+++ b/rust/op-rbuilder/Cargo.lock
@@ -7768,6 +7768,7 @@ dependencies = [
  "alloy-contract 2.0.5",
  "alloy-eips 2.0.5",
  "alloy-evm",
+ "alloy-hardforks",
  "alloy-json-rpc 2.0.5",
  "alloy-network 2.0.5",
  "alloy-op-evm",
@@ -11262,6 +11263,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-optimism-post-exec-replay"
+version = "1.11.3"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
+ "op-alloy-consensus",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-node-api",
+ "reth-optimism-evm",
+ "reth-primitives-traits",
+ "revm",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reth-optimism-primitives"
 version = "1.11.3"
 dependencies = [
@@ -11281,6 +11300,7 @@ version = "1.11.3"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
+ "alloy-hardforks",
  "alloy-json-rpc 2.0.5",
  "alloy-op-evm",
  "alloy-primitives 1.6.0",
@@ -11318,6 +11338,7 @@ dependencies = [
  "reth-optimism-flashblocks",
  "reth-optimism-forks",
  "reth-optimism-payload-builder",
+ "reth-optimism-post-exec-replay",
  "reth-optimism-primitives",
  "reth-optimism-trie",
  "reth-optimism-txpool",

--- a/rust/op-rbuilder/crates/op-rbuilder/Cargo.toml
+++ b/rust/op-rbuilder/crates/op-rbuilder/Cargo.toml
@@ -52,6 +52,7 @@ reth-transaction-pool.workspace = true
 reth-network-peers.workspace = true
 reth-testing-utils.workspace = true
 reth-optimism-forks.workspace = true
+alloy-hardforks.workspace = true
 reth-node-builder.workspace = true
 reth-storage-api.workspace = true
 reth-rpc-api.workspace = true

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
@@ -11,12 +11,14 @@ use op_revm::{L1BlockInfo, OpSpecId};
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{
-    ConfigureEvm, EvmEnv,
+    EvmEnv,
     execute::{BlockBuilder, BlockExecutionError, BlockValidationError},
 };
 use reth_node_api::PayloadBuilderError;
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
+use reth_optimism_evm::{
+    ConfigurePostExecEvm, OpEvmConfig, OpNextBlockEnvAttributes, PostExecExecutorExt, PostExecMode,
+};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::OpPayloadBuilderAttributes;
 use reth_optimism_payload_builder::{
@@ -34,7 +36,11 @@ use reth_primitives_traits::{InMemorySize, SealedHeader, SignedTransaction};
 use reth_revm::{State, context::Block};
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction};
 use revm::interpreter::as_u64_saturated;
-use std::{sync::Arc, time::Instant};
+use std::{
+    ops::DerefMut,
+    sync::{Arc, atomic::Ordering},
+    time::Instant,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace};
 
@@ -42,6 +48,7 @@ use crate::{
     gas_limiter::AddressGasLimiter,
     metrics::OpRBuilderMetrics,
     primitives::reth::{ExecutionInfo, TxnExecutionResult},
+    sdm_admin::SdmDesiredEnabledFlag,
     traits::PayloadTxsBounds,
     tx::MaybeRevertingTransaction,
     tx_signer::Signer,
@@ -57,6 +64,69 @@ where
     let mut receipt = executor.receipts().last().cloned()?;
     receipt.as_receipt_mut().cumulative_gas_used = cumulative_gas_used;
     Some(receipt)
+}
+
+pub(super) struct PostExecBuilder<B> {
+    inner: B,
+}
+
+impl<B> PostExecBuilder<B> {
+    pub(super) fn new(inner: B) -> Self {
+        Self { inner }
+    }
+}
+
+impl<B> BlockBuilder for PostExecBuilder<B>
+where
+    B: BlockBuilder,
+{
+    type Primitives = B::Primitives;
+    type Executor = B::Executor;
+
+    fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
+        self.inner.apply_pre_execution_changes()
+    }
+
+    fn execute_transaction_with_commit_condition(
+        &mut self,
+        tx: impl reth_evm::execute::ExecutorTx<Self::Executor>,
+        f: impl FnOnce(&<Self::Executor as AlloyBlockExecutor>::Result) -> CommitChanges,
+    ) -> Result<Option<alloy_evm::block::GasOutput>, BlockExecutionError> {
+        self.inner.execute_transaction_with_commit_condition(tx, f)
+    }
+
+    fn finish(
+        self,
+        state_provider: impl reth_provider::StateProvider,
+        state_root_precomputed: Option<(alloy_primitives::B256, reth_trie::updates::TrieUpdates)>,
+    ) -> Result<reth_evm::execute::BlockBuilderOutcome<Self::Primitives>, BlockExecutionError> {
+        self.inner.finish(state_provider, state_root_precomputed)
+    }
+
+    fn executor_mut(&mut self) -> &mut Self::Executor {
+        self.inner.executor_mut()
+    }
+
+    fn executor(&self) -> &Self::Executor {
+        self.inner.executor()
+    }
+
+    fn into_executor(self) -> Self::Executor {
+        self.inner.into_executor()
+    }
+}
+
+impl<B> PostExecBuilder<B>
+where
+    B: BlockBuilder,
+{
+    pub(super) fn state_db_mut<DB>(&mut self) -> &mut State<DB>
+    where
+        B::Executor: AlloyBlockExecutor<Evm: AlloyEvm<DB: DerefMut<Target = State<DB>>>>,
+        DB: Database,
+    {
+        self.inner.evm_mut().db_mut().deref_mut()
+    }
 }
 
 /// Container type that holds all necessities to build a new payload.
@@ -88,6 +158,9 @@ pub struct OpPayloadBuilderCtx<ExtraCtx: Debug + Default = ()> {
     pub max_gas_per_txn: Option<u64>,
     /// Rate limiting based on gas. This is an optional feature.
     pub address_gas_limiter: AddressGasLimiter,
+    /// Local operator opt-in for SDM PostExec production. ANDed with the chain-spec
+    /// Interop gate in [`Self::post_exec_mode`].
+    pub sdm_desired_enabled: SdmDesiredEnabledFlag,
 }
 
 impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
@@ -253,23 +326,49 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
 }
 
 impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
-    /// Returns a block builder for the next block in the payload.
+    /// Returns the post-exec mode for the current payload.
+    ///
+    /// Two gates must agree: the protocol gate (chain spec Interop at this block's
+    /// timestamp) and the operator gate (`sdm_desired_enabled`, mutated via
+    /// `admin_setSdmEnabled`). Either being false disables production.
+    pub fn post_exec_mode(&self) -> PostExecMode {
+        let protocol_active = self
+            .evm_config
+            .is_sdm_active_at_timestamp(self.attributes().timestamp());
+        let operator_opted_in = self.sdm_desired_enabled.load(Ordering::Acquire);
+        if protocol_active && operator_opted_in {
+            PostExecMode::Produce
+        } else {
+            PostExecMode::Disabled
+        }
+    }
+
+    /// Returns a post-exec-aware block builder for the next block in the payload.
     pub(super) fn block_builder_for_next_block<'a, DB: Database + 'a>(
         &'a self,
         db: &'a mut State<DB>,
     ) -> Result<
-        impl BlockBuilder<
-            Primitives = reth_optimism_primitives::OpPrimitives,
-            Executor: AlloyBlockExecutor<
-                Transaction = OpTransactionSigned,
-                Receipt = OpReceipt,
-                Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
-            >,
-        > + 'a,
+        PostExecBuilder<
+            impl BlockBuilder<
+                Primitives = reth_optimism_primitives::OpPrimitives,
+                Executor: PostExecExecutorExt
+                              + AlloyBlockExecutor<
+                    Transaction = OpTransactionSigned,
+                    Receipt = OpReceipt,
+                    Evm: AlloyEvm<DB: DerefMut<Target = State<DB>>>,
+                >,
+            > + 'a,
+        >,
         PayloadBuilderError,
     > {
         self.evm_config
-            .builder_for_next_block(db, self.parent(), self.block_env_attributes.clone())
+            .post_exec_builder_for_next_block(
+                db,
+                self.parent(),
+                self.block_env_attributes.clone(),
+                self.post_exec_mode(),
+            )
+            .map(PostExecBuilder::new)
             .map_err(PayloadBuilderError::other)
     }
 

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/ctx.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/ctx.rs
@@ -2,6 +2,7 @@ use crate::{
     builders::{BuilderConfig, OpPayloadBuilderCtx, flashblocks::FlashblocksConfig},
     gas_limiter::{AddressGasLimiter, args::GasLimiterArgs},
     metrics::OpRBuilderMetrics,
+    sdm_admin::SdmDesiredEnabledFlag,
     traits::ClientBounds,
 };
 use op_revm::OpSpecId;
@@ -29,6 +30,8 @@ pub(super) struct OpPayloadSyncerCtx {
     max_gas_per_txn: Option<u64>,
     /// The metrics for the builder
     metrics: Arc<OpRBuilderMetrics>,
+    /// Operator opt-in flag for SDM PostExec production, shared with the admin RPC.
+    sdm_desired_enabled: SdmDesiredEnabledFlag,
 }
 
 impl OpPayloadSyncerCtx {
@@ -48,6 +51,7 @@ impl OpPayloadSyncerCtx {
             chain_spec,
             max_gas_per_txn: builder_config.max_gas_per_txn,
             metrics,
+            sdm_desired_enabled: builder_config.sdm_desired_enabled.clone(),
         })
     }
 
@@ -80,6 +84,7 @@ impl OpPayloadSyncerCtx {
             extra_ctx: (),
             max_gas_per_txn: self.max_gas_per_txn,
             address_gas_limiter: AddressGasLimiter::new(GasLimiterArgs::default()),
+            sdm_desired_enabled: self.sdm_desired_enabled,
         }
     }
 }

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -905,6 +905,8 @@ where
         ctx.metrics
             .payload_num_tx_gauge
             .set(info.executed_transactions.len() as f64);
+        ctx.metrics
+            .record_sdm_refund_gas(sdm_refund_gas(&info.extra.post_exec_entries));
 
         debug!(
             target: "payload_builder",
@@ -1067,6 +1069,10 @@ where
     fn take_bundle(&mut self) -> BundleState {
         State::take_bundle(self)
     }
+}
+
+fn sdm_refund_gas(entries: &[SDMGasEntry]) -> u64 {
+    entries.iter().map(|entry| entry.gas_refund).sum()
 }
 
 fn offset_post_exec_entries(

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -3,7 +3,7 @@ use crate::{
     builders::{
         BuilderConfig,
         builder_tx::BuilderTransactions,
-        context::OpPayloadBuilderCtx,
+        context::{OpPayloadBuilderCtx, PostExecBuilder},
         flashblocks::{best_txs::BestFlashblocksTxs, config::FlashBlocksConfigExt},
         generator::{BlockCell, BuildArguments, PayloadBuilder},
     },
@@ -13,32 +13,39 @@ use crate::{
     traits::{ClientBounds, PoolBounds},
 };
 use alloy_consensus::{
-    BlockBody, EMPTY_OMMER_ROOT_HASH, Header, constants::EMPTY_WITHDRAWALS, proofs,
+    BlockBody, EMPTY_OMMER_ROOT_HASH, Header, Sealable, constants::EMPTY_WITHDRAWALS, proofs,
 };
 use alloy_eips::{Encodable2718, eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
+use alloy_evm::block::BlockExecutor as AlloyBlockExecutor;
 use alloy_primitives::{Address, B256, U256, map::foldhash::HashMap};
 use core::time::Duration;
 use eyre::WrapErr as _;
+use op_alloy_consensus::{SDMGasEntry, build_post_exec_tx};
 use reth_basic_payload_builder::{BuildOutcome, PayloadConfig};
 use reth_chainspec::EthChainSpec;
-use reth_evm::{ConfigureEvm, execute::BlockBuilder};
+use reth_evm::{
+    ConfigureEvm,
+    execute::{BlockBuilder, BlockBuilderOutcome},
+};
 use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult};
 use reth_node_api::{Block, NodePrimitives, PayloadBuilderError};
 use reth_optimism_consensus::{calculate_receipt_root_no_memo_optimism, isthmus};
-use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
+use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes, PostExecExecutorExt, PostExecMode};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{OpBuiltPayload, OpPayloadBuilderAttributes};
 use reth_optimism_payload_builder::OpPayloadAttrs;
 use reth_optimism_primitives::{OpPrimitives, OpReceipt, OpTransactionSigned};
 use reth_payload_primitives::BuiltPayloadExecutedBlock;
 use reth_payload_util::BestPayloadTransactions;
-use reth_primitives_traits::RecoveredBlock;
+use reth_primitives_traits::{Recovered, RecoveredBlock};
 use reth_provider::{
     ExecutionOutcome, HashedPostStateProvider, ProviderError, StateRootProvider,
     StorageRootProvider,
 };
 use reth_revm::{
-    State, database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
+    State,
+    database::StateProviderDatabase,
+    db::{BundleState, states::bundle_state::BundleRetention},
 };
 use reth_transaction_pool::TransactionPool;
 use reth_trie::{HashedPostState, updates::TrieUpdates};
@@ -73,6 +80,18 @@ type NextBestFlashblocksTxs<Pool> = BestFlashblocksTxs<
 pub(super) struct FlashblocksExecutionInfo {
     /// Index of the last consumed flashblock, counting normal executed transactions only.
     last_flashblock_index: usize,
+    /// Block-global SDM refund entries already captured from previous flashblock builders.
+    post_exec_entries: Vec<SDMGasEntry>,
+}
+
+pub(super) struct CanonicalPostExecExecution {
+    execution_result: BlockExecutionResult<OpReceipt>,
+    block: RecoveredBlock<alloy_consensus::Block<OpTransactionSigned>>,
+    bundle: BundleState,
+    hashed_state: HashedPostState,
+    trie_updates: TrieUpdates,
+    post_exec_entries: Vec<SDMGasEntry>,
+    post_exec_tx: Option<OpTransactionSigned>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -280,6 +299,7 @@ where
             extra_ctx,
             max_gas_per_txn: self.config.max_gas_per_txn,
             address_gas_limiter: self.address_gas_limiter.clone(),
+            sdm_desired_enabled: self.config.sdm_desired_enabled.clone(),
         })
     }
 
@@ -331,10 +351,6 @@ where
             )
             .map_err(|e| PayloadBuilderError::Other(e.into()))?;
 
-        // The DB owns one StateProvider because `State` is held across awaits and
-        // `Box<dyn StateProvider + Send>` is not `Sync` (so borrowing it would make
-        // the future non-`Send`). A second StateProvider is borrowed for builder-tx
-        // simulation calls below.
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
         let db_state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
         let db = StateProviderDatabase::new(db_state_provider);
@@ -347,10 +363,8 @@ where
             .with_bundle_update()
             .build();
 
-        let mut info = {
-            let mut builder = ctx.block_builder_for_next_block(&mut state)?;
-            builder.apply_pre_execution_changes()?;
-            let mut info = ctx.execute_sequencer_transactions(&mut builder)?;
+        let (mut info, payload, fb_payload) = {
+            let (mut builder, mut info) = execute_pre_steps(&mut state, &ctx)?;
             let sequencer_tx_time = sequencer_tx_start_time.elapsed();
             ctx.metrics.sequencer_tx_duration.record(sequencer_tx_time);
             ctx.metrics.sequencer_tx_gauge.set(sequencer_tx_time);
@@ -372,15 +386,31 @@ where
                 );
             };
 
-            info
-        };
+            let canonical_execution = if matches!(ctx.post_exec_mode(), PostExecMode::Produce) {
+                let replay_state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
+                Some(replay_canonical_post_exec_execution(
+                    &ctx,
+                    replay_state_provider,
+                    &info,
+                )?)
+            } else {
+                None
+            };
+            let post_exec_entries = canonical_execution.as_ref().map_or_else(
+                || current_post_exec_entries(&info, &builder, 0),
+                |execution| execution.post_exec_entries.clone(),
+            );
+            let (payload, fb_payload) = build_block(
+                builder.state_db_mut(),
+                &ctx,
+                &mut info,
+                !disable_state_root || ctx.attributes().no_tx_pool, // need to calculate state root for CL sync
+                canonical_execution,
+            )?;
+            info.extra.post_exec_entries = post_exec_entries;
 
-        let (payload, fb_payload) = build_block(
-            &mut state,
-            &ctx,
-            &mut info,
-            !disable_state_root || ctx.attributes().no_tx_pool, // need to calculate state root for CL sync
-        )?;
+            (info, payload, fb_payload)
+        };
 
         self.payload_tx
             .try_send(payload.clone())
@@ -548,36 +578,39 @@ where
             }
 
             // build first flashblock immediately
-            let next_flashblocks_ctx = match self.build_next_flashblock(
-                &ctx,
-                &mut info,
-                &mut state,
-                &state_provider,
-                &mut best_txs,
-                &block_cancel,
-                &best_payload,
-                &fb_span,
-            ) {
-                Ok(Some(next_flashblocks_ctx)) => next_flashblocks_ctx,
-                Ok(None) => {
-                    self.record_flashblocks_metrics(
-                        &ctx,
-                        &info,
-                        flashblocks_per_block,
-                        &span,
-                        "Payload building complete, job cancelled or target flashblock count reached",
-                    );
-                    return Ok(());
-                }
-                Err(err) => {
-                    error!(
-                        target: "payload_builder",
-                        "Failed to build flashblock {} for block number {}: {}",
-                        ctx.flashblock_index(),
-                        ctx.block_number(),
-                        err
-                    );
-                    return Err(PayloadBuilderError::Other(err.into()));
+            let next_flashblocks_ctx = {
+                let mut builder = ctx.block_builder_for_next_block(&mut state)?;
+                match self.build_next_flashblock(
+                    &ctx,
+                    &mut info,
+                    &mut builder,
+                    &state_provider,
+                    &mut best_txs,
+                    &block_cancel,
+                    &best_payload,
+                    &fb_span,
+                ) {
+                    Ok(Some(next_flashblocks_ctx)) => next_flashblocks_ctx,
+                    Ok(None) => {
+                        self.record_flashblocks_metrics(
+                            &ctx,
+                            &info,
+                            flashblocks_per_block,
+                            &span,
+                            "Payload building complete, job cancelled or target flashblock count reached",
+                        );
+                        return Ok(());
+                    }
+                    Err(err) => {
+                        error!(
+                            target: "payload_builder",
+                            "Failed to build flashblock {} for block number {}: {}",
+                            ctx.flashblock_index(),
+                            ctx.block_number(),
+                            err
+                        );
+                        return Err(PayloadBuilderError::Other(err.into()));
+                    }
                 }
             };
 
@@ -600,11 +633,15 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn build_next_flashblock<DB, P>(
+    fn build_next_flashblock<
+        Builder,
+        DB,
+        P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
+    >(
         &self,
         ctx: &OpPayloadBuilderCtx<FlashblocksExtraCtx>,
         info: &mut ExecutionInfo<FlashblocksExecutionInfo>,
-        state: &mut State<DB>,
+        builder: &mut PostExecBuilder<Builder>,
         state_provider: impl reth::providers::StateProvider + Clone,
         best_txs: &mut NextBestFlashblocksTxs<Pool>,
         block_cancel: &CancellationToken,
@@ -612,10 +649,18 @@ where
         span: &tracing::Span,
     ) -> eyre::Result<Option<FlashblocksExtraCtx>>
     where
-        DB: Database<Error = ProviderError> + std::fmt::Debug + AsRef<P>,
-        P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
+        Builder:
+            reth_evm::execute::BlockBuilder<Primitives = reth_optimism_primitives::OpPrimitives>,
+        Builder::Executor: PostExecExecutorExt
+            + AlloyBlockExecutor<
+                Transaction = OpTransactionSigned,
+                Receipt = OpReceipt,
+                Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+            >,
+        DB: Database + std::fmt::Debug + AsRef<P>,
     {
         let flashblock_index = ctx.flashblock_index();
+        let post_exec_index_offset = info.executed_transactions.len() as u64;
         let mut target_gas_for_batch = ctx.extra_ctx.target_gas_for_batch;
         let mut target_da_for_batch = ctx.extra_ctx.target_da_for_batch;
         let mut target_da_footprint_for_batch = ctx.extra_ctx.target_da_footprint_for_batch;
@@ -634,12 +679,10 @@ where
         );
         let flashblock_build_start_time = Instant::now();
 
-        let mut builder = ctx.block_builder_for_next_block(state)?;
-
         let builder_txs =
             match self
                 .builder_tx
-                .add_builder_txs(&state_provider, info, ctx, &mut builder, true)
+                .add_builder_txs(&state_provider, info, ctx, builder, true)
             {
                 Ok(builder_txs) => builder_txs,
                 Err(e) => {
@@ -691,7 +734,7 @@ where
         let tx_execution_start_time = Instant::now();
         ctx.execute_best_transactions(
             info,
-            &mut builder,
+            builder,
             best_txs,
             target_gas_for_batch.min(ctx.block_gas_limit()),
             target_da_for_batch,
@@ -727,21 +770,27 @@ where
             .payload_transaction_simulation_gauge
             .set(payload_transaction_simulation_time);
 
-        if let Err(e) =
-            self.builder_tx
-                .add_builder_txs(&state_provider, info, ctx, &mut builder, false)
+        if let Err(e) = self
+            .builder_tx
+            .add_builder_txs(&state_provider, info, ctx, builder, false)
         {
             error!(target: "payload_builder", "Error simulating builder txs: {}", e);
         };
 
-        drop(builder);
-
+        let canonical_execution = matches!(ctx.post_exec_mode(), PostExecMode::Produce)
+            .then(|| replay_canonical_post_exec_execution(ctx, state_provider.clone(), info))
+            .transpose()?;
+        let post_exec_entries = canonical_execution.as_ref().map_or_else(
+            || current_post_exec_entries(info, builder, post_exec_index_offset),
+            |execution| execution.post_exec_entries.clone(),
+        );
         let total_block_built_duration = Instant::now();
         let build_result = build_block(
-            state,
+            builder.state_db_mut::<DB>(),
             ctx,
             info,
             !ctx.extra_ctx.disable_state_root || ctx.attributes().no_tx_pool,
+            canonical_execution,
         );
         let total_block_built_duration = total_block_built_duration.elapsed();
         ctx.metrics
@@ -757,6 +806,7 @@ where
                 Err(err).wrap_err("failed to build payload")
             }
             Ok((new_payload, mut fb_payload)) => {
+                info.extra.post_exec_entries = post_exec_entries;
                 fb_payload.index = flashblock_index;
                 fb_payload.base = None;
 
@@ -972,19 +1022,197 @@ struct FlashblocksMetadata {
     block_number: u64,
 }
 
-pub(super) fn build_block<DB, P, ExtraCtx>(
-    state: &mut State<DB>,
+pub(super) trait FlashblockBuildState<P> {
+    type TransitionState: Clone;
+
+    fn transition_state_snapshot(&self) -> Self::TransitionState;
+    fn restore_transition_state(&mut self, transition_state: Self::TransitionState);
+    fn merge_transitions(&mut self, retention: BundleRetention);
+    fn bundle_state_clone(&self) -> BundleState;
+    fn bundle_state(&self) -> &BundleState;
+    fn provider(&self) -> &P;
+    fn take_bundle(&mut self) -> BundleState;
+}
+
+impl<DB, P> FlashblockBuildState<P> for State<DB>
+where
+    DB: Database + AsRef<P>,
+{
+    type TransitionState = Option<revm::database::TransitionState>;
+
+    fn transition_state_snapshot(&self) -> Self::TransitionState {
+        self.transition_state.clone()
+    }
+
+    fn restore_transition_state(&mut self, transition_state: Self::TransitionState) {
+        self.transition_state = transition_state;
+    }
+
+    fn merge_transitions(&mut self, retention: BundleRetention) {
+        State::merge_transitions(self, retention);
+    }
+
+    fn bundle_state_clone(&self) -> BundleState {
+        self.bundle_state.clone()
+    }
+
+    fn bundle_state(&self) -> &BundleState {
+        &self.bundle_state
+    }
+
+    fn provider(&self) -> &P {
+        self.database.as_ref()
+    }
+
+    fn take_bundle(&mut self) -> BundleState {
+        State::take_bundle(self)
+    }
+}
+
+fn offset_post_exec_entries(
+    previous_entries: &[SDMGasEntry],
+    builder_entries: &[SDMGasEntry],
+    tx_index_offset: u64,
+) -> Vec<SDMGasEntry> {
+    previous_entries
+        .iter()
+        .cloned()
+        .chain(builder_entries.iter().cloned().map(|mut entry| {
+            entry.index = entry.index.saturating_add(tx_index_offset);
+            entry
+        }))
+        .collect()
+}
+
+fn current_post_exec_entries<Builder>(
+    info: &ExecutionInfo<FlashblocksExecutionInfo>,
+    builder: &PostExecBuilder<Builder>,
+    tx_index_offset: u64,
+) -> Vec<SDMGasEntry>
+where
+    Builder: BlockBuilder,
+    Builder::Executor: PostExecExecutorExt,
+{
+    offset_post_exec_entries(
+        &info.extra.post_exec_entries,
+        builder.executor().post_exec_entries(),
+        tx_index_offset,
+    )
+}
+
+fn replay_canonical_post_exec_execution<ExtraCtx>(
+    ctx: &OpPayloadBuilderCtx<ExtraCtx>,
+    state_provider: impl reth::providers::StateProvider,
+    info: &ExecutionInfo<FlashblocksExecutionInfo>,
+) -> Result<CanonicalPostExecExecution, PayloadBuilderError>
+where
+    ExtraCtx: std::fmt::Debug + Default,
+{
+    let db = StateProviderDatabase::new(&state_provider);
+    let mut replay_state = State::builder()
+        .with_database(db)
+        .with_bundle_update()
+        .build();
+    let mut replay_builder = ctx.block_builder_for_next_block(&mut replay_state)?;
+    replay_builder.apply_pre_execution_changes()?;
+
+    for (tx, sender) in info
+        .executed_transactions
+        .iter()
+        .cloned()
+        .zip(info.executed_senders.iter().copied())
+    {
+        replay_builder.execute_transaction(Recovered::new_unchecked(tx, sender))?;
+    }
+
+    let post_exec_entries = replay_builder.executor_mut().take_post_exec_entries();
+    let post_exec_tx = build_current_post_exec_tx(ctx, post_exec_entries.clone());
+    if let Some(post_exec_tx) = &post_exec_tx {
+        replay_builder.execute_transaction(Recovered::new_unchecked(
+            post_exec_tx.clone(),
+            Address::ZERO,
+        ))?;
+    }
+
+    let BlockBuilderOutcome {
+        execution_result,
+        hashed_state,
+        trie_updates,
+        block,
+        block_access_list: _,
+    } = replay_builder.finish(&state_provider, None)?;
+    let bundle = replay_state.take_bundle();
+
+    Ok(CanonicalPostExecExecution {
+        execution_result,
+        block,
+        bundle,
+        hashed_state,
+        trie_updates,
+        post_exec_entries,
+        post_exec_tx,
+    })
+}
+
+fn build_current_post_exec_tx<ExtraCtx>(
+    ctx: &OpPayloadBuilderCtx<ExtraCtx>,
+    entries: Vec<SDMGasEntry>,
+) -> Option<OpTransactionSigned>
+where
+    ExtraCtx: std::fmt::Debug + Default,
+{
+    if !matches!(ctx.post_exec_mode(), PostExecMode::Produce) || entries.is_empty() {
+        return None;
+    }
+
+    Some(OpTransactionSigned::from(
+        build_post_exec_tx(ctx.block_number(), entries).seal_slow(),
+    ))
+}
+
+#[allow(clippy::type_complexity)]
+fn execute_pre_steps<'a, DB, ExtraCtx>(
+    state: &'a mut State<DB>,
+    ctx: &'a OpPayloadBuilderCtx<ExtraCtx>,
+) -> Result<
+    (
+        PostExecBuilder<
+            impl reth_evm::execute::BlockBuilder<
+                Primitives = reth_optimism_primitives::OpPrimitives,
+                Executor: PostExecExecutorExt
+                              + AlloyBlockExecutor<
+                    Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+                >,
+            > + 'a,
+        >,
+        ExecutionInfo<FlashblocksExecutionInfo>,
+    ),
+    PayloadBuilderError,
+>
+where
+    DB: Database<Error = ProviderError> + std::fmt::Debug,
+    ExtraCtx: std::fmt::Debug + Default,
+{
+    let mut builder = ctx.block_builder_for_next_block(state)?;
+    builder.apply_pre_execution_changes()?;
+    let info = ctx.execute_sequencer_transactions(&mut builder)?;
+
+    Ok((builder, info))
+}
+
+pub(super) fn build_block<P, ExtraCtx>(
+    state: &mut impl FlashblockBuildState<P>,
     ctx: &OpPayloadBuilderCtx<ExtraCtx>,
     info: &mut ExecutionInfo<FlashblocksExecutionInfo>,
     calculate_state_root: bool,
+    canonical_execution: Option<CanonicalPostExecExecution>,
 ) -> Result<(OpBuiltPayload, FlashblocksPayloadV1), PayloadBuilderError>
 where
-    DB: Database<Error = ProviderError> + AsRef<P>,
     P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
     ExtraCtx: std::fmt::Debug + Default,
 {
     // We use it to preserve state, so we run merge_transitions on transition state at most once
-    let untouched_transition_state = state.transition_state.clone();
+    let untouched_transition_state = state.transition_state_snapshot();
     let state_merge_start_time = Instant::now();
     state.merge_transitions(BundleRetention::Reverts);
     let state_transition_merge_time = state_merge_start_time.elapsed();
@@ -998,8 +1226,102 @@ where
     let block_number = ctx.block_number();
     assert_eq!(block_number, ctx.parent().number + 1);
 
+    if let Some(canonical_execution) = canonical_execution {
+        let sealed_block = Arc::new(canonical_execution.block.sealed_block().clone());
+        let header = sealed_block.header();
+        let block_hash = sealed_block.hash();
+
+        let new_transactions =
+            info.executed_transactions[info.extra.last_flashblock_index..].to_vec();
+        let new_transactions_encoded = new_transactions
+            .clone()
+            .into_iter()
+            .map(|tx| tx.encoded_2718().into())
+            .collect::<Vec<_>>();
+
+        let new_receipts = canonical_execution.execution_result.receipts
+            [info.extra.last_flashblock_index..info.executed_transactions.len()]
+            .to_vec();
+        info.extra.last_flashblock_index = info.executed_transactions.len();
+        let receipts_with_hash = new_transactions
+            .iter()
+            .zip(new_receipts.iter())
+            .map(|(tx, receipt)| (tx.tx_hash(), receipt.clone()))
+            .collect::<HashMap<B256, OpReceipt>>();
+        let new_account_balances = canonical_execution
+            .bundle
+            .state
+            .iter()
+            .filter_map(|(address, account)| {
+                account.info.as_ref().map(|info| (*address, info.balance))
+            })
+            .collect::<HashMap<Address, U256>>();
+
+        let metadata = FlashblocksMetadata {
+            receipts: receipts_with_hash,
+            new_account_balances,
+            block_number,
+        };
+
+        let execution_output = BlockExecutionOutput {
+            state: canonical_execution.bundle.clone(),
+            result: canonical_execution.execution_result.clone(),
+        };
+        let executed = BuiltPayloadExecutedBlock {
+            recovered_block: Arc::new(canonical_execution.block.clone()),
+            execution_output: Arc::new(execution_output),
+            hashed_state: Arc::new(canonical_execution.hashed_state.clone()),
+            trie_updates: Arc::new(canonical_execution.trie_updates.clone()),
+        };
+
+        let fb_payload = FlashblocksPayloadV1 {
+            payload_id: ctx.payload_id(),
+            index: 0,
+            base: Some(ExecutionPayloadBaseV1 {
+                parent_beacon_block_root: ctx.attributes().parent_beacon_block_root().unwrap(),
+                parent_hash: ctx.parent().hash(),
+                fee_recipient: ctx.attributes().suggested_fee_recipient(),
+                prev_randao: ctx.attributes().prev_randao(),
+                block_number,
+                gas_limit: ctx.block_gas_limit(),
+                timestamp: ctx.attributes().timestamp(),
+                extra_data: ctx.extra_data()?,
+                base_fee_per_gas: ctx.base_fee().try_into().unwrap(),
+            }),
+            diff: ExecutionPayloadFlashblockDeltaV1 {
+                state_root: header.state_root,
+                receipts_root: header.receipts_root,
+                logs_bloom: header.logs_bloom,
+                gas_used: header.gas_used,
+                block_hash,
+                transactions: new_transactions_encoded,
+                post_exec_tx: canonical_execution
+                    .post_exec_tx
+                    .as_ref()
+                    .map(|tx| tx.encoded_2718().into()),
+                withdrawals: ctx.withdrawals().cloned().unwrap_or_default().to_vec(),
+                withdrawals_root: header.withdrawals_root.unwrap_or_default(),
+                blob_gas_used: header.blob_gas_used,
+            },
+            metadata: serde_json::to_value(&metadata).unwrap_or_default(),
+        };
+
+        state.take_bundle();
+        state.restore_transition_state(untouched_transition_state);
+
+        return Ok((
+            OpBuiltPayload::new(
+                ctx.payload_id(),
+                sealed_block,
+                info.total_fees,
+                Some(executed),
+            ),
+            fb_payload,
+        ));
+    }
+
     let execution_outcome = ExecutionOutcome::new(
-        state.bundle_state.clone(),
+        state.bundle_state_clone(),
         vec![info.receipts.clone()],
         block_number,
         vec![],
@@ -1026,12 +1348,11 @@ where
     let mut hashed_state = HashedPostState::default();
 
     if calculate_state_root {
-        let state_provider = state.database.as_ref();
+        let state_provider = state.provider();
         hashed_state = state_provider.hashed_post_state(execution_outcome.state());
         (state_root, trie_output) = {
             state
-                .database
-                .as_ref()
+                .provider()
                 .state_root_with_updates(hashed_state.clone())
                 .inspect_err(|err| {
                     warn!(target: "payload_builder",
@@ -1061,7 +1382,7 @@ where
         // withdrawals root field in block header is used for storage root of L2 predeploy
         // `l2tol1-message-passer`
         Some(
-            isthmus::withdrawals_root(execution_outcome.state(), state.database.as_ref())
+            isthmus::withdrawals_root(execution_outcome.state(), state.provider())
                 .map_err(PayloadBuilderError::other)?,
         )
     } else if ctx
@@ -1073,8 +1394,11 @@ where
         None
     };
 
+    let materialized_transactions = info.executed_transactions.clone();
+    let materialized_senders = info.executed_senders.clone();
+
     // create the block header
-    let transactions_root = proofs::calculate_transaction_root(&info.executed_transactions);
+    let transactions_root = proofs::calculate_transaction_root(&materialized_transactions);
 
     let (excess_blob_gas, blob_gas_used) = ctx.blob_fields(info);
     let block_gas_used = info.cumulative_gas_used;
@@ -1110,14 +1434,13 @@ where
     let block = alloy_consensus::Block::<OpTransactionSigned>::new(
         header,
         BlockBody {
-            transactions: info.executed_transactions.clone(),
+            transactions: materialized_transactions,
             ommers: vec![],
             withdrawals: ctx.withdrawals().cloned(),
         },
     );
 
-    let recovered_block =
-        RecoveredBlock::new_unhashed(block.clone(), info.executed_senders.clone());
+    let recovered_block = RecoveredBlock::new_unhashed(block.clone(), materialized_senders);
     // create the executed block data
 
     let execution_output = BlockExecutionOutput {
@@ -1163,7 +1486,7 @@ where
         .map(|(tx, receipt)| (tx.tx_hash(), receipt.clone()))
         .collect::<HashMap<B256, OpReceipt>>();
     let new_account_balances = state
-        .bundle_state
+        .bundle_state()
         .state
         .iter()
         .filter_map(|(address, account)| account.info.as_ref().map(|info| (*address, info.balance)))
@@ -1199,6 +1522,7 @@ where
             gas_used: block_gas_used,
             block_hash,
             transactions: new_transactions_encoded,
+            post_exec_tx: None,
             withdrawals: ctx.withdrawals().cloned().unwrap_or_default().to_vec(),
             withdrawals_root: withdrawals_root.unwrap_or_default(),
             blob_gas_used,
@@ -1208,7 +1532,7 @@ where
 
     // We clean bundle and place initial state transaction back
     state.take_bundle();
-    state.transition_state = untouched_transition_state;
+    state.restore_transition_state(untouched_transition_state);
 
     Ok((
         OpBuiltPayload::new(
@@ -1219,4 +1543,47 @@ where
         ),
         fb_payload,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn offset_post_exec_entries_preserves_previous_and_offsets_current() {
+        let previous = vec![SDMGasEntry {
+            index: 1,
+            gas_refund: 10,
+        }];
+        let current = vec![
+            SDMGasEntry {
+                index: 0,
+                gas_refund: 20,
+            },
+            SDMGasEntry {
+                index: 2,
+                gas_refund: 30,
+            },
+        ];
+
+        let entries = offset_post_exec_entries(&previous, &current, 5);
+
+        assert_eq!(
+            entries,
+            vec![
+                SDMGasEntry {
+                    index: 1,
+                    gas_refund: 10
+                },
+                SDMGasEntry {
+                    index: 5,
+                    gas_refund: 20
+                },
+                SDMGasEntry {
+                    index: 7,
+                    gas_refund: 30
+                },
+            ]
+        );
+    }
 }

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload_handler.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload_handler.rs
@@ -239,6 +239,7 @@ where
         &builder_ctx,
         &mut info,
         true,
+        None,
     )
     .wrap_err("failed to build flashblock")?;
 

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/mod.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/mod.rs
@@ -126,6 +126,11 @@ pub struct BuilderConfig<Specific: Clone> {
 
     /// Address gas limiter stuff
     pub gas_limiter_config: GasLimiterArgs,
+
+    /// Local operator opt-in for SDM PostExec production. Combined with the chain-spec
+    /// Interop gate in [`OpPayloadBuilderCtx::post_exec_mode`]; both must be true to
+    /// produce a PostExec tx. Mutated via the `admin_setSdmEnabled` RPC.
+    pub sdm_desired_enabled: crate::sdm_admin::SdmDesiredEnabledFlag,
 }
 
 impl<S: Debug + Clone> core::fmt::Debug for BuilderConfig<S> {
@@ -166,6 +171,7 @@ impl<S: Default + Clone> Default for BuilderConfig<S> {
             sampling_ratio: 100,
             max_gas_per_txn: None,
             gas_limiter_config: GasLimiterArgs::default(),
+            sdm_desired_enabled: Default::default(),
         }
     }
 }
@@ -188,6 +194,7 @@ where
             sampling_ratio: args.telemetry.sampling_ratio,
             max_gas_per_txn: args.max_gas_per_txn,
             gas_limiter_config: args.gas_limiter.clone(),
+            sdm_desired_enabled: Default::default(),
             specific: S::try_from(args)?,
         })
     }

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/standard/payload.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/standard/payload.rs
@@ -271,6 +271,7 @@ where
             extra_ctx: Default::default(),
             max_gas_per_txn: self.config.max_gas_per_txn,
             address_gas_limiter: self.address_gas_limiter.clone(),
+            sdm_desired_enabled: self.config.sdm_desired_enabled.clone(),
         };
 
         let builder = OpBuilder::new(best);

--- a/rust/op-rbuilder/crates/op-rbuilder/src/launcher.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/launcher.rs
@@ -8,11 +8,13 @@ use crate::{
     monitor_tx_pool::monitor_tx_pool,
     primitives::reth::engine_api_builder::OpEngineApiBuilder,
     revert_protection::{EthApiExtServer, RevertProtectionExt},
+    sdm_admin::{SdmAdminApiServer, SdmAdminExt},
     tx::FBPooledTransaction,
 };
 use core::fmt::Debug;
 use moka::future::Cache;
 use reth::builder::{NodeBuilder, WithLaunchContext};
+use reth_chainspec::ChainSpecProvider;
 use reth_cli_commands::launcher::Launcher;
 use reth_db::mdbx::DatabaseEnv;
 use reth_optimism_chainspec::OpChainSpec;
@@ -105,6 +107,7 @@ where
 
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
+        let sdm_desired_enabled = builder_config.sdm_desired_enabled.clone();
         let rollup_args = builder_args.rollup_args;
         let op_node = OpNode::new(rollup_args.clone());
         let reverted_cache = Cache::builder().max_capacity(100).build();
@@ -163,6 +166,11 @@ where
                     ctx.modules
                         .add_or_replace_configured(revert_protection_ext.into_rpc())?;
                 }
+
+                let sdm_admin_ext =
+                    SdmAdminExt::new(sdm_desired_enabled.clone(), ctx.provider().chain_spec());
+                ctx.modules
+                    .add_or_replace_configured(sdm_admin_ext.into_rpc())?;
 
                 Ok(())
             })

--- a/rust/op-rbuilder/crates/op-rbuilder/src/lib.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/lib.rs
@@ -7,6 +7,7 @@ pub mod metrics;
 mod monitor_tx_pool;
 pub mod primitives;
 pub mod revert_protection;
+pub mod sdm_admin;
 pub mod traits;
 pub mod tx;
 pub mod tx_signer;

--- a/rust/op-rbuilder/crates/op-rbuilder/src/metrics.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/metrics.rs
@@ -213,6 +213,10 @@ pub fn record_flag_gauge_metrics(builder_args: &OpRbuilderArgs) {
         .set(builder_args.flashtestations.flashtestations_enabled as i32);
     gauge!("op_rbuilder_flags_enable_revert_protection")
         .set(builder_args.enable_revert_protection as i32);
+    // SDM opt-in starts disabled on every process boot; the value is mutated at runtime via
+    // admin_setSdmEnabled. We seed the gauge here so scrapes pre-RPC see 0 rather than
+    // missing-metric.
+    gauge!("op_rbuilder_flags_sdm_enabled").set(0);
 }
 
 /// Record TEE workload ID and measurement metrics

--- a/rust/op-rbuilder/crates/op-rbuilder/src/sdm_admin.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/sdm_admin.rs
@@ -1,0 +1,106 @@
+//! Local SDM PostExec opt-in for op-rbuilder.
+//!
+//! The protocol gate (chain spec Interop activation) controls *whether* a block may
+//! carry a PostExec tx — that's a consensus rule shared by every node. This module
+//! adds an orthogonal *operator* gate: even on an SDM-active chain, the local
+//! builder produces PostExec txs only when the operator has explicitly opted in
+//! via [`admin_setSdmEnabled`]. Both gates must be true.
+//!
+//! State is in-memory and starts disabled on every process boot; persistence is
+//! deliberately out of scope.
+
+use alloy_hardforks::ForkCondition;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use metrics::gauge;
+use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_forks::{OpHardfork, OpHardforks};
+use serde::{Deserialize, Serialize};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+/// Shared "operator wants to produce PostExec" flag. Cloned into both the RPC
+/// handler (writer) and every payload-builder ctx (reader).
+pub type SdmDesiredEnabledFlag = Arc<AtomicBool>;
+
+/// Status snapshot returned by `admin_sdmStatus`.
+///
+/// Mirrors the op-node side so a single client surface can render either node's
+/// state without translation.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SdmStatus {
+    /// Whether the operator has opted in via `admin_setSdmEnabled`.
+    pub desired_enabled: bool,
+    /// Whether SDM is active per the chain spec at `query_timestamp`.
+    pub protocol_active: bool,
+    /// AND of the above — the actual decision the builder will make for a block
+    /// at `query_timestamp`.
+    pub effective: bool,
+    /// Activation timestamp of the protocol gate (Interop) if scheduled.
+    pub activation_time: Option<u64>,
+}
+
+#[cfg_attr(not(test), rpc(server, namespace = "admin"))]
+#[cfg_attr(test, rpc(server, client, namespace = "admin"))]
+pub trait SdmAdminApi {
+    /// Toggle local PostExec production. Starts disabled on process boot.
+    #[method(name = "setSdmEnabled")]
+    fn set_sdm_enabled(&self, enabled: bool) -> RpcResult<()>;
+
+    /// Report the local opt-in flag, the chain-spec gate at `query_timestamp`,
+    /// and the AND. If `query_timestamp` is omitted, uses the current wall-clock
+    /// time, which is good enough for "is this builder configured to produce now?".
+    #[method(name = "sdmStatus")]
+    fn sdm_status(&self, query_timestamp: Option<u64>) -> RpcResult<SdmStatus>;
+}
+
+#[derive(Clone)]
+pub struct SdmAdminExt {
+    desired_enabled: SdmDesiredEnabledFlag,
+    chain_spec: Arc<OpChainSpec>,
+}
+
+impl SdmAdminExt {
+    pub fn new(desired_enabled: SdmDesiredEnabledFlag, chain_spec: Arc<OpChainSpec>) -> Self {
+        Self {
+            desired_enabled,
+            chain_spec,
+        }
+    }
+}
+
+impl SdmAdminApiServer for SdmAdminExt {
+    fn set_sdm_enabled(&self, enabled: bool) -> RpcResult<()> {
+        self.desired_enabled.store(enabled, Ordering::Release);
+        gauge!("op_rbuilder_flags_sdm_enabled").set(enabled as i32);
+        Ok(())
+    }
+
+    fn sdm_status(&self, query_timestamp: Option<u64>) -> RpcResult<SdmStatus> {
+        let timestamp = query_timestamp.unwrap_or_else(current_unix_timestamp);
+        let desired = self.desired_enabled.load(Ordering::Acquire);
+        let protocol_active = self.chain_spec.is_interop_active_at_timestamp(timestamp);
+        let activation_time = match self.chain_spec.op_fork_activation(OpHardfork::Interop) {
+            ForkCondition::Timestamp(t) => Some(t),
+            _ => None,
+        };
+        Ok(SdmStatus {
+            desired_enabled: desired,
+            protocol_active,
+            effective: desired && protocol_active,
+            activation_time,
+        })
+    }
+}
+
+fn current_unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}

--- a/rust/op-reth/crates/evm/src/post_exec_ext.rs
+++ b/rust/op-reth/crates/evm/src/post_exec_ext.rs
@@ -55,7 +55,13 @@ pub trait ConfigurePostExecEvm: ConfigureEvm {
         attributes: Self::NextBlockEnvCtx,
         post_exec_mode: PostExecMode,
     ) -> Result<
-        impl BlockBuilder<Primitives = Self::Primitives, Executor: PostExecExecutorExt> + 'a,
+        impl BlockBuilder<
+            Primitives = Self::Primitives,
+            Executor: PostExecExecutorExt
+                          + BlockExecutor<
+                Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+            >,
+        > + 'a,
         Self::Error,
     >;
 }
@@ -112,7 +118,13 @@ where
         attributes: Self::NextBlockEnvCtx,
         post_exec_mode: PostExecMode,
     ) -> Result<
-        impl BlockBuilder<Primitives = Self::Primitives, Executor: PostExecExecutorExt> + 'a,
+        impl BlockBuilder<
+            Primitives = Self::Primitives,
+            Executor: PostExecExecutorExt
+                          + BlockExecutor<
+                Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+            >,
+        > + 'a,
         Self::Error,
     > {
         let evm_env = self.next_evm_env(parent, &attributes)?;
@@ -209,7 +221,13 @@ where
         attributes: Self::NextBlockEnvCtx,
         post_exec_mode: PostExecMode,
     ) -> Result<
-        impl BlockBuilder<Primitives = Self::Primitives, Executor: PostExecExecutorExt> + 'a,
+        impl BlockBuilder<
+            Primitives = Self::Primitives,
+            Executor: PostExecExecutorExt
+                          + BlockExecutor<
+                Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+            >,
+        > + 'a,
         Self::Error,
     > {
         let evm_env = self.next_evm_env(parent, &attributes)?;

--- a/rust/op-reth/examples/custom-node/src/evm/config.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/config.rs
@@ -239,7 +239,13 @@ impl ConfigurePostExecEvm for CustomEvmConfig {
         attributes: Self::NextBlockEnvCtx,
         post_exec_mode: PostExecMode,
     ) -> Result<
-        impl BlockBuilder<Primitives = CustomNodePrimitives, Executor: PostExecExecutorExt> + 'a,
+        impl BlockBuilder<
+            Primitives = CustomNodePrimitives,
+            Executor: PostExecExecutorExt
+                          + alloy_evm::block::BlockExecutor<
+                Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+            >,
+        > + 'a,
         Self::Error,
     > {
         let evm_env = self.next_evm_env(parent, &attributes)?;

--- a/rust/rollup-boost/Cargo.lock
+++ b/rust/rollup-boost/Cargo.lock
@@ -9333,6 +9333,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-optimism-post-exec-replay"
+version = "1.11.3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
+ "op-alloy-consensus",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-node-api",
+ "reth-optimism-evm",
+ "reth-primitives-traits",
+ "revm",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reth-optimism-primitives"
 version = "1.11.3"
 dependencies = [
@@ -9352,6 +9370,7 @@ version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
+ "alloy-hardforks",
  "alloy-json-rpc",
  "alloy-op-evm",
  "alloy-primitives",
@@ -9389,6 +9408,7 @@ dependencies = [
  "reth-optimism-flashblocks",
  "reth-optimism-forks",
  "reth-optimism-payload-builder",
+ "reth-optimism-post-exec-replay",
  "reth-optimism-primitives",
  "reth-optimism-trie",
  "reth-optimism-txpool",

--- a/rust/rollup-boost/Justfile
+++ b/rust/rollup-boost/Justfile
@@ -10,11 +10,11 @@ kurtosis-stress-test:
 
 # Build docker image (release)
 build:
-    docker buildx build --build-arg RELEASE=true -t flashbots/rollup-boost:develop .
+    docker buildx build --build-context monorepo-rust=.. --build-arg RELEASE=true -t rollup-boost:latest .
 
 # Build docker image (debug)
 build-debug:
-    docker buildx build --build-arg RELEASE=false -t flashbots/rollup-boost:develop .
+    docker buildx build --build-context monorepo-rust=.. --build-arg RELEASE=false -t rollup-boost:latest .
 
 kurtosis-spawn:
     kurtosis run github.com/ethpandaops/optimism-package@452133367b693e3ba22214a6615c86c60a1efd5e --args-file ./scripts/ci/kurtosis-params.yaml --enclave op-rollup-boost

--- a/rust/rollup-boost/crates/flashblocks-rpc/src/tests/mod.rs
+++ b/rust/rollup-boost/crates/flashblocks-rpc/src/tests/mod.rs
@@ -186,6 +186,7 @@ fn create_second_payload() -> FlashblocksPayloadV1 {
             gas_used: 0,
             block_hash: B256::default(),
             transactions: vec![tx1, tx2],
+            post_exec_tx: None,
             withdrawals: Vec::new(),
             logs_bloom: Default::default(),
             withdrawals_root: Default::default(),

--- a/rust/rollup-boost/crates/rollup-boost/src/flashblocks/primitives.rs
+++ b/rust/rollup-boost/crates/rollup-boost/src/flashblocks/primitives.rs
@@ -24,6 +24,9 @@ pub struct ExecutionPayloadFlashblockDeltaV1 {
     pub block_hash: B256,
     /// The transactions of the block.
     pub transactions: Vec<Bytes>,
+    /// Latest mutable synthetic post-exec transaction for the materialized block view.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_exec_tx: Option<Bytes>,
     /// Array of [`Withdrawal`] enabled with V2
     pub withdrawals: Vec<Withdrawal>,
     /// The withdrawals root of the block.


### PR DESCRIPTION
Stacked on #21043.

Wires SDM PostExec through the flashblocks path:
- rollup-boost carries PostExec tx in flashblock frames
- op-rbuilder produces PostExec flashblock payloads + admin opt-in
- op-reth trait tightening to expose \`State<DB>\` to the builder
- Flashblocks devstack preset, devnet flashblocks collector, \`TestFlashblocksSDMMaterializesPostExecBlock\`

Brings the stack to functional parity with #20738.