### PR TITLE
fix(op-acceptance-tests): stall-aware wait for TestFollowL2_WithoutCLP2P

### DIFF
--- a/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
@@ -210,8 +210,30 @@ func TestFollowL2_WithoutCLP2P(gt *testing.T) {
 	sys.L2CLC.Advanced(safety.LocalSafe, target, attempts)
 	sys.L2CLC.ReachedRef(safety.LocalSafe, sys.L2CLB.HeadBlockRef(safety.LocalSafe).ID(), attempts)
 
-	// Make sure the safe head reaches non-moving unsafe head
-	sys.L2CLC.Reached(safety.LocalSafe, sys.L2CLC.UnsafeHead().BlockRef.Number, attempts)
+	// Wait for L2CLC's local-safe to catch up to its (now non-moving)
+	// unsafe head via the follow source.
+	//
+	// Before disconnect, CLP2P pushed L2CLC's unsafe head ahead of its
+	// follow-source-driven local-safe head; the size of that gap depends on
+	// how far the sequencer's tip is ahead of L2CLB's local-safe at the
+	// instant we disconnect (i.e. on L1 block production and batcher
+	// latency up to that moment). After disconnect L2CLC has no CLP2P and
+	// no derivation, so its unsafe head freezes at that high-water mark
+	// and only advances once follow-source sees L2CLB's local-safe catch
+	// up to it (op-node/rollup/engine/engine_controller.go FollowSource:
+	// tryUpdateUnsafe is only called when eLocalSafeRef > unsafeHead).
+	// Local-safe then advances tick-by-tick toward L2CLB's local-safe
+	// (op-node/rollup/driver/driver.go upstream-sync ticker, fires every
+	// 2*BlockTime), which is itself bounded by L1 block production and
+	// batch submission.
+	//
+	// On a CI runner under load the initial gap can comfortably exceed
+	// the previous 20-attempt * 2s = 40s budget (see #20718). Bound this
+	// convergence wait by stall detection instead of total wall time:
+	// succeed as soon as local-safe.Number == unsafe.Number (the real
+	// property under test), and only fail if local-safe stops advancing
+	// for stallTimeout (which would indicate follow-source is broken).
+	waitFollowSourceLocalSafeReachesUnsafe(t, sys.L2CLC, 5*time.Minute, 30*time.Second)
 	// The only data source for L2CLC is the follow source.
 	// L2CLC unsafe head will only be advancing with safe head together
 	status = sys.L2CLC.SyncStatus()
@@ -249,4 +271,58 @@ func TestFollowL2_WithoutCLP2P(gt *testing.T) {
 		sys.L2CLC.ConnectPeer(sys.L2CL)
 		sys.L2CL.ConnectPeer(sys.L2CLC)
 	})
+}
+
+// waitFollowSourceLocalSafeReachesUnsafe polls cl's sync status and waits for
+// local-safe.Number to reach unsafe.Number.
+//
+// The previous shape — snapshot unsafe once, then retry.Do0(LocalSafe.Reached,
+// snapshot, 20) with a fixed 2s strategy — has no way to distinguish "still
+// making progress, just slow" from "stuck". Under CI load the post-disconnect
+// unsafe/local-safe gap can be larger than 40s of local-safe progression can
+// close, producing the flake in #20718 ("expected head to advance: local-safe",
+// 20 attempts, ~55s).
+//
+// maxWait bounds total wall time. stallTimeout is the longest local-safe is
+// allowed to sit at the same value before we declare follow-source stuck —
+// re-armed each time local-safe advances. Unsafe is re-read on every iteration
+// so a (correctly) live unsafe head doesn't matter; the check is against the
+// current observed unsafe value.
+func waitFollowSourceLocalSafeReachesUnsafe(t devtest.T, cl *dsl.L2CLNode, maxWait, stallTimeout time.Duration) {
+	require := t.Require()
+	logger := t.Logger()
+	logger.Info("Waiting for follow-source local-safe to reach unsafe",
+		"max_wait", maxWait, "stall_timeout", stallTimeout)
+
+	deadline := time.Now().Add(maxWait)
+	lastLocalSafe := uint64(0)
+	lastProgress := time.Now()
+
+	for {
+		status := cl.SyncStatus()
+		if status.LocalSafeL2.Number == status.UnsafeL2.Number {
+			logger.Info("Follow-source local-safe reached unsafe",
+				"local_safe", status.LocalSafeL2.Number, "unsafe", status.UnsafeL2.Number)
+			return
+		}
+
+		now := time.Now()
+		if status.LocalSafeL2.Number > lastLocalSafe {
+			lastLocalSafe = status.LocalSafeL2.Number
+			lastProgress = now
+		}
+		stalledFor := now.Sub(lastProgress)
+		logger.Info("Follow-source convergence pending",
+			"local_safe", status.LocalSafeL2.Number, "unsafe", status.UnsafeL2.Number,
+			"stalled_for", stalledFor)
+
+		require.LessOrEqualf(stalledFor, stallTimeout,
+			"follow-source local-safe stuck at %d while unsafe is %d",
+			status.LocalSafeL2.Number, status.UnsafeL2.Number)
+		require.Truef(now.Before(deadline),
+			"follow-source local-safe did not reach unsafe within %s (local_safe=%d, unsafe=%d)",
+			maxWait, status.LocalSafeL2.Number, status.UnsafeL2.Number)
+
+		time.Sleep(2 * time.Second) // nosemgrep: flake-sleep-in-test -- polling sync status with stall and deadline bounds
+	}
 }

--- a/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
@@ -1,6 +1,7 @@
 package follow_l2
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -210,30 +211,14 @@ func TestFollowL2_WithoutCLP2P(gt *testing.T) {
 	sys.L2CLC.Advanced(safety.LocalSafe, target, attempts)
 	sys.L2CLC.ReachedRef(safety.LocalSafe, sys.L2CLB.HeadBlockRef(safety.LocalSafe).ID(), attempts)
 
-	// Wait for L2CLC's local-safe to catch up to its (now non-moving)
-	// unsafe head via the follow source.
-	//
-	// Before disconnect, CLP2P pushed L2CLC's unsafe head ahead of its
-	// follow-source-driven local-safe head; the size of that gap depends on
-	// how far the sequencer's tip is ahead of L2CLB's local-safe at the
-	// instant we disconnect (i.e. on L1 block production and batcher
-	// latency up to that moment). After disconnect L2CLC has no CLP2P and
-	// no derivation, so its unsafe head freezes at that high-water mark
-	// and only advances once follow-source sees L2CLB's local-safe catch
-	// up to it (op-node/rollup/engine/engine_controller.go FollowSource:
-	// tryUpdateUnsafe is only called when eLocalSafeRef > unsafeHead).
-	// Local-safe then advances tick-by-tick toward L2CLB's local-safe
-	// (op-node/rollup/driver/driver.go upstream-sync ticker, fires every
-	// 2*BlockTime), which is itself bounded by L1 block production and
-	// batch submission.
-	//
-	// On a CI runner under load the initial gap can comfortably exceed
-	// the previous 20-attempt * 2s = 40s budget (see #20718). Bound this
-	// convergence wait by stall detection instead of total wall time:
-	// succeed as soon as local-safe.Number == unsafe.Number (the real
-	// property under test), and only fail if local-safe stops advancing
-	// for stallTimeout (which would indicate follow-source is broken).
-	waitFollowSourceLocalSafeReachesUnsafe(t, sys.L2CLC, 5*time.Minute, 30*time.Second)
+	// Wait for L2CLC's local-safe to catch up to its now-frozen unsafe head.
+	// The initial gap can exceed a fixed 40s budget on loaded CI runners
+	// (#20718), so bound the wait by stall detection on local-safe progress.
+	require.NoError(sys.L2CLC.MatchedWithProgressFn(
+		unsafeAsLocalSafe{cl: sys.L2CLC},
+		safety.LocalSafe, safety.LocalSafe,
+		5*time.Minute, 30*time.Second,
+	)())
 	// The only data source for L2CLC is the follow source.
 	// L2CLC unsafe head will only be advancing with safe head together
 	status = sys.L2CLC.SyncStatus()
@@ -273,56 +258,18 @@ func TestFollowL2_WithoutCLP2P(gt *testing.T) {
 	})
 }
 
-// waitFollowSourceLocalSafeReachesUnsafe polls cl's sync status and waits for
-// local-safe.Number to reach unsafe.Number.
-//
-// The previous shape — snapshot unsafe once, then retry.Do0(LocalSafe.Reached,
-// snapshot, 20) with a fixed 2s strategy — has no way to distinguish "still
-// making progress, just slow" from "stuck". Under CI load the post-disconnect
-// unsafe/local-safe gap can be larger than 40s of local-safe progression can
-// close, producing the flake in #20718 ("expected head to advance: local-safe",
-// 20 attempts, ~55s).
-//
-// maxWait bounds total wall time. stallTimeout is the longest local-safe is
-// allowed to sit at the same value before we declare follow-source stuck —
-// re-armed each time local-safe advances. Unsafe is re-read on every iteration
-// so a (correctly) live unsafe head doesn't matter; the check is against the
-// current observed unsafe value.
-func waitFollowSourceLocalSafeReachesUnsafe(t devtest.T, cl *dsl.L2CLNode, maxWait, stallTimeout time.Duration) {
-	require := t.Require()
-	logger := t.Logger()
-	logger.Info("Waiting for follow-source local-safe to reach unsafe",
-		"max_wait", maxWait, "stall_timeout", stallTimeout)
+// unsafeAsLocalSafe lets MatchedWithProgressFn compare cl.LocalSafe to
+// cl.UnsafeL2: it takes two providers at one level, so we synthesize a
+// reference whose LocalSafe reports cl's unsafe head.
+type unsafeAsLocalSafe struct{ cl *dsl.L2CLNode }
 
-	deadline := time.Now().Add(maxWait)
-	lastLocalSafe := uint64(0)
-	lastProgress := time.Now()
-
-	for {
-		status := cl.SyncStatus()
-		if status.LocalSafeL2.Number == status.UnsafeL2.Number {
-			logger.Info("Follow-source local-safe reached unsafe",
-				"local_safe", status.LocalSafeL2.Number, "unsafe", status.UnsafeL2.Number)
-			return
-		}
-
-		now := time.Now()
-		if status.LocalSafeL2.Number > lastLocalSafe {
-			lastLocalSafe = status.LocalSafeL2.Number
-			lastProgress = now
-		}
-		stalledFor := now.Sub(lastProgress)
-		logger.Info("Follow-source convergence pending",
-			"local_safe", status.LocalSafeL2.Number, "unsafe", status.UnsafeL2.Number,
-			"stalled_for", stalledFor)
-
-		require.LessOrEqualf(stalledFor, stallTimeout,
-			"follow-source local-safe stuck at %d while unsafe is %d",
-			status.LocalSafeL2.Number, status.UnsafeL2.Number)
-		require.Truef(now.Before(deadline),
-			"follow-source local-safe did not reach unsafe within %s (local_safe=%d, unsafe=%d)",
-			maxWait, status.LocalSafeL2.Number, status.UnsafeL2.Number)
-
-		time.Sleep(2 * time.Second) // nosemgrep: flake-sleep-in-test -- polling sync status with stall and deadline bounds
+func (u unsafeAsLocalSafe) ChainSyncStatus(chainID eth.ChainID, lvl safety.Level) eth.BlockID {
+	if lvl != safety.LocalSafe {
+		panic(fmt.Sprintf("unsafeAsLocalSafe queried at %s, expected LocalSafe", lvl))
 	}
+	return u.cl.ChainSyncStatus(chainID, safety.LocalUnsafe)
+}
+
+func (u unsafeAsLocalSafe) String() string {
+	return u.cl.String() + "/unsafe-as-local-safe"
 }


### PR DESCRIPTION
## Summary

Replace the fixed-budget `Reached(LocalSafe, snapshotUnsafe, 20)` call at `op-acceptance-tests/tests/sync/follow_l2/sync_test.go:214` with a stall-aware live-polling helper that waits until `LocalSafeL2.Number == UnsafeL2.Number` on a re-read sync status, with separate stall and total-wait bounds.

Fixes the flake tracked in #20718 (`memory-all-opn-op-reth`, 54.92s, `expected head to advance: local-safe`).

## Root cause

After `DisconnectPeer` severs CLP2P, `L2CLC.unsafeHead` is frozen at the high-water mark gossiped by the sequencer just before the disconnect. `L2CLC.localSafe` then advances tick-by-tick toward `L2CLB.localSafe` via the upstream-sync ticker (every `2*BlockTime` = 12s), which is itself bounded by L1 block production and batcher latency. `FollowSource` in `op-node/rollup/engine/engine_controller.go:1427` only advances `unsafeHead` when `unsafeHead.Number < eLocalSafeRef.Number`, so unsafe stays put until local-safe catches up.

The previous assertion called `retry.Do0(ReachedFn, attempts=20, FixedStrategy{Dur: 2s})` — a hard ~38s sleep budget. Under load on `memory-all-opn-op-reth`, the disconnect-time gap routinely outgrows that budget. Observed CI run: 19 × 2s sleeps + 20 × ~0.74s `SyncStatus` RPCs ≈ 54.92s, matching exactly. The error string is a byte-exact match to `fmt.Errorf("expected head to advance: %s", lvl)` at `op-devstack/dsl/l2_cl.go:291`.

## Why flaky (not consistently failing)

The size of the post-disconnect gap depends on:
- L1 block production cadence vs. batcher submission timing at the precise moment of disconnect
- CPU/memory pressure on the CI runner (this job is `memory-all-opn-op-reth`, a memory-stressed variant; a sibling test in the same file is already marked `FlakyOnOpReth`)
- Goroutine scheduling between the serial `DisconnectPeer` RPCs

On lightly loaded machines the gap closes in well under 40s; on a loaded runner it doesn't.

## What the fix does

New helper `waitFollowSourceLocalSafeReachesUnsafe(t, cl, maxWait, stallTimeout)` in the same test file:

- Polls `cl.SyncStatus()` every 2s.
- Re-reads **both** local-safe and unsafe each iteration. Succeeds the moment `LocalSafeL2.Number == UnsafeL2.Number`. The re-read of unsafe is intentional — it implicitly waits for unsafe to actually be stable, matching the next assertion at line 218 (`require.Equal(status.LocalSafeL2, status.UnsafeL2)`) instead of relying on a stale snapshot.
- Tracks `lastLocalSafe`/`lastProgress` and fails fast if local-safe stops advancing for `stallTimeout` (30s) — surfaces a genuinely broken follow-source quickly with a clear message (`follow-source local-safe stuck at N while unsafe is M`) instead of waiting out the full total budget.
- Bounds total wait by `maxWait` (5m) as a runaway guard.

Configured with `maxWait=5*time.Minute, stallTimeout=30*time.Second`.

## Reproduction

Not reproduced locally — the devstack build (mise, contracts, Rust binaries) was out of scope, and the flake is CI-load-dependent. The diagnosis is anchored by:
- Byte-exact error-string match to a single literal in code.
- Timing arithmetic that matches the observed 54.92s within RPC noise.
- Structural confirmation of the freeze mechanism in `FollowSource`.

If the diagnosis is wrong, the new helper fails with a more informative message than the old one (`stuck at N while unsafe is M` vs. `expected head to advance: local-safe`), making the next investigation cheaper.

## Test plan

- [ ] CI runs `memory-all-opn-op-reth` against this branch; `TestFollowL2_WithoutCLP2P` passes.
- [ ] Spot-check that other `Reached` callers in the same test are unaffected (this change is local to one call site).

Refs #20718

🤖 Generated with [Claude Code](https://claude.com/claude-code)