### PR TITLE
fix(kona-host): retry witness fetches via the get_preimage loop, not debug_dbGet

### DIFF
--- a/rust/kona/bin/host/src/backend/online.rs
+++ b/rust/kona/bin/host/src/backend/online.rs
@@ -54,9 +54,15 @@ where
     kv: SharedKeyValueStore,
     /// The providers that are used to fetch data in response to hints.
     providers: C::Providers,
-    /// Hints that should be immediately executed by the host.
-    proactive_hints: HashSet<C::HintType>,
-    /// The last hint that was received.
+    /// Hint types treated as "high-level" (see [`Self::last_high_level_hint`]).
+    high_level_hint_types: HashSet<C::HintType>,
+    /// The latest high-level hint. High-level hints bulk-populate the key-value store, so rather
+    /// than being fetched once on receipt the latest is retained and tried before
+    /// [`Self::last_hint`] on every [`Self::get_preimage`] attempt: cleared once it succeeds (its
+    /// response is deterministic) and kept while it fails, so a transient error is retried
+    /// indefinitely instead of falling back to an unavailable `debug_dbGet`.
+    last_high_level_hint: Arc<RwLock<Option<Hint<C::HintType>>>>,
+    /// The latest fine-grained hint.
     last_hint: Arc<RwLock<Option<Hint<C::HintType>>>>,
     /// Phantom marker for the [`HintHandler`].
     _hint_handler: std::marker::PhantomData<H>,
@@ -74,15 +80,17 @@ where
             cfg,
             kv,
             providers,
-            proactive_hints: HashSet::default(),
+            high_level_hint_types: HashSet::default(),
+            last_high_level_hint: Arc::new(RwLock::new(None)),
             last_hint: Arc::new(RwLock::new(None)),
             _hint_handler: std::marker::PhantomData,
         }
     }
 
-    /// Adds a new proactive hint to the [`OnlineHostBackend`].
-    pub fn with_proactive_hint(mut self, hint_type: C::HintType) -> Self {
-        self.proactive_hints.insert(hint_type);
+    /// Registers a hint type as "high-level": rather than being fetched once and discarded, the
+    /// latest hint of this type is retained and tried first by the `get_preimage` retry loop.
+    pub fn with_high_level_hint(mut self, hint_type: C::HintType) -> Self {
+        self.high_level_hint_types.insert(hint_type);
         self
     }
 }
@@ -100,14 +108,11 @@ where
         let parsed_hint = hint
             .parse::<Hint<C::HintType>>()
             .map_err(|e| PreimageOracleError::HintParseFailed(e.to_string()))?;
-        if self.proactive_hints.contains(&parsed_hint.ty) {
-            debug!(target: "host_backend", "Proactive hint received; Immediately fetching {hint}");
-            H::fetch_hint(parsed_hint, &self.cfg, &self.providers, self.kv.clone())
-                .await
-                .map_err(|e| PreimageOracleError::Other(e.to_string()))?;
+        if self.high_level_hint_types.contains(&parsed_hint.ty) {
+            debug!(target: "host_backend", "High-level hint received; retaining {hint}");
+            self.last_high_level_hint.write().await.replace(parsed_hint);
         } else {
-            let mut hint_lock = self.last_hint.write().await;
-            hint_lock.replace(parsed_hint);
+            self.last_hint.write().await.replace(parsed_hint);
         }
 
         Ok(())
@@ -133,20 +138,289 @@ where
 
         // Use a loop to keep retrying the prefetch as long as the key is not found
         while preimage.is_none() {
-            if let Some(hint) = self.last_hint.read().await.as_ref() {
-                let value =
-                    H::fetch_hint(hint.clone(), &self.cfg, &self.providers, self.kv.clone()).await;
+            // Try the retained high-level hint first (see `last_high_level_hint`).
+            let high_level_hint = self.last_high_level_hint.read().await.clone();
+            if let Some(hint) = high_level_hint {
+                match H::fetch_hint(hint, &self.cfg, &self.providers, self.kv.clone()).await {
+                    Ok(()) => {
+                        // Clearing unconditionally is safe: the client blocks on this request and
+                        // issues hints and preimage requests sequentially, so no newer high-level
+                        // hint can arrive mid-fetch.
+                        self.last_high_level_hint.write().await.take();
+                        preimage = self.kv.read().await.get(key.into());
+                        if preimage.is_some() {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        error!(target: "host_backend", "Failed to prefetch high-level hint: {e}");
+                    }
+                }
+            }
 
-                if let Err(e) = value {
+            // Fall back to the fine-grained hint.
+            if let Some(hint) = self.last_hint.read().await.clone() {
+                if let Err(e) =
+                    H::fetch_hint(hint, &self.cfg, &self.providers, self.kv.clone()).await
+                {
                     error!(target: "host_backend", "Failed to prefetch hint: {e}");
                     continue;
                 }
 
-                let kv_lock = self.kv.read().await;
-                preimage = kv_lock.get(key.into());
+                preimage = self.kv.read().await.get(key.into());
             }
         }
 
         preimage.ok_or(PreimageOracleError::KeyNotFound)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kv::MemoryKeyValueStore;
+    use alloy_primitives::B256;
+    use kona_preimage::PreimageKey;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Clone, PartialEq, Eq, Hash, Debug)]
+    enum TestHint {
+        HighLevel,
+        LowLevel,
+    }
+
+    impl FromStr for TestHint {
+        type Err = HintParsingError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            match s {
+                "high" => Ok(Self::HighLevel),
+                "low" => Ok(Self::LowLevel),
+                other => Err(HintParsingError(format!("unknown test hint: {other}"))),
+            }
+        }
+    }
+
+    struct TestCfg;
+
+    impl OnlineHostBackendCfg for TestCfg {
+        type HintType = TestHint;
+        type Providers = TestProviders;
+    }
+
+    /// Configures the mock [`HintHandler`]. The attempt counters are behind `Arc`s so a test can
+    /// inspect them after `providers` has been moved into the backend.
+    #[derive(Clone)]
+    struct TestProviders {
+        /// The keccak key both hints populate; equal to what `get_preimage` looks up.
+        target: B256,
+        /// The value stored under `target`.
+        value: Vec<u8>,
+        /// Number of times the high-level fetch fails before it succeeds.
+        high_level_fail_until: usize,
+        /// Whether the high-level fetch stores `target` once it succeeds (false models a
+        /// method-not-found, where the witness call returns `Ok` without populating anything).
+        high_level_stores_target: bool,
+        high_level_attempts: Arc<AtomicUsize>,
+        /// Whether the fine-grained fetch stores `target`.
+        low_level_stores_target: bool,
+        low_level_attempts: Arc<AtomicUsize>,
+    }
+
+    struct TestHintHandler;
+
+    #[async_trait]
+    impl HintHandler for TestHintHandler {
+        type Cfg = TestCfg;
+
+        async fn fetch_hint(
+            hint: Hint<TestHint>,
+            _cfg: &TestCfg,
+            providers: &TestProviders,
+            kv: SharedKeyValueStore,
+        ) -> Result<()> {
+            match hint.ty {
+                TestHint::HighLevel => {
+                    let attempt = providers.high_level_attempts.fetch_add(1, Ordering::SeqCst);
+                    if attempt < providers.high_level_fail_until {
+                        anyhow::bail!("transient high-level failure");
+                    }
+                    if providers.high_level_stores_target {
+                        kv.write().await.set(providers.target, providers.value.clone())?;
+                    }
+                    Ok(())
+                }
+                TestHint::LowLevel => {
+                    providers.low_level_attempts.fetch_add(1, Ordering::SeqCst);
+                    if providers.low_level_stores_target {
+                        kv.write().await.set(providers.target, providers.value.clone())?;
+                    }
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    /// A keccak preimage key and the `B256` it maps to in the key-value store.
+    fn target_key() -> (PreimageKey, B256) {
+        let key = PreimageKey::new_keccak256(*B256::repeat_byte(0x11));
+        (key, key.into())
+    }
+
+    fn new_backend(providers: TestProviders) -> OnlineHostBackend<TestCfg, TestHintHandler> {
+        let kv: SharedKeyValueStore = Arc::new(RwLock::new(MemoryKeyValueStore::new()));
+        OnlineHostBackend::new(TestCfg, kv, providers, TestHintHandler)
+            .with_high_level_hint(TestHint::HighLevel)
+    }
+
+    /// The core regression: a transient high-level (witness) fetch failure is retried by the
+    /// `get_preimage` loop until it succeeds, rather than being surfaced as a permanent error that
+    /// forces a fall-through to the unsupported `debug_dbGet`.
+    #[tokio::test]
+    async fn high_level_hint_retried_until_success_then_cleared() {
+        let (key, target) = target_key();
+        let high_level_attempts = Arc::new(AtomicUsize::new(0));
+        let backend = new_backend(TestProviders {
+            target,
+            value: b"witness".to_vec(),
+            high_level_fail_until: 2,
+            high_level_stores_target: true,
+            high_level_attempts: high_level_attempts.clone(),
+            low_level_stores_target: false,
+            low_level_attempts: Arc::new(AtomicUsize::new(0)),
+        });
+        backend.route_hint("high 00".to_string()).await.unwrap();
+
+        let preimage = backend.get_preimage(key).await.unwrap();
+
+        assert_eq!(preimage, b"witness".to_vec());
+        assert_eq!(
+            high_level_attempts.load(Ordering::SeqCst),
+            3,
+            "should fail twice then succeed on the third attempt"
+        );
+        assert!(
+            backend.last_high_level_hint.read().await.is_none(),
+            "high-level hint should be cleared once it succeeds"
+        );
+    }
+
+    /// The high-level hint is tried before the fine-grained hint, so when it satisfies the key the
+    /// fine-grained hint is never fetched.
+    #[tokio::test]
+    async fn high_level_hint_tried_before_fine_grained() {
+        let (key, target) = target_key();
+        let high_level_attempts = Arc::new(AtomicUsize::new(0));
+        let low_level_attempts = Arc::new(AtomicUsize::new(0));
+        let backend = new_backend(TestProviders {
+            target,
+            value: b"witness".to_vec(),
+            high_level_fail_until: 0,
+            high_level_stores_target: true,
+            high_level_attempts: high_level_attempts.clone(),
+            low_level_stores_target: true,
+            low_level_attempts: low_level_attempts.clone(),
+        });
+        backend.route_hint("high 00".to_string()).await.unwrap();
+        backend.route_hint("low 00".to_string()).await.unwrap();
+
+        let preimage = backend.get_preimage(key).await.unwrap();
+
+        assert_eq!(preimage, b"witness".to_vec());
+        assert_eq!(high_level_attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            low_level_attempts.load(Ordering::SeqCst),
+            0,
+            "fine-grained hint should not run once the high-level hint satisfies the key"
+        );
+    }
+
+    /// When the high-level hint succeeds but doesn't populate this key (a node outside the
+    /// witness), it is cleared and the loop falls through to the fine-grained `debug_dbGet` hint.
+    #[tokio::test]
+    async fn falls_back_to_fine_grained_when_high_level_does_not_populate() {
+        let (key, target) = target_key();
+        let high_level_attempts = Arc::new(AtomicUsize::new(0));
+        let low_level_attempts = Arc::new(AtomicUsize::new(0));
+        let backend = new_backend(TestProviders {
+            target,
+            value: b"node".to_vec(),
+            high_level_fail_until: 0,
+            high_level_stores_target: false,
+            high_level_attempts: high_level_attempts.clone(),
+            low_level_stores_target: true,
+            low_level_attempts: low_level_attempts.clone(),
+        });
+        backend.route_hint("high 00".to_string()).await.unwrap();
+        backend.route_hint("low 00".to_string()).await.unwrap();
+
+        let preimage = backend.get_preimage(key).await.unwrap();
+
+        assert_eq!(preimage, b"node".to_vec());
+        assert_eq!(
+            high_level_attempts.load(Ordering::SeqCst),
+            1,
+            "high-level hint should be cleared after one non-populating success"
+        );
+        assert!(low_level_attempts.load(Ordering::SeqCst) >= 1);
+        assert!(backend.last_high_level_hint.read().await.is_none());
+    }
+
+    /// A high-level hint that keeps failing (e.g. an unimplemented `debug_executePayload`) is
+    /// retried and kept, but never blocks the fine-grained fallback that still serves the key.
+    #[tokio::test]
+    async fn fine_grained_fallback_survives_failing_high_level_hint() {
+        let (key, target) = target_key();
+        let high_level_attempts = Arc::new(AtomicUsize::new(0));
+        let low_level_attempts = Arc::new(AtomicUsize::new(0));
+        let backend = new_backend(TestProviders {
+            target,
+            value: b"node".to_vec(),
+            high_level_fail_until: usize::MAX,
+            high_level_stores_target: false,
+            high_level_attempts: high_level_attempts.clone(),
+            low_level_stores_target: true,
+            low_level_attempts: low_level_attempts.clone(),
+        });
+        backend.route_hint("high 00".to_string()).await.unwrap();
+        backend.route_hint("low 00".to_string()).await.unwrap();
+
+        let preimage = backend.get_preimage(key).await.unwrap();
+
+        assert_eq!(preimage, b"node".to_vec());
+        assert!(high_level_attempts.load(Ordering::SeqCst) >= 1);
+        assert!(low_level_attempts.load(Ordering::SeqCst) >= 1);
+        assert!(
+            backend.last_high_level_hint.read().await.is_some(),
+            "a failing high-level hint is kept for retry, not cleared"
+        );
+    }
+
+    /// `route_hint` routes a registered high-level type to its retained slot and everything else to
+    /// the fine-grained slot.
+    #[tokio::test]
+    async fn route_hint_separates_high_level_from_fine_grained() {
+        let (_key, target) = target_key();
+        let backend = new_backend(TestProviders {
+            target,
+            value: Vec::new(),
+            high_level_fail_until: 0,
+            high_level_stores_target: false,
+            high_level_attempts: Arc::new(AtomicUsize::new(0)),
+            low_level_stores_target: false,
+            low_level_attempts: Arc::new(AtomicUsize::new(0)),
+        });
+
+        backend.route_hint("high 00".to_string()).await.unwrap();
+        backend.route_hint("low 00".to_string()).await.unwrap();
+
+        assert_eq!(
+            backend.last_high_level_hint.read().await.as_ref().map(|h| h.ty.clone()),
+            Some(TestHint::HighLevel)
+        );
+        assert_eq!(
+            backend.last_hint.read().await.as_ref().map(|h| h.ty.clone()),
+            Some(TestHint::LowLevel)
+        );
     }
 }

--- a/rust/kona/bin/host/src/backend/util.rs
+++ b/rust/kona/bin/host/src/backend/util.rs
@@ -2,10 +2,32 @@
 
 use crate::{KeyValueStore, Result};
 use alloy_consensus::EMPTY_ROOT_HASH;
-use alloy_primitives::keccak256;
+use alloy_primitives::{B256, keccak256};
 use alloy_rlp::EMPTY_STRING_CODE;
+use alloy_rpc_client::ClientRef;
+use alloy_rpc_types::debug::ExecutionWitness;
 use kona_preimage::{PreimageKey, PreimageKeyType};
+use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use tokio::sync::RwLock;
+
+/// Fetches a block's execution witness via `debug_executePayload`.
+///
+/// Any failure — including "method not found" — is returned as an error rather than swallowed. The
+/// `L2PayloadWitness` hint is high-level, so the `get_preimage` loop retries it; retrying is cheap
+/// and lets the fetch recover if the node is upgraded.
+pub(crate) async fn fetch_execution_witness(
+    client: ClientRef<'_>,
+    parent_block_hash: B256,
+    payload_attributes: OpPayloadAttributes,
+) -> anyhow::Result<ExecutionWitness> {
+    client
+        .request::<(B256, OpPayloadAttributes), ExecutionWitness>(
+            "debug_executePayload",
+            (parent_block_hash, payload_attributes),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("debug_executePayload failed: {e}"))
+}
 
 /// Constructs a merkle patricia trie from the ordered list passed and stores all encoded
 /// intermediate nodes of the trie in the [`KeyValueStore`].

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -210,8 +210,8 @@ impl InteropHost {
                 providers,
                 InteropHintHandler,
             )
-            .with_proactive_hint(HintType::L2BlockData)
-            .with_proactive_hint(HintType::L2PayloadWitness);
+            .with_high_level_hint(HintType::L2BlockData)
+            .with_high_level_hint(HintType::L2PayloadWitness);
 
             task::spawn(async {
                 PreimageServer::new(

--- a/rust/kona/bin/host/src/interop/handler.rs
+++ b/rust/kona/bin/host/src/interop/handler.rs
@@ -11,8 +11,7 @@ use alloy_op_evm::OpEvmFactory;
 use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_provider::Provider;
 use alloy_rlp::{Decodable, Encodable};
-use alloy_rpc_types::{Block, debug::ExecutionWitness};
-use alloy_transport::{RpcError, TransportErrorKind};
+use alloy_rpc_types::Block;
 use anyhow::{Result, anyhow, ensure};
 use ark_ff::{BigInteger, PrimeField};
 use async_trait::async_trait;
@@ -55,12 +54,6 @@ fn parse_l2_payload_witness_hint(data: &[u8]) -> Result<(B256, &[u8], u64)> {
     let chain_id = u64::from_be_bytes(data[data.len() - 8..].try_into()?);
     let payload_attributes_bytes = &data[32..data.len() - 8];
     Ok((parent_block_hash, payload_attributes_bytes, chain_id))
-}
-
-/// Returns `true` if the RPC error indicates the node does not support the requested method
-/// (JSON-RPC error code -32601: Method not found).
-const fn is_rpc_method_not_found(e: &RpcError<TransportErrorKind>) -> bool {
-    matches!(e, RpcError::ErrorResp(p) if p.code == -32601)
 }
 
 /// The [`HintHandler`] for the [`InteropHost`].
@@ -677,27 +670,13 @@ impl HintHandler for InteropHintHandler {
                 // 2. Route to correct L2 provider
                 let l2_provider = providers.l2(&chain_id)?;
 
-                // 3. Call debug_executePayload RPC
-                let execute_payload_response = match l2_provider
-                    .client()
-                    .request::<(B256, OpPayloadAttributes), ExecutionWitness>(
-                        "debug_executePayload",
-                        (parent_block_hash, payload_attributes),
-                    )
-                    .await
-                {
-                    Ok(response) => response,
-                    Err(e) => {
-                        info!(
-                            target: "interop_hint_handler",
-                            err = %e,
-                            chain_id,
-                            method_not_found = is_rpc_method_not_found(&e),
-                            "debug_executePayload unavailable, skipping witness preimage collection"
-                        );
-                        return Ok(());
-                    }
-                };
+                // 3. Call debug_executePayload RPC.
+                let execute_payload_response = crate::backend::util::fetch_execution_witness(
+                    l2_provider.client(),
+                    parent_block_hash,
+                    payload_attributes,
+                )
+                .await?;
 
                 // 4. Store preimages in KV store
                 let preimages = execute_payload_response
@@ -722,34 +701,6 @@ impl HintHandler for InteropHintHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_json_rpc::ErrorPayload;
-    use alloy_transport::TransportErrorKind;
-
-    #[test]
-    fn test_is_rpc_method_not_found_true() {
-        let e = RpcError::<TransportErrorKind>::ErrorResp(ErrorPayload {
-            code: -32601,
-            message: "method not found".into(),
-            data: None,
-        });
-        assert!(is_rpc_method_not_found(&e));
-    }
-
-    #[test]
-    fn test_is_rpc_method_not_found_false_wrong_code() {
-        let e = RpcError::<TransportErrorKind>::ErrorResp(ErrorPayload {
-            code: -32600,
-            message: "invalid request".into(),
-            data: None,
-        });
-        assert!(!is_rpc_method_not_found(&e));
-    }
-
-    #[test]
-    fn test_is_rpc_method_not_found_false_null_resp() {
-        let e = RpcError::<TransportErrorKind>::NullResp;
-        assert!(!is_rpc_method_not_found(&e));
-    }
 
     fn make_hint(parent_hash: B256, json: &[u8], chain_id: u64) -> Vec<u8> {
         let mut data = Vec::new();

--- a/rust/kona/bin/host/src/single/cfg.rs
+++ b/rust/kona/bin/host/src/single/cfg.rs
@@ -186,7 +186,7 @@ impl SingleChainHost {
                 providers,
                 SingleChainHintHandler,
             )
-            .with_proactive_hint(HintType::L2PayloadWitness);
+            .with_high_level_hint(HintType::L2PayloadWitness);
 
             task::spawn(async {
                 PreimageServer::new(

--- a/rust/kona/bin/host/src/single/handler.rs
+++ b/rust/kona/bin/host/src/single/handler.rs
@@ -9,8 +9,7 @@ use alloy_eips::{eip2718::Encodable2718, eip4844::FIELD_ELEMENTS_PER_BLOB};
 use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_provider::Provider;
 use alloy_rlp::Decodable;
-use alloy_rpc_types::{Block, debug::ExecutionWitness};
-use alloy_transport::{RpcError, TransportErrorKind};
+use alloy_rpc_types::Block;
 use anyhow::{Result, anyhow, ensure};
 use ark_ff::{BigInteger, PrimeField};
 use async_trait::async_trait;
@@ -19,7 +18,7 @@ use kona_proof::{Hint, HintType, l1::ROOTS_OF_UNITY};
 use kona_protocol::{BlockInfo, OutputRoot, Predeploys};
 use kona_providers_alloy::BlobWithCommitmentAndProof;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
-use tracing::{info, warn};
+use tracing::warn;
 
 /// Parses a blob hint, supporting both legacy (48-byte) and new (40-byte) formats.
 ///
@@ -58,12 +57,6 @@ pub fn parse_blob_hint(hint_data: &[u8]) -> Result<(B256, u64)> {
             );
         }
     }
-}
-
-/// Returns `true` if the RPC error indicates the node does not support the requested method
-/// (JSON-RPC error code -32601: Method not found).
-const fn is_rpc_method_not_found(e: &RpcError<TransportErrorKind>) -> bool {
-    matches!(e, RpcError::ErrorResp(p) if p.code == -32601)
 }
 
 /// The [`HintHandler`] for the [`SingleChainHost`].
@@ -405,26 +398,12 @@ impl HintHandler for SingleChainHintHandler {
                 let payload_attributes: OpPayloadAttributes =
                     serde_json::from_slice(&hint.data[32..])?;
 
-                let execute_payload_response = match providers
-                    .l2
-                    .client()
-                    .request::<(B256, OpPayloadAttributes), ExecutionWitness>(
-                        "debug_executePayload",
-                        (parent_block_hash, payload_attributes),
-                    )
-                    .await
-                {
-                    Ok(response) => response,
-                    Err(e) => {
-                        info!(
-                            target: "single_hint_handler",
-                            err = %e,
-                            method_not_found = is_rpc_method_not_found(&e),
-                            "debug_executePayload unavailable, skipping witness preimage collection"
-                        );
-                        return Ok(());
-                    }
-                };
+                let execute_payload_response = crate::backend::util::fetch_execution_witness(
+                    providers.l2.client(),
+                    parent_block_hash,
+                    payload_attributes,
+                )
+                .await?;
 
                 let preimages = execute_payload_response
                     .state
@@ -449,34 +428,6 @@ impl HintHandler for SingleChainHintHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_json_rpc::ErrorPayload;
-    use alloy_transport::TransportErrorKind;
-
-    #[test]
-    fn test_is_rpc_method_not_found_true() {
-        let e = RpcError::<TransportErrorKind>::ErrorResp(ErrorPayload {
-            code: -32601,
-            message: "method not found".into(),
-            data: None,
-        });
-        assert!(is_rpc_method_not_found(&e));
-    }
-
-    #[test]
-    fn test_is_rpc_method_not_found_false_wrong_code() {
-        let e = RpcError::<TransportErrorKind>::ErrorResp(ErrorPayload {
-            code: -32600,
-            message: "invalid request".into(),
-            data: None,
-        });
-        assert!(!is_rpc_method_not_found(&e));
-    }
-
-    #[test]
-    fn test_is_rpc_method_not_found_false_null_resp() {
-        let e = RpcError::<TransportErrorKind>::NullResp;
-        assert!(!is_rpc_method_not_found(&e));
-    }
 
     const TEST_HASH: B256 = B256::new([0x42u8; 32]);
     const TEST_TIMESTAMP: u64 = 1234567890;


### PR DESCRIPTION
`debug_executePayload` (the `L2PayloadWitness` hint) and the `L2BlockData` optimistic-block re-execution are "high-level" hints that bulk-populate the preimage store. They were fetched once when received and then discarded, so any error was terminal — the client fell back to per-node `debug_dbGet`, which op-reth doesn't implement, turning a transient failure into a permanent one.

Rather than introduce a separate retry/backoff path, this plugs them into the **existing `get_preimage` retry loop** (the same one that already retries `debug_dbGet` forever):

- High-level hints are no longer fetched eagerly in `route_hint`; the latest one is **retained**.
- On each `get_preimage` attempt the retained high-level hint is tried **first** (bulk-populating the store), then the fine-grained hints.
- A high-level hint is **cleared once it succeeds** (its response is deterministic, so re-issuing it is pointless) and **kept while it fails**, so a transient error is retried indefinitely — and an unrelated later low-level hint won't re-trigger an already-satisfied high-level fetch.
- Any failure is retried, **including JSON-RPC method-not-found** — it's cheap and lets the fetch start working if the node is upgraded. Even while the high-level fetch keeps failing, each loop attempt still falls through to the fine-grained `debug_dbGet` hint, so nodes that genuinely lack `debug_executePayload` are still served.

### Behavioral change: high-level hints are now lazy

Previously a high-level (proactive) hint was fetched **eagerly and synchronously** in `route_hint` the moment it was received. Now it is only **retained** there and executed lazily by the `get_preimage` loop — i.e. **not until an actual preimage request arrives for a key that isn't already in the store**. If the requested preimage already exists, the loop never runs and the high-level fetch is skipped entirely.

This is functionally equivalent for the proof flow (the witness fetch just shifts from hint-receipt time to the first cache-missing `get_preimage`), and it **avoids redundant executions**: an expensive fetch like `debug_executePayload` or the `L2BlockData` re-execution is no longer re-run when the needed preimages are already available, and is cleared after its first success so subsequent requests don't repeat the identical call.

The `debug_executePayload` call is consolidated into `backend::util::fetch_execution_witness`, de-duplicating the single-chain and interop handlers. `L2BlockData`'s handler body is unchanged — it benefits from the retained-hint retry automatically. Regression coverage lives in `backend::online`'s test module (retry-to-success + clear, high-level-before-fine-grained, fine-grained fallback survival, and route separation).