### PR TITLE
chore: safe dependency cleanups

### DIFF
--- a/cannon/testdata/go-1-24/keccak/go.mod
+++ b/cannon/testdata/go-1-24/keccak/go.mod
@@ -7,5 +7,3 @@ toolchain go1.24.2
 require golang.org/x/crypto v0.35.0
 
 require golang.org/x/sys v0.30.0 // indirect
-
-replace github.com/ethereum-optimism/optimism v0.0.0 => ./../../../..

--- a/cannon/testdata/go-1-25/keccak/go.mod
+++ b/cannon/testdata/go-1-25/keccak/go.mod
@@ -7,5 +7,3 @@ toolchain go1.25.4
 require golang.org/x/crypto v0.35.0
 
 require golang.org/x/sys v0.30.0 // indirect
-
-replace github.com/ethereum-optimism/optimism v0.0.0 => ./../../../..

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/coder/websocket v1.8.13
 	github.com/consensys/gnark-crypto v0.18.1
-	github.com/crate-crypto/go-kzg-4844 v1.1.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.12.0
 	github.com/lmittmann/w3 v0.20.7
 	github.com/minio/minio-go/v7 v7.0.85
-	github.com/minio/sha256-simd v1.0.1
 	github.com/multiformats/go-base32 v0.1.0
 	github.com/multiformats/go-multiaddr v0.14.0
 	github.com/multiformats/go-multiaddr-dns v0.4.1
@@ -70,6 +69,7 @@ require (
 	github.com/grafana/pyroscope-go v1.2.7 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB
 github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/crate-crypto/go-eth-kzg v1.5.0 h1:FYRiJMJG2iv+2Dy3fi14SVGjcPteZ5HAAUe4YWlJygc=
 github.com/crate-crypto/go-eth-kzg v1.5.0/go.mod h1:J9/u5sWfznSObptgfa92Jq8rTswn6ahQWEuiLHOjCUI=
-github.com/crate-crypto/go-kzg-4844 v1.1.0 h1:EN/u9k2TF6OWSHrCCDBBU6GLNMq88OspHHlMnHfoyU4=
-github.com/crate-crypto/go-kzg-4844 v1.1.0/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/mise.toml
+++ b/mise.toml
@@ -53,7 +53,6 @@ cast = "1.2.3"
 anvil = "1.2.3"
 
 # Other dependencies
-codecov-uploader = "0.8.0"
 goreleaser-pro = "2.11.2"
 git-cliff = "2.12.0"
 
@@ -69,7 +68,6 @@ forge = "github:foundry-rs/foundry[bin=forge,version_prefix=v]"
 cast = "github:foundry-rs/foundry[bin=cast,version_prefix=v]"
 anvil = "github:foundry-rs/foundry[bin=anvil,version_prefix=v]"
 just = "github:casey/just"
-codecov-uploader = "github:codecov/uploader[version_prefix=v]"
 goreleaser-pro = "github:goreleaser/goreleaser-pro[bin=goreleaser,version_prefix=v]"
 gotestsum = "github:gotestyourself/gotestsum[version_prefix=v]"
 mockery = "github:vektra/mockery[version_prefix=v]"

--- a/op-challenger/game/fault/trace/utils/preimage_test.go
+++ b/op-challenger/game/fault/trace/utils/preimage_test.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"testing"
 
-	gokzg4844 "github.com/crate-crypto/go-kzg-4844"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
@@ -152,7 +151,7 @@ func TestPreimageLoader_BlobPreimage(t *testing.T) {
 			loader := NewPreimageLoader(func() (PreimageSource, error) {
 				return kv, nil
 			})
-			storeBlob(t, kv, gokzg4844.KZGCommitment(commitment), gokzg4844.Blob(blob))
+			storeBlob(t, kv, commitment, blob)
 			actual, err := loader.LoadPreimage(proof)
 			require.NoError(t, err)
 
@@ -206,7 +205,7 @@ func TestPreimageLoader_PrecompilePreimage(t *testing.T) {
 	})
 }
 
-func storeBlob(t *testing.T, kv kvstore.KV, commitment gokzg4844.KZGCommitment, blob gokzg4844.Blob) {
+func storeBlob(t *testing.T, kv kvstore.KV, commitment kzg4844.Commitment, blob kzg4844.Blob) {
 	// Pre-store versioned hash preimage (commitment)
 	key := preimage.Sha256Key(sha256.Sum256(commitment[:]))
 	err := kv.Put(key.PreimageKey(), commitment[:])

--- a/op-deployer/pkg/deployer/artifacts/download_test.go
+++ b/op-deployer/pkg/deployer/artifacts/download_test.go
@@ -2,6 +2,7 @@ package artifacts
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,8 +13,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/minio/sha256-simd"
 
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/common"


### PR DESCRIPTION
## Summary

This PR removes a small set of stale or unnecessary dependency references. The changes are intentionally narrow: metadata-only cleanups plus test-helper import swaps, with no contract compiler settings, remappings, generated artifacts, protocol code, or CircleCI Codecov jobs touched.

## Dependency and vulnerability impact

Comparing latest `origin/develop` (`e8a82c19d1`) to this PR head (`7ee2d36e02`), the root Go module build list goes from 540 modules to 539 modules. The only removed module is `github.com/crate-crypto/go-kzg-4844 v1.1.0`.

`github.com/minio/sha256-simd` remains present only as an indirect dependency through the existing geth/fastssz dependency path, so that commit removes a direct test import without reducing the full Go build-list size.

## Commit details

### chore: drop unused codecov mise tool

Removes `codecov-uploader` from `mise.toml` in both the managed tool list and the tool alias list.

We do this because the repo no longer uses the mise-managed Codecov uploader. The cleanup only affects local tool provisioning metadata. Codecov upload behavior in CI is preserved because this PR does not edit the CircleCI Codecov upload jobs or orb usage.

This is safe because `codecov-uploader`, `codecov upload`, and `codecov/upload` have no repo references outside `mise.toml`, so removing the mise entry cannot disconnect an in-repo command path.

### chore: remove inert optimism replace from cannon fixtures

Removes the `github.com/ethereum-optimism/optimism` `replace` directive from the Go 1.24 and Go 1.25 Cannon keccak fixture modules.

We do this because those fixture modules do not require the Optimism module. Their `main.go` files only import `fmt` and `golang.org/x/crypto/sha3`, so the replace directive has no effect on module resolution or fixture behavior.

This is safe because the change removes only an unused `replace` line from isolated testdata modules. It does not rewrite dependencies, source code, generated fixture outputs, or Cannon production paths.

### test: use geth kzg types in preimage loader test

Updates `op-challenger/game/fault/trace/utils/preimage_test.go` so the blob helper accepts geth `kzg4844.Commitment` and `kzg4844.Blob` directly instead of casting them through `github.com/crate-crypto/go-kzg-4844` types.

We do this because the test already gets its blob and commitment from the geth KZG type surface and already uses geth `kzg4844` for proof computation and verification. The crate-crypto import was only a test helper type bridge, not a behavior requirement.

This is safe because the helper still writes the same commitment and blob bytes into the in-memory KV store. The affected file is test-only, and `go mod why` confirms the root module no longer needs `github.com/crate-crypto/go-kzg-4844` after the import is removed.

### test: use stdlib sha256 in artifact download test

Updates `op-deployer/pkg/deployer/artifacts/download_test.go` to use `crypto/sha256` instead of `github.com/minio/sha256-simd` for the cache-file hash in the artifact download test.

We do this because the test only needs standard SHA-256 over a URL string via `sha256.Sum256`. The standard library implementation has the same API shape for this use and avoids a direct test import of the MinIO SIMD package.

This is safe because the test logic and hash input are unchanged. `github.com/minio/sha256-simd` remains in `go.mod` only as an indirect dependency through the existing geth/fastssz dependency path, so this PR removes the direct dependency without forcing unrelated module churn.