### PR TITLE
fix(rollup-boost): ship the real binary from the Docker build

### DIFF
--- a/rust/rollup-boost/.dockerignore
+++ b/rust/rollup-boost/.dockerignore
@@ -17,7 +17,6 @@ integration_logs
 
 # Cargo artifacts
 **/.cargo
-**/Cargo.lock
 
 # Documentation
 **/*.md

--- a/rust/rollup-boost/Dockerfile
+++ b/rust/rollup-boost/Dockerfile
@@ -75,8 +75,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     PROFILE_FLAG=$([ "$RELEASE" = "true" ] && echo "--release" || echo "") && \
     TARGET_DIR=$([ "$RELEASE" = "true" ] && echo "release" || echo "debug") && \
-    cargo build $PROFILE_FLAG --locked --features="$FEATURES" --package=${SERVICE_NAME}; \
-    cp target/$TARGET_DIR/${SERVICE_NAME} /tmp/final_binary
+    cargo build $PROFILE_FLAG --locked --features="$FEATURES" --package=${SERVICE_NAME} && \
+    cp "target/${TARGET_DIR}/${SERVICE_NAME}" /tmp/final_binary && \
+    test -n "$('/tmp/final_binary' --help 2>&1)"
 
 #
 # Runtime container


### PR DESCRIPTION
## Problem

The `rollup-boost` Docker image (now built/pushed by CI per #21229) ships a **~435 KB cargo-chef stub** — an empty `fn main(){}` with `rollup_boost::main` but none of its dependencies (no clap/tokio/alloy, no `--l2-url`, no CLI). It exits `0` immediately with no output, so any stack using it (e.g. local SDM/`anton-sdm` devnets) loses its sequencer engine the moment the container "starts."

## Root cause

`rust/rollup-boost/.dockerignore` excluded `**/Cargo.lock`, so the lock never entered the build context. With `--locked` (enabled in #21225), the builder's real `cargo build` then fails:

```
error: cannot update the lock file /workspace/rollup-boost/Cargo.lock because --locked was passed to prevent this
```

…because there's no committed lock to honor. The builder joined the build and the `cp` with `;` instead of `&&`:

```dockerfile
cargo build ... --package=${SERVICE_NAME}; \
cp target/$TARGET_DIR/${SERVICE_NAME} /tmp/final_binary
```

so the failed build still `cp`-ed cargo-chef's leftover **dummy** binary out of `target/`, and the image build "succeeded" with a stub. `op-reth` and `op-rbuilder` don't ignore `Cargo.lock`, which is why only `rollup-boost` was affected.

## Fix

- Stop ignoring `Cargo.lock` in `rust/rollup-boost/.dockerignore` so `--locked` has the committed lock.
- Use `&&` instead of `;` so a failed build fails the image instead of `cp`-ing a stale binary, and assert the built binary has a working CLI (`test -n "$(... --help)"`) as defense-in-depth against ever shipping a silent stub again.

## Verification

Reproduced locally from the develop Dockerfile: the unpatched build produces the identical 435 KB stub (0 `--l2-url` strings, silent `--help`, exit 0); a build with `&&` but the lock still ignored fails loudly at the `--locked` step; un-ignoring `Cargo.lock` lets the real binary build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)