### PR TITLE
[codex] simplify SuperAuthority safe fallback

### DIFF
--- a/op-acceptance-tests/tests/interop/upgrade/finalized_activation_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/finalized_activation_test.go
@@ -1,0 +1,38 @@
+//go:build !ci
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
+)
+
+// TestFinalizedL2DoesNotRegressAcrossActivation reproduces #20365.
+// The 240s activation delay must exceed the FakePoS L1 finality lag (~120s)
+// so the pre-activation FinalizedL2 baseline is non-zero.
+func TestFinalizedL2DoesNotRegressAcrossActivation(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewTwoL2SupernodeInterop(t, 240)
+	require := t.Require()
+
+	interopTimeA := sys.L2A.Escape().ChainConfig().InteropTime
+	interopTimeB := sys.L2B.Escape().ChainConfig().InteropTime
+	require.NotNil(interopTimeA, "L2A must have InteropTime configured")
+	require.NotNil(interopTimeB, "L2B must have InteropTime configured")
+
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedFn(safety.Finalized, 1, 120),
+		sys.L2BCL.ReachedFn(safety.Finalized, 1, 120),
+	)
+
+	// +1 so the head must be strictly past activation.
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeA+1),
+		sys.L2BCL.ReachedTimeWithoutRegressionFn(safety.Finalized, *interopTimeB+1),
+	)
+}

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -314,6 +314,47 @@ func (cl *L2CLNode) ReachedRefFn(lvl safety.Level, target eth.BlockID, attempts 
 	}
 }
 
+// ReachedTimeWithoutRegressionFn waits for the head's block timestamp to reach
+// targetTime, failing on any regression. Requires a non-zero baseline behind
+// targetTime so a regression to genesis isn't vacuous (0 >= 0). Polls every
+// 100ms; deadline is targetTime + 5min.
+func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime uint64) CheckFunc {
+	return func() error {
+		initial, err := cl.headBlockRef(lvl)
+		if err != nil {
+			return fmt.Errorf("read initial %s head: %w", lvl, err)
+		}
+		if initial.Number == 0 {
+			return fmt.Errorf("initial %s head is at genesis; cannot detect regression below zero — wait for the head to advance past genesis before snapshotting", lvl)
+		}
+		if initial.Time >= targetTime {
+			return fmt.Errorf("initial %s head time %d already at or past target %d; nothing to observe across the boundary", lvl, initial.Time, targetTime)
+		}
+		const buffer = 5 * time.Minute
+		deadline := time.Unix(int64(targetTime), 0).Add(buffer)
+		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "initial", initial.Number, "initial_time", initial.Time, "target_time", targetTime, "deadline", deadline)
+		logger.Info("Watching head for regression until target time reached")
+		// End the wait early on regression by returning true; surfaced below.
+		var regressionErr error
+		cl.require.Eventuallyf(func() bool {
+			head, err := cl.headBlockRef(lvl)
+			if err != nil {
+				logger.Warn("SyncStatus RPC failed; will retry", "err", err)
+				return false
+			}
+			if head.Number < initial.Number {
+				regressionErr = fmt.Errorf("%s head regressed: was %d (%s, t=%d), observed %d (%s, t=%d)",
+					lvl, initial.Number, initial.Hash, initial.Time, head.Number, head.Hash, head.Time)
+				return true
+			}
+			logger.Info("Chain sync status", "current", head.Number, "current_time", head.Time)
+			return head.Time >= targetTime
+		}, time.Until(deadline), 100*time.Millisecond,
+			"%s head did not reach target time %d (initial=%d)", lvl, targetTime, initial.Number)
+		return regressionErr
+	}
+}
+
 // RewindedFn returns a lambda that checks the L2CL chain head with given safety level rewinded more than the delta block number
 // Composable with other lambdas to wait in parallel
 func (cl *L2CLNode) RewindedFn(lvl safety.Level, delta uint64, attempts int) CheckFunc {

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -318,6 +318,10 @@ func (cl *L2CLNode) ReachedRefFn(lvl safety.Level, target eth.BlockID, attempts 
 // targetTime, failing on any regression. Requires a non-zero baseline behind
 // targetTime so a regression to genesis isn't vacuous (0 >= 0). Polls every
 // 100ms; deadline is targetTime + 5min.
+//
+// Uses an explicit ticker/deadline loop and returns errors through the
+// CheckFunc contract. require.Eventuallyf would call FailNow inside the
+// dsl.CheckAll worker goroutine, which is not safe.
 func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime uint64) CheckFunc {
 	return func() error {
 		initial, err := cl.headBlockRef(lvl)
@@ -334,24 +338,33 @@ func (cl *L2CLNode) ReachedTimeWithoutRegressionFn(lvl safety.Level, targetTime 
 		deadline := time.Unix(int64(targetTime), 0).Add(buffer)
 		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "initial", initial.Number, "initial_time", initial.Time, "target_time", targetTime, "deadline", deadline)
 		logger.Info("Watching head for regression until target time reached")
-		// End the wait early on regression by returning true; surfaced below.
-		var regressionErr error
-		cl.require.Eventuallyf(func() bool {
+
+		ctx, cancel := context.WithDeadline(cl.ctx, deadline)
+		defer cancel()
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
 			head, err := cl.headBlockRef(lvl)
 			if err != nil {
 				logger.Warn("SyncStatus RPC failed; will retry", "err", err)
-				return false
+			} else {
+				if head.Number < initial.Number {
+					return fmt.Errorf("%s head regressed: was %d (%s, t=%d), observed %d (%s, t=%d)",
+						lvl, initial.Number, initial.Hash, initial.Time, head.Number, head.Hash, head.Time)
+				}
+				if head.Time >= targetTime {
+					return nil
+				}
+				logger.Info("Chain sync status", "current", head.Number, "current_time", head.Time)
 			}
-			if head.Number < initial.Number {
-				regressionErr = fmt.Errorf("%s head regressed: was %d (%s, t=%d), observed %d (%s, t=%d)",
-					lvl, initial.Number, initial.Hash, initial.Time, head.Number, head.Hash, head.Time)
-				return true
+
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("%s head did not reach target time %d (initial=%d): %w", lvl, targetTime, initial.Number, ctx.Err())
+			case <-ticker.C:
 			}
-			logger.Info("Chain sync status", "current", head.Number, "current_time", head.Time)
-			return head.Time >= targetTime
-		}, time.Until(deadline), 100*time.Millisecond,
-			"%s head did not reach target time %d (initial=%d)", lvl, targetTime, initial.Number)
-		return regressionErr
+		}
 	}
 }
 

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -126,7 +126,16 @@ type EngineController struct {
 	localFinalizedHead eth.L2BlockRef
 	// Last successfully materialized superAuthority finalized head,
 	// used as a fallback when the authority or EL is temporarily unavailable.
+	// Finalized blocks cannot reorg, so this cache does not require
+	// canonicality re-validation before use.
 	superAuthorityFinalizedHead eth.L2BlockRef
+	// Last successfully materialized superAuthority safe (cross-safe) head,
+	// used as a fallback when the authority returns HoldPrevious or the fresh
+	// result fails canonicality / EL lookup. Cross-safe CAN reorg, so the
+	// cache MUST be re-validated against the EL via L2BlockRefByNumber before
+	// use (see useSuperAuthoritySafeCache). If the cached block is no longer
+	// canonical, the cache is cleared and the caller floors at FinalizedHead.
+	superAuthoritySafeHead eth.L2BlockRef
 	// The unsafe head to roll back to,
 	// after the pendingSafeHead fails to become safe.
 	// This is changing in the Holocene fork.
@@ -199,21 +208,24 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 // SafeL2Head returns the safe L2 head.
 //
 // With a SuperAuthority registered: consume the tri-state result. On
-// HoldPrevious (verifier read error), floor at FinalizedHead — never advance,
-// never fall back to local-safe. On PreActivation, use local-safe. On Anchor or
+// HoldPrevious (verifier read error), use the cached cross-safe head if it is
+// still canonical, otherwise floor at FinalizedHead — never advance, never
+// fall back to local-safe. On PreActivation, use local-safe. On Anchor or
 // Verified, bound by local-safe and validate canonicality; EL-unknown or
 // non-canonical results are unambiguous reorg signals (the verifier cannot be
-// ahead of the EL otherwise) and degrade to FinalizedHead — never below.
-// Cross-safe is not cached because cross-safe can reorg.
+// ahead of the EL otherwise) and degrade to the canonicality-checked cache,
+// then to FinalizedHead — never below.
+//
+// The cross-safe cache (superAuthoritySafeHead) is updated on every successful
+// canonical resolution. Because cross-safe can reorg, the cache is
+// re-validated against the EL before each use; on reorg it is cleared.
 //
 // Without a SuperAuthority: existing behavior unchanged.
 func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	if e.superAuthority != nil {
 		head, status := e.superAuthority.FullyVerifiedL2Head()
 		if status == rollup.VerifierHeadHoldPrevious {
-			finalized := e.FinalizedHead()
-			e.log.Debug("super authority HoldPrevious, flooring at finalized", "finalized", finalized)
-			return finalized
+			return e.floorCrossSafe("HoldPrevious")
 		}
 		switch head.Source {
 		case rollup.VerifierHeadPreActivation:
@@ -222,11 +234,8 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 			if (head.Block == eth.BlockID{}) {
 				// Reachable only when an anchor lookup couldn't return a concrete
 				// block (e.g. verifier with no activation timestamp configured).
-				// Treat as engine-not-ready and floor at finalized.
-				finalized := e.FinalizedHead()
-				e.log.Warn("super authority returned zero block with non-pre-activation source; flooring at finalized",
-					"source", head.Source, "finalized", finalized)
-				return finalized
+				e.log.Warn("super authority returned zero block with non-pre-activation source", "source", head.Source)
+				return e.floorCrossSafe("zero-block")
 			}
 			if head.Block.Number > e.localSafeHead.Number {
 				e.log.Debug("super authority head ahead of local safe; using local safe", "head", head.Block, "source", head.Source)
@@ -234,24 +243,22 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 			}
 			br, err := e.engine.L2BlockRefByHash(e.ctx, head.Block.Hash)
 			if err != nil {
-				finalized := e.FinalizedHead()
-				e.log.Warn("super authority safe head unknown to engine (reorg signal); flooring at finalized",
-					"super_authority_safe", head.Block, "source", head.Source, "finalized", finalized, "err", err)
-				return finalized
+				e.log.Warn("super authority safe head unknown to engine (reorg signal)",
+					"super_authority_safe", head.Block, "source", head.Source, "err", err)
+				return e.floorCrossSafe("el-unknown")
 			}
 			canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
 			if err != nil {
-				finalized := e.FinalizedHead()
-				e.log.Warn("cannot verify super authority safe head canonicality; flooring at finalized",
-					"super_authority_safe", br, "source", head.Source, "finalized", finalized, "err", err)
-				return finalized
+				e.log.Warn("cannot verify super authority safe head canonicality",
+					"super_authority_safe", br, "source", head.Source, "err", err)
+				return e.floorCrossSafe("canonicality-lookup-failed")
 			}
 			if canonical.Hash != br.Hash {
-				finalized := e.FinalizedHead()
-				e.log.Warn("super authority safe head non-canonical (reorg signal); flooring at finalized",
-					"super_authority_safe", br, "canonical", canonical, "source", head.Source, "finalized", finalized)
-				return finalized
+				e.log.Warn("super authority safe head non-canonical (reorg signal)",
+					"super_authority_safe", br, "canonical", canonical, "source", head.Source)
+				return e.floorCrossSafe("non-canonical")
 			}
+			e.superAuthoritySafeHead = br
 			return br
 		default:
 			panic(fmt.Errorf("unhandled VerifierHeadSource: %v", head.Source))
@@ -261,6 +268,54 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	} else {
 		return e.localSafeHead
 	}
+}
+
+// floorCrossSafe is the cross-safe fallback path. It tries the cached
+// superAuthoritySafeHead first — re-validating its canonicality against the
+// EL — and falls back to FinalizedHead if the cache is empty, non-canonical,
+// or unavailable. A non-canonical cache is cleared so we don't keep paying the
+// validation cost.
+func (e *EngineController) floorCrossSafe(reason string) eth.L2BlockRef {
+	if cached, ok := e.useSuperAuthoritySafeCache(); ok {
+		e.log.Debug("cross-safe fallback using canonicality-validated cache", "reason", reason, "cached", cached)
+		return cached
+	}
+	finalized := e.FinalizedHead()
+	e.log.Debug("cross-safe fallback flooring at finalized", "reason", reason, "finalized", finalized)
+	return finalized
+}
+
+// useSuperAuthoritySafeCache returns the cached cross-safe head if it is still
+// canonical on the EL and still within local-safe. Otherwise clears the cache
+// and returns false. Cross-safe can reorg, so the cache must be re-validated
+// before each use — we never blindly return a cached cross-safe value.
+func (e *EngineController) useSuperAuthoritySafeCache() (eth.L2BlockRef, bool) {
+	cached := e.superAuthoritySafeHead
+	if cached == (eth.L2BlockRef{}) {
+		return eth.L2BlockRef{}, false
+	}
+	if cached.Number > e.localSafeHead.Number {
+		// Local-safe regressed (or cache is otherwise stale relative to current
+		// derivation state). Stop trusting the cache.
+		e.log.Info("cached cross-safe ahead of local-safe; clearing cache",
+			"cached", cached, "local_safe", e.localSafeHead)
+		e.superAuthoritySafeHead = eth.L2BlockRef{}
+		return eth.L2BlockRef{}, false
+	}
+	canonical, err := e.engine.L2BlockRefByNumber(e.ctx, cached.Number)
+	if err != nil {
+		e.log.Warn("cannot validate cached cross-safe canonicality; clearing cache",
+			"cached", cached, "err", err)
+		e.superAuthoritySafeHead = eth.L2BlockRef{}
+		return eth.L2BlockRef{}, false
+	}
+	if canonical.Hash != cached.Hash {
+		e.log.Info("cached cross-safe non-canonical (reorg); clearing cache",
+			"cached", cached, "canonical", canonical)
+		e.superAuthoritySafeHead = eth.L2BlockRef{}
+		return eth.L2BlockRef{}, false
+	}
+	return cached, true
 }
 
 // FinalizedHead returns the finalized L2 head, with the same tri-state contract

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -205,26 +205,15 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 	}
 }
 
-// SafeL2Head returns the safe L2 head.
-//
-// With a SuperAuthority registered: consume the tri-state result. On
-// HoldPrevious (verifier read error), use the cached cross-safe head if it is
-// still canonical, otherwise floor at FinalizedHead — never advance, never
-// fall back to local-safe. On PreActivation, use local-safe. On Anchor or
-// Verified, bound by local-safe and validate canonicality; EL-unknown or
-// non-canonical results are unambiguous reorg signals (the verifier cannot be
-// ahead of the EL otherwise) and degrade to the canonicality-checked cache,
-// then to FinalizedHead — never below.
-//
-// The cross-safe cache (superAuthoritySafeHead) is updated on every successful
-// canonical resolution. Because cross-safe can reorg, the cache is
-// re-validated against the EL before each use; on reorg it is cleared.
-//
-// Without a SuperAuthority: existing behavior unchanged.
+// SafeL2Head returns the safe L2 head. With a SuperAuthority registered, the
+// result is bounded by local-safe, validated against the EL for canonicality,
+// and cached. On a transient verifier read failure or any reorg signal
+// (EL-unknown, non-canonical), the canonicality-checked cache is consulted
+// first, then FinalizedHead — never local-safe, never below finalized.
 func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	if e.superAuthority != nil {
-		head, status := e.superAuthority.FullyVerifiedL2Head()
-		if status == rollup.VerifierHeadHoldPrevious {
+		head, ok := e.superAuthority.FullyVerifiedL2Head(e.ctx)
+		if !ok {
 			return e.floorCrossSafe("HoldPrevious")
 		}
 		switch head.Source {
@@ -232,13 +221,10 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 			return e.localSafeHead
 		case rollup.VerifierHeadAnchor, rollup.VerifierHeadVerified:
 			if (head.Block == eth.BlockID{}) {
-				// Reachable only when an anchor lookup couldn't return a concrete
-				// block (e.g. verifier with no activation timestamp configured).
 				e.log.Warn("super authority returned zero block with non-pre-activation source", "source", head.Source)
 				return e.floorCrossSafe("zero-block")
 			}
 			if head.Block.Number > e.localSafeHead.Number {
-				e.log.Debug("super authority head ahead of local safe; using local safe", "head", head.Block, "source", head.Source)
 				return e.localSafeHead
 			}
 			br, err := e.engine.L2BlockRefByHash(e.ctx, head.Block.Hash)
@@ -247,15 +233,15 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 					"super_authority_safe", head.Block, "source", head.Source, "err", err)
 				return e.floorCrossSafe("el-unknown")
 			}
-			ok, canonical, err := e.isCanonical(br)
+			canonical, canonicalCheck, err := e.isCanonical(br)
 			if err != nil {
 				e.log.Warn("cannot verify super authority safe head canonicality",
 					"super_authority_safe", br, "source", head.Source, "err", err)
 				return e.floorCrossSafe("canonicality-lookup-failed")
 			}
-			if !ok {
+			if !canonical {
 				e.log.Warn("super authority safe head non-canonical (reorg signal)",
-					"super_authority_safe", br, "canonical", canonical, "source", head.Source)
+					"super_authority_safe", br, "canonical", canonicalCheck, "source", head.Source)
 				return e.floorCrossSafe("non-canonical")
 			}
 			e.superAuthoritySafeHead = br
@@ -334,21 +320,19 @@ func (e *EngineController) isCanonical(target eth.L2BlockRef) (ok bool, canonica
 	return canonical.Hash == target.Hash, canonical, nil
 }
 
-// FinalizedHead returns the finalized L2 head, with the same tri-state contract
-// as SafeL2Head plus a cache (superAuthorityFinalizedHead). Finalized blocks
-// cannot reorg, so caching the last successful resolution is safe and is used
-// to (a) hold across HoldPrevious and (b) preserve monotonicity across
-// transient EL hash-lookup failures and stale super-authority reports.
+// FinalizedHead returns the finalized L2 head, bounded by local-finalized
+// (the SuperAuthority can delay finalization but cannot finalize a block the
+// node hasn't locally finalized). superAuthorityFinalizedHead caches the last
+// successful resolution and is trusted without re-validation — finalized
+// blocks cannot reorg.
 func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 	if e.superAuthority != nil {
-		head, status := e.superAuthority.FinalizedL2Head()
-		if status == rollup.VerifierHeadHoldPrevious {
+		head, ok := e.superAuthority.FinalizedL2Head(e.ctx)
+		if !ok {
 			if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
-				e.log.Debug("super authority finalized HoldPrevious; using cached super authority finalized",
-					"cached_super_authority_finalized", e.superAuthorityFinalizedHead)
 				return e.superAuthorityFinalizedHead
 			}
-			e.log.Debug("super authority finalized HoldPrevious with no cache; returning zero")
+			e.log.Error("super authority finalized HoldPrevious with no cache; returning zero")
 			return eth.L2BlockRef{}
 		}
 		switch head.Source {
@@ -362,9 +346,8 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 				e.log.Warn("super authority returned zero finalized block; no cache; returning zero", "source", head.Source)
 				return eth.L2BlockRef{}
 			}
-			if head.Block.Number > e.localSafeHead.Number {
-				e.log.Debug("super authority finalized ahead of local safe; using local safe as ceiling", "head", head.Block, "source", head.Source)
-				return e.localSafeHead
+			if head.Block.Number > e.localFinalizedHead.Number {
+				return e.localFinalizedHead
 			}
 			if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
 				if head.Block == e.superAuthorityFinalizedHead.ID() {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -197,48 +197,65 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 }
 
 // SafeL2Head returns the safe L2 head.
-// If the super authority is enabled, it returns the fully verified L2 head
-// else it returns the local safe L2 head.
+//
+// With a SuperAuthority registered: consume the tri-state result. On
+// HoldPrevious (verifier read error), floor at FinalizedHead — never advance,
+// never fall back to local-safe. On PreActivation, use local-safe. On Anchor or
+// Verified, bound by local-safe and validate canonicality; EL-unknown or
+// non-canonical results are unambiguous reorg signals (the verifier cannot be
+// ahead of the EL otherwise) and degrade to FinalizedHead — never below.
+// Cross-safe is not cached because cross-safe can reorg.
+//
+// Without a SuperAuthority: existing behavior unchanged.
 func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	if e.superAuthority != nil {
-		fvshid, useLocalSafe := e.superAuthority.FullyVerifiedL2Head()
-		// If SuperAuthority signals to use local-safe (e.g., no verifiers or pre-interop)
-		if useLocalSafe {
-			e.log.Debug("super authority signaled to use local-safe fallback")
-			return e.localSafeHead
+		head, status := e.superAuthority.FullyVerifiedL2Head()
+		if status == rollup.VerifierHeadHoldPrevious {
+			finalized := e.FinalizedHead()
+			e.log.Debug("super authority HoldPrevious, flooring at finalized", "finalized", finalized)
+			return finalized
 		}
-		// SuperAuthority provided a cross-verified safe head
-		if (fvshid == eth.BlockID{}) {
-			// Fallback to genesis block (safe by consensus) if possible
-			br, err := e.engine.L2BlockRefByNumber(e.ctx, 0)
+		switch head.Source {
+		case rollup.VerifierHeadPreActivation:
+			return e.localSafeHead
+		case rollup.VerifierHeadAnchor, rollup.VerifierHeadVerified:
+			if (head.Block == eth.BlockID{}) {
+				// Reachable only when an anchor lookup couldn't return a concrete
+				// block (e.g. verifier with no activation timestamp configured).
+				// Treat as engine-not-ready and floor at finalized.
+				finalized := e.FinalizedHead()
+				e.log.Warn("super authority returned zero block with non-pre-activation source; flooring at finalized",
+					"source", head.Source, "finalized", finalized)
+				return finalized
+			}
+			if head.Block.Number > e.localSafeHead.Number {
+				e.log.Debug("super authority head ahead of local safe; using local safe", "head", head.Block, "source", head.Source)
+				return e.localSafeHead
+			}
+			br, err := e.engine.L2BlockRefByHash(e.ctx, head.Block.Hash)
 			if err != nil {
-				e.log.Warn("cannot get genesis block from engine")
-				return eth.L2BlockRef{}
+				finalized := e.FinalizedHead()
+				e.log.Warn("super authority safe head unknown to engine (reorg signal); flooring at finalized",
+					"super_authority_safe", head.Block, "source", head.Source, "finalized", finalized, "err", err)
+				return finalized
+			}
+			canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
+			if err != nil {
+				finalized := e.FinalizedHead()
+				e.log.Warn("cannot verify super authority safe head canonicality; flooring at finalized",
+					"super_authority_safe", br, "source", head.Source, "finalized", finalized, "err", err)
+				return finalized
+			}
+			if canonical.Hash != br.Hash {
+				finalized := e.FinalizedHead()
+				e.log.Warn("super authority safe head non-canonical (reorg signal); flooring at finalized",
+					"super_authority_safe", br, "canonical", canonical, "source", head.Source, "finalized", finalized)
+				return finalized
 			}
 			return br
+		default:
+			panic(fmt.Errorf("unhandled VerifierHeadSource: %v", head.Source))
 		}
-		if fvshid.Number > e.localSafeHead.Number {
-			e.log.Debug("super authority fully verified l2 head is ahead of local safe head, using local safe head as SafeL2Head")
-			return e.localSafeHead
-		}
-		br, err := e.engine.L2BlockRefByHash(e.ctx, fvshid.Hash)
-		if err != nil {
-			finalized := e.FinalizedHead()
-			e.log.Warn("superAuthority safe head is not known to the engine, using finalized head", "super_authority_safe", fvshid, "finalized", finalized, "err", err)
-			return finalized
-		}
-		canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
-		if err != nil {
-			finalized := e.FinalizedHead()
-			e.log.Warn("cannot verify superAuthority safe head canonicality, using finalized head", "super_authority_safe", br, "finalized", finalized, "err", err)
-			return finalized
-		}
-		if canonical.Hash != br.Hash {
-			finalized := e.FinalizedHead()
-			e.log.Warn("superAuthority safe head is not canonical, using finalized head", "super_authority_safe", br, "canonical", canonical, "finalized", finalized)
-			return finalized
-		}
-		return br
 	} else if e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedSafeHead
 	} else {
@@ -246,52 +263,69 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	}
 }
 
+// FinalizedHead returns the finalized L2 head, with the same tri-state contract
+// as SafeL2Head plus a cache (superAuthorityFinalizedHead). Finalized blocks
+// cannot reorg, so caching the last successful resolution is safe and is used
+// to (a) hold across HoldPrevious and (b) preserve monotonicity across
+// transient EL hash-lookup failures and stale super-authority reports.
 func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 	if e.superAuthority != nil {
-		f, useLocalFinalized := e.superAuthority.FinalizedL2Head()
-		if useLocalFinalized {
-			// No verifiers registered, fall back to local finalized
-			e.log.Debug("super authority has no verifiers, using local finalized head")
-			return e.localFinalizedHead
-		}
-		if (f == eth.BlockID{}) {
-			// Fallback to genesis block (final by consensus) if possible
-			br, err := e.engine.L2BlockRefByNumber(e.ctx, 0)
-			if err != nil {
-				e.log.Warn("cannot get genesis block from engine")
-				return eth.L2BlockRef{}
-			}
-			return br
-		}
-		if f.Number > e.localSafeHead.Number {
-			e.log.Debug("super authority finalized l2 head is ahead of local safe head, using local safe head as FinalizedHead")
-			return e.localSafeHead
-		}
-		if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
-			if f == e.superAuthorityFinalizedHead.ID() {
-				return e.superAuthorityFinalizedHead
-			}
-			if f.Number < e.superAuthorityFinalizedHead.Number {
-				// SuperAuthority finality is expected to be monotonic. A lower
-				// finalized head means the authority is reporting stale state.
-				e.log.Warn("superAuthority finalized head is behind cached superAuthority finalized head, using cached superAuthority finalized head", "super_authority_finalized", f, "cached_super_authority_finalized", e.superAuthorityFinalizedHead)
-				return e.superAuthorityFinalizedHead
-			}
-			if f.Number == e.superAuthorityFinalizedHead.Number {
-				panic("superAuthority finalized head conflicts with cached superAuthority finalized head at same height")
-			}
-		}
-		br, err := e.engine.L2BlockRefByHash(e.ctx, f.Hash)
-		if err != nil {
+		head, status := e.superAuthority.FinalizedL2Head()
+		if status == rollup.VerifierHeadHoldPrevious {
 			if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
-				e.log.Warn("superAuthority finalized head is not known to the engine, using cached superAuthority finalized head", "super_authority_finalized", f, "cached_super_authority_finalized", e.superAuthorityFinalizedHead, "err", err)
+				e.log.Debug("super authority finalized HoldPrevious; using cached super authority finalized",
+					"cached_super_authority_finalized", e.superAuthorityFinalizedHead)
 				return e.superAuthorityFinalizedHead
 			}
-			e.log.Warn("superAuthority finalized head is not known to the engine and no cached superAuthority finalized head is available", "super_authority_finalized", f, "err", err)
+			e.log.Debug("super authority finalized HoldPrevious with no cache; returning zero")
 			return eth.L2BlockRef{}
 		}
-		e.superAuthorityFinalizedHead = br
-		return br
+		switch head.Source {
+		case rollup.VerifierHeadPreActivation:
+			return e.localFinalizedHead
+		case rollup.VerifierHeadAnchor, rollup.VerifierHeadVerified:
+			if (head.Block == eth.BlockID{}) {
+				if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+					return e.superAuthorityFinalizedHead
+				}
+				e.log.Warn("super authority returned zero finalized block; no cache; returning zero", "source", head.Source)
+				return eth.L2BlockRef{}
+			}
+			if head.Block.Number > e.localSafeHead.Number {
+				e.log.Debug("super authority finalized ahead of local safe; using local safe as ceiling", "head", head.Block, "source", head.Source)
+				return e.localSafeHead
+			}
+			if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+				if head.Block == e.superAuthorityFinalizedHead.ID() {
+					return e.superAuthorityFinalizedHead
+				}
+				if head.Block.Number < e.superAuthorityFinalizedHead.Number {
+					e.log.Warn("super authority finalized behind cached; using cache",
+						"super_authority_finalized", head.Block, "source", head.Source,
+						"cached_super_authority_finalized", e.superAuthorityFinalizedHead)
+					return e.superAuthorityFinalizedHead
+				}
+				if head.Block.Number == e.superAuthorityFinalizedHead.Number {
+					panic("superAuthority finalized head conflicts with cached superAuthority finalized head at same height")
+				}
+			}
+			br, err := e.engine.L2BlockRefByHash(e.ctx, head.Block.Hash)
+			if err != nil {
+				if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+					e.log.Warn("super authority finalized unknown to engine; using cache",
+						"super_authority_finalized", head.Block, "source", head.Source,
+						"cached_super_authority_finalized", e.superAuthorityFinalizedHead, "err", err)
+					return e.superAuthorityFinalizedHead
+				}
+				e.log.Warn("super authority finalized unknown to engine and no cache available",
+					"super_authority_finalized", head.Block, "source", head.Source, "err", err)
+				return eth.L2BlockRef{}
+			}
+			e.superAuthorityFinalizedHead = br
+			return br
+		default:
+			panic(fmt.Errorf("unhandled VerifierHeadSource: %v", head.Source))
+		}
 	} else if e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedFinalizedHead
 	} else {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -206,10 +206,10 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 }
 
 // SafeL2Head returns the safe L2 head. With a SuperAuthority registered, the
-// result is bounded by local-safe, validated against the EL for canonicality,
-// and cached. On a transient verifier read failure or any reorg signal
-// (EL-unknown, non-canonical), the canonicality-checked cache is consulted
-// first, then FinalizedHead — never local-safe, never below finalized.
+// result is bounded by local-safe, validated against the EL where applicable,
+// and cached. On a transient verifier read failure or any reorg signal, the
+// canonicality-checked cache is consulted first, then FinalizedHead — never
+// local-safe, never below finalized.
 func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	if e.superAuthority != nil {
 		head, ok := e.superAuthority.FullyVerifiedL2Head(e.ctx)
@@ -219,33 +219,10 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		switch head.Source {
 		case rollup.VerifierHeadPreActivation:
 			return e.localSafeHead
-		case rollup.VerifierHeadAnchor, rollup.VerifierHeadVerified:
-			if (head.Block == eth.BlockID{}) {
-				e.log.Warn("super authority returned zero block with non-pre-activation source", "source", head.Source)
-				return e.floorCrossSafe("zero-block")
-			}
-			if head.Block.Number > e.localSafeHead.Number {
-				return e.localSafeHead
-			}
-			br, err := e.engine.L2BlockRefByHash(e.ctx, head.Block.Hash)
-			if err != nil {
-				e.log.Warn("super authority safe head unknown to engine (reorg signal)",
-					"super_authority_safe", head.Block, "source", head.Source, "err", err)
-				return e.floorCrossSafe("el-unknown")
-			}
-			canonical, canonicalCheck, err := e.isCanonical(br)
-			if err != nil {
-				e.log.Warn("cannot verify super authority safe head canonicality",
-					"super_authority_safe", br, "source", head.Source, "err", err)
-				return e.floorCrossSafe("canonicality-lookup-failed")
-			}
-			if !canonical {
-				e.log.Warn("super authority safe head non-canonical (reorg signal)",
-					"super_authority_safe", br, "canonical", canonicalCheck, "source", head.Source)
-				return e.floorCrossSafe("non-canonical")
-			}
-			e.superAuthoritySafeHead = br
-			return br
+		case rollup.VerifierHeadAnchor:
+			return e.resolveAnchorAsSafe(head.Timestamp)
+		case rollup.VerifierHeadVerified:
+			return e.resolveVerifiedAsSafe(head.Block)
 		default:
 			panic(fmt.Errorf("unhandled VerifierHeadSource: %v", head.Source))
 		}
@@ -254,6 +231,53 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	} else {
 		return e.localSafeHead
 	}
+}
+
+// resolveVerifiedAsSafe handles the Verified branch of SafeL2Head.
+func (e *EngineController) resolveVerifiedAsSafe(block eth.BlockID) eth.L2BlockRef {
+	if block.Number > e.localSafeHead.Number {
+		return e.localSafeHead
+	}
+	br, err := e.engine.L2BlockRefByHash(e.ctx, block.Hash)
+	if err != nil {
+		e.log.Warn("super authority safe head unknown to engine (reorg signal)",
+			"super_authority_safe", block, "err", err)
+		return e.floorCrossSafe("el-unknown")
+	}
+	canonical, canonicalRef, err := e.isCanonical(br)
+	if err != nil {
+		e.log.Warn("cannot verify super authority safe head canonicality",
+			"super_authority_safe", br, "err", err)
+		return e.floorCrossSafe("canonicality-lookup-failed")
+	}
+	if !canonical {
+		e.log.Warn("super authority safe head non-canonical (reorg signal)",
+			"super_authority_safe", br, "canonical", canonicalRef)
+		return e.floorCrossSafe("non-canonical")
+	}
+	e.superAuthoritySafeHead = br
+	return br
+}
+
+// resolveAnchorAsSafe handles the Anchor branch of SafeL2Head: resolve the
+// canonical L2 block at the supplied pre-activation cap timestamp. The block
+// is canonical by construction (looked up by number); no second check needed.
+func (e *EngineController) resolveAnchorAsSafe(ts uint64) eth.L2BlockRef {
+	num, err := e.rollupCfg.TargetBlockNumber(ts)
+	if err != nil {
+		e.log.Warn("cannot compute anchor block number", "ts", ts, "err", err)
+		return e.floorCrossSafe("anchor-target-block-number")
+	}
+	br, err := e.engine.L2BlockRefByNumber(e.ctx, num)
+	if err != nil {
+		e.log.Warn("cannot resolve anchor block", "ts", ts, "num", num, "err", err)
+		return e.floorCrossSafe("anchor-lookup-failed")
+	}
+	if br.Number > e.localSafeHead.Number {
+		return e.localSafeHead
+	}
+	e.superAuthoritySafeHead = br
+	return br
 }
 
 // floorCrossSafe is the cross-safe fallback path. It tries the cached
@@ -338,45 +362,10 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 		switch head.Source {
 		case rollup.VerifierHeadPreActivation:
 			return e.localFinalizedHead
-		case rollup.VerifierHeadAnchor, rollup.VerifierHeadVerified:
-			if (head.Block == eth.BlockID{}) {
-				if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
-					return e.superAuthorityFinalizedHead
-				}
-				e.log.Warn("super authority returned zero finalized block; no cache; returning zero", "source", head.Source)
-				return eth.L2BlockRef{}
-			}
-			if head.Block.Number > e.localFinalizedHead.Number {
-				return e.localFinalizedHead
-			}
-			if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
-				if head.Block == e.superAuthorityFinalizedHead.ID() {
-					return e.superAuthorityFinalizedHead
-				}
-				if head.Block.Number < e.superAuthorityFinalizedHead.Number {
-					e.log.Warn("super authority finalized behind cached; using cache",
-						"super_authority_finalized", head.Block, "source", head.Source,
-						"cached_super_authority_finalized", e.superAuthorityFinalizedHead)
-					return e.superAuthorityFinalizedHead
-				}
-				if head.Block.Number == e.superAuthorityFinalizedHead.Number {
-					panic("superAuthority finalized head conflicts with cached superAuthority finalized head at same height")
-				}
-			}
-			br, err := e.engine.L2BlockRefByHash(e.ctx, head.Block.Hash)
-			if err != nil {
-				if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
-					e.log.Warn("super authority finalized unknown to engine; using cache",
-						"super_authority_finalized", head.Block, "source", head.Source,
-						"cached_super_authority_finalized", e.superAuthorityFinalizedHead, "err", err)
-					return e.superAuthorityFinalizedHead
-				}
-				e.log.Warn("super authority finalized unknown to engine and no cache available",
-					"super_authority_finalized", head.Block, "source", head.Source, "err", err)
-				return eth.L2BlockRef{}
-			}
-			e.superAuthorityFinalizedHead = br
-			return br
+		case rollup.VerifierHeadAnchor:
+			return e.resolveAnchorAsFinalized(head.Timestamp)
+		case rollup.VerifierHeadVerified:
+			return e.resolveVerifiedAsFinalized(head.Block)
 		default:
 			panic(fmt.Errorf("unhandled VerifierHeadSource: %v", head.Source))
 		}
@@ -385,6 +374,66 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 	} else {
 		return e.localFinalizedHead
 	}
+}
+
+// resolveVerifiedAsFinalized handles the Verified branch of FinalizedHead.
+func (e *EngineController) resolveVerifiedAsFinalized(block eth.BlockID) eth.L2BlockRef {
+	if block.Number > e.localFinalizedHead.Number {
+		return e.localFinalizedHead
+	}
+	if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+		if block == e.superAuthorityFinalizedHead.ID() {
+			return e.superAuthorityFinalizedHead
+		}
+		if block.Number < e.superAuthorityFinalizedHead.Number {
+			e.log.Warn("super authority finalized behind cached; using cache",
+				"super_authority_finalized", block,
+				"cached_super_authority_finalized", e.superAuthorityFinalizedHead)
+			return e.superAuthorityFinalizedHead
+		}
+		if block.Number == e.superAuthorityFinalizedHead.Number {
+			panic("superAuthority finalized head conflicts with cached superAuthority finalized head at same height")
+		}
+	}
+	br, err := e.engine.L2BlockRefByHash(e.ctx, block.Hash)
+	if err != nil {
+		if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+			e.log.Warn("super authority finalized unknown to engine; using cache",
+				"super_authority_finalized", block,
+				"cached_super_authority_finalized", e.superAuthorityFinalizedHead, "err", err)
+			return e.superAuthorityFinalizedHead
+		}
+		e.log.Warn("super authority finalized unknown to engine and no cache available",
+			"super_authority_finalized", block, "err", err)
+		return eth.L2BlockRef{}
+	}
+	e.superAuthorityFinalizedHead = br
+	return br
+}
+
+// resolveAnchorAsFinalized handles the Anchor branch of FinalizedHead.
+func (e *EngineController) resolveAnchorAsFinalized(ts uint64) eth.L2BlockRef {
+	num, err := e.rollupCfg.TargetBlockNumber(ts)
+	if err != nil {
+		e.log.Warn("cannot compute finalized anchor block number", "ts", ts, "err", err)
+		if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+			return e.superAuthorityFinalizedHead
+		}
+		return eth.L2BlockRef{}
+	}
+	br, err := e.engine.L2BlockRefByNumber(e.ctx, num)
+	if err != nil {
+		e.log.Warn("cannot resolve finalized anchor block", "ts", ts, "num", num, "err", err)
+		if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+			return e.superAuthorityFinalizedHead
+		}
+		return eth.L2BlockRef{}
+	}
+	if br.Number > e.localFinalizedHead.Number {
+		return e.localFinalizedHead
+	}
+	e.superAuthorityFinalizedHead = br
+	return br
 }
 
 func (e *EngineController) UnsafeL2Head() eth.L2BlockRef {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -129,13 +129,6 @@ type EngineController struct {
 	// Finalized blocks cannot reorg, so this cache does not require
 	// canonicality re-validation before use.
 	superAuthorityFinalizedHead eth.L2BlockRef
-	// Last successfully materialized superAuthority safe (cross-safe) head,
-	// used as a fallback when the authority returns HoldPrevious or the fresh
-	// result fails canonicality / EL lookup. Cross-safe CAN reorg, so the
-	// cache MUST be re-validated against the EL via L2BlockRefByNumber before
-	// use (see useSuperAuthoritySafeCache). If the cached block is no longer
-	// canonical, the cache is cleared and the caller floors at FinalizedHead.
-	superAuthoritySafeHead eth.L2BlockRef
 	// The unsafe head to roll back to,
 	// after the pendingSafeHead fails to become safe.
 	// This is changing in the Holocene fork.
@@ -207,20 +200,23 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 
 // SafeL2Head returns the safe L2 head. With a SuperAuthority registered, the
 // result is bounded by local-safe, validated against the EL where applicable,
-// and cached. On a transient verifier read failure or any reorg signal, the
-// canonicality-checked cache is consulted first, then FinalizedHead — never
-// local-safe, never below finalized.
+// and on a transient verifier read failure or any reorg signal falls back to
+// FinalizedHead — never local-safe, never below finalized.
 func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	if e.superAuthority != nil {
 		head, ok := e.superAuthority.FullyVerifiedL2Head(e.ctx)
 		if !ok {
-			return e.floorCrossSafe("HoldPrevious")
+			finalized := e.FinalizedHead()
+			e.log.Debug("super authority safe head unavailable; using finalized", "finalized", finalized)
+			return finalized
 		}
 		switch head.Source {
 		case rollup.VerifierHeadPreActivation:
 			return e.localSafeHead
 		case rollup.VerifierHeadAnchor:
-			return e.resolveAnchorAsSafe(head.Timestamp)
+			finalized := e.FinalizedHead()
+			e.log.Debug("super authority safe head anchored; using finalized", "anchor_time", head.Timestamp, "finalized", finalized)
+			return finalized
 		case rollup.VerifierHeadVerified:
 			return e.resolveVerifiedAsSafe(head.Block)
 		default:
@@ -238,110 +234,20 @@ func (e *EngineController) resolveVerifiedAsSafe(block eth.BlockID) eth.L2BlockR
 	if block.Number > e.localSafeHead.Number {
 		return e.localSafeHead
 	}
-	br, err := e.engine.L2BlockRefByHash(e.ctx, block.Hash)
+	br, err := e.engine.L2BlockRefByNumber(e.ctx, block.Number)
 	if err != nil {
-		e.log.Warn("super authority safe head unknown to engine (reorg signal)",
-			"super_authority_safe", block, "err", err)
-		return e.floorCrossSafe("el-unknown")
-	}
-	canonical, canonicalRef, err := e.isCanonical(br)
-	if err != nil {
+		finalized := e.FinalizedHead()
 		e.log.Warn("cannot verify super authority safe head canonicality",
-			"super_authority_safe", br, "err", err)
-		return e.floorCrossSafe("canonicality-lookup-failed")
+			"super_authority_safe", block, "finalized", finalized, "err", err)
+		return finalized
 	}
-	if !canonical {
+	if br.Hash != block.Hash {
+		finalized := e.FinalizedHead()
 		e.log.Warn("super authority safe head non-canonical (reorg signal)",
-			"super_authority_safe", br, "canonical", canonicalRef)
-		return e.floorCrossSafe("non-canonical")
+			"super_authority_safe", block, "canonical", br, "finalized", finalized)
+		return finalized
 	}
-	e.superAuthoritySafeHead = br
 	return br
-}
-
-// resolveAnchorAsSafe handles the Anchor branch of SafeL2Head: resolve the
-// canonical L2 block at the supplied pre-activation cap timestamp. The block
-// is canonical by construction (looked up by number); no second check needed.
-func (e *EngineController) resolveAnchorAsSafe(ts uint64) eth.L2BlockRef {
-	num, err := e.rollupCfg.TargetBlockNumber(ts)
-	if err != nil {
-		e.log.Warn("cannot compute anchor block number", "ts", ts, "err", err)
-		return e.floorCrossSafe("anchor-target-block-number")
-	}
-	br, err := e.engine.L2BlockRefByNumber(e.ctx, num)
-	if err != nil {
-		e.log.Warn("cannot resolve anchor block", "ts", ts, "num", num, "err", err)
-		return e.floorCrossSafe("anchor-lookup-failed")
-	}
-	if br.Number > e.localSafeHead.Number {
-		return e.localSafeHead
-	}
-	e.superAuthoritySafeHead = br
-	return br
-}
-
-// floorCrossSafe is the cross-safe fallback path. It tries the cached
-// superAuthoritySafeHead first — re-validating its canonicality against the
-// EL — and falls back to FinalizedHead if the cache is empty, non-canonical,
-// or unavailable. A non-canonical cache is cleared so we don't keep paying the
-// validation cost.
-func (e *EngineController) floorCrossSafe(reason string) eth.L2BlockRef {
-	if cached, ok := e.useSuperAuthoritySafeCache(); ok {
-		e.log.Debug("cross-safe fallback using canonicality-validated cache", "reason", reason, "cached", cached)
-		return cached
-	}
-	finalized := e.FinalizedHead()
-	e.log.Debug("cross-safe fallback flooring at finalized", "reason", reason, "finalized", finalized)
-	return finalized
-}
-
-// useSuperAuthoritySafeCache returns the cached cross-safe head if it is still
-// canonical on the EL and still within local-safe. Otherwise clears the cache
-// and returns false. Cross-safe can reorg, so the cache must be re-validated
-// before each use — we never blindly return a cached cross-safe value.
-func (e *EngineController) useSuperAuthoritySafeCache() (eth.L2BlockRef, bool) {
-	cached := e.superAuthoritySafeHead
-	if cached == (eth.L2BlockRef{}) {
-		return eth.L2BlockRef{}, false
-	}
-	if cached.Number > e.localSafeHead.Number {
-		// Local-safe regressed (or cache is otherwise stale relative to current
-		// derivation state). Stop trusting the cache.
-		e.log.Info("cached cross-safe ahead of local-safe; clearing cache",
-			"cached", cached, "local_safe", e.localSafeHead)
-		e.superAuthoritySafeHead = eth.L2BlockRef{}
-		return eth.L2BlockRef{}, false
-	}
-	ok, canonical, err := e.isCanonical(cached)
-	if err != nil {
-		e.log.Warn("cannot validate cached cross-safe canonicality; clearing cache",
-			"cached", cached, "err", err)
-		e.superAuthoritySafeHead = eth.L2BlockRef{}
-		return eth.L2BlockRef{}, false
-	}
-	if !ok {
-		e.log.Info("cached cross-safe non-canonical (reorg); clearing cache",
-			"cached", cached, "canonical", canonical)
-		e.superAuthoritySafeHead = eth.L2BlockRef{}
-		return eth.L2BlockRef{}, false
-	}
-	return cached, true
-}
-
-// isCanonical reports whether `target` still matches the EL's canonical chain
-// at its number. Three outcomes:
-//   - ok=true,  canonical=target,           err=nil  → canonical.
-//   - ok=false, canonical=different block,  err=nil  → non-canonical (reorg).
-//   - ok=false, canonical=zero,             err≠nil  → lookup failed.
-//
-// The returned canonical block is exposed so callers can log the divergence on
-// reorg without a second lookup.
-func (e *EngineController) isCanonical(target eth.L2BlockRef) (ok bool, canonical eth.L2BlockRef, err error) {
-	canonical, err = e.engine.L2BlockRefByNumber(e.ctx, target.Number)
-	if err != nil {
-		return false, eth.L2BlockRef{}, err
-	}
-	return canonical.Hash == target.Hash, canonical, nil
 }
 
 // FinalizedHead returns the finalized L2 head, bounded by local-finalized
@@ -431,6 +337,20 @@ func (e *EngineController) resolveAnchorAsFinalized(ts uint64) eth.L2BlockRef {
 	}
 	if br.Number > e.localFinalizedHead.Number {
 		return e.localFinalizedHead
+	}
+	if e.superAuthorityFinalizedHead != (eth.L2BlockRef{}) {
+		if br.ID() == e.superAuthorityFinalizedHead.ID() {
+			return e.superAuthorityFinalizedHead
+		}
+		if br.Number < e.superAuthorityFinalizedHead.Number {
+			e.log.Warn("super authority finalized anchor behind cached; using cache",
+				"super_authority_finalized_anchor", br,
+				"cached_super_authority_finalized", e.superAuthorityFinalizedHead)
+			return e.superAuthorityFinalizedHead
+		}
+		if br.Number == e.superAuthorityFinalizedHead.Number {
+			panic("superAuthority finalized anchor conflicts with cached superAuthority finalized head at same height")
+		}
 	}
 	e.superAuthorityFinalizedHead = br
 	return br

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -247,13 +247,13 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 					"super_authority_safe", head.Block, "source", head.Source, "err", err)
 				return e.floorCrossSafe("el-unknown")
 			}
-			canonical, err := e.engine.L2BlockRefByNumber(e.ctx, br.Number)
+			ok, canonical, err := e.isCanonical(br)
 			if err != nil {
 				e.log.Warn("cannot verify super authority safe head canonicality",
 					"super_authority_safe", br, "source", head.Source, "err", err)
 				return e.floorCrossSafe("canonicality-lookup-failed")
 			}
-			if canonical.Hash != br.Hash {
+			if !ok {
 				e.log.Warn("super authority safe head non-canonical (reorg signal)",
 					"super_authority_safe", br, "canonical", canonical, "source", head.Source)
 				return e.floorCrossSafe("non-canonical")
@@ -302,20 +302,36 @@ func (e *EngineController) useSuperAuthoritySafeCache() (eth.L2BlockRef, bool) {
 		e.superAuthoritySafeHead = eth.L2BlockRef{}
 		return eth.L2BlockRef{}, false
 	}
-	canonical, err := e.engine.L2BlockRefByNumber(e.ctx, cached.Number)
+	ok, canonical, err := e.isCanonical(cached)
 	if err != nil {
 		e.log.Warn("cannot validate cached cross-safe canonicality; clearing cache",
 			"cached", cached, "err", err)
 		e.superAuthoritySafeHead = eth.L2BlockRef{}
 		return eth.L2BlockRef{}, false
 	}
-	if canonical.Hash != cached.Hash {
+	if !ok {
 		e.log.Info("cached cross-safe non-canonical (reorg); clearing cache",
 			"cached", cached, "canonical", canonical)
 		e.superAuthoritySafeHead = eth.L2BlockRef{}
 		return eth.L2BlockRef{}, false
 	}
 	return cached, true
+}
+
+// isCanonical reports whether `target` still matches the EL's canonical chain
+// at its number. Three outcomes:
+//   - ok=true,  canonical=target,           err=nil  → canonical.
+//   - ok=false, canonical=different block,  err=nil  → non-canonical (reorg).
+//   - ok=false, canonical=zero,             err≠nil  → lookup failed.
+//
+// The returned canonical block is exposed so callers can log the divergence on
+// reorg without a second lookup.
+func (e *EngineController) isCanonical(target eth.L2BlockRef) (ok bool, canonical eth.L2BlockRef, err error) {
+	canonical, err = e.engine.L2BlockRefByNumber(e.ctx, target.Number)
+	if err != nil {
+		return false, eth.L2BlockRef{}, err
+	}
+	return canonical.Hash == target.Hash, canonical, nil
 }
 
 // FinalizedHead returns the finalized L2 head, with the same tri-state contract

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -238,7 +238,6 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 			setupEngine: func(m *testutils.MockEngine) {
-				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 			},
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50},
@@ -256,7 +255,6 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 			setupEngine: func(m *testutils.MockEngine) {
-				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}, nil)
 				m.ExpectL2BlockRefByHash(common.Hash{0xee}, eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40}, nil)
 			},
@@ -308,7 +306,7 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 			setupEngine: func(m *testutils.MockEngine) {
-				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
+				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{}, errors.New("block not found"))
 				m.ExpectL2BlockRefByHash(common.Hash{0xee}, eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40}, nil)
 			},
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40},
@@ -1050,6 +1048,49 @@ func TestEngineController_FinalizedHeadUsesCachedSuperAuthorityFinalizedWhenAuth
 	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xff}, Number: 60})
 	cachedSuperAuthority := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50}
 	ec.superAuthorityFinalizedHead = cachedSuperAuthority
+
+	require.Equal(t, cachedSuperAuthority, ec.FinalizedHead())
+	require.Equal(t, cachedSuperAuthority, ec.superAuthorityFinalizedHead)
+}
+
+func TestEngineController_FinalizedHeadPanicsOnCachedSuperAuthorityAnchorSameHeightConflict(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2HeadSource: rollup.VerifierHeadAnchor,
+		finalizedTimestamp:    100,
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	cfg := &rollup.Config{BlockTime: 2}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xff}, Number: 80})
+	cachedSuperAuthority := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50}
+	ec.superAuthorityFinalizedHead = cachedSuperAuthority
+
+	anchorRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	mockEngine.ExpectL2BlockRefByNumber(50, anchorRef, nil)
+
+	require.PanicsWithValue(t, "superAuthority finalized anchor conflicts with cached superAuthority finalized head at same height", func() {
+		ec.FinalizedHead()
+	})
+}
+
+func TestEngineController_FinalizedHeadUsesCachedSuperAuthorityFinalizedWhenAnchorBehindCache(t *testing.T) {
+	superAuth := &mockSuperAuthority{
+		finalizedL2HeadSource: rollup.VerifierHeadAnchor,
+		finalizedTimestamp:    100,
+	}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	cfg := &rollup.Config{BlockTime: 2}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xff}, Number: 80})
+	cachedSuperAuthority := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 60}
+	ec.superAuthorityFinalizedHead = cachedSuperAuthority
+
+	anchorRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	mockEngine.ExpectL2BlockRefByNumber(50, anchorRef, nil)
 
 	require.Equal(t, cachedSuperAuthority, ec.FinalizedHead())
 	require.Equal(t, cachedSuperAuthority, ec.superAuthorityFinalizedHead)

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -232,7 +232,8 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			name: "with SuperAuthority returns verified block",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					fullyVerifiedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
@@ -243,11 +244,13 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50},
 		},
 		{
-			name: "falls back to SuperAuthority finalized when SuperAuthority block is not canonical",
+			name: "floors at finalized when SuperAuthority block is not canonical (reorg signal)",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
-					finalizedL2Head:     eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
+					fullyVerifiedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+					finalizedL2Head:           eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
+					finalizedL2HeadSource:     rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
@@ -260,14 +263,20 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40},
 		},
 		{
-			name: "with SuperAuthority empty BlockID returns genesis",
+			// Pre-fix this asserted "empty BlockID → genesis" (bug B). Under the
+			// new contract, an empty verifier surfaces as Source=Anchor with a
+			// concrete block (see super_authority_safe_head_test.go), and the
+			// engine controller never reaches L2BlockRefByNumber(0). The path
+			// that previously dropped to genesis is structurally gone; this
+			// case is replaced by the PreActivation behavior below.
+			name: "PreActivation source returns localSafeHead, never genesis",
 			setupSuperAuth: func() *mockSuperAuthority {
-				return &mockSuperAuthority{fullyVerifiedL2Head: eth.BlockID{}}
+				return &mockSuperAuthority{
+					fullyVerifiedL2HeadSource: rollup.VerifierHeadPreActivation,
+				}
 			},
-			setupEngine: func(m *testutils.MockEngine) {
-				m.ExpectL2BlockRefByNumber(0, eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0}, nil)
-			},
-			expectResult: &eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0},
+			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			expectResult:   &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
 			name:           "without SuperAuthority uses local safe",
@@ -279,18 +288,21 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			name: "falls back to local safe when SuperAuthority block ahead of local safe",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0xff}, Number: 200},
+					fullyVerifiedL2Head:       eth.BlockID{Hash: common.Hash{0xff}, Number: 200},
+					fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 			expectResult:   &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
-			name: "falls back to SuperAuthority finalized when SuperAuthority block unknown to engine",
+			name: "floors at finalized when SuperAuthority block unknown to engine (reorg signal)",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					fullyVerifiedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
-					finalizedL2Head:     eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
+					fullyVerifiedL2Head:       eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
+					fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+					finalizedL2Head:           eth.BlockID{Hash: common.Hash{0xee}, Number: 40},
+					finalizedL2HeadSource:     rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
@@ -300,6 +312,18 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xee}, eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40}, nil)
 			},
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40},
+		},
+		{
+			name: "HoldPrevious floors at finalized, never local-safe",
+			setupSuperAuth: func() *mockSuperAuthority {
+				return &mockSuperAuthority{
+					fullyVerifiedStatus:   rollup.VerifierHeadHoldPrevious,
+					finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
+				}
+			},
+			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			expectResult:   &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 		},
 	}
 
@@ -364,8 +388,10 @@ func TestEngineController_ForkchoiceUpdateUsesSuperAuthority(t *testing.T) {
 	}
 	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}
 	mockSA := &mockSuperAuthority{
-		fullyVerifiedL2Head: verifiedRef.ID(),
-		finalizedL2Head:     finalizedRef.ID(),
+		fullyVerifiedL2Head:       verifiedRef.ID(),
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+		finalizedL2Head:           finalizedRef.ID(),
+		finalizedL2HeadSource:     rollup.VerifierHeadVerified,
 	}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, &testutils.MockL1Source{}, emitter, mockSA)
 
@@ -828,7 +854,8 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			name: "with SuperAuthority returns finalized block",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					finalizedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
@@ -839,21 +866,25 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50},
 		},
 		{
-			name: "with SuperAuthority empty BlockID fallback to genesis",
+			// Pre-fix this asserted "empty BlockID → genesis" (bug B applied to
+			// finalized; root cause of ethereum-optimism/optimism#20944). Under
+			// the new contract that path is structurally eliminated. The
+			// PreActivation source now returns localFinalizedHead.
+			name: "PreActivation source returns localFinalizedHead, never genesis",
 			setupSuperAuth: func() *mockSuperAuthority {
-				return &mockSuperAuthority{finalizedL2Head: eth.BlockID{}}
+				return &mockSuperAuthority{
+					finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
+				}
 			},
 			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupEngine: func(m *testutils.MockEngine) {
-				m.ExpectL2BlockRefByNumber(0, eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0}, nil)
-			},
-			expectResult: &eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0},
+			expectResult:    &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
 			name: "with SuperAuthority ahead of local safe uses local safe",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+					finalizedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 40},
@@ -866,13 +897,14 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			expectResult:   &eth.L2BlockRef{},
 		},
 		{
-			name: "returns empty block when genesis lookup fails",
+			// Cold-start HoldPrevious (verifier error, no cache, no local data).
+			// Must return eth.L2BlockRef{} — no garbage, no genesis. This is the
+			// error-after-startup safety trace from the design discussion.
+			name: "HoldPrevious with no cache returns zero",
 			setupSuperAuth: func() *mockSuperAuthority {
-				return &mockSuperAuthority{finalizedL2Head: eth.BlockID{}}
-			},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupEngine: func(m *testutils.MockEngine) {
-				m.ExpectL2BlockRefByNumber(0, eth.L2BlockRef{}, errors.New("genesis not found"))
+				return &mockSuperAuthority{
+					finalizedStatus: rollup.VerifierHeadHoldPrevious,
+				}
 			},
 			expectResult: &eth.L2BlockRef{},
 		},
@@ -880,7 +912,8 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			name: "returns empty when SuperAuthority block unknown to engine and no SuperAuthority cache exists",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					finalizedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
+					finalizedL2Head:       eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
+					finalizedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
@@ -894,7 +927,8 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			name: "falls back to cached SuperAuthority finalized when SuperAuthority block unknown to engine",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					finalizedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 60},
+					finalizedL2Head:       eth.BlockID{Hash: common.Hash{0x99}, Number: 60},
+					finalizedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
@@ -951,7 +985,8 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 
 func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) {
 	superAuth := &mockSuperAuthority{
-		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2HeadSource: rollup.VerifierHeadVerified,
 	}
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
@@ -968,6 +1003,7 @@ func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) 
 	require.Equal(t, finalizedRef, ec.superAuthorityFinalizedHead)
 
 	superAuth.finalizedL2Head = eth.BlockID{Hash: common.Hash{0xcc}, Number: 60}
+	superAuth.finalizedL2HeadSource = rollup.VerifierHeadVerified
 	mockEngine.ExpectL2BlockRefByHash(common.Hash{0xcc}, eth.L2BlockRef{}, errors.New("temporary EL error"))
 
 	require.Equal(t, finalizedRef, ec.FinalizedHead())
@@ -977,7 +1013,8 @@ func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) 
 
 func TestEngineController_FinalizedHeadDoesNotCacheLocalSafeFallback(t *testing.T) {
 	superAuth := &mockSuperAuthority{
-		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2HeadSource: rollup.VerifierHeadVerified,
 	}
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
@@ -994,7 +1031,8 @@ func TestEngineController_FinalizedHeadDoesNotCacheLocalSafeFallback(t *testing.
 
 func TestEngineController_FinalizedHeadUsesCachedSuperAuthorityFinalizedWhenAuthorityRegresses(t *testing.T) {
 	superAuth := &mockSuperAuthority{
-		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 40},
+		finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 40},
+		finalizedL2HeadSource: rollup.VerifierHeadVerified,
 	}
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
@@ -1009,7 +1047,8 @@ func TestEngineController_FinalizedHeadUsesCachedSuperAuthorityFinalizedWhenAuth
 
 func TestEngineController_FinalizedHeadPanicsOnCachedSuperAuthoritySameHeightConflict(t *testing.T) {
 	superAuth := &mockSuperAuthority{
-		finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+		finalizedL2HeadSource: rollup.VerifierHeadVerified,
 	}
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -254,7 +254,7 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 				m.ExpectL2BlockRefByNumber(50, eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}, nil)
@@ -306,7 +306,7 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 				}
 			},
 			setupLocalSafe: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			setupFinalized: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 40},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 				m.ExpectL2BlockRefByHash(common.Hash{0xee}, eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 40}, nil)
@@ -317,7 +317,7 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			name: "HoldPrevious floors at finalized, never local-safe",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					fullyVerifiedStatus:   rollup.VerifierHeadHoldPrevious,
+					holdPreviousVerified:  true,
 					finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
 				}
 			},
@@ -859,7 +859,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 30},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 50},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
 			},
@@ -880,16 +880,18 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			expectResult:    &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
-			name: "with SuperAuthority ahead of local safe uses local safe",
+			// Super authority cannot finalize a block that isn't locally finalized:
+			// authority=50, localFinalized=30 → clamp to localFinalized.
+			name: "SuperAuthority finalized ahead of local-finalized uses local-finalized",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
 					finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
 					finalizedL2HeadSource: rollup.VerifierHeadVerified,
 				}
 			},
-			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 40},
+			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 100},
 			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
-			expectResult:    &eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 40},
+			expectResult:    &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
 		},
 		{
 			name:           "without SuperAuthority returns zero value",
@@ -903,7 +905,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			name: "HoldPrevious with no cache returns zero",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
-					finalizedStatus: rollup.VerifierHeadHoldPrevious,
+					holdPreviousFinalized: true,
 				}
 			},
 			expectResult: &eth.L2BlockRef{},
@@ -917,7 +919,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 			},
@@ -932,7 +934,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 				}
 			},
 			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
-			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 60},
 			setupSACache:    &eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 50},
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
@@ -992,7 +994,9 @@ func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) 
 	emitter := &testutils.MockEmitter{}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
 	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
-	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30}
+	// localFinalized must be >= the SuperAuthority finalized values (50, 60)
+	// since FinalizedHead is now bounded by local-finalized.
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 60}
 	ec.SetFinalizedHead(localFinalized)
 
 	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
@@ -1011,7 +1015,11 @@ func TestEngineController_FinalizedHeadCachesSuperAuthorityResult(t *testing.T) 
 	require.Equal(t, finalizedRef, ec.superAuthorityFinalizedHead)
 }
 
-func TestEngineController_FinalizedHeadDoesNotCacheLocalSafeFallback(t *testing.T) {
+// FinalizedHead is bounded by local-finalized (the super authority cannot
+// finalize a block that isn't locally final). When the authority reports a
+// finalized block ahead of local-finalized, the local-finalized head wins and
+// the super-authority cache stays empty.
+func TestEngineController_FinalizedHeadAheadOfLocalFinalUsesLocalFinal(t *testing.T) {
 	superAuth := &mockSuperAuthority{
 		finalizedL2Head:       eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
 		finalizedL2HeadSource: rollup.VerifierHeadVerified,
@@ -1019,14 +1027,15 @@ func TestEngineController_FinalizedHeadDoesNotCacheLocalSafeFallback(t *testing.
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
-	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 40}
-	cachedFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30}
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30}
 	ec.SetLocalSafeHead(localSafe)
-	ec.SetFinalizedHead(cachedFinalized)
+	ec.SetFinalizedHead(localFinalized)
 
-	require.Equal(t, localSafe, ec.FinalizedHead())
-	require.Equal(t, cachedFinalized, ec.localFinalizedHead)
-	require.Equal(t, eth.L2BlockRef{}, ec.superAuthorityFinalizedHead)
+	require.Equal(t, localFinalized, ec.FinalizedHead())
+	require.Equal(t, localFinalized, ec.localFinalizedHead)
+	require.Equal(t, eth.L2BlockRef{}, ec.superAuthorityFinalizedHead,
+		"cache must not be populated when the SuperAuthority result is clamped to local-finalized")
 }
 
 func TestEngineController_FinalizedHeadUsesCachedSuperAuthorityFinalizedWhenAuthorityRegresses(t *testing.T) {
@@ -1038,6 +1047,7 @@ func TestEngineController_FinalizedHeadUsesCachedSuperAuthorityFinalizedWhenAuth
 	emitter := &testutils.MockEmitter{}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
 	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xff}, Number: 60})
 	cachedSuperAuthority := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50}
 	ec.superAuthorityFinalizedHead = cachedSuperAuthority
 
@@ -1054,6 +1064,7 @@ func TestEngineController_FinalizedHeadPanicsOnCachedSuperAuthoritySameHeightCon
 	emitter := &testutils.MockEmitter{}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter, superAuth)
 	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xff}, Number: 60})
 	ec.superAuthorityFinalizedHead = eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 50}
 
 	require.PanicsWithValue(t, "superAuthority finalized head conflicts with cached superAuthority finalized head at same height", func() {

--- a/op-node/rollup/engine/super_authority_mock_test.go
+++ b/op-node/rollup/engine/super_authority_mock_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -9,18 +10,16 @@ import (
 )
 
 // mockSuperAuthority implements rollup.SuperAuthority for testing.
-//
-// Helper fields fullyVerifiedL2Head / finalizedL2Head and the *Source fields
-// carry the head returned by the tri-state contract methods. *Status carries
-// the VerifierHeadStatus (defaults to VerifierHeadOk).
+// holdPrevious{Verified,Finalized} default to false so struct-literal tests
+// without explicit setup get the happy-path (ok=true).
 type mockSuperAuthority struct {
 	fullyVerifiedL2Head       eth.BlockID
 	fullyVerifiedL2HeadSource rollup.VerifierHeadSource
-	fullyVerifiedStatus       rollup.VerifierHeadStatus
+	holdPreviousVerified      bool
 
 	finalizedL2Head       eth.BlockID
 	finalizedL2HeadSource rollup.VerifierHeadSource
-	finalizedStatus       rollup.VerifierHeadStatus
+	holdPreviousFinalized bool
 
 	deniedBlocks map[uint64]common.Hash
 	shouldError  bool
@@ -47,12 +46,12 @@ func (m *mockSuperAuthority) IsDenied(blockNumber uint64, payloadHash common.Has
 	return false, nil
 }
 
-func (m *mockSuperAuthority) FullyVerifiedL2Head() (rollup.VerifierHead, rollup.VerifierHeadStatus) {
-	return rollup.VerifierHead{Block: m.fullyVerifiedL2Head, Source: m.fullyVerifiedL2HeadSource}, m.fullyVerifiedStatus
+func (m *mockSuperAuthority) FullyVerifiedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
+	return rollup.VerifierHead{Block: m.fullyVerifiedL2Head, Source: m.fullyVerifiedL2HeadSource}, !m.holdPreviousVerified
 }
 
-func (m *mockSuperAuthority) FinalizedL2Head() (rollup.VerifierHead, rollup.VerifierHeadStatus) {
-	return rollup.VerifierHead{Block: m.finalizedL2Head, Source: m.finalizedL2HeadSource}, m.finalizedStatus
+func (m *mockSuperAuthority) FinalizedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
+	return rollup.VerifierHead{Block: m.finalizedL2Head, Source: m.finalizedL2HeadSource}, !m.holdPreviousFinalized
 }
 
 var _ rollup.SuperAuthority = (*mockSuperAuthority)(nil)

--- a/op-node/rollup/engine/super_authority_mock_test.go
+++ b/op-node/rollup/engine/super_authority_mock_test.go
@@ -14,10 +14,12 @@ import (
 // without explicit setup get the happy-path (ok=true).
 type mockSuperAuthority struct {
 	fullyVerifiedL2Head       eth.BlockID
+	fullyVerifiedTimestamp    uint64
 	fullyVerifiedL2HeadSource rollup.VerifierHeadSource
 	holdPreviousVerified      bool
 
 	finalizedL2Head       eth.BlockID
+	finalizedTimestamp    uint64
 	finalizedL2HeadSource rollup.VerifierHeadSource
 	holdPreviousFinalized bool
 
@@ -47,11 +49,19 @@ func (m *mockSuperAuthority) IsDenied(blockNumber uint64, payloadHash common.Has
 }
 
 func (m *mockSuperAuthority) FullyVerifiedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
-	return rollup.VerifierHead{Block: m.fullyVerifiedL2Head, Source: m.fullyVerifiedL2HeadSource}, !m.holdPreviousVerified
+	return rollup.VerifierHead{
+		Block:     m.fullyVerifiedL2Head,
+		Timestamp: m.fullyVerifiedTimestamp,
+		Source:    m.fullyVerifiedL2HeadSource,
+	}, !m.holdPreviousVerified
 }
 
 func (m *mockSuperAuthority) FinalizedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
-	return rollup.VerifierHead{Block: m.finalizedL2Head, Source: m.finalizedL2HeadSource}, !m.holdPreviousFinalized
+	return rollup.VerifierHead{
+		Block:     m.finalizedL2Head,
+		Timestamp: m.finalizedTimestamp,
+		Source:    m.finalizedL2HeadSource,
+	}, !m.holdPreviousFinalized
 }
 
 var _ rollup.SuperAuthority = (*mockSuperAuthority)(nil)

--- a/op-node/rollup/engine/super_authority_mock_test.go
+++ b/op-node/rollup/engine/super_authority_mock_test.go
@@ -8,12 +8,22 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// mockSuperAuthority implements SuperAuthority for testing.
+// mockSuperAuthority implements rollup.SuperAuthority for testing.
+//
+// Helper fields fullyVerifiedL2Head / finalizedL2Head and the *Source fields
+// carry the head returned by the tri-state contract methods. *Status carries
+// the VerifierHeadStatus (defaults to VerifierHeadOk).
 type mockSuperAuthority struct {
-	fullyVerifiedL2Head eth.BlockID
-	finalizedL2Head     eth.BlockID
-	deniedBlocks        map[uint64]common.Hash
-	shouldError         bool
+	fullyVerifiedL2Head       eth.BlockID
+	fullyVerifiedL2HeadSource rollup.VerifierHeadSource
+	fullyVerifiedStatus       rollup.VerifierHeadStatus
+
+	finalizedL2Head       eth.BlockID
+	finalizedL2HeadSource rollup.VerifierHeadSource
+	finalizedStatus       rollup.VerifierHeadStatus
+
+	deniedBlocks map[uint64]common.Hash
+	shouldError  bool
 }
 
 func newMockSuperAuthority() *mockSuperAuthority {
@@ -37,12 +47,12 @@ func (m *mockSuperAuthority) IsDenied(blockNumber uint64, payloadHash common.Has
 	return false, nil
 }
 
-func (m *mockSuperAuthority) FullyVerifiedL2Head() (eth.BlockID, bool) {
-	return m.fullyVerifiedL2Head, false
+func (m *mockSuperAuthority) FullyVerifiedL2Head() (rollup.VerifierHead, rollup.VerifierHeadStatus) {
+	return rollup.VerifierHead{Block: m.fullyVerifiedL2Head, Source: m.fullyVerifiedL2HeadSource}, m.fullyVerifiedStatus
 }
 
-func (m *mockSuperAuthority) FinalizedL2Head() (eth.BlockID, bool) {
-	return m.finalizedL2Head, false
+func (m *mockSuperAuthority) FinalizedL2Head() (rollup.VerifierHead, rollup.VerifierHeadStatus) {
+	return rollup.VerifierHead{Block: m.finalizedL2Head, Source: m.finalizedL2HeadSource}, m.finalizedStatus
 }
 
 var _ rollup.SuperAuthority = (*mockSuperAuthority)(nil)

--- a/op-node/rollup/engine/super_authority_safe_head_test.go
+++ b/op-node/rollup/engine/super_authority_safe_head_test.go
@@ -39,7 +39,6 @@ func TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis(t *testing.T) {
 		// supernode contributes its activation anchor as a concrete block.
 		fullyVerifiedL2Head:       anchorBlock,
 		fullyVerifiedL2HeadSource: rollup.VerifierHeadAnchor,
-		fullyVerifiedStatus:       rollup.VerifierHeadOk,
 	}
 	ec := NewEngineController(
 		context.Background(),
@@ -85,11 +84,10 @@ func TestSafeL2Head_VerifierError_FloorsAtFinalized(t *testing.T) {
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
 	sa := &mockSuperAuthority{
-		fullyVerifiedStatus: rollup.VerifierHeadHoldPrevious,
+		holdPreviousVerified: true,
 		// FinalizedHead is also consulted; configure it to PreActivation so the
 		// floor resolves to localFinalizedHead.
 		finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
-		finalizedStatus:       rollup.VerifierHeadOk,
 	}
 	ec := NewEngineController(
 		context.Background(),
@@ -129,11 +127,9 @@ func TestSafeL2Head_HoldPrevious_UsesCanonicalCache(t *testing.T) {
 	sa := &mockSuperAuthority{
 		fullyVerifiedL2Head:       verifiedBlock,
 		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
-		fullyVerifiedStatus:       rollup.VerifierHeadOk,
 		// Finalized stays PreActivation so the floor would resolve to
 		// localFinalized — distinguishable from the cache hit at block 80.
 		finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
-		finalizedStatus:       rollup.VerifierHeadOk,
 	}
 	ec := NewEngineController(
 		context.Background(),
@@ -157,7 +153,7 @@ func TestSafeL2Head_HoldPrevious_UsesCanonicalCache(t *testing.T) {
 
 	// Verifier now returns HoldPrevious; cache canonicality re-validates and is
 	// returned in preference to flooring at finalized.
-	sa.fullyVerifiedStatus = rollup.VerifierHeadHoldPrevious
+	sa.holdPreviousVerified = true
 	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
 	got = ec.SafeL2Head()
 	require.Equal(t, verifiedRef, got,
@@ -178,9 +174,7 @@ func TestSafeL2Head_HoldPrevious_NonCanonicalCache_FloorsAtFinalized(t *testing.
 	sa := &mockSuperAuthority{
 		fullyVerifiedL2Head:       verifiedBlock,
 		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
-		fullyVerifiedStatus:       rollup.VerifierHeadOk,
 		finalizedL2HeadSource:     rollup.VerifierHeadPreActivation,
-		finalizedStatus:           rollup.VerifierHeadOk,
 	}
 	ec := NewEngineController(
 		context.Background(),
@@ -204,7 +198,7 @@ func TestSafeL2Head_HoldPrevious_NonCanonicalCache_FloorsAtFinalized(t *testing.
 
 	// Simulate a reorg: the EL now reports a different canonical block at the
 	// cached number. HoldPrevious must clear the cache and floor at finalized.
-	sa.fullyVerifiedStatus = rollup.VerifierHeadHoldPrevious
+	sa.holdPreviousVerified = true
 	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number,
 		eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: verifiedBlock.Number}, nil)
 	got := ec.SafeL2Head()
@@ -222,7 +216,7 @@ func TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero(t *testing.T) {
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
 	sa := &mockSuperAuthority{
-		finalizedStatus: rollup.VerifierHeadHoldPrevious,
+		holdPreviousFinalized: true,
 	}
 	ec := NewEngineController(
 		context.Background(),

--- a/op-node/rollup/engine/super_authority_safe_head_test.go
+++ b/op-node/rollup/engine/super_authority_safe_head_test.go
@@ -28,24 +28,28 @@ import (
 // returns the verifier's contribution. SafeL2Head must never return the L2
 // genesis block when local-safe and local-finalized are non-zero.
 func TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis(t *testing.T) {
-	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	// Realistic shape: local-safe has crossed activation. With BlockTime=2 and
+	// genesis at time 0, timestamp 999 maps to block 499. Local-safe must be
+	// at or past the anchor block (otherwise the chain hasn't crossed
+	// activation and the PreActivation path would have fired upstream).
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 600}
 	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
-	anchorBlock := eth.BlockID{Hash: common.Hash{0xa1}, Number: 80}
+
+	cfg := &rollup.Config{BlockTime: 2}
+	anchorRef := eth.L2BlockRef{Hash: common.Hash{0xa1}, Number: 499}
 
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
 	sa := &mockSuperAuthority{
-		// Empty-verifier post-activation case under the new contract: the
-		// supernode contributes its activation anchor as a concrete block.
-		fullyVerifiedL2Head:       anchorBlock,
 		fullyVerifiedL2HeadSource: rollup.VerifierHeadAnchor,
+		fullyVerifiedTimestamp:    999,
 	}
 	ec := NewEngineController(
 		context.Background(),
 		mockEngine,
 		testlog.Logger(t, 0),
 		metrics.NoopMetrics,
-		&rollup.Config{},
+		cfg,
 		&sync.Config{},
 		&testutils.MockL1Source{},
 		emitter,
@@ -54,19 +58,16 @@ func TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis(t *testing.T) {
 	ec.SetLocalSafeHead(localSafe)
 	ec.SetFinalizedHead(localFinalized)
 
-	// Anchor block 80 is bounded above by local-safe 100, so we expect the EL
-	// canonicality lookups to be exercised.
-	anchorRef := eth.L2BlockRef{Hash: anchorBlock.Hash, Number: anchorBlock.Number}
-	mockEngine.ExpectL2BlockRefByHash(anchorBlock.Hash, anchorRef, nil)
-	mockEngine.ExpectL2BlockRefByNumber(anchorBlock.Number, anchorRef, nil)
+	mockEngine.ExpectL2BlockRefByNumber(uint64(499), anchorRef, nil)
 
 	got := ec.SafeL2Head()
 	require.NotEqual(t, uint64(0), got.Number,
 		"SafeL2Head must not drop to genesis when local-safe (%d) and local-finalized (%d) are non-zero. "+
 			"Pre-fix, empty verifier returned (BlockID{}, false) and SafeL2Head fetched L2BlockRefByNumber(0). "+
-			"Post-fix, Anchor source carries a concrete activation-anchor block (ethereum-optimism/optimism#20944).",
+			"Post-fix, Anchor source carries the pre-activation cap timestamp and the engine controller "+
+			"resolves the canonical L2 block at that timestamp (ethereum-optimism/optimism#20944).",
 		localSafe.Number, localFinalized.Number)
-	require.Equal(t, anchorRef, got, "SafeL2Head must return the anchor block when verifier is active but empty")
+	require.Equal(t, anchorRef, got, "SafeL2Head must return the canonical anchor block at the cap timestamp")
 }
 
 // TestSafeL2Head_VerifierError_FloorsAtFinalized exercises bug A and the

--- a/op-node/rollup/engine/super_authority_safe_head_test.go
+++ b/op-node/rollup/engine/super_authority_safe_head_test.go
@@ -1,0 +1,146 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+// TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis exercises bug B.
+//
+// Under the previous boolean contract, an active verifier with no entries for
+// this chain returned (BlockID{}, false), and engine_controller.SafeL2Head
+// resolved the empty BlockID to L2 genesis via L2BlockRefByNumber(0). That
+// dropped cross-safe to genesis once the chain hadn't yet been covered by the
+// verifier's depset — see ethereum-optimism/optimism#20944.
+//
+// Under the tri-state contract, that scenario surfaces as Source = Anchor with
+// a concrete activation-anchor block. SafeL2Head bounds by local-safe and
+// returns the verifier's contribution. SafeL2Head must never return the L2
+// genesis block when local-safe and local-finalized are non-zero.
+func TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	anchorBlock := eth.BlockID{Hash: common.Hash{0xa1}, Number: 80}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		// Empty-verifier post-activation case under the new contract: the
+		// supernode contributes its activation anchor as a concrete block.
+		fullyVerifiedL2Head:       anchorBlock,
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadAnchor,
+		fullyVerifiedStatus:       rollup.VerifierHeadOk,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(localFinalized)
+
+	// Anchor block 80 is bounded above by local-safe 100, so we expect the EL
+	// canonicality lookups to be exercised.
+	anchorRef := eth.L2BlockRef{Hash: anchorBlock.Hash, Number: anchorBlock.Number}
+	mockEngine.ExpectL2BlockRefByHash(anchorBlock.Hash, anchorRef, nil)
+	mockEngine.ExpectL2BlockRefByNumber(anchorBlock.Number, anchorRef, nil)
+
+	got := ec.SafeL2Head()
+	require.NotEqual(t, uint64(0), got.Number,
+		"SafeL2Head must not drop to genesis when local-safe (%d) and local-finalized (%d) are non-zero. "+
+			"Pre-fix, empty verifier returned (BlockID{}, false) and SafeL2Head fetched L2BlockRefByNumber(0). "+
+			"Post-fix, Anchor source carries a concrete activation-anchor block (ethereum-optimism/optimism#20944).",
+		localSafe.Number, localFinalized.Number)
+	require.Equal(t, anchorRef, got, "SafeL2Head must return the anchor block when verifier is active but empty")
+}
+
+// TestSafeL2Head_VerifierError_FloorsAtFinalized exercises bug A and the
+// verifier-error portion of bug D.
+//
+// Under the previous boolean contract, a verifier read error returned
+// (BlockID{}, true) which engine_controller.SafeL2Head interpreted as
+// "fall back to local-safe", advancing cross-safe past verification. Under the
+// tri-state contract, errors surface as VerifierHeadHoldPrevious and the caller
+// floors at FinalizedHead — never below.
+func TestSafeL2Head_VerifierError_FloorsAtFinalized(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedStatus: rollup.VerifierHeadHoldPrevious,
+		// FinalizedHead is also consulted; configure it to PreActivation so the
+		// floor resolves to localFinalizedHead.
+		finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
+		finalizedStatus:       rollup.VerifierHeadOk,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(localFinalized)
+
+	got := ec.SafeL2Head()
+	require.NotEqual(t, localSafe, got,
+		"SafeL2Head must not return localSafeHead on verifier error; "+
+			"the previous (BlockID{}, true) signal advanced cross-safe past verification (bug A).")
+	require.Equal(t, localFinalized, got,
+		"SafeL2Head must floor at localFinalizedHead on verifier error (HoldPrevious semantics).")
+}
+
+// TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero documents the
+// error-after-startup trace: verifier errors on the first call, no cached
+// super-authority finalized head yet, localSafeHead and localFinalizedHead are
+// both zero. The expected behavior is a zero L2BlockRef — not garbage, not
+// genesis, not localFinalizedHead. This is the cold-start safety property the
+// design discussion explicitly called for.
+func TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero(t *testing.T) {
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		finalizedStatus: rollup.VerifierHeadHoldPrevious,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	// localSafeHead / localFinalizedHead deliberately left as zero.
+
+	got := ec.FinalizedHead()
+	require.Equal(t, eth.L2BlockRef{}, got,
+		"FinalizedHead on cold-start HoldPrevious must return zero L2BlockRef, not garbage")
+	require.Equal(t, common.Hash{}, got.Hash,
+		"resulting ForkchoiceUpdate sends a zero finalized hash, preserving the EL's own label")
+}

--- a/op-node/rollup/engine/super_authority_safe_head_test.go
+++ b/op-node/rollup/engine/super_authority_safe_head_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
-// TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis exercises bug B.
+// TestSafeL2Head_EmptyVerifier_FloorsAtFinalized exercises bug B.
 //
 // Under the previous boolean contract, an active verifier with no entries for
 // this chain returned (BlockID{}, false), and engine_controller.SafeL2Head
@@ -23,21 +23,14 @@ import (
 // dropped cross-safe to genesis once the chain hadn't yet been covered by the
 // verifier's depset — see ethereum-optimism/optimism#20944.
 //
-// Under the tri-state contract, that scenario surfaces as Source = Anchor with
-// a concrete activation-anchor block. SafeL2Head bounds by local-safe and
-// returns the verifier's contribution. SafeL2Head must never return the L2
-// genesis block when local-safe and local-finalized are non-zero.
-func TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis(t *testing.T) {
-	// Realistic shape: local-safe has crossed activation. With BlockTime=2 and
-	// genesis at time 0, timestamp 999 maps to block 499. Local-safe must be
-	// at or past the anchor block (otherwise the chain hasn't crossed
-	// activation and the PreActivation path would have fired upstream).
+// Under the tri-state contract, that scenario surfaces as Source = Anchor.
+// SafeL2Head handles the anchor conservatively by flooring at FinalizedHead,
+// never local-safe and never a synthetic genesis lookup.
+func TestSafeL2Head_EmptyVerifier_FloorsAtFinalized(t *testing.T) {
 	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 600}
 	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
 
 	cfg := &rollup.Config{BlockTime: 2}
-	anchorRef := eth.L2BlockRef{Hash: common.Hash{0xa1}, Number: 499}
-
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
 	sa := &mockSuperAuthority{
@@ -58,16 +51,13 @@ func TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis(t *testing.T) {
 	ec.SetLocalSafeHead(localSafe)
 	ec.SetFinalizedHead(localFinalized)
 
-	mockEngine.ExpectL2BlockRefByNumber(uint64(499), anchorRef, nil)
-
 	got := ec.SafeL2Head()
 	require.NotEqual(t, uint64(0), got.Number,
 		"SafeL2Head must not drop to genesis when local-safe (%d) and local-finalized (%d) are non-zero. "+
 			"Pre-fix, empty verifier returned (BlockID{}, false) and SafeL2Head fetched L2BlockRefByNumber(0). "+
-			"Post-fix, Anchor source carries the pre-activation cap timestamp and the engine controller "+
-			"resolves the canonical L2 block at that timestamp (ethereum-optimism/optimism#20944).",
+			"Post-fix, Anchor source floors at FinalizedHead (ethereum-optimism/optimism#20944).",
 		localSafe.Number, localFinalized.Number)
-	require.Equal(t, anchorRef, got, "SafeL2Head must return the canonical anchor block at the cap timestamp")
+	require.Equal(t, localFinalized, got, "SafeL2Head must floor at FinalizedHead for anchor results")
 }
 
 // TestSafeL2Head_VerifierError_FloorsAtFinalized exercises bug A and the
@@ -112,12 +102,10 @@ func TestSafeL2Head_VerifierError_FloorsAtFinalized(t *testing.T) {
 		"SafeL2Head must floor at localFinalizedHead on verifier error (HoldPrevious semantics).")
 }
 
-// TestSafeL2Head_HoldPrevious_UsesCanonicalCache verifies the cross-safe
-// cache: on HoldPrevious, return the previously-resolved cross-safe head if
-// it is still canonical on the EL, rather than dropping all the way to
-// FinalizedHead. Preserves cross-safe progress across transient verifier
-// outages.
-func TestSafeL2Head_HoldPrevious_UsesCanonicalCache(t *testing.T) {
+// TestSafeL2Head_HoldPrevious_UsesFinalized verifies the simplified
+// conservative fallback: on HoldPrevious, return FinalizedHead rather than
+// trying to preserve the previous cross-safe head with an extra cache.
+func TestSafeL2Head_HoldPrevious_UsesFinalized(t *testing.T) {
 	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
 	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
 	verifiedBlock := eth.BlockID{Hash: common.Hash{0xcc}, Number: 80}
@@ -128,8 +116,7 @@ func TestSafeL2Head_HoldPrevious_UsesCanonicalCache(t *testing.T) {
 	sa := &mockSuperAuthority{
 		fullyVerifiedL2Head:       verifiedBlock,
 		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
-		// Finalized stays PreActivation so the floor would resolve to
-		// localFinalized — distinguishable from the cache hit at block 80.
+		// Finalized stays PreActivation so the floor resolves to localFinalized.
 		finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
 	}
 	ec := NewEngineController(
@@ -146,65 +133,16 @@ func TestSafeL2Head_HoldPrevious_UsesCanonicalCache(t *testing.T) {
 	ec.SetLocalSafeHead(localSafe)
 	ec.SetFinalizedHead(localFinalized)
 
-	// First call: verified path populates the cache.
-	mockEngine.ExpectL2BlockRefByHash(verifiedBlock.Hash, verifiedRef, nil)
+	// First call: verified path returns cross-safe.
 	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
 	got := ec.SafeL2Head()
 	require.Equal(t, verifiedRef, got, "first call should resolve via the Verified path")
 
-	// Verifier now returns HoldPrevious; cache canonicality re-validates and is
-	// returned in preference to flooring at finalized.
+	// Verifier now returns HoldPrevious; the simplified path falls back to
+	// finalized directly, without introducing a separate cross-safe cache.
 	sa.holdPreviousVerified = true
-	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
 	got = ec.SafeL2Head()
-	require.Equal(t, verifiedRef, got,
-		"HoldPrevious must return the canonicality-validated cache, not drop to localFinalized")
-}
-
-// TestSafeL2Head_HoldPrevious_NonCanonicalCache_FloorsAtFinalized verifies
-// that the cross-safe cache is cleared when the cached block is no longer
-// canonical (reorg), and the caller then floors at FinalizedHead.
-func TestSafeL2Head_HoldPrevious_NonCanonicalCache_FloorsAtFinalized(t *testing.T) {
-	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
-	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
-	verifiedBlock := eth.BlockID{Hash: common.Hash{0xcc}, Number: 80}
-	verifiedRef := eth.L2BlockRef{Hash: verifiedBlock.Hash, Number: verifiedBlock.Number}
-
-	mockEngine := &testutils.MockEngine{}
-	emitter := &testutils.MockEmitter{}
-	sa := &mockSuperAuthority{
-		fullyVerifiedL2Head:       verifiedBlock,
-		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
-		finalizedL2HeadSource:     rollup.VerifierHeadPreActivation,
-	}
-	ec := NewEngineController(
-		context.Background(),
-		mockEngine,
-		testlog.Logger(t, 0),
-		metrics.NoopMetrics,
-		&rollup.Config{},
-		&sync.Config{},
-		&testutils.MockL1Source{},
-		emitter,
-		sa,
-	)
-	ec.SetLocalSafeHead(localSafe)
-	ec.SetFinalizedHead(localFinalized)
-
-	// First call: verified path populates the cache.
-	mockEngine.ExpectL2BlockRefByHash(verifiedBlock.Hash, verifiedRef, nil)
-	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
-	_ = ec.SafeL2Head()
-	require.Equal(t, verifiedRef, ec.superAuthoritySafeHead, "cache must be populated after successful resolution")
-
-	// Simulate a reorg: the EL now reports a different canonical block at the
-	// cached number. HoldPrevious must clear the cache and floor at finalized.
-	sa.holdPreviousVerified = true
-	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number,
-		eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: verifiedBlock.Number}, nil)
-	got := ec.SafeL2Head()
-	require.Equal(t, localFinalized, got, "non-canonical cache must clear and floor at finalized")
-	require.Equal(t, eth.L2BlockRef{}, ec.superAuthoritySafeHead, "cache must be cleared after non-canonical reorg")
+	require.Equal(t, localFinalized, got, "HoldPrevious must fall back to FinalizedHead")
 }
 
 // TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero documents the

--- a/op-node/rollup/engine/super_authority_safe_head_test.go
+++ b/op-node/rollup/engine/super_authority_safe_head_test.go
@@ -113,6 +113,105 @@ func TestSafeL2Head_VerifierError_FloorsAtFinalized(t *testing.T) {
 		"SafeL2Head must floor at localFinalizedHead on verifier error (HoldPrevious semantics).")
 }
 
+// TestSafeL2Head_HoldPrevious_UsesCanonicalCache verifies the cross-safe
+// cache: on HoldPrevious, return the previously-resolved cross-safe head if
+// it is still canonical on the EL, rather than dropping all the way to
+// FinalizedHead. Preserves cross-safe progress across transient verifier
+// outages.
+func TestSafeL2Head_HoldPrevious_UsesCanonicalCache(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	verifiedBlock := eth.BlockID{Hash: common.Hash{0xcc}, Number: 80}
+	verifiedRef := eth.L2BlockRef{Hash: verifiedBlock.Hash, Number: verifiedBlock.Number}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2Head:       verifiedBlock,
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+		fullyVerifiedStatus:       rollup.VerifierHeadOk,
+		// Finalized stays PreActivation so the floor would resolve to
+		// localFinalized — distinguishable from the cache hit at block 80.
+		finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
+		finalizedStatus:       rollup.VerifierHeadOk,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(localFinalized)
+
+	// First call: verified path populates the cache.
+	mockEngine.ExpectL2BlockRefByHash(verifiedBlock.Hash, verifiedRef, nil)
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
+	got := ec.SafeL2Head()
+	require.Equal(t, verifiedRef, got, "first call should resolve via the Verified path")
+
+	// Verifier now returns HoldPrevious; cache canonicality re-validates and is
+	// returned in preference to flooring at finalized.
+	sa.fullyVerifiedStatus = rollup.VerifierHeadHoldPrevious
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
+	got = ec.SafeL2Head()
+	require.Equal(t, verifiedRef, got,
+		"HoldPrevious must return the canonicality-validated cache, not drop to localFinalized")
+}
+
+// TestSafeL2Head_HoldPrevious_NonCanonicalCache_FloorsAtFinalized verifies
+// that the cross-safe cache is cleared when the cached block is no longer
+// canonical (reorg), and the caller then floors at FinalizedHead.
+func TestSafeL2Head_HoldPrevious_NonCanonicalCache_FloorsAtFinalized(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	verifiedBlock := eth.BlockID{Hash: common.Hash{0xcc}, Number: 80}
+	verifiedRef := eth.L2BlockRef{Hash: verifiedBlock.Hash, Number: verifiedBlock.Number}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2Head:       verifiedBlock,
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+		fullyVerifiedStatus:       rollup.VerifierHeadOk,
+		finalizedL2HeadSource:     rollup.VerifierHeadPreActivation,
+		finalizedStatus:           rollup.VerifierHeadOk,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(localFinalized)
+
+	// First call: verified path populates the cache.
+	mockEngine.ExpectL2BlockRefByHash(verifiedBlock.Hash, verifiedRef, nil)
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
+	_ = ec.SafeL2Head()
+	require.Equal(t, verifiedRef, ec.superAuthoritySafeHead, "cache must be populated after successful resolution")
+
+	// Simulate a reorg: the EL now reports a different canonical block at the
+	// cached number. HoldPrevious must clear the cache and floor at finalized.
+	sa.fullyVerifiedStatus = rollup.VerifierHeadHoldPrevious
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number,
+		eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: verifiedBlock.Number}, nil)
+	got := ec.SafeL2Head()
+	require.Equal(t, localFinalized, got, "non-canonical cache must clear and floor at finalized")
+	require.Equal(t, eth.L2BlockRef{}, ec.superAuthoritySafeHead, "cache must be cleared after non-canonical reorg")
+}
+
 // TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero documents the
 // error-after-startup trace: verifier errors on the first call, no cached
 // super-authority finalized head yet, localSafeHead and localFinalizedHead are

--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -39,10 +39,15 @@ func (s VerifierHeadSource) String() string {
 }
 
 // VerifierHead is the result of a SuperAuthority head query.
-// Block is zero when Source == VerifierHeadPreActivation.
+//   - Source == PreActivation: Block and Timestamp are zero; caller uses local.
+//   - Source == Verified:      Block is the verified tip; Timestamp is its L2 time.
+//   - Source == Anchor:        Block is zero; Timestamp is the pre-activation cap
+//     (`activationTimestamp - 1`); caller resolves the canonical L2 block at that
+//     timestamp itself.
 type VerifierHead struct {
-	Block  eth.BlockID
-	Source VerifierHeadSource
+	Block     eth.BlockID
+	Timestamp uint64
+	Source    VerifierHeadSource
 }
 
 // SuperAuthority is the cross-chain attestation surface a supernode exposes to

--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -17,8 +17,8 @@ const (
 	// current local-safe timestamp. Caller uses local-safe / local-finalized.
 	VerifierHeadPreActivation VerifierHeadSource = iota
 	// VerifierHeadAnchor: at least one active verifier has no verified-DB entry
-	// for this chain yet. Block is the per-(chain, verifier) activation-anchor:
-	// the L2 block at `verifier.ActivationTimestamp() - 1`.
+	// for this chain yet. Timestamp is the pre-activation cap:
+	// `verifier.ActivationTimestamp() - 1`.
 	VerifierHeadAnchor
 	// VerifierHeadVerified: Block is the oldest verified tip across active verifiers.
 	VerifierHeadVerified
@@ -42,8 +42,7 @@ func (s VerifierHeadSource) String() string {
 //   - Source == PreActivation: Block and Timestamp are zero; caller uses local.
 //   - Source == Verified:      Block is the verified tip; Timestamp is its L2 time.
 //   - Source == Anchor:        Block is zero; Timestamp is the pre-activation cap
-//     (`activationTimestamp - 1`); caller resolves the canonical L2 block at that
-//     timestamp itself.
+//     (`activationTimestamp - 1`); caller decides how conservatively to apply it.
 type VerifierHead struct {
 	Block     eth.BlockID
 	Timestamp uint64

--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -1,25 +1,105 @@
 package rollup
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// SuperAuthority provides payload validation functionality from a supernode.
-// When running inside a supernode, this allows the engine controller to check
-// if payloads are denied before applying them, enabling coordinated block invalidation.
+// VerifierHeadSource classifies the origin of a head reported by the SuperAuthority.
+type VerifierHeadSource uint8
+
+const (
+	// VerifierHeadPreActivation signals that every registered verifier is still
+	// inactive at the current local-safe timestamp. The caller should use its
+	// local-safe / local-finalized head — pre-activation content is verified by
+	// consensus alone.
+	VerifierHeadPreActivation VerifierHeadSource = iota
+	// VerifierHeadAnchor signals that at least one active verifier has no
+	// verified-DB entry that includes this chain yet (the chain hasn't joined
+	// the verifier's depset, or the verifier just started). The Block field
+	// carries the per-(chain, verifier) activation-anchor block — the L2 block
+	// at timestamp `verifier.ActivationTimestamp() - 1`.
+	VerifierHeadAnchor
+	// VerifierHeadVerified signals the head is the verifier's verified tip for
+	// this chain. The Block field carries that tip.
+	VerifierHeadVerified
+)
+
+// String implements fmt.Stringer. The exhaustive switch is the structural gate
+// that forces new VerifierHeadSource variants to update every consumer.
+func (s VerifierHeadSource) String() string {
+	switch s {
+	case VerifierHeadPreActivation:
+		return "pre-activation"
+	case VerifierHeadAnchor:
+		return "anchor"
+	case VerifierHeadVerified:
+		return "verified"
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(s))
+	}
+}
+
+// VerifierHeadStatus classifies whether a SuperAuthority call produced a usable
+// answer or signalled a transient read failure.
+type VerifierHeadStatus uint8
+
+const (
+	// VerifierHeadOk signals the returned VerifierHead is valid and should be
+	// honored. The caller still bounds the result by its own local-safe head
+	// and validates EL canonicality.
+	VerifierHeadOk VerifierHeadStatus = iota
+	// VerifierHeadHoldPrevious signals a transient verifier read failure. The
+	// caller must not advance the head and must not fall back to local-safe;
+	// floor at FinalizedHead instead.
+	VerifierHeadHoldPrevious
+)
+
+// String implements fmt.Stringer.
+func (s VerifierHeadStatus) String() string {
+	switch s {
+	case VerifierHeadOk:
+		return "ok"
+	case VerifierHeadHoldPrevious:
+		return "hold-previous"
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(s))
+	}
+}
+
+// VerifierHead is the tri-state head reported by the SuperAuthority.
+// Block is zero when Source == VerifierHeadPreActivation.
+type VerifierHead struct {
+	Block  eth.BlockID
+	Source VerifierHeadSource
+}
+
+// SuperAuthority provides cross-verified safe / finalized head reporting and
+// payload deny-list checks from a supernode. When running inside a supernode,
+// this is what the engine controller consults to decide what to publish as
+// SafeL2Head / FinalizedHead and whether to apply a payload.
 type SuperAuthority interface {
-	// FullyVerifiedL2Head returns the fully verified L2 head block reference.
-	// The second return value indicates whether the caller should fall back to local-safe.
-	// If useLocalSafe is true, the BlockID return value should be ignored and local-safe used instead.
-	// If useLocalSafe is false, the BlockID is the cross-verified safe head.
-	FullyVerifiedL2Head() (head eth.BlockID, useLocalSafe bool)
-	// FinalizedL2Head returns the finalized L2 head block reference.
-	// The second return value indicates whether the caller should fall back to local-finalized.
-	// If useLocalFinalized is true, the BlockID return value should be ignored and local-finalized used instead.
-	// If useLocalFinalized is false, the BlockID is the cross-verified finalized head.
-	FinalizedL2Head() (head eth.BlockID, useLocalFinalized bool)
+	// FullyVerifiedL2Head returns the cross-verified safe L2 head, as a tri-state.
+	//
+	// On VerifierHeadOk:
+	//   - Source == VerifierHeadPreActivation: caller uses local-safe.
+	//   - Source == VerifierHeadAnchor: Block is the activation-anchor block,
+	//     contributed by at least one active verifier with no entry for this chain.
+	//   - Source == VerifierHeadVerified: Block is the oldest verified tip across
+	//     active verifiers.
+	// On VerifierHeadHoldPrevious: a verifier read failed; the caller must hold
+	// the previous value and floor at FinalizedHead — never advance, never fall
+	// back to local-safe.
+	FullyVerifiedL2Head() (VerifierHead, VerifierHeadStatus)
+
+	// FinalizedL2Head returns the cross-verified finalized L2 head, as a tri-state
+	// with the same semantics as FullyVerifiedL2Head. The finalized head is
+	// caller-cacheable because finalized blocks cannot reorg.
+	FinalizedL2Head() (VerifierHead, VerifierHeadStatus)
+
 	// IsDenied checks if a payload hash is denied at the given block number.
 	// Returns true if the payload should not be applied.
 	// The error indicates if the check could not be performed (should be logged but not fatal).

--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -1,6 +1,7 @@
 package rollup
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -12,24 +13,18 @@ import (
 type VerifierHeadSource uint8
 
 const (
-	// VerifierHeadPreActivation signals that every registered verifier is still
-	// inactive at the current local-safe timestamp. The caller should use its
-	// local-safe / local-finalized head — pre-activation content is verified by
-	// consensus alone.
+	// VerifierHeadPreActivation: every registered verifier is inactive at the
+	// current local-safe timestamp. Caller uses local-safe / local-finalized.
 	VerifierHeadPreActivation VerifierHeadSource = iota
-	// VerifierHeadAnchor signals that at least one active verifier has no
-	// verified-DB entry that includes this chain yet (the chain hasn't joined
-	// the verifier's depset, or the verifier just started). The Block field
-	// carries the per-(chain, verifier) activation-anchor block — the L2 block
-	// at timestamp `verifier.ActivationTimestamp() - 1`.
+	// VerifierHeadAnchor: at least one active verifier has no verified-DB entry
+	// for this chain yet. Block is the per-(chain, verifier) activation-anchor:
+	// the L2 block at `verifier.ActivationTimestamp() - 1`.
 	VerifierHeadAnchor
-	// VerifierHeadVerified signals the head is the verifier's verified tip for
-	// this chain. The Block field carries that tip.
+	// VerifierHeadVerified: Block is the oldest verified tip across active verifiers.
 	VerifierHeadVerified
 )
 
-// String implements fmt.Stringer. The exhaustive switch is the structural gate
-// that forces new VerifierHeadSource variants to update every consumer.
+// Exhaustive — adding a variant requires updating every consumer's switch.
 func (s VerifierHeadSource) String() string {
 	switch s {
 	case VerifierHeadPreActivation:
@@ -43,66 +38,29 @@ func (s VerifierHeadSource) String() string {
 	}
 }
 
-// VerifierHeadStatus classifies whether a SuperAuthority call produced a usable
-// answer or signalled a transient read failure.
-type VerifierHeadStatus uint8
-
-const (
-	// VerifierHeadOk signals the returned VerifierHead is valid and should be
-	// honored. The caller still bounds the result by its own local-safe head
-	// and validates EL canonicality.
-	VerifierHeadOk VerifierHeadStatus = iota
-	// VerifierHeadHoldPrevious signals a transient verifier read failure. The
-	// caller must not advance the head and must not fall back to local-safe;
-	// floor at FinalizedHead instead.
-	VerifierHeadHoldPrevious
-)
-
-// String implements fmt.Stringer.
-func (s VerifierHeadStatus) String() string {
-	switch s {
-	case VerifierHeadOk:
-		return "ok"
-	case VerifierHeadHoldPrevious:
-		return "hold-previous"
-	default:
-		return fmt.Sprintf("unknown(%d)", uint8(s))
-	}
-}
-
-// VerifierHead is the tri-state head reported by the SuperAuthority.
+// VerifierHead is the result of a SuperAuthority head query.
 // Block is zero when Source == VerifierHeadPreActivation.
 type VerifierHead struct {
 	Block  eth.BlockID
 	Source VerifierHeadSource
 }
 
-// SuperAuthority provides cross-verified safe / finalized head reporting and
-// payload deny-list checks from a supernode. When running inside a supernode,
-// this is what the engine controller consults to decide what to publish as
-// SafeL2Head / FinalizedHead and whether to apply a payload.
+// SuperAuthority is the cross-chain attestation surface a supernode exposes to
+// op-node: cross-verified safe / finalized head reporting and payload deny-list
+// checks. Returned heads are consumed by the engine controller to choose what
+// to publish as SafeL2Head / FinalizedHead and whether to apply a payload.
 type SuperAuthority interface {
-	// FullyVerifiedL2Head returns the cross-verified safe L2 head, as a tri-state.
-	//
-	// On VerifierHeadOk:
-	//   - Source == VerifierHeadPreActivation: caller uses local-safe.
-	//   - Source == VerifierHeadAnchor: Block is the activation-anchor block,
-	//     contributed by at least one active verifier with no entry for this chain.
-	//   - Source == VerifierHeadVerified: Block is the oldest verified tip across
-	//     active verifiers.
-	// On VerifierHeadHoldPrevious: a verifier read failed; the caller must hold
-	// the previous value and floor at FinalizedHead — never advance, never fall
-	// back to local-safe.
-	FullyVerifiedL2Head() (VerifierHead, VerifierHeadStatus)
+	// FullyVerifiedL2Head returns the cross-verified safe L2 head.
+	// `ok=false` signals a transient read failure — caller must hold the
+	// previous value (floored at FinalizedHead), never fall back to local-safe.
+	FullyVerifiedL2Head(ctx context.Context) (head VerifierHead, ok bool)
 
-	// FinalizedL2Head returns the cross-verified finalized L2 head, as a tri-state
-	// with the same semantics as FullyVerifiedL2Head. The finalized head is
-	// caller-cacheable because finalized blocks cannot reorg.
-	FinalizedL2Head() (VerifierHead, VerifierHeadStatus)
+	// FinalizedL2Head is the finalized analogue of FullyVerifiedL2Head.
+	// Finalized blocks cannot reorg, so the caller may cache the result.
+	FinalizedL2Head(ctx context.Context) (head VerifierHead, ok bool)
 
-	// IsDenied checks if a payload hash is denied at the given block number.
-	// Returns true if the payload should not be applied.
-	// The error indicates if the check could not be performed (should be logged but not fatal).
+	// IsDenied reports whether a payload hash is denied at the given block
+	// number. Errors are logged but not fatal.
 	IsDenied(blockNumber uint64, payloadHash common.Hash) (bool, error)
 }
 

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -52,22 +52,16 @@ type VerificationActivity interface {
 	// data at or before that timestamp as safe without consulting this activity.
 	IsActiveAt(ts uint64) bool
 
-	// ActivationTimestamp returns the L2 timestamp at which this verification
-	// activity becomes active. Blocks with timestamp < ActivationTimestamp() are
-	// pre-activation and are verified by consensus alone. Used by the
-	// SuperAuthority to compute the per-(chain, verifier) activation-anchor
-	// block when the verifier is active but has no verified-DB entry for the
-	// chain (e.g. the chain hasn't joined the depset yet).
-	ActivationTimestamp() uint64
-
-	// LatestVerifiedL2Block returns the latest verified L2 block and its
-	// timestamp. (empty, 0, nil) means nothing verified yet; a non-nil error
-	// means the verifier is transiently unavailable.
+	// LatestVerifiedL2Block returns the latest verified L2 block.
+	// (block, ts, nil) — verified tip at ts.
+	// (empty, ts, nil) — no verified entry; ts is the pre-activation cap the
+	//   caller should resolve to a canonical L2 block. ts==0 means no cap.
+	// (empty, 0, err) — verifier is transiently unavailable.
 	LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error)
 
 	// VerifiedBlockAtL1 returns the latest verified L2 block whose data was
-	// derived from or before the supplied L1 block. (empty, 0, nil) means no
-	// such entry yet; a non-nil error means the verifier is transiently
-	// unavailable.
+	// derived from or before the supplied L1 block. Return shape matches
+	// LatestVerifiedL2Block: an empty BlockID with non-zero ts is a cap, not a
+	// failure.
 	VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64, error)
 }

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -52,6 +52,14 @@ type VerificationActivity interface {
 	// data at or before that timestamp as safe without consulting this activity.
 	IsActiveAt(ts uint64) bool
 
+	// ActivationTimestamp returns the L2 timestamp at which this verification
+	// activity becomes active. Blocks with timestamp < ActivationTimestamp() are
+	// pre-activation and are verified by consensus alone. Used by the
+	// SuperAuthority to compute the per-(chain, verifier) activation-anchor
+	// block when the verifier is active but has no verified-DB entry for the
+	// chain (e.g. the chain hasn't joined the depset yet).
+	ActivationTimestamp() uint64
+
 	// LatestVerifiedL2Block returns the latest verified L2 block and its
 	// timestamp. (empty, 0, nil) means nothing verified yet; a non-nil error
 	// means the verifier is transiently unavailable.

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1199,40 +1199,53 @@ func (i *Interop) ActivationTimestamp() uint64 {
 	return i.activationTimestamp
 }
 
-// LatestVerifiedL2Block returns the latest verified L2 block for chainID and
-// its timestamp. (empty, 0, nil) means nothing verified yet; a non-nil error
-// means verifiedDB could not be read.
+// activationCap is the L2 timestamp the verifier reports as a cap when it has
+// no verified entry for the caller's chain. The caller resolves the canonical
+// L2 block at this timestamp (the pre-activation anchor). Returns 0 when no
+// activation timestamp is configured — caller treats that as "no contribution".
+func (i *Interop) activationCap() uint64 {
+	if i.activationTimestamp == 0 {
+		return 0
+	}
+	return i.activationTimestamp - 1
+}
+
+// LatestVerifiedL2Block returns the latest verified L2 block for chainID.
+// (empty, capTimestamp, nil) means nothing verified — capTimestamp is the
+// pre-activation anchor (`activationTimestamp - 1`) for the caller to resolve.
+// A non-nil error means verifiedDB could not be read.
 func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error) {
 	emptyBlock := eth.BlockID{}
 	ts, ok := i.verifiedDB.LastTimestamp()
 	if !ok {
-		return emptyBlock, 0, nil
+		return emptyBlock, i.activationCap(), nil
 	}
 	res, err := i.verifiedDB.Get(ts)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			return emptyBlock, 0, nil
+			return emptyBlock, i.activationCap(), nil
 		}
 		return emptyBlock, 0, fmt.Errorf("LatestVerifiedL2Block: read verifiedDB at %d: %w", ts, err)
 	}
 	head, ok := res.L2Heads[chainID]
 	if !ok {
-		return emptyBlock, 0, nil
+		return emptyBlock, i.activationCap(), nil
 	}
 	return head, ts, nil
 }
 
 // VerifiedBlockAtL1 returns the latest verified L2 block for chainID whose
-// L1 inclusion is at or below l1Block. (empty, 0, nil) means no match;
-// a non-nil error means verifiedDB could not be read.
+// L1 inclusion is at or below l1Block. (empty, capTimestamp, nil) means no
+// match — capTimestamp is the pre-activation anchor for the caller to resolve.
+// A non-nil error means verifiedDB could not be read.
 func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64, error) {
 	if l1Block == (eth.L1BlockRef{}) {
-		return eth.BlockID{}, 0, nil
+		return eth.BlockID{}, i.activationCap(), nil
 	}
 
 	lastTs, ok := i.verifiedDB.LastTimestamp()
 	if !ok {
-		return eth.BlockID{}, 0, nil
+		return eth.BlockID{}, i.activationCap(), nil
 	}
 
 	// activationTimestamp is the floor: no verified results exist before activation.
@@ -1251,13 +1264,13 @@ func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef)
 		if result.L1Inclusion.Number <= l1Block.Number {
 			head, ok := result.L2Heads[chainID]
 			if !ok {
-				return eth.BlockID{}, 0, nil
+				return eth.BlockID{}, i.activationCap(), nil
 			}
 			return head, ts, nil
 		}
 	}
 
-	return eth.BlockID{}, 0, nil
+	return eth.BlockID{}, i.activationCap(), nil
 }
 
 // Reset is intentionally a no-op for interop.

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1191,6 +1191,14 @@ func (i *Interop) IsActiveAt(ts uint64) bool {
 	return ts >= i.activationTimestamp
 }
 
+// ActivationTimestamp returns the immutable protocol-defined interop activation
+// timestamp for this verifier. Used by the SuperAuthority to compute the
+// per-(chain, verifier) activation-anchor block and by RPC surfaces that expose
+// the configured activation point.
+func (i *Interop) ActivationTimestamp() uint64 {
+	return i.activationTimestamp
+}
+
 // LatestVerifiedL2Block returns the latest verified L2 block for chainID and
 // its timestamp. (empty, 0, nil) means nothing verified yet; a non-nil error
 // means verifiedDB could not be read.

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1192,17 +1192,14 @@ func (i *Interop) IsActiveAt(ts uint64) bool {
 }
 
 // ActivationTimestamp returns the immutable protocol-defined interop activation
-// timestamp for this verifier. Used by the SuperAuthority to compute the
-// per-(chain, verifier) activation-anchor block and by RPC surfaces that expose
-// the configured activation point.
+// timestamp for RPC and test surfaces that expose the configured activation point.
 func (i *Interop) ActivationTimestamp() uint64 {
 	return i.activationTimestamp
 }
 
 // activationCap is the L2 timestamp the verifier reports as a cap when it has
-// no verified entry for the caller's chain. The caller resolves the canonical
-// L2 block at this timestamp (the pre-activation anchor). Returns 0 when no
-// activation timestamp is configured — caller treats that as "no contribution".
+// no verified entry for the caller's chain. Returns 0 when no activation
+// timestamp is configured — caller treats that as "no contribution".
 func (i *Interop) activationCap() uint64 {
 	if i.activationTimestamp == 0 {
 		return 0
@@ -1212,7 +1209,7 @@ func (i *Interop) activationCap() uint64 {
 
 // LatestVerifiedL2Block returns the latest verified L2 block for chainID.
 // (empty, capTimestamp, nil) means nothing verified — capTimestamp is the
-// pre-activation anchor (`activationTimestamp - 1`) for the caller to resolve.
+// pre-activation cap (`activationTimestamp - 1`).
 // A non-nil error means verifiedDB could not be read.
 func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error) {
 	emptyBlock := eth.BlockID{}

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -2838,7 +2838,9 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		blockID, ts, err := h.interop.VerifiedBlockAtL1(h.Mock(10).id, eth.L1BlockRef{})
 		require.NoError(t, err)
 		require.Equal(t, eth.BlockID{}, blockID)
-		require.Equal(t, uint64(0), ts)
+		// Empty result returns the pre-activation cap (activationTimestamp-1)
+		// so the caller can resolve the canonical L2 anchor block.
+		require.Equal(t, h.interop.activationTimestamp-1, ts)
 	})
 
 	t.Run("non-zero l1Block finds matching entry", func(t *testing.T) {
@@ -2879,7 +2881,8 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		blockID, ts, err := h.interop.VerifiedBlockAtL1(h.Mock(10).id, l1Block)
 		require.NoError(t, err)
 		require.Equal(t, eth.BlockID{}, blockID)
-		require.Equal(t, uint64(0), ts)
+		// Empty DB returns the pre-activation cap (activationTimestamp-1).
+		require.Equal(t, h.interop.activationTimestamp-1, ts)
 	})
 
 	t.Run("closed verifiedDB surfaces error", func(t *testing.T) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -2838,8 +2838,7 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		blockID, ts, err := h.interop.VerifiedBlockAtL1(h.Mock(10).id, eth.L1BlockRef{})
 		require.NoError(t, err)
 		require.Equal(t, eth.BlockID{}, blockID)
-		// Empty result returns the pre-activation cap (activationTimestamp-1)
-		// so the caller can resolve the canonical L2 anchor block.
+		// Empty result returns the pre-activation cap (activationTimestamp-1).
 		require.Equal(t, h.interop.activationTimestamp-1, ts)
 	})
 

--- a/op-supernode/supernode/activity/interop/interop_test_access.go
+++ b/op-supernode/supernode/activity/interop/interop_test_access.go
@@ -53,13 +53,9 @@ func (i *Interop) BackfillCompleted() bool {
 // ---------------------------------------------------------------------------
 // Activation-timestamp inspection
 // ---------------------------------------------------------------------------
-
-// ActivationTimestamp returns the immutable protocol-defined interop
-// activation timestamp. This is the value that fronts protocol-facing RPC
-// responses and never advances at runtime.
-func (i *Interop) ActivationTimestamp() uint64 {
-	return i.activationTimestamp
-}
+//
+// Note: ActivationTimestamp is part of the production VerificationActivity
+// interface and lives in interop.go alongside IsActiveAt.
 
 // VerificationStartTimestamp returns the L2 timestamp at which the main loop
 // begins verification on the most recent Start. Returns 0 before

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -170,7 +170,9 @@ type simpleChainContainer struct {
 // Interface conformance assertions
 var _ ChainContainer = (*simpleChainContainer)(nil)
 var _ InteropChain = (*simpleChainContainer)(nil)
-var _ rollup.SuperAuthority = (*simpleChainContainer)(nil)
+
+// rollup.SuperAuthority conformance is asserted in super_authority.go alongside
+// the method definitions.
 
 func NewChainContainer(
 	chainID eth.ChainID,

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -7,99 +7,190 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// FullyVerifiedL2Head returns the oldest fully-verified L2 head across all
-// verifiers. The bool is true to signal use-local-safe (no verifiers, all
-// pre-activation, or transient verifier error); false carries the verifier
-// result (block, or empty when verifiers are operational but have nothing
-// verified yet). Panics if verifiers disagree at the same timestamp.
-func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
+// FullyVerifiedL2Head reports the cross-verified safe L2 head as a tri-state.
+//
+// Returns one of:
+//   - (VerifierHead{Source: PreActivation}, Ok): no verifiers registered, or
+//     every registered verifier is still inactive at the current local-safe
+//     timestamp. Caller uses local-safe.
+//   - (VerifierHead{Source: Anchor, Block: anchor}, Ok): at least one active
+//     verifier has no verified-DB entry for this chain yet. The Block is the
+//     per-(chain, verifier) activation-anchor block (the L2 block at
+//     timestamp `verifier.ActivationTimestamp() - 1`), selected as the oldest
+//     contribution across active verifiers.
+//   - (VerifierHead{Source: Verified, Block: tip}, Ok): all active verifiers
+//     have verified tips; Block is the oldest tip across them.
+//   - (VerifierHead{}, HoldPrevious): a verifier read failed transiently. The
+//     caller must not advance and must not fall back to local-safe; floor at
+//     FinalizedHead.
+//
+// Panics if two verifiers report distinct Verified tips at the same timestamp —
+// that is a consensus-violating state.
+func (c *simpleChainContainer) FullyVerifiedL2Head() (rollup.VerifierHead, rollup.VerifierHeadStatus) {
 	if len(c.verifiers) == 0 {
-		c.log.Debug("FullyVerifiedL2Head: no verifiers registered, signaling local-safe fallback")
-		return eth.BlockID{}, true
+		c.log.Debug("FullyVerifiedL2Head: no verifiers registered, pre-activation")
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
 	}
 
-	// Pre-activation L2 content is verified by consensus alone; gating it on
-	// a not-yet-active interop verifier would stall the head at genesis (#20191).
-	if activeTS, ok := c.localSafeTimestamp(); ok && c.allVerifiersPreActivationAt(activeTS) {
-		c.log.Debug("FullyVerifiedL2Head: all verifiers pre-activation, signaling local-safe fallback", "localSafeTime", activeTS)
-		return eth.BlockID{}, true
+	// Pre-activation L2 content is verified by consensus alone; gating it on a
+	// not-yet-active interop verifier would stall the head at genesis (#20191).
+	localTS, localTSOk := c.localSafeTimestamp()
+	if localTSOk && c.allVerifiersPreActivationAt(localTS) {
+		c.log.Debug("FullyVerifiedL2Head: all verifiers pre-activation", "localSafeTime", localTS)
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
 	}
 
-	timestamp := uint64(math.MaxUint64)
-	oldestVerifiedBlock := eth.BlockID{}
+	ctx := context.Background()
+	oldestTimestamp := uint64(math.MaxUint64)
+	oldest := rollup.VerifierHead{}
+	contributed := 0
 	for _, v := range c.verifiers {
-		bId, ts, err := v.LatestVerifiedL2Block(c.chainID)
+		// Skip verifiers not yet active at the current local-safe timestamp.
+		// Their activation-anchor block doesn't exist on this chain yet, so we
+		// must not try to resolve it and must not treat them as errors.
+		if localTSOk && !v.IsActiveAt(localTS) {
+			continue
+		}
+		contribution, ts, err := c.verifierSafeContribution(ctx, v)
 		if err != nil {
-			c.log.Warn("FullyVerifiedL2Head: verifier read failed, signaling local-safe fallback",
+			c.log.Warn("FullyVerifiedL2Head: verifier read failed, holding previous",
 				"verifier", v.Name(), "err", err)
-			return eth.BlockID{}, true
+			return rollup.VerifierHead{}, rollup.VerifierHeadHoldPrevious
 		}
-		if (bId == eth.BlockID{} || ts == 0) {
-			c.log.Debug("FullyVerifiedL2Head: verifier returned empty, returning empty without fallback", "verifier", v.Name())
-			return eth.BlockID{}, false
-		}
-		if ts < timestamp {
-			timestamp = ts
-			oldestVerifiedBlock = bId
-		} else if ts == timestamp && bId != oldestVerifiedBlock {
+		contributed++
+		if ts < oldestTimestamp ||
+			(ts == oldestTimestamp && contribution.Source == rollup.VerifierHeadAnchor && oldest.Source == rollup.VerifierHeadVerified) {
+			oldestTimestamp = ts
+			oldest = contribution
+		} else if ts == oldestTimestamp && contribution.Block != oldest.Block && oldest.Source == rollup.VerifierHeadVerified && contribution.Source == rollup.VerifierHeadVerified {
 			panic("verifiers disagree on block hash for same timestamp")
 		}
 	}
-
-	c.log.Debug("FullyVerifiedL2Head: returning verified block", "block", oldestVerifiedBlock, "timestamp", timestamp)
-	return oldestVerifiedBlock, false
+	if contributed == 0 {
+		// Reachable only when localSafeTimestamp is unavailable AND every verifier
+		// is currently inactive. The pre-activation short-circuit above handles
+		// the common case; this is the cold-start safety net.
+		c.log.Debug("FullyVerifiedL2Head: no active verifiers contributed, pre-activation")
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
+	}
+	c.log.Debug("FullyVerifiedL2Head: returning head", "block", oldest.Block, "source", oldest.Source, "timestamp", oldestTimestamp)
+	return oldest, rollup.VerifierHeadOk
 }
 
-// FinalizedL2Head returns the oldest finalized L2 head across all verifiers.
-// The bool is true to signal use-local-finalized (no verifiers, all
-// pre-activation, sync status unavailable, or transient verifier error);
-// false carries the verifier result. Panics if verifiers disagree at the
-// same timestamp.
-func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
+// FinalizedL2Head reports the cross-verified finalized L2 head with the same
+// tri-state semantics as FullyVerifiedL2Head. Per-verifier finalized comes from
+// VerifiedBlockAtL1(chainID, ss.FinalizedL1); empty results contribute the
+// activation anchor; read errors return HoldPrevious. Finalized is bounded
+// below by `min(verified-safe-tip, L1-finalized-reflection)` implicitly via
+// VerifiedBlockAtL1's L1-anchored lookup.
+func (c *simpleChainContainer) FinalizedL2Head() (rollup.VerifierHead, rollup.VerifierHeadStatus) {
 	if len(c.verifiers) == 0 {
-		c.log.Debug("FinalizedL2Head: no verifiers registered, signaling local-finalized fallback")
-		return eth.BlockID{}, true
+		c.log.Debug("FinalizedL2Head: no verifiers registered, pre-activation")
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
 	}
 
-	ss, err := c.SyncStatus(context.Background())
+	ctx := context.Background()
+	ss, err := c.SyncStatus(ctx)
 	if err != nil {
-		c.log.Error("FinalizedL2Head: failed to get sync status", "err", err)
-		return eth.BlockID{}, true
+		c.log.Warn("FinalizedL2Head: failed to get sync status, holding previous", "err", err)
+		return rollup.VerifierHead{}, rollup.VerifierHeadHoldPrevious
 	}
 
 	// FinalizedL2 <= LocalSafeL2; if local-safe is pre-activation, so is finalized.
 	if c.allVerifiersPreActivationAt(ss.LocalSafeL2.Time) {
-		c.log.Debug("FinalizedL2Head: all verifiers pre-activation, signaling local-finalized fallback", "localSafeTime", ss.LocalSafeL2.Time)
-		return eth.BlockID{}, true
+		c.log.Debug("FinalizedL2Head: all verifiers pre-activation", "localSafeTime", ss.LocalSafeL2.Time)
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
 	}
 
-	timestamp := uint64(math.MaxUint64)
-	oldestFinalizedBlock := eth.BlockID{}
+	oldestTimestamp := uint64(math.MaxUint64)
+	oldest := rollup.VerifierHead{}
+	contributed := 0
 	for _, v := range c.verifiers {
-		bId, ts, err := v.VerifiedBlockAtL1(c.chainID, ss.FinalizedL1)
+		if !v.IsActiveAt(ss.LocalSafeL2.Time) {
+			continue
+		}
+		contribution, ts, err := c.verifierFinalizedContribution(ctx, v, ss.FinalizedL1)
 		if err != nil {
-			c.log.Warn("FinalizedL2Head: verifier read failed, signaling local-finalized fallback",
+			c.log.Warn("FinalizedL2Head: verifier read failed, holding previous",
 				"verifier", v.Name(), "err", err)
-			return eth.BlockID{}, true
+			return rollup.VerifierHead{}, rollup.VerifierHeadHoldPrevious
 		}
-		if (bId == eth.BlockID{} || ts == 0) {
-			c.log.Debug("FinalizedL2Head: verifier returned empty, returning empty without fallback", "verifier", v.Name())
-			return eth.BlockID{}, false
-		}
-		if ts < timestamp {
-			timestamp = ts
-			oldestFinalizedBlock = bId
-		} else if ts == timestamp && bId != oldestFinalizedBlock {
+		contributed++
+		if ts < oldestTimestamp ||
+			(ts == oldestTimestamp && contribution.Source == rollup.VerifierHeadAnchor && oldest.Source == rollup.VerifierHeadVerified) {
+			oldestTimestamp = ts
+			oldest = contribution
+		} else if ts == oldestTimestamp && contribution.Block != oldest.Block && oldest.Source == rollup.VerifierHeadVerified && contribution.Source == rollup.VerifierHeadVerified {
 			panic("verifiers disagree on block hash for same timestamp")
 		}
 	}
+	if contributed == 0 {
+		c.log.Debug("FinalizedL2Head: no active verifiers contributed, pre-activation")
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
+	}
+	c.log.Debug("FinalizedL2Head: returning head", "block", oldest.Block, "source", oldest.Source, "timestamp", oldestTimestamp)
+	return oldest, rollup.VerifierHeadOk
+}
 
-	c.log.Debug("FinalizedL2Head: returning finalized block", "block", oldestFinalizedBlock, "timestamp", timestamp)
-	return oldestFinalizedBlock, false
+// verifierSafeContribution returns the (head, timestamp) this verifier
+// contributes to the safe-head oldest-across-verifiers comparison: its verified
+// tip if present, otherwise its per-(chain, verifier) activation anchor. Must
+// only be called for verifiers active at the current local-safe timestamp.
+func (c *simpleChainContainer) verifierSafeContribution(ctx context.Context, v activity.VerificationActivity) (rollup.VerifierHead, uint64, error) {
+	bId, ts, err := v.LatestVerifiedL2Block(c.chainID)
+	if err != nil {
+		return rollup.VerifierHead{}, 0, err
+	}
+	if (bId == eth.BlockID{}) || ts == 0 {
+		return c.anchorContribution(ctx, v)
+	}
+	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bId}, ts, nil
+}
+
+// verifierFinalizedContribution mirrors verifierSafeContribution for the
+// finalized-head path, using VerifiedBlockAtL1 with the L1 finalized block.
+func (c *simpleChainContainer) verifierFinalizedContribution(ctx context.Context, v activity.VerificationActivity, finalizedL1 eth.L1BlockRef) (rollup.VerifierHead, uint64, error) {
+	bId, ts, err := v.VerifiedBlockAtL1(c.chainID, finalizedL1)
+	if err != nil {
+		return rollup.VerifierHead{}, 0, err
+	}
+	if (bId == eth.BlockID{}) || ts == 0 {
+		return c.anchorContribution(ctx, v)
+	}
+	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bId}, ts, nil
+}
+
+// anchorContribution computes the per-(chain, verifier) activation-anchor block
+// — the L2 block on this chain at timestamp `verifier.ActivationTimestamp() - 1`
+// — and returns it together with the anchor timestamp for cross-verifier
+// oldest-comparison. Engine-not-ready or RPC failure returns an error which
+// the caller surfaces as HoldPrevious.
+func (c *simpleChainContainer) anchorContribution(ctx context.Context, v activity.VerificationActivity) (rollup.VerifierHead, uint64, error) {
+	if c.engine == nil {
+		return rollup.VerifierHead{}, 0, engine_controller.ErrNoEngineClient
+	}
+	activeTS := v.ActivationTimestamp()
+	if activeTS == 0 {
+		// Verifier with no activation timestamp configured; treat as a
+		// zero-timestamped anchor (oldest possible) carrying no concrete block.
+		// This case is informational — production verifiers always configure
+		// an activation timestamp.
+		return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor}, 0, nil
+	}
+	num, err := c.vncfg.Rollup.TargetBlockNumber(activeTS - 1)
+	if err != nil {
+		return rollup.VerifierHead{}, 0, fmt.Errorf("compute anchor block number for activation %d: %w", activeTS, err)
+	}
+	ref, err := c.engine.L2BlockRefByNumber(ctx, num)
+	if err != nil {
+		return rollup.VerifierHead{}, 0, fmt.Errorf("resolve anchor block %d: %w", num, err)
+	}
+	return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor, Block: ref.ID()}, activeTS - 1, nil
 }
 
 // localSafeTimestamp returns the timestamp of the current local-safe L2 head.

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -7,17 +7,18 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum/go-ethereum/common"
 )
 
 // FullyVerifiedL2Head reports the cross-verified safe L2 head.
 //
-// With no verifiers, returns PreActivation. Per verifier active at the current
-// local-safe timestamp, contribute either the verified tip or an activation
-// anchor; take the oldest contribution across active verifiers. Not-yet-active
-// verifiers are skipped — their anchor block doesn't exist on this chain yet.
+// Per active verifier, contribute either the verified tip or an Anchor with
+// the pre-activation cap timestamp (returned by the verifier when it has no
+// entry for this chain). Take the oldest contribution. Not-yet-active
+// verifiers are skipped. The caller (engine_controller) resolves Anchor
+// timestamps to canonical L2 blocks.
+//
 // Panics if two active verifiers report distinct Verified tips at the same
 // timestamp.
 func (c *simpleChainContainer) FullyVerifiedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
@@ -27,27 +28,20 @@ func (c *simpleChainContainer) FullyVerifiedL2Head(ctx context.Context) (rollup.
 
 	localTS, localTSOk := c.localSafeTimestamp(ctx)
 
-	oldestTimestamp := uint64(math.MaxUint64)
-	oldest := rollup.VerifierHead{}
+	oldest := rollup.VerifierHead{Timestamp: math.MaxUint64}
 	contributed := 0
 	for _, v := range c.verifiers {
 		if localTSOk && !v.IsActiveAt(localTS) {
 			continue
 		}
-		contribution, ts, err := c.verifierSafeContribution(ctx, v)
+		contribution, err := c.verifierContribution(v.LatestVerifiedL2Block(c.chainID))
 		if err != nil {
 			c.log.Warn("FullyVerifiedL2Head: verifier read failed, holding previous",
 				"verifier", v.Name(), "err", err)
 			return rollup.VerifierHead{}, false
 		}
 		contributed++
-		if ts < oldestTimestamp ||
-			(ts == oldestTimestamp && contribution.Source == rollup.VerifierHeadAnchor && oldest.Source == rollup.VerifierHeadVerified) {
-			oldestTimestamp = ts
-			oldest = contribution
-		} else if ts == oldestTimestamp && contribution.Block != oldest.Block && oldest.Source == rollup.VerifierHeadVerified && contribution.Source == rollup.VerifierHeadVerified {
-			panic("verifiers disagree on block hash for same timestamp")
-		}
+		oldest = pickOldest(oldest, contribution)
 	}
 	if contributed == 0 {
 		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
@@ -55,9 +49,7 @@ func (c *simpleChainContainer) FullyVerifiedL2Head(ctx context.Context) (rollup.
 	return oldest, true
 }
 
-// FinalizedL2Head is the finalized analogue of FullyVerifiedL2Head. Per-verifier
-// contribution comes from VerifiedBlockAtL1(chainID, ss.FinalizedL1); empty
-// results yield the activation anchor; read errors return HoldPrevious.
+// FinalizedL2Head is the finalized analogue of FullyVerifiedL2Head.
 func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
 	if len(c.verifiers) == 0 {
 		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
@@ -69,27 +61,20 @@ func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.Veri
 		return rollup.VerifierHead{}, false
 	}
 
-	oldestTimestamp := uint64(math.MaxUint64)
-	oldest := rollup.VerifierHead{}
+	oldest := rollup.VerifierHead{Timestamp: math.MaxUint64}
 	contributed := 0
 	for _, v := range c.verifiers {
 		if !v.IsActiveAt(ss.LocalSafeL2.Time) {
 			continue
 		}
-		contribution, ts, err := c.verifierFinalizedContribution(ctx, v, ss.FinalizedL1)
+		contribution, err := c.verifierContribution(v.VerifiedBlockAtL1(c.chainID, ss.FinalizedL1))
 		if err != nil {
 			c.log.Warn("FinalizedL2Head: verifier read failed, holding previous",
 				"verifier", v.Name(), "err", err)
 			return rollup.VerifierHead{}, false
 		}
 		contributed++
-		if ts < oldestTimestamp ||
-			(ts == oldestTimestamp && contribution.Source == rollup.VerifierHeadAnchor && oldest.Source == rollup.VerifierHeadVerified) {
-			oldestTimestamp = ts
-			oldest = contribution
-		} else if ts == oldestTimestamp && contribution.Block != oldest.Block && oldest.Source == rollup.VerifierHeadVerified && contribution.Source == rollup.VerifierHeadVerified {
-			panic("verifiers disagree on block hash for same timestamp")
-		}
+		oldest = pickOldest(oldest, contribution)
 	}
 	if contributed == 0 {
 		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
@@ -97,49 +82,36 @@ func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.Veri
 	return oldest, true
 }
 
-// verifierSafeContribution: verified tip if present, otherwise activation anchor.
-// Caller must filter inactive verifiers — anchor lookup assumes the verifier is active.
-func (c *simpleChainContainer) verifierSafeContribution(ctx context.Context, v activity.VerificationActivity) (rollup.VerifierHead, uint64, error) {
-	bId, ts, err := v.LatestVerifiedL2Block(c.chainID)
+// verifierContribution classifies a verifier's (block, ts) return:
+//   - empty block → Anchor (caller resolves the canonical L2 block at ts).
+//   - non-empty block → Verified tip.
+func (c *simpleChainContainer) verifierContribution(bId eth.BlockID, ts uint64, err error) (rollup.VerifierHead, error) {
 	if err != nil {
-		return rollup.VerifierHead{}, 0, err
+		return rollup.VerifierHead{}, err
 	}
-	if (bId == eth.BlockID{}) || ts == 0 {
-		return c.anchorContribution(ctx, v)
+	if (bId == eth.BlockID{}) {
+		return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor, Timestamp: ts}, nil
 	}
-	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bId}, ts, nil
+	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bId, Timestamp: ts}, nil
 }
 
-func (c *simpleChainContainer) verifierFinalizedContribution(ctx context.Context, v activity.VerificationActivity, finalizedL1 eth.L1BlockRef) (rollup.VerifierHead, uint64, error) {
-	bId, ts, err := v.VerifiedBlockAtL1(c.chainID, finalizedL1)
-	if err != nil {
-		return rollup.VerifierHead{}, 0, err
+// pickOldest returns the older of two contributions. Ties break toward Anchor
+// (more conservative). Panics if two Verified tips disagree at the same timestamp.
+func pickOldest(a, b rollup.VerifierHead) rollup.VerifierHead {
+	if b.Timestamp < a.Timestamp {
+		return b
 	}
-	if (bId == eth.BlockID{}) || ts == 0 {
-		return c.anchorContribution(ctx, v)
+	if b.Timestamp > a.Timestamp {
+		return a
 	}
-	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bId}, ts, nil
-}
-
-// anchorContribution resolves the L2 block at `verifier.ActivationTimestamp() - 1`
-// on this chain. Engine-not-ready or RPC failure becomes HoldPrevious upstream.
-func (c *simpleChainContainer) anchorContribution(ctx context.Context, v activity.VerificationActivity) (rollup.VerifierHead, uint64, error) {
-	if c.engine == nil {
-		return rollup.VerifierHead{}, 0, engine_controller.ErrNoEngineClient
+	// Equal timestamps.
+	if a.Source == rollup.VerifierHeadVerified && b.Source == rollup.VerifierHeadVerified && a.Block != b.Block {
+		panic("verifiers disagree on block hash for same timestamp")
 	}
-	activeTS := v.ActivationTimestamp()
-	if activeTS == 0 {
-		return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor}, 0, nil
+	if b.Source == rollup.VerifierHeadAnchor && a.Source == rollup.VerifierHeadVerified {
+		return b
 	}
-	num, err := c.vncfg.Rollup.TargetBlockNumber(activeTS - 1)
-	if err != nil {
-		return rollup.VerifierHead{}, 0, fmt.Errorf("compute anchor block number for activation %d: %w", activeTS, err)
-	}
-	ref, err := c.engine.L2BlockRefByNumber(ctx, num)
-	if err != nil {
-		return rollup.VerifierHead{}, 0, fmt.Errorf("resolve anchor block %d: %w", num, err)
-	}
-	return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor, Block: ref.ID()}, activeTS - 1, nil
+	return a
 }
 
 func (c *simpleChainContainer) localSafeTimestamp(ctx context.Context) (uint64, bool) {

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -16,8 +16,8 @@ import (
 // Per active verifier, contribute either the verified tip or an Anchor with
 // the pre-activation cap timestamp (returned by the verifier when it has no
 // entry for this chain). Take the oldest contribution. Not-yet-active
-// verifiers are skipped. The caller (engine_controller) resolves Anchor
-// timestamps to canonical L2 blocks.
+// verifiers are skipped. The caller decides whether to resolve Anchor timestamps
+// or fall back more conservatively.
 //
 // Panics if two active verifiers report distinct Verified tips at the same
 // timestamp.
@@ -83,7 +83,7 @@ func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.Veri
 }
 
 // verifierContribution classifies a verifier's (block, ts) return:
-//   - empty block → Anchor (caller resolves the canonical L2 block at ts).
+//   - empty block → Anchor (ts is the pre-activation cap).
 //   - non-empty block → Verified tip.
 func (c *simpleChainContainer) verifierContribution(bId eth.BlockID, ts uint64, err error) (rollup.VerifierHead, error) {
 	if err != nil {

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -12,47 +12,25 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// FullyVerifiedL2Head reports the cross-verified safe L2 head as a tri-state.
+// FullyVerifiedL2Head reports the cross-verified safe L2 head.
 //
-// Returns one of:
-//   - (VerifierHead{Source: PreActivation}, Ok): no verifiers registered, or
-//     every registered verifier is still inactive at the current local-safe
-//     timestamp. Caller uses local-safe.
-//   - (VerifierHead{Source: Anchor, Block: anchor}, Ok): at least one active
-//     verifier has no verified-DB entry for this chain yet. The Block is the
-//     per-(chain, verifier) activation-anchor block (the L2 block at
-//     timestamp `verifier.ActivationTimestamp() - 1`), selected as the oldest
-//     contribution across active verifiers.
-//   - (VerifierHead{Source: Verified, Block: tip}, Ok): all active verifiers
-//     have verified tips; Block is the oldest tip across them.
-//   - (VerifierHead{}, HoldPrevious): a verifier read failed transiently. The
-//     caller must not advance and must not fall back to local-safe; floor at
-//     FinalizedHead.
-//
-// Panics if two verifiers report distinct Verified tips at the same timestamp —
-// that is a consensus-violating state.
-func (c *simpleChainContainer) FullyVerifiedL2Head() (rollup.VerifierHead, rollup.VerifierHeadStatus) {
+// With no verifiers, returns PreActivation. Per verifier active at the current
+// local-safe timestamp, contribute either the verified tip or an activation
+// anchor; take the oldest contribution across active verifiers. Not-yet-active
+// verifiers are skipped — their anchor block doesn't exist on this chain yet.
+// Panics if two active verifiers report distinct Verified tips at the same
+// timestamp.
+func (c *simpleChainContainer) FullyVerifiedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
 	if len(c.verifiers) == 0 {
-		c.log.Debug("FullyVerifiedL2Head: no verifiers registered, pre-activation")
-		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
 
-	// Pre-activation L2 content is verified by consensus alone; gating it on a
-	// not-yet-active interop verifier would stall the head at genesis (#20191).
-	localTS, localTSOk := c.localSafeTimestamp()
-	if localTSOk && c.allVerifiersPreActivationAt(localTS) {
-		c.log.Debug("FullyVerifiedL2Head: all verifiers pre-activation", "localSafeTime", localTS)
-		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
-	}
+	localTS, localTSOk := c.localSafeTimestamp(ctx)
 
-	ctx := context.Background()
 	oldestTimestamp := uint64(math.MaxUint64)
 	oldest := rollup.VerifierHead{}
 	contributed := 0
 	for _, v := range c.verifiers {
-		// Skip verifiers not yet active at the current local-safe timestamp.
-		// Their activation-anchor block doesn't exist on this chain yet, so we
-		// must not try to resolve it and must not treat them as errors.
 		if localTSOk && !v.IsActiveAt(localTS) {
 			continue
 		}
@@ -60,7 +38,7 @@ func (c *simpleChainContainer) FullyVerifiedL2Head() (rollup.VerifierHead, rollu
 		if err != nil {
 			c.log.Warn("FullyVerifiedL2Head: verifier read failed, holding previous",
 				"verifier", v.Name(), "err", err)
-			return rollup.VerifierHead{}, rollup.VerifierHeadHoldPrevious
+			return rollup.VerifierHead{}, false
 		}
 		contributed++
 		if ts < oldestTimestamp ||
@@ -72,39 +50,23 @@ func (c *simpleChainContainer) FullyVerifiedL2Head() (rollup.VerifierHead, rollu
 		}
 	}
 	if contributed == 0 {
-		// Reachable only when localSafeTimestamp is unavailable AND every verifier
-		// is currently inactive. The pre-activation short-circuit above handles
-		// the common case; this is the cold-start safety net.
-		c.log.Debug("FullyVerifiedL2Head: no active verifiers contributed, pre-activation")
-		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
-	c.log.Debug("FullyVerifiedL2Head: returning head", "block", oldest.Block, "source", oldest.Source, "timestamp", oldestTimestamp)
-	return oldest, rollup.VerifierHeadOk
+	return oldest, true
 }
 
-// FinalizedL2Head reports the cross-verified finalized L2 head with the same
-// tri-state semantics as FullyVerifiedL2Head. Per-verifier finalized comes from
-// VerifiedBlockAtL1(chainID, ss.FinalizedL1); empty results contribute the
-// activation anchor; read errors return HoldPrevious. Finalized is bounded
-// below by `min(verified-safe-tip, L1-finalized-reflection)` implicitly via
-// VerifiedBlockAtL1's L1-anchored lookup.
-func (c *simpleChainContainer) FinalizedL2Head() (rollup.VerifierHead, rollup.VerifierHeadStatus) {
+// FinalizedL2Head is the finalized analogue of FullyVerifiedL2Head. Per-verifier
+// contribution comes from VerifiedBlockAtL1(chainID, ss.FinalizedL1); empty
+// results yield the activation anchor; read errors return HoldPrevious.
+func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
 	if len(c.verifiers) == 0 {
-		c.log.Debug("FinalizedL2Head: no verifiers registered, pre-activation")
-		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
 
-	ctx := context.Background()
 	ss, err := c.SyncStatus(ctx)
 	if err != nil {
 		c.log.Warn("FinalizedL2Head: failed to get sync status, holding previous", "err", err)
-		return rollup.VerifierHead{}, rollup.VerifierHeadHoldPrevious
-	}
-
-	// FinalizedL2 <= LocalSafeL2; if local-safe is pre-activation, so is finalized.
-	if c.allVerifiersPreActivationAt(ss.LocalSafeL2.Time) {
-		c.log.Debug("FinalizedL2Head: all verifiers pre-activation", "localSafeTime", ss.LocalSafeL2.Time)
-		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
+		return rollup.VerifierHead{}, false
 	}
 
 	oldestTimestamp := uint64(math.MaxUint64)
@@ -118,7 +80,7 @@ func (c *simpleChainContainer) FinalizedL2Head() (rollup.VerifierHead, rollup.Ve
 		if err != nil {
 			c.log.Warn("FinalizedL2Head: verifier read failed, holding previous",
 				"verifier", v.Name(), "err", err)
-			return rollup.VerifierHead{}, rollup.VerifierHeadHoldPrevious
+			return rollup.VerifierHead{}, false
 		}
 		contributed++
 		if ts < oldestTimestamp ||
@@ -130,17 +92,13 @@ func (c *simpleChainContainer) FinalizedL2Head() (rollup.VerifierHead, rollup.Ve
 		}
 	}
 	if contributed == 0 {
-		c.log.Debug("FinalizedL2Head: no active verifiers contributed, pre-activation")
-		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, rollup.VerifierHeadOk
+		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
-	c.log.Debug("FinalizedL2Head: returning head", "block", oldest.Block, "source", oldest.Source, "timestamp", oldestTimestamp)
-	return oldest, rollup.VerifierHeadOk
+	return oldest, true
 }
 
-// verifierSafeContribution returns the (head, timestamp) this verifier
-// contributes to the safe-head oldest-across-verifiers comparison: its verified
-// tip if present, otherwise its per-(chain, verifier) activation anchor. Must
-// only be called for verifiers active at the current local-safe timestamp.
+// verifierSafeContribution: verified tip if present, otherwise activation anchor.
+// Caller must filter inactive verifiers — anchor lookup assumes the verifier is active.
 func (c *simpleChainContainer) verifierSafeContribution(ctx context.Context, v activity.VerificationActivity) (rollup.VerifierHead, uint64, error) {
 	bId, ts, err := v.LatestVerifiedL2Block(c.chainID)
 	if err != nil {
@@ -152,8 +110,6 @@ func (c *simpleChainContainer) verifierSafeContribution(ctx context.Context, v a
 	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bId}, ts, nil
 }
 
-// verifierFinalizedContribution mirrors verifierSafeContribution for the
-// finalized-head path, using VerifiedBlockAtL1 with the L1 finalized block.
 func (c *simpleChainContainer) verifierFinalizedContribution(ctx context.Context, v activity.VerificationActivity, finalizedL1 eth.L1BlockRef) (rollup.VerifierHead, uint64, error) {
 	bId, ts, err := v.VerifiedBlockAtL1(c.chainID, finalizedL1)
 	if err != nil {
@@ -165,21 +121,14 @@ func (c *simpleChainContainer) verifierFinalizedContribution(ctx context.Context
 	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bId}, ts, nil
 }
 
-// anchorContribution computes the per-(chain, verifier) activation-anchor block
-// — the L2 block on this chain at timestamp `verifier.ActivationTimestamp() - 1`
-// — and returns it together with the anchor timestamp for cross-verifier
-// oldest-comparison. Engine-not-ready or RPC failure returns an error which
-// the caller surfaces as HoldPrevious.
+// anchorContribution resolves the L2 block at `verifier.ActivationTimestamp() - 1`
+// on this chain. Engine-not-ready or RPC failure becomes HoldPrevious upstream.
 func (c *simpleChainContainer) anchorContribution(ctx context.Context, v activity.VerificationActivity) (rollup.VerifierHead, uint64, error) {
 	if c.engine == nil {
 		return rollup.VerifierHead{}, 0, engine_controller.ErrNoEngineClient
 	}
 	activeTS := v.ActivationTimestamp()
 	if activeTS == 0 {
-		// Verifier with no activation timestamp configured; treat as a
-		// zero-timestamped anchor (oldest possible) carrying no concrete block.
-		// This case is informational — production verifiers always configure
-		// an activation timestamp.
 		return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor}, 0, nil
 	}
 	num, err := c.vncfg.Rollup.TargetBlockNumber(activeTS - 1)
@@ -193,31 +142,13 @@ func (c *simpleChainContainer) anchorContribution(ctx context.Context, v activit
 	return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor, Block: ref.ID()}, activeTS - 1, nil
 }
 
-// localSafeTimestamp returns the timestamp of the current local-safe L2 head.
-// The bool is false if SyncStatus is unavailable, in which case callers should
-// not attempt the pre-activation short-circuit.
-func (c *simpleChainContainer) localSafeTimestamp() (uint64, bool) {
-	ss, err := c.SyncStatus(context.Background())
+func (c *simpleChainContainer) localSafeTimestamp(ctx context.Context) (uint64, bool) {
+	ss, err := c.SyncStatus(ctx)
 	if err != nil {
 		c.log.Warn("localSafeTimestamp: failed to get sync status", "err", err)
 		return 0, false
 	}
 	return ss.LocalSafeL2.Time, true
-}
-
-// allVerifiersPreActivationAt reports whether every registered verifier is
-// still inactive at the given L2 timestamp. Returns false if there are no
-// verifiers; callers are expected to handle that case separately.
-func (c *simpleChainContainer) allVerifiersPreActivationAt(ts uint64) bool {
-	if len(c.verifiers) == 0 {
-		return false
-	}
-	for _, v := range c.verifiers {
-		if v.IsActiveAt(ts) {
-			return false
-		}
-	}
-	return true
 }
 
 // IsDenied checks if a block hash is on the deny list at the given height.
@@ -244,5 +175,4 @@ func (c *simpleChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2Bloc
 	return c.engine.OutputV0AtBlockNumber(ctx, l2BlockNum)
 }
 
-// Interface satisfaction static check
 var _ rollup.SuperAuthority = (*simpleChainContainer)(nil)

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -3,10 +3,8 @@ package chain_container
 import (
 	"context"
 	"errors"
-	"math/big"
 	"testing"
 
-	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -39,20 +37,35 @@ func (m *mockVerificationActivityForSuperAuthority) VerifiedAtTimestamp(ts uint6
 	return false, nil
 }
 func (m *mockVerificationActivityForSuperAuthority) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error) {
-	return m.latestVerifiedBlock, m.latestVerifiedTS, m.latestVerifiedErr
+	if m.latestVerifiedErr != nil {
+		return eth.BlockID{}, 0, m.latestVerifiedErr
+	}
+	if m.latestVerifiedBlock == (eth.BlockID{}) {
+		return eth.BlockID{}, m.activationCap(), nil
+	}
+	return m.latestVerifiedBlock, m.latestVerifiedTS, nil
 }
 func (m *mockVerificationActivityForSuperAuthority) Reset(eth.ChainID, uint64, eth.BlockRef) {}
 func (m *mockVerificationActivityForSuperAuthority) VerifiedBlockAtL1(chainID eth.ChainID, l1BlockRef eth.L1BlockRef) (eth.BlockID, uint64, error) {
-	return m.latestFinalizedBlock, m.latestFinalizedTS, m.latestFinalizedErr
+	if m.latestFinalizedErr != nil {
+		return eth.BlockID{}, 0, m.latestFinalizedErr
+	}
+	if m.latestFinalizedBlock == (eth.BlockID{}) {
+		return eth.BlockID{}, m.activationCap(), nil
+	}
+	return m.latestFinalizedBlock, m.latestFinalizedTS, nil
+}
+func (m *mockVerificationActivityForSuperAuthority) activationCap() uint64 {
+	if m.activationTimestamp == 0 {
+		return 0
+	}
+	return m.activationTimestamp - 1
 }
 func (m *mockVerificationActivityForSuperAuthority) IsActiveAt(ts uint64) bool {
 	if m.isActiveAtFn != nil {
 		return m.isActiveAtFn(ts)
 	}
 	return ts >= m.activationTimestamp
-}
-func (m *mockVerificationActivityForSuperAuthority) ActivationTimestamp() uint64 {
-	return m.activationTimestamp
 }
 
 var _ activity.VerificationActivity = (*mockVerificationActivityForSuperAuthority)(nil)
@@ -68,23 +81,6 @@ func newTestChainContainer(t *testing.T, chainID eth.ChainID) *simpleChainContai
 		log:       testlog.Logger(t, log.LevelDebug),
 		vn:        &mockVirtualNode{},
 	}
-}
-
-// newTestChainContainerWithAnchor extends newTestChainContainer with a mock
-// engine and a rollup config so the activation-anchor lookup
-// (vncfg.Rollup.TargetBlockNumber + engine.L2BlockRefByNumber) can succeed in
-// tests that exercise the Anchor source.
-func newTestChainContainerWithAnchor(t *testing.T, chainID eth.ChainID) (*simpleChainContainer, *mockEngineController) {
-	cc := newTestChainContainer(t, chainID)
-	eng := newMockEngineController()
-	cc.engine = eng
-	cc.vncfg = &opnodecfg.Config{
-		Rollup: rollup.Config{
-			L2ChainID: big.NewInt(420),
-			BlockTime: 2,
-		},
-	}
-	return cc, eng
 }
 
 // setSyncStatus configures the chain's mock virtual node to return the given SyncStatus.
@@ -179,37 +175,34 @@ func TestChainContainer_FullyVerifiedL2Head_VerifiersDisagreeAtSameTimestamp_Pan
 // BlockID. This was bug B: post-activation empty verifiers caused SafeL2Head
 // to drop to genesis.
 
+// Chain_container no longer resolves anchor blocks — it returns the cap
+// timestamp via VerifierHead.Timestamp and the engine controller does the
+// L2BlockRefByNumber lookup. These tests pin the timestamp pass-through.
+
 func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierContributesAnchor(t *testing.T) {
 	t.Parallel()
 
-	cc, eng := newTestChainContainerWithAnchor(t, eth.ChainIDFromUInt64(420))
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
 	setSyncStatus(t, cc, &eth.SyncStatus{
 		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
 	})
 
-	// Active verifier with no entries for this chain — contributes its anchor.
-	v := &mockVerificationActivityForSuperAuthority{
-		activationTimestamp: 1000,
-	}
+	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
 	cc.verifiers = []activity.VerificationActivity{v}
-
-	// Engine returns a real block for the anchor lookup
-	// (block at timestamp activationTS - 1 = 999 → block number 499 with BlockTime=2).
-	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
-	eng.l2BlockRefByNumberResult = anchorBlock
 
 	head, ok := cc.FullyVerifiedL2Head(t.Context())
 	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
-		"empty verifier post-activation must contribute its activation anchor, not empty")
-	require.Equal(t, anchorBlock.ID(), head.Block,
-		"anchor block must be the L2 block at activationTimestamp - 1")
+		"empty verifier post-activation must contribute its activation anchor")
+	require.Equal(t, eth.BlockID{}, head.Block, "anchor contribution carries no block")
+	require.Equal(t, uint64(999), head.Timestamp,
+		"anchor timestamp is activationTimestamp - 1; engine_controller resolves to a block")
 }
 
 func TestChainContainer_FullyVerifiedL2Head_AllUnverified_ContributeAnchors(t *testing.T) {
 	t.Parallel()
 
-	cc, eng := newTestChainContainerWithAnchor(t, eth.ChainIDFromUInt64(420))
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
 	setSyncStatus(t, cc, &eth.SyncStatus{
 		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 3000},
 	})
@@ -218,19 +211,16 @@ func TestChainContainer_FullyVerifiedL2Head_AllUnverified_ContributeAnchors(t *t
 	v2 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
 	cc.verifiers = []activity.VerificationActivity{v1, v2}
 
-	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
-	eng.l2BlockRefByNumberResult = anchorBlock
-
 	head, ok := cc.FullyVerifiedL2Head(t.Context())
 	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadAnchor, head.Source)
-	require.Equal(t, anchorBlock.ID(), head.Block)
+	require.Equal(t, uint64(999), head.Timestamp)
 }
 
 func TestChainContainer_FullyVerifiedL2Head_MixedAnchorAndVerified_OldestWins(t *testing.T) {
 	t.Parallel()
 
-	cc, eng := newTestChainContainerWithAnchor(t, eth.ChainIDFromUInt64(420))
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
 	setSyncStatus(t, cc, &eth.SyncStatus{
 		LocalSafeL2: eth.L2BlockRef{Number: 1000, Time: 3000},
 	})
@@ -245,20 +235,17 @@ func TestChainContainer_FullyVerifiedL2Head_MixedAnchorAndVerified_OldestWins(t 
 	}
 	cc.verifiers = []activity.VerificationActivity{v1, v2}
 
-	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
-	eng.l2BlockRefByNumberResult = anchorBlock
-
 	head, ok := cc.FullyVerifiedL2Head(t.Context())
 	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
-		"oldest contribution is v1's anchor at TS 999; v2's verified tip at TS 2500 is newer")
-	require.Equal(t, anchorBlock.ID(), head.Block)
+		"v1's anchor at TS 999 is the oldest contribution")
+	require.Equal(t, uint64(999), head.Timestamp)
 }
 
 func TestChainContainer_FullyVerifiedL2Head_OneEmptyOneVerified_AnchorOlder(t *testing.T) {
 	t.Parallel()
 
-	cc, eng := newTestChainContainerWithAnchor(t, eth.ChainIDFromUInt64(420))
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
 	setSyncStatus(t, cc, &eth.SyncStatus{
 		LocalSafeL2: eth.L2BlockRef{Number: 1000, Time: 3000},
 	})
@@ -266,7 +253,7 @@ func TestChainContainer_FullyVerifiedL2Head_OneEmptyOneVerified_AnchorOlder(t *t
 	v1 := &mockVerificationActivityForSuperAuthority{
 		activationTimestamp: 1000,
 		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestVerifiedTS:    2000, // newer than anchor
+		latestVerifiedTS:    2000,
 	}
 	v2 := &mockVerificationActivityForSuperAuthority{
 		activationTimestamp: 1000, // empty → anchor at TS 999
@@ -278,14 +265,11 @@ func TestChainContainer_FullyVerifiedL2Head_OneEmptyOneVerified_AnchorOlder(t *t
 	}
 	cc.verifiers = []activity.VerificationActivity{v1, v2, v3}
 
-	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
-	eng.l2BlockRefByNumberResult = anchorBlock
-
 	head, ok := cc.FullyVerifiedL2Head(t.Context())
 	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
 		"v2's anchor at TS 999 is the oldest contribution")
-	require.Equal(t, anchorBlock.ID(), head.Block)
+	require.Equal(t, uint64(999), head.Timestamp)
 }
 
 // =============================================================================
@@ -427,7 +411,7 @@ func TestChainContainer_FinalizedL2Head_NoVerifiers_ReturnsPreActivation(t *test
 func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierContributesAnchor(t *testing.T) {
 	t.Parallel()
 
-	cc, eng := newTestChainContainerWithAnchor(t, eth.ChainIDFromUInt64(420))
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
 	setSyncStatus(t, cc, &eth.SyncStatus{
 		FinalizedL1: eth.L1BlockRef{Number: 400},
 		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 1500},
@@ -436,14 +420,12 @@ func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierContributesA
 	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
 	cc.verifiers = []activity.VerificationActivity{v}
 
-	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
-	eng.l2BlockRefByNumberResult = anchorBlock
-
 	head, ok := cc.FinalizedL2Head(t.Context())
 	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
 		"empty verifier post-activation contributes anchor (fixes the safeDB-to-genesis bug, #20944)")
-	require.Equal(t, anchorBlock.ID(), head.Block)
+	require.Equal(t, uint64(999), head.Timestamp,
+		"anchor timestamp is activationTimestamp - 1; engine_controller resolves to a block")
 }
 
 func TestChainContainer_FinalizedL2Head_PreActivation_ReturnsPreActivationSource(t *testing.T) {

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -117,8 +117,8 @@ func TestChainContainer_FullyVerifiedL2Head_MultipleVerifiers_OldestWins(t *test
 	}
 	cc.verifiers = []activity.VerificationActivity{v1, v2, v3}
 
-	head, status := cc.FullyVerifiedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
 	require.Equal(t, v1.latestVerifiedBlock, head.Block, "should return oldest verified block")
 }
@@ -128,8 +128,8 @@ func TestChainContainer_FullyVerifiedL2Head_NoVerifiers_ReturnsPreActivation(t *
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
 
-	head, status := cc.FullyVerifiedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source,
 		"no verifiers registered → PreActivation; caller uses local-safe")
 	require.Equal(t, eth.BlockID{}, head.Block)
@@ -145,8 +145,8 @@ func TestChainContainer_FullyVerifiedL2Head_SingleVerifier(t *testing.T) {
 	}
 	cc.verifiers = []activity.VerificationActivity{v}
 
-	head, status := cc.FullyVerifiedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
 	require.Equal(t, v.latestVerifiedBlock, head.Block)
 }
@@ -166,7 +166,7 @@ func TestChainContainer_FullyVerifiedL2Head_VerifiersDisagreeAtSameTimestamp_Pan
 	cc.verifiers = []activity.VerificationActivity{v1, v2}
 
 	require.Panics(t, func() {
-		_, _ = cc.FullyVerifiedL2Head()
+		_, _ = cc.FullyVerifiedL2Head(t.Context())
 	})
 }
 
@@ -198,8 +198,8 @@ func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierContribu
 	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
 	eng.l2BlockRefByNumberResult = anchorBlock
 
-	head, status := cc.FullyVerifiedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
 		"empty verifier post-activation must contribute its activation anchor, not empty")
 	require.Equal(t, anchorBlock.ID(), head.Block,
@@ -221,8 +221,8 @@ func TestChainContainer_FullyVerifiedL2Head_AllUnverified_ContributeAnchors(t *t
 	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
 	eng.l2BlockRefByNumberResult = anchorBlock
 
-	head, status := cc.FullyVerifiedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadAnchor, head.Source)
 	require.Equal(t, anchorBlock.ID(), head.Block)
 }
@@ -248,8 +248,8 @@ func TestChainContainer_FullyVerifiedL2Head_MixedAnchorAndVerified_OldestWins(t 
 	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
 	eng.l2BlockRefByNumberResult = anchorBlock
 
-	head, status := cc.FullyVerifiedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
 		"oldest contribution is v1's anchor at TS 999; v2's verified tip at TS 2500 is newer")
 	require.Equal(t, anchorBlock.ID(), head.Block)
@@ -281,8 +281,8 @@ func TestChainContainer_FullyVerifiedL2Head_OneEmptyOneVerified_AnchorOlder(t *t
 	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
 	eng.l2BlockRefByNumberResult = anchorBlock
 
-	head, status := cc.FullyVerifiedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
 		"v2's anchor at TS 999 is the oldest contribution")
 	require.Equal(t, anchorBlock.ID(), head.Block)
@@ -303,8 +303,8 @@ func TestChainContainer_FullyVerifiedL2Head_PreActivation_ReturnsPreActivationSo
 	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
 	cc.verifiers = []activity.VerificationActivity{v}
 
-	head, status := cc.FullyVerifiedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source,
 		"pre-activation → caller uses local-safe (Source=PreActivation)")
 	require.Equal(t, eth.BlockID{}, head.Block)
@@ -322,8 +322,8 @@ func TestChainContainer_FullyVerifiedL2Head_AllPreActivation_ReturnsPreActivatio
 	v2 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 2000}
 	cc.verifiers = []activity.VerificationActivity{v1, v2}
 
-	head, status := cc.FullyVerifiedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
 }
 
@@ -346,8 +346,8 @@ func TestChainContainer_FullyVerifiedL2Head_MixedActiveAndPreActivation_SkipsIna
 	preAct := &mockVerificationActivityForSuperAuthority{activationTimestamp: 2000}
 	cc.verifiers = []activity.VerificationActivity{active, preAct}
 
-	head, status := cc.FullyVerifiedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status,
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok,
 		"not-yet-active verifier must be skipped, not surface as HoldPrevious")
 	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
 	require.Equal(t, active.latestVerifiedBlock, head.Block)
@@ -371,8 +371,8 @@ func TestChainContainer_FullyVerifiedL2Head_VerifierError_ReturnsHoldPrevious(t 
 	}
 	cc.verifiers = []activity.VerificationActivity{v}
 
-	head, status := cc.FullyVerifiedL2Head()
-	require.Equal(t, rollup.VerifierHeadHoldPrevious, status,
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.False(t, ok,
 		"verifier read error must surface as HoldPrevious so the caller floors at finalized, "+
 			"NOT use local-safe (that was the bug)")
 	require.Equal(t, eth.BlockID{}, head.Block)
@@ -408,8 +408,8 @@ func TestChainContainer_FinalizedL2Head_MultipleVerifiers_OldestWins(t *testing.
 	}
 	cc.verifiers = []activity.VerificationActivity{v1, v2, v3}
 
-	head, status := cc.FinalizedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
 	require.Equal(t, v1.latestFinalizedBlock, head.Block)
 }
@@ -419,8 +419,8 @@ func TestChainContainer_FinalizedL2Head_NoVerifiers_ReturnsPreActivation(t *test
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
 
-	head, status := cc.FinalizedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
 }
 
@@ -439,8 +439,8 @@ func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierContributesA
 	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
 	eng.l2BlockRefByNumberResult = anchorBlock
 
-	head, status := cc.FinalizedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
 		"empty verifier post-activation contributes anchor (fixes the safeDB-to-genesis bug, #20944)")
 	require.Equal(t, anchorBlock.ID(), head.Block)
@@ -458,8 +458,8 @@ func TestChainContainer_FinalizedL2Head_PreActivation_ReturnsPreActivationSource
 	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
 	cc.verifiers = []activity.VerificationActivity{v}
 
-	head, status := cc.FinalizedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
 }
 
@@ -476,8 +476,8 @@ func TestChainContainer_FinalizedL2Head_AllPreActivation_ReturnsPreActivationSou
 	v2 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 2000}
 	cc.verifiers = []activity.VerificationActivity{v1, v2}
 
-	head, status := cc.FinalizedL2Head()
-	require.Equal(t, rollup.VerifierHeadOk, status)
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
 }
 
@@ -496,8 +496,8 @@ func TestChainContainer_FinalizedL2Head_VerifierError_ReturnsHoldPrevious(t *tes
 	}
 	cc.verifiers = []activity.VerificationActivity{v}
 
-	head, status := cc.FinalizedL2Head()
-	require.Equal(t, rollup.VerifierHeadHoldPrevious, status,
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.False(t, ok,
 		"verifier read error must surface as HoldPrevious, NOT use local-finalized")
 	require.Equal(t, eth.BlockID{}, head.Block)
 }
@@ -516,7 +516,7 @@ func TestChainContainer_FinalizedL2Head_SyncStatusError_ReturnsHoldPrevious(t *t
 	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
 	cc.verifiers = []activity.VerificationActivity{v}
 
-	head, status := cc.FinalizedL2Head()
-	require.Equal(t, rollup.VerifierHeadHoldPrevious, status)
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.False(t, ok)
 	require.Equal(t, eth.BlockID{}, head.Block)
 }

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -3,8 +3,11 @@ package chain_container
 import (
 	"context"
 	"errors"
+	"math/big"
 	"testing"
 
+	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
@@ -20,9 +23,9 @@ type mockVerificationActivityForSuperAuthority struct {
 	latestFinalizedBlock eth.BlockID
 	latestFinalizedTS    uint64
 	latestFinalizedErr   error
-	// isActiveAtFn drives IsActiveAt for pre-activation fallback tests.
-	// When nil, IsActiveAt returns true (active for all timestamps), matching
-	// the default "always-active" semantics the existing tests assume.
+	activationTimestamp  uint64
+	// isActiveAtFn drives IsActiveAt. When nil, IsActiveAt returns true for any
+	// timestamp >= activationTimestamp (matching the production semantics).
 	isActiveAtFn func(ts uint64) bool
 }
 
@@ -46,12 +49,18 @@ func (m *mockVerificationActivityForSuperAuthority) IsActiveAt(ts uint64) bool {
 	if m.isActiveAtFn != nil {
 		return m.isActiveAtFn(ts)
 	}
-	return true
+	return ts >= m.activationTimestamp
+}
+func (m *mockVerificationActivityForSuperAuthority) ActivationTimestamp() uint64 {
+	return m.activationTimestamp
 }
 
 var _ activity.VerificationActivity = (*mockVerificationActivityForSuperAuthority)(nil)
 
-// newTestChainContainer creates a simpleChainContainer for testing with a test logger
+// newTestChainContainer creates a simpleChainContainer with a test logger and a
+// mock virtual node. Engine and vncfg are nil — tests that exercise the anchor
+// path (Source == VerifierHeadAnchor) should use newTestChainContainerWithAnchor
+// to install both.
 func newTestChainContainer(t *testing.T, chainID eth.ChainID) *simpleChainContainer {
 	return &simpleChainContainer{
 		chainID:   chainID,
@@ -61,284 +70,24 @@ func newTestChainContainer(t *testing.T, chainID eth.ChainID) *simpleChainContai
 	}
 }
 
-// TestChainContainer_FullyVerifiedL2Head_MultipleVerifiers tests that FullyVerifiedL2Head
-// returns the block with the minimum (oldest) timestamp across all verifiers
-func TestChainContainer_FullyVerifiedL2Head_MultipleVerifiers(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
+// newTestChainContainerWithAnchor extends newTestChainContainer with a mock
+// engine and a rollup config so the activation-anchor lookup
+// (vncfg.Rollup.TargetBlockNumber + engine.L2BlockRefByNumber) can succeed in
+// tests that exercise the Anchor source.
+func newTestChainContainerWithAnchor(t *testing.T, chainID eth.ChainID) (*simpleChainContainer, *mockEngineController) {
 	cc := newTestChainContainer(t, chainID)
-
-	// Setup three verifiers with different timestamps
-	verifier1 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestVerifiedTS:    1000, // oldest
+	eng := newMockEngineController()
+	cc.engine = eng
+	cc.vncfg = &opnodecfg.Config{
+		Rollup: rollup.Config{
+			L2ChainID: big.NewInt(420),
+			BlockTime: 2,
+		},
 	}
-	verifier2 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{2}, Number: 200},
-		latestVerifiedTS:    2000, // middle
-	}
-	verifier3 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
-		latestVerifiedTS:    3000, // newest
-	}
-
-	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2, verifier3}
-
-	// Should return the block with minimum timestamp (verifier1)
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, verifier1.latestVerifiedBlock, result, "should return oldest verified block")
-	require.False(t, useLocalSafe, "should not signal fallback when verifiers have verified blocks")
+	return cc, eng
 }
 
-// TestChainContainer_FullyVerifiedL2Head_NoVerifiers tests that FullyVerifiedL2Head
-// returns an empty BlockID and signals fallback when there are no verification activities
-func TestChainContainer_FullyVerifiedL2Head_NoVerifiers(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID with no verifiers")
-	require.True(t, useLocalSafe, "should signal fallback to local-safe when no verifiers registered")
-}
-
-// TestChainContainer_FullyVerifiedL2Head_OneUnverified tests that FullyVerifiedL2Head
-// returns an empty BlockID without signaling fallback if any verifier returns an unverified state
-func TestChainContainer_FullyVerifiedL2Head_OneUnverified(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	// Setup verifiers where one is unverified (empty BlockID)
-	verifier1 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestVerifiedTS:    1000,
-	}
-	verifier2 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{}, // unverified
-		latestVerifiedTS:    0,             // zero timestamp
-	}
-	verifier3 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
-		latestVerifiedTS:    3000,
-	}
-
-	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2, verifier3}
-
-	// Should return empty BlockID (conservative approach) but NOT signal fallback
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID when any verifier is unverified")
-	require.False(t, useLocalSafe, "should not signal fallback when verifiers exist but are unverified")
-}
-
-// TestChainContainer_FullyVerifiedL2Head_SameTimestamp tests that FullyVerifiedL2Head
-// panics when multiple verifiers report the same timestamp but different block hashes
-func TestChainContainer_FullyVerifiedL2Head_SameTimestamp(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	// Setup verifiers with same timestamp but different block hashes
-	verifier1 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestVerifiedTS:    1000,
-	}
-	verifier2 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{2}, Number: 100},
-		latestVerifiedTS:    1000, // same timestamp, different hash
-	}
-
-	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2}
-
-	// Should panic because verifiers disagree on block hash for same timestamp
-	require.Panics(t, func() {
-		_, _ = cc.FullyVerifiedL2Head()
-	}, "should panic when verifiers disagree on block hash for same timestamp")
-}
-
-// TestChainContainer_FullyVerifiedL2Head_SingleVerifier tests the simple case
-// with just one verification activity
-func TestChainContainer_FullyVerifiedL2Head_SingleVerifier(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	verifier := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestVerifiedTS:    1000,
-	}
-
-	cc.verifiers = []activity.VerificationActivity{verifier}
-
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, verifier.latestVerifiedBlock, result, "should return the single verifier's block")
-	require.False(t, useLocalSafe, "should not signal fallback when verifier has verified blocks")
-}
-
-// TestChainContainer_FullyVerifiedL2Head_AllUnverified tests that an empty BlockID
-// is returned without signaling fallback when all verifiers are unverified
-func TestChainContainer_FullyVerifiedL2Head_AllUnverified(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	// All verifiers unverified
-	verifier1 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{},
-		latestVerifiedTS:    0,
-	}
-	verifier2 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{},
-		latestVerifiedTS:    0,
-	}
-
-	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2}
-
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID when all verifiers are unverified")
-	require.False(t, useLocalSafe, "should not signal fallback when verifiers exist but are unverified")
-}
-
-// TestChainContainer_FinalizedL2Head_MultipleVerifiers tests that FinalizedL2Head
-// returns the block with the minimum (oldest) timestamp across all verifiers
-func TestChainContainer_FinalizedL2Head_MultipleVerifiers(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	// Setup three verifiers with different timestamps
-	verifier1 := &mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestFinalizedTS:    1000, // oldest
-	}
-	verifier2 := &mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{2}, Number: 200},
-		latestFinalizedTS:    2000, // middle
-	}
-	verifier3 := &mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
-		latestFinalizedTS:    3000, // newest
-	}
-
-	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2, verifier3}
-
-	// Should return the block with minimum timestamp (verifier1)
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, verifier1.latestFinalizedBlock, result, "should return oldest finalized block")
-	require.False(t, useLocalFinalized, "should not signal fallback when verifiers have finalized blocks")
-}
-
-// TestChainContainer_FinalizedL2Head_NoVerifiers tests that FinalizedL2Head
-// returns an empty BlockID and signals fallback when there are no verification activities
-func TestChainContainer_FinalizedL2Head_NoVerifiers(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID with no verifiers")
-	require.True(t, useLocalFinalized, "should signal fallback to local-finalized when no verifiers registered")
-}
-
-// TestChainContainer_FinalizedL2Head_OneUnfinalized tests that FinalizedL2Head
-// returns an empty BlockID without signaling fallback if any verifier returns an unfinalized state
-func TestChainContainer_FinalizedL2Head_OneUnfinalized(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	// Setup verifiers where one is unfinalized (empty BlockID)
-	verifier1 := &mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestFinalizedTS:    1000,
-	}
-	verifier2 := &mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: eth.BlockID{}, // unfinalized
-		latestFinalizedTS:    0,             // zero timestamp
-	}
-	verifier3 := &mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
-		latestFinalizedTS:    3000,
-	}
-
-	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2, verifier3}
-
-	// Should return empty BlockID (conservative approach) but NOT signal fallback
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID when any verifier is unfinalized")
-	require.False(t, useLocalFinalized, "should not signal fallback when verifiers exist but are unfinalized")
-}
-
-// TestChainContainer_FinalizedL2Head_SingleVerifier tests the simple case
-// with just one verification activity
-func TestChainContainer_FinalizedL2Head_SingleVerifier(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	verifier := &mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestFinalizedTS:    1000,
-	}
-
-	cc.verifiers = []activity.VerificationActivity{verifier}
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, verifier.latestFinalizedBlock, result, "should return the single verifier's block")
-	require.False(t, useLocalFinalized, "should not signal fallback when verifier has finalized blocks")
-}
-
-// TestChainContainer_FinalizedL2Head_AllUnfinalized tests that an empty BlockID
-// is returned without signaling fallback when all verifiers are unfinalized
-func TestChainContainer_FinalizedL2Head_AllUnfinalized(t *testing.T) {
-	t.Parallel()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	cc := newTestChainContainer(t, chainID)
-
-	// All verifiers unfinalized
-	verifier1 := &mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: eth.BlockID{},
-		latestFinalizedTS:    0,
-	}
-	verifier2 := &mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: eth.BlockID{},
-		latestFinalizedTS:    0,
-	}
-
-	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2}
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID when all verifiers are unfinalized")
-	require.False(t, useLocalFinalized, "should not signal fallback when verifiers exist but are unfinalized")
-}
-
-// =============================================================================
-// Pre-activation fallback tests (issue #20191)
-// =============================================================================
-//
-// These tests pin the contract that when every registered verifier reports
-// IsActiveAt(ss.LocalSafeL2.Time) == false (i.e. the supernode has interop
-// scheduled but the L1-derived local-safe head has not yet crossed the
-// activation timestamp), super_authority falls back to local-safe /
-// local-finalized rather than stalling the engine at genesis.
-//
-// Note: super_authority consults IsActiveAt(ss.LocalSafeL2.Time) for both the
-// safe and finalized head queries, since FinalizedL2 <= LocalSafeL2 always:
-// if local-safe is still pre-activation, finalized is too.
-
-// setSyncStatus configures the chain's mock virtual node to return the given
-// SyncStatus. The test-only mockVirtualNode always backs newTestChainContainer.
+// setSyncStatus configures the chain's mock virtual node to return the given SyncStatus.
 func setSyncStatus(t *testing.T, cc *simpleChainContainer, ss *eth.SyncStatus) {
 	t.Helper()
 	mvn, ok := cc.vn.(*mockVirtualNode)
@@ -346,16 +95,204 @@ func setSyncStatus(t *testing.T, cc *simpleChainContainer, ss *eth.SyncStatus) {
 	mvn.syncStatusOverride = func() (*eth.SyncStatus, error) { return ss, nil }
 }
 
-// preActivationFn returns an isActiveAtFn that reports inactive for all
-// timestamps strictly below activationTS.
-func preActivationFn(activationTS uint64) func(ts uint64) bool {
-	return func(ts uint64) bool { return ts >= activationTS }
+// =============================================================================
+// FullyVerifiedL2Head — happy paths
+// =============================================================================
+
+func TestChainContainer_FullyVerifiedL2Head_MultipleVerifiers_OldestWins(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	v1 := &mockVerificationActivityForSuperAuthority{
+		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
+		latestVerifiedTS:    1000, // oldest
+	}
+	v2 := &mockVerificationActivityForSuperAuthority{
+		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{2}, Number: 200},
+		latestVerifiedTS:    2000,
+	}
+	v3 := &mockVerificationActivityForSuperAuthority{
+		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
+		latestVerifiedTS:    3000,
+	}
+	cc.verifiers = []activity.VerificationActivity{v1, v2, v3}
+
+	head, status := cc.FullyVerifiedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
+	require.Equal(t, v1.latestVerifiedBlock, head.Block, "should return oldest verified block")
 }
 
-// TestChainContainer_FullyVerifiedL2Head_PreActivation_FallsBackToLocalSafe
-// (case B1a) verifies that a single verifier reporting pre-activation for the
-// current LocalSafeL2 timestamp causes a fallback to local-safe.
-func TestChainContainer_FullyVerifiedL2Head_PreActivation_FallsBackToLocalSafe(t *testing.T) {
+func TestChainContainer_FullyVerifiedL2Head_NoVerifiers_ReturnsPreActivation(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+
+	head, status := cc.FullyVerifiedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source,
+		"no verifiers registered → PreActivation; caller uses local-safe")
+	require.Equal(t, eth.BlockID{}, head.Block)
+}
+
+func TestChainContainer_FullyVerifiedL2Head_SingleVerifier(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	v := &mockVerificationActivityForSuperAuthority{
+		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
+		latestVerifiedTS:    1000,
+	}
+	cc.verifiers = []activity.VerificationActivity{v}
+
+	head, status := cc.FullyVerifiedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
+	require.Equal(t, v.latestVerifiedBlock, head.Block)
+}
+
+func TestChainContainer_FullyVerifiedL2Head_VerifiersDisagreeAtSameTimestamp_Panics(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	v1 := &mockVerificationActivityForSuperAuthority{
+		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
+		latestVerifiedTS:    1000,
+	}
+	v2 := &mockVerificationActivityForSuperAuthority{
+		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{2}, Number: 100},
+		latestVerifiedTS:    1000, // same TS, different hash → consensus violation
+	}
+	cc.verifiers = []activity.VerificationActivity{v1, v2}
+
+	require.Panics(t, func() {
+		_, _ = cc.FullyVerifiedL2Head()
+	})
+}
+
+// =============================================================================
+// FullyVerifiedL2Head — anchor contribution (replaces "empty BlockID" cases)
+// =============================================================================
+
+// Under the new contract, a verifier that is active but has no verified-DB
+// entry for this chain contributes its activation-anchor block, NOT an empty
+// BlockID. This was bug B: post-activation empty verifiers caused SafeL2Head
+// to drop to genesis.
+
+func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierContributesAnchor(t *testing.T) {
+	t.Parallel()
+
+	cc, eng := newTestChainContainerWithAnchor(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
+	})
+
+	// Active verifier with no entries for this chain — contributes its anchor.
+	v := &mockVerificationActivityForSuperAuthority{
+		activationTimestamp: 1000,
+	}
+	cc.verifiers = []activity.VerificationActivity{v}
+
+	// Engine returns a real block for the anchor lookup
+	// (block at timestamp activationTS - 1 = 999 → block number 499 with BlockTime=2).
+	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
+	eng.l2BlockRefByNumberResult = anchorBlock
+
+	head, status := cc.FullyVerifiedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
+		"empty verifier post-activation must contribute its activation anchor, not empty")
+	require.Equal(t, anchorBlock.ID(), head.Block,
+		"anchor block must be the L2 block at activationTimestamp - 1")
+}
+
+func TestChainContainer_FullyVerifiedL2Head_AllUnverified_ContributeAnchors(t *testing.T) {
+	t.Parallel()
+
+	cc, eng := newTestChainContainerWithAnchor(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 3000},
+	})
+
+	v1 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
+	v2 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
+	cc.verifiers = []activity.VerificationActivity{v1, v2}
+
+	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
+	eng.l2BlockRefByNumberResult = anchorBlock
+
+	head, status := cc.FullyVerifiedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadAnchor, head.Source)
+	require.Equal(t, anchorBlock.ID(), head.Block)
+}
+
+func TestChainContainer_FullyVerifiedL2Head_MixedAnchorAndVerified_OldestWins(t *testing.T) {
+	t.Parallel()
+
+	cc, eng := newTestChainContainerWithAnchor(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 1000, Time: 3000},
+	})
+
+	// v1: empty → contributes anchor at TS 999 (older).
+	v1 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
+	// v2: has a verified tip at TS 2500 (newer).
+	v2 := &mockVerificationActivityForSuperAuthority{
+		activationTimestamp: 1000,
+		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{0xbb}, Number: 750},
+		latestVerifiedTS:    2500,
+	}
+	cc.verifiers = []activity.VerificationActivity{v1, v2}
+
+	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
+	eng.l2BlockRefByNumberResult = anchorBlock
+
+	head, status := cc.FullyVerifiedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
+		"oldest contribution is v1's anchor at TS 999; v2's verified tip at TS 2500 is newer")
+	require.Equal(t, anchorBlock.ID(), head.Block)
+}
+
+func TestChainContainer_FullyVerifiedL2Head_OneEmptyOneVerified_AnchorOlder(t *testing.T) {
+	t.Parallel()
+
+	cc, eng := newTestChainContainerWithAnchor(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 1000, Time: 3000},
+	})
+
+	v1 := &mockVerificationActivityForSuperAuthority{
+		activationTimestamp: 1000,
+		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
+		latestVerifiedTS:    2000, // newer than anchor
+	}
+	v2 := &mockVerificationActivityForSuperAuthority{
+		activationTimestamp: 1000, // empty → anchor at TS 999
+	}
+	v3 := &mockVerificationActivityForSuperAuthority{
+		activationTimestamp: 1000,
+		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
+		latestVerifiedTS:    3000,
+	}
+	cc.verifiers = []activity.VerificationActivity{v1, v2, v3}
+
+	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
+	eng.l2BlockRefByNumberResult = anchorBlock
+
+	head, status := cc.FullyVerifiedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
+		"v2's anchor at TS 999 is the oldest contribution")
+	require.Equal(t, anchorBlock.ID(), head.Block)
+}
+
+// =============================================================================
+// FullyVerifiedL2Head — pre-activation
+// =============================================================================
+
+func TestChainContainer_FullyVerifiedL2Head_PreActivation_ReturnsPreActivationSource(t *testing.T) {
 	t.Parallel()
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
@@ -363,66 +300,17 @@ func TestChainContainer_FullyVerifiedL2Head_PreActivation_FallsBackToLocalSafe(t
 		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xaa}, Time: 999},
 	})
 
-	verifier := &mockVerificationActivityForSuperAuthority{
-		isActiveAtFn: preActivationFn(1000),
-	}
-	cc.verifiers = []activity.VerificationActivity{verifier}
+	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
+	cc.verifiers = []activity.VerificationActivity{v}
 
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "pre-activation should return empty BlockID")
-	require.True(t, useLocalSafe, "pre-activation should signal fallback to local-safe")
+	head, status := cc.FullyVerifiedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source,
+		"pre-activation → caller uses local-safe (Source=PreActivation)")
+	require.Equal(t, eth.BlockID{}, head.Block)
 }
 
-// TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierNoFallback
-// (case B1b) verifies that once activation has been reached, the existing
-// "verifier present but nothing verified yet" behavior is preserved: no
-// fallback even though the verifier returns empty.
-func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierNoFallback(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
-	})
-
-	verifier := &mockVerificationActivityForSuperAuthority{
-		isActiveAtFn: preActivationFn(1000),
-	}
-	cc.verifiers = []activity.VerificationActivity{verifier}
-
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "post-activation empty verifier returns empty")
-	require.False(t, useLocalSafe, "post-activation empty verifier must not signal fallback")
-}
-
-// TestChainContainer_FullyVerifiedL2Head_PostActivation_VerifiedBlockReturned
-// (case B1c) verifies that the existing "happy path" of returning the
-// verifier's LatestVerifiedL2Block is preserved after activation.
-func TestChainContainer_FullyVerifiedL2Head_PostActivation_VerifiedBlockReturned(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
-	})
-
-	verifiedBlock := eth.BlockID{Hash: [32]byte{0x11}, Number: 100}
-	verifier := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: verifiedBlock,
-		latestVerifiedTS:    1500,
-		isActiveAtFn:        preActivationFn(1000),
-	}
-	cc.verifiers = []activity.VerificationActivity{verifier}
-
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, verifiedBlock, result, "post-activation should return verified block")
-	require.False(t, useLocalSafe, "post-activation with a verified block must not signal fallback")
-}
-
-// TestChainContainer_FullyVerifiedL2Head_AllPreActivation_FallsBackToLocalSafe
-// (case B1d) verifies the multi-verifier case: when every verifier reports
-// pre-activation, fall back to local-safe.
-func TestChainContainer_FullyVerifiedL2Head_AllPreActivation_FallsBackToLocalSafe(t *testing.T) {
+func TestChainContainer_FullyVerifiedL2Head_AllPreActivation_ReturnsPreActivationSource(t *testing.T) {
 	t.Parallel()
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
@@ -430,20 +318,16 @@ func TestChainContainer_FullyVerifiedL2Head_AllPreActivation_FallsBackToLocalSaf
 		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xaa}, Time: 999},
 	})
 
-	verifier1 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(1000)}
-	verifier2 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(2000)}
-	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2}
+	v1 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
+	v2 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 2000}
+	cc.verifiers = []activity.VerificationActivity{v1, v2}
 
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "all-pre-activation should return empty BlockID")
-	require.True(t, useLocalSafe, "all-pre-activation should signal fallback to local-safe")
+	head, status := cc.FullyVerifiedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
 }
 
-// TestChainContainer_FullyVerifiedL2Head_MixedActiveAndPreActivation_NoFallback
-// (case B1e) verifies that a partial pre-activation state does NOT force
-// fallback: if at least one verifier is active but unverified, the existing
-// conservative behavior (empty, false) holds.
-func TestChainContainer_FullyVerifiedL2Head_MixedActiveAndPreActivation_NoFallback(t *testing.T) {
+func TestChainContainer_FullyVerifiedL2Head_MixedActiveAndPreActivation_SkipsInactive(t *testing.T) {
 	t.Parallel()
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
@@ -451,126 +335,29 @@ func TestChainContainer_FullyVerifiedL2Head_MixedActiveAndPreActivation_NoFallba
 		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
 	})
 
+	// active: has a verified tip
 	active := &mockVerificationActivityForSuperAuthority{
-		isActiveAtFn: preActivationFn(1000), // active at 1500
+		activationTimestamp: 1000,
+		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{0x11}, Number: 250},
+		latestVerifiedTS:    1500,
 	}
-	preAct := &mockVerificationActivityForSuperAuthority{
-		isActiveAtFn: preActivationFn(2000), // still pre-activation at 1500
-	}
+	// preAct: not yet active — must be skipped, must NOT try to resolve an anchor
+	// for a block that doesn't exist on this chain yet.
+	preAct := &mockVerificationActivityForSuperAuthority{activationTimestamp: 2000}
 	cc.verifiers = []activity.VerificationActivity{active, preAct}
 
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "mixed case should return empty BlockID")
-	require.False(t, useLocalSafe, "mixed case must not signal fallback; at least one verifier is active and unverified")
+	head, status := cc.FullyVerifiedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status,
+		"not-yet-active verifier must be skipped, not surface as HoldPrevious")
+	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
+	require.Equal(t, active.latestVerifiedBlock, head.Block)
 }
 
-// TestChainContainer_FinalizedL2Head_PreActivation_FallsBackToLocalFinalized
-// (case B2a) mirrors B1a for the finalized head.
-func TestChainContainer_FinalizedL2Head_PreActivation_FallsBackToLocalFinalized(t *testing.T) {
-	t.Parallel()
+// =============================================================================
+// FullyVerifiedL2Head — verifier error → HoldPrevious (was: useLocalSafe=true)
+// =============================================================================
 
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		FinalizedL1: eth.L1BlockRef{Number: 40},
-		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xcc}, Time: 999},
-	})
-
-	verifier := &mockVerificationActivityForSuperAuthority{
-		isActiveAtFn: preActivationFn(1000),
-	}
-	cc.verifiers = []activity.VerificationActivity{verifier}
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result, "pre-activation should return empty BlockID")
-	require.True(t, useLocalFinalized, "pre-activation should signal fallback to local-finalized")
-}
-
-// TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierNoFallback
-// (case B2b) — post-activation, verifier empty → empty, no fallback (unchanged).
-func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierNoFallback(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		FinalizedL1: eth.L1BlockRef{Number: 400},
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
-	})
-
-	verifier := &mockVerificationActivityForSuperAuthority{
-		isActiveAtFn: preActivationFn(1000),
-	}
-	cc.verifiers = []activity.VerificationActivity{verifier}
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result)
-	require.False(t, useLocalFinalized, "post-activation empty verifier must not signal fallback")
-}
-
-// TestChainContainer_FinalizedL2Head_PostActivation_FinalizedBlockReturned
-// (case B2c) — post-activation, verifier has a finalized block → returned (unchanged).
-func TestChainContainer_FinalizedL2Head_PostActivation_FinalizedBlockReturned(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		FinalizedL1: eth.L1BlockRef{Number: 400},
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
-	})
-
-	finalizedBlock := eth.BlockID{Hash: [32]byte{0x22}, Number: 100}
-	verifier := &mockVerificationActivityForSuperAuthority{
-		latestFinalizedBlock: finalizedBlock,
-		latestFinalizedTS:    1500,
-		isActiveAtFn:         preActivationFn(1000),
-	}
-	cc.verifiers = []activity.VerificationActivity{verifier}
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, finalizedBlock, result, "post-activation should return finalized block")
-	require.False(t, useLocalFinalized)
-}
-
-// TestChainContainer_FinalizedL2Head_AllPreActivation_FallsBackToLocalFinalized
-// (case B2d) — multi-verifier all-pre-activation fallback.
-func TestChainContainer_FinalizedL2Head_AllPreActivation_FallsBackToLocalFinalized(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		FinalizedL1: eth.L1BlockRef{Number: 40},
-		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xcc}, Time: 999},
-	})
-
-	verifier1 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(1000)}
-	verifier2 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(2000)}
-	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2}
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result)
-	require.True(t, useLocalFinalized, "all-pre-activation should signal fallback to local-finalized")
-}
-
-func TestChainContainer_FinalizedL2Head_VerifierError_SignalsLocalFinalizedFallback(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		FinalizedL1: eth.L1BlockRef{Number: 400},
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
-	})
-
-	verifier := &mockVerificationActivityForSuperAuthority{
-		isActiveAtFn:       preActivationFn(1000),
-		latestFinalizedErr: errors.New("database not open"),
-	}
-	cc.verifiers = []activity.VerificationActivity{verifier}
-
-	result, useLocalFinalized := cc.FinalizedL2Head()
-	require.Equal(t, eth.BlockID{}, result)
-	require.True(t, useLocalFinalized)
-}
-
-func TestChainContainer_FullyVerifiedL2Head_VerifierError_SignalsLocalSafeFallback(t *testing.T) {
+func TestChainContainer_FullyVerifiedL2Head_VerifierError_ReturnsHoldPrevious(t *testing.T) {
 	t.Parallel()
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
@@ -578,13 +365,158 @@ func TestChainContainer_FullyVerifiedL2Head_VerifierError_SignalsLocalSafeFallba
 		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
 	})
 
-	verifier := &mockVerificationActivityForSuperAuthority{
-		isActiveAtFn:      preActivationFn(1000),
-		latestVerifiedErr: errors.New("database not open"),
+	v := &mockVerificationActivityForSuperAuthority{
+		activationTimestamp: 1000,
+		latestVerifiedErr:   errors.New("database not open"),
 	}
-	cc.verifiers = []activity.VerificationActivity{verifier}
+	cc.verifiers = []activity.VerificationActivity{v}
 
-	result, useLocalSafe := cc.FullyVerifiedL2Head()
-	require.Equal(t, eth.BlockID{}, result)
-	require.True(t, useLocalSafe)
+	head, status := cc.FullyVerifiedL2Head()
+	require.Equal(t, rollup.VerifierHeadHoldPrevious, status,
+		"verifier read error must surface as HoldPrevious so the caller floors at finalized, "+
+			"NOT use local-safe (that was the bug)")
+	require.Equal(t, eth.BlockID{}, head.Block)
+}
+
+// =============================================================================
+// FinalizedL2Head — same shape as FullyVerifiedL2Head
+// =============================================================================
+
+func TestChainContainer_FinalizedL2Head_MultipleVerifiers_OldestWins(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 1500},
+	})
+
+	v1 := &mockVerificationActivityForSuperAuthority{
+		activationTimestamp:  1000,
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
+		latestFinalizedTS:    1000, // oldest
+	}
+	v2 := &mockVerificationActivityForSuperAuthority{
+		activationTimestamp:  1000,
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{2}, Number: 200},
+		latestFinalizedTS:    2000,
+	}
+	v3 := &mockVerificationActivityForSuperAuthority{
+		activationTimestamp:  1000,
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
+		latestFinalizedTS:    3000,
+	}
+	cc.verifiers = []activity.VerificationActivity{v1, v2, v3}
+
+	head, status := cc.FinalizedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
+	require.Equal(t, v1.latestFinalizedBlock, head.Block)
+}
+
+func TestChainContainer_FinalizedL2Head_NoVerifiers_ReturnsPreActivation(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+
+	head, status := cc.FinalizedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
+}
+
+func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierContributesAnchor(t *testing.T) {
+	t.Parallel()
+
+	cc, eng := newTestChainContainerWithAnchor(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 1500},
+	})
+
+	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
+	cc.verifiers = []activity.VerificationActivity{v}
+
+	anchorBlock := eth.L2BlockRef{Hash: [32]byte{0xa1}, Number: 499, Time: 999}
+	eng.l2BlockRefByNumberResult = anchorBlock
+
+	head, status := cc.FinalizedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
+		"empty verifier post-activation contributes anchor (fixes the safeDB-to-genesis bug, #20944)")
+	require.Equal(t, anchorBlock.ID(), head.Block)
+}
+
+func TestChainContainer_FinalizedL2Head_PreActivation_ReturnsPreActivationSource(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 40},
+		LocalSafeL2: eth.L2BlockRef{Number: 50, Time: 999},
+	})
+
+	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
+	cc.verifiers = []activity.VerificationActivity{v}
+
+	head, status := cc.FinalizedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
+}
+
+func TestChainContainer_FinalizedL2Head_AllPreActivation_ReturnsPreActivationSource(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 40},
+		LocalSafeL2: eth.L2BlockRef{Number: 50, Time: 999},
+	})
+
+	v1 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
+	v2 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 2000}
+	cc.verifiers = []activity.VerificationActivity{v1, v2}
+
+	head, status := cc.FinalizedL2Head()
+	require.Equal(t, rollup.VerifierHeadOk, status)
+	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
+}
+
+func TestChainContainer_FinalizedL2Head_VerifierError_ReturnsHoldPrevious(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 1500},
+	})
+
+	v := &mockVerificationActivityForSuperAuthority{
+		activationTimestamp: 1000,
+		latestFinalizedErr:  errors.New("database not open"),
+	}
+	cc.verifiers = []activity.VerificationActivity{v}
+
+	head, status := cc.FinalizedL2Head()
+	require.Equal(t, rollup.VerifierHeadHoldPrevious, status,
+		"verifier read error must surface as HoldPrevious, NOT use local-finalized")
+	require.Equal(t, eth.BlockID{}, head.Block)
+}
+
+// SyncStatus error path: under the new contract this returns HoldPrevious so the
+// caller floors at finalized instead of silently advancing.
+func TestChainContainer_FinalizedL2Head_SyncStatusError_ReturnsHoldPrevious(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	mvn := cc.vn.(*mockVirtualNode)
+	mvn.syncStatusOverride = func() (*eth.SyncStatus, error) {
+		return nil, errors.New("vn not ready")
+	}
+
+	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
+	cc.verifiers = []activity.VerificationActivity{v}
+
+	head, status := cc.FinalizedL2Head()
+	require.Equal(t, rollup.VerifierHeadHoldPrevious, status)
+	require.Equal(t, eth.BlockID{}, head.Block)
 }

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -171,13 +171,12 @@ func TestChainContainer_FullyVerifiedL2Head_VerifiersDisagreeAtSameTimestamp_Pan
 // =============================================================================
 
 // Under the new contract, a verifier that is active but has no verified-DB
-// entry for this chain contributes its activation-anchor block, NOT an empty
-// BlockID. This was bug B: post-activation empty verifiers caused SafeL2Head
-// to drop to genesis.
+// entry for this chain contributes its activation-anchor timestamp, NOT an
+// empty BlockID. This was bug B: post-activation empty verifiers caused
+// SafeL2Head to drop to genesis.
 
-// Chain_container no longer resolves anchor blocks — it returns the cap
-// timestamp via VerifierHead.Timestamp and the engine controller does the
-// L2BlockRefByNumber lookup. These tests pin the timestamp pass-through.
+// Chain_container does not resolve anchor blocks — it returns the cap timestamp
+// via VerifierHead.Timestamp. These tests pin the timestamp pass-through.
 
 func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierContributesAnchor(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Stacked on #21049.

This keeps the smaller approach: make SuperAuthority safe-head failures and anchor results fall back to finalized instead of local-safe, while preserving Adrian's tri-state verifier model.

What changed:
- safe head HoldPrevious falls back to FinalizedHead
- safe head Anchor falls back to FinalizedHead
- verified safe heads use a single canonical number/hash check before publishing
- finalized anchor resolution preserves the existing finalized cache monotonicity
- tests/docs updated around the fallback semantics

Validation:
- go test ./op-supernode/supernode/chain_container ./op-supernode/supernode/activity/internal/syncstatus ./op-node/rollup/engine ./op-supernode/supernode/activity/interop
- git diff --check