### PR TITLE
[claude] ci: delete redundant kona-registry-snapshot-check

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -851,50 +851,6 @@ jobs:
           command: |
             lychee --config ./lychee.toml --cache-exclude-status 429 '**/README.md' || true
 
-  # Verifies that the committed `etc/{chainList,configs,depsets}.json` snapshots
-  # in `kona-registry` match what `KONA_BIND=true cargo build -p kona-registry`
-  # would regenerate from the current `superchain-registry` submodule. Catches
-  # drift between submodule and snapshot — i.e. someone bumped the submodule
-  # without refreshing the snapshots, or hand-edited the snapshots, or refreshed
-  # only some of the three coupled files.
-  kona-registry-snapshot-check:
-    docker:
-      - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: medium.gen2
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - run:
-          name: Initialize superchain-registry submodule
-          command: |
-            git submodule update --init --depth=1 \
-              packages/contracts-bedrock/lib/superchain-registry
-      - rust-prepare-and-restore-cache: &kona-registry-snapshot-cache
-          directory: rust
-          prefix: rust-kona-registry-snapshot
-      - run:
-          name: Regenerate kona-registry snapshots
-          working_directory: rust/kona
-          environment:
-            KONA_BIND: "true"
-          command: cargo build -p kona-registry
-      - run:
-          name: Assert committed snapshots match regenerated output
-          command: |
-            if ! git diff --exit-code -- \
-                rust/kona/crates/protocol/registry/etc/; then
-              echo
-              echo "kona-registry etc/ snapshots are out of sync with the"
-              echo "superchain-registry submodule. Run:"
-              echo
-              echo "  KONA_BIND=true cargo build -p kona-registry"
-              echo
-              echo "from rust/kona and commit the resulting changes to"
-              echo "rust/kona/crates/protocol/registry/etc/."
-              exit 1
-            fi
-      - rust-save-build-cache: *kona-registry-snapshot-cache
-
   # Kona Publish Prestate Artifacts
   kona-publish-prestate-artifacts:
     parameters:
@@ -1124,9 +1080,6 @@ workflows:
             cargo test --workspace --verbose --no-default-features
           context: *rust-ci-context
 
-      - kona-registry-snapshot-check:
-          context: *rust-ci-context
-
       # -----------------------------------------------------------------------
       # Required gate — fans in on required Rust CI jobs
       # -----------------------------------------------------------------------
@@ -1154,7 +1107,6 @@ workflows:
             - kona-host-client-offline-cannon: terminal
             - op-rbuilder-checks: terminal
             - rollup-boost-checks: terminal
-            - kona-registry-snapshot-check: terminal
           context:
             - circleci-api-token
   # =====================================
@@ -1183,15 +1135,11 @@ workflows:
           target: "cannon-client"
           context: *rust-ci-context
 
-      - kona-registry-snapshot-check:
-          context: *rust-ci-context
-
       - required-rust-ci:
           requires:
             - rust-tests: terminal
             - op-reth-integration-tests: terminal
             - kona-build-fpvm-cannon-client: terminal
-            - kona-registry-snapshot-check: terminal
           context:
             - circleci-api-token
 


### PR DESCRIPTION
## Summary

Final PR in the registry-sync consolidation (5/5). Stacks on #21055 → #21054 → #21053 → #21050.

Deletes the `kona-registry-snapshot-check` CI job and its two workflow references. After #21053 made `op-superchain/gen/` gitignored and regenerated by `build.rs` on every build, there's no source of drift between the submodule and the artifacts that a `git diff --exit-code` could ever catch — `gen/` is never tracked, so it's structurally impossible for it to lag the submodule pointer.

## What this replaces

Pre-consolidation, `kona-registry-snapshot-check` diffed the committed `etc/{chainList,configs,depsets}.json` snapshots against what `KONA_BIND=true cargo build -p kona-registry` would regenerate from the submodule. Real drift gate at the time.

Post-consolidation:
- kona-registry's `etc/` snapshots are gone (#21054 — sourced from op-superchain via const re-export).
- op-superchain's `gen/` is gitignored and regenerated by `build.rs` on every build (#21053).
- Any `cargo build` that produces a working binary already implies fresh `gen/`. No CI gate adds information.

## Remaining safeguards

- **Build-time:** op-superchain's `build.rs` panics with a directed `just source` message when both the submodule and a pre-built `gen/` are absent. Catches fresh-clone-without-init silently producing broken binaries.
- **Determinism:** the `cargo test -p op-superchain` smoke tests + `cargo build -p kona-registry -p reth-optimism-chainspec` in the rust-tests job exercise the full data path on every CI run.

## Test plan

- [ ] Workflow YAML still valid (CI confirms by not erroring out on workflow parse)
- [ ] Stack-wide CI (#21050–#21056) stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)