### PR TITLE
chore(op-e2e): drop op-program references

### DIFF
--- a/op-e2e/actions/helpers/engineapi/block_processor.go
+++ b/op-e2e/actions/helpers/engineapi/block_processor.go
@@ -1,0 +1,200 @@
+package engineapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	ErrExceedsGasLimit  = errors.New("tx gas exceeds block gas limit")
+	ErrUsesTooMuchGas   = errors.New("action takes too much gas")
+	errInvalidGasLimit  = errors.New("invalid gas limit")
+	errInvalidTimestamp = errors.New("invalid timestamp")
+)
+
+type BlockDataProvider interface {
+	StateAt(root common.Hash) (*state.StateDB, error)
+	GetHeader(common.Hash, uint64) *types.Header
+	Engine() consensus.Engine
+	GetVMConfig() *vm.Config
+	Config() *params.ChainConfig
+	consensus.ChainHeaderReader
+}
+
+type BlockProcessor struct {
+	header       *types.Header
+	state        *state.StateDB
+	receipts     types.Receipts
+	transactions types.Transactions
+	gasPool      *core.GasPool
+	dataProvider BlockDataProvider
+	evm          *vm.EVM
+}
+
+func NewBlockProcessorFromPayloadAttributes(provider BlockDataProvider, parent common.Hash, attrs *eth.PayloadAttributes) (*BlockProcessor, error) {
+	header := &types.Header{
+		ParentHash:       parent,
+		Coinbase:         attrs.SuggestedFeeRecipient,
+		Difficulty:       common.Big0,
+		GasLimit:         uint64(*attrs.GasLimit),
+		Time:             uint64(attrs.Timestamp),
+		Extra:            nil,
+		MixDigest:        common.Hash(attrs.PrevRandao),
+		Nonce:            types.EncodeNonce(0),
+		ParentBeaconRoot: attrs.ParentBeaconBlockRoot,
+	}
+	if attrs.EIP1559Params != nil {
+		d, e := eip1559.DecodeHolocene1559Params(attrs.EIP1559Params[:])
+		if d == 0 {
+			d = provider.Config().BaseFeeChangeDenominator(header.Time)
+			e = provider.Config().ElasticityMultiplier()
+		}
+		if provider.Config().IsOptimismHolocene(header.Time) {
+			header.Extra = eip1559.EncodeOptimismExtraData(provider.Config(), header.Time, d, e, attrs.MinBaseFee)
+		}
+	}
+
+	return NewBlockProcessorFromHeader(provider, header)
+}
+
+func NewBlockProcessorFromHeader(provider BlockDataProvider, h *types.Header) (*BlockProcessor, error) {
+	header := types.CopyHeader(h) // Copy to avoid mutating the original header
+
+	if header.GasLimit > params.MaxGasLimit {
+		return nil, fmt.Errorf("%w: have %v, max %v", errInvalidGasLimit, header.GasLimit, params.MaxGasLimit)
+	}
+	parentHeader := provider.GetHeaderByHash(header.ParentHash)
+	if header.Time <= parentHeader.Time {
+		return nil, errInvalidTimestamp
+	}
+	statedb, err := provider.StateAt(parentHeader.Root)
+	if err != nil {
+		return nil, fmt.Errorf("get parent state: %w", err)
+	}
+	header.Number = new(big.Int).Add(parentHeader.Number, common.Big1)
+	header.BaseFee = eip1559.CalcBaseFee(provider.Config(), parentHeader, header.Time)
+	header.GasUsed = 0
+	gasPool := core.NewGasPool(header.GasLimit)
+	mkEVM := func() *vm.EVM {
+		// Unfortunately this is not part of any Geth environment setup,
+		// we just have to apply it, like how the Geth block-builder worker does.
+		context := core.NewEVMBlockContext(header, provider, nil, provider.Config(), statedb)
+		// NOTE: Unlikely to be needed for the beacon block root, but we setup any precompile overrides anyways for forwards-compatibility
+		var precompileOverrides vm.PrecompileOverrides
+		if vmConfig := provider.GetVMConfig(); vmConfig != nil && vmConfig.PrecompileOverrides != nil {
+			precompileOverrides = vmConfig.PrecompileOverrides
+		}
+		vmenv := vm.NewEVM(context, statedb, provider.Config(), vm.Config{PrecompileOverrides: precompileOverrides})
+		return vmenv
+	}
+	var vmenv *vm.EVM
+	if h.ParentBeaconRoot != nil {
+		if provider.Config().IsCancun(header.Number, header.Time) {
+			// Blob tx not supported on optimism chains but fields must be set when Cancun is active.
+			zero := uint64(0)
+			header.BlobGasUsed = &zero
+			header.ExcessBlobGas = &zero
+		}
+		// core.NewEVMBlockContext need to be called after the blob gas fields are set
+		vmenv = mkEVM()
+		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, vmenv)
+	} else {
+		vmenv = mkEVM()
+	}
+	if provider.Config().IsPrague(header.Number, header.Time) {
+		core.ProcessParentBlockHash(header.ParentHash, vmenv)
+	}
+	if provider.Config().IsIsthmus(header.Time) {
+		// set the header withdrawals root for Isthmus blocks
+		mpHash := statedb.GetStorageRoot(predeploys.L2ToL1MessagePasserAddr)
+		header.WithdrawalsHash = &mpHash
+
+		// set the header requests root to empty hash for Isthmus blocks
+		header.RequestsHash = &types.EmptyRequestsHash
+	}
+
+	return &BlockProcessor{
+		header:       header,
+		state:        statedb,
+		gasPool:      gasPool,
+		dataProvider: provider,
+		evm:          vmenv,
+	}, nil
+}
+
+func (b *BlockProcessor) CheckTxWithinGasLimit(tx *types.Transaction) error {
+	if tx.Gas() > b.header.GasLimit {
+		return fmt.Errorf("%w tx gas: %d, block gas limit: %d", ErrExceedsGasLimit, tx.Gas(), b.header.GasLimit)
+	}
+	if tx.Gas() > b.gasPool.Gas() {
+		return fmt.Errorf("%w: %d, only have %d", ErrUsesTooMuchGas, tx.Gas(), b.gasPool.Gas())
+	}
+	return nil
+}
+
+func (b *BlockProcessor) AddTx(tx *types.Transaction) (*types.Receipt, error) {
+	txIndex := len(b.transactions)
+	b.state.SetTxContext(tx.Hash(), txIndex)
+	receipt, err := core.ApplyTransaction(b.evm, b.gasPool, b.state, b.header, tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply transaction to L2 block (tx %d): %w", txIndex, err)
+	}
+	b.header.GasUsed = b.gasPool.Used()
+	b.receipts = append(b.receipts, receipt)
+	b.transactions = append(b.transactions, tx)
+	return receipt, nil
+}
+
+func (b *BlockProcessor) Assemble() (*types.Block, types.Receipts, error) {
+	body := types.Body{
+		Transactions: b.transactions,
+	}
+
+	cfg := b.evm.ChainConfig()
+	// Processing for EIP-7685 requests would happen here, but is skipped on OP.
+	// Kept here to minimize diff.
+	if cfg.IsPrague(b.header.Number, b.header.Time) && !cfg.IsIsthmus(b.header.Time) {
+		_requests := [][]byte{}
+		// EIP-6110 - no-op because we just ignore all deposit requests, so no need to parse logs
+		// EIP-7002
+		if err := core.ProcessWithdrawalQueue(&_requests, b.evm); err != nil {
+			return nil, nil, err
+		}
+		// EIP-7251
+		if err := core.ProcessConsolidationQueue(&_requests, b.evm); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	block, err := b.dataProvider.Engine().FinalizeAndAssemble(context.Background(), b.dataProvider, b.header, b.state, &body, b.receipts)
+	if err != nil {
+		return nil, nil, err
+	}
+	return block, b.receipts, nil
+}
+
+func (b *BlockProcessor) Commit() error {
+	isCancun := b.dataProvider.Config().IsCancun(b.header.Number, b.header.Time)
+	root, err := b.state.Commit(bigs.Uint64Strict(b.header.Number), b.dataProvider.Config().IsEIP158(b.header.Number), isCancun)
+	if err != nil {
+		return fmt.Errorf("state write error: %w", err)
+	}
+	if err := b.state.Database().TrieDB().Commit(root, false); err != nil {
+		return fmt.Errorf("trie write error: %w", err)
+	}
+	return nil
+}

--- a/op-e2e/actions/helpers/engineapi/l2_engine_api.go
+++ b/op-e2e/actions/helpers/engineapi/l2_engine_api.go
@@ -1,0 +1,643 @@
+package engineapi
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/stateless"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+type EngineBackend interface {
+	CurrentSafeBlock() *types.Header
+	CurrentFinalBlock() *types.Header
+	GetBlockByHash(hash common.Hash) *types.Block
+	GetBlock(hash common.Hash, number uint64) *types.Block
+	HasBlockAndState(hash common.Hash, number uint64) bool
+	GetCanonicalHash(n uint64) common.Hash
+
+	GetVMConfig() *vm.Config
+	Config() *params.ChainConfig
+	// Engine retrieves the chain's consensus engine.
+	Engine() consensus.Engine
+
+	StateAt(root common.Hash) (*state.StateDB, error)
+
+	InsertBlockWithoutSetHead(ctx context.Context, block *types.Block, makeWitness bool) (*stateless.Witness, error)
+	SetCanonical(head *types.Block) (common.Hash, error)
+	SetFinalized(header *types.Header)
+	SetSafe(header *types.Header)
+
+	consensus.ChainHeaderReader
+}
+
+type CachingEngineBackend interface {
+	EngineBackend
+	GetReceiptsByBlockHash(hash common.Hash) types.Receipts
+	AssembleAndInsertBlockWithoutSetHead(processor *BlockProcessor) (*types.Block, error)
+}
+
+// L2EngineAPI wraps an engine actor, and implements the RPC backend required to serve the engine API.
+// This re-implements some of the Geth API work, but changes the API backend so we can deterministically
+// build and control the L2 block contents to reach very specific edge cases as desired for testing.
+type L2EngineAPI struct {
+	log     log.Logger
+	backend EngineBackend
+
+	// Functionality for snap sync
+	remotes    map[common.Hash]*types.Block
+	downloader *downloader.Downloader
+
+	// L2 block building data
+	blockProcessor *BlockProcessor
+	pendingIndices map[common.Address]uint64 // per account, how many txs from the pool were already included in the block, since the pool is lagging behind block mining.
+	l2ForceEmpty   bool                      // when no additional txs may be processed (i.e. when sequencer drift runs out)
+	l2TxFailed     []*types.Transaction      // log of failed transactions which could not be included
+
+	payloadID engine.PayloadID // ID of payload that is currently being built
+}
+
+func NewL2EngineAPI(log log.Logger, backend EngineBackend, downloader *downloader.Downloader) *L2EngineAPI {
+	return &L2EngineAPI{
+		log:        log,
+		backend:    backend,
+		remotes:    make(map[common.Hash]*types.Block),
+		downloader: downloader,
+	}
+}
+
+var (
+	STATUS_INVALID = &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}
+	STATUS_SYNCING = &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}
+)
+
+// computePayloadId computes a pseudo-random payloadid, based on the parameters.
+func computePayloadId(headBlockHash common.Hash, attrs *eth.PayloadAttributes) engine.PayloadID {
+	// Hash
+	hasher := sha256.New()
+	hasher.Write(headBlockHash[:])
+	_ = binary.Write(hasher, binary.BigEndian, attrs.Timestamp)
+	hasher.Write(attrs.PrevRandao[:])
+	hasher.Write(attrs.SuggestedFeeRecipient[:])
+	_ = binary.Write(hasher, binary.BigEndian, attrs.NoTxPool)
+	_ = binary.Write(hasher, binary.BigEndian, uint64(len(attrs.Transactions)))
+	for _, tx := range attrs.Transactions {
+		_ = binary.Write(hasher, binary.BigEndian, uint64(len(tx))) // length-prefix to avoid collisions
+		hasher.Write(tx)
+	}
+	_ = binary.Write(hasher, binary.BigEndian, *attrs.GasLimit)
+	if attrs.EIP1559Params != nil {
+		hasher.Write(attrs.EIP1559Params[:])
+	}
+	if attrs.MinBaseFee != nil {
+		_ = binary.Write(hasher, binary.BigEndian, *attrs.MinBaseFee)
+	}
+	var out engine.PayloadID
+	copy(out[:], hasher.Sum(nil)[:8])
+	return out
+}
+
+func (ea *L2EngineAPI) RemainingBlockGas() uint64 {
+	if ea.blockProcessor == nil {
+		return 0
+	}
+	return ea.blockProcessor.gasPool.Gas()
+}
+
+func (ea *L2EngineAPI) ForcedEmpty() bool {
+	return ea.l2ForceEmpty
+}
+
+// SetForceEmpty changes the way the remainder of the block is being built
+func (ea *L2EngineAPI) SetForceEmpty(v bool) {
+	ea.l2ForceEmpty = v
+}
+
+func (ea *L2EngineAPI) PendingIndices(from common.Address) uint64 {
+	return ea.pendingIndices[from]
+}
+
+var ErrNotBuildingBlock = errors.New("not currently building a block, cannot include tx from queue")
+
+func (ea *L2EngineAPI) IncludeTx(tx *types.Transaction, from common.Address) (*types.Receipt, error) {
+	if ea.blockProcessor == nil {
+		return nil, ErrNotBuildingBlock
+	}
+
+	if ea.l2ForceEmpty {
+		ea.log.Info("Skipping including a transaction because e.L2ForceEmpty is true")
+		return nil, nil
+	}
+
+	err := ea.blockProcessor.CheckTxWithinGasLimit(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	ea.pendingIndices[from] = ea.pendingIndices[from] + 1 // won't retry the tx
+	rcpt, err := ea.blockProcessor.AddTx(tx)
+	if err != nil {
+		ea.l2TxFailed = append(ea.l2TxFailed, tx)
+		return nil, fmt.Errorf("invalid L2 block (tx %d): %w", len(ea.blockProcessor.transactions), err)
+	}
+	return rcpt, nil
+}
+
+func (ea *L2EngineAPI) startBlock(parent common.Hash, attrs *eth.PayloadAttributes) error {
+	if ea.blockProcessor != nil {
+		ea.log.Warn("started building new block without ending previous block", "previous", ea.blockProcessor.header, "prev_payload_id", ea.payloadID)
+	}
+
+	processor, err := NewBlockProcessorFromPayloadAttributes(ea.backend, parent, attrs)
+	if err != nil {
+		return err
+	}
+
+	ea.blockProcessor = processor
+	ea.pendingIndices = make(map[common.Address]uint64)
+	ea.l2ForceEmpty = attrs.NoTxPool
+	ea.payloadID = computePayloadId(parent, attrs)
+
+	// pre-process the deposits
+	for i, otx := range attrs.Transactions {
+		var tx types.Transaction
+		if err := tx.UnmarshalBinary(otx); err != nil {
+			return fmt.Errorf("transaction %d is not valid: %w", i, err)
+		}
+		_, err := ea.blockProcessor.AddTx(&tx)
+		if err != nil {
+			ea.l2TxFailed = append(ea.l2TxFailed, &tx)
+			return fmt.Errorf("failed to apply deposit transaction to L2 block (tx %d): %w", i, err)
+		}
+	}
+	return nil
+}
+
+//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+func (ea *L2EngineAPI) endBlock() (*types.Block, error) {
+	if ea.blockProcessor == nil {
+		return nil, fmt.Errorf("no block is being built currently (id %s)", ea.payloadID)
+	}
+	processor := ea.blockProcessor
+	ea.blockProcessor = nil
+
+	var block *types.Block
+	var err error
+	// If the backend supports it, write the newly created block to the database without making it canonical.
+	// This avoids needing to reprocess the block if it is sent back via newPayload.
+	// The block is not made canonical so if it is never sent back via newPayload worst case it just wastes some storage
+	// In the context of the OP Stack derivation, the created block is always immediately imported so it makes sense to
+	// optimise.
+	if cachingBackend, ok := ea.backend.(CachingEngineBackend); ok {
+		block, err = cachingBackend.AssembleAndInsertBlockWithoutSetHead(processor)
+	} else {
+		block, _, err = processor.Assemble()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("assemble block: %w", err)
+	}
+	return block, nil
+}
+
+func (ea *L2EngineAPI) GetPayloadV1(ctx context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayload, error) {
+	res, err := ea.getPayload(ctx, payloadId)
+	if err != nil {
+		return nil, err
+	}
+	return res.ExecutionPayload, nil
+}
+
+func (ea *L2EngineAPI) GetPayloadV2(ctx context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
+	return ea.getPayload(ctx, payloadId)
+}
+
+func (ea *L2EngineAPI) GetPayloadV3(ctx context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
+	return ea.getPayload(ctx, payloadId)
+}
+
+func (ea *L2EngineAPI) GetPayloadV4(ctx context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
+	return ea.getPayload(ctx, payloadId)
+}
+
+func (ea *L2EngineAPI) config() *params.ChainConfig {
+	return ea.backend.Config()
+}
+
+func (ea *L2EngineAPI) ForkchoiceUpdatedV1(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
+	if attr != nil {
+		if attr.Withdrawals != nil {
+			//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+			return STATUS_INVALID, engine.InvalidParams.With(errors.New("withdrawals not supported in V1"))
+		}
+		if ea.config().IsShanghai(ea.config().LondonBlock, uint64(attr.Timestamp)) {
+			//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+			return STATUS_INVALID, engine.InvalidParams.With(errors.New("forkChoiceUpdateV1 called post-shanghai"))
+		}
+	}
+
+	return ea.forkchoiceUpdated(ctx, state, attr)
+}
+
+func (ea *L2EngineAPI) ForkchoiceUpdatedV2(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
+	if attr != nil {
+		if err := ea.verifyPayloadAttributes(attr); err != nil {
+			return STATUS_INVALID, engine.InvalidParams.With(err)
+		}
+	}
+
+	return ea.forkchoiceUpdated(ctx, state, attr)
+}
+
+// Ported from: https://github.com/ethereum-optimism/op-geth/blob/c50337a60a1309a0f1dca3bf33ed1bb38c46cdd7/eth/catalyst/api.go#L197C1-L205C1
+func (ea *L2EngineAPI) ForkchoiceUpdatedV3(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
+	if attr != nil {
+		if err := ea.verifyPayloadAttributes(attr); err != nil {
+			return STATUS_INVALID, engine.InvalidParams.With(err)
+		}
+	}
+	return ea.forkchoiceUpdated(ctx, state, attr)
+}
+
+// Ported from: https://github.com/ethereum-optimism/op-geth/blob/c50337a60a1309a0f1dca3bf33ed1bb38c46cdd7/eth/catalyst/api.go#L206-L218
+func (ea *L2EngineAPI) verifyPayloadAttributes(attr *eth.PayloadAttributes) error {
+	c := ea.config()
+	t := uint64(attr.Timestamp)
+
+	// Verify withdrawals attribute for Shanghai.
+	if err := checkAttribute(c.IsShanghai, attr.Withdrawals != nil, c.LondonBlock, t); err != nil {
+		return fmt.Errorf("invalid withdrawals: %w", err)
+	}
+	// Verify beacon root attribute for Cancun.
+	if err := checkAttribute(c.IsCancun, attr.ParentBeaconBlockRoot != nil, c.LondonBlock, t); err != nil {
+		return fmt.Errorf("invalid parent beacon block root: %w", err)
+	}
+	// Verify EIP-1559 params for Holocene.
+	if c.IsHolocene(t) {
+		if attr.EIP1559Params == nil {
+			//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+			return errors.New("got nil eip-1559 params while Holocene is active")
+		}
+		if err := eip1559.ValidateHolocene1559Params(attr.EIP1559Params[:]); err != nil {
+			return fmt.Errorf("invalid Holocene params: %w", err)
+		}
+	} else if attr.EIP1559Params != nil {
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+		return errors.New("got Holocene params though fork not active")
+	}
+
+	return nil
+}
+
+func checkAttribute(active func(*big.Int, uint64) bool, exists bool, block *big.Int, time uint64) error {
+	if active(block, time) && !exists {
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+		return errors.New("fork active, missing expected attribute")
+	}
+	if !active(block, time) && exists {
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+		return errors.New("fork inactive, unexpected attribute set")
+	}
+	return nil
+}
+
+func (ea *L2EngineAPI) NewPayloadV1(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
+	if payload.Withdrawals != nil {
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("withdrawals not supported in V1"))
+	}
+
+	return ea.newPayload(ctx, payload, nil, nil, nil)
+}
+
+func (ea *L2EngineAPI) NewPayloadV2(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
+	if ea.config().IsShanghai(new(big.Int).SetUint64(uint64(payload.BlockNumber)), uint64(payload.Timestamp)) {
+		if payload.Withdrawals == nil {
+			//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))
+		}
+	} else if payload.Withdrawals != nil {
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("non-nil withdrawals pre-shanghai"))
+	}
+
+	return ea.newPayload(ctx, payload, nil, nil, nil)
+}
+
+// Ported from: https://github.com/ethereum-optimism/op-geth/blob/c50337a60a1309a0f1dca3bf33ed1bb38c46cdd7/eth/catalyst/api.go#L486C1-L507
+//
+//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+func (ea *L2EngineAPI) NewPayloadV3(ctx context.Context, params *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash) (*eth.PayloadStatusV1, error) {
+	if params.ExcessBlobGas == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil excessBlobGas post-cancun"))
+	}
+	if params.BlobGasUsed == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil params.BlobGasUsed post-cancun"))
+	}
+	if versionedHashes == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil versionedHashes post-cancun"))
+	}
+	if beaconRoot == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil parentBeaconBlockRoot post-cancun"))
+	}
+
+	cfg := ea.config()
+
+	if !cfg.IsCancun(new(big.Int).SetUint64(uint64(params.BlockNumber)), uint64(params.Timestamp)) {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.UnsupportedFork.With(errors.New("newPayloadV3 called pre-cancun"))
+	}
+
+	if err := eip1559.ValidateOptimismExtraData(cfg, uint64(params.Timestamp), params.ExtraData); err != nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.UnsupportedFork.With(err)
+	}
+
+	// Payload must have WithdrawalsRoot after Isthmus
+	if cfg.IsIsthmus(uint64(params.Timestamp)) {
+		if params.WithdrawalsRoot == nil {
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.UnsupportedFork.With(errors.New("nil withdrawalsRoot post-isthmus"))
+		}
+	}
+
+	return ea.newPayload(ctx, params, versionedHashes, beaconRoot, nil)
+}
+
+// Ported from: https://github.com/ethereum-optimism/op-geth/blob/94bb3f660f770afd407280055e7f58c0d89a01af/eth/catalyst/api.go#L646
+//
+//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+func (ea *L2EngineAPI) NewPayloadV4(ctx context.Context, params *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error) {
+	if params.Withdrawals == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))
+	}
+	if params.ExcessBlobGas == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil excessBlobGas post-cancun"))
+	}
+	if params.BlobGasUsed == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil blobGasUsed post-cancun"))
+	}
+
+	if versionedHashes == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil versionedHashes post-cancun"))
+	}
+	if beaconRoot == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil beaconRoot post-cancun"))
+	}
+	if executionRequests == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil executionRequests post-prague"))
+	}
+
+	if !ea.config().IsIsthmus(uint64(params.Timestamp)) {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.UnsupportedFork.With(errors.New("newPayloadV4 called pre-isthmus"))
+	}
+
+	if params.WithdrawalsRoot == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawalsRoot post-isthmus"))
+	}
+
+	requests := convertRequests(executionRequests)
+	return ea.newPayload(ctx, params, versionedHashes, beaconRoot, requests)
+}
+
+func (ea *L2EngineAPI) getPayload(_ context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
+	ea.log.Trace("L2Engine API request received", "method", "GetPayload", "id", payloadId)
+	if ea.payloadID != payloadId {
+		ea.log.Warn("unexpected payload ID requested for block building", "expected", ea.payloadID, "got", payloadId)
+		return nil, engine.UnknownPayload
+	}
+	bl, err := ea.endBlock()
+	if err != nil {
+		ea.log.Error("failed to finish block building", "err", err)
+		return nil, engine.UnknownPayload
+	}
+
+	return eth.BlockAsPayloadEnv(bl, ea.config())
+}
+
+//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+func (ea *L2EngineAPI) forkchoiceUpdated(_ context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
+	ea.log.Trace("L2Engine API request received", "method", "ForkchoiceUpdated", "head", state.HeadBlockHash, "finalized", state.FinalizedBlockHash, "safe", state.SafeBlockHash)
+	if state.HeadBlockHash == (common.Hash{}) {
+		ea.log.Warn("Forkchoice requested update to zero hash")
+		return STATUS_INVALID, nil
+	}
+	// Check whether we have the block yet in our database or not. If not, we'll
+	// need to either trigger a sync, or to reject this forkchoice update for a
+	// reason.
+	block := ea.backend.GetBlockByHash(state.HeadBlockHash)
+	if block == nil {
+		if ea.downloader == nil {
+			ea.log.Warn("Must register downloader to be able to snap sync")
+			return STATUS_SYNCING, nil
+		}
+		// If the head hash is unknown (was not given to us in a newPayload request),
+		// we cannot resolve the header, so not much to do. This could be extended in
+		// the future to resolve from the `eth` network, but it's an unexpected case
+		// that should be fixed, not papered over.
+		header := ea.remotes[state.HeadBlockHash]
+		if header == nil {
+			ea.log.Warn("Forkchoice requested unknown head", "hash", state.HeadBlockHash)
+			return STATUS_SYNCING, nil
+		}
+
+		ea.log.Info("Forkchoice requested sync to new head", "number", header.Number(), "hash", header.Hash())
+		if err := ea.downloader.BeaconSync(header.Header(), nil); err != nil {
+			return STATUS_SYNCING, err
+		}
+		return STATUS_SYNCING, nil
+	}
+	// Block is known locally, just sanity check that the beacon client does not
+	// attempt to push us back to before the merge.
+	// Note: Differs from op-geth implementation as pre-merge blocks are never supported here
+	if block.Difficulty().BitLen() > 0 && block.NumberU64() > 0 {
+		return STATUS_INVALID, errors.New("pre-merge blocks not supported")
+	}
+	valid := func(id *engine.PayloadID) *eth.ForkchoiceUpdatedResult {
+		return &eth.ForkchoiceUpdatedResult{
+			PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &state.HeadBlockHash},
+			PayloadID:     id,
+		}
+	}
+	if ea.backend.GetCanonicalHash(block.NumberU64()) != state.HeadBlockHash {
+		// Block is not canonical, set head.
+		if latestValid, err := ea.backend.SetCanonical(block); err != nil {
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid, LatestValidHash: &latestValid}}, err
+		}
+	} else if ea.backend.CurrentHeader().Hash() == state.HeadBlockHash {
+		// If the specified head matches with our local head, do nothing and keep
+		// generating the payload. It's a special corner case that a few slots are
+		// missing and we are requested to generate the payload in slot.
+	} else if ea.backend.Config().Optimism == nil { // minor L2Engine API divergence: allow proposers to reorg their own chain
+		panic("engine not configured as optimism engine")
+	}
+
+	// If the beacon client also advertised a finalized block, mark the local
+	// chain final and completely in PoS mode.
+	if state.FinalizedBlockHash != (common.Hash{}) {
+		// If the finalized block is not in our canonical tree, somethings wrong
+		finalHeader := ea.backend.GetHeaderByHash(state.FinalizedBlockHash)
+		if finalHeader == nil {
+			ea.log.Warn("Final block not available in database", "hash", state.FinalizedBlockHash)
+			return STATUS_INVALID, engine.InvalidForkChoiceState.With(errors.New("final block not available in database"))
+		} else if ea.backend.GetCanonicalHash(bigs.Uint64Strict(finalHeader.Number)) != state.FinalizedBlockHash {
+			ea.log.Warn("Final block not in canonical chain", "number", block.NumberU64(), "hash", state.HeadBlockHash)
+			return STATUS_INVALID, engine.InvalidForkChoiceState.With(errors.New("final block not in canonical chain"))
+		}
+		// Set the finalized block
+		ea.backend.SetFinalized(finalHeader)
+	}
+	// Check if the safe block hash is in our canonical tree, if not somethings wrong
+	if state.SafeBlockHash != (common.Hash{}) {
+		safeHeader := ea.backend.GetHeaderByHash(state.SafeBlockHash)
+		if safeHeader == nil {
+			ea.log.Warn("Safe block not available in database")
+			return STATUS_INVALID, engine.InvalidForkChoiceState.With(errors.New("safe block not available in database"))
+		}
+		if ea.backend.GetCanonicalHash(bigs.Uint64Strict(safeHeader.Number)) != state.SafeBlockHash {
+			ea.log.Warn("Safe block not in canonical chain")
+			return STATUS_INVALID, engine.InvalidForkChoiceState.With(errors.New("safe block not in canonical chain"))
+		}
+		// Set the safe block
+		ea.backend.SetSafe(safeHeader)
+	}
+	// If payload generation was requested, create a new block to be potentially
+	// sealed by the beacon client. The payload will be requested later, and we
+	// might replace it arbitrarily many times in between.
+	if attr != nil {
+		err := ea.startBlock(state.HeadBlockHash, attr)
+		if err != nil {
+			ea.log.Error("Failed to start block building", "err", err, "noTxPool", attr.NoTxPool, "txs", len(attr.Transactions), "timestamp", attr.Timestamp)
+			return STATUS_INVALID, engine.InvalidPayloadAttributes.With(err)
+		}
+
+		return valid(&ea.payloadID), nil
+	}
+	return valid(nil), nil
+}
+
+func toGethWithdrawals(payload *eth.ExecutionPayload) []*types.Withdrawal {
+	if payload.Withdrawals == nil {
+		return nil
+	}
+
+	result := make([]*types.Withdrawal, 0, len(*payload.Withdrawals))
+
+	for _, w := range *payload.Withdrawals {
+		result = append(result, &types.Withdrawal{
+			Index:     w.Index,
+			Validator: w.Validator,
+			Address:   w.Address,
+			Amount:    w.Amount,
+		})
+	}
+
+	return result
+}
+
+func (ea *L2EngineAPI) newPayload(ctx context.Context, payload *eth.ExecutionPayload, hashes []common.Hash, root *common.Hash, requests [][]byte) (*eth.PayloadStatusV1, error) {
+	ea.log.Trace("L2Engine API request received", "method", "ExecutePayload", "number", payload.BlockNumber, "hash", payload.BlockHash)
+	txs := make([][]byte, len(payload.Transactions))
+	for i, tx := range payload.Transactions {
+		txs[i] = tx
+	}
+	block, err := engine.ExecutableDataToBlock(engine.ExecutableData{
+		ParentHash:      payload.ParentHash,
+		FeeRecipient:    payload.FeeRecipient,
+		StateRoot:       common.Hash(payload.StateRoot),
+		ReceiptsRoot:    common.Hash(payload.ReceiptsRoot),
+		LogsBloom:       payload.LogsBloom[:],
+		Random:          common.Hash(payload.PrevRandao),
+		Number:          uint64(payload.BlockNumber),
+		GasLimit:        uint64(payload.GasLimit),
+		GasUsed:         uint64(payload.GasUsed),
+		Timestamp:       uint64(payload.Timestamp),
+		ExtraData:       payload.ExtraData,
+		BaseFeePerGas:   (*uint256.Int)(&payload.BaseFeePerGas).ToBig(),
+		BlockHash:       payload.BlockHash,
+		Transactions:    txs,
+		Withdrawals:     toGethWithdrawals(payload),
+		ExcessBlobGas:   (*uint64)(payload.ExcessBlobGas),
+		WithdrawalsRoot: payload.WithdrawalsRoot,
+		BlobGasUsed:     (*uint64)(payload.BlobGasUsed),
+	}, hashes, root, requests, ea.backend.Config())
+	if err != nil {
+		log.Debug("Invalid NewPayload params", "params", payload, "error", err)
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalidBlockHash}, nil
+	}
+	// If we already have the block locally, ignore the entire execution and just
+	// return a fake success.
+	if block := ea.backend.GetBlock(payload.BlockHash, uint64(payload.BlockNumber)); block != nil {
+		ea.log.Info("Using existing beacon payload", "number", payload.BlockNumber, "hash", payload.BlockHash, "age", common.PrettyAge(time.Unix(int64(block.Time()), 0)))
+		hash := block.Hash()
+		return &eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &hash}, nil
+	}
+
+	// Skip invalid ancestor check (i.e. not remembering previously failed blocks)
+
+	parent := ea.backend.GetBlock(block.ParentHash(), block.NumberU64()-1)
+	if parent == nil {
+		ea.remotes[block.Hash()] = block
+		// Return accepted if we don't know the parent block. Note that there's no actual sync to activate.
+		return &eth.PayloadStatusV1{Status: eth.ExecutionAccepted, LatestValidHash: nil}, nil
+	}
+
+	if block.Time() <= parent.Time() {
+		log.Warn("Invalid timestamp", "parent", block.Time(), "block", block.Time())
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
+		return ea.invalid(errors.New("invalid timestamp"), parent.Header()), nil
+	}
+
+	if !ea.backend.HasBlockAndState(block.ParentHash(), block.NumberU64()-1) {
+		ea.log.Warn("State not available, ignoring new payload")
+		return &eth.PayloadStatusV1{Status: eth.ExecutionAccepted}, nil
+	}
+	log.Trace("Inserting block without sethead", "hash", block.Hash(), "number", block.Number)
+	if _, err := ea.backend.InsertBlockWithoutSetHead(ctx, block, false); err != nil {
+		ea.log.Warn("NewPayloadV1: inserting block failed", "error", err)
+		// Skip remembering the block was invalid, but do return the invalid response.
+		return ea.invalid(err, parent.Header()), nil
+	}
+	hash := block.Hash()
+	return &eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &hash}, nil
+}
+
+func (ea *L2EngineAPI) invalid(err error, latestValid *types.Header) *eth.PayloadStatusV1 {
+	currentHash := ea.backend.CurrentHeader().Hash()
+	if latestValid != nil {
+		// Set latest valid hash to 0x0 if parent is PoW block
+		currentHash = common.Hash{}
+		if latestValid.Difficulty.BitLen() == 0 {
+			// Otherwise set latest valid hash to parent hash
+			currentHash = latestValid.Hash()
+		}
+	}
+	errorMsg := err.Error()
+	return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid, LatestValidHash: &currentHash, ValidationError: &errorMsg}
+}
+
+// convertRequests converts a hex requests slice to plain [][]byte.
+func convertRequests(hex []hexutil.Bytes) [][]byte {
+	if hex == nil {
+		return nil
+	}
+	req := make([][]byte, len(hex))
+	for i := range hex {
+		req[i] = hex[i]
+	}
+	return req
+}

--- a/op-e2e/actions/helpers/engineapi/l2_engine_api_test.go
+++ b/op-e2e/actions/helpers/engineapi/l2_engine_api_test.go
@@ -1,0 +1,216 @@
+package engineapi
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	geth "github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewPayloadV4 tests the NewPayloadV4 behavior with pre- and post-Isthmus payload
+// attributes.
+func TestNewPayloadV4(t *testing.T) {
+	cases := []struct {
+		isthmusTime       uint64
+		blockTime         uint64
+		expectedError     string
+		nilWithdrawalRoot bool
+	}{
+		{6, 5, engine.UnsupportedFork.Error(), false}, // before isthmus
+		{6, 8, "", false},                  // after isthmus
+		{6, 8, "Invalid parameters", true}, // after isthmus, nil withdrawal root
+	}
+	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+
+	for _, c := range cases {
+		genesis := createGenesisWithIsthmusTimeOffset(c.isthmusTime)
+		ethCfg := &ethconfig.Config{
+			NetworkId:   bigs.Uint64Strict(genesis.Config.ChainID),
+			Genesis:     genesis,
+			StateScheme: rawdb.HashScheme,
+			NoPruning:   true,
+		}
+		backend := newStubBackendWithConfig(t, ethCfg)
+		engineAPI := NewL2EngineAPI(logger, backend, nil)
+		require.NotNil(t, engineAPI)
+		genesisBlock := backend.GetHeaderByNumber(0)
+		genesisHash := genesisBlock.Hash()
+		attribs := createPayloadAttributes(genesisBlock.Time + c.blockTime)
+		result, err := engineAPI.ForkchoiceUpdatedV3(context.Background(), &eth.ForkchoiceState{
+			HeadBlockHash:      genesisHash,
+			SafeBlockHash:      genesisHash,
+			FinalizedBlockHash: genesisHash,
+		}, attribs)
+		require.NoError(t, err)
+		require.EqualValues(t, engine.VALID, result.PayloadStatus.Status)
+		require.NotNil(t, result.PayloadID)
+
+		var envelope *eth.ExecutionPayloadEnvelope
+		if c.blockTime >= c.isthmusTime {
+			envelope, err = engineAPI.GetPayloadV4(context.Background(), *result.PayloadID)
+		} else {
+			envelope, err = engineAPI.GetPayloadV3(context.Background(), *result.PayloadID)
+		}
+		require.NoError(t, err)
+		require.NotNil(t, envelope)
+
+		if c.nilWithdrawalRoot {
+			envelope.ExecutionPayload.WithdrawalsRoot = nil
+		}
+
+		newPayloadResult, err := engineAPI.NewPayloadV4(context.Background(), envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, []hexutil.Bytes{})
+		if c.expectedError != "" {
+			require.ErrorContains(t, err, c.expectedError)
+		} else {
+			require.NoError(t, err)
+			require.EqualValues(t, engine.VALID, newPayloadResult.Status)
+		}
+	}
+}
+
+func TestCreatedBlocksAreCached(t *testing.T) {
+	logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+
+	backend := newStubBackend(t)
+	engineAPI := NewL2EngineAPI(logger, backend, nil)
+	require.NotNil(t, engineAPI)
+	genesis := backend.GetHeaderByNumber(0)
+	genesisHash := genesis.Hash()
+	attribs := createPayloadAttributes(genesis.Time + 1)
+	result, err := engineAPI.ForkchoiceUpdatedV3(context.Background(), &eth.ForkchoiceState{
+		HeadBlockHash:      genesisHash,
+		SafeBlockHash:      genesisHash,
+		FinalizedBlockHash: genesisHash,
+	}, attribs)
+	require.NoError(t, err)
+	require.EqualValues(t, engine.VALID, result.PayloadStatus.Status)
+	require.NotNil(t, result.PayloadID)
+
+	envelope, err := engineAPI.GetPayloadV4(context.Background(), *result.PayloadID)
+	require.NoError(t, err)
+	require.NotNil(t, envelope)
+	newPayloadResult, err := engineAPI.NewPayloadV4(context.Background(), envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, []hexutil.Bytes{})
+	require.NoError(t, err)
+	require.EqualValues(t, engine.VALID, newPayloadResult.Status)
+
+	foundLog := logs.FindLog(testlog.NewMessageFilter("Using existing beacon payload"))
+	require.NotNil(t, foundLog)
+	require.Equal(t, envelope.ExecutionPayload.BlockHash, foundLog.AttrValue("hash"))
+}
+
+func createPayloadAttributes(ts uint64) *eth.PayloadAttributes {
+	eip1559Params := eth.Bytes8([]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8})
+	gasLimit := eth.Uint64Quantity(30e6)
+	return &eth.PayloadAttributes{
+		Timestamp:             eth.Uint64Quantity(ts),
+		PrevRandao:            eth.Bytes32{0x11},
+		SuggestedFeeRecipient: common.Address{0x33},
+		Withdrawals:           &types.Withdrawals{},
+		ParentBeaconBlockRoot: &common.Hash{0x22},
+		GasLimit:              &gasLimit,
+		EIP1559Params:         &eip1559Params,
+	}
+}
+
+func newStubBackendWithConfig(t *testing.T, ethCfg *ethconfig.Config) *stubCachingBackend {
+	nodeCfg := &node.Config{
+		Name: "l2-geth",
+	}
+	n, err := node.New(nodeCfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = n.Close()
+	})
+	backend, err := geth.New(n, ethCfg)
+	require.NoError(t, err)
+
+	chain := backend.BlockChain()
+	return &stubCachingBackend{EngineBackend: chain}
+}
+
+func newStubBackend(t *testing.T) *stubCachingBackend {
+	genesis := createIsthmusGenesis()
+	ethCfg := &ethconfig.Config{
+		NetworkId:   bigs.Uint64Strict(genesis.Config.ChainID),
+		Genesis:     genesis,
+		StateScheme: rawdb.HashScheme,
+		NoPruning:   true,
+	}
+	return newStubBackendWithConfig(t, ethCfg)
+}
+
+func createIsthmusGenesis() *core.Genesis {
+	return createGenesisWithIsthmusTimeOffset(0)
+}
+
+func createGenesisWithIsthmusTimeOffset(forkTimeOffset uint64) *core.Genesis {
+	deployConfig := &genesis.DeployConfig{
+		L2InitializationConfig: genesis.L2InitializationConfig{
+			DevDeployConfig: genesis.DevDeployConfig{
+				FundDevAccounts: true,
+			},
+			L2GenesisBlockDeployConfig: genesis.L2GenesisBlockDeployConfig{
+				L2GenesisBlockGasLimit:   30_000_000,
+				L2GenesisBlockDifficulty: (*hexutil.Big)(big.NewInt(100)),
+			},
+			L2CoreDeployConfig: genesis.L2CoreDeployConfig{
+				L1ChainID:   900,
+				L2ChainID:   901,
+				L2BlockTime: 2,
+			},
+			UpgradeScheduleDeployConfig: genesis.UpgradeScheduleDeployConfig{
+				L1CancunTimeOffset: new(hexutil.Uint64),
+			},
+		},
+	}
+
+	deployConfig.ActivateForkAtOffset(forks.Isthmus, forkTimeOffset)
+
+	l1Genesis, err := genesis.NewL1Genesis(deployConfig)
+	if err != nil {
+		panic(err)
+	}
+	l2Genesis, err := genesis.NewL2Genesis(deployConfig, eth.BlockRefFromHeader(l1Genesis.ToBlock().Header()))
+	if err != nil {
+		panic(err)
+	}
+
+	return l2Genesis
+}
+
+type stubCachingBackend struct {
+	EngineBackend
+}
+
+func (s *stubCachingBackend) AssembleAndInsertBlockWithoutSetHead(processor *BlockProcessor) (*types.Block, error) {
+	block, _, err := processor.Assemble()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.EngineBackend.InsertBlockWithoutSetHead(context.Background(), block, false); err != nil {
+		return nil, err
+	}
+	return block, nil
+}
+
+func (s *stubCachingBackend) GetReceiptsByBlockHash(hash common.Hash) types.Receipts {
+	panic("unsupported")
+}
+
+var _ CachingEngineBackend = (*stubCachingBackend)(nil)

--- a/op-e2e/actions/helpers/engineapi/precompiles.go
+++ b/op-e2e/actions/helpers/engineapi/precompiles.go
@@ -1,0 +1,431 @@
+// This file contains code of the upstream go-ethereum kzgPointEvaluation implementation.
+// Modifications have been made, primarily to substitute kzgPointEvaluation, ecrecover, and runBn256Pairing
+// functions to interact with the preimage oracle.
+//
+// Original copyright disclaimer, applicable only to this file:
+// -------------------------------------------------------------------
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package engineapi
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+var (
+	ecrecoverPrecompileAddress          = common.BytesToAddress([]byte{0x1})
+	bn256PairingPrecompileAddress       = common.BytesToAddress([]byte{0x8})
+	kzgPointEvaluationPrecompileAddress = common.BytesToAddress([]byte{0xa})
+	blsG1AddPrecompileAddress           = common.BytesToAddress([]byte{0xb})
+	blsG1MSMPrecompileAddress           = common.BytesToAddress([]byte{0xc})
+	blsG2AddPrecompileAddress           = common.BytesToAddress([]byte{0xd})
+	blsG2MSMPrecompileAddress           = common.BytesToAddress([]byte{0xe})
+	blsPairingPrecompileAddress         = common.BytesToAddress([]byte{0xf})
+	blsMapToG1PrecompileAddress         = common.BytesToAddress([]byte{0x10})
+	blsMapToG2PrecompileAddress         = common.BytesToAddress([]byte{0x11})
+)
+
+// PrecompileOracle defines the high-level API used to retrieve the result of a precompile call
+// The caller is expected to validate the input to the precompile call
+type PrecompileOracle interface {
+	Precompile(address common.Address, input []byte, requiredGas uint64) ([]byte, bool)
+}
+
+func CreatePrecompileOverrides(precompileOracle PrecompileOracle) vm.PrecompileOverrides {
+	return func(rules params.Rules, orig vm.PrecompiledContract, address common.Address) vm.PrecompiledContract {
+		if orig == nil { // Only override existing contracts. Never introduce a precompile that is not there.
+			return nil
+		}
+		// NOTE: Ignoring chain rules for now. We assume that precompile behavior won't change for the foreseeable future
+		switch address {
+		case ecrecoverPrecompileAddress:
+			return &ecrecoverOracle{Orig: orig, Oracle: precompileOracle}
+		case bn256PairingPrecompileAddress:
+			precompile := bn256PairingOracle{Orig: orig, Oracle: precompileOracle}
+			if rules.IsOptimismJovian {
+				return &bn256PairingOracleJovian{precompile}
+			}
+			if rules.IsOptimismGranite {
+				return &bn256PairingOracleGranite{precompile}
+			}
+			return &precompile
+		case kzgPointEvaluationPrecompileAddress:
+			return &kzgPointEvaluationOracle{Orig: orig, Oracle: precompileOracle}
+		case blsG1AddPrecompileAddress:
+			// no size limit - fixed input
+			return &blsOperationOracle{
+				Orig:              orig,
+				Oracle:            precompileOracle,
+				checkInputSize:    checkInputExactSize(256),
+				checkOutput:       checkOutputExactSize(128),
+				precompileAddress: blsG1AddPrecompileAddress,
+			}
+		case blsG1MSMPrecompileAddress:
+			sizeLimit := params.Bls12381G1MulMaxInputSizeIsthmus
+			if rules.IsOptimismJovian {
+				sizeLimit = params.Bls12381G1MulMaxInputSizeJovian
+			}
+			return &blsOperationOracleWithSizeLimit{
+				sizeLimit: sizeLimit,
+				blsOperationOracle: blsOperationOracle{
+					Orig:              orig,
+					Oracle:            precompileOracle,
+					checkInputSize:    checkInputSizeNonzeroMultipleOf(160),
+					checkOutput:       checkOutputExactSize(128),
+					precompileAddress: blsG1MSMPrecompileAddress,
+				},
+			}
+		case blsG2AddPrecompileAddress:
+			// no size limit - fixed input
+			return &blsOperationOracle{
+				Orig:              orig,
+				Oracle:            precompileOracle,
+				checkInputSize:    checkInputExactSize(512),
+				checkOutput:       checkOutputExactSize(256),
+				precompileAddress: blsG2AddPrecompileAddress,
+			}
+		case blsG2MSMPrecompileAddress:
+			sizeLimit := params.Bls12381G2MulMaxInputSizeIsthmus
+			if rules.IsOptimismJovian {
+				sizeLimit = params.Bls12381G2MulMaxInputSizeJovian
+			}
+			return &blsOperationOracleWithSizeLimit{
+				sizeLimit: sizeLimit,
+				blsOperationOracle: blsOperationOracle{
+					Orig:              orig,
+					Oracle:            precompileOracle,
+					checkInputSize:    checkInputSizeNonzeroMultipleOf(288),
+					checkOutput:       checkOutputExactSize(256),
+					precompileAddress: blsG2MSMPrecompileAddress,
+				},
+			}
+		case blsPairingPrecompileAddress:
+			sizeLimit := params.Bls12381PairingMaxInputSizeIsthmus
+			if rules.IsOptimismJovian {
+				sizeLimit = params.Bls12381PairingMaxInputSizeJovian
+			}
+			return &blsOperationOracleWithSizeLimit{
+				sizeLimit: sizeLimit,
+				blsOperationOracle: blsOperationOracle{
+					Orig:              orig,
+					Oracle:            precompileOracle,
+					checkInputSize:    checkInputSizeNonzeroMultipleOf(384),
+					checkOutput:       checkOutputTrueOrFalse(),
+					precompileAddress: blsPairingPrecompileAddress,
+				},
+			}
+		case blsMapToG1PrecompileAddress:
+			// no size limit - fixed input
+			return &blsOperationOracle{
+				Orig:              orig,
+				Oracle:            precompileOracle,
+				checkInputSize:    checkInputExactSize(64),
+				checkOutput:       checkOutputExactSize(128),
+				precompileAddress: blsMapToG1PrecompileAddress,
+			}
+		case blsMapToG2PrecompileAddress:
+			// no size limit - fixed input
+			return &blsOperationOracle{
+				Orig:              orig,
+				Oracle:            precompileOracle,
+				checkInputSize:    checkInputExactSize(128),
+				checkOutput:       checkOutputExactSize(256),
+				precompileAddress: blsMapToG2PrecompileAddress,
+			}
+		default:
+			return orig
+		}
+	}
+}
+
+var (
+	errInvalidEcrecoverInput = errors.New("invalid ecrecover input")
+)
+
+type ecrecoverOracle struct {
+	Orig   vm.PrecompiledContract
+	Oracle PrecompileOracle
+}
+
+func (c *ecrecoverOracle) RequiredGas(input []byte) uint64 {
+	return c.Orig.RequiredGas(input)
+}
+
+func (c *ecrecoverOracle) Run(input []byte) ([]byte, error) {
+	// Modification note: the L1 precompile behavior may change, but not in incompatible ways.
+	// We want to enforce the subset that represents the EVM behavior activated in L2.
+	// Below is a copy of the Cancun behavior. L1 might expand on that at a later point.
+
+	const ecRecoverInputLength = 128
+
+	if len(input) > ecRecoverInputLength {
+		input = input[:ecRecoverInputLength]
+	}
+
+	input = common.RightPadBytes(input, ecRecoverInputLength)
+	// "input" is (hash, v, r, s), each 32 bytes
+	r := new(big.Int).SetBytes(input[64:96])
+	s := new(big.Int).SetBytes(input[96:128])
+	v := input[63] - 27
+
+	// tighter sig s values input homestead only apply to tx sigs
+	if !allZero(input[32:63]) || !crypto.ValidateSignatureValues(v, r, s, false) {
+		return nil, nil
+	}
+
+	// Modification note: below replaces the crypto.Ecrecover call
+	result, ok := c.Oracle.Precompile(ecrecoverPrecompileAddress, input, c.RequiredGas(input))
+	if !ok {
+		return nil, errInvalidEcrecoverInput
+	}
+	return result, nil
+}
+
+func (c *ecrecoverOracle) Name() string {
+	return "ECRECOVER_ORACLE"
+}
+
+func allZero(b []byte) bool {
+	for _, byte := range b {
+		if byte != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+type bn256PairingOracle struct {
+	Orig   vm.PrecompiledContract
+	Oracle PrecompileOracle
+}
+
+func (b *bn256PairingOracle) RequiredGas(input []byte) uint64 {
+	return b.Orig.RequiredGas(input)
+}
+
+func (b *bn256PairingOracle) Name() string {
+	return b.Orig.Name()
+}
+
+var (
+	// true32Byte is returned if the bn256 pairing check succeeds.
+	true32Byte = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+
+	// false32Byte is returned if the bn256 pairing check fails.
+	false32Byte = make([]byte, 32)
+
+	// errBadPairingInput is returned if the bn256 pairing input is invalid.
+	errBadPairingInput = errors.New("bad elliptic curve pairing size")
+
+	// errBadPairingInputSize is returned if the bn256 pairing input size is invalid.
+	errBadPairingInputSize = errors.New("bad elliptic curve pairing input size")
+
+	errInvalidBn256PairingCheck = errors.New("invalid bn256Pairing check")
+)
+
+func (b *bn256PairingOracle) Run(input []byte) ([]byte, error) {
+	// Handle some corner cases cheaply
+	if len(input)%192 > 0 {
+		return nil, errBadPairingInput
+	}
+	// Modification note: below replaces point verification and pairing checks
+	// Assumes both L2 and the L1 oracle have an identical range of valid points
+	result, ok := b.Oracle.Precompile(bn256PairingPrecompileAddress, input, b.RequiredGas(input))
+	if !ok {
+		return nil, errInvalidBn256PairingCheck
+	}
+	if !bytes.Equal(result, true32Byte) && !bytes.Equal(result, false32Byte) {
+		panic("unexpected result from bn256Pairing check")
+	}
+	return result, nil
+}
+
+type bn256PairingOracleGranite struct {
+	bn256PairingOracle
+}
+
+func (b *bn256PairingOracleGranite) Run(input []byte) ([]byte, error) {
+	if len(input) > int(params.Bn256PairingMaxInputSizeGranite) {
+		return nil, errBadPairingInputSize
+	}
+	return b.bn256PairingOracle.Run(input)
+}
+
+func (b *bn256PairingOracleGranite) Name() string {
+	return b.Orig.Name()
+}
+
+type bn256PairingOracleJovian struct {
+	bn256PairingOracle
+}
+
+func (b *bn256PairingOracleJovian) Run(input []byte) ([]byte, error) {
+	if len(input) > int(params.Bn256PairingMaxInputSizeJovian) {
+		return nil, errBadPairingInputSize
+	}
+	return b.bn256PairingOracle.Run(input)
+}
+
+func (b *bn256PairingOracleJovian) Name() string {
+	return b.Orig.Name()
+}
+
+// kzgPointEvaluationOracle implements the EIP-4844 point evaluation precompile,
+// using the preimage-oracle to perform the evaluation.
+type kzgPointEvaluationOracle struct {
+	Orig   vm.PrecompiledContract
+	Oracle PrecompileOracle
+}
+
+// RequiredGas estimates the gas required for running the point evaluation precompile.
+func (b *kzgPointEvaluationOracle) RequiredGas(input []byte) uint64 {
+	return b.Orig.RequiredGas(input)
+}
+
+func (b *kzgPointEvaluationOracle) Name() string {
+	return b.Orig.Name()
+}
+
+const (
+	blobVerifyInputLength     = 192 // Max input length for the point evaluation precompile.
+	blobPrecompileReturnValue = "000000000000000000000000000000000000000000000000000000000000100073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
+)
+
+var (
+	errBlobVerifyInvalidInputLength = errors.New("invalid input length")
+	errBlobVerifyMismatchedVersion  = errors.New("mismatched versioned hash")
+	errBlobVerifyKZGProof           = errors.New("error verifying kzg proof")
+)
+
+// Run executes the point evaluation precompile.
+func (b *kzgPointEvaluationOracle) Run(input []byte) ([]byte, error) {
+	// Modification note: the L1 precompile behavior may change, but not in incompatible ways.
+	// We want to enforce the subset that represents the EVM behavior activated in L2.
+	// Below is a copy of the Cancun behavior. L1 might expand on that at a later point.
+
+	if len(input) != blobVerifyInputLength {
+		return nil, errBlobVerifyInvalidInputLength
+	}
+	// Input is 32 byte versioned hash, 32 byte point, 32 byte claim, 48 byte commitment, 48 byte proof
+	// versioned hash: first 32 bytes
+	var versionedHash common.Hash
+	copy(versionedHash[:], input[:])
+
+	// input kzg point
+	var commitment kzg4844.Commitment
+	copy(commitment[:], input[96:])
+	if eth.KZGToVersionedHash(commitment) != versionedHash {
+		return nil, errBlobVerifyMismatchedVersion
+	}
+
+	// Modification note: below replaces the kzg4844.VerifyProof call
+	result, ok := b.Oracle.Precompile(kzgPointEvaluationPrecompileAddress, input, b.RequiredGas(input))
+	if !ok {
+		return nil, fmt.Errorf("%w: invalid KZG point evaluation", errBlobVerifyKZGProof)
+	}
+	if !bytes.Equal(result, common.FromHex(blobPrecompileReturnValue)) {
+		panic("unexpected result from KZG point evaluation check")
+	}
+	return result, nil
+}
+
+var (
+	errInvalidBlsSize      = errors.New("invalid input size for BLS12-381 operation")
+	errInvalidBlsOperation = errors.New("invalid BLS12-381 operation")
+)
+
+func checkInputExactSize(size int) func([]byte) bool {
+	return func(input []byte) bool {
+		return len(input) == size
+	}
+}
+
+func checkInputSizeNonzeroMultipleOf(size int) func([]byte) bool {
+	return func(input []byte) bool {
+		return len(input)%size == 0 && len(input) > 0
+	}
+}
+
+func checkOutputExactSize(size int) func([]byte) bool {
+	return func(output []byte) bool {
+		return len(output) == size
+	}
+}
+
+func checkOutputTrueOrFalse() func([]byte) bool {
+	return func(output []byte) bool {
+		return bytes.Equal(output, true32Byte) || bytes.Equal(output, false32Byte)
+	}
+}
+
+type blsOperationOracle struct {
+	Orig              vm.PrecompiledContract
+	Oracle            PrecompileOracle
+	checkInputSize    func([]byte) (ok bool)
+	checkOutput       func([]byte) (ok bool)
+	precompileAddress common.Address
+}
+
+func (b *blsOperationOracle) RequiredGas(input []byte) uint64 {
+	return b.Orig.RequiredGas(input)
+}
+
+func (b *blsOperationOracle) Run(input []byte) ([]byte, error) {
+	inputSizeValid := b.checkInputSize(input)
+	// Handle some corner cases cheaply
+	if !inputSizeValid {
+		return nil, errInvalidBlsSize
+	}
+
+	// Modification note: below replaces point verification and pairing checks
+	// Assumes both L2 and the L1 oracle have an identical range of valid points
+	result, ok := b.Oracle.Precompile(b.precompileAddress, input, b.RequiredGas(input))
+	if !ok {
+		return nil, errInvalidBlsOperation
+	}
+	if !b.checkOutput(result) {
+		panic("unexpected result from BLS12-381 operation")
+	}
+	return result, nil
+}
+
+func (b *blsOperationOracle) Name() string {
+	return b.Orig.Name()
+}
+
+type blsOperationOracleWithSizeLimit struct {
+	blsOperationOracle
+	sizeLimit uint64
+}
+
+func (b *blsOperationOracleWithSizeLimit) Run(input []byte) ([]byte, error) {
+	if uint64(len(input)) > b.sizeLimit {
+		return nil, errInvalidBlsSize
+	}
+	return b.blsOperationOracle.Run(input)
+}

--- a/op-e2e/actions/helpers/engineapi/precompiles_test.go
+++ b/op-e2e/actions/helpers/engineapi/precompiles_test.go
@@ -1,0 +1,557 @@
+package engineapi
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	stubRequiredGas     = uint64(29382938)
+	stubResult          = []byte{1, 2, 3, 6, 4, 3, 6, 6}
+	defaultOracleResult = []byte{9, 9, 9, 10, 10, 10}
+)
+
+func TestOverriddenPrecompiles(t *testing.T) {
+	tests := []struct {
+		name         string
+		addr         common.Address
+		rules        params.Rules
+		overrideWith any
+	}{
+		{name: "ecrecover", addr: ecrecoverPrecompileAddress, overrideWith: &ecrecoverOracle{}},
+		{name: "bn256Pairing", addr: bn256PairingPrecompileAddress, overrideWith: &bn256PairingOracle{}},
+		{name: "bn256PairingGranite", addr: bn256PairingPrecompileAddress, rules: params.Rules{IsOptimismGranite: true}, overrideWith: &bn256PairingOracleGranite{}},
+		{name: "bn256PairingJovian", addr: bn256PairingPrecompileAddress, rules: params.Rules{IsOptimismJovian: true}, overrideWith: &bn256PairingOracleJovian{}},
+		{name: "kzgPointEvaluation", addr: kzgPointEvaluationPrecompileAddress, overrideWith: &kzgPointEvaluationOracle{}},
+
+		{name: "blsG1Add", addr: blsG1AddPrecompileAddress, overrideWith: &blsOperationOracle{}},
+		{name: "blsG1MSM", addr: blsG1MSMPrecompileAddress, overrideWith: &blsOperationOracleWithSizeLimit{}},
+		{name: "blsG2Add", addr: blsG2AddPrecompileAddress, overrideWith: &blsOperationOracle{}},
+		{name: "blsG2MSM", addr: blsG2MSMPrecompileAddress, overrideWith: &blsOperationOracleWithSizeLimit{}},
+		{name: "blsPairingCheck", addr: blsPairingPrecompileAddress, overrideWith: &blsOperationOracleWithSizeLimit{}},
+		{name: "blsMapFpToG1", addr: blsMapToG1PrecompileAddress, overrideWith: &blsOperationOracle{}},
+		{name: "blsMapFp2ToG2", addr: blsMapToG2PrecompileAddress, overrideWith: &blsOperationOracle{}},
+
+		// Actual precompiles but not overridden
+		{name: "identity", addr: common.Address{0x04}},
+		{name: "ripemd160", addr: common.BytesToAddress([]byte{0x03})},
+		{name: "blake2F", addr: common.BytesToAddress([]byte{0x09})},
+		{name: "sha256", addr: common.BytesToAddress([]byte{0x02})},
+
+		// Not a precompile, not overridden
+		{name: "unknown", addr: common.Address{0xdd, 0xff, 0x33, 0xaa}},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			orig := &stubPrecompile{}
+			oracle := &stubPrecompileOracle{}
+			overrides := CreatePrecompileOverrides(oracle)
+
+			actual := overrides(test.rules, orig, test.addr)
+			if test.overrideWith != nil {
+				require.NotSame(t, orig, actual, "should have overridden precompile")
+				require.IsType(t, test.overrideWith, actual, "should have overridden with correct type")
+			} else {
+				require.Same(t, orig, actual, "should not have overridden precompile")
+			}
+		})
+	}
+
+	// Ensures that if the pre-compile isn't present in the active fork, we don't add an override that enables it
+	t.Run("nil-orig", func(t *testing.T) {
+		oracle := &stubPrecompileOracle{}
+		overrides := CreatePrecompileOverrides(oracle)
+
+		actual := overrides(params.Rules{}, nil, ecrecoverPrecompileAddress)
+		require.Nil(t, actual, "should not add new pre-compiles")
+	})
+}
+
+func TestEcrecover(t *testing.T) {
+	setup := func() (vm.PrecompiledContract, *stubPrecompileOracle) {
+		orig := &stubPrecompile{}
+		oracle := &stubPrecompileOracle{}
+		overrides := CreatePrecompileOverrides(oracle)
+		override := overrides(params.Rules{}, orig, ecrecoverPrecompileAddress)
+		return override, oracle
+	}
+	validInput := common.FromHex("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000000000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549")
+
+	t.Run("RequiredGas", func(t *testing.T) {
+		impl, _ := setup()
+		require.Equal(t, stubRequiredGas, impl.RequiredGas(validInput))
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		impl, oracle := setup()
+		result, err := impl.Run(validInput)
+		require.NoError(t, err)
+		require.Equal(t, defaultOracleResult, result)
+		require.Equal(t, oracle.calledAddr, ecrecoverPrecompileAddress)
+		require.Equal(t, oracle.calledInput, validInput)
+		require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+	})
+
+	t.Run("OracleRevert", func(t *testing.T) {
+		impl, oracle := setup()
+		oracle.failureResponse = true
+		result, err := impl.Run(validInput)
+		require.ErrorIs(t, err, errInvalidEcrecoverInput)
+		require.Nil(t, result)
+		require.Equal(t, oracle.calledAddr, ecrecoverPrecompileAddress)
+		require.Equal(t, oracle.calledInput, validInput)
+		require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+	})
+
+	t.Run("NotAllZeroV", func(t *testing.T) {
+		impl, oracle := setup()
+		input := make([]byte, 128)
+		copy(input, validInput)
+		input[33] = 1
+		result, err := impl.Run(input)
+		require.NoError(t, err)
+		require.Nil(t, result)
+		require.Equal(t, oracle.calledAddr, common.Address{}, "should not call oracle")
+	})
+
+	t.Run("InvalidSignatureValues", func(t *testing.T) {
+		impl, oracle := setup()
+		input := []byte{1, 2, 3, 4} // Rubbish input that doesn't pass the sanity checks.
+		result, err := impl.Run(input)
+		require.NoError(t, err)
+		require.Nil(t, result)
+		require.Equal(t, oracle.calledAddr, common.Address{}, "should not call oracle")
+	})
+
+	t.Run("RightPadInput", func(t *testing.T) {
+		impl, oracle := setup()
+		// No expected hash, but valid r,s,v values
+		input := validInput[:len(validInput)-2]
+		paddedInput := make([]byte, len(validInput))
+		copy(paddedInput, validInput)
+		paddedInput[len(paddedInput)-1] = 0
+		paddedInput[len(paddedInput)-2] = 0
+		result, err := impl.Run(input)
+		require.NoError(t, err)
+		require.Equal(t, defaultOracleResult, result)
+		require.Equal(t, oracle.calledAddr, ecrecoverPrecompileAddress)
+		require.Equal(t, oracle.calledInput, paddedInput)
+		require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+	})
+
+	t.Run("TruncateOversizedInput", func(t *testing.T) {
+		impl, oracle := setup()
+		// Input larger than 128 bytes
+		oversizedInput := make([]byte, 256)
+		copy(oversizedInput, validInput)
+		for i := 128; i < 256; i++ {
+			oversizedInput[i] = byte(i)
+		}
+
+		result, err := impl.Run(oversizedInput)
+		require.NoError(t, err)
+		require.Equal(t, defaultOracleResult, result)
+		require.Equal(t, oracle.calledAddr, ecrecoverPrecompileAddress)
+		require.Equal(t, 128, len(oracle.calledInput), "oracle should receive truncated input")
+		require.Equal(t, validInput, oracle.calledInput, "oracle should receive first 128 bytes")
+		require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+	})
+
+	t.Run("Exactly128Bytes", func(t *testing.T) {
+		impl, oracle := setup()
+		input128 := validInput
+
+		result, err := impl.Run(input128)
+		require.NoError(t, err)
+		require.Equal(t, defaultOracleResult, result)
+		require.Equal(t, oracle.calledAddr, ecrecoverPrecompileAddress)
+		require.Equal(t, 128, len(oracle.calledInput), "oracle should receive exactly 128 bytes")
+		require.Equal(t, input128, oracle.calledInput)
+		require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+	})
+}
+
+func TestBn256Pairing(t *testing.T) {
+	type forkConfig struct {
+		name  string
+		rules params.Rules
+		limit uint64
+	}
+
+	forks := []forkConfig{
+		{name: "Pre-Granite", rules: params.Rules{}, limit: 0}, // No limit
+		{name: "Granite", rules: params.Rules{IsOptimismGranite: true}, limit: params.Bn256PairingMaxInputSizeGranite},
+		{name: "Jovian", rules: params.Rules{IsOptimismGranite: true, IsOptimismJovian: true}, limit: params.Bn256PairingMaxInputSizeJovian},
+	}
+
+	setup := func(rules params.Rules) (vm.PrecompiledContract, *stubPrecompileOracle) {
+		orig := &stubPrecompile{}
+		oracle := &stubPrecompileOracle{result: bytes.Clone(true32Byte)}
+		overrides := CreatePrecompileOverrides(oracle)
+		override := overrides(rules, orig, bn256PairingPrecompileAddress)
+		return override, oracle
+	}
+	validInput := common.FromHex("1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f593034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf704bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a416782bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550111e129f1cf1097710d41c4ac70fcdfa5ba2023c6ff1cbeac322de49d1b6df7c2032c61a830e3c17286de9462bf242fca2883585b93870a73853face6a6bf411198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa")
+
+	for _, fork := range forks {
+		fork := fork
+		t.Run(fork.name, func(t *testing.T) {
+			t.Run("RequiredGas", func(t *testing.T) {
+				impl, _ := setup(fork.rules)
+				require.Equal(t, stubRequiredGas, impl.RequiredGas(validInput))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				impl, oracle := setup(fork.rules)
+				result, err := impl.Run(validInput)
+				require.NoError(t, err)
+				require.Equal(t, true32Byte, result)
+				require.Equal(t, oracle.calledAddr, bn256PairingPrecompileAddress)
+				require.Equal(t, oracle.calledInput, validInput)
+				require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+			})
+
+			t.Run("OracleRevert", func(t *testing.T) {
+				impl, oracle := setup(fork.rules)
+				oracle.failureResponse = true
+				result, err := impl.Run(validInput)
+				require.ErrorIs(t, err, errInvalidBn256PairingCheck)
+				require.Nil(t, result)
+				require.Equal(t, oracle.calledAddr, bn256PairingPrecompileAddress)
+				require.Equal(t, oracle.calledInput, validInput)
+				require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+			})
+
+			t.Run("LengthNotMultipleOf192", func(t *testing.T) {
+				impl, oracle := setup(fork.rules)
+				input := make([]byte, 193)
+				result, err := impl.Run(input)
+				require.ErrorIs(t, err, errBadPairingInput)
+				require.Nil(t, result)
+				require.Equal(t, oracle.calledAddr, common.Address{}, "should not call oracle")
+			})
+
+			if fork.limit > 0 {
+				t.Run("AtLimit", func(t *testing.T) {
+					impl, oracle := setup(fork.rules)
+					// bn256Pairing requires inputs to be multiples of 192
+					inputSize := (int(fork.limit) / 192) * 192
+					input := make([]byte, inputSize)
+					result, err := impl.Run(input)
+					require.NoError(t, err, "should accept input at %s limit", fork.name)
+					require.Equal(t, true32Byte, result)
+					require.Equal(t, oracle.calledAddr, bn256PairingPrecompileAddress)
+				})
+
+				t.Run("AboveLimit", func(t *testing.T) {
+					impl, oracle := setup(fork.rules)
+					input := make([]byte, fork.limit+1)
+					result, err := impl.Run(input)
+					require.ErrorIs(t, err, errBadPairingInputSize)
+					require.Nil(t, result)
+					require.Equal(t, oracle.calledAddr, common.Address{}, "should not call oracle")
+				})
+			}
+		})
+	}
+
+	// Test that Pre-Granite accepts inputs above Granite limit
+	t.Run("LongInputPreGranite", func(t *testing.T) {
+		impl, oracle := setup(params.Rules{})
+		input := make([]byte, (params.Bn256PairingMaxInputSizeGranite/192+1)*192)
+		result, err := impl.Run(input)
+		require.NoError(t, err)
+		require.Equal(t, true32Byte, result)
+		require.Equal(t, oracle.calledAddr, bn256PairingPrecompileAddress)
+		require.Equal(t, oracle.calledInput, input)
+		require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+	})
+
+	t.Run("InputBetweenJovianAndGraniteLimits", func(t *testing.T) {
+		impl, oracle := setup(params.Rules{IsOptimismGranite: true})
+		// Must be a multiple of 192
+		inputSize := (int(params.Bn256PairingMaxInputSizeGranite) / 192) * 192
+		input := make([]byte, inputSize)
+		result, err := impl.Run(input)
+		require.NoError(t, err, "Granite should accept input at its limit")
+		require.Equal(t, true32Byte, result)
+		require.Equal(t, oracle.calledAddr, bn256PairingPrecompileAddress)
+	})
+}
+
+func TestKzgPointEvaluationPrecompile(t *testing.T) {
+	oracleResult := common.FromHex(blobPrecompileReturnValue)
+	setup := func() (vm.PrecompiledContract, *stubPrecompileOracle) {
+		orig := &stubPrecompile{}
+		oracle := &stubPrecompileOracle{result: bytes.Clone(oracleResult)}
+		overrides := CreatePrecompileOverrides(oracle)
+		override := overrides(params.Rules{}, orig, kzgPointEvaluationPrecompileAddress)
+		return override, oracle
+	}
+	validInput := common.FromHex("01e798154708fe7789429634053cbf9f99b619f9f084048927333fce637f549b564c0a11a0f704f4fc3e8acfe0f8245f0ad1347b378fbf96e206da11a5d3630624d25032e67a7e6a4910df5834b8fe70e6bcfeeac0352434196bdf4b2485d5a18f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7873033e038326e87ed3e1276fd140253fa08e9fc25fb2d9a98527fc22a2c9612fbeafdad446cbc7bcdbdcd780af2c16a")
+
+	t.Run("RequiredGas", func(t *testing.T) {
+		impl, _ := setup()
+		require.Equal(t, stubRequiredGas, impl.RequiredGas(validInput))
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		impl, oracle := setup()
+		result, err := impl.Run(validInput)
+		require.NoError(t, err)
+		require.Equal(t, oracleResult, result)
+		require.Equal(t, oracle.calledAddr, kzgPointEvaluationPrecompileAddress)
+		require.Equal(t, oracle.calledInput, validInput)
+		require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+	})
+
+	t.Run("OracleRevert", func(t *testing.T) {
+		impl, oracle := setup()
+		oracle.failureResponse = true
+		result, err := impl.Run(validInput)
+		require.ErrorIs(t, err, errBlobVerifyKZGProof)
+		require.Nil(t, result)
+		require.Equal(t, oracle.calledAddr, kzgPointEvaluationPrecompileAddress)
+		require.Equal(t, oracle.calledInput, validInput)
+		require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+	})
+
+	t.Run("IncorrectVersionedHash", func(t *testing.T) {
+		impl, oracle := setup()
+		input := make([]byte, len(validInput))
+		copy(input, validInput)
+		input[3] = 74 // Change part of the versioned hash so it doesn't match the commitment
+		result, err := impl.Run(input)
+		require.ErrorIs(t, err, errBlobVerifyMismatchedVersion)
+		require.Nil(t, result)
+		require.Equal(t, oracle.calledAddr, common.Address{}, "should not call oracle")
+	})
+
+	t.Run("IncorrectLength", func(t *testing.T) {
+		impl, oracle := setup()
+		input := make([]byte, 193)
+		result, err := impl.Run(input)
+		require.ErrorIs(t, err, errBlobVerifyInvalidInputLength)
+		require.Nil(t, result)
+		require.Equal(t, oracle.calledAddr, common.Address{}, "should not call oracle")
+	})
+}
+
+func TestBLSPrecompileWithSizeLimit(t *testing.T) {
+	type forkConfig struct {
+		name  string
+		rules params.Rules
+	}
+
+	forks := []forkConfig{
+		{name: "Isthmus", rules: params.Rules{}},
+		{name: "Jovian", rules: params.Rules{IsOptimismGranite: true, IsOptimismJovian: true}},
+	}
+
+	testCases := []struct {
+		name          string
+		validInput    []byte
+		validOutput   []byte
+		address       common.Address
+		isthumusLimit uint64
+		jovianLimit   uint64
+		elementSize   int // for multi-element inputs (MSM, pairing)
+	}{
+		{
+			name:          "blsG1Add",
+			address:       blsG1AddPrecompileAddress,
+			validInput:    common.FromHex("0000000000000000000000000000000017f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb0000000000000000000000000000000008b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e100000000000000000000000000000000112b98340eee2777cc3c14163dea3ec97977ac3dc5c70da32e6e87578f44912e902ccef9efe28d4a78b8999dfbca942600000000000000000000000000000000186b28d92356c4dfec4b5201ad099dbdede3781f8998ddf929b4cd7756192185ca7b8f4ef7088f813270ac3d48868a21"),
+			validOutput:   common.FromHex("000000000000000000000000000000000a40300ce2dec9888b60690e9a41d3004fda4886854573974fab73b046d3147ba5b7a5bde85279ffede1b45b3918d82d0000000000000000000000000000000006d3d887e9f53b9ec4eb6cedf5607226754b07c01ace7834f57f3e7315faefb739e59018e22c492006190fba4a870025"),
+			isthumusLimit: 256,
+			jovianLimit:   256,
+		},
+		{
+			name:          "blsG1MSM",
+			address:       blsG1MSMPrecompileAddress,
+			validInput:    common.FromHex("0000000000000000000000000000000017f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb0000000000000000000000000000000008b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000112b98340eee2777cc3c14163dea3ec97977ac3dc5c70da32e6e87578f44912e902ccef9efe28d4a78b8999dfbca942600000000000000000000000000000000186b28d92356c4dfec4b5201ad099dbdede3781f8998ddf929b4cd7756192185ca7b8f4ef7088f813270ac3d48868a210000000000000000000000000000000000000000000000000000000000000002"),
+			validOutput:   common.FromHex("00000000000000000000000000000000148f92dced907361b4782ab542a75281d4b6f71f65c8abf94a5a9082388c64662d30fd6a01ced724feef3e284752038c0000000000000000000000000000000015c3634c3b67bc18e19150e12bfd8a1769306ed010f59be645a0823acb5b38f39e8e0d86e59b6353fdafc59ca971b769"),
+			isthumusLimit: params.Bls12381G1MulMaxInputSizeIsthmus,
+			jovianLimit:   params.Bls12381G1MulMaxInputSizeJovian,
+			elementSize:   160,
+		},
+		{
+			name:          "blsG2Add",
+			address:       blsG2AddPrecompileAddress,
+			validInput:    common.FromHex("00000000000000000000000000000000024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb80000000000000000000000000000000013e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e000000000000000000000000000000000ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801000000000000000000000000000000000606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be00000000000000000000000000000000103121a2ceaae586d240843a398967325f8eb5a93e8fea99b62b9f88d8556c80dd726a4b30e84a36eeabaf3592937f2700000000000000000000000000000000086b990f3da2aeac0a36143b7d7c824428215140db1bb859338764cb58458f081d92664f9053b50b3fbd2e4723121b68000000000000000000000000000000000f9e7ba9a86a8f7624aa2b42dcc8772e1af4ae115685e60abc2c9b90242167acef3d0be4050bf935eed7c3b6fc7ba77e000000000000000000000000000000000d22c3652d0dc6f0fc9316e14268477c2049ef772e852108d269d9c38dba1d4802e8dae479818184c08f9a569d878451"),
+			validOutput:   common.FromHex("000000000000000000000000000000000b54a8a7b08bd6827ed9a797de216b8c9057b3a9ca93e2f88e7f04f19accc42da90d883632b9ca4dc38d013f71ede4db00000000000000000000000000000000077eba4eecf0bd764dce8ed5f45040dd8f3b3427cb35230509482c14651713282946306247866dfe39a8e33016fcbe520000000000000000000000000000000014e60a76a29ef85cbd69f251b9f29147b67cfe3ed2823d3f9776b3a0efd2731941d47436dc6d2b58d9e65f8438bad073000000000000000000000000000000001586c3c910d95754fef7a732df78e279c3d37431c6a2b77e67a00c7c130a8fcd4d19f159cbeb997a178108fffffcbd20"),
+			isthumusLimit: 512,
+			jovianLimit:   512,
+		},
+		{
+			name:          "blsG2MSM",
+			address:       blsG2MSMPrecompileAddress,
+			validInput:    common.FromHex("00000000000000000000000000000000024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb80000000000000000000000000000000013e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e000000000000000000000000000000000ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801000000000000000000000000000000000606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000103121a2ceaae586d240843a398967325f8eb5a93e8fea99b62b9f88d8556c80dd726a4b30e84a36eeabaf3592937f2700000000000000000000000000000000086b990f3da2aeac0a36143b7d7c824428215140db1bb859338764cb58458f081d92664f9053b50b3fbd2e4723121b68000000000000000000000000000000000f9e7ba9a86a8f7624aa2b42dcc8772e1af4ae115685e60abc2c9b90242167acef3d0be4050bf935eed7c3b6fc7ba77e000000000000000000000000000000000d22c3652d0dc6f0fc9316e14268477c2049ef772e852108d269d9c38dba1d4802e8dae479818184c08f9a569d8784510000000000000000000000000000000000000000000000000000000000000002"),
+			validOutput:   common.FromHex("00000000000000000000000000000000009cc9ed6635623ba19b340cbc1b0eb05c3a58770623986bb7e041645175b0a38d663d929afb9a949f7524656043bccc000000000000000000000000000000000c0fb19d3f083fd5641d22a861a11979da258003f888c59c33005cb4a2df4df9e5a2868832063ac289dfa3e997f21f8a00000000000000000000000000000000168bf7d87cef37cf1707849e0a6708cb856846f5392d205ae7418dd94d94ef6c8aa5b424af2e99d957567654b9dae1d90000000000000000000000000000000017e0fa3c3b2665d52c26c7d4cea9f35443f4f9007840384163d3aa3c7d4d18b21b65ff4380cf3f3b48e94b5eecb221dd"),
+			isthumusLimit: params.Bls12381G2MulMaxInputSizeIsthmus,
+			jovianLimit:   params.Bls12381G2MulMaxInputSizeJovian,
+			elementSize:   288,
+		},
+		{
+			name:          "blsPairingCheck",
+			address:       blsPairingPrecompileAddress,
+			validInput:    common.FromHex("0000000000000000000000000000000017f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb0000000000000000000000000000000008b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb80000000000000000000000000000000013e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e000000000000000000000000000000000ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801000000000000000000000000000000000606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be"),
+			validOutput:   common.FromHex("0000000000000000000000000000000000000000000000000000000000000001"),
+			isthumusLimit: params.Bls12381PairingMaxInputSizeIsthmus,
+			jovianLimit:   params.Bls12381PairingMaxInputSizeJovian,
+			elementSize:   384,
+		},
+		{
+			name:          "blsMapToG1",
+			address:       blsMapToG1PrecompileAddress,
+			validInput:    common.FromHex("00000000000000000000000000000000156c8a6a2c184569d69a76be144b5cdc5141d2d2ca4fe341f011e25e3969c55ad9e9b9ce2eb833c81a908e5fa4ac5f03"),
+			validOutput:   common.FromHex("00000000000000000000000000000000184bb665c37ff561a89ec2122dd343f20e0f4cbcaec84e3c3052ea81d1834e192c426074b02ed3dca4e7676ce4ce48ba0000000000000000000000000000000004407b8d35af4dacc809927071fc0405218f1401a6d15af775810e4e460064bcc9468beeba82fdc751be70476c888bf3"),
+			isthumusLimit: 64,
+			jovianLimit:   64,
+		},
+		{
+			name:          "blsMapToG2",
+			address:       blsMapToG2PrecompileAddress,
+			validInput:    common.FromHex("0000000000000000000000000000000007355d25caf6e7f2f0cb2812ca0e513bd026ed09dda65b177500fa31714e09ea0ded3a078b526bed3307f804d4b93b040000000000000000000000000000000002829ce3c021339ccb5caf3e187f6370e1e2a311dec9b75363117063ab2015603ff52c3d3b98f19c2f65575e99e8b78c"),
+			validOutput:   common.FromHex("0000000000000000000000000000000000e7f4568a82b4b7dc1f14c6aaa055edf51502319c723c4dc2688c7fe5944c213f510328082396515734b6612c4e7bb700000000000000000000000000000000126b855e9e69b1f691f816e48ac6977664d24d99f8724868a184186469ddfd4617367e94527d4b74fc86413483afb35b000000000000000000000000000000000caead0fd7b6176c01436833c79d305c78be307da5f6af6c133c47311def6ff1e0babf57a0fb5539fce7ee12407b0a42000000000000000000000000000000001498aadcf7ae2b345243e281ae076df6de84455d766ab6fcdaad71fab60abb2e8b980a440043cd305db09d283c895e3d"),
+			isthumusLimit: 128,
+			jovianLimit:   128,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			for _, fork := range forks {
+				forkLimit := testCase.isthumusLimit
+				if fork.rules.IsOptimismJovian {
+					forkLimit = testCase.jovianLimit
+				}
+
+				oracleResult := testCase.validOutput
+				setup := func() (vm.PrecompiledContract, *stubPrecompileOracle) {
+					orig := &stubPrecompile{}
+					oracle := &stubPrecompileOracle{result: bytes.Clone(oracleResult)}
+					overrides := CreatePrecompileOverrides(oracle)
+					override := overrides(fork.rules, orig, testCase.address)
+					return override, oracle
+				}
+				validInput := testCase.validInput
+
+				t.Run(fmt.Sprintf("%s-RequiredGas", fork.name), func(t *testing.T) {
+					impl, _ := setup()
+					require.Equal(t, stubRequiredGas, impl.RequiredGas(validInput))
+				})
+
+				t.Run(fmt.Sprintf("%s-Valid", fork.name), func(t *testing.T) {
+					impl, oracle := setup()
+					result, err := impl.Run(validInput)
+					require.NoError(t, err)
+					require.Equal(t, oracleResult, result)
+					require.Equal(t, oracle.calledAddr, testCase.address)
+					require.Equal(t, oracle.calledInput, validInput)
+					require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+				})
+
+				t.Run(fmt.Sprintf("%s-OracleRevert", fork.name), func(t *testing.T) {
+					impl, oracle := setup()
+					oracle.failureResponse = true
+					result, err := impl.Run(validInput)
+					require.ErrorIs(t, err, errInvalidBlsOperation)
+					require.Nil(t, result)
+					require.Equal(t, oracle.calledAddr, testCase.address)
+					require.Equal(t, oracle.calledInput, validInput)
+					require.Equal(t, oracle.calledRequiredGas, stubRequiredGas)
+				})
+
+				// Test size limits for variable-size precompiles
+				if testCase.elementSize > 0 {
+					t.Run(fmt.Sprintf("%s-AtLimit", fork.name), func(t *testing.T) {
+						impl, oracle := setup()
+						// Input at exact fork limit (rounded to element size)
+						inputSize := int(forkLimit)
+						inputSize = (inputSize / testCase.elementSize) * testCase.elementSize
+						input := make([]byte, inputSize)
+						result, err := impl.Run(input)
+						require.NoError(t, err, "should accept input at %s limit", fork.name)
+						require.NotNil(t, result)
+						require.Equal(t, oracle.calledAddr, testCase.address)
+					})
+
+					t.Run(fmt.Sprintf("%s-AboveLimit", fork.name), func(t *testing.T) {
+						impl, oracle := setup()
+						// Input above fork limit
+						input := make([]byte, forkLimit+1)
+						result, err := impl.Run(input)
+						require.Error(t, err, "should reject input above %s limit", fork.name)
+						require.Nil(t, result)
+						require.Equal(t, oracle.calledAddr, common.Address{}, "should not call oracle")
+					})
+				}
+			}
+
+			// Test inputs between Jovian and Isthmus limits to ensure compatibility
+			if testCase.jovianLimit < testCase.isthumusLimit && testCase.elementSize > 0 {
+				t.Run("InputBetweenJovianAndIsthumusLimits", func(t *testing.T) {
+					// Isthmus rules should accept inputs between the two limits
+					orig := &stubPrecompile{}
+					oracle := &stubPrecompileOracle{result: bytes.Clone(testCase.validOutput)}
+					overrides := CreatePrecompileOverrides(oracle)
+					impl := overrides(params.Rules{}, orig, testCase.address)
+
+					// Input between Jovian and Isthmus limit
+					inputSize := int(testCase.jovianLimit) + testCase.elementSize
+					if inputSize > int(testCase.isthumusLimit) {
+						inputSize = int(testCase.isthumusLimit)
+					}
+					inputSize = (inputSize / testCase.elementSize) * testCase.elementSize
+					input := make([]byte, inputSize)
+
+					result, err := impl.Run(input)
+					require.NoError(t, err, "Isthmus should accept input between Jovian and Isthmus limits")
+					require.NotNil(t, result)
+					require.Equal(t, oracle.calledAddr, testCase.address)
+				})
+			}
+		})
+	}
+}
+
+type stubPrecompile struct{}
+
+func (s *stubPrecompile) RequiredGas(_ []byte) uint64 {
+	return stubRequiredGas
+}
+
+func (s *stubPrecompile) Run(_ []byte) ([]byte, error) {
+	return stubResult, nil
+}
+
+func (s *stubPrecompile) Name() string {
+	return "STUB"
+}
+
+type stubPrecompileOracle struct {
+	result            []byte
+	failureResponse   bool
+	calledAddr        common.Address
+	calledInput       []byte
+	calledRequiredGas uint64
+}
+
+func (s *stubPrecompileOracle) Precompile(addr common.Address, input []byte, requiredGas uint64) ([]byte, bool) {
+	s.calledAddr = addr
+	s.calledInput = input
+	s.calledRequiredGas = requiredGas
+	result := defaultOracleResult
+	if s.result != nil {
+		result = s.result
+	}
+	return result, !s.failureResponse
+}

--- a/op-e2e/actions/helpers/engineapi/test/l2_engine_api_tests.go
+++ b/op-e2e/actions/helpers/engineapi/test/l2_engine_api_tests.go
@@ -1,0 +1,461 @@
+package test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers/engineapi"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+var gasLimit = eth.Uint64Quantity(30_000_000)
+var feeRecipient = common.Address{}
+
+func RunEngineAPITests(t *testing.T, createBackend func(t *testing.T) engineapi.EngineBackend) {
+	t.Run("CreateBlock", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+
+		block := api.addBlock()
+		api.assert.Equal(block.BlockHash, api.headHash(), "should create and import new block")
+	})
+
+	zero := uint64(0)
+	rollupCfg := &rollup.Config{
+		RegolithTime: &zero, // activate Regolith upgrade
+	}
+	t.Run("IncludeRequiredTransactions", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesis := api.backend.CurrentHeader()
+
+		txData, err := derive.L1InfoDeposit(rollupCfg, params.MergedTestChainConfig, eth.SystemConfig{}, 1, eth.HeaderBlockInfo(genesis), 0)
+		api.assert.NoError(err)
+		tx := types.NewTx(txData)
+		block := api.addBlock(tx)
+		api.assert.Equal(block.BlockHash, api.headHash(), "should create and import new block")
+		imported := api.backend.GetBlockByHash(block.BlockHash)
+		api.assert.Len(imported.Transactions(), 1, "should include transaction")
+
+		api.assert.NotEqual(genesis.Root, block.StateRoot)
+		newState, err := api.backend.StateAt(common.Hash(block.StateRoot))
+		require.NoError(t, err, "imported block state should be available")
+		require.NotNil(t, newState)
+	})
+
+	t.Run("RejectCreatingBlockWithInvalidRequiredTransaction", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesis := api.backend.CurrentHeader()
+
+		txData, err := derive.L1InfoDeposit(rollupCfg, params.MergedTestChainConfig, eth.SystemConfig{}, 1, eth.HeaderBlockInfo(genesis), 0)
+		api.assert.NoError(err)
+		txData.Gas = uint64(gasLimit + 1)
+		tx := types.NewTx(txData)
+		txRlp, err := tx.MarshalBinary()
+		api.assert.NoError(err)
+
+		nextBlockTime := eth.Uint64Quantity(genesis.Time + 1)
+
+		var w *types.Withdrawals
+		if api.backend.Config().IsCanyon(uint64(nextBlockTime)) {
+			w = &types.Withdrawals{}
+		}
+
+		result, err := api.engine.ForkchoiceUpdatedV2(api.ctx, &eth.ForkchoiceState{
+			HeadBlockHash:      genesis.Hash(),
+			SafeBlockHash:      genesis.Hash(),
+			FinalizedBlockHash: genesis.Hash(),
+		}, &eth.PayloadAttributes{
+			Timestamp:             nextBlockTime,
+			PrevRandao:            eth.Bytes32(genesis.MixDigest),
+			SuggestedFeeRecipient: feeRecipient,
+			Transactions:          []eth.Data{txRlp},
+			NoTxPool:              true,
+			GasLimit:              &gasLimit,
+			Withdrawals:           w,
+		})
+		api.assert.Error(err)
+		api.assert.Equal(eth.ExecutionInvalid, result.PayloadStatus.Status)
+	})
+
+	t.Run("IgnoreUpdateHeadToOlderBlock", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesisHash := api.headHash()
+		api.addBlock()
+		block := api.addBlock()
+		api.assert.Equal(block.BlockHash, api.headHash(), "should have extended chain")
+
+		api.forkChoiceUpdated(genesisHash, genesisHash, genesisHash)
+		api.assert.Equal(block.BlockHash, api.headHash(), "should not have reset chain head")
+	})
+
+	t.Run("AllowBuildingOnOlderBlock", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesis := api.backend.CurrentHeader()
+		api.addBlock()
+		block := api.addBlock()
+		api.assert.Equal(block.BlockHash, api.headHash(), "should have extended chain")
+
+		payloadID := api.startBlockBuilding(genesis, eth.Uint64Quantity(genesis.Time+3))
+		api.assert.Equal(block.BlockHash, api.headHash(), "should not reset chain head when building starts")
+
+		envelope := api.getPayload(payloadID)
+		payload := envelope.ExecutionPayload
+		api.assert.Equal(genesis.Hash(), payload.ParentHash, "should have old block as parent")
+
+		api.newPayload(envelope)
+		api.forkChoiceUpdated(payload.BlockHash, genesis.Hash(), genesis.Hash())
+		api.assert.Equal(payload.BlockHash, api.headHash(), "should reorg to block built on old parent")
+	})
+
+	t.Run("RejectInvalidBlockHash", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+
+		var w *types.Withdrawals
+		if api.backend.Config().IsCanyon(uint64(0)) {
+			w = &types.Withdrawals{}
+		}
+
+		// Invalid because BlockHash won't be correct (among many other reasons)
+		block := &eth.ExecutionPayload{
+			Withdrawals: w,
+		}
+		r, err := api.engine.NewPayloadV2(api.ctx, block)
+		api.assert.NoError(err)
+		api.assert.Equal(eth.ExecutionInvalidBlockHash, r.Status)
+	})
+
+	t.Run("RejectBlockWithInvalidStateTransition", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesis := api.backend.CurrentHeader()
+
+		// Build a valid block
+		payloadID := api.startBlockBuilding(genesis, eth.Uint64Quantity(genesis.Time+2))
+		envelope := api.getPayload(payloadID)
+
+		// But then make it invalid by changing the state root
+		envelope.ExecutionPayload.StateRoot = eth.Bytes32(genesis.TxHash)
+		updateBlockHash(envelope)
+
+		r, err := api.callNewPayload(envelope)
+		api.assert.NoError(err)
+		api.assert.Equal(eth.ExecutionInvalid, r.Status)
+	})
+
+	t.Run("RejectBlockWithSameTimeAsParent", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesis := api.backend.CurrentHeader()
+
+		// Start with a valid time
+		payloadID := api.startBlockBuilding(genesis, eth.Uint64Quantity(genesis.Time+1))
+		envelope := api.getPayload(payloadID)
+
+		// Then make it invalid to check NewPayload rejects it
+		envelope.ExecutionPayload.Timestamp = eth.Uint64Quantity(genesis.Time)
+		updateBlockHash(envelope)
+
+		r, err := api.callNewPayload(envelope)
+		api.assert.NoError(err)
+		api.assert.Equal(eth.ExecutionInvalid, r.Status)
+	})
+
+	t.Run("RejectBlockWithTimeBeforeParent", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesis := api.backend.CurrentHeader()
+
+		// Start with a valid time
+		payloadID := api.startBlockBuilding(genesis, eth.Uint64Quantity(genesis.Time+1))
+		envelope := api.getPayload(payloadID)
+
+		// Then make it invalid to check NewPayload rejects it
+		envelope.ExecutionPayload.Timestamp = eth.Uint64Quantity(genesis.Time - 1)
+		updateBlockHash(envelope)
+
+		r, err := api.callNewPayload(envelope)
+		api.assert.NoError(err)
+		api.assert.Equal(eth.ExecutionInvalid, r.Status)
+	})
+
+	t.Run("RejectCreateBlockWithSameTimeAsParent", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesis := api.backend.CurrentHeader()
+
+		result, err := api.engine.ForkchoiceUpdatedV2(api.ctx, &eth.ForkchoiceState{
+			HeadBlockHash:      genesis.Hash(),
+			SafeBlockHash:      genesis.Hash(),
+			FinalizedBlockHash: genesis.Hash(),
+		}, &eth.PayloadAttributes{
+			Timestamp:             eth.Uint64Quantity(genesis.Time),
+			PrevRandao:            eth.Bytes32(genesis.MixDigest),
+			SuggestedFeeRecipient: feeRecipient,
+			Transactions:          nil,
+			NoTxPool:              true,
+			GasLimit:              &gasLimit,
+		})
+		api.assert.Error(err)
+		api.assert.Equal(eth.ExecutionInvalid, result.PayloadStatus.Status)
+	})
+
+	t.Run("RejectCreateBlockWithTimeBeforeParent", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesis := api.backend.CurrentHeader()
+
+		result, err := api.engine.ForkchoiceUpdatedV2(api.ctx, &eth.ForkchoiceState{
+			HeadBlockHash:      genesis.Hash(),
+			SafeBlockHash:      genesis.Hash(),
+			FinalizedBlockHash: genesis.Hash(),
+		}, &eth.PayloadAttributes{
+			Timestamp:             eth.Uint64Quantity(genesis.Time - 1),
+			PrevRandao:            eth.Bytes32(genesis.MixDigest),
+			SuggestedFeeRecipient: feeRecipient,
+			Transactions:          nil,
+			NoTxPool:              true,
+			GasLimit:              &gasLimit,
+		})
+		api.assert.Error(err)
+		api.assert.Equal(eth.ExecutionInvalid, result.PayloadStatus.Status)
+	})
+
+	t.Run("RejectCreateBlockWithGasLimitAboveMax", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesis := api.backend.CurrentHeader()
+
+		gasLimit := eth.Uint64Quantity(params.MaxGasLimit + 1)
+
+		result, err := api.engine.ForkchoiceUpdatedV2(api.ctx, &eth.ForkchoiceState{
+			HeadBlockHash:      genesis.Hash(),
+			SafeBlockHash:      genesis.Hash(),
+			FinalizedBlockHash: genesis.Hash(),
+		}, &eth.PayloadAttributes{
+			Timestamp:             eth.Uint64Quantity(genesis.Time + 1),
+			PrevRandao:            eth.Bytes32(genesis.MixDigest),
+			SuggestedFeeRecipient: feeRecipient,
+			Transactions:          nil,
+			NoTxPool:              true,
+			GasLimit:              &gasLimit,
+		})
+		api.assert.Error(err)
+		api.assert.Equal(eth.ExecutionInvalid, result.PayloadStatus.Status)
+	})
+
+	t.Run("UpdateSafeAndFinalizedHead", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+
+		finalized := api.addBlock()
+		safe := api.addBlock()
+		head := api.addBlock()
+
+		api.forkChoiceUpdated(head.BlockHash, safe.BlockHash, finalized.BlockHash)
+		api.assert.Equal(head.BlockHash, api.headHash(), "should update head block")
+		api.assert.Equal(safe.BlockHash, api.safeHash(), "should update safe block")
+		api.assert.Equal(finalized.BlockHash, api.finalHash(), "should update finalized block")
+	})
+
+	t.Run("RejectSafeHeadWhenNotAncestor", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesis := api.backend.CurrentHeader()
+
+		api.addBlock()
+		chainA2 := api.addBlock()
+		chainA3 := api.addBlock()
+
+		chainB1 := api.addBlockWithParent(genesis, eth.Uint64Quantity(genesis.Time+3))
+
+		result, err := api.engine.ForkchoiceUpdatedV2(api.ctx, &eth.ForkchoiceState{
+			HeadBlockHash:      chainA3.BlockHash,
+			SafeBlockHash:      chainB1.BlockHash,
+			FinalizedBlockHash: chainA2.BlockHash,
+		}, nil)
+		api.assert.ErrorContains(err, "Invalid forkchoice state", "should return error from forkChoiceUpdated")
+		api.assert.Equal(eth.ExecutionInvalid, result.PayloadStatus.Status, "forkChoiceUpdated should return invalid")
+		api.assert.Nil(result.PayloadID, "should not provide payload ID when invalid")
+	})
+
+	t.Run("RejectFinalizedHeadWhenNotAncestor", func(t *testing.T) {
+		api := newTestHelper(t, createBackend)
+		genesis := api.backend.CurrentHeader()
+
+		api.addBlock()
+		chainA2 := api.addBlock()
+		chainA3 := api.addBlock()
+
+		chainB1 := api.addBlockWithParent(genesis, eth.Uint64Quantity(genesis.Time+3))
+
+		result, err := api.engine.ForkchoiceUpdatedV2(api.ctx, &eth.ForkchoiceState{
+			HeadBlockHash:      chainA3.BlockHash,
+			SafeBlockHash:      chainA2.BlockHash,
+			FinalizedBlockHash: chainB1.BlockHash,
+		}, nil)
+		api.assert.ErrorContains(err, "Invalid forkchoice state", "should return error from forkChoiceUpdated")
+		api.assert.Equal(eth.ExecutionInvalid, result.PayloadStatus.Status, "forkChoiceUpdated should return invalid")
+		api.assert.Nil(result.PayloadID, "should not provide payload ID when invalid")
+	})
+}
+
+// Updates the block hash to the expected value based on the other fields in the payload
+func updateBlockHash(envelope *eth.ExecutionPayloadEnvelope) {
+	// And fix up the block hash
+	newHash, _ := envelope.CheckBlockHash()
+	envelope.ExecutionPayload.BlockHash = newHash
+}
+
+type testHelper struct {
+	t       *testing.T
+	ctx     context.Context
+	engine  *engineapi.L2EngineAPI
+	backend engineapi.EngineBackend
+	assert  *require.Assertions
+}
+
+func newTestHelper(t *testing.T, createBackend func(t *testing.T) engineapi.EngineBackend) *testHelper {
+	logger := testlog.Logger(t, log.LevelDebug)
+	ctx := context.Background()
+	backend := createBackend(t)
+	api := engineapi.NewL2EngineAPI(logger, backend, nil)
+	test := &testHelper{
+		t:       t,
+		ctx:     ctx,
+		engine:  api,
+		backend: backend,
+		assert:  require.New(t),
+	}
+	return test
+}
+
+func (h *testHelper) headHash() common.Hash {
+	return h.backend.CurrentHeader().Hash()
+}
+
+func (h *testHelper) safeHash() common.Hash {
+	return h.backend.CurrentSafeBlock().Hash()
+}
+
+func (h *testHelper) finalHash() common.Hash {
+	return h.backend.CurrentFinalBlock().Hash()
+}
+
+func (h *testHelper) Log(args ...any) {
+	h.t.Log(args...)
+}
+
+func (h *testHelper) addBlock(txs ...*types.Transaction) *eth.ExecutionPayload {
+	head := h.backend.CurrentHeader()
+	return h.addBlockWithParent(head, eth.Uint64Quantity(head.Time+2), txs...)
+}
+
+func (h *testHelper) addBlockWithParent(head *types.Header, timestamp eth.Uint64Quantity, txs ...*types.Transaction) *eth.ExecutionPayload {
+	prevHead := h.backend.CurrentHeader()
+	id := h.startBlockBuilding(head, timestamp, txs...)
+
+	envelope := h.getPayload(id)
+	block := envelope.ExecutionPayload
+
+	h.assert.Equal(timestamp, block.Timestamp, "should create block with correct timestamp")
+	h.assert.Equal(head.Hash(), block.ParentHash, "should have correct parent")
+	h.assert.Len(block.Transactions, len(txs))
+
+	h.newPayload(envelope)
+
+	// Should not have changed the chain head yet
+	h.assert.Equal(prevHead, h.backend.CurrentHeader())
+
+	h.forkChoiceUpdated(block.BlockHash, head.Hash(), head.Hash())
+	h.assert.Equal(block.BlockHash, h.backend.CurrentHeader().Hash())
+	return block
+}
+
+func (h *testHelper) forkChoiceUpdated(head common.Hash, safe common.Hash, finalized common.Hash) {
+	h.Log("forkChoiceUpdated", "head", head, "safe", safe, "finalized", finalized)
+	result, err := h.engine.ForkchoiceUpdatedV2(h.ctx, &eth.ForkchoiceState{
+		HeadBlockHash:      head,
+		SafeBlockHash:      safe,
+		FinalizedBlockHash: finalized,
+	}, nil)
+	h.assert.NoError(err)
+	h.assert.Equal(eth.ExecutionValid, result.PayloadStatus.Status, "forkChoiceUpdated should return valid")
+	h.assert.Nil(result.PayloadStatus.ValidationError, "should not have validation error when valid")
+	h.assert.Nil(result.PayloadID, "should not provide payload ID when block building not requested")
+}
+
+func (h *testHelper) startBlockBuilding(head *types.Header, newBlockTimestamp eth.Uint64Quantity, txs ...*types.Transaction) *eth.PayloadID {
+	h.Log("Start block building", "head", head.Hash(), "timestamp", newBlockTimestamp)
+	var txData []eth.Data
+	for _, tx := range txs {
+		rlp, err := tx.MarshalBinary()
+		h.assert.NoError(err, "Failed to marshall tx %v", tx)
+		txData = append(txData, rlp)
+	}
+
+	attr := &eth.PayloadAttributes{
+		Timestamp:             newBlockTimestamp,
+		PrevRandao:            eth.Bytes32(head.MixDigest),
+		SuggestedFeeRecipient: feeRecipient,
+		Transactions:          txData,
+		NoTxPool:              true,
+		GasLimit:              &gasLimit,
+	}
+	n := new(big.Int).Add(head.Number, big.NewInt(1))
+	if h.backend.Config().IsShanghai(n, uint64(newBlockTimestamp)) {
+		attr.Withdrawals = &types.Withdrawals{}
+	}
+	if h.backend.Config().IsCancun(n, uint64(newBlockTimestamp)) {
+		attr.ParentBeaconBlockRoot = &common.Hash{}
+	}
+	fcState := &eth.ForkchoiceState{
+		HeadBlockHash:      head.Hash(),
+		SafeBlockHash:      head.Hash(),
+		FinalizedBlockHash: head.Hash(),
+	}
+	var result *eth.ForkchoiceUpdatedResult
+	var err error
+	if h.backend.Config().IsCancun(n, uint64(newBlockTimestamp)) {
+		result, err = h.engine.ForkchoiceUpdatedV3(h.ctx, fcState, attr)
+	} else if h.backend.Config().IsShanghai(n, uint64(newBlockTimestamp)) {
+		result, err = h.engine.ForkchoiceUpdatedV2(h.ctx, fcState, attr)
+	} else {
+		result, err = h.engine.ForkchoiceUpdatedV1(h.ctx, fcState, attr)
+	}
+	h.assert.NoError(err)
+	h.assert.Equal(eth.ExecutionValid, result.PayloadStatus.Status)
+	id := result.PayloadID
+	h.assert.NotNil(id)
+	return id
+}
+
+func (h *testHelper) getPayload(id *eth.PayloadID) *eth.ExecutionPayloadEnvelope {
+	h.Log("getPayload", "id", id)
+	envelope, err := h.engine.GetPayloadV2(h.ctx, *id) // calls the same underlying function as V1 and V3
+	h.assert.NoError(err)
+	h.assert.NotNil(envelope)
+	h.assert.NotNil(envelope.ExecutionPayload)
+	return envelope
+}
+
+func (h *testHelper) callNewPayload(envelope *eth.ExecutionPayloadEnvelope) (*eth.PayloadStatusV1, error) {
+	n := new(big.Int).SetUint64(uint64(envelope.ExecutionPayload.BlockNumber))
+	if h.backend.Config().IsIsthmus(uint64(envelope.ExecutionPayload.Timestamp)) {
+		return h.engine.NewPayloadV4(h.ctx, envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, []hexutil.Bytes{})
+	} else if h.backend.Config().IsCancun(n, uint64(envelope.ExecutionPayload.Timestamp)) {
+		return h.engine.NewPayloadV3(h.ctx, envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot)
+	} else {
+		return h.engine.NewPayloadV2(h.ctx, envelope.ExecutionPayload)
+	}
+}
+
+func (h *testHelper) newPayload(envelope *eth.ExecutionPayloadEnvelope) {
+	h.Log("newPayload", "hash", envelope.ExecutionPayload.BlockHash)
+	r, err := h.callNewPayload(envelope)
+	h.assert.NoError(err)
+	h.assert.Equal(eth.ExecutionValid, r.Status)
+	h.assert.Nil(r.ValidationError)
+}

--- a/op-e2e/actions/helpers/l1_miner.go
+++ b/op-e2e/actions/helpers/l1_miner.go
@@ -106,7 +106,7 @@ func (s *L1Miner) ActL1StartBlock(timeDelta uint64) Action {
 			root := crypto.Keccak256Hash([]byte("fake-beacon-block-root"), header.Number.Bytes())
 			header.ParentBeaconRoot = &root
 
-			// Copied from op-program/client/l2/engineapi/block_processor.go
+			// Copied from op-e2e/actions/helpers/engineapi/block_processor.go
 			// TODO(client-pod#826)
 			// Unfortunately this is not part of any Geth environment setup,
 			// we just have to apply it, like how the Geth block-builder worker does.

--- a/op-e2e/actions/helpers/l2_engine.go
+++ b/op-e2e/actions/helpers/l2_engine.go
@@ -3,8 +3,8 @@ package helpers
 import (
 	"errors"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers/engineapi"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
-	"github.com/ethereum-optimism/optimism/op-program/client/l2/engineapi"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/stretchr/testify/require"
 

--- a/op-e2e/actions/helpers/l2_engine_test.go
+++ b/op-e2e/actions/helpers/l2_engine_test.go
@@ -20,9 +20,9 @@ import (
 	"github.com/ethereum/go-ethereum/triedb"
 	"github.com/ethereum/go-ethereum/triedb/hashdb"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers/engineapi"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers/engineapi/test"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
-	"github.com/ethereum-optimism/optimism/op-program/client/l2/engineapi"
-	"github.com/ethereum-optimism/optimism/op-program/client/l2/engineapi/test"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
@@ -496,17 +495,6 @@ func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address,
 					},
 					{
 						ChainProofParams: state.ChainProofParams{
-							DisputeGameType:         0,
-							DisputeAbsolutePrestate: cannonPrestate(root, allocType),
-							DisputeMaxGameDepth:     50,
-							DisputeSplitDepth:       14,
-							DisputeClockExtension:   0,
-							DisputeMaxClockDuration: 1200,
-						},
-						VMType: cannonVMType(allocType),
-					},
-					{
-						ChainProofParams: state.ChainProofParams{
 							// CANNON_KONA game
 							DisputeGameType:         8,
 							DisputeAbsolutePrestate: konaPrestate(root),
@@ -549,60 +537,8 @@ type prestateFile struct {
 	Pre string `json:"pre"`
 }
 
-var cannonPrestateMT common.Hash
-var cannonPrestateMTNext common.Hash
-var cannonPrestateMTOnce sync.Once
-var cannonPrestateMTNextOnce sync.Once
-
 var konaPrestateHash common.Hash
 var konaPrestateOnce sync.Once
-
-func cannonPrestate(monorepoRoot string, allocType AllocType) common.Hash {
-	var filename string
-
-	var once *sync.Once
-	var cacheVar *common.Hash
-	cannonVmType := cannonVMType(allocType)
-	if cannonVmType == state.VMTypeCannon {
-		filename = "prestate-proof-mt64.json"
-		once = &cannonPrestateMTOnce
-		cacheVar = &cannonPrestateMT
-	} else if cannonVmType == state.VMTypeCannonNext {
-		if versions.GetCurrentVersion() != versions.GetExperimentalVersion() {
-			filename = "prestate-proof-mt64Next.json"
-		} else {
-			filename = "prestate-proof-mt64.json"
-		}
-		once = &cannonPrestateMTNextOnce
-		cacheVar = &cannonPrestateMTNext
-	} else {
-		panic("Unsupported cannon VM type: " + cannonVmType)
-	}
-
-	once.Do(func() {
-		f, err := os.Open(path.Join(monorepoRoot, "op-program", "bin", filename))
-		if err != nil {
-			log.Warn("error opening prestate file. If you're running a test that requires prestates, make sure you've run `make cannon-prestates`", "err", err)
-			return
-		}
-		defer f.Close()
-
-		var prestate prestateFile
-		dec := json.NewDecoder(f)
-		if err := dec.Decode(&prestate); err != nil {
-			log.Error("error decoding prestate file. If you're running a test that requires prestates, make sure you've run `make cannon-prestates`", "err", err)
-			return
-		}
-
-		*cacheVar = common.HexToHash(prestate.Pre)
-	})
-
-	// Provide a dummy value so that the DeployDisputeGame script succeeds. Many tests do not require a dispute game. So this allieviates the need to build prestates during local development.
-	if *cacheVar == (common.Hash{}) {
-		*cacheVar = common.HexToHash("0xc02b59f772cb23a75b6ffb9f7602ba25fdd5d8e75ad88efcc013fec2c63b0895") // keccak("dummy")
-	}
-	return *cacheVar
-}
 
 func konaPrestate(monorepoRoot string) common.Hash {
 	konaPrestateOnce.Do(func() {

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -152,7 +152,7 @@ func testOutputCannonStepWithLargePreimage(t *testing.T, allocType config.AllocT
 	t.Cleanup(sys.Close)
 
 	// Manually send a tx from the correct batcher key to the batcher input with very large (invalid) data
-	// This forces op-program to load a large preimage.
+	// This forces the fault-proof program to load a large preimage.
 	sys.BatcherHelper().SendLargeInvalidBatch(ctx)
 
 	require.NoError(t, sys.BatchSubmitter.Start(ctx))

--- a/op-e2e/faultproofs/preimages_test.go
+++ b/op-e2e/faultproofs/preimages_test.go
@@ -24,7 +24,7 @@ func TestLocalPreimages(t *testing.T) {
 		{key: preimage.L2ClaimLocalIndex},
 		{key: preimage.L2ClaimBlockNumberLocalIndex},
 		// We don't check client.L2ChainIDLocalIndex because e2e tests use a custom chain configuration
-		// which requires using a custom chain ID indicator so op-program will load the full rollup config and
+		// which requires using a custom chain ID indicator so the fault-proof program will load the full rollup config and
 		// genesis from the preimage oracle
 	}
 	for _, test := range tests {

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -194,7 +194,7 @@ func TestSuperCannonStepWithLargePreimage(t *testing.T) {
 			require.NoError(t, sys.Batcher(id).Stop(ctx))
 		}
 		// Manually send a tx from the correct batcher key to the batcher input with very large (invalid) data
-		// This forces op-program to load a large preimage.
+		// This forces the fault-proof program to load a large preimage.
 		for _, id := range sys.L2IDs() {
 			batcherKey := sys.L2OperatorKey(id, devkeys.BatcherRole)
 			batcherHelper := batcher.NewHelper(t, &batcherKey, sys.RollupConfig(id), sys.L1GethClient())


### PR DESCRIPTION
Decouples op-e2e from op-program so it can be deleted from the monorepo, part of ethereum-optimism/optimism#20276. After this PR, neither op-e2e nor op-devstack reference op-program.

- Moves the `engineapi` package (the in-process L2 engine used by action tests) from `op-program/client/l2/engineapi` into `op-e2e/actions/helpers/engineapi`.
- Stops deploying the legacy type-0 Cannon dispute game in the op-e2e deploy intent. It is no longer served by op-challenger, and it was the only reason op-e2e read `op-program/bin/prestate-proof-mt64.json`. The generic CannonKona (type 8) game still exercises the proof system.

Stacked on ethereum-optimism/optimism#21254 (Cannon game-type removal), which already cleared op-program out of op-devstack.

Test plan: `go test ./op-e2e/actions/helpers/engineapi/...` and `TestL2EngineAPI` pass; `just lint-go` clean.