### PR TITLE
feat(op-interop-filter): correct + per-reason failsafe metrics & logs

### DIFF
--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -61,11 +61,19 @@ type BackendParams struct {
 	ReorgRecoveryEnabled bool
 }
 
+// failsafeObserver is implemented by components whose error state feeds into
+// FailsafeEnabled. The backend wires a callback so the failsafe_enabled metric
+// is refreshed whenever a component enters or clears its error state, not only
+// on the manual SetFailsafeEnabled path.
+type failsafeObserver interface {
+	SetOnFailsafeChange(func())
+}
+
 // NewBackend creates a new Backend instance with the provided components.
 func NewBackend(parentCtx context.Context, params BackendParams) *Backend {
 	ctx, cancel := context.WithCancel(parentCtx)
 
-	return &Backend{
+	b := &Backend{
 		log:                         params.Logger,
 		metrics:                     params.Metrics,
 		chains:                      params.Chains,
@@ -76,6 +84,22 @@ func NewBackend(parentCtx context.Context, params BackendParams) *Backend {
 		cancel:                      cancel,
 		reorgRecoveryEnabled:        params.ReorgRecoveryEnabled,
 	}
+
+	// Refresh the metric from the combined failsafe state whenever a component's
+	// error state changes. Recomputing FailsafeEnabled() (rather than passing a
+	// bool) keeps the gauge correct when multiple chains or the cross-validator
+	// can independently hold failsafe on.
+	refresh := func() { b.metrics.RecordFailsafeEnabled(b.FailsafeEnabled()) }
+	for _, ingester := range b.chains {
+		if o, ok := ingester.(failsafeObserver); ok {
+			o.SetOnFailsafeChange(refresh)
+		}
+	}
+	if o, ok := b.crossValidator.(failsafeObserver); ok {
+		o.SetOnFailsafeChange(refresh)
+	}
+
+	return b
 }
 
 // Start starts all chain ingesters and the cross-validator

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -53,6 +53,9 @@ type Backend struct {
 
 	reorgRecoveryEnabled bool
 	reorgRecoveryWg      sync.WaitGroup
+
+	// failsafeWg tracks the periodic failsafe-heartbeat goroutine.
+	failsafeWg sync.WaitGroup
 }
 
 // BackendParams contains parameters for creating a Backend.
@@ -74,6 +77,10 @@ const (
 	failsafeReasonCrossValidation = "cross_validation"
 	failsafeReasonNone            = "none"
 )
+
+// failsafeHeartbeatInterval is how often the backend re-logs the active failsafe
+// reason while failsafe remains on, so the reason stays visible in recent logs.
+const failsafeHeartbeatInterval = time.Minute
 
 // allFailsafeReasons is the full set of reason labels the failsafe_reason_active
 // gauge can emit. Every refresh sets all of them so a cleared reason drops back
@@ -149,6 +156,9 @@ func (b *Backend) Start(ctx context.Context) error {
 		go b.runReorgRecovery(b.ctx)
 	}
 
+	b.failsafeWg.Add(1)
+	go b.runFailsafeHeartbeat(b.ctx)
+
 	return nil
 }
 
@@ -160,6 +170,7 @@ func (b *Backend) Stop(ctx context.Context) error {
 	var result error
 
 	b.reorgRecoveryWg.Wait()
+	b.failsafeWg.Wait()
 
 	if err := b.crossValidator.Stop(); err != nil {
 		result = errors.Join(result, fmt.Errorf("failed to stop cross-validator: %w", err))
@@ -229,7 +240,8 @@ func (b *Backend) refreshFailsafe() {
 	}
 	b.lastFailsafeSummary = summary
 	if enabled {
-		b.log.Warn("Failsafe active", "reasons", summary)
+		b.log.Warn("Failsafe active", "reasons", summary,
+			"detail", failsafeReasonDetail(manual, chainErrs, cvErr))
 	} else {
 		b.log.Info("Failsafe cleared")
 	}
@@ -259,6 +271,66 @@ func failsafeSummary(manual bool, chainErrs map[eth.ChainID]*IngesterError, cvEr
 		return failsafeReasonNone
 	}
 	return strings.Join(parts, ",")
+}
+
+// failsafeReasonDetail renders the active failsafe reasons together with each
+// source's underlying error message — the "why" behind the failsafe. Returns
+// failsafeReasonNone when nothing is active.
+func failsafeReasonDetail(manual bool, chainErrs map[eth.ChainID]*IngesterError, cvErr *ValidatorError) string {
+	var parts []string
+	if manual {
+		parts = append(parts, "manual override")
+	}
+	ids := make([]eth.ChainID, 0, len(chainErrs))
+	for id := range chainErrs {
+		ids = append(ids, id)
+	}
+	eth.SortChainID(ids)
+	for _, id := range ids {
+		ie := chainErrs[id]
+		parts = append(parts, fmt.Sprintf("chain[%s] %s: %s", id, ie.Reason, ie.Message))
+	}
+	if cvErr != nil {
+		parts = append(parts, fmt.Sprintf("cross-validation: %s", cvErr.Message))
+	}
+	if len(parts) == 0 {
+		return failsafeReasonNone
+	}
+	return strings.Join(parts, "; ")
+}
+
+// runFailsafeHeartbeat periodically re-logs the active failsafe reason while
+// failsafe remains on. The transition log in refreshFailsafe fires only once
+// (when the reason set changes), so without this a long-lived failsafe (e.g. a
+// reorg awaiting recovery) would stop appearing in recent logs.
+func (b *Backend) runFailsafeHeartbeat(ctx context.Context) {
+	defer b.failsafeWg.Done()
+
+	ticker := time.NewTicker(failsafeHeartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			b.logFailsafeIfActive()
+		}
+	}
+}
+
+// logFailsafeIfActive logs the current failsafe reasons at Warn if failsafe is
+// active; no-op otherwise.
+func (b *Backend) logFailsafeIfActive() {
+	manual := b.manualFailsafe.Load()
+	chainErrs := b.GetChainErrors()
+	cvErr := b.crossValidator.Error()
+	if !manual && len(chainErrs) == 0 && cvErr == nil {
+		return
+	}
+	b.log.Warn("Failsafe still active",
+		"reasons", failsafeSummary(manual, chainErrs, cvErr),
+		"detail", failsafeReasonDetail(manual, chainErrs, cvErr))
 }
 
 // GetChainErrors returns all chains that are in an error state

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -54,8 +54,10 @@ type Backend struct {
 	reorgRecoveryEnabled bool
 	reorgRecoveryWg      sync.WaitGroup
 
-	// failsafeWg tracks the periodic failsafe-heartbeat goroutine.
-	failsafeWg sync.WaitGroup
+	// failsafeLogInterval is how often the active failsafe reason is re-logged
+	// while failsafe is enabled. failsafeWg tracks that heartbeat goroutine.
+	failsafeLogInterval time.Duration
+	failsafeWg          sync.WaitGroup
 }
 
 // BackendParams contains parameters for creating a Backend.
@@ -68,6 +70,7 @@ type BackendParams struct {
 	LegacyCheckAccessListFormat bool
 
 	ReorgRecoveryEnabled bool
+	FailsafeLogInterval  time.Duration
 }
 
 // Failsafe reason labels that are not chain-ingester errors. Chain errors use
@@ -78,9 +81,10 @@ const (
 	failsafeReasonNone            = "none"
 )
 
-// failsafeHeartbeatInterval is how often the backend re-logs the active failsafe
-// reason while failsafe remains on, so the reason stays visible in recent logs.
-const failsafeHeartbeatInterval = time.Minute
+// defaultFailsafeLogInterval is the fallback heartbeat interval used when
+// BackendParams.FailsafeLogInterval is unset (e.g. in tests). Production wires
+// the --failsafe-log-interval flag (also defaulting to 1m).
+const defaultFailsafeLogInterval = time.Minute
 
 // allFailsafeReasons is the full set of reason labels the failsafe_reason_active
 // gauge can emit. Every refresh sets all of them so a cleared reason drops back
@@ -116,6 +120,10 @@ func NewBackend(parentCtx context.Context, params BackendParams) *Backend {
 		ctx:                         ctx,
 		cancel:                      cancel,
 		reorgRecoveryEnabled:        params.ReorgRecoveryEnabled,
+		failsafeLogInterval:         params.FailsafeLogInterval,
+	}
+	if b.failsafeLogInterval <= 0 {
+		b.failsafeLogInterval = defaultFailsafeLogInterval
 	}
 
 	// Initialize so the first benign refresh (state == off) does not log a
@@ -306,7 +314,7 @@ func failsafeReasonDetail(manual bool, chainErrs map[eth.ChainID]*IngesterError,
 func (b *Backend) runFailsafeHeartbeat(ctx context.Context) {
 	defer b.failsafeWg.Done()
 
-	ticker := time.NewTicker(failsafeHeartbeatInterval)
+	ticker := time.NewTicker(b.failsafeLogInterval)
 	defer ticker.Stop()
 
 	for {

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -36,6 +38,11 @@ type Backend struct {
 	// Manual failsafe override
 	manualFailsafe atomic.Bool
 
+	// failsafeMu serializes failsafe metric/log refreshes so concurrent error
+	// transitions cannot latch a stale gauge value or interleave log lines.
+	failsafeMu          sync.Mutex
+	lastFailsafeSummary string
+
 	// Passthrough mode: all transactions pass without filtering
 	passthrough bool
 
@@ -61,9 +68,29 @@ type BackendParams struct {
 	ReorgRecoveryEnabled bool
 }
 
+// Failsafe reason labels that are not chain-ingester errors. Chain errors use
+// IngesterErrorReason.String() (reorg, conflict, data_corruption, invalid_log).
+const (
+	failsafeReasonManual          = "manual"
+	failsafeReasonCrossValidation = "cross_validation"
+	failsafeReasonNone            = "none"
+)
+
+// allFailsafeReasons is the full set of reason labels the failsafe_reason_active
+// gauge can emit. Every refresh sets all of them so a cleared reason drops back
+// to 0 instead of holding its last value.
+var allFailsafeReasons = []string{
+	failsafeReasonManual,
+	ErrorReorg.String(),
+	ErrorConflict.String(),
+	ErrorDataCorruption.String(),
+	ErrorInvalidExecutingMessage.String(),
+	failsafeReasonCrossValidation,
+}
+
 // failsafeObserver is implemented by components whose error state feeds into
-// FailsafeEnabled. The backend wires a callback so the failsafe_enabled metric
-// is refreshed whenever a component enters or clears its error state, not only
+// FailsafeEnabled. The backend wires a callback so the failsafe metrics and logs
+// are refreshed whenever a component enters or clears its error state, not only
 // on the manual SetFailsafeEnabled path.
 type failsafeObserver interface {
 	SetOnFailsafeChange(func())
@@ -85,18 +112,20 @@ func NewBackend(parentCtx context.Context, params BackendParams) *Backend {
 		reorgRecoveryEnabled:        params.ReorgRecoveryEnabled,
 	}
 
-	// Refresh the metric from the combined failsafe state whenever a component's
-	// error state changes. Recomputing FailsafeEnabled() (rather than passing a
-	// bool) keeps the gauge correct when multiple chains or the cross-validator
-	// can independently hold failsafe on.
-	refresh := func() { b.metrics.RecordFailsafeEnabled(b.FailsafeEnabled()) }
+	// Initialize so the first benign refresh (state == off) does not log a
+	// spurious "cleared" transition.
+	b.lastFailsafeSummary = failsafeReasonNone
+
+	// Refresh failsafe metrics/logs whenever a component's error state changes,
+	// so auto-triggered failsafe (chain or cross-validator errors) is reflected,
+	// not just the manual SetFailsafeEnabled path.
 	for _, ingester := range b.chains {
 		if o, ok := ingester.(failsafeObserver); ok {
-			o.SetOnFailsafeChange(refresh)
+			o.SetOnFailsafeChange(b.refreshFailsafe)
 		}
 	}
 	if o, ok := b.crossValidator.(failsafeObserver); ok {
-		o.SetOnFailsafeChange(refresh)
+		o.SetOnFailsafeChange(b.refreshFailsafe)
 	}
 
 	return b
@@ -155,7 +184,82 @@ func (b *Backend) FailsafeEnabled() bool {
 // SetFailsafeEnabled sets the manual failsafe override.
 func (b *Backend) SetFailsafeEnabled(enabled bool) {
 	b.manualFailsafe.Store(enabled)
-	b.metrics.RecordFailsafeEnabled(b.FailsafeEnabled())
+	b.refreshFailsafe()
+}
+
+// refreshFailsafe recomputes the failsafe metrics and logs reason transitions.
+// It is the single choke point for failsafe observability: invoked on the manual
+// toggle and via the onFailsafeChange callback whenever a chain ingester or the
+// cross-validator changes error state.
+//
+// failsafeMu serializes compute+record+log so concurrent transitions cannot
+// latch a stale gauge value (the last writer observes all completed state
+// changes) or interleave log lines.
+func (b *Backend) refreshFailsafe() {
+	b.failsafeMu.Lock()
+	defer b.failsafeMu.Unlock()
+
+	manual := b.manualFailsafe.Load()
+	chainErrs := b.GetChainErrors()
+	cvErr := b.crossValidator.Error()
+
+	enabled := manual || len(chainErrs) > 0 || cvErr != nil
+
+	// Build the active-reason set (deduped across chains: a reason is "active"
+	// if at least one source currently holds it).
+	active := make(map[string]bool, len(allFailsafeReasons))
+	if manual {
+		active[failsafeReasonManual] = true
+	}
+	for _, ie := range chainErrs {
+		active[ie.Reason.String()] = true
+	}
+	if cvErr != nil {
+		active[failsafeReasonCrossValidation] = true
+	}
+
+	b.metrics.RecordFailsafeEnabled(enabled)
+	for _, reason := range allFailsafeReasons {
+		b.metrics.RecordFailsafeReason(reason, active[reason])
+	}
+
+	// Log only when the reason set changes, to avoid spam from frequent refreshes.
+	summary := failsafeSummary(manual, chainErrs, cvErr)
+	if summary == b.lastFailsafeSummary {
+		return
+	}
+	b.lastFailsafeSummary = summary
+	if enabled {
+		b.log.Warn("Failsafe active", "reasons", summary)
+	} else {
+		b.log.Info("Failsafe cleared")
+	}
+}
+
+// failsafeSummary renders the active failsafe reasons as a stable, greppable
+// string with per-chain detail, e.g. "manual,chain[901]=reorg,cross_validation".
+// Returns failsafeReasonNone when nothing is active. Chain IDs are sorted for
+// deterministic output (so change-detection logging does not fire spuriously).
+func failsafeSummary(manual bool, chainErrs map[eth.ChainID]*IngesterError, cvErr *ValidatorError) string {
+	var parts []string
+	if manual {
+		parts = append(parts, failsafeReasonManual)
+	}
+	ids := make([]eth.ChainID, 0, len(chainErrs))
+	for id := range chainErrs {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i].String() < ids[j].String() })
+	for _, id := range ids {
+		parts = append(parts, fmt.Sprintf("chain[%s]=%s", id, chainErrs[id].Reason))
+	}
+	if cvErr != nil {
+		parts = append(parts, failsafeReasonCrossValidation)
+	}
+	if len(parts) == 0 {
+		return failsafeReasonNone
+	}
+	return strings.Join(parts, ",")
 }
 
 // GetChainErrors returns all chains that are in an error state

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -249,7 +248,7 @@ func failsafeSummary(manual bool, chainErrs map[eth.ChainID]*IngesterError, cvEr
 	for id := range chainErrs {
 		ids = append(ids, id)
 	}
-	sort.Slice(ids, func(i, j int) bool { return ids[i].String() < ids[j].String() })
+	eth.SortChainID(ids) // numeric (not lexicographic) order for stable, readable summaries
 	for _, id := range ids {
 		parts = append(parts, fmt.Sprintf("chain[%s]=%s", id, chainErrs[id].Reason))
 	}

--- a/op-interop-filter/filter/backend_test.go
+++ b/op-interop-filter/filter/backend_test.go
@@ -2,6 +2,8 @@ package filter
 
 import (
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -180,4 +182,96 @@ func TestBackend_CheckAccessList_SupportLegacyCheckAccessListFormat(t *testing.T
 
 	err := backend.CheckAccessList(context.Background(), nil, safety.LocalUnsafe, makeExecDescriptor(0, 150, 0))
 	require.NoError(t, err)
+}
+
+// =============================================================================
+// Failsafe reason logging
+// =============================================================================
+
+func TestFailsafeReasonDetail(t *testing.T) {
+	chain900 := eth.ChainIDFromUInt64(900)
+	chain1000 := eth.ChainIDFromUInt64(1000)
+
+	tests := []struct {
+		name      string
+		manual    bool
+		chainErrs map[eth.ChainID]*IngesterError
+		cvErr     *ValidatorError
+		want      string
+	}{
+		{
+			name: "none active",
+			want: failsafeReasonNone,
+		},
+		{
+			name:   "manual only",
+			manual: true,
+			want:   "manual override",
+		},
+		{
+			name:      "chain error includes reason and message",
+			chainErrs: map[eth.ChainID]*IngesterError{chain900: {Reason: ErrorReorg, Message: "parent hash mismatch at block 175901"}},
+			want:      "chain[900] reorg: parent hash mismatch at block 175901",
+		},
+		{
+			name:  "cross-validation includes message",
+			cvErr: &ValidatorError{Message: "invalid executing message at ts 42"},
+			want:  "cross-validation: invalid executing message at ts 42",
+		},
+		{
+			name:      "combined sources joined with semicolons",
+			manual:    true,
+			chainErrs: map[eth.ChainID]*IngesterError{chain900: {Reason: ErrorConflict, Message: "db conflict"}},
+			cvErr:     &ValidatorError{Message: "validation failed"},
+			want:      "manual override; chain[900] conflict: db conflict; cross-validation: validation failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, failsafeReasonDetail(tt.manual, tt.chainErrs, tt.cvErr))
+		})
+	}
+
+	t.Run("chains ordered numerically not lexicographically", func(t *testing.T) {
+		errs := map[eth.ChainID]*IngesterError{
+			chain1000: {Reason: ErrorReorg, Message: "r1000"},
+			chain900:  {Reason: ErrorReorg, Message: "r900"},
+		}
+		got := failsafeReasonDetail(false, errs, nil)
+		require.Less(t, strings.Index(got, "chain[900]"), strings.Index(got, "chain[1000]"),
+			"chains must be ordered numerically, got %q", got)
+	})
+}
+
+func TestBackend_FailsafeHeartbeat_LogsReasonWhileActive(t *testing.T) {
+	logger, logs := testlog.CaptureLogger(t, log.LevelInfo)
+	mock := newMockChainIngester()
+	b := NewBackend(context.Background(), BackendParams{
+		Logger:         logger,
+		Metrics:        metrics.NoopMetrics,
+		Chains:         map[eth.ChainID]ChainIngester{eth.ChainIDFromUInt64(testChainA): mock},
+		CrossValidator: &mockCrossValidator{},
+	})
+
+	const heartbeatMsg = "Failsafe still active"
+
+	// Not in failsafe -> heartbeat is silent.
+	b.logFailsafeIfActive()
+	require.Nil(t, logs.FindLog(testlog.NewMessageFilter(heartbeatMsg)),
+		"heartbeat must not log when failsafe is inactive")
+
+	// In failsafe -> heartbeat logs the reason and the underlying "why" at Warn.
+	mock.SetError(ErrorReorg, "parent hash mismatch at block 175901")
+	b.logFailsafeIfActive()
+	rec := logs.FindLog(testlog.NewMessageFilter(heartbeatMsg), testlog.NewLevelFilter(slog.LevelWarn))
+	require.NotNil(t, rec, "heartbeat must log at Warn while failsafe is active")
+	require.Contains(t, rec.AttrValue("reasons"), "reorg")
+	require.Contains(t, rec.AttrValue("detail"), "parent hash mismatch at block 175901")
+
+	// Cleared -> heartbeat goes silent again.
+	logs.Clear()
+	mock.ClearError()
+	b.logFailsafeIfActive()
+	require.Nil(t, logs.FindLog(testlog.NewMessageFilter(heartbeatMsg)),
+		"heartbeat must stop once failsafe clears")
 }

--- a/op-interop-filter/filter/backend_test.go
+++ b/op-interop-filter/filter/backend_test.go
@@ -275,3 +275,21 @@ func TestBackend_FailsafeHeartbeat_LogsReasonWhileActive(t *testing.T) {
 	require.Nil(t, logs.FindLog(testlog.NewMessageFilter(heartbeatMsg)),
 		"heartbeat must stop once failsafe clears")
 }
+
+func TestBackend_FailsafeLogInterval_Configured(t *testing.T) {
+	newBackend := func(interval time.Duration) *Backend {
+		return NewBackend(context.Background(), BackendParams{
+			Logger:              testlog.Logger(t, log.LevelError),
+			Metrics:             metrics.NoopMetrics,
+			Chains:              map[eth.ChainID]ChainIngester{},
+			CrossValidator:      &mockCrossValidator{},
+			FailsafeLogInterval: interval,
+		})
+	}
+
+	// Configured interval is honored.
+	require.Equal(t, 15*time.Second, newBackend(15*time.Second).failsafeLogInterval)
+
+	// Unset (zero) falls back to the default — guards against time.NewTicker(0) panicking.
+	require.Equal(t, defaultFailsafeLogInterval, newBackend(0).failsafeLogInterval)
+}

--- a/op-interop-filter/filter/config.go
+++ b/op-interop-filter/filter/config.go
@@ -72,9 +72,10 @@ func (c *Config) Check() error {
 	if c.ValidationInterval <= 0 {
 		result = errors.Join(result, errors.New("validation-interval must be positive"))
 	}
-	if c.FailsafeLogInterval <= 0 {
-		result = errors.Join(result, errors.New("failsafe-log-interval must be positive"))
-	}
+	// FailsafeLogInterval is intentionally not required: a zero value means
+	// "use the default" and is defaulted to defaultFailsafeLogInterval by the
+	// backend. The CLI flag defaults to 1m, and callers that build Config
+	// directly (e.g. tests) may leave it unset.
 	if c.RPCConcurrency <= 0 {
 		result = errors.Join(result, errors.New("rpc-concurrency must be positive"))
 	}

--- a/op-interop-filter/filter/config.go
+++ b/op-interop-filter/filter/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	Version                     string
 	PollInterval                time.Duration // Interval for polling new blocks (default: 2s)
 	ValidationInterval          time.Duration // Interval for cross-chain validation (default: 500ms)
+	FailsafeLogInterval         time.Duration // Interval for re-logging the active failsafe reason (default: 1m)
 	ReorgRecoveryEnabled        bool          // If true, automatically rewinds reorg-triggered failsafe to finalized
 	Passthrough                 bool          // If true, all transactions pass through without filtering
 	LegacyCheckAccessListFormat bool          // If true, allows access list requests that omit executing chainID
@@ -70,6 +71,9 @@ func (c *Config) Check() error {
 	}
 	if c.ValidationInterval <= 0 {
 		result = errors.Join(result, errors.New("validation-interval must be positive"))
+	}
+	if c.FailsafeLogInterval <= 0 {
+		result = errors.Join(result, errors.New("failsafe-log-interval must be positive"))
 	}
 	if c.RPCConcurrency <= 0 {
 		result = errors.Join(result, errors.New("rpc-concurrency must be positive"))
@@ -108,6 +112,10 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 	if validationInterval <= 0 {
 		return nil, fmt.Errorf("validation-interval must be positive, got %s", validationInterval)
 	}
+	failsafeLogInterval := ctx.Duration(flags.FailsafeLogIntervalFlag.Name)
+	if failsafeLogInterval <= 0 {
+		return nil, fmt.Errorf("failsafe-log-interval must be positive, got %s", failsafeLogInterval)
+	}
 	rpcConcurrency := ctx.Int(flags.RPCConcurrencyFlag.Name)
 	if rpcConcurrency <= 0 {
 		return nil, fmt.Errorf("rpc-concurrency must be positive, got %d", rpcConcurrency)
@@ -144,6 +152,7 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 		Version:                     version,
 		PollInterval:                pollInterval,
 		ValidationInterval:          validationInterval,
+		FailsafeLogInterval:         failsafeLogInterval,
 		ReorgRecoveryEnabled:        ctx.Bool(flags.ReorgRecoveryEnabledFlag.Name),
 		Passthrough:                 ctx.Bool(flags.DangerouslyEnablePassthroughFlag.Name),
 		LegacyCheckAccessListFormat: ctx.Bool(flags.SupportLegacyCheckAccessListFormatFlag.Name),

--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -50,6 +50,10 @@ type LockstepCrossValidator struct {
 	errMu sync.RWMutex
 	err   *ValidatorError
 
+	// onFailsafeChange, if set, is invoked after the error state changes so the
+	// backend can refresh the failsafe metric. Set once before Start.
+	onFailsafeChange func()
+
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -108,10 +112,22 @@ func (v *LockstepCrossValidator) Error() *ValidatorError {
 // setError sets the validation error state.
 func (v *LockstepCrossValidator) setError(msg string) {
 	v.errMu.Lock()
-	defer v.errMu.Unlock()
 	v.err = &ValidatorError{
 		Message: msg,
 	}
+	v.errMu.Unlock()
+
+	// Invoke after releasing errMu: the callback recomputes the backend's
+	// combined failsafe state, which reads Error() and would re-acquire errMu.
+	if v.onFailsafeChange != nil {
+		v.onFailsafeChange()
+	}
+}
+
+// SetOnFailsafeChange registers a callback invoked after the error state
+// changes. Used by the backend to keep the failsafe metric in sync.
+func (v *LockstepCrossValidator) SetOnFailsafeChange(fn func()) {
+	v.onFailsafeChange = fn
 }
 
 // CrossValidatedTimestamp returns the global cross-validated timestamp.

--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -109,7 +109,11 @@ func (v *LockstepCrossValidator) Error() *ValidatorError {
 	return v.err
 }
 
-// setError sets the validation error state.
+// setError sets the validation error state. There is intentionally no clear
+// path today: the cross-validator does not self-recover, so its error — and the
+// failsafe_reason_active{reason="cross_validation"} gauge — clears only on
+// process restart. If a recovery path is ever added, it MUST also fire
+// onFailsafeChange so the failsafe metrics drop back accordingly.
 func (v *LockstepCrossValidator) setError(msg string) {
 	v.errMu.Lock()
 	v.err = &ValidatorError{

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -66,6 +66,10 @@ type LogsDBChainIngester struct {
 
 	errorState atomic.Pointer[IngesterError]
 
+	// onFailsafeChange, if set, is invoked after the error state changes so the
+	// backend can refresh the failsafe metric. Set once before Start.
+	onFailsafeChange func()
+
 	earliestIngestedBlock    atomic.Uint64
 	earliestIngestedBlockSet atomic.Bool
 
@@ -208,6 +212,16 @@ func (c *LogsDBChainIngester) SetError(reason IngesterErrorReason, msg string) {
 	if reason == ErrorReorg || reason == ErrorConflict {
 		c.metrics.RecordReorgDetected(chainIDUint64)
 	}
+
+	if c.onFailsafeChange != nil {
+		c.onFailsafeChange()
+	}
+}
+
+// SetOnFailsafeChange registers a callback invoked after the error state
+// changes. Used by the backend to keep the failsafe metric in sync.
+func (c *LogsDBChainIngester) SetOnFailsafeChange(fn func()) {
+	c.onFailsafeChange = fn
 }
 
 // Error returns the current error state, or nil if no error.
@@ -219,6 +233,10 @@ func (c *LogsDBChainIngester) Error() *IngesterError {
 func (c *LogsDBChainIngester) ClearError() {
 	c.errorState.Store(nil)
 	c.log.Info("Ingester error state cleared")
+
+	if c.onFailsafeChange != nil {
+		c.onFailsafeChange()
+	}
 }
 
 // Contains checks if a log exists in the database

--- a/op-interop-filter/filter/logsdb_integration_backend_test.go
+++ b/op-interop-filter/filter/logsdb_integration_backend_test.go
@@ -55,6 +55,40 @@ func TestIntegration_Backend_IngesterErrorTripsFailsafe(t *testing.T) {
 	bk.requireRejection(executingChain(), inclusionTs, "failsafe", bk.sourceAccess(100, 0))
 }
 
+func TestIntegration_Backend_MultipleFailsafeReasons_Reflected(t *testing.T) {
+	t.Parallel()
+
+	bk := twoChainBackend(t, 1)
+	require.False(t, bk.metrics.failsafeMetric(), "metric starts off")
+
+	// Three concurrent reasons: manual override + two chains erroring with
+	// different reasons.
+	bk.SetFailsafeEnabled(true)
+	bk.ingesters[eth.ChainIDFromUInt64(901)].SetError(ErrorReorg, "forced")
+	bk.ingesters[eth.ChainIDFromUInt64(902)].SetError(ErrorConflict, "forced")
+
+	require.True(t, bk.metrics.failsafeMetric())
+	require.True(t, bk.metrics.failsafeReasonActive(failsafeReasonManual))
+	require.True(t, bk.metrics.failsafeReasonActive(ErrorReorg.String()))
+	require.True(t, bk.metrics.failsafeReasonActive(ErrorConflict.String()))
+	require.False(t, bk.metrics.failsafeReasonActive(failsafeReasonCrossValidation))
+
+	// Clearing the reorg chain drops only the reorg reason; the rest remain.
+	bk.ingesters[eth.ChainIDFromUInt64(901)].ClearError()
+	require.True(t, bk.metrics.failsafeMetric())
+	require.False(t, bk.metrics.failsafeReasonActive(ErrorReorg.String()),
+		"reorg reason must drop once no chain holds it")
+	require.True(t, bk.metrics.failsafeReasonActive(ErrorConflict.String()))
+	require.True(t, bk.metrics.failsafeReasonActive(failsafeReasonManual))
+
+	// Clearing the last chain error and the manual override drops everything.
+	bk.ingesters[eth.ChainIDFromUInt64(902)].ClearError()
+	bk.SetFailsafeEnabled(false)
+	require.False(t, bk.metrics.failsafeMetric())
+	require.False(t, bk.metrics.failsafeReasonActive(failsafeReasonManual))
+	require.False(t, bk.metrics.failsafeReasonActive(ErrorConflict.String()))
+}
+
 func TestIntegration_Backend_RPCSetFailsafe_UpdatesMetric(t *testing.T) {
 	t.Parallel()
 

--- a/op-interop-filter/filter/logsdb_integration_backend_test.go
+++ b/op-interop-filter/filter/logsdb_integration_backend_test.go
@@ -55,6 +55,55 @@ func TestIntegration_Backend_IngesterErrorTripsFailsafe(t *testing.T) {
 	bk.requireRejection(executingChain(), inclusionTs, "failsafe", bk.sourceAccess(100, 0))
 }
 
+func TestIntegration_Backend_RPCSetFailsafe_UpdatesMetric(t *testing.T) {
+	t.Parallel()
+
+	bk := twoChainBackend(t, 1)
+	require.False(t, bk.metrics.failsafeMetric(), "metric starts off")
+
+	// Drive the actual admin RPC handler, not just the backend method.
+	admin := &AdminFrontend{backend: bk.Backend}
+
+	require.NoError(t, admin.SetFailsafeEnabled(context.Background(), true))
+	require.True(t, bk.FailsafeEnabled())
+	require.True(t, bk.metrics.failsafeMetric(),
+		"admin_setFailsafeEnabled(true) must flip the metric on")
+
+	require.NoError(t, admin.SetFailsafeEnabled(context.Background(), false))
+	require.False(t, bk.FailsafeEnabled())
+	require.False(t, bk.metrics.failsafeMetric(),
+		"admin_setFailsafeEnabled(false) must flip the metric off")
+}
+
+func TestIntegration_Backend_AutoFailsafe_UpdatesMetric(t *testing.T) {
+	t.Parallel()
+
+	bk := twoChainBackend(t, 1)
+	require.False(t, bk.metrics.failsafeMetric(), "metric starts off")
+
+	// Auto-trip via an ingester error, without any manual SetFailsafeEnabled call.
+	bk.ingesters[eth.ChainIDFromUInt64(901)].SetError(ErrorConflict, "forced")
+	require.True(t, bk.FailsafeEnabled())
+	require.True(t, bk.metrics.failsafeMetric(),
+		"ingester error must flip the failsafe metric on")
+
+	// A second chain entering error keeps the metric on.
+	bk.ingesters[eth.ChainIDFromUInt64(902)].SetError(ErrorConflict, "forced")
+	require.True(t, bk.metrics.failsafeMetric())
+
+	// Clearing one chain while another still errors must NOT report failsafe off.
+	bk.ingesters[eth.ChainIDFromUInt64(901)].ClearError()
+	require.True(t, bk.FailsafeEnabled())
+	require.True(t, bk.metrics.failsafeMetric(),
+		"metric must stay on while another chain still errors")
+
+	// Clearing the last error flips the metric off.
+	bk.ingesters[eth.ChainIDFromUInt64(902)].ClearError()
+	require.False(t, bk.FailsafeEnabled())
+	require.False(t, bk.metrics.failsafeMetric(),
+		"metric must clear once all errors clear")
+}
+
 func TestIntegration_Backend_RecoverReorg_ClearsFailsafe(t *testing.T) {
 	t.Parallel()
 

--- a/op-interop-filter/filter/logsdb_integration_helpers_test.go
+++ b/op-interop-filter/filter/logsdb_integration_helpers_test.go
@@ -487,12 +487,14 @@ func (sb *seededBackend) requireAccepted(execChain eth.ChainID, execTs uint64, a
 // =============================================================================
 
 type capturingMetrics struct {
-	mu          sync.Mutex
-	rejections  map[string]int
-	reorgs      map[uint64]int
-	blockSealed map[uint64]int64
-	logsAdded   map[uint64]int64
-	chainHead   map[uint64]uint64
+	mu             sync.Mutex
+	rejections     map[string]int
+	reorgs         map[uint64]int
+	blockSealed    map[uint64]int64
+	logsAdded      map[uint64]int64
+	chainHead      map[uint64]uint64
+	failsafeGauge  bool
+	failsafeWrites int
 }
 
 func newCapturingMetrics() *capturingMetrics {
@@ -523,9 +525,21 @@ func (m *capturingMetrics) sealedCount(chainID uint64) int64 {
 	return m.blockSealed[chainID]
 }
 
-func (m *capturingMetrics) RecordInfo(version string)          {}
-func (m *capturingMetrics) RecordUp()                          {}
-func (m *capturingMetrics) RecordFailsafeEnabled(enabled bool) {}
+func (m *capturingMetrics) RecordInfo(version string) {}
+func (m *capturingMetrics) RecordUp()                 {}
+func (m *capturingMetrics) RecordFailsafeEnabled(enabled bool) {
+	m.locked(func() {
+		m.failsafeGauge = enabled
+		m.failsafeWrites++
+	})
+}
+
+// failsafeMetric returns the last value passed to RecordFailsafeEnabled.
+func (m *capturingMetrics) failsafeMetric() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.failsafeGauge
+}
 func (m *capturingMetrics) RecordChainHead(chainID uint64, blockNum uint64) {
 	m.locked(func() { m.chainHead[chainID] = blockNum })
 }

--- a/op-interop-filter/filter/logsdb_integration_helpers_test.go
+++ b/op-interop-filter/filter/logsdb_integration_helpers_test.go
@@ -487,23 +487,24 @@ func (sb *seededBackend) requireAccepted(execChain eth.ChainID, execTs uint64, a
 // =============================================================================
 
 type capturingMetrics struct {
-	mu             sync.Mutex
-	rejections     map[string]int
-	reorgs         map[uint64]int
-	blockSealed    map[uint64]int64
-	logsAdded      map[uint64]int64
-	chainHead      map[uint64]uint64
-	failsafeGauge  bool
-	failsafeWrites int
+	mu              sync.Mutex
+	rejections      map[string]int
+	reorgs          map[uint64]int
+	blockSealed     map[uint64]int64
+	logsAdded       map[uint64]int64
+	chainHead       map[uint64]uint64
+	failsafeGauge   bool
+	failsafeReasons map[string]bool
 }
 
 func newCapturingMetrics() *capturingMetrics {
 	return &capturingMetrics{
-		rejections:  map[string]int{},
-		reorgs:      map[uint64]int{},
-		blockSealed: map[uint64]int64{},
-		logsAdded:   map[uint64]int64{},
-		chainHead:   map[uint64]uint64{},
+		rejections:      map[string]int{},
+		reorgs:          map[uint64]int{},
+		blockSealed:     map[uint64]int64{},
+		logsAdded:       map[uint64]int64{},
+		chainHead:       map[uint64]uint64{},
+		failsafeReasons: map[string]bool{},
 	}
 }
 
@@ -528,10 +529,11 @@ func (m *capturingMetrics) sealedCount(chainID uint64) int64 {
 func (m *capturingMetrics) RecordInfo(version string) {}
 func (m *capturingMetrics) RecordUp()                 {}
 func (m *capturingMetrics) RecordFailsafeEnabled(enabled bool) {
-	m.locked(func() {
-		m.failsafeGauge = enabled
-		m.failsafeWrites++
-	})
+	m.locked(func() { m.failsafeGauge = enabled })
+}
+
+func (m *capturingMetrics) RecordFailsafeReason(reason string, active bool) {
+	m.locked(func() { m.failsafeReasons[reason] = active })
 }
 
 // failsafeMetric returns the last value passed to RecordFailsafeEnabled.
@@ -539,6 +541,13 @@ func (m *capturingMetrics) failsafeMetric() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.failsafeGauge
+}
+
+// failsafeReasonActive returns the last value recorded for the given reason.
+func (m *capturingMetrics) failsafeReasonActive(reason string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.failsafeReasons[reason]
 }
 func (m *capturingMetrics) RecordChainHead(chainID uint64, blockNum uint64) {
 	m.locked(func() { m.chainHead[chainID] = blockNum })

--- a/op-interop-filter/filter/logsdb_integration_helpers_test.go
+++ b/op-interop-filter/filter/logsdb_integration_helpers_test.go
@@ -549,6 +549,7 @@ func (m *capturingMetrics) failsafeReasonActive(reason string) bool {
 	defer m.mu.Unlock()
 	return m.failsafeReasons[reason]
 }
+
 func (m *capturingMetrics) RecordChainHead(chainID uint64, blockNum uint64) {
 	m.locked(func() { m.chainHead[chainID] = blockNum })
 }

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -232,6 +232,7 @@ func (s *Service) initBackend(ctx context.Context, cfg *Config) error {
 		LegacyCheckAccessListFormat: cfg.LegacyCheckAccessListFormat,
 
 		ReorgRecoveryEnabled: cfg.ReorgRecoveryEnabled,
+		FailsafeLogInterval:  cfg.FailsafeLogInterval,
 	})
 
 	s.log.Info("Created backend", "chains", len(chains))

--- a/op-interop-filter/flags/flags.go
+++ b/op-interop-filter/flags/flags.go
@@ -109,6 +109,12 @@ var (
 		Usage:   "Automatically resolve reorg-triggered failsafe by rewinding logs DBs to finalized.",
 		EnvVars: prefixEnvVars("REORG_RECOVERY_ENABLED"),
 	}
+	FailsafeLogIntervalFlag = &cli.DurationFlag{
+		Name:    "failsafe-log-interval",
+		Usage:   "Interval at which the active failsafe reason is re-logged while failsafe is enabled (e.g., 1m, 30s)",
+		EnvVars: prefixEnvVars("FAILSAFE_LOG_INTERVAL"),
+		Value:   time.Minute,
+	}
 	RPCConcurrencyFlag = &cli.IntFlag{
 		Name:    "rpc-concurrency",
 		Usage:   "Maximum number of concurrent RPC requests per chain",
@@ -151,6 +157,7 @@ var optionalFlags = []cli.Flag{
 	PollIntervalFlag,
 	ValidationIntervalFlag,
 	ReorgRecoveryEnabledFlag,
+	FailsafeLogIntervalFlag,
 	RPCConcurrencyFlag,
 	FetchConcurrencyFlag,
 	SupportLegacyCheckAccessListFormatFlag,

--- a/op-interop-filter/metrics/metrics.go
+++ b/op-interop-filter/metrics/metrics.go
@@ -14,6 +14,7 @@ type Metricer interface {
 	RecordInfo(version string)
 	RecordUp()
 	RecordFailsafeEnabled(enabled bool)
+	RecordFailsafeReason(reason string, active bool)
 	RecordChainHead(chainID uint64, blockNum uint64)
 	RecordChainTip(chainID uint64, blockNum uint64)
 	RecordTipLagBlocks(chainID uint64, lag uint64)
@@ -36,6 +37,7 @@ type Metrics struct {
 	info                     *prometheus.GaugeVec
 	up                       prometheus.Gauge
 	failsafeEnabled          prometheus.Gauge
+	failsafeReason           *prometheus.GaugeVec
 	chainHead                *prometheus.GaugeVec
 	checkAccessTotal         *prometheus.CounterVec
 	checkAccessListDuration  prometheus.Histogram
@@ -87,6 +89,12 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "failsafe_enabled",
 			Help:      "1 if failsafe is enabled",
 		}),
+
+		failsafeReason: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "failsafe_reason_active",
+			Help:      "1 if the given reason is currently forcing failsafe on; multiple reasons may be active at once",
+		}, []string{"reason"}),
 
 		chainHead: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
@@ -187,6 +195,14 @@ func (m *Metrics) RecordFailsafeEnabled(enabled bool) {
 	}
 }
 
+func (m *Metrics) RecordFailsafeReason(reason string, active bool) {
+	v := 0.0
+	if active {
+		v = 1.0
+	}
+	m.failsafeReason.WithLabelValues(reason).Set(v)
+}
+
 func (m *Metrics) RecordChainHead(chainID uint64, blockNum uint64) {
 	m.chainHead.WithLabelValues(strconv.FormatUint(chainID, 10)).Set(float64(blockNum))
 }
@@ -247,6 +263,7 @@ type noopMetrics struct{}
 func (n *noopMetrics) RecordInfo(version string)                               {}
 func (n *noopMetrics) RecordUp()                                               {}
 func (n *noopMetrics) RecordFailsafeEnabled(enabled bool)                      {}
+func (n *noopMetrics) RecordFailsafeReason(reason string, active bool)         {}
 func (n *noopMetrics) RecordChainHead(chainID uint64, blockNum uint64)         {}
 func (n *noopMetrics) RecordChainTip(chainID uint64, blockNum uint64)          {}
 func (n *noopMetrics) RecordTipLagBlocks(chainID uint64, lag uint64)           {}


### PR DESCRIPTION
## Problem

The `failsafe_enabled` gauge was wrong in two ways:

1. **It only reflected the manual toggle.** Observed in prod: `admin_getFailsafeEnabled` returned `true` while `op_interop_filter_default_failsafe_enabled` read `0`. Failsafe entered automatically via a chain ingester error or a cross-validator error never updated the gauge, and reorg auto-recovery clearing an error didn't either.

2. **It collapsed multiple reasons into one boolean.** Failsafe can be on for several reasons at once — manual override, one-or-more chain ingester errors (each with its own reason: `reorg` / `conflict` / `data_corruption` / `invalid_log`), and a cross-validator error — with no way to see which, or which chain.

## Changes

**Commit 1 — reflect auto-triggered failsafe.** Wire an `onFailsafeChange` callback into the ingester (`SetError`/`ClearError`) and cross-validator (`setError`); the backend records the recomputed combined `FailsafeEnabled()`. The callback recomputes (rather than pushing a bool) so the gauge stays correct when multiple chains/validator hold failsafe independently — clearing one chain while another errors keeps it at 1. The cross-validator fires after releasing `errMu` to avoid re-acquiring the RWMutex via `Error()`.

**Commit 2 — per-reason metric + logs.**
- New gauge `failsafe_reason_active{reason}` with `reason ∈ {manual, reorg, conflict, data_corruption, invalid_log, cross_validation}`. Multiple series read `1` simultaneously, so you can see *all* active reasons. Every refresh sets all reasons, so a cleared one drops back to `0`.
- New consolidated log `"Failsafe active" reasons=manual,chain[901]=reorg,cross_validation` (per-chain detail), emitted only when the reason set changes (deduped to avoid spam).
- All failsafe observability funnels through one `refreshFailsafe` method, **serialized by `failsafeMu`** so concurrent error transitions can't latch a stale gauge value (last writer observes all completed state changes) or interleave log lines. This also removes the previously-duplicated record call in `SetFailsafeEnabled`.

`failsafe_enabled` (overall boolean) is unchanged and still emitted for top-level alerting. Public `ChainIngester`/`CrossValidator` interfaces and the test mocks are untouched — the observer is a narrow optional interface matched by type-assertion.

### Coverage matrix

| Path | overall gauge | per-reason gauge + log |
|------|:---:|:---:|
| RPC / manual `SetFailsafeEnabled` | ✅ | ✅ |
| Chain ingester `SetError`/`ClearError` | ✅ | ✅ |
| Cross-validator `setError` | ✅ | ✅ |
| Reorg auto-recovery (via `ClearError`) | ✅ | ✅ |

## Tests

- `TestIntegration_Backend_AutoFailsafe_UpdatesMetric` — auto-trip via ingester error; multi-chain set/clear keeps the gauge on while any chain errors.
- `TestIntegration_Backend_RPCSetFailsafe_UpdatesMetric` — drives the actual `AdminFrontend` RPC handler.
- `TestIntegration_Backend_MultipleFailsafeReasons_Reflected` — manual + two chains with different reasons all active at once; clearing one reason drops only that series.
- `TestFailsafeReasonDetail` — detail rendering + numeric (not lexicographic) chain ordering.
- `TestBackend_FailsafeHeartbeat_LogsReasonWhileActive` — log capture: heartbeat logs reason+detail at Warn while active, silent once cleared.

All `filter` tests pass with `-race`; custom `op-golangci-lint` clean.