### PR TITLE
fix(op-reth): verify embedded PostExec tx when rebuilding derived blocks

### DIFF
--- a/op-acceptance-tests/tests/sdm/block_test.go
+++ b/op-acceptance-tests/tests/sdm/block_test.go
@@ -408,6 +408,86 @@ func testSDMPostExecBlockDerivesAndChainProgresses(t devtest.T, batchType string
 		"l1_after_batching", l1AfterBatching.ID())
 }
 
+// TestSDMPostExecBlockDerivesOnIsolatedVerifier checks that a verifier with no L2 P2P connectivity
+// — one that can only learn the chain by deriving it from L1 — still reproduces a PostExec block
+// and keeps its safe head moving.
+//
+// This exercises the force-build path: with no gossiped unsafe block to consolidate against,
+// op-node hands the derived attributes (which embed the block's 0x7D tx) to the EL to rebuild via
+// FCU-with-attributes (`no_tx_pool = true`). The verifier never opts into SDM production, so its EL
+// must still rebuild the block in Verify mode purely from the embedded payload. The
+// consolidation-path test (TestSDMPostExecBlockDerivesAndChainProgresses) cannot catch a
+// regression here because its verifier receives the block over P2P first and only consolidates.
+func TestSDMPostExecBlockDerivesOnIsolatedVerifier(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := newSDMRethSystemWithIsolatedVerifier(t)
+	verifyOpReth(t, sys.L2EL)
+	verifyOpReth(t, sys.L2ELVerifier)
+
+	// Produce a PostExec block on the sequencer, plus a sentinel after it so derivation must carry
+	// the verifier past the PostExec block to succeed.
+	block, included, targetBlockNum := mustFindRepeatedSlotBlock(t, sys, 2, 3)
+	t.Require().NotEmpty(included, "target block must include workload transactions")
+	postExecTx, _ := findPostExecTransaction(block)
+	t.Require().NotNil(postExecTx, "SDM-enabled sequencer must include a post-exec tx before batching")
+	payload, err := sdmpkg.DecodePayload(postExecTx.Input)
+	t.Require().NoError(err, "post-exec payload must decode")
+	t.Require().NotEmpty(payload.GasRefundEntries,
+		"post-exec payload must be non-empty for repeated-slot workload")
+	targetRef := sys.L2EL.BlockRefByNumber(targetBlockNum)
+	t.Require().Equal(block.Hash, targetRef.Hash,
+		"selected post-exec block must match canonical sequencer block")
+
+	alice := sys.FunderL2.NewFundedEOA(eth.OneEther)
+	sentinel := txplan.NewPlannedTx(
+		alice.Plan(),
+		txplan.WithTo(addrPtr(common.HexToAddress("0x000000000000000000000000000000000000dEaD"))),
+		txplan.WithValue(eth.OneHundredthEther),
+	)
+	sentinelReceipt, err := sentinel.Included.Eval(t.Ctx())
+	t.Require().NoError(err, "sentinel tx after the post-exec block must be included")
+	t.Require().Equal(types.ReceiptStatusSuccessful, sentinelReceipt.Status, "sentinel tx must succeed")
+	sentinelBlockNum := bigs.Uint64Strict(sentinelReceipt.BlockNumber)
+	t.Require().Greater(sentinelBlockNum, targetBlockNum, "sentinel must land after the post-exec block")
+	sentinelRef := sys.L2EL.BlockRefByNumber(sentinelBlockNum)
+
+	// Precondition that makes this test meaningful: with the batcher stopped and the verifier off
+	// the P2P mesh, the verifier has learned nothing — its unsafe head is still at genesis while
+	// the sequencer is well ahead. So any safe progress below comes from L1 derivation + force-build,
+	// not from gossip + consolidation.
+	sequencerUnsafeBefore := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	verifierUnsafeBefore := sys.L2ELVerifier.BlockRefByLabel(eth.Unsafe)
+	t.Require().GreaterOrEqual(sequencerUnsafeBefore.Number, targetBlockNum,
+		"sequencer must have built the post-exec block locally before batching")
+	t.Require().Equal(uint64(0), verifierUnsafeBefore.Number,
+		"isolated verifier must not receive any unsafe blocks over P2P; it should still be at genesis")
+
+	// Start batching: the verifier can now derive from L1. With no unsafe block to consolidate
+	// against, op-node force-builds each derived block — including the PostExec block — through the
+	// EL payload builder.
+	sys.L2Batcher.Start()
+	dsl.CheckAll(t,
+		sys.L2CLVerifier.ReachedRefFn(safety.CrossSafe, sentinelRef.ID(), 120),
+		sys.L2ELVerifier.ReachedFn(eth.Safe, sentinelBlockNum, 120),
+	)
+
+	// The verifier rebuilt the PostExec block (and the blocks around it) byte-for-byte: a Verify-mode
+	// rejection or a duplicated 0x7D would change the block hash and stall safe progress.
+	verifierPostExecRef := sys.L2ELVerifier.BlockRefByNumber(targetBlockNum)
+	t.Require().Equal(targetRef.Hash, verifierPostExecRef.Hash,
+		"isolated verifier must rebuild the same post-exec block as the sequencer")
+	verifierSentinelRef := sys.L2ELVerifier.BlockRefByNumber(sentinelBlockNum)
+	t.Require().Equal(sentinelRef.Hash, verifierSentinelRef.Hash,
+		"isolated verifier must rebuild blocks after the post-exec block")
+
+	t.Logger().Info("TestSDMPostExecBlockDerivesOnIsolatedVerifier passed",
+		"post_exec_block", targetBlockNum,
+		"post_exec_block_hash", targetRef.Hash,
+		"sentinel_block", sentinelBlockNum,
+		"payload_entries", len(payload.GasRefundEntries),
+		"verifier_unsafe_before_batching", verifierUnsafeBefore.Number)
+}
+
 func TestSDMStorageRefundBreakdown(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := newSDMRethSystem(t, true)

--- a/op-acceptance-tests/tests/sdm/init_test.go
+++ b/op-acceptance-tests/tests/sdm/init_test.go
@@ -42,6 +42,15 @@ func newSDMRethSystemWithBatcherOptions(t devtest.T, sdmEnabled bool, batcherOpt
 // unsafe block. That is the only path on which the verifier's EL rebuilds a derived PostExec block
 // locally.
 func newSDMRethSystemWithIsolatedVerifier(t devtest.T) *sdmRethSystem {
+	// kona-node gates derivation behind EL-sync completion, and a verifier only marks EL-sync
+	// complete after its first engine forkchoiceUpdated — which is bootstrapped by an unsafe
+	// payload received over L2 P2P. With P2P fully isolated, that bootstrap never happens: the
+	// derivation actor stays in AwaitingELSyncCompletion, the EL gets no engine calls, and the
+	// safe head never leaves genesis. kona-node has no L1-only bootstrap of the force-build path
+	// today, so this test cannot pass under kona-node and is op-node-only for now.
+	if sysgo.ResolveMixedL2CLKind() == sysgo.MixedL2CLKona {
+		t.Skip("isolated-verifier force-build path is not supported by kona-node (no L1-only EL-sync bootstrap); op-node only")
+	}
 	return buildSDMRethSystem(t, true, true, nil)
 }
 

--- a/op-acceptance-tests/tests/sdm/init_test.go
+++ b/op-acceptance-tests/tests/sdm/init_test.go
@@ -32,7 +32,17 @@ func newSDMRethSystemWithBatcherOptions(t devtest.T, sdmEnabled bool, batcherOpt
 	// op-node derivation, op-reth execution, and the op-rbuilder payload builder. The
 	// runtime also provisions a DependencySet for op-node, required whenever Interop is
 	// scheduled, even in single-chain setups without a supervisor.
-	return buildSDMRethSystem(t, sdmEnabled, nil, batcherOpts...)
+	return buildSDMRethSystem(t, sdmEnabled, false, nil, batcherOpts...)
+}
+
+// newSDMRethSystemWithIsolatedVerifier builds the SDM system (Interop/SDM at genesis) with the
+// verifier kept off the L2 P2P mesh. The verifier receives no gossiped unsafe blocks and must
+// advance its safe head purely by deriving from L1, which forces op-node down the force-build path
+// (FCU-with-attributes, `no_tx_pool = true`) instead of consolidating against an already-present
+// unsafe block. That is the only path on which the verifier's EL rebuilds a derived PostExec block
+// locally.
+func newSDMRethSystemWithIsolatedVerifier(t devtest.T) *sdmRethSystem {
+	return buildSDMRethSystem(t, true, true, nil)
 }
 
 // newSDMRethSystemWithInteropOffset builds the SDM system with Interop scheduled at the given
@@ -54,12 +64,12 @@ func newSDMRethSystemWithInteropOffset(
 				l2Cfg.WithForkAtOffset(forks.Lagoon, &offset)
 			}
 		})
-		return buildSDMRethSystem(t, true, deployerOpts, batcherOpts...)
+		return buildSDMRethSystem(t, true, false, deployerOpts, batcherOpts...)
 	}
-	return buildSDMRethSystem(t, false, deployerOpts, batcherOpts...)
+	return buildSDMRethSystem(t, false, false, deployerOpts, batcherOpts...)
 }
 
-func buildSDMRethSystem(t devtest.T, interopAtGenesis bool, deployerOpts []sysgo.DeployerOption, batcherOpts ...sysgo.BatcherOption) *sdmRethSystem {
+func buildSDMRethSystem(t devtest.T, interopAtGenesis bool, isolateVerifier bool, deployerOpts []sysgo.DeployerOption, batcherOpts ...sysgo.BatcherOption) *sdmRethSystem {
 	sysgo.SkipOnOpGeth(t, "SDM acceptance tests require op-reth post-exec support")
 
 	// Honor DEVSTACK_L2CL_KIND so the kona acceptance suite exercises this test with
@@ -76,11 +86,12 @@ func buildSDMRethSystem(t devtest.T, interopAtGenesis bool, deployerOpts []sysgo
 				IsSequencer: true,
 			},
 			{
-				ELKey:       "verifier-op-reth",
-				CLKey:       "verifier",
-				ELKind:      sysgo.MixedL2ELOpReth,
-				CLKind:      clKind,
-				IsSequencer: false,
+				ELKey:            "verifier-op-reth",
+				CLKey:            "verifier",
+				ELKind:           sysgo.MixedL2ELOpReth,
+				CLKind:           clKind,
+				IsSequencer:      false,
+				IsolateFromL2P2P: isolateVerifier,
 			},
 		},
 		BatcherOptions:   batcherOpts,

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -128,6 +128,11 @@ type MixedSingleChainNodeSpec struct {
 	ELKind      MixedL2ELKind
 	CLKind      MixedL2CLKind
 	IsSequencer bool
+	// IsolateFromL2P2P keeps this node off the L2 CL/EL P2P mesh: it is never peered with the
+	// other nodes, so it receives no gossiped or req-resp'd unsafe blocks and must advance purely
+	// by deriving from L1. Used to exercise the derivation/force-build path (FCU-with-attributes)
+	// rather than the consolidation path. Defaults to false (fully peered).
+	IsolateFromL2P2P bool
 }
 
 type MixedSingleChainPresetConfig struct {
@@ -246,7 +251,12 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 	}
 
 	for i := range nodes {
-		for j := 0; j < i; j++ {
+		for j := range i {
+			// Skip peering any pair involving an isolated node, so it stays off the L2 P2P mesh
+			// and can only learn the chain by deriving it from L1.
+			if nodes[i].spec.IsolateFromL2P2P || nodes[j].spec.IsolateFromL2P2P {
+				continue
+			}
 			connectL2CLPeers(t, t.Logger(), nodes[i].cl, nodes[j].cl)
 			connectL2ELPeers(t, t.Logger(), nodes[i].el.UserRPC(), nodes[j].el.UserRPC(), false)
 		}

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -9,7 +9,10 @@ use alloy_evm::Evm as AlloyEvm;
 use alloy_primitives::{Address, B256, Sealed, U256};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_engine::PayloadId;
-use op_alloy_consensus::{SDMGasEntry, TxPostExec, build_post_exec_tx};
+use op_alloy_consensus::{
+    ParsedPostExecPayload, SDMGasEntry, TxPostExec, build_post_exec_tx,
+    parse_post_exec_payload_from_transactions,
+};
 use op_revm::{L1BlockInfo, constants::L1_BLOCK_CONTRACT};
 use reth_basic_payload_builder::*;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
@@ -491,7 +494,9 @@ impl<Txs> OpBuilder<'_, Txs> {
             }
         }
 
-        let sdm_refund_gas = if ctx.sdm_production_enabled() {
+        // Only locally-sequenced blocks append a post-exec tx; a derived block (force_empty)
+        // already carries its own `0x7D`, so appending would duplicate it. See `post_exec_mode`.
+        let sdm_refund_gas = if !ctx.force_empty() && ctx.sdm_production_enabled() {
             let block_number = builder.evm_mut().block().number().saturating_to();
             let entries = builder.executor_mut().take_post_exec_entries();
             let refund_gas = self::sdm_refund_gas(&entries);
@@ -785,6 +790,50 @@ where
         protocol_active && self.builder_config.sdm_post_exec_opt_in.enabled()
     }
 
+    /// Returns true when the tx pool is excluded and the block must be reproduced
+    /// deterministically from forced transactions only (i.e. `no_tx_pool = true`).
+    ///
+    /// Mirrors op-geth's `l2ForceEmpty` / `ForcedEmpty()` concept for cross-client consistency.
+    pub fn force_empty(&self) -> bool {
+        self.attributes().no_tx_pool()
+    }
+
+    /// Parses the `0x7D` post-exec tx embedded by op-node into derived payload attributes.
+    ///
+    /// Returns `Ok(None)` when no such tx is present; errors if the embedded payload is
+    /// structurally invalid (present before SDM activation, duplicated, not last, or anchored
+    /// to the wrong block number).
+    fn parse_embedded_post_exec(
+        &self,
+    ) -> Result<Option<ParsedPostExecPayload>, PayloadBuilderError> {
+        let sdm_active = reth_optimism_evm::is_sdm_active_at_timestamp(
+            &self.chain_spec,
+            self.attributes().timestamp(),
+        );
+        let next_block_number = self.parent().number().saturating_add(1);
+        parse_post_exec_payload_from_transactions(
+            self.attributes().sequencer_transactions().iter().map(|tx| tx.value()),
+            next_block_number,
+            sdm_active,
+        )
+        .map_err(PayloadBuilderError::other)
+    }
+
+    /// Resolves the canonical post-exec mode for this payload.
+    ///
+    /// - **`force_empty` (rebuilding a derived block)**: *verify* against any `0x7D` op-node
+    ///   embedded in the attributes, regardless of the opt-in; `Disabled` if there is none. Never
+    ///   produce.
+    /// - **otherwise (local sequencing)**: *produce* iff [`Self::sdm_production_enabled`].
+    pub fn post_exec_mode(&self) -> Result<PostExecMode, PayloadBuilderError> {
+        if !self.force_empty() {
+            return Ok(self.sdm_production_enabled().into());
+        }
+
+        let parsed = self.parse_embedded_post_exec()?;
+        Ok(parsed.map_or(PostExecMode::Disabled, |p| PostExecMode::Verify(p.payload)))
+    }
+
     /// Returns the unique id for this payload job.
     pub fn payload_id(&self) -> PayloadId {
         self.attributes().payload_id()
@@ -806,7 +855,7 @@ where
         > + 'a,
         PayloadBuilderError,
     > {
-        let post_exec_mode: PostExecMode = self.sdm_production_enabled().into();
+        let post_exec_mode = self.post_exec_mode()?;
 
         self.evm_config
             .post_exec_builder_for_next_block(

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -819,12 +819,16 @@ where
         .map_err(PayloadBuilderError::other)
     }
 
-    /// Resolves the canonical post-exec mode for this payload.
+    /// Decides this payload's SDM post-exec mode: *produce*, *verify*, or `Disabled`.
     ///
-    /// - **`force_empty` (rebuilding a derived block)**: *verify* against any `0x7D` op-node
-    ///   embedded in the attributes, regardless of the opt-in; `Disabled` if there is none. Never
-    ///   produce.
-    /// - **otherwise (local sequencing)**: *produce* iff [`Self::sdm_production_enabled`].
+    /// The deciding factor is whether we're sequencing the block or rebuilding one
+    /// that CL already derived (`force_empty` / `no_tx_pool`):
+    ///
+    /// - **Local sequencing**: *produce* the post-exec tx when [`Self::sdm_production_enabled`],
+    ///   otherwise `Disabled`.
+    /// - **Rebuilding a derived block**: never produce — instead *verify* against the `0x7D`
+    ///   post-exec tx that CL embedded in the attributes, or `Disabled` if there is none. This
+    ///   holds regardless of the local opt-in, since the chain has already committed to it.
     pub fn post_exec_mode(&self) -> Result<PostExecMode, PayloadBuilderError> {
         if !self.force_empty() {
             return Ok(self.sdm_production_enabled().into());

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use crate::{OpPayloadBuilderAttributes, config::OpBuilderConfig};
 use alloy_consensus::{
-    Header, SignableTransaction, Transaction, TxEip1559, Typed2718,
+    Header, Sealable, SignableTransaction, Transaction, TxEip1559, Typed2718,
     transaction::{Recovered, TxHashRef},
 };
 use alloy_eips::{
@@ -12,14 +12,14 @@ use alloy_eips::{
     eip7702::SignedAuthorization,
 };
 use alloy_evm::RecoveredTx;
-use alloy_primitives::{Address, B256, Bytes, Signature, TxHash, TxKind, U256};
+use alloy_primitives::{Address, B64, B256, Bytes, Signature, TxHash, TxKind, U256};
 use alloy_rpc_types_eth::erc4337::TransactionConditional;
-use op_alloy_consensus::SDMGasEntry;
+use op_alloy_consensus::{SDMGasEntry, build_post_exec_tx};
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::MIN_TRANSACTION_GAS;
 use reth_evm::execute::{BlockBuilder, BlockExecutionError};
 use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
-use reth_optimism_evm::OpEvmConfig;
+use reth_optimism_evm::{OpEvmConfig, PostExecMode};
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_optimism_txpool::{
     OpPooledTransaction, OpPooledTx, conditional::MaybeConditionalTransaction,
@@ -34,6 +34,74 @@ use std::{borrow::Cow, cell::Cell, sync::Arc};
 
 fn entries(specs: &[(u64, u64)]) -> Vec<SDMGasEntry> {
     specs.iter().map(|&(index, gas_refund)| SDMGasEntry { index, gas_refund }).collect()
+}
+
+/// Wraps a block-level post-exec (`0x7D`) tx in a `WithEncoded` exactly as it would arrive in
+/// derived payload attributes (op-node embeds it into the batch).
+fn post_exec_with_encoded(
+    block_number: u64,
+    payload_entries: Vec<SDMGasEntry>,
+) -> WithEncoded<OpTransactionSigned> {
+    let tx =
+        OpTransactionSigned::from(build_post_exec_tx(block_number, payload_entries).seal_slow());
+    let encoded = Bytes::from(tx.encoded_2718());
+    WithEncoded::new(encoded, tx)
+}
+
+/// Builds a payload-builder ctx on an SDM-active (Interop/Lagoon at genesis) chain.
+///
+/// `no_tx_pool` picks local sequencing (`false`) vs rebuilding a derived block (`true`); `opt_in`
+/// sets the sequencer-only production flag; `embedded_post_exec` optionally embeds a `0x7D` tx
+/// (anchored to block 1) into the attributes, as op-node does for a derived block with refunds.
+fn interop_ctx(
+    no_tx_pool: bool,
+    opt_in: bool,
+    embedded_post_exec: Option<Vec<SDMGasEntry>>,
+) -> OpPayloadBuilderCtx<
+    OpEvmConfig<OpChainSpec, OpPrimitives>,
+    OpChainSpec,
+    OpPayloadBuilderAttributes<OpTransactionSigned>,
+> {
+    let gas_limit = 1_000_000;
+    let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().interop_activated().build());
+    let parent = SealedHeader::seal_slow(Header {
+        gas_limit,
+        number: 0,
+        timestamp: 0,
+        ..Default::default()
+    });
+    // Parent is block 0, so the block being built — and any embedded payload — anchors to block 1.
+    let transactions =
+        embedded_post_exec.map(|e| vec![post_exec_with_encoded(1, e)]).unwrap_or_default();
+    let attributes = OpPayloadBuilderAttributes {
+        timestamp: 1,
+        gas_limit: Some(gas_limit),
+        no_tx_pool,
+        transactions,
+        // Holocene/Jovian are active under Interop; supply default EIP-1559 params (zero means
+        // "use chain defaults", matching op-node) so next-env construction succeeds.
+        eip_1559_params: Some(B64::ZERO),
+        min_base_fee: Some(0),
+        ..Default::default()
+    };
+    let builder_config = OpBuilderConfig::default();
+    if opt_in {
+        builder_config.sdm_post_exec_opt_in.set(true);
+    }
+
+    OpPayloadBuilderCtx {
+        evm_config: OpEvmConfig::optimism(chain_spec.clone()),
+        builder_config,
+        chain_spec,
+        config: PayloadConfig {
+            parent_header: Arc::new(parent),
+            parent_block_info: None,
+            payload_id: attributes.id,
+            attributes,
+        },
+        cancel: Default::default(),
+        best_payload: None,
+    }
 }
 
 fn unwrap_post_exec(tx: Recovered<OpTransactionSigned>) -> (u8, u64, Vec<SDMGasEntry>) {
@@ -156,6 +224,66 @@ where
         .collect();
 
     (info, included_tx_hashes)
+}
+
+/// The opt-in is a sequencer-only control: a following node verifies the embedded `0x7D` whatever
+/// the flag, and only local sequencing consults it. Pins [`OpPayloadBuilderCtx::post_exec_mode`].
+#[test]
+fn post_exec_mode_follows_chain_regardless_of_opt_in() {
+    // Follow path with an embedded 0x7D: Verify for either opt-in value.
+    for opt_in in [false, true] {
+        let ctx = interop_ctx(true, opt_in, Some(entries(&[(0, 7)])));
+        let PostExecMode::Verify(payload) = ctx.post_exec_mode().expect("mode resolves") else {
+            panic!("expected Verify mode on the follow path with opt_in={opt_in}");
+        };
+        assert_eq!(payload.block_number, 1);
+        assert_eq!(payload.gas_refund_entries, entries(&[(0, 7)]));
+    }
+
+    // Follow path with no embedded 0x7D: disabled even with the opt-in on (nothing to reproduce).
+    assert!(matches!(
+        interop_ctx(true, true, None).post_exec_mode().expect("mode resolves"),
+        PostExecMode::Disabled
+    ));
+
+    // Local sequencing is the only path that consults the opt-in.
+    assert!(matches!(
+        interop_ctx(false, true, None).post_exec_mode().expect("mode resolves"),
+        PostExecMode::Produce
+    ));
+    assert!(matches!(
+        interop_ctx(false, false, None).post_exec_mode().expect("mode resolves"),
+        PostExecMode::Disabled
+    ));
+}
+
+/// End-to-end regression test for the derived-attrs verify path: rebuilding a block whose
+/// attributes embed a `0x7D` (`no_tx_pool = true`) must succeed for either opt-in value.
+///
+/// `block_builder()` previously picked the mode from the opt-in alone (never `Verify`), so with
+/// the opt-in off the executor fatally rejected the embedded `0x7D` ("unexpected post-exec tx ...
+/// SDM not active") and a verifier could not reproduce the block. Empty entries keep the fixture
+/// deterministic; the executor's own tests cover refund-matching.
+#[test]
+fn rebuilds_derived_block_with_embedded_post_exec_tx_regardless_of_opt_in() {
+    for opt_in in [false, true] {
+        let ctx = interop_ctx(true, opt_in, Some(Vec::new()));
+
+        let state_provider = StateProviderTest::default();
+        let mut db = State::builder()
+            .with_database(StateProviderDatabase::new(&state_provider))
+            .with_bundle_update()
+            .build();
+        let mut builder = ctx.block_builder(&mut db).expect("block builder can be created");
+
+        let result = ctx.execute_sequencer_transactions(&mut builder, None);
+
+        assert!(
+            result.is_ok(),
+            "rebuilding a derived block whose attributes embed a 0x7D post-exec tx must succeed \
+             in Verify mode (opt_in={opt_in}); got {result:?}",
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes reproducing the trailing SDM PostExec tx (`0x7D`) when rebuilding a derived block. OP consensus requires at most one PostExec tx, and it must be last.

### op-reth — derived-block rebuild
Rebuilding a derived block via FCU-with-attributes (`no_tx_pool=true`) picked the post-exec mode from the local SDM opt-in alone and never `Verify`. A verifier (opt-in off) hit `Disabled` mode and rejected the embedded `0x7D` (`"unexpected post-exec tx … SDM not active"`), stalling its safe head; with opt-in on it double-appended. `OpPayloadBuilderCtx::post_exec_mode()` now verifies against the embedded payload regardless of the opt-in (a sequencer-only control), and appends only when locally producing.

### Tests
- op-reth unit tests: `post_exec_mode_follows_chain_regardless_of_opt_in`, `rebuilds_derived_block_with_embedded_post_exec_tx_regardless_of_opt_in`.
- acceptance: `TestSDMPostExecBlockDerivesOnIsolatedVerifier` isolates the verifier from L2 P2P (new `IsolateFromL2P2P` devstack flag) so it must derive + force-build the PostExec block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
