### PR TITLE
feat(op-reth): interop failsafe observability — gauge metric + state logs

### DIFF
--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -131,6 +131,14 @@ impl InteropFilterClient {
         self.inner.failsafe_enabled.load(Ordering::Acquire)
     }
 
+    /// Applies a freshly polled failsafe state to the cached flag (read live by the admission
+    /// fast-path and the block-event handler) and the gauge. Split out of [`Self::query_failsafe`]
+    /// so the live, restart-free state transition can be exercised in tests without an RPC.
+    pub(crate) fn apply_failsafe_state(&self, enabled: bool) {
+        self.inner.failsafe_enabled.store(enabled, Ordering::Release);
+        self.inner.metrics.set_failsafe_enabled(enabled);
+    }
+
     /// Queries the interop filter for failsafe state and caches the result.
     /// Calls `admin_getFailsafeEnabled` RPC.
     pub async fn query_failsafe(&self) -> Result<bool, InteropTxValidatorError> {
@@ -142,8 +150,7 @@ impl InteropFilterClient {
         .map_err(|_| InteropTxValidatorError::Timeout(self.inner.timeout.as_secs()))?
         .map_err(InteropTxValidatorError::from_json_rpc)?;
 
-        self.inner.failsafe_enabled.store(result, Ordering::Release);
-        self.inner.metrics.set_failsafe_enabled(result);
+        self.apply_failsafe_state(result);
         Ok(result)
     }
 
@@ -315,5 +322,48 @@ impl<'a> IntoFuture for CheckAccessListRequest<'a> {
                 .map_err(|_| InteropTxValidatorError::Timeout(timeout.as_secs()))?
                 .map_err(InteropTxValidatorError::from_json_rpc)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interop_filter::CROSS_L2_INBOX_ADDRESS;
+    use alloy_eips::eip2930::AccessListItem;
+
+    async fn test_client() -> InteropFilterClient {
+        InteropFilterClient::builder("http://localhost:8545", 1).build().await
+    }
+
+    /// An access list that marks the tx as cross-chain (one entry targeting the cross-L2 inbox).
+    fn interop_access_list() -> AccessList {
+        AccessList(vec![AccessListItem {
+            address: CROSS_L2_INBOX_ADDRESS,
+            storage_keys: vec![B256::ZERO],
+        }])
+    }
+
+    /// The failsafe gate is a live, runtime-mutable flag: enabling it rejects interop txs on the
+    /// fast-path (no RPC), and clearing it flips the gate back in-process — so admission resumes
+    /// without restarting reth. This is the property the `poll_failsafe` loop relies on.
+    #[tokio::test]
+    async fn failsafe_gate_is_live_and_resumes_without_restart() {
+        let client = test_client().await;
+        let access_list = interop_access_list();
+        let hash = TxHash::ZERO;
+
+        // Filter signals failsafe enabled -> admission fast-path rejects immediately, no RPC.
+        client.apply_failsafe_state(true);
+        assert!(client.is_failsafe_enabled());
+        let outcome = client.is_valid_cross_tx(Some(&access_list), &hash, 0, None, true).await;
+        assert!(
+            matches!(outcome, Some(Err(InvalidCrossTx::FailsafeEnabled))),
+            "failsafe-enabled interop tx should be rejected on the fast-path, got {outcome:?}"
+        );
+
+        // Filter clears failsafe -> the cached gate flips back in-process on the next poll, so
+        // interop admission resumes without restarting the execution layer.
+        client.apply_failsafe_state(false);
+        assert!(!client.is_failsafe_enabled(), "failsafe gate must clear at runtime, no restart");
     }
 }

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -143,6 +143,7 @@ impl InteropFilterClient {
         .map_err(InteropTxValidatorError::from_json_rpc)?;
 
         self.inner.failsafe_enabled.store(result, Ordering::Release);
+        self.inner.metrics.set_failsafe_enabled(result);
         Ok(result)
     }
 

--- a/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
@@ -4,7 +4,7 @@ use crate::interop_filter::InteropTxValidatorError;
 use op_alloy_rpc_types::SuperchainDAError;
 use reth_metrics::{
     Metrics,
-    metrics::{Counter, Histogram},
+    metrics::{Counter, Gauge, Histogram},
 };
 use std::time::Duration;
 
@@ -37,6 +37,10 @@ pub struct InteropMetrics {
     pub(crate) missed_data_count: Counter,
     /// Counter for the number of times data corruption was encountered
     pub(crate) data_corruption_count: Counter,
+
+    /// Current interop failsafe state: `1` if failsafe is enabled (all interop txs are
+    /// rejected/evicted), `0` if disabled. Refreshed on every failsafe poll.
+    pub(crate) failsafe_enabled: Gauge,
 }
 
 impl InteropMetrics {
@@ -44,6 +48,12 @@ impl InteropMetrics {
     #[inline]
     pub fn record_interop_query(&self, duration: Duration) {
         self.interop_query_latency.record(duration.as_secs_f64());
+    }
+
+    /// Records the current interop failsafe state (`1` = enabled, `0` = disabled).
+    #[inline]
+    pub fn set_failsafe_enabled(&self, enabled: bool) {
+        self.failsafe_enabled.set(if enabled { 1.0 } else { 0.0 });
     }
 
     /// Increments the metrics for the given error

--- a/rust/op-reth/crates/txpool/src/maintain.rs
+++ b/rust/op-reth/crates/txpool/src/maintain.rs
@@ -4,6 +4,9 @@
 const OFFSET_TIME: u64 = 60;
 /// Maximum number of interop filter requests at the same time.
 const MAX_INTEROP_QUERIES: usize = 10;
+/// Interval at which a heartbeat warning is re-logged while failsafe stays enabled, so a
+/// long-lived failsafe keeps surfacing in recent logs rather than only at the transition.
+const FAILSAFE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 
 use crate::{
     conditional::MaybeConditionalTransaction,
@@ -265,27 +268,46 @@ where
     let metrics = MaintainPoolInteropMetrics::default();
     let mut interval = tokio::time::interval(Duration::from_secs(1));
     let mut was_enabled = false;
+    let mut last_heartbeat = Instant::now();
     loop {
         interval.tick().await;
         match interop_client.query_failsafe().await {
             Ok(enabled) => {
-                // On transition to enabled: evict all interop txs immediately
                 if enabled && !was_enabled {
+                    // Transition to enabled: log unconditionally (so the state change is
+                    // visible even when no interop txs are pooled) and evict all interop
+                    // txs immediately.
                     let interop_hashes: Vec<_> = pool
                         .pooled_transactions()
                         .iter()
                         .filter(|tx| is_interop_tx(&tx.transaction))
                         .map(|tx| *tx.hash())
                         .collect();
-                    if !interop_hashes.is_empty() {
-                        info!(
-                            target: "txpool::interop",
-                            count = interop_hashes.len(),
-                            "failsafe enabled: evicting all interop transactions"
-                        );
-                        let removed = pool.remove_transactions(interop_hashes);
-                        metrics.inc_removed_tx_interop(removed.len());
-                    }
+                    let evicted = if interop_hashes.is_empty() {
+                        0
+                    } else {
+                        let removed = pool.remove_transactions(interop_hashes).len();
+                        metrics.inc_removed_tx_interop(removed);
+                        removed
+                    };
+                    warn!(
+                        target: "txpool::interop",
+                        evicted,
+                        "interop failsafe enabled: rejecting all interop transactions; the execution layer may need to be restarted to resume interop"
+                    );
+                    last_heartbeat = Instant::now();
+                } else if enabled && last_heartbeat.elapsed() >= FAILSAFE_HEARTBEAT_INTERVAL {
+                    // Heartbeat: keep a long-lived failsafe visible in recent logs.
+                    warn!(
+                        target: "txpool::interop",
+                        "interop failsafe still active: all interop transactions are being rejected; the execution layer may need to be restarted to resume interop"
+                    );
+                    last_heartbeat = Instant::now();
+                } else if !enabled && was_enabled {
+                    info!(
+                        target: "txpool::interop",
+                        "interop failsafe cleared: resuming interop transaction processing"
+                    );
                 }
                 was_enabled = enabled;
             }

--- a/rust/op-reth/crates/txpool/src/maintain.rs
+++ b/rust/op-reth/crates/txpool/src/maintain.rs
@@ -293,14 +293,14 @@ where
                     warn!(
                         target: "txpool::interop",
                         evicted,
-                        "interop failsafe enabled: rejecting all interop transactions; the execution layer may need to be restarted to resume interop"
+                        "interop failsafe enabled: rejecting all interop transactions; admission resumes automatically (within the ~1s poll interval) once the interop filter clears failsafe"
                     );
                     last_heartbeat = Instant::now();
                 } else if enabled && last_heartbeat.elapsed() >= FAILSAFE_HEARTBEAT_INTERVAL {
                     // Heartbeat: keep a long-lived failsafe visible in recent logs.
                     warn!(
                         target: "txpool::interop",
-                        "interop failsafe still active: all interop transactions are being rejected; the execution layer may need to be restarted to resume interop"
+                        "interop failsafe still active: all interop transactions are being rejected; admission resumes automatically once the interop filter clears failsafe"
                     );
                     last_heartbeat = Instant::now();
                 } else if !enabled && was_enabled {


### PR DESCRIPTION
## What

Improves op-reth interop **failsafe** observability in two ways:

1. **Gauge metric** — `reth_optimism_transaction_pool_interop_failsafe_enabled` (`1` = enabled, `0` = disabled), refreshed on every failsafe poll (`query_failsafe`, ~1s).
2. **Consistent state logging** in `poll_failsafe` — the failsafe state is now logged on every transition and re-logged on a heartbeat while it stays enabled.

## Why

Today there is no metric that exposes reth's failsafe state, and the only failsafe log fired as a *side effect of eviction* — so it was silent when no interop txs were pooled, silent while failsafe stayed on, and silent when it cleared. This made a recent incident hard to diagnose: after the op-interop-filter failsafe was toggled, reth-based components (op-reth **and** op-rbuilder) stayed in the failsafe-evicted state and silently dropped interop txs, with no metric or recurring log to confirm the state.

## Related

- **#21149** — *op-reth interop tx pool does not resume after failsafe is disabled (requires restart)*, observed on `op-reth v2.2.6-rc.3`. This PR adds the gauge + logs that make that state **observable**, and verifies the resume behavior on current code: `poll_failsafe` re-polls `admin_getFailsafeEnabled` every ~1s and overwrites the cached flag that both the admission fast-path and the block-event handler read live, so clearing failsafe resumes interop admission **automatically within ~1s — no restart required**. (Already-evicted txs are dropped and must be resubmitted.) The restart requirement in #21149 was specific to the older build. The log wording is corrected accordingly (see below), and a test pins the restart-free resume.

## Changes

**Metric**
- `interop_filter/metrics.rs`: add `failsafe_enabled: Gauge` to `InteropMetrics` + `set_failsafe_enabled(bool)`.
- `interop_filter/client.rs`: extract `apply_failsafe_state(bool)` (sets the flag + gauge), called by `query_failsafe()`.

**Logging** (`txpool/src/maintain.rs`, `poll_failsafe`)
- `warn` on the disabled→enabled transition — fires unconditionally (with `evicted` count), not only when there were txs to evict. States that admission resumes automatically once the filter clears failsafe.
- `warn` heartbeat every 60s while failsafe stays enabled (same auto-resume wording).
- `info` on the enabled→disabled transition (cleared).

This mirrors the op-interop-filter (Go) transition + heartbeat logging pattern, so the EL and the filter report failsafe consistently.

## Testing

- `cargo fmt`, `cargo clippy`, and `cargo test -p reth-optimism-txpool` pass.
- Unit test `failsafe_gate_is_live_and_resumes_without_restart`: with failsafe enabled an interop tx is rejected on the fast-path (no RPC); after clearing, the cached gate flips back in-process — pinning the restart-free resume described above.

## Notes

- The gauge and logs track the **polled** failsafe state (the same value the txpool fast-path and block-event eviction read), so they reflect what reth is actually enforcing.
- Applies to every reth-based component running this txpool (op-reth and op-rbuilder), which is exactly where the observability gap was.

