### PR TITLE
rust: add maxperf-dbg profile

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -233,6 +233,11 @@ inherits = "release"
 lto = "fat"
 codegen-units = 1
 
+[profile.maxperf-dbg]
+inherits = "maxperf"
+debug = "full"
+strip = "none"
+
 [profile.reproducible]
 inherits = "release"
 panic = "abort"


### PR DESCRIPTION
Useful for debugging core dumps of our prod releases.