### PR TITLE
Retry supernode engine controller setup

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/startup_resync/startup_resync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/startup_resync/startup_resync_test.go
@@ -20,6 +20,7 @@ const (
 	l2BlockTime         = uint64(1)
 	backfillDepth       = 3 * time.Second
 	preRestartFinalized = uint64(5)
+	elOfflineProbeDelay = 15 * time.Second
 )
 
 // TestSupernodeResyncResumesAtActivation_PostActivation drives a full
@@ -92,6 +93,43 @@ func TestSupernodeResyncSchedulesAtActivation_PreActivation(gt *testing.T) {
 	sys.Supernode.RestartWithFreshDataDir()
 	sys.Supernode.AwaitVerificationStartsAt(activation)
 
+	dsl.CheckAll(t,
+		sys.L2ACL.AdvancedFn(safety.CrossSafe, 1, 60),
+		sys.L2BCL.AdvancedFn(safety.CrossSafe, 1, 60),
+	)
+}
+
+func TestSupernodeEngineControllerRetriesAfterELUnavailableAtStartup(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewTwoL2SupernodeInterop(t, 0,
+		presets.WithUniformL2BlockTimes(l2BlockTime),
+		presets.WithInteropLogBackfillDepth(backfillDepth),
+	)
+
+	sys.Supernode.AwaitBackfillCompleted()
+
+	sys.Supernode.Stop()
+	sys.L2ELA.Stop()
+	sys.L2ELB.Stop()
+	t.Cleanup(func() {
+		sys.L2ELA.Start()
+		sys.L2ELB.Start()
+	})
+
+	// Start the supernode while the EL RPC endpoints are down. Before the
+	// engine-controller retry loop, this left interop permanently stuck with
+	// ErrNoEngineClient even after the ELs came back.
+	sys.Supernode.Start()
+	// Keep the ELs offline long enough for the first engine-controller setup
+	// attempt to time out and enter the retry path.
+	time.Sleep(elOfflineProbeDelay)
+
+	sys.L2ELA.Start()
+	sys.L2ELB.Start()
+	sys.L2ELA.WaitForOnline()
+	sys.L2ELB.WaitForOnline()
+
+	sys.Supernode.AwaitBackfillCompleted()
 	dsl.CheckAll(t,
 		sys.L2ACL.AdvancedFn(safety.CrossSafe, 1, 60),
 		sys.L2BCL.AdvancedFn(safety.CrossSafe, 1, 60),

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -193,6 +193,10 @@ func (n *OpReth) Start() {
 func (n *OpReth) Stop() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	if n.sub == nil {
+		n.p.Logger().Warn("op-reth already stopped")
+		return
+	}
 	err := n.sub.Stop(true)
 	n.p.Require().NoError(err, "Must stop")
 	n.sub = nil

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -45,6 +45,12 @@ var ErrHistoryUnavailable = errors.New("safedb history unavailable on this node"
 // during cold start; callers should back off and retry.
 var ErrSafeDBNotReady = errors.New("safedb not ready: no stable first entry yet")
 
+var (
+	engineControllerSetupTimeout  = 10 * time.Second
+	engineControllerRetryDelay    = 2 * time.Second
+	newEngineControllerFromConfig = engine_controller.NewEngineControllerFromConfig
+)
+
 type ChainContainer interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
@@ -153,6 +159,7 @@ type simpleChainContainer struct {
 	vn                 virtual_node.VirtualNode
 	vncfg              *opnodecfg.Config
 	cfg                config.CLIConfig
+	engineMu           sync.RWMutex
 	engine             engine_controller.EngineController
 	denyList           *DenyList
 	pause              atomic.Bool
@@ -297,7 +304,18 @@ func (c *simpleChainContainer) subPath(path string) string {
 }
 
 func (c *simpleChainContainer) Start(ctx context.Context) error {
-	defer func() { c.stopped <- struct{}{} }()
+	retryCtx, retryCancel := context.WithCancel(ctx)
+	var retryWG sync.WaitGroup
+	retryWG.Add(1)
+	go func() {
+		defer retryWG.Done()
+		c.retryEngineController(retryCtx)
+	}()
+	defer func() {
+		retryCancel()
+		retryWG.Wait()
+		c.stopped <- struct{}{}
+	}()
 	if c.rpcRouter != nil {
 		c.rpcRouter.SetReadinessCheck(c.chainID.String(), c.IsRPCReady)
 	}
@@ -349,18 +367,6 @@ func (c *simpleChainContainer) Start(ctx context.Context) error {
 		}
 		if c.stop.Load() {
 			break
-		}
-
-		// Initialize engine controller if not yet connected (retries on each VN restart)
-		if c.engine == nil && c.vncfg.L2 != nil {
-			setupCtx, setupCancel := context.WithTimeout(ctx, 10*time.Second)
-			engLog := c.log.New("chain_id", c.chainID.String(), "component", "engine_controller")
-			if eng, engErr := engine_controller.NewEngineControllerFromConfig(setupCtx, engLog, c.vncfg); engErr != nil {
-				c.log.Error("failed to setup engine controller", "err", engErr)
-			} else {
-				c.engine = eng
-			}
-			setupCancel()
 		}
 
 		// start the virtual node
@@ -417,10 +423,7 @@ func (c *simpleChainContainer) Stop(ctx context.Context) error {
 		}
 	}
 
-	// Close engine controller RPC resources
-	if c.engine != nil {
-		_ = c.engine.Close()
-	}
+	c.closeEngine()
 
 	// Close deny list database
 	if c.denyList != nil {
@@ -437,6 +440,65 @@ func (c *simpleChainContainer) Stop(ctx context.Context) error {
 	}
 }
 
+func (c *simpleChainContainer) getEngine() engine_controller.EngineController {
+	c.engineMu.RLock()
+	defer c.engineMu.RUnlock()
+	return c.engine
+}
+
+func (c *simpleChainContainer) setEngineIfRunning(eng engine_controller.EngineController) bool {
+	c.engineMu.Lock()
+	defer c.engineMu.Unlock()
+	if c.stop.Load() || c.engine != nil {
+		return false
+	}
+	c.engine = eng
+	return true
+}
+
+func (c *simpleChainContainer) closeEngine() {
+	c.engineMu.Lock()
+	eng := c.engine
+	c.engine = nil
+	c.engineMu.Unlock()
+	if eng != nil {
+		_ = eng.Close()
+	}
+}
+
+func (c *simpleChainContainer) retryEngineController(ctx context.Context) {
+	if c.vncfg == nil || c.vncfg.L2 == nil {
+		return
+	}
+	engLog := c.log.New("chain_id", c.chainID.String(), "component", "engine_controller")
+	for {
+		if ctx.Err() != nil || c.stop.Load() || c.getEngine() != nil {
+			return
+		}
+
+		setupCtx, setupCancel := context.WithTimeout(ctx, engineControllerSetupTimeout)
+		eng, err := newEngineControllerFromConfig(setupCtx, engLog, c.vncfg)
+		setupCancel()
+		if err == nil {
+			if ctx.Err() != nil || !c.setEngineIfRunning(eng) {
+				_ = eng.Close()
+				return
+			}
+			c.log.Info("engine controller connected")
+			return
+		}
+		c.log.Error("failed to setup engine controller", "err", err)
+
+		timer := time.NewTimer(engineControllerRetryDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+
 func (c *simpleChainContainer) Pause(ctx context.Context) error {
 	c.pause.Store(true)
 	return nil
@@ -448,10 +510,11 @@ func (c *simpleChainContainer) Resume(ctx context.Context) error {
 }
 
 func (c *simpleChainContainer) ELFinalizedHead(ctx context.Context) (eth.L2BlockRef, error) {
-	if c.engine == nil {
+	eng := c.getEngine()
+	if eng == nil {
 		return eth.L2BlockRef{}, engine_controller.ErrNoEngineClient
 	}
-	return c.engine.L2BlockRefByLabel(ctx, eth.Finalized)
+	return eng.L2BlockRefByLabel(ctx, eth.Finalized)
 }
 
 func (c *simpleChainContainer) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error) {
@@ -504,7 +567,8 @@ func (c *simpleChainContainer) FirstSafeHeadTimestamp(ctx context.Context) (uint
 // LocalSafeBlockAtTimestamp returns the highest L2 block with timestamp <= ts using the L2 client,
 // if the block at that timestamp is local safe.
 func (c *simpleChainContainer) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
-	if c.engine == nil {
+	eng := c.getEngine()
+	if eng == nil {
 		return eth.L2BlockRef{}, engine_controller.ErrNoEngineClient
 	}
 
@@ -524,7 +588,7 @@ func (c *simpleChainContainer) LocalSafeBlockAtTimestamp(ctx context.Context, ts
 		return eth.L2BlockRef{}, ethereum.NotFound
 	}
 
-	return c.engine.L2BlockRefByNumber(ctx, num)
+	return eng.L2BlockRefByNumber(ctx, num)
 }
 
 // SyncStatus returns the in-process op-node sync status for this chain.
@@ -544,10 +608,11 @@ func (c *simpleChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus,
 }
 
 func (c *simpleChainContainer) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
-	if c.engine == nil {
+	eng := c.getEngine()
+	if eng == nil {
 		return eth.Bytes32{}, engine_controller.ErrNoEngineClient
 	}
-	out, err := c.engine.OutputV0ByBlockHash(ctx, blockHash)
+	out, err := eng.OutputV0ByBlockHash(ctx, blockHash)
 	if err != nil {
 		return eth.Bytes32{}, err
 	}
@@ -633,24 +698,27 @@ func (c *simpleChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, 
 
 // FetchReceipts fetches the receipts for a given block by hash.
 func (c *simpleChainContainer) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
-	if c.engine == nil {
+	eng := c.getEngine()
+	if eng == nil {
 		return nil, engine_controller.ErrNoEngineClient
 	}
-	return c.engine.PayloadByHash(ctx, hash)
+	return eng.PayloadByHash(ctx, hash)
 }
 
 func (c *simpleChainContainer) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
-	if c.engine == nil {
+	eng := c.getEngine()
+	if eng == nil {
 		return nil, engine_controller.ErrNoEngineClient
 	}
-	return c.engine.PayloadByNumber(ctx, number)
+	return eng.PayloadByNumber(ctx, number)
 }
 
 func (c *simpleChainContainer) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
-	if c.engine == nil {
+	eng := c.getEngine()
+	if eng == nil {
 		return nil, nil, engine_controller.ErrNoEngineClient
 	}
-	return c.engine.FetchReceipts(ctx, blockID.Hash)
+	return eng.FetchReceipts(ctx, blockID.Hash)
 }
 
 // BlockTime returns the block time in seconds for this chain from the rollup config.
@@ -707,7 +775,8 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, target *eth.Exe
 	if vn == nil {
 		return fmt.Errorf("virtual node not initialized")
 	}
-	if c.engine == nil {
+	eng := c.getEngine()
+	if eng == nil {
 		return fmt.Errorf("engine not initialized")
 	}
 
@@ -731,7 +800,7 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, target *eth.Exe
 
 retryLoop:
 	for {
-		err = c.engine.Rewind(ctx, target)
+		err = eng.Rewind(ctx, target)
 		switch {
 		case isCriticalRewindError(err):
 			c.log.Error("chain_container/RewindEngine: critical error", "err", err)

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -221,6 +221,8 @@ type mockEngineController struct {
 	rewindFunc               func(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error // optional custom behavior
 	l2BlockRefByNumberResult eth.L2BlockRef
 	l2BlockRefByNumberErr    error
+	outputV0Result           *eth.OutputV0
+	outputV0Err              error
 	payloadByHashResult      *eth.ExecutionPayloadEnvelope
 	payloadByHashErr         error
 	payloadByNumberResult    *eth.ExecutionPayloadEnvelope
@@ -240,7 +242,7 @@ func (m *mockEngineController) L2BlockRefByLabel(ctx context.Context, label eth.
 }
 
 func (m *mockEngineController) OutputV0AtBlockNumber(ctx context.Context, num uint64) (*eth.OutputV0, error) {
-	return nil, nil
+	return m.outputV0Result, m.outputV0Err
 }
 
 func (m *mockEngineController) OutputV0ByBlockHash(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
@@ -429,6 +431,135 @@ func TestChainContainer_EngineControllerNotInitInConstructor(t *testing.T) {
 	impl, ok := container.(*simpleChainContainer)
 	require.True(t, ok)
 	require.Nil(t, impl.engine, "engine should not be initialized in constructor; it is deferred to Start loop")
+}
+
+func TestChainContainer_EngineControllerRetryContinuesWhileVNRunning(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+	vncfg := createTestVNConfig()
+	vncfg.L2 = &opnodecfg.L2EndpointConfig{L2EngineAddr: "http://unused.example"}
+	log := createTestLogger(t)
+	cfg := createTestCLIConfig(t.TempDir())
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	impl, ok := container.(*simpleChainContainer)
+	require.True(t, ok)
+
+	mockVN := newMockVirtualNode()
+	mockVN.blockOnStart = true
+	impl.virtualNodeFactory = func(cfg *opnodecfg.Config, log gethlog.Logger, initOverload *rollupNode.InitializationOverrides, appVersion string, superAuthority rollup.SuperAuthority) virtual_node.VirtualNode {
+		return mockVN
+	}
+
+	firstAttempt := make(chan struct{})
+	allowSecondAttempt := make(chan struct{})
+	var attempts int
+	expectedOutput := &eth.OutputV0{BlockHash: common.Hash{0x42}}
+	mockEngine := &mockEngineController{outputV0Result: expectedOutput}
+
+	prevSetup := newEngineControllerFromConfig
+	prevRetryDelay := engineControllerRetryDelay
+	newEngineControllerFromConfig = func(ctx context.Context, log gethlog.Logger, vncfg *opnodecfg.Config) (engine_controller.EngineController, error) {
+		attempts++
+		if attempts == 1 {
+			close(firstAttempt)
+			return nil, errors.New("el unavailable")
+		}
+		select {
+		case <-allowSecondAttempt:
+			return mockEngine, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	engineControllerRetryDelay = 10 * time.Millisecond
+	t.Cleanup(func() {
+		newEngineControllerFromConfig = prevSetup
+		engineControllerRetryDelay = prevRetryDelay
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- container.Start(ctx)
+	}()
+	defer func() {
+		cancel()
+		select {
+		case err := <-startDone:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("chain container Start did not return")
+		}
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+		defer stopCancel()
+		require.NoError(t, container.Stop(stopCtx))
+	}()
+
+	select {
+	case <-mockVN.startSignal:
+	case <-time.After(time.Second):
+		t.Fatal("virtual node did not start")
+	}
+	select {
+	case <-firstAttempt:
+	case <-time.After(time.Second):
+		t.Fatal("engine controller setup was not attempted")
+	}
+
+	_, err := container.OutputV0AtBlockNumber(context.Background(), 0)
+	require.ErrorIs(t, err, engine_controller.ErrNoEngineClient)
+
+	close(allowSecondAttempt)
+	require.Eventually(t, func() bool {
+		out, err := container.OutputV0AtBlockNumber(context.Background(), 0)
+		return err == nil && out == expectedOutput
+	}, time.Second, 10*time.Millisecond, "engine controller should connect without a VN restart")
+
+	mockVN.mu.Lock()
+	startCalls := mockVN.startCalled
+	mockVN.mu.Unlock()
+	require.Equal(t, 1, startCalls, "engine retry should not restart the virtual node")
+}
+
+func TestChainContainer_EngineControllerRetryStopsWhenStartReturns(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+	vncfg := createTestVNConfig()
+	vncfg.L2 = &opnodecfg.L2EndpointConfig{L2EngineAddr: "http://unused.example"}
+	log := createTestLogger(t)
+	cfg := createTestCLIConfig(t.TempDir())
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	impl, ok := container.(*simpleChainContainer)
+	require.True(t, ok)
+	setupStarted := make(chan struct{})
+	impl.virtualNodeFactory = func(cfg *opnodecfg.Config, log gethlog.Logger, initOverload *rollupNode.InitializationOverrides, appVersion string, superAuthority rollup.SuperAuthority) virtual_node.VirtualNode {
+		<-setupStarted
+		return nil
+	}
+
+	var once sync.Once
+	prevSetup := newEngineControllerFromConfig
+	newEngineControllerFromConfig = func(ctx context.Context, log gethlog.Logger, vncfg *opnodecfg.Config) (engine_controller.EngineController, error) {
+		once.Do(func() { close(setupStarted) })
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	t.Cleanup(func() {
+		newEngineControllerFromConfig = prevSetup
+	})
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- container.Start(context.Background())
+	}()
+	select {
+	case err := <-startDone:
+		require.ErrorIs(t, err, virtual_node.ErrVirtualNodeNotRunning)
+	case <-time.After(time.Second):
+		t.Fatal("Start should return even when engine setup is blocked")
+	}
 }
 
 func TestChainContainerIsRPCReady(t *testing.T) {

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -403,7 +403,8 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 
 	// Errors here propagate so the caller preserves the pending transition for
 	// retry on restart; the deny list entry above is already durable.
-	if c.engine == nil {
+	eng := c.getEngine()
+	if eng == nil {
 		return false, fmt.Errorf("cannot check current block at height %d: %w", height, engine_controller.ErrNoEngineClient)
 	}
 
@@ -412,7 +413,7 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	// have left the synthetic block at this height with no canonical entry visible by
 	// number, and we need to drive the rewind to completion.
 	var invalidatedBlock eth.BlockRef
-	currentBlock, err := c.engine.L2BlockRefByNumber(ctx, height)
+	currentBlock, err := eng.L2BlockRefByNumber(ctx, height)
 	switch {
 	case err == nil:
 		if currentBlock.Hash != payloadHash {

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -113,10 +113,11 @@ func (c *simpleChainContainer) GetDeniedOutput(height uint64, payloadHash common
 
 // OutputV0AtBlockNumber returns the full OutputV0 for the block at the given number.
 func (c *simpleChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
-	if c.engine == nil {
+	eng := c.getEngine()
+	if eng == nil {
 		return nil, engine_controller.ErrNoEngineClient
 	}
-	return c.engine.OutputV0AtBlockNumber(ctx, l2BlockNum)
+	return eng.OutputV0AtBlockNumber(ctx, l2BlockNum)
 }
 
 var _ rollup.SuperAuthority = (*simpleChainContainer)(nil)


### PR DESCRIPTION
## Summary

- Retry op-supernode engine-controller setup independently of the virtual-node restart loop.
- Guard shared engine-controller access with a mutex so the retry goroutine can safely install the controller while interop paths read it.
- Add a chain-container regression test and a devstack startup-resync repro where supernode starts while L2 EL RPC is unavailable.

## Root Cause

The supernode virtual node and interop engine controller use separate EL connections. If the interop engine-controller connection failed during startup, `c.engine` stayed nil. The only retry was tied to the VN restart loop, but a healthy VN can keep running and reconnect its own EL client without restarting. Interop then kept retrying work and failing with `engine client not initialized`.

## Validation

- `go test ./op-supernode/supernode/chain_container -count=1`
- `go test -race ./op-supernode/supernode/chain_container -run TestChainContainer_EngineControllerRetryContinuesWhileVNRunning -count=1`
- `go test ./op-acceptance-tests/tests/supernode/interop/startup_resync -run '^$' -count=1`\n\nAttempted full devstack repro locally:\n\n- `go test ./op-acceptance-tests/tests/supernode/interop/startup_resync -run TestSupernodeEngineControllerRetriesAfterELUnavailableAtStartup -count=1 -timeout=10m`\n\nThis compiled and started, but local execution is blocked before the test body by missing `packages/contracts-bedrock/forge-artifacts` in this checkout.\n\nFixes #21136