### PR TITLE
test: cover near-max cross-domain relay payloads

### DIFF
--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -601,12 +601,8 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         // Skip if this is a fork test, won't work.
         skipIfForkTest("L2CrossDomainMessenger doesn't exist on L1 in forked test");
 
-        // Using smaller uint so the fuzzer doesn't give as many massive values that get bounded.
-        // TODO: Known issue, messages above 34k can actually OOG on the receiving side if the
-        // target uses all available gas. Can be resolved by capping data sizes on the XDM or by
-        // increasing the amount of available relay gas to ~100k. If increasing relay gas, should
-        // have the relay gas only increase when the calldata size is large to avoid disrupting
-        // in-flight L2 -> L1 messages.
+        // Keep the fuzz input bounded so the test remains fast. Near-max payloads are covered by a
+        // deterministic regression test below.
         _messageLength = uint24(bound(_messageLength, 0, 34_000));
 
         // Need more than 500 since GasBurner requires it.
@@ -666,6 +662,68 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         assertTrue(success, "L2CrossDomainMessenger call should not fail");
 
         // Message should either be in the failed or successful messages mapping.
+        bool inFailedMessages = l2CrossDomainMessenger.failedMessages(keccak256(encoded));
+        bool inSuccessfulMessages = l2CrossDomainMessenger.successfulMessages(keccak256(encoded));
+        assertTrue(
+            inFailedMessages || inSuccessfulMessages, "message should be in either failed or successful messages"
+        );
+    }
+
+    /// @notice Tests that `relayMessage` has enough base gas to finish when relaying a near-max
+    ///         L1 => L2 payload to a target that consumes all forwarded gas.
+    function test_relayMessage_nearMaxPayloadAllGasTarget_succeeds() external {
+        skipIfForkTest("L2CrossDomainMessenger doesn't exist on L1 in forked test");
+
+        // Use the PoC's _minGasLimit value referenced from client-pod#609:
+        // https://github.com/ethereum-optimism/client-pod/issues/609
+        uint32 minGasLimit = 50_000;
+
+        // Largest 32-byte-aligned user message that fits under the portal's 120k calldata cap once
+        // encoded as relayMessage(uint256,address,address,uint256,uint256,bytes). The fixed
+        // encoding overhead is 4 bytes for the selector, 6 ABI words for the nonce, sender,
+        // target, value, minGasLimit, and message offset, and 1 ABI word for the dynamic bytes
+        // length. The message length is rounded down to a 32-byte multiple because dynamic bytes
+        // data is ABI word-padded.
+        uint256 portalCalldataLimit = 120_000;
+        uint256 relayMessageEncodingOverhead = 4 + 6 * 32 + 32;
+        uint256 messageLength = ((portalCalldataLimit - relayMessageEncodingOverhead) / 32) * 32;
+        bytes memory message = new bytes(messageLength);
+        for (uint256 i = 0; i < message.length; i++) {
+            message[i] = 0x01;
+        }
+
+        uint64 baseGas = l1CrossDomainMessenger.baseGas(message, minGasLimit);
+        address target = address(new GasBurner(type(uint32).max));
+        bytes memory encoded = Encoding.encodeCrossDomainMessage(
+            Encoding.encodeVersionedNonce(0, 1), alice, target, 0, minGasLimit, message
+        );
+
+        assertEq(encoded.length, relayMessageEncodingOverhead + message.length);
+        assertLe(encoded.length, portalCalldataLimit);
+        assertGt(encoded.length + 32, portalCalldataLimit);
+
+        uint256 zeroBytesInCalldata = 0;
+        uint256 nonzeroBytesInCalldata = 0;
+        for (uint256 i = 0; i < encoded.length; i++) {
+            if (encoded[i] != bytes1(0)) {
+                nonzeroBytesInCalldata++;
+            } else {
+                zeroBytesInCalldata++;
+            }
+        }
+        // The message body is non-zero, but the ABI-encoded selector and fixed-size arguments
+        // still include zero bytes.
+        assertGt(zeroBytesInCalldata, 0);
+
+        // Actual gas on L2 is the deposited gas limit minus L2 intrinsic gas.
+        uint256 gasSupplied = baseGas - (21_000 + ((zeroBytesInCalldata + nonzeroBytesInCalldata * 4) * 4));
+
+        address caller = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+        vm.prank(caller);
+
+        (bool success,) = address(l2CrossDomainMessenger).call{ gas: gasSupplied }(encoded);
+        assertTrue(success, "L2CrossDomainMessenger call should not fail");
+
         bool inFailedMessages = l2CrossDomainMessenger.failedMessages(keccak256(encoded));
         bool inSuccessfulMessages = l2CrossDomainMessenger.successfulMessages(keccak256(encoded));
         assertTrue(

--- a/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
@@ -299,12 +299,8 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
         // Skip if this is a fork test, won't work.
         skipIfForkTest("L2CrossDomainMessenger doesn't exist on L1 in forked test");
 
-        // Using smaller uint so the fuzzer doesn't give as many massive values that get bounded.
-        // TODO: Known issue, messages above 34k can actually OOG on the receiving side if the
-        // target uses all available gas. Can be resolved by capping data sizes on the XDM or by
-        // increasing the amount of available relay gas to ~100k. If increasing relay gas, should
-        // have the relay gas only increase when the calldata size is large to avoid disrupting
-        // in-flight L2 -> L1 messages.
+        // Keep the fuzz input bounded so the test remains fast. Near-max payloads are covered by a
+        // deterministic regression test below.
         _messageLength = uint24(bound(_messageLength, 0, 34_000));
 
         // Need more than 500 since GasBurner requires it.
@@ -366,6 +362,55 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
         assertTrue(success, "L1CrossDomainMessenger call should not fail");
 
         // Message should either be in the failed or successful messages mapping.
+        bool inFailedMessages = l1CrossDomainMessenger.failedMessages(keccak256(encoded));
+        bool inSuccessfulMessages = l1CrossDomainMessenger.successfulMessages(keccak256(encoded));
+        assertTrue(
+            inFailedMessages || inSuccessfulMessages, "message should be in either failed or successful messages"
+        );
+    }
+
+    /// @notice Tests that `relayMessage` has enough base gas to finish when relaying a near-max
+    ///         L2 => L1 payload to a target that consumes all forwarded gas.
+    function test_relayMessage_nearMaxPayloadAllGasTarget_succeeds() external {
+        skipIfForkTest("L2CrossDomainMessenger doesn't exist on L1 in forked test");
+
+        // Use the PoC's _minGasLimit value referenced from client-pod#609:
+        // https://github.com/ethereum-optimism/client-pod/issues/609
+        uint32 minGasLimit = 50_000;
+
+        // Match the largest 32-byte-aligned user message that fits under the portal's 120k
+        // calldata cap once encoded as relayMessage(uint256,address,address,uint256,uint256,bytes).
+        // The fixed encoding overhead is 4 bytes for the selector, 6 ABI words for the nonce,
+        // sender, target, value, minGasLimit, and message offset, and 1 ABI word for the dynamic
+        // bytes length. The message length is rounded down to a 32-byte multiple because dynamic
+        // bytes data is ABI word-padded.
+        uint256 portalCalldataLimit = 120_000;
+        uint256 relayMessageEncodingOverhead = 4 + 6 * 32 + 32;
+        uint256 messageLength = ((portalCalldataLimit - relayMessageEncodingOverhead) / 32) * 32;
+        bytes memory message = new bytes(messageLength);
+        for (uint256 i = 0; i < message.length; i++) {
+            message[i] = 0x01;
+        }
+
+        uint64 baseGas = l2CrossDomainMessenger.baseGas(message, minGasLimit);
+        address target = address(new GasBurner(type(uint32).max));
+        bytes memory encoded = Encoding.encodeCrossDomainMessage(
+            Encoding.encodeVersionedNonce(0, 1), alice, target, 0, minGasLimit, message
+        );
+
+        assertEq(encoded.length, relayMessageEncodingOverhead + message.length);
+        assertLe(encoded.length, portalCalldataLimit);
+        assertGt(encoded.length + 32, portalCalldataLimit);
+
+        StorageSlot memory slot = ForgeArtifacts.getSlot("OptimismPortal2", "l2Sender");
+        bytes32 l2SenderSlot = bytes32(slot.slot);
+        bytes32 l2Sender = bytes32(abi.encode(address(l2CrossDomainMessenger)));
+        vm.store(address(optimismPortal2), l2SenderSlot, l2Sender);
+        vm.prank(address(optimismPortal2));
+
+        (bool success,) = address(l1CrossDomainMessenger).call{ gas: baseGas }(encoded);
+        assertTrue(success, "L1CrossDomainMessenger call should not fail");
+
         bool inFailedMessages = l1CrossDomainMessenger.failedMessages(keccak256(encoded));
         bool inSuccessfulMessages = l1CrossDomainMessenger.successfulMessages(keccak256(encoded));
         assertTrue(


### PR DESCRIPTION
## Summary

This adds deterministic regression coverage for the large cross-domain message case that motivated ethereum-optimism/client-pod#609.

The old issue was that large L1 => L2 messenger payloads could pass the portal calldata limit but run out of gas inside `relayMessage` before the messenger recorded the message as successful or failed. That could leave value stranded because the relay frame would brick before updating `successfulMessages` or `failedMessages`.

The current `baseGas` formula was later updated for EIP-7623 and now includes both a larger relay execution buffer and a calldata floor. The stale test comments still claimed that messages above 34k could OOG when the target consumed all available gas, but the important behavior was not covered by a deterministic near-limit regression.

## Solution

- Replace the stale 34k warning with a note that the fuzz bound exists to keep fuzz runs fast.
- Add L1 => L2 and L2 => L1 deterministic tests for a near-max cross-domain payload.
- Use a 119,744-byte non-zero user message, which ABI-encodes to just under the portal 120k calldata cap.
- Relay to a `GasBurner(type(uint32).max)` target so the target consumes all forwarded gas.
- Assert that the messenger call itself does not fail and that the message is recorded in either `successfulMessages` or `failedMessages`.

This verifies the safety property that large messenger payloads may cause the target call to fail, but should not cause the messenger relay frame to OOG before recording the message outcome.

## Tests

- `mise exec -- just test --match-test 'test.*relayMessage_baseGasSufficient.*' -vv`