### PR TITLE
ci: gate contracts on fork-lock drift

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
           command: .circleci/scripts/collect-params.sh detect
           environment:
             c-rust_files_changed: "^rust/"
-            c-contracts_changed: "^(packages/contracts-bedrock|\\.circleci|\\.github|ops/check-changed)/|^(package\\.json|mise\\.toml)$"
+            c-contracts_changed: "^(packages/contracts-bedrock|op-core/forks|op-core/nuts|\\.circleci|\\.github|ops/check-changed)/|^(package\\.json|mise\\.toml)$"
             c-docs_changes_detected: "^docs/public-docs/"
             c-rust_changes_detected: "^(rust|op-e2e|\\.circleci)/"
       # Safer "docs-only" detection: true iff EVERY changed file is under docs/public-docs/.

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3148,6 +3148,7 @@ workflows:
             - contracts-bedrock-tests-heavy-fuzz-modified main: terminal
             - contracts-bedrock-coverage main: terminal
             - contracts-bedrock-tests-upgrade op-mainnet main: terminal
+            - contracts-bedrock-tests-l2-fork op-mainnet: terminal
             - contracts-bedrock-checks-fast-feature-tests: terminal
           context:
             - circleci-api-token


### PR DESCRIPTION
Follow up to #21224.

#21224 fixes the immediate breakage (the `[interop]` → `[lagoon]` lock key). This PR closes the two CI gaps that let that breakage merge in the first place:

1. **Path filter** — `contracts_changed` didn't watch `op-core/forks` or `op-core/nuts`, which the contracts go-ffi tooling depends on. A fork rename therefore ran only `contracts-feature-tests-short` on the PR, so the l2-fork job and `check-nut-locks` never executed. Added both paths.
2. **Required gate** — even in the merge queue (which runs the full suite), `contracts-bedrock-tests-l2-fork op-mainnet` failed but wasn't in `required-contracts-ci`'s `requires:` list, so it never blocked the merge. Added it (consistent with `contracts-bedrock-tests-upgrade op-mainnet`, already required and also RPC-dependent).

Non-contracts PRs are unaffected: when the path filter skips contracts, `contracts-feature-tests-short` still satisfies the `required-contracts-ci` status via `always-succeed`.

Validated locally with `circleci config validate` against the merged continuation config.