### PR TITLE
[codex] simplify SuperAuthority verifier aggregation

### DIFF
--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -13,14 +13,14 @@ import (
 type VerifierHeadSource uint8
 
 const (
-	// VerifierHeadPreActivation: every registered verifier is inactive at the
+	// VerifierHeadPreActivation: the registered verifier is inactive at the
 	// current local-safe timestamp. Caller uses local-safe / local-finalized.
 	VerifierHeadPreActivation VerifierHeadSource = iota
-	// VerifierHeadAnchor: at least one active verifier has no verified-DB entry
+	// VerifierHeadAnchor: the active verifier has no verified-DB entry
 	// for this chain yet. Timestamp is the pre-activation cap:
 	// `verifier.ActivationTimestamp() - 1`.
 	VerifierHeadAnchor
-	// VerifierHeadVerified: Block is the oldest verified tip across active verifiers.
+	// VerifierHeadVerified: Block is the verified tip.
 	VerifierHeadVerified
 )
 

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -52,16 +52,19 @@ type VerificationActivity interface {
 	// data at or before that timestamp as safe without consulting this activity.
 	IsActiveAt(ts uint64) bool
 
+	// ActivationTimestamp returns the timestamp at which this verifier becomes
+	// active. Callers may use ActivationTimestamp()-1 as a pre-activation anchor
+	// when the verifier is active but has no verified DB entry yet.
+	ActivationTimestamp() uint64
+
 	// LatestVerifiedL2Block returns the latest verified L2 block.
-	// (block, ts, nil) — verified tip at ts.
-	// (empty, ts, nil) — no verified entry; ts is the pre-activation cap the
-	//   caller should resolve to a canonical L2 block. ts==0 means no cap.
-	// (empty, 0, err) — verifier is transiently unavailable.
+	// (block, ts, nil) - verified tip at ts.
+	// (empty, 0, nil) - no verified entry.
+	// (empty, 0, err) - verifier is transiently unavailable.
 	LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error)
 
 	// VerifiedBlockAtL1 returns the latest verified L2 block whose data was
 	// derived from or before the supplied L1 block. Return shape matches
-	// LatestVerifiedL2Block: an empty BlockID with non-zero ts is a cap, not a
-	// failure.
+	// LatestVerifiedL2Block.
 	VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64, error)
 }

--- a/op-supernode/supernode/activity/internal/syncstatus/syncstatus.go
+++ b/op-supernode/supernode/activity/internal/syncstatus/syncstatus.go
@@ -35,13 +35,13 @@ func Aggregate(ctx context.Context, log gethlog.Logger, chains map[eth.ChainID]c
 		}
 		statuses[chainID] = *status
 
-		// Get current L1s — the minimum L1 block that all derivation pipelines and verifiers have processed.
+		// Get current L1s — the minimum L1 block that all derivation pipelines and verifier activity have processed.
 		// This informs callers that the chains' local views have considered at least up to this L1 block.
 		currentL1 := status.CurrentL1.ID()
 		if currentL1.Number < minCurrentL1.Number || minCurrentL1 == (eth.BlockID{}) {
 			minCurrentL1 = currentL1
 		}
-		// Also consider the L1 progress of any registered verifiers.
+		// Also consider the L1 progress of any registered verifier.
 		for _, verifierL1 := range chain.VerifierCurrentL1s() {
 			if verifierL1.Number < minCurrentL1.Number || minCurrentL1 == (eth.BlockID{}) {
 				minCurrentL1 = verifierL1

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1197,52 +1197,40 @@ func (i *Interop) ActivationTimestamp() uint64 {
 	return i.activationTimestamp
 }
 
-// activationCap is the L2 timestamp the verifier reports as a cap when it has
-// no verified entry for the caller's chain. Returns 0 when no activation
-// timestamp is configured — caller treats that as "no contribution".
-func (i *Interop) activationCap() uint64 {
-	if i.activationTimestamp == 0 {
-		return 0
-	}
-	return i.activationTimestamp - 1
-}
-
 // LatestVerifiedL2Block returns the latest verified L2 block for chainID.
-// (empty, capTimestamp, nil) means nothing verified — capTimestamp is the
-// pre-activation cap (`activationTimestamp - 1`).
-// A non-nil error means verifiedDB could not be read.
+// (empty, 0, nil) means nothing verified. A non-nil error means verifiedDB
+// could not be read.
 func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error) {
 	emptyBlock := eth.BlockID{}
 	ts, ok := i.verifiedDB.LastTimestamp()
 	if !ok {
-		return emptyBlock, i.activationCap(), nil
+		return emptyBlock, 0, nil
 	}
 	res, err := i.verifiedDB.Get(ts)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			return emptyBlock, i.activationCap(), nil
+			return emptyBlock, 0, nil
 		}
 		return emptyBlock, 0, fmt.Errorf("LatestVerifiedL2Block: read verifiedDB at %d: %w", ts, err)
 	}
 	head, ok := res.L2Heads[chainID]
 	if !ok {
-		return emptyBlock, i.activationCap(), nil
+		return emptyBlock, 0, nil
 	}
 	return head, ts, nil
 }
 
 // VerifiedBlockAtL1 returns the latest verified L2 block for chainID whose
-// L1 inclusion is at or below l1Block. (empty, capTimestamp, nil) means no
-// match — capTimestamp is the pre-activation anchor for the caller to resolve.
-// A non-nil error means verifiedDB could not be read.
+// L1 inclusion is at or below l1Block. (empty, 0, nil) means no match. A
+// non-nil error means verifiedDB could not be read.
 func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64, error) {
 	if l1Block == (eth.L1BlockRef{}) {
-		return eth.BlockID{}, i.activationCap(), nil
+		return eth.BlockID{}, 0, nil
 	}
 
 	lastTs, ok := i.verifiedDB.LastTimestamp()
 	if !ok {
-		return eth.BlockID{}, i.activationCap(), nil
+		return eth.BlockID{}, 0, nil
 	}
 
 	// activationTimestamp is the floor: no verified results exist before activation.
@@ -1261,13 +1249,13 @@ func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef)
 		if result.L1Inclusion.Number <= l1Block.Number {
 			head, ok := result.L2Heads[chainID]
 			if !ok {
-				return eth.BlockID{}, i.activationCap(), nil
+				return eth.BlockID{}, 0, nil
 			}
 			return head, ts, nil
 		}
 	}
 
-	return eth.BlockID{}, i.activationCap(), nil
+	return eth.BlockID{}, 0, nil
 }
 
 // Reset is intentionally a no-op for interop.

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -2838,8 +2838,7 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		blockID, ts, err := h.interop.VerifiedBlockAtL1(h.Mock(10).id, eth.L1BlockRef{})
 		require.NoError(t, err)
 		require.Equal(t, eth.BlockID{}, blockID)
-		// Empty result returns the pre-activation cap (activationTimestamp-1).
-		require.Equal(t, h.interop.activationTimestamp-1, ts)
+		require.Equal(t, uint64(0), ts)
 	})
 
 	t.Run("non-zero l1Block finds matching entry", func(t *testing.T) {
@@ -2880,8 +2879,7 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		blockID, ts, err := h.interop.VerifiedBlockAtL1(h.Mock(10).id, l1Block)
 		require.NoError(t, err)
 		require.Equal(t, eth.BlockID{}, blockID)
-		// Empty DB returns the pre-activation cap (activationTimestamp-1).
-		require.Equal(t, h.interop.activationTimestamp-1, ts)
+		require.Equal(t, uint64(0), ts)
 	})
 
 	t.Run("closed verifiedDB surfaces error", func(t *testing.T) {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -71,8 +71,7 @@ type ChainContainer interface {
 	OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error)
 	OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputV0, error)
 	RegisterVerifier(v activity.VerificationActivity)
-	// VerifierCurrentL1s returns the CurrentL1 from each registered verifier.
-	// This allows callers to determine the minimum L1 block that all verifiers have processed.
+	// VerifierCurrentL1s returns the CurrentL1 from the registered verifier, if any.
 	VerifierCurrentL1s() []eth.BlockID
 	// FetchReceipts fetches the receipts for a given block by hash.
 	// Returns block info and receipts, or an error if the block or receipts cannot be fetched.
@@ -161,10 +160,10 @@ type simpleChainContainer struct {
 	rollupClient       *sources.RollupClient // In-proc rollup RPC client bound to rpcHandler
 	metrics            *resources.SupernodeMetrics
 
-	// verifiersMu guards writes and reads of the verifiers slice.
-	verifiersMu sync.RWMutex
-	verifiers   []activity.VerificationActivity
-	onReset     ResetCallback // Called when chain resets to notify activities
+	// verifierMu guards writes and reads of the verifier.
+	verifierMu sync.RWMutex
+	verifier   activity.VerificationActivity
+	onReset    ResetCallback // Called when chain resets to notify activities
 }
 
 // Interface conformance assertions
@@ -224,22 +223,30 @@ func (c *simpleChainContainer) ID() eth.ChainID {
 	return c.chainID
 }
 
-// RegisterVerifier adds a verification activity to this chain container.
+// RegisterVerifier adds the verification activity to this chain container.
 // This allows late binding when activities and chains have circular dependencies.
+// The chain container supports a single verifier activity.
 func (c *simpleChainContainer) RegisterVerifier(v activity.VerificationActivity) {
-	c.verifiersMu.Lock()
-	defer c.verifiersMu.Unlock()
-	c.verifiers = append(c.verifiers, v)
+	c.verifierMu.Lock()
+	defer c.verifierMu.Unlock()
+	if c.verifier != nil {
+		panic("chain container supports only one verifier")
+	}
+	c.verifier = v
 }
 
 func (c *simpleChainContainer) VerifierCurrentL1s() []eth.BlockID {
-	c.verifiersMu.RLock()
-	defer c.verifiersMu.RUnlock()
-	result := make([]eth.BlockID, len(c.verifiers))
-	for i, v := range c.verifiers {
-		result[i] = v.CurrentL1()
+	v := c.registeredVerifier()
+	if v == nil {
+		return nil
 	}
-	return result
+	return []eth.BlockID{v.CurrentL1()}
+}
+
+func (c *simpleChainContainer) registeredVerifier() activity.VerificationActivity {
+	c.verifierMu.RLock()
+	defer c.verifierMu.RUnlock()
+	return c.verifier
 }
 
 // defaultVirtualNodeFactory is the default factory that creates a real VirtualNode

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -3,7 +3,6 @@ package chain_container
 import (
 	"context"
 	"fmt"
-	"math"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -13,45 +12,34 @@ import (
 
 // FullyVerifiedL2Head reports the cross-verified safe L2 head.
 //
-// Per active verifier, contribute either the verified tip or an Anchor with
-// the pre-activation cap timestamp (returned by the verifier when it has no
-// entry for this chain). Take the oldest contribution. Not-yet-active
-// verifiers are skipped. The caller decides whether to resolve Anchor timestamps
-// or fall back more conservatively.
-//
-// Panics if two active verifiers report distinct Verified tips at the same
-// timestamp.
+// The verifier contributes either the verified tip or an Anchor with the
+// pre-activation cap timestamp (returned by the verifier when it has no entry
+// for this chain). A not-yet-active verifier returns PreActivation. The caller
+// decides whether to resolve Anchor timestamps or fall back more conservatively.
 func (c *simpleChainContainer) FullyVerifiedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
-	if len(c.verifiers) == 0 {
+	v := c.registeredVerifier()
+	if v == nil {
 		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
 
 	localTS, localTSOk := c.localSafeTimestamp(ctx)
-
-	oldest := rollup.VerifierHead{Timestamp: math.MaxUint64}
-	contributed := 0
-	for _, v := range c.verifiers {
-		if localTSOk && !v.IsActiveAt(localTS) {
-			continue
-		}
-		contribution, err := c.verifierContribution(v.LatestVerifiedL2Block(c.chainID))
-		if err != nil {
-			c.log.Warn("FullyVerifiedL2Head: verifier read failed, holding previous",
-				"verifier", v.Name(), "err", err)
-			return rollup.VerifierHead{}, false
-		}
-		contributed++
-		oldest = pickOldest(oldest, contribution)
-	}
-	if contributed == 0 {
+	if localTSOk && !v.IsActiveAt(localTS) {
 		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
-	return oldest, true
+
+	head, err := c.verifierContribution(v.LatestVerifiedL2Block(c.chainID))
+	if err != nil {
+		c.log.Warn("FullyVerifiedL2Head: verifier read failed, holding previous",
+			"verifier", v.Name(), "err", err)
+		return rollup.VerifierHead{}, false
+	}
+	return head, true
 }
 
 // FinalizedL2Head is the finalized analogue of FullyVerifiedL2Head.
 func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
-	if len(c.verifiers) == 0 {
+	v := c.registeredVerifier()
+	if v == nil {
 		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
 
@@ -61,57 +49,30 @@ func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.Veri
 		return rollup.VerifierHead{}, false
 	}
 
-	oldest := rollup.VerifierHead{Timestamp: math.MaxUint64}
-	contributed := 0
-	for _, v := range c.verifiers {
-		if !v.IsActiveAt(ss.LocalSafeL2.Time) {
-			continue
-		}
-		contribution, err := c.verifierContribution(v.VerifiedBlockAtL1(c.chainID, ss.FinalizedL1))
-		if err != nil {
-			c.log.Warn("FinalizedL2Head: verifier read failed, holding previous",
-				"verifier", v.Name(), "err", err)
-			return rollup.VerifierHead{}, false
-		}
-		contributed++
-		oldest = pickOldest(oldest, contribution)
-	}
-	if contributed == 0 {
+	if !v.IsActiveAt(ss.LocalSafeL2.Time) {
 		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
-	return oldest, true
+
+	head, err := c.verifierContribution(v.VerifiedBlockAtL1(c.chainID, ss.FinalizedL1))
+	if err != nil {
+		c.log.Warn("FinalizedL2Head: verifier read failed, holding previous",
+			"verifier", v.Name(), "err", err)
+		return rollup.VerifierHead{}, false
+	}
+	return head, true
 }
 
 // verifierContribution classifies a verifier's (block, ts) return:
-//   - empty block → Anchor (ts is the pre-activation cap).
-//   - non-empty block → Verified tip.
-func (c *simpleChainContainer) verifierContribution(bId eth.BlockID, ts uint64, err error) (rollup.VerifierHead, error) {
+//   - empty block -> Anchor (ts is the pre-activation cap).
+//   - non-empty block -> Verified tip.
+func (c *simpleChainContainer) verifierContribution(bID eth.BlockID, ts uint64, err error) (rollup.VerifierHead, error) {
 	if err != nil {
 		return rollup.VerifierHead{}, err
 	}
-	if (bId == eth.BlockID{}) {
+	if (bID == eth.BlockID{}) {
 		return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor, Timestamp: ts}, nil
 	}
-	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bId, Timestamp: ts}, nil
-}
-
-// pickOldest returns the older of two contributions. Ties break toward Anchor
-// (more conservative). Panics if two Verified tips disagree at the same timestamp.
-func pickOldest(a, b rollup.VerifierHead) rollup.VerifierHead {
-	if b.Timestamp < a.Timestamp {
-		return b
-	}
-	if b.Timestamp > a.Timestamp {
-		return a
-	}
-	// Equal timestamps.
-	if a.Source == rollup.VerifierHeadVerified && b.Source == rollup.VerifierHeadVerified && a.Block != b.Block {
-		panic("verifiers disagree on block hash for same timestamp")
-	}
-	if b.Source == rollup.VerifierHeadAnchor && a.Source == rollup.VerifierHeadVerified {
-		return b
-	}
-	return a
+	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bID, Timestamp: ts}, nil
 }
 
 func (c *simpleChainContainer) localSafeTimestamp(ctx context.Context) (uint64, bool) {

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -6,16 +6,18 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum/go-ethereum/common"
 )
 
 // FullyVerifiedL2Head reports the cross-verified safe L2 head.
 //
-// The verifier contributes either the verified tip or an Anchor with the
-// pre-activation cap timestamp (returned by the verifier when it has no entry
-// for this chain). A not-yet-active verifier returns PreActivation. The caller
-// decides whether to resolve Anchor timestamps or fall back more conservatively.
+// The verifier contributes either the verified tip or no entry. If the verifier
+// is active but has no entry for this chain, SuperAuthority contributes an
+// Anchor at the pre-activation cap timestamp. A not-yet-active verifier returns
+// PreActivation. The caller decides whether to resolve Anchor timestamps or
+// fall back more conservatively.
 func (c *simpleChainContainer) FullyVerifiedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
 	v := c.registeredVerifier()
 	if v == nil {
@@ -27,7 +29,8 @@ func (c *simpleChainContainer) FullyVerifiedL2Head(ctx context.Context) (rollup.
 		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
 
-	head, err := c.verifierContribution(v.LatestVerifiedL2Block(c.chainID))
+	block, ts, err := v.LatestVerifiedL2Block(c.chainID)
+	head, err := c.verifierContribution(v, block, ts, err)
 	if err != nil {
 		c.log.Warn("FullyVerifiedL2Head: verifier read failed, holding previous",
 			"verifier", v.Name(), "err", err)
@@ -53,7 +56,8 @@ func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.Veri
 		return rollup.VerifierHead{Source: rollup.VerifierHeadPreActivation}, true
 	}
 
-	head, err := c.verifierContribution(v.VerifiedBlockAtL1(c.chainID, ss.FinalizedL1))
+	block, ts, err := v.VerifiedBlockAtL1(c.chainID, ss.FinalizedL1)
+	head, err := c.verifierContribution(v, block, ts, err)
 	if err != nil {
 		c.log.Warn("FinalizedL2Head: verifier read failed, holding previous",
 			"verifier", v.Name(), "err", err)
@@ -63,16 +67,23 @@ func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.Veri
 }
 
 // verifierContribution classifies a verifier's (block, ts) return:
-//   - empty block -> Anchor (ts is the pre-activation cap).
+//   - empty block -> Anchor (activationTimestamp - 1).
 //   - non-empty block -> Verified tip.
-func (c *simpleChainContainer) verifierContribution(bID eth.BlockID, ts uint64, err error) (rollup.VerifierHead, error) {
+func (c *simpleChainContainer) verifierContribution(v activity.VerificationActivity, bID eth.BlockID, ts uint64, err error) (rollup.VerifierHead, error) {
 	if err != nil {
 		return rollup.VerifierHead{}, err
 	}
 	if (bID == eth.BlockID{}) {
-		return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor, Timestamp: ts}, nil
+		return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor, Timestamp: activationCap(v.ActivationTimestamp())}, nil
 	}
 	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bID, Timestamp: ts}, nil
+}
+
+func activationCap(activationTimestamp uint64) uint64 {
+	if activationTimestamp == 0 {
+		return 0
+	}
+	return activationTimestamp - 1
 }
 
 func (c *simpleChainContainer) localSafeTimestamp(ctx context.Context) (uint64, bool) {

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -42,7 +42,7 @@ func (m *mockVerificationActivityForSuperAuthority) LatestVerifiedL2Block(chainI
 		return eth.BlockID{}, 0, m.latestVerifiedErr
 	}
 	if m.latestVerifiedBlock == (eth.BlockID{}) {
-		return eth.BlockID{}, m.activationCap(), nil
+		return eth.BlockID{}, 0, nil
 	}
 	return m.latestVerifiedBlock, m.latestVerifiedTS, nil
 }
@@ -52,15 +52,12 @@ func (m *mockVerificationActivityForSuperAuthority) VerifiedBlockAtL1(chainID et
 		return eth.BlockID{}, 0, m.latestFinalizedErr
 	}
 	if m.latestFinalizedBlock == (eth.BlockID{}) {
-		return eth.BlockID{}, m.activationCap(), nil
+		return eth.BlockID{}, 0, nil
 	}
 	return m.latestFinalizedBlock, m.latestFinalizedTS, nil
 }
-func (m *mockVerificationActivityForSuperAuthority) activationCap() uint64 {
-	if m.activationTimestamp == 0 {
-		return 0
-	}
-	return m.activationTimestamp - 1
+func (m *mockVerificationActivityForSuperAuthority) ActivationTimestamp() uint64 {
+	return m.activationTimestamp
 }
 func (m *mockVerificationActivityForSuperAuthority) IsActiveAt(ts uint64) bool {
 	if m.isActiveAtFn != nil {

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -22,6 +22,7 @@ type mockVerificationActivityForSuperAuthority struct {
 	latestFinalizedTS    uint64
 	latestFinalizedErr   error
 	activationTimestamp  uint64
+	currentL1            eth.BlockID
 	// isActiveAtFn drives IsActiveAt. When nil, IsActiveAt returns true for any
 	// timestamp >= activationTimestamp (matching the production semantics).
 	isActiveAtFn func(ts uint64) bool
@@ -31,7 +32,7 @@ func (m *mockVerificationActivityForSuperAuthority) Start(ctx context.Context) e
 func (m *mockVerificationActivityForSuperAuthority) Stop(ctx context.Context) error  { return nil }
 func (m *mockVerificationActivityForSuperAuthority) Name() string                    { return "mock" }
 func (m *mockVerificationActivityForSuperAuthority) CurrentL1() eth.BlockID {
-	return eth.BlockID{}
+	return m.currentL1
 }
 func (m *mockVerificationActivityForSuperAuthority) VerifiedAtTimestamp(ts uint64) (bool, error) {
 	return false, nil
@@ -76,10 +77,9 @@ var _ activity.VerificationActivity = (*mockVerificationActivityForSuperAuthorit
 // to install both.
 func newTestChainContainer(t *testing.T, chainID eth.ChainID) *simpleChainContainer {
 	return &simpleChainContainer{
-		chainID:   chainID,
-		verifiers: []activity.VerificationActivity{},
-		log:       testlog.Logger(t, log.LevelDebug),
-		vn:        &mockVirtualNode{},
+		chainID: chainID,
+		log:     testlog.Logger(t, log.LevelDebug),
+		vn:      &mockVirtualNode{},
 	}
 }
 
@@ -91,32 +91,27 @@ func setSyncStatus(t *testing.T, cc *simpleChainContainer, ss *eth.SyncStatus) {
 	mvn.syncStatusOverride = func() (*eth.SyncStatus, error) { return ss, nil }
 }
 
-// =============================================================================
-// FullyVerifiedL2Head — happy paths
-// =============================================================================
-
-func TestChainContainer_FullyVerifiedL2Head_MultipleVerifiers_OldestWins(t *testing.T) {
+func TestChainContainer_RegisterVerifier_RejectsSecondVerifier(t *testing.T) {
 	t.Parallel()
 
 	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	v1 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestVerifiedTS:    1000, // oldest
-	}
-	v2 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{2}, Number: 200},
-		latestVerifiedTS:    2000,
-	}
-	v3 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
-		latestVerifiedTS:    3000,
-	}
-	cc.verifiers = []activity.VerificationActivity{v1, v2, v3}
+	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{})
 
-	head, ok := cc.FullyVerifiedL2Head(t.Context())
-	require.True(t, ok)
-	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
-	require.Equal(t, v1.latestVerifiedBlock, head.Block, "should return oldest verified block")
+	require.Panics(t, func() {
+		cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{})
+	})
+}
+
+func TestChainContainer_VerifierCurrentL1s_ReturnsRegisteredVerifier(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	require.Nil(t, cc.VerifierCurrentL1s())
+
+	currentL1 := eth.BlockID{Hash: [32]byte{0xaa}, Number: 10}
+	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{currentL1: currentL1})
+
+	require.Equal(t, []eth.BlockID{currentL1}, cc.VerifierCurrentL1s())
 }
 
 func TestChainContainer_FullyVerifiedL2Head_NoVerifiers_ReturnsPreActivation(t *testing.T) {
@@ -127,7 +122,7 @@ func TestChainContainer_FullyVerifiedL2Head_NoVerifiers_ReturnsPreActivation(t *
 	head, ok := cc.FullyVerifiedL2Head(t.Context())
 	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source,
-		"no verifiers registered → PreActivation; caller uses local-safe")
+		"no verifier registered -> PreActivation; caller uses local-safe")
 	require.Equal(t, eth.BlockID{}, head.Block)
 }
 
@@ -139,31 +134,12 @@ func TestChainContainer_FullyVerifiedL2Head_SingleVerifier(t *testing.T) {
 		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
 		latestVerifiedTS:    1000,
 	}
-	cc.verifiers = []activity.VerificationActivity{v}
+	cc.RegisterVerifier(v)
 
 	head, ok := cc.FullyVerifiedL2Head(t.Context())
 	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
 	require.Equal(t, v.latestVerifiedBlock, head.Block)
-}
-
-func TestChainContainer_FullyVerifiedL2Head_VerifiersDisagreeAtSameTimestamp_Panics(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	v1 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestVerifiedTS:    1000,
-	}
-	v2 := &mockVerificationActivityForSuperAuthority{
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{2}, Number: 100},
-		latestVerifiedTS:    1000, // same TS, different hash → consensus violation
-	}
-	cc.verifiers = []activity.VerificationActivity{v1, v2}
-
-	require.Panics(t, func() {
-		_, _ = cc.FullyVerifiedL2Head(t.Context())
-	})
 }
 
 // =============================================================================
@@ -172,7 +148,7 @@ func TestChainContainer_FullyVerifiedL2Head_VerifiersDisagreeAtSameTimestamp_Pan
 
 // Under the new contract, a verifier that is active but has no verified-DB
 // entry for this chain contributes its activation-anchor timestamp, NOT an
-// empty BlockID. This was bug B: post-activation empty verifiers caused
+// empty BlockID. This was bug B: a post-activation empty verifier caused
 // SafeL2Head to drop to genesis.
 
 // Chain_container does not resolve anchor blocks — it returns the cap timestamp
@@ -187,7 +163,7 @@ func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierContribu
 	})
 
 	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
-	cc.verifiers = []activity.VerificationActivity{v}
+	cc.RegisterVerifier(v)
 
 	head, ok := cc.FullyVerifiedL2Head(t.Context())
 	require.True(t, ok)
@@ -196,79 +172,6 @@ func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierContribu
 	require.Equal(t, eth.BlockID{}, head.Block, "anchor contribution carries no block")
 	require.Equal(t, uint64(999), head.Timestamp,
 		"anchor timestamp is activationTimestamp - 1; engine_controller resolves to a block")
-}
-
-func TestChainContainer_FullyVerifiedL2Head_AllUnverified_ContributeAnchors(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 3000},
-	})
-
-	v1 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
-	v2 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
-	cc.verifiers = []activity.VerificationActivity{v1, v2}
-
-	head, ok := cc.FullyVerifiedL2Head(t.Context())
-	require.True(t, ok)
-	require.Equal(t, rollup.VerifierHeadAnchor, head.Source)
-	require.Equal(t, uint64(999), head.Timestamp)
-}
-
-func TestChainContainer_FullyVerifiedL2Head_MixedAnchorAndVerified_OldestWins(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		LocalSafeL2: eth.L2BlockRef{Number: 1000, Time: 3000},
-	})
-
-	// v1: empty → contributes anchor at TS 999 (older).
-	v1 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
-	// v2: has a verified tip at TS 2500 (newer).
-	v2 := &mockVerificationActivityForSuperAuthority{
-		activationTimestamp: 1000,
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{0xbb}, Number: 750},
-		latestVerifiedTS:    2500,
-	}
-	cc.verifiers = []activity.VerificationActivity{v1, v2}
-
-	head, ok := cc.FullyVerifiedL2Head(t.Context())
-	require.True(t, ok)
-	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
-		"v1's anchor at TS 999 is the oldest contribution")
-	require.Equal(t, uint64(999), head.Timestamp)
-}
-
-func TestChainContainer_FullyVerifiedL2Head_OneEmptyOneVerified_AnchorOlder(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		LocalSafeL2: eth.L2BlockRef{Number: 1000, Time: 3000},
-	})
-
-	v1 := &mockVerificationActivityForSuperAuthority{
-		activationTimestamp: 1000,
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestVerifiedTS:    2000,
-	}
-	v2 := &mockVerificationActivityForSuperAuthority{
-		activationTimestamp: 1000, // empty → anchor at TS 999
-	}
-	v3 := &mockVerificationActivityForSuperAuthority{
-		activationTimestamp: 1000,
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
-		latestVerifiedTS:    3000,
-	}
-	cc.verifiers = []activity.VerificationActivity{v1, v2, v3}
-
-	head, ok := cc.FullyVerifiedL2Head(t.Context())
-	require.True(t, ok)
-	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
-		"v2's anchor at TS 999 is the oldest contribution")
-	require.Equal(t, uint64(999), head.Timestamp)
 }
 
 // =============================================================================
@@ -284,56 +187,13 @@ func TestChainContainer_FullyVerifiedL2Head_PreActivation_ReturnsPreActivationSo
 	})
 
 	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
-	cc.verifiers = []activity.VerificationActivity{v}
+	cc.RegisterVerifier(v)
 
 	head, ok := cc.FullyVerifiedL2Head(t.Context())
 	require.True(t, ok)
 	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source,
-		"pre-activation → caller uses local-safe (Source=PreActivation)")
+		"pre-activation -> caller uses local-safe (Source=PreActivation)")
 	require.Equal(t, eth.BlockID{}, head.Block)
-}
-
-func TestChainContainer_FullyVerifiedL2Head_AllPreActivation_ReturnsPreActivationSource(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xaa}, Time: 999},
-	})
-
-	v1 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
-	v2 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 2000}
-	cc.verifiers = []activity.VerificationActivity{v1, v2}
-
-	head, ok := cc.FullyVerifiedL2Head(t.Context())
-	require.True(t, ok)
-	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
-}
-
-func TestChainContainer_FullyVerifiedL2Head_MixedActiveAndPreActivation_SkipsInactive(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
-	})
-
-	// active: has a verified tip
-	active := &mockVerificationActivityForSuperAuthority{
-		activationTimestamp: 1000,
-		latestVerifiedBlock: eth.BlockID{Hash: [32]byte{0x11}, Number: 250},
-		latestVerifiedTS:    1500,
-	}
-	// preAct: not yet active — must be skipped, must NOT try to resolve an anchor
-	// for a block that doesn't exist on this chain yet.
-	preAct := &mockVerificationActivityForSuperAuthority{activationTimestamp: 2000}
-	cc.verifiers = []activity.VerificationActivity{active, preAct}
-
-	head, ok := cc.FullyVerifiedL2Head(t.Context())
-	require.True(t, ok,
-		"not-yet-active verifier must be skipped, not surface as HoldPrevious")
-	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
-	require.Equal(t, active.latestVerifiedBlock, head.Block)
 }
 
 // =============================================================================
@@ -352,49 +212,13 @@ func TestChainContainer_FullyVerifiedL2Head_VerifierError_ReturnsHoldPrevious(t 
 		activationTimestamp: 1000,
 		latestVerifiedErr:   errors.New("database not open"),
 	}
-	cc.verifiers = []activity.VerificationActivity{v}
+	cc.RegisterVerifier(v)
 
 	head, ok := cc.FullyVerifiedL2Head(t.Context())
 	require.False(t, ok,
 		"verifier read error must surface as HoldPrevious so the caller floors at finalized, "+
 			"NOT use local-safe (that was the bug)")
 	require.Equal(t, eth.BlockID{}, head.Block)
-}
-
-// =============================================================================
-// FinalizedL2Head — same shape as FullyVerifiedL2Head
-// =============================================================================
-
-func TestChainContainer_FinalizedL2Head_MultipleVerifiers_OldestWins(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		FinalizedL1: eth.L1BlockRef{Number: 400},
-		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 1500},
-	})
-
-	v1 := &mockVerificationActivityForSuperAuthority{
-		activationTimestamp:  1000,
-		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
-		latestFinalizedTS:    1000, // oldest
-	}
-	v2 := &mockVerificationActivityForSuperAuthority{
-		activationTimestamp:  1000,
-		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{2}, Number: 200},
-		latestFinalizedTS:    2000,
-	}
-	v3 := &mockVerificationActivityForSuperAuthority{
-		activationTimestamp:  1000,
-		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
-		latestFinalizedTS:    3000,
-	}
-	cc.verifiers = []activity.VerificationActivity{v1, v2, v3}
-
-	head, ok := cc.FinalizedL2Head(t.Context())
-	require.True(t, ok)
-	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
-	require.Equal(t, v1.latestFinalizedBlock, head.Block)
 }
 
 func TestChainContainer_FinalizedL2Head_NoVerifiers_ReturnsPreActivation(t *testing.T) {
@@ -417,7 +241,7 @@ func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierContributesA
 	})
 
 	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
-	cc.verifiers = []activity.VerificationActivity{v}
+	cc.RegisterVerifier(v)
 
 	head, ok := cc.FinalizedL2Head(t.Context())
 	require.True(t, ok)
@@ -437,25 +261,7 @@ func TestChainContainer_FinalizedL2Head_PreActivation_ReturnsPreActivationSource
 	})
 
 	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
-	cc.verifiers = []activity.VerificationActivity{v}
-
-	head, ok := cc.FinalizedL2Head(t.Context())
-	require.True(t, ok)
-	require.Equal(t, rollup.VerifierHeadPreActivation, head.Source)
-}
-
-func TestChainContainer_FinalizedL2Head_AllPreActivation_ReturnsPreActivationSource(t *testing.T) {
-	t.Parallel()
-
-	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
-	setSyncStatus(t, cc, &eth.SyncStatus{
-		FinalizedL1: eth.L1BlockRef{Number: 40},
-		LocalSafeL2: eth.L2BlockRef{Number: 50, Time: 999},
-	})
-
-	v1 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
-	v2 := &mockVerificationActivityForSuperAuthority{activationTimestamp: 2000}
-	cc.verifiers = []activity.VerificationActivity{v1, v2}
+	cc.RegisterVerifier(v)
 
 	head, ok := cc.FinalizedL2Head(t.Context())
 	require.True(t, ok)
@@ -475,7 +281,7 @@ func TestChainContainer_FinalizedL2Head_VerifierError_ReturnsHoldPrevious(t *tes
 		activationTimestamp: 1000,
 		latestFinalizedErr:  errors.New("database not open"),
 	}
-	cc.verifiers = []activity.VerificationActivity{v}
+	cc.RegisterVerifier(v)
 
 	head, ok := cc.FinalizedL2Head(t.Context())
 	require.False(t, ok,
@@ -495,7 +301,7 @@ func TestChainContainer_FinalizedL2Head_SyncStatusError_ReturnsHoldPrevious(t *t
 	}
 
 	v := &mockVerificationActivityForSuperAuthority{activationTimestamp: 1000}
-	cc.verifiers = []activity.VerificationActivity{v}
+	cc.RegisterVerifier(v)
 
 	head, ok := cc.FinalizedL2Head(t.Context())
 	require.False(t, ok)


### PR DESCRIPTION
Stacked on #21066.

This is the extra simplification on top of the minimal fallback PR: collapse SuperAuthority verifier handling to the single interop verifier, and remove the multi-verifier aggregation path.

What changed:
- replace the verifier slice with a single registered verifier
- make a second RegisterVerifier call panic so aggregation does not silently reappear
- remove pickOldest and multi-verifier oldest/disagreement behavior
- keep the same single-verifier semantics: pre-activation returns PreActivation; active empty verifier result returns the activation anchor timestamp; read errors return HoldPrevious
- update comments and tests to match the single-verifier model

Validation:
- tree matches the previously tested final version
- go test ./op-supernode/supernode/chain_container ./op-supernode/supernode/activity/internal/syncstatus ./op-node/rollup/engine ./op-supernode/supernode/activity/interop
- git diff --check