### PR TITLE
feat(op-conductor): flag-gated interop reorg recovery (#20006)

### DIFF
--- a/docs/public-docs/chain-operators/tools/op-conductor.mdx
+++ b/docs/public-docs/chain-operators/tools/op-conductor.mdx
@@ -330,6 +330,10 @@ It is configured via its [flags / environment variables](https://github.com/ethe
     semantics and MUST be set identically on every conductor in the cluster — all-on or
     all-off, never mixed; a mixed setting causes silent Raft FSM divergence.** Enable only
     as a coordinated, fleet-wide rollout. Requires `--execution.ws-url` when set. op-reth only.
+    Also adds a non-cancellable 5s demotion grace on unsafe-staleness so a leader can commit
+    a deep-reorg head before failing over: this adds up to ~5s failover latency on a
+    stuck-but-connected sequencer and one guaranteed leadership handoff per deep reorg
+    (connection loss still fails over immediately; shallow reorgs are unaffected).
 *   **Default Value:** `false`
 *   **Required:** no
 

--- a/docs/public-docs/chain-operators/tools/op-conductor.mdx
+++ b/docs/public-docs/chain-operators/tools/op-conductor.mdx
@@ -25,7 +25,9 @@ all participating nodes are honest and act correctly.
 
 The design of the `op-conductor` provides the following guarantees:
 
-*   **No Unsafe Reorgs**
+*   **No Unsafe Reorgs** (default). With `--reorg-recovery.enabled` set, this guarantee
+    is intentionally relaxed: the recorded unsafe head can move backward to follow an
+    op-reth interop reorg. With the flag off (the default), the guarantee holds as before.
 *   **No Unsafe Head Stall During Network Partition**
 *   **100% Uptime with No More Than 1 Node Failure**
 
@@ -319,6 +321,24 @@ It is configured via its [flags / environment variables](https://github.com/ethe
 *   **Usage:** HTTP provider URL for execution layer
 *   **Default Value:** None specified
 *   **Required:** yes
+
+#### --reorg-recovery.enabled (`REORG_RECOVERY_ENABLED`)
+
+*   **Usage:** Enable reth reorg-recovery. When true, op-conductor subscribes to op-reth
+    reorg notifications and removes the FSM forward-only head guard so a reorg can move
+    the recorded unsafe head backward. **CRITICAL: this flag changes Raft FSM apply
+    semantics and MUST be set identically on every conductor in the cluster — all-on or
+    all-off, never mixed; a mixed setting causes silent Raft FSM divergence.** Enable only
+    as a coordinated, fleet-wide rollout. Requires `--execution.ws-url` when set. op-reth only.
+*   **Default Value:** `false`
+*   **Required:** no
+
+#### --execution.ws-url (`EXECUTION_WS_URL`)
+
+*   **Usage:** WebSocket URL for the execution layer (op-reth) reorg subscription.
+    Required when `--reorg-recovery.enabled` is set.
+*   **Default Value:** None specified
+*   **Required:** only when `--reorg-recovery.enabled` is set
 
 #### --healthcheck.interval (`HEALTHCHECK_INTERVAL`)
 

--- a/op-acceptance-tests/tests/supernode/interop/reorg/conductor_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/conductor_reorg_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"math/rand"
 	"os"
+	"sort"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,7 +30,29 @@ import (
 const (
 	reorgObservedMetric  = "op_conductor_reorgs_observed_count"
 	reorgCommittedMetric = "op_conductor_reorgs_committed_count"
+
+	// deepReorgBuildPerBlock budgets wall-clock time per L2 block while burying the invalid
+	// block under reorgDepth descendants and while the chain re-derives them after the
+	// reorg. L2 blocks are produced in real time, so a deep reorg needs a long window.
+	deepReorgBuildPerBlock = 4 * time.Second
+	// deepReorgBuildBase is fixed slack on top of the per-block build/settle budget.
+	deepReorgBuildBase = 120 * time.Second
 )
+
+// deepReorgBuildTimeout returns a generous timeout for building or re-deriving reorgDepth
+// L2 blocks at real-time block production.
+func deepReorgBuildTimeout(reorgDepth uint64) time.Duration {
+	return time.Duration(reorgDepth)*deepReorgBuildPerBlock + deepReorgBuildBase
+}
+
+// requireDeepReorgEnabled skips a test unless OP_RUN_DEEP_REORG_TEST is set. Deep reorg
+// tests pause interop and wait for the chain to extend by the reorg depth in real time, so
+// they take minutes and are excluded from CI by default.
+func requireDeepReorgEnabled(t devtest.T) {
+	if os.Getenv("OP_RUN_DEEP_REORG_TEST") == "" {
+		t.Skip("deep reorg test is manual-only (real-time L2 block production makes it slow); set OP_RUN_DEEP_REORG_TEST=1 to run")
+	}
+}
 
 // requireOpReth skips the test unless the EL backend is op-reth. The acceptance CI
 // matrix runs the same package under an op-geth job (which leaves DEVSTACK_L2EL_KIND
@@ -46,11 +70,21 @@ type reorgTrigger struct {
 	invalidBlockTimestamp uint64
 }
 
-// triggerInvalidMessageReorgOnB forces a same-chain reorg on chain B by including an
-// invalid executing message and resuming interop, which invalidates and replaces the
-// offending block. It returns once the EL has replaced the block. Mirrors the trigger in
-// invalid_message_reorg_test.go.
+// triggerInvalidMessageReorgOnB forces a same-height, single-block reorg on chain B by
+// including an invalid executing message and resuming interop, which invalidates and
+// replaces the offending block. It returns once the EL has replaced the block. Mirrors the
+// trigger in invalid_message_reorg_test.go.
 func triggerInvalidMessageReorgOnB(t devtest.T, sys *presets.TwoL2SupernodeInteropWithConductors) reorgTrigger {
+	return triggerInvalidMessageReorgOnBWithDepth(t, sys, 0)
+}
+
+// triggerInvalidMessageReorgOnBWithDepth is triggerInvalidMessageReorgOnB with an optional
+// reorg depth: while interop stays paused, the chain is extended reorgDepth blocks past the
+// invalid executing message before interop is resumed. Resuming then invalidates the buried
+// block and re-derives every descendant, producing a reorg that spans ~reorgDepth blocks
+// (the EL unsafe head transiently rewinds to the replacement before climbing back). A depth
+// of 0 reproduces the shallow same-height replacement.
+func triggerInvalidMessageReorgOnBWithDepth(t devtest.T, sys *presets.TwoL2SupernodeInteropWithConductors, reorgDepth uint64) reorgTrigger {
 	ctx := t.Ctx()
 
 	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
@@ -72,20 +106,51 @@ func triggerInvalidMessageReorgOnB(t devtest.T, sys *presets.TwoL2SupernodeInter
 	invalidBlockHash := execMsg.BlockHash()
 	invalidBlockTimestamp := sys.L2B.TimestampForBlockNum(invalidBlockNumber)
 	t.Logger().Info("invalid executing message sent on chain B",
-		"block", invalidBlockNumber, "hash", invalidBlockHash, "timestamp", invalidBlockTimestamp)
+		"block", invalidBlockNumber, "hash", invalidBlockHash, "timestamp", invalidBlockTimestamp, "depth", reorgDepth)
 
 	require.Eventually(t, func() bool {
 		return sys.L2BCL.SyncStatus().LocalSafeL2.Number >= invalidBlockNumber
 	}, 60*time.Second, time.Second, "invalid block should become locally safe")
 
+	// Bury the invalid block under reorgDepth descendants while interop is paused, so the
+	// invalidation on resume rewinds a deep span rather than a single block. Capture a deep
+	// descendant's hash to later prove the reorg actually cascaded that far.
+	var deepDescendant eth.BlockRef
+	if reorgDepth > 0 {
+		target := invalidBlockNumber + reorgDepth
+		require.Eventually(t, func() bool {
+			return sys.L2BCL.SyncStatus().UnsafeL2.Number >= target
+		}, deepReorgBuildTimeout(reorgDepth), time.Second,
+			"chain B must extend reorgDepth blocks past the invalid block while interop is paused")
+		var err error
+		deepDescendant, err = sys.L2ELB.Escape().EthClient().BlockRefByNumber(ctx, invalidBlockNumber+reorgDepth-1)
+		require.NoError(t, err, "read deep descendant before resume")
+		t.Logger().Info("buried invalid block under descendants",
+			"invalid", invalidBlockNumber, "depth", reorgDepth,
+			"unsafe_head", sys.L2BCL.SyncStatus().UnsafeL2.Number, "deep_descendant", deepDescendant.Hash)
+	}
+
 	sys.Supernode.ResumeInterop()
+	replaceTimeout := 60 * time.Second
+	if reorgDepth > 0 {
+		replaceTimeout = deepReorgBuildTimeout(reorgDepth)
+	}
 	require.Eventually(t, func() bool {
 		currentBlock, err := sys.L2ELB.Escape().EthClient().BlockRefByNumber(ctx, invalidBlockNumber)
 		if err != nil {
 			return false
 		}
 		return currentBlock.Hash != invalidBlockHash
-	}, 60*time.Second, time.Second, "the invalid block at the reorg height should be replaced at the EL")
+	}, replaceTimeout, time.Second, "the invalid block at the reorg height should be replaced at the EL")
+
+	if reorgDepth > 0 {
+		require.Eventually(t, func() bool {
+			cur, err := sys.L2ELB.Escape().EthClient().BlockRefByNumber(ctx, deepDescendant.Number)
+			return err == nil && cur.Hash != deepDescendant.Hash
+		}, replaceTimeout, time.Second,
+			"a deep descendant block must be reorged, proving the reorg spanned reorgDepth blocks")
+		t.Logger().Info("deep reorg confirmed: descendant reorged", "descendant_block", deepDescendant.Number)
+	}
 
 	return reorgTrigger{
 		invalidBlockNumber:    invalidBlockNumber,
@@ -164,6 +229,188 @@ func leaderUnsafePayload(ctx context.Context, leader *dsl.Conductor) (*eth.Execu
 
 type ethBlockByNumber interface {
 	BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error)
+}
+
+type ethLiveClient interface {
+	InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error)
+}
+
+// assertSequencerLive asserts the cluster is left with a working sequencer after the reorg
+// stabilizes: some conductor is leader + healthy + actively sequencing, and chain B's unsafe
+// head keeps advancing. Convergence alone does not prove this — if a leadership transfer
+// stalls (e.g. on a head mismatch during the reorg) every EL can still converge on the
+// post-reorg chain via gossip/derivation while no conductor is active, halting block
+// production. Without this check that wedge passes the convergence assertions silently.
+func assertSequencerLive(t devtest.T, conductors dsl.ConductorSet, elClient ethLiveClient) {
+	ctx := t.Ctx()
+	require.Eventually(t, func() bool {
+		for _, c := range conductors {
+			callCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			leader, lerr := c.Escape().RpcAPI().Leader(callCtx)
+			healthy, herr := c.Escape().RpcAPI().SequencerHealthy(callCtx)
+			active, aerr := c.Escape().RpcAPI().Active(callCtx)
+			cancel()
+			if lerr == nil && herr == nil && aerr == nil && leader && healthy && active {
+				return true
+			}
+		}
+		return false
+	}, 90*time.Second, time.Second,
+		"after the reorg a conductor must be leader+healthy+active (a live sequencer)")
+
+	start, err := elClient.InfoByLabel(ctx, eth.Unsafe)
+	require.NoError(t, err, "read chain B unsafe head for liveness baseline")
+	const minAdvance = 3
+	target := start.NumberU64() + minAdvance
+	require.Eventually(t, func() bool {
+		head, err := elClient.InfoByLabel(ctx, eth.Unsafe)
+		return err == nil && head.NumberU64() >= target
+	}, 60*time.Second, time.Second,
+		"chain B must keep producing blocks after the reorg (unsafe head must advance)")
+}
+
+// runDeepReorgRecovery drives a depth-block deep reorg on chain B and asserts the conductor
+// cluster recovers: some node observes and commits the post-reorg head into the FSM, every
+// chain-B EL converges on the replacement, AND the cluster is left with a live sequencer. The
+// caller sets the health-check config via preset options, which determines whether the
+// unsafe-staleness check trips during the reorg (and thus whether the FSM-commit vs
+// unhealthy-driven-transfer race is exercised). Per-conductor reorg metrics are logged so a
+// repeated stress run can tell which node committed (the initial leader = race won; a
+// post-transfer leader = race window entered but self-healed).
+func runDeepReorgRecovery(t devtest.T, sys *presets.TwoL2SupernodeInteropWithConductors, depth uint64) {
+	conductors := conductorsForChainB(t, sys)
+	elB := sys.L2ELB.Escape().EthClient()
+
+	leaderBefore := findLeader(t, conductors)
+	t.Logger().Info("chain B leader before deep reorg", "leader", leaderBefore.String(), "depth", depth)
+
+	// Watch leadership/health across the whole reorg window.
+	stopWatch := watchClusterHealth(t, conductors, leaderBefore)
+
+	trigger := triggerInvalidMessageReorgOnBWithDepth(t, sys, depth)
+
+	// Some node observed the deep reorg notification and committed the post-reorg head. Sum
+	// across the cluster: under a tight health check leadership can churn mid-reorg, so the
+	// committer is not necessarily the node that is leader when we scrape.
+	require.Eventually(t, func() bool {
+		var observed, committed float64
+		for _, c := range conductors {
+			observed += c.ScrapeCounter(reorgObservedMetric)
+			committed += c.ScrapeCounter(reorgCommittedMetric)
+		}
+		return observed >= 1 && committed >= 1
+	}, 90*time.Second, time.Second, "some conductor should observe and commit the post-reorg head")
+
+	// The leader's FSM head converges to the canonical post-reorg chain.
+	assertLeaderHeadConverges(t, conductors, elB, trigger.invalidBlockNumber)
+
+	// Every chain-B EL (VN + leader + candidates) converges on the replacement.
+	assertAllChainBELsConverged(t, sys, trigger)
+
+	// Liveness: the cluster must still have a healthy, active sequencer producing blocks.
+	assertSequencerLive(t, conductors, elB)
+
+	healthTrips, leaderChurned := stopWatch()
+	for _, c := range conductors {
+		t.Logger().Info("conductor reorg metrics",
+			"conductor", c.String(),
+			"was_initial_leader", c.String() == leaderBefore.String(),
+			"observed", c.ScrapeCounter(reorgObservedMetric),
+			"committed", c.ScrapeCounter(reorgCommittedMetric))
+	}
+	t.Logger().Info("deep reorg gating measurement",
+		"depth", depth,
+		"leader_health_tripped", healthTrips,
+		"leadership_churned", leaderChurned,
+		"initial_leader_committed", leaderBefore.ScrapeCounter(reorgCommittedMetric),
+		"note", "with reorg-recovery ON the cluster should recover; health/leadership detail is in conductor logs")
+}
+
+// chainBELNodes returns every chain-B EL the reorg must converge across: the supernode
+// validator-node EL plus every conductor-controlled sequencer EL (leader + candidates).
+func chainBELNodes(t devtest.T, sys *presets.TwoL2SupernodeInteropWithConductors) []*dsl.L2ELNode {
+	chainB := sys.L2B.Escape().ChainID()
+	vn := sys.SupernodeELs[chainB]
+	t.Require().NotNil(vn, "missing supernode VN EL for chain B")
+	seqELs := sys.SequencerELs[chainB]
+	t.Require().NotEmpty(seqELs, "missing conductor sequencer ELs for chain B")
+	names := make([]string, 0, len(seqELs))
+	for name := range seqELs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]*dsl.L2ELNode, 0, len(seqELs)+1)
+	out = append(out, vn)
+	for _, name := range names {
+		out = append(out, seqELs[name])
+	}
+	return out
+}
+
+// assertAllChainBELsConverged asserts every chain-B EL replaced the invalid block at the
+// reorg height and converged on a single canonical hash — proving the reorg propagated to
+// the supernode VN EL and every conductor-controlled sequencer EL, not just the leader's
+// EL that assertLeaderHeadConverges checks. On timeout it logs each EL's block-at-height
+// hash and current unsafe head so a holdout (stuck or diverged) is identified by name.
+func assertAllChainBELsConverged(t devtest.T, sys *presets.TwoL2SupernodeInteropWithConductors, trigger reorgTrigger) {
+	ctx := t.Ctx()
+	els := chainBELNodes(t, sys)
+	deadline := time.Now().Add(90 * time.Second)
+	var lastReport string
+	nextLog := time.Now()
+	for {
+		converged, report := chainBELConvergence(ctx, els, trigger)
+		if converged {
+			t.Logger().Info("all chain-B ELs converged on the post-reorg replacement",
+				"block", trigger.invalidBlockNumber, "el_count", len(els))
+			return
+		}
+		lastReport = report
+		if time.Now().After(nextLog) {
+			t.Logger().Info("waiting for chain-B ELs to converge", "block", trigger.invalidBlockNumber, "state", report)
+			nextLog = time.Now().Add(10 * time.Second)
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	t.Require().FailNowf("chain-B ELs did not converge",
+		"every chain-B EL (VN + all conductor sequencer ELs) must converge on the replacement at block %d; last observation: %s",
+		trigger.invalidBlockNumber, lastReport)
+}
+
+// chainBELConvergence reports whether every EL has replaced the invalid block at the reorg
+// height with a single shared canonical hash. The returned string describes each EL's
+// block-at-height hash and current unsafe head, so a failed poll names the holdout.
+func chainBELConvergence(ctx context.Context, els []*dsl.L2ELNode, trigger reorgTrigger) (bool, string) {
+	var canonical common.Hash
+	converged := true
+	var report string
+	for i, el := range els {
+		ref, err := el.Escape().EthClient().BlockRefByNumber(ctx, trigger.invalidBlockNumber)
+		head, headErr := el.Escape().EthClient().InfoByLabel(ctx, eth.Unsafe)
+		headStr := "?"
+		if headErr == nil {
+			headStr = head.Hash().TerminalString() + ":" + strconv.FormatUint(head.NumberU64(), 10)
+		}
+		switch {
+		case err != nil:
+			report += " " + el.String() + "(blk=err:" + err.Error() + " head=" + headStr + ")"
+			converged = false
+		case ref.Hash == trigger.invalidBlockHash:
+			report += " " + el.String() + "(blk=INVALID head=" + headStr + ")"
+			converged = false
+		default:
+			report += " " + el.String() + "(blk=" + ref.Hash.TerminalString() + " head=" + headStr + ")"
+			if i == 0 {
+				canonical = ref.Hash
+			} else if ref.Hash != canonical {
+				converged = false
+			}
+		}
+	}
+	return converged, report
 }
 
 // pickNonLeader returns a voter in the cluster other than the current leader.
@@ -265,6 +512,11 @@ func TestConductorReorgRecovery(gt *testing.T) {
 	// former follower has it after a transfer).
 	assertLeaderHeadConverges(t, conductors, elB, trigger.invalidBlockNumber)
 
+	// Scenario A (cont.): the reorg must propagate to every chain-B EL — the supernode
+	// VN EL and every conductor-controlled sequencer EL (leader + candidates) — not just
+	// the leader's EL. All converge on the same canonical replacement block.
+	assertAllChainBELsConverged(t, sys, trigger)
+
 	// Scenario C: only the leader writes — every non-leader's committed count stays 0.
 	for _, c := range conductors {
 		if c.IsLeader() {
@@ -305,6 +557,64 @@ func TestConductorReorgRecovery(gt *testing.T) {
 	require.NoError(t, err, "new leader's recorded head should exist on the canonical chain")
 	require.Equal(t, head.ExecutionPayload.BlockHash, ref.Hash,
 		"new leader's recorded head should be canonical — Raft state survived the transfer")
+}
+
+// TestConductorDeepReorgRecovery exercises reorg-recovery against a deep reorg: the invalid
+// executing message is buried under deepReorgDepth descendants (built while interop is
+// paused) before interop resumes, so the invalidation rewinds a deep span rather than a
+// single same-height block. With reorg-recovery ON, the leader must observe and commit the
+// post-reorg head, its FSM head must converge to the canonical post-reorg chain, every
+// chain-B EL must converge on the replacement, and leadership must stay stable.
+//
+// Manual-only (gated by OP_RUN_DEEP_REORG_TEST): L2 blocks are produced in real time, so
+// extending the chain by deepReorgDepth takes minutes — too slow for CI.
+func TestConductorDeepReorgRecovery(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	requireOpReth(t)
+	requireDeepReorgEnabled(t)
+
+	// deepReorgDepth is the number of blocks the chain is extended past the invalid block
+	// before interop resumes, i.e. the depth of the resulting reorg. Tune as needed.
+	const deepReorgDepth = 100
+
+	sys := presets.NewTwoL2SupernodeInteropWithConductors(t, 0,
+		presets.WithConductorReorgRecovery(),
+	)
+	runDeepReorgRecovery(t, sys, deepReorgDepth)
+}
+
+// TestConductorDeepReorgRecoveryTightHealth runs deep-reorg recovery under an aggressive but
+// valid health check: a 1s poll cadence with a 4s unsafe-staleness window (one notch tighter
+// than production's 5s, still safely above the 2s block time so steady-state production never
+// trips). Unlike TestConductorDeepReorgRecovery's lenient default (UnsafeInterval 3600, which
+// never trips and so never transfers leadership), the deep rewind here makes the unsafe head
+// stale enough to trip the staleness check and force a leadership transfer mid-reorg. That
+// exercises the safety-critical race between the reorg-recovery FSM commit and the
+// unhealthy-driven leadership transfer: if leadership moves away before the post-reorg head is
+// committed, a new leader could be left on a stale FSM head with no pending notification to
+// re-commit. The liveness assertion in runDeepReorgRecovery catches a resulting wedge.
+//
+// Depth is OP_DEEP_REORG_DEPTH (default 25) — small enough to keep iterations short for
+// repeated stress runs, large enough that the rewind (depth*blocktime ≈ 50s) far exceeds the
+// 4s window and reliably trips health.
+func TestConductorDeepReorgRecoveryTightHealth(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	requireOpReth(t)
+	requireDeepReorgEnabled(t)
+
+	depth := uint64(25)
+	if v := os.Getenv("OP_DEEP_REORG_DEPTH"); v != "" {
+		parsed, err := strconv.ParseUint(v, 10, 64)
+		require.NoError(t, err, "OP_DEEP_REORG_DEPTH must be a uint")
+		require.Positive(t, parsed, "OP_DEEP_REORG_DEPTH must be > 0")
+		depth = parsed
+	}
+
+	sys := presets.NewTwoL2SupernodeInteropWithConductors(t, 0,
+		presets.WithConductorReorgRecovery(),
+		presets.WithConductorHealthCheck(1, 4, 1200),
+	)
+	runDeepReorgRecovery(t, sys, depth)
 }
 
 // TestConductorReorgRecoveryDisabled is Scenario D: with reorg-recovery OFF (the

--- a/op-acceptance-tests/tests/supernode/interop/reorg/conductor_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/conductor_reorg_test.go
@@ -1,0 +1,335 @@
+package reorg
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// These tests exercise op-conductor's reorg-recovery mode end-to-end against a real
+// op-reth backend: a real `reth_subscribeChainNotifications` reorg notification must
+// drive the leader to commit the post-reorg unsafe head into the Raft FSM, and that
+// state must replicate cluster-wide. They depend on the `reth` namespace, which op-geth
+// does not serve, so they skip on any non-op-reth backend.
+
+const (
+	reorgObservedMetric  = "op_conductor_reorgs_observed_count"
+	reorgCommittedMetric = "op_conductor_reorgs_committed_count"
+)
+
+// requireOpReth skips the test unless the EL backend is op-reth. The acceptance CI
+// matrix runs the same package under an op-geth job (which leaves DEVSTACK_L2EL_KIND
+// unset) and op-reth jobs (which set it).
+func requireOpReth(t devtest.T) {
+	if os.Getenv("DEVSTACK_L2EL_KIND") != "op-reth" {
+		t.Skip("conductor reorg-recovery requires the op-reth reth_subscribeChainNotifications subscription")
+	}
+}
+
+// reorgTrigger describes the invalid-message reorg that was forced on chain B.
+type reorgTrigger struct {
+	invalidBlockNumber    uint64
+	invalidBlockHash      common.Hash
+	invalidBlockTimestamp uint64
+}
+
+// triggerInvalidMessageReorgOnB forces a same-chain reorg on chain B by including an
+// invalid executing message and resuming interop, which invalidates and replaces the
+// offending block. It returns once the EL has replaced the block. Mirrors the trigger in
+// invalid_message_reorg_test.go.
+func triggerInvalidMessageReorgOnB(t devtest.T, sys *presets.TwoL2SupernodeInteropWithConductors) reorgTrigger {
+	ctx := t.Ctx()
+
+	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
+	bob := sys.FunderB.NewFundedEOA(eth.OneEther)
+	eventLoggerA := alice.DeployEventLogger()
+
+	sys.L2B.CatchUpTo(sys.L2A)
+	sys.L2A.CatchUpTo(sys.L2B)
+
+	paused := sys.Supernode.EnsureInteropPaused(sys.L2ACL, sys.L2BCL, 10)
+	t.Logger().Info("interop paused", "paused", paused)
+
+	rng := rand.New(rand.NewSource(12345))
+	initMsg := alice.SendRandomInitMessage(rng, eventLoggerA, 2, 10)
+	sys.L2B.WaitForBlock()
+
+	execMsg := bob.SendInvalidExecMessage(initMsg)
+	invalidBlockNumber := bigs.Uint64Strict(execMsg.BlockNumber())
+	invalidBlockHash := execMsg.BlockHash()
+	invalidBlockTimestamp := sys.L2B.TimestampForBlockNum(invalidBlockNumber)
+	t.Logger().Info("invalid executing message sent on chain B",
+		"block", invalidBlockNumber, "hash", invalidBlockHash, "timestamp", invalidBlockTimestamp)
+
+	require.Eventually(t, func() bool {
+		return sys.L2BCL.SyncStatus().LocalSafeL2.Number >= invalidBlockNumber
+	}, 60*time.Second, time.Second, "invalid block should become locally safe")
+
+	sys.Supernode.ResumeInterop()
+	require.Eventually(t, func() bool {
+		currentBlock, err := sys.L2ELB.Escape().EthClient().BlockRefByNumber(ctx, invalidBlockNumber)
+		if err != nil {
+			return false
+		}
+		return currentBlock.Hash != invalidBlockHash
+	}, 60*time.Second, time.Second, "the invalid block at the reorg height should be replaced at the EL")
+
+	return reorgTrigger{
+		invalidBlockNumber:    invalidBlockNumber,
+		invalidBlockHash:      invalidBlockHash,
+		invalidBlockTimestamp: invalidBlockTimestamp,
+	}
+}
+
+func conductorsForChainB(t devtest.T, sys *presets.TwoL2SupernodeInteropWithConductors) dsl.ConductorSet {
+	conductors := sys.ConductorSets[sys.L2B.Escape().ChainID()]
+	require.NotEmpty(t, conductors, "expected conductors for chain B")
+	return conductors
+}
+
+func findLeader(t devtest.T, conductors dsl.ConductorSet) *dsl.Conductor {
+	var leader *dsl.Conductor
+	require.Eventually(t, func() bool {
+		for _, c := range conductors {
+			if c.IsLeader() {
+				leader = c
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 500*time.Millisecond, "a conductor should be leader")
+	return leader
+}
+
+// assertLeaderHeadConverges asserts the leader's recorded unsafe head sits on the
+// canonical EL chain at or beyond the reorg height — i.e. the FSM followed the reorg.
+// LatestUnsafePayload is a leader-only linearizable read (it applies a Raft barrier), so
+// only the leader can serve it; Raft guarantees the committed entry replicates to
+// followers, and Scenario B independently confirms a former follower has it after a
+// leadership transfer.
+func assertLeaderHeadConverges(t devtest.T, conductors dsl.ConductorSet, elClient ethBlockByNumber, minNumber uint64) {
+	ctx := t.Ctx()
+	require.Eventually(t, func() bool {
+		leader := currentLeader(ctx, conductors)
+		if leader == nil {
+			return false
+		}
+		head, err := leaderUnsafePayload(ctx, leader)
+		if err != nil || head == nil {
+			return false
+		}
+		num := uint64(head.ExecutionPayload.BlockNumber)
+		if num < minNumber {
+			return false
+		}
+		ref, err := elClient.BlockRefByNumber(ctx, num)
+		return err == nil && ref.Hash == head.ExecutionPayload.BlockHash
+	}, 90*time.Second, time.Second, "the leader's FSM head should converge to the canonical post-reorg chain")
+}
+
+// currentLeader returns the conductor that currently reports itself leader, or nil. The
+// Leader RPC is a local check (no Raft barrier), so it is safe to call on followers.
+func currentLeader(ctx context.Context, conductors dsl.ConductorSet) *dsl.Conductor {
+	for _, c := range conductors {
+		callCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		isLeader, err := c.Escape().RpcAPI().Leader(callCtx)
+		cancel()
+		if err == nil && isLeader {
+			return c
+		}
+	}
+	return nil
+}
+
+// leaderUnsafePayload reads the leader's recorded unsafe head without the DSL's
+// fail-on-error wrapper, so callers can poll inside require.Eventually.
+func leaderUnsafePayload(ctx context.Context, leader *dsl.Conductor) (*eth.ExecutionPayloadEnvelope, error) {
+	callCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	return leader.Escape().RpcAPI().LatestUnsafePayload(callCtx)
+}
+
+type ethBlockByNumber interface {
+	BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error)
+}
+
+// pickNonLeader returns a voter in the cluster other than the current leader.
+func pickNonLeader(t devtest.T, leader *dsl.Conductor) *consensus.ServerInfo {
+	leaderInfo := leader.FetchLeader()
+	membership := leader.FetchClusterMembership()
+	for i := range membership.Servers {
+		if membership.Servers[i].ID != leaderInfo.ID && membership.Servers[i].Suffrage == consensus.Voter {
+			return &membership.Servers[i]
+		}
+	}
+	t.Require().FailNow("no non-leader voter found in cluster")
+	return nil
+}
+
+// watchClusterHealth polls every conductor for sequencer health and the observed leader
+// until the returned stop func is called, which reports whether any conductor went
+// unhealthy and whether leadership moved away from the initial leader during the window.
+// RPC errors are tolerated (not treated as trips) so the watcher never aborts the test.
+func watchClusterHealth(t devtest.T, conductors dsl.ConductorSet, initialLeader *dsl.Conductor) func() (healthTripped bool, leaderChurned bool) {
+	ctx, cancel := context.WithCancel(t.Ctx())
+	initialLeaderID := initialLeader.FetchLeader().ID
+	var healthTripped, leaderChurned atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				for _, c := range conductors {
+					callCtx, callCancel := context.WithTimeout(ctx, 3*time.Second)
+					healthy, err := c.Escape().RpcAPI().SequencerHealthy(callCtx)
+					leaderInfo, lerr := c.Escape().RpcAPI().LeaderWithID(callCtx)
+					callCancel()
+					if err == nil && !healthy {
+						healthTripped.Store(true)
+					}
+					if lerr == nil && leaderInfo != nil && leaderInfo.ID != "" && leaderInfo.ID != initialLeaderID {
+						leaderChurned.Store(true)
+					}
+				}
+			}
+		}
+	}()
+	return func() (bool, bool) {
+		cancel()
+		<-done
+		return healthTripped.Load(), leaderChurned.Load()
+	}
+}
+
+// TestConductorReorgRecovery covers the flag-ON path on a 3-conductor-per-chain cluster:
+//   - Scenario A: a real op-reth reorg notification drives the leader to commit the
+//     post-reorg head, and it converges cluster-wide.
+//   - Scenario C: only the leader writes the reorg commit (followers stay at 0).
+//   - Scenario B: the post-reorg Raft state survives a leadership transfer.
+func TestConductorReorgRecovery(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	requireOpReth(t)
+
+	// Use the default lenient health-check intervals. The synthetic devstack genesis sits
+	// minutes behind wallclock at startup, so a tight unsafe-staleness interval would trip
+	// every conductor unhealthy at bring-up and churn leadership continuously — which, with
+	// reorg-recovery driving sequencing, prevents the supernode reorg rewind from
+	// converging. With lenient intervals the leader stays stable and the Phase 4 gating
+	// measurement below records whether a realistic reorg still trips it.
+	sys := presets.NewTwoL2SupernodeInteropWithConductors(t, 0,
+		presets.WithConductorReorgRecovery(),
+	)
+	conductors := conductorsForChainB(t, sys)
+	elB := sys.L2ELB.Escape().EthClient()
+
+	leaderBefore := findLeader(t, conductors)
+	t.Logger().Info("chain B leader before reorg", "leader", leaderBefore.String())
+
+	// --- Phase 4 gating measurement: watch for leader health trips / churn during the
+	// reorg window. A transfer is not itself a failure; convergence is the success
+	// criterion. The specific health error (ErrSequencerNotHealthy vs
+	// ErrSequencerConnectionDown) is only visible in conductor logs.
+	stopWatch := watchClusterHealth(t, conductors, leaderBefore)
+
+	trigger := triggerInvalidMessageReorgOnB(t, sys)
+
+	// Scenario A: the subscriber observed a real reth reorg notification, and the leader
+	// committed the post-reorg head.
+	leader := findLeader(t, conductors)
+	require.Eventually(t, func() bool {
+		return leader.ScrapeCounter(reorgObservedMetric) >= 1
+	}, 60*time.Second, time.Second, "leader should observe at least one reth reorg notification")
+	require.GreaterOrEqual(t, leader.ScrapeCounter(reorgCommittedMetric), float64(1),
+		"leader should commit at least one post-reorg head")
+
+	// Scenario A (cont.): the leader's FSM head converges to the canonical post-reorg
+	// chain (Raft replicates the committed entry to followers; Scenario B confirms a
+	// former follower has it after a transfer).
+	assertLeaderHeadConverges(t, conductors, elB, trigger.invalidBlockNumber)
+
+	// Scenario C: only the leader writes — every non-leader's committed count stays 0.
+	for _, c := range conductors {
+		if c.IsLeader() {
+			continue
+		}
+		require.Equal(t, float64(0), c.ScrapeCounter(reorgCommittedMetric),
+			"non-leader conductor %s must not commit reorg heads", c.String())
+	}
+
+	healthTrips, leaderChurned := stopWatch()
+	t.Logger().Info("Phase 4 gating measurement",
+		"leader_health_tripped", healthTrips,
+		"leadership_churned", leaderChurned,
+		"note", "convergence succeeded regardless; specific health error (if any) is in conductor logs")
+
+	// Scenario B: leadership transfer preserves the post-reorg Raft state.
+	currentLeader := findLeader(t, conductors)
+	target := pickNonLeader(t, currentLeader)
+	t.Logger().Info("transferring leadership", "from", currentLeader.String(), "to", target.ID)
+	currentLeader.TransferLeadershipTo(*target)
+
+	var newLeader *dsl.Conductor
+	require.Eventually(t, func() bool {
+		for _, c := range conductors {
+			if c.IsLeader() && c.FetchLeader().ID == target.ID {
+				newLeader = c
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 500*time.Millisecond, "leadership should transfer to the target server")
+
+	head := newLeader.FetchLatestUnsafePayload()
+	num := uint64(head.ExecutionPayload.BlockNumber)
+	require.GreaterOrEqual(t, num, trigger.invalidBlockNumber,
+		"new leader's FSM head should be at or beyond the reorg height")
+	ref, err := elB.BlockRefByNumber(t.Ctx(), num)
+	require.NoError(t, err, "new leader's recorded head should exist on the canonical chain")
+	require.Equal(t, head.ExecutionPayload.BlockHash, ref.Hash,
+		"new leader's recorded head should be canonical — Raft state survived the transfer")
+}
+
+// TestConductorReorgRecoveryDisabled is Scenario D: with reorg-recovery OFF (the
+// default), the same reorg leaves the subscriber fully dormant — no reth subscription is
+// opened and reorgs_observed_count stays 0, proving the flag gates the entire change.
+func TestConductorReorgRecoveryDisabled(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	requireOpReth(t)
+
+	sys := presets.NewTwoL2SupernodeInteropWithConductors(t, 0)
+	conductors := conductorsForChainB(t, sys)
+
+	_ = findLeader(t, conductors)
+	trigger := triggerInvalidMessageReorgOnB(t, sys)
+	t.Logger().Info("reorg triggered with reorg-recovery disabled", "invalid_block", trigger.invalidBlockNumber)
+
+	// The replacement is verified by interop, confirming the chain made progress; the
+	// recovery machinery simply never engaged.
+	sys.Supernode.AwaitValidatedTimestamp(trigger.invalidBlockTimestamp)
+
+	// No conductor opened a reth subscription: the observed counter is dormant at 0.
+	for _, c := range conductors {
+		require.Equal(t, float64(0), c.ScrapeCounter(reorgObservedMetric),
+			"conductor %s must not observe reorgs when reorg-recovery is disabled", c.String())
+		require.Equal(t, float64(0), c.ScrapeCounter(reorgCommittedMetric),
+			"conductor %s must not commit reorg heads when reorg-recovery is disabled", c.String())
+	}
+}

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
-	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
 // TestSupernodeInteropInvalidMessageReplacement runs the invalid-message
@@ -152,51 +151,34 @@ func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2
 		"invalid_block_hash", invalidBlockHash,
 	)
 
-	// We should still be able to include new transactions and have them be fully
-	// validated. After the invalid-message reorg the chain can still be settling for a
-	// while — the light sequencer rebuilds on the supernode's replacement and may briefly
-	// reorg again before converging, and under a loaded executor that recovery can be
-	// several times slower. So don't assert immediate inclusion (which would race a slow
-	// box) or a single pre-settle snapshot. Submit the tx, then assert eventual
-	// consistency: it must end up in a cross-safe block (supernode-validated and
-	// reorg-immune), re-resolving its block on each poll. The whole inclusion + validation
-	// window is covered by one generous timeout rather than the default short inclusion
-	// retry budget.
-	bruce := sys.FunderB.NewFundedEOA(eth.OneEther)
-	tx := txplan.NewPlannedTx(bruce.PlanTransfer(alice.Address(), eth.OneHundredthEther))
-	signed, err := tx.Signed.Eval(ctx)
-	require.NoError(t, err, "sign post-reorg transfer")
-	txHash := signed.Hash()
-	_, err = tx.Submitted.Eval(ctx)
-	require.NoError(t, err, "submit post-reorg transfer")
-	require.Eventually(t, func() bool {
-		client := sys.L2ELB.Escape().EthClient()
-		rcpt, err := client.TransactionReceipt(ctx, txHash)
-		if err != nil {
-			return false // not currently canonical (mid-reorg); keep waiting
-		}
-		// Cross-safe (the EL "safe" label) is supernode-validated and will not reorg.
-		safe, err := client.BlockRefByLabel(ctx, eth.Safe)
-		if err != nil {
-			return false
-		}
-		return safe.Number >= bigs.Uint64Strict(rcpt.BlockNumber)
-	}, 240*time.Second, time.Second, "new tx must reach a cross-safe (validated, reorg-immune) block")
-
-	// CONVERGENCE & STABILITY: every node on the reorged chain must agree on the single
-	// canonical replacement chain AND keep building on top of it — no oscillation back
-	// onto the invalidated fork (the #21119 failure mode). We require each chain's block
-	// producer (L2{A,B}CL — the supernode's virtual sequencer, or the light op-node
-	// sequencer in follow-mode presets) to converge with the supernode's verifier route
-	// (L2{A,B}SupernodeCL) at cross-safe while its local-unsafe head keeps advancing.
+	// CONVERGENCE & STABILITY (settle first): every node on the reorged chain must agree on
+	// the single canonical replacement chain AND keep building on top of it — no oscillation
+	// back onto the invalidated fork (the #21119 failure mode). Each chain's block producer
+	// (L2{A,B}CL — the supernode's virtual sequencer, or the light op-node sequencer in
+	// follow-mode presets) must converge with the supernode's verifier route
+	// (L2{A,B}SupernodeCL) at cross-safe while its local-unsafe head keeps advancing, and
+	// agree at local-safe. MatchedWithProgressFn is progress-aware — it fails on a stall, not
+	// a wall-clock deadline — so it tolerates a slow/loaded executor while still catching a
+	// genuine non-convergence stall. We settle here before transacting below, so the new tx
+	// lands on an already-converged chain instead of racing the in-flight reorgs.
 	dsl.CheckAll(t,
 		sys.L2BCL.MatchedWithProgressFn(sys.L2BSupernodeCL, safety.CrossSafe, safety.LocalUnsafe, 90*time.Second, 30*time.Second),
 		sys.L2ACL.MatchedWithProgressFn(sys.L2ASupernodeCL, safety.CrossSafe, safety.LocalUnsafe, 90*time.Second, 30*time.Second),
 	)
-	// Both nodes on the reorged chain must also agree at local-safe, confirming the
-	// replacement chain (not the fork) is the one they consolidated.
 	dsl.CheckAll(t,
 		sys.L2BCL.MatchedFn(sys.L2BSupernodeCL, safety.LocalSafe, 30),
 		sys.L2ACL.MatchedFn(sys.L2ASupernodeCL, safety.LocalSafe, 30),
 	)
+
+	// With the chain settled on the replacement, a new transaction must still be includable
+	// and fully validated. On the now-converged chain it lands cleanly, so the idiomatic
+	// timestamp-validation flow (the same one used for the replacement block above) is
+	// robust: include it, wait for the supernode to validate its timestamp (which makes its
+	// block cross-safe and reorg-immune), and confirm it is still in its block.
+	bruce := sys.FunderB.NewFundedEOA(eth.OneEther)
+	tx := bruce.Transfer(alice.Address(), eth.OneHundredthEther)
+	txBlock := bigs.Uint64Strict(tx.Included.Value().BlockNumber)
+	txTimestamp := sys.L2B.TimestampForBlockNum(txBlock)
+	sys.Supernode.AwaitValidatedTimestamp(txTimestamp)
+	sys.L2ELB.AssertTxInBlock(txBlock, tx.Included.Value().TxHash)
 }

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -139,15 +139,28 @@ func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2
 		"invalid_block_hash", invalidBlockHash,
 	)
 
-	// We should still be able to include new transactions and have them be fully validated
+	// We should still be able to include new transactions and have them be fully
+	// validated. After the invalid-message reorg the chain can still be settling for a
+	// few blocks — the light sequencer rebuilds on the supernode's replacement and may
+	// briefly reorg again before converging — so assert eventual consistency rather than
+	// a single pre-settle snapshot: the new tx must end up in a cross-safe block
+	// (supernode-validated and reorg-immune), re-resolving its block on each poll.
 	bruce := sys.FunderB.NewFundedEOA(eth.OneEther)
 	tx := bruce.Transfer(alice.Address(), eth.OneHundredthEther)
-	sys.L2ELB.AssertTxInBlock(bigs.Uint64Strict(tx.Included.Value().BlockNumber), tx.Included.Value().TxHash)
-
-	txTimestamp := sys.L2B.TimestampForBlockNum(bigs.Uint64Strict(tx.Included.Value().BlockNumber))
-	sys.Supernode.AwaitValidatedTimestamp(txTimestamp)
-	// Should still have the tx in the block.
-	sys.L2ELB.AssertTxInBlock(bigs.Uint64Strict(tx.Included.Value().BlockNumber), tx.Included.Value().TxHash)
+	txHash := tx.Included.Value().TxHash
+	require.Eventually(t, func() bool {
+		client := sys.L2ELB.Escape().EthClient()
+		rcpt, err := client.TransactionReceipt(ctx, txHash)
+		if err != nil {
+			return false // not currently canonical (mid-reorg); keep waiting
+		}
+		// Cross-safe (the EL "safe" label) is supernode-validated and will not reorg.
+		safe, err := client.BlockRefByLabel(ctx, eth.Safe)
+		if err != nil {
+			return false
+		}
+		return safe.Number >= rcpt.BlockNumber.Uint64()
+	}, 120*time.Second, time.Second, "new tx must reach a cross-safe (validated, reorg-immune) block")
 
 	// CONVERGENCE & STABILITY: every node on the reorged chain must agree on the single
 	// canonical replacement chain AND keep building on top of it — no oscillation back

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -29,21 +29,13 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 }
 
 // TestSupernodeLightSequencerInteropInvalidMessageReplacement is the follow-mode
-// (light op-node CL sequencer) analogue of TestSupernodeInteropInvalidMessageReplacement.
-// The light CLs sequence unsafe blocks on their own ELs and follow the shared
-// supernode's safe head via EL sync. It asserts the follower adopts the supernode's
-// deposits-only replacement after an invalid executing message and the chain keeps
-// making validated progress. See https://github.com/ethereum-optimism/optimism/issues/21119.
+// (light op-node CL sequencer) analogue of TestSupernodeInteropInvalidMessageReplacement:
+// the light CLs sequence on their own ELs and follow the shared supernode's safe head via
+// EL sync. See https://github.com/ethereum-optimism/optimism/issues/21119.
 //
-// op-reth only: on op-geth this scenario consistently does not converge (0/12 locally).
-// After the deposits-only replacement, the op-geth follower never adopts the supernode's
-// replacement block — cross-safe stalls at the replacement height while the sequencer
-// keeps building a divergent chain above it, so the follow-source reorg fires every tick
-// and no block past the replacement is ever validated. The new transaction therefore
-// never gets a stable receipt (`tx.Included` fails with "after 5 attempts: not found").
-// The virtual-sequencer variant above passes on op-geth, so this is specific to the
-// light-sequencer follow path. op-geth is being deprecated, so we skip rather than block
-// on it; tracked for follow-up.
+// op-reth only. On op-geth the follower never adopts the replacement (cross-safe stalls,
+// follow-source reorgs forever); the virtual variant passes there, so it's specific to the
+// light-sequencer path. op-geth is being deprecated, so we skip rather than block on it.
 func TestSupernodeLightSequencerInteropInvalidMessageReplacement(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sysgo.SkipOnOpGeth(t, "light-sequencer follow-mode reorg recovery does not converge on op-geth (op-geth deprecating); see #21119")
@@ -153,33 +145,22 @@ func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2
 		"invalid_block_hash", invalidBlockHash,
 	)
 
-	// CONVERGENCE & STABILITY (settle first): every node on the reorged chain must agree on
-	// the single canonical replacement chain AND keep building on top of it — no oscillation
-	// back onto the invalidated fork (the #21119 failure mode). Each chain's block producer
-	// (L2{A,B}CL — the supernode's virtual sequencer, or the light op-node sequencer in
-	// follow-mode presets) must converge with the supernode's verifier route
-	// (L2{A,B}SupernodeCL) at cross-safe while its local-unsafe head keeps advancing, and
-	// agree at local-safe. MatchedWithProgressFn is progress-aware — it fails on a stall, not
-	// a wall-clock deadline — so it tolerates a slow/loaded executor while still catching a
-	// genuine non-convergence stall. We settle here before transacting below, so the new tx
-	// lands on an already-converged chain instead of racing the in-flight reorgs.
+	// Settle before transacting. Cross-safe is pinned at the replacement while the
+	// follow-source oscillates (#21119), and only advances once the divergence resolves, so
+	// gate on cross-safe advancing — not a match, which passes trivially while both sides are
+	// pinned. A tx sequenced mid-oscillation would land in a fork block and get orphaned.
 	dsl.CheckAll(t,
-		sys.L2BCL.MatchedWithProgressFn(sys.L2BSupernodeCL, safety.CrossSafe, safety.LocalUnsafe, 90*time.Second, 30*time.Second),
-		sys.L2ACL.MatchedWithProgressFn(sys.L2ASupernodeCL, safety.CrossSafe, safety.LocalUnsafe, 90*time.Second, 30*time.Second),
+		sys.L2ACL.AdvancedFn(safety.CrossSafe, 3, 45),
+		sys.L2BCL.AdvancedFn(safety.CrossSafe, 3, 45),
 	)
 	dsl.CheckAll(t,
-		sys.L2BCL.MatchedFn(sys.L2BSupernodeCL, safety.LocalSafe, 30),
-		sys.L2ACL.MatchedFn(sys.L2ASupernodeCL, safety.LocalSafe, 30),
+		sys.L2ACL.MatchedFn(sys.L2ASupernodeCL, safety.CrossSafe, 30),
+		sys.L2BCL.MatchedFn(sys.L2BSupernodeCL, safety.CrossSafe, 30),
 	)
 
-	// With the chain settled on the replacement, a new transaction must still be includable
-	// and fully validated. On the now-converged chain it lands cleanly, so the idiomatic
-	// timestamp-validation flow (the same one used for the replacement block above) is
-	// robust: include it, wait for the supernode to validate its timestamp (which makes its
-	// block cross-safe and reorg-immune), and confirm it is still in its block. We widen the
-	// inclusion budget from the default 5 to 10 attempts (matching the contention-sensitive
-	// txs in isthmus/superroot) so a saturated CI executor with slow block production still
-	// produces the receipt — this is an attempt-bounded retry, not a wall-clock deadline.
+	// A new tx on the settled chain must still be includable and validated. The 10-attempt
+	// inclusion budget (vs the default 5, matching isthmus/superroot) tolerates slow block
+	// production on a loaded executor.
 	bruce := sys.FunderB.NewFundedEOA(eth.OneEther)
 	tx := bruce.Transact(
 		bruce.PlanTransfer(alice.Address(), eth.OneHundredthEther),

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
 // TestSupernodeInteropInvalidMessageReplacement runs the invalid-message
@@ -153,13 +154,21 @@ func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2
 
 	// We should still be able to include new transactions and have them be fully
 	// validated. After the invalid-message reorg the chain can still be settling for a
-	// few blocks — the light sequencer rebuilds on the supernode's replacement and may
-	// briefly reorg again before converging — so assert eventual consistency rather than
-	// a single pre-settle snapshot: the new tx must end up in a cross-safe block
-	// (supernode-validated and reorg-immune), re-resolving its block on each poll.
+	// while — the light sequencer rebuilds on the supernode's replacement and may briefly
+	// reorg again before converging, and under a loaded executor that recovery can be
+	// several times slower. So don't assert immediate inclusion (which would race a slow
+	// box) or a single pre-settle snapshot. Submit the tx, then assert eventual
+	// consistency: it must end up in a cross-safe block (supernode-validated and
+	// reorg-immune), re-resolving its block on each poll. The whole inclusion + validation
+	// window is covered by one generous timeout rather than the default short inclusion
+	// retry budget.
 	bruce := sys.FunderB.NewFundedEOA(eth.OneEther)
-	tx := bruce.Transfer(alice.Address(), eth.OneHundredthEther)
-	txHash := tx.Included.Value().TxHash
+	tx := txplan.NewPlannedTx(bruce.PlanTransfer(alice.Address(), eth.OneHundredthEther))
+	signed, err := tx.Signed.Eval(ctx)
+	require.NoError(t, err, "sign post-reorg transfer")
+	txHash := signed.Hash()
+	_, err = tx.Submitted.Eval(ctx)
+	require.NoError(t, err, "submit post-reorg transfer")
 	require.Eventually(t, func() bool {
 		client := sys.L2ELB.Escape().EthClient()
 		rcpt, err := client.TransactionReceipt(ctx, txHash)
@@ -172,7 +181,7 @@ func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2
 			return false
 		}
 		return safe.Number >= bigs.Uint64Strict(rcpt.BlockNumber)
-	}, 120*time.Second, time.Second, "new tx must reach a cross-safe (validated, reorg-immune) block")
+	}, 240*time.Second, time.Second, "new tx must reach a cross-safe (validated, reorg-immune) block")
 
 	// CONVERGENCE & STABILITY: every node on the reorged chain must agree on the single
 	// canonical replacement chain AND keep building on top of it — no oscillation back

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
 // TestSupernodeInteropInvalidMessageReplacement runs the invalid-message
@@ -174,9 +176,15 @@ func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2
 	// and fully validated. On the now-converged chain it lands cleanly, so the idiomatic
 	// timestamp-validation flow (the same one used for the replacement block above) is
 	// robust: include it, wait for the supernode to validate its timestamp (which makes its
-	// block cross-safe and reorg-immune), and confirm it is still in its block.
+	// block cross-safe and reorg-immune), and confirm it is still in its block. We widen the
+	// inclusion budget from the default 5 to 10 attempts (matching the contention-sensitive
+	// txs in isthmus/superroot) so a saturated CI executor with slow block production still
+	// produces the receipt — this is an attempt-bounded retry, not a wall-clock deadline.
 	bruce := sys.FunderB.NewFundedEOA(eth.OneEther)
-	tx := bruce.Transfer(alice.Address(), eth.OneHundredthEther)
+	tx := bruce.Transact(
+		bruce.PlanTransfer(alice.Address(), eth.OneHundredthEther),
+		txplan.WithRetryInclusion(sys.L2ELB.Escape().EthClient(), 10, retry.Exponential()),
+	)
 	txBlock := bigs.Uint64Strict(tx.Included.Value().BlockNumber)
 	txTimestamp := sys.L2B.TimestampForBlockNum(txBlock)
 	sys.Supernode.AwaitValidatedTimestamp(txTimestamp)

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
@@ -28,11 +29,22 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 // TestSupernodeLightSequencerInteropInvalidMessageReplacement is the follow-mode
 // (light op-node CL sequencer) analogue of TestSupernodeInteropInvalidMessageReplacement.
 // The light CLs sequence unsafe blocks on their own ELs and follow the shared
-// supernode's safe head (consensus-layer sync, the production default). It asserts
-// the follower adopts the supernode's deposits-only replacement after an invalid
-// executing message. See https://github.com/ethereum-optimism/optimism/issues/21119.
+// supernode's safe head via EL sync. It asserts the follower adopts the supernode's
+// deposits-only replacement after an invalid executing message and the chain keeps
+// making validated progress. See https://github.com/ethereum-optimism/optimism/issues/21119.
+//
+// op-reth only: on op-geth this scenario consistently does not converge (0/12 locally).
+// After the deposits-only replacement, the op-geth follower never adopts the supernode's
+// replacement block — cross-safe stalls at the replacement height while the sequencer
+// keeps building a divergent chain above it, so the follow-source reorg fires every tick
+// and no block past the replacement is ever validated. The new transaction therefore
+// never gets a stable receipt (`tx.Included` fails with "after 5 attempts: not found").
+// The virtual-sequencer variant above passes on op-geth, so this is specific to the
+// light-sequencer follow path. op-geth is being deprecated, so we skip rather than block
+// on it; tracked for follow-up.
 func TestSupernodeLightSequencerInteropInvalidMessageReplacement(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	sysgo.SkipOnOpGeth(t, "light-sequencer follow-mode reorg recovery does not converge on op-geth (op-geth deprecating); see #21119")
 	sys := presets.NewTwoL2SupernodeLightSequencerInterop(t, 0)
 	runInteropInvalidMessageReplacementScenario(t, sys)
 }
@@ -159,7 +171,7 @@ func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2
 		if err != nil {
 			return false
 		}
-		return safe.Number >= rcpt.BlockNumber.Uint64()
+		return safe.Number >= bigs.Uint64Strict(rcpt.BlockNumber)
 	}, 120*time.Second, time.Second, "new tx must reach a cross-safe (validated, reorg-immune) block")
 
 	// CONVERGENCE & STABILITY: every node on the reorged chain must agree on the single

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -10,12 +10,37 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
-// TestSupernodeInteropInvalidMessageReplacement tests that:
+// TestSupernodeInteropInvalidMessageReplacement runs the invalid-message
+// replacement scenario with the supernode virtual sequencer.
+func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewTwoL2SupernodeInterop(t, 0)
+	runInteropInvalidMessageReplacementScenario(t, sys)
+}
+
+// TestSupernodeLightSequencerInteropInvalidMessageReplacement is the follow-mode
+// (light op-node CL sequencer) analogue of TestSupernodeInteropInvalidMessageReplacement.
+// The light CLs sequence unsafe blocks on their own ELs and follow the shared
+// supernode's safe head (consensus-layer sync, the production default). It asserts
+// the follower adopts the supernode's deposits-only replacement after an invalid
+// executing message. See https://github.com/ethereum-optimism/optimism/issues/21119.
+func TestSupernodeLightSequencerInteropInvalidMessageReplacement(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewTwoL2SupernodeLightSequencerInterop(t, 0)
+	runInteropInvalidMessageReplacementScenario(t, sys)
+}
+
+// runInteropInvalidMessageReplacementScenario drives the invalid-message replacement
+// scenario against an already-constructed two-L2 supernode interop system, so the
+// caller owns the sequencer topology (virtual sequencer vs light op-node follow-CL).
+//
 // WHEN: an invalid Executing Message is included in a chain
 // THEN:
 // - The interop activity detects the invalid block
@@ -23,10 +48,7 @@ import (
 // - A reset/rewind is triggered if the chain is using that block
 // - A replacement block is built at the same height (deposits-only)
 // - The replacement block's timestamp eventually becomes verified
-func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
-	t := devtest.SerialT(gt)
-	sys := presets.NewTwoL2SupernodeInterop(t, 0)
-
+func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
 	ctx := t.Ctx()
 
 	// Create funded EOAs on both chains
@@ -126,4 +148,21 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 	sys.Supernode.AwaitValidatedTimestamp(txTimestamp)
 	// Should still have the tx in the block.
 	sys.L2ELB.AssertTxInBlock(bigs.Uint64Strict(tx.Included.Value().BlockNumber), tx.Included.Value().TxHash)
+
+	// CONVERGENCE & STABILITY: every node on the reorged chain must agree on the single
+	// canonical replacement chain AND keep building on top of it — no oscillation back
+	// onto the invalidated fork (the #21119 failure mode). We require each chain's block
+	// producer (L2{A,B}CL — the supernode's virtual sequencer, or the light op-node
+	// sequencer in follow-mode presets) to converge with the supernode's verifier route
+	// (L2{A,B}SupernodeCL) at cross-safe while its local-unsafe head keeps advancing.
+	dsl.CheckAll(t,
+		sys.L2BCL.MatchedWithProgressFn(sys.L2BSupernodeCL, safety.CrossSafe, safety.LocalUnsafe, 90*time.Second, 30*time.Second),
+		sys.L2ACL.MatchedWithProgressFn(sys.L2ASupernodeCL, safety.CrossSafe, safety.LocalUnsafe, 90*time.Second, 30*time.Second),
+	)
+	// Both nodes on the reorged chain must also agree at local-safe, confirming the
+	// replacement chain (not the fork) is the one they consolidated.
+	dsl.CheckAll(t,
+		sys.L2BCL.MatchedFn(sys.L2BSupernodeCL, safety.LocalSafe, 30),
+		sys.L2ACL.MatchedFn(sys.L2ASupernodeCL, safety.LocalSafe, 30),
+	)
 }

--- a/op-conductor/README.md
+++ b/op-conductor/README.md
@@ -14,7 +14,11 @@ intended to run inside a private network with access restricted to authorized us
 
 The design will provide below guarantees:
 
-1. No unsafe reorgs
+1. No unsafe reorgs (default). With `--reorg-recovery.enabled` set, this guarantee is
+   intentionally relaxed: the recorded unsafe head **can move backward** to follow an
+   op-reth interop reorg (last-write-wins in the FSM), driven by a
+   `reth_subscribeChainNotifications` subscription on the leader. With the flag OFF (the
+   default) the guarantee holds exactly as before.
 2. No unsafe head stall during network partition
 3. 100% uptime with no more than 1 node failure (for a standard 3 node setup)
 
@@ -49,6 +53,22 @@ On a high level, op-conductor serves the following functions:
 Helpful tips:
 To better understand the graph, focus on one node at a time, understand what can be transitioned to this current state and how it can transition to other states.
 This way you could understand how we handle the state transitions.
+
+### Reorg recovery (optional, `--reorg-recovery.enabled`)
+
+By default the FSM only records forward-moving unsafe heads, so a backward interop
+reorg leaves the recorded head pinned to the orphaned block (issue #20006). When
+`--reorg-recovery.enabled` is set, the leader subscribes to its op-reth's
+`reth_subscribeChainNotifications` over a WebSocket (`--execution.ws-url`). On a reorg
+notification it reads the EL's current canonical head (`eth_getBlockByNumber` for the
+unsafe label — the authoritative post-reorg tip, since the notification itself carries
+no block hash), fetches the full payload, and commits it via the existing
+`CommitUnsafePayload`. The FSM's forward-only guard is bypassed in this mode so the
+recorded head can move backward.
+
+**This flag changes Raft FSM apply semantics and MUST be set identically on every
+conductor in the cluster — all-on or all-off, never mixed.** A mixed setting causes
+silent FSM divergence. See [RUNBOOK.md](./RUNBOOK.md) for the operational contract.
 
 ### RPC design
 

--- a/op-conductor/README.md
+++ b/op-conductor/README.md
@@ -66,6 +66,20 @@ no block hash), fetches the full payload, and commits it via the existing
 `CommitUnsafePayload`. The FSM's forward-only guard is bypassed in this mode so the
 recorded head can move backward.
 
+A deep reorg rewinds the unsafe head far enough to trip the unsafe-staleness health
+check, which would normally transfer leadership away before the leader processes the
+(one-shot, non-replayed) reorg notification — wedging the cluster on the pre-reorg head.
+To close that race, this mode adds a **non-cancellable demotion grace** (5s): the first
+staleness observation keeps the leader reporting healthy for the grace so it can commit
+the post-reorg head, then demotes it **unconditionally** at expiry (a fresh block
+timestamp does not prove a correct chain, so a healthy poll during the grace cannot
+cancel the demotion). `ErrSequencerConnectionDown` still fails over immediately. Cost: up
+to ~5s added failover latency on a stuck-but-connected sequencer, and one guaranteed
+leadership handoff per deep reorg (shallow reorgs never trip staleness, so they are
+unaffected). The grace is 0 (today's immediate demotion) when the flag is off. Separately,
+because the subscription has no replay, the leader re-commits its EL's current head on
+every (re)subscribe, recovering any reorg missed during a WebSocket disconnect.
+
 **This flag changes Raft FSM apply semantics and MUST be set identically on every
 conductor in the cluster — all-on or all-off, never mixed.** A mixed setting causes
 silent FSM divergence. See [RUNBOOK.md](./RUNBOOK.md) for the operational contract.

--- a/op-conductor/RUNBOOK.md
+++ b/op-conductor/RUNBOOK.md
@@ -31,7 +31,32 @@ OP_CONDUCTOR_HEALTHCHECK_INTERVAL=<healthcheck-interval> # in seconds
 OP_CONDUCTOR_HEALTHCHECK_UNSAFE_INTERVAL=<unsafe-interval> # Interval allowed between unsafe head and now measured in seconds
 OP_CONDUCTOR_HEALTHCHECK_MIN_PEER_COUNT=<min-peer-count> # minimum number of peers required to be considered healthy
 OP_CONDUCTOR_RAFT_BOOTSTRAP=true/false # set to true if you want to bootstrap the raft cluster
+
+# Reorg recovery (optional, op-reth only). Both must be set together.
+OP_CONDUCTOR_REORG_RECOVERY_ENABLED=true/false # default false
+OP_CONDUCTOR_EXECUTION_WS_URL=<execution-ws-url> # for example, ws://op-reth:8546 ; required when reorg-recovery is enabled
 ```
+
+#### Reorg recovery (`OP_CONDUCTOR_REORG_RECOVERY_ENABLED`)
+
+When enabled, op-conductor subscribes to its op-reth's
+`reth_subscribeChainNotifications` (over `OP_CONDUCTOR_EXECUTION_WS_URL`) and, on a
+reorg, moves the recorded unsafe head backward to follow the EL — relaxing the default
+"no unsafe reorgs" guarantee. Requirements and constraints:
+
+- **op-reth only.** The op-reth pod must enable `--ws` and include `reth` in `--ws.api`.
+  The WS endpoint must be bound **pod-local / cluster-internal** — with the FSM guard
+  bypassed, this signal is part of the consensus trust boundary, and the `reth`
+  namespace must not expose unrelated admin methods.
+- **MUST be fleet-uniform.** The flag changes Raft FSM apply semantics, so it MUST be
+  set **identically on every conductor in the cluster — all-on or all-off, never
+  mixed.** A mixed setting causes silent Raft FSM divergence with no in-protocol
+  detection.
+- **A toggle is a coordinated, state-incompatible event.** Raft snapshots and logs are
+  not portable across a flag flip (a backward entry applies differently under each flag
+  value). Enabling or disabling is **not** a hot-flip: follow the
+  "Redeploy a HA sequencer" / "Disaster recovery" procedures below and treat it as a
+  single coordinated version + config change across the whole cluster.
 
 ### How to bootstrap a sequencer cluster from scratch
 

--- a/op-conductor/RUNBOOK.md
+++ b/op-conductor/RUNBOOK.md
@@ -57,6 +57,16 @@ reorg, moves the recorded unsafe head backward to follow the EL — relaxing the
   value). Enabling or disabling is **not** a hot-flip: follow the
   "Redeploy a HA sequencer" / "Disaster recovery" procedures below and treat it as a
   single coordinated version + config change across the whole cluster.
+- **Adds a 5s demotion grace on staleness.** A deep reorg rewinds the unsafe head far
+  enough to trip the staleness health check; without a grace, leadership would transfer
+  away before the leader commits the (one-shot, non-replayed) reorg notification, wedging
+  the cluster. In this mode the first staleness observation holds the leader healthy for
+  5s so it can commit the post-reorg head, then demotes it **unconditionally** (a healthy
+  poll during the grace cannot cancel it). Operational effects: (1) up to ~5s extra
+  failover latency on a stuck-but-connected sequencer (a genuine connection loss still
+  fails over immediately); (2) one guaranteed leadership handoff per deep reorg. Shallow
+  reorgs never trip staleness and see no change. With the flag off the grace is 0
+  (immediate demotion, exactly as before).
 
 ### How to bootstrap a sequencer cluster from scratch
 

--- a/op-conductor/chainevents/subscriber.go
+++ b/op-conductor/chainevents/subscriber.go
@@ -1,0 +1,205 @@
+package chainevents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/ethereum/go-ethereum/log"
+
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
+)
+
+const (
+	// subscribeMethod is reth's chain-notifications subscription method.
+	subscribeMethod = "reth_subscribeChainNotifications"
+	// minBackoff and maxBackoff bound the reconnect backoff. Backoff is applied on
+	// ALL errors (dial, subscribe, read, parse) — unlike the flashblocks handler,
+	// which busy-spins on read errors and would hot-loop against an accept-then-EOF EL.
+	minBackoff = 1 * time.Second
+	maxBackoff = 30 * time.Second
+	// readTimeout bounds a single Read while waiting for the next notification.
+	readTimeout = 60 * time.Second
+)
+
+// ReorgEvent is emitted when op-reth reports a chain reorg. The reth notification
+// does not carry block hashes, so only block numbers are available; the handler
+// reads the authoritative head hash from the EL.
+type ReorgEvent struct {
+	// OldTipNumber is the highest block number of the reverted ("old") chain.
+	OldTipNumber uint64
+	// NewTipNumber is the highest block number of the replacement ("new") chain.
+	// HasNewTip is false on a pure revert (empty "new" chain).
+	NewTipNumber uint64
+	HasNewTip    bool
+}
+
+// Subscriber maintains a WebSocket subscription to op-reth's reorg notifications,
+// reconnecting with capped backoff, and delivers ReorgEvents on out.
+//
+// out is a cap-1 channel shared with the consumer. Delivery is non-blocking and
+// coalesces to the latest event (see deliver): the read loop never blocks on a
+// busy consumer, so reth's tokio::broadcast lagged-receiver drop is not tripped
+// while the consumer is mid-fetch. A coalesced/stale event is safe because the
+// handler re-reads the EL's current head before committing.
+type Subscriber struct {
+	log   log.Logger
+	wsURL string
+	out   chan ReorgEvent
+}
+
+// NewSubscriber creates a Subscriber that delivers reorg events on out (cap 1).
+func NewSubscriber(logger log.Logger, wsURL string, out chan ReorgEvent) *Subscriber {
+	return &Subscriber{log: logger, wsURL: wsURL, out: out}
+}
+
+// Start runs the subscription loop on its own goroutine until ctx is cancelled.
+func (s *Subscriber) Start(ctx context.Context) {
+	go s.run(ctx)
+}
+
+func (s *Subscriber) run(ctx context.Context) {
+	backoff := minBackoff
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		subscribed, err := s.connectAndRead(ctx)
+		if subscribed {
+			// A live connection resets the backoff so a later drop reconnects fast.
+			backoff = minBackoff
+		}
+		if err == nil {
+			// connectAndRead only returns nil error on ctx cancellation.
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		s.log.Warn("reth reorg subscription error; reconnecting", "err", err, "backoff", backoff)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff = nextBackoff(backoff)
+	}
+}
+
+func nextBackoff(d time.Duration) time.Duration {
+	d *= 2
+	if d > maxBackoff {
+		return maxBackoff
+	}
+	return d
+}
+
+// connectAndRead dials, subscribes, and reads notifications until an error or ctx
+// cancellation. subscribed reports whether the subscribe handshake succeeded (used
+// by run to reset backoff). It returns a nil error only when ctx is cancelled.
+func (s *Subscriber) connectAndRead(ctx context.Context) (subscribed bool, err error) {
+	conn, err := opclient.DialWS(ctx, opclient.WSConfig{
+		URL:         s.wsURL,
+		MaxAttempts: 1,
+		Log:         s.log,
+	})
+	if err != nil {
+		return false, fmt.Errorf("dial: %w", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "closing reorg subscription")
+
+	req := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":%q,"params":[]}`, subscribeMethod)
+	if err := conn.Write(ctx, websocket.MessageText, []byte(req)); err != nil {
+		return false, fmt.Errorf("write subscribe request: %w", err)
+	}
+	if err := s.readSubscribeResponse(ctx, conn); err != nil {
+		return false, err
+	}
+	s.log.Info("subscribed to reth chain notifications", "url", s.wsURL)
+
+	for {
+		if ctx.Err() != nil {
+			return true, nil
+		}
+		readCtx, cancel := context.WithTimeout(ctx, readTimeout)
+		_, data, readErr := conn.Read(readCtx)
+		cancel()
+		if readErr != nil {
+			return true, fmt.Errorf("read notification: %w", readErr)
+		}
+		s.handleFrame(data)
+	}
+}
+
+func (s *Subscriber) readSubscribeResponse(ctx context.Context, conn *opclient.WSClient) error {
+	readCtx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+	_, data, err := conn.Read(readCtx)
+	if err != nil {
+		return fmt.Errorf("read subscribe response: %w", err)
+	}
+	var resp subscribeResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("decode subscribe response: %w", err)
+	}
+	if resp.Error != nil {
+		return fmt.Errorf("subscribe rejected: %s", string(*resp.Error))
+	}
+	if resp.Result == "" {
+		return fmt.Errorf("subscribe response missing subscription id: %s", string(data))
+	}
+	return nil
+}
+
+// handleFrame parses a single WS frame and, on a Reorg notification, delivers a
+// ReorgEvent. Commit notifications (forward sealed blocks) are ignored: those are
+// already covered by op-node's existing forward CommitUnsafePayload writes.
+func (s *Subscriber) handleFrame(data []byte) {
+	var env notificationEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		s.log.Warn("failed to decode reth notification envelope", "err", err)
+		return
+	}
+	if len(env.Params.Result) == 0 {
+		return // not a subscription notification
+	}
+	var notif canonStateNotification
+	if err := json.Unmarshal(env.Params.Result, &notif); err != nil {
+		s.log.Warn("failed to decode chain notification", "err", err)
+		return
+	}
+	if notif.Reorg == nil {
+		return // Commit (forward) variant
+	}
+	ev := ReorgEvent{}
+	if n, ok := notif.Reorg.Old.tipNumber(); ok {
+		ev.OldTipNumber = n
+	}
+	if n, ok := notif.Reorg.New.tipNumber(); ok {
+		ev.NewTipNumber = n
+		ev.HasNewTip = true
+	}
+	s.deliver(ev)
+}
+
+// deliver performs a non-blocking, best-effort-latest send on the cap-1 channel.
+// A bare drop on a cap-1 channel is not latest-wins, so on a full channel we drain
+// the stale buffered event and store the newest. If the consumer reads concurrently
+// between drain and re-send, the channel may momentarily hold a slightly older event
+// — the guarantee is "best-effort latest, made safe by handler-side re-validation".
+func (s *Subscriber) deliver(ev ReorgEvent) {
+	select {
+	case s.out <- ev:
+	default:
+		select {
+		case <-s.out:
+		default:
+		}
+		select {
+		case s.out <- ev:
+		default:
+		}
+	}
+}

--- a/op-conductor/chainevents/subscriber.go
+++ b/op-conductor/chainevents/subscriber.go
@@ -34,6 +34,12 @@ type ReorgEvent struct {
 	// HasNewTip is false on a pure revert (empty "new" chain).
 	NewTipNumber uint64
 	HasNewTip    bool
+	// Resync marks a synthetic catch-up trigger emitted on each successful (re)subscribe,
+	// not a reth-reported reorg. reth_subscribeChainNotifications has no replay, so a reorg
+	// that lands during a WS disconnect is lost; re-reading and committing the EL's current
+	// unsafe head on reconnect reconciles any reorg missed during the gap. Idempotent: a
+	// no-op when the EL head already matches the FSM head.
+	Resync bool
 }
 
 // Subscriber maintains a WebSocket subscription to op-reth's reorg notifications,
@@ -118,6 +124,10 @@ func (s *Subscriber) connectAndRead(ctx context.Context) (subscribed bool, err e
 		return false, err
 	}
 	s.log.Info("subscribed to reth chain notifications", "url", s.wsURL)
+	// Emit a catch-up trigger on every (re)subscribe so the leader reconciles its EL's
+	// current unsafe head, recovering any reorg missed while the WS was disconnected
+	// (reth notifications have no replay). Idempotent on the handler side.
+	s.deliver(ReorgEvent{Resync: true})
 
 	for {
 		if ctx.Err() != nil {

--- a/op-conductor/chainevents/subscriber_test.go
+++ b/op-conductor/chainevents/subscriber_test.go
@@ -1,9 +1,16 @@
 package chainevents
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/coder/websocket"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -82,6 +89,129 @@ func TestDeliverCoalescesToLatest(t *testing.T) {
 		t.Fatalf("expected only one buffered event, got extra %+v", extra)
 	default:
 	}
+}
+
+// subscribeResp is a minimal valid JSON-RPC subscribe reply carrying a subscription id.
+const subscribeResp = `{"jsonrpc":"2.0","id":1,"result":"0x1"}`
+
+// reorgFrameA tips old at 47, new at 45.
+const reorgFrameA = `{"jsonrpc":"2.0","method":"reth_subscribeChainNotifications","params":{"subscription":"0x1","result":{"Reorg":{"old":{"blocks":{"45":{},"46":{},"47":{}}},"new":{"blocks":{"45":{}}}}}}}`
+
+// reorgFrameB tips old at 60, new at 58.
+const reorgFrameB = `{"jsonrpc":"2.0","method":"reth_subscribeChainNotifications","params":{"subscription":"0x1","result":{"Reorg":{"old":{"blocks":{"58":{},"59":{},"60":{}}},"new":{"blocks":{"58":{}}}}}}}`
+
+// wsURLOf converts an httptest server URL to a ws:// URL.
+func wsURLOf(srv *httptest.Server) string {
+	return "ws" + strings.TrimPrefix(srv.URL, "http")
+}
+
+// recv reads one event from out within a generous timeout, failing the test otherwise.
+func recv(t *testing.T, out <-chan ReorgEvent) ReorgEvent {
+	t.Helper()
+	select {
+	case ev := <-out:
+		return ev
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for a ReorgEvent")
+		return ReorgEvent{}
+	}
+}
+
+// TestSubscriberReconnectsAndResubscribes drives the full reconnect path: the first
+// connection delivers a reorg then drops; the subscriber must reconnect, re-subscribe,
+// emit a fresh catch-up (Resync) trigger, and resume delivering reorgs.
+func TestSubscriberReconnectsAndResubscribes(t *testing.T) {
+	var subscribeCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.CloseNow() }()
+		ctx := r.Context()
+		if _, _, err := c.Read(ctx); err != nil { // subscribe request
+			return
+		}
+		n := subscribeCount.Add(1)
+		if err := c.Write(ctx, websocket.MessageText, []byte(subscribeResp)); err != nil {
+			return
+		}
+		if n == 1 {
+			// Deliver a reorg, then drop the connection to force a reconnect.
+			_ = c.Write(ctx, websocket.MessageText, []byte(reorgFrameA))
+			time.Sleep(100 * time.Millisecond)
+			return // defer CloseNow drops the socket
+		}
+		// Subsequent connections: deliver another reorg and stay open until teardown.
+		_ = c.Write(ctx, websocket.MessageText, []byte(reorgFrameB))
+		<-ctx.Done()
+	}))
+	defer srv.Close()
+
+	out := make(chan ReorgEvent, 16)
+	s := NewSubscriber(log.NewLogger(log.DiscardHandler()), wsURLOf(srv), out)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.Start(ctx)
+
+	// First subscribe → catch-up Resync, then the conn-1 reorg.
+	require.True(t, recv(t, out).Resync, "first (re)subscribe must emit a Resync catch-up trigger")
+	ev := recv(t, out)
+	require.False(t, ev.Resync)
+	require.Equal(t, uint64(47), ev.OldTipNumber)
+	require.Equal(t, uint64(45), ev.NewTipNumber)
+
+	// After the drop the subscriber reconnects: a second Resync, then the conn-2 reorg.
+	require.True(t, recv(t, out).Resync, "reconnect must re-subscribe and emit another Resync")
+	ev = recv(t, out)
+	require.False(t, ev.Resync)
+	require.Equal(t, uint64(60), ev.OldTipNumber)
+	require.Equal(t, uint64(58), ev.NewTipNumber)
+
+	require.GreaterOrEqual(t, subscribeCount.Load(), int32(2), "subscriber must have re-subscribed after the drop")
+}
+
+// TestSubscriberCommitFramesKeepReadAlive guards against filtering Commit frames at the
+// transport layer: a Commit frame must be read and ignored (not reconnected on), and a
+// following Reorg on the SAME connection must still be delivered.
+func TestSubscriberCommitFramesKeepReadAlive(t *testing.T) {
+	var subscribeCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.CloseNow() }()
+		ctx := r.Context()
+		if _, _, err := c.Read(ctx); err != nil {
+			return
+		}
+		subscribeCount.Add(1)
+		if err := c.Write(ctx, websocket.MessageText, []byte(subscribeResp)); err != nil {
+			return
+		}
+		// Commit first (must be consumed and ignored), then a Reorg on the same socket.
+		_ = c.Write(ctx, websocket.MessageText, []byte(commitFrame))
+		_ = c.Write(ctx, websocket.MessageText, []byte(reorgFrameA))
+		<-ctx.Done()
+	}))
+	defer srv.Close()
+
+	out := make(chan ReorgEvent, 16)
+	s := NewSubscriber(log.NewLogger(log.DiscardHandler()), wsURLOf(srv), out)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.Start(ctx)
+
+	require.True(t, recv(t, out).Resync)
+	// The very next event is the Reorg — proving the Commit frame was read and skipped,
+	// not turned into an event nor a reconnect.
+	ev := recv(t, out)
+	require.False(t, ev.Resync)
+	require.Equal(t, uint64(47), ev.OldTipNumber)
+
+	// No reconnect happened: a single subscribe handshake.
+	require.Equal(t, int32(1), subscribeCount.Load(), "Commit frames must not trigger a reconnect")
 }
 
 func TestChainTipNumber(t *testing.T) {

--- a/op-conductor/chainevents/subscriber_test.go
+++ b/op-conductor/chainevents/subscriber_test.go
@@ -1,0 +1,96 @@
+package chainevents
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestSubscriber builds a Subscriber wired to a cap-1 channel for frame-parsing tests.
+func newTestSubscriber() (*Subscriber, chan ReorgEvent) {
+	out := make(chan ReorgEvent, 1)
+	return NewSubscriber(log.NewLogger(log.DiscardHandler()), "ws://test", out), out
+}
+
+// A realistic Commit frame matching the empirically-captured op-reth shape (Phase 0):
+// externally-tagged variant, double-nested block.header.header, decimal-string block keys,
+// and the heavy execution_outcome / trie_data fields the decoder must ignore.
+const commitFrame = `{"jsonrpc":"2.0","method":"reth_subscribeChainNotifications","params":{"subscription":"0xfad3","result":{"Commit":{"new":{"blocks":{"47":{"block":{"header":{"header":{"parentHash":"0xdc04","number":"0x2f"}},"body":{"transactions":[],"ommers":[],"withdrawals":[]}},"senders":[]}},"execution_outcome":{"first_block":47},"trie_data":{}}}}}}`
+
+func TestHandleFrameCommitIsIgnored(t *testing.T) {
+	s, out := newTestSubscriber()
+	s.handleFrame([]byte(commitFrame))
+	select {
+	case ev := <-out:
+		t.Fatalf("Commit frame should yield no ReorgEvent, got %+v", ev)
+	default:
+	}
+}
+
+func TestHandleFrameReorgYieldsTipNumbers(t *testing.T) {
+	s, out := newTestSubscriber()
+	// Reorg: old chain tips at 47 (blocks 45,46,47), new chain tips at 45.
+	frame := `{"jsonrpc":"2.0","method":"reth_subscribeChainNotifications","params":{"subscription":"0xabc","result":{"Reorg":{"old":{"blocks":{"45":{},"46":{},"47":{}}},"new":{"blocks":{"45":{}}}}}}}`
+	s.handleFrame([]byte(frame))
+	select {
+	case ev := <-out:
+		require.Equal(t, uint64(47), ev.OldTipNumber)
+		require.Equal(t, uint64(45), ev.NewTipNumber)
+		require.True(t, ev.HasNewTip)
+	default:
+		t.Fatal("expected a ReorgEvent for a Reorg frame")
+	}
+}
+
+func TestHandleFrameReorgPureRevertHasNoNewTip(t *testing.T) {
+	s, out := newTestSubscriber()
+	// Pure revert: new chain is empty.
+	frame := `{"jsonrpc":"2.0","method":"reth_subscribeChainNotifications","params":{"subscription":"0xabc","result":{"Reorg":{"old":{"blocks":{"46":{},"47":{}}},"new":{"blocks":{}}}}}}`
+	s.handleFrame([]byte(frame))
+	select {
+	case ev := <-out:
+		require.Equal(t, uint64(47), ev.OldTipNumber)
+		require.False(t, ev.HasNewTip)
+		require.Equal(t, uint64(0), ev.NewTipNumber)
+	default:
+		t.Fatal("expected a ReorgEvent for a pure-revert Reorg frame")
+	}
+}
+
+func TestHandleFrameNonNotificationIsIgnored(t *testing.T) {
+	s, out := newTestSubscriber()
+	// A subscribe response (no params) must not produce an event.
+	s.handleFrame([]byte(`{"jsonrpc":"2.0","id":1,"result":"0xdeadbeef"}`))
+	select {
+	case ev := <-out:
+		t.Fatalf("subscribe response should yield no ReorgEvent, got %+v", ev)
+	default:
+	}
+}
+
+func TestDeliverCoalescesToLatest(t *testing.T) {
+	s, out := newTestSubscriber()
+	// Two events without a reader between them: the channel (cap 1) must hold the latest.
+	s.deliver(ReorgEvent{NewTipNumber: 10, HasNewTip: true})
+	s.deliver(ReorgEvent{NewTipNumber: 20, HasNewTip: true})
+	ev := <-out
+	require.Equal(t, uint64(20), ev.NewTipNumber, "cap-1 channel should coalesce to the latest event")
+	select {
+	case extra := <-out:
+		t.Fatalf("expected only one buffered event, got extra %+v", extra)
+	default:
+	}
+}
+
+func TestChainTipNumber(t *testing.T) {
+	c := &chain{Blocks: nil}
+	_, ok := c.tipNumber()
+	require.False(t, ok, "empty chain has no tip")
+
+	c = &chain{Blocks: map[uint64]json.RawMessage{3: nil, 7: nil, 5: nil}}
+	tip, ok := c.tipNumber()
+	require.True(t, ok)
+	require.Equal(t, uint64(7), tip)
+}

--- a/op-conductor/chainevents/types.go
+++ b/op-conductor/chainevents/types.go
@@ -1,0 +1,62 @@
+package chainevents
+
+import "encoding/json"
+
+// canonStateNotification mirrors reth's externally-tagged CanonStateNotification.
+// Only the variant discriminator and each chain's block numbers are decoded; the
+// heavy execution_outcome / trie_data / block bodies in the frame are ignored.
+//
+// The reth notification does NOT carry block hashes (reth's SealedHeader.hash is
+// serde-skipped), so we extract only block numbers here. The reorg handler reads
+// the authoritative head hash from the EL via InfoByLabel(eth.Unsafe).
+type canonStateNotification struct {
+	Commit *commitNotification `json:"Commit,omitempty"`
+	Reorg  *reorgNotification  `json:"Reorg,omitempty"`
+}
+
+type commitNotification struct {
+	New chain `json:"new"`
+}
+
+type reorgNotification struct {
+	Old chain `json:"old"`
+	New chain `json:"new"`
+}
+
+// chain mirrors reth's Chain, decoding only the blocks map. reth serializes the
+// block-number keys as decimal strings, which encoding/json parses into uint64.
+type chain struct {
+	Blocks map[uint64]json.RawMessage `json:"blocks"`
+}
+
+// tipNumber returns the highest block number in the chain and whether the chain
+// is non-empty. reth's "new" chain can be empty on a pure revert.
+func (c *chain) tipNumber() (uint64, bool) {
+	var tip uint64
+	found := false
+	for n := range c.Blocks {
+		if !found || n > tip {
+			tip = n
+			found = true
+		}
+	}
+	return tip, found
+}
+
+// subscribeResponse is the JSON-RPC reply to the subscribe request. A successful
+// response carries the subscription id as a hex string in Result.
+type subscribeResponse struct {
+	ID     int              `json:"id"`
+	Result string           `json:"result"`
+	Error  *json.RawMessage `json:"error,omitempty"`
+}
+
+// notificationEnvelope is the JSON-RPC notification pushed for each chain event:
+// {"method":"reth_subscribeChainNotifications","params":{"subscription":"0x..","result":<CanonStateNotification>}}
+type notificationEnvelope struct {
+	Method string `json:"method"`
+	Params struct {
+		Subscription string          `json:"subscription"`
+		Result       json.RawMessage `json:"result"`
+	} `json:"params"`
+}

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -105,6 +105,17 @@ type Config struct {
 
 	// RoundRobinLeaderTransfer enables deterministic round-robin leader transfer.
 	RoundRobinLeaderTransfer bool
+
+	// ReorgRecoveryEnabled gates the entire reth reorg-recovery behavior change.
+	// When true, the FSM forward-only unsafe-head guard is bypassed (last-write-wins)
+	// and op-conductor subscribes to op-reth reorg notifications via ExecutionWSURL.
+	// This flag changes Raft FSM apply semantics and MUST be set identically on every
+	// conductor in the cluster (all-on or all-off). Defaults OFF (byte-for-byte today).
+	ReorgRecoveryEnabled bool
+
+	// ExecutionWSURL is the WebSocket URL for the execution layer (op-reth) reorg
+	// subscription. Required when ReorgRecoveryEnabled is true.
+	ExecutionWSURL string
 }
 
 // Check validates the CLIConfig.
@@ -132,6 +143,9 @@ func (c *Config) Check() error {
 	}
 	if c.RollupBoostNextEnabled && c.RollupBoostNextHealthcheckURL == "" {
 		return fmt.Errorf("missing rollup-boost next healthcheck URL")
+	}
+	if c.ReorgRecoveryEnabled && c.ExecutionWSURL == "" {
+		return fmt.Errorf("reorg-recovery enabled but missing execution WS URL (--execution.ws-url)")
 	}
 	if err := c.HealthCheck.Check(); err != nil {
 		return fmt.Errorf("invalid health check config: %w", err)
@@ -214,6 +228,8 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 		RPC:                 oprpc.ReadCLIConfig(ctx),
 		// RoundRobinLeaderTransfer enables deterministic round-robin leader transfer.
 		RoundRobinLeaderTransfer: ctx.Bool(flags.RoundRobinLeaderTransfer.Name),
+		ReorgRecoveryEnabled:     ctx.Bool(flags.ReorgRecoveryEnabled.Name),
+		ExecutionWSURL:           ctx.String(flags.ExecutionWSURL.Name),
 	}, nil
 }
 

--- a/op-conductor/conductor/config_test.go
+++ b/op-conductor/conductor/config_test.go
@@ -23,3 +23,20 @@ func TestConfigCheckRollupBoostAndNextMutuallyExclusive(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "only one of rollup-boost or rollup-boost next healthchecks can be enabled")
 }
+
+func TestConfigCheckReorgRecoveryRequiresExecutionWSURL(t *testing.T) {
+	cfg := &Config{
+		ConsensusAddr:        "127.0.0.1",
+		ConsensusPort:        9000,
+		RaftServerID:         "server-1",
+		RaftStorageDir:       "/tmp/op-conductor",
+		NodeRPC:              "http://node.example",
+		ExecutionRPC:         "http://exec.example",
+		ReorgRecoveryEnabled: true,
+		// ExecutionWSURL intentionally empty.
+	}
+
+	err := cfg.Check()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reorg-recovery enabled but missing execution WS URL")
+}

--- a/op-conductor/conductor/demotion_latch.go
+++ b/op-conductor/conductor/demotion_latch.go
@@ -1,0 +1,113 @@
+package conductor
+
+import (
+	"errors"
+
+	"github.com/ethereum-optimism/optimism/op-conductor/health"
+)
+
+// latchState is the state of the demotion-grace latch.
+type latchState int
+
+const (
+	// latchDisarmed is the normal state: health results pass through unchanged.
+	latchDisarmed latchState = iota
+	// latchArmed means a staleness grace is running. The node reports healthy until
+	// the grace expires, at which point it is demoted unconditionally.
+	latchArmed
+	// latchFired means the demotion has been applied. The node stays unhealthy until
+	// a genuine healthy poll returns it to latchDisarmed (re-arming for a future episode).
+	latchFired
+)
+
+// demotionLatch implements the non-cancellable demotion-grace latch (Phase 7 Fix 1).
+//
+// With reorg recovery enabled, a leader that goes stale (ErrSequencerNotHealthy) is
+// given a fixed grace during which it keeps reporting healthy, so it can still receive
+// and commit the op-reth reorg notification before leadership transfers away. At grace
+// expiry the node is demoted UNCONDITIONALLY: the latch can never be cancelled, even by
+// a healthy poll during the grace, because a fresh block timestamp does not prove the
+// node is sequencing the correct chain — it could be extending a reorged-out fork that
+// still carries the invalid message. A node oscillating onto a fresh-but-wrong fork must
+// not be able to evade demotion by polling healthy.
+//
+// A healthy result only matters once a demotion has fired: it returns the latch to
+// disarmed, re-arming it for a future episode. ErrSequencerConnectionDown and any other
+// non-staleness error demote immediately (no grace) — a genuine connection loss should
+// fail over fast.
+//
+// The latch is a pure state machine with no time dependency: arming reports that a timer
+// should start, and expire() (driven by that timer in the control loop) performs the
+// armed→fired transition. All methods run on the single control-loop goroutine.
+type demotionLatch struct {
+	// enabled mirrors reorg-recovery being on. When false the latch is inert and every
+	// health result passes through unchanged (byte-for-byte today's behavior).
+	enabled bool
+	state   latchState
+	// armErr is the staleness error that armed the latch; re-applied as the active health
+	// error when the demotion fires so action() behaves as if it had just arrived.
+	armErr error
+}
+
+// observe processes a health result. It returns the health error that should be reported
+// to the rest of the conductor (nil == healthy). arm reports whether the latch just
+// transitioned into the armed state (the caller starts the grace timer); when false and
+// the latch is not armed, the caller stops any pending timer.
+func (l *demotionLatch) observe(hcerr error) (report error, arm bool) {
+	if !l.enabled {
+		return hcerr, false
+	}
+
+	healthy := hcerr == nil
+	staleness := errors.Is(hcerr, health.ErrSequencerNotHealthy)
+
+	switch l.state {
+	case latchDisarmed:
+		switch {
+		case healthy:
+			return nil, false
+		case staleness:
+			// Arm the grace: keep reporting healthy so the leader can commit the reorg
+			// notification before staleness would otherwise transfer leadership away.
+			l.state = latchArmed
+			l.armErr = hcerr
+			return nil, true
+		default:
+			// Connection-down and any other hard failure: demote immediately.
+			return hcerr, false
+		}
+	case latchArmed:
+		switch {
+		case healthy, staleness:
+			// Cannot cancel a pending demotion, and cannot reset the deadline: a healthy
+			// poll does not prove a correct chain, and repeated staleness must not extend
+			// the grace. Keep reporting healthy until the timer fires.
+			return nil, false
+		default:
+			// A hard failure during the grace demotes immediately.
+			l.state = latchFired
+			return hcerr, false
+		}
+	case latchFired:
+		if healthy {
+			// Genuine recovery after a demotion: return to normal, re-arm-eligible.
+			l.state = latchDisarmed
+			return nil, false
+		}
+		// Still unhealthy (staleness or hard): stay demoted.
+		return hcerr, false
+	default:
+		return hcerr, false
+	}
+}
+
+// expire performs the armed→fired transition when the grace timer fires. It returns the
+// health error to apply (the staleness error that armed the latch) and ok=false when the
+// latch was not armed (a superseded timer fire), in which case the caller ignores it.
+func (l *demotionLatch) expire() (report error, ok bool) {
+	if l.state != latchArmed {
+		return nil, false
+	}
+	l.state = latchFired
+	return l.armErr, true
+}

--- a/op-conductor/conductor/demotion_latch_test.go
+++ b/op-conductor/conductor/demotion_latch_test.go
@@ -1,0 +1,171 @@
+package conductor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-conductor/health"
+)
+
+// The latch is a pure state machine: observe() processes scripted health results and
+// expire() simulates the grace timer firing. Driving expire() manually stands in for a
+// fake clock — the test controls exactly when the grace elapses.
+
+func TestDemotionLatchDisabledPassThrough(t *testing.T) {
+	l := &demotionLatch{enabled: false}
+
+	// Every result passes through unchanged; nothing ever arms.
+	report, arm := l.observe(nil)
+	require.NoError(t, report)
+	require.False(t, arm)
+
+	report, arm = l.observe(health.ErrSequencerNotHealthy)
+	require.ErrorIs(t, report, health.ErrSequencerNotHealthy, "disabled latch must not mask staleness")
+	require.False(t, arm)
+
+	report, arm = l.observe(health.ErrSequencerConnectionDown)
+	require.ErrorIs(t, report, health.ErrSequencerConnectionDown)
+	require.False(t, arm)
+}
+
+func TestDemotionLatchStaleWithinGraceReportsHealthy(t *testing.T) {
+	l := &demotionLatch{enabled: true}
+
+	// First staleness arms the grace and reports healthy.
+	report, arm := l.observe(health.ErrSequencerNotHealthy)
+	require.NoError(t, report, "stale leader must report healthy during the grace")
+	require.True(t, arm)
+	require.Equal(t, latchArmed, l.state)
+
+	// Repeated staleness keeps reporting healthy and does not re-arm (no deadline reset).
+	report, arm = l.observe(health.ErrSequencerNotHealthy)
+	require.NoError(t, report)
+	require.False(t, arm, "repeated staleness must not re-arm the timer")
+	require.Equal(t, latchArmed, l.state)
+}
+
+func TestDemotionLatchExpiryDemotes(t *testing.T) {
+	l := &demotionLatch{enabled: true}
+
+	_, arm := l.observe(health.ErrSequencerNotHealthy)
+	require.True(t, arm)
+
+	// Grace elapses → unconditional demotion with the original staleness error.
+	report, ok := l.expire()
+	require.True(t, ok)
+	require.ErrorIs(t, report, health.ErrSequencerNotHealthy)
+	require.Equal(t, latchFired, l.state)
+}
+
+func TestDemotionLatchHealthyDuringGraceStillDemotes(t *testing.T) {
+	l := &demotionLatch{enabled: true}
+
+	_, arm := l.observe(health.ErrSequencerNotHealthy)
+	require.True(t, arm)
+
+	// A healthy poll during the grace must NOT cancel the pending demotion: a fresh
+	// timestamp does not prove a correct chain.
+	report, arm := l.observe(nil)
+	require.NoError(t, report)
+	require.False(t, arm)
+	require.Equal(t, latchArmed, l.state, "healthy poll must not disarm the latch")
+
+	report, ok := l.expire()
+	require.True(t, ok)
+	require.ErrorIs(t, report, health.ErrSequencerNotHealthy, "must still demote at expiry despite the healthy poll")
+}
+
+func TestDemotionLatchOscillationDoesNotEvade(t *testing.T) {
+	l := &demotionLatch{enabled: true}
+
+	_, arm := l.observe(health.ErrSequencerNotHealthy)
+	require.True(t, arm)
+
+	// Oscillate stale↔healthy throughout the grace; none of it can cancel the latch.
+	for i := 0; i < 5; i++ {
+		report, arm := l.observe(nil)
+		require.NoError(t, report)
+		require.False(t, arm)
+		report, arm = l.observe(health.ErrSequencerNotHealthy)
+		require.NoError(t, report)
+		require.False(t, arm)
+		require.Equal(t, latchArmed, l.state)
+	}
+
+	_, ok := l.expire()
+	require.True(t, ok, "oscillating onto a fresh-but-wrong fork must not evade demotion")
+}
+
+func TestDemotionLatchConnectionDownImmediate(t *testing.T) {
+	l := &demotionLatch{enabled: true}
+
+	// Connection-down from disarmed: immediate unhealthy, no arming.
+	report, arm := l.observe(health.ErrSequencerConnectionDown)
+	require.ErrorIs(t, report, health.ErrSequencerConnectionDown)
+	require.False(t, arm)
+	require.Equal(t, latchDisarmed, l.state)
+}
+
+func TestDemotionLatchConnectionDownDuringGraceDemotesNow(t *testing.T) {
+	l := &demotionLatch{enabled: true}
+
+	_, arm := l.observe(health.ErrSequencerNotHealthy)
+	require.True(t, arm)
+
+	// A hard failure during the grace short-circuits to immediate demotion.
+	report, arm := l.observe(health.ErrSequencerConnectionDown)
+	require.ErrorIs(t, report, health.ErrSequencerConnectionDown)
+	require.False(t, arm)
+	require.Equal(t, latchFired, l.state)
+
+	// The grace timer, if it fires afterward, is a superseded no-op.
+	_, ok := l.expire()
+	require.False(t, ok)
+}
+
+func TestDemotionLatchReArmsAfterRecovery(t *testing.T) {
+	l := &demotionLatch{enabled: true}
+
+	_, _ = l.observe(health.ErrSequencerNotHealthy)
+	_, ok := l.expire()
+	require.True(t, ok)
+	require.Equal(t, latchFired, l.state)
+
+	// Still unhealthy while staleness persists.
+	report, arm := l.observe(health.ErrSequencerNotHealthy)
+	require.ErrorIs(t, report, health.ErrSequencerNotHealthy)
+	require.False(t, arm)
+	require.Equal(t, latchFired, l.state)
+
+	// Genuine recovery returns to disarmed.
+	report, arm = l.observe(nil)
+	require.NoError(t, report)
+	require.False(t, arm)
+	require.Equal(t, latchDisarmed, l.state)
+
+	// A fresh staleness episode arms again.
+	_, arm = l.observe(health.ErrSequencerNotHealthy)
+	require.True(t, arm, "latch must re-arm for a future episode after recovery")
+	require.Equal(t, latchArmed, l.state)
+}
+
+func TestDemotionLatchExpireWhenNotArmedIsNoOp(t *testing.T) {
+	l := &demotionLatch{enabled: true}
+	report, ok := l.expire()
+	require.False(t, ok)
+	require.NoError(t, report)
+	require.Equal(t, latchDisarmed, l.state)
+}
+
+func TestDemotionLatchNonStalenessErrorNotGraced(t *testing.T) {
+	l := &demotionLatch{enabled: true}
+
+	// A non-staleness, non-connection-down error (e.g. rollup-boost) is treated as a hard
+	// failure: immediate, not graced.
+	report, arm := l.observe(errors.New("some other unhealthy condition"))
+	require.Error(t, report)
+	require.False(t, arm)
+	require.Equal(t, latchDisarmed, l.state)
+}

--- a/op-conductor/conductor/demotion_wiring_test.go
+++ b/op-conductor/conductor/demotion_wiring_test.go
@@ -1,0 +1,119 @@
+package conductor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	clientmocks "github.com/ethereum-optimism/optimism/op-conductor/client/mocks"
+	consensusmocks "github.com/ethereum-optimism/optimism/op-conductor/consensus/mocks"
+	"github.com/ethereum-optimism/optimism/op-conductor/health"
+	healthmocks "github.com/ethereum-optimism/optimism/op-conductor/health/mocks"
+	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+// newWiringConductor builds an OpConductor wired for demotion-latch tests, with reorg
+// recovery toggled by `enabled`. It mirrors Start's demotion-timer creation so
+// handleHealthUpdate/handleDemotionExpiry can be driven directly without the full loop.
+func newWiringConductor(t *testing.T, enabled bool) *OpConductor {
+	cfg := mockConfig(t)
+	cfg.ReorgRecoveryEnabled = enabled
+	cfg.ExecutionWSURL = "ws://test:8546" // required by Config.Check when enabled
+
+	ctrl := &clientmocks.SequencerControl{}
+	cons := &consensusmocks.Consensus{}
+	hmon := &healthmocks.HealthMonitor{}
+	cons.EXPECT().ServerID().Return("SequencerA").Maybe()
+
+	oc, err := NewOpConductor(context.Background(), &cfg, testlog.Logger(t, log.LevelDebug),
+		&metrics.NoopMetricsImpl{}, "v0.0.1", ctrl, cons, hmon, nil)
+	require.NoError(t, err)
+
+	if enabled {
+		oc.demotionTimer = time.NewTimer(reorgDemotionGrace)
+		if !oc.demotionTimer.Stop() {
+			<-oc.demotionTimer.C
+		}
+	}
+	return oc
+}
+
+func TestHandleHealthUpdateFlagOffImmediateDemotion(t *testing.T) {
+	oc := newWiringConductor(t, false)
+	require.True(t, oc.healthy.Load())
+
+	// With the flag off, staleness demotes immediately — today's behavior, unchanged.
+	oc.handleHealthUpdate(health.ErrSequencerNotHealthy)
+	require.False(t, oc.healthy.Load())
+	require.ErrorIs(t, oc.hcerr, health.ErrSequencerNotHealthy)
+}
+
+func TestHandleHealthUpdateGracedStalenessStaysHealthyThenDemotes(t *testing.T) {
+	oc := newWiringConductor(t, true)
+	require.True(t, oc.healthy.Load())
+
+	// Staleness arms the grace; the leader keeps reporting healthy.
+	oc.handleHealthUpdate(health.ErrSequencerNotHealthy)
+	require.True(t, oc.healthy.Load(), "stale leader must stay healthy during the grace")
+	require.True(t, oc.demotionTimerArmed)
+	require.Equal(t, latchArmed, oc.latch.state)
+
+	// A healthy poll during the grace does not cancel the latch.
+	oc.handleHealthUpdate(nil)
+	require.True(t, oc.healthy.Load())
+	require.True(t, oc.demotionTimerArmed)
+	require.Equal(t, latchArmed, oc.latch.state)
+
+	// Grace expiry demotes unconditionally and surfaces the staleness error to action().
+	oc.handleDemotionExpiry()
+	require.False(t, oc.healthy.Load(), "must demote at grace expiry")
+	require.ErrorIs(t, oc.hcerr, health.ErrSequencerNotHealthy)
+	require.False(t, oc.demotionTimerArmed)
+
+	// Genuine recovery returns to healthy and re-arms for the future.
+	oc.handleHealthUpdate(nil)
+	require.True(t, oc.healthy.Load())
+	require.Equal(t, latchDisarmed, oc.latch.state)
+}
+
+func TestHandleHealthUpdateGracedConnectionDownImmediate(t *testing.T) {
+	oc := newWiringConductor(t, true)
+
+	// Connection-down is not graced even with the flag on: fail over fast.
+	oc.handleHealthUpdate(health.ErrSequencerConnectionDown)
+	require.False(t, oc.healthy.Load())
+	require.ErrorIs(t, oc.hcerr, health.ErrSequencerConnectionDown)
+	require.False(t, oc.demotionTimerArmed)
+}
+
+// TestDemotionTimerFiresIntoLoop exercises the real timer firing through the control loop:
+// a stale poll arms the grace, and after the grace elapses the loop demotes without any
+// further health update (covering the fresh-but-wrong-fork case where polls stop arriving).
+func TestDemotionTimerFiresIntoLoop(t *testing.T) {
+	oc := newWiringConductor(t, true)
+
+	// Arm via the real handler, then run a single loop iteration that should block on the
+	// timer and demote when it fires. Use the real (5s) grace but bound the wait generously.
+	oc.handleHealthUpdate(health.ErrSequencerNotHealthy)
+	require.True(t, oc.healthy.Load())
+	require.True(t, oc.demotionTimerArmed)
+
+	done := make(chan struct{})
+	go func() {
+		// loopAction selects the demotion-timer case once the grace elapses.
+		oc.loopAction()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(reorgDemotionGrace + 5*time.Second):
+		t.Fatal("demotion timer did not fire into the loop within grace + margin")
+	}
+	require.False(t, oc.healthy.Load(), "loop must demote when the grace timer fires")
+	require.ErrorIs(t, oc.hcerr, health.ErrSequencerNotHealthy)
+}

--- a/op-conductor/conductor/execution_miner_proxy_test.go
+++ b/op-conductor/conductor/execution_miner_proxy_test.go
@@ -60,6 +60,7 @@ func testSetMaxDASize(t *testing.T, compliantSequencer bool, sequencerDown bool)
 		&clientmocks.SequencerControl{}, // not used in this test
 		&consensusmocks.Consensus{},     // not used in this test
 		&healthmocks.HealthMonitor{},    // not used in this test
+		nil,                             // elClient not used in this test
 	)
 	require.NoError(t, err)
 

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -12,10 +12,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hashicorp/raft"
 
+	"github.com/ethereum-optimism/optimism/op-conductor/chainevents"
 	"github.com/ethereum-optimism/optimism/op-conductor/client"
 	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	"github.com/ethereum-optimism/optimism/op-conductor/health"
@@ -41,9 +43,19 @@ var (
 	ErrNoUnsafeHead       = errors.New("no unsafe head")
 )
 
+// ELClient is the execution-layer dependency used by the reorg handler. It is a
+// focused seam (distinct from client.SequencerControl, which lacks PayloadByHash):
+// InfoByLabel reads the EL's current canonical head (the authoritative post-reorg
+// tip, since the reth notification carries no block hash), and PayloadByHash fetches
+// the full envelope to commit. *sources.EthClient satisfies it.
+type ELClient interface {
+	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
+	InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error)
+}
+
 // New creates a new OpConductor instance.
 func New(ctx context.Context, cfg *Config, log log.Logger, version string) (*OpConductor, error) {
-	return NewOpConductor(ctx, cfg, log, metrics.NewMetrics(), version, nil, nil, nil)
+	return NewOpConductor(ctx, cfg, log, metrics.NewMetrics(), version, nil, nil, nil, nil)
 }
 
 // NewOpConductor creates a new OpConductor instance.
@@ -56,6 +68,7 @@ func NewOpConductor(
 	ctrl client.SequencerControl,
 	cons consensus.Consensus,
 	hmon health.HealthMonitor,
+	elClient ELClient,
 ) (*OpConductor, error) {
 	if err := cfg.Check(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
@@ -74,9 +87,17 @@ func NewOpConductor(
 		ctrl:         ctrl,
 		cons:         cons,
 		hmon:         hmon,
+		elClient:     elClient,
 		retryBackoff: func() time.Duration { return time.Duration(rand.Intn(2000)) * time.Millisecond },
 	}
 	oc.loopActionFn = oc.loopAction
+
+	// When reorg-recovery is enabled, the subscriber produces events on this cap-1
+	// channel and reorgLoop consumes them. ExecutionWSURL is guaranteed non-empty
+	// by Config.Check when the feature is on.
+	if oc.reorgRecoveryEnabled() {
+		oc.reorgEventCh = make(chan chainevents.ReorgEvent, 1)
+	}
 
 	// explicitly set all atomic.Bool values
 	oc.leader.Store(false)         // upon start, it should not be the leader unless specified otherwise by raft bootstrap, in that case, it'll receive a leadership update from consensus.
@@ -145,6 +166,10 @@ func (c *OpConductor) initSequencerControl(ctx context.Context) error {
 	}
 	node := sources.NewRollupClient(nc)
 	c.ctrl = client.NewSequencerControl(exec, node)
+	// Reuse the same EL client for the reorg handler (PayloadByHash + InfoByLabel).
+	// Only set on the production path; when ctrl is injected in tests, initSequencerControl
+	// returns early above and elClient comes from the NewOpConductor parameter.
+	c.elClient = exec
 
 	enabled, err := retry.Do(ctx, 60, retry.Fixed(5*time.Second), func() (bool, error) {
 		enabled, err := c.ctrl.ConductorEnabled(ctx)
@@ -362,6 +387,16 @@ type OpConductor struct {
 	cons consensus.Consensus
 	hmon health.HealthMonitor
 
+	// elClient is the EL client used by the reorg handler (PayloadByHash + InfoByLabel).
+	// On the production path it is assigned in initSequencerControl; tests may inject a mock.
+	elClient ELClient
+	// reorgEventCh carries reorg events from the subscriber to reorgLoop. Non-nil only
+	// when reorg-recovery is enabled.
+	reorgEventCh chan chainevents.ReorgEvent
+	// subscriber maintains the op-reth reorg-notification WS subscription. Non-nil only
+	// when reorg-recovery is enabled.
+	subscriber *chainevents.Subscriber
+
 	leader         atomic.Bool
 	leaderOverride atomic.Bool
 	seqActive      atomic.Bool
@@ -434,6 +469,18 @@ func (oc *OpConductor) Start(ctx context.Context) error {
 		if err := oc.flashblocksHandler.Start(ctx); err != nil {
 			return fmt.Errorf("failed to start flashblocks handler: %w", err)
 		}
+	}
+
+	// Start the reth reorg subscription and its consumer loop when reorg-recovery is
+	// enabled. The subscriber's internal read loop is shutdownCtx-cancelled (not
+	// wg-joined, matching the flashblocks cancel-only posture); reorgLoop IS wg-joined
+	// so Stop's oc.wg.Wait() blocks until it returns.
+	if oc.reorgRecoveryEnabled() {
+		oc.log.Info("starting reth reorg subscription", "url", oc.cfg.ExecutionWSURL)
+		oc.subscriber = chainevents.NewSubscriber(oc.log, oc.cfg.ExecutionWSURL, oc.reorgEventCh)
+		oc.subscriber.Start(oc.shutdownCtx)
+		oc.wg.Add(1)
+		go oc.reorgLoop(oc.shutdownCtx)
 	}
 
 	if oc.cfg.MetricsConfig.Enabled {
@@ -645,6 +692,27 @@ func (oc *OpConductor) ClusterMembership(_ context.Context) (*consensus.ClusterM
 // LatestUnsafePayload returns the latest unsafe payload envelope from FSM in a strongly consistent fashion.
 func (oc *OpConductor) LatestUnsafePayload(_ context.Context) (*eth.ExecutionPayloadEnvelope, error) {
 	return oc.cons.LatestUnsafePayload()
+}
+
+// reorgRecoveryEnabled reports whether the reth reorg-recovery feature is on.
+// Stated once here so every gate reads from a single source.
+func (oc *OpConductor) reorgRecoveryEnabled() bool {
+	return oc.cfg.ReorgRecoveryEnabled
+}
+
+// reorgLoop consumes reorg events from the subscriber. It is wg-joined and exits
+// when ctx (shutdownCtx) is cancelled. Phase 1: log only; the commit handler is
+// added in Phase 2.
+func (oc *OpConductor) reorgLoop(ctx context.Context) {
+	defer oc.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev := <-oc.reorgEventCh:
+			oc.log.Info("reorg observed", "old_tip", ev.OldTipNumber, "new_tip", ev.NewTipNumber, "has_new_tip", ev.HasNewTip)
+		}
+	}
 }
 
 func (oc *OpConductor) loop() {

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -89,6 +89,7 @@ func NewOpConductor(
 		hmon:         hmon,
 		elClient:     elClient,
 		retryBackoff: func() time.Duration { return time.Duration(rand.Intn(2000)) * time.Millisecond },
+		latch:        demotionLatch{enabled: cfg.ReorgRecoveryEnabled},
 	}
 	oc.loopActionFn = oc.loopAction
 
@@ -406,6 +407,15 @@ type OpConductor struct {
 	hcerr          error // error from health check
 	prevState      *state
 
+	// Phase 7 reorg-recovery demotion grace (Fix 1). latch is the non-cancellable
+	// staleness-demotion state machine; demotionTimer fires the unconditional demotion
+	// at grace expiry. All three are mutated only on the control-loop goroutine;
+	// demotionTimer is non-nil only when reorg recovery is enabled, and loopAction
+	// selects on its channel (a nil-channel case never fires when disabled).
+	latch              demotionLatch
+	demotionTimer      *time.Timer
+	demotionTimerArmed bool
+
 	healthUpdateCh <-chan error
 	leaderUpdateCh <-chan bool
 	loopActionFn   func() // loopActionFn defines the logic to be executed inside control loop.
@@ -483,6 +493,12 @@ func (oc *OpConductor) Start(ctx context.Context) error {
 		oc.subscriber.Start(oc.shutdownCtx)
 		oc.wg.Add(1)
 		go oc.reorgLoop(oc.shutdownCtx)
+		// Create the demotion-grace timer in the stopped state; loopAction arms it when
+		// the latch goes armed. Drain the initial fire so the first Reset is clean.
+		oc.demotionTimer = time.NewTimer(reorgDemotionGrace)
+		if !oc.demotionTimer.Stop() {
+			<-oc.demotionTimer.C
+		}
 	}
 
 	if oc.cfg.MetricsConfig.Enabled {
@@ -711,6 +727,21 @@ func (oc *OpConductor) reorgRecoveryEnabled() bool {
 	return oc.cfg.ReorgRecoveryEnabled
 }
 
+// reorgDemotionGrace is the fixed grace a stale leader is given before being demoted
+// unconditionally (Phase 7 Fix 1). It must exceed the observed op-reth reorg
+// notification→commit gap (~5–6s, partly debug-build latency) so the leader can commit
+// the post-reorg head before staleness transfers leadership away. Active only when
+// reorg recovery is enabled; with the flag off the grace is 0 (today's immediate demotion).
+const reorgDemotionGrace = 5 * time.Second
+
+// demotionGrace returns the staleness-demotion grace, or 0 when reorg recovery is off.
+func (oc *OpConductor) demotionGrace() time.Duration {
+	if oc.reorgRecoveryEnabled() {
+		return reorgDemotionGrace
+	}
+	return 0
+}
+
 // reorgHandlerTimeout bounds a single reorg handler invocation. It must exceed the
 // Raft Apply bound (defaultTimeout=5s) plus an EL round-trip: CommitUnsafePayload
 // takes no ctx and applies its own internal 5s on rc.r.Apply, so this outer ctx does
@@ -739,14 +770,19 @@ func (oc *OpConductor) reorgLoop(ctx context.Context) {
 // EL via InfoByLabel(eth.Unsafe). With the guard bypassed, Apply records the (possibly
 // backward) head unconditionally.
 func (oc *OpConductor) handleReorgEvent(parent context.Context, ev chainevents.ReorgEvent) {
-	oc.metrics.RecordReorgObserved()
+	if ev.Resync {
+		// Synthetic catch-up trigger from a (re)subscribe, not a reth-reported reorg.
+		oc.metrics.RecordReorgResync()
+	} else {
+		oc.metrics.RecordReorgObserved()
+	}
 	// oc.Leader() is LeaderOverridden() || cons.Leader(), so an operator leader-override
 	// can pass this gate on a non-Raft-leader node. That is safe: the real gate is the
 	// Raft layer — a non-leader Apply (raft.go, rc.r.Apply) returns the hashicorp/raft
 	// library's ErrNotLeader, so a stray write is rejected and only logged as a commit
 	// failure, never replicated. This pre-check is a cheap fast-path, not the authority.
 	if !oc.Leader(parent) {
-		oc.log.Info("reorg observed on non-leader; ignoring", "new_tip", ev.NewTipNumber)
+		oc.log.Info("reorg event on non-leader; ignoring", "new_tip", ev.NewTipNumber, "resync", ev.Resync)
 		return
 	}
 	ctx, cancel := context.WithTimeout(parent, reorgHandlerTimeout)
@@ -807,6 +843,8 @@ func (oc *OpConductor) loopAction() {
 	select {
 	case healthy := <-oc.healthUpdateCh:
 		oc.handleHealthUpdate(healthy)
+	case <-oc.demotionTimerC():
+		oc.handleDemotionExpiry()
 	case leader := <-oc.leaderUpdateCh:
 		oc.handleLeaderUpdate(leader)
 	case <-oc.pauseCh:
@@ -841,9 +879,29 @@ func (oc *OpConductor) handleLeaderUpdate(leader bool) {
 	oc.queueAction()
 }
 
-// handleHealthUpdate handles health update from health monitor.
+// handleHealthUpdate handles health update from health monitor. When reorg recovery is
+// enabled the result is filtered through the demotion-grace latch (Fix 1): a stale leader
+// keeps reporting healthy for a fixed grace so it can commit the reorg notification before
+// staleness would transfer leadership away. With the flag off, demotionGrace is 0 and the
+// result passes through unchanged (byte-for-byte today's behavior).
 func (oc *OpConductor) handleHealthUpdate(hcerr error) {
 	oc.log.Debug("received health update", "server", oc.cons.ServerID(), "error", hcerr)
+	if oc.demotionGrace() == 0 {
+		oc.applyHealth(hcerr)
+		return
+	}
+	report, arm := oc.latch.observe(hcerr)
+	if arm {
+		oc.log.Warn("reorg-recovery: arming demotion grace on stale leader", "grace", oc.demotionGrace(), "err", hcerr)
+	}
+	oc.syncDemotionTimer()
+	oc.applyHealth(report)
+}
+
+// applyHealth records a health result, updating oc.healthy/oc.hcerr and queueing actions.
+// This is the original handleHealthUpdate behavior, extracted so the demotion latch can
+// feed it a graced (possibly-deferred) result.
+func (oc *OpConductor) applyHealth(hcerr error) {
 	healthy := hcerr == nil
 	if !healthy {
 		oc.log.Error("Sequencer is unhealthy", "server", oc.cons.ServerID(), "err", hcerr)
@@ -858,6 +916,48 @@ func (oc *OpConductor) handleHealthUpdate(hcerr error) {
 	}
 
 	oc.hcerr = hcerr
+}
+
+// demotionTimerC returns the demotion-grace timer's channel, or nil when reorg recovery is
+// disabled. Selecting on a nil channel never fires, so the loop's demotion case is inert
+// when the feature is off.
+func (oc *OpConductor) demotionTimerC() <-chan time.Time {
+	if oc.demotionTimer == nil {
+		return nil
+	}
+	return oc.demotionTimer.C
+}
+
+// syncDemotionTimer reconciles the demotion-grace timer with the latch state. It (re)arms
+// the timer only on the disarmed→armed transition — never resetting an already-running
+// grace — and stops it (draining a pending fire) otherwise. Runs on the control loop only.
+func (oc *OpConductor) syncDemotionTimer() {
+	armed := oc.latch.state == latchArmed
+	switch {
+	case armed && !oc.demotionTimerArmed:
+		oc.demotionTimer.Reset(oc.demotionGrace())
+		oc.demotionTimerArmed = true
+	case !armed && oc.demotionTimerArmed:
+		if !oc.demotionTimer.Stop() {
+			select {
+			case <-oc.demotionTimer.C:
+			default:
+			}
+		}
+		oc.demotionTimerArmed = false
+	}
+}
+
+// handleDemotionExpiry fires when the grace timer elapses: the stale leader is demoted
+// unconditionally. A superseded fire (latch no longer armed) is ignored.
+func (oc *OpConductor) handleDemotionExpiry() {
+	report, ok := oc.latch.expire()
+	if !ok {
+		return
+	}
+	oc.demotionTimerArmed = false
+	oc.log.Warn("reorg-recovery: demotion grace expired; demoting stale leader", "err", report)
+	oc.applyHealth(report)
 }
 
 // action tries to bring the sequencer to the desired state, a retry will be queued if any action failed.

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -619,6 +619,15 @@ func (oc *OpConductor) HTTPEndpoint() string {
 	return fmt.Sprintf("http://%s", oc.rpcServer.Endpoint())
 }
 
+// MetricsEndpoint returns the HTTP metrics endpoint, or "" if the metrics server
+// is not running.
+func (oc *OpConductor) MetricsEndpoint() string {
+	if oc.metricsServer == nil {
+		return ""
+	}
+	return oc.metricsServer.HTTPEndpoint()
+}
+
 func (oc *OpConductor) OverrideLeader(override bool) {
 	oc.leaderOverride.Store(override)
 }

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -212,6 +212,8 @@ func (c *OpConductor) initConsensus(ctx context.Context) error {
 		TrailingLogs:       c.cfg.RaftTrailingLogs,
 		HeartbeatTimeout:   c.cfg.RaftHeartbeatTimeout,
 		LeaderLeaseTimeout: c.cfg.RaftLeaderLeaseTimeout,
+		// Single point tying the fleet-uniform flag to FSM apply semantics.
+		AllowNonMonotonicUnsafeHead: c.cfg.ReorgRecoveryEnabled,
 	}
 	cons, err := consensus.NewRaftConsensus(c.log, raftConsensusConfig)
 	if err != nil {
@@ -700,9 +702,16 @@ func (oc *OpConductor) reorgRecoveryEnabled() bool {
 	return oc.cfg.ReorgRecoveryEnabled
 }
 
-// reorgLoop consumes reorg events from the subscriber. It is wg-joined and exits
-// when ctx (shutdownCtx) is cancelled. Phase 1: log only; the commit handler is
-// added in Phase 2.
+// reorgHandlerTimeout bounds a single reorg handler invocation. It must exceed the
+// Raft Apply bound (defaultTimeout=5s) plus an EL round-trip: CommitUnsafePayload
+// takes no ctx and applies its own internal 5s on rc.r.Apply, so this outer ctx does
+// not propagate into the Apply leg; it bounds the EL reads (InfoByLabel + PayloadByHash)
+// and gives headroom for a full 5s Apply before the handler abandons.
+const reorgHandlerTimeout = 15 * time.Second
+
+// reorgLoop consumes reorg events from the subscriber and runs the commit handler
+// off the main control loop. It is wg-joined and exits when ctx (shutdownCtx) is
+// cancelled.
 func (oc *OpConductor) reorgLoop(ctx context.Context) {
 	defer oc.wg.Done()
 	for {
@@ -710,9 +719,64 @@ func (oc *OpConductor) reorgLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case ev := <-oc.reorgEventCh:
-			oc.log.Info("reorg observed", "old_tip", ev.OldTipNumber, "new_tip", ev.NewTipNumber, "has_new_tip", ev.HasNewTip)
+			oc.handleReorgEvent(ctx, ev)
 		}
 	}
+}
+
+// handleReorgEvent reacts to an op-reth reorg notification by committing the EL's
+// current unsafe head into consensus. The notification is a trigger only: reth does
+// not serialize the block hash, so the authoritative post-reorg tip is read from the
+// EL via InfoByLabel(eth.Unsafe). With the guard bypassed, Apply records the (possibly
+// backward) head unconditionally.
+func (oc *OpConductor) handleReorgEvent(parent context.Context, ev chainevents.ReorgEvent) {
+	oc.metrics.RecordReorgObserved()
+	// oc.Leader() is LeaderOverridden() || cons.Leader(), so an operator leader-override
+	// can pass this gate on a non-Raft-leader node. That is safe: the real gate is the
+	// Raft layer — a non-leader Apply (raft.go, rc.r.Apply) returns the hashicorp/raft
+	// library's ErrNotLeader, so a stray write is rejected and only logged as a commit
+	// failure, never replicated. This pre-check is a cheap fast-path, not the authority.
+	if !oc.Leader(parent) {
+		oc.log.Info("reorg observed on non-leader; ignoring", "new_tip", ev.NewTipNumber)
+		return
+	}
+	ctx, cancel := context.WithTimeout(parent, reorgHandlerTimeout)
+	defer cancel()
+
+	// The reth notification carries no block hash (SealedHeader.hash is serde-skipped),
+	// so read the authoritative head from the EL. reth broadcasts the notification only
+	// after the canonical head/label updates, so InfoByLabel(eth.Unsafe) should already
+	// reflect the post-reorg tip.
+	head, err := oc.elClient.InfoByLabel(ctx, eth.Unsafe)
+	if err != nil {
+		oc.log.Error("reorg: failed to read EL unsafe head", "err", err)
+		oc.metrics.RecordReorgFetchFailure()
+		return
+	}
+	// Diagnostic for the (expected-impossible) race where the notification arrives
+	// before the label reflects the new tip. We commit the EL head regardless; the
+	// metric lets Phase 3 confirm whether the race ever occurs in practice.
+	if ev.HasNewTip && head.NumberU64() != ev.NewTipNumber {
+		oc.log.Warn("reorg: EL head number differs from notification tip (possible label-lag race)",
+			"el_head", head.NumberU64(), "notification_tip", ev.NewTipNumber)
+		oc.metrics.RecordReorgNumberMismatch()
+	}
+	// No depth bound: legitimate interop rewinds to the common ancestor can be deep.
+	payload, err := oc.elClient.PayloadByHash(ctx, head.Hash())
+	if err != nil {
+		oc.log.Error("reorg: failed to fetch post-reorg payload from EL", "hash", head.Hash(), "err", err)
+		oc.metrics.RecordReorgFetchFailure()
+		return
+	}
+	// Always commit the EL's current unsafe head: reorgs can recur at the same height,
+	// so we never skip on equal number/hash. CommitUnsafePayload is the existing FSM
+	// write; with the flag on, Apply records this (possibly backward) head unconditionally.
+	if err := oc.cons.CommitUnsafePayload(payload); err != nil {
+		oc.log.Error("reorg: failed to commit post-reorg unsafe head", "hash", head.Hash(), "err", err)
+		return
+	}
+	oc.log.Info("committed post-reorg unsafe head", "number", head.NumberU64(), "hash", head.Hash())
+	oc.metrics.RecordReorgCommitted()
 }
 
 func (oc *OpConductor) loop() {
@@ -1039,7 +1103,17 @@ func (oc *OpConductor) startSequencer() error {
 	// When starting sequencer, we need to make sure that the current node has the latest unsafe head from the consensus protocol
 	// If not, then we wait for the unsafe head to catch up or gossip it to op-node manually from op-conductor.
 	unsafeInCons, unsafeInNode, err := oc.compareUnsafeHead(ctx)
-	// if there's a mismatch, try to post the unsafe head to op-node
+	// if there's a mismatch, try to post the unsafe head to op-node.
+	//
+	// REORG-RECOVERY FAIL-SAFE (issue #20006): this == 1 branch fires only when
+	// consensus is exactly one block AHEAD of the node (the normal gossip-delay
+	// catch-up). After a reorg-recovery backward write, consensus is BEHIND the node
+	// (cons < node), so this unsigned subtraction underflows to a huge value, is never
+	// == 1, and control falls through to the mismatch error instead of posting the node
+	// onto a lower head. This safety is IMPLICIT in the unsigned arithmetic — do NOT
+	// refactor to a signed delta, which would silently reintroduce the #20006-style
+	// "drag op-node onto the stale/orphaned hash" behavior. Guarded by
+	// TestStartSequencerConsensusBehindNodeFailsSafe.
 	if errors.Is(err, ErrUnsafeHeadMismatch) && uint64(unsafeInCons.ExecutionPayload.BlockNumber)-unsafeInNode.NumberU64() == 1 {
 		// tries to post the unsafe head to op-node when head is only 1 block behind (most likely due to gossip delay)
 		oc.log.Debug(

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/ethereum-optimism/optimism/op-conductor/chainevents"
 	clientmocks "github.com/ethereum-optimism/optimism/op-conductor/client/mocks"
 	consensusmocks "github.com/ethereum-optimism/optimism/op-conductor/consensus/mocks"
 	"github.com/ethereum-optimism/optimism/op-conductor/health"
@@ -504,6 +505,103 @@ func (s *OpConductorTestSuite) TestStartSequencerConsensusBehindNodeFailsSafe() 
 	s.False(s.conductor.seqActive.Load())
 	s.ctrl.AssertNotCalled(s.T(), "PostUnsafePayload", mock.Anything, mock.Anything)
 	s.ctrl.AssertNotCalled(s.T(), "StartSequencer", mock.Anything, mock.Anything)
+}
+
+// mockELClient is a hand-rolled ELClient for handleReorgEvent tests.
+type mockELClient struct {
+	head                eth.BlockInfo
+	headErr             error
+	payload             *eth.ExecutionPayloadEnvelope
+	payloadErr          error
+	infoByLabelCalls    int
+	payloadByHashCalls  int
+	payloadByHashArgHsh common.Hash
+}
+
+func (m *mockELClient) InfoByLabel(_ context.Context, _ eth.BlockLabel) (eth.BlockInfo, error) {
+	m.infoByLabelCalls++
+	return m.head, m.headErr
+}
+
+func (m *mockELClient) PayloadByHash(_ context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	m.payloadByHashCalls++
+	m.payloadByHashArgHsh = hash
+	return m.payload, m.payloadErr
+}
+
+func reorgTestPayload(number uint64, hash common.Hash) *eth.ExecutionPayloadEnvelope {
+	return &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: hexutil.Uint64(number),
+			BlockHash:   hash,
+		},
+	}
+}
+
+// TestHandleReorgEventCommitsELHead: as leader, the handler reads the EL head and
+// commits the fetched payload via CommitUnsafePayload.
+func (s *OpConductorTestSuite) TestHandleReorgEventCommitsELHead() {
+	headHash := common.HexToHash("0xabc")
+	payload := reorgTestPayload(5, headHash)
+	el := &mockELClient{head: &testutils.MockBlockInfo{InfoNum: 5, InfoHash: headHash}, payload: payload}
+	s.conductor.elClient = el
+	s.conductor.leaderOverride.Store(true) // force leader without a cons.Leader expectation
+
+	s.cons.EXPECT().CommitUnsafePayload(payload).Return(nil).Times(1)
+
+	s.conductor.handleReorgEvent(s.ctx, chainevents.ReorgEvent{NewTipNumber: 5, HasNewTip: true})
+
+	s.Equal(1, el.infoByLabelCalls)
+	s.Equal(1, el.payloadByHashCalls)
+	s.Equal(headHash, el.payloadByHashArgHsh, "must fetch the EL head hash, not a notified hash")
+	s.cons.AssertNumberOfCalls(s.T(), "CommitUnsafePayload", 1)
+}
+
+// TestHandleReorgEventNonLeaderNoCommit: a non-leader observes but never commits.
+func (s *OpConductorTestSuite) TestHandleReorgEventNonLeaderNoCommit() {
+	el := &mockELClient{head: &testutils.MockBlockInfo{InfoNum: 5, InfoHash: common.HexToHash("0xabc")}}
+	s.conductor.elClient = el
+	s.conductor.leaderOverride.Store(false)
+	s.cons.EXPECT().Leader().Return(false).Times(1)
+
+	s.conductor.handleReorgEvent(s.ctx, chainevents.ReorgEvent{NewTipNumber: 5, HasNewTip: true})
+
+	s.Equal(0, el.infoByLabelCalls, "non-leader must not read the EL")
+	s.Equal(0, el.payloadByHashCalls)
+	s.cons.AssertNotCalled(s.T(), "CommitUnsafePayload", mock.Anything)
+}
+
+// TestHandleReorgEventInfoByLabelErrorNoCommit: an EL head-read failure aborts before
+// fetching or committing.
+func (s *OpConductorTestSuite) TestHandleReorgEventInfoByLabelErrorNoCommit() {
+	el := &mockELClient{headErr: errors.New("el down")}
+	s.conductor.elClient = el
+	s.conductor.leaderOverride.Store(true)
+
+	s.conductor.handleReorgEvent(s.ctx, chainevents.ReorgEvent{NewTipNumber: 5, HasNewTip: true})
+
+	s.Equal(1, el.infoByLabelCalls)
+	s.Equal(0, el.payloadByHashCalls, "must not fetch a payload when the head read failed")
+	s.cons.AssertNotCalled(s.T(), "CommitUnsafePayload", mock.Anything)
+}
+
+// TestHandleReorgEventNumberMismatchStillCommits: when the EL head number differs from
+// the notification tip (the label-lag race diagnostic), the handler still commits the
+// EL head — reorgs can recur at the same height, so we never skip.
+func (s *OpConductorTestSuite) TestHandleReorgEventNumberMismatchStillCommits() {
+	headHash := common.HexToHash("0xdef")
+	payload := reorgTestPayload(4, headHash)
+	el := &mockELClient{head: &testutils.MockBlockInfo{InfoNum: 4, InfoHash: headHash}, payload: payload}
+	s.conductor.elClient = el
+	s.conductor.leaderOverride.Store(true)
+
+	s.cons.EXPECT().CommitUnsafePayload(payload).Return(nil).Times(1)
+
+	// Notification says tip 5, EL head is 4 — mismatch, but we still commit the EL head.
+	s.conductor.handleReorgEvent(s.ctx, chainevents.ReorgEvent{NewTipNumber: 5, HasNewTip: true})
+
+	s.Equal(1, el.payloadByHashCalls)
+	s.cons.AssertNumberOfCalls(s.T(), "CommitUnsafePayload", 1)
 }
 
 // In this test, we have a follower that is healthy and not sequencing, we send a unhealthy update to it and expect it to stay as follower and not start sequencing.

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -119,7 +119,7 @@ func (s *OpConductorTestSuite) SetupTest() {
 	s.hmon = &healthmocks.HealthMonitor{}
 	s.cons.EXPECT().ServerID().Return("SequencerA")
 
-	conductor, err := NewOpConductor(s.ctx, &s.cfg, s.log, s.metrics, s.version, s.ctrl, s.cons, s.hmon)
+	conductor, err := NewOpConductor(s.ctx, &s.cfg, s.log, s.metrics, s.version, s.ctrl, s.cons, s.hmon, nil)
 	s.NoError(err)
 	conductor.retryBackoff = func() time.Duration { return 0 } // disable retry backoff for tests
 	s.conductor = conductor
@@ -1035,7 +1035,7 @@ func (s *OpConductorTestSuite) TestFlashblocksHandlerIntegration() {
 	testCfg.WebsocketServerPort = 0
 
 	// Create a new conductor with the updated config
-	conductor, err := NewOpConductor(s.ctx, &testCfg, s.log, s.metrics, s.version, s.ctrl, s.cons, s.hmon)
+	conductor, err := NewOpConductor(s.ctx, &testCfg, s.log, s.metrics, s.version, s.ctrl, s.cons, s.hmon, nil)
 	s.NoError(err)
 
 	// Set up mock expectation for Leader() calls - the flashblocks handler checks leadership

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -494,8 +494,12 @@ func (s *OpConductorTestSuite) TestStartSequencerConsensusBehindNodeFailsSafe() 
 		InfoNum:  5,
 		InfoHash: [32]byte{2, 3, 4},
 	}
-	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil).Times(1)
-	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil).Times(1)
+	// No call-count caps: the fail-safe makes startSequencer return an error, so the
+	// control loop re-queues and retries the catch-up, reading these heads again. The
+	// fail-safe is proven by the PostUnsafePayload/StartSequencer AssertNotCalled below,
+	// which hold no matter how many times the loop retries.
+	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil)
+	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil)
 
 	s.updateLeaderStatusAndExecuteAction(true)
 

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -470,6 +470,42 @@ func (s *OpConductorTestSuite) TestScenario4() {
 	s.ctrl.AssertNumberOfCalls(s.T(), "StartSequencer", 1)
 }
 
+// TestStartSequencerConsensusBehindNodeFailsSafe is the regression guard for the
+// reorg-recovery catch-up fail-safe (issue #20006 / plan Risk 4). After a backward
+// reorg write, consensus is BEHIND the node (cons < node). startSequencer's
+// `uint64(consNum) - nodeNum == 1` check then underflows (it is not 1) and must NOT
+// post the node onto the lower/stale consensus head. The underflow lives in
+// startSequencer (service.go), not compareUnsafeHead (which only returns the
+// mismatch), so this test drives the full start path. It asserts the conductor does
+// not reach PostUnsafePayload or StartSequencer and stays not-sequencing.
+func (s *OpConductorTestSuite) TestStartSequencerConsensusBehindNodeFailsSafe() {
+	s.enableSynchronization()
+
+	// consensus head (2) is BEHIND the node head (5) — the post-backward-write state.
+	mockPayload := &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: 2,
+			Timestamp:   hexutil.Uint64(time.Now().Unix()),
+			BlockHash:   [32]byte{1, 2, 3},
+		},
+	}
+	mockBlockInfo := &testutils.MockBlockInfo{
+		InfoNum:  5,
+		InfoHash: [32]byte{2, 3, 4},
+	}
+	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil).Times(1)
+	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil).Times(1)
+
+	s.updateLeaderStatusAndExecuteAction(true)
+
+	// [leader, healthy, NOT sequencing]: the underflow fail-safe blocks the catch-up.
+	s.True(s.conductor.leader.Load())
+	s.True(s.conductor.healthy.Load())
+	s.False(s.conductor.seqActive.Load())
+	s.ctrl.AssertNotCalled(s.T(), "PostUnsafePayload", mock.Anything, mock.Anything)
+	s.ctrl.AssertNotCalled(s.T(), "StartSequencer", mock.Anything, mock.Anything)
+}
+
 // In this test, we have a follower that is healthy and not sequencing, we send a unhealthy update to it and expect it to stay as follower and not start sequencing.
 // [follower, healthy, not sequencing] -- become unhealthy --> [follower, not healthy, not sequencing]
 func (s *OpConductorTestSuite) TestScenario5() {

--- a/op-conductor/consensus/raft.go
+++ b/op-conductor/consensus/raft.go
@@ -61,6 +61,12 @@ type RaftConsensusConfig struct {
 	TrailingLogs       uint64
 	HeartbeatTimeout   time.Duration
 	LeaderLeaseTimeout time.Duration
+
+	// AllowNonMonotonicUnsafeHead bypasses the FSM forward-only unsafe-head guard
+	// (last-write-wins) so a reorg can move the recorded head backward. Must be
+	// fleet-uniform across the cluster (see plan Risk 1). Sourced from the
+	// --reorg-recovery.enabled flag.
+	AllowNonMonotonicUnsafeHead bool
 }
 
 // checkTCPPortOpen attempts to connect to the specified address and returns an error if the connection fails.
@@ -140,7 +146,7 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 	}
 	log.Info("Raft server network transport is up", "addr", transport.LocalAddr())
 
-	fsm := NewUnsafeHeadTracker(log)
+	fsm := NewUnsafeHeadTracker(log, cfg.AllowNonMonotonicUnsafeHead)
 
 	r, err := raft.NewRaft(rc, fsm, logStore, stableStore, snapshotStore, transport)
 	if err != nil {

--- a/op-conductor/consensus/raft_fsm.go
+++ b/op-conductor/consensus/raft_fsm.go
@@ -19,11 +19,18 @@ type unsafeHeadTracker struct {
 	log        log.Logger
 	mtx        sync.RWMutex
 	unsafeHead *eth.ExecutionPayloadEnvelope
+	// allowNonMonotonic bypasses the forward-only guard in Apply (last-write-wins),
+	// letting a reorg move the recorded unsafe head backward. It is set once at
+	// construction from the fleet-uniform --reorg-recovery.enabled flag. Because Apply
+	// is deterministic, every node in the cluster MUST share this value or the FSM
+	// diverges (see plan Risk 1).
+	allowNonMonotonic bool
 }
 
-func NewUnsafeHeadTracker(log log.Logger) *unsafeHeadTracker {
+func NewUnsafeHeadTracker(log log.Logger, allowNonMonotonic bool) *unsafeHeadTracker {
 	return &unsafeHeadTracker{
-		log: log,
+		log:               log,
+		allowNonMonotonic: allowNonMonotonic,
 	}
 }
 
@@ -45,8 +52,17 @@ func (t *unsafeHeadTracker) Apply(l *raft.Log) interface{} {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	t.log.Debug("applying new unsafe head", "number", uint64(data.ExecutionPayload.BlockNumber), "hash", data.ExecutionPayload.BlockHash.Hex())
-	if t.unsafeHead == nil || t.unsafeHead.ExecutionPayload.BlockNumber < data.ExecutionPayload.BlockNumber {
-		t.unsafeHead = data
+	if t.allowNonMonotonic {
+		if t.unsafeHead != nil && data.ExecutionPayload.BlockNumber < t.unsafeHead.ExecutionPayload.BlockNumber {
+			t.log.Info("recording non-monotonic unsafe head (reorg)",
+				"old", t.unsafeHead.ExecutionPayload.BlockHash.Hex(),
+				"old_number", uint64(t.unsafeHead.ExecutionPayload.BlockNumber),
+				"new", data.ExecutionPayload.BlockHash.Hex(),
+				"new_number", uint64(data.ExecutionPayload.BlockNumber))
+		}
+		t.unsafeHead = data // unconditional — last-write-wins
+	} else if t.unsafeHead == nil || t.unsafeHead.ExecutionPayload.BlockNumber < data.ExecutionPayload.BlockNumber {
+		t.unsafeHead = data // forward-only guard (existing behavior)
 	}
 
 	return nil

--- a/op-conductor/consensus/raft_fsm_test.go
+++ b/op-conductor/consensus/raft_fsm_test.go
@@ -71,6 +71,41 @@ func TestUnsafeHeadTracker(t *testing.T) {
 	})
 }
 
+// applyEnvelope SSZ-encodes env and applies it to the tracker, asserting no error.
+func applyEnvelope(t *testing.T, tracker *unsafeHeadTracker, env *eth.ExecutionPayloadEnvelope) {
+	var buf bytes.Buffer
+	_, err := env.MarshalSSZ(&buf)
+	require.NoError(t, err)
+	require.Nil(t, tracker.Apply(&raft.Log{Data: buf.Bytes()}))
+}
+
+// TestApplyForwardOnlyWhenGuarded asserts the default (flag OFF) forward-only guard:
+// a lower-number entry is dropped. This is byte-for-byte today's behavior.
+func TestApplyForwardOnlyWhenGuarded(t *testing.T) {
+	tracker := NewUnsafeHeadTracker(testlog.Logger(t, log.LevelDebug), false)
+	applyEnvelope(t, tracker, createPayloadEnvelope(333))
+	applyEnvelope(t, tracker, createPayloadEnvelope(222)) // lower — must be dropped
+	require.Equal(t, hexutil.Uint64(333), tracker.unsafeHead.ExecutionPayload.BlockNumber)
+}
+
+// TestApplyLastWriteWinsWhenUnguarded asserts the flag-ON behavior: a lower-number
+// entry replaces the head (reorg recorded).
+func TestApplyLastWriteWinsWhenUnguarded(t *testing.T) {
+	tracker := NewUnsafeHeadTracker(testlog.Logger(t, log.LevelDebug), true)
+	applyEnvelope(t, tracker, createPayloadEnvelope(333))
+	applyEnvelope(t, tracker, createPayloadEnvelope(222)) // lower — must replace
+	require.Equal(t, hexutil.Uint64(222), tracker.unsafeHead.ExecutionPayload.BlockNumber)
+}
+
+// TestApplyForwardStillAdvancesWhenUnguarded asserts no regression on the forward
+// path with the flag ON: a higher-number entry still advances the head.
+func TestApplyForwardStillAdvancesWhenUnguarded(t *testing.T) {
+	tracker := NewUnsafeHeadTracker(testlog.Logger(t, log.LevelDebug), true)
+	applyEnvelope(t, tracker, createPayloadEnvelope(333))
+	applyEnvelope(t, tracker, createPayloadEnvelope(444)) // higher — must advance
+	require.Equal(t, hexutil.Uint64(444), tracker.unsafeHead.ExecutionPayload.BlockNumber)
+}
+
 type mockReadCloser struct {
 	currentPosition int
 	data            *eth.ExecutionPayloadEnvelope

--- a/op-conductor/consensus/raft_test.go
+++ b/op-conductor/consensus/raft_test.go
@@ -85,3 +85,78 @@ func TestCommitAndRead(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, payload, unsafeHead)
 }
+
+// v3Payload builds a minimal BlockV3 ExecutionPayloadEnvelope at the given number.
+func v3Payload(number uint64) *eth.ExecutionPayloadEnvelope {
+	one := hexutil.Uint64(1)
+	hash := common.HexToHash("0x12345")
+	return &eth.ExecutionPayloadEnvelope{
+		ParentBeaconBlockRoot: &hash,
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber:   hexutil.Uint64(number),
+			Timestamp:     hexutil.Uint64(time.Now().Unix()),
+			Transactions:  []eth.Data{},
+			ExtraData:     []byte{},
+			Withdrawals:   &types.Withdrawals{},
+			ExcessBlobGas: &one,
+			BlobGasUsed:   &one,
+		},
+	}
+}
+
+// newBootstrapConsensus spins up a single-node bootstrapped raft cluster and waits
+// for leadership. storageDir is wiped first.
+func newBootstrapConsensus(t *testing.T, serverID, storageDir string, allowNonMonotonic bool) *RaftConsensus {
+	now := uint64(time.Now().Unix())
+	rollupCfg := &rollup.Config{CanyonTime: &now}
+	require.NoError(t, os.RemoveAll(storageDir))
+	cfg := &RaftConsensusConfig{
+		ServerID:                    serverID,
+		ListenPort:                  0,
+		ListenAddr:                  "127.0.0.1",
+		AdvertisedAddr:              "",
+		StorageDir:                  storageDir,
+		Bootstrap:                   true,
+		RollupCfg:                   rollupCfg,
+		SnapshotInterval:            120 * time.Second,
+		SnapshotThreshold:           10240,
+		TrailingLogs:                8192,
+		HeartbeatTimeout:            1000 * time.Millisecond,
+		LeaderLeaseTimeout:          500 * time.Millisecond,
+		AllowNonMonotonicUnsafeHead: allowNonMonotonic,
+	}
+	cons, err := NewRaftConsensus(testlog.Logger(t, log.LevelInfo), cfg)
+	require.NoError(t, err)
+	<-cons.LeaderCh()
+	return cons
+}
+
+// TestCommitNonMonotonicWhenUnguarded proves a backward CommitUnsafePayload is
+// recorded through the real raft Apply path when the flag is on (the reorg case).
+// Multi-node follower convergence is covered by the Phase 3 acceptance test; the
+// FSM Apply that followers replay is identical, exercised in raft_fsm_test.go.
+func TestCommitNonMonotonicWhenUnguarded(t *testing.T) {
+	cons := newBootstrapConsensus(t, "SequencerReorgOn", "/tmp/sequencer-reorg-on", true)
+
+	require.NoError(t, cons.CommitUnsafePayload(v3Payload(5)))
+	require.NoError(t, cons.CommitUnsafePayload(v3Payload(2))) // backward (reorg)
+
+	unsafeHead, err := cons.LatestUnsafePayload()
+	require.NoError(t, err)
+	require.Equal(t, hexutil.Uint64(2), unsafeHead.ExecutionPayload.BlockNumber,
+		"with the guard bypassed, a backward commit must move the recorded head back")
+}
+
+// TestCommitForwardOnlyWhenGuarded proves the default (flag off) path drops a
+// backward commit through the real raft Apply path — byte-for-byte today's behavior.
+func TestCommitForwardOnlyWhenGuarded(t *testing.T) {
+	cons := newBootstrapConsensus(t, "SequencerReorgOff", "/tmp/sequencer-reorg-off", false)
+
+	require.NoError(t, cons.CommitUnsafePayload(v3Payload(5)))
+	require.NoError(t, cons.CommitUnsafePayload(v3Payload(2))) // backward — must be dropped
+
+	unsafeHead, err := cons.LatestUnsafePayload()
+	require.NoError(t, err)
+	require.Equal(t, hexutil.Uint64(5), unsafeHead.ExecutionPayload.BlockNumber,
+		"with the guard on, a backward commit must be ignored")
+}

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -210,6 +210,23 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_ROUND_ROBIN_LEADER_TRANSFER"),
 		Value:   false,
 	}
+	ReorgRecoveryEnabled = &cli.BoolFlag{
+		Name:  "reorg-recovery.enabled",
+		Value: false, // default OFF — ships dormant
+		Usage: "Enable reth reorg-recovery. When true, op-conductor subscribes to " +
+			"op-reth reorg notifications and removes the FSM forward-only head guard " +
+			"so a reorg can move the recorded unsafe head backward. " +
+			"CRITICAL: this flag changes Raft FSM apply semantics. It MUST be set " +
+			"IDENTICALLY on EVERY conductor in the cluster — all-on or all-off, NEVER " +
+			"mixed. A mixed setting causes silent Raft FSM divergence. Enable only as a " +
+			"coordinated, fleet-wide rollout. Requires --execution.ws-url when set.",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "REORG_RECOVERY_ENABLED"),
+	}
+	ExecutionWSURL = &cli.StringFlag{
+		Name:    "execution.ws-url",
+		Usage:   "WebSocket URL for the execution layer (op-reth) reorg subscription. Required when --reorg-recovery.enabled is set.",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "EXECUTION_WS_URL"),
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -257,6 +274,8 @@ func init() {
 	optionalFlags = append(optionalFlags, opflags.CLIFlags(EnvVarPrefix, "")...)
 	optionalFlags = append(optionalFlags, RollupBoostWsURL)
 	optionalFlags = append(optionalFlags, WebsocketServerPort)
+	optionalFlags = append(optionalFlags, ReorgRecoveryEnabled)
+	optionalFlags = append(optionalFlags, ExecutionWSURL)
 	Flags = append(requiredFlags, optionalFlags...)
 }
 

--- a/op-conductor/metrics/metrics.go
+++ b/op-conductor/metrics/metrics.go
@@ -21,6 +21,10 @@ type Metricer interface {
 	RecordLoopExecutionTime(duration float64)
 	RecordRollupBoostConnectionAttempts(success bool, source string)
 	RecordWebSocketClientCount(count int)
+	RecordReorgObserved()
+	RecordReorgCommitted()
+	RecordReorgNumberMismatch()
+	RecordReorgFetchFailure()
 	opmetrics.RPCMetricer
 }
 
@@ -46,6 +50,13 @@ type Metrics struct {
 
 	loopExecutionTime prometheus.Histogram
 	webSocketClients  prometheus.Gauge
+
+	// Reorg-recovery counters are label-less (no dimension), so they are plain
+	// Counters, not CounterVecs. They use the local _count suffix convention.
+	reorgsObserved      prometheus.Counter
+	reorgsCommitted     prometheus.Counter
+	reorgNumberMismatch prometheus.Counter
+	reorgFetchErrors    prometheus.Counter
 }
 
 func (m *Metrics) Registry() *prometheus.Registry {
@@ -122,6 +133,26 @@ func NewMetrics() *Metrics {
 			Name:      "websocket_clients_connected",
 			Help:      "Number of WebSocket clients currently connected to the hub",
 		}),
+		reorgsObserved: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "reorgs_observed_count",
+			Help:      "Number of reth reorg notifications observed",
+		}),
+		reorgsCommitted: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "reorgs_committed_count",
+			Help:      "Number of post-reorg unsafe heads committed to consensus",
+		}),
+		reorgNumberMismatch: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "reorg_number_mismatch_count",
+			Help:      "Number of reorgs where the EL head number differed from the notification tip number (possible label-lag race)",
+		}),
+		reorgFetchErrors: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "reorg_fetch_errors_count",
+			Help:      "Number of reorg EL fetch failures (InfoByLabel or PayloadByHash)",
+		}),
 	}
 }
 
@@ -182,4 +213,25 @@ func (m *Metrics) RecordRollupBoostConnectionAttempts(success bool, source strin
 // RecordWebSocketClientCount sets the current number of WebSocket clients connected.
 func (m *Metrics) RecordWebSocketClientCount(count int) {
 	m.webSocketClients.Set(float64(count))
+}
+
+// RecordReorgObserved increments the count of observed reth reorg notifications.
+func (m *Metrics) RecordReorgObserved() {
+	m.reorgsObserved.Inc()
+}
+
+// RecordReorgCommitted increments the count of post-reorg unsafe heads committed.
+func (m *Metrics) RecordReorgCommitted() {
+	m.reorgsCommitted.Inc()
+}
+
+// RecordReorgNumberMismatch increments the count of reorgs where the EL head
+// number differed from the notification tip number.
+func (m *Metrics) RecordReorgNumberMismatch() {
+	m.reorgNumberMismatch.Inc()
+}
+
+// RecordReorgFetchFailure increments the count of reorg EL fetch failures.
+func (m *Metrics) RecordReorgFetchFailure() {
+	m.reorgFetchErrors.Inc()
 }

--- a/op-conductor/metrics/metrics.go
+++ b/op-conductor/metrics/metrics.go
@@ -25,6 +25,7 @@ type Metricer interface {
 	RecordReorgCommitted()
 	RecordReorgNumberMismatch()
 	RecordReorgFetchFailure()
+	RecordReorgResync()
 	opmetrics.RPCMetricer
 }
 
@@ -57,6 +58,7 @@ type Metrics struct {
 	reorgsCommitted     prometheus.Counter
 	reorgNumberMismatch prometheus.Counter
 	reorgFetchErrors    prometheus.Counter
+	reorgResyncs        prometheus.Counter
 }
 
 func (m *Metrics) Registry() *prometheus.Registry {
@@ -153,6 +155,11 @@ func NewMetrics() *Metrics {
 			Name:      "reorg_fetch_errors_count",
 			Help:      "Number of reorg EL fetch failures (InfoByLabel or PayloadByHash)",
 		}),
+		reorgResyncs: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "reorg_resyncs_count",
+			Help:      "Number of reconnect-reconcile catch-up triggers emitted on (re)subscribe",
+		}),
 	}
 }
 
@@ -234,4 +241,9 @@ func (m *Metrics) RecordReorgNumberMismatch() {
 // RecordReorgFetchFailure increments the count of reorg EL fetch failures.
 func (m *Metrics) RecordReorgFetchFailure() {
 	m.reorgFetchErrors.Inc()
+}
+
+// RecordReorgResync increments the count of reconnect-reconcile catch-up triggers.
+func (m *Metrics) RecordReorgResync() {
+	m.reorgResyncs.Inc()
 }

--- a/op-conductor/metrics/noop.go
+++ b/op-conductor/metrics/noop.go
@@ -22,3 +22,4 @@ func (*NoopMetricsImpl) RecordReorgObserved()                                   
 func (*NoopMetricsImpl) RecordReorgCommitted()                                           {}
 func (*NoopMetricsImpl) RecordReorgNumberMismatch()                                      {}
 func (*NoopMetricsImpl) RecordReorgFetchFailure()                                        {}
+func (*NoopMetricsImpl) RecordReorgResync()                                              {}

--- a/op-conductor/metrics/noop.go
+++ b/op-conductor/metrics/noop.go
@@ -18,3 +18,7 @@ func (*NoopMetricsImpl) RecordHealthCheck(success bool, err error)              
 func (*NoopMetricsImpl) RecordLoopExecutionTime(duration float64)                        {}
 func (*NoopMetricsImpl) RecordRollupBoostConnectionAttempts(success bool, source string) {}
 func (*NoopMetricsImpl) RecordWebSocketClientCount(count int)                            {}
+func (*NoopMetricsImpl) RecordReorgObserved()                                            {}
+func (*NoopMetricsImpl) RecordReorgCommitted()                                           {}
+func (*NoopMetricsImpl) RecordReorgNumberMismatch()                                      {}
+func (*NoopMetricsImpl) RecordReorgFetchFailure()                                        {}

--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -62,6 +62,11 @@ type API interface {
 	Active(ctx context.Context) (bool, error)
 	// CommitUnsafePayload commits an unsafe payload (latest head) to the consensus layer.
 	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
+	// LatestUnsafePayload returns the latest unsafe payload recorded in the consensus
+	// layer. NOTE: when reorg-recovery is enabled (--reorg-recovery.enabled), this value
+	// is non-monotonic — it can move backward on a reorg — so callers must not assume the
+	// recorded unsafe head only ever advances.
+	LatestUnsafePayload(ctx context.Context) (*eth.ExecutionPayloadEnvelope, error)
 }
 
 // ExecutionProxyAPI defines the methods proxied to the execution 'eth_' rpc backend

--- a/op-conductor/rpc/backend.go
+++ b/op-conductor/rpc/backend.go
@@ -28,6 +28,7 @@ type conductor interface {
 	TransferLeader(ctx context.Context) error
 	TransferLeaderToServer(ctx context.Context, id string, addr string) error
 	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
+	LatestUnsafePayload(ctx context.Context) (*eth.ExecutionPayloadEnvelope, error)
 	ClusterMembership(ctx context.Context) (*consensus.ClusterMembership, error)
 }
 
@@ -97,6 +98,11 @@ func (api *APIBackend) DemoteVoter(ctx context.Context, id string, version uint6
 // CommitUnsafePayload implements API.
 func (api *APIBackend) CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
 	return api.con.CommitUnsafePayload(ctx, payload)
+}
+
+// LatestUnsafePayload implements API.
+func (api *APIBackend) LatestUnsafePayload(ctx context.Context) (*eth.ExecutionPayloadEnvelope, error) {
+	return api.con.LatestUnsafePayload(ctx)
 }
 
 // Leader implements API, returns true if current conductor is leader of the cluster.

--- a/op-conductor/rpc/client.go
+++ b/op-conductor/rpc/client.go
@@ -90,6 +90,13 @@ func (c *APIClient) CommitUnsafePayload(ctx context.Context, payload *eth.Execut
 	return c.c.CallContext(ctx, nil, prefixRPC("commitUnsafePayload"), payload)
 }
 
+// LatestUnsafePayload implements API.
+func (c *APIClient) LatestUnsafePayload(ctx context.Context) (*eth.ExecutionPayloadEnvelope, error) {
+	var payload *eth.ExecutionPayloadEnvelope
+	err := c.c.CallContext(ctx, &payload, prefixRPC("latestUnsafePayload"))
+	return payload, err
+}
+
 // Leader implements API.
 func (c *APIClient) Leader(ctx context.Context) (bool, error) {
 	var leader bool

--- a/op-devstack/dsl/conductor.go
+++ b/op-devstack/dsl/conductor.go
@@ -1,7 +1,12 @@
 package dsl
 
 import (
+	"bufio"
 	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
@@ -110,6 +115,57 @@ func (c *Conductor) IsLeader() bool {
 	c.require.NoError(err, "Failed to check if conductor is leader")
 	c.log.Info("Checked if conductor is leader", "leader", leader)
 	return leader
+}
+
+// ScrapeCounter fetches the conductor's Prometheus metrics endpoint and returns the
+// value of the named counter (e.g. "op_conductor_reorgs_committed_count"). Returns 0
+// when the metric is absent, which is the correct reading for a counter that has never
+// been incremented.
+func (c *Conductor) ScrapeCounter(name string) float64 {
+	endpoint := c.inner.MetricsEndpoint()
+	c.require.NotEmpty(endpoint, "conductor %s does not expose a metrics endpoint", c.inner.Name())
+	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+	defer cancel()
+	value, err := retry.Do(ctx, 3, retry.Fixed(250*time.Millisecond), func() (float64, error) {
+		return scrapeCounter(ctx, endpoint, name)
+	})
+	c.require.NoErrorf(err, "failed to scrape metric %s from conductor %s", name, c.inner.Name())
+	return value
+}
+
+func scrapeCounter(ctx context.Context, endpoint string, name string) (float64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+	scanner := bufio.NewScanner(strings.NewReader(string(body)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Prometheus exposition: "<metric>[{labels}] <value>". The reorg counters are
+		// label-less, so an exact name prefix followed by a space is sufficient.
+		if !strings.HasPrefix(line, name+" ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		return strconv.ParseFloat(fields[len(fields)-1], 64)
+	}
+	// Metric not yet emitted — a never-incremented counter reads as 0.
+	return 0, nil
 }
 
 func (c *Conductor) TransferLeadershipTo(targetLeaderInfo consensus.ServerInfo) {

--- a/op-devstack/dsl/conductor.go
+++ b/op-devstack/dsl/conductor.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 )
 
@@ -65,6 +66,20 @@ func (c *Conductor) FetchLeader() *consensus.ServerInfo {
 	c.log.Info("Fetched leader information",
 		"leaderInfo", leaderInfo)
 	return leaderInfo
+}
+
+// FetchLatestUnsafePayload returns the latest unsafe payload recorded in the
+// conductor's consensus layer. With reorg-recovery enabled this value is
+// non-monotonic (it can move backward on a reorg).
+func (c *Conductor) FetchLatestUnsafePayload() *eth.ExecutionPayloadEnvelope {
+	c.log.Debug("Fetching latest unsafe payload")
+	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+	defer cancel()
+	payload, err := retry.Do(ctx, 2, retry.Fixed(500*time.Millisecond), func() (*eth.ExecutionPayloadEnvelope, error) {
+		return c.inner.RpcAPI().LatestUnsafePayload(ctx)
+	})
+	c.require.NoError(err, "Failed to fetch latest unsafe payload")
+	return payload
 }
 
 func (c *Conductor) FetchSequencerHealthy() bool {

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -32,6 +32,7 @@ const (
 	optionKindSkipHonestProposer
 	optionKindSupernodeVerifierSyncMode
 	optionKindInteropActivationDelay
+	optionKindConductor
 )
 
 const allOptionKinds = optionKindDeployer |
@@ -54,7 +55,8 @@ const allOptionKinds = optionKindDeployer |
 	optionKindPreGenesisSuperGame |
 	optionKindSkipHonestProposer |
 	optionKindSupernodeVerifierSyncMode |
-	optionKindInteropActivationDelay
+	optionKindInteropActivationDelay |
+	optionKindConductor
 
 var optionKindLabels = []struct {
 	kind  optionKinds
@@ -81,6 +83,7 @@ var optionKindLabels = []struct {
 	{kind: optionKindSkipHonestProposer, label: "skip honest proposer"},
 	{kind: optionKindSupernodeVerifierSyncMode, label: "supernode verifier sync mode"},
 	{kind: optionKindInteropActivationDelay, label: "interop activation delay"},
+	{kind: optionKindConductor, label: "conductor options"},
 }
 
 func (k optionKinds) String() string {
@@ -136,7 +139,8 @@ const minimalWithConductorsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindRespectedGameType |
 	optionKindTimeTravel |
 	optionKindAfterBuild |
-	optionKindProofValidation
+	optionKindProofValidation |
+	optionKindConductor
 
 const simpleWithSyncTesterPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds |
 	optionKindGlobalSyncTesterEL
@@ -176,6 +180,9 @@ const twoL2SupernodeInteropPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindInteropLogBackfill |
 	optionKindInteropFilter |
 	optionKindPreGenesisSuperGame
+
+const twoL2SupernodeInteropWithConductorsPresetSupportedOptionKinds = twoL2SupernodeInteropPresetSupportedOptionKinds |
+	optionKindConductor
 
 const singleChainWithFlashblocksPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindOPRBuilder

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	opconductor "github.com/ethereum-optimism/optimism/op-conductor/conductor"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -280,6 +281,57 @@ func WithInteropFilter() Option {
 			cfg.UseInteropFilter = true
 		},
 	}
+}
+
+func WithConductorHealthCheck(interval, unsafeInterval, safeInterval uint64) Option {
+	return option{
+		kinds: optionKindConductor,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			minPeerCount := uint64(1)
+			if cfg.ConductorHealthCheck != nil {
+				minPeerCount = cfg.ConductorHealthCheck.MinPeerCount
+			}
+			cfg.ConductorHealthCheck = &opconductor.HealthCheckConfig{
+				Interval:       interval,
+				UnsafeInterval: unsafeInterval,
+				SafeInterval:   safeInterval,
+				MinPeerCount:   minPeerCount,
+			}
+		},
+	}
+}
+
+func WithConductorHealthCheckMinPeerCount(minPeerCount uint64) Option {
+	return option{
+		kinds: optionKindConductor,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			ensureConductorHealthCheck(cfg).MinPeerCount = minPeerCount
+		},
+	}
+}
+
+// WithConductorReorgRecovery enables op-conductor's reorg-recovery mode on every
+// conductor in the preset (the fleet-uniform `--reorg-recovery.enabled` flag plus
+// the op-reth WebSocket subscription). Only effective with op-reth ELs.
+func WithConductorReorgRecovery() Option {
+	return option{
+		kinds: optionKindConductor,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			cfg.ConductorReorgRecoveryEnabled = true
+		},
+	}
+}
+
+func ensureConductorHealthCheck(cfg *sysgo.PresetConfig) *opconductor.HealthCheckConfig {
+	if cfg.ConductorHealthCheck == nil {
+		cfg.ConductorHealthCheck = &opconductor.HealthCheckConfig{
+			Interval:       3600,
+			UnsafeInterval: 3600,
+			SafeInterval:   3600,
+			MinPeerCount:   1,
+		}
+	}
+	return cfg.ConductorHealthCheck
 }
 
 func WithRequireInteropNotAtGenesis() Option {

--- a/op-devstack/presets/rpc_frontends.go
+++ b/op-devstack/presets/rpc_frontends.go
@@ -447,18 +447,20 @@ func (r *supernodeFrontend) QueryAPI() apis.SupernodeQueryAPI {
 
 type conductorFrontend struct {
 	presetCommon
-	chainID eth.ChainID
-	api     conductorRpc.API
+	chainID         eth.ChainID
+	api             conductorRpc.API
+	metricsEndpoint string
 }
 
 var _ stack.Conductor = (*conductorFrontend)(nil)
 
-func newPresetConductor(t devtest.T, name string, chainID eth.ChainID, rpcCl *gethrpc.Client) *conductorFrontend {
+func newPresetConductor(t devtest.T, name string, chainID eth.ChainID, rpcCl *gethrpc.Client, metricsEndpoint string) *conductorFrontend {
 	t = t.WithCtx(stack.ContextWithChainID(t.Ctx(), chainID))
 	return &conductorFrontend{
-		presetCommon: newPresetCommon(t, name),
-		chainID:      chainID,
-		api:          conductorRpc.NewAPIClient(rpcCl),
+		presetCommon:    newPresetCommon(t, name),
+		chainID:         chainID,
+		api:             conductorRpc.NewAPIClient(rpcCl),
+		metricsEndpoint: metricsEndpoint,
 	}
 }
 
@@ -468,6 +470,10 @@ func (r *conductorFrontend) ChainID() eth.ChainID {
 
 func (r *conductorFrontend) RpcAPI() conductorRpc.API {
 	return r.api
+}
+
+func (r *conductorFrontend) MetricsEndpoint() string {
+	return r.metricsEndpoint
 }
 
 type faucetFrontend struct {

--- a/op-devstack/presets/singlechain_from_runtime.go
+++ b/op-devstack/presets/singlechain_from_runtime.go
@@ -267,9 +267,9 @@ func minimalWithConductorsFromRuntime(t devtest.T, runtime *sysgo.SingleChainRun
 	cAName := "sequencer"
 	cBName := "b"
 	cCName := "c"
-	cA := newConductorFrontend(t, cAName, l2ChainID, runtime.Conductors[cAName].HTTPEndpoint())
-	cB := newConductorFrontend(t, cBName, l2ChainID, runtime.Conductors[cBName].HTTPEndpoint())
-	cC := newConductorFrontend(t, cCName, l2ChainID, runtime.Conductors[cCName].HTTPEndpoint())
+	cA := newConductorFrontend(t, cAName, l2ChainID, runtime.Conductors[cAName].HTTPEndpoint(), runtime.Conductors[cAName].MetricsEndpoint())
+	cB := newConductorFrontend(t, cBName, l2ChainID, runtime.Conductors[cBName].HTTPEndpoint(), runtime.Conductors[cBName].MetricsEndpoint())
+	cC := newConductorFrontend(t, cCName, l2ChainID, runtime.Conductors[cCName].HTTPEndpoint(), runtime.Conductors[cCName].MetricsEndpoint())
 	l2Net, ok := minimal.L2Chain.Escape().(*presetL2Network)
 	t.Require().True(ok, "expected preset L2 network")
 	l2Net.AddConductor(cA)

--- a/op-devstack/presets/sysgo_runtime.go
+++ b/op-devstack/presets/sysgo_runtime.go
@@ -129,11 +129,11 @@ func newSupernodeFrontend(t devtest.T, name string, userRPC string) *supernodeFr
 	return newPresetSupernode(t, name, rpcCl)
 }
 
-func newConductorFrontend(t devtest.T, name string, chainID eth.ChainID, rpcEndpoint string) *conductorFrontend {
+func newConductorFrontend(t devtest.T, name string, chainID eth.ChainID, rpcEndpoint string, metricsEndpoint string) *conductorFrontend {
 	rpcCl, err := rpc.DialContext(t.Ctx(), rpcEndpoint)
 	t.Require().NoError(err)
 	t.Cleanup(rpcCl.Close)
-	return newPresetConductor(t, name, chainID, rpcCl)
+	return newPresetConductor(t, name, chainID, rpcCl, metricsEndpoint)
 }
 
 func newTestSequencerFrontend(t devtest.T, name string, adminRPC string, controlRPCs map[eth.ChainID]string, jwtSecret [32]byte) *testSequencerFrontend {

--- a/op-devstack/presets/twol2.go
+++ b/op-devstack/presets/twol2.go
@@ -105,6 +105,17 @@ type TwoL2SupernodeInteropWithConductors struct {
 	*TwoL2SupernodeInterop
 
 	ConductorSets map[eth.ChainID]dsl.ConductorSet
+
+	// SupernodeELs maps each chain to its supernode validator-node EL. In this
+	// production-faithful topology that EL is distinct from the conductor-controlled
+	// sequencer ELs, joined only by L1 + P2P.
+	SupernodeELs map[eth.ChainID]*dsl.L2ELNode
+
+	// SequencerELs maps each chain to its conductor-controlled sequencer ELs, keyed
+	// by conductor name ("sequencer" is the bootstrap leader candidate). Together
+	// with SupernodeELs these are every EL that must converge on the canonical chain
+	// after a reorg.
+	SequencerELs map[eth.ChainID]map[string]*dsl.L2ELNode
 }
 
 // AdvanceTime advances the time-travel clock if enabled.

--- a/op-devstack/presets/twol2.go
+++ b/op-devstack/presets/twol2.go
@@ -101,6 +101,12 @@ func (s *TwoL2SupernodeInterop) L2UserRPCURLs() []string {
 	return []string{s.L2ELA.Escape().UserRPC(), s.L2ELB.Escape().UserRPC()}
 }
 
+type TwoL2SupernodeInteropWithConductors struct {
+	*TwoL2SupernodeInterop
+
+	ConductorSets map[eth.ChainID]dsl.ConductorSet
+}
+
 // AdvanceTime advances the time-travel clock if enabled.
 func (s *TwoL2SupernodeInterop) AdvanceTime(amount time.Duration) {
 	s.T.Require().NotNil(s.timeTravel, "attempting to advance time on incompatible system")
@@ -134,6 +140,13 @@ func NewTwoL2SupernodeLightSequencerInterop(t devtest.T, delaySeconds uint64, op
 		sysgo.SkipOnOpGeth(t, "interop filter is only supported with op-reth")
 	}
 	return twoL2SupernodeInteropFromRuntime(t, sysgo.NewTwoL2SupernodeLightSequencerInteropRuntimeWithConfig(t, delaySeconds, presetCfg))
+}
+
+func NewTwoL2SupernodeInteropWithConductors(t devtest.T, delaySeconds uint64, opts ...Option) *TwoL2SupernodeInteropWithConductors {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewTwoL2SupernodeInteropWithConductors", opts, twoL2SupernodeInteropWithConductorsPresetSupportedOptionKinds)
+	out := twoL2SupernodeInteropWithConductorsFromRuntime(t, sysgo.NewTwoL2SupernodeInteropWithConductorsRuntimeWithConfig(t, delaySeconds, presetCfg))
+	presetOpts.applyPreset(out)
+	return out
 }
 
 // =============================================================================

--- a/op-devstack/presets/twol2_from_runtime.go
+++ b/op-devstack/presets/twol2_from_runtime.go
@@ -117,9 +117,9 @@ func twoL2SupernodeInteropFromRuntime(t devtest.T, runtime *sysgo.MultiChainRunt
 
 	supernode := newSupernodeFrontend(t, "supernode-two-l2-system", runtime.Supernode.UserRPC())
 	l2ASupernodeCL := newL2CLFrontend(t, "supernode", chainA.Network.ChainID(), chainA.SupernodeCL.UserRPC(), chainA.SupernodeCL)
-	l2ASupernodeCL.attachEL(components.l2AEL)
+	l2ASupernodeCL.attachEL(supernodeELFrontend(t, chainA, components.l2AEL))
 	l2BSupernodeCL := newL2CLFrontend(t, "supernode", chainB.Network.ChainID(), chainB.SupernodeCL.UserRPC(), chainB.SupernodeCL)
-	l2BSupernodeCL.attachEL(components.l2BEL)
+	l2BSupernodeCL.attachEL(supernodeELFrontend(t, chainB, components.l2BEL))
 	testSequencer := newTestSequencerFrontend(
 		t,
 		runtime.TestSequencer.Name,
@@ -161,6 +161,27 @@ func twoL2SupernodeInteropFromRuntime(t devtest.T, runtime *sysgo.MultiChainRunt
 	preset.FunderA = dsl.NewFunder(preset.Wallet, preset.FaucetA, preset.L2ELA)
 	preset.FunderB = dsl.NewFunder(preset.Wallet, preset.FaucetB, preset.L2ELB)
 	return preset
+}
+
+// supernodeELFrontend returns an EL frontend for the supernode VN's EL. When
+// the supernode shares the chain's primary EL (virtual-sequencer presets) it
+// reuses the already-built sequencer EL frontend; when the supernode has its
+// own EL (light-sequencer presets, production topology) it builds a dedicated
+// frontend so the supernode CL is attached to the EL it actually drives.
+func supernodeELFrontend(t devtest.T, chain *sysgo.MultiChainNodeRuntime, seqELFrontend *l2ELFrontend) *l2ELFrontend {
+	if chain.SupernodeEL == nil || chain.SupernodeEL == chain.EL {
+		return seqELFrontend
+	}
+	return newL2ELFrontend(
+		t,
+		"supernode",
+		chain.Network.ChainID(),
+		chain.SupernodeEL.UserRPC(),
+		chain.SupernodeEL.EngineRPC(),
+		chain.SupernodeEL.JWTPath(),
+		chain.Network.RollupConfig(),
+		chain.SupernodeEL,
+	)
 }
 
 func twoL2SupernodeFollowL2FromRuntime(t devtest.T, runtime *sysgo.MultiChainRuntime) *TwoL2SupernodeFollowL2 {

--- a/op-devstack/presets/twol2_from_runtime.go
+++ b/op-devstack/presets/twol2_from_runtime.go
@@ -1,9 +1,13 @@
 package presets
 
 import (
+	"sort"
+
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type twoL2RuntimeComponents struct {
@@ -182,6 +186,45 @@ func supernodeELFrontend(t devtest.T, chain *sysgo.MultiChainNodeRuntime, seqELF
 		chain.Network.RollupConfig(),
 		chain.SupernodeEL,
 	)
+}
+
+func twoL2SupernodeInteropWithConductorsFromRuntime(t devtest.T, runtime *sysgo.MultiChainRuntime) *TwoL2SupernodeInteropWithConductors {
+	base := twoL2SupernodeInteropFromRuntime(t, runtime)
+	chainA := runtime.Chains["l2a"]
+	chainB := runtime.Chains["l2b"]
+	t.Require().NotNil(chainA, "missing l2a supernode chain")
+	t.Require().NotNil(chainB, "missing l2b supernode chain")
+	t.Require().NotNil(chainA.Conductors, "missing l2a conductors")
+	t.Require().NotNil(chainB.Conductors, "missing l2b conductors")
+
+	conductorSets := map[eth.ChainID]dsl.ConductorSet{
+		chainA.Network.ChainID(): addConductorsToL2Network(t, base.L2A, chainA.Network.ChainID(), chainA.Conductors),
+		chainB.Network.ChainID(): addConductorsToL2Network(t, base.L2B, chainB.Network.ChainID(), chainB.Conductors),
+	}
+	return &TwoL2SupernodeInteropWithConductors{
+		TwoL2SupernodeInterop: base,
+		ConductorSets:         conductorSets,
+	}
+}
+
+func addConductorsToL2Network(t devtest.T, l2 *dsl.L2Network, chainID eth.ChainID, conductors map[string]*sysgo.Conductor) dsl.ConductorSet {
+	names := make([]string, 0, len(conductors))
+	for name := range conductors {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	frontends := make([]stack.Conductor, 0, len(names))
+	l2Net, ok := l2.Escape().(*presetL2Network)
+	t.Require().True(ok, "expected preset L2 network")
+	for _, name := range names {
+		conductor := conductors[name]
+		t.Require().NotNil(conductor, "missing conductor %s", name)
+		frontend := newConductorFrontend(t, name, chainID, conductor.HTTPEndpoint(), conductor.MetricsEndpoint())
+		l2Net.AddConductor(frontend)
+		frontends = append(frontends, frontend)
+	}
+	return dsl.NewConductorSet(frontends)
 }
 
 func twoL2SupernodeFollowL2FromRuntime(t devtest.T, runtime *sysgo.MultiChainRuntime) *TwoL2SupernodeFollowL2 {

--- a/op-devstack/presets/twol2_from_runtime.go
+++ b/op-devstack/presets/twol2_from_runtime.go
@@ -201,10 +201,61 @@ func twoL2SupernodeInteropWithConductorsFromRuntime(t devtest.T, runtime *sysgo.
 		chainA.Network.ChainID(): addConductorsToL2Network(t, base.L2A, chainA.Network.ChainID(), chainA.Conductors),
 		chainB.Network.ChainID(): addConductorsToL2Network(t, base.L2B, chainB.Network.ChainID(), chainB.Conductors),
 	}
+	supernodeELs := map[eth.ChainID]*dsl.L2ELNode{
+		chainA.Network.ChainID(): supernodeELNode(t, chainA),
+		chainB.Network.ChainID(): supernodeELNode(t, chainB),
+	}
+	sequencerELs := map[eth.ChainID]map[string]*dsl.L2ELNode{
+		chainA.Network.ChainID(): conductorSequencerELNodes(t, chainA, base.L2ELA),
+		chainB.Network.ChainID(): conductorSequencerELNodes(t, chainB, base.L2ELB),
+	}
 	return &TwoL2SupernodeInteropWithConductors{
 		TwoL2SupernodeInterop: base,
 		ConductorSets:         conductorSets,
+		SupernodeELs:          supernodeELs,
+		SequencerELs:          sequencerELs,
 	}
+}
+
+// l2ELNodeFromRuntime wraps a sysgo EL handle into a DSL L2ELNode frontend so it can
+// be queried directly (used to expose the supernode VN ELs and conductor candidate ELs
+// that the base preset does not surface).
+func l2ELNodeFromRuntime(t devtest.T, name string, net *sysgo.L2Network, el sysgo.L2ELNode) *dsl.L2ELNode {
+	return dsl.NewL2ELNode(newL2ELFrontend(
+		t,
+		name,
+		net.ChainID(),
+		el.UserRPC(),
+		el.EngineRPC(),
+		el.JWTPath(),
+		net.RollupConfig(),
+		el,
+	))
+}
+
+// supernodeELNode returns the supernode VN EL for the chain as a DSL handle.
+func supernodeELNode(t devtest.T, chain *sysgo.MultiChainNodeRuntime) *dsl.L2ELNode {
+	t.Require().NotNil(chain.SupernodeEL, "missing supernode EL for chain %s", chain.Name)
+	return l2ELNodeFromRuntime(t, "supernode", chain.Network, chain.SupernodeEL)
+}
+
+// conductorSequencerELNodes returns every conductor-controlled sequencer EL for the
+// chain, keyed by conductor name. The bootstrap leader ("sequencer") drives the chain's
+// primary EL, which the base preset already exposes as leaderEL; each candidate runs its
+// own EL recorded in the runtime's Followers map.
+func conductorSequencerELNodes(t devtest.T, chain *sysgo.MultiChainNodeRuntime, leaderEL *dsl.L2ELNode) map[string]*dsl.L2ELNode {
+	out := make(map[string]*dsl.L2ELNode, len(chain.Conductors))
+	for name := range chain.Conductors {
+		if name == "sequencer" {
+			out[name] = leaderEL
+			continue
+		}
+		follower := chain.Followers[name]
+		t.Require().NotNil(follower, "missing follower runtime for conductor candidate %s", name)
+		t.Require().NotNil(follower.EL, "missing EL for conductor candidate %s", name)
+		out[name] = l2ELNodeFromRuntime(t, name, chain.Network, follower.EL)
+	}
+	return out
 }
 
 func addConductorsToL2Network(t devtest.T, l2 *dsl.L2Network, chainID eth.ChainID, conductors map[string]*sysgo.Conductor) dsl.ConductorSet {

--- a/op-devstack/stack/conductor.go
+++ b/op-devstack/stack/conductor.go
@@ -10,4 +10,8 @@ type Conductor interface {
 	ChainID() eth.ChainID
 
 	RpcAPI() conductorRpc.API
+
+	// MetricsEndpoint returns the conductor's HTTP metrics endpoint, or "" if metrics
+	// are not exposed.
+	MetricsEndpoint() string
 }

--- a/op-devstack/sysgo/l2_conductor.go
+++ b/op-devstack/sysgo/l2_conductor.go
@@ -9,10 +9,12 @@ type Conductor struct {
 	name    string
 	chainID eth.ChainID
 
-	serverID          string
-	consensusEndpoint string
-	rpcEndpoint       string
-	service           *opconductor.OpConductor
+	serverID             string
+	consensusEndpoint    string
+	rpcEndpoint          string
+	metricsEndpoint      string
+	initialUnsafePayload *eth.ExecutionPayloadEnvelope
+	service              *opconductor.OpConductor
 }
 
 func (c *Conductor) ServerID() string {
@@ -25,4 +27,8 @@ func (c *Conductor) ConsensusEndpoint() string {
 
 func (c *Conductor) HTTPEndpoint() string {
 	return c.rpcEndpoint
+}
+
+func (c *Conductor) MetricsEndpoint() string {
+	return c.metricsEndpoint
 }

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -18,11 +18,13 @@ import (
 type OpRethConfig struct {
 	// ExtraArgs are appended to the generated CLI args.
 	ExtraArgs []string
+	// ProofsHistory enables the proofs-history ExEx sidecar. Defaults to true.
+	ProofsHistory bool
 }
 
-// DefaultOpRethConfig returns a zero-valued OpRethConfig that callers can mutate via OpRethOptions.
+// DefaultOpRethConfig returns the default OpRethConfig that callers can mutate via OpRethOptions.
 func DefaultOpRethConfig() *OpRethConfig {
-	return &OpRethConfig{}
+	return &OpRethConfig{ProofsHistory: true}
 }
 
 // OpRethOption customises an OpRethConfig for a specific component target.
@@ -57,6 +59,16 @@ func (b OpRethOptionBundle) Apply(p devtest.T, target ComponentTarget, cfg *OpRe
 func OpRethWithExtraArgs(args ...string) OpRethOption {
 	return OpRethOptionFn(func(p devtest.T, _ ComponentTarget, cfg *OpRethConfig) {
 		cfg.ExtraArgs = append(cfg.ExtraArgs, args...)
+	})
+}
+
+// OpRethWithoutProofsHistory disables the proofs-history ExEx sidecar. Sequencer ELs do
+// not serve historical proofs, and the sidecar currently crashes the node on a deep reorg
+// (parent-hash mismatch in the proofs-history trie engine), so conductor sequencer ELs that
+// must survive deep reorgs run without it.
+func OpRethWithoutProofsHistory() OpRethOption {
+	return OpRethOptionFn(func(_ devtest.T, _ ComponentTarget, cfg *OpRethConfig) {
+		cfg.ProofsHistory = false
 	})
 }
 

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -354,29 +354,32 @@ func buildMixedOpRethNode(
 	err = exec.Command(execPath, initArgs...).Run()
 	t.Require().NoError(err, "must init op-reth node")
 
-	proofHistoryDir := filepath.Join(tempDir, "proof-history")
-
-	initProofsArgs := []string{
-		"proofs",
-		"init",
-		"--datadir=" + dataDirPath,
-		"--chain=" + chainConfigPath,
-		"--proofs-history.storage-path=" + proofHistoryDir,
-		"--proofs-history.storage-version=" + storageVersion,
-	}
-	initOut, initErr := exec.Command(execPath, initProofsArgs...).CombinedOutput()
-	t.Require().NoError(initErr, "must init op-reth proof history: %s", string(initOut))
-
-	args = append(
-		args,
-		"--proofs-history",
-		"--proofs-history.window=10000",
-		"--proofs-history.storage-path="+proofHistoryDir,
-		"--proofs-history.storage-version="+storageVersion,
-	)
-
 	opRethCfg := DefaultOpRethConfig()
 	OpRethOptionBundle(opts).Apply(t, NewComponentTarget(key, l2Net.ChainID()), opRethCfg)
+
+	if opRethCfg.ProofsHistory {
+		proofHistoryDir := filepath.Join(tempDir, "proof-history")
+
+		initProofsArgs := []string{
+			"proofs",
+			"init",
+			"--datadir=" + dataDirPath,
+			"--chain=" + chainConfigPath,
+			"--proofs-history.storage-path=" + proofHistoryDir,
+			"--proofs-history.storage-version=" + storageVersion,
+		}
+		initOut, initErr := exec.Command(execPath, initProofsArgs...).CombinedOutput()
+		t.Require().NoError(initErr, "must init op-reth proof history: %s", string(initOut))
+
+		args = append(
+			args,
+			"--proofs-history",
+			"--proofs-history.window=10000",
+			"--proofs-history.storage-path="+proofHistoryDir,
+			"--proofs-history.storage-version="+storageVersion,
+		)
+	}
+
 	args = append(args, opRethCfg.ExtraArgs...)
 
 	return &OpReth{

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -330,38 +330,65 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 
 	var l2ACL L2CLNode = supernodeL2ACL
 	var l2BCL L2CLNode = supernodeL2BCL
+	// supernode VN ELs (always distinct identity from any follow-mode sequencer EL).
+	supernodeL2AEL, supernodeL2BEL := l2AEL, l2BEL
+	// sequencer ELs default to the supernode ELs in virtual-sequencer mode;
+	// in light-sequencer mode each follow-mode sequencer gets its own EL.
+	seqL2AEL, seqL2BEL := l2AEL, l2BEL
 	if !supernodeSequencerEnabled {
-		l2ACL = startL2CLNode(t, keys, l1Net, l2ANet, l1EL, l1CL, l2AEL, jwtSecret, l2CLNodeStartConfig{
-			Key:           "sequencer",
-			IsSequencer:   true,
-			NoDiscovery:   true,
-			EnableReqResp: true,
-			UseReqResp:    true,
-			DependencySet: runtimeDepSet,
-			L2CLOptions:   cfg.GlobalL2CLOptions,
+		// Production-faithful topology: each follow-mode sequencer runs its own
+		// EL, distinct from the supernode VN's EL, joined only by L1 and P2P.
+		seqL2AEL = startSequencerEL(t, l2ANet, jwtPath, jwtSecret, NewELNodeIdentity(0))
+		seqL2BEL = startSequencerEL(t, l2BNet, jwtPath, jwtSecret, NewELNodeIdentity(0))
+
+		// Light sequencers follow the supernode's safe head (production:
+		// kind=sequencer, lightNode=true, deps on op-supernode). They sequence
+		// unsafe blocks but disable L1 derivation, importing safe/finalized state
+		// from the supernode route and reorging onto its invalid-message
+		// replacements.
+		l2ACL = startL2CLNode(t, keys, l1Net, l2ANet, l1EL, l1CL, seqL2AEL, jwtSecret, l2CLNodeStartConfig{
+			Key:            "sequencer",
+			IsSequencer:    true,
+			NoDiscovery:    true,
+			EnableReqResp:  true,
+			UseReqResp:     false,
+			DependencySet:  runtimeDepSet,
+			L2FollowSource: supernodeL2ACL.UserRPC(),
+			L2CLOptions:    cfg.GlobalL2CLOptions,
+			// Follow-mode sequencers reorg onto the supernode's invalid-message
+			// replacement via EL sync; req-resp CL sync is being deprecated.
+			SyncMode: nodeSync.ELSync,
 		})
-		l2BCL = startL2CLNode(t, keys, l1Net, l2BNet, l1EL, l1CL, l2BEL, jwtSecret, l2CLNodeStartConfig{
-			Key:           "sequencer",
-			IsSequencer:   true,
-			NoDiscovery:   true,
-			EnableReqResp: true,
-			UseReqResp:    true,
-			DependencySet: runtimeDepSet,
-			L2CLOptions:   cfg.GlobalL2CLOptions,
+		l2BCL = startL2CLNode(t, keys, l1Net, l2BNet, l1EL, l1CL, seqL2BEL, jwtSecret, l2CLNodeStartConfig{
+			Key:            "sequencer",
+			IsSequencer:    true,
+			NoDiscovery:    true,
+			EnableReqResp:  true,
+			UseReqResp:     false,
+			DependencySet:  runtimeDepSet,
+			L2FollowSource: supernodeL2BCL.UserRPC(),
+			L2CLOptions:    cfg.GlobalL2CLOptions,
+			SyncMode:       nodeSync.ELSync,
 		})
+		// CL gossip: unsafe blocks (incl. the supernode's deposits-only
+		// replacement) propagate between the sequencer CLs and the VN CLs.
 		connectL2CLPeers(t, t.Logger(), l2ACL, supernodeL2ACL)
 		connectL2CLPeers(t, t.Logger(), l2BCL, supernodeL2BCL)
+		// EL P2P: block bodies sync between each sequencer EL and its paired
+		// supernode EL (required for the ELSync follow path).
+		connectL2ELPeers(t, t.Logger(), supernodeL2AEL.UserRPC(), seqL2AEL.UserRPC(), false)
+		connectL2ELPeers(t, t.Logger(), supernodeL2BEL.UserRPC(), seqL2BEL.UserRPC(), false)
 	}
 
-	l2ABatcher := startMinimalBatcher(t, keys, l2ANet, l1EL, l2ACL, l2AEL, cfg.BatcherOptions...)
+	l2ABatcher := startMinimalBatcher(t, keys, l2ANet, l1EL, l2ACL, seqL2AEL, cfg.BatcherOptions...)
 	l2AProposer := startMinimalProposer(t, keys, l2ANet, l1EL, supernodeL2ACL)
-	l2BBatcher := startMinimalBatcher(t, keys, l2BNet, l1EL, l2BCL, l2BEL, cfg.BatcherOptions...)
+	l2BBatcher := startMinimalBatcher(t, keys, l2BNet, l1EL, l2BCL, seqL2BEL, cfg.BatcherOptions...)
 	l2BProposer := startMinimalProposer(t, keys, l2BNet, l1EL, supernodeL2BCL)
 
 	faucetService := startFaucetsForRPCs(t, keys, map[eth.ChainID]string{
 		l1Net.ChainID():  l1EL.UserRPC(),
-		l2ANet.ChainID(): l2AEL.UserRPC(),
-		l2BNet.ChainID(): l2BEL.UserRPC(),
+		l2ANet.ChainID(): seqL2AEL.UserRPC(),
+		l2BNet.ChainID(): seqL2BEL.UserRPC(),
 	})
 
 	// Wait for interop filter readiness now that the supernode and batchers are running.
@@ -381,18 +408,20 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 			"l2a": {
 				Name:        "l2a",
 				Network:     l2ANet,
-				EL:          l2AEL,
+				EL:          seqL2AEL,
 				CL:          l2ACL,
 				SupernodeCL: supernodeL2ACL,
+				SupernodeEL: supernodeL2AEL,
 				Batcher:     l2ABatcher,
 				Proposer:    l2AProposer,
 			},
 			"l2b": {
 				Name:        "l2b",
 				Network:     l2BNet,
-				EL:          l2BEL,
+				EL:          seqL2BEL,
 				CL:          l2BCL,
 				SupernodeCL: supernodeL2BCL,
+				SupernodeEL: supernodeL2BEL,
 				Batcher:     l2BBatcher,
 				Proposer:    l2BProposer,
 			},
@@ -492,6 +521,9 @@ func addMultiChainFollowL2Node(t devtest.T, runtime *MultiChainRuntime, chainKey
 		UseReqResp:     false,
 		L2FollowSource: chain.CL.UserRPC(),
 		DependencySet:  runtime.DependencySet,
+		// Follow nodes catch up to their follow source via EL sync;
+		// req-resp CL sync is being deprecated.
+		SyncMode: nodeSync.ELSync,
 	})
 
 	connectL2ELPeers(t, t.Logger(), chain.EL.UserRPC(), l2EL.UserRPC(), false)

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -373,8 +373,10 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 		// sequencer runs its own EL, distinct from the supernode VN's EL, joined
 		// only by L1 and P2P. This lets it reorg onto the supernode's
 		// invalid-message replacement via EL sync (see startConductorControlledSequencerCL).
-		seqL2AEL = startSequencerEL(t, l2ANet, jwtPath, jwtSecret, NewELNodeIdentity(0))
-		seqL2BEL = startSequencerEL(t, l2BNet, jwtPath, jwtSecret, NewELNodeIdentity(0))
+		// They run without the proofs-history ExEx: sequencers don't serve historical proofs,
+		// and the sidecar crashes the node on a deep reorg (parent-hash mismatch).
+		seqL2AEL = startSequencerEL(t, l2ANet, jwtPath, jwtSecret, NewELNodeIdentity(0), OpRethWithoutProofsHistory())
+		seqL2BEL = startSequencerEL(t, l2BNet, jwtPath, jwtSecret, NewELNodeIdentity(0), OpRethWithoutProofsHistory())
 
 		conductorCfg := conductorConfigFromPreset(cfg)
 		var conductorNodeDepSet depset.DependencySet
@@ -681,8 +683,10 @@ func startConductorClusterForChain(
 		name := fmt.Sprintf("candidate-%d", i)
 		// startL2ELForKey respects DEVSTACK_L2EL_KIND, so candidates run op-reth (with the
 		// reth namespace, needed for reorg-recovery subscriptions) rather than the op-geth
-		// that startL2ELNode hardcodes. This keeps the conductor fleet EL-uniform.
-		candidateEL := startL2ELForKey(t, l2Net, jwtPath, jwtSecret, name, NewELNodeIdentity(0))
+		// that startL2ELNode hardcodes. This keeps the conductor fleet EL-uniform. Like the
+		// leader sequencer EL, candidates run without the proofs-history ExEx (it crashes the
+		// node on a deep reorg).
+		candidateEL := startL2ELForKey(t, l2Net, jwtPath, jwtSecret, name, NewELNodeIdentity(0), OpRethWithoutProofsHistory())
 		connectL2ELPeers(t, t.Logger(), l2EL.UserRPC(), candidateEL.UserRPC(), false)
 		candidateEndpoint := newConductorRPCEndpoint()
 		candidateCL := startConductorControlledSequencerCL(t, keys, l1Net, l1EL, l1CL, l2Net, candidateEL, name, supernodeCL, dependencySet, jwtSecret, candidateEndpoint)

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -83,7 +84,7 @@ func NewTwoL2SupernodeInteropRuntimeWithConfig(t devtest.T, delaySeconds uint64,
 }
 
 func NewTwoL2SupernodeLightSequencerInteropRuntimeWithConfig(t devtest.T, delaySeconds uint64, cfg PresetConfig) *MultiChainRuntime {
-	base, activationTime := newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t, true, delaySeconds, cfg, false)
+	base, activationTime := newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t, true, delaySeconds, cfg, false, false)
 	chainA := base.Chains["l2a"]
 	chainB := base.Chains["l2b"]
 	t.Require().NotNil(chainA, "missing l2a supernode chain")
@@ -91,6 +92,26 @@ func NewTwoL2SupernodeLightSequencerInteropRuntimeWithConfig(t devtest.T, delayS
 	attachTestSequencerToRuntime(t, base, "test-sequencer-2l2-light-cl")
 
 	t.Logger().Info("configured supernode interop runtime with light CL sequencers",
+		"genesis_time", chainA.Network.rollupCfg.Genesis.L2Time,
+		"activation_time", activationTime,
+		"delay_seconds", delaySeconds,
+	)
+
+	base.DelaySeconds = delaySeconds
+	return base
+}
+
+func NewTwoL2SupernodeInteropWithConductorsRuntimeWithConfig(t devtest.T, delaySeconds uint64, cfg PresetConfig) *MultiChainRuntime {
+	base, activationTime := newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t, true, delaySeconds, cfg, false, true)
+	chainA := base.Chains["l2a"]
+	chainB := base.Chains["l2b"]
+	t.Require().NotNil(chainA, "missing l2a supernode chain")
+	t.Require().NotNil(chainB, "missing l2b supernode chain")
+	t.Require().NotNil(chainA.Conductors, "missing l2a conductors")
+	t.Require().NotNil(chainB.Conductors, "missing l2b conductors")
+	attachTestSequencerToRuntime(t, base, "test-sequencer-2l2")
+
+	t.Logger().Info("configured supernode interop runtime with conductors",
 		"genesis_time", chainA.Network.rollupCfg.Genesis.L2Time,
 		"activation_time", activationTime,
 		"delay_seconds", delaySeconds,
@@ -228,10 +249,10 @@ func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 }
 
 func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySeconds uint64, cfg PresetConfig) (*MultiChainRuntime, uint64) {
-	return newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t, enableInterop, delaySeconds, cfg, true)
+	return newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t, enableInterop, delaySeconds, cfg, true, false)
 }
 
-func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInterop bool, delaySeconds uint64, cfg PresetConfig, supernodeSequencerEnabled bool) (*MultiChainRuntime, uint64) {
+func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInterop bool, delaySeconds uint64, cfg PresetConfig, supernodeSequencerEnabled bool, enableConductors bool) (*MultiChainRuntime, uint64) {
 	require := t.Require()
 
 	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
@@ -312,6 +333,14 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 		runtimeDepSet = wb.outFullCfgSet.DependencySet
 	}
 
+	var conductorEndpoints map[eth.ChainID]*atomic.Value
+	if enableConductors {
+		conductorEndpoints = map[eth.ChainID]*atomic.Value{
+			l2ANet.ChainID(): newConductorRPCEndpoint(),
+			l2BNet.ChainID(): newConductorRPCEndpoint(),
+		}
+	}
+
 	supernode, supernodeL2ACL, supernodeL2BCL := startTwoL2SharedSupernode(
 		t,
 		l1Net,
@@ -327,15 +356,50 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 		jwtSecret,
 		supernodeSequencerEnabled,
 	)
-
 	var l2ACL L2CLNode = supernodeL2ACL
 	var l2BCL L2CLNode = supernodeL2BCL
 	// supernode VN ELs (always distinct identity from any follow-mode sequencer EL).
 	supernodeL2AEL, supernodeL2BEL := l2AEL, l2BEL
 	// sequencer ELs default to the supernode ELs in virtual-sequencer mode;
-	// in light-sequencer mode each follow-mode sequencer gets its own EL.
+	// in follow-mode (conductor or light-sequencer) each sequencer gets its own EL.
 	seqL2AEL, seqL2BEL := l2AEL, l2BEL
-	if !supernodeSequencerEnabled {
+
+	var l2AConductors map[string]*Conductor
+	var l2BConductors map[string]*Conductor
+	var l2AFollowers map[string]*SingleChainNodeRuntime
+	var l2BFollowers map[string]*SingleChainNodeRuntime
+	if enableConductors {
+		// Production-faithful topology: the conductor-controlled follow-mode
+		// sequencer runs its own EL, distinct from the supernode VN's EL, joined
+		// only by L1 and P2P. This lets it reorg onto the supernode's
+		// invalid-message replacement via EL sync (see startConductorControlledSequencerCL).
+		seqL2AEL = startSequencerEL(t, l2ANet, jwtPath, jwtSecret, NewELNodeIdentity(0))
+		seqL2BEL = startSequencerEL(t, l2BNet, jwtPath, jwtSecret, NewELNodeIdentity(0))
+
+		conductorCfg := conductorConfigFromPreset(cfg)
+		var conductorNodeDepSet depset.DependencySet
+		if depSet != nil {
+			conductorNodeDepSet = depSet
+		} else {
+			conductorNodeDepSet = wb.outFullCfgSet.DependencySet
+		}
+		l2ACL = startConductorControlledSequencerCL(t, keys, l1Net, l1EL, l1CL, l2ANet, seqL2AEL, "sequencer", supernodeL2ACL, conductorNodeDepSet, jwtSecret, conductorEndpoints[l2ANet.ChainID()])
+		l2BCL = startConductorControlledSequencerCL(t, keys, l1Net, l1EL, l1CL, l2BNet, seqL2BEL, "sequencer", supernodeL2BCL, conductorNodeDepSet, jwtSecret, conductorEndpoints[l2BNet.ChainID()])
+
+		l2AFollowers = startConductorHealthPeers(t, keys, l1Net, l1EL, l1CL, l2ANet, seqL2AEL, l2ACL, conductorNodeDepSet, conductorCfg.HealthCheck.MinPeerCount)
+		l2BFollowers = startConductorHealthPeers(t, keys, l1Net, l1EL, l1CL, l2BNet, seqL2BEL, l2BCL, conductorNodeDepSet, conductorCfg.HealthCheck.MinPeerCount)
+
+		// Build a 3-conductor raft cluster per chain (one bootstrap leader on the
+		// primary sequencer CL + two conductor-controlled candidates), so leader-transfer
+		// and cluster-wide convergence scenarios are exercisable.
+		l2AConductors = startConductorClusterForChain(t, keys, l1Net, l1EL, l1CL, l2ANet, seqL2AEL, l2ACL, supernodeL2ACL, conductorNodeDepSet, jwtSecret, conductorEndpoints[l2ANet.ChainID()], conductorCfg, 2, l2AFollowers)
+		l2BConductors = startConductorClusterForChain(t, keys, l1Net, l1EL, l1CL, l2BNet, seqL2BEL, l2BCL, supernodeL2BCL, conductorNodeDepSet, jwtSecret, conductorEndpoints[l2BNet.ChainID()], conductorCfg, 2, l2BFollowers)
+
+		// EL P2P: block bodies sync between each sequencer EL and its paired
+		// supernode EL (required for the ELSync follow path).
+		connectL2ELPeers(t, t.Logger(), supernodeL2AEL.UserRPC(), seqL2AEL.UserRPC(), false)
+		connectL2ELPeers(t, t.Logger(), supernodeL2BEL.UserRPC(), seqL2BEL.UserRPC(), false)
+	} else if !supernodeSequencerEnabled {
 		// Production-faithful topology: each follow-mode sequencer runs its own
 		// EL, distinct from the supernode VN's EL, joined only by L1 and P2P.
 		seqL2AEL = startSequencerEL(t, l2ANet, jwtPath, jwtSecret, NewELNodeIdentity(0))
@@ -414,6 +478,8 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 				SupernodeEL: supernodeL2AEL,
 				Batcher:     l2ABatcher,
 				Proposer:    l2AProposer,
+				Followers:   l2AFollowers,
+				Conductors:  l2AConductors,
 			},
 			"l2b": {
 				Name:        "l2b",
@@ -424,6 +490,8 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 				SupernodeEL: supernodeL2BEL,
 				Batcher:     l2BBatcher,
 				Proposer:    l2BProposer,
+				Followers:   l2BFollowers,
+				Conductors:  l2BConductors,
 			},
 		},
 		Supernode:     supernode,
@@ -510,36 +578,177 @@ func addMultiChainFollowL2Node(t devtest.T, runtime *MultiChainRuntime, chainKey
 	t.Require().NotNil(chain, "missing %s runtime chain", chainKey)
 	t.Require().NotNil(chain.CL, "%s runtime chain missing CL follow source", chainKey)
 
-	jwtPath := chain.EL.JWTPath()
-	jwtSecret := readJWTSecretFromPath(t, jwtPath)
-	l2EL := startL2ELNode(t, chain.Network, jwtPath, jwtSecret, name, NewELNodeIdentity(0))
-	l2CL := startL2CLNode(t, runtime.Keys, runtime.L1Network, chain.Network, runtime.L1EL, runtime.L1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
-		Key:            name,
-		IsSequencer:    false,
-		NoDiscovery:    true,
-		EnableReqResp:  false,
-		UseReqResp:     false,
-		L2FollowSource: chain.CL.UserRPC(),
-		DependencySet:  runtime.DependencySet,
-		// Follow nodes catch up to their follow source via EL sync;
-		// req-resp CL sync is being deprecated.
-		SyncMode: nodeSync.ELSync,
-	})
-
-	connectL2ELPeers(t, t.Logger(), chain.EL.UserRPC(), l2EL.UserRPC(), false)
-	connectL2CLPeers(t, t.Logger(), chain.CL, l2CL)
-
-	node := &SingleChainNodeRuntime{
-		Name:        name,
-		IsSequencer: false,
-		EL:          l2EL,
-		CL:          l2CL,
-	}
+	node := startMultiChainFollowL2Node(t, runtime.Keys, runtime.L1Network, runtime.L1EL, runtime.L1CL, chain.Network, chain.EL, chain.CL, runtime.DependencySet, name)
 	if chain.Followers == nil {
 		chain.Followers = make(map[string]*SingleChainNodeRuntime)
 	}
 	chain.Followers[name] = node
 	return node
+}
+
+func startConductorHealthPeers(
+	t devtest.T,
+	keys devkeys.Keys,
+	l1Net *L1Network,
+	l1EL L1ELNode,
+	l1CL *L1CLNode,
+	l2Net *L2Network,
+	l2EL L2ELNode,
+	l2CL L2CLNode,
+	dependencySet depset.DependencySet,
+	peerCount uint64,
+) map[string]*SingleChainNodeRuntime {
+	followers := make(map[string]*SingleChainNodeRuntime)
+	for i := uint64(1); i <= peerCount; i++ {
+		name := fmt.Sprintf("conductor-health-peer-%d", i)
+		node := startMultiChainFollowL2Node(t, keys, l1Net, l1EL, l1CL, l2Net, l2EL, l2CL, dependencySet, name)
+		followers[node.Name] = node
+	}
+	return followers
+}
+
+func startConductorControlledSequencerCL(
+	t devtest.T,
+	keys devkeys.Keys,
+	l1Net *L1Network,
+	l1EL L1ELNode,
+	l1CL *L1CLNode,
+	l2Net *L2Network,
+	l2EL L2ELNode,
+	key string,
+	followSource L2CLNode,
+	dependencySet depset.DependencySet,
+	jwtSecret [32]byte,
+	conductorRPCEndpoint *atomic.Value,
+) *OpNode {
+	sequencerCL := startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
+		Key:           key,
+		IsSequencer:   true,
+		NoDiscovery:   true,
+		EnableReqResp: true,
+		UseReqResp:    false,
+		// Conductor-controlled follow-mode sequencers reorg onto the supernode's
+		// invalid-message replacement via EL sync; req-resp CL sync is being deprecated.
+		SyncMode:             nodeSync.ELSync,
+		L2FollowSource:       followSource.UserRPC(),
+		DependencySet:        dependencySet,
+		ConductorRPCEndpoint: conductorRPCEndpoint,
+	})
+	connectL2CLPeers(t, t.Logger(), followSource, sequencerCL)
+	return sequencerCL
+}
+
+// startConductorClusterForChain builds a multi-conductor raft cluster for a single
+// supernode-interop chain. It starts a bootstrap conductor on the primary sequencer CL,
+// then memberCount additional conductor-controlled sequencer candidates — each with its
+// own EL, CL, and conductor — and joins them as voters via startConductorCluster (which
+// also resumes every conductor and waits for the cluster to converge). Every conductor
+// shares conductorCfg, so reorg-recovery is enabled fleet-uniformly when requested. The
+// candidate node runtimes are recorded in followers (when non-nil). Returns the conductor
+// set keyed by conductor name ("sequencer" for the bootstrap leader candidate).
+func startConductorClusterForChain(
+	t devtest.T,
+	keys devkeys.Keys,
+	l1Net *L1Network,
+	l1EL L1ELNode,
+	l1CL *L1CLNode,
+	l2Net *L2Network,
+	l2EL L2ELNode,
+	primarySequencerCL L2CLNode,
+	supernodeCL L2CLNode,
+	dependencySet depset.DependencySet,
+	jwtSecret [32]byte,
+	primaryConductorEndpoint *atomic.Value,
+	conductorCfg conductorNodeConfig,
+	memberCount int,
+	followers map[string]*SingleChainNodeRuntime,
+) map[string]*Conductor {
+	bootstrap := startConductorForRPC(
+		t,
+		"sequencer",
+		l2Net,
+		primarySequencerCL.UserRPC(),
+		l2EL.UserRPC(),
+		true,
+		false,
+		primaryConductorEndpoint,
+		conductorCfg,
+	)
+	conductors := map[string]*Conductor{"sequencer": bootstrap}
+	members := make([]*Conductor, 0, memberCount)
+	jwtPath := l2EL.JWTPath()
+	for i := 1; i <= memberCount; i++ {
+		name := fmt.Sprintf("candidate-%d", i)
+		// startL2ELForKey respects DEVSTACK_L2EL_KIND, so candidates run op-reth (with the
+		// reth namespace, needed for reorg-recovery subscriptions) rather than the op-geth
+		// that startL2ELNode hardcodes. This keeps the conductor fleet EL-uniform.
+		candidateEL := startL2ELForKey(t, l2Net, jwtPath, jwtSecret, name, NewELNodeIdentity(0))
+		connectL2ELPeers(t, t.Logger(), l2EL.UserRPC(), candidateEL.UserRPC(), false)
+		candidateEndpoint := newConductorRPCEndpoint()
+		candidateCL := startConductorControlledSequencerCL(t, keys, l1Net, l1EL, l1CL, l2Net, candidateEL, name, supernodeCL, dependencySet, jwtSecret, candidateEndpoint)
+		candidateConductor := startConductorForRPC(
+			t,
+			name,
+			l2Net,
+			candidateCL.UserRPC(),
+			candidateEL.UserRPC(),
+			false,
+			true,
+			candidateEndpoint,
+			conductorCfg,
+		)
+		conductors[name] = candidateConductor
+		members = append(members, candidateConductor)
+		if followers != nil {
+			followers[name] = &SingleChainNodeRuntime{
+				Name:        name,
+				IsSequencer: true,
+				EL:          candidateEL,
+				CL:          candidateCL,
+			}
+		}
+	}
+	startConductorCluster(t, bootstrap, members)
+	return conductors
+}
+
+func startMultiChainFollowL2Node(
+	t devtest.T,
+	keys devkeys.Keys,
+	l1Net *L1Network,
+	l1EL L1ELNode,
+	l1CL *L1CLNode,
+	l2Net *L2Network,
+	l2EL L2ELNode,
+	l2CL L2CLNode,
+	dependencySet depset.DependencySet,
+	name string,
+) *SingleChainNodeRuntime {
+	jwtPath := l2EL.JWTPath()
+	jwtSecret := readJWTSecretFromPath(t, jwtPath)
+	followerEL := startL2ELNode(t, l2Net, jwtPath, jwtSecret, name, NewELNodeIdentity(0))
+	followerCL := startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, followerEL, jwtSecret, l2CLNodeStartConfig{
+		Key:            name,
+		IsSequencer:    false,
+		NoDiscovery:    true,
+		EnableReqResp:  false,
+		UseReqResp:     false,
+		L2FollowSource: l2CL.UserRPC(),
+		DependencySet:  dependencySet,
+		// Follow nodes catch up to their follow source via EL sync;
+		// req-resp CL sync is being deprecated.
+		SyncMode: nodeSync.ELSync,
+	})
+
+	connectL2ELPeers(t, t.Logger(), l2EL.UserRPC(), followerEL.UserRPC(), false)
+	connectL2CLPeers(t, t.Logger(), l2CL, followerCL)
+
+	return &SingleChainNodeRuntime{
+		Name:        name,
+		IsSequencer: false,
+		EL:          followerEL,
+		CL:          followerCL,
+	}
 }
 
 func startTwoL2SharedSupernode(

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	opconductor "github.com/ethereum-optimism/optimism/op-conductor/conductor"
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -41,6 +42,13 @@ type PresetConfig struct {
 	SupernodeVerifierSyncMode *nodeSync.Mode
 	// InteropActivationDelaySeconds offsets Interop activation past genesis (0 = at genesis).
 	InteropActivationDelaySeconds uint64
+	// ConductorHealthCheck overrides the default slow conductor health check
+	// intervals for tests that intentionally exercise health transitions.
+	ConductorHealthCheck *opconductor.HealthCheckConfig
+	// ConductorReorgRecoveryEnabled turns on op-conductor's reorg-recovery mode
+	// (the fleet-uniform --reorg-recovery.enabled flag plus the op-reth WS
+	// subscription) on every conductor in the preset. op-reth only.
+	ConductorReorgRecoveryEnabled bool
 }
 
 func NewPresetConfig() PresetConfig {

--- a/op-devstack/sysgo/runtime_state.go
+++ b/op-devstack/sysgo/runtime_state.go
@@ -127,11 +127,18 @@ func (r *SingleChainRuntime) VMConfig(t devtest.T, dir string) *vm.Config {
 }
 
 type MultiChainNodeRuntime struct {
-	Name        string
-	Network     *L2Network
+	Name    string
+	Network *L2Network
+	// EL is the chain's primary EL. In light-sequencer presets it is the
+	// follow-mode sequencer's own EL; in virtual-sequencer presets it is the
+	// same EL the supernode VN drives.
 	EL          L2ELNode
 	CL          L2CLNode
 	SupernodeCL L2CLNode
+	// SupernodeEL is the EL the supernode VN reads/writes. In light-sequencer
+	// presets it is distinct from EL (production topology: separate ELs joined
+	// only by L1 + P2P); in virtual-sequencer presets it equals EL.
+	SupernodeEL L2ELNode
 	Batcher     *L2Batcher
 	Proposer    *L2Proposer
 	Followers   map[string]*SingleChainNodeRuntime

--- a/op-devstack/sysgo/runtime_state.go
+++ b/op-devstack/sysgo/runtime_state.go
@@ -142,6 +142,7 @@ type MultiChainNodeRuntime struct {
 	Batcher     *L2Batcher
 	Proposer    *L2Proposer
 	Followers   map[string]*SingleChainNodeRuntime
+	Conductors  map[string]*Conductor
 }
 
 type MultiChainRuntime struct {

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -285,6 +285,11 @@ type l2CLNodeStartConfig struct {
 	L2FollowSource string
 	DependencySet  depset.DependencySet
 	L2CLOptions    []L2CLOption
+	// SyncMode overrides the sequencer and verifier sync modes. The zero value
+	// equals nodeSync.CLSync (iota 0), which is already the DefaultL2CLConfig
+	// default, so leaving it unset is a no-op; set it to nodeSync.ELSync to switch
+	// follow-mode nodes to EL sync.
+	SyncMode nodeSync.Mode
 }
 
 func startL2CLNode(
@@ -313,6 +318,11 @@ func startL2CLNode(
 			}
 			opt.Apply(t, l2CLTarget, cfg)
 		}
+	}
+
+	if startCfg.SyncMode != 0 {
+		cfg.SequencerSyncMode = startCfg.SyncMode
+		cfg.VerifierSyncMode = startCfg.SyncMode
 	}
 
 	syncMode := cfg.VerifierSyncMode
@@ -409,8 +419,10 @@ func startL2CLNode(
 			SkipSyncStartCheck:             false,
 			SupportsPostFinalizationELSync: false,
 			L2FollowSourceEndpoint:         cfg.FollowSource,
-			NeedInitialResetEngine:         false,
-			OffsetELSafe:                   cfg.OffsetELSafe,
+			// Mirror op-node/service.go: a follow-mode sequencer needs a single
+			// initial engine reset to trigger block building (TryInitialResetEngineForSequencer).
+			NeedInitialResetEngine: cfg.IsSequencer && cfg.FollowSource != "",
+			OffsetELSafe:           cfg.OffsetELSafe,
 		},
 		ConfigPersistence:               config.DisabledConfigPersistence{},
 		Metrics:                         opmetrics.CLIConfig{},

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -239,27 +240,51 @@ func connectL2CLPeers(t devtest.T, logger log.Logger, l2CL1, l2CL2 L2CLNode) {
 	require := t.Require()
 	ctx := t.Ctx()
 
-	p := getP2PClientsAndPeers(ctx, logger, require, l2CL1, l2CL2)
+	err := retry.Do0(ctx, 6, retry.Exponential(), func() error {
+		p2pClient1, err := GetP2PClient(ctx, logger, l2CL1)
+		if err != nil {
+			return err
+		}
+		p2pClient2, err := GetP2PClient(ctx, logger, l2CL2)
+		if err != nil {
+			return err
+		}
+		peerInfo1, err := GetPeerInfo(ctx, p2pClient1)
+		if err != nil {
+			return err
+		}
+		peerInfo2, err := GetPeerInfo(ctx, p2pClient2)
+		if err != nil {
+			return err
+		}
+		if len(peerInfo1.Addresses) == 0 || len(peerInfo2.Addresses) == 0 {
+			return fmt.Errorf("malformed peer info")
+		}
 
-	connectPeer := func(p2pClient *sources.P2PClient, multiAddress string) {
-		err := retry.Do0(ctx, 6, retry.Exponential(), func() error {
-			return p2pClient.ConnectPeer(ctx, multiAddress)
-		})
-		require.NoError(err, "failed to connect L2CL peer")
-	}
+		if err := p2pClient1.ConnectPeer(ctx, peerInfo2.Addresses[0]); err != nil {
+			return fmt.Errorf("connect cl1 to cl2: %w", err)
+		}
+		if err := p2pClient2.ConnectPeer(ctx, peerInfo1.Addresses[0]); err != nil {
+			return fmt.Errorf("connect cl2 to cl1: %w", err)
+		}
 
-	connectPeer(p.client1, p.peerInfo2.Addresses[0])
-	connectPeer(p.client2, p.peerInfo1.Addresses[0])
-
-	peerDump1, err := GetPeers(ctx, p.client1)
-	require.NoError(err)
-	peerDump2, err := GetPeers(ctx, p.client2)
-	require.NoError(err)
-
-	_, ok1 := peerDump1.Peers[p.peerInfo2.PeerID.String()]
-	require.True(ok1, "peer register invalid (cl1 missing cl2)")
-	_, ok2 := peerDump2.Peers[p.peerInfo1.PeerID.String()]
-	require.True(ok2, "peer register invalid (cl2 missing cl1)")
+		peerDump1, err := GetPeers(ctx, p2pClient1)
+		if err != nil {
+			return err
+		}
+		peerDump2, err := GetPeers(ctx, p2pClient2)
+		if err != nil {
+			return err
+		}
+		if _, ok := peerDump1.Peers[peerInfo2.PeerID.String()]; !ok {
+			return fmt.Errorf("peer register invalid (cl1 missing cl2)")
+		}
+		if _, ok := peerDump2.Peers[peerInfo1.PeerID.String()]; !ok {
+			return fmt.Errorf("peer register invalid (cl2 missing cl1)")
+		}
+		return nil
+	})
+	require.NoError(err, "failed to connect L2CL peer")
 }
 
 func startSequencerCL(
@@ -290,6 +315,8 @@ type l2CLNodeStartConfig struct {
 	// default, so leaving it unset is a no-op; set it to nodeSync.ELSync to switch
 	// follow-mode nodes to EL sync.
 	SyncMode nodeSync.Mode
+
+	ConductorRPCEndpoint *atomic.Value
 }
 
 func startL2CLNode(
@@ -435,6 +462,9 @@ func startL2CLNode(
 		AltDA:                           altda.CLIConfig{},
 		IgnoreMissingPectraBlobSchedule: false,
 		ExperimentalOPStackAPI:          true,
+	}
+	if startCfg.ConductorRPCEndpoint != nil {
+		configureOpNodeConfigForConductor(nodeCfg, startCfg.ConductorRPCEndpoint)
 	}
 	l2CL := &OpNode{
 		name:     startCfg.Key,

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -151,14 +151,14 @@ func applyConfigPrefundedL2(t devtest.T, keys devkeys.Keys, l1ChainID, l2ChainID
 
 // startL2ELForKey starts an L2 EL node for the given key, respecting DEVSTACK_L2EL_KIND.
 // This is the single env-aware dispatch point for L2 EL selection.
-func startL2ELForKey(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte, key string, identity *ELNodeIdentity) L2ELNode {
+func startL2ELForKey(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte, key string, identity *ELNodeIdentity, opRethOpts ...OpRethOption) L2ELNode {
 	switch devstackL2ELKind() {
 	case MixedL2ELOpGeth:
 		return startL2ELNode(t, l2Net, jwtPath, jwtSecret, key, identity)
 	case MixedL2ELOpRethV2:
-		return startMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, nil, "v2")
+		return startMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, nil, "v2", opRethOpts...)
 	default: // op-reth v1
-		return startMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, nil, "v1")
+		return startMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, nil, "v1", opRethOpts...)
 	}
 }
 
@@ -194,8 +194,8 @@ func startL2CLForKey(
 	}
 }
 
-func startSequencerEL(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte, identity *ELNodeIdentity) L2ELNode {
-	return startL2ELForKey(t, l2Net, jwtPath, jwtSecret, "sequencer", identity)
+func startSequencerEL(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte, identity *ELNodeIdentity, opRethOpts ...OpRethOption) L2ELNode {
+	return startL2ELForKey(t, l2Net, jwtPath, jwtSecret, "sequencer", identity, opRethOpts...)
 }
 
 func startL2ELNode(

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -8,13 +8,21 @@ import (
 	"sync/atomic"
 	"time"
 
+	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+
 	opconductor "github.com/ethereum-optimism/optimism/op-conductor/conductor"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	opnodeconfig "github.com/ethereum-optimism/optimism/op-node/config"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	synctesterconfig "github.com/ethereum-optimism/optimism/op-sync-tester/config"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester"
 	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
@@ -118,10 +126,14 @@ func NewMinimalWithConductorsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *S
 	nodeB := addSingleChainOpNode(t, runtime, "b", true, "", cfg.GlobalL2CLOptions...)
 	nodeC := addSingleChainOpNode(t, runtime, "c", true, "", cfg.GlobalL2CLOptions...)
 
-	conductorA := startConductorNode(t, "sequencer", runtime.L2Network, runtime.L2CL.(*OpNode), runtime.L2EL, true, false)
-	conductorB := startConductorNode(t, "b", runtime.L2Network, nodeB.CL.(*OpNode), nodeB.EL, false, true)
-	conductorC := startConductorNode(t, "c", runtime.L2Network, nodeC.CL.(*OpNode), nodeC.EL, false, true)
+	conductorCfg := conductorConfigFromPreset(cfg)
+	conductorA := startConductorNode(t, "sequencer", runtime.L2Network, runtime.L2CL.(*OpNode), runtime.L2EL, true, false, conductorCfg)
+	conductorB := startConductorNode(t, "b", runtime.L2Network, nodeB.CL.(*OpNode), nodeB.EL, false, true, conductorCfg)
+	conductorC := startConductorNode(t, "c", runtime.L2Network, nodeC.CL.(*OpNode), nodeC.EL, false, true, conductorCfg)
+	connectSingleChainCLPeer(t, runtime.L2CL, nodeB.CL)
+	connectSingleChainCLPeer(t, runtime.L2CL, nodeC.CL)
 	startConductorCluster(t, conductorA, []*Conductor{conductorB, conductorC})
+	waitForRollupSequencerActive(t, runtime.L2CL.UserRPC())
 
 	runtime.Conductors = map[string]*Conductor{
 		"sequencer": conductorA,
@@ -173,6 +185,73 @@ func addSingleChainOpNode(
 	node := newSingleChainNodeRuntime(name, isSequencer, l2EL, l2CL)
 	runtime.Nodes[name] = node
 	return node
+}
+
+type conductorNodeConfig struct {
+	HealthCheck          opconductor.HealthCheckConfig
+	ReorgRecoveryEnabled bool
+}
+
+func conductorConfigFromPreset(cfg PresetConfig) conductorNodeConfig {
+	healthCfg := opconductor.HealthCheckConfig{
+		Interval:       3600,
+		UnsafeInterval: 3600,
+		SafeInterval:   3600,
+		MinPeerCount:   1,
+	}
+	if cfg.ConductorHealthCheck != nil {
+		healthCfg = *cfg.ConductorHealthCheck
+	}
+	return conductorNodeConfig{
+		HealthCheck:          healthCfg,
+		ReorgRecoveryEnabled: cfg.ConductorReorgRecoveryEnabled,
+	}
+}
+
+// reorgRecoveryWSURL returns the op-reth WebSocket URL the conductor should
+// subscribe to for reorg notifications, or "" when reorg recovery is disabled.
+// In devstack the op-reth EL exposes its user RPC over WebSocket (ws://) with the
+// `reth` namespace enabled, so the execution RPC endpoint doubles as the WS URL.
+func reorgRecoveryWSURL(conductorCfg conductorNodeConfig, executionRPC string) string {
+	if !conductorCfg.ReorgRecoveryEnabled {
+		return ""
+	}
+	return executionRPC
+}
+
+func newConductorRPCEndpoint() *atomic.Value {
+	var conductorRPCEndpoint atomic.Value
+	conductorRPCEndpoint.Store("")
+	return &conductorRPCEndpoint
+}
+
+func configureOpNodeConfigForConductor(cfg *opnodeconfig.Config, conductorRPCEndpoint *atomic.Value) {
+	cfg.ConductorEnabled = true
+	cfg.ConductorRpcTimeout = 5 * time.Second
+	cfg.ConductorRpc = conductorRPCFromEndpoint(conductorRPCEndpoint)
+	cfg.Driver.SequencerStopped = true
+}
+
+func configureOpNodeForConductor(opNode *OpNode, conductorRPCEndpoint *atomic.Value) {
+	configureOpNodeConfigForConductor(opNode.cfg, conductorRPCEndpoint)
+	if p2pCfg, ok := opNode.cfg.P2P.(*p2p.Config); ok {
+		p2pCfg.Store = dssync.MutexWrap(ds.NewMapDatastore())
+	}
+}
+
+func conductorRPCFromEndpoint(conductorRPCEndpoint *atomic.Value) func(ctx context.Context) (string, error) {
+	return func(ctx context.Context) (string, error) {
+		for {
+			if endpoint, _ := conductorRPCEndpoint.Load().(string); endpoint != "" {
+				return endpoint, nil
+			}
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	}
 }
 
 func startSyncTesterService(t devtest.T, chainRPCs map[eth.ChainID]string) *SyncTesterService {
@@ -236,30 +315,30 @@ func startConductorNode(
 	l2EL L2ELNode,
 	bootstrap bool,
 	paused bool,
+	conductorCfg conductorNodeConfig,
+) *Conductor {
+	conductorRPCEndpoint := newConductorRPCEndpoint()
+	configureOpNodeForConductor(opNode, conductorRPCEndpoint)
+	opNode.Stop()
+	opNode.Start()
+
+	return startConductorForRPC(t, conductorName, l2Net, opNode.UserRPC(), l2EL.UserRPC(), bootstrap, paused, conductorRPCEndpoint, conductorCfg)
+}
+
+func startConductorForRPC(
+	t devtest.T,
+	conductorName string,
+	l2Net *L2Network,
+	nodeRPC string,
+	executionRPC string,
+	bootstrap bool,
+	paused bool,
+	conductorRPCEndpoint *atomic.Value,
+	conductorCfg conductorNodeConfig,
 ) *Conductor {
 	require := t.Require()
 	serverID := conductorName
 	require.NotEmpty(serverID, "conductor ID key cannot be empty")
-
-	var conductorRPCEndpoint atomic.Value
-	conductorRPCEndpoint.Store("")
-	opNode.cfg.ConductorEnabled = true
-	opNode.cfg.ConductorRpcTimeout = 5 * time.Second
-	opNode.cfg.ConductorRpc = func(ctx context.Context) (string, error) {
-		for {
-			if endpoint, _ := conductorRPCEndpoint.Load().(string); endpoint != "" {
-				return endpoint, nil
-			}
-			select {
-			case <-ctx.Done():
-				return "", ctx.Err()
-			case <-time.After(100 * time.Millisecond):
-			}
-		}
-	}
-	opNode.cfg.Driver.SequencerStopped = true
-	opNode.Stop()
-	opNode.Start()
 
 	cfg := opconductor.Config{
 		ConsensusAddr:           "127.0.0.1",
@@ -273,17 +352,14 @@ func startConductorNode(
 		RaftTrailingLogs:        10240,
 		RaftHeartbeatTimeout:    1000 * time.Millisecond,
 		RaftLeaderLeaseTimeout:  500 * time.Millisecond,
-		NodeRPC:                 opNode.UserRPC(),
-		ExecutionRPC:            l2EL.UserRPC(),
+		NodeRPC:                 nodeRPC,
+		ExecutionRPC:            executionRPC,
 		Paused:                  paused,
-		HealthCheck: opconductor.HealthCheckConfig{
-			Interval:       3600,
-			UnsafeInterval: 3600,
-			SafeInterval:   3600,
-			MinPeerCount:   1,
-		},
-		RollupCfg:      *l2Net.rollupCfg,
-		RPCEnableProxy: false,
+		HealthCheck:             conductorCfg.HealthCheck,
+		RollupCfg:               *l2Net.rollupCfg,
+		RPCEnableProxy:          false,
+		ReorgRecoveryEnabled:    conductorCfg.ReorgRecoveryEnabled,
+		ExecutionWSURL:          reorgRecoveryWSURL(conductorCfg, executionRPC),
 		LogConfig: oplog.CLIConfig{
 			Level:  log.LevelInfo,
 			Format: oplog.FormatText,
@@ -293,9 +369,15 @@ func startConductorNode(
 			ListenAddr: "127.0.0.1",
 			ListenPort: 0,
 		},
+		MetricsConfig: opmetrics.CLIConfig{
+			Enabled:    true,
+			ListenAddr: "127.0.0.1",
+			ListenPort: 0,
+		},
 	}
 
 	logger := t.Logger().New("component", "conductor", "name", conductorName, "chain", l2Net.ChainID())
+	initialUnsafePayload := fetchInitialUnsafePayload(t, nodeRPC, executionRPC)
 	svc, err := opconductor.New(t.Ctx(), &cfg, logger, "0.0.1")
 	require.NoError(err)
 	require.NoError(svc.Start(t.Ctx()))
@@ -309,15 +391,77 @@ func startConductorNode(
 	})
 
 	out := &Conductor{
-		name:              conductorName,
-		chainID:           l2Net.ChainID(),
-		serverID:          serverID,
-		consensusEndpoint: svc.ConsensusEndpoint(),
-		rpcEndpoint:       svc.HTTPEndpoint(),
-		service:           svc,
+		name:                 conductorName,
+		chainID:              l2Net.ChainID(),
+		serverID:             serverID,
+		consensusEndpoint:    svc.ConsensusEndpoint(),
+		rpcEndpoint:          svc.HTTPEndpoint(),
+		metricsEndpoint:      svc.MetricsEndpoint(),
+		initialUnsafePayload: initialUnsafePayload,
+		service:              svc,
 	}
-	conductorRPCEndpoint.Store(svc.HTTPEndpoint())
+	if conductorRPCEndpoint != nil {
+		conductorRPCEndpoint.Store(svc.HTTPEndpoint())
+	}
 	return out
+}
+
+func fetchInitialUnsafePayload(t devtest.T, nodeRPC string, executionRPC string) *eth.ExecutionPayloadEnvelope {
+	nodeRPCClient, err := opclient.NewRPC(t.Ctx(), t.Logger(), nodeRPC)
+	t.Require().NoError(err, "dial node RPC for conductor unsafe head")
+	defer nodeRPCClient.Close()
+	rollupClient := sources.NewRollupClient(nodeRPCClient)
+
+	executionRPCClient, err := opclient.NewRPC(t.Ctx(), t.Logger(), executionRPC)
+	t.Require().NoError(err, "dial execution RPC for conductor unsafe head")
+	defer executionRPCClient.Close()
+	ethClient, err := sources.NewEthClient(executionRPCClient, t.Logger(), nil, sources.DefaultEthClientConfig(10))
+	t.Require().NoError(err, "create execution client for conductor unsafe head")
+
+	var payload *eth.ExecutionPayloadEnvelope
+	err = retry.Do0(t.Ctx(), 120, retry.Fixed(250*time.Millisecond), func() error {
+		status, err := rollupClient.SyncStatus(t.Ctx())
+		if err != nil {
+			return fmt.Errorf("fetch node sync status: %w", err)
+		}
+		if status == nil {
+			return errors.New("node sync status is nil")
+		}
+		currentPayload, err := ethClient.PayloadByHash(t.Ctx(), status.UnsafeL2.Hash)
+		if err != nil {
+			return fmt.Errorf("fetch unsafe payload %s: %w", status.UnsafeL2, err)
+		}
+		if currentPayload.ExecutionPayload.BlockHash != status.UnsafeL2.Hash ||
+			uint64(currentPayload.ExecutionPayload.BlockNumber) != status.UnsafeL2.Number {
+			return fmt.Errorf("unsafe payload %s does not match sync status %s", currentPayload.ID(), status.UnsafeL2)
+		}
+		payload = currentPayload
+		return nil
+	})
+	t.Require().NoError(err, "fetch conductor initial unsafe payload")
+	return payload
+}
+
+func waitForRollupSequencerActive(t devtest.T, nodeRPC string) {
+	require := t.Require()
+	rpcClient, err := opclient.NewRPC(t.Ctx(), t.Logger(), nodeRPC)
+	require.NoError(err, "dial op-node RPC for sequencer active check")
+	defer rpcClient.Close()
+	rollupClient := sources.NewRollupClient(rpcClient)
+
+	ctx, cancel := context.WithTimeout(t.Ctx(), 30*time.Second)
+	defer cancel()
+	err = retry.Do0(ctx, 60, retry.Fixed(500*time.Millisecond), func() error {
+		active, err := rollupClient.SequencerActive(ctx)
+		if err != nil {
+			return err
+		}
+		if !active {
+			return errors.New("sequencer is not active yet")
+		}
+		return nil
+	})
+	require.NoError(err, "sequencer never became active")
 }
 
 func startConductorCluster(t devtest.T, bootstrap *Conductor, members []*Conductor) {
@@ -332,6 +476,13 @@ func startConductorCluster(t devtest.T, bootstrap *Conductor, members []*Conduct
 		return nil
 	})
 	require.NoError(err, "bootstrap conductor never became leader")
+
+	if bootstrap.initialUnsafePayload != nil {
+		err = retry.Do0(ctx, 40, retry.Fixed(250*time.Millisecond), func() error {
+			return bootstrap.service.CommitUnsafePayload(ctx, bootstrap.initialUnsafePayload)
+		})
+		require.NoError(err, "failed to seed conductor unsafe head")
+	}
 
 	for _, member := range members {
 		err := retry.Do0(ctx, 40, retry.Fixed(250*time.Millisecond), func() error {

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -211,6 +211,13 @@ func (s *SyncDeriver) SyncStep() {
 
 	s.tryBackupUnsafeReorg()
 
+	// Seed a follow-mode sequencer's engine before the EL-sync backoff below: it is the sole
+	// block producer, so at genesis there is no peer payload to initial-EL-sync from and it
+	// would otherwise back off forever. Idempotent, so this is a one-time genesis bootstrap.
+	if s.SyncCfg.FollowSourceEnabled() && s.SyncCfg.NeedInitialResetEngine {
+		s.Engine.TryInitialResetEngineForSequencer(s.Ctx)
+	}
+
 	if s.Engine.IsEngineInitialELSyncing() {
 		// The pipeline cannot move forwards if doing initial EL sync.
 		s.Log.Debug("Rollup driver is backing off because execution engine is performing initial EL sync.",
@@ -220,10 +227,6 @@ func (s *SyncDeriver) SyncStep() {
 	}
 
 	if s.SyncCfg.FollowSourceEnabled() {
-		if s.SyncCfg.NeedInitialResetEngine {
-			// May need a single reset to trigger sequencer block building
-			s.Engine.TryInitialResetEngineForSequencer(s.Ctx)
-		}
 		return
 	}
 

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -1460,8 +1460,22 @@ func (e *EngineController) FollowSource(eSafeBlockRef, eLocalSafeRef, eFinalized
 		return
 	}
 
-	// External local safe is found locally but they differ so trigger reorg.
-	// Reorging may trigger EL Sync, or updating the EL Sync target.
+	// External local safe is found locally but differs: the follower diverged from upstream
+	// and must reorg onto it.
+	if e.originSelectorResetter != nil {
+		// This follower is also a sequencer (the origin-selector resetter is wired only when
+		// sequencing is enabled). A soft unsafe-head update would be clobbered by the next
+		// sequencer block before the FCU lands (head on the fork, safe on upstream ->
+		// InvalidForkchoiceState -> reset re-selects the fork -> oscillation, #21119). forceReset
+		// cancels the in-flight build and FCUs onto the upstream chain in one shot (head==safe);
+		// the sequencer then rebuilds from there.
+		logger.Warn("Follow Source: Reorg onto upstream chain")
+		e.forceReset(e.ctx, eLocalSafeRef, eLocalSafeRef, eLocalSafeRef, eSafeBlockRef, eFinalizedRef, false)
+		return
+	}
+
+	// Pure verifier (no local block production): a soft update suffices and may trigger or
+	// retarget EL sync.
 	logger.Warn("Follow Source: Reorg. May Trigger EL sync")
 	followExternalRefs(true)
 }

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -1336,6 +1336,12 @@ func (e *EngineController) TryInitialResetEngineForSequencer(ctx context.Context
 		return
 	}
 	e.forceReset(ctx, result.Unsafe, result.Unsafe, result.Safe, result.Safe, result.Finalized, true)
+	// Once seeded, a follow-mode sequencer has nothing to initial-EL-sync to, so leave the
+	// initial-EL-sync state (as insertUnsafePayload does) and let the driver proceed. EL sync
+	// still engages later via forkchoice updates if the follow source gets ahead.
+	if e.syncStatus == syncStatusWillStartEL {
+		e.syncStatus = syncStatusFinishedEL
+	}
 }
 
 var ErrEngineSyncing = errors.New("engine is syncing")

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -838,6 +838,70 @@ func TestFollowSource_SeedsGenesisRefsFromZeroState(t *testing.T) {
 	mockEngine.AssertExpectations(t)
 }
 
+// TestTryInitialResetEngineForSequencer_GenesisELSyncBootstrap verifies the genesis
+// bootstrap path for a follow-mode ELSync sequencer (ethereum-optimism/optimism#21119): with
+// no peer payload to exit syncStatusWillStartEL, the method must seed the engine from
+// FindL2Heads and leave the initial-EL-sync state so the sole-producer sequencer can build.
+func TestTryInitialResetEngineForSequencer_GenesisELSyncBootstrap(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(0xb0075))
+	l1Genesis := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     0,
+		ParentHash: common.Hash{},
+		Time:       123456,
+	}
+	l2Genesis := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           l1Genesis.Time,
+		L1Origin:       l1Genesis.ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L1:     l1Genesis.ID(),
+			L2:     l2Genesis.ID(),
+			L2Time: l2Genesis.Time,
+		},
+		BlockTime:     2,
+		SeqWindowSize: 2,
+	}
+
+	// A fresh genesis-only engine reports genesis for all labeled heads; FindL2Heads
+	// (via currentHeads) then confirms genesis's L1 origin is canonical and returns it.
+	mockEngine := &testutils.MockEngine{}
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, l2Genesis, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Safe, l2Genesis, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Unsafe, l2Genesis, nil)
+	mockL1 := &testutils.MockL1Source{}
+	mockL1.ExpectL1BlockRefByNumber(0, l1Genesis, nil)
+
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+		metrics.NoopMetrics, cfg,
+		&sync.Config{SyncMode: sync.ELSync, L2FollowSourceEndpoint: "http://localhost"},
+		mockL1, discardEmitter{}, nil)
+
+	// Precondition: a fresh ELSync engine is in initial EL sync with no unsafe head.
+	require.Equal(t, syncStatusWillStartEL, ec.syncStatus)
+	require.True(t, ec.IsEngineInitialELSyncing())
+	require.Equal(t, eth.L2BlockRef{}, ec.unsafeHead)
+
+	ec.TryInitialResetEngineForSequencer(context.Background())
+
+	// The engine is seeded at genesis and has left initial EL sync.
+	require.Equal(t, l2Genesis, ec.unsafeHead, "engine seeded at genesis")
+	require.Equal(t, syncStatusFinishedEL, ec.syncStatus, "left initial EL sync so the driver stops backing off")
+	require.False(t, ec.IsEngineInitialELSyncing())
+	mockEngine.AssertExpectations(t)
+	mockL1.AssertExpectations(t)
+
+	// Idempotent: once the engine has an unsafe head the method early-returns, making
+	// no further engine/L1 lookups (any would fail against the now-exhausted mocks).
+	ec.TryInitialResetEngineForSequencer(context.Background())
+	require.Equal(t, l2Genesis, ec.unsafeHead)
+}
+
 // TestEngineController_FinalizedHead tests FinalizedHead behavior with various configurations
 func TestEngineController_FinalizedHead(t *testing.T) {
 	tests := []struct {

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -902,6 +902,137 @@ func TestTryInitialResetEngineForSequencer_GenesisELSyncBootstrap(t *testing.T) 
 	require.Equal(t, l2Genesis, ec.unsafeHead)
 }
 
+// recordingOriginResetter counts ResetOrigins calls. A non-nil resetter is what marks an
+// EngineController as a sequencer (wired only when SequencerEnabled), which is the
+// discriminator the follow-source divergence branch uses.
+type recordingOriginResetter struct{ resets int }
+
+func (r *recordingOriginResetter) ResetOrigins() { r.resets++ }
+
+// TestFollowSource_SequencerDivergenceForcesReset verifies a follow-mode SEQUENCER reorgs
+// decisively onto the upstream chain on divergence (forceReset, resetting origins). Regression
+// guard for #21119, where the pre-fix soft update oscillated (see FollowSource).
+func TestFollowSource_SequencerDivergenceForcesReset(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(4242))
+	l1Origin := testutils.RandomBlockRef(rng)
+	mk := func(num uint64, parent common.Hash) eth.L2BlockRef {
+		return eth.L2BlockRef{
+			Hash: testutils.RandomHash(rng), Number: num,
+			ParentHash: parent, Time: l1Origin.Time + num,
+			L1Origin: l1Origin.ID(), SequenceNumber: num,
+		}
+	}
+	block3 := mk(3, testutils.RandomHash(rng))
+	block4 := mk(4, block3.Hash)
+	// Two competing block 5s on top of the common ancestor block4:
+	extBlock5 := mk(5, block4.Hash)  // upstream replacement (deposits-only N')
+	forkBlock5 := mk(5, block4.Hash) // the follower-sequencer's own fork
+
+	interopTime := uint64(0)
+	cfg := &rollup.Config{InteropTime: &interopTime}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	emitter.Mock.On("Emit", mock.Anything).Maybe()
+
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+		metrics.NoopMetrics, cfg, &sync.Config{L2FollowSourceEndpoint: "http://localhost"}, &testutils.MockL1Source{}, emitter, nil)
+
+	// Wiring an origin-selector resetter marks this controller as a sequencer.
+	originResetter := &recordingOriginResetter{}
+	ec.SetOriginSelectorResetter(originResetter)
+
+	// Local state: the sequencer has built its own fork to block 5.
+	ec.unsafeHead = forkBlock5
+	ec.SetLocalSafeHead(block4)
+	ec.SetDeprecatedSafeHead(block4)
+	ec.SetFinalizedHead(block3)
+	ec.lastForkchoice = eth.ForkchoiceState{
+		HeadBlockHash:      forkBlock5.Hash,
+		SafeBlockHash:      block4.Hash,
+		FinalizedBlockHash: block3.Hash,
+	}
+
+	// Divergence: the local block at height 5 is the fork, not the upstream's block 5.
+	mockEngine.ExpectL2BlockRefByNumber(5, forkBlock5, nil)
+
+	// forceReset FCUs the engine onto the upstream chain in one shot.
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      extBlock5.Hash,
+			SafeBlockHash:      extBlock5.Hash,
+			FinalizedBlockHash: block4.Hash,
+		}, nil,
+		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil,
+	)
+
+	// externalCrossSafe=extBlock5, externalLocalSafe=extBlock5, externalFinalized=block4
+	ec.FollowSource(extBlock5, extBlock5, block4)
+
+	require.Equal(t, 1, originResetter.resets, "sequencer divergence must reset origins to cancel the in-flight fork build")
+	require.Equal(t, extBlock5, ec.unsafeHead, "unsafe head must reorg onto the upstream chain")
+	require.Equal(t, extBlock5, ec.localSafeHead, "local safe must reorg onto the upstream chain")
+	require.Equal(t, extBlock5, ec.deprecatedSafeHead, "cross safe must follow the upstream chain")
+	mockEngine.AssertExpectations(t)
+}
+
+// TestFollowSource_VerifierDivergenceStaysSoft verifies a follow-mode VERIFIER (no origin-
+// selector resetter) keeps the soft follow path on divergence WITHOUT resetting origins —
+// there is no competing block production. The #21119 fix must not change this path.
+func TestFollowSource_VerifierDivergenceStaysSoft(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(7373))
+	l1Origin := testutils.RandomBlockRef(rng)
+	mk := func(num uint64, parent common.Hash) eth.L2BlockRef {
+		return eth.L2BlockRef{
+			Hash: testutils.RandomHash(rng), Number: num,
+			ParentHash: parent, Time: l1Origin.Time + num,
+			L1Origin: l1Origin.ID(), SequenceNumber: num,
+		}
+	}
+	block3 := mk(3, testutils.RandomHash(rng))
+	block4 := mk(4, block3.Hash)
+	extBlock5 := mk(5, block4.Hash)  // upstream chain
+	forkBlock5 := mk(5, block4.Hash) // local block at the same height, different hash
+
+	interopTime := uint64(0)
+	cfg := &rollup.Config{InteropTime: &interopTime}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	emitter.Mock.On("Emit", mock.Anything).Maybe()
+
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+		metrics.NoopMetrics, cfg, &sync.Config{L2FollowSourceEndpoint: "http://localhost"}, &testutils.MockL1Source{}, emitter, nil)
+
+	// No origin-selector resetter: this is a pure verifier.
+	ec.unsafeHead = forkBlock5
+	ec.SetLocalSafeHead(block4)
+	ec.SetDeprecatedSafeHead(block4)
+	ec.SetFinalizedHead(block3)
+	ec.lastForkchoice = eth.ForkchoiceState{
+		HeadBlockHash:      forkBlock5.Hash,
+		SafeBlockHash:      block4.Hash,
+		FinalizedBlockHash: block3.Hash,
+	}
+
+	mockEngine.ExpectL2BlockRefByNumber(5, forkBlock5, nil)
+
+	// The soft path FCUs once finalized advances (via promoteFinalized): head=safe=extBlock5,
+	// finalized=block4.
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      extBlock5.Hash,
+			SafeBlockHash:      extBlock5.Hash,
+			FinalizedBlockHash: block4.Hash,
+		}, nil,
+		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil,
+	)
+
+	ec.FollowSource(extBlock5, extBlock5, block4)
+
+	require.Equal(t, extBlock5, ec.unsafeHead, "soft path still advances the unsafe head toward upstream")
+	require.Equal(t, extBlock5, ec.localSafeHead, "soft path advances local safe toward upstream")
+	mockEngine.AssertExpectations(t)
+}
+
 // TestEngineController_FinalizedHead tests FinalizedHead behavior with various configurations
 func TestEngineController_FinalizedHead(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Adds flag-gated **reorg recovery** to op-conductor (issue #20006). By default the Raft FSM only records forward-moving unsafe heads, so a backward interop reorg leaves the recorded head pinned to an orphaned block and wedges the cluster. With `--reorg-recovery.enabled` set, the leader subscribes to its op-reth's `reth_subscribeChainNotifications`, and on a reorg notification commits the EL's current canonical head — letting the recorded unsafe head move backward (last-write-wins).

**The flag defaults OFF. With it off, behavior is byte-for-byte unchanged.** When on, it changes Raft FSM apply semantics and MUST be set identically on every conductor in the cluster (all-on or all-off, never mixed).

### What's included

- **Reth chain-notifications subscriber** (`chainevents/`): WebSocket subscription on the leader (`--execution.ws-url`); on each reorg reads the EL's canonical unsafe head, fetches the payload, and commits via the existing `CommitUnsafePayload`. The subscription has no replay, so the leader re-commits its EL head on every (re)subscribe to recover any reorg missed during a disconnect.
- **Flag-gated FSM guard bypass** (`consensus/raft_fsm.go`): backward head moves are accepted only when the flag is on.
- **Non-cancellable demotion grace (5s)** (`conductor/demotion_latch.go`, `service.go`): a deep reorg rewinds the unsafe head far enough to trip the unsafe-staleness health check, which would normally transfer leadership away before the leader processes the one-shot reorg notification. The first staleness observation keeps the leader reporting healthy for the grace so it can commit the post-reorg head, then demotes it **unconditionally** at expiry (a fresh block timestamp does not prove a correct chain, so a healthy poll during the grace cannot cancel the demotion). `ErrSequencerConnectionDown` still fails over immediately. Cost: up to ~5s added failover latency on a stuck-but-connected sequencer and one guaranteed handoff per deep reorg. Grace is 0 (today's immediate demotion) when the flag is off.
- **`conductor_latestUnsafePayload` admin RPC** for inspection/recovery.
- **Metrics**: reorg observations and resyncs.
- **op-devstack interop harness**: 3-conductor cluster on op-reth ELSync follow-mode, with acceptance scenarios A–D plus a deep-reorg + tight-health recovery test asserting all-EL convergence.
- **Docs**: README, RUNBOOK, and public chain-operator docs describe the flag, the fleet-uniform contract, and the demotion-grace trade-offs.

## Stacking

Stacked on **#21122** (`feat/devstack-follow-mode-supernode-elsync`), which is itself stacked on #21121 → #21120. Review/merge those first. This PR's diff is only the 12 conductor commits on top.

## Test plan

- `go test ./op-conductor/...` — unit tests for the demotion latch (9 cases), service-level timer wiring (incl. a real 5s timer fire), subscriber reconnect/resubscribe, FSM guard bypass, and the reorg-event handler. All pass; race clean; custom linter clean.
- op-acceptance: conductor reorg-recovery scenarios A–D and the deep-reorg + tight-health convergence test.
- Stress: 100× deep-reorg + tight-health runs. 95/100 pass cleanly. The 5 failures were root-caused to a **separate upstream op-node `forceReset`/`latestHead` re-anchor bug** under EL-sync (op-node's sequencer `latestHead` stays pinned past a `FollowSource` reset; the conductor FSM correctly tracks the canonical head) — not a defect in this PR. That bug is tracked separately and needs an op-node-side fix; it is out of scope here.

## Notes

Left as **draft** pending the base PRs and the upstream op-node fix discussion.

Closes #20006 (recovery path; the upstream op-node bug is tracked in #21125).
