### PR TITLE
docs: add chain-operator interop opt-in guide

### DIFF
--- a/docs/public-docs/chain-operators/guides/features/interop.mdx
+++ b/docs/public-docs/chain-operators/guides/features/interop.mdx
@@ -98,8 +98,5 @@ Walk through the migration in [Upgrading a chain from output roots to super root
 ## Where to go next
 
 *   Read the [interop explainer](/op-stack/interop/explainer) for how cross-chain messaging and block safety work at the protocol level.
-*   Read the [interop prep notice](/notices/interop-prep) and the [specialized op-node topology notice](/notices/specialized-node-topology) for the node-operator topology your fleet runs.
-*   Read the [op-supernode explainer](/op-stack/interop/supernode) and [supernode configuration guide](/node-operators/guides/configuration/supernode) for the consensus-layer side of interop.
-*   Read the [op-interop-filter page](/chain-operators/tools/op-interop-filter) for sequencer transaction admission.
-*   Follow [Upgrading a chain from output roots to super roots](/chain-operators/tutorials/upgrade-chain-to-super-roots) to move your fault proofs to super-root games.
-*   Read [interop reorg awareness](/op-stack/interop/reorg) for how the safety model handles equivocation and L1 reorgs.
+*   Read the [op-supernode explainer](/op-stack/interop/supernode) for the consensus-layer component you run.
+*   Follow [Upgrading a chain from output roots to super roots](/chain-operators/tutorials/upgrade-chain-to-super-roots) for the first hands-on step.

--- a/docs/public-docs/chain-operators/guides/features/interop.mdx
+++ b/docs/public-docs/chain-operators/guides/features/interop.mdx
@@ -16,8 +16,8 @@ audit-source:
 </Info>
 
 Opting into interop is two actions: activate the Lagoon hardfork on your chain (which turns on the interop feature), and join a dependency set, the group of chains your chain can exchange cross-chain messages with.
-Joining a dependency set is what makes the setup below necessary, not Lagoon on its own.
-With an empty dependency set there's nothing to cross-validate, so a Lagoon-active chain can keep running a plain op-node setup and its existing output-root fault proofs.
+Cross-chain messaging only switches on once your dependency set has more than one chain.
+A Lagoon-active chain in a dependency set of one runs the base interop upgrades but never deploys the cross-chain machinery, so it has nothing to cross-validate and keeps a plain op-node setup and its existing output-root fault proofs.
 
 For how cross-chain messaging and block safety work at the protocol level, start with the [interop explainer](/op-stack/interop/explainer).
 
@@ -58,14 +58,13 @@ Once your chain is admitted, the set is published in the superchain-registry tha
 ### Does adding a chain to the set require another hardfork?
 
 No.
-Lagoon and dependency-set membership are separate mechanisms.
-Lagoon turns on the interop feature per chain; set membership changes through the coordinated process above, not through a hardfork.
-A chain joining an existing set needs Lagoon active on itself, which is a one-time activation of the existing hardfork, not a new one.
+Lagoon and dependency-set membership are separate mechanisms, and a chain joining a set just needs Lagoon active on itself: a one-time activation of the existing hardfork, not a new one.
+Forming a set is still a coordinated migration across all its members, not a config flip; adding a chain to an already-live set is more involved still and isn't yet a routine operation.
 For how membership and cross-chain message validity interact, see the [interop explainer](/op-stack/interop/explainer) and [interop reorg awareness](/op-stack/interop/reorg).
 
 ## Configure your sequencer
 
-Once your chain is in a dependency set, your sequencer setup changes in two ways.
+Once your dependency set has more than one chain and cross-chain messaging is live, your sequencer setup changes in two ways.
 
 **An execution client wired to the interop filter.**
 Run op-reth as your sequencer's execution client and point it at an [op-interop-filter](/chain-operators/tools/op-interop-filter) endpoint with `--rollup.interop-http`.
@@ -84,7 +83,7 @@ It manages leader election and no-downtime sequencer handover; the interop filte
 
 ## Move fault proofs to super roots
 
-Interop changes how your chain's state is proven.
+Interop changes how your chain's state is proven, and you do this before activating Lagoon, not after.
 A chain in a dependency set proves its state with super roots (commitments across every chain in the set at a timestamp) rather than per-chain output roots, so its fault-proof system moves to super-root dispute games.
 After the migration, op-proposer proposes super-root claims against an op-supernode and op-challenger defends them.
 

--- a/docs/public-docs/chain-operators/guides/features/interop.mdx
+++ b/docs/public-docs/chain-operators/guides/features/interop.mdx
@@ -43,7 +43,13 @@ The table below shows what each role owns.
 
 ## Opt in: activate Lagoon and join a dependency set
 
-Opting in is two distinct actions.
+Opting in means activating the Lagoon hardfork and being part of a dependency set, but the work runs in a specific order:
+
+1. Migrate to super-root fault proofs, as a dependency set of one.
+2. Form the shared dependency set with the other chains.
+3. Activate the Lagoon hardfork.
+
+The sequencer's interop filter comes online once cross-chain messaging is live (a dependency set of more than one chain).
 
 **Activate the Lagoon hardfork.**
 Lagoon is the hardfork that turns on the interop feature for your chain.
@@ -83,7 +89,7 @@ It manages leader election and no-downtime sequencer handover; the interop filte
 
 ## Move fault proofs to super roots
 
-Interop changes how your chain's state is proven, and you do this before activating Lagoon, not after.
+Interop changes how your chain's state is proven.
 A chain in a dependency set proves its state with super roots (commitments across every chain in the set at a timestamp) rather than per-chain output roots, so its fault-proof system moves to super-root dispute games.
 After the migration, op-proposer proposes super-root claims against an op-supernode and op-challenger defends them.
 

--- a/docs/public-docs/chain-operators/guides/features/interop.mdx
+++ b/docs/public-docs/chain-operators/guides/features/interop.mdx
@@ -1,0 +1,100 @@
+---
+title: Opting your chain into interop
+description: What a chain operator must do to opt an OP Stack chain into interop — activate the Lagoon hardfork, join a dependency set, and configure the sequencer, interop filter, and fault proofs.
+audit-source:
+  - op-core/interop/depset/depset.go
+  - op-core/interop/depset/links.go
+  - op-core/interop/depset/static_depset.go
+  - op-interop-filter/README.md
+  - op-supernode/supernode/activity/interop/interop.go
+---
+
+<Info>
+  OP Stack interop is in active development.
+  Interop activates through the Lagoon hardfork, targeted first for OP Sepolia and Unichain Sepolia on testnet, then OP Mainnet and Unichain.
+  The components and steps below may change as the rollout progresses.
+</Info>
+
+Opting into interop is two actions: activate the Lagoon hardfork on your chain (which turns on the interop feature), and join a dependency set, the group of chains your chain can exchange cross-chain messages with.
+Joining a dependency set is what makes the setup below necessary, not Lagoon on its own.
+With an empty dependency set there's nothing to cross-validate, so a Lagoon-active chain can keep running a plain op-node setup and its existing output-root fault proofs.
+
+For how cross-chain messaging and block safety work at the protocol level, start with the [interop explainer](/op-stack/interop/explainer).
+
+## Chain operator vs node operator responsibilities
+
+A chain operator runs everything a node operator runs, plus the sequencer-side and activation work.
+
+The node-operator baseline is running one or more [op-supernode](/op-stack/interop/supernode) instances that derive every chain in the dependency set, with the rest of the fleet following as [Light CLs](/notices/specialized-node-topology).
+That baseline is covered by the [interop prep notice](/notices/interop-prep) and the [specialized op-node topology notice](/notices/specialized-node-topology).
+Read those first, because the chain-operator setup builds on them.
+
+The table below shows what each role owns.
+
+| Responsibility | Node operator | Chain operator |
+| --- | --- | --- |
+| Supernode + Light CL topology | Yes | Yes |
+| Execution clients (op-reth, one per chain) | Yes | Yes |
+| Block production (sequencing) | No | Yes |
+| Interop activation (Lagoon) and dependency-set membership | No | Yes |
+| op-interop-filter for sequencer transaction admission | No | Yes |
+| Fault proofs over super roots (op-proposer, op-challenger) | No | Yes |
+| High-availability sequencer handover (op-conductor) | No | Yes |
+
+## Opt in: activate Lagoon and join a dependency set
+
+Opting in is two distinct actions.
+
+**Activate the Lagoon hardfork.**
+Lagoon is the hardfork that turns on the interop feature for your chain.
+For a new chain, schedule the Lagoon activation in your [op-deployer](/chain-operators/tools/op-deployer/overview) genesis configuration.
+For an existing chain, the activation timestamp is a governance-approved rollup-config update published in the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry).
+
+**Join a dependency set.**
+A dependency set is the group of chains that can exchange cross-chain messages, and OP Mainnet and Unichain form the initial set.
+Because every chain in the set depends on the others' messages being valid, membership is a mutual trust boundary: joining one is a coordinated, governance-gated process agreed across all members, not a change you make to your chain alone.
+Once your chain is admitted, the set is published in the superchain-registry that your supernode and interop filter read.
+
+### Does adding a chain to the set require another hardfork?
+
+No.
+Lagoon and dependency-set membership are separate mechanisms.
+Lagoon turns on the interop feature per chain; set membership changes through the coordinated process above, not through a hardfork.
+A chain joining an existing set needs Lagoon active on itself, which is a one-time activation of the existing hardfork, not a new one.
+For how membership and cross-chain message validity interact, see the [interop explainer](/op-stack/interop/explainer) and [interop reorg awareness](/op-stack/interop/reorg).
+
+## Configure your sequencer
+
+Once your chain is in a dependency set, your sequencer setup changes in two ways.
+
+**An execution client wired to the interop filter.**
+Run op-reth as your sequencer's execution client and point it at an [op-interop-filter](/chain-operators/tools/op-interop-filter) endpoint with `--rollup.interop-http`.
+The filter ingests the logs of every chain in your dependency set and answers the execution layer's `interop_checkAccessList` calls; the execution layer rejects any interop transaction the filter can't validate before it enters the pool.
+Run more than one filter for high availability: the execution layer fails closed, so if the filter it points at is unreachable, the sequencer stops admitting interop transactions until it recovers.
+See the [op-interop-filter page](/chain-operators/tools/op-interop-filter) for configuration, the RPC surface, and failsafe behavior.
+
+**A consensus layer that follows the supernode.**
+Run your sequencer's consensus client (op-node or kona-node) in Light CL mode with `--l2.follow.source` pointed at an op-supernode, the same as the rest of your fleet.
+The difference is that the sequencer is the one producing unsafe blocks.
+The supernode derives every chain in the dependency set and promotes a block to safe only once its cross-chain dependencies have been reproduced from L1, so the sequencer inherits a cross-validated safe view.
+See the [supernode explainer](/op-stack/interop/supernode) for the topology.
+
+For high-availability sequencing, run [op-conductor](/chain-operators/tools/op-conductor) as you would for any OP Stack chain.
+It manages leader election and no-downtime sequencer handover; the interop filter and supernode attach to whichever execution and consensus layer the active sequencer is running.
+
+## Move fault proofs to super roots
+
+Interop changes how your chain's state is proven.
+A chain in a dependency set proves its state with super roots (commitments across every chain in the set at a timestamp) rather than per-chain output roots, so its fault-proof system moves to super-root dispute games.
+After the migration, op-proposer proposes super-root claims against an op-supernode and op-challenger defends them.
+
+Walk through the migration in [Upgrading a chain from output roots to super roots](/chain-operators/tutorials/upgrade-chain-to-super-roots).
+
+## Where to go next
+
+*   Read the [interop explainer](/op-stack/interop/explainer) for how cross-chain messaging and block safety work at the protocol level.
+*   Read the [interop prep notice](/notices/interop-prep) and the [specialized op-node topology notice](/notices/specialized-node-topology) for the node-operator topology your fleet runs.
+*   Read the [op-supernode explainer](/op-stack/interop/supernode) and [supernode configuration guide](/node-operators/guides/configuration/supernode) for the consensus-layer side of interop.
+*   Read the [op-interop-filter page](/chain-operators/tools/op-interop-filter) for sequencer transaction admission.
+*   Follow [Upgrading a chain from output roots to super roots](/chain-operators/tutorials/upgrade-chain-to-super-roots) to move your fault proofs to super-root games.
+*   Read [interop reorg awareness](/op-stack/interop/reorg) for how the safety model handles equivocation and L1 reorgs.

--- a/docs/public-docs/chain-operators/tools/op-interop-filter.mdx
+++ b/docs/public-docs/chain-operators/tools/op-interop-filter.mdx
@@ -144,4 +144,5 @@ Admin RPC is intended for operator tooling and should not be exposed publicly.
 *   Read the [interop explainer](/op-stack/interop/explainer) for how cross-chain messaging and executing-message access lists work at the protocol level.
 *   Read the [op-supernode page](/op-stack/interop/supernode) for the consensus-layer side of an interop deployment — block-safety promotion and the supernode topology.
 *   Read [interop reorg awareness](/op-stack/interop/reorg) for how reorgs interact with cross-chain message safety.
+*   Read [Opting your chain into interop](/chain-operators/guides/features/interop) for where the filter fits in a chain operator's interop setup.
 *   For implementation detail, see the [op-interop-filter source](https://github.com/ethereum-optimism/optimism/tree/develop/op-interop-filter) in the monorepo.

--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -1917,7 +1917,8 @@
                   "chain-operators/guides/features/flashblocks-guide",
                   "chain-operators/guides/features/alt-da-mode-guide",
                   "chain-operators/guides/features/blobs",
-                  "chain-operators/guides/features/snap-sync"
+                  "chain-operators/guides/features/snap-sync",
+                  "chain-operators/guides/features/interop"
                 ]
               },
               {


### PR DESCRIPTION
## Summary

New chain-operator guide at `chain-operators/guides/features/interop.mdx` — a high-level overview of what opting an OP Stack chain into interop entails, plus 2 companion edits.

- **Audience:** chain operators considering or starting interop.
- **Problem solved:** there was no chain-operator-facing doc on the interop opt-in process or how chain-operator responsibilities differ from node-operator ones.
- **Form:** overview guide that links out to the detailed pages, kept deliberately high-level by request. In-active-development framing; Lagoon as the activating hardfork; op-reth as the canonical execution client.
- **Tracks:** current `develop`. Dependencies (`#21109` op-interop-filter page, `#20866` `--rollup.interop-http` rename) are both merged, so every reference resolves.

## Files changed

| File | Change |
|---|---|
| `docs/public-docs/chain-operators/guides/features/interop.mdx` | New page. |
| `docs/public-docs/chain-operators/tools/op-interop-filter.mdx` | One-line cross-link in "Where to go next" pointing to the new guide. |
| `docs/public-docs/docs.json` | Added the page to the chain-operators **Features** group. |

## What to review

**Source-derived accuracy (highest priority — needs interop domain context):**

1. **Dependency-set size gates the cross-chain machinery.** Lagoon turns on the interop *feature*, but the cross-chain machinery (the `CrossL2Inbox` predeploy, and therefore the interop filter) only activates when the dependency set has **more than one chain** — gated by `len(ba.depSet.Chains()) > 1` in `op-node/rollup/derive/attributes.go:178`. A Lagoon-active chain in a set of one runs the base upgrades only and keeps plain op-node + output-root proofs. *(Refined per engineering feedback; source-verified.)*
2. **Order of operations.** The move to super-root games happens *before* Lagoon activation, not after — the guide states the sequence explicitly. (Full sequence per engineering: super-root games as a dep-set-of-one → shared dispute games → Lagoon. The shared-dispute migration is intentionally left out per the high-level scope.)
3. **Sequencer runs as a Light CL** following the supernode (just the one producing blocks). From `op-stack/interop/supernode.mdx` ("sequencer Light CLs").
4. **Filter validates / EL rejects** (the EL calls `interop_checkAccessList`; it doesn't validate itself). Wiring via `--rollup.interop-http`.
5. **Super-root fault proofs** are scoped to dependency-set chains; output-root games otherwise.

**Adding a chain to a live set** — the guide states this isn't yet a routine operation. Verified: `OPContractsManagerMigrator.migrate()` is one-shot (N independent chains → one set) with no partial-migration / add-a-chain path ([OPContractsManagerMigrator.sol:8-12](packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol)).

**Two items I could not fully verify (worth an interop engineer's confirm):**

1. **Lagoon activation for a *new* chain** ("schedule in op-deployer genesis config") — inferred; the existing-chain governance path is from the interop-prep notice.
2. **op-conductor "as you would for any OP Stack chain"** — kept minimal; I did not verify that the Light-CL/supernode topology changes nothing about conductor.

## Judgment calls

- **SDM omitted** — not required to run an interop chain (`--rollup.sdm-enabled` defaults false; no interop preset sets it).
- **Relayer omitted** — no operator-run relayer service today (relaying is sender/app-side), and one may exist in future; the page stays silent rather than asserting "no relayer service."
- Placement under `chain-operators/guides/features/`; gerund title, consistent with sibling guides.
- High-level overview that links out, by request — `opcm.migrate` / shared-contract mechanics deferred to the super-roots and merge-shared-dispute-game tutorials.

## Test plan

- [ ] `mintlify dev` renders the page and the updated sidebar without errors.
- [ ] Internal links resolve (lint clean at commit time).
- [ ] `docs.json` parses as valid JSON.
- [ ] An interop engineer confirms the source-derived claims and the two open items above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)