### PR TITLE
docs(ai): add /update-reth skill and fold bump learnings into the guide

### DIFF
--- a/.claude/skills/update-reth/SKILL.md
+++ b/.claude/skills/update-reth/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: update-reth
+description: Update the pinned upstream reth dependency across the Rust workspaces — pin bump, shared dependency sync, compile-and-adapt loop, full verification, and PR. Use when asked to bump, update, or upgrade reth (e.g. "update to reth v2.4.0").
+---
+
+# Update reth
+
+Bump the `paradigmxyz/reth` pin (normally to the latest release tag) and adapt the
+OP Stack Rust workspaces to upstream API changes.
+
+The complete procedure — pin audit, the four manifests, shared dependency sync,
+lockfiles, the compile-and-adapt loop, and verification — lives in
+[`rust/UPDATING-RETH.md`](../../../rust/UPDATING-RETH.md). **Read it in full first
+and follow it exactly**; this skill only adds the agent workflow around it. Don't
+restate the guide to the user — execute it.
+
+## Arguments
+
+Optional target: a release tag (`v2.4.0`), a commit sha, or an upstream PR number.
+Default: the latest upstream release tag (`gh release list --repo paradigmxyz/reth`).
+
+## Workflow
+
+1. **Orient.** Read the guide. Find a local `paradigmxyz/reth` checkout (ask the
+   user if you can't find one) and fetch its tags — you'll need it for tag
+   resolution, API archaeology, and diffing replicated code.
+
+2. **Isolate.** Work in a fresh git worktree (or jj workspace) based on latest
+   `develop` — never on the main checkout's working copy. Run `mise trust` in the
+   new directory.
+
+3. **Execute the guide's procedure**, including the current-pin audit before
+   moving off it. Iterate the compile loop to green rather than enumerating
+   breakages up front; don't ask the user to confirm each adaptation.
+
+4. **Verify everything the guide lists** before any push. On memory-constrained
+   machines, wrap heavy builds in `systemd-run --user --scope -p MemoryMax=<n>G`
+   with reduced `-j` (not `ulimit -v`, which SIGABRTs rustc).
+
+5. **Ship.** One commit (`rust: update reth to <version>`) describing the pin
+   move, each shared dependency sync, and every API adaptation. Run the AI review
+   (code + security) before pushing; PR to `develop` with verification results
+   spelled out.
+
+6. **Compound.** If this bump taught you something the guide doesn't cover, fold
+   it into `rust/UPDATING-RETH.md` in the same PR.

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -156,7 +156,7 @@ Op-reth requires `clang` / `libclang-dev` for reth-mdbx-sys bindgen. CI installs
 
 ## Updating the reth dependency
 
-The full guide lives at [`rust/UPDATING-RETH.md`](../../rust/UPDATING-RETH.md). Read it before bumping the reth rev in `rust/Cargo.toml`.
+The full guide lives at [`rust/UPDATING-RETH.md`](../../rust/UPDATING-RETH.md). Read it before bumping the reth pin in `rust/Cargo.toml` — or run the `/update-reth` skill (`.claude/skills/update-reth/`), which wraps the guide in an end-to-end agent workflow.
 
 Agent-specific tips beyond what's in the guide:
 

--- a/rust/UPDATING-RETH.md
+++ b/rust/UPDATING-RETH.md
@@ -26,7 +26,15 @@ main's CI actually validated.
    `gh pr view <N> --repo paradigmxyz/reth --json mergeCommit`). Otherwise take
    the current head of `paradigmxyz/reth` `main`.
 
-2. Update the pin. The ref is pinned in **four** manifests, not just the main
+2. Audit what the current pin carries before moving off it. If the current pin
+   is **not an ancestor of the target** (e.g. it was an unmerged-PR commit),
+   find what it carried — the monorepo commit that introduced it
+   (`git log -S '<pin>' -- rust/Cargo.toml`) and the upstream PR
+   (`gh api repos/paradigmxyz/reth/commits/<sha>/pulls`) — and verify each
+   carried change is contained in, or explicitly superseded by, the target.
+   Never silently drop a fix the pin was carrying.
+
+3. Update the pin. The ref is pinned in **four** manifests, not just the main
    workspace: `op-rbuilder` and `rollup-boost` are separate Cargo workspaces
    that path-depend on the op-reth crates while also pinning reth directly.
    Bumping only `rust/Cargo.toml` leaves them on the old ref, so their
@@ -50,7 +58,7 @@ main's CI actually validated.
    The lockfiles record the resolved commit either way, so builds stay
    reproducible even if an upstream tag were to move.
 
-3. Sync shared dependency versions to the new rev's pins. reth and the OP Stack
+4. Sync shared dependency versions to the new rev's pins. reth and the OP Stack
    share the `revm`/`revm-*`, `alloy-*` (core and main), `alloy-eip7928`, and
    the published reth-core crate families (`reth-primitives-traits`,
    `reth-codecs`, `reth-rpc-traits`, `reth-zstd-compressors`). reth pins them
@@ -89,7 +97,7 @@ main's CI actually validated.
    keeps the manifest honest about what we actually build against and signals
    the sync to downstream consumers (e.g. Hardhat tracking `op-revm`).
 
-4. Refresh the lockfiles — all three workspaces have their own. `cargo update
+5. Refresh the lockfiles — all three workspaces have their own. `cargo update
    -p reth` does **not** work — there is no top-level crate literally named
    `reth` in the dep graph; the workspace depends on `reth-*` subcrates. Pass
    any real reth subcrate; cargo cascades to every git dep sharing the same
@@ -101,7 +109,7 @@ main's CI actually validated.
    done
    ```
 
-5. Revisit the slot-preimage layout reference.
+6. Revisit the slot-preimage layout reference.
    `op-reth/crates/cli/src/commands/slot_preimages_seed.rs` replicates reth's
    private `SlotPreimages` MDBX layout and carries the rev it was copied from.
    Diff the upstream source between the revs; if unchanged, just update the rev
@@ -112,7 +120,7 @@ main's CI actually validated.
      crates/stages/stages/src/stages/execution/slot_preimages.rs
    ```
 
-6. Compile and adapt:
+7. Compile and adapt:
 
    ```bash
    mise exec -- cargo check --workspace --tests
@@ -126,6 +134,13 @@ main's CI actually validated.
    default/eth implementation does, found in the new rev's sources or the
    cargo registry sources under `~/.cargo/registry/src/`.
 
+   **Gas accounting and other consensus-adjacent overrides** deserve extra
+   rigor: derive the change as *(old upstream default → new upstream default)*
+   applied onto our override, leaving the OP-specific branches byte-identical —
+   never invent logic. Any new semantic branch (even fork-gated and inert
+   today) gets a unit test, verified red against a deliberately broken variant
+   and green against the real code.
+
    Then repeat for the vendored workspaces:
 
    ```bash
@@ -133,13 +148,18 @@ main's CI actually validated.
    (cd rollup-boost && mise exec -- cargo check --workspace --tests)
    ```
 
-7. Build, format, and test before pushing:
+8. Build, format, and test before pushing:
 
    ```bash
    mise exec -- cargo build -p op-reth
    just fmt-fix && just lint
    just test   # unit + doc tests — CI runs both, and doc examples call reth APIs too
    ```
+
+   Only the `just` recipes use the repo-pinned nightly rustfmt — a bare
+   `cargo fmt` on the stable toolchain reformats unrelated files and fails
+   CI's `rust-fmt` gate. Also run the test suites of any vendored-workspace
+   crate whose source you touched.
 
 ## Expect upstream churn beyond your target change
 


### PR DESCRIPTION
## Description

Adds `.claude/skills/update-reth/` — a thin agent workflow for bumping the pinned upstream reth dependency. The skill deliberately repeats none of the procedure: `rust/UPDATING-RETH.md` stays the single source of truth, and the skill just orchestrates (orient → isolate in a worktree → execute the guide → verify → reviewed PR → fold learnings back).

The durable learnings from the v2.3.0 bump (#21348) move into the guide itself instead of living in the skill:

- a new **current-pin audit** step: when the existing pin isn't an ancestor of the target, verify what it carried is contained in or superseded by the target before moving
- the **consensus-adjacent adaptation rule**: derive gas-accounting changes as (old upstream default → new upstream default) applied onto our override, with a red/green-verified test for any new semantic branch — even fork-gated ones
- the **stable-toolchain `cargo fmt` trap** (only the `just` recipes use the pinned nightly)

Cross-referenced from `docs/ai/rust-dev.md`.

## Tests

Docs-only change; reviewed locally via tuicr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)