### PR TITLE
[experiment] A/B: Rust CI with sccache OFF (do not merge)

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -145,7 +145,7 @@ commands:
       enabled:
         description: "Master switch for the GCS compile cache."
         type: boolean
-        default: true
+        default: false
     steps:
       - when:
           condition: << parameters.enabled >>


### PR DESCRIPTION
Experiment to measure warm Rust job durations with sccache disabled (Adrian's caching only) vs develop (sccache on). Not for merge — will close after measuring.