### PR TITLE
feat(op-alloy-network): make reqwest opt-in

### DIFF
--- a/rust/op-alloy/crates/network/Cargo.toml
+++ b/rust/op-alloy/crates/network/Cargo.toml
@@ -22,10 +22,20 @@ op-alloy-rpc-types = { workspace = true, features = ["std"] }
 # Alloy
 alloy-consensus.workspace = true
 alloy-network.workspace = true
-alloy-provider.workspace = true
+# `alloy-provider` is declared explicitly (rather than `workspace = true`) so the
+# `reqwest` HTTP transport can be made opt-in via the `reqwest` feature below. The
+# `Optimism` network marker and the `RecommendedFillers` impl only use transport-agnostic
+# types from `alloy-provider`, so an HTTP backend is not required to depend on this crate.
+alloy-provider = { version = "2.0.5", default-features = false, features = ["debug-api"] }
 alloy-rpc-types-eth.workspace = true
 
 [features]
+default = ["reqwest"]
+# Enables `alloy-provider`'s reqwest-based HTTP transport. On by default to preserve
+# existing behavior; type-only consumers (e.g. zkVM targets without OS networking) can
+# set `default-features = false` to avoid pulling `reqwest` / `hyper` / `tokio` (`net`) /
+# `mio` / `socket2`.
+reqwest = ["alloy-provider/reqwest"]
 std = [
 	"op-alloy-consensus/std",
 	"op-alloy-rpc-types/std",


### PR DESCRIPTION
## Summary

Makes `alloy-provider`'s `reqwest` HTTP transport an **opt-in** feature of `op-alloy-network`, while preserving current behavior by enabling it in `default`.

## Why

`op-alloy-network` inherits `alloy-provider` from the workspace, which enables `["reqwest", "debug-api"]`. This **unconditionally** pulls the reqwest HTTP transport — and therefore `reqwest → hyper → tokio (net) → mio / socket2` — into every consumer of `op-alloy-network`, even those that only use the `Optimism` network marker type or `RecommendedFillers`.

Those types are transport-agnostic: the `Optimism` `Network` impl and the `RecommendedFillers` impl only use `alloy_provider::fillers::{ChainIdFiller, GasFiller, JoinFill, NonceFiller, RecommendedFillers}`, none of which require an HTTP backend. The forced `reqwest` breaks `std` targets that lack OS networking syscalls — e.g. the `riscv64im-succinct-zkvm` zkVM target, where `mio`/`socket2` fail to compile (`clock_gettime`/socket APIs unavailable).

## Change

`rust/op-alloy/crates/network/Cargo.toml`:
- Declare `alloy-provider` explicitly (instead of `workspace = true`) so its feature set can be controlled per-crate, with `default-features = false, features = ["debug-api"]` (no `reqwest`). `debug-api` only adds type-level RPC extensions (`alloy-rpc-types-trace`/`-debug`), no networking.
- Add a `reqwest = ["alloy-provider/reqwest"]` feature.
- Add `default = ["reqwest"]`.

## Backward compatibility

- **Default consumers** (`default-features = true`): unchanged — `default` still enables `reqwest`.
- **Type-only / zkVM consumers**: can set `default-features = false` to drop `reqwest` (and the `hyper`/`tokio(net)`/`mio`/`socket2` chain) while still using the `Optimism` marker and fillers.
- No public API names changed.

## Validation

Downstream (succinctlabs/rsp, SP1 zkVM `rsp-client-op` ELF for `riscv64im-succinct-zkvm`): with this change applied via `[patch.crates-io]` and `op-alloy-network = { default-features = false }`, `mio`/`socket2`/`reqwest`/`hyper` are absent from the compiled feature graph and the ELF builds. Default (host) builds are unaffected.