### PR TITLE
docs(op-challenger): warn against restoring SafeDB from snapshot

### DIFF
--- a/docs/public-docs/chain-operators/guides/configuration/op-challenger-config-guide.mdx
+++ b/docs/public-docs/chain-operators/guides/configuration/op-challenger-config-guide.mdx
@@ -235,7 +235,7 @@ Check that you have properly installed the challenger component:
           </Info>
 
       <Warning>
-        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and resync: `op-node` will populate the SafeDB going forward from the current EL head. Resyncing from an EL snapshot no older than 30 days via consensus sync is sufficient — dispute games only look back 28 days, so 30 days of safe head history covers all active games.
+        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and resync via consensus sync from a snapshot that is at least 30 days old — `op-node` does not backfill the SafeDB, so it will only populate it going forward from that point. A 30-day-old snapshot provides enough history to cover the 28-day dispute game window.
       </Warning>
   
   2.  Ensuring Historical Data Availability:
@@ -456,7 +456,7 @@ The Docker setup provides a containerized environment for running the challenger
           </Info>
 
       <Warning>
-        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and resync: `op-node` will populate the SafeDB going forward from the current EL head. Resyncing from an EL snapshot no older than 30 days via consensus sync is sufficient — dispute games only look back 28 days, so 30 days of safe head history covers all active games.
+        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and resync via consensus sync from a snapshot that is at least 30 days old — `op-node` does not backfill the SafeDB, so it will only populate it going forward from that point. A 30-day-old snapshot provides enough history to cover the 28-day dispute game window.
       </Warning>
   
   2.  Ensuring Historical Data Availability:

--- a/docs/public-docs/chain-operators/guides/configuration/op-challenger-config-guide.mdx
+++ b/docs/public-docs/chain-operators/guides/configuration/op-challenger-config-guide.mdx
@@ -233,6 +233,10 @@ Check that you have properly installed the challenger component:
           <Info>
             If this path is not set, the SafeDB feature will be disabled.
           </Info>
+
+      <Warning>
+        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and allow `op-node` to rebuild it from scratch by re-running derivation.
+      </Warning>
   
   2.  Ensuring Historical Data Availability:
   
@@ -450,6 +454,10 @@ The Docker setup provides a containerized environment for running the challenger
           <Info>
             If this path is not set, the SafeDB feature will be disabled.
           </Info>
+
+      <Warning>
+        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and allow `op-node` to rebuild it from scratch by re-running derivation.
+      </Warning>
   
   2.  Ensuring Historical Data Availability:
   

--- a/docs/public-docs/chain-operators/guides/configuration/op-challenger-config-guide.mdx
+++ b/docs/public-docs/chain-operators/guides/configuration/op-challenger-config-guide.mdx
@@ -235,7 +235,7 @@ Check that you have properly installed the challenger component:
           </Info>
 
       <Warning>
-        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and allow `op-node` to rebuild it from scratch by re-running derivation.
+        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and resync: `op-node` will populate the SafeDB going forward from the current EL head. Resyncing from an EL snapshot no older than 30 days via consensus sync is sufficient — dispute games only look back 28 days, so 30 days of safe head history covers all active games.
       </Warning>
   
   2.  Ensuring Historical Data Availability:
@@ -456,7 +456,7 @@ The Docker setup provides a containerized environment for running the challenger
           </Info>
 
       <Warning>
-        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and allow `op-node` to rebuild it from scratch by re-running derivation.
+        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and resync: `op-node` will populate the SafeDB going forward from the current EL head. Resyncing from an EL snapshot no older than 30 days via consensus sync is sufficient — dispute games only look back 28 days, so 30 days of safe head history covers all active games.
       </Warning>
   
   2.  Ensuring Historical Data Availability:

--- a/docs/public-docs/chain-operators/guides/configuration/op-challenger-config-guide.mdx
+++ b/docs/public-docs/chain-operators/guides/configuration/op-challenger-config-guide.mdx
@@ -235,7 +235,7 @@ Check that you have properly installed the challenger component:
           </Info>
 
       <Warning>
-        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and resync via consensus sync from a snapshot that is at least 30 days old — `op-node` does not backfill the SafeDB, so it will only populate it going forward from that point. A 30-day-old snapshot provides enough history to cover the 28-day dispute game window.
+        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and resync from a snapshot that is at least 30 days old — `op-node` does not backfill the SafeDB, so it will only populate it going forward from that point. A 30-day-old snapshot provides enough history to cover the 28-day dispute game window.
       </Warning>
   
   2.  Ensuring Historical Data Availability:

--- a/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-challenger-setup.mdx
+++ b/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-challenger-setup.mdx
@@ -404,7 +404,7 @@ For challenger deployment, we recommend using Docker as it provides a consistent
         </Info>
 
       <Warning>
-        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and resync: `op-node` will populate the SafeDB going forward from the current EL head. Resyncing from an EL snapshot no older than 30 days via consensus sync is sufficient — dispute games only look back 28 days, so 30 days of safe head history covers all active games.
+        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and resync via consensus sync from a snapshot that is at least 30 days old — `op-node` does not backfill the SafeDB, so it will only populate it going forward from that point. A 30-day-old snapshot provides enough history to cover the 28-day dispute game window.
       </Warning>
 
     2.  Ensuring Historical Data Availability:

--- a/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-challenger-setup.mdx
+++ b/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-challenger-setup.mdx
@@ -404,7 +404,7 @@ For challenger deployment, we recommend using Docker as it provides a consistent
         </Info>
 
       <Warning>
-        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and allow `op-node` to rebuild it from scratch by re-running derivation.
+        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and resync: `op-node` will populate the SafeDB going forward from the current EL head. Resyncing from an EL snapshot no older than 30 days via consensus sync is sufficient — dispute games only look back 28 days, so 30 days of safe head history covers all active games.
       </Warning>
 
     2.  Ensuring Historical Data Availability:

--- a/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-challenger-setup.mdx
+++ b/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-challenger-setup.mdx
@@ -403,6 +403,10 @@ For challenger deployment, we recommend using Docker as it provides a consistent
           If this path is not set, the SafeDB feature will be disabled.
         </Info>
 
+      <Warning>
+        **Never restore the SafeDB from a snapshot.** The SafeDB records the safe head as derived from L1, and a snapshot may not reflect the actual on-chain derivation state. If the SafeDB is out of sync with L1, `op-challenger` will act on an incorrect safe head and may incorrectly attack valid outputs. `op-challenger` cannot detect this condition — the data it receives appears normal. If you suspect the SafeDB was restored from a snapshot or is otherwise corrupted, delete it and allow `op-node` to rebuild it from scratch by re-running derivation.
+      </Warning>
+
     2.  Ensuring Historical Data Availability:
 
         *   Both `op-node` and `op-geth` must have data from the start of the games to maintain network consistency and allow nodes to reference historical state and transactions.


### PR DESCRIPTION
## Summary

- Adds a `<Warning>` callout to the `--rollup-rpc` SafeDB configuration section in the op-challenger config guide
- Covers both the Build from Source and Docker Setup tabs
- Explains why restoring the SafeDB from a snapshot is unsafe and what to do instead

The SafeDB records the safe head as derived from L1. If it's restored from a snapshot, it can silently diverge from the actual derivation state — causing `op-challenger` to act on an incorrect safe head and potentially attack valid outputs. Because the data the challenger receives looks normal, this condition is undetectable by the challenger itself. The correct recovery path is to delete the SafeDB and let `op-node` rebuild it by re-running derivation.

## Test plan

- [x] Verify Warning callout renders correctly in both tabs of the config guide at `/chain-operators/guides/configuration/op-challenger-config-guide`

Closes https://github.com/ethereum-optimism/solutions/issues/706

🤖 Generated with [Claude Code](https://claude.com/claude-code)