### PR TITLE
fix(check-karst): Use fixed gas limit for deposit submission

### DIFF
--- a/op-chain-ops/cmd/check-karst/karsttest/checks.go
+++ b/op-chain-ops/cmd/check-karst/karsttest/checks.go
@@ -393,7 +393,7 @@ func CheckEIP7825DepositBypass(
 	// ~depositGasLimit gas on L1. WithGasLimit overrides the estimator.
 	l1Receipt, err := txplan.NewPlannedTx(l1Plan, callPlan,
 		txplan.WithValue(depositAmount),
-		txplan.WithGasLimit(depositGasLimit+1_000_000),
+		txplan.WithGasLimit(2_000_000),
 	).Included.Eval(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("L1 deposit submission: %w", err)


### PR DESCRIPTION
The previous calculation using depositGasLimit+1_000_000 was above the maximum transaction gas limit under EIP-7825. A fixed 2M gas limit is
sufficient for the L1 deposit transaction.
