### PR TITLE
docs(op-rbuilder): correct stale O(N²) note on sdm_canonical_replay_duration

### DIFF
--- a/rust/op-rbuilder/crates/op-rbuilder/src/metrics.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/metrics.rs
@@ -143,10 +143,9 @@ pub struct OpRBuilderMetrics {
     pub sdm_refund_gas_total: Counter,
     /// SDM gas refunded by the latest produced block.
     pub sdm_refund_gas_per_block: Gauge,
-    /// Histogram of duration spent replaying flashblock txs into a canonical block to attach
-    /// the PostExec tx. Cost is O(N) per invocation in tx count, and the function is invoked
-    /// once per flashblock when SDM PostExec production is active — so cumulative per-block
-    /// cost grows ~O(N²). Useful for tracking the perf impact of the SDM PostExec path.
+    /// Histogram of duration spent materializing the canonical PostExec block. Execution is O(1)
+    /// (only the single PostExec tx runs, not prior txs); cost is dominated by the O(N) clone of
+    /// the accumulated tx/receipt/sender vecs, once per flashblock when SDM PostExec is active.
     pub sdm_canonical_replay_duration: Histogram,
     /// Histogram of tx simulation duration
     pub tx_simulation_duration: Histogram,


### PR DESCRIPTION
## Summary

`materialize_post_exec` replaced the old O(N) full replay (re-executing every prior tx from the parent state) with O(1) single-tx execution on a bundle-seeded prestate. The doc comment on the `sdm_canonical_replay_duration` metric was never updated and still described the path as "O(N) per invocation … cumulative per-block cost grows ~O(N²)", which contradicts `materialize_post_exec`'s own doc.

This reswords the metric comment to reflect reality: execution is O(1), and the per-invocation cost is dominated by the O(N) clone of the accumulated tx/receipt/sender vecs.

Doc-comment-only change; no behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)