### PR TITLE
ci: smoke-test bundled binaries in op-challenger image

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -145,6 +145,18 @@ jobs:
           IMAGE_NAME: ${{ matrix.image_name }}
         run: docker run "$IMAGE" "$IMAGE_NAME" --version
 
+      # op-challenger is the only "fat" image: besides itself (run above) it
+      # bundles helper binaries that it execs at runtime. Run each one so a
+      # broken bundled binary (e.g. a runtime-loader/libc mismatch from a
+      # base-image change) fails the build instead of shipping.
+      - name: Run bundled cannon (op-challenger)
+        if: matrix.image_name == 'op-challenger'
+        run: docker run --rm --entrypoint cannon "$IMAGE" --version
+
+      - name: Run bundled kona-host (op-challenger)
+        if: matrix.image_name == 'op-challenger'
+        run: docker run --rm --entrypoint kona-host "$IMAGE" --version
+
   check-cross-platform-rust:
     needs: [plan, build]
     if: |


### PR DESCRIPTION
## Problem

The image-build smoke check (`check-cross-platform` in `build-images.yaml`) runs `docker run <image> <image_name> --version`, exercising only each image's primary binary.

`op-challenger` is the one "fat" image: it bundles helper binaries (`op-program`, `cannon`, `kona-host`) and execs them at runtime during dispute games. The existing check only runs `op-challenger --version`, so a broken bundled binary is invisible.

This gap let a runtime-loader mismatch ship: `cannon` is cgo/musl-linked and could not exec on a glibc-only base image, while `op-challenger --version` kept passing. (Fixed separately in #21236 by restoring the ubuntu base.)

## Change

Add a step to the cross-platform check that, for `op-challenger` only, execs each bundled binary (`op-challenger`, `op-program`, `cannon`, `kona-host`) with `--version`, on both amd64 and arm64 runners. It fails on exit 126/127 (not executable / missing loader) or a signal-termination exit (`>=128`, e.g. 139 SIGSEGV). Other non-zero codes still prove the binary loaded, so they are not treated as failures.

## Verification

Ran all four bundled binaries against the current `op-challenger:develop` image on arm64 — all exit 0. Confirmed the check flags 126/127/signal exits.