### PR TITLE
feat(op-supernode,op-sync-tester): drive supernode VN via sync-tester EL + finalize anchor at genesis

### DIFF
--- a/op-acceptance-tests/tests/supernode/sync_tester/supernode_sync_tester_e2e_test.go
+++ b/op-acceptance-tests/tests/supernode/sync_tester/supernode_sync_tester_e2e_test.go
@@ -70,12 +70,29 @@ func TestSupernodeVerifierELSyncsFromCold(gt *testing.T) {
 }
 
 // Interop activates a few seconds after genesis; the VN must cross the
-// activation boundary both initially and during a cold catch-up resync.
+// activation boundary both initially and during a cold catch-up resync
+// (default CLSync + reqresp).
 func TestSupernodeVerifierSyncsThroughInteropActivation(gt *testing.T) {
+	syncsThroughInteropActivation(gt)
+}
+
+// Same activation-boundary catch-up under ELSync mode.
+func TestSupernodeVerifierELSyncsThroughInteropActivation(gt *testing.T) {
+	syncsThroughInteropActivation(gt,
+		presets.WithSupernodeVerifierSyncMode(nodeSync.ELSync),
+		presets.WithGlobalSyncTesterELOption(sysgo.SyncTesterELOptionFn(
+			func(_ devtest.T, _ sysgo.ComponentTarget, cfg *sysgo.SyncTesterELConfig) {
+				cfg.ELSyncActive = true
+			},
+		)),
+	)
+}
+
+func syncsThroughInteropActivation(gt *testing.T, opts ...presets.Option) {
 	t := devtest.ParallelT(gt)
 	const activationDelay = uint64(6) // ~3 L2 blocks at the 2s block time
 	sys := presets.NewSingleSupernodeWithSyncTester(t,
-		presets.WithInteropActivationDelay(activationDelay),
+		append([]presets.Option{presets.WithInteropActivationDelay(activationDelay)}, opts...)...,
 	)
 	require := t.Require()
 

--- a/op-acceptance-tests/tests/supernode/sync_tester/supernode_sync_tester_e2e_test.go
+++ b/op-acceptance-tests/tests/supernode/sync_tester/supernode_sync_tester_e2e_test.go
@@ -73,26 +73,48 @@ func TestSupernodeVerifierELSyncsFromCold(gt *testing.T) {
 // activation boundary both initially and during a cold catch-up resync
 // (default CLSync + reqresp).
 func TestSupernodeVerifierSyncsThroughInteropActivation(gt *testing.T) {
-	syncsThroughInteropActivation(gt)
+	t := devtest.ParallelT(gt)
+	const activationDelay = uint64(6) // ~3 L2 blocks at the 2s block time
+	sys := presets.NewSingleSupernodeWithSyncTester(t,
+		presets.WithInteropActivationDelay(activationDelay),
+	)
+	require := t.Require()
+
+	dsl.CheckAll(t,
+		sys.L2CL.AllHeadsAdvancedFn(),
+		sys.SupernodeCL.AllHeadsAdvancedFn(),
+	)
+	require.GreaterOrEqual(
+		sys.SupernodeCL.HeadBlockRef(safety.LocalUnsafe).Time,
+		sys.InteropActivationTime,
+		"supernode VN must have crossed the interop activation timestamp",
+	)
+
+	snap := sys.SupernodeCL.SafetyHeads()
+	sys.Supernode.Stop()
+	sys.SyncTester.ResetAllSessions()
+	sys.Supernode.Start()
+
+	dsl.CheckAll(t, sys.SupernodeCL.AllHeadsReachedFn(snap))
+	require.GreaterOrEqual(
+		sys.SupernodeCL.HeadBlockRef(safety.LocalUnsafe).Time,
+		sys.InteropActivationTime,
+		"resynced supernode VN must again be past the interop activation timestamp",
+	)
 }
 
 // Same activation-boundary catch-up under ELSync mode.
 func TestSupernodeVerifierELSyncsThroughInteropActivation(gt *testing.T) {
-	syncsThroughInteropActivation(gt,
+	t := devtest.ParallelT(gt)
+	const activationDelay = uint64(6) // ~3 L2 blocks at the 2s block time
+	sys := presets.NewSingleSupernodeWithSyncTester(t,
+		presets.WithInteropActivationDelay(activationDelay),
 		presets.WithSupernodeVerifierSyncMode(nodeSync.ELSync),
 		presets.WithGlobalSyncTesterELOption(sysgo.SyncTesterELOptionFn(
 			func(_ devtest.T, _ sysgo.ComponentTarget, cfg *sysgo.SyncTesterELConfig) {
 				cfg.ELSyncActive = true
 			},
 		)),
-	)
-}
-
-func syncsThroughInteropActivation(gt *testing.T, opts ...presets.Option) {
-	t := devtest.ParallelT(gt)
-	const activationDelay = uint64(6) // ~3 L2 blocks at the 2s block time
-	sys := presets.NewSingleSupernodeWithSyncTester(t,
-		append([]presets.Option{presets.WithInteropActivationDelay(activationDelay)}, opts...)...,
 	)
 	require := t.Require()
 

--- a/op-acceptance-tests/tests/supernode/sync_tester/supernode_sync_tester_e2e_test.go
+++ b/op-acceptance-tests/tests/supernode/sync_tester/supernode_sync_tester_e2e_test.go
@@ -1,0 +1,103 @@
+package supernode_sync_tester
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
+)
+
+// All safety heads of a supernode VN driven by a sync-tester EL advance
+// alongside the sequencer. Interop active from genesis.
+func TestSupernodeVerifierAdvancesViaSyncTester(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleSupernodeWithSyncTester(t)
+
+	dsl.CheckAll(t,
+		sys.L2CL.AllHeadsAdvancedFn(),
+		sys.SupernodeCL.AllHeadsAdvancedFn(),
+	)
+}
+
+// Supernode joins a chain already in flight: stop, reset the mocked EL, start.
+// VN must catch up across all safety heads (default CLSync + reqresp).
+func TestSupernodeVerifierCatchesUpFromCold(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleSupernodeWithSyncTester(t)
+
+	dsl.CheckAll(t,
+		sys.L2CL.AllHeadsAdvancedFn(),
+		sys.SupernodeCL.AllHeadsAdvancedFn(),
+	)
+
+	snap := sys.SupernodeCL.SafetyHeads()
+	sys.Supernode.Stop()
+	sys.SyncTester.ResetAllSessions()
+	sys.Supernode.Start()
+
+	dsl.CheckAll(t, sys.SupernodeCL.AllHeadsReachedFn(snap))
+}
+
+// Same cold catch-up under ELSync mode. Mirror of TestSyncTesterELSync with
+// the verifier op-node replaced by a supernode VN.
+func TestSupernodeVerifierELSyncsFromCold(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleSupernodeWithSyncTester(t,
+		presets.WithSupernodeVerifierSyncMode(nodeSync.ELSync),
+		presets.WithGlobalSyncTesterELOption(sysgo.SyncTesterELOptionFn(
+			func(_ devtest.T, _ sysgo.ComponentTarget, cfg *sysgo.SyncTesterELConfig) {
+				cfg.ELSyncActive = true
+			},
+		)),
+	)
+
+	dsl.CheckAll(t,
+		sys.L2CL.AllHeadsAdvancedFn(),
+		sys.SupernodeCL.AllHeadsAdvancedFn(),
+	)
+
+	snap := sys.SupernodeCL.SafetyHeads()
+	sys.Supernode.Stop()
+	sys.SyncTester.ResetAllSessions()
+	sys.Supernode.Start()
+
+	dsl.CheckAll(t, sys.SupernodeCL.AllHeadsReachedFn(snap))
+}
+
+// Interop activates a few seconds after genesis; the VN must cross the
+// activation boundary both initially and during a cold catch-up resync.
+func TestSupernodeVerifierSyncsThroughInteropActivation(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	const activationDelay = uint64(6) // ~3 L2 blocks at the 2s block time
+	sys := presets.NewSingleSupernodeWithSyncTester(t,
+		presets.WithInteropActivationDelay(activationDelay),
+	)
+	require := t.Require()
+
+	dsl.CheckAll(t,
+		sys.L2CL.AllHeadsAdvancedFn(),
+		sys.SupernodeCL.AllHeadsAdvancedFn(),
+	)
+	require.GreaterOrEqual(
+		sys.SupernodeCL.HeadBlockRef(safety.LocalUnsafe).Time,
+		sys.InteropActivationTime,
+		"supernode VN must have crossed the interop activation timestamp",
+	)
+
+	snap := sys.SupernodeCL.SafetyHeads()
+	sys.Supernode.Stop()
+	sys.SyncTester.ResetAllSessions()
+	sys.Supernode.Start()
+
+	dsl.CheckAll(t, sys.SupernodeCL.AllHeadsReachedFn(snap))
+	require.GreaterOrEqual(
+		sys.SupernodeCL.HeadBlockRef(safety.LocalUnsafe).Time,
+		sys.InteropActivationTime,
+		"resynced supernode VN must again be past the interop activation timestamp",
+	)
+}

--- a/op-devstack/dsl/l2_cl_safety_heads.go
+++ b/op-devstack/dsl/l2_cl_safety_heads.go
@@ -7,33 +7,39 @@ import (
 )
 
 // SafetyHeadsAdvancement is the per-level delta and attempt budget for
-// asserting unsafe + safe + finalized progress together.
+// asserting unsafe + safe + cross-safe + finalized progress together.
 type SafetyHeadsAdvancement struct {
 	UnsafeDelta       uint64
 	UnsafeAttempts    int
 	SafeDelta         uint64
 	SafeAttempts      int
+	CrossSafeDelta    uint64
+	CrossSafeAttempts int
 	FinalizedDelta    uint64
 	FinalizedAttempts int
 }
 
-// DefaultSafetyHeadsAdvancement: unsafe + safe within ~60s, finalized within
-// ~720s (in-process L1 has FinalizedDistance=20 blocks @ 6s).
+// DefaultSafetyHeadsAdvancement: unsafe + safe + cross-safe within ~60s,
+// finalized within ~720s (in-process L1 has FinalizedDistance=20 blocks @ 6s).
 func DefaultSafetyHeadsAdvancement() SafetyHeadsAdvancement {
 	return SafetyHeadsAdvancement{
 		UnsafeDelta:       5,
 		UnsafeAttempts:    30,
 		SafeDelta:         1,
 		SafeAttempts:      30,
+		CrossSafeDelta:    1,
+		CrossSafeAttempts: 30,
 		FinalizedDelta:    1,
 		FinalizedAttempts: 360,
 	}
 }
 
-// SafetyHeads is a snapshot of an L2 CL's unsafe/safe/finalized block numbers.
+// SafetyHeads is a snapshot of an L2 CL's unsafe/safe/cross-safe/finalized
+// block numbers.
 type SafetyHeads struct {
 	Unsafe    uint64
 	Safe      uint64
+	CrossSafe uint64
 	Finalized uint64
 }
 
@@ -41,6 +47,7 @@ func (cl *L2CLNode) SafetyHeads() SafetyHeads {
 	return SafetyHeads{
 		Unsafe:    cl.HeadBlockRef(safety.LocalUnsafe).Number,
 		Safe:      cl.HeadBlockRef(safety.LocalSafe).Number,
+		CrossSafe: cl.HeadBlockRef(safety.CrossSafe).Number,
 		Finalized: cl.HeadBlockRef(safety.Finalized).Number,
 	}
 }
@@ -52,6 +59,7 @@ func (cl *L2CLNode) AllHeadsAdvancedFn() CheckFunc {
 	fns := []CheckFunc{
 		cl.AdvancedFn(safety.LocalUnsafe, adv.UnsafeDelta, adv.UnsafeAttempts),
 		cl.AdvancedFn(safety.LocalSafe, adv.SafeDelta, adv.SafeAttempts),
+		cl.AdvancedFn(safety.CrossSafe, adv.CrossSafeDelta, adv.CrossSafeAttempts),
 		cl.AdvancedFn(safety.Finalized, adv.FinalizedDelta, adv.FinalizedAttempts),
 	}
 	return runAllInParallel(fns)
@@ -64,6 +72,7 @@ func (cl *L2CLNode) AllHeadsReachedFn(snap SafetyHeads) CheckFunc {
 	fns := []CheckFunc{
 		cl.ReachedFn(safety.LocalUnsafe, snap.Unsafe+adv.UnsafeDelta, adv.UnsafeAttempts),
 		cl.ReachedFn(safety.LocalSafe, snap.Safe+adv.SafeDelta, adv.SafeAttempts),
+		cl.ReachedFn(safety.CrossSafe, snap.CrossSafe+adv.CrossSafeDelta, adv.CrossSafeAttempts),
 		cl.ReachedFn(safety.Finalized, snap.Finalized+adv.FinalizedDelta, adv.FinalizedAttempts),
 	}
 	return runAllInParallel(fns)

--- a/op-devstack/dsl/l2_cl_safety_heads.go
+++ b/op-devstack/dsl/l2_cl_safety_heads.go
@@ -1,0 +1,81 @@
+package dsl
+
+import (
+	"golang.org/x/sync/errgroup"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
+)
+
+// SafetyHeadsAdvancement is the per-level delta and attempt budget for
+// asserting unsafe + safe + finalized progress together.
+type SafetyHeadsAdvancement struct {
+	UnsafeDelta       uint64
+	UnsafeAttempts    int
+	SafeDelta         uint64
+	SafeAttempts      int
+	FinalizedDelta    uint64
+	FinalizedAttempts int
+}
+
+// DefaultSafetyHeadsAdvancement: unsafe + safe within ~60s, finalized within
+// ~720s (in-process L1 has FinalizedDistance=20 blocks @ 6s).
+func DefaultSafetyHeadsAdvancement() SafetyHeadsAdvancement {
+	return SafetyHeadsAdvancement{
+		UnsafeDelta:       5,
+		UnsafeAttempts:    30,
+		SafeDelta:         1,
+		SafeAttempts:      30,
+		FinalizedDelta:    1,
+		FinalizedAttempts: 360,
+	}
+}
+
+// SafetyHeads is a snapshot of an L2 CL's unsafe/safe/finalized block numbers.
+type SafetyHeads struct {
+	Unsafe    uint64
+	Safe      uint64
+	Finalized uint64
+}
+
+func (cl *L2CLNode) SafetyHeads() SafetyHeads {
+	return SafetyHeads{
+		Unsafe:    cl.HeadBlockRef(safety.LocalUnsafe).Number,
+		Safe:      cl.HeadBlockRef(safety.LocalSafe).Number,
+		Finalized: cl.HeadBlockRef(safety.Finalized).Number,
+	}
+}
+
+// AllHeadsAdvancedFn asserts every safety head advances from the head
+// observed at call time, using DefaultSafetyHeadsAdvancement.
+func (cl *L2CLNode) AllHeadsAdvancedFn() CheckFunc {
+	adv := DefaultSafetyHeadsAdvancement()
+	fns := []CheckFunc{
+		cl.AdvancedFn(safety.LocalUnsafe, adv.UnsafeDelta, adv.UnsafeAttempts),
+		cl.AdvancedFn(safety.LocalSafe, adv.SafeDelta, adv.SafeAttempts),
+		cl.AdvancedFn(safety.Finalized, adv.FinalizedDelta, adv.FinalizedAttempts),
+	}
+	return runAllInParallel(fns)
+}
+
+// AllHeadsReachedFn asserts every safety head reaches snap + the default
+// delta. Used to assert catch-up after a resync.
+func (cl *L2CLNode) AllHeadsReachedFn(snap SafetyHeads) CheckFunc {
+	adv := DefaultSafetyHeadsAdvancement()
+	fns := []CheckFunc{
+		cl.ReachedFn(safety.LocalUnsafe, snap.Unsafe+adv.UnsafeDelta, adv.UnsafeAttempts),
+		cl.ReachedFn(safety.LocalSafe, snap.Safe+adv.SafeDelta, adv.SafeAttempts),
+		cl.ReachedFn(safety.Finalized, snap.Finalized+adv.FinalizedDelta, adv.FinalizedAttempts),
+	}
+	return runAllInParallel(fns)
+}
+
+func runAllInParallel(fns []CheckFunc) CheckFunc {
+	return func() error {
+		var g errgroup.Group
+		for _, fn := range fns {
+			fn := fn
+			g.Go(func() error { return fn() })
+		}
+		return g.Wait()
+	}
+}

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -183,6 +183,21 @@ func (s *Supernode) RestartWithFreshDataDir() {
 	s.require.NoError(err, "failed to restart supernode with fresh data dir")
 }
 
+// Stop halts the supernode while preserving its data directory and RPC
+// address. Requires NewSupernodeWithTestControl.
+func (s *Supernode) Stop() {
+	s.require.NotNil(s.testControl, "Stop requires test control; use NewSupernodeWithTestControl")
+	s.log.Info("stopping supernode")
+	s.testControl.Stop()
+}
+
+// Start brings the supernode back up after Stop. Requires NewSupernodeWithTestControl.
+func (s *Supernode) Start() {
+	s.require.NotNil(s.testControl, "Start requires test control; use NewSupernodeWithTestControl")
+	s.log.Info("starting supernode")
+	s.testControl.Start()
+}
+
 // BackfillAttempts returns the number of log-backfill attempts since the
 // running interop activity's most recent (re)start.
 // Requires the Supernode to be created with NewSupernodeWithTestControl.

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -17,6 +17,15 @@ type Supernode struct {
 	commonImpl
 	inner       stack.Supernode
 	testControl stack.SupernodeTestControl
+	managedVNs  []*L2CLNode
+}
+
+// ManageVN registers a VN-proxy L2CLNode as hosted by this supernode so that
+// Start() can re-establish its DSL-managed peer connections after a Stop/Start
+// cycle. Initial peering is done by the sysgo runtime; this hook only matters
+// across restarts driven through Supernode.Start.
+func (s *Supernode) ManageVN(vn *L2CLNode) {
+	s.managedVNs = append(s.managedVNs, vn)
 }
 
 // NewSupernode creates a new Supernode DSL wrapper
@@ -192,10 +201,15 @@ func (s *Supernode) Stop() {
 }
 
 // Start brings the supernode back up after Stop. Requires NewSupernodeWithTestControl.
+// After the supernode is up, any VNs registered via ManageVN have their
+// DSL-managed peer connections re-established, mirroring L2CLNode.Start.
 func (s *Supernode) Start() {
 	s.require.NotNil(s.testControl, "Start requires test control; use NewSupernodeWithTestControl")
 	s.log.Info("starting supernode")
 	s.testControl.Start()
+	for _, vn := range s.managedVNs {
+		vn.restoreManagedPeers()
+	}
 }
 
 // BackfillAttempts returns the number of log-backfill attempts since the

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -141,7 +141,18 @@ const minimalWithConductorsPresetSupportedOptionKinds = optionKindDeployer |
 const simpleWithSyncTesterPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds |
 	optionKindGlobalSyncTesterEL
 
-const singleSupernodeWithSyncTesterPresetSupportedOptionKinds = simpleWithSyncTesterPresetSupportedOptionKinds |
+// singleSupernodeWithSyncTesterPresetSupportedOptionKinds covers exactly what
+// the runtime in singlechain_supernode_synctester_variant.go actually wires.
+// Proposer / game-type / proof-validation options are intentionally excluded:
+// this preset has no proposer and no dispute game surface, so accepting them
+// would be a silent no-op footgun.
+const singleSupernodeWithSyncTesterPresetSupportedOptionKinds = optionKindDeployer |
+	optionKindBatcher |
+	optionKindGlobalL2CL |
+	optionKindGlobalSyncTesterEL |
+	optionKindL1EL |
+	optionKindTimeTravel |
+	optionKindAfterBuild |
 	optionKindSupernodeVerifierSyncMode |
 	optionKindInteropActivationDelay
 

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -30,6 +30,8 @@ const (
 	optionKindInteropFilter
 	optionKindPreGenesisSuperGame
 	optionKindSkipHonestProposer
+	optionKindSupernodeVerifierSyncMode
+	optionKindInteropActivationDelay
 )
 
 const allOptionKinds = optionKindDeployer |
@@ -50,7 +52,9 @@ const allOptionKinds = optionKindDeployer |
 	optionKindInteropLogBackfill |
 	optionKindInteropFilter |
 	optionKindPreGenesisSuperGame |
-	optionKindSkipHonestProposer
+	optionKindSkipHonestProposer |
+	optionKindSupernodeVerifierSyncMode |
+	optionKindInteropActivationDelay
 
 var optionKindLabels = []struct {
 	kind  optionKinds
@@ -75,6 +79,8 @@ var optionKindLabels = []struct {
 	{kind: optionKindInteropFilter, label: "interop filter"},
 	{kind: optionKindPreGenesisSuperGame, label: "pre-genesis super game"},
 	{kind: optionKindSkipHonestProposer, label: "skip honest proposer"},
+	{kind: optionKindSupernodeVerifierSyncMode, label: "supernode verifier sync mode"},
+	{kind: optionKindInteropActivationDelay, label: "interop activation delay"},
 }
 
 func (k optionKinds) String() string {
@@ -134,6 +140,10 @@ const minimalWithConductorsPresetSupportedOptionKinds = optionKindDeployer |
 
 const simpleWithSyncTesterPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds |
 	optionKindGlobalSyncTesterEL
+
+const singleSupernodeWithSyncTesterPresetSupportedOptionKinds = simpleWithSyncTesterPresetSupportedOptionKinds |
+	optionKindSupernodeVerifierSyncMode |
+	optionKindInteropActivationDelay
 
 const supernodeProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindBatcher |

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -5,6 +5,7 @@ import (
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -150,6 +151,27 @@ func WithGlobalL2CLOption(opt sysgo.L2CLOption) Option {
 				return
 			}
 			cfg.GlobalL2CLOptions = append(cfg.GlobalL2CLOptions, opt)
+		},
+	}
+}
+
+// WithSupernodeVerifierSyncMode overrides the supernode VN's sync mode.
+func WithSupernodeVerifierSyncMode(mode nodeSync.Mode) Option {
+	return option{
+		kinds: optionKindSupernodeVerifierSyncMode,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			m := mode
+			cfg.SupernodeVerifierSyncMode = &m
+		},
+	}
+}
+
+// WithInteropActivationDelay sets the Interop activation offset past genesis.
+func WithInteropActivationDelay(delaySeconds uint64) Option {
+	return option{
+		kinds: optionKindInteropActivationDelay,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			cfg.InteropActivationDelaySeconds = delaySeconds
 		},
 	}
 }

--- a/op-devstack/presets/singlechain_supernode_with_synctester.go
+++ b/op-devstack/presets/singlechain_supernode_with_synctester.go
@@ -1,0 +1,35 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// SingleSupernodeWithSyncTester mirrors SimpleWithSyncTester but replaces the
+// verifier op-node CL with a verifier-mode supernode VN. Interop is always
+// enabled; activation is controlled by WithInteropActivationDelay (0 = genesis).
+type SingleSupernodeWithSyncTester struct {
+	Minimal
+
+	Supernode      *dsl.Supernode
+	SupernodeCL    *dsl.L2CLNode // per-chain VN proxy
+	SyncTester     *dsl.SyncTester
+	SyncTesterL2EL *dsl.L2ELNode
+
+	GenesisTime           uint64
+	InteropActivationTime uint64
+	DelaySeconds          uint64
+}
+
+func NewSingleSupernodeWithSyncTester(t devtest.T, opts ...Option) *SingleSupernodeWithSyncTester {
+	presetCfg, presetOpts := collectSupportedPresetConfig(
+		t,
+		"NewSingleSupernodeWithSyncTester",
+		opts,
+		singleSupernodeWithSyncTesterPresetSupportedOptionKinds,
+	)
+	out := singleSupernodeWithSyncTesterFromRuntime(t, sysgo.NewSingleSupernodeWithSyncTesterRuntimeWithConfig(t, presetCfg))
+	presetOpts.applyPreset(out)
+	return out
+}

--- a/op-devstack/presets/singlechain_supernode_with_synctester_from_runtime.go
+++ b/op-devstack/presets/singlechain_supernode_with_synctester_from_runtime.go
@@ -109,5 +109,6 @@ func singleSupernodeWithSyncTesterFromRuntime(t devtest.T, runtime *sysgo.MultiC
 		DelaySeconds:          runtime.DelaySeconds,
 	}
 	preset.SupernodeCL.ManagePeer(preset.L2CL)
+	preset.Supernode.ManageVN(preset.SupernodeCL)
 	return preset
 }

--- a/op-devstack/presets/singlechain_supernode_with_synctester_from_runtime.go
+++ b/op-devstack/presets/singlechain_supernode_with_synctester_from_runtime.go
@@ -1,0 +1,113 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+func singleSupernodeWithSyncTesterFromRuntime(t devtest.T, runtime *sysgo.MultiChainRuntime) *SingleSupernodeWithSyncTester {
+	require := t.Require()
+	chain := runtime.Chains["l2a"]
+	require.NotNil(chain, "missing l2a chain")
+	require.NotNil(runtime.Supernode, "missing supernode")
+	require.NotNil(runtime.SyncTester, "missing sync tester support")
+	require.NotNil(runtime.SyncTester.EL, "missing sync tester EL")
+	require.NotNil(runtime.SyncTester.CL, "missing sync tester CL")
+
+	l1ChainID := runtime.L1Network.ChainID()
+	l2ChainID := chain.Network.ChainID()
+
+	l1Network := newPresetL1Network(t, "l1", runtime.L1Network.ChainConfig())
+	l1ELFront := newL1ELFrontend(t, "l1", l1ChainID, runtime.L1EL.UserRPC())
+	l1CLFront := newL1CLFrontend(t, "l1", l1ChainID, runtime.L1CL.BeaconHTTPAddr(), runtime.L1CL.FakePoS())
+	l1Network.AddL1ELNode(l1ELFront)
+	l1Network.AddL1CLNode(l1CLFront)
+
+	l2Net := newPresetL2Network(
+		t,
+		"l2a",
+		chain.Network.ChainConfig(),
+		chain.Network.RollupConfig(),
+		chain.Network.Deployment(),
+		newKeyring(runtime.Keys, require),
+		l1Network,
+	)
+	seqEL := newL2ELFrontend(t, "sequencer", l2ChainID,
+		chain.EL.UserRPC(), chain.EL.EngineRPC(), chain.EL.JWTPath(),
+		chain.Network.RollupConfig())
+	seqCL := newL2CLFrontend(t, "sequencer", l2ChainID, chain.CL.UserRPC(), chain.CL)
+	seqCL.attachEL(seqEL)
+	seqBatcher := newL2BatcherFrontend(t, "main", l2ChainID, chain.Batcher.UserRPC())
+	l2Net.AddL2ELNode(seqEL)
+	l2Net.AddL2CLNode(seqCL)
+	l2Net.AddL2Batcher(seqBatcher)
+
+	faucetL1Front := newFaucetFrontendForChain(t, runtime.FaucetService, l1ChainID)
+	faucetL2Front := newFaucetFrontendForChain(t, runtime.FaucetService, l2ChainID)
+	l1Network.AddFaucet(faucetL1Front)
+	l2Net.AddFaucet(faucetL2Front)
+	faucetL1 := dsl.NewFaucet(faucetL1Front)
+	faucetL2 := dsl.NewFaucet(faucetL2Front)
+
+	// Sync-tester frontends.
+	syncTesterName, syncTesterRPC, ok := runtime.SyncTester.Service.DefaultEndpoint(l2ChainID)
+	require.Truef(ok, "missing sync tester for chain %s", l2ChainID)
+	syncTesterFront := newSyncTesterFrontend(t, syncTesterName, l2ChainID, syncTesterRPC)
+	syncTesterELFront := newL2ELFrontend(
+		t, "sync-tester-el", l2ChainID,
+		runtime.SyncTester.EL.UserRPC(),
+		runtime.SyncTester.EL.EngineRPC(),
+		runtime.SyncTester.EL.JWTPath(),
+		chain.Network.RollupConfig(),
+	)
+
+	// Per-chain supernode VN as the verifier CL.
+	supernodeCLFront := newL2CLFrontend(t, "supernode-vn", l2ChainID,
+		runtime.SyncTester.CL.UserRPC(), runtime.SyncTester.CL)
+	supernodeCLFront.attachEL(syncTesterELFront)
+
+	l2Net.AddSyncTester(syncTesterFront)
+	l2Net.AddL2ELNode(syncTesterELFront)
+	l2Net.AddL2CLNode(supernodeCLFront)
+
+	supernodeFront := newSupernodeFrontend(t, "supernode-sync-tester-system", runtime.Supernode.UserRPC())
+
+	l1ELDSL := dsl.NewL1ELNode(l1ELFront)
+	l1CLDSL := dsl.NewL1CLNode(l1CLFront)
+	seqELDSL := dsl.NewL2ELNode(seqEL)
+	seqCLDSL := dsl.NewL2CLNode(seqCL)
+	supernodeCLDSL := dsl.NewL2CLNode(supernodeCLFront)
+
+	minimal := Minimal{
+		Log:        t.Logger(),
+		T:          t,
+		timeTravel: runtime.TimeTravel,
+		L1Network:  dsl.NewL1Network(l1Network, l1ELDSL, l1CLDSL),
+		L1EL:       l1ELDSL,
+		L1CL:       l1CLDSL,
+		L2Chain:    dsl.NewL2Network(l2Net, seqELDSL, seqCLDSL, l1ELDSL, nil, nil),
+		L2Batcher:  dsl.NewL2Batcher(seqBatcher),
+		L2EL:       seqELDSL,
+		L2CL:       seqCLDSL,
+		Wallet:     dsl.NewRandomHDWallet(t, 30),
+		FaucetL1:   faucetL1,
+		FaucetL2:   faucetL2,
+	}
+	minimal.FunderL1 = dsl.NewFunder(minimal.Wallet, minimal.FaucetL1, minimal.L1EL)
+	minimal.FunderL2 = dsl.NewFunder(minimal.Wallet, minimal.FaucetL2, minimal.L2EL)
+
+	genesisTime := chain.Network.RollupConfig().Genesis.L2Time
+	preset := &SingleSupernodeWithSyncTester{
+		Minimal:               minimal,
+		Supernode:             dsl.NewSupernodeWithTestControl(supernodeFront, runtime.Supernode),
+		SupernodeCL:           supernodeCLDSL,
+		SyncTester:            dsl.NewSyncTester(syncTesterFront),
+		SyncTesterL2EL:        dsl.NewL2ELNode(syncTesterELFront),
+		GenesisTime:           genesisTime,
+		InteropActivationTime: genesisTime + runtime.DelaySeconds,
+		DelaySeconds:          runtime.DelaySeconds,
+	}
+	preset.SupernodeCL.ManagePeer(preset.L2CL)
+	return preset
+}

--- a/op-devstack/stack/supernode.go
+++ b/op-devstack/stack/supernode.go
@@ -23,4 +23,10 @@ type SupernodeTestControl interface {
 	// data directory, and starts a fresh supernode against the same chain
 	// containers, virtual nodes, and externally-visible RPC address.
 	RestartWithFreshDataDir() error
+
+	// Stop halts the supernode while preserving its data directory and RPC
+	// address; Start brings it back up. Used by sync tests that need to halt
+	// the verifier, mutate external state, and resume.
+	Stop()
+	Start()
 }

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -188,7 +188,12 @@ func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 		require.NoError(overrideErr, "failed to override message expiry window")
 	}
 
-	supernode, l2CL := startSingleChainSharedSupernode(t, l1Net, l1EL, l1CL, l2Net, l2EL, depSetStatic, jwtSecret, interopAtGenesis)
+	var interopActivationTimestamp *uint64
+	if interopAtGenesis {
+		ts := l2Net.rollupCfg.Genesis.L2Time
+		interopActivationTimestamp = &ts
+	}
+	supernode, l2CL := startSingleChainSharedSupernode(t, l1Net, l1EL, l1CL, l2Net, l2EL, depSetStatic, jwtSecret, interopActivationTimestamp, true, nodeSync.CLSync)
 	l2Batcher := startMinimalBatcher(t, keys, l2Net, l1EL, l2CL, l2EL, cfg.BatcherOptions...)
 	faucetService := startFaucets(t, keys, l1Net.ChainID(), l2Net.ChainID(), l1EL.UserRPC(), l2EL.UserRPC())
 
@@ -633,20 +638,26 @@ func startSingleChainSharedSupernode(
 	l2EL L2ELNode,
 	depSet *depset.StaticConfigDependencySet,
 	jwtSecret [32]byte,
-	interopAtGenesis bool,
+	interopActivationTimestamp *uint64,
+	sequencerEnabled bool,
+	verifierSyncMode nodeSync.Mode,
 ) (*SuperNode, *SuperNodeProxy) {
 	require := t.Require()
 	logger := t.Logger().New("component", "supernode")
 	makeNodeCfg := func() *opnodeconfig.Config {
-		p2pKey, err := l2Net.keys.Secret(devkeys.SequencerP2PRole.Key(l2Net.ChainID().ToBig()))
-		require.NoError(err, "need p2p key for supernode virtual sequencer")
+		var sequencerP2PKeyHex string
+		if sequencerEnabled {
+			p2pKey, err := l2Net.keys.Secret(devkeys.SequencerP2PRole.Key(l2Net.ChainID().ToBig()))
+			require.NoError(err, "need p2p key for supernode virtual sequencer")
+			sequencerP2PKeyHex = hex.EncodeToString(crypto.FromECDSA(p2pKey))
+		}
 		p2pConfig, p2pSignerSetup := newDevstackP2PConfig(
 			t,
 			logger.New("chain_id", l2Net.ChainID().String(), "component", "supernode-p2p"),
 			l2Net.rollupCfg.BlockTime,
 			false,
 			true,
-			hex.EncodeToString(crypto.FromECDSA(p2pKey)),
+			sequencerP2PKeyHex,
 		)
 		cfg := &opnodeconfig.Config{
 			L1: &opnodeconfig.L1EndpointConfig{
@@ -666,13 +677,13 @@ func startSingleChainSharedSupernode(
 			},
 			DependencySet:                   depSet,
 			Beacon:                          &opnodeconfig.L1BeaconEndpointConfig{BeaconAddr: l1CL.beaconHTTPAddr},
-			Driver:                          driver.Config{SequencerEnabled: true, SequencerConfDepth: 2},
+			Driver:                          driver.Config{SequencerEnabled: sequencerEnabled, SequencerConfDepth: 2},
 			Rollup:                          *l2Net.rollupCfg,
 			P2PSigner:                       p2pSignerSetup,
 			RPC:                             oprpc.CLIConfig{ListenAddr: "127.0.0.1", ListenPort: 0, EnableAdmin: true},
 			P2P:                             p2pConfig,
 			L1EpochPollInterval:             2 * time.Second,
-			Sync:                            nodeSync.Config{SyncMode: nodeSync.CLSync, SyncModeReqResp: true},
+			Sync:                            nodeSync.Config{SyncMode: verifierSyncMode, SyncModeReqResp: true},
 			ConfigPersistence:               opnodeconfig.DisabledConfigPersistence{},
 			Metrics:                         opmetrics.CLIConfig{},
 			Pprof:                           oppprof.CLIConfig{},
@@ -681,12 +692,6 @@ func startSingleChainSharedSupernode(
 		}
 		require.NoError(cfg.Check(), "invalid supernode op-node config for chain %s", l2Net.ChainID())
 		return cfg
-	}
-
-	var interopActivationTimestamp *uint64
-	if interopAtGenesis {
-		ts := l2Net.rollupCfg.Genesis.L2Time
-		interopActivationTimestamp = &ts
 	}
 
 	snCfg := &snconfig.CLIConfig{

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -36,6 +37,10 @@ type PresetConfig struct {
 	PreGenesisSuperGame     *PreGenesisSuperGameConfig
 	// SkipHonestProposer skips starting op-proposer.
 	SkipHonestProposer bool
+	// SupernodeVerifierSyncMode overrides the supernode VN's sync mode when set.
+	SupernodeVerifierSyncMode *nodeSync.Mode
+	// InteropActivationDelaySeconds offsets Interop activation past genesis (0 = at genesis).
+	InteropActivationDelaySeconds uint64
 }
 
 func NewPresetConfig() PresetConfig {

--- a/op-devstack/sysgo/runtime_state.go
+++ b/op-devstack/sysgo/runtime_state.go
@@ -51,7 +51,12 @@ type SingleChainNodeRuntime struct {
 
 type SyncTesterRuntime struct {
 	Service *SyncTesterService
-	Node    *SingleChainNodeRuntime
+	// Node is set on the op-node-verifier path; nil on the supernode path.
+	Node *SingleChainNodeRuntime
+	// EL is the sync-tester-backed L2ELNode.
+	EL L2ELNode
+	// CL drives the sync-tester EL (op-node or SuperNodeProxy).
+	CL L2CLNode
 }
 
 type FlashblocksRuntimeSupport struct {
@@ -152,4 +157,5 @@ type MultiChainRuntime struct {
 	L2ChallengerConfig *challengerconfig.Config
 	DelaySeconds       uint64
 	InteropFilter      *InteropFilter // nil if not using interop filter
+	SyncTester         *SyncTesterRuntime
 }

--- a/op-devstack/sysgo/singlechain_supernode_synctester_variant.go
+++ b/op-devstack/sysgo/singlechain_supernode_synctester_variant.go
@@ -1,0 +1,150 @@
+package sysgo
+
+import (
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
+	opforks "github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
+	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// NewSingleSupernodeWithSyncTesterRuntime builds a single-chain runtime: real
+// sequencer op-node + EL driving the chain, sync-tester service feeding a
+// mocked EL, and a verifier-mode supernode VN wired to that mocked EL.
+// Interop is always on; cfg.InteropActivationDelaySeconds picks at-genesis (0)
+// or post-genesis activation.
+func NewSingleSupernodeWithSyncTesterRuntime(t devtest.T) *MultiChainRuntime {
+	return NewSingleSupernodeWithSyncTesterRuntimeWithConfig(t, PresetConfig{})
+}
+
+func NewSingleSupernodeWithSyncTesterRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiChainRuntime {
+	require := t.Require()
+
+	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(err, "failed to derive dev keys from mnemonic")
+
+	delaySeconds := cfg.InteropActivationDelaySeconds
+	interopAtGenesis := delaySeconds == 0
+
+	deployerOpts := []DeployerOption{
+		WithDevFeatureEnabled(devfeatures.OptimismPortalInteropFlag),
+	}
+	if !interopAtGenesis {
+		// Karst at genesis, Interop at offset — exercises the activation transition.
+		deployerOpts = append(deployerOpts, func(_ devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
+			for _, l2Cfg := range builder.L2s() {
+				l2Cfg.WithForkAtGenesis(opforks.Karst)
+				l2Cfg.WithForkAtOffset(opforks.Interop, &delaySeconds)
+			}
+		})
+	}
+	deployerOpts = append(deployerOpts, cfg.DeployerOptions...)
+
+	migration, l1Net, l2Net, depSet, _ := buildSingleChainWorldWithInteropAndState(t, keys, interopAtGenesis, cfg.LocalContractArtifactsPath, deployerOpts...)
+	validateSimpleInteropPresetConfig(t, cfg, l2Net)
+
+	jwtPath, jwtSecret := writeJWTSecret(t)
+	l1Clock := clock.SystemClock
+	var timeTravelClock *clock.AdvancingClock
+	if cfg.EnableTimeTravel {
+		timeTravelClock = clock.NewAdvancingClock()
+		l1Clock = timeTravelClock
+	}
+	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
+
+	l2EL := startL2ELNode(t, l2Net, jwtPath, jwtSecret, "sequencer", NewELNodeIdentity(0))
+	l2CL := startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
+		Key:           "sequencer",
+		IsSequencer:   true,
+		L2CLOptions:   cfg.GlobalL2CLOptions,
+		DependencySet: depSet,
+	})
+	l2Batcher := startMinimalBatcher(t, keys, l2Net, l1EL, l2CL, l2EL, cfg.BatcherOptions...)
+
+	syncTester := startSyncTesterService(t, map[eth.ChainID]string{
+		l2Net.ChainID(): l2EL.UserRPC(),
+	})
+	syncTesterELCfg := DefaultSyncTesterELConfig()
+	if len(cfg.GlobalSyncTesterELOptions) > 0 {
+		target := NewComponentTarget("sync-tester-el", l2Net.ChainID())
+		for _, opt := range cfg.GlobalSyncTesterELOptions {
+			if opt == nil {
+				continue
+			}
+			opt.Apply(t, target, syncTesterELCfg)
+		}
+	}
+	syncTesterEL := startSyncTesterELNode(
+		t,
+		jwtPath,
+		syncTester,
+		NewComponentTarget("sync-tester-el", l2Net.ChainID()),
+		syncTesterELCfg,
+	)
+
+	var depSetStatic *depset.StaticConfigDependencySet
+	if depSet != nil {
+		cast, ok := depSet.(*depset.StaticConfigDependencySet)
+		require.True(ok, "expected static dependency set")
+		depSetStatic = cast
+	}
+	if cfg.MessageExpiryWindow != nil && depSetStatic != nil {
+		var overrideErr error
+		depSetStatic, overrideErr = depset.NewStaticConfigDependencySetWithMessageExpiryOverride(
+			depSetStatic.Dependencies(), *cfg.MessageExpiryWindow)
+		require.NoError(overrideErr, "failed to override message expiry window")
+	}
+
+	verifierSyncMode := nodeSync.CLSync
+	if cfg.SupernodeVerifierSyncMode != nil {
+		verifierSyncMode = *cfg.SupernodeVerifierSyncMode
+	}
+	activationTimestamp := l2Net.rollupCfg.Genesis.L2Time + delaySeconds
+	supernode, supernodeProxy := startSingleChainSharedSupernode(
+		t, l1Net, l1EL, l1CL, l2Net, syncTesterEL, depSetStatic, jwtSecret, &activationTimestamp, false, verifierSyncMode,
+	)
+	// Peer the VN with the sequencer so unsafe payloads flow via P2P
+	// (the two-L2 supernode runtime does the same for verifier-mode VNs).
+	connectL2CLPeers(t, t.Logger(), l2CL, supernodeProxy)
+
+	faucetService := startFaucets(t, keys, l1Net.ChainID(), l2Net.ChainID(), l1EL.UserRPC(), l2EL.UserRPC())
+
+	var runtimeDepSet depset.DependencySet
+	if depSetStatic != nil {
+		runtimeDepSet = depSetStatic
+	} else {
+		runtimeDepSet = depSet
+	}
+
+	return &MultiChainRuntime{
+		Keys:          keys,
+		Migration:     migration,
+		DependencySet: runtimeDepSet,
+		L1Network:     l1Net,
+		L1EL:          l1EL,
+		L1CL:          l1CL,
+		Chains: map[string]*MultiChainNodeRuntime{
+			"l2a": {
+				Name:        "l2a",
+				Network:     l2Net,
+				EL:          l2EL,
+				CL:          l2CL,
+				SupernodeCL: supernodeProxy,
+				Batcher:     l2Batcher,
+			},
+		},
+		Supernode:     supernode,
+		FaucetService: faucetService,
+		TimeTravel:    timeTravelClock,
+		DelaySeconds:  delaySeconds,
+		SyncTester: &SyncTesterRuntime{
+			Service: syncTester,
+			EL:      syncTesterEL,
+			CL:      supernodeProxy,
+		},
+	}
+}

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -95,6 +95,8 @@ func NewSimpleWithSyncTesterRuntimeWithConfig(t devtest.T, cfg PresetConfig) *Si
 	runtime.SyncTester = &SyncTesterRuntime{
 		Service: syncTester,
 		Node:    node,
+		EL:      node.EL,
+		CL:      node.CL,
 	}
 	return runtime
 }

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -69,11 +69,18 @@ func (c *simpleChainContainer) FinalizedL2Head(ctx context.Context) (rollup.Veri
 // verifierContribution classifies a verifier's (block, ts) return:
 //   - empty block → Anchor (caller resolves the canonical L2 block at ts).
 //   - non-empty block → Verified tip.
+//
+// Anchor timestamps are clamped up to L2 genesis: the verifier's raw cap is
+// activationTimestamp - 1, which is pre-genesis when interop activates at
+// genesis and has no resolvable block downstream.
 func (c *simpleChainContainer) verifierContribution(bId eth.BlockID, ts uint64, err error) (rollup.VerifierHead, error) {
 	if err != nil {
 		return rollup.VerifierHead{}, err
 	}
 	if (bId == eth.BlockID{}) {
+		if genesisTs := c.vncfg.Rollup.Genesis.L2Time; ts < genesisTs {
+			ts = genesisTs
+		}
 		return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor, Timestamp: ts}, nil
 	}
 	return rollup.VerifierHead{Source: rollup.VerifierHeadVerified, Block: bId, Timestamp: ts}, nil

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -73,10 +74,17 @@ var _ activity.VerificationActivity = (*mockVerificationActivityForSuperAuthorit
 
 // newTestChainContainer creates a simpleChainContainer for testing with a test logger
 func newTestChainContainer(t *testing.T, chainID eth.ChainID) *simpleChainContainer {
+	return newTestChainContainerWithGenesis(t, chainID, 0)
+}
+
+func newTestChainContainerWithGenesis(t *testing.T, chainID eth.ChainID, l2GenesisTime uint64) *simpleChainContainer {
+	cfg := &opnodecfg.Config{}
+	cfg.Rollup.Genesis.L2Time = l2GenesisTime
 	return &simpleChainContainer{
 		chainID: chainID,
 		log:     testlog.Logger(t, log.LevelDebug),
 		vn:      &mockVirtualNode{},
+		vncfg:   cfg,
 	}
 }
 
@@ -178,6 +186,30 @@ func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierContribu
 	require.Equal(t, eth.BlockID{}, head.Block, "anchor contribution carries no block")
 	require.Equal(t, uint64(999), head.Timestamp,
 		"anchor timestamp is activationTimestamp - 1; engine_controller resolves to a block")
+}
+
+// When interop activates at genesis the verifier's raw cap is pre-genesis;
+// the super-authority must clamp the anchor timestamp up to L2 genesis so the
+// engine controller can resolve a canonical block.
+func TestChainContainer_FullyVerifiedL2Head_ActivationAtGenesis_ClampsAnchorToGenesis(t *testing.T) {
+	t.Parallel()
+
+	const genesisL2Time = uint64(1_700_000_000)
+	const activationTime = genesisL2Time // interop activates at genesis
+
+	cc := newTestChainContainerWithGenesis(t, eth.ChainIDFromUInt64(420), genesisL2Time)
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 5, Hash: [32]byte{0xbb}, Time: genesisL2Time + 10},
+	})
+
+	cc.RegisterVerifier(&mockVerificationActivityForSuperAuthority{activationTimestamp: activationTime})
+
+	head, ok := cc.FullyVerifiedL2Head(t.Context())
+	require.True(t, ok)
+	require.Equal(t, rollup.VerifierHeadAnchor, head.Source)
+	require.Equal(t, eth.BlockID{}, head.Block)
+	require.Equal(t, genesisL2Time, head.Timestamp,
+		"anchor cap must clamp to L2 genesis (raw cap %d is pre-genesis)", activationTime-1)
 }
 
 // =============================================================================

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -129,9 +129,8 @@ func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Blo
 			}
 		}
 		if len(receipts) == 0 {
-			// Should never happen since every block except genesis has at least one deposit tx
-			logger.Warn("L2 Block has zero receipts", "blockNrHash", blockNrOrHash)
-			return nil, errors.New("no receipts")
+			// Genesis legitimately has no receipts.
+			return receipts, nil
 		}
 		target := bigs.Uint64Strict(receipts[0].BlockNumber)
 		if target > session.CurrentState.Latest {


### PR DESCRIPTION
**Claude:** Part A of ethereum-optimism/optimism#21096. Wires a single op-supernode VN to drive an op-sync-tester mocked EL, plus two production fixes uncovered along the way.

## Production fixes
- **`op-supernode` super-authority** — `simpleChainContainer.verifierContribution` now clamps the Anchor cap timestamp up to L2 genesis. Previously the verifier reported `activationTimestamp - 1` as the cap, which is pre-genesis when interop activates at genesis; the engine controller then failed to resolve a block and floored finalized at zero, blocking finalization indefinitely. The clamp keeps safe/finalized anchored at the genesis block until the verifier confirms a post-activation block via the Verified path.
- **`op-sync-tester` `GetBlockReceipts`** — no longer errors on empty receipts; genesis legitimately has none, and the error blocked the supernode interop verifier from reading the frontier genesis block.

## Devstack
- New `NewSingleSupernodeWithSyncTester` preset (sequencer + sync-tester + verifier-mode supernode VN); interop always on, activation timestamp via `WithInteropActivationDelay`.
- `startSingleChainSharedSupernode` threads `sequencerEnabled`, `interopActivationTimestamp`, `verifierSyncMode`.
- `SupernodeTestControl` gains `Stop`/`Start`; `Supernode.Start` now restores DSL-managed peers on registered VN proxies via the new `ManageVN` hook, mirroring `L2CLNode.Start`.
- Preset option surface narrowed to what the runtime actually wires — proposer / game-type / proof-validation options are rejected instead of silently dropped.
- New DSL: `SafetyHeads`/`AllHeadsAdvancedFn`/`AllHeadsReachedFn` + `DefaultSafetyHeadsAdvancement`.

## Tests (`tests/supernode/sync_tester/`)
- `AdvancesViaSyncTester`, `CatchesUpFromCold`, `ELSyncsFromCold`, `SyncsThroughInteropActivation`, `ELSyncsThroughInteropActivation` — all assert unsafe + safe + cross-safe + finalized.
- Super-authority unit test for the at-genesis clamp.
