### PR TITLE
ci: disable sccache for kona prestate publish jobs

### DIFF
--- a/.circleci/continue/helpers.yml
+++ b/.circleci/continue/helpers.yml
@@ -85,6 +85,13 @@ commands:
         description: "Whether to install clang (needed by bindgen for reth-mdbx-sys)."
         type: boolean
         default: true
+      enable_sccache:
+        description: >
+          Whether to set up the sccache GCS compile cache. Disable for jobs that
+          don't compile on the host (e.g. the reproducible prestate build runs in
+          Docker) so they don't need the sccache-gcs-optimism context.
+        type: boolean
+        default: true
     description: "Prepare the Rust environment for the build."
     steps:
       - rust-setup-env
@@ -95,4 +102,5 @@ commands:
                 name: Ensure clang available
                 command: 'command -v clang >/dev/null 2>&1 || { echo "ERROR: clang is required but was not found in PATH" >&2; exit 1; }'
       # Shared GCS compile cache (op-rust-sccache).
-      - rust-sccache-setup
+      - rust-sccache-setup:
+          enabled: << parameters.enable_sccache >>

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -485,9 +485,14 @@ commands:
         description: "Prefix to add to the cache key"
         type: string
         default: "rust-build"
+      enable_sccache:
+        description: "Whether to set up the sccache GCS compile cache (see rust-prepare)."
+        type: boolean
+        default: true
     steps:
       - rust-prepare:
           needs_clang: << parameters.needs_clang >>
+          enable_sccache: << parameters.enable_sccache >>
       - rust-restore-build-cache:
           version: << parameters.version >>
           directory: << parameters.directory >>

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -680,9 +680,15 @@ jobs:
       - apt-install:
           packages: "clang llvm-dev libclang-dev"
           extra_flags: "--no-install-recommends"
-      - rust-prepare-and-restore-cache: &kona-publish-prestate-cache
+      # No sccache here: the prestate is built reproducibly in Docker
+      # (just build-kona-reproducible-prestate-variant), so the host never
+      # compiles and the job doesn't need the sccache-gcs-optimism context. That
+      # context also defines GCP_SERVICE_ACCOUNT_EMAIL, which would otherwise
+      # shadow the oplabs-network-data publisher SA used by the upload below.
+      - rust-prepare-and-restore-cache:
           directory: rust
           profile: release
+          enable_sccache: false
       - gcp-cli/install
       - gcp-oidc-authenticate:
           gcp_cred_config_file_path: /tmp/gcp_cred_config.json
@@ -711,7 +717,9 @@ jobs:
             fi
             gsutil cp ./prestate-artifacts-<<parameters.kind>>/prestate.bin.gz "gs://oplabs-network-data/proofs/kona/<<parameters.kind>>/${PRESTATE_HASH}.bin.gz"
             echo "Successfully published prestates artifacts to GCS"
-      - rust-save-build-cache: *kona-publish-prestate-cache
+      - rust-save-build-cache:
+          directory: rust
+          profile: release
 
   required-rust-ci:
     docker:
@@ -971,9 +979,6 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - oplabs-network-optimism-io-bucket
-            # kona-publish builds the prestate via rust-prepare -> rust-sccache-setup,
-            # which now fails loud, so it must carry the sccache context.
-            - sccache-gcs-optimism
 
   # Kona publish prestate artifacts - on kona-client/v* tag push
   kona-publish-prestates-on-tag:
@@ -987,9 +992,6 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - oplabs-network-optimism-io-bucket
-            # kona-publish builds the prestate via rust-prepare -> rust-sccache-setup,
-            # which now fails loud, so it must carry the sccache context.
-            - sccache-gcs-optimism
           filters:
             tags:
               only: /^kona-client\/v.*/


### PR DESCRIPTION
## Problem

The `kona-publish-prestate-artifacts` job (on `kona-client/v*` tag and on `develop` push) fails when uploading the prestate binary to `gs://oplabs-network-data/...`:

```
AccessDeniedException: 403 ... does not have storage.objects.list access to the
Google Cloud Storage bucket ... 'oplabs-network-data'
```

The job carries two contexts that both define `GCP_SERVICE_ACCOUNT_EMAIL`:
- `oplabs-network-optimism-io-bucket` — the publisher SA (write access to `oplabs-network-data`)
- `sccache-gcs-optimism` — the sccache **read-only** SA (no access to that bucket)

CircleCI merges contexts last-wins, and `sccache-gcs-optimism` was listed last, so the `gsutil` upload authenticated as the sccache SA → 403. The sccache context was only added (#21227) because the build path runs `rust-prepare -> rust-sccache-setup`, which fails loud without it.

## Fix

The kona prestate is built reproducibly **in Docker** (`just build-kona-reproducible-prestate-variant`), so the host never compiles and doesn't need sccache at all. This:

- Threads a new `enable_sccache` boolean param (default `true`) through `rust-prepare-and-restore-cache` → `rust-prepare` → `rust-sccache-setup` (which already gates its whole body on an `enabled` param).
- Sets `enable_sccache: false` on the publish job.
- Drops the `sccache-gcs-optimism` context from both publish workflows.

With sccache off, nothing shadows `GCP_SERVICE_ACCOUNT_EMAIL`, so the upload authenticates as the `oplabs-network-optimism-io-bucket` publisher SA. All other callers default to `enable_sccache: true` — no behavior change anywhere else.

Validated by running the repo's `merge-configs` (yq `explode`) and confirming the exploded publish job has `enable_sccache: false`, the cache save/restore still pass `directory`/`profile`, and the contexts no longer include `sccache-gcs-optimism`.