### PR TITLE
ci: restore go module cache in all go-building jobs

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1407,6 +1407,8 @@ jobs:
       - install-contracts-dependencies
       - check-changed:
           patterns: contracts-bedrock
+      # `just check-fast` runs `go run ./scripts/check-runner`, so it builds Go.
+      - restore-go-mod-cache
       - run:
           name: Print forge version
           command: forge --version
@@ -1633,6 +1635,8 @@ jobs:
       - install-contracts-dependencies
       - check-changed:
           patterns: op-core/nuts
+      # The verify script runs `go run ./ops/scripts/nut-provenance-verify`.
+      - restore-go-mod-cache
       - run:
           name: verify NUT bundle provenance
           command: ./ops/scripts/nut-provenance-verify-changed.sh
@@ -1934,6 +1938,8 @@ jobs:
       - utils/checkout-with-mise:
           checkout-method: blobless
           enable-mise-cache: true
+      # `just verify-reproducibility` runs `go run ...verify.go` on the host.
+      - restore-go-mod-cache
       - run:
           name: Verify reproducibility
           command: just verify-reproducibility
@@ -2158,6 +2164,8 @@ jobs:
       - utils/checkout-with-mise:
           enable-mise-cache: true
       - attach_workspace: { at: "." }
+      # goreleaser compiles the Go release binaries on the host.
+      - restore-go-mod-cache
       - run:
           name: Configure Docker
           command: |
@@ -2335,6 +2343,8 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - nut-provenance-verify:
+          requires:
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
       - fuzz-golang:
@@ -2974,6 +2984,8 @@ workflows:
             - slack
       - contracts-bedrock-checks-fast:
           name: contracts-bedrock-checks-fast-feature-tests
+          requires:
+            - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -295,6 +295,10 @@ jobs:
           directory: rust
           prefix: rust-interop-deposits-diff
           profile: debug
+      # The diff script runs `go run ./op-node/cmd/interop-deposits-dump`, so it
+      # builds Go code. Restore the shared Go module cache to avoid a cold
+      # `go mod download` (slow, and a per-pipeline proxy.golang.org flake risk).
+      - restore-go-mod-cache
       - run:
           name: Cross-language Interop activation diff
           command: |


### PR DESCRIPTION
Five CircleCI jobs run Go on the host but never restored the shared Go module cache, so each did a cold `go mod download`. That's slow and exposes every run to `proxy.golang.org` flakes — one such flake just failed `interop-deposits-diff` on a gnark-crypto download.

Adds `restore-go-mod-cache` to `interop-deposits-go-rust-diff`, `contracts-bedrock-checks-fast`, `nut-provenance-verify`, `preimage-reproducibility`, and `go-release`. Also requires `prep-go-modules` for the two that run in a workflow already containing it, so the cache is warm within the pipeline (matching their siblings).

Audited the rest of the config with the ci-config-reviewer agent: no other host-Go jobs are missing the cache, and no gate/required-check/path-filter regressions.