### PR TITLE
fix(op-node,op-supernode): redesign SuperAuthority safe/finalized head as tri-state

### DIFF
--- a/op-acceptance-tests/tests/interop/upgrade/finalized_activation_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/finalized_activation_test.go
@@ -1,0 +1,38 @@
+//go:build !ci
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
+)
+
+// TestFinalizedL2DoesNotRegressAcrossActivation reproduces #20365.
+// The 240s activation delay must exceed the FakePoS L1 finality lag (~120s)
+// so the pre-activation FinalizedL2 baseline is non-zero.
+func TestFinalizedL2DoesNotRegressAcrossActivation(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewTwoL2SupernodeInterop(t, 240)
+	require := t.Require()
+
+	interopTimeA := sys.L2A.Escape().ChainConfig().InteropTime
+	interopTimeB := sys.L2B.Escape().ChainConfig().InteropTime
+	require.NotNil(interopTimeA, "L2A must have InteropTime configured")
+	require.NotNil(interopTimeB, "L2B must have InteropTime configured")
+
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedFn(safety.Finalized, 1, 120),
+		sys.L2BCL.ReachedFn(safety.Finalized, 1, 120),
+	)
+
+	// +1 so the head must be strictly past activation.
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeA+1),
+		sys.L2BCL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeB+1),
+	)
+}

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -314,6 +314,60 @@ func (cl *L2CLNode) ReachedRefFn(lvl safety.Level, target eth.BlockID, attempts 
 	}
 }
 
+// ReachedTimeWithoutRegressionFn waits for the head's block timestamp to reach
+// targetTime, failing on any regression. Requires a non-zero baseline behind
+// targetTime so a regression to genesis isn't vacuous (0 >= 0). Polls every
+// 100ms; deadline is targetTime + 5min.
+//
+// Uses an explicit ticker/deadline loop and returns errors through the
+// CheckFunc contract. require.Eventuallyf would call FailNow inside the
+// dsl.CheckAll worker goroutine, which is not safe.
+func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime uint64) CheckFunc {
+	return func() error {
+		initial, err := cl.headBlockRef(lvl)
+		if err != nil {
+			return fmt.Errorf("read initial %s head: %w", lvl, err)
+		}
+		if initial.Number == 0 {
+			return fmt.Errorf("initial %s head is at genesis; cannot detect regression below zero — wait for the head to advance past genesis before snapshotting", lvl)
+		}
+		if initial.Time >= targetTime {
+			return fmt.Errorf("initial %s head time %d already at or past target %d; nothing to observe across the boundary", lvl, initial.Time, targetTime)
+		}
+		const buffer = 5 * time.Minute
+		deadline := time.Unix(int64(targetTime), 0).Add(buffer)
+		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "initial", initial.Number, "initial_time", initial.Time, "target_time", targetTime, "deadline", deadline)
+		logger.Info("Watching head for regression until target time reached")
+
+		ctx, cancel := context.WithDeadline(cl.ctx, deadline)
+		defer cancel()
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			head, err := cl.headBlockRef(lvl)
+			if err != nil {
+				logger.Warn("SyncStatus RPC failed; will retry", "err", err)
+			} else {
+				if head.Number < initial.Number {
+					return fmt.Errorf("%s head regressed: was %d (%s, t=%d), observed %d (%s, t=%d)",
+						lvl, initial.Number, initial.Hash, initial.Time, head.Number, head.Hash, head.Time)
+				}
+				if head.Time >= targetTime {
+					return nil
+				}
+				logger.Info("Chain sync status", "current", head.Number, "current_time", head.Time)
+			}
+
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("%s head did not reach target time %d (initial=%d): %w", lvl, targetTime, initial.Number, ctx.Err())
+			case <-ticker.C:
+			}
+		}
+	}
+}
+
 // RewindedFn returns a lambda that checks the L2CL chain head with given safety level rewinded more than the delta block number
 // Composable with other lambdas to wait in parallel
 func (cl *L2CLNode) RewindedFn(lvl safety.Level, delta uint64, attempts int) CheckFunc {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -329,6 +329,8 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 // resolveVerifiedAsFinalized handles the Verified branch of FinalizedHead.
 func (e *EngineController) resolveVerifiedAsFinalized(block eth.BlockID) eth.L2BlockRef {
 	if block.Number > e.localFinalizedHead.Number {
+		e.log.Warn("super authority finalized a block ahead of local finalized; using local finalized",
+			"super_authority_finalized", block, "local_finalized", e.localFinalizedHead)
 		return e.localFinalizedHead
 	}
 	br, err := e.engine.L2BlockRefByHash(e.ctx, block.Hash)
@@ -357,6 +359,8 @@ func (e *EngineController) resolveAnchorAsFinalized(ts uint64) eth.L2BlockRef {
 		return eth.L2BlockRef{}
 	}
 	if num > e.localFinalizedHead.Number {
+		e.log.Warn("super authority finalized a block ahead of local finalized; using local finalized",
+			"super_authority_finalized", num, "local_finalized", e.localFinalizedHead)
 		return e.localFinalizedHead
 	}
 	br, err := e.engine.L2BlockRefByNumber(e.ctx, num)
@@ -377,9 +381,6 @@ func (e *EngineController) resolveAnchorAsFinalized(ts uint64) eth.L2BlockRef {
 // anchor) regress a previously cached value, and we panic on same-height
 // different-hash conflicts.
 func (e *EngineController) applyFinalizedHeadCacheChecks(br eth.L2BlockRef, source string) eth.L2BlockRef {
-	if br.Number > e.localFinalizedHead.Number {
-		return e.localFinalizedHead
-	}
 	if cached := e.superAuthorityFinalizedHead; cached != (eth.L2BlockRef{}) {
 		if br.ID() == cached.ID() {
 			return cached

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -126,6 +126,8 @@ type EngineController struct {
 	localFinalizedHead eth.L2BlockRef
 	// Last successfully materialized superAuthority finalized head,
 	// used as a fallback when the authority or EL is temporarily unavailable.
+	// Finalized blocks cannot reorg, so this cache does not require
+	// canonicality re-validation before use.
 	superAuthorityFinalizedHead eth.L2BlockRef
 	// The unsafe head to roll back to,
 	// after the pendingSafeHead fails to become safe.
@@ -196,49 +198,26 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 	}
 }
 
-// SafeL2Head returns the safe L2 head.
-// If the super authority is enabled, it returns the fully verified L2 head
-// else it returns the local safe L2 head.
+// SafeL2Head returns the safe L2 head. With a SuperAuthority registered, the
+// result is bounded by local-safe and validated against the EL where
+// applicable. On a transient verifier read failure or any reorg signal, the
+// cross-safe fallback is consulted.
 func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	if e.superAuthority != nil {
-		fvshid, useLocalSafe := e.superAuthority.FullyVerifiedL2Head()
-		// If SuperAuthority signals to use local-safe (e.g., no verifiers or pre-interop)
-		if useLocalSafe {
-			e.log.Debug("super authority signaled to use local-safe fallback")
+		head, ok := e.superAuthority.FullyVerifiedL2Head(e.ctx)
+		if !ok {
+			return e.crossSafeFallback("HoldPrevious")
+		}
+		switch head.Source {
+		case rollup.VerifierHeadPreActivation:
 			return e.localSafeHead
+		case rollup.VerifierHeadAnchor:
+			return e.resolveAnchorAsSafe(head.Timestamp)
+		case rollup.VerifierHeadVerified:
+			return e.resolveVerifiedAsSafe(head.Block)
+		default:
+			panic(fmt.Errorf("unhandled VerifierHeadSource: %v", head.Source))
 		}
-		// SuperAuthority provided a cross-verified safe head
-		if (fvshid == eth.BlockID{}) {
-			// Fallback to genesis block (safe by consensus) if possible
-			br, err := e.engine.L2BlockRefByNumber(e.ctx, 0)
-			if err != nil {
-				e.log.Warn("cannot get genesis block from engine")
-				return eth.L2BlockRef{}
-			}
-			return br
-		}
-		if fvshid.Number > e.localSafeHead.Number {
-			e.log.Debug("super authority fully verified l2 head is ahead of local safe head, using local safe head as SafeL2Head")
-			return e.localSafeHead
-		}
-		br, err := e.engine.L2BlockRefByHash(e.ctx, fvshid.Hash)
-		if err != nil {
-			finalized := e.FinalizedHead()
-			e.log.Warn("superAuthority safe head is not known to the engine, using finalized head", "super_authority_safe", fvshid, "finalized", finalized, "err", err)
-			return finalized
-		}
-		canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
-		if err != nil {
-			finalized := e.FinalizedHead()
-			e.log.Warn("cannot verify superAuthority safe head canonicality, using finalized head", "super_authority_safe", br, "finalized", finalized, "err", err)
-			return finalized
-		}
-		if canonical.Hash != br.Hash {
-			finalized := e.FinalizedHead()
-			e.log.Warn("superAuthority safe head is not canonical, using finalized head", "super_authority_safe", br, "canonical", canonical, "finalized", finalized)
-			return finalized
-		}
-		return br
 	} else if e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedSafeHead
 	} else {
@@ -246,57 +225,166 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	}
 }
 
+// resolveVerifiedAsSafe handles the Verified branch of SafeL2Head.
+func (e *EngineController) resolveVerifiedAsSafe(block eth.BlockID) eth.L2BlockRef {
+	if block.Number > e.localSafeHead.Number {
+		return e.localSafeHead
+	}
+	br, err := e.engine.L2BlockRefByHash(e.ctx, block.Hash)
+	if err != nil {
+		e.log.Warn("super authority safe head unknown to engine (reorg signal)",
+			"super_authority_safe", block, "err", err)
+		return e.crossSafeFallback("el-unknown")
+	}
+	canonical, canonicalRef, err := e.isCanonical(br)
+	if err != nil {
+		e.log.Warn("cannot verify super authority safe head canonicality",
+			"super_authority_safe", br, "err", err)
+		return e.crossSafeFallback("canonicality-lookup-failed")
+	}
+	if !canonical {
+		e.log.Warn("super authority safe head non-canonical (reorg signal)",
+			"super_authority_safe", br, "canonical", canonicalRef)
+		return e.crossSafeFallback("non-canonical")
+	}
+	return br
+}
+
+// resolveAnchorAsSafe handles the Anchor branch of SafeL2Head: resolve the
+// canonical L2 block at the supplied pre-activation cap timestamp. The block
+// is canonical by construction (looked up by number); no second check needed.
+func (e *EngineController) resolveAnchorAsSafe(ts uint64) eth.L2BlockRef {
+	num, err := e.rollupCfg.TargetBlockNumber(ts)
+	if err != nil {
+		e.log.Warn("cannot compute anchor block number", "ts", ts, "err", err)
+		return e.crossSafeFallback("anchor-target-block-number")
+	}
+	br, err := e.engine.L2BlockRefByNumber(e.ctx, num)
+	if err != nil {
+		e.log.Warn("cannot resolve anchor block", "ts", ts, "num", num, "err", err)
+		return e.crossSafeFallback("anchor-lookup-failed")
+	}
+	if br.Number > e.localSafeHead.Number {
+		return e.localSafeHead
+	}
+	return br
+}
+
+// crossSafeFallback is the cross-safe fallback path: returns FinalizedHead so
+// we never advance cross-safe to local-safe on a verifier read failure or any
+// reorg signal, and never drop below finalized.
+func (e *EngineController) crossSafeFallback(reason string) eth.L2BlockRef {
+	finalized := e.FinalizedHead()
+	e.log.Debug("cross-safe fallback flooring at finalized", "reason", reason, "finalized", finalized)
+	return finalized
+}
+
+// isCanonical reports whether `target` still matches the EL's canonical chain
+// at its number. Three outcomes:
+//   - ok=true,  canonical=target,           err=nil  → canonical.
+//   - ok=false, canonical=different block,  err=nil  → non-canonical (reorg).
+//   - ok=false, canonical=zero,             err≠nil  → lookup failed.
+//
+// The returned canonical block is exposed so callers can log the divergence on
+// reorg without a second lookup.
+func (e *EngineController) isCanonical(target eth.L2BlockRef) (ok bool, canonical eth.L2BlockRef, err error) {
+	canonical, err = e.engine.L2BlockRefByNumber(e.ctx, target.Number)
+	if err != nil {
+		return false, eth.L2BlockRef{}, err
+	}
+	return canonical.Hash == target.Hash, canonical, nil
+}
+
+// FinalizedHead returns the finalized L2 head, bounded by local-finalized
+// (the SuperAuthority can delay finalization but cannot finalize a block the
+// node hasn't locally finalized). superAuthorityFinalizedHead caches the last
+// successful resolution and is trusted without re-validation — finalized
+// blocks cannot reorg.
 func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 	if e.superAuthority != nil {
-		f, useLocalFinalized := e.superAuthority.FinalizedL2Head()
-		if useLocalFinalized {
-			// No verifiers registered, fall back to local finalized
-			e.log.Debug("super authority has no verifiers, using local finalized head")
-			return e.localFinalizedHead
-		}
-		if (f == eth.BlockID{}) {
-			// Fallback to genesis block (final by consensus) if possible
-			br, err := e.engine.L2BlockRefByNumber(e.ctx, 0)
-			if err != nil {
-				e.log.Warn("cannot get genesis block from engine")
-				return eth.L2BlockRef{}
-			}
-			return br
-		}
-		if f.Number > e.localSafeHead.Number {
-			e.log.Debug("super authority finalized l2 head is ahead of local safe head, using local safe head as FinalizedHead")
-			return e.localSafeHead
-		}
-		if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
-			if f == e.superAuthorityFinalizedHead.ID() {
-				return e.superAuthorityFinalizedHead
-			}
-			if f.Number < e.superAuthorityFinalizedHead.Number {
-				// SuperAuthority finality is expected to be monotonic. A lower
-				// finalized head means the authority is reporting stale state.
-				e.log.Warn("superAuthority finalized head is behind cached superAuthority finalized head, using cached superAuthority finalized head", "super_authority_finalized", f, "cached_super_authority_finalized", e.superAuthorityFinalizedHead)
-				return e.superAuthorityFinalizedHead
-			}
-			if f.Number == e.superAuthorityFinalizedHead.Number {
-				panic("superAuthority finalized head conflicts with cached superAuthority finalized head at same height")
-			}
-		}
-		br, err := e.engine.L2BlockRefByHash(e.ctx, f.Hash)
-		if err != nil {
+		head, ok := e.superAuthority.FinalizedL2Head(e.ctx)
+		if !ok {
 			if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
-				e.log.Warn("superAuthority finalized head is not known to the engine, using cached superAuthority finalized head", "super_authority_finalized", f, "cached_super_authority_finalized", e.superAuthorityFinalizedHead, "err", err)
 				return e.superAuthorityFinalizedHead
 			}
-			e.log.Warn("superAuthority finalized head is not known to the engine and no cached superAuthority finalized head is available", "super_authority_finalized", f, "err", err)
+			e.log.Error("super authority finalized HoldPrevious with no cache; returning zero")
 			return eth.L2BlockRef{}
 		}
-		e.superAuthorityFinalizedHead = br
-		return br
+		switch head.Source {
+		case rollup.VerifierHeadPreActivation:
+			return e.localFinalizedHead
+		case rollup.VerifierHeadAnchor:
+			return e.resolveAnchorAsFinalized(head.Timestamp)
+		case rollup.VerifierHeadVerified:
+			return e.resolveVerifiedAsFinalized(head.Block)
+		default:
+			panic(fmt.Errorf("unhandled VerifierHeadSource: %v", head.Source))
+		}
 	} else if e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedFinalizedHead
 	} else {
 		return e.localFinalizedHead
 	}
+}
+
+// resolveVerifiedAsFinalized handles the Verified branch of FinalizedHead.
+func (e *EngineController) resolveVerifiedAsFinalized(block eth.BlockID) eth.L2BlockRef {
+	if block.Number > e.localFinalizedHead.Number {
+		return e.localFinalizedHead
+	}
+	if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+		if block == e.superAuthorityFinalizedHead.ID() {
+			return e.superAuthorityFinalizedHead
+		}
+		if block.Number < e.superAuthorityFinalizedHead.Number {
+			e.log.Warn("super authority finalized behind cached; using cache",
+				"super_authority_finalized", block,
+				"cached_super_authority_finalized", e.superAuthorityFinalizedHead)
+			return e.superAuthorityFinalizedHead
+		}
+		if block.Number == e.superAuthorityFinalizedHead.Number {
+			panic("superAuthority finalized head conflicts with cached superAuthority finalized head at same height")
+		}
+	}
+	br, err := e.engine.L2BlockRefByHash(e.ctx, block.Hash)
+	if err != nil {
+		if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+			e.log.Warn("super authority finalized unknown to engine; using cache",
+				"super_authority_finalized", block,
+				"cached_super_authority_finalized", e.superAuthorityFinalizedHead, "err", err)
+			return e.superAuthorityFinalizedHead
+		}
+		e.log.Warn("super authority finalized unknown to engine and no cache available",
+			"super_authority_finalized", block, "err", err)
+		return eth.L2BlockRef{}
+	}
+	e.superAuthorityFinalizedHead = br
+	return br
+}
+
+// resolveAnchorAsFinalized handles the Anchor branch of FinalizedHead.
+func (e *EngineController) resolveAnchorAsFinalized(ts uint64) eth.L2BlockRef {
+	num, err := e.rollupCfg.TargetBlockNumber(ts)
+	if err != nil {
+		e.log.Warn("cannot compute finalized anchor block number", "ts", ts, "err", err)
+		if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+			return e.superAuthorityFinalizedHead
+		}
+		return eth.L2BlockRef{}
+	}
+	br, err := e.engine.L2BlockRefByNumber(e.ctx, num)
+	if err != nil {
+		e.log.Warn("cannot resolve finalized anchor block", "ts", ts, "num", num, "err", err)
+		if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+			return e.superAuthorityFinalizedHead
+		}
+		return eth.L2BlockRef{}
+	}
+	if br.Number > e.localFinalizedHead.Number {
+		return e.localFinalizedHead
+	}
+	e.superAuthorityFinalizedHead = br
+	return br
 }
 
 func (e *EngineController) UnsafeL2Head() eth.L2BlockRef {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -41,8 +41,7 @@ const maxUnsafePayloadsMemory = 500 * 1024 * 1024
 // the L2 chain backwards until it finds a plausible unsafe head,
 // and find an L2 safe block that is guaranteed to still be from the L1 chain.
 // This event is not used in interop.
-type ResetEngineRequestEvent struct {
-}
+type ResetEngineRequestEvent struct{}
 
 func (ev ResetEngineRequestEvent) String() string {
 	return "reset-engine-request"
@@ -126,8 +125,6 @@ type EngineController struct {
 	localFinalizedHead eth.L2BlockRef
 	// Last successfully materialized superAuthority finalized head,
 	// used as a fallback when the authority or EL is temporarily unavailable.
-	// Finalized blocks cannot reorg, so this cache does not require
-	// canonicality re-validation before use.
 	superAuthorityFinalizedHead eth.L2BlockRef
 	// The unsafe head to roll back to,
 	// after the pendingSafeHead fails to become safe.
@@ -201,33 +198,35 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 // SafeL2Head returns the safe L2 head. With a SuperAuthority registered, the
 // result is bounded by local-safe and validated against the EL where
 // applicable. On a transient verifier read failure or any reorg signal, the
-// cross-safe fallback is consulted.
+// cross-safe fallback is used.
 func (e *EngineController) SafeL2Head() eth.L2BlockRef {
-	if e.superAuthority != nil {
-		head, ok := e.superAuthority.FullyVerifiedL2Head(e.ctx)
-		if !ok {
-			return e.crossSafeFallback("HoldPrevious")
-		}
-		switch head.Source {
-		case rollup.VerifierHeadPreActivation:
+	if e.superAuthority == nil {
+		if e.syncCfg.FollowSourceEnabled() {
+			return e.deprecatedSafeHead
+		} else {
 			return e.localSafeHead
-		case rollup.VerifierHeadAnchor:
-			return e.resolveAnchorAsSafe(head.Timestamp)
-		case rollup.VerifierHeadVerified:
-			return e.resolveVerifiedAsSafe(head.Block)
-		default:
-			panic(fmt.Errorf("unhandled VerifierHeadSource: %v", head.Source))
 		}
-	} else if e.syncCfg.FollowSourceEnabled() {
-		return e.deprecatedSafeHead
-	} else {
+	}
+	head, ok := e.superAuthority.FullyVerifiedL2Head(e.ctx)
+	if !ok {
+		return e.crossSafeFallback("HoldPrevious")
+	}
+	switch head.Source {
+	case rollup.VerifierHeadPreActivation:
 		return e.localSafeHead
+	case rollup.VerifierHeadAnchor:
+		return e.resolveAnchorAsSafe(head.Timestamp)
+	case rollup.VerifierHeadVerified:
+		return e.resolveVerifiedAsSafe(head.Block)
+	default:
+		panic(fmt.Errorf("unhandled VerifierHeadSource: %v", head.Source))
 	}
 }
 
 // resolveVerifiedAsSafe handles the Verified branch of SafeL2Head.
 func (e *EngineController) resolveVerifiedAsSafe(block eth.BlockID) eth.L2BlockRef {
 	if block.Number > e.localSafeHead.Number {
+		e.log.Warn("super authority safe head ahead of local safe head, using local safe", "super_authority_safe", block, "local_safe", e.localSafeHead)
 		return e.localSafeHead
 	}
 	br, err := e.engine.L2BlockRefByHash(e.ctx, block.Hash)
@@ -236,13 +235,11 @@ func (e *EngineController) resolveVerifiedAsSafe(block eth.BlockID) eth.L2BlockR
 			"super_authority_safe", block, "err", err)
 		return e.crossSafeFallback("el-unknown")
 	}
-	canonical, canonicalRef, err := e.isCanonical(br)
-	if err != nil {
+	if canonical, canonicalRef, err := e.isCanonical(br); err != nil {
 		e.log.Warn("cannot verify super authority safe head canonicality",
 			"super_authority_safe", br, "err", err)
 		return e.crossSafeFallback("canonicality-lookup-failed")
-	}
-	if !canonical {
+	} else if !canonical {
 		e.log.Warn("super authority safe head non-canonical (reorg signal)",
 			"super_authority_safe", br, "canonical", canonicalRef)
 		return e.crossSafeFallback("non-canonical")
@@ -265,6 +262,7 @@ func (e *EngineController) resolveAnchorAsSafe(ts uint64) eth.L2BlockRef {
 		return e.crossSafeFallback("anchor-lookup-failed")
 	}
 	if br.Number > e.localSafeHead.Number {
+		// Local safe hasn't reached the anchor block for the validator, so use local safe head.
 		return e.localSafeHead
 	}
 	return br
@@ -301,29 +299,30 @@ func (e *EngineController) isCanonical(target eth.L2BlockRef) (ok bool, canonica
 // successful resolution and is trusted without re-validation — finalized
 // blocks cannot reorg.
 func (e *EngineController) FinalizedHead() eth.L2BlockRef {
-	if e.superAuthority != nil {
-		head, ok := e.superAuthority.FinalizedL2Head(e.ctx)
-		if !ok {
-			if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
-				return e.superAuthorityFinalizedHead
-			}
-			e.log.Error("super authority finalized HoldPrevious with no cache; returning zero")
-			return eth.L2BlockRef{}
-		}
-		switch head.Source {
-		case rollup.VerifierHeadPreActivation:
+	if e.superAuthority == nil {
+		if e.syncCfg.FollowSourceEnabled() {
+			return e.deprecatedFinalizedHead
+		} else {
 			return e.localFinalizedHead
-		case rollup.VerifierHeadAnchor:
-			return e.resolveAnchorAsFinalized(head.Timestamp)
-		case rollup.VerifierHeadVerified:
-			return e.resolveVerifiedAsFinalized(head.Block)
-		default:
-			panic(fmt.Errorf("unhandled VerifierHeadSource: %v", head.Source))
 		}
-	} else if e.syncCfg.FollowSourceEnabled() {
-		return e.deprecatedFinalizedHead
-	} else {
+	}
+	head, ok := e.superAuthority.FinalizedL2Head(e.ctx)
+	if !ok {
+		if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+			return e.superAuthorityFinalizedHead
+		}
+		e.log.Error("super authority finalized HoldPrevious with no cache; returning zero")
+		return eth.L2BlockRef{}
+	}
+	switch head.Source {
+	case rollup.VerifierHeadPreActivation:
 		return e.localFinalizedHead
+	case rollup.VerifierHeadAnchor:
+		return e.resolveAnchorAsFinalized(head.Timestamp)
+	case rollup.VerifierHeadVerified:
+		return e.resolveVerifiedAsFinalized(head.Block)
+	default:
+		panic(fmt.Errorf("unhandled VerifierHeadSource: %v", head.Source))
 	}
 }
 
@@ -1075,6 +1074,7 @@ func (e *EngineController) PromoteFinalized(ctx context.Context, ref eth.L2Block
 	defer e.mu.Unlock()
 	e.promoteFinalized(ctx, ref)
 }
+
 func (e *EngineController) promoteFinalized(ctx context.Context, ref eth.L2BlockRef) {
 	if ref.Number < e.FinalizedHead().Number {
 		e.log.Error("Cannot rewind finality,", "ref", ref, "finalized", e.FinalizedHead())

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -331,20 +331,6 @@ func (e *EngineController) resolveVerifiedAsFinalized(block eth.BlockID) eth.L2B
 	if block.Number > e.localFinalizedHead.Number {
 		return e.localFinalizedHead
 	}
-	if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
-		if block == e.superAuthorityFinalizedHead.ID() {
-			return e.superAuthorityFinalizedHead
-		}
-		if block.Number < e.superAuthorityFinalizedHead.Number {
-			e.log.Warn("super authority finalized behind cached; using cache",
-				"super_authority_finalized", block,
-				"cached_super_authority_finalized", e.superAuthorityFinalizedHead)
-			return e.superAuthorityFinalizedHead
-		}
-		if block.Number == e.superAuthorityFinalizedHead.Number {
-			panic("superAuthority finalized head conflicts with cached superAuthority finalized head at same height")
-		}
-	}
 	br, err := e.engine.L2BlockRefByHash(e.ctx, block.Hash)
 	if err != nil {
 		if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
@@ -357,8 +343,7 @@ func (e *EngineController) resolveVerifiedAsFinalized(block eth.BlockID) eth.L2B
 			"super_authority_finalized", block, "err", err)
 		return eth.L2BlockRef{}
 	}
-	e.superAuthorityFinalizedHead = br
-	return br
+	return e.applyFinalizedHeadCacheChecks(br, "verified")
 }
 
 // resolveAnchorAsFinalized handles the Anchor branch of FinalizedHead.
@@ -371,6 +356,9 @@ func (e *EngineController) resolveAnchorAsFinalized(ts uint64) eth.L2BlockRef {
 		}
 		return eth.L2BlockRef{}
 	}
+	if num > e.localFinalizedHead.Number {
+		return e.localFinalizedHead
+	}
 	br, err := e.engine.L2BlockRefByNumber(e.ctx, num)
 	if err != nil {
 		e.log.Warn("cannot resolve finalized anchor block", "ts", ts, "num", num, "err", err)
@@ -379,8 +367,31 @@ func (e *EngineController) resolveAnchorAsFinalized(ts uint64) eth.L2BlockRef {
 		}
 		return eth.L2BlockRef{}
 	}
+	return e.applyFinalizedHeadCacheChecks(br, "anchor")
+}
+
+// applyFinalizedHeadCacheChecks validates a freshly resolved SuperAuthority
+// finalized head against localFinalizedHead and superAuthorityFinalizedHead,
+// returns the head to publish, and updates the cache when the head advances.
+// Finalized is monotonic by contract: we never let either branch (verified or
+// anchor) regress a previously cached value, and we panic on same-height
+// different-hash conflicts.
+func (e *EngineController) applyFinalizedHeadCacheChecks(br eth.L2BlockRef, source string) eth.L2BlockRef {
 	if br.Number > e.localFinalizedHead.Number {
 		return e.localFinalizedHead
+	}
+	if cached := e.superAuthorityFinalizedHead; cached != (eth.L2BlockRef{}) {
+		if br.ID() == cached.ID() {
+			return cached
+		}
+		if br.Number < cached.Number {
+			e.log.Warn("super authority finalized behind cached; using cache",
+				"source", source, "super_authority_finalized", br, "cached_super_authority_finalized", cached)
+			return cached
+		}
+		if br.Number == cached.Number {
+			panic("superAuthority finalized head conflicts with cached superAuthority finalized head at same height")
+		}
 	}
 	e.superAuthorityFinalizedHead = br
 	return br

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -232,7 +232,8 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			name: "with SuperAuthority returns verified block",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					fullyVerifiedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
@@ -243,15 +244,17 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50},
 		},
 		{
-			name: "falls back to SuperAuthority finalized when SuperAuthority block is not canonical",
+			name: "floors at finalized when SuperAuthority block is not canonical (reorg signal)",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
-					finalizedL2Head:     eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
+					fullyVerifiedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+					finalizedL2Head:           eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
+					finalizedL2HeadSource:     rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}, nil)
@@ -260,14 +263,20 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40},
 		},
 		{
-			name: "with SuperAuthority empty BlockID returns genesis",
+			// Pre-fix this asserted "empty BlockID → genesis" (bug B). Under the
+			// new contract, an empty verifier surfaces as Source=Anchor with a
+			// concrete block (see super_authority_safe_head_test.go), and the
+			// engine controller never reaches L2BlockRefByNumber(0). The path
+			// that previously dropped to genesis is structurally gone; this
+			// case is replaced by the PreActivation behavior below.
+			name: "PreActivation source returns localSafeHead, never genesis",
 			setupSuperAuth: func() *mockSuperAuthority {
-				return &mockSuperAuthority{fullyVerifiedL2Head: eth.BlockID{}}
+				return &mockSuperAuthority{
+					fullyVerifiedL2HeadSource: rollup.VerifierHeadPreActivation,
+				}
 			},
-			setupEngine: func(m *testutils.MockEngine) {
-				m.ExpectL2BlockRefByNumber(0, eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0}, nil)
-			},
-			expectResult: &eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0},
+			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			expectResult:   &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
 			name:           "without SuperAuthority uses local safe",
@@ -279,27 +288,42 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			name: "falls back to local safe when SuperAuthority block ahead of local safe",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0xff}, Number: 200},
+					fullyVerifiedL2Head:       eth.BlockID{Hash: common.Hash{0xff}, Number: 200},
+					fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 			expectResult:   &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
-			name: "falls back to SuperAuthority finalized when SuperAuthority block unknown to engine",
+			name: "floors at finalized when SuperAuthority block unknown to engine (reorg signal)",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
-					finalizedL2Head:     eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
+					fullyVerifiedL2Head:       eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
+					fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+					finalizedL2Head:           eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
+					finalizedL2HeadSource:     rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 				m.ExpectL2BlockRefByHash(common.Hash{0xee}, eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40}, nil)
 			},
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40},
+		},
+		{
+			name: "HoldPrevious floors at finalized, never local-safe",
+			setupSuperAuth: func() *mockSuperAuthority {
+				return &mockSuperAuthority{
+					holdPreviousVerified:  true,
+					finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
+				}
+			},
+			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			expectResult:   &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 		},
 	}
 
@@ -364,8 +388,10 @@ func TestEngineController_ForkchoiceUpdateUsesSuperAuthority(t *testing.T) {
 	}
 	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}
 	mockSA := &mockSuperAuthority{
-		fullyVerifiedL2Head: verifiedRef.ID(),
-		finalizedL2Head:     finalizedRef.ID(),
+		fullyVerifiedL2Head:       verifiedRef.ID(),
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+		finalizedL2Head:           finalizedRef.ID(),
+		finalizedL2HeadSource:     rollup.VerifierHeadVerified,
 	}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, &testutils.MockL1Source{}, emitter, mockSA)
 
@@ -828,37 +854,44 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			name: "with SuperAuthority returns finalized block",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					finalizedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 30},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 50},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 			},
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50},
 		},
 		{
-			name: "with SuperAuthority empty BlockID fallback to genesis",
-			setupSuperAuth: func() *mockSuperAuthority {
-				return &mockSuperAuthority{finalizedL2Head: eth.BlockID{}}
-			},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupEngine: func(m *testutils.MockEngine) {
-				m.ExpectL2BlockRefByNumber(0, eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0}, nil)
-			},
-			expectResult: &eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0},
-		},
-		{
-			name: "with SuperAuthority ahead of local safe uses local safe",
+			// Pre-fix this asserted "empty BlockID → genesis" (bug B applied to
+			// finalized; root cause of ethereum-optimism/optimism#20944). Under
+			// the new contract that path is structurally eliminated. The
+			// PreActivation source now returns localFinalizedHead.
+			name: "PreActivation source returns localFinalizedHead, never genesis",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
 				}
 			},
-			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 40},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			expectResult:    &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+		},
+		{
+			// Super authority cannot finalize a block that isn't locally finalized:
+			// authority=50, localFinalized=30 → clamp to localFinalized.
+			name: "SuperAuthority finalized ahead of local-finalized uses local-finalized",
+			setupSuperAuth: func() *mockSuperAuthority {
+				return &mockSuperAuthority{
+					finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					finalizedL2HeadSource: rollup.VerifierHeadVerified,
+				}
+			},
+			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 100},
 			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
-			expectResult:    &eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 40},
+			expectResult:    &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 		},
 		{
 			name:           "without SuperAuthority returns zero value",
@@ -866,13 +899,14 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			expectResult:   &eth.L2BlockRef{},
 		},
 		{
-			name: "returns empty block when genesis lookup fails",
+			// Cold-start HoldPrevious (verifier error, no cache, no local data).
+			// Must return eth.L2BlockRef{} — no garbage, no genesis. This is the
+			// error-after-startup safety trace from the design discussion.
+			name: "HoldPrevious with no cache returns zero",
 			setupSuperAuth: func() *mockSuperAuthority {
-				return &mockSuperAuthority{finalizedL2Head: eth.BlockID{}}
-			},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupEngine: func(m *testutils.MockEngine) {
-				m.ExpectL2BlockRefByNumber(0, eth.L2BlockRef{}, errors.New("genesis not found"))
+				return &mockSuperAuthority{
+					holdPreviousFinalized: true,
+				}
 			},
 			expectResult: &eth.L2BlockRef{},
 		},
@@ -880,11 +914,12 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			name: "returns empty when SuperAuthority block unknown to engine and no SuperAuthority cache exists",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					finalizedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
+					finalizedL2Head:       eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
+					finalizedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 			},
@@ -894,11 +929,12 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			name: "falls back to cached SuperAuthority finalized when SuperAuthority block unknown to engine",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					finalizedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 60},
+					finalizedL2Head:       eth.BlockID{Hash: common.Hash{0x99}, Number: 60},
+					finalizedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 60},
 			setupSACache:    &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 50},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
@@ -951,13 +987,16 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 
 func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) {
 	superAuth := &mockSuperAuthority{
-		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2HeadSource: rollup.VerifierHeadVerified,
 	}
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
 	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
-	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30}
+	// localFinalized must be >= the SuperAuthority finalized values (50, 60)
+	// since FinalizedHead is now bounded by local-finalized.
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 60}
 	ec.SetFinalizedHead(localFinalized)
 
 	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
@@ -968,6 +1007,7 @@ func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) 
 	require.Equal(t, finalizedRef, ec.superAuthorityFinalizedHead)
 
 	superAuth.finalizedL2Head = eth.BlockID{Hash: common.Hash{0xcc}, Number: 60}
+	superAuth.finalizedL2HeadSource = rollup.VerifierHeadVerified
 	mockEngine.ExpectL2BlockRefByHash(common.Hash{0xcc}, eth.L2BlockRef{}, errors.New("temporary EL error"))
 
 	require.Equal(t, finalizedRef, ec.FinalizedHead())
@@ -975,31 +1015,39 @@ func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) 
 	require.Equal(t, finalizedRef, ec.superAuthorityFinalizedHead)
 }
 
-func TestEngineController_FinalizedHeadDoesNotCacheLocalSafeFallback(t *testing.T) {
+// FinalizedHead is bounded by local-finalized (the super authority cannot
+// finalize a block that isn't locally final). When the authority reports a
+// finalized block ahead of local-finalized, the local-finalized head wins and
+// the super-authority cache stays empty.
+func TestEngineController_FinalizedHeadAheadOfLocalFinalUsesLocalFinal(t *testing.T) {
 	superAuth := &mockSuperAuthority{
-		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2HeadSource: rollup.VerifierHeadVerified,
 	}
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
-	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 40}
-	cachedFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30}
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30}
 	ec.SetLocalSafeHead(localSafe)
-	ec.SetFinalizedHead(cachedFinalized)
+	ec.SetFinalizedHead(localFinalized)
 
-	require.Equal(t, localSafe, ec.FinalizedHead())
-	require.Equal(t, cachedFinalized, ec.localFinalizedHead)
-	require.Equal(t, eth.L2BlockRef{}, ec.superAuthorityFinalizedHead)
+	require.Equal(t, localFinalized, ec.FinalizedHead())
+	require.Equal(t, localFinalized, ec.localFinalizedHead)
+	require.Equal(t, eth.L2BlockRef{}, ec.superAuthorityFinalizedHead,
+		"cache must not be populated when the SuperAuthority result is clamped to local-finalized")
 }
 
 func TestEngineController_FinalizedHeadUsesCachedSuperAuthorityFinalizedWhenAuthorityRegresses(t *testing.T) {
 	superAuth := &mockSuperAuthority{
-		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 40},
+		finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 40},
+		finalizedL2HeadSource: rollup.VerifierHeadVerified,
 	}
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
 	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xff}, Number: 60})
 	cachedSuperAuthority := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50}
 	ec.superAuthorityFinalizedHead = cachedSuperAuthority
 
@@ -1009,12 +1057,14 @@ func TestEngineController_FinalizedHeadUsesCachedSuperAuthorityFinalizedWhenAuth
 
 func TestEngineController_FinalizedHeadPanicsOnCachedSuperAuthoritySameHeightConflict(t *testing.T) {
 	superAuth := &mockSuperAuthority{
-		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2HeadSource: rollup.VerifierHeadVerified,
 	}
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
 	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xff}, Number: 60})
 	ec.superAuthorityFinalizedHead = eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50}
 
 	require.PanicsWithValue(t, "superAuthority finalized head conflicts with cached superAuthority finalized head at same height", func() {

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -1039,11 +1039,14 @@ func TestEngineController_FinalizedHeadAheadOfLocalFinalUsesLocalFinal(t *testin
 }
 
 func TestEngineController_FinalizedHeadUsesCachedSuperAuthorityFinalizedWhenAuthorityRegresses(t *testing.T) {
+	authorityBlock := eth.BlockID{Hash: common.Hash{0xbb}, Number: 40}
+	authorityRef := eth.L2BlockRef{Hash: authorityBlock.Hash, Number: authorityBlock.Number}
 	superAuth := &mockSuperAuthority{
-		finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 40},
+		finalizedL2Head:       authorityBlock,
 		finalizedL2HeadSource: rollup.VerifierHeadVerified,
 	}
 	mockEngine := &testutils.MockEngine{}
+	mockEngine.ExpectL2BlockRefByHash(authorityBlock.Hash, authorityRef, nil)
 	emitter := &testutils.MockEmitter{}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
 	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
@@ -1056,11 +1059,14 @@ func TestEngineController_FinalizedHeadUsesCachedSuperAuthorityFinalizedWhenAuth
 }
 
 func TestEngineController_FinalizedHeadPanicsOnCachedSuperAuthoritySameHeightConflict(t *testing.T) {
+	authorityBlock := eth.BlockID{Hash: common.Hash{0xbb}, Number: 50}
+	authorityRef := eth.L2BlockRef{Hash: authorityBlock.Hash, Number: authorityBlock.Number}
 	superAuth := &mockSuperAuthority{
-		finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2Head:       authorityBlock,
 		finalizedL2HeadSource: rollup.VerifierHeadVerified,
 	}
 	mockEngine := &testutils.MockEngine{}
+	mockEngine.ExpectL2BlockRefByHash(authorityBlock.Hash, authorityRef, nil)
 	emitter := &testutils.MockEmitter{}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
 	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
@@ -1070,6 +1076,33 @@ func TestEngineController_FinalizedHeadPanicsOnCachedSuperAuthoritySameHeightCon
 	require.PanicsWithValue(t, "superAuthority finalized head conflicts with cached superAuthority finalized head at same height", func() {
 		ec.FinalizedHead()
 	})
+}
+
+// TestEngineController_FinalizedHeadAnchorDoesNotRegressCache locks in the
+// monotonicity guarantee for the Anchor branch: once a Verified result has
+// populated the cache, a subsequent Anchor result behind the cache must not
+// regress it.
+func TestEngineController_FinalizedHeadAnchorDoesNotRegressCache(t *testing.T) {
+	cfg := &rollup.Config{BlockTime: 2}
+	// Anchor cap timestamp 999 → block 499 with BlockTime=2.
+	anchorRef := eth.L2BlockRef{Hash: common.Hash{0xa1}, Number: 499}
+	cached := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 1000}
+	superAuth := &mockSuperAuthority{
+		finalizedL2HeadSource: rollup.VerifierHeadAnchor,
+		finalizedTimestamp:    999,
+	}
+	mockEngine := &testutils.MockEngine{}
+	mockEngine.ExpectL2BlockRefByNumber(uint64(499), anchorRef, nil)
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 2000})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xff}, Number: 1500})
+	ec.superAuthorityFinalizedHead = cached
+
+	require.Equal(t, cached, ec.FinalizedHead(),
+		"Anchor result behind the cache must not regress FinalizedHead")
+	require.Equal(t, cached, ec.superAuthorityFinalizedHead,
+		"cache must not be overwritten with a regressing Anchor result")
 }
 
 // TestTryUpdateEngine_SyncingInCLModeTriggersReset tests that when the EL returns SYNCING

--- a/op-node/rollup/engine/super_authority_mock_test.go
+++ b/op-node/rollup/engine/super_authority_mock_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -8,12 +9,22 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// mockSuperAuthority implements SuperAuthority for testing.
+// mockSuperAuthority implements rollup.SuperAuthority for testing.
+// holdPrevious{Verified,Finalized} default to false so struct-literal tests
+// without explicit setup get the happy-path (ok=true).
 type mockSuperAuthority struct {
-	fullyVerifiedL2Head eth.BlockID
-	finalizedL2Head     eth.BlockID
-	deniedBlocks        map[uint64]common.Hash
-	shouldError         bool
+	fullyVerifiedL2Head       eth.BlockID
+	fullyVerifiedTimestamp    uint64
+	fullyVerifiedL2HeadSource rollup.VerifierHeadSource
+	holdPreviousVerified      bool
+
+	finalizedL2Head       eth.BlockID
+	finalizedTimestamp    uint64
+	finalizedL2HeadSource rollup.VerifierHeadSource
+	holdPreviousFinalized bool
+
+	deniedBlocks map[uint64]common.Hash
+	shouldError  bool
 }
 
 func newMockSuperAuthority() *mockSuperAuthority {
@@ -37,12 +48,20 @@ func (m *mockSuperAuthority) IsDenied(blockNumber uint64, payloadHash common.Has
 	return false, nil
 }
 
-func (m *mockSuperAuthority) FullyVerifiedL2Head() (eth.BlockID, bool) {
-	return m.fullyVerifiedL2Head, false
+func (m *mockSuperAuthority) FullyVerifiedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
+	return rollup.VerifierHead{
+		Block:     m.fullyVerifiedL2Head,
+		Timestamp: m.fullyVerifiedTimestamp,
+		Source:    m.fullyVerifiedL2HeadSource,
+	}, !m.holdPreviousVerified
 }
 
-func (m *mockSuperAuthority) FinalizedL2Head() (eth.BlockID, bool) {
-	return m.finalizedL2Head, false
+func (m *mockSuperAuthority) FinalizedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
+	return rollup.VerifierHead{
+		Block:     m.finalizedL2Head,
+		Timestamp: m.finalizedTimestamp,
+		Source:    m.finalizedL2HeadSource,
+	}, !m.holdPreviousFinalized
 }
 
 var _ rollup.SuperAuthority = (*mockSuperAuthority)(nil)

--- a/op-node/rollup/engine/super_authority_safe_head_test.go
+++ b/op-node/rollup/engine/super_authority_safe_head_test.go
@@ -1,0 +1,145 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+// TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis exercises bug B.
+//
+// Under the previous boolean contract, an active verifier with no entries for
+// this chain returned (BlockID{}, false), and engine_controller.SafeL2Head
+// resolved the empty BlockID to L2 genesis via L2BlockRefByNumber(0). That
+// dropped cross-safe to genesis once the chain hadn't yet been covered by the
+// verifier's depset — see ethereum-optimism/optimism#20944.
+//
+// Under the tri-state contract, that scenario surfaces as Source = Anchor with
+// a concrete activation-anchor block. SafeL2Head bounds by local-safe and
+// returns the verifier's contribution. SafeL2Head must never return the L2
+// genesis block when local-safe and local-finalized are non-zero.
+func TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis(t *testing.T) {
+	// Realistic shape: local-safe has crossed activation. With BlockTime=2 and
+	// genesis at time 0, timestamp 999 maps to block 499. Local-safe must be
+	// at or past the anchor block (otherwise the chain hasn't crossed
+	// activation and the PreActivation path would have fired upstream).
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 600}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+
+	cfg := &rollup.Config{BlockTime: 2}
+	anchorRef := eth.L2BlockRef{Hash: common.Hash{0xa1}, Number: 499}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadAnchor,
+		fullyVerifiedTimestamp:    999,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		cfg,
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(localFinalized)
+
+	mockEngine.ExpectL2BlockRefByNumber(uint64(499), anchorRef, nil)
+
+	got := ec.SafeL2Head()
+	require.NotEqual(t, uint64(0), got.Number,
+		"SafeL2Head must not drop to genesis when local-safe (%d) and local-finalized (%d) are non-zero. "+
+			"Pre-fix, empty verifier returned (BlockID{}, false) and SafeL2Head fetched L2BlockRefByNumber(0). "+
+			"Post-fix, Anchor source carries the pre-activation cap timestamp and the engine controller "+
+			"resolves the canonical L2 block at that timestamp (ethereum-optimism/optimism#20944).",
+		localSafe.Number, localFinalized.Number)
+	require.Equal(t, anchorRef, got, "SafeL2Head must return the canonical anchor block at the cap timestamp")
+}
+
+// TestSafeL2Head_VerifierError_FloorsAtFinalized exercises bug A and the
+// verifier-error portion of bug D.
+//
+// Under the previous boolean contract, a verifier read error returned
+// (BlockID{}, true) which engine_controller.SafeL2Head interpreted as
+// "fall back to local-safe", advancing cross-safe past verification. Under the
+// tri-state contract, errors surface as VerifierHeadHoldPrevious and the caller
+// floors at FinalizedHead — never below.
+func TestSafeL2Head_VerifierError_FloorsAtFinalized(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		holdPreviousVerified: true,
+		// FinalizedHead is also consulted; configure it to PreActivation so the
+		// floor resolves to localFinalizedHead.
+		finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(localFinalized)
+
+	got := ec.SafeL2Head()
+	require.NotEqual(t, localSafe, got,
+		"SafeL2Head must not return localSafeHead on verifier error; "+
+			"the previous (BlockID{}, true) signal advanced cross-safe past verification (bug A).")
+	require.Equal(t, localFinalized, got,
+		"SafeL2Head must floor at localFinalizedHead on verifier error (HoldPrevious semantics).")
+}
+
+// TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero documents the
+// error-after-startup trace: verifier errors on the first call, no cached
+// super-authority finalized head yet, localSafeHead and localFinalizedHead are
+// both zero. The expected behavior is a zero L2BlockRef — not garbage, not
+// genesis, not localFinalizedHead. This is the cold-start safety property the
+// design discussion explicitly called for.
+func TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero(t *testing.T) {
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		holdPreviousFinalized: true,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	// localSafeHead / localFinalizedHead deliberately left as zero.
+
+	got := ec.FinalizedHead()
+	require.Equal(t, eth.L2BlockRef{}, got,
+		"FinalizedHead on cold-start HoldPrevious must return zero L2BlockRef, not garbage")
+	require.Equal(t, common.Hash{}, got.Hash,
+		"resulting ForkchoiceUpdate sends a zero finalized hash, preserving the EL's own label")
+}

--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -1,28 +1,72 @@
 package rollup
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// SuperAuthority provides payload validation functionality from a supernode.
-// When running inside a supernode, this allows the engine controller to check
-// if payloads are denied before applying them, enabling coordinated block invalidation.
+// VerifierHeadSource classifies the origin of a head reported by the SuperAuthority.
+type VerifierHeadSource uint8
+
+const (
+	// VerifierHeadPreActivation: the registered verifier is inactive at the
+	// current local-safe timestamp. Caller uses local-safe / local-finalized.
+	VerifierHeadPreActivation VerifierHeadSource = iota
+	// VerifierHeadAnchor: the active verifier has no verified-DB entry for this
+	// chain yet. Block is zero; Timestamp is the pre-activation cap
+	// (`activationTimestamp - 1`); caller resolves the canonical L2 block at
+	// that timestamp.
+	VerifierHeadAnchor
+	// VerifierHeadVerified: Block is the verified tip from the verifier.
+	VerifierHeadVerified
+)
+
+// Exhaustive — adding a variant requires updating every consumer's switch.
+func (s VerifierHeadSource) String() string {
+	switch s {
+	case VerifierHeadPreActivation:
+		return "pre-activation"
+	case VerifierHeadAnchor:
+		return "anchor"
+	case VerifierHeadVerified:
+		return "verified"
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(s))
+	}
+}
+
+// VerifierHead is the result of a SuperAuthority head query.
+//   - Source == PreActivation: Block and Timestamp are zero; caller uses local.
+//   - Source == Verified:      Block is the verified tip; Timestamp is its L2 time.
+//   - Source == Anchor:        Block is zero; Timestamp is the pre-activation cap
+//     (`activationTimestamp - 1`); caller resolves the canonical L2 block at that
+//     timestamp itself.
+type VerifierHead struct {
+	Block     eth.BlockID
+	Timestamp uint64
+	Source    VerifierHeadSource
+}
+
+// SuperAuthority is the cross-chain attestation surface a supernode exposes to
+// op-node: cross-verified safe / finalized head reporting and payload deny-list
+// checks. Returned heads are consumed by the engine controller to choose what
+// to publish as SafeL2Head / FinalizedHead and whether to apply a payload.
 type SuperAuthority interface {
-	// FullyVerifiedL2Head returns the fully verified L2 head block reference.
-	// The second return value indicates whether the caller should fall back to local-safe.
-	// If useLocalSafe is true, the BlockID return value should be ignored and local-safe used instead.
-	// If useLocalSafe is false, the BlockID is the cross-verified safe head.
-	FullyVerifiedL2Head() (head eth.BlockID, useLocalSafe bool)
-	// FinalizedL2Head returns the finalized L2 head block reference.
-	// The second return value indicates whether the caller should fall back to local-finalized.
-	// If useLocalFinalized is true, the BlockID return value should be ignored and local-finalized used instead.
-	// If useLocalFinalized is false, the BlockID is the cross-verified finalized head.
-	FinalizedL2Head() (head eth.BlockID, useLocalFinalized bool)
-	// IsDenied checks if a payload hash is denied at the given block number.
-	// Returns true if the payload should not be applied.
-	// The error indicates if the check could not be performed (should be logged but not fatal).
+	// FullyVerifiedL2Head returns the cross-verified safe L2 head.
+	// `ok=false` signals a transient read failure — caller must hold the
+	// previous value (floored at FinalizedHead), never fall back to local-safe.
+	FullyVerifiedL2Head(ctx context.Context) (head VerifierHead, ok bool)
+
+	// FinalizedL2Head is the finalized analogue of FullyVerifiedL2Head.
+	// Finalized blocks cannot reorg, so the caller may cache the result.
+	FinalizedL2Head(ctx context.Context) (head VerifierHead, ok bool)
+
+	// IsDenied reports whether a payload hash is denied at the given block
+	// number. Errors are logged but not fatal.
 	IsDenied(blockNumber uint64, payloadHash common.Hash) (bool, error)
 }
 

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -52,14 +52,16 @@ type VerificationActivity interface {
 	// data at or before that timestamp as safe without consulting this activity.
 	IsActiveAt(ts uint64) bool
 
-	// LatestVerifiedL2Block returns the latest verified L2 block and its
-	// timestamp. (empty, 0, nil) means nothing verified yet; a non-nil error
-	// means the verifier is transiently unavailable.
+	// LatestVerifiedL2Block returns the latest verified L2 block.
+	// (block, ts, nil) — verified tip at ts.
+	// (empty, ts, nil) — no verified entry; ts is the pre-activation cap the
+	//   caller should resolve to a canonical L2 block. ts==0 means no cap.
+	// (empty, 0, err) — verifier is transiently unavailable.
 	LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error)
 
 	// VerifiedBlockAtL1 returns the latest verified L2 block whose data was
-	// derived from or before the supplied L1 block. (empty, 0, nil) means no
-	// such entry yet; a non-nil error means the verifier is transiently
-	// unavailable.
+	// derived from or before the supplied L1 block. Return shape matches
+	// LatestVerifiedL2Block: an empty BlockID with non-zero ts is a cap, not a
+	// failure.
 	VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64, error)
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1191,40 +1191,61 @@ func (i *Interop) IsActiveAt(ts uint64) bool {
 	return ts >= i.activationTimestamp
 }
 
-// LatestVerifiedL2Block returns the latest verified L2 block for chainID and
-// its timestamp. (empty, 0, nil) means nothing verified yet; a non-nil error
-// means verifiedDB could not be read.
+// ActivationTimestamp returns the immutable protocol-defined interop activation
+// timestamp for this verifier. Used by the SuperAuthority to compute the
+// per-(chain, verifier) activation-anchor block and by RPC surfaces that expose
+// the configured activation point.
+func (i *Interop) ActivationTimestamp() uint64 {
+	return i.activationTimestamp
+}
+
+// activationCap is the L2 timestamp the verifier reports as a cap when it has
+// no verified entry for the caller's chain. The caller resolves the canonical
+// L2 block at this timestamp (the pre-activation anchor). Returns 0 when no
+// activation timestamp is configured — caller treats that as "no contribution".
+func (i *Interop) activationCap() uint64 {
+	if i.activationTimestamp == 0 {
+		return 0
+	}
+	return i.activationTimestamp - 1
+}
+
+// LatestVerifiedL2Block returns the latest verified L2 block for chainID.
+// (empty, capTimestamp, nil) means nothing verified — capTimestamp is the
+// pre-activation anchor (`activationTimestamp - 1`) for the caller to resolve.
+// A non-nil error means verifiedDB could not be read.
 func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error) {
 	emptyBlock := eth.BlockID{}
 	ts, ok := i.verifiedDB.LastTimestamp()
 	if !ok {
-		return emptyBlock, 0, nil
+		return emptyBlock, i.activationCap(), nil
 	}
 	res, err := i.verifiedDB.Get(ts)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			return emptyBlock, 0, nil
+			return emptyBlock, i.activationCap(), nil
 		}
 		return emptyBlock, 0, fmt.Errorf("LatestVerifiedL2Block: read verifiedDB at %d: %w", ts, err)
 	}
 	head, ok := res.L2Heads[chainID]
 	if !ok {
-		return emptyBlock, 0, nil
+		return emptyBlock, i.activationCap(), nil
 	}
 	return head, ts, nil
 }
 
 // VerifiedBlockAtL1 returns the latest verified L2 block for chainID whose
-// L1 inclusion is at or below l1Block. (empty, 0, nil) means no match;
-// a non-nil error means verifiedDB could not be read.
+// L1 inclusion is at or below l1Block. (empty, capTimestamp, nil) means no
+// match — capTimestamp is the pre-activation anchor for the caller to resolve.
+// A non-nil error means verifiedDB could not be read.
 func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64, error) {
 	if l1Block == (eth.L1BlockRef{}) {
-		return eth.BlockID{}, 0, nil
+		return eth.BlockID{}, i.activationCap(), nil
 	}
 
 	lastTs, ok := i.verifiedDB.LastTimestamp()
 	if !ok {
-		return eth.BlockID{}, 0, nil
+		return eth.BlockID{}, i.activationCap(), nil
 	}
 
 	// activationTimestamp is the floor: no verified results exist before activation.
@@ -1243,13 +1264,13 @@ func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef)
 		if result.L1Inclusion.Number <= l1Block.Number {
 			head, ok := result.L2Heads[chainID]
 			if !ok {
-				return eth.BlockID{}, 0, nil
+				return eth.BlockID{}, i.activationCap(), nil
 			}
 			return head, ts, nil
 		}
 	}
 
-	return eth.BlockID{}, 0, nil
+	return eth.BlockID{}, i.activationCap(), nil
 }
 
 // Reset is intentionally a no-op for interop.

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -2838,7 +2838,9 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		blockID, ts, err := h.interop.VerifiedBlockAtL1(h.Mock(10).id, eth.L1BlockRef{})
 		require.NoError(t, err)
 		require.Equal(t, eth.BlockID{}, blockID)
-		require.Equal(t, uint64(0), ts)
+		// Empty result returns the pre-activation cap (activationTimestamp-1)
+		// so the caller can resolve the canonical L2 anchor block.
+		require.Equal(t, h.interop.activationTimestamp-1, ts)
 	})
 
 	t.Run("non-zero l1Block finds matching entry", func(t *testing.T) {
@@ -2879,7 +2881,8 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		blockID, ts, err := h.interop.VerifiedBlockAtL1(h.Mock(10).id, l1Block)
 		require.NoError(t, err)
 		require.Equal(t, eth.BlockID{}, blockID)
-		require.Equal(t, uint64(0), ts)
+		// Empty DB returns the pre-activation cap (activationTimestamp-1).
+		require.Equal(t, h.interop.activationTimestamp-1, ts)
 	})
 
 	t.Run("closed verifiedDB surfaces error", func(t *testing.T) {

--- a/op-supernode/supernode/activity/interop/interop_test_access.go
+++ b/op-supernode/supernode/activity/interop/interop_test_access.go
@@ -53,13 +53,9 @@ func (i *Interop) BackfillCompleted() bool {
 // ---------------------------------------------------------------------------
 // Activation-timestamp inspection
 // ---------------------------------------------------------------------------
-
-// ActivationTimestamp returns the immutable protocol-defined interop
-// activation timestamp. This is the value that fronts protocol-facing RPC
-// responses and never advances at runtime.
-func (i *Interop) ActivationTimestamp() uint64 {
-	return i.activationTimestamp
-}
+//
+// Note: ActivationTimestamp is part of the production VerificationActivity
+// interface and lives in interop.go alongside IsActiveAt.
 
 // VerificationStartTimestamp returns the L2 timestamp at which the main loop
 // begins verification on the most recent Start. Returns 0 before

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -170,7 +170,9 @@ type simpleChainContainer struct {
 // Interface conformance assertions
 var _ ChainContainer = (*simpleChainContainer)(nil)
 var _ InteropChain = (*simpleChainContainer)(nil)
-var _ rollup.SuperAuthority = (*simpleChainContainer)(nil)
+
+// rollup.SuperAuthority conformance is asserted in super_authority.go alongside
+// the method definitions.
 
 func NewChainContainer(
 	chainID eth.ChainID,

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -10,83 +10,77 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// FullyVerifiedL2Head returns the fully-verified L2 head from the registered
-// verifier. The bool is true to signal use-local-safe (no verifier registered,
-// pre-activation, or transient verifier error); false carries the verifier
-// result (block, or empty when the verifier is operational but has nothing
-// verified yet).
-func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
+// FullyVerifiedL2Head reports the cross-verified safe L2 head.
+//
+// With a single registered verifier:
+//   - No verifier registered → PreActivation; caller uses local-safe.
+//   - Verifier not yet active at local-safe time → PreActivation.
+//   - Verifier read error → HoldPrevious (ok=false).
+//   - Verifier has no entry for this chain → Anchor with cap timestamp
+//     (`activationTimestamp - 1`); engine controller resolves to a canonical
+//     block.
+//   - Verifier has a verified tip → Verified.
+func (c *simpleChainContainer) FullyVerifiedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
 	v := c.registeredVerifier()
 	if v == nil {
-		c.log.Debug("FullyVerifiedL2Head: no verifier registered, signaling local-safe fallback")
-		return eth.BlockID{}, true
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
 
-	// Pre-activation L2 content is verified by consensus alone; gating it on
-	// a not-yet-active interop verifier would stall the head at genesis (#20191).
-	if activeTS, ok := c.localSafeTimestamp(); ok && !v.IsActiveAt(activeTS) {
-		c.log.Debug("FullyVerifiedL2Head: verifier pre-activation, signaling local-safe fallback", "localSafeTime", activeTS)
-		return eth.BlockID{}, true
+	if activeTS, ok := c.localSafeTimestamp(ctx); ok && !v.IsActiveAt(activeTS) {
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
 
-	bId, ts, err := v.LatestVerifiedL2Block(c.chainID)
+	contribution, err := c.verifierContribution(v.LatestVerifiedL2Block(c.chainID))
 	if err != nil {
-		c.log.Warn("FullyVerifiedL2Head: verifier read failed, signaling local-safe fallback",
+		c.log.Warn("FullyVerifiedL2Head: verifier read failed, holding previous",
 			"verifier", v.Name(), "err", err)
-		return eth.BlockID{}, true
+		return rollup.VerifierHead{}, false
 	}
-	if (bId == eth.BlockID{} || ts == 0) {
-		c.log.Debug("FullyVerifiedL2Head: verifier returned empty, returning empty without fallback", "verifier", v.Name())
-		return eth.BlockID{}, false
-	}
-
-	c.log.Debug("FullyVerifiedL2Head: returning verified block", "block", bId, "timestamp", ts)
-	return bId, false
+	return contribution, true
 }
 
-// FinalizedL2Head returns the finalized L2 head from the registered verifier.
-// The bool is true to signal use-local-finalized (no verifier registered,
-// pre-activation, sync status unavailable, or transient verifier error);
-// false carries the verifier result.
-func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
+// FinalizedL2Head is the finalized analogue of FullyVerifiedL2Head.
+func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
 	v := c.registeredVerifier()
 	if v == nil {
-		c.log.Debug("FinalizedL2Head: no verifier registered, signaling local-finalized fallback")
-		return eth.BlockID{}, true
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
 
-	ss, err := c.SyncStatus(context.Background())
+	ss, err := c.SyncStatus(ctx)
 	if err != nil {
-		c.log.Error("FinalizedL2Head: failed to get sync status", "err", err)
-		return eth.BlockID{}, true
+		c.log.Warn("FinalizedL2Head: failed to get sync status, holding previous", "err", err)
+		return rollup.VerifierHead{}, false
 	}
 
 	// FinalizedL2 <= LocalSafeL2; if local-safe is pre-activation, so is finalized.
 	if !v.IsActiveAt(ss.LocalSafeL2.Time) {
-		c.log.Debug("FinalizedL2Head: verifier pre-activation, signaling local-finalized fallback", "localSafeTime", ss.LocalSafeL2.Time)
-		return eth.BlockID{}, true
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
 
-	bId, ts, err := v.VerifiedBlockAtL1(c.chainID, ss.FinalizedL1)
+	contribution, err := c.verifierContribution(v.VerifiedBlockAtL1(c.chainID, ss.FinalizedL1))
 	if err != nil {
-		c.log.Warn("FinalizedL2Head: verifier read failed, signaling local-finalized fallback",
+		c.log.Warn("FinalizedL2Head: verifier read failed, holding previous",
 			"verifier", v.Name(), "err", err)
-		return eth.BlockID{}, true
+		return rollup.VerifierHead{}, false
 	}
-	if (bId == eth.BlockID{} || ts == 0) {
-		c.log.Debug("FinalizedL2Head: verifier returned empty, returning empty without fallback", "verifier", v.Name())
-		return eth.BlockID{}, false
-	}
-
-	c.log.Debug("FinalizedL2Head: returning finalized block", "block", bId, "timestamp", ts)
-	return bId, false
+	return contribution, true
 }
 
-// localSafeTimestamp returns the timestamp of the current local-safe L2 head.
-// The bool is false if SyncStatus is unavailable, in which case callers should
-// not attempt the pre-activation short-circuit.
-func (c *simpleChainContainer) localSafeTimestamp() (uint64, bool) {
-	ss, err := c.SyncStatus(context.Background())
+// verifierContribution classifies a verifier's (block, ts) return:
+//   - empty block → Anchor (caller resolves the canonical L2 block at ts).
+//   - non-empty block → Verified tip.
+func (c *simpleChainContainer) verifierContribution(bId eth.BlockID, ts uint64, err error) (rollup.VerifierHead, error) {
+	if err != nil {
+		return rollup.VerifierHead{}, err
+	}
+	if (bId == eth.BlockID{}) {
+		return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor, Timestamp: ts}, nil
+	}
+	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bId, Timestamp: ts}, nil
+}
+
+func (c *simpleChainContainer) localSafeTimestamp(ctx context.Context) (uint64, bool) {
+	ss, err := c.SyncStatus(ctx)
 	if err != nil {
 		c.log.Warn("localSafeTimestamp: failed to get sync status", "err", err)
 		return 0, false
@@ -118,5 +112,4 @@ func (c *simpleChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2Bloc
 	return c.engine.OutputV0AtBlockNumber(ctx, l2BlockNum)
 }
 
-// Interface satisfaction static check
 var _ rollup.SuperAuthority = (*simpleChainContainer)(nil)

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
@@ -21,9 +22,9 @@ type mockVerificationActivityForSuperAuthority struct {
 	latestFinalizedTS    uint64
 	latestFinalizedErr   error
 	currentL1            eth.BlockID
-	// isActiveAtFn drives IsActiveAt for pre-activation fallback tests.
-	// When nil, IsActiveAt returns true (active for all timestamps), matching
-	// the default "always-active" semantics the existing tests assume.
+	activationTimestamp  uint64
+	// isActiveAtFn drives IsActiveAt. When nil, IsActiveAt returns true for any
+	// timestamp >= activationTimestamp (matching the production semantics).
 	isActiveAtFn func(ts uint64) bool
 }
 
@@ -37,17 +38,35 @@ func (m *mockVerificationActivityForSuperAuthority) VerifiedAtTimestamp(ts uint6
 	return false, nil
 }
 func (m *mockVerificationActivityForSuperAuthority) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error) {
-	return m.latestVerifiedBlock, m.latestVerifiedTS, m.latestVerifiedErr
+	if m.latestVerifiedErr != nil {
+		return eth.BlockID{}, 0, m.latestVerifiedErr
+	}
+	if m.latestVerifiedBlock == (eth.BlockID{}) {
+		return eth.BlockID{}, m.activationCap(), nil
+	}
+	return m.latestVerifiedBlock, m.latestVerifiedTS, nil
 }
 func (m *mockVerificationActivityForSuperAuthority) Reset(eth.ChainID, uint64, eth.BlockRef) {}
 func (m *mockVerificationActivityForSuperAuthority) VerifiedBlockAtL1(chainID eth.ChainID, l1BlockRef eth.L1BlockRef) (eth.BlockID, uint64, error) {
-	return m.latestFinalizedBlock, m.latestFinalizedTS, m.latestFinalizedErr
+	if m.latestFinalizedErr != nil {
+		return eth.BlockID{}, 0, m.latestFinalizedErr
+	}
+	if m.latestFinalizedBlock == (eth.BlockID{}) {
+		return eth.BlockID{}, m.activationCap(), nil
+	}
+	return m.latestFinalizedBlock, m.latestFinalizedTS, nil
+}
+func (m *mockVerificationActivityForSuperAuthority) activationCap() uint64 {
+	if m.activationTimestamp == 0 {
+		return 0
+	}
+	return m.activationTimestamp - 1
 }
 func (m *mockVerificationActivityForSuperAuthority) IsActiveAt(ts uint64) bool {
 	if m.isActiveAtFn != nil {
 		return m.isActiveAtFn(ts)
 	}
-	return true
+	return ts >= m.activationTimestamp
 }
 
 var _ activity.VerificationActivity = (*mockVerificationActivityForSuperAuthority)(nil)
@@ -59,6 +78,14 @@ func newTestChainContainer(t *testing.T, chainID eth.ChainID) *simpleChainContai
 		log:     testlog.Logger(t, log.LevelDebug),
 		vn:      &mockVirtualNode{},
 	}
+}
+
+// setSyncStatus configures the chain's mock virtual node to return the given SyncStatus.
+func setSyncStatus(t *testing.T, cc *simpleChainContainer, ss *eth.SyncStatus) {
+	t.Helper()
+	mvn, ok := cc.vn.(*mockVirtualNode)
+	require.True(t, ok, "newTestChainContainer must install a *mockVirtualNode")
+	mvn.syncStatusOverride = func() (*eth.SyncStatus, error) { return ss, nil }
 }
 
 // TestChainContainer_RegisterVerifier_RejectsSecondVerifier pins the contract
@@ -93,141 +120,71 @@ func TestChainContainer_VerifierCurrentL1_ReturnsRegisteredVerifier(t *testing.T
 	require.Equal(t, currentL1, l1)
 }
 
-// TestChainContainer_FullyVerifiedL2Head_NoVerifier tests that FullyVerifiedL2Head
-// returns an empty BlockID and signals fallback when no verifier is registered
-func TestChainContainer_FullyVerifiedL2Head_NoVerifier(t *testing.T) {
+// =============================================================================
+// FullyVerifiedL2Head — happy paths
+// =============================================================================
+
+func TestChainContainer_FullyVerifiedL2Head_NoVerifier_ReturnsPreActivation(t *testing.T) {
 	t.Parallel()
 
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
 
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID with no verifier")
-	require.True(t, useLocalSafe, "should signal fallback to local-safe when no verifier registered")
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
+	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source,
+		"no verifier registered → PreActivation; caller uses local-safe")
+	require.Equal(t, eth.BlockID{}, head.Block)
 }
 
-// TestChainContainer_FullyVerifiedL2Head_SingleVerifier tests the happy path
-// where a single verifier reports a verified block.
 func TestChainContainer_FullyVerifiedL2Head_SingleVerifier(t *testing.T) {
 	t.Parallel()
 
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	verifier := &mockVerificationActivityForSuperAuthority{
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	v := &mockVerificationActivityForSuperAuthority{
 		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
 		latestVerifiedTS:    1000,
 	}
-	cc.RegisterVerifier(verifier)
+	cc.RegisterVerifier(v)
 
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, verifier.latestVerifiedBlock, result, "should return the verifier's block")
-	require.False(t, useLocalSafe, "should not signal fallback when verifier has a verified block")
-}
-
-// TestChainContainer_FullyVerifiedL2Head_Unverified tests that an empty BlockID
-// is returned without signaling fallback when the verifier is operational but
-// has nothing verified yet.
-func TestChainContainer_FullyVerifiedL2Head_Unverified(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{},
-		latestVerifiedTS:    0,
-	})
-
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID when verifier is unverified")
-	require.False(t, useLocalSafe, "should not signal fallback when verifier exists but is unverified")
-}
-
-// TestChainContainer_FinalizedL2Head_NoVerifier tests that FinalizedL2Head
-// returns an empty BlockID and signals fallback when no verifier is registered
-func TestChainContainer_FinalizedL2Head_NoVerifier(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID with no verifier")
-	require.True(t, useLocalFinalized, "should signal fallback to local-finalized when no verifier registered")
-}
-
-// TestChainContainer_FinalizedL2Head_SingleVerifier tests the happy path
-// where a single verifier reports a finalized block.
-func TestChainContainer_FinalizedL2Head_SingleVerifier(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	verifier := &mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestFinalizedTS:    1000,
-	}
-	cc.RegisterVerifier(verifier)
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, verifier.latestFinalizedBlock, result, "should return the verifier's block")
-	require.False(t, useLocalFinalized, "should not signal fallback when verifier has a finalized block")
-}
-
-// TestChainContainer_FinalizedL2Head_Unfinalized tests that an empty BlockID
-// is returned without signaling fallback when the verifier is operational but
-// has nothing finalized yet.
-func TestChainContainer_FinalizedL2Head_Unfinalized(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: eth.BlockID{},
-		latestFinalizedTS:    0,
-	})
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID when verifier is unfinalized")
-	require.False(t, useLocalFinalized, "should not signal fallback when verifier exists but is unfinalized")
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
+	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
+	require.Equal(t, v.latestVerifiedBlock, head.Block)
 }
 
 // =============================================================================
-// Pre-activation fallback tests (issue #20191)
+// FullyVerifiedL2Head — anchor contribution
 // =============================================================================
 //
-// These tests pin the contract that when the registered verifier reports
-// IsActiveAt(ss.LocalSafeL2.Time) == false (i.e. the supernode has interop
-// scheduled but the L1-derived local-safe head has not yet crossed the
-// activation timestamp), super_authority falls back to local-safe /
-// local-finalized rather than stalling the engine at genesis.
-//
-// Note: super_authority consults IsActiveAt(ss.LocalSafeL2.Time) for both the
-// safe and finalized head queries, since FinalizedL2 <= LocalSafeL2 always:
-// if local-safe is still pre-activation, finalized is too.
+// Under the new contract, a verifier that is active but has no verified-DB
+// entry for this chain contributes its activation-anchor block, NOT an empty
+// BlockID. This was bug B: post-activation empty verifiers caused SafeL2Head
+// to drop to genesis.
 
-// setSyncStatus configures the chain's mock virtual node to return the given
-// SyncStatus. The test-only mockVirtualNode always backs newTestChainContainer.
-func setSyncStatus(t *testing.T, cc *simpleChainContainer, ss *eth.SyncStatus) {
-	t.Helper()
-	mvn, ok := cc.vn.(*mockVirtualNode)
-	require.True(t, ok, "newTestChainContainer must install a *mockVirtualNode")
-	mvn.syncStatusOverride = func() (*eth.SyncStatus, error) { return ss, nil }
+func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierContributesAnchor(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
+	})
+
+	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{activationTimestamp: 1000})
+
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
+	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
+		"empty verifier post-activation must contribute its activation anchor")
+	require.Equal(t, eth.BlockID{}, head.Block, "anchor contribution carries no block")
+	require.Equal(t, uint64(999), head.Timestamp,
+		"anchor timestamp is activationTimestamp - 1; engine_controller resolves to a block")
 }
 
-// preActivationFn returns an isActiveAtFn that reports inactive for all
-// timestamps strictly below activationTS.
-func preActivationFn(activationTS uint64) func(ts uint64) bool {
-	return func(ts uint64) bool { return ts >= activationTS }
-}
+// =============================================================================
+// FullyVerifiedL2Head — pre-activation
+// =============================================================================
 
-// TestChainContainer_FullyVerifiedL2Head_PreActivation_FallsBackToLocalSafe
-// verifies that a verifier reporting pre-activation for the current LocalSafeL2
-// timestamp causes a fallback to local-safe.
-func TestChainContainer_FullyVerifiedL2Head_PreActivation_FallsBackToLocalSafe(t *testing.T) {
+func TestChainContainer_FullyVerifiedL2Head_PreActivation_ReturnsPreActivationSource(t *testing.T) {
 	t.Parallel()
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
@@ -235,20 +192,20 @@ func TestChainContainer_FullyVerifiedL2Head_PreActivation_FallsBackToLocalSafe(t
 		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xaa}, Time: 999},
 	})
 
-	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
-		isActiveAtFn: preActivationFn(1000),
-	})
+	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{activationTimestamp: 1000})
 
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "pre-activation should return empty BlockID")
-	require.True(t, useLocalSafe, "pre-activation should signal fallback to local-safe")
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
+	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source,
+		"pre-activation → caller uses local-safe (Source=PreActivation)")
+	require.Equal(t, eth.BlockID{}, head.Block)
 }
 
-// TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierNoFallback
-// verifies that once activation has been reached, the existing "verifier
-// present but nothing verified yet" behavior is preserved: no fallback even
-// though the verifier returns empty.
-func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierNoFallback(t *testing.T) {
+// =============================================================================
+// FullyVerifiedL2Head — verifier error → HoldPrevious
+// =============================================================================
+
+func TestChainContainer_FullyVerifiedL2Head_VerifierError_ReturnsHoldPrevious(t *testing.T) {
 	t.Parallel()
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
@@ -257,133 +214,122 @@ func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierNoFallba
 	})
 
 	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
-		isActiveAtFn: preActivationFn(1000),
+		activationTimestamp: 1000,
+		latestVerifiedErr:   errors.New("database not open"),
 	})
 
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "post-activation empty verifier returns empty")
-	require.False(t, useLocalSafe, "post-activation empty verifier must not signal fallback")
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.False(t, ok,
+		"verifier read error must surface as HoldPrevious so the caller floors at finalized, "+
+			"NOT use local-safe (that was the bug)")
+	require.Equal(t, eth.BlockID{}, head.Block)
 }
 
-// TestChainContainer_FullyVerifiedL2Head_PostActivation_VerifiedBlockReturned
-// verifies that the existing "happy path" of returning the verifier's
-// LatestVerifiedL2Block is preserved after activation.
-func TestChainContainer_FullyVerifiedL2Head_PostActivation_VerifiedBlockReturned(t *testing.T) {
+// =============================================================================
+// FinalizedL2Head — same shape as FullyVerifiedL2Head
+// =============================================================================
+
+func TestChainContainer_FinalizedL2Head_NoVerifier_ReturnsPreActivation(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.True(t, ok)
+	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
+}
+
+func TestChainContainer_FinalizedL2Head_SingleVerifier(t *testing.T) {
 	t.Parallel()
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
 	setSyncStatus(t, cc, &eth.SyncStatus{
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 1500},
 	})
 
-	verifiedBlock := eth.BlockID{Hash: [32]byte{0x11}, Number: 100}
-	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: verifiedBlock,
-		latestVerifiedTS:    1500,
-		isActiveAtFn:        preActivationFn(1000),
-	})
+	v := &mockVerificationActivityForSuperAuthority{
+		activationTimestamp:  1000,
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
+		latestFinalizedTS:    1000,
+	}
+	cc.RegisterVerifier(v)
 
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, verifiedBlock, result, "post-activation should return verified block")
-	require.False(t, useLocalSafe, "post-activation with a verified block must not signal fallback")
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.True(t, ok)
+	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
+	require.Equal(t, v.latestFinalizedBlock, head.Block)
 }
 
-// TestChainContainer_FinalizedL2Head_PreActivation_FallsBackToLocalFinalized
-// mirrors the FullyVerified pre-activation case for the finalized head.
-func TestChainContainer_FinalizedL2Head_PreActivation_FallsBackToLocalFinalized(t *testing.T) {
+func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierContributesAnchor(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 1500},
+	})
+
+	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{activationTimestamp: 1000})
+
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.True(t, ok)
+	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
+		"empty verifier post-activation contributes anchor (fixes the safeDB-to-genesis bug, #20944)")
+	require.Equal(t, uint64(999), head.Timestamp,
+		"anchor timestamp is activationTimestamp - 1; engine_controller resolves to a block")
+}
+
+func TestChainContainer_FinalizedL2Head_PreActivation_ReturnsPreActivationSource(t *testing.T) {
 	t.Parallel()
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
 	setSyncStatus(t, cc, &eth.SyncStatus{
 		FinalizedL1: eth.L1BlockRef{Number: 40},
-		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xcc}, Time: 999},
+		LocalSafeL2: eth.L2BlockRef{Number: 50, Time: 999},
 	})
 
-	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
-		isActiveAtFn: preActivationFn(1000),
-	})
+	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{activationTimestamp: 1000})
 
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "pre-activation should return empty BlockID")
-	require.True(t, useLocalFinalized, "pre-activation should signal fallback to local-finalized")
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.True(t, ok)
+	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
 }
 
-// TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierNoFallback —
-// post-activation, verifier empty → empty, no fallback (unchanged).
-func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierNoFallback(t *testing.T) {
+func TestChainContainer_FinalizedL2Head_VerifierError_ReturnsHoldPrevious(t *testing.T) {
 	t.Parallel()
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
 	setSyncStatus(t, cc, &eth.SyncStatus{
 		FinalizedL1: eth.L1BlockRef{Number: 400},
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 1500},
 	})
 
 	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
-		isActiveAtFn: preActivationFn(1000),
+		activationTimestamp: 1000,
+		latestFinalizedErr:  errors.New("database not open"),
 	})
 
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result)
-	require.False(t, useLocalFinalized, "post-activation empty verifier must not signal fallback")
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.False(t, ok,
+		"verifier read error must surface as HoldPrevious, NOT use local-finalized")
+	require.Equal(t, eth.BlockID{}, head.Block)
 }
 
-// TestChainContainer_FinalizedL2Head_PostActivation_FinalizedBlockReturned —
-// post-activation, verifier has a finalized block → returned (unchanged).
-func TestChainContainer_FinalizedL2Head_PostActivation_FinalizedBlockReturned(t *testing.T) {
+// SyncStatus error path: under the new contract this returns HoldPrevious so the
+// caller floors at finalized instead of silently advancing.
+func TestChainContainer_FinalizedL2Head_SyncStatusError_ReturnsHoldPrevious(t *testing.T) {
 	t.Parallel()
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		FinalizedL1: eth.L1BlockRef{Number: 400},
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
-	})
+	mvn := cc.vn.(*mockVirtualNode)
+	mvn.syncStatusOverride = func() (*eth.SyncStatus, error) {
+		return nil, errors.New("vn not ready")
+	}
 
-	finalizedBlock := eth.BlockID{Hash: [32]byte{0x22}, Number: 100}
-	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: finalizedBlock,
-		latestFinalizedTS:    1500,
-		isActiveAtFn:         preActivationFn(1000),
-	})
+	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{activationTimestamp: 1000})
 
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, finalizedBlock, result, "post-activation should return finalized block")
-	require.False(t, useLocalFinalized)
-}
-
-func TestChainContainer_FinalizedL2Head_VerifierError_SignalsLocalFinalizedFallback(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		FinalizedL1: eth.L1BlockRef{Number: 400},
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
-	})
-
-	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
-		isActiveAtFn:       preActivationFn(1000),
-		latestFinalizedErr: errors.New("database not open"),
-	})
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result)
-	require.True(t, useLocalFinalized)
-}
-
-func TestChainContainer_FullyVerifiedL2Head_VerifierError_SignalsLocalSafeFallback(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
-	})
-
-	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
-		isActiveAtFn:      preActivationFn(1000),
-		latestVerifiedErr: errors.New("database not open"),
-	})
-
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result)
-	require.True(t, useLocalSafe)
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.False(t, ok)
+	require.Equal(t, eth.BlockID{}, head.Block)
 }


### PR DESCRIPTION
Redesigns SuperAuthority's safe/finalized head contract as a tri-state result (`VerifierHead` with `Source = PreActivation | Anchor | Verified`, plus an `ok bool`) and fixes three live bugs:

- **Bug A** — verifier read error returned `(BlockID{}, true)` which advanced cross-safe to `localSafeHead` despite no verification. Now: `ok=false` floors at `FinalizedHead` — never local-safe.
- **Bug B** — post-activation empty verifier returned `(BlockID{}, false)` which resolved to L2 genesis via `L2BlockRefByNumber(0)` (ethereum-optimism/optimism#20944). Now: the active verifier contributes its activation anchor as a cap timestamp (`activationTimestamp - 1`); the engine controller resolves the canonical L2 block.
- **Bug D** — EL-unknown / non-canonical verifier results could fall below `FinalizedHead`. Now: degrade to `FinalizedHead` — never below.

`FinalizedHead` is bounded by `localFinalizedHead` (not `localSafeHead`).

`EngineController.SafeL2Head` / `FinalizedHead` own block resolution and canonicality validation. Cross-safe fallback paths unify through `crossSafeFallback`, which currently just returns `FinalizedHead`; the existing `superAuthorityFinalizedHead` cache is unchanged. Lookup-and-compare is extracted into `isCanonical`. `SuperAuthority` methods take an explicit `ctx`.

Stacked on #21077. Slimmer take on the original #21049 against develop — the single-verifier base collapses the per-verifier loop, `pickOldest` aggregation, and mixed-active-verifier plumbing into direct single-verifier calls. Cross-safe caching is deferred to a follow-up.

## Test plan

- `op-node/rollup/engine/super_authority_safe_head_test.go` adds red/green repro tests:
  - `TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis` (bug B)
  - `TestSafeL2Head_VerifierError_FloorsAtFinalized` (bugs A + D)
  - `TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero` (cold-start safety)
- `op-acceptance-tests/tests/interop/upgrade/finalized_activation_test.go` brought over; DSL helper `ReachedTimeWithoutRegressionFn` added to `op-devstack/dsl/l2_cl.go`.
- `go test ./op-node/rollup/... ./op-supernode/...` all green; `just lint-go` clean.