### PR TITLE
feat(op-reth): add configurable max uncompressed block size cap

### DIFF
--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -160,6 +160,15 @@ pub struct RollupArgs {
     #[arg(long, default_value_t = 1_000_000)]
     pub min_suggested_priority_fee: u64,
 
+    /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
+    ///
+    /// When set, the payload builder stops including mempool transactions once the block's total
+    /// uncompressed transaction size would exceed this value. This bounds the size of the
+    /// `engine_getPayload` response so it stays within the limits assumed by consensus-layer
+    /// clients (e.g. the common 10 MiB JSON payload cap). Unset means no limit.
+    #[arg(long = "rollup.max-uncompressed-block-size", value_name = "MAX_UNCOMPRESSED_BLOCK_SIZE")]
+    pub max_uncompressed_block_size: Option<u64>,
+
     /// A URL pointing to a secure websocket subscription that streams out flashblocks.
     ///
     /// If given, the flashblocks are received to build pending block. All request with "pending"
@@ -227,6 +236,7 @@ impl Default for RollupArgs {
             sequencer_headers: Vec::new(),
             historical_rpc: None,
             min_suggested_priority_fee: 1_000_000,
+            max_uncompressed_block_size: None,
             flashblocks_url: None,
             flashblock_consensus: false,
             proofs_history: false,
@@ -323,6 +333,19 @@ mod tests {
             "http://c:3",
             "--rollup.interop-min-responses",
             "2",
+        ])
+        .args;
+        assert_eq!(args, expected_args);
+    }
+
+    #[test]
+    fn test_parse_max_uncompressed_block_size() {
+        let expected_args =
+            RollupArgs { max_uncompressed_block_size: Some(7_340_032), ..Default::default() };
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--rollup.max-uncompressed-block-size",
+            "7340032",
         ])
         .args;
         assert_eq!(args, expected_args);

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -265,7 +265,8 @@ impl OpNode {
                 OpPayloadBuilder::new(compute_pending_block)
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone())
-                    .with_sdm_post_exec_opt_in(self.sdm_post_exec_opt_in.clone()),
+                    .with_sdm_post_exec_opt_in(self.sdm_post_exec_opt_in.clone())
+                    .with_max_uncompressed_block_size(self.args.max_uncompressed_block_size),
             ))
             .network(OpNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
             .consensus(OpConsensusBuilder::default())
@@ -1301,6 +1302,11 @@ pub struct OpPayloadBuilder<Txs = ()> {
     pub gas_limit_config: OpGasLimitConfig,
     /// Operator opt-in flag for SDM `PostExec` production. Shared with the admin RPC.
     pub sdm_post_exec_opt_in: SdmPostExecOptIn,
+    /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
+    ///
+    /// `None` disables the limit. See
+    /// [`OpBuilderConfig::max_uncompressed_block_size`](reth_optimism_payload_builder::config::OpBuilderConfig::max_uncompressed_block_size).
+    pub max_uncompressed_block_size: Option<u64>,
 }
 
 impl OpPayloadBuilder {
@@ -1313,12 +1319,22 @@ impl OpPayloadBuilder {
             da_config: OpDAConfig::default(),
             gas_limit_config: OpGasLimitConfig::default(),
             sdm_post_exec_opt_in: SdmPostExecOptIn::default(),
+            max_uncompressed_block_size: None,
         }
     }
 
     /// Configure the data availability configuration for the OP payload builder.
     pub fn with_da_config(mut self, da_config: OpDAConfig) -> Self {
         self.da_config = da_config;
+        self
+    }
+
+    /// Configure the maximum uncompressed (EIP-2718 encoded) block size for the OP payload builder.
+    pub const fn with_max_uncompressed_block_size(
+        mut self,
+        max_uncompressed_block_size: Option<u64>,
+    ) -> Self {
+        self.max_uncompressed_block_size = max_uncompressed_block_size;
         self
     }
 
@@ -1341,7 +1357,12 @@ impl<Txs> OpPayloadBuilder<Txs> {
     /// payload.
     pub fn with_transactions<T>(self, best_transactions: T) -> OpPayloadBuilder<T> {
         let Self {
-            compute_pending_block, da_config, gas_limit_config, sdm_post_exec_opt_in, ..
+            compute_pending_block,
+            da_config,
+            gas_limit_config,
+            sdm_post_exec_opt_in,
+            max_uncompressed_block_size,
+            ..
         } = self;
         OpPayloadBuilder {
             compute_pending_block,
@@ -1349,6 +1370,7 @@ impl<Txs> OpPayloadBuilder<Txs> {
             da_config,
             gas_limit_config,
             sdm_post_exec_opt_in,
+            max_uncompressed_block_size,
         }
     }
 }
@@ -1399,6 +1421,7 @@ where
                 da_config: self.da_config.clone(),
                 gas_limit_config: self.gas_limit_config.clone(),
                 sdm_post_exec_opt_in: self.sdm_post_exec_opt_in.clone(),
+                max_uncompressed_block_size: self.max_uncompressed_block_size,
             },
         )
         .with_transactions(self.best_transactions.clone())

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -664,6 +664,7 @@ impl ExecutionInfo {
     ///   maximum allowed DA limit per block.
     /// - block uncompressed size limit: if configured, ensures including the transaction would not
     ///   push the block's total uncompressed (EIP-2718 encoded) size past the maximum.
+    #[allow(clippy::too_many_arguments)]
     pub fn is_tx_over_limits(
         &self,
         tx_da_size: u64,

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -4,6 +4,7 @@ use crate::{
     error::OpPayloadBuilderError, payload::OpBuiltPayload,
 };
 use alloy_consensus::{BlockHeader, Sealable, Transaction, Typed2718, transaction::Recovered};
+use alloy_eips::eip2718::Encodable2718;
 use alloy_evm::Evm as AlloyEvm;
 use alloy_primitives::{Address, B256, Sealed, U256};
 use alloy_rpc_types_debug::ExecutionWitness;
@@ -627,6 +628,10 @@ pub struct ExecutionInfo {
     pub cumulative_evm_gas_used: u64,
     /// Estimated DA size
     pub cumulative_da_bytes_used: u64,
+    /// Cumulative uncompressed (EIP-2718 encoded) size of every transaction included in the block
+    /// so far, in bytes. Bounds the block against the configured
+    /// [`max_uncompressed_block_size`](crate::config::OpBuilderConfig::max_uncompressed_block_size).
+    pub cumulative_uncompressed_bytes: u64,
     /// Tracks fees from executed mempool transactions
     pub total_fees: U256,
 }
@@ -638,6 +643,7 @@ impl ExecutionInfo {
             cumulative_gas_used: 0,
             cumulative_evm_gas_used: 0,
             cumulative_da_bytes_used: 0,
+            cumulative_uncompressed_bytes: 0,
             total_fees: U256::ZERO,
         }
     }
@@ -656,6 +662,8 @@ impl ExecutionInfo {
     ///   per tx.
     /// - block DA limit: if configured, ensures the transaction's DA size does not exceed the
     ///   maximum allowed DA limit per block.
+    /// - block uncompressed size limit: if configured, ensures including the transaction would not
+    ///   push the block's total uncompressed (EIP-2718 encoded) size past the maximum.
     pub fn is_tx_over_limits(
         &self,
         tx_da_size: u64,
@@ -664,6 +672,8 @@ impl ExecutionInfo {
         block_data_limit: Option<u64>,
         tx_gas_limit: u64,
         da_footprint_gas_scalar: Option<u16>,
+        tx_uncompressed_size: u64,
+        max_uncompressed_block_size: Option<u64>,
     ) -> bool {
         if tx_data_limit.is_some_and(|da_limit| tx_da_size > da_limit) {
             return true;
@@ -673,6 +683,17 @@ impl ExecutionInfo {
 
         if block_data_limit.is_some_and(|da_limit| total_da_bytes_used > da_limit) {
             return true;
+        }
+
+        // Stop including transactions once the block's uncompressed (EIP-2718 encoded) size would
+        // exceed the configured maximum. This keeps the built payload within the size assumed by
+        // consensus-layer clients.
+        if let Some(max_uncompressed_block_size) = max_uncompressed_block_size {
+            let total_uncompressed_bytes =
+                self.cumulative_uncompressed_bytes.saturating_add(tx_uncompressed_size);
+            if total_uncompressed_bytes > max_uncompressed_block_size {
+                return true;
+            }
         }
 
         // Post Jovian: the tx DA footprint must be less than the block gas limit
@@ -844,6 +865,9 @@ where
             // Sequencer txs (deposits/system txs) are never SDM-refunded, so pre-refund gas equals
             // canonical gas; track it so the pool-tx pre-refund check starts from the right total.
             info.accumulate_gas(tx_gas_used, tx_gas_used);
+            // Count the sequencer tx towards the block's uncompressed size so the pool-tx
+            // uncompressed-size check starts from the right total.
+            info.cumulative_uncompressed_bytes += sequencer_tx.encode_2718_len() as u64;
 
             // Record the successfully committed transaction for callers that want per-call
             // visibility.
@@ -895,6 +919,7 @@ where
         }
         let block_da_limit = self.builder_config.da_config.max_da_block_size();
         let tx_da_limit = self.builder_config.da_config.max_da_tx_size();
+        let max_uncompressed_block_size = self.builder_config.max_uncompressed_block_size;
         let base_fee = builder.evm_mut().block().basefee();
 
         while let Some(tx) = best_txs.next(()) {
@@ -907,6 +932,7 @@ where
                 .effective_tip_per_gas(base_fee)
                 .expect("selected pool transaction must have a valid effective miner tip at the block base fee");
             let tx = tx.into_consensus();
+            let tx_uncompressed_size = tx.encode_2718_len() as u64;
 
             let da_footprint_gas_scalar = self
                 .chain_spec
@@ -924,6 +950,8 @@ where
                 block_da_limit,
                 tx.gas_limit(),
                 da_footprint_gas_scalar,
+                tx_uncompressed_size,
+                max_uncompressed_block_size,
             ) {
                 // we can't fit this transaction into the block, so we need to mark it as
                 // invalid which also removes all dependent transaction from
@@ -983,6 +1011,7 @@ where
             let tx_gas_used = gas_used.tx_gas_used();
             info.accumulate_gas(tx_gas_used, evm_gas_used);
             info.cumulative_da_bytes_used += tx_da_size;
+            info.cumulative_uncompressed_bytes += tx_uncompressed_size;
 
             // update and add to total fees
             info.total_fees += U256::from(miner_fee) * U256::from(tx_gas_used);

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -164,13 +164,28 @@ fn execution_info_pre_refund_limit_uses_evm_gas_not_canonical_gas() {
     info.cumulative_evm_gas_used = 90;
 
     assert!(
-        !info.is_tx_over_limits(0, 100, None, None, 10, None),
+        !info.is_tx_over_limits(0, 100, None, None, 10, None, 0, None),
         "tx exactly filling the remaining pre-refund budget should fit"
     );
     assert!(
-        info.is_tx_over_limits(0, 100, None, None, 11, None),
+        info.is_tx_over_limits(0, 100, None, None, 11, None, 0, None),
         "tx that fits canonical gas but exceeds pre-refund gas must be skipped"
     );
+}
+
+#[test]
+fn is_tx_over_limits_enforces_max_uncompressed_block_size() {
+    let mut info = ExecutionInfo::new();
+    info.cumulative_uncompressed_bytes = 100;
+
+    // No limit configured: never over the uncompressed-size limit.
+    assert!(!info.is_tx_over_limits(0, u64::MAX, None, None, 0, None, 1_000, None));
+
+    // Exactly filling the remaining budget fits (100 + 50 == 150).
+    assert!(!info.is_tx_over_limits(0, u64::MAX, None, None, 0, None, 50, Some(150)));
+
+    // One byte over the limit is rejected (100 + 51 > 150).
+    assert!(info.is_tx_over_limits(0, u64::MAX, None, None, 0, None, 51, Some(150)));
 }
 
 #[test]

--- a/rust/op-reth/crates/payload/src/config.rs
+++ b/rust/op-reth/crates/payload/src/config.rs
@@ -14,12 +14,26 @@ pub struct OpBuilderConfig {
     pub gas_limit_config: OpGasLimitConfig,
     /// Local SDM `PostExec` production opt-in. Shared with the admin RPC.
     pub sdm_post_exec_opt_in: SdmPostExecOptIn,
+    /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
+    ///
+    /// `None` disables the limit (the historical behavior). When set, the payload builder stops
+    /// pulling mempool transactions once including the next one would push the block's total
+    /// EIP-2718 encoded transaction size past this value. This bounds the size of the
+    /// `engine_getPayload` response so it does not exceed the limits assumed by consensus-layer
+    /// clients (e.g. the common 10 MiB JSON payload cap). op-geth enforces an equivalent but
+    /// non-configurable cap via `params.MaxBlockSize`.
+    pub max_uncompressed_block_size: Option<u64>,
 }
 
 impl OpBuilderConfig {
     /// Creates a new OP builder configuration with the given data availability configuration.
     pub fn new(da_config: OpDAConfig, gas_limit_config: OpGasLimitConfig) -> Self {
-        Self { da_config, gas_limit_config, sdm_post_exec_opt_in: SdmPostExecOptIn::default() }
+        Self {
+            da_config,
+            gas_limit_config,
+            sdm_post_exec_opt_in: SdmPostExecOptIn::default(),
+            max_uncompressed_block_size: None,
+        }
     }
 
     /// Returns the Data Availability configuration for the OP builder, if it has configured


### PR DESCRIPTION
## Motivation

Today op-reth's payload builder can produce blocks whose uncompressed (EIP-2718 encoded) size exceeds **10 MiB**. Many consensus-layer clients assume the `engine_getPayload` JSON response stays under that limit, so an oversized block can break them.

op-geth already enforces an equivalent cap via the in-protocol, non-configurable [`params.MaxBlockSize`](https://github.com/ethereum-optimism/op-geth). op-rbuilder exposes a configurable `--builder.max-uncompressed-block-size` flag. This PR brings the configurable version to op-reth.

## What this does

Adds a `--rollup.max-uncompressed-block-size` flag (bytes). The payload builder:

- tracks the cumulative **EIP-2718 encoded** size of every transaction included in the block — both sequencer/deposit txs and mempool txs;
- stops pulling further mempool transactions once including the next one would push the total past the configured limit (via the existing `is_tx_over_limits` gate, alongside the gas and DA limits);
- leaves behavior unchanged when the flag is unset (`None` = no cap), so this is opt-in.

## Notes on parity with op-geth

The **per-transaction size metric matches op-geth exactly** — `tx.Size()` (`len(rlp(payload)) + 1` for typed txs) equals alloy's `encode_2718_len()`. Three behaviors intentionally follow op-rbuilder rather than op-geth:

1. **Boundary**: the block may reach the limit exactly; op-geth requires strictly under and additionally reserves a 1 MiB buffer zone for non-tx block parts.
2. **Scope**: this counts only transaction bytes; op-geth caps the whole RLP block (header + tx-list framing + withdrawals), which the 1 MiB buffer covers. Operators should set the limit a little below the true target to leave headroom (header + ~3 bytes/tx of RLP string framing).
3. **On overflow**: op-reth marks the tx invalid and continues (consistent with its existing DA/gas-limit handling, so smaller later txs can still pack); op-geth `break`s.

The **flashblocks** crate is intentionally untouched: in op-reth it *consumes* externally-built flashblocks rather than building them (no transaction-selection path), so the cap belongs only on the mempool-selection path in `OpPayloadBuilder`.

## Testing

- `cargo check -p reth-optimism-payload-builder` / `-p reth-optimism-node` ✅
- New unit test `is_tx_over_limits_enforces_max_uncompressed_block_size` (no-limit / exact-fit / one-over) ✅
- New CLI parse test `test_parse_max_uncompressed_block_size` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)