### PR TITLE
chore(opd): update SCR dep for op-contracts/v7.0.0-rc.4 tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260522182924-6fe4a0b30c92
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260526203230-6ddbaeba348c
 	github.com/ethereum/go-ethereum v1.17.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/golang/snappy v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15c
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e/go.mod h1:DYj7+vYJ4cIB7zera9mv4LcAynCL5u4YVfoeUu6Wa+w=
 github.com/ethereum-optimism/op-geth v1.101702.2-rc.2 h1:I/Jtfi7oOTlbP2E1VC8v6MZvYmY7I1Xm5IYRoIce1aM=
 github.com/ethereum-optimism/op-geth v1.101702.2-rc.2/go.mod h1:HzvOtk7c9KwFaSxRvUBPFHGSjIjomWtw4iSXX6vruQE=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260522182924-6fe4a0b30c92 h1:pPxbTRvTXxOg+d14kM3X2Ks2AIdBN9eHBNUajvOtN1Q=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260522182924-6fe4a0b30c92/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260526203230-6ddbaeba348c h1:XiMsRM9dyf1pupSZ4gw2cNgBtweiR2HkPRokDYupnag=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260526203230-6ddbaeba348c/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6 h1:xQymkKCT5E2Jiaoqf3v4wsNgjZLY0lRSkZn27fRjSls=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6/go.mod h1:8HMkUZ5JRv4hpw/XUrYWSQNAUzhHMg2UDb/U+5m+XNw=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJhy07IMfEKuARQ9TKojGqLVNxQajaXEp/BoqSk=

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -42,7 +42,7 @@ const (
 	ContractsV410Tag        = "op-contracts/v4.1.0"
 	ContractsV500Tag        = "op-contracts/v5.0.0"
 	ContractsV600Tag        = "op-contracts/v6.0.0-rc.2"
-	ContractsV700Tag        = "op-contracts/v7.0.0-rc.3"
+	ContractsV700Tag        = "op-contracts/v7.0.0-rc.4"
 	CurrentTag              = ContractsV700Tag
 )
 


### PR DESCRIPTION
Bumps `superchain-registry/validation` to the merge commit of [superchain-registry#1245](https://github.com/ethereum-optimism/superchain-registry/pull/1245) (which adds standard-versions entries for `op-contracts/v7.0.0-rc.4`), and updates `ContractsV700Tag` in `op-deployer/pkg/deployer/standard/standard.go` to point at rc.4.