### PR TITLE
docs: add OP Enterprise CTA to chain operator docs

### DIFF
--- a/docs/public-docs/chain-operators/guides/management/best-practices.mdx
+++ b/docs/public-docs/chain-operators/guides/management/best-practices.mdx
@@ -81,3 +81,9 @@ You'll want to setup metrics endpoints and monitoring on your key components of 
 The `op-proposer` currently assumes that `op-geth` is being run in archive
 mode. This will likely be updated in a future network upgrade, but it is
 necessary for L2 withdrawals at the moment.
+
+## Want expert guidance?
+
+<Card title="Talk to the Optimism team" icon="handshake" href="https://optimism.io/learn-more?utm_source=docs&utm_medium=cta&utm_campaign=best-practices">
+  Interested in OP Enterprise, premium features, or chain management? Reach out early, we can help you make the right architecture decisions before you start building.
+</Card>

--- a/docs/public-docs/index.mdx
+++ b/docs/public-docs/index.mdx
@@ -62,3 +62,9 @@ The following section will walk you through the sequence of steps a chain operat
 
 Of course there is a lot more work to do ensure you're operating a highly available chain.
 Take a look at some of the [chain operator best practices](/chain-operators/guides/management/best-practices) to get an idea of some of the things you'll need to keep in mind.
+
+## Ready to go further?
+
+<Card title="Talk to the Optimism team" icon="handshake" href="https://optimism.io/learn-more?utm_source=docs&utm_medium=cta&utm_campaign=chain-operator-docs">
+  Interested in OP Enterprise, premium features, or chain management? Reach out early, we can help you make the right architecture decisions before you start building.
+</Card>

--- a/docs/public-docs/op-stack/introduction/op-stack.mdx
+++ b/docs/public-docs/op-stack/introduction/op-stack.mdx
@@ -103,3 +103,9 @@ The OP Stack is a modular collection of software components that work together t
 <Info>
   The OP Stack is continuously evolving. Check the [OP Stack specifications](https://specs.optimism.io) to stay current with new features and improvements.
 </Info>
+
+## Ready to build your chain?
+
+<Card title="Talk to the Optimism team" icon="handshake" href="https://optimism.io/learn-more?utm_source=docs&utm_medium=cta&utm_campaign=op-stack-intro">
+  Interested in OP Enterprise, premium features, or chain management? Reach out early, we can help you make the right architecture decisions before you start building.
+</Card>


### PR DESCRIPTION
## Summary

- Adds a persistent \"Talk to the Optimism team\" `<Card>` CTA to three high-traffic chain operator pages
- Links to `optimism.io/learn-more` with UTM params (`utm_source=docs&utm_medium=cta&utm_campaign=...`) for HubSpot tracking
- Motivated by prospects (e.g. Whitebit) using docs to make architecture decisions before ever contacting the Optimism team

**Pages updated:**
- `/` — chain operators landing page
- `/chain-operators/guides/management/best-practices`
- `/op-stack/introduction/op-stack`

## Test plan

- [x] Verify cards render correctly on all 3 pages in local preview
- [x] Confirm UTM links resolve to `optimism.io/learn-more`

Closes https://github.com/ethereum-optimism/solutions/issues/707

🤖 Generated with [Claude Code](https://claude.com/claude-code)