### PR TITLE
op-devstack: add op-rbuilder as el option

### DIFF
--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -48,6 +48,7 @@ const (
 	MixedL2ELOpGeth   MixedL2ELKind = "op-geth"
 	MixedL2ELOpReth   MixedL2ELKind = "op-reth"
 	MixedL2ELOpRethV2 MixedL2ELKind = "op-reth-proof-v2"
+	MixedOpRbuilder   MixedL2ELKind = "op-rbuilder"
 )
 
 type MixedL2CLKind string

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -156,6 +156,8 @@ func startL2ELForKey(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [3
 		return startL2ELNode(t, l2Net, jwtPath, jwtSecret, key, identity)
 	case MixedL2ELOpRethV2:
 		return startMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, nil, "v2", opts...)
+	case MixedOpRbuilder:
+		return startBuilderEL(t, l2Net, jwtPath, identity)
 	default: // op-reth v1
 		return startMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, nil, "v1", opts...)
 	}


### PR DESCRIPTION
For now, using this for manual testing of Osaka on L2 against rbuilder. In the future we may want to run all tests against rbuilder in ci (and explicitly skip on tests where it is expected to fail due to feature gaps with op-reth).