### PR TITLE
op-alloy: reject zero elasticity in EIP-1559 params decoding

### DIFF
--- a/rust/kona/crates/node/engine/src/attributes.rs
+++ b/rust/kona/crates/node/engine/src/attributes.rs
@@ -397,7 +397,6 @@ impl From<AttributesMismatch> for AttributesMatch {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::AttributesMismatch::EIP1559Parameters;
     use alloy_consensus::EMPTY_ROOT_HASH;
     use alloy_primitives::{Bytes, FixedBytes, address, b256};
     use alloy_rpc_types_eth::BlockTransactions;
@@ -795,8 +794,9 @@ mod tests {
         assert!(check.is_mismatch());
     }
 
-    /// Check that, when the eip1559 params are specified and empty, the check fails because we
-    /// fallback on canyon params for the attributes but not for the block (edge case).
+    /// Check that, when the eip1559 params are specified and empty, the check fails: the attributes
+    /// fall back to canyon params, but the block's all-zero extraData is rejected at decode (a zero
+    /// denominator is invalid per the Holocene header rules).
     #[test]
     fn test_eip1559_parameters_specified_both_and_empty() {
         let (cfg, mut attributes, mut block) = eip1559_test_setup();
@@ -807,9 +807,8 @@ mod tests {
         let check = AttributesMatch::check(&cfg, &attributes, &block);
         assert_eq!(
             check,
-            AttributesMatch::Mismatch(EIP1559Parameters(
-                BaseFeeParams { max_change_denominator: 250, elasticity_multiplier: 6 },
-                BaseFeeParams { max_change_denominator: 0, elasticity_multiplier: 0 }
+            AttributesMatch::Mismatch(AttributesMismatch::UnknownExtraDataDecodingError(
+                EIP1559ParamError::ZeroDenominator
             ))
         );
         assert!(check.is_mismatch());
@@ -975,16 +974,13 @@ mod tests {
 
         let check = AttributesMatch::check(&cfg, &attributes, &block);
 
-        // Note that in this case we *always* have a mismatch because there isn't enough bytes in
-        // the default representation of the extra params to represent a u128
+        // The block's all-zero extraData is rejected at decode (a zero denominator is invalid per
+        // the Holocene header rules), so the check fails there regardless of the attributes'
+        // (here intentionally oversized) canyon params.
         assert_eq!(
             check,
-            AttributesMatch::Mismatch(EIP1559Parameters(
-                BaseFeeParams {
-                    max_change_denominator: u64::MAX as u128,
-                    elasticity_multiplier: u64::MAX as u128
-                },
-                BaseFeeParams { max_change_denominator: 0, elasticity_multiplier: 0 }
+            AttributesMatch::Mismatch(AttributesMismatch::UnknownExtraDataDecodingError(
+                EIP1559ParamError::ZeroDenominator
             ))
         );
         assert!(check.is_mismatch());

--- a/rust/kona/crates/proof/executor/src/errors.rs
+++ b/rust/kona/crates/proof/executor/src/errors.rs
@@ -13,21 +13,14 @@ use thiserror::Error;
 
 /// Errors that can occur when validating EIP-1559 parameters from block header extra data.
 ///
-/// This error type is used for validation errors during decoding of EIP-1559 parameters,
-/// providing more specific error variants than the upstream [`EIP1559ParamError`] which
-/// is primarily designed for encoding errors.
+/// This error type is used for validation errors during decoding of EIP-1559 parameters.
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum Eip1559ValidationError {
-    /// The EIP-1559 denominator cannot be zero as it would cause division by zero.
-    ///
-    /// This error occurs when the decoded denominator value from the block header's
-    /// extra data field is zero, which violates protocol specifications.
-    #[error("EIP-1559 denominator cannot be zero")]
-    ZeroDenominator,
     /// Error from EIP-1559 parameter decoding.
     ///
-    /// This variant wraps errors from the underlying EIP-1559 parameter decoding,
-    /// such as invalid version bytes, incorrect data lengths, or missing parameters.
+    /// This variant wraps errors from the underlying EIP-1559 parameter decoding, such as invalid
+    /// version bytes, incorrect data lengths, missing parameters, or a zero denominator/elasticity
+    /// encoded in the block header extra data.
     #[error(transparent)]
     Decode(#[from] EIP1559ParamError),
 }

--- a/rust/kona/crates/proof/executor/src/util.rs
+++ b/rust/kona/crates/proof/executor/src/util.rs
@@ -22,14 +22,9 @@ use op_alloy_rpc_types_engine::OpPayloadAttributes;
 pub(crate) fn decode_holocene_eip_1559_params_block_header(
     header: &Header,
 ) -> ExecutorResult<BaseFeeParams> {
+    // `decode_holocene_extra_data` rejects a zero denominator and zero elasticity, so the base fee
+    // params are guaranteed to be non-zero here (no division by zero downstream).
     let (elasticity, denominator) = decode_holocene_extra_data(header.extra_data())?;
-
-    // Check for potential division by zero.
-    // In the block header, the denominator is always non-zero.
-    // <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#eip-1559-parameters-in-block-header>
-    if denominator == 0 {
-        return Err(ExecutorError::InvalidExtraData(Eip1559ValidationError::ZeroDenominator));
-    }
 
     Ok(BaseFeeParams {
         elasticity_multiplier: elasticity.into(),
@@ -40,14 +35,9 @@ pub(crate) fn decode_holocene_eip_1559_params_block_header(
 pub(crate) fn decode_jovian_eip_1559_params_block_header(
     header: &Header,
 ) -> ExecutorResult<(BaseFeeParams, u64)> {
+    // `decode_jovian_extra_data` rejects a zero denominator and zero elasticity, so the base fee
+    // params are guaranteed to be non-zero here (no division by zero downstream).
     let (elasticity, denominator, min_base_fee) = decode_jovian_extra_data(header.extra_data())?;
-
-    // Check for potential division by zero.
-    // In the block header, the denominator is always non-zero.
-    // <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#eip-1559-parameters-in-block-header>
-    if denominator == 0 {
-        return Err(ExecutorError::InvalidExtraData(Eip1559ValidationError::ZeroDenominator));
-    }
 
     Ok((
         BaseFeeParams {
@@ -159,9 +149,26 @@ mod test {
 
     #[test]
     fn test_decode_holocene_eip_1559_params_invalid_denominator() {
+        // version 0, denominator 0, elasticity 0x0BADC0DE
         let params = bytes!("00000000000BADC0DE");
         let mock_header = Header { extra_data: params, ..Default::default() };
         assert!(decode_holocene_eip_1559_params_block_header(&mock_header).is_err());
+    }
+
+    #[test]
+    fn test_decode_holocene_eip_1559_params_invalid_elasticity() {
+        // version 0, denominator 0xBEEFBABE, elasticity 0
+        let params = bytes!("00BEEFBABE00000000");
+        let mock_header = Header { extra_data: params, ..Default::default() };
+        assert!(decode_holocene_eip_1559_params_block_header(&mock_header).is_err());
+    }
+
+    #[test]
+    fn test_decode_jovian_eip_1559_params_invalid_elasticity() {
+        // version 1, denominator 0xBEEFBABE, elasticity 0, min_base_fee 0xDEADBEEF
+        let params = bytes!("01BEEFBABE0000000000000000DEADBEEF");
+        let mock_header = Header { extra_data: params, ..Default::default() };
+        assert!(decode_jovian_eip_1559_params_block_header(&mock_header).is_err());
     }
 
     #[test]

--- a/rust/op-alloy/crates/consensus/src/eip1559.rs
+++ b/rust/op-alloy/crates/consensus/src/eip1559.rs
@@ -67,7 +67,7 @@ const fn validate_extra_data_eip_1559_params(
 /// Decodes the `eip1559` parameters from the `extradata` bytes.
 ///
 /// Both the denominator and elasticity encoded in the header extraData must be non-zero, otherwise
-/// an error is returned. See [`validate_extra_data_eip_1559_params`].
+/// an error is returned.
 ///
 /// Returns (`elasticity`, `denominator`)
 pub fn decode_holocene_extra_data(extra_data: &[u8]) -> Result<(u32, u32), EIP1559ParamError> {
@@ -102,7 +102,7 @@ pub fn encode_holocene_extra_data(
 ///
 /// The Holocene rules apply to the 8 bytes encoding the EIP-1559 parameters, i.e. both the
 /// denominator and elasticity must be non-zero. The encoded minimum base fee can be set
-/// arbitrarily. See [`validate_extra_data_eip_1559_params`].
+/// arbitrarily.
 ///
 /// Returns (`elasticity`, `denominator`, `min_base_fee`)
 pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u64), EIP1559ParamError> {

--- a/rust/op-alloy/crates/consensus/src/eip1559.rs
+++ b/rust/op-alloy/crates/consensus/src/eip1559.rs
@@ -52,8 +52,8 @@ pub fn decode_eip_1559_params(eip_1559_params: B64) -> (u32, u32) {
 /// may also be zero (at the same time, signalling the default parameters).
 /// See <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#eip-1559-parameters-in-block-header>
 const fn validate_extra_data_eip_1559_params(
-    denominator: u32,
     elasticity: u32,
+    denominator: u32,
 ) -> Result<(), EIP1559ParamError> {
     if denominator == 0 {
         return Err(EIP1559ParamError::ZeroDenominator);
@@ -82,7 +82,7 @@ pub fn decode_holocene_extra_data(extra_data: &[u8]) -> Result<(u32, u32), EIP15
     }
     // skip the first version byte
     let (elasticity, denominator) = decode_eip_1559_params(B64::from_slice(&extra_data[1..9]));
-    validate_extra_data_eip_1559_params(denominator, elasticity)?;
+    validate_extra_data_eip_1559_params(elasticity, denominator)?;
     Ok((elasticity, denominator))
 }
 
@@ -100,9 +100,9 @@ pub fn encode_holocene_extra_data(
 /// Decodes the EIP-1559 parameters from `extra_data`,
 /// as well as the minimum base fee.
 ///
-/// The Holocene rules apply to the 8 bytes encoding the EIP-1559 parameters, i.e. both the
-/// denominator and elasticity must be non-zero. The encoded minimum base fee can be set
-/// arbitrarily.
+/// Jovian inherits the Holocene header rules for the 8 bytes encoding the EIP-1559 parameters,
+/// i.e. both the denominator and elasticity must be non-zero. The encoded minimum base fee can be
+/// set arbitrarily.
 ///
 /// Returns (`elasticity`, `denominator`, `min_base_fee`)
 pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u64), EIP1559ParamError> {
@@ -121,7 +121,7 @@ pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u64), EI
 
     let denominator = u32::from_be_bytes(denominator_bytes);
     let elasticity = u32::from_be_bytes(elasticity_bytes);
-    validate_extra_data_eip_1559_params(denominator, elasticity)?;
+    validate_extra_data_eip_1559_params(elasticity, denominator)?;
 
     Ok((elasticity, denominator, u64::from_be_bytes(min_base_fee_bytes)))
 }

--- a/rust/op-alloy/crates/consensus/src/eip1559.rs
+++ b/rust/op-alloy/crates/consensus/src/eip1559.rs
@@ -45,7 +45,29 @@ pub fn decode_eip_1559_params(eip_1559_params: B64) -> (u32, u32) {
     (u32::from_be_bytes(elasticity), u32::from_be_bytes(denominator))
 }
 
+/// Validates the EIP-1559 parameters encoded in a block header's extraData.
+///
+/// Per the Holocene rules, both the denominator and elasticity encoded in the header extraData
+/// must be non-zero. Note this differs from the payload attributes validation, where both values
+/// may also be zero (at the same time, signalling the default parameters).
+/// See <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#eip-1559-parameters-in-block-header>
+const fn validate_extra_data_eip_1559_params(
+    denominator: u32,
+    elasticity: u32,
+) -> Result<(), EIP1559ParamError> {
+    if denominator == 0 {
+        return Err(EIP1559ParamError::ZeroDenominator);
+    }
+    if elasticity == 0 {
+        return Err(EIP1559ParamError::ZeroElasticity);
+    }
+    Ok(())
+}
+
 /// Decodes the `eip1559` parameters from the `extradata` bytes.
+///
+/// Both the denominator and elasticity encoded in the header extraData must be non-zero, otherwise
+/// an error is returned. See [`validate_extra_data_eip_1559_params`].
 ///
 /// Returns (`elasticity`, `denominator`)
 pub fn decode_holocene_extra_data(extra_data: &[u8]) -> Result<(u32, u32), EIP1559ParamError> {
@@ -59,7 +81,9 @@ pub fn decode_holocene_extra_data(extra_data: &[u8]) -> Result<(u32, u32), EIP15
         return Err(EIP1559ParamError::InvalidVersion(extra_data[0]));
     }
     // skip the first version byte
-    Ok(decode_eip_1559_params(B64::from_slice(&extra_data[1..9])))
+    let (elasticity, denominator) = decode_eip_1559_params(B64::from_slice(&extra_data[1..9]));
+    validate_extra_data_eip_1559_params(denominator, elasticity)?;
+    Ok((elasticity, denominator))
 }
 
 /// Encodes the `eip1559` parameters for the payload.
@@ -76,6 +100,10 @@ pub fn encode_holocene_extra_data(
 /// Decodes the EIP-1559 parameters from `extra_data`,
 /// as well as the minimum base fee.
 ///
+/// The Holocene rules apply to the 8 bytes encoding the EIP-1559 parameters, i.e. both the
+/// denominator and elasticity must be non-zero. The encoded minimum base fee can be set
+/// arbitrarily. See [`validate_extra_data_eip_1559_params`].
+///
 /// Returns (`elasticity`, `denominator`, `min_base_fee`)
 pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u64), EIP1559ParamError> {
     if extra_data.len() != 17 {
@@ -87,15 +115,15 @@ pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u64), EI
         return Err(EIP1559ParamError::InvalidVersion(extra_data[0]));
     }
     // skip the first version byte
-    let denominator: [u8; 4] = extra_data[1..5].try_into().expect("sufficient length");
-    let elasticity: [u8; 4] = extra_data[5..9].try_into().expect("sufficient length");
-    let min_base_fee: [u8; 8] = extra_data[9..17].try_into().expect("sufficient length");
+    let denominator_bytes: [u8; 4] = extra_data[1..5].try_into().expect("sufficient length");
+    let elasticity_bytes: [u8; 4] = extra_data[5..9].try_into().expect("sufficient length");
+    let min_base_fee_bytes: [u8; 8] = extra_data[9..17].try_into().expect("sufficient length");
 
-    Ok((
-        u32::from_be_bytes(elasticity),
-        u32::from_be_bytes(denominator),
-        u64::from_be_bytes(min_base_fee),
-    ))
+    let denominator = u32::from_be_bytes(denominator_bytes);
+    let elasticity = u32::from_be_bytes(elasticity_bytes);
+    validate_extra_data_eip_1559_params(denominator, elasticity)?;
+
+    Ok((elasticity, denominator, u64::from_be_bytes(min_base_fee_bytes)))
 }
 
 /// Encodes the EIP-1559 parameters for the payload,
@@ -129,6 +157,12 @@ pub enum EIP1559ParamError {
     /// Elasticity overflow.
     #[error("Elasticity overflow")]
     ElasticityOverflow,
+    /// The extraData encodes a zero denominator, which is not allowed by the Holocene rules.
+    #[error("EIP1559 extraData must encode a non-zero denominator")]
+    ZeroDenominator,
+    /// The extraData encodes a zero elasticity, which is not allowed by the Holocene rules.
+    #[error("EIP1559 extraData must encode a non-zero elasticity")]
+    ZeroElasticity,
     /// Extra data is not the correct length.
     #[error("Extra data is not the correct length")]
     InvalidExtraDataLength,
@@ -217,5 +251,63 @@ mod tests {
         let extra_data = [0u8; 8];
         let res = decode_jovian_extra_data(&extra_data);
         assert_eq!(res.unwrap_err(), EIP1559ParamError::InvalidExtraDataLength);
+    }
+
+    #[test]
+    fn test_decode_holocene_extra_data_valid() {
+        // version 0, denominator 8, elasticity 8
+        let extra_data = [0, 0, 0, 0, 8, 0, 0, 0, 8];
+        assert_eq!(decode_holocene_extra_data(&extra_data).unwrap(), (8, 8));
+    }
+
+    #[test]
+    fn test_decode_holocene_extra_data_zero_denominator() {
+        // version 0, denominator 0, elasticity 8
+        let extra_data = [0, 0, 0, 0, 0, 0, 0, 0, 8];
+        assert_eq!(
+            decode_holocene_extra_data(&extra_data).unwrap_err(),
+            EIP1559ParamError::ZeroDenominator
+        );
+    }
+
+    #[test]
+    fn test_decode_holocene_extra_data_zero_elasticity() {
+        // version 0, denominator 8, elasticity 0
+        let extra_data = [0, 0, 0, 0, 8, 0, 0, 0, 0];
+        assert_eq!(
+            decode_holocene_extra_data(&extra_data).unwrap_err(),
+            EIP1559ParamError::ZeroElasticity
+        );
+    }
+
+    #[test]
+    fn test_decode_holocene_extra_data_both_zero() {
+        // version 0, denominator 0, elasticity 0. Unlike payload attributes, the extraData must
+        // encode non-zero params, so this is rejected (denominator is checked first).
+        let extra_data = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(
+            decode_holocene_extra_data(&extra_data).unwrap_err(),
+            EIP1559ParamError::ZeroDenominator
+        );
+    }
+
+    #[test]
+    fn test_decode_jovian_extra_data_zero_denominator() {
+        // version 1, denominator 0, elasticity 8, min_base_fee 0
+        let extra_data = [1, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(
+            decode_jovian_extra_data(&extra_data).unwrap_err(),
+            EIP1559ParamError::ZeroDenominator
+        );
+    }
+
+    #[test]
+    fn test_decode_jovian_extra_data_zero_elasticity() {
+        // version 1, denominator 8, elasticity 0, min_base_fee 0
+        let extra_data = [1, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(
+            decode_jovian_extra_data(&extra_data).unwrap_err(),
+            EIP1559ParamError::ZeroElasticity
+        );
     }
 }

--- a/rust/op-reth/crates/chainspec/src/basefee.rs
+++ b/rust/op-reth/crates/chainspec/src/basefee.rs
@@ -5,29 +5,21 @@ use core::cmp::max;
 use alloy_consensus::BlockHeader;
 use alloy_eips::calc_next_block_base_fee;
 use op_alloy_consensus::{EIP1559ParamError, decode_holocene_extra_data, decode_jovian_extra_data};
-use reth_chainspec::{BaseFeeParams, EthChainSpec};
-use reth_optimism_forks::OpHardforks;
+use reth_chainspec::BaseFeeParams;
 
 /// Extracts the Holocene 1599 parameters from the encoded extra data from the parent header.
 ///
 /// Caution: Caller must ensure that holocene is active in the parent header.
 ///
 /// See also [Base fee computation](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#base-fee-computation)
-pub fn decode_holocene_base_fee<H>(
-    chain_spec: impl EthChainSpec + OpHardforks,
-    parent: &H,
-    timestamp: u64,
-) -> Result<u64, EIP1559ParamError>
+pub fn decode_holocene_base_fee<H>(parent: &H) -> Result<u64, EIP1559ParamError>
 where
     H: BlockHeader,
 {
+    // The denominator and elasticity are guaranteed non-zero: `decode_holocene_extra_data` rejects
+    // a zero of either, per the Holocene header rules.
     let (elasticity, denominator) = decode_holocene_extra_data(parent.extra_data())?;
-
-    let base_fee_params = if elasticity == 0 && denominator == 0 {
-        chain_spec.base_fee_params_at_timestamp(timestamp)
-    } else {
-        BaseFeeParams::new(denominator as u128, elasticity as u128)
-    };
+    let base_fee_params = BaseFeeParams::new(denominator as u128, elasticity as u128);
 
     Ok(parent.next_block_base_fee(base_fee_params).unwrap_or_default())
 }
@@ -40,21 +32,14 @@ where
 ///
 /// See also [Base fee computation](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/exec-engine.md#base-fee-computation)
 /// and [Minimum base fee in block header](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/exec-engine.md#minimum-base-fee-in-block-header)
-pub fn compute_jovian_base_fee<H>(
-    chain_spec: impl EthChainSpec + OpHardforks,
-    parent: &H,
-    timestamp: u64,
-) -> Result<u64, EIP1559ParamError>
+pub fn compute_jovian_base_fee<H>(parent: &H) -> Result<u64, EIP1559ParamError>
 where
     H: BlockHeader,
 {
+    // The denominator and elasticity are guaranteed non-zero: `decode_jovian_extra_data` rejects a
+    // zero of either, per the Holocene header rules that Jovian inherits.
     let (elasticity, denominator, min_base_fee) = decode_jovian_extra_data(parent.extra_data())?;
-
-    let base_fee_params = if elasticity == 0 && denominator == 0 {
-        chain_spec.base_fee_params_at_timestamp(timestamp)
-    } else {
-        BaseFeeParams::new(denominator as u128, elasticity as u128)
-    };
+    let base_fee_params = BaseFeeParams::new(denominator as u128, elasticity as u128);
 
     // Starting from Jovian, we use the maximum of the gas used and the blob gas used to calculate
     // the next base fee.
@@ -107,7 +92,6 @@ mod tests {
     fn test_next_base_fee_jovian_blob_gas_used_greater_than_gas_used() {
         let chain_spec = get_chainspec();
         let mut parent = chain_spec.genesis_header().clone();
-        let timestamp = JOVIAN_TIMESTAMP;
 
         const GAS_LIMIT: u64 = 10_000_000_000;
         const BLOB_GAS_USED: u64 = 5_000_000_000;
@@ -127,10 +111,7 @@ mod tests {
             parent.base_fee_per_gas().unwrap_or_default(),
             BaseFeeParams::base_sepolia(),
         );
-        assert_eq!(
-            expected_base_fee,
-            compute_jovian_base_fee(chain_spec, &parent, timestamp).unwrap()
-        );
+        assert_eq!(expected_base_fee, compute_jovian_base_fee(&parent).unwrap());
         assert_ne!(
             expected_base_fee,
             calc_next_block_base_fee(
@@ -146,7 +127,6 @@ mod tests {
     fn test_next_base_fee_jovian_blob_gas_used_less_than_gas_used() {
         let chain_spec = get_chainspec();
         let mut parent = chain_spec.genesis_header().clone();
-        let timestamp = JOVIAN_TIMESTAMP;
 
         const GAS_LIMIT: u64 = 10_000_000_000;
         const BLOB_GAS_USED: u64 = 100_000_000;
@@ -166,17 +146,13 @@ mod tests {
             parent.base_fee_per_gas().unwrap_or_default(),
             BaseFeeParams::base_sepolia(),
         );
-        assert_eq!(
-            expected_base_fee,
-            compute_jovian_base_fee(chain_spec, &parent, timestamp).unwrap()
-        );
+        assert_eq!(expected_base_fee, compute_jovian_base_fee(&parent).unwrap());
     }
 
     #[test]
     fn test_next_base_fee_jovian_min_base_fee() {
         let chain_spec = get_chainspec();
         let mut parent = chain_spec.genesis_header().clone();
-        let timestamp = JOVIAN_TIMESTAMP;
 
         const GAS_LIMIT: u64 = 10_000_000_000;
         const BLOB_GAS_USED: u64 = 100_000_000;
@@ -191,9 +167,6 @@ mod tests {
         parent.gas_limit = GAS_LIMIT;
 
         let expected_base_fee = MIN_BASE_FEE;
-        assert_eq!(
-            expected_base_fee,
-            compute_jovian_base_fee(chain_spec, &parent, timestamp).unwrap()
-        );
+        assert_eq!(expected_base_fee, compute_jovian_base_fee(&parent).unwrap());
     }
 }

--- a/rust/op-reth/crates/chainspec/src/lib.rs
+++ b/rust/op-reth/crates/chainspec/src/lib.rs
@@ -311,9 +311,9 @@ impl EthChainSpec for OpChainSpec {
 
     fn next_block_base_fee(&self, parent: &Header, target_timestamp: u64) -> Option<u64> {
         if self.is_jovian_active_at_timestamp(parent.timestamp()) {
-            compute_jovian_base_fee(self, parent, target_timestamp).ok()
+            compute_jovian_base_fee(parent).ok()
         } else if self.is_holocene_active_at_timestamp(parent.timestamp()) {
-            decode_holocene_base_fee(self, parent, target_timestamp).ok()
+            decode_holocene_base_fee(parent).ok()
         } else {
             self.inner.next_block_base_fee(parent, target_timestamp)
         }

--- a/rust/op-reth/crates/consensus/src/validation/mod.rs
+++ b/rust/op-reth/crates/consensus/src/validation/mod.rs
@@ -210,7 +210,7 @@ mod tests {
     use alloy_consensus::Header;
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::{Bytes, U256, b256, hex};
-    use op_alloy_consensus::OpTxEnvelope;
+    use op_alloy_consensus::{OpTxEnvelope, encode_jovian_extra_data};
     use reth_chainspec::{BaseFeeParams, ChainSpec, EthChainSpec, ForkCondition, Hardfork};
     use reth_optimism_chainspec::{BASE_SEPOLIA, OpChainSpec};
     use reth_optimism_forks::{BASE_SEPOLIA_HARDFORKS, OpHardfork};
@@ -291,10 +291,9 @@ mod tests {
             &parent,
             HOLOCENE_TIMESTAMP + 5,
         );
-        assert_eq!(
-            base_fee.unwrap(),
-            op_chain_spec.next_block_base_fee(&parent, 0).unwrap_or_default()
-        );
+        // An all-zero Holocene extraData encodes a zero denominator/elasticity, which is invalid
+        // per the Holocene header rules, so no base fee can be derived.
+        assert_eq!(base_fee, None);
     }
 
     #[test]
@@ -405,13 +404,14 @@ mod tests {
         const CURR_BASE_FEE: u64 = 1;
         const MIN_BASE_FEE: u64 = 10;
 
-        let mut extra_data = Vec::new();
-        extra_data.push(JOVIAN_EXTRA_DATA_VERSION_BYTE);
-        // eip1559 params
-        extra_data.append(&mut [0_u8; 8].to_vec());
-        // min base fee
-        extra_data.append(&mut MIN_BASE_FEE.to_be_bytes().to_vec());
-        let extra_data = Bytes::from(extra_data);
+        // A real header never carries raw (0, 0) eip1559 params: zero payload-attribute params are
+        // encoded as the chain's default params. Build the parent's extraData the same way.
+        let extra_data = encode_jovian_extra_data(
+            [0u8; 8].into(),
+            jovian_chainspec().base_fee_params_at_timestamp(JOVIAN_TIMESTAMP + BLOCK_TIME_SECONDS),
+            MIN_BASE_FEE,
+        )
+        .unwrap();
 
         let op_chain_spec = jovian_chainspec();
         let parent = Header {
@@ -435,13 +435,14 @@ mod tests {
     fn test_jovian_min_base_fee_cannot_decrease() {
         const MIN_BASE_FEE: u64 = 10;
 
-        let mut extra_data = Vec::new();
-        extra_data.push(JOVIAN_EXTRA_DATA_VERSION_BYTE);
-        // eip1559 params
-        extra_data.append(&mut [0_u8; 8].to_vec());
-        // min base fee
-        extra_data.append(&mut MIN_BASE_FEE.to_be_bytes().to_vec());
-        let extra_data = Bytes::from(extra_data);
+        // A real header never carries raw (0, 0) eip1559 params: zero payload-attribute params are
+        // encoded as the chain's default params. Build the parent's extraData the same way.
+        let extra_data = encode_jovian_extra_data(
+            [0u8; 8].into(),
+            jovian_chainspec().base_fee_params_at_timestamp(JOVIAN_TIMESTAMP + BLOCK_TIME_SECONDS),
+            MIN_BASE_FEE,
+        )
+        .unwrap();
 
         let op_chain_spec = jovian_chainspec();
 
@@ -482,13 +483,14 @@ mod tests {
     fn test_jovian_base_fee_can_decrease_if_above_min_base_fee() {
         const MIN_BASE_FEE: u64 = 10;
 
-        let mut extra_data = Vec::new();
-        extra_data.push(JOVIAN_EXTRA_DATA_VERSION_BYTE);
-        // eip1559 params
-        extra_data.append(&mut [0_u8; 8].to_vec());
-        // min base fee
-        extra_data.append(&mut MIN_BASE_FEE.to_be_bytes().to_vec());
-        let extra_data = Bytes::from(extra_data);
+        // A real header never carries raw (0, 0) eip1559 params: zero payload-attribute params are
+        // encoded as the chain's default params. Build the parent's extraData the same way.
+        let extra_data = encode_jovian_extra_data(
+            [0u8; 8].into(),
+            jovian_chainspec().base_fee_params_at_timestamp(JOVIAN_TIMESTAMP + BLOCK_TIME_SECONDS),
+            MIN_BASE_FEE,
+        )
+        .unwrap();
 
         let op_chain_spec = jovian_chainspec();
 


### PR DESCRIPTION
## Summary

Closes ethereum-optimism/optimism#18951 (follow-up to #18625). Pushes EIP-1559 `extraData` validation down to op-alloy so decoding fails early on invalid params, mirroring op-geth's `validateHoloceneExtraDataPart` and op-reth#20858.

### op-alloy — reject zero denominator/elasticity in extraData decoding
`decode_holocene_extra_data` / `decode_jovian_extra_data` now reject a zero **denominator** (`ZeroDenominator`) or zero **elasticity** (new `ZeroElasticity`), per the Holocene rule that header `extraData` must encode non-zero params.

Note this is the **header extraData** rule only. `(0,0)` in *payload attributes* remains valid and is translated to the canyon defaults at **encode** time (`encode_eip_1559_params`'s `is_zero()` branch) — that path is unchanged.

### kona — simplify, relying on the early op-alloy error
Removes the redundant `denominator == 0` checks in the executor's extraData decoders and drops the now-unreachable `Eip1559ValidationError::ZeroDenominator` variant; errors now flow through `EIP1559ParamError::Zero{Denominator,Elasticity}`.

### op-reth — drop the now-dead both-zero base-fee fallback
With extraData decoding rejecting `(0,0)`, the `elasticity == 0 && denominator == 0 → chain defaults` branch in `decode_holocene_base_fee` / `compute_jovian_base_fee` is unreachable. Removes it and the now-unused `chain_spec` / `timestamp` parameters.

## Testing
- `op-alloy-consensus` (67), `kona-executor` (39, incl. stateless block-execution fixtures), `reth-optimism-chainspec` (23) unit tests pass
- `cargo clippy --all-features -- -D warnings` clean; `cargo +nightly fmt` clean
- Downstream `reth-optimism-consensus` / `reth-optimism-evm` compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
