### PR TITLE
test(devstack): make Reached/AdvancedFn tolerate transient block-ref lookups

### DIFF
--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -207,7 +207,19 @@ func (cl *L2CLNode) AwaitMinL1Processed(minL1 uint64) {
 // Composable with other lambdas to wait in parallel
 func (cl *L2CLNode) AdvancedFn(lvl safety.Level, delta uint64, attempts int) CheckFunc {
 	return func() error {
-		initial := cl.HeadBlockRef(lvl)
+		var initial eth.L2BlockRef
+		if err := retry.Do0(cl.ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
+			func() error {
+				head, err := cl.headBlockRef(lvl)
+				if err != nil {
+					cl.log.Warn("SyncStatus RPC failed; will retry", "err", err)
+					return err
+				}
+				initial = head
+				return nil
+			}); err != nil {
+			return err
+		}
 		target := initial.Number + delta
 		cl.log.Info("Expecting chain to advance", "name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "delta", delta)
 		return cl.ReachedFn(lvl, target, attempts)()

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -51,10 +51,16 @@ func (el *L2ELNode) EthClient() apis.EthClient {
 	return el.inner.EthClient()
 }
 
-func (el *L2ELNode) BlockRefByLabel(label eth.BlockLabel) eth.L2BlockRef {
+// blockRefByLabel returns the block ref for a label and its lookup error, so the polling helpers
+// can retry transient failures. BlockRefByLabel is the one-shot variant that fails the test.
+func (el *L2ELNode) blockRefByLabel(label eth.BlockLabel) (eth.L2BlockRef, error) {
 	ctx, cancel := context.WithTimeout(el.ctx, DefaultTimeout)
 	defer cancel()
-	block, err := el.inner.L2EthClient().L2BlockRefByLabel(ctx, label)
+	return el.inner.L2EthClient().L2BlockRefByLabel(ctx, label)
+}
+
+func (el *L2ELNode) BlockRefByLabel(label eth.BlockLabel) eth.L2BlockRef {
+	block, err := el.blockRefByLabel(label)
 	el.require.NoError(err, "block not found using block label")
 	return block
 }
@@ -87,19 +93,22 @@ func (el *L2ELNode) AdvancedFn(label eth.BlockLabel, block uint64, opts ...Advan
 		opt(&o)
 	}
 	return func() error {
-		initial := el.BlockRefByLabel(label)
+		var initial eth.L2BlockRef
+		if err := retry.Do0(el.ctx, o.attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
+			func() error {
+				head, err := el.blockRefByLabel(label)
+				if err != nil {
+					el.log.Warn("block-label lookup failed; will retry", "chain", el.inner.ChainID(), "label", label, "err", err)
+					return err
+				}
+				initial = head
+				return nil
+			}); err != nil {
+			return err
+		}
 		target := initial.Number + block
 		el.log.Info("expecting chain to advance", "chain", el.inner.ChainID(), "label", label, "target", target, "attempts", o.attempts)
-		return retry.Do0(el.ctx, o.attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
-			func() error {
-				head := el.BlockRefByLabel(label)
-				if head.Number >= target {
-					el.log.Info("chain advanced", "chain", el.inner.ChainID(), "target", target)
-					return nil
-				}
-				el.log.Info("chain sync status", "chain", el.inner.ChainID(), "initial", initial.Number, "current", head.Number, "target", target)
-				return fmt.Errorf("expected head to advance: %s", label)
-			})
+		return el.ReachedFn(label, target, o.attempts)()
 	}
 }
 
@@ -128,7 +137,11 @@ func (el *L2ELNode) ReachedFn(label eth.BlockLabel, target uint64, attempts int)
 		logger.Info("Expecting L2EL to reach")
 		return retry.Do0(el.ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
 			func() error {
-				head := el.BlockRefByLabel(label)
+				head, err := el.blockRefByLabel(label)
+				if err != nil {
+					logger.Warn("block-label lookup failed; will retry", "err", err)
+					return err
+				}
 				if head.Number >= target {
 					logger.Info("L2EL advanced", "target", target)
 					return nil


### PR DESCRIPTION
## Summary

The DSL polling helpers `L2ELNode.ReachedFn` / `AdvancedFn` (and `L2CLNode.AdvancedFn`)
wrap their reads in `retry.Do0`, but they read through the **infallible** getters
(`BlockRefByLabel` / `HeadBlockRef`), which call `require.NoError`. `require` aborts the
test goroutine (`FailNow` → `runtime.Goexit`) on the first error — it never returns the
error to the surrounding retry loop. So the retry can only ever handle the "not reached
yet" case, never a lookup error.

That makes these helpers fragile during reorgs: while the op-node engine is mid-reset it
can transiently fail to resolve a block label for a single call. The chain recovers a
moment later, but the helper has already hard-failed the test. This shows up as flakes in
reorg/reset-heavy acceptance tests (e.g. supernode interop invalid-message replacement)
that wait on a safe head while the unsafe tip is oscillating.

## Change

- Add an unexported, fallible `L2ELNode.blockRefByLabel(label) (eth.L2BlockRef, error)`,
  mirroring the existing `headBlockRef` / `HeadBlockRef` pair on `L2CLNode`. The exported
  `BlockRefByLabel` becomes a thin requiring wrapper for one-shot callers (unchanged
  behavior).
- Route `L2ELNode.ReachedFn` and `AdvancedFn` through the fallible getter, returning lookup
  errors to the retry loop instead of aborting. A transient is now retried; a genuine
  sustained failure still exhausts the budget and fails.
- `L2ELNode.AdvancedFn` now retries its baseline read (previously a one-shot infallible
  read outside the loop) and delegates the progress poll to `ReachedFn` — the same shape
  `L2CLNode.AdvancedFn` already uses.
- `L2CLNode.AdvancedFn`'s baseline read switches from the infallible `HeadBlockRef` to the
  fallible `headBlockRef` with retry (its `ReachedFn` already tolerated lookup errors).

No public signatures change. On the success path behavior is identical (same target,
2s cadence, and `attempts` budget for the progress poll); the only behavioral change is
that transient lookup errors during the wait are retried rather than fatal.

## Testing

- `go build ./op-devstack/...`, `go vet ./op-devstack/dsl/`, `gofmt` — clean.
- `just lint-go` — 0 issues, `go mod tidy -diff` clean.
- CI passes on this PR.
