### PR TITLE
op-supernode: retry chain engine setup on demand

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -128,6 +128,7 @@ type InteropChain interface {
 }
 
 type virtualNodeFactory func(cfg *opnodecfg.Config, log gethlog.Logger, initOverrides *rollupNode.InitializationOverrides, appVersion string, superAuthority rollup.SuperAuthority) virtual_node.VirtualNode
+type engineControllerFactory func(ctx context.Context, log gethlog.Logger, vncfg *opnodecfg.Config) (engine_controller.EngineController, error)
 
 // ResetCallback is called when the chain container resets due to an invalidated block.
 // The supernode uses this to notify activities about the reset.
@@ -144,6 +145,7 @@ type simpleChainContainer struct {
 	vn                 virtual_node.VirtualNode
 	vncfg              *opnodecfg.Config
 	cfg                config.CLIConfig
+	engineMu           sync.Mutex
 	engine             engine_controller.EngineController
 	denyList           *DenyList
 	pause              atomic.Bool
@@ -157,7 +159,8 @@ type simpleChainContainer struct {
 	setHandler         func(chainID string, h http.Handler)    // Set the RPC handler on the router for the chain
 	addMetricsRegistry func(key string, g prometheus.Gatherer) // Set the metrics registry on the global metrics server
 	appVersion         string
-	virtualNodeFactory virtualNodeFactory    // Factory function to create virtual node (for testing)
+	virtualNodeFactory virtualNodeFactory // Factory function to create virtual node (for testing)
+	engineFactory      engineControllerFactory
 	rollupClient       *sources.RollupClient // In-proc rollup RPC client bound to rpcHandler
 	metrics            *resources.SupernodeMetrics
 
@@ -200,6 +203,7 @@ func NewChainContainer(
 		addMetricsRegistry: addMetricsRegistry,
 		appVersion:         virtualNodeVersion,
 		virtualNodeFactory: defaultVirtualNodeFactory,
+		engineFactory:      engine_controller.NewEngineControllerFromConfig,
 		metrics:            metrics,
 	}
 	vncfg.SafeDBPath = c.subPath("safe_db")
@@ -327,16 +331,12 @@ func (c *simpleChainContainer) Start(ctx context.Context) error {
 			break
 		}
 
-		// Initialize engine controller if not yet connected (retries on each VN restart)
-		if c.engine == nil && c.vncfg.L2 != nil {
-			setupCtx, setupCancel := context.WithTimeout(ctx, 10*time.Second)
-			engLog := c.log.New("chain_id", c.chainID.String(), "component", "engine_controller")
-			if eng, engErr := engine_controller.NewEngineControllerFromConfig(setupCtx, engLog, c.vncfg); engErr != nil {
-				c.log.Error("failed to setup engine controller", "err", engErr)
-			} else {
-				c.engine = eng
-			}
-			setupCancel()
+		// Initialize engine controller before starting the virtual node when
+		// possible. Callers also retry lazily via ensureEngineController, since
+		// vn.Start may keep running after this early setup misses a not-yet-ready
+		// EL auth RPC.
+		if _, engErr := c.ensureEngineController(ctx); engErr != nil && !errors.Is(engErr, engine_controller.ErrNoEngineClient) {
+			c.log.Error("failed to setup engine controller", "err", engErr)
 		}
 
 		// start the virtual node
@@ -390,9 +390,12 @@ func (c *simpleChainContainer) Stop(ctx context.Context) error {
 	}
 
 	// Close engine controller RPC resources
+	c.engineMu.Lock()
 	if c.engine != nil {
 		_ = c.engine.Close()
+		c.engine = nil
 	}
+	c.engineMu.Unlock()
 
 	// Close deny list database
 	if c.denyList != nil {
@@ -419,11 +422,36 @@ func (c *simpleChainContainer) Resume(ctx context.Context) error {
 	return nil
 }
 
-func (c *simpleChainContainer) ELFinalizedHead(ctx context.Context) (eth.L2BlockRef, error) {
-	if c.engine == nil {
-		return eth.L2BlockRef{}, engine_controller.ErrNoEngineClient
+func (c *simpleChainContainer) ensureEngineController(ctx context.Context) (engine_controller.EngineController, error) {
+	c.engineMu.Lock()
+	defer c.engineMu.Unlock()
+
+	if c.engine != nil {
+		return c.engine, nil
 	}
-	return c.engine.L2BlockRefByLabel(ctx, eth.Finalized)
+	if c.vncfg == nil || c.vncfg.L2 == nil {
+		return nil, engine_controller.ErrNoEngineClient
+	}
+
+	setupCtx, setupCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer setupCancel()
+
+	engLog := c.log.New("chain_id", c.chainID.String(), "component", "engine_controller")
+	eng, err := c.engineFactory(setupCtx, engLog, c.vncfg)
+	if err != nil {
+		return nil, fmt.Errorf("setup engine controller: %w", err)
+	}
+	c.engine = eng
+	c.log.Info("setup engine controller")
+	return eng, nil
+}
+
+func (c *simpleChainContainer) ELFinalizedHead(ctx context.Context) (eth.L2BlockRef, error) {
+	eng, err := c.ensureEngineController(ctx)
+	if err != nil {
+		return eth.L2BlockRef{}, err
+	}
+	return eng.L2BlockRefByLabel(ctx, eth.Finalized)
 }
 
 func (c *simpleChainContainer) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error) {
@@ -476,8 +504,9 @@ func (c *simpleChainContainer) FirstSafeHeadTimestamp(ctx context.Context) (uint
 // LocalSafeBlockAtTimestamp returns the highest L2 block with timestamp <= ts using the L2 client,
 // if the block at that timestamp is local safe.
 func (c *simpleChainContainer) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
-	if c.engine == nil {
-		return eth.L2BlockRef{}, engine_controller.ErrNoEngineClient
+	eng, err := c.ensureEngineController(ctx)
+	if err != nil {
+		return eth.L2BlockRef{}, err
 	}
 
 	// Compute the target block directly from rollup config
@@ -496,7 +525,7 @@ func (c *simpleChainContainer) LocalSafeBlockAtTimestamp(ctx context.Context, ts
 		return eth.L2BlockRef{}, ethereum.NotFound
 	}
 
-	return c.engine.L2BlockRefByNumber(ctx, num)
+	return eng.L2BlockRefByNumber(ctx, num)
 }
 
 // SyncStatus returns the in-process op-node sync status for this chain.
@@ -516,10 +545,11 @@ func (c *simpleChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus,
 }
 
 func (c *simpleChainContainer) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
-	if c.engine == nil {
-		return eth.Bytes32{}, engine_controller.ErrNoEngineClient
+	eng, err := c.ensureEngineController(ctx)
+	if err != nil {
+		return eth.Bytes32{}, err
 	}
-	out, err := c.engine.OutputV0ByBlockHash(ctx, blockHash)
+	out, err := eng.OutputV0ByBlockHash(ctx, blockHash)
 	if err != nil {
 		return eth.Bytes32{}, err
 	}
@@ -605,24 +635,27 @@ func (c *simpleChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, 
 
 // FetchReceipts fetches the receipts for a given block by hash.
 func (c *simpleChainContainer) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
-	if c.engine == nil {
-		return nil, engine_controller.ErrNoEngineClient
+	eng, err := c.ensureEngineController(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return c.engine.PayloadByHash(ctx, hash)
+	return eng.PayloadByHash(ctx, hash)
 }
 
 func (c *simpleChainContainer) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
-	if c.engine == nil {
-		return nil, engine_controller.ErrNoEngineClient
+	eng, err := c.ensureEngineController(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return c.engine.PayloadByNumber(ctx, number)
+	return eng.PayloadByNumber(ctx, number)
 }
 
 func (c *simpleChainContainer) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
-	if c.engine == nil {
-		return nil, nil, engine_controller.ErrNoEngineClient
+	eng, err := c.ensureEngineController(ctx)
+	if err != nil {
+		return nil, nil, err
 	}
-	return c.engine.FetchReceipts(ctx, blockID.Hash)
+	return eng.FetchReceipts(ctx, blockID.Hash)
 }
 
 // BlockTime returns the block time in seconds for this chain from the rollup config.
@@ -679,12 +712,13 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, target *eth.Exe
 	if vn == nil {
 		return fmt.Errorf("virtual node not initialized")
 	}
-	if c.engine == nil {
-		return fmt.Errorf("engine not initialized")
+	eng, err := c.ensureEngineController(ctx)
+	if err != nil {
+		return fmt.Errorf("engine not initialized: %w", err)
 	}
 
 	// Pause the container to stop it restarting the vn when we kill it
-	err := c.Pause(ctx)
+	err = c.Pause(ctx)
 	if err != nil {
 		return err
 	}
@@ -703,7 +737,7 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, target *eth.Exe
 
 retryLoop:
 	for {
-		err = c.engine.Rewind(ctx, target)
+		err = eng.Rewind(ctx, target)
 		switch {
 		case isCriticalRewindError(err):
 			c.log.Error("chain_container/RewindEngine: critical error", "err", err)

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -1331,6 +1331,56 @@ func TestChainContainer_LocalSafeBlockAtTimestamp(t *testing.T) {
 	}
 }
 
+func TestChainContainer_LocalSafeBlockAtTimestamp_RetriesEngineSetup(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	log := createTestLogger(t)
+	cfg := createTestCLIConfig(t.TempDir())
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	vncfg := createTestVNConfig()
+	vncfg.L2 = &opnodecfg.L2EndpointConfig{L2EngineAddr: "unused"}
+	vncfg.Rollup.Genesis.L2Time = 1000
+	vncfg.Rollup.BlockTime = 2
+
+	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	impl, ok := container.(*simpleChainContainer)
+	require.True(t, ok)
+
+	mockVN := newMockVirtualNode()
+	mockVN.safeHeadL2 = eth.BlockID{Number: 10}
+	impl.vn = mockVN
+
+	mockEngine := &mockEngineController{
+		l2BlockRefByNumberResult: eth.L2BlockRef{Hash: common.Hash{0x11}, Number: 5, Time: 1010},
+	}
+
+	setupErr := errors.New("temporary engine setup failure")
+	var calls int
+	impl.engineFactory = func(ctx context.Context, log gethlog.Logger, vncfg *opnodecfg.Config) (engine_controller.EngineController, error) {
+		calls++
+		if calls == 1 {
+			return nil, setupErr
+		}
+		return mockEngine, nil
+	}
+
+	_, err := container.LocalSafeBlockAtTimestamp(context.Background(), 1010)
+	require.ErrorIs(t, err, setupErr)
+	require.Equal(t, 1, calls)
+
+	ref, err := container.LocalSafeBlockAtTimestamp(context.Background(), 1010)
+	require.NoError(t, err)
+	require.Equal(t, mockEngine.l2BlockRefByNumberResult, ref)
+	require.Equal(t, 2, calls)
+
+	ref, err = container.LocalSafeBlockAtTimestamp(context.Background(), 1010)
+	require.NoError(t, err)
+	require.Equal(t, mockEngine.l2BlockRefByNumberResult, ref)
+	require.Equal(t, 2, calls, "initialized engine should be reused")
+}
+
 func TestChainContainer_OptimisticOutputAtTimestamp_ReturnsDeniedOutput(t *testing.T) {
 	t.Parallel()
 

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -403,8 +403,9 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 
 	// Errors here propagate so the caller preserves the pending transition for
 	// retry on restart; the deny list entry above is already durable.
-	if c.engine == nil {
-		return false, fmt.Errorf("cannot check current block at height %d: %w", height, engine_controller.ErrNoEngineClient)
+	eng, err := c.ensureEngineController(ctx)
+	if err != nil {
+		return false, fmt.Errorf("cannot check current block at height %d: %w", height, err)
 	}
 
 	// Only skip the rewind when the engine reports a block at this height that is not the
@@ -412,7 +413,7 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	// have left the synthetic block at this height with no canonical entry visible by
 	// number, and we need to drive the rewind to completion.
 	var invalidatedBlock eth.BlockRef
-	currentBlock, err := c.engine.L2BlockRefByNumber(ctx, height)
+	currentBlock, err := eng.L2BlockRefByNumber(ctx, height)
 	switch {
 	case err == nil:
 		if currentBlock.Hash != payloadHash {

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -106,10 +105,11 @@ func (c *simpleChainContainer) GetDeniedOutput(height uint64, payloadHash common
 
 // OutputV0AtBlockNumber returns the full OutputV0 for the block at the given number.
 func (c *simpleChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
-	if c.engine == nil {
-		return nil, engine_controller.ErrNoEngineClient
+	eng, err := c.ensureEngineController(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return c.engine.OutputV0AtBlockNumber(ctx, l2BlockNum)
+	return eng.OutputV0AtBlockNumber(ctx, l2BlockNum)
 }
 
 var _ rollup.SuperAuthority = (*simpleChainContainer)(nil)


### PR DESCRIPTION
## Summary
- retry chain-container engine controller setup lazily from engine-dependent call sites
- keep the early startup setup path, but avoid permanently pinning `c.engine` nil if the EL auth RPC was not ready yet
- close and clear the cached engine controller on stop
- add regression coverage for transient engine setup failure followed by successful retry

## Motivation
If op-supernode starts before its EL auth RPC is reachable, the initial engine-controller setup can fail. The embedded virtual node can keep running, so there may be no later virtual-node restart to retry setup. That leaves supernode interop paths returning `engine client not initialized` even after the EL is healthy and local derivation is otherwise moving.

This makes the startup order resilient: engine users retry setup on demand and then reuse the initialized controller.

## Tests
- `go test -count=1 ./op-supernode/supernode/chain_container`