### PR TITLE
docs(notices): warn op-reth operators on OP Sepolia about SCR loading bug

### DIFF
--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -69,6 +69,10 @@ L2CM introduces a new mechanism for upgrading L2 predeploy contracts. App develo
 
 Because Upgrade 19 includes hard fork changes (Osaka on L2 and Glamsterdam Defense), all node operators must update their execution and consensus clients before the activation timestamp.
 
+<Warning>
+  **Action required for node operators on OP Sepolia.** There is a known bug in op-reth where nodes running `--chain op-sepolia` **will not** activate Karst automatically via the Superchain Registry. You must manually configure the Karst timestamp. See Step 2 below for instructions.
+</Warning>
+
 <Steps>
   <Step title="Update to the latest release">
   Update `op-node` and `op-reth` to the version specified in the component table below. The new version includes consensus rules for the Karst hard fork activation for chains in the superchain-registry.
@@ -77,10 +81,16 @@ Because Upgrade 19 includes hard fork changes (Osaka on L2 and Glamsterdam Defen
   <Step title="Configure the Karst activation timestamp">
   How you configure the Karst activation timestamp depends on whether your chain is in the superchain-registry.
 
-  **Chains in the superchain-registry** (e.g. `OP`, `Soneium`, `Ink`, `Unichain`, `Mode`, `Metal`, `Zora`):
+  **Chains in the superchain-registry** (e.g. `Soneium`, `Ink`, `Unichain`, `Mode`, `Metal`, `Zora`):
   The Karst activation timestamp is built into the updated releases — no manual timestamp configuration is needed. Make sure you are using the network flag so that op-node and op-reth load chain config from the superchain-registry:
-  * `op-node`: [`--network <network>`](/node-operators/reference/op-node-config#network) (e.g. `--network op-mainnet`, `--network soneium-mainnet`, `--network op-sepolia`)
-  * `op-reth`: [`--chain <network>`](/node-operators/reference/op-reth-config#chain) (e.g. `--chain op`, `--chain soneium`, `--chain unichain`)
+  * `op-node`: [`--network <network>`](/node-operators/reference/op-node-config#network) (e.g. `--network soneium-mainnet`, `--network op-sepolia`)
+  * `op-reth`: [`--chain <network>`](/node-operators/reference/op-reth-config#chain) (e.g. `--chain soneium`, `--chain unichain`)
+
+  **OP Sepolia:**
+  Due to a bug in op-reth, the Karst activation timestamp is **not** loaded from the Superchain Registry for `op-sepolia` and `op`. You must configure it manually by providing a genesis file with `"karstTime"` set and passing it via `--chain <path-to-genesis.json>`:
+  * **OP Sepolia**: `"karstTime": 1781712001`
+
+  `op-node` is not affected by this bug — `--network op-sepolia` will correctly activate Karst for op-node.
 
   **Chains not in the superchain-registry:**
   Set the activation timestamp manually in each client's config:

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -87,8 +87,11 @@ Because Upgrade 19 includes hard fork changes (Osaka on L2 and Glamsterdam Defen
   * `op-reth`: [`--chain <network>`](/node-operators/reference/op-reth-config#chain) (e.g. `--chain soneium`, `--chain unichain`)
 
   **OP Sepolia:**
-  Due to a bug in op-reth, the Karst activation timestamp is **not** loaded from the Superchain Registry for `op-sepolia` and `op`. You must configure it manually by providing a genesis file with `"karstTime"` set and passing it via `--chain <path-to-genesis.json>`:
-  * **OP Sepolia**: `"karstTime": 1781712001`
+  Due to a bug in op-reth, the Karst activation timestamp is **not** loaded from the Superchain Registry for `op-sepolia` and `op`. You must configure it manually by providing a genesis file passed via `--chain <path-to-genesis.json>`. Download the pre-built genesis file for your chain and pass it directly — do not edit the file.
+
+  <Warning>
+    With `op-reth v2.3.1`, the genesis file must **not** include an `osakaTime` field. The pre-built file linked above is compatible with `op-reth v2.3.1` as-is. Both the SCR loading bug and this restriction will be fixed in a following op-reth release.
+  </Warning>
 
   `op-node` is not affected by this bug — `--network op-sepolia` will correctly activate Karst for op-node.
 

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -92,7 +92,7 @@ Because Upgrade 19 includes hard fork changes (Osaka on L2 and Glamsterdam Defen
   * **OP Sepolia**: [Download genesis.json](https://drive.google.com/file/d/13aHDba8O25KPq6uSbzS3ix7abKHjE48q/view)
 
   <Warning>
-    With `op-reth v2.3.1`, the genesis file must **not** include an `osakaTime` field. The pre-built file linked above is compatible with `op-reth v2.3.1` as-is. Both the SCR loading bug and this restriction will be fixed in a following op-reth release.
+    With `op-reth v2.3.1`, the genesis file must **not** include an `osakaTime` field. The pre-built file linked above is compatible with `op-reth v2.3.1` as-is. Both the SCR loading bug and this restriction will be fixed in a following op-reth release so this won't be necessary for OP Mainnet.
   </Warning>
 
   `op-node` is not affected by this bug — `--network op-sepolia` will correctly activate Karst for op-node.

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -87,7 +87,9 @@ Because Upgrade 19 includes hard fork changes (Osaka on L2 and Glamsterdam Defen
   * `op-reth`: [`--chain <network>`](/node-operators/reference/op-reth-config#chain) (e.g. `--chain soneium`, `--chain unichain`)
 
   **OP Sepolia:**
-  Due to a bug in op-reth, the Karst activation timestamp is **not** loaded from the Superchain Registry for `op-sepolia` and `op`. You must configure it manually by providing a genesis file passed via `--chain <path-to-genesis.json>`. Download the pre-built genesis file for your chain and pass it directly — do not edit the file.
+  Due to a bug in op-reth, the Karst activation timestamp is **not** loaded from the Superchain Registry for `op-sepolia` and `op`. You must configure it manually by providing a genesis file passed via `--chain <path-to-genesis.json>`. Download the pre-built genesis file and pass it directly — do not edit the file.
+
+  * **OP Sepolia**: [Download genesis.json](https://drive.google.com/file/d/13aHDba8O25KPq6uSbzS3ix7abKHjE48q/view)
 
   <Warning>
     With `op-reth v2.3.1`, the genesis file must **not** include an `osakaTime` field. The pre-built file linked above is compatible with `op-reth v2.3.1` as-is. Both the SCR loading bug and this restriction will be fixed in a following op-reth release.


### PR DESCRIPTION
## Summary

- Adds a `<Warning>` banner to the Upgrade 19 / Karst node operator section calling out that op-reth does **not** load the Karst activation timestamp from the Superchain Registry for `op-sepolia` and `op`
- Updates Step 2 to separate OP Sepolia from the "SCR works automatically" group and give explicit manual configuration instructions (`"karstTime": 1781712001` in the genesis file)
- Clarifies that op-node is not affected by this bug

Tracking incident: #incident-2026-06-15-op-reth-superchain-registry-loading-bug-op-sepolia-and-op-m

## Test plan

- [ ] Verify the Warning banner renders correctly on the docs site
- [ ] Confirm timestamps match: OP Sepolia `1781712001` (Jun 17 16:00:01 UTC), OP Mainnet `1783526401` (Jul 8 16:00:01 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)