### PR TITLE
refactor(sdm): gate SDM directly on Lagoon hardfork

### DIFF
--- a/op-node/rollup/toggles.go
+++ b/op-node/rollup/toggles.go
@@ -23,16 +23,15 @@ func (c *Config) IsL2CMActivationBlock(l2BlockTime uint64) bool {
 	return c.IsKarstActivationBlock(l2BlockTime)
 }
 
-// IsSDM gates Sequencer-Defined Metering: when false, span batches carrying PostExec
-// transactions are rejected during derivation. Gated directly on Lagoon (not the interop
-// toggle) so the two can't drift apart.
+// IsSDM gates Sequencer-Defined Metering: when false, batches carrying PostExec
+// transactions are rejected during derivation. Defers to the hardfork where SDM is activated.
 func (c *Config) IsSDM(time uint64) bool {
 	return c.IsLagoon(time)
 }
 
 // IsInterop returns true if the interoperability feature is active at or past the given timestamp.
-// The feature is currently gated on the Lagoon hard fork; this toggle exists so the feature can
-// be decoupled from the fork if needed.
+// The feature defers to the hardfork where interop is activated; this toggle exists so the feature
+// can be decoupled from the fork if needed.
 func (c *Config) IsInterop(timestamp uint64) bool {
 	return c.IsLagoon(timestamp)
 }

--- a/op-node/rollup/toggles.go
+++ b/op-node/rollup/toggles.go
@@ -23,10 +23,11 @@ func (c *Config) IsL2CMActivationBlock(l2BlockTime uint64) bool {
 	return c.IsKarstActivationBlock(l2BlockTime)
 }
 
-// IsSDM gates Sequencer-Defined Metering. When this returns false, span batches
-// carrying PostExec transactions are rejected during derivation.
+// IsSDM gates Sequencer-Defined Metering: when false, span batches carrying PostExec
+// transactions are rejected during derivation. Gated directly on Lagoon (not the interop
+// toggle) so the two can't drift apart.
 func (c *Config) IsSDM(time uint64) bool {
-	return c.IsInterop(time)
+	return c.IsLagoon(time)
 }
 
 // IsInterop returns true if the interoperability feature is active at or past the given timestamp.

--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -166,7 +166,7 @@ impl RollupConfig {
     /// ## Returns
     /// The active [`op_revm::OpSpecId`] for the executor.
     pub fn spec_id(&self, timestamp: u64) -> op_revm::OpSpecId {
-        if self.is_interop_active(timestamp) {
+        if self.is_lagoon_active(timestamp) {
             op_revm::OpSpecId::INTEROP
         } else if self.is_karst_active(timestamp) {
             op_revm::OpSpecId::KARST
@@ -302,11 +302,11 @@ impl RollupConfig {
 
     /// Returns true if SDM post-exec transactions are active at the given timestamp.
     ///
-    /// SDM rides the Interop hardfork: it is active iff Interop is active at `timestamp`,
-    /// matching op-node's `IsSDM` (see `op-node/rollup/toggles.go`).
+    /// SDM activates at the Lagoon hardfork, matching op-node's `IsSDM`. Gated directly on
+    /// Lagoon (not the interop toggle) so the two can't drift apart.
     #[must_use]
     pub fn is_sdm_active(&self, timestamp: u64) -> bool {
-        self.is_interop_active(timestamp)
+        self.is_lagoon_active(timestamp)
     }
 
     /// Returns true if Jovian is active at the given timestamp.
@@ -324,7 +324,7 @@ impl RollupConfig {
     /// Returns true if Karst is active at the given timestamp.
     pub fn is_karst_active(&self, timestamp: u64) -> bool {
         self.hardforks.karst_time.is_some_and(|t| timestamp >= t) ||
-            self.is_interop_active(timestamp)
+            self.is_lagoon_active(timestamp)
     }
 
     /// Returns true if the timestamp marks the first Karst block.
@@ -333,12 +333,28 @@ impl RollupConfig {
             !self.is_karst_active(timestamp.saturating_sub(self.block_time))
     }
 
-    /// Returns true if Interop is active at the given timestamp.
-    pub fn is_interop_active(&self, timestamp: u64) -> bool {
+    /// Returns true if Lagoon is active at the given timestamp.
+    pub fn is_lagoon_active(&self, timestamp: u64) -> bool {
         self.hardforks.lagoon_time.is_some_and(|t| timestamp >= t)
     }
 
-    /// Returns true if the timestamp marks the first Interop block.
+    /// Returns true if the timestamp marks the first Lagoon block.
+    pub fn is_first_lagoon_block(&self, timestamp: u64) -> bool {
+        self.is_lagoon_active(timestamp) &&
+            !self.is_lagoon_active(timestamp.saturating_sub(self.block_time))
+    }
+
+    /// Returns true if the interop feature is active at the given timestamp.
+    ///
+    /// Equivalent to [`Self::is_lagoon_active`] today (interop rides Lagoon), but kept as a
+    /// separate feature gate — mirroring op-node's `IsInterop` — so interop can diverge from the
+    /// fork if its activation is ever decoupled. Interop-feature code should gate on this, not on
+    /// the raw Lagoon accessor.
+    pub fn is_interop_active(&self, timestamp: u64) -> bool {
+        self.is_lagoon_active(timestamp)
+    }
+
+    /// Returns true if the timestamp marks the first interop-active block.
     pub fn is_first_interop_block(&self, timestamp: u64) -> bool {
         self.is_interop_active(timestamp) &&
             !self.is_interop_active(timestamp.saturating_sub(self.block_time))
@@ -704,7 +720,7 @@ mod tests {
     #[test]
     fn test_jovian_active() {
         let mut config = RollupConfig::default();
-        assert!(!config.is_interop_active(0));
+        assert!(!config.is_lagoon_active(0));
         config.hardforks.jovian_time = Some(10);
         assert!(config.is_regolith_active(10));
         assert!(config.is_canyon_active(10));
@@ -739,9 +755,38 @@ mod tests {
     }
 
     #[test]
-    fn test_sdm_rides_interop() {
+    fn test_lagoon_active() {
         let mut config = RollupConfig::default();
-        // Jovian/Karst alone must not activate SDM — only Interop does.
+        assert!(!config.is_lagoon_active(0));
+        config.hardforks.lagoon_time = Some(10);
+        assert!(config.is_lagoon_active(10));
+        assert!(!config.is_lagoon_active(9));
+    }
+
+    #[test]
+    fn test_first_lagoon_block() {
+        let mut config = RollupConfig { block_time: 2, ..Default::default() };
+        config.hardforks.lagoon_time = Some(120);
+        assert!(!config.is_first_lagoon_block(118));
+        assert!(config.is_first_lagoon_block(120));
+        assert!(!config.is_first_lagoon_block(122));
+    }
+
+    #[test]
+    fn test_interop_feature_tracks_lagoon() {
+        // The interop feature gate rides Lagoon today.
+        let mut config = RollupConfig { block_time: 2, ..Default::default() };
+        config.hardforks.lagoon_time = Some(120);
+        assert_eq!(config.is_interop_active(119), config.is_lagoon_active(119));
+        assert_eq!(config.is_interop_active(120), config.is_lagoon_active(120));
+        assert!(config.is_first_interop_block(120));
+        assert!(!config.is_first_interop_block(122));
+    }
+
+    #[test]
+    fn test_sdm_rides_lagoon() {
+        let mut config = RollupConfig::default();
+        // Jovian/Karst alone must not activate SDM — only Lagoon does.
         config.hardforks.jovian_time = Some(10);
         config.hardforks.karst_time = Some(20);
         assert!(config.is_jovian_active(10));
@@ -757,9 +802,9 @@ mod tests {
     }
 
     #[test]
-    fn test_interop_active() {
+    fn test_lagoon_stacks_prior_forks() {
         let mut config = RollupConfig::default();
-        assert!(!config.is_interop_active(0));
+        assert!(!config.is_lagoon_active(0));
         config.hardforks.lagoon_time = Some(10);
         assert!(config.is_regolith_active(10));
         assert!(config.is_canyon_active(10));
@@ -771,8 +816,8 @@ mod tests {
         assert!(!config.is_pectra_blob_schedule_active(10));
         assert!(config.is_isthmus_active(10));
         assert!(config.is_karst_active(10));
-        assert!(config.is_interop_active(10));
-        assert!(!config.is_interop_active(9));
+        assert!(config.is_lagoon_active(10));
+        assert!(!config.is_lagoon_active(9));
     }
 
     #[test]
@@ -851,10 +896,10 @@ mod tests {
         assert!(cfg.is_first_karst_block(110));
         assert!(!cfg.is_first_karst_block(112));
 
-        // Interop
-        assert!(!cfg.is_first_interop_block(118));
-        assert!(cfg.is_first_interop_block(120));
-        assert!(!cfg.is_first_interop_block(122));
+        // Lagoon
+        assert!(!cfg.is_first_lagoon_block(118));
+        assert!(cfg.is_first_lagoon_block(120));
+        assert!(!cfg.is_first_lagoon_block(122));
     }
 
     #[test]

--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -302,8 +302,7 @@ impl RollupConfig {
 
     /// Returns true if SDM post-exec transactions are active at the given timestamp.
     ///
-    /// SDM activates at the Lagoon hardfork, matching op-node's `IsSDM`. Gated directly on
-    /// Lagoon (not the interop toggle) so the two can't drift apart.
+    /// Defers to the hardfork where SDM is activated, matching op-node's `IsSDM`.
     #[must_use]
     pub fn is_sdm_active(&self, timestamp: u64) -> bool {
         self.is_lagoon_active(timestamp)
@@ -346,10 +345,9 @@ impl RollupConfig {
 
     /// Returns true if the interop feature is active at the given timestamp.
     ///
-    /// Equivalent to [`Self::is_lagoon_active`] today (interop rides Lagoon), but kept as a
-    /// separate feature gate — mirroring op-node's `IsInterop` — so interop can diverge from the
-    /// fork if its activation is ever decoupled. Interop-feature code should gate on this, not on
-    /// the raw Lagoon accessor.
+    /// Defers to the hardfork where interop is activated, but kept as a separate feature gate —
+    /// mirroring op-node's `IsInterop` — so interop can diverge from the fork if its activation is
+    /// ever decoupled. Interop-feature code should gate on this, not on the raw fork accessor.
     pub fn is_interop_active(&self, timestamp: u64) -> bool {
         self.is_lagoon_active(timestamp)
     }

--- a/rust/kona/crates/protocol/interop/src/graph.rs
+++ b/rust/kona/crates/protocol/interop/src/graph.rs
@@ -893,7 +893,7 @@ mod test {
         let chain_b_time = superchain.chain(CHAIN_B_ID).header.timestamp;
 
         // Move CHAIN_B (the executing chain) activation to t=50, so its block at t=2 is
-        // pre-interop. CHAIN_A (initiating) stays at the default (interop_time=0, well
+        // pre-interop. CHAIN_A (initiating) stays at the default (lagoon_time=0, well
         // past activation). The executing-chain guard must reject via `!is_interop_active`.
         superchain.chain(CHAIN_B_ID).with_interop_activation_time(50);
         superchain.chain(CHAIN_A_ID).add_initiating_message(MOCK_MESSAGE.into());

--- a/rust/kona/crates/protocol/interop/src/graph.rs
+++ b/rust/kona/crates/protocol/interop/src/graph.rs
@@ -384,7 +384,7 @@ where
 
         // Timestamp invariant: The timestamp at the time of inclusion of the initiating message
         // MUST be less than or equal to the timestamp of the executing message as well as greater
-        // than the Lagoon activation block's timestamp.
+        // than the interop activation block's timestamp.
         if initiating_timestamp > message.executing_timestamp {
             return Err(MessageGraphError::MessageInFuture {
                 max: message.executing_timestamp,
@@ -840,7 +840,7 @@ mod test {
 
         // Init chain (A): `lagoon_time = None`. Simulates a chain whose rollup config
         // (bundled registry stale, oracle-supplied, or genuinely pre-interop but
-        // incorrectly included in the dep set) has no Lagoon (interop) activation.
+        // incorrectly included in the dep set) has no interop activation.
         superchain.chain(CHAIN_A_ID).modify_rollup_cfg(|cfg| cfg.hardforks.lagoon_time = None);
         // Sanity-check the precondition; otherwise we'd be testing the wrong thing.
         assert!(
@@ -893,8 +893,8 @@ mod test {
         let chain_b_time = superchain.chain(CHAIN_B_ID).header.timestamp;
 
         // Move CHAIN_B (the executing chain) activation to t=50, so its block at t=2 is
-        // pre-interop. CHAIN_A (initiating) stays at the default (lagoon_time=0, well
-        // past activation). The executing-chain guard must reject via `!is_interop_active`.
+        // pre-interop. CHAIN_A (initiating) stays at the default (interop active from t=0,
+        // well past activation). The executing-chain guard must reject via `!is_interop_active`.
         superchain.chain(CHAIN_B_ID).with_interop_activation_time(50);
         superchain.chain(CHAIN_A_ID).add_initiating_message(MOCK_MESSAGE.into());
         superchain.chain(CHAIN_B_ID).add_executing_message(

--- a/rust/kona/crates/protocol/protocol/src/batch/single.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/single.rs
@@ -153,16 +153,15 @@ impl SingleBatch {
             }
         }
 
-        // If this is the first block in the jovian or interop hardfork, and the batch contains any
-        // transactions, it must be dropped.
+        // A jovian, karst, or lagoon transition block must be empty; drop it otherwise.
         if (cfg.is_first_jovian_block(self.timestamp) ||
             cfg.is_first_karst_block(self.timestamp) ||
-            cfg.is_first_interop_block(self.timestamp)) &&
+            cfg.is_first_lagoon_block(self.timestamp)) &&
             !self.transactions.is_empty()
         {
             warn!(
                 target: "single_batch",
-                "Sequencer included user transactions in jovian, karst, or interop transition block. Dropping batch."
+                "Sequencer included user transactions in jovian, karst, or lagoon transition block. Dropping batch."
             );
             return BatchValidity::Drop(BatchDropReason::NonEmptyTransitionBlock);
         }

--- a/rust/op-rbuilder/crates/op-rbuilder/src/sdm_admin.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/sdm_admin.rs
@@ -1,10 +1,9 @@
 //! Local SDM PostExec opt-in for op-rbuilder.
 //!
-//! The protocol gate (chain spec Interop activation) controls *whether* a block may
-//! carry a PostExec tx — that's a consensus rule shared by every node. This module
-//! adds an orthogonal *operator* gate: even on an SDM-active chain, the local
-//! builder produces PostExec txs only when the operator has explicitly opted in
-//! via [`admin_setSdmPostExecOptIn`]. Both gates must be true.
+//! The protocol gate (Lagoon activation) is a consensus rule shared by every node. This module
+//! adds an orthogonal *operator* gate: even on an SDM-active chain, the local builder produces
+//! PostExec txs only when the operator has opted in via [`admin_setSdmPostExecOptIn`]. Both must
+//! be true.
 //!
 //! State is in-memory and starts disabled on every process boot; persistence is
 //! deliberately out of scope.
@@ -42,7 +41,7 @@ pub struct SdmStatus {
     /// AND of the above — the actual decision the builder will make for a block
     /// at `query_timestamp`.
     pub effective: bool,
-    /// Activation timestamp of the protocol gate (Interop) if scheduled.
+    /// Activation timestamp of the protocol gate (Lagoon) if scheduled.
     pub activation_time: Option<u64>,
 }
 

--- a/rust/op-rbuilder/crates/op-rbuilder/src/sdm_admin.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/sdm_admin.rs
@@ -1,9 +1,9 @@
 //! Local SDM PostExec opt-in for op-rbuilder.
 //!
-//! The protocol gate (Lagoon activation) is a consensus rule shared by every node. This module
+//! The protocol gate (hardfork activation) is a consensus rule shared by every node. This module
 //! adds an orthogonal *operator* gate: even on an SDM-active chain, the local builder produces
 //! PostExec txs only when the operator has opted in via [`admin_setSdmPostExecOptIn`]. Both must
-//! be true.
+//! be true in order for SDM to be active.
 //!
 //! State is in-memory and starts disabled on every process boot; persistence is
 //! deliberately out of scope.
@@ -41,7 +41,7 @@ pub struct SdmStatus {
     /// AND of the above — the actual decision the builder will make for a block
     /// at `query_timestamp`.
     pub effective: bool,
-    /// Activation timestamp of the protocol gate (Lagoon) if scheduled.
+    /// Activation timestamp of the protocol gate if scheduled.
     pub activation_time: Option<u64>,
 }
 

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -129,14 +129,13 @@ impl<ChainSpec: EthChainSpec<Header = Header> + OpHardforks, N: NodePrimitives, 
 
 /// Returns true when SDM post-exec transactions are consensus-active at `timestamp`.
 ///
-/// SDM rides the Interop hardfork: it is active iff Interop is active at `timestamp`
-/// per the chain spec. This matches op-node's `IsSDM` (see `op-node/rollup/toggles.go`).
+/// SDM activates at the Lagoon hardfork, matching op-node's `IsSDM` and kona's `is_sdm_active`.
+/// Gated directly on Lagoon (not the interop toggle) so the two can't drift apart.
 ///
-/// This is the single source of truth for the SDM protocol gate. Call sites that only hold a
-/// chain spec should route through this helper rather than calling
-/// [`OpHardforks::is_interop_active_at_timestamp`] directly, so the gate cannot drift.
+/// Single source of truth for the SDM protocol gate: call sites holding only a chain spec should
+/// route through this rather than calling [`OpHardforks::is_lagoon_active_at_timestamp`] directly.
 pub fn is_sdm_active_at_timestamp(chain_spec: &impl OpHardforks, timestamp: u64) -> bool {
-    chain_spec.is_interop_active_at_timestamp(timestamp)
+    chain_spec.is_lagoon_active_at_timestamp(timestamp)
 }
 
 fn post_exec_mode_from_transactions<'a, I, T>(
@@ -441,7 +440,7 @@ mod tests {
         OpEvmConfig::optimism(BASE_MAINNET.clone())
     }
 
-    fn interop_at_timestamp_chain_spec(activation: u64) -> Arc<OpChainSpec> {
+    fn lagoon_at_timestamp_chain_spec(activation: u64) -> Arc<OpChainSpec> {
         Arc::new(
             OpChainSpecBuilder::default()
                 .chain(10.into())
@@ -455,10 +454,9 @@ mod tests {
     }
 
     #[test]
-    fn sdm_rides_interop_activation() {
-        // SDM follows Interop: inactive before the Interop activation timestamp,
-        // active at and after it. This matches op-node's `IsSDM == IsInterop`.
-        let evm_config = OpEvmConfig::optimism(interop_at_timestamp_chain_spec(100));
+    fn sdm_rides_lagoon_activation() {
+        // SDM follows Lagoon: inactive before activation, active at and after it.
+        let evm_config = OpEvmConfig::optimism(lagoon_at_timestamp_chain_spec(100));
 
         assert!(!evm_config.is_sdm_active_at_timestamp(0));
         assert!(!evm_config.is_sdm_active_at_timestamp(99));
@@ -468,17 +466,15 @@ mod tests {
     }
 
     #[test]
-    fn sdm_inactive_without_interop_schedule() {
-        // A chain spec that never activates Interop must never activate SDM, even at far
-        // future timestamps.
+    fn sdm_inactive_without_lagoon_schedule() {
+        // Without a Lagoon schedule, SDM never activates — even at far-future timestamps.
         let chain_spec = Arc::new(
             OpChainSpecBuilder::default().chain(10.into()).genesis(Genesis::default()).build(),
         );
         let evm_config = OpEvmConfig::optimism(chain_spec);
 
         assert!(!evm_config.is_sdm_active_at_timestamp(0));
-        // SDM inactivity is a consequence of the Interop precondition: assert it explicitly.
-        assert!(!evm_config.chain_spec().is_interop_active_at_timestamp(u64::MAX));
+        assert!(!evm_config.chain_spec().is_lagoon_active_at_timestamp(u64::MAX));
         assert!(!evm_config.is_sdm_active_at_timestamp(u64::MAX));
     }
 
@@ -503,7 +499,7 @@ mod tests {
     }
 
     // Covers Interop-driven SDM activation for imported blocks: pre-Interop blocks reject 0x7d,
-    // Interop-active blocks enter Verify mode, and malformed payload anchors are rejected.
+    // Lagoon-active blocks enter Verify mode, and malformed payload anchors are rejected.
     #[test]
     fn context_for_block_applies_sdm_post_exec_mode() {
         let disabled_err = test_evm_config()
@@ -511,7 +507,7 @@ mod tests {
             .expect_err("SDM disabled rejects 0x7d");
         assert!(matches!(disabled_err, EIP1559ParamError::InvalidPostExecPayload));
 
-        let evm_config = OpEvmConfig::optimism(interop_at_timestamp_chain_spec(0));
+        let evm_config = OpEvmConfig::optimism(lagoon_at_timestamp_chain_spec(0));
         let ctx = evm_config
             .context_for_block(&block_with_post_exec_tx(7, 123, 7))
             .expect("SDM-enabled block parses");

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -129,11 +129,11 @@ impl<ChainSpec: EthChainSpec<Header = Header> + OpHardforks, N: NodePrimitives, 
 
 /// Returns true when SDM post-exec transactions are consensus-active at `timestamp`.
 ///
-/// SDM activates at the Lagoon hardfork, matching op-node's `IsSDM` and kona's `is_sdm_active`.
-/// Gated directly on Lagoon (not the interop toggle) so the two can't drift apart.
+/// Defers to the hardfork where SDM is activated, matching op-node's `IsSDM` and kona's
+/// `is_sdm_active`.
 ///
 /// Single source of truth for the SDM protocol gate: call sites holding only a chain spec should
-/// route through this rather than calling [`OpHardforks::is_lagoon_active_at_timestamp`] directly.
+/// route through this rather than calling the underlying fork accessor directly.
 pub fn is_sdm_active_at_timestamp(chain_spec: &impl OpHardforks, timestamp: u64) -> bool {
     chain_spec.is_lagoon_active_at_timestamp(timestamp)
 }

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -775,13 +775,10 @@ where
 
     /// Returns whether SDM production should run for this payload.
     ///
-    /// Two gates must agree:
-    /// - **Protocol**: SDM rides the Interop hardfork, so this requires Interop active at the next
-    ///   block's timestamp per the chain spec.
-    /// - **Operator**: the local opt-in flag on `OpBuilderConfig`, mutated by the `admin_` SDM RPC.
-    ///   Starts disabled at process boot.
-    ///
-    /// Either being false disables production.
+    /// Both gates must agree (either being false disables production):
+    /// - **Protocol**: SDM active per the chain spec at the next block's timestamp (rides Lagoon).
+    /// - **Operator**: the local opt-in flag on `OpBuilderConfig`, mutated by the `admin_` SDM RPC;
+    ///   starts disabled at process boot.
     pub fn sdm_production_enabled(&self) -> bool {
         let protocol_active = reth_optimism_evm::is_sdm_active_at_timestamp(
             &self.chain_spec,

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -776,7 +776,7 @@ where
     /// Returns whether SDM production should run for this payload.
     ///
     /// Both gates must agree (either being false disables production):
-    /// - **Protocol**: SDM active per the chain spec at the next block's timestamp (rides Lagoon).
+    /// - **Protocol**: SDM active per the chain spec at the next block's timestamp.
     /// - **Operator**: the local opt-in flag on `OpBuilderConfig`, mutated by the `admin_` SDM RPC;
     ///   starts disabled at process boot.
     pub fn sdm_production_enabled(&self) -> bool {

--- a/rust/op-reth/crates/rpc/src/sdm_admin.rs
+++ b/rust/op-reth/crates/rpc/src/sdm_admin.rs
@@ -1,9 +1,9 @@
 //! Local SDM `PostExec` opt-in admin RPC for op-reth's payload builder.
 //!
-//! The protocol gate (Lagoon activation) is a consensus rule shared by every node. This module
+//! The protocol gate (hardfork activation) is a consensus rule shared by every node. This module
 //! adds an orthogonal *operator* gate: even on an SDM-active chain, op-reth's standard payload
 //! builder produces `PostExec` txs only when the operator has opted in via
-//! `admin_setSdmPostExecOptIn`. Both must be true.
+//! `admin_setSdmPostExecOptIn`. Both must be true in order for SDM to be active.
 //!
 //! State is in-memory and starts disabled on every process boot; persistence is deliberately
 //! out of scope.
@@ -29,7 +29,7 @@ pub struct SdmStatus {
     pub protocol_active: bool,
     /// AND of the two gates.
     pub effective: bool,
-    /// Activation timestamp of the protocol gate (Lagoon) if scheduled.
+    /// Activation timestamp of the protocol gate if scheduled.
     pub activation_time: Option<u64>,
 }
 

--- a/rust/op-reth/crates/rpc/src/sdm_admin.rs
+++ b/rust/op-reth/crates/rpc/src/sdm_admin.rs
@@ -1,9 +1,9 @@
 //! Local SDM `PostExec` opt-in admin RPC for op-reth's payload builder.
 //!
-//! The protocol gate (chain spec Interop activation) is a consensus rule shared by every node.
-//! This module adds an orthogonal *operator* gate: even on an SDM-active chain, op-reth's
-//! standard payload builder produces `PostExec` txs only when the operator has explicitly opted
-//! in via `admin_setSdmPostExecOptIn`. Both gates must be true.
+//! The protocol gate (Lagoon activation) is a consensus rule shared by every node. This module
+//! adds an orthogonal *operator* gate: even on an SDM-active chain, op-reth's standard payload
+//! builder produces `PostExec` txs only when the operator has opted in via
+//! `admin_setSdmPostExecOptIn`. Both must be true.
 //!
 //! State is in-memory and starts disabled on every process boot; persistence is deliberately
 //! out of scope.
@@ -29,7 +29,7 @@ pub struct SdmStatus {
     pub protocol_active: bool,
     /// AND of the two gates.
     pub effective: bool,
-    /// Activation timestamp of the protocol gate (Interop) if scheduled.
+    /// Activation timestamp of the protocol gate (Lagoon) if scheduled.
     pub activation_time: Option<u64>,
 }
 


### PR DESCRIPTION
## Summary

PR #21105 renamed the **Interop hardfork → Lagoon**. SDM previously gated transitively through the interop feature toggle (`IsSDM → IsInterop → IsLagoon`), coupling two unrelated features: if interop's activation is ever decoupled from Lagoon (the reason that toggle exists), SDM would silently follow it to the wrong activation.

This gates SDM **directly on the Lagoon hardfork accessor** in all three clients and refreshes the stale "rides the Interop hardfork" comments. **Behavior-preserving today** — every path resolves to `lagoon_time`.

## Fork accessor vs. feature gate

The change preserves the deliberate split (matching op-node):
- **Lagoon fork accessor** — what SDM and fork-timing checks gate on.
- **Interop feature gate** (`IsInterop` / `is_interop_active`, `= Lagoon` today but kept separable) — what the interop *feature* gates on, so it can be decoupled from the fork later.

## Changes

- **op-node** (`rollup/toggles.go`): `IsSDM` → `IsLagoon`
- **op-reth** (`crates/evm/src/lib.rs`): `is_sdm_active_at_timestamp` → `is_lagoon_active_at_timestamp`
- **kona** (`crates/protocol/genesis/src/rollup.rs`):
  - added `is_lagoon_active` / `is_first_lagoon_block` **fork** accessors (kona had none)
  - `is_sdm_active` and the fork-ordered `spec_id` now gate on the Lagoon accessor
  - `is_interop_active` / `is_first_interop_block` are **kept as the interop feature gate** (delegating to Lagoon) and continue to back genuinely interop-feature code: the cross-chain message graph, proof-driver interop mode, derivation attributes (interop NUT bundle), and the node sequencer/derivation actors
- Comment/naming sweep across op-reth payload builder + RPC `sdm_admin`, op-rbuilder `sdm_admin` (their `activation_time` already derived from `OpHardfork::Lagoon`), and kona `single.rs` transition-block rule
- Added/renamed tests: `test_lagoon_active`, `test_first_lagoon_block`, `test_sdm_rides_lagoon`, `test_interop_feature_tracks_lagoon`

Left untouched: the `OpSpecId::INTEROP` revm spec name, op-reth's txpool interop filter, op-node's `IsInterop` toggle (still used by depsets / fault proofs / engine controller), and alloy's `is_interop_active_at_timestamp`.

## Testing

- `go test ./op-node/rollup/ ./op-node/rollup/derive/`
- `cargo nextest run -p kona-genesis -p kona-protocol -p kona-interop -p kona-derive --all-features` (628 pass)
- `cargo nextest run -p reth-optimism-evm`
- `cargo build -p kona-driver -p kona-node-service` clean; op-reth / op-rbuilder build clean; rustfmt clean across all three workspaces

Closes #21129

🤖 Generated with [Claude Code](https://claude.com/claude-code)