### PR TITLE
docs(notices): update U19 kona-client absolute prestate to v1.6.0-rc.2

### DIFF
--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -75,12 +75,21 @@ Because Upgrade 19 includes hard fork changes (Osaka on L2 and Glamsterdam Defen
   </Step>
 
   <Step title="Configure the Karst activation timestamp">
-  * Set the `karst_time: <timestamp>` in the `op-node` rollup config.
-  * Set the `"karstTime": <timestamp>` in the `op-reth` genesis file.
+  How you configure the Karst activation timestamp depends on whether your chain is in the superchain-registry.
+
+  **Chains in the superchain-registry** (e.g. `OP`, `Soneium`, `Ink`, `Unichain`, `Mode`, `Metal`, `Zora`):
+  The Karst activation timestamp is built into the updated releases — no manual timestamp configuration is needed. Make sure you are using the network flag so that op-node and op-reth load chain config from the superchain-registry:
+  * `op-node`: [`--network <network>`](/node-operators/reference/op-node-config#network) (e.g. `--network op-mainnet`, `--network soneium-mainnet`, `--network op-sepolia`)
+  * `op-reth`: [`--chain <network>`](/node-operators/reference/op-reth-config#chain) (e.g. `--chain op`, `--chain soneium`, `--chain unichain`)
+
+  **Chains not in the superchain-registry:**
+  Set the activation timestamp manually in each client's config:
+  * `op-node`: set `karst_time: <timestamp>` in the rollup config
+  * `op-reth`: set `"karstTime": <timestamp>` in the genesis file
   </Step>
 
   <Step title="Verify activation configuration">
-  Make the following checks to verify that your node is properly configured.
+  Make the following checks to verify that your node is properly configured:
     * The configurations will be logged at startup
     * Check that the Karst time is set to its correct activation timestamp
   </Step>

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -115,7 +115,7 @@ If your chain was already configured for `cannon-kona` as part of [Upgrade 18](/
 <Steps>
   <Step title="Verify the new kona-client absolute prestate">
 
-  The absolute prestate is generated with [`kona-client/v1.6.0`](https://github.com/ethereum-optimism/optimism/releases/tag/kona-client%2Fv1.6.0). As of Upgrade 19, the `kona-client` source lives inside the [`ethereum-optimism/optimism`](https://github.com/ethereum-optimism/optimism) monorepo.
+  The absolute prestate is generated with [`kona-client/v1.6.0-rc.2`](https://github.com/ethereum-optimism/optimism/releases/tag/kona-client%2Fv1.6.0-rc.2). As of Upgrade 19, the `kona-client` source lives inside the [`ethereum-optimism/optimism`](https://github.com/ethereum-optimism/optimism) monorepo.
 
   Choose the verification path that matches your chain:
 
@@ -123,14 +123,14 @@ If your chain was already configured for `cannon-kona` as part of [Upgrade 18](/
     <Tab title="Chains in the superchain-registry">
       Two variants ship with this release:
 
-      *   **`cannon64-kona`** (`0x03cdb57a890f7e129d5abbe074f19425f94cf2b84f614aab008a96f91debae65`) — standard variant for chains adopting `CANNON_KONA` (game type 8) as the respected game type.
-      *   **`cannon64-kona-interop`** (`0x039e98f06aa04983d15f8dfce40884c4c93131de8ab4c01d9e647ab38a954894`) — for chains also running the interop fault proof variant.
+      *   **`cannon64-kona`** (`0x0337ecb3604c0b40c352e0c7711beb17a212d583f4fe956fd8d66e29ad5f9025`) — standard variant for chains adopting `CANNON_KONA` (game type 8) as the respected game type.
+      *   **`cannon64-kona-interop`** (`0x03e3a42cf9a1d116f414206c465c6cdb74556136090e7c9556329403da0f310f`) — for chains also running the interop fault proof variant.
 
       These prestates apply to the following chains:
 
       *   Mainnet and Sepolia: `OP`, `Ink`, `Soneium`, and `Unichain`
 
-      You can verify both absolute prestates by running the following command in the root of the monorepo on the `kona-client/v1.6.0` tag:
+      You can verify both absolute prestates by running the following command in the root of the monorepo on the `kona-client/v1.6.0-rc.2` tag:
 
       ```shell
       just reproducible-prestate-kona


### PR DESCRIPTION
## Summary

- Updates `kona-client` reference from `v1.6.0` to `v1.6.0-rc.2` (the final `v1.6.0` tag does not exist yet)
- Updates `cannon64-kona` prestate hash to `0x0337ecb3604c0b40c352e0c7711beb17a212d583f4fe956fd8d66e29ad5f9025`
- Updates `cannon64-kona-interop` prestate hash to `0x03e3a42cf9a1d116f414206c465c6cdb74556136090e7c9556329403da0f310f`

Both hashes were independently verified by a local Docker reproducible build (`just reproducible-prestate-kona` at the `kona-client/v1.6.0-rc.2` tag) and match the entries in [superchain-registry standard-prestates.toml](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml) (merged via superchain-registry#1256, also independently verified by @Wazabie ).

## Test plan

- [ ] Verify hashes match superchain-registry `standard-prestates.toml` entries for `1.6.0-rc.2`
- [ ] Confirm docs render correctly at the preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)