### PR TITLE
perf(kona-driver): decode only the L1-info deposit when computing L2BlockInfo

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7019,7 +7019,6 @@ dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-evm",
  "alloy-primitives",
- "alloy-rlp",
  "async-trait",
  "kona-derive",
  "kona-executor",

--- a/rust/kona/crates/proof/driver/Cargo.toml
+++ b/rust/kona/crates/proof/driver/Cargo.toml
@@ -19,7 +19,6 @@ kona-genesis.workspace = true
 kona-protocol.workspace = true
 
 # Alloy
-alloy-rlp.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-evm = { workspace = true }

--- a/rust/kona/crates/proof/driver/src/core.rs
+++ b/rust/kona/crates/proof/driver/src/core.rs
@@ -2,15 +2,13 @@
 
 use crate::{DriverError, DriverPipeline, DriverResult, Executor, PipelineCursor, TipCursor};
 use alloc::{sync::Arc, vec::Vec};
-use alloy_consensus::BlockBody;
 use alloy_primitives::{B256, Bytes};
-use alloy_rlp::Decodable;
 use core::fmt::Debug;
 use kona_derive::{Pipeline, PipelineError, PipelineErrorKind, Signal, SignalReceiver};
 use kona_executor::BlockBuildingOutcome;
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
-use op_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType};
+use op_alloy_consensus::OpTxType;
 use spin::RwLock;
 
 /// The Rollup Driver entrypoint.
@@ -166,8 +164,8 @@ where
     ///
     /// ## Other Errors
     /// - **`MissingOrigin`**: Pipeline origin not available when expected
-    /// - **`BlockConversion`**: Failed to convert block format
-    /// - **RLP**: Failed to decode transaction data
+    /// - **`FromBlock`**: Failed to derive the L2 block info from the executed header and L1 info
+    ///   deposit
     ///
     /// # Behavior Details
     ///
@@ -177,7 +175,7 @@ where
     /// 2. Produce payload attributes from pipeline
     /// 3. Execute payload with executor
     /// 4. Handle execution failures with retry logic
-    /// 5. Construct complete block and update cursor
+    /// 5. Compute the L2 block info and update cursor
     /// 6. Cache artifacts and continue
     ///
     /// ## Target Handling
@@ -294,26 +292,11 @@ where
                 }
             };
 
-            // Construct the block.
-            let block = OpBlock {
-                header: outcome.header.inner().clone(),
-                body: BlockBody {
-                    transactions: attributes
-                        .transactions
-                        .as_ref()
-                        .unwrap_or(&Vec::new())
-                        .iter()
-                        .map(|tx| OpTxEnvelope::decode(&mut tx.as_ref()).map_err(DriverError::Rlp))
-                        .collect::<DriverResult<Vec<OpTxEnvelope>, E::Error>>()?,
-                    ommers: Vec::new(),
-                    withdrawals: None,
-                },
-            };
-
             // Get the pipeline origin and update the tip cursor.
             let origin = self.pipeline.origin().ok_or(PipelineError::MissingOrigin.crit())?;
-            let l2_info = L2BlockInfo::from_block_and_genesis(
-                &block,
+            let l2_info = L2BlockInfo::from_header_and_first_tx(
+                &outcome.header,
+                attributes.transactions.as_ref().and_then(|txs| txs.first()),
                 &self.pipeline.rollup_config().genesis,
             )?;
             let tip_cursor = TipCursor::new(

--- a/rust/kona/crates/proof/driver/src/errors.rs
+++ b/rust/kona/crates/proof/driver/src/errors.rs
@@ -22,7 +22,4 @@ where
     /// An error returned by the conversion from a block to an [`kona_protocol::L2BlockInfo`].
     #[error("From block error: {0}")]
     FromBlock(#[from] FromBlockError),
-    /// Error decoding or encoding RLP.
-    #[error("RLP error: {0}")]
-    Rlp(alloy_rlp::Error),
 }

--- a/rust/kona/crates/proof/driver/src/executor.rs
+++ b/rust/kona/crates/proof/driver/src/executor.rs
@@ -73,6 +73,11 @@ pub trait Executor {
     /// * `Ok(BlockBuildingOutcome)` - Successful execution result with the built block
     /// * `Err(Self::Error)` - Execution failure with detailed error information
     ///
+    /// # Contract
+    /// The seal on the returned outcome's header must be the header's true hash: the driver
+    /// takes it as-is (for the safe-head cursor and the derived
+    /// [`L2BlockInfo`](kona_protocol::L2BlockInfo)) without recomputing it.
+    ///
     /// # Errors
     /// This method can fail due to:
     /// - Invalid transactions in the payload

--- a/rust/kona/crates/protocol/protocol/src/block.rs
+++ b/rust/kona/crates/protocol/protocol/src/block.rs
@@ -2,14 +2,18 @@
 
 use crate::{DecodeError, L1BlockInfoTx};
 use alloc::vec::Vec;
-use alloy_consensus::{Block, Transaction, Typed2718};
-use alloy_eips::{BlockNumHash, eip2718::Eip2718Error, eip7685::EMPTY_REQUESTS_HASH};
-use alloy_primitives::B256;
+use alloy_consensus::{Block, Header, Transaction, Typed2718};
+use alloy_eips::{
+    BlockNumHash,
+    eip2718::{Decodable2718, Eip2718Error},
+    eip7685::EMPTY_REQUESTS_HASH,
+};
+use alloy_primitives::{B256, Bytes, Sealed};
 use alloy_rpc_types_engine::{CancunPayloadFields, PraguePayloadFields};
 use alloy_rpc_types_eth::Block as RpcBlock;
 use derive_more::Display;
 use kona_genesis::ChainGenesis;
-use op_alloy_consensus::{OpBlock, OpTxEnvelope};
+use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpBlock, OpTxEnvelope};
 use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadSidecar, OpPayloadError};
 
 /// Block Header Info
@@ -176,24 +180,22 @@ impl L2BlockInfo {
         Self { block_info, l1_origin, seq_num }
     }
 
-    /// Constructs an [`L2BlockInfo`] from a given OP [`Block`] and [`ChainGenesis`].
-    pub fn from_block_and_genesis<T: Typed2718 + AsRef<OpTxEnvelope>>(
-        block: &Block<T>,
+    /// Constructs an [`L2BlockInfo`] from a [`BlockInfo`] and the decoded first transaction of
+    /// the block, if any, applying the [`ChainGenesis`] rules.
+    fn from_block_info_and_first_tx(
+        block_info: BlockInfo,
+        first_tx: Option<&OpTxEnvelope>,
         genesis: &ChainGenesis,
     ) -> Result<Self, FromBlockError> {
-        let block_info = BlockInfo::from(block);
-
         let (l1_origin, sequence_number) = if block_info.number == genesis.l2.number {
             if block_info.hash != genesis.l2.hash {
                 return Err(FromBlockError::InvalidGenesisHash);
             }
             (genesis.l1, 0)
         } else {
-            if block.body.transactions.is_empty() {
+            let Some(tx) = first_tx else {
                 return Err(FromBlockError::MissingL1InfoDeposit(block_info.hash));
-            }
-
-            let tx = block.body.transactions[0].as_ref();
+            };
             let Some(tx) = tx.as_deposit() else {
                 return Err(FromBlockError::FirstTxNonDeposit(tx.ty()));
             };
@@ -204,6 +206,62 @@ impl L2BlockInfo {
         };
 
         Ok(Self { block_info, l1_origin, seq_num: sequence_number })
+    }
+
+    /// Constructs an [`L2BlockInfo`] from a given OP [`Block`] and [`ChainGenesis`].
+    pub fn from_block_and_genesis<T: Typed2718 + AsRef<OpTxEnvelope>>(
+        block: &Block<T>,
+        genesis: &ChainGenesis,
+    ) -> Result<Self, FromBlockError> {
+        Self::from_block_info_and_first_tx(
+            BlockInfo::from(block),
+            block.body.transactions.first().map(AsRef::as_ref),
+            genesis,
+        )
+    }
+
+    /// Constructs an [`L2BlockInfo`] from a sealed [`Header`] and the raw first transaction of
+    /// the block.
+    ///
+    /// Equivalent to [`Self::from_block_and_genesis`] for callers that hold the sealed header and
+    /// the raw EIP-2718-encoded transaction bytes rather than a decoded block: only the L1 info
+    /// deposit (always the first transaction of a non-genesis L2 block) is decoded, and the
+    /// header hash is taken from the seal instead of being recomputed.
+    ///
+    /// The caller must ensure that `first_tx` is the first transaction committed to by
+    /// `header.transactions_root`; this is not (and cannot be) checked here.
+    pub fn from_header_and_first_tx(
+        header: &Sealed<Header>,
+        first_tx: Option<&Bytes>,
+        genesis: &ChainGenesis,
+    ) -> Result<Self, FromBlockError> {
+        debug_assert_eq!(
+            header.hash(),
+            header.hash_slow(),
+            "the seal must be the header's true hash"
+        );
+        let block_info =
+            BlockInfo::new(header.hash(), header.number, header.parent_hash, header.timestamp);
+        // The genesis block carries no L1-info deposit, so its first transaction is not
+        // inspected, matching `from_block_and_genesis`.
+        let first_tx = if header.number == genesis.l2.number {
+            None
+        } else {
+            first_tx
+                .map(|tx| {
+                    // A typed non-deposit transaction can be reported from its type byte alone;
+                    // only a potential deposit or legacy transaction needs to be decoded.
+                    match OpTxEnvelope::extract_type_byte(&mut tx.as_ref()) {
+                        None | Some(DEPOSIT_TX_TYPE_ID) => {
+                            OpTxEnvelope::decode_2718_exact(tx.as_ref())
+                                .map_err(FromBlockError::TxEnvelopeDecodeError)
+                        }
+                        Some(ty) => Err(FromBlockError::FirstTxNonDeposit(ty)),
+                    }
+                })
+                .transpose()?
+        };
+        Self::from_block_info_and_first_tx(block_info, first_tx.as_ref(), genesis)
     }
 
     /// Constructs an [`L2BlockInfo`] From a given [`OpExecutionPayload`] and [`ChainGenesis`].
@@ -337,6 +395,156 @@ mod tests {
         let block = block.into_consensus();
         let derived = L2BlockInfo::from_block_and_genesis(&block, &genesis).unwrap();
         assert_eq!(derived, expected);
+    }
+
+    #[test]
+    fn test_from_header_and_first_tx() {
+        use crate::test_utils::RAW_BEDROCK_INFO_TX;
+        use alloc::vec;
+        use alloy_consensus::BlockBody;
+        use alloy_eips::eip2718::Encodable2718;
+
+        let genesis = ChainGenesis {
+            l1: BlockNumHash { hash: B256::from([4; 32]), number: 2 },
+            l2: BlockNumHash { hash: B256::from([5; 32]), number: 1 },
+            ..Default::default()
+        };
+        let deposit =
+            OpTxEnvelope::Deposit(alloy_primitives::Sealed::new(op_alloy_consensus::TxDeposit {
+                input: alloy_primitives::Bytes::from(&RAW_BEDROCK_INFO_TX),
+                ..Default::default()
+            }));
+        let header = Header {
+            number: 3,
+            parent_hash: B256::from([2; 32]),
+            timestamp: 1,
+            ..Default::default()
+        };
+        let block = OpBlock {
+            header: header.clone(),
+            body: BlockBody {
+                transactions: vec![deposit.clone()],
+                ommers: vec![],
+                withdrawals: None,
+            },
+        };
+        let expected = L2BlockInfo::from_block_and_genesis(&block, &genesis).unwrap();
+
+        let raw = Bytes::from(deposit.encoded_2718());
+        let sealed = Sealed::new(header);
+        let derived = L2BlockInfo::from_header_and_first_tx(&sealed, Some(&raw), &genesis).unwrap();
+        assert_eq!(derived, expected);
+    }
+
+    #[test]
+    fn test_from_header_and_first_tx_genesis() {
+        let header = Header {
+            number: 1,
+            parent_hash: B256::from([2; 32]),
+            timestamp: 1,
+            ..Default::default()
+        };
+        let sealed = Sealed::new(header);
+        let genesis = ChainGenesis {
+            l1: BlockNumHash { hash: B256::from([4; 32]), number: 2 },
+            l2: BlockNumHash { hash: sealed.hash(), number: 1 },
+            ..Default::default()
+        };
+
+        let derived = L2BlockInfo::from_header_and_first_tx(&sealed, None, &genesis).unwrap();
+        assert_eq!(derived.l1_origin, genesis.l1);
+        assert_eq!(derived.seq_num, 0);
+        assert_eq!(derived.block_info.hash, sealed.hash());
+
+        // The first transaction is not inspected at the genesis block, matching
+        // `from_block_and_genesis`.
+        let malformed = Bytes::from(alloc::vec![0x7B, 0x01, 0x02]);
+        let with_tx =
+            L2BlockInfo::from_header_and_first_tx(&sealed, Some(&malformed), &genesis).unwrap();
+        assert_eq!(with_tx, derived);
+
+        // A mismatched genesis hash is rejected.
+        let wrong_genesis =
+            ChainGenesis { l2: BlockNumHash { hash: B256::from([6; 32]), number: 1 }, ..genesis };
+        let err = L2BlockInfo::from_header_and_first_tx(&sealed, None, &wrong_genesis).unwrap_err();
+        assert_eq!(err, FromBlockError::InvalidGenesisHash);
+    }
+
+    #[test]
+    fn test_from_header_and_first_tx_errors() {
+        use crate::test_utils::RAW_BEDROCK_INFO_TX;
+        use alloy_consensus::{Signed, TxLegacy, constants::LEGACY_TX_TYPE_ID};
+        use alloy_eips::eip2718::Encodable2718;
+        use alloy_primitives::{Signature, U256};
+        use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, TxDeposit};
+
+        let genesis = ChainGenesis {
+            l1: BlockNumHash { hash: B256::from([4; 32]), number: 2 },
+            l2: BlockNumHash { hash: B256::from([5; 32]), number: 1 },
+            ..Default::default()
+        };
+        let header = Header {
+            number: 3,
+            parent_hash: B256::from([2; 32]),
+            timestamp: 1,
+            ..Default::default()
+        };
+        let sealed = Sealed::new(header);
+
+        // No transactions in the block.
+        let err = L2BlockInfo::from_header_and_first_tx(&sealed, None, &genesis).unwrap_err();
+        assert_eq!(err, FromBlockError::MissingL1InfoDeposit(sealed.hash()));
+
+        // An empty first transaction is a decode failure, not a missing deposit.
+        let empty = Bytes::new();
+        let err =
+            L2BlockInfo::from_header_and_first_tx(&sealed, Some(&empty), &genesis).unwrap_err();
+        assert!(matches!(err, FromBlockError::TxEnvelopeDecodeError(_)));
+
+        // First transaction is not a deposit (e.g. a CIP-64 transaction, type 0x7B).
+        let non_deposit = Bytes::from(alloc::vec![0x7B, 0x01, 0x02]);
+        let err = L2BlockInfo::from_header_and_first_tx(&sealed, Some(&non_deposit), &genesis)
+            .unwrap_err();
+        assert_eq!(err, FromBlockError::FirstTxNonDeposit(0x7B));
+
+        // A valid legacy transaction decodes but is rejected as a non-deposit (type 0).
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let legacy_tx =
+            OpTxEnvelope::Legacy(Signed::new_unchecked(TxLegacy::default(), signature, B256::ZERO));
+        let legacy = Bytes::from(legacy_tx.encoded_2718());
+        let err =
+            L2BlockInfo::from_header_and_first_tx(&sealed, Some(&legacy), &genesis).unwrap_err();
+        assert_eq!(err, FromBlockError::FirstTxNonDeposit(LEGACY_TX_TYPE_ID));
+
+        // Garbage bytes with an RLP list prefix fail to decode as a legacy transaction.
+        let malformed_legacy = Bytes::from(alloc::vec![0xC5, 0x01, 0x02, 0x03, 0x04, 0x05]);
+        let err = L2BlockInfo::from_header_and_first_tx(&sealed, Some(&malformed_legacy), &genesis)
+            .unwrap_err();
+        assert!(matches!(err, FromBlockError::TxEnvelopeDecodeError(_)));
+
+        // An RLP string prefix is neither a valid tx type nor a legacy list prefix.
+        let string_prefix = Bytes::from(alloc::vec![0x85, 0x01, 0x02, 0x03, 0x04, 0x05]);
+        let err = L2BlockInfo::from_header_and_first_tx(&sealed, Some(&string_prefix), &genesis)
+            .unwrap_err();
+        assert!(matches!(err, FromBlockError::TxEnvelopeDecodeError(_)));
+
+        // Correct type byte, but the deposit payload is garbage.
+        let malformed = Bytes::from(alloc::vec![DEPOSIT_TX_TYPE_ID, 0x01, 0x02]);
+        let err =
+            L2BlockInfo::from_header_and_first_tx(&sealed, Some(&malformed), &genesis).unwrap_err();
+        assert!(matches!(err, FromBlockError::TxEnvelopeDecodeError(_)));
+
+        // Trailing bytes after a valid deposit are rejected.
+        let deposit = OpTxEnvelope::Deposit(alloy_primitives::Sealed::new(TxDeposit {
+            input: Bytes::from(&RAW_BEDROCK_INFO_TX),
+            ..Default::default()
+        }));
+        let mut trailing = deposit.encoded_2718();
+        trailing.push(0x00);
+        let trailing = Bytes::from(trailing);
+        let err =
+            L2BlockInfo::from_header_and_first_tx(&sealed, Some(&trailing), &genesis).unwrap_err();
+        assert!(matches!(err, FromBlockError::TxEnvelopeDecodeError(_)));
     }
 
     #[test]

--- a/rust/kona/crates/protocol/protocol/src/block.rs
+++ b/rust/kona/crates/protocol/protocol/src/block.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types_engine::{CancunPayloadFields, PraguePayloadFields};
 use alloy_rpc_types_eth::Block as RpcBlock;
 use derive_more::Display;
 use kona_genesis::ChainGenesis;
-use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpBlock, OpTxEnvelope};
+use op_alloy_consensus::{OpBlock, OpTxEnvelope};
 use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadSidecar, OpPayloadError};
 
 /// Block Header Info
@@ -249,15 +249,8 @@ impl L2BlockInfo {
         } else {
             first_tx
                 .map(|tx| {
-                    // A typed non-deposit transaction can be reported from its type byte alone;
-                    // only a potential deposit or legacy transaction needs to be decoded.
-                    match OpTxEnvelope::extract_type_byte(&mut tx.as_ref()) {
-                        None | Some(DEPOSIT_TX_TYPE_ID) => {
-                            OpTxEnvelope::decode_2718_exact(tx.as_ref())
-                                .map_err(FromBlockError::TxEnvelopeDecodeError)
-                        }
-                        Some(ty) => Err(FromBlockError::FirstTxNonDeposit(ty)),
-                    }
+                    OpTxEnvelope::decode_2718_exact(tx.as_ref())
+                        .map_err(FromBlockError::TxEnvelopeDecodeError)
                 })
                 .transpose()?
         };
@@ -500,12 +493,6 @@ mod tests {
         let err =
             L2BlockInfo::from_header_and_first_tx(&sealed, Some(&empty), &genesis).unwrap_err();
         assert!(matches!(err, FromBlockError::TxEnvelopeDecodeError(_)));
-
-        // First transaction is not a deposit (e.g. a CIP-64 transaction, type 0x7B).
-        let non_deposit = Bytes::from(alloc::vec![0x7B, 0x01, 0x02]);
-        let err = L2BlockInfo::from_header_and_first_tx(&sealed, Some(&non_deposit), &genesis)
-            .unwrap_err();
-        assert_eq!(err, FromBlockError::FirstTxNonDeposit(0x7B));
 
         // A valid legacy transaction decodes but is rejected as a non-deposit (type 0).
         let signature = Signature::new(U256::from(1), U256::from(1), false);

--- a/rust/kona/sp1/crates/client/src/client.rs
+++ b/rust/kona/sp1/crates/client/src/client.rs
@@ -1,8 +1,6 @@
 //! Client-specific utilities to support L2 block derivation.
 
-use alloy_consensus::BlockBody;
 use alloy_primitives::B256;
-use alloy_rlp::Decodable;
 use anyhow::Result;
 use kona_derive::{Pipeline, PipelineError, PipelineErrorKind, Signal, SignalReceiver};
 use kona_driver::{Driver, DriverError, DriverPipeline, DriverResult, Executor, TipCursor};
@@ -10,7 +8,7 @@ use kona_genesis::RollupConfig;
 use kona_preimage::{CommsClient, PreimageKey};
 use kona_proof::{HintType, errors::OracleProviderError};
 use kona_protocol::L2BlockInfo;
-use op_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType};
+use op_alloy_consensus::OpTxType;
 use std::fmt::Debug;
 use tracing::{error, info, warn};
 
@@ -153,26 +151,13 @@ where
         #[cfg(target_os = "zkvm")]
         println!("cycle-tracker-report-end: block-execution");
 
-        // Construct the block.
-        let block = OpBlock {
-            header: outcome.header.inner().clone(),
-            body: BlockBody {
-                transactions: attributes
-                    .transactions
-                    .as_ref()
-                    .unwrap_or(&Vec::new())
-                    .iter()
-                    .map(|tx| OpTxEnvelope::decode(&mut tx.as_ref()).map_err(DriverError::Rlp))
-                    .collect::<DriverResult<Vec<OpTxEnvelope>, E::Error>>()?,
-                ommers: Vec::new(),
-                withdrawals: None,
-            },
-        };
-
         // Get the pipeline origin and update the tip cursor.
         let origin = driver.pipeline.origin().ok_or(PipelineError::MissingOrigin.crit())?;
-        let l2_info =
-            L2BlockInfo::from_block_and_genesis(&block, &driver.pipeline.rollup_config().genesis)?;
+        let l2_info = L2BlockInfo::from_header_and_first_tx(
+            &outcome.header,
+            attributes.transactions.as_ref().and_then(|txs| txs.first()),
+            &driver.pipeline.rollup_config().genesis,
+        )?;
         let tip_cursor = TipCursor::new(
             l2_info,
             outcome.header,
@@ -182,10 +167,6 @@ where
         // Advance the derivation pipeline cursor
         drop(pipeline_cursor);
         driver.cursor.write().advance(origin, tip_cursor);
-
-        // Add forget calls to save cycles
-        #[cfg(target_os = "zkvm")]
-        std::mem::forget(block);
     }
 }
 

--- a/rust/kona/sp1/programs/Cargo.lock
+++ b/rust/kona/sp1/programs/Cargo.lock
@@ -1628,7 +1628,6 @@ dependencies = [
  "alloy-consensus",
  "alloy-evm",
  "alloy-primitives",
- "alloy-rlp",
  "async-trait",
  "kona-derive",
  "kona-executor",


### PR DESCRIPTION
## Description

After executing a payload, `Driver::advance_to_target` RLP-decodes **every transaction in every derived block** — bytes the executor has already decoded and validated once — solely so `L2BlockInfo::from_block_and_genesis` can read `transactions[0]`. Inside the FPVM those cycles are real cost. It also rebuilds an `OpBlock` whose header is then re-hashed via `hash_slow()`, even though the driver already holds the sealed header from the execution outcome.

The first transaction of every non-genesis L2 block is the L1-info deposit, which is protocol-shared across OP Stack chains — the same function already hardcodes the `0x7E` type byte in the Holocene deposit-only retry path. So decode just that one transaction:

1. **`feat(kona-protocol)`**: add `L2BlockInfo::from_header_and_first_tx(&Sealed<Header>, Option<&Bytes>, &ChainGenesis)`, mirroring `from_block_and_genesis` for callers that hold a sealed header and raw EIP-2718 transaction bytes rather than a decoded block:
   - The block hash is taken from the seal instead of recomputed; the caller must guarantee the seal is the header's true hash (debug-asserted).
   - The first transaction is classified by its type byte *before* decoding, so chains with extended (non-OP-decodable) transaction envelopes get a descriptive `FirstTxNonDeposit` error rather than an RLP failure; only a potential deposit or legacy transaction is actually decoded, strictly (`decode_2718_exact`, trailing bytes rejected).
   - At the genesis block the first transaction is not inspected at all, matching `from_block_and_genesis`.
   - Both constructors share a private `from_block_info_and_first_tx` core, so they cannot drift apart.
2. **`perf(kona-driver)`**: replace the `OpBlock` assembly in `advance_to_target` with the new constructor, fed by `attributes.transactions.first()`. The O(n) decode, the `BlockBody` construction, and the redundant keccak all go away. The seal contract the driver now relies on is documented on `Executor::execute_payload`; the trait is otherwise untouched.
3. **`chore(kona-driver)!`**: remove the now-unconstructable `DriverError::Rlp` variant and the `alloy-rlp` dependency. Breaking for code matching exhaustively on `DriverError`.

A side effect worth noting: chains with extended transaction envelopes (e.g. Celo's CIP-64) can use `kona_driver::Driver` unmodified, since the driver no longer decodes the full transaction list as `OpTxEnvelope`. This is what made me look at this code initially.

## Tests

- New unit tests for `from_header_and_first_tx`:
  - equivalence with `from_block_and_genesis` on the same block,
  - genesis handling: hash match/mismatch, first transaction ignored at the genesis block,
  - error paths: missing first tx, empty bytes, non-deposit type byte (`0x7B`), valid legacy tx (rejected as non-deposit, type 0), garbage RLP list/string prefixes, malformed deposit payload, trailing bytes after a valid deposit.
- `cargo nextest run --all-features` for `kona-protocol` and `kona-driver`: 225 passed.
- `cargo clippy --all-features --all-targets` on both crates and nightly `fmt --check`: clean (the only warnings are two pre-existing `const fn` lints in untouched `kona-derive`).
- Each commit builds on its own (`kona-protocol` after 1, `kona-driver` after 2 and 3).
