### PR TITLE
Use resilient CircleCI checkout command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ parameters:
 
 orbs:
   continuation: circleci/continuation@2.0.1
+  utils: ethereum-optimism/circleci-utils@1.0.28
 
 jobs:
   # --------------------------------------------------------------------------
@@ -106,7 +107,7 @@ jobs:
     environment:
       BASE_REVISION: develop
     steps:
-      - checkout
+      - utils/checkout-code
       # yq is used by the "Merge continuation configs" step to deep-merge YAML files.
       # Keep version in sync with mise.toml.
       - run:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -77,7 +77,7 @@ parameters:
     default: false
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.27
+  utils: ethereum-optimism/circleci-utils@1.0.28
   go: circleci/go@1.8.0
   gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@6.0.0
@@ -2023,7 +2023,7 @@ jobs:
       - image: returntocorp/semgrep
     resource_class: xlarge.gen2
     steps:
-      - checkout # no need to use mise here since the docker image contains the only dependency
+      - utils/checkout-code
       - unless:
           condition:
             equal: ["develop", << pipeline.git.branch >>]

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -4,7 +4,7 @@ version: 2.1
 # This file contains all Rust CI commands, parameterized jobs, crate-specific jobs, and workflows.
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.27
+  utils: ethereum-optimism/circleci-utils@1.0.28
   gcp-cli: circleci/gcp-cli@3.0.1
 
 parameters:

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -5,7 +5,7 @@ version: 2.1
 # It is merged with main.yml and rust-ci.yml when rust/** changes are detected.
 # Shared orbs, commands, and jobs come from main.yml and rust-ci.yml during merge.
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.27
+  utils: ethereum-optimism/circleci-utils@1.0.28
 
 parameters:
   c-default_docker_image:


### PR DESCRIPTION
## Summary
Recent develop failures were caused by flaky CircleCI checkout setup, not contract test failures.

Bump `circleci-utils` to `1.0.28` and replace raw CircleCI checkout steps with `utils/checkout-code`, so setup and Semgrep jobs use the shared HTTPS retrying checkout path.

Depends on https://github.com/ethereum-optimism/circleci-utils/pull/30 being merged and released as `ethereum-optimism/circleci-utils@1.0.28`.
