### PR TITLE
op-node: enforce cross-safe cache invariants

### DIFF
--- a/op-node/rollup/engine/cross_safe_cache.go
+++ b/op-node/rollup/engine/cross_safe_cache.go
@@ -27,31 +27,49 @@ func (c *crossSafeCache) Store(br eth.L2BlockRef) {
 	c.cached = br
 }
 
+func (c *crossSafeCache) Clear() {
+	c.cached = eth.L2BlockRef{}
+}
+
 // Get returns the cached cross-safe head if it is still canonical on the EL
-// and not ahead of localSafeHead. Otherwise clears the cache and returns
-// (zero, false).
-func (c *crossSafeCache) Get(ctx context.Context, engine ExecEngine, localSafeHead eth.L2BlockRef) (eth.L2BlockRef, bool) {
+// and within the local-safe/finalized bounds. Otherwise clears the cache and
+// returns (zero, false).
+func (c *crossSafeCache) Get(ctx context.Context, engine ExecEngine, localSafeHead, finalizedHead eth.L2BlockRef) (eth.L2BlockRef, bool) {
 	cached := c.cached
 	if cached == (eth.L2BlockRef{}) {
 		return eth.L2BlockRef{}, false
 	}
+	if finalizedHead != (eth.L2BlockRef{}) {
+		if cached.Number < finalizedHead.Number {
+			c.log.Warn("cached cross-safe behind finalized; clearing cache",
+				"cached", cached, "finalized", finalizedHead)
+			c.Clear()
+			return eth.L2BlockRef{}, false
+		}
+		if cached.Number == finalizedHead.Number && cached.Hash != finalizedHead.Hash {
+			c.log.Warn("cached cross-safe conflicts with finalized at same height; clearing cache",
+				"cached", cached, "finalized", finalizedHead)
+			c.Clear()
+			return eth.L2BlockRef{}, false
+		}
+	}
 	if cached.Number > localSafeHead.Number {
 		c.log.Info("cached cross-safe ahead of local-safe; clearing cache",
 			"cached", cached, "local_safe", localSafeHead)
-		c.cached = eth.L2BlockRef{}
+		c.Clear()
 		return eth.L2BlockRef{}, false
 	}
 	canonical, err := engine.L2BlockRefByNumber(ctx, cached.Number)
 	if err != nil {
 		c.log.Warn("cannot validate cached cross-safe canonicality; clearing cache",
 			"cached", cached, "err", err)
-		c.cached = eth.L2BlockRef{}
+		c.Clear()
 		return eth.L2BlockRef{}, false
 	}
 	if canonical.Hash != cached.Hash {
 		c.log.Info("cached cross-safe non-canonical (reorg); clearing cache",
 			"cached", cached, "canonical", canonical)
-		c.cached = eth.L2BlockRef{}
+		c.Clear()
 		return eth.L2BlockRef{}, false
 	}
 	return cached, true

--- a/op-node/rollup/engine/cross_safe_cache_test.go
+++ b/op-node/rollup/engine/cross_safe_cache_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCrossSafeCache_EmptyReturnsFalse(t *testing.T) {
 	c := newCrossSafeCache(testlog.Logger(t, 0))
-	_, ok := c.Get(context.Background(), &testutils.MockEngine{}, eth.L2BlockRef{Number: 100})
+	_, ok := c.Get(context.Background(), &testutils.MockEngine{}, eth.L2BlockRef{Number: 100}, eth.L2BlockRef{})
 	require.False(t, ok)
 }
 
@@ -27,7 +27,7 @@ func TestCrossSafeCache_CanonicalReturnsCached(t *testing.T) {
 	c := newCrossSafeCache(testlog.Logger(t, 0))
 	c.Store(cached)
 
-	got, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	got, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100}, eth.L2BlockRef{Number: 50})
 	require.True(t, ok)
 	require.Equal(t, cached, got)
 }
@@ -41,11 +41,11 @@ func TestCrossSafeCache_NonCanonicalClears(t *testing.T) {
 	c := newCrossSafeCache(testlog.Logger(t, 0))
 	c.Store(cached)
 
-	_, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	_, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100}, eth.L2BlockRef{})
 	require.False(t, ok)
 
 	// Second call short-circuits: cache cleared, no further engine calls expected.
-	_, ok = c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	_, ok = c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100}, eth.L2BlockRef{})
 	require.False(t, ok)
 }
 
@@ -56,12 +56,12 @@ func TestCrossSafeCache_AheadOfLocalSafeClears(t *testing.T) {
 	c := newCrossSafeCache(testlog.Logger(t, 0))
 	c.Store(cached)
 
-	_, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	_, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100}, eth.L2BlockRef{})
 	require.False(t, ok, "cache ahead of local-safe must not be returned")
 
 	// And it's been cleared — no engine call ever happened for that read, and the
 	// next read short-circuits on empty.
-	_, ok = c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	_, ok = c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100}, eth.L2BlockRef{})
 	require.False(t, ok)
 }
 
@@ -73,10 +73,38 @@ func TestCrossSafeCache_EngineErrorClears(t *testing.T) {
 	c := newCrossSafeCache(testlog.Logger(t, 0))
 	c.Store(cached)
 
-	_, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	_, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100}, eth.L2BlockRef{})
 	require.False(t, ok)
 
 	// Cache cleared on lookup failure; next read short-circuits.
-	_, ok = c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100})
+	_, ok = c.Get(context.Background(), engine, eth.L2BlockRef{Number: 100}, eth.L2BlockRef{})
+	require.False(t, ok)
+}
+
+func TestCrossSafeCache_BehindFinalizedClears(t *testing.T) {
+	cached := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 80}
+	finalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 100}
+	engine := &testutils.MockEngine{}
+
+	c := newCrossSafeCache(testlog.Logger(t, 0))
+	c.Store(cached)
+
+	_, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 120}, finalized)
+	require.False(t, ok, "cache behind finalized must not be returned")
+
+	// Cache cleared before any engine lookup.
+	_, ok = c.Get(context.Background(), engine, eth.L2BlockRef{Number: 120}, finalized)
+	require.False(t, ok)
+}
+
+func TestCrossSafeCache_ConflictsWithFinalizedAtSameHeightClears(t *testing.T) {
+	cached := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	finalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 100}
+	engine := &testutils.MockEngine{}
+
+	c := newCrossSafeCache(testlog.Logger(t, 0))
+	c.Store(cached)
+
+	_, ok := c.Get(context.Background(), engine, eth.L2BlockRef{Number: 120}, finalized)
 	require.False(t, ok)
 }

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -281,11 +281,11 @@ func (e *EngineController) resolveAnchorAsSafe(ts uint64) eth.L2BlockRef {
 // doesn't drop cross-safe to FinalizedHead), and otherwise floors at
 // FinalizedHead — never local-safe, never below finalized.
 func (e *EngineController) crossSafeFallback(reason string) eth.L2BlockRef {
-	if cached, ok := e.crossSafeCache.Get(e.ctx, e.engine, e.localSafeHead); ok {
+	finalized := e.FinalizedHead()
+	if cached, ok := e.crossSafeCache.Get(e.ctx, e.engine, e.localSafeHead, finalized); ok {
 		e.log.Debug("cross-safe fallback using cache", "reason", reason, "cached", cached)
 		return cached
 	}
-	finalized := e.FinalizedHead()
 	e.log.Debug("cross-safe fallback flooring at finalized", "reason", reason, "finalized", finalized)
 	return finalized
 }
@@ -1152,6 +1152,11 @@ func (e *EngineController) forceReset(ctx context.Context, localUnsafe, crossUns
 	}
 
 	ForceEngineReset(e, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized)
+	if crossSafe == (eth.L2BlockRef{}) {
+		e.crossSafeCache.Clear()
+	} else {
+		e.crossSafeCache.Store(crossSafe)
+	}
 
 	if e.pipelineResetter != nil {
 		e.emitter.Emit(ctx, derive.ConfirmPipelineResetEvent{})

--- a/op-node/rollup/engine/super_authority_safe_head_test.go
+++ b/op-node/rollup/engine/super_authority_safe_head_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
@@ -39,7 +40,6 @@ func TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis(t *testing.T) {
 	anchorRef := eth.L2BlockRef{Hash: common.Hash{0xa1}, Number: 499}
 
 	mockEngine := &testutils.MockEngine{}
-	emitter := &testutils.MockEmitter{}
 	sa := &mockSuperAuthority{
 		fullyVerifiedL2HeadSource: rollup.VerifierHeadAnchor,
 		fullyVerifiedTimestamp:    999,
@@ -52,7 +52,7 @@ func TestSafeL2Head_EmptyVerifier_DoesNotDropToGenesis(t *testing.T) {
 		cfg,
 		&sync.Config{},
 		&testutils.MockL1Source{},
-		emitter,
+		event.NoopEmitter{},
 		sa,
 	)
 	ec.SetLocalSafeHead(localSafe)
@@ -83,7 +83,6 @@ func TestSafeL2Head_VerifierError_FloorsAtFinalized(t *testing.T) {
 	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
 
 	mockEngine := &testutils.MockEngine{}
-	emitter := &testutils.MockEmitter{}
 	sa := &mockSuperAuthority{
 		holdPreviousVerified: true,
 		// FinalizedHead is also consulted; configure it to PreActivation so the
@@ -98,7 +97,7 @@ func TestSafeL2Head_VerifierError_FloorsAtFinalized(t *testing.T) {
 		&rollup.Config{},
 		&sync.Config{},
 		&testutils.MockL1Source{},
-		emitter,
+		event.NoopEmitter{},
 		sa,
 	)
 	ec.SetLocalSafeHead(localSafe)
@@ -123,7 +122,6 @@ func TestSafeL2Head_HoldPrevious_UsesCanonicalCache(t *testing.T) {
 	verifiedRef := eth.L2BlockRef{Hash: verifiedBlock.Hash, Number: verifiedBlock.Number}
 
 	mockEngine := &testutils.MockEngine{}
-	emitter := &testutils.MockEmitter{}
 	sa := &mockSuperAuthority{
 		fullyVerifiedL2Head:       verifiedBlock,
 		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
@@ -137,7 +135,7 @@ func TestSafeL2Head_HoldPrevious_UsesCanonicalCache(t *testing.T) {
 		&rollup.Config{},
 		&sync.Config{},
 		&testutils.MockL1Source{},
-		emitter,
+		event.NoopEmitter{},
 		sa,
 	)
 	ec.SetLocalSafeHead(localSafe)
@@ -200,6 +198,87 @@ func TestSafeL2Head_HoldPrevious_NonCanonicalCache_FloorsAtFinalized(t *testing.
 		eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: verifiedBlock.Number}, nil)
 	got := ec.SafeL2Head()
 	require.Equal(t, localFinalized, got, "non-canonical cache must clear and floor at finalized")
+}
+
+func TestSafeL2Head_HoldPrevious_CachedBehindFinalized_FloorsAtFinalized(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 120}
+	initialFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	newFinalized := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 100}
+	verifiedBlock := eth.BlockID{Hash: common.Hash{0xcc}, Number: 80}
+	verifiedRef := eth.L2BlockRef{Hash: verifiedBlock.Hash, Number: verifiedBlock.Number}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2Head:       verifiedBlock,
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+		finalizedL2HeadSource:     rollup.VerifierHeadPreActivation,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(initialFinalized)
+
+	mockEngine.ExpectL2BlockRefByHash(verifiedBlock.Hash, verifiedRef, nil)
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
+	got := ec.SafeL2Head()
+	require.Equal(t, verifiedRef, got)
+
+	ec.SetFinalizedHead(newFinalized)
+	sa.holdPreviousVerified = true
+	got = ec.SafeL2Head()
+	require.Equal(t, newFinalized, got, "cache behind finalized must be ignored to preserve finalized <= safe")
+}
+
+func TestForceReset_SeedsCrossSafeCache(t *testing.T) {
+	localSafe := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	localFinalized := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}
+	verifiedBlock := eth.BlockID{Hash: common.Hash{0xcc}, Number: 80}
+	verifiedRef := eth.L2BlockRef{Hash: verifiedBlock.Hash, Number: verifiedBlock.Number}
+	resetCrossSafe := eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 60}
+
+	mockEngine := &testutils.MockEngine{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2Head:       verifiedBlock,
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+		finalizedL2HeadSource:     rollup.VerifierHeadPreActivation,
+	}
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		event.NoopEmitter{},
+		sa,
+	)
+	ec.SetLocalSafeHead(localSafe)
+	ec.SetFinalizedHead(localFinalized)
+
+	mockEngine.ExpectL2BlockRefByHash(verifiedBlock.Hash, verifiedRef, nil)
+	mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
+	got := ec.SafeL2Head()
+	require.Equal(t, verifiedRef, got)
+
+	sa.holdPreviousVerified = true
+	mockEngine.ExpectL2BlockRefByNumber(resetCrossSafe.Number, resetCrossSafe, nil)
+	mockEngine.ExpectL2BlockRefByNumber(resetCrossSafe.Number, resetCrossSafe, nil)
+	mockEngine.ExpectL2BlockRefByNumber(resetCrossSafe.Number, resetCrossSafe, nil)
+	ec.forceReset(context.Background(), localSafe, localSafe, localSafe, resetCrossSafe, localFinalized, true)
+
+	got = ec.SafeL2Head()
+	require.Equal(t, resetCrossSafe, got, "reset cross-safe must replace any stale pre-reset cache value")
 }
 
 // TestFinalizedHead_HoldPrevious_NoCache_ReturnsZero documents the


### PR DESCRIPTION
## Summary

Fixes two cross-safe cache edge cases in #21079:

- reject cached cross-safe values that are behind or conflict with finalized
- reseed/clear the cross-safe cache when `forceReset` applies reset cross-safe state

## Rationale

The cross-safe cache is valid only while it remains compatible with the forkchoice invariant `finalized <= safe <= unsafe`. A cached cross-safe may have been valid when stored, but finalized can later advance independently through startup, reset, or finality promotion paths. If SuperAuthority then returns HoldPrevious, the fallback must not republish a cached safe below finalized.

The cache is also independent state from `deprecatedSafeHead`, so reset needs to update it explicitly. Otherwise a HoldPrevious after reset can return stale pre-reset cache state.

## Tests

- `go test ./op-node/rollup/engine`
