### PR TITLE
refactor(op-e2e): drop dead L1Miner.BlobSource, decouple from op-program

### DIFF
--- a/op-e2e/actions/helpers/l1_miner.go
+++ b/op-e2e/actions/helpers/l1_miner.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum-optimism/optimism/op-program/host/prefetcher"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -54,10 +53,6 @@ func NewL1Miner(t Testing, log log.Logger, genesis *core.Genesis) *L1Miner {
 		L1Replica: *rep,
 		blobStore: blobstore.New(),
 	}
-}
-
-func (s *L1Miner) BlobSource() prefetcher.L1BlobSource {
-	return s.blobStore
 }
 
 func (s *L1Miner) BlobStore() *blobstore.Store {


### PR DESCRIPTION
`L1Miner.BlobSource()` returned the blob store typed as `op-program/host/prefetcher.L1BlobSource`. Its only caller was the op-program in-process prefetcher path in the proof action tests, which was removed when those moved to kona-only in ethereum-optimism/optimism#21193. With no remaining callers, this deletes the dead method and the `op-program/host/prefetcher` import.

`BlobStore()` — the method actually used across the action tests (sequencer/verifier setup, fakebeacon) — is unchanged.

After this, the only remaining op-program import in `op-e2e/actions/helpers` is `client/l2/engineapi` (used by `l2_engine.go`), which will move into op-e2e as part of the op-program deletion PR (op-program's own guest still consumes it until then).

Part of the op-program removal effort.

Verification: `go vet ./op-e2e/actions/helpers/... ./op-e2e/actions/derivation/... ./rust/kona/tests/proofs/...` clean.