### PR TITLE
fix(ci): force always-succeed on rust skip-path gates

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1186,6 +1186,7 @@ workflows:
     when: << pipeline.parameters.c-run_rust_ci_gate_short >>
     jobs:
       - required-rust-ci:
+          always-succeed: true
           context:
             - circleci-api-token
 

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -291,5 +291,6 @@ workflows:
     when: << pipeline.parameters.c-run_rust_e2e_gate_skip >>
     jobs:
       - required-rust-e2e:
+          always-succeed: true
           context:
             - circleci-api-token


### PR DESCRIPTION
## Problem

Docs-only PRs were failing CI with:

```
required-rust-e2e: ERROR: no dependency IDs found — possible API failure or gate job "required-rust-e2e" not found in workflow
```

#20863 ("make rust skip jobs trivial") correctly stripped the expensive build/test jobs out of the two skip-path workflows (`rust-ci-gate-short`, `rust-e2e-gate-skip`) so docs-only PRs finish fast. But it left the fan-in gate jobs (`required-rust-ci` / `required-rust-e2e`) with **no `requires` and no `always-succeed: true`**.

The `utils/ci-gate` command (from `ethereum-optimism/circleci-utils@1.0.27`) defaults to `always-succeed: false`, which makes it query the CircleCI API for its upstream dependency job IDs and verify they passed. With the upstreams removed, that query returns nothing → the gate errors out.

## Fix

Pass `always-succeed: true` on both skip-path gate jobs so they emit the required status-check name without querying dependencies. This matches the established pattern used by `ci-gate-skip` (`main.yml:3202`) and `contracts-feature-tests-short` (`main.yml:3188`).

The full `main` / `rust-e2e-ci` workflows still run the real gate (`always-succeed` defaults to `false`), so enforcement on actual rust changes is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)