### PR TITLE
feat(op-reth): make chainspec reth-codec opt-in

### DIFF
--- a/rust/op-reth/crates/chainspec/Cargo.toml
+++ b/rust/op-reth/crates/chainspec/Cargo.toml
@@ -20,7 +20,7 @@ reth-network-peers.workspace = true
 
 # op-reth
 reth-optimism-forks.workspace = true
-reth-optimism-primitives = { workspace = true, features = ["serde", "reth-codec"] }
+reth-optimism-primitives = { workspace = true, features = ["serde"] }
 
 # ethereum
 alloy-chains.workspace = true
@@ -51,7 +51,12 @@ reth-chainspec = { workspace = true, features = ["test-utils"] }
 alloy-op-hardforks.workspace = true
 
 [features]
-default = ["std"]
+default = ["std", "reth-codec"]
+# Enables `reth-optimism-primitives`' reth-codec (Compact DB codec / zstd compression).
+# On by default to preserve existing behavior; type-only consumers (e.g. zkVM targets) can
+# set `default-features = false` to avoid the native `zstd-sys` C build, which this crate
+# does not need (it has no Compact/zstd usage of its own).
+reth-codec = ["reth-optimism-primitives/reth-codec"]
 superchain-configs = ["miniz_oxide", "paste", "tar-no-std", "thiserror", "thiserror", "dep:serde"]
 std = [
     "alloy-chains/std",


### PR DESCRIPTION
## Summary

Makes the `reth-codec` feature **opt-in** for `reth-optimism-chainspec` (on by default to preserve behavior), so type-only consumers can avoid the native `zstd-sys` C build.

## Why

`reth-optimism-chainspec` force-enables `reth-codec` on its `reth-optimism-primitives` dependency:
```toml
reth-optimism-primitives = { workspace = true, features = ["serde", "reth-codec"] }
```
Because this is in the dependency line (not gated by a feature), it is **unconditional**: every consumer of `reth-optimism-chainspec` transitively pulls
`reth-optimism-primitives/reth-codec → op-alloy-consensus/reth-codec → reth-zstd-compressors → zstd → zstd-sys` (native C).

`reth-optimism-chainspec` itself has **no `Compact` / `reth_codec` / `reth_zstd` usage** — the feature is only there for downstream convenience. The forced native zstd C build breaks `std` targets without a C cross-compiler — e.g. the `riscv64im-succinct-zkvm` zkVM target, where `zstd-sys` fails (`cc: unrecognized argument -mabi=lp64`).

## Change

`rust/op-reth/crates/chainspec/Cargo.toml`:
- Drop `reth-codec` from the unconditional `reth-optimism-primitives` dep features (keep `serde`).
- Add `reth-codec = ["reth-optimism-primitives/reth-codec"]`.
- Add `reth-codec` to `default` (was `default = ["std"]` → `["std", "reth-codec"]`).

## Backward compatibility

- **Default consumers**: unchanged — `default` still enables `reth-codec`.
- **Type-only / zkVM consumers**: set `default-features = false` to drop `reth-codec` and the `reth-zstd-compressors`/`zstd`/`zstd-sys` chain.
- No public API names changed; `reth-optimism-chainspec` builds the same with default features.

## Validation

Downstream (succinctlabs/rsp, SP1 zkVM `rsp-client-op` ELF for `riscv64im-succinct-zkvm`): with this applied (+ `default-features = false` on the chainspec edge), `zstd-sys`/`zstd`/`reth-zstd-compressors` are absent from the compiled feature graph. Default (host) builds are unaffected.