### PR TITLE
fix(contracts-bedrock): make semver lock artifact selection deterministic

### DIFF
--- a/packages/contracts-bedrock/scripts/autogen/generate-semver-lock/main.go
+++ b/packages/contracts-bedrock/scripts/autogen/generate-semver-lock/main.go
@@ -105,12 +105,8 @@ func processFile(file string) (*SemverLockResult, []error) {
 		return nil, nil
 	}
 
-	// Forge emits artifacts from additional_compiler_profiles with profile suffixes
-	// such as Contract.dispute.json. The source file's primary artifact remains
-	// unsuffixed as Contract.json: default-profile contracts use default settings
-	// there, and directly restricted contracts use their restricted settings there.
-	// Ignore suffixed duplicate dependency artifacts so they cannot overwrite the
-	// semver-lock entry for the same source:contract key.
+	// Only canonical Contract.json artifacts should contribute to semver-lock.
+	// Profile-suffixed duplicates like Contract.dispute.json are ignored.
 	if filepath.Base(file) != contractName+".json" {
 		return nil, nil
 	}

--- a/packages/contracts-bedrock/scripts/autogen/generate-semver-lock/main.go
+++ b/packages/contracts-bedrock/scripts/autogen/generate-semver-lock/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -21,6 +22,7 @@ type SemverLockOutput struct {
 }
 
 type SemverLockResult struct {
+	ArtifactPath     string
 	ContractKey      string
 	SemverLockOutput SemverLockOutput
 }
@@ -37,12 +39,26 @@ func main() {
 	}
 
 	// Create the output map
-	output := make(map[string]SemverLockOutput)
+	output := make(map[string]*SemverLockResult)
 	for _, result := range results {
 		if result == nil {
 			continue
 		}
-		output[result.ContractKey] = result.SemverLockOutput
+		if existing, ok := output[result.ContractKey]; ok {
+			if existing.SemverLockOutput != result.SemverLockOutput {
+				fmt.Printf(
+					"Conflicting semver lock entries for %s:\n  %s: %+v\n  %s: %+v\n",
+					result.ContractKey,
+					existing.ArtifactPath,
+					existing.SemverLockOutput,
+					result.ArtifactPath,
+					result.SemverLockOutput,
+				)
+				os.Exit(1)
+			}
+			continue
+		}
+		output[result.ContractKey] = result
 	}
 
 	// Get and sort the keys
@@ -55,7 +71,7 @@ func main() {
 	// Create a sorted map for output
 	sortedOutput := make(map[string]SemverLockOutput)
 	for _, k := range keys {
-		sortedOutput[k] = output[k]
+		sortedOutput[k] = output[k].SemverLockOutput
 	}
 
 	// Write to JSON file
@@ -86,6 +102,16 @@ func processFile(file string) (*SemverLockResult, []error) {
 
 	// Only apply to files in the src directory.
 	if !strings.HasPrefix(sourceFilePath, "src/") {
+		return nil, nil
+	}
+
+	// Forge emits artifacts from additional_compiler_profiles with profile suffixes
+	// such as Contract.dispute.json. The source file's primary artifact remains
+	// unsuffixed as Contract.json: default-profile contracts use default settings
+	// there, and directly restricted contracts use their restricted settings there.
+	// Ignore suffixed duplicate dependency artifacts so they cannot overwrite the
+	// semver-lock entry for the same source:contract key.
+	if filepath.Base(file) != contractName+".json" {
 		return nil, nil
 	}
 
@@ -150,7 +176,8 @@ func processFile(file string) (*SemverLockResult, []error) {
 	sourceCodeHash := fmt.Sprintf("0x%x", crypto.Keccak256Hash(trimmedSourceCode))
 
 	return &SemverLockResult{
-		ContractKey: contractKey,
+		ArtifactPath: file,
+		ContractKey:  contractKey,
 		SemverLockOutput: SemverLockOutput{
 			InitCodeHash:   initCodeHash,
 			SourceCodeHash: sourceCodeHash,


### PR DESCRIPTION
**Description**

Makes `generate-semver-lock` deterministic when Forge emits multiple artifacts for the same `source:contract` key. The generator now ignores profile-suffixed artifacts like `Contract.dispute.json`, uses the canonical unsuffixed `Contract.json`, and fails explicitly if canonical duplicates conflict.

**Tests**

No regression test added yet. `go test ./scripts/autogen/generate-semver-lock` currently has no test files. Validated with:

```bash
go test ./scripts/autogen/generate-semver-lock
go run scripts/autogen/generate-semver-lock/main.go
git diff --exit-code -- snapshots/semver-lock.json
```

Also validated that repeated semver-lock generation produced no snapshot diff.

**Additional context**

This keeps transitively compiled profile artifacts from overwriting the canonical `L2ProxyAdmin` semver-lock entry while preserving directly restricted artifacts such as `FaultDisputeGame`, `OPContractsManagerStandardValidator`, and `L2ContractsManager`.

**Metadata**

- Fixes #21032
