### PR TITLE
chore(rust): ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -20,6 +20,10 @@ ignore = [
   # hickory-proto <0.26.1 O(n^2) name-compression CPU exhaustion in BinEncoder;
   # transitive via reth-network -> reth-dns-discovery. Pending upstream bump.
   "RUSTSEC-2026-0119",
+  # proc-macro-error2 is unmaintained (no vulnerability, no patched release exists).
+  # Build-time-only dep pulled in via alloy-sol-macro; latest alloy-core (1.6.0) and
+  # its main branch still pin it (it uses a private API), so no upgrade removes it.
+  "RUSTSEC-2026-0173",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
`rust-deny` is currently failing on `develop` (and every open PR) with `advisories FAILED`: RUSTSEC-2026-0173 flags `proc-macro-error2 v2.0.1` as **unmaintained** — it is not a vulnerability, and the advisory itself states no safe upgrade exists.

The crate is a build-time-only proc-macro dependency pulled in solely via `alloy-sol-macro v1.6.0` (alloy-core). Both the latest published alloy-core (1.6.0) and its `main` branch still pin `proc-macro-error2` because they rely on its private `entry_point` API, so there is no upgrade path that removes it.

Fix: add a scoped advisory ignore in `rust/deny.toml`, consistent with the existing unmaintained/transitive ignores already there (paste, bincode, hickory-proto). Config-only — no `Cargo.lock` change.

Verified locally: `cargo deny --all-features check advisories` → `advisories ok` (was `advisories FAILED` before the change).