### PR TITLE
review(rust): add rust-review just recipe for AI-assisted review

### DIFF
--- a/justfile
+++ b/justfile
@@ -506,3 +506,7 @@ release-notes component from='latest' to='latest-rc' mode='':
         "${tag_args[@]}" \
         "${offline_args[@]}" \
         -- "${from_tag}..${range_end}"
+
+# Run the rust-code-reviewer agent over the current branch (delegates to rust/justfile).
+rust-review base='':
+  cd rust && just rust-review "{{base}}"

--- a/rust/justfile
+++ b/rust/justfile
@@ -107,6 +107,59 @@ lint-docs:
   RUSTDOCFLAGS="--cfg docsrs -D warnings --show-type-layout --generate-link-to-definition -Zunstable-options" \
     cargo +{{NIGHTLY}} doc --workspace --all-features --no-deps --document-private-items
 
+############################ Review #################################
+
+# Run the rust-code-reviewer agent over the current branch's Rust diff in an interactive session (latest opus, max effort). The agent reviews, asks which findings to apply, then applies them. Base auto-detects from upstream / origin/HEAD; override with `base=...`.
+[script('bash')]
+rust-review base='':
+  set -euo pipefail
+  command -v claude >/dev/null 2>&1 || { echo "claude CLI not found on PATH; install it before running rust-review." >&2; exit 1; }
+  base="{{base}}"
+  if [[ -z "$base" ]]; then
+    # Prefer origin/HEAD (the repo's default branch) so a pushed feature
+    # branch that tracks itself on origin doesn't end up diffing against
+    # HEAD. Fall back to @{upstream}, then origin/develop.
+    base=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null \
+           || git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null \
+           || echo origin/develop)
+  fi
+  head_ref=$(git rev-parse --abbrev-ref HEAD)
+  merge_base=$(git merge-base "$base" HEAD)
+  if git diff --quiet "$merge_base"..HEAD -- ':/rust/**'; then
+    echo "No Rust changes on $head_ref relative to $base; nothing to review."
+    exit 0
+  fi
+  prompt=$(cat <<EOF
+  Review the Rust changes on the current branch.
+
+  Branch: $head_ref
+  Base:   $base (merge-base $merge_base)
+
+  Inspect the diff with:
+    git diff $merge_base..HEAD -- ':/rust/**'
+
+  Follow your standard review process from .claude/agents/rust-code-reviewer.md,
+  including running the project's lint recipe (mise exec -- just l) from the
+  appropriate Rust workspace root before reading the diff. Report findings
+  scoped to the diff only.
+
+  After presenting the findings, use the AskUserQuestion tool to ask which
+  findings (if any) to apply, then apply only the selected ones.
+  EOF
+  )
+  eta=$(date -v +10M '+%H:%M' 2>/dev/null || date -d '+10 min' '+%H:%M')
+  echo "Reviewer starting with ETA before $eta.."
+  echo
+  start=$(date +%s)
+  trap 'rc=$?; end=$(date +%s); printf "\nReviewer ran for %dm %02ds (exit %d)\n" $(( (end - start) / 60 )) $(( (end - start) % 60 )) "$rc"' EXIT
+  claude \
+    --agent rust-code-reviewer \
+    --model opus \
+    --effort max \
+    "$prompt"
+  echo
+  echo "Please help us make our reviewer better by contributing to .claude/agents/rust-code-reviewer.md"
+
 ############################ no_std #################################
 
 # Check no_std compatibility for proof, protocol, alloy, and op-alloy crates


### PR DESCRIPTION
## Human Summary

Add convenience recipes that trigger a high effort, _company style_, pre-review of the diff `origin/develop..HEAD`. Only Rust code is checked.

Company style is whatever we define in `.claude/agents/rust-code-reviewer.md`.

1. It launches the existing Claude `rust-code-reviewer` agent on the diff, and then
2. drops the user in interactive session with the recommendations ready to action.

The purpose is to harmonize and mechanize how we do pre-reviews on our PRs, shift effort towards author and _favour the reviewer™_.

## Reviewing this PR

- You can try running it with `just rust-review` on its own branch first.  It should tell you there is no Rust diff.  I should have fixed all high priority issues.
- Then I suggest try merging it into an existing feature branch and run `just rust-review` and see what happens.

## Claude Summary
- Adds a `rust-review` recipe to `rust/justfile` (with a thin wrapper in the root `justfile`) that launches an interactive `claude` session running the existing `rust-code-reviewer` agent over the current branch's Rust diff.
- Auto-detects the diff base (`origin/HEAD` → `@{upstream}` → `origin/develop`); override with `base=...`.
- The prompt instructs the agent to present findings, then call `AskUserQuestion` to gate which fixes to apply, then apply only the selected ones.
- Skips early when there are no Rust changes vs the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)