### PR TITLE
docs(op-challenger): dispute-game-investigator skill + investigation guide

### DIFF
--- a/.claude/agents/dispute-game-investigator.md
+++ b/.claude/agents/dispute-game-investigator.md
@@ -1,0 +1,39 @@
+---
+name: dispute-game-investigator
+description: "Read-only fault-dispute-game investigator. Given a network/factory (and optionally a game), identifies the actors, recomputes the canonical output root, classifies every claim correct-vs-invalid, diagnoses the responsible op-node, explains uncountered invalid claims via the honest-actor algorithm, and reports the bond outcome. Use when a challenger is disagreeing / doing many moves / contradicting itself, or to check whether proposals are valid and who wins the bonds."
+model: opus
+---
+
+You investigate OP Stack fault dispute games and report a grounded conclusion —
+which side is correct and why — backed by recomputed chain data.
+
+## Source of truth
+
+The full methodology lives in **[docs/ai/dispute-game-investigation.md](../../docs/ai/dispute-game-investigation.md)**. Follow it end to end:
+
+1. Identify the actors (proposer / challengers / our node), recalling that a signer
+   may be a key pool and anyone can move on any claim.
+2. Enumerate games/claims with `op-challenger list-games`/`list-claims --format json`.
+3. Establish the canonical output root (`op-chain-ops` `check-output-root` /
+   `check-super-root`, or recompute from the Isthmus header `withdrawalsRoot`).
+4. Classify every claim correct-vs-invalid via the trace-index/clamping math.
+5. Diagnose the responsible op-node with `op-challenger/scripts/game-proposal-outputs.sh`
+   (output root + safe head at each game's `l1Head`) and `check-game-block-hashes.sh`;
+   check each load-balancer backend individually.
+6. Explain uncountered invalid claims via the honest-actor algorithm
+   (`op-challenger/game/fault/solver/solver.go` `shouldCounter`) — usually correct
+   behavior, not a bug.
+7. Work out the bond outcome from `claimData[i].bond` and the leftmost-uncountered-
+   child rule in `FaultDisputeGame.sol`.
+
+## Boundary
+
+Strictly read-only. Never make moves, resolve, `resolveClaim`, fund a signer, or
+restart/stop a challenger, and never mutate infra. Recommend actions for humans; do
+not take them.
+
+## Output
+
+A concise report: the conclusion (which side is correct and why), the evidence
+(recomputed roots, node diagnosis), the bond outcome, and recommended human action.
+If the conclusion implicates our own node/challenger, say so plainly.

--- a/.claude/agents/dispute-game-investigator.md
+++ b/.claude/agents/dispute-game-investigator.md
@@ -1,11 +1,14 @@
 ---
 name: dispute-game-investigator
-description: "Read-only fault-dispute-game investigator. Given a network/factory (and optionally a game), identifies the actors, recomputes the canonical output root, classifies every claim correct-vs-invalid, diagnoses the responsible op-node, explains uncountered invalid claims via the honest-actor algorithm, and reports the bond outcome. Use when a challenger is disagreeing / doing many moves / contradicting itself, or to check whether proposals are valid and who wins the bonds."
+description: "Read-only fault-dispute-game investigator that runs a FULL end-to-end analysis and produces a written report: identifies the actors, recomputes the canonical output root, classifies every claim correct-vs-invalid, diagnoses the responsible op-node, verifies uncountered invalid claims against the honest-actor algorithm, and reports the bond outcome. Use for a complete written analysis of a game (or a chain's in-progress games); for live Q&A during an incident use the dispute-game-investigator skill instead."
 model: opus
 ---
 
-You investigate OP Stack fault dispute games and report a grounded conclusion —
-which side is correct and why — backed by recomputed chain data.
+You run a **complete** investigation of an OP Stack fault dispute game (or a chain's
+in-progress games) and produce a written report. Unlike the interactive
+`dispute-game-investigator` skill — which answers a specific question using only the
+relevant steps — you run the full pass end to end (including the bond outcome) and don't
+stop at the first answer.
 
 ## Source of truth
 
@@ -34,6 +37,8 @@ not take them.
 
 ## Output
 
-A concise report: the conclusion (which side is correct and why), the evidence
-(recomputed roots, node diagnosis), the bond outcome, and recommended human action.
-If the conclusion implicates our own node/challenger, say so plainly.
+A complete report covering every step: the conclusion (which side is correct and why),
+the evidence (recomputed roots, node diagnosis), any uncountered invalid claims and
+whether each is honest-actor-expected or a missed counter, the bond outcome, and
+recommended human action. If the conclusion implicates our own node/challenger, say so
+plainly.

--- a/.claude/agents/dispute-game-investigator.md
+++ b/.claude/agents/dispute-game-investigator.md
@@ -14,8 +14,8 @@ The full methodology lives in **[docs/ai/dispute-game-investigation.md](../../do
 1. Identify the actors (proposer / challengers / our node), recalling that a signer
    may be a key pool and anyone can move on any claim.
 2. Enumerate games/claims with `op-challenger list-games`/`list-claims --format json`.
-3. Establish the canonical output root (`op-chain-ops` `check-output-root` /
-   `check-super-root`, or recompute from the Isthmus header `withdrawalsRoot`).
+3. Establish the canonical output root with `op-chain-ops` `check-output-root` /
+   `check-super-root` (EL-only, work against public nodes).
 4. Classify every claim correct-vs-invalid via the trace-index/clamping math.
 5. Diagnose the responsible op-node with `op-challenger/scripts/game-proposal-outputs.sh`
    (output root + safe head at each game's `l1Head`) and `check-game-block-hashes.sh`;

--- a/.claude/skills/dispute-game-investigator/SKILL.md
+++ b/.claude/skills/dispute-game-investigator/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: dispute-game-investigator
+description: Investigate an OP Stack fault dispute game — why a challenger is disagreeing, doing a lot of moves, or contradicting itself; whether a proposal is valid; which node is at fault; and who wins the bonds. Read-only.
+---
+
+# Dispute Game Investigator
+
+## When to Use
+
+- A challenger is disagreeing with a proposal or another challenger, performing many
+  moves, or contradicting itself (posting both roots / attacking its own claims).
+- You need to know whether the in-progress proposals for a chain are valid.
+- You need to diagnose which op-node is responsible, or work out the bond outcome.
+
+## Guide
+
+@docs/ai/dispute-game-investigation.md
+
+## Tooling
+
+- `op-challenger list-games`/`list-claims --format json` — enumerate games/claims.
+- `op-chain-ops/cmd/check-output-root` and `check-super-root` — canonical output root.
+- `op-challenger/scripts/game-proposal-outputs.sh` — per-game `outputAtBlock` +
+  `safeHeadAtL1Block` from a node (spots an incomplete safe-head DB).
+- `op-challenger/scripts/check-game-block-hashes.sh` — block-hash cross-check, node vs
+  reference.
+
+Read-only: investigate and explain; never make moves, resolve, fund, or restart a
+challenger.

--- a/.claude/skills/dispute-game-investigator/SKILL.md
+++ b/.claude/skills/dispute-game-investigator/SKILL.md
@@ -1,16 +1,26 @@
 ---
 name: dispute-game-investigator
-description: Investigate an OP Stack fault dispute game — why a challenger is disagreeing, doing a lot of moves, or contradicting itself; whether a proposal is valid; which node is at fault; and who wins the bonds. Read-only.
+description: Investigate an OP Stack fault dispute game during (or after) an incident — answer the user's questions and diagnose: why a challenger is disagreeing, doing a lot of moves, or contradicting itself; whether a proposal is valid; which op-node is at fault; and (after the fact) who wins the bonds. Read-only.
 ---
 
 # Dispute Game Investigator
 
 ## When to Use
 
-- A challenger is disagreeing with a proposal or another challenger, performing many
-  moves, or contradicting itself (posting both roots / attacking its own claims).
-- You need to know whether the in-progress proposals for a chain are valid.
-- You need to diagnose which op-node is responsible, or work out the bond outcome.
+- **During an incident**, to answer questions and diagnose: a challenger disagreeing
+  with a proposal or another challenger, performing many moves, or contradicting itself;
+  whether the in-progress proposals are valid; which op-node is responsible.
+- **After the fact**, for specifics like the bond outcome.
+
+## How to use it
+
+Answer the user's actual question using only the **relevant** parts of the guide — you do
+not need to run every step. Triage first (which game(s)? whose node? valid or not?) and pull
+in only what bears on the question; some parts are situational (e.g. the bond outcome in §7 is
+usually a post-incident question, not live triage). For a full end-to-end written analysis,
+use the **`dispute-game-investigator` agent** instead.
+
+Read-only: investigate and explain; never make moves, resolve, fund, or restart a challenger.
 
 ## Guide
 
@@ -22,8 +32,4 @@ description: Investigate an OP Stack fault dispute game — why a challenger is 
 - `op-chain-ops/cmd/check-output-root` and `check-super-root` — canonical output root (EL-only, work against public nodes).
 - `op-challenger/scripts/game-proposal-outputs.sh` — per-game `outputAtBlock` +
   `safeHeadAtL1Block` from a node (spots an incomplete safe-head DB).
-- `op-challenger/scripts/check-game-block-hashes.sh` — block-hash cross-check, node vs
-  reference.
-
-Read-only: investigate and explain; never make moves, resolve, fund, or restart a
-challenger.
+- `op-challenger/scripts/check-game-block-hashes.sh` — block-hash cross-check, node vs reference.

--- a/.claude/skills/dispute-game-investigator/SKILL.md
+++ b/.claude/skills/dispute-game-investigator/SKILL.md
@@ -19,7 +19,7 @@ description: Investigate an OP Stack fault dispute game — why a challenger is 
 ## Tooling
 
 - `op-challenger list-games`/`list-claims --format json` — enumerate games/claims.
-- `op-chain-ops/cmd/check-output-root` and `check-super-root` — canonical output root.
+- `op-chain-ops/cmd/check-output-root` and `check-super-root` — canonical output root (EL-only, work against public nodes).
 - `op-challenger/scripts/game-proposal-outputs.sh` — per-game `outputAtBlock` +
   `safeHeadAtL1Block` from a node (spots an incomplete safe-head DB).
 - `op-challenger/scripts/check-game-block-hashes.sh` — block-hash cross-check, node vs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ More detailed guidance for AI agents can be found in:
 - [docs/ai/ci-ops.md](docs/ai/ci-ops.md) - CI/CD operations
 - [docs/ai/ci-config-review.md](docs/ai/ci-config-review.md) - Reviewing changes to CI config (`.circleci/`, `.github/workflows/`): gate coverage, required checks, path filtering, caching, plus general CircleCI/GHA best practices
 - [docs/ai/contract-dev.md](docs/ai/contract-dev.md) - Smart contract development
+- [docs/ai/dispute-game-investigation.md](docs/ai/dispute-game-investigation.md) - Investigating fault dispute games: challenger disagreements, excessive moves, self-contradiction, proposal validity, diagnosing the responsible op-node, and the bond outcome (read-only)
 - [docs/ai/flake-prevention.md](docs/ai/flake-prevention.md) - Guidance for preventing flaky tests
 - [docs/ai/go-dev.md](docs/ai/go-dev.md) - Go service development
 - [docs/ai/rust-dev.md](docs/ai/rust-dev.md) - Rust development (kona, op-reth, alloy crates)

--- a/docs/ai/dispute-game-investigation.md
+++ b/docs/ai/dispute-game-investigation.md
@@ -1,0 +1,136 @@
+# Investigating fault dispute games
+
+How to investigate an OP Stack fault dispute game when something looks wrong — a
+challenger **disagreeing** with a proposal or another challenger, **performing a
+lot of moves**, **contradicting itself** (posting both roots / attacking its own
+claims), or when you need to know whether a proposal is **valid** and who will win
+the bonds. The goal is a conclusion about *which side is correct and why*, grounded
+in recomputed chain data.
+
+This is **read-only**: investigate and explain; never `move`, `resolve`,
+`resolveClaim`, `create`, fund a signer, or restart/stop a challenger.
+
+## What you need
+
+- **L1 EL RPC** (the games live on L1).
+- **An L2 EL RPC** for the chain — to recompute output roots from block headers.
+- **The chain's op-node rollup RPC** (ideal) — `optimism_outputAtBlock`,
+  `optimism_safeHeadAtL1Block`, `optimism_syncStatus`. Often cluster-internal.
+- `op-challenger` built locally: `go build -o /tmp/op-challenger ./op-challenger/cmd`.
+
+## 1. Identify the actors
+
+Addresses alone don't tell you who is who, and a single logical actor may use a
+**key pool** (several EOAs). In a fault game *anyone* can attack or defend *any*
+claim — the chess-clock parity is by depth, not by address. Resolve roles from
+deployment/config (e.g. the chain's proposer and challenger addresses, and the
+`DisputeGameFactoryProxy` from the superchain-registry).
+
+## 2. Enumerate games and claims
+
+```bash
+op-challenger list-games  --game-factory-address <factory> --l1-eth-rpc <l1> --format json
+op-challenger list-claims --game-address <game>            --l1-eth-rpc <l1> --format json
+```
+
+Use `--format json` for reliable parsing (full values, exact bonds, structured
+resolution fields). In the text view the `Value` column is `Hash.TerminalString()`
+(first+last 3 bytes), so the *same* short hash repeating across positions means the
+*same* output root (clamping — see below).
+
+## 3. Establish the canonical output root (ground truth)
+
+Prefer the existing tooling:
+
+```bash
+go run ./op-chain-ops/cmd/check-output-root --help   # output-root games
+go run ./op-chain-ops/cmd/check-super-root  --help    # super-root games
+```
+
+If you only have a public EL RPC (no archive / no `eth_getProof`), recompute from
+the **block header** — on Isthmus the header `withdrawalsRoot` **equals** the
+L2ToL1MessagePasser storage root:
+
+```
+outputRoot = keccak256( version(32×0) ‖ stateRoot ‖ withdrawalsRoot ‖ blockHash )
+```
+
+i.e. `eth.OutputRoot(&eth.OutputV0{StateRoot, MessagePasserStorageRoot: header.withdrawalsRoot, BlockHash})`.
+Needs only `eth_getBlockByNumber`, no archive node.
+
+## 4. Classify every claim (correct vs invalid)
+
+Map a claim's position to its L2 block, then compare its value to canonical:
+
+- `traceIdx = (idxAtDepth+1)·2^(splitDepth−depth) − 1` (depth ≤ split depth).
+- attack child `= t − 2^(splitDepth−d−1)`; defend child `= t + 2^(splitDepth−d−1)`.
+- `block = rangeStart + traceIdx + 1`, **clamped** at the claimed L2 block.
+- Beyond the chain tip every position clamps to the final output root (why one hash
+  repeats). A claim is **invalid** iff its value ≠ canonical(block).
+
+## 5. Diagnose the responsible op-node
+
+If two parties disagree, at least one node is wrong. Compare nodes with the bundled
+scripts (`op-challenger/scripts/`, chain-agnostic, `curl` + `python3`):
+
+- **`game-proposal-outputs.sh <rollup-rpc> <l1-rpc> --factory <addr>`** — per game,
+  prints the node's `optimism_outputAtBlock` *and* `optimism_safeHeadAtL1Block` at the
+  game's `l1Head`. **Identical output roots but a safe head BELOW the proposed block**
+  is the fingerprint of an **incomplete safe-head DB / lagging node**: the challenger
+  clamps the max valid L2 block to its safe head and disputes everything beyond it.
+- **`check-game-block-hashes.sh <node-rpc> <ref-rpc> <blocks…>`** — confirms a node is
+  on canonical history for the proposal blocks (a mismatch = real divergence).
+
+Behind a **load balancer, check each backend individually** — one bad backend
+produces intermittent, contradictory behavior (a single challenger emitting *both*
+roots and attacking its own claims). A clean cross-check: every claim's value should
+be either the canonical root **or** the single clamped value of the bad node — any
+third value implies a different fault.
+
+## 6. Why some invalid claims are intentionally left uncountered
+
+A correct challenger does **not** counter every invalid claim. Per
+`op-challenger/game/fault/solver/solver.go` `shouldCounter`, it counters a dishonest
+claim only when:
+
+- the claim's **parent is honest** (it attacks our line), **or**
+- the parent was itself countered by us **and** the claim is at/left of our counter.
+
+It **ignores** dishonest claims to the **right** of its leftmost honest counter and
+**all descendants of an ignored claim** ("do not respond to a claim countering a
+claim the honest actor ignored") — countering them is unnecessary (they can't change
+resolution) and risks **prestate/agreement poisoning** (the "freeloader" solver
+tests). So uncountered invalid claims are usually *correct behavior*, not a gap.
+
+## 7. Bond outcome
+
+`packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol` `resolveClaim`: a
+claim's bond goes to its **claimant** if **uncountered**, else to the claimant of the
+**leftmost correctly-positioned uncountered child**. Therefore:
+
+- invalid claims an honest actor countered → bond to the counterer;
+- invalid claims left **uncountered** (§6) → bond **returns to the claimant**;
+- valid claims → bond returns to the claimant.
+
+Read bonds straight from `claimData[i].bond`; read `l1Head()` / `l2BlockNumber()` /
+`status()` from the game. Distribution is final once all challengers are up to date
+(modulo on-chain resolution after the chess clocks expire; refund mode returns bonds
+to original posters). Note **resolution** (status flips, clocks expired) precedes
+**finalization** (an additional air-gap before credits can be withdrawn).
+
+## Common root causes
+
+- **Incomplete safe-head DB / lagging op-node behind a load balancer** — the
+  challenger clamps to its safe head and disputes valid proposals; LB flapping makes
+  one challenger emit *both* roots and attack its own claims (looks like a bug, isn't).
+- **Genuinely diverged node** (wrong chain) — block hashes mismatch (§5).
+- **Misconfiguration** — wrong rollup config / L1 / game type.
+
+## Reading the signals
+
+- Same `outputRoot`, different `safeHead` across nodes ⇒ chain state fine, one node's
+  safe-head DB incomplete ⇒ it clamps and disputes valid proposals.
+- A single challenger posting two roots / attacking its own claims ⇒ often one
+  challenger behind a load balancer with one bad backend, **not** a second bug.
+- A challenger making many moves to counter a faulty challenger is **by design**;
+  bonds escalate against the loser.

--- a/docs/ai/dispute-game-investigation.md
+++ b/docs/ai/dispute-game-investigation.md
@@ -7,8 +7,10 @@ proposal is valid and who wins the bonds. Investigate and explain; never `move`,
 
 ## Inputs
 
-- L1 EL RPC (games live on L1) and an L2 EL RPC for the chain. The chain's op-node
-  rollup RPC is useful but optional.
+- L1 EL RPC (games live on L1) and an L2 EL RPC for the chain. The rollup-node RPC is
+  useful but optional — **op-node** (`optimism_outputAtBlock` / `optimism_safeHeadAtL1Block`)
+  for output-root games; **op-node or op-supernode** (`superroot_atTimestamp`) for super-root
+  games.
 - The `op-challenger` binary: `just op-challenger` (builds `./op-challenger/bin/op-challenger`).
 
 ## Steps
@@ -64,6 +66,12 @@ proposal is valid and who wins the bonds. Investigate and explain; never `move`,
    single challenger emit *both* roots and attack its own claims. Clean test: every claim
    value should be either canonical or the bad node's single clamped value; anything else
    is a different fault.
+
+   These queries (and `game-proposal-outputs.sh`) target **output-root games** via op-node
+   `optimism_outputAtBlock` / `optimism_safeHeadAtL1Block`. For **super-root games** the data
+   source is `superroot_atTimestamp` on the op-node **or op-supernode** — compare per the
+   super-root rules in §4 (the response carries the `RequiredL1` / `VerifiedRequiredL1` that
+   determine when the trace turns invalid).
 
 6. **Check uncountered invalid claims against the honest actor — don't assume they're fine.**
    The honest-actor algorithm (`op-challenger/game/fault/solver/solver.go` `shouldCounter`)

--- a/docs/ai/dispute-game-investigation.md
+++ b/docs/ai/dispute-game-investigation.md
@@ -1,136 +1,77 @@
 # Investigating fault dispute games
 
-How to investigate an OP Stack fault dispute game when something looks wrong — a
-challenger **disagreeing** with a proposal or another challenger, **performing a
-lot of moves**, **contradicting itself** (posting both roots / attacking its own
-claims), or when you need to know whether a proposal is **valid** and who will win
-the bonds. The goal is a conclusion about *which side is correct and why*, grounded
-in recomputed chain data.
+Read-only playbook for when a dispute game looks wrong — a challenger disagreeing,
+doing lots of moves, contradicting itself, or when you need to know whether a
+proposal is valid and who wins the bonds. Investigate and explain; never `move`,
+`resolve`, `resolveClaim`, `create`, fund a signer, or restart/stop a challenger.
 
-This is **read-only**: investigate and explain; never `move`, `resolve`,
-`resolveClaim`, `create`, fund a signer, or restart/stop a challenger.
+## Inputs
 
-## What you need
-
-- **L1 EL RPC** (the games live on L1).
-- **An L2 EL RPC** for the chain — to recompute output roots from block headers.
-- **The chain's op-node rollup RPC** (ideal) — `optimism_outputAtBlock`,
-  `optimism_safeHeadAtL1Block`, `optimism_syncStatus`. Often cluster-internal.
+- L1 EL RPC (games live on L1) and an L2 EL RPC for the chain. The chain's op-node
+  rollup RPC is useful but optional.
 - `op-challenger` built locally: `go build -o /tmp/op-challenger ./op-challenger/cmd`.
 
-## 1. Identify the actors
+## Steps
 
-Addresses alone don't tell you who is who, and a single logical actor may use a
-**key pool** (several EOAs). In a fault game *anyone* can attack or defend *any*
-claim — the chess-clock parity is by depth, not by address. Resolve roles from
-deployment/config (e.g. the chain's proposer and challenger addresses, and the
-`DisputeGameFactoryProxy` from the superchain-registry).
+1. **Identify the actors.** Resolve proposer / challenger(s) / our node and the
+   `DisputeGameFactoryProxy` from deployment config + the superchain-registry. A
+   signer may be a key pool, and anyone can move on any claim — never infer "side"
+   from an address; chess-clock parity is by depth.
 
-## 2. Enumerate games and claims
+2. **Enumerate.** `op-challenger list-games --game-factory-address <f> --l1-eth-rpc <l1> --format json`
+   and `op-challenger list-claims --game-address <g> --l1-eth-rpc <l1> --format json`.
+   (In text, `Value` is `Hash.TerminalString()` — a repeated short hash means the same
+   output root, from clamping.)
 
-```bash
-op-challenger list-games  --game-factory-address <factory> --l1-eth-rpc <l1> --format json
-op-challenger list-claims --game-address <game>            --l1-eth-rpc <l1> --format json
-```
+3. **Canonical output root (ground truth).** Use the EL-only tools — they need just an
+   L2 EL RPC and work against public nodes:
+   - output-root games: `go run ./op-chain-ops/cmd/check-output-root --l2-eth-rpc <l2> --block-num <n>`
+   - super-root games: `go run ./op-chain-ops/cmd/check-super-root --rpc-endpoints <l2…>`
 
-Use `--format json` for reliable parsing (full values, exact bonds, structured
-resolution fields). In the text view the `Value` column is `Hash.TerminalString()`
-(first+last 3 bytes), so the *same* short hash repeating across positions means the
-*same* output root (clamping — see below).
+4. **Classify each claim correct-vs-invalid.** Map position → L2 block:
+   `traceIdx = (idxAtDepth+1)·2^(splitDepth−depth) − 1`; attack child `t − 2^(splitDepth−d−1)`,
+   defend child `t + 2^(splitDepth−d−1)`; `block = rangeStart + traceIdx + 1`. The honest
+   value at a position is the canonical output root at that block **clamped to the safe head
+   as of the game's `l1Head`** (`optimism_safeHeadAtL1Block(l1Head)`), not the chain tip —
+   positions beyond that safe head clamp to its output root (why a hash repeats). A claim is
+   invalid iff its value differs. Crucially this means a claim/proposal can carry a genuinely
+   canonical output root and still be **invalid** if its block was not yet safe at the game's
+   `l1Head` (e.g. proposing ahead of the safe head) — so always clamp to the safe head, not
+   just to the claimed block.
 
-## 3. Establish the canonical output root (ground truth)
+5. **Diagnose the responsible op-node** (`op-challenger/scripts/`, chain-agnostic,
+   `curl` + `python3`):
+   - `game-proposal-outputs.sh <rollup-rpc> <l1-rpc> --factory <f>` — per game, the node's
+     `optimism_outputAtBlock` and `optimism_safeHeadAtL1Block` at the game's `l1Head`.
+     Identical output roots but a **safe head below the proposed block** = an incomplete
+     safe-head DB / lagging node: the challenger clamps to its safe head and disputes
+     everything beyond it.
+   - `check-game-block-hashes.sh <node-rpc> <ref-rpc> <blocks…>` — block-hash cross-check
+     (a mismatch = real divergence).
 
-Prefer the existing tooling:
+   Behind a load balancer, check each backend separately — one bad backend makes a
+   single challenger emit *both* roots and attack its own claims. Clean test: every claim
+   value should be either canonical or the bad node's single clamped value; anything else
+   is a different fault.
 
-```bash
-go run ./op-chain-ops/cmd/check-output-root --help   # output-root games
-go run ./op-chain-ops/cmd/check-super-root  --help    # super-root games
-```
+6. **Uncountered invalid claims are usually correct.** `op-challenger/game/fault/solver/solver.go`
+   `shouldCounter` counters a dishonest claim only when its parent is honest, or the
+   parent was countered by us and the claim is at/left of our counter. It ignores claims
+   to the right of our leftmost counter and all descendants of an ignored claim — avoids
+   wasted bonds and prestate/agreement poisoning.
 
-If you only have a public EL RPC (no archive / no `eth_getProof`), recompute from
-the **block header** — on Isthmus the header `withdrawalsRoot` **equals** the
-L2ToL1MessagePasser storage root:
+7. **Bond outcome.** `packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol`
+   `resolveClaim`: a claim's bond goes to its claimant if uncountered, else to the
+   leftmost correctly-positioned uncountered child's claimant. So invalid-but-countered →
+   counterer; invalid-but-ignored → back to the claimant; valid → back to the claimant.
+   Read bonds from `claimData[i].bond`. Resolution (clocks expired) precedes finalization
+   (an extra air-gap before credits can be withdrawn).
 
-```
-outputRoot = keccak256( version(32×0) ‖ stateRoot ‖ withdrawalsRoot ‖ blockHash )
-```
+## Common causes
 
-i.e. `eth.OutputRoot(&eth.OutputV0{StateRoot, MessagePasserStorageRoot: header.withdrawalsRoot, BlockHash})`.
-Needs only `eth_getBlockByNumber`, no archive node.
-
-## 4. Classify every claim (correct vs invalid)
-
-Map a claim's position to its L2 block, then compare its value to canonical:
-
-- `traceIdx = (idxAtDepth+1)·2^(splitDepth−depth) − 1` (depth ≤ split depth).
-- attack child `= t − 2^(splitDepth−d−1)`; defend child `= t + 2^(splitDepth−d−1)`.
-- `block = rangeStart + traceIdx + 1`, **clamped** at the claimed L2 block.
-- Beyond the chain tip every position clamps to the final output root (why one hash
-  repeats). A claim is **invalid** iff its value ≠ canonical(block).
-
-## 5. Diagnose the responsible op-node
-
-If two parties disagree, at least one node is wrong. Compare nodes with the bundled
-scripts (`op-challenger/scripts/`, chain-agnostic, `curl` + `python3`):
-
-- **`game-proposal-outputs.sh <rollup-rpc> <l1-rpc> --factory <addr>`** — per game,
-  prints the node's `optimism_outputAtBlock` *and* `optimism_safeHeadAtL1Block` at the
-  game's `l1Head`. **Identical output roots but a safe head BELOW the proposed block**
-  is the fingerprint of an **incomplete safe-head DB / lagging node**: the challenger
-  clamps the max valid L2 block to its safe head and disputes everything beyond it.
-- **`check-game-block-hashes.sh <node-rpc> <ref-rpc> <blocks…>`** — confirms a node is
-  on canonical history for the proposal blocks (a mismatch = real divergence).
-
-Behind a **load balancer, check each backend individually** — one bad backend
-produces intermittent, contradictory behavior (a single challenger emitting *both*
-roots and attacking its own claims). A clean cross-check: every claim's value should
-be either the canonical root **or** the single clamped value of the bad node — any
-third value implies a different fault.
-
-## 6. Why some invalid claims are intentionally left uncountered
-
-A correct challenger does **not** counter every invalid claim. Per
-`op-challenger/game/fault/solver/solver.go` `shouldCounter`, it counters a dishonest
-claim only when:
-
-- the claim's **parent is honest** (it attacks our line), **or**
-- the parent was itself countered by us **and** the claim is at/left of our counter.
-
-It **ignores** dishonest claims to the **right** of its leftmost honest counter and
-**all descendants of an ignored claim** ("do not respond to a claim countering a
-claim the honest actor ignored") — countering them is unnecessary (they can't change
-resolution) and risks **prestate/agreement poisoning** (the "freeloader" solver
-tests). So uncountered invalid claims are usually *correct behavior*, not a gap.
-
-## 7. Bond outcome
-
-`packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol` `resolveClaim`: a
-claim's bond goes to its **claimant** if **uncountered**, else to the claimant of the
-**leftmost correctly-positioned uncountered child**. Therefore:
-
-- invalid claims an honest actor countered → bond to the counterer;
-- invalid claims left **uncountered** (§6) → bond **returns to the claimant**;
-- valid claims → bond returns to the claimant.
-
-Read bonds straight from `claimData[i].bond`; read `l1Head()` / `l2BlockNumber()` /
-`status()` from the game. Distribution is final once all challengers are up to date
-(modulo on-chain resolution after the chess clocks expire; refund mode returns bonds
-to original posters). Note **resolution** (status flips, clocks expired) precedes
-**finalization** (an additional air-gap before credits can be withdrawn).
-
-## Common root causes
-
-- **Incomplete safe-head DB / lagging op-node behind a load balancer** — the
-  challenger clamps to its safe head and disputes valid proposals; LB flapping makes
-  one challenger emit *both* roots and attack its own claims (looks like a bug, isn't).
-- **Genuinely diverged node** (wrong chain) — block hashes mismatch (§5).
-- **Misconfiguration** — wrong rollup config / L1 / game type.
-
-## Reading the signals
-
-- Same `outputRoot`, different `safeHead` across nodes ⇒ chain state fine, one node's
-  safe-head DB incomplete ⇒ it clamps and disputes valid proposals.
-- A single challenger posting two roots / attacking its own claims ⇒ often one
-  challenger behind a load balancer with one bad backend, **not** a second bug.
-- A challenger making many moves to counter a faulty challenger is **by design**;
-  bonds escalate against the loser.
+- Incomplete safe-head DB / lagging op-node behind a load balancer — clamps and disputes
+  valid proposals; LB flapping makes one challenger emit both roots and self-contradict
+  (looks like a bug, isn't).
+- Diverged node (wrong chain — block hashes mismatch), or misconfig (wrong rollup config /
+  L1 / game type).
+- Many moves to counter a faulty challenger is by design; bonds escalate against the loser.

--- a/docs/ai/dispute-game-investigation.md
+++ b/docs/ai/dispute-game-investigation.md
@@ -9,7 +9,7 @@ proposal is valid and who wins the bonds. Investigate and explain; never `move`,
 
 - L1 EL RPC (games live on L1) and an L2 EL RPC for the chain. The chain's op-node
   rollup RPC is useful but optional.
-- `op-challenger` built locally: `go build -o /tmp/op-challenger ./op-challenger/cmd`.
+- The `op-challenger` binary: `just op-challenger` (builds `./op-challenger/bin/op-challenger`).
 
 ## Steps
 

--- a/docs/ai/dispute-game-investigation.md
+++ b/docs/ai/dispute-game-investigation.md
@@ -28,16 +28,20 @@ proposal is valid and who wins the bonds. Investigate and explain; never `move`,
    - output-root games: `go run ./op-chain-ops/cmd/check-output-root --l2-eth-rpc <l2> --block-num <n>`
    - super-root games: `go run ./op-chain-ops/cmd/check-super-root --rpc-endpoints <l2…>`
 
-4. **Classify each claim correct-vs-invalid.** Map position → L2 block:
-   `traceIdx = (idxAtDepth+1)·2^(splitDepth−depth) − 1`; attack child `t − 2^(splitDepth−d−1)`,
-   defend child `t + 2^(splitDepth−d−1)`; `block = rangeStart + traceIdx + 1`. The honest
-   value at a position is the canonical output root at that block **clamped to the safe head
-   as of the game's `l1Head`** (`optimism_safeHeadAtL1Block(l1Head)`), not the chain tip —
-   positions beyond that safe head clamp to its output root (why a hash repeats). A claim is
-   invalid iff its value differs. Crucially this means a claim/proposal can carry a genuinely
-   canonical output root and still be **invalid** if its block was not yet safe at the game's
-   `l1Head` (e.g. proposing ahead of the safe head) — so always clamp to the safe head, not
-   just to the claimed block.
+4. **Classify each claim correct-vs-invalid.** A claim is invalid iff its value differs from
+   the honest value at its position, **clamped to the safe head as of the game's `l1Head`**
+   (`optimism_safeHeadAtL1Block(l1Head)`), not the chain tip — positions beyond that clamp to
+   the safe head's value (why a hash repeats). So a genuinely canonical value for a
+   block/timestamp that was not yet safe at the game's `l1Head` is still **invalid** (e.g.
+   proposing ahead of the safe head) — always clamp to the safe head, not just the claimed tip.
+
+   - **Output-root games:** position → L2 block is `traceIdx = (idxAtDepth+1)·2^(splitDepth−depth) − 1`
+     (attack child `t − 2^(splitDepth−d−1)`, defend child `t + 2^(splitDepth−d−1)`),
+     `block = rangeStart + traceIdx + 1`; honest value = canonical output root at that block.
+   - **Super-root games:** the trace advances by **timestamp**, not block — each timestamp
+     transition spans multiple steps and a position commits to a **super root over several
+     chains** at a timestamp. The output-root block math does not apply; use `check-super-root`
+     and reason in timestamps / super roots.
 
 5. **Diagnose the responsible op-node** (`op-challenger/scripts/`, chain-agnostic,
    `curl` + `python3`):

--- a/docs/ai/dispute-game-investigation.md
+++ b/docs/ai/dispute-game-investigation.md
@@ -29,19 +29,26 @@ proposal is valid and who wins the bonds. Investigate and explain; never `move`,
    - super-root games: `go run ./op-chain-ops/cmd/check-super-root --rpc-endpoints <l2…>`
 
 4. **Classify each claim correct-vs-invalid.** A claim is invalid iff its value differs from
-   the honest value at its position, **clamped to the safe head as of the game's `l1Head`**
-   (`optimism_safeHeadAtL1Block(l1Head)`), not the chain tip — positions beyond that clamp to
-   the safe head's value (why a hash repeats). So a genuinely canonical value for a
-   block/timestamp that was not yet safe at the game's `l1Head` is still **invalid** (e.g.
-   proposing ahead of the safe head) — always clamp to the safe head, not just the claimed tip.
+   the honest value at its position. Validity is bounded by the game's **`l1Head`**: a
+   genuinely canonical value is still **invalid** if it depends on L2 data not yet derivable
+   from L1 at that `l1Head` (e.g. proposing ahead of what L1 has anchored). The exact mechanism
+   differs by game type:
 
    - **Output-root games:** position → L2 block is `traceIdx = (idxAtDepth+1)·2^(splitDepth−depth) − 1`
      (attack child `t − 2^(splitDepth−d−1)`, defend child `t + 2^(splitDepth−d−1)`),
-     `block = rangeStart + traceIdx + 1`; honest value = canonical output root at that block.
-   - **Super-root games:** the trace advances by **timestamp**, not block — each timestamp
-     transition spans multiple steps and a position commits to a **super root over several
-     chains** at a timestamp. The output-root block math does not apply; use `check-super-root`
-     and reason in timestamps / super roots.
+     `block = rangeStart + traceIdx + 1`; the honest value is the canonical output root at that
+     block **clamped to the safe head as of the game's `l1Head`** (`optimism_safeHeadAtL1Block(l1Head)`)
+     — positions beyond it clamp to the safe head's root (why a hash repeats).
+   - **Super-root games:** the trace advances **step by step**; `StepsPerTimestamp` (=128)
+     steps make up one timestamp's transition (`ComputeStep`: `traceIdx = pos.TraceIndex(depth)+1`,
+     `timestamp = prestateTimestamp + traceIdx/128`, `step = traceIdx % 128`). Step 0 is the
+     **super root at that timestamp**; steps 1..N each consolidate the next timestamp's optimistic
+     block for the Nth chain (chains sorted by ID). The honest value is the **invalid-transition
+     hash** (`eth.InvalidTransition`) once the next state can't be derived from L1 ≤ the game's
+     `l1Head` — at step 0 when the timestamp's `VerifiedRequiredL1 > l1Head` (or it has no block),
+     or at the specific step where a chain's `optimistic.RequiredL1 > l1Head` (or that chain has
+     no block) — and it stays invalid thereafter, so the exact step it flips at matters. See
+     `op-challenger/game/fault/trace/super/provider.go`.
 
 5. **Diagnose the responsible op-node** (`op-challenger/scripts/`, chain-agnostic,
    `curl` + `python3`):
@@ -58,11 +65,15 @@ proposal is valid and who wins the bonds. Investigate and explain; never `move`,
    value should be either canonical or the bad node's single clamped value; anything else
    is a different fault.
 
-6. **Uncountered invalid claims are usually correct.** `op-challenger/game/fault/solver/solver.go`
-   `shouldCounter` counters a dishonest claim only when its parent is honest, or the
-   parent was countered by us and the claim is at/left of our counter. It ignores claims
-   to the right of our leftmost counter and all descendants of an ignored claim — avoids
-   wasted bonds and prestate/agreement poisoning.
+6. **Check uncountered invalid claims against the honest actor — don't assume they're fine.**
+   The honest-actor algorithm (`op-challenger/game/fault/solver/solver.go` `shouldCounter`)
+   intentionally leaves many invalid claims uncountered: it counters a dishonest claim only when
+   its parent is honest, or the parent was countered by us and the claim is at/left of our
+   counter; it ignores claims to the right of our leftmost counter and all descendants of an
+   ignored claim (avoids wasted bonds and prestate/agreement poisoning). So an uncountered
+   invalid claim is often expected — but **verify** each one is genuinely one `shouldCounter`
+   would skip. A challenger failing to counter a claim it *should* have is a real and serious
+   failure mode; if an uncountered invalid claim isn't explained by the algorithm, flag it.
 
 7. **Bond outcome.** `packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol`
    `resolveClaim`: a claim's bond goes to its claimant if uncountered, else to the

--- a/op-challenger/scripts/check-game-block-hashes.sh
+++ b/op-challenger/scripts/check-game-block-hashes.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# check-game-block-hashes.sh
+#
+# Compare the L2 block hash a node returns against a reference node for a set of
+# L2 blocks. A mismatch means the node is on a different chain than the reference
+# for that block — i.e. a challenger using it would derive output roots from a
+# diverged history. Chain-agnostic: pass any two EL RPCs and any block numbers.
+#
+# Usage:
+#   check-game-block-hashes.sh <node-rpc> <reference-rpc> [block ...]
+#
+#   <node-rpc>       EL JSON-RPC of the node under test (e.g. our op-geth).
+#   <reference-rpc>  EL JSON-RPC trusted as the reference (e.g. a public RPC).
+#   [block ...]      L2 block numbers (decimal). If omitted, read one per line
+#                    from stdin (e.g. piped from the proposal blocks of a game set).
+#
+# Env: RETRIES (per-request attempts, default 5).
+# Exit code: 0 if every block matches, 1 if any mismatch / RPC failure.
+
+set -uo pipefail
+
+NODE_RPC="${1:-}"; REF_RPC="${2:-}"
+if [[ -z "$NODE_RPC" || -z "$REF_RPC" ]]; then
+  echo "usage: $0 <node-rpc> <reference-rpc> [block ...]" >&2
+  exit 2
+fi
+shift 2
+
+RETRIES="${RETRIES:-5}"
+
+if [[ $# -gt 0 ]]; then BLOCKS=("$@"); else mapfile -t BLOCKS; fi
+if [[ ${#BLOCKS[@]} -eq 0 ]]; then echo "no blocks given (args or stdin)" >&2; exit 2; fi
+
+# fetch_hash <rpc> <decimal-block> -> block hash, only if the node returns the
+# exact block requested (guards against a lagging/pruned/load-balanced backend).
+fetch_hash() {
+  local rpc="$1" dec="$2" hexbn payload resp out attempt
+  hexbn=$(printf '0x%x' "$dec")
+  payload="{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_getBlockByNumber\",\"params\":[\"$hexbn\",false]}"
+  for ((attempt = 1; attempt <= RETRIES; attempt++)); do
+    resp=$(curl -s -m 20 -X POST "$rpc" -H 'content-type: application/json' --data "$payload")
+    out=$(printf '%s' "$resp" | python3 -c '
+import sys, json
+try: d = json.load(sys.stdin)
+except Exception: print("RETRY"); sys.exit()
+r = d.get("result")
+if not r or r.get("hash") is None or r.get("number") is None: print("RETRY"); sys.exit()
+if int(r["number"], 16) != int(sys.argv[1]): print("RETRY"); sys.exit()  # backend returned a different block
+print(r["hash"].lower())
+' "$dec" 2>/dev/null)
+    if [[ "$out" != "RETRY" && -n "$out" ]]; then printf '%s' "$out"; return 0; fi
+    sleep 1
+  done
+  printf ''; return 1
+}
+
+printf '%-10s  %-66s  %-66s  %s\n' "Block" "Node" "Reference" "Result"
+fail=0
+for bn in "${BLOCKS[@]}"; do
+  node=$(fetch_hash "$NODE_RPC" "$bn")
+  ref=$(fetch_hash "$REF_RPC" "$bn")
+  if [[ -z "$node" || -z "$ref" ]]; then
+    result="⚠️  RPC-FAIL (node=${node:-none} ref=${ref:-none})"; fail=1
+  elif [[ "$node" == "$ref" ]]; then
+    result="✅ match"
+  else
+    result="❌ MISMATCH"; fail=1
+  fi
+  printf '%-10s  %-66s  %-66s  %s\n' "$bn" "${node:-<none>}" "${ref:-<none>}" "$result"
+done
+
+echo
+if [[ "$fail" -eq 0 ]]; then echo "All ${#BLOCKS[@]} blocks match between the node and ${REF_RPC}."
+else echo "One or more blocks did NOT match (or an RPC failed)."; fi
+exit "$fail"

--- a/op-challenger/scripts/game-proposal-outputs.sh
+++ b/op-challenger/scripts/game-proposal-outputs.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# game-proposal-outputs.sh
+#
+# For each dispute game, ask OUR op-node what it derives, so you can tell whether
+# a challenger pointed at it would agree with the proposal:
+#   * optimism_outputAtBlock(<game l2BlockNumber>)   -> output root our node derives
+#   * optimism_safeHeadAtL1Block(<game l1Head>)      -> our node's L2 safe head at
+#                                                       the L1 view the game is anchored to
+#
+# A safe head BELOW the proposed block (with identical output roots between nodes)
+# is the fingerprint of an incomplete safe-head DB / lagging node — the challenger
+# clamps to the safe head and disputes valid proposals. Chain-agnostic.
+#
+# Usage:
+#   game-proposal-outputs.sh <rollup-rpc> <l1-rpc> [--factory <addr> [--last N]] [game-addr ...]
+#
+#   <rollup-rpc>   OUR op-node rollup RPC (exposes optimism_* methods).
+#   <l1-rpc>       L1 EL RPC (reads each game's l2BlockNumber()/l1Head()).
+#   --factory A    DisputeGameFactory; enumerate games from it (newest first).
+#   --last N       With --factory, inspect the newest N games (default 25).
+#   game-addr ...  Explicit FaultDisputeGame addresses (overrides --factory).
+#
+# Discover games yourself instead with:
+#   op-challenger list-games --game-factory-address <factory> --l1-eth-rpc <l1> --format json
+#
+# Env: RETRIES (default 5).
+
+set -uo pipefail
+
+ROLLUP_RPC="${1:-}"; L1_RPC="${2:-}"
+if [[ -z "$ROLLUP_RPC" || -z "$L1_RPC" ]]; then
+  echo "usage: $0 <rollup-rpc> <l1-rpc> [--factory <addr> [--last N]] [game-addr ...]" >&2
+  exit 2
+fi
+shift 2
+
+RETRIES="${RETRIES:-5}"
+FACTORY=""; LAST=25; GAMES=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --factory) FACTORY="$2"; shift 2 ;;
+    --last)    LAST="$2"; shift 2 ;;
+    *)         GAMES+=("$1"); shift ;;
+  esac
+done
+
+# selectors
+SEL_L2BLOCK="0x8b85902b"   # l2BlockNumber()
+SEL_L1HEAD="0x6361506d"    # l1Head()
+SEL_STATUS="0x200d2ed2"    # status() -> uint8 (0=IN_PROGRESS,1=CHALLENGER_WINS,2=DEFENDER_WINS)
+SEL_COUNT="0x4d1975b4"     # gameCount()
+SEL_AT="0xbb8aa1fc"        # gameAtIndex(uint256) -> (gameType, timestamp, proxy)
+
+rpc() { # rpc <url> <method> <params-json> -> .result (string), retries
+  local url="$1" m="$2" p="$3" resp out attempt
+  for ((attempt = 1; attempt <= RETRIES; attempt++)); do
+    resp=$(curl -s -m 25 -X POST "$url" -H 'content-type: application/json' \
+      --data "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$m\",\"params\":$p}")
+    out=$(printf '%s' "$resp" | python3 -c 'import sys,json
+try: d=json.load(sys.stdin)
+except Exception: print("RETRY"); sys.exit()
+r=d.get("result")
+print(r if r is not None else "ERR:"+json.dumps(d.get("error","no result")))' 2>/dev/null)
+    [[ "$out" == "RETRY" || -z "$out" ]] && { sleep 1; continue; }
+    printf '%s' "$out"; return 0
+  done
+  printf ''; return 1
+}
+ethcall() { rpc "$L1_RPC" eth_call "[{\"to\":\"$1\",\"data\":\"$2\"},\"latest\"]"; }
+hex() { printf '0x%x' "$1"; }
+addr_of_word() { python3 -c "import sys;h=sys.argv[1][2:];w=h[int(sys.argv[2])*64:(int(sys.argv[2])+1)*64];print('0x'+w[24:])" "$1" "$2"; }
+to_int() { python3 -c "import sys;print(int(sys.argv[1],16))" "$1"; }
+is_hash32() { python3 -c "import sys;h=sys.argv[1];print('1' if h.startswith('0x') and len(h)==66 and int(h,16)!=0 else '0')" "$1" 2>/dev/null; }
+
+# Enumerate games from a factory if no explicit games were given.
+if [[ ${#GAMES[@]} -eq 0 ]]; then
+  [[ -z "$FACTORY" ]] && { echo "provide game addresses or --factory <addr>" >&2; exit 2; }
+  cnt_hex=$(ethcall "$FACTORY" "$SEL_COUNT"); cnt=$(to_int "$cnt_hex")
+  start=$(( cnt - LAST )); (( start < 0 )) && start=0
+  for (( i = cnt - 1; i >= start; i-- )); do
+    res=$(ethcall "$FACTORY" "${SEL_AT}$(printf '%064x' "$i")")
+    GAMES+=("$(addr_of_word "$res" 2)")
+  done
+fi
+
+echo "# rollup (our node): $ROLLUP_RPC"
+echo "# safeHeadAtL1Block queried per-game at each game's l1Head anchor"
+printf '%-44s %-7s %-10s %-66s %-10s %s\n' "game" "status" "l2block" "outputRoot(ours)" "l1Head" "safeHead(ours)"
+
+statusName() { case "$1" in 0) echo IN_PROG;; 1) echo CHAL_WON;; 2) echo DEF_WON;; *) echo "?$1";; esac; }
+
+for game in "${GAMES[@]}"; do
+  st=$(to_int "$(ethcall "$game" "$SEL_STATUS")" 2>/dev/null || echo -1)
+  l2hex=$(ethcall "$game" "$SEL_L2BLOCK"); l2=$(to_int "$l2hex")
+  l1h=$(ethcall "$game" "$SEL_L1HEAD")        # bytes32 L1 block hash
+  l1num="ERR"
+  if [[ "$(is_hash32 "$l1h")" == "1" ]]; then
+    blk=$(rpc "$L1_RPC" eth_getBlockByHash "[\"$l1h\",false]")
+    l1num=$(printf '%s' "$blk" | python3 -c 'import sys,json
+try: print(int(json.load(sys.stdin)["number"],16))
+except Exception: print("ERR")' 2>/dev/null)
+  fi
+  oroot=$(rpc "$ROLLUP_RPC" optimism_outputAtBlock "[\"$(hex "$l2")\"]" | python3 -c 'import sys,json
+try: print(json.load(sys.stdin)["outputRoot"])
+except Exception: print("ERR")' 2>/dev/null)
+  shnum="ERR"; shhash=""
+  if [[ "$l1num" != "ERR" && -n "$l1num" ]]; then
+    sh=$(rpc "$ROLLUP_RPC" optimism_safeHeadAtL1Block "[\"$(hex "$l1num")\"]")
+    read -r shnum shhash < <(printf '%s' "$sh" | python3 -c 'import sys,json
+try:
+  r=json.load(sys.stdin)["safeHead"]; n=r["number"]
+  print(int(n,16) if isinstance(n,str) else int(n), r["hash"])
+except Exception: print("ERR ERR")' 2>/dev/null)
+  fi
+  printf '%-44s %-7s %-10s %-66s %-10s %s %s\n' \
+    "$game" "$(statusName "$st")" "$l2" "${oroot:-ERR}" "${l1num:-ERR}" "${shnum:-ERR}" "$shhash"
+done


### PR DESCRIPTION
A read-only **dispute-game-investigator** skill/agent for diagnosing fault dispute games — challenger disagreements, excessive moves, self-contradiction, proposal validity, and the bond outcome.

- `docs/ai/dispute-game-investigation.md` — the playbook: identify actors → enumerate (`list-games`/`list-claims --format json`) → canonical output root (`op-chain-ops check-output-root`/`check-super-root`, EL-only) → classify claims (clamped to the safe head at the game's `l1Head`) → diagnose the responsible op-node → honest-actor non-counter rule (`solver.go`) → bond outcome (`FaultDisputeGame.sol`).
- `.claude/skills/...` + `.claude/agents/...` entrypoints; registered in `AGENTS.md`/`CLAUDE.md`.
- `op-challenger/scripts/{check-game-block-hashes,game-proposal-outputs}.sh` — chain-agnostic helpers (curl + python3).

Distilled from the 2026-06-09 ink-mainnet incident (challenger disputing valid proposals due to an incomplete safe-head DB behind a load balancer). Draft.