### PR TITLE
fix(op-acceptance-tests): stabilize TestReorgUnsafeHead reorg race

### DIFF
--- a/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
@@ -86,11 +86,21 @@ func TestReorgUnsafeHead(gt *testing.T) {
 	// start batcher on chain A
 	sys.L2BatcherA.Start()
 
-	// sequence a second block with op-test-sequencer (no L1 origin override)
+	// Don't read eth.Unsafe ("latest") for the parent: it can lag the EL's
+	// post-forkchoice canonical swap and return the original head, and building on
+	// that stale parent would forkchoice the EL back onto the original chain,
+	// undoing the reorg. Wait until the divergence height has actually reorged,
+	// then extend that confirmed conflicting block explicitly.
+	sys.L2ELA.ReorgExact(originalRef_A, 30)
+	conflictingHead := sys.L2ELA.BlockRefByNumber(divergenceBlockNumber_A)
+	l.Info("EL reflects conflicting block at divergence height",
+		"number", conflictingHead.Number, "hash", conflictingHead.Hash, "parent", conflictingHead.ParentID().Hash)
+
+	// sequence a second block extending the confirmed conflicting head
 	{
 		l.Info("Sequencing with op-test-sequencer (no L1 origin override)")
 		err := ia.New(ctx, seqtypes.BuildOpts{
-			Parent:   sys.L2ELA.BlockRefByLabel(eth.Unsafe).Hash,
+			Parent:   conflictingHead.Hash,
 			L1Origin: nil,
 		})
 		require.NoError(t, err, "Expected to be able to create a new block job for sequencing on op-test-sequencer, but got error")
@@ -122,13 +132,12 @@ func TestReorgUnsafeHead(gt *testing.T) {
 
 	sys.L2A.WaitForBlock()
 
-	reorgedRef_A, err := sys.L2ELA.Escape().EthClient().BlockRefByNumber(ctx, divergenceBlockNumber_A)
-	require.NoError(t, err, "Expected to be able to call BlockRefByNumber API, but got error")
-
-	l.Info("Reorged chain A on divergence block number (prior the reorg)", "number", divergenceBlockNumber_A, "head", originalRef_A.Hash, "parent", originalRef_A.ParentID().Hash)
-	l.Info("Reorged chain A on divergence block number (after the reorg)", "number", divergenceBlockNumber_A, "head", reorgedRef_A.Hash, "parent", reorgedRef_A.ParentID().Hash)
-	require.NotEqual(t, originalRef_A.Hash, reorgedRef_A.Hash, "Expected to get different heads on divergence block number, but got the same hash, so no reorg happened on chain A")
-	require.Equal(t, originalRef_A.ParentID().Hash, reorgedRef_A.ParentHash, "Expected to get same parent hashes on divergence block number, but got different hashes")
+	// Poll for the reorg rather than reading once: ReorgExact waits until the
+	// divergence height has a different hash with the same parent. The generous
+	// attempt budget tolerates a slow-to-canonicalize op-reth under CI load.
+	l.Info("Asserting chain A reorged on divergence block number",
+		"number", divergenceBlockNumber_A, "original", originalRef_A.Hash, "parent", originalRef_A.ParentID().Hash)
+	sys.L2ELA.ReorgExact(originalRef_A, 30)
 
 	err = wait.For(ctx, 5*time.Second, func() (bool, error) {
 		safeL2Head_A_sequencer := sys.L2ACL.SafeL2BlockRef()


### PR DESCRIPTION
## Problem

`TestReorgUnsafeHead` is flaky in CI (~8 occurrences in the Insights window, mostly on op-reth jobs), failing with:

```
unsafe_head_test.go: Should not be: 0x1440ed…
Expected to get different heads on divergence block number, but got the same hash, so no reorg happened on chain A
```

Tracking issue: #20198.

## Root cause

After the op-test-sequencer commits the conflicting block (`engine_newPayload` + `forkchoiceUpdated`), the test read the EL's mutable `eth.Unsafe` ("latest") label to choose the parent for the *next* block:

```go
Parent: sys.L2ELA.BlockRefByLabel(eth.Unsafe).Hash,
```

That read can lag op-reth's post-forkchoice canonical-tag swap and return the **original** head instead of the conflicting block. Building the next block on that stale parent issues a `forkchoiceUpdated(head=original)`, which reorgs the EL **back** onto the original chain — silently undoing the reorg. op-node then resumes sequencing on the original fork, so the divergence-height block is unchanged and the assertion fails.

CI logs show the exact signature: a forward reorg `X→Y` immediately followed by `Y→X`, after which blocks are built on `X`.

This is a **different** window from the one #20201 closed (that fix addressed an op-node-side stale-head race in `StartSequencer`, and is preserved here).

## Fix

- Replace the racy `eth.Unsafe` label read with the `ReorgExact` DSL poll (the same helper the sibling reorg tests use): wait until the divergence height reports a different hash with a matching parent, then read that confirmed conflicting block back **by number** and use it as the explicit parent. This makes building on a stale head structurally impossible.
- Use `ReorgExact` for the final assertion too, instead of a one-shot read + `require.NotEqual`/`require.Equal` (it enforces the same two invariants — hash changed, parent unchanged — but polls).
- Both polls use a generous attempt budget (30 × 2s) so an oversubscribed CI box, where op-reth can be slow to surface the reorged block, doesn't trip a tight timeout.

Test-only change; no production code touched.

## Validation

Reproduced the flake under load and confirmed the fix on op-reth (`RUST_JIT_BUILD=1 DEVSTACK_L2EL_KIND=op-reth`):

| Run | Config | `no reorg happened` | timeout | Result |
|---|---|---|---|---|
| Baseline | 30× @ -parallel=6 | 0 | 0 | race not triggered on idle box |
| Baseline | 48× @ -parallel=24 | **1** | 0 | reproduced exact CI symptom |
| Fix (initial, tight budget) | 96× @ -parallel=24 | 0 | 1 | original flake gone; exposed an under-load timeout |
| **Fix (final, 60s budget)** | **128× @ -parallel=32** | **0** | **0** | **128/128 pass** |

Refs #20198