### PR TITLE
feat(op-reth): consolidate interop filter metrics into labeled counters

### DIFF
--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -4,7 +4,10 @@ use crate::{
     InvalidCrossTx,
     interop_filter::{
         ExecutingDescriptor, InteropTxValidatorError,
-        metrics::{EndpointMetrics, InteropMetrics},
+        metrics::{
+            EndpointMetrics, InteropMetrics, REASON_NONE, RESULT_ALLOWED, RESULT_REJECTED_FAILSAFE,
+            RESULT_REJECTED_PRE_INTEROP, decision_for_error,
+        },
         parse_access_list_items_to_inbox_entries,
     },
     maintain::FAILSAFE_HEARTBEAT_INTERVAL,
@@ -131,7 +134,7 @@ impl InteropFilterClient {
             }
         }
         // Dropping `futs` here cancels any in-flight slow requests.
-        self.inner.metrics.record_quorum_outcome(valid, invalid, self.inner.min_responses);
+        self.inner.metrics.record_quorum_verdicts_collected(valid + invalid);
 
         if valid + invalid < self.inner.min_responses {
             self.log_degraded_quorum(valid + invalid);
@@ -186,11 +189,13 @@ impl InteropFilterClient {
         // Interop check
         if !is_interop_active {
             // No cross chain tx allowed before interop
+            self.inner.metrics.record_decision(RESULT_REJECTED_PRE_INTEROP, REASON_NONE);
             return Some(Err(InvalidCrossTx::CrossChainTxPreInterop));
         }
 
         // Fast-path: reject immediately if failsafe is active (no RPC round-trip)
         if self.is_failsafe_enabled() {
+            self.inner.metrics.record_decision(RESULT_REJECTED_FAILSAFE, REASON_NONE);
             return Some(Err(InvalidCrossTx::FailsafeEnabled));
         }
 
@@ -203,28 +208,34 @@ impl InteropFilterClient {
         {
             // A failsafe reported by any endpoint maps to the same rejection the fast-path uses.
             if err.is_failsafe() {
+                self.inner.metrics.record_decision(RESULT_REJECTED_FAILSAFE, REASON_NONE);
                 trace!(target: "txpool", hash=%hash, "Cross chain transaction rejected: endpoint failsafe active");
                 return Some(Err(InvalidCrossTx::FailsafeEnabled));
             }
-            self.inner.metrics.increment_metrics_for_error(&err);
+            // Classify the rejection on the single decision counter: a genuine invalid verdict, a
+            // disagreement, and a fail-closed quorum miss are all distinguishable via the labels.
+            let (result, reason) = decision_for_error(&err);
+            self.inner.metrics.record_decision(result, reason);
             trace!(target: "txpool", hash=%hash, err=%err, "Cross chain transaction invalid");
             return Some(Err(InvalidCrossTx::ValidationError(err)));
         }
+        self.inner.metrics.record_decision(RESULT_ALLOWED, REASON_NONE);
         Some(Ok(()))
     }
 
-    /// Records a hard failsafe rejection and flips the cached gate (and gauge) on immediately, so a
-    /// failsafe detected on a check stops admission and is visible on the dashboard right away
-    /// rather than only after the next ~1s failsafe poll. The poll re-confirms or clears it.
+    /// Flips the cached failsafe gate (and gauge) on immediately when a failsafe is detected on a
+    /// check, so admission stops and the dashboard reflects it right away rather than only after
+    /// the next ~1s failsafe poll. The poll re-confirms or clears it. The rejection itself is
+    /// counted on the decision counter by [`is_valid_cross_tx`](Self::is_valid_cross_tx).
     fn reject_failsafe(&self) -> InteropTxValidatorError {
-        self.inner.metrics.record_failsafe_reject();
         self.apply_failsafe_state(true);
         InteropTxValidatorError::FailsafeEnabled
     }
 
     /// Logs a rate-limited line when a check fails closed because too few endpoints reached the
     /// quorum. A degraded quorum silently rejects every interop tx, so without this the only signal
-    /// is the `quorum_reject_not_reached` counter; the log makes the halted state visible. Logged
+    /// is the `filter_decisions_total{result="rejected_no_quorum"}` counter; the log makes the
+    /// halted state visible. Logged
     /// at most once per [`FAILSAFE_HEARTBEAT_INTERVAL`] (and on the first occurrence) to avoid
     /// per-tx spam, and at `info` because the rejection itself is expected, by-design
     /// fail-closed behavior.
@@ -473,6 +484,11 @@ impl InteropFilterClientBuilder {
             clients.push(Endpoint { client, metrics });
         }
 
+        // Publish the quorum threshold once so dashboards can draw the fail-closed line against
+        // `quorum_verdicts_collected` without hardcoding config.
+        let metrics = InteropMetrics::default();
+        metrics.set_quorum_min_responses(min_responses);
+
         InteropFilterClient {
             inner: Arc::new(InteropFilterClientInner {
                 endpoints: clients,
@@ -480,7 +496,7 @@ impl InteropFilterClientBuilder {
                 chain_id,
                 safety,
                 timeout,
-                metrics: InteropMetrics::default(),
+                metrics,
                 failsafe_enabled: AtomicBool::new(false),
                 created_at: Instant::now(),
                 last_degraded_log_ms: AtomicU64::new(0),

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -133,8 +133,6 @@ impl InteropFilterClient {
                 break;
             }
         }
-        // Dropping `futs` here cancels any in-flight slow requests.
-        self.inner.metrics.record_quorum_verdicts_collected(valid + invalid);
 
         if valid + invalid < self.inner.min_responses {
             self.log_degraded_quorum(valid + invalid);
@@ -234,7 +232,7 @@ impl InteropFilterClient {
 
     /// Logs a rate-limited line when a check fails closed because too few endpoints reached the
     /// quorum. A degraded quorum silently rejects every interop tx, so without this the only signal
-    /// is the `filter_decisions_total{result="rejected_no_quorum"}` counter; the log makes the
+    /// is the `filter_decisions{result="rejected_no_quorum"}` counter; the log makes the
     /// halted state visible. Logged
     /// at most once per [`FAILSAFE_HEARTBEAT_INTERVAL`] (and on the first occurrence) to avoid
     /// per-tx spam, and at `info` because the rejection itself is expected, by-design
@@ -484,10 +482,11 @@ impl InteropFilterClientBuilder {
             clients.push(Endpoint { client, metrics });
         }
 
-        // Publish the quorum threshold once so dashboards can draw the fail-closed line against
-        // `quorum_verdicts_collected` without hardcoding config.
+        // Publish the quorum threshold once so dashboards can draw the fail-closed line for
+        // `sum(endpoint.up)` without hardcoding config, and pre-create the decision series at 0.
         let metrics = InteropMetrics::default();
         metrics.set_quorum_min_responses(min_responses);
+        metrics.init();
 
         InteropFilterClient {
             inner: Arc::new(InteropFilterClientInner {

--- a/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
@@ -4,7 +4,10 @@ use crate::interop_filter::InteropTxValidatorError;
 use op_alloy_rpc_types::SuperchainDAError;
 use reth_metrics::{
     Metrics,
-    metrics::{Counter, Gauge, Histogram, counter, histogram},
+    metrics::{
+        Counter, Gauge, Histogram, Unit, counter, describe_counter, describe_gauge,
+        describe_histogram, gauge, histogram,
+    },
 };
 use std::time::Duration;
 
@@ -12,18 +15,27 @@ use std::time::Duration;
 /// reaches the filter increments this exactly once, labeled by `result` (and `reason`, where a
 /// result carries a sub-classification). It is the one source of truth for the decision taxonomy:
 /// `sum by (result)` is the outcome breakdown (including the former `quorum_*` counters), and
-/// `sum by (reason) (filter_decisions_total{result="rejected_invalid"})` is the DA-reason breakdown
-/// (the former per-reason `*_count` counters).
-const FILTER_DECISIONS: &str = "optimism_transaction_pool.interop.filter_decisions_total";
+/// `sum by (reason) (filter_decisions{result="rejected_invalid"})` is the DA-reason breakdown
+/// (the former per-reason `*_count` counters). No `_total` suffix: the Prometheus recorder does not
+/// append one (unit suffixes are disabled), matching the rest of the reth counter naming.
+const FILTER_DECISIONS: &str = "optimism_transaction_pool.interop.filter_decisions";
 
 /// Fully-qualified name of the per-endpoint verdict counter, labeled by `endpoint` index and
 /// `verdict`. Answers *which* endpoint is returning invalids or going unavailable. Labeled by index
 /// (not the raw URL), since interop-http URLs can carry basic-auth credentials.
-const ENDPOINT_VERDICTS: &str = "optimism_transaction_pool.interop.endpoint.verdicts_total";
+const ENDPOINT_VERDICTS: &str = "optimism_transaction_pool.interop.endpoint.verdicts";
 
 /// Fully-qualified name of the per-endpoint query-latency histogram. Matches the metric the derived
 /// `EndpointMetrics` used to emit, so existing dashboards keep working.
 const ENDPOINT_QUERY_LATENCY: &str = "optimism_transaction_pool.interop.endpoint.query_latency";
+
+/// Fully-qualified name of the per-endpoint health gauge: `1` if the endpoint answered its last
+/// *completed* check (valid or invalid — both mean it responded), `0` if that check was a
+/// non-response. Left untouched when a check is cancelled by fast-accept, so it reflects the last
+/// real outcome. `sum(endpoint.up)` against
+/// [`quorum_min_responses`](InteropMetrics::quorum_min_responses) is the fail-closed headroom: it
+/// drops as endpoints fall away, *before* quorum is lost.
+const ENDPOINT_UP: &str = "optimism_transaction_pool.interop.endpoint.up";
 
 /// `result` label values for [`InteropMetrics::record_decision`]. Every transaction that reaches
 /// the interop filter records exactly one of these. Low-cardinality and stable.
@@ -71,14 +83,9 @@ pub struct InteropMetrics {
     /// rejected/evicted), `0` if disabled. Refreshed on every failsafe poll.
     pub(crate) failsafe_enabled: Gauge,
 
-    /// Distribution of definitive verdicts (valid + invalid) collected per check. Watch the low
-    /// percentile against [`quorum_min_responses`](Self::quorum_min_responses): when it approaches
-    /// the threshold, the filter is one endpoint blip away from failing closed on every interop tx
-    /// — a leading indicator the outcome counts alone cannot give.
-    pub(crate) quorum_verdicts_collected: Histogram,
-
     /// The configured quorum threshold (minimum definitive verdicts required to decide a check).
-    /// Set once at startup so a dashboard can draw the fail-closed line without hardcoding config.
+    /// Set once at startup so a dashboard can draw the fail-closed line for `sum(endpoint.up)`
+    /// without hardcoding config.
     pub(crate) quorum_min_responses: Gauge,
 }
 
@@ -88,7 +95,7 @@ pub struct InteropMetrics {
 /// client.
 ///
 /// Hand-rolled rather than `#[derive(Metrics)]` so the three verdicts collapse into a single
-/// `verdicts_total{verdict=…}` counter instead of three separate metrics.
+/// `verdicts{verdict=…}` counter instead of three separate metrics.
 #[derive(Clone, Debug)]
 pub struct EndpointMetrics {
     /// How long this endpoint took to answer an `interop_checkAccessList` query. Lets an endpoint
@@ -98,9 +105,11 @@ pub struct EndpointMetrics {
     valid: Counter,
     /// Definitive invalid verdicts returned by this endpoint.
     invalid: Counter,
-    /// Non-responses from this endpoint (timeout, transport error, soft out-of-sync,
-    /// cancellation).
+    /// Non-responses from this endpoint (timeout, transport error, soft out-of-sync).
     unavailable: Counter,
+    /// `1` if this endpoint's last completed check produced a verdict, `0` if it was a
+    /// non-response. See [`ENDPOINT_UP`].
+    up: Gauge,
 }
 
 impl EndpointMetrics {
@@ -108,11 +117,16 @@ impl EndpointMetrics {
     /// are resolved once here (not per-call) since each endpoint is built once at startup.
     pub fn for_endpoint(index: usize) -> Self {
         let endpoint = index.to_string();
+        let up = gauge!(ENDPOINT_UP, "endpoint" => endpoint.clone());
+        // Assume healthy until a check proves otherwise, so `sum(endpoint.up)` reads at full quorum
+        // headroom from boot instead of the series being absent until the first failure.
+        up.set(1.0);
         Self {
             query_latency: histogram!(ENDPOINT_QUERY_LATENCY, "endpoint" => endpoint.clone()),
             valid: counter!(ENDPOINT_VERDICTS, "endpoint" => endpoint.clone(), "verdict" => VERDICT_VALID),
             invalid: counter!(ENDPOINT_VERDICTS, "endpoint" => endpoint.clone(), "verdict" => VERDICT_INVALID),
             unavailable: counter!(ENDPOINT_VERDICTS, "endpoint" => endpoint, "verdict" => VERDICT_UNAVAILABLE),
+            up,
         }
     }
 
@@ -122,22 +136,26 @@ impl EndpointMetrics {
         self.query_latency.record(duration.as_secs_f64());
     }
 
-    /// Records this endpoint's definitive valid verdict.
+    /// Records this endpoint's definitive valid verdict (a valid verdict still means it responded).
     #[inline]
     pub fn record_valid(&self) {
         self.valid.increment(1);
+        self.up.set(1.0);
     }
 
-    /// Records this endpoint's definitive invalid verdict.
+    /// Records this endpoint's definitive invalid verdict (an invalid verdict still means it
+    /// responded).
     #[inline]
     pub fn record_invalid(&self) {
         self.invalid.increment(1);
+        self.up.set(1.0);
     }
 
     /// Records this endpoint's non-response (timeout, transport error, soft out-of-sync).
     #[inline]
     pub fn record_unavailable(&self) {
         self.unavailable.increment(1);
+        self.up.set(0.0);
     }
 }
 
@@ -160,11 +178,18 @@ impl InteropMetrics {
         self.quorum_min_responses.set(min_responses as f64);
     }
 
-    /// Records how many definitive verdicts (valid + invalid) a check collected, for the
-    /// fail-closed margin signal. Called once per check.
-    #[inline]
-    pub fn record_quorum_verdicts_collected(&self, collected: usize) {
-        self.quorum_verdicts_collected.record(collected as f64);
+    /// Registers HELP descriptions for the hand-rolled metrics and pre-creates every decision
+    /// series at `0`. Called once at startup.
+    ///
+    /// Both are needed because `counter!`/`gauge!`/`histogram!` (unlike `#[derive(Metrics)]`) carry
+    /// no description and create a series only on first use — so an outcome that has never happened
+    /// would otherwise be *absent*, making `rate(filter_decisions{result="rejected_no_quorum"})`
+    /// return empty instead of `0` and silently breaking fail-closed alerting.
+    pub fn init(&self) {
+        describe_metrics();
+        for (result, reason) in canonical_decisions() {
+            counter!(FILTER_DECISIONS, "result" => result, "reason" => reason).increment(0);
+        }
     }
 
     /// Records a single interop filter decision under the given `result` and `reason` labels.
@@ -225,6 +250,74 @@ pub(crate) const fn decision_for_error(
             (RESULT_ERRORED, REASON_OTHER)
         }
     }
+}
+
+/// Decision pairs that are not sub-classified by a DA reason. Combined with one
+/// `(rejected_invalid, <reason>)` pair per [`CLASSIFIED_DA_REASONS`] entry, this is every series
+/// the filter can emit — the set [`InteropMetrics::init`] pre-creates at `0`. Kept beside
+/// [`decision_for_error`] so the two stay in lockstep.
+const STRUCTURAL_DECISIONS: &[(&str, &str)] = &[
+    (RESULT_ALLOWED, REASON_NONE),
+    (RESULT_REJECTED_PRE_INTEROP, REASON_NONE),
+    (RESULT_REJECTED_FAILSAFE, REASON_NONE),
+    (RESULT_REJECTED_DISAGREEMENT, REASON_NONE),
+    (RESULT_REJECTED_NO_QUORUM, REASON_NONE),
+    (RESULT_ERRORED, REASON_TIMEOUT),
+    (RESULT_ERRORED, REASON_OTHER),
+    // A definitive rejection that carries no recognized DA reason (e.g. a generic `-32602`).
+    (RESULT_REJECTED_INVALID, REASON_OTHER),
+];
+
+/// Every DA error variant [`validation_reason`] maps to a dedicated `reason` label. Drives the
+/// `rejected_invalid` zero-init through `validation_reason` so the reason strings have a single
+/// source of truth. A new, unmapped DA variant falls through to [`REASON_OTHER`] (already covered
+/// by [`STRUCTURAL_DECISIONS`]), so it is never left uncounted.
+const CLASSIFIED_DA_REASONS: &[SuperchainDAError] = &[
+    SuperchainDAError::SkippedData,
+    SuperchainDAError::UnknownChain,
+    SuperchainDAError::ConflictingData,
+    SuperchainDAError::IneffectiveData,
+    SuperchainDAError::OutOfOrder,
+    SuperchainDAError::AwaitingReplacement,
+    SuperchainDAError::OutOfScope,
+    SuperchainDAError::NoParentForFirstBlock,
+    SuperchainDAError::FutureData,
+    SuperchainDAError::MissedData,
+    SuperchainDAError::DataCorruption,
+];
+
+/// Every `(result, reason)` series the filter can emit — the single source of truth for the
+/// zero-init in [`InteropMetrics::init`].
+fn canonical_decisions() -> impl Iterator<Item = (&'static str, &'static str)> {
+    STRUCTURAL_DECISIONS.iter().copied().chain(
+        CLASSIFIED_DA_REASONS
+            .iter()
+            .map(|reason| (RESULT_REJECTED_INVALID, validation_reason(reason))),
+    )
+}
+
+/// Registers HELP text for the metrics created via the `counter!`/`gauge!`/`histogram!` macros (the
+/// `#[derive(Metrics)]` fields get theirs from doc comments). Idempotent; called from
+/// [`InteropMetrics::init`].
+fn describe_metrics() {
+    describe_counter!(
+        FILTER_DECISIONS,
+        "Interop filter decisions, one per interop tx reaching the filter (labels: result, reason)"
+    );
+    describe_counter!(
+        ENDPOINT_VERDICTS,
+        "Per-endpoint interop verdicts (labels: endpoint, verdict)"
+    );
+    describe_histogram!(
+        ENDPOINT_QUERY_LATENCY,
+        Unit::Seconds,
+        "Per-endpoint interop_checkAccessList query latency"
+    );
+    describe_gauge!(
+        ENDPOINT_UP,
+        "1 if an interop endpoint answered its last completed check, else 0; sum vs \
+         quorum_min_responses is the fail-closed headroom (labels: endpoint)"
+    );
 }
 
 #[cfg(test)]
@@ -306,5 +399,44 @@ mod tests {
             (RESULT_ERRORED, REASON_OTHER)
         );
         assert_eq!(decision_for_error(&server_error()), (RESULT_ERRORED, REASON_OTHER));
+    }
+
+    /// Guards [`InteropMetrics::init`] against drift: every decision the filter can emit must be in
+    /// the pre-created set, or its series goes absent until the first occurrence (breaking
+    /// `rate()`-based alerts on never-yet-seen outcomes).
+    #[test]
+    fn canonical_decisions_covers_every_emitted_pair() {
+        let canonical: std::collections::HashSet<_> = canonical_decisions().collect();
+
+        // Pre-filter gates, recorded directly in `is_valid_cross_tx` (not via
+        // `decision_for_error`).
+        for pair in [
+            (RESULT_ALLOWED, REASON_NONE),
+            (RESULT_REJECTED_PRE_INTEROP, REASON_NONE),
+            (RESULT_REJECTED_FAILSAFE, REASON_NONE),
+        ] {
+            assert!(canonical.contains(&pair), "gate decision {pair:?} not pre-created");
+        }
+
+        // Every non-`InvalidEntry` outcome `decision_for_error` can return.
+        let errors = [
+            InteropTxValidatorError::Rejected { code: -32602, message: String::new() },
+            InteropTxValidatorError::Disagreement { valid: 1, invalid: 1 },
+            InteropTxValidatorError::QuorumNotReached { received: 1, required: 2 },
+            InteropTxValidatorError::FailsafeEnabled,
+            InteropTxValidatorError::Timeout(1),
+            InteropTxValidatorError::DataUnavailable { code: -1 },
+            server_error(),
+        ];
+        for err in &errors {
+            let pair = decision_for_error(err);
+            assert!(canonical.contains(&pair), "decision {pair:?} not pre-created");
+        }
+
+        // Every classified DA reason, routed through `decision_for_error` like production does.
+        for reason in CLASSIFIED_DA_REASONS {
+            let pair = decision_for_error(&InteropTxValidatorError::InvalidEntry(*reason));
+            assert!(canonical.contains(&pair), "invalid decision {pair:?} not pre-created");
+        }
     }
 }

--- a/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
@@ -4,80 +4,116 @@ use crate::interop_filter::InteropTxValidatorError;
 use op_alloy_rpc_types::SuperchainDAError;
 use reth_metrics::{
     Metrics,
-    metrics::{Counter, Gauge, Histogram, Label},
+    metrics::{Counter, Gauge, Histogram, counter, histogram},
 };
 use std::time::Duration;
+
+/// Fully-qualified name of the single per-tx interop filter decision counter. Every interop tx that
+/// reaches the filter increments this exactly once, labeled by `result` (and `reason`, where a
+/// result carries a sub-classification). It is the one source of truth for the decision taxonomy:
+/// `sum by (result)` is the outcome breakdown (including the former `quorum_*` counters), and
+/// `sum by (reason) (filter_decisions_total{result="rejected_invalid"})` is the DA-reason breakdown
+/// (the former per-reason `*_count` counters).
+const FILTER_DECISIONS: &str = "optimism_transaction_pool.interop.filter_decisions_total";
+
+/// Fully-qualified name of the per-endpoint verdict counter, labeled by `endpoint` index and
+/// `verdict`. Answers *which* endpoint is returning invalids or going unavailable. Labeled by index
+/// (not the raw URL), since interop-http URLs can carry basic-auth credentials.
+const ENDPOINT_VERDICTS: &str = "optimism_transaction_pool.interop.endpoint.verdicts_total";
+
+/// Fully-qualified name of the per-endpoint query-latency histogram. Matches the metric the derived
+/// `EndpointMetrics` used to emit, so existing dashboards keep working.
+const ENDPOINT_QUERY_LATENCY: &str = "optimism_transaction_pool.interop.endpoint.query_latency";
+
+/// `result` label values for [`InteropMetrics::record_decision`]. Every transaction that reaches
+/// the interop filter records exactly one of these. Low-cardinality and stable.
+pub(crate) const RESULT_ALLOWED: &str = "allowed";
+/// Rejected because the interop hardfork is not yet active at this block (a cross-chain tx cannot
+/// exist pre-activation). A local gate — the filter is not contacted.
+pub(crate) const RESULT_REJECTED_PRE_INTEROP: &str = "rejected_pre_interop";
+/// Rejected because failsafe is active (fast-path cached gate, or an endpoint reported failsafe
+/// during the check). All interop txs are rejected while failsafe is on.
+pub(crate) const RESULT_REJECTED_FAILSAFE: &str = "rejected_failsafe";
+/// The filter reached quorum and the verdict was invalid (a genuine invalid-entry verdict). The
+/// `reason` label carries the DA reason.
+pub(crate) const RESULT_REJECTED_INVALID: &str = "rejected_invalid";
+/// The endpoints that responded definitively disagreed (a mix of valid and invalid).
+pub(crate) const RESULT_REJECTED_DISAGREEMENT: &str = "rejected_disagreement";
+/// Too few definitive verdicts were collected to satisfy the configured quorum (fail closed).
+pub(crate) const RESULT_REJECTED_NO_QUORUM: &str = "rejected_no_quorum";
+/// No trustworthy answer was produced for this tx (a non-response surfaced as the decision). The
+/// quorum aggregator never returns this — it folds non-responses into `rejected_no_quorum` — so
+/// this is a defensive catch-all that keeps every decision counted.
+pub(crate) const RESULT_ERRORED: &str = "errored";
+
+/// `reason` label value when a `result` has no sub-classification.
+pub(crate) const REASON_NONE: &str = "none";
+/// `reason` label value for a definitive rejection that carries no recognized DA reason (a generic
+/// filter rejection, or a DA variant without a dedicated label), and for an unclassified error.
+pub(crate) const REASON_OTHER: &str = "other";
+/// `reason` label value for a query that timed out.
+pub(crate) const REASON_TIMEOUT: &str = "timeout";
+
+/// `verdict` label values for [`EndpointMetrics`].
+const VERDICT_VALID: &str = "valid";
+const VERDICT_INVALID: &str = "invalid";
+const VERDICT_UNAVAILABLE: &str = "unavailable";
 
 /// Optimism interop txpool metrics.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "optimism_transaction_pool.interop")]
 pub struct InteropMetrics {
-    /// How long it takes to query the interop filter in the Optimism transaction pool.
+    /// How long it takes to query the interop filter in the Optimism transaction pool (fleet-wide
+    /// across endpoints).
     pub(crate) interop_query_latency: Histogram,
-
-    /// Counter for the number of times data was skipped
-    pub(crate) skipped_data_count: Counter,
-    /// Counter for the number of times an unknown chain was encountered
-    pub(crate) unknown_chain_count: Counter,
-    /// Counter for the number of times conflicting data was encountered
-    pub(crate) conflicting_data_count: Counter,
-    /// Counter for the number of times ineffective data was encountered
-    pub(crate) ineffective_data_count: Counter,
-    /// Counter for the number of times data was out of order
-    pub(crate) out_of_order_count: Counter,
-    /// Counter for the number of times data was awaiting replacement
-    pub(crate) awaiting_replacement_count: Counter,
-    /// Counter for the number of times data was out of scope
-    pub(crate) out_of_scope_count: Counter,
-    /// Counter for the number of times there was no parent for the first block
-    pub(crate) no_parent_for_first_block_count: Counter,
-    /// Counter for the number of times future data was encountered
-    pub(crate) future_data_count: Counter,
-    /// Counter for the number of times data was missed
-    pub(crate) missed_data_count: Counter,
-    /// Counter for the number of times data corruption was encountered
-    pub(crate) data_corruption_count: Counter,
 
     /// Current interop failsafe state: `1` if failsafe is enabled (all interop txs are
     /// rejected/evicted), `0` if disabled. Refreshed on every failsafe poll.
     pub(crate) failsafe_enabled: Gauge,
 
-    /// Quorum accepted: enough definitive verdicts collected and all agreed valid.
-    pub(crate) quorum_accept: Counter,
-    /// Quorum rejected: enough definitive verdicts collected and all agreed invalid.
-    pub(crate) quorum_reject_agreed: Counter,
-    /// Quorum rejected: collected verdicts disagreed (mix of valid and invalid).
-    pub(crate) quorum_reject_disagreement: Counter,
-    /// Quorum rejected: fewer definitive verdicts than required were collected (fail closed).
-    pub(crate) quorum_reject_not_reached: Counter,
-    /// Quorum rejected: an endpoint reported its failsafe active (hard short-circuit rejection).
-    pub(crate) quorum_reject_failsafe: Counter,
+    /// Distribution of definitive verdicts (valid + invalid) collected per check. Watch the low
+    /// percentile against [`quorum_min_responses`](Self::quorum_min_responses): when it approaches
+    /// the threshold, the filter is one endpoint blip away from failing closed on every interop tx
+    /// — a leading indicator the outcome counts alone cannot give.
+    pub(crate) quorum_verdicts_collected: Histogram,
+
+    /// The configured quorum threshold (minimum definitive verdicts required to decide a check).
+    /// Set once at startup so a dashboard can draw the fail-closed line without hardcoding config.
+    pub(crate) quorum_min_responses: Gauge,
 }
 
 /// Per-endpoint interop metrics, labeled by endpoint index so each configured interop filter can be
 /// observed independently. With the fleet-wide counters alone you can tell *an* endpoint is slow or
 /// down; these labeled metrics answer *which* one — the first question on call for a fan-out
-/// client. Labeled by index (not the raw URL), since interop-http URLs can carry basic-auth
-/// credentials.
-#[derive(Metrics, Clone)]
-#[metrics(scope = "optimism_transaction_pool.interop.endpoint")]
+/// client.
+///
+/// Hand-rolled rather than `#[derive(Metrics)]` so the three verdicts collapse into a single
+/// `verdicts_total{verdict=…}` counter instead of three separate metrics.
+#[derive(Clone, Debug)]
 pub struct EndpointMetrics {
     /// How long this endpoint took to answer an `interop_checkAccessList` query. Lets an endpoint
     /// creeping toward the request timeout be spotted before it starts failing.
-    pub(crate) query_latency: Histogram,
+    query_latency: Histogram,
     /// Definitive valid verdicts returned by this endpoint.
-    pub(crate) valid: Counter,
+    valid: Counter,
     /// Definitive invalid verdicts returned by this endpoint.
-    pub(crate) invalid: Counter,
+    invalid: Counter,
     /// Non-responses from this endpoint (timeout, transport error, soft out-of-sync,
     /// cancellation).
-    pub(crate) unavailable: Counter,
+    unavailable: Counter,
 }
 
 impl EndpointMetrics {
-    /// Builds per-endpoint metrics labeled with the endpoint's index.
+    /// Builds per-endpoint metrics labeled with the endpoint's index. Counter and histogram handles
+    /// are resolved once here (not per-call) since each endpoint is built once at startup.
     pub fn for_endpoint(index: usize) -> Self {
-        Self::new_with_labels(vec![Label::new("endpoint", index.to_string())])
+        let endpoint = index.to_string();
+        Self {
+            query_latency: histogram!(ENDPOINT_QUERY_LATENCY, "endpoint" => endpoint.clone()),
+            valid: counter!(ENDPOINT_VERDICTS, "endpoint" => endpoint.clone(), "verdict" => VERDICT_VALID),
+            invalid: counter!(ENDPOINT_VERDICTS, "endpoint" => endpoint.clone(), "verdict" => VERDICT_INVALID),
+            unavailable: counter!(ENDPOINT_VERDICTS, "endpoint" => endpoint, "verdict" => VERDICT_UNAVAILABLE),
+        }
     }
 
     /// Records the duration of this endpoint's interop filter query.
@@ -118,51 +154,157 @@ impl InteropMetrics {
         self.failsafe_enabled.set(if enabled { 1.0 } else { 0.0 });
     }
 
-    /// Records the outcome of a multi-endpoint quorum decision. Increments exactly one of the
-    /// `quorum_*` counters based on the collected verdicts. This is the sole signal for the
-    /// [`Disagreement`](InteropTxValidatorError::Disagreement) and
-    /// [`QuorumNotReached`](InteropTxValidatorError::QuorumNotReached) outcomes, which
-    /// [`increment_metrics_for_error`](Self::increment_metrics_for_error) does not record.
-    pub fn record_quorum_outcome(&self, valid: usize, invalid: usize, min_responses: usize) {
-        if valid + invalid < min_responses {
-            self.quorum_reject_not_reached.increment(1);
-        } else if invalid == 0 {
-            self.quorum_accept.increment(1);
-        } else if valid == 0 {
-            self.quorum_reject_agreed.increment(1);
-        } else {
-            self.quorum_reject_disagreement.increment(1);
-        }
-    }
-
-    /// Records a hard failsafe rejection: an endpoint reported its failsafe active and the check
-    /// was short-circuited.
+    /// Records the configured quorum threshold. Called once at startup.
     #[inline]
-    pub fn record_failsafe_reject(&self) {
-        self.quorum_reject_failsafe.increment(1);
+    pub fn set_quorum_min_responses(&self, min_responses: usize) {
+        self.quorum_min_responses.set(min_responses as f64);
     }
 
-    /// Increments the metrics for the given error
-    pub fn increment_metrics_for_error(&self, error: &InteropTxValidatorError) {
-        if let InteropTxValidatorError::InvalidEntry(inner) = error {
-            match inner {
-                SuperchainDAError::SkippedData => self.skipped_data_count.increment(1),
-                SuperchainDAError::UnknownChain => self.unknown_chain_count.increment(1),
-                SuperchainDAError::ConflictingData => self.conflicting_data_count.increment(1),
-                SuperchainDAError::IneffectiveData => self.ineffective_data_count.increment(1),
-                SuperchainDAError::OutOfOrder => self.out_of_order_count.increment(1),
-                SuperchainDAError::AwaitingReplacement => {
-                    self.awaiting_replacement_count.increment(1)
-                }
-                SuperchainDAError::OutOfScope => self.out_of_scope_count.increment(1),
-                SuperchainDAError::NoParentForFirstBlock => {
-                    self.no_parent_for_first_block_count.increment(1)
-                }
-                SuperchainDAError::FutureData => self.future_data_count.increment(1),
-                SuperchainDAError::MissedData => self.missed_data_count.increment(1),
-                SuperchainDAError::DataCorruption => self.data_corruption_count.increment(1),
-                _ => {}
-            }
+    /// Records how many definitive verdicts (valid + invalid) a check collected, for the
+    /// fail-closed margin signal. Called once per check.
+    #[inline]
+    pub fn record_quorum_verdicts_collected(&self, collected: usize) {
+        self.quorum_verdicts_collected.record(collected as f64);
+    }
+
+    /// Records a single interop filter decision under the given `result` and `reason` labels.
+    ///
+    /// Both must be one of the `RESULT_*` / `REASON_*` constants (or a DA reason from
+    /// [`validation_reason`]) so the label set stays low-cardinality and stable. Use
+    /// [`decision_for_error`] to derive the pair from a validation error.
+    #[inline]
+    pub fn record_decision(&self, result: &'static str, reason: &'static str) {
+        counter!(FILTER_DECISIONS, "result" => result, "reason" => reason).increment(1);
+    }
+}
+
+/// Maps a DA validation error to its stable `reason` label.
+pub(crate) const fn validation_reason(error: &SuperchainDAError) -> &'static str {
+    match error {
+        SuperchainDAError::SkippedData => "skipped_data",
+        SuperchainDAError::UnknownChain => "unknown_chain",
+        SuperchainDAError::ConflictingData => "conflicting_data",
+        SuperchainDAError::IneffectiveData => "ineffective_data",
+        SuperchainDAError::OutOfOrder => "out_of_order",
+        SuperchainDAError::AwaitingReplacement => "awaiting_replacement",
+        SuperchainDAError::OutOfScope => "out_of_scope",
+        SuperchainDAError::NoParentForFirstBlock => "no_parent_for_first_block",
+        SuperchainDAError::FutureData => "future_data",
+        SuperchainDAError::MissedData => "missed_data",
+        SuperchainDAError::DataCorruption => "data_corruption",
+        _ => REASON_OTHER,
+    }
+}
+
+/// Maps a validation failure to its `(result, reason)` decision labels. This is the single source
+/// of truth for how an [`InteropTxValidatorError`] is classified on the `filter_decisions_total`
+/// counter. Failsafe is handled before this is reached (it rejects on the fast-path and on
+/// detection), but is mapped here too for completeness.
+///
+/// The quorum aggregator only ever returns `InvalidEntry`, `Rejected`, `Disagreement`,
+/// `QuorumNotReached`, or `FailsafeEnabled`; the remaining arms are defensive so every decision is
+/// counted regardless of future changes to the aggregator.
+pub(crate) const fn decision_for_error(
+    error: &InteropTxValidatorError,
+) -> (&'static str, &'static str) {
+    match error {
+        // The filter reached quorum and answered "invalid".
+        InteropTxValidatorError::InvalidEntry(reason) => {
+            (RESULT_REJECTED_INVALID, validation_reason(reason))
         }
+        // A definitive rejection that is not a recognized DA code (e.g. a generic `-32602`).
+        InteropTxValidatorError::Rejected { .. } => (RESULT_REJECTED_INVALID, REASON_OTHER),
+        InteropTxValidatorError::Disagreement { .. } => (RESULT_REJECTED_DISAGREEMENT, REASON_NONE),
+        InteropTxValidatorError::QuorumNotReached { .. } => {
+            (RESULT_REJECTED_NO_QUORUM, REASON_NONE)
+        }
+        InteropTxValidatorError::FailsafeEnabled => (RESULT_REJECTED_FAILSAFE, REASON_NONE),
+        InteropTxValidatorError::Timeout(_) => (RESULT_ERRORED, REASON_TIMEOUT),
+        // Non-responses that never surface as the aggregate's decision; counted defensively.
+        InteropTxValidatorError::DataUnavailable { .. } | InteropTxValidatorError::Other(_) => {
+            (RESULT_ERRORED, REASON_OTHER)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn server_error() -> InteropTxValidatorError {
+        InteropTxValidatorError::other(std::io::Error::other("filter unreachable"))
+    }
+
+    #[test]
+    fn validation_reason_maps_every_da_error() {
+        assert_eq!(validation_reason(&SuperchainDAError::SkippedData), "skipped_data");
+        assert_eq!(validation_reason(&SuperchainDAError::UnknownChain), "unknown_chain");
+        assert_eq!(validation_reason(&SuperchainDAError::ConflictingData), "conflicting_data");
+        assert_eq!(validation_reason(&SuperchainDAError::IneffectiveData), "ineffective_data");
+        assert_eq!(validation_reason(&SuperchainDAError::OutOfOrder), "out_of_order");
+        assert_eq!(
+            validation_reason(&SuperchainDAError::AwaitingReplacement),
+            "awaiting_replacement"
+        );
+        assert_eq!(validation_reason(&SuperchainDAError::OutOfScope), "out_of_scope");
+        assert_eq!(
+            validation_reason(&SuperchainDAError::NoParentForFirstBlock),
+            "no_parent_for_first_block"
+        );
+        assert_eq!(validation_reason(&SuperchainDAError::FutureData), "future_data");
+        assert_eq!(validation_reason(&SuperchainDAError::MissedData), "missed_data");
+        assert_eq!(validation_reason(&SuperchainDAError::DataCorruption), "data_corruption");
+        // Unmapped DA variants fall back to a stable catch-all.
+        assert_eq!(validation_reason(&SuperchainDAError::InvalidatedRead), REASON_OTHER);
+    }
+
+    #[test]
+    fn decision_for_error_maps_invalid_to_da_reason() {
+        assert_eq!(
+            decision_for_error(&InteropTxValidatorError::InvalidEntry(
+                SuperchainDAError::ConflictingData
+            )),
+            (RESULT_REJECTED_INVALID, "conflicting_data")
+        );
+        // A generic (non-DA) rejection is still a genuine invalid verdict, reason `other`.
+        assert_eq!(
+            decision_for_error(&InteropTxValidatorError::Rejected {
+                code: -32602,
+                message: "failed to parse access entry".to_string(),
+            }),
+            (RESULT_REJECTED_INVALID, REASON_OTHER)
+        );
+    }
+
+    #[test]
+    fn decision_for_error_separates_quorum_outcomes() {
+        assert_eq!(
+            decision_for_error(&InteropTxValidatorError::Disagreement { valid: 1, invalid: 1 }),
+            (RESULT_REJECTED_DISAGREEMENT, REASON_NONE)
+        );
+        assert_eq!(
+            decision_for_error(&InteropTxValidatorError::QuorumNotReached {
+                received: 1,
+                required: 2
+            }),
+            (RESULT_REJECTED_NO_QUORUM, REASON_NONE)
+        );
+        assert_eq!(
+            decision_for_error(&InteropTxValidatorError::FailsafeEnabled),
+            (RESULT_REJECTED_FAILSAFE, REASON_NONE)
+        );
+    }
+
+    #[test]
+    fn decision_for_error_classifies_non_responses_as_errored() {
+        assert_eq!(
+            decision_for_error(&InteropTxValidatorError::Timeout(2)),
+            (RESULT_ERRORED, REASON_TIMEOUT)
+        );
+        assert_eq!(
+            decision_for_error(&InteropTxValidatorError::DataUnavailable { code: -321401 }),
+            (RESULT_ERRORED, REASON_OTHER)
+        );
+        assert_eq!(decision_for_error(&server_error()), (RESULT_ERRORED, REASON_OTHER));
     }
 }

--- a/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/metrics.rs
@@ -195,8 +195,8 @@ impl InteropMetrics {
     /// Records a single interop filter decision under the given `result` and `reason` labels.
     ///
     /// Both must be one of the `RESULT_*` / `REASON_*` constants (or a DA reason from
-    /// [`validation_reason`]) so the label set stays low-cardinality and stable. Use
-    /// [`decision_for_error`] to derive the pair from a validation error.
+    /// `validation_reason`) so the label set stays low-cardinality and stable. Use
+    /// `decision_for_error` to derive the pair from a validation error.
     #[inline]
     pub fn record_decision(&self, result: &'static str, reason: &'static str) {
         counter!(FILTER_DECISIONS, "result" => result, "reason" => reason).increment(1);


### PR DESCRIPTION
## Summary

Consolidates the op-reth interop filter metrics into a single labeled decision counter, plus quorum-margin observability. This reworks the original interop-metrics change (#21234) on top of `develop`, which meanwhile gained multi-endpoint quorum validation (#21195). The two had introduced overlapping counters (per-DA-reason vs. quorum outcomes), so this collapses everything into one coherent, non-duplicative metric set — every interop tx that reaches the filter is counted exactly once.

## Metrics

- **`filter_decisions_total{result, reason}`** — one increment per interop tx reaching the filter.
  - `result` ∈ `allowed | rejected_pre_interop | rejected_failsafe | rejected_invalid | rejected_disagreement | rejected_no_quorum | errored`
  - `reason` carries the DA reason for `rejected_invalid` and the failure kind for `errored`, else `none`
  - Replaces the 11 per-reason `*_count` counters **and** the 5 `quorum_*` counters:
    - `sum by (result)` → outcome breakdown
    - `sum by (reason) (…{result="rejected_invalid"})` → DA-reason breakdown
- **`endpoint.verdicts_total{endpoint, verdict}`** — folds the per-endpoint `valid`/`invalid`/`unavailable` counters into one labeled counter.
- **`quorum_verdicts_collected`** (histogram) + **`quorum_min_responses`** (gauge) — definitive verdicts collected per check vs. the configured threshold; the leading indicator for how close the filter runs to failing closed.

Latency histograms (`interop_query_latency`, per-endpoint `query_latency`) and the `failsafe_enabled` gauge are unchanged.

## Notes

- Decision/label logic lives in pure functions (`validation_reason`, `decision_for_error`) with exhaustive unit tests. **Behavior is unchanged.**
- Supersedes #21234 (rebased onto `develop` + redesigned to avoid duplicating the quorum metrics from #21195).

## Testing

- `just fmt-check` ✅
- `cargo clippy -p reth-optimism-txpool --all-features --all-targets -- -D warnings` ✅
- `cargo nextest run -p reth-optimism-txpool interop_filter` — 25/25 ✅