### PR TITLE
op-reth: activate implied L1 forks in OpChainSpecBuilder *_activated() helpers

### DIFF
--- a/rust/op-reth/crates/chainspec/src/lib.rs
+++ b/rust/op-reth/crates/chainspec/src/lib.rs
@@ -190,6 +190,8 @@ impl OpChainSpecBuilder {
     /// Enable Isthmus at genesis
     pub fn isthmus_activated(mut self) -> Self {
         self = self.holocene_activated();
+        // Isthmus also activates changes from L1's Prague hardfork
+        self.inner = self.inner.with_fork(EthereumHardfork::Prague, ForkCondition::Timestamp(0));
         self.inner = self.inner.with_fork(OpHardfork::Isthmus, ForkCondition::Timestamp(0));
         self
     }
@@ -204,6 +206,8 @@ impl OpChainSpecBuilder {
     /// Enable Karst at genesis
     pub fn karst_activated(mut self) -> Self {
         self = self.jovian_activated();
+        // Karst also activates changes from L1's Osaka hardfork
+        self.inner = self.inner.with_fork(EthereumHardfork::Osaka, ForkCondition::Timestamp(0));
         self.inner = self.inner.with_fork(OpHardfork::Karst, ForkCondition::Timestamp(0));
         self
     }
@@ -401,6 +405,7 @@ impl From<Genesis> for OpChainSpec {
             (EthereumHardfork::Shanghai.boxed(), genesis_info.canyon_time),
             (EthereumHardfork::Cancun.boxed(), genesis_info.ecotone_time),
             (EthereumHardfork::Prague.boxed(), genesis_info.isthmus_time),
+            (EthereumHardfork::Osaka.boxed(), genesis_info.karst_time),
             // OP
             (OpHardfork::Regolith.boxed(), genesis_info.regolith_time),
             (OpHardfork::Canyon.boxed(), genesis_info.canyon_time),
@@ -912,6 +917,104 @@ mod tests {
     fn is_bedrock_active() {
         let op_mainnet = OpChainSpecBuilder::optimism_mainnet().build();
         assert!(!op_mainnet.is_bedrock_active_at_block(1))
+    }
+
+    /// Each `*_activated()` builder helper must activate the L1 (Ethereum) hardfork its OP fork
+    /// implies, exactly as the genesis `From<Genesis>` conversion does. Guards against a future
+    /// fork silently shipping without its L1 fork — the gap that left Isthmus without Prague.
+    #[test]
+    fn builder_activated_specs_match_genesis_l1_forks() {
+        // Builder spec with every OP fork (through Lagoon) active at genesis.
+        let builder_spec = OpChainSpecBuilder::optimism_mainnet().interop_activated().build();
+
+        // Equivalent genesis: every OP fork active at timestamp 0. `From<Genesis>` derives the
+        // implied L1 forks (Shanghai/Cancun/Prague/Osaka) from these OP timestamps.
+        let geth_genesis = r#"
+        {
+            "config": {
+                "chainId": 10,
+                "homesteadBlock": 0,
+                "eip150Block": 0,
+                "eip155Block": 0,
+                "eip158Block": 0,
+                "byzantiumBlock": 0,
+                "constantinopleBlock": 0,
+                "petersburgBlock": 0,
+                "istanbulBlock": 0,
+                "muirGlacierBlock": 0,
+                "berlinBlock": 0,
+                "londonBlock": 0,
+                "arrowGlacierBlock": 0,
+                "grayGlacierBlock": 0,
+                "mergeNetsplitBlock": 0,
+                "bedrockBlock": 0,
+                "regolithTime": 0,
+                "canyonTime": 0,
+                "ecotoneTime": 0,
+                "fjordTime": 0,
+                "graniteTime": 0,
+                "holoceneTime": 0,
+                "isthmusTime": 0,
+                "jovianTime": 0,
+                "karstTime": 0,
+                "lagoonTime": 0,
+                "terminalTotalDifficulty": 0,
+                "terminalTotalDifficultyPassed": true,
+                "optimism": {
+                    "eip1559Elasticity": 6,
+                    "eip1559Denominator": 50
+                }
+            }
+        }
+        "#;
+        let genesis: Genesis = serde_json::from_str(geth_genesis).unwrap();
+        let genesis_spec = OpChainSpec::from_genesis(genesis);
+
+        // Builder- and genesis-built specs must agree on every OP fork and the L1 fork it implies.
+        macro_rules! assert_parity {
+            ($fork:expr) => {
+                assert_eq!(
+                    builder_spec.hardforks.get($fork),
+                    genesis_spec.hardforks.get($fork),
+                    "builder vs genesis disagree on {:?}",
+                    $fork
+                );
+            };
+        }
+
+        assert_parity!(OpHardfork::Regolith);
+        assert_parity!(OpHardfork::Canyon);
+        assert_parity!(EthereumHardfork::Shanghai);
+        assert_parity!(OpHardfork::Ecotone);
+        assert_parity!(EthereumHardfork::Cancun);
+        assert_parity!(OpHardfork::Fjord);
+        assert_parity!(OpHardfork::Granite);
+        assert_parity!(OpHardfork::Holocene);
+        assert_parity!(OpHardfork::Isthmus);
+        assert_parity!(EthereumHardfork::Prague);
+        assert_parity!(OpHardfork::Jovian);
+        assert_parity!(OpHardfork::Karst);
+        assert_parity!(EthereumHardfork::Osaka);
+        assert_parity!(OpHardfork::Lagoon);
+
+        // Pin the invariant directly on the builder spec: every implied L1 fork is active at
+        // genesis.
+        assert_eq!(
+            builder_spec.hardforks.get(EthereumHardfork::Shanghai),
+            Some(ForkCondition::Timestamp(0))
+        );
+        assert_eq!(
+            builder_spec.hardforks.get(EthereumHardfork::Cancun),
+            Some(ForkCondition::Timestamp(0))
+        );
+        assert_eq!(
+            builder_spec.hardforks.get(EthereumHardfork::Prague),
+            Some(ForkCondition::Timestamp(0))
+        );
+        assert_eq!(
+            builder_spec.hardforks.get(EthereumHardfork::Osaka),
+            Some(ForkCondition::Timestamp(0))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

In `OpChainSpecBuilder`, the `*_activated()` helpers enable an OP hardfork and the earlier ones also enable the Ethereum (L1) hardfork that the OP fork implies (`canyon_activated` → Shanghai, `ecotone_activated` → Cancun). `isthmus_activated()` broke this pattern: it activated `OpHardfork::Isthmus` but **not** `EthereumHardfork::Prague`. So specs built via `isthmus_activated()` / `jovian_activated()` / `karst_activated()` / `interop_activated()` ended up with the OP fork active but Prague inactive — an inconsistent state the genesis-based `From<Genesis>` path never produces, which breaks validation (e.g. `requests present in pre-prague payload`).

## Changes

- `isthmus_activated()` now also activates `EthereumHardfork::Prague` at `Timestamp(0)` (Isthmus implies Prague), mirroring `ecotone_activated()` → Cancun.
- `karst_activated()` now also activates `EthereumHardfork::Osaka` at `Timestamp(0)` (Karst implies Osaka).
- Added the missing `(EthereumHardfork::Osaka, karst_time)` mapping to the `From<Genesis>` conversion, so the genesis path activates Osaka with Karst — keeping the builder and genesis paths consistent with each other and with op-revm `into_eth_spec` (`KARST | INTEROP => OSAKA`) and the superchain config path (`osaka_time = karst_time`).

The other helpers are already correct: fjord/granite/holocene imply Cancun (active via ecotone); jovian implies Prague (inherited from isthmus); interop/lagoon imply Osaka (inherited from karst). No L1 fork is added where the OP fork doesn't start implying a *new* L1 fork.

## Fork-id safety

`Osaka` activates at the same timestamp as `Karst`, so the two collapse to a single fork boundary (exactly as Prague+Isthmus do today) — no fork-id change for existing chains. `test_fork_order_optimism_mainnet` and the base/op mainnet+sepolia fork-id tests all still pass.

## Test

Added `builder_activated_specs_match_genesis_l1_forks`, asserting builder `*_activated()` specs match the equivalent genesis-activated specs fork-for-fork, so a future fork can't silently reintroduce the gap. Verified red→green (reverting the fix makes it fail with "builder vs genesis disagree on Prague").

Full local run (all green): `reth-optimism-chainspec`, `-consensus`, `-evm`, `-payload-builder`, `-rpc`, `-trie`, `-txpool`, `-node` (incl. the e2e `test_testsuite_op_assert_mine_block_isthmus_activated`); `cargo +nightly fmt --check` and `cargo clippy --all-features --all-targets -- -D warnings` clean.

Fixes #21239

🤖 Generated with [Claude Code](https://claude.com/claude-code)