### PR TITLE
op-reth(debug): OP_RETH_STATE_TRIE_OVERLAY_THREADS knob to reproduce state-trie-overlay deadlock (authored by Claude)

### DIFF
--- a/rust/op-reth/crates/cli/Cargo.toml
+++ b/rust/op-reth/crates/cli/Cargo.toml
@@ -43,7 +43,7 @@ reth-chainspec.workspace = true
 reth-node-events.workspace = true
 reth-optimism-evm.workspace = true
 reth-cli-runner.workspace = true
-reth-tasks.workspace = true
+reth-tasks = { workspace = true, features = ["rayon"] }
 reth-node-builder.workspace = true
 reth-tracing.workspace = true
 

--- a/rust/op-reth/crates/cli/src/app.rs
+++ b/rust/op-reth/crates/cli/src/app.rs
@@ -54,7 +54,7 @@ where
     pub fn run(mut self, launcher: impl Launcher<C, Ext>) -> Result<()> {
         let runner = match self.runner.take() {
             Some(runner) => runner,
-            None => CliRunner::try_default_runtime()?,
+            None => crate::build_cli_runner()?,
         };
 
         // add network name to logs dir

--- a/rust/op-reth/crates/cli/src/lib.rs
+++ b/rust/op-reth/crates/cli/src/lib.rs
@@ -58,6 +58,36 @@ use reth_optimism_node::args::RollupArgs;
 // reporting
 use reth_node_metrics as _;
 
+/// Builds the [`CliRunner`], optionally overriding the state-trie-overlay worker-pool thread count
+/// via the `OP_RETH_STATE_TRIE_OVERLAY_THREADS` environment variable.
+///
+/// The overlay worker pool defaults to 4 threads, and that headroom normally masks the
+/// `StateTrieOverlayManager::get_overlay` shard-lock-vs-worker-pool deadlock. Setting the variable
+/// to a small value (e.g. `1`) removes the headroom so the race surfaces readily on a devnet,
+/// which is useful for reproducing the hang and validating fixes for it. When the variable is
+/// unset or not a positive integer, this behaves exactly like [`CliRunner::try_default_runtime`].
+pub(crate) fn build_cli_runner() -> Result<CliRunner, reth_tasks::RuntimeBuildError> {
+    let mut config = reth_tasks::RuntimeConfig::default();
+
+    if let Some(threads) = std::env::var("OP_RETH_STATE_TRIE_OVERLAY_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|threads| *threads > 0)
+    {
+        tracing::warn!(
+            target: "reth::cli",
+            threads,
+            "Overriding state-trie-overlay worker pool size via OP_RETH_STATE_TRIE_OVERLAY_THREADS \
+             (debug/repro aid for the overlay deadlock; not for production use)"
+        );
+        config = config.with_rayon(
+            reth_tasks::RayonConfig::default().with_state_trie_overlay_worker_threads(threads),
+        );
+    }
+
+    CliRunner::try_with_runtime_config(config)
+}
+
 /// The main op-reth cli interface.
 ///
 /// This is the entrypoint to the executable.
@@ -124,7 +154,7 @@ where
         L: FnOnce(WithLaunchContext<NodeBuilder<DatabaseEnv, C::ChainSpec>>, Ext) -> Fut,
         Fut: Future<Output = eyre::Result<()>>,
     {
-        self.with_runner(CliRunner::try_default_runtime()?, launcher)
+        self.with_runner(build_cli_runner()?, launcher)
     }
 
     /// Execute the configured cli command with the provided [`CliRunner`].


### PR DESCRIPTION
## Summary

**Authored by Claude (Claude Code).** Debugging / reproduction aid — not intended to merge to `develop`.

Adds an env-gated override for the state-trie-overlay worker-pool thread count so we can reproduce the Ink sequencer halt — a `StateTrieOverlayManager::get_overlay` shard-lock-vs-worker-pool deadlock — on a devnet, and validate the fix end-to-end.

## What it does

`reth_optimism_cli` now builds its `CliRunner` via a small helper that reads `OP_RETH_STATE_TRIE_OVERLAY_THREADS`:

- **unset / non-positive** → identical to `CliRunner::try_default_runtime()` (stock 4-thread overlay pool). No behavior change.
- **set to `N` > 0** → builds the runtime with `RuntimeConfig::with_rayon(RayonConfig::default().with_state_trie_overlay_worker_threads(N))`, and logs a `WARN` so it's obvious in the logs.

3 files, +33/-3, all in `rust/op-reth/crates/cli` (`reth-tasks` also gains `features = ["rayon"]` so the override API is guaranteed present — already on transitively for the node, so no net change).

## Why this reproduces it

The overlay pool defaults to 4 threads, and that headroom almost always lets the background `insert_block` precompute finish before a synchronous `get_overlay` (block build/validation over the in-memory head) asks for the same `(anchor, tip)` key — so the entry is cached and there's no collision. Shrinking the pool to **1** removes the headroom: a single same-key race wedges it (the lone worker parks on the shard the synchronous caller holds across the blocking `install_fn`, and there's no spare worker to break the cycle). That's the deterministic core of the production halt.

## How to use

Run op-reth as a loaded sequencer (behind rollup-boost / flashblocks) with:

```
OP_RETH_STATE_TRIE_OVERLAY_THREADS=1
```

Pair with real state-churn load and a couple of concurrent `eth_getProof` / `eth_call` loops at `latest` to hit it fastest. Unset the variable for a stock run.

## Building the devnet image

The `op-reth` bake target (`rust/op-reth/DockerfileOp`) builds from this branch. The image pins reth at upstream `81c026181…` (the rev op-reth/v2.2.5 ships), so a fresh docker build links the **genuinely buggy** overlay code — i.e. this image + `OP_RETH_STATE_TRIE_OVERLAY_THREADS=1` is a valid *repro* build. To instead *validate the fix*, build against a reth rev carrying the `get_overlay` fix and confirm it no longer wedges under the same knob.

## Caveats

- Default behavior is unchanged, so it's safe to carry this knob in a debug image.
- This is a triage tool, not a production feature; please don't merge to `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
