### PR TITLE
fix(ci): remove the rust target-dir build cache (was serving stale binaries)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,6 @@ jobs:
           name: Detect file tree changes and store in JSON file
           command: .circleci/scripts/collect-params.sh detect
           environment:
-            c-rust_files_changed: "^rust/"
             c-contracts_changed: "^(packages/contracts-bedrock|op-core/forks|op-core/nuts|\\.circleci|\\.github|ops/check-changed)/|^(package\\.json|mise\\.toml)$"
             c-docs_changes_detected: "^docs/public-docs/"
             c-rust_changes_detected: "^(rust|op-e2e|\\.circleci)/"
@@ -320,7 +319,7 @@ jobs:
             esac
 
             # Params to forward to continuation configs (everything else is stripped)
-            finalize "c-default_docker_image,c-rust_base_image,c-base_image,c-github-event-base64,c-go-cache-version,c-rust_files_changed,c-publish_contract_artifacts_ref"
+            finalize "c-default_docker_image,c-rust_base_image,c-base_image,c-github-event-base64,c-go-cache-version,c-publish_contract_artifacts_ref"
       # Deep-merges the 3 continuation YAML configs (main, rust-ci, rust-e2e)
       # into /tmp/merged-config.yml using yq. Later files win on key conflicts.
       # explode(.) resolves YAML anchors/aliases so the output is self-contained.

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -13,12 +13,6 @@ parameters:
   c-github-event-base64:
     type: string
     default: "__not_set__"
-  # Set to true by path-filtering when files under rust/ change.
-  # When false on feature branches, kona-build-release skips cargo build and
-  # reuses cached binaries — saving ~9 minutes on PRs that don't touch Rust.
-  c-rust_files_changed:
-    type: boolean
-    default: false
   # go-cache-version can be used as a cache buster when making breaking changes to caching strategy
   c-go-cache-version:
     type: string
@@ -383,7 +377,7 @@ commands:
 
   # --- Rust environment setup commands ---
   rust-restore-build-cache:
-    description: "Restore the target directory cache for a Rust workspace"
+    description: "Restore the dependency and toolchain caches for a Rust workspace"
     parameters:
       directory:
         description: "Directory containing the Cargo workspace"
@@ -405,12 +399,6 @@ commands:
         type: string
         default: "rust-build"
     steps:
-      - restore_cache:
-          name: Restore << parameters.directory >> target cache
-          keys:
-            - << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}-<< parameters.profile >>-<< parameters.features >>
-            - << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}-<< parameters.profile >>
-            - << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}
       # Shared across every Rust job: the downloaded crate set is identical
       # for a given Cargo.lock regardless of job, profile, or features, so a
       # single key avoids each job downloading and storing its own copy.
@@ -430,7 +418,7 @@ commands:
             - rust-toolchain-v<< parameters.version >>-{{ checksum "mise.toml" }}-{{ checksum "rust/rust-toolchain.toml" }}
 
   rust-save-build-cache:
-    description: "Save the target directory cache for a Rust workspace"
+    description: "Save the dependency and toolchain caches for a Rust workspace"
     parameters:
       directory:
         description: "Directory containing the Cargo workspace"
@@ -470,11 +458,6 @@ commands:
           paths:
             - /data/mise-data/.cargo/bin
             - /data/mise-data/.rustup
-      - save_cache:
-          key: << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}-<< parameters.profile >>-<< parameters.features >>
-          name: Save << parameters.directory >> target cache
-          paths:
-            - << parameters.directory >>/target/<< parameters.profile >>
 
   rust-prepare-and-restore-cache:
     description: "Prepare the Rust environment and restore the cache"
@@ -546,10 +529,6 @@ commands:
         description: "Whether to save the cache at the end of the build"
         type: boolean
         default: false
-      rust_files_changed:
-        description: "Set to false to skip cargo build and reuse cached binaries (feature branches only)."
-        type: boolean
-        default: true
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -565,21 +544,6 @@ commands:
             PWD=$(pwd)
             export CARGO_TARGET_DIR="$PWD/<< parameters.directory >>/target"
             echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
-
-            # On feature branches where rust/ hasn't changed, reuse binaries from
-            # the restored target cache instead of running cargo build (~9 min saving).
-            # Always build on develop/main as a safety backstop.
-            if [ "<< parameters.rust_files_changed >>" = "false" ] \
-                && [ "$CIRCLE_BRANCH" != "develop" ] \
-                && [ "$CIRCLE_BRANCH" != "main" ]; then
-              binary_dir="$CARGO_TARGET_DIR/<< parameters.profile >>"
-              if [ -d "$binary_dir" ] && ls "$binary_dir"/* >/dev/null 2>&1; then
-                echo "No rust/ changes on feature branch — skipping cargo build"
-                ls -lh "$binary_dir"/ | head -20 || true
-                exit 0
-              fi
-              echo "WARNING: no cached binaries found, building from source"
-            fi
 
             export PROFILE="--profile << parameters.profile >>"
 
@@ -669,10 +633,6 @@ jobs:
         description: "Whether to persist the built binaries to the CircleCI workspace"
         type: boolean
         default: false
-      rust_files_changed:
-        description: "Set to false to skip cargo build and reuse cached binaries (feature branches only)."
-        type: boolean
-        default: true
     steps:
       - rust-build:
           directory: << parameters.directory >>
@@ -683,7 +643,6 @@ jobs:
           package: << parameters.package >>
           binary: << parameters.binary >>
           save_cache: << parameters.save_cache >>
-          rust_files_changed: << parameters.rust_files_changed >>
       - when:
           condition: << parameters.persist_to_workspace >>
           steps:
@@ -1861,7 +1820,7 @@ jobs:
             BIN_DIR="$ROOT_DIR/.circleci-cache/rust-binaries"
 
             echo "export RUST_BINARY_PATH_KONA_NODE=$ROOT_DIR/rust/target/release/kona-node" >> "$BASH_ENV"
-            echo "export OP_RETH_EXEC_PATH=$ROOT_DIR/rust/target/release/op-reth" >> "$BASH_ENV"
+            echo "export RUST_BINARY_PATH_OP_RETH=$ROOT_DIR/rust/target/release/op-reth" >> "$BASH_ENV"
             echo "export RUST_BINARY_PATH_OP_RBUILDER=$BIN_DIR/op-rbuilder" >> "$BASH_ENV"
             echo "export RUST_BINARY_PATH_ROLLUP_BOOST=$BIN_DIR/rollup-boost" >> "$BASH_ENV"
       - run:
@@ -2491,7 +2450,6 @@ workflows:
           profile: "release"
           save_cache: true
           persist_to_workspace: true
-          rust_files_changed: << pipeline.parameters.c-rust_files_changed >>
           context:
             - circleci-repo-readonly-authenticated-github-token
             - sccache-gcs-optimism
@@ -2712,7 +2670,6 @@ workflows:
           profile: "release"
           save_cache: true
           persist_to_workspace: true
-          rust_files_changed: << pipeline.parameters.c-rust_files_changed >>
           context:
             - circleci-repo-readonly-authenticated-github-token
             - sccache-gcs-optimism

--- a/op-devstack/shared/rustbin/rust_binary.go
+++ b/op-devstack/shared/rustbin/rust_binary.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 
@@ -106,7 +106,14 @@ func resolveBuiltRustBinaryPath(srcRoot, binary string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return selectNewestBinary(targetDir, binary)
+}
 
+// selectNewestBinary locates the built binary under targetDir, preferring the
+// most recently modified when several profiles or target triples are present.
+// Picking by mtime avoids silently shadowing a freshly built release binary with
+// a stale debug leftover (alphabetical order would prefer "debug" over "release").
+func selectNewestBinary(targetDir, binary string) (string, error) {
 	candidates := []string{
 		filepath.Join(targetDir, "release", binary),
 		filepath.Join(targetDir, "debug", binary),
@@ -117,26 +124,27 @@ func resolveBuiltRustBinaryPath(srcRoot, binary string) (string, error) {
 	}
 
 	seen := make(map[string]struct{}, len(candidates))
-	var existing []string
+	var newest string
+	var newestMod time.Time
 	for _, candidate := range candidates {
 		if _, dup := seen[candidate]; dup {
 			continue
 		}
 		seen[candidate] = struct{}{}
-		if _, err := os.Stat(candidate); err == nil {
-			existing = append(existing, candidate)
+		info, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+		if newest == "" || info.ModTime().After(newestMod) {
+			newest = candidate
+			newestMod = info.ModTime()
 		}
 	}
 
-	switch len(existing) {
-	case 0:
+	if newest == "" {
 		return "", fmt.Errorf("no built binary found under target dir %s", targetDir)
-	case 1:
-		return existing[0], nil
-	default:
-		sort.Strings(existing)
-		return existing[0], nil
 	}
+	return newest, nil
 }
 
 func cargoTargetDirectory(srcRoot string) (string, error) {

--- a/op-devstack/shared/rustbin/rust_binary_test.go
+++ b/op-devstack/shared/rustbin/rust_binary_test.go
@@ -1,0 +1,59 @@
+package rustbin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSelectNewestBinaryPrefersFreshReleaseOverStaleDebug(t *testing.T) {
+	targetDir := t.TempDir()
+	releaseBin := filepath.Join(targetDir, "release", "op-reth")
+	debugBin := filepath.Join(targetDir, "debug", "op-reth")
+	writeStubBinary(t, debugBin, time.Now().Add(-time.Hour))
+	writeStubBinary(t, releaseBin, time.Now())
+
+	got, err := selectNewestBinary(targetDir, "op-reth")
+	if err != nil {
+		t.Fatalf("selectNewestBinary: %v", err)
+	}
+	if got != releaseBin {
+		t.Fatalf("expected freshest binary %q, got %q", releaseBin, got)
+	}
+}
+
+func TestSelectNewestBinaryPrefersFreshDebugOverStaleRelease(t *testing.T) {
+	targetDir := t.TempDir()
+	releaseBin := filepath.Join(targetDir, "release", "op-reth")
+	debugBin := filepath.Join(targetDir, "debug", "op-reth")
+	writeStubBinary(t, releaseBin, time.Now().Add(-time.Hour))
+	writeStubBinary(t, debugBin, time.Now())
+
+	got, err := selectNewestBinary(targetDir, "op-reth")
+	if err != nil {
+		t.Fatalf("selectNewestBinary: %v", err)
+	}
+	if got != debugBin {
+		t.Fatalf("expected freshest binary %q, got %q", debugBin, got)
+	}
+}
+
+func TestSelectNewestBinaryMissing(t *testing.T) {
+	if _, err := selectNewestBinary(t.TempDir(), "op-reth"); err == nil {
+		t.Fatal("expected error when no binary is present")
+	}
+}
+
+func writeStubBinary(t *testing.T, path string, mod time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mod, mod); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Acceptance jobs (e.g. `memory-all-opn-op-reth`) have been failing deterministically with `op-reth proofs init: unexpected argument '--proofs-history.skip-backfill'` — the Go sysgo harness passes a new op-reth CLI flag while CI runs a **stale** op-reth binary. It looks like a flake only because pass/fail depends on which cached binary CircleCI happens to restore.

The culprit is the rust **target-dir** build cache. It was keyed only on `Cargo.lock`, and `save_cache` is immutable per key — so a source-only change that adds a CLI flag (without touching `Cargo.lock`) never rotated the key, and the cache kept serving the pre-change binary. The `rust-build` job then skipped `cargo build` on non-develop branches whenever the PR didn't touch `rust/`, reusing that stale binary.

Rather than bolt on staleness detection, this drops the target-dir cache entirely. Rust jobs now always run `cargo build`; the **dependency cache** (keyed on `Cargo.lock`) and **sccache** keep that fast. The toolchain cache and the vendored-binary cache are untouched (the latter is keyed on the directory's git tree hash, so it can't go stale the same way).

What changed:
- Remove the "rust target cache" restore/save from `rust-restore-build-cache` / `rust-save-build-cache` (deps + toolchain caches kept).
- Remove the `rust_files_changed` build-skip from `rust-build` and all its plumbing (command params, call sites, the `c-rust_files_changed` pipeline parameter and its detection/forwarding in `config.yml`).
- Pin the sysgo acceptance job to `RUST_BINARY_PATH_OP_RETH` (the var `rustbin` actually reads); `OP_RETH_EXEC_PATH` was dead for the Go path.
- `rustbin` selects the newest binary by mtime instead of alphabetically (which preferred a stale `target/debug` over a fresh `target/release`).

The now-unused `profile`/`features`/`prefix` params on the cache commands are left in place to keep this diff focused — a follow-up can strip them.

Test plan: new unit tests in `op-devstack/shared/rustbin` cover the binary-selection fix (red on the old alphabetical logic). The CircleCI config was validated locally via the merge-fragments + `circleci config validate` flow.