### PR TITLE
test(op-e2e): bound fuzz RPC/engine calls and stream output to diagnose no-output timeout

### DIFF
--- a/op-e2e/justfile
+++ b/op-e2e/justfile
@@ -69,7 +69,7 @@ clean:
 
 # Run fuzz tests
 fuzz:
-    parallel --tag -N1 "go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz {} ./opgeth" ::: FuzzFjordCostFunction FuzzFastLzGethSolidity FuzzFastLzCgo
+    parallel --line-buffer --tag -N1 "go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz {} ./opgeth" ::: FuzzFjordCostFunction FuzzFastLzGethSolidity FuzzFastLzCgo
 
 # Generate contract bindings
 gen-binding CONTRACT:

--- a/op-e2e/opgeth/fastlz_test.go
+++ b/op-e2e/opgeth/fastlz_test.go
@@ -97,26 +97,31 @@ func FuzzFjordCostFunction(f *testing.F) {
 	gpoCaller, err := bindings.NewGasPriceOracleCaller(predeploys.GasPriceOracleAddr, opGeth.L2Client)
 	require.NoError(f, err)
 
-	isFjord, err := gpoCaller.IsFjord(&bind.CallOpts{})
+	// Bound every RPC/engine call so a wedged call fails fast with a clear
+	// error instead of hanging until the CI job's no-output timeout kills it.
+	// The one-time setup calls share the 60s ctx above; they complete well
+	// within it. The per-iteration GetL1Fee uses a fresh deadline below, since
+	// the fuzzing phase outlives this ctx.
+	isFjord, err := gpoCaller.IsFjord(&bind.CallOpts{Context: ctx})
 	require.NoError(f, err)
 	require.True(f, isFjord)
 
-	_, err = opGeth.AddL2Block(context.Background())
+	_, err = opGeth.AddL2Block(ctx)
 	require.NoError(f, err)
 
-	baseFee, err := gpoCaller.L1BaseFee(&bind.CallOpts{})
+	baseFee, err := gpoCaller.L1BaseFee(&bind.CallOpts{Context: ctx})
 	require.NoError(f, err)
 	require.Greater(f, baseFee.Uint64(), uint64(0))
 
-	blobBaseFee, err := gpoCaller.BlobBaseFee(&bind.CallOpts{})
+	blobBaseFee, err := gpoCaller.BlobBaseFee(&bind.CallOpts{Context: ctx})
 	require.NoError(f, err)
 	require.Greater(f, blobBaseFee.Uint64(), uint64(0))
 
-	baseFeeScalar, err := gpoCaller.BaseFeeScalar(&bind.CallOpts{})
+	baseFeeScalar, err := gpoCaller.BaseFeeScalar(&bind.CallOpts{Context: ctx})
 	require.NoError(f, err)
 	require.Greater(f, baseFeeScalar, uint32(0))
 
-	blobBaseFeeScalar, err := gpoCaller.BlobBaseFeeScalar(&bind.CallOpts{})
+	blobBaseFeeScalar, err := gpoCaller.BlobBaseFeeScalar(&bind.CallOpts{Context: ctx})
 	require.NoError(f, err)
 	require.Equal(f, blobBaseFeeScalar, uint32(0))
 
@@ -160,7 +165,12 @@ func FuzzFjordCostFunction(f *testing.F) {
 			return
 		}
 
-		l1FeeSolidity, err := gpoCaller.GetL1Fee(&bind.CallOpts{}, fuzzedData)
+		// Fresh per-iteration deadline: the fuzzing phase outlives any single
+		// setup-scoped context, so a wedged eth_call still fails fast here.
+		callCtx, callCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer callCancel()
+
+		l1FeeSolidity, err := gpoCaller.GetL1Fee(&bind.CallOpts{Context: callCtx}, fuzzedData)
 		require.NoError(t, err)
 
 		// remove the adjustment


### PR DESCRIPTION
The `op-e2e-fuzz` step is intermittently killed by CircleCI's 15-min no-output timeout (3/733 on main). The job's healthy runtime is ~6.5 min, so this is an unbounded-wait hang, not slowness.

This does **not** fix the underlying hang — the trigger isn't identified and isn't reproducible locally. It makes the failure diagnosable instead of silent:

- `FuzzFjordCostFunction` made every RPC/engine call on an unbounded context (`&bind.CallOpts{}` defaults to `context.Background()`; `AddL2Block(context.Background())`). Bounding them means a wedged call fails fast with `context deadline exceeded` instead of running out the 15-min clock. Setup reuses the existing 60s context; the per-iteration `GetL1Fee` gets a fresh 30s deadline (the 60s setup context expires during fuzzing).
- `op-e2e/justfile`: `--line-buffer` on the `parallel` invocation (keeps `--tag`) so `go test`'s `fuzz: elapsed:` lines stream in real time — a future hang shows its last progress line.

Refs ethereum-optimism/optimism#21191