### PR TITLE
docs(chain-operators): default batcher / operations / snap-sync / troubleshooting to op-reth

### DIFF
--- a/docs/public-docs/chain-operators/guides/configuration/batcher.mdx
+++ b/docs/public-docs/chain-operators/guides/configuration/batcher.mdx
@@ -92,8 +92,8 @@ There are two throttling knobs:
 
 **Feature requirements**
 
-*   This new feature is enabled by default and requires running op-geth version `v1.101411.1` or later. It can be disabled by setting `--throttle-threshold` to 0. The sequencer's op-geth node has to be updated first, before updating the batcher, so that the new required RPC is available at the time of the batcher restart.
-*   It is required to upgrade to `op-conductor/v0.2.0` if you are using conductor's leader-aware rpc proxy feature. This conductor release includes support for the `miner_setMaxDASize` op-geth rpc proxy.
+*   This feature is enabled by default and requires the sequencer's `op-reth` node to expose the `miner_setMaxDASize` RPC (enable the `miner` namespace, below). It can be disabled by setting `--throttle-threshold` to 0. The sequencer's `op-reth` node has to be updated first, before updating the batcher, so that the required RPC is available at the time of the batcher restart.
+*   It is required to upgrade to `op-conductor/v0.2.0` if you are using conductor's leader-aware rpc proxy feature. This conductor release includes support for proxying the `miner_setMaxDASize` RPC.
 
 **Configuration**
 
@@ -110,21 +110,21 @@ The batcher is configured for throttling by default with the parameters describe
 
 For full details, see the [readme](https://github.com/ethereum-optimism/optimism/blob/develop/op-batcher/readme.md).
 
-If the batcher at startup has throttling enabled and the sequencer's `op-geth` instance to which it's talking doesn't have the `miner_setMaxDASize` RPC enabled, it will fail with an error message like:
+If the batcher at startup has throttling enabled and the sequencer's `op-reth` node to which it's talking doesn't have the `miner_setMaxDASize` RPC enabled, it will fail with an error message like:
 
 ```
 lvl=warn msg="Served miner_setMaxDASize" reqid=1 duration=11.22µs err="the method miner_setMaxDASize does not exist/is not available"
 In this case, make sure the miner API namespace is enabled for the correct transport protocol (HTTP or WS), see next paragraph.
 ```
 
-The new RPC `miner_setMaxDASize` is available in `op-geth` since `v1.101411.1`. It has to be enabled by adding the miner namespace to the correct API flags, like
+The `miner_setMaxDASize` RPC has to be enabled by adding the `miner` namespace to `op-reth`'s API flags:
 
 ```
-GETH_HTTP_API: web3,debug,eth,txpool,net,miner
-GETH_WS_API: debug,eth,txpool,net,miner
+--http.api=web3,debug,eth,txpool,net,miner
+--ws.api=web3,debug,eth,txpool,net,miner
 ```
 
-It is recommended to add it to both, HTTP and WS.
+It is recommended to add it to both HTTP and WS.
 
 ## Example configuration
 

--- a/docs/public-docs/chain-operators/guides/features/snap-sync.mdx
+++ b/docs/public-docs/chain-operators/guides/features/snap-sync.mdx
@@ -3,7 +3,7 @@ title: Using snap sync for chain operators
 description: Learn how to enable snap sync on your OP Stack chain.
 ---
 
-Snap sync significantly improves the experience of syncing an OP Stack node. Snap sync is optionally enabled on `op-node` & `op-reth`.
+Snap sync significantly improves the experience of syncing an OP Stack node. Snap sync is a native feature of go-ethereum that is now optionally enabled on `op-node` & `op-geth`.
 Snap sync works by downloading a snapshot of the state from other nodes on the network and is then able to start executing blocks from the completed state rather than having to re-execute every single block.
 This means that performing a snap sync is significantly faster than performing a full sync.
 
@@ -16,16 +16,16 @@ To enable snap sync, chain operators need to spin up a node which is exposed to 
 This node will serve snap sync requests on the execution layer from other nodes on the network.
 
 <Info>
-For snap sync, all `op-reth` nodes should expose port `30303` TCP and `30303` UDP to easily find other `op-reth` nodes to sync from. 
-  *   If you set the UDP discovery port with `--discovery.port`, then you must open the port specified for UDP.
-  *   If you set the TCP listening port with `--port`, then you must open the port specified for TCP.
+For snap sync, all `op-geth` nodes should expose port `30303` TCP and `30303` UDP to easily find other `op-geth` nodes to sync from. 
+  *   If you set the port with [`--discovery.port`](/node-operators/reference/op-geth-config#discovery-port), then you must open the port specified for UDP.
+  *   If you set [`--port`](/node-operators/reference/op-geth-config#port), then you must open the port specified for TCP.
   *   The only exception is for sequencers and transaction ingress nodes.
 </Info>
 
 <Steps>
   <Step title="Setup a snap sync node">
-  *   Expose port `30303` (`op-reth`'s default discovery port) to the internet on TCP and UDP.
-    *   Disable transaction gossip with the `--rollup.disable-tx-pool-gossip` flag
+  *   Expose port `30303` (`op-geth`'s default discovery port) to the internet on TCP and UDP.
+    *   Disable transaction gossip with the [`--rollup.disabletxpoolgossip`](/node-operators/reference/op-geth-config#rollupdisabletxpoolgossip) flag
   </Step>
 
   <Step title="Enable snap sync on your network">

--- a/docs/public-docs/chain-operators/guides/features/snap-sync.mdx
+++ b/docs/public-docs/chain-operators/guides/features/snap-sync.mdx
@@ -3,7 +3,7 @@ title: Using snap sync for chain operators
 description: Learn how to enable snap sync on your OP Stack chain.
 ---
 
-Snap sync significantly improves the experience of syncing an OP Stack node. Snap sync is a native feature of go-ethereum that is now optionally enabled on `op-node` & `op-geth`.
+Snap sync significantly improves the experience of syncing an OP Stack node. Snap sync is optionally enabled on `op-node` & `op-reth`.
 Snap sync works by downloading a snapshot of the state from other nodes on the network and is then able to start executing blocks from the completed state rather than having to re-execute every single block.
 This means that performing a snap sync is significantly faster than performing a full sync.
 
@@ -16,16 +16,16 @@ To enable snap sync, chain operators need to spin up a node which is exposed to 
 This node will serve snap sync requests on the execution layer from other nodes on the network.
 
 <Info>
-For snap sync, all `op-geth` nodes should expose port `30303` TCP and `30303` UDP to easily find other `op-geth` nodes to sync from. 
-  *   If you set the port with [`--discovery.port`](/node-operators/reference/op-geth-config#discovery-port), then you must open the port specified for UDP.
-  *   If you set [`--port`](/node-operators/reference/op-geth-config#port), then you must open the port specified for TCP.
+For snap sync, all `op-reth` nodes should expose port `30303` TCP and `30303` UDP to easily find other `op-reth` nodes to sync from. 
+  *   If you set the UDP discovery port with `--discovery.port`, then you must open the port specified for UDP.
+  *   If you set the TCP listening port with `--port`, then you must open the port specified for TCP.
   *   The only exception is for sequencers and transaction ingress nodes.
 </Info>
 
 <Steps>
   <Step title="Setup a snap sync node">
-  *   Expose port `30303` (`op-geth`'s default discovery port) to the internet on TCP and UDP.
-    *   Disable transaction gossip with the [`--rollup.disabletxpoolgossip`](/node-operators/reference/op-geth-config#rollupdisabletxpoolgossip) flag
+  *   Expose port `30303` (`op-reth`'s default discovery port) to the internet on TCP and UDP.
+    *   Disable transaction gossip with the `--rollup.disable-tx-pool-gossip` flag
   </Step>
 
   <Step title="Enable snap sync on your network">

--- a/docs/public-docs/chain-operators/guides/management/operations.mdx
+++ b/docs/public-docs/chain-operators/guides/management/operations.mdx
@@ -32,8 +32,8 @@ An orderly shutdown is done in the reverse order to the order in which component
   This component is stateless, so you can just stop the process.
   </Step>
 
-  <Step title="Stop `op-geth`">
-  Make sure you use **CTRL-C** to avoid database corruption. If Geth stops unexpectedly the database can be corrupted. This is known as an "[unclean shutdown](https://geth.ethereum.org/docs/fundamentals/databases#unclean-shutdowns)" and it can lead to a variety of problems for the node when it is restarted.
+  <Step title="Stop `op-reth`">
+  Use **CTRL-C** (SIGINT) so the execution client shuts down gracefully and flushes its database. Killing the process abruptly can leave the database in an inconsistent state and cause problems on the next start.
   </Step>
 </Steps>
 
@@ -41,7 +41,7 @@ An orderly shutdown is done in the reverse order to the order in which component
 
 To restart the blockchain, use the same order of components you did when you initialized it.
 <Steps>
-  <Step title="Start `op-geth`">
+  <Step title="Start `op-reth`">
   
   </Step>
 
@@ -155,36 +155,36 @@ This script will NOT work for chain operators trying to generate this data in or
 
 ## Adding nodes
 
-To add nodes to the rollup, you need to initialize `op-node` and `op-geth`, similar to what you did for the first node.
+To add nodes to the rollup, you need to initialize `op-node` and `op-reth`, similar to what you did for the first node.
 You should *not* add an `op-batcher` because there should be only one.
 <Steps>
   <Step title="Configure the OS and prerequisites as you did for the first node">
   
   </Step>
 
-  <Step title="Build the Optimism monorepo and `op-geth` as you did for the first node">
+  <Step title="Install `op-reth` and `op-node` as you did for the first node">
   
   </Step>
 
   <Step title="Copy from the first node these files:">
   ```bash
-      ~/op-geth/genesis.json
+      ~/op-reth/genesis.json
       ~/optimism/op-node/rollup.json
       ```
   </Step>
 
   <Step title="Create a new `jwt.txt` file as a shared secret:">
   ```bash
-      cd ~/op-geth
+      cd ~/op-reth
       openssl rand -hex 32 > jwt.txt
       cp jwt.txt ~/optimism/op-node
       ```
   </Step>
 
-  <Step title="Initialize the new op-geth:">
+  <Step title="Initialize the new op-reth:">
   ```bash
-      cd ~/op-geth
-      ./build/bin/geth init --datadir=./datadir ./genesis.json
+      cd ~/op-reth
+      op-reth init --chain=./genesis.json --datadir=./datadir
       ```
   </Step>
 
@@ -193,9 +193,9 @@ You should *not* add an `op-batcher` because there should be only one.
       If you already have peer to peer synchronization, add the new node to the `--p2p.static` list so it can synchronize.
   </Step>
 
-  <Step title="Start `op-geth` (using the same command line you used on the initial node)">
+  <Step title="Start `op-reth` (using the same command line you used on the initial node)">
   <Info>
-  **Important:** Make sure to configure the `--rollup.sequencerhttp` flag to point to your sequencer node. This HTTP endpoint is crucial because `op-geth` will route `eth_sendRawTransaction` calls to this URL. The OP Stack does not currently have a public mempool, so configuring this is required if you want your node to support transaction submission.
+  **Important:** Make sure to configure the `--rollup.sequencer` flag (alias `--rollup.sequencer-http`) to point to your sequencer node. This endpoint is crucial because `op-reth` will route `eth_sendRawTransaction` calls to this URL. The OP Stack does not currently have a public mempool, so configuring this is required if you want your node to support transaction submission.
   </Info>
   </Step>
 

--- a/docs/public-docs/chain-operators/guides/management/troubleshooting.mdx
+++ b/docs/public-docs/chain-operators/guides/management/troubleshooting.mdx
@@ -38,18 +38,17 @@ WARN [02-16|21:22:02.868] Derivation process temporary error       attempts=14 e
 
 ### Solution
 
-This error can occur when the data directory for `op-geth` becomes corrupted (for example, as a result of a computer crash).
+This error can occur when the data directory for `op-reth` becomes corrupted (for example, as a result of a computer crash).
 You will need to reinitialize the data directory.
 
-If you are following the tutorial for [Creating Your Own L2 Rollup](/chain-operators/tutorials/create-l2-rollup/create-l2-rollup), make sure to rerun the commands within the [Initialize `op-geth`](/operators/chain-operators/tutorials/create-l2-rollup#initialize-op-geth) section.
+If you are following the tutorial for [Creating Your Own L2 Rollup](/chain-operators/tutorials/create-l2-rollup/create-l2-rollup), make sure to rerun the commands within the [Spin up sequencer](/chain-operators/tutorials/create-l2-rollup/op-reth-setup) section.
 
 If you are not following the tutorial, make sure to take the following steps:
 
-1.  Stop `op-node` and `op-geth`.
-2.  Delete the corresponding `op-geth` data directory.
-3.  If running a Sequencer node, import the Sequencer key into the `op-geth` keychain.
-4.  Reinitialize `op-geth` with the `genesis.json` file.
-5.  Restart `op-geth` and `op-node`.
+1.  Stop `op-node` and `op-reth`.
+2.  Delete the corresponding `op-reth` data directory.
+3.  Reinitialize `op-reth` with the `genesis.json` file: `op-reth init --chain=./genesis.json --datadir=./datadir`.
+4.  Restart `op-reth` and `op-node`.
 
 ## Batcher unable to publish transaction
 


### PR DESCRIPTION
## Description

Replace op-geth with op-reth across the chain-operator operational guides so an operator following any of them defaults to op-reth (op-geth reached end-of-support on 2026-05-31 and will not support Glamsterdam). These pages are taken fully op-reth — no op-geth references and no deprecation banner.

Pages updated:

- **`configuration/batcher.mdx`** — DA-throttling section: `miner_setMaxDASize` is framed as an op-reth RPC (enable the `miner` namespace); `GETH_HTTP_API`/`GETH_WS_API` examples replaced with op-reth `--http.api`/`--ws.api`.
- **`management/operations.mdx`** — stop/start steps and the "adding nodes" procedure use `op-reth init --chain --datadir` and `--rollup.sequencer`; the geth-specific unclean-shutdown link is replaced with a generic graceful-shutdown note.
- **`features/snap-sync.mdx`** — op-reth nodes/ports; `--rollup.disabletxpoolgossip` → `--rollup.disable-tx-pool-gossip`; dropped the `op-geth-config` reference deep-links.
- **`management/troubleshooting.mdx`** — corrupted-datadir recovery uses `op-reth init` (4 steps; dropped the op-geth keychain step — the sequencer key lives on `op-node` via `--p2p.sequencer.key`, not the EL).

All flag examples were verified against op-reth `v2.2.5`.

> Note: `management/snap-sync.mdx` (listed in the issue's action items) does not exist on `develop`; only `features/snap-sync.mdx` was present, so this PR covers 4 pages.

Refs ethereum-optimism/solutions#691
