### PR TITLE
op-up: add devnet preset runner and control CLI

### DIFF
--- a/op-devstack/devtest/common.go
+++ b/op-devstack/devtest/common.go
@@ -3,6 +3,7 @@ package devtest
 import (
 	"context"
 	"log/slog"
+	"strings"
 
 	"go.opentelemetry.io/otel/trace"
 
@@ -25,6 +26,7 @@ type CommonT interface {
 	SkipNow()
 
 	TempDir() string
+	TempDirWithPrefix(prefix string) string
 	Cleanup(fn func())
 	Log(args ...any)
 	Logf(format string, args ...any)
@@ -35,6 +37,15 @@ type CommonT interface {
 	Tracer() trace.Tracer
 	Ctx() context.Context
 	Require() *testreq.Assertions
+}
+
+func tempDirPattern(prefix string) string {
+	prefix = strings.NewReplacer("/", "-", "\\", "-", " ", "-", "_", "-").Replace(strings.TrimSpace(prefix))
+	prefix = strings.Trim(prefix, "-")
+	if prefix == "" {
+		prefix = "op-dev"
+	}
+	return prefix + "-*"
 }
 
 type testScopeCtxKeyType struct{}

--- a/op-devstack/devtest/package.go
+++ b/op-devstack/devtest/package.go
@@ -93,8 +93,12 @@ func (t *implP) SkipNow() {
 }
 
 func (t *implP) TempDir() string {
+	return t.TempDirWithPrefix("op-dev")
+}
+
+func (t *implP) TempDirWithPrefix(prefix string) string {
 	// The last "*" will be replaced with the random temp dir name
-	tempDir, err := os.MkdirTemp("", "op-dev-*")
+	tempDir, err := os.MkdirTemp("", tempDirPattern(prefix))
 	if err != nil {
 		t.Errorf("failed to create temp dir: %v", err)
 		t.FailNow()

--- a/op-devstack/devtest/testing.go
+++ b/op-devstack/devtest/testing.go
@@ -187,6 +187,23 @@ func (t *testingT) TempDir() string {
 	return t.t.TempDir()
 }
 
+func (t *testingT) TempDirWithPrefix(prefix string) string {
+	t.t.Helper()
+	tempDir, err := os.MkdirTemp("", tempDirPattern(prefix))
+	if err != nil {
+		t.Errorf("failed to create temp dir: %v", err)
+		t.FailNow()
+	}
+	require.NotEmpty(t, tempDir, "sanity check temp-dir path is not empty")
+	require.NotEqual(t, "/", tempDir, "sanity-check temp-dir is not root")
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.logger.Error("Failed to clean up temp dir", "dir", tempDir, "err", err)
+		}
+	})
+	return tempDir
+}
+
 func (t *testingT) Cleanup(fn func()) {
 	t.t.Cleanup(fn)
 }

--- a/op-devstack/dsl/l1_cl.go
+++ b/op-devstack/dsl/l1_cl.go
@@ -25,6 +25,10 @@ func (cl *L1CLNode) Escape() stack.L1CLNode {
 	return cl.inner
 }
 
+func (cl *L1CLNode) BeaconHTTPAddr() string {
+	return cl.inner.BeaconHTTPAddr()
+}
+
 func (cl *L1CLNode) Start() {
 	lifecycle, ok := cl.inner.(stack.Lifecycle)
 	cl.require.Truef(ok, "L1CL node %s is not lifecycle-controllable", cl.inner.Name())

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 	"github.com/ethereum/go-ethereum/common"
@@ -62,6 +63,14 @@ func (s *Supernode) Escape() stack.Supernode {
 // QueryAPI returns the supernode's query API
 func (s *Supernode) QueryAPI() apis.SupernodeQueryAPI {
 	return s.inner.QueryAPI()
+}
+
+func (s *Supernode) ClientRPC() opclient.RPC {
+	return s.inner.ClientRPC()
+}
+
+func (s *Supernode) UserRPC() string {
+	return s.inner.UserRPC()
 }
 
 // SuperRootAtTimestamp fetches the super-root at the given timestamp

--- a/op-devstack/presets/minimal_from_runtime.go
+++ b/op-devstack/presets/minimal_from_runtime.go
@@ -26,7 +26,7 @@ func minimalFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *Minimal
 		newKeyring(runtime.Keys, t.Require()),
 		l1Network,
 	)
-	l2EL := newL2ELFrontend(t, "sequencer", l2ChainID, runtime.L2EL.UserRPC(), runtime.L2EL.EngineRPC(), runtime.L2EL.JWTPath(), runtime.L2Network.RollupConfig())
+	l2EL := newL2ELFrontend(t, "sequencer", l2ChainID, runtime.L2EL.UserRPC(), runtime.L2EL.EngineRPC(), runtime.L2EL.JWTPath(), runtime.L2Network.RollupConfig(), runtime.L2EL)
 	l2CL := newL2CLFrontend(t, "sequencer", l2ChainID, runtime.L2CL.UserRPC(), runtime.L2CL)
 	l2CL.attachEL(l2EL)
 	l2Batcher := newL2BatcherFrontend(t, "main", l2ChainID, runtime.L2Batcher.UserRPC())

--- a/op-devstack/presets/rpc_frontends.go
+++ b/op-devstack/presets/rpc_frontends.go
@@ -1,7 +1,9 @@
 package presets
 
 import (
+	"context"
 	"crypto/ecdsa"
+	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -107,24 +109,30 @@ func newPresetL1ELNode(t devtest.T, name string, chainID eth.ChainID, rpcCl opcl
 
 type l1CLFrontend struct {
 	presetCommon
-	chainID   eth.ChainID
-	client    apis.BeaconClient
-	lifecycle stack.Lifecycle
+	chainID        eth.ChainID
+	beaconHTTPAddr string
+	client         apis.BeaconClient
+	lifecycle      stack.Lifecycle
 }
 
 var _ stack.L1CLNode = (*l1CLFrontend)(nil)
 
-func newPresetL1CLNode(t devtest.T, name string, chainID eth.ChainID, httpCl opclient.HTTP) *l1CLFrontend {
+func newPresetL1CLNode(t devtest.T, name string, chainID eth.ChainID, beaconHTTPAddr string, httpCl opclient.HTTP) *l1CLFrontend {
 	t = t.WithCtx(stack.ContextWithChainID(t.Ctx(), chainID))
 	return &l1CLFrontend{
-		presetCommon: newPresetCommon(t, name),
-		chainID:      chainID,
-		client:       sources.NewBeaconHTTPClient(httpCl),
+		presetCommon:   newPresetCommon(t, name),
+		chainID:        chainID,
+		beaconHTTPAddr: beaconHTTPAddr,
+		client:         sources.NewBeaconHTTPClient(httpCl),
 	}
 }
 
 func (r *l1CLFrontend) ChainID() eth.ChainID {
 	return r.chainID
+}
+
+func (r *l1CLFrontend) BeaconHTTPAddr() string {
+	return r.beaconHTTPAddr
 }
 
 func (r *l1CLFrontend) BeaconClient() apis.BeaconClient {
@@ -146,6 +154,7 @@ type l2ELFrontend struct {
 	l2Client       *sources.L2Client
 	l2EngineClient *sources.EngineClient
 	lifecycle      stack.Lifecycle
+	control        stack.ControlledLifecycle
 }
 
 var _ stack.L2ELNode = (*l2ELFrontend)(nil)
@@ -184,6 +193,24 @@ func (r *l2ELFrontend) Stop() {
 	r.lifecycle.Stop()
 }
 
+func (r *l2ELFrontend) StartControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("L2EL node %s is not controllable", r.Name())
+	}
+	return r.control.StartControlled(ctx)
+}
+
+func (r *l2ELFrontend) StopControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("L2EL node %s is not controllable", r.Name())
+	}
+	return r.control.StopControlled(ctx)
+}
+
+func (r *l2ELFrontend) Running() bool {
+	return r.control != nil && r.control.Running()
+}
+
 type l2CLFrontend struct {
 	presetCommon
 	chainID          eth.ChainID
@@ -195,6 +222,7 @@ type l2CLFrontend struct {
 	oprBuilderNodes  locks.RWMap[string, *oprBuilderFrontend]
 	userRPC          string
 	lifecycle        stack.Lifecycle
+	control          stack.ControlledLifecycle
 }
 
 var _ stack.L2CLNode = (*l2CLFrontend)(nil)
@@ -276,6 +304,24 @@ func (r *l2CLFrontend) Start() {
 func (r *l2CLFrontend) Stop() {
 	r.require().NotNil(r.lifecycle, "L2CL node %s is not lifecycle-controllable", r.Name())
 	r.lifecycle.Stop()
+}
+
+func (r *l2CLFrontend) StartControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("L2CL node %s is not controllable", r.Name())
+	}
+	return r.control.StartControlled(ctx)
+}
+
+func (r *l2CLFrontend) StopControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("L2CL node %s is not controllable", r.Name())
+	}
+	return r.control.StopControlled(ctx)
+}
+
+func (r *l2CLFrontend) Running() bool {
+	return r.control != nil && r.control.Running()
 }
 
 type l2BatcherFrontend struct {
@@ -429,20 +475,51 @@ func (r *rollupBoostFrontend) Stop() {
 
 type supernodeFrontend struct {
 	presetCommon
-	api apis.SupernodeQueryAPI
+	client  opclient.RPC
+	userRPC string
+	api     apis.SupernodeQueryAPI
+	control stack.ControlledLifecycle
 }
 
 var _ stack.Supernode = (*supernodeFrontend)(nil)
 
-func newPresetSupernode(t devtest.T, name string, rpcCl opclient.RPC) *supernodeFrontend {
+func newPresetSupernode(t devtest.T, name string, userRPC string, rpcCl opclient.RPC) *supernodeFrontend {
 	return &supernodeFrontend{
 		presetCommon: newPresetCommon(t, name),
+		client:       rpcCl,
+		userRPC:      userRPC,
 		api:          sources.NewSuperNodeClient(rpcCl),
 	}
 }
 
+func (r *supernodeFrontend) ClientRPC() opclient.RPC {
+	return r.client
+}
+
 func (r *supernodeFrontend) QueryAPI() apis.SupernodeQueryAPI {
 	return r.api
+}
+
+func (r *supernodeFrontend) UserRPC() string {
+	return r.userRPC
+}
+
+func (r *supernodeFrontend) StartControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("supernode %s is not controllable", r.Name())
+	}
+	return r.control.StartControlled(ctx)
+}
+
+func (r *supernodeFrontend) StopControlled(ctx context.Context) error {
+	if r.control == nil {
+		return fmt.Errorf("supernode %s is not controllable", r.Name())
+	}
+	return r.control.StopControlled(ctx)
+}
+
+func (r *supernodeFrontend) Running() bool {
+	return r.control != nil && r.control.Running()
 }
 
 type conductorFrontend struct {

--- a/op-devstack/presets/superproofs_from_runtime.go
+++ b/op-devstack/presets/superproofs_from_runtime.go
@@ -24,7 +24,7 @@ func simpleInteropFromSupernodeProofsRuntime(t devtest.T, runtime *sysgo.MultiCh
 	t.Require().NotNil(chainB, "missing l2b superproofs chain")
 	twoL2, components := twoL2FromRuntime(t, runtime)
 
-	supernodeFrontend := newSupernodeFrontend(t, "supernode-two-l2-system", runtime.Supernode.UserRPC())
+	supernodeFrontend := newSupernodeFrontend(t, "supernode-two-l2-system", runtime.Supernode.UserRPC(), runtime.Supernode)
 	testSequencer := newTestSequencerFrontend(
 		t,
 		runtime.TestSequencer.Name,
@@ -113,7 +113,7 @@ func singleChainInteropFromSupernodeProofsRuntime(t devtest.T, runtime *sysgo.Mu
 		l2Chain.AddL2Challenger(newPresetL2Challenger(t, "main", l2ChainID, challengerCfg))
 	}
 
-	supernodeFrontend := newSupernodeFrontend(t, "supernode-single-system-proofs", runtime.Supernode.UserRPC())
+	supernodeFrontend := newSupernodeFrontend(t, "supernode-single-system-proofs", runtime.Supernode.UserRPC(), runtime.Supernode)
 	testSequencer := newTestSequencerFrontend(
 		t,
 		runtime.TestSequencer.Name,

--- a/op-devstack/presets/sysgo_runtime.go
+++ b/op-devstack/presets/sysgo_runtime.go
@@ -25,7 +25,7 @@ func newL1ELFrontend(t devtest.T, name string, chainID eth.ChainID, userRPC stri
 
 func newL1CLFrontend(t devtest.T, name string, chainID eth.ChainID, beaconHTTPAddr string, lifecycle ...stack.Lifecycle) *l1CLFrontend {
 	beaconCl := client.NewBasicHTTPClient(beaconHTTPAddr, t.Logger())
-	l1CL := newPresetL1CLNode(t, name, chainID, beaconCl)
+	l1CL := newPresetL1CLNode(t, name, chainID, beaconHTTPAddr, beaconCl)
 	if len(lifecycle) > 0 {
 		l1CL.lifecycle = lifecycle[0]
 	}
@@ -49,6 +49,9 @@ func newL2ELFrontend(t devtest.T, name string, chainID eth.ChainID, userRPC stri
 	l2EL := newPresetL2ELNode(t, name, chainID, userRPCCl, userRPC, engineRPCCl, rollupCfg)
 	if len(lifecycle) > 0 {
 		l2EL.lifecycle = lifecycle[0]
+		if control, ok := lifecycle[0].(stack.ControlledLifecycle); ok {
+			l2EL.control = control
+		}
 	}
 	return l2EL
 }
@@ -73,6 +76,9 @@ func newL2CLFrontend(t devtest.T, name string, chainID eth.ChainID, userRPC stri
 	l2CL := newPresetL2CLNode(t, name, chainID, rpcCl, userRPC)
 	if lifecycle, ok := any(node).(stack.Lifecycle); ok {
 		l2CL.lifecycle = lifecycle
+	}
+	if control, ok := any(node).(stack.ControlledLifecycle); ok {
+		l2CL.control = control
 	}
 	return l2CL
 }
@@ -122,11 +128,15 @@ func newRollupBoostFrontend(t devtest.T, name string, chainID eth.ChainID, userR
 	return rollupBoost
 }
 
-func newSupernodeFrontend(t devtest.T, name string, userRPC string) *supernodeFrontend {
+func newSupernodeFrontend(t devtest.T, name string, userRPC string, control ...stack.ControlledLifecycle) *supernodeFrontend {
 	rpcCl, err := client.NewRPC(t.Ctx(), t.Logger(), userRPC, client.WithLazyDial())
 	t.Require().NoError(err)
 	t.Cleanup(rpcCl.Close)
-	return newPresetSupernode(t, name, rpcCl)
+	supernode := newPresetSupernode(t, name, userRPC, rpcCl)
+	if len(control) > 0 {
+		supernode.control = control[0]
+	}
+	return supernode
 }
 
 func newConductorFrontend(t devtest.T, name string, chainID eth.ChainID, rpcEndpoint string) *conductorFrontend {

--- a/op-devstack/presets/twol2_from_runtime.go
+++ b/op-devstack/presets/twol2_from_runtime.go
@@ -115,7 +115,7 @@ func twoL2SupernodeInteropFromRuntime(t devtest.T, runtime *sysgo.MultiChainRunt
 	t.Require().NotNil(chainA.SupernodeCL, "missing l2a supernode CL")
 	t.Require().NotNil(chainB.SupernodeCL, "missing l2b supernode CL")
 
-	supernode := newSupernodeFrontend(t, "supernode-two-l2-system", runtime.Supernode.UserRPC())
+	supernode := newSupernodeFrontend(t, "supernode-two-l2-system", runtime.Supernode.UserRPC(), runtime.Supernode)
 	// The supernode VN drives its own EL, distinct from the sequencer's
 	// (joined only by L1 + P2P) in light-sequencer presets. In virtual-sequencer
 	// presets the supernode VN is itself the sequencer, so SupernodeEL == EL and

--- a/op-devstack/stack/l1_cl.go
+++ b/op-devstack/stack/l1_cl.go
@@ -11,5 +11,6 @@ type L1CLNode interface {
 	Common
 	ChainID() eth.ChainID
 
+	BeaconHTTPAddr() string
 	BeaconClient() apis.BeaconClient
 }

--- a/op-devstack/stack/lifecycle.go
+++ b/op-devstack/stack/lifecycle.go
@@ -1,6 +1,14 @@
 package stack
 
+import "context"
+
 type Lifecycle interface {
 	Start()
 	Stop()
+}
+
+type ControlledLifecycle interface {
+	StartControlled(ctx context.Context) error
+	StopControlled(ctx context.Context) error
+	Running() bool
 }

--- a/op-devstack/stack/supernode.go
+++ b/op-devstack/stack/supernode.go
@@ -2,12 +2,15 @@ package stack
 
 import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 )
 
 type Supernode interface {
 	Common
+	ClientRPC() client.RPC
 	QueryAPI() apis.SupernodeQueryAPI
+	UserRPC() string
 }
 
 // SupernodeTestControl is the integration-test surface on a running

--- a/op-devstack/sysgo/control_lifecycle.go
+++ b/op-devstack/sysgo/control_lifecycle.go
@@ -1,0 +1,38 @@
+package sysgo
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const (
+	controlledInterruptWait = 10 * time.Second
+	controlledKillWait      = 5 * time.Second
+)
+
+func controlCall(fn func()) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if recoveredErr, ok := recovered.(error); ok {
+				err = recoveredErr
+				return
+			}
+			err = fmt.Errorf("control operation failed: %v", recovered)
+		}
+	}()
+	fn()
+	return nil
+}
+
+func runControlStart(ctx context.Context, running func() bool, start func()) error {
+	if running() {
+		return fmt.Errorf("service is already running")
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	return controlCall(start)
+}

--- a/op-devstack/sysgo/interop_filter.go
+++ b/op-devstack/sysgo/interop_filter.go
@@ -101,7 +101,7 @@ func startInteropFilter(
 	cfg := &filter.Config{
 		L2RPCs:              l2RPCs,
 		RollupConfigs:       rollupConfigs,
-		DataDir:             t.TempDir(),
+		DataDir:             t.TempDirWithPrefix(name),
 		BackfillDuration:    30 * time.Second,
 		MessageExpiryWindow: 7 * 24 * 3600, // 7 days in seconds
 		PollInterval:        500 * time.Millisecond,

--- a/op-devstack/sysgo/l1_runtime.go
+++ b/op-devstack/sysgo/l1_runtime.go
@@ -24,7 +24,7 @@ const DevstackL1ELKindEnvVar = "DEVSTACK_L1EL_KIND"
 const GethExecPathEnvVar = "SYSGO_GETH_EXEC_PATH"
 
 func writeJWTSecret(t devtest.T) (string, [32]byte) {
-	jwtPath := filepath.Join(t.TempDir(), "jwt_secret")
+	jwtPath := filepath.Join(t.TempDirWithPrefix("jwt-secret"), "jwt_secret")
 	jwtSecret := [32]byte{123}
 	err := os.WriteFile(jwtPath, []byte(hexutil.Encode(jwtSecret[:])), 0o600)
 	t.Require().NoError(err, "failed to write jwt secret")
@@ -47,7 +47,7 @@ func startInProcessL1WithClockConfig(t devtest.T, l1Net *L1Network, jwtPath stri
 	require := t.Require()
 	l1ChainID := l1Net.ChainID()
 
-	blobPath := t.TempDir()
+	blobPath := t.TempDirWithPrefix("l1-el")
 	bcn := fakebeacon.NewBeacon(t.Logger().New("component", "l1cl"), blobstore.New(), l1Net.genesis.Timestamp, l1Net.blockTime)
 	t.Cleanup(func() {
 		_ = bcn.Close()
@@ -103,7 +103,7 @@ func startSubprocessL1WithClock(t devtest.T, l1Net *L1Network, jwtPath string, l
 	_, err := os.Stat(execPath)
 	require.NotErrorIs(err, os.ErrNotExist, "geth executable must exist")
 
-	tempDir := t.TempDir()
+	tempDir := t.TempDirWithPrefix("l1-el")
 	data, err := json.Marshal(l1Net.genesis)
 	require.NoError(err, "must json-encode genesis")
 	chainConfigPath := filepath.Join(tempDir, "genesis.json")

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -1,6 +1,7 @@
 package sysgo
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -117,6 +118,29 @@ func (k *KonaNode) Stop() {
 	err := k.sub.Stop(true)
 	k.p.Require().NoError(err, "Must stop")
 	k.sub = nil
+}
+
+func (k *KonaNode) StartControlled(ctx context.Context) error {
+	return runControlStart(ctx, k.Running, k.Start)
+}
+
+func (k *KonaNode) StopControlled(ctx context.Context) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.sub == nil {
+		return nil
+	}
+	if err := k.sub.StopControlled(ctx, controlledInterruptWait, controlledKillWait); err != nil {
+		return err
+	}
+	k.sub = nil
+	return nil
+}
+
+func (k *KonaNode) Running() bool {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.sub != nil
 }
 
 func (k *KonaNode) UserRPC() string {

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -85,3 +85,35 @@ func (n *OpNode) Stop() {
 
 	n.opNode = nil
 }
+
+func (n *OpNode) StartControlled(ctx context.Context) error {
+	return runControlStart(ctx, n.Running, n.Start)
+}
+
+func (n *OpNode) StopControlled(ctx context.Context) error {
+	n.mu.Lock()
+	if n.opNode == nil {
+		n.mu.Unlock()
+		return nil
+	}
+	opNode := n.opNode
+	n.mu.Unlock()
+
+	err := opNode.Stop(ctx)
+	if err != nil && !opNode.Stopped() {
+		return err
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.opNode == opNode {
+		n.opNode = nil
+	}
+	return nil
+}
+
+func (n *OpNode) Running() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.opNode != nil
+}

--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -91,6 +91,45 @@ func (n *SuperNode) Stop() {
 	n.stopLocked()
 }
 
+func (n *SuperNode) StartControlled(ctx context.Context) error {
+	return runControlStart(ctx, n.Running, n.Start)
+}
+
+func (n *SuperNode) StopControlled(ctx context.Context) error {
+	n.mu.Lock()
+	if n.sn == nil {
+		n.mu.Unlock()
+		return nil
+	}
+	sn := n.sn
+	cancel := n.cancel
+	n.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if err := sn.Stop(ctx); err != nil {
+		return err
+	}
+	if !sn.Stopped() {
+		return fmt.Errorf("supernode stop did not confirm all goroutines exited")
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.sn == sn {
+		n.sn = nil
+		n.cancel = nil
+	}
+	return nil
+}
+
+func (n *SuperNode) Running() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.sn != nil
+}
+
 // stopLocked tears down the supernode instance, leaving httpProxy in place
 // so a later startLocked can repoint it. Caller must hold n.mu.
 func (n *SuperNode) stopLocked() {

--- a/op-devstack/sysgo/l2_el_opgeth.go
+++ b/op-devstack/sysgo/l2_el_opgeth.go
@@ -1,6 +1,7 @@
 package sysgo
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"sync"
@@ -141,4 +142,35 @@ func (n *OpGeth) Stop() {
 	closeErr := n.l2Geth.Close()
 	n.logger.Info("Closed op-geth", "name", n.name, "chain", n.l2Net.ChainID(), "err", closeErr)
 	n.l2Geth = nil
+}
+
+func (n *OpGeth) StartControlled(ctx context.Context) error {
+	return runControlStart(ctx, n.Running, n.Start)
+}
+
+func (n *OpGeth) StopControlled(ctx context.Context) error {
+	n.mu.Lock()
+	if n.l2Geth == nil {
+		n.mu.Unlock()
+		return nil
+	}
+	l2Geth := n.l2Geth
+	n.mu.Unlock()
+
+	if err := l2Geth.Close(); err != nil {
+		return err
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.l2Geth == l2Geth {
+		n.l2Geth = nil
+	}
+	return nil
+}
+
+func (n *OpGeth) Running() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.l2Geth != nil
 }

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -1,6 +1,7 @@
 package sysgo
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -195,6 +196,29 @@ func (n *OpReth) Stop() {
 	err := n.sub.Stop(true)
 	n.p.Require().NoError(err, "Must stop")
 	n.sub = nil
+}
+
+func (n *OpReth) StartControlled(ctx context.Context) error {
+	return runControlStart(ctx, n.Running, n.Start)
+}
+
+func (n *OpReth) StopControlled(ctx context.Context) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.sub == nil {
+		return nil
+	}
+	if err := n.sub.StopControlled(ctx, controlledInterruptWait, controlledKillWait); err != nil {
+		return err
+	}
+	n.sub = nil
+	return nil
+}
+
+func (n *OpReth) Running() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.sub != nil
 }
 
 func (n *OpReth) UserRPC() string {

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -308,7 +308,7 @@ func buildMixedOpRethNode(
 	storageVersion string,
 	opts ...OpRethOption,
 ) *OpReth {
-	tempDir := t.TempDir()
+	tempDir := t.TempDirWithPrefix("l2-el-" + NewComponentTarget(key, l2Net.ChainID()).String())
 
 	data, err := json.Marshal(l2Net.genesis)
 	t.Require().NoError(err, "must json-encode genesis")
@@ -474,7 +474,7 @@ func startMixedKonaNode(
 	isSequencer bool,
 	metricsRegistrar L2MetricsRegistrar,
 ) *KonaNode {
-	tempKonaDir := t.TempDir()
+	tempKonaDir := t.TempDirWithPrefix("l2-cl-kona-" + NewComponentTarget(clKey, l2Net.ChainID()).String())
 
 	tempP2PPath := filepath.Join(tempKonaDir, "p2pkey.txt")
 

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -272,7 +272,7 @@ func startInteropChallenger(
 	}
 	cfg, err := sharedchallenger.NewInteropChallengerConfig(
 		t.Ctx(),
-		t.TempDir(),
+		t.TempDirWithPrefix("super-challenger"),
 		l1EL.UserRPC(),
 		l1CL.beaconHTTPAddr,
 		superRPC,

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -634,7 +634,7 @@ func startTwoL2SharedSupernode(
 
 	snCfg := &snconfig.CLIConfig{
 		Chains:                     chainIDs,
-		DataDir:                    t.TempDir(),
+		DataDir:                    t.TempDirWithPrefix("supernode"),
 		L1NodeAddr:                 l1EL.UserRPC(),
 		L1HTTPPollInterval:         100 * time.Millisecond,
 		L1BeaconAddr:               l1CL.beaconHTTPAddr,
@@ -744,7 +744,7 @@ func startSingleChainSharedSupernode(
 
 	snCfg := &snconfig.CLIConfig{
 		Chains:                     []uint64{eth.EvilChainIDToUInt64(l2Net.ChainID())},
-		DataDir:                    t.TempDir(),
+		DataDir:                    t.TempDirWithPrefix("supernode"),
 		L1NodeAddr:                 l1EL.UserRPC(),
 		L1HTTPPollInterval:         100 * time.Millisecond,
 		L1BeaconAddr:               l1CL.beaconHTTPAddr,

--- a/op-devstack/sysgo/op_rbuilder.go
+++ b/op-devstack/sysgo/op_rbuilder.go
@@ -168,7 +168,7 @@ func (cfg *OPRBuilderNodeConfig) LaunchSpec(p devtest.CommonT) (args []string, e
 		key := strings.TrimPrefix(cfg.P2PNodeKeyHex, "0x")
 		_, err := hex.DecodeString(key)
 		p.Require().NoError(err, "decode p2p node key")
-		keyPath := filepath.Join(p.TempDir(), "oprbuilder-nodekey")
+		keyPath := filepath.Join(p.TempDirWithPrefix("op-rbuilder"), "oprbuilder-nodekey")
 		p.Require().NoError(os.WriteFile(keyPath, []byte(key), 0o600), "write p2p node key")
 		args = append(args, "--p2p-secret-key", keyPath)
 	}

--- a/op-devstack/sysgo/singlechain_flashblocks.go
+++ b/op-devstack/sysgo/singlechain_flashblocks.go
@@ -77,7 +77,7 @@ func startBuilderEL(t devtest.T, l2Net *L2Network, jwtPath string, identity *ELN
 
 	data, err := json.Marshal(l2Net.genesis)
 	require.NoError(err, "must json-encode L2 genesis")
-	chainConfigPath := filepath.Join(t.TempDir(), "op-rbuilder-genesis.json")
+	chainConfigPath := filepath.Join(t.TempDirWithPrefix("op-rbuilder"), "op-rbuilder-genesis.json")
 	require.NoError(os.WriteFile(chainConfigPath, data, 0o644), "must write op-rbuilder genesis file")
 
 	cfg := DefaultOPRbuilderNodeConfig()

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -379,7 +379,7 @@ func startMinimalChallenger(
 	}
 	cfg, err := sharedchallenger.NewPreInteropChallengerConfig(
 		t.Ctx(),
-		t.TempDir(),
+		t.TempDirWithPrefix("l2-challenger-"+l2Net.ChainID().String()),
 		l1EL.UserRPC(),
 		l1CL.beaconHTTPAddr,
 		l2CL.UserRPC(),

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -266,7 +266,7 @@ func startConductorNode(
 		ConsensusPort:           0,
 		ConsensusAdvertisedAddr: "",
 		RaftServerID:            serverID,
-		RaftStorageDir:          filepath.Join(t.TempDir(), "raft"),
+		RaftStorageDir:          filepath.Join(t.TempDirWithPrefix("op-conductor-"+NewComponentTarget(conductorName, l2Net.ChainID()).String()), "raft"),
 		RaftBootstrap:           bootstrap,
 		RaftSnapshotInterval:    120 * time.Second,
 		RaftSnapshotThreshold:   8192,

--- a/op-devstack/sysgo/subproc.go
+++ b/op-devstack/sysgo/subproc.go
@@ -1,11 +1,13 @@
 package sysgo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"sync"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-service/logpipe"
@@ -21,6 +23,7 @@ type SubProcess struct {
 
 	stdOutProc *logpipe.LineBuffer
 	stdErrProc *logpipe.LineBuffer
+	waitCh     chan error
 
 	mu sync.Mutex
 }
@@ -52,6 +55,7 @@ func (sp *SubProcess) Start(cmdPath string, args []string, env []string) error {
 		return err
 	}
 	sp.cmd = cmd
+	sp.waitCh = nil
 	sp.stdOutProc = stdOutProc
 	sp.stdErrProc = stdErrProc
 	sp.p.Cleanup(func() {
@@ -66,16 +70,38 @@ func (sp *SubProcess) Start(cmdPath string, args []string, env []string) error {
 // Stop waits for the process to stop, interrupting the process if it has not completed and
 // interrupt is true.
 func (sp *SubProcess) Stop(interrupt bool) error {
+	return sp.stop(context.Background(), interrupt, 0, 0)
+}
+
+func (sp *SubProcess) StopControlled(ctx context.Context, interruptWait time.Duration, killWait time.Duration) error {
+	return sp.stop(ctx, true, interruptWait, killWait)
+}
+
+func (sp *SubProcess) stop(ctx context.Context, interrupt bool, interruptWait time.Duration, killWait time.Duration) error {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 	if sp.cmd == nil {
 		return nil // already stopped gracefully
 	}
+	cmd := sp.cmd
+	waitCh := sp.waitCh
+	if waitCh == nil {
+		waitCh = make(chan error, 1)
+		sp.waitCh = waitCh
+		go func() {
+			waitCh <- cmd.Wait()
+		}()
+	}
+	select {
+	case waitErr := <-waitCh:
+		return sp.completeStopLocked(interrupt, waitErr)
+	default:
+	}
 
 	// If not already done, then try an interrupt first as requested.
-	if sp.cmd.ProcessState == nil && interrupt {
+	if cmd.ProcessState == nil && interrupt {
 		sp.p.Logger().Info("Sending interrupt")
-		if err := sp.cmd.Process.Signal(os.Interrupt); err != nil {
+		if err := cmd.Process.Signal(os.Interrupt); err != nil && !errors.Is(err, os.ErrProcessDone) {
 			return err
 		}
 	}
@@ -84,7 +110,25 @@ func (sp *SubProcess) Stop(interrupt bool) error {
 	// data is fully flushed before returning. Process.Wait() only waits for the
 	// process to exit but does not guarantee I/O completion, which causes races
 	// where log output hasn't been written to the LineBuffer yet.
-	waitErr := sp.cmd.Wait()
+	waitErr, ok := waitProcess(ctx, waitCh, interruptWait)
+	if !ok {
+		if err := cmd.Process.Kill(); err != nil {
+			waitErr, ok = waitProcess(ctx, waitCh, killWait)
+			if !ok {
+				return fmt.Errorf("interrupt timed out and kill failed: %w", err)
+			}
+			return sp.completeStopLocked(interrupt, waitErr)
+		}
+		waitErr, ok = waitProcess(ctx, waitCh, killWait)
+		if !ok {
+			return fmt.Errorf("process did not stop after interrupt and kill")
+		}
+	}
+
+	return sp.completeStopLocked(interrupt, waitErr)
+}
+
+func (sp *SubProcess) completeStopLocked(interrupt bool, waitErr error) error {
 	var exitErr *exec.ExitError
 	if waitErr != nil && !(interrupt && errors.As(waitErr, &exitErr)) {
 		sp.p.Logger().Warn("Sub-process exited with error", "err", waitErr)
@@ -103,5 +147,27 @@ func (sp *SubProcess) Stop(interrupt bool) error {
 		sp.stdErrProc = nil
 	}
 	sp.cmd = nil
+	sp.waitCh = nil
 	return nil
+}
+
+func waitProcess(ctx context.Context, waitCh <-chan error, timeout time.Duration) (error, bool) {
+	if timeout <= 0 {
+		select {
+		case err := <-waitCh:
+			return err, true
+		case <-ctx.Done():
+			return ctx.Err(), false
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-waitCh:
+		return err, true
+	case <-timer.C:
+		return nil, false
+	case <-ctx.Done():
+		return ctx.Err(), false
+	}
 }

--- a/op-devstack/sysgo/subproc_test.go
+++ b/op-devstack/sysgo/subproc_test.go
@@ -3,6 +3,7 @@ package sysgo
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -43,6 +44,46 @@ func TestSubProcess(gt *testing.T) {
 	gt.Log("Second run of different command")
 	capt.Clear()
 	testEcho(gt, capt, sp)
+}
+
+func TestSubProcessConcurrentStop(gt *testing.T) {
+	tLog := testlog.Logger(gt, log.LevelInfo)
+	logger, _ := testlog.CaptureLogger(gt, log.LevelInfo)
+
+	onFailNow := func(v bool) {
+		panic("fail")
+	}
+	onSkipNow := func() {
+		panic("skip")
+	}
+	p := devtest.NewP(context.Background(), logger, onFailNow, onSkipNow)
+	gt.Cleanup(p.Close)
+
+	logCallback := logpipe.LogCallback(func(line []byte) {
+		logger.Info(string(line))
+		tLog.Info("Sub-process logged message", "line", string(line))
+	})
+	sp := NewSubProcess(p, logCallback, logCallback)
+
+	require.NoError(gt, sp.Start("/bin/sh", []string{"-c", "trap '' INT; exec /bin/sleep 10000000000"}, []string{}))
+
+	start := make(chan struct{})
+	errCh := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			<-start
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			errCh <- sp.StopControlled(ctx, 100*time.Millisecond, time.Second)
+		}()
+	}
+	close(start)
+
+	require.NoError(gt, <-errCh)
+	require.NoError(gt, <-errCh)
+
+	require.NoError(gt, sp.Start("/bin/echo", []string{"restart ok"}, []string{}))
+	require.NoError(gt, sp.Stop(false))
 }
 
 // testEcho tests that we can handle a sub-process that completes on its own

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
@@ -33,7 +34,7 @@ type Supernode struct {
 	log         gethlog.Logger
 	version     string
 	requestStop context.CancelCauseFunc
-	stopped     bool
+	stopped     atomic.Bool
 	cfg         *config.CLIConfig
 	chains      map[eth.ChainID]cc.InteropChain
 	// activitiesMu guards reads and writes of the activities slice.
@@ -282,7 +283,7 @@ func (s *Supernode) Start(ctx context.Context) error {
 
 func (s *Supernode) Stop(ctx context.Context) error {
 	s.log.Info("supernode stopping")
-	s.stopped = true
+	s.stopped.Store(false)
 
 	// Cancel the lifecycle context before anything else. This guarantees that
 	// activity and chain goroutines will observe a canceled context even if
@@ -351,6 +352,9 @@ func (s *Supernode) Stop(ctx context.Context) error {
 	select {
 	case <-wgDone:
 		s.log.Info("goroutines finished, closing l1 client")
+		s.stopped.Store(true)
+	case <-ctx.Done():
+		s.log.Error("context canceled while waiting for chain goroutines to finish, proceeding with cleanup", "err", ctx.Err())
 	case <-time.After(60 * time.Second):
 		s.log.Error("timed out waiting for chain goroutines to finish after 60s, proceeding with cleanup")
 	}
@@ -379,7 +383,7 @@ func (s *Supernode) onChainReset(chainID eth.ChainID, timestamp uint64, invalida
 	}
 }
 
-func (s *Supernode) Stopped() bool { return s.stopped }
+func (s *Supernode) Stopped() bool { return s.stopped.Load() }
 
 // RPCAddr returns the bound RPC address (host:port) if the server is listening.
 // ok is false if the listener has not been created yet.

--- a/op-up/README.md
+++ b/op-up/README.md
@@ -1,0 +1,73 @@
+# op-up
+
+`op-up` starts local OP Stack devnets backed by `op-devstack` presets. It is intended for interactive local testing: choose a topology, get stable localhost RPC ports, and use the printed account and contract addresses from another terminal.
+
+## Quick Start
+
+```bash
+cd op-up
+just op-up
+./bin/op-up presets
+./bin/op-up up minimal
+```
+
+The default preset is `minimal`.
+
+```bash
+./bin/op-up
+./bin/op-up --preset interop
+./bin/op-up up multinode
+```
+
+When the devnet is ready, `op-up` prints:
+
+- stable service RPC ports for L1/L2 EL nodes and L2 CL/rollup nodes
+- a prefunded dev account and private key
+- deployed L1 contract addresses for each L2, including `OptimismPortalProxy`, `SystemConfigProxy`, `L1StandardBridgeProxy`, and `DisputeGameFactoryProxy`
+- a config export directory under `~/.op-up/configs/` with endpoint, contract, rollup, dependency-set, and generated JSON config files when available
+
+Press `Ctrl+C` to stop the devnet and clean up resources.
+
+## Presets
+
+List available presets:
+
+```bash
+./bin/op-up presets
+```
+
+Start a preset:
+
+```bash
+./bin/op-up --preset two-l2
+./bin/op-up up interop
+./bin/op-up deploy conductors
+```
+
+The legacy `--interop` flag is still supported as an alias for `--preset interop`.
+
+## Ports
+
+Every exposed service binds a random available localhost port. `op-up` prints the actual endpoints after the devnet is ready.
+
+## Runtime Selection
+
+`op-up` exposes the common devstack implementation selectors as CLI flags:
+
+```bash
+./bin/op-up up --l2-el-kind op-geth minimal
+./bin/op-up up --l2-el-kind op-reth-proof-v2 minimal
+./bin/op-up up --l2-cl-kind kona-node minimal
+```
+
+These flags set `DEVSTACK_L2EL_KIND` and `DEVSTACK_L2CL_KIND` for the devnet startup. Binary path overrides such as `OP_RETH_EXEC_PATH`, `KONA_NODE_EXEC_PATH`, and `SYSGO_GETH_EXEC_PATH` are still read by devstack directly.
+
+## Metrics
+
+Enable devstack metrics and dashboards:
+
+```bash
+./bin/op-up --metrics
+```
+
+When supported components finish starting, Grafana is served at `http://localhost:3000`.

--- a/op-up/config_export.go
+++ b/op-up/config_export.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+const configExportRPCTimeout = 2 * time.Second
+
+type configExport struct {
+	Dir      string
+	Files    []configExportFile
+	Warnings []string
+}
+
+type configExportFile struct {
+	Path   string `json:"path"`
+	Kind   string `json:"kind"`
+	Source string `json:"source,omitempty"`
+}
+
+type configExportManifest struct {
+	Preset    string             `json:"preset"`
+	CreatedAt string             `json:"created_at"`
+	Files     []configExportFile `json:"files"`
+	Warnings  []string           `json:"warnings,omitempty"`
+}
+
+type endpointConfig struct {
+	Name       string `json:"name"`
+	Layer      string `json:"layer"`
+	Chain      string `json:"chain"`
+	ChainID    string `json:"chain_id,omitempty"`
+	ChainLabel string `json:"chain_label,omitempty"`
+	URL        string `json:"url"`
+	Proxied    bool   `json:"proxied"`
+}
+
+type contractSetConfig struct {
+	Network   string                  `json:"network"`
+	ChainID   string                  `json:"chain_id"`
+	Contracts []contractAddressConfig `json:"contracts"`
+}
+
+type contractAddressConfig struct {
+	Name    string `json:"name"`
+	Address string `json:"address"`
+}
+
+type rollupConfigIndexEntry struct {
+	Network string `json:"network"`
+	ChainID string `json:"chain_id"`
+	Path    string `json:"path"`
+}
+
+func exportDevnetConfigs(ctx context.Context, cfg opUpConfig, spec *devnetPreset, tempRoot string, devnet *runningDevnet, endpoints []*localEndpoint) (*configExport, error) {
+	configRoot := filepath.Join(cfg.Dir, "configs")
+	if err := os.MkdirAll(configRoot, 0o700); err != nil {
+		return nil, fmt.Errorf("create config export root: %w", err)
+	}
+	if err := os.Chmod(configRoot, 0o700); err != nil {
+		return nil, fmt.Errorf("restrict config export root: %w", err)
+	}
+
+	createdAt := time.Now().UTC().Format(time.RFC3339)
+	prefix := fmt.Sprintf("op-up-%s-%s-", tempDirSafePrefix(spec.Name), time.Now().UTC().Format("20060102T150405Z"))
+	exportDir, err := os.MkdirTemp(configRoot, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("create config export dir: %w", err)
+	}
+	if err := os.Chmod(exportDir, 0o700); err != nil {
+		return nil, fmt.Errorf("restrict config export dir: %w", err)
+	}
+
+	out := &configExport{Dir: exportDir}
+	addFile := func(kind string, relPath string, source string) {
+		out.Files = append(out.Files, configExportFile{
+			Path:   filepath.ToSlash(relPath),
+			Kind:   kind,
+			Source: source,
+		})
+	}
+
+	if err := writeJSONConfig(exportDir, "endpoints.json", endpointsForConfig(endpoints)); err != nil {
+		return nil, err
+	}
+	addFile("endpoints", "endpoints.json", "op-up")
+
+	if err := writeJSONConfig(exportDir, "contracts.json", contractsForConfig(devnet.Contracts)); err != nil {
+		return nil, err
+	}
+	addFile("contracts", "contracts.json", "op-up")
+
+	rollupIndex, err := exportRollupConfigs(exportDir, devnet.L2Networks, addFile)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeJSONConfig(exportDir, "rollups/index.json", rollupIndex); err != nil {
+		return nil, err
+	}
+	addFile("rollup-index", "rollups/index.json", "op-up")
+
+	if devnet.ExportDepset {
+		if err := exportDependencySets(ctx, exportDir, endpoints, addFile); err != nil {
+			return nil, err
+		}
+	}
+	if err := copyGeneratedJSONConfigs(tempRoot, exportDir, addFile); err != nil {
+		return nil, err
+	}
+
+	manifestFile := configExportFile{Path: "manifest.json", Kind: "manifest", Source: "op-up"}
+	manifestFiles := append([]configExportFile{}, out.Files...)
+	manifestFiles = append(manifestFiles, manifestFile)
+	manifest := configExportManifest{
+		Preset:    spec.Name,
+		CreatedAt: createdAt,
+		Files:     manifestFiles,
+		Warnings:  out.Warnings,
+	}
+	if err := writeJSONConfig(exportDir, "manifest.json", manifest); err != nil {
+		return nil, err
+	}
+	out.Files = manifestFiles
+	return out, nil
+}
+
+func endpointsForConfig(endpoints []*localEndpoint) []endpointConfig {
+	out := make([]endpointConfig, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		if endpoint == nil || endpoint.devnetEndpoint == nil {
+			continue
+		}
+		chainID := ""
+		if endpoint.ChainID != (eth.ChainID{}) {
+			chainID = endpoint.ChainID.String()
+		}
+		out = append(out, endpointConfig{
+			Name:       endpoint.Name,
+			Layer:      endpoint.Layer,
+			Chain:      endpoint.Chain(),
+			ChainID:    chainID,
+			ChainLabel: endpoint.ChainLabel,
+			URL:        endpoint.LocalURL,
+			Proxied:    endpoint.Listener != nil,
+		})
+	}
+	return out
+}
+
+func contractsForConfig(sets []*contractSet) []contractSetConfig {
+	out := make([]contractSetConfig, 0, len(sets))
+	for _, set := range sets {
+		if set == nil {
+			continue
+		}
+		contracts := make([]contractAddressConfig, 0, len(set.Contracts))
+		for _, contract := range set.Contracts {
+			contracts = append(contracts, contractAddressConfig{
+				Name:    contract.Name,
+				Address: contract.Address.Hex(),
+			})
+		}
+		out = append(out, contractSetConfig{
+			Network:   set.Network,
+			ChainID:   set.ChainID.String(),
+			Contracts: contracts,
+		})
+	}
+	return out
+}
+
+func exportRollupConfigs(exportDir string, networks []*namedL2Network, addFile func(kind string, relPath string, source string)) ([]rollupConfigIndexEntry, error) {
+	out := make([]rollupConfigIndexEntry, 0, len(networks))
+	for _, network := range networks {
+		if network == nil || network.Network == nil {
+			continue
+		}
+		chainID := network.Network.ChainID()
+		relPath := filepath.Join("rollups", fmt.Sprintf("rollup-%s-%s.json", configFilenameComponent(network.Name), chainID))
+		if err := writeJSONConfig(exportDir, relPath, network.Network.Escape().RollupConfig()); err != nil {
+			return nil, err
+		}
+		relPath = filepath.ToSlash(relPath)
+		addFile("rollup", relPath, "op-devstack dsl")
+		out = append(out, rollupConfigIndexEntry{
+			Network: network.Name,
+			ChainID: chainID.String(),
+			Path:    relPath,
+		})
+	}
+	return out, nil
+}
+
+func exportDependencySets(ctx context.Context, exportDir string, endpoints []*localEndpoint, addFile func(kind string, relPath string, source string)) error {
+	seen := make(map[string]struct{})
+	written := 0
+	for _, endpoint := range endpoints {
+		if endpoint == nil || endpoint.RPC == nil || !shouldFetchDependencySet(endpoint) {
+			continue
+		}
+		raw, ok := fetchDependencySet(ctx, endpoint)
+		if !ok {
+			continue
+		}
+		key := string(raw)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		relPath := "depset.json"
+		if written > 0 {
+			relPath = filepath.Join("depsets", fmt.Sprintf("depset-%s-%s.json", configFilenameComponent(endpoint.Name), configFilenameComponent(endpoint.Chain())))
+		}
+		if err := writeRawJSONConfig(exportDir, relPath, raw); err != nil {
+			return err
+		}
+		addFile("dependency-set", relPath, "optimism_dependencySet")
+		written++
+	}
+	return nil
+}
+
+func shouldFetchDependencySet(endpoint *localEndpoint) bool {
+	return endpoint.Layer == "CL" || endpoint.Layer == "RPC" || endpoint.ChainLabel == "shared"
+}
+
+func fetchDependencySet(ctx context.Context, endpoint *localEndpoint) (json.RawMessage, bool) {
+	callCtx, cancel := context.WithTimeout(ctx, configExportRPCTimeout)
+	defer cancel()
+
+	var raw json.RawMessage
+	if err := endpoint.RPC.CallContext(callCtx, &raw, "optimism_dependencySet"); err != nil {
+		return nil, false
+	}
+	if len(bytes.TrimSpace(raw)) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, false
+	}
+	return raw, true
+}
+
+func copyGeneratedJSONConfigs(tempRoot string, exportDir string, addFile func(kind string, relPath string, source string)) error {
+	generatedRoot := filepath.Join(exportDir, "generated")
+	return filepath.WalkDir(tempRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !isGeneratedConfigJSON(entry.Name()) {
+			return nil
+		}
+		rel, err := filepath.Rel(tempRoot, path)
+		if err != nil {
+			return fmt.Errorf("relativize generated config %s: %w", path, err)
+		}
+		dest := filepath.Join(generatedRoot, rel)
+		if err := copyFile(path, dest); err != nil {
+			return err
+		}
+		relDest := filepath.ToSlash(filepath.Join("generated", rel))
+		addFile("generated-json", relDest, path)
+		return nil
+	})
+}
+
+func isGeneratedConfigJSON(name string) bool {
+	if filepath.Ext(name) != ".json" {
+		return false
+	}
+	name = strings.ToLower(name)
+	return strings.Contains(name, "genesis") ||
+		strings.Contains(name, "rollup") ||
+		strings.Contains(name, "depset") ||
+		strings.Contains(name, "config")
+}
+
+func writeJSONConfig(root string, relPath string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", relPath, err)
+	}
+	data = append(data, '\n')
+	return writeConfigFile(root, relPath, data)
+}
+
+func writeRawJSONConfig(root string, relPath string, raw json.RawMessage) error {
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, raw, "", "  "); err != nil {
+		return fmt.Errorf("format %s: %w", relPath, err)
+	}
+	pretty.WriteByte('\n')
+	return writeConfigFile(root, relPath, pretty.Bytes())
+}
+
+func writeConfigFile(root string, relPath string, data []byte) error {
+	path := filepath.Join(root, relPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create config dir for %s: %w", relPath, err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write config %s: %w", relPath, err)
+	}
+	return nil
+}
+
+func copyFile(src string, dest string) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		return fmt.Errorf("create destination dir for %s: %w", dest, err)
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open generated config %s: %w", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("create generated config copy %s: %w", dest, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("copy generated config %s: %w", src, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close generated config copy %s: %w", dest, err)
+	}
+	return nil
+}
+
+func configFilenameComponent(v string) string {
+	v = strings.ToLower(tempDirSafePrefix(v))
+	if v == "" {
+		return "unknown"
+	}
+	return v
+}

--- a/op-up/control.go
+++ b/op-up/control.go
@@ -1,0 +1,769 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"text/tabwriter"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	serviceStateRunning    = "running"
+	serviceStateStopping   = "stopping"
+	serviceStateStopped    = "stopped"
+	serviceStateStarting   = "starting"
+	serviceStateError      = "error"
+	serviceStateStopFailed = "stop_failed"
+
+	serviceHealthOK          = "ok"
+	serviceHealthUnreachable = "unreachable"
+	serviceHealthStopped     = "stopped"
+	serviceHealthUnknown     = "unknown"
+
+	controlStopTimeout   = 30 * time.Second
+	controlStartTimeout  = 30 * time.Second
+	controlStartStuck    = 2 * time.Minute
+	controlHealthTimeout = time.Second
+)
+
+var errControlOperationPending = errors.New("control operation still in progress")
+
+var controlSessionFlag = &cli.StringFlag{
+	Name:  "session",
+	Usage: "op-up control session id. Defaults to the newest live session.",
+}
+
+type controlledService struct {
+	ID          string
+	Name        string
+	Kind        string
+	ChainID     eth.ChainID
+	Endpoint    *devnetEndpoint
+	EndpointURL string
+	RPC         opclient.RPC
+	Control     stack.ControlledLifecycle
+	LogDir      string
+
+	mu            sync.Mutex
+	state         string
+	lastOperation string
+	lastError     string
+	lastUpdated   time.Time
+	opSeq         uint64
+}
+
+type controlledServiceStatus struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Kind          string `json:"kind"`
+	Chain         string `json:"chain"`
+	State         string `json:"state"`
+	Health        string `json:"health"`
+	EndpointURL   string `json:"endpoint_url,omitempty"`
+	LogDir        string `json:"log_dir,omitempty"`
+	LastOperation string `json:"last_operation,omitempty"`
+	LastError     string `json:"last_error,omitempty"`
+	LastUpdated   string `json:"last_updated,omitempty"`
+}
+
+type controlSessionMetadata struct {
+	ID         string                    `json:"id"`
+	Preset     string                    `json:"preset"`
+	PID        int                       `json:"pid"`
+	StartedAt  string                    `json:"started_at"`
+	ControlURL string                    `json:"control_url"`
+	Token      string                    `json:"token"`
+	LogFile    string                    `json:"log_file,omitempty"`
+	Services   []controlledServiceStatus `json:"services"`
+}
+
+type controlServer struct {
+	session controlSessionMetadata
+	token   string
+	byID    map[string]*controlledService
+	server  *http.Server
+	file    string
+}
+
+type controlResponse struct {
+	Session  controlSessionMetadata    `json:"session"`
+	Service  *controlledServiceStatus  `json:"service,omitempty"`
+	Services []controlledServiceStatus `json:"services,omitempty"`
+	Error    string                    `json:"error,omitempty"`
+}
+
+func controlCommand() *cli.Command {
+	flags := []cli.Flag{controlSessionFlag, dirFlag}
+	return &cli.Command{
+		Name:  "control",
+		Usage: "control services in a running op-up devnet",
+		Subcommands: []*cli.Command{
+			{
+				Name:    "services",
+				Aliases: []string{"ls", "list", "ps"},
+				Usage:   "list controllable services",
+				Flags:   flags,
+				Action: func(cliCtx *cli.Context) error {
+					return runControlCLI(cliCtx.Context, cliCtx, "services", "")
+				},
+			},
+			{
+				Name:      "status",
+				Usage:     "show one service status",
+				ArgsUsage: "<service-id>",
+				Flags:     flags,
+				Action: func(cliCtx *cli.Context) error {
+					id, err := oneControlServiceArg(cliCtx)
+					if err != nil {
+						return err
+					}
+					return runControlCLI(cliCtx.Context, cliCtx, "status", id)
+				},
+			},
+			controlActionCommand("start"),
+			controlActionCommand("stop"),
+			controlActionCommand("restart"),
+		},
+	}
+}
+
+func controlActionCommand(action string) *cli.Command {
+	return &cli.Command{
+		Name:      action,
+		Usage:     action + " one service",
+		ArgsUsage: "<service-id>",
+		Flags:     []cli.Flag{controlSessionFlag, dirFlag},
+		Action: func(cliCtx *cli.Context) error {
+			id, err := oneControlServiceArg(cliCtx)
+			if err != nil {
+				return err
+			}
+			return runControlCLI(cliCtx.Context, cliCtx, action, id)
+		},
+	}
+}
+
+func oneControlServiceArg(cliCtx *cli.Context) (string, error) {
+	if cliCtx.NArg() != 1 {
+		return "", fmt.Errorf("expected exactly one service id")
+	}
+	return cliCtx.Args().First(), nil
+}
+
+func runControlCLI(ctx context.Context, cliCtx *cli.Context, action string, serviceID string) error {
+	dir := cliPath(cliCtx, dirFlag.Name)
+	sessionID := cliString(cliCtx, controlSessionFlag.Name)
+	session, err := selectControlSession(dir, sessionID)
+	if err != nil {
+		return err
+	}
+	resp, err := callControlServer(ctx, session, action, serviceID)
+	if err != nil {
+		return err
+	}
+	printControlResponse(cliCtx.App.Writer, resp, action)
+	if resp.Error != "" {
+		return errors.New(resp.Error)
+	}
+	return nil
+}
+
+func selectControlSession(dir string, sessionID string) (controlSessionMetadata, error) {
+	controlDir := filepath.Join(dir, "control")
+	files, err := os.ReadDir(controlDir)
+	if err != nil {
+		return controlSessionMetadata{}, fmt.Errorf("read control sessions: %w", err)
+	}
+	var candidates []controlSessionMetadata
+	for _, file := range files {
+		if file.IsDir() || filepath.Ext(file.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(controlDir, file.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var meta controlSessionMetadata
+		if err := json.Unmarshal(data, &meta); err != nil {
+			continue
+		}
+		if sessionID != "" && meta.ID != sessionID {
+			continue
+		}
+		if !controlSessionLive(meta) {
+			continue
+		}
+		candidates = append(candidates, meta)
+	}
+	if len(candidates) == 0 {
+		if sessionID != "" {
+			return controlSessionMetadata{}, fmt.Errorf("no live op-up session %q found", sessionID)
+		}
+		return controlSessionMetadata{}, fmt.Errorf("no live op-up sessions found")
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].StartedAt > candidates[j].StartedAt
+	})
+	return candidates[0], nil
+}
+
+func processExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func controlSessionLive(meta controlSessionMetadata) bool {
+	if !processExists(meta.PID) {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(meta.ControlURL, "/")+"/healthz", nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Authorization", "Bearer "+meta.Token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func callControlServer(ctx context.Context, session controlSessionMetadata, action string, serviceID string) (controlResponse, error) {
+	method := http.MethodGet
+	path := "/services"
+	if action != "services" {
+		path = "/services/" + serviceID
+		if action != "status" {
+			method = http.MethodPost
+			path += "/" + action
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(session.ControlURL, "/")+path, nil)
+	if err != nil {
+		return controlResponse{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+session.Token)
+	httpResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return controlResponse{}, err
+	}
+	defer httpResp.Body.Close()
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return controlResponse{}, err
+	}
+	var resp controlResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return controlResponse{}, fmt.Errorf("decode control response: %w", err)
+	}
+	if httpResp.StatusCode >= 400 && resp.Error == "" {
+		resp.Error = httpResp.Status
+	}
+	return resp, nil
+}
+
+func printControlResponse(w io.Writer, resp controlResponse, action string) {
+	fmt.Fprintf(w, "Session: %s\nPreset: %s\nPID: %d\n", resp.Session.ID, resp.Session.Preset, resp.Session.PID)
+	if resp.Session.LogFile != "" {
+		fmt.Fprintf(w, "Logs: %s\n", resp.Session.LogFile)
+	}
+	fmt.Fprintln(w)
+	if resp.Service != nil {
+		printControlServices(w, []controlledServiceStatus{*resp.Service})
+		if resp.Error == "" && action != "status" && action != "services" && resp.Service.LastError != "" && (resp.Service.State == serviceStateStarting || resp.Service.State == serviceStateStopping) {
+			fmt.Fprintf(w, "\nOperation still in progress for %s; rerun `op-up control status %s --session %s`.\n", resp.Service.ID, resp.Service.ID, resp.Session.ID)
+		}
+		return
+	}
+	printControlServices(w, resp.Services)
+}
+
+func printControlServices(w io.Writer, services []controlledServiceStatus) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	showLogDir := false
+	for _, svc := range services {
+		if svc.LogDir != "" {
+			showLogDir = true
+			break
+		}
+	}
+	if showLogDir {
+		fmt.Fprintln(tw, "SERVICE ID\tKIND\tCHAIN\tSTATE\tHEALTH\tENDPOINT\tLOG DIR\tLAST ERROR")
+	} else {
+		fmt.Fprintln(tw, "SERVICE ID\tKIND\tCHAIN\tSTATE\tHEALTH\tENDPOINT\tLAST ERROR")
+	}
+	for _, svc := range services {
+		if showLogDir {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", svc.ID, svc.Kind, svc.Chain, svc.State, svc.Health, svc.EndpointURL, svc.LogDir, svc.LastError)
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", svc.ID, svc.Kind, svc.Chain, svc.State, svc.Health, svc.EndpointURL, svc.LastError)
+		}
+	}
+	_ = tw.Flush()
+}
+
+func newControlServer(ctx context.Context, cfg opUpConfig, spec *devnetPreset, services []*controlledService, runID string, logFilePath string) (*controlServer, error) {
+	if len(services) == 0 {
+		return nil, nil
+	}
+	controlDir := filepath.Join(cfg.Dir, "control")
+	if err := os.MkdirAll(controlDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create control dir: %w", err)
+	}
+	if err := os.Chmod(controlDir, 0o700); err != nil {
+		return nil, fmt.Errorf("restrict control dir: %w", err)
+	}
+	token, err := randomControlToken()
+	if err != nil {
+		return nil, err
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("listen for control server: %w", err)
+	}
+	id := runID
+	if id == "" {
+		id = newOpUpRunID(spec.Name)
+	}
+	startedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	byID := make(map[string]*controlledService, len(services))
+	for _, svc := range services {
+		svc.initState()
+		byID[svc.ID] = svc
+	}
+	session := controlSessionMetadata{
+		ID:         id,
+		Preset:     spec.Name,
+		PID:        os.Getpid(),
+		StartedAt:  startedAt,
+		ControlURL: "http://" + listener.Addr().String(),
+		Token:      token,
+		LogFile:    logFilePath,
+		Services:   serviceStatuses(ctx, services),
+	}
+	file := filepath.Join(controlDir, id+".json")
+	if err := writeControlSessionFile(file, session); err != nil {
+		_ = listener.Close()
+		return nil, err
+	}
+	cs := &controlServer{session: session, token: token, byID: byID, file: file}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", cs.handleHealthz)
+	mux.HandleFunc("/services", cs.handleServices)
+	mux.HandleFunc("/services/", cs.handleService)
+	cs.server = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		_ = cs.server.Serve(listener)
+	}()
+	go func() {
+		<-ctx.Done()
+		_ = cs.Close()
+	}()
+	return cs, nil
+}
+
+func (c *controlServer) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	if !c.authorized(w, r) {
+		return
+	}
+	if r.URL.Path != "/healthz" || r.Method != http.MethodGet {
+		writeControlError(w, http.StatusNotFound, "not found")
+		return
+	}
+	session := c.session
+	session.Services = nil
+	writeControlJSON(w, http.StatusOK, controlResponse{Session: session})
+}
+
+func writeControlSessionFile(path string, session controlSessionMetadata) error {
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal control session: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write control session: %w", err)
+	}
+	return nil
+}
+
+func (c *controlServer) Close() error {
+	if c == nil {
+		return nil
+	}
+	_ = os.Remove(c.file)
+	if c.server == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return c.server.Shutdown(ctx)
+}
+
+func (c *controlServer) handleServices(w http.ResponseWriter, r *http.Request) {
+	if !c.authorized(w, r) {
+		return
+	}
+	if r.URL.Path != "/services" || r.Method != http.MethodGet {
+		writeControlError(w, http.StatusNotFound, "not found")
+		return
+	}
+	writeControlJSON(w, http.StatusOK, controlResponse{Session: c.currentSession(r.Context()), Services: c.statuses(r.Context())})
+}
+
+func (c *controlServer) handleService(w http.ResponseWriter, r *http.Request) {
+	if !c.authorized(w, r) {
+		return
+	}
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/services/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		c.writeControlError(w, r, http.StatusNotFound, "missing service id")
+		return
+	}
+	svc, ok := c.byID[parts[0]]
+	if !ok {
+		c.writeControlError(w, r, http.StatusNotFound, "unknown service id "+parts[0])
+		return
+	}
+	if len(parts) == 1 && r.Method == http.MethodGet {
+		status := svc.status(r.Context())
+		writeControlJSON(w, http.StatusOK, controlResponse{Session: c.sessionSummary(), Service: &status})
+		return
+	}
+	if len(parts) != 2 || r.Method != http.MethodPost {
+		c.writeControlError(w, r, http.StatusNotFound, "not found")
+		return
+	}
+	var err error
+	switch parts[1] {
+	case "start":
+		err = svc.start(r.Context())
+	case "stop":
+		err = svc.stop(r.Context())
+	case "restart":
+		err = svc.restart(r.Context())
+	default:
+		c.writeControlError(w, r, http.StatusNotFound, "unknown action "+parts[1])
+		return
+	}
+	status := svc.status(r.Context())
+	code := http.StatusOK
+	resp := controlResponse{Session: c.sessionSummary(), Service: &status}
+	if err != nil {
+		if errors.Is(err, errControlOperationPending) {
+			code = http.StatusAccepted
+		} else {
+			code = http.StatusConflict
+			resp.Error = err.Error()
+		}
+	}
+	writeControlJSON(w, code, resp)
+}
+
+func (c *controlServer) writeControlError(w http.ResponseWriter, r *http.Request, code int, message string) {
+	writeControlJSON(w, code, controlResponse{Session: c.sessionSummary(), Error: message})
+}
+
+func (c *controlServer) authorized(w http.ResponseWriter, r *http.Request) bool {
+	if r.Header.Get("Authorization") != "Bearer "+c.token {
+		writeControlError(w, http.StatusUnauthorized, "unauthorized")
+		return false
+	}
+	return true
+}
+
+func (c *controlServer) currentSession(ctx context.Context) controlSessionMetadata {
+	session := c.session
+	session.Services = c.statuses(ctx)
+	return session
+}
+
+func (c *controlServer) sessionSummary() controlSessionMetadata {
+	session := c.session
+	session.Services = nil
+	return session
+}
+
+func (c *controlServer) statuses(ctx context.Context) []controlledServiceStatus {
+	services := make([]*controlledService, 0, len(c.byID))
+	for _, svc := range c.byID {
+		services = append(services, svc)
+	}
+	sort.Slice(services, func(i, j int) bool {
+		return services[i].ID < services[j].ID
+	})
+	return serviceStatuses(ctx, services)
+}
+
+func serviceStatuses(ctx context.Context, services []*controlledService) []controlledServiceStatus {
+	out := make([]controlledServiceStatus, 0, len(services))
+	for _, svc := range services {
+		out = append(out, svc.status(ctx))
+	}
+	return out
+}
+
+func (s *controlledService) initState() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Control != nil && s.Control.Running() {
+		s.state = serviceStateRunning
+	} else {
+		s.state = serviceStateStopped
+	}
+	s.lastUpdated = time.Now().UTC()
+}
+
+func (s *controlledService) status(ctx context.Context) controlledServiceStatus {
+	s.mu.Lock()
+	state := s.state
+	lastOperation := s.lastOperation
+	lastError := s.lastError
+	lastUpdated := s.lastUpdated
+	s.mu.Unlock()
+	endpointURL := ""
+	if s.EndpointURL != "" {
+		endpointURL = s.EndpointURL
+	}
+	chain := "shared"
+	if s.ChainID != (eth.ChainID{}) {
+		chain = s.ChainID.String()
+	}
+	updated := ""
+	if !lastUpdated.IsZero() {
+		updated = lastUpdated.Format(time.RFC3339Nano)
+	}
+	return controlledServiceStatus{
+		ID:            s.ID,
+		Name:          s.Name,
+		Kind:          s.Kind,
+		Chain:         chain,
+		State:         state,
+		Health:        s.health(ctx, state),
+		EndpointURL:   endpointURL,
+		LogDir:        s.LogDir,
+		LastOperation: lastOperation,
+		LastError:     lastError,
+		LastUpdated:   updated,
+	}
+}
+
+func (s *controlledService) health(ctx context.Context, state string) string {
+	if state == serviceStateStopped || state == serviceStateStopFailed {
+		return serviceHealthStopped
+	}
+	if s.RPC == nil {
+		return serviceHealthUnknown
+	}
+	callCtx, cancel := context.WithTimeout(ctx, controlHealthTimeout)
+	defer cancel()
+	var out json.RawMessage
+	if err := s.RPC.CallContext(callCtx, &out, "rpc_modules"); err != nil {
+		return serviceHealthUnreachable
+	}
+	return serviceHealthOK
+}
+
+func (s *controlledService) start(ctx context.Context) error {
+	if s.Control == nil {
+		return fmt.Errorf("service %s is not controllable", s.ID)
+	}
+	s.mu.Lock()
+	if s.state != serviceStateStopped {
+		err := fmt.Errorf("service %s cannot start from state %s", s.ID, s.state)
+		s.mu.Unlock()
+		return err
+	}
+	s.opSeq++
+	seq := s.opSeq
+	s.state = serviceStateStarting
+	s.lastOperation = "start"
+	s.lastError = ""
+	s.lastUpdated = time.Now().UTC()
+	s.mu.Unlock()
+
+	opCtx, cancel := context.WithTimeout(ctx, controlStartTimeout)
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Control.StartControlled(opCtx)
+	}()
+	select {
+	case err := <-done:
+		cancel()
+		return s.completeStart(seq, err)
+	case <-opCtx.Done():
+		err := fmt.Errorf("start still in progress after %s: %w", controlStartTimeout, opCtx.Err())
+		s.noteStartPending(seq, err)
+		go func() {
+			timer := time.NewTimer(controlStartStuck)
+			defer timer.Stop()
+			select {
+			case err := <-done:
+				_ = s.completeStart(seq, err)
+			case <-timer.C:
+				s.noteStartPending(seq, fmt.Errorf("start has not completed after %s; safest recovery is restarting the op-up devnet", controlStartStuck))
+				_ = s.completeStart(seq, <-done)
+			}
+		}()
+		cancel()
+		return errControlOperationPending
+	}
+}
+
+func (s *controlledService) noteStartPending(seq uint64, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.opSeq != seq {
+		return
+	}
+	s.state = serviceStateStarting
+	s.lastError = err.Error()
+	s.lastUpdated = time.Now().UTC()
+}
+
+func (s *controlledService) completeStart(seq uint64, err error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.opSeq != seq {
+		return err
+	}
+	if err != nil {
+		s.state = serviceStateError
+		s.lastError = err.Error()
+	} else {
+		s.state = serviceStateRunning
+	}
+	s.lastUpdated = time.Now().UTC()
+	return err
+}
+
+func (s *controlledService) stop(ctx context.Context) error {
+	if s.Control == nil {
+		return fmt.Errorf("service %s is not controllable", s.ID)
+	}
+	s.mu.Lock()
+	switch s.state {
+	case serviceStateStopped:
+		s.mu.Unlock()
+		return nil
+	case serviceStateStarting, serviceStateStopping:
+		err := fmt.Errorf("service %s is busy in state %s", s.ID, s.state)
+		s.mu.Unlock()
+		return err
+	}
+	s.opSeq++
+	seq := s.opSeq
+	s.state = serviceStateStopping
+	s.lastOperation = "stop"
+	s.lastError = ""
+	s.lastUpdated = time.Now().UTC()
+	s.mu.Unlock()
+
+	opCtx, cancel := context.WithTimeout(ctx, controlStopTimeout)
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Control.StopControlled(opCtx)
+	}()
+	select {
+	case err := <-done:
+		cancel()
+		return s.completeStop(seq, err)
+	case <-opCtx.Done():
+		err := opCtx.Err()
+		go func() {
+			if lateErr := <-done; lateErr == nil {
+				_ = s.completeStop(seq, nil)
+			}
+		}()
+		cancel()
+		return s.completeStop(seq, err)
+	}
+}
+
+func (s *controlledService) completeStop(seq uint64, err error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.opSeq != seq {
+		return err
+	}
+	if err != nil {
+		s.state = serviceStateStopFailed
+		s.lastError = err.Error()
+	} else {
+		s.state = serviceStateStopped
+		s.lastError = ""
+	}
+	s.lastUpdated = time.Now().UTC()
+	return err
+}
+
+func (s *controlledService) restart(ctx context.Context) error {
+	if err := s.stop(ctx); err != nil {
+		return err
+	}
+	return s.start(ctx)
+}
+
+func (s *controlledService) proxyAvailable() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state == serviceStateRunning
+}
+
+func writeControlJSON(w http.ResponseWriter, code int, value controlResponse) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		writeControlError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_, _ = w.Write(append(data, '\n'))
+}
+
+func writeControlError(w http.ResponseWriter, code int, message string) {
+	writeControlJSON(w, code, controlResponse{Error: message})
+}
+
+func randomControlToken() (string, error) {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("generate control token: %w", err)
+	}
+	return hex.EncodeToString(buf[:]), nil
+}
+
+func backendStoppedError(id json.RawMessage, method string) rpcProxyResponse {
+	return rpcProxyErr(id, -32000, fmt.Sprintf("backend stopped or unavailable for method %q", method))
+}

--- a/op-up/devnet.go
+++ b/op-up/devnet.go
@@ -1,0 +1,744 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"slices"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	defaultPresetName = "minimal"
+
+	devstackL2ELKindEnvVar       = "DEVSTACK_L2EL_KIND"
+	devstackL2CLKindEnvVar       = "DEVSTACK_L2CL_KIND"
+	sysgoMetricsEnabledEnvVar    = "SYSGO_METRICS_ENABLED"
+	defaultInteropActivationSecs = uint64(2)
+)
+
+type opUpConfig struct {
+	Dir           string
+	Preset        string
+	LegacyInterop bool
+	L2ELKind      string
+	L2CLKind      string
+	Metrics       bool
+}
+
+type devnetPreset struct {
+	Name        string
+	Aliases     []string
+	Summary     string
+	Description string
+	Build       func(*testingT) (*runningDevnet, error)
+}
+
+type runningDevnet struct {
+	L1EL               *devnetEndpoint
+	L1CL               *devnetEndpoint
+	L2Networks         []*namedL2Network
+	L2ELs              []*devnetEndpoint
+	L2CLs              []*devnetEndpoint
+	Services           []*devnetEndpoint
+	ControlledServices []*controlledService
+	Contracts          []*contractSet
+	ExportDepset       bool
+	BackgroundLoggers  []func(context.Context, io.Writer)
+	Notes              []string
+}
+
+type devnetEndpoint struct {
+	Name       string
+	Layer      string
+	ChainID    eth.ChainID
+	ChainLabel string
+	RPC        opclient.RPC
+	BackendURL string
+	DirectURL  string
+}
+
+type namedL2Network struct {
+	Name    string
+	Network *dsl.L2Network
+}
+
+type contractSet struct {
+	Network   string
+	ChainID   eth.ChainID
+	Contracts []contractAddress
+}
+
+type contractAddress struct {
+	Name    string
+	Address common.Address
+}
+
+type localEndpoint struct {
+	*devnetEndpoint
+	LocalURL string
+	Listener net.Listener
+}
+
+type localEndpointRequest struct {
+	Endpoint *devnetEndpoint
+}
+
+var devnetPresets = []*devnetPreset{
+	{
+		Name:        defaultPresetName,
+		Aliases:     []string{"single", "single-chain"},
+		Summary:     "single L2 with one sequencer, batcher, proposer, and dev faucets",
+		Description: "The fastest general-purpose OP Stack devnet. This is the default.",
+		Build:       buildMinimalDevnet,
+	},
+	{
+		Name:        "interop",
+		Aliases:     []string{"two-l2-interop", "supernode-interop"},
+		Summary:     "two L2s with interop enabled and a shared op-supernode",
+		Description: "Use this when testing cross-chain messages or op-supernode behavior.",
+		Build:       buildInteropDevnet,
+	},
+	{
+		Name:        "two-l2",
+		Aliases:     []string{"supernode", "multi-chain"},
+		Summary:     "two L2s backed by a shared op-supernode, without interop activation",
+		Description: "Useful for tooling that needs multiple L2 RPCs without interop semantics.",
+		Build:       buildTwoL2Devnet,
+	},
+	{
+		Name:        "multinode",
+		Aliases:     []string{"multi-node", "singlechain-multinode"},
+		Summary:     "single L2 with a sequencer and verifier node",
+		Description: "Exercises a small sequencer/verifier topology on one L2.",
+		Build:       buildMultinodeDevnet,
+	},
+	{
+		Name:        "two-verifiers",
+		Aliases:     []string{"singlechain-twoverifiers"},
+		Summary:     "single L2 with a sequencer and two verifier nodes",
+		Description: "A larger single-chain topology for verifier and P2P behavior.",
+		Build:       buildTwoVerifiersDevnet,
+	},
+	{
+		Name:        "conductors",
+		Aliases:     []string{"conductor", "failover"},
+		Summary:     "single L2 with an op-conductor cluster around the sequencer",
+		Description: "Use this for local sequencer failover and conductor workflows.",
+		Build:       buildConductorsDevnet,
+	},
+	{
+		Name:        "flashblocks",
+		Aliases:     []string{"flashblock"},
+		Summary:     "single L2 with rollup-boost and op-rbuilder flashblocks components",
+		Description: "Requires the local flashblocks-capable binaries expected by devstack.",
+		Build:       buildFlashblocksDevnet,
+	},
+}
+
+func resolvePreset(name string) (*devnetPreset, error) {
+	normalized := normalizePresetName(name)
+	for _, spec := range devnetPresets {
+		if normalized == spec.Name {
+			return spec, nil
+		}
+		for _, alias := range spec.Aliases {
+			if normalized == alias {
+				return spec, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("unknown preset %q (run `op-up presets` to list available presets)", name)
+}
+
+func normalizePresetName(name string) string {
+	name = strings.TrimSpace(strings.ToLower(name))
+	name = strings.ReplaceAll(name, "_", "-")
+	return name
+}
+
+func printPresetList(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "PRESET\tALIASES\tDESCRIPTION"); err != nil {
+		return err
+	}
+	for _, spec := range devnetPresets {
+		aliases := "-"
+		if len(spec.Aliases) > 0 {
+			aliases = strings.Join(spec.Aliases, ", ")
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", spec.Name, aliases, spec.Summary); err != nil {
+			return err
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintln(w, "\nStart one with `op-up --preset <name>` or `op-up up <name>`.")
+	return err
+}
+
+func runSelectedDevnet(ctx context.Context, stdout io.Writer, stderr io.Writer, cfg opUpConfig, spec *devnetPreset, tempRoot string, devnet *runningDevnet, runID string, logFilePath string) error {
+	fmt.Fprintf(stderr, "\nPreset: %s\n", spec.Name)
+	fmt.Fprintf(stderr, "%s\n\n", spec.Description)
+
+	if err := printAccountInfo(stderr); err != nil {
+		return err
+	}
+
+	endpoints, err := devnet.localEndpoints()
+	if err != nil {
+		return err
+	}
+	defer closeLocalEndpointListeners(endpoints)
+	devnet.applyControlEndpointURLs(endpoints)
+
+	configExport, err := exportDevnetConfigs(ctx, cfg, spec, tempRoot, devnet, endpoints)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "Config files: %s\n", configExport.Dir)
+	fmt.Fprintf(stderr, "\nConfig files: %s\n", configExport.Dir)
+	if logFilePath != "" {
+		fmt.Fprintf(stdout, "Logs: %s\n", logFilePath)
+	}
+	controlServer, err := newControlServer(ctx, cfg, spec, devnet.ControlledServices, runID, logFilePath)
+	if err != nil {
+		return err
+	}
+	defer controlServer.Close()
+
+	if len(endpoints) > 0 {
+		fmt.Fprintln(stderr, "\nServices / Endpoints:")
+		controlIDs := devnet.controlIDsByEndpoint()
+		for _, endpoint := range endpoints {
+			fmt.Fprintf(stderr, "  %-14s %-4s control=%-18s chain=%-12s %s\n", endpoint.Name, endpoint.Layer, controlIDs[endpoint.devnetEndpoint], endpoint.Chain(), endpoint.LocalURL)
+		}
+	}
+	if controlServer != nil {
+		fmt.Fprintf(stderr, "\nControl: op-up control services --session %s\n", controlServer.session.ID)
+	}
+	if len(devnet.Contracts) > 0 {
+		fmt.Fprintln(stderr, "\nDeployed Contracts:")
+		for _, contracts := range devnet.Contracts {
+			fmt.Fprintf(stderr, "  %s chain=%s\n", contracts.Network, contracts.ChainID)
+			for _, contract := range contracts.Contracts {
+				fmt.Fprintf(stderr, "    %-34s %s\n", contract.Name, contract.Address)
+			}
+		}
+	}
+
+	if cfg.Metrics {
+		fmt.Fprintln(stderr, "\nMetrics: Grafana should be available at http://localhost:3000 when sysgo metrics finish starting.")
+	}
+	for _, note := range devnet.Notes {
+		fmt.Fprintf(stderr, "\n%s\n", note)
+	}
+	fmt.Fprintln(stderr, "\nPress Ctrl+C to stop the devnet and clean up resources.")
+
+	errCh := make(chan error, len(endpoints))
+	controlledByEndpoint := devnet.controlledServiceByEndpoint()
+	for _, endpoint := range endpoints {
+		if endpoint.Listener == nil || endpoint.RPC == nil {
+			continue
+		}
+		endpoint := endpoint
+		controlled := controlledByEndpoint[endpoint.devnetEndpoint]
+		go func() {
+			errCh <- proxyEL(ctx, stderr, endpoint.Listener, endpoint.RPC, endpoint.BackendURL, controlled)
+		}()
+	}
+	for _, logger := range devnet.BackgroundLoggers {
+		go logger(ctx, stderr)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-errCh:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				return err
+			}
+		}
+	}
+}
+
+func (d *runningDevnet) localEndpoints() ([]*localEndpoint, error) {
+	var requests []localEndpointRequest
+	if d.L1EL != nil {
+		requests = appendLocalEndpointRequests(requests, []*devnetEndpoint{d.L1EL})
+	}
+	if d.L1CL != nil {
+		requests = appendLocalEndpointRequests(requests, []*devnetEndpoint{d.L1CL})
+	}
+	if len(d.L2ELs) > 0 {
+		requests = appendLocalEndpointRequests(requests, d.L2ELs)
+	}
+	if len(d.L2CLs) > 0 {
+		requests = appendLocalEndpointRequests(requests, d.L2CLs)
+	}
+	if len(d.Services) > 0 {
+		requests = appendLocalEndpointRequests(requests, d.Services)
+	}
+	return bindLocalEndpoints(requests)
+}
+
+func (d *runningDevnet) applyControlEndpointURLs(endpoints []*localEndpoint) {
+	for _, svc := range d.ControlledServices {
+		if svc == nil || svc.Endpoint == nil {
+			continue
+		}
+		for _, endpoint := range endpoints {
+			if endpoint != nil && endpoint.devnetEndpoint == svc.Endpoint {
+				svc.EndpointURL = endpoint.LocalURL
+				break
+			}
+		}
+	}
+}
+
+func (d *runningDevnet) controlIDsByEndpoint() map[*devnetEndpoint]string {
+	out := make(map[*devnetEndpoint]string)
+	for _, svc := range d.ControlledServices {
+		if svc != nil && svc.Endpoint != nil {
+			out[svc.Endpoint] = svc.ID
+		}
+	}
+	return out
+}
+
+func (d *runningDevnet) controlledServiceByEndpoint() map[*devnetEndpoint]*controlledService {
+	out := make(map[*devnetEndpoint]*controlledService)
+	for _, svc := range d.ControlledServices {
+		if svc != nil && svc.Endpoint != nil {
+			out[svc.Endpoint] = svc
+		}
+	}
+	return out
+}
+
+func appendLocalEndpointRequests(out []localEndpointRequest, endpoints []*devnetEndpoint) []localEndpointRequest {
+	for _, endpoint := range endpoints {
+		out = append(out, localEndpointRequest{Endpoint: endpoint})
+	}
+	return out
+}
+
+func bindLocalEndpoints(requests []localEndpointRequest) ([]*localEndpoint, error) {
+	out := make([]*localEndpoint, len(requests))
+	for i, request := range requests {
+		if request.Endpoint.DirectURL != "" {
+			out[i] = &localEndpoint{
+				devnetEndpoint: request.Endpoint,
+				LocalURL:       request.Endpoint.DirectURL,
+			}
+			continue
+		}
+		listener, port, err := listenOnRandomLocalPort()
+		if err != nil {
+			closeLocalEndpointListeners(out)
+			return nil, err
+		}
+		out[i] = newLocalEndpoint(request.Endpoint, port, listener)
+	}
+
+	return out, nil
+}
+
+func newLocalEndpoint(endpoint *devnetEndpoint, port uint, listener net.Listener) *localEndpoint {
+	return &localEndpoint{
+		devnetEndpoint: endpoint,
+		LocalURL:       localURL(port),
+		Listener:       listener,
+	}
+}
+
+func listenOnRandomLocalPort() (net.Listener, uint, error) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, 0, fmt.Errorf("listen on a random localhost port: %w", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	return listener, uint(port), nil
+}
+
+func closeLocalEndpointListeners(endpoints []*localEndpoint) {
+	for _, endpoint := range endpoints {
+		if endpoint != nil && endpoint.Listener != nil {
+			_ = endpoint.Listener.Close()
+		}
+	}
+}
+
+func localURL(port uint) string {
+	return fmt.Sprintf("http://localhost:%d", port)
+}
+
+func applyRuntimeOverrides(cfg opUpConfig) (func(), error) {
+	restore := make([]func(), 0, 3)
+	set := func(key, val string) {
+		old, ok := os.LookupEnv(key)
+		restore = append(restore, func() {
+			if ok {
+				_ = os.Setenv(key, old)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		})
+		_ = os.Setenv(key, val)
+	}
+
+	if cfg.L2ELKind != "" {
+		switch cfg.L2ELKind {
+		case string(sysgo.MixedL2ELOpGeth), string(sysgo.MixedL2ELOpReth), string(sysgo.MixedL2ELOpRethV2):
+			set(devstackL2ELKindEnvVar, cfg.L2ELKind)
+		default:
+			return nil, fmt.Errorf("unsupported L2 EL kind %q (expected op-geth, op-reth, or op-reth-proof-v2)", cfg.L2ELKind)
+		}
+	}
+	if cfg.L2CLKind != "" {
+		switch cfg.L2CLKind {
+		case string(sysgo.MixedL2CLOpNode), string(sysgo.MixedL2CLKona):
+			set(devstackL2CLKindEnvVar, cfg.L2CLKind)
+		default:
+			return nil, fmt.Errorf("unsupported L2 CL kind %q (expected op-node or kona-node)", cfg.L2CLKind)
+		}
+	}
+	if cfg.Metrics {
+		set(sysgoMetricsEnabledEnvVar, "true")
+	}
+
+	return func() {
+		for _, fn := range slices.Backward(restore) {
+			fn()
+		}
+	}, nil
+}
+
+func buildMinimalDevnet(t *testingT) (*runningDevnet, error) {
+	sys, err := newMinimalSystem(t)
+	if err != nil {
+		return nil, err
+	}
+	return singleChainDevnet(sys.L1EL, sys.L1CL, sys.L2Chain, sys.L2EL, sys.L2CL), nil
+}
+
+func buildInteropDevnet(t *testingT) (*runningDevnet, error) {
+	sys, err := newSupernodeInteropSystem(t)
+	if err != nil {
+		return nil, err
+	}
+	l2AEp := l2ELEndpoint("L2A", sys.L2ELA)
+	l2BEp := l2ELEndpoint("L2B", sys.L2ELB)
+	superEp := supernodeEndpoint("Supernode", sys.Supernode)
+	return &runningDevnet{
+		L1EL:       l1ELEndpoint("L1", sys.L1EL),
+		L1CL:       l1CLEndpoint("L1 Beacon", sys.L1CL),
+		L2Networks: []*namedL2Network{l2Network("L2A", sys.L2A), l2Network("L2B", sys.L2B)},
+		L2ELs:      []*devnetEndpoint{l2AEp, l2BEp},
+		Services:   []*devnetEndpoint{superEp},
+		ControlledServices: []*controlledService{
+			controlledL2EL("l2a-el", "L2A EL", sys.L2ELA, l2AEp),
+			controlledL2EL("l2b-el", "L2B EL", sys.L2ELB, l2BEp),
+			controlledSupernode("supernode", "Supernode", sys.Supernode, superEp),
+		},
+		Contracts: []*contractSet{
+			contractsForL2("L2A", sys.L2A),
+			contractsForL2("L2B", sys.L2B),
+		},
+		ExportDepset: true,
+		BackgroundLoggers: []func(context.Context, io.Writer){
+			func(ctx context.Context, stderr io.Writer) {
+				logInterop(ctx, stderr, sys)
+			},
+		},
+		Notes: []string{
+			fmt.Sprintf("Interop activates %d seconds after genesis; run `op-up smoke-interop all --l2a-rpc <printed L2A EL URL> --l2b-rpc <printed L2B EL URL> --private-key <printed Test Account Private Key>` in another terminal for a cross-chain smoke test.", defaultInteropActivationSecs),
+			"Supernode per-chain rollup RPCs are available at <printed Supernode RPC>/<chain-id>, for example /901 and /902.",
+		},
+	}, nil
+}
+
+func buildTwoL2Devnet(t *testingT) (*runningDevnet, error) {
+	sys, err := buildPreset(func() *presets.TwoL2 {
+		return presets.NewTwoL2Supernode(t)
+	})
+	if err != nil {
+		return nil, err
+	}
+	l2AEL := sys.L2A.PublicRPC()
+	l2BEL := sys.L2B.PublicRPC()
+	l2AEp := l2ELEndpoint("L2A", l2AEL)
+	l2BEp := l2ELEndpoint("L2B", l2BEL)
+	l2ACLEp := l2CLEndpoint("L2A CL", sys.L2ACL)
+	l2BCLEp := l2CLEndpoint("L2B CL", sys.L2BCL)
+	return &runningDevnet{
+		L1EL:       l1ELEndpoint("L1", sys.L1EL),
+		L1CL:       l1CLEndpoint("L1 Beacon", sys.L1CL),
+		L2Networks: []*namedL2Network{l2Network("L2A", sys.L2A), l2Network("L2B", sys.L2B)},
+		L2ELs:      []*devnetEndpoint{l2AEp, l2BEp},
+		L2CLs:      []*devnetEndpoint{l2ACLEp, l2BCLEp},
+		ControlledServices: []*controlledService{
+			controlledL2EL("l2a-el", "L2A EL", l2AEL, l2AEp),
+			controlledL2EL("l2b-el", "L2B EL", l2BEL, l2BEp),
+			controlledL2CL("l2a-cl", "L2A CL", sys.L2ACL, l2ACLEp),
+			controlledL2CL("l2b-cl", "L2B CL", sys.L2BCL, l2BCLEp),
+		},
+		Contracts: []*contractSet{
+			contractsForL2("L2A", sys.L2A),
+			contractsForL2("L2B", sys.L2B),
+		},
+	}, nil
+}
+
+func buildMultinodeDevnet(t *testingT) (*runningDevnet, error) {
+	sys, err := buildPreset(func() *presets.SingleChainMultiNode {
+		return presets.NewSingleChainMultiNodeWithoutCheck(t)
+	})
+	if err != nil {
+		return nil, err
+	}
+	seqELEp := l2ELEndpoint("L2 sequencer", sys.L2EL)
+	verELEp := l2ELEndpoint("L2 verifier", sys.L2ELB)
+	seqCLEp := l2CLEndpoint("L2 sequencer CL", sys.L2CL)
+	verCLEp := l2CLEndpoint("L2 verifier CL", sys.L2CLB)
+	return &runningDevnet{
+		L1EL:       l1ELEndpoint("L1", sys.L1EL),
+		L1CL:       l1CLEndpoint("L1 Beacon", sys.L1CL),
+		L2Networks: []*namedL2Network{l2Network("L2", sys.L2Chain)},
+		L2ELs:      []*devnetEndpoint{seqELEp, verELEp},
+		L2CLs:      []*devnetEndpoint{seqCLEp, verCLEp},
+		ControlledServices: []*controlledService{
+			controlledL2EL("l2-sequencer-el", "L2 sequencer EL", sys.L2EL, seqELEp),
+			controlledL2EL("l2-verifier-el", "L2 verifier EL", sys.L2ELB, verELEp),
+			controlledL2CL("l2-sequencer-cl", "L2 sequencer CL", sys.L2CL, seqCLEp),
+			controlledL2CL("l2-verifier-cl", "L2 verifier CL", sys.L2CLB, verCLEp),
+		},
+		Contracts: []*contractSet{contractsForL2("L2", sys.L2Chain)},
+	}, nil
+}
+
+func buildTwoVerifiersDevnet(t *testingT) (*runningDevnet, error) {
+	sys, err := buildPreset(func() *presets.SingleChainTwoVerifiers {
+		return presets.NewSingleChainTwoVerifiersWithoutCheck(t)
+	})
+	if err != nil {
+		return nil, err
+	}
+	seqELEp := l2ELEndpoint("L2 sequencer", sys.L2EL)
+	verBEL := l2ELEndpoint("L2 verifier B", sys.L2ELB)
+	verCEL := l2ELEndpoint("L2 verifier C", sys.L2ELC)
+	seqCLEp := l2CLEndpoint("L2 sequencer CL", sys.L2CL)
+	verBCL := l2CLEndpoint("L2 verifier B CL", sys.L2CLB)
+	verCCL := l2CLEndpoint("L2 verifier C CL", sys.L2CLC)
+	return &runningDevnet{
+		L1EL:       l1ELEndpoint("L1", sys.L1EL),
+		L1CL:       l1CLEndpoint("L1 Beacon", sys.L1CL),
+		L2Networks: []*namedL2Network{l2Network("L2", sys.L2Chain)},
+		L2ELs:      []*devnetEndpoint{seqELEp, verBEL, verCEL},
+		L2CLs:      []*devnetEndpoint{seqCLEp, verBCL, verCCL},
+		ControlledServices: []*controlledService{
+			controlledL2EL("l2-sequencer-el", "L2 sequencer EL", sys.L2EL, seqELEp),
+			controlledL2EL("l2-verifier-b-el", "L2 verifier B EL", sys.L2ELB, verBEL),
+			controlledL2EL("l2-verifier-c-el", "L2 verifier C EL", sys.L2ELC, verCEL),
+			controlledL2CL("l2-sequencer-cl", "L2 sequencer CL", sys.L2CL, seqCLEp),
+			controlledL2CL("l2-verifier-b-cl", "L2 verifier B CL", sys.L2CLB, verBCL),
+			controlledL2CL("l2-verifier-c-cl", "L2 verifier C CL", sys.L2CLC, verCCL),
+		},
+		Contracts: []*contractSet{contractsForL2("L2", sys.L2Chain)},
+	}, nil
+}
+
+func buildConductorsDevnet(t *testingT) (*runningDevnet, error) {
+	sys, err := buildPreset(func() *presets.MinimalWithConductors {
+		return presets.NewMinimalWithConductors(t)
+	})
+	if err != nil {
+		return nil, err
+	}
+	devnet := singleChainDevnet(sys.L1EL, sys.L1CL, sys.L2Chain, sys.L2EL, sys.L2CL)
+	devnet.Notes = append(devnet.Notes, "op-conductor is running inside the preset; the stable L2 EL and CL proxies are exposed for transactions and rollup RPC calls.")
+	return devnet, nil
+}
+
+func buildFlashblocksDevnet(t *testingT) (*runningDevnet, error) {
+	sys, err := buildPreset(func() *presets.SingleChainWithFlashblocks {
+		return presets.NewSingleChainWithFlashblocks(t)
+	})
+	if err != nil {
+		return nil, err
+	}
+	devnet := singleChainDevnet(sys.L1EL, sys.L1CL, sys.L2Chain, sys.L2EL, sys.L2CL)
+	devnet.Notes = append(devnet.Notes, "flashblocks support is running through rollup-boost and op-rbuilder in the selected preset.")
+	return devnet, nil
+}
+
+func buildPreset[T any](fn func() T) (out T, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			var failure testingFailure
+			if errors.As(asError(recovered), &failure) {
+				err = failure.err
+				return
+			}
+			panic(recovered)
+		}
+	}()
+	return fn(), nil
+}
+
+func singleChainDevnet(l1 *dsl.L1ELNode, l1CL *dsl.L1CLNode, l2 *dsl.L2Network, l2EL *dsl.L2ELNode, l2CL *dsl.L2CLNode) *runningDevnet {
+	l2ELEp := l2ELEndpoint("L2", l2EL)
+	l2CLEp := l2CLEndpoint("L2 CL", l2CL)
+	return &runningDevnet{
+		L1EL:       l1ELEndpoint("L1", l1),
+		L1CL:       l1CLEndpoint("L1 Beacon", l1CL),
+		L2Networks: []*namedL2Network{l2Network("L2", l2)},
+		L2ELs:      []*devnetEndpoint{l2ELEp},
+		L2CLs:      []*devnetEndpoint{l2CLEp},
+		ControlledServices: []*controlledService{
+			controlledL2EL("l2-el", "L2 EL", l2EL, l2ELEp),
+			controlledL2CL("l2-cl", "L2 CL", l2CL, l2CLEp),
+		},
+		Contracts: []*contractSet{contractsForL2("L2", l2)},
+	}
+}
+
+func l2Network(name string, l2 *dsl.L2Network) *namedL2Network {
+	return &namedL2Network{Name: name, Network: l2}
+}
+
+func contractsForL2(name string, l2 *dsl.L2Network) *contractSet {
+	deployment := l2.Escape().Deployment()
+	contracts := []contractAddress{
+		{Name: "OptimismPortalProxy", Address: l2.DepositContractAddr()},
+		{Name: "SystemConfigProxy", Address: deployment.SystemConfigProxyAddr()},
+		{Name: "L1StandardBridgeProxy", Address: deployment.L1StandardBridgeProxyAddr()},
+		{Name: "DisputeGameFactoryProxy", Address: deployment.DisputeGameFactoryProxyAddr()},
+	}
+	if withProxyAdmin, ok := deployment.(interface{ ProxyAdminAddr() common.Address }); ok {
+		contracts = appendNonZeroContract(contracts, "ProxyAdmin", withProxyAdmin.ProxyAdminAddr())
+	}
+	if withDelayedWETH, ok := deployment.(interface{ PermissionlessDelayedWETHProxyAddr() common.Address }); ok {
+		contracts = appendNonZeroContract(contracts, "PermissionlessDelayedWETHProxy", withDelayedWETH.PermissionlessDelayedWETHProxyAddr())
+	}
+	return &contractSet{
+		Network:   name,
+		ChainID:   l2.ChainID(),
+		Contracts: contracts,
+	}
+}
+
+func appendNonZeroContract(contracts []contractAddress, name string, addr common.Address) []contractAddress {
+	if addr == (common.Address{}) {
+		return contracts
+	}
+	return append(contracts, contractAddress{Name: name, Address: addr})
+}
+
+func (e *devnetEndpoint) Chain() string {
+	if e.ChainLabel != "" {
+		return e.ChainLabel
+	}
+	return e.ChainID.String()
+}
+
+func l1ELEndpoint(name string, node *dsl.L1ELNode) *devnetEndpoint {
+	return &devnetEndpoint{
+		Name:    name,
+		Layer:   "EL",
+		ChainID: node.Escape().ChainID(),
+		RPC:     node.EthClient().RPC(),
+	}
+}
+
+func l1CLEndpoint(name string, node *dsl.L1CLNode) *devnetEndpoint {
+	return &devnetEndpoint{
+		Name:      name,
+		Layer:     "HTTP",
+		ChainID:   node.Escape().ChainID(),
+		DirectURL: node.BeaconHTTPAddr(),
+	}
+}
+
+func l2ELEndpoint(name string, node *dsl.L2ELNode) *devnetEndpoint {
+	return &devnetEndpoint{
+		Name:    name,
+		Layer:   "EL",
+		ChainID: node.Escape().ChainID(),
+		RPC:     node.Escape().L2EthClient().RPC(),
+	}
+}
+
+func controlledL2EL(id string, name string, node *dsl.L2ELNode, endpoint *devnetEndpoint) *controlledService {
+	return controlledLifecycleService(id, name, "EL", endpoint.ChainID, endpoint, endpoint.RPC, node.Escape())
+}
+
+func l2CLEndpoint(name string, node *dsl.L2CLNode) *devnetEndpoint {
+	return &devnetEndpoint{
+		Name:    name,
+		Layer:   "CL",
+		ChainID: node.ChainID(),
+		RPC:     node.Escape().ClientRPC(),
+	}
+}
+
+func controlledL2CL(id string, name string, node *dsl.L2CLNode, endpoint *devnetEndpoint) *controlledService {
+	return controlledLifecycleService(id, name, "CL", endpoint.ChainID, endpoint, endpoint.RPC, node.Escape())
+}
+
+func supernodeEndpoint(name string, node *dsl.Supernode) *devnetEndpoint {
+	return &devnetEndpoint{
+		Name:       name,
+		Layer:      "RPC",
+		ChainLabel: "shared",
+		RPC:        node.ClientRPC(),
+		BackendURL: node.UserRPC(),
+	}
+}
+
+func controlledSupernode(id string, name string, node *dsl.Supernode, endpoint *devnetEndpoint) *controlledService {
+	return controlledLifecycleService(id, name, "RPC", eth.ChainID{}, endpoint, endpoint.RPC, node.Escape())
+}
+
+func controlledLifecycleService(id string, name string, kind string, chainID eth.ChainID, endpoint *devnetEndpoint, rpc opclient.RPC, candidate any) *controlledService {
+	control, _ := candidate.(stack.ControlledLifecycle)
+	return &controlledService{
+		ID:       id,
+		Name:     name,
+		Kind:     kind,
+		ChainID:  chainID,
+		Endpoint: endpoint,
+		RPC:      rpc,
+		Control:  control,
+	}
+}
+
+func logRuntimeOverrides(stderr io.Writer, cfg opUpConfig) {
+	var settings []string
+	if cfg.L2ELKind != "" {
+		settings = append(settings, fmt.Sprintf("%s=%s", devstackL2ELKindEnvVar, cfg.L2ELKind))
+	}
+	if cfg.L2CLKind != "" {
+		settings = append(settings, fmt.Sprintf("%s=%s", devstackL2CLKindEnvVar, cfg.L2CLKind))
+	}
+	if cfg.Metrics {
+		settings = append(settings, fmt.Sprintf("%s=true", sysgoMetricsEnabledEnvVar))
+	}
+	if len(settings) > 0 {
+		fmt.Fprintf(stderr, "Runtime overrides: %s\n", strings.Join(settings, " "))
+	}
+}

--- a/op-up/main.go
+++ b/op-up/main.go
@@ -1,0 +1,974 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime/debug"
+	"slices"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/log/logfilter"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const asciiArt = ` ____  ____        _     ____
+/  _ \/  __\      / \ /\/  __\
+| / \||  \/|_____ | | |||  \/|
+| \_/||  __/\____\| \_/||  __/
+\____/\_/         \____/\_/`
+
+var (
+	Version     = "v0.0.0"
+	VersionMeta = "dev"
+	GitCommit   string
+	GitDate     string
+
+	envPrefix = "OP_UP"
+	dirFlag   = &cli.PathFlag{
+		Name:    "dir",
+		Usage:   "the path to the op-up directory, which is used for caching among other things.",
+		EnvVars: opservice.PrefixEnvVar(envPrefix, "DIR"),
+		Value: func() string {
+			parentDir, err := os.UserHomeDir()
+			if err != nil {
+				parentDir, err = os.Getwd()
+				if err != nil {
+					return "error: could not find home or working directories"
+				}
+			}
+			return filepath.Join(parentDir, ".op-up")
+		}(),
+	}
+	presetFlag = &cli.StringFlag{
+		Name:    "preset",
+		Aliases: []string{"p"},
+		Usage:   "devnet preset to start. Run `op-up presets` to list available presets.",
+		EnvVars: opservice.PrefixEnvVar(envPrefix, "PRESET"),
+		Value:   defaultPresetName,
+	}
+	interopFlag = &cli.BoolFlag{
+		Name:    "interop",
+		Usage:   "alias for --preset interop.",
+		EnvVars: opservice.PrefixEnvVar(envPrefix, "INTEROP"),
+	}
+	l2ELKindFlag = &cli.StringFlag{
+		Name:    "l2-el-kind",
+		Usage:   "override the L2 EL implementation: op-reth, op-reth-proof-v2, or op-geth.",
+		EnvVars: opservice.PrefixEnvVar(envPrefix, "L2_EL_KIND"),
+	}
+	l2CLKindFlag = &cli.StringFlag{
+		Name:    "l2-cl-kind",
+		Usage:   "override the L2 CL implementation: op-node or kona-node.",
+		EnvVars: opservice.PrefixEnvVar(envPrefix, "L2_CL_KIND"),
+	}
+	metricsFlag = &cli.BoolFlag{
+		Name:    "metrics",
+		Usage:   "enable sysgo metrics and dashboards for supported components.",
+		EnvVars: opservice.PrefixEnvVar(envPrefix, "METRICS"),
+	}
+)
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, os.Interrupt)
+	defer cancel()
+	if err := run(ctx, os.Args, os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	app := cli.NewApp()
+	app.Writer = stdout
+	app.ErrWriter = stderr
+	app.Version = opservice.FormatVersion(Version, GitCommit, GitDate, VersionMeta)
+	app.Name = "op-up"
+	app.Usage = "starts op-devstack devnet presets with printed local RPC endpoints."
+	app.Flags = opUpFlags()
+	// The default OnUsageError behavior will print the error twice: once in the cli package and
+	// once in our main function.
+	// The function below prints help and returns the error for further handling/error messages.
+	app.OnUsageError = func(cliCtx *cli.Context, err error, isSubcommand bool) error {
+		if !cliCtx.App.HideHelp {
+			_ = cli.ShowAppHelp(cliCtx)
+		}
+		return err
+	}
+	app.Action = func(cliCtx *cli.Context) error {
+		cfg, err := opUpConfigFromCLI(cliCtx)
+		if err != nil {
+			return err
+		}
+		return runOpUp(cliCtx.Context, cliCtx.App.Writer, cliCtx.App.ErrWriter, cfg)
+	}
+	app.Commands = []*cli.Command{
+		upCommand(),
+		controlCommand(),
+		presetsCommand(),
+		smokeCommand(),
+	}
+	return app.RunContext(ctx, args)
+}
+
+func opUpFlags() []cli.Flag {
+	return cliapp.ProtectFlags([]cli.Flag{
+		dirFlag,
+		presetFlag,
+		interopFlag,
+		l2ELKindFlag,
+		l2CLKindFlag,
+		metricsFlag,
+	})
+}
+
+func upCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "up",
+		Aliases:   []string{"run", "deploy"},
+		Usage:     "start a devnet preset",
+		ArgsUsage: "[preset]",
+		Flags:     opUpFlags(),
+		Action: func(cliCtx *cli.Context) error {
+			cfg, err := opUpConfigFromCLI(cliCtx)
+			if err != nil {
+				return err
+			}
+			return runOpUp(cliCtx.Context, cliCtx.App.Writer, cliCtx.App.ErrWriter, cfg)
+		},
+	}
+}
+
+func presetsCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "presets",
+		Aliases: []string{"list"},
+		Usage:   "list available devnet presets",
+		Action: func(cliCtx *cli.Context) error {
+			return printPresetList(cliCtx.App.Writer)
+		},
+	}
+}
+
+func opUpConfigFromCLI(cliCtx *cli.Context) (opUpConfig, error) {
+	cfg := opUpConfig{
+		Dir:           cliPath(cliCtx, dirFlag.Name),
+		Preset:        cliString(cliCtx, presetFlag.Name),
+		LegacyInterop: cliBool(cliCtx, interopFlag.Name),
+		L2ELKind:      normalizePresetName(cliString(cliCtx, l2ELKindFlag.Name)),
+		L2CLKind:      normalizePresetName(cliString(cliCtx, l2CLKindFlag.Name)),
+		Metrics:       cliBool(cliCtx, metricsFlag.Name),
+	}
+	if cliCtx.NArg() > 1 {
+		return cfg, fmt.Errorf("expected at most one preset argument, got %d", cliCtx.NArg())
+	}
+	if cliCtx.NArg() == 1 {
+		if cliIsSet(cliCtx, presetFlag.Name) {
+			return cfg, fmt.Errorf("provide a preset either as an argument or with --preset, not both")
+		}
+		cfg.Preset = cliCtx.Args().First()
+	}
+	if cfg.LegacyInterop {
+		if cliCtx.NArg() == 1 && normalizePresetName(cliCtx.Args().First()) != "interop" {
+			return cfg, fmt.Errorf("--interop cannot be combined with preset argument %s", cliCtx.Args().First())
+		}
+		if cliIsSet(cliCtx, presetFlag.Name) && normalizePresetName(cfg.Preset) != defaultPresetName && normalizePresetName(cfg.Preset) != "interop" {
+			return cfg, fmt.Errorf("--interop cannot be combined with --preset %s", cfg.Preset)
+		}
+		cfg.Preset = "interop"
+	}
+	return cfg, nil
+}
+
+func cliString(cliCtx *cli.Context, name string) string {
+	for _, ctx := range cliCtx.Lineage() {
+		if ctx.IsSet(name) {
+			return ctx.String(name)
+		}
+	}
+	return cliCtx.String(name)
+}
+
+func cliPath(cliCtx *cli.Context, name string) string {
+	for _, ctx := range cliCtx.Lineage() {
+		if ctx.IsSet(name) {
+			return ctx.Path(name)
+		}
+	}
+	return cliCtx.Path(name)
+}
+
+func cliBool(cliCtx *cli.Context, name string) bool {
+	for _, ctx := range cliCtx.Lineage() {
+		if ctx.IsSet(name) {
+			return ctx.Bool(name)
+		}
+	}
+	return cliCtx.Bool(name)
+}
+
+func cliIsSet(cliCtx *cli.Context, name string) bool {
+	for _, ctx := range cliCtx.Lineage() {
+		if ctx.IsSet(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func runOpUp(ctx context.Context, stdout io.Writer, stderr io.Writer, cfg opUpConfig) error {
+	fmt.Fprintf(stderr, "%s\n", asciiArt)
+
+	spec, err := resolvePreset(cfg.Preset)
+	if err != nil {
+		return err
+	}
+	restoreEnv, err := applyRuntimeOverrides(cfg)
+	if err != nil {
+		return err
+	}
+	defer restoreEnv()
+	logRuntimeOverrides(stderr, cfg)
+
+	if err := os.MkdirAll(cfg.Dir, 0o700); err != nil {
+		return fmt.Errorf("create the op-up dir: %w", err)
+	}
+	if err := os.Chmod(cfg.Dir, 0o700); err != nil {
+		return fmt.Errorf("restrict the op-up dir: %w", err)
+	}
+	tempRoot := filepath.Join(cfg.Dir, "tmp")
+	if err := os.MkdirAll(tempRoot, 0o700); err != nil {
+		return fmt.Errorf("create the op-up temp dir: %w", err)
+	}
+	if err := os.Chmod(tempRoot, 0o700); err != nil {
+		return fmt.Errorf("restrict the op-up temp dir: %w", err)
+	}
+
+	runID := newOpUpRunID(spec.Name)
+	logFile, logFilePath, err := createRunLogFile(cfg, runID)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+	fmt.Fprintf(stderr, "\nLogs: %s\n", logFilePath)
+
+	devtest.RootContext = ctx
+	t := newTestingT(ctx, stderr, tempRoot, fmt.Sprintf("op-up-%s", spec.Name), logFile)
+	defer t.doCleanup()
+
+	devnet, err := spec.Build(t)
+	if err != nil {
+		return err
+	}
+	if err := runSelectedDevnet(ctx, stdout, stderr, cfg, spec, tempRoot, devnet, runID, logFilePath); err != nil {
+		return err
+	}
+	fmt.Fprintf(stderr, "\nPlease consider filling out this survey to influence future development: https://www.surveymonkey.com/r/JTGHFK3\n")
+	return nil
+}
+
+func newOpUpRunID(preset string) string {
+	return fmt.Sprintf("op-up-%s-%s-%d", tempDirSafePrefix(preset), time.Now().UTC().Format("20060102T150405Z"), os.Getpid())
+}
+
+func createRunLogFile(cfg opUpConfig, runID string) (*os.File, string, error) {
+	logDir := filepath.Join(cfg.Dir, "logs")
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		return nil, "", fmt.Errorf("create log dir: %w", err)
+	}
+	if err := os.Chmod(logDir, 0o700); err != nil {
+		return nil, "", fmt.Errorf("restrict log dir: %w", err)
+	}
+	logPath := filepath.Join(logDir, runID+".log")
+	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, "", fmt.Errorf("open run log: %w", err)
+	}
+	return file, logPath, nil
+}
+
+func newLogger(ctx context.Context, stderr io.Writer, logWriters ...io.Writer) log.Logger {
+	terminalHandler := oplog.NewLogHandler(stderr, oplog.DefaultCLIConfig())
+	terminalHandler = logfilter.WrapFilterHandler(terminalHandler)
+	terminalHandler.(logfilter.FilterHandler).Set(logfilter.DefaultMute())
+
+	handlers := []slog.Handler{terminalHandler}
+	for _, logWriter := range logWriters {
+		if logWriter == nil {
+			continue
+		}
+		cfg := oplog.DefaultCLIConfig()
+		cfg.Color = false
+		handlers = append(handlers, oplog.NewLogHandler(logWriter, cfg))
+	}
+
+	logHandler := newTeeLogHandler(handlers...)
+	logHandler = logfilter.WrapContextHandler(logHandler)
+	logger := log.NewLogger(logHandler)
+	oplog.SetGlobalLogHandler(logHandler)
+	logger.SetContext(ctx)
+	return logger
+}
+
+type teeLogHandler struct {
+	handlers []slog.Handler
+}
+
+func newTeeLogHandler(handlers ...slog.Handler) slog.Handler {
+	out := make([]slog.Handler, 0, len(handlers))
+	for _, handler := range handlers {
+		if handler != nil {
+			out = append(out, handler)
+		}
+	}
+	return teeLogHandler{handlers: out}
+}
+
+func (h teeLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, handler := range h.handlers {
+		if handler.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h teeLogHandler) Handle(ctx context.Context, record slog.Record) error {
+	var result error
+	for _, handler := range h.handlers {
+		if !handler.Enabled(ctx, record.Level) {
+			continue
+		}
+		result = errors.Join(result, handler.Handle(ctx, record.Clone()))
+	}
+	return result
+}
+
+func (h teeLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := make([]slog.Handler, 0, len(h.handlers))
+	for _, handler := range h.handlers {
+		next = append(next, handler.WithAttrs(attrs))
+	}
+	return teeLogHandler{handlers: next}
+}
+
+func (h teeLogHandler) WithGroup(name string) slog.Handler {
+	next := make([]slog.Handler, 0, len(h.handlers))
+	for _, handler := range h.handlers {
+		next = append(next, handler.WithGroup(name))
+	}
+	return teeLogHandler{handlers: next}
+}
+
+func newMinimalSystem(t *testingT) (sys *presets.Minimal, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			var failure testingFailure
+			if errors.As(asError(recovered), &failure) {
+				err = failure.err
+				return
+			}
+			panic(recovered)
+		}
+	}()
+	return presets.NewMinimal(t), nil
+}
+
+func newSupernodeInteropSystem(t *testingT) (sys *presets.TwoL2SupernodeInterop, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			var failure testingFailure
+			if errors.As(asError(recovered), &failure) {
+				err = failure.err
+				return
+			}
+			panic(recovered)
+		}
+	}()
+	return presets.NewTwoL2SupernodeInterop(t, defaultInteropActivationSecs,
+		presets.WithSuggestedInteropActivationOffset(defaultInteropActivationSecs),
+	), nil
+}
+
+func printAccountInfo(stderr io.Writer) error {
+	hd, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	if err != nil {
+		return fmt.Errorf("new mnemonic dev keys: %w", err)
+	}
+	const funderIndex = 10_000
+	funderUserKey := devkeys.UserKey(funderIndex)
+	funderAddress, err := hd.Address(funderUserKey)
+	if err != nil {
+		return fmt.Errorf("address: %w", err)
+	}
+	funderPrivKey, err := hd.Secret(funderUserKey)
+	if err != nil {
+		return fmt.Errorf("secret: %w", err)
+	}
+
+	fmt.Fprintf(stderr, "Test Account Address: %s\n", funderAddress)
+	fmt.Fprintf(stderr, "Test Account Private Key: %s\n", "0x"+common.Bytes2Hex(crypto.FromECDSA(funderPrivKey)))
+	return nil
+}
+
+func logInterop(ctx context.Context, stderr io.Writer, sys *presets.TwoL2SupernodeInterop) {
+	const pollInterval = 2 * time.Second
+	queryAPI := sys.Supernode.QueryAPI()
+
+	var lastSafeTS, lastLocalSafeTS uint64
+	lastSafe := make(map[string]uint64)
+	lastLocalSafe := make(map[string]uint64)
+	lastCrossUnsafe := make(map[string]uint64)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(pollInterval):
+			status, err := queryAPI.SyncStatus(ctx)
+			if err != nil {
+				continue
+			}
+
+			// Global safe timestamp
+			if status.SafeTimestamp != lastSafeTS && status.SafeTimestamp > 0 {
+				fmt.Fprintf(stderr, "[interop] Cross-safe timestamp: %d\n", status.SafeTimestamp)
+				lastSafeTS = status.SafeTimestamp
+			}
+
+			// Global local-safe timestamp
+			if status.LocalSafeTimestamp != lastLocalSafeTS && status.LocalSafeTimestamp > 0 {
+				fmt.Fprintf(stderr, "[interop] Local-safe timestamp: %d\n", status.LocalSafeTimestamp)
+				lastLocalSafeTS = status.LocalSafeTimestamp
+			}
+
+			// Per-chain details
+			for chainID, cs := range status.Chains {
+				id := chainID.String()
+
+				// Cross-unsafe progression
+				if cs.CrossUnsafeL2.Number != lastCrossUnsafe[id] && cs.CrossUnsafeL2.Number > 0 {
+					fmt.Fprintf(stderr, "[interop] Chain %s cross-unsafe: #%d\n", id, cs.CrossUnsafeL2.Number)
+					lastCrossUnsafe[id] = cs.CrossUnsafeL2.Number
+				}
+
+				// Local-safe progression
+				if cs.LocalSafeL2.Number != lastLocalSafe[id] {
+					fmt.Fprintf(stderr, "[interop] Chain %s local-safe: #%d\n", id, cs.LocalSafeL2.Number)
+					lastLocalSafe[id] = cs.LocalSafeL2.Number
+				}
+
+				// Cross-safe (safe head) — reorg shows as decrease
+				if cs.SafeL2.Number != lastSafe[id] {
+					if cs.SafeL2.Number < lastSafe[id] {
+						fmt.Fprintf(stderr, "[interop] Chain %s REORG: safe #%d -> #%d\n",
+							id, lastSafe[id], cs.SafeL2.Number)
+					} else {
+						fmt.Fprintf(stderr, "[interop] Chain %s cross-safe: #%d\n", id, cs.SafeL2.Number)
+					}
+					lastSafe[id] = cs.SafeL2.Number
+				}
+			}
+		}
+	}
+}
+
+func proxyEL(ctx context.Context, stderr io.Writer, listener net.Listener, client client.RPC, backendURL string, controlled *controlledService) error {
+	mux := http.NewServeMux()
+	handler, err := rpcProxyHandler(ctx, stderr, client, backendURL, controlled)
+	if err != nil {
+		return err
+	}
+	mux.Handle("/", handler)
+
+	server := &http.Server{
+		Addr:              listener.Addr().String(),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      35 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Serve(listener)
+	}()
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("shutdown proxy server: %w", err)
+		}
+		if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	case err := <-errCh:
+		if err != nil {
+			return fmt.Errorf("listen and serve: %w", err)
+		}
+		return nil
+	}
+}
+
+func rpcProxyHandler(ctx context.Context, stderr io.Writer, client client.RPC, backendURL string, controlled *controlledService) (http.Handler, error) {
+	if backendURL != "" {
+		target, err := url.Parse(backendURL)
+		if err != nil {
+			return nil, fmt.Errorf("parse backend URL %q: %w", backendURL, err)
+		}
+		proxy := httputil.NewSingleHostReverseProxy(target)
+		originalDirector := proxy.Director
+		proxy.Director = func(r *http.Request) {
+			originalDirector(r)
+			r.Host = target.Host
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !prepareRPCProxyResponse(w, r) {
+				return
+			}
+			if controlled != nil && !controlled.proxyAvailable() {
+				writeRPCProxyStopped(ctx, stderr, w, r, controlled)
+				return
+			}
+			proxy.ServeHTTP(w, r)
+		}), nil
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !prepareRPCProxyResponse(w, r) {
+			return
+		}
+
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read request body", http.StatusInternalServerError)
+			return
+		}
+		defer r.Body.Close()
+
+		response, ok := handleRPCProxyRequest(ctx, stderr, client, controlled, requestBody)
+		if !ok {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		writeRPCProxyJSON(w, response)
+	}), nil
+}
+
+func prepareRPCProxyResponse(w http.ResponseWriter, r *http.Request) bool {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "content-type")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return false
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return false
+	}
+	return true
+}
+
+func writeRPCProxyStopped(ctx context.Context, stderr io.Writer, w http.ResponseWriter, r *http.Request, controlled *controlledService) {
+	requestBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read request body", http.StatusInternalServerError)
+		return
+	}
+	defer r.Body.Close()
+
+	response, ok := handleRPCProxyRequest(ctx, stderr, nil, controlled, requestBody)
+	if !ok {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	writeRPCProxyJSON(w, response)
+}
+
+func writeRPCProxyJSON(w http.ResponseWriter, response any) {
+	jsonResponse, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, "Failed to marshal RPC response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(jsonResponse); err != nil {
+		return
+	}
+}
+
+type rpcProxyRequest struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+type rpcProxyResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcProxyError  `json:"error,omitempty"`
+}
+
+type rpcProxyError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func handleRPCProxyRequest(ctx context.Context, stderr io.Writer, client client.RPC, controlled *controlledService, body []byte) (any, bool) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return rpcProxyErr(nil, -32700, "empty JSON-RPC request"), true
+	}
+
+	isBatch := trimmed[0] == '['
+	var requests []rpcProxyRequest
+	if isBatch {
+		if err := json.Unmarshal(trimmed, &requests); err != nil {
+			return rpcProxyErr(nil, -32700, "invalid JSON-RPC batch"), true
+		}
+		if len(requests) == 0 {
+			return rpcProxyErr(nil, -32600, "empty JSON-RPC batch"), true
+		}
+	} else {
+		var req rpcProxyRequest
+		if err := json.Unmarshal(trimmed, &req); err != nil {
+			return rpcProxyErr(nil, -32700, "invalid JSON-RPC request"), true
+		}
+		requests = []rpcProxyRequest{req}
+	}
+
+	responses := make([]rpcProxyResponse, 0, len(requests))
+	for _, req := range requests {
+		resp, reply := executeRPCProxyRequest(ctx, stderr, client, controlled, req)
+		if reply {
+			responses = append(responses, resp)
+		}
+	}
+	if len(responses) == 0 {
+		return nil, false
+	}
+	if isBatch {
+		return responses, true
+	}
+	return responses[0], true
+}
+
+func executeRPCProxyRequest(ctx context.Context, stderr io.Writer, client client.RPC, controlled *controlledService, req rpcProxyRequest) (rpcProxyResponse, bool) {
+	if req.Method == "" {
+		return rpcProxyErr(req.ID, -32600, "missing JSON-RPC method"), true
+	}
+	if controlled != nil && !controlled.proxyAvailable() {
+		return backendStoppedError(req.ID, req.Method), true
+	}
+
+	params, err := decodeRPCProxyParams(req.Params)
+	if err != nil {
+		return rpcProxyErr(req.ID, -32602, err.Error()), true
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	var result json.RawMessage
+	if err := client.CallContext(callCtx, &result, req.Method, params...); err != nil {
+		message := fmt.Sprintf("RPC call to backend failed for method %q: %v", req.Method, err)
+		fmt.Fprintf(stderr, "RPC error: %s\n", message)
+		return rpcProxyErr(req.ID, -32000, message), true
+	}
+	if len(result) == 0 {
+		result = json.RawMessage("null")
+	}
+	if len(req.ID) == 0 {
+		return rpcProxyResponse{}, false
+	}
+	return rpcProxyResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  result,
+	}, true
+}
+
+func decodeRPCProxyParams(raw json.RawMessage) ([]any, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil, nil
+	}
+	switch raw[0] {
+	case '[':
+		var params []any
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, fmt.Errorf("invalid JSON-RPC params array")
+		}
+		return params, nil
+	case '{':
+		var param map[string]any
+		if err := json.Unmarshal(raw, &param); err != nil {
+			return nil, fmt.Errorf("invalid JSON-RPC params object")
+		}
+		return []any{param}, nil
+	default:
+		return nil, fmt.Errorf("invalid JSON-RPC params: expected array, object, or null")
+	}
+}
+
+func rpcProxyErr(id json.RawMessage, code int, message string) rpcProxyResponse {
+	if len(id) == 0 {
+		id = json.RawMessage("null")
+	}
+	return rpcProxyResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &rpcProxyError{
+			Code:    code,
+			Message: message,
+		},
+	}
+}
+
+type testingT struct {
+	state  *testingState
+	ctx    context.Context
+	logger log.Logger
+	tracer trace.Tracer
+	req    *testreq.Assertions
+	gate   *testreq.Assertions
+}
+
+type testingState struct {
+	mu            sync.Mutex
+	tempRoot      string
+	tempDirPrefix string
+	cleanups      []func()
+}
+
+type testingFailure struct {
+	err error
+}
+
+func (f testingFailure) Error() string {
+	return f.err.Error()
+}
+
+func asError(v any) error {
+	if err, ok := v.(error); ok {
+		return err
+	}
+	return nil
+}
+
+func newTestingT(ctx context.Context, stderr io.Writer, tempRoot string, tempDirPrefix string, logWriters ...io.Writer) *testingT {
+	logger := newLogger(ctx, stderr, logWriters...)
+	t := &testingT{
+		state: &testingState{
+			tempRoot:      tempRoot,
+			tempDirPrefix: tempDirPrefix,
+			cleanups:      make([]func(), 0),
+		},
+		ctx:    ctx,
+		logger: logger,
+		tracer: otel.Tracer("op-up"),
+	}
+	t.req = testreq.New(t)
+	t.gate = testreq.New(t)
+	return t
+}
+
+func (t *testingT) failf(format string, args ...any) {
+	err := fmt.Errorf(format, args...)
+	t.logger.Error("op-up runtime failure", "err", err)
+	debug.PrintStack()
+	panic(testingFailure{err: err})
+}
+
+var _ devtest.T = (*testingT)(nil)
+var _ testreq.TestingT = (*testingT)(nil)
+
+func (t *testingT) doCleanup() {
+	t.state.mu.Lock()
+	cleanups := append([]func(){}, t.state.cleanups...)
+	t.state.cleanups = nil
+	t.state.mu.Unlock()
+	for _, cleanup := range slices.Backward(cleanups) {
+		cleanup()
+	}
+}
+
+// Cleanup implements devtest.T.
+func (t *testingT) Cleanup(fn func()) {
+	t.state.mu.Lock()
+	defer t.state.mu.Unlock()
+	t.state.cleanups = append(t.state.cleanups, fn)
+}
+
+// Ctx implements devtest.T.
+func (t *testingT) Ctx() context.Context {
+	return t.ctx
+}
+
+// Deadline implements devtest.T.
+func (t *testingT) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+// Error implements devtest.T.
+func (t *testingT) Error(args ...any) {
+	t.failf("%s", fmt.Sprint(args...))
+}
+
+// Errorf implements devtest.T.
+func (t *testingT) Errorf(format string, args ...any) {
+	t.failf(format, args...)
+}
+
+// Fail implements devtest.T.
+func (t *testingT) Fail() {
+	t.failf("test failed")
+}
+
+// FailNow implements devtest.T.
+func (t *testingT) FailNow() {
+	t.failf("test failed immediately")
+}
+
+// Gate implements devtest.T.
+func (t *testingT) Gate() *testreq.Assertions {
+	return t.gate
+}
+
+// MarkFlaky implements devtest.T.
+func (t *testingT) MarkFlaky(string) {
+}
+
+// Helper implements devtest.T.
+func (t *testingT) Helper() {
+}
+
+// Log implements devtest.T.
+func (t *testingT) Log(args ...any) {
+	t.logger.Info(fmt.Sprint(args...))
+}
+
+// Logf implements devtest.T.
+func (t *testingT) Logf(format string, args ...any) {
+	t.logger.Info(fmt.Sprintf(format, args...))
+}
+
+func (t *testingT) Logger() log.Logger {
+	return t.logger
+}
+
+func (t *testingT) Name() string {
+	return "dev"
+}
+
+func (t *testingT) Parallel() {
+}
+
+func (t *testingT) Require() *testreq.Assertions {
+	return t.req
+}
+
+func (t *testingT) Run(name string, fn func(devtest.T)) {
+	subCtx := devtest.AddTestScope(t.ctx, name)
+	fn(t.WithCtx(subCtx))
+}
+
+func (t *testingT) Skip(args ...any) {
+	t.failf("unexpected skip: %s", fmt.Sprint(args...))
+}
+
+func (t *testingT) SkipNow() {
+	t.failf("unexpected skip")
+}
+
+// Skipf implements devtest.T.
+func (t *testingT) Skipf(format string, args ...any) {
+	t.failf("unexpected skip: "+format, args...)
+}
+
+// Skipped implements devtest.T.
+func (t *testingT) Skipped() bool {
+	return false
+}
+
+// TempDir implements devtest.T.
+func (t *testingT) TempDir() string {
+	return t.TempDirWithPrefix("")
+}
+
+func (t *testingT) TempDirWithPrefix(prefix string) string {
+	tempDirPrefix := t.state.tempDirPrefix
+	if servicePrefix := tempDirSafePrefix(prefix); servicePrefix != "" {
+		tempDirPrefix += "-" + servicePrefix
+	}
+	dir, err := os.MkdirTemp(t.state.tempRoot, tempDirPrefix+"-*")
+	if err != nil {
+		t.failf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.logger.Error("failed to clean up temp dir", "dir", dir, "err", err)
+		}
+	})
+	return dir
+}
+
+func tempDirSafePrefix(prefix string) string {
+	prefix = strings.NewReplacer("/", "-", "\\", "-", " ", "-", "_", "-").Replace(strings.TrimSpace(prefix))
+	return strings.Trim(prefix, "-")
+}
+
+// Tracer implements devtest.T.
+func (t *testingT) Tracer() trace.Tracer {
+	return t.tracer
+}
+
+// WithCtx implements devtest.T.
+func (t *testingT) WithCtx(ctx context.Context) devtest.T {
+	logger := t.logger.New()
+	logger.SetContext(ctx)
+	out := &testingT{
+		state:  t.state,
+		ctx:    ctx,
+		logger: logger,
+		tracer: t.tracer,
+	}
+	out.req = testreq.New(out)
+	out.gate = testreq.New(out)
+	return out
+}
+
+// _TestOnly implements devtest.T.
+func (t *testingT) TestOnly() {
+}

--- a/op-up/main_test.go
+++ b/op-up/main_test.go
@@ -1,0 +1,532 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPresetsCommand(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run(context.Background(), []string{"op-up", "presets"}, &stdout, io.Discard)
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "minimal")
+	require.Contains(t, stdout.String(), "interop")
+	require.Contains(t, stdout.String(), "flashblocks")
+}
+
+func TestPresetAliases(t *testing.T) {
+	spec, err := resolvePreset("two_l2_interop")
+	require.NoError(t, err)
+	require.Equal(t, "interop", spec.Name)
+
+	spec, err = resolvePreset("multi-node")
+	require.NoError(t, err)
+	require.Equal(t, "multinode", spec.Name)
+}
+
+func TestUnknownPresetFailsBeforeStarting(t *testing.T) {
+	err := run(context.Background(), []string{"op-up", "--dir", t.TempDir(), "--preset", "does-not-exist"}, io.Discard, io.Discard)
+	require.ErrorContains(t, err, "unknown preset")
+}
+
+func TestGlobalFlagsApplyToUpCommand(t *testing.T) {
+	err := run(context.Background(), []string{"op-up", "--preset", "does-not-exist", "up", "--l2-el-kind", "definitely-invalid"}, io.Discard, io.Discard)
+	require.ErrorContains(t, err, "unknown preset")
+	require.NotContains(t, err.Error(), "unsupported L2 EL kind")
+}
+
+func TestInteropCannotOverridePositionalPreset(t *testing.T) {
+	err := run(context.Background(), []string{"op-up", "up", "--interop", "two-l2"}, io.Discard, io.Discard)
+	require.ErrorContains(t, err, "--interop cannot be combined with preset argument two-l2")
+}
+
+func TestRuntimeFlagsBeforePresetAreParsed(t *testing.T) {
+	err := run(context.Background(), []string{"op-up", "up", "--l2-el-kind", "definitely-invalid", "minimal"}, io.Discard, io.Discard)
+	require.ErrorContains(t, err, "unsupported L2 EL kind")
+}
+
+func TestTempDirIncludesPresetName(t *testing.T) {
+	tempRoot := t.TempDir()
+	tt := newTestingT(context.Background(), io.Discard, tempRoot, "op-up-interop")
+	defer tt.doCleanup()
+
+	dir := tt.TempDir()
+	require.DirExists(t, dir)
+	require.Contains(t, filepath.Base(dir), "op-up-interop-")
+}
+
+func TestTempDirWithPrefixIncludesPresetAndServiceName(t *testing.T) {
+	tempRoot := t.TempDir()
+	tt := newTestingT(context.Background(), io.Discard, tempRoot, "op-up-interop")
+	defer tt.doCleanup()
+
+	dir := tt.TempDirWithPrefix("l2-el-sequencer-901")
+	require.DirExists(t, dir)
+	require.Contains(t, filepath.Base(dir), "op-up-interop-l2-el-sequencer-901-")
+}
+
+func TestCreateRunLogFile(t *testing.T) {
+	cfg := opUpConfig{Dir: t.TempDir()}
+	logFile, logFilePath, err := createRunLogFile(cfg, "op-up-minimal-test")
+	require.NoError(t, err)
+	defer logFile.Close()
+
+	_, err = logFile.WriteString("hello\n")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(cfg.Dir, "logs", "op-up-minimal-test.log"), logFilePath)
+
+	data, err := os.ReadFile(logFilePath)
+	require.NoError(t, err)
+	require.Equal(t, "hello\n", string(data))
+	info, err := os.Stat(logFilePath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestNewLoggerWritesToFileSink(t *testing.T) {
+	var stderr bytes.Buffer
+	var logs bytes.Buffer
+	logger := newLogger(context.Background(), &stderr, &logs)
+
+	logger.Info("service started", "service", "l2-el")
+
+	require.Contains(t, logs.String(), "service started")
+	require.Contains(t, logs.String(), "l2-el")
+	require.NotContains(t, stderr.String(), "service started")
+}
+
+func TestRPCProxyHandlerPreservesBackendPath(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/901", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"optimism":"1.0"}}`))
+	}))
+	defer backend.Close()
+
+	handler, err := rpcProxyHandler(context.Background(), io.Discard, nil, backend.URL, nil)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "http://op-up.local/901", bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"rpc_modules","params":[]}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"jsonrpc":"2.0","id":1,"result":{"optimism":"1.0"}}`, rec.Body.String())
+}
+
+func TestSmokeInteropRequiresRPCFlags(t *testing.T) {
+	err := run(context.Background(), []string{"op-up", "smoke-interop", "identity"}, io.Discard, io.Discard)
+	require.ErrorContains(t, err, "provide --l2a-rpc and --l2b-rpc")
+}
+
+func TestLocalEndpointsUseRandomPortsByDefault(t *testing.T) {
+	devnet := &runningDevnet{
+		L1CL: &devnetEndpoint{
+			Name:      "L1 Beacon",
+			Layer:     "HTTP",
+			ChainID:   eth.ChainIDFromUInt64(900),
+			DirectURL: "http://127.0.0.1:12345",
+		},
+		L2ELs: []*devnetEndpoint{{
+			Name:    "L2",
+			Layer:   "EL",
+			ChainID: eth.ChainIDFromUInt64(901),
+		}},
+		Services: []*devnetEndpoint{{
+			Name:       "Aux RPC",
+			Layer:      "RPC",
+			ChainLabel: "shared",
+		}},
+	}
+
+	endpoints, err := devnet.localEndpoints()
+	require.NoError(t, err)
+	defer closeLocalEndpointListeners(endpoints)
+	require.Len(t, endpoints, 3)
+
+	for _, endpoint := range endpoints {
+		if endpoint.DirectURL != "" {
+			require.Nil(t, endpoint.Listener)
+			require.Equal(t, endpoint.DirectURL, endpoint.LocalURL)
+			continue
+		}
+		boundPort := uint(endpoint.Listener.Addr().(*net.TCPAddr).Port)
+		require.NotZero(t, boundPort)
+		require.Equal(t, localURL(boundPort), endpoint.LocalURL)
+	}
+}
+
+func TestExportDevnetConfigsWritesStandardFiles(t *testing.T) {
+	tempRoot := t.TempDir()
+	generatedDir := filepath.Join(tempRoot, "op-up-interop-l2-el-sequencer-901-123")
+	require.NoError(t, os.MkdirAll(generatedDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(generatedDir, "genesis.json"), []byte(`{"config":{"chainId":901}}`), 0o600))
+
+	cfg := opUpConfig{Dir: t.TempDir()}
+	spec := &devnetPreset{Name: "interop"}
+	devnet := &runningDevnet{
+		ExportDepset: true,
+		Contracts: []*contractSet{{
+			Network: "L2A",
+			ChainID: eth.ChainIDFromUInt64(901),
+			Contracts: []contractAddress{{
+				Name:    "OptimismPortalProxy",
+				Address: common.HexToAddress("0x1234"),
+			}},
+		}},
+	}
+	endpoints := []*localEndpoint{{
+		devnetEndpoint: &devnetEndpoint{
+			Name:    "L2A CL",
+			Layer:   "CL",
+			ChainID: eth.ChainIDFromUInt64(901),
+			RPC:     staticRawRPC{raw: json.RawMessage(`{"dependencies":{"901":{}}}`)},
+		},
+		LocalURL: "http://localhost:12345",
+	}}
+
+	export, err := exportDevnetConfigs(context.Background(), cfg, spec, tempRoot, devnet, endpoints)
+	require.NoError(t, err)
+	require.Contains(t, export.Dir, filepath.Join(cfg.Dir, "configs", "op-up-interop-"))
+	require.FileExists(t, filepath.Join(export.Dir, "manifest.json"))
+	require.FileExists(t, filepath.Join(export.Dir, "endpoints.json"))
+	require.FileExists(t, filepath.Join(export.Dir, "contracts.json"))
+	require.FileExists(t, filepath.Join(export.Dir, "depset.json"))
+	require.FileExists(t, filepath.Join(export.Dir, "generated", "op-up-interop-l2-el-sequencer-901-123", "genesis.json"))
+
+	var manifest configExportManifest
+	manifestData, err := os.ReadFile(filepath.Join(export.Dir, "manifest.json"))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(manifestData, &manifest))
+	require.Equal(t, "interop", manifest.Preset)
+	require.Contains(t, manifest.Files, configExportFile{Path: "depset.json", Kind: "dependency-set", Source: "optimism_dependencySet"})
+}
+
+func TestControlledServiceStopFailureBlocksStartAndAllowsRetry(t *testing.T) {
+	lifecycle := &fakeControlledLifecycle{running: true, stopErr: errors.New("stop failed")}
+	svc := &controlledService{ID: "l2-el", Name: "L2 EL", Kind: "EL", Control: lifecycle}
+	svc.initState()
+
+	err := svc.stop(context.Background())
+	require.ErrorContains(t, err, "stop failed")
+	require.Equal(t, serviceStateStopFailed, svc.status(context.Background()).State)
+
+	err = svc.start(context.Background())
+	require.ErrorContains(t, err, "cannot start from state stop_failed")
+
+	lifecycle.stopErr = nil
+	err = svc.stop(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, serviceStateStopped, svc.status(context.Background()).State)
+
+	err = svc.start(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, serviceStateRunning, svc.status(context.Background()).State)
+}
+
+func TestControlledServiceRestartSkipsStartAfterStopFailure(t *testing.T) {
+	lifecycle := &fakeControlledLifecycle{running: true, stopErr: errors.New("stop failed")}
+	svc := &controlledService{ID: "l2-cl", Name: "L2 CL", Kind: "CL", Control: lifecycle}
+	svc.initState()
+
+	err := svc.restart(context.Background())
+	require.ErrorContains(t, err, "stop failed")
+	require.Equal(t, serviceStateStopFailed, svc.status(context.Background()).State)
+	require.Zero(t, lifecycle.startCalls)
+}
+
+func TestControlledServiceStartTimeoutStaysStartingUntilLateResult(t *testing.T) {
+	startBlock := make(chan struct{})
+	lifecycle := &fakeControlledLifecycle{startBlock: startBlock}
+	svc := &controlledService{ID: "l2-cl", Name: "L2 CL", Kind: "CL", Control: lifecycle}
+	svc.initState()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	err := svc.start(ctx)
+	require.ErrorIs(t, err, errControlOperationPending)
+	status := svc.status(context.Background())
+	require.Equal(t, serviceStateStarting, status.State)
+	require.Contains(t, status.LastError, "start still in progress")
+
+	close(startBlock)
+	require.Eventually(t, func() bool {
+		return svc.status(context.Background()).State == serviceStateRunning
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestControlledServiceStopTimeoutAppliesLateSuccess(t *testing.T) {
+	stopBlock := make(chan struct{})
+	lifecycle := &fakeControlledLifecycle{running: true, stopBlock: stopBlock}
+	svc := &controlledService{ID: "l2-cl", Name: "L2 CL", Kind: "CL", Control: lifecycle}
+	svc.initState()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	err := svc.stop(ctx)
+	require.Error(t, err)
+	status := svc.status(context.Background())
+	require.Equal(t, serviceStateStopFailed, status.State)
+
+	close(stopBlock)
+	require.Eventually(t, func() bool {
+		return svc.status(context.Background()).State == serviceStateStopped
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestControlServerRequiresAuth(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc := &controlledService{ID: "l2-el", Name: "L2 EL", Kind: "EL", Control: &fakeControlledLifecycle{running: true}}
+	server, err := newControlServer(ctx, opUpConfig{Dir: t.TempDir()}, &devnetPreset{Name: "minimal"}, []*controlledService{svc}, "op-up-minimal-test", "/tmp/op-up-minimal-test.log")
+	require.NoError(t, err)
+	defer server.Close()
+
+	resp, err := http.Get(server.session.ControlURL + "/services")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	controlResp, err := callControlServer(ctx, server.session, "services", "")
+	require.NoError(t, err)
+	require.Len(t, controlResp.Services, 1)
+	require.Equal(t, "l2-el", controlResp.Services[0].ID)
+}
+
+func TestControlCLIAliasesAndUnknownService(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dir := t.TempDir()
+	server, err := newControlServer(ctx, opUpConfig{Dir: dir}, &devnetPreset{Name: "minimal"}, []*controlledService{
+		{ID: "l2-el", Name: "L2 EL", Kind: "EL", Control: &fakeControlledLifecycle{running: true}},
+	}, "op-up-minimal-test", "/tmp/op-up-minimal-test.log")
+	require.NoError(t, err)
+	defer server.Close()
+
+	for _, alias := range []string{"services", "ls", "list", "ps"} {
+		var stdout bytes.Buffer
+		err := run(ctx, []string{"op-up", "control", alias, "--dir", dir, "--session", server.session.ID}, &stdout, io.Discard)
+		require.NoError(t, err)
+		require.Contains(t, stdout.String(), "Session: "+server.session.ID)
+		require.Contains(t, stdout.String(), "Logs: /tmp/op-up-minimal-test.log")
+		require.Contains(t, stdout.String(), "l2-el")
+	}
+
+	var stdout bytes.Buffer
+	err = run(ctx, []string{"op-up", "control", "status", "--dir", dir, "--session", server.session.ID, "missing"}, &stdout, io.Discard)
+	require.ErrorContains(t, err, "unknown service id missing")
+	require.Contains(t, stdout.String(), "Session: "+server.session.ID)
+}
+
+func TestSelectControlSessionDefaultsToNewestLiveSession(t *testing.T) {
+	dir := t.TempDir()
+	oldCtx, oldCancel := context.WithCancel(context.Background())
+	defer oldCancel()
+	oldServer, err := newControlServer(oldCtx, opUpConfig{Dir: dir}, &devnetPreset{Name: "minimal"}, []*controlledService{
+		{ID: "l2-el", Name: "L2 EL", Kind: "EL", Control: &fakeControlledLifecycle{running: true}},
+	}, "op-up-minimal-old", "/tmp/op-up-minimal-old.log")
+	require.NoError(t, err)
+	defer oldServer.Close()
+
+	newCtx, newCancel := context.WithCancel(context.Background())
+	defer newCancel()
+	newServer, err := newControlServer(newCtx, opUpConfig{Dir: dir}, &devnetPreset{Name: "interop"}, []*controlledService{
+		{ID: "l2a-el", Name: "L2A EL", Kind: "EL", Control: &fakeControlledLifecycle{running: true}},
+	}, "op-up-interop-new", "/tmp/op-up-interop-new.log")
+	require.NoError(t, err)
+	defer newServer.Close()
+
+	controlDir := filepath.Join(dir, "control")
+	require.NoError(t, os.Remove(oldServer.file))
+	require.NoError(t, os.Remove(newServer.file))
+	oldSession := oldServer.session
+	oldSession.ID = "old"
+	oldSession.StartedAt = "2026-05-26T10:00:00Z"
+	newSession := newServer.session
+	newSession.ID = "new"
+	newSession.StartedAt = "2026-05-26T11:00:00Z"
+	staleSession := controlSessionMetadata{
+		ID:         "stale",
+		Preset:     "interop",
+		PID:        os.Getpid(),
+		StartedAt:  "2026-05-26T12:00:00Z",
+		ControlURL: "http://127.0.0.1:3",
+		Token:      "stale-token",
+	}
+	require.NoError(t, writeControlSessionFile(filepath.Join(controlDir, "old.json"), oldSession))
+	require.NoError(t, writeControlSessionFile(filepath.Join(controlDir, "new.json"), newSession))
+	require.NoError(t, writeControlSessionFile(filepath.Join(controlDir, "stale.json"), staleSession))
+
+	selected, err := selectControlSession(dir, "")
+	require.NoError(t, err)
+	require.Equal(t, "new", selected.ID)
+
+	selected, err = selectControlSession(dir, "old")
+	require.NoError(t, err)
+	require.Equal(t, "old", selected.ID)
+}
+
+func TestRun(t *testing.T) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stderr lockedBuffer
+	errCh := make(chan error)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(errCh)
+		if err := run(ctx, []string{"op-up", "--dir", t.TempDir(), "--l2-el-kind", "op-geth"}, io.Discard, &stderr); err != nil {
+			errCh <- err
+		}
+	}()
+
+	ticker := time.NewTicker(time.Millisecond * 250)
+	defer ticker.Stop()
+	for {
+		select {
+		case e := <-errCh:
+			require.NoError(t, e)
+		case <-ticker.C:
+			url := firstL2ELURL(stderr.String())
+			if url == "" {
+				continue
+			}
+			client, err := ethclient.DialContext(ctx, url)
+			require.NoError(t, err)
+			chainID, err := client.ChainID(ctx)
+			if err != nil {
+				t.Logf("error while querying chain ID, will retry: %s", err)
+				continue
+			}
+			require.Equal(t, sysgo.DefaultL2AID.ToBig(), chainID)
+			return
+		}
+	}
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+var l2ELURLPattern = regexp.MustCompile(`(?m)^\s+L2\s+EL\s+control=\S+\s+chain=\S+\s+(http://localhost:\d+)\s*$`)
+
+func firstL2ELURL(output string) string {
+	match := l2ELURLPattern.FindStringSubmatch(output)
+	if len(match) < 2 {
+		return ""
+	}
+	return match[1]
+}
+
+type staticRawRPC struct {
+	raw json.RawMessage
+}
+
+func (s staticRawRPC) Close() {}
+
+func (s staticRawRPC) CallContext(_ context.Context, result any, method string, _ ...any) error {
+	if method != "optimism_dependencySet" {
+		return errors.New("unexpected method")
+	}
+	out, ok := result.(*json.RawMessage)
+	if !ok {
+		return errors.New("unexpected result type")
+	}
+	*out = append((*out)[:0], s.raw...)
+	return nil
+}
+
+func (s staticRawRPC) BatchCallContext(context.Context, []rpc.BatchElem) error {
+	return errors.New("unexpected batch call")
+}
+
+func (s staticRawRPC) Subscribe(context.Context, string, any, ...any) (ethereum.Subscription, error) {
+	return nil, errors.New("unexpected subscription")
+}
+
+type fakeControlledLifecycle struct {
+	mu         sync.Mutex
+	running    bool
+	startErr   error
+	stopErr    error
+	startBlock <-chan struct{}
+	stopBlock  <-chan struct{}
+	startCalls int
+	stopCalls  int
+}
+
+func (f *fakeControlledLifecycle) StartControlled(context.Context) error {
+	f.mu.Lock()
+	f.startCalls++
+	startBlock := f.startBlock
+	f.mu.Unlock()
+	if startBlock != nil {
+		<-startBlock
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.startErr != nil {
+		return f.startErr
+	}
+	f.running = true
+	return nil
+}
+
+func (f *fakeControlledLifecycle) StopControlled(context.Context) error {
+	f.mu.Lock()
+	f.stopCalls++
+	stopBlock := f.stopBlock
+	f.mu.Unlock()
+	if stopBlock != nil {
+		<-stopBlock
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.stopErr != nil {
+		return f.stopErr
+	}
+	f.running = false
+	return nil
+}
+
+func (f *fakeControlledLifecycle) Running() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.running
+}

--- a/op-up/smoke.go
+++ b/op-up/smoke.go
@@ -1,0 +1,752 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	txIntentBindings "github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/lmittmann/w3"
+)
+
+const smokeWaitTimeout = 60 * time.Second
+
+var (
+	sendETHFn = w3.MustNewFunc("sendETH(address,uint256)", "bytes32")
+
+	smokeL2AURLFlag = &cli.StringFlag{
+		Name:    "l2a-rpc",
+		Usage:   "RPC URL for chain A.",
+		EnvVars: opservice.PrefixEnvVar(envPrefix, "SMOKE_L2A_RPC"),
+	}
+	smokeL2BURLFlag = &cli.StringFlag{
+		Name:    "l2b-rpc",
+		Usage:   "RPC URL for chain B.",
+		EnvVars: opservice.PrefixEnvVar(envPrefix, "SMOKE_L2B_RPC"),
+	}
+	smokePrivateKeyFlag = &cli.StringFlag{
+		Name:    "private-key",
+		Usage:   "Private key to fund smoke-test transactions. If empty, uses the default dev key.",
+		EnvVars: opservice.PrefixEnvVar(envPrefix, "SMOKE_PRIVATE_KEY"),
+	}
+)
+
+type sendETHTrigger struct {
+	Recipient   common.Address
+	Destination eth.ChainID
+}
+
+func (t *sendETHTrigger) To() (*common.Address, error) {
+	addr := predeploys.SuperchainETHBridgeAddr
+	return &addr, nil
+}
+
+func (t *sendETHTrigger) EncodeInput() ([]byte, error) {
+	return sendETHFn.EncodeArgs(t.Recipient, t.Destination.ToBig())
+}
+
+func (t *sendETHTrigger) AccessList() (types.AccessList, error) {
+	return nil, nil
+}
+
+type remoteChain struct {
+	name      string
+	url       string
+	rpc       opclient.RPC
+	ethClient apis.EthClient
+	chainID   eth.ChainID
+}
+
+type remoteUser struct {
+	chain   *remoteChain
+	privKey *ecdsa.PrivateKey
+	address common.Address
+}
+
+type initMessage struct {
+	Tx      *txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput]
+	Receipt *types.Receipt
+}
+
+type execMessage struct {
+	Init    *initMessage
+	Tx      *txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput]
+	Receipt *types.Receipt
+}
+
+type smokeEnv struct {
+	ctx    context.Context
+	stderr io.Writer
+	chainA *remoteChain
+	chainB *remoteChain
+	userA  *remoteUser
+	userB  *remoteUser
+}
+
+func (m *initMessage) BlockNumber() uint64 {
+	return bigs.Uint64Strict(m.Receipt.BlockNumber)
+}
+
+func (m *initMessage) BlockHash() common.Hash {
+	return m.Receipt.BlockHash
+}
+
+func (m *execMessage) BlockNumber() uint64 {
+	return bigs.Uint64Strict(m.Receipt.BlockNumber)
+}
+
+func (m *execMessage) BlockHash() common.Hash {
+	return m.Receipt.BlockHash
+}
+
+func (u *remoteUser) plan() txplan.Option {
+	return txplan.Combine(
+		txplan.WithChainID(u.chain.ethClient),
+		txplan.WithPrivateKey(u.privKey),
+		txplan.WithPendingNonce(u.chain.ethClient),
+		txplan.WithAgainstLatestBlock(u.chain.ethClient),
+		txplan.WithEstimator(u.chain.ethClient, true),
+		txplan.WithRetrySubmission(u.chain.ethClient, 5, retry.Exponential()),
+		txplan.WithRetryInclusion(u.chain.ethClient, 5, retry.Exponential()),
+		txplan.WithBlockInclusionInfo(u.chain.ethClient),
+	)
+}
+
+func (u *remoteUser) transfer(ctx context.Context, to common.Address, amount eth.ETH) (*txplan.PlannedTx, error) {
+	tx := txplan.NewPlannedTx(
+		u.plan(),
+		txplan.WithTo(&to),
+		txplan.WithValue(amount),
+	)
+	_, err := tx.Success.Eval(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return tx, nil
+}
+
+func (u *remoteUser) deployEventLogger(ctx context.Context) (common.Address, error) {
+	tx := txplan.NewPlannedTx(u.plan(), txplan.WithData(common.FromHex(txIntentBindings.EventloggerBin)))
+	receipt, err := tx.Included.Eval(ctx)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return receipt.ContractAddress, nil
+}
+
+func (u *remoteUser) sendRandomInitMessage(ctx context.Context, rng *rand.Rand, eventLogger common.Address, topicCount, dataLen int) (*initMessage, error) {
+	if topicCount > 4 {
+		topicCount = 4
+	}
+	if topicCount < 1 {
+		topicCount = 1
+	}
+	if dataLen < 1 {
+		dataLen = 1
+	}
+
+	topics := make([][32]byte, topicCount)
+	for i := range topics {
+		copy(topics[i][:], testutils.RandomData(rng, 32))
+	}
+
+	trigger := &txintent.InitTrigger{
+		Emitter:    eventLogger,
+		Topics:     topics,
+		OpaqueData: testutils.RandomData(rng, dataLen),
+	}
+	tx := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](u.plan())
+	tx.Content.Set(trigger)
+	receipt, err := tx.PlannedTx.Included.Eval(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &initMessage{Tx: tx, Receipt: receipt}, nil
+}
+
+func (u *remoteUser) sendExecMessage(ctx context.Context, initMsg *initMessage) (*execMessage, error) {
+	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.plan())
+	tx.Content.DependOn(&initMsg.Tx.Result)
+	tx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initMsg.Tx.Result, 0))
+	receipt, err := tx.PlannedTx.Included.Eval(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &execMessage{
+		Init:    initMsg,
+		Tx:      tx,
+		Receipt: receipt,
+	}, nil
+}
+
+func (u *remoteUser) sendInvalidExecMessage(ctx context.Context, initMsg *initMessage) (*execMessage, error) {
+	result, err := initMsg.Tx.Result.Eval(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(result.Entries) == 0 {
+		return nil, fmt.Errorf("init tx produced no interop entries")
+	}
+
+	msg := result.Entries[0]
+	msg.Identifier.LogIndex++
+
+	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.plan())
+	tx.Content.DependOn(&initMsg.Tx.Result)
+	tx.Content.Fn(func(context.Context) (*txintent.ExecTrigger, error) {
+		return &txintent.ExecTrigger{
+			Executor: predeploys.CrossL2InboxAddr,
+			Msg:      msg,
+		}, nil
+	})
+
+	receipt, err := tx.PlannedTx.Included.Eval(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &execMessage{
+		Init:    initMsg,
+		Tx:      tx,
+		Receipt: receipt,
+	}, nil
+}
+
+func newSmokeEnv(ctx context.Context, stderr io.Writer, l2AURL, l2BURL, privateKey string) (*smokeEnv, func(), error) {
+	logger := newLogger(ctx, stderr)
+
+	chainA, err := connectRemoteChain(ctx, logger, "L2A", l2AURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	chainB, err := connectRemoteChain(ctx, logger, "L2B", l2BURL)
+	if err != nil {
+		chainA.ethClient.Close()
+		return nil, nil, err
+	}
+
+	privKey, address, err := resolveSmokeKey(privateKey)
+	if err != nil {
+		chainA.ethClient.Close()
+		chainB.ethClient.Close()
+		return nil, nil, err
+	}
+
+	env := &smokeEnv{
+		ctx:    ctx,
+		stderr: stderr,
+		chainA: chainA,
+		chainB: chainB,
+		userA:  &remoteUser{chain: chainA, privKey: privKey, address: address},
+		userB:  &remoteUser{chain: chainB, privKey: privKey, address: address},
+	}
+	cleanup := func() {
+		chainA.ethClient.Close()
+		chainB.ethClient.Close()
+	}
+	return env, cleanup, nil
+}
+
+func connectRemoteChain(ctx context.Context, logger log.Logger, name, url string) (*remoteChain, error) {
+	chainLogger := logger.New("chain", name, "rpc", url)
+	rpcCl, err := opclient.NewRPC(
+		ctx,
+		chainLogger,
+		url,
+		opclient.WithFixedDialBackoff(time.Second),
+		opclient.WithDialAttempts(5),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s RPC %s: %w", name, url, err)
+	}
+	ethCl, err := sources.NewEthClient(rpcCl, chainLogger, nil, sources.DefaultEthClientConfig(10))
+	if err != nil {
+		rpcCl.Close()
+		return nil, fmt.Errorf("create %s eth client: %w", name, err)
+	}
+	chainIDBig, err := ethCl.ChainID(ctx)
+	if err != nil {
+		ethCl.Close()
+		return nil, fmt.Errorf("fetch %s chain ID: %w", name, err)
+	}
+	return &remoteChain{
+		name:      name,
+		url:       url,
+		rpc:       rpcCl,
+		ethClient: ethCl,
+		chainID:   eth.ChainIDFromBig(chainIDBig),
+	}, nil
+}
+
+func defaultSmokeKey() (*ecdsa.PrivateKey, common.Address, error) {
+	hd, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("new mnemonic dev keys: %w", err)
+	}
+	const funderIndex = 10_000
+	key := devkeys.UserKey(funderIndex)
+	privKey, err := hd.Secret(key)
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("secret: %w", err)
+	}
+	address := crypto.PubkeyToAddress(privKey.PublicKey)
+	return privKey, address, nil
+}
+
+func resolveSmokeKey(privateKey string) (*ecdsa.PrivateKey, common.Address, error) {
+	if privateKey == "" {
+		return defaultSmokeKey()
+	}
+	privKey, err := crypto.HexToECDSA(strings.TrimPrefix(privateKey, "0x"))
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("parse private key: %w", err)
+	}
+	return privKey, crypto.PubkeyToAddress(privKey.PublicKey), nil
+}
+
+func withSmokeEnv(cliCtx *cli.Context, name string, fn func(env *smokeEnv) error) error {
+	ctx := cliCtx.Context
+	stderr := cliCtx.App.ErrWriter
+	l2AURL := cliCtx.String(smokeL2AURLFlag.Name)
+	l2BURL := cliCtx.String(smokeL2BURLFlag.Name)
+	privateKey := cliCtx.String(smokePrivateKeyFlag.Name)
+
+	fmt.Fprintf(stderr, "%s\n", asciiArt)
+	fmt.Fprintf(stderr, "\nSmoke: %s\n\n", name)
+
+	if l2AURL == "" || l2BURL == "" {
+		return fmt.Errorf("provide --l2a-rpc and --l2b-rpc from the printed op-up endpoints")
+	}
+
+	env, cleanup, err := newSmokeEnv(ctx, stderr, l2AURL, l2BURL, privateKey)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	fmt.Fprintf(stderr, "Chain A RPC: %s (chain ID %s)\n", env.chainA.url, env.chainA.chainID)
+	fmt.Fprintf(stderr, "Chain B RPC: %s (chain ID %s)\n", env.chainB.url, env.chainB.chainID)
+	fmt.Fprintf(stderr, "Smoke Sender Address: %s\n\n", env.userA.address)
+
+	if err := fn(env); err != nil {
+		fmt.Fprintf(stderr, "\nFAIL: %s (%v)\n", name, err)
+		return err
+	}
+	fmt.Fprintf(stderr, "\nPASS: %s\n", name)
+	return nil
+}
+
+func smokeCommand() *cli.Command {
+	smokeFlags := cliapp.ProtectFlags([]cli.Flag{smokeL2AURLFlag, smokeL2BURLFlag, smokePrivateKeyFlag})
+
+	return &cli.Command{
+		Name:  "smoke-interop",
+		Usage: "run interop smoke tests against remote chain RPCs",
+		Subcommands: []*cli.Command{
+			{
+				Name:  "all",
+				Usage: "run all smoke tests sequentially",
+				Flags: smokeFlags,
+				Action: func(cliCtx *cli.Context) error {
+					return withSmokeEnv(cliCtx, "All Tests", smokeAll)
+				},
+			},
+			{
+				Name:  "identity",
+				Usage: "verify both chains have different chain IDs",
+				Flags: smokeFlags,
+				Action: func(cliCtx *cli.Context) error {
+					return withSmokeEnv(cliCtx, "Chain Identity", smokeIdentity)
+				},
+			},
+			{
+				Name:  "transfer",
+				Usage: "send ETH transfers on both chains",
+				Flags: smokeFlags,
+				Action: func(cliCtx *cli.Context) error {
+					return withSmokeEnv(cliCtx, "ETH Transfers", smokeTransfer)
+				},
+			},
+			{
+				Name:  "bridge",
+				Usage: "bridge ETH from chain A to chain B via SuperchainETHBridge",
+				Flags: smokeFlags,
+				Action: func(cliCtx *cli.Context) error {
+					return withSmokeEnv(cliCtx, "Cross-Chain ETH Bridge", smokeBridge)
+				},
+			},
+			{
+				Name:  "valid-message",
+				Usage: "send a valid executing message and verify it stays in-chain",
+				Flags: smokeFlags,
+				Action: func(cliCtx *cli.Context) error {
+					return withSmokeEnv(cliCtx, "Valid Exec Message", smokeValidMessage)
+				},
+			},
+			{
+				Name:  "invalid-message",
+				Usage: "send an invalid executing message and verify it is reorged out",
+				Flags: smokeFlags,
+				Action: func(cliCtx *cli.Context) error {
+					return withSmokeEnv(cliCtx, "Invalid Exec Message (reorg)", smokeInvalidMessage)
+				},
+			},
+		},
+	}
+}
+
+func smokeAll(env *smokeEnv) error {
+	tests := []struct {
+		name string
+		fn   func(env *smokeEnv) error
+	}{
+		{"Chain Identity", smokeIdentity},
+		{"ETH Transfers", smokeTransfer},
+		{"Cross-Chain ETH Bridge", smokeBridge},
+		{"Valid Exec Message", smokeValidMessage},
+		{"Invalid Exec Message (reorg)", smokeInvalidMessage},
+	}
+
+	var failed []string
+	for _, test := range tests {
+		fmt.Fprintf(env.stderr, "--- %s\n", test.name)
+		if err := test.fn(env); err != nil {
+			fmt.Fprintf(env.stderr, "    FAIL: %v\n", err)
+			failed = append(failed, test.name)
+		} else {
+			fmt.Fprintf(env.stderr, "    PASS\n")
+		}
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("failed tests: %v", failed)
+	}
+	return nil
+}
+
+func smokeIdentity(env *smokeEnv) error {
+	if env.chainA.chainID == env.chainB.chainID {
+		return fmt.Errorf("chains have the same ID: %s", env.chainA.chainID)
+	}
+	fmt.Fprintf(env.stderr, "    Chain A: %s, Chain B: %s\n", env.chainA.chainID, env.chainB.chainID)
+	return nil
+}
+
+func smokeTransfer(env *smokeEnv) error {
+	recipientA := randomAddress()
+	if _, err := env.userA.transfer(env.ctx, recipientA, eth.OneHundredthEther); err != nil {
+		return fmt.Errorf("chain A transfer failed: %w", err)
+	}
+	if err := waitForBalance(env.ctx, env.chainA, recipientA, eth.OneHundredthEther); err != nil {
+		return err
+	}
+	fmt.Fprintf(env.stderr, "    Chain A transfer: OK\n")
+
+	recipientB := randomAddress()
+	if _, err := env.userB.transfer(env.ctx, recipientB, eth.OneHundredthEther); err != nil {
+		return fmt.Errorf("chain B transfer failed: %w", err)
+	}
+	if err := waitForBalance(env.ctx, env.chainB, recipientB, eth.OneHundredthEther); err != nil {
+		return err
+	}
+	fmt.Fprintf(env.stderr, "    Chain B transfer: OK\n")
+	return nil
+}
+
+func smokeBridge(env *smokeEnv) error {
+	recipient := randomAddress()
+	amount := eth.OneHundredthEther
+
+	sendTx := txintent.NewIntent[*sendETHTrigger, *txintent.InteropOutput](
+		env.userA.plan(),
+		txplan.WithValue(amount),
+	)
+	sendTx.Content.Set(&sendETHTrigger{
+		Recipient:   recipient,
+		Destination: env.chainB.chainID,
+	})
+
+	sendReceipt, err := sendTx.PlannedTx.Included.Eval(env.ctx)
+	if err != nil {
+		return fmt.Errorf("sendETH failed: %w", err)
+	}
+	if sendReceipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("sendETH tx reverted")
+	}
+	fmt.Fprintf(env.stderr, "    sendETH tx included: %s\n", sendReceipt.TxHash)
+
+	relayReceipt, err := waitForRelaySuccess(env, sendTx)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(env.stderr, "    relayETH tx included: %s\n", relayReceipt.TxHash)
+
+	if err := waitForBalance(env.ctx, env.chainB, recipient, amount); err != nil {
+		return err
+	}
+	fmt.Fprintf(env.stderr, "    Recipient received %s ETH on Chain B\n", amount)
+	return nil
+}
+
+func smokeValidMessage(env *smokeEnv) error {
+	rng := rand.New(rand.NewSource(42))
+
+	eventLogger, err := env.userA.deployEventLogger(env.ctx)
+	if err != nil {
+		return fmt.Errorf("deploy EventLogger: %w", err)
+	}
+
+	initMsg, err := env.userA.sendRandomInitMessage(env.ctx, rng, eventLogger, 2, 10)
+	if err != nil {
+		return fmt.Errorf("send init message: %w", err)
+	}
+	fmt.Fprintf(env.stderr, "    Init message sent on Chain A (block %d)\n", initMsg.BlockNumber())
+
+	if _, err := waitForNextBlock(env.ctx, env.chainB); err != nil {
+		return err
+	}
+	execMsg, err := env.userB.sendExecMessage(env.ctx, initMsg)
+	if err != nil {
+		return fmt.Errorf("send exec message: %w", err)
+	}
+	if execMsg.Receipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("exec tx reverted")
+	}
+
+	execBlockNum := execMsg.BlockNumber()
+	execBlockHash := execMsg.BlockHash()
+	fmt.Fprintf(env.stderr, "    Exec message sent on Chain B (block %d)\n", execBlockNum)
+
+	if err := waitForHeadAtLeast(env.ctx, env.chainB, execBlockNum+2); err != nil {
+		return err
+	}
+
+	currentBlock, err := env.chainB.ethClient.BlockRefByNumber(env.ctx, execBlockNum)
+	if err != nil {
+		return fmt.Errorf("fetch block %d: %w", execBlockNum, err)
+	}
+	if currentBlock.Hash != execBlockHash {
+		return fmt.Errorf("block was replaced: expected %s, got %s", execBlockHash, currentBlock.Hash)
+	}
+	if err := assertTxInBlock(env.ctx, env.chainB, execBlockNum, execMsg.Receipt.TxHash); err != nil {
+		return err
+	}
+	fmt.Fprintf(env.stderr, "    Block remained canonical after head advanced past it\n")
+	return nil
+}
+
+func smokeInvalidMessage(env *smokeEnv) error {
+	rng := rand.New(rand.NewSource(99))
+
+	eventLogger, err := env.userA.deployEventLogger(env.ctx)
+	if err != nil {
+		return fmt.Errorf("deploy EventLogger: %w", err)
+	}
+
+	initMsg, err := env.userA.sendRandomInitMessage(env.ctx, rng, eventLogger, 2, 10)
+	if err != nil {
+		return fmt.Errorf("send init message: %w", err)
+	}
+	if _, err := waitForNextBlock(env.ctx, env.chainB); err != nil {
+		return err
+	}
+
+	invalidExec, err := env.userB.sendInvalidExecMessage(env.ctx, initMsg)
+	if err != nil {
+		return fmt.Errorf("send invalid exec message: %w", err)
+	}
+	if invalidExec.Receipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("invalid exec tx reverted before inclusion")
+	}
+
+	invalidBlockNum := invalidExec.BlockNumber()
+	invalidBlockHash := invalidExec.BlockHash()
+	fmt.Fprintf(env.stderr, "    Invalid exec tx included: %s\n", invalidExec.Receipt.TxHash)
+	fmt.Fprintf(env.stderr, "    Invalid exec message landed in block %d (%s)\n", invalidBlockNum, invalidBlockHash)
+
+	if err := waitForReorgedOut(env.ctx, env.stderr, env.chainB, invalidBlockNum, invalidBlockHash, invalidExec.Receipt.TxHash); err != nil {
+		return err
+	}
+	fmt.Fprintf(env.stderr, "    Invalid tx was reorged out after block %d was replaced\n", invalidBlockNum)
+	return nil
+}
+
+func waitForRelaySuccess(env *smokeEnv, sendTx *txintent.IntentTx[*sendETHTrigger, *txintent.InteropOutput]) (*types.Receipt, error) {
+	deadline := time.Now().Add(smokeWaitTimeout)
+	for attempt := 0; ; attempt++ {
+		relayTx := txintent.NewIntent[*txintent.RelayTrigger, *txintent.InteropOutput](env.userB.plan())
+		relayTx.Content.DependOn(&sendTx.Result)
+		relayTx.Content.Fn(txintent.RelayIndexed(
+			predeploys.L2toL2CrossDomainMessengerAddr,
+			&sendTx.Result,
+			&sendTx.PlannedTx.Included,
+			1,
+		))
+
+		relayReceipt, err := relayTx.PlannedTx.Included.Eval(env.ctx)
+		if err == nil && relayReceipt.Status == types.ReceiptStatusSuccessful {
+			return relayReceipt, nil
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return nil, fmt.Errorf("relayETH failed before timeout: %w", err)
+			}
+			return nil, fmt.Errorf("relayETH tx kept reverting until timeout")
+		}
+		if err != nil {
+			fmt.Fprintf(env.stderr, "    Waiting for relayability: attempt %d failed: %v\n", attempt+1, err)
+		} else {
+			fmt.Fprintf(env.stderr, "    Waiting for relayability: attempt %d reverted in tx %s\n", attempt+1, relayReceipt.TxHash)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func waitForBalance(ctx context.Context, chain *remoteChain, addr common.Address, want eth.ETH) error {
+	deadline := time.Now().Add(smokeWaitTimeout)
+	for {
+		balance, err := chain.ethClient.BalanceAt(ctx, addr, nil)
+		if err == nil && balance.Cmp(want.ToBig()) == 0 {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return fmt.Errorf("timed out waiting for balance on %s: %w", chain.name, err)
+			}
+			return fmt.Errorf("timed out waiting for %s balance on %s; got %s", addr, chain.name, eth.WeiBig(balance))
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func waitForNextBlock(ctx context.Context, chain *remoteChain) (eth.BlockRef, error) {
+	head, err := chain.ethClient.BlockRefByLabel(ctx, eth.Unsafe)
+	if err != nil {
+		return eth.BlockRef{}, fmt.Errorf("fetch latest block on %s: %w", chain.name, err)
+	}
+	if err := waitForHeadAtLeast(ctx, chain, head.Number+1); err != nil {
+		return eth.BlockRef{}, err
+	}
+	return chain.ethClient.BlockRefByLabel(ctx, eth.Unsafe)
+}
+
+func waitForHeadAtLeast(ctx context.Context, chain *remoteChain, target uint64) error {
+	deadline := time.Now().Add(smokeWaitTimeout)
+	for {
+		head, err := chain.ethClient.BlockRefByLabel(ctx, eth.Unsafe)
+		if err == nil && head.Number >= target {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return fmt.Errorf("timed out waiting for %s head >= %d: %w", chain.name, target, err)
+			}
+			return fmt.Errorf("timed out waiting for %s head >= %d; current head is %d", chain.name, target, head.Number)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func waitForReorgedOut(ctx context.Context, stderr io.Writer, chain *remoteChain, blockNum uint64, oldHash, txHash common.Hash) error {
+	deadline := time.Now().Add(smokeWaitTimeout)
+	replaced := false
+	for attempt := 0; ; attempt++ {
+		currentBlock, err := chain.ethClient.BlockRefByNumber(ctx, blockNum)
+		if err == nil {
+			if currentBlock.Hash != oldHash {
+				fmt.Fprintf(stderr, "    Reorg detected at block %d: %s -> %s\n", blockNum, oldHash, currentBlock.Hash)
+				replaced = true
+				break
+			}
+			if attempt == 0 || attempt%10 == 0 {
+				fmt.Fprintf(stderr, "    Waiting for reorg at block %d: still %s\n", blockNum, currentBlock.Hash)
+			}
+		} else if errors.Is(eth.MaybeAsNotFoundErr(err), ethereum.NotFound) {
+			if attempt == 0 || attempt%10 == 0 {
+				fmt.Fprintf(stderr, "    Waiting for reorg at block %d: block temporarily missing\n", blockNum)
+			}
+		} else if attempt == 0 || attempt%10 == 0 {
+			fmt.Fprintf(stderr, "    Waiting for reorg at block %d: lookup error: %v\n", blockNum, err)
+		}
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for block %d (%s) to be reorged out", blockNum, oldHash)
+		}
+		time.Sleep(time.Second)
+	}
+
+	if !replaced {
+		return fmt.Errorf("invalid reorg state")
+	}
+	if err := waitForHeadAtLeast(ctx, chain, blockNum+1); err != nil {
+		return err
+	}
+	return assertTxNotInBlock(ctx, chain, blockNum, txHash)
+}
+
+func assertTxInBlock(ctx context.Context, chain *remoteChain, blockNum uint64, txHash common.Hash) error {
+	_, txs, err := chain.ethClient.InfoAndTxsByNumber(ctx, blockNum)
+	if err != nil {
+		return fmt.Errorf("fetch block %d txs on %s: %w", blockNum, chain.name, err)
+	}
+	for _, tx := range txs {
+		if tx.Hash() == txHash {
+			return nil
+		}
+	}
+	return fmt.Errorf("tx %s not found in block %d on %s", txHash, blockNum, chain.name)
+}
+
+func assertTxNotInBlock(ctx context.Context, chain *remoteChain, blockNum uint64, txHash common.Hash) error {
+	_, txs, err := chain.ethClient.InfoAndTxsByNumber(ctx, blockNum)
+	if err != nil {
+		return fmt.Errorf("fetch block %d txs on %s: %w", blockNum, chain.name, err)
+	}
+	for _, tx := range txs {
+		if tx.Hash() == txHash {
+			return fmt.Errorf("tx %s still present in block %d on %s", txHash, blockNum, chain.name)
+		}
+	}
+	return nil
+}
+
+func randomAddress() common.Address {
+	privKey, err := crypto.GenerateKey()
+	if err != nil {
+		panic(err)
+	}
+	return crypto.PubkeyToAddress(privKey.PublicKey)
+}

--- a/rust/kona/tests/node/utils/package_scope.go
+++ b/rust/kona/tests/node/utils/package_scope.go
@@ -67,6 +67,10 @@ func (t *packageScopeT) TempDir() string {
 	return t.p.TempDir()
 }
 
+func (t *packageScopeT) TempDirWithPrefix(prefix string) string {
+	return t.p.TempDirWithPrefix(prefix)
+}
+
 func (t *packageScopeT) Cleanup(fn func()) {
 	t.p.Cleanup(fn)
 }


### PR DESCRIPTION
## Summary

Adds a friendlier `op-up` UX for launching local op-devstack devnet presets.

This lets users run preset devnets from `op-up`, get randomized local RPC ports automatically, and see the information needed to interact with the network after startup.

## Features

- Start realistic OP Stack devnets with one command.
- Pick from useful presets like minimal, interop, two-L2, multinode, conductors, and flashblocks.
- No manual port management: op-up finds ports and prints every endpoint.
- Get the funded test account, deployed contracts, L1 beacon RPC, L2 RPCs, and supernode RPC in one place.
- Export configs automatically for external tools like challenger/proposer runners.
- Control running services with start, stop, restart, and status.
- Simulate failures without editing presets or writing custom test code.
- Keep RPC endpoints stable across service restarts.
- Find service logs easily under ~/.op-up/logs.

## Changes

- Add `op-up up <preset>` / preset selection UX backed by op-devstack presets.
- Print service endpoints for L1/L2 EL, L2 CL, L1 beacon, and interop supernode RPC when available.
- Print deployed L1 contract addresses for each L2, including portal, system config, bridge, DGF, proxy admin, and delayed WETH.
- Use random local ports by default so users do not need to manually pick ports.
- Export devnet config files under `~/.op-up/configs/`, including endpoints, contracts, rollup configs, dependency set config, and generated JSON configs when available.