### PR TITLE
chore(alloy-op-evm): drop dead-on-read sender/evm_gas_used from OpTxResult

### DIFF
--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -276,10 +276,6 @@ pub struct OpTxResult<H, T> {
     pub is_deposit: bool,
     /// Whether the transaction is a post-exec transaction.
     pub is_post_exec: bool,
-    /// The sender of the transaction.
-    pub sender: Address,
-    /// Gas used returned by normal EVM execution, before any canonical post-exec adjustment.
-    pub evm_gas_used: u64,
     /// Canonical gas used after any post-exec adjustment.
     pub canonical_gas_used: u64,
     /// Canonical post-exec adjustment, if any.
@@ -813,8 +809,6 @@ where
                 },
                 is_deposit: false,
                 is_post_exec: true,
-                sender: *tx.signer(),
-                evm_gas_used: 0,
                 canonical_gas_used: 0,
                 post_exec: None,
                 depositor_nonce: None,
@@ -920,8 +914,6 @@ where
             },
             is_deposit,
             is_post_exec: false,
-            sender,
-            evm_gas_used,
             canonical_gas_used,
             post_exec,
             depositor_nonce,
@@ -934,8 +926,6 @@ where
             inner: EthTxResult { result: ResultAndState { result, state }, blob_gas_used, tx_type },
             is_deposit,
             is_post_exec,
-            sender: _,
-            evm_gas_used: _,
             canonical_gas_used,
             post_exec,
             depositor_nonce,


### PR DESCRIPTION
## Summary

Removes the two `OpTxResult` fields that are written during execution but never read on commit:

- `pub sender: Address`
- `pub evm_gas_used: u64`

Both are destructured as `_` in `commit_transaction`. After the reth v2.2.0 bump (#20459), the depositor-nonce DB lookup that needed `sender` was relocated into `execute_transaction_without_commit` and cached as `OpTxResult.depositor_nonce`, so `sender` no longer informs `commit_transaction`. Only `canonical_gas_used` is consumed downstream (gas_used, receipts, DA-footprint accounting); `evm_gas_used` is computed and stored but never read back.

Neither field is part of the upstream `EthTxResult` (`{ result, blob_gas_used, tx_type }`) — they're OP-specific extensions that are now dead-on-read.

### Replay note

The lone comment on the issue worried `evm_gas_used` might be needed by the SDM post-exec replay RPC (#20357). That PR was closed unmerged, and the replay logic that *did* land (`op-reth/crates/post-exec-replay`) reconstructs raw gas independently from `receipt.cumulative_gas_used` + the replayed refund — it never references `OpTxResult`. So both fields are confirmed dead.

## Changes

All in `rust/alloy-op-evm/src/block/mod.rs`:
- Drop both field declarations from `OpTxResult`.
- Drop the assignments at the post-exec injection site and the normal commit construction site.
- Drop the `sender: _` / `evm_gas_used: _` lines from the `commit_transaction` destructure.

The local `sender` / `evm_gas_used` variables in `execute_transaction_without_commit` stay — still used for the depositor-nonce lookup, refund-to-state application, `canonical_gas_used`, and operator-fee charge.

## Testing

- `cargo check -p alloy-op-evm` — clean
- `cargo clippy -p alloy-op-evm --all-targets` — exit 0, no warnings

Closes #20463

🤖 Generated with [Claude Code](https://claude.com/claude-code)