### PR TITLE
ci: verify provenance for all ci-base-clang pins, not just config.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,7 +64,7 @@ jobs:
             [[ -z "${ref}" ]] && continue
             echo "::group::verify ${ref}"
             gh attestation verify "oci://${ref}" \
-              --owner ethereum-optimism \
+              --repo ethereum-optimism/optimism \
               --signer-repo ethereum-optimism/factory \
               --source-ref refs/heads/develop
             echo "::endgroup::"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,12 +6,14 @@ on:
       - 'develop'
     paths:
       - '.circleci/config.yml'
+      - '.circleci/continue/**'
       - '.github/workflows/security.yml'
   pull_request:
     branches:
       - 'develop'
     paths:
       - '.circleci/config.yml'
+      - '.circleci/continue/**'
       - '.github/workflows/security.yml'
   workflow_dispatch:
 
@@ -21,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      attestations: read
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2
@@ -28,27 +31,41 @@ jobs:
           egress-policy: audit
       - name: Checkout
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6
-      - name: Extract pinned image reference
+      - name: Extract pinned image references
         id: extract
         run: |
           set -euo pipefail
-          IMAGE_REF=$(grep -A2 '^  rust_base_image:' .circleci/config.yml \
-            | grep -oE 'us-docker\.pkg\.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:[0-9a-f]{64}' \
-            | head -n1)
-          if [[ -z "${IMAGE_REF}" ]]; then
-            echo "Could not extract ci-base-clang image reference from .circleci/config.yml" >&2
+          # Every ci-base-clang digest pinned anywhere in the CircleCI config: the
+          # canonical pin in config.yml plus the copies redeclared in each
+          # continuation fragment (continue/*.yml). All must be attested, since a
+          # divergent or unattested digest in any of them can reach the runners.
+          IMAGE_REFS=$(
+            grep -rhoE 'us-docker\.pkg\.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:[0-9a-f]{64}' \
+              .circleci/config.yml .circleci/continue \
+              | sort -u
+          )
+          if [[ -z "${IMAGE_REFS}" ]]; then
+            echo "Could not extract any ci-base-clang image reference from .circleci" >&2
             exit 1
           fi
-          echo "image=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
-          echo "Pinned image: ${IMAGE_REF}"
+          echo "${IMAGE_REFS}" | sed 's/^/Pinned image: /'
+          {
+            echo "images<<EOF"
+            echo "${IMAGE_REFS}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Verify provenance attestation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_REF: ${{ steps.extract.outputs.image }}
+          IMAGES: ${{ steps.extract.outputs.images }}
         run: |
           set -euo pipefail
-          gh attestation verify "oci://${IMAGE_REF}" \
-            --bundle-from-oci \
-            --owner ethereum-optimism \
-            --signer-repo ethereum-optimism/factory \
-            --source-ref refs/heads/develop
+          while IFS= read -r ref; do
+            [[ -z "${ref}" ]] && continue
+            echo "::group::verify ${ref}"
+            gh attestation verify "oci://${ref}" \
+              --owner ethereum-optimism \
+              --signer-repo ethereum-optimism/factory \
+              --source-ref refs/heads/develop
+            echo "::endgroup::"
+          done <<< "${IMAGES}"


### PR DESCRIPTION
## Problem

The `security` workflow verifies the provenance attestation of the pinned `ci-base-clang` image, but only the copy in `.circleci/config.yml`:

- It greps the digest out of `.circleci/config.yml` only.
- Its `paths:` trigger only lists `.circleci/config.yml`.

That digest is redeclared in every continuation fragment (`.circleci/continue/main.yml`, `rust-ci.yml`, `rust-e2e.yml`) — 4 copies total — and the fragments are what the Rust CI jobs actually run on. So a digest changed in a fragment is neither verified nor able to trigger the workflow. The check stays green while the real surface is unguarded.

## Fix

- Trigger on `.circleci/continue/**` in addition to `.circleci/config.yml`.
- Extract **every** unique `ci-base-clang` digest across `config.yml` and the continuation fragments, and verify each one (today they're identical, so this is one verification; it fans out only if a copy diverges).
- Drop `--bundle-from-oci`: verification now resolves the attestation via the org attestation API instead of depending on a bundle being attached to the OCI image, and `attestations: read` is granted for that lookup.

## Verification

Locally, against the current pin:

- Good digest + `--owner ethereum-optimism --signer-repo ethereum-optimism/factory --source-ref refs/heads/develop` → passes (cert `sourceRepositoryRef` = `refs/heads/develop`).
- Wrong `--source-ref` → fails (`expected SourceRepositoryRef ...`).
- Wrong `--owner` → fails (`expected SourceRepositoryOwnerURI ...`).
- Extract step output confirmed to collect all `.circleci` digests, deduped.