### PR TITLE
fix(op-node): bootstrap follow-mode ELSync sequencer from genesis

### DIFF
--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -211,6 +211,13 @@ func (s *SyncDeriver) SyncStep() {
 
 	s.tryBackupUnsafeReorg()
 
+	// Seed a follow-mode sequencer's engine before the EL-sync backoff below: it is the sole
+	// block producer, so at genesis there is no peer payload to initial-EL-sync from and it
+	// would otherwise back off forever. Idempotent, so this is a one-time genesis bootstrap.
+	if s.SyncCfg.FollowSourceEnabled() && s.SyncCfg.NeedInitialResetEngine {
+		s.Engine.TryInitialResetEngineForSequencer(s.Ctx)
+	}
+
 	if s.Engine.IsEngineInitialELSyncing() {
 		// The pipeline cannot move forwards if doing initial EL sync.
 		s.Log.Debug("Rollup driver is backing off because execution engine is performing initial EL sync.",
@@ -220,10 +227,6 @@ func (s *SyncDeriver) SyncStep() {
 	}
 
 	if s.SyncCfg.FollowSourceEnabled() {
-		if s.SyncCfg.NeedInitialResetEngine {
-			// May need a single reset to trigger sequencer block building
-			s.Engine.TryInitialResetEngineForSequencer(s.Ctx)
-		}
 		return
 	}
 

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -1336,6 +1336,12 @@ func (e *EngineController) TryInitialResetEngineForSequencer(ctx context.Context
 		return
 	}
 	e.forceReset(ctx, result.Unsafe, result.Unsafe, result.Safe, result.Safe, result.Finalized, true)
+	// Once seeded, a follow-mode sequencer has nothing to initial-EL-sync to, so leave the
+	// initial-EL-sync state (as insertUnsafePayload does) and let the driver proceed. EL sync
+	// still engages later via forkchoice updates if the follow source gets ahead.
+	if e.syncStatus == syncStatusWillStartEL {
+		e.syncStatus = syncStatusFinishedEL
+	}
 }
 
 var ErrEngineSyncing = errors.New("engine is syncing")

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -838,6 +838,70 @@ func TestFollowSource_SeedsGenesisRefsFromZeroState(t *testing.T) {
 	mockEngine.AssertExpectations(t)
 }
 
+// TestTryInitialResetEngineForSequencer_GenesisELSyncBootstrap verifies the genesis
+// bootstrap path for a follow-mode ELSync sequencer (ethereum-optimism/optimism#21119): with
+// no peer payload to exit syncStatusWillStartEL, the method must seed the engine from
+// FindL2Heads and leave the initial-EL-sync state so the sole-producer sequencer can build.
+func TestTryInitialResetEngineForSequencer_GenesisELSyncBootstrap(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(0xb0075))
+	l1Genesis := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     0,
+		ParentHash: common.Hash{},
+		Time:       123456,
+	}
+	l2Genesis := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           l1Genesis.Time,
+		L1Origin:       l1Genesis.ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L1:     l1Genesis.ID(),
+			L2:     l2Genesis.ID(),
+			L2Time: l2Genesis.Time,
+		},
+		BlockTime:     2,
+		SeqWindowSize: 2,
+	}
+
+	// A fresh genesis-only engine reports genesis for all labeled heads; FindL2Heads
+	// (via currentHeads) then confirms genesis's L1 origin is canonical and returns it.
+	mockEngine := &testutils.MockEngine{}
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, l2Genesis, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Safe, l2Genesis, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Unsafe, l2Genesis, nil)
+	mockL1 := &testutils.MockL1Source{}
+	mockL1.ExpectL1BlockRefByNumber(0, l1Genesis, nil)
+
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+		metrics.NoopMetrics, cfg,
+		&sync.Config{SyncMode: sync.ELSync, L2FollowSourceEndpoint: "http://localhost"},
+		mockL1, discardEmitter{}, nil)
+
+	// Precondition: a fresh ELSync engine is in initial EL sync with no unsafe head.
+	require.Equal(t, syncStatusWillStartEL, ec.syncStatus)
+	require.True(t, ec.IsEngineInitialELSyncing())
+	require.Equal(t, eth.L2BlockRef{}, ec.unsafeHead)
+
+	ec.TryInitialResetEngineForSequencer(context.Background())
+
+	// The engine is seeded at genesis and has left initial EL sync.
+	require.Equal(t, l2Genesis, ec.unsafeHead, "engine seeded at genesis")
+	require.Equal(t, syncStatusFinishedEL, ec.syncStatus, "left initial EL sync so the driver stops backing off")
+	require.False(t, ec.IsEngineInitialELSyncing())
+	mockEngine.AssertExpectations(t)
+	mockL1.AssertExpectations(t)
+
+	// Idempotent: once the engine has an unsafe head the method early-returns, making
+	// no further engine/L1 lookups (any would fail against the now-exhausted mocks).
+	ec.TryInitialResetEngineForSequencer(context.Background())
+	require.Equal(t, l2Genesis, ec.unsafeHead)
+}
+
 // TestEngineController_FinalizedHead tests FinalizedHead behavior with various configurations
 func TestEngineController_FinalizedHead(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
A follow-mode ELSync sequencer (a light op-node CL that produces unsafe blocks while following a supernode's safe head) cannot start from genesis. A fresh ELSync engine begins in `syncStatusWillStartEL`, whose only normal exit is an inbound peer payload via `insertUnsafePayload`. A follow-mode sequencer is the **sole block producer** at genesis, so no such payload ever arrives — both `SyncStep` and the follow-upstream loop back off on `IsEngineInitialELSyncing()`, and the node deadlocks.

## Changes
- `sync_deriver.go` `SyncStep`: for a follow-mode sequencer (`FollowSourceEnabled && NeedInitialResetEngine`), run the initial engine reset **before** the EL-sync backoff so the engine gets seeded.
- `engine_controller.go` `TryInitialResetEngineForSequencer`: after seeding the engine from `FindL2Heads`, transition `willStartEL → finishedEL` (mirroring `insertUnsafePayload`'s existing "skip EL sync when a finalized block exists" transition), so the driver stops backing off and the sequencer can build. Later forkchoice updates still engage EL sync (tolerating SYNCING) if the follow source ever gets ahead.

## Test plan
- New unit test `TestTryInitialResetEngineForSequencer_GenesisELSyncBootstrap`: a fresh ELSync engine in `willStartEL` with no unsafe head is seeded at genesis and leaves initial EL sync; idempotent on a second call.
- `go test ./op-node/rollup/engine/ ./op-node/rollup/driver/` green.

---
Part 1 of 3 in the #21119 fix. The behavioral end-to-end proof lands in the top PR (which switches the presets to ELSync); this PR is unit-scoped because the genesis-bootstrap path is only exercised by an ELSync follow-mode sequencer preset.


## Stack (merge bottom-up)
1. #21120 — op-node: genesis bootstrap for ELSync follow-mode sequencers
2. #21121 — op-node: divergence reorg-reset for follow-mode sequencers
3. #21122 — devstack: switch follow-mode supernode presets to ELSync + #21119 end-to-end proof