### PR TITLE
fix(interop): drain cross-safe verification backlog with adaptive backoff

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -27,8 +27,19 @@ import (
 var (
 	_                  activity.RunnableActivity     = (*Interop)(nil)
 	_                  activity.VerificationActivity = (*Interop)(nil)
-	backoffPeriod                                    = 1 * time.Second // backoff when chains aren't ready
+	backoffPeriod                                    = 1 * time.Second // backoff when chains aren't ready and caught up to the tip
 	errorBackoffPeriod                               = 2 * time.Second // backoff on errors
+	// catchupBackoffPeriod is the shorter backoff used after a no-op round while
+	// still draining a verification backlog, so the verifier retries promptly
+	// instead of sleeping a full second per transient wait (e.g. timestamp gaps
+	// from differing per-chain block times). See progress.
+	catchupBackoffPeriod = 50 * time.Millisecond
+	// maxFastNoProgress bounds how many consecutive no-op rounds use the short
+	// catchupBackoffPeriod before falling back to backoffPeriod. During a drain,
+	// advances reset the streak so the verifier stays in fast mode; once caught
+	// up to the tip the streak grows and the verifier idles calmly without
+	// busy-polling. See progress.
+	maxFastNoProgress = 10
 )
 
 // DefaultLogBackfillDepth matches the interop message expiry window so backfill
@@ -205,6 +216,12 @@ type Interop struct {
 
 	// verifyRounds counts verification loop iterations for periodic progress logging.
 	verifyRounds atomic.Int32
+
+	// noProgressStreak counts consecutive no-op verification rounds. It is used
+	// to keep the backoff short while a backlog is being drained (advances reset
+	// it) and only fall back to the full backoff once genuinely caught up to the
+	// tip. Only read/written by the main loop goroutine; no mutex needed.
+	noProgressStreak int
 
 	// l1Checker must be non-nil whenever observeRound runs. Production sets it
 	// via New; tests inject noopL1Checker.
@@ -441,9 +458,26 @@ func (i *Interop) progress() (time.Duration, error) {
 		i.log.Info("interop verification progress", fields...)
 	}
 	if !madeProgress {
-		return backoffPeriod, nil
+		return i.backoffAfterNoProgress(), nil
 	}
+	i.noProgressStreak = 0
 	return 0, nil
+}
+
+// backoffAfterNoProgress records a no-op verification round and returns how long
+// to wait before the next attempt. While a backlog is being drained, no-op
+// rounds (e.g. timestamp gaps between chains with different block times) are
+// interleaved with advances that reset the streak, so this keeps the backoff
+// short (catchupBackoffPeriod) and the verifier drains at IO/CPU speed instead
+// of ~1 round/sec. Sustained no-ops (streak past maxFastNoProgress) mean we are
+// caught up to the tip and waiting for new data, so it falls back to the full
+// backoffPeriod to avoid busy-polling. Only called from the main loop goroutine.
+func (i *Interop) backoffAfterNoProgress() time.Duration {
+	i.noProgressStreak++
+	if i.noProgressStreak <= maxFastNoProgress {
+		return catchupBackoffPeriod
+	}
+	return backoffPeriod
 }
 
 // Stop stops the Interop activity.

--- a/op-supernode/supernode/activity/interop/progress_backoff_test.go
+++ b/op-supernode/supernode/activity/interop/progress_backoff_test.go
@@ -1,0 +1,37 @@
+package interop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackoffAfterNoProgress verifies that no-op verification rounds back off
+// only briefly while a backlog is being drained (advances reset the streak),
+// and escalate to the full backoff once sustained no-ops indicate we are caught
+// up to the tip — so the verifier drains backlogs fast but idles calmly.
+func TestBackoffAfterNoProgress(t *testing.T) {
+	require.Less(t, catchupBackoffPeriod, backoffPeriod,
+		"catch-up backoff must be shorter than the steady-state backoff to drain faster")
+
+	i := &Interop{}
+
+	// The first maxFastNoProgress consecutive no-ops use the short catch-up
+	// backoff so a backlog drains promptly.
+	for n := 1; n <= maxFastNoProgress; n++ {
+		require.Equal(t, catchupBackoffPeriod, i.backoffAfterNoProgress(),
+			"no-op #%d while behind should use the catch-up backoff", n)
+	}
+
+	// Once the streak exceeds maxFastNoProgress (caught up to the tip, no data
+	// to process) it falls back to the full backoff to avoid busy-polling.
+	require.Equal(t, backoffPeriod, i.backoffAfterNoProgress(),
+		"sustained no-ops should fall back to the steady-state backoff")
+	require.Equal(t, backoffPeriod, i.backoffAfterNoProgress())
+
+	// An advancing round resets the streak (progress() sets noProgressStreak=0),
+	// so the next no-op is back in fast catch-up mode.
+	i.noProgressStreak = 0
+	require.Equal(t, catchupBackoffPeriod, i.backoffAfterNoProgress(),
+		"after an advance, the next no-op should use the catch-up backoff again")
+}


### PR DESCRIPTION
## Problem

The interop verification loop (`op-supernode/supernode/activity/interop`) sleeps a fixed `backoffPeriod` (**1s**) after every no-op round (`progress()` → `backoffPeriod` when `!madeProgress`). On a live 2-chain network, roughly **half of all rounds are no-ops** (e.g. timestamp gaps between chains with different block times — one chain at 1s blocks, the other at 2s), so the verifier spends ~1s sleeping per no-op while *advance* rounds take only ~34ms.

This pins cross-safe verification throughput to **~1 round/sec ≈ real-time**, even when there is a large, fully-local backlog to drain and CPU is idle. The consequence: after any multi-hour interruption, the cross-safe (`l2_safe`) head **tracks the tip but never closes the gap**.

### Evidence (live `op-supernode v0.3.1-rc.2`, 2-chain interop net)

After a ~24h sequencer-EL stall, local-safe + batcher recovered to tip in seconds, but cross-safe sat **~21.6k blocks / ~12h behind**, recovering at **0.998× real-time** over a 31-minute window. Verifier metrics:

```
supervisor_interop_round_decisions_total{decision="advance"} 1621
supervisor_interop_round_decisions_total{decision="wait"}    1558   # ~49% of rounds
interop_verification_duration_seconds: sum=54.6 / count=1621        # ~34ms per advance, 97% < 100ms
```

≈1,558 waits × 1s = ~1,558s sleeping vs ~55s of actual work — CPU ~33% of a 1-core limit, memory flat. The loop already runs the next round immediately when it advances (`progress()` returns `0`); the only thing capping it is the fixed 1s backoff on the very frequent no-op rounds.

## Fix

Use a short **catch-up backoff** while behind. Consecutive no-op rounds back off only briefly (`catchupBackoffPeriod = 50ms`); each advancing round resets the streak, so during a drain — where no-ops are interleaved with advances — the verifier stays in fast mode and drains at IO/CPU speed. Once **sustained** no-ops (`> maxFastNoProgress`) indicate we are caught up to the tip and waiting for new data, it falls back to the full `backoffPeriod` to avoid busy-polling.

- No verification semantics change — only the wait between scheduling rounds.
- RPC-free signal (consecutive no-op streak), single-goroutine, no locking.
- Self-limiting: at the tip it reverts to the 1s backoff after a few rounds, so steady-state CPU is unchanged.

Expected effect: a backlog that previously drained at ~1× real-time drains at roughly `1 / (advance_time + catchup_backoff)` ≈ tens of rounds/sec (idle-CPU bound), closing a ~12h gap in minutes rather than days.

## Testing

- New unit test `TestBackoffAfterNoProgress` (white-box) asserts the streak→duration behavior: short backoff while draining, fallback after sustained no-ops, reset after an advance, and `catchupBackoffPeriod < backoffPeriod`.
- Full `op-supernode/supernode/activity/interop` package tests pass.

## Notes / open questions for reviewers

- `catchupBackoffPeriod = 50ms` and `maxFastNoProgress = 10` are conservative starting values; happy to tune.
- The same `progress()`/backoff structure could be extended if other no-op causes (empty-timestamp waits, L1 readiness) deserve distinct handling, but those weren't the dominant cost in the measured data.
- Diagnosed against `op-supernode v0.3.1-rc.2`; implemented against `develop` where the loop is identical.