### PR TITLE
docs(redirects): fix 404 target for deprecated sequencer-node redirect

### DIFF
--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -1736,7 +1736,7 @@
     },
     {
       "source": "/chain-operators/guides/deployment/sequencer-node",
-      "destination": "/chain-operators/tutorials/op-geth-setup"
+      "destination": "/chain-operators/tutorials/create-l2-rollup/create-l2-rollup"
     },
     {
       "source": "/chain-operators/guides/deployment/spin-batcher",


### PR DESCRIPTION
## Description

Fix a 404-ending redirect found during the docs.json redirect audit:
`/chain-operators/guides/deployment/sequencer-node` redirected to
`/chain-operators/tutorials/op-geth-setup`, which does not exist (the page is
under `create-l2-rollup/`). Retargeted to the stable create-l2-rollup tutorial
landing.

### Audit notes (for the post-merge sweep)

The broader redirect/nav changes are intentionally **deferred** until the
dependent PRs land, because they all edit `docs.json` and would conflict:

- Nav entries for `create-l2-rollup/op-geth-setup` and `rewind-op-geth` are
  removed by the page-hide PRs (#692 / #693).
- The create-l2-rollup setup redirects (op-geth/op-deployer/op-proposer/op-batcher)
  have destinations missing a leading slash; these are touched by the
  create-l2-rollup op-reth migration (ethereum-optimism/optimism#21130).
- op-geth reference pages (`op-geth-config`, `op-geth-json-rpc`) and
  `notices/op-geth-deprecation` correctly stay (per #688).

No redirect loops or duplicate sources were found in scope.

Refs ethereum-optimism/solutions#696
