### PR TITLE
op-challenger: stop handling super permissioned games

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -108,16 +108,13 @@ func TestL1Beacon(t *testing.T) {
 }
 
 func TestSuperNodeRpc(t *testing.T) {
-	t.Run("RequiredForSuperPermissioned", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag supernode-rpc is required", addRequiredArgsExcept(gameTypes.SuperPermissionedGameType, "--supernode-rpc"))
-	})
 	t.Run("RequiredForSuperCannonKona", func(t *testing.T) {
 		verifyArgsInvalid(t, "flag supernode-rpc is required", addRequiredArgsExcept(gameTypes.SuperCannonKonaGameType, "--supernode-rpc"))
 	})
 
 	for _, gameType := range gameTypes.SupportedGameTypes {
 		gameType := gameType
-		if gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
+		if gameType == gameTypes.SuperCannonKonaGameType {
 			continue
 		}
 
@@ -125,12 +122,6 @@ func TestSuperNodeRpc(t *testing.T) {
 			configForArgs(t, addRequiredArgsExcept(gameType, "--supernode-rpc"))
 		})
 	}
-
-	t.Run("Valid-SuperPermissioned", func(t *testing.T) {
-		url := "http://localhost/super"
-		cfg := configForArgs(t, addRequiredArgsExcept(gameTypes.SuperPermissionedGameType, "--supernode-rpc", "--supernode-rpc", url))
-		require.Equal(t, url, cfg.SuperRPC)
-	})
 
 	t.Run("Valid-SuperCannonKona", func(t *testing.T) {
 		url := "http://localhost/super"
@@ -156,6 +147,9 @@ func TestGameTypes(t *testing.T) {
 
 	t.Run("Invalid", func(t *testing.T) {
 		verifyArgsInvalid(t, "unknown game type: \"foo\"", addRequiredArgsExcept(gameTypes.AlphabetGameType, "--game-types", "--game-types=foo"))
+	})
+	t.Run("SuperPermissionedUnsupported", func(t *testing.T) {
+		verifyArgsInvalid(t, "unknown game type: \"super-permissioned\"", addRequiredArgsExcept(gameTypes.AlphabetGameType, "--game-types", "--game-types=super-permissioned"))
 	})
 
 	// Check we provide an alias for --trace-type to preserve backwards compatibility
@@ -479,7 +473,7 @@ func TestCannonCustomConfigArgs(t *testing.T) {
 }
 
 func TestSuperCannonKonaCustomConfigArgs(t *testing.T) {
-	for _, gameType := range []gameTypes.GameType{gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType} {
+	for _, gameType := range []gameTypes.GameType{gameTypes.SuperCannonKonaGameType} {
 		gameType := gameType
 
 		t.Run(fmt.Sprintf("TestRequireEitherCannonKonaNetworkOrRollupAndGenesisAndDepset-%v", gameType), func(t *testing.T) {
@@ -705,7 +699,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 }
 
 func TestCannonKonaRequiredArgs(t *testing.T) {
-	for _, gameType := range []gameTypes.GameType{gameTypes.CannonKonaGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType} {
+	for _, gameType := range []gameTypes.GameType{gameTypes.CannonKonaGameType, gameTypes.SuperCannonKonaGameType} {
 		gameType := gameType
 		t.Run(fmt.Sprintf("TestCannonKonaServer-%v", gameType), func(t *testing.T) {
 			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
@@ -769,7 +763,7 @@ func TestCannonKonaRequiredArgs(t *testing.T) {
 
 func TestDepsetConfig(t *testing.T) {
 	for _, gameType := range gameTypes.SupportedGameTypes {
-		if gameType == gameTypes.SuperCannonKonaGameType || gameType == gameTypes.SuperPermissionedGameType {
+		if gameType == gameTypes.SuperCannonKonaGameType {
 			t.Run("Required-"+gameType.String(), func(t *testing.T) {
 				verifyArgsInvalid(t,
 					"flag network or rollup-config/cannon-kona-rollup-config, l2-genesis/cannon-kona-l2-genesis and depset-config/cannon-kona-depset-config is required",
@@ -803,7 +797,7 @@ func TestRollupRpc(t *testing.T) {
 	for _, gameType := range gameTypes.SupportedGameTypes {
 		gameType := gameType
 
-		if gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
+		if gameType == gameTypes.SuperCannonKonaGameType {
 			t.Run(fmt.Sprintf("NotRequiredFor-%v", gameType), func(t *testing.T) {
 				configForArgs(t, addRequiredArgsExcept(gameType, "--rollup-rpc"))
 			})
@@ -986,7 +980,7 @@ func requiredArgs(gameType gameTypes.GameType) map[string]string {
 		addRequiredCannonArgs(args)
 	case gameTypes.CannonKonaGameType:
 		addRequiredCannonKonaArgs(args)
-	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+	case gameTypes.SuperCannonKonaGameType:
 		addRequiredSuperCannonKonaArgs(args)
 	case gameTypes.ZKDisputeGameType, gameTypes.AlphabetGameType, gameTypes.FastGameType:
 		addRequiredOutputRootArgs(args)

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -236,6 +236,11 @@ func (c Config) Check() error {
 	if len(c.GameTypes) == 0 {
 		return ErrMissingGameType
 	}
+	for _, gameType := range c.GameTypes {
+		if !slices.Contains(gameTypes.SupportedGameTypes, gameType) {
+			return fmt.Errorf("%w: %q", gameTypes.ErrUnknownGameType, gameType.String())
+		}
+	}
 	if c.Datadir == "" {
 		return ErrMissingDatadir
 	}
@@ -250,7 +255,7 @@ func (c Config) Check() error {
 			return err
 		}
 	}
-	if c.GameTypeEnabled(gameTypes.SuperCannonKonaGameType) || c.GameTypeEnabled(gameTypes.SuperPermissionedGameType) {
+	if c.GameTypeEnabled(gameTypes.SuperCannonKonaGameType) {
 		if c.SuperRPC == "" {
 			return ErrMissingSuperRpc
 		}

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -40,7 +40,7 @@ var (
 )
 
 var singleCannonGameTypes = []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.PermissionedGameType}
-var cannonKonaGameTypes = []gameTypes.GameType{gameTypes.CannonKonaGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType}
+var cannonKonaGameTypes = []gameTypes.GameType{gameTypes.CannonKonaGameType, gameTypes.SuperCannonKonaGameType}
 
 func ensureExists(path string) error {
 	_, err := os.Stat(path)
@@ -103,7 +103,7 @@ func validConfig(t *testing.T, gameType gameTypes.GameType) Config {
 	if gameType == gameTypes.CannonKonaGameType {
 		applyValidConfigForCannonKona(t, &cfg)
 	}
-	if gameType == gameTypes.SuperCannonKonaGameType || gameType == gameTypes.SuperPermissionedGameType {
+	if gameType == gameTypes.SuperCannonKonaGameType {
 		applyValidConfigForSuperCannonKona(t, &cfg)
 	}
 	if gameType == gameTypes.ZKDisputeGameType {
@@ -435,7 +435,7 @@ func TestCannonKonaRequiredArgs(t *testing.T) {
 }
 
 func TestDepsetConfig(t *testing.T) {
-	for _, gameType := range []gameTypes.GameType{gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType} {
+	for _, gameType := range []gameTypes.GameType{gameTypes.SuperCannonKonaGameType} {
 		gameType := gameType
 		t.Run(fmt.Sprintf("TestCannonKonaNetworkOrDepsetConfigRequired-%v", gameType), func(t *testing.T) {
 			cfg := validConfig(t, gameType)
@@ -490,7 +490,7 @@ func TestHttpPollInterval(t *testing.T) {
 func TestRollupRpcRequired(t *testing.T) {
 	for _, gameType := range gameTypes.SupportedGameTypes {
 		gameType := gameType
-		if gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
+		if gameType == gameTypes.SuperCannonKonaGameType {
 			continue
 		}
 		t.Run(gameType.String(), func(t *testing.T) {
@@ -502,12 +502,6 @@ func TestRollupRpcRequired(t *testing.T) {
 }
 
 func TestRollupRpcNotRequiredForInterop(t *testing.T) {
-	t.Run("SuperPermissioned", func(t *testing.T) {
-		config := validConfig(t, gameTypes.SuperPermissionedGameType)
-		config.RollupRpc = ""
-		require.NoError(t, config.Check())
-	})
-
 	t.Run("SuperCannonKona", func(t *testing.T) {
 		config := validConfig(t, gameTypes.SuperCannonKonaGameType)
 		config.RollupRpc = ""
@@ -518,7 +512,7 @@ func TestRollupRpcNotRequiredForInterop(t *testing.T) {
 func TestSuperRpc(t *testing.T) {
 	for _, gameType := range gameTypes.SupportedGameTypes {
 		gameType := gameType
-		if gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
+		if gameType == gameTypes.SuperCannonKonaGameType {
 			t.Run("RequiredFor"+gameType.String(), func(t *testing.T) {
 				config := validConfig(t, gameType)
 				config.SuperRPC = ""
@@ -532,6 +526,12 @@ func TestSuperRpc(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestSuperPermissionedGameTypeUnsupported(t *testing.T) {
+	config := validConfig(t, gameTypes.CannonGameType)
+	config.GameTypes = []gameTypes.GameType{gameTypes.SuperPermissionedGameType}
+	require.ErrorIs(t, config.Check(), gameTypes.ErrUnknownGameType)
 }
 
 func TestRequireConfigForMultipleGameTypesForCannon(t *testing.T) {

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -438,7 +438,7 @@ func CheckRequired(ctx *cli.Context, types []gameTypes.GameType) error {
 			if err := CheckCannonKonaFlags(ctx); err != nil {
 				return err
 			}
-		case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+		case gameTypes.SuperCannonKonaGameType:
 			if err := CheckSuperCannonKonaFlags(ctx); err != nil {
 				return err
 			}

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -81,13 +81,6 @@ func RegisterGameTypes(
 		}
 		registerTasks = append(registerTasks, NewCannonRegisterTask(gameTypes.PermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
-	if cfg.GameTypeEnabled(gameTypes.SuperPermissionedGameType) {
-		superNodeProvider, syncValidator, err := clients.SuperchainClients()
-		if err != nil {
-			return err
-		}
-		registerTasks = append(registerTasks, NewSuperCannonKonaRegisterTask(gameTypes.SuperPermissionedGameType, cfg, m, vm.NewKonaSuperExecutor(), superNodeProvider, syncValidator))
-	}
 	if cfg.GameTypeEnabled(gameTypes.FastGameType) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
 		if err != nil {

--- a/op-challenger/game/fault/register_task.go
+++ b/op-challenger/game/fault/register_task.go
@@ -69,9 +69,8 @@ func newSuperCannonVMRegisterTaskWithConfig(
 ) *RegisterTask {
 	stateConverter := cannon.NewStateConverter(vmCfg)
 	return &RegisterTask{
-		gameType:               gameType,
-		syncValidator:          syncValidator,
-		skipPrestateValidation: gameType == gameTypes.SuperPermissionedGameType,
+		gameType:      gameType,
+		syncValidator: syncValidator,
 		getTopPrestateProvider: func(ctx context.Context, prestateTimestamp uint64) (faultTypes.PrestateProvider, error) {
 			return super.NewSuperNodePrestateProvider(superNodeProvider, prestateTimestamp), nil
 		},

--- a/op-challenger/game/monitor.go
+++ b/op-challenger/game/monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -49,6 +50,7 @@ type gameMonitor struct {
 	preimages           preimageScheduler
 	gameWindow          time.Duration
 	claimer             claimer
+	gameTypes           []types.GameType
 	allowedGames        []common.Address
 	l1HeadsSub          ethereum.Subscription
 	l1Source            *headSource
@@ -77,6 +79,7 @@ func newGameMonitor(
 	preimages preimageScheduler,
 	gameWindow time.Duration,
 	claimer claimer,
+	gameTypes []types.GameType,
 	allowedGames []common.Address,
 	l1Source MinimalSubscriber,
 	minUpdatePeriodSeconds time.Duration,
@@ -89,6 +92,7 @@ func newGameMonitor(
 		source:          source,
 		gameWindow:      gameWindow,
 		claimer:         claimer,
+		gameTypes:       gameTypes,
 		allowedGames:    allowedGames,
 		l1Source:        &headSource{inner: l1Source},
 		minUpdatePeriod: minUpdatePeriodSeconds,
@@ -107,6 +111,10 @@ func (m *gameMonitor) allowedGame(game common.Address) bool {
 	return false
 }
 
+func (m *gameMonitor) supportedGameType(gameType uint32) bool {
+	return slices.Contains(m.gameTypes, types.GameType(gameType))
+}
+
 func (m *gameMonitor) progressGames(ctx context.Context, blockHash common.Hash, blockNumber uint64) error {
 	minGameTimestamp := clock.MinCheckedTimestamp(m.clock, m.gameWindow)
 	games, err := m.source.GetGamesAtOrAfter(ctx, blockHash, minGameTimestamp)
@@ -115,6 +123,10 @@ func (m *gameMonitor) progressGames(ctx context.Context, blockHash common.Hash, 
 	}
 	var gamesToPlay []types.GameMetadata
 	for _, game := range games {
+		if !m.supportedGameType(game.GameType) {
+			m.logger.Debug("Skipping unsupported game type", "game", game.Proxy, "gameType", game.GameType)
+			continue
+		}
 		if !m.allowedGame(game.Proxy) {
 			m.logger.Debug("Skipping game not on allow list", "game", game.Proxy)
 			continue

--- a/op-challenger/game/monitor.go
+++ b/op-challenger/game/monitor.go
@@ -124,7 +124,11 @@ func (m *gameMonitor) progressGames(ctx context.Context, blockHash common.Hash, 
 	var gamesToPlay []types.GameMetadata
 	for _, game := range games {
 		if !m.supportedGameType(game.GameType) {
-			m.logger.Debug("Skipping unsupported game type", "game", game.Proxy, "gameType", game.GameType)
+			if game.GameType == uint32(types.SuperPermissionedGameType) {
+				m.logger.Info("Skipping unsupported super permissioned game type", "game", game.Proxy)
+			} else {
+				m.logger.Warn("Skipping unsupported game type", "game", game.Proxy, "gameType", game.GameType)
+			}
 			continue
 		}
 		if !m.allowedGame(game.Proxy) {

--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -143,6 +143,22 @@ func TestMonitorOnlyScheduleSpecifiedGame(t *testing.T) {
 	require.Equal(t, 1, stubClaimer.scheduledGames)
 }
 
+func TestMonitorSkipsUnsupportedGameTypes(t *testing.T) {
+	addr1 := common.Address{0xaa}
+	addr2 := common.Address{0xbb}
+	monitor, source, sched, _, _, stubClaimer := setupMonitorTest(t, []common.Address{}, 0)
+	source.games = []types.GameMetadata{
+		newTypedFDG(addr1, 9999, types.CannonGameType),
+		newTypedFDG(addr2, 9999, types.SuperPermissionedGameType),
+	}
+
+	require.NoError(t, monitor.progressGames(context.Background(), common.Hash{0x01}, 0))
+
+	require.Len(t, sched.Scheduled(), 1)
+	require.Equal(t, []common.Address{addr1}, sched.Scheduled()[0])
+	require.Equal(t, 1, stubClaimer.scheduledGames)
+}
+
 func TestMinUpdatePeriod(t *testing.T) {
 	tests := []struct {
 		name                   string
@@ -196,8 +212,13 @@ func TestMinUpdatePeriod(t *testing.T) {
 }
 
 func newFDG(proxy common.Address, timestamp uint64) types.GameMetadata {
+	return newTypedFDG(proxy, timestamp, types.CannonGameType)
+}
+
+func newTypedFDG(proxy common.Address, timestamp uint64, gameType types.GameType) types.GameMetadata {
 	return types.GameMetadata{
 		Proxy:     proxy,
+		GameType:  uint32(gameType),
 		Timestamp: timestamp,
 	}
 }
@@ -221,6 +242,7 @@ func setupMonitorTest(
 		preimages,
 		time.Duration(0),
 		stubClaimer,
+		[]types.GameType{types.CannonGameType},
 		allowedGames,
 		mockHeadSource,
 		time.Duration(minUpdatePeriodSeconds)*time.Second,

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -249,7 +249,7 @@ func (s *Service) initLargePreimages() error {
 }
 
 func (s *Service) initMonitor(cfg *config.Config) {
-	s.monitor = newGameMonitor(s.logger, s.l1Clock, s.factoryContract, s.sched, s.preimages, cfg.GameWindow, s.claimer, cfg.GameAllowlist, s.l1RPC, cfg.MinUpdateInterval)
+	s.monitor = newGameMonitor(s.logger, s.l1Clock, s.factoryContract, s.sched, s.preimages, cfg.GameWindow, s.claimer, cfg.GameTypes, cfg.GameAllowlist, s.l1RPC, cfg.MinUpdateInterval)
 }
 
 func (s *Service) Start(ctx context.Context) error {

--- a/op-challenger/game/types/game_type.go
+++ b/op-challenger/game/types/game_type.go
@@ -37,7 +37,6 @@ var SupportedGameTypes = []GameType{
 	PermissionedGameType,
 	FastGameType,
 	SuperCannonKonaGameType,
-	SuperPermissionedGameType,
 	ZKDisputeGameType,
 }
 

--- a/op-challenger/game/types/game_type_test.go
+++ b/op-challenger/game/types/game_type_test.go
@@ -35,6 +35,12 @@ func TestSupportedGameTypeFromString_RejectsSuperCannon(t *testing.T) {
 	require.Equal(t, UnknownGameType, result)
 }
 
+func TestSupportedGameTypeFromString_RejectsSuperPermissioned(t *testing.T) {
+	result, err := SupportedGameTypeFromString(SuperPermissionedGameType.String())
+	require.ErrorIs(t, err, ErrUnknownGameType)
+	require.Equal(t, UnknownGameType, result)
+}
+
 func TestKnownStringForAllSupportedGameTypes(t *testing.T) {
 	for _, gameType := range SupportedGameTypes {
 		t.Run(gameType.String(), func(t *testing.T) {

--- a/op-challenger/runner/game_inputs.go
+++ b/op-challenger/runner/game_inputs.go
@@ -30,7 +30,7 @@ const (
 
 func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, l1Client *ethclient.Client, typeName string, gameType gameTypes.GameType, ageGameInputs bool) (utils.LocalGameInputs, error) {
 	switch gameType {
-	case gameTypes.SuperPermissionedGameType, gameTypes.SuperCannonKonaGameType:
+	case gameTypes.SuperCannonKonaGameType:
 		if superNodeClient == nil {
 			return utils.LocalGameInputs{}, fmt.Errorf("game type %s requires supernode rpc to be set", gameType)
 		}

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -195,13 +195,6 @@ func WithSuperCannonKonaGameType() Option {
 	}
 }
 
-func WithSuperPermissionedGameType() Option {
-	return func(_ context.Context, c *config.Config) error {
-		c.GameTypes = append(c.GameTypes, gameTypes.SuperPermissionedGameType)
-		return nil
-	}
-}
-
 func WithFastGames() Option {
 	return func(_ context.Context, c *config.Config) error {
 		c.GameTypes = append(c.GameTypes, gameTypes.FastGameType)


### PR DESCRIPTION
The simplified super permissioned game does not require challenger interaction. Because the game cannot be challenged, does not require bonds, and it resolves automatically.

dispute-mon also needs to be updated. This will be addressed in a separate PR.

fixes https://github.com/ethereum-optimism/optimism/issues/20932