### PR TITLE
fix(alloy-op-evm): override `execute_transaction_with_commit_condition` on `OpBlockExecutor` to prevent phantom SDM refunds

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/flashblocks_sdm_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_sdm_test.go
@@ -44,13 +44,6 @@ func TestFlashblocksSDMMaterializesPostExecBlock(gt *testing.T) {
 	sysgo.SkipOnKonaNode(t, "flashblocks acceptance preset requires user RPC")
 	sysgo.SkipOnOpGeth(t, "SDM flashblocks require op-reth post-exec support")
 
-	// op-rbuilder mishandles Osaka SDM post-exec accumulation: with Osaka active it includes
-	// more txs' gas refunds in the post-exec payload than op-node derives, so the builder and
-	// derivation payloads diverge. Skipped while #21337 activates Osaka at Karst; SDM rides
-	// Interop (Lagoon), which isn't activated yet, so this is not user-facing. Re-enable once
-	// op-rbuilder is fixed: ethereum-optimism/optimism#21354.
-	t.Skip("op-rbuilder Osaka SDM post-exec divergence — re-enable after ethereum-optimism/optimism#21354")
-
 	// SDM rides Interop: activating Interop at genesis turns SDM on for op-reth execution
 	// and the op-rbuilder payload builder consistently with op-node derivation. The preset
 	// also provisions the DependencySet required by op-node whenever Interop is scheduled.

--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -9,8 +9,7 @@ use alloy_evm::{
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory,
         BlockValidationError, CommitChanges, ExecutableTx, GasOutput, StateDB, SystemCaller,
-        TxResult,
-        state_changes::post_block_balance_increments,
+        TxResult, state_changes::post_block_balance_increments,
     },
     eth::{EthTxResult, receipt_builder::ReceiptBuilderCtx},
 };
@@ -812,13 +811,14 @@ where
         f: impl FnOnce(&Self::Result) -> CommitChanges,
     ) -> Result<Option<GasOutput>, BlockExecutionError> {
         // SDM warming refunds are *block*-scoped and are recorded by an inspector whose maps are
-        // mutated during EVM execution (inside `execute_transaction_without_commit`) — i.e. *before*
-        // the commit decision below — and are not part of the journaled state, so they are not
-        // rolled back when a transaction's changes are discarded. A caller (e.g. the op-rbuilder
-        // payload builder) that executes a candidate transaction and then declines to commit it
-        // (`CommitChanges::No`: over a builder gas/DA/address limit, or reverted-and-excluded) would
-        // otherwise leave behind "phantom" warming provenance: a later *committed* transaction would
-        // claim a block-warming refund attributed to a transaction that never enters the block. The
+        // mutated during EVM execution (inside `execute_transaction_without_commit`) — i.e.
+        // *before* the commit decision below — and are not part of the journaled state, so
+        // they are not rolled back when a transaction's changes are discarded. A caller
+        // (e.g. the op-rbuilder payload builder) that executes a candidate transaction and
+        // then declines to commit it (`CommitChanges::No`: over a builder gas/DA/address
+        // limit, or reverted-and-excluded) would otherwise leave behind "phantom" warming
+        // provenance: a later *committed* transaction would claim a block-warming refund
+        // attributed to a transaction that never enters the block. The
         // canonical single-pass paths — block import and `debug_replaySDMBlock` derivation — only
         // ever commit transactions (`execute_transaction`), so they never observe that warmth and
         // derive a strictly smaller refund set, diverging from the producer's payload.

--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -8,7 +8,8 @@ use alloy_evm::{
     Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, RecoveredTx,
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory,
-        BlockValidationError, ExecutableTx, GasOutput, StateDB, SystemCaller, TxResult,
+        BlockValidationError, CommitChanges, ExecutableTx, GasOutput, StateDB, SystemCaller,
+        TxResult,
         state_changes::post_block_balance_increments,
     },
     eth::{EthTxResult, receipt_builder::ReceiptBuilderCtx},
@@ -803,6 +804,41 @@ where
         .map_err(BlockExecutionError::other)?;
 
         Ok(())
+    }
+
+    fn execute_transaction_with_commit_condition(
+        &mut self,
+        tx: impl ExecutableTx<Self>,
+        f: impl FnOnce(&Self::Result) -> CommitChanges,
+    ) -> Result<Option<GasOutput>, BlockExecutionError> {
+        // SDM warming refunds are *block*-scoped and are recorded by an inspector whose maps are
+        // mutated during EVM execution (inside `execute_transaction_without_commit`) — i.e. *before*
+        // the commit decision below — and are not part of the journaled state, so they are not
+        // rolled back when a transaction's changes are discarded. A caller (e.g. the op-rbuilder
+        // payload builder) that executes a candidate transaction and then declines to commit it
+        // (`CommitChanges::No`: over a builder gas/DA/address limit, or reverted-and-excluded) would
+        // otherwise leave behind "phantom" warming provenance: a later *committed* transaction would
+        // claim a block-warming refund attributed to a transaction that never enters the block. The
+        // canonical single-pass paths — block import and `debug_replaySDMBlock` derivation — only
+        // ever commit transactions (`execute_transaction`), so they never observe that warmth and
+        // derive a strictly smaller refund set, diverging from the producer's payload.
+        //
+        // Snapshot the block-scoped warming state before execution and restore it whenever the
+        // transaction is not committed, so the producer's accumulated `SDMGasEntry` set stays
+        // identical to a commit-only canonical pass. Only `Producing` mode tracks warming, so the
+        // snapshot (a clone of the warming maps) is taken solely on that path.
+        let warming_snapshot = self.post_exec.is_producing().then(|| self.warming_state());
+
+        let output = self.execute_transaction_without_commit(tx)?;
+
+        if !f(&output).should_commit() {
+            if let Some(snapshot) = warming_snapshot {
+                self.seed_warming_state(snapshot);
+            }
+            return Ok(None);
+        }
+
+        Ok(Some(self.commit_transaction(output)))
     }
 
     fn execute_transaction_without_commit(

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -523,7 +523,8 @@ mod sdm {
         let mut producer = fixture.executor_with_post_exec_mode(PostExecMode::Produce);
 
         // Execute a candidate that touches `target` (warming it) but decline to commit it, as the
-        // payload builder does when a candidate exceeds a builder limit or is reverted-and-excluded.
+        // payload builder does when a candidate exceeds a builder limit or is
+        // reverted-and-excluded.
         let outcome = producer
             .execute_transaction_with_commit_condition(&legacy_tx(0, target), |_| CommitChanges::No)
             .expect("declined candidate still executes");
@@ -535,9 +536,7 @@ mod sdm {
 
         // The first *committed* tx touching `target` must be treated as its first toucher: the
         // declined candidate's warming must have been rolled back, so no refund is produced.
-        producer
-            .execute_transaction(&legacy_tx(0, target))
-            .expect("first committed tx executes");
+        producer.execute_transaction(&legacy_tx(0, target)).expect("first committed tx executes");
         assert!(
             producer.post_exec_entries().is_empty(),
             "an uncommitted candidate must not warm a later committed tx (no phantom SDM refund)",
@@ -545,9 +544,7 @@ mod sdm {
 
         // Sanity: committed warmth still accumulates through the overridden commit path — a second
         // committed tx re-warms the now-committed address and earns a refund at its tx index.
-        producer
-            .execute_transaction(&legacy_tx(1, target))
-            .expect("second committed tx executes");
+        producer.execute_transaction(&legacy_tx(1, target)).expect("second committed tx executes");
         let entries = producer.post_exec_entries();
         assert_eq!(entries.len(), 1, "second committed tx re-warms the block-warmed address");
         assert_eq!(entries[0].index, 1, "refund is attributed to the second committed tx");

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -508,6 +508,52 @@ mod sdm {
         assert_eq!(verified.receipts.len(), user_txs.len() + 1);
     }
 
+    // A candidate transaction that is executed but declined (`CommitChanges::No`) must not leave
+    // behind block-scoped warming provenance: the SDM warming maps are mutated during EVM
+    // execution, before the commit decision, and are not journaled, so without an explicit
+    // rollback an uncommitted candidate would grant a later *committed* tx a phantom re-warming
+    // refund. Block import and `debug_replaySDMBlock` derivation only ever commit transactions, so
+    // such phantom entries would make the producer's payload diverge from derivation
+    // (ethereum-optimism/optimism#21354).
+    #[test]
+    fn test_uncommitted_candidate_does_not_warm_later_committed_tx() {
+        let target = Address::from([0x11; 20]);
+
+        let mut fixture = SDMExecutorFixture::default();
+        let mut producer = fixture.executor_with_post_exec_mode(PostExecMode::Produce);
+
+        // Execute a candidate that touches `target` (warming it) but decline to commit it, as the
+        // payload builder does when a candidate exceeds a builder limit or is reverted-and-excluded.
+        let outcome = producer
+            .execute_transaction_with_commit_condition(&legacy_tx(0, target), |_| CommitChanges::No)
+            .expect("declined candidate still executes");
+        assert!(outcome.is_none(), "candidate must not be committed");
+        assert!(
+            producer.post_exec_entries().is_empty(),
+            "a declined candidate emits no SDM refund entries",
+        );
+
+        // The first *committed* tx touching `target` must be treated as its first toucher: the
+        // declined candidate's warming must have been rolled back, so no refund is produced.
+        producer
+            .execute_transaction(&legacy_tx(0, target))
+            .expect("first committed tx executes");
+        assert!(
+            producer.post_exec_entries().is_empty(),
+            "an uncommitted candidate must not warm a later committed tx (no phantom SDM refund)",
+        );
+
+        // Sanity: committed warmth still accumulates through the overridden commit path — a second
+        // committed tx re-warms the now-committed address and earns a refund at its tx index.
+        producer
+            .execute_transaction(&legacy_tx(1, target))
+            .expect("second committed tx executes");
+        let entries = producer.post_exec_entries();
+        assert_eq!(entries.len(), 1, "second committed tx re-warms the block-warmed address");
+        assert_eq!(entries[0].index, 1, "refund is attributed to the second committed tx");
+        assert!(entries[0].gas_refund > 0);
+    }
+
     // Demonstrates the accounting the pre-refund cap relies on: under SDM refunds, canonical
     // `gas_used` falls below `evm_gas_used`, so capping on `evm_gas_used` (not `gas_used`) keeps
     // tracking the real compute performed.


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/optimism/issues/21354

## Root cause

The SDM warming inspector (`alloy-op-evm/src/post_exec/inspector.rs`) maintains **block-scoped** `warmed_accounts`/`warmed_slots` maps. These are mutated during EVM execution inside `execute_transaction_without_commit` — **before** the commit decision — and they aren't part of the journaled state, so discarding a transaction's changes does **not** roll them back.

op-rbuilder's payload builder selects transactions with `execute_transaction_with_commit_condition` and declines candidates (`CommitChanges::No`) that exceed a builder gas/DA/address limit or are reverted-and-excluded. Those declined candidates still warmed the maps, so a later *committed* tx could claim a block-warming refund attributed to a transaction that never entered the block. The canonical single-pass paths — block import and `debug_replaySDMBlock` derivation — only ever `execute_transaction` (commit-only), so they never see that phantom warmth and derive a strictly smaller refund set. Hence the producer's payload had more `SDMGasEntry`s than derivation reproduced.

## Fix

`rust/alloy-op-evm/src/block/mod.rs` — overrode `execute_transaction_with_commit_condition` on `OpBlockExecutor` to snapshot the block-scoped warming state before execution and **restore it whenever the tx isn't committed** (producer mode only, so no clone cost when SDM is off/verifying). This keeps the producer's accumulated entry set identical to a commit-only canonical pass. It also benefits op-reth's own block builder, which selects txs the same way.