### PR TITLE
chore(ci): test all Go packages by default via an exclude list

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,13 +6,19 @@ PYTHON := env('PYTHON', 'python3')
 
 TEST_TIMEOUT := env('TEST_TIMEOUT', '10m')
 
-TEST_PKGS := "./op-alt-da/... ./op-batcher/... ./op-chain-ops/... ./op-core/... ./op-node/... ./op-proposer/... ./op-challenger/... ./op-faucet/... ./op-dispute-mon/... ./op-conductor/... ./op-program/... ./op-service/... ./op-test-sequencer/... ./op-fetcher/... ./op-e2e/system/... ./op-e2e/e2eutils/... ./op-e2e/opgeth/... ./op-e2e/interop/... ./op-e2e/actions/altda ./op-e2e/actions/batcher ./op-e2e/actions/derivation ./op-e2e/actions/helpers ./op-e2e/actions/proofs ./op-e2e/actions/proposer ./op-e2e/actions/safedb ./op-e2e/actions/sequencer ./op-e2e/actions/supernode ./op-e2e/actions/sync ./op-e2e/actions/upgrades ./packages/contracts-bedrock/scripts/checks/... ./ops/scripts/... ./op-dripper/... ./op-devstack/... ./op-deployer/pkg/deployer/artifacts/... ./op-deployer/pkg/deployer/broadcaster/... ./op-deployer/pkg/deployer/clean/... ./op-deployer/pkg/deployer/integration_test/ ./op-deployer/pkg/deployer/integration_test/cli/... ./op-deployer/pkg/deployer/standard/... ./op-deployer/pkg/deployer/state/... ./op-deployer/pkg/deployer/verify/... ./op-sync-tester/... ./op-supernode/..."
+# Go test runs cover every package in the module except these, which run in
+# dedicated CI jobs or can't run in the standard go-tests environment:
+#   op-acceptance-tests             dedicated acceptance-test job (needs a running devnet)
+#   cannon                          dedicated cannon job (slow MIPS emulation tests)
+#   rust                            rust-e2e pipeline (needs prebuilt Rust binaries)
+#   op-up                           needs the op-reth binary, not built here (ethereum-optimism/optimism#21202)
+#   op-deployer/pkg/deployer/forge  fails when forge is on PATH (ethereum-optimism/optimism#21200)
+# See the list-test-packages recipe, which expands `go list ./...` minus these.
+EXCLUDED_TEST_PKGS := "op-acceptance-tests cannon rust op-up op-deployer/pkg/deployer/forge"
 
+# Fault-proof packages run in the default go-tests job and again in a dedicated
+# job with Cannon enabled, so they keep a separate list.
 FRAUD_PROOF_TEST_PKGS := "./op-e2e/faultproofs/..."
-
-RPC_TEST_PKGS := "./op-validator/pkg/validations/... ./op-deployer/pkg/deployer/bootstrap/... ./op-deployer/pkg/deployer/manage/... ./op-deployer/pkg/deployer/opcm/... ./op-deployer/pkg/deployer/pipeline/... ./op-deployer/pkg/deployer/upgrade/..."
-
-ALL_TEST_PACKAGES := TEST_PKGS + " " + RPC_TEST_PKGS + " " + FRAUD_PROOF_TEST_PKGS
 
 # Lists all available targets.
 help:
@@ -264,6 +270,13 @@ op-program-host:
 make-pre-test:
   cd op-e2e && just pre-test
 
+# Lists the Go packages under test: every package in the module except those in
+# EXCLUDED_TEST_PKGS (which run in dedicated CI jobs or can't run in this environment).
+[script('bash')]
+list-test-packages:
+  set -euo pipefail
+  go list -e ./... | grep -vE "^github.com/ethereum-optimism/optimism/($(echo '{{EXCLUDED_TEST_PKGS}}' | tr ' ' '|'))(/|$)"
+
 # Runs comprehensive Go tests across all packages.
 [script('bash')]
 go-tests: op-program-client op-program-host cannon build-contracts cannon-prestates make-pre-test sync-superchain
@@ -273,7 +286,7 @@ go-tests: op-program-client op-program-host cannon build-contracts cannon-presta
   export OP_E2E_USE_HTTP=true
   export ENABLE_ANVIL=true
   export PARALLEL=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
-  go test -parallel="$PARALLEL" -timeout={{TEST_TIMEOUT}} {{TEST_PKGS}}
+  go test -parallel="$PARALLEL" -timeout={{TEST_TIMEOUT}} $(just list-test-packages)
 
 # Runs comprehensive Go tests with -short flag.
 [script('bash')]
@@ -284,7 +297,7 @@ go-tests-short: op-program-client op-program-host cannon build-contracts cannon-
   export OP_E2E_USE_HTTP=true
   export ENABLE_ANVIL=true
   export PARALLEL=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
-  go test -short -parallel="$PARALLEL" -timeout={{TEST_TIMEOUT}} {{TEST_PKGS}}
+  go test -short -parallel="$PARALLEL" -timeout={{TEST_TIMEOUT}} $(just list-test-packages)
 
 # Internal: runs Go tests with gotestsum for CI.
 [script('bash')]
@@ -303,7 +316,7 @@ _go-tests-ci-internal go_test_flags="": sync-superchain
   source ./ops/scripts/source-ci-archive-rpcs.sh
   export NAT_INTEROP_LOADTEST_TARGET=10
   export NAT_INTEROP_LOADTEST_TIMEOUT=30s
-  ALL_PACKAGES="{{ALL_TEST_PACKAGES}}"
+  ALL_PACKAGES="$(just list-test-packages | tr '\n' ' ')"
   if [ -n "${CIRCLE_NODE_TOTAL:-}" ] && [ "$CIRCLE_NODE_TOTAL" -gt 1 ]; then
       NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
       NODE_TOTAL=${CIRCLE_NODE_TOTAL:-1}
@@ -318,7 +331,7 @@ _go-tests-ci-internal go_test_flags="": sync-superchain
               --packages="$PARALLEL_PACKAGES" \
               -- -p=4 -parallel="$PARALLEL" {{go_test_flags}} -timeout={{TEST_TIMEOUT}} -tags="ci"
       else
-          echo "ERROR: Node $NODE_INDEX/$NODE_TOTAL has no packages to run! Perhaps parallelism is set too high? (ALL_TEST_PACKAGES has $(echo "$ALL_PACKAGES" | wc -w) packages)"
+          echo "ERROR: Node $NODE_INDEX/$NODE_TOTAL has no packages to run! Perhaps parallelism is set too high? (package list has $(echo "$ALL_PACKAGES" | wc -w) packages)"
           exit 1
       fi
   else


### PR DESCRIPTION
The `go-tests` package set was a hand-maintained **include** list (`TEST_PKGS` / `RPC_TEST_PKGS`), and nothing ran `go test ./...`. So new packages were silently skipped until someone remembered to add them — a gap this repo kept hitting (op-interop-filter, op-interop-mon, op-preimage, op-supervisor's remaining tests, several op-deployer and op-e2e packages had never run in CI).

This inverts it: run **every package in the module except an explicit exclude list**.

- `list-test-packages` expands `go list ./...` minus `EXCLUDED_TEST_PKGS`.
- `EXCLUDED_TEST_PKGS` is only whole subsystems that run in dedicated jobs or can't run here: `op-acceptance-tests`, `cannon`, `rust`, `op-up` (#21202), `op-deployer/pkg/deployer/forge` (#21200).
- Local `just go-tests` / `go-tests-short` use the same computed set, so local and CI match.

### Newly covered (all verified passing locally, `-tags=ci`)
`op-supervisor/...`, `op-e2e/config{,/secrets}`, `op-interop-filter`, `op-interop-mon`, `op-preimage`, `op-deployer/pkg/deployer{,/validate}`, `packages/contracts-bedrock/scripts/go-ffi`, `packages/contracts-bedrock/snapshots`, `linter/analyzers/bigint`, and `op-e2e/actions/supernode`.

### Trade-off
A new package needing infra that isn't excluded now **fails loudly in CI** until it's excluded or fixed — the inverse of silently skipping it. Fix is a one-line addition to `EXCLUDED_TEST_PKGS`.

### Verification
The computed set is a superset of the current CI package set plus the newly-covered packages above (all individually verified green); nothing currently-running is dropped. The full suite was not run end-to-end locally (hundreds of packages); CI is the first full run.

---
**Supersedes #21197** (those packages are now included automatically).
**Stacked on #21206** (base branch) — the exclude list pulls in `op-e2e/actions/supernode`, which needs that PR's test fix. Will retarget to `develop` once #21206 merges.