### PR TITLE
fix(op-chain-ops): support proving withdrawals with super roots

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
@@ -2,10 +2,14 @@ package withdrawal
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	ps "github.com/ethereum-optimism/optimism/op-proposer/proposer"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,4 +57,35 @@ func TestSuperRootWithdrawal(gt *testing.T) {
 		Sub(withdrawal.FinalizeGasCost()).
 		// Plus received withdrawal amount
 		Add(withdrawalAmount))
+}
+
+func TestProveWithdrawalParametersFaultProofsSuperRoot(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSimpleInterop(t,
+		presets.WithTimeTravelEnabled(),
+		presets.WithProposerOption(func(_ sysgo.ComponentTarget, cfg *ps.CLIConfig) {
+			cfg.PollInterval = 100 * time.Millisecond
+			cfg.ProposalInterval = time.Second
+			cfg.AllowNonFinalized = true
+		}),
+	)
+	sys.L1Network.WaitForOnline()
+
+	initialL1Balance := eth.HalfEther
+	depositAmount := eth.OneThirdEther
+	withdrawalAmount := eth.OneTenthEther
+
+	l1User := sys.FunderL1.NewFundedEOA(initialL1Balance)
+	l2User := l1User.AsEL(sys.L2ELA)
+
+	bridge := sys.StandardBridge(sys.L2ChainA)
+	require.True(t, bridge.UsesSuperRoots(), "Expected interop system to be using super roots")
+
+	bridge.Deposit(depositAmount, l1User)
+	sys.L2ChainA.WaitForBlock()
+
+	withdrawal := bridge.InitiateWithdrawal(withdrawalAmount, l2User)
+	params := withdrawal.FaultProofProveParams(sys.AdvanceTime)
+	proveReceipt := bridge.ProveWithFaultProofParams(l1User, params)
+	require.Equal(t, types.ReceiptStatusSuccessful, proveReceipt.Status)
 }

--- a/op-chain-ops/cmd/withdrawal/prove.go
+++ b/op-chain-ops/cmd/withdrawal/prove.go
@@ -87,7 +87,13 @@ func ProveWithdrawal(ctx *cli.Context) error {
 		return fmt.Errorf("failed to bind dispute game factory: %w", err)
 	}
 
-	_, err = wait.ForGamePublished(ctx.Context, l1Client, portalAddr, factoryAddr, rcpt.BlockNumber)
+	head, err := l2Client.HeaderByHash(ctx.Context, rcpt.BlockHash)
+	if err != nil {
+		return fmt.Errorf("failed to get block header for tx receipt: %w", err)
+	}
+	l2BlockTimestamp := head.Time
+
+	_, err = wait.ForGamePublished(ctx.Context, l1Client, portalAddr, factoryAddr, rcpt.BlockNumber, l2BlockTimestamp)
 	if err != nil {
 		return fmt.Errorf("could not find a dispute game at or above l2 block number %v: %w", rcpt.BlockNumber, err)
 	}

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
@@ -12,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	nodebindings "github.com/ethereum-optimism/optimism/op-node/bindings"
+	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
@@ -20,10 +22,13 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/ethclient/gethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/holiman/uint256"
 )
 
@@ -52,6 +57,7 @@ type StandardBridge struct {
 
 	l1Client *L1ELNode
 	l2Client apis.EthClient
+	l2EL     *L2ELNode
 
 	// L1 bridge contract
 	l1StandardBridge bindings.L1StandardBridge
@@ -89,6 +95,7 @@ func NewStandardBridge(t devtest.T, l2Network *L2Network, l1EL *L1ELNode) *Stand
 
 		l1Client:         l1EL,
 		l2Client:         l2Client,
+		l2EL:             l2Network.PrimaryEL(),
 		l1StandardBridge: l1StandardBridge,
 	}
 }
@@ -261,77 +268,145 @@ type disputeGame struct {
 	Address        common.Address
 	L2BlockNumber  uint64
 	SequenceNumber uint64
+	OutputRoot     common.Hash
 	UsesSuperRoots bool
 }
 
-// forGamePublished waits until a game is published on L1 for the given l2BlockNumber
+// forGamePublished waits until the earliest game that covers the given l2BlockNumber is published on L1.
 // Note that the l2 block number is passed even for super games. Conversion to timestamp is done automatically
 // when required by the respected game type
 func (b *StandardBridge) forGamePublished(l2BlockNumber *big.Int) disputeGame {
-	respectedGameType := b.RespectedGameType()
-	l2SequenceNumber := bigs.Uint64Strict(l2BlockNumber)
-	superRootsActive := b.UsesSuperRoots()
-	if superRootsActive {
-		l2SequenceNumber = b.rollupCfg.TimestampForBlock(l2SequenceNumber)
-	}
-
-	var game bindings.DisputeGame
-	var gameSeqNum uint64
-	var gameIndex *big.Int
-	b.require.Eventuallyf(func() bool {
-		var err error
-		game, gameIndex, err = b.findLatestGame(respectedGameType)
-		if err != nil {
-			b.log.Warn("No game of required type found", "err", err)
-			return false
-		}
-		gameContract := bindings.NewBindings[bindings.FaultDisputeGame](
-			bindings.WithClient(b.l1Client.EthClient()),
-			bindings.WithTo(game.Proxy),
-			bindings.WithTest(b.t))
-		seqNum, err := contractio.Read(gameContract.L2SequenceNumber(), b.ctx)
-		b.require.NoError(err, "Failed to read sequence number")
-		gameSeqNum = bigs.Uint64Strict(seqNum)
-		b.log.Info("Found latest game", "index", gameIndex, "seqNum", gameSeqNum)
-		return gameSeqNum >= l2SequenceNumber
-	}, 90*time.Second, 100*time.Millisecond, "did not find a game of type %v at or after l2 sequence number %v", respectedGameType, l2SequenceNumber)
-
-	gameBlockNum := gameSeqNum
-	if superRootsActive {
-		blockNum, err := b.rollupCfg.TargetBlockNumber(gameSeqNum)
-		b.require.NoError(err, "Failed to convert game timestamp to block number")
-		gameBlockNum = blockNum
-	}
-	return disputeGame{
-		Index:          gameIndex,
-		Address:        game.Proxy,
-		L2BlockNumber:  gameBlockNum,
-		SequenceNumber: gameSeqNum,
-		UsesSuperRoots: superRootsActive,
-	}
+	return b.waitForCoveringGames(l2BlockNumber, 1)[0]
 }
 
-// findLatestGame finds the latest game in the DisputeGameFactory contract.
-// Ported from op-node/withdrawals/utils.go to fit in the op-devstack, using op-service ethclient
-func (b *StandardBridge) findLatestGame(gameType uint32) (bindings.DisputeGame, *big.Int, error) {
+func (b *StandardBridge) waitForCoveringGames(l2BlockNumber *big.Int, count int) []disputeGame {
+	b.require.Positive(count, "expected covering game count must be positive")
+
+	respectedGameType := b.RespectedGameType()
+	minSequence := bigs.Uint64Strict(l2BlockNumber)
+	superRootsActive := b.UsesSuperRoots()
+	if superRootsActive {
+		minSequence = b.rollupCfg.TimestampForBlock(minSequence)
+	}
+
+	var games []disputeGame
+	b.require.Eventuallyf(func() bool {
+		var err error
+		games, err = b.findCoveringGames(respectedGameType, new(big.Int).SetUint64(minSequence), superRootsActive)
+		if err != nil {
+			b.log.Warn("No covering game of required type found", "err", err)
+			return false
+		}
+		if len(games) < count {
+			b.log.Info("Waiting for covering games", "found", len(games), "expected", count, "minSequence", minSequence)
+			return false
+		}
+		b.log.Info("Found covering games", "count", len(games), "earliestIndex", games[0].Index, "earliestSeqNum", games[0].SequenceNumber, "earliestBlock", games[0].L2BlockNumber)
+		return true
+	}, 90*time.Second, 100*time.Millisecond, "did not find %d games of type %v at or after l2 sequence number %v", count, respectedGameType, minSequence)
+
+	return games
+}
+
+func (b *StandardBridge) findCoveringGames(gameType uint32, minSequence *big.Int, superRootsActive bool) ([]disputeGame, error) {
 	gameCount, err := contractio.Read(b.disputeGameFactory.GameCount(), b.ctx)
 	b.require.NoError(err, "Failed to read game count")
 	if gameCount.Cmp(common.Big0) == 0 {
-		return bindings.DisputeGame{}, nil, errors.New("no games")
+		return nil, errors.New("no games")
 	}
 
-	gameIdx := new(big.Int).Sub(gameCount, common.Big1)
-	for gameIdx.Cmp(common.Big0) >= 0 {
-		latestGame, err := contractio.Read(b.disputeGameFactory.GameAtIndex(gameIdx), b.ctx)
-		b.require.NoErrorf(err, "Failed to find latest game for %v", gameType)
-		if latestGame.GameType != gameType {
-			// Wrong game type, continue searching backwards
-			gameIdx = new(big.Int).Sub(gameIdx, common.Big1)
-			continue
-		}
-		return latestGame, gameIdx, nil
+	type candidate struct {
+		index      *big.Int
+		sequence   *big.Int
+		outputRoot common.Hash
 	}
-	return bindings.DisputeGame{}, nil, errors.New("no suitable games found")
+	var candidates []candidate
+	l2ChainID := b.rollupCfg.L2ChainID
+	searchStart := new(big.Int).Sub(gameCount, common.Big1)
+	for searchStart.Sign() >= 0 {
+		games, err := contractio.Read(b.disputeGameFactory.FindLatestGames(gameType, searchStart, big.NewInt(32)), b.ctx)
+		b.require.NoErrorf(err, "Failed to find latest games for %v", gameType)
+		if len(games) == 0 {
+			break
+		}
+		for _, game := range games {
+			sequence, outputRoot, ok, err := bridgeGameSequenceAndOutputRoot(game, gameTypes.GameType(gameType), l2ChainID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode game %v: %w", game.Index, err)
+			}
+			if ok && sequence.Cmp(minSequence) >= 0 {
+				candidates = append(candidates, candidate{
+					index:      game.Index,
+					sequence:   sequence,
+					outputRoot: outputRoot,
+				})
+			}
+			searchStart = new(big.Int).Sub(game.Index, common.Big1)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no covering game found for sequence %v", minSequence)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].index.Cmp(candidates[j].index) < 0
+	})
+
+	coveringGames := make([]disputeGame, 0, len(candidates))
+	for _, selected := range candidates {
+		gameAtIndex, err := contractio.Read(b.disputeGameFactory.GameAtIndex(selected.index), b.ctx)
+		b.require.NoErrorf(err, "Failed to get game at index %v", selected.index)
+		gameBlockNum := bigs.Uint64Strict(selected.sequence)
+		if superRootsActive {
+			blockNum, err := b.rollupCfg.TargetBlockNumber(gameBlockNum)
+			b.require.NoError(err, "Failed to convert game timestamp to block number")
+			gameBlockNum = blockNum
+		}
+		coveringGames = append(coveringGames, disputeGame{
+			Index:          selected.index,
+			Address:        gameAtIndex.Proxy,
+			L2BlockNumber:  gameBlockNum,
+			SequenceNumber: bigs.Uint64Strict(selected.sequence),
+			OutputRoot:     selected.outputRoot,
+			UsesSuperRoots: superRootsActive,
+		})
+	}
+	return coveringGames, nil
+}
+
+func bridgeGameSequenceAndOutputRoot(game bindings.GameSearchResult, gameType gameTypes.GameType, l2ChainID *big.Int) (*big.Int, common.Hash, bool, error) {
+	switch gameType {
+	case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+		if len(game.ExtraData) < 32 {
+			return nil, common.Hash{}, false, fmt.Errorf("legacy game extra data is %d bytes, need at least 32", len(game.ExtraData))
+		}
+		return new(big.Int).SetBytes(game.ExtraData[:32]), game.RootClaim, true, nil
+	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+		return bridgeSuperRootChainOutput(game.ExtraData, l2ChainID)
+	default:
+		return nil, common.Hash{}, false, fmt.Errorf("unsupported game type: %v", gameType)
+	}
+}
+
+func bridgeSuperRootChainOutput(extraData []byte, l2ChainID *big.Int) (*big.Int, common.Hash, bool, error) {
+	if l2ChainID == nil {
+		return nil, common.Hash{}, false, errors.New("l2 chain id is required for super root games")
+	}
+	super, err := eth.UnmarshalSuperRoot(extraData)
+	if err != nil {
+		return nil, common.Hash{}, false, fmt.Errorf("failed to decode super root: %w", err)
+	}
+	superV1, ok := super.(*eth.SuperV1)
+	if !ok {
+		return nil, common.Hash{}, false, fmt.Errorf("unsupported super root type %T", super)
+	}
+	targetChainID := eth.ChainIDFromBig(l2ChainID)
+	sequence := new(big.Int).SetUint64(superV1.Timestamp)
+	for _, chain := range superV1.Chains {
+		if chain.ChainID.Cmp(targetChainID) == 0 {
+			return sequence, common.Hash(chain.Output), true, nil
+		}
+	}
+	return sequence, common.Hash{}, false, nil
 }
 
 type Withdrawal struct {
@@ -360,6 +435,10 @@ func (w *Withdrawal) FinalizeGasCost() eth.ETH {
 
 func (w *Withdrawal) InitiateBlockHash() common.Hash {
 	return w.initReceipt.BlockHash
+}
+
+func (w *Withdrawal) InitiateTxHash() common.Hash {
+	return w.initReceipt.TxHash
 }
 
 func (w *Withdrawal) Prove(user *EOA) {
@@ -415,6 +494,104 @@ func (w *Withdrawal) Prove(user *EOA) {
 	}, 30*time.Second, 1*time.Second, "Sending prove transaction")
 }
 
+func (w *Withdrawal) FaultProofProveParams(advanceTime ...func(time.Duration)) withdrawals.ProvenWithdrawalParameters {
+	var params withdrawals.ProvenWithdrawalParameters
+	var lastErr error
+	w.require.Eventuallyf(func() bool {
+		params, lastErr = w.bridge.faultProofProveParams(w)
+		if lastErr == nil {
+			return true
+		}
+		w.log.Warn("Failed to build fault proof withdrawal parameters", "err", lastErr)
+		if len(advanceTime) != 0 {
+			advanceTime[0](2 * time.Second)
+		}
+		return false
+	}, 90*time.Second, time.Second, "failed to build fault proof withdrawal parameters")
+	return params
+}
+
+func (b *StandardBridge) faultProofProveParams(withdrawal *Withdrawal) (withdrawals.ProvenWithdrawalParameters, error) {
+	l1Client, err := ethclient.DialContext(b.ctx, b.l1Client.Escape().UserRPC())
+	if err != nil {
+		return withdrawals.ProvenWithdrawalParameters{}, fmt.Errorf("failed to dial L1 RPC: %w", err)
+	}
+	defer l1Client.Close()
+
+	l2RPC, err := rpc.DialContext(b.ctx, b.l2EL.Escape().UserRPC())
+	if err != nil {
+		return withdrawals.ProvenWithdrawalParameters{}, fmt.Errorf("failed to dial L2 RPC: %w", err)
+	}
+	defer l2RPC.Close()
+
+	proofClient := gethclient.New(l2RPC)
+	l2Client := ethclient.NewClient(l2RPC)
+	defer l2Client.Close()
+
+	portal, err := bindingspreview.NewOptimismPortal2(b.l1PortalAddr, l1Client)
+	if err != nil {
+		return withdrawals.ProvenWithdrawalParameters{}, fmt.Errorf("failed to bind OptimismPortal2: %w", err)
+	}
+	factoryAddr, err := portal.DisputeGameFactory(&bind.CallOpts{Context: b.ctx})
+	if err != nil {
+		return withdrawals.ProvenWithdrawalParameters{}, fmt.Errorf("failed to read dispute game factory: %w", err)
+	}
+	factory, err := nodebindings.NewDisputeGameFactoryCaller(factoryAddr, l1Client)
+	if err != nil {
+		return withdrawals.ProvenWithdrawalParameters{}, fmt.Errorf("failed to bind dispute game factory: %w", err)
+	}
+
+	params, err := withdrawals.ProveWithdrawalParametersFaultProofs(
+		b.ctx,
+		proofClient,
+		l2Client,
+		l2Client,
+		withdrawal.InitiateTxHash(),
+		factory,
+		&portal.OptimismPortal2Caller,
+	)
+	if err != nil {
+		return withdrawals.ProvenWithdrawalParameters{}, err
+	}
+	return params, nil
+}
+
+func (b *StandardBridge) ProveWithFaultProofParams(user *EOA, params withdrawals.ProvenWithdrawalParameters) *types.Receipt {
+	gameInfo, err := contractio.Read(b.disputeGameFactory.GameAtIndex(params.L2OutputIndex), b.ctx)
+	b.require.NoErrorf(err, "failed to read dispute game %v", params.L2OutputIndex)
+	b.require.Eventuallyf(func() bool {
+		head, err := b.l1Client.EthClient().InfoByLabel(b.ctx, eth.Unsafe)
+		return err == nil && head.Time() > gameInfo.Timestamp
+	}, 60*time.Second, 500*time.Millisecond, "L1 head did not advance past dispute game createdAt %d", gameInfo.Timestamp)
+
+	tx := bindings.WithdrawalTransaction{
+		Nonce:    params.Nonce,
+		Sender:   params.Sender,
+		Target:   params.Target,
+		Value:    params.Value,
+		GasLimit: params.GasLimit,
+		Data:     params.Data,
+	}
+	proof := bindings.OutputRootProof{
+		Version:                  params.OutputRootProof.Version,
+		StateRoot:                params.OutputRootProof.StateRoot,
+		MessagePasserStorageRoot: params.OutputRootProof.MessagePasserStorageRoot,
+		LatestBlockhash:          params.OutputRootProof.LatestBlockhash,
+	}
+	call := b.l1Portal.ProveWithdrawalTransaction(tx, params.L2OutputIndex, proof, params.WithdrawalProof)
+	var receipt *types.Receipt
+	b.require.Eventually(func() bool {
+		receipt, err = contractio.Write(call, b.ctx, user.Plan())
+		if err != nil {
+			b.log.Error("Failed to send prove transaction", "err", err)
+			return false
+		}
+		return true
+	}, 30*time.Second, time.Second, "Sending prove transaction with fault proof params")
+	b.require.Equal(types.ReceiptStatusSuccessful, receipt.Status, "prove withdrawal was not successful")
+	return receipt
+}
+
 // ProveWithdrawalParameters calls ProveWithdrawalParametersForBlock with the most recent L2 output after the latest game.
 // Ported from op-node/withdrawals/utils.go to fit in the op-devstack
 func (w *Withdrawal) proveWithdrawalParameters() ProvenWithdrawalParameters {
@@ -461,7 +638,7 @@ func (w *Withdrawal) proveWithdrawalParametersForEvent(ev *nodebindings.L2ToL1Me
 		trieNodes[i] = s
 	}
 
-	return ProvenWithdrawalParameters{
+	params := ProvenWithdrawalParameters{
 		Nonce:              ev.Nonce,
 		Sender:             ev.Sender,
 		Target:             ev.Target,
@@ -478,6 +655,14 @@ func (w *Withdrawal) proveWithdrawalParametersForEvent(ev *nodebindings.L2ToL1Me
 		},
 		WithdrawalProof: trieNodes,
 	}
+	outputRoot := eth.OutputRoot(&eth.OutputV0{
+		StateRoot:                eth.Bytes32(params.OutputRootProof.StateRoot),
+		MessagePasserStorageRoot: eth.Bytes32(params.OutputRootProof.MessagePasserStorageRoot),
+		BlockHash:                common.Hash(params.OutputRootProof.LatestBlockhash),
+	})
+	w.require.Equalf(disputeGame.OutputRoot, common.Hash(outputRoot),
+		"computed output root must match dispute game root claim for game index %v", disputeGame.Index)
+	return params
 }
 
 // Ported from op-node/withdrawals/proof.go to fit in the op-devstack, using op-service proof types

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -155,6 +155,7 @@ const singleSupernodeWithSyncTesterPresetSupportedOptionKinds = optionKindDeploy
 
 const supernodeProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindBatcher |
+	optionKindProposer |
 	optionKindL1EL |
 	optionKindTimeTravel |
 	optionKindMessageExpiryWindow |

--- a/op-e2e/e2eutils/wait/withdrawals.go
+++ b/op-e2e/e2eutils/wait/withdrawals.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
@@ -17,10 +18,11 @@ import (
 )
 
 // ForGamePublished waits until a game is published on L1 for the given l2BlockNumber.
-func ForGamePublished(ctx context.Context, client *ethclient.Client, optimismPortalAddr common.Address, disputeGameFactoryAddr common.Address, l2BlockNumber *big.Int) (uint64, error) {
+func ForGamePublished(ctx context.Context, client *ethclient.Client, optimismPortalAddr common.Address, disputeGameFactoryAddr common.Address, l2BlockNumber *big.Int, l2BlockTimestamp uint64) (uint64, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 	l2BlockNumber = new(big.Int).Set(l2BlockNumber) // Don't clobber caller owned l2BlockNumber
+	l2SequenceNumber := l2BlockTimestamp
 
 	optimismPortal2Contract, err := bindingspreview.NewOptimismPortal2Caller(optimismPortalAddr, client)
 	if err != nil {
@@ -32,17 +34,37 @@ func ForGamePublished(ctx context.Context, client *ethclient.Client, optimismPor
 		return 0, err
 	}
 
+	respectedGameType, err := optimismPortal2Contract.RespectedGameType(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get respected game type: %w", err)
+	}
+
 	getL2BlockFromLatestGame := func() (*big.Int, error) {
-		latestGame, err := withdrawals.FindLatestGame(ctx, disputeGameFactoryContract, optimismPortal2Contract)
+		latestGame, err := withdrawals.FindLatestGameForGameType(ctx, disputeGameFactoryContract, respectedGameType)
 		if err != nil {
 			return big.NewInt(-1), nil
 		}
 
-		gameBlockNumber := new(big.Int).SetBytes(latestGame.ExtraData[0:32])
-		return gameBlockNumber, nil
+		var gameSequenceNumber *big.Int
+		switch gameTypes.GameType(respectedGameType) {
+		case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+			gameSequenceNumber = new(big.Int).SetBytes(latestGame.ExtraData[0:32])
+		case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+			gameSequenceNumber = new(big.Int).SetBytes(latestGame.ExtraData[1:9])
+		default:
+			return nil, fmt.Errorf("unsupported game type: %v", respectedGameType)
+		}
+		return gameSequenceNumber, nil
 	}
-	outputBlockNum, err := AndGet(ctx, time.Second, getL2BlockFromLatestGame, func(latest *big.Int) bool {
-		return latest.Cmp(l2BlockNumber) >= 0
+	outputBlockNum, err := AndGet(ctx, time.Second, getL2BlockFromLatestGame, func(latestSeqnum *big.Int) bool {
+		switch gameTypes.GameType(respectedGameType) {
+		case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+			return latestSeqnum.Cmp(l2BlockNumber) >= 0
+		case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+			return bigs.Uint64Strict(latestSeqnum) >= l2SequenceNumber
+		default:
+			panic("unreachable") // given above predicate asserting unsupported games return errors
+		}
 	})
 	if err != nil {
 		return 0, err

--- a/op-e2e/e2eutils/wait/withdrawals.go
+++ b/op-e2e/e2eutils/wait/withdrawals.go
@@ -47,7 +47,7 @@ func ForGamePublished(ctx context.Context, client *ethclient.Client, optimismPor
 
 		var gameSequenceNumber *big.Int
 		switch gameTypes.GameType(respectedGameType) {
-		case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+		case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType, gameTypes.FastGameType:
 			gameSequenceNumber = new(big.Int).SetBytes(latestGame.ExtraData[0:32])
 		case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 			gameSequenceNumber = new(big.Int).SetBytes(latestGame.ExtraData[1:9])
@@ -58,7 +58,7 @@ func ForGamePublished(ctx context.Context, client *ethclient.Client, optimismPor
 	}
 	outputBlockNum, err := AndGet(ctx, time.Second, getL2BlockFromLatestGame, func(latestSeqnum *big.Int) bool {
 		switch gameTypes.GameType(respectedGameType) {
-		case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+		case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType, gameTypes.FastGameType:
 			return latestSeqnum.Cmp(l2BlockNumber) >= 0
 		case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 			return bigs.Uint64Strict(latestSeqnum) >= l2SequenceNumber

--- a/op-e2e/system/bridge/validity_test.go
+++ b/op-e2e/system/bridge/validity_test.go
@@ -417,7 +417,7 @@ func testMixedWithdrawalValidity(t *testing.T, allocType config.AllocType) {
 			transactor.ExpectedL2Nonce = transactor.ExpectedL2Nonce + 1
 
 			// Wait for the finalization period, then we can finalize this withdrawal.
-			_, err = wait.ForGamePublished(ctx, l1Client, cfg.L1Deployments.OptimismPortalProxy, cfg.L1Deployments.DisputeGameFactoryProxy, receipt.BlockNumber)
+			_, err = wait.ForGamePublished(ctx, l1Client, cfg.L1Deployments.OptimismPortalProxy, cfg.L1Deployments.DisputeGameFactoryProxy, receipt.BlockNumber, header.Time)
 			require.Nil(t, err)
 
 			rpcClient, err := rpc.Dial(sys.EthInstances["verifier"].UserRPC().RPC())

--- a/op-e2e/system/helpers/withdrawal_helper.go
+++ b/op-e2e/system/helpers/withdrawal_helper.go
@@ -116,9 +116,13 @@ func ProveWithdrawal(t *testing.T, cfg e2esys.SystemConfig, clients ClientProvid
 	allocType := cfg.AllocType
 
 	l1Client := clients.NodeClient(e2esys.RoleL1)
-	var err error
 	l1Deployments := config.L1Deployments(allocType)
-	_, err = wait.ForGamePublished(ctx, l1Client, l1Deployments.OptimismPortalProxy, l1Deployments.DisputeGameFactoryProxy, l2WithdrawalReceipt.BlockNumber)
+
+	head, err := clients.NodeClient(e2esys.RoleSeq).HeaderByHash(ctx, l2WithdrawalReceipt.BlockHash)
+	require.NoError(t, err)
+	withdrawalTimestamp := head.Time
+
+	_, err = wait.ForGamePublished(ctx, l1Client, l1Deployments.OptimismPortalProxy, l1Deployments.DisputeGameFactoryProxy, l2WithdrawalReceipt.BlockNumber, withdrawalTimestamp)
 	require.NoError(t, err)
 
 	// Wait for another block to be mined so that the timestamp increases. Otherwise,

--- a/op-node/withdrawals/utils.go
+++ b/op-node/withdrawals/utils.go
@@ -137,7 +137,7 @@ func ProveWithdrawalParametersFaultProofs(ctx context.Context, proofCl ProofClie
 	var minSequence *big.Int
 	var l2ChainID *big.Int
 	switch respectedGame {
-	case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+	case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType, gameTypes.FastGameType:
 		minSequence = new(big.Int).Set(receipt.BlockNumber)
 	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		minSequence = new(big.Int).SetUint64(withdrawalHeader.Time)
@@ -183,7 +183,7 @@ func chainID(ctx context.Context, clients ...any) (*big.Int, error) {
 
 func l2HeaderForGame(ctx context.Context, l2HeaderCl HeaderClient, gameType gameTypes.GameType, sequence *big.Int) (*types.Header, error) {
 	switch gameType {
-	case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+	case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType, gameTypes.FastGameType:
 		header, err := l2HeaderCl.HeaderByNumber(ctx, sequence)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get l2 header %v: %w", sequence, err)
@@ -247,7 +247,7 @@ func findLatestWithdrawalGameCandidate(ctx context.Context, disputeGameFactoryCo
 
 func gameSequenceAndOutputRoot(game bindings.IDisputeGameFactoryGameSearchResult, gameType gameTypes.GameType, l2ChainID *big.Int) (*big.Int, common.Hash, bool, error) {
 	switch gameType {
-	case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+	case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType, gameTypes.FastGameType:
 		if len(game.ExtraData) < 32 {
 			return nil, common.Hash{}, false, fmt.Errorf("legacy game extra data is %d bytes, need at least 32", len(game.ExtraData))
 		}

--- a/op-node/withdrawals/utils.go
+++ b/op-node/withdrawals/utils.go
@@ -14,9 +14,13 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 var MessagePassedTopic = crypto.Keccak256Hash([]byte("MessagePassed(uint256,address,address,uint256,uint256,bytes,bytes32)"))
@@ -33,6 +37,64 @@ type HeaderClient interface {
 	HeaderByNumber(context.Context, *big.Int) (*types.Header, error)
 }
 
+type ChainIDClient interface {
+	ChainID(context.Context) (*big.Int, error)
+}
+
+// FindL2HeaderForTimestamp finds the highest L2 block header with a timestamp at or before targetTimestamp.
+func FindL2HeaderForTimestamp(ctx context.Context, l2HeaderCl HeaderClient, targetTimestamp uint64) (*types.Header, error) {
+	latestHeader, err := l2HeaderCl.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest l2 header: %w", err)
+	}
+	if latestHeader == nil {
+		return nil, errors.New("latest l2 header was nil")
+	}
+	if !latestHeader.Number.IsUint64() {
+		return nil, fmt.Errorf("latest l2 block number does not fit in uint64: %v", latestHeader.Number)
+	}
+	if latestHeader.Time < targetTimestamp {
+		return nil, fmt.Errorf("latest l2 header timestamp %d is before target timestamp %d", latestHeader.Time, targetTimestamp)
+	}
+
+	var result *types.Header
+	low := uint64(0)
+	high := bigs.Uint64Strict(latestHeader.Number)
+	for low <= high {
+		mid := low + (high-low)/2
+		header, err := l2HeaderCl.HeaderByNumber(ctx, new(big.Int).SetUint64(mid))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get l2 header %d: %w", mid, err)
+		}
+		if header == nil {
+			return nil, fmt.Errorf("l2 header %d was nil", mid)
+		}
+
+		if header.Time <= targetTimestamp {
+			result = header
+			if mid == high {
+				break
+			}
+			low = mid + 1
+			continue
+		}
+		if mid == 0 {
+			break
+		}
+		high = mid - 1
+	}
+	if result == nil {
+		return nil, fmt.Errorf("no l2 header found at or before target timestamp %d", targetTimestamp)
+	}
+	return result, nil
+}
+
+type withdrawalGameCandidate struct {
+	Game       bindings.IDisputeGameFactoryGameSearchResult
+	Sequence   *big.Int
+	OutputRoot common.Hash
+}
+
 // ProvenWithdrawalParameters is the set of parameters to pass to the ProveWithdrawalTransaction
 // and FinalizeWithdrawalTransaction functions
 type ProvenWithdrawalParameters struct {
@@ -47,21 +109,177 @@ type ProvenWithdrawalParameters struct {
 	WithdrawalProof [][]byte // List of trie nodes to prove L2 storage
 }
 
-// ProveWithdrawalParametersFaultProofs calls ProveWithdrawalParametersForBlock with the most recent L2 output after the latest game.
+// ProveWithdrawalParametersFaultProofs generates withdrawal proof parameters using the latest
+// dispute game that covers the withdrawal transaction's L2 block.
 func ProveWithdrawalParametersFaultProofs(ctx context.Context, proofCl ProofClient, l2ReceiptCl ReceiptClient, l2HeaderCl HeaderClient, txHash common.Hash, disputeGameFactoryContract *bindings.DisputeGameFactoryCaller, optimismPortal2Contract *bindingspreview.OptimismPortal2Caller) (ProvenWithdrawalParameters, error) {
-	latestGame, err := FindLatestGame(ctx, disputeGameFactoryContract, optimismPortal2Contract)
+	respectedGameType, err := optimismPortal2Contract.RespectedGameType(&bind.CallOpts{})
 	if err != nil {
-		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to find latest game: %w", err)
+		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to get respected game type: %w", err)
 	}
 
-	l2BlockNumber := new(big.Int).SetBytes(latestGame.ExtraData[0:32])
-	l2OutputIndex := latestGame.Index
-	// Fetch the block header from the L2 node
-	l2Header, err := l2HeaderCl.HeaderByNumber(ctx, l2BlockNumber)
+	receipt, err := l2ReceiptCl.TransactionReceipt(ctx, txHash)
 	if err != nil {
-		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to get l2Block: %w", err)
+		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to get transaction receipt: %w", err)
 	}
-	return ProveWithdrawalParametersForBlock(ctx, proofCl, l2ReceiptCl, txHash, l2Header, l2OutputIndex)
+	ev, err := ParseMessagePassed(receipt)
+	if err != nil {
+		return ProvenWithdrawalParameters{}, err
+	}
+	withdrawalHeader, err := l2HeaderCl.HeaderByNumber(ctx, receipt.BlockNumber)
+	if err != nil {
+		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to get withdrawal l2 header: %w", err)
+	}
+	if withdrawalHeader == nil {
+		return ProvenWithdrawalParameters{}, errors.New("withdrawal l2 header was nil")
+	}
+
+	respectedGame := gameTypes.GameType(respectedGameType)
+	var minSequence *big.Int
+	var l2ChainID *big.Int
+	switch respectedGame {
+	case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+		minSequence = new(big.Int).Set(receipt.BlockNumber)
+	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+		minSequence = new(big.Int).SetUint64(withdrawalHeader.Time)
+		l2ChainID, err = chainID(ctx, l2ReceiptCl, l2HeaderCl)
+		if err != nil {
+			return ProvenWithdrawalParameters{}, fmt.Errorf("failed to get l2 chain id: %w", err)
+		}
+	default:
+		return ProvenWithdrawalParameters{}, fmt.Errorf("unsupported game type: %v", respectedGameType)
+	}
+
+	candidate, err := findLatestWithdrawalGameCandidate(ctx, disputeGameFactoryContract, respectedGame, minSequence, l2ChainID)
+	if err != nil {
+		return ProvenWithdrawalParameters{}, err
+	}
+
+	l2Header, err := l2HeaderForGame(ctx, l2HeaderCl, respectedGame, candidate.Sequence)
+	if err != nil {
+		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to get l2 header for dispute game %v: %w", candidate.Game.Index, err)
+	}
+	params, err := ProveWithdrawalParametersForEvent(ctx, proofCl, ev, l2Header, candidate.Game.Index)
+	if err != nil {
+		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to create proof for dispute game %v: %w", candidate.Game.Index, err)
+	}
+	provenOutputRoot, err := rollup.ComputeL2OutputRoot(&params.OutputRootProof)
+	if err != nil {
+		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to compute output root for dispute game %v: %w", candidate.Game.Index, err)
+	}
+	if common.Hash(provenOutputRoot) != candidate.OutputRoot {
+		return ProvenWithdrawalParameters{}, fmt.Errorf("dispute game %v output root mismatch: expected %s, got %s", candidate.Game.Index, candidate.OutputRoot, common.Hash(provenOutputRoot))
+	}
+	return params, nil
+}
+
+func chainID(ctx context.Context, clients ...any) (*big.Int, error) {
+	for _, cl := range clients {
+		if chainIDCl, ok := cl.(ChainIDClient); ok {
+			return chainIDCl.ChainID(ctx)
+		}
+	}
+	return nil, errors.New("l2 client does not support ChainID")
+}
+
+func l2HeaderForGame(ctx context.Context, l2HeaderCl HeaderClient, gameType gameTypes.GameType, sequence *big.Int) (*types.Header, error) {
+	switch gameType {
+	case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+		header, err := l2HeaderCl.HeaderByNumber(ctx, sequence)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get l2 header %v: %w", sequence, err)
+		}
+		if header == nil {
+			return nil, fmt.Errorf("l2 header %v was nil", sequence)
+		}
+		return header, nil
+	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+		if !sequence.IsUint64() {
+			return nil, fmt.Errorf("l2 sequence number does not fit in uint64: %v", sequence)
+		}
+		header, err := FindL2HeaderForTimestamp(ctx, l2HeaderCl, bigs.Uint64Strict(sequence))
+		if err != nil {
+			return nil, fmt.Errorf("failed to find l2 header for timestamp %v: %w", sequence, err)
+		}
+		return header, nil
+	default:
+		return nil, fmt.Errorf("unsupported game type: %v", gameType)
+	}
+}
+
+// findLatestWithdrawalGameCandidate walks backwards through currently published games and returns
+// the first game that covers the withdrawal sequence.
+func findLatestWithdrawalGameCandidate(ctx context.Context, disputeGameFactoryContract *bindings.DisputeGameFactoryCaller, gameType gameTypes.GameType, minSequence *big.Int, l2ChainID *big.Int) (withdrawalGameCandidate, error) {
+	gameCount, err := disputeGameFactoryContract.GameCount(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return withdrawalGameCandidate{}, fmt.Errorf("failed to get game count: %w", err)
+	}
+	if gameCount.Cmp(common.Big0) == 0 {
+		return withdrawalGameCandidate{}, errors.New("no games")
+	}
+
+	searchStart := new(big.Int).Sub(gameCount, common.Big1)
+	batchSize := big.NewInt(32)
+	for searchStart.Sign() >= 0 {
+		games, err := disputeGameFactoryContract.FindLatestGames(&bind.CallOpts{Context: ctx}, uint32(gameType), searchStart, batchSize)
+		if err != nil {
+			return withdrawalGameCandidate{}, fmt.Errorf("failed to get latest games: %w", err)
+		}
+		if len(games) == 0 {
+			break
+		}
+		for _, game := range games {
+			sequence, outputRoot, ok, err := gameSequenceAndOutputRoot(game, gameType, l2ChainID)
+			if err != nil {
+				return withdrawalGameCandidate{}, fmt.Errorf("failed to decode game %v: %w", game.Index, err)
+			}
+			if ok && sequence.Cmp(minSequence) >= 0 {
+				return withdrawalGameCandidate{
+					Game:       game,
+					Sequence:   sequence,
+					OutputRoot: outputRoot,
+				}, nil
+			}
+			searchStart = new(big.Int).Sub(game.Index, common.Big1)
+		}
+	}
+	return withdrawalGameCandidate{}, fmt.Errorf("no dispute game covers withdrawal sequence %v", minSequence)
+}
+
+func gameSequenceAndOutputRoot(game bindings.IDisputeGameFactoryGameSearchResult, gameType gameTypes.GameType, l2ChainID *big.Int) (*big.Int, common.Hash, bool, error) {
+	switch gameType {
+	case gameTypes.CannonKonaGameType, gameTypes.CannonGameType, gameTypes.PermissionedGameType:
+		if len(game.ExtraData) < 32 {
+			return nil, common.Hash{}, false, fmt.Errorf("legacy game extra data is %d bytes, need at least 32", len(game.ExtraData))
+		}
+		return new(big.Int).SetBytes(game.ExtraData[:32]), game.RootClaim, true, nil
+	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+		sequence, root, ok, err := superRootChainOutput(game.ExtraData, l2ChainID)
+		return sequence, root, ok, err
+	default:
+		return nil, common.Hash{}, false, fmt.Errorf("unsupported game type: %v", gameType)
+	}
+}
+
+func superRootChainOutput(extraData []byte, l2ChainID *big.Int) (*big.Int, common.Hash, bool, error) {
+	if l2ChainID == nil {
+		return nil, common.Hash{}, false, errors.New("l2 chain id is required for super root games")
+	}
+	super, err := eth.UnmarshalSuperRoot(extraData)
+	if err != nil {
+		return nil, common.Hash{}, false, fmt.Errorf("failed to decode super root: %w", err)
+	}
+	superV1, ok := super.(*eth.SuperV1)
+	if !ok {
+		return nil, common.Hash{}, false, fmt.Errorf("unsupported super root type %T", super)
+	}
+	targetChainID := eth.ChainIDFromBig(l2ChainID)
+	sequence := new(big.Int).SetUint64(superV1.Timestamp)
+	for _, chain := range superV1.Chains {
+		if chain.ChainID.Cmp(targetChainID) == 0 {
+			return sequence, common.Hash(chain.Output), true, nil
+		}
+	}
+	return sequence, common.Hash{}, false, nil
 }
 
 // ProveWithdrawalParametersForBlock queries L1 & L2 to generate all withdrawal parameters and proof necessary to prove a withdrawal on L1.
@@ -107,14 +325,9 @@ func ProveWithdrawalParametersForEvent(ctx context.Context, proofCl ProofClient,
 	}, nil
 }
 
-// FindLatestGame finds the latest game in the DisputeGameFactory contract.
-func FindLatestGame(ctx context.Context, disputeGameFactoryContract *bindings.DisputeGameFactoryCaller, optimismPortal2Contract *bindingspreview.OptimismPortal2Caller) (*bindings.IDisputeGameFactoryGameSearchResult, error) {
-	respectedGameType, err := optimismPortal2Contract.RespectedGameType(&bind.CallOpts{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get respected game type: %w", err)
-	}
-
-	gameCount, err := disputeGameFactoryContract.GameCount(&bind.CallOpts{})
+// FindLatestGame finds the latest game in the DisputeGameFactory contract for the specified game type.
+func FindLatestGameForGameType(ctx context.Context, disputeGameFactoryContract *bindings.DisputeGameFactoryCaller, gameType uint32) (*bindings.IDisputeGameFactoryGameSearchResult, error) {
+	gameCount, err := disputeGameFactoryContract.GameCount(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get game count: %w", err)
 	}
@@ -123,7 +336,7 @@ func FindLatestGame(ctx context.Context, disputeGameFactoryContract *bindings.Di
 	}
 
 	searchStart := new(big.Int).Sub(gameCount, common.Big1)
-	latestGames, err := disputeGameFactoryContract.FindLatestGames(&bind.CallOpts{}, respectedGameType, searchStart, common.Big1)
+	latestGames, err := disputeGameFactoryContract.FindLatestGames(&bind.CallOpts{Context: ctx}, gameType, searchStart, common.Big1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest games: %w", err)
 	}
@@ -133,6 +346,15 @@ func FindLatestGame(ctx context.Context, disputeGameFactoryContract *bindings.Di
 
 	latestGame := latestGames[0]
 	return &latestGame, nil
+}
+
+// FindLatestGame finds the latest game in the DisputeGameFactory contract.
+func FindLatestGame(ctx context.Context, disputeGameFactoryContract *bindings.DisputeGameFactoryCaller, optimismPortal2Contract *bindingspreview.OptimismPortal2Caller) (*bindings.IDisputeGameFactoryGameSearchResult, error) {
+	respectedGameType, err := optimismPortal2Contract.RespectedGameType(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get respected game type: %w", err)
+	}
+	return FindLatestGameForGameType(ctx, disputeGameFactoryContract, respectedGameType)
 }
 
 // Standard ABI types copied from golang ABI tests

--- a/op-node/withdrawals/utils_test.go
+++ b/op-node/withdrawals/utils_test.go
@@ -1,19 +1,154 @@
 package withdrawals
 
 import (
+	"context"
+	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"os"
 	"path"
 	"testing"
 
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-node/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
+
+type testHeaderClient struct {
+	headers []*types.Header
+}
+
+func newTestHeaderClient(timestamps ...uint64) *testHeaderClient {
+	headers := make([]*types.Header, len(timestamps))
+	for i, timestamp := range timestamps {
+		headers[i] = &types.Header{
+			Number: new(big.Int).SetUint64(uint64(i)),
+			Time:   timestamp,
+		}
+	}
+	return &testHeaderClient{headers: headers}
+}
+
+func (c *testHeaderClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	if number == nil {
+		return c.headers[len(c.headers)-1], nil
+	}
+	if !number.IsUint64() {
+		return nil, fmt.Errorf("block number does not fit in uint64: %v", number)
+	}
+	n := bigs.Uint64Strict(number)
+	if n >= uint64(len(c.headers)) {
+		return nil, fmt.Errorf("missing header %d", n)
+	}
+	return c.headers[n], nil
+}
+
+func TestFindL2HeaderForTimestamp(t *testing.T) {
+	ctx := context.Background()
+	client := newTestHeaderClient(10, 12, 14, 16)
+
+	tests := []struct {
+		name            string
+		targetTimestamp uint64
+		expectedNumber  uint64
+	}{
+		{
+			name:            "exact timestamp",
+			targetTimestamp: 14,
+			expectedNumber:  2,
+		},
+		{
+			name:            "between timestamps",
+			targetTimestamp: 15,
+			expectedNumber:  2,
+		},
+		{
+			name:            "genesis timestamp",
+			targetTimestamp: 10,
+			expectedNumber:  0,
+		},
+		{
+			name:            "latest timestamp",
+			targetTimestamp: 16,
+			expectedNumber:  3,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			header, err := FindL2HeaderForTimestamp(ctx, client, test.targetTimestamp)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedNumber, bigs.Uint64Strict(header.Number))
+		})
+	}
+}
+
+func TestFindL2HeaderForTimestampErrors(t *testing.T) {
+	ctx := context.Background()
+	client := newTestHeaderClient(10, 12, 14, 16)
+
+	_, err := FindL2HeaderForTimestamp(ctx, client, 9)
+	require.ErrorContains(t, err, "no l2 header found at or before target timestamp 9")
+
+	_, err = FindL2HeaderForTimestamp(ctx, client, 17)
+	require.ErrorContains(t, err, "latest l2 header timestamp 16 is before target timestamp 17")
+}
+
+func TestGameSequenceAndOutputRoot(t *testing.T) {
+	l2ChainID := big.NewInt(420120092)
+	expectedRoot := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+
+	t.Run("legacy game uses block number and root claim", func(t *testing.T) {
+		game := bindings.IDisputeGameFactoryGameSearchResult{
+			RootClaim: expectedRoot,
+			ExtraData: common.LeftPadBytes(
+				big.NewInt(1234).Bytes(),
+				32,
+			),
+		}
+		sequence, root, ok, err := gameSequenceAndOutputRoot(game, gameTypes.CannonGameType, nil)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, uint64(1234), bigs.Uint64Strict(sequence))
+		require.Equal(t, expectedRoot, root)
+	})
+
+	t.Run("super game uses timestamp and matching chain output", func(t *testing.T) {
+		game := bindings.IDisputeGameFactoryGameSearchResult{
+			ExtraData: superRootExtraData(5678, l2ChainID, expectedRoot),
+		}
+		sequence, root, ok, err := gameSequenceAndOutputRoot(game, gameTypes.SuperCannonKonaGameType, l2ChainID)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, uint64(5678), bigs.Uint64Strict(sequence))
+		require.Equal(t, expectedRoot, root)
+	})
+
+	t.Run("super game without matching chain is not usable", func(t *testing.T) {
+		game := bindings.IDisputeGameFactoryGameSearchResult{
+			ExtraData: superRootExtraData(5678, big.NewInt(11155420), expectedRoot),
+		}
+		sequence, root, ok, err := gameSequenceAndOutputRoot(game, gameTypes.SuperCannonKonaGameType, l2ChainID)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Equal(t, uint64(5678), bigs.Uint64Strict(sequence))
+		require.Equal(t, common.Hash{}, root)
+	})
+}
+
+func superRootExtraData(timestamp uint64, chainID *big.Int, outputRoot common.Hash) []byte {
+	extra := make([]byte, 9+64)
+	extra[0] = 1
+	binary.BigEndian.PutUint64(extra[1:9], timestamp)
+	copy(extra[9:41], common.LeftPadBytes(chainID.Bytes(), 32))
+	copy(extra[41:73], outputRoot[:])
+	return extra
+}
 
 func TestParseMessagePassed(t *testing.T) {
 	tests := []struct {

--- a/op-node/withdrawals/utils_test.go
+++ b/op-node/withdrawals/utils_test.go
@@ -118,6 +118,21 @@ func TestGameSequenceAndOutputRoot(t *testing.T) {
 		require.Equal(t, expectedRoot, root)
 	})
 
+	t.Run("fast game uses block number and root claim", func(t *testing.T) {
+		game := bindings.IDisputeGameFactoryGameSearchResult{
+			RootClaim: expectedRoot,
+			ExtraData: common.LeftPadBytes(
+				big.NewInt(1234).Bytes(),
+				32,
+			),
+		}
+		sequence, root, ok, err := gameSequenceAndOutputRoot(game, gameTypes.FastGameType, nil)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, uint64(1234), bigs.Uint64Strict(sequence))
+		require.Equal(t, expectedRoot, root)
+	})
+
 	t.Run("super game uses timestamp and matching chain output", func(t *testing.T) {
 		game := bindings.IDisputeGameFactoryGameSearchResult{
 			ExtraData: superRootExtraData(5678, l2ChainID, expectedRoot),


### PR DESCRIPTION
This updates the withdrawal prove flow to support super-root dispute games by using the withdrawal’s L2 timestamp, locating the matching L2 header, and selecting the latest usable game that covers the withdrawal. It also adds unit and devstack acceptance coverage for proving super-root withdrawals through the script’s core helper path.

fixes https://github.com/ethereum-optimism/optimism/issues/21113