### PR TITLE
docs(node-from-docker): clarify validator vs sequencer-forwarding role

### DIFF
--- a/docs/public-docs/node-operators/tutorials/node-from-docker.mdx
+++ b/docs/public-docs/node-operators/tutorials/node-from-docker.mdx
@@ -131,6 +131,10 @@ This tutorial runs an OP Stack node using the **official op-reth and op-node Doc
     The op-reth datadir is bind-mounted from `./reth-data` on the host so you can inspect / restore from a snapshot directly (see [Bootstrap from a snapshot](#bootstrap-from-a-snapshot) below).
 
     Image tags shown are the latest as of writing. For the current tags, see the [op-reth releases](https://github.com/ethereum-optimism/optimism/releases?q=op-reth) and [op-node releases](https://github.com/ethereum-optimism/optimism/releases?q=op-node).
+
+    <Info>
+      This is a validator node which serves reads locally and forwards writes to the sequencer (via `--rollup.sequencer`). You can remove that flag if you don't plan to make any write transactions with the node.
+    </Info>
   </Step>
 
   <Step title="Start the node">


### PR DESCRIPTION
Adds an Info callout after the docker-compose step explaining `--rollup.sequencer` forwards writes to the sequencer and can be dropped for a pure replica.