### PR TITLE
docs(chain-operators): retarget network design example to op-reth

### DIFF
--- a/docs/public-docs/chain-operators/reference/architecture.mdx
+++ b/docs/public-docs/chain-operators/reference/architecture.mdx
@@ -9,14 +9,14 @@ This document describes an example configuration for an OP Stack network deploym
 
 ## Sequencers
 
-Sequencers receive transactions from the Tx Ingress Nodes via geth p2p gossip and work with the batcher and proposer to create new blocks.
+Sequencers receive transactions from the Tx Ingress Nodes via reth p2p gossip and work with the batcher and proposer to create new blocks.
 
 ### Node Configuration
 
-*   **Sequencer op-geth** can be either full or archive. Full nodes offer better performance but can't recover from deep L1 reorgs, so run at least one archive sequencer as a backup.
+*   **Sequencer op-reth** can be either full or archive. op-reth runs as an archive node by default; pass `--full` to run a (pruned) full node. Full nodes offer better performance but can't recover from deep L1 reorgs, so run at least one archive sequencer as a backup.
 *   **Sequencer op-node** should have p2p discovery disabled and only be statically peered with other internal nodes (or use [peer-management-service](https://github.com/ethereum-optimism/infra/tree/main/peer-mgmt-service) to define peering network).
-*   The **op-conductor** RPC can act as a leader-aware RPC proxy for op-batcher (proxies the necessary op-geth / op-node RPC methods if the node is the leader).
-*   Sequencers should have transaction journalling disabled.
+*   The **op-conductor** RPC can act as a leader-aware RPC proxy for op-batcher (proxies the necessary op-reth / op-node RPC methods if the node is the leader).
+*   Sequencers should have local transaction backup (journalling) disabled.
 
 ### op-node Configuration
 
@@ -26,20 +26,21 @@ OP_NODE_P2P_PEER_BANNING: "false"
 OP_NODE_P2P_STATIC: "<static peer list>"
 ```
 
-### op-geth Configuration
+### op-reth Configuration
 
-```yaml
-GETH_ROLLUP_DISABLETXPOOLGOSSIP: "false"
-GETH_TXPOOL_JOURNAL: ""
-GETH_TXPOOL_JOURNALREMOTES: "false"
-GETH_TXPOOL_LIFETIME: "1h"
-GETH_TXPOOL_NOLOCALS: "true"
-GETH_NETRESTRICT: "10.0.0.0/8" # ex: restrict p2p to internal ips
+op-reth is configured via CLI flags rather than `GETH_*` environment variables:
+
+```sh
+# Leave --rollup.disable-tx-pool-gossip unset so transactions are gossiped to the internal network
+--txpool.disable-transactions-backup   # disable local transaction backup/journalling
+--txpool.lifetime 3600                  # 1h, in seconds
+--txpool.nolocals
+--netrestrict "10.0.0.0/8"              # ex: restrict p2p to internal ips
 ```
 
 ## Tx Ingress Nodes
 
-These nodes receive `eth_sendRawTransaction` calls from the public and then gossip the transactions to the internal geth network. This allows the Sequencer to focus on block creation while these nodes handle transaction ingress.
+These nodes receive `eth_sendRawTransaction` calls from the public and then gossip the transactions to the internal reth network. This allows the Sequencer to focus on block creation while these nodes handle transaction ingress.
 
 ### Node Configuration
 
@@ -48,12 +49,12 @@ These nodes receive `eth_sendRawTransaction` calls from the public and then goss
 
 ### Configuration
 
-```yaml
-GETH_ROLLUP_DISABLETXPOOLGOSSIP: "false"
-GETH_TXPOOL_JOURNALREMOTES: "false"
-GETH_TXPOOL_LIFETIME: "1h"
-GETH_TXPOOL_NOLOCALS: "true"
-GETH_NETRESTRICT: "10.0.0.0/8" # ex: restrict p2p to internal ips
+```sh
+# Leave --rollup.disable-tx-pool-gossip unset so transactions are gossiped to sequencers
+--txpool.disable-transactions-backup
+--txpool.lifetime 3600                  # 1h, in seconds
+--txpool.nolocals
+--netrestrict "10.0.0.0/8"              # ex: restrict p2p to internal ips
 ```
 
 ## Archive RPC Nodes
@@ -67,35 +68,32 @@ We recommend setting up some archive nodes for internal RPC usage, primarily use
 
 ### Configuration
 
-```yaml
-GETH_GCMODE: "archive"
-GETH_DB_ENGINE: "pebble"
-GETH_STATE_SCHEME: "hash"
+op-reth runs as an archive node by default, so no extra flags are required — simply do **not** pass `--full` or `--minimal` (both enable pruning). op-reth stores state in MDBX plus static files, so the geth-specific `GETH_DB_ENGINE` and `GETH_STATE_SCHEME` options have no equivalent.
+
+```sh
+# op-reth is archive by default; no pruning flags needed.
 ```
 
-## Full Snapsync Nodes
+## Full Nodes
 
-These nodes provide peers for snap sync, using the snapsync bootnodes for peer discovery.
+These nodes run as full (pruned) nodes. op-reth does not implement geth-style snap sync; it syncs using its own staged-sync pipeline, so the geth `GETH_SYNCMODE`, `GETH_DB_ENGINE`, and `GETH_STATE_SCHEME` options do not apply.
 
 ### Configuration
 
-```yaml
-GETH_GCMODE: "full"
-GETH_DB_ENGINE: "pebble"
-GETH_STATE_SCHEME: "path"
-GETH_SYNCMODE: "snap"
+```sh
+--full        # run a pruned full node (or --minimal for maximum pruning)
 ```
 
-## Snapsync Bootnodes
+## P2P Bootnodes (Execution Layer)
 
-These bootnodes facilitate peer discovery for public nodes using snapsync.
+These bootnodes facilitate peer discovery for public op-reth nodes.
 
 ### Node Configuration
 
-*   The bootnode can be either a geth instance or the [geth bootnode tool](https://etclabscore.github.io/core-geth/core/alltools/).
-*   If you want to use geth for snapsync bootnodes, you may want to just make the Full Snapsync Nodes serve as your bootnodes as well.
+*   The bootnode can be an op-reth instance or the [geth bootnode tool](https://etclabscore.github.io/core-geth/core/alltools/).
+*   You may want to make your Full Nodes serve as your bootnodes as well.
 
-## P2P Bootnodes
+## P2P Bootnodes (Consensus Layer)
 
 These are the op-node p2p network bootnodes. We recommend using the [geth bootnode tool](https://etclabscore.github.io/core-geth/core/alltools/) with discovery v5 enabled.
 
@@ -106,8 +104,8 @@ Public RPC design is not listed in the above diagram but can be implemented very
 ### Configuration Differences
 
 *   Public RPC should **not** participate in the internal tx pool p2p network.
-    *   While it is possible to run Public RPC from the same nodes that serve Tx Ingress and participate in tx pool gossip, there have been geth bugs in the past that leaked tx pool details on read RPCs, so it is a possible risk to consider.
-*   Public RPC [proxyd](https://github.com/ethereum-optimism/infra/tree/main/proxyd) should be run in `consensus_aware` routing mode and whitelist any RPCs you want to serve from op-geth.
+    *   While it is possible to run Public RPC from the same nodes that serve Tx Ingress and participate in tx pool gossip, there have been execution-client bugs in the past that leaked tx pool details on read RPCs, so it is a possible risk to consider.
+*   Public RPC [proxyd](https://github.com/ethereum-optimism/infra/tree/main/proxyd) should be run in `consensus_aware` routing mode and whitelist any RPCs you want to serve from op-reth.
 *   Public RPC nodes should likely be archive nodes.
 
 ### About proxyd

--- a/docs/public-docs/chain-operators/reference/architecture.mdx
+++ b/docs/public-docs/chain-operators/reference/architecture.mdx
@@ -9,7 +9,7 @@ This document describes an example configuration for an OP Stack network deploym
 
 ## Sequencers
 
-Sequencers receive transactions from the Tx Ingress Nodes via reth p2p gossip and work with the batcher and proposer to create new blocks.
+Sequencers receive transactions from the Tx Ingress Nodes via execution-layer p2p gossip and work with the batcher and proposer to create new blocks.
 
 ### Node Configuration
 
@@ -40,7 +40,7 @@ op-reth is configured via CLI flags rather than `GETH_*` environment variables:
 
 ## Tx Ingress Nodes
 
-These nodes receive `eth_sendRawTransaction` calls from the public and then gossip the transactions to the internal reth network. This allows the Sequencer to focus on block creation while these nodes handle transaction ingress.
+These nodes receive `eth_sendRawTransaction` calls from the public and then gossip the transactions to the internal execution-layer network. This allows the Sequencer to focus on block creation while these nodes handle transaction ingress.
 
 ### Node Configuration
 
@@ -59,7 +59,7 @@ These nodes receive `eth_sendRawTransaction` calls from the public and then goss
 
 ## Archive RPC Nodes
 
-We recommend setting up some archive nodes for internal RPC usage, primarily used by the challenger, proposer, and security monitoring tools like [monitorism](/operators/chain-operators/tools/chain-monitoring#monitorism).
+We recommend setting up some archive nodes for internal RPC usage, primarily used by the challenger, proposer, and security monitoring tools like [monitorism](/chain-operators/tools/chain-monitoring#monitorism).
 
 ### Node Configuration
 

--- a/rust/kona/tests/proofs/sdm_postexec_test.go
+++ b/rust/kona/tests/proofs/sdm_postexec_test.go
@@ -1,0 +1,168 @@
+package proofs
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	sdmpkg "github.com/ethereum-optimism/optimism/op-chain-ops/pkg/sdm"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/rust/kona/tests/proofs/helpers"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
+)
+
+// postExecMode selects which trailing PostExec transaction (if any) the batcher
+// injects into the test block when it is encoded into the span batch.
+type postExecMode int
+
+const (
+	// noPostExec leaves the block untouched: user transactions only.
+	noPostExec postExecMode = iota
+	// validPostExec appends a well-formed, refund-bearing PostExec tx anchored to
+	// the block it lives in.
+	validPostExec
+	// invalidPostExec appends a PostExec tx whose payload is anchored to the wrong
+	// block number, which kona's executor rejects (InvalidPostExecPayload).
+	invalidPostExec
+)
+
+// TestSDMPostExecDerivation exercises op-node derivation of span batches carrying
+// SDM (Sequencer-Defined Metering) PostExec transactions across the Lagoon
+// activation boundary. Lagoon gates SDM and Interop together
+// (IsSDM == IsInterop == IsLagoon), so activating it turns both on at once.
+//
+// This is a derivation-only test: the fault-proof program is intentionally NOT
+// run, for the same reason as the Lagoon branch of TestActivationBlockNUTBundle —
+// the single-chain interop fault-proof host wiring has not landed yet
+// (https://github.com/ethereum-optimism/optimism/issues/21114, item 4). Interop
+// fault proofs are covered in op-acceptance-tests via kona-host super.
+//
+// IMPORTANT HARNESS LIMITATION: the action-test L2 engine is op-geth, which
+// recognizes the PostExec tx *type* but has no SDM *execution* (no refund
+// metering, no payload validation — see core/state_processor.go). A PostExec tx
+// therefore fails execution in the engine queue, and Holocene falls back to a
+// deposit-only block. Consequently BOTH validPostExec and invalidPostExec
+// degrade to a deposit-only block here; the payload-validity distinction is an
+// execution-layer concern verified against op-reth + kona in
+// op-acceptance-tests/tests/sdm. What this test pins on the op-node side is:
+//   - PostExec txs pass the span-batch SDM type-gate once Lagoon is active, and
+//   - an unexecutable payload is replaced by a deposit-only block (and the safe
+//     head still advances), rather than stalling derivation.
+func TestSDMPostExecDerivation(gt *testing.T) {
+	run := func(gt *testing.T, testCfg *helpers.TestCfg[postExecMode]) {
+		t := actionsHelpers.NewDefaultTesting(gt)
+
+		// Schedule Lagoon (= SDM + Interop) after genesis so the test crosses the
+		// activation boundary. Genesis sits at the preceding fork (Karst).
+		lagoonOffset := uint64(4)
+		setup := func(dc *genesis.DeployConfig) {
+			dc.L1PragueTimeOffset = ptr(hexutil.Uint64(0))
+			dc.SetForkTimeOffset(forks.Lagoon, &lagoonOffset)
+		}
+		env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg(), setup)
+
+		// Build empty L2 blocks until SDM/Interop activates, then make them safe.
+		env.Miner.ActEmptyBlock(t)
+		env.Sequencer.ActL1HeadSignal(t)
+		env.Sequencer.ActBuildL2ToFork(t, forks.Lagoon)
+		require.True(t, env.Sd.RollupCfg.IsSDM(env.Sequencer.L2Unsafe().Time),
+			"SDM must be active once Lagoon has activated")
+		env.BatchMineAndSync(t)
+
+		// Build the block under test: a single user transaction (Alice -> Bob).
+		env.Alice.L2.ActResetTxOpts(t)
+		env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)(t)
+		env.Alice.L2.ActMakeTx(t)
+		env.Sequencer.ActL2StartBlock(t)
+		env.Engine.ActL2IncludeTx(env.Alice.Address())(t)
+		env.Sequencer.ActL2EndBlock(t)
+		testBlock := env.Sequencer.L2Unsafe()
+
+		// Buffer the test block, optionally appending a trailing PostExec tx as the
+		// block is encoded into the span batch.
+		var bufferOpts []actionsHelpers.BufferOption
+		switch testCfg.Custom {
+		case validPostExec:
+			// A valid payload anchored to this block, offering a small refund to the
+			// user tx at index 1 (index 0 is the L1-info deposit).
+			pe := postExecTx(t, sdmpkg.PostExecPayload{
+				Version:          sdmpkg.PostExecPayloadVersion,
+				BlockNumber:      testBlock.Number,
+				GasRefundEntries: []sdmpkg.SDMGasEntry{{Index: 1, GasRefund: 1}},
+			})
+			bufferOpts = append(bufferOpts, actionsHelpers.WithBlockModifier(appendTx(pe)))
+		case invalidPostExec:
+			// Wrong block number: kona rejects this as "does not match block number".
+			pe := postExecTx(t, sdmpkg.PostExecPayload{
+				Version:     sdmpkg.PostExecPayloadVersion,
+				BlockNumber: testBlock.Number + 99,
+			})
+			bufferOpts = append(bufferOpts, actionsHelpers.WithBlockModifier(appendTx(pe)))
+		}
+
+		env.Batcher.ActL2BatchBuffer(t, bufferOpts...)
+		env.Batcher.ActL2ChannelClose(t)
+		env.Batcher.ActL2BatchSubmit(t)
+
+		// Include the batcher tx on L1 and derive.
+		env.Miner.ActL1StartBlock(12)(t)
+		env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+		env.Miner.ActL1EndBlock(t)
+		env.Miner.ActL1SafeNext(t)
+		env.Sequencer.ActL1HeadSignal(t)
+		env.Sequencer.ActL2PipelineFull(t)
+
+		// In every case the safe head advances to the test block's height.
+		safe := env.Sequencer.L2Safe()
+		require.Equal(t, testBlock.Number, safe.Number, "safe head should advance to the test block height")
+		safeBlock := env.Engine.L2Chain().GetBlockByHash(safe.Hash)
+		require.NotNil(t, safeBlock, "safe block must be present in the engine")
+
+		if testCfg.Custom == noPostExec {
+			// The honest block derives verbatim: same hash, user tx retained.
+			require.Equal(t, testBlock.Hash, safe.Hash, "no-PostExec block should derive verbatim")
+			require.Len(t, safeBlock.Transactions(), 2, "block should hold the L1-info deposit + 1 user tx")
+			require.False(t, safeBlock.Transactions()[1].IsDepositTx(), "second tx should be the user tx")
+			return
+		}
+
+		// op-geth cannot execute a PostExec tx, so the engine queue rejects the
+		// payload and Holocene installs a deposit-only block in its place.
+		require.NotEqual(t, testBlock.Hash, safe.Hash, "PostExec block must be replaced on derivation")
+		for i, tx := range safeBlock.Transactions() {
+			require.Truef(t, tx.IsDepositTx(), "deposit-only fallback must contain only deposits, tx %d is not a deposit", i)
+		}
+		require.NotEmpty(t,
+			env.Logs.FindLogs(testlog.NewMessageContainsFilter("deposits-only")),
+			"derivation should fall back to deposits-only attributes")
+	}
+
+	matrix := helpers.NewMatrix[postExecMode]()
+	base := helpers.NewForkMatrix(helpers.Karst)
+	matrix.AddTestCase("NoPostExec", noPostExec, base, run, helpers.ExpectNoError())
+	matrix.AddTestCase("ValidPostExec", validPostExec, base, run, helpers.ExpectNoError())
+	matrix.AddTestCase("InvalidPostExec", invalidPostExec, base, run, helpers.ExpectNoError())
+	matrix.Run(gt)
+}
+
+// postExecTx builds a synthetic SDM PostExec transaction (tx type 0x7D) wrapping
+// the RLP-encoded payload.
+func postExecTx(t actionsHelpers.Testing, payload sdmpkg.PostExecPayload) *types.Transaction {
+	data, err := rlp.EncodeToBytes(&payload)
+	require.NoError(t, err, "encode post-exec payload")
+	return types.NewTx(&types.PostExecTx{Data: data})
+}
+
+// appendTx returns a BlockModifier that appends extra as the trailing transaction
+// of the block, leaving the header untouched (re-derivation recomputes roots).
+func appendTx(extra *types.Transaction) actionsHelpers.BlockModifier {
+	return func(block *types.Block) *types.Block {
+		body := block.Body()
+		body.Transactions = append(body.Transactions, extra)
+		return block.WithBody(*body)
+	}
+}


### PR DESCRIPTION
## Description

Updates the [Network Design Example](https://docs.optimism.io/chain-operators/reference/architecture#network-design-example) architecture reference (`docs/public-docs/chain-operators/reference/architecture.mdx`) to use **op-reth** as the execution client instead of op-geth.

### Changes

- Replace all `op-geth` references with `op-reth` (node descriptions, op-conductor RPC proxy, proxyd whitelist, EL gossip/network mentions).
- Convert the `GETH_*` environment-variable config blocks to op-reth CLI flags, verified against `rust/op-reth/crates/node/src/args.rs` and the op-reth CLI reference:
  - `TXPOOL_JOURNAL*` → `--txpool.disable-transactions-backup`
  - `TXPOOL_LIFETIME: "1h"` → `--txpool.lifetime 3600` (reth uses seconds)
  - `TXPOOL_NOLOCALS` → `--txpool.nolocals`
  - `NETRESTRICT` → `--netrestrict`
  - `ROLLUP_DISABLETXPOOLGOSSIP: "false"` → leave `--rollup.disable-tx-pool-gossip` unset (presence-only bool)
  - `GCMODE: archive` → default (no flag); `GCMODE: full` → `--full`
- Document geth-only options with **no op-reth equivalent**: DB engine and state scheme (reth uses MDBX + static files), and snap sync (reth uses staged sync, archive by default).
- Rename **"Full Snapsync Nodes" → "Full Nodes"** and disambiguate the execution-layer vs consensus-layer **"P2P Bootnodes"** sections.

### Follow-up needed

The `network-design-example.png` diagram still shows `op-geth` labels. It's a flattened raster with no editable source in-repo, so it must be relabeled externally (legend `op-geth p2p` entries, every `op-geth` node box, and the renamed section titles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)