### PR TITLE
chore(rust): point reth deps at joshklop/reth fix/state-trie-overlay-deadlock

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9409,7 +9409,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9436,7 +9436,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9469,7 +9469,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9590,7 +9590,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9600,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9653,7 +9653,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9669,7 +9669,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9683,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9696,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9721,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9806,7 +9806,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9846,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9870,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9894,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9929,7 +9929,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9986,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10037,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10062,7 +10062,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10120,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10150,7 +10150,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10166,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10182,7 +10182,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10204,7 +10204,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10215,7 +10215,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -10244,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "clap",
  "eyre",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10349,7 +10349,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -10365,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10379,7 +10379,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10409,7 +10409,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10457,7 +10457,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10477,7 +10477,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10495,7 +10495,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10508,7 +10508,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10527,7 +10527,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10565,7 +10565,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eips 2.0.5",
  "eyre",
@@ -10597,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -10611,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "serde",
  "serde_json",
@@ -10621,7 +10621,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "bytes",
  "futures",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10686,7 +10686,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "bindgen",
  "cc",
@@ -10695,7 +10695,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "futures",
  "metrics",
@@ -10708,7 +10708,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10717,7 +10717,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -10731,7 +10731,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10789,7 +10789,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10814,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10837,7 +10837,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10852,7 +10852,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10866,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -10883,7 +10883,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10907,7 +10907,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -11030,7 +11030,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network",
@@ -11073,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11097,7 +11097,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -11121,7 +11121,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "bytes",
  "eyre",
@@ -11150,7 +11150,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11758,7 +11758,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11782,7 +11782,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11794,7 +11794,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -11817,7 +11817,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11827,7 +11827,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -11870,7 +11870,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11919,7 +11919,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -11948,7 +11948,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11964,7 +11964,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11979,7 +11979,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -12055,7 +12055,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -12085,7 +12085,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -12128,7 +12128,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12148,7 +12148,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -12179,7 +12179,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -12225,7 +12225,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -12273,7 +12273,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -12287,7 +12287,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -12318,7 +12318,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -12370,7 +12370,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -12398,7 +12398,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -12412,7 +12412,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -12432,7 +12432,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -12447,7 +12447,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -12472,7 +12472,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -12490,7 +12490,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -12511,7 +12511,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -12527,7 +12527,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12537,7 +12537,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "clap",
  "eyre",
@@ -12556,7 +12556,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "clap",
  "eyre",
@@ -12574,7 +12574,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -12621,7 +12621,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -12647,7 +12647,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12674,7 +12674,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -12694,7 +12694,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -12722,7 +12722,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=81c026181e96ef33a823f3ef4d2a28940e9fa4fe#81c026181e96ef33a823f3ef4d2a28940e9fa4fe"
+source = "git+https://github.com/joshklop/reth?branch=fix%2Fstate-trie-overlay-deadlock#dc33689170b32bc17c124f4eb8bc102c3c13c759"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -323,77 +323,77 @@ reth-primitives-traits = { version = "0.3.1", default-features = false }
 reth-rpc-traits = { version = "0.3.1", default-features = false }
 reth-zstd-compressors = { version = "0.3.1", default-features = false }
 
-# ==================== RETH CRATES (git @ 88505c7fcbfdebfd3b56d88c86b62e950043c6c4) ====================
-reth = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-fs-util = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-node-events = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-prune = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe", default-features = false }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "81c026181e96ef33a823f3ef4d2a28940e9fa4fe" }
+# ==================== RETH CRATES (git @ joshklop/reth:fix/state-trie-overlay-deadlock) ====================
+reth = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-basic-payload-builder = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-chain-state = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-chainspec = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-cli = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-cli-commands = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-cli-runner = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-cli-util = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-consensus = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-consensus-common = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-db = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-db-api = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-db-common = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-downloaders = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-e2e-test-utils = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-engine-local = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-engine-primitives = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-errors = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-eth-wire = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-eth-wire-types = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-ethereum = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-ethereum-cli = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-ethereum-consensus = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-ethereum-forks = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-evm = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-exex = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-exex-test-utils = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-execution-errors = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-execution-types = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-fs-util = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-metrics = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-network = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-network-api = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-network-peers = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-node-api = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-node-builder = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-node-core = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-node-ethereum = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-node-events = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-node-metrics = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-payload-builder = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-payload-builder-primitives = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-payload-primitives = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-payload-util = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-payload-validator = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-provider = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-prune = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-prune-types = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-revm = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-rpc = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-rpc-api = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-rpc-builder = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-rpc-engine-api = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-rpc-eth-api = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-rpc-eth-types = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-stages = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-stages-types = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-static-file = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-static-file-types = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-storage-api = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-storage-errors = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-tasks = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-tracing = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-transaction-pool = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-trie = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
+reth-trie-common = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock", default-features = false }
+reth-trie-db = { git = "https://github.com/joshklop/reth", branch = "fix/state-trie-overlay-deadlock" }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "38.0.0", default-features = false }


### PR DESCRIPTION
## What

Repoints all 70 `reth-*` git dependencies in the Rust workspace (`rust/Cargo.toml`) from the upstream pin `paradigmxyz/reth@81c0261` to the fork branch [`joshklop/reth:fix/state-trie-overlay-deadlock`](https://github.com/joshklop/reth/tree/fix/state-trie-overlay-deadlock), which contains a fix for a deadlock in the state trie overlay.

`rust/Cargo.lock` is regenerated to match. The lockfile diff is limited to the reth git `source` URLs (now pinned to branch tip `dc33689`); no other dependency versions change.

## Why

To pull in / test the state-trie-overlay deadlock fix from the fork branch.

## Notes

- ⚠️ **Not mergeable as-is** — this points reth at a personal fork branch. Opened as a **draft** for CI/testing. Before this can land, the fix should be upstreamed to `paradigmxyz/reth` and the deps repointed there with a proper `rev`.
- The existing repo convention uses `rev = "<sha>"`; this PR intentionally uses `branch = "fix/state-trie-overlay-deadlock"` per the request to track the branch. Cargo.lock still pins the exact commit, so builds remain reproducible.
- Verified the dependency graph re-resolves cleanly (`cargo metadata`); a full compile is left to CI.

## Attribution

This change was generated by **Claude Code** (Opus 4.8) at the request of @joshklop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)