### PR TITLE
chore(cimg): revert unnecessary deps and add mold

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
   # Provenance is verified by .github/workflows/security.yml.
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:758f67c7212e7d05c3d02c34f26766ef86f657d3bb811da07cc01e37b736ebef
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:bd6af9a868a1486689a2bda822b97877d1a43734c19ec310a2977ed1c2c795a5
   base_image:
     type: string
     default: default

--- a/ops/docker/ci-base-clang/Dockerfile
+++ b/ops/docker/ci-base-clang/Dockerfile
@@ -19,14 +19,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
-      build-essential \
       clang \
-      llvm \
       llvm-dev \
       libclang-dev \
-      libsqlite3-dev \
-      libtss2-dev \
-      pkg-config \
+      mold \
+ && apt clean \
  && rm -rf /var/lib/apt/lists/*
 
 # Install sccache (statically linked musl build works on glibc cimg/base).


### PR DESCRIPTION
This reverts https://github.com/ethereum-optimism/optimism/pull/20839/ as it turned out not to be needed anyway.

At the same time it adds `mold` to speed up linking rust binaries.