### PR TITLE
feat(op-node): cache cross-safe head with canonicality re-validation

### DIFF
--- a/op-node/rollup/engine/cross_safe_cache.go
+++ b/op-node/rollup/engine/cross_safe_cache.go
@@ -1,0 +1,58 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// crossSafeCache caches the most recently resolved cross-safe head so that
+// transient verifier outages and reorg signals don't drop cross-safe all the
+// way to FinalizedHead. Cross-safe CAN reorg, so the cache is re-validated
+// against the EL on every read and cleared if stale or non-canonical.
+type crossSafeCache struct {
+	cached eth.L2BlockRef
+	log    log.Logger
+}
+
+func newCrossSafeCache(log log.Logger) *crossSafeCache {
+	return &crossSafeCache{log: log}
+}
+
+// Store records br as the latest known canonical cross-safe head. Callers
+// must only Store blocks they have just verified canonical on the EL.
+func (c *crossSafeCache) Store(br eth.L2BlockRef) {
+	c.cached = br
+}
+
+// Get returns the cached cross-safe head if it is still canonical on the EL
+// and not ahead of localSafeHead. Otherwise clears the cache and returns
+// (zero, false).
+func (c *crossSafeCache) Get(ctx context.Context, engine ExecEngine, localSafeHead eth.L2BlockRef) (eth.L2BlockRef, bool) {
+	cached := c.cached
+	if cached == (eth.L2BlockRef{}) {
+		return eth.L2BlockRef{}, false
+	}
+	if cached.Number > localSafeHead.Number {
+		c.log.Info("cached cross-safe ahead of local-safe; clearing cache",
+			"cached", cached, "local_safe", localSafeHead)
+		c.cached = eth.L2BlockRef{}
+		return eth.L2BlockRef{}, false
+	}
+	canonical, err := engine.L2BlockRefByNumber(ctx, cached.Number)
+	if err != nil {
+		c.log.Warn("cannot validate cached cross-safe canonicality; clearing cache",
+			"cached", cached, "err", err)
+		c.cached = eth.L2BlockRef{}
+		return eth.L2BlockRef{}, false
+	}
+	if canonical.Hash != cached.Hash {
+		c.log.Info("cached cross-safe non-canonical (reorg); clearing cache",
+			"cached", cached, "canonical", canonical)
+		c.cached = eth.L2BlockRef{}
+		return eth.L2BlockRef{}, false
+	}
+	return cached, true
+}

--- a/op-node/rollup/engine/cross_safe_cache_test.go
+++ b/op-node/rollup/engine/cross_safe_cache_test.go
@@ -1,0 +1,82 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+func TestCrossSafeCache_EmptyReturnsFalse(t *testing.T) {
+	c := newCrossSafeCache(testlog.Logger(t, 0))
+	_, ok := c.Get(context.Background(), &testutils.MockEngine{}, eth.L2BlockRef{Number: 100})
+	require.False(t, ok)
+}
+
+func TestCrossSafeCache_CanonicalReturnsCached(t *testing.T) {
+	cached := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 80}
+	engine := &testutils.MockEngine{}
+	engine.ExpectL2BlockRefByNumber(cached.Number, cached, nil)
+
+	c := newCrossSafeCache(testlog.Logger(t, 0))
+	c.Store(cached)
+
+	got, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	require.True(t, ok)
+	require.Equal(t, cached, got)
+}
+
+func TestCrossSafeCache_NonCanonicalClears(t *testing.T) {
+	cached := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 80}
+	differentCanonical := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 80}
+	engine := &testutils.MockEngine{}
+	engine.ExpectL2BlockRefByNumber(cached.Number, differentCanonical, nil)
+
+	c := newCrossSafeCache(testlog.Logger(t, 0))
+	c.Store(cached)
+
+	_, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	require.False(t, ok)
+
+	// Second call short-circuits: cache cleared, no further engine calls expected.
+	_, ok = c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	require.False(t, ok)
+}
+
+func TestCrossSafeCache_AheadOfLocalSafeClears(t *testing.T) {
+	cached := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 200}
+	engine := &testutils.MockEngine{}
+
+	c := newCrossSafeCache(testlog.Logger(t, 0))
+	c.Store(cached)
+
+	_, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	require.False(t, ok, "cache ahead of local-safe must not be returned")
+
+	// And it's been cleared — no engine call ever happened for that read, and the
+	// next read short-circuits on empty.
+	_, ok = c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	require.False(t, ok)
+}
+
+func TestCrossSafeCache_EngineErrorClears(t *testing.T) {
+	cached := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 80}
+	engine := &testutils.MockEngine{}
+	engine.ExpectL2BlockRefByNumber(cached.Number, eth.L2BlockRef{}, errors.New("boom"))
+
+	c := newCrossSafeCache(testlog.Logger(t, 0))
+	c.Store(cached)
+
+	_, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	require.False(t, ok)
+
+	// Cache cleared on lookup failure; next read short-circuits.
+	_, ok = c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	require.False(t, ok)
+}

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -164,6 +164,11 @@ type EngineController struct {
 	// SuperAuthority for payload validation (may be nil when not in supernode context)
 	superAuthority rollup.SuperAuthority
 
+	// crossSafeCache holds the last canonical cross-safe head; consulted by
+	// crossSafeFallback when the verifier is unavailable or returns a reorg
+	// signal, so a transient outage doesn't drop cross-safe to FinalizedHead.
+	crossSafeCache *crossSafeCache
+
 	unsafePayloads *PayloadsQueue // queue of unsafe payloads, ordered by ascending block number, may have gaps and duplicates
 }
 
@@ -191,6 +196,7 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 		ctx:            ctx,
 		emitter:        emitter,
 		superAuthority: superAuthority,
+		crossSafeCache: newCrossSafeCache(log),
 		unsafePayloads: NewPayloadsQueue(log, maxUnsafePayloadsMemory, payloadMemSize),
 	}
 }
@@ -244,6 +250,7 @@ func (e *EngineController) resolveVerifiedAsSafe(block eth.BlockID) eth.L2BlockR
 			"super_authority_safe", br, "canonical", canonicalRef)
 		return e.crossSafeFallback("non-canonical")
 	}
+	e.crossSafeCache.Store(br)
 	return br
 }
 
@@ -265,13 +272,19 @@ func (e *EngineController) resolveAnchorAsSafe(ts uint64) eth.L2BlockRef {
 		// Local safe hasn't reached the anchor block for the validator, so use local safe head.
 		return e.localSafeHead
 	}
+	e.crossSafeCache.Store(br)
 	return br
 }
 
-// crossSafeFallback is the cross-safe fallback path: returns FinalizedHead so
-// we never advance cross-safe to local-safe on a verifier read failure or any
-// reorg signal, and never drop below finalized.
+// crossSafeFallback is the cross-safe fallback path. It first tries the
+// canonicality-validated cross-safe cache (so a transient verifier outage
+// doesn't drop cross-safe to FinalizedHead), and otherwise floors at
+// FinalizedHead — never local-safe, never below finalized.
 func (e *EngineController) crossSafeFallback(reason string) eth.L2BlockRef {
+	if cached, ok := e.crossSafeCache.Get(e.ctx, e.engine, e.localSafeHead); ok {
+		e.log.Debug("cross-safe fallback using cache", "reason", reason, "cached", cached)
+		return cached
+	}
 	finalized := e.FinalizedHead()
 	e.log.Debug("cross-safe fallback flooring at finalized", "reason", reason, "finalized", finalized)
 	return finalized

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -281,11 +281,11 @@ func (e *EngineController) resolveAnchorAsSafe(ts uint64) eth.L2BlockRef {
 // doesn't drop cross-safe to FinalizedHead), and otherwise floors at
 // FinalizedHead — never local-safe, never below finalized.
 func (e *EngineController) crossSafeFallback(reason string) eth.L2BlockRef {
-	if cached, ok := e.crossSafeCache.Get(e.ctx, e.engine, e.localSafeHead); ok {
+	finalized := e.FinalizedHead()
+	if cached, ok := e.crossSafeCache.Get(e.ctx, e.engine, e.localSafeHead); ok && cached.Number >= finalized.Number {
 		e.log.Debug("cross-safe fallback using cache", "reason", reason, "cached", cached)
 		return cached
 	}
-	finalized := e.FinalizedHead()
 	e.log.Debug("cross-safe fallback flooring at finalized", "reason", reason, "finalized", finalized)
 	return finalized
 }
@@ -1152,6 +1152,7 @@ func (e *EngineController) forceReset(ctx context.Context, localUnsafe, crossUns
 	}
 
 	ForceEngineReset(e, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized)
+	e.crossSafeCache.Store(crossSafe)
 
 	if e.pipelineResetter != nil {
 		e.emitter.Emit(ctx, derive.ConfirmPipelineResetEvent{})

--- a/op-node/rollup/engine/super_authority_safe_head_test.go
+++ b/op-node/rollup/engine/super_authority_safe_head_test.go
@@ -112,6 +112,96 @@ func TestSafeL2Head_VerifierError_FloorsAtFinalized(t *testing.T) {
 		"SafeL2Head must floor at localFinalizedHead on verifier error (HoldPrevious semantics).")
 }
 
+// TestSafeL2Head_HoldPrevious_UsesCanonicalCache verifies that on HoldPrevious
+// the cross-safe cache is consulted (and re-validated for canonicality) before
+// falling back to FinalizedHead, so a transient verifier outage doesn't drop
+// cross-safe.
+func TestSafeL2Head_HoldPrevious_UsesCanonicalCache(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	verifiedBlock := eth.BlockID{Hash: common.Hash{0xcc}, Number: 80}
+	verifiedRef := eth.L2BlockRef{Hash: verifiedBlock.Hash, Number: verifiedBlock.Number}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2Head:       verifiedBlock,
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+		finalizedL2HeadSource:     rollup.VerifierHeadPreActivation,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(localFinalized)
+
+	// First call: Verified path populates the cache.
+	mockEngine.ExpectL2BlockRefByHash(verifiedBlock.Hash, verifiedRef, nil)
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
+	got := ec.SafeL2Head()
+	require.Equal(t, verifiedRef, got, "first call should resolve via the Verified path")
+
+	// Verifier returns HoldPrevious; cache canonicality re-validates and is
+	// returned in preference to flooring at finalized.
+	sa.holdPreviousVerified = true
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
+	got = ec.SafeL2Head()
+	require.Equal(t, verifiedRef, got,
+		"HoldPrevious must return the canonicality-validated cache, not drop to localFinalized")
+}
+
+// TestSafeL2Head_HoldPrevious_NonCanonicalCache_FloorsAtFinalized verifies
+// that the cross-safe cache is cleared when the cached block is no longer
+// canonical (reorg), and the caller then floors at FinalizedHead.
+func TestSafeL2Head_HoldPrevious_NonCanonicalCache_FloorsAtFinalized(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	verifiedBlock := eth.BlockID{Hash: common.Hash{0xcc}, Number: 80}
+	verifiedRef := eth.L2BlockRef{Hash: verifiedBlock.Hash, Number: verifiedBlock.Number}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2Head:       verifiedBlock,
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+		finalizedL2HeadSource:     rollup.VerifierHeadPreActivation,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(localFinalized)
+
+	// First call: Verified path populates the cache.
+	mockEngine.ExpectL2BlockRefByHash(verifiedBlock.Hash, verifiedRef, nil)
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
+	_ = ec.SafeL2Head()
+
+	// Simulate a reorg: the EL now reports a different canonical block at the
+	// cached number. HoldPrevious must clear the cache and floor at finalized.
+	sa.holdPreviousVerified = true
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number,
+		eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: verifiedBlock.Number}, nil)
+	got := ec.SafeL2Head()
+	require.Equal(t, localFinalized, got, "non-canonical cache must clear and floor at finalized")
+}
+
 // TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero documents the
 // error-after-startup trace: verifier errors on the first call, no cached
 // super-authority finalized head yet, localSafeHead and localFinalizedHead are

--- a/op-node/rollup/engine/super_authority_safe_head_test.go
+++ b/op-node/rollup/engine/super_authority_safe_head_test.go
@@ -158,6 +158,110 @@ func TestSafeL2Head_HoldPrevious_UsesCanonicalCache(t *testing.T) {
 		"HoldPrevious must return the canonicality-validated cache, not drop to localFinalized")
 }
 
+// TestSafeL2Head_HoldPrevious_CacheBelowFinalized_FloorsAtFinalized verifies
+// that when finalized advances past the cached cross-safe (the cache hasn't
+// been refreshed because the verifier has been HoldPrevious throughout), the
+// cache is cleared and the fallback returns finalized rather than a cached
+// cross-safe that violates the safe >= finalized engine invariant.
+func TestSafeL2Head_HoldPrevious_CacheBelowFinalized_FloorsAtFinalized(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 200}
+	initialFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	verifiedBlock := eth.BlockID{Hash: common.Hash{0xcc}, Number: 80}
+	verifiedRef := eth.L2BlockRef{Hash: verifiedBlock.Hash, Number: verifiedBlock.Number}
+	advancedFinalized := eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 100}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2Head:       verifiedBlock,
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+		finalizedL2HeadSource:     rollup.VerifierHeadPreActivation,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(initialFinalized)
+
+	// Populate the cache via the Verified path.
+	mockEngine.ExpectL2BlockRefByHash(verifiedBlock.Hash, verifiedRef, nil)
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
+	_ = ec.SafeL2Head()
+
+	// Finalized advances past the cached cross-safe while the verifier is
+	// HoldPrevious. The cache must not be returned (would publish
+	// safe=80 < finalized=100), and instead the fallback returns finalized.
+	ec.SetFinalizedHead(advancedFinalized)
+	sa.holdPreviousVerified = true
+	// Cache canonicality re-validates against the EL; the cached block is still
+	// canonical, but the fallback prefers finalized because cached < finalized.
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
+	got := ec.SafeL2Head()
+	require.Equal(t, advancedFinalized, got,
+		"cached cross-safe below finalized must not be returned; fallback floors at finalized")
+}
+
+// TestForceReset_SeedsCrossSafeCache verifies that a forced engine reset
+// replaces any pre-reset cached cross-safe with the reset crossSafe value, so
+// the fallback path returns the reset value (not pre-reset state, and not
+// finalized) on a subsequent HoldPrevious.
+func TestForceReset_SeedsCrossSafeCache(t *testing.T) {
+	cachedRef := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 80}
+	resetRef := eth.L2BlockRef{Hash: common.Hash{0xa1}, Number: 70}
+	resetFinalized := eth.L2BlockRef{Hash: common.Hash{0xb1}, Number: 40}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		nil,
+	)
+
+	// Seed the cache directly.
+	ec.crossSafeCache.Store(cachedRef)
+
+	// ForceReset performs a ForkchoiceUpdate; satisfy it with a noop expectation.
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      resetRef.Hash,
+			SafeBlockHash:      resetRef.Hash,
+			FinalizedBlockHash: resetFinalized.Hash,
+		},
+		nil,
+		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}},
+		nil,
+	)
+	emitter.ExpectOnceType("ForkchoiceUpdateEvent")
+	emitter.ExpectOnceType("EngineResetConfirmedEvent")
+
+	ec.ForceReset(context.Background(), resetRef, resetRef, resetRef, resetRef, resetFinalized)
+
+	// Cache must hold the reset crossSafe, not the pre-reset value. Get
+	// re-validates canonicality against the EL; expect the lookup at the reset
+	// block number to return the reset ref.
+	mockEngine.ExpectL2BlockRefByNumber(resetRef.Number, resetRef, nil)
+	got, ok := ec.crossSafeCache.Get(context.Background(), mockEngine,
+		eth.L2BlockRef{Number: 200})
+	require.True(t, ok, "forced reset must seed the cross-safe cache")
+	require.Equal(t, resetRef, got,
+		"forced reset must replace stale cached cross-safe with the reset value")
+}
+
 // TestSafeL2Head_HoldPrevious_NonCanonicalCache_FloorsAtFinalized verifies
 // that the cross-safe cache is cleared when the cached block is no longer
 // canonical (reorg), and the caller then floors at FinalizedHead.


### PR DESCRIPTION
Stacked on #21049. Adds a `crossSafeCache` so a transient verifier outage or reorg signal preserves cross-safe progress instead of dropping straight to `FinalizedHead`.

The cache is self-contained (`op-node/rollup/engine/cross_safe_cache.go`): `Store(br)` records a just-verified canonical block; `Get(ctx, engine, localSafeHead)` re-validates the cached block against the EL via `L2BlockRefByNumber` and bounds it by local-safe. Non-canonical, ahead-of-local-safe, or lookup-failed entries are cleared.

`EngineController.crossSafeFallback` consults the cache before flooring at finalized, and prefers finalized whenever the cached cross-safe is below it — preserving the engine invariant that safe >= finalized even when finalized has advanced past a stale cached value.

`forceReset` seeds the cache with the reset `crossSafe` so a subsequent HoldPrevious returns the reset value rather than dropping all the way to finalized.

Cross-safe can reorg, so the cache must be re-validated on every read — we never blindly return a cached cross-safe value.