### PR TITLE
feat(kona-executor): make StatelessL2Builder/KonaExecutor generic over receipt builder

### DIFF
--- a/rust/alloy-op-evm/src/block/receipt_builder.rs
+++ b/rust/alloy-op-evm/src/block/receipt_builder.rs
@@ -1,8 +1,9 @@
 //! Abstraction over receipt building logic to allow plugging different primitive types into
 //! [`super::OpBlockExecutor`].
 
-use alloy_consensus::{Eip658Value, TransactionEnvelope};
+use alloy_consensus::{Eip658Value, TransactionEnvelope, TxReceipt};
 use alloy_evm::{Evm, eth::receipt_builder::ReceiptBuilderCtx};
+use alloy_primitives::Log;
 use core::fmt::Debug;
 use op_alloy::consensus::{OpDepositReceipt, OpReceiptEnvelope, OpTxEnvelope, OpTxType};
 
@@ -15,7 +16,12 @@ pub trait OpReceiptBuilder: Debug {
     /// upstream `TxResult` trait bound (`Self: Send + 'static`).
     type Transaction: TransactionEnvelope<TxType: Send + 'static>;
     /// Receipt type.
-    type Receipt;
+    ///
+    /// `TxReceipt<Log = Log> + Clone` is the bundle every downstream impl already satisfies, so
+    /// requiring it here lets `R::Receipt` bound lists drop those bounds. Sites that additionally
+    /// encode receipts (e.g. the receipts-root computation) keep `Encodable2718` as a call-site
+    /// bound — not every receipt builder's `Receipt` implements it.
+    type Receipt: TxReceipt<Log = Log> + Clone;
 
     /// Builds a receipt given a transaction and the result of the execution.
     ///
@@ -31,6 +37,16 @@ pub trait OpReceiptBuilder: Debug {
 
     /// Builds receipt for a deposit transaction.
     fn build_deposit_receipt(&self, inner: OpDepositReceipt) -> Self::Receipt;
+
+    /// Strips the deposit nonce from `receipt` if the receipt is a deposit variant that carries
+    /// one.
+    ///
+    /// Used by the executor's receipts-root computation to reproduce the op-geth/op-erigon
+    /// Regolith-era encoding bug, in which the deposit nonce is omitted from the receipts-trie
+    /// encoding from Regolith activation up to (but not including) Canyon activation. OP Stack
+    /// implementations clear the nonce; chains whose deposit receipt has no nonce field
+    /// implement this as a no-op.
+    fn strip_deposit_nonce(&self, receipt: &mut Self::Receipt);
 }
 
 /// Receipt builder operating on op-alloy types.
@@ -70,5 +86,11 @@ impl OpReceiptBuilder for OpAlloyReceiptBuilder {
 
     fn build_deposit_receipt(&self, inner: OpDepositReceipt) -> Self::Receipt {
         OpReceiptEnvelope::Deposit(inner.with_bloom())
+    }
+
+    fn strip_deposit_nonce(&self, receipt: &mut Self::Receipt) {
+        if let OpReceiptEnvelope::Deposit(d) = receipt {
+            d.receipt.deposit_nonce = None;
+        }
     }
 }

--- a/rust/kona/bin/client/src/interop/transition.rs
+++ b/rust/kona/bin/client/src/interop/transition.rs
@@ -146,6 +146,7 @@ where
         l2_provider.clone(),
         l2_provider,
         evm_factory,
+        OpAlloyReceiptBuilder::default(),
         None,
     );
     let mut driver = Driver::new(cursor, executor, pipeline);

--- a/rust/kona/bin/client/src/single.rs
+++ b/rust/kona/bin/client/src/single.rs
@@ -153,6 +153,7 @@ where
         l2_provider.clone(),
         l2_provider,
         evm_factory,
+        alloy_op_evm::block::OpAlloyReceiptBuilder::default(),
         None,
     );
     let mut driver = Driver::new(cursor, executor, pipeline);

--- a/rust/kona/bin/host/src/interop/handler.rs
+++ b/rust/kona/bin/host/src/interop/handler.rs
@@ -606,6 +606,7 @@ impl HintHandler for InteropHintHandler {
                             l2_provider.clone(),
                             l2_provider,
                             OpEvmFactory::<alloy_op_evm::OpTx>::default(),
+                            alloy_op_evm::block::OpAlloyReceiptBuilder::default(),
                             None,
                         );
                         let mut driver = Driver::new(cursor, executor, pipeline);

--- a/rust/kona/crates/proof/driver/src/core.rs
+++ b/rust/kona/crates/proof/driver/src/core.rs
@@ -73,7 +73,7 @@ where
     /// This cache contains the [`BlockBuildingOutcome`] and raw transaction data
     /// from the last successfully executed block. It's used for efficiency and
     /// debugging purposes. `None` when no block has been executed yet.
-    pub safe_head_artifacts: Option<(BlockBuildingOutcome, Vec<Bytes>)>,
+    pub safe_head_artifacts: Option<(BlockBuildingOutcome<E::Receipt>, Vec<Bytes>)>,
 }
 
 impl<E, DP, P> Driver<E, DP, P>

--- a/rust/kona/crates/proof/driver/src/executor.rs
+++ b/rust/kona/crates/proof/driver/src/executor.rs
@@ -31,6 +31,12 @@ pub trait Executor {
     /// execution failures, including transaction-level errors and state issues.
     type Error: Error;
 
+    /// The receipt type produced by this executor.
+    ///
+    /// Threaded through to [`BlockBuildingOutcome`] so non-OP chains that produce different
+    /// receipt envelopes (e.g. Celo's CIP-64 receipt) can carry their type out of the driver.
+    type Receipt;
+
     /// Waits for the executor to be ready for block execution.
     ///
     /// This method blocks until the executor has completed any necessary
@@ -80,7 +86,7 @@ pub trait Executor {
     async fn execute_payload(
         &mut self,
         attributes: OpPayloadAttributes,
-    ) -> Result<BlockBuildingOutcome, Self::Error>;
+    ) -> Result<BlockBuildingOutcome<Self::Receipt>, Self::Error>;
 
     /// Computes the output root for the most recently executed block.
     ///

--- a/rust/kona/crates/proof/executor/src/builder/assemble.rs
+++ b/rust/kona/crates/proof/executor/src/builder/assemble.rs
@@ -6,23 +6,25 @@ use crate::{
     util::{encode_holocene_eip_1559_params, encode_jovian_eip_1559_params},
 };
 use alloc::vec::Vec;
-use alloy_consensus::{EMPTY_OMMER_ROOT_HASH, Header, Sealed};
+use alloy_consensus::{EMPTY_OMMER_ROOT_HASH, Header, Sealed, TxReceipt};
 use alloy_eips::{Encodable2718, eip7685::EMPTY_REQUESTS_HASH};
 use alloy_evm::{EvmFactory, block::BlockExecutionResult};
+use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
 use alloy_primitives::{B256, Sealable, U256, logs_bloom};
 use alloy_trie::EMPTY_ROOT_HASH;
 use kona_genesis::RollupConfig;
 use kona_mpt::{TrieHinter, ordered_trie_with_encoder};
 use kona_protocol::{OutputRoot, Predeploys};
-use op_alloy_consensus::OpReceiptEnvelope;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use revm::{context::BlockEnv, database::BundleState};
 
-impl<P, H, Evm> StatelessL2Builder<'_, P, H, Evm>
+impl<P, H, Evm, R> StatelessL2Builder<'_, P, H, Evm, R>
 where
     P: TrieDBProvider,
     H: TrieHinter,
     Evm: EvmFactory,
+    R: OpReceiptBuilder,
+    R::Receipt: Encodable2718,
 {
     /// Seals the block executed from the given [`OpPayloadAttributes`] and [`BlockEnv`], returning
     /// the computed [Header].
@@ -31,7 +33,7 @@ where
         attrs: &OpPayloadAttributes,
         parent_hash: B256,
         block_env: &BlockEnv,
-        ex_result: &BlockExecutionResult<OpReceiptEnvelope>,
+        ex_result: &BlockExecutionResult<R::Receipt>,
         bundle: BundleState,
     ) -> ExecutorResult<Sealed<Header>> {
         let timestamp = block_env.timestamp.saturating_to::<u64>();
@@ -46,7 +48,12 @@ where
             |tx, buf| buf.put_slice(tx.as_ref()),
         )
         .root();
-        let receipts_root = compute_receipts_root(&ex_result.receipts, self.config, timestamp);
+        let receipts_root = compute_receipts_root(
+            self.factory.receipt_builder(),
+            &ex_result.receipts,
+            self.config,
+            timestamp,
+        );
         let withdrawals_root = if self.config.is_isthmus_active(timestamp) {
             Some(self.message_passer_account()?)
         } else if self.config.is_canyon_active(timestamp) {
@@ -168,25 +175,30 @@ where
 }
 
 /// Computes the receipts root from the given set of receipts.
-pub fn compute_receipts_root(
-    receipts: &[OpReceiptEnvelope],
+///
+/// Generic over the receipt builder so non-OP receipt shapes (e.g. Celo's CIP-64 receipt) can
+/// plug in their own [`OpReceiptBuilder`]. From Regolith activation up to (but not including)
+/// Canyon activation, op-geth/op-erigon compute the receipts-trie root from a deposit-receipt
+/// encoding that omits the deposit nonce; this function reproduces that encoding by delegating
+/// nonce-stripping to [`OpReceiptBuilder::strip_deposit_nonce`], which OP Stack implementations
+/// override and other chains inherit as a no-op.
+pub fn compute_receipts_root<R>(
+    receipt_builder: &R,
+    receipts: &[R::Receipt],
     config: &RollupConfig,
     timestamp: u64,
-) -> B256 {
-    // There is a minor bug in op-geth and op-erigon where in the Regolith hardfork,
-    // the receipt root calculation does not include the deposit nonce in the
-    // receipt encoding. In the Regolith hardfork, we must strip the deposit nonce
-    // from the receipt encoding to match the receipt root calculation.
+) -> B256
+where
+    R: OpReceiptBuilder,
+    R::Receipt: Encodable2718,
+{
     if config.is_regolith_active(timestamp) && !config.is_canyon_active(timestamp) {
         let receipts = receipts
             .iter()
             .cloned()
-            .map(|receipt| match receipt {
-                OpReceiptEnvelope::Deposit(mut deposit_receipt) => {
-                    deposit_receipt.receipt.deposit_nonce = None;
-                    OpReceiptEnvelope::Deposit(deposit_receipt)
-                }
-                _ => receipt,
+            .map(|mut receipt| {
+                receipt_builder.strip_deposit_nonce(&mut receipt);
+                receipt
             })
             .collect::<Vec<_>>();
 

--- a/rust/kona/crates/proof/executor/src/builder/core.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core.rs
@@ -7,20 +7,19 @@
 use crate::{ExecutorError, ExecutorResult, TrieDB, TrieDBError, TrieDBProvider};
 use alloc::{string::ToString, vec::Vec};
 use alloy_consensus::{Header, Sealed, crypto::RecoveryError};
+use alloy_eips::Encodable2718;
 use alloy_evm::{
     EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
     block::{BlockExecutionResult, BlockExecutor, BlockExecutorFactory},
 };
 use alloy_op_evm::{
     OpBlockExecutionCtx, OpBlockExecutorFactory, PostExecMode,
-    block::{OpAlloyReceiptBuilder, OpTxEnv},
+    block::{OpTxEnv, receipt_builder::OpReceiptBuilder},
 };
 use core::fmt::Debug;
 use kona_genesis::RollupConfig;
 use kona_mpt::TrieHinter;
-use op_alloy_consensus::{
-    OpReceiptEnvelope, OpTxEnvelope, parse_post_exec_payload_from_transactions,
-};
+use op_alloy_consensus::{OpTxEnvelope, parse_post_exec_payload_from_transactions};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use op_revm::OpSpecId;
 use revm::{
@@ -74,8 +73,11 @@ use revm::{
 /// * `P` - Trie database provider implementing [`TrieDBProvider`]
 /// * `H` - Trie hinter implementing [`TrieHinter`] for state access optimization
 /// * `Evm` - EVM factory implementing [`EvmFactory`] for execution environment creation
+/// * `R` - Receipt builder implementing [`OpReceiptBuilder`]. OP Stack callers pass
+///   `OpAlloyReceiptBuilder`; chains that produce non-`OpReceiptEnvelope` receipts (e.g. Celo's
+///   CIP-64 receipt) plug in their own builder.
 #[derive(Debug)]
-pub struct StatelessL2Builder<'a, P, H, Evm>
+pub struct StatelessL2Builder<'a, P, H, Evm, R>
 where
     P: TrieDBProvider,
     H: TrieHinter,
@@ -98,24 +100,26 @@ where
     /// This factory creates specialized OP Stack execution environments that
     /// understand OP-specific transaction types, system calls, and state
     /// management required for proper L2 block execution.
-    pub(crate) factory: OpBlockExecutorFactory<OpAlloyReceiptBuilder, RollupConfig, Evm>,
+    pub(crate) factory: OpBlockExecutorFactory<R, RollupConfig, Evm>,
     /// Test-only override for SDM activation while the fork is not yet scheduled.
     #[cfg(any(test, feature = "test-utils"))]
     pub(crate) sdm_active_override: Option<bool>,
 }
 
-impl<'a, P, H, Evm> StatelessL2Builder<'a, P, H, Evm>
+impl<'a, P, H, Evm, R> StatelessL2Builder<'a, P, H, Evm, R>
 where
     P: TrieDBProvider + Debug,
     H: TrieHinter + Debug,
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
-    OpBlockExecutorFactory<OpAlloyReceiptBuilder, RollupConfig, Evm>: for<'b> BlockExecutorFactory<
+    R: OpReceiptBuilder<Transaction = OpTxEnvelope> + 'static,
+    R::Receipt: Encodable2718,
+    OpBlockExecutorFactory<R, RollupConfig, Evm>: for<'b> BlockExecutorFactory<
             EvmFactory = Evm,
             ExecutionCtx<'b> = OpBlockExecutionCtx,
             Transaction = OpTxEnvelope,
-            Receipt = OpReceiptEnvelope,
+            Receipt = R::Receipt,
         >,
 {
     /// Creates a new stateless L2 block builder instance.
@@ -126,6 +130,7 @@ where
     /// # Arguments
     /// * `config` - Rollup configuration with chain parameters and activation heights
     /// * `evm_factory` - EVM factory for creating execution environments
+    /// * `receipt_builder` - Receipt builder selecting the receipt envelope shape
     /// * `provider` - Trie database provider for state access
     /// * `hinter` - Trie hinter for optimizing state access patterns
     /// * `parent_header` - Sealed header of the parent block to build upon
@@ -138,6 +143,7 @@ where
     /// let builder = StatelessL2Builder::new(
     ///     &rollup_config,
     ///     evm_factory,
+    ///     receipt_builder,
     ///     trie_provider,
     ///     trie_hinter,
     ///     parent_header,
@@ -146,16 +152,13 @@ where
     pub fn new(
         config: &'a RollupConfig,
         evm_factory: Evm,
+        receipt_builder: R,
         provider: P,
         hinter: H,
         parent_header: Sealed<Header>,
     ) -> Self {
         let trie_db = TrieDB::new(parent_header, provider, hinter);
-        let factory = OpBlockExecutorFactory::new(
-            OpAlloyReceiptBuilder::default(),
-            config.clone(),
-            evm_factory,
-        );
+        let factory = OpBlockExecutorFactory::new(receipt_builder, config.clone(), evm_factory);
         Self {
             config,
             trie_db,
@@ -245,7 +248,7 @@ where
     pub fn build_block(
         &mut self,
         attrs: OpPayloadAttributes,
-    ) -> ExecutorResult<BlockBuildingOutcome> {
+    ) -> ExecutorResult<BlockBuildingOutcome<R::Receipt>> {
         // Step 1. Set up the execution environment.
         let (base_fee_params, min_base_fee) = Self::active_base_fee_params(
             self.config,
@@ -342,18 +345,21 @@ where
 
 /// The outcome of a block building operation, returning the sealed block [`Header`] and the
 /// [`BlockExecutionResult`].
+///
+/// Generic over the receipt envelope so non-OP receipt shapes (e.g. CIP-64) can be carried out of
+/// the builder.
 #[derive(Debug, Clone)]
-pub struct BlockBuildingOutcome {
+pub struct BlockBuildingOutcome<Receipt> {
     /// The block header.
     pub header: Sealed<Header>,
     /// The block execution result.
-    pub execution_result: BlockExecutionResult<OpReceiptEnvelope>,
+    pub execution_result: BlockExecutionResult<Receipt>,
 }
 
-impl From<(Sealed<Header>, BlockExecutionResult<OpReceiptEnvelope>)> for BlockBuildingOutcome {
-    fn from(
-        (header, execution_result): (Sealed<Header>, BlockExecutionResult<OpReceiptEnvelope>),
-    ) -> Self {
+impl<Receipt> From<(Sealed<Header>, BlockExecutionResult<Receipt>)>
+    for BlockBuildingOutcome<Receipt>
+{
+    fn from((header, execution_result): (Sealed<Header>, BlockExecutionResult<Receipt>)) -> Self {
         Self { header, execution_result }
     }
 }

--- a/rust/kona/crates/proof/executor/src/builder/env.rs
+++ b/rust/kona/crates/proof/executor/src/builder/env.rs
@@ -23,7 +23,7 @@ use revm::{
     },
 };
 
-impl<P, H, Evm> StatelessL2Builder<'_, P, H, Evm>
+impl<P, H, Evm, R> StatelessL2Builder<'_, P, H, Evm, R>
 where
     P: TrieDBProvider,
     H: TrieHinter,

--- a/rust/kona/crates/proof/executor/src/test_utils.rs
+++ b/rust/kona/crates/proof/executor/src/test_utils.rs
@@ -59,13 +59,14 @@ pub async fn load_test_fixture(fixture_path: PathBuf) -> LoadedExecutorTestFixtu
 pub fn execute_loaded_fixture(
     loaded: LoadedExecutorTestFixture,
     sdm_active_override: Option<bool>,
-) -> ExecutorResult<BlockBuildingOutcome> {
+) -> ExecutorResult<BlockBuildingOutcome<op_alloy_consensus::OpReceiptEnvelope>> {
     let LoadedExecutorTestFixture { fixture_dir: _fixture_dir, fixture, provider } = loaded;
     let ExecutorTestFixture { rollup_config, parent_header, executing_payload, .. } = fixture;
 
     let mut executor = StatelessL2Builder::new(
         &rollup_config,
         OpEvmFactory::<alloy_op_evm::OpTx>::default(),
+        alloy_op_evm::block::OpAlloyReceiptBuilder::default(),
         provider,
         NoopTrieHinter,
         parent_header.seal_slow(),
@@ -212,6 +213,7 @@ impl ExecutorTestFixtureCreator {
         let mut executor = StatelessL2Builder::new(
             rollup_config,
             OpEvmFactory::<alloy_op_evm::OpTx>::default(),
+            alloy_op_evm::block::OpAlloyReceiptBuilder::default(),
             self,
             NoopTrieHinter,
             parent_header,

--- a/rust/kona/crates/proof/proof-interop/src/consolidation.rs
+++ b/rust/kona/crates/proof/proof-interop/src/consolidation.rs
@@ -261,6 +261,7 @@ where
             let mut executor = StatelessL2Builder::new(
                 rollup_config,
                 self.evm_factory.clone(),
+                OpAlloyReceiptBuilder::default(),
                 l2_provider.clone(),
                 l2_provider.clone(),
                 parent_header.seal_slow(),

--- a/rust/kona/crates/proof/proof/src/executor.rs
+++ b/rust/kona/crates/proof/proof/src/executor.rs
@@ -2,13 +2,14 @@
 
 use alloc::boxed::Box;
 use alloy_consensus::{Header, Sealed};
+use alloy_eips::Encodable2718;
 use alloy_evm::{
     EvmFactory, FromRecoveredTx, FromTxWithEncoded, block::BlockExecutorFactory,
     revm::context::BlockEnv,
 };
 use alloy_op_evm::{
     OpBlockExecutionCtx, OpBlockExecutorFactory,
-    block::{OpAlloyReceiptBuilder, OpTxEnv},
+    block::{OpTxEnv, receipt_builder::OpReceiptBuilder},
 };
 use alloy_primitives::B256;
 use async_trait::async_trait;
@@ -17,13 +18,17 @@ use kona_driver::Executor;
 use kona_executor::{BlockBuildingOutcome, StatelessL2Builder, TrieDBProvider};
 use kona_genesis::RollupConfig;
 use kona_mpt::TrieHinter;
-use op_alloy_consensus::{OpReceiptEnvelope, OpTxEnvelope};
+use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use op_revm::OpSpecId;
 
 /// An executor wrapper type.
+///
+/// `R` selects the [`OpReceiptBuilder`] used to assemble per-tx receipts. OP Stack callers pass
+/// `OpAlloyReceiptBuilder`; chains with different receipt envelopes (e.g. Celo's CIP-64 receipt)
+/// pass their own.
 #[derive(Debug)]
-pub struct KonaExecutor<'a, P, H, Evm>
+pub struct KonaExecutor<'a, P, H, Evm, R>
 where
     P: TrieDBProvider + Send + Sync + Clone,
     H: TrieHinter + Send + Sync + Clone,
@@ -37,11 +42,13 @@ where
     trie_hinter: H,
     /// The evm factory for the executor.
     evm_factory: Evm,
+    /// The receipt builder. Cloned into each stateless builder spun up at `update_safe_head`.
+    receipt_builder: R,
     /// The executor.
-    inner: Option<StatelessL2Builder<'a, P, H, Evm>>,
+    inner: Option<StatelessL2Builder<'a, P, H, Evm, R>>,
 }
 
-impl<'a, P, H, Evm> KonaExecutor<'a, P, H, Evm>
+impl<'a, P, H, Evm, R> KonaExecutor<'a, P, H, Evm, R>
 where
     P: TrieDBProvider + Send + Sync + Clone,
     H: TrieHinter + Send + Sync + Clone,
@@ -53,28 +60,32 @@ where
         trie_provider: P,
         trie_hinter: H,
         evm_factory: Evm,
-        inner: Option<StatelessL2Builder<'a, P, H, Evm>>,
+        receipt_builder: R,
+        inner: Option<StatelessL2Builder<'a, P, H, Evm, R>>,
     ) -> Self {
-        Self { rollup_config, trie_provider, trie_hinter, evm_factory, inner }
+        Self { rollup_config, trie_provider, trie_hinter, evm_factory, receipt_builder, inner }
     }
 }
 
 #[async_trait]
-impl<P, H, Evm> Executor for KonaExecutor<'_, P, H, Evm>
+impl<P, H, Evm, R> Executor for KonaExecutor<'_, P, H, Evm, R>
 where
     P: TrieDBProvider + Debug + Send + Sync + Clone,
     H: TrieHinter + Debug + Send + Sync + Clone,
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + Send + Sync + Clone + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
-    OpBlockExecutorFactory<OpAlloyReceiptBuilder, RollupConfig, Evm>: for<'b> BlockExecutorFactory<
+    R: OpReceiptBuilder<Transaction = OpTxEnvelope> + Clone + Send + Sync + 'static,
+    R::Receipt: Encodable2718 + Send + Sync + 'static,
+    OpBlockExecutorFactory<R, RollupConfig, Evm>: for<'b> BlockExecutorFactory<
             EvmFactory = Evm,
             ExecutionCtx<'b> = OpBlockExecutionCtx,
             Transaction = OpTxEnvelope,
-            Receipt = OpReceiptEnvelope,
+            Receipt = R::Receipt,
         >,
 {
     type Error = kona_executor::ExecutorError;
+    type Receipt = R::Receipt;
 
     /// Waits for the executor to be ready.
     async fn wait_until_ready(&mut self) {
@@ -90,6 +101,7 @@ where
         self.inner = Some(StatelessL2Builder::new(
             self.rollup_config,
             self.evm_factory.clone(),
+            self.receipt_builder.clone(),
             self.trie_provider.clone(),
             self.trie_hinter.clone(),
             header,
@@ -100,7 +112,7 @@ where
     async fn execute_payload(
         &mut self,
         attributes: OpPayloadAttributes,
-    ) -> Result<BlockBuildingOutcome, Self::Error> {
+    ) -> Result<BlockBuildingOutcome<R::Receipt>, Self::Error> {
         self.inner.as_mut().map_or_else(
             || Err(kona_executor::ExecutorError::MissingExecutor),
             |e| e.build_block(attributes),

--- a/rust/op-reth/crates/evm/src/receipts.rs
+++ b/rust/op-reth/crates/evm/src/receipts.rs
@@ -45,4 +45,10 @@ impl OpReceiptBuilder for OpRethReceiptBuilder {
     fn build_deposit_receipt(&self, inner: OpDepositReceipt) -> Self::Receipt {
         OpReceipt::Deposit(inner)
     }
+
+    fn strip_deposit_nonce(&self, receipt: &mut Self::Receipt) {
+        if let OpReceipt::Deposit(d) = receipt {
+            d.deposit_nonce = None;
+        }
+    }
 }


### PR DESCRIPTION
Parameterizes `StatelessL2Builder`, `KonaExecutor`, `BlockBuildingOutcome`, and `Executor::Receipt` over a receipt builder `R: OpReceiptBuilder`. In-tree call sites pass `OpAlloyReceiptBuilder::default()` so the OP path is byte-for-byte identical.

## Motivation

Celo (a downstream OP-Stack fork) needs to produce blocks whose receipts include a CIP-64 variant. The stateless executor currently pipes `OpReceiptEnvelope` through everywhere, so the only way to ship Celo's receipt envelope is to fork the entire builder + executor. This change swaps the concrete type for a single generic parameter.

## Trait extensions

`OpReceiptBuilder` gains:

* `strip_deposit_nonce(&self, receipt: &mut Self::Receipt)` — required (no default). Drives the Regolith receipts-root fixup that was previously inlined in `compute_receipts_root`. Required so any downstream implementor whose receipt envelope carries a deposit nonce is forced to confront the fixup at compile time rather than silently inherit a no-op.
* `type Receipt: TxReceipt<Log = Log> + Clone` — moves a bound bundle off every kona-executor impl site. `Encodable2718` stays as a call-site bound because not every impl's `Receipt` implements it.

## Compatibility

* No generic default on `R` — every caller is updated explicitly.
* Out-of-tree `OpReceiptBuilder` implementors need to add a `strip_deposit_nonce` impl.
* Out-of-tree `Executor` implementors need to add `type Receipt = ...;`.
* Wire formats are unchanged.

## Follow-up

The transaction side is still concrete (`Transaction = OpTxEnvelope`); parameterizing it is a separate change.