### PR TITLE
feat(kona): drop batches with PostExec tx before SDM activation

### DIFF
--- a/rust/kona/crates/proof/executor/src/builder/core.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core.rs
@@ -172,7 +172,7 @@ where
     }
 
     /// Returns whether SDM is active at the given timestamp.
-    const fn is_sdm_active(&self, timestamp: u64) -> bool {
+    fn is_sdm_active(&self, timestamp: u64) -> bool {
         #[cfg(any(test, feature = "test-utils"))]
         if let Some(active) = self.sdm_active_override {
             return active;

--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -300,10 +300,11 @@ impl RollupConfig {
 
     /// Returns true if SDM post-exec transactions are active at the given timestamp.
     ///
-    /// SDM is currently unscheduled and must not activate as part of Jovian or Karst.
+    /// SDM rides the Interop hardfork: it is active iff Interop is active at `timestamp`,
+    /// matching op-node's `IsSDM` (see `op-node/rollup/toggles.go`).
     #[must_use]
-    pub const fn is_sdm_active(&self, _timestamp: u64) -> bool {
-        false
+    pub fn is_sdm_active(&self, timestamp: u64) -> bool {
+        self.is_interop_active(timestamp)
     }
 
     /// Returns true if Jovian is active at the given timestamp.
@@ -700,15 +701,21 @@ mod tests {
     }
 
     #[test]
-    fn test_sdm_disabled_after_jovian_and_karst() {
+    fn test_sdm_rides_interop() {
         let mut config = RollupConfig::default();
+        // Jovian/Karst alone must not activate SDM — only Interop does.
         config.hardforks.jovian_time = Some(10);
         config.hardforks.karst_time = Some(20);
-
         assert!(config.is_jovian_active(10));
         assert!(!config.is_sdm_active(10));
         assert!(config.is_karst_active(20));
         assert!(!config.is_sdm_active(20));
+
+        // Schedule Interop and SDM must follow.
+        config.hardforks.interop_time = Some(30);
+        assert!(!config.is_sdm_active(29));
+        assert!(config.is_sdm_active(30));
+        assert!(config.is_sdm_active(31));
     }
 
     #[test]

--- a/rust/kona/crates/protocol/protocol/src/batch/single.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/single.rs
@@ -169,17 +169,17 @@ impl SingleBatch {
 
         // We can do this check earlier, but it's intensive so we do it last for the sad-path.
         for tx in &self.transactions {
-            if tx.is_empty() {
+            let Some(tx_type) = tx.as_ref().first().copied() else {
                 return BatchValidity::Drop(BatchDropReason::EmptyTransaction);
-            }
-            if tx.as_ref().first() == Some(&(OpTxType::Deposit as u8)) {
+            };
+            if tx_type == OpTxType::Deposit as u8 {
                 return BatchValidity::Drop(BatchDropReason::DepositTransaction);
             }
-            // If isthmus is not active yet and the transaction is a 7702, drop the batch.
-            if !cfg.is_isthmus_active(self.timestamp) &&
-                tx.as_ref().first() == Some(&(OpTxType::Eip7702 as u8))
-            {
+            if !cfg.is_isthmus_active(self.timestamp) && tx_type == OpTxType::Eip7702 as u8 {
                 return BatchValidity::Drop(BatchDropReason::Eip7702PreIsthmus);
+            }
+            if !cfg.is_sdm_active(self.timestamp) && tx_type == OpTxType::PostExec as u8 {
+                return BatchValidity::Drop(BatchDropReason::PostExecPreSDM);
             }
         }
 

--- a/rust/kona/crates/protocol/protocol/src/batch/span.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/span.rs
@@ -490,15 +490,15 @@ impl SpanBatch {
 
             // Check that the transactions are not empty and do not contain any deposits.
             for (i, tx) in batch.transactions.iter().enumerate() {
-                if tx.is_empty() {
+                let Some(tx_type) = tx.as_ref().first().copied() else {
                     warn!(
                         target: "batch_span",
                         "transaction data must not be empty, but found empty tx, tx_index: {}",
                         i
                     );
                     return BatchValidity::Drop(BatchDropReason::EmptyTransaction);
-                }
-                if tx.as_ref().first() == Some(&(OpTxType::Deposit as u8)) {
+                };
+                if tx_type == OpTxType::Deposit as u8 {
                     warn!(
                         target: "batch_span",
                         "sequencers may not embed any deposits into batch data, but found tx that has one, tx_index: {}",
@@ -506,13 +506,13 @@ impl SpanBatch {
                     );
                     return BatchValidity::Drop(BatchDropReason::DepositTransaction);
                 }
-
-                // If isthmus is not active yet and the transaction is a 7702, drop the batch.
-                if !cfg.is_isthmus_active(batch.timestamp) &&
-                    tx.as_ref().first() == Some(&(OpTxType::Eip7702 as u8))
-                {
+                if !cfg.is_isthmus_active(batch.timestamp) && tx_type == OpTxType::Eip7702 as u8 {
                     warn!(target: "batch_span", "EIP-7702 transactions are not supported pre-isthmus. tx_index: {}", i);
                     return BatchValidity::Drop(BatchDropReason::Eip7702PreIsthmus);
+                }
+                if !cfg.is_sdm_active(batch.timestamp) && tx_type == OpTxType::PostExec as u8 {
+                    warn!(target: "batch_span", "PostExec transactions are not supported pre-SDM. tx_index: {}", i);
+                    return BatchValidity::Drop(BatchDropReason::PostExecPreSDM);
                 }
             }
         }

--- a/rust/kona/crates/protocol/protocol/src/batch/validity.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/validity.rs
@@ -42,6 +42,8 @@ pub enum BatchDropReason {
     DepositTransaction,
     /// EIP-7702 transaction included before Isthmus activation.
     Eip7702PreIsthmus,
+    /// `PostExec` transaction included before SDM activation.
+    PostExecPreSDM,
     /// Non-empty batch in Jovian or Interop transition block.
     NonEmptyTransitionBlock,
 
@@ -93,6 +95,7 @@ impl core::fmt::Display for BatchDropReason {
             Self::EmptyTransaction => write!(f, "batch contains empty transaction"),
             Self::DepositTransaction => write!(f, "batch contains deposit transaction"),
             Self::Eip7702PreIsthmus => write!(f, "EIP-7702 transaction before Isthmus activation"),
+            Self::PostExecPreSDM => write!(f, "PostExec transaction before SDM activation"),
             Self::NonEmptyTransitionBlock => write!(f, "non-empty batch in transition block"),
             Self::SpanBatchPreDelta => write!(f, "span batch received before Delta hard fork"),
             Self::SpanBatchNoNewBlocksPreHolocene => {


### PR DESCRIPTION
## Summary

Strict extraction of the single/span batch SDM gate from the broader kona-native SDM work in #21034. Adds production-code rejection of batches containing a `0x7D` PostExec transaction when SDM is inactive at the batch timestamp.

- `batch/single.rs` + `batch/span.rs`: drop a batch with a PostExec tx when `!cfg.is_sdm_active(timestamp)`
- `batch/validity.rs`: add `BatchDropReason::PostExecPreSDM`
- `genesis/src/rollup.rs`: redefine `is_sdm_active` from a `const fn` returning `false` to `fn(t) -> self.is_interop_active(t)`, matching op-node's `IsSDM` (`op-node/rollup/toggles.go`); regression test updated
- `proof/executor/src/builder/core.rs`: drop `const` on the wrapper that now calls the non-const `RollupConfig::is_sdm_active`

Scope deliberately excludes the supporting pieces from #21034 that aren't strictly part of the gate: `BootInfo::dependency_set` plumbing, the `bin/client/src/single.rs` change that threads the dependency set into `StatefulAttributesBuilder`, the kona-host `--depset-cfg` flag, the `SpanBatchPostExecTransactionData` span-batch tx-data variant, and the devstack/acceptance-test changes. Those remain in #21034 and depend on this slice.

## Test plan

- [x] `just b` — workspace builds
- [x] `just l` — clippy `-D warnings` clean
- [x] `cargo nextest run --release --all-features -p kona-genesis -p kona-protocol` — 359 tests pass, including the new `kona-genesis rollup::tests::test_sdm_rides_interop`
- [ ] Full kona test suite (`just t`) in CI
- [ ] Confirm op-node `IsSDM` and kona `is_sdm_active` agree on the activation boundary (CI cross-check via existing fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)