### PR TITLE
chore: gitignore local AI planning docs (.claude/plans)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ packages/contracts-bedrock/deployments/anvil
 
 .claude/worktrees
 
+# Local AI planning docs (op-claude and similar agent tooling)
+.claude/plans
+
 # Ignore local fuzzing results
 **/testdata/fuzz/
 


### PR DESCRIPTION
## Description

Agent tooling like [op-claude](https://github.com/ethereum-optimism/op-claude) writes its planning documents to a `.claude/plans` directory inside the repo it's working on. Ignore it alongside the existing `.claude/worktrees` entry so plans never end up committed or cluttering `git status`.

Follow-up to [op-claude#147 review discussion](https://github.com/ethereum-optimism/op-claude/pull/147#discussion_r3398174163): main repositories get the ignore proactively, lesser-used repos as encountered. The plans location moved from a top-level `plans/` to `.claude/plans` in [op-claude#150](https://github.com/ethereum-optimism/op-claude/pull/150); this PR matches that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
