### PR TITLE
feat(op-dispute-mon): monitor anchor state L2 sequence number

### DIFF
--- a/op-challenger/game/fault/contracts/anchorstateregistry.go
+++ b/op-challenger/game/fault/contracts/anchorstateregistry.go
@@ -1,0 +1,43 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const methodGetAnchorRoot = "getAnchorRoot"
+
+type AnchorStateRegistryContract struct {
+	metrics     metrics.ContractMetricer
+	multiCaller *batching.MultiCaller
+	contract    *batching.BoundContract
+}
+
+func NewAnchorStateRegistryContract(metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) *AnchorStateRegistryContract {
+	return &AnchorStateRegistryContract{
+		metrics:     metrics,
+		multiCaller: caller,
+		contract:    batching.NewBoundContract(snapshots.LoadAnchorStateRegistryABI(), addr),
+	}
+}
+
+func (a *AnchorStateRegistryContract) Addr() common.Address {
+	return a.contract.Addr()
+}
+
+// GetAnchorRoot returns the current anchor state root and its L2 sequence number.
+func (a *AnchorStateRegistryContract) GetAnchorRoot(ctx context.Context, block rpcblock.Block) (common.Hash, *big.Int, error) {
+	defer a.metrics.StartContractRequest("GetAnchorRoot")()
+	result, err := a.multiCaller.SingleCall(ctx, block, a.contract.Call(methodGetAnchorRoot))
+	if err != nil {
+		return common.Hash{}, nil, fmt.Errorf("failed to retrieve anchor root: %w", err)
+	}
+	return result.GetHash(0), result.GetBigInt(1), nil
+}

--- a/op-challenger/game/fault/contracts/anchorstateregistry_test.go
+++ b/op-challenger/game/fault/contracts/anchorstateregistry_test.go
@@ -1,0 +1,33 @@
+package contracts
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnchorStateRegistry_GetAnchorRoot(t *testing.T) {
+	asrAddr := common.HexToAddress("0x24112842371dFC380576ebb09Ae16Cb6B6caD7CB")
+	asrAbi := snapshots.LoadAnchorStateRegistryABI()
+	stubRpc := batchingTest.NewAbiBasedRpc(t, asrAddr, asrAbi)
+	caller := batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize)
+	asr := NewAnchorStateRegistryContract(contractMetrics.NoopContractMetrics, asrAddr, caller)
+
+	block := rpcblock.ByNumber(482)
+	expectedRoot := common.Hash{0xab, 0xcd, 0xef}
+	expectedSeq := big.NewInt(1234567)
+	stubRpc.SetResponse(asrAddr, methodGetAnchorRoot, block, nil, []interface{}{expectedRoot, expectedSeq})
+
+	root, seq, err := asr.GetAnchorRoot(context.Background(), block)
+	require.NoError(t, err)
+	require.Equal(t, expectedRoot, root)
+	require.Zerof(t, expectedSeq.Cmp(seq), "expected: %v actual: %v", expectedSeq, seq)
+}

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -57,12 +57,14 @@ var (
 	methodChallengeRootL2Block    = "challengeRootL2Block"
 	methodBondDistributionMode    = "bondDistributionMode"
 	methodCloseGame               = "closeGame"
+	methodAnchorStateRegistry     = "anchorStateRegistry"
 )
 
 var (
-	ErrSimulationFailed             = errors.New("tx simulation failed")
-	ErrChallengeL2BlockNotSupported = errors.New("contract version does not support challenging L2 block number")
-	ErrCloseGameNotSupported        = errors.New("contract version does not support closeGame")
+	ErrSimulationFailed                = errors.New("tx simulation failed")
+	ErrChallengeL2BlockNotSupported    = errors.New("contract version does not support challenging L2 block number")
+	ErrCloseGameNotSupported           = errors.New("contract version does not support closeGame")
+	ErrAnchorStateRegistryNotSupported = errors.New("contract version does not support anchorStateRegistry")
 )
 
 type FaultDisputeGameContractLatest struct {
@@ -301,6 +303,15 @@ func (f *FaultDisputeGameContractLatest) GetResolvedAt(ctx context.Context, bloc
 	}
 	resolvedAt := time.Unix(int64(result.GetUint64(0)), 0)
 	return resolvedAt, nil
+}
+
+func (f *FaultDisputeGameContractLatest) GetAnchorStateRegistry(ctx context.Context, block rpcblock.Block) (common.Address, error) {
+	defer f.metrics.StartContractRequest("GetAnchorStateRegistry")()
+	result, err := f.multiCaller.SingleCall(ctx, block, f.contract.Call(methodAnchorStateRegistry))
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to retrieve anchor state registry: %w", err)
+	}
+	return result.GetAddress(0), nil
 }
 
 func (f *FaultDisputeGameContractLatest) GetStartingRootHash(ctx context.Context) (common.Hash, error) {
@@ -729,4 +740,5 @@ type FaultDisputeGameContract interface {
 	Vm(ctx context.Context) (*VMContract, error)
 	GetBondDistributionMode(ctx context.Context, block rpcblock.Block) (types.BondDistributionMode, error)
 	CloseGameTx(ctx context.Context) (txmgr.TxCandidate, error)
+	GetAnchorStateRegistry(ctx context.Context, block rpcblock.Block) (common.Address, error)
 }

--- a/op-challenger/game/fault/contracts/faultdisputegame080.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame080.go
@@ -165,3 +165,7 @@ func (f *FaultDisputeGameContract080) GetBondDistributionMode(ctx context.Contex
 func (f *FaultDisputeGameContract080) CloseGameTx(ctx context.Context) (txmgr.TxCandidate, error) {
 	return txmgr.TxCandidate{}, ErrCloseGameNotSupported
 }
+
+func (f *FaultDisputeGameContract080) GetAnchorStateRegistry(_ context.Context, _ rpcblock.Block) (common.Address, error) {
+	return common.Address{}, ErrAnchorStateRegistryNotSupported
+}

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -253,6 +253,25 @@ func TestBondDistributionMode(t *testing.T) {
 	}
 }
 
+func TestGetAnchorStateRegistry(t *testing.T) {
+	expected := common.HexToAddress("0x0123456789abcDEF0123456789abCDef01234567")
+	for _, version := range versions {
+		version := version
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, game := setupFaultDisputeGameTest(t, version)
+			if version.version == vers080 {
+				_, err := game.GetAnchorStateRegistry(context.Background(), rpcblock.Latest)
+				require.ErrorIs(t, err, ErrAnchorStateRegistryNotSupported)
+				return
+			}
+			stubRpc.SetResponse(fdgAddr, methodAnchorStateRegistry, rpcblock.Latest, nil, []interface{}{expected})
+			actual, err := game.GetAnchorStateRegistry(context.Background(), rpcblock.Latest)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+		})
+	}
+}
+
 func TestClock_EncodingDecoding(t *testing.T) {
 	t.Run("DurationAndTimestamp", func(t *testing.T) {
 		by := common.FromHex("00000000000000050000000000000002")

--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -199,6 +199,8 @@ type Metricer interface {
 
 	RecordGameTypes(gameTypeCounts map[string]int)
 
+	RecordAnchorStateL2SequenceNumber(anchorStateRegistry common.Address, l2SequenceNumber uint64)
+
 	caching.Metrics
 	contractMetrics.ContractMetricer
 	opmetrics.RPCMetricer
@@ -236,12 +238,13 @@ type Metrics struct {
 	lastOutputFetch      prometheus.Gauge
 	oldestGameUpdateTime prometheus.Gauge
 
-	gamesAgreement             prometheus.GaugeVec
-	latestValidProposalL2Block prometheus.Gauge
-	latestProposals            prometheus.GaugeVec
-	ignoredGames               prometheus.Gauge
-	failedGames                prometheus.Gauge
-	l2Challenges               prometheus.GaugeVec
+	gamesAgreement              prometheus.GaugeVec
+	latestValidProposalL2Block  prometheus.Gauge
+	latestProposals             prometheus.GaugeVec
+	anchorStateL2SequenceNumber prometheus.GaugeVec
+	ignoredGames                prometheus.Gauge
+	failedGames                 prometheus.Gauge
+	l2Challenges                prometheus.GaugeVec
 
 	requiredCollateral         prometheus.GaugeVec
 	availableCollateral        prometheus.GaugeVec
@@ -373,6 +376,14 @@ func NewMetrics() *Metrics {
 			Namespace: Namespace,
 			Name:      "latest_valid_proposal_l2_block",
 			Help:      "L2 block number proposed by the latest game with a valid root claim",
+		}),
+		anchorStateL2SequenceNumber: *factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "anchor_state_l2_sequence_number",
+			Help:      "L2 sequence number of the current anchor state in the AnchorStateRegistry",
+		}, []string{
+			// Address of the AnchorStateRegistry. A small, controlled set (typically one per chain).
+			"anchor_state_registry",
 		}),
 		latestProposals: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
@@ -583,6 +594,10 @@ func (m *Metrics) RecordLatestValidProposalL2Block(latestValid uint64) {
 func (m *Metrics) RecordLatestProposals(latestValid, latestInvalid uint64) {
 	m.latestProposals.WithLabelValues("agree").Set(float64(latestValid))
 	m.latestProposals.WithLabelValues("disagree").Set(float64(latestInvalid))
+}
+
+func (m *Metrics) RecordAnchorStateL2SequenceNumber(anchorStateRegistry common.Address, l2SequenceNumber uint64) {
+	m.anchorStateL2SequenceNumber.WithLabelValues(anchorStateRegistry.Hex()).Set(float64(l2SequenceNumber))
 }
 
 func (m *Metrics) RecordIgnoredGames(count int) {

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -67,3 +67,5 @@ func (*NoopMetricsImpl) RecordMixedSafetyGames(_ int) {}
 func (*NoopMetricsImpl) RecordDifferentRootGames(_ int) {}
 
 func (*NoopMetricsImpl) RecordGameTypes(_ map[string]int) {}
+
+func (*NoopMetricsImpl) RecordAnchorStateL2SequenceNumber(_ common.Address, _ uint64) {}

--- a/op-dispute-mon/mon/anchor_state.go
+++ b/op-dispute-mon/mon/anchor_state.go
@@ -1,0 +1,61 @@
+package mon
+
+import (
+	"context"
+	"math"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type AnchorStateMetrics interface {
+	RecordAnchorStateL2SequenceNumber(anchorStateRegistry common.Address, l2SequenceNumber uint64)
+}
+
+// AnchorRootProvider fetches the anchor root for a single AnchorStateRegistry.
+type AnchorRootProvider interface {
+	GetAnchorRoot(ctx context.Context, block rpcblock.Block) (common.Hash, *big.Int, error)
+}
+
+type AnchorRootProviderCreator func(addr common.Address) AnchorRootProvider
+
+type AnchorStateMonitor struct {
+	logger      log.Logger
+	metrics     AnchorStateMetrics
+	newContract AnchorRootProviderCreator
+}
+
+func NewAnchorStateMonitor(logger log.Logger, metrics AnchorStateMetrics, newContract AnchorRootProviderCreator) *AnchorStateMonitor {
+	return &AnchorStateMonitor{
+		logger:      logger,
+		metrics:     metrics,
+		newContract: newContract,
+	}
+}
+
+// CheckAnchorState reads the current anchor state L2 sequence number for every distinct
+// AnchorStateRegistry referenced by the monitored games and records it as a metric.
+func (m *AnchorStateMonitor) CheckAnchorState(ctx context.Context, blockHash common.Hash, games []*types.EnrichedGameData) {
+	seen := make(map[common.Address]bool)
+	for _, game := range games {
+		asr := game.AnchorStateRegistry
+		if asr == (common.Address{}) || seen[asr] {
+			continue
+		}
+		seen[asr] = true
+		_, l2SequenceNumber, err := m.newContract(asr).GetAnchorRoot(ctx, rpcblock.ByHash(blockHash))
+		if err != nil {
+			m.logger.Warn("Failed to retrieve anchor root", "anchorStateRegistry", asr, "err", err)
+			continue
+		}
+		l2 := uint64(math.MaxUint64)
+		if l2SequenceNumber.IsUint64() {
+			l2 = bigs.Uint64Strict(l2SequenceNumber)
+		}
+		m.metrics.RecordAnchorStateL2SequenceNumber(asr, l2)
+	}
+}

--- a/op-dispute-mon/mon/anchor_state_test.go
+++ b/op-dispute-mon/mon/anchor_state_test.go
@@ -1,0 +1,119 @@
+package mon
+
+import (
+	"context"
+	"errors"
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	asrA = common.HexToAddress("0xaa00000000000000000000000000000000000000")
+	asrB = common.HexToAddress("0xbb00000000000000000000000000000000000000")
+)
+
+func TestAnchorStateMonitor_NoGames(t *testing.T) {
+	monitor, metrics, providers := setupAnchorStateTest(t)
+	monitor.CheckAnchorState(context.Background(), common.Hash{0xaa}, nil)
+	require.Empty(t, metrics.recorded)
+	require.Empty(t, providers.created)
+}
+
+func TestAnchorStateMonitor_DedupesPerASR(t *testing.T) {
+	monitor, metrics, providers := setupAnchorStateTest(t)
+	providers.set(asrA, big.NewInt(100), nil)
+	providers.set(asrB, big.NewInt(200), nil)
+
+	games := []*types.EnrichedGameData{
+		{AnchorStateRegistry: asrA},
+		{AnchorStateRegistry: asrA},
+		{AnchorStateRegistry: asrB},
+		{AnchorStateRegistry: common.Address{}}, // skipped
+	}
+	monitor.CheckAnchorState(context.Background(), common.Hash{0xaa}, games)
+
+	require.Equal(t, map[common.Address]uint64{asrA: 100, asrB: 200}, metrics.recorded)
+	require.Equal(t, 1, providers.providers[asrA].calls, "asrA queried once despite two games")
+	require.Equal(t, 1, providers.providers[asrB].calls)
+}
+
+func TestAnchorStateMonitor_ToleratesPerASRError(t *testing.T) {
+	monitor, metrics, providers := setupAnchorStateTest(t)
+	providers.set(asrA, nil, errors.New("boom"))
+	providers.set(asrB, big.NewInt(200), nil)
+
+	games := []*types.EnrichedGameData{
+		{AnchorStateRegistry: asrA},
+		{AnchorStateRegistry: asrB},
+	}
+	monitor.CheckAnchorState(context.Background(), common.Hash{0xaa}, games)
+
+	require.Equal(t, map[common.Address]uint64{asrB: 200}, metrics.recorded)
+}
+
+func TestAnchorStateMonitor_SequenceNumberOverflow(t *testing.T) {
+	monitor, metrics, providers := setupAnchorStateTest(t)
+	tooBig := new(big.Int).Add(new(big.Int).SetUint64(math.MaxUint64), big.NewInt(1))
+	providers.set(asrA, tooBig, nil)
+
+	monitor.CheckAnchorState(context.Background(), common.Hash{0xaa}, []*types.EnrichedGameData{
+		{AnchorStateRegistry: asrA},
+	})
+
+	require.Equal(t, map[common.Address]uint64{asrA: math.MaxUint64}, metrics.recorded)
+}
+
+func setupAnchorStateTest(t *testing.T) (*AnchorStateMonitor, *mockAnchorStateMetrics, *mockAnchorRootProviders) {
+	logger := testlog.Logger(t, log.LevelError)
+	metrics := &mockAnchorStateMetrics{recorded: map[common.Address]uint64{}}
+	providers := &mockAnchorRootProviders{providers: map[common.Address]*mockAnchorRootProvider{}}
+	monitor := NewAnchorStateMonitor(logger, metrics, providers.create)
+	return monitor, metrics, providers
+}
+
+type mockAnchorStateMetrics struct {
+	recorded map[common.Address]uint64
+}
+
+func (m *mockAnchorStateMetrics) RecordAnchorStateL2SequenceNumber(asr common.Address, l2SequenceNumber uint64) {
+	m.recorded[asr] = l2SequenceNumber
+}
+
+type mockAnchorRootProviders struct {
+	providers map[common.Address]*mockAnchorRootProvider
+	created   []common.Address
+}
+
+func (m *mockAnchorRootProviders) set(addr common.Address, seq *big.Int, err error) {
+	m.providers[addr] = &mockAnchorRootProvider{seq: seq, err: err}
+}
+
+func (m *mockAnchorRootProviders) create(addr common.Address) AnchorRootProvider {
+	m.created = append(m.created, addr)
+	if p, ok := m.providers[addr]; ok {
+		return p
+	}
+	return &mockAnchorRootProvider{seq: big.NewInt(0)}
+}
+
+type mockAnchorRootProvider struct {
+	seq   *big.Int
+	err   error
+	calls int
+}
+
+func (m *mockAnchorRootProvider) GetAnchorRoot(_ context.Context, _ rpcblock.Block) (common.Hash, *big.Int, error) {
+	m.calls++
+	if m.err != nil {
+		return common.Hash{}, nil, m.err
+	}
+	return common.Hash{}, m.seq, nil
+}

--- a/op-dispute-mon/mon/extract/anchor_state_registry_enricher.go
+++ b/op-dispute-mon/mon/extract/anchor_state_registry_enricher.go
@@ -1,0 +1,38 @@
+package extract
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var _ Enricher = (*AnchorStateRegistryEnricher)(nil)
+
+// AnchorStateRegistryEnricher records the address of the AnchorStateRegistry each game builds on.
+// This is best-effort: a game whose contract version does not expose anchorStateRegistry() is skipped
+// silently, and any other read error is logged but never fails enrichment, so a failure to read the
+// anchor state registry cannot drop the game from the rest of the monitoring.
+type AnchorStateRegistryEnricher struct {
+	logger log.Logger
+}
+
+func NewAnchorStateRegistryEnricher(logger log.Logger) *AnchorStateRegistryEnricher {
+	return &AnchorStateRegistryEnricher{logger: logger}
+}
+
+func (e *AnchorStateRegistryEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
+	addr, err := caller.GetAnchorStateRegistry(ctx, block)
+	if errors.Is(err, contracts.ErrAnchorStateRegistryNotSupported) {
+		return nil
+	}
+	if err != nil {
+		e.logger.Warn("Failed to retrieve anchor state registry", "game", game.Proxy, "err", err)
+		return nil
+	}
+	game.AnchorStateRegistry = addr
+	return nil
+}

--- a/op-dispute-mon/mon/extract/anchor_state_registry_enricher_test.go
+++ b/op-dispute-mon/mon/extract/anchor_state_registry_enricher_test.go
@@ -1,0 +1,47 @@
+package extract
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnchorStateRegistryEnricher(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	expected := common.HexToAddress("0x0123456789abcDEF0123456789abCDef01234567")
+
+	t.Run("Success", func(t *testing.T) {
+		enricher := NewAnchorStateRegistryEnricher(logger)
+		caller := &mockGameCaller{anchorStateRegistry: expected}
+		game := &types.EnrichedGameData{}
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
+		require.NoError(t, err)
+		require.Equal(t, expected, game.AnchorStateRegistry)
+	})
+
+	t.Run("NotSupportedSkipsSilently", func(t *testing.T) {
+		enricher := NewAnchorStateRegistryEnricher(logger)
+		caller := &mockGameCaller{anchorStateRegErr: contracts.ErrAnchorStateRegistryNotSupported}
+		game := &types.EnrichedGameData{}
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
+		require.NoError(t, err)
+		require.Equal(t, common.Address{}, game.AnchorStateRegistry)
+	})
+
+	t.Run("OtherErrorDoesNotFailGame", func(t *testing.T) {
+		enricher := NewAnchorStateRegistryEnricher(logger)
+		caller := &mockGameCaller{anchorStateRegErr: errors.New("boom")}
+		game := &types.EnrichedGameData{}
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
+		require.NoError(t, err)
+		require.Equal(t, common.Address{}, game.AnchorStateRegistry)
+	})
+}

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -27,6 +27,7 @@ type GameCaller interface {
 	GetWithdrawals(context.Context, rpcblock.Block, ...common.Address) ([]*contracts.WithdrawalRequest, error)
 	GetExtendedMetadata(context.Context, rpcblock.Block) (contracts.GameMetadata, error)
 	GetAllClaims(context.Context, rpcblock.Block) ([]faultTypes.Claim, error)
+	GetAnchorStateRegistry(context.Context, rpcblock.Block) (common.Address, error)
 	BondCaller
 	BalanceCaller
 	ClaimCaller

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -294,6 +294,8 @@ type mockGameCaller struct {
 	resolvedCalls        int
 	resolvedErr          error
 	resolved             map[int]bool
+	anchorStateRegistry  common.Address
+	anchorStateRegErr    error
 }
 
 func (m *mockGameCaller) GetWithdrawals(_ context.Context, _ rpcblock.Block, _ ...common.Address) ([]*contracts.WithdrawalRequest, error) {
@@ -325,6 +327,13 @@ func (m *mockGameCaller) GetExtendedMetadata(_ context.Context, _ rpcblock.Block
 		L1Head:    common.Hash{0xaa},
 		RootClaim: mockRootClaim,
 	}, nil
+}
+
+func (m *mockGameCaller) GetAnchorStateRegistry(_ context.Context, _ rpcblock.Block) (common.Address, error) {
+	if m.anchorStateRegErr != nil {
+		return common.Address{}, m.anchorStateRegErr
+	}
+	return m.anchorStateRegistry, nil
 }
 
 func (m *mockGameCaller) GetAllClaims(_ context.Context, _ rpcblock.Block) ([]faultTypes.Claim, error) {

--- a/op-dispute-mon/mon/extract/super_permissioned_caller.go
+++ b/op-dispute-mon/mon/extract/super_permissioned_caller.go
@@ -19,10 +19,11 @@ import (
 )
 
 const (
-	methodL1Head           = "l1Head"
-	methodL2SequenceNumber = "l2SequenceNumber"
-	methodRootClaim        = "rootClaim"
-	methodStatus           = "status"
+	methodL1Head              = "l1Head"
+	methodL2SequenceNumber    = "l2SequenceNumber"
+	methodRootClaim           = "rootClaim"
+	methodStatus              = "status"
+	methodAnchorStateRegistry = "anchorStateRegistry"
 )
 
 type SuperPermissionedGameCaller struct {
@@ -68,6 +69,15 @@ func (s *SuperPermissionedGameCaller) GetExtendedMetadata(ctx context.Context, b
 		RootClaim:     results[2].GetHash(0),
 		Status:        status,
 	}, nil
+}
+
+func (s *SuperPermissionedGameCaller) GetAnchorStateRegistry(ctx context.Context, block rpcblock.Block) (common.Address, error) {
+	defer s.metrics.StartContractRequest("GetAnchorStateRegistry")()
+	result, err := s.multiCaller.SingleCall(ctx, block, s.contract.Call(methodAnchorStateRegistry))
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to retrieve anchor state registry: %w", err)
+	}
+	return result.GetAddress(0), nil
 }
 
 func (s *SuperPermissionedGameCaller) GetAllClaims(context.Context, rpcblock.Block) ([]faultTypes.Claim, error) {

--- a/op-dispute-mon/mon/extract/super_permissioned_caller_test.go
+++ b/op-dispute-mon/mon/extract/super_permissioned_caller_test.go
@@ -1,0 +1,122 @@
+package extract
+
+import (
+	"context"
+	"math"
+	"math/big"
+	"testing"
+	"time"
+
+	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func setupSuperPermissionedGameCallerTest(t *testing.T) (*batchingTest.AbiBasedRpc, common.Address, *SuperPermissionedGameCaller) {
+	gameAddr := common.Address{0xaa}
+	rpc := batchingTest.NewAbiBasedRpc(t, gameAddr, snapshots.LoadSuperPermissionedDisputeGameABI())
+	caller := batching.NewMultiCaller(rpc, batching.DefaultBatchSize)
+	game := NewSuperPermissionedGameCaller(contractMetrics.NoopContractMetrics, gameAddr, caller)
+	return rpc, gameAddr, game
+}
+
+func TestSuperPermissionedGameCaller_GetExtendedMetadata(t *testing.T) {
+	rpc, gameAddr, game := setupSuperPermissionedGameCallerTest(t)
+	block := rpcblock.Latest
+	l1Head := common.Hash{0xcc}
+	rpc.SetResponse(gameAddr, methodL1Head, block, nil, []any{l1Head})
+	rpc.SetResponse(gameAddr, methodL2SequenceNumber, block, nil, []any{big.NewInt(1234)})
+	rpc.SetResponse(gameAddr, methodRootClaim, block, nil, []any{mockRootClaim})
+	rpc.SetResponse(gameAddr, methodStatus, block, nil, []any{uint8(gameTypes.GameStatusDefenderWon)})
+
+	meta, err := game.GetExtendedMetadata(context.Background(), block)
+	require.NoError(t, err)
+	require.Equal(t, l1Head, meta.L1Head)
+	require.Equal(t, uint64(1234), meta.L2SequenceNum)
+	require.Equal(t, mockRootClaim, meta.RootClaim)
+	require.Equal(t, gameTypes.GameStatusDefenderWon, meta.Status)
+}
+
+func TestSuperPermissionedGameCaller_GetExtendedMetadata_L2SequenceNumberOverflow(t *testing.T) {
+	rpc, gameAddr, game := setupSuperPermissionedGameCallerTest(t)
+	block := rpcblock.Latest
+	tooBig := new(big.Int).Add(new(big.Int).SetUint64(math.MaxUint64), big.NewInt(1))
+	rpc.SetResponse(gameAddr, methodL1Head, block, nil, []any{common.Hash{}})
+	rpc.SetResponse(gameAddr, methodL2SequenceNumber, block, nil, []any{tooBig})
+	rpc.SetResponse(gameAddr, methodRootClaim, block, nil, []any{mockRootClaim})
+	rpc.SetResponse(gameAddr, methodStatus, block, nil, []any{uint8(gameTypes.GameStatusInProgress)})
+
+	meta, err := game.GetExtendedMetadata(context.Background(), block)
+	require.NoError(t, err)
+	require.Equal(t, uint64(math.MaxUint64), meta.L2SequenceNum)
+}
+
+func TestSuperPermissionedGameCaller_GetAnchorStateRegistry(t *testing.T) {
+	rpc, gameAddr, game := setupSuperPermissionedGameCallerTest(t)
+	block := rpcblock.Latest
+	expected := common.HexToAddress("0x0123456789abcDEF0123456789abCDef01234567")
+	rpc.SetResponse(gameAddr, methodAnchorStateRegistry, block, nil, []any{expected})
+
+	actual, err := game.GetAnchorStateRegistry(context.Background(), block)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestSuperPermissionedGameCaller_GetAllClaims(t *testing.T) {
+	_, _, game := setupSuperPermissionedGameCallerTest(t)
+	claims, err := game.GetAllClaims(context.Background(), rpcblock.Latest)
+	require.NoError(t, err)
+	require.Nil(t, claims)
+}
+
+func TestSuperPermissionedGameCaller_IsResolved(t *testing.T) {
+	_, _, game := setupSuperPermissionedGameCallerTest(t)
+	resolved, err := game.IsResolved(context.Background(), rpcblock.Latest, faultTypes.Claim{}, faultTypes.Claim{})
+	require.NoError(t, err)
+	require.Equal(t, []bool{false, false}, resolved)
+}
+
+func TestSuperPermissionedGameCaller_GetWithdrawals(t *testing.T) {
+	_, _, game := setupSuperPermissionedGameCallerTest(t)
+	recipients := []common.Address{{0x01}, {0x02}}
+	withdrawals, err := game.GetWithdrawals(context.Background(), rpcblock.Latest, recipients...)
+	require.NoError(t, err)
+	require.Len(t, withdrawals, len(recipients))
+	for _, w := range withdrawals {
+		require.Equal(t, big.NewInt(0), w.Amount)
+		require.Equal(t, big.NewInt(0), w.Timestamp)
+	}
+}
+
+func TestSuperPermissionedGameCaller_GetCredits(t *testing.T) {
+	_, _, game := setupSuperPermissionedGameCallerTest(t)
+	recipients := []common.Address{{0x01}, {0x02}, {0x03}}
+	credits, err := game.GetCredits(context.Background(), rpcblock.Latest, recipients...)
+	require.NoError(t, err)
+	require.Len(t, credits, len(recipients))
+	for _, c := range credits {
+		require.Equal(t, big.NewInt(0), c)
+	}
+}
+
+func TestSuperPermissionedGameCaller_GetBondDistributionMode(t *testing.T) {
+	_, _, game := setupSuperPermissionedGameCallerTest(t)
+	mode, err := game.GetBondDistributionMode(context.Background(), rpcblock.Latest)
+	require.NoError(t, err)
+	require.Equal(t, faultTypes.UndecidedDistributionMode, mode)
+}
+
+func TestSuperPermissionedGameCaller_GetBalanceAndDelay(t *testing.T) {
+	_, _, game := setupSuperPermissionedGameCallerTest(t)
+	balance, delay, addr, err := game.GetBalanceAndDelay(context.Background(), rpcblock.Latest)
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(0), balance)
+	require.Equal(t, time.Duration(0), delay)
+	require.Equal(t, common.Address{}, addr)
+}

--- a/op-dispute-mon/mon/monitor.go
+++ b/op-dispute-mon/mon/monitor.go
@@ -14,6 +14,7 @@ import (
 )
 
 type ForecastResolution func(games []*types.EnrichedGameData, ignoredCount, failedCount int)
+type AnchorStateCheck func(ctx context.Context, blockHash common.Hash, games []*types.EnrichedGameData)
 type Monitor func(games []*types.EnrichedGameData)
 type HeadBlockFetcher func(ctx context.Context) (eth.L1BlockRef, error)
 type Extract func(ctx context.Context, blockHash common.Hash, minTimestamp uint64) ([]*types.EnrichedGameData, int, int, error)
@@ -34,10 +35,11 @@ type gameMonitor struct {
 	gameWindow      time.Duration
 	monitorInterval time.Duration
 
-	forecast       ForecastResolution
-	monitors       []Monitor
-	extract        Extract
-	fetchHeadBlock HeadBlockFetcher
+	forecast         ForecastResolution
+	checkAnchorState AnchorStateCheck
+	monitors         []Monitor
+	extract          Extract
+	fetchHeadBlock   HeadBlockFetcher
 }
 
 func newGameMonitor(
@@ -50,19 +52,21 @@ func newGameMonitor(
 	fetchHeadBlock HeadBlockFetcher,
 	extract Extract,
 	forecast ForecastResolution,
+	checkAnchorState AnchorStateCheck,
 	monitors ...Monitor) *gameMonitor {
 	return &gameMonitor{
-		logger:          logger,
-		clock:           cl,
-		ctx:             ctx,
-		done:            make(chan struct{}),
-		metrics:         metrics,
-		monitorInterval: monitorInterval,
-		gameWindow:      gameWindow,
-		forecast:        forecast,
-		monitors:        monitors,
-		extract:         extract,
-		fetchHeadBlock:  fetchHeadBlock,
+		logger:           logger,
+		clock:            cl,
+		ctx:              ctx,
+		done:             make(chan struct{}),
+		metrics:          metrics,
+		monitorInterval:  monitorInterval,
+		gameWindow:       gameWindow,
+		forecast:         forecast,
+		checkAnchorState: checkAnchorState,
+		monitors:         monitors,
+		extract:          extract,
+		fetchHeadBlock:   fetchHeadBlock,
 	}
 }
 
@@ -79,6 +83,7 @@ func (m *gameMonitor) monitorGames() error {
 		return fmt.Errorf("failed to load games: %w", err)
 	}
 	m.forecast(enrichedGames, ignored, failed)
+	m.checkAnchorState(m.ctx, headBlock.Hash, enrichedGames)
 	for _, monitor := range m.monitors {
 		monitor(enrichedGames)
 	}

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -111,9 +111,11 @@ func setupMonitorTest(t *testing.T) (*gameMonitor, *mockExtractor, *mockForecast
 	monitor2 := &mockMonitor{}
 	monitor3 := &mockMonitor{}
 	monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-		extractor.Extract, forecast.Forecast, monitor1.Check, monitor2.Check, monitor3.Check)
+		extractor.Extract, forecast.Forecast, noopAnchorStateCheck, monitor1.Check, monitor2.Check, monitor3.Check)
 	return monitor, extractor, forecast, []*mockMonitor{monitor1, monitor2, monitor3}
 }
+
+func noopAnchorStateCheck(_ context.Context, _ common.Hash, _ []*monTypes.EnrichedGameData) {}
 
 type mockMonitor struct {
 	calls int
@@ -195,7 +197,7 @@ func TestMonitor_NodeEndpointErrorsMonitorIntegration(t *testing.T) {
 		nodeEndpointErrorsMonitor := NewNodeEndpointErrorsMonitor(logger, nodeEndpointErrorsMetrics)
 
 		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, nodeEndpointErrorsMonitor.CheckNodeEndpointErrors)
+			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, nodeEndpointErrorsMonitor.CheckNodeEndpointErrors)
 
 		err := monitor.monitorGames()
 		require.NoError(t, err)
@@ -240,7 +242,7 @@ func TestMonitor_NodeEndpointErrorCountMonitorIntegration(t *testing.T) {
 		nodeEndpointErrorCountMonitor := NewNodeEndpointErrorCountMonitor(logger, nodeEndpointErrorCountMetrics)
 
 		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount)
+			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount)
 
 		err := monitor.monitorGames()
 		require.NoError(t, err)
@@ -306,7 +308,7 @@ func TestMonitor_MixedAvailabilityMonitorIntegration(t *testing.T) {
 		mixedAvailabilityMonitor := NewMixedAvailability(logger, mixedAvailabilityMetrics)
 
 		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, mixedAvailabilityMonitor.CheckMixedAvailability)
+			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, mixedAvailabilityMonitor.CheckMixedAvailability)
 
 		err := monitor.monitorGames()
 		require.NoError(t, err)
@@ -373,7 +375,7 @@ func TestMonitor_MixedSafetyMonitorIntegration(t *testing.T) {
 		mixedSafetyMonitor := NewMixedSafetyMonitor(logger, mixedSafetyMetrics)
 
 		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, mixedSafetyMonitor.CheckMixedSafety)
+			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, mixedSafetyMonitor.CheckMixedSafety)
 
 		err := monitor.monitorGames()
 		require.NoError(t, err)
@@ -417,7 +419,7 @@ func TestMonitor_MixedSafetyMonitorIntegration(t *testing.T) {
 		mixedSafetyMonitor := NewMixedSafetyMonitor(logger, mixedSafetyMetrics)
 
 		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, mixedSafetyMonitor.CheckMixedSafety)
+			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, mixedSafetyMonitor.CheckMixedSafety)
 
 		err := monitor.monitorGames()
 		require.NoError(t, err)
@@ -450,7 +452,7 @@ func TestMonitor_MixedSafetyMonitorIntegration(t *testing.T) {
 		mixedSafetyMonitor := NewMixedSafetyMonitor(logger, mixedSafetyMetrics)
 
 		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, mixedSafetyMonitor.CheckMixedSafety)
+			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, mixedSafetyMonitor.CheckMixedSafety)
 
 		err := monitor.monitorGames()
 		require.NoError(t, err)
@@ -507,7 +509,7 @@ func TestMonitor_DifferentOutputRootMonitorIntegration(t *testing.T) {
 		differentOutputRootMonitor := NewDifferentRootMonitor(logger, differentOutputRootMetrics)
 
 		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, differentOutputRootMonitor.CheckDifferentRoots)
+			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, differentOutputRootMonitor.CheckDifferentRoots)
 
 		err := monitor.monitorGames()
 		require.NoError(t, err)
@@ -548,7 +550,7 @@ func TestMonitor_DifferentOutputRootMonitorIntegration(t *testing.T) {
 		differentOutputRootMonitor := NewDifferentRootMonitor(logger, differentOutputRootMetrics)
 
 		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, differentOutputRootMonitor.CheckDifferentRoots)
+			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, differentOutputRootMonitor.CheckDifferentRoots)
 
 		err := monitor.monitorGames()
 		require.NoError(t, err)
@@ -588,7 +590,7 @@ func TestMonitor_DifferentOutputRootMonitorIntegration(t *testing.T) {
 		differentOutputRootMonitor := NewDifferentRootMonitor(logger, differentOutputRootMetrics)
 
 		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, differentOutputRootMonitor.CheckDifferentRoots)
+			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, differentOutputRootMonitor.CheckDifferentRoots)
 
 		err := monitor.monitorGames()
 		require.NoError(t, err)
@@ -615,7 +617,7 @@ func TestMonitor_DifferentOutputRootMonitorIntegration(t *testing.T) {
 		differentOutputRootMonitor := NewDifferentRootMonitor(logger, differentOutputRootMetrics)
 
 		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, differentOutputRootMonitor.CheckDifferentRoots)
+			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, differentOutputRootMonitor.CheckDifferentRoots)
 
 		err := monitor.monitorGames()
 		require.NoError(t, err)

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	rpcclient "github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/config"
@@ -228,6 +229,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		extract.NewL1HeadBlockNumEnricher(s.l1Client),
 		extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.outputRollupClients(), clock.SystemClock),
 		extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.asSuperRootProviders(), clock.SystemClock),
+		extract.NewAnchorStateRegistryEnricher(s.logger),
 	)
 	forecast := NewForecast(s.logger, s.metrics)
 	bonds := bonds.NewBonds(s.logger, s.metrics, s.cl)
@@ -243,9 +245,13 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 	mixedSafetyMonitor := NewMixedSafetyMonitor(s.logger, s.metrics)
 	differentRootMonitor := NewDifferentRootMonitor(s.logger, s.metrics)
 	gameTypeMonitor := NewGameTypeMonitor(s.metrics)
+	anchorStateMonitor := NewAnchorStateMonitor(s.logger, s.metrics, func(addr common.Address) AnchorRootProvider {
+		return contracts.NewAnchorStateRegistryContract(s.metrics, addr, s.l1Caller)
+	})
 	s.monitor = newGameMonitor(ctx, s.logger, s.cl, s.metrics, cfg.MonitorInterval, cfg.GameWindow, headBlockFetcher,
 		extractor.Extract,
 		forecast.Forecast,
+		anchorStateMonitor.CheckAnchorState,
 		bonds.CheckBonds,
 		resolutions.CheckResolutions,
 		claims.CheckClaims,

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -51,6 +51,10 @@ type EnrichedGameData struct {
 	BlockNumberChallenger common.Address
 	Claims                []EnrichedClaim
 
+	// AnchorStateRegistry is the address of the AnchorStateRegistry this game builds on.
+	// Zero if the game's contract version does not expose it.
+	AnchorStateRegistry common.Address
+
 	AgreeWithClaim    bool
 	ExpectedRootClaim common.Hash
 

--- a/packages/contracts-bedrock/snapshots/abi_loader.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader.go
@@ -37,6 +37,9 @@ var systemConfig []byte
 //go:embed abi/CrossL2Inbox.json
 var crossL2Inbox []byte
 
+//go:embed abi/AnchorStateRegistry.json
+var anchorStateRegistry []byte
+
 func LoadDisputeGameFactoryABI() *abi.ABI {
 	return loadABI(disputeGameFactory)
 }
@@ -74,6 +77,10 @@ func LoadSystemConfigABI() *abi.ABI {
 
 func LoadCrossL2InboxABI() *abi.ABI {
 	return loadABI(crossL2Inbox)
+}
+
+func LoadAnchorStateRegistryABI() *abi.ABI {
+	return loadABI(anchorStateRegistry)
 }
 
 func loadABI(json []byte) *abi.ABI {


### PR DESCRIPTION
Adds anchor-state monitoring to op-dispute-mon. Publishes `anchor_state_l2_sequence_number`, a gauge labelled per `AnchorStateRegistry` address, sourced from `getAnchorRoot()`. This lets operators alert on a stalling anchor state by comparing the published sequence number against the live L2 head.

- ASR addresses are discovered per monitored game via a new `anchorStateRegistry()` getter on the game bindings. The 0.8.0 binding returns `ErrAnchorStateRegistryNotSupported` and is skipped.
- A new `AnchorStateRegistry` contract binding (`GetAnchorRoot`) reads the anchor root once per unique ASR each cycle.
- Reading the ASR address is best-effort — a failure logs and is skipped rather than dropping the game from the rest of the monitoring.