### PR TITLE
fix(op-supernode): error instead of silently dropping chains in interop cycle detection

### DIFF
--- a/op-supernode/supernode/activity/interop/cycle.go
+++ b/op-supernode/supernode/activity/interop/cycle.go
@@ -187,18 +187,23 @@ func (i *Interop) verifyCycleMessages(ts uint64, blocksAtTimestamp map[eth.Chain
 
 		db, ok := i.logsDBs[chainID]
 		if !ok {
-			// Chain not in logsDBs - skip it for cycle verification
+			// Chain not registered with the interop activity - out of scope for
+			// cycle verification, consistent with verifyInteropMessages.
 			continue
 		}
 		blockRef, _, execMsgs, err := db.OpenBlock(blockID.Number)
 		if err != nil {
-			// Can't open block - no EMs to add to the graph for this chain
-			// This can happen if the logsDB is empty or the block hasn't been indexed
-			continue
+			// The block is expected to be available: chain-readiness gating and
+			// the frontier view guarantee it. A read failure means the data the
+			// cycle check needs is missing, not that the chain has no
+			// same-timestamp messages. Surface it so the round retries rather
+			// than silently dropping the chain - and with it every cross-chain
+			// edge that targets it, which could hide a real cycle.
+			return Result{}, fmt.Errorf("chain %s: failed to open block %d for cycle verification: %w", chainID, blockID.Number, err)
 		}
-		// Verify the block has the expected timestamp
+		// A block at a different timestamp legitimately contributes no
+		// same-timestamp executing messages; skip it without error.
 		if blockRef.Time != ts {
-			// Block timestamp mismatch - skip this chain for cycle verification
 			continue
 		}
 		chainEMs[chainID] = execMsgs

--- a/op-supernode/supernode/activity/interop/cycle_test.go
+++ b/op-supernode/supernode/activity/interop/cycle_test.go
@@ -1,8 +1,11 @@
 package interop
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
@@ -489,4 +492,52 @@ func TestBuildCycleGraph(t *testing.T) {
 			}
 		})
 	}
+}
+
+// =============================================================================
+// verifyCycleMessages data-availability handling
+// =============================================================================
+
+// A failed logsDB read means the block data the cycle check needs is
+// unavailable. That must surface as an error so the round retries, not be
+// silently swallowed - dropping a chain removes its nodes and every cross-chain
+// edge targeting it, which can hide a real cycle.
+func TestVerifyCycleMessages_OpenBlockErrorReturnsError(t *testing.T) {
+	t.Parallel()
+	chainID := eth.ChainIDFromUInt64(10)
+	block := eth.BlockID{Number: 100, Hash: common.HexToHash("0x123")}
+
+	mockDB := &algoMockLogsDB{openBlockErr: errors.New("database read failed")}
+
+	i := &Interop{
+		log:     gethlog.New(),
+		logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
+	}
+
+	// A nil view forces the logsDB branch (view.block returns false on nil).
+	_, err := i.verifyCycleMessages(testTS, map[eth.ChainID]eth.BlockID{chainID: block}, nil)
+	require.Error(t, err, "unavailable block data must surface as an error, not silently drop the chain")
+	require.Contains(t, err.Error(), "database read failed")
+}
+
+// A block that opens successfully but sits at a different timestamp legitimately
+// contributes no same-timestamp executing messages. That is not a data-
+// availability failure, so it must be skipped without error.
+func TestVerifyCycleMessages_BlockNotAtTimestampSkippedWithoutError(t *testing.T) {
+	t.Parallel()
+	chainID := eth.ChainIDFromUInt64(10)
+	block := eth.BlockID{Number: 100, Hash: common.HexToHash("0x123")}
+
+	mockDB := &algoMockLogsDB{
+		openBlockRef: eth.BlockRef{Hash: block.Hash, Number: 100, Time: testTS + 1},
+	}
+
+	i := &Interop{
+		log:     gethlog.New(),
+		logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
+	}
+
+	result, err := i.verifyCycleMessages(testTS, map[eth.ChainID]eth.BlockID{chainID: block}, nil)
+	require.NoError(t, err)
+	require.Empty(t, result.InvalidHeads)
 }


### PR DESCRIPTION
`verifyCycleMessages` silently skipped a chain when `db.OpenBlock` failed. Dropping a chain removes its nodes and every cross-chain edge targeting it, which can hide a real same-timestamp cycle and let an invalid block be treated as valid.

Now a read failure (data unavailable) returns an error so the round retries, matching `verifyInteropMessages`. A block that opens but sits at a different timestamp still legitimately contributes no same-timestamp messages and is skipped without error.

Tests: added a red/green test for the OpenBlock-error path plus one asserting the not-at-this-timestamp skip is preserved.