### PR TITLE
feat(supernode): gate per-chain RPC during VN lifecycle transitions

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/reorg/rpc_gate_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/rpc_gate_test.go
@@ -1,121 +1,22 @@
 package reorg
 
 import (
-	"context"
-	"errors"
 	"math/rand"
-	"strings"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum"
-	gethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/poller"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-type rpcGatePollStats struct {
-	success        atomic.Int64
-	methodNotFound atomic.Int64
-	notFound       atomic.Int64
-	unavailable    atomic.Int64
-}
-
-const maxSyncStatusPollsInFlight = 4
-
-func (s *rpcGatePollStats) total() int64 {
-	return s.success.Load() +
-		s.methodNotFound.Load() +
-		s.notFound.Load() +
-		s.unavailable.Load()
-}
-
-func (s *rpcGatePollStats) record(err error) {
-	if err == nil {
-		s.success.Add(1)
-		return
-	}
-
-	var rpcErr gethrpc.Error
-	if errors.As(err, &rpcErr) && rpcErr.ErrorCode() == int(eth.MethodNotFound) {
-		s.methodNotFound.Add(1)
-		return
-	}
-
-	msg := strings.ToLower(err.Error())
-	switch {
-	case strings.Contains(msg, "404") || strings.Contains(msg, "not found"):
-		s.notFound.Add(1)
-	case strings.Contains(msg, "503") || strings.Contains(msg, "service unavailable") || errors.Is(err, context.DeadlineExceeded):
-		s.unavailable.Add(1)
-	}
-}
-
-func startSyncStatusPoller(ctx context.Context, t devtest.T, rpcCl client.RPC) (*rpcGatePollStats, <-chan struct{}) {
-	stats := new(rpcGatePollStats)
-	done := make(chan struct{})
-
-	go func() {
-		defer close(done)
-
-		var wg sync.WaitGroup
-		defer wg.Wait()
-		inFlight := make(chan struct{}, maxSyncStatusPollsInFlight)
-
-		poll := func() {
-			select {
-			case inFlight <- struct{}{}:
-			case <-ctx.Done():
-				return
-			default:
-				return
-			}
-
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				defer func() {
-					<-inFlight
-				}()
-
-				callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				defer cancel()
-
-				var out eth.SyncStatus
-				err := rpcCl.CallContext(callCtx, &out, "optimism_syncStatus")
-				if err != nil && ctx.Err() != nil {
-					return
-				}
-				stats.record(err)
-				if err != nil {
-					t.Logger().Warn("supernode sync status poll failed", "err", err)
-				}
-			}()
-		}
-
-		poll()
-		ticker := time.NewTicker(200 * time.Millisecond)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				poll()
-			}
-		}
-	}()
-
-	return stats, done
-}
+// reorgWaitAttempts bounds how long we wait for the invalid block to be reorged
+// out. ReorgTriggered retries every 2s, so 30 attempts is a ~60s window.
+const reorgWaitAttempts = 30
 
 // TestSupernodeInteropRPCGatedDuringReorg proves patient callers do not see
 // method-not-found or route-missing responses while supernode restarts chain B's
@@ -123,8 +24,6 @@ func startSyncStatusPoller(ctx context.Context, t devtest.T, rpcCl client.RPC) (
 func TestSupernodeInteropRPCGatedDuringReorg(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewTwoL2SupernodeInterop(t, 0)
-
-	ctx := t.Ctx()
 
 	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
 	bob := sys.FunderB.NewFundedEOA(eth.OneEther)
@@ -160,41 +59,18 @@ func TestSupernodeInteropRPCGatedDuringReorg(gt *testing.T) {
 		return sys.L2BCL.SyncStatus().LocalSafeL2.Number >= invalidBlockNumber
 	}, 60*time.Second, time.Second, "invalid block should become locally safe")
 
-	rpcURL := sys.L2BCL.Escape().UserRPC()
-	rpcCl, err := client.NewRPC(t.Ctx(), t.Logger(), rpcURL, client.WithLazyDial(), client.WithCallTimeout(30*time.Second))
-	require.NoError(t, err)
-	defer rpcCl.Close()
+	// Capture the invalid block before reorg so we can wait for it to be replaced.
+	invalidRef := sys.L2ELB.BlockRefByNumber(invalidBlockNumber)
 
-	pollCtx, cancelPoll := context.WithCancel(ctx)
-	stats, pollDone := startSyncStatusPoller(pollCtx, t, rpcCl)
-	require.Eventually(t, func() bool {
-		return stats.success.Load() > 0
-	}, 10*time.Second, 200*time.Millisecond, "sync status poller should succeed before reorg")
+	// Continuously poll the supernode's chain-B RPC route across the reorg. The
+	// poller stops itself via t.Cleanup at the end of the test.
+	statusPoller := poller.StartStatusPoller(sys.L2BCL)
+	statusPoller.WaitForNextSuccess()
 
 	sys.Supernode.ResumeInterop()
-	require.Eventually(t, func() bool {
-		currentBlock, err := sys.L2ELB.Escape().EthClient().BlockRefByNumber(ctx, invalidBlockNumber)
-		if err != nil {
-			if errors.Is(eth.MaybeAsNotFoundErr(err), ethereum.NotFound) {
-				t.Logger().Info("reset detected: block no longer exists",
-					"block_number", invalidBlockNumber,
-				)
-			} else {
-				t.Logger().Warn("unexpected error checking block",
-					"block_number", invalidBlockNumber,
-					"err", err,
-				)
-			}
-		} else if currentBlock.Hash != invalidBlockHash {
-			t.Logger().Info("reset detected: block hash changed",
-				"block_number", invalidBlockNumber,
-				"old_hash", invalidBlockHash,
-				"new_hash", currentBlock.Hash,
-			)
-			return true
-		}
-		return false
-	}, 60*time.Second, time.Second, "reset should be detected")
+
+	// Recovery reorgs the invalid block out and replaces it with a valid one.
+	sys.L2ELB.ReorgTriggered(invalidRef, reorgWaitAttempts)
 
 	sys.Supernode.AwaitValidatedTimestamp(invalidBlockTimestamp)
 	sys.L2ELB.AssertTxNotInBlock(invalidBlockNumber, execMsg.Receipt.TxHash)
@@ -208,15 +84,8 @@ func TestSupernodeInteropRPCGatedDuringReorg(gt *testing.T) {
 	sys.Supernode.AwaitValidatedTimestamp(txTimestamp)
 	sys.L2ELB.AssertTxInBlock(txBlock, tx.Included.Value().TxHash)
 
-	postReorgSuccesses := stats.success.Load()
-	require.Eventually(t, func() bool {
-		return stats.success.Load() > postReorgSuccesses
-	}, 10*time.Second, 200*time.Millisecond, "sync status poller should succeed after reorg")
-
-	cancelPoll()
-	<-pollDone
-
-	require.Greater(t, stats.total(), int64(0), "sync status poller should observe RPC calls")
-	require.Zero(t, stats.methodNotFound.Load(), "supernode route returned JSON-RPC method-not-found during reorg")
-	require.Zero(t, stats.notFound.Load(), "supernode route returned 404 during reorg")
+	// The route must keep serving across the swap, never returning method-not-found
+	// or a route-missing 404.
+	statusPoller.WaitForNextSuccess()
+	statusPoller.RequireNoRouteErrors()
 }

--- a/op-acceptance-tests/tests/supernode/interop/reorg/rpc_gate_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/rpc_gate_test.go
@@ -1,0 +1,222 @@
+package reorg
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type rpcGatePollStats struct {
+	success        atomic.Int64
+	methodNotFound atomic.Int64
+	notFound       atomic.Int64
+	unavailable    atomic.Int64
+}
+
+const maxSyncStatusPollsInFlight = 4
+
+func (s *rpcGatePollStats) total() int64 {
+	return s.success.Load() +
+		s.methodNotFound.Load() +
+		s.notFound.Load() +
+		s.unavailable.Load()
+}
+
+func (s *rpcGatePollStats) record(err error) {
+	if err == nil {
+		s.success.Add(1)
+		return
+	}
+
+	var rpcErr gethrpc.Error
+	if errors.As(err, &rpcErr) && rpcErr.ErrorCode() == int(eth.MethodNotFound) {
+		s.methodNotFound.Add(1)
+		return
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "404") || strings.Contains(msg, "not found"):
+		s.notFound.Add(1)
+	case strings.Contains(msg, "503") || strings.Contains(msg, "service unavailable") || errors.Is(err, context.DeadlineExceeded):
+		s.unavailable.Add(1)
+	}
+}
+
+func startSyncStatusPoller(ctx context.Context, t devtest.T, rpcCl client.RPC) (*rpcGatePollStats, <-chan struct{}) {
+	stats := new(rpcGatePollStats)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		inFlight := make(chan struct{}, maxSyncStatusPollsInFlight)
+
+		poll := func() {
+			select {
+			case inFlight <- struct{}{}:
+			case <-ctx.Done():
+				return
+			default:
+				return
+			}
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() {
+					<-inFlight
+				}()
+
+				callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				defer cancel()
+
+				var out eth.SyncStatus
+				err := rpcCl.CallContext(callCtx, &out, "optimism_syncStatus")
+				if err != nil && ctx.Err() != nil {
+					return
+				}
+				stats.record(err)
+				if err != nil {
+					t.Logger().Warn("supernode sync status poll failed", "err", err)
+				}
+			}()
+		}
+
+		poll()
+		ticker := time.NewTicker(200 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				poll()
+			}
+		}
+	}()
+
+	return stats, done
+}
+
+// TestSupernodeInteropRPCGatedDuringReorg proves patient callers do not see
+// method-not-found or route-missing responses while supernode restarts chain B's
+// virtual node during interop reorg recovery.
+func TestSupernodeInteropRPCGatedDuringReorg(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewTwoL2SupernodeInterop(t, 0)
+
+	ctx := t.Ctx()
+
+	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
+	bob := sys.FunderB.NewFundedEOA(eth.OneEther)
+	eventLoggerA := alice.DeployEventLogger()
+
+	sys.L2B.CatchUpTo(sys.L2A)
+	sys.L2A.CatchUpTo(sys.L2B)
+
+	paused := sys.Supernode.EnsureInteropPaused(sys.L2ACL, sys.L2BCL, 10)
+	t.Logger().Info("interop paused", "paused", paused)
+
+	rng := rand.New(rand.NewSource(12345))
+	initMsg := alice.SendRandomInitMessage(rng, eventLoggerA, 2, 10)
+
+	t.Logger().Info("initiating message sent on chain A",
+		"block", initMsg.BlockNumber(),
+		"hash", initMsg.BlockHash(),
+	)
+
+	sys.L2B.WaitForBlock()
+
+	execMsg := bob.SendInvalidExecMessage(initMsg)
+	invalidBlockNumber := bigs.Uint64Strict(execMsg.BlockNumber())
+	invalidBlockHash := execMsg.BlockHash()
+	invalidBlockTimestamp := sys.L2B.TimestampForBlockNum(invalidBlockNumber)
+	t.Logger().Info("invalid executing message sent on chain B",
+		"block", invalidBlockNumber,
+		"hash", invalidBlockHash,
+		"timestamp", invalidBlockTimestamp,
+	)
+
+	require.Eventually(t, func() bool {
+		return sys.L2BCL.SyncStatus().LocalSafeL2.Number >= invalidBlockNumber
+	}, 60*time.Second, time.Second, "invalid block should become locally safe")
+
+	rpcURL := sys.L2BCL.Escape().UserRPC()
+	rpcCl, err := client.NewRPC(t.Ctx(), t.Logger(), rpcURL, client.WithLazyDial(), client.WithCallTimeout(30*time.Second))
+	require.NoError(t, err)
+	defer rpcCl.Close()
+
+	pollCtx, cancelPoll := context.WithCancel(ctx)
+	stats, pollDone := startSyncStatusPoller(pollCtx, t, rpcCl)
+	require.Eventually(t, func() bool {
+		return stats.success.Load() > 0
+	}, 10*time.Second, 200*time.Millisecond, "sync status poller should succeed before reorg")
+
+	sys.Supernode.ResumeInterop()
+	require.Eventually(t, func() bool {
+		currentBlock, err := sys.L2ELB.Escape().EthClient().BlockRefByNumber(ctx, invalidBlockNumber)
+		if err != nil {
+			if errors.Is(eth.MaybeAsNotFoundErr(err), ethereum.NotFound) {
+				t.Logger().Info("reset detected: block no longer exists",
+					"block_number", invalidBlockNumber,
+				)
+			} else {
+				t.Logger().Warn("unexpected error checking block",
+					"block_number", invalidBlockNumber,
+					"err", err,
+				)
+			}
+		} else if currentBlock.Hash != invalidBlockHash {
+			t.Logger().Info("reset detected: block hash changed",
+				"block_number", invalidBlockNumber,
+				"old_hash", invalidBlockHash,
+				"new_hash", currentBlock.Hash,
+			)
+			return true
+		}
+		return false
+	}, 60*time.Second, time.Second, "reset should be detected")
+
+	sys.Supernode.AwaitValidatedTimestamp(invalidBlockTimestamp)
+	sys.L2ELB.AssertTxNotInBlock(invalidBlockNumber, execMsg.Receipt.TxHash)
+
+	bruce := sys.FunderB.NewFundedEOA(eth.OneEther)
+	tx := bruce.Transfer(alice.Address(), eth.OneHundredthEther)
+	txBlock := bigs.Uint64Strict(tx.Included.Value().BlockNumber)
+	sys.L2ELB.AssertTxInBlock(txBlock, tx.Included.Value().TxHash)
+
+	txTimestamp := sys.L2B.TimestampForBlockNum(txBlock)
+	sys.Supernode.AwaitValidatedTimestamp(txTimestamp)
+	sys.L2ELB.AssertTxInBlock(txBlock, tx.Included.Value().TxHash)
+
+	postReorgSuccesses := stats.success.Load()
+	require.Eventually(t, func() bool {
+		return stats.success.Load() > postReorgSuccesses
+	}, 10*time.Second, 200*time.Millisecond, "sync status poller should succeed after reorg")
+
+	cancelPoll()
+	<-pollDone
+
+	require.Greater(t, stats.total(), int64(0), "sync status poller should observe RPC calls")
+	require.Zero(t, stats.methodNotFound.Load(), "supernode route returned JSON-RPC method-not-found during reorg")
+	require.Zero(t, stats.notFound.Load(), "supernode route returned 404 during reorg")
+}

--- a/op-devstack/dsl/poller/status_poller.go
+++ b/op-devstack/dsl/poller/status_poller.go
@@ -1,0 +1,165 @@
+package poller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// maxSyncStatusPollsInFlight bounds the number of concurrent sync-status calls,
+// so a slow or hung RPC during a virtual-node swap cannot grow the goroutine set
+// without limit while still keeping pressure on the route.
+const maxSyncStatusPollsInFlight = 4
+
+// StatusPoller repeatedly calls optimism_syncStatus on an L2 CL node in the
+// background and classifies each response. It exists so an acceptance test can
+// prove that patient callers never observe method-not-found or route-missing
+// responses while the supernode swaps a chain's virtual node during reorg
+// recovery, without the test having to manage RPC clients or goroutines itself.
+type StatusPoller struct {
+	t   devtest.T
+	log log.Logger
+	rpc client.RPC
+
+	cancel context.CancelFunc
+	done   <-chan struct{}
+
+	success        atomic.Int64
+	methodNotFound atomic.Int64
+	notFound       atomic.Int64
+	unavailable    atomic.Int64
+}
+
+// StartStatusPoller begins polling the CL node's sync status in the background.
+// It registers a t.Cleanup() to stop the poller and wait for it to drain at the
+// end of the test, so callers never manage its lifecycle directly.
+func StartStatusPoller(cl *dsl.L2CLNode) *StatusPoller {
+	t := cl.Escape().T()
+	ctx, cancel := context.WithCancel(t.Ctx())
+	done := make(chan struct{})
+
+	p := &StatusPoller{
+		t:      t,
+		log:    cl.Escape().Logger(),
+		rpc:    cl.Escape().ClientRPC(),
+		cancel: cancel,
+		done:   done,
+	}
+	t.Cleanup(p.stop)
+
+	go p.run(ctx, done)
+	return p
+}
+
+func (p *StatusPoller) run(ctx context.Context, done chan struct{}) {
+	defer close(done)
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	inFlight := make(chan struct{}, maxSyncStatusPollsInFlight)
+
+	poll := func() {
+		select {
+		case inFlight <- struct{}{}:
+		case <-ctx.Done():
+			return
+		default:
+			return
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-inFlight }()
+
+			callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+
+			var out eth.SyncStatus
+			err := p.rpc.CallContext(callCtx, &out, "optimism_syncStatus")
+			if err != nil && ctx.Err() != nil {
+				return
+			}
+			p.record(err)
+			if err != nil {
+				p.log.Warn("supernode sync status poll failed", "err", err)
+			}
+		}()
+	}
+
+	poll()
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			poll()
+		}
+	}
+}
+
+func (p *StatusPoller) record(err error) {
+	if err == nil {
+		p.success.Add(1)
+		return
+	}
+
+	var rpcErr gethrpc.Error
+	if errors.As(err, &rpcErr) && rpcErr.ErrorCode() == int(eth.MethodNotFound) {
+		p.methodNotFound.Add(1)
+		return
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "404") || strings.Contains(msg, "not found"):
+		p.notFound.Add(1)
+	case strings.Contains(msg, "503") || strings.Contains(msg, "service unavailable") || errors.Is(err, context.DeadlineExceeded):
+		p.unavailable.Add(1)
+	}
+}
+
+func (p *StatusPoller) total() int64 {
+	return p.success.Load() +
+		p.methodNotFound.Load() +
+		p.notFound.Load() +
+		p.unavailable.Load()
+}
+
+// WaitForNextSuccess blocks until the poller records a successful sync-status
+// response after this call, failing the test if none arrives in time.
+func (p *StatusPoller) WaitForNextSuccess() {
+	baseline := p.success.Load()
+	require.Eventually(p.t, func() bool {
+		return p.success.Load() > baseline
+	}, 10*time.Second, 200*time.Millisecond, "sync status poller should record a successful response")
+}
+
+// RequireNoRouteErrors asserts the poller observed at least one response and
+// never saw a JSON-RPC method-not-found or a 404 route-missing response — i.e.
+// the per-chain RPC gate held across the virtual-node swap.
+func (p *StatusPoller) RequireNoRouteErrors() {
+	require.Greater(p.t, p.total(), int64(0), "sync status poller should observe RPC calls")
+	require.Zero(p.t, p.methodNotFound.Load(), "supernode route returned JSON-RPC method-not-found during reorg")
+	require.Zero(p.t, p.notFound.Load(), "supernode route returned 404 during reorg")
+}
+
+func (p *StatusPoller) stop() {
+	p.cancel()
+	<-p.done
+}

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -399,6 +399,10 @@ func (c *simpleChainContainer) Start(ctx context.Context) error {
 
 func (c *simpleChainContainer) Stop(ctx context.Context) error {
 	c.stop.Store(true)
+	if c.rpcRouter != nil {
+		defer c.rpcRouter.RemoveHandler(c.chainID.String())
+	}
+
 	stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -427,9 +431,6 @@ func (c *simpleChainContainer) Stop(ctx context.Context) error {
 
 	select {
 	case <-c.stopped:
-		if c.rpcRouter != nil {
-			c.rpcRouter.RemoveHandler(c.chainID.String())
-		}
 		return nil
 	case <-stopCtx.Done():
 		return stopCtx.Err()

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -129,6 +129,15 @@ type InteropChain interface {
 
 type virtualNodeFactory func(cfg *opnodecfg.Config, log gethlog.Logger, initOverrides *rollupNode.InitializationOverrides, appVersion string, superAuthority rollup.SuperAuthority) virtual_node.VirtualNode
 
+// RPCRouterGate is the chain container's narrow view of the shared RPC router.
+// It lets containers swap per-chain handlers while also controlling when the
+// router may dispatch requests to them.
+type RPCRouterGate interface {
+	SetHandler(chainID string, h http.Handler)
+	SetReadinessCheck(chainID string, fn func() bool)
+	RemoveHandler(chainID string)
+}
+
 // ResetCallback is called when the chain container resets due to an invalidated block.
 // The supernode uses this to notify activities about the reset.
 // invalidatedBlock is the block that was invalidated and triggered the reset.
@@ -154,7 +163,7 @@ type simpleChainContainer struct {
 	chainID            eth.ChainID
 	initOverload       *rollupNode.InitializationOverrides     // Base shared resources for all virtual nodes
 	rpcHandler         *oprpc.Handler                          // Current per-chain RPC handler instance
-	setHandler         func(chainID string, h http.Handler)    // Set the RPC handler on the router for the chain
+	rpcRouter          RPCRouterGate                           // Gates and dispatches RPC traffic for this chain
 	addMetricsRegistry func(key string, g prometheus.Gatherer) // Set the metrics registry on the global metrics server
 	appVersion         string
 	virtualNodeFactory virtualNodeFactory    // Factory function to create virtual node (for testing)
@@ -181,7 +190,7 @@ func NewChainContainer(
 	cfg config.CLIConfig,
 	initOverload *rollupNode.InitializationOverrides,
 	rpcHandler *oprpc.Handler,
-	setHandler func(chainID string, h http.Handler),
+	rpcRouter RPCRouterGate,
 	addMetricsRegistry func(key string, g prometheus.Gatherer),
 	metrics *resources.SupernodeMetrics,
 ) InteropChain {
@@ -196,7 +205,7 @@ func NewChainContainer(
 		stopped:            make(chan struct{}, 1),
 		initOverload:       initOverload,
 		rpcHandler:         rpcHandler,
-		setHandler:         setHandler,
+		rpcRouter:          rpcRouter,
 		addMetricsRegistry: addMetricsRegistry,
 		appVersion:         virtualNodeVersion,
 		virtualNodeFactory: defaultVirtualNodeFactory,
@@ -272,20 +281,34 @@ func (c *simpleChainContainer) setVN(vn virtual_node.VirtualNode) {
 	c.vn = vn
 }
 
+// IsRPCReady reports whether the chain's router handler may serve requests.
+// Pause and stop close the gate immediately; otherwise the current virtual node
+// must be installed and running.
+func (c *simpleChainContainer) IsRPCReady() bool {
+	if c.pause.Load() || c.stop.Load() {
+		return false
+	}
+	vn := c.getVN()
+	return vn != nil && vn.State() == virtual_node.VNStateRunning
+}
+
 func (c *simpleChainContainer) subPath(path string) string {
 	return filepath.Join(c.cfg.DataDir, c.chainID.String(), path)
 }
 
 func (c *simpleChainContainer) Start(ctx context.Context) error {
 	defer func() { c.stopped <- struct{}{} }()
+	if c.rpcRouter != nil {
+		c.rpcRouter.SetReadinessCheck(c.chainID.String(), c.IsRPCReady)
+	}
 	for {
 		// Refresh per-start derived fields
 		c.vncfg.SafeDBPath = c.subPath("safe_db")
 		c.vncfg.RPC = c.cfg.RPCConfig
 		// create a fresh handler per (re)start, swap it into the router, and inject into overload
 		h := oprpc.NewHandler("", oprpc.WithLogger(c.log.New("chain_id", c.chainID.String())))
-		if c.setHandler != nil {
-			c.setHandler(c.chainID.String(), h)
+		if c.rpcRouter != nil {
+			c.rpcRouter.SetHandler(c.chainID.String(), h)
 		}
 		c.initOverload.RPCHandler = h
 		c.rpcHandler = h
@@ -310,6 +333,7 @@ func (c *simpleChainContainer) Start(ctx context.Context) error {
 		if vn == nil {
 			return virtual_node.ErrVirtualNodeNotRunning
 		}
+		// Install before Start so the RPC gate can observe this VN entering running state.
 		c.setVN(vn)
 		if c.pause.Load() {
 			// Check for stop/cancellation even while paused, so teardown doesn't hang.
@@ -403,6 +427,9 @@ func (c *simpleChainContainer) Stop(ctx context.Context) error {
 
 	select {
 	case <-c.stopped:
+		if c.rpcRouter != nil {
+			c.rpcRouter.RemoveHandler(c.chainID.String())
+		}
 		return nil
 	case <-stopCtx.Done():
 		return stopCtx.Err()

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -35,6 +35,7 @@ type mockVirtualNode struct {
 	mu           sync.Mutex
 	startCalled  int
 	stopCalled   int
+	state        virtual_node.VNState
 	startErr     error
 	stopErr      error
 	startFunc    func(ctx context.Context) error
@@ -73,6 +74,7 @@ func newMockVirtualNode() *mockVirtualNode {
 func (m *mockVirtualNode) Start(ctx context.Context) error {
 	m.mu.Lock()
 	m.startCalled++
+	m.state = virtual_node.VNStateRunning
 	callCount := m.startCalled
 	m.mu.Unlock()
 
@@ -82,26 +84,43 @@ func (m *mockVirtualNode) Start(ctx context.Context) error {
 	}
 
 	if m.startFunc != nil {
-		return m.startFunc(ctx)
+		err := m.startFunc(ctx)
+		m.setState(virtual_node.VNStateStopped)
+		return err
 	}
 
 	if m.blockOnStart {
 		<-ctx.Done()
+		m.setState(virtual_node.VNStateStopped)
 		return ctx.Err()
 	}
 
+	m.setState(virtual_node.VNStateStopped)
 	return m.startErr
 }
 
 func (m *mockVirtualNode) Stop(ctx context.Context) error {
 	m.mu.Lock()
 	m.stopCalled++
+	m.state = virtual_node.VNStateStopped
 	m.mu.Unlock()
 
 	if m.stopFunc != nil {
 		return m.stopFunc(ctx)
 	}
 	return m.stopErr
+}
+
+func (m *mockVirtualNode) State() virtual_node.VNState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.state
+}
+
+func (m *mockVirtualNode) setState(state virtual_node.VNState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.state = state
 }
 
 // SafeTimestamp implements virtual_node.VirtualNode SafeTimestamp
@@ -154,6 +173,45 @@ func (m *mockVirtualNode) SyncStatus(ctx context.Context) (*eth.SyncStatus, erro
 }
 
 // SafeDB is not required by VirtualNode in these tests
+
+type fakeRPCRouterGate struct {
+	mu             sync.Mutex
+	calls          []string
+	handlerChainID string
+	handler        http.Handler
+	readyChainID   string
+	ready          func() bool
+	removedChainID string
+}
+
+func (f *fakeRPCRouterGate) SetHandler(chainID string, h http.Handler) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "handler")
+	f.handlerChainID = chainID
+	f.handler = h
+}
+
+func (f *fakeRPCRouterGate) SetReadinessCheck(chainID string, fn func() bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "ready")
+	f.readyChainID = chainID
+	f.ready = fn
+}
+
+func (f *fakeRPCRouterGate) RemoveHandler(chainID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "remove")
+	f.removedChainID = chainID
+}
+
+func (f *fakeRPCRouterGate) snapshot() (calls []string, handlerChainID string, readyChainID string, ready func() bool, removedChainID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...), f.handlerChainID, f.readyChainID, f.ready, f.removedChainID
+}
 
 // mockEngineController is a mock implementation of engine_controller.EngineController
 type mockEngineController struct {
@@ -371,6 +429,51 @@ func TestChainContainer_EngineControllerNotInitInConstructor(t *testing.T) {
 	impl, ok := container.(*simpleChainContainer)
 	require.True(t, ok)
 	require.Nil(t, impl.engine, "engine should not be initialized in constructor; it is deferred to Start loop")
+}
+
+func TestChainContainerIsRPCReady(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	log := createTestLogger(t)
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	tests := []struct {
+		name    string
+		hasVN   bool
+		vnState virtual_node.VNState
+		pause   bool
+		stop    bool
+		want    bool
+	}{
+		{name: "no virtual node", want: false},
+		{name: "virtual node not running", hasVN: true, vnState: virtual_node.VNStateNotStarted, want: false},
+		{name: "virtual node running", hasVN: true, vnState: virtual_node.VNStateRunning, want: true},
+		{name: "paused closes gate", hasVN: true, vnState: virtual_node.VNStateRunning, pause: true, want: false},
+		{name: "stopped closes gate", hasVN: true, vnState: virtual_node.VNStateRunning, stop: true, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			vncfg := createTestVNConfig()
+			cfg := createTestCLIConfig(t.TempDir())
+			container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+			impl, ok := container.(*simpleChainContainer)
+			require.True(t, ok)
+
+			if tc.hasVN {
+				mockVN := newMockVirtualNode()
+				mockVN.setState(tc.vnState)
+				impl.setVN(mockVN)
+			}
+			impl.pause.Store(tc.pause)
+			impl.stop.Store(tc.stop)
+
+			require.Equal(t, tc.want, impl.IsRPCReady())
+		})
+	}
 }
 
 // TestChainContainer_Lifecycle tests Start/Stop behavior
@@ -1006,18 +1109,11 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 		cancel()
 	})
 
-	t.Run("registers handler with reverse proxy", func(t *testing.T) {
-		var setHandlerCalled bool
-		var calledChainID string
-
-		setHandler := func(id string, h http.Handler) {
-			setHandlerCalled = true
-			calledChainID = id
-		}
-
+	t.Run("registers readiness and handler with router", func(t *testing.T) {
+		router := &fakeRPCRouterGate{}
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, setHandler, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, router, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -1027,18 +1123,49 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 			return mockVN
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
+		startDone := make(chan error, 1)
 		go func() {
-			_ = container.Start(ctx)
+			startDone <- container.Start(ctx)
 		}()
 
-		<-mockVN.startSignal
+		select {
+		case <-mockVN.startSignal:
+		case <-time.After(3 * time.Second):
+			t.Fatal("virtual node did not start")
+		}
 
 		require.Eventually(t, func() bool {
-			return setHandlerCalled && calledChainID == "420"
+			calls, handlerChainID, readyChainID, readyFn, _ := router.snapshot()
+			return len(calls) >= 2 &&
+				calls[0] == "ready" &&
+				calls[1] == "handler" &&
+				readyChainID == "420" &&
+				handlerChainID == "420" &&
+				readyFn != nil
 		}, 1*time.Second, 10*time.Millisecond)
+
+		_, _, _, readyFn, _ := router.snapshot()
+		require.True(t, readyFn())
+
+		cancel()
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer stopCancel()
+		require.NoError(t, container.Stop(stopCtx))
+
+		select {
+		case err := <-startDone:
+			require.NoError(t, err)
+		case <-time.After(3 * time.Second):
+			t.Fatal("chain container Start did not return after Stop")
+		}
+
+		require.Eventually(t, func() bool {
+			_, _, _, _, removedChainID := router.snapshot()
+			return removedChainID == "420"
+		}, time.Second, 10*time.Millisecond)
 	})
 }
 
@@ -1142,6 +1269,9 @@ type mockVNForL1AtSafeHeadError struct {
 
 func (m *mockVNForL1AtSafeHeadError) Start(ctx context.Context) error { return nil }
 func (m *mockVNForL1AtSafeHeadError) Stop(ctx context.Context) error  { return nil }
+func (m *mockVNForL1AtSafeHeadError) State() virtual_node.VNState {
+	return virtual_node.VNStateRunning
+}
 func (m *mockVNForL1AtSafeHeadError) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (eth.BlockID, eth.BlockID, error) {
 	return eth.BlockID{}, eth.BlockID{}, nil
 }

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -349,6 +349,9 @@ type mockVNForInvalidation struct {
 
 func (m *mockVNForInvalidation) Start(ctx context.Context) error { return nil }
 func (m *mockVNForInvalidation) Stop(ctx context.Context) error  { return m.stopErr }
+func (m *mockVNForInvalidation) State() virtual_node.VNState {
+	return virtual_node.VNStateRunning
+}
 func (m *mockVNForInvalidation) LatestSafe(ctx context.Context) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -187,6 +187,11 @@ func (v *simpleVirtualNode) Stop(ctx context.Context) error {
 		return nil // Already stopped or not started
 	}
 
+	// Keep this setState before the cancel() below; do not reorder them.
+	// The per-chain RPC route gate reads this state to decide readiness, and it
+	// must observe VNStateStopped ("not ready") before the run context starts
+	// unwinding. If the cancel ran first, a request could still be routed to a
+	// chain handler that is already tearing down.
 	v.setState(VNStateStopped)
 
 	// Cancel the run context to trigger shutdown

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -89,7 +89,7 @@ func generateVirtualNodeID() string {
 func NewVirtualNode(cfg *opnodecfg.Config, log gethlog.Logger, initOverload *rollupNode.InitializationOverrides, appVersion string) *simpleVirtualNode {
 	vnID := generateVirtualNodeID()
 	l := log.New("chain_id", cfg.Rollup.L2ChainID.String(), "vn_id", vnID)
-	return &simpleVirtualNode{
+	vn := &simpleVirtualNode{
 		vnID:             vnID,
 		cfg:              cfg,
 		log:              l,
@@ -97,6 +97,8 @@ func NewVirtualNode(cfg *opnodecfg.Config, log gethlog.Logger, initOverload *rol
 		appVersion:       appVersion,
 		innerNodeFactory: defaultInnerNodeFactory,
 	}
+	vn.setState(VNStateNotStarted)
+	return vn
 }
 
 func (v *simpleVirtualNode) Start(ctx context.Context) error {

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
@@ -46,6 +47,7 @@ type VirtualNode interface {
 	// Returns safedb.ErrNotFound when SafeDB has no entries yet.
 	FirstSafeHeadEntry(ctx context.Context) (eth.BlockID, eth.BlockID, error)
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
+	State() VNState
 }
 
 type innerNode interface {
@@ -57,7 +59,7 @@ type innerNode interface {
 
 type innerNodeFactory func(ctx context.Context, cfg *opnodecfg.Config, log gethlog.Logger, appVersion string, m *opmetrics.Metrics, initOverload *rollupNode.InitializationOverrides) (innerNode, error)
 
-type VNState int
+type VNState int32
 
 const (
 	VNStateNotStarted VNState = iota
@@ -75,9 +77,9 @@ type simpleVirtualNode struct {
 	initOverload     *rollupNode.InitializationOverrides // Shared resources which are overridden by the supernode
 	innerNodeFactory innerNodeFactory                    // Factory function to create inner node (overloadable for testing)
 
-	mu     sync.Mutex         // Protects state transitions
-	state  VNState            // Current lifecycle state
-	cancel context.CancelFunc // Cancels the running context
+	mu     sync.Mutex   // Coordinates Start/Stop transitions and protects cancel.
+	state  atomic.Int32 // Current lifecycle state; stores VNState values.
+	cancel context.CancelFunc
 }
 
 func generateVirtualNodeID() string {
@@ -94,16 +96,15 @@ func NewVirtualNode(cfg *opnodecfg.Config, log gethlog.Logger, initOverload *rol
 		initOverload:     initOverload,
 		appVersion:       appVersion,
 		innerNodeFactory: defaultInnerNodeFactory,
-		state:            VNStateNotStarted,
 	}
 }
 
 func (v *simpleVirtualNode) Start(ctx context.Context) error {
 	// Accquire lock while setting up inner node
 	v.mu.Lock()
-	if v.state != VNStateNotStarted {
+	if state := v.State(); state != VNStateNotStarted {
 		v.mu.Unlock()
-		v.log.Debug("virtual node not in a valid state to start", "state", v.state)
+		v.log.Debug("virtual node not in a valid state to start", "state", state)
 		return ErrVirtualNodeCantStart
 	}
 	if v.cfg == nil {
@@ -126,12 +127,12 @@ func (v *simpleVirtualNode) Start(ctx context.Context) error {
 	m := opmetrics.NewMetrics("supernode", additionalLabels)
 	n, err := v.innerNodeFactory(runCtx, v.cfg, v.log, v.appVersion, m, v.initOverload)
 	if err != nil {
-		v.state = VNStateStopped
+		v.setState(VNStateStopped)
 		v.mu.Unlock()
 		return err
 	}
 	v.inner = n
-	v.state = VNStateRunning
+	v.setState(VNStateRunning)
 	v.mu.Unlock()
 
 	// Run inner node in goroutine
@@ -147,7 +148,7 @@ func (v *simpleVirtualNode) Start(ctx context.Context) error {
 	// this VirtualNode (e.g. SyncStatus via EngineController.FinalizedHead).
 	// SyncStatus needs v.mu, so holding it here would deadlock.
 	v.mu.Lock()
-	v.state = VNStateStopped
+	v.setState(VNStateStopped)
 	v.cancel = nil
 	v.mu.Unlock()
 
@@ -180,9 +181,11 @@ func (v *simpleVirtualNode) Stop(ctx context.Context) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
-	if v.state != VNStateRunning {
+	if v.State() != VNStateRunning {
 		return nil // Already stopped or not started
 	}
+
+	v.setState(VNStateStopped)
 
 	// Cancel the run context to trigger shutdown
 	if v.cancel != nil {
@@ -194,9 +197,11 @@ func (v *simpleVirtualNode) Stop(ctx context.Context) error {
 
 // State returns the current state of the virtual node (for testing and monitoring)
 func (v *simpleVirtualNode) State() VNState {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	return v.state
+	return VNState(v.state.Load())
+}
+
+func (v *simpleVirtualNode) setState(state VNState) {
+	v.state.Store(int32(state))
 }
 
 // SafeHeadAtL1 returns the recorded mapping of L1 block -> L2 safe head at or before the given L1 block number.

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
@@ -326,6 +326,7 @@ func TestVirtualNode_Lifecycle(t *testing.T) {
 		// Stop it
 		err := vn.Stop(ctx)
 		require.NoError(t, err)
+		require.Equal(t, VNStateStopped, vn.State())
 
 		// Start should exit
 		select {
@@ -501,7 +502,7 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 		mock := newMockInnerNode()
 		mock.db = nil
 		vn.inner = mock
-		vn.state = VNStateRunning
+		vn.setState(VNStateRunning)
 
 		_, err := vn.L1AtSafeHead(context.Background(), eth.BlockID{Number: 10})
 		require.ErrorIs(t, err, ErrVirtualNodeNotRunning)
@@ -517,7 +518,7 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 		mock := newMockInnerNode()
 		mock.db = mockDB
 		vn.inner = mock
-		vn.state = VNStateRunning
+		vn.setState(VNStateRunning)
 
 		// Query for genesis L2 block
 		result, err := vn.L1AtSafeHead(context.Background(), genesisL2)
@@ -534,7 +535,7 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 		mock := newMockInnerNode()
 		mock.db = mockDB
 		vn.inner = mock
-		vn.state = VNStateRunning
+		vn.setState(VNStateRunning)
 
 		// Query with same number as genesis but different hash
 		// Should NOT match genesis since both number AND hash must match
@@ -564,7 +565,7 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 		mock := newMockInnerNode()
 		mock.db = mockDB
 		vn.inner = mock
-		vn.state = VNStateRunning
+		vn.setState(VNStateRunning)
 
 		// Query for L2 block 10 - should return L1=102 (earliest L1 where L2 safe head >= 10)
 		target := eth.BlockID{Number: 10, Hash: [32]byte{0x06}}
@@ -585,7 +586,7 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 		mock := newMockInnerNode()
 		mock.db = mockDB
 		vn.inner = mock
-		vn.state = VNStateRunning
+		vn.setState(VNStateRunning)
 
 		// Query for L2 block 100 - beyond latest L2 safe head (5)
 		target := eth.BlockID{Number: 100, Hash: [32]byte{}}
@@ -606,7 +607,7 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 		mock := newMockInnerNode()
 		mock.db = mockDB
 		vn.inner = mock
-		vn.state = VNStateRunning
+		vn.setState(VNStateRunning)
 
 		// The first recorded SafeDB entry is still usable for that exact L2.
 		target := eth.BlockID{Number: 100, Hash: [32]byte{0x11}}
@@ -630,7 +631,7 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 		mock := newMockInnerNode()
 		mock.db = mockDB
 		vn.inner = mock
-		vn.state = VNStateRunning
+		vn.setState(VNStateRunning)
 
 		// target within latest L2 (90 <= 120) so we enter walkback; prev=499
 		// is below the earliest entry (500) but above genesisL1 (100), so the
@@ -656,7 +657,7 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 		mock := newMockInnerNode()
 		mock.db = mockDB
 		vn.inner = mock
-		vn.state = VNStateRunning
+		vn.setState(VNStateRunning)
 
 		target := eth.BlockID{Number: 10, Hash: [32]byte{0x02}}
 		_, err := vn.L1AtSafeHead(context.Background(), target)
@@ -673,7 +674,7 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 		mock := newMockInnerNode()
 		mock.db = mockDB
 		vn.inner = mock
-		vn.state = VNStateRunning
+		vn.setState(VNStateRunning)
 
 		target := eth.BlockID{Number: 50, Hash: [32]byte{0xaa}}
 		_, err := vn.L1AtSafeHead(context.Background(), target)

--- a/op-supernode/supernode/resources/rpc_router.go
+++ b/op-supernode/supernode/resources/rpc_router.go
@@ -1,33 +1,58 @@
 package resources
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	gethlog "github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	defaultGatePoll    = 25 * time.Millisecond
+	defaultGateTimeout = 60 * time.Second
 )
 
 // RouterConfig defines runtime options for the RPC router server.
 type RouterConfig struct {
 	EnableWebsockets bool
 	MaxBodyBytes     int64
+	GateTimeout      time.Duration
+}
+
+type chainRoute struct {
+	handler http.Handler
+	ready   func() bool
 }
 
 // Router multiplexes JSON-RPC requests by the first path segment which represents the chainID.
 type Router struct {
-	log     gethlog.Logger
-	cfg     RouterConfig
-	mu      sync.RWMutex
-	paths   map[string]http.Handler // chainID -> handler
-	root    http.Handler            // root handler mounted at '/'
-	closers []io.Closer
+	log          gethlog.Logger
+	cfg          RouterConfig
+	mu           sync.RWMutex
+	routes       map[string]*chainRoute // chainID -> route
+	root         http.Handler           // root handler mounted at '/'
+	closers      []io.Closer
+	gateTimeout  time.Duration
+	pollInterval time.Duration
 }
 
 // NewRouter constructs an empty Router. Handlers can be added later via SetHandler.
 func NewRouter(log gethlog.Logger, cfg RouterConfig) *Router {
-	return &Router{log: log, cfg: cfg, paths: make(map[string]http.Handler)}
+	gateTimeout := cfg.GateTimeout
+	if gateTimeout == 0 {
+		gateTimeout = defaultGateTimeout
+	}
+	return &Router{
+		log:          log,
+		cfg:          cfg,
+		routes:       make(map[string]*chainRoute),
+		gateTimeout:  gateTimeout,
+		pollInterval: defaultGatePoll,
+	}
 }
 
 // Close releases any resources created by the factory.
@@ -41,14 +66,43 @@ func (r *Router) Close() error {
 	return firstErr
 }
 
+// getOrCreateRouteLocked returns the chain route, creating it if necessary.
+// Callers must hold r.mu for writes.
+func (r *Router) getOrCreateRouteLocked(chainID string) *chainRoute {
+	if r.routes == nil {
+		r.routes = make(map[string]*chainRoute)
+	}
+	route := r.routes[chainID]
+	if route == nil {
+		route = &chainRoute{}
+		r.routes[chainID] = route
+	}
+	return route
+}
+
 // SetHandler replaces or adds the handler for a given chainID at runtime.
 func (r *Router) SetHandler(chainID string, h http.Handler) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.paths == nil {
-		r.paths = make(map[string]http.Handler)
-	}
-	r.paths[chainID] = h
+	r.getOrCreateRouteLocked(chainID).handler = h
+}
+
+// SetReadinessCheck registers the readiness predicate for a given chainID.
+// Requests wait while the predicate returns false, and dispatch immediately
+// when no predicate is registered.
+func (r *Router) SetReadinessCheck(chainID string, fn func() bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.getOrCreateRouteLocked(chainID).ready = fn
+}
+
+// RemoveHandler permanently removes the chain route from the router. Requests
+// waiting on the removed route observe the same not-found response as requests
+// for an unknown chain.
+func (r *Router) RemoveHandler(chainID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.routes, chainID)
 }
 
 // SetRootHandler sets the optional handler for '/'. If unset, '/' returns 404.
@@ -74,10 +128,43 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	r.mu.RLock()
-	h, ok := r.paths[chainID]
+	route := r.routes[chainID]
+	var readyFn func() bool
+	if route != nil {
+		readyFn = route.ready
+	}
 	r.mu.RUnlock()
-	if !ok {
+	if route == nil {
 		http.NotFound(w, req)
+		return
+	}
+
+	if readyFn != nil && !readyFn() {
+		waitResult := r.waitReady(req.Context(), chainID)
+		switch waitResult {
+		case waitReady:
+		case waitRemoved:
+			http.NotFound(w, req)
+			return
+		case waitTimedOut:
+			http.Error(w, "chain RPC not ready", http.StatusServiceUnavailable)
+			return
+		}
+	}
+
+	r.mu.RLock()
+	route = r.routes[chainID]
+	var h http.Handler
+	if route != nil {
+		h = route.handler
+	}
+	r.mu.RUnlock()
+	if route == nil {
+		http.NotFound(w, req)
+		return
+	}
+	if h == nil {
+		http.Error(w, "chain RPC not ready", http.StatusServiceUnavailable)
 		return
 	}
 
@@ -97,6 +184,48 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}()
 
 	h.ServeHTTP(w, req)
+}
+
+type waitReadyResult int
+
+const (
+	waitReady waitReadyResult = iota
+	waitRemoved
+	waitTimedOut
+)
+
+func (r *Router) waitReady(ctx context.Context, chainID string) waitReadyResult {
+	gateCtx := ctx
+	var cancel context.CancelFunc
+	if r.gateTimeout > 0 {
+		gateCtx, cancel = context.WithTimeout(ctx, r.gateTimeout)
+		defer cancel()
+	}
+
+	ticker := time.NewTicker(r.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		r.mu.RLock()
+		route := r.routes[chainID]
+		var readyFn func() bool
+		if route != nil {
+			readyFn = route.ready
+		}
+		r.mu.RUnlock()
+		if route == nil {
+			return waitRemoved
+		}
+		if readyFn == nil || readyFn() {
+			return waitReady
+		}
+
+		select {
+		case <-ticker.C:
+		case <-gateCtx.Done():
+			return waitTimedOut
+		}
+	}
 }
 
 // splitFirstSegment returns the first non-empty path segment and the remainder path starting with '/'.

--- a/op-supernode/supernode/resources/rpc_router.go
+++ b/op-supernode/supernode/resources/rpc_router.go
@@ -69,9 +69,6 @@ func (r *Router) Close() error {
 // getOrCreateRouteLocked returns the chain route, creating it if necessary.
 // Callers must hold r.mu for writes.
 func (r *Router) getOrCreateRouteLocked(chainID string) *chainRoute {
-	if r.routes == nil {
-		r.routes = make(map[string]*chainRoute)
-	}
 	route := r.routes[chainID]
 	if route == nil {
 		route = &chainRoute{}

--- a/op-supernode/supernode/resources/rpc_router_test.go
+++ b/op-supernode/supernode/resources/rpc_router_test.go
@@ -1,9 +1,12 @@
 package resources
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	gethlog "github.com/ethereum/go-ethereum/log"
 )
@@ -55,5 +58,216 @@ func TestUnknownChain(t *testing.T) {
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestRouterHoldsUntilReady(t *testing.T) {
+	l := gethlog.Root()
+	router := NewRouter(l, RouterConfig{GateTimeout: time.Second})
+
+	var ready atomic.Bool
+	handlerCalled := make(chan struct{})
+	router.SetHandler("10", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(handlerCalled)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	router.SetReadinessCheck("10", ready.Load)
+
+	done := make(chan int, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/10", nil)
+		router.ServeHTTP(rec, req)
+		done <- rec.Code
+	}()
+
+	select {
+	case code := <-done:
+		t.Fatalf("expected request to wait for readiness, completed with %d", code)
+	case <-time.After(2 * defaultGatePoll):
+	}
+
+	select {
+	case <-handlerCalled:
+		t.Fatalf("handler was called before route became ready")
+	default:
+	}
+
+	ready.Store(true)
+
+	select {
+	case code := <-done:
+		if code != http.StatusNoContent {
+			t.Fatalf("expected 204 after route became ready, got %d", code)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("request did not complete after route became ready")
+	}
+}
+
+func TestRouterGateRespectsContextDeadline(t *testing.T) {
+	l := gethlog.Root()
+	router := NewRouter(l, RouterConfig{GateTimeout: 5 * time.Second})
+
+	var handlerCalled atomic.Bool
+	router.SetHandler("10", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	router.SetReadinessCheck("10", func() bool { return false })
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/10", nil)
+	ctx, cancel := context.WithTimeout(req.Context(), 100*time.Millisecond)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	done := make(chan int, 1)
+	go func() {
+		router.ServeHTTP(rec, req)
+		done <- rec.Code
+	}()
+
+	select {
+	case code := <-done:
+		if code != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d", code)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("request did not complete after context deadline")
+	}
+	if handlerCalled.Load() {
+		t.Fatalf("handler should not be called while route is not ready")
+	}
+}
+
+func TestRouterHandlerSwapDuringHold(t *testing.T) {
+	l := gethlog.Root()
+	router := NewRouter(l, RouterConfig{GateTimeout: time.Second})
+
+	var ready atomic.Bool
+	router.SetHandler("10", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Handler", "old")
+	}))
+	router.SetReadinessCheck("10", ready.Load)
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/10", nil)
+		router.ServeHTTP(rec, req)
+		done <- rec
+	}()
+
+	select {
+	case rec := <-done:
+		t.Fatalf("expected request to wait for readiness, completed with %d", rec.Code)
+	case <-time.After(2 * defaultGatePoll):
+	}
+
+	router.SetHandler("10", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Handler", "new")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	ready.Store(true)
+
+	select {
+	case rec := <-done:
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("expected 204 after route became ready, got %d", rec.Code)
+		}
+		if got := rec.Header().Get("X-Handler"); got != "new" {
+			t.Fatalf("expected swapped handler to serve request, got %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("request did not complete after route became ready")
+	}
+}
+
+func TestRouterNoReadinessCheckDispatches(t *testing.T) {
+	l := gethlog.Root()
+	router := NewRouter(l, RouterConfig{})
+
+	router.SetHandler("10", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/10", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected ungated route to dispatch immediately, got %d", rec.Code)
+	}
+}
+
+func TestRouterRemoveHandlerDrainsWaiter(t *testing.T) {
+	l := gethlog.Root()
+	router := NewRouter(l, RouterConfig{GateTimeout: time.Second})
+
+	router.SetHandler("10", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("handler should not be called after route is removed")
+	}))
+	router.SetReadinessCheck("10", func() bool { return false })
+
+	done := make(chan int, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/10", nil)
+		router.ServeHTTP(rec, req)
+		done <- rec.Code
+	}()
+
+	select {
+	case code := <-done:
+		t.Fatalf("expected request to wait before removal, completed with %d", code)
+	case <-time.After(2 * defaultGatePoll):
+	}
+
+	router.RemoveHandler("10")
+
+	select {
+	case code := <-done:
+		if code != http.StatusNotFound {
+			t.Fatalf("expected 404 after route removal, got %d", code)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("request did not complete after route removal")
+	}
+}
+
+func TestRouterGateTimeoutBackstop(t *testing.T) {
+	l := gethlog.Root()
+	router := NewRouter(l, RouterConfig{GateTimeout: 100 * time.Millisecond})
+
+	var handlerCalled atomic.Bool
+	router.SetHandler("10", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	router.SetReadinessCheck("10", func() bool { return false })
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/10", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	done := make(chan int, 1)
+	go func() {
+		router.ServeHTTP(rec, req)
+		done <- rec.Code
+	}()
+
+	select {
+	case code := <-done:
+		if code != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d", code)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("request did not complete after gate timeout")
+	}
+	if handlerCalled.Load() {
+		t.Fatalf("handler should not be called while route is not ready")
 	}
 }

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -69,7 +69,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 
 	// Initialize chain containers for each configured chain ID
 	// Pass shared resources via InitializationOverrides to all containers
-	// Build RPC router first; we'll attach per-chain handlers at runtime via SetHandler
+	// Build RPC router first; chain containers attach handlers and readiness checks at runtime.
 	s.rpcRouter = resources.NewRouter(log, resources.RouterConfig{})
 	// Root JSON-RPC handler mounted at '/'
 	s.rootRPC = oprpc.NewHandler(version, oprpc.WithLogger(log))
@@ -84,12 +84,12 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 			L1Source: resources.NewNonCloseableL1Client(s.l1Client),
 			Beacon:   resources.NewNonCloseableL1BeaconClient(s.beaconClient),
 		}
-		// no rpc handler is passed to the chain container, it will create a new one per (re)start using rpcRouter.SetHandler
+		// no rpc handler is passed to the chain container, it will create a new one per (re)start
 		if vnCfgs[chainID] == nil {
 			log.Error("missing virtual node config for chain", "chain", id)
 			continue
 		}
-		container := cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter.SetHandler, s.metricsFanIn.SetMetricsRegistry, s.supernodeMetrics)
+		container := cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter, s.metricsFanIn.SetMetricsRegistry, s.supernodeMetrics)
 		s.chains[chainID] = container
 	}
 


### PR DESCRIPTION
## Summary

Adds a per-chain readiness gate to the supernode RPC router so requests do not dispatch to a chain handler while the chain virtual node is paused, stopping, or still booting after a restart.

This fixes the interop reorg recovery window where supernode could swap in a fresh per-chain RPC handler before op-node had registered its APIs, causing patient callers to observe transient `-32601` / route-missing failures instead of waiting for the new VN to become ready.

## Changes

- Add per-chain readiness predicates to the supernode RPC router.
- Wait for readiness before dispatching chain RPC requests.
- Respect caller context deadlines and a router gate-timeout backstop.
- Preserve readiness predicates across per-chain handler swaps.
- Remove chain routes on permanent chain-container shutdown.
- Change the VN lifecycle state to an `atomic.Int32` so the request gate can poll it without taking the VN lifecycle mutex.
- Derive readiness from chain pause/stop state and the VN atomic lifecycle state.
- Mark VN state as stopped before canceling the run context so teardown closes the RPC gate immediately.
- Add unit coverage for router wait, timeout, removal, and handler-swap behavior.
- Add chain-container and VN lifecycle coverage for the readiness wiring.
- Add an acceptance test covering supernode RPC calls during interop reorg recovery, with CI-friendly polling bounds.

## Tests

- `go test ./op-supernode/supernode/resources -run 'TestRouter(GateRespectsContextDeadline|GateTimeoutBackstop|HoldsUntilReady|HandlerSwapDuringHold|RemoveHandlerDrainsWaiter)' -count=1`
- `go test ./op-supernode/supernode/chain_container -run 'TestChainContainerIsRPCReady|TestChainContainer_VirtualNodeIntegration/registers_readiness_and_handler_with_router' -count=1`
- `go test ./op-acceptance-tests/tests/supernode/interop/reorg -run TestSupernodeInteropRPCGatedDuringReorg -count=0`
- `go test ./op-supernode/... -count=1`
- `go vet ./op-supernode/...`
- `just lint-go`

Fixes #20854