### PR TITLE
fix(txmgr): suppress receipt-missing log after successful send cleanup

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -868,6 +868,9 @@ func (m *SimpleTxManager) waitForTx(ctx context.Context, tx *types.Transaction, 
 	// Poll for the transaction to be ready & then send the result to receiptChan
 	receipt, err := m.waitMined(ctx, tx, sendState)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
 		// this will happen if the tx was successfully replaced by a tx with bumped fees
 		m.txLogger(tx, true).Info("Transaction receipt not found", "err", err)
 		return


### PR DESCRIPTION
## Summary

Suppress misleading `Transaction receipt not found` logs when a receipt waiter exits due to normal txmgr context cleanup.

## Details

`sendTx` can start multiple receipt waiter goroutines across publish/republish attempts. Once one waiter finds the receipt and `sendTx` returns successfully, txmgr cancels its internal context to stop the remaining waiters. Those leftover waiters previously logged `Transaction receipt not found err="context canceled"`, even though the transaction had already confirmed.

This change treats `context.Canceled` in `waitForTx` as expected cleanup and returns without logging.