### PR TITLE
chore(op-challenger): drop op-program from the op-challenger docker image

### DIFF
--- a/.github/images.json
+++ b/.github/images.json
@@ -39,14 +39,6 @@
       "target": "op-faucet",
       "paths": ["op-faucet/**"]
     },
-    "op-program": {
-      "type": "go",
-      "check": "go",
-      "mode": "bake",
-      "bake_file": "docker-bake.hcl",
-      "target": "op-program",
-      "paths": ["op-program/**", "op-preimage/**"]
-    },
     "op-proposer": {
       "type": "go",
       "check": "go",
@@ -61,7 +53,7 @@
       "mode": "bake",
       "bake_file": "docker-bake.hcl",
       "target": "op-challenger",
-      "paths": ["op-challenger/**", "op-program/**", "cannon/**", "op-preimage/**", "rust/kona/**"]
+      "paths": ["op-challenger/**", "cannon/**", "op-preimage/**", "rust/kona/**"]
     },
     "op-dispute-mon": {
       "type": "go",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -53,10 +53,6 @@ variable "OP_DISPUTE_MON_VERSION" {
   default = "${GIT_VERSION}"
 }
 
-variable "OP_PROGRAM_VERSION" {
-  default = "${GIT_VERSION}"
-}
-
 variable "OP_SUPERNODE_VERSION" {
   default = "${GIT_VERSION}"
 }
@@ -182,19 +178,6 @@ target "da-server" {
   target = "da-server-target"
   platforms = split(",", PLATFORMS)
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/da-server:${tag}"]
-}
-
-target "op-program" {
-  dockerfile = "ops/docker/op-stack-go/Dockerfile"
-  context = "."
-  args = {
-    GIT_COMMIT = "${GIT_COMMIT}"
-    GIT_DATE = "${GIT_DATE}"
-    OP_PROGRAM_VERSION = "${OP_PROGRAM_VERSION}"
-  }
-  target = "op-program-target"
-  platforms = split(",", PLATFORMS)
-  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-program:${tag}"]
 }
 
 target "op-supernode" {

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -286,9 +286,7 @@ CMD ["op-node"]
 FROM $UBUNTU_TARGET_BASE_IMAGE AS op-challenger-target
 RUN apt-get update && apt-get install -y --no-install-recommends musl openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=op-challenger-builder /app/op-challenger/bin/op-challenger /usr/local/bin/
-# Copy in op-program and cannon
-COPY --from=op-program-builder /app/op-program/bin/op-program /usr/local/bin/
-ENV OP_CHALLENGER_CANNON_SERVER=/usr/local/bin/op-program
+# Copy in cannon
 COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/
 ENV OP_CHALLENGER_CANNON_BIN=/usr/local/bin/cannon
 # Copy in kona-host (built from local kona/ source)

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -115,12 +115,6 @@ COPY --from=cannon-builder-v1-6-0 /usr/local/bin/cannon-7 ./cannon/multicannon/e
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   cd cannon && GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION" just cannon
 
-FROM --platform=$BUILDPLATFORM builder AS op-program-builder
-ARG OP_PROGRAM_VERSION=v0.0.0
-# note: we only build the host, that's all the user needs. No Go MIPS cross-build in docker
-RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
-  cd op-program && GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROGRAM_VERSION" just op-program-host
-
 FROM --platform=$BUILDPLATFORM builder AS op-wheel-builder
 ARG OP_WHEEL_VERSION=v0.0.0
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
@@ -266,11 +260,6 @@ USER 0
 COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/
 COPY --from=cannon-builder /app/cannon/multicannon/embeds/* /usr/local/bin/
 CMD ["cannon"]
-
-FROM $TARGET_BASE_IMAGE AS op-program-target
-USER 0
-COPY --from=op-program-builder /app/op-program/bin/op-program /usr/local/bin/
-CMD ["op-program"]
 
 FROM $TARGET_BASE_IMAGE AS op-wheel-target
 USER 0


### PR DESCRIPTION
The `op-challenger` docker image (`op-challenger-target` stage in `ops/docker/op-stack-go/Dockerfile`) bundled the op-program binary as the legacy cannon server:

```dockerfile
COPY --from=op-program-builder /app/op-program/bin/op-program /usr/local/bin/
ENV OP_CHALLENGER_CANNON_SERVER=/usr/local/bin/op-program
```

With op-program removed from the monorepo (ethereum-optimism/optimism#21271), that `COPY` can no longer build, breaking the op-challenger image. This drops the op-program `COPY` and the `OP_CHALLENGER_CANNON_SERVER` env.

The image still ships cannon (`OP_CHALLENGER_CANNON_BIN`) and kona-host (`OP_CHALLENGER_CANNON_KONA_SERVER` / `OP_CHALLENGER_ASTERISC_KONA_SERVER`) — which is what production fault proofs use. The legacy cannon game type (0) is no longer in use, and the permissioned game type never runs a fault-proof server (ethereum-optimism/optimism#21270).

Stacked on ethereum-optimism/optimism#21271. Image build is validated by the GitHub Actions `build-images` workflow (can't be built locally here).