### PR TITLE
fix(op-supernode): block on VN readiness after Resume in rewind/invalidate

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -1084,6 +1084,7 @@ func (m *algoMockChain) Start(ctx context.Context) error                  { retu
 func (m *algoMockChain) Stop(ctx context.Context) error                   { return nil }
 func (m *algoMockChain) Pause(ctx context.Context) error                  { return nil }
 func (m *algoMockChain) Resume(ctx context.Context) error                 { return nil }
+func (m *algoMockChain) WaitReady(_ context.Context) error                { return nil }
 func (m *algoMockChain) PauseAndStopVN(ctx context.Context) error         { return nil }
 func (m *algoMockChain) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *algoMockChain) VerifierCurrentL1() (eth.BlockID, bool)           { return eth.BlockID{}, false }
@@ -1167,4 +1168,4 @@ func (m *algoMockChain) IsDenied(height uint64, payloadHash common.Hash) (bool, 
 }
 func (m *algoMockChain) SetResetCallback(cb cc.ResetCallback) {}
 
-var _ cc.ChainContainer = (*algoMockChain)(nil)
+var _ cc.InteropChain = (*algoMockChain)(nil)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -828,7 +828,8 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 				i.metrics.InteropInvalidations.WithLabelValues(p.ChainID.String()).Inc()
 			}
 		}
-		// Resume non-invalidated chains. Invalidated chains are resumed by RewindEngine.
+		// Resume non-invalidated chains. Invalidated chains are resumed by
+		// RewindEngine internally (which also waits for readiness).
 		for chainID, chain := range i.chains {
 			if _, isInvalid := pending.Result.InvalidHeads[chainID]; !isInvalid {
 				if err := chain.Resume(i.ctx); err != nil {
@@ -839,6 +840,22 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		if failedAny {
 			return false, fmt.Errorf("one or more invalidations failed, transition preserved")
 		}
+		// Wait for all resumed chains to be ready for traffic before clearing
+		// the pending transition. Without this barrier the next verifier round
+		// (or external RPC traffic via the shared router gate) hits a chain
+		// whose new VN has not yet reached VNStateRunning. Runs only on the
+		// success path so the error path returns immediately on partial
+		// invalidation failure. Per-chain timeouts are absorbed by the natural
+		// verifier backoff loop, so we log and continue rather than return.
+		waitCtx, cancel := context.WithTimeout(i.ctx, cc.DefaultWaitReadyTimeout)
+		for chainID, chain := range i.chains {
+			if _, isInvalid := pending.Result.InvalidHeads[chainID]; !isInvalid {
+				if err := chain.WaitReady(waitCtx); err != nil {
+					i.log.Error("chain not ready after resume", "chainID", chainID, "err", err)
+				}
+			}
+		}
+		cancel()
 		if err := i.verifiedDB.ClearPendingTransition(); err != nil {
 			return false, fmt.Errorf("clear pending transition: %w", err)
 		}

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1831,6 +1831,10 @@ func (m *mockChainContainer) Resume(ctx context.Context) error {
 	return m.resumeErr
 }
 
+// WaitReady is a no-op for the mock: ordering tests assert
+// Resume/InvalidateBlock/PauseAndStopVN ordering, not readiness semantics.
+func (m *mockChainContainer) WaitReady(_ context.Context) error { return nil }
+
 func (m *mockChainContainer) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
 	if m.blockNumberToTimestampOverride != nil {
 		return m.blockNumberToTimestampOverride(ctx, blocknum)
@@ -2095,7 +2099,7 @@ func (m *mockChainContainer) IsDenied(height uint64, payloadHash common.Hash) (b
 }
 func (m *mockChainContainer) SetResetCallback(cb cc.ResetCallback) {}
 
-var _ cc.ChainContainer = (*mockChainContainer)(nil)
+var _ cc.InteropChain = (*mockChainContainer)(nil)
 
 func testLogger() gethlog.Logger {
 	return gethlog.New()

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -32,6 +32,21 @@ import (
 
 const virtualNodeVersion = "0.1.0"
 
+const (
+	// defaultWaitReadyPoll is the polling interval used by
+	// simpleChainContainer.WaitReady. Matches the RPC router's
+	// defaultGatePoll (25ms) so a WaitReady'ed container becomes
+	// routable on the very next router gate tick.
+	defaultWaitReadyPoll = 25 * time.Millisecond
+	// DefaultWaitReadyTimeout is the default upper bound on WaitReady when
+	// callers do not supply a ctx with their own deadline. Bounded so a
+	// stuck Resume cannot wedge the interop activity loop indefinitely;
+	// matches the RPC router's defaultGateTimeout (60s). Exported so
+	// callers in adjacent packages (e.g. interop activity) can derive
+	// their own ctx deadlines from a single source of truth.
+	DefaultWaitReadyTimeout = 60 * time.Second
+)
+
 // newEngineControllerFromConfig is the engine-controller constructor, overridable in tests.
 var newEngineControllerFromConfig = engine_controller.NewEngineControllerFromConfig
 
@@ -128,6 +143,11 @@ type InteropChain interface {
 	// callers must capture it at build time, before the rewind starts. Returns true if
 	// a rewind was triggered, false otherwise.
 	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) (bool, error)
+	// WaitReady blocks until IsRPCReady() returns true or ctx is cancelled / times out.
+	// Used by callers that must not return until the chain is actually ready to serve
+	// traffic after a Pause/Resume cycle. Returns ctx.Err() on cancellation or timeout;
+	// returns nil as soon as readiness is observed.
+	WaitReady(ctx context.Context) error
 }
 
 type virtualNodeFactory func(cfg *opnodecfg.Config, log gethlog.Logger, initOverrides *rollupNode.InitializationOverrides, appVersion string, superAuthority rollup.SuperAuthority) virtual_node.VirtualNode
@@ -311,6 +331,32 @@ func (c *simpleChainContainer) IsRPCReady() bool {
 	}
 	vn := c.getVN()
 	return vn != nil && vn.State() == virtual_node.VNStateRunning
+}
+
+// WaitReady polls IsRPCReady() until true or ctx is done. If ctx has no
+// deadline, applies DefaultWaitReadyTimeout as a safety bound so a stuck
+// container cannot wedge the caller indefinitely.
+func (c *simpleChainContainer) WaitReady(ctx context.Context) error {
+	if c.IsRPCReady() {
+		return nil
+	}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, DefaultWaitReadyTimeout)
+		defer cancel()
+	}
+	ticker := time.NewTicker(defaultWaitReadyPoll)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("WaitReady: %w", ctx.Err())
+		case <-ticker.C:
+			if c.IsRPCReady() {
+				return nil
+			}
+		}
+	}
 }
 
 func (c *simpleChainContainer) subPath(path string) string {
@@ -775,7 +821,16 @@ retryLoop:
 	if err != nil {
 		return err
 	}
-	c.log.Info("chain_container/RewindEngine: resumed container")
+
+	// Block until the new VN is installed and running. Without this barrier
+	// callers see RewindEngine return while the next Start() iteration is
+	// still constructing/starting the VN — any RPC traffic submitted in
+	// that window 503s on the router gate. Symmetric with the post-Resume
+	// barrier in interop.applyPendingTransition.
+	if err := c.WaitReady(ctx); err != nil {
+		return fmt.Errorf("RewindEngine: VN not ready after resume: %w", err)
+	}
+	c.log.Info("chain_container/RewindEngine: resumed container, VN ready")
 
 	return nil
 }

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -832,6 +832,12 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 	t.Run("calls engine Rewind with the supplied target and stops VN", func(t *testing.T) {
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()
+		// RewindEngine blocks on WaitReady after Resume; simulate the Start
+		// loop bringing the VN back up immediately after the successful Rewind.
+		mockEngine.rewindFunc = func(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error {
+			mockVN.setState(virtual_node.VNStateRunning)
+			return nil
+		}
 
 		chainID := eth.ChainIDFromUInt64(420)
 		log := createTestLogger(t)
@@ -843,12 +849,13 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 			vn:      mockVN,
 		}
 
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		rewindTimestamp := uint64(1234567890)
 		target := makeTarget(rewindTimestamp)
 		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: rewindTimestamp + 2}
-		err := c.RewindEngine(ctx, target, invalidatedBlock)
-		require.NoError(t, err)
+
+		require.NoError(t, c.RewindEngine(ctx, target, invalidatedBlock))
 
 		require.Equal(t, 1, mockEngine.rewindCalls, "engine.Rewind should be called once")
 		require.Same(t, target, mockEngine.rewindTarget, "engine.Rewind should receive the supplied target envelope")
@@ -961,11 +968,14 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()
 		callCount := 0
+		// RewindEngine blocks on WaitReady after Resume; simulate the Start
+		// loop bringing the VN back up immediately after the successful Rewind.
 		mockEngine.rewindFunc = func(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error {
 			callCount++
 			if callCount < 3 {
 				return context.DeadlineExceeded
 			}
+			mockVN.setState(virtual_node.VNStateRunning)
 			return nil
 		}
 
@@ -979,8 +989,8 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
-		err := c.RewindEngine(ctx, makeTarget(12345), invalidatedBlock)
-		require.NoError(t, err)
+
+		require.NoError(t, c.RewindEngine(ctx, makeTarget(12345), invalidatedBlock))
 		require.Equal(t, 3, mockEngine.rewindCalls, "engine.Rewind should be retried through DeadlineExceeded errors")
 		require.False(t, c.pause.Load(), "Container should be resumed after successful rewind")
 	})
@@ -1014,11 +1024,14 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()
 		failCount := 0
+		// RewindEngine blocks on WaitReady after Resume; simulate the Start
+		// loop bringing the VN back up immediately after the successful Rewind.
 		mockEngine.rewindFunc = func(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error {
 			failCount++
 			if failCount < 3 {
 				return engine_controller.ErrRewindFCUTargetFailed
 			}
+			mockVN.setState(virtual_node.VNStateRunning)
 			return nil
 		}
 
@@ -1030,11 +1043,215 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 		}
 
 		invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 12347}
-		err := c.RewindEngine(context.Background(), makeTarget(12345), invalidatedBlock)
-		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, c.RewindEngine(ctx, makeTarget(12345), invalidatedBlock))
 		require.Equal(t, 3, mockEngine.rewindCalls, "engine.Rewind should be called 3 times (2 failures + 1 success)")
 		require.False(t, c.pause.Load(), "Container should be resumed after successful rewind")
 	})
+}
+
+func TestChainContainer_WaitReady(t *testing.T) {
+	t.Parallel()
+
+	newReadyContainer := func(t *testing.T) *simpleChainContainer {
+		mockVN := newMockVirtualNode()
+		mockVN.state = virtual_node.VNStateRunning
+		return &simpleChainContainer{
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
+			vn:      mockVN,
+		}
+	}
+
+	t.Run("short-circuits when already ready", func(t *testing.T) {
+		t.Parallel()
+		c := newReadyContainer(t)
+		require.True(t, c.IsRPCReady())
+
+		start := time.Now()
+		err := c.WaitReady(context.Background())
+		require.NoError(t, err)
+		require.Less(t, time.Since(start), 10*time.Millisecond, "ready short-circuit should not poll")
+	})
+
+	t.Run("blocks while not ready, returns nil once ready", func(t *testing.T) {
+		t.Parallel()
+		c := &simpleChainContainer{
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
+		}
+		c.pause.Store(true)
+
+		done := make(chan error, 1)
+		go func() { done <- c.WaitReady(context.Background()) }()
+
+		select {
+		case <-done:
+			t.Fatal("WaitReady returned while container was paused")
+		case <-time.After(50 * time.Millisecond):
+		}
+
+		// Mirror the Start loop: install a fresh running VN, then unpause.
+		readyVN := newMockVirtualNode()
+		readyVN.state = virtual_node.VNStateRunning
+		c.setVN(readyVN)
+		c.pause.Store(false)
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("WaitReady did not return after container became ready")
+		}
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		t.Parallel()
+		c := &simpleChainContainer{
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
+		}
+		c.pause.Store(true)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- c.WaitReady(ctx) }()
+
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+
+		select {
+		case err := <-done:
+			require.Error(t, err)
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("WaitReady did not return after ctx cancel")
+		}
+	})
+
+	t.Run("respects context deadline", func(t *testing.T) {
+		t.Parallel()
+		c := &simpleChainContainer{
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
+		}
+		c.pause.Store(true)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		err := c.WaitReady(ctx)
+		elapsed := time.Since(start)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Greater(t, elapsed, 90*time.Millisecond)
+		require.Less(t, elapsed, 500*time.Millisecond, "should not wait beyond caller deadline")
+	})
+
+	t.Run("returns error when stopped even with running VN", func(t *testing.T) {
+		t.Parallel()
+		// Distinct from the pause path: stop=true permanently closes the gate.
+		// Locks in that WaitReady never short-circuits past a stopped container,
+		// even when a running VN is still installed.
+		runningVN := newMockVirtualNode()
+		runningVN.state = virtual_node.VNStateRunning
+		c := &simpleChainContainer{
+			chainID: eth.ChainIDFromUInt64(420),
+			log:     createTestLogger(t),
+			vn:      runningVN,
+		}
+		c.stop.Store(true)
+		require.False(t, c.IsRPCReady())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		err := c.WaitReady(ctx)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+}
+
+// TestChainContainer_RewindEngine_WaitsForVNReady proves the WaitReady barrier
+// in RewindEngine: the call does not return until the chain is ready to serve
+// traffic, even when VN installation lags behind Resume.
+func TestChainContainer_RewindEngine_WaitsForVNReady(t *testing.T) {
+	t.Parallel()
+
+	mockVN := newMockVirtualNode()
+	mockVN.state = virtual_node.VNStateRunning
+	mockEngine := newMockEngineController()
+
+	// rewindCalled fires once engine.Rewind has been entered — proves
+	// RewindEngine has progressed past Pause + vn.Stop and is now committed
+	// to the Resume + WaitReady path. Using this signal instead of polling
+	// !c.pause.Load() avoids racing against the goroutine start: pause
+	// defaults to false, so a polling check could return immediately before
+	// RewindEngine ever ran.
+	rewindCalled := make(chan struct{})
+	mockEngine.rewindFunc = func(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error {
+		close(rewindCalled)
+		return nil
+	}
+
+	c := &simpleChainContainer{
+		chainID: eth.ChainIDFromUInt64(420),
+		log:     createTestLogger(t),
+		engine:  mockEngine,
+		vn:      mockVN,
+	}
+
+	target := &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: eth.Uint64Quantity(99),
+			Timestamp:   eth.Uint64Quantity(1234567890),
+			BlockHash:   common.Hash{0xaa},
+			ParentHash:  common.Hash{0xab},
+		},
+	}
+	invalidatedBlock := eth.BlockRef{Number: 100, Hash: common.Hash{0x1}, ParentHash: common.Hash{0x2}, Time: 1234567892}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- c.RewindEngine(ctx, target, invalidatedBlock) }()
+
+	// Confirm RewindEngine reached engine.Rewind. After this returns, the
+	// goroutine is committed to Resume → WaitReady. mockVN has already been
+	// Stop'd (state=Stopped), so IsRPCReady() is false and WaitReady polls.
+	select {
+	case <-rewindCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("engine.Rewind was not called within timeout")
+	}
+
+	// Simulate the Start loop spinning up a new VN after a delay. Until this
+	// completes, RewindEngine must remain blocked inside WaitReady.
+	const installDelay = 200 * time.Millisecond
+	start := time.Now()
+	time.Sleep(installDelay)
+	select {
+	case <-done:
+		t.Fatal("RewindEngine returned before a running VN was installed")
+	default:
+	}
+	freshVN := newMockVirtualNode()
+	freshVN.state = virtual_node.VNStateRunning
+	c.setVN(freshVN)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("RewindEngine did not return after a running VN was installed")
+	}
+
+	require.GreaterOrEqual(t, time.Since(start), installDelay, "RewindEngine should have blocked through VN install")
+	require.True(t, c.IsRPCReady(), "container should be ready after RewindEngine returns")
 }
 
 // TestChainContainer_VirtualNodeIntegration tests interaction with VirtualNode


### PR DESCRIPTION
## Summary

`TestSupernodeInteropInvalidMessageReplacement` flaked on deferred liveness: after invalidating a bad executing message, the test would send a fresh transfer and time out waiting for the sequencer to accept it (~10-20% failure rate).

Root cause: `RewindEngine` and `applyPendingTransition`'s `DecisionInvalidate` arm called `chain.Resume(ctx)` and returned. But `Resume` only flips a pause flag — the chain container's `Start` loop still needs time to construct, start, and observe `VNStateRunning` on a new `VirtualNode`. Between `Resume` returning and the next `Start()` iteration installing the VN, `IsRPCReady()` is false and the RPC router gate 503s any traffic. Callers had no way to wait for that.

Fix: add `WaitReady(ctx) error` to the `InteropChain` interface and call it after `Resume` at both sites. `WaitReady` polls `IsRPCReady()` at 25 ms (matching the router's `defaultGatePoll`) with a 60 s safety bound.

Structural protection: compile-time conformance assertions (`var _ InteropChain = (*…)(nil)`) on `simpleChainContainer`, `algoMockChain`, and `mockChainContainer` force any new implementer to provide `WaitReady`. A future caller that adds a third `Resume` site without the companion `WaitReady` is still possible, but the two existing sites carry comments explaining the pairing, and the unit + acceptance tests will catch the regression symptom.

## Changes

- `op-supernode/supernode/chain_container/chain_container.go`
  - Add `WaitReady(ctx context.Context) error` to the `InteropChain` interface (preserves `ChainContainer`-only consumers like `mockCC`).
  - Implement on `simpleChainContainer`: short-circuit if ready, otherwise 25 ms ticker + 60 s default timeout.
  - Call `WaitReady` from `RewindEngine` after the explicit `Resume`.
- `op-supernode/supernode/activity/interop/interop.go`
  - `applyPendingTransition`'s `DecisionInvalidate` arm: after resuming non-invalidated chains, two-loop pattern resumes all then `WaitReady`s all, bounded by `DefaultWaitReadyTimeout`.
- `op-supernode/supernode/activity/interop/algo_test.go`, `interop_test.go`
  - Add no-op `WaitReady` to `algoMockChain` and `mockChainContainer`; strengthen their `var _` assertions from `ChainContainer` to `InteropChain` so future renames break loudly.
- `op-supernode/supernode/chain_container/chain_container_test.go`
  - New `TestChainContainer_WaitReady` (5 subtests) and `TestChainContainer_RewindEngine_WaitsForVNReady`.
  - Three existing `TestChainContainer_RewindEngine` subtests adapted to the new barrier via `rewindFunc` + `mockVN.setState(VNStateRunning)` — simulating the production Start loop bringing the VN back up. All original assertions preserved.

## Test Plan

- [x] `go build ./op-supernode/...` clean
- [x] `go vet ./op-supernode/...` clean
- [x] `go test ./op-supernode/...` — full suite green
- [x] Unit-test stress (`-count=20`, `TestChainContainer_RewindEngine|TestChainContainer_WaitReady`): 20/20 pass (155 s)
- [x] Pre-fix vs post-fix comparative stress (5x, same-machine, see plan for full data):
  | Variant | Failed runs | Failed subtest invocations |
  |---|---|---|
  | Pre-fix Eventually pattern | 5/5 | 13/15 |
  | Post-fix rewindFunc+setState | 0/5 | 0/15 |
- [x] Single-iteration `TestSupernodeInteropInvalidMessageReplacement` passed locally (prior session)
- [ ] CI: 3 acceptance-test backend combos (`opn-op-geth`, `opn-op-reth`, `kona-op-reth`) will exercise the test against the new barrier

## Notes for reviewers

- `mockCC` test doubles in `supernode_test.go` and `superroot_test.go` intentionally implement `ChainContainer` (not `InteropChain`) — they don't trigger reorg paths, so no `WaitReady` method is needed. Verified the compile-time set of `var _` assertions is exactly as expected.
- The `defer c.Resume(context.Background())` in `RewindEngine` is preserved as the cancellation-safety net; the new explicit `Resume` → `WaitReady` sequence on the happy path is what guarantees readiness before return.
- `WaitReady`'s 60 s timeout matches the router's existing `defaultGateTimeout`. If a VN cannot come up in 60 s, downstream RPC would have failed anyway; the acceptance tests already budget ≥ 150 s for `AwaitValidatedTimestamp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)