### PR TITLE
chore(supernode,interop-filter): remove virtual-parent indirection from logsDB

### DIFF
--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -341,22 +341,9 @@ func (c *LogsDBChainIngester) GetExecMsgsAtTimestamp(timestamp uint64) ([]Includ
 }
 
 // findAndSetEarliestBlock determines the earliest queryable block on resume.
-//
-// The first sealed block is the anchor checkpoint (sealed without log data).
-// The earliest block that can be opened for queries is the block immediately
-// after it. nextBlock is the next block ingestion will attempt (i.e.
-// latestSealed+1) and is used to distinguish two states:
-//
-//   - nextBlock == first+1: the DB contains only the anchor. No blocks with
-//     log data have been ingested yet. We leave earliestIngestedBlockSet false
-//     and let the first successful ingestBlock set it, exactly as in the
-//     fresh-start path.
-//   - nextBlock > first+1: at least one block past the anchor has been sealed,
-//     which under normal operation also means it has log data. We verify with
-//     OpenBlock(first+1); if that fails the DB is in an unexpected state and
-//     we refuse to start rather than serve potentially incorrect query
-//     results.
-func (c *LogsDBChainIngester) findAndSetEarliestBlock(nextBlock uint64) error {
+// The first sealed block is the earliest block with log data — it is sealed
+// directly with its receipts, not as a separate anchor checkpoint.
+func (c *LogsDBChainIngester) findAndSetEarliestBlock() error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -364,22 +351,10 @@ func (c *LogsDBChainIngester) findAndSetEarliestBlock(nextBlock uint64) error {
 	if err != nil {
 		return fmt.Errorf("failed to find first sealed block in DB: %w", err)
 	}
-	earliest := first.Number + 1
 
-	if nextBlock == earliest {
-		c.log.Info("DB contains only anchor block; deferring earliest-block tracking to first ingestion",
-			"anchor", first.Number)
-		return nil
-	}
-
-	if _, _, _, err := c.logsDB.OpenBlock(earliest); err != nil {
-		return fmt.Errorf("DB has sealed blocks past anchor %d but earliest %d cannot be opened: %w",
-			first.Number, earliest, err)
-	}
-
-	c.earliestIngestedBlock.Store(earliest)
+	c.earliestIngestedBlock.Store(first.Number)
 	c.earliestIngestedBlockSet.Store(true)
-	c.log.Info("Found earliest block in DB", "block", earliest, "anchor", first.Number)
+	c.log.Info("Found earliest block in DB", "block", first.Number)
 	return nil
 }
 
@@ -566,17 +541,12 @@ func (c *LogsDBChainIngester) initIngestion() (uint64, error) {
 		c.log.Info("Resuming from existing DB", "lastSealed", latestSealed.Number, "resumeFrom", nextBlock)
 
 		if !c.earliestIngestedBlockSet.Load() {
-			if err := c.findAndSetEarliestBlock(nextBlock); err != nil {
+			if err := c.findAndSetEarliestBlock(); err != nil {
 				return 0, fmt.Errorf("failed to determine earliest ingested block: %w", err)
 			}
 		}
 
 		return nextBlock, nil
-	}
-
-	// Fresh start: seal parent block as anchor
-	if err := c.sealParentBlock(startingBlock - 1); err != nil {
-		return 0, fmt.Errorf("failed to seal parent block: %w", err)
 	}
 
 	c.log.Info("Starting fresh ingestion",
@@ -655,32 +625,6 @@ func (c *LogsDBChainIngester) RewindToFinalized(ctx context.Context) (eth.BlockI
 	c.pendingRewindResumeFromSet = true
 	c.log.Info("Rewound logs DB to finalized", "block", targetID.Number, "hash", targetID.Hash)
 	return targetID, targetInfo.Time(), nil
-}
-
-func (c *LogsDBChainIngester) sealParentBlock(blockNum uint64) error {
-	c.log.Info("Sealing parent block as starting point", "block", blockNum)
-
-	blockInfo, err := c.ethClient.InfoByNumber(c.ctx, blockNum)
-	if err != nil {
-		return fmt.Errorf("failed to get block info: %w", err)
-	}
-
-	blockID := eth.BlockID{Hash: blockInfo.Hash(), Number: blockInfo.NumberU64()}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	parentHash := blockInfo.ParentHash()
-	if err := c.logsDB.SealBlock(parentHash, blockID, blockInfo.Time()); err != nil {
-		return fmt.Errorf("failed to seal block: %w", err)
-	}
-
-	// Note: We don't set earliestIngestedBlock here because the parent block is just
-	// an anchor checkpoint. earliestIngestedBlock will be set in ingestBlock when
-	// the first block with actual log data is ingested.
-
-	c.log.Info("Sealed parent block", "block", blockNum, "hash", blockID.Hash)
-	return nil
 }
 
 func (c *LogsDBChainIngester) ingestBlock(blockNum uint64) error {

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -204,42 +204,6 @@ func TestLogsDBChainIngester_InitLogsDB(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestLogsDBChainIngester_SealParentBlock(t *testing.T) {
-	chainID := eth.ChainIDFromUInt64(901)
-	tempDir := t.TempDir()
-
-	// Set up mock client with a parent block
-	mockClient := NewMockEthClient()
-	parentBlock := createTestBlock(99, 1198, common.Hash{})
-	mockClient.AddBlock(parentBlock, nil)
-
-	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
-		chainID:   chainID,
-		dataDir:   tempDir,
-		ethClient: mockClient,
-		rollupCfg: testRollupConfig(901, 0, 1000),
-	})
-
-	// Initialize logsDB first
-	err := ingester.initLogsDB()
-	require.NoError(t, err)
-	t.Cleanup(func() { ingester.logsDB.Close() })
-
-	// Seal the parent block
-	err = ingester.sealParentBlock(99)
-	require.NoError(t, err)
-
-	// Verify the block was sealed
-	latestBlock, ok := ingester.LatestBlock()
-	require.True(t, ok)
-	require.Equal(t, uint64(99), latestBlock.Number)
-
-	// Note: earliestIngestedBlock is NOT set in sealParentBlock anymore.
-	// It's now set in ingestBlock when the first block with actual log data is ingested.
-	// The anchor block is just a checkpoint, not a block with queryable log data.
-	require.False(t, ingester.earliestIngestedBlockSet.Load(), "sealParentBlock should not set earliestIngestedBlock")
-}
-
 func TestLogsDBChainIngester_IngestBlockRange_WritesInOrder(t *testing.T) {
 	chainID := eth.ChainIDFromUInt64(901)
 	tempDir := t.TempDir()
@@ -271,7 +235,6 @@ func TestLogsDBChainIngester_IngestBlockRange_WritesInOrder(t *testing.T) {
 
 	require.NoError(t, ingester.initLogsDB())
 	t.Cleanup(func() { ingester.logsDB.Close() })
-	require.NoError(t, ingester.sealParentBlock(99))
 	mockClient.ResetCompleted()
 
 	nextBlock, _, err := ingester.ingestBlockRange(100, 101, clock.SystemClock.Now())
@@ -307,7 +270,6 @@ func TestLogsDBChainIngester_IngestBlockRange_FetchFailureReturnsFailingBlock(t 
 
 	require.NoError(t, ingester.initLogsDB())
 	t.Cleanup(func() { ingester.logsDB.Close() })
-	require.NoError(t, ingester.sealParentBlock(99))
 
 	nextBlock, _, err := ingester.ingestBlockRange(100, 102, clock.SystemClock.Now())
 	require.Error(t, err)
@@ -374,13 +336,6 @@ func TestLogsDBChainIngester_Ready(t *testing.T) {
 	// Still not ready - no blocks sealed
 	require.False(t, ingester.Ready())
 
-	// Seal parent and ingest block 100
-	err = ingester.sealParentBlock(99)
-	require.NoError(t, err)
-
-	// Still not ready - latest timestamp is 1198 (block 99), startTimestamp is 1200
-	require.False(t, ingester.Ready())
-
 	err = ingester.ingestBlock(100)
 	require.NoError(t, err)
 
@@ -444,10 +399,6 @@ func TestLogsDBChainIngester_Contains(t *testing.T) {
 	err = ingester.initLogsDB()
 	require.NoError(t, err)
 	t.Cleanup(func() { ingester.logsDB.Close() })
-
-	// Seal parent and ingest block
-	err = ingester.sealParentBlock(99)
-	require.NoError(t, err)
 
 	err = ingester.ingestBlock(100)
 	require.NoError(t, err)

--- a/op-interop-filter/filter/logsdb_integration_accessors_test.go
+++ b/op-interop-filter/filter/logsdb_integration_accessors_test.go
@@ -1,92 +1,58 @@
 package filter
 
 import (
-	"testing"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestIntegration_BlockHashAt_KnownBlock(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
 		Blocks: []seedBlock{{Num: 100, Ts: 1200}},
 	})
-
 	hash, ok := si.BlockHashAt(100)
 	require.True(t, ok)
 	require.Equal(t, si.blockInfo[100].hash, hash)
 }
-
 func TestIntegration_BlockHashAt_FutureBlock_ReturnsNotFound(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
 		Blocks: []seedBlock{{Num: 100, Ts: 1200}},
 	})
-
 	_, ok := si.BlockHashAt(200)
 	require.False(t, ok)
 }
-
 func TestIntegration_BlockHashAt_BelowEarliest_ReturnsNotFound(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
 		AnchorNumber: 99,
 		AnchorTime:   1198,
 		Blocks:       []seedBlock{{Num: 100, Ts: 1200}},
 	})
-
 	_, ok := si.BlockHashAt(50)
 	require.False(t, ok)
 }
-
 func TestIntegration_BlockHashAt_BeforeInit_ReturnsNotFound(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
-		NoSealAnchor: true,
-		NoIngest:     true,
+		NoIngest: true,
 	})
 	require.NoError(t, si.logsDB.Close())
 	si.logsDB = nil
-
 	_, ok := si.BlockHashAt(100)
 	require.False(t, ok)
 }
-
 func TestIntegration_LatestBlock_Empty_ReturnsNotOk(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
-		NoSealAnchor: true,
-		NoIngest:     true,
+		NoIngest: true,
 	})
-
 	_, ok := si.LatestBlock()
 	require.False(t, ok)
 }
-
-func TestIntegration_LatestBlock_AnchorOnly_ReturnsAnchor(t *testing.T) {
-	t.Parallel()
-
-	si := newSeededIngester(t, seedSpec{
-		AnchorNumber: 99,
-		AnchorTime:   1198,
-		NoIngest:     true,
-	})
-
-	anchor, ok := si.LatestBlock()
-	require.True(t, ok)
-	require.Equal(t, uint64(99), anchor.Number)
-	require.Equal(t, si.blockInfo[99].hash, anchor.Hash)
-}
-
 func TestIntegration_LatestBlock_AfterIngest_AdvancesToHead(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
 		AnchorNumber: 99,
 		AnchorTime:   1198,
@@ -95,16 +61,13 @@ func TestIntegration_LatestBlock_AfterIngest_AdvancesToHead(t *testing.T) {
 			{Num: 101, Ts: 1202},
 		},
 	})
-
 	latest, ok := si.LatestBlock()
 	require.True(t, ok)
 	require.Equal(t, uint64(101), latest.Number)
 	require.Equal(t, si.blockInfo[101].hash, latest.Hash)
 }
-
 func TestIntegration_LatestTimestamp_TracksLatestSealedBlock(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
 		AnchorNumber: 99,
 		AnchorTime:   1198,
@@ -114,11 +77,9 @@ func TestIntegration_LatestTimestamp_TracksLatestSealedBlock(t *testing.T) {
 			{Num: 102, Ts: 1204},
 		},
 	})
-
 	ts, ok := si.LatestTimestamp()
 	require.True(t, ok)
 	require.Equal(t, uint64(1204), ts)
-
 	for n, want := range map[uint64]common.Hash{
 		100: si.blockInfo[100].hash,
 		101: si.blockInfo[101].hash,

--- a/op-interop-filter/filter/logsdb_integration_accessors_test.go
+++ b/op-interop-filter/filter/logsdb_integration_accessors_test.go
@@ -1,9 +1,10 @@
 package filter
 
 import (
+	"testing"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestIntegration_BlockHashAt_KnownBlock(t *testing.T) {

--- a/op-interop-filter/filter/logsdb_integration_contains_test.go
+++ b/op-interop-filter/filter/logsdb_integration_contains_test.go
@@ -1,45 +1,35 @@
 package filter
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/ethereum-optimism/optimism/op-service/eth"
-
 	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestIntegration_Contains_HappyPath_AccessListAccepted(t *testing.T) {
 	t.Parallel()
-
 	bk := twoChainBackend(t, 1)
 	bk.requireAccepted(executingChain(), inclusionTs, bk.sourceAccess(100, 0))
 }
-
 func TestIntegration_Contains_FutureLog_RejectedAsInvalidExecutingMessage(t *testing.T) {
 	t.Parallel()
-
 	bk := twoChainBackend(t, 1)
 	future := bk.sourceAccess(100, 0)
 	future.BlockNumber = 200
 	future.Timestamp = 1202 // == latestSealedTs on source, satisfies gate, triggers ErrFuture
 	bk.requireRejection(executingChain(), inclusionTs, "invalid_executing_message", future)
 }
-
 func TestIntegration_Contains_LogIdxOutOfRangeOnSealedBlock_ExpiredMessage(t *testing.T) {
 	t.Parallel()
-
 	bk := twoChainBackend(t, 2)
 	bad := bk.sourceAccess(100, 0)
 	bad.LogIndex = 5
 	bk.requireRejection(executingChain(), inclusionTs, "expired_message", bad)
 }
-
 func TestIntegration_Contains_BlockPastTipWithStaleLatestTs_ExpiredMessage(t *testing.T) {
 	t.Parallel()
-
 	bk := newSeededBackend(t, backendOpts{
 		Specs: []seedSpec{
 			{ChainID: 901, AnchorNumber: 99, AnchorTime: 1198,
@@ -54,64 +44,49 @@ func TestIntegration_Contains_BlockPastTipWithStaleLatestTs_ExpiredMessage(t *te
 				}},
 		},
 	})
-
 	bad := bk.sourceAccess(100, 0)
 	bad.BlockNumber = 102
 	bad.Timestamp = 1300
 	bk.requireRejection(executingChain(), 1500, "expired_message", bad)
 }
-
 func TestIntegration_Contains_ChecksumMismatch_ExpiredMessage(t *testing.T) {
 	t.Parallel()
-
 	bk := twoChainBackend(t, 1)
 	bad := withChecksum(bk.sourceAccess(100, 0), [32]byte{0x03, 0xff, 0xff, 0xff, 0xff})
 	bk.requireRejection(executingChain(), inclusionTs, "expired_message", bad)
 }
-
 func TestIntegration_Contains_StoredTimestampMismatch_ExpiredMessage(t *testing.T) {
 	t.Parallel()
-
 	bk := twoChainBackend(t, 1)
 	bad := bk.sourceAccess(100, 0)
 	bad.Timestamp = 1199 // block 100 was sealed at 1200; gate uses access.Timestamp <= minIngestedTs
 	bk.requireRejection(executingChain(), inclusionTs, "expired_message", bad)
 }
-
 func TestIntegration_Contains_BelowEarliestStored_RejectedAsInvalidExecutingMessage(t *testing.T) {
 	t.Parallel()
-
 	bk := twoChainBackend(t, 1)
 	bad := bk.sourceAccess(100, 0)
 	bad.BlockNumber = 50
 	bad.Timestamp = 1100
 	bk.requireRejection(executingChain(), inclusionTs, "invalid_executing_message", bad)
 }
-
 func TestIntegration_Contains_UnknownChain_UnknownChainReason(t *testing.T) {
 	t.Parallel()
-
 	bk := twoChainBackend(t, 1)
 	bk.requireRejection(eth.ChainIDFromUInt64(7777), inclusionTs, "unknown_chain")
 }
-
 func TestIntegration_Contains_BeforeInit_Uninitialized(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
-		NoSealAnchor: true,
-		NoIngest:     true,
+		NoIngest: true,
 	})
 	require.NoError(t, si.logsDB.Close())
 	si.logsDB = nil
-
 	_, err := si.Contains(messages.ContainsQuery{BlockNum: 100, Timestamp: 1200})
 	require.ErrorIs(t, err, interop.ErrUninitialized)
 }
-
 func TestIntegration_Contains_FailsafeAlreadyEnabled_Rejected(t *testing.T) {
 	t.Parallel()
-
 	bk := twoChainBackend(t, 1)
 	bk.SetFailsafeEnabled(true)
 	bk.requireRejection(executingChain(), inclusionTs, "failsafe", bk.sourceAccess(100, 0))

--- a/op-interop-filter/filter/logsdb_integration_contains_test.go
+++ b/op-interop-filter/filter/logsdb_integration_contains_test.go
@@ -1,11 +1,12 @@
 package filter
 
 import (
+	"testing"
+
 	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestIntegration_Contains_HappyPath_AccessListAccepted(t *testing.T) {

--- a/op-interop-filter/filter/logsdb_integration_execmsgs_test.go
+++ b/op-interop-filter/filter/logsdb_integration_execmsgs_test.go
@@ -2,13 +2,11 @@ package filter
 
 import (
 	"errors"
-	"testing"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
-
 	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 // remoteExecMsg constructs a seedLog declaring an executing message that
@@ -25,10 +23,8 @@ func remoteExecMsg(remote eth.ChainID, remoteBlock, remoteTs uint64, remoteLogId
 		},
 	}
 }
-
 func TestIntegration_GetExecMsgsAtTimestamp_HappyPath(t *testing.T) {
 	t.Parallel()
-
 	remote := eth.ChainIDFromUInt64(999)
 	si := newSeededIngester(t, seedSpec{
 		AnchorNumber: 99,
@@ -40,7 +36,6 @@ func TestIntegration_GetExecMsgsAtTimestamp_HappyPath(t *testing.T) {
 			}},
 		},
 	})
-
 	msgs, err := si.GetExecMsgsAtTimestamp(1200)
 	require.NoError(t, err)
 	require.Len(t, msgs, 2)
@@ -52,10 +47,8 @@ func TestIntegration_GetExecMsgsAtTimestamp_HappyPath(t *testing.T) {
 		require.Equal(t, uint64(1200), m.InclusionTimestamp)
 	}
 }
-
 func TestIntegration_GetExecMsgsAtTimestamp_NoMessagesAtTimestamp(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
 		AnchorNumber: 99,
 		AnchorTime:   1198,
@@ -63,42 +56,22 @@ func TestIntegration_GetExecMsgsAtTimestamp_NoMessagesAtTimestamp(t *testing.T) 
 			{Num: 100, Ts: 1200, Logs: []seedLog{{}}},
 		},
 	})
-
 	msgs, err := si.GetExecMsgsAtTimestamp(1200)
 	require.NoError(t, err)
 	require.Empty(t, msgs)
 }
-
 func TestIntegration_GetExecMsgsAtTimestamp_BeforeInit_Uninitialized(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
-		NoSealAnchor: true,
-		NoIngest:     true,
+		NoIngest: true,
 	})
 	require.NoError(t, si.logsDB.Close())
 	si.logsDB = nil
-
 	_, err := si.GetExecMsgsAtTimestamp(1200)
 	require.ErrorIs(t, err, interop.ErrUninitialized)
 }
-
-func TestIntegration_GetExecMsgsAtTimestamp_AnchorOnly_Uninitialized(t *testing.T) {
-	t.Parallel()
-
-	si := newSeededIngester(t, seedSpec{
-		AnchorNumber: 99,
-		AnchorTime:   1198,
-		NoIngest:     true,
-	})
-
-	_, err := si.GetExecMsgsAtTimestamp(1198)
-	require.ErrorIs(t, err, interop.ErrUninitialized)
-}
-
 func TestIntegration_GetExecMsgsAtTimestamp_BelowEarliest_ReturnsEmpty(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
 		AnchorNumber: 99,
 		AnchorTime:   1198,
@@ -106,7 +79,6 @@ func TestIntegration_GetExecMsgsAtTimestamp_BelowEarliest_ReturnsEmpty(t *testin
 			{Num: 100, Ts: 1200, Logs: []seedLog{{}}},
 		},
 	})
-
 	// Force earliestIngestedBlock past block 50 — already true (it's 100) — so
 	// a query for ts=1100 (-> block 50) short-circuits to (nil, nil) before
 	// hitting the DB.
@@ -114,10 +86,8 @@ func TestIntegration_GetExecMsgsAtTimestamp_BelowEarliest_ReturnsEmpty(t *testin
 	require.NoError(t, err)
 	require.Empty(t, msgs)
 }
-
 func TestIntegration_GetExecMsgsAtTimestamp_FirstSealedBlock_ReturnsExecMsgs(t *testing.T) {
 	t.Parallel()
-
 	remote := eth.ChainIDFromUInt64(999)
 	si := newSeededIngester(t, seedSpec{
 		AnchorNumber: 99,
@@ -129,18 +99,14 @@ func TestIntegration_GetExecMsgsAtTimestamp_FirstSealedBlock_ReturnsExecMsgs(t *
 			{Num: 101, Ts: 1202},
 		},
 	})
-
 	si2 := reopenSeededIngester(t, si)
-
 	msgs, err := si2.GetExecMsgsAtTimestamp(1200)
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	require.Equal(t, remote, msgs[0].ExecutingMessage.ChainID)
 }
-
 func TestIntegration_GetExecMsgsAtTimestamp_NonexistentTimestamp_ReturnsEmpty(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
 		AnchorNumber: 99,
 		AnchorTime:   1198,
@@ -149,13 +115,11 @@ func TestIntegration_GetExecMsgsAtTimestamp_NonexistentTimestamp_ReturnsEmpty(t 
 			{Num: 101, Ts: 1202, Logs: []seedLog{{}}},
 		},
 	})
-
 	// 1201 has no block — TargetBlockNumber should resolve to a block whose
 	// stored ts is 1200, so the ts mismatch short-circuits to empty.
 	msgs, err := si.GetExecMsgsAtTimestamp(1201)
 	require.NoError(t, err)
 	require.Empty(t, msgs)
-
 	// Future timestamp beyond latest also returns empty (no error).
 	msgs, err = si.GetExecMsgsAtTimestamp(9999)
 	require.False(t, errors.Is(err, interop.ErrUninitialized))

--- a/op-interop-filter/filter/logsdb_integration_execmsgs_test.go
+++ b/op-interop-filter/filter/logsdb_integration_execmsgs_test.go
@@ -2,11 +2,12 @@ package filter
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // remoteExecMsg constructs a seedLog declaring an executing message that

--- a/op-interop-filter/filter/logsdb_integration_helpers_test.go
+++ b/op-interop-filter/filter/logsdb_integration_helpers_test.go
@@ -72,7 +72,6 @@ type seedSpec struct {
 	BackfillDuration time.Duration
 	PollInterval     time.Duration
 	FetchConcurrency int
-	NoSealAnchor     bool // omit sealParentBlock; used by init tests
 	NoIngest         bool // omit per-block ingest; used by init tests
 }
 
@@ -114,9 +113,6 @@ func newSeededIngester(t *testing.T, spec seedSpec) *seededIngester {
 		}
 	})
 
-	if !spec.NoSealAnchor {
-		require.NoError(t, si.sealParentBlock(spec.AnchorNumber), "sealParentBlock")
-	}
 	if !spec.NoIngest {
 		for _, b := range spec.Blocks {
 			require.NoErrorf(t, si.ingestBlock(b.Num), "ingestBlock %d", b.Num)
@@ -372,9 +368,9 @@ func reopenSeededIngester(t *testing.T, prev *seededIngester) *seededIngester {
 		}
 	})
 
-	latest, ok := si.logsDB.LatestSealedBlock()
+	_, ok := si.logsDB.LatestSealedBlock()
 	require.True(t, ok, "reopened DB has no sealed blocks")
-	require.NoError(t, si.findAndSetEarliestBlock(latest.Number+1))
+	require.NoError(t, si.findAndSetEarliestBlock())
 	return si
 }
 

--- a/op-interop-filter/filter/logsdb_integration_init_test.go
+++ b/op-interop-filter/filter/logsdb_integration_init_test.go
@@ -1,20 +1,18 @@
 package filter
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestIntegration_Init_FreshStart_SealsAnchor(t *testing.T) {
+func TestIntegration_Init_FreshStart_StartsWithEmptyDB(t *testing.T) {
 	t.Parallel()
 
 	si := newSeededIngester(t, seedSpec{
 		AnchorNumber:   99,
 		AnchorTime:     1198,
 		StartTimestamp: 1200,
-		NoSealAnchor:   true,
 		NoIngest:       true,
 		Blocks:         []seedBlock{{Num: 100, Ts: 1200}}, // head, not ingested
 	})
@@ -23,12 +21,11 @@ func TestIntegration_Init_FreshStart_SealsAnchor(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(100), nextBlock)
 
-	latest, ok := si.LatestBlock()
-	require.True(t, ok)
-	require.Equal(t, uint64(99), latest.Number)
+	_, ok := si.LatestBlock()
+	require.False(t, ok, "fresh start must not seal any block before the first ingestion")
 }
 
-func TestIntegration_Init_AnchorOnly_NotInitialized(t *testing.T) {
+func TestIntegration_Init_EmptyDB_NotInitialized(t *testing.T) {
 	t.Parallel()
 
 	si := newSeededIngester(t, seedSpec{
@@ -38,7 +35,7 @@ func TestIntegration_Init_AnchorOnly_NotInitialized(t *testing.T) {
 	})
 
 	require.False(t, si.earliestIngestedBlockSet.Load(),
-		"earliestIngestedBlockSet must stay false when only the anchor is sealed")
+		"earliestIngestedBlockSet must stay false until the first block is ingested")
 }
 
 func TestIntegration_Init_Resume_FromExistingDB_FindsEarliest(t *testing.T) {
@@ -63,20 +60,6 @@ func TestIntegration_Init_Resume_FromExistingDB_FindsEarliest(t *testing.T) {
 	require.Equal(t, uint64(102), latest.Number)
 }
 
-func TestIntegration_Init_Resume_AnchorOnly_DoesNotMarkInitialized(t *testing.T) {
-	t.Parallel()
-
-	si := newSeededIngester(t, seedSpec{
-		AnchorNumber: 99,
-		AnchorTime:   1198,
-		NoIngest:     true,
-	})
-
-	si2 := reopenSeededIngester(t, si)
-	require.False(t, si2.earliestIngestedBlockSet.Load(),
-		"resuming with only the anchor must not mark the ingester initialized")
-}
-
 func TestIntegration_Init_FirstSealedBlock_OnEmptyDB_NeverReached(t *testing.T) {
 	t.Parallel()
 
@@ -84,7 +67,6 @@ func TestIntegration_Init_FirstSealedBlock_OnEmptyDB_NeverReached(t *testing.T) 
 		AnchorNumber:   99,
 		AnchorTime:     1198,
 		StartTimestamp: 1200,
-		NoSealAnchor:   true,
 		NoIngest:       true,
 		Blocks:         []seedBlock{{Num: 100, Ts: 1200}},
 	})
@@ -92,8 +74,7 @@ func TestIntegration_Init_FirstSealedBlock_OnEmptyDB_NeverReached(t *testing.T) 
 	_, hasSealed := si.logsDB.LatestSealedBlock()
 	require.False(t, hasSealed)
 
-	// initIngestion takes the fresh-start branch, which seals the parent without
-	// consulting FirstSealedBlock.
+	// initIngestion takes the fresh-start branch without consulting FirstSealedBlock.
 	_, err := si.initIngestion()
 	require.NoError(t, err)
 }
@@ -136,24 +117,4 @@ func TestIntegration_Init_Close_FlushesAndStops(t *testing.T) {
 	latest, ok := si2.LatestBlock()
 	require.True(t, ok)
 	require.Equal(t, uint64(100), latest.Number)
-}
-
-func TestIntegration_Init_SealParentBlockFails_IngesterNotReady(t *testing.T) {
-	t.Parallel()
-
-	si := newSeededIngester(t, seedSpec{
-		AnchorNumber:   99,
-		AnchorTime:     1198,
-		StartTimestamp: 1200,
-		NoSealAnchor:   true,
-		NoIngest:       true,
-		Blocks:         []seedBlock{{Num: 100, Ts: 1200}},
-	})
-
-	si.eth.SetInfoByNumberErr(errors.New("rpc not ready"))
-
-	_, err := si.initIngestion()
-	require.Error(t, err)
-	require.False(t, si.Ready())
-	require.Nil(t, si.Error(), "startup failure must not set an IngesterError (silent-startup-failure contract)")
 }

--- a/op-interop-filter/filter/logsdb_integration_reorg_recovery_test.go
+++ b/op-interop-filter/filter/logsdb_integration_reorg_recovery_test.go
@@ -3,13 +3,11 @@ package filter
 import (
 	"context"
 	"errors"
-	"testing"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
-
 	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 // putIntoReorg forces the ingester into ErrorReorg by ingesting a block whose
@@ -42,15 +40,11 @@ func reorgRecoveryBackend(t *testing.T) (*seededBackend, *seededIngester) {
 	si := bk.ingesters[eth.ChainIDFromUInt64(901)]
 	return bk, si
 }
-
 func TestIntegration_RecoverReorg_HappyPath(t *testing.T) {
 	t.Parallel()
-
 	bk, si := reorgRecoveryBackend(t)
 	si.eth.SetLabelBlock(eth.Finalized, si.blockInfo[101])
-
 	putIntoReorg(t, si, 103, 1206)
-
 	blockID, timestamp, err := bk.recoverChainReorg(context.Background(), si.chainID, si.LogsDBChainIngester)
 	require.NoError(t, err)
 	require.Equal(t, uint64(101), blockID.Number)
@@ -59,95 +53,68 @@ func TestIntegration_RecoverReorg_HappyPath(t *testing.T) {
 	require.Equal(t, uint64(102), si.applyPendingRewind(200),
 		"ingestion loop must resume from finalized+1 after recovery")
 }
-
 func TestIntegration_RecoverReorg_BeforeInit_Uninitialized(t *testing.T) {
 	t.Parallel()
-
 	si := newSeededIngester(t, seedSpec{
-		NoSealAnchor: true,
-		NoIngest:     true,
+		NoIngest: true,
 	})
 	require.NoError(t, si.logsDB.Close())
 	si.logsDB = nil
-
 	_, _, err := si.RewindToFinalized(context.Background())
 	require.ErrorIs(t, err, interop.ErrUninitialized)
 }
-
 func TestIntegration_RecoverReorg_FinalizedBlockNotInDB_StaysInFailsafe(t *testing.T) {
 	t.Parallel()
-
 	bk, si := reorgRecoveryBackend(t)
-
 	// finalized points at a block far past latest sealed — FindSealedBlock returns ErrFuture.
 	future := makeBlockInfo(200, 1500, common.Hash{0x99})
 	si.eth.SetLabelBlock(eth.Finalized, future)
-
 	putIntoReorg(t, si, 103, 1206)
-
 	_, _, err := bk.recoverChainReorg(context.Background(), si.chainID, si.LogsDBChainIngester)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, interop.ErrFuture), "expected ErrFuture, got %v", err)
 	require.NotNil(t, si.Error())
 	require.Equal(t, ErrorReorg, si.Error().Reason)
 }
-
 func TestIntegration_RecoverReorg_FinalizedHashMismatch_StaysInFailsafe(t *testing.T) {
 	t.Parallel()
-
 	bk, si := reorgRecoveryBackend(t)
-
 	// finalized block has the correct number but a different hash than stored.
 	fake := makeBlockInfo(101, 1202, common.Hash{0x77})
 	si.eth.SetLabelBlock(eth.Finalized, fake)
-
 	putIntoReorg(t, si, 103, 1206)
-
 	_, _, err := bk.recoverChainReorg(context.Background(), si.chainID, si.LogsDBChainIngester)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, interop.ErrConflict), "expected ErrConflict, got %v", err)
 	require.NotNil(t, si.Error())
 	require.Equal(t, ErrorReorg, si.Error().Reason)
 }
-
 func TestIntegration_RecoverReorg_FinalizedBelowEarliest_StaysInFailsafe(t *testing.T) {
 	t.Parallel()
-
 	bk, si := reorgRecoveryBackend(t)
-
 	stale := makeBlockInfo(10, 1020, common.Hash{0x55})
 	si.eth.SetLabelBlock(eth.Finalized, stale)
-
 	putIntoReorg(t, si, 103, 1206)
-
 	_, _, err := bk.recoverChainReorg(context.Background(), si.chainID, si.LogsDBChainIngester)
 	require.Error(t, err)
 	require.NotNil(t, si.Error())
 	require.Equal(t, ErrorReorg, si.Error().Reason)
 }
-
 func TestIntegration_RecoverReorg_NotInReorgState_SkippedNoOp(t *testing.T) {
 	t.Parallel()
-
 	bk, si := reorgRecoveryBackend(t)
 	si.eth.SetLabelBlock(eth.Finalized, si.blockInfo[101])
-
 	si.SetError(ErrorConflict, "forced")
-
 	_, _, err := bk.recoverChainReorg(context.Background(), si.chainID, si.LogsDBChainIngester)
 	require.Error(t, err)
 	require.NotNil(t, si.Error())
 	require.Equal(t, ErrorConflict, si.Error().Reason)
 }
-
 func TestIntegration_RecoverReorg_FullSequence_ResolvesAndResumes(t *testing.T) {
 	t.Parallel()
-
 	bk, si := reorgRecoveryBackend(t)
 	si.eth.SetLabelBlock(eth.Finalized, si.blockInfo[101])
-
 	putIntoReorg(t, si, 103, 1206)
-
 	bk.tryResolveReorgs(context.Background())
 	require.Nil(t, si.Error(), "ingester error should be cleared after resolution")
 	require.False(t, bk.FailsafeEnabled(), "failsafe should clear once last ingester error clears")

--- a/op-interop-filter/filter/logsdb_integration_reorg_recovery_test.go
+++ b/op-interop-filter/filter/logsdb_integration_reorg_recovery_test.go
@@ -3,11 +3,12 @@ package filter
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/ethereum-optimism/optimism/op-core/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // putIntoReorg forces the ingester into ErrorReorg by ingesting a block whose

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
-	"github.com/ethereum-optimism/optimism/op-core/interop"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 )
 
@@ -98,35 +97,8 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 				continue
 			}
 
-			// Get the block from the logsDB
 			blockRef, _, execMsgs, err = db.OpenBlock(expectedBlock.Number)
 			if err != nil {
-				// OpenBlock fails for the first block in the DB because it tries to find the parent.
-				// Handle this by checking if this is the first sealed block and using FirstSealedBlock instead.
-				if errors.Is(err, interop.ErrSkipped) {
-					firstBlock, firstErr := db.FirstSealedBlock()
-					if firstErr != nil {
-						return Result{}, fmt.Errorf("chain %s: failed to open block %d and failed to get first block: %w", chainID, expectedBlock.Number, err)
-					}
-					if firstBlock.Number == expectedBlock.Number {
-						// This is the first block in the logsDB. Use FirstSealedBlock info.
-						// The first block has no executing messages (since we can't verify them without prior data).
-						if firstBlock.Hash != expectedBlock.Hash {
-							i.log.Warn("first block hash mismatch",
-								"chain", chainID,
-								"expected", expectedBlock.Hash,
-								"got", firstBlock.Hash,
-							)
-							invalid, err := i.newInvalidHead(chainID, expectedBlock)
-							if err != nil {
-								return Result{}, fmt.Errorf("chain %s: %w", chainID, err)
-							}
-							result.InvalidHeads[chainID] = invalid
-						}
-						result.L2Heads[chainID] = expectedBlock
-						continue
-					}
-				}
 				return Result{}, fmt.Errorf("chain %s: failed to open block %d: %w", chainID, expectedBlock.Number, err)
 			}
 		}

--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -138,8 +138,7 @@ func (i *Interop) sealBlockDataIntoLogsDB(chainID eth.ChainID, blockID eth.Block
 		}
 	}
 
-	isFirstBlock := !hasBlocks
-	if err := i.processBlockLogs(db, blockInfo, receipts, isFirstBlock); err != nil {
+	if err := i.processBlockLogs(db, blockInfo, receipts); err != nil {
 		return fmt.Errorf("chain %s: failed to process block logs for block %d: %w", chainID, blockID.Number, err)
 	}
 	return nil
@@ -215,10 +214,9 @@ func (i *Interop) verifyCanAddTimestamp(chainID eth.ChainID, db LogsDB, ts uint6
 }
 
 // processBlockLogs processes the receipts for a block and stores the logs in the database.
-// If isFirstBlock is true, this is the first block being added to the logsDB (at activation timestamp),
-// and we first seal a "virtual parent" block so that logs have a sealed block to reference.
-// This allows the logsDB to start at any block number, not just genesis.
-func (i *Interop) processBlockLogs(db LogsDB, blockInfo eth.BlockInfo, receipts gethTypes.Receipts, isFirstBlock bool) error {
+// The logsDB starts at any block number — the first block is sealed directly with its
+// real logs and executing messages.
+func (i *Interop) processBlockLogs(db LogsDB, blockInfo eth.BlockInfo, receipts gethTypes.Receipts) error {
 	blockNum := blockInfo.NumberU64()
 	blockID := eth.BlockID{Hash: blockInfo.Hash(), Number: blockNum}
 	parentHash := blockInfo.ParentHash()
@@ -226,17 +224,7 @@ func (i *Interop) processBlockLogs(db LogsDB, blockInfo eth.BlockInfo, receipts 
 	parentBlock := eth.BlockID{Hash: parentHash, Number: blockNum - 1}
 	sealParentHash := parentHash
 
-	// For the first block in the logsDB (activation block), we need to first seal
-	// a virtual parent block so that logs have a sealed block to reference.
-	// When the DB is empty, SealBlock allows any block to be added without parent validation.
-	if isFirstBlock && blockNum > 0 {
-		// Seal the parent as a "virtual genesis" - this works because DB is empty
-		if err := db.SealBlock(common.Hash{}, parentBlock, blockInfo.Time()); err != nil {
-			return fmt.Errorf("failed to seal virtual parent for first block: %w", err)
-		}
-		// parentBlock stays as-is (references the now-sealed parent)
-		// sealParentHash stays as parentHash
-	} else if blockNum == 0 {
+	if blockNum == 0 {
 		// Actual genesis block - no parent, no logs allowed
 		parentBlock = eth.BlockID{}
 		sealParentHash = common.Hash{}

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -279,7 +279,7 @@ func TestProcessBlockLogs(t *testing.T) {
 			timestamp:  1000,
 		}
 
-		err := interop.processBlockLogs(db, blockInfo, types.Receipts{}, false)
+		err := interop.processBlockLogs(db, blockInfo, types.Receipts{})
 
 		require.NoError(t, err)
 		require.Len(t, db.sealBlockCalls, 1)
@@ -315,7 +315,7 @@ func TestProcessBlockLogs(t *testing.T) {
 			},
 		}
 
-		err := interop.processBlockLogs(db, blockInfo, receipts, false)
+		err := interop.processBlockLogs(db, blockInfo, receipts)
 
 		require.NoError(t, err)
 		require.Equal(t, 3, db.addLogCalls)
@@ -334,41 +334,32 @@ func TestProcessBlockLogs(t *testing.T) {
 			timestamp:  1000,
 		}
 
-		err := interop.processBlockLogs(db, blockInfo, types.Receipts{}, true)
+		err := interop.processBlockLogs(db, blockInfo, types.Receipts{})
 
 		require.NoError(t, err)
 		require.Len(t, db.sealBlockCalls, 1)
 		require.Equal(t, uint64(0), db.sealBlockCalls[0].block.Number)
 	})
 
-	t.Run("first block at non-zero number seals virtual parent first", func(t *testing.T) {
+	t.Run("first block at non-zero number is sealed directly", func(t *testing.T) {
 		t.Parallel()
 
 		interop := &Interop{log: gethlog.New()}
 		db := &mockLogsDB{}
 		blockInfo := &testBlockInfo{
 			hash:       common.Hash{0x02},
-			parentHash: common.Hash{0x01}, // Real parent hash
-			number:     10,                // Non-zero block number
+			parentHash: common.Hash{0x01},
+			number:     10,
 			timestamp:  1000,
 		}
 
-		// isFirstBlock=true should first seal a "virtual parent" block,
-		// then seal the actual block. This allows logs to reference a sealed parent.
-		err := interop.processBlockLogs(db, blockInfo, types.Receipts{}, true)
+		err := interop.processBlockLogs(db, blockInfo, types.Receipts{})
 
 		require.NoError(t, err)
-		require.Len(t, db.sealBlockCalls, 2)
-
-		// First call: seal the virtual parent (block 9) with empty parent hash
-		require.Equal(t, common.Hash{}, db.sealBlockCalls[0].parentHash)
-		require.Equal(t, uint64(9), db.sealBlockCalls[0].block.Number)
-		require.Equal(t, common.Hash{0x01}, db.sealBlockCalls[0].block.Hash)
-
-		// Second call: seal the actual block (block 10) with real parent hash
-		require.Equal(t, common.Hash{0x01}, db.sealBlockCalls[1].parentHash)
-		require.Equal(t, uint64(10), db.sealBlockCalls[1].block.Number)
-		require.Equal(t, common.Hash{0x02}, db.sealBlockCalls[1].block.Hash)
+		require.Len(t, db.sealBlockCalls, 1)
+		require.Equal(t, common.Hash{0x01}, db.sealBlockCalls[0].parentHash)
+		require.Equal(t, uint64(10), db.sealBlockCalls[0].block.Number)
+		require.Equal(t, common.Hash{0x02}, db.sealBlockCalls[0].block.Hash)
 	})
 
 	t.Run("first block with logs succeeds", func(t *testing.T) {
@@ -391,12 +382,10 @@ func TestProcessBlockLogs(t *testing.T) {
 			},
 		}
 
-		// This is the key test: first block with logs should work because
-		// we seal the virtual parent first, allowing AddLog to reference it
-		err := interop.processBlockLogs(db, blockInfo, receipts, true)
+		err := interop.processBlockLogs(db, blockInfo, receipts)
 
 		require.NoError(t, err)
-		require.Len(t, db.sealBlockCalls, 2) // virtual parent + actual block
+		require.Len(t, db.sealBlockCalls, 1)
 		require.Equal(t, 1, db.addLogCalls)
 	})
 
@@ -426,9 +415,7 @@ func TestProcessBlockLogs(t *testing.T) {
 			},
 		}
 
-		// This is the key integration test: first block with logs must work
-		// against the real logs.DB, not just the mock.
-		err = interop.processBlockLogs(db, blockInfo, receipts, true)
+		err = interop.processBlockLogs(db, blockInfo, receipts)
 		require.NoError(t, err)
 
 		// Verify data is correctly in the DB
@@ -461,7 +448,7 @@ func TestProcessBlockLogs(t *testing.T) {
 			},
 		}
 
-		err := interop.processBlockLogs(db, blockInfo, receipts, false)
+		err := interop.processBlockLogs(db, blockInfo, receipts)
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "add log failed")
@@ -479,7 +466,7 @@ func TestProcessBlockLogs(t *testing.T) {
 			timestamp:  1000,
 		}
 
-		err := interop.processBlockLogs(db, blockInfo, types.Receipts{}, false)
+		err := interop.processBlockLogs(db, blockInfo, types.Receipts{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "seal failed")

--- a/op-supernode/supernode/activity/interop/raftwallogdb/compat_virtual_parent.go
+++ b/op-supernode/supernode/activity/interop/raftwallogdb/compat_virtual_parent.go
@@ -1,0 +1,55 @@
+// COMPATIBILITY SHIM — safe to delete once no live databases predate
+// ethereum-optimism/optimism#20726.
+//
+// Pre-#20726, the supernode and interop filter sealed a synthetic "virtual
+// parent" entry as the first block in a fresh logsDB: number = activation-1,
+// parent hash = zero, no logs, no exec messages. #20726 removed that
+// indirection and seals the activation block directly. Databases written
+// before the change still carry the vestigial entry.
+//
+// hidePreVirtualParentLayout detects the entry on Open and bumps d.firstBlock
+// past it. The raft-wal record stays on disk (one wasted entry) but is
+// unreachable through the public API. Internal write paths maintain
+// firstBlock from this point forward, so the detection only runs once per
+// process lifetime.
+//
+// Removal: delete this file and the single call from refreshCache. Behaviour
+// for post-#20726 databases is unchanged because the detection is a no-op
+// when the first entry has a non-zero parent hash.
+
+package raftwallogdb
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// hidePreVirtualParentLayout hides a pre-#20726 virtual-parent entry, if
+// present, by advancing d.firstBlock past it. Must be called with the cache
+// already populated (hasBlocks/firstBlock/latest set).
+func (d *DB) hidePreVirtualParentLayout() error {
+	// No data, genesis-anchored DB, or only the (possibly virtual) entry
+	// exists: nothing to hide. Requiring a second entry means we never bump
+	// firstBlock past latest, and avoids touching DBs that never wrote an
+	// activation block.
+	if !d.hasBlocks || d.firstBlock == 0 || d.firstBlock >= d.latest.Number {
+		return nil
+	}
+
+	rec, err := d.readBlockAt(indexFor(d.firstBlock))
+	if err != nil {
+		return fmt.Errorf("read first entry for virtual-parent detection: %w", err)
+	}
+
+	// The virtual parent was sealed via SealBlock(common.Hash{}, ...) with no
+	// AddLog calls preceding it. Any of these three deviations rules it out;
+	// require all three for belt-and-braces (the supernode/filter write paths
+	// never produce a non-genesis entry with a zero parent hash).
+	if rec.ParentHash != (common.Hash{}) || rec.LogCount != 0 || rec.ExecMsgCount != 0 {
+		return nil
+	}
+
+	d.firstBlock++
+	return nil
+}

--- a/op-supernode/supernode/activity/interop/raftwallogdb/compat_virtual_parent_test.go
+++ b/op-supernode/supernode/activity/interop/raftwallogdb/compat_virtual_parent_test.go
@@ -1,0 +1,117 @@
+// COMPATIBILITY SHIM TEST — safe to delete alongside compat_virtual_parent.go
+// once no pre-#20726 databases remain in operation.
+
+package raftwallogdb
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+
+	"github.com/ethereum-optimism/optimism/op-core/interop"
+)
+
+// seedPreVirtualParentDB writes a pre-#20726 head layout into dir: a virtual
+// parent at activation-1 (sealed with a zero parent hash, no logs) followed
+// by the activation block with its real parent hash.
+func seedPreVirtualParentDB(t *testing.T, dir string, activation eth.BlockID, parentHash common.Hash, ts uint64) {
+	t.Helper()
+	db, err := Open(dir, eth.ChainIDFromUInt64(10))
+	require.NoError(t, err)
+
+	virtualParent := eth.BlockID{Hash: parentHash, Number: activation.Number - 1}
+	require.NoError(t, db.SealBlock(common.Hash{}, virtualParent, ts))
+	require.NoError(t, db.SealBlock(parentHash, activation, ts))
+
+	require.NoError(t, db.Close())
+}
+
+func TestCompat_HidesPreVirtualParentEntry(t *testing.T) {
+	dir := t.TempDir()
+	activation := blockID(100, 0x64)
+	parentHash := hash(0x63)
+	seedPreVirtualParentDB(t, dir, activation, parentHash, 1000)
+
+	db, err := Open(dir, eth.ChainIDFromUInt64(10))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	seal, err := db.FirstSealedBlock()
+	require.NoError(t, err)
+	require.Equal(t, activation.Number, seal.Number, "FirstSealedBlock must skip the virtual parent")
+	require.Equal(t, activation.Hash, seal.Hash)
+
+	// OpenBlock on the hidden entry reports it as below the (post-shim) first.
+	_, _, _, err = db.OpenBlock(activation.Number - 1)
+	require.ErrorIs(t, err, interop.ErrSkipped)
+
+	// Activation block is queryable as the new first block.
+	ref, _, _, err := db.OpenBlock(activation.Number)
+	require.NoError(t, err)
+	require.Equal(t, activation.Hash, ref.Hash)
+	require.Equal(t, parentHash, ref.ParentHash)
+}
+
+func TestCompat_PostChangeLayoutUnaffected(t *testing.T) {
+	dir := t.TempDir()
+	{
+		db, err := Open(dir, eth.ChainIDFromUInt64(10))
+		require.NoError(t, err)
+		// Post-#20726: activation block is the first entry, with a real parent hash.
+		require.NoError(t, db.SealBlock(hash(0x63), blockID(100, 0x64), 1000))
+		require.NoError(t, db.Close())
+	}
+
+	db, err := Open(dir, eth.ChainIDFromUInt64(10))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	seal, err := db.FirstSealedBlock()
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), seal.Number)
+}
+
+// Only-virtual-parent DB (no activation block yet) is not touched — the shim
+// requires a second entry to distinguish a genuine empty-anchor DB from one
+// that just happens to have a zero parent hash.
+func TestCompat_OnlyVirtualParent_NotHidden(t *testing.T) {
+	dir := t.TempDir()
+	{
+		db, err := Open(dir, eth.ChainIDFromUInt64(10))
+		require.NoError(t, err)
+		require.NoError(t, db.SealBlock(common.Hash{}, blockID(99, 0x63), 1000))
+		require.NoError(t, db.Close())
+	}
+
+	db, err := Open(dir, eth.ChainIDFromUInt64(10))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	seal, err := db.FirstSealedBlock()
+	require.NoError(t, err)
+	require.Equal(t, uint64(99), seal.Number)
+}
+
+// Genesis-anchored DBs legitimately have a zero parent hash at block 0; the
+// shim's d.firstBlock == 0 guard keeps them intact.
+func TestCompat_GenesisAnchor_NotHidden(t *testing.T) {
+	dir := t.TempDir()
+	{
+		db, err := Open(dir, eth.ChainIDFromUInt64(10))
+		require.NoError(t, err)
+		require.NoError(t, db.SealBlock(common.Hash{}, blockID(0, 0xA0), 0))
+		require.NoError(t, db.SealBlock(hash(0xA0), blockID(1, 0xA1), 1))
+		require.NoError(t, db.Close())
+	}
+
+	db, err := Open(dir, eth.ChainIDFromUInt64(10))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	seal, err := db.FirstSealedBlock()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), seal.Number)
+}

--- a/op-supernode/supernode/activity/interop/raftwallogdb/db.go
+++ b/op-supernode/supernode/activity/interop/raftwallogdb/db.go
@@ -192,7 +192,10 @@ func (d *DB) refreshCache() error {
 	d.latest = eth.BlockID{Hash: rec.Hash, Number: blockNumFor(last)}
 	d.latestTS = rec.Timestamp
 	d.hasBlocks = true
-	return nil
+	// COMPATIBILITY: hide a pre-#20726 virtual-parent head entry, if any.
+	// Safe to delete with compat_virtual_parent.go once no such databases
+	// remain in operation.
+	return d.hidePreVirtualParentLayout()
 }
 
 // readBlockAt fetches the block record at the given raft-wal index.
@@ -254,11 +257,7 @@ func (d *DB) OpenBlock(blockNum uint64) (eth.BlockRef, uint32, map[uint32]*messa
 	if blockNum > d.latest.Number {
 		return eth.BlockRef{}, 0, nil, interop.ErrFuture
 	}
-	// Matches the old op-supervisor logs DB: the first sealed block is an
-	// anchor with no resolvable parent state, so OpenBlock on it returns
-	// ErrSkipped. Genesis (firstBlock == 0) is exempt since it is its own
-	// anchor. Callers retrieve the anchor via FirstSealedBlock.
-	if blockNum < d.firstBlock || (blockNum == d.firstBlock && d.firstBlock > 0) {
+	if blockNum < d.firstBlock {
 		return eth.BlockRef{}, 0, nil, interop.ErrSkipped
 	}
 	var log raft.Log

--- a/op-supernode/supernode/activity/interop/raftwallogdb/db_test.go
+++ b/op-supernode/supernode/activity/interop/raftwallogdb/db_test.go
@@ -283,30 +283,27 @@ func TestOpenBlock_Boundaries(t *testing.T) {
 	require.Empty(t, msgs)
 }
 
-// TestOpenBlock_FirstBlockReturnsSkipped asserts that OpenBlock at the first
-// sealed block number returns ErrSkipped when the first block is not genesis,
-// matching the old op-supervisor logs DB contract. Callers (op-supernode's
-// algo.go fallback) rely on this to identify the anchor and use
-// FirstSealedBlock instead. FirstSealedBlock must still return the block.
-func TestOpenBlock_FirstBlockReturnsSkipped(t *testing.T) {
+// TestOpenBlock_FirstBlockOpens asserts that OpenBlock at the first sealed
+// block number succeeds, returning the block's stored data, even when the
+// first block is not genesis. The first sealed block is no longer treated as
+// an opaque anchor.
+func TestOpenBlock_FirstBlockOpens(t *testing.T) {
 	db := tempDB(t)
 	first := blockID(100, 0x64)
 	require.NoError(t, db.SealBlock(common.Hash{}, first, 1000))
 	sealRange(t, db, first, 101, 103)
 
-	_, _, _, err := db.OpenBlock(100)
-	require.ErrorIs(t, err, interop.ErrSkipped, "OpenBlock(firstBlock) must return ErrSkipped when firstBlock > 0")
+	ref, _, _, err := db.OpenBlock(100)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), ref.Number)
+	require.Equal(t, first.Hash, ref.Hash)
+	require.Equal(t, uint64(1000), ref.Time)
 
 	seal, err := db.FirstSealedBlock()
 	require.NoError(t, err)
 	require.Equal(t, uint64(100), seal.Number)
 	require.Equal(t, first.Hash, seal.Hash)
 	require.Equal(t, uint64(1000), seal.Timestamp)
-
-	// OpenBlock(firstBlock + 1) still succeeds.
-	ref, _, _, err := db.OpenBlock(101)
-	require.NoError(t, err)
-	require.Equal(t, uint64(101), ref.Number)
 }
 
 func TestMultiBlockRoundtrip(t *testing.T) {
@@ -661,7 +658,7 @@ func TestPersistence_AfterRewind(t *testing.T) {
 	db, err := Open(dir, chain)
 	require.NoError(t, err)
 	first := blockID(100, 0x64)
-	require.NoError(t, db.SealBlock(common.Hash{}, first, 1000))
+	require.NoError(t, db.SealBlock(hash(0x63), first, 1000))
 	last := sealRange(t, db, first, 101, 105)
 	require.Equal(t, uint64(105), last.Number)
 


### PR DESCRIPTION
Pre-#20688 op-supervisor logsDB returned `ErrSkipped` from `OpenBlock(firstBlock)` when `firstBlock > 0`, so the supernode sealed a synthetic "virtual parent" ahead of the activation block. With raft-wal LogsDB that contract is no longer needed — seal the activation block directly with its real logs and exec messages, drop the `ErrSkipped` fallback in `algo.go`, and collapse the filter ingester's anchor model (`earliest = first.Number`, no separate `sealParentBlock` call).

`OpenBlock(firstBlock)` now succeeds for non-genesis first blocks. Existing on-disk databases keep a vestigial virtual-parent entry; `raftwallogdb` hides it on `Open` via a self-contained compat shim (`compat_virtual_parent.go` plus tests) that can be deleted whole once those databases are gone — fresh DBs are unaffected because the detection is a no-op when the first entry has a non-zero parent hash.

Closes #20726.