### PR TITLE
test(sdm): run SDM PostExec derivation suite on kona-node

### DIFF
--- a/op-acceptance-tests/tests/sdm/init_test.go
+++ b/op-acceptance-tests/tests/sdm/init_test.go
@@ -62,20 +62,24 @@ func newSDMRethSystemWithInteropOffset(
 func buildSDMRethSystem(t devtest.T, interopAtGenesis bool, deployerOpts []sysgo.DeployerOption, batcherOpts ...sysgo.BatcherOption) *sdmRethSystem {
 	sysgo.SkipOnOpGeth(t, "SDM acceptance tests require op-reth post-exec support")
 
+	// Honor DEVSTACK_L2CL_KIND so the kona acceptance suite exercises this test with
+	// kona-node on both the sequencer and verifier (defaults to op-node when unset).
+	clKind := sysgo.ResolveMixedL2CLKind()
+
 	runtime := sysgo.NewMixedSingleChainRuntime(t, sysgo.MixedSingleChainPresetConfig{
 		NodeSpecs: []sysgo.MixedSingleChainNodeSpec{
 			{
 				ELKey:       "sequencer-op-reth",
 				CLKey:       "sequencer",
 				ELKind:      sysgo.MixedL2ELOpReth,
-				CLKind:      sysgo.MixedL2CLOpNode,
+				CLKind:      clKind,
 				IsSequencer: true,
 			},
 			{
 				ELKey:       "verifier-op-reth",
 				CLKey:       "verifier",
 				ELKind:      sysgo.MixedL2ELOpReth,
-				CLKind:      sysgo.MixedL2CLOpNode,
+				CLKind:      clKind,
 				IsSequencer: false,
 			},
 		},

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -93,8 +93,22 @@ func (k *KonaNode) Start() {
 	err := k.sub.Start(k.execPath, k.args, k.env)
 	k.p.Require().NoError(err, "Must start")
 
+	// Wait for kona-node to log its RPC address, but fail fast if the process exits first
+	// (e.g. a crash on boot) rather than blocking on the context until the test times out.
 	var userRPCAddr string
-	k.p.Require().NoError(tasks.Await(k.p.Ctx(), userRPCChan, &userRPCAddr), "need user RPC")
+	select {
+	case userRPCAddr = <-userRPCChan:
+	case <-k.sub.Exited():
+		// Re-check the RPC channel in case the address was logged in the same instant the
+		// process exited; otherwise the process died before becoming ready.
+		select {
+		case userRPCAddr = <-userRPCChan:
+		default:
+			k.p.Require().FailNow("kona-node exited before its RPC server became ready")
+		}
+	case <-k.p.Ctx().Done():
+		k.p.Require().NoError(k.p.Ctx().Err(), "need user RPC")
+	}
 
 	if areMetricsEnabled() {
 		var metricsTarget PrometheusMetricsTarget

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -111,6 +111,17 @@ func devstackL2CLKind() MixedL2CLKind {
 	return MixedL2CLKind(os.Getenv("DEVSTACK_L2CL_KIND"))
 }
 
+// ResolveMixedL2CLKind returns the L2 CL kind requested via DEVSTACK_L2CL_KIND,
+// defaulting to op-node when the variable is unset. Tests that build explicit
+// MixedSingleChainNodeSpec lists use this so they honor the same env-driven CL
+// selection as the higher-level single-chain presets (see startL2CLForKey).
+func ResolveMixedL2CLKind() MixedL2CLKind {
+	if kind := devstackL2CLKind(); kind != "" {
+		return kind
+	}
+	return MixedL2CLOpNode
+}
+
 type MixedSingleChainNodeSpec struct {
 	ELKey       string
 	CLKey       string
@@ -221,6 +232,7 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 				spec.ELKey,
 				spec.IsSequencer,
 				metricsRegistrar,
+				depSet,
 			)
 		default:
 			require.FailNowf("unsupported CL kind", "unsupported mixed CL kind %q", spec.CLKind)
@@ -473,6 +485,7 @@ func startMixedKonaNode(
 	elKey string,
 	isSequencer bool,
 	metricsRegistrar L2MetricsRegistrar,
+	depSet coredepset.DependencySet,
 ) *KonaNode {
 	tempKonaDir := t.TempDir()
 
@@ -506,6 +519,17 @@ func startMixedKonaNode(
 		propagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_IP", "127.0.0.1"),
 		propagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_TCP_PORT", "0"),
 		propagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_UDP_PORT", "0"),
+	}
+
+	// When Interop/Lagoon is scheduled, kona-node refuses to start without an interop
+	// dependency set (to avoid silent state divergence at activation). Mirror the depset
+	// op-node receives by serializing it to JSON — the format matches what kona expects.
+	if depSet != nil {
+		depSetData, err := json.Marshal(depSet)
+		t.Require().NoError(err, "must marshal interop dependency set")
+		tempDepSetPath := filepath.Join(tempKonaDir, "interop-depset.json")
+		t.Require().NoError(os.WriteFile(tempDepSetPath, depSetData, 0o644), "must write interop dependency set")
+		envVars = append(envVars, "KONA_NODE_INTEROP_DEPENDENCY_SET="+tempDepSetPath)
 	}
 
 	if areMetricsEnabled() {

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -325,7 +325,7 @@ func buildMixedOpRethNode(
 	data, err := json.Marshal(l2Net.genesis)
 	t.Require().NoError(err, "must json-encode genesis")
 	chainConfigPath := filepath.Join(tempDir, "genesis.json")
-	t.Require().NoError(os.WriteFile(chainConfigPath, data, 0o644), "must write genesis file")
+	t.Require().NoError(os.WriteFile(chainConfigPath, data, 0o640), "must write genesis file")
 
 	dataDirPath := filepath.Join(tempDir, "data")
 	t.Require().NoError(os.MkdirAll(dataDirPath, 0o755), "must create datadir")
@@ -494,12 +494,12 @@ func startMixedKonaNode(
 	tempRollupCfgPath := filepath.Join(tempKonaDir, "rollup.json")
 	rollupCfgData, err := json.Marshal(l2Net.rollupCfg)
 	t.Require().NoError(err, "must write rollup config")
-	t.Require().NoError(os.WriteFile(tempRollupCfgPath, rollupCfgData, 0o644))
+	t.Require().NoError(os.WriteFile(tempRollupCfgPath, rollupCfgData, 0o640))
 
 	tempL1CfgPath := filepath.Join(tempKonaDir, "l1-chain-config.json")
 	l1CfgData, err := json.Marshal(l1Net.genesis.Config)
 	t.Require().NoError(err, "must write l1 chain config")
-	t.Require().NoError(os.WriteFile(tempL1CfgPath, l1CfgData, 0o644))
+	t.Require().NoError(os.WriteFile(tempL1CfgPath, l1CfgData, 0o640))
 
 	envVars := []string{
 		"KONA_NODE_L1_ETH_RPC=" + l1EL.UserRPC(),
@@ -528,7 +528,7 @@ func startMixedKonaNode(
 		depSetData, err := json.Marshal(depSet)
 		t.Require().NoError(err, "must marshal interop dependency set")
 		tempDepSetPath := filepath.Join(tempKonaDir, "interop-depset.json")
-		t.Require().NoError(os.WriteFile(tempDepSetPath, depSetData, 0o644), "must write interop dependency set")
+		t.Require().NoError(os.WriteFile(tempDepSetPath, depSetData, 0o640), "must write interop dependency set")
 		envVars = append(envVars, "KONA_NODE_INTEROP_DEPENDENCY_SET="+tempDepSetPath)
 	}
 
@@ -544,7 +544,7 @@ func startMixedKonaNode(
 		t.Require().NoError(err, "need p2p key for sequencer")
 		p2pKeyHex := "0x" + hex.EncodeToString(crypto.FromECDSA(p2pKey))
 		tempSeqKeyPath := filepath.Join(tempKonaDir, "p2p-sequencer.txt")
-		t.Require().NoError(os.WriteFile(tempSeqKeyPath, []byte(p2pKeyHex), 0o644))
+		t.Require().NoError(os.WriteFile(tempSeqKeyPath, []byte(p2pKeyHex), 0o640))
 		envVars = append(envVars,
 			"KONA_NODE_P2P_SEQUENCER_KEY_PATH="+tempSeqKeyPath,
 			"KONA_NODE_SEQUENCER_L1_CONFS=2",

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -181,7 +181,7 @@ func startL2CLForKey(
 ) L2CLNode {
 	switch devstackL2CLKind() {
 	case MixedL2CLKona:
-		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, nil)
+		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, nil, nil)
 	default: // op-node
 		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 			Key:            clKey,

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -164,7 +164,10 @@ func startL2ELForKey(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [3
 }
 
 // startL2CLForKey starts an L2 CL node for the given key, respecting DEVSTACK_L2CL_KIND.
-// This is the single env-aware dispatch point for L2 CL selection.
+// This is the env-aware dispatch point for preset runtimes that don't build explicit node
+// specs. Runtimes constructed from explicit MixedSingleChainNodeSpec.CLKind values (e.g.
+// NewMixedSingleChainRuntime) don't route through here; they resolve the env up front via
+// ResolveMixedL2CLKind instead.
 func startL2CLForKey(
 	t devtest.T,
 	keys devkeys.Keys,

--- a/op-devstack/sysgo/subproc.go
+++ b/op-devstack/sysgo/subproc.go
@@ -22,6 +22,12 @@ type SubProcess struct {
 	stdOutProc *logpipe.LineBuffer
 	stdErrProc *logpipe.LineBuffer
 
+	// exited is closed once cmd.Wait() returns, i.e. the process has exited and its
+	// stdout/stderr have been fully flushed. waitErr holds that Wait() result and is
+	// safe to read only after exited is closed.
+	exited  chan struct{}
+	waitErr error
+
 	mu sync.Mutex
 }
 
@@ -54,6 +60,14 @@ func (sp *SubProcess) Start(cmdPath string, args []string, env []string) error {
 	sp.cmd = cmd
 	sp.stdOutProc = stdOutProc
 	sp.stdErrProc = stdErrProc
+	sp.exited = make(chan struct{})
+	// Own the single cmd.Wait() here so callers can observe an early exit via Exited()
+	// without racing a second Wait() in Stop(). cmd.Wait() also blocks until stdout/stderr
+	// have been fully copied, so all log output is flushed by the time exited is closed.
+	go func() {
+		sp.waitErr = sp.cmd.Wait()
+		close(sp.exited)
+	}()
 	sp.p.Cleanup(func() {
 		err := sp.Stop(true)
 		if err != nil {
@@ -61,6 +75,14 @@ func (sp *SubProcess) Start(cmdPath string, args []string, env []string) error {
 		}
 	})
 	return nil
+}
+
+// Exited returns a channel that is closed once the process has exited and its
+// stdout/stderr have been fully flushed. It must only be called after Start.
+func (sp *SubProcess) Exited() <-chan struct{} {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	return sp.exited
 }
 
 // Stop waits for the process to stop, interrupting the process if it has not completed and
@@ -72,19 +94,27 @@ func (sp *SubProcess) Stop(interrupt bool) error {
 		return nil // already stopped gracefully
 	}
 
-	// If not already done, then try an interrupt first as requested.
-	if sp.cmd.ProcessState == nil && interrupt {
-		sp.p.Logger().Info("Sending interrupt")
-		if err := sp.cmd.Process.Signal(os.Interrupt); err != nil {
-			return err
+	// If the process is still running, request an interrupt as requested. We avoid
+	// reading sp.cmd.ProcessState here since the Wait() goroutine writes it; instead
+	// check the exited channel without blocking.
+	select {
+	case <-sp.exited:
+		// already exited; nothing to interrupt
+	default:
+		if interrupt {
+			sp.p.Logger().Info("Sending interrupt")
+			if err := sp.cmd.Process.Signal(os.Interrupt); err != nil {
+				// The process may have exited between the check and the signal; log
+				// rather than fail, then fall through to wait for the exit result.
+				sp.p.Logger().Warn("Failed to interrupt sub-process", "err", err)
+			}
 		}
 	}
 
-	// Use cmd.Wait() instead of cmd.Process.Wait() to ensure all stdout/stderr
-	// data is fully flushed before returning. Process.Wait() only waits for the
-	// process to exit but does not guarantee I/O completion, which causes races
-	// where log output hasn't been written to the LineBuffer yet.
-	waitErr := sp.cmd.Wait()
+	// Wait for the Wait() goroutine to report the exit. cmd.Wait() (run there) blocks
+	// until all stdout/stderr data is flushed, so log output is complete before we return.
+	<-sp.exited
+	waitErr := sp.waitErr
 	var exitErr *exec.ExitError
 	if waitErr != nil && !(interrupt && errors.As(waitErr, &exitErr)) {
 		sp.p.Logger().Warn("Sub-process exited with error", "err", waitErr)


### PR DESCRIPTION
## Summary

Makes the SDM PostExec acceptance coverage run on **kona-node**, satisfying the node-side acceptance gate for #21185.

`TestSDMPostExecBlockDerivesAndChainProgresses` hardcoded `MixedL2CLOpNode` for both the sequencer and verifier, so the kona acceptance suite (which sets `DEVSTACK_L2CL_KIND=kona-node`) silently kept exercising op-node.

## Changes

- **Honor `DEVSTACK_L2CL_KIND` in the SDM runtime.** Added `sysgo.ResolveMixedL2CLKind()` (defaults to op-node) and use it for both the sequencer and verifier specs in `buildSDMRethSystem`, matching how the higher-level single-chain presets already dispatch in `startL2CLForKey`.
- **Supply the interop dependency set to kona-node.** kona-node refuses to boot when Lagoon/Interop is scheduled unless an interop dependency set is provided. Thread the runtime's `depSet` into `startMixedKonaNode`, serialize it to JSON (the same format op-node consumes), and set `KONA_NODE_INTEROP_DEPENDENCY_SET`.
- **Fail fast when kona-node exits before its RPC is ready.** Previously a kona-node that crashed on boot (or any stand-in that exits immediately) left `KonaNode.Start` blocked on the RPC-readiness channel until the test's context deadline, turning a quick boot failure into a multi-minute timeout. `SubProcess` now owns a single `cmd.Wait()` in a goroutine that closes a new `Exited()` channel (with `Stop` consuming that result instead of calling `Wait` again — behavior-preserving for all `SubProcess` users), and `KonaNode.Start` selects on `Exited()` alongside the RPC channel, failing immediately with `kona-node exited before its RPC server became ready`. Observed effect: the early-exit case now fails in ~4s instead of ~600s.
- **Tighten temp-file permissions.** The temp files the mixed runtime writes for kona-node / op-reth startup now use `0o640` instead of `0o644` (in `op-devstack/sysgo/mixed_runtime.go`): op-reth genesis, kona-node rollup config, kona-node L1 chain config, the interop dependency set, and the sequencer P2P key. These are throwaway files under the test's `TempDir()`; this just drops the world-readable bit (group read retained) and has no functional impact.

## Testing

Run locally with op-reth ELs (`DEVSTACK_L2EL_KIND=op-reth`):

| Suite | CL | Result |
|---|---|---|
| `tests/sdm` (all 6 tests) | kona-node | ✅ |
| `tests/sdm` (all 6 tests) | op-node | ✅ |
| `TestInteropSingleChainFaultProofsWithSDM` (`kona-host super --native`) | op-supernode | ✅ |

The kona-node run covers `TestSDMPostExecBlockDerivesAndChainProgresses` reaching a cross-safe sentinel past the 0x7D block on both sequencer and verifier, for span and singular batches.

Fail-fast behavior was verified by pointing `RUST_BINARY_PATH_KONA_NODE` at `/usr/bin/true`: the run now fails in ~4s (`kona-node exited before its RPC server became ready`) rather than waiting out the full test timeout.

Resolves: https://github.com/ethereum-optimism/optimism/issues/21185