### PR TITLE
chore: remove the op-program docker image

### DIFF
--- a/.github/images.json
+++ b/.github/images.json
@@ -39,14 +39,6 @@
       "target": "op-faucet",
       "paths": ["op-faucet/**"]
     },
-    "op-program": {
-      "type": "go",
-      "check": "go",
-      "mode": "bake",
-      "bake_file": "docker-bake.hcl",
-      "target": "op-program",
-      "paths": ["op-program/**", "op-preimage/**"]
-    },
     "op-proposer": {
       "type": "go",
       "check": "go",
@@ -61,7 +53,7 @@
       "mode": "bake",
       "bake_file": "docker-bake.hcl",
       "target": "op-challenger",
-      "paths": ["op-challenger/**", "op-program/**", "cannon/**", "op-preimage/**", "rust/kona/**"]
+      "paths": ["op-challenger/**", "cannon/**", "op-preimage/**", "rust/kona/**"]
     },
     "op-dispute-mon": {
       "type": "go",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -53,10 +53,6 @@ variable "OP_DISPUTE_MON_VERSION" {
   default = "${GIT_VERSION}"
 }
 
-variable "OP_PROGRAM_VERSION" {
-  default = "${GIT_VERSION}"
-}
-
 variable "OP_SUPERNODE_VERSION" {
   default = "${GIT_VERSION}"
 }
@@ -182,19 +178,6 @@ target "da-server" {
   target = "da-server-target"
   platforms = split(",", PLATFORMS)
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/da-server:${tag}"]
-}
-
-target "op-program" {
-  dockerfile = "ops/docker/op-stack-go/Dockerfile"
-  context = "."
-  args = {
-    GIT_COMMIT = "${GIT_COMMIT}"
-    GIT_DATE = "${GIT_DATE}"
-    OP_PROGRAM_VERSION = "${OP_PROGRAM_VERSION}"
-  }
-  target = "op-program-target"
-  platforms = split(",", PLATFORMS)
-  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-program:${tag}"]
 }
 
 target "op-supernode" {

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -115,12 +115,6 @@ COPY --from=cannon-builder-v1-6-0 /usr/local/bin/cannon-7 ./cannon/multicannon/e
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   cd cannon && GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION" just cannon
 
-FROM --platform=$BUILDPLATFORM builder AS op-program-builder
-ARG OP_PROGRAM_VERSION=v0.0.0
-# note: we only build the host, that's all the user needs. No Go MIPS cross-build in docker
-RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
-  cd op-program && GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROGRAM_VERSION" just op-program-host
-
 FROM --platform=$BUILDPLATFORM builder AS op-wheel-builder
 ARG OP_WHEEL_VERSION=v0.0.0
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
@@ -266,11 +260,6 @@ USER 0
 COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/
 COPY --from=cannon-builder /app/cannon/multicannon/embeds/* /usr/local/bin/
 CMD ["cannon"]
-
-FROM $TARGET_BASE_IMAGE AS op-program-target
-USER 0
-COPY --from=op-program-builder /app/op-program/bin/op-program /usr/local/bin/
-CMD ["op-program"]
 
 FROM $TARGET_BASE_IMAGE AS op-wheel-target
 USER 0


### PR DESCRIPTION
With op-program removed from the monorepo (ethereum-optimism/optimism#21271), the `op-program` docker image can no longer be built. Remove it everywhere it's defined:

- `.github/images.json`: drop the `op-program` image entry, and the stale `op-program/**` path from the op-challenger image's trigger paths.
- `docker-bake.hcl`: remove the `op-program` bake target and the now-unused `OP_PROGRAM_VERSION` variable.
- `ops/docker/op-stack-go/Dockerfile`: remove the `op-program-builder` and `op-program-target` build stages.

The op-challenger image stopped bundling op-program in the previous stacked PR (ethereum-optimism/optimism#21284), so removing the `op-program-builder` stage is now safe.

Stacked on ethereum-optimism/optimism#21284. Note: this touches `.github/images.json` — if merge/CI hits an access or review restriction on `.github`, that's expected and we'll route it through someone with the right authorization.