### PR TITLE
feat(op-reth): interop filter decision metrics (allow/reject + infra-failure split)

### DIFF
--- a/rust/op-alloy/crates/rpc-types/src/error.rs
+++ b/rust/op-alloy/crates/rpc-types/src/error.rs
@@ -54,6 +54,11 @@ pub enum SuperchainDAError {
     #[error("data is already known and didn't change anything")]
     IneffectiveData = -320601,
 
+    /// Happens when the interop filter has failsafe enabled and is rejecting all interop
+    /// (executing-message) transactions until failsafe is cleared.
+    #[error("interop filter failsafe is enabled")]
+    Failsafe = -320602,
+
     //-------------------------- -3209XX FAILED_PRECONDITION errors ----------------------------//
     /// Happens when you try to add data to the DB, but it does not actually fit onto
     /// the latest data.

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -125,17 +125,25 @@ impl InteropFilterClient {
             )
             .await
         {
-            // Distinguish a legitimate rejection (the filter answered and said no) from an infra
-            // failure (we never got a trustworthy answer), so an outage does not masquerade as a
-            // flood of rejections in the allow-rate signal.
+            // Classify the failure: the filter answered "no" (legitimate rejection), it is in
+            // failsafe, or we never got a trustworthy answer (infra failure) — so an outage does
+            // not masquerade as a flood of rejections in the allow-rate signal.
             self.inner.metrics.record_decision(validation_failure_result(&err));
-            if let InteropTxValidatorError::InvalidEntry(reason) = &err {
-                self.inner.metrics.record_validation_error(reason);
-            } else {
-                self.inner.metrics.record_filter_error(&err);
+            match &err {
+                InteropTxValidatorError::InvalidEntry(reason) => {
+                    self.inner.metrics.record_validation_error(reason);
+                }
+                // Single-cause outcome, counted via the decision metric; no breakdown.
+                InteropTxValidatorError::FailsafeEnabled => {}
+                _ => self.inner.metrics.record_filter_error(&err),
             }
             trace!(target: "txpool", hash=%hash, err=%err, "Cross chain transaction invalid");
-            return Some(Err(InvalidCrossTx::ValidationError(err)));
+            // A per-tx failsafe response maps to the same rejection as the cached fast-path,
+            // covering the race where failsafe turns on between the poll and this check.
+            return Some(Err(match err {
+                InteropTxValidatorError::FailsafeEnabled => InvalidCrossTx::FailsafeEnabled,
+                other => InvalidCrossTx::ValidationError(other),
+            }));
         }
         self.inner.metrics.record_decision(RESULT_ALLOWED);
         Some(Ok(()))

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -3,7 +3,11 @@
 use crate::{
     InvalidCrossTx,
     interop_filter::{
-        ExecutingDescriptor, InteropTxValidatorError, metrics::InteropMetrics,
+        ExecutingDescriptor, InteropTxValidatorError,
+        metrics::{
+            InteropMetrics, RESULT_ALLOWED, RESULT_REJECTED_FAILSAFE,
+            RESULT_REJECTED_PRE_INTEROP_HARDFORK, validation_failure_result,
+        },
         parse_access_list_items_to_inbox_entries,
     },
 };
@@ -104,11 +108,13 @@ impl InteropFilterClient {
         // Interop check
         if !is_interop_active {
             // No cross chain tx allowed before interop
+            self.inner.metrics.record_decision(RESULT_REJECTED_PRE_INTEROP_HARDFORK);
             return Some(Err(InvalidCrossTx::CrossChainTxPreInterop));
         }
 
         // Fast-path: reject immediately if failsafe is active (no RPC round-trip)
         if self.is_failsafe_enabled() {
+            self.inner.metrics.record_decision(RESULT_REJECTED_FAILSAFE);
             return Some(Err(InvalidCrossTx::FailsafeEnabled));
         }
 
@@ -119,10 +125,19 @@ impl InteropFilterClient {
             )
             .await
         {
-            self.inner.metrics.increment_metrics_for_error(&err);
+            // Distinguish a legitimate rejection (the filter answered and said no) from an infra
+            // failure (we never got a trustworthy answer), so an outage does not masquerade as a
+            // flood of rejections in the allow-rate signal.
+            self.inner.metrics.record_decision(validation_failure_result(&err));
+            if let InteropTxValidatorError::InvalidEntry(reason) = &err {
+                self.inner.metrics.record_validation_error(reason);
+            } else {
+                self.inner.metrics.record_filter_error(&err);
+            }
             trace!(target: "txpool", hash=%hash, err=%err, "Cross chain transaction invalid");
             return Some(Err(InvalidCrossTx::ValidationError(err)));
         }
+        self.inner.metrics.record_decision(RESULT_ALLOWED);
         Some(Ok(()))
     }
 

--- a/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
@@ -53,8 +53,8 @@ impl InteropTxValidatorError {
         E: error::Error + Send + Sync + 'static,
     {
         // Try to extract a known error variant from the RPC error code.
-        if let Some(error_payload) = err.as_error_resp()
-            && let Some(known) = Self::from_error_code(error_payload.code as i32)
+        if let Some(error_payload) = err.as_error_resp() &&
+            let Some(known) = Self::from_error_code(error_payload.code as i32)
         {
             return known;
         }

--- a/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
@@ -2,6 +2,10 @@ use alloy_json_rpc::RpcError;
 use core::error;
 use op_alloy_rpc_types::SuperchainDAError;
 
+/// Dedicated JSON-RPC error code the interop filter returns when failsafe is enabled.
+/// See ethereum-optimism/optimism#21205 (previously shared the generic invalid-params code).
+const FAILSAFE_ERROR_CODE: i32 = -320602;
+
 /// Failures occurring during validation of inbox entries.
 #[derive(thiserror::Error, Debug)]
 pub enum InteropTxValidatorError {
@@ -12,6 +16,11 @@ pub enum InteropTxValidatorError {
     /// Message does not satisfy validation requirements
     #[error(transparent)]
     InvalidEntry(#[from] SuperchainDAError),
+
+    /// The interop filter rejected the request because failsafe is enabled. Distinct from a
+    /// transport/server error so it is counted as a failsafe rejection, not an infra failure.
+    #[error("interop filter failsafe is enabled")]
+    FailsafeEnabled,
 
     /// Catch-all variant.
     #[error("interop filter server error: {0}")]
@@ -27,6 +36,15 @@ impl InteropTxValidatorError {
         Self::Other(Box::new(err))
     }
 
+    /// Maps a JSON-RPC error code to a known interop filter error variant, if recognized.
+    /// Returns `None` for unknown codes (the caller falls back to [`Other`](Self::Other)).
+    fn from_error_code(code: i32) -> Option<Self> {
+        if code == FAILSAFE_ERROR_CODE {
+            return Some(Self::FailsafeEnabled);
+        }
+        SuperchainDAError::try_from(code).ok().map(Self::InvalidEntry)
+    }
+
     /// This function will parse the error code to determine if it matches
     /// one of the known interop filter errors, and return the corresponding
     /// error variant. Otherwise, it returns a generic [`Other`](Self::Other) error.
@@ -34,17 +52,40 @@ impl InteropTxValidatorError {
     where
         E: error::Error + Send + Sync + 'static,
     {
-        // Try to extract error details from the RPC error
-        if let Some(error_payload) = err.as_error_resp() {
-            let code = error_payload.code as i32;
-
-            // Try to convert the error code to an SuperchainDAError variant
-            if let Ok(invalid_entry) = SuperchainDAError::try_from(code) {
-                return Self::InvalidEntry(invalid_entry);
-            }
+        // Try to extract a known error variant from the RPC error code.
+        if let Some(error_payload) = err.as_error_resp()
+            && let Some(known) = Self::from_error_code(error_payload.code as i32)
+        {
+            return known;
         }
 
         // Default to generic error
         Self::Other(Box::new(err))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failsafe_code_maps_to_failsafe_variant() {
+        assert!(matches!(
+            InteropTxValidatorError::from_error_code(FAILSAFE_ERROR_CODE),
+            Some(InteropTxValidatorError::FailsafeEnabled)
+        ));
+    }
+
+    #[test]
+    fn da_error_codes_map_to_invalid_entry() {
+        assert!(matches!(
+            InteropTxValidatorError::from_error_code(-320600),
+            Some(InteropTxValidatorError::InvalidEntry(SuperchainDAError::ConflictingData))
+        ));
+    }
+
+    #[test]
+    fn unknown_code_is_unrecognized() {
+        assert!(InteropTxValidatorError::from_error_code(-32000).is_none());
     }
 }

--- a/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
@@ -2,10 +2,6 @@ use alloy_json_rpc::RpcError;
 use core::error;
 use op_alloy_rpc_types::SuperchainDAError;
 
-/// Dedicated JSON-RPC error code the interop filter returns when failsafe is enabled.
-/// See ethereum-optimism/optimism#21205 (previously shared the generic invalid-params code).
-const FAILSAFE_ERROR_CODE: i32 = -320602;
-
 /// Failures occurring during validation of inbox entries.
 #[derive(thiserror::Error, Debug)]
 pub enum InteropTxValidatorError {
@@ -38,11 +34,15 @@ impl InteropTxValidatorError {
 
     /// Maps a JSON-RPC error code to a known interop filter error variant, if recognized.
     /// Returns `None` for unknown codes (the caller falls back to [`Other`](Self::Other)).
+    ///
+    /// Failsafe shares the [`SuperchainDAError`] code space (`-320602`) but is an operational
+    /// state, not a data-availability rejection, so it maps to its own variant.
     fn from_error_code(code: i32) -> Option<Self> {
-        if code == FAILSAFE_ERROR_CODE {
-            return Some(Self::FailsafeEnabled);
+        match SuperchainDAError::try_from(code) {
+            Ok(SuperchainDAError::Failsafe) => Some(Self::FailsafeEnabled),
+            Ok(invalid_entry) => Some(Self::InvalidEntry(invalid_entry)),
+            Err(_) => None,
         }
-        SuperchainDAError::try_from(code).ok().map(Self::InvalidEntry)
     }
 
     /// This function will parse the error code to determine if it matches
@@ -71,7 +71,7 @@ mod tests {
     #[test]
     fn failsafe_code_maps_to_failsafe_variant() {
         assert!(matches!(
-            InteropTxValidatorError::from_error_code(FAILSAFE_ERROR_CODE),
+            InteropTxValidatorError::from_error_code(SuperchainDAError::Failsafe as i32),
             Some(InteropTxValidatorError::FailsafeEnabled)
         ));
     }

--- a/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
@@ -4,9 +4,31 @@ use crate::interop_filter::InteropTxValidatorError;
 use op_alloy_rpc_types::SuperchainDAError;
 use reth_metrics::{
     Metrics,
-    metrics::{Counter, Gauge, Histogram},
+    metrics::{Gauge, Histogram, counter},
 };
 use std::time::Duration;
+
+/// Fully-qualified name of the per-decision filter outcome counter.
+const FILTER_DECISIONS: &str = "optimism_transaction_pool.interop.filter_decisions_total";
+/// Fully-qualified name of the legitimate-rejection reason breakdown counter.
+const VALIDATION_ERRORS: &str = "optimism_transaction_pool.interop.validation_errors_total";
+/// Fully-qualified name of the infra-failure breakdown counter (filter unreachable / no
+/// trustworthy answer), kept separate from legitimate rejections so an outage does not look
+/// like a flood of rejected transactions.
+const FILTER_ERRORS: &str = "optimism_transaction_pool.interop.filter_errors_total";
+
+/// `result` label values for [`InteropMetrics::record_decision`]. Every transaction that reaches
+/// the interop filter records exactly one of these.
+pub(crate) const RESULT_ALLOWED: &str = "allowed";
+pub(crate) const RESULT_REJECTED_FAILSAFE: &str = "rejected_failsafe";
+/// Rejected because the interop hardfork is not yet active at this block (a cross-chain tx cannot
+/// exist pre-activation). A local gate — the filter is not contacted.
+pub(crate) const RESULT_REJECTED_PRE_INTEROP_HARDFORK: &str = "rejected_pre_interop_hardfork";
+/// The filter answered and rejected the tx (a genuine invalid-entry verdict).
+pub(crate) const RESULT_REJECTED_VALIDATION: &str = "rejected_validation";
+/// The filter could not be reached or did not return a trustworthy answer (timeout / transport /
+/// server error). The tx is still rejected, but this is an infra failure, not the chain's fault.
+pub(crate) const RESULT_ERRORED: &str = "errored";
 
 /// Optimism interop txpool metrics.
 #[derive(Metrics, Clone)]
@@ -14,29 +36,6 @@ use std::time::Duration;
 pub struct InteropMetrics {
     /// How long it takes to query the interop filter in the Optimism transaction pool.
     pub(crate) interop_query_latency: Histogram,
-
-    /// Counter for the number of times data was skipped
-    pub(crate) skipped_data_count: Counter,
-    /// Counter for the number of times an unknown chain was encountered
-    pub(crate) unknown_chain_count: Counter,
-    /// Counter for the number of times conflicting data was encountered
-    pub(crate) conflicting_data_count: Counter,
-    /// Counter for the number of times ineffective data was encountered
-    pub(crate) ineffective_data_count: Counter,
-    /// Counter for the number of times data was out of order
-    pub(crate) out_of_order_count: Counter,
-    /// Counter for the number of times data was awaiting replacement
-    pub(crate) awaiting_replacement_count: Counter,
-    /// Counter for the number of times data was out of scope
-    pub(crate) out_of_scope_count: Counter,
-    /// Counter for the number of times there was no parent for the first block
-    pub(crate) no_parent_for_first_block_count: Counter,
-    /// Counter for the number of times future data was encountered
-    pub(crate) future_data_count: Counter,
-    /// Counter for the number of times data was missed
-    pub(crate) missed_data_count: Counter,
-    /// Counter for the number of times data corruption was encountered
-    pub(crate) data_corruption_count: Counter,
 
     /// Current interop failsafe state: `1` if failsafe is enabled (all interop txs are
     /// rejected/evicted), `0` if disabled. Refreshed on every failsafe poll.
@@ -56,27 +55,124 @@ impl InteropMetrics {
         self.failsafe_enabled.set(if enabled { 1.0 } else { 0.0 });
     }
 
-    /// Increments the metrics for the given error
-    pub fn increment_metrics_for_error(&self, error: &InteropTxValidatorError) {
-        if let InteropTxValidatorError::InvalidEntry(inner) = error {
-            match inner {
-                SuperchainDAError::SkippedData => self.skipped_data_count.increment(1),
-                SuperchainDAError::UnknownChain => self.unknown_chain_count.increment(1),
-                SuperchainDAError::ConflictingData => self.conflicting_data_count.increment(1),
-                SuperchainDAError::IneffectiveData => self.ineffective_data_count.increment(1),
-                SuperchainDAError::OutOfOrder => self.out_of_order_count.increment(1),
-                SuperchainDAError::AwaitingReplacement => {
-                    self.awaiting_replacement_count.increment(1)
-                }
-                SuperchainDAError::OutOfScope => self.out_of_scope_count.increment(1),
-                SuperchainDAError::NoParentForFirstBlock => {
-                    self.no_parent_for_first_block_count.increment(1)
-                }
-                SuperchainDAError::FutureData => self.future_data_count.increment(1),
-                SuperchainDAError::MissedData => self.missed_data_count.increment(1),
-                SuperchainDAError::DataCorruption => self.data_corruption_count.increment(1),
-                _ => {}
-            }
-        }
+    /// Records a single interop filter decision under the given `result` label.
+    ///
+    /// `result` must be one of the `RESULT_*` constants in this module so the label set stays
+    /// low-cardinality and stable.
+    #[inline]
+    pub fn record_decision(&self, result: &'static str) {
+        counter!(FILTER_DECISIONS, "result" => result).increment(1);
+    }
+
+    /// Records a legitimate validation rejection (the filter answered and rejected the tx), broken
+    /// down by DA `reason`. Always increments exactly once, so `sum(validation_errors_total)`
+    /// equals `filter_decisions_total{result="rejected_validation"}`.
+    pub fn record_validation_error(&self, error: &SuperchainDAError) {
+        counter!(VALIDATION_ERRORS, "reason" => validation_reason(error)).increment(1);
+    }
+
+    /// Records an infra failure where the filter could not return a trustworthy answer, broken
+    /// down by `kind`. Kept separate from [`Self::record_validation_error`] so a filter outage
+    /// does not corrupt the legitimate-rejection signal. Always increments exactly once, so
+    /// `sum(filter_errors_total)` equals `filter_decisions_total{result="errored"}`.
+    pub fn record_filter_error(&self, error: &InteropTxValidatorError) {
+        counter!(FILTER_ERRORS, "kind" => filter_error_kind(error)).increment(1);
+    }
+}
+
+/// Maps a DA validation error to its stable `reason` label for `validation_errors_total`.
+pub(crate) const fn validation_reason(error: &SuperchainDAError) -> &'static str {
+    match error {
+        SuperchainDAError::SkippedData => "skipped_data",
+        SuperchainDAError::UnknownChain => "unknown_chain",
+        SuperchainDAError::ConflictingData => "conflicting_data",
+        SuperchainDAError::IneffectiveData => "ineffective_data",
+        SuperchainDAError::OutOfOrder => "out_of_order",
+        SuperchainDAError::AwaitingReplacement => "awaiting_replacement",
+        SuperchainDAError::OutOfScope => "out_of_scope",
+        SuperchainDAError::NoParentForFirstBlock => "no_parent_for_first_block",
+        SuperchainDAError::FutureData => "future_data",
+        SuperchainDAError::MissedData => "missed_data",
+        SuperchainDAError::DataCorruption => "data_corruption",
+        _ => "other",
+    }
+}
+
+/// Maps an infra failure to its stable `kind` label for `filter_errors_total`. `InvalidEntry` is a
+/// legitimate rejection, not an infra failure, and is never routed here; it (and any transport /
+/// server error) is classified as `other` defensively.
+pub(crate) const fn filter_error_kind(error: &InteropTxValidatorError) -> &'static str {
+    match error {
+        InteropTxValidatorError::Timeout(_) => "timeout",
+        _ => "other",
+    }
+}
+
+/// Maps a filter validation failure to its decision `result` label, separating a legitimate
+/// rejection (the filter answered "no") from an infra failure (no trustworthy answer). This is the
+/// single source of truth for which `result` the error path records.
+pub(crate) const fn validation_failure_result(error: &InteropTxValidatorError) -> &'static str {
+    match error {
+        InteropTxValidatorError::InvalidEntry(_) => RESULT_REJECTED_VALIDATION,
+        _ => RESULT_ERRORED,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn server_error() -> InteropTxValidatorError {
+        InteropTxValidatorError::other(std::io::Error::other("filter unreachable"))
+    }
+
+    #[test]
+    fn validation_reason_maps_every_da_error() {
+        assert_eq!(validation_reason(&SuperchainDAError::SkippedData), "skipped_data");
+        assert_eq!(validation_reason(&SuperchainDAError::UnknownChain), "unknown_chain");
+        assert_eq!(validation_reason(&SuperchainDAError::ConflictingData), "conflicting_data");
+        assert_eq!(validation_reason(&SuperchainDAError::IneffectiveData), "ineffective_data");
+        assert_eq!(validation_reason(&SuperchainDAError::OutOfOrder), "out_of_order");
+        assert_eq!(
+            validation_reason(&SuperchainDAError::AwaitingReplacement),
+            "awaiting_replacement"
+        );
+        assert_eq!(validation_reason(&SuperchainDAError::OutOfScope), "out_of_scope");
+        assert_eq!(
+            validation_reason(&SuperchainDAError::NoParentForFirstBlock),
+            "no_parent_for_first_block"
+        );
+        assert_eq!(validation_reason(&SuperchainDAError::FutureData), "future_data");
+        assert_eq!(validation_reason(&SuperchainDAError::MissedData), "missed_data");
+        assert_eq!(validation_reason(&SuperchainDAError::DataCorruption), "data_corruption");
+        // Unmapped DA variants fall back to a stable catch-all.
+        assert_eq!(validation_reason(&SuperchainDAError::InvalidatedRead), "other");
+    }
+
+    #[test]
+    fn filter_error_kind_distinguishes_timeout_from_other() {
+        assert_eq!(filter_error_kind(&InteropTxValidatorError::Timeout(2)), "timeout");
+        assert_eq!(filter_error_kind(&server_error()), "other");
+        // A legitimate rejection is never routed here, but is defensively classified as `other`.
+        assert_eq!(
+            filter_error_kind(&InteropTxValidatorError::InvalidEntry(
+                SuperchainDAError::SkippedData
+            )),
+            "other"
+        );
+    }
+
+    #[test]
+    fn validation_failure_result_separates_infra_failure_from_rejection() {
+        // The filter answered "no" -> legitimate rejection.
+        assert_eq!(
+            validation_failure_result(&InteropTxValidatorError::InvalidEntry(
+                SuperchainDAError::ConflictingData
+            )),
+            RESULT_REJECTED_VALIDATION
+        );
+        // No trustworthy answer -> infra failure, must not look like a rejection.
+        assert_eq!(validation_failure_result(&InteropTxValidatorError::Timeout(2)), RESULT_ERRORED);
+        assert_eq!(validation_failure_result(&server_error()), RESULT_ERRORED);
     }
 }

--- a/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
@@ -113,6 +113,7 @@ pub(crate) const fn filter_error_kind(error: &InteropTxValidatorError) -> &'stat
 /// single source of truth for which `result` the error path records.
 pub(crate) const fn validation_failure_result(error: &InteropTxValidatorError) -> &'static str {
     match error {
+        InteropTxValidatorError::FailsafeEnabled => RESULT_REJECTED_FAILSAFE,
         InteropTxValidatorError::InvalidEntry(_) => RESULT_REJECTED_VALIDATION,
         _ => RESULT_ERRORED,
     }
@@ -174,5 +175,10 @@ mod tests {
         // No trustworthy answer -> infra failure, must not look like a rejection.
         assert_eq!(validation_failure_result(&InteropTxValidatorError::Timeout(2)), RESULT_ERRORED);
         assert_eq!(validation_failure_result(&server_error()), RESULT_ERRORED);
+        // The dedicated failsafe error code is a failsafe rejection, not an infra failure.
+        assert_eq!(
+            validation_failure_result(&InteropTxValidatorError::FailsafeEnabled),
+            RESULT_REJECTED_FAILSAFE
+        );
     }
 }


### PR DESCRIPTION
## What

Adds allow/reject decision observability to the op-reth interop filter, and separates legitimate rejections from infra failures.

1. **Labeled decision metric** — replace the 11 per-reason `*_count` counters with `filter_decisions_total{result}` + a `validation_errors_total{reason}` breakdown.
2. **Infra-failure split** — a filter timeout / transport / server error is recorded as `result="errored"` + `filter_errors_total{kind}`, distinct from a legitimate `rejected_validation`, so an outage no longer masquerades as a flood of rejections and corrupts the allow-rate.

## Why

You currently can't answer "what is the interop filter allowing vs rejecting, and why" — there's no allowed/rejected count, and an RPC failure to the filter is recorded identically to a legitimate rejection, silently corrupting any allow-rate signal.

## Failsafe RPC error code (#21205)

[#21205](https://github.com/ethereum-optimism/optimism/pull/21205) gives failsafe a dedicated `interop_checkAccessList` error code (`-320602`) instead of the generic invalid-params fallback. Since every other interop-filter code lives in op-alloy's `SuperchainDAError`, this PR adds `SuperchainDAError::Failsafe = -320602` there too (single source of truth). op-reth maps that variant to `InteropTxValidatorError::FailsafeEnabled` — an operational state, kept distinct from data-availability rejections — which is counted as `result="rejected_failsafe"` (not `errored`) and returns the same `FailsafeEnabled` rejection as the cached fast-path. This covers the race where failsafe turns on between the ~1s poll and a per-tx check. Unknown codes still fall back to `errored`.

## Metric surface (after this PR)

Names below are the **scraped Prometheus names** (reth prepends `reth_` and sanitizes the `optimism_transaction_pool.interop` scope to underscores).

- `reth_optimism_transaction_pool_interop_filter_decisions_total{result}` — one increment per tx reaching the filter. `result` ∈ `allowed`, `rejected_failsafe`, `rejected_pre_interop_hardfork`, `rejected_validation` (filter answered "no"), `errored` (no trustworthy answer).
- `reth_optimism_transaction_pool_interop_validation_errors_total{reason}` — DA-reason breakdown of legitimate rejections; sums to `result="rejected_validation"`.
- `reth_optimism_transaction_pool_interop_filter_errors_total{kind}` — infra-failure breakdown (`timeout` / `other`); sums to `result="errored"`.

### What the emitted series look like

A scrape of `/metrics` on a node that has seen some interop traffic would look like:

```
# every decision, one counter, split by outcome
reth_optimism_transaction_pool_interop_filter_decisions_total{result="allowed"}             1432
reth_optimism_transaction_pool_interop_filter_decisions_total{result="rejected_validation"}   87
reth_optimism_transaction_pool_interop_filter_decisions_total{result="rejected_failsafe"}      5
reth_optimism_transaction_pool_interop_filter_decisions_total{result="rejected_pre_interop_hardfork"}   0
reth_optimism_transaction_pool_interop_filter_decisions_total{result="errored"}                3

# why the 87 legitimate rejections happened (sums to result="rejected_validation")
reth_optimism_transaction_pool_interop_validation_errors_total{reason="conflicting_data"}      80
reth_optimism_transaction_pool_interop_validation_errors_total{reason="unknown_chain"}          5
reth_optimism_transaction_pool_interop_validation_errors_total{reason="out_of_order"}           2

# why the 3 infra failures happened (sums to result="errored")
reth_optimism_transaction_pool_interop_filter_errors_total{kind="timeout"}                      3
```

Invariants, by construction (each decision increments exactly one breakdown counter):
- `sum(validation_errors_total) == filter_decisions_total{result="rejected_validation"}`
- `sum(filter_errors_total) == filter_decisions_total{result="errored"}`

### `validation_errors_total` in detail

One counter, one `reason` label per legitimate rejection. A series is created lazily the first time a given reason is observed, so in practice only the reasons a node has actually hit are present — the others are simply absent (and read as `0` in PromQL). The full set of `reason` values:

```
reth_optimism_transaction_pool_interop_validation_errors_total{reason="conflicting_data"}          80
reth_optimism_transaction_pool_interop_validation_errors_total{reason="unknown_chain"}              5
reth_optimism_transaction_pool_interop_validation_errors_total{reason="out_of_order"}               2
reth_optimism_transaction_pool_interop_validation_errors_total{reason="skipped_data"}               0
reth_optimism_transaction_pool_interop_validation_errors_total{reason="ineffective_data"}           0
reth_optimism_transaction_pool_interop_validation_errors_total{reason="awaiting_replacement"}       0
reth_optimism_transaction_pool_interop_validation_errors_total{reason="out_of_scope"}               0
reth_optimism_transaction_pool_interop_validation_errors_total{reason="no_parent_for_first_block"}  0
reth_optimism_transaction_pool_interop_validation_errors_total{reason="future_data"}                0
reth_optimism_transaction_pool_interop_validation_errors_total{reason="missed_data"}                0
reth_optimism_transaction_pool_interop_validation_errors_total{reason="data_corruption"}            0
reth_optimism_transaction_pool_interop_validation_errors_total{reason="other"}                      0
```

(`0` rows shown only to enumerate the complete label set; an unhit reason has no series until its first occurrence.) The three non-zero rows above sum to `87` = `filter_decisions_total{result="rejected_validation"}`.

### Reject reason ↔ error code

`reason` is the human-readable name of the `SuperchainDAError` the filter returned. Each maps 1:1 to a JSON-RPC error code from the [interop supervisor spec](https://specs.optimism.io/interop/supervisor.html#protocol-specific-error-codes):

| `reason` | `SuperchainDAError` | JSON-RPC code |
|---|---|---|
| `skipped_data` | `SkippedData` | `-320500` |
| `unknown_chain` | `UnknownChain` | `-320501` |
| `conflicting_data` | `ConflictingData` | `-320600` |
| `ineffective_data` | `IneffectiveData` | `-320601` |
| `out_of_order` | `OutOfOrder` | `-320900` |
| `awaiting_replacement` | `AwaitingReplacement` | `-320901` |
| `out_of_scope` | `OutOfScope` | `-321100` |
| `no_parent_for_first_block` | `NoParentForFirstBlock` | `-321200` |
| `future_data` | `FutureData` | `-321401` |
| `missed_data` | `MissedData` | `-321500` |
| `data_corruption` | `DataCorruption` | `-321501` |
| `other` | `InvalidatedRead` / `RewindFailed` / any non-DA error | `-32901` / `-321000` / — |

> Note: the numeric code is **not** emitted as a label — `reason` is its human-readable 1:1 equivalent. `InvalidatedRead` and `RewindFailed` currently collapse into `other`.

### Example queries

```promql
# Allow-rate over decisions the filter actually made (infra failures excluded)
sum(rate(reth_optimism_transaction_pool_interop_filter_decisions_total{result="allowed"}[5m]))
  / sum(rate(reth_optimism_transaction_pool_interop_filter_decisions_total{result!="errored"}[5m]))

# Filter availability — its own health signal, no longer hidden in "rejections"
sum(rate(reth_optimism_transaction_pool_interop_filter_decisions_total{result="errored"}[5m]))
  / sum(rate(reth_optimism_transaction_pool_interop_filter_decisions_total[5m]))

# Top rejection reasons
topk(5, sum by (reason) (rate(reth_optimism_transaction_pool_interop_validation_errors_total[5m])))
```

## Changes

- `interop_filter/metrics.rs`: remove the 11 `*_count` counters + `increment_metrics_for_error`; add `record_decision`, `record_validation_error`, `record_filter_error`, and pure label-mapping helpers (`validation_reason`, `filter_error_kind`, `validation_failure_result`).
- `interop_filter/client.rs`: record exactly one decision per path in `is_valid_cross_tx`; classify the error branch via `validation_failure_result` (single source of truth) into rejection vs failsafe vs infra failure. Behavior unchanged — `errored` txs are still rejected (fail-closed).
- `op-alloy` `rpc-types`: add `SuperchainDAError::Failsafe = -320602` (#21205).
- `interop_filter/errors.rs`: add `InteropTxValidatorError::FailsafeEnabled`; `from_error_code` maps `SuperchainDAError::Failsafe` to it (operational state, not a DA rejection).

## ⚠️ Breaking (metrics)

The 11 `reth_optimism_transaction_pool_interop_*_count` counters are removed in favor of `validation_errors_total{reason}`. No dashboards/alerts reference the old names (verified across infra repos — only stale Grafana adaptive-metrics cost rules still point at the pre-rename `supervisor_*` names, already orphaned by the supervisor→interop rename).

## Testing

- `cargo fmt`, `cargo clippy`, and `cargo test -p reth-optimism-txpool` pass.
- Unit tests exhaustively cover the `result`/`reason`/`kind` label mapping: every DA `reason`, the timeout-vs-other infra `kind`, and the infra-failure-vs-legitimate-rejection `result` split.




