### PR TITLE
chore: remove unused kona interop action-test recipe

### DIFF
--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -266,7 +266,8 @@ workflows:
             - contracts-bedrock-build
             - cannon-prestate
             - rust-workspace-release
-      # Proof tests - single kind only, interop excluded per original config
+      # Proof action tests - single-chain only. Interop proof coverage runs
+      # under kona-host in op-acceptance-tests, not as action tests.
       - kona-proof-action-tests:
           name: kona-proof-action-single
           kind: single

--- a/rust/kona/tests/justfile
+++ b/rust/kona/tests/justfile
@@ -267,23 +267,6 @@ action-tests-single-run test_name='.*' parallel="0" *args='':
     --jsonfile=./tmp/testlogs/log.json \
     -- -count=1 -parallel=$PARALLEL -timeout=60m -run "{{test_name}}"
 
-# Run action tests for the interop client program on the native target
-action-tests-interop test_name='TestInteropFaultProofs' *args='': action-tests-build (action-tests-interop-run test_name args)
-
-action-tests-interop-run test_name='TestInteropFaultProofs' *args='':
-  #!/bin/bash
-  set -euo pipefail
-
-  echo "Building host program for the native target"
-  just build-native --bin kona-host
-  export KONA_HOST_PATH="{{SOURCE}}/../target/debug/kona-host"
-
-  # GitHub actions patch - do not print logs.
-  # https://github.com/gotestyourself/gotestsum/blob/b4b13345fee56744d80016a20b760d3599c13504/testjson/format.go#L442-L444
-  echo "Running action tests for the client program on the native target"
-
-  cd {{SOURCE}}/../../../op-e2e/actions/interop && GITHUB_ACTIONS=false {{SOURCE}}/../../../ops/scripts/gotestsum-split.sh --format=short-verbose -- -count=1 -timeout 60m -run "{{test_name}}" {{args}}
-
 update-packages:
     #!/bin/bash
     cd {{SOURCE}}/optimism/op-deployer && just build-contracts copy-contract-artifacts


### PR DESCRIPTION
The `action-tests-interop` / `action-tests-interop-run` recipes in `rust/kona/tests/justfile` are dead code: they target `op-e2e/actions/interop`, which was deleted when interop fault-proof coverage moved to `op-acceptance-tests` (where it runs under kona-host via the devstack super fault-proof runner, not as an action test). Nothing in CI or any other justfile invokes them.

This removes the orphaned recipes and corrects the now-misleading "interop excluded per original config" comment in `rust-e2e.yml` to point at the real home of interop proof coverage.