### PR TITLE
fix(contracts): clear residual proxy admin owner nonce in L2 genesis

### DIFF
--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -286,6 +286,9 @@ contract L2Genesis is Script {
             setNativeAssetLiquidity(_input); // 2A
         }
         vm.stopPrank();
+        // The pranked `create` calls in setEAS() and setGovernanceToken() bump the proxy admin
+        // owner's nonce. Reset it so the account does not appear in the genesis state dump.
+        vm.resetNonce(_input.opChainProxyAdminOwner);
         // These calls don't need the opChainProxyAdminOwner prank: setConditionalDeployer uses
         // vm.etch and setL2DevFeatureFlags manages its own prank as DEPOSITOR_ACCOUNT.
         if (DevFeatures.isDevFeatureEnabled(_input.devFeatureBitmap, DevFeatures.L2CM)) {

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -50,6 +50,10 @@ abstract contract L2Genesis_TestInit is Test {
         assertEq(
             IL2ProxyAdmin(proxyAdminImpl).owner(), address(0), "ProxyAdmin implementation owner should match expected"
         );
+
+        // The proxy admin owner must not leak into the genesis state dump. The pranked `create`
+        // calls in setEAS() and setGovernanceToken() bump its nonce, which L2Genesis must reset.
+        assertEq(vm.getNonce(input.opChainProxyAdminOwner), 0, "ProxyAdmin owner nonce should be reset to zero");
     }
 
     function testPredeploys() internal view {


### PR DESCRIPTION
**Description**

`setPredeployImplementations` pranks as `opChainProxyAdminOwner`, and the `create` calls in `setEAS()` and `setGovernanceToken()` bump its nonce. Every generated L2 genesis therefore contained the owner account with a nonzero nonce. Reset the nonce after the prank block so the account no longer appears in the state dump.

**Tests**

Added a nonce-is-zero assertion to `testProxyAdmin()` in `L2Genesis.t.sol`, exercised by all `test_run_*` feature combos (default, interop, CGT, L2CM). Fails with `2 != 0` if the reset is removed.

**Additional context**

Part of #20903 (PCD Milestone 1.5). Keeps the genesis dump clean ahead of the allocs validator in #21340.

**Metadata**

- Fixes #21339
