### PR TITLE
ci: force rebuild of ci-base-clang image

### DIFF
--- a/ops/docker/ci-base-clang/Dockerfile
+++ b/ops/docker/ci-base-clang/Dockerfile
@@ -1,5 +1,8 @@
 FROM cimg/base:2026.03
 
+# Rebuild marker: 2026-06-08 — force a fresh image so `apt-get upgrade` pulls
+# the latest base-image security updates.
+
 LABEL org.opencontainers.image.title="optimism ci-base clang"
 LABEL org.opencontainers.image.description="CircleCI base image with clang, llvm-dev, libclang-dev, and sccache preinstalled for Rust bindgen jobs"
 LABEL org.opencontainers.image.source="https://github.com/ethereum-optimism/optimism"


### PR DESCRIPTION
Adds a dated rebuild marker comment to the ci-base-clang Dockerfile so the image build — triggered by changes under `ops/docker/ci-base-clang/**` (.github/images.json) — runs again and `apt-get upgrade` picks up the latest base-image security updates.

No functional change to the image contents.