### PR TITLE
docs(notices): add op-challenger and op-dispute-mon versions for Upgrade 19

### DIFF
--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -73,8 +73,8 @@ Update the following components:
 | ---------------- | ------- | ----- |
 | `op-node`        | `TBD`   | Must be updated **prior** to the activation timestamp. Required for Osaka on L2 and Glamsterdam Defense hard fork changes. |
 | `op-reth`        | `TBD`   | Must be updated **prior** to the activation timestamp. Required for EIP-7825 gas limit enforcement, MODEXP/P256VERIFY gas changes, and BN256 pairing input size reduction. |
-| `op-challenger` | `TBD` | Must be updated **prior** to the upgrade. Required for `CANNON_KONA` respected game type. |
-| `op-dispute-mon` | `TBD` | Must be updated **prior** to the upgrade. |
+| `op-challenger` | [`v1.9.3`](https://github.com/ethereum-optimism/optimism/releases/tag/op-challenger%2Fv1.9.3) | Must be updated **prior** to the upgrade. Required for `CANNON_KONA` respected game type. |
+| `op-dispute-mon` | [`v1.5.2`](https://github.com/ethereum-optimism/optimism/releases/tag/op-dispute-mon%2Fv1.5.2) | Must be updated **prior** to the upgrade. |
 | `op-contracts` | `TBD` | Required for L2CM, OPCMv2, and `CANNON_KONA` respected game type support. |
 
 ### For permissionless fault proof enabled chains


### PR DESCRIPTION
Set the `op-challenger` and `op-dispute-mon` versions in the Upgrade 19 notice to `v1.9.3` and `v1.5.2` respectively, linked to their GitHub release tags.