### PR TITLE
kona: Reduce cardinality of exposed metrics

### DIFF
--- a/rust/kona/crates/node/gossip/src/driver.rs
+++ b/rust/kona/crates/node/gossip/src/driver.rs
@@ -261,7 +261,7 @@ where
 
         if self.swarm.connected_peers().any(|p| p == &peer_id) {
             debug!(target: "gossip", peer=?addr, "Already connected to peer, not dialing");
-            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "already_connected", "peer" => peer_id.to_string());
+            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "already_connected");
             return;
         }
 
@@ -274,12 +274,12 @@ where
             Ok(_) => {
                 trace!(target: "gossip", peer=?addr, "Dialed peer");
                 self.connection_gate.dialed(&addr);
-                kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER, "peer" => peer_id.to_string());
+                kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER);
             }
             Err(e) => {
                 error!(target: "gossip", "Failed to connect to peer: {:?}", e);
                 self.connection_gate.remove_dial(&peer_id);
-                kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "connection_error", "error" => e.to_string(), "peer" => peer_id.to_string());
+                kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "connection_error");
             }
         }
     }
@@ -302,13 +302,7 @@ where
 
                 // Record the peer score in the metrics if available.
                 if let Some(_peer_score) = self.behaviour_mut().gossipsub.peer_score(&peer) {
-                    kona_macros::record!(
-                        histogram,
-                        crate::Metrics::PEER_SCORES,
-                        "peer",
-                        peer.to_string(),
-                        _peer_score
-                    );
+                    kona_macros::record!(histogram, crate::Metrics::PEER_SCORES, _peer_score);
                 }
 
                 let pings = Arc::clone(&self.ping);
@@ -379,11 +373,11 @@ where
             }
             libp2p::gossipsub::Event::SlowPeer { peer_id, .. } => {
                 trace!(target: "gossip", "Slow peer: {:?}", peer_id);
-                kona_macros::inc!(gauge, crate::Metrics::GOSSIP_EVENT, "type" => "slow_peer", "peer" => peer_id.to_string());
+                kona_macros::inc!(gauge, crate::Metrics::GOSSIP_EVENT, "type" => "slow_peer");
             }
             libp2p::gossipsub::Event::GossipsubNotSupported { peer_id } => {
                 trace!(target: "gossip", "Peer: {:?} does not support gossipsub", peer_id);
-                kona_macros::inc!(gauge, crate::Metrics::GOSSIP_EVENT, "type" => "not_supported", "peer" => peer_id.to_string());
+                kona_macros::inc!(gauge, crate::Metrics::GOSSIP_EVENT, "type" => "not_supported");
             }
         }
         None
@@ -398,12 +392,7 @@ where
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 let peer_count = self.swarm.connected_peers().count();
                 info!(target: "gossip", "Connection established: {:?} | Peer Count: {}", peer_id, peer_count);
-                kona_macros::inc!(
-                    gauge,
-                    crate::Metrics::GOSSIPSUB_CONNECTION,
-                    "type" => "connected",
-                    "peer" => peer_id.to_string(),
-                );
+                kona_macros::inc!(gauge, crate::Metrics::GOSSIPSUB_CONNECTION, "type" => "connected");
                 kona_macros::set!(gauge, crate::Metrics::GOSSIP_PEER_COUNT, peer_count as f64);
 
                 self.peer_connection_start.insert(peer_id, Instant::now());
@@ -417,30 +406,21 @@ where
                 kona_macros::inc!(
                     gauge,
                     crate::Metrics::GOSSIPSUB_CONNECTION,
-                    "type" => "outgoing_error",
-                    "peer" => _peer_id.map(|p| p.to_string()).unwrap_or_default()
+                    "type" => "outgoing_error"
                 );
             }
-            SwarmEvent::IncomingConnectionError {
-                error, connection_id: _connection_id, ..
-            } => {
+            SwarmEvent::IncomingConnectionError { error, .. } => {
                 debug!(target: "gossip", "Incoming connection error: {:?}", error);
                 kona_macros::inc!(
                     gauge,
                     crate::Metrics::GOSSIPSUB_CONNECTION,
-                    "type" => "incoming_error",
-                    "connection_id" => _connection_id.to_string()
+                    "type" => "incoming_error"
                 );
             }
             SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
                 let peer_count = self.swarm.connected_peers().count();
                 warn!(target: "gossip", ?peer_id, ?cause, peer_count, "Connection closed");
-                kona_macros::inc!(
-                    gauge,
-                    crate::Metrics::GOSSIPSUB_CONNECTION,
-                    "type" => "closed",
-                    "peer" => peer_id.to_string()
-                );
+                kona_macros::inc!(gauge, crate::Metrics::GOSSIPSUB_CONNECTION, "type" => "closed");
                 kona_macros::set!(gauge, crate::Metrics::GOSSIP_PEER_COUNT, peer_count as f64);
 
                 // Record the total connection duration.
@@ -455,13 +435,7 @@ where
 
                 // Record the peer score in the metrics if available.
                 if let Some(_peer_score) = self.behaviour_mut().gossipsub.peer_score(&peer_id) {
-                    kona_macros::record!(
-                        histogram,
-                        crate::Metrics::PEER_SCORES,
-                        "peer",
-                        peer_id.to_string(),
-                        _peer_score
-                    );
+                    kona_macros::record!(histogram, crate::Metrics::PEER_SCORES, _peer_score);
                 }
 
                 let pings = Arc::clone(&self.ping);

--- a/rust/kona/crates/node/gossip/src/gater.rs
+++ b/rust/kona/crates/node/gossip/src/gater.rs
@@ -218,7 +218,7 @@ impl ConnectionGate for ConnectionGater {
         // Cannot dial a peer that is already being dialed.
         if self.current_dials.contains(&peer_id) {
             debug!(target: "gossip", peer=?addr, "Already dialing peer, not dialing");
-            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "already_dialing", "peer" => peer_id.to_string());
+            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "already_dialing");
             return Err(DialError::AlreadyDialing { peer_id });
         }
 
@@ -230,14 +230,14 @@ impl ConnectionGate for ConnectionGater {
         if !protected && self.dial_threshold_reached(addr) && !self.dial_period_expired(addr) {
             debug!(target: "gossip", peer=?addr, "Dial threshold reached, not dialing");
             self.connectedness.insert(peer_id, Connectedness::CannotConnect);
-            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "threshold_reached", "peer" => peer_id.to_string());
+            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "threshold_reached");
             return Err(DialError::ThresholdReached { addr: addr.clone() });
         }
 
         // If the peer is blocked, do not dial.
         if self.blocked_peers.contains(&peer_id) {
             debug!(target: "gossip", peer=?addr, "Peer is blocked, not dialing");
-            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "blocked_peer", "peer" => peer_id.to_string());
+            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "blocked_peer");
             return Err(DialError::PeerBlocked { peer_id });
         }
 
@@ -262,14 +262,14 @@ impl ConnectionGate for ConnectionGater {
         if self.blocked_addrs.contains(&ip_addr) {
             debug!(target: "gossip", peer=?addr, "Address is blocked, not dialing");
             self.connectedness.insert(peer_id, Connectedness::CannotConnect);
-            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "blocked_address", "peer" => peer_id.to_string());
+            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "blocked_address");
             return Err(DialError::AddressBlocked { ip: ip_addr });
         }
 
         // If address lies in any blocked subnets, do not dial.
         if self.check_ip_in_blocked_subnets(&ip_addr) {
             debug!(target: "gossip", ip=?ip_addr, "IP address is in a blocked subnet, not dialing");
-            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "blocked_subnet", "peer" => peer_id.to_string());
+            kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER_ERROR, "type" => "blocked_subnet");
             return Err(DialError::SubnetBlocked { ip: ip_addr });
         }
 

--- a/rust/kona/crates/node/service/src/actors/network/handler.rs
+++ b/rust/kona/crates/node/service/src/actors/network/handler.rs
@@ -43,13 +43,7 @@ impl NetworkHandler {
                     self.gossip.swarm.behaviour().gossipsub.peer_score(peer_id).unwrap_or_default();
 
                 // Record the peer score in the metrics.
-                kona_macros::record!(
-                    histogram,
-                    kona_gossip::Metrics::PEER_SCORES,
-                    "peer",
-                    peer_id.to_string(),
-                    score
-                );
+                kona_macros::record!(histogram, kona_gossip::Metrics::PEER_SCORES, score);
 
                 if score < ban_peers.ban_threshold {
                     return Some(*peer_id);


### PR DESCRIPTION
See https://github.com/ethereum-optimism/optimism/issues/19927

The cardinality of the following metrics are always increasing, making fetching metrics from kona more and more painful overtime:
    919 kona_node_dial_peer_error
   1538 kona_node_peer_scores_count
   1538 kona_node_peer_scores_sum
   1711 kona_node_dial_peer
   1808 kona_node_gossip_events
  10766 kona_node_peer_scores
2078662 kona_node_gossipsub_connection

Let's just drop the unique labels.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
