### PR TITLE
op-devstack: add controlled lifecycle support

### DIFF
--- a/op-devstack/devtest/common.go
+++ b/op-devstack/devtest/common.go
@@ -3,6 +3,7 @@ package devtest
 import (
 	"context"
 	"log/slog"
+	"strings"
 
 	"go.opentelemetry.io/otel/trace"
 
@@ -25,6 +26,7 @@ type CommonT interface {
 	SkipNow()
 
 	TempDir() string
+	TempDirWithPrefix(prefix string) string
 	Cleanup(fn func())
 	Log(args ...any)
 	Logf(format string, args ...any)
@@ -35,6 +37,15 @@ type CommonT interface {
 	Tracer() trace.Tracer
 	Ctx() context.Context
 	Require() *testreq.Assertions
+}
+
+func tempDirPattern(prefix string) string {
+	prefix = strings.NewReplacer("/", "-", "\\", "-", " ", "-", "_", "-").Replace(strings.TrimSpace(prefix))
+	prefix = strings.Trim(prefix, "-")
+	if prefix == "" {
+		prefix = "op-dev"
+	}
+	return prefix + "-*"
 }
 
 type testScopeCtxKeyType struct{}

--- a/op-devstack/devtest/package.go
+++ b/op-devstack/devtest/package.go
@@ -93,8 +93,12 @@ func (t *implP) SkipNow() {
 }
 
 func (t *implP) TempDir() string {
+	return t.TempDirWithPrefix("op-dev")
+}
+
+func (t *implP) TempDirWithPrefix(prefix string) string {
 	// The last "*" will be replaced with the random temp dir name
-	tempDir, err := os.MkdirTemp("", "op-dev-*")
+	tempDir, err := os.MkdirTemp("", tempDirPattern(prefix))
 	if err != nil {
 		t.Errorf("failed to create temp dir: %v", err)
 		t.FailNow()

--- a/op-devstack/devtest/testing.go
+++ b/op-devstack/devtest/testing.go
@@ -187,6 +187,23 @@ func (t *testingT) TempDir() string {
 	return t.t.TempDir()
 }
 
+func (t *testingT) TempDirWithPrefix(prefix string) string {
+	t.t.Helper()
+	tempDir, err := os.MkdirTemp("", tempDirPattern(prefix))
+	if err != nil {
+		t.Errorf("failed to create temp dir: %v", err)
+		t.FailNow()
+	}
+	require.NotEmpty(t, tempDir, "sanity check temp-dir path is not empty")
+	require.NotEqual(t, "/", tempDir, "sanity-check temp-dir is not root")
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.logger.Error("Failed to clean up temp dir", "dir", tempDir, "err", err)
+		}
+	})
+	return tempDir
+}
+
 func (t *testingT) Cleanup(fn func()) {
 	t.t.Cleanup(fn)
 }

--- a/op-devstack/dsl/l1_cl.go
+++ b/op-devstack/dsl/l1_cl.go
@@ -25,6 +25,10 @@ func (cl *L1CLNode) Escape() stack.L1CLNode {
 	return cl.inner
 }
 
+func (cl *L1CLNode) BeaconHTTPAddr() string {
+	return cl.inner.BeaconHTTPAddr()
+}
+
 func (cl *L1CLNode) Start() {
 	lifecycle, ok := cl.inner.(stack.Lifecycle)
 	cl.require.Truef(ok, "L1CL node %s is not lifecycle-controllable", cl.inner.Name())

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 	"github.com/ethereum/go-ethereum/common"
@@ -62,6 +63,14 @@ func (s *Supernode) Escape() stack.Supernode {
 // QueryAPI returns the supernode's query API
 func (s *Supernode) QueryAPI() apis.SupernodeQueryAPI {
 	return s.inner.QueryAPI()
+}
+
+func (s *Supernode) ClientRPC() opclient.RPC {
+	return s.inner.ClientRPC()
+}
+
+func (s *Supernode) UserRPC() string {
+	return s.inner.UserRPC()
 }
 
 // SuperRootAtTimestamp fetches the super-root at the given timestamp

--- a/op-devstack/presets/minimal_from_runtime.go
+++ b/op-devstack/presets/minimal_from_runtime.go
@@ -26,7 +26,7 @@ func minimalFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *Minimal
 		newKeyring(runtime.Keys, t.Require()),
 		l1Network,
 	)
-	l2EL := newL2ELFrontend(t, "sequencer", l2ChainID, runtime.L2EL.UserRPC(), runtime.L2EL.EngineRPC(), runtime.L2EL.JWTPath(), runtime.L2Network.RollupConfig())
+	l2EL := newL2ELFrontend(t, "sequencer", l2ChainID, runtime.L2EL.UserRPC(), runtime.L2EL.EngineRPC(), runtime.L2EL.JWTPath(), runtime.L2Network.RollupConfig(), runtime.L2EL)
 	l2CL := newL2CLFrontend(t, "sequencer", l2ChainID, runtime.L2CL.UserRPC(), runtime.L2CL)
 	l2CL.attachEL(l2EL)
 	l2Batcher := newL2BatcherFrontend(t, "main", l2ChainID, runtime.L2Batcher.UserRPC())

--- a/op-devstack/presets/rpc_frontends.go
+++ b/op-devstack/presets/rpc_frontends.go
@@ -1,7 +1,9 @@
 package presets
 
 import (
+	"context"
 	"crypto/ecdsa"
+	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -107,24 +109,30 @@ func newPresetL1ELNode(t devtest.T, name string, chainID eth.ChainID, rpcCl opcl
 
 type l1CLFrontend struct {
 	presetCommon
-	chainID   eth.ChainID
-	client    apis.BeaconClient
-	lifecycle stack.Lifecycle
+	chainID        eth.ChainID
+	beaconHTTPAddr string
+	client         apis.BeaconClient
+	lifecycle      stack.Lifecycle
 }
 
 var _ stack.L1CLNode = (*l1CLFrontend)(nil)
 
-func newPresetL1CLNode(t devtest.T, name string, chainID eth.ChainID, httpCl opclient.HTTP) *l1CLFrontend {
+func newPresetL1CLNode(t devtest.T, name string, chainID eth.ChainID, beaconHTTPAddr string, httpCl opclient.HTTP) *l1CLFrontend {
 	t = t.WithCtx(stack.ContextWithChainID(t.Ctx(), chainID))
 	return &l1CLFrontend{
-		presetCommon: newPresetCommon(t, name),
-		chainID:      chainID,
-		client:       sources.NewBeaconHTTPClient(httpCl),
+		presetCommon:   newPresetCommon(t, name),
+		chainID:        chainID,
+		beaconHTTPAddr: beaconHTTPAddr,
+		client:         sources.NewBeaconHTTPClient(httpCl),
 	}
 }
 
 func (r *l1CLFrontend) ChainID() eth.ChainID {
 	return r.chainID
+}
+
+func (r *l1CLFrontend) BeaconHTTPAddr() string {
+	return r.beaconHTTPAddr
 }
 
 func (r *l1CLFrontend) BeaconClient() apis.BeaconClient {
@@ -146,6 +154,7 @@ type l2ELFrontend struct {
 	l2Client       *sources.L2Client
 	l2EngineClient *sources.EngineClient
 	lifecycle      stack.Lifecycle
+	control        stack.ControlledLifecycle
 }
 
 var _ stack.L2ELNode = (*l2ELFrontend)(nil)
@@ -184,6 +193,24 @@ func (r *l2ELFrontend) Stop() {
 	r.lifecycle.Stop()
 }
 
+func (r *l2ELFrontend) StartControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("L2EL node %s is not controllable", r.Name())
+	}
+	return r.control.StartControlled(ctx)
+}
+
+func (r *l2ELFrontend) StopControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("L2EL node %s is not controllable", r.Name())
+	}
+	return r.control.StopControlled(ctx)
+}
+
+func (r *l2ELFrontend) Running() bool {
+	return r.control != nil && r.control.Running()
+}
+
 type l2CLFrontend struct {
 	presetCommon
 	chainID          eth.ChainID
@@ -195,6 +222,7 @@ type l2CLFrontend struct {
 	oprBuilderNodes  locks.RWMap[string, *oprBuilderFrontend]
 	userRPC          string
 	lifecycle        stack.Lifecycle
+	control          stack.ControlledLifecycle
 }
 
 var _ stack.L2CLNode = (*l2CLFrontend)(nil)
@@ -276,6 +304,24 @@ func (r *l2CLFrontend) Start() {
 func (r *l2CLFrontend) Stop() {
 	r.require().NotNil(r.lifecycle, "L2CL node %s is not lifecycle-controllable", r.Name())
 	r.lifecycle.Stop()
+}
+
+func (r *l2CLFrontend) StartControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("L2CL node %s is not controllable", r.Name())
+	}
+	return r.control.StartControlled(ctx)
+}
+
+func (r *l2CLFrontend) StopControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("L2CL node %s is not controllable", r.Name())
+	}
+	return r.control.StopControlled(ctx)
+}
+
+func (r *l2CLFrontend) Running() bool {
+	return r.control != nil && r.control.Running()
 }
 
 type l2BatcherFrontend struct {
@@ -429,20 +475,51 @@ func (r *rollupBoostFrontend) Stop() {
 
 type supernodeFrontend struct {
 	presetCommon
-	api apis.SupernodeQueryAPI
+	client  opclient.RPC
+	userRPC string
+	api     apis.SupernodeQueryAPI
+	control stack.ControlledLifecycle
 }
 
 var _ stack.Supernode = (*supernodeFrontend)(nil)
 
-func newPresetSupernode(t devtest.T, name string, rpcCl opclient.RPC) *supernodeFrontend {
+func newPresetSupernode(t devtest.T, name string, userRPC string, rpcCl opclient.RPC) *supernodeFrontend {
 	return &supernodeFrontend{
 		presetCommon: newPresetCommon(t, name),
+		client:       rpcCl,
+		userRPC:      userRPC,
 		api:          sources.NewSuperNodeClient(rpcCl),
 	}
 }
 
+func (r *supernodeFrontend) ClientRPC() opclient.RPC {
+	return r.client
+}
+
 func (r *supernodeFrontend) QueryAPI() apis.SupernodeQueryAPI {
 	return r.api
+}
+
+func (r *supernodeFrontend) UserRPC() string {
+	return r.userRPC
+}
+
+func (r *supernodeFrontend) StartControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("supernode %s is not controllable", r.Name())
+	}
+	return r.control.StartControlled(ctx)
+}
+
+func (r *supernodeFrontend) StopControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("supernode %s is not controllable", r.Name())
+	}
+	return r.control.StopControlled(ctx)
+}
+
+func (r *supernodeFrontend) Running() bool {
+	return r.control != nil && r.control.Running()
 }
 
 type conductorFrontend struct {

--- a/op-devstack/presets/superproofs_from_runtime.go
+++ b/op-devstack/presets/superproofs_from_runtime.go
@@ -24,7 +24,7 @@ func simpleInteropFromSupernodeProofsRuntime(t devtest.T, runtime *sysgo.MultiCh
 	t.Require().NotNil(chainB, "missing l2b superproofs chain")
 	twoL2, components := twoL2FromRuntime(t, runtime)
 
-	supernodeFrontend := newSupernodeFrontend(t, "supernode-two-l2-system", runtime.Supernode.UserRPC())
+	supernodeFrontend := newSupernodeFrontend(t, "supernode-two-l2-system", runtime.Supernode.UserRPC(), runtime.Supernode)
 	testSequencer := newTestSequencerFrontend(
 		t,
 		runtime.TestSequencer.Name,
@@ -113,7 +113,7 @@ func singleChainInteropFromSupernodeProofsRuntime(t devtest.T, runtime *sysgo.Mu
 		l2Chain.AddL2Challenger(newPresetL2Challenger(t, "main", l2ChainID, challengerCfg))
 	}
 
-	supernodeFrontend := newSupernodeFrontend(t, "supernode-single-system-proofs", runtime.Supernode.UserRPC())
+	supernodeFrontend := newSupernodeFrontend(t, "supernode-single-system-proofs", runtime.Supernode.UserRPC(), runtime.Supernode)
 	testSequencer := newTestSequencerFrontend(
 		t,
 		runtime.TestSequencer.Name,

--- a/op-devstack/presets/sysgo_runtime.go
+++ b/op-devstack/presets/sysgo_runtime.go
@@ -25,7 +25,7 @@ func newL1ELFrontend(t devtest.T, name string, chainID eth.ChainID, userRPC stri
 
 func newL1CLFrontend(t devtest.T, name string, chainID eth.ChainID, beaconHTTPAddr string, lifecycle ...stack.Lifecycle) *l1CLFrontend {
 	beaconCl := client.NewBasicHTTPClient(beaconHTTPAddr, t.Logger())
-	l1CL := newPresetL1CLNode(t, name, chainID, beaconCl)
+	l1CL := newPresetL1CLNode(t, name, chainID, beaconHTTPAddr, beaconCl)
 	if len(lifecycle) > 0 {
 		l1CL.lifecycle = lifecycle[0]
 	}
@@ -49,6 +49,9 @@ func newL2ELFrontend(t devtest.T, name string, chainID eth.ChainID, userRPC stri
 	l2EL := newPresetL2ELNode(t, name, chainID, userRPCCl, userRPC, engineRPCCl, rollupCfg)
 	if len(lifecycle) > 0 {
 		l2EL.lifecycle = lifecycle[0]
+		if control, ok := lifecycle[0].(stack.ControlledLifecycle); ok {
+			l2EL.control = control
+		}
 	}
 	return l2EL
 }
@@ -73,6 +76,9 @@ func newL2CLFrontend(t devtest.T, name string, chainID eth.ChainID, userRPC stri
 	l2CL := newPresetL2CLNode(t, name, chainID, rpcCl, userRPC)
 	if lifecycle, ok := any(node).(stack.Lifecycle); ok {
 		l2CL.lifecycle = lifecycle
+	}
+	if control, ok := any(node).(stack.ControlledLifecycle); ok {
+		l2CL.control = control
 	}
 	return l2CL
 }
@@ -122,11 +128,15 @@ func newRollupBoostFrontend(t devtest.T, name string, chainID eth.ChainID, userR
 	return rollupBoost
 }
 
-func newSupernodeFrontend(t devtest.T, name string, userRPC string) *supernodeFrontend {
+func newSupernodeFrontend(t devtest.T, name string, userRPC string, control ...stack.ControlledLifecycle) *supernodeFrontend {
 	rpcCl, err := client.NewRPC(t.Ctx(), t.Logger(), userRPC, client.WithLazyDial())
 	t.Require().NoError(err)
 	t.Cleanup(rpcCl.Close)
-	return newPresetSupernode(t, name, rpcCl)
+	supernode := newPresetSupernode(t, name, userRPC, rpcCl)
+	if len(control) > 0 {
+		supernode.control = control[0]
+	}
+	return supernode
 }
 
 func newConductorFrontend(t devtest.T, name string, chainID eth.ChainID, rpcEndpoint string) *conductorFrontend {

--- a/op-devstack/presets/twol2_from_runtime.go
+++ b/op-devstack/presets/twol2_from_runtime.go
@@ -115,7 +115,7 @@ func twoL2SupernodeInteropFromRuntime(t devtest.T, runtime *sysgo.MultiChainRunt
 	t.Require().NotNil(chainA.SupernodeCL, "missing l2a supernode CL")
 	t.Require().NotNil(chainB.SupernodeCL, "missing l2b supernode CL")
 
-	supernode := newSupernodeFrontend(t, "supernode-two-l2-system", runtime.Supernode.UserRPC())
+	supernode := newSupernodeFrontend(t, "supernode-two-l2-system", runtime.Supernode.UserRPC(), runtime.Supernode)
 	// The supernode VN drives its own EL, distinct from the sequencer's
 	// (joined only by L1 + P2P) in light-sequencer presets. In virtual-sequencer
 	// presets the supernode VN is itself the sequencer, so SupernodeEL == EL and

--- a/op-devstack/stack/l1_cl.go
+++ b/op-devstack/stack/l1_cl.go
@@ -11,5 +11,6 @@ type L1CLNode interface {
 	Common
 	ChainID() eth.ChainID
 
+	BeaconHTTPAddr() string
 	BeaconClient() apis.BeaconClient
 }

--- a/op-devstack/stack/lifecycle.go
+++ b/op-devstack/stack/lifecycle.go
@@ -1,6 +1,14 @@
 package stack
 
+import "context"
+
 type Lifecycle interface {
 	Start()
 	Stop()
+}
+
+type ControlledLifecycle interface {
+	StartControlled(ctx context.Context) error
+	StopControlled(ctx context.Context) error
+	Running() bool
 }

--- a/op-devstack/stack/supernode.go
+++ b/op-devstack/stack/supernode.go
@@ -2,12 +2,15 @@ package stack
 
 import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 )
 
 type Supernode interface {
 	Common
+	ClientRPC() client.RPC
 	QueryAPI() apis.SupernodeQueryAPI
+	UserRPC() string
 }
 
 // SupernodeTestControl is the integration-test surface on a running

--- a/op-devstack/sysgo/control_lifecycle.go
+++ b/op-devstack/sysgo/control_lifecycle.go
@@ -2,6 +2,7 @@ package sysgo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -11,18 +12,29 @@ const (
 	controlledKillWait      = 5 * time.Second
 )
 
-func controlCall(fn func()) (err error) {
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			if recoveredErr, ok := recovered.(error); ok {
-				err = recoveredErr
+func controlCall(fn func()) error {
+	result := make(chan error, 1)
+	// Run fn in its own goroutine so runtime.Goexit, e.g. from FailNow, can be reported.
+	go func() {
+		completed := false
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				if recoveredErr, ok := recovered.(error); ok {
+					result <- recoveredErr
+					return
+				}
+				result <- fmt.Errorf("control operation failed: %v", recovered)
 				return
 			}
-			err = fmt.Errorf("control operation failed: %v", recovered)
-		}
+			if !completed {
+				result <- errors.New("control operation failed: function exited without returning; did it call runtime.Goexit or FailNow?")
+			}
+		}()
+		fn()
+		completed = true
+		result <- nil
 	}()
-	fn()
-	return nil
+	return <-result
 }
 
 func runControlStart(ctx context.Context, running func() bool, start func()) error {

--- a/op-devstack/sysgo/control_lifecycle.go
+++ b/op-devstack/sysgo/control_lifecycle.go
@@ -1,0 +1,38 @@
+package sysgo
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const (
+	controlledInterruptWait = 10 * time.Second
+	controlledKillWait      = 5 * time.Second
+)
+
+func controlCall(fn func()) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if recoveredErr, ok := recovered.(error); ok {
+				err = recoveredErr
+				return
+			}
+			err = fmt.Errorf("control operation failed: %v", recovered)
+		}
+	}()
+	fn()
+	return nil
+}
+
+func runControlStart(ctx context.Context, running func() bool, start func()) error {
+	if running() {
+		return fmt.Errorf("service is already running")
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	return controlCall(start)
+}

--- a/op-devstack/sysgo/interop_filter.go
+++ b/op-devstack/sysgo/interop_filter.go
@@ -101,7 +101,7 @@ func startInteropFilter(
 	cfg := &filter.Config{
 		L2RPCs:              l2RPCs,
 		RollupConfigs:       rollupConfigs,
-		DataDir:             t.TempDir(),
+		DataDir:             t.TempDirWithPrefix(name),
 		BackfillDuration:    30 * time.Second,
 		MessageExpiryWindow: 7 * 24 * 3600, // 7 days in seconds
 		PollInterval:        500 * time.Millisecond,

--- a/op-devstack/sysgo/l1_runtime.go
+++ b/op-devstack/sysgo/l1_runtime.go
@@ -24,7 +24,7 @@ const DevstackL1ELKindEnvVar = "DEVSTACK_L1EL_KIND"
 const GethExecPathEnvVar = "SYSGO_GETH_EXEC_PATH"
 
 func writeJWTSecret(t devtest.T) (string, [32]byte) {
-	jwtPath := filepath.Join(t.TempDir(), "jwt_secret")
+	jwtPath := filepath.Join(t.TempDirWithPrefix("jwt-secret"), "jwt_secret")
 	jwtSecret := [32]byte{123}
 	err := os.WriteFile(jwtPath, []byte(hexutil.Encode(jwtSecret[:])), 0o600)
 	t.Require().NoError(err, "failed to write jwt secret")
@@ -47,7 +47,7 @@ func startInProcessL1WithClockConfig(t devtest.T, l1Net *L1Network, jwtPath stri
 	require := t.Require()
 	l1ChainID := l1Net.ChainID()
 
-	blobPath := t.TempDir()
+	blobPath := t.TempDirWithPrefix("l1-el")
 	bcn := fakebeacon.NewBeacon(t.Logger().New("component", "l1cl"), blobstore.New(), l1Net.genesis.Timestamp, l1Net.blockTime)
 	t.Cleanup(func() {
 		_ = bcn.Close()
@@ -103,7 +103,7 @@ func startSubprocessL1WithClock(t devtest.T, l1Net *L1Network, jwtPath string, l
 	_, err := os.Stat(execPath)
 	require.NotErrorIs(err, os.ErrNotExist, "geth executable must exist")
 
-	tempDir := t.TempDir()
+	tempDir := t.TempDirWithPrefix("l1-el")
 	data, err := json.Marshal(l1Net.genesis)
 	require.NoError(err, "must json-encode genesis")
 	chainConfigPath := filepath.Join(tempDir, "genesis.json")

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -1,6 +1,7 @@
 package sysgo
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -131,6 +132,29 @@ func (k *KonaNode) Stop() {
 	err := k.sub.Stop(true)
 	k.p.Require().NoError(err, "Must stop")
 	k.sub = nil
+}
+
+func (k *KonaNode) StartControlled(ctx context.Context) error {
+	return runControlStart(ctx, k.Running, k.Start)
+}
+
+func (k *KonaNode) StopControlled(ctx context.Context) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.sub == nil {
+		return nil
+	}
+	if err := k.sub.StopControlled(ctx, controlledInterruptWait, controlledKillWait); err != nil {
+		return err
+	}
+	k.sub = nil
+	return nil
+}
+
+func (k *KonaNode) Running() bool {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.sub != nil
 }
 
 func (k *KonaNode) UserRPC() string {

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -85,3 +85,35 @@ func (n *OpNode) Stop() {
 
 	n.opNode = nil
 }
+
+func (n *OpNode) StartControlled(ctx context.Context) error {
+	return runControlStart(ctx, n.Running, n.Start)
+}
+
+func (n *OpNode) StopControlled(ctx context.Context) error {
+	n.mu.Lock()
+	if n.opNode == nil {
+		n.mu.Unlock()
+		return nil
+	}
+	opNode := n.opNode
+	n.mu.Unlock()
+
+	err := opNode.Stop(ctx)
+	if err != nil && !opNode.Stopped() {
+		return err
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.opNode == opNode {
+		n.opNode = nil
+	}
+	return nil
+}
+
+func (n *OpNode) Running() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.opNode != nil
+}

--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -91,6 +91,45 @@ func (n *SuperNode) Stop() {
 	n.stopLocked()
 }
 
+func (n *SuperNode) StartControlled(ctx context.Context) error {
+	return runControlStart(ctx, n.Running, n.Start)
+}
+
+func (n *SuperNode) StopControlled(ctx context.Context) error {
+	n.mu.Lock()
+	if n.sn == nil {
+		n.mu.Unlock()
+		return nil
+	}
+	sn := n.sn
+	cancel := n.cancel
+	n.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if err := sn.Stop(ctx); err != nil {
+		return err
+	}
+	if !sn.Stopped() {
+		return fmt.Errorf("supernode stop did not confirm all goroutines exited")
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.sn == sn {
+		n.sn = nil
+		n.cancel = nil
+	}
+	return nil
+}
+
+func (n *SuperNode) Running() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.sn != nil
+}
+
 // stopLocked tears down the supernode instance, leaving httpProxy in place
 // so a later startLocked can repoint it. Caller must hold n.mu.
 func (n *SuperNode) stopLocked() {

--- a/op-devstack/sysgo/l2_el_opgeth.go
+++ b/op-devstack/sysgo/l2_el_opgeth.go
@@ -1,6 +1,7 @@
 package sysgo
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"sync"
@@ -141,4 +142,35 @@ func (n *OpGeth) Stop() {
 	closeErr := n.l2Geth.Close()
 	n.logger.Info("Closed op-geth", "name", n.name, "chain", n.l2Net.ChainID(), "err", closeErr)
 	n.l2Geth = nil
+}
+
+func (n *OpGeth) StartControlled(ctx context.Context) error {
+	return runControlStart(ctx, n.Running, n.Start)
+}
+
+func (n *OpGeth) StopControlled(ctx context.Context) error {
+	n.mu.Lock()
+	if n.l2Geth == nil {
+		n.mu.Unlock()
+		return nil
+	}
+	l2Geth := n.l2Geth
+	n.mu.Unlock()
+
+	if err := l2Geth.Close(); err != nil {
+		return err
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.l2Geth == l2Geth {
+		n.l2Geth = nil
+	}
+	return nil
+}
+
+func (n *OpGeth) Running() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.l2Geth != nil
 }

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -1,6 +1,7 @@
 package sysgo
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -209,6 +210,29 @@ func (n *OpReth) Stop() {
 	err := n.sub.Stop(true)
 	n.p.Require().NoError(err, "Must stop")
 	n.sub = nil
+}
+
+func (n *OpReth) StartControlled(ctx context.Context) error {
+	return runControlStart(ctx, n.Running, n.Start)
+}
+
+func (n *OpReth) StopControlled(ctx context.Context) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.sub == nil {
+		return nil
+	}
+	if err := n.sub.StopControlled(ctx, controlledInterruptWait, controlledKillWait); err != nil {
+		return err
+	}
+	n.sub = nil
+	return nil
+}
+
+func (n *OpReth) Running() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.sub != nil
 }
 
 func (n *OpReth) UserRPC() string {

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -341,7 +341,7 @@ func buildMixedOpRethNode(
 	storageVersion string,
 	opts ...OpRethOption,
 ) *OpReth {
-	tempDir := t.TempDir()
+	tempDir := t.TempDirWithPrefix("l2-el-" + NewComponentTarget(key, l2Net.ChainID()).String())
 
 	data, err := json.Marshal(l2Net.genesis)
 	t.Require().NoError(err, "must json-encode genesis")
@@ -515,7 +515,7 @@ func startMixedKonaNode(
 	metricsRegistrar L2MetricsRegistrar,
 	depSet coredepset.DependencySet,
 ) *KonaNode {
-	tempKonaDir := t.TempDir()
+	tempKonaDir := t.TempDirWithPrefix("l2-cl-kona-" + NewComponentTarget(clKey, l2Net.ChainID()).String())
 
 	tempP2PPath := filepath.Join(tempKonaDir, "p2pkey.txt")
 

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -272,7 +272,7 @@ func startInteropChallenger(
 	}
 	cfg, err := sharedchallenger.NewInteropChallengerConfig(
 		t.Ctx(),
-		t.TempDir(),
+		t.TempDirWithPrefix("super-challenger"),
 		l1EL.UserRPC(),
 		l1CL.beaconHTTPAddr,
 		superRPC,

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -639,7 +639,7 @@ func startTwoL2SharedSupernode(
 
 	snCfg := &snconfig.CLIConfig{
 		Chains:                     chainIDs,
-		DataDir:                    t.TempDir(),
+		DataDir:                    t.TempDirWithPrefix("supernode"),
 		L1NodeAddr:                 l1EL.UserRPC(),
 		L1HTTPPollInterval:         100 * time.Millisecond,
 		L1BeaconAddr:               l1CL.beaconHTTPAddr,
@@ -749,7 +749,7 @@ func startSingleChainSharedSupernode(
 
 	snCfg := &snconfig.CLIConfig{
 		Chains:                     []uint64{eth.EvilChainIDToUInt64(l2Net.ChainID())},
-		DataDir:                    t.TempDir(),
+		DataDir:                    t.TempDirWithPrefix("supernode"),
 		L1NodeAddr:                 l1EL.UserRPC(),
 		L1HTTPPollInterval:         100 * time.Millisecond,
 		L1BeaconAddr:               l1CL.beaconHTTPAddr,

--- a/op-devstack/sysgo/op_rbuilder.go
+++ b/op-devstack/sysgo/op_rbuilder.go
@@ -168,7 +168,7 @@ func (cfg *OPRBuilderNodeConfig) LaunchSpec(p devtest.CommonT) (args []string, e
 		key := strings.TrimPrefix(cfg.P2PNodeKeyHex, "0x")
 		_, err := hex.DecodeString(key)
 		p.Require().NoError(err, "decode p2p node key")
-		keyPath := filepath.Join(p.TempDir(), "oprbuilder-nodekey")
+		keyPath := filepath.Join(p.TempDirWithPrefix("op-rbuilder"), "oprbuilder-nodekey")
 		p.Require().NoError(os.WriteFile(keyPath, []byte(key), 0o600), "write p2p node key")
 		args = append(args, "--p2p-secret-key", keyPath)
 	}

--- a/op-devstack/sysgo/singlechain_flashblocks.go
+++ b/op-devstack/sysgo/singlechain_flashblocks.go
@@ -76,7 +76,7 @@ func startBuilderEL(t devtest.T, l2Net *L2Network, jwtPath string, identity *ELN
 
 	data, err := json.Marshal(l2Net.genesis)
 	require.NoError(err, "must json-encode L2 genesis")
-	chainConfigPath := filepath.Join(t.TempDir(), "op-rbuilder-genesis.json")
+	chainConfigPath := filepath.Join(t.TempDirWithPrefix("op-rbuilder"), "op-rbuilder-genesis.json")
 	require.NoError(os.WriteFile(chainConfigPath, data, 0o644), "must write op-rbuilder genesis file")
 
 	cfg := DefaultOPRbuilderNodeConfig()

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -378,7 +378,7 @@ func startMinimalChallenger(
 	}
 	cfg, err := sharedchallenger.NewPreInteropChallengerConfig(
 		t.Ctx(),
-		t.TempDir(),
+		t.TempDirWithPrefix("l2-challenger-"+l2Net.ChainID().String()),
 		l1EL.UserRPC(),
 		l1CL.beaconHTTPAddr,
 		l2CL.UserRPC(),

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -265,7 +265,7 @@ func startConductorNode(
 		ConsensusPort:           0,
 		ConsensusAdvertisedAddr: "",
 		RaftServerID:            serverID,
-		RaftStorageDir:          filepath.Join(t.TempDir(), "raft"),
+		RaftStorageDir:          filepath.Join(t.TempDirWithPrefix("op-conductor-"+NewComponentTarget(conductorName, l2Net.ChainID()).String()), "raft"),
 		RaftBootstrap:           bootstrap,
 		RaftSnapshotInterval:    120 * time.Second,
 		RaftSnapshotThreshold:   8192,

--- a/op-devstack/sysgo/subproc.go
+++ b/op-devstack/sysgo/subproc.go
@@ -1,11 +1,13 @@
 package sysgo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"sync"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-service/logpipe"
@@ -65,7 +67,7 @@ func (sp *SubProcess) Start(cmdPath string, args []string, env []string) error {
 	// without racing a second Wait() in Stop(). cmd.Wait() also blocks until stdout/stderr
 	// have been fully copied, so all log output is flushed by the time exited is closed.
 	go func() {
-		sp.waitErr = sp.cmd.Wait()
+		sp.waitErr = cmd.Wait()
 		close(sp.exited)
 	}()
 	sp.p.Cleanup(func() {
@@ -88,11 +90,20 @@ func (sp *SubProcess) Exited() <-chan struct{} {
 // Stop waits for the process to stop, interrupting the process if it has not completed and
 // interrupt is true.
 func (sp *SubProcess) Stop(interrupt bool) error {
+	return sp.stop(context.Background(), interrupt, 0, 0)
+}
+
+func (sp *SubProcess) StopControlled(ctx context.Context, interruptWait time.Duration, killWait time.Duration) error {
+	return sp.stop(ctx, true, interruptWait, killWait)
+}
+
+func (sp *SubProcess) stop(ctx context.Context, interrupt bool, interruptWait time.Duration, killWait time.Duration) error {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 	if sp.cmd == nil {
 		return nil // already stopped gracefully
 	}
+	cmd := sp.cmd
 
 	// If the process is still running, request an interrupt as requested. We avoid
 	// reading sp.cmd.ProcessState here since the Wait() goroutine writes it; instead
@@ -113,8 +124,25 @@ func (sp *SubProcess) Stop(interrupt bool) error {
 
 	// Wait for the Wait() goroutine to report the exit. cmd.Wait() (run there) blocks
 	// until all stdout/stderr data is flushed, so log output is complete before we return.
-	<-sp.exited
-	waitErr := sp.waitErr
+	ok := waitProcess(ctx, sp.exited, interruptWait)
+	if !ok {
+		if err := cmd.Process.Kill(); err != nil {
+			ok = waitProcess(ctx, sp.exited, killWait)
+			if !ok {
+				return fmt.Errorf("interrupt timed out and kill failed: %w", err)
+			}
+			return sp.completeStopLocked(interrupt, sp.waitErr)
+		}
+		ok = waitProcess(ctx, sp.exited, killWait)
+		if !ok {
+			return fmt.Errorf("process did not stop after interrupt and kill")
+		}
+	}
+
+	return sp.completeStopLocked(interrupt, sp.waitErr)
+}
+
+func (sp *SubProcess) completeStopLocked(interrupt bool, waitErr error) error {
 	var exitErr *exec.ExitError
 	if waitErr != nil && !(interrupt && errors.As(waitErr, &exitErr)) {
 		sp.p.Logger().Warn("Sub-process exited with error", "err", waitErr)
@@ -134,4 +162,25 @@ func (sp *SubProcess) Stop(interrupt bool) error {
 	}
 	sp.cmd = nil
 	return nil
+}
+
+func waitProcess(ctx context.Context, exited <-chan struct{}, timeout time.Duration) bool {
+	if timeout <= 0 {
+		select {
+		case <-exited:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-exited:
+		return true
+	case <-timer.C:
+		return false
+	case <-ctx.Done():
+		return false
+	}
 }

--- a/op-devstack/sysgo/subproc_test.go
+++ b/op-devstack/sysgo/subproc_test.go
@@ -3,6 +3,7 @@ package sysgo
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -43,6 +44,46 @@ func TestSubProcess(gt *testing.T) {
 	gt.Log("Second run of different command")
 	capt.Clear()
 	testEcho(gt, capt, sp)
+}
+
+func TestSubProcessConcurrentStop(gt *testing.T) {
+	tLog := testlog.Logger(gt, log.LevelInfo)
+	logger, _ := testlog.CaptureLogger(gt, log.LevelInfo)
+
+	onFailNow := func(v bool) {
+		panic("fail")
+	}
+	onSkipNow := func() {
+		panic("skip")
+	}
+	p := devtest.NewP(context.Background(), logger, onFailNow, onSkipNow)
+	gt.Cleanup(p.Close)
+
+	logCallback := logpipe.LogCallback(func(line []byte) {
+		logger.Info(string(line))
+		tLog.Info("Sub-process logged message", "line", string(line))
+	})
+	sp := NewSubProcess(p, logCallback, logCallback)
+
+	require.NoError(gt, sp.Start("/bin/sh", []string{"-c", "trap '' INT; exec /bin/sleep 10000000000"}, []string{}))
+
+	start := make(chan struct{})
+	errCh := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			<-start
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			errCh <- sp.StopControlled(ctx, 100*time.Millisecond, time.Second)
+		}()
+	}
+	close(start)
+
+	require.NoError(gt, <-errCh)
+	require.NoError(gt, <-errCh)
+
+	require.NoError(gt, sp.Start("/bin/echo", []string{"restart ok"}, []string{}))
+	require.NoError(gt, sp.Stop(false))
 }
 
 // testEcho tests that we can handle a sub-process that completes on its own

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
@@ -33,7 +34,7 @@ type Supernode struct {
 	log         gethlog.Logger
 	version     string
 	requestStop context.CancelCauseFunc
-	stopped     bool
+	stopped     atomic.Bool
 	cfg         *config.CLIConfig
 	chains      map[eth.ChainID]cc.InteropChain
 	// activitiesMu guards reads and writes of the activities slice.
@@ -282,7 +283,7 @@ func (s *Supernode) Start(ctx context.Context) error {
 
 func (s *Supernode) Stop(ctx context.Context) error {
 	s.log.Info("supernode stopping")
-	s.stopped = true
+	s.stopped.Store(false)
 
 	// Cancel the lifecycle context before anything else. This guarantees that
 	// activity and chain goroutines will observe a canceled context even if
@@ -351,6 +352,9 @@ func (s *Supernode) Stop(ctx context.Context) error {
 	select {
 	case <-wgDone:
 		s.log.Info("goroutines finished, closing l1 client")
+		s.stopped.Store(true)
+	case <-ctx.Done():
+		s.log.Error("context canceled while waiting for chain goroutines to finish, proceeding with cleanup", "err", ctx.Err())
 	case <-time.After(60 * time.Second):
 		s.log.Error("timed out waiting for chain goroutines to finish after 60s, proceeding with cleanup")
 	}
@@ -379,7 +383,7 @@ func (s *Supernode) onChainReset(chainID eth.ChainID, timestamp uint64, invalida
 	}
 }
 
-func (s *Supernode) Stopped() bool { return s.stopped }
+func (s *Supernode) Stopped() bool { return s.stopped.Load() }
 
 // RPCAddr returns the bound RPC address (host:port) if the server is listening.
 // ok is false if the listener has not been created yet.

--- a/op-up/main.go
+++ b/op-up/main.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"slices"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -641,7 +642,17 @@ func (t *testingT) Skipped() bool {
 
 // TempDir implements devtest.T.
 func (t *testingT) TempDir() string {
-	dir, err := os.MkdirTemp(t.state.tempRoot, "op-up-*")
+	return t.TempDirWithPrefix("op-up")
+}
+
+// TempDirWithPrefix implements devtest.T.
+func (t *testingT) TempDirWithPrefix(prefix string) string {
+	prefix = strings.NewReplacer("/", "-", "\\", "-", " ", "-", "_", "-").Replace(strings.TrimSpace(prefix))
+	prefix = strings.Trim(prefix, "-")
+	if prefix == "" {
+		prefix = "op-up"
+	}
+	dir, err := os.MkdirTemp(t.state.tempRoot, prefix+"-*")
 	if err != nil {
 		t.failf("failed to create temp dir: %v", err)
 	}

--- a/rust/kona/tests/node/utils/package_scope.go
+++ b/rust/kona/tests/node/utils/package_scope.go
@@ -67,6 +67,10 @@ func (t *packageScopeT) TempDir() string {
 	return t.p.TempDir()
 }
 
+func (t *packageScopeT) TempDirWithPrefix(prefix string) string {
+	return t.p.TempDirWithPrefix(prefix)
+}
+
 func (t *packageScopeT) Cleanup(fn func()) {
 	t.p.Cleanup(fn)
 }


### PR DESCRIPTION
## Summary

Adds controlled lifecycle support to `op-devstack` so external callers can start and stop selected devstack services with error-returning semantics instead of test-style `Require()` failures.

This is intended to support higher-level tooling like `op-up control` (see https://github.com/ethereum-optimism/optimism/pull/21315), where a CLI needs to stop/restart devnet services safely and report failures without crashing the parent process.


## What Changed

- Adds `stack.ControlledLifecycle` with:
  - `StartControlled(ctx)`
  - `StopControlled(ctx)`

- Adds controlled lifecycle implementations for:
  - `op-geth`
  - `op-reth`
  - `op-node`
  - `kona-node`
  - `op-supernode`

- Adds subprocess controlled-stop support:
  - interrupt first
  - wait for a bounded period
  - kill fallback
  - wait for confirmed process exit

- Keeps existing devstack test APIs compatible:
  - existing `Start()` / `Stop()` behavior remains available
  - controlled APIs return errors instead of calling `Require()`

- Wires controlled lifecycle through preset RPC frontends where applicable.

## Intended Semantics

The important guarantee is that callers can distinguish a confirmed stop from a failed or unconfirmed stop.

A service should only be considered stopped once the underlying process or in-process service has actually stopped. If stop confirmation fails, callers can preserve the old handle and avoid accidentally starting a duplicate service instance.