### PR TITLE
feat(interop): dedicated RPC error code for failsafe (-320602)

### DIFF
--- a/op-core/interop/interop.go
+++ b/op-core/interop/interop.go
@@ -66,8 +66,6 @@ var errorCodeMap = map[error]int{
 	ErrUnknownChain:          -320501,
 	ErrUninitialized:         -320400,
 
-	// Dedicated failsafe code so clients detect failsafe by code, not message string.
-	// -320602 is the next free subcode in the -3206xx class (after -320600 CONFLICTING, -320601 INEFFECTIVE).
 	ErrFailsafeEnabled: -320602,
 
 	ErrNoRPCSource:             genericInvalidParamsErr,

--- a/op-core/interop/interop.go
+++ b/op-core/interop/interop.go
@@ -66,8 +66,11 @@ var errorCodeMap = map[error]int{
 	ErrUnknownChain:          -320501,
 	ErrUninitialized:         -320400,
 
+	// Dedicated failsafe code so clients detect failsafe by code, not message string.
+	// -320602 is the next free subcode in the -3206xx class (after -320600 CONFLICTING, -320601 INEFFECTIVE).
+	ErrFailsafeEnabled: -320602,
+
 	ErrNoRPCSource:             genericInvalidParamsErr,
-	ErrFailsafeEnabled:         genericInvalidParamsErr,
 	ErrInvalidatedRead:         genericInvalidParamsErr,
 	ErrAlreadyInvalidatingRead: genericInvalidParamsErr,
 	ErrRewindFailed:            genericInvalidParamsErr,

--- a/op-core/interop/interop_test.go
+++ b/op-core/interop/interop_test.go
@@ -1,0 +1,26 @@
+package interop
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFailsafeErrorCode verifies failsafe has a dedicated RPC error code that
+// clients can detect by code rather than by matching the message string. This
+// code is a deployment contract with op-reth and proxyd, so it must not change.
+func TestFailsafeErrorCode(t *testing.T) {
+	require.Equal(t, -320602, GetErrorCode(ErrFailsafeEnabled),
+		"failsafe must map to the dedicated -320602 code")
+
+	require.NotEqual(t, genericInvalidParamsErr, GetErrorCode(ErrFailsafeEnabled),
+		"failsafe must not share the generic invalid-params fallback code")
+}
+
+// TestFailsafeErrorCodeWrapped confirms detection survives error wrapping, since
+// GetErrorCode uses errors.Is and callers wrap the sentinel with context.
+func TestFailsafeErrorCodeWrapped(t *testing.T) {
+	wrapped := fmt.Errorf("rejecting request: %w", ErrFailsafeEnabled)
+	require.Equal(t, -320602, GetErrorCode(wrapped))
+}


### PR DESCRIPTION
Give the interop filter's failsafe rejection a dedicated JSON-RPC error code (`-320602`) so clients detect failsafe by code instead of matching the error message string.

`ErrFailsafeEnabled` previously mapped to the generic `-32602`, shared with `ErrNoRPCSource`, invalidated-read, and the `GetErrorCode` default — indistinguishable from unrelated failures. `-320602` is the next free subcode in the `-3206xx` class (after `-320600` CONFLICTING, `-320601` INEFFECTIVE). The filter frontend already returns `rpc.JsonError{Code: interop.GetErrorCode(err)}`, so it emits the new code automatically — no frontend change needed.

**Deployment ordering (prerequisite):** This change must deploy to all `op-interop-filter` instances **before** the client-side code-based detection lands in op-reth (ethereum-optimism/optimism#21195) and proxyd (#640). Detection is code-only with no message fallback, so a client pointed at a not-yet-upgraded filter would see the legacy `-32602` and miss failsafe — a safety regression. Phase 0 merges and rolls out first.

**Follow-up (not in this PR):** document `-320602` in the supervisor/filter error-code table in `ethereum-optimism/specs`.

Phase 0 of the multi-endpoint interop filter quorum plan.