### PR TITLE
op-core/types: add DepositTx, PostExecTx and Receipt types

### DIFF
--- a/docs/ai/opgeth-decoupling.md
+++ b/docs/ai/opgeth-decoupling.md
@@ -198,8 +198,16 @@ with `dep.MarshalBinary()`.
 ### `PostExecTx` (type `0x7D`)
 
 op-geth also adds `types.PostExecTx` (`core/types/post_exec_tx.go`), a synthetic unsigned
-transaction carrying post-execution metadata in SDM blocks. Its wire format is
-`0x7D || data` — the payload is **opaque bytes, not RLP**.
+transaction carrying post-execution metadata. Its wire format is `0x7D || data` — the
+payload is **opaque bytes, not RLP**.
+
+`PostExecTx` is **a canonical block transaction**, not a side channel: in the Lagoon
+hardfork it can be the **last transaction of a block**, encoding sequencer rebates. So a
+Lagoon+ L2 block's transaction list is `[L1-info deposit (0x7E), …user txs…, optional
+post-exec (0x7D)]`. This matters for the decode path (§11): under upstream go-ethereum a
+full block's transaction list will fail to decode on **both** the deposit (`0x7E`) and the
+post-exec (`0x7D`) entries, so the OP-aware client must route both out before handing the
+remainder to upstream.
 
 Current usage:
 
@@ -246,6 +254,18 @@ arrive as raw bytes from the Engine API or ethclient RPC:
   fields from the monorepo struct. Wrap in short helper functions.
 - `RollupCostData()`: replaced by `opfees.TxRollupCostData(tx)` free function in `op-core/fees`
   (see §4). The computation only requires `tx.Data()` and `tx.Type()`, both upstream.
+
+**These `*types.Transaction` helpers are transition scaffolding, not the destination.**
+`IsDepositTx(tx)`, `SourceHash(tx)`, `Mint(tx)`, `IsSystemTx(tx)`, `IsPostExecTx(tx)` (and
+the differential test) only work while the build still resolves go-ethereum to op-geth,
+where a `*types.Transaction` can carry a `0x7E`/`0x7D` tx. They let §2's call sites drop
+their dependency on op-geth's `Transaction` methods *before* the underlying transaction
+representation changes. After the cutover, an upstream `*types.Transaction` can never hold a
+deposit or post-exec tx, so the helpers would be permanently dead — they are **deleted at
+the cutover (§14), along with the differential test.** The durable shape never wraps an OP
+tx in a `*types.Transaction`: it decodes raw bytes into `optypes.DepositTx` /
+`optypes.PostExecTx` and reads fields off the struct, and code never asks "is this a
+deposit?" of a generic tx because the sources accessors already partition by class (§11).
 
 ---
 
@@ -668,21 +688,60 @@ No migration work needed for op-faucet.
 
 **Don't create a new "OP ethclient" wrapper package.** Instead:
 
-1. **Reuse and extend `op-service/sources`.** The clients there (`EthClient`, `L1Client`,
-   `L2Client`) already do raw JSON-RPC via `client.RPC` — not via `ethclient`. Their `RPCBlock`
-   type in `op-service/sources/types.go` already deserialises blocks with `[]*types.Transaction`
-   and already calls `IsDepositTx()` on L2 blocks. We add custom JSON unmarshaling there so the
-   transactions list round-trips deposit txs (type 0x7E) against upstream go-ethereum: decode each
-   entry by inspecting the `"type"` field, routing `0x7e` to `op-core/types.DepositTx` and all
-   others to upstream `types.Transaction`.
+1. **Reuse and extend `op-service/sources`, and partition the transaction accessors by tx
+   class rather than introducing an `optypes.Transaction` wrapper.** The clients there
+   (`EthClient`, `L1Client`, `L2Client`) already do raw JSON-RPC via `client.RPC` — not via
+   `ethclient`. Their `RPCBlock` type in `op-service/sources/types.go` already deserialises
+   blocks with `[]*types.Transaction` and calls `IsDepositTx()` on L2 blocks. Under upstream
+   go-ethereum that decode breaks on **both** synthetic OP tx types — the L1-info deposit
+   (`0x7E`) and, on Lagoon+ blocks, a trailing post-exec rebate tx (`0x7D`) (§1).
+
+   **Why no wrapper.** The codebase's dominant L2-tx currency is already opaque
+   `[]hexutil.Bytes` (`eth.ExecutionPayload.Transactions`); most of the pipeline never holds
+   typed L2 txs. Where typed access *is* needed, the need is almost always class-specific —
+   "the first tx, as a deposit" or "the user txs, skipping the synthetic ones" — and each
+   class has a clean home type. A go-ethereum-style `Transaction`+`TxData` wrapper would
+   re-import the signer/hashing machinery we are trying to shed, for a list that is read
+   typed-ly in very few places. So instead of a wrapper, split the accessor on
+   `apis.EthClient` (`op-service/apis/eth.go`) by class:
+
+   - `InfoAndUserTxs(...) (eth.BlockInfo, types.Transactions, error)` — **excludes** the
+     synthetic OP types (`0x7E` deposits and `0x7D` post-exec). The remainder are all standard
+     Ethereum tx types, so the returned list is plain **upstream** `types.Transactions` and
+     decodes fine post-cutover. Serves the dominant "skip deposits, operate on user txs"
+     pattern (op-batcher DA estimation; most acceptance-test iterators).
+   - `InfoAndDeposits(...) (eth.BlockInfo, []*optypes.DepositTx, error)` — the deposits, as
+     op-core structs; fields read directly off the struct.
+   - `InfoAndFirstDeposit(...) (eth.BlockInfo, *optypes.DepositTx, error)` — header + the
+     first tx (the L1-info deposit) only, for hot paths that never want the full body. This
+     is exactly the shape prototyped (header-only fetch + first-tx decode) in PR #20532
+     (`HeaderAndFirstTx` / `BlockRefFromHeaderAndDeposit`), which closed unmerged but
+     established the pattern; revive it here.
+
+   `InfoAndTxsBy*` stays as-is for **L1** (no OP tx types there, upstream-safe). Internally,
+   `RPCBlock` keeps the txs as raw per-tx bytes: the transactions-trie root is recomputed
+   directly from those bytes (the trie leaf for a typed tx *is* its opaque `MarshalBinary`
+   encoding), deposit/post-exec detection is a type-byte check, and the partitioned accessors
+   decode each class on demand. A post-exec tx (`0x7D`) is similarly routed to
+   `optypes.PostExecTx`; add an `InfoAndPostExecTx`-style accessor only if a consumer needs to
+   read it (most code only needs to *exclude* it, which `InfoAndUserTxs` already does).
+
+   **Index-correlation caveat.** Some callers iterate the *full* list and correlate by
+   position with the receipts list — e.g. `op-acceptance-tests/tests/jovian/da_footprint.go`
+   does `for i, tx := range txs { if tx.IsDepositTx() { continue }; …receipts[i]… }`. Because
+   `InfoAndUserTxs` drops the synthetic txs, those indices shift relative to a full receipts
+   list and the correlation misaligns. Such tests must filter receipts in lockstep (or use a
+   paired `(userTx, receipt)` accessor). Tracked with the test migration in §13 / #20265.
 
 2. **Migrate `op-batcher/batcher/driver.go` to `op-service/sources.EthClient`.** Its `L2Client`
-   interface (`BlockByNumber` returning `*types.Block`) changes to a sources-based accessor that
-   returns whatever shape the batcher needs (block info + transaction bytes or typed txs). The
-   batcher only uses the block to iterate transactions and filter out deposits for DA
-   estimation — it does not need go-ethereum's `*types.Block` specifically. Also change
-   `op-service/dial/ethclient_interface.go` so `L2EndpointProvider.EthClient` returns a sources
-   client instead of `*ethclient.Client` (or phase that interface out altogether).
+   interface (`BlockByNumber` returning `*types.Block`) changes to the `InfoAndUserTxs`
+   accessor above: the batcher only iterates transactions to filter out deposits for DA
+   estimation (`op-batcher/batcher/types.go` — `IsDepositTx()` skip + `RollupCostData()` /
+   `Size()` on the rest), so the user-txs list is exactly what it needs and it no longer
+   touches deposits at all. `tx.RollupCostData()` becomes `opfees.TxRollupCostData(tx)` (§4).
+   Also change `op-service/dial/ethclient_interface.go` so `L2EndpointProvider.EthClient`
+   returns a sources client instead of `*ethclient.Client` (or phase that interface out
+   altogether).
 
 3. **Change `op-service/txinclude/EL.TransactionReceipt` return type to `*optypes.Receipt`**
    (from §3). The underlying implementation switches from `ethclient.TransactionReceipt` to a
@@ -817,10 +876,12 @@ make `op-service/sources` the canonical implementation of `apis.EthClient`.**
    Implementations in `op-service/sources` unmarshal the extended fields; all 21 call sites
    that read OP receipt fields keep working.
 
-2. **`apis.EthBlockInfo.InfoAndTxsBy*`**: the current signature returns `types.Transactions`.
-   Extend the underlying JSON unmarshal (in `op-service/sources`) to route type `0x7e` to
-   `op-core/types.DepositTx` (from §11). Tests that call `IsDepositTx()` on returned
-   transactions migrate to `optypes.IsDepositTx(tx)` free function.
+2. **L2 transaction accessors**: rather than make `InfoAndTxsBy*` round-trip OP tx types,
+   add the class-partitioned accessors from §11 — `InfoAndUserTxs` (synthetic `0x7E`/`0x7D`
+   excluded → upstream `types.Transactions`), `InfoAndDeposits` / `InfoAndFirstDeposit`
+   (→ `*optypes.DepositTx`). Tests that fetch the L2 block and iterate migrate to whichever
+   accessor matches their intent; "skip deposits, read user txs" becomes `InfoAndUserTxs`,
+   removing the per-tx `IsDepositTx()` check entirely. `InfoAndTxsBy*` is unchanged for L1.
 
 3. **`op-e2e/e2eutils/geth/wait.go`**: the central wait helpers (`WaitForBlock`,
    `WaitForBlockToBeSafe`, `WaitForBlockToBeFinalized`, `WaitForTransaction`,
@@ -968,8 +1029,8 @@ This is a bounded follow-up, unblocked by `op-core/params` + `GethChainConfig()`
 | `op-service/superutil/` (by-chain-ID loader) | monorepo | moves to `op-core/params/` (avoids params↔superchain cycle) | Low |
 | EIP-1559 Holocene/Jovian helpers | `consensus/misc/eip1559/eip1559_optimism.go` | `op-core/eip1559/` | Trivial |
 | `HardforkConfig` interface | n/a | `op-service/eth/` (for `BlockAsPayload`) | Trivial |
-| op-batcher L2 block fetch (ethclient → sources) | `op-batcher/batcher/driver.go` | migrate to `op-service/sources.EthClient` | Medium |
-| op-service/sources deposit-tx JSON decoding | `op-service/sources/types.go` | custom `RPCBlock.Transactions` unmarshal | Medium |
+| op-batcher L2 block fetch (ethclient → sources) | `op-batcher/batcher/driver.go` | migrate to `sources.EthClient.InfoAndUserTxs` | Medium |
+| op-service/sources L2 tx accessors (partition by class, no tx wrapper) | `op-service/sources/types.go`, `op-service/apis/eth.go` | `InfoAndUserTxs` / `InfoAndDeposits` / `InfoAndFirstDeposit`; raw-bytes `RPCBlock.Transactions` internally | Medium |
 | `apis.EthClient.TransactionReceipt` return type | `op-service/apis/eth.go` | change to `*optypes.Receipt` | Low |
 | `op-e2e/e2eutils/geth/wait.go` — split into header-only + full-block variants | `op-e2e/e2eutils/geth/wait.go` | `HeaderByNumber`-based helpers for height-only callers; migrate block-body callers to `apis.EthClient` | Medium |
 | `op-e2e/system/e2esys.SystemConfig.L2Client` type | `op-e2e/system/e2esys/` | change to `apis.EthClient` | Medium |

--- a/docs/ai/opgeth-decoupling.md
+++ b/docs/ai/opgeth-decoupling.md
@@ -296,14 +296,26 @@ and a custom JSON unmarshaler:
 // in op-core/types, called simply Receipt; consumers import as optypes
 type Receipt struct {
     types.Receipt
-    L1GasPrice          *big.Int `json:"l1GasPrice,omitempty"`
-    L1BlobBaseFee       *big.Int `json:"l1BlobBaseFee,omitempty"`
-    L1BaseFeeScalar     *uint64  `json:"l1BaseFeeScalar,omitempty"`
-    L1BlobBaseFeeScalar *uint64  `json:"l1BlobBaseFeeScalar,omitempty"`
-    OperatorFeeScalar   *uint64  `json:"operatorFeeScalar,omitempty"`
-    OperatorFeeConstant *uint64  `json:"operatorFeeConstant,omitempty"`
+    DepositNonce          *uint64    `json:"depositNonce,omitempty"`
+    DepositReceiptVersion *uint64    `json:"depositReceiptVersion,omitempty"`
+    L1GasPrice            *big.Int   `json:"l1GasPrice,omitempty"`
+    L1BlobBaseFee         *big.Int   `json:"l1BlobBaseFee,omitempty"`
+    L1GasUsed             *big.Int   `json:"l1GasUsed,omitempty"`
+    L1Fee                 *big.Int   `json:"l1Fee,omitempty"`
+    FeeScalar             *big.Float `json:"l1FeeScalar,omitempty"`
+    L1BaseFeeScalar       *uint64    `json:"l1BaseFeeScalar,omitempty"`
+    L1BlobBaseFeeScalar   *uint64    `json:"l1BlobBaseFeeScalar,omitempty"`
+    OperatorFeeScalar     *uint64    `json:"operatorFeeScalar,omitempty"`
+    OperatorFeeConstant   *uint64    `json:"operatorFeeConstant,omitempty"`
+    DAFootprintGasScalar  *uint64    `json:"daFootprintGasScalar,omitempty"`
 }
 ```
+
+The type carries op-geth's **complete** OP receipt field set, not just the six fields
+`txinclude` reads: the e2e/acceptance suites also read `L1Fee`, `L1GasUsed`, `DepositNonce`,
+etc. (§13), and a partial set would silently drop those fields from receipt JSON at cutover
+— while the go.mod replace still points at op-geth, the embedded receipt masks the gap, so
+no differential test can catch it.
 
 The `EL` interface in `txinclude` returns `*optypes.Receipt` instead of `*types.Receipt`.
 `IncludedTx.Receipt` becomes `*optypes.Receipt`. This contains all the changes within

--- a/docs/ai/opgeth-decoupling.md
+++ b/docs/ai/opgeth-decoupling.md
@@ -16,8 +16,8 @@ op-acceptance-tests, op-devstack).
 The op-geth diff vs. upstream go-ethereum (currently based on v1.17.2) can be summarised in three
 kinds of change:
 
-1. **New standalone types/files** – `DepositTx`, `RollupCostData`, the `superchain/` package,
-   eip1559 Holocene/Jovian helpers.
+1. **New standalone types/files** – `DepositTx`, `PostExecTx`, `RollupCostData`, the
+   `superchain/` package, eip1559 Holocene/Jovian helpers.
 2. **Fields/methods added to existing upstream types** – `Transaction` methods (`IsDepositTx`,
    `SourceHash`, `Mint`, `IsSystemTx`, `RollupCostData`), `Receipt` L1-cost fields, `ChainConfig`
    OP hardfork fields and methods, `PayloadAttributes` extensions.
@@ -107,7 +107,7 @@ continue to work and are addressed in §§6–7.
 
 ---
 
-## 1. `core/types` – Deposit transaction
+## 1. `core/types` – OP Stack transaction types (`DepositTx`, `PostExecTx`)
 
 ### Current usage
 
@@ -194,6 +194,28 @@ we go straight from struct to `[]byte`.
 **`UnmarshalDepositLogEvent`** returns `*types.DepositTx` today; change to return
 `*optypes.DepositTx`. `DeriveDeposits` calls `types.NewTx(dep).MarshalBinary()`; replace
 with `dep.MarshalBinary()`.
+
+### `PostExecTx` (type `0x7D`)
+
+op-geth also adds `types.PostExecTx` (`core/types/post_exec_tx.go`), a synthetic unsigned
+transaction carrying post-execution metadata in SDM blocks. Its wire format is
+`0x7D || data` — the payload is **opaque bytes, not RLP**.
+
+Current usage:
+
+- `op-node/rollup/derive/` — span batch encode/decode (`span_batch_tx.go` has its own
+  `spanBatchPostExecTxData`, `span_batch_txs.go` special-cases the synthetic signature),
+  batch validity checks (`batches.go`), and raw type-byte sniffing (`span_batch.go`).
+  Mostly just the `types.PostExecTxType` constant; one site constructs
+  `types.NewTx(&types.PostExecTx{...})`.
+- `op-chain-ops/pkg/sdm/` and `op-service/sources/flashblock_client.go` — handle post-exec
+  payloads as raw/hex bytes only; no type dependency.
+
+Proposed decoupling: define `PostExecTx` in `op-core/types/` next to `DepositTx`, same
+pattern — `MarshalBinary` / `UnmarshalPostExecTx` plus an `IsPostExecTx` free function,
+with a differential test against op-geth. The span-batch construction site goes straight
+from struct to bytes. Note that op-geth (like upstream) rejects typed-tx envelopes of
+`len <= 1`, so an empty payload cannot round-trip; `UnmarshalPostExecTx` mirrors that.
 
 ---
 
@@ -920,6 +942,7 @@ This is a bounded follow-up, unblocked by `op-core/params` + `GethChainConfig()`
 | `DepositTxType` constant | `core/types/deposit_tx.go` | `op-core/types/` | Trivial |
 | `IsDepositTx()` free function | `core/types/transaction.go` | `op-core/types/` | Trivial |
 | `IsSystemTx()`, `SourceHash()`, `Mint()` helpers | `core/types/transaction.go` | `op-core/types/` | Low |
+| `PostExecTx` type + `MarshalBinary`, `PostExecTxType` constant, `IsPostExecTx()` | `core/types/post_exec_tx.go` | `op-core/types/` | Low |
 | `RollupCostData`, `NewRollupCostData`, `EstimatedDASize`, `NewL1CostFuncFjord`, `L1CostFunc` | `core/types/rollup_cost.go` | `op-core/fees/` | Low |
 | `OperatorCost(gasUsed, scalar, constant)` — new helper | n/a (deduplicates inline math) | `op-core/fees/` | Trivial |
 | `TxRollupCostData(tx)` — replaces method | `core/types/transaction.go` | `op-core/fees/` | Trivial |

--- a/docs/ai/opgeth-decoupling.md
+++ b/docs/ai/opgeth-decoupling.md
@@ -198,8 +198,13 @@ with `dep.MarshalBinary()`.
 ### `PostExecTx` (type `0x7D`)
 
 op-geth also adds `types.PostExecTx` (`core/types/post_exec_tx.go`), a synthetic unsigned
-transaction carrying post-execution metadata. Its wire format is `0x7D || data` — the
-payload is **opaque bytes, not RLP**.
+transaction carrying post-execution metadata. Its wire format is `0x7D || data`, where
+`data` is appended **verbatim** — there is no outer RLP envelope around the transaction
+body, unlike the deposit tx's `0x7E || RLP(struct)`. op-geth treats `data` as opaque bytes
+and never parses it; the bytes are in fact an RLP-encoded `PostExecPayload` (a `version`
+plus SDM `gas_refund_entries`) that op-alloy/kona decode and version-check (see
+`rust/kona/crates/protocol/protocol/src/batch/transactions.rs`). Mirroring op-geth's opaque
+handling keeps `op-core/types.PostExecTx` wire-compatible without re-implementing that parse.
 
 `PostExecTx` is **a canonical block transaction**, not a side channel: in the Lagoon
 hardfork it can be the **last transaction of a block**, encoding sequencer rebates. So a

--- a/op-core/types/deposit_tx.go
+++ b/op-core/types/deposit_tx.go
@@ -26,7 +26,8 @@ type DepositTx struct {
 	From common.Address
 	// To is the recipient; nil means contract creation.
 	To *common.Address `rlp:"nil"`
-	// Mint is minted on L2, locked on L1; nil if no minting.
+	// Mint is minted on L2, locked on L1; nil if no minting. Note that nil and
+	// zero share the same wire encoding and decode to zero.
 	Mint *big.Int `rlp:"nil"`
 	// Value is transferred from the L2 balance, executed after Mint (if any).
 	Value *big.Int
@@ -78,7 +79,9 @@ func SourceHash(tx *types.Transaction) (common.Hash, error) {
 	return d.SourceHash, nil
 }
 
-// Mint returns the ETH minted by a deposit transaction, nil if it mints nothing.
+// Mint returns the ETH minted by a deposit transaction. A deposit that mints
+// nothing yields zero, never nil: the wire encoding does not distinguish a nil
+// from a zero mint, and the transaction is decoded from its wire bytes.
 // It errors if tx is not a deposit transaction.
 func Mint(tx *types.Transaction) (*big.Int, error) {
 	d, err := asDepositTx(tx)

--- a/op-core/types/deposit_tx.go
+++ b/op-core/types/deposit_tx.go
@@ -1,0 +1,110 @@
+// Package types holds the OP-Stack-specific transaction and receipt types.
+// Consumers import it as optypes.
+package types
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// DepositTxType is the EIP-2718 type byte of OP Stack deposit transactions.
+const DepositTxType = byte(0x7E)
+
+// DepositTx is an OP Stack deposit transaction, derived from L1 (or generated
+// for network upgrades) rather than signed by a user. Its canonical encoding is
+// DepositTxType || RLP(fields), matching op-geth's types.DepositTx wire format.
+type DepositTx struct {
+	// SourceHash uniquely identifies the source of the deposit.
+	SourceHash common.Hash
+	// From is the sender address, determined by the deposit's origin instead of a signature.
+	From common.Address
+	// To is the recipient; nil means contract creation.
+	To *common.Address `rlp:"nil"`
+	// Mint is minted on L2, locked on L1; nil if no minting.
+	Mint *big.Int `rlp:"nil"`
+	// Value is transferred from the L2 balance, executed after Mint (if any).
+	Value *big.Int
+	// Gas is the gas limit.
+	Gas uint64
+	// IsSystemTransaction indicates the transaction is exempt from the L2 gas limit.
+	IsSystemTransaction bool
+	// Data is the calldata.
+	Data []byte
+}
+
+// MarshalBinary returns the canonical EIP-2718 encoding of the deposit transaction.
+func (d *DepositTx) MarshalBinary() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte(DepositTxType)
+	if err := rlp.Encode(&buf, d); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalDepositTx decodes a deposit transaction from its EIP-2718 encoding.
+func UnmarshalDepositTx(raw []byte) (*DepositTx, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("empty transaction bytes")
+	}
+	if raw[0] != DepositTxType {
+		return nil, fmt.Errorf("expected deposit tx type byte %#x, got %#x", DepositTxType, raw[0])
+	}
+	d := new(DepositTx)
+	if err := rlp.DecodeBytes(raw[1:], d); err != nil {
+		return nil, fmt.Errorf("invalid deposit tx payload: %w", err)
+	}
+	return d, nil
+}
+
+// IsDepositTx reports whether tx is an OP Stack deposit transaction.
+func IsDepositTx(tx *types.Transaction) bool {
+	return tx.Type() == DepositTxType
+}
+
+// SourceHash returns the source hash of a deposit transaction.
+// It errors if tx is not a deposit transaction.
+func SourceHash(tx *types.Transaction) (common.Hash, error) {
+	d, err := asDepositTx(tx)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return d.SourceHash, nil
+}
+
+// Mint returns the ETH minted by a deposit transaction, nil if it mints nothing.
+// It errors if tx is not a deposit transaction.
+func Mint(tx *types.Transaction) (*big.Int, error) {
+	d, err := asDepositTx(tx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Mint, nil
+}
+
+// IsSystemTx reports whether tx is a deposit that is a system transaction,
+// exempt from the L2 gas limit. It errors if tx is not a deposit transaction.
+func IsSystemTx(tx *types.Transaction) (bool, error) {
+	d, err := asDepositTx(tx)
+	if err != nil {
+		return false, err
+	}
+	return d.IsSystemTransaction, nil
+}
+
+func asDepositTx(tx *types.Transaction) (*DepositTx, error) {
+	if !IsDepositTx(tx) {
+		return nil, fmt.Errorf("transaction %s (type %#x) is not a deposit transaction", tx.Hash(), tx.Type())
+	}
+	raw, err := tx.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode transaction %s: %w", tx.Hash(), err)
+	}
+	return UnmarshalDepositTx(raw)
+}

--- a/op-core/types/deposit_tx.go
+++ b/op-core/types/deposit_tx.go
@@ -64,6 +64,17 @@ func UnmarshalDepositTx(raw []byte) (*DepositTx, error) {
 	return d, nil
 }
 
+// The helpers below operate on a go-ethereum *types.Transaction. They exist
+// only for the decoupling transition: while the build still resolves
+// go-ethereum to op-geth, a *types.Transaction can hold a deposit, so these let
+// call sites drop their dependency on op-geth's Transaction methods before the
+// underlying transaction representation is migrated. Once the build moves to
+// upstream go-ethereum a *types.Transaction can never hold a deposit (the
+// 0x7E type is rejected on decode), making these dead — they are removed at the
+// cutover, together with the differential test. The durable shape decodes raw
+// bytes into a [DepositTx] (via [UnmarshalDepositTx]) and reads its fields
+// directly; see op-service/sources accessors (#20264).
+
 // IsDepositTx reports whether tx is an OP Stack deposit transaction.
 func IsDepositTx(tx *types.Transaction) bool {
 	return tx.Type() == DepositTxType

--- a/op-core/types/deposit_tx_test.go
+++ b/op-core/types/deposit_tx_test.go
@@ -1,0 +1,225 @@
+package types_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
+)
+
+type depositTxTestCase struct {
+	name string
+	tx   optypes.DepositTx
+}
+
+func depositTxTestCases() []depositTxTestCase {
+	to := common.HexToAddress("0x4242424242424242424242424242424242424242")
+	return []depositTxTestCase{
+		{
+			name: "all fields set",
+			tx: optypes.DepositTx{
+				SourceHash:          common.HexToHash("0x0001"),
+				From:                common.HexToAddress("0x1111111111111111111111111111111111111111"),
+				To:                  &to,
+				Mint:                big.NewInt(1234),
+				Value:               big.NewInt(5678),
+				Gas:                 21000,
+				IsSystemTransaction: false,
+				Data:                []byte{0xde, 0xad, 0xbe, 0xef},
+			},
+		},
+		{
+			name: "contract creation (nil To)",
+			tx: optypes.DepositTx{
+				SourceHash: common.HexToHash("0x0002"),
+				From:       common.HexToAddress("0x2222222222222222222222222222222222222222"),
+				To:         nil,
+				Mint:       big.NewInt(0),
+				Value:      big.NewInt(0),
+				Gas:        1_000_000,
+				Data:       []byte{0x60, 0x80, 0x60, 0x40},
+			},
+		},
+		{
+			name: "nil Mint",
+			tx: optypes.DepositTx{
+				SourceHash: common.HexToHash("0x0003"),
+				From:       common.HexToAddress("0x3333333333333333333333333333333333333333"),
+				To:         &to,
+				Mint:       nil,
+				Value:      big.NewInt(7),
+				Gas:        50_000,
+				Data:       nil,
+			},
+		},
+		{
+			name: "zero values",
+			tx: optypes.DepositTx{
+				SourceHash: common.Hash{},
+				From:       common.Address{},
+				To:         nil,
+				Mint:       nil,
+				Value:      big.NewInt(0),
+				Gas:        0,
+				Data:       []byte{},
+			},
+		},
+		{
+			name: "nil Value",
+			tx: optypes.DepositTx{
+				SourceHash: common.HexToHash("0x0004"),
+				From:       common.HexToAddress("0x4444444444444444444444444444444444444444"),
+				To:         &to,
+				Mint:       nil,
+				Value:      nil,
+				Gas:        21000,
+			},
+		},
+		{
+			name: "system transaction",
+			tx: optypes.DepositTx{
+				SourceHash:          common.HexToHash("0x0005"),
+				From:                common.HexToAddress("0x5555555555555555555555555555555555555555"),
+				To:                  &to,
+				Mint:                big.NewInt(0),
+				Value:               big.NewInt(0),
+				Gas:                 150_000_000,
+				IsSystemTransaction: true,
+				Data:                []byte{0x01},
+			},
+		},
+		{
+			name: "large values",
+			tx: optypes.DepositTx{
+				SourceHash: common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+				From:       common.HexToAddress("0xffffffffffffffffffffffffffffffffffffffff"),
+				To:         &to,
+				Mint:       new(big.Int).Lsh(big.NewInt(1), 255),
+				Value:      new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)),
+				Gas:        ^uint64(0),
+				Data:       make([]byte, 512),
+			},
+		},
+	}
+}
+
+func (tc depositTxTestCase) gethTx() *gethtypes.Transaction {
+	return gethtypes.NewTx(&gethtypes.DepositTx{
+		SourceHash:          tc.tx.SourceHash,
+		From:                tc.tx.From,
+		To:                  tc.tx.To,
+		Mint:                tc.tx.Mint,
+		Value:               tc.tx.Value,
+		Gas:                 tc.tx.Gas,
+		IsSystemTransaction: tc.tx.IsSystemTransaction,
+		Data:                tc.tx.Data,
+	})
+}
+
+// TestDepositTxMarshalBinaryDifferential asserts that DepositTx.MarshalBinary is
+// byte-for-byte identical to op-geth's encoding of the same transaction.
+// It will be removed in the final cutover, when the op-geth dependency is
+// replaced with upstream go-ethereum.
+func TestDepositTxMarshalBinaryDifferential(t *testing.T) {
+	for _, tc := range depositTxTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			ours, err := tc.tx.MarshalBinary()
+			require.NoError(t, err)
+
+			theirs, err := tc.gethTx().MarshalBinary()
+			require.NoError(t, err)
+
+			require.Equal(t, theirs, ours)
+		})
+	}
+}
+
+func TestUnmarshalDepositTxRoundTrip(t *testing.T) {
+	for _, tc := range depositTxTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := tc.tx.MarshalBinary()
+			require.NoError(t, err)
+
+			decoded, err := optypes.UnmarshalDepositTx(raw)
+			require.NoError(t, err)
+
+			reencoded, err := decoded.MarshalBinary()
+			require.NoError(t, err)
+			require.Equal(t, raw, reencoded)
+		})
+	}
+}
+
+func TestUnmarshalDepositTxErrors(t *testing.T) {
+	_, err := optypes.UnmarshalDepositTx(nil)
+	require.ErrorContains(t, err, "empty")
+
+	_, err = optypes.UnmarshalDepositTx([]byte{0x02, 0xc0})
+	require.ErrorContains(t, err, "type byte")
+
+	_, err = optypes.UnmarshalDepositTx([]byte{optypes.DepositTxType, 0xff})
+	require.ErrorContains(t, err, "invalid deposit tx payload")
+
+	// trailing bytes after the RLP list must be rejected
+	valid, err := depositTxTestCases()[0].tx.MarshalBinary()
+	require.NoError(t, err)
+	_, err = optypes.UnmarshalDepositTx(append(valid, 0x00))
+	require.ErrorContains(t, err, "invalid deposit tx payload")
+}
+
+// TestDepositTxHelpers checks the free-function replacements for op-geth's
+// Transaction methods against op-geth's methods themselves, on transactions
+// decoded from raw bytes the way they arrive from the Engine API. Note that
+// a nil Mint round-trips to zero through the wire encoding, in both
+// implementations.
+func TestDepositTxHelpers(t *testing.T) {
+	for _, tc := range depositTxTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := tc.gethTx().MarshalBinary()
+			require.NoError(t, err)
+			tx := new(gethtypes.Transaction)
+			require.NoError(t, tx.UnmarshalBinary(raw))
+
+			require.True(t, optypes.IsDepositTx(tx))
+			require.Equal(t, tx.IsDepositTx(), optypes.IsDepositTx(tx))
+
+			sourceHash, err := optypes.SourceHash(tx)
+			require.NoError(t, err)
+			require.Equal(t, tx.SourceHash(), sourceHash)
+			require.Equal(t, tc.tx.SourceHash, sourceHash)
+
+			mint, err := optypes.Mint(tx)
+			require.NoError(t, err)
+			require.Equal(t, tx.Mint(), mint)
+
+			isSystemTx, err := optypes.IsSystemTx(tx)
+			require.NoError(t, err)
+			require.Equal(t, tx.IsSystemTx(), isSystemTx)
+			require.Equal(t, tc.tx.IsSystemTransaction, isSystemTx)
+		})
+	}
+}
+
+func TestDepositTxHelpersNonDeposit(t *testing.T) {
+	tx := gethtypes.NewTx(&gethtypes.LegacyTx{
+		Nonce:    1,
+		GasPrice: big.NewInt(1),
+		Gas:      21000,
+		To:       &common.Address{},
+		Value:    big.NewInt(0),
+	})
+
+	require.False(t, optypes.IsDepositTx(tx))
+
+	_, err := optypes.SourceHash(tx)
+	require.ErrorContains(t, err, "not a deposit transaction")
+	_, err = optypes.Mint(tx)
+	require.ErrorContains(t, err, "not a deposit transaction")
+	_, err = optypes.IsSystemTx(tx)
+	require.ErrorContains(t, err, "not a deposit transaction")
+}

--- a/op-core/types/deposit_tx_test.go
+++ b/op-core/types/deposit_tx_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -203,6 +204,47 @@ func TestDepositTxHelpers(t *testing.T) {
 			require.Equal(t, tc.tx.IsSystemTransaction, isSystemTx)
 		})
 	}
+}
+
+// TestDepositTxHelpersJSONDecoded checks the helpers on deposits decoded from
+// JSON-RPC responses, where op-geth uses a different inner type that carries
+// the deposit nonce (depositTxWithNonce). The nonce must not leak into the
+// re-encoded wire bytes the helpers decode.
+func TestDepositTxHelpersJSONDecoded(t *testing.T) {
+	tc := depositTxTestCases()[0]
+	gethTx := tc.gethTx()
+
+	rpcJSON, err := gethTx.MarshalJSON()
+	require.NoError(t, err)
+	var obj map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rpcJSON, &obj))
+	obj["nonce"] = json.RawMessage(`"0x7"`)
+	rpcJSON, err = json.Marshal(obj)
+	require.NoError(t, err)
+
+	tx := new(gethtypes.Transaction)
+	require.NoError(t, tx.UnmarshalJSON(rpcJSON))
+	nonce := tx.EffectiveNonce()
+	require.NotNil(t, nonce)
+	require.EqualValues(t, 7, *nonce) // proves we hit the depositTxWithNonce path
+
+	raw, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	canonical, err := tc.tx.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, canonical, raw)
+
+	sourceHash, err := optypes.SourceHash(tx)
+	require.NoError(t, err)
+	require.Equal(t, tx.SourceHash(), sourceHash)
+
+	mint, err := optypes.Mint(tx)
+	require.NoError(t, err)
+	require.Equal(t, tx.Mint(), mint)
+
+	isSystemTx, err := optypes.IsSystemTx(tx)
+	require.NoError(t, err)
+	require.Equal(t, tx.IsSystemTx(), isSystemTx)
 }
 
 func TestDepositTxHelpersNonDeposit(t *testing.T) {

--- a/op-core/types/post_exec_tx.go
+++ b/op-core/types/post_exec_tx.go
@@ -1,0 +1,47 @@
+package types
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// PostExecTxType is the EIP-2718 type byte of OP Stack post-execution transactions.
+const PostExecTxType = byte(0x7D)
+
+// PostExecTx is a synthetic, unsigned OP Stack transaction used to carry
+// post-execution metadata in SDM blocks. Its canonical encoding is
+// PostExecTxType || Data — the payload is opaque bytes, not RLP — matching
+// op-geth's types.PostExecTx wire format.
+type PostExecTx struct {
+	Data []byte
+}
+
+// MarshalBinary returns the canonical EIP-2718 encoding of the post-exec transaction.
+func (p *PostExecTx) MarshalBinary() ([]byte, error) {
+	out := make([]byte, 0, 1+len(p.Data))
+	out = append(out, PostExecTxType)
+	return append(out, p.Data...), nil
+}
+
+// UnmarshalPostExecTx decodes a post-exec transaction from its EIP-2718 encoding.
+// Like op-geth, it rejects an empty payload.
+func UnmarshalPostExecTx(raw []byte) (*PostExecTx, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("empty transaction bytes")
+	}
+	if raw[0] != PostExecTxType {
+		return nil, fmt.Errorf("expected post-exec tx type byte %#x, got %#x", PostExecTxType, raw[0])
+	}
+	if len(raw) == 1 {
+		return nil, errors.New("post-exec tx payload is empty")
+	}
+	return &PostExecTx{Data: bytes.Clone(raw[1:])}, nil
+}
+
+// IsPostExecTx reports whether tx is an OP Stack post-execution transaction.
+func IsPostExecTx(tx *types.Transaction) bool {
+	return tx.Type() == PostExecTxType
+}

--- a/op-core/types/post_exec_tx.go
+++ b/op-core/types/post_exec_tx.go
@@ -42,6 +42,12 @@ func UnmarshalPostExecTx(raw []byte) (*PostExecTx, error) {
 }
 
 // IsPostExecTx reports whether tx is an OP Stack post-execution transaction.
+//
+// Like the deposit helpers in deposit_tx.go, this is transition-only: a
+// go-ethereum *types.Transaction can hold a post-exec tx only while the build
+// resolves to op-geth. After the cutover to upstream go-ethereum the 0x7D type
+// is rejected on decode, so this is removed; the durable shape decodes raw
+// bytes via [UnmarshalPostExecTx].
 func IsPostExecTx(tx *types.Transaction) bool {
 	return tx.Type() == PostExecTxType
 }

--- a/op-core/types/post_exec_tx.go
+++ b/op-core/types/post_exec_tx.go
@@ -13,8 +13,10 @@ const PostExecTxType = byte(0x7D)
 
 // PostExecTx is a synthetic, unsigned OP Stack transaction used to carry
 // post-execution metadata in SDM blocks. Its canonical encoding is
-// PostExecTxType || Data — the payload is opaque bytes, not RLP — matching
-// op-geth's types.PostExecTx wire format.
+// PostExecTxType || Data, where Data is appended verbatim with no outer RLP
+// envelope, matching op-geth's types.PostExecTx wire format. Data is itself an
+// RLP-encoded payload, but op-geth (and this type) treat it as opaque bytes and
+// never parse it.
 type PostExecTx struct {
 	Data []byte
 }

--- a/op-core/types/post_exec_tx_test.go
+++ b/op-core/types/post_exec_tx_test.go
@@ -1,0 +1,73 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
+)
+
+func postExecTxTestCases() []optypes.PostExecTx {
+	return []optypes.PostExecTx{
+		{Data: []byte{0x01}},
+		{Data: []byte{0xde, 0xad, 0xbe, 0xef}},
+		{Data: make([]byte, 1024)},
+	}
+}
+
+// TestPostExecTxMarshalBinaryDifferential asserts that PostExecTx.MarshalBinary
+// is byte-for-byte identical to op-geth's encoding of the same transaction.
+// It will be removed in the final cutover, when the op-geth dependency is
+// replaced with upstream go-ethereum.
+func TestPostExecTxMarshalBinaryDifferential(t *testing.T) {
+	for _, tx := range postExecTxTestCases() {
+		ours, err := tx.MarshalBinary()
+		require.NoError(t, err)
+
+		theirs, err := gethtypes.NewTx(&gethtypes.PostExecTx{Data: tx.Data}).MarshalBinary()
+		require.NoError(t, err)
+
+		require.Equal(t, theirs, ours)
+	}
+}
+
+func TestUnmarshalPostExecTxRoundTrip(t *testing.T) {
+	for _, tx := range postExecTxTestCases() {
+		raw, err := tx.MarshalBinary()
+		require.NoError(t, err)
+
+		decoded, err := optypes.UnmarshalPostExecTx(raw)
+		require.NoError(t, err)
+		require.Equal(t, tx.Data, decoded.Data)
+	}
+}
+
+func TestUnmarshalPostExecTxErrors(t *testing.T) {
+	_, err := optypes.UnmarshalPostExecTx(nil)
+	require.ErrorContains(t, err, "empty")
+
+	_, err = optypes.UnmarshalPostExecTx([]byte{optypes.DepositTxType, 0x01})
+	require.ErrorContains(t, err, "type byte")
+
+	// op-geth rejects a bare type byte without payload, and so do we
+	var gethTx gethtypes.Transaction
+	require.ErrorContains(t, gethTx.UnmarshalBinary([]byte{optypes.PostExecTxType}), "too short")
+	_, err = optypes.UnmarshalPostExecTx([]byte{optypes.PostExecTxType})
+	require.ErrorContains(t, err, "payload is empty")
+}
+
+func TestIsPostExecTx(t *testing.T) {
+	raw, err := gethtypes.NewTx(&gethtypes.PostExecTx{Data: []byte{0x42}}).MarshalBinary()
+	require.NoError(t, err)
+	tx := new(gethtypes.Transaction)
+	require.NoError(t, tx.UnmarshalBinary(raw))
+
+	require.True(t, optypes.IsPostExecTx(tx))
+	require.False(t, optypes.IsDepositTx(tx))
+
+	depositTx := depositTxTestCases()[0].gethTx()
+	require.False(t, optypes.IsPostExecTx(depositTx))
+}

--- a/op-core/types/post_exec_tx_test.go
+++ b/op-core/types/post_exec_tx_test.go
@@ -59,6 +59,26 @@ func TestUnmarshalPostExecTxErrors(t *testing.T) {
 	require.ErrorContains(t, err, "payload is empty")
 }
 
+// TestPostExecTxEmptyData pins the marshal/unmarshal asymmetry for an empty
+// payload: both implementations produce the bare type byte, and neither
+// accepts it back.
+func TestPostExecTxEmptyData(t *testing.T) {
+	bareTypeByte := []byte{optypes.PostExecTxType}
+
+	ours, err := (&optypes.PostExecTx{Data: nil}).MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, bareTypeByte, ours)
+
+	theirs, err := gethtypes.NewTx(&gethtypes.PostExecTx{Data: nil}).MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, bareTypeByte, theirs)
+
+	var gethTx gethtypes.Transaction
+	require.Error(t, gethTx.UnmarshalBinary(bareTypeByte))
+	_, err = optypes.UnmarshalPostExecTx(bareTypeByte)
+	require.Error(t, err)
+}
+
 func TestIsPostExecTx(t *testing.T) {
 	raw, err := gethtypes.NewTx(&gethtypes.PostExecTx{Data: []byte{0x42}}).MarshalBinary()
 	require.NoError(t, err)

--- a/op-core/types/receipt.go
+++ b/op-core/types/receipt.go
@@ -1,0 +1,85 @@
+package types
+
+import (
+	"encoding/json"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Receipt extends go-ethereum's receipt with the OP Stack L1-cost and
+// operator-fee fields that L2 endpoints include in eth_getTransactionReceipt
+// responses. The JSON field names match op-geth's types.Receipt verbatim for
+// wire compatibility; values are hex-encoded on the wire, hence the custom
+// JSON methods.
+type Receipt struct {
+	types.Receipt
+	L1GasPrice          *big.Int `json:"l1GasPrice,omitempty"`
+	L1BlobBaseFee       *big.Int `json:"l1BlobBaseFee,omitempty"`
+	L1BaseFeeScalar     *uint64  `json:"l1BaseFeeScalar,omitempty"`
+	L1BlobBaseFeeScalar *uint64  `json:"l1BlobBaseFeeScalar,omitempty"`
+	OperatorFeeScalar   *uint64  `json:"operatorFeeScalar,omitempty"`
+	OperatorFeeConstant *uint64  `json:"operatorFeeConstant,omitempty"`
+}
+
+// receiptOpFields is the wire representation of the OP Stack receipt extensions.
+type receiptOpFields struct {
+	L1GasPrice          *hexutil.Big    `json:"l1GasPrice,omitempty"`
+	L1BlobBaseFee       *hexutil.Big    `json:"l1BlobBaseFee,omitempty"`
+	L1BaseFeeScalar     *hexutil.Uint64 `json:"l1BaseFeeScalar,omitempty"`
+	L1BlobBaseFeeScalar *hexutil.Uint64 `json:"l1BlobBaseFeeScalar,omitempty"`
+	OperatorFeeScalar   *hexutil.Uint64 `json:"operatorFeeScalar,omitempty"`
+	OperatorFeeConstant *hexutil.Uint64 `json:"operatorFeeConstant,omitempty"`
+}
+
+// UnmarshalJSON decodes both the embedded go-ethereum receipt and the OP Stack
+// extension fields from the same JSON object.
+func (r *Receipt) UnmarshalJSON(input []byte) error {
+	if err := json.Unmarshal(input, &r.Receipt); err != nil {
+		return err
+	}
+	var dec receiptOpFields
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	r.L1GasPrice = (*big.Int)(dec.L1GasPrice)
+	r.L1BlobBaseFee = (*big.Int)(dec.L1BlobBaseFee)
+	r.L1BaseFeeScalar = (*uint64)(dec.L1BaseFeeScalar)
+	r.L1BlobBaseFeeScalar = (*uint64)(dec.L1BlobBaseFeeScalar)
+	r.OperatorFeeScalar = (*uint64)(dec.OperatorFeeScalar)
+	r.OperatorFeeConstant = (*uint64)(dec.OperatorFeeConstant)
+	return nil
+}
+
+// MarshalJSON encodes the embedded go-ethereum receipt and merges the OP Stack
+// extension fields into the same JSON object, so the encoding round-trips.
+func (r Receipt) MarshalJSON() ([]byte, error) {
+	base, err := json.Marshal(&r.Receipt)
+	if err != nil {
+		return nil, err
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(base, &obj); err != nil {
+		return nil, err
+	}
+	extra, err := json.Marshal(&receiptOpFields{
+		L1GasPrice:          (*hexutil.Big)(r.L1GasPrice),
+		L1BlobBaseFee:       (*hexutil.Big)(r.L1BlobBaseFee),
+		L1BaseFeeScalar:     (*hexutil.Uint64)(r.L1BaseFeeScalar),
+		L1BlobBaseFeeScalar: (*hexutil.Uint64)(r.L1BlobBaseFeeScalar),
+		OperatorFeeScalar:   (*hexutil.Uint64)(r.OperatorFeeScalar),
+		OperatorFeeConstant: (*hexutil.Uint64)(r.OperatorFeeConstant),
+	})
+	if err != nil {
+		return nil, err
+	}
+	var extraObj map[string]json.RawMessage
+	if err := json.Unmarshal(extra, &extraObj); err != nil {
+		return nil, err
+	}
+	for k, v := range extraObj {
+		obj[k] = v
+	}
+	return json.Marshal(obj)
+}

--- a/op-core/types/receipt.go
+++ b/op-core/types/receipt.go
@@ -8,29 +8,60 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// Receipt extends go-ethereum's receipt with the OP Stack L1-cost and
-// operator-fee fields that L2 endpoints include in eth_getTransactionReceipt
-// responses. The JSON field names match op-geth's types.Receipt verbatim for
-// wire compatibility; values are hex-encoded on the wire, hence the custom
-// JSON methods.
+// Receipt extends go-ethereum's receipt with the OP Stack fields that L2
+// endpoints include in eth_getTransactionReceipt responses. The full op-geth
+// field set is carried — not just the fields the monorepo services read — so
+// receipt JSON round-trips completely. JSON field names match op-geth's
+// types.Receipt verbatim for wire compatibility; values are hex-encoded on the
+// wire, hence the custom JSON methods.
+//
+// While the go.mod replace still points at op-geth, the embedded types.Receipt
+// carries identically-named fields. UnmarshalJSON populates both copies
+// consistently; when marshaling, the outer fields take precedence.
 type Receipt struct {
 	types.Receipt
-	L1GasPrice          *big.Int `json:"l1GasPrice,omitempty"`
-	L1BlobBaseFee       *big.Int `json:"l1BlobBaseFee,omitempty"`
-	L1BaseFeeScalar     *uint64  `json:"l1BaseFeeScalar,omitempty"`
-	L1BlobBaseFeeScalar *uint64  `json:"l1BlobBaseFeeScalar,omitempty"`
-	OperatorFeeScalar   *uint64  `json:"operatorFeeScalar,omitempty"`
-	OperatorFeeConstant *uint64  `json:"operatorFeeConstant,omitempty"`
+	// DepositNonce was introduced in Regolith to store the actual nonce used by
+	// deposit transactions.
+	DepositNonce *uint64 `json:"depositNonce,omitempty"`
+	// DepositReceiptVersion was introduced in Canyon to indicate an update to
+	// how receipt hashes should be computed when set; nil when not set.
+	DepositReceiptVersion *uint64 `json:"depositReceiptVersion,omitempty"`
+	// L1GasPrice is present from pre-bedrock; the L1 base fee after Bedrock.
+	L1GasPrice *big.Int `json:"l1GasPrice,omitempty"`
+	// L1BlobBaseFee is nil prior to the Ecotone hardfork.
+	L1BlobBaseFee *big.Int `json:"l1BlobBaseFee,omitempty"`
+	// L1GasUsed is present from pre-bedrock, deprecated as of Fjord.
+	L1GasUsed *big.Int `json:"l1GasUsed,omitempty"`
+	// L1Fee is present from pre-bedrock.
+	L1Fee *big.Int `json:"l1Fee,omitempty"`
+	// FeeScalar is present from pre-bedrock to Ecotone; nil after Ecotone.
+	FeeScalar *big.Float `json:"l1FeeScalar,omitempty"`
+	// L1BaseFeeScalar is nil prior to the Ecotone hardfork.
+	L1BaseFeeScalar *uint64 `json:"l1BaseFeeScalar,omitempty"`
+	// L1BlobBaseFeeScalar is nil prior to the Ecotone hardfork.
+	L1BlobBaseFeeScalar *uint64 `json:"l1BlobBaseFeeScalar,omitempty"`
+	// OperatorFeeScalar is nil prior to the Isthmus hardfork.
+	OperatorFeeScalar *uint64 `json:"operatorFeeScalar,omitempty"`
+	// OperatorFeeConstant is nil prior to the Isthmus hardfork.
+	OperatorFeeConstant *uint64 `json:"operatorFeeConstant,omitempty"`
+	// DAFootprintGasScalar is nil prior to the Jovian hardfork.
+	DAFootprintGasScalar *uint64 `json:"daFootprintGasScalar,omitempty"`
 }
 
 // receiptOpFields is the wire representation of the OP Stack receipt extensions.
 type receiptOpFields struct {
-	L1GasPrice          *hexutil.Big    `json:"l1GasPrice,omitempty"`
-	L1BlobBaseFee       *hexutil.Big    `json:"l1BlobBaseFee,omitempty"`
-	L1BaseFeeScalar     *hexutil.Uint64 `json:"l1BaseFeeScalar,omitempty"`
-	L1BlobBaseFeeScalar *hexutil.Uint64 `json:"l1BlobBaseFeeScalar,omitempty"`
-	OperatorFeeScalar   *hexutil.Uint64 `json:"operatorFeeScalar,omitempty"`
-	OperatorFeeConstant *hexutil.Uint64 `json:"operatorFeeConstant,omitempty"`
+	DepositNonce          *hexutil.Uint64 `json:"depositNonce,omitempty"`
+	DepositReceiptVersion *hexutil.Uint64 `json:"depositReceiptVersion,omitempty"`
+	L1GasPrice            *hexutil.Big    `json:"l1GasPrice,omitempty"`
+	L1BlobBaseFee         *hexutil.Big    `json:"l1BlobBaseFee,omitempty"`
+	L1GasUsed             *hexutil.Big    `json:"l1GasUsed,omitempty"`
+	L1Fee                 *hexutil.Big    `json:"l1Fee,omitempty"`
+	FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
+	L1BaseFeeScalar       *hexutil.Uint64 `json:"l1BaseFeeScalar,omitempty"`
+	L1BlobBaseFeeScalar   *hexutil.Uint64 `json:"l1BlobBaseFeeScalar,omitempty"`
+	OperatorFeeScalar     *hexutil.Uint64 `json:"operatorFeeScalar,omitempty"`
+	OperatorFeeConstant   *hexutil.Uint64 `json:"operatorFeeConstant,omitempty"`
+	DAFootprintGasScalar  *hexutil.Uint64 `json:"daFootprintGasScalar,omitempty"`
 }
 
 // UnmarshalJSON decodes both the embedded go-ethereum receipt and the OP Stack
@@ -43,12 +74,18 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
+	r.DepositNonce = (*uint64)(dec.DepositNonce)
+	r.DepositReceiptVersion = (*uint64)(dec.DepositReceiptVersion)
 	r.L1GasPrice = (*big.Int)(dec.L1GasPrice)
 	r.L1BlobBaseFee = (*big.Int)(dec.L1BlobBaseFee)
+	r.L1GasUsed = (*big.Int)(dec.L1GasUsed)
+	r.L1Fee = (*big.Int)(dec.L1Fee)
+	r.FeeScalar = dec.FeeScalar
 	r.L1BaseFeeScalar = (*uint64)(dec.L1BaseFeeScalar)
 	r.L1BlobBaseFeeScalar = (*uint64)(dec.L1BlobBaseFeeScalar)
 	r.OperatorFeeScalar = (*uint64)(dec.OperatorFeeScalar)
 	r.OperatorFeeConstant = (*uint64)(dec.OperatorFeeConstant)
+	r.DAFootprintGasScalar = (*uint64)(dec.DAFootprintGasScalar)
 	return nil
 }
 
@@ -64,12 +101,18 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	extra, err := json.Marshal(&receiptOpFields{
-		L1GasPrice:          (*hexutil.Big)(r.L1GasPrice),
-		L1BlobBaseFee:       (*hexutil.Big)(r.L1BlobBaseFee),
-		L1BaseFeeScalar:     (*hexutil.Uint64)(r.L1BaseFeeScalar),
-		L1BlobBaseFeeScalar: (*hexutil.Uint64)(r.L1BlobBaseFeeScalar),
-		OperatorFeeScalar:   (*hexutil.Uint64)(r.OperatorFeeScalar),
-		OperatorFeeConstant: (*hexutil.Uint64)(r.OperatorFeeConstant),
+		DepositNonce:          (*hexutil.Uint64)(r.DepositNonce),
+		DepositReceiptVersion: (*hexutil.Uint64)(r.DepositReceiptVersion),
+		L1GasPrice:            (*hexutil.Big)(r.L1GasPrice),
+		L1BlobBaseFee:         (*hexutil.Big)(r.L1BlobBaseFee),
+		L1GasUsed:             (*hexutil.Big)(r.L1GasUsed),
+		L1Fee:                 (*hexutil.Big)(r.L1Fee),
+		FeeScalar:             r.FeeScalar,
+		L1BaseFeeScalar:       (*hexutil.Uint64)(r.L1BaseFeeScalar),
+		L1BlobBaseFeeScalar:   (*hexutil.Uint64)(r.L1BlobBaseFeeScalar),
+		OperatorFeeScalar:     (*hexutil.Uint64)(r.OperatorFeeScalar),
+		OperatorFeeConstant:   (*hexutil.Uint64)(r.OperatorFeeConstant),
+		DAFootprintGasScalar:  (*hexutil.Uint64)(r.DAFootprintGasScalar),
 	})
 	if err != nil {
 		return nil, err

--- a/op-core/types/receipt_test.go
+++ b/op-core/types/receipt_test.go
@@ -36,19 +36,33 @@ func gethReceipt() *gethtypes.Receipt {
 	}
 }
 
+// gethReceiptAllOpFields sets every OP Stack extension field. A real receipt
+// never has all of them at once (e.g. deposit fields exclude fee fields), but
+// for wire-format testing the combination is irrelevant.
+func gethReceiptAllOpFields() *gethtypes.Receipt {
+	gr := gethReceipt()
+	gr.DepositNonce = uint64Ptr(12)
+	gr.DepositReceiptVersion = uint64Ptr(1)
+	gr.L1GasPrice = big.NewInt(42_000_000_000)
+	gr.L1BlobBaseFee = big.NewInt(123_456)
+	gr.L1GasUsed = big.NewInt(2048)
+	gr.L1Fee = big.NewInt(77_000)
+	gr.FeeScalar = big.NewFloat(0.5)
+	gr.L1BaseFeeScalar = uint64Ptr(5227)
+	gr.L1BlobBaseFeeScalar = uint64Ptr(1014213)
+	gr.OperatorFeeScalar = uint64Ptr(7)
+	gr.OperatorFeeConstant = uint64Ptr(9000)
+	gr.DAFootprintGasScalar = uint64Ptr(160)
+	return gr
+}
+
 // TestReceiptUnmarshalJSONDifferential asserts that the receipt JSON produced
 // by op-geth — the wire format of eth_getTransactionReceipt on an L2 endpoint —
 // decodes into optypes.Receipt with all OP Stack extension fields intact.
 // It will be removed in the final cutover, when the op-geth dependency is
 // replaced with upstream go-ethereum.
 func TestReceiptUnmarshalJSONDifferential(t *testing.T) {
-	gr := gethReceipt()
-	gr.L1GasPrice = big.NewInt(42_000_000_000)
-	gr.L1BlobBaseFee = big.NewInt(123_456)
-	gr.L1BaseFeeScalar = uint64Ptr(5227)
-	gr.L1BlobBaseFeeScalar = uint64Ptr(1014213)
-	gr.OperatorFeeScalar = uint64Ptr(7)
-	gr.OperatorFeeConstant = uint64Ptr(9000)
+	gr := gethReceiptAllOpFields()
 
 	wire, err := json.Marshal(gr)
 	require.NoError(t, err)
@@ -56,12 +70,19 @@ func TestReceiptUnmarshalJSONDifferential(t *testing.T) {
 	var r optypes.Receipt
 	require.NoError(t, json.Unmarshal(wire, &r))
 
+	require.Equal(t, gr.DepositNonce, r.DepositNonce)
+	require.Equal(t, gr.DepositReceiptVersion, r.DepositReceiptVersion)
 	require.Equal(t, gr.L1GasPrice, r.L1GasPrice)
 	require.Equal(t, gr.L1BlobBaseFee, r.L1BlobBaseFee)
+	require.Equal(t, gr.L1GasUsed, r.L1GasUsed)
+	require.Equal(t, gr.L1Fee, r.L1Fee)
+	require.NotNil(t, r.FeeScalar)
+	require.Zero(t, gr.FeeScalar.Cmp(r.FeeScalar))
 	require.Equal(t, gr.L1BaseFeeScalar, r.L1BaseFeeScalar)
 	require.Equal(t, gr.L1BlobBaseFeeScalar, r.L1BlobBaseFeeScalar)
 	require.Equal(t, gr.OperatorFeeScalar, r.OperatorFeeScalar)
 	require.Equal(t, gr.OperatorFeeConstant, r.OperatorFeeConstant)
+	require.Equal(t, gr.DAFootprintGasScalar, r.DAFootprintGasScalar)
 
 	// embedded standard fields survive
 	require.Equal(t, gr.TxHash, r.TxHash)
@@ -87,12 +108,18 @@ func TestReceiptUnmarshalJSONWithoutOpFields(t *testing.T) {
 	var r optypes.Receipt
 	require.NoError(t, json.Unmarshal(wire, &r))
 
+	require.Nil(t, r.DepositNonce)
+	require.Nil(t, r.DepositReceiptVersion)
 	require.Nil(t, r.L1GasPrice)
 	require.Nil(t, r.L1BlobBaseFee)
+	require.Nil(t, r.L1GasUsed)
+	require.Nil(t, r.L1Fee)
+	require.Nil(t, r.FeeScalar)
 	require.Nil(t, r.L1BaseFeeScalar)
 	require.Nil(t, r.L1BlobBaseFeeScalar)
 	require.Nil(t, r.OperatorFeeScalar)
 	require.Nil(t, r.OperatorFeeConstant)
+	require.Nil(t, r.DAFootprintGasScalar)
 	require.Equal(t, common.HexToHash("0xaaaa"), r.TxHash)
 
 	reencoded, err := json.Marshal(&r)
@@ -100,15 +127,42 @@ func TestReceiptUnmarshalJSONWithoutOpFields(t *testing.T) {
 	require.JSONEq(t, string(wire), string(reencoded))
 }
 
+func TestReceiptUnmarshalJSONNullOpFields(t *testing.T) {
+	wire, err := json.Marshal(gethReceipt())
+	require.NoError(t, err)
+	var obj map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(wire, &obj))
+	for _, k := range []string{"l1GasPrice", "l1Fee", "l1FeeScalar", "l1BaseFeeScalar", "operatorFeeScalar", "depositNonce"} {
+		obj[k] = json.RawMessage("null")
+	}
+	wire, err = json.Marshal(obj)
+	require.NoError(t, err)
+
+	var r optypes.Receipt
+	require.NoError(t, json.Unmarshal(wire, &r))
+	require.Nil(t, r.L1GasPrice)
+	require.Nil(t, r.L1Fee)
+	require.Nil(t, r.FeeScalar)
+	require.Nil(t, r.L1BaseFeeScalar)
+	require.Nil(t, r.OperatorFeeScalar)
+	require.Nil(t, r.DepositNonce)
+}
+
 func TestReceiptMarshalJSONRoundTrip(t *testing.T) {
 	r := optypes.Receipt{
-		Receipt:             *gethReceipt(),
-		L1GasPrice:          big.NewInt(1_000_000_007),
-		L1BlobBaseFee:       big.NewInt(1),
-		L1BaseFeeScalar:     uint64Ptr(11),
-		L1BlobBaseFeeScalar: uint64Ptr(0),
-		OperatorFeeScalar:   uint64Ptr(123),
-		OperatorFeeConstant: uint64Ptr(456),
+		Receipt:               *gethReceipt(),
+		DepositNonce:          uint64Ptr(12),
+		DepositReceiptVersion: uint64Ptr(1),
+		L1GasPrice:            big.NewInt(1_000_000_007),
+		L1BlobBaseFee:         big.NewInt(1),
+		L1GasUsed:             big.NewInt(4096),
+		L1Fee:                 big.NewInt(55_555),
+		FeeScalar:             big.NewFloat(0.25),
+		L1BaseFeeScalar:       uint64Ptr(11),
+		L1BlobBaseFeeScalar:   uint64Ptr(0),
+		OperatorFeeScalar:     uint64Ptr(123),
+		OperatorFeeConstant:   uint64Ptr(456),
+		DAFootprintGasScalar:  uint64Ptr(160),
 	}
 
 	wire, err := json.Marshal(&r)
@@ -117,12 +171,19 @@ func TestReceiptMarshalJSONRoundTrip(t *testing.T) {
 	var decoded optypes.Receipt
 	require.NoError(t, json.Unmarshal(wire, &decoded))
 
+	require.Equal(t, r.DepositNonce, decoded.DepositNonce)
+	require.Equal(t, r.DepositReceiptVersion, decoded.DepositReceiptVersion)
 	require.Equal(t, r.L1GasPrice, decoded.L1GasPrice)
 	require.Equal(t, r.L1BlobBaseFee, decoded.L1BlobBaseFee)
+	require.Equal(t, r.L1GasUsed, decoded.L1GasUsed)
+	require.Equal(t, r.L1Fee, decoded.L1Fee)
+	require.NotNil(t, decoded.FeeScalar)
+	require.Zero(t, r.FeeScalar.Cmp(decoded.FeeScalar))
 	require.Equal(t, r.L1BaseFeeScalar, decoded.L1BaseFeeScalar)
 	require.Equal(t, r.L1BlobBaseFeeScalar, decoded.L1BlobBaseFeeScalar)
 	require.Equal(t, r.OperatorFeeScalar, decoded.OperatorFeeScalar)
 	require.Equal(t, r.OperatorFeeConstant, decoded.OperatorFeeConstant)
+	require.Equal(t, r.DAFootprintGasScalar, decoded.DAFootprintGasScalar)
 	require.Equal(t, r.TxHash, decoded.TxHash)
 	require.Equal(t, r.GasUsed, decoded.GasUsed)
 }

--- a/op-core/types/receipt_test.go
+++ b/op-core/types/receipt_test.go
@@ -1,0 +1,128 @@
+package types_test
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
+)
+
+func uint64Ptr(v uint64) *uint64 { return &v }
+
+func gethReceipt() *gethtypes.Receipt {
+	return &gethtypes.Receipt{
+		Type:              gethtypes.DynamicFeeTxType,
+		Status:            gethtypes.ReceiptStatusSuccessful,
+		CumulativeGasUsed: 100_000,
+		Logs: []*gethtypes.Log{
+			{
+				Address: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+				Topics:  []common.Hash{common.HexToHash("0x01")},
+				Data:    []byte{0x42},
+			},
+		},
+		TxHash:            common.HexToHash("0xaaaa"),
+		GasUsed:           21_000,
+		EffectiveGasPrice: big.NewInt(1_000_000_000),
+		BlockHash:         common.HexToHash("0xbbbb"),
+		BlockNumber:       big.NewInt(1234),
+		TransactionIndex:  3,
+	}
+}
+
+// TestReceiptUnmarshalJSONDifferential asserts that the receipt JSON produced
+// by op-geth — the wire format of eth_getTransactionReceipt on an L2 endpoint —
+// decodes into optypes.Receipt with all OP Stack extension fields intact.
+// It will be removed in the final cutover, when the op-geth dependency is
+// replaced with upstream go-ethereum.
+func TestReceiptUnmarshalJSONDifferential(t *testing.T) {
+	gr := gethReceipt()
+	gr.L1GasPrice = big.NewInt(42_000_000_000)
+	gr.L1BlobBaseFee = big.NewInt(123_456)
+	gr.L1BaseFeeScalar = uint64Ptr(5227)
+	gr.L1BlobBaseFeeScalar = uint64Ptr(1014213)
+	gr.OperatorFeeScalar = uint64Ptr(7)
+	gr.OperatorFeeConstant = uint64Ptr(9000)
+
+	wire, err := json.Marshal(gr)
+	require.NoError(t, err)
+
+	var r optypes.Receipt
+	require.NoError(t, json.Unmarshal(wire, &r))
+
+	require.Equal(t, gr.L1GasPrice, r.L1GasPrice)
+	require.Equal(t, gr.L1BlobBaseFee, r.L1BlobBaseFee)
+	require.Equal(t, gr.L1BaseFeeScalar, r.L1BaseFeeScalar)
+	require.Equal(t, gr.L1BlobBaseFeeScalar, r.L1BlobBaseFeeScalar)
+	require.Equal(t, gr.OperatorFeeScalar, r.OperatorFeeScalar)
+	require.Equal(t, gr.OperatorFeeConstant, r.OperatorFeeConstant)
+
+	// embedded standard fields survive
+	require.Equal(t, gr.TxHash, r.TxHash)
+	require.Equal(t, gr.Status, r.Status)
+	require.Equal(t, gr.CumulativeGasUsed, r.CumulativeGasUsed)
+	require.Equal(t, gr.GasUsed, r.GasUsed)
+	require.Equal(t, gr.EffectiveGasPrice, r.EffectiveGasPrice)
+	require.Equal(t, gr.BlockNumber, r.BlockNumber)
+	require.Len(t, r.Logs, 1)
+	require.Equal(t, gr.Logs[0].Address, r.Logs[0].Address)
+
+	// re-encoding matches op-geth's encoding, modulo JSON key order
+	reencoded, err := json.Marshal(&r)
+	require.NoError(t, err)
+	require.JSONEq(t, string(wire), string(reencoded))
+}
+
+func TestReceiptUnmarshalJSONWithoutOpFields(t *testing.T) {
+	// an L1 receipt has none of the OP Stack extension fields
+	wire, err := json.Marshal(gethReceipt())
+	require.NoError(t, err)
+
+	var r optypes.Receipt
+	require.NoError(t, json.Unmarshal(wire, &r))
+
+	require.Nil(t, r.L1GasPrice)
+	require.Nil(t, r.L1BlobBaseFee)
+	require.Nil(t, r.L1BaseFeeScalar)
+	require.Nil(t, r.L1BlobBaseFeeScalar)
+	require.Nil(t, r.OperatorFeeScalar)
+	require.Nil(t, r.OperatorFeeConstant)
+	require.Equal(t, common.HexToHash("0xaaaa"), r.TxHash)
+
+	reencoded, err := json.Marshal(&r)
+	require.NoError(t, err)
+	require.JSONEq(t, string(wire), string(reencoded))
+}
+
+func TestReceiptMarshalJSONRoundTrip(t *testing.T) {
+	r := optypes.Receipt{
+		Receipt:             *gethReceipt(),
+		L1GasPrice:          big.NewInt(1_000_000_007),
+		L1BlobBaseFee:       big.NewInt(1),
+		L1BaseFeeScalar:     uint64Ptr(11),
+		L1BlobBaseFeeScalar: uint64Ptr(0),
+		OperatorFeeScalar:   uint64Ptr(123),
+		OperatorFeeConstant: uint64Ptr(456),
+	}
+
+	wire, err := json.Marshal(&r)
+	require.NoError(t, err)
+
+	var decoded optypes.Receipt
+	require.NoError(t, json.Unmarshal(wire, &decoded))
+
+	require.Equal(t, r.L1GasPrice, decoded.L1GasPrice)
+	require.Equal(t, r.L1BlobBaseFee, decoded.L1BlobBaseFee)
+	require.Equal(t, r.L1BaseFeeScalar, decoded.L1BaseFeeScalar)
+	require.Equal(t, r.L1BlobBaseFeeScalar, decoded.L1BlobBaseFeeScalar)
+	require.Equal(t, r.OperatorFeeScalar, decoded.OperatorFeeScalar)
+	require.Equal(t, r.OperatorFeeConstant, decoded.OperatorFeeConstant)
+	require.Equal(t, r.TxHash, decoded.TxHash)
+	require.Equal(t, r.GasUsed, decoded.GasUsed)
+}


### PR DESCRIPTION
## Description

Part of the op-geth decoupling (#20257); closes #20262. Creates `op-core/types` (imported as `optypes`) with the OP-Stack-specific transaction and receipt types, per §1–§3 of [docs/ai/opgeth-decoupling.md](https://github.com/ethereum-optimism/optimism/blob/develop/docs/ai/opgeth-decoupling.md):

- **`DepositTx`** — standalone RLP type matching op-geth's wire format (`0x7E || RLP(struct)`), with `MarshalBinary` / `UnmarshalDepositTx`. No dependency on go-ethereum's `TxData` interface.
- **`PostExecTx`** — standalone type for the SDM post-exec transaction (`0x7D || data`, where `data` is appended verbatim with no outer RLP envelope; `data` is itself an RLP-encoded payload that op-geth and this type treat as opaque), with `MarshalBinary` / `UnmarshalPostExecTx`. Like op-geth, decoding rejects an empty payload (typed-tx envelopes of `len <= 1` are unparseable).
- **Free-function helpers** replacing op-geth's `Transaction` methods: `IsDepositTx`, `SourceHash`, `Mint`, `IsSystemTx`, `IsPostExecTx`. These are **transition scaffolding**: they take a go-ethereum `*types.Transaction`, which can carry a `0x7E`/`0x7D` tx only while the build still resolves to op-geth. After the cutover an upstream `*types.Transaction` can never hold one, so the helpers (and the differential test) are removed then — the durable shape decodes raw bytes into `optypes` structs and reads fields directly. Documented as such in the code.
- **`Receipt`** — embeds `types.Receipt` and adds op-geth's complete OP Stack receipt field set (deposit nonce/version, L1 fee fields, operator fee, DA footprint gas scalar) with JSON names verbatim from op-geth — a partial set would silently drop fields from receipt JSON at cutover, masked until then by the embedded op-geth receipt. Custom `UnmarshalJSON` decodes the wire's hex encoding via `hexutil`; a matching `MarshalJSON` merges the fields back in so the type round-trips (the promoted upstream marshaler would silently drop them).

**Differential tests** (to be removed at the final cutover) assert byte-for-byte equality of both tx encodings against op-geth, compare helper outputs against op-geth's `Transaction` methods on round-tripped txs, and check receipt JSON decode/re-encode against op-geth's marshaler. Notable behavior pinned down by the tests: a nil `Mint` round-trips to `0` through the wire encoding — in op-geth too.

Also updates the decoupling plan: `PostExecTx` is a canonical block tx in Lagoon (trailing sequencer-rebate tx), so the L2 decode path must route both `0x7E` and `0x7D` out (§1); and the L2 transaction representation is resolved as a class-partitioned accessor set (`InfoAndUserTxs` / `InfoAndDeposits` / `InfoAndFirstDeposit`) rather than an `optypes.Transaction` wrapper (§11). The accessor work lands in #20264.

Call-site swaps follow in #20263.

## Tests

- `go test ./op-core/types/...` — new unit + differential tests.
- `just lint-go` clean.

## Additional context

No production code uses the new package yet; consumers migrate in #20263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





