### PR TITLE
fix(op-challenger): restore ubuntu runtime image

### DIFF
--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -9,9 +9,8 @@
 # It will default to the target platform.
 ARG TARGET_BASE_IMAGE=chainguard/static:latest
 
-# The wolfi target base image is used for the op-challenger build with kona,
-# which links against openssl/ca-certificates at runtime.
-ARG UBUNTU_TARGET_BASE_IMAGE=chainguard/wolfi-base:latest
+# The ubuntu target base image is used for the op-challenger build with kona.
+ARG UBUNTU_TARGET_BASE_IMAGE=ubuntu:24.04
 
 # builder_foundry does not need to be built on $BUILDPLATFORM, as foundry produces static binaries.
 FROM alpine:3.21 AS builder_foundry
@@ -285,7 +284,7 @@ CMD ["op-node"]
 
 # Also produce an op-challenger loaded with kona using ubuntu
 FROM $UBUNTU_TARGET_BASE_IMAGE AS op-challenger-target
-RUN apk add --no-cache openssl libstdc++ ca-certificates
+RUN apt-get update && apt-get install -y --no-install-recommends musl openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=op-challenger-builder /app/op-challenger/bin/op-challenger /usr/local/bin/
 # Copy in op-program and cannon
 COPY --from=op-program-builder /app/op-program/bin/op-program /usr/local/bin/


### PR DESCRIPTION
## Summary

`op-challenger` images on `develop` include `/usr/local/bin/cannon`, but it cannot execute:

```sh
sh: /usr/local/bin/cannon: not found
```

## Cause

The runtime image was changed from Ubuntu to Wolfi. `cannon` is dynamically linked against the musl loader at `/lib/ld-musl-aarch64.so.1`, which is missing from the Wolfi image.

`kona-host` is also dynamic, but glibc-linked and happened to work in Wolfi.

## Fix

Restore the `op-challenger` runtime image to `ubuntu:24.04` and install the needed runtime packages:

```sh
musl openssl ca-certificates
```

## Verification

Built the image and confirmed these all run inside it:

```text
kona-host 1.0.2
multicannon version v0.0.0
op-challenger version v0.0.0

Also confirmed multicannon run can extract and execute both embedded Cannon impls currently present in the image:
cannon-7
cannon-8
```