### PR TITLE
fix(mise): resolve just via default registry, not github/ubi alias

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -67,7 +67,10 @@ binary_signer = "1.0.4"
 forge = "github:foundry-rs/foundry[bin=forge,version_prefix=v]"
 cast = "github:foundry-rs/foundry[bin=cast,version_prefix=v]"
 anvil = "github:foundry-rs/foundry[bin=anvil,version_prefix=v]"
-just = "github:casey/just"
+# just resolves via the default registry (aqua), which fetches a pinned version by
+# its exact tag. Do not alias it to github:/ubi: just's tags have no `v` prefix, so
+# once the pinned version ages out of the GitHub releases listing, ubi's fallback
+# direct-fetches a `v`-prefixed tag that doesn't exist and the build 404s.
 goreleaser-pro = "github:goreleaser/goreleaser-pro[bin=goreleaser,version_prefix=v]"
 gotestsum = "github:gotestyourself/gotestsum[version_prefix=v]"
 mockery = "github:vektra/mockery[version_prefix=v]"


### PR DESCRIPTION
The `develop-fault-proofs` `cannon-prestate` job is failing while building the reproducible kona prestate:

```
ubi 'ubi:casey/just@1.46.0': 404 Not Found ... releases/tags/v1.46.0
```

`cannon-repro.dockerfile` runs `mise install … just` inside the pinned `cannon-builder:v2.0.0` image, whose old mise maps `just = "github:casey/just"` to the deprecated **ubi** backend. just's release tags have no `v` prefix; ubi matches a pinned version against the GitHub releases *listing*, and once that version ages out of the listing (just `1.52.0` landed 2026-06-08) it falls back to direct-fetching a `v`-prefixed tag that doesn't exist → 404. The job kept passing on the cached Docker layer (`docker_layer_caching: true`) until that layer was evicted, surfacing the break.

Drop the alias so `just` resolves through the default registry (**aqua**), which fetches the exact pinned tag regardless of listing recency. The version pin (`1.46.0`) is unchanged; aqua is already proven in this image (`jq` resolves via it and installs fine in the same build).

No new `cannon-builder` image is needed — `mise.toml` is copied from the repo at build time, and editing it invalidates the cached `mise install` layer so the fix applies on the next run.
