### PR TITLE
rust: align kona/op-revm/alloy spec_id resolution and eth base

### DIFF
--- a/rust/alloy-op-evm/src/env.rs
+++ b/rust/alloy-op-evm/src/env.rs
@@ -34,10 +34,12 @@ pub fn spec_by_timestamp_after_bedrock(chain_spec: impl OpHardforks, timestamp: 
             )+
         };
     }
+    // Forks must be checked newest-first. Interop (op-revm's `INTEROP` spec) is activated by the
+    // Lagoon hardfork, which is newer than Karst, so Lagoon is checked before Karst.
     check_forks! {
-        is_karst_active_at_timestamp => KARST,
         // op-revm still names this spec `INTEROP`; Lagoon is the hard fork that activates it.
         is_lagoon_active_at_timestamp => INTEROP,
+        is_karst_active_at_timestamp => KARST,
         is_jovian_active_at_timestamp => JOVIAN,
         is_isthmus_active_at_timestamp => ISTHMUS,
         is_holocene_active_at_timestamp => HOLOCENE,
@@ -263,5 +265,77 @@ mod tests {
         let actual_spec = spec(&fork, &header);
 
         assert_eq!(actual_spec, expected_spec);
+    }
+
+    /// The OP fork chronology, oldest first. `INTEROP` is op-revm's name for the spec activated by
+    /// the `Lagoon` hardfork, which is the newest fork.
+    const FORK_CHRONOLOGY: [(OpHardfork, OpSpecId); 11] = [
+        (OpHardfork::Bedrock, OpSpecId::BEDROCK),
+        (OpHardfork::Regolith, OpSpecId::REGOLITH),
+        (OpHardfork::Canyon, OpSpecId::CANYON),
+        (OpHardfork::Ecotone, OpSpecId::ECOTONE),
+        (OpHardfork::Fjord, OpSpecId::FJORD),
+        (OpHardfork::Granite, OpSpecId::GRANITE),
+        (OpHardfork::Holocene, OpSpecId::HOLOCENE),
+        (OpHardfork::Isthmus, OpSpecId::ISTHMUS),
+        (OpHardfork::Jovian, OpSpecId::JOVIAN),
+        (OpHardfork::Karst, OpSpecId::KARST),
+        (OpHardfork::Lagoon, OpSpecId::INTEROP),
+    ];
+
+    /// Builds a chain config where every fork up to and including `forks[idx]` is active at
+    /// timestamp 1, mirroring a real chain that has progressed through the schedule. This is what
+    /// exercises the newest-first precedence in `spec_by_timestamp_after_bedrock`: with several
+    /// forks simultaneously active, the resolver must return the newest one.
+    fn cumulative_hardforks(idx: usize) -> OpChainHardforks {
+        let activations = FORK_CHRONOLOGY.iter().take(idx + 1).map(|(fork, _)| {
+            let cond = if *fork == OpHardfork::Bedrock {
+                ForkCondition::Block(0)
+            } else {
+                ForkCondition::Timestamp(1)
+            };
+            (*fork, cond)
+        });
+        OpChainHardforks::new(activations)
+    }
+
+    /// Locks in the corrected newest-first fork ordering: when forks are activated cumulatively
+    /// (as on a real chain), the resolver must return the newest active spec, not an older one.
+    /// In particular, a post-Lagoon block resolves to `INTEROP`, not `KARST`.
+    #[test]
+    fn test_spec_resolves_newest_active_fork() {
+        for (idx, (fork, expected_spec)) in FORK_CHRONOLOGY.iter().enumerate() {
+            let chain = cumulative_hardforks(idx);
+            let header = Header { timestamp: 1, ..Default::default() };
+            let actual_spec = spec(&chain, &header);
+            assert_eq!(
+                actual_spec, *expected_spec,
+                "with forks active up to {fork:?}, expected newest spec {expected_spec:?}",
+            );
+        }
+    }
+
+    /// Conformance guard: the eth base spec must be non-decreasing across the OP fork chronology.
+    /// A newer OP fork must never map to an older eth base (e.g. INTEROP must not downgrade Karst's
+    /// OSAKA base back to PRAGUE).
+    #[test]
+    fn test_eth_base_is_monotonic_across_chronology() {
+        let mut prev_eth = SpecId::default();
+        let mut first = true;
+        for (fork, op_spec) in FORK_CHRONOLOGY {
+            let eth = op_spec.into_eth_spec();
+            if !first {
+                assert!(
+                    eth >= prev_eth,
+                    "{fork:?} ({op_spec:?}) eth base {eth:?} is older than the previous fork's {prev_eth:?}",
+                );
+            }
+            prev_eth = eth;
+            first = false;
+        }
+        // Sanity-check the specific pairing the bug was about.
+        assert_eq!(OpSpecId::KARST.into_eth_spec(), SpecId::OSAKA);
+        assert_eq!(OpSpecId::INTEROP.into_eth_spec(), SpecId::OSAKA);
+        assert!(OpSpecId::INTEROP.into_eth_spec() >= OpSpecId::KARST.into_eth_spec());
     }
 }

--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -176,6 +176,8 @@ impl RollupConfig {
             op_revm::OpSpecId::ISTHMUS
         } else if self.is_holocene_active(timestamp) {
             op_revm::OpSpecId::HOLOCENE
+        } else if self.is_granite_active(timestamp) {
+            op_revm::OpSpecId::GRANITE
         } else if self.is_fjord_active(timestamp) {
             op_revm::OpSpecId::FJORD
         } else if self.is_ecotone_active(timestamp) {
@@ -533,6 +535,8 @@ mod tests {
         assert_eq!(config.spec_id(30), op_revm::OpSpecId::ECOTONE);
         config.hardforks.fjord_time = Some(40);
         assert_eq!(config.spec_id(40), op_revm::OpSpecId::FJORD);
+        config.hardforks.granite_time = Some(45);
+        assert_eq!(config.spec_id(45), op_revm::OpSpecId::GRANITE);
         config.hardforks.holocene_time = Some(50);
         assert_eq!(config.spec_id(50), op_revm::OpSpecId::HOLOCENE);
         config.hardforks.isthmus_time = Some(60);

--- a/rust/op-revm/src/spec.rs
+++ b/rust/op-revm/src/spec.rs
@@ -40,8 +40,10 @@ impl OpSpecId {
             Self::BEDROCK | Self::REGOLITH => SpecId::MERGE,
             Self::CANYON => SpecId::SHANGHAI,
             Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE => SpecId::CANCUN,
-            Self::ISTHMUS | Self::JOVIAN | Self::INTEROP => SpecId::PRAGUE,
-            Self::KARST => SpecId::OSAKA,
+            Self::ISTHMUS | Self::JOVIAN => SpecId::PRAGUE,
+            // Interop (activated by the Lagoon hardfork) is newer than Karst, so its eth base
+            // must not be older than Karst's (OSAKA).
+            Self::KARST | Self::INTEROP => SpecId::OSAKA,
         }
     }
 
@@ -268,5 +270,46 @@ mod tests {
     #[test]
     fn default_op_spec_id() {
         assert_eq!(OpSpecId::default(), OpSpecId::JOVIAN);
+    }
+
+    #[test]
+    fn karst_and_interop_eth_base_is_osaka() {
+        // Interop (activated by the Lagoon hardfork) is newer than Karst, so it must not downgrade
+        // the eth base below Karst's OSAKA.
+        assert_eq!(OpSpecId::KARST.into_eth_spec(), SpecId::OSAKA);
+        assert_eq!(OpSpecId::INTEROP.into_eth_spec(), SpecId::OSAKA);
+    }
+
+    /// Conformance guard: the eth base spec must be non-decreasing across the OP fork chronology
+    /// (oldest to newest). A newer OP fork must never map to an older eth base.
+    #[test]
+    fn eth_base_is_monotonic_across_chronology() {
+        // OP forks in chronological order, oldest first. INTEROP (the Lagoon hardfork's spec) is
+        // newest. This also matches the `OpSpecId` discriminant order, which `is_enabled_in` relies
+        // on.
+        let chronology = [
+            OpSpecId::BEDROCK,
+            OpSpecId::REGOLITH,
+            OpSpecId::CANYON,
+            OpSpecId::ECOTONE,
+            OpSpecId::FJORD,
+            OpSpecId::GRANITE,
+            OpSpecId::HOLOCENE,
+            OpSpecId::ISTHMUS,
+            OpSpecId::JOVIAN,
+            OpSpecId::KARST,
+            OpSpecId::INTEROP,
+        ];
+        for pair in chronology.windows(2) {
+            let [older, newer] = [pair[0], pair[1]];
+            // The chronology must agree with the discriminant ordering.
+            assert!(newer.is_enabled_in(older), "{newer:?} should be newer than {older:?}");
+            assert!(
+                newer.into_eth_spec() >= older.into_eth_spec(),
+                "{newer:?} eth base {:?} is older than {older:?} eth base {:?}",
+                newer.into_eth_spec(),
+                older.into_eth_spec(),
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Aligns the EVM hardfork → `OpSpecId` resolution and the eth-base mapping across **kona-client**, **op-revm**, and **alloy-op-evm** so they agree with each other and with op-geth. The OP fork chronology is `Jovian < Karst < Lagoon (Interop)`, with Interop the newest fork.

### 1. kona-genesis — add the missing `GRANITE` branch to `spec_id`
`RollupConfig::spec_id` jumped from `HOLOCENE` straight to `FJORD`, so Granite-era (post-Granite, pre-Holocene) blocks resolved to `FJORD`. op-revm selects the restricted bn256Pairing precompile (input limit `112687`) only for `GRANITE`, and op-geth enforces it at `IsOptimismGranite` — so kona would skip that limit. Adds the `GRANITE` branch between `HOLOCENE` and `FJORD`.

### 2. op-revm — map `INTEROP` to `OSAKA` (not `PRAGUE`)
`into_eth_spec` mapped the newer `INTEROP` to `PRAGUE` while the older `KARST` mapped to `OSAKA` — a downgrade of the eth base for a newer fork. op-geth decouples the eth base via independent `OsakaTime`/`PragueTime`, so a post-Interop block's eth base should be Osaka (matching Karst). Maps `KARST | INTEROP → OSAKA`.

### 3. alloy-op-evm — check Lagoon/Interop before Karst
`spec_by_timestamp_after_bedrock` checked Karst before Lagoon, returning `KARST` for post-Lagoon blocks. Reorders to newest-first (Lagoon/Interop before Karst), matching kona's already-correct ordering.

Together, a post-Lagoon block now resolves to `INTEROP → OSAKA` consistently in kona and op-reth, matching op-geth's Osaka base.

### Conformance guards
Adds tests in op-revm and alloy-op-evm locking in the newest-first fork ordering and eth-base monotonicity (a newer OP fork must never map to an older eth base), so future fork additions can't silently regress this.

## Safety
Karst and Lagoon/Interop are not yet scheduled on mainnet, and the Granite→Holocene window is historical, so this does not change execution for any live chain — it brings the Rust spec resolution into agreement with op-geth ahead of those forks.

## Testing
- `op-revm` (75), `alloy-op-evm` (46), `kona-genesis` (142) unit tests pass
- `cargo clippy --all-features -- -D warnings` clean; `cargo +nightly fmt` clean
- Downstream `reth-optimism-evm` / `reth-optimism-consensus` / `reth-optimism-chainspec` compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
