### PR TITLE
fix(op-challenger): tear down VM process group on timeout

### DIFF
--- a/op-challenger/game/fault/trace/vm/prestates.go
+++ b/op-challenger/game/fault/trace/vm/prestates.go
@@ -9,10 +9,16 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"time"
 
 	log2 "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/log"
 )
+
+// runCmdWaitDelay bounds how long cmd.Wait blocks after the context is cancelled
+// before its I/O is force-closed. It is a backstop for the case where a descendant
+// process still holds a stdout/stderr pipe open after the process group is killed.
+const runCmdWaitDelay = 10 * time.Second
 
 type SnapshotSelect func(logger log.Logger, dir string, absolutePreState string, i uint64, binary bool) (string, error)
 type CmdExecutor func(ctx context.Context, l log.Logger, binary string, args ...string) error
@@ -48,6 +54,16 @@ func RunCmd(ctx context.Context, l log.Logger, binary string, args ...string) er
 	defer stdErr.Close()
 	cmd.Stdout = stdOut
 	cmd.Stderr = stdErr
+
+	// The VM (cannon) spawns the oracle/preimage server as its own child process which
+	// inherits the VM's stdout/stderr pipes. exec.CommandContext only kills the direct
+	// child on cancellation, leaving the oracle server orphaned and still holding the
+	// pipe write ends open. cmd.Wait would then block forever waiting for EOF on those
+	// pipes. Kill the whole process group on cancellation and bound the wait so a wedged
+	// run is always torn down when the VM timeout fires.
+	setProcessGroup(cmd)
+	cmd.WaitDelay = runCmdWaitDelay
+
 	return cmd.Run()
 }
 

--- a/op-challenger/game/fault/trace/vm/prestates_other.go
+++ b/op-challenger/game/fault/trace/vm/prestates_other.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package vm
+
+import "os/exec"
+
+// setProcessGroup is a no-op on non-Unix platforms. Process-group teardown relies on
+// Unix-only syscalls; op-challenger runs on Linux in production. cmd.WaitDelay still
+// bounds the wait as a backstop.
+func setProcessGroup(cmd *exec.Cmd) {}

--- a/op-challenger/game/fault/trace/vm/prestates_unix.go
+++ b/op-challenger/game/fault/trace/vm/prestates_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package vm
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup runs cmd in its own process group and, on context cancellation,
+// kills the entire group (negative pid) rather than just the leader. This ensures
+// the VM's orphaned oracle-server grandchild is terminated along with the VM.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/op-challenger/game/fault/trace/vm/prestates_unix_test.go
+++ b/op-challenger/game/fault/trace/vm/prestates_unix_test.go
@@ -34,16 +34,19 @@ func TestRunCmdKillsGrandchildOnCancel(t *testing.T) {
 	script := fmt.Sprintf(`( echo $$ > %q; sleep 600 ) & sleep 600`, pidFile)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(200 * time.Millisecond)
-		cancel()
-	}()
+	defer cancel()
 
 	done := make(chan error, 1)
-	start := time.Now()
 	go func() {
 		done <- RunCmd(ctx, logger, "sh", "-c", script)
 	}()
+
+	// Wait until the grandchild has recorded its pid before cancelling. This guarantees the
+	// full process tree is up, so the test exercises the teardown deadlock rather than racing
+	// cancellation against process startup (which could spuriously pass on an overloaded box).
+	grandchildPid := readPid(t, pidFile)
+	start := time.Now()
+	cancel()
 
 	select {
 	case <-done:
@@ -52,7 +55,6 @@ func TestRunCmdKillsGrandchildOnCancel(t *testing.T) {
 		t.Fatal("RunCmd did not return after context cancellation - process tree teardown hung")
 	}
 
-	grandchildPid := readPid(t, pidFile)
 	require.Eventually(t, func() bool {
 		return !processAlive(grandchildPid)
 	}, 5*time.Second, 50*time.Millisecond, "grandchild oracle-server process should be killed with the group")

--- a/op-challenger/game/fault/trace/vm/prestates_unix_test.go
+++ b/op-challenger/game/fault/trace/vm/prestates_unix_test.go
@@ -1,0 +1,76 @@
+//go:build unix
+
+package vm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+// TestRunCmdKillsGrandchildOnCancel reproduces the orphaned-grandchild deadlock: the VM
+// spawns an oracle-server child that inherits the VM's stdout/stderr pipes and sleeps
+// forever. Without process-group teardown, killing only the direct child leaves the
+// grandchild holding the pipes open and cmd.Wait blocks indefinitely. RunCmd must return
+// promptly when the context is cancelled and the grandchild must be killed.
+func TestRunCmdKillsGrandchildOnCancel(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+
+	// The parent (the "VM") forks a grandchild (the "oracle server") that records its pid,
+	// keeps the inherited stdout open, and sleeps far longer than the test. The parent then
+	// sleeps too. Neither writes EOF, mirroring the production deadlock.
+	script := fmt.Sprintf(`( echo $$ > %q; sleep 600 ) & sleep 600`, pidFile)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- RunCmd(ctx, logger, "sh", "-c", script)
+	}()
+
+	select {
+	case <-done:
+		require.Less(t, time.Since(start), 5*time.Second, "RunCmd should return promptly after cancellation")
+	case <-time.After(20 * time.Second):
+		t.Fatal("RunCmd did not return after context cancellation - process tree teardown hung")
+	}
+
+	grandchildPid := readPid(t, pidFile)
+	require.Eventually(t, func() bool {
+		return !processAlive(grandchildPid)
+	}, 5*time.Second, 50*time.Millisecond, "grandchild oracle-server process should be killed with the group")
+}
+
+func readPid(t *testing.T, pidFile string) int {
+	var data []byte
+	require.Eventually(t, func() bool {
+		var err error
+		data, err = os.ReadFile(pidFile)
+		return err == nil && len(strings.TrimSpace(string(data))) > 0
+	}, 5*time.Second, 50*time.Millisecond, "grandchild should record its pid")
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	require.NoError(t, err)
+	return pid
+}
+
+func processAlive(pid int) bool {
+	// Signal 0 performs error checking without sending a signal.
+	return syscall.Kill(pid, 0) == nil
+}


### PR DESCRIPTION
The run-trace runner bounds each VM run with `--vm-timeout`, but the timeout did not reliably terminate a wedged run.

The VM (cannon) spawns the oracle/preimage server as its own child, which inherits the VM's stdout/stderr pipes. `exec.CommandContext` only SIGKILLs the direct child on cancellation, so the oracle server is orphaned and keeps the pipe write ends open. `cmd.Wait` then blocks forever waiting for EOF, so the VM timeout never actually tears the run down (we observed a run wedged ~18h despite the 3h default).

Fix: run the VM in its own process group, kill the whole group (negative pid) on cancellation, and set a bounded `WaitDelay` as a backstop so `RunCmd` always returns once the context is cancelled. The process-group bits are Unix-only and guarded behind a build tag with a no-op fallback so cross-compilation still works.

Adds a regression test that spawns a grandchild holding stdout open and asserts `RunCmd` returns promptly and the grandchild is killed.