### PR TITLE
feat(sdm): enforce block gas limit on pre-refund EVM gas

### DIFF
--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -741,6 +741,32 @@ where
     }
 }
 
+/// Ensures a transaction's gas limit fits within the gas still available in the block.
+///
+/// Checks one condition at a time: pre-Regolith deposits are exempt from this check, and any
+/// other transaction must not declare more gas than remains in the block.
+fn validate_block_gas(
+    transaction_gas_limit: u64,
+    block_available_gas: u64,
+    is_regolith: bool,
+    is_deposit: bool,
+) -> Result<(), BlockExecutionError> {
+    // Pre-Regolith deposits are exempt from the available-block-gas check.
+    if is_deposit && !is_regolith {
+        return Ok(());
+    }
+
+    if transaction_gas_limit > block_available_gas {
+        return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+            transaction_gas_limit,
+            block_available_gas,
+        }
+        .into());
+    }
+
+    Ok(())
+}
+
 impl<E, R, Spec> BlockExecutor for OpBlockExecutor<E, R, Spec>
 where
     E: PostExecEvm<
@@ -796,16 +822,6 @@ where
         let tx_index = self.receipts.len() as u64;
 
         let transaction_gas_limit = tx.tx().gas_limit();
-        let validate_block_gas = |block_available_gas| -> Result<(), BlockExecutionError> {
-            if transaction_gas_limit > block_available_gas && (self.is_regolith || !is_deposit) {
-                return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
-                    transaction_gas_limit,
-                    block_available_gas,
-                }
-                .into());
-            }
-            Ok(())
-        };
 
         // Bound the block's *pre-refund* `evm_gas_used` (real compute) rather than canonical
         // `gas_used`, so SDM refunds can't admit more compute than the block gas limit allows.
@@ -813,7 +829,12 @@ where
         // pre-refund sum within the limit. Since `evm_gas_used >= gas_used`, this subsumes the
         // canonical block-gas-limit check; with SDM off the two are identical.
         let evm_gas_available = self.evm.block().gas_limit().saturating_sub(self.evm_gas_used);
-        validate_block_gas(evm_gas_available)?;
+        validate_block_gas(
+            transaction_gas_limit,
+            evm_gas_available,
+            self.is_regolith,
+            is_deposit,
+        )?;
 
         if is_post_exec {
             let payload =

--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -276,6 +276,11 @@ pub struct OpTxResult<H, T> {
     pub is_deposit: bool,
     /// Whether the transaction is a post-exec transaction.
     pub is_post_exec: bool,
+    /// Gas used by EVM execution before any post-exec (SDM) refund — the "real compute" performed.
+    ///
+    /// Accumulated and bounded against the block gas limit by both block builders and the executor
+    /// (see [`PreRefundGasUsed`]).
+    pub evm_gas_used: u64,
     /// Canonical gas used after any post-exec adjustment.
     pub canonical_gas_used: u64,
     /// Canonical post-exec adjustment, if any.
@@ -283,6 +288,21 @@ pub struct OpTxResult<H, T> {
     /// Cached depositor nonce — looked up during execute so commit can be infallible.
     /// `Some` only for regolith deposit transactions.
     pub depositor_nonce: Option<u64>,
+}
+
+/// Read access to a transaction's pre-refund EVM gas usage.
+///
+/// Lets block builders read `evm_gas_used` through the generic [`BlockExecutor::Result`] type
+/// (otherwise only bounded by `TxResult`) to self-limit a block against the block gas limit.
+pub trait PreRefundGasUsed {
+    /// Gas used by EVM execution, before any post-exec (SDM) refund.
+    fn evm_gas_used(&self) -> u64;
+}
+
+impl<H, T> PreRefundGasUsed for OpTxResult<H, T> {
+    fn evm_gas_used(&self) -> u64 {
+        self.evm_gas_used
+    }
 }
 
 impl<H, T> TxResult for OpTxResult<H, T>
@@ -316,6 +336,10 @@ pub struct OpBlockExecutor<Evm, R: OpReceiptBuilder, Spec> {
     pub receipts: Vec<R::Receipt>,
     /// Total gas used by executed transactions.
     pub gas_used: u64,
+    /// Total pre-refund EVM gas (real compute) across executed txs, before any post-exec (SDM)
+    /// refund. Bounded by the block gas limit; equals [`Self::gas_used`] with SDM off, greater
+    /// otherwise.
+    pub evm_gas_used: u64,
     /// Da footprint.
     ///
     /// This is only set for blocks post-Jovian activation.
@@ -351,6 +375,7 @@ where
             receipt_builder,
             receipts: Vec::new(),
             gas_used: 0,
+            evm_gas_used: 0,
             da_footprint_used: 0,
             ctx,
             l1_block_info: None,
@@ -770,16 +795,25 @@ where
         let is_post_exec = tx.tx().ty() == POST_EXEC_TX_TYPE_ID;
         let tx_index = self.receipts.len() as u64;
 
-        // The sum of the transaction's gas limit, Tg, and the gas utilized in this block prior,
-        // must be no greater than the block's gasLimit.
-        let block_available_gas = self.evm.block().gas_limit() - self.gas_used;
-        if tx.tx().gas_limit() > block_available_gas && (self.is_regolith || !is_deposit) {
-            return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
-                transaction_gas_limit: tx.tx().gas_limit(),
-                block_available_gas,
+        let transaction_gas_limit = tx.tx().gas_limit();
+        let validate_block_gas = |block_available_gas| -> Result<(), BlockExecutionError> {
+            if transaction_gas_limit > block_available_gas && (self.is_regolith || !is_deposit) {
+                return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                    transaction_gas_limit,
+                    block_available_gas,
+                }
+                .into());
             }
-            .into());
-        }
+            Ok(())
+        };
+
+        // Bound the block's *pre-refund* `evm_gas_used` (real compute) rather than canonical
+        // `gas_used`, so SDM refunds can't admit more compute than the block gas limit allows.
+        // Inducting off the declared gas limit (an upper bound on actual `evm_gas_used`) keeps the
+        // pre-refund sum within the limit. Since `evm_gas_used >= gas_used`, this subsumes the
+        // canonical block-gas-limit check; with SDM off the two are identical.
+        let evm_gas_available = self.evm.block().gas_limit().saturating_sub(self.evm_gas_used);
+        validate_block_gas(evm_gas_available)?;
 
         if is_post_exec {
             let payload =
@@ -809,6 +843,7 @@ where
                 },
                 is_deposit: false,
                 is_post_exec: true,
+                evm_gas_used: 0,
                 canonical_gas_used: 0,
                 post_exec: None,
                 depositor_nonce: None,
@@ -820,7 +855,8 @@ where
             .is_jovian_active_at_timestamp(self.evm.block().timestamp().saturating_to()) &&
             !is_deposit
         {
-            let da_footprint_available = self.evm.block().gas_limit() - self.da_footprint_used;
+            let da_footprint_available =
+                self.evm.block().gas_limit().saturating_sub(self.da_footprint_used);
 
             let tx_da_footprint = self.jovian_da_footprint_estimation(&tx_env, &tx)?;
 
@@ -914,6 +950,7 @@ where
             },
             is_deposit,
             is_post_exec: false,
+            evm_gas_used,
             canonical_gas_used,
             post_exec,
             depositor_nonce,
@@ -926,6 +963,7 @@ where
             inner: EthTxResult { result: ResultAndState { result, state }, blob_gas_used, tx_type },
             is_deposit,
             is_post_exec,
+            evm_gas_used,
             canonical_gas_used,
             post_exec,
             depositor_nonce,
@@ -952,6 +990,9 @@ where
 
         // add canonical gas used
         self.gas_used += canonical_gas_used;
+        // Accumulate pre-refund EVM gas (real compute); bounded against the block gas limit by the
+        // admission check in `execute_transaction_without_commit`.
+        self.evm_gas_used += evm_gas_used;
 
         // Update DA footprint if Jovian is active
         if self.spec.is_jovian_active_at_timestamp(self.evm.block().timestamp().saturating_to()) &&

--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -829,12 +829,7 @@ where
         // pre-refund sum within the limit. Since `evm_gas_used >= gas_used`, this subsumes the
         // canonical block-gas-limit check; with SDM off the two are identical.
         let evm_gas_available = self.evm.block().gas_limit().saturating_sub(self.evm_gas_used);
-        validate_block_gas(
-            transaction_gas_limit,
-            evm_gas_available,
-            self.is_regolith,
-            is_deposit,
-        )?;
+        validate_block_gas(transaction_gas_limit, evm_gas_available, self.is_regolith, is_deposit)?;
 
         if is_post_exec {
             let payload =

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -269,6 +269,90 @@ fn test_jovian_da_footprint_estimation_maxed_out_da_footprint() {
     assert!(result.blob_gas_used > result.gas_used);
 }
 
+/// Asserts that `err` is a `TransactionGasLimitMoreThanAvailableBlockGas` with the expected fields.
+fn assert_gas_limit_exceeded(
+    err: BlockExecutionError,
+    expected_tx_gas_limit: u64,
+    expected_available: u64,
+) {
+    match err {
+        BlockExecutionError::Validation(
+            BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                transaction_gas_limit,
+                block_available_gas,
+            },
+        ) => {
+            assert_eq!(transaction_gas_limit, expected_tx_gas_limit);
+            assert_eq!(block_available_gas, expected_available);
+        }
+        other => panic!("expected TransactionGasLimitMoreThanAvailableBlockGas, got: {other:?}"),
+    }
+}
+
+// SDM-off regression: with refunds disabled `evm_gas_used` equals `gas_used`, so a tx over the
+// block gas limit is rejected with the full block gas limit as available gas.
+#[test]
+fn test_pre_refund_gas_limit_never_binds_with_sdm_off() {
+    const BLOCK_GAS_LIMIT: u64 = 100_000;
+    let mut fixture =
+        SDMExecutorFixture::new(DEFAULT_DA_FOOTPRINT_GAS_SCALAR, BLOCK_GAS_LIMIT, JOVIAN_TIMESTAMP);
+    let mut executor = fixture.executor();
+
+    let tx = recovered_legacy(TxLegacy { gas_limit: BLOCK_GAS_LIMIT + 1, ..Default::default() });
+    let err = executor.execute_transaction(&tx).expect_err("tx over the block gas limit");
+
+    assert_gas_limit_exceeded(err, BLOCK_GAS_LIMIT + 1, BLOCK_GAS_LIMIT);
+}
+
+// SDM refunds lower canonical gas but must not increase the real compute admitted into a block:
+// after a refund, a tx that fits canonical `gas_used` while exceeding the pre-refund `evm_gas_used`
+// budget must still be rejected.
+#[test]
+fn test_pre_refund_gas_limit_counts_sdm_refunded_gas() {
+    const BLOCK_GAS_LIMIT: u64 = 100_000;
+    let target = Address::from([0x11; 20]);
+    let tx0 = recovered_legacy(TxLegacy {
+        nonce: 0,
+        gas_limit: 50_000,
+        to: alloy_primitives::TxKind::Call(target),
+        ..Default::default()
+    });
+    let tx1 = recovered_legacy(TxLegacy {
+        nonce: 1,
+        gas_limit: 50_000,
+        to: alloy_primitives::TxKind::Call(target),
+        ..Default::default()
+    });
+
+    let mut fixture =
+        SDMExecutorFixture::new(DEFAULT_DA_FOOTPRINT_GAS_SCALAR, BLOCK_GAS_LIMIT, JOVIAN_TIMESTAMP);
+    let mut executor = fixture.executor_with_post_exec_mode(PostExecMode::Produce);
+    executor.execute_transaction(&tx0).expect("first tx fits");
+    executor.execute_transaction(&tx1).expect("second tx fits and receives a refund");
+
+    assert!(executor.evm_gas_used > executor.gas_used, "expected SDM to refund canonical gas");
+    let evm_gas_available = BLOCK_GAS_LIMIT - executor.evm_gas_used;
+    let canonical_gas_available = BLOCK_GAS_LIMIT - executor.gas_used;
+    assert!(evm_gas_available < canonical_gas_available);
+
+    let tx2_gas_limit = evm_gas_available + 1;
+    assert!(
+        tx2_gas_limit <= canonical_gas_available,
+        "test tx should fit canonical gas but exceed pre-refund gas"
+    );
+    let tx2 = recovered_legacy(TxLegacy {
+        nonce: 2,
+        gas_limit: tx2_gas_limit,
+        to: alloy_primitives::TxKind::Call(target),
+        ..Default::default()
+    });
+
+    let err = executor
+        .execute_transaction(&tx2)
+        .expect_err("tx exceeding pre-refund block gas must be rejected");
+    assert_gas_limit_exceeded(err, tx2_gas_limit, evm_gas_available);
+}
+
 mod sdm {
     use super::*;
     use alloy_consensus::Sealable;
@@ -286,12 +370,34 @@ mod sdm {
     }
 
     fn legacy_tx(nonce: u64, to: Address) -> Recovered<OpTxEnvelope> {
+        legacy_tx_with_gas(nonce, to, 50_000)
+    }
+
+    fn legacy_tx_with_gas(nonce: u64, to: Address, gas_limit: u64) -> Recovered<OpTxEnvelope> {
         recovered_legacy(TxLegacy {
             nonce,
-            gas_limit: 50_000,
+            gas_limit,
             to: alloy_primitives::TxKind::Call(to),
             ..Default::default()
         })
+    }
+
+    fn full_refund_for_second_tx(
+        block_gas_limit: u64,
+        tx0: &Recovered<OpTxEnvelope>,
+        tx1: &Recovered<OpTxEnvelope>,
+    ) -> Vec<SDMGasEntry> {
+        let mut fixture = SDMExecutorFixture::new(
+            DEFAULT_DA_FOOTPRINT_GAS_SCALAR,
+            block_gas_limit,
+            JOVIAN_TIMESTAMP,
+        );
+        let mut probe = fixture.executor();
+        probe.execute_transaction(tx0).expect("probe first tx");
+        let tx1_evm_gas_used =
+            probe.execute_transaction(tx1).expect("probe second tx").tx_gas_used();
+
+        vec![SDMGasEntry { index: 1, gas_refund: tx1_evm_gas_used }]
     }
 
     fn assert_invalid_post_exec(err: BlockExecutionError, expected_reason: &str) {
@@ -400,6 +506,97 @@ mod sdm {
         assert_eq!(verified.blob_gas_used, produced.blob_gas_used);
         assert_eq!(verified.receipts, produced.receipts);
         assert_eq!(verified.receipts.len(), user_txs.len() + 1);
+    }
+
+    // Demonstrates the accounting the pre-refund cap relies on: under SDM refunds, canonical
+    // `gas_used` falls below `evm_gas_used`, so capping on `evm_gas_used` (not `gas_used`) keeps
+    // tracking the real compute performed.
+    #[test]
+    fn test_evm_gas_used_tracks_pre_refund_gas_under_sdm() {
+        let target = Address::from([0x11; 20]);
+        let user_txs = vec![legacy_tx(0, target), legacy_tx(1, target)];
+
+        let mut fixture = SDMExecutorFixture::default();
+        let mut producer = fixture.executor_with_post_exec_mode(PostExecMode::Produce);
+        for tx in &user_txs {
+            producer.execute_transaction(tx).expect("producer executes user tx");
+        }
+
+        // The second tx reuses block-warmed addresses and earns an SDM refund, so canonical gas is
+        // strictly less than the pre-refund EVM gas spent.
+        assert!(!producer.post_exec_entries().is_empty(), "expected an SDM refund to be produced");
+        assert!(
+            producer.evm_gas_used > producer.gas_used,
+            "pre-refund evm_gas_used ({}) must exceed canonical gas_used ({}) once refunds apply",
+            producer.evm_gas_used,
+            producer.gas_used,
+        );
+        // The gap is exactly the total refund.
+        let total_refund: u64 = producer.post_exec_entries().iter().map(|e| e.gas_refund).sum();
+        assert_eq!(producer.evm_gas_used - producer.gas_used, total_refund);
+    }
+
+    #[test]
+    fn test_verifier_rejects_malicious_payload_whose_refunds_hide_pre_refund_overuse() {
+        const BLOCK_GAS_LIMIT: u64 = 100_000;
+        let target = Address::from([0x11; 20]);
+        let tx0 = legacy_tx(0, target);
+        let tx1 = legacy_tx(1, target);
+
+        // Refund the second tx completely. The verifier accepts refund == evm_gas_used but must not
+        // let that canonical-gas discount buy extra real compute later in the block.
+        let entries = full_refund_for_second_tx(BLOCK_GAS_LIMIT, &tx0, &tx1);
+
+        let mut fixture = SDMExecutorFixture::new(
+            DEFAULT_DA_FOOTPRINT_GAS_SCALAR,
+            BLOCK_GAS_LIMIT,
+            JOVIAN_TIMESTAMP,
+        );
+        let mut verifier = fixture.verifier(0, entries);
+        verifier.execute_transaction(&tx0).expect("first tx fits");
+        verifier.execute_transaction(&tx1).expect("second tx is fully refunded canonically");
+
+        let evm_gas_available = BLOCK_GAS_LIMIT - verifier.evm_gas_used;
+        let canonical_gas_available = BLOCK_GAS_LIMIT - verifier.gas_used;
+        assert!(evm_gas_available < canonical_gas_available);
+
+        let tx2_gas_limit = evm_gas_available + 1;
+        assert!(
+            tx2_gas_limit <= canonical_gas_available,
+            "malicious tx should fit canonical gas but exceed pre-refund gas"
+        );
+        let tx2 = legacy_tx_with_gas(2, target, tx2_gas_limit);
+
+        let err = verifier
+            .execute_transaction(&tx2)
+            .expect_err("verifier must reject pre-refund gas overuse even if refunds hide it");
+        assert_gas_limit_exceeded(err, tx2_gas_limit, evm_gas_available);
+    }
+
+    #[test]
+    fn test_verifier_accepts_payload_when_pre_refund_stays_below_limit() {
+        const BLOCK_GAS_LIMIT: u64 = 100_000;
+        let target = Address::from([0x11; 20]);
+        let tx0 = legacy_tx(0, target);
+        let tx1 = legacy_tx(1, target);
+        let entries = full_refund_for_second_tx(BLOCK_GAS_LIMIT, &tx0, &tx1);
+
+        let mut fixture = SDMExecutorFixture::new(
+            DEFAULT_DA_FOOTPRINT_GAS_SCALAR,
+            BLOCK_GAS_LIMIT,
+            JOVIAN_TIMESTAMP,
+        );
+        let mut verifier = fixture.verifier(0, entries.clone());
+        verifier.execute_transaction(&tx0).expect("first tx fits");
+        verifier.execute_transaction(&tx1).expect("second tx is fully refunded canonically");
+
+        let tx2 = legacy_tx_with_gas(2, target, BLOCK_GAS_LIMIT - verifier.evm_gas_used);
+        verifier
+            .execute_transaction(&tx2)
+            .expect("tx declared within the remaining pre-refund budget is accepted");
+        let post_exec_recovered = recovered_post_exec(0, entries);
+        verifier.execute_transaction(&post_exec_recovered).expect("post-exec tx verifies");
+        verifier.finish().expect("verifier finishes accepted boundary block");
     }
 
     #[test]

--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -47,7 +47,9 @@ pub mod tx;
 pub use tx::OpTx;
 
 pub mod block;
-pub use block::{OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory, PostExecMode};
+pub use block::{
+    OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory, PostExecMode, PreRefundGasUsed,
+};
 
 pub mod post_exec;
 

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/builder_tx.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/builder_tx.rs
@@ -5,7 +5,7 @@ use alloy_evm::{
     block::{BlockExecutor as AlloyBlockExecutor, CommitChanges, TxResult},
     rpc::TryIntoTxEnv,
 };
-use alloy_op_evm::{OpEvm, OpTx};
+use alloy_op_evm::{OpEvm, OpTx, PreRefundGasUsed};
 use alloy_primitives::{
     Address, B256, Bytes, TxKind, U256,
     map::{AddressMap, HashSet},
@@ -188,6 +188,7 @@ pub trait BuilderTransactions<ExtraCtx: Debug + Default = (), Extra: Debug + Def
                 Transaction = OpTransactionSigned,
                 Receipt = OpReceipt,
                 Evm: alloy_evm::Evm<DB: core::ops::Deref<Target = State<DB>>>,
+                Result: PreRefundGasUsed,
             >,
         DB: Database,
     {
@@ -213,11 +214,14 @@ pub trait BuilderTransactions<ExtraCtx: Debug + Default = (), Extra: Debug + Def
             }
 
             let mut gas_used = 0;
+            let mut evm_gas_used = 0;
             let committed = match builder.execute_transaction_with_commit_condition(
                 builder_tx.signed_tx.clone(),
                 |result| {
-                    gas_used = result.result().result.tx_gas_used();
-                    if result.result().result.is_success() {
+                    let execution_result = &result.result().result;
+                    gas_used = execution_result.tx_gas_used();
+                    evm_gas_used = result.evm_gas_used();
+                    if execution_result.is_success() {
                         CommitChanges::Yes
                     } else {
                         warn!(target: "payload_builder", tx_hash = ?builder_tx.signed_tx.tx_hash(), "builder tx reverted");
@@ -254,6 +258,7 @@ pub trait BuilderTransactions<ExtraCtx: Debug + Default = (), Extra: Debug + Def
             }
 
             info.cumulative_gas_used += gas_used;
+            info.cumulative_evm_gas_used += evm_gas_used;
             info.cumulative_da_bytes_used += builder_tx.da_size;
             info.receipts.push(
                 last_receipt_with_cumulative_gas(builder.executor(), info.cumulative_gas_used)

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
@@ -4,6 +4,7 @@ use alloy_evm::{
     Database, Evm as AlloyEvm,
     block::{BlockExecutor as AlloyBlockExecutor, CommitChanges, TxResult},
 };
+use alloy_op_evm::PreRefundGasUsed;
 use alloy_primitives::{BlockHash, Bytes, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use core::fmt::Debug;
@@ -321,6 +322,7 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
                 Transaction = OpTransactionSigned,
                 Receipt = OpReceipt,
                 Evm: AlloyEvm<DB: DerefMut<Target = State<DB>>>,
+                Result: PreRefundGasUsed,
             >,
         > + 'a,
         PayloadBuilderError,
@@ -382,7 +384,12 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
             };
 
             // add gas used by the transaction to cumulative gas used, before creating the receipt
-            info.cumulative_gas_used += gas_used.tx_gas_used();
+            let tx_gas_used = gas_used.tx_gas_used();
+            info.cumulative_gas_used += tx_gas_used;
+            // Sequencer txs (deposits/system txs) are never SDM-refunded, so pre-refund gas equals
+            // canonical gas; track it to stay in lockstep with the executor's pre-refund accumulator
+            // (otherwise we'd admit a tx the executor then fatally rejects).
+            info.cumulative_evm_gas_used += tx_gas_used;
 
             if !sequencer_tx.is_deposit() {
                 info.cumulative_da_bytes_used += op_alloy_flz::tx_estimated_size_fjord_bytes(
@@ -429,6 +436,7 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
         Builder: BlockBuilder<Primitives = reth_optimism_primitives::OpPrimitives>,
         Builder::Executor:
             AlloyBlockExecutor<Transaction = OpTransactionSigned, Receipt = OpReceipt>,
+        <Builder::Executor as AlloyBlockExecutor>::Result: PreRefundGasUsed,
     {
         let execute_txs_start_time = Instant::now();
         let mut num_txs_considered = 0;
@@ -537,14 +545,17 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
 
             let tx_simulation_start_time = Instant::now();
             let mut gas_used = 0;
+            let mut evm_gas_used = 0;
             let mut tx_succeeded = false;
             let mut gas_limit_exceeded = false;
             let mut address_limit_exceeded = false;
             let committed = match builder.execute_transaction_with_commit_condition(
                 tx.clone(),
                 |result| {
-                    gas_used = result.result().result.tx_gas_used();
-                    tx_succeeded = result.result().result.is_success();
+                    let execution_result = &result.result().result;
+                    gas_used = execution_result.tx_gas_used();
+                    evm_gas_used = result.evm_gas_used();
+                    tx_succeeded = execution_result.is_success();
                     gas_limit_exceeded = self
                         .max_gas_per_txn
                         .is_some_and(|max_gas_per_txn| gas_used > max_gas_per_txn);
@@ -627,6 +638,7 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
             }
 
             info.cumulative_gas_used += gas_used;
+            info.cumulative_evm_gas_used += evm_gas_used;
             info.cumulative_da_bytes_used += tx_da_size;
 
             info.receipts.push(

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -20,6 +20,7 @@ use alloy_consensus::{
 };
 use alloy_eips::{Encodable2718, eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
 use alloy_evm::block::BlockExecutor as AlloyBlockExecutor;
+use alloy_op_evm::PreRefundGasUsed;
 use alloy_primitives::{Address, B256, U256, map::foldhash::HashMap};
 use core::time::Duration;
 use eyre::WrapErr as _;
@@ -692,6 +693,7 @@ where
                 Transaction = OpTransactionSigned,
                 Receipt = OpReceipt,
                 Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+                Result: PreRefundGasUsed,
             >,
         DB: Database + std::fmt::Debug + AsRef<P>,
     {
@@ -1246,6 +1248,7 @@ fn execute_pre_steps<'a, DB, ExtraCtx>(
             Executor: PostExecExecutorExt
                           + AlloyBlockExecutor<
                 Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+                Result: PreRefundGasUsed,
             >,
         > + 'a,
         ExecutionInfo<FlashblocksExecutionInfo>,

--- a/rust/op-rbuilder/crates/op-rbuilder/src/primitives/reth/execution.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/primitives/reth/execution.rs
@@ -12,6 +12,10 @@ pub enum TxnExecutionResult {
     BlockDALimitExceeded(u64, u64, u64),
     #[display("TransactionGasLimitExceeded: total_gas_used={_0} tx_gas_limit={_1}")]
     TransactionGasLimitExceeded(u64, u64, u64),
+    #[display(
+        "PreRefundGasLimitExceeded: cumulative_evm_gas_used={_0} tx_gas_limit={_1} block_gas_limit={_2}"
+    )]
+    PreRefundGasLimitExceeded(u64, u64, u64),
     SequencerTransaction,
     NonceTooLow,
     InteropFailed,
@@ -34,6 +38,11 @@ pub struct ExecutionInfo<Extra: Debug + Default = ()> {
     pub receipts: Vec<OpReceipt>,
     /// All gas used so far
     pub cumulative_gas_used: u64,
+    /// All pre-refund EVM gas (real compute) so far, before any SDM/post-exec refund.
+    ///
+    /// Persists across flashblocks (each gets a fresh executor whose accumulator resets), so it is
+    /// the binding quantity for the cross-flashblock pre-refund block-gas cap.
+    pub cumulative_evm_gas_used: u64,
     /// Estimated DA size
     pub cumulative_da_bytes_used: u64,
     /// Tracks fees from executed mempool transactions
@@ -52,6 +61,7 @@ impl<T: Debug + Default> ExecutionInfo<T> {
             executed_senders: Vec::with_capacity(capacity),
             receipts: Vec::with_capacity(capacity),
             cumulative_gas_used: 0,
+            cumulative_evm_gas_used: 0,
             cumulative_da_bytes_used: 0,
             total_fees: U256::ZERO,
             extra: Default::default(),
@@ -101,6 +111,10 @@ impl<T: Debug + Default> ExecutionInfo<T> {
             }
         }
 
+        // Canonical (post-refund) block-gas-limit check. The pre-refund check below subsumes the
+        // *bound* (since `cumulative_evm_gas_used >= cumulative_gas_used`), but this is kept as a
+        // distinct diagnostic: it fires only when even canonical gas overflows (the only case with
+        // SDM off).
         if self.cumulative_gas_used + tx_gas_limit > block_gas_limit {
             return Err(TxnExecutionResult::TransactionGasLimitExceeded(
                 self.cumulative_gas_used,
@@ -108,6 +122,49 @@ impl<T: Debug + Default> ExecutionInfo<T> {
                 block_gas_limit,
             ));
         }
+
+        // Cap real compute (pre-refund EVM gas) at the block gas limit, regardless of SDM refunds.
+        // Binds across flashblocks because `cumulative_evm_gas_used` persists while the per-
+        // flashblock executor accumulator resets. With SDM on, this fires (where the canonical check
+        // above did not) when refunds let canonical gas fit but real compute is the binding limit.
+        if self.cumulative_evm_gas_used + tx_gas_limit > block_gas_limit {
+            return Err(TxnExecutionResult::PreRefundGasLimitExceeded(
+                self.cumulative_evm_gas_used,
+                tx_gas_limit,
+                block_gas_limit,
+            ));
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pre_refund_limit_uses_evm_gas_not_canonical_gas() {
+        let mut info: ExecutionInfo = ExecutionInfo::with_capacity(0);
+        info.cumulative_gas_used = 50;
+        info.cumulative_evm_gas_used = 90;
+
+        assert!(
+            info.is_tx_over_limits(0, 100, None, None, 10, None, None)
+                .is_ok(),
+            "tx exactly filling the remaining pre-refund budget should fit"
+        );
+
+        match info.is_tx_over_limits(0, 100, None, None, 11, None, None) {
+            Err(TxnExecutionResult::PreRefundGasLimitExceeded(
+                cumulative_evm_gas_used,
+                tx_gas_limit,
+                block_gas_limit,
+            )) => {
+                assert_eq!(cumulative_evm_gas_used, 90);
+                assert_eq!(tx_gas_limit, 11);
+                assert_eq!(block_gas_limit, 100);
+            }
+            other => panic!("expected pre-refund gas limit error, got {other:?}"),
+        }
     }
 }

--- a/rust/op-rbuilder/crates/op-rbuilder/src/primitives/reth/execution/mod.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/primitives/reth/execution/mod.rs
@@ -139,32 +139,4 @@ impl<T: Debug + Default> ExecutionInfo<T> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn pre_refund_limit_uses_evm_gas_not_canonical_gas() {
-        let mut info: ExecutionInfo = ExecutionInfo::with_capacity(0);
-        info.cumulative_gas_used = 50;
-        info.cumulative_evm_gas_used = 90;
-
-        assert!(
-            info.is_tx_over_limits(0, 100, None, None, 10, None, None)
-                .is_ok(),
-            "tx exactly filling the remaining pre-refund budget should fit"
-        );
-
-        match info.is_tx_over_limits(0, 100, None, None, 11, None, None) {
-            Err(TxnExecutionResult::PreRefundGasLimitExceeded(
-                cumulative_evm_gas_used,
-                tx_gas_limit,
-                block_gas_limit,
-            )) => {
-                assert_eq!(cumulative_evm_gas_used, 90);
-                assert_eq!(tx_gas_limit, 11);
-                assert_eq!(block_gas_limit, 100);
-            }
-            other => panic!("expected pre-refund gas limit error, got {other:?}"),
-        }
-    }
-}
+mod tests;

--- a/rust/op-rbuilder/crates/op-rbuilder/src/primitives/reth/execution/mod.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/primitives/reth/execution/mod.rs
@@ -115,7 +115,7 @@ impl<T: Debug + Default> ExecutionInfo<T> {
         // *bound* (since `cumulative_evm_gas_used >= cumulative_gas_used`), but this is kept as a
         // distinct diagnostic: it fires only when even canonical gas overflows (the only case with
         // SDM off).
-        if self.cumulative_gas_used + tx_gas_limit > block_gas_limit {
+        if self.cumulative_gas_used.saturating_add(tx_gas_limit) > block_gas_limit {
             return Err(TxnExecutionResult::TransactionGasLimitExceeded(
                 self.cumulative_gas_used,
                 tx_gas_limit,
@@ -127,7 +127,7 @@ impl<T: Debug + Default> ExecutionInfo<T> {
         // Binds across flashblocks because `cumulative_evm_gas_used` persists while the per-
         // flashblock executor accumulator resets. With SDM on, this fires (where the canonical check
         // above did not) when refunds let canonical gas fit but real compute is the binding limit.
-        if self.cumulative_evm_gas_used + tx_gas_limit > block_gas_limit {
+        if self.cumulative_evm_gas_used.saturating_add(tx_gas_limit) > block_gas_limit {
             return Err(TxnExecutionResult::PreRefundGasLimitExceeded(
                 self.cumulative_evm_gas_used,
                 tx_gas_limit,

--- a/rust/op-rbuilder/crates/op-rbuilder/src/primitives/reth/execution/tests.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/primitives/reth/execution/tests.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+#[test]
+fn pre_refund_limit_uses_evm_gas_not_canonical_gas() {
+    let mut info: ExecutionInfo = ExecutionInfo::with_capacity(0);
+    info.cumulative_gas_used = 50;
+    info.cumulative_evm_gas_used = 90;
+
+    assert!(
+        info.is_tx_over_limits(0, 100, None, None, 10, None, None)
+            .is_ok(),
+        "tx exactly filling the remaining pre-refund budget should fit"
+    );
+
+    match info.is_tx_over_limits(0, 100, None, None, 11, None, None) {
+        Err(TxnExecutionResult::PreRefundGasLimitExceeded(
+            cumulative_evm_gas_used,
+            tx_gas_limit,
+            block_gas_limit,
+        )) => {
+            assert_eq!(cumulative_evm_gas_used, 90);
+            assert_eq!(tx_gas_limit, 11);
+            assert_eq!(block_gas_limit, 100);
+        }
+        other => panic!("expected pre-refund gas limit error, got {other:?}"),
+    }
+}

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -68,6 +68,7 @@ pub use tx::OpTx;
 
 pub use alloy_op_evm::{
     OpBlockExecutionCtx, OpBlockExecutorFactory, OpEvm, OpEvmFactory, PostExecMode,
+    PreRefundGasUsed,
     post_exec::{PostExecExecutorExt, WarmingRefundEvent, WarmingRefundKind, WarmingState},
 };
 

--- a/rust/op-reth/crates/evm/src/post_exec_ext.rs
+++ b/rust/op-reth/crates/evm/src/post_exec_ext.rs
@@ -2,7 +2,7 @@ use alloc::{sync::Arc, vec::Vec};
 use alloy_consensus::Header;
 use alloy_evm::{FromRecoveredTx, FromTxWithEncoded, block::BlockExecutor};
 use alloy_op_evm::{
-    OpBlockExecutor,
+    OpBlockExecutor, PreRefundGasUsed,
     block::{OpTxEnv, receipt_builder::OpReceiptBuilder},
     post_exec::{PostExecEvmFactoryAdapter, PostExecEvmFactoryHooks, PostExecExecutorExt},
 };
@@ -60,6 +60,7 @@ pub trait ConfigurePostExecEvm: ConfigureEvm {
             Executor: PostExecExecutorExt
                           + BlockExecutor<
                 Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+                Result: PreRefundGasUsed,
             >,
         > + 'a,
         Self::Error,
@@ -123,6 +124,7 @@ where
             Executor: PostExecExecutorExt
                           + BlockExecutor<
                 Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+                Result: PreRefundGasUsed,
             >,
         > + 'a,
         Self::Error,
@@ -226,6 +228,7 @@ where
             Executor: PostExecExecutorExt
                           + BlockExecutor<
                 Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+                Result: PreRefundGasUsed,
             >,
         > + 'a,
         Self::Error,

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -645,7 +645,7 @@ impl ExecutionInfo {
     /// Adds a transaction's gas to both the canonical and pre-refund (real compute) counters,
     /// saturating to guard against overflow. `evm_gas` equals `canonical_gas` when SDM refunds
     /// are off. Encapsulated so the saturating add is enforced at every call site.
-    pub fn accumulate_gas(&mut self, canonical_gas: u64, evm_gas: u64) {
+    pub const fn accumulate_gas(&mut self, canonical_gas: u64, evm_gas: u64) {
         self.cumulative_gas_used = self.cumulative_gas_used.saturating_add(canonical_gas);
         self.cumulative_evm_gas_used = self.cumulative_evm_gas_used.saturating_add(evm_gas);
     }

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -642,6 +642,14 @@ impl ExecutionInfo {
         }
     }
 
+    /// Adds a transaction's gas to both the canonical and pre-refund (real compute) counters,
+    /// saturating to guard against overflow. `evm_gas` equals `canonical_gas` when SDM refunds
+    /// are off. Encapsulated so the saturating add is enforced at every call site.
+    pub fn accumulate_gas(&mut self, canonical_gas: u64, evm_gas: u64) {
+        self.cumulative_gas_used = self.cumulative_gas_used.saturating_add(canonical_gas);
+        self.cumulative_evm_gas_used = self.cumulative_evm_gas_used.saturating_add(evm_gas);
+    }
+
     /// Returns true if the transaction would exceed the block limits:
     /// - block gas limit: ensures the transaction still fits into the block.
     /// - tx DA limit: if configured, ensures the tx does not exceed the maximum allowed DA limit
@@ -680,7 +688,7 @@ impl ExecutionInfo {
         // Inducting off the declared gas limit bounds the actual sum. Since
         // `cumulative_evm_gas_used >= cumulative_gas_used`, this subsumes the canonical
         // block-gas-limit check; with SDM off the two are identical.
-        self.cumulative_evm_gas_used + tx_gas_limit > block_gas_limit
+        self.cumulative_evm_gas_used.saturating_add(tx_gas_limit) > block_gas_limit
     }
 }
 
@@ -833,10 +841,9 @@ where
 
             // add gas used by the transaction to cumulative gas used, before creating the receipt
             let tx_gas_used = gas_used.tx_gas_used();
-            info.cumulative_gas_used += tx_gas_used;
             // Sequencer txs (deposits/system txs) are never SDM-refunded, so pre-refund gas equals
             // canonical gas; track it so the pool-tx pre-refund check starts from the right total.
-            info.cumulative_evm_gas_used += tx_gas_used;
+            info.accumulate_gas(tx_gas_used, tx_gas_used);
 
             // Record the successfully committed transaction for callers that want per-call
             // visibility.
@@ -974,8 +981,7 @@ where
             // add gas used by the transaction to cumulative gas used, before creating the
             // receipt
             let tx_gas_used = gas_used.tx_gas_used();
-            info.cumulative_gas_used += tx_gas_used;
-            info.cumulative_evm_gas_used += evm_gas_used;
+            info.accumulate_gas(tx_gas_used, evm_gas_used);
             info.cumulative_da_bytes_used += tx_da_size;
 
             // update and add to total fees

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -23,7 +23,9 @@ use reth_metrics::{
     Metrics,
     metrics::{self, Counter, Gauge},
 };
-use reth_optimism_evm::{ConfigurePostExecEvm, PostExecExecutorExt, PostExecMode};
+use reth_optimism_evm::{
+    ConfigurePostExecEvm, PostExecExecutorExt, PostExecMode, PreRefundGasUsed,
+};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::{L2_TO_L1_MESSAGE_PASSER_ADDRESS, OpTransaction};
 use reth_optimism_txpool::{
@@ -617,6 +619,12 @@ pub struct ExecutedPayload<N: NodePrimitives> {
 pub struct ExecutionInfo {
     /// All gas used so far
     pub cumulative_gas_used: u64,
+    /// All pre-refund EVM gas (real compute) so far, before any SDM/post-exec refund.
+    ///
+    /// Bounds the block against the block gas limit regardless of refunds, so an honest block
+    /// never trips the executor's consensus check. Equals [`Self::cumulative_gas_used`] with
+    /// SDM off.
+    pub cumulative_evm_gas_used: u64,
     /// Estimated DA size
     pub cumulative_da_bytes_used: u64,
     /// Tracks fees from executed mempool transactions
@@ -626,7 +634,12 @@ pub struct ExecutionInfo {
 impl ExecutionInfo {
     /// Create a new instance with allocated slots.
     pub const fn new() -> Self {
-        Self { cumulative_gas_used: 0, cumulative_da_bytes_used: 0, total_fees: U256::ZERO }
+        Self {
+            cumulative_gas_used: 0,
+            cumulative_evm_gas_used: 0,
+            cumulative_da_bytes_used: 0,
+            total_fees: U256::ZERO,
+        }
     }
 
     /// Returns true if the transaction would exceed the block limits:
@@ -663,7 +676,11 @@ impl ExecutionInfo {
             }
         }
 
-        self.cumulative_gas_used + tx_gas_limit > block_gas_limit
+        // Cap real compute (pre-refund EVM gas) at the block gas limit, regardless of SDM refunds.
+        // Inducting off the declared gas limit bounds the actual sum. Since
+        // `cumulative_evm_gas_used >= cumulative_gas_used`, this subsumes the canonical
+        // block-gas-limit check; with SDM off the two are identical.
+        self.cumulative_evm_gas_used + tx_gas_limit > block_gas_limit
     }
 }
 
@@ -747,7 +764,10 @@ where
         &'a self,
         db: &'a mut State<DB>,
     ) -> Result<
-        impl BlockBuilder<Primitives = Evm::Primitives, Executor: PostExecExecutorExt> + 'a,
+        impl BlockBuilder<
+            Primitives = Evm::Primitives,
+            Executor: PostExecExecutorExt + BlockExecutor<Result: PreRefundGasUsed>,
+        > + 'a,
         PayloadBuilderError,
     > {
         let post_exec_mode: PostExecMode = self.sdm_production_enabled().into();
@@ -812,7 +832,11 @@ where
             };
 
             // add gas used by the transaction to cumulative gas used, before creating the receipt
-            info.cumulative_gas_used += gas_used.tx_gas_used();
+            let tx_gas_used = gas_used.tx_gas_used();
+            info.cumulative_gas_used += tx_gas_used;
+            // Sequencer txs (deposits/system txs) are never SDM-refunded, so pre-refund gas equals
+            // canonical gas; track it so the pool-tx pre-refund check starts from the right total.
+            info.cumulative_evm_gas_used += tx_gas_used;
 
             // Record the successfully committed transaction for callers that want per-call
             // visibility.
@@ -849,6 +873,7 @@ where
     where
         Builder: BlockBuilder<Primitives = Evm::Primitives>,
         <<Builder::Executor as BlockExecutor>::Evm as AlloyEvm>::DB: Database,
+        <Builder::Executor as BlockExecutor>::Result: PreRefundGasUsed,
     {
         let mut block_gas_limit = builder.evm_mut().block().gas_limit();
         if let Some(gas_limit_config) = self.builder_config.gas_limit_config.gas_limit() {
@@ -919,7 +944,11 @@ where
                 return Ok(Some(()));
             }
 
-            let gas_used = match builder.execute_transaction(tx.clone()) {
+            let mut evm_gas_used = 0;
+            let gas_used = match builder
+                .execute_transaction_with_result_closure(tx.clone(), |result| {
+                    evm_gas_used = result.evm_gas_used()
+                }) {
                 Ok(gas_used) => gas_used,
                 Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
                     error,
@@ -946,6 +975,7 @@ where
             // receipt
             let tx_gas_used = gas_used.tx_gas_used();
             info.cumulative_gas_used += tx_gas_used;
+            info.cumulative_evm_gas_used += evm_gas_used;
             info.cumulative_da_bytes_used += tx_da_size;
 
             // update and add to total fees

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -158,6 +158,22 @@ where
 }
 
 #[test]
+fn execution_info_pre_refund_limit_uses_evm_gas_not_canonical_gas() {
+    let mut info = ExecutionInfo::new();
+    info.cumulative_gas_used = 50;
+    info.cumulative_evm_gas_used = 90;
+
+    assert!(
+        !info.is_tx_over_limits(0, 100, None, None, 10, None),
+        "tx exactly filling the remaining pre-refund budget should fit"
+    );
+    assert!(
+        info.is_tx_over_limits(0, 100, None, None, 11, None),
+        "tx that fits canonical gas but exceeds pre-refund gas must be skipped"
+    );
+}
+
+#[test]
 fn execute_best_transactions_committed_txs_preserves_execution() {
     let mut committed_txs = Vec::new();
     let signer = Address::repeat_byte(0x11);

--- a/rust/op-reth/examples/custom-node/src/evm/config.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/config.rs
@@ -24,7 +24,7 @@ use reth_op::{
     evm::primitives::{EvmEnvFor, ExecutionCtxFor},
     node::{OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder},
 };
-use reth_optimism_evm::{ConfigurePostExecEvm, PostExecMode};
+use reth_optimism_evm::{ConfigurePostExecEvm, PostExecMode, PreRefundGasUsed};
 use reth_primitives_traits::{SealedBlock, SealedHeader, SignedTransaction};
 use reth_rpc_api::eth::helpers::pending_block::BuildPendingEnv;
 use revm::database::State;
@@ -244,6 +244,7 @@ impl ConfigurePostExecEvm for CustomEvmConfig {
             Executor: PostExecExecutorExt
                           + alloy_evm::block::BlockExecutor<
                 Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
+                Result: PreRefundGasUsed,
             >,
         > + 'a,
         Self::Error,


### PR DESCRIPTION
Fixes: https://github.com/ethereum-optimism/optimism/issues/20709

Enforce the `SystemConfig`-derived block gas limit against pre-refund EVM gas under SDM/PostExec.

Previously, block gas accounting accumulated canonical/post-refund gas only. With SDM refunds enabled, a block could keep `canonical gas_used` within the block gas limit **while performing more real EVM work** than the limit permits.

 This PR adds a separate pre-refund gas accumulator and admission check so that:

```
sum(evm_gas_used before SDM refunds) <= block gas limit
```

SDM refunds still lower canonical gas usage and receipts, but they can no longer increase the amount of real per-block compute.