### PR TITLE
docs: refine "Talk to the Optimism team" CTAs per feedback

### DIFF
--- a/docs/public-docs/chain-operators/guides/management/best-practices.mdx
+++ b/docs/public-docs/chain-operators/guides/management/best-practices.mdx
@@ -84,6 +84,6 @@ necessary for L2 withdrawals at the moment.
 
 ## Want expert guidance?
 
-<Card title="Talk to the Optimism team" icon="handshake" href="https://optimism.io/learn-more?utm_source=docs&utm_medium=cta&utm_campaign=best-practices">
-  Interested in OP Enterprise, premium features, or chain management? Reach out early, we can help you make the right architecture decisions before you start building.
+<Card title="Talk to the Optimism team" icon="envelope" href="https://www.optimism.io/learn-more?utm_source=docs&utm_medium=docs&utm_campaign=talk-to-the-optimism-team">
+  Tell us what you're building. We'll help you scope the right setup before you write a line of code.
 </Card>

--- a/docs/public-docs/index.mdx
+++ b/docs/public-docs/index.mdx
@@ -65,6 +65,6 @@ Take a look at some of the [chain operator best practices](/chain-operators/guid
 
 ## Ready to go further?
 
-<Card title="Talk to the Optimism team" icon="handshake" href="https://optimism.io/learn-more?utm_source=docs&utm_medium=cta&utm_campaign=chain-operator-docs">
-  Interested in OP Enterprise, premium features, or chain management? Reach out early, we can help you make the right architecture decisions before you start building.
+<Card title="Talk to the Optimism team" icon="envelope" href="https://www.optimism.io/learn-more?utm_source=docs&utm_medium=docs&utm_campaign=talk-to-the-optimism-team">
+  Tell us what you're building. We'll help you scope the right setup before you write a line of code.
 </Card>

--- a/docs/public-docs/op-stack/introduction/op-stack.mdx
+++ b/docs/public-docs/op-stack/introduction/op-stack.mdx
@@ -106,6 +106,6 @@ The OP Stack is a modular collection of software components that work together t
 
 ## Ready to build your chain?
 
-<Card title="Talk to the Optimism team" icon="handshake" href="https://optimism.io/learn-more?utm_source=docs&utm_medium=cta&utm_campaign=op-stack-intro">
-  Interested in OP Enterprise, premium features, or chain management? Reach out early, we can help you make the right architecture decisions before you start building.
+<Card title="Talk to the Optimism team" icon="envelope" href="https://www.optimism.io/learn-more?utm_source=docs&utm_medium=docs&utm_campaign=talk-to-the-optimism-team">
+  Tell us what you're building. We'll help you scope the right setup before you write a line of code.
 </Card>


### PR DESCRIPTION
## Description

Refines the three "Talk to the Optimism team" OP Enterprise CTAs added in #21081 (chain operators landing page, best practices guide, OP Stack introduction) based on feedback from Andrea.

Changes to all three cards:
- **Icon**: `handshake` → `envelope` (email)
- **Copy**: → "Tell us what you're building. We'll help you scope the right setup before you write a line of code."
- **Link**: now points to the canonical `https://www.optimism.io/learn-more` with shared UTM params (`utm_source=docs`, `utm_medium=docs`, `utm_campaign=talk-to-the-optimism-team`) so all inbound is tracked in one place.

## Notes

- UTM → contact association is still being configured in Hubspot (tracked separately); inbound from the Learn More form is already captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)