### PR TITLE
fix(nuts): key NUT bundle lock entry by the lagoon fork

### DIFF
--- a/op-core/nuts/fork_lock.toml
+++ b/op-core/nuts/fork_lock.toml
@@ -6,7 +6,7 @@
   hash = "sha256:08f5df36f7ff29a9421ab84beebe96684a7455df9a5d234a2468613a4008ad91"
   commit = "f2e5bfe4a502788d33d7914d2d5cd42793c0bce5"
 
-[interop]
+[lagoon]
   bundle = "op-core/nuts/bundles/interop_nut_bundle.json"
   hash = "sha256:2124ce31c0947cac15f00114214dd4354848f7b4642ff2d12ebb3f94b28cc989"
   commit = "fa9974a2cd38d9e7633a12f9024d52f41de55f86"

--- a/packages/contracts-bedrock/scripts/go-ffi/nut_bundles_test.go
+++ b/packages/contracts-bedrock/scripts/go-ffi/nut_bundles_test.go
@@ -17,14 +17,14 @@ func TestOrderedNUTBundlesFromLocks(t *testing.T) {
 	writeBundle(t, root, "op-core/nuts/bundles/interop_nut_bundle.json")
 
 	bundles, err := orderedNUTBundlesFromLocks(nuts.ForkLock{
-		"interop": {Bundle: "op-core/nuts/bundles/interop_nut_bundle.json"},
-		"karst":   {Bundle: "op-core/nuts/bundles/karst_nut_bundle.json"},
+		"lagoon": {Bundle: "op-core/nuts/bundles/interop_nut_bundle.json"},
+		"karst":  {Bundle: "op-core/nuts/bundles/karst_nut_bundle.json"},
 	}, root)
 
 	require.NoError(t, err)
 	require.Equal(t, []NUTBundleEncoded{
 		{Fork: "karst", Path: "../../op-core/nuts/bundles/karst_nut_bundle.json"},
-		{Fork: "interop", Path: "../../op-core/nuts/bundles/interop_nut_bundle.json"},
+		{Fork: "lagoon", Path: "../../op-core/nuts/bundles/interop_nut_bundle.json"},
 	}, bundles)
 }
 
@@ -105,7 +105,7 @@ func TestNUTBundleABIRoundTrip(t *testing.T) {
 	args := abi.Arguments{{Type: nutBundleType}}
 	original := []NUTBundleEncoded{
 		{Fork: "karst", Path: "../../op-core/nuts/bundles/karst_nut_bundle.json"},
-		{Fork: "interop", Path: "../../op-core/nuts/bundles/interop_nut_bundle.json"},
+		{Fork: "lagoon", Path: "../../op-core/nuts/bundles/interop_nut_bundle.json"},
 	}
 
 	encoded, err := args.Pack(original)


### PR DESCRIPTION
The Lagoon hardfork rename (ethereum-optimism/optimism#21105) renamed the `interop` fork to `lagoon` and made `go-ffi nut-bundles` validate `fork_lock.toml` keys against `forks.All`, but left the lock entry keyed `[interop]`. Validation then fails with `locked fork "interop" is not in forks.All`, breaking the `contracts-bedrock-tests-l2-fork` job on develop and on every PR branched from it.

Rekeys the entry to `[lagoon]`. The bundle file/label intentionally stays `interop_nut_bundle` — #21105 deliberately decoupled the bundle's concept-level label from the fork name (`upgrade_transaction.go`) to preserve source-hash determinism with kona's codegen, so only the lock *key* needed fixing.