### PR TITLE
fix(op-e2e): lazily generate genesis allocs per alloc type

### DIFF
--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -93,9 +93,50 @@ var (
 
 	// mtx is a lock to protect the above variables
 	mtx sync.RWMutex
+
+	// monorepoRoot is resolved once in init and reused by lazy alloc-type
+	// initialization. It is read-only after init.
+	monorepoRoot string
+	// regularLogHandler is the log handler installed after alloc generation;
+	// lazy initialization temporarily lowers the level during generation.
+	regularLogHandler slog.Handler
+	errorLogHandler   slog.Handler
+
+	// allocTypeOnce guards lazy, on-demand generation of each alloc type's
+	// genesis data. Each alloc type runs a full op-deployer genesis pipeline
+	// across every L2 hardfork mode, which is several minutes of CPU work.
+	// Generating only the alloc types a test binary actually requests keeps a
+	// binary that uses a single alloc type (e.g. the opgeth fuzz targets) from
+	// paying for all of them up front.
+	allocTypeOnce = make(map[AllocType]*sync.Once)
 )
 
+// ensureAllocType generates the genesis data for the given alloc type if it has
+// not been generated yet. Generation is expensive (a full op-deployer pipeline
+// per L2 hardfork mode), so it runs lazily and exactly once per alloc type. A
+// test binary therefore only pays for the alloc types its tests actually use,
+// instead of every alloc type up front. Logs are kept at error level during
+// generation, which is heavy on the logs.
+func ensureAllocType(allocType AllocType) {
+	once, ok := allocTypeOnce[allocType]
+	if !ok {
+		// Not a lazily-generated alloc type (e.g. a test-injected one, or any
+		// type outside allocTypes that the original eager loop never generated
+		// either). The getters validate map presence and panic on their own if
+		// the data is genuinely missing.
+		return
+	}
+	once.Do(func() {
+		if errorLogHandler != nil {
+			oplog.SetGlobalLogHandler(errorLogHandler)
+			defer oplog.SetGlobalLogHandler(regularLogHandler)
+		}
+		initAllocType(monorepoRoot, allocType)
+	})
+}
+
 func L1Allocs(allocType AllocType) *foundry.ForgeAllocs {
+	ensureAllocType(allocType)
 	mtx.RLock()
 	defer mtx.RUnlock()
 	allocs, ok := l1AllocsByType[allocType]
@@ -106,6 +147,7 @@ func L1Allocs(allocType AllocType) *foundry.ForgeAllocs {
 }
 
 func L1Deployments(allocType AllocType) *genesis.L1Deployments {
+	ensureAllocType(allocType)
 	mtx.RLock()
 	defer mtx.RUnlock()
 	deployments, ok := l1DeploymentsByType[allocType]
@@ -116,6 +158,7 @@ func L1Deployments(allocType AllocType) *genesis.L1Deployments {
 }
 
 func L2Allocs(allocType AllocType, mode genesis.L2AllocsMode) *foundry.ForgeAllocs {
+	ensureAllocType(allocType)
 	mtx.RLock()
 	defer mtx.RUnlock()
 	allocsByType, ok := l2AllocsByType[allocType]
@@ -135,6 +178,7 @@ func L2Allocs(allocType AllocType, mode genesis.L2AllocsMode) *foundry.ForgeAllo
 // the returned value shares no maps, slices or pointers with any other call.
 // Callers can freely mutate the result without affecting any other test.
 func DeployConfig(allocType AllocType) *genesis.DeployConfig {
+	ensureAllocType(allocType)
 	mtx.RLock()
 	raw, ok := deployConfigBytesByType[allocType]
 	mtx.RUnlock()
@@ -160,6 +204,11 @@ func init() {
 	root, err := op_service.FindMonorepoRoot(cwd)
 	if err != nil {
 		panic(err)
+	}
+	monorepoRoot = root
+
+	for _, allocType := range allocTypes {
+		allocTypeOnce[allocType] = new(sync.Once)
 	}
 
 	// Setup global logger
@@ -189,15 +238,12 @@ func init() {
 		})
 	}
 
-	// Start at warning level since alloc generation is heavy on the logs,
-	// which reduces CI performance.
-	oplog.SetGlobalLogHandler(errHandler)
-
-	for _, allocType := range allocTypes {
-		initAllocType(root, allocType)
-	}
-
-	// Use regular level going forward.
+	// Alloc generation is heavy on the logs, which reduces CI performance.
+	// Generation now happens lazily per alloc type (see ensureAllocType), so
+	// keep the regular handler installed here and let ensureAllocType lower the
+	// level to error only while generating.
+	regularLogHandler = handler
+	errorLogHandler = errHandler
 	oplog.SetGlobalLogHandler(handler)
 }
 


### PR DESCRIPTION
## What

`op-e2e/config`'s `init()` ran a full genesis pipeline for all 4 alloc types × 9 hardfork modes (36 pipelines) at test-binary startup — minutes of CPU before any test runs. Generate each alloc type lazily and once instead, so a binary only pays for the types it uses.

## Why

Fixes the recurring `op-e2e-fuzz` 15m no-output timeout (ethereum-optimism/optimism#21191). The job runs 3 concurrent `go test -fuzz ./opgeth` procs, each paying the full init, oversubscribing the 8-vCPU box. Work is fixed but wall time is long-tailed (median ~6.6m, max ~24.6m over 735 runs); the slow tail crosses the 15m ceiling. The hang is in `init()` before any output, so the job dies with zero output from all three targets — which is why #21203 (bounding RPC calls inside `FuzzFjordCostFunction`) didn't help. opgeth uses only `DefaultAllocType`, so its startup drops from 4 alloc types to 1.

## Test plan

- `go test -race ./config/...` passes (incl. `TestDeployConfigConcurrentMutationIsolated`).
- `go build -tags cgo_test ./...` clean.
- `FuzzFastLzCgo` streams output in ~1s (was 271s of silent init).

Refs ethereum-optimism/optimism#21191