### PR TITLE
refactor(op-preimage): move FPP local preimage-key indices to op-preimage

### DIFF
--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -14,10 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-const (
-	L2ClaimBlockNumberLocalIndex = 4
-)
-
 var (
 	ErrIndexTooLarge = errors.New("index is larger than the maximum index")
 )
@@ -44,7 +40,7 @@ func NewTraceProvider(startingBlockNumber *big.Int, depth types.Depth) *Alphabet
 
 func (ap *AlphabetTraceProvider) GetStepData(ctx context.Context, pos types.Position) ([]byte, []byte, *types.PreimageOracleData, error) {
 	traceIndex := pos.TraceIndex(ap.depth)
-	key := preimage.LocalIndexKey(L2ClaimBlockNumberLocalIndex).PreimageKey()
+	key := preimage.L2ClaimBlockNumberLocalIndex.PreimageKey()
 	preimageData := types.NewPreimageOracleData(key[:], ap.startingBlockNumber.Bytes(), 0)
 	if traceIndex.Cmp(common.Big0) == 0 {
 		return absolutePrestate, []byte{}, preimageData, nil

--- a/op-challenger/game/fault/trace/alphabet/provider_test.go
+++ b/op-challenger/game/fault/trace/alphabet/provider_test.go
@@ -104,7 +104,7 @@ func TestAlphabetProvider_GetStepData(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
 	ap := NewTraceProvider(startingL2BlockNumber, depth)
-	key := preimage.LocalIndexKey(L2ClaimBlockNumberLocalIndex).PreimageKey()
+	key := preimage.L2ClaimBlockNumberLocalIndex.PreimageKey()
 	expectedPreimageData := types.NewPreimageOracleData(key[:], startingL2BlockNumber.Bytes(), 0)
 
 	tests := []struct {

--- a/op-e2e/faultproofs/preimages_test.go
+++ b/op-e2e/faultproofs/preimages_test.go
@@ -7,7 +7,6 @@ import (
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
-	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
@@ -20,10 +19,10 @@ func TestLocalPreimages(t *testing.T) {
 	tests := []struct {
 		key preimage.Key
 	}{
-		{key: boot.L1HeadLocalIndex},
-		{key: boot.L2OutputRootLocalIndex},
-		{key: boot.L2ClaimLocalIndex},
-		{key: boot.L2ClaimBlockNumberLocalIndex},
+		{key: preimage.L1HeadLocalIndex},
+		{key: preimage.L2OutputRootLocalIndex},
+		{key: preimage.L2ClaimLocalIndex},
+		{key: preimage.L2ClaimBlockNumberLocalIndex},
 		// We don't check client.L2ChainIDLocalIndex because e2e tests use a custom chain configuration
 		// which requires using a custom chain ID indicator so op-program will load the full rollup config and
 		// genesis from the preimage oracle

--- a/op-preimage/local_keys.go
+++ b/op-preimage/local_keys.go
@@ -1,0 +1,19 @@
+package preimage
+
+// Local key indices for the fault-proof program's bootstrap inputs. These are
+// provided by the host via the local preimage key space and read by the client
+// program during boot. The values are part of the fault-proof ABI and must not
+// change.
+const (
+	L1HeadLocalIndex LocalIndexKey = iota + 1
+	L2OutputRootLocalIndex
+	L2ClaimLocalIndex
+	L2ClaimBlockNumberLocalIndex
+	L2ChainIDLocalIndex
+
+	// These local keys are only used for custom chains
+	L2ChainConfigLocalIndex
+	RollupConfigLocalIndex
+	DependencySetLocalIndex
+	L1ChainConfigLocalIndex
+)

--- a/op-program/client/boot/boot.go
+++ b/op-program/client/boot/boot.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
@@ -37,28 +38,28 @@ func NewBootstrapClient(r oracleClient) *BootstrapClient {
 }
 
 func (br *BootstrapClient) BootInfo() *BootInfo {
-	l1Head := common.BytesToHash(br.r.Get(L1HeadLocalIndex))
-	l2OutputRoot := common.BytesToHash(br.r.Get(L2OutputRootLocalIndex))
-	l2Claim := common.BytesToHash(br.r.Get(L2ClaimLocalIndex))
-	l2ClaimBlockNumber := binary.BigEndian.Uint64(br.r.Get(L2ClaimBlockNumberLocalIndex))
-	l2ChainID := eth.ChainIDFromUInt64(binary.BigEndian.Uint64(br.r.Get(L2ChainIDLocalIndex)))
+	l1Head := common.BytesToHash(br.r.Get(preimage.L1HeadLocalIndex))
+	l2OutputRoot := common.BytesToHash(br.r.Get(preimage.L2OutputRootLocalIndex))
+	l2Claim := common.BytesToHash(br.r.Get(preimage.L2ClaimLocalIndex))
+	l2ClaimBlockNumber := binary.BigEndian.Uint64(br.r.Get(preimage.L2ClaimBlockNumberLocalIndex))
+	l2ChainID := eth.ChainIDFromUInt64(binary.BigEndian.Uint64(br.r.Get(preimage.L2ChainIDLocalIndex)))
 
 	var l1ChainConfig *params.ChainConfig
 	var l2ChainConfig *params.ChainConfig
 	var rollupConfig *rollup.Config
 	if l2ChainID == CustomChainIDIndicator {
 		l2ChainConfig = new(params.ChainConfig)
-		err := json.Unmarshal(br.r.Get(L2ChainConfigLocalIndex), &l2ChainConfig)
+		err := json.Unmarshal(br.r.Get(preimage.L2ChainConfigLocalIndex), &l2ChainConfig)
 		if err != nil {
 			panic("failed to bootstrap l2ChainConfig")
 		}
 		rollupConfig = new(rollup.Config)
-		err = json.Unmarshal(br.r.Get(RollupConfigLocalIndex), rollupConfig)
+		err = json.Unmarshal(br.r.Get(preimage.RollupConfigLocalIndex), rollupConfig)
 		if err != nil {
 			panic("failed to bootstrap rollup config")
 		}
 		l1ChainConfig = new(params.ChainConfig)
-		err = json.Unmarshal(br.r.Get(L1ChainConfigLocalIndex), l1ChainConfig)
+		err = json.Unmarshal(br.r.Get(preimage.L1ChainConfigLocalIndex), l1ChainConfig)
 		if err != nil {
 			panic("failed to bootstrap l1ChainConfig: " + fmt.Sprintf("%v", err))
 		}

--- a/op-program/client/boot/boot_interop.go
+++ b/op-program/client/boot/boot_interop.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
@@ -119,7 +120,7 @@ func (c *OracleConfigSource) L1ChainConfig(chainID eth.ChainID) (*params.ChainCo
 
 func (c *OracleConfigSource) loadCustomConfigs() {
 	var rollupConfigs []*rollup.Config
-	err := json.Unmarshal(c.oracle.Get(RollupConfigLocalIndex), &rollupConfigs)
+	err := json.Unmarshal(c.oracle.Get(preimage.RollupConfigLocalIndex), &rollupConfigs)
 	if err != nil {
 		panic("failed to bootstrap rollup configs")
 	}
@@ -128,7 +129,7 @@ func (c *OracleConfigSource) loadCustomConfigs() {
 	}
 
 	var chainConfigs []*params.ChainConfig
-	err = json.Unmarshal(c.oracle.Get(L2ChainConfigLocalIndex), &chainConfigs)
+	err = json.Unmarshal(c.oracle.Get(preimage.L2ChainConfigLocalIndex), &chainConfigs)
 	if err != nil {
 		panic("failed to bootstrap chain configs")
 	}
@@ -137,7 +138,7 @@ func (c *OracleConfigSource) loadCustomConfigs() {
 	}
 
 	var depset depset.StaticConfigDependencySet
-	err = json.Unmarshal(c.oracle.Get(DependencySetLocalIndex), &depset)
+	err = json.Unmarshal(c.oracle.Get(preimage.DependencySetLocalIndex), &depset)
 	if err != nil {
 		panic("failed to bootstrap dependency set")
 	}
@@ -145,7 +146,7 @@ func (c *OracleConfigSource) loadCustomConfigs() {
 	c.customConfigsLoaded = true
 
 	var l1ChainConfig *params.ChainConfig
-	err = json.Unmarshal(c.oracle.Get(L1ChainConfigLocalIndex), &l1ChainConfig)
+	err = json.Unmarshal(c.oracle.Get(preimage.L1ChainConfigLocalIndex), &l1ChainConfig)
 	if err != nil {
 		panic("failed to bootstrap l1 chain configs: " + fmt.Sprintf("%v", err))
 	}
@@ -153,10 +154,10 @@ func (c *OracleConfigSource) loadCustomConfigs() {
 }
 
 func BootstrapInterop(r oracleClient) *BootInfoInterop {
-	l1Head := common.BytesToHash(r.Get(L1HeadLocalIndex))
-	agreedPrestate := common.BytesToHash(r.Get(L2OutputRootLocalIndex))
-	claim := common.BytesToHash(r.Get(L2ClaimLocalIndex))
-	claimTimestamp := binary.BigEndian.Uint64(r.Get(L2ClaimBlockNumberLocalIndex))
+	l1Head := common.BytesToHash(r.Get(preimage.L1HeadLocalIndex))
+	agreedPrestate := common.BytesToHash(r.Get(preimage.L2OutputRootLocalIndex))
+	claim := common.BytesToHash(r.Get(preimage.L2ClaimLocalIndex))
+	claimTimestamp := binary.BigEndian.Uint64(r.Get(preimage.L2ClaimBlockNumberLocalIndex))
 
 	return &BootInfoInterop{
 		Configs: &OracleConfigSource{

--- a/op-program/client/boot/boot_interop_test.go
+++ b/op-program/client/boot/boot_interop_test.go
@@ -161,27 +161,27 @@ type mockInteropBootstrapOracle struct {
 
 func (o *mockInteropBootstrapOracle) Get(key preimage.Key) []byte {
 	switch key.PreimageKey() {
-	case L2ChainConfigLocalIndex.PreimageKey():
+	case preimage.L2ChainConfigLocalIndex.PreimageKey():
 		if !o.custom {
 			panic(fmt.Sprintf("unexpected oracle request for preimage key %x", key.PreimageKey()))
 		}
 		b, _ := json.Marshal(o.chainCfgs)
 		return b
-	case RollupConfigLocalIndex.PreimageKey():
+	case preimage.RollupConfigLocalIndex.PreimageKey():
 		if !o.custom {
 			panic(fmt.Sprintf("unexpected oracle request for preimage key %x", key.PreimageKey()))
 		}
 		b, _ := json.Marshal(o.rollupCfgs)
 		return b
-	case L2ChainIDLocalIndex.PreimageKey():
+	case preimage.L2ChainIDLocalIndex.PreimageKey():
 		panic("unexpected oracle request for l2 chain ID preimage key")
-	case DependencySetLocalIndex.PreimageKey():
+	case preimage.DependencySetLocalIndex.PreimageKey():
 		if !o.custom {
 			panic(fmt.Sprintf("unexpected oracle request for preimage key %x", key.PreimageKey()))
 		}
 		b, _ := json.Marshal(o.depset)
 		return b
-	case L1ChainConfigLocalIndex.PreimageKey():
+	case preimage.L1ChainConfigLocalIndex.PreimageKey():
 		if !o.custom {
 			panic(fmt.Sprintf("unexpected oracle request for preimage key %x", key.PreimageKey()))
 		}

--- a/op-program/client/boot/boot_test.go
+++ b/op-program/client/boot/boot_test.go
@@ -97,21 +97,21 @@ type mockPreinteropBootstrapOracle struct {
 
 func (o *mockPreinteropBootstrapOracle) Get(key preimage.Key) []byte {
 	switch key.PreimageKey() {
-	case L2ChainIDLocalIndex.PreimageKey():
+	case preimage.L2ChainIDLocalIndex.PreimageKey():
 		return binary.BigEndian.AppendUint64(nil, eth.EvilChainIDToUInt64(o.b.L2ChainID))
-	case L2ChainConfigLocalIndex.PreimageKey():
+	case preimage.L2ChainConfigLocalIndex.PreimageKey():
 		if !o.custom {
 			panic(fmt.Sprintf("unexpected oracle request for preimage key %x", key.PreimageKey()))
 		}
 		b, _ := json.Marshal(o.b.L2ChainConfig)
 		return b
-	case L1ChainConfigLocalIndex.PreimageKey():
+	case preimage.L1ChainConfigLocalIndex.PreimageKey():
 		if !o.custom {
 			panic(fmt.Sprintf("unexpected oracle request for preimage key %x", key.PreimageKey()))
 		}
 		b, _ := json.Marshal(o.b.L1ChainConfig)
 		return b
-	case RollupConfigLocalIndex.PreimageKey():
+	case preimage.RollupConfigLocalIndex.PreimageKey():
 		if !o.custom {
 			panic(fmt.Sprintf("unexpected oracle request for preimage key %x", key.PreimageKey()))
 		}

--- a/op-program/client/boot/common.go
+++ b/op-program/client/boot/common.go
@@ -2,20 +2,6 @@ package boot
 
 import preimage "github.com/ethereum-optimism/optimism/op-preimage"
 
-const (
-	L1HeadLocalIndex preimage.LocalIndexKey = iota + 1
-	L2OutputRootLocalIndex
-	L2ClaimLocalIndex
-	L2ClaimBlockNumberLocalIndex
-	L2ChainIDLocalIndex
-
-	// These local keys are only used for custom chains
-	L2ChainConfigLocalIndex
-	RollupConfigLocalIndex
-	DependencySetLocalIndex
-	L1ChainConfigLocalIndex
-)
-
 type oracleClient interface {
 	Get(key preimage.Key) []byte
 }

--- a/op-program/client/boot/common_test.go
+++ b/op-program/client/boot/common_test.go
@@ -16,13 +16,13 @@ type mockBootstrapOracle struct {
 
 func (o *mockBootstrapOracle) Get(key preimage.Key) []byte {
 	switch key.PreimageKey() {
-	case L1HeadLocalIndex.PreimageKey():
+	case preimage.L1HeadLocalIndex.PreimageKey():
 		return o.l1Head[:]
-	case L2OutputRootLocalIndex.PreimageKey():
+	case preimage.L2OutputRootLocalIndex.PreimageKey():
 		return o.l2OutputRoot[:]
-	case L2ClaimLocalIndex.PreimageKey():
+	case preimage.L2ClaimLocalIndex.PreimageKey():
 		return o.l2Claim[:]
-	case L2ClaimBlockNumberLocalIndex.PreimageKey():
+	case preimage.L2ClaimBlockNumberLocalIndex.PreimageKey():
 		return binary.BigEndian.AppendUint64(nil, o.l2ClaimBlockNumber)
 	default:
 		panic("unknown key")

--- a/op-program/host/common/local_preimage.go
+++ b/op-program/host/common/local_preimage.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/kvstore"
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -21,15 +22,15 @@ func NewLocalPreimageSource(config *config.Config) *LocalPreimageSource {
 }
 
 var (
-	l1HeadKey             = boot.L1HeadLocalIndex.PreimageKey()
-	l2OutputRootKey       = boot.L2OutputRootLocalIndex.PreimageKey()
-	l2ClaimKey            = boot.L2ClaimLocalIndex.PreimageKey()
-	l2ClaimBlockNumberKey = boot.L2ClaimBlockNumberLocalIndex.PreimageKey()
-	l2ChainIDKey          = boot.L2ChainIDLocalIndex.PreimageKey()
-	l2ChainConfigKey      = boot.L2ChainConfigLocalIndex.PreimageKey()
-	rollupKey             = boot.RollupConfigLocalIndex.PreimageKey()
-	dependencySetKey      = boot.DependencySetLocalIndex.PreimageKey()
-	l1ChainConfigKey      = boot.L1ChainConfigLocalIndex.PreimageKey()
+	l1HeadKey             = preimage.L1HeadLocalIndex.PreimageKey()
+	l2OutputRootKey       = preimage.L2OutputRootLocalIndex.PreimageKey()
+	l2ClaimKey            = preimage.L2ClaimLocalIndex.PreimageKey()
+	l2ClaimBlockNumberKey = preimage.L2ClaimBlockNumberLocalIndex.PreimageKey()
+	l2ChainIDKey          = preimage.L2ChainIDLocalIndex.PreimageKey()
+	l2ChainConfigKey      = preimage.L2ChainConfigLocalIndex.PreimageKey()
+	rollupKey             = preimage.RollupConfigLocalIndex.PreimageKey()
+	dependencySetKey      = preimage.DependencySetLocalIndex.PreimageKey()
+	l1ChainConfigKey      = preimage.L1ChainConfigLocalIndex.PreimageKey()
 )
 
 func (s *LocalPreimageSource) Get(key common.Hash) ([]byte, error) {

--- a/op-program/host/host_test.go
+++ b/op-program/host/host_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
-	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/client/l1"
 	hostcommon "github.com/ethereum-optimism/optimism/op-program/host/common"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
@@ -46,8 +45,8 @@ func TestServerMode(t *testing.T) {
 	hClient := preimage.NewHintWriter(hintClient)
 	l1PreimageOracle := l1.NewPreimageOracle(pClient, hClient)
 
-	require.Equal(t, l1Head.Bytes(), pClient.Get(boot.L1HeadLocalIndex), "Should get l1 head preimages")
-	require.Equal(t, l2OutputRoot.Bytes(), pClient.Get(boot.L2OutputRootLocalIndex), "Should get l2 output root preimages")
+	require.Equal(t, l1Head.Bytes(), pClient.Get(preimage.L1HeadLocalIndex), "Should get l1 head preimages")
+	require.Equal(t, l2OutputRoot.Bytes(), pClient.Get(preimage.L2OutputRootLocalIndex), "Should get l2 output root preimages")
 
 	// Should exit when a preimage is unavailable
 	require.Panics(t, func() {


### PR DESCRIPTION
Moves the fault-proof program's local preimage-key index constants (`L1HeadLocalIndex`, `L2OutputRootLocalIndex`, `L2ClaimLocalIndex`, `L2ClaimBlockNumberLocalIndex`, `L2ChainIDLocalIndex`, and the custom-chain ones) from `op-program/client/boot` into `op-preimage`.

These are part of the preimage-key ABI — they're already typed `preimage.LocalIndexKey`, and they're consumed outside op-program (op-e2e, op-challenger). op-preimage is a lower-level dependency of all consumers, so this is the correct shared home. **Values are unchanged** (`iota + 1`), preserving the fault-proof ABI.

### What changed
- New `op-preimage/local_keys.go` holds the const block; removed from `op-program/client/boot/common.go`.
- `op-program/client/boot` and `op-program/host/common` now reference `preimage.X`.
- `op-e2e/faultproofs/preimages_test.go` drops its `op-program/client/boot` import (now uses op-preimage) — removing one of op-e2e's remaining op-program dependencies.
- `op-challenger` alphabet provider now uses the canonical `preimage.L2ClaimBlockNumberLocalIndex` instead of a private `L2ClaimBlockNumberLocalIndex = 4` magic-number duplicate.

Part of the op-program removal effort.

### Verification
- `go vet` and the custom `op-golangci-lint` clean across op-preimage, op-program, the alphabet provider, and op-e2e/faultproofs.
- Unit tests pass: `go test ./op-preimage/... ./op-program/client/boot/... ./op-challenger/game/fault/trace/alphabet/...` — including the boot preimage-key mapping tests that assert the local-index → `PreimageKey()` values. (`op-e2e/faultproofs/preimages_test.go` is a heavier e2e test left to CI; the change there is a pure import swap and compiles/vets clean.)