### PR TITLE
op-node: default --l2.enginekind to reth

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -221,7 +221,7 @@ var (
 			openum.EnumString(engine.Kinds),
 		EnvVars: prefixEnvVars("L2_ENGINE_KIND"),
 		Value: func() *engine.Kind {
-			out := engine.Geth
+			out := engine.Reth
 			return &out
 		}(),
 		Category: RollupCategory,


### PR DESCRIPTION
## Summary

- Changes the default value of `--l2.enginekind` from `geth` to `reth` now that op-geth has reached end of support (2026-05-31)
- The behavioral difference: reth enables `SupportsPostFinalizationELSync`, allowing EL sync even when a finalized block exists on restart

## Test plan

- [ ] Existing engine kind tests cover the behavioral difference (`op-e2e/actions/sync/sync_test.go`)
- [ ] Operators still using op-geth must now explicitly set `--l2.enginekind=geth`

> Note: docs updates (`op-node-config.mdx`, `run-node-from-source.mdx`, `consensus-clients.mdx`) are a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)