### PR TITLE
ci: enable manual contract artifact publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,9 @@ parameters:
   publish_contract_artifacts_dispatch:
     type: boolean
     default: false
+  publish_contract_artifacts_ref:
+    type: string
+    default: ""
   stale_check_dispatch:
     type: boolean
     default: false
@@ -134,6 +137,7 @@ jobs:
             c-github-event-action: << pipeline.parameters.github-event-action >>
             c-github-event-base64: << pipeline.parameters.github-event-base64 >>
             c-go-cache-version: << pipeline.parameters.go-cache-version >>
+            c-publish_contract_artifacts_ref: << pipeline.parameters.publish_contract_artifacts_ref >>
       # Same as above but for booleans. Separate step because CircleCI renders
       # boolean pipeline params as 0/1 in environment blocks — the "bool" mode
       # normalizes them to JSON true/false.
@@ -278,6 +282,7 @@ jobs:
                 elif [[ "${BRANCH}" == "develop" ]]; then
                   run main
                   run release
+                  run publish_contract_artifacts
                   run develop_fault_proofs
                   run develop_kontrol_tests
                   run contracts_feature_tests
@@ -304,6 +309,7 @@ jobs:
                 if is_true reproducibility_dispatch;  then run scheduled_preimage_reproducibility; fi
                 if is_true stale_check_dispatch;      then run scheduled_stale_check; fi
                 if is_true heavy_fuzz_dispatch;       then run scheduled_heavy_fuzz_tests; fi
+                if is_true publish_contract_artifacts_dispatch; then run publish_contract_artifacts; fi
                 if is_true l2_fork_test_dispatch;     then run l2_fork_test; fi
                 if is_true rust_ci_dispatch;          then run rust_ci; fi
                 if is_true rust_e2e_dispatch;         then run rust_e2e_ci; fi
@@ -314,7 +320,7 @@ jobs:
             esac
 
             # Params to forward to continuation configs (everything else is stripped)
-            finalize "c-default_docker_image,c-rust_base_image,c-base_image,c-github-event-base64,c-go-cache-version,c-rust_files_changed"
+            finalize "c-default_docker_image,c-rust_base_image,c-base_image,c-github-event-base64,c-go-cache-version,c-rust_files_changed,c-publish_contract_artifacts_ref"
       # Deep-merges the 3 continuation YAML configs (main, rust-ci, rust-e2e)
       # into /tmp/merged-config.yml using yq. Later files win on key conflicts.
       # explode(.) resolves YAML anchors/aliases so the output is self-contained.

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -23,6 +23,9 @@ parameters:
   c-go-cache-version:
     type: string
     default: "v0.0"
+  c-publish_contract_artifacts_ref:
+    type: string
+    default: ""
   # Workflow activation flags (set by the decision tree in config.yml)
   c-run_main:
     type: boolean
@@ -67,6 +70,9 @@ parameters:
     type: boolean
     default: false
   c-run_ci_gate_skip:
+    type: boolean
+    default: false
+  c-run_publish_contract_artifacts:
     type: boolean
     default: false
 
@@ -2293,6 +2299,24 @@ jobs:
       - utils/checkout-with-mise:
           checkout-method: blobless
           enable-mise-cache: true
+      - run:
+          name: Checkout publish ref
+          environment:
+            PUBLISH_CONTRACT_ARTIFACTS_REF: << pipeline.parameters.c-publish_contract_artifacts_ref >>
+          command: |
+            set -euo pipefail
+
+            if [ -z "$PUBLISH_CONTRACT_ARTIFACTS_REF" ]; then
+              echo "Using pipeline checkout $(git rev-parse HEAD)"
+              exit 0
+            fi
+
+            git fetch --no-tags origin "$PUBLISH_CONTRACT_ARTIFACTS_REF"
+            git checkout --detach FETCH_HEAD
+            echo "Checked out publish ref '$PUBLISH_CONTRACT_ARTIFACTS_REF' at $(git rev-parse HEAD)"
+
+            # Respect the tool versions specified by the ref being published.
+            mise install -v -y
       - install-contracts-dependencies
       - install-zstd
       - run:
@@ -2831,6 +2855,13 @@ workflows:
               only: /^op-contracts\/v.*/
             branches:
               ignore: /.*/
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+
+  publish-contract-artifacts-auto-or-manual:
+    when: << pipeline.parameters.c-run_publish_contract_artifacts >>
+    jobs:
+      - publish-contract-artifacts:
           context:
             - circleci-repo-readonly-authenticated-github-token
 

--- a/.circleci/scripts/test-decision-tree.sh
+++ b/.circleci/scripts/test-decision-tree.sh
@@ -149,13 +149,13 @@ run_scenario \
   "After merge (develop), rust changed" \
   "webhook" "develop" "" "" \
   '{"c-rust_changes_detected": true, "c-contracts_changed": false, "c-docs_changes_detected": true}' \
-  main release develop_fault_proofs develop_kontrol_tests contracts_feature_tests rust_ci rust_e2e_ci kona_publish_prestates
+  main release publish_contract_artifacts develop_fault_proofs develop_kontrol_tests contracts_feature_tests rust_ci rust_e2e_ci kona_publish_prestates
 
 run_scenario \
   "After merge (develop), no rust changes" \
   "webhook" "develop" "" "" \
   '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": false}' \
-  main release develop_fault_proofs develop_kontrol_tests contracts_feature_tests rust_ci_gate_short rust_e2e_gate_skip
+  main release publish_contract_artifacts develop_fault_proofs develop_kontrol_tests contracts_feature_tests rust_ci_gate_short rust_e2e_gate_skip
 
 run_scenario \
   "Scheduled: build_four_hours" \
@@ -186,6 +186,12 @@ run_scenario \
   "api" "" "" "" \
   '{"c-main_dispatch": false, "c-rust_ci_dispatch": true, "c-github-event-type": "__not_set__"}' \
   release rust_ci
+
+run_scenario \
+  "API: publish_contract_artifacts_dispatch" \
+  "api" "" "" "" \
+  '{"c-main_dispatch": false, "c-publish_contract_artifacts_dispatch": true, "c-github-event-type": "__not_set__"}' \
+  release publish_contract_artifacts
 
 run_scenario \
   "API: github event labeled PR" \


### PR DESCRIPTION
## Summary
- enable contract artifact publishing automatically on develop continuation pipelines
- wire the existing CircleCI `publish_contract_artifacts_dispatch` parameter to run the publish workflow manually
- add optional `publish_contract_artifacts_ref` so manual runs can publish artifacts for a specific branch, tag, or commit
- add decision-tree coverage for develop auto-publish and manual dispatch

## Validation
- `bash .circleci/scripts/test-decision-tree.sh`
- `circleci config validate .circleci/config.yml`
- `git diff --check`
- merged config includes `c-run_publish_contract_artifacts` and `c-publish_contract_artifacts_ref`

Note: full merged config validation is blocked locally because the private `ethereum-optimism/circleci-utils@1.0.27` orb is not resolvable by the public CircleCI CLI.