### PR TITLE
fix(op-rbuilder): append trailing SDM PostExec tx in the standard builder

### DIFF
--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
@@ -197,6 +197,14 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
         &self.config.attributes
     }
 
+    /// Returns true when the tx pool is excluded and the block must be reproduced
+    /// deterministically from forced transactions only (i.e. `no_tx_pool = true`).
+    ///
+    /// Mirrors op-reth's `force_empty` for cross-builder consistency.
+    pub fn force_empty(&self) -> bool {
+        self.attributes().no_tx_pool
+    }
+
     /// Returns the withdrawals if shanghai is active.
     pub fn withdrawals(&self) -> Option<&Withdrawals> {
         self.chain_spec

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
@@ -1,4 +1,4 @@
-use alloy_consensus::{Transaction, conditional::BlockConditionalAttributes};
+use alloy_consensus::{Sealable, Transaction, conditional::BlockConditionalAttributes};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_evm::{
     Database, Evm as AlloyEvm,
@@ -8,6 +8,7 @@ use alloy_op_evm::PreRefundGasUsed;
 use alloy_primitives::{BlockHash, Bytes, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use core::fmt::Debug;
+use op_alloy_consensus::{SDMGasEntry, build_post_exec_tx};
 use op_revm::{L1BlockInfo, OpSpecId};
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
@@ -109,6 +110,26 @@ pub(super) fn compute_post_exec_mode(
     } else {
         PostExecMode::Disabled
     }
+}
+
+/// Builds the canonical PostExec (`0x7D`) tx for the block being built, or `None` when the
+/// builder is not producing or there is nothing to refund — producers never emit an
+/// empty-entries PostExec tx. Shared by the standard and flashblocks builders so the
+/// produce-side rules live in one place.
+pub(super) fn build_current_post_exec_tx<ExtraCtx>(
+    ctx: &OpPayloadBuilderCtx<ExtraCtx>,
+    entries: Vec<SDMGasEntry>,
+) -> Option<OpTransactionSigned>
+where
+    ExtraCtx: Debug + Default,
+{
+    if !matches!(ctx.post_exec_mode, PostExecMode::Produce) || entries.is_empty() {
+        return None;
+    }
+
+    Some(OpTransactionSigned::from(
+        build_post_exec_tx(ctx.block_number(), entries).seal_slow(),
+    ))
 }
 
 /// Container type that holds all necessities to build a new payload.

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -4,8 +4,8 @@ use crate::{
         BuilderConfig,
         builder_tx::BuilderTransactions,
         context::{
-            BlockBuilderStateDbExt, OpPayloadBuilderCtx, compute_post_exec_mode,
-            last_receipt_with_cumulative_gas,
+            BlockBuilderStateDbExt, OpPayloadBuilderCtx, build_current_post_exec_tx,
+            compute_post_exec_mode, last_receipt_with_cumulative_gas,
         },
         flashblocks::{best_txs::BestFlashblocksTxs, config::FlashBlocksConfigExt},
         generator::{BlockCell, BuildArguments, PayloadBuilder},
@@ -16,7 +16,7 @@ use crate::{
     traits::{ClientBounds, PoolBounds},
 };
 use alloy_consensus::{
-    BlockBody, EMPTY_OMMER_ROOT_HASH, Header, Sealable, constants::EMPTY_WITHDRAWALS, proofs,
+    BlockBody, EMPTY_OMMER_ROOT_HASH, Header, constants::EMPTY_WITHDRAWALS, proofs,
 };
 use alloy_eips::{Encodable2718, eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
 use alloy_evm::block::BlockExecutor as AlloyBlockExecutor;
@@ -24,7 +24,7 @@ use alloy_op_evm::PreRefundGasUsed;
 use alloy_primitives::{Address, B256, U256, map::foldhash::HashMap};
 use core::time::Duration;
 use eyre::WrapErr as _;
-use op_alloy_consensus::{SDMGasEntry, build_post_exec_tx};
+use op_alloy_consensus::SDMGasEntry;
 use reth_basic_payload_builder::{BuildOutcome, PayloadConfig};
 use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
@@ -1220,22 +1220,6 @@ where
         gas_used,
         post_exec_tx,
     })
-}
-
-fn build_current_post_exec_tx<ExtraCtx>(
-    ctx: &OpPayloadBuilderCtx<ExtraCtx>,
-    entries: Vec<SDMGasEntry>,
-) -> Option<OpTransactionSigned>
-where
-    ExtraCtx: std::fmt::Debug + Default,
-{
-    if !matches!(ctx.post_exec_mode, PostExecMode::Produce) || entries.is_empty() {
-        return None;
-    }
-
-    Some(OpTransactionSigned::from(
-        build_post_exec_tx(ctx.block_number(), entries).seal_slow(),
-    ))
 }
 
 #[allow(clippy::type_complexity)]

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/standard/payload.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/standard/payload.rs
@@ -466,7 +466,7 @@ impl<Txs: PayloadTxsBounds> OpBuilder<'_, Txs> {
         // empty entries → no tx, zero-address sender, appended last (consensus requires at most
         // one PostExec tx, in the final position). A derived block (`no_tx_pool`) must reproduce
         // exactly the attribute transactions, so never append one there.
-        if matches!(ctx.post_exec_mode, PostExecMode::Produce) && !ctx.attributes().no_tx_pool {
+        if matches!(ctx.post_exec_mode, PostExecMode::Produce) && !ctx.force_empty() {
             let entries = builder.executor_mut().take_post_exec_entries();
             if let Some(post_exec_tx) = build_current_post_exec_tx(ctx, entries) {
                 let gas_output = builder.execute_transaction(Recovered::new_unchecked(

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/standard/payload.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/standard/payload.rs
@@ -1,4 +1,7 @@
-use super::super::context::{OpPayloadBuilderCtx, compute_post_exec_mode};
+use super::super::context::{
+    OpPayloadBuilderCtx, build_current_post_exec_tx, compute_post_exec_mode,
+    last_receipt_with_cumulative_gas,
+};
 use crate::{
     builders::{BuilderConfig, BuilderTransactions, generator::BuildArguments},
     gas_limiter::AddressGasLimiter,
@@ -11,20 +14,20 @@ use alloy_consensus::{
 };
 use alloy_eips::{eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
 use alloy_evm::Database;
-use alloy_primitives::U256;
+use alloy_primitives::{Address, U256};
 use reth_basic_payload_builder::{BuildOutcome, BuildOutcomeKind, MissingPayloadBehaviour};
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult};
 use reth_node_api::{Block, PayloadBuilderError};
 use reth_optimism_consensus::{calculate_receipt_root_no_memo_optimism, isthmus};
-use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
+use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes, PostExecExecutorExt, PostExecMode};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{OpBuiltPayload, OpPayloadBuilderAttributes};
 use reth_optimism_payload_builder::OpPayloadAttrs;
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_payload_primitives::BuiltPayloadExecutedBlock;
 use reth_payload_util::{BestPayloadTransactions, NoopPayloadTransactions, PayloadTransactions};
-use reth_primitives_traits::{InMemorySize, RecoveredBlock};
+use reth_primitives_traits::{InMemorySize, Recovered, RecoveredBlock};
 use reth_provider::{ExecutionOutcome, StateProvider};
 use reth_revm::{
     State, database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
@@ -453,6 +456,32 @@ impl<Txs: PayloadTxsBounds> OpBuilder<'_, Txs> {
         {
             error!(target: "payload_builder", "Error adding builder txs to fallback block: {}", e);
         };
+
+        // Materialize the canonical SDM PostExec (`0x7D`) tx when producing. The executor has
+        // applied refund settlement to state and receipts throughout the build, and a verifier
+        // re-executes the block with the mode derived from the block's own transactions — without
+        // the trailing PostExec tx carrying the refund entries it runs with SDM disabled and
+        // computes a different state root. Same produce-side rules as op-reth's
+        // `try_include_post_exec_tx` and the flashblocks builder's `materialize_post_exec`:
+        // empty entries → no tx, zero-address sender, appended last (consensus requires at most
+        // one PostExec tx, in the final position). A derived block (`no_tx_pool`) must reproduce
+        // exactly the attribute transactions, so never append one there.
+        if matches!(ctx.post_exec_mode, PostExecMode::Produce) && !ctx.attributes().no_tx_pool {
+            let entries = builder.executor_mut().take_post_exec_entries();
+            if let Some(post_exec_tx) = build_current_post_exec_tx(ctx, entries) {
+                let gas_output = builder.execute_transaction(Recovered::new_unchecked(
+                    post_exec_tx.clone(),
+                    Address::ZERO,
+                ))?;
+                info.cumulative_gas_used += gas_output.tx_gas_used();
+                let receipt =
+                    last_receipt_with_cumulative_gas(builder.executor(), info.cumulative_gas_used)
+                        .expect("executor must record a receipt for the post-exec tx");
+                info.executed_transactions.push(post_exec_tx);
+                info.executed_senders.push(Address::ZERO);
+                info.receipts.push(receipt);
+            }
+        }
 
         drop(builder);
 

--- a/rust/op-rbuilder/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -3,6 +3,7 @@ use crate::{
     builders::{BuilderConfig, FlashblocksBuilder, PayloadBuilder, StandardBuilder},
     primitives::reth::engine_api_builder::OpEngineApiBuilder,
     revert_protection::{EthApiExtServer, RevertProtectionExt},
+    sdm_admin::{SdmAdminApiServer, SdmAdminExt},
     tests::{
         EngineApi, Ipc, TEE_DEBUG_ADDRESS, TransactionPoolObserver, builder_signer, create_test_db,
         framework::driver::ChainDriver, get_available_port,
@@ -26,6 +27,7 @@ use http::{Request, Response, StatusCode};
 use http_body_util::Full;
 use hyper::{body::Bytes as HyperBytes, server::conn::http1, service::service_fn};
 use hyper_util::rt::TokioIo;
+use jsonrpsee::core::client::SubscriptionClientT;
 use moka::future::Cache;
 use nanoid::nanoid;
 use op_alloy_network::Optimism;
@@ -35,6 +37,7 @@ use reth::{
     core::exit::NodeExitFuture,
     tasks::Runtime,
 };
+use reth_chainspec::ChainSpecProvider;
 use reth_node_builder::{NodeBuilder, NodeConfig};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_cli::commands::Commands;
@@ -112,6 +115,7 @@ impl LocalInstance {
             .expect("Failed to convert rollup args to builder config");
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
+        let sdm_post_exec_opt_in = builder_config.sdm_post_exec_opt_in.clone();
 
         let addons: OpAddOns<
             _,
@@ -152,6 +156,14 @@ impl LocalInstance {
                     ctx.modules
                         .add_or_replace_configured(revert_protection_ext.into_rpc())?;
                 }
+
+                // Same wiring as the production launcher: the admin namespace exposes
+                // `admin_setSdmPostExecOptIn` / `admin_sdmStatus`, sharing the opt-in flag
+                // with every payload-builder ctx.
+                let sdm_admin_ext =
+                    SdmAdminExt::new(sdm_post_exec_opt_in.clone(), ctx.provider().chain_spec());
+                ctx.modules
+                    .add_or_replace_configured(sdm_admin_ext.into_rpc())?;
 
                 Ok(())
             })
@@ -253,6 +265,16 @@ impl LocalInstance {
 
     pub fn auth_ipc(&self) -> &str {
         &self.config.rpc.auth_ipc_path
+    }
+
+    /// jsonrpsee client over the node's user-facing RPC IPC endpoint, for calling extension
+    /// namespaces (e.g. `admin_setSdmPostExecOptIn` via `SdmAdminApiClient`) in tests.
+    pub async fn rpc_client(
+        &self,
+    ) -> eyre::Result<impl SubscriptionClientT + Send + Sync + Unpin + use<>> {
+        Ok(reth_ipc::client::IpcClientBuilder::default()
+            .build(self.rpc_ipc())
+            .await?)
     }
 
     pub fn engine_api(&self) -> EngineApi<Ipc> {

--- a/rust/op-rbuilder/crates/op-rbuilder/src/tests/mod.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/tests/mod.rs
@@ -24,6 +24,9 @@ mod ordering;
 mod revert;
 
 #[cfg(test)]
+mod sdm;
+
+#[cfg(test)]
 mod smoke;
 
 #[cfg(test)]

--- a/rust/op-rbuilder/crates/op-rbuilder/src/tests/sdm.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/tests/sdm.rs
@@ -1,0 +1,154 @@
+//! SDM PostExec (`0x7D`) production tests.
+//!
+//! These run against a chain spec with Interop (Lagoon) active at genesis, so the SDM
+//! protocol gate is on and the operator opt-in (`admin_setSdmPostExecOptIn`) decides
+//! whether the builder produces the trailing PostExec tx. The driver round-trips every
+//! built payload through `newPayload` on the same node, which re-executes it with the
+//! post-exec mode derived from the block's own transactions — so a block whose state
+//! includes refund settlement but lacks the trailing `0x7D` (or carries a spurious one)
+//! fails validation with a state-root mismatch and the test errors out.
+
+use crate::{
+    sdm_admin::SdmAdminApiClient,
+    tests::{BlockTransactionsExt, LocalInstance, default_node_config},
+};
+use alloy_primitives::{Bytes, hex};
+use alloy_provider::Provider;
+use alloy_rpc_types_eth::Block;
+use macros::rb_test;
+use op_alloy_consensus::{OpTxEnvelope, PostExecPayload};
+use op_alloy_rpc_types::Transaction;
+use reth_node_builder::NodeConfig;
+use reth_optimism_chainspec::OpChainSpec;
+use std::sync::Arc;
+
+/// Init code deploying a 5-byte runtime (`PUSH1 1, PUSH0, SSTORE, STOP`) that stores `1`
+/// into slot 0 on every call. Two calls in the same block make the second call touch a
+/// slot the first already warmed, which is exactly what generates an SDM gas refund entry.
+const STORE_SLOT_ZERO_INIT_CODE: [u8; 14] = hex!("60058060095f395ff360015f5500");
+
+/// The test-framework chain spec with the SDM protocol gate (Interop/Lagoon) active at
+/// genesis. Everything else matches [`default_node_config`].
+fn sdm_node_config() -> NodeConfig<OpChainSpec> {
+    let mut genesis: serde_json::Value =
+        serde_json::from_str(include_str!("./framework/artifacts/genesis.json.tmpl"))
+            .expect("invalid genesis JSON");
+    genesis["config"]["lagoonTime"] = 0.into();
+    let chain_spec =
+        OpChainSpec::from_genesis(serde_json::from_value(genesis).expect("invalid genesis"));
+
+    NodeConfig::<OpChainSpec> {
+        chain: Arc::new(chain_spec),
+        ..default_node_config()
+    }
+}
+
+/// Returns `(tx position, decoded payload)` for every PostExec tx in the block.
+fn post_exec_txs(block: &Block<Transaction>) -> Vec<(usize, PostExecPayload)> {
+    block
+        .transactions
+        .as_transactions()
+        .expect("block must be requested with full transactions")
+        .iter()
+        .enumerate()
+        .filter_map(|(position, tx)| match tx.inner.inner.inner() {
+            OpTxEnvelope::PostExec(sealed) => Some((position, sealed.inner().payload.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+#[rb_test(config = sdm_node_config())]
+async fn post_exec_tx_follows_operator_opt_in(rbuilder: LocalInstance) -> eyre::Result<()> {
+    let driver = rbuilder.driver().await?;
+    let client = rbuilder.rpc_client().await?;
+
+    let status = client.sdm_status(None).await?;
+    assert!(
+        status.protocol_active,
+        "chain spec must have the SDM protocol gate active at genesis"
+    );
+    assert!(
+        !status.post_exec_opt_in,
+        "operator opt-in must start disabled on boot"
+    );
+
+    // Deploy the repeated-slot contract.
+    let deploy = driver
+        .create_transaction()
+        .with_create()
+        .with_input(Bytes::from_static(&STORE_SLOT_ZERO_INIT_CODE))
+        .send()
+        .await?;
+    driver.build_new_block().await?;
+    let receipt = driver
+        .provider()
+        .get_transaction_receipt(*deploy.tx_hash())
+        .await?
+        .expect("deploy receipt must exist");
+    let contract = receipt
+        .inner
+        .contract_address
+        .expect("deploy receipt must carry the contract address");
+
+    // Not opted in: the repeated-slot workload must not produce a PostExec tx even though
+    // the protocol gate is active.
+    let first = driver.create_transaction().with_to(contract).send().await?;
+    let second = driver.create_transaction().with_to(contract).send().await?;
+    let block = driver.build_new_block().await?;
+    assert!(block.includes(first.tx_hash()) && block.includes(second.tx_hash()));
+    assert!(
+        post_exec_txs(&block).is_empty(),
+        "no PostExec tx may be produced without the operator opt-in"
+    );
+
+    // Opted in: the same workload must produce exactly one PostExec tx, in the final
+    // position, anchored to this block, with refund entries pointing at earlier txs.
+    client.set_sdm_post_exec_opt_in(true).await?;
+    assert!(client.sdm_status(None).await?.effective);
+
+    let first = driver.create_transaction().with_to(contract).send().await?;
+    let second = driver.create_transaction().with_to(contract).send().await?;
+    let block = driver.build_new_block().await?;
+    assert!(block.includes(first.tx_hash()) && block.includes(second.tx_hash()));
+
+    let post_exec = post_exec_txs(&block);
+    let tx_count = block.transactions.len();
+    assert_eq!(
+        post_exec.len(),
+        1,
+        "opted-in builder must produce exactly one PostExec tx, found {post_exec:?}"
+    );
+    let (position, payload) = &post_exec[0];
+    assert_eq!(
+        *position,
+        tx_count - 1,
+        "the PostExec tx must be the last transaction in the block"
+    );
+    assert_eq!(
+        payload.block_number, block.header.number,
+        "the PostExec payload must be anchored to its block"
+    );
+    assert!(
+        !payload.gas_refund_entries.is_empty(),
+        "the repeated-slot workload must generate refund entries"
+    );
+    for entry in &payload.gas_refund_entries {
+        assert!(
+            (entry.index as usize) < *position,
+            "refund entries must reference transactions before the PostExec tx"
+        );
+    }
+
+    // Opting back out stops production again.
+    client.set_sdm_post_exec_opt_in(false).await?;
+    let first = driver.create_transaction().with_to(contract).send().await?;
+    let block = driver.build_new_block().await?;
+    assert!(block.includes(first.tx_hash()));
+    assert!(
+        post_exec_txs(&block).is_empty(),
+        "no PostExec tx may be produced after opting back out"
+    );
+
+    Ok(())
+}

--- a/rust/op-rbuilder/crates/op-rbuilder/src/tests/sdm.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/tests/sdm.rs
@@ -12,7 +12,7 @@ use crate::{
     sdm_admin::SdmAdminApiClient,
     tests::{BlockTransactionsExt, LocalInstance, default_node_config},
 };
-use alloy_primitives::{Bytes, hex};
+use alloy_primitives::Bytes;
 use alloy_provider::Provider;
 use alloy_rpc_types_eth::Block;
 use macros::rb_test;
@@ -20,12 +20,44 @@ use op_alloy_consensus::{OpTxEnvelope, PostExecPayload};
 use op_alloy_rpc_types::Transaction;
 use reth_node_builder::NodeConfig;
 use reth_optimism_chainspec::OpChainSpec;
+use revm::bytecode::opcode;
 use std::sync::Arc;
 
-/// Init code deploying a 5-byte runtime (`PUSH1 1, PUSH0, SSTORE, STOP`) that stores `1`
-/// into slot 0 on every call. Two calls in the same block make the second call touch a
-/// slot the first already warmed, which is exactly what generates an SDM gas refund entry.
-const STORE_SLOT_ZERO_INIT_CODE: [u8; 14] = hex!("60058060095f395ff360015f5500");
+/// Runtime bytecode `SSTORE(slot 0, 1); STOP` — stores `1` into slot 0 on every call.
+/// Calling the deployed contract twice in one block makes the second call write a slot the
+/// first already warmed, which is exactly the access pattern that produces an SDM gas
+/// refund entry.
+fn store_slot_zero_runtime() -> [u8; 5] {
+    [
+        opcode::PUSH1,
+        0x01,
+        opcode::PUSH0,
+        opcode::SSTORE,
+        opcode::STOP,
+    ]
+}
+
+/// Wraps `runtime` in a minimal constructor that copies it into memory and returns it,
+/// yielding init code for a `CREATE` transaction.
+fn deploy(runtime: &[u8]) -> Bytes {
+    let size = u8::try_from(runtime.len()).expect("runtime length fits in one byte");
+    let mut code = vec![
+        opcode::PUSH1,
+        size,         // size of the runtime to copy and return
+        opcode::DUP1, //   keep a second copy of size for RETURN below
+        opcode::PUSH1,
+        0,                // [patched] offset of the runtime within this code
+        opcode::PUSH0,    // destination offset 0 in memory
+        opcode::CODECOPY, // memory[0..size] = code[offset..offset + size]
+        opcode::PUSH0,    // return offset 0
+        opcode::RETURN,   // return memory[0..size] as the deployed runtime
+    ];
+    // The runtime is appended right after the constructor, so its offset is the
+    // constructor length — patch the placeholder rather than hard-coding it.
+    code[4] = u8::try_from(code.len()).expect("constructor length fits in one byte");
+    code.extend_from_slice(runtime);
+    Bytes::from(code)
+}
 
 /// The test-framework chain spec with the SDM protocol gate (Interop/Lagoon) active at
 /// genesis. Everything else matches [`default_node_config`].
@@ -77,7 +109,7 @@ async fn post_exec_tx_follows_operator_opt_in(rbuilder: LocalInstance) -> eyre::
     let deploy = driver
         .create_transaction()
         .with_create()
-        .with_input(Bytes::from_static(&STORE_SLOT_ZERO_INIT_CODE))
+        .with_input(deploy(&store_slot_zero_runtime()))
         .send()
         .await?;
     driver.build_new_block().await?;


### PR DESCRIPTION
Fixes producing the trailing SDM PostExec tx (`0x7D`) in op-rbuilder's **standard** builder. OP consensus requires at most one PostExec tx, and it must be last.

### op-rbuilder — standard builder materialization
The standard builder threaded the post-exec mode into its ctx, so in `Produce` mode the executor applied SDM refund settlement to state and post-refund gas to receipts — but unlike the flashblocks builder (`materialize_post_exec`) and op-reth (`try_include_post_exec_tx`), it never appended the PostExec tx carrying the refund entries. A verifier re-executes the block with the mode derived from the block's own transactions, finds no `0x7D`, runs with SDM disabled, and computes a different state root: every block built by an opted-in standard-mode builder was consensus-invalid. Since `SdmAdminExt` is registered regardless of builder mode, flipping `admin_setSdmPostExecOptIn` on a standard-mode builder silently bricked block production.

`OpBuilder::execute` now materializes the tx with the same produce-side rules as the other two builders, shared via the new `context::build_current_post_exec_tx` (moved out of `flashblocks/payload.rs`): empty entries → no tx, zero-address sender, appended last (after the builder tx). Derived blocks (`no_tx_pool`) never append — they must reproduce exactly the attribute transactions.

### Tests
- `post_exec_tx_follows_operator_opt_in` (standard + flashblocks variants) runs on a chain spec with Interop (Lagoon) at genesis and pins the operator opt-in contract: no PostExec tx without the opt-in, exactly one trailing PostExec tx anchored to its block with non-empty entries under a repeated-slot workload with it, and none again after opting out. The test driver round-trips every built payload through `newPayload` on the same node, so the missing append fails with a state-root mismatch — verified to fail against the unfixed builder.
- Test framework: `LocalInstance` now registers `SdmAdminExt` exactly like the production launcher and exposes an IPC `rpc_client()` for extension namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
