### PR TITLE
feat(op-supernode): pre-initialize interop decision metric series

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -94,6 +94,10 @@ const (
 	DecisionRewind
 )
 
+// roundDecisions enumerates every Decision the round loop can emit. Used to
+// pre-initialize the decision counter so all label series exist from startup.
+var roundDecisions = []Decision{DecisionWait, DecisionAdvance, DecisionInvalidate, DecisionRewind}
+
 // Decision is serialized as a self-describing string in the WAL so that the
 // on-disk format survives enum re-ordering or the insertion of new variants.
 func (d Decision) String() string {
@@ -277,6 +281,14 @@ func New(
 	}
 	if metrics == nil {
 		metrics = resources.NewSupernodeMetrics()
+	}
+	// Pre-initialize every decision label series to 0 so the invalidate signal
+	// exists from startup. Without this, the {decision="invalidate"} series only
+	// appears on the first invalidation — already at 1 — and Prometheus
+	// increase()/rate() has no prior 0 sample to diff against, so an alert built
+	// on it misses the very event it guards.
+	for _, d := range roundDecisions {
+		metrics.InteropRoundDecisions.WithLabelValues(d.String())
 	}
 	i := &Interop{
 		log:                 log,

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -290,6 +290,11 @@ func New(
 	for _, d := range roundDecisions {
 		metrics.InteropRoundDecisions.WithLabelValues(d.String())
 	}
+	// Likewise pre-initialize the per-chain invalidation counter to 0 for every
+	// configured chain, so a per-chain invalidate alert has a 0 baseline.
+	for chainID := range chains {
+		metrics.InteropInvalidations.WithLabelValues(chainID.String())
+	}
 	i := &Interop{
 		log:                 log,
 		chains:              chains,

--- a/op-supernode/supernode/activity/interop/metrics_test.go
+++ b/op-supernode/supernode/activity/interop/metrics_test.go
@@ -1,0 +1,47 @@
+package interop
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewPreInitializesDecisionMetrics guards the alerting contract: every
+// decision label series must exist at 0 from process startup. Prometheus
+// increase()/rate() cannot see a counter's first increment if the series only
+// springs into existence already non-zero, so an invalidate alert built on
+// increase(...{decision="invalidate"}[w]) > 0 would miss the very event it
+// guards unless the series starts at 0.
+func TestNewPreInitializesDecisionMetrics(t *testing.T) {
+	h := newInteropTestHarness(t).WithChain(10, nil).Build()
+	require.NotNil(t, h.interop)
+
+	for _, d := range roundDecisions {
+		v, found := gatheredDecisionCount(t, h.interop.metrics, d.String())
+		require.Truef(t, found, "decision series %q must exist from startup for alerting", d)
+		require.Zerof(t, v, "decision series %q must start at 0", d)
+	}
+}
+
+// gatheredDecisionCount reads the value of the round-decisions counter for a
+// given decision label directly from the registry, without touching the metric
+// (WithLabelValues would itself create the series and mask a missing one).
+func gatheredDecisionCount(t *testing.T, m *resources.SupernodeMetrics, decision string) (float64, bool) {
+	t.Helper()
+	families, err := m.Registry().Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() != "supernode_interop_round_decisions_total" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "decision" && label.GetValue() == decision {
+					return metric.GetCounter().GetValue(), true
+				}
+			}
+		}
+	}
+	return 0, false
+}

--- a/op-supernode/supernode/activity/interop/metrics_test.go
+++ b/op-supernode/supernode/activity/interop/metrics_test.go
@@ -3,6 +3,7 @@ package interop
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	"github.com/stretchr/testify/require"
 )
@@ -18,26 +19,41 @@ func TestNewPreInitializesDecisionMetrics(t *testing.T) {
 	require.NotNil(t, h.interop)
 
 	for _, d := range roundDecisions {
-		v, found := gatheredDecisionCount(t, h.interop.metrics, d.String())
+		v, found := gatheredCounter(t, h.interop.metrics, "supernode_interop_round_decisions_total", "decision", d.String())
 		require.Truef(t, found, "decision series %q must exist from startup for alerting", d)
 		require.Zerof(t, v, "decision series %q must start at 0", d)
 	}
 }
 
-// gatheredDecisionCount reads the value of the round-decisions counter for a
-// given decision label directly from the registry, without touching the metric
-// (WithLabelValues would itself create the series and mask a missing one).
-func gatheredDecisionCount(t *testing.T, m *resources.SupernodeMetrics, decision string) (float64, bool) {
+// TestNewPreInitializesInvalidationMetrics guards the same alerting contract for
+// the per-chain invalidation counter: every configured chain's series must exist
+// at 0 from startup so a per-chain invalidate alert has a 0 baseline.
+func TestNewPreInitializesInvalidationMetrics(t *testing.T) {
+	h := newInteropTestHarness(t).WithChain(10, nil).WithChain(8453, nil).Build()
+	require.NotNil(t, h.interop)
+
+	for _, id := range []uint64{10, 8453} {
+		chainID := eth.ChainIDFromUInt64(id).String()
+		v, found := gatheredCounter(t, h.interop.metrics, "supernode_interop_invalidations_total", "chain_id", chainID)
+		require.Truef(t, found, "invalidation series for chain %q must exist from startup for alerting", chainID)
+		require.Zerof(t, v, "invalidation series for chain %q must start at 0", chainID)
+	}
+}
+
+// gatheredCounter reads the value of a counter series for a given single-label
+// value directly from the registry, without touching the metric (WithLabelValues
+// would itself create the series and mask a missing one).
+func gatheredCounter(t *testing.T, m *resources.SupernodeMetrics, metricName, labelName, labelValue string) (float64, bool) {
 	t.Helper()
 	families, err := m.Registry().Gather()
 	require.NoError(t, err)
 	for _, mf := range families {
-		if mf.GetName() != "supernode_interop_round_decisions_total" {
+		if mf.GetName() != metricName {
 			continue
 		}
 		for _, metric := range mf.GetMetric() {
 			for _, label := range metric.GetLabel() {
-				if label.GetName() == "decision" && label.GetValue() == decision {
+				if label.GetName() == labelName && label.GetValue() == labelValue {
 					return metric.GetCounter().GetValue(), true
 				}
 			}


### PR DESCRIPTION
Closes ethereum-optimism/optimism#21159.

`supernode_interop_round_decisions_total` already counts every round decision (including `invalidate`, which means an invalid interop message was detected). But its label series only appear on first use, so a `{decision="invalidate"}` series whose first observed sample is already `1` gives Prometheus `increase()`/`rate()` no prior `0` baseline — an alert built on it can miss the very invalidation it guards.

This pre-initializes, at construction:
- every `decision` series of `supernode_interop_round_decisions_total` to `0`
- the per-chain `supernode_interop_invalidations_total` series to `0` for every configured chain

making the invalidate signals reliably alertable from startup. The decision counter is incremented at decision time, before any apply side-effects, so it fires even if the subsequent rewind/invalidation fails.

Suggested alert: `increase(supernode_interop_round_decisions_total{decision="invalidate"}[10m]) > 0`.