### PR TITLE
feat(op-reth): expose `OpPool::inner` accessor

### DIFF
--- a/rust/op-reth/crates/txpool/src/pool.rs
+++ b/rust/op-reth/crates/txpool/src/pool.rs
@@ -139,6 +139,15 @@ where
         Self { inner, reorg_state, metrics: OpPoolMetrics::default() }
     }
 
+    /// Returns a reference to the wrapped inner pool.
+    ///
+    /// Useful for downstream consumers that need to reach inherent methods on
+    /// the concrete pool type (e.g. `reth_transaction_pool::Pool::validator`)
+    /// which aren't exposed via the [`TransactionPool`] trait.
+    pub const fn inner(&self) -> &P {
+        &self.inner
+    }
+
     /// Returns true if interop filtering should fire on this
     /// `add_external_transactions` call.
     ///


### PR DESCRIPTION
## Summary

- `OpPool<P>` only delegates the `TransactionPool` *trait* surface to its inner pool. Inherent methods on the wrapped concrete pool — notably `reth_transaction_pool::Pool::validator` — are unreachable from outside this crate, because `OpPool::inner` is private and has no accessor.
- This appears to be incidental rather than intentional: the wrapper was introduced in #20001 to layer interop-reorg filtering on `add_external_transactions`, and the lost accessibility wasn't part of the change's scope.
- Add `pub const fn inner(&self) -> &P` so downstream consumers can opt in to the inherent surface of the wrapped pool when they need it.

## Motivation

Downstream pool wrappers that want to pre-validate transactions before dispatching them to a more expensive path (e.g. flashblocks-style pre-simulation) previously did `pool.validator()` directly on the inner pool. Since the move to `OpPool`, that no longer compiles. The current workaround is to construct a *parallel* validator with the same configuration `OpPoolBuilder::build_pool` already used — duplicating both the runtime cost (extra `TransactionValidationTaskExecutor` background tasks) and the maintenance cost (the parameter list has to be kept in sync with op-reth by hand).

Exposing `inner()` is a one-line change that fixes both concerns without any change to the wrapper's public contract.

## Test plan

- [x] `cargo check -p reth-optimism-txpool`
- [ ] CI on this PR