### PR TITLE
chore(op-challenger): don't require --cannon-server for the permissioned game

### DIFF
--- a/op-challenger/README.md
+++ b/op-challenger/README.md
@@ -51,6 +51,12 @@ The challenger will monitor dispute games and respond to any invalid
 claims by posting the correct trace as the counter-claim. The commands
 below can then be used to create and interact with games.
 
+`--cannon-server` is only required for the `cannon` game type, which runs
+op-program to generate fault proofs. The `permissioned` game type is played
+only by trusted actors and resolves at the output-root level without ever
+reaching `step()`, so it does not run op-program and `--cannon-server` may be
+omitted when only the `permissioned` game type is configured.
+
 #### Devnet Management Commands
 
 ```shell

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -591,6 +591,12 @@ func TestCannonRequiredArgs(t *testing.T) {
 				}
 			})
 
+			t.Run("RequiredWhenCannonAndPermissionedBothEnabled", func(t *testing.T) {
+				gameTypesArg := fmt.Sprintf("%v,%v", gameTypes.CannonGameType.String(), gameTypes.PermissionedGameType.String())
+				args := addRequiredArgsExceptArr(gameTypes.CannonGameType, []string{"--game-types", "--cannon-server"}, "--game-types", gameTypesArg)
+				verifyArgsInvalid(t, "flag cannon-server is required", args)
+			})
+
 			t.Run("Valid", func(t *testing.T) {
 				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--cannon-server", "--cannon-server=./op-program"))
 				require.Equal(t, "./op-program", cfg.Cannon.Server)

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -583,7 +583,12 @@ func TestCannonRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Required", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag cannon-server is required", addRequiredArgsExcept(gameType, "--cannon-server"))
+				if gameType == gameTypes.PermissionedGameType {
+					// The permissioned game never reaches step() so does not run op-program.
+					configForArgs(t, addRequiredArgsExcept(gameType, "--cannon-server"))
+				} else {
+					verifyArgsInvalid(t, "flag cannon-server is required", addRequiredArgsExcept(gameType, "--cannon-server"))
+				}
 			})
 
 			t.Run("Valid", func(t *testing.T) {

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -251,7 +251,10 @@ func (c Config) Check() error {
 		if c.RollupRpc == "" {
 			return ErrMissingRollupRpc
 		}
-		if err := c.validateBaseCannonOptions(); err != nil {
+		// The permissioned game never reaches step() so does not run op-program; only the
+		// legacy Cannon game type requires the op-program server binary.
+		requireServer := c.GameTypeEnabled(gameTypes.CannonGameType)
+		if err := c.validateBaseCannonOptions(requireServer); err != nil {
 			return err
 		}
 	}
@@ -297,8 +300,8 @@ func (c Config) Check() error {
 	return nil
 }
 
-func (c Config) validateBaseCannonOptions() error {
-	if err := c.Cannon.Check(); err != nil {
+func (c Config) validateBaseCannonOptions(requireServer bool) error {
+	if err := c.Cannon.Check(requireServer); err != nil {
 		return fmt.Errorf("cannon: %w", err)
 	}
 	if c.CannonAbsolutePreState == "" && c.CannonAbsolutePreStateBaseURL == nil {
@@ -314,7 +317,7 @@ func (c Config) validateBaseCannonOptions() error {
 }
 
 func (c Config) validateBaseCannonKonaOptions() error {
-	if err := c.CannonKona.Check(); err != nil {
+	if err := c.CannonKona.Check(true); err != nil {
 		return fmt.Errorf("cannon kona: %w", err)
 	}
 	if c.CannonKonaAbsolutePreState == "" && c.CannonKonaAbsolutePreStateBaseURL == nil {

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -199,7 +199,12 @@ func TestCannonRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestCannonServerRequired-%v", gameType), func(t *testing.T) {
 			config := validConfig(t, gameType)
 			config.Cannon.Server = ""
-			require.ErrorIs(t, config.Check(), vm.ErrMissingServer)
+			if gameType == gameTypes.PermissionedGameType {
+				// The permissioned game never reaches step() so does not run op-program.
+				require.NoError(t, config.Check())
+			} else {
+				require.ErrorIs(t, config.Check(), vm.ErrMissingServer)
+			}
 		})
 
 		t.Run(fmt.Sprintf("TestCannonAbsolutePreStateOrBaseURLRequired-%v", gameType), func(t *testing.T) {
@@ -305,7 +310,12 @@ func TestCannonRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestServerExists-%v", gameType), func(t *testing.T) {
 			cfg := validConfig(t, gameType)
 			cfg.Cannon.Server = nonExistingFile
-			require.ErrorIs(t, cfg.Check(), vm.ErrMissingServer)
+			if gameType == gameTypes.PermissionedGameType {
+				// The permissioned game never reaches step() so does not run op-program.
+				require.NoError(t, cfg.Check())
+			} else {
+				require.ErrorIs(t, cfg.Check(), vm.ErrMissingServer)
+			}
 		})
 	}
 }

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -320,6 +320,24 @@ func TestCannonRequiredArgs(t *testing.T) {
 	}
 }
 
+// The op-program server is still required when both the cannon and permissioned game types
+// are enabled, because the cannon game runs op-program even though the permissioned game does not.
+func TestCannonServerRequiredWhenCannonAndPermissionedBothEnabled(t *testing.T) {
+	t.Run("ServerEmpty", func(t *testing.T) {
+		config := validConfig(t, gameTypes.CannonGameType)
+		config.GameTypes = []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.PermissionedGameType}
+		config.Cannon.Server = ""
+		require.ErrorIs(t, config.Check(), vm.ErrMissingServer)
+	})
+
+	t.Run("ServerMissing", func(t *testing.T) {
+		config := validConfig(t, gameTypes.CannonGameType)
+		config.GameTypes = []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.PermissionedGameType}
+		config.Cannon.Server = nonExistingFile
+		require.ErrorIs(t, config.Check(), vm.ErrMissingServer)
+	})
+}
+
 func TestCannonKonaRequiredArgs(t *testing.T) {
 	for _, gameType := range cannonKonaGameTypes {
 		gameType := gameType

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -325,7 +325,7 @@ func checkOutputProviderFlags(ctx *cli.Context) error {
 	return nil
 }
 
-func CheckCannonBaseFlags(ctx *cli.Context) error {
+func CheckCannonBaseFlags(ctx *cli.Context, requireServer bool) error {
 	if ctx.IsSet(flags.NetworkFlagName) &&
 		(RollupConfigFlag.IsSet(ctx, gameTypes.CannonGameType) || L2GenesisFlag.IsSet(ctx, gameTypes.CannonGameType) || L1GenesisFlag.IsSet(ctx, gameTypes.CannonGameType) || ctx.Bool(CannonL2CustomFlag.Name)) {
 		return fmt.Errorf("flag %v can not be used with %v, %v, %v or %v",
@@ -338,7 +338,7 @@ func CheckCannonBaseFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(CannonBinFlag.Name) {
 		return fmt.Errorf("flag %s is required", CannonBinFlag.Name)
 	}
-	if !ctx.IsSet(CannonServerFlag.Name) {
+	if requireServer && !ctx.IsSet(CannonServerFlag.Name) {
 		return fmt.Errorf("flag %s is required", CannonServerFlag.Name)
 	}
 	if !PreStatesURLFlag.IsSet(ctx, gameTypes.CannonGameType) && !ctx.IsSet(CannonPreStateFlag.Name) {
@@ -371,7 +371,7 @@ func CheckSuperCannonKonaFlags(ctx *cli.Context) error {
 	return nil
 }
 
-func CheckCannonFlags(ctx *cli.Context) error {
+func CheckCannonFlags(ctx *cli.Context, requireServer bool) error {
 	if err := checkOutputProviderFlags(ctx); err != nil {
 		return err
 	}
@@ -380,7 +380,7 @@ func CheckCannonFlags(ctx *cli.Context) error {
 		return fmt.Errorf("flag %v or %v and %v is required",
 			flags.NetworkFlagName, RollupConfigFlag.EitherFlagName(gameTypes.CannonGameType), L2GenesisFlag.EitherFlagName(gameTypes.CannonGameType))
 	}
-	if err := CheckCannonBaseFlags(ctx); err != nil {
+	if err := CheckCannonBaseFlags(ctx, requireServer); err != nil {
 		return err
 	}
 	return nil
@@ -431,7 +431,10 @@ func CheckRequired(ctx *cli.Context, types []gameTypes.GameType) error {
 	for _, gameType := range types {
 		switch gameType {
 		case gameTypes.CannonGameType, gameTypes.PermissionedGameType:
-			if err := CheckCannonFlags(ctx); err != nil {
+			// The permissioned game never reaches step() so does not run op-program; only the
+			// legacy Cannon game type requires the op-program server binary.
+			requireServer := slices.Contains(types, gameTypes.CannonGameType)
+			if err := CheckCannonFlags(ctx, requireServer); err != nil {
 				return err
 			}
 		case gameTypes.CannonKonaGameType:

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -62,19 +62,21 @@ type Config struct {
 	DepsetConfigPath  string
 }
 
-func (c *Config) Check() error {
+func (c *Config) Check(requireServer bool) error {
 	if c.VmBin == "" {
 		return ErrMissingBin
 	}
-	if c.Server == "" {
+	if requireServer && c.Server == "" {
 		return ErrMissingServer
 	}
 
 	if _, err := os.Stat(c.VmBin); err != nil {
 		return fmt.Errorf("%w: %w", ErrMissingBin, err)
 	}
-	if _, err := os.Stat(c.Server); err != nil {
-		return fmt.Errorf("%w: %w", ErrMissingServer, err)
+	if requireServer {
+		if _, err := os.Stat(c.Server); err != nil {
+			return fmt.Errorf("%w: %w", ErrMissingServer, err)
+		}
 	}
 
 	if len(c.Networks) == 0 {


### PR DESCRIPTION
The permissioned game type is played only by trusted actors and resolves at the output-root level without ever reaching `step()`, so it never runs op-program. This makes `--cannon-server` (and the runtime op-program server binary existence check) optional when only the permissioned game type is enabled, so a permissioned-only challenger no longer needs the op-program binary.

The legacy Cannon game type (0) still requires it (it does run op-program), and CannonKona is unaffected (kona-host stays required). Part of removing op-program from the monorepo (ethereum-optimism/optimism#20276).

Independent of the other op-program-removal PRs — based directly on `develop`.

Test plan: `go test ./op-challenger/config/... ./op-challenger/cmd/... ./op-challenger/game/fault/trace/vm/...` pass (added red/green cases asserting permissioned-only is valid without `--cannon-server` while the cannon type still rejects it, including the cannon+permissioned both-enabled case); `just lint-go` clean.