### PR TITLE
fix(alloy-op-evm): roll back SDM block-warming for declined op-rbuilder candidates

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/flashblocks_sdm_phantom_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_sdm_phantom_test.go
@@ -1,0 +1,197 @@
+package flashblocks
+
+import (
+	"fmt"
+	"math/big"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/pkg/sdm"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+)
+
+// phantomMaxGasPerTxn caps op-rbuilder's per-tx gas used. A candidate over the cap is executed
+// (warming the slots it touches) then declined — the "executed but not committed" path that leaks
+// SDM warming when it isn't rolled back. Sized between the victim's gas and the poisoner's.
+const phantomMaxGasPerTxn = 200_000
+
+// The declined "poisoner" call writes a superset of the committed "victim" call's slots, so the
+// victim re-touches slots that — in the canonical block — were only warmed by a tx that never
+// entered the block.
+const (
+	poisonerSlots = 30 // run(30) ≈ 0.68M gas  > cap  => executed then declined
+	victimSlots   = 4  // run(4)  ≈ 0.11M gas  < cap  => committed
+)
+
+// TestFlashblocksSDMPhantomWarmingDivergence makes the op-rbuilder phantom-warming bug observable
+// at the acceptance level (ethereum-optimism/optimism#21354).
+//
+// SDM block-warming refunds are recorded during EVM execution (before the commit decision) and
+// aren't journaled. When op-rbuilder executes a candidate then declines it (here: over
+// `--builder.max_gas_per_txn`), the declined candidate's warming is (pre-fix) left behind, and a
+// later committed tx touching the same slots claims a "phantom" refund for a tx that never entered
+// the block. Commit-only paths (block import, `debug_replaySDMBlock` derivation) never see that
+// warmth. This test drives a persistently-declined poisoner alongside committed victims and, per
+// victim block, compares the producer-baked SDM payload against the commit-only derivation; they
+// must be identical. Pre-fix they diverge and the failure prints the phantom entries.
+func TestFlashblocksSDMPhantomWarmingDivergence(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sysgo.SkipOnKonaNode(t, "flashblocks acceptance preset requires user RPC")
+	sysgo.SkipOnOpGeth(t, "SDM flashblocks require op-reth post-exec support")
+
+	// Cap per-tx gas so the poisoner is declined post-execution (the warming-leak path). SDM rides
+	// Interop; activating it at genesis turns SDM on across op-reth, op-rbuilder, and op-node.
+	sys := presets.NewSingleChainWithFlashblocks(t,
+		presets.WithInteropAtGenesis(),
+		presets.WithOPRBuilderOption(sysgo.OPRBuilderNodeWithExtraArgs(
+			fmt.Sprintf("--builder.max_gas_per_txn=%d", phantomMaxGasPerTxn),
+		)),
+	)
+
+	driveViaTestSequencer(t, sys, 2)
+
+	// Opt SDM PostExec production in on both the sequencer EL (op-reth fallback) and op-rbuilder;
+	// the flag is process-local and starts disabled on boot. See flashblocks_sdm_test.go.
+	setFlashblocksSDMEnabled(t, sys.L2EL.Escape().L2EthClient().RPC(), true)
+	setFlashblocksSDMEnabled(t, sys.L2OPRBuilder.Escape().L2EthClient().RPC(), true)
+
+	rpc := sys.L2EL.Escape().L2EthClient().RPC()
+
+	// Deploy the StateBloat contract; run(n) writes slots [0, n).
+	deployer := sys.FunderL2.NewFundedEOA(eth.OneEther)
+	stateBloat := flashblocksDeployContract(t, deployer, sdm.StateBloatBin)
+
+	// The poisoner: one persistent, top-priority call that always exceeds the gas cap, so op-rbuilder
+	// re-declines it every block — warming the poisoner's slots before any victim commits. A declined
+	// candidate isn't marked invalid, so it lingers in the mempool and keeps poisoning blocks. It's
+	// never included, so we don't wait for it.
+	poisoner := sys.FunderL2.NewFundedEOA(eth.OneEther)
+	flashblocksSubmitTxWithoutWait(t, poisoner, poisoner.PendingNonce(),
+		txplan.WithTo(&stateBloat),
+		txplan.WithData(sdm.EncodeRun(poisonerSlots)),
+		txplan.WithGasLimit(1_500_000),
+		// Highest priority so op-rbuilder processes (and declines) it first in each block.
+		txplan.WithGasTipCap(big.NewInt(5_000_000_000)),
+		txplan.WithGasFeeCap(big.NewInt(500_000_000_000)),
+	)
+
+	// The victims: small committed calls that re-touch the poisoner's slots, sent one at a time
+	// (waiting for each receipt) so each lands in its own block behind the declined poisoner.
+	const victimCount = 6
+	victim := sys.FunderL2.NewFundedEOA(eth.OneEther)
+	victimBlocks := make([]uint64, 0, victimCount)
+	seen := make(map[uint64]bool)
+	for i := range victimCount {
+		ptx := txplan.NewPlannedTx(
+			victim.Plan(),
+			txplan.WithNonce(victim.PendingNonce()),
+			txplan.WithTo(&stateBloat),
+			txplan.WithData(sdm.EncodeRun(victimSlots)),
+			txplan.WithGasLimit(400_000),
+		)
+		receipt, err := ptx.Included.Eval(t.Ctx())
+		t.Require().NoError(err, "victim %d must be included", i)
+		bn := bigs.Uint64Strict(receipt.BlockNumber)
+		if !seen[bn] {
+			seen[bn] = true
+			victimBlocks = append(victimBlocks, bn)
+		}
+	}
+	slices.Sort(victimBlocks)
+	t.Require().NotEmpty(victimBlocks, "expected at least one victim block")
+
+	// Compare producer-baked vs commit-only-derived SDM payload for each victim block.
+	var divergentBlocks []uint64
+	var viz strings.Builder
+	for _, bn := range victimBlocks {
+		replay, err := sdm.ReplayBlockWithSDM(t.Ctx(), rpc, bn, true)
+		t.Require().NoError(err, "debug_replaySDMBlock(%d)", bn)
+		if !replay.PostExecTxPresent {
+			// No SDM post-exec tx in this block (no committed warm re-touch landed here); skip.
+			continue
+		}
+
+		producer := entryMap(replay.EmbeddedPayload)
+		derived := entryMap(&replay.SynthesizedPayload)
+		if payloadsEqual(producer, derived) {
+			continue
+		}
+		divergentBlocks = append(divergentBlocks, bn)
+		writeBlockViz(&viz, bn, replay, producer, derived)
+	}
+
+	t.Logger().Info("SDM phantom-warming scan complete",
+		"victim_blocks", len(victimBlocks),
+		"divergent_blocks", len(divergentBlocks))
+
+	t.Require().Empty(divergentBlocks,
+		"producer-baked SDM payload diverges from commit-only derivation in %d block(s) — "+
+			"op-rbuilder credited phantom warming refunds from a declined (uncommitted) candidate "+
+			"(ethereum-optimism/optimism#21354):\n%s", len(divergentBlocks), viz.String())
+}
+
+// entryMap indexes an SDM payload's refund entries by tx index. A nil payload yields an empty map.
+func entryMap(p *sdm.PostExecPayload) map[uint64]uint64 {
+	out := make(map[uint64]uint64)
+	if p == nil {
+		return out
+	}
+	for _, e := range p.GasRefundEntries {
+		out[e.Index] = e.GasRefund
+	}
+	return out
+}
+
+func payloadsEqual(a, b map[uint64]uint64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for idx, v := range a {
+		if b[idx] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// writeBlockViz renders a per-tx table contrasting the producer-baked refund against the
+// commit-only-derived refund, flagging phantom entries (present in the producer payload, absent or
+// smaller in derivation).
+func writeBlockViz(w *strings.Builder, bn uint64, replay *sdm.ReplaySDMBlock, producer, derived map[uint64]uint64) {
+	fmt.Fprintf(w, "block %d (hash %s):\n", bn, replay.BlockHash)
+	fmt.Fprintf(w, "  embedded(producer) entries=%d  synthesized(derivation) entries=%d  mismatches=%d\n",
+		len(producer), len(derived), len(replay.Mismatches))
+	fmt.Fprintf(w, "  %-9s %-18s %-18s %s\n", "tx_index", "producer_refund", "derived_refund", "")
+	idxs := unionKeys(producer, derived)
+	for _, idx := range idxs {
+		p, pOK := producer[idx]
+		d, dOK := derived[idx]
+		flag := ""
+		if pOK && (!dOK || d < p) {
+			flag = "<- phantom"
+		}
+		fmt.Fprintf(w, "  %-9d %-18d %-18d %s\n", idx, p, d, flag)
+	}
+}
+
+func unionKeys(a, b map[uint64]uint64) []uint64 {
+	set := make(map[uint64]struct{})
+	for k := range a {
+		set[k] = struct{}{}
+	}
+	for k := range b {
+		set[k] = struct{}{}
+	}
+	out := make([]uint64, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/op-acceptance-tests/tests/flashblocks/flashblocks_sdm_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_sdm_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/pkg/sdm"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -43,13 +42,6 @@ func TestFlashblocksSDMMaterializesPostExecBlock(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sysgo.SkipOnKonaNode(t, "flashblocks acceptance preset requires user RPC")
 	sysgo.SkipOnOpGeth(t, "SDM flashblocks require op-reth post-exec support")
-
-	// op-rbuilder mishandles Osaka SDM post-exec accumulation: with Osaka active it includes
-	// more txs' gas refunds in the post-exec payload than op-node derives, so the builder and
-	// derivation payloads diverge. Skipped while #21337 activates Osaka at Karst; SDM rides
-	// Interop (Lagoon), which isn't activated yet, so this is not user-facing. Re-enable once
-	// op-rbuilder is fixed: ethereum-optimism/optimism#21354.
-	t.Skip("op-rbuilder Osaka SDM post-exec divergence — re-enable after ethereum-optimism/optimism#21354")
 
 	// SDM rides Interop: activating Interop at genesis turns SDM on for op-reth execution
 	// and the op-rbuilder payload builder consistently with op-node derivation. The preset
@@ -120,66 +112,58 @@ func TestFlashblocksSDMMaterializesPostExecBlock(gt *testing.T) {
 		}
 	}()
 
-	observedByBlock := make(map[uint64]observedSdmFlashblock)
+	// observedByHash records every streamed SDM post_exec flashblock, keyed by the materialized
+	// view hash op-rbuilder reports in diff.block_hash. Flashblocks carry no is_final flag, so
+	// rather than guess which is final we match the sealed canonical block by hash — an identity
+	// match, immune to stream timing.
+	observedByHash := make(map[common.Hash]observedSdmFlashblock)
+	// observedBlocks records which block numbers produced at least one post_exec flashblock.
+	observedBlocks := make(map[uint64]bool)
 	includedByBlock := make(map[uint64][]flashblocksIncludedTx)
-	var targetBlockNum uint64
-	// candidate is a block that satisfies the "2+ workload receipts AND an observed
-	// post_exec_tx flashblock" criteria. We don't commit it as targetBlockNum until we
-	// see a flashblock for a later block, which is op-rbuilder's de-facto seal signal —
-	// flashblock payloads carry no explicit "is_final" flag, and post_exec_tx accumulates
-	// entries with every new flashblock for the same block. Committing the candidate
-	// earlier risks comparing the final materialized block against an in-progress
-	// flashblock snapshot.
-	var candidate uint64
-	var postReceiptTimer *time.Timer
-	var postReceiptDeadline <-chan time.Time
-	defer func() {
-		if postReceiptTimer != nil {
-			postReceiptTimer.Stop()
-		}
-	}()
 
-	tryMarkCandidate := func(blockNum uint64) {
-		if candidate != 0 {
+	recordFlashblock := func(fb *sources.Flashblock) {
+		if fb.Diff.PostExecTx == nil {
 			return
 		}
-		if len(includedByBlock[blockNum]) < 2 {
-			return
+		t.Require().False(flashblockTransactionsContainPostExec(fb),
+			"SDM post-exec tx must be carried in diff.post_exec_tx, not diff.transactions")
+		payload, raw := decodeFlashblockPostExecTx(t, fb)
+		hash := common.HexToHash(fb.Diff.BlockHash)
+		observedByHash[hash] = observedSdmFlashblock{
+			index:      uint64(fb.Index),
+			postExecTx: raw,
+			payload:    payload,
+			blockHash:  hash,
 		}
-		if _, ok := observedByBlock[blockNum]; !ok {
-			return
-		}
-		candidate = blockNum
+		observedBlocks[uint64(fb.Metadata.BlockNumber)] = true
 	}
 
+	// pickTarget returns the lowest block number that carries 2+ workload receipts and at
+	// least one observed SDM post_exec flashblock, or 0 if none qualifies yet.
+	pickTarget := func() uint64 {
+		var best uint64
+		for blockNum, txs := range includedByBlock {
+			if len(txs) < 2 || !observedBlocks[blockNum] {
+				continue
+			}
+			if best == 0 || blockNum < best {
+				best = blockNum
+			}
+		}
+		return best
+	}
+
+	// Phase 1: discover a target block — one with enough workload txs and an SDM post_exec.
+	var targetBlockNum uint64
 	for targetBlockNum == 0 {
 		select {
 		case fb, ok := <-fbClient.Next():
 			t.Require().True(ok, "flashblock client closed before observing SDM post_exec_tx")
 			t.Require().NotNil(fb)
-			blockNum := uint64(fb.Metadata.BlockNumber)
-			if candidate != 0 && blockNum > candidate {
-				targetBlockNum = candidate
-				continue
-			}
-			if fb.Diff.PostExecTx == nil {
-				continue
-			}
-			t.Require().False(flashblockTransactionsContainPostExec(fb),
-				"SDM post-exec tx must be carried in diff.post_exec_tx, not diff.transactions")
-			payload, raw := decodeFlashblockPostExecTx(t, fb)
-			observedByBlock[blockNum] = observedSdmFlashblock{
-				index:      uint64(fb.Index),
-				postExecTx: raw,
-				payload:    payload,
-				blockHash:  common.HexToHash(fb.Diff.BlockHash),
-			}
-			tryMarkCandidate(blockNum)
+			recordFlashblock(fb)
 		case result, ok := <-receiptCh:
 			if !ok {
 				receiptCh = nil
-				postReceiptTimer = time.NewTimer(15 * time.Second)
-				postReceiptDeadline = postReceiptTimer.C
 				continue
 			}
 			t.Require().NoError(result.err, "workload tx %d failed before inclusion", result.idx)
@@ -190,30 +174,54 @@ func TestFlashblocksSDMMaterializesPostExecBlock(gt *testing.T) {
 				receipt:  result.receipt,
 				blockNum: blockNum,
 			})
-			tryMarkCandidate(blockNum)
-		case <-postReceiptDeadline:
-			if candidate != 0 {
-				targetBlockNum = candidate
-				continue
-			}
-			t.Require().Fail("post-receipt wait expired", "all workload receipts arrived but no matching SDM flashblock post_exec_tx was observed")
 		case <-t.Ctx().Done():
 			t.Require().NoError(t.Ctx().Err(), "never found a multi-tx workload block with SDM flashblock post_exec_tx")
 		}
+		targetBlockNum = pickTarget()
 	}
 
-	observed := observedByBlock[targetBlockNum]
 	t.Require().NotEmpty(includedByBlock[targetBlockNum], "target block must include workload txs")
 
+	// The target block already carries workload receipts, so it is sealed: read its canonical form.
 	block := getFlashblocksBlockWithTxs(t, sys.L2EL, targetBlockNum)
 	t.Require().NotEmpty(block.Transactions, "final materialized block must have transactions")
 
-	// Pin the canonical block to the rollup-boost materialization path: its hash must equal the
-	// builder's diff.block_hash. A plain "block has a trailing PostExec tx" check would also pass
-	// under the EL fallback (the sequencer EL runs SDM too), so it cannot distinguish a dropped
-	// post_exec_tx during materialization from the real builder payload.
-	t.Require().Equal(observed.blockHash, block.Hash,
-		"canonical block must be the rollup-boost-materialized flashblock view (diff.block_hash), not an EL fallback block")
+	// Phase 2: identity match. Find the streamed flashblock whose materialized view hash
+	// (diff.block_hash) equals the sealed canonical block hash and compare that snapshot — no
+	// guessing which flashblock was final. A matching hash also pins the block to the rollup-boost
+	// materialization path: a plain "has a trailing PostExec tx" check would also pass under the EL
+	// fallback (the sequencer EL runs SDM), so it can't tell a dropped post_exec_tx from the real
+	// builder payload.
+	//
+	// Keep draining until the match arrives. Once op-rbuilder advances past the target block,
+	// in-order delivery guarantees all its flashblocks were already delivered, so a continued miss
+	// is a genuine divergence (EL fallback, or builder stream != seal), not a capture race.
+	var observed observedSdmFlashblock
+	for {
+		if snap, ok := observedByHash[block.Hash]; ok {
+			observed = snap
+			break
+		}
+		select {
+		case fb, ok := <-fbClient.Next():
+			t.Require().True(ok,
+				"flashblock stream closed before the flashblock matching canonical block %d (hash %s) arrived",
+				targetBlockNum, block.Hash)
+			t.Require().NotNil(fb)
+			advanced := uint64(fb.Metadata.BlockNumber) > targetBlockNum
+			recordFlashblock(fb)
+			if _, ok := observedByHash[block.Hash]; !ok {
+				t.Require().False(advanced,
+					"canonical block %d (hash %s) matched no streamed op-rbuilder flashblock — "+
+						"served from EL fallback or builder stream diverged from seal",
+					targetBlockNum, block.Hash)
+			}
+		case <-t.Ctx().Done():
+			t.Require().NoError(t.Ctx().Err(),
+				"timed out waiting for op-rbuilder flashblock matching canonical block %d (hash %s)",
+				targetBlockNum, block.Hash)
+		}
+	}
 
 	postExecTx, postExecPos := sdm.FindPostExecTransaction(block)
 	t.Require().NotNil(postExecTx, "final materialized block must contain one PostExec tx")
@@ -227,7 +235,7 @@ func TestFlashblocksSDMMaterializesPostExecBlock(gt *testing.T) {
 	t.Require().NotEmpty(payload.GasRefundEntries, "final payload must contain SDM refund entries")
 	t.Require().Equal(observed.payload, payload, "observed flashblock payload must match final payload")
 	t.Require().Equal(observed.postExecTx[1:], []byte(postExecTx.Input),
-		"final PostExec tx input must match latest observed flashblock post_exec_tx")
+		"final PostExec tx input must match the hash-matched flashblock post_exec_tx")
 
 	validation, err := sdm.ValidatePostExecBlock(
 		t.Ctx(),

--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -8,8 +8,8 @@ use alloy_evm::{
     Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, RecoveredTx,
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory,
-        BlockValidationError, ExecutableTx, GasOutput, StateDB, SystemCaller, TxResult,
-        state_changes::post_block_balance_increments,
+        BlockValidationError, CommitChanges, ExecutableTx, GasOutput, StateDB, SystemCaller,
+        TxResult, state_changes::post_block_balance_increments,
     },
     eth::{EthTxResult, receipt_builder::ReceiptBuilderCtx},
 };
@@ -803,6 +803,35 @@ where
         .map_err(BlockExecutionError::other)?;
 
         Ok(())
+    }
+
+    fn execute_transaction_with_commit_condition(
+        &mut self,
+        tx: impl ExecutableTx<Self>,
+        f: impl FnOnce(&Self::Result) -> CommitChanges,
+    ) -> Result<Option<GasOutput>, BlockExecutionError> {
+        // SDM block-warming refunds are recorded during EVM execution (before the commit
+        // decision) and aren't journaled, so discarding a tx's changes doesn't roll them back. A
+        // caller that executes a candidate then declines it (`CommitChanges::No`: over a builder
+        // gas/DA/address limit, or reverted-and-excluded) would leave behind "phantom" warming: a
+        // later committed tx claims a refund attributed to a tx that never entered the block.
+        // Commit-only paths (block import, `debug_replaySDMBlock` derivation) never see that
+        // warmth, so the producer's payload would diverge from derivation.
+        //
+        // Snapshot warming before execution and restore it when the tx isn't committed. Only
+        // `Producing` mode tracks warming, so we clone the maps solely on that path.
+        let warming_snapshot = self.post_exec.is_producing().then(|| self.warming_state());
+
+        let output = self.execute_transaction_without_commit(tx)?;
+
+        if !f(&output).should_commit() {
+            if let Some(snapshot) = warming_snapshot {
+                self.seed_warming_state(snapshot);
+            }
+            return Ok(None);
+        }
+
+        Ok(Some(self.commit_transaction(output)))
     }
 
     fn execute_transaction_without_commit(

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -728,4 +728,43 @@ mod sdm {
             "unexpected post-exec tx at index 0: SDM not active for this block",
         );
     }
+
+    // A candidate that is executed but declined (`CommitChanges::No`) must not leave behind
+    // block-scoped warming: without rollback, an uncommitted candidate would grant a later
+    // committed tx a phantom refund, diverging the producer's payload from derivation
+    // (ethereum-optimism/optimism#21354).
+    #[test]
+    fn test_declined_candidate_does_not_warm_later_committed_tx() {
+        let target = Address::from([0x11; 20]);
+
+        let mut fixture = SDMExecutorFixture::default();
+        let mut producer = fixture.executor_with_post_exec_mode(PostExecMode::Produce);
+
+        // Execute a candidate that warms `target` but decline to commit it, as the payload builder
+        // does when a candidate exceeds a limit or is reverted-and-excluded.
+        let outcome = producer
+            .execute_transaction_with_commit_condition(&legacy_tx(0, target), |_| CommitChanges::No)
+            .expect("declined candidate still executes");
+        assert!(outcome.is_none(), "candidate must not be committed");
+        assert!(
+            producer.post_exec_entries().is_empty(),
+            "a declined candidate emits no SDM refund entries",
+        );
+
+        // The first committed tx touching `target` must be its first toucher: the declined
+        // candidate's warming was rolled back, so no refund.
+        producer.execute_transaction(&legacy_tx(0, target)).expect("first committed tx executes");
+        assert!(
+            producer.post_exec_entries().is_empty(),
+            "an uncommitted candidate must not warm a later committed tx (no phantom SDM refund)",
+        );
+
+        // Sanity: committed warmth still accumulates — a second committed tx re-warms the
+        // now-committed address and earns a refund.
+        producer.execute_transaction(&legacy_tx(1, target)).expect("second committed tx executes");
+        let entries = producer.post_exec_entries();
+        assert_eq!(entries.len(), 1, "second committed tx re-warms the block-warmed address");
+        assert_eq!(entries[0].index, 1, "refund is attributed to the second committed tx");
+        assert!(entries[0].gas_refund > 0);
+    }
 }

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
@@ -549,6 +549,9 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
             let mut tx_succeeded = false;
             let mut gas_limit_exceeded = false;
             let mut address_limit_exceeded = false;
+            // Declining a candidate (CommitChanges::No, below) must not leak SDM block-warming into
+            // a later committed tx; that rollback lives in alloy-op-evm's
+            // execute_transaction_with_commit_condition override (ethereum-optimism/optimism#21354).
             let committed = match builder.execute_transaction_with_commit_condition(
                 tx.clone(),
                 |result| {


### PR DESCRIPTION
Fixes: https://github.com/ethereum-optimism/optimism/issues/21354
Test disabled at: https://github.com/ethereum-optimism/optimism/pull/21337

## Summary

`TestFlashblocksSDMMaterializesPostExecBlock` was skipped in #21337 after it failed under Osaka (Karst) with a 9-vs-15 post-exec gas-refund **entry-count** mismatch. Investigating that failure split it into two distinct findings:

1. **The 9-vs-15 CI failure itself was a test-harness flake, not an op-rbuilder bug** — op-rbuilder's block was correct.
2. **A separate, genuine producer↔derivation divergence does exist** — phantom SDM block-warming from declined builder candidates — which the flaky test was *not* actually catching.

This PR fixes the real divergence (alloy-op-evm), de-flakes and re-enables the test, and adds a dedicated test that pins the real divergence end-to-end.

## Root cause

### 1. The reported 9-vs-15 mismatch was a test capture-race, not a divergence

Issue #21354 framed the failure as op-rbuilder over-accumulating refunds and diverging from op-node's derivation under Osaka. That framing doesn't hold up against the assertion that actually failed:

- The two sides compared at the failing line are **not** "op-node vs op-rbuilder". They are op-rbuilder's own **streamed flashblock snapshot** (`observed.payload`, the 9-entry side) vs the **sealed canonical block** read back from the sequencer EL (the 15-entry side). op-node's derivation (`ValidatePostExecBlock`) runs *after* that line and never executed.
- The per-tx refund was identical (`0xd4e4`) on every entry on both sides — only the **count** differed. So it was never a refund-math/accumulation bug; it was "how many txs the snapshot had seen so far".
- Post-exec entries accumulate monotonically across a block's flashblocks, and flashblocks carry no `is_final` flag. The test guessed which flashblock was "final". Under Osaka, calldata repricing packs more txs per block → more flashblocks per block → a wider window in which the test latches `observed` on a stale, in-progress flashblock (9) and compares it against the fully-sealed block (15). Fast hosts win the race (green 19/19 locally); loaded CI loses it.

So op-rbuilder produced the correct block; Osaka only widened the timing window. **This part is fixed in the test, not in op-rbuilder** — by matching the streamed flashblock to the sealed block by canonical hash instead of guessing the final one.

### 2. The real divergence: phantom SDM warming from declined candidates

While building coverage that would *actually* exercise producer-vs-derivation, a real divergence surfaced. SDM block-warming refunds are recorded by an inspector during EVM execution — *before* the builder's commit decision — and are **not** journaled, so discarding a tx's changes does not roll them back. The op-rbuilder payload builder (standard and flashblocks) selects txs via `execute_transaction_with_commit_condition` and **declines** candidates (`CommitChanges::No`) that exceed a builder gas/DA/address limit or are reverted-and-excluded. A declined candidate still warmed the maps, so a later *committed* tx could claim a block-warming refund attributed to a tx that never entered the block.

Commit-only paths — block import and `debug_replaySDMBlock` derivation — only ever commit txs, so they never observe that phantom warmth and derive a strictly smaller refund set. The producer's payload then genuinely diverges from derivation. This is independent of Osaka and is the bug worth fixing in the builder/EVM.

## The fix

- **`rust/alloy-op-evm/src/block/mod.rs`** — override `execute_transaction_with_commit_condition` on `OpBlockExecutor`: snapshot the block-scoped warming state before execution and restore it whenever the tx is not committed. The snapshot (a clone of the warming maps) is taken only in `Producing` mode, so there's no clone cost when SDM is off or verifying.
- **`rust/op-rbuilder/.../builders/context.rs`** — comment at the decline site documenting that `CommitChanges::No` relies on the alloy-op-evm rollback.

## Tests

- **`flashblocks_sdm_phantom_test.go`** (new) — `TestFlashblocksSDMPhantomWarmingDivergence` reproduces finding #2: a persistently-declined poisoner (over `--builder.max_gas_per_txn`) alongside committed victims, comparing each victim block's producer-baked SDM payload against the commit-only derivation. FAILS on develop (divergent_blocks=6, victim refund 18400 vs derived 0); PASSES with the fix (divergent_blocks=0).
- **`alloy-op-evm/src/block/tests.rs`** — unit test for the declined-candidate warming rollback in isolation.
- **`flashblocks_sdm_test.go`** — re-enables `TestFlashblocksSDMMaterializesPostExecBlock` (removes the `t.Skip`) and fixes finding #1: replaces the flaky "final flashblock" heuristic (and its 15s deadline backstop) with an identity match by canonical block hash (`observedByHash`). The sealed block is looked up by hash among streamed flashblocks; a miss after op-rbuilder has advanced past the block fails loudly (EL fallback / builder stream ≠ seal) rather than racing.

## Notes

SDM rides Interop (Lagoon), which is not activated on any chain in the near term, so neither the flake nor the divergence was user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
