### PR TITLE
Remove unused rust/kona/version.json

### DIFF
--- a/rust/kona/version.json
+++ b/rust/kona/version.json
@@ -1,5 +1,0 @@
-{
-    "version": "1.2.7",
-    "prestateHash": "0x0323914d3050e80c3d09da528be54794fde60cd26849cd3410dde0da7cd7d4fa",
-    "interopPrestateHash": "0x03f03018773fae0603f7c110ef1defa8d19b601b32ee530f9951987baec435b0"
-}


### PR DESCRIPTION
The file `rust/kona/version.json` is not referenced anywhere in the repo (no Go embed, no scripts, no docs, no CI), so this PR deletes it. It appears to be a vestige from the upstream `op-rs/kona` layout, introduced during the kona workspace merge and never wired into anything in this monorepo.

It was removed in https://github.com/ethereum-optimism/optimism/commit/d3fb96d0ba0c72688f01c22418d37a4bea2bffde and re-added (accidentally I assume) in https://github.com/ethereum-optimism/optimism/commit/48a7a09bfcce4bf95144cbc73062d5baabe88f6c