### PR TITLE
ci: fix contract artifact publish dispatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
               # API triggers: dispatch flags select workflows
               api)
                 run release
-                if is_true main_dispatch && [[ "$(param github-event-type)" == "__not_set__" ]]; then
+                if is_true main_dispatch && ! is_true publish_contract_artifacts_dispatch && [[ "$(param github-event-type)" == "__not_set__" ]]; then
                   run main contracts_feature_tests
                 fi
                 if is_true fault_proofs_dispatch;     then run develop_fault_proofs; fi

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -26,6 +26,17 @@ parameters:
   c-publish_contract_artifacts_ref:
     type: string
     default: ""
+  # CircleCI forwards user-supplied setup params into continuation validation.
+  # These aliases are transformed into the c-* params above by config.yml.
+  main_dispatch:
+    type: boolean
+    default: true
+  publish_contract_artifacts_dispatch:
+    type: boolean
+    default: false
+  publish_contract_artifacts_ref:
+    type: string
+    default: ""
   # Workflow activation flags (set by the decision tree in config.yml)
   c-run_main:
     type: boolean

--- a/.circleci/scripts/test-decision-tree.sh
+++ b/.circleci/scripts/test-decision-tree.sh
@@ -190,7 +190,7 @@ run_scenario \
 run_scenario \
   "API: publish_contract_artifacts_dispatch" \
   "api" "" "" "" \
-  '{"c-main_dispatch": false, "c-publish_contract_artifacts_dispatch": true, "c-github-event-type": "__not_set__"}' \
+  '{"c-main_dispatch": true, "c-publish_contract_artifacts_dispatch": true, "c-github-event-type": "__not_set__"}' \
   release publish_contract_artifacts
 
 run_scenario \

--- a/packages/contracts-bedrock/scripts/ops/publish-artifacts.sh
+++ b/packages/contracts-bedrock/scripts/ops/publish-artifacts.sh
@@ -44,16 +44,21 @@ if [ "${1:-}" = "--force" ] || [ "${1:-}" = "-f" ]; then
 fi
 
 checksum=$(bash "$CONTRACTS_DIR/scripts/ops/calculate-checksum.sh")
+commit=$(git -C "$ROOT_DIR" rev-parse HEAD)
 
 archive_name_zst="artifacts-v1-$checksum.tar.zst"
+commit_archive_name_zst="artifacts-v1-$commit.tar.zst"
 upload_url_zst="$BUCKET_URL/$archive_name_zst"
+commit_upload_url_zst="$BUCKET_URL/$commit_archive_name_zst"
 
 echoerr "> Checksum: $checksum"
+echoerr "> Commit: $commit"
 echoerr "> Checking for existing artifacts..."
 
 exists_zst=$(curl -s -o /dev/null --fail -LI "$upload_url_zst" || echo "fail")
-if [ "$exists_zst" != "fail" ] && [ "$FORCE" = false ]; then
-  echoerr "> Existing artifacts found (.tar.zst), nothing to do. Use --force to overwrite."
+commit_exists_zst=$(curl -s -o /dev/null --fail -LI "$commit_upload_url_zst" || echo "fail")
+if [ "$exists_zst" != "fail" ] && [ "$commit_exists_zst" != "fail" ] && [ "$FORCE" = false ]; then
+  echoerr "> Existing checksum and commit artifacts found (.tar.zst), nothing to do. Use --force to overwrite."
   exit 0
 fi
 
@@ -87,6 +92,10 @@ gcloud config set storage/parallel_composite_upload_enabled False
 
 gcloud --verbosity="info" storage cp "$TEMP_DIR/$archive_name_zst" "gs://$DEPLOY_BUCKET/$archive_name_zst"
 echoerr "> Uploaded to: $upload_url_zst"
+
+echoerr "> Uploading commit-addressed artifact..."
+gcloud --verbosity="info" storage cp "$TEMP_DIR/$archive_name_zst" "gs://$DEPLOY_BUCKET/$commit_archive_name_zst"
+echoerr "> Uploaded to: $commit_upload_url_zst"
 
 echoerr "> Uploading as 'latest' for PR fallback..."
 gcloud --verbosity="info" storage cp "gs://$DEPLOY_BUCKET/$archive_name_zst" "gs://$DEPLOY_BUCKET/artifacts-v1-latest.tar.zst"


### PR DESCRIPTION
## Summary
- keep the human-readable manual publish params in setup config
- suppress the default manual `main` workflow when publish dispatch is requested
- declare `main_dispatch`, `publish_contract_artifacts_dispatch`, and `publish_contract_artifacts_ref` in continuation so CircleCI accepts user-supplied setup params after dynamic config continuation
- upload commit-addressed contract artifact archives in addition to checksum-addressed and `latest`

## Why
Manual pipeline `a3490fbc-7ffa-48e8-8b26-dab71fa6ebb1` failed continuation validation with `Unexpected argument(s)` for user-supplied setup params. A follow-up test using direct `c-*` params (`539ddb46-bedb-4c06-926d-b8fccccf966b`) failed with `Conflicting pipeline parameters`, because those names are both setup and continuation params. This PR keeps the UI names as setup aliases and transforms them into the real `c-*` continuation params.

Pipeline `05e56ab6-58b6-4e1d-af4d-a8cd24e0c22e` proved setup/continuation/ref checkout/zstd/build work, but failed GCS upload from the PR branch due to service-account impersonation policy. The successful develop publish job from #21140 also showed the current script only uploaded checksum/latest artifacts, while op-deployer git sources need commit-addressed archives.

## Validation
- `bash .circleci/scripts/test-decision-tree.sh`
- `circleci config validate .circleci/config.yml`
- `shellcheck packages/contracts-bedrock/scripts/ops/publish-artifacts.sh`
- `git diff --check`
- merged continuation config declares `main_dispatch`, `publish_contract_artifacts_dispatch`, `publish_contract_artifacts_ref`, `c-run_publish_contract_artifacts`, and `c-publish_contract_artifacts_ref`