### PR TITLE
fix(op-supernode): dial interop engine controller lazily

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/startup_resync/startup_resync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/startup_resync/startup_resync_test.go
@@ -97,3 +97,48 @@ func TestSupernodeResyncSchedulesAtActivation_PreActivation(gt *testing.T) {
 		sys.L2BCL.AdvancedFn(safety.CrossSafe, 1, 60),
 	)
 }
+
+// TestSupernodeEngineControllerConnectsAfterELUnavailableAtStartup starts the
+// supernode while both L2 EL RPC endpoints are down. The interop engine
+// controller dials lazily, so startup succeeds and the controller connects on
+// demand once the ELs come back -- without restarting the virtual node. Before
+// the lazy-dial fix this left interop permanently stuck with ErrNoEngineClient.
+func TestSupernodeEngineControllerConnectsAfterELUnavailableAtStartup(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewTwoL2SupernodeInterop(t, 0,
+		presets.WithUniformL2BlockTimes(l2BlockTime),
+		presets.WithInteropLogBackfillDepth(backfillDepth),
+	)
+
+	sys.Supernode.AwaitBackfillCompleted()
+
+	sys.Supernode.Stop()
+	sys.L2ELA.Stop()
+	sys.L2ELB.Stop()
+	t.Cleanup(func() {
+		sys.L2ELA.Start()
+		sys.L2ELB.Start()
+	})
+
+	// Start the supernode while the EL RPC endpoints are down. Start blocks until
+	// the supernode RPC is bound, so on return the supernode is fully up with its
+	// ELs unreachable.
+	sys.Supernode.Start()
+	// Deterministically assert we are in the EL-down state instead of sleeping: an
+	// engine-backed query must fail while the engine cannot reach the L2 ELs. This
+	// is the state in which the bug left interop permanently stuck on
+	// ErrNoEngineClient before the engine controller dialed lazily.
+	_, err := sys.Supernode.QueryAPI().SuperRootAtTimestamp(t.Ctx(), uint64(time.Now().Unix()))
+	t.Require().Error(err, "engine-backed query should fail while the L2 ELs are down")
+
+	sys.L2ELA.Start()
+	sys.L2ELB.Start()
+	sys.L2ELA.WaitForOnline()
+	sys.L2ELB.WaitForOnline()
+
+	sys.Supernode.AwaitBackfillCompleted()
+	dsl.CheckAll(t,
+		sys.L2ACL.AdvancedFn(safety.CrossSafe, 1, 60),
+		sys.L2BCL.AdvancedFn(safety.CrossSafe, 1, 60),
+	)
+}

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -188,6 +188,10 @@ func (n *OpReth) Start() {
 func (n *OpReth) Stop() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	if n.sub == nil {
+		n.p.Logger().Warn("op-reth already stopped")
+		return
+	}
 	err := n.sub.Stop(true)
 	n.p.Require().NoError(err, "Must stop")
 	n.sub = nil

--- a/op-node/config/l2_el_rpc.go
+++ b/op-node/config/l2_el_rpc.go
@@ -33,6 +33,11 @@ type L2EndpointConfig struct {
 	// L2EngineCallTimeout is the default timeout duration for L2 calls.
 	// Defines the maximum time a call to the L2 engine is allowed to take before timing out.
 	L2EngineCallTimeout time.Duration
+
+	// LazyDial defers the initial engine connection until the first call and lets the
+	// underlying client (re)connect on demand, instead of dialing eagerly at setup. This
+	// keeps a consumer usable when the L2 engine is unavailable at startup. Off by default.
+	LazyDial bool
 }
 
 var _ L2EndpointSetup = (*L2EndpointConfig)(nil)
@@ -56,6 +61,9 @@ func (cfg *L2EndpointConfig) Setup(ctx context.Context, log log.Logger,
 		client.WithDialAttempts(10),
 		client.WithCallTimeout(cfg.L2EngineCallTimeout),
 		client.WithRPCRecorder(metrics.NewRecorder("engine-api")),
+	}
+	if cfg.LazyDial {
+		opts = append(opts, client.WithLazyDial())
 	}
 	l2Node, err := client.NewRPC(ctx, log, cfg.L2EngineAddr, opts...)
 	if err != nil {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -32,6 +32,9 @@ import (
 
 const virtualNodeVersion = "0.1.0"
 
+// newEngineControllerFromConfig is the engine-controller constructor, overridable in tests.
+var newEngineControllerFromConfig = engine_controller.NewEngineControllerFromConfig
+
 // ErrHistoryUnavailable is the permanent counterpart of ethereum.NotFound:
 // SafeDB on this node cannot and will not contain the requested history
 // (e.g. snap/CL-sync bootstrap gap). Interop halts on this rather than
@@ -193,7 +196,7 @@ func NewChainContainer(
 	rpcRouter RPCRouterGate,
 	addMetricsRegistry func(key string, g prometheus.Gatherer),
 	metrics *resources.SupernodeMetrics,
-) InteropChain {
+) (InteropChain, error) {
 	if metrics == nil {
 		metrics = resources.NewSupernodeMetrics()
 	}
@@ -226,7 +229,25 @@ func NewChainContainer(
 	} else {
 		c.denyList = denyList
 	}
-	return c
+	// Set up the interop engine controller. The connection is dialed lazily, so setup never
+	// blocks on or fails because of an unreachable L2 engine at startup -- the client connects
+	// on first use and reconnects on demand. This is what lets interop recover once the EL comes
+	// up, without restarting the virtual node. engine is written only here, before the container
+	// is published to other goroutines, so later reads need no synchronization. Chains without an
+	// L2 engine configured leave engine nil and surface ErrNoEngineClient to callers.
+	//
+	// Because the dial is lazy, the only way this fails is an unrecoverable misconfiguration
+	// (e.g. an empty engine address); that must abort startup rather than run a chain that can
+	// never reach its engine.
+	if vncfg.L2 != nil {
+		engLog := log.New("chain_id", chainID.String(), "component", "engine_controller")
+		eng, err := newEngineControllerFromConfig(context.Background(), engLog, vncfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up engine controller for chain %s: %w", chainID, err)
+		}
+		c.engine = eng
+	}
+	return c, nil
 }
 
 func (c *simpleChainContainer) ID() eth.ChainID {
@@ -349,18 +370,6 @@ func (c *simpleChainContainer) Start(ctx context.Context) error {
 		}
 		if c.stop.Load() {
 			break
-		}
-
-		// Initialize engine controller if not yet connected (retries on each VN restart)
-		if c.engine == nil && c.vncfg.L2 != nil {
-			setupCtx, setupCancel := context.WithTimeout(ctx, 10*time.Second)
-			engLog := c.log.New("chain_id", c.chainID.String(), "component", "engine_controller")
-			if eng, engErr := engine_controller.NewEngineControllerFromConfig(setupCtx, engLog, c.vncfg); engErr != nil {
-				c.log.Error("failed to setup engine controller", "err", engErr)
-			} else {
-				c.engine = eng
-			}
-			setupCancel()
 		}
 
 		// start the virtual node

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
@@ -221,6 +222,8 @@ type mockEngineController struct {
 	rewindFunc               func(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error // optional custom behavior
 	l2BlockRefByNumberResult eth.L2BlockRef
 	l2BlockRefByNumberErr    error
+	outputV0Result           *eth.OutputV0
+	outputV0Err              error
 	payloadByHashResult      *eth.ExecutionPayloadEnvelope
 	payloadByHashErr         error
 	payloadByNumberResult    *eth.ExecutionPayloadEnvelope
@@ -240,7 +243,7 @@ func (m *mockEngineController) L2BlockRefByLabel(ctx context.Context, label eth.
 }
 
 func (m *mockEngineController) OutputV0AtBlockNumber(ctx context.Context, num uint64) (*eth.OutputV0, error) {
-	return nil, nil
+	return m.outputV0Result, m.outputV0Err
 }
 
 func (m *mockEngineController) OutputV0ByBlockHash(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
@@ -307,6 +310,25 @@ func createTestLogger(t testing.TB) gethlog.Logger {
 	return testlog.Logger(t, gethlog.LevelDebug)
 }
 
+// mustNewChainContainer builds a chain container and fails the test on error.
+func mustNewChainContainer(
+	t testing.TB,
+	chainID eth.ChainID,
+	vncfg *opnodecfg.Config,
+	log gethlog.Logger,
+	cfg config.CLIConfig,
+	initOverload *rollupNode.InitializationOverrides,
+	rpcHandler *oprpc.Handler,
+	rpcRouter RPCRouterGate,
+	addMetricsRegistry func(key string, g prometheus.Gatherer),
+	metrics *resources.SupernodeMetrics,
+) InteropChain {
+	t.Helper()
+	container, err := NewChainContainer(chainID, vncfg, log, cfg, initOverload, rpcHandler, rpcRouter, addMetricsRegistry, metrics)
+	require.NoError(t, err)
+	return container
+}
+
 // TestChainContainer_Constructor tests initialization and configuration
 func TestChainContainer_Constructor(t *testing.T) {
 	t.Parallel()
@@ -318,7 +340,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 
 	t.Run("creates container with correct config", func(t *testing.T) {
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 
 		require.NotNil(t, container)
 
@@ -338,7 +360,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 		cfg := config.CLIConfig{
 			DataDir: dataDir,
 		}
-		container := NewChainContainer(eth.ChainIDFromUInt64(420), vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, eth.ChainIDFromUInt64(420), vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
@@ -355,7 +377,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 				ListenPort: 9545,
 			},
 		}
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
@@ -365,7 +387,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 
 	t.Run("appVersion set correctly", func(t *testing.T) {
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -377,7 +399,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 		cfg := config.CLIConfig{
 			DataDir: dataDir,
 		}
-		container := NewChainContainer(eth.ChainIDFromUInt64(420), vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, eth.ChainIDFromUInt64(420), vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -402,7 +424,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			container := NewChainContainer(tc.chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+			container := mustNewChainContainer(t, tc.chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 			impl, ok := container.(*simpleChainContainer)
 			require.True(t, ok)
 
@@ -413,22 +435,75 @@ func TestChainContainer_Constructor(t *testing.T) {
 	})
 }
 
-// TestChainContainer_EngineControllerNotInitInConstructor verifies that the
-// engine controller is NOT initialized in NewChainContainer (it is deferred to
-// the Start loop so that transient EL unavailability at startup is retried).
-func TestChainContainer_EngineControllerNotInitInConstructor(t *testing.T) {
+// TestChainContainer_EngineControllerNotInitWhenNoL2 verifies that a chain with
+// no L2 engine configured leaves the engine controller nil.
+func TestChainContainer_EngineControllerNotInitWhenNoL2(t *testing.T) {
 	t.Parallel()
 
 	chainID := eth.ChainIDFromUInt64(420)
-	vncfg := createTestVNConfig()
+	vncfg := createTestVNConfig() // no L2 endpoint configured
 	log := createTestLogger(t)
 	cfg := createTestCLIConfig(t.TempDir())
 	initOverload := &rollupNode.InitializationOverrides{}
 
-	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 	impl, ok := container.(*simpleChainContainer)
 	require.True(t, ok)
-	require.Nil(t, impl.engine, "engine should not be initialized in constructor; it is deferred to Start loop")
+	require.Nil(t, impl.engine, "engine should be nil when no L2 endpoint is configured")
+}
+
+// TestChainContainer_EngineControllerInitInConstructor verifies that, when an L2
+// endpoint is configured, the engine controller is set up eagerly in the
+// constructor. Because the dial is lazy this never blocks on a reachable EL, so
+// the controller is available immediately and usable once the EL comes up,
+// without waiting for a virtual-node restart.
+func TestChainContainer_EngineControllerInitInConstructor(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+	vncfg := createTestVNConfig()
+	vncfg.L2 = &opnodecfg.L2EndpointConfig{L2EngineAddr: "http://unused.example"}
+	log := createTestLogger(t)
+	cfg := createTestCLIConfig(t.TempDir())
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	expectedOutput := &eth.OutputV0{BlockHash: common.Hash{0x42}}
+	mockEngine := &mockEngineController{outputV0Result: expectedOutput}
+
+	prevSetup := newEngineControllerFromConfig
+	newEngineControllerFromConfig = func(ctx context.Context, log gethlog.Logger, vncfg *opnodecfg.Config) (engine_controller.EngineController, error) {
+		return mockEngine, nil
+	}
+	t.Cleanup(func() { newEngineControllerFromConfig = prevSetup })
+
+	container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	impl, ok := container.(*simpleChainContainer)
+	require.True(t, ok)
+	require.NotNil(t, impl.engine, "engine should be initialized in constructor when L2 is configured")
+
+	out, err := container.OutputV0AtBlockNumber(context.Background(), 0)
+	require.NoError(t, err)
+	require.Equal(t, expectedOutput, out, "calls should dispatch to the engine set up in the constructor")
+}
+
+// TestChainContainer_EngineControllerSetupErrorFailsConstruction verifies that a
+// fatal engine-controller setup error aborts construction rather than being
+// swallowed, since a chain that can never reach its engine must not start.
+func TestChainContainer_EngineControllerSetupErrorFailsConstruction(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+	vncfg := createTestVNConfig()
+	vncfg.L2 = &opnodecfg.L2EndpointConfig{L2EngineAddr: "http://unused.example"}
+	log := createTestLogger(t)
+	cfg := createTestCLIConfig(t.TempDir())
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	setupErr := errors.New("bad engine config")
+	prevSetup := newEngineControllerFromConfig
+	newEngineControllerFromConfig = func(ctx context.Context, log gethlog.Logger, vncfg *opnodecfg.Config) (engine_controller.EngineController, error) {
+		return nil, setupErr
+	}
+	t.Cleanup(func() { newEngineControllerFromConfig = prevSetup })
+
+	_, err := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	require.ErrorIs(t, err, setupErr)
 }
 
 func TestChainContainerIsRPCReady(t *testing.T) {
@@ -459,7 +534,7 @@ func TestChainContainerIsRPCReady(t *testing.T) {
 
 			vncfg := createTestVNConfig()
 			cfg := createTestCLIConfig(t.TempDir())
-			container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+			container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 			impl, ok := container.(*simpleChainContainer)
 			require.True(t, ok)
 
@@ -487,7 +562,7 @@ func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Run("Start respects stop flag", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -514,7 +589,7 @@ func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Run("Stop sets stop flag", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -529,7 +604,7 @@ func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Run("signals stopped channel on exit", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -559,7 +634,7 @@ func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Run("context cancellation stops restart loop", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -600,7 +675,7 @@ func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Run("Stop flag stops restart loop", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -647,7 +722,7 @@ func TestChainContainer_PauseResume(t *testing.T) {
 	t.Run("Pause sets pause flag", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -661,7 +736,7 @@ func TestChainContainer_PauseResume(t *testing.T) {
 	t.Run("Resume clears pause flag", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -677,7 +752,7 @@ func TestChainContainer_PauseResume(t *testing.T) {
 	t.Run("paused container doesn't start VN, resumed does", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -973,7 +1048,7 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 	t.Run("Start creates and starts virtual node", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -1004,7 +1079,7 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 	t.Run("auto-restart virtual node on exit", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -1042,7 +1117,7 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
 		metrics := resources.NewSupernodeMetrics()
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, metrics)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, metrics)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -1074,7 +1149,7 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 	t.Run("Stop calls virtual node Stop", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -1113,7 +1188,7 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 		router := &fakeRPCRouterGate{}
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, router, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, router, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -1183,7 +1258,7 @@ func TestChainContainer_OptimisticAt_ErrL1AtSafeHeadNotFound(t *testing.T) {
 	cfg := createTestCLIConfig(t.TempDir())
 	initOverload := &rollupNode.InitializationOverrides{}
 
-	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 	impl, ok := container.(*simpleChainContainer)
 	require.True(t, ok)
 
@@ -1235,7 +1310,7 @@ func TestChainContainer_OptimisticAt_LocalSafeTipNotFoundLogsDebug(t *testing.T)
 	cfg := createTestCLIConfig(t.TempDir())
 	initOverload := &rollupNode.InitializationOverrides{}
 
-	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 	impl, ok := container.(*simpleChainContainer)
 	require.True(t, ok)
 
@@ -1301,7 +1376,7 @@ func TestChainContainer_OptimisticAt_ErrL1AtSafeHeadUnavailable(t *testing.T) {
 	cfg := createTestCLIConfig(t.TempDir())
 	initOverload := &rollupNode.InitializationOverrides{}
 
-	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 	impl, ok := container.(*simpleChainContainer)
 	require.True(t, ok)
 
@@ -1416,7 +1491,7 @@ func TestChainContainer_LocalSafeBlockAtTimestamp(t *testing.T) {
 		vncfg.Rollup.Genesis.L2Time = tc.genesisTime
 		vncfg.Rollup.BlockTime = tc.blockTime
 
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+		container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -1574,7 +1649,7 @@ func TestChainContainer_SyncStatus_UninitializedVirtualNode(t *testing.T) {
 	cfg := createTestCLIConfig(t.TempDir())
 	initOverload := &rollupNode.InitializationOverrides{}
 
-	container := NewChainContainer(chainID, createTestVNConfig(), log, cfg, initOverload, nil, nil, nil, nil)
+	container := mustNewChainContainer(t, chainID, createTestVNConfig(), log, cfg, initOverload, nil, nil, nil, nil)
 
 	status, err := container.SyncStatus(context.Background())
 	require.Nil(t, status)
@@ -1594,7 +1669,7 @@ func TestChainContainer_BlockNumberToTimestamp_RespectsGenesisBlockNumber(t *tes
 	vncfg.Rollup.Genesis.L2.Number = 100
 	vncfg.Rollup.BlockTime = 2
 
-	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	container := mustNewChainContainer(t, chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 	impl, ok := container.(*simpleChainContainer)
 	require.True(t, ok)
 

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -74,8 +74,20 @@ func NewEngineControllerWithL2AndRollup(l2 l2Provider, rollup *rollup.Config) En
 
 // NewEngineControllerFromConfig builds an engine client from the op-node L2 endpoint config.
 // This creates a separate connection (not passed as an override to op-node).
+//
+// The connection is dialed lazily: setup never touches the network, so the controller is
+// usable even when the L2 engine is unreachable at startup. The underlying client dials on
+// first use and reconnects on demand, which is what lets interop recover once the EL comes up
+// without restarting the virtual node. Lazy is applied to a copy of the endpoint config so the
+// virtual node, which shares vncfg.L2, keeps its eager-dial behavior.
 func NewEngineControllerFromConfig(ctx context.Context, log gethlog.Logger, vncfg *opnodecfg.Config) (EngineController, error) {
-	rpc, engCfg, err := vncfg.L2.Setup(ctx, log, &vncfg.Rollup, &opmetrics.NoopRPCMetrics{})
+	l2Setup := vncfg.L2
+	if l2cfg, ok := l2Setup.(*opnodecfg.L2EndpointConfig); ok {
+		lazyCfg := *l2cfg
+		lazyCfg.LazyDial = true
+		l2Setup = &lazyCfg
+	}
+	rpc, engCfg, err := l2Setup.Setup(ctx, log, &vncfg.Rollup, &opmetrics.NoopRPCMetrics{})
 	if err != nil {
 		return nil, err
 	}

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
@@ -3,8 +3,10 @@ package engine_controller
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"testing"
 
+	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
@@ -13,6 +15,28 @@ import (
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
+
+// TestNewEngineControllerFromConfig_LazyDialSucceedsWhenELUnavailable is the
+// regression test for the startup-resync bug: with lazy dialing, building the
+// engine controller must succeed even when the L2 engine is unreachable, so the
+// supernode can start while its EL is down and recover once it comes up without
+// restarting the virtual node. It also asserts the shared endpoint config is not
+// mutated, so the virtual node keeps its eager-dial behavior.
+func TestNewEngineControllerFromConfig_LazyDialSucceedsWhenELUnavailable(t *testing.T) {
+	t.Parallel()
+
+	l2cfg := &opnodecfg.L2EndpointConfig{L2EngineAddr: "ws://127.0.0.1:0"}
+	vncfg := &opnodecfg.Config{
+		L2:     l2cfg,
+		Rollup: rollup.Config{L2ChainID: big.NewInt(420), BlockTime: 2},
+	}
+
+	ec, err := NewEngineControllerFromConfig(context.Background(), gethlog.New(), vncfg)
+	require.NoError(t, err, "lazy setup must not dial, so an unreachable EL must not fail construction")
+	require.NotNil(t, ec)
+	require.False(t, l2cfg.LazyDial, "lazy must be applied to a copy, leaving the shared VN config eager")
+	require.NoError(t, ec.Close())
+}
 
 // unified mock covers both payload/output paths and BlockAtTimestamp path
 

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -89,7 +89,10 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 			log.Error("missing virtual node config for chain", "chain", id)
 			continue
 		}
-		container := cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter, s.metricsFanIn.SetMetricsRegistry, s.supernodeMetrics)
+		container, err := cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter, s.metricsFanIn.SetMetricsRegistry, s.supernodeMetrics)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create chain container for chain %s: %w", chainID, err)
+		}
 		s.chains[chainID] = container
 	}
 


### PR DESCRIPTION
Alternative to #21137 for #21136.

The interop engine controller uses a separate EL connection from the virtual node and was set up inside the VN restart loop. A healthy VN keeps running and reconnects its own EL client without restarting, so an engine-controller connection that failed at startup stayed `nil` forever and interop kept failing with `ErrNoEngineClient`.

This dials the engine controller **lazily** and sets it up once in the chain-container constructor. Lazy dialing never touches the network at setup, so the controller is usable immediately and (re)connects on demand once the EL is reachable — no VN restart, and no separate retry loop or mutex. Lazy is applied to a *copy* of the L2 endpoint config so the virtual node, which shares `vncfg.L2`, keeps its eager-dial behavior. Setting the engine up once in the constructor also makes `c.engine` write-once. A fatal setup error now aborts construction instead of being logged and ignored.

Compared with #21137, this **removes** the retry goroutine, the engine mutex, and the per-call accessors rather than adding them.

## Test plan
- `go test -race ./op-supernode/supernode/chain_container/...` — engine is set up in the constructor; a fatal setup error aborts construction; hermetic `NewEngineControllerFromConfig` test confirms lazy setup succeeds against an unreachable EL and does not mutate the shared config.
- `go test ./op-node/config/...`
- Acceptance (run locally, op-reth built): `TestSupernodeEngineControllerConnectsAfterELUnavailableAtStartup` — supernode starts with both L2 ELs down, then recovers once they return. **Passes on this branch (60s); fails on `develop`** (`expected head to advance: safe` — cross-safe never advances), confirming it reproduces #21136. Uses a deterministic down-state assertion (an engine-backed query must error while the ELs are down) instead of a fixed sleep.

---
_Authored by Claude (AI assistant) as an alternative implementation for review._
