### PR TITLE
ci: wire merge-queue jobs into the required CI gates

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2178,13 +2178,6 @@ jobs:
           no_output_timeout: 20m
       - notify-failures-on-develop
 
-  bedrock-go-tests: # just a helper, that depends on all the actual test jobs
-    docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: medium.gen2
-    steps:
-      - run: echo Done
-
   analyze-op-program-client:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
@@ -2630,17 +2623,6 @@ workflows:
       - op-program-compat:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - bedrock-go-tests:
-          requires:
-            - go-lint
-            - cannon-go-lint-and-test
-            - check-generated-mocks-op-node
-            - check-generated-mocks-op-service
-            - op-program-compat
-            - go-tests-short
-            - sanitize-op-program
-          context:
-            - circleci-repo-readonly-authenticated-github-tokens
       - cannon-prestate:
           context:
             - circleci-repo-readonly-authenticated-github-token
@@ -2779,10 +2761,32 @@ workflows:
             - shell-check: terminal
             - go-lint: terminal
             - semgrep-scan-local: terminal
+            - semgrep-test: terminal
             - go-tests-short: terminal
             - memory-all-opn-op-geth: terminal
             - memory-all-opn-op-reth: terminal
             - memory-all-kona-op-reth: terminal
+            # Go test/lint jobs previously fanned in via the bedrock-go-tests helper.
+            - cannon-go-lint-and-test: terminal
+            - check-generated-mocks-op-node: terminal
+            - check-generated-mocks-op-service: terminal
+            - op-program-compat: terminal
+            - sanitize-op-program: terminal
+            # Misc checks that run on the merge queue.
+            - analyze-op-program-client: terminal
+            - check-nut-locks: terminal
+            - check-op-geth-version: terminal
+            - op-deployer-forge-version: terminal
+            - l2-chains-sync-check: terminal
+            - nut-provenance-verify: terminal
+            - diff-fetcher-forge-artifacts: terminal
+            # Fuzz jobs.
+            - cannon-fuzz: terminal
+            - op-e2e-fuzz: terminal
+            - fuzz-golang-op-challenger: terminal
+            - fuzz-golang-op-node: terminal
+            - fuzz-golang-op-service: terminal
+            - fuzz-golang-op-chain-ops: terminal
           context:
             - circleci-api-token
           filters:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3235,9 +3235,28 @@ workflows:
       - required-contracts-ci:
           requires:
             - contracts-bedrock-tests main: terminal
+            - contracts-bedrock-tests CUSTOM_GAS_TOKEN: terminal
+            - contracts-bedrock-tests OPTIMISM_PORTAL_INTEROP: terminal
+            - contracts-bedrock-tests ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-tests SUPER_ROOT_GAMES_MIGRATION: terminal
             - contracts-bedrock-tests-heavy-fuzz-modified main: terminal
+            - contracts-bedrock-tests-heavy-fuzz-modified CUSTOM_GAS_TOKEN: terminal
+            - contracts-bedrock-tests-heavy-fuzz-modified OPTIMISM_PORTAL_INTEROP: terminal
+            - contracts-bedrock-tests-heavy-fuzz-modified ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-tests-heavy-fuzz-modified SUPER_ROOT_GAMES_MIGRATION: terminal
             - contracts-bedrock-coverage main: terminal
+            - contracts-bedrock-coverage CUSTOM_GAS_TOKEN: terminal
+            - contracts-bedrock-coverage OPTIMISM_PORTAL_INTEROP: terminal
+            - contracts-bedrock-coverage ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-coverage SUPER_ROOT_GAMES_MIGRATION: terminal
             - contracts-bedrock-tests-upgrade op-mainnet main: terminal
+            - contracts-bedrock-tests-upgrade op-mainnet CUSTOM_GAS_TOKEN: terminal
+            - contracts-bedrock-tests-upgrade op-mainnet OPTIMISM_PORTAL_INTEROP: terminal
+            - contracts-bedrock-tests-upgrade op-mainnet ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-tests-upgrade op-mainnet SUPER_ROOT_GAMES_MIGRATION: terminal
+            - contracts-bedrock-tests-upgrade op-mainnet: terminal
+            - contracts-bedrock-tests-upgrade ink-mainnet: terminal
+            - contracts-bedrock-tests-upgrade unichain-mainnet: terminal
             - contracts-bedrock-tests-l2-fork op-mainnet: terminal
             - contracts-bedrock-checks-fast-feature-tests: terminal
           context:

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -247,6 +247,7 @@ workflows:
             - rust-e2e-simple-kona-geth: terminal
             - rust-e2e-simple-kona-sequencer: terminal
             - rust-e2e-restart: terminal
+            - op-reth-e2e-sysgo-tests: terminal
             - kona-proof-action-single: terminal
           context:
             - circleci-api-token


### PR DESCRIPTION
Several jobs run on `gh-readonly-queue` (merge queue) branches but were not part of any required gate's `requires` chain, so the merge queue could pass without them succeeding. The four gate jobs (`ci-gate`, `required-contracts-ci`, `required-rust-ci`, `required-rust-e2e`) are the only required status checks in the `enforce-ci-checks-develop` ruleset, so anything they don't transitively require is not gating merges.

This wires the gaps in:

**`ci-gate`**
- Removes the `bedrock-go-tests` helper and requires its underlying jobs directly: `cannon-go-lint-and-test`, `check-generated-mocks-op-node`, `check-generated-mocks-op-service`, `op-program-compat`, `sanitize-op-program`. (These were last gated before `ci-gate` replaced the per-job required checks in #19535.)
- Adds ungated misc checks: `analyze-op-program-client`, `check-nut-locks`, `check-op-geth-version`, `op-deployer-forge-version`, `l2-chains-sync-check`, `nut-provenance-verify`, `diff-fetcher-forge-artifacts`, `semgrep-test`.
- Adds fuzz jobs: `cannon-fuzz`, `op-e2e-fuzz`, `fuzz-golang-{op-challenger,op-node,op-service,op-chain-ops}`.

**`required-contracts-ci`**
- Adds the non-`main` feature variants (`CUSTOM_GAS_TOKEN`, `OPTIMISM_PORTAL_INTEROP`, `ZK_DISPUTE_GAME`, `SUPER_ROOT_GAMES_MIGRATION`) of `contracts-bedrock-tests`, `-heavy-fuzz-modified`, `-coverage`, and `-tests-upgrade op-mainnet`, plus the chain-specific upgrade tests (`op-mainnet` default, `ink-mainnet`, `unichain-mainnet`). The post-merge-only `-develop` variants are excluded — they don't run on the merge queue.

**`required-rust-e2e`**
- Adds `op-reth-e2e-sysgo-tests`.

Validated locally with `circleci config validate` on the merged continuation config.