### PR TITLE
fix(op-acceptance-tests): deflake TestReorgUnsafeHead batcher race

### DIFF
--- a/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
@@ -83,9 +83,6 @@ func TestReorgUnsafeHead(gt *testing.T) {
 		}
 	}
 
-	// start batcher on chain A
-	sys.L2BatcherA.Start()
-
 	// Don't read eth.Unsafe ("latest") for the parent: it can lag the EL's
 	// post-forkchoice canonical swap and return the original head, and building on
 	// that stale parent would forkchoice the EL back onto the original chain,
@@ -126,6 +123,13 @@ func TestReorgUnsafeHead(gt *testing.T) {
 	})
 	waitCancel()
 	require.NoError(t, err, "op-node never observed test-sequencer's committed unsafe head %s", expectedUnsafe.Hash)
+
+	// Only start the batcher now that op-node and the EL agree on the conflicting
+	// chain. Earlier, during the reorg window, the batcher could pick its block
+	// range from op-node's syncStatus (conflicting head) but load block content
+	// by number from the EL (still the original) and anchor the ORIGINAL block to
+	// L1 — pinning it as safe and making the unsafe reorg impossible to keep.
+	sys.L2BatcherA.Start()
 
 	// continue sequencing with consensus node (op-node)
 	sys.L2ACL.StartSequencer()


### PR DESCRIPTION
## Problem

`TestReorgUnsafeHead` flakes at the first `ReorgExact` with:

```
operation failed permanently after 30 attempts:
  expected head to reorg 0x868bc5…1076e9:9, but got 0x868bc5…1076e9:9
```

The EL never keeps the conflicting block at the divergence height — it settles back on the original block and stays there. (Seen on [pipeline 127831](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/127831/workflows/f1d7c0ce-f7d3-4a12-89dc-408f7b09e6fa/jobs/5194074/tests).)

## Root cause

The test restarted batcher A immediately after the test-sequencer committed the conflicting block — i.e. *during* the reorg window where op-node's reported sync status and the EL's canonical chain disagree:

- op-node's `optimism_syncStatus` reported `unsafeL2 = 62bea4:9` (the conflicting head), because the test-sequencer published it.
- the EL's canonical block at height 9 was still `868bc5` (the original), because op-node's lagging forkchoice had transiently swapped it back (it kicked off a build job rooted on the stale head).

The batcher picks the **range** of blocks to load from `syncStatus.unsafeL2`, but loads each block's **content** by number directly from the EL via `BlockByNumber` (`op-batcher/batcher/driver.go`). With those two views inconsistent, it loaded and anchored the **original** block 9 to L1. Once derivation made it the safe head, the original chain was pinned and the unsafe reorg could never stick — so `ReorgExact` polled until timeout.

(The reorg-back after L1 derivation is correct, by-design behavior: an unsafe block must not conflict with your own L1-derived safe head. The bug was the test letting the batcher anchor the wrong block in the first place.)

## Fix

Move `L2BatcherA.Start()` to **after** the existing wait that confirms op-node's sync status matches the test-sequencer's committed head. By then both the batcher's range read (op-node status) and its content read (EL by-number) reflect the conflicting chain, so it anchors the conflicting block and the L1-derived safe head follows the reorg — which is what the final assertion wants.

Nothing between the old and new start positions needs the batcher (conflicting blocks are built via the test-sequencer; `ReorgExact` and the wait-loop read the EL/CL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)