### PR TITLE
test(op-e2e): use kona-host as Cannon.Server in op-e2e; drop op-program step test

### DIFF
--- a/op-acceptance-tests/tests/proofs/cannon/step_test.go
+++ b/op-acceptance-tests/tests/proofs/cannon/step_test.go
@@ -11,24 +11,6 @@ import (
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
-func TestExecuteStep_Cannon(gt *testing.T) {
-	t := devtest.ParallelT(gt)
-	sysgo.SkipOnOpReth(t, "not supported (timeout)")
-	sys := newSystem(t)
-
-	l1User := sys.FunderL1.NewFundedEOA(eth.ThousandEther)
-	blockNum := uint64(3)
-	sys.L2CL.Reached(safety.LocalSafe, blockNum, 30)
-
-	game := sys.DisputeGameFactory().StartCannonGame(l1User, proofs.WithL2SequenceNumber(blockNum))
-	claim := game.DisputeL2SequenceNumber(l1User, game.RootClaim(), blockNum)
-	game.LogGameData()
-	claim = claim.WaitForCounterClaim()             // Wait for the honest challenger to counter
-	claim = game.DisputeToStep(l1User, claim, 1000) // Skip down to max depth
-	game.LogGameData()
-	claim.WaitForCountered()
-}
-
 func TestExecuteStep_CannonKona(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	// Example error with kona-node:

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -74,6 +74,19 @@ func applyCannonConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Genesis 
 	return nil
 }
 
+// LocateKonaHost ensures the kona-host native binary is built and returns its path.
+func LocateKonaHost(ctx context.Context) (string, error) {
+	bin, err := rustbin.Spec{
+		SrcDir:  "rust/kona",
+		Package: "kona-host",
+		Binary:  "kona-host",
+	}.EnsureExists(ctx, log.NewLogger(log.DiscardHandler()))
+	if err != nil {
+		return "", fmt.Errorf("kona-host binary: %w", err)
+	}
+	return bin, nil
+}
+
 func applyCannonKonaConfig(ctx context.Context, c *config.Config, rollupCfgs []*rollup.Config, l1Genesis *core.Genesis, l2Geneses []*core.Genesis, interop bool) error {
 	root, err := findMonorepoRoot()
 	if err != nil {
@@ -82,13 +95,9 @@ func applyCannonKonaConfig(ctx context.Context, c *config.Config, rollupCfgs []*
 	if err := applyVmConfig(root, &c.CannonKona, c.Datadir, rollupCfgs, l1Genesis, l2Geneses); err != nil {
 		return err
 	}
-	konaHostBin, err := rustbin.Spec{
-		SrcDir:  "rust/kona",
-		Package: "kona-host",
-		Binary:  "kona-host",
-	}.EnsureExists(ctx, log.NewLogger(log.DiscardHandler()))
+	konaHostBin, err := LocateKonaHost(ctx)
 	if err != nil {
-		return fmt.Errorf("kona-host binary: %w", err)
+		return err
 	}
 	c.CannonKona.Server = konaHostBin
 	if interop {

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -132,9 +132,24 @@ func handleOptError(t *testing.T, opt shared.Option) Option {
 		require.NoError(t, opt(t.Context(), c))
 	}
 }
+
+// withKonaHostCannonServer points Cannon.Server at the kona-host binary instead of
+// op-program. In op-e2e the op-program cannon game type is never executed (output
+// games use cannon-kona and the permissioned game uses an invalid prestate), so the
+// configured server is only validated for existence — pointing it at kona-host keeps
+// op-e2e from depending on the op-program binary.
+func withKonaHostCannonServer(t *testing.T) Option {
+	return func(c *config.Config) {
+		bin, err := shared.LocateKonaHost(t.Context())
+		require.NoError(t, err, "locate kona-host")
+		c.Cannon.Server = bin
+	}
+}
+
 func WithCannon(t *testing.T, system System) Option {
 	return func(c *config.Config) {
 		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L1Genesis(), system.L2Geneses(), system.PrestateVariant()))(c)
+		withKonaHostCannonServer(t)(c)
 		handleOptError(t, shared.WithCannonGameType())(c)
 	}
 }
@@ -142,6 +157,7 @@ func WithCannon(t *testing.T, system System) Option {
 func WithPermissioned(t *testing.T, system System) Option {
 	return func(c *config.Config) {
 		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L1Genesis(), system.L2Geneses(), system.PrestateVariant()))(c)
+		withKonaHostCannonServer(t)(c)
 		handleOptError(t, shared.WithPermissionedGameType())(c)
 	}
 }
@@ -149,6 +165,7 @@ func WithPermissioned(t *testing.T, system System) Option {
 func WithCannonKona(t *testing.T, system System) Option {
 	return func(c *config.Config) {
 		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L1Genesis(), system.L2Geneses(), system.PrestateVariant()))(c)
+		withKonaHostCannonServer(t)(c)
 		handleOptError(t, shared.WithCannonKonaConfig(system.RollupCfgs(), system.L1Genesis(), system.L2Geneses()))(c)
 		handleOptError(t, shared.WithCannonKonaGameType())(c)
 	}
@@ -157,6 +174,7 @@ func WithCannonKona(t *testing.T, system System) Option {
 func WithSuperCannonKona(t *testing.T, system System) Option {
 	return func(c *config.Config) {
 		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L1Genesis(), system.L2Geneses(), system.PrestateVariant()))(c)
+		withKonaHostCannonServer(t)(c)
 		handleOptError(t, shared.WithCannonKonaInteropConfig(system.RollupCfgs(), system.L1Genesis(), system.L2Geneses()))(c)
 		handleOptError(t, shared.WithSuperCannonKonaGameType())(c)
 	}
@@ -229,7 +247,7 @@ func NewChallengerConfig(t *testing.T, sys EndpointProvider, l2NodeName string, 
 	}
 	if cfg.Cannon.Server != "" {
 		_, err := os.Stat(cfg.Cannon.Server)
-		require.NoError(t, err, "op-program should be built. Make sure you've run make cannon-prestates")
+		require.NoError(t, err, "kona-host should be built. Run: cd rust/kona && just build-native --profile=release")
 	}
 	if cfg.CannonAbsolutePreState != "" {
 		_, err := os.Stat(cfg.CannonAbsolutePreState)


### PR DESCRIPTION
Two parts of the op-program removal effort.

### 1. op-e2e Cannon.Server → kona-host
In op-e2e the op-program cannon game type is never executed: output games use the **cannon-kona** game type (kona-host), and the permissioned game uses an invalid prestate so the challenger counter-claims without running the VM. The configured `Cannon.Server` is only validated for existence (a stat check) and pointed at the op-program binary.

This overrides `Cannon.Server` with the **kona-host** binary in the **op-e2e** challenger helper (`WithCannon`/`WithPermissioned`/`WithCannonKona`/`WithSuperCannonKona`), so op-e2e no longer depends on the op-program executable. Adds an exported `LocateKonaHost` helper in `op-devstack/shared/challenger` (also dedupes `applyCannonKonaConfig`).

### 2. Remove `TestExecuteStep_Cannon`
This test existed solely to exercise op-program cannon execution. `TestExecuteStep_CannonKona` provides the equivalent coverage against kona-host, so the op-program variant is removed.

### Scope
**op-challenger itself is unchanged.** The op-devstack shared challenger config still points at op-program because the remaining `CannonGameType` consumers — `smoke_test.go` and the withdrawal acceptance tests (`base/withdrawal/cannon`, `karst`) plus the permissioned game — still need it. Fully removing the op-program `CannonGameType` (and moving the permissioned game off op-program) is a separate, larger step of the op-program removal.

### Verification
- `go vet` + `op-golangci-lint` clean across touched packages.
- `TestPermissionedGameType` passes locally against a built kona-host (challenger starts with kona-host `Cannon.Server` and counter-claims).
- The op-devstack op-program cannon path is unchanged vs develop (`git diff`), so the remaining `CannonGameType` tests are unaffected.