### PR TITLE
feat(op-reth): build OP Mainnet/Sepolia chainspecs from the superchain registry

### DIFF
--- a/rust/op-reth/crates/chainspec/src/op.rs
+++ b/rust/op-reth/crates/chainspec/src/op.rs
@@ -1,15 +1,74 @@
 //! Chain specification for the Optimism Mainnet network.
 
-use crate::{LazyLock, OpChainSpec, make_op_genesis_header};
-use alloc::{sync::Arc, vec};
+use crate::{LazyLock, OpChainSpec};
+use alloc::sync::Arc;
+use alloy_primitives::{B256, b256};
+
+#[cfg(not(feature = "superchain-configs"))]
+use crate::make_op_genesis_header;
+#[cfg(not(feature = "superchain-configs"))]
+use alloc::vec;
+#[cfg(not(feature = "superchain-configs"))]
 use alloy_chains::Chain;
-use alloy_primitives::{U256, b256};
+#[cfg(not(feature = "superchain-configs"))]
+use alloy_primitives::U256;
+#[cfg(not(feature = "superchain-configs"))]
 use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
+#[cfg(not(feature = "superchain-configs"))]
 use reth_ethereum_forks::EthereumHardfork;
+#[cfg(not(feature = "superchain-configs"))]
 use reth_optimism_forks::{OP_MAINNET_HARDFORKS, OpHardfork};
+#[cfg(not(feature = "superchain-configs"))]
 use reth_primitives_traits::SealedHeader;
 
-/// The Optimism Mainnet spec
+/// The canonical OP Mainnet (Bedrock) genesis block hash.
+pub(crate) const OP_MAINNET_GENESIS_HASH: B256 =
+    b256!("0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b");
+
+/// OP Mainnet genesis state root.
+///
+/// The OP Mainnet genesis `alloc` is empty: the state of the first Bedrock block was imported from a
+/// trusted source rather than expressed as an allocation, so the state root cannot be recomputed
+/// from `alloc`. This is that precomputed root (op-geth carries it as the genesis `stateHash`; see
+/// `core/superchain.go`).
+#[cfg(feature = "superchain-configs")]
+pub(crate) const OP_MAINNET_GENESIS_STATE_ROOT: B256 =
+    b256!("0xeddb4c1786789419153a27c4c80ff44a2226b6eda04f7e22ce5bae892ea568eb");
+
+/// The Optimism Mainnet spec, built from the embedded superchain registry.
+///
+/// Forks (including their activation timestamps) come straight from the registry, so a new hardfork
+/// only needs a registry bump rather than a hand-edited fork list. The Bedrock genesis state root is
+/// restored via [`OP_MAINNET_GENESIS_STATE_ROOT`] and verified against [`OP_MAINNET_GENESIS_HASH`].
+#[cfg(feature = "superchain-configs")]
+pub static OP_MAINNET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
+    use crate::make_op_genesis_header;
+    use reth_primitives_traits::SealedHeader;
+
+    let genesis = crate::superchain::read_superchain_genesis("op", "mainnet")
+        .expect("embedded superchain registry must contain op-mainnet");
+    let mut spec = OpChainSpec::from(genesis.clone());
+
+    // `from_genesis` derives the state root from `alloc`, which is empty for OP Mainnet. Restore the
+    // imported Bedrock state root and re-seal the genesis header (mirrors op-geth's `stateHash`
+    // handling), then verify we reproduced the canonical genesis hash.
+    let mut header = make_op_genesis_header(&genesis, &spec.inner.hardforks);
+    header.state_root = OP_MAINNET_GENESIS_STATE_ROOT;
+    spec.inner.genesis_header = SealedHeader::seal_slow(header);
+    assert_eq!(
+        spec.inner.genesis_header.hash(),
+        OP_MAINNET_GENESIS_HASH,
+        "op-mainnet genesis derived from the superchain registry does not match the canonical hash",
+    );
+
+    Arc::new(spec)
+});
+
+/// The Optimism Mainnet spec.
+///
+/// Fallback used when the `superchain-configs` feature is disabled (the registry archive is then not
+/// compiled in). Hand-coded fork schedule with the genesis hash pinned explicitly.
+#[cfg(not(feature = "superchain-configs"))]
 pub static OP_MAINNET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
     // genesis contains empty alloc field because state at first bedrock block is imported
     // manually from trusted source
@@ -21,7 +80,7 @@ pub static OP_MAINNET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
             chain: Chain::optimism_mainnet(),
             genesis_header: SealedHeader::new(
                 make_op_genesis_header(&genesis, &hardforks),
-                b256!("0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"),
+                OP_MAINNET_GENESIS_HASH,
             ),
             genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),

--- a/rust/op-reth/crates/chainspec/src/op_sepolia.rs
+++ b/rust/op-reth/crates/chainspec/src/op_sepolia.rs
@@ -1,15 +1,56 @@
 //! Chain specification for the Optimism Sepolia testnet network.
 
-use crate::{LazyLock, OpChainSpec, make_op_genesis_header};
-use alloc::{sync::Arc, vec};
+use crate::{LazyLock, OpChainSpec};
+use alloc::sync::Arc;
+use alloy_primitives::{B256, b256};
+
+#[cfg(not(feature = "superchain-configs"))]
+use crate::make_op_genesis_header;
+#[cfg(not(feature = "superchain-configs"))]
+use alloc::vec;
+#[cfg(not(feature = "superchain-configs"))]
 use alloy_chains::{Chain, NamedChain};
-use alloy_primitives::{U256, b256};
+#[cfg(not(feature = "superchain-configs"))]
+use alloy_primitives::U256;
+#[cfg(not(feature = "superchain-configs"))]
 use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
+#[cfg(not(feature = "superchain-configs"))]
 use reth_ethereum_forks::EthereumHardfork;
+#[cfg(not(feature = "superchain-configs"))]
 use reth_optimism_forks::{OP_SEPOLIA_HARDFORKS, OpHardfork};
+#[cfg(not(feature = "superchain-configs"))]
 use reth_primitives_traits::SealedHeader;
 
-/// The OP Sepolia spec
+/// The canonical OP Sepolia genesis block hash.
+pub(crate) const OP_SEPOLIA_GENESIS_HASH: B256 =
+    b256!("0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d");
+
+/// The OP Sepolia spec, built from the embedded superchain registry.
+///
+/// Forks (including their activation timestamps) come straight from the registry. Unlike OP Mainnet,
+/// the OP Sepolia genesis ships a full `alloc`, so `from_genesis` reproduces the genesis header
+/// directly; we still verify it against [`OP_SEPOLIA_GENESIS_HASH`].
+#[cfg(feature = "superchain-configs")]
+pub static OP_SEPOLIA: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
+    use reth_chainspec::EthChainSpec;
+
+    let spec = OpChainSpec::from(
+        crate::superchain::read_superchain_genesis("op", "sepolia")
+            .expect("embedded superchain registry must contain op-sepolia"),
+    );
+    assert_eq!(
+        spec.genesis_hash(),
+        OP_SEPOLIA_GENESIS_HASH,
+        "op-sepolia genesis derived from the superchain registry does not match the canonical hash",
+    );
+    Arc::new(spec)
+});
+
+/// The OP Sepolia spec.
+///
+/// Fallback used when the `superchain-configs` feature is disabled (the registry archive is then not
+/// compiled in). Hand-coded fork schedule with the genesis hash pinned explicitly.
+#[cfg(not(feature = "superchain-configs"))]
 pub static OP_SEPOLIA: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
     let genesis = serde_json::from_str(include_str!("../res/genesis/sepolia_op.json"))
         .expect("Can't deserialize OP Sepolia genesis json");
@@ -19,7 +60,7 @@ pub static OP_SEPOLIA: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
             chain: Chain::from_named(NamedChain::OptimismSepolia),
             genesis_header: SealedHeader::new(
                 make_op_genesis_header(&genesis, &hardforks),
-                b256!("0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"),
+                OP_SEPOLIA_GENESIS_HASH,
             ),
             genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),

--- a/rust/op-reth/crates/chainspec/src/superchain/configs.rs
+++ b/rust/op-reth/crates/chainspec/src/superchain/configs.rs
@@ -295,4 +295,70 @@ mod tests {
             }
         }
     }
+
+    /// The well-known OP chains resolved by the CLI (`--chain optimism` / `optimism-sepolia`) are
+    /// built from the embedded superchain registry: their genesis hashes are canonical and Karst
+    /// (=> the L1 Osaka feature set) activates at exactly the registry-scheduled timestamp. This is
+    /// the guarantee that a running op-reth node follows the SCR-scheduled fork.
+    #[test]
+    fn op_well_known_chains_follow_scr() {
+        use alloy_op_hardforks::{
+            OP_MAINNET_KARST_TIMESTAMP, OP_SEPOLIA_KARST_TIMESTAMP, OpHardforks,
+        };
+        use alloy_primitives::b256;
+        use reth_chainspec::{EthChainSpec, EthereumHardforks};
+        use reth_ethereum_forks::{EthereumHardfork, ForkCondition};
+
+        let cases = [
+            (
+                "optimism",
+                OP_MAINNET_KARST_TIMESTAMP,
+                b256!("0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"),
+            ),
+            (
+                "optimism-sepolia",
+                OP_SEPOLIA_KARST_TIMESTAMP,
+                b256!("0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"),
+            ),
+        ];
+        for (name, karst, genesis_hash) in cases {
+            let spec = generated_chain_value_parser(name).expect("known chain");
+            // Genesis identity is preserved when building from the registry.
+            assert_eq!(spec.genesis_hash(), genesis_hash, "{name}: genesis hash");
+            // Karst (and the L1 Osaka fork it implies) activates exactly at the SCR timestamp.
+            assert!(!spec.is_karst_active_at_timestamp(karst - 1), "{name}: karst active too early");
+            assert!(spec.is_karst_active_at_timestamp(karst), "{name}: karst inactive at SCR time");
+            assert_eq!(
+                spec.ethereum_fork_activation(EthereumHardfork::Osaka),
+                ForkCondition::Timestamp(karst),
+                "{name}: osaka not scheduled at karst time",
+            );
+        }
+    }
+
+    /// The registry → chainspec pipeline maps a chain's `karst_time` to both Karst and the implied
+    /// Osaka fork.
+    #[test]
+    fn scr_genesis_pipeline_schedules_karst_and_osaka() {
+        use crate::OpChainSpec;
+        use alloy_op_hardforks::OpHardforks;
+        use reth_chainspec::EthereumHardforks;
+        use reth_ethereum_forks::{EthereumHardfork, ForkCondition};
+
+        let genesis = read_superchain_genesis("op", "sepolia").unwrap();
+        // `to_genesis_chain_config` maps SCR `karst_time` -> `osaka_time`.
+        let karst = genesis.config.osaka_time.expect("karst_time maps to osaka_time");
+        let spec = OpChainSpec::from(genesis);
+
+        assert_eq!(
+            spec.op_fork_activation(OpHardfork::Karst),
+            ForkCondition::Timestamp(karst),
+        );
+        assert_eq!(
+            spec.ethereum_fork_activation(EthereumHardfork::Osaka),
+            ForkCondition::Timestamp(karst),
+        );
+        assert!(!spec.is_karst_active_at_timestamp(karst - 1));
+        assert!(spec.is_karst_active_at_timestamp(karst));
+    }
 }

--- a/rust/op-reth/crates/chainspec/src/superchain/mod.rs
+++ b/rust/op-reth/crates/chainspec/src/superchain/mod.rs
@@ -6,6 +6,9 @@ mod chain_specs;
 mod configs;
 
 pub use chain_specs::*;
+/// Re-exported so the well-known OP chain specs ([`crate::OP_MAINNET`], [`crate::OP_SEPOLIA`]) can be
+/// built from the embedded registry instead of a hand-coded fork list.
+pub(crate) use configs::read_superchain_genesis;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

The well-known OP chains (`--chain optimism` / `optimism-sepolia`) were built from hand-coded fork schedules (`OP_MAINNET_HARDFORKS` / `OP_SEPOLIA_HARDFORKS`) that **lagged the embedded superchain registry**. The registry already schedules **Karst** (and therefore the L1 **Osaka** feature set), but the hand-coded lists stopped at **Jovian** — so an op-reth node would *not* have activated Karst at the registry-scheduled time and would have diverged from the network at the fork boundary:

- op-sepolia Karst: **2026-06-17 16:00:01 UTC** (`1781712001`)
- op-mainnet Karst: **2026-07-08 16:00:01 UTC** (`1783526401`)

This builds the OP Mainnet/Sepolia specs from the **embedded registry** instead — the same `from_genesis` path the long-tail superchain chains already use — so fork activations track the registry and a new hardfork only needs a registry bump rather than a hand-edited fork list.

## OP Mainnet genesis (the tricky bit)

OP Mainnet's Bedrock genesis ships an **empty `alloc` + a precomputed state root**, which `from_genesis` cannot reconstruct (it derives the state root from `alloc`, getting the empty-trie root and the wrong genesis hash). We restore the state root explicitly and re-seal the genesis header, then **assert the canonical genesis hash** — mirroring op-geth's `stateHash` handling in `core/superchain.go`. OP Sepolia ships a full `alloc`, so it reconstructs directly; its genesis hash is verified the same way.

## Scope / caveats

- **Base is unchanged** — it stays on its hand-coded spec because base's genesis/config are not bundled in the embedded registry archive (`fetch_superchain_config.sh` skips op/base from the generated list, and base's genesis isn't shipped). Base therefore is *not* served from the registry; this is intentional for now.
- A `not(superchain-configs)` fallback keeps the hand-coded specs for builds compiled without the registry archive. The shipped `op-reth` binary always enables `superchain-configs`, so it uses the registry path.

## Testing

`reth-optimism-chainspec` suite passes in both feature configurations:

- `--features superchain-configs` (the binary's path): **39 passed**, incl. a new `op_well_known_chains_follow_scr` guard (canonical genesis hash + Karst/Osaka active at the registry timestamp for `optimism` and `optimism-sepolia`), `scr_genesis_pipeline_schedules_karst_and_osaka`, and the existing `op_*_forkids` / `test_hardfork_timestamps` tests.
- default features (fallback): **24 passed**.

> Note: a local downstream `cargo check -p reth-optimism-cli` could not complete in this environment (disk-quota limit while building `bindgen`); CI will validate the full build. The change is confined to the chainspec crate with no public-API changes (`OP_MAINNET`, `OP_SEPOLIA`, `generated_chain_value_parser` keep their signatures).

## Follow-ups

- Base still lags the registry for Karst. Serving base from the registry would require bundling its config/genesis into the archive (and `BASE_*_KARST_TIMESTAMP` constants if it stays hand-coded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
