### PR TITLE
fix(op-wheel): record block base fee on its own gauge

### DIFF
--- a/op-wheel/engine/engine.go
+++ b/op-wheel/engine/engine.go
@@ -247,7 +247,7 @@ func Auto(
 					continue
 				}
 				log.Info("status", "head", status.Head, "safe", status.Safe, "finalized", status.Finalized,
-					"head_time", status.Head.Time, "txs", status.Txs, "gas", status.Gas, "basefee", status.Gas)
+					"head_time", status.Head.Time, "txs", status.Txs, "gas", status.Gas, "basefee", status.BaseFee)
 
 				// On a mocked "beacon epoch transition", update finalization and justification checkpoints.
 				// There are no gap slots, so we just go back 32 blocks.

--- a/op-wheel/engine/metrics.go
+++ b/op-wheel/engine/metrics.go
@@ -81,7 +81,7 @@ func (r *Metrics) RecordBlockStats(hash common.Hash, num uint64, time uint64, tx
 	r.BlockTime.Set(float64(time))
 	r.BlockTxs.Set(float64(txs))
 	r.BlockGas.Set(float64(gas))
-	r.BlockGas.Set(float64(baseFee))
+	r.BlockBaseFee.Set(baseFee)
 }
 
 var _ Metricer = (*Metrics)(nil)

--- a/op-wheel/engine/metrics_test.go
+++ b/op-wheel/engine/metrics_test.go
@@ -1,0 +1,32 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, g.Write(&m))
+	return m.GetGauge().GetValue()
+}
+
+// TestRecordBlockStats ensures gas and base fee are recorded on their own
+// gauges. Distinct values are used so a regression that records the base fee
+// onto the gas gauge (or leaves the base-fee gauge unset) is caught.
+func TestRecordBlockStats(t *testing.T) {
+	m := NewMetrics("test", prometheus.NewRegistry())
+
+	const gas = uint64(21000)
+	const baseFee = float64(1234)
+
+	m.RecordBlockStats(common.Hash{0x01}, 5, 100, 3, gas, baseFee)
+
+	require.Equal(t, float64(gas), gaugeValue(t, m.BlockGas), "BlockGas should record gas used")
+	require.Equal(t, baseFee, gaugeValue(t, m.BlockBaseFee), "BlockBaseFee should record the block base fee")
+}


### PR DESCRIPTION
## Summary

`op-wheel`'s `RecordBlockStats` set `BlockGas` twice — once with gas used and once with the base fee — which left the `BlockBaseFee` gauge unset and clobbered the gas gauge value with the base fee. This records the base fee on `BlockBaseFee` instead.

The nearby pre-block status log also emitted `status.Gas` for its `basefee` field; it now emits `status.BaseFee`.

## Changes

- `op-wheel/engine/metrics.go` — `RecordBlockStats` now sets `BlockBaseFee` (not `BlockGas`) with the base fee.
- `op-wheel/engine/engine.go` — status log `basefee` field now logs `status.BaseFee`.
- `op-wheel/engine/metrics_test.go` — adds `TestRecordBlockStats` asserting gas and base fee land on their own gauges (uses distinct values so the old bug fails the test).

## Testing

`go build ./engine/`, `go vet ./engine/`, and `go test ./engine/` all pass. `go.mod`/`go.sum` unchanged.

Closes #20958
