### PR TITLE
ci: share one Go module cache, downloaded once per pipeline

### DIFF
--- a/.circleci/continue/helpers.yml
+++ b/.circleci/continue/helpers.yml
@@ -25,8 +25,11 @@ commands:
             - ~/go/pkg/mod
 
   # Restores the shared module cache plus a per-namespace Go build cache. The
-  # build cache holds compiled artifacts specific to each job's build flags and
-  # targets, so it stays namespaced per job.
+  # build cache holds compiled artifacts that track the source, so it is keyed
+  # on branch+revision and saved fresh on every commit (CircleCI cache keys are
+  # immutable, so a key that didn't change with the source could never be
+  # refreshed). Restore falls back from this exact commit, to the latest on the
+  # branch, to the latest overall for the namespace.
   go-restore-cache:
     parameters:
       namespace:
@@ -36,11 +39,13 @@ commands:
       - restore_cache:
           name: Restore Go build cache for <<parameters.namespace>>
           keys:
-            - go-build-<<parameters.namespace>>-<<pipeline.parameters.c-go-cache-version>>-{{ checksum "go.sum" }}
+            - go-build-<<parameters.namespace>>-<<pipeline.parameters.c-go-cache-version>>-{{ .Branch }}-{{ .Revision }}
+            - go-build-<<parameters.namespace>>-<<pipeline.parameters.c-go-cache-version>>-{{ .Branch }}-
             - go-build-<<parameters.namespace>>-<<pipeline.parameters.c-go-cache-version>>-
 
   # Saves only the per-namespace build cache; the module cache is written once
-  # by prep-go-modules.
+  # by prep-go-modules. The revision in the key makes it unique per commit so
+  # each build persists an up-to-date cache.
   go-save-cache:
     parameters:
       namespace:
@@ -48,6 +53,6 @@ commands:
     steps:
       - save_cache:
           name: Save Go build cache for <<parameters.namespace>>
-          key: go-build-<<parameters.namespace>>-<<pipeline.parameters.c-go-cache-version>>-{{ checksum "go.sum" }}
+          key: go-build-<<parameters.namespace>>-<<pipeline.parameters.c-go-cache-version>>-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/.cache/go-build

--- a/.circleci/continue/helpers.yml
+++ b/.circleci/continue/helpers.yml
@@ -7,33 +7,20 @@ commands:
   # populated once by the prep-go-modules job and restored read-only everywhere
   # else, so modules are downloaded a single time per go.sum rather than once
   # per job (every download is an opportunity for a proxy.golang.org flake).
+  # c-go-cache-version is the global cache-buster for breaking changes.
   restore-go-mod-cache:
-    parameters:
-      module:
-        type: string
-        default: .
-      version:
-        type: string
-        default: <<pipeline.parameters.c-go-cache-version>>
     steps:
       - restore_cache:
-          name: Restore Go module cache (<<parameters.module>>/go.sum)
+          name: Restore Go module cache (go.sum)
           keys:
-            - go-mod-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.sum" }}
-            - go-mod-<<parameters.version>>-<<parameters.module>>-
+            - go-mod-<<pipeline.parameters.c-go-cache-version>>-{{ checksum "go.sum" }}
+            - go-mod-<<pipeline.parameters.c-go-cache-version>>-
 
   save-go-mod-cache:
-    parameters:
-      module:
-        type: string
-        default: .
-      version:
-        type: string
-        default: <<pipeline.parameters.c-go-cache-version>>
     steps:
       - save_cache:
-          name: Save Go module cache (<<parameters.module>>/go.sum)
-          key: go-mod-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.sum" }}
+          name: Save Go module cache (go.sum)
+          key: go-mod-<<pipeline.parameters.c-go-cache-version>>-{{ checksum "go.sum" }}
           paths:
             - ~/go/pkg/mod
 
@@ -42,39 +29,25 @@ commands:
   # targets, so it stays namespaced per job.
   go-restore-cache:
     parameters:
-      module:
-        type: string
-        default: .
       namespace:
         type: string
-      version:
-        type: string
-        default: <<pipeline.parameters.c-go-cache-version>>
     steps:
-      - restore-go-mod-cache:
-          module: <<parameters.module>>
-          version: <<parameters.version>>
+      - restore-go-mod-cache
       - restore_cache:
           name: Restore Go build cache for <<parameters.namespace>>
           keys:
-            - go-build-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.sum" }}
-            - go-build-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-
+            - go-build-<<parameters.namespace>>-<<pipeline.parameters.c-go-cache-version>>-{{ checksum "go.sum" }}
+            - go-build-<<parameters.namespace>>-<<pipeline.parameters.c-go-cache-version>>-
 
   # Saves only the per-namespace build cache; the module cache is written once
   # by prep-go-modules.
   go-save-cache:
     parameters:
-      module:
-        type: string
-        default: .
       namespace:
         type: string
-      version:
-        type: string
-        default: <<pipeline.parameters.c-go-cache-version>>
     steps:
       - save_cache:
           name: Save Go build cache for <<parameters.namespace>>
-          key: go-build-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.sum" }}
+          key: go-build-<<parameters.namespace>>-<<pipeline.parameters.c-go-cache-version>>-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go-build

--- a/.circleci/continue/helpers.yml
+++ b/.circleci/continue/helpers.yml
@@ -1,0 +1,80 @@
+# Shared command helpers merged into every continuation config (see
+# .circleci/scripts/merge-configs.sh). Defining them here once avoids
+# duplicating the definitions across main.yml and rust-e2e.yml.
+commands:
+  # Shared Go module cache. There is a single Go module in the repo, so the
+  # downloaded module set is identical for every job at a given go.sum. It is
+  # populated once by the prep-go-modules job and restored read-only everywhere
+  # else, so modules are downloaded a single time per go.sum rather than once
+  # per job (every download is an opportunity for a proxy.golang.org flake).
+  restore-go-mod-cache:
+    parameters:
+      module:
+        type: string
+        default: .
+      version:
+        type: string
+        default: <<pipeline.parameters.c-go-cache-version>>
+    steps:
+      - restore_cache:
+          name: Restore Go module cache (<<parameters.module>>/go.sum)
+          keys:
+            - go-mod-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.sum" }}
+            - go-mod-<<parameters.version>>-<<parameters.module>>-
+
+  save-go-mod-cache:
+    parameters:
+      module:
+        type: string
+        default: .
+      version:
+        type: string
+        default: <<pipeline.parameters.c-go-cache-version>>
+    steps:
+      - save_cache:
+          name: Save Go module cache (<<parameters.module>>/go.sum)
+          key: go-mod-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.sum" }}
+          paths:
+            - ~/go/pkg/mod
+
+  # Restores the shared module cache plus a per-namespace Go build cache. The
+  # build cache holds compiled artifacts specific to each job's build flags and
+  # targets, so it stays namespaced per job.
+  go-restore-cache:
+    parameters:
+      module:
+        type: string
+        default: .
+      namespace:
+        type: string
+      version:
+        type: string
+        default: <<pipeline.parameters.c-go-cache-version>>
+    steps:
+      - restore-go-mod-cache:
+          module: <<parameters.module>>
+          version: <<parameters.version>>
+      - restore_cache:
+          name: Restore Go build cache for <<parameters.namespace>>
+          keys:
+            - go-build-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.sum" }}
+            - go-build-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-
+
+  # Saves only the per-namespace build cache; the module cache is written once
+  # by prep-go-modules.
+  go-save-cache:
+    parameters:
+      module:
+        type: string
+        default: .
+      namespace:
+        type: string
+      version:
+        type: string
+        default: <<pipeline.parameters.c-go-cache-version>>
+    steps:
+      - save_cache:
+          name: Save Go build cache for <<parameters.namespace>>
+          key: go-build-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.sum" }}
+          paths:
+            - ~/.cache/go-build

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -159,6 +159,10 @@ commands:
           keys:
             # use mise.toml to anchor on the underlying forge/svm versions
             - svm-cache-{{ checksum "mise.toml" }}-<<parameters.solc_versions>>
+            # Fall back to any svm cache for the same forge/svm versions so a
+            # changed solc_versions list reuses what's there and installs only
+            # the difference instead of a full cold install.
+            - svm-cache-{{ checksum "mise.toml" }}-
       - run:
           name: Install solc compilers
           command: |
@@ -842,6 +846,8 @@ jobs:
           at: .
       - check-changed:
           patterns: cannon,packages/contracts-bedrock/src/cannon,op-preimage,go.mod
+      - go-restore-cache:
+          namespace: cannon-go-lint-and-test
       - run:
           name: prep Cannon results dir
           command: |
@@ -868,6 +874,8 @@ jobs:
             ../ops/scripts/gotestsum-split.sh --format=testname --junitfile=../tmp/test-results/cannon-64.xml --jsonfile=../tmp/testlogs/log-64.json \
             -- -timeout=$TIMEOUT -parallel=$(nproc) ./...
           working_directory: cannon
+      - go-save-cache:
+          namespace: cannon-go-lint-and-test
       - store_test_results:
           path: ./tmp/test-results
       - store_artifacts:
@@ -1142,6 +1150,8 @@ jobs:
           key: forked-state-contracts-bedrock-tests-upgrade-{{ checksum "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
       - setup-features:
           features: <<parameters.features>>
+      - go-restore-cache:
+          namespace: contracts-bedrock-coverage
       - run:
           name: Build go-ffi
           command: just build-go-ffi
@@ -1168,6 +1178,8 @@ jobs:
           disable_search: true
           files: ./packages/contracts-bedrock/lcov-all.info
           flags: contracts-bedrock-tests
+      - go-save-cache:
+          namespace: contracts-bedrock-coverage
       - save_cache:
           name: Save forked state
           key: forked-state-contracts-bedrock-tests-upgrade-{{ checksum "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
@@ -1552,7 +1564,11 @@ jobs:
       - go-restore-cache:
           namespace: go-lint
       - restore_cache:
-          key: golangci-v1-{{ checksum ".golangci.yaml" }}
+          keys:
+            - golangci-v1-{{ checksum ".golangci.yaml" }}
+            # Fall back to the latest golangci cache so a config change reuses
+            # the prior analysis cache instead of a full cold lint.
+            - golangci-v1-
       - run:
           name: run Go linter
           command: |
@@ -1560,7 +1576,10 @@ jobs:
       - go-save-cache:
           namespace: go-lint
       - save_cache:
+          # Warm the analysis cache even when linting fails, so a branch with
+          # lint errors doesn't repeatedly cold-start golangci-lint.
           key: golangci-v1-{{ checksum ".golangci.yaml" }}
+          when: always
           paths:
             - "/home/circleci/.cache/golangci-lint"
 
@@ -1880,14 +1899,11 @@ jobs:
           command: |
             echo "export DEVSTACK_L2CL_KIND=<<parameters.l2_cl_kind>>" >> "$BASH_ENV"
             echo "export DEVSTACK_L2EL_KIND=<<parameters.l2_el_kind>>" >> "$BASH_ENV"
-      # Restore cached Go modules
+      # Restore cached Go modules (downloaded once by prep-go-modules) plus the
+      # per-job build cache. Modules are already present, so the test run below
+      # does not need a separate `go mod download`.
       - go-restore-cache:
           namespace: op-acceptance-tests
-      # Download Go dependencies
-      - run:
-          name: Download Go dependencies
-          working_directory: op-acceptance-tests
-          command: go mod download
       # Run the acceptance tests (if the devnet is running)
       - run:
           name: Run acceptance tests
@@ -2209,9 +2225,13 @@ jobs:
           enable-mise-cache: true
       - check-changed:
           patterns: op-node
+      - go-restore-cache:
+          namespace: check-generated-mocks-op-node
       - run:
           name: check-generated-mocks
           command: just generate-mocks-op-node && git diff --exit-code
+      - go-save-cache:
+          namespace: check-generated-mocks-op-node
 
   check-generated-mocks-op-service:
     docker:
@@ -2223,9 +2243,13 @@ jobs:
           enable-mise-cache: true
       - check-changed:
           patterns: op-service
+      - go-restore-cache:
+          namespace: check-generated-mocks-op-service
       - run:
           name: check-generated-mocks
           command: just generate-mocks-op-service && git diff --exit-code
+      - go-save-cache:
+          namespace: check-generated-mocks-op-service
 
   op-deployer-forge-version:
     docker:
@@ -3022,9 +3046,14 @@ workflows:
   contracts-feature-tests:
     when: << pipeline.parameters.c-run_contracts_feature_tests >>
     jobs:
+      - prep-go-modules:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-tests:
           # Heavily fuzz any fuzz tests within added or modified test files.
           name: contracts-bedrock-tests-heavy-fuzz-modified <<matrix.features>>
+          requires:
+            - prep-go-modules
           test_list: git diff origin/develop...HEAD --name-only --diff-filter=AM -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
           test_timeout: 1h
           test_profile: ciheavy
@@ -3051,6 +3080,8 @@ workflows:
       # On PRs, run tests with lite profile for better build times.
       - contracts-bedrock-tests:
           name: contracts-bedrock-tests <<matrix.features>>
+          requires:
+            - prep-go-modules
           test_list: find test -name "*.t.sol"
           test_profile: liteci
           features: <<matrix.features>>
@@ -3066,6 +3097,8 @@ workflows:
       # On develop, run tests with ci profile to mirror production.
       - contracts-bedrock-tests:
           name: contracts-bedrock-tests-develop <<matrix.features>>
+          requires:
+            - prep-go-modules
           test_list: find test -name "*.t.sol"
           test_profile: ci
           features: <<matrix.features>>
@@ -3081,6 +3114,8 @@ workflows:
       - contracts-bedrock-coverage:
           # Generate coverage reports.
           name: contracts-bedrock-coverage <<matrix.features>>
+          requires:
+            - prep-go-modules
           test_timeout: 1h
           test_profile: cicoverage
           features: <<matrix.features>>
@@ -3094,6 +3129,8 @@ workflows:
       # On PRs, run upgrade tests with lite profile for better build times.
       - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade op-mainnet <<matrix.features>>
+          requires:
+            - prep-go-modules
           fork_op_chain: op
           fork_base_chain: mainnet
           test_profile: liteci
@@ -3111,6 +3148,8 @@ workflows:
       # On develop, run upgrade tests with ci profile to mirror production.
       - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade-develop op-mainnet <<matrix.features>>
+          requires:
+            - prep-go-modules
           fork_op_chain: op
           fork_base_chain: mainnet
           test_profile: ci
@@ -3128,6 +3167,8 @@ workflows:
       # On PRs, run chain-specific upgrade tests with lite profile for better build times.
       - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade <<matrix.fork_op_chain>>-mainnet
+          requires:
+            - prep-go-modules
           fork_op_chain: <<matrix.fork_op_chain>>
           fork_base_chain: mainnet
           test_profile: liteci
@@ -3144,6 +3185,8 @@ workflows:
       # On develop, run chain-specific upgrade tests with ci profile to mirror production.
       - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade-develop <<matrix.fork_op_chain>>-mainnet
+          requires:
+            - prep-go-modules
           fork_op_chain: <<matrix.fork_op_chain>>
           fork_base_chain: mainnet
           test_profile: ci
@@ -3160,6 +3203,8 @@ workflows:
       # Always run L2 fork tests with ci profile
       - contracts-bedrock-tests-l2-fork:
           name: contracts-bedrock-tests-l2-fork op-mainnet
+          requires:
+            - prep-go-modules
           fork_op_chain: op-mainnet
           l2_fork_block_number: latest
           test_profile: ci

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -298,49 +298,6 @@ commands:
               fi
             fi
 
-  go-restore-cache:
-    parameters:
-      # The go module to cache for. If the go module does not come with its own go.mod and go.sum,
-      # "." can be used to point to the root go.mod and go.sum
-      module:
-        type: string
-        default: .
-      # Since many builds can run off the same go.mod/go.sum, we'll namespace the caches
-      namespace:
-        type: string
-      # Version can be used as a cache buster when making breaking changes to caching strategy
-      version:
-        type: string
-        default: <<pipeline.parameters.c-go-cache-version>>
-    steps:
-      - restore_cache:
-          name: Restore go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
-          keys:
-            - go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
-            - go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-
-            - go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-
-
-  go-save-cache:
-    parameters:
-      # The go module to cache for. If the go module does not come with its own go.mod and go.sum,
-      # "." can be used to point to the root go.mod and go.sum
-      module:
-        type: string
-        default: .
-      # Since many builds can run off the same go.mod/go.sum, we'll namespace the caches
-      namespace:
-        type: string
-      version:
-        type: string
-        default: <<pipeline.parameters.c-go-cache-version>>
-    steps:
-      - save_cache:
-          name: Save go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
-          paths:
-            - ~/.cache/go-build
-            - ~/go/pkg/mod
-          key: go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
-
   # --- Rust environment setup commands ---
   rust-setup-env:
     description: "Fix rust mise environment variables"
@@ -1094,6 +1051,8 @@ jobs:
           name: Print forge version
           command: forge --version
           working_directory: packages/contracts-bedrock
+      - go-restore-cache:
+          namespace: contracts-bedrock-heavy-fuzz
       - run:
           name: Build go-ffi
           command: just build-go-ffi
@@ -1115,11 +1074,8 @@ jobs:
             FOUNDRY_PROFILE: ciheavy
           working_directory: packages/contracts-bedrock
           when: on_fail
-      - save_cache:
-          name: Save Go build cache
-          key: golang-build-cache-contracts-bedrock-heavy-fuzz-{{ checksum "go.sum" }}
-          paths:
-            - "~/.cache/go-build"
+      - go-save-cache:
+          namespace: contracts-bedrock-heavy-fuzz
       # Store raw JUnit XML as artifact for debugging when store_test_results
       # shows 0 results (see ethereum-optimism/optimism#19577)
       - store_artifacts:
@@ -1252,6 +1208,8 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           enable-mise-cache: true
+      - go-restore-cache:
+          namespace: contracts-bedrock-tests-upgrade
       - install-contracts-dependencies
       - check-changed:
           patterns: contracts-bedrock
@@ -1306,11 +1264,8 @@ jobs:
             FORK_BASE_CHAIN: <<parameters.fork_base_chain>>
           working_directory: packages/contracts-bedrock
           when: on_fail
-      - save_cache:
-          name: Save Go build cache
-          key: golang-build-cache-contracts-bedrock-tests-{{ checksum "go.sum" }}
-          paths:
-            - "~/.cache/go-build"
+      - go-save-cache:
+          namespace: contracts-bedrock-tests-upgrade
       - save_cache:
           name: Save forked state
           key: forked-state-contracts-bedrock-tests-upgrade-<<parameters.fork_op_chain>>-<<parameters.fork_base_chain>>-{{ checksum "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
@@ -1367,6 +1322,8 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           enable-mise-cache: true
+      - go-restore-cache:
+          namespace: contracts-bedrock-tests-l2-fork
       - install-contracts-dependencies
       - check-changed:
           patterns: contracts-bedrock
@@ -1443,11 +1400,8 @@ jobs:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
           working_directory: packages/contracts-bedrock
           when: on_fail
-      - save_cache:
-          name: Save Go build cache
-          key: golang-build-cache-contracts-bedrock-tests-{{ checksum "go.sum" }}
-          paths:
-            - "~/.cache/go-build"
+      - go-save-cache:
+          namespace: contracts-bedrock-tests-l2-fork
       - save_cache:
           name: Save forked L2 state
           key: forked-state-l2-<<parameters.fork_op_chain>>-{{ checksum "packages/contracts-bedrock/l2ForkBlockNumber.txt" }}
@@ -1595,12 +1549,16 @@ jobs:
           enable-mise-cache: true
       - attach_workspace:
           at: .
+      - go-restore-cache:
+          namespace: go-lint
       - restore_cache:
           key: golangci-v1-{{ checksum ".golangci.yaml" }}
       - run:
           name: run Go linter
           command: |
             just lint-go
+      - go-save-cache:
+          namespace: go-lint
       - save_cache:
           key: golangci-v1-{{ checksum ".golangci.yaml" }}
           paths:
@@ -1674,6 +1632,24 @@ jobs:
           paths:
             - op-core/superchain/superchain-configs.zip
 
+  # Downloads the Go module set once and saves the shared module cache so the
+  # many downstream Go jobs restore it instead of each hitting proxy.golang.org.
+  # Downstream jobs require this so the cache is warm within the same pipeline,
+  # including the first run after a go.sum change.
+  prep-go-modules:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: medium.gen2
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+          enable-mise-cache: true
+      - restore-go-mod-cache
+      - run:
+          name: Download Go modules
+          command: go mod download
+      - save-go-mod-cache
+
   check-nut-locks:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
@@ -1682,10 +1658,14 @@ jobs:
       - utils/checkout-with-mise:
           checkout-method: blobless
           enable-mise-cache: true
+      - go-restore-cache:
+          namespace: check-nut-locks
       - run:
           name: check nut locks
           command: |
             go run ./ops/scripts/check-nut-locks
+      - go-save-cache:
+          namespace: check-nut-locks
 
   nut-provenance-verify:
     docker:
@@ -1741,8 +1721,8 @@ jobs:
           enable-mise-cache: true
       - attach_workspace:
           at: .
-      - restore_cache:
-          key: go-tests-v2-{{ checksum "go.mod" }}
+      - go-restore-cache:
+          namespace: go-tests
       - run:
           name: Run Go tests
           no_output_timeout: <<parameters.no_output_timeout>>
@@ -1753,11 +1733,8 @@ jobs:
             # like Geth
             export PARALLEL=12
             just <<parameters.rule>>
-      - save_cache:
-          key: go-tests-v2-{{ checksum "go.mod" }}
-          paths:
-            - "~/.cache/go-build"
-            - "~/go"
+      - go-save-cache:
+          namespace: go-tests
       - store_test_results:
           path: ./tmp/test-results
       - run:
@@ -1813,6 +1790,8 @@ jobs:
           enable-mise-cache: true
       - attach_workspace:
           at: .
+      - go-restore-cache:
+          namespace: go-tests-with-fault-proof-deps
       - run:
           name: build op-program-client
           command: just op-program-client
@@ -1831,6 +1810,8 @@ jobs:
             <<parameters.environment_overrides>>
             export TEST_TIMEOUT=<<parameters.test_timeout>>
             just go-tests-fraud-proofs-ci
+      - go-save-cache:
+          namespace: go-tests-with-fault-proof-deps
       - store_test_results:
           path: ./tmp/test-results
       - run:
@@ -1970,6 +1951,8 @@ jobs:
           enable-mise-cache: true
       - apt-install:
           packages: "binutils-mips-linux-gnu"
+      - go-restore-cache:
+          namespace: sanitize-op-program
       - run:
           name: Build cannon
           command: just cannon
@@ -1980,6 +1963,8 @@ jobs:
           name: Sanitize op-program client
           command: GUEST_PROGRAM=../op-program/bin/op-program-client64.elf just sanitize-program
           working_directory: cannon
+      - go-save-cache:
+          namespace: sanitize-op-program
 
   cannon-prestate:
     machine:
@@ -2112,6 +2097,8 @@ jobs:
           checkout-method: blobless
           enable-mise-cache: true
       - setup_remote_docker
+      - go-restore-cache:
+          namespace: cannon-stf-verify
       - run:
           name: Build cannon
           command: just cannon
@@ -2119,6 +2106,8 @@ jobs:
           name: Verify the Cannon STF
           command: just cannon-stf-verify
           working_directory: cannon
+      - go-save-cache:
+          namespace: cannon-stf-verify
       - notify-failures-on-develop:
           mentions: "@proofs-team"
 
@@ -2182,11 +2171,15 @@ jobs:
           checkout-method: blobless
           enable-mise-cache: true
       - setup_remote_docker
+      - go-restore-cache:
+          namespace: analyze-op-program-client
       - run:
           name: Run Analyzer
           command: |
             just run-vm-compat
           working_directory: op-program
+      - go-save-cache:
+          namespace: analyze-op-program-client
       - store_artifacts:
           path: op-program/bin/vm-compat-output/vm-compat-findings.json
           destination: vm-compat-findings.json
@@ -2460,6 +2453,8 @@ workflows:
           name: contracts-bedrock-build
           # Build with just core + script contracts.
           build_args: --deny-warnings --skip test
+          requires:
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
@@ -2504,6 +2499,7 @@ workflows:
       - go-lint:
           requires:
             - prep-superchain
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
       - check-op-geth-version:
@@ -2512,7 +2508,12 @@ workflows:
       - prep-superchain:
           context:
             - circleci-repo-readonly-authenticated-github-token
+      - prep-go-modules:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - check-nut-locks:
+          requires:
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
       - nut-provenance-verify:
@@ -2528,6 +2529,8 @@ workflows:
                 - op-node
                 - op-service
                 - op-chain-ops
+          requires:
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
       - fuzz-golang:
@@ -2539,6 +2542,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - contracts-bedrock-build
+            - prep-go-modules
       - fuzz-golang:
           name: op-e2e-fuzz
           package_name: op-e2e
@@ -2549,6 +2553,7 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate
+            - prep-go-modules
       - go-tests:
           name: go-tests-short
           parallelism: 12
@@ -2559,6 +2564,7 @@ workflows:
             - cannon-prestate
             - go-binaries-for-sysgo
             - prep-superchain
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
             - circleci-repo-rpc-secrets
@@ -2580,11 +2586,14 @@ workflows:
             - cannon-prestate
             - go-binaries-for-sysgo
             - prep-superchain
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
             - circleci-repo-rpc-secrets
             - slack
       - analyze-op-program-client:
+          requires:
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
       - op-program-compat:
@@ -2607,6 +2616,7 @@ workflows:
       - sanitize-op-program:
           requires:
             - cannon-prestate
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
       - check-generated-mocks-op-node:
@@ -2673,6 +2683,8 @@ workflows:
             - rust-build-op-rbuilder
             - rust-build-rollup-boost
       - go-binaries-for-sysgo:
+          requires:
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
       # IN-MEMORY (all) - op-node/op-geth
@@ -2690,6 +2702,7 @@ workflows:
             - cannon-prestate
             - rust-binaries-for-sysgo
             - go-binaries-for-sysgo
+            - prep-go-modules
       # IN-MEMORY - op-node/op-reth
       - op-acceptance-tests:
           name: memory-all-opn-op-reth
@@ -2706,6 +2719,7 @@ workflows:
             - cannon-prestate
             - rust-binaries-for-sysgo
             - go-binaries-for-sysgo
+            - prep-go-modules
       # IN-MEMORY - kona/op-reth
       - op-acceptance-tests:
           name: memory-all-kona-op-reth
@@ -2723,6 +2737,7 @@ workflows:
             - cannon-prestate
             - rust-binaries-for-sysgo
             - go-binaries-for-sysgo
+            - prep-go-modules
       # Gate job - single stable job used as GitHub required status check for develop.
       # Uses terminal requires so it always runs (even when deps fail), giving the
       # merge queue an immediate failure signal instead of a timeout.
@@ -2838,15 +2853,22 @@ workflows:
   develop-fault-proofs:
     when: << pipeline.parameters.c-run_develop_fault_proofs >>
     jobs:
+      - prep-go-modules:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - cannon-prestate:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - cannon-stf-verify:
+          requires:
+            - prep-go-modules
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build:
           build_args: --deny-warnings --skip test
+          requires:
+            - prep-go-modules
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token
@@ -2874,6 +2896,7 @@ workflows:
             - contracts-bedrock-build
             - cannon-prestate
             - rust-workspace-binaries
+            - prep-go-modules
       - publish-cannon-prestates:
           context:
             - slack
@@ -2927,7 +2950,12 @@ workflows:
   scheduled-heavy-fuzz-tests:
     when: << pipeline.parameters.c-run_scheduled_heavy_fuzz_tests >>
     jobs:
+      - prep-go-modules:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-heavy-fuzz-nightly:
+          requires:
+            - prep-go-modules
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token
@@ -2946,11 +2974,16 @@ workflows:
   l2-fork-test-workflow:
     when: << pipeline.parameters.c-run_l2_fork_test >>
     jobs:
+      - prep-go-modules:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-tests-l2-fork:
           name: contracts-bedrock-tests-l2-fork-dispatch op-mainnet
           fork_op_chain: op-mainnet
           l2_fork_block_number: latest
           test_profile: ci
+          requires:
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
             - circleci-repo-rpc-secrets
@@ -2959,7 +2992,12 @@ workflows:
   scheduled-weekly-tests:
     when: << pipeline.parameters.c-run_scheduled_weekly_tests >>
     jobs:
+      - prep-go-modules:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-tests-l2-fork:
+          requires:
+            - prep-go-modules
           matrix:
             parameters:
               fork_op_chain:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1900,10 +1900,8 @@ jobs:
             echo "export DEVSTACK_L2CL_KIND=<<parameters.l2_cl_kind>>" >> "$BASH_ENV"
             echo "export DEVSTACK_L2EL_KIND=<<parameters.l2_el_kind>>" >> "$BASH_ENV"
       # Restore cached Go modules
-      - restore_cache:
-          keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
-            - go-mod-v1-
+      - go-restore-cache:
+          namespace: op-acceptance-tests
       # Download Go dependencies
       - run:
           name: Download Go dependencies
@@ -1933,10 +1931,8 @@ jobs:
             cat "$LOG_DIR"/failed/*.log || true
           when: on_fail
       # Save the module cache for future runs
-      - save_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
+      - go-save-cache:
+          namespace: op-acceptance-tests
       # Store test results and artifacts
       - when:
           condition: always

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -914,11 +914,18 @@ jobs:
           environment:
             FOUNDRY_PROFILE: <<parameters.profile>>
           working_directory: packages/contracts-bedrock
+      # copy-contract-artifacts runs `go run ... mktar`, which needs the Go
+      # module set. Restore the shared cache (warmed by prep-go-modules) so it
+      # doesn't hit proxy.golang.org.
+      - go-restore-cache:
+          namespace: contracts-bedrock-build
       - run:
           name: "Copy artifacts into deployer"
           command: |
             just copy-contract-artifacts
           working_directory: op-deployer
+      - go-save-cache:
+          namespace: contracts-bedrock-build
       - persist_to_workspace:
           root: "."
           paths:

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -25,43 +25,8 @@ parameters:
     type: boolean
     default: false
 
-# Commands used by rust-e2e jobs
-commands:
-  go-restore-cache:
-    parameters:
-      module:
-        type: string
-        default: .
-      namespace:
-        type: string
-      version:
-        type: string
-        default: <<pipeline.parameters.c-go-cache-version>>
-    steps:
-      - restore_cache:
-          name: Restore go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
-          keys:
-            - go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
-            - go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-
-            - go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-
-
-  go-save-cache:
-    parameters:
-      module:
-        type: string
-        default: .
-      namespace:
-        type: string
-      version:
-        type: string
-        default: <<pipeline.parameters.c-go-cache-version>>
-    steps:
-      - save_cache:
-          name: Save go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
-          paths:
-            - ~/.cache/go-build
-            - ~/go/pkg/mod
-          key: go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
+# Cache helper commands (go-restore-cache, go-save-cache, …) are defined once
+# in helpers.yml and merged into every continuation config.
 
 # ============================================================================
 # RUST E2E JOBS

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -25,9 +25,6 @@ parameters:
     type: boolean
     default: false
 
-# Cache helper commands (go-restore-cache, go-save-cache, …) are defined once
-# in helpers.yml and merged into every continuation config.
-
 # ============================================================================
 # RUST E2E JOBS
 # ============================================================================

--- a/.circleci/scripts/merge-configs.sh
+++ b/.circleci/scripts/merge-configs.sh
@@ -3,8 +3,10 @@
 # yq is installed via mise (see mise.toml).
 # The merged file is written to /tmp/merged-config.yml for the continuation step.
 #
-# Merge order: main → rust-ci → rust-e2e
+# Merge order: helpers → main → rust-ci → rust-e2e
 # Later files win on key conflicts (same as path-filtering orb behaviour).
+# helpers.yml holds shared command definitions (e.g. the Go cache helpers) so
+# they live in one place instead of being duplicated across the configs.
 set -euo pipefail
 
 # Deep-merge all continuation configs.
@@ -14,6 +16,7 @@ set -euo pipefail
 # Single quotes are intentional to prevent shell expansion.
 # shellcheck disable=SC2016
 yq eval-all 'explode(.) | . as $item ireduce ({}; . * $item)' \
+  .circleci/continue/helpers.yml \
   .circleci/continue/main.yml \
   .circleci/continue/rust-ci.yml \
   .circleci/continue/rust-e2e.yml \


### PR DESCRIPTION
Every Go CI job downloaded the module set independently (`go mod download`, or implicitly via `go build`/`go test`), so each job was its own opportunity to hit a transient `proxy.golang.org` failure — the cause of the intermittent "go dependencies fail to download" job failures. There is a single Go module in the repo, so that download is identical for every job.

On top of that, the caches that were supposed to prevent re-downloads weren't working:
- `op-acceptance-tests` cached `/go/pkg/mod`, but the module cache lives at `~/go/pkg/mod` — the saved archive was empty (restore logs showed `Size: 16 B`), so it re-downloaded everything every run.
- The `golang-build-cache-*` caches in the contracts jobs were save-only with no matching restore (dead).
- Several Go jobs (`go-lint`, `go-tests-with-fault-proof-deps`, `sanitize-op-program`, `cannon-stf-verify`, `analyze-op-program-client`, `check-nut-locks`, `cannon-go-lint-and-test`, `contracts-bedrock-coverage`, the mock-check jobs) had no Go cache at all.

## Changes

- Split the bundled go cache into a **shared module cache** (keyed on `go.sum`, path `~/go/pkg/mod`) and a **per-namespace build cache** (`~/.cache/go-build`). `go-restore-cache`/`go-save-cache` keep their `namespace`-only interface, so existing callers are unchanged.
- Add a **`prep-go-modules`** job that downloads the modules once and saves the shared cache. Workflows that run Go jobs (`main`, `develop-fault-proofs`, `contracts-feature-tests`, `l2-fork-test-workflow`, `scheduled-weekly-tests`, `scheduled-heavy-fuzz-tests`) include it and the Go jobs `require` it, so the cache is warm in-pipeline including the first run after a `go.sum` change.
- Key the **build cache on branch+revision** and save it fresh per commit (CircleCI cache keys are immutable, so a key tied only to `go.sum` would freeze the build cache after the first commit and never refresh). Restore falls back: this exact commit → latest on the branch → latest overall for the namespace.
- Replace the remaining hand-rolled caches (`go-tests-v2`, the dead `golang-build-cache`) with the shared commands, and add caching to the Go jobs that had none.
- Give the **golangci-lint and svm/solc caches a prefix fallback** so a config change reuses the prior cache instead of a cold start, and save the golangci cache with `when: always` so a failing lint run still warms it.
- Drop the now-redundant `go mod download` in `op-acceptance-tests` (the shared module cache already provides them).
- Extract the cache helper commands into `helpers.yml` so they're defined once and merged into every continuation config instead of duplicated across `main.yml` and `rust-e2e.yml`.

Out of scope (filed separately): the duplicate `rust-build` definition that silently disables the feature-branch cargo-build skip — ethereum-optimism/optimism#21219.

Validated locally with `circleci config validate` against the merged continuation config (`merge-configs.sh` output, with the private `utils` orb stubbed).