### PR TITLE
build: enforce locked dependencies in Docker builds

### DIFF
--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -1,5 +1,9 @@
 FROM golang:1.24.13-alpine3.22 AS builder
 
+# Enforce that builds use the committed go.mod/go.sum exactly and never
+# silently mutate them. Fails the build if the lockfile is out of date.
+ENV GOFLAGS=-mod=readonly
+
 # Install just from GitHub releases to match the version pinned in mise.toml.
 # The Alpine package is too old and doesn't support the [script] attribute
 # used in testdata justfiles.

--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -2,6 +2,10 @@ ARG GO_VERSION=1.24.10-alpine3.21
 ARG EXPORT_TARGET=current
 FROM golang:${GO_VERSION} AS src
 
+# Enforce that builds use the committed go.mod/go.sum exactly and never
+# silently mutate them. Fails the build if the lockfile is out of date.
+ENV GOFLAGS=-mod=readonly
+
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash just
 
 COPY ./go.mod /app/go.mod

--- a/op-program/Dockerfile.vmcompat
+++ b/op-program/Dockerfile.vmcompat
@@ -7,6 +7,10 @@ FROM golang:${GO_VERSION} AS builder
 ARG VM_TARGET
 ARG VM_COMPAT_TASK
 
+# Enforce that builds use the committed go.mod/go.sum exactly and never
+# silently mutate them. Fails the build if the lockfile is out of date.
+ENV GOFLAGS=-mod=readonly
+
 # Install dependencies
 RUN apk add --no-cache make git bash jq llvm just
 

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -52,6 +52,10 @@ RUN forge --version
 # We may be cross-building for another platform. Specify which platform we need as builder.
 FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.22 AS builder
 
+# Enforce that builds use the committed go.mod/go.sum exactly and never
+# silently mutate them. Fails the build if the lockfile is out of date.
+ENV GOFLAGS=-mod=readonly
+
 RUN apk add --no-cache curl tar gzip make gcc musl-dev linux-headers git jq yq-go bash just
 
 ARG TARGETARCH
@@ -176,6 +180,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 # Uses BUILDPLATFORM so it runs natively (no QEMU). Contract artifacts are platform-independent.
 FROM --platform=$BUILDPLATFORM golang:1.24.13-bookworm AS op-deployer-contracts
 ARG BUILDARCH
+ENV GOFLAGS=-mod=readonly
 RUN apt-get update && apt-get install -y --no-install-recommends curl jq git && rm -rf /var/lib/apt/lists/*
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
@@ -254,7 +259,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,targe
     *) echo "Unsupported architecture: $TARGETARCH" && exit 1 ;; \
   esac && \
   rustup target add "$RUST_TARGET" && \
-  RUSTFLAGS="-C target-cpu=generic" cargo build --bin kona-host --profile release-perf --target "$RUST_TARGET" && \
+  RUSTFLAGS="-C target-cpu=generic" cargo build --locked --bin kona-host --profile release-perf --target "$RUST_TARGET" && \
   cp "/rust/target/$RUST_TARGET/release-perf/kona-host" /kona-host
 
 FROM dhi.io/alpine-base:3.23 AS cannon-target

--- a/rust/kona/docker/apps/kona_app_generic.dockerfile
+++ b/rust/kona/docker/apps/kona_app_generic.dockerfile
@@ -81,13 +81,13 @@ FROM build-entrypoint AS builder
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer!
-RUN RUSTFLAGS="-C target-cpu=generic" cargo chef cook --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}" --recipe-path recipe.json
+RUN RUSTFLAGS="-C target-cpu=generic" cargo chef cook --bin "${BIN_TARGET}" --locked --profile "${BUILD_PROFILE}" --recipe-path recipe.json
 
 # Build application. This step will systematically trigger a cache invalidation if the source code changes.
 COPY --from=app-setup /workspace .
 # Build the application binary on the selected tag. Since we build the external dependencies in the previous step,
 # this step will reuse the target directory from the previous step.
-RUN RUSTFLAGS="-C target-cpu=generic" cargo auditable build --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}"
+RUN RUSTFLAGS="-C target-cpu=generic" cargo auditable build --bin "${BIN_TARGET}" --locked --profile "${BUILD_PROFILE}"
 
 # Export stage
 FROM chainguard/wolfi-base:latest AS export-stage

--- a/rust/op-rbuilder/Dockerfile
+++ b/rust/op-rbuilder/Dockerfile
@@ -86,7 +86,7 @@ COPY --from=planner /workspace/op-rbuilder/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    cargo chef cook --release --recipe-path recipe.json
+    cargo chef cook --release --locked --recipe-path recipe.json
 COPY . .
 
 
@@ -96,7 +96,7 @@ ARG FEATURES
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    cargo build --release --features="$FEATURES" --package=${RBUILDER_BIN}
+    cargo build --release --locked --features="$FEATURES" --package=${RBUILDER_BIN}
 
 #
 # Reproducible builder container (deterministic source-date-epoch, no caching, no incremental builds)

--- a/rust/op-rbuilder/crates/tdx-quote-provider/Dockerfile
+++ b/rust/op-rbuilder/crates/tdx-quote-provider/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 
 RUN apt-get update && apt-get install -y libssl3 libtss2-dev
 
-RUN cargo build --release --features="$FEATURES" --package=${BINARY}
+RUN cargo build --release --locked --features="$FEATURES" --package=${BINARY}
 
 FROM debian:12-slim
 WORKDIR /app

--- a/rust/op-reth/DockerfileOp
+++ b/rust/op-reth/DockerfileOp
@@ -27,10 +27,10 @@ ENV FEATURES=$FEATURES
 # Allow cook to fail on patched crates (op-alloy-network) whose crates.io
 # version conflicts with alloy 1.8.  All other dependencies are still cached.
 # The real build below uses the workspace [patch.crates-io] sources.
-RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json --manifest-path /app/op-reth/bin/Cargo.toml || true
+RUN cargo chef cook --profile $BUILD_PROFILE --locked --features "$FEATURES" --recipe-path recipe.json --manifest-path /app/op-reth/bin/Cargo.toml || true
 
 COPY . .
-RUN cargo auditable build --profile $BUILD_PROFILE --features "$FEATURES" --bin op-reth --manifest-path /app/op-reth/bin/Cargo.toml
+RUN cargo auditable build --profile $BUILD_PROFILE --locked --features "$FEATURES" --bin op-reth --manifest-path /app/op-reth/bin/Cargo.toml
 
 RUN ls -la /app/target/$BUILD_PROFILE/op-reth
 RUN cp /app/target/$BUILD_PROFILE/op-reth /app/op-reth

--- a/rust/rollup-boost/Dockerfile
+++ b/rust/rollup-boost/Dockerfile
@@ -66,7 +66,7 @@ COPY --from=planner /workspace/rollup-boost/recipe.json recipe.json
 
 RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     PROFILE_FLAG=$([ "$RELEASE" = "true" ] && echo "--release" || echo "") && \
-    cargo chef cook $PROFILE_FLAG --recipe-path recipe.json
+    cargo chef cook $PROFILE_FLAG --locked --recipe-path recipe.json
 
 COPY . .
 
@@ -75,7 +75,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     PROFILE_FLAG=$([ "$RELEASE" = "true" ] && echo "--release" || echo "") && \
     TARGET_DIR=$([ "$RELEASE" = "true" ] && echo "release" || echo "debug") && \
-    cargo build $PROFILE_FLAG --features="$FEATURES" --package=${SERVICE_NAME}; \
+    cargo build $PROFILE_FLAG --locked --features="$FEATURES" --package=${SERVICE_NAME}; \
     cp target/$TARGET_DIR/${SERVICE_NAME} /tmp/final_binary
 
 #

--- a/rust/rollup-boost/crates/websocket-proxy/Dockerfile
+++ b/rust/rollup-boost/crates/websocket-proxy/Dockerfile
@@ -7,7 +7,7 @@ ARG FEATURES
 
 COPY . .
 
-RUN cargo build --release --features="$FEATURES" --package=${BINARY}
+RUN cargo build --release --locked --features="$FEATURES" --package=${BINARY}
 
 FROM gcr.io/distroless/cc-debian12
 WORKDIR /app


### PR DESCRIPTION
## Summary

Make every Docker image build from the committed dependency lockfiles instead of resolving versions at build time. This guarantees the bytes we ship match the bytes pinned in git, and fails fast if a lockfile drifts.

- **Go**: set `GOFLAGS=-mod=readonly` in every Go Docker builder stage. Builds now fail if `go.mod`/`go.sum` are out of date and never silently mutate them. The env propagates through `just` recipes into `go build`, so the `just` targets themselves need no change. Covers:
  - `ops/docker/op-stack-go/Dockerfile` (all primary Go service images + op-deployer contracts stage)
  - `op-program/Dockerfile.repro` (fault-proof prestate; reproducibility is verified in CI)
  - `op-program/Dockerfile.vmcompat` (VM-compat prestate analysis)
  - `cannon/Dockerfile.diff` (cannon diff testing)
- **Rust**: add `--locked` to every app build (`cargo build` / `cargo chef cook` / `cargo auditable build`) across:
  - `ops/docker/op-stack-go/Dockerfile` (kona-host)
  - `rust/kona/docker/apps/kona_app_generic.dockerfile` (kona-host / kona-node / kona-client bake images)
  - `rust/op-rbuilder/Dockerfile`
  - `rust/op-rbuilder/crates/tdx-quote-provider/Dockerfile`
  - `rust/op-reth/DockerfileOp`
  - `rust/rollup-boost/Dockerfile`
  - `rust/rollup-boost/crates/websocket-proxy/Dockerfile`

  Builds now fail if `Cargo.lock` would change.

Lockfiles (`go.sum`, `Cargo.lock`) are already committed; this change only enforces them at Docker build time. No dependency versions change.

## Test plan

- [ ] Docker images build successfully in CI with locked dependencies.
- [ ] Confirm a deliberately stale lockfile fails the build (manual spot check).