### PR TITLE
fix ci manual dispatch continuation params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,9 @@ jobs:
       - run:
           name: Merge continuation configs
           command: .circleci/scripts/merge-configs.sh
+      - run:
+          name: Test continuation parameter compatibility
+          command: .circleci/scripts/test-continuation-params.sh
       # Calls the CircleCI continuation API with the merged config + JSON params.
       # This triggers the actual CI pipeline where only workflows with their
       # c-run_* flag set to true will execute.

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -20,6 +20,72 @@ parameters:
   c-publish_contract_artifacts_ref:
     type: string
     default: ""
+  # CircleCI forwards user-supplied setup params into continuation validation.
+  # These aliases are transformed into c-* params by config.yml and are not
+  # referenced by jobs in the continuation config.
+  default_docker_image:
+    type: string
+    default: cimg/base:2026.03
+  rust_base_image:
+    type: string
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:d79c625a042269c64b2444ef1edf9bb4a399d1c892caee57f9021be067da5617
+  base_image:
+    type: string
+    default: default
+  main_dispatch:
+    type: boolean
+    default: true
+  fault_proofs_dispatch:
+    type: boolean
+    default: false
+  reproducibility_dispatch:
+    type: boolean
+    default: false
+  kontrol_dispatch:
+    type: boolean
+    default: false
+  cannon_full_test_dispatch:
+    type: boolean
+    default: false
+  sdk_dispatch:
+    type: boolean
+    default: false
+  publish_contract_artifacts_dispatch:
+    type: boolean
+    default: false
+  publish_contract_artifacts_ref:
+    type: string
+    default: ""
+  stale_check_dispatch:
+    type: boolean
+    default: false
+  contracts_coverage_dispatch:
+    type: boolean
+    default: false
+  heavy_fuzz_dispatch:
+    type: boolean
+    default: false
+  rust_ci_dispatch:
+    type: boolean
+    default: false
+  rust_e2e_dispatch:
+    type: boolean
+    default: false
+  l2_fork_test_dispatch:
+    type: boolean
+    default: false
+  github-event-type:
+    type: string
+    default: "__not_set__"
+  github-event-action:
+    type: string
+    default: "__not_set__"
+  github-event-base64:
+    type: string
+    default: "__not_set__"
+  go-cache-version:
+    type: string
+    default: "v0.0"
   # Workflow activation flags (set by the decision tree in config.yml)
   c-run_main:
     type: boolean

--- a/.circleci/scripts/test-continuation-params.sh
+++ b/.circleci/scripts/test-continuation-params.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Ensures UI/API supplied setup params are accepted by the continuation config.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SETUP_CONFIG="${REPO_ROOT}/.circleci/config.yml"
+MERGED_CONFIG="${1:-/tmp/merged-config.yml}"
+
+if [[ ! -f "${MERGED_CONFIG}" ]]; then
+  echo "ERROR: merged continuation config not found: ${MERGED_CONFIG}" >&2
+  echo "Run .circleci/scripts/merge-configs.sh first." >&2
+  exit 1
+fi
+
+missing=$(
+  comm -23 \
+    <(yq -r '.parameters | keys | .[]' "${SETUP_CONFIG}" | sort) \
+    <(yq -r '.parameters | keys | .[]' "${MERGED_CONFIG}" | sort)
+)
+
+if [[ -n "${missing}" ]]; then
+  echo "ERROR: setup pipeline params missing from continuation config:" >&2
+  while IFS= read -r param; do
+    echo "  - ${param}" >&2
+  done <<< "${missing}"
+  echo >&2
+  echo "CircleCI forwards explicitly supplied UI/API parameters into continuation validation." >&2
+  echo "Declare these names as unused passthrough params in the continuation config." >&2
+  exit 1
+fi
+
+mismatched=$(
+  jq -r --argjson continuation "$(yq -o=json '.parameters' "${MERGED_CONFIG}")" '
+    to_entries[]
+    | select($continuation[.key] != .value)
+    | "  - \(.key)\n    setup: \(.value | tojson)\n    continuation: \($continuation[.key] | tojson)"
+  ' < <(yq -o=json '.parameters' "${SETUP_CONFIG}")
+)
+
+if [[ -n "${mismatched}" ]]; then
+  echo "ERROR: setup pipeline params do not match continuation passthrough declarations:" >&2
+  echo "${mismatched}" >&2
+  echo >&2
+  echo "Keep passthrough defaults and types identical to the setup config." >&2
+  exit 1
+fi
+
+echo "All setup pipeline params are declared in the continuation config."


### PR DESCRIPTION
Fix manual CircleCI UI/API dispatches for the dynamic continuation pipeline.

CircleCI validates explicitly supplied setup parameters against the continuation config too. The continuation config consumes transformed `c-*` parameters, but it still needs unused passthrough declarations for original UI/API parameter names like `fault_proofs_dispatch`; otherwise manual runs fail with `Unexpected argument(s)` before workflows start.

This adds those passthrough declarations and a setup-time check that compares setup parameters against the merged continuation config so future refactors fail before calling the continuation API.

Validated with:
- `mise exec -- bash .circleci/scripts/test-decision-tree.sh`
- `mise exec -- bash -lc '.circleci/scripts/merge-configs.sh && .circleci/scripts/test-continuation-params.sh'`\n- `mise exec -- shellcheck .circleci/scripts/test-continuation-params.sh`\n- `git diff --check`