### PR TITLE
fix(devstack): loosen single-chain gossip timestamp threshold

### DIFF
--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -356,6 +356,13 @@ func startL2CLNode(
 	require.NoError(err, "failed to load p2p config")
 	p2pConfig.NoDiscovery = cfg.NoDiscovery
 	p2pConfig.EnableReqRespSync = cfg.EnableReqRespSync
+	// Devstack chain timestamps are synthetic: genesis is set in the past and the
+	// chain may lag many seconds behind wallclock during startup (or many minutes
+	// during long tests like dispute games). The production-default 60s gossip
+	// "too old" check then rejects otherwise-valid TestSequencer-produced blocks
+	// — surfacing as "validation failed" out of ts.Next at startup. Match the
+	// multichain devstack (see newDevstackP2PConfig) by loosening to 1 hour.
+	p2pConfig.GossipTimestampThreshold = time.Hour
 
 	nodeCfg := &config.Config{
 		L1: &config.L1EndpointConfig{


### PR DESCRIPTION
## Summary

- Aligns `op-devstack/sysgo/singlechain_build.go` with the multichain devstack's existing 1-hour `GossipTimestampThreshold` override (see `op-devstack/sysgo/l2_cl_p2p_config.go:77`).
- Fixes a startup flake where the flashblocks acceptance tests intermittently fail at `driveViaTestSequencer` (`op-acceptance-tests/tests/flashblocks/utils.go:28`) with `Failed to publish block ... err="validation failed"`.

## Why

Devstack chains use synthetic genesis timestamps set in the past. On a fresh devstack, the first TestSequencer-driven block (built off stale-timestamp genesis) carries a `payload.Timestamp` more than 60s old. The production-default `GossipTimestampThreshold = 60s` causes the local libp2p-pubsub validator (`op-node/p2p/gossip.go:345`) to return `ValidationReject` → `Publish` errors out → `ts.Next` surfaces `"validation failed"`.

The multichain config has loosened this to 1 hour for exactly this reason (with a comment about long-running dispute-game tests). Single-chain devstacks hit the same trap; this matches the existing fix.

## Test plan

- [x] `TestFlashblocksStream` + `TestFlashblocksTransfer` pass locally (`ok ... 198.795s`).
- [ ] CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)