### PR TITLE
feat(op-reth): multi-endpoint quorum validation for interop filter

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11729,6 +11729,8 @@ dependencies = [
  "c-kzg",
  "derive_more",
  "futures-util",
+ "jsonrpsee",
+ "jsonrpsee-server",
  "metrics",
  "op-alloy-consensus",
  "op-alloy-flz",

--- a/rust/op-rbuilder/crates/op-rbuilder/src/launcher.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/launcher.rs
@@ -144,6 +144,7 @@ where
                             )
                             .with_interop(
                                 rollup_args.interop_http.clone(),
+                                rollup_args.interop_min_responses,
                                 rollup_args.interop_safety_level,
                             ),
                     )

--- a/rust/op-rbuilder/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -370,6 +370,7 @@ fn pool_component(args: &OpRbuilderArgs) -> OpPoolBuilder<FBPooledTransaction> {
         )
         .with_interop(
             rollup_args.interop_http.clone(),
+            rollup_args.interop_min_responses,
             rollup_args.interop_safety_level,
         )
 }

--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -49,13 +49,24 @@ pub struct RollupArgs {
     #[arg(long = "rollup.enable-tx-conditional", default_value = "false")]
     pub enable_tx_conditional: bool,
 
-    /// HTTP endpoint for the interop filter, used to validate the interop messages referenced by
-    /// incoming transactions. When not set, interop transaction validation is disabled: a node
-    /// that builds blocks will then include transactions carrying invalid interop messages,
-    /// producing invalid blocks. It is only safe to leave this unset on nodes that do not build
-    /// blocks.
+    /// HTTP endpoint(s) for the interop filter, used to validate the interop messages referenced
+    /// by incoming transactions. Repeat the flag to configure multiple endpoints; each check is
+    /// fanned out to all of them and combined by quorum agreement (see
+    /// `--rollup.interop-min-responses`). When none are set, interop transaction validation is
+    /// disabled: a node that builds blocks will then include transactions carrying invalid
+    /// interop messages, producing invalid blocks. It is only safe to leave this unset on nodes
+    /// that do not build blocks.
     #[arg(long = "rollup.interop-http", value_name = "INTEROP_HTTP_URL")]
-    pub interop_http: Option<String>,
+    pub interop_http: Vec<String>,
+
+    /// Minimum number of definitive verdicts required to decide an interop check across the
+    /// configured `--rollup.interop-http` endpoints. Defaults to the number of endpoints
+    /// (unanimity, fail-closed). A transaction is accepted only when this many endpoints return a
+    /// definitive verdict and all of them agree it is valid; if they disagree the transaction is
+    /// rejected. Disagreement detection is best-effort: once the quorum is reached the remaining
+    /// endpoints are not awaited, so a slow dissenter beyond the quorum may go unseen.
+    #[arg(long = "rollup.interop-min-responses", value_name = "INTEROP_MIN_RESPONSES")]
+    pub interop_min_responses: Option<usize>,
 
     /// Safety level for interop filter validation.
     #[arg(
@@ -158,7 +169,8 @@ impl Default for RollupArgs {
             compute_pending_block: false,
             discovery_v4: false,
             enable_tx_conditional: false,
-            interop_http: None,
+            interop_http: Vec::new(),
+            interop_min_responses: None,
             interop_safety_level: SafetyLevel::CrossUnsafe,
             sequencer_headers: Vec::new(),
             historical_rpc: None,
@@ -237,6 +249,28 @@ mod tests {
         let args =
             CommandParser::<RollupArgs>::parse_from(["reth", "--rollup.enable-tx-conditional"])
                 .args;
+        assert_eq!(args, expected_args);
+    }
+
+    #[test]
+    fn test_parse_interop_multiple_endpoints() {
+        let expected_args = RollupArgs {
+            interop_http: vec!["http://a:1".into(), "http://b:2".into(), "http://c:3".into()],
+            interop_min_responses: Some(2),
+            ..Default::default()
+        };
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--rollup.interop-http",
+            "http://a:1",
+            "--rollup.interop-http",
+            "http://b:2",
+            "--rollup.interop-http",
+            "http://c:3",
+            "--rollup.interop-min-responses",
+            "2",
+        ])
+        .args;
         assert_eq!(args, expected_args);
     }
 

--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -60,11 +60,18 @@ pub struct RollupArgs {
     pub interop_http: Vec<String>,
 
     /// Minimum number of definitive verdicts required to decide an interop check across the
-    /// configured `--rollup.interop-http` endpoints. Defaults to the number of endpoints
-    /// (unanimity, fail-closed). A transaction is accepted only when this many endpoints return a
-    /// definitive verdict and all of them agree it is valid; if they disagree the transaction is
-    /// rejected. Disagreement detection is best-effort: once the quorum is reached the remaining
-    /// endpoints are not awaited, so a slow dissenter beyond the quorum may go unseen.
+    /// configured `--rollup.interop-http` endpoints. A transaction is accepted only when this many
+    /// endpoints return a definitive verdict and all of them agree it is valid; if they disagree
+    /// the transaction is rejected.
+    ///
+    /// Defaults to the number of endpoints (unanimity, fail-closed). Note this means any single
+    /// unreachable or out-of-sync endpoint blocks ALL interop admission until it recovers, so
+    /// adding endpoints under the default REDUCES availability. Set a majority quorum (e.g.
+    /// N/2+1) to tolerate a degraded endpoint while still only accepting on unanimous
+    /// agreement among responders.
+    ///
+    /// Disagreement detection is best-effort: once the quorum is reached the remaining endpoints
+    /// are not awaited, so a slow dissenter beyond the quorum may go unseen.
     #[arg(long = "rollup.interop-min-responses", value_name = "INTEROP_MIN_RESPONSES")]
     pub interop_min_responses: Option<usize>,
 

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -255,7 +255,11 @@ impl OpNode {
             .pool(
                 OpPoolBuilder::default()
                     .with_enable_tx_conditional(self.args.enable_tx_conditional)
-                    .with_interop(self.args.interop_http.clone(), self.args.interop_safety_level),
+                    .with_interop(
+                        self.args.interop_http.clone(),
+                        self.args.interop_min_responses,
+                        self.args.interop_safety_level,
+                    ),
             )
             .payload(BasicPayloadServiceBuilder::new(
                 OpPayloadBuilder::new(compute_pending_block)
@@ -1070,9 +1074,12 @@ pub struct OpPoolBuilder<T = crate::txpool::OpPooledTransaction> {
     pub pool_config_overrides: PoolBuilderConfigOverrides,
     /// Enable transaction conditionals.
     pub enable_tx_conditional: bool,
-    /// Interop filter URL for txpool-level interop validation. When None, interop transaction
-    /// validation in the txpool is disabled.
-    pub interop_http: Option<String>,
+    /// Interop filter endpoints for txpool-level interop validation. When empty, interop
+    /// transaction validation in the txpool is disabled.
+    pub interop_endpoints: Vec<String>,
+    /// Minimum number of definitive verdicts required to decide an interop check. When None,
+    /// defaults to the number of endpoints (unanimity).
+    pub interop_min_responses: Option<usize>,
     /// Safety level for interop filter validation.
     pub interop_safety_level: SafetyLevel,
     /// Marker for the pooled transaction type.
@@ -1084,7 +1091,8 @@ impl<T> Default for OpPoolBuilder<T> {
         Self {
             pool_config_overrides: Default::default(),
             enable_tx_conditional: false,
-            interop_http: None,
+            interop_endpoints: Vec::new(),
+            interop_min_responses: None,
             interop_safety_level: SafetyLevel::CrossUnsafe,
             _pd: Default::default(),
         }
@@ -1096,7 +1104,8 @@ impl<T> Clone for OpPoolBuilder<T> {
         Self {
             pool_config_overrides: self.pool_config_overrides.clone(),
             enable_tx_conditional: self.enable_tx_conditional,
-            interop_http: self.interop_http.clone(),
+            interop_endpoints: self.interop_endpoints.clone(),
+            interop_min_responses: self.interop_min_responses,
             interop_safety_level: self.interop_safety_level,
             _pd: core::marker::PhantomData,
         }
@@ -1119,13 +1128,17 @@ impl<T> OpPoolBuilder<T> {
         self
     }
 
-    /// Sets the interop filter URL. Pass None to disable interop transaction validation.
+    /// Sets the interop filter endpoints and quorum. Pass an empty vec to disable interop
+    /// transaction validation. `interop_min_responses` defaults to the number of endpoints
+    /// (unanimity) when None.
     pub fn with_interop(
         mut self,
-        interop_client: Option<String>,
+        interop_endpoints: Vec<String>,
+        interop_min_responses: Option<usize>,
         interop_safety_level: SafetyLevel,
     ) -> Self {
-        self.interop_http = interop_client;
+        self.interop_endpoints = interop_endpoints;
+        self.interop_min_responses = interop_min_responses;
         self.interop_safety_level = interop_safety_level;
         self
     }
@@ -1147,20 +1160,23 @@ where
         let Self { pool_config_overrides, .. } = self;
 
         // Interop filter used for txpool validation.
-        let interop_client = if let Some(url) = self.interop_http.clone() {
-            Some(
-                InteropFilterClient::builder(url, ctx.chain_spec().chain_id())
-                    .minimum_safety(self.interop_safety_level)
-                    .build()
-                    .await,
-            )
-        } else {
+        let interop_client = if self.interop_endpoints.is_empty() {
             if ctx.chain_spec().is_interop_active_at_timestamp(ctx.head().timestamp) {
                 info!(target: "reth::cli",
                     "No interop filter URL configured (--rollup.interop-http), interop transaction validation disabled."
                 );
             }
             None
+        } else {
+            let mut builder = InteropFilterClient::builder(
+                self.interop_endpoints.clone(),
+                ctx.chain_spec().chain_id(),
+            )
+            .minimum_safety(self.interop_safety_level);
+            if let Some(min) = self.interop_min_responses {
+                builder = builder.min_responses(min);
+            }
+            Some(builder.build().await)
         };
 
         let blob_store = reth_node_builder::components::create_blob_store(ctx)?;

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -1168,6 +1168,13 @@ where
             }
             None
         } else {
+            let endpoint_count = self.interop_endpoints.len();
+            let effective_min_responses = self.interop_min_responses.unwrap_or(endpoint_count);
+            info!(target: "reth::cli",
+                endpoints = endpoint_count,
+                min_responses = effective_min_responses,
+                "Interop filter configured: a tx is accepted only when {effective_min_responses} of {endpoint_count} endpoints return a definitive verdict and all agree it is valid"
+            );
             let mut builder = InteropFilterClient::builder(
                 self.interop_endpoints.clone(),
                 ctx.chain_spec().chain_id(),

--- a/rust/op-reth/crates/txpool/Cargo.toml
+++ b/rust/op-reth/crates/txpool/Cargo.toml
@@ -60,4 +60,9 @@ tokio = { workspace = true, features = ["time"] }
 reth-optimism-chainspec.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
-tokio = { workspace = true, features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+# Mock JSON-RPC server for interop filter client tests. jsonrpsee-server is already a workspace
+# dependency used by kona's RPC actor, so this reuses an in-tree, maintained server rather than
+# pulling in a new HTTP-mock crate (e.g. wiremock).
+jsonrpsee-server.workspace = true
+jsonrpsee.workspace = true

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -12,7 +12,7 @@ use alloy_eips::eip2930::AccessList;
 use alloy_primitives::{B256, TxHash};
 use alloy_rpc_client::ReqwestClient;
 use futures_util::{
-    Stream,
+    FutureExt, Stream,
     future::BoxFuture,
     stream::{self, FuturesUnordered, StreamExt},
 };
@@ -111,8 +111,25 @@ impl InteropFilterClient {
                 // Non-response (timeout / transport): does not count toward quorum.
                 Err(_) => continue,
             }
-            // Quorum reached: stop without awaiting not-yet-responded endpoints.
+            // Quorum reached: stop without awaiting not-yet-responded endpoints. But a failsafe
+            // that has *already* arrived must still reject, so non-blocking-drain the responses
+            // that are ready right now first. We never await endpoints that haven't responded
+            // (fast-accept preserved); dropping `futs` afterwards cancels them.
             if valid + invalid >= self.inner.min_responses {
+                while let Some(ready) = futs.next().now_or_never().flatten() {
+                    match ready {
+                        Err(e) if e.is_failsafe() => {
+                            self.inner.metrics.record_failsafe_reject();
+                            return Err(InteropTxValidatorError::FailsafeEnabled);
+                        }
+                        Ok(()) => valid += 1,
+                        Err(e) if e.is_definitive_invalid() => {
+                            invalid += 1;
+                            first_invalid.get_or_insert(e);
+                        }
+                        Err(_) => {}
+                    }
+                }
                 break;
             }
         }
@@ -656,12 +673,14 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn failsafe_on_any_endpoint_hard_rejects() {
+        // All three endpoints respond immediately, and `min_responses == 3` forces the aggregator
+        // to collect every verdict before deciding. This makes the test deterministic (no
+        // arrival-order race): the failsafe verdict is always observed, and any failsafe response
+        // already received must hard-reject even though two valid verdicts are also in hand.
         let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
         let b = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
         let failsafe = MockEndpoint::start(Verdict::Failsafe, Failsafe::Reply(false)).await;
-        // min 2 of 3: the two valid endpoints would otherwise satisfy quorum, but a single
-        // endpoint reporting failsafe must hard-reject regardless.
-        let client = client_for(&[&a, &b, &failsafe], Some(2)).await;
+        let client = client_for(&[&a, &b, &failsafe], Some(3)).await;
         let err = check(&client).await.unwrap_err();
         assert!(
             matches!(err, InteropTxValidatorError::FailsafeEnabled),
@@ -679,6 +698,22 @@ mod tests {
         let start = Instant::now();
         assert!(check(&client).await.is_ok());
         assert!(start.elapsed() < Duration::from_secs(1), "decision waited on the slow endpoint");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn slow_non_failsafe_endpoint_does_not_delay_accept() {
+        // Two valid endpoints meet a quorum of 2; a third endpoint is slow but NOT a failsafe.
+        // The aggregator must fast-accept without awaiting the slow endpoint.
+        let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let b = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let slow = MockEndpoint::start(Verdict::Slow, Failsafe::Reply(false)).await;
+        let client = client_for(&[&a, &b, &slow], Some(2)).await;
+        let start = Instant::now();
+        assert!(check(&client).await.is_ok());
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "a slow non-failsafe endpoint must not delay accept"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -3,9 +3,11 @@
 use crate::{
     InvalidCrossTx,
     interop_filter::{
-        ExecutingDescriptor, InteropTxValidatorError, metrics::InteropMetrics,
+        ExecutingDescriptor, InteropTxValidatorError,
+        metrics::{EndpointMetrics, InteropMetrics},
         parse_access_list_items_to_inbox_entries,
     },
+    maintain::FAILSAFE_HEARTBEAT_INTERVAL,
 };
 use alloy_consensus::Transaction;
 use alloy_eips::eip2930::AccessList;
@@ -23,11 +25,11 @@ use std::{
     future::IntoFuture,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::{Duration, Instant},
 };
-use tracing::{error, trace};
+use tracing::{error, info, trace};
 
 /// The default request timeout to use
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
@@ -79,14 +81,15 @@ impl InteropFilterClient {
             .inner
             .endpoints
             .iter()
-            .map(|client| {
+            .map(|endpoint| {
                 CheckAccessListRequest {
-                    client: client.clone(),
+                    client: endpoint.client.clone(),
                     inbox_entries: Cow::Borrowed(inbox_entries),
                     executing_descriptor,
                     timeout: self.inner.timeout,
                     safety: self.inner.safety,
                     metrics: self.inner.metrics.clone(),
+                    endpoint_metrics: endpoint.metrics.clone(),
                 }
                 .into_future()
             })
@@ -100,10 +103,7 @@ impl InteropFilterClient {
                 // Failsafe on any endpoint is a hard rejection: short-circuit immediately, even
                 // if the quorum was already met by valid responses. Dropping `futs` cancels the
                 // remaining in-flight requests.
-                Err(e) if e.is_failsafe() => {
-                    self.inner.metrics.record_failsafe_reject();
-                    return Err(InteropTxValidatorError::FailsafeEnabled);
-                }
+                Err(e) if e.is_failsafe() => return Err(self.reject_failsafe()),
                 Err(e) if e.is_definitive_invalid() => {
                     invalid += 1;
                     first_invalid.get_or_insert(e);
@@ -118,10 +118,7 @@ impl InteropFilterClient {
             if valid + invalid >= self.inner.min_responses {
                 while let Some(ready) = futs.next().now_or_never().flatten() {
                     match ready {
-                        Err(e) if e.is_failsafe() => {
-                            self.inner.metrics.record_failsafe_reject();
-                            return Err(InteropTxValidatorError::FailsafeEnabled);
-                        }
+                        Err(e) if e.is_failsafe() => return Err(self.reject_failsafe()),
                         Ok(()) => valid += 1,
                         Err(e) if e.is_definitive_invalid() => {
                             invalid += 1;
@@ -137,6 +134,7 @@ impl InteropFilterClient {
         self.inner.metrics.record_quorum_outcome(valid, invalid, self.inner.min_responses);
 
         if valid + invalid < self.inner.min_responses {
+            self.log_degraded_quorum(valid + invalid);
             return Err(InteropTxValidatorError::QuorumNotReached {
                 received: valid + invalid,
                 required: self.inner.min_responses,
@@ -215,6 +213,43 @@ impl InteropFilterClient {
         Some(Ok(()))
     }
 
+    /// Records a hard failsafe rejection and flips the cached gate (and gauge) on immediately, so a
+    /// failsafe detected on a check stops admission and is visible on the dashboard right away
+    /// rather than only after the next ~1s failsafe poll. The poll re-confirms or clears it.
+    fn reject_failsafe(&self) -> InteropTxValidatorError {
+        self.inner.metrics.record_failsafe_reject();
+        self.apply_failsafe_state(true);
+        InteropTxValidatorError::FailsafeEnabled
+    }
+
+    /// Logs a rate-limited line when a check fails closed because too few endpoints reached the
+    /// quorum. A degraded quorum silently rejects every interop tx, so without this the only signal
+    /// is the `quorum_reject_not_reached` counter; the log makes the halted state visible. Logged
+    /// at most once per [`FAILSAFE_HEARTBEAT_INTERVAL`] (and on the first occurrence) to avoid
+    /// per-tx spam, and at `info` because the rejection itself is expected, by-design
+    /// fail-closed behavior.
+    fn log_degraded_quorum(&self, received: usize) {
+        let now = self.inner.created_at.elapsed().as_millis() as u64;
+        let interval = FAILSAFE_HEARTBEAT_INTERVAL.as_millis() as u64;
+        let last = self.inner.last_degraded_log_ms.load(Ordering::Relaxed);
+        let due = last == 0 || now.saturating_sub(last) >= interval;
+        if due &&
+            self.inner
+                .last_degraded_log_ms
+                .compare_exchange(last, now.max(1), Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+        {
+            info!(
+                target: "txpool::interop",
+                received,
+                required = self.inner.min_responses,
+                endpoints = self.inner.endpoints.len(),
+                "interop failing closed: too few endpoints returned a definitive verdict to reach \
+                 quorum; all interop transactions are rejected until enough endpoints respond"
+            );
+        }
+    }
+
     /// Returns the cached failsafe state.
     pub fn is_failsafe_enabled(&self) -> bool {
         self.inner.failsafe_enabled.load(Ordering::Acquire)
@@ -229,39 +264,57 @@ impl InteropFilterClient {
     }
 
     /// Queries every configured interop filter for failsafe state and caches the OR across the
-    /// reachable endpoints. Calls `admin_getFailsafeEnabled` on each endpoint concurrently and
-    /// short-circuits on the first `true` (the OR is decisive, so a single slow endpoint must
-    /// not delay the failsafe poll).
+    /// endpoints. Calls `admin_getFailsafeEnabled` on each endpoint concurrently and short-circuits
+    /// on the first `true` (the OR is decisive, so a single slow endpoint must not delay turning
+    /// the gate on).
+    ///
+    /// Clearing the gate (to `false`) requires *every* endpoint to have replied `false`. If some
+    /// endpoints did not answer and none reported failsafe, the result is "don't know": the cached
+    /// state is left unchanged rather than cleared, because a silent endpoint might itself be the
+    /// one in failsafe. Turning the gate *on* never requires unanimity. This matters once
+    /// `min_responses` is lowered for availability — with the unanimity default a silent endpoint
+    /// also fails the check closed, so the partial-information case never decided admission.
     ///
     /// If no endpoint replies, the cache is left unchanged and an error is returned (matching the
     /// previous single-endpoint behavior).
     pub async fn query_failsafe(&self) -> Result<bool, InteropTxValidatorError> {
+        let endpoint_count = self.inner.endpoints.len();
         let mut futs: FuturesUnordered<_> = self
             .inner
             .endpoints
             .iter()
-            .map(|client| {
+            .map(|endpoint| {
                 tokio::time::timeout(
                     self.inner.timeout,
-                    client.request::<_, bool>("admin_getFailsafeEnabled", ()),
+                    endpoint.client.request::<_, bool>("admin_getFailsafeEnabled", ()),
                 )
             })
             .collect();
 
-        let mut any = false;
+        let mut replied = 0usize;
         let mut enabled = false;
         while let Some(res) = futs.next().await {
             if let Ok(Ok(v)) = res {
-                any = true;
+                replied += 1;
+                // Any endpoint reporting failsafe is decisive: turn the gate on immediately.
                 if v {
                     enabled = true;
                     break;
                 }
             }
         }
-        if !any {
+
+        if replied == 0 {
+            // No endpoint answered: leave the cache unchanged (the single-endpoint behavior).
             return Err(InteropTxValidatorError::Timeout(self.inner.timeout.as_secs()));
         }
+        if !enabled && replied < endpoint_count {
+            // Some endpoints did not answer and none reported failsafe. We cannot confirm failsafe
+            // is off — a silent endpoint might itself be in failsafe — so leave the cached gate
+            // unchanged rather than clearing it on partial information.
+            return Ok(self.is_failsafe_enabled());
+        }
+        // Decisive: an endpoint reported failsafe, or every endpoint replied and all said off.
         self.apply_failsafe_state(enabled);
         Ok(enabled)
     }
@@ -309,11 +362,20 @@ impl InteropFilterClient {
     }
 }
 
+/// A single configured interop filter endpoint and its per-endpoint metrics.
+#[derive(Debug)]
+pub(crate) struct Endpoint {
+    /// RPC client for this endpoint.
+    client: ReqwestClient,
+    /// Metrics labeled with this endpoint's index.
+    metrics: EndpointMetrics,
+}
+
 /// Holds interop RPC data. Inner type of [`InteropFilterClient`].
 #[derive(Debug)]
 pub(crate) struct InteropFilterClientInner {
     /// Interop filter endpoints queried concurrently for each check.
-    endpoints: Vec<ReqwestClient>,
+    endpoints: Vec<Endpoint>,
     /// Minimum number of definitive verdicts required to decide a check.
     min_responses: usize,
     /// The chain ID of the executing chain
@@ -326,6 +388,11 @@ pub(crate) struct InteropFilterClientInner {
     metrics: InteropMetrics,
     /// Cached failsafe state (OR across endpoints), polled by the background failsafe task.
     failsafe_enabled: AtomicBool,
+    /// Reference instant for rate-limiting the degraded-quorum log.
+    created_at: Instant,
+    /// Millis (since [`created_at`](Self::created_at)) of the last degraded-quorum log; `0` means
+    /// never. Rate-limits [`log_degraded_quorum`](InteropFilterClient::log_degraded_quorum).
+    last_degraded_log_ms: AtomicU64,
 }
 
 /// Builds [`InteropFilterClient`].
@@ -396,12 +463,14 @@ impl InteropFilterClientBuilder {
         );
 
         let mut clients = Vec::with_capacity(endpoints.len());
-        for endpoint in &endpoints {
+        for (idx, endpoint) in endpoints.iter().enumerate() {
             let client = ReqwestClient::builder()
                 .connect(endpoint.as_str())
                 .await
                 .expect("building interop filter client");
-            clients.push(client);
+            // Label by index, not the raw URL: interop-http URLs can carry basic-auth credentials.
+            let metrics = EndpointMetrics::for_endpoint(idx);
+            clients.push(Endpoint { client, metrics });
         }
 
         InteropFilterClient {
@@ -413,6 +482,8 @@ impl InteropFilterClientBuilder {
                 timeout,
                 metrics: InteropMetrics::default(),
                 failsafe_enabled: AtomicBool::new(false),
+                created_at: Instant::now(),
+                last_degraded_log_ms: AtomicU64::new(0),
             }),
         }
     }
@@ -427,6 +498,7 @@ pub struct CheckAccessListRequest<'a> {
     timeout: Duration,
     safety: SafetyLevel,
     metrics: InteropMetrics,
+    endpoint_metrics: EndpointMetrics,
 }
 
 impl<'a> CheckAccessListRequest<'a> {
@@ -448,7 +520,15 @@ impl<'a> IntoFuture for CheckAccessListRequest<'a> {
     type IntoFuture = BoxFuture<'a, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
-        let Self { client, inbox_entries, executing_descriptor, timeout, safety, metrics } = self;
+        let Self {
+            client,
+            inbox_entries,
+            executing_descriptor,
+            timeout,
+            safety,
+            metrics,
+            endpoint_metrics,
+        } = self;
         Box::pin(async move {
             let start = Instant::now();
 
@@ -460,16 +540,18 @@ impl<'a> IntoFuture for CheckAccessListRequest<'a> {
                 ),
             )
             .await;
-            metrics.record_interop_query(start.elapsed());
+            let elapsed = start.elapsed();
+            metrics.record_interop_query(elapsed);
+            endpoint_metrics.record_query(elapsed);
 
             let verdict = result
                 .map_err(|_| InteropTxValidatorError::Timeout(timeout.as_secs()))
                 .and_then(|r| r.map_err(InteropTxValidatorError::from_json_rpc));
 
             match &verdict {
-                Ok(()) => metrics.record_endpoint_valid(),
-                Err(e) if e.is_definitive_invalid() => metrics.record_endpoint_invalid(),
-                Err(_) => metrics.record_endpoint_unavailable(),
+                Ok(()) => endpoint_metrics.record_valid(),
+                Err(e) if e.is_definitive_invalid() => endpoint_metrics.record_invalid(),
+                Err(_) => endpoint_metrics.record_unavailable(),
             }
             verdict
         })
@@ -760,6 +842,24 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn failsafe_on_check_flips_cached_gate() {
+        // A failsafe detected on a check must flip the cached gate (and gauge) immediately, so
+        // admission stops and the dashboard reflects it without waiting for the next failsafe poll.
+        let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let failsafe = MockEndpoint::start(Verdict::Failsafe, Failsafe::Reply(false)).await;
+        let client = client_for(&[&a, &failsafe], Some(2)).await;
+        assert!(!client.is_failsafe_enabled());
+        assert!(matches!(
+            check(&client).await.unwrap_err(),
+            InteropTxValidatorError::FailsafeEnabled
+        ));
+        assert!(
+            client.is_failsafe_enabled(),
+            "a failsafe detected on a check must flip the cached gate immediately"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn ignores_slow_endpoint_once_quorum_met() {
         let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
         let b = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
@@ -846,6 +946,36 @@ mod tests {
         let start = Instant::now();
         assert!(client.query_failsafe().await.unwrap());
         assert!(start.elapsed() < Duration::from_secs(1), "failsafe waited on the slow endpoint");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn failsafe_partial_replies_do_not_clear_gate() {
+        // One endpoint is unreachable (slow/timing out) and the other replies "not in failsafe".
+        // The silent endpoint might itself be the one in failsafe, so a partial poll must NOT clear
+        // a previously-set gate to false. Only a unanimous "all replied false" may clear it. This
+        // bug only surfaces once `min_responses` is lowered for availability (with the unanimity
+        // default the slow endpoint also fails the check closed).
+        let silent = MockEndpoint::start(Verdict::Valid, Failsafe::Slow).await;
+        let healthy = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let client = client_for(&[&silent, &healthy], Some(1)).await;
+        // Failsafe was previously detected and cached.
+        client.apply_failsafe_state(true);
+        let result = client.query_failsafe().await;
+        assert!(
+            client.is_failsafe_enabled(),
+            "a partial poll (one endpoint silent) must not clear the failsafe gate, got {result:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn failsafe_unanimous_false_clears_gate() {
+        // Every endpoint replied "not in failsafe", so the gate is cleared (decisive).
+        let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let b = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let client = client_for(&[&a, &b], None).await;
+        client.apply_failsafe_state(true);
+        assert!(!client.query_failsafe().await.unwrap());
+        assert!(!client.is_failsafe_enabled(), "a unanimous all-false poll must clear the gate");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -560,9 +560,11 @@ mod tests {
                             Verdict::InternalError => {
                                 Err(ErrorObjectOwned::owned(-32603, "internal error", None::<()>))
                             }
-                            // The filter codes failsafe as -32602 with a "failsafe" message.
+                            // The filter emits the dedicated failsafe code -320602. The message is
+                            // intentionally unrelated to "failsafe" to prove detection is by code,
+                            // not by message text.
                             Verdict::Failsafe => {
-                                Err(ErrorObjectOwned::owned(-32602, "failsafe enabled", None::<()>))
+                                Err(ErrorObjectOwned::owned(-320602, "rejected", None::<()>))
                             }
                             Verdict::Slow => {
                                 tokio::time::sleep(Duration::from_secs(60)).await;

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -524,14 +524,23 @@ mod tests {
     use std::net::SocketAddr;
 
     /// Behavior of a mock interop filter endpoint for `interop_checkAccessList`.
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, Debug)]
     enum Verdict {
         /// Responds immediately with a valid result.
         Valid,
         /// Responds immediately with a definitive validation rejection (maps to `InvalidEntry`).
         Invalid,
+        /// Responds immediately with a generic `-32602` rejection that is not a `SuperchainDAError`
+        /// code (e.g. "failed to parse access entry"). Maps to `Rejected`, a definitive verdict.
+        GenericRejection,
         /// Responds immediately with a non-definitive internal error (maps to `Other`).
         InternalError,
+        /// Responds immediately with `FutureData` (-321401): the node is out of sync. Maps to the
+        /// soft, non-response `DataUnavailable`.
+        OutOfSyncFutureData,
+        /// Responds immediately with `Uninitialized` (-320400): the node is out of sync. Maps to
+        /// the soft, non-response `DataUnavailable`.
+        OutOfSyncUninitialized,
         /// Responds immediately with the filter's failsafe rejection (maps to `FailsafeEnabled`).
         Failsafe,
         /// Sleeps far longer than the client timeout before responding valid (a slow endpoint).
@@ -574,8 +583,23 @@ mod tests {
                                 "conflicting data",
                                 None::<()>,
                             )),
+                            // Generic -32602 rejection (e.g. malformed entry). Not a
+                            // SuperchainDAError code, not -320602; must count as a definitive
+                            // rejection and surface its message.
+                            Verdict::GenericRejection => Err(ErrorObjectOwned::owned(
+                                -32602,
+                                "failed to parse access entry",
+                                None::<()>,
+                            )),
                             Verdict::InternalError => {
                                 Err(ErrorObjectOwned::owned(-32603, "internal error", None::<()>))
+                            }
+                            // Out-of-sync soft failures: node lacks the data yet.
+                            Verdict::OutOfSyncFutureData => {
+                                Err(ErrorObjectOwned::owned(-321401, "future data", None::<()>))
+                            }
+                            Verdict::OutOfSyncUninitialized => {
+                                Err(ErrorObjectOwned::owned(-320400, "uninitialized", None::<()>))
                             }
                             // The filter emits the dedicated failsafe code -320602. The message is
                             // intentionally unrelated to "failsafe" to prove detection is by code,
@@ -656,6 +680,53 @@ mod tests {
                 InteropTxValidatorError::InvalidEntry(SuperchainDAError::ConflictingData)
             ),
             "expected the real rejection reason, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn generic_rejection_counts_and_surfaces_message() {
+        // A generic -32602 rejection (not a SuperchainDAError code) must count as a definitive
+        // verdict and reject with the filter's real message preserved (single endpoint, min 1).
+        let a = MockEndpoint::start(Verdict::GenericRejection, Failsafe::Reply(false)).await;
+        let client = client_for(&[&a], None).await;
+        let err = check(&client).await.unwrap_err();
+        assert!(
+            matches!(&err, InteropTxValidatorError::Rejected { code: -32602, .. }),
+            "expected a definitive Rejected verdict, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("failed to parse access entry"),
+            "rejection must preserve the filter's message, got: {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn out_of_sync_endpoint_is_soft() {
+        // One endpoint is out of sync (FutureData / Uninitialized), the others are valid and meet
+        // the quorum. The soft node must be ignored (treated as a non-response), not a rejection.
+        for soft in [Verdict::OutOfSyncFutureData, Verdict::OutOfSyncUninitialized] {
+            let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+            let b = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+            let out_of_sync = MockEndpoint::start(soft, Failsafe::Reply(false)).await;
+            // min 2 of 3: the two valid endpoints meet the quorum; the soft node is ignored.
+            let client = client_for(&[&a, &b, &out_of_sync], Some(2)).await;
+            assert!(
+                check(&client).await.is_ok(),
+                "an out-of-sync soft failure ({soft:?}) must not cause rejection when quorum is met"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn all_endpoints_out_of_sync_fail_closed() {
+        // Every endpoint is out of sync: no definitive verdicts collected, so fail closed.
+        let a = MockEndpoint::start(Verdict::OutOfSyncFutureData, Failsafe::Reply(false)).await;
+        let b = MockEndpoint::start(Verdict::OutOfSyncUninitialized, Failsafe::Reply(false)).await;
+        let client = client_for(&[&a, &b], None).await;
+        let err = check(&client).await.unwrap_err();
+        assert!(
+            matches!(err, InteropTxValidatorError::QuorumNotReached { received: 0, required: 2 }),
+            "all endpoints out of sync must fail closed, got {err:?}"
         );
     }
 

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -14,7 +14,7 @@ use alloy_rpc_client::ReqwestClient;
 use futures_util::{
     Stream,
     future::BoxFuture,
-    stream::{self, StreamExt},
+    stream::{self, FuturesUnordered, StreamExt},
 };
 use op_alloy_consensus::interop::SafetyLevel;
 use reth_transaction_pool::PoolTransaction;
@@ -27,7 +27,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use tracing::trace;
+use tracing::{error, trace};
 
 /// The default request timeout to use
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
@@ -40,12 +40,12 @@ pub struct InteropFilterClient {
 }
 
 impl InteropFilterClient {
-    /// Returns a new [`InteropFilterClientBuilder`].
-    pub fn builder(
-        interop_endpoint: impl Into<String>,
+    /// Returns a new [`InteropFilterClientBuilder`] for the given interop filter endpoints.
+    pub const fn builder(
+        interop_endpoints: Vec<String>,
         chain_id: u64,
     ) -> InteropFilterClientBuilder {
-        InteropFilterClientBuilder::new(interop_endpoint, chain_id)
+        InteropFilterClientBuilder::new(interop_endpoints, chain_id)
     }
 
     /// Returns the configured request timeout.
@@ -58,19 +58,86 @@ impl InteropFilterClient {
         self.inner.safety
     }
 
-    /// Executes an `interop_checkAccessList` with the configured safety level.
-    pub fn check_access_list<'a>(
+    /// Executes an `interop_checkAccessList` against every configured endpoint concurrently and
+    /// combines the results by quorum agreement.
+    ///
+    /// A "response" counts only when an endpoint returns a definitive verdict (valid, or a known
+    /// validation rejection). Transport errors and timeouts are non-responses. The aggregator
+    /// decides as soon as `min_responses` definitive verdicts arrive and does not await slower
+    /// endpoints; dropping the in-flight futures cancels their requests.
+    ///
+    /// Returns `Ok(())` iff `min_responses` definitive verdicts were collected and all agreed
+    /// valid. All-invalid yields the real rejection reason; a mix yields
+    /// [`Disagreement`](InteropTxValidatorError::Disagreement); too few definitive verdicts
+    /// yields [`QuorumNotReached`](InteropTxValidatorError::QuorumNotReached) (fail closed).
+    pub async fn check_access_list(
         &self,
-        inbox_entries: &'a [B256],
+        inbox_entries: &[B256],
         executing_descriptor: ExecutingDescriptor,
-    ) -> CheckAccessListRequest<'a> {
-        CheckAccessListRequest {
-            client: self.inner.client.clone(),
-            inbox_entries: Cow::Borrowed(inbox_entries),
-            executing_descriptor,
-            timeout: self.inner.timeout,
-            safety: self.inner.safety,
-            metrics: self.inner.metrics.clone(),
+    ) -> Result<(), InteropTxValidatorError> {
+        let mut futs: FuturesUnordered<_> = self
+            .inner
+            .endpoints
+            .iter()
+            .map(|client| {
+                CheckAccessListRequest {
+                    client: client.clone(),
+                    inbox_entries: Cow::Borrowed(inbox_entries),
+                    executing_descriptor,
+                    timeout: self.inner.timeout,
+                    safety: self.inner.safety,
+                    metrics: self.inner.metrics.clone(),
+                }
+                .into_future()
+            })
+            .collect();
+
+        let (mut valid, mut invalid) = (0usize, 0usize);
+        let mut first_invalid: Option<InteropTxValidatorError> = None;
+        while let Some(result) = futs.next().await {
+            match result {
+                Ok(()) => valid += 1,
+                // Failsafe on any endpoint is a hard rejection: short-circuit immediately, even
+                // if the quorum was already met by valid responses. Dropping `futs` cancels the
+                // remaining in-flight requests.
+                Err(e) if e.is_failsafe() => {
+                    self.inner.metrics.record_failsafe_reject();
+                    return Err(InteropTxValidatorError::FailsafeEnabled);
+                }
+                Err(e) if e.is_definitive_invalid() => {
+                    invalid += 1;
+                    first_invalid.get_or_insert(e);
+                }
+                // Non-response (timeout / transport): does not count toward quorum.
+                Err(_) => continue,
+            }
+            // Quorum reached: stop without awaiting not-yet-responded endpoints.
+            if valid + invalid >= self.inner.min_responses {
+                break;
+            }
+        }
+        // Dropping `futs` here cancels any in-flight slow requests.
+        self.inner.metrics.record_quorum_outcome(valid, invalid, self.inner.min_responses);
+
+        if valid + invalid < self.inner.min_responses {
+            return Err(InteropTxValidatorError::QuorumNotReached {
+                received: valid + invalid,
+                required: self.inner.min_responses,
+            });
+        }
+        match (valid, invalid) {
+            (_, 0) => Ok(()),
+            // All collected verdicts agree invalid: surface the real rejection reason.
+            (0, _) => Err(first_invalid.expect("invalid > 0 implies a recorded invalid verdict")),
+            (valid, invalid) => {
+                error!(
+                    target: "txpool::interop",
+                    valid,
+                    invalid,
+                    "interop endpoints disagreed; rejecting"
+                );
+                Err(InteropTxValidatorError::Disagreement { valid, invalid })
+            }
         }
     }
 
@@ -119,6 +186,11 @@ impl InteropFilterClient {
             )
             .await
         {
+            // A failsafe reported by any endpoint maps to the same rejection the fast-path uses.
+            if err.is_failsafe() {
+                trace!(target: "txpool", hash=%hash, "Cross chain transaction rejected: endpoint failsafe active");
+                return Some(Err(InvalidCrossTx::FailsafeEnabled));
+            }
             self.inner.metrics.increment_metrics_for_error(&err);
             trace!(target: "txpool", hash=%hash, err=%err, "Cross chain transaction invalid");
             return Some(Err(InvalidCrossTx::ValidationError(err)));
@@ -139,19 +211,42 @@ impl InteropFilterClient {
         self.inner.metrics.set_failsafe_enabled(enabled);
     }
 
-    /// Queries the interop filter for failsafe state and caches the result.
-    /// Calls `admin_getFailsafeEnabled` RPC.
+    /// Queries every configured interop filter for failsafe state and caches the OR across the
+    /// reachable endpoints. Calls `admin_getFailsafeEnabled` on each endpoint concurrently and
+    /// short-circuits on the first `true` (the OR is decisive, so a single slow endpoint must
+    /// not delay the failsafe poll).
+    ///
+    /// If no endpoint replies, the cache is left unchanged and an error is returned (matching the
+    /// previous single-endpoint behavior).
     pub async fn query_failsafe(&self) -> Result<bool, InteropTxValidatorError> {
-        let result = tokio::time::timeout(
-            self.inner.timeout,
-            self.inner.client.request::<_, bool>("admin_getFailsafeEnabled", ()),
-        )
-        .await
-        .map_err(|_| InteropTxValidatorError::Timeout(self.inner.timeout.as_secs()))?
-        .map_err(InteropTxValidatorError::from_json_rpc)?;
+        let mut futs: FuturesUnordered<_> = self
+            .inner
+            .endpoints
+            .iter()
+            .map(|client| {
+                tokio::time::timeout(
+                    self.inner.timeout,
+                    client.request::<_, bool>("admin_getFailsafeEnabled", ()),
+                )
+            })
+            .collect();
 
-        self.apply_failsafe_state(result);
-        Ok(result)
+        let mut any = false;
+        let mut enabled = false;
+        while let Some(res) = futs.next().await {
+            if let Ok(Ok(v)) = res {
+                any = true;
+                if v {
+                    enabled = true;
+                    break;
+                }
+            }
+        }
+        if !any {
+            return Err(InteropTxValidatorError::Timeout(self.inner.timeout.as_secs()));
+        }
+        self.apply_failsafe_state(enabled);
+        Ok(enabled)
     }
 
     /// Creates a stream that revalidates interop transactions against the interop filter.
@@ -200,7 +295,10 @@ impl InteropFilterClient {
 /// Holds interop RPC data. Inner type of [`InteropFilterClient`].
 #[derive(Debug)]
 pub(crate) struct InteropFilterClientInner {
-    client: ReqwestClient,
+    /// Interop filter endpoints queried concurrently for each check.
+    endpoints: Vec<ReqwestClient>,
+    /// Minimum number of definitive verdicts required to decide a check.
+    min_responses: usize,
     /// The chain ID of the executing chain
     chain_id: u64,
     /// The default
@@ -209,15 +307,18 @@ pub(crate) struct InteropFilterClientInner {
     timeout: Duration,
     /// Metrics for tracking interop RPC operations.
     metrics: InteropMetrics,
-    /// Cached failsafe state, polled by the background failsafe task.
+    /// Cached failsafe state (OR across endpoints), polled by the background failsafe task.
     failsafe_enabled: AtomicBool,
 }
 
 /// Builds [`InteropFilterClient`].
 #[derive(Debug)]
 pub struct InteropFilterClientBuilder {
-    /// Interop filter RPC endpoint.
-    endpoint: String,
+    /// Interop filter RPC endpoints, queried concurrently for each check.
+    endpoints: Vec<String>,
+    /// Minimum number of definitive verdicts required to decide a check. When unset, defaults to
+    /// the number of endpoints (unanimity).
+    min_responses: Option<usize>,
     /// The chain ID of the executing chain.
     chain_id: u64,
     /// Timeout for requests.
@@ -230,10 +331,11 @@ pub struct InteropFilterClientBuilder {
 }
 
 impl InteropFilterClientBuilder {
-    /// Creates a new builder.
-    pub fn new(interop_endpoint: impl Into<String>, chain_id: u64) -> Self {
+    /// Creates a new builder for the given interop filter endpoints.
+    pub const fn new(interop_endpoints: Vec<String>, chain_id: u64) -> Self {
         Self {
-            endpoint: interop_endpoint.into(),
+            endpoints: interop_endpoints,
+            min_responses: None,
             chain_id,
             timeout: DEFAULT_REQUEST_TIMEOUT,
             safety: SafetyLevel::CrossUnsafe,
@@ -252,18 +354,43 @@ impl InteropFilterClientBuilder {
         self
     }
 
-    /// Creates a new interop RPC client.
-    pub async fn build(self) -> InteropFilterClient {
-        let Self { endpoint, chain_id, timeout, safety } = self;
+    /// Sets the minimum number of definitive verdicts required to decide a check. Defaults to the
+    /// number of endpoints (unanimity) when not set.
+    pub const fn min_responses(mut self, min_responses: usize) -> Self {
+        self.min_responses = Some(min_responses);
+        self
+    }
 
-        let client = ReqwestClient::builder()
-            .connect(endpoint.as_str())
-            .await
-            .expect("building interop filter client");
+    /// Creates a new interop RPC client.
+    ///
+    /// Panics if no endpoints are configured, or if `min_responses` is 0 or exceeds the number of
+    /// endpoints. This is a startup-boundary validation, matching the existing
+    /// `.expect("building interop filter client")` failure mode.
+    pub async fn build(self) -> InteropFilterClient {
+        let Self { endpoints, min_responses, chain_id, timeout, safety } = self;
+
+        assert!(!endpoints.is_empty(), "interop filter client requires at least one endpoint");
+        let min_responses = min_responses.unwrap_or(endpoints.len());
+        assert!(
+            min_responses >= 1 && min_responses <= endpoints.len(),
+            "interop filter min_responses ({min_responses}) must be between 1 and the number of \
+             endpoints ({})",
+            endpoints.len()
+        );
+
+        let mut clients = Vec::with_capacity(endpoints.len());
+        for endpoint in &endpoints {
+            let client = ReqwestClient::builder()
+                .connect(endpoint.as_str())
+                .await
+                .expect("building interop filter client");
+            clients.push(client);
+        }
 
         InteropFilterClient {
             inner: Arc::new(InteropFilterClientInner {
-                client,
+                endpoints: clients,
+                min_responses,
                 chain_id,
                 safety,
                 timeout,
@@ -318,9 +445,16 @@ impl<'a> IntoFuture for CheckAccessListRequest<'a> {
             .await;
             metrics.record_interop_query(start.elapsed());
 
-            result
-                .map_err(|_| InteropTxValidatorError::Timeout(timeout.as_secs()))?
-                .map_err(InteropTxValidatorError::from_json_rpc)
+            let verdict = result
+                .map_err(|_| InteropTxValidatorError::Timeout(timeout.as_secs()))
+                .and_then(|r| r.map_err(InteropTxValidatorError::from_json_rpc));
+
+            match &verdict {
+                Ok(()) => metrics.record_endpoint_valid(),
+                Err(e) if e.is_definitive_invalid() => metrics.record_endpoint_invalid(),
+                Err(_) => metrics.record_endpoint_unavailable(),
+            }
+            verdict
         })
     }
 }
@@ -332,7 +466,7 @@ mod tests {
     use alloy_eips::eip2930::AccessListItem;
 
     async fn test_client() -> InteropFilterClient {
-        InteropFilterClient::builder("http://localhost:8545", 1).build().await
+        InteropFilterClient::builder(vec!["http://localhost:8545".to_string()], 1).build().await
     }
 
     /// An access list that marks the tx as cross-chain (one entry targeting the cross-L2 inbox).
@@ -365,5 +499,269 @@ mod tests {
         // interop admission resumes without restarting the execution layer.
         client.apply_failsafe_state(false);
         assert!(!client.is_failsafe_enabled(), "failsafe gate must clear at runtime, no restart");
+    }
+
+    use jsonrpsee::types::ErrorObjectOwned;
+    use jsonrpsee_server::{RpcModule, ServerBuilder, ServerHandle};
+    use op_alloy_rpc_types::SuperchainDAError;
+    use std::net::SocketAddr;
+
+    /// Behavior of a mock interop filter endpoint for `interop_checkAccessList`.
+    #[derive(Clone, Copy)]
+    enum Verdict {
+        /// Responds immediately with a valid result.
+        Valid,
+        /// Responds immediately with a definitive validation rejection (maps to `InvalidEntry`).
+        Invalid,
+        /// Responds immediately with a non-definitive internal error (maps to `Other`).
+        InternalError,
+        /// Responds immediately with the filter's failsafe rejection (maps to `FailsafeEnabled`).
+        Failsafe,
+        /// Sleeps far longer than the client timeout before responding valid (a slow endpoint).
+        Slow,
+    }
+
+    /// Behavior of a mock endpoint for `admin_getFailsafeEnabled`.
+    #[derive(Clone, Copy)]
+    enum Failsafe {
+        /// Responds immediately with the given boolean.
+        Reply(bool),
+        /// Responds immediately with an error.
+        Error,
+        /// Sleeps far longer than the client timeout before responding `false`.
+        Slow,
+    }
+
+    struct MockEndpoint {
+        url: String,
+        _handle: ServerHandle,
+    }
+
+    impl MockEndpoint {
+        async fn start(check: Verdict, failsafe: Failsafe) -> Self {
+            let server = ServerBuilder::default()
+                .build("127.0.0.1:0".parse::<SocketAddr>().unwrap())
+                .await
+                .unwrap();
+            let addr = server.local_addr().unwrap();
+
+            let mut module = RpcModule::new(());
+            module
+                .register_async_method(
+                    "interop_checkAccessList",
+                    move |_params, _ctx, _| async move {
+                        match check {
+                            Verdict::Valid => Ok(()),
+                            Verdict::Invalid => Err(ErrorObjectOwned::owned(
+                                SuperchainDAError::ConflictingData as i32,
+                                "conflicting data",
+                                None::<()>,
+                            )),
+                            Verdict::InternalError => {
+                                Err(ErrorObjectOwned::owned(-32603, "internal error", None::<()>))
+                            }
+                            // The filter codes failsafe as -32602 with a "failsafe" message.
+                            Verdict::Failsafe => {
+                                Err(ErrorObjectOwned::owned(-32602, "failsafe enabled", None::<()>))
+                            }
+                            Verdict::Slow => {
+                                tokio::time::sleep(Duration::from_secs(60)).await;
+                                Ok(())
+                            }
+                        }
+                    },
+                )
+                .unwrap();
+            module
+                .register_async_method(
+                    "admin_getFailsafeEnabled",
+                    move |_params, _ctx, _| async move {
+                        match failsafe {
+                            Failsafe::Reply(v) => Ok(v),
+                            Failsafe::Error => {
+                                Err(ErrorObjectOwned::owned(-32603, "internal error", None::<()>))
+                            }
+                            Failsafe::Slow => {
+                                tokio::time::sleep(Duration::from_secs(60)).await;
+                                Ok(false)
+                            }
+                        }
+                    },
+                )
+                .unwrap();
+
+            let handle = server.start(module);
+            Self { url: format!("http://{addr}"), _handle: handle }
+        }
+    }
+
+    /// Builds a client over the given mock endpoints with a short request timeout.
+    async fn client_for(
+        endpoints: &[&MockEndpoint],
+        min_responses: Option<usize>,
+    ) -> InteropFilterClient {
+        let urls = endpoints.iter().map(|e| e.url.clone()).collect();
+        let mut builder =
+            InteropFilterClient::builder(urls, 10).timeout(Duration::from_millis(300));
+        if let Some(min) = min_responses {
+            builder = builder.min_responses(min);
+        }
+        builder.build().await
+    }
+
+    fn descriptor() -> ExecutingDescriptor {
+        ExecutingDescriptor::new(10, 0, None)
+    }
+
+    async fn check(client: &InteropFilterClient) -> Result<(), InteropTxValidatorError> {
+        client.check_access_list(&[B256::ZERO], descriptor()).await
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn quorum_all_valid_accepts() {
+        let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let b = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let client = client_for(&[&a, &b], None).await;
+        assert!(check(&client).await.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn quorum_all_invalid_rejects_with_real_error() {
+        let a = MockEndpoint::start(Verdict::Invalid, Failsafe::Reply(false)).await;
+        let b = MockEndpoint::start(Verdict::Invalid, Failsafe::Reply(false)).await;
+        let client = client_for(&[&a, &b], None).await;
+        let err = check(&client).await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                InteropTxValidatorError::InvalidEntry(SuperchainDAError::ConflictingData)
+            ),
+            "expected the real rejection reason, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn disagreement_logs_and_rejects() {
+        let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let b = MockEndpoint::start(Verdict::Invalid, Failsafe::Reply(false)).await;
+        let client = client_for(&[&a, &b], None).await;
+        let err = check(&client).await.unwrap_err();
+        assert!(
+            matches!(err, InteropTxValidatorError::Disagreement { valid: 1, invalid: 1 }),
+            "expected disagreement, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn failsafe_on_any_endpoint_hard_rejects() {
+        let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let b = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let failsafe = MockEndpoint::start(Verdict::Failsafe, Failsafe::Reply(false)).await;
+        // min 2 of 3: the two valid endpoints would otherwise satisfy quorum, but a single
+        // endpoint reporting failsafe must hard-reject regardless.
+        let client = client_for(&[&a, &b, &failsafe], Some(2)).await;
+        let err = check(&client).await.unwrap_err();
+        assert!(
+            matches!(err, InteropTxValidatorError::FailsafeEnabled),
+            "failsafe on any endpoint must hard-reject, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ignores_slow_endpoint_once_quorum_met() {
+        let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let b = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let slow = MockEndpoint::start(Verdict::Slow, Failsafe::Reply(false)).await;
+        // min 2 of 3; the slow endpoint must not delay the decision.
+        let client = client_for(&[&a, &b, &slow], Some(2)).await;
+        let start = Instant::now();
+        assert!(check(&client).await.is_ok());
+        assert!(start.elapsed() < Duration::from_secs(1), "decision waited on the slow endpoint");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn timeouts_do_not_count_fail_closed() {
+        let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let slow = MockEndpoint::start(Verdict::Slow, Failsafe::Reply(false)).await;
+        // Require 2 definitive verdicts but only one endpoint responds; the timeout is not a
+        // response, so quorum is never reached.
+        let client = client_for(&[&a, &slow], Some(2)).await;
+        let err = check(&client).await.unwrap_err();
+        assert!(
+            matches!(err, InteropTxValidatorError::QuorumNotReached { received: 1, required: 2 }),
+            "expected fail-closed quorum-not-reached, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn transport_error_not_counted() {
+        let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let b = MockEndpoint::start(Verdict::InternalError, Failsafe::Reply(false)).await;
+        // Internal errors are non-responses; with min 2 of 2, quorum is not reached.
+        let client = client_for(&[&a, &b], None).await;
+        let err = check(&client).await.unwrap_err();
+        assert!(
+            matches!(err, InteropTxValidatorError::QuorumNotReached { received: 1, required: 2 }),
+            "expected quorum-not-reached, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn single_endpoint_behaves_as_before() {
+        let valid = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let invalid = MockEndpoint::start(Verdict::Invalid, Failsafe::Reply(false)).await;
+
+        let valid_client = client_for(&[&valid], None).await;
+        assert!(check(&valid_client).await.is_ok());
+
+        let invalid_client = client_for(&[&invalid], None).await;
+        assert!(matches!(
+            check(&invalid_client).await.unwrap_err(),
+            InteropTxValidatorError::InvalidEntry(SuperchainDAError::ConflictingData)
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn failsafe_or_across_endpoints() {
+        let off = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        let on = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(true)).await;
+        let client = client_for(&[&off, &on], None).await;
+        assert!(client.query_failsafe().await.unwrap());
+        assert!(client.is_failsafe_enabled());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn failsafe_short_circuits_on_first_true() {
+        let on = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(true)).await;
+        let slow = MockEndpoint::start(Verdict::Valid, Failsafe::Slow).await;
+        let client = client_for(&[&on, &slow], None).await;
+        let start = Instant::now();
+        assert!(client.query_failsafe().await.unwrap());
+        assert!(start.elapsed() < Duration::from_secs(1), "failsafe waited on the slow endpoint");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn failsafe_all_error_keeps_cache() {
+        let a = MockEndpoint::start(Verdict::Valid, Failsafe::Error).await;
+        let b = MockEndpoint::start(Verdict::Valid, Failsafe::Error).await;
+        let client = client_for(&[&a, &b], None).await;
+        // Seed a known cached value, then confirm an all-error poll leaves it unchanged and errors.
+        client.inner.failsafe_enabled.store(true, Ordering::Release);
+        assert!(client.query_failsafe().await.is_err());
+        assert!(client.is_failsafe_enabled(), "cache should be unchanged when no endpoint replies");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[should_panic(expected = "min_responses")]
+    async fn builder_rejects_bad_min_responses() {
+        let a = MockEndpoint::start(Verdict::Valid, Failsafe::Reply(false)).await;
+        // min_responses exceeds the single configured endpoint.
+        let _ = client_for(&[&a], Some(2)).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[should_panic(expected = "at least one endpoint")]
+    async fn builder_rejects_no_endpoints() {
+        let _ = InteropFilterClient::builder(Vec::new(), 10).build().await;
     }
 }

--- a/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
@@ -2,6 +2,10 @@ use alloy_json_rpc::RpcError;
 use core::error;
 use op_alloy_rpc_types::SuperchainDAError;
 
+/// Dedicated JSON-RPC error code emitted by the op-interop-filter server when its failsafe is
+/// active. Detection relies on this code; the filter must emit it (a prerequisite server change).
+const FAILSAFE_ENABLED_CODE: i32 = -320602;
+
 /// Failures occurring during validation of inbox entries.
 #[derive(thiserror::Error, Debug)]
 pub enum InteropTxValidatorError {
@@ -75,9 +79,9 @@ impl InteropTxValidatorError {
         if let Some(error_payload) = err.as_error_resp() {
             let code = error_payload.code as i32;
 
-            // The filter's failsafe rejection is coded -32602, which is overloaded (it also
-            // covers generic param/read fallbacks), so disambiguate on the message.
-            if error_payload.message.to_ascii_lowercase().contains("failsafe") {
+            // The filter emits a dedicated code for failsafe rejections. Detect by code only;
+            // never match on the message text.
+            if code == FAILSAFE_ENABLED_CODE {
                 return Self::FailsafeEnabled;
             }
 

--- a/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
@@ -6,6 +6,19 @@ use op_alloy_rpc_types::SuperchainDAError;
 /// active. Detection relies on this code; the filter must emit it (a prerequisite server change).
 const FAILSAFE_ENABLED_CODE: i32 = -320602;
 
+/// Standard JSON-RPC "internal error" code. Treated as a non-response (transport-class), not a
+/// definitive rejection, because it signals a filter-internal failure rather than a verdict.
+const JSON_RPC_INTERNAL_ERROR_CODE: i32 = -32603;
+
+/// Filter codes meaning "this node does not have the data yet" (it is out of sync), as opposed to
+/// a verdict that the entry is invalid. These are soft, non-response failures: a single out-of-sync
+/// node is ignored as long as the quorum is met by other nodes.
+///
+/// `FUTURE_DATA_CODE` is also a [`SuperchainDAError`] variant, so this check must run before the
+/// `SuperchainDAError` mapping; `UNINITIALIZED_CODE` is not in that enum and needs the raw check.
+const FUTURE_DATA_CODE: i32 = -321401;
+const UNINITIALIZED_CODE: i32 = -320400;
+
 /// Failures occurring during validation of inbox entries.
 #[derive(thiserror::Error, Debug)]
 pub enum InteropTxValidatorError {
@@ -17,10 +30,32 @@ pub enum InteropTxValidatorError {
     #[error(transparent)]
     InvalidEntry(#[from] SuperchainDAError),
 
+    /// The filter returned a JSON-RPC error response rejecting the access list that is not one of
+    /// the known [`SuperchainDAError`] codes (e.g. a generic `-32602` "failed to parse access
+    /// entry"). This is still a definitive rejection — only transport failures are non-responses.
+    /// The original code and message are preserved so the real reason propagates to the caller.
+    #[error("interop filter rejected access list (code {code}): {message}")]
+    Rejected {
+        /// The JSON-RPC error code returned by the filter.
+        code: i32,
+        /// The JSON-RPC error message returned by the filter.
+        message: String,
+    },
+
     /// An endpoint reported that its failsafe is active. Failsafe on any endpoint is a hard
     /// rejection: a message must never be accepted while any reachable endpoint is in failsafe.
     #[error("interop filter failsafe enabled")]
     FailsafeEnabled,
+
+    /// An endpoint does not yet have the data needed to decide (it is out of sync). This is a soft
+    /// failure, not a verdict: it counts as a non-response, so a single out-of-sync node is
+    /// ignored as long as the quorum is met by other nodes. It is neither a definitive invalid nor
+    /// a failsafe.
+    #[error("interop filter data not yet available (code {code})")]
+    DataUnavailable {
+        /// The JSON-RPC error code indicating the data is not yet available.
+        code: i32,
+    },
 
     /// Not enough endpoints returned a definitive verdict to satisfy the configured quorum.
     /// Produced only by the multi-endpoint aggregator; never fed back into the classifier.
@@ -52,7 +87,7 @@ impl InteropTxValidatorError {
     /// endpoint (i.e. a verdict that counts toward quorum). Transport errors, timeouts, and
     /// the aggregator's own outcomes are not definitive rejections.
     pub const fn is_definitive_invalid(&self) -> bool {
-        matches!(self, Self::InvalidEntry(_))
+        matches!(self, Self::InvalidEntry(_) | Self::Rejected { .. })
     }
 
     /// Returns `true` if this error represents an endpoint reporting that its failsafe is active.
@@ -68,30 +103,54 @@ impl InteropTxValidatorError {
         Self::Other(Box::new(err))
     }
 
-    /// This function will parse the error code to determine if it matches
-    /// one of the known interop filter errors, and return the corresponding
-    /// error variant. Otherwise, it returns a generic [`Other`](Self::Other) error.
+    /// Classifies a JSON-RPC error from the interop filter.
+    ///
+    /// Any error *response* from the filter is a definitive rejection verdict — the filter
+    /// evaluated the request and refused it — except a JSON-RPC internal error
+    /// (`-32603`), which signals a filter-internal failure rather than a verdict. Only
+    /// transport-level failures (no error response at all) are non-responses.
+    ///
+    /// - failsafe code (`-320602`) → [`FailsafeEnabled`](Self::FailsafeEnabled)
+    /// - data-not-yet-available code (`-321401` / `-320400`) →
+    ///   [`DataUnavailable`](Self::DataUnavailable) (soft, non-response)
+    /// - known [`SuperchainDAError`] code → [`InvalidEntry`](Self::InvalidEntry)
+    /// - internal error (`-32603`) → [`Other`](Self::Other) (non-response)
+    /// - any other error response → [`Rejected`](Self::Rejected), preserving code + message
+    /// - no error response (transport) → [`Other`](Self::Other) (non-response)
     pub fn from_json_rpc<E>(err: RpcError<E>) -> Self
     where
         E: error::Error + Send + Sync + 'static,
     {
-        // Try to extract error details from the RPC error
-        if let Some(error_payload) = err.as_error_resp() {
-            let code = error_payload.code as i32;
+        let Some(error_payload) = err.as_error_resp() else {
+            // No error response: a transport-level failure, treated as a non-response.
+            return Self::Other(Box::new(err));
+        };
+        let code = error_payload.code as i32;
 
-            // The filter emits a dedicated code for failsafe rejections. Detect by code only;
-            // never match on the message text.
-            if code == FAILSAFE_ENABLED_CODE {
-                return Self::FailsafeEnabled;
-            }
-
-            // Try to convert the error code to an SuperchainDAError variant
-            if let Ok(invalid_entry) = SuperchainDAError::try_from(code) {
-                return Self::InvalidEntry(invalid_entry);
-            }
+        // The filter emits a dedicated code for failsafe rejections. Detect by code only;
+        // never match on the message text.
+        if code == FAILSAFE_ENABLED_CODE {
+            return Self::FailsafeEnabled;
         }
 
-        // Default to generic error
-        Self::Other(Box::new(err))
+        // An out-of-sync node that does not have the data yet is a soft, non-response failure.
+        // Must precede the `SuperchainDAError` mapping because `FUTURE_DATA_CODE` is one of its
+        // variants but should be treated as soft, not as a definitive invalid.
+        if code == FUTURE_DATA_CODE || code == UNINITIALIZED_CODE {
+            return Self::DataUnavailable { code };
+        }
+
+        // Known structured rejection codes map to the typed variant.
+        if let Ok(invalid_entry) = SuperchainDAError::try_from(code) {
+            return Self::InvalidEntry(invalid_entry);
+        }
+
+        // A JSON-RPC internal error is a filter-internal failure, not a verdict — non-response.
+        if code == JSON_RPC_INTERNAL_ERROR_CODE {
+            return Self::Other(Box::new(err));
+        }
+
+        // Any other error response is a definitive rejection; preserve the real code + message.
+        Self::Rejected { code, message: error_payload.message.to_string() }
     }
 }

--- a/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
@@ -13,12 +13,49 @@ pub enum InteropTxValidatorError {
     #[error(transparent)]
     InvalidEntry(#[from] SuperchainDAError),
 
+    /// An endpoint reported that its failsafe is active. Failsafe on any endpoint is a hard
+    /// rejection: a message must never be accepted while any reachable endpoint is in failsafe.
+    #[error("interop filter failsafe enabled")]
+    FailsafeEnabled,
+
+    /// Not enough endpoints returned a definitive verdict to satisfy the configured quorum.
+    /// Produced only by the multi-endpoint aggregator; never fed back into the classifier.
+    #[error("interop quorum not reached: {received} definitive responses, {required} required")]
+    QuorumNotReached {
+        /// Number of definitive verdicts (valid + invalid) collected.
+        received: usize,
+        /// Number of definitive verdicts required to decide.
+        required: usize,
+    },
+
+    /// The endpoints that responded definitively disagreed on the verdict.
+    /// Produced only by the multi-endpoint aggregator; never fed back into the classifier.
+    #[error("interop endpoints disagreed: {valid} valid, {invalid} invalid")]
+    Disagreement {
+        /// Number of endpoints that returned a valid verdict.
+        valid: usize,
+        /// Number of endpoints that returned a definitive invalid verdict.
+        invalid: usize,
+    },
+
     /// Catch-all variant.
     #[error("interop filter server error: {0}")]
     Other(Box<dyn error::Error + Send + Sync>),
 }
 
 impl InteropTxValidatorError {
+    /// Returns `true` if this error represents a definitive validation rejection from an
+    /// endpoint (i.e. a verdict that counts toward quorum). Transport errors, timeouts, and
+    /// the aggregator's own outcomes are not definitive rejections.
+    pub const fn is_definitive_invalid(&self) -> bool {
+        matches!(self, Self::InvalidEntry(_))
+    }
+
+    /// Returns `true` if this error represents an endpoint reporting that its failsafe is active.
+    pub const fn is_failsafe(&self) -> bool {
+        matches!(self, Self::FailsafeEnabled)
+    }
+
     /// Returns a new instance of [`Other`](Self::Other) error variant.
     pub fn other<E>(err: E) -> Self
     where
@@ -37,6 +74,12 @@ impl InteropTxValidatorError {
         // Try to extract error details from the RPC error
         if let Some(error_payload) = err.as_error_resp() {
             let code = error_payload.code as i32;
+
+            // The filter's failsafe rejection is coded -32602, which is overloaded (it also
+            // covers generic param/read fallbacks), so disambiguate on the message.
+            if error_payload.message.to_ascii_lowercase().contains("failsafe") {
+                return Self::FailsafeEnabled;
+            }
 
             // Try to convert the error code to an SuperchainDAError variant
             if let Ok(invalid_entry) = SuperchainDAError::try_from(code) {

--- a/rust/op-reth/crates/txpool/src/interop_filter/message.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/message.rs
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /// An [`ExecutingDescriptor`] is a part of the payload to `interop_checkAccessList`
 /// Interop RPC request descriptor.
-#[derive(Default, Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct ExecutingDescriptor {
     /// The chain ID of the executing chain.
     #[serde(rename = "chainID", with = "alloy_serde::quantity")]

--- a/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
@@ -41,6 +41,24 @@ pub struct InteropMetrics {
     /// Current interop failsafe state: `1` if failsafe is enabled (all interop txs are
     /// rejected/evicted), `0` if disabled. Refreshed on every failsafe poll.
     pub(crate) failsafe_enabled: Gauge,
+
+    /// Quorum accepted: enough definitive verdicts collected and all agreed valid.
+    pub(crate) quorum_accept: Counter,
+    /// Quorum rejected: enough definitive verdicts collected and all agreed invalid.
+    pub(crate) quorum_reject_agreed: Counter,
+    /// Quorum rejected: collected verdicts disagreed (mix of valid and invalid).
+    pub(crate) quorum_reject_disagreement: Counter,
+    /// Quorum rejected: fewer definitive verdicts than required were collected (fail closed).
+    pub(crate) quorum_reject_not_reached: Counter,
+    /// Quorum rejected: an endpoint reported its failsafe active (hard short-circuit rejection).
+    pub(crate) quorum_reject_failsafe: Counter,
+
+    /// Per-endpoint counter for definitive valid verdicts.
+    pub(crate) endpoint_valid: Counter,
+    /// Per-endpoint counter for definitive invalid verdicts.
+    pub(crate) endpoint_invalid: Counter,
+    /// Per-endpoint counter for non-responses (timeout, transport error, cancellation).
+    pub(crate) endpoint_unavailable: Counter,
 }
 
 impl InteropMetrics {
@@ -54,6 +72,48 @@ impl InteropMetrics {
     #[inline]
     pub fn set_failsafe_enabled(&self, enabled: bool) {
         self.failsafe_enabled.set(if enabled { 1.0 } else { 0.0 });
+    }
+
+    /// Records the outcome of a multi-endpoint quorum decision. Increments exactly one of the
+    /// `quorum_*` counters based on the collected verdicts. This is the sole signal for the
+    /// [`Disagreement`](InteropTxValidatorError::Disagreement) and
+    /// [`QuorumNotReached`](InteropTxValidatorError::QuorumNotReached) outcomes, which
+    /// [`increment_metrics_for_error`](Self::increment_metrics_for_error) does not record.
+    pub fn record_quorum_outcome(&self, valid: usize, invalid: usize, min_responses: usize) {
+        if valid + invalid < min_responses {
+            self.quorum_reject_not_reached.increment(1);
+        } else if invalid == 0 {
+            self.quorum_accept.increment(1);
+        } else if valid == 0 {
+            self.quorum_reject_agreed.increment(1);
+        } else {
+            self.quorum_reject_disagreement.increment(1);
+        }
+    }
+
+    /// Records a hard failsafe rejection: an endpoint reported its failsafe active and the check
+    /// was short-circuited.
+    #[inline]
+    pub fn record_failsafe_reject(&self) {
+        self.quorum_reject_failsafe.increment(1);
+    }
+
+    /// Records a single endpoint's definitive valid verdict.
+    #[inline]
+    pub fn record_endpoint_valid(&self) {
+        self.endpoint_valid.increment(1);
+    }
+
+    /// Records a single endpoint's definitive invalid verdict.
+    #[inline]
+    pub fn record_endpoint_invalid(&self) {
+        self.endpoint_invalid.increment(1);
+    }
+
+    /// Records a single endpoint's non-response (timeout, transport error, cancellation).
+    #[inline]
+    pub fn record_endpoint_unavailable(&self) {
+        self.endpoint_unavailable.increment(1);
     }
 
     /// Increments the metrics for the given error

--- a/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
@@ -4,7 +4,7 @@ use crate::interop_filter::InteropTxValidatorError;
 use op_alloy_rpc_types::SuperchainDAError;
 use reth_metrics::{
     Metrics,
-    metrics::{Counter, Gauge, Histogram},
+    metrics::{Counter, Gauge, Histogram, Label},
 };
 use std::time::Duration;
 
@@ -52,13 +52,57 @@ pub struct InteropMetrics {
     pub(crate) quorum_reject_not_reached: Counter,
     /// Quorum rejected: an endpoint reported its failsafe active (hard short-circuit rejection).
     pub(crate) quorum_reject_failsafe: Counter,
+}
 
-    /// Per-endpoint counter for definitive valid verdicts.
-    pub(crate) endpoint_valid: Counter,
-    /// Per-endpoint counter for definitive invalid verdicts.
-    pub(crate) endpoint_invalid: Counter,
-    /// Per-endpoint counter for non-responses (timeout, transport error, cancellation).
-    pub(crate) endpoint_unavailable: Counter,
+/// Per-endpoint interop metrics, labeled by endpoint index so each configured interop filter can be
+/// observed independently. With the fleet-wide counters alone you can tell *an* endpoint is slow or
+/// down; these labeled metrics answer *which* one — the first question on call for a fan-out
+/// client. Labeled by index (not the raw URL), since interop-http URLs can carry basic-auth
+/// credentials.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "optimism_transaction_pool.interop.endpoint")]
+pub struct EndpointMetrics {
+    /// How long this endpoint took to answer an `interop_checkAccessList` query. Lets an endpoint
+    /// creeping toward the request timeout be spotted before it starts failing.
+    pub(crate) query_latency: Histogram,
+    /// Definitive valid verdicts returned by this endpoint.
+    pub(crate) valid: Counter,
+    /// Definitive invalid verdicts returned by this endpoint.
+    pub(crate) invalid: Counter,
+    /// Non-responses from this endpoint (timeout, transport error, soft out-of-sync,
+    /// cancellation).
+    pub(crate) unavailable: Counter,
+}
+
+impl EndpointMetrics {
+    /// Builds per-endpoint metrics labeled with the endpoint's index.
+    pub fn for_endpoint(index: usize) -> Self {
+        Self::new_with_labels(vec![Label::new("endpoint", index.to_string())])
+    }
+
+    /// Records the duration of this endpoint's interop filter query.
+    #[inline]
+    pub fn record_query(&self, duration: Duration) {
+        self.query_latency.record(duration.as_secs_f64());
+    }
+
+    /// Records this endpoint's definitive valid verdict.
+    #[inline]
+    pub fn record_valid(&self) {
+        self.valid.increment(1);
+    }
+
+    /// Records this endpoint's definitive invalid verdict.
+    #[inline]
+    pub fn record_invalid(&self) {
+        self.invalid.increment(1);
+    }
+
+    /// Records this endpoint's non-response (timeout, transport error, soft out-of-sync).
+    #[inline]
+    pub fn record_unavailable(&self) {
+        self.unavailable.increment(1);
+    }
 }
 
 impl InteropMetrics {
@@ -96,24 +140,6 @@ impl InteropMetrics {
     #[inline]
     pub fn record_failsafe_reject(&self) {
         self.quorum_reject_failsafe.increment(1);
-    }
-
-    /// Records a single endpoint's definitive valid verdict.
-    #[inline]
-    pub fn record_endpoint_valid(&self) {
-        self.endpoint_valid.increment(1);
-    }
-
-    /// Records a single endpoint's definitive invalid verdict.
-    #[inline]
-    pub fn record_endpoint_invalid(&self) {
-        self.endpoint_invalid.increment(1);
-    }
-
-    /// Records a single endpoint's non-response (timeout, transport error, cancellation).
-    #[inline]
-    pub fn record_endpoint_unavailable(&self) {
-        self.endpoint_unavailable.increment(1);
     }
 
     /// Increments the metrics for the given error

--- a/rust/op-reth/crates/txpool/src/maintain.rs
+++ b/rust/op-reth/crates/txpool/src/maintain.rs
@@ -2,7 +2,10 @@
 
 /// Offset before deadline expiry at which a tx becomes "stale" and triggers revalidation.
 const OFFSET_TIME: u64 = 60;
-/// Maximum number of interop filter requests at the same time.
+/// Maximum number of transactions revalidated against the interop filter concurrently. Each
+/// transaction issues up to one request per configured endpoint, so total in-flight interop
+/// requests can reach `MAX_INTEROP_QUERIES * <number of endpoints>`. The bound is on
+/// transactions (per-endpoint load is unchanged by fan-out).
 const MAX_INTEROP_QUERIES: usize = 10;
 /// Interval at which a heartbeat warning is re-logged while failsafe stays enabled, so a
 /// long-lived failsafe keeps surfacing in recent logs rather than only at the transition.

--- a/rust/op-reth/crates/txpool/src/maintain.rs
+++ b/rust/op-reth/crates/txpool/src/maintain.rs
@@ -9,8 +9,7 @@ const OFFSET_TIME: u64 = 60;
 const MAX_INTEROP_QUERIES: usize = 10;
 /// Interval at which a heartbeat warning is re-logged while failsafe stays enabled, so a
 /// long-lived failsafe keeps surfacing in recent logs rather than only at the transition. Also
-/// reused to rate-limit the degraded-quorum log in
-/// [`InteropFilterClient`](crate::InteropFilterClient).
+/// reused to rate-limit the degraded-quorum log in [`InteropFilterClient`].
 pub(crate) const FAILSAFE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 
 use crate::{

--- a/rust/op-reth/crates/txpool/src/maintain.rs
+++ b/rust/op-reth/crates/txpool/src/maintain.rs
@@ -8,8 +8,10 @@ const OFFSET_TIME: u64 = 60;
 /// transactions (per-endpoint load is unchanged by fan-out).
 const MAX_INTEROP_QUERIES: usize = 10;
 /// Interval at which a heartbeat warning is re-logged while failsafe stays enabled, so a
-/// long-lived failsafe keeps surfacing in recent logs rather than only at the transition.
-const FAILSAFE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
+/// long-lived failsafe keeps surfacing in recent logs rather than only at the transition. Also
+/// reused to rate-limit the degraded-quorum log in
+/// [`InteropFilterClient`](crate::InteropFilterClient).
+pub(crate) const FAILSAFE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 
 use crate::{
     conditional::MaybeConditionalTransaction,


### PR DESCRIPTION
Fan out `interop_checkAccessList` to multiple interop-filter endpoints concurrently inside `InteropFilterClient` and combine by quorum agreement. A definitive verdict counts toward quorum; transport errors, timeouts, and soft out-of-sync responses do not. The aggregator decides once `min_responses` verdicts arrive and does not await slower endpoints.

- Accept iff `min_responses` definitive verdicts are collected and all agree valid; all-invalid surfaces the real reason; a mix logs and rejects (`Disagreement`); too few definitive verdicts fail closed (`QuorumNotReached`).
- **Failsafe semantics:** a failsafe reported by any endpoint is a hard rejection. The main loop short-circuits the moment a failsafe arrives. On reaching the quorum, before accepting, the aggregator also non-blocking-drains the responses that are *already ready* and rejects if any is a failsafe — so a failsafe that has already arrived deterministically beats a met quorum. Endpoints that have not yet responded are never awaited (fast-accept preserved); dropping the in-flight futures cancels them. A failsafe detected on a check also flips the cached gate/gauge immediately, so admission stops without waiting for the next ~1s poll.
- `query_failsafe` ORs `admin_getFailsafeEnabled` across endpoints, short-circuiting on the first `true`. Clearing the gate to `false` requires *every* endpoint to have replied `false`; on partial information (some endpoints silent, none reporting failsafe) the cached state is left unchanged, so a slow/down endpoint that is itself in failsafe can't be masked by a healthy endpoint.
- CLI: `--rollup.interop-http` is now repeatable and `--rollup.interop-min-responses` sets the quorum (defaults to the endpoint count — unanimity / fail-closed). Single-endpoint configs behave as before.

Updates `OpPoolBuilder` and the op-rbuilder callers for the new `with_interop` signature.

The proxyd/infra `agreement` strategy from the same plan is a separate PR.

## Observability

- **Per-endpoint metrics** labeled by endpoint index (`optimism_transaction_pool.interop.endpoint{endpoint="N"}`): `valid` / `invalid` / `unavailable` counters and `query_latency`, so "which endpoint is slow/down/dissenting?" is answerable. Labeled by index, never the raw URL (which can carry basic-auth creds). Fleet-wide quorum/failsafe counters stay unlabeled.
- **Degraded-quorum visibility:** a rate-limited `info!` (reuses `FAILSAFE_HEARTBEAT_INTERVAL`) when a check fails closed on an unmet quorum, plus a startup `info!` of the effective `min_responses` / endpoint count — so a sustained interop halt is visible beyond the counter.

## Verdict classification (`from_json_rpc`)

Each endpoint result is classified by the filter's JSON-RPC response. Order matters:

| Filter response | Classification | Counts toward quorum? |
|---|---|---|
| no error response (transport failure) | `Other` | no (non-response) |
| `-320602` (dedicated failsafe code) | `FailsafeEnabled` | hard reject |
| `-321401` FutureData / `-320400` Uninitialized | `DataUnavailable` | **no (soft, non-response)** |
| known `SuperchainDAError` code | `InvalidEntry` | yes (definitive invalid) |
| `-32603` (JSON-RPC internal error) | `Other` | no (non-response) |
| any other error response | `Rejected { code, message }` | yes (definitive invalid) |

- **Any filter error response is a definitive rejection** (not just known `SuperchainDAError` codes): e.g. a fabricated entry yields a generic `-32602` "failed to parse access entry", now classified `Rejected` with the real message preserved so the rejection reason propagates. Only transport failures and `-32603` are non-responses. (This fixes the `QuorumNotReached` regression on `TestInteropFilter_IngressRejectsInvalid`.)
- **Soft out-of-sync failures:** `FutureData` (`-321401`) and `Uninitialized` (`-320400`) mean a node simply doesn't have the data yet, not that the entry is invalid. They are soft, non-response failures — a single out-of-sync node is ignored as long as the quorum is met by others; if every node is out of sync the aggregator fails closed. `FutureData` is a `SuperchainDAError` variant, so the soft carve-out is checked before the `SuperchainDAError` mapping.

## ⚠️ Hard cutover: requires op-interop-filter `-320602`

Failsafe detection relies on the op-interop-filter server emitting a **dedicated** JSON-RPC error code `-320602` for failsafe rejections (replacing the previously overloaded `-32602`). Detection is by code only — never by message text. This is a hard cutover with no fallback: **the prerequisite server PR that emits `-320602` must be deployed to all interop filters before (or together with) this change**, otherwise a filter in failsafe will no longer be recognized as `FailsafeEnabled`. In that case its `-32602` failsafe response degrades to a generic `Rejected` (still a rejection, never an accept), so the failure mode remains fail-closed.

## Test plan
`InteropFilterClient` unit tests (mock jsonrpsee servers) cover all-valid, all-invalid (real error), disagreement, slow-endpoint-ignored, timeout/transport fail-closed, generic `-32602` rejection (definitive, message preserved), out-of-sync soft failure ignored when quorum met, all-out-of-sync fail-closed, failsafe OR, failsafe short-circuit, failsafe-on-any-endpoint hard reject (deterministic), failsafe-on-check-flips-cached-gate, slow-non-failsafe-endpoint-does-not-delay-accept, all-error-keeps-cache, partial-failsafe-replies-do-not-clear-gate, unanimous-false-clears-gate, single-endpoint equivalence, and builder bounds validation; plus `test_parse_interop_multiple_endpoints`. Verified locally: `cargo fmt --all --check` (nightly), `cargo clippy -p reth-optimism-txpool -p reth-optimism-node --all-targets -- -D warnings`, `cargo nextest run -p reth-optimism-txpool -p reth-optimism-node` (63 passed / 1 skipped), `cargo build -p op-rbuilder`, **and the `op-acceptance-tests` interop/filter suite — `TestInteropFilter_IngressRejectsInvalid` and `TestInteropFilter_FailsafeLifecycle` both pass.**
