### PR TITLE
contracts-bedrock: bump OPCM version to 8.0.0

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x2650f2af1df017387e1f1aa6273decc4c46dd4f3ac7f0910c6f0edc92aef4747"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x3823112f729f99c7e94bd5a17cb34fc7b720a2cab5b071d92c7c8c402604890c",
-    "sourceCodeHash": "0xe859ca5810eea955d018f35e9220fdc5b74b130f645fef67834cfbb69782564a"
+    "initCodeHash": "0x435b08c5f9b0bbb4c2a4ab9f43d35fdbc1242fa13c89b5dd9a39472693195010",
+    "sourceCodeHash": "0xab487e8004be6306c11e3d50236b18501648f58b2bd0673e78c550478ef37c38"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0xf1fb169c6dd4eceb5cec6ed6dfa3affc45970e5a01e00827d06af1f9e8df026d",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -158,9 +158,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 7.1.22
+    /// @custom:semver 8.0.0
     function version() public pure returns (string memory) {
-        return "7.1.22";
+        return "8.0.0";
     }
 
     /// @param _standardValidator The standard validator for this OPCM release.


### PR DESCRIPTION
## Summary
- Bumps `OPContractsManagerV2` semver from `7.1.22` to `8.0.0`.
- Regenerates the contracts semver lock snapshot.

## Testing
- `mise exec -- just semver-lock`
- `mise exec -- forge test --match-path test/L1/opcm/OPContractsManagerV2.t.sol --match-contract OPContractsManagerV2_IsPermittedUpgradeSequence_Test`