### PR TITLE
feat(op-chain-ops): add check-interop smoke-test CLI

### DIFF
--- a/op-chain-ops/cmd/check-interop/checks/checks.go
+++ b/op-chain-ops/cmd/check-interop/checks/checks.go
@@ -105,16 +105,23 @@ func (t *sendETHTrigger) AccessList() (types.AccessList, error) {
 }
 
 // CheckRoundTrip bridges ETH A -> B and then B -> A through the
-// SuperchainETHBridge predeploy, relaying each message itself.
-func CheckRoundTrip(ctx context.Context, cfg *CheckInteropConfig) error {
+// SuperchainETHBridge predeploy, relaying each message itself, repeated for the
+// given number of iterations.
+func CheckRoundTrip(ctx context.Context, cfg *CheckInteropConfig, iterations int) error {
+	if iterations < 1 {
+		return fmt.Errorf("iterations must be >= 1, got %d", iterations)
+	}
 	recipient := randomRecipient()
-	if err := cfg.bridgeETH(ctx, "A", "B", recipient); err != nil {
-		return err
+	for i := 1; i <= iterations; i++ {
+		cfg.Log.Info("round-trip iteration", "iteration", i, "of", iterations)
+		if err := cfg.bridgeETH(ctx, "A", "B", recipient); err != nil {
+			return fmt.Errorf("iteration %d/%d: %w", i, iterations, err)
+		}
+		if err := cfg.bridgeETH(ctx, "B", "A", recipient); err != nil {
+			return fmt.Errorf("iteration %d/%d: %w", i, iterations, err)
+		}
 	}
-	if err := cfg.bridgeETH(ctx, "B", "A", recipient); err != nil {
-		return err
-	}
-	cfg.Log.Info("interop ETH round-trip check passed")
+	cfg.Log.Info("interop ETH round-trip check passed", "iterations", iterations)
 	return nil
 }
 

--- a/op-chain-ops/cmd/check-interop/checks/checks.go
+++ b/op-chain-ops/cmd/check-interop/checks/checks.go
@@ -294,7 +294,9 @@ func singleSubmitPlan(cl *sources.EthClient, key *ecdsa.PrivateKey) txplan.Optio
 // destination-chain balance delta over a bridge leg is exactly the bridged amount.
 func randomRecipient() common.Address {
 	var b [20]byte
-	_, _ = rand.Read(b[:])
+	if _, err := rand.Read(b[:]); err != nil {
+		panic(fmt.Errorf("failed to read random recipient address: %w", err))
+	}
 	return common.Address(b)
 }
 

--- a/op-chain-ops/cmd/check-interop/checks/checks.go
+++ b/op-chain-ops/cmd/check-interop/checks/checks.go
@@ -1,0 +1,314 @@
+package checks
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/lmittmann/w3"
+
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+)
+
+const (
+	// maxRelayRetries caps submission/inclusion retry attempts. The effective
+	// bound is the per-leg context deadline (RelayTimeout); this is just large
+	// enough not to give up before that deadline ends the retries.
+	maxRelayRetries = 1024
+	// execGasLimit is a fixed gas limit for the failsafe-blocked relay, so we
+	// skip eth_estimateGas and let the txpool rejection surface on submission.
+	execGasLimit = 300_000
+)
+
+// bridgeAmount is the ETH moved across chains on each leg.
+var bridgeAmount = eth.OneHundredthEther
+
+// sendETHFn is the SuperchainETHBridge.sendETH(to, chainId) entrypoint.
+var sendETHFn = w3.MustNewFunc("sendETH(address,uint256)", "bytes32")
+
+// CheckInteropConfig holds the dependencies shared by the interop checks.
+type CheckInteropConfig struct {
+	Log log.Logger
+	L2A *sources.EthClient
+	L2B *sources.EthClient
+	Key *ecdsa.PrivateKey
+
+	// L2AChainID and L2BChainID are the chain IDs of L2A and L2B, used as the
+	// SuperchainETHBridge destination chain when bridging in each direction.
+	L2AChainID eth.ChainID
+	L2BChainID eth.ChainID
+
+	// RelayTimeout bounds each bridge leg (the send and its self-relay).
+	RelayTimeout time.Duration
+
+	// FilterAdmin is the JWT-authenticated admin RPC of the op-interop-filter,
+	// required only by CheckFailsafe.
+	FilterAdmin client.RPC
+	// PropagationWait is how long to wait after the initiating send before the
+	// expected-to-be-blocked relay, so that absent failsafe it would be admittable.
+	PropagationWait time.Duration
+}
+
+// Close releases the underlying RPC clients.
+func (cfg *CheckInteropConfig) Close() {
+	if cfg.L2A != nil {
+		cfg.L2A.Close()
+	}
+	if cfg.L2B != nil {
+		cfg.L2B.Close()
+	}
+	if cfg.FilterAdmin != nil {
+		cfg.FilterAdmin.Close()
+	}
+}
+
+// chain returns the client and chain ID for "A" or "B".
+func (cfg *CheckInteropConfig) chain(name string) (*sources.EthClient, eth.ChainID) {
+	if name == "A" {
+		return cfg.L2A, cfg.L2AChainID
+	}
+	return cfg.L2B, cfg.L2BChainID
+}
+
+// sendETHTrigger initiates a cross-chain ETH transfer through the
+// SuperchainETHBridge predeploy. The bridged amount is the tx value.
+type sendETHTrigger struct {
+	Recipient   common.Address
+	Destination eth.ChainID
+}
+
+func (t *sendETHTrigger) To() (*common.Address, error) {
+	addr := predeploys.SuperchainETHBridgeAddr
+	return &addr, nil
+}
+
+func (t *sendETHTrigger) EncodeInput() ([]byte, error) {
+	return sendETHFn.EncodeArgs(t.Recipient, t.Destination.ToBig())
+}
+
+func (t *sendETHTrigger) AccessList() (types.AccessList, error) {
+	return nil, nil
+}
+
+// CheckRoundTrip bridges ETH A -> B and then B -> A through the
+// SuperchainETHBridge predeploy, relaying each message itself.
+func CheckRoundTrip(ctx context.Context, cfg *CheckInteropConfig) error {
+	recipient := randomRecipient()
+	if err := cfg.bridgeETH(ctx, "A", "B", recipient); err != nil {
+		return err
+	}
+	if err := cfg.bridgeETH(ctx, "B", "A", recipient); err != nil {
+		return err
+	}
+	cfg.Log.Info("interop ETH round-trip check passed")
+	return nil
+}
+
+// CheckFailsafe verifies the interop filter failsafe lifecycle: an interop ETH
+// bridge succeeds, its relay is rejected while failsafe is enabled, and bridging
+// succeeds again once failsafe is disabled.
+func CheckFailsafe(ctx context.Context, cfg *CheckInteropConfig) error {
+	if cfg.FilterAdmin == nil {
+		return errors.New("failsafe check requires --filter.admin-rpc and --filter.jwt-secret")
+	}
+	recipient := randomRecipient()
+
+	// Start from a known-disabled state in case a previous run left it enabled.
+	if err := cfg.setFailsafe(ctx, false); err != nil {
+		return err
+	}
+
+	cfg.Log.Info("step 1: bridge before failsafe (expect success)")
+	if err := cfg.bridgeETH(ctx, "A", "B", recipient); err != nil {
+		return err
+	}
+
+	cfg.Log.Info("step 2: enabling failsafe")
+	if err := cfg.setFailsafe(ctx, true); err != nil {
+		return err
+	}
+
+	cfg.Log.Info("step 3: relay with failsafe enabled (expect rejection)")
+	if err := cfg.expectBlocked(ctx, "A", "B", recipient); err != nil {
+		_ = cfg.setFailsafe(ctx, false) // best-effort: leave the filter disabled
+		return err
+	}
+
+	cfg.Log.Info("step 4: disabling failsafe")
+	if err := cfg.setFailsafe(ctx, false); err != nil {
+		return err
+	}
+
+	// The retrying plan tolerates the brief window during which the execution
+	// client's cached failsafe flag is still refreshing.
+	cfg.Log.Info("step 5: bridge after failsafe disabled (expect success)")
+	if err := cfg.bridgeETH(ctx, "A", "B", recipient); err != nil {
+		return err
+	}
+
+	cfg.Log.Info("interop failsafe lifecycle check passed")
+	return nil
+}
+
+// bridgeETH sends bridgeAmount of ETH from the test account on src to recipient
+// on dst via the SuperchainETHBridge predeploy, relays the message itself, and
+// asserts recipient's dst-chain balance grew by exactly bridgeAmount.
+func (cfg *CheckInteropConfig) bridgeETH(ctx context.Context, src, dst string, recipient common.Address) error {
+	ctx, cancel := context.WithTimeout(ctx, cfg.RelayTimeout)
+	defer cancel()
+
+	srcCl, _ := cfg.chain(src)
+	dstCl, dstChainID := cfg.chain(dst)
+
+	before, err := dstCl.BalanceAt(ctx, recipient, nil)
+	if err != nil {
+		return fmt.Errorf("read recipient balance on %s: %w", dst, err)
+	}
+
+	send := txintent.NewIntent[*sendETHTrigger, *txintent.InteropOutput](retryPlan(srcCl, cfg.Key), txplan.WithValue(bridgeAmount))
+	send.Content.Set(&sendETHTrigger{Recipient: recipient, Destination: dstChainID})
+	if _, err := send.PlannedTx.Success.Eval(ctx); err != nil {
+		return fmt.Errorf("send ETH %s -> %s: %w", src, dst, err)
+	}
+	cfg.Log.Info("sent ETH", "from", src, "to", dst, "tx", send.PlannedTx.Included.Value().TxHash)
+
+	relay := txintent.NewIntent[*txintent.RelayTrigger, *txintent.InteropOutput](retryPlan(dstCl, cfg.Key))
+	relay.Content.DependOn(&send.Result)
+	relay.Content.Fn(txintent.RelayIndexed(predeploys.L2toL2CrossDomainMessengerAddr, &send.Result, &send.PlannedTx.Included, 1))
+	if _, err := relay.PlannedTx.Success.Eval(ctx); err != nil {
+		return fmt.Errorf("relay ETH on %s: %w", dst, err)
+	}
+	cfg.Log.Info("relayed ETH", "chain", dst, "tx", relay.PlannedTx.Included.Value().TxHash)
+
+	after, err := dstCl.BalanceAt(ctx, recipient, nil)
+	if err != nil {
+		return fmt.Errorf("read recipient balance on %s: %w", dst, err)
+	}
+	if credited := new(big.Int).Sub(after, before); credited.Cmp(bridgeAmount.ToBig()) != 0 {
+		return fmt.Errorf("recipient on %s credited %s wei, want %s wei", dst, credited, bridgeAmount.ToBig())
+	}
+	cfg.Log.Info("bridged ETH", "from", src, "to", dst, "amount", bridgeAmount, "recipient", recipient)
+	return nil
+}
+
+// expectBlocked sends ETH on src, then submits the relay on dst once, asserting
+// it is rejected by the interop filter (failsafe).
+func (cfg *CheckInteropConfig) expectBlocked(ctx context.Context, src, dst string, recipient common.Address) error {
+	srcCl, _ := cfg.chain(src)
+	dstCl, dstChainID := cfg.chain(dst)
+
+	send := txintent.NewIntent[*sendETHTrigger, *txintent.InteropOutput](retryPlan(srcCl, cfg.Key), txplan.WithValue(bridgeAmount))
+	send.Content.Set(&sendETHTrigger{Recipient: recipient, Destination: dstChainID})
+	sendCtx, cancel := context.WithTimeout(ctx, cfg.RelayTimeout)
+	_, err := send.PlannedTx.Success.Eval(sendCtx)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("send ETH %s -> %s: %w", src, dst, err)
+	}
+
+	// Let the destination ingest the message so that, absent failsafe, the relay
+	// would have been admittable — making the rejection attributable to failsafe.
+	select {
+	case <-time.After(cfg.PropagationWait):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	relay := txintent.NewIntent[*txintent.RelayTrigger, *txintent.InteropOutput](singleSubmitPlan(dstCl, cfg.Key))
+	relay.Content.DependOn(&send.Result)
+	relay.Content.Fn(txintent.RelayIndexed(predeploys.L2toL2CrossDomainMessengerAddr, &send.Result, &send.PlannedTx.Included, 1))
+	if _, err := relay.PlannedTx.Submitted.Eval(ctx); err == nil {
+		return fmt.Errorf("relay on %s was accepted while failsafe enabled, expected rejection", dst)
+	} else if !interopTxRejected(err) {
+		return fmt.Errorf("relay on %s failed but not with a recognized interop filter rejection: %w", dst, err)
+	}
+	cfg.Log.Info("relay correctly rejected while failsafe enabled", "chain", dst)
+	return nil
+}
+
+// setFailsafe toggles failsafe mode on the interop filter and confirms it took effect.
+func (cfg *CheckInteropConfig) setFailsafe(ctx context.Context, enabled bool) error {
+	if err := cfg.FilterAdmin.CallContext(ctx, nil, "admin_setFailsafeEnabled", enabled); err != nil {
+		return fmt.Errorf("admin_setFailsafeEnabled(%v): %w", enabled, err)
+	}
+	var got bool
+	if err := cfg.FilterAdmin.CallContext(ctx, &got, "admin_getFailsafeEnabled"); err != nil {
+		return fmt.Errorf("admin_getFailsafeEnabled: %w", err)
+	}
+	if got != enabled {
+		return fmt.Errorf("failsafe state did not update: wanted %v, got %v", enabled, got)
+	}
+	return nil
+}
+
+// retryPlan estimates gas and retries submission and inclusion to ride out
+// cross-chain propagation; the overall wait is capped by the caller's context.
+func retryPlan(cl *sources.EthClient, key *ecdsa.PrivateKey) txplan.Option {
+	return txplan.Combine(
+		txplan.WithChainID(cl),
+		txplan.WithPrivateKey(key),
+		txplan.WithPendingNonce(cl),
+		txplan.WithAgainstLatestBlock(cl),
+		txplan.WithEstimator(cl, true),
+		txplan.WithRetrySubmission(cl, maxRelayRetries, retry.Exponential()),
+		txplan.WithRetryInclusion(cl, maxRelayRetries, retry.Exponential()),
+		txplan.WithBlockInclusionInfo(cl),
+	)
+}
+
+// singleSubmitPlan submits once with a fixed gas limit (skipping eth_estimateGas)
+// so a txpool rejection surfaces immediately instead of being retried.
+func singleSubmitPlan(cl *sources.EthClient, key *ecdsa.PrivateKey) txplan.Option {
+	return txplan.Combine(
+		txplan.WithChainID(cl),
+		txplan.WithPrivateKey(key),
+		txplan.WithPendingNonce(cl),
+		txplan.WithAgainstLatestBlock(cl),
+		txplan.WithGasLimit(execGasLimit),
+		txplan.WithTransactionSubmitter(cl),
+	)
+}
+
+// randomRecipient returns a fresh address that only ever receives ETH, so its
+// destination-chain balance delta over a bridge leg is exactly the bridged amount.
+func randomRecipient() common.Address {
+	var b [20]byte
+	_, _ = rand.Read(b[:])
+	return common.Address(b)
+}
+
+// interopTxRejected reports whether err is a known interop-transaction rejection
+// from op-geth, op-reth, or the interop filter.
+func interopTxRejected(err error) bool {
+	msg := err.Error()
+	switch {
+	// op-geth: generic filter rejection wrapping all causes
+	case strings.Contains(msg, "transaction filtered out"):
+		return true
+	// op-interop-filter: malformed or unrecognized access list entry
+	case strings.Contains(msg, "failed to parse access entry"):
+		return true
+	// op-reth fast-path: cached failsafe state rejects before calling the filter
+	case strings.Contains(msg, "interop failsafe is active"):
+		return true
+	// op-interop-filter: failsafe enabled at the filter level
+	case strings.Contains(msg, "failsafe is enabled"):
+		return true
+	default:
+		return false
+	}
+}

--- a/op-chain-ops/cmd/check-interop/checks/checks_test.go
+++ b/op-chain-ops/cmd/check-interop/checks/checks_test.go
@@ -1,0 +1,58 @@
+package checks
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestInteropTxRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "op-geth filter rejection",
+			err:  errors.New("transaction filtered out"),
+			want: true,
+		},
+		{
+			name: "op-interop-filter access entry parse failure",
+			err:  errors.New("failed to parse access entry: bad data"),
+			want: true,
+		},
+		{
+			name: "op-reth fast-path failsafe",
+			err:  errors.New("interop failsafe is active"),
+			want: true,
+		},
+		{
+			name: "op-interop-filter failsafe enabled",
+			err:  errors.New("failsafe is enabled"),
+			want: true,
+		},
+		{
+			name: "rejection wrapped in another error",
+			err:  fmt.Errorf("submit failed: %w", errors.New("transaction filtered out")),
+			want: true,
+		},
+		{
+			name: "unrelated rpc error",
+			err:  errors.New("nonce too low"),
+			want: false,
+		},
+		{
+			name: "context deadline exceeded is not a rejection",
+			err:  errors.New("context deadline exceeded"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := interopTxRejected(tt.err); got != tt.want {
+				t.Errorf("interopTxRejected(%q) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/op-chain-ops/cmd/check-interop/config.example.toml
+++ b/op-chain-ops/cmd/check-interop/config.example.toml
@@ -1,0 +1,17 @@
+# Example config for check-interop. Pass with --config <path>.
+# Keys are the flag names. CLI flags and CHECK_INTEROP_* env vars override anything set here.
+
+l2-a = "http://localhost:9545"
+l2-b = "http://localhost:9546"
+account = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+# Durations are strings parsed by time.ParseDuration.
+relay-timeout = "2m"
+
+# The following only apply to the `failsafe` subcommand.
+propagation-wait = "6s"
+
+# Dotted flag names (--filter.admin-rpc, --filter.jwt-secret) map to a [filter] table.
+[filter]
+admin-rpc = "http://localhost:8420"
+jwt-secret = "/path/to/jwt.txt"

--- a/op-chain-ops/cmd/check-interop/config.example.toml
+++ b/op-chain-ops/cmd/check-interop/config.example.toml
@@ -8,6 +8,9 @@ account = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 # Durations are strings parsed by time.ParseDuration.
 relay-timeout = "2m"
 
+# Number of A->B->A round-trips the `roundtrip` command performs.
+iterations = 3
+
 # The following only apply to the `failsafe` subcommand.
 propagation-wait = "6s"
 

--- a/op-chain-ops/cmd/check-interop/config.example.toml
+++ b/op-chain-ops/cmd/check-interop/config.example.toml
@@ -1,19 +1,21 @@
 # Example config for check-interop. Pass with --config <path>.
 # Keys are the flag names. CLI flags and CHECK_INTEROP_* env vars override anything set here.
+# Each command ignores keys it doesn't register, so a single file can serve both.
 
+# --- Used by both `roundtrip` and `failsafe` ---
 l2-a = "http://localhost:9545"
 l2-b = "http://localhost:9546"
 account = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-
 # Durations are strings parsed by time.ParseDuration.
 relay-timeout = "2m"
 
-# Number of A->B->A round-trips the `roundtrip` command performs.
+# --- Used only by `roundtrip` ---
+# Number of A->B->A round-trips to perform.
 iterations = 3
 
-# The following only apply to the `failsafe` subcommand.
+# --- Used only by `failsafe` ---
+# How long to wait for the initiating message to propagate before the blocked relay.
 propagation-wait = "6s"
-
 # Dotted flag names (--filter.admin-rpc, --filter.jwt-secret) map to a [filter] table.
 [filter]
 admin-rpc = "http://localhost:8420"

--- a/op-chain-ops/cmd/check-interop/main.go
+++ b/op-chain-ops/cmd/check-interop/main.go
@@ -72,6 +72,12 @@ var (
 		EnvVars: op_service.PrefixEnvVar(prefix, "PROPAGATION_WAIT"),
 		Value:   6 * time.Second,
 	}
+	Iterations = &cli.IntFlag{
+		Name:    "iterations",
+		Usage:   "Number of A->B->A round-trips to perform",
+		EnvVars: op_service.PrefixEnvVar(prefix, "ITERATIONS"),
+		Value:   3,
+	}
 )
 
 func baseFlags() []cli.Flag {
@@ -82,6 +88,10 @@ func baseFlags() []cli.Flag {
 		altsrc.NewStringFlag(AccountKey),
 		altsrc.NewDurationFlag(RelayTimeout),
 	}, oplog.CLIFlags(prefix)...)
+}
+
+func roundtripFlags() []cli.Flag {
+	return append(baseFlags(), altsrc.NewIntFlag(Iterations))
 }
 
 func failsafeFlags() []cli.Flag {
@@ -184,7 +194,7 @@ func roundTripAction(c *cli.Context) error {
 		return err
 	}
 	defer cfg.Close()
-	return checks.CheckRoundTrip(ctx, cfg)
+	return checks.CheckRoundTrip(ctx, cfg, c.Int(Iterations.Name))
 }
 
 func failsafeAction(c *cli.Context) error {
@@ -213,15 +223,15 @@ func main() {
 	}
 	app.Writer = os.Stdout
 	app.ErrWriter = os.Stderr
-	roundtripFlags := cliapp.ProtectFlags(baseFlags())
+	roundtripCmdFlags := cliapp.ProtectFlags(roundtripFlags())
 	failsafeCmdFlags := cliapp.ProtectFlags(failsafeFlags())
 	tomlSource := altsrc.NewTomlSourceFromFlagFunc(ConfigFile.Name)
 	app.Commands = []*cli.Command{
 		{
 			Name:   "roundtrip",
 			Usage:  "Send an interop message A -> B and B -> A, relaying each.",
-			Flags:  roundtripFlags,
-			Before: altsrc.InitInputSourceWithContext(roundtripFlags, tomlSource),
+			Flags:  roundtripCmdFlags,
+			Before: altsrc.InitInputSourceWithContext(roundtripCmdFlags, tomlSource),
 			Action: roundTripAction,
 		},
 		{

--- a/op-chain-ops/cmd/check-interop/main.go
+++ b/op-chain-ops/cmd/check-interop/main.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	gn "github.com/ethereum/go-ethereum/node"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2/altsrc"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-interop/checks"
+	op_service "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+)
+
+const prefix = "CHECK_INTEROP"
+
+var (
+	ConfigFile = &cli.StringFlag{
+		Name:    "config",
+		Usage:   "Path to a TOML config file supplying flag values. CLI flags and env vars override it.",
+		EnvVars: op_service.PrefixEnvVar(prefix, "CONFIG"),
+	}
+	EndpointL2A = &cli.StringFlag{
+		Name:    "l2-a",
+		Usage:   "L2 chain A execution RPC endpoint",
+		EnvVars: op_service.PrefixEnvVar(prefix, "L2_A"),
+		Value:   "http://localhost:9545",
+	}
+	EndpointL2B = &cli.StringFlag{
+		Name:    "l2-b",
+		Usage:   "L2 chain B execution RPC endpoint",
+		EnvVars: op_service.PrefixEnvVar(prefix, "L2_B"),
+		Value:   "http://localhost:9546",
+	}
+	AccountKey = &cli.StringFlag{
+		Name:    "account",
+		Usage:   "Private key (hex-formatted string) of a funded test account on both chains",
+		EnvVars: op_service.PrefixEnvVar(prefix, "ACCOUNT"),
+	}
+	FilterAdminRPC = &cli.StringFlag{
+		Name:    "filter.admin-rpc",
+		Usage:   "op-interop-filter admin RPC endpoint (used to toggle failsafe)",
+		EnvVars: op_service.PrefixEnvVar(prefix, "FILTER_ADMIN_RPC"),
+	}
+	FilterJWTSecret = &cli.StringFlag{
+		Name:    "filter.jwt-secret",
+		Usage:   "Path to the JWT secret authenticating the op-interop-filter admin RPC",
+		EnvVars: op_service.PrefixEnvVar(prefix, "FILTER_JWT_SECRET"),
+	}
+	RelayTimeout = &cli.DurationFlag{
+		Name:    "relay-timeout",
+		Usage:   "Maximum time to wait for a relayed cross-chain message (and other txs) to be included",
+		EnvVars: op_service.PrefixEnvVar(prefix, "RELAY_TIMEOUT"),
+		Value:   2 * time.Minute,
+	}
+	PropagationWait = &cli.DurationFlag{
+		Name:    "propagation-wait",
+		Usage:   "How long to wait for an initiating message to propagate before the failsafe-blocked attempt",
+		EnvVars: op_service.PrefixEnvVar(prefix, "PROPAGATION_WAIT"),
+		Value:   6 * time.Second,
+	}
+)
+
+func baseFlags() []cli.Flag {
+	return append([]cli.Flag{
+		ConfigFile,
+		altsrc.NewStringFlag(EndpointL2A),
+		altsrc.NewStringFlag(EndpointL2B),
+		altsrc.NewStringFlag(AccountKey),
+		altsrc.NewDurationFlag(RelayTimeout),
+	}, oplog.CLIFlags(prefix)...)
+}
+
+func failsafeFlags() []cli.Flag {
+	return append(baseFlags(),
+		altsrc.NewStringFlag(FilterAdminRPC),
+		altsrc.NewStringFlag(FilterJWTSecret),
+		altsrc.NewDurationFlag(PropagationWait),
+	)
+}
+
+// setup reads the logging config and wires interrupt cancellation onto the context.
+func setup(c *cli.Context) (log.Logger, context.Context) {
+	logCfg := oplog.ReadCLIConfig(c)
+	logger := oplog.NewLogger(c.App.Writer, logCfg)
+	c.Context = ctxinterrupt.WithCancelOnInterrupt(c.Context)
+	return logger, c.Context
+}
+
+// baseConfig dials both L2 clients, parses the test account, and verifies the
+// two endpoints are distinct chains.
+func baseConfig(ctx context.Context, logger log.Logger, c *cli.Context) (cfg *checks.CheckInteropConfig, err error) {
+	var l2A, l2B *sources.EthClient
+	defer func() {
+		if err != nil {
+			if l2A != nil {
+				l2A.Close()
+			}
+			if l2B != nil {
+				l2B.Close()
+			}
+		}
+	}()
+
+	l2A, err = dialEthClient(ctx, logger, c.String(EndpointL2A.Name))
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial L2 chain A: %w", err)
+	}
+	l2B, err = dialEthClient(ctx, logger, c.String(EndpointL2B.Name))
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial L2 chain B: %w", err)
+	}
+	keyHex := c.String(AccountKey.Name)
+	if keyHex == "" {
+		return nil, errors.New("test account private key is required: set --account, the env var, or 'account' in --config")
+	}
+	key, err := crypto.HexToECDSA(keyHex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse test private key: %w", err)
+	}
+
+	chainA, err := l2A.ChainID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch L2 chain A id: %w", err)
+	}
+	chainB, err := l2B.ChainID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch L2 chain B id: %w", err)
+	}
+	if chainA.Cmp(chainB) == 0 {
+		return nil, fmt.Errorf("--l2-a and --l2-b must be different chains, both report chain id %s", chainA)
+	}
+
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	logger.Info("running interop check", "chainA", chainA, "chainB", chainB, "account", addr)
+	return &checks.CheckInteropConfig{
+		Log:          logger,
+		L2A:          l2A,
+		L2B:          l2B,
+		Key:          key,
+		L2AChainID:   eth.ChainIDFromBig(chainA),
+		L2BChainID:   eth.ChainIDFromBig(chainB),
+		RelayTimeout: c.Duration(RelayTimeout.Name),
+	}, nil
+}
+
+func dialEthClient(ctx context.Context, logger log.Logger, url string) (*sources.EthClient, error) {
+	rpcCl, err := client.NewRPC(ctx, logger, url)
+	if err != nil {
+		return nil, err
+	}
+	return sources.NewEthClient(rpcCl, logger, nil, sources.DefaultEthClientConfig(10))
+}
+
+func dialFilterAdmin(ctx context.Context, logger log.Logger, url, jwtPath string) (client.RPC, error) {
+	if url == "" || jwtPath == "" {
+		return nil, errors.New("both --filter.admin-rpc and --filter.jwt-secret are required for the failsafe check")
+	}
+	secret, err := oprpc.ObtainJWTSecret(logger, jwtPath, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load filter admin JWT secret: %w", err)
+	}
+	return client.NewRPC(ctx, logger, url,
+		client.WithGethRPCOptions(gethrpc.WithHTTPAuth(gn.NewJWTAuth([32]byte(secret)))))
+}
+
+func roundTripAction(c *cli.Context) error {
+	logger, ctx := setup(c)
+	cfg, err := baseConfig(ctx, logger, c)
+	if err != nil {
+		return err
+	}
+	defer cfg.Close()
+	return checks.CheckRoundTrip(ctx, cfg)
+}
+
+func failsafeAction(c *cli.Context) error {
+	logger, ctx := setup(c)
+	cfg, err := baseConfig(ctx, logger, c)
+	if err != nil {
+		return err
+	}
+	defer cfg.Close()
+	admin, err := dialFilterAdmin(ctx, logger, c.String(FilterAdminRPC.Name), c.String(FilterJWTSecret.Name))
+	if err != nil {
+		return err
+	}
+	cfg.FilterAdmin = admin
+	cfg.PropagationWait = c.Duration(PropagationWait.Name)
+	return checks.CheckFailsafe(ctx, cfg)
+}
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "check-interop"
+	app.Usage = "Smoke-test interop cross-chain messaging and the interop filter failsafe."
+	app.Description = "Smoke-test interop cross-chain messaging and the interop filter failsafe."
+	app.Action = func(c *cli.Context) error {
+		return errors.New("see sub-commands")
+	}
+	app.Writer = os.Stdout
+	app.ErrWriter = os.Stderr
+	roundtripFlags := cliapp.ProtectFlags(baseFlags())
+	failsafeCmdFlags := cliapp.ProtectFlags(failsafeFlags())
+	tomlSource := altsrc.NewTomlSourceFromFlagFunc(ConfigFile.Name)
+	app.Commands = []*cli.Command{
+		{
+			Name:   "roundtrip",
+			Usage:  "Send an interop message A -> B and B -> A, relaying each.",
+			Flags:  roundtripFlags,
+			Before: altsrc.InitInputSourceWithContext(roundtripFlags, tomlSource),
+			Action: roundTripAction,
+		},
+		{
+			Name:   "failsafe",
+			Usage:  "Verify interop messages succeed, are blocked while failsafe is enabled, then succeed again.",
+			Flags:  failsafeCmdFlags,
+			Before: altsrc.InitInputSourceWithContext(failsafeCmdFlags, tomlSource),
+			Action: failsafeAction,
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Application failed: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Overview

Adds a small CLI under `op-chain-ops/cmd/check-interop` for smoke-testing interop cross-chain messaging against a running pair of L2 chains.

## Subcommands

- **`roundtrip`** — bridges ETH `A -> B` and `B -> A` via the `SuperchainETHBridge` predeploy, relaying each message itself through `L2ToL2CrossDomainMessenger.relayMessage` (no autorelayer), and asserts a fresh recipient is credited the exact bridged amount on each destination chain. No contract deploys — it uses the predeploys that already exist on every OP chain.
- **`failsafe`** — verifies the op-interop-filter failsafe lifecycle via the filter admin RPC: a bridge succeeds, its relay is rejected while failsafe is enabled (`admin_setFailsafeEnabled`), and succeeds again once disabled.

## Usage

Flags can be supplied via CLI, `CHECK_INTEROP_*` env vars, or a TOML config file (`--config`, see `config.example.toml`); CLI and env values override the file. Endpoints can be any reachable RPC URL (e.g. a devnet's direct ingress), so no `kubectl port-forward` is required.

```
go run ./op-chain-ops/cmd/check-interop roundtrip \
  --l2-a <chain-A EL RPC> --l2-b <chain-B EL RPC> \
  --account <funded test key, no 0x> --relay-timeout 5m
```

## Testing

- `roundtrip` verified live against the `interop-reorg-0` dev devnet (direct ingress URLs, no port-forward): full `A<->B` round-trip lands in ~20s when the network is healthy, with both legs asserting the recipient gained exactly 0.01 ETH on the destination chain.
- `failsafe` is **not** exercised live in this PR — it requires the op-interop-filter admin RPC + JWT. It compiles and shares the verified `bridgeETH` / `Success.Eval` plumbing, but the enable→block→disable lifecycle has not been run against a live filter.
- `go build`, `go vet`, `gofmt`, and the repo's custom `op-golangci-lint` all pass (0 issues).
