### PR TITLE
fix(ci): correct BASE_REVISION typo (devlop -> develop)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
     docker:
       - image: << pipeline.parameters.default_docker_image >>
     environment:
-      BASE_REVISION: devlop
+      BASE_REVISION: develop
     steps:
       - checkout
       # yq is used by the "Merge continuation configs" step to deep-merge YAML files.


### PR DESCRIPTION
`prepare-continuation-config` set `BASE_REVISION: devlop`. `collect-params.sh` computes the changed-file set with `git diff --name-only "origin/${BASE_REVISION}...HEAD"` and silently falls back to `git diff HEAD~1 HEAD` on failure. Since `origin/devlop` doesn't exist, the merge-base diff never ran and change detection only saw the **last commit** of a multi-commit PR — so a PR that changed `rust/` or contracts in an earlier commit but ended on a docs-only commit could be misclassified and skip its required tests.

Reproduced: `origin/devlop` does not resolve (triggering the `HEAD~1` fallback); `origin/develop` resolves. No unit test added — `collect-params.sh` isn't unit-tested and `test-decision-tree.sh` stubs the parameter JSON rather than exercising the diff, so there's no natural harness for this one-line config value; the fix is verified by ref resolution.