### PR TITLE
op-conductor: raise RPC HTTP body limit to 15MB

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -274,6 +274,9 @@ func (oc *OpConductor) initRPCServer(ctx context.Context) error {
 		oc.version,
 		oprpc.WithLogger(oc.log),
 		oprpc.WithRPCRecorder(oc.metrics.NewRecorder("main")),
+		// op-node commits unsafe payloads via conductor_commitUnsafePayload; raise the
+		// HTTP body limit above the go-ethereum default to accommodate large payloads.
+		oprpc.WithHTTPBodyLimit(15*1024*1024),
 	)
 	api := conductorrpc.NewAPIBackend(oc.log, oc)
 	server.AddAPI(rpc.API{

--- a/op-service/rpc/handler.go
+++ b/op-service/rpc/handler.go
@@ -40,6 +40,9 @@ type Handler struct {
 	jwtSecret      []byte
 	wsEnabled      bool
 	httpRecorder   opmetrics.HTTPRecorder
+	// httpBodyLimit overrides the max HTTP request body size for RPC servers
+	// created by this handler. If 0, the go-ethereum default is used.
+	httpBodyLimit int
 
 	log         log.Logger
 	middlewares []Middleware
@@ -160,6 +163,9 @@ func (b *Handler) AddRPCWithAuthentication(route string, isAuthenticated *bool) 
 
 	srv := rpc.NewServer()
 	srv.SetRecorder(b.recorder)
+	if b.httpBodyLimit > 0 {
+		srv.SetHTTPBodyLimit(b.httpBodyLimit)
+	}
 
 	if err := srv.RegisterName("health", &healthzAPI{
 		appVersion: b.appVersion,

--- a/op-service/rpc/handler_options.go
+++ b/op-service/rpc/handler_options.go
@@ -47,6 +47,15 @@ func WithJWTSecret(secret []byte) Option {
 	}
 }
 
+// WithHTTPBodyLimit overrides the maximum HTTP request body size (in bytes)
+// accepted by the RPC servers created by this handler. If not set, the
+// go-ethereum default is used.
+func WithHTTPBodyLimit(limit int) Option {
+	return func(b *Handler) {
+		b.httpBodyLimit = limit
+	}
+}
+
 func WithHTTPRecorder(recorder opmetrics.HTTPRecorder) Option {
 	return func(b *Handler) {
 		b.httpRecorder = recorder


### PR DESCRIPTION
## Description

op-conductor's RPC server inherited go-ethereum's default HTTP request body limit. This caps the size of payloads that op-node commits to the conductor via `conductor_commitUnsafePayload` (and any other HTTP RPC request).

This PR raises op-conductor's limit to 15MB.

## Changes

- **`op-service/rpc`**: Add a `WithHTTPBodyLimit(limit int)` option to the RPC `Handler`. When set (`> 0`), it calls `srv.SetHTTPBodyLimit(...)` on the underlying go-ethereum RPC server. When unset, the go-ethereum default is used, so **all other op-service RPC consumers are unaffected**.
- **`op-conductor`**: Pass `oprpc.WithHTTPBodyLimit(15*1024*1024)` in `initRPCServer`.

## Notes

- The limit is currently hardcoded at 15MiB. If a configurable CLI flag / env var is preferred, that can be added as a follow-up.
- Comments intentionally avoid naming the specific upstream default value so they don't go stale if go-ethereum changes it.

## Tests

- `go build ./op-service/rpc/... ./op-conductor/...` passes.
- `go test ./op-service/rpc/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)