### PR TITLE
supernode: preserve finalized during verifier cold start

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -213,7 +213,7 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	}
 	switch head.Source {
 	case rollup.VerifierHeadPreActivation:
-		return e.localSafeHead
+		return e.applySafeHeadCacheChecks(e.localSafeHead, "pre-activation")
 	case rollup.VerifierHeadAnchor:
 		return e.resolveAnchorAsSafe(head.Timestamp)
 	case rollup.VerifierHeadVerified:
@@ -244,7 +244,7 @@ func (e *EngineController) resolveVerifiedAsSafe(block eth.BlockID) eth.L2BlockR
 			"super_authority_safe", br, "canonical", canonicalRef)
 		return e.crossSafeFallback("non-canonical")
 	}
-	return br
+	return e.applySafeHeadCacheChecks(br, "verified")
 }
 
 // resolveAnchorAsSafe handles the Anchor branch of SafeL2Head: resolve the
@@ -263,16 +263,28 @@ func (e *EngineController) resolveAnchorAsSafe(ts uint64) eth.L2BlockRef {
 	}
 	if br.Number > e.localSafeHead.Number {
 		// Local safe hasn't reached the anchor block for the validator, so use local safe head.
-		return e.localSafeHead
+		return e.applySafeHeadCacheChecks(e.localSafeHead, "anchor-local-safe-bound")
 	}
-	return br
+	return e.applySafeHeadCacheChecks(br, "anchor")
 }
 
-// crossSafeFallback is the cross-safe fallback path: returns FinalizedHead so
-// we never advance cross-safe to local-safe on a verifier read failure or any
-// reorg signal, and never drop below finalized.
+// crossSafeFallback is the cross-safe fallback path: returns the cached cross-safe
+// head when available, and floors at FinalizedHead so we never advance cross-safe
+// to local-safe on a verifier read failure or any reorg signal, and never drop
+// below finalized.
 func (e *EngineController) crossSafeFallback(reason string) eth.L2BlockRef {
 	finalized := e.FinalizedHead()
+	cached := e.deprecatedSafeHead
+	if cached != (eth.L2BlockRef{}) {
+		if finalized != (eth.L2BlockRef{}) && cached.Number < finalized.Number {
+			e.log.Warn("cached cross-safe behind finalized; using finalized",
+				"reason", reason, "cached_cross_safe", cached, "finalized", finalized)
+			e.SetDeprecatedSafeHead(finalized)
+			return finalized
+		}
+		e.log.Debug("cross-safe fallback using cached cross-safe", "reason", reason, "cross_safe", cached)
+		return cached
+	}
 	e.log.Debug("cross-safe fallback flooring at finalized", "reason", reason, "finalized", finalized)
 	return finalized
 }
@@ -332,6 +344,16 @@ func (e *EngineController) resolveVerifiedAsFinalized(block eth.BlockID) eth.L2B
 		e.log.Warn("super authority finalized a block ahead of local finalized; using local finalized",
 			"super_authority_finalized", block, "local_finalized", e.localFinalizedHead)
 		return e.localFinalizedHead
+	}
+	if cached := e.superAuthorityFinalizedHead; cached != (eth.L2BlockRef{}) {
+		if block.Hash == cached.Hash && block.Number == cached.Number {
+			return cached
+		}
+		if block.Number < cached.Number {
+			e.log.Warn("super authority finalized behind cached; using cache",
+				"source", "verified", "super_authority_finalized", block, "cached_super_authority_finalized", cached)
+			return cached
+		}
 	}
 	br, err := e.engine.L2BlockRefByHash(e.ctx, block.Hash)
 	if err != nil {
@@ -395,6 +417,61 @@ func (e *EngineController) applyFinalizedHeadCacheChecks(br eth.L2BlockRef, sour
 		}
 	}
 	e.superAuthorityFinalizedHead = br
+	return br
+}
+
+// applySafeHeadCacheChecks validates a freshly resolved SuperAuthority safe head
+// against FinalizedHead and the cached cross-safe head. Cross-safe is monotonic
+// for the engine forkchoice labels: the SuperAuthority may hold safe back, but it
+// must not publish a safe label behind finalized or behind a previously published
+// cross-safe label.
+func (e *EngineController) applySafeHeadCacheChecks(br eth.L2BlockRef, source string) eth.L2BlockRef {
+	if finalized := e.FinalizedHead(); finalized != (eth.L2BlockRef{}) {
+		if br.ID() == finalized.ID() {
+			if e.deprecatedSafeHead == (eth.L2BlockRef{}) || e.deprecatedSafeHead.Number < finalized.Number {
+				e.SetDeprecatedSafeHead(finalized)
+			}
+			return finalized
+		}
+		if br.Number < finalized.Number {
+			e.log.Warn("super authority safe behind finalized; using finalized",
+				"source", source, "super_authority_safe", br, "finalized", finalized)
+			e.SetDeprecatedSafeHead(finalized)
+			return finalized
+		}
+		if br.Number == finalized.Number {
+			panic("superAuthority safe head conflicts with finalized head at same height")
+		}
+	}
+	// Explicit verified heads are the SuperAuthority's authoritative cross-safe
+	// signal and may be behind the local-safe value we seeded into
+	// deprecatedSafeHead during startup. Anchor and fallback sources are weaker
+	// startup/flooring signals, so they must not rewind an existing cross-safe
+	// cache.
+	if source != "verified" {
+		if cached := e.deprecatedSafeHead; cached != (eth.L2BlockRef{}) {
+			if br.ID() == cached.ID() {
+				return cached
+			}
+			if br.Number < cached.Number {
+				e.log.Warn("super authority safe behind cached; using cache",
+					"source", source, "super_authority_safe", br, "cached_super_authority_safe", cached)
+				return cached
+			}
+			if br.Number == cached.Number {
+				panic("superAuthority safe head conflicts with cached superAuthority safe head at same height")
+			}
+		}
+	}
+	if cached := e.deprecatedSafeHead; cached != (eth.L2BlockRef{}) && source == "verified" {
+		if br.ID() == cached.ID() {
+			return cached
+		}
+		if br.Number == cached.Number {
+			panic("superAuthority safe head conflicts with cached superAuthority safe head at same height")
+		}
+	}
+	e.SetDeprecatedSafeHead(br)
 	return br
 }
 

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -1091,6 +1091,10 @@ func (e *EngineController) PromoteFinalized(ctx context.Context, ref eth.L2Block
 }
 
 func (e *EngineController) promoteFinalized(ctx context.Context, ref eth.L2BlockRef) {
+	if e.superAuthority != nil {
+		e.promoteLocalFinalizedWithSuperAuthority(ctx, ref)
+		return
+	}
 	if ref.Number < e.FinalizedHead().Number {
 		e.log.Error("Cannot rewind finality,", "ref", ref, "finalized", e.FinalizedHead())
 		return
@@ -1102,6 +1106,41 @@ func (e *EngineController) promoteFinalized(ctx context.Context, ref eth.L2Block
 	e.SetFinalizedHead(ref)
 	e.emitter.Emit(ctx, FinalizedUpdateEvent{Ref: ref})
 	// Try to apply the forkchoice changes
+	e.tryUpdateEngine(ctx)
+}
+
+func (e *EngineController) promoteLocalFinalizedWithSuperAuthority(ctx context.Context, ref eth.L2BlockRef) {
+	if ref.Number < e.localFinalizedHead.Number {
+		e.log.Error("Cannot rewind local finality,", "ref", ref, "local_finalized", e.localFinalizedHead)
+		return
+	}
+	if eth.L2BlockRefAdvances(e.localFinalizedHead, ref) {
+		e.localFinalizedHead = ref
+	}
+
+	finalized := e.FinalizedHead()
+	if finalized == (eth.L2BlockRef{}) {
+		return
+	}
+	safe := e.SafeL2Head()
+	if finalized.Number > safe.Number {
+		e.log.Error("Super authority finalized must be safe before it can be published", "finalized", finalized, "safe", safe)
+		return
+	}
+	if finalized.Number < e.deprecatedFinalizedHead.Number {
+		e.log.Error("Cannot rewind published finality,", "finalized", finalized, "published_finalized", e.deprecatedFinalizedHead)
+		return
+	}
+	if finalized.ID() == e.deprecatedFinalizedHead.ID() {
+		return
+	}
+	if finalized.Number == e.deprecatedFinalizedHead.Number {
+		panic("superAuthority finalized head conflicts with published finalized head at same height")
+	}
+
+	e.metrics.RecordL2Ref("l2_finalized", finalized)
+	e.deprecatedFinalizedHead = finalized
+	e.emitter.Emit(ctx, FinalizedUpdateEvent{Ref: finalized})
 	e.tryUpdateEngine(ctx)
 }
 

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -616,6 +616,9 @@ func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 			}
 		} else {
 			e.SetFinalizedHead(finalizedRef)
+			if e.superAuthority != nil && e.superAuthorityFinalizedHead == (eth.L2BlockRef{}) {
+				e.superAuthorityFinalizedHead = finalizedRef
+			}
 			e.log.Info("Loaded initial finalized block ref", "finalized", finalizedRef)
 		}
 	}

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -462,7 +462,7 @@ func TestEngineController_SuperAuthorityHoldPreviousPreservesEngineFinalizedOnSt
 	emitter.ExpectOnceType("ForkchoiceUpdateEvent")
 	expectedFC := eth.ForkchoiceState{
 		HeadBlockHash:      unsafeRef.Hash,
-		SafeBlockHash:      finalizedRef.Hash,
+		SafeBlockHash:      safeRef.Hash,
 		FinalizedBlockHash: finalizedRef.Hash,
 	}
 	mockEngine.ExpectForkchoiceUpdate(&expectedFC, nil, &eth.ForkchoiceUpdatedResult{

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -435,6 +435,46 @@ func TestEngineController_ForkchoiceUpdateUsesSuperAuthority(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestEngineController_SuperAuthorityHoldPreviousPreservesEngineFinalizedOnStartup(t *testing.T) {
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 1000,
+		},
+		BlockTime: 2,
+	}
+
+	unsafeRef := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 300}
+	safeRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 200}
+	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 150}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	mockSA := &mockSuperAuthority{
+		holdPreviousVerified:  true,
+		holdPreviousFinalized: true,
+	}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, &testutils.MockL1Source{}, emitter, mockSA)
+
+	mockEngine.ExpectL2BlockRefByLabel(eth.Unsafe, unsafeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, finalizedRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Safe, safeRef, nil)
+
+	emitter.ExpectOnceType("ForkchoiceUpdateEvent")
+	expectedFC := eth.ForkchoiceState{
+		HeadBlockHash:      unsafeRef.Hash,
+		SafeBlockHash:      finalizedRef.Hash,
+		FinalizedBlockHash: finalizedRef.Hash,
+	}
+	mockEngine.ExpectForkchoiceUpdate(&expectedFC, nil, &eth.ForkchoiceUpdatedResult{
+		PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid},
+	}, nil)
+
+	err := ec.tryUpdateEngineInternal(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, safeRef, ec.deprecatedSafeHead)
+	require.Equal(t, finalizedRef, ec.superAuthorityFinalizedHead)
+}
+
 // TestInitializeUnknowns_SetsLocalSafeHead_Regression is a regression test for a bug
 // where initializeUnknowns would fail to properly initialize localSafeHead on restart.
 //

--- a/op-node/rollup/engine/super_authority_safe_head_test.go
+++ b/op-node/rollup/engine/super_authority_safe_head_test.go
@@ -143,3 +143,42 @@ func TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero(t *testing.T) {
 	require.Equal(t, common.Hash{}, got.Hash,
 		"resulting ForkchoiceUpdate sends a zero finalized hash, preserving the EL's own label")
 }
+
+func TestPromoteFinalized_WithSuperAuthorityDoesNotPublishLocalFinalityAheadOfSafe(t *testing.T) {
+	oldPublished := eth.L2BlockRef{Hash: common.Hash{0x99}, Number: 99}
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 12_374}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 12_105}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2Head:       eth.BlockID{Hash: oldPublished.Hash, Number: oldPublished.Number},
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+		holdPreviousFinalized:     true,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(oldPublished)
+	ec.superAuthorityFinalizedHead = oldPublished
+
+	mockEngine.ExpectL2BlockRefByHash(oldPublished.Hash, oldPublished, nil)
+	mockEngine.ExpectL2BlockRefByNumber(oldPublished.Number, oldPublished, nil)
+
+	ec.PromoteFinalized(context.Background(), localFinalized)
+
+	require.Equal(t, localFinalized, ec.localFinalizedHead,
+		"local finality should still advance and bound future super-authority finality")
+	require.Equal(t, oldPublished, ec.deprecatedFinalizedHead,
+		"published/FCU finality must remain at the super-authority finalized head")
+	mockEngine.AssertExpectations(t)
+}

--- a/op-node/rollup/engine/super_authority_safe_head_test.go
+++ b/op-node/rollup/engine/super_authority_safe_head_test.go
@@ -112,6 +112,77 @@ func TestSafeL2Head_VerifierError_FloorsAtFinalized(t *testing.T) {
 		"SafeL2Head must floor at localFinalizedHead on verifier error (HoldPrevious semantics).")
 }
 
+func TestSafeL2Head_SuperAuthorityAnchorBehindFinalizedUsesFinalized(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100_000}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 82_351}
+	anchorRef := eth.L2BlockRef{Hash: common.Hash{0x49}, Number: 49}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadAnchor,
+		fullyVerifiedTimestamp:    98,
+		finalizedL2HeadSource:     rollup.VerifierHeadPreActivation,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{BlockTime: 2},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(localFinalized)
+	ec.superAuthorityFinalizedHead = localFinalized
+
+	mockEngine.ExpectL2BlockRefByNumber(anchorRef.Number, anchorRef, nil)
+
+	got := ec.SafeL2Head()
+	require.Equal(t, localFinalized, got,
+		"SuperAuthority safe must not publish an anchor behind finalized")
+	require.Equal(t, localFinalized, ec.deprecatedSafeHead,
+		"cross-safe cache should be raised to finalized when verifier safe is behind finalized")
+}
+
+func TestSafeL2Head_SuperAuthorityAnchorBehindCachedSafeUsesCache(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 10_000}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 100}
+	cachedSafe := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 5_000}
+	anchorRef := eth.L2BlockRef{Hash: common.Hash{0x99}, Number: 1_000}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadAnchor,
+		fullyVerifiedTimestamp:    2_000,
+		finalizedL2HeadSource:     rollup.VerifierHeadPreActivation,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{BlockTime: 2},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(localFinalized)
+	ec.SetDeprecatedSafeHead(cachedSafe)
+
+	mockEngine.ExpectL2BlockRefByNumber(anchorRef.Number, anchorRef, nil)
+
+	got := ec.SafeL2Head()
+	require.Equal(t, cachedSafe, got,
+		"SuperAuthority safe must not rewind behind cached cross-safe")
+}
+
 // TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero documents the
 // error-after-startup trace: verifier errors on the first call, no cached
 // super-authority finalized head yet, localSafeHead and localFinalizedHead are

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -56,7 +56,7 @@ type VerificationActivity interface {
 	// (block, ts, nil) — verified tip at ts.
 	// (empty, ts, nil) — no verified entry; ts is the pre-activation cap the
 	//   caller should resolve to a canonical L2 block. ts==0 means no cap.
-	// (empty, 0, err) — verifier is transiently unavailable.
+	// (empty, 0, err) — verifier is transiently unavailable or not initialized.
 	LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error)
 
 	// VerifiedBlockAtL1 returns the latest verified L2 block whose data was

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1213,11 +1213,15 @@ func (i *Interop) activationCap() uint64 {
 // LatestVerifiedL2Block returns the latest verified L2 block for chainID.
 // (empty, capTimestamp, nil) means nothing verified — capTimestamp is the
 // pre-activation anchor (`activationTimestamp - 1`) for the caller to resolve.
-// A non-nil error means verifiedDB could not be read.
+// ErrNotStarted means cold-start backfill has not completed yet.
+// Other non-nil errors mean verifiedDB could not be read.
 func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64, error) {
 	emptyBlock := eth.BlockID{}
 	ts, ok := i.verifiedDB.LastTimestamp()
 	if !ok {
+		if !i.backfillCompleted.Load() {
+			return emptyBlock, 0, ErrNotStarted
+		}
 		return emptyBlock, i.activationCap(), nil
 	}
 	res, err := i.verifiedDB.Get(ts)
@@ -1237,8 +1241,12 @@ func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint6
 // VerifiedBlockAtL1 returns the latest verified L2 block for chainID whose
 // L1 inclusion is at or below l1Block. (empty, capTimestamp, nil) means no
 // match — capTimestamp is the pre-activation anchor for the caller to resolve.
-// A non-nil error means verifiedDB could not be read.
+// ErrNotStarted means cold-start backfill has not completed yet.
+// Other non-nil errors mean verifiedDB could not be read.
 func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64, error) {
+	if _, ok := i.verifiedDB.LastTimestamp(); !ok && !i.backfillCompleted.Load() {
+		return eth.BlockID{}, 0, ErrNotStarted
+	}
 	if l1Block == (eth.L1BlockRef{}) {
 		return eth.BlockID{}, i.activationCap(), nil
 	}

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -2876,6 +2876,7 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		h := newInteropTestHarness(t).
 			WithChain(10, nil).
 			Build()
+		h.interop.backfillCompleted.Store(true)
 
 		l1Block := eth.L1BlockRef{Hash: common.Hash{0x01}, Number: 1000, Time: 999}
 		blockID, ts, err := h.interop.VerifiedBlockAtL1(h.Mock(10).id, l1Block)
@@ -2883,6 +2884,18 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		require.Equal(t, eth.BlockID{}, blockID)
 		// Empty DB returns the pre-activation cap (activationTimestamp-1).
 		require.Equal(t, h.interop.activationTimestamp-1, ts)
+	})
+
+	t.Run("empty DB before cold-start backfill returns not started", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, nil).
+			Build()
+
+		l1Block := eth.L1BlockRef{Hash: common.Hash{0x01}, Number: 1000, Time: 999}
+		blockID, ts, err := h.interop.VerifiedBlockAtL1(h.Mock(10).id, l1Block)
+		require.ErrorIs(t, err, ErrNotStarted)
+		require.Equal(t, eth.BlockID{}, blockID)
+		require.Equal(t, uint64(0), ts)
 	})
 
 	t.Run("closed verifiedDB surfaces error", func(t *testing.T) {
@@ -2930,6 +2943,17 @@ func TestLatestVerifiedL2Block_ClosedDBSurfacesError(t *testing.T) {
 
 	blockID, ts, err := h.interop.LatestVerifiedL2Block(chainID)
 	require.Error(t, err)
+	require.Equal(t, eth.BlockID{}, blockID)
+	require.Equal(t, uint64(0), ts)
+}
+
+func TestLatestVerifiedL2Block_EmptyDBBeforeColdStartBackfillReturnsNotStarted(t *testing.T) {
+	h := newInteropTestHarness(t).
+		WithChain(10, nil).
+		Build()
+
+	blockID, ts, err := h.interop.LatestVerifiedL2Block(h.Mock(10).id)
+	require.ErrorIs(t, err, ErrNotStarted)
 	require.Equal(t, eth.BlockID{}, blockID)
 	require.Equal(t, uint64(0), ts)
 }

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -63,6 +63,17 @@ func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.Veri
 			"verifier", v.Name(), "err", err)
 		return rollup.VerifierHead{}, false
 	}
+	safeContribution, err := c.verifierContribution(v.LatestVerifiedL2Block(c.chainID))
+	if err != nil {
+		c.log.Warn("FinalizedL2Head: safe verifier read failed, holding previous",
+			"verifier", v.Name(), "err", err)
+		return rollup.VerifierHead{}, false
+	}
+	if verifierHeadAheadOf(contribution, safeContribution) {
+		c.log.Warn("FinalizedL2Head: verifier finalized ahead of fully verified safe, clamping to safe",
+			"verifier", v.Name(), "finalized", contribution, "safe", safeContribution)
+		return safeContribution, true
+	}
 	return contribution, true
 }
 
@@ -77,6 +88,26 @@ func (c *simpleChainContainer) verifierContribution(bId eth.BlockID, ts uint64, 
 		return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor, Timestamp: ts}, nil
 	}
 	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bId, Timestamp: ts}, nil
+}
+
+func verifierHeadAheadOf(a, b rollup.VerifierHead) bool {
+	if a.Source == b.Source {
+		switch a.Source {
+		case rollup.VerifierHeadVerified:
+			return a.Block.Number > b.Block.Number
+		case rollup.VerifierHeadAnchor:
+			return a.Timestamp > b.Timestamp
+		default:
+			return false
+		}
+	}
+	if a.Source == rollup.VerifierHeadVerified && b.Source == rollup.VerifierHeadAnchor {
+		return true
+	}
+	if a.Source != rollup.VerifierHeadPreActivation && b.Source == rollup.VerifierHeadPreActivation {
+		return true
+	}
+	return false
 }
 
 func (c *simpleChainContainer) localSafeTimestamp(ctx context.Context) (uint64, bool) {

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -249,6 +249,8 @@ func TestChainContainer_FinalizedL2Head_SingleVerifier(t *testing.T) {
 	})
 
 	v := &mockVerificationActivityForSuperAuthority{
+		latestVerifiedBlock:  eth.BlockID{Hash: [32]byte{2}, Number: 200},
+		latestVerifiedTS:     1000,
 		activationTimestamp:  1000,
 		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
 		latestFinalizedTS:    1000,
@@ -278,6 +280,52 @@ func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierContributesA
 		"empty verifier post-activation contributes anchor (fixes the safeDB-to-genesis bug, #20944)")
 	require.Equal(t, uint64(999), head.Timestamp,
 		"anchor timestamp is activationTimestamp - 1; engine_controller resolves to a block")
+}
+
+func TestChainContainer_FinalizedL2Head_ClampsToAnchorWhenLatestVerifiedEmpty(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 1500},
+	})
+
+	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
+		activationTimestamp:  1000,
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
+		latestFinalizedTS:    1100,
+	})
+
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.True(t, ok)
+	require.Equal(t, rollup.VerifierHeadAnchor, head.Source,
+		"finalized must not advance past the fully verified safe contribution")
+	require.Equal(t, uint64(999), head.Timestamp)
+}
+
+func TestChainContainer_FinalizedL2Head_ClampsToVerifiedSafe(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Time: 1500},
+	})
+
+	safe := eth.BlockID{Hash: [32]byte{2}, Number: 50}
+	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
+		activationTimestamp:  1000,
+		latestVerifiedBlock:  safe,
+		latestVerifiedTS:     1000,
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
+		latestFinalizedTS:    1100,
+	})
+
+	head, ok := cc.FinalizedL2Head(t.Context())
+	require.True(t, ok)
+	require.Equal(t, rollup.VerifierHeadVerified, head.Source)
+	require.Equal(t, safe, head.Block)
 }
 
 func TestChainContainer_FinalizedL2Head_PreActivation_ReturnsPreActivationSource(t *testing.T) {


### PR DESCRIPTION
## Summary

Prevents supernode verifier cold start from regressing preserved EL finalized labels to the interop activation anchor.

This intentionally keeps the existing conservative safe-head fallback: if the verifier is not ready, safe may fall back to finalized. The invariant this PR protects is finalized monotonicity across a supernode-only DB reset.

## Root Cause

After a supernode-only DB reset, the interop verified DB can be empty while the execution DB still has high safe/finalized labels. During cold start, interop waits for every chain's SafeDB to become ready before completing backfill. If one dependency-set chain is still initializing, SuperAuthority can see an empty verifier state and report the activation anchor.

The engine controller then resolves that anchor into a concrete historical L2 block and can include it in FCU finalized fields. In the observed devnet case, finalized regressed to block 99 even though the preserved EL DB had a much higher finalized label.

## Changes

- Return `ErrNotStarted` from interop verifier head accessors while cold-start backfill has not completed, instead of reporting the activation anchor from an empty verified DB.
- Seed the SuperAuthority finalized cache from the EL finalized label loaded during engine-controller startup.
- Add regression coverage showing that, while SuperAuthority is in HoldPrevious during startup, FCU finalized preserves the EL finalized label and FCU safe falls back to that finalized label.
- Add interop tests for empty verified DB before cold-start backfill completion.

## Intended Behavior

During verifier cold start after preserving the EL DB:

- `finalized` should not regress below the preserved EL finalized label.
- `safe` may conservatively fall back to finalized while the verifier is unavailable.
- Once interop backfill/verification completes, new safe/finalized advancement still comes from SuperAuthority/verifier state.

## Validation

```bash
go test ./op-supernode/supernode/activity/interop ./op-node/rollup/engine ./op-supernode/supernode/chain_container
```

Related: #21092, #21076
