### PR TITLE
fix(op-acceptance-tests): fix flaky TestNotTruncateDatabaseOnRestartWithExistingDatabase

### DIFF
--- a/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
@@ -91,7 +91,11 @@ func TestNotTruncateDatabaseOnRestartWithExistingDatabase(gt *testing.T) {
 		sys.L2CLB.AdvancedFn(safety.LocalSafe, 1, 30))
 	sys.L2CLB.InSync(sys.L2CL, safety.LocalSafe, 30)
 
-	preRestartSafeBlock := sys.L2CLB.SafeL2BlockRef().Number
+	// Capture the db's oldest recorded safe head (its "floor") rather than the live safe head:
+	// the live safe head advances continuously and may be sampled mid-L1-block, which races against
+	// the db's per-L1-block granularity (esp. after the initial EL-sync reset). The floor is stable
+	// until the db is truncated, so re-checking it after restart is a sound no-truncation assertion.
+	preRestartSafeBlock := sys.L2CLB.SafeHeadDBFloor()
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(preRestartSafeBlock))
 
 	// Restart the verifier op-node, but not the EL so the existing chain data is not deleted.

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -588,6 +588,17 @@ func WithMinRequiredL2Block(blockNum uint64) func(opts *safeHeadDbMatchOpts) {
 	}
 }
 
+// SafeHeadDBFloor returns the oldest L2 safe-head block number recorded in this node's safe head
+// db, sampled at its current (fully-processed) L1 block. Prefer this over the live SafeL2BlockRef
+// when capturing a no-truncation baseline: the live safe head advances continuously and may be
+// sampled mid-L1-block, which races against the db's per-L1-block granularity, whereas the floor
+// is stable until the db is reset.
+func (cl *L2CLNode) SafeHeadDBFloor() uint64 {
+	l1Block := cl.SyncStatus().CurrentL1.Number
+	cl.AwaitMinL1Processed(l1Block) // Ensure this block is fully processed before reading the safe head db
+	return safeHeadDBFloor(cl.t, l1Block, cl)
+}
+
 func (cl *L2CLNode) VerifySafeHeadDatabaseMatches(sourceOfTruth *L2CLNode, args ...func(opts *safeHeadDbMatchOpts)) {
 	opts := applyOpts(safeHeadDbMatchOpts{}, args...)
 	l1Block := cl.SyncStatus().CurrentL1.Number

--- a/op-devstack/dsl/safedb.go
+++ b/op-devstack/dsl/safedb.go
@@ -10,6 +10,30 @@ type safeHeadDBProvider interface {
 	safeHeadAtL1Block(l1BlockNum uint64) *eth.SafeHeadResponse
 }
 
+// safeHeadDBFloor walks the safe head db backwards from maxL1BlockNum and returns the lowest
+// L2 safe-head block number that still has a recorded entry, i.e. the oldest point the db has
+// data for. The returned value is aligned to the db's per-L1-block granularity, which makes it
+// a stable baseline: unlike the live safe head (which advances continuously, possibly mid-L1-block),
+// the floor only changes when the db is reset/truncated. Capture it before an action and re-check
+// afterwards to assert the db was not truncated. Fails the test if the db has no data at all.
+func safeHeadDBFloor(t devtest.T, maxL1BlockNum uint64, node safeHeadDBProvider) uint64 {
+	require := testreq.New(t)
+	l1BlockNum := maxL1BlockNum
+	var floor *uint64
+	for {
+		actual := node.safeHeadAtL1Block(l1BlockNum)
+		if actual == nil {
+			require.NotNil(floor, "no safe head data available at or below L1 block %v", maxL1BlockNum)
+			return *floor
+		}
+		floor = &actual.SafeHead.Number
+		if actual.L1Block.Number == 0 {
+			return *floor // Reached L1 and L2 genesis.
+		}
+		l1BlockNum = actual.L1Block.Number - 1
+	}
+}
+
 func checkSafeHeadConsistent(t devtest.T, maxL1BlockNum uint64, checkNode, sourceOfTruth safeHeadDBProvider, minRequiredL2Block *uint64) {
 	require := testreq.New(t)
 	l1BlockNum := maxL1BlockNum


### PR DESCRIPTION
## Problem

`TestNotTruncateDatabaseOnRestartWithExistingDatabase` flakes ([example failure](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/127382/workflows/45ce14ec-7fbe-4bd8-a91a-7f8c2e53b7b2/jobs/5171994/tests), job `memory-all-opn-op-reth`):

```
op-devstack/dsl/safedb.go:25
  Error:    "8" is not less than or equal to "7"
  Messages: safe head db did not go back far enough
```

This fires at the **pre-restart baseline check** (`safeheaddb_test.go:95`), before any restart happens.

## Root cause

The baseline was sampled from the live safe head:

```go
preRestartSafeBlock := sys.L2CLB.SafeL2BlockRef().Number
```

The live safe head advances **continuously** (per L2 block), but the safe head DB only resolves at **per-L1-origin granularity**. After the initial EL-sync reset, the DB's oldest retained entry holds the *final* safe head reached at that L1 origin.

From the failing run's `l2cl-b` timeline:

| time | event |
|------|-------|
| 18:44:52.746 | safe head db **reset at L2 block 5** (initial EL sync) |
| 18:44:59.678 | records L2 **block 7** @ L1 origin **3** |
| 18:44:59.777 | test samples baseline & calls verify (`maxL1Block=3`) |
| 18:45:00.780 | records L2 **block 8** @ L1 origin **3** ← after sample |

The baseline was sampled as `7` (between blocks 7 and 8). By the time the walk-back queried `safeHeadAtL1Block(3)`, the oldest retained origin (L1 block 3) had settled at safe head `8`, and the reset wiped everything below it. Assertion `8 <= 7` → fail.

The window is narrow: it requires the live sample to land strictly inside the range of L2 blocks sharing the oldest retained L1 origin. op-reth + memory backends just hit the timing more often. Not a regression — the assertion (#16644) and sampling (#17127) have been stable since mid-2025.

## Fix

Capture the baseline from the DB's own **floor** (oldest recorded safe head) instead of the live safe head. New `safeHeadDBFloor` walks the DB backward and returns the lowest recorded safe-head L2 block; exposed via `L2CLNode.SafeHeadDBFloor()`.

```go
preRestartSafeBlock := sys.L2CLB.SafeHeadDBFloor()
```

The floor is aligned to per-L1-origin granularity and only moves when the DB is reset/truncated — not as the live chain advances. So the pre-restart check becomes self-consistent (`8 <= 8`), and the post-restart check still correctly fails if a CL restart with an existing EL DB ever truncates the safe head DB. The regression-catching intent is preserved; only the granularity race is removed.

## Testing

`go build` / `go vet` pass on the changed packages. The acceptance test itself requires a full devstack (op-reth, contracts, prestates) and was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)