### PR TITLE
ci(contracts): remove Codecov upload step

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -82,7 +82,6 @@ orbs:
   gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@6.0.0
   shellcheck: circleci/shellcheck@3.2.0
-  codecov: codecov/codecov@5.0.3
   docker: circleci/docker@2.8.2
   github-cli: circleci/github-cli@2.7.0
 
@@ -1159,10 +1158,6 @@ jobs:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
           working_directory: packages/contracts-bedrock
           when: on_fail
-      - codecov/upload:
-          disable_search: true
-          files: ./packages/contracts-bedrock/lcov-all.info
-          flags: contracts-bedrock-tests
       - go-save-cache:
           namespace: contracts-bedrock-coverage
       - save_cache:


### PR DESCRIPTION
## Summary
- remove the contracts-bedrock Codecov upload step from the forge coverage job
- drop the unused Codecov CircleCI orb declaration
- keep the contracts-bedrock forge coverage job scheduled and required

## Test plan
- circleci config validate .circleci/config.yml --org-slug github/ethereum-optimism
- .circleci/scripts/merge-configs.sh
- circleci config validate /tmp/merged-config.yml --org-slug github/ethereum-optimism
- git diff --check HEAD^