### PR TITLE
feat(op-reth): evict pooled interop txs on a permanently-invalid filter verdict; configurable validity window

### DIFF
--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -144,6 +144,21 @@ pub struct RollupArgs {
     )]
     pub interop_safety_level: SafetyLevel,
 
+    /// Validity window, in seconds, for cross-chain (interop) transactions admitted to the pool.
+    ///
+    /// Bounds how long an admitted interop tx may sit in the pool: once it ages past this window
+    /// it is evicted. Within the final 60s before that deadline the tx is revalidated against
+    /// the interop filter on each block, and evicted early if the filter returns a
+    /// permanently-invalid verdict (e.g. conflicting data). The same value is sent to the
+    /// filter as the `ExecutingDescriptor` timeout, requiring it to guarantee the referenced
+    /// source message will not expire within the window.
+    #[arg(
+        long = "rollup.interop-validity-window",
+        value_name = "INTEROP_VALIDITY_WINDOW_SECS",
+        default_value_t = reth_optimism_txpool::DEFAULT_INTEROP_VALIDITY_WINDOW_SECS,
+    )]
+    pub interop_validity_window: u64,
+
     /// Optional headers to use when connecting to the sequencer.
     #[arg(long = "rollup.sequencer-headers", requires = "sequencer")]
     pub sequencer_headers: Vec<String>,
@@ -224,6 +239,7 @@ impl Default for RollupArgs {
             interop_http: Vec::new(),
             interop_min_responses: None,
             interop_safety_level: SafetyLevel::CrossUnsafe,
+            interop_validity_window: reth_optimism_txpool::DEFAULT_INTEROP_VALIDITY_WINDOW_SECS,
             sequencer_headers: Vec::new(),
             historical_rpc: None,
             min_suggested_priority_fee: 1_000_000,
@@ -326,6 +342,25 @@ mod tests {
         ])
         .args;
         assert_eq!(args, expected_args);
+    }
+
+    #[test]
+    fn test_interop_validity_window_default_and_parse() {
+        // Default matches the txpool's documented default.
+        let default_args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
+        assert_eq!(
+            default_args.interop_validity_window,
+            reth_optimism_txpool::DEFAULT_INTEROP_VALIDITY_WINDOW_SECS
+        );
+
+        // Overridable via the flag.
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--rollup.interop-validity-window",
+            "300",
+        ])
+        .args;
+        assert_eq!(args.interop_validity_window, 300);
     }
 
     #[test]

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -259,6 +259,7 @@ impl OpNode {
                         self.args.interop_http.clone(),
                         self.args.interop_min_responses,
                         self.args.interop_safety_level,
+                        self.args.interop_validity_window,
                     ),
             )
             .payload(BasicPayloadServiceBuilder::new(
@@ -1082,6 +1083,10 @@ pub struct OpPoolBuilder<T = crate::txpool::OpPooledTransaction> {
     pub interop_min_responses: Option<usize>,
     /// Safety level for interop filter validation.
     pub interop_safety_level: SafetyLevel,
+    /// Validity window (seconds) applied to admitted interop txs: the pool deadline and the filter
+    /// `ExecutingDescriptor` timeout. See
+    /// [`reth_optimism_txpool::DEFAULT_INTEROP_VALIDITY_WINDOW_SECS`].
+    pub interop_validity_window: u64,
     /// Marker for the pooled transaction type.
     _pd: core::marker::PhantomData<T>,
 }
@@ -1094,6 +1099,7 @@ impl<T> Default for OpPoolBuilder<T> {
             interop_endpoints: Vec::new(),
             interop_min_responses: None,
             interop_safety_level: SafetyLevel::CrossUnsafe,
+            interop_validity_window: reth_optimism_txpool::DEFAULT_INTEROP_VALIDITY_WINDOW_SECS,
             _pd: Default::default(),
         }
     }
@@ -1107,6 +1113,7 @@ impl<T> Clone for OpPoolBuilder<T> {
             interop_endpoints: self.interop_endpoints.clone(),
             interop_min_responses: self.interop_min_responses,
             interop_safety_level: self.interop_safety_level,
+            interop_validity_window: self.interop_validity_window,
             _pd: core::marker::PhantomData,
         }
     }
@@ -1136,10 +1143,12 @@ impl<T> OpPoolBuilder<T> {
         interop_endpoints: Vec<String>,
         interop_min_responses: Option<usize>,
         interop_safety_level: SafetyLevel,
+        interop_validity_window: u64,
     ) -> Self {
         self.interop_endpoints = interop_endpoints;
         self.interop_min_responses = interop_min_responses;
         self.interop_safety_level = interop_safety_level;
+        self.interop_validity_window = interop_validity_window;
         self
     }
 }
@@ -1205,7 +1214,8 @@ where
                     let v = OpTransactionValidator::new(validator)
                         // In --dev mode we can't require gas fees because we're unable to decode
                         // the L1 block info
-                        .require_l1_data_gas_fee(!ctx.config().dev.dev);
+                        .require_l1_data_gas_fee(!ctx.config().dev.dev)
+                        .with_interop_validity_window(self.interop_validity_window);
                     if let Some(client) = interop_client.clone() {
                         v.with_interop(client)
                     } else {
@@ -1256,6 +1266,7 @@ where
                     transaction_pool.clone(),
                     chain_events,
                     interop.clone(),
+                    self.interop_validity_window,
                 ),
             );
             debug!(target: "reth::cli", "Spawned Op interop txpool maintenance task");

--- a/rust/op-reth/crates/txpool/src/error.rs
+++ b/rust/op-reth/crates/txpool/src/error.rs
@@ -16,6 +16,20 @@ pub enum InvalidCrossTx {
     FailsafeEnabled,
 }
 
+impl InvalidCrossTx {
+    /// Whether an already-pooled interop tx should be evicted when revalidation against the filter
+    /// returns this error. Only a permanently-invalid filter verdict (or a cross-chain tx seen
+    /// before interop activation) evicts; transient or out-of-sync verdicts keep the tx, and
+    /// failsafe is handled separately by the global failsafe eviction path.
+    pub const fn should_evict_on_revalidation(&self) -> bool {
+        match self {
+            Self::CrossChainTxPreInterop => true,
+            Self::ValidationError(e) => e.is_message_permanently_invalid(),
+            Self::FailsafeEnabled => false,
+        }
+    }
+}
+
 impl PoolTransactionError for InvalidCrossTx {
     fn is_bad_transaction(&self) -> bool {
         match self {

--- a/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/errors.rs
@@ -95,6 +95,25 @@ impl InteropTxValidatorError {
         matches!(self, Self::FailsafeEnabled)
     }
 
+    /// Returns `true` if this verdict means the referenced interop message is *permanently* invalid
+    /// — it conflicts with canonical data, is ineffective, or is corrupt, and will never become
+    /// valid. This is deliberately narrower than
+    /// [`is_definitive_invalid`](Self::is_definitive_invalid): it excludes out-of-sync / "ask
+    /// later" verdicts (e.g. [`SuperchainDAError::OutOfScope`],
+    /// [`SuperchainDAError::FutureData`]) and unknown-code [`Rejected`](Self::Rejected) responses.
+    /// Used to decide whether to evict an already-pooled interop tx on revalidation: a transient
+    /// verdict must keep the tx, or a momentarily-lagging filter would drop valid transactions.
+    pub const fn is_message_permanently_invalid(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidEntry(
+                SuperchainDAError::ConflictingData |
+                    SuperchainDAError::IneffectiveData |
+                    SuperchainDAError::DataCorruption
+            )
+        )
+    }
+
     /// Returns a new instance of [`Other`](Self::Other) error variant.
     pub fn other<E>(err: E) -> Self
     where
@@ -152,5 +171,50 @@ impl InteropTxValidatorError {
 
         // Any other error response is a definitive rejection; preserve the real code + message.
         Self::Rejected { code, message: error_payload.message.to_string() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permanently_invalid_only_for_genuinely_bad_messages() {
+        // Genuinely-invalid verdicts evict.
+        for code in [
+            SuperchainDAError::ConflictingData,
+            SuperchainDAError::IneffectiveData,
+            SuperchainDAError::DataCorruption,
+        ] {
+            assert!(
+                InteropTxValidatorError::InvalidEntry(code).is_message_permanently_invalid(),
+                "{code:?} should be permanently invalid"
+            );
+        }
+
+        // Out-of-sync / "ask later" verdicts must NOT evict, even though some are
+        // `is_definitive_invalid`.
+        for code in [SuperchainDAError::OutOfScope, SuperchainDAError::FutureData] {
+            assert!(
+                !InteropTxValidatorError::InvalidEntry(code).is_message_permanently_invalid(),
+                "{code:?} is transient and must not evict"
+            );
+        }
+
+        // Aggregator outcomes, unknown-code rejections, and soft failures must not evict.
+        assert!(
+            !InteropTxValidatorError::Rejected { code: -32602, message: "x".into() }
+                .is_message_permanently_invalid()
+        );
+        assert!(
+            !InteropTxValidatorError::QuorumNotReached { received: 0, required: 2 }
+                .is_message_permanently_invalid()
+        );
+        assert!(!InteropTxValidatorError::Timeout(2).is_message_permanently_invalid());
+        assert!(
+            !InteropTxValidatorError::DataUnavailable { code: -321401 }
+                .is_message_permanently_invalid()
+        );
+        assert!(!InteropTxValidatorError::FailsafeEnabled.is_message_permanently_invalid());
     }
 }

--- a/rust/op-reth/crates/txpool/src/lib.rs
+++ b/rust/op-reth/crates/txpool/src/lib.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod validator;
-pub use validator::{OpL1BlockInfo, OpTransactionValidator};
+pub use validator::{DEFAULT_INTEROP_VALIDITY_WINDOW_SECS, OpL1BlockInfo, OpTransactionValidator};
 
 pub mod conditional;
 mod pool;

--- a/rust/op-reth/crates/txpool/src/maintain.rs
+++ b/rust/op-reth/crates/txpool/src/maintain.rs
@@ -16,7 +16,6 @@ use crate::{
     conditional::MaybeConditionalTransaction,
     interop::{MaybeInteropTransaction, is_interop_tx, is_stale_interop, is_valid_interop},
     interop_filter::InteropFilterClient,
-    validator::CHECK_ACCESS_LIST_TIMEOUT_SECS,
 };
 use alloy_consensus::{BlockHeader, conditional::BlockConditionalAttributes};
 use futures_util::{FutureExt, Stream, StreamExt, future::BoxFuture};
@@ -24,7 +23,7 @@ use metrics::{Gauge, Histogram};
 use reth_chain_state::CanonStateNotification;
 use reth_metrics::{Metrics, metrics::Counter};
 use reth_primitives_traits::NodePrimitives;
-use reth_transaction_pool::{PoolTransaction, TransactionPool, error::PoolTransactionError};
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::time::{Duration, Instant};
 use tracing::{info, warn};
 
@@ -139,6 +138,7 @@ pub fn maintain_transaction_pool_interop_future<N, Pool, St>(
     pool: Pool,
     events: St,
     interop_client: InteropFilterClient,
+    validity_window: u64,
 ) -> BoxFuture<'static, ()>
 where
     N: NodePrimitives,
@@ -147,7 +147,7 @@ where
     St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
 {
     async move {
-        maintain_transaction_pool_interop(pool, events, interop_client).await;
+        maintain_transaction_pool_interop(pool, events, interop_client, validity_window).await;
     }
     .boxed()
 }
@@ -160,6 +160,7 @@ pub async fn maintain_transaction_pool_interop<N, Pool, St>(
     pool: Pool,
     mut events: St,
     interop_client: InteropFilterClient,
+    validity_window: u64,
 ) where
     N: NodePrimitives,
     Pool: TransactionPool,
@@ -219,7 +220,7 @@ pub async fn maintain_transaction_pool_interop<N, Pool, St>(
                 let revalidation_stream = interop_client.revalidate_interop_txs_stream(
                     to_revalidate,
                     timestamp,
-                    CHECK_ACCESS_LIST_TIMEOUT_SECS,
+                    validity_window,
                     MAX_INTEROP_QUERIES,
                 );
 
@@ -230,11 +231,14 @@ pub async fn maintain_transaction_pool_interop<N, Pool, St>(
                 {
                     match validation_result {
                         Some(Ok(())) => {
-                            tx_item_from_stream
-                                .set_interop_deadline(timestamp + CHECK_ACCESS_LIST_TIMEOUT_SECS);
+                            tx_item_from_stream.set_interop_deadline(timestamp + validity_window);
                         }
                         Some(Err(err)) => {
-                            if err.is_bad_transaction() {
+                            // Evict only on a definitive "message is invalid" verdict; transient or
+                            // out-of-sync verdicts (out of scope, future data, quorum not reached,
+                            // timeout) must keep the tx, or a momentarily-lagging filter would drop
+                            // valid txs.
+                            if err.should_evict_on_revalidation() {
                                 to_remove.push(*tx_item_from_stream.hash());
                             }
                         }

--- a/rust/op-reth/crates/txpool/src/validator.rs
+++ b/rust/op-reth/crates/txpool/src/validator.rs
@@ -20,8 +20,17 @@ use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
-/// The timeout for cross-chain transaction validation against the interop filter.
-pub(crate) const CHECK_ACCESS_LIST_TIMEOUT_SECS: u64 = 7200;
+/// Default validity window for cross-chain (interop) transactions, in seconds.
+///
+/// This single value serves two coupled purposes:
+/// - the pool `interop_deadline`: how long an admitted interop tx may sit in the pool before it is
+///   revalidated against the filter and ultimately evicted (see [`crate::maintain`]); and
+/// - the `ExecutingDescriptor` timeout sent to the interop filter: the filter must guarantee the
+///   referenced source message will not expire within this window.
+///
+/// Holding a tx for as long as the filter guarantees its source stays valid is why the two uses
+/// share one value. Overridable via `--rollup.interop-validity-window`.
+pub const DEFAULT_INTEROP_VALIDITY_WINDOW_SECS: u64 = 120;
 
 /// Tracks additional infos for the current block.
 #[derive(Debug, Default)]
@@ -52,6 +61,10 @@ pub struct OpTransactionValidator<Client, Tx, Evm> {
     require_l1_data_gas_fee: bool,
     /// Client used to check transaction validity with the interop filter.
     interop_client: Option<InteropFilterClient>,
+    /// Validity window (seconds) applied to admitted interop txs: the pool `interop_deadline` and
+    /// the `ExecutingDescriptor` timeout sent to the filter. See
+    /// [`DEFAULT_INTEROP_VALIDITY_WINDOW_SECS`].
+    interop_validity_window: u64,
     /// tracks activated forks relevant for transaction validation
     fork_tracker: Arc<OpForkTracker>,
 }
@@ -123,6 +136,7 @@ where
             block_info: Arc::new(block_info),
             require_l1_data_gas_fee: true,
             interop_client: None,
+            interop_validity_window: DEFAULT_INTEROP_VALIDITY_WINDOW_SECS,
             fork_tracker: Arc::new(OpForkTracker { interop: AtomicBool::from(false) }),
         }
     }
@@ -130,6 +144,13 @@ where
     /// Sets the interop filter client and safety level.
     pub fn with_interop(mut self, interop_client: InteropFilterClient) -> Self {
         self.interop_client = Some(interop_client);
+        self
+    }
+
+    /// Sets the validity window (seconds) applied to admitted interop txs. See
+    /// [`DEFAULT_INTEROP_VALIDITY_WINDOW_SECS`].
+    pub const fn with_interop_validity_window(mut self, secs: u64) -> Self {
+        self.interop_validity_window = secs;
         self
     }
 
@@ -204,7 +225,7 @@ where
             Some(Ok(_)) => {
                 // valid interop tx
                 transaction
-                    .set_interop_deadline(self.block_timestamp() + CHECK_ACCESS_LIST_TIMEOUT_SECS);
+                    .set_interop_deadline(self.block_timestamp() + self.interop_validity_window);
             }
             _ => {}
         }
@@ -283,7 +304,7 @@ where
                 tx.access_list(),
                 tx.hash(),
                 self.block_info.timestamp.load(Ordering::Relaxed),
-                Some(CHECK_ACCESS_LIST_TIMEOUT_SECS),
+                Some(self.interop_validity_window),
                 self.fork_tracker.is_interop_activated(),
             )
             .await


### PR DESCRIPTION
## Summary

Two scoped changes to op-reth's interop txpool:

### 1. Act on the filter verdict when revalidating a pooled interop tx (latent-bug fix)

Previously a filter rejection during revalidation was silently ignored: `maintain.rs` evicted only when `err.is_bad_transaction()`, which is `false` for every `InvalidCrossTx::ValidationError`. So the filter's verdict on an already-pooled tx was never acted on.

Now eviction goes through `InvalidCrossTx::should_evict_on_revalidation` → `InteropTxValidatorError::is_message_permanently_invalid`, which matches **only** `ConflictingData`, `IneffectiveData`, and `DataCorruption` — verdicts meaning the message will never be valid.

This is deliberately narrower than the existing `is_definitive_invalid()` (which also includes `OutOfScope`). Transient / out-of-sync verdicts — `OutOfScope`, `FutureData`, `QuorumNotReached`, `Disagreement`, `Timeout` — **keep** the tx, so a momentarily-lagging filter (e.g. the 1-2s cross-unsafe frontier lag) never drops a valid transaction.

### 2. Configurable validity window

The hardcoded `CHECK_ACCESS_LIST_TIMEOUT_SECS` — which is both the pool `interop_deadline` and the `ExecutingDescriptor` timeout sent to the filter — becomes `--rollup.interop-validity-window` (default `DEFAULT_INTEROP_VALIDITY_WINDOW_SECS = 120`), threaded through the validator and the interop maintenance task.

## Out of scope (intentionally)

The revalidation **cadence is unchanged**: pooled interop txs are still revalidated only in the final 60s before their deadline (the existing `OFFSET_TIME` stale gate). No throttled/continuous revalidation is introduced here.

## Changes

- `crates/txpool/src/interop_filter/errors.rs` — `is_message_permanently_invalid()` (+ unit test).
- `crates/txpool/src/error.rs` — `InvalidCrossTx::should_evict_on_revalidation()`.
- `crates/txpool/src/maintain.rs` — evict via `should_evict_on_revalidation` instead of `is_bad_transaction`; thread the configurable window.
- `crates/txpool/src/validator.rs` — `DEFAULT_INTEROP_VALIDITY_WINDOW_SECS = 120` + per-validator field/setter.
- `crates/node/src/{args.rs,node.rs}`, `crates/txpool/src/lib.rs` — `--rollup.interop-validity-window` flag + plumbing (+ arg test).

## Testing

- `cargo check` / `clippy` / `cargo +nightly fmt` clean on `reth-optimism-txpool` and `reth-optimism-node`.
- `cargo test -p reth-optimism-txpool` — 37 passed (incl. the new `is_message_permanently_invalid` test); arg test passes.