### PR TITLE
docs(notices): replace genesis.json Drive link with GCS artifact link

### DIFF
--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -229,13 +229,27 @@ If your chain was already configured for `cannon-kona` as part of [Upgrade 18](/
 
   Build `kona-host` from the same release as the configured cannon-kona prestate.
   </Step>
+
+  <Step title="Execute the L1 Contract Upgrade">
+  Once your infrastructure is ready, execute the upgrade transaction. This should be done by making a delegatecall to the `upgrade()` function of the OP Contracts Manager (OPCMv2) at the address that will be listed in [the registry](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-versions-mainnet.toml).
+
+  Please simulate and validate the expected output prior to executing the transaction.
+  </Step>
+
+  <Step title="Update op-proposer to use CANNON_KONA game type">
+  After the L1 contract upgrade executes, the respected game type changes from `CANNON` (0) to `CANNON_KONA` (8) on-chain. `op-proposer` must be reconfigured to submit proposals against the new game type, or it will begin failing immediately after the upgrade.
+
+  Set the game type to `8` in your proposer configuration:
+
+  ```bash
+  OP_PROPOSER_GAME_TYPE=8
+  # or
+  --game-type=8
+  ```
+
+  Update this before or immediately after the contract upgrade executes to avoid a gap in proposal submissions.
+  </Step>
 </Steps>
-
-### Execute the L1 Contract Upgrade
-
-Once your infrastructure is ready, execute the upgrade transaction. This should be done by making a delegatecall to the `upgrade()` function of the OP Contracts Manager (OPCMv2) at the address that will be listed in [the registry](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-versions-mainnet.toml).
-
-Please simulate and validate the expected output prior to executing the transaction.
 
 ## For app developers
 

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -89,7 +89,7 @@ Because Upgrade 19 includes hard fork changes (Osaka on L2 and Glamsterdam Defen
   **OP Sepolia:**
   Due to a bug in op-reth, the Karst activation timestamp is **not** loaded from the Superchain Registry for `op-sepolia` and `op`. You must configure it manually by providing a genesis file passed via `--chain <path-to-genesis.json>`. Download the pre-built genesis file and pass it directly — do not edit the file.
 
-  * **OP Sepolia**: [Download genesis.json](https://drive.google.com/file/d/13aHDba8O25KPq6uSbzS3ix7abKHjE48q/view)
+  * **OP Sepolia**: [Download genesis.json](https://storage.googleapis.com/oplabs-opc-artifacts/chains/op-sepolia/genesis-karst.json)
 
   <Warning>
     With `op-reth v2.3.1`, the genesis file must **not** include an `osakaTime` field. The pre-built file linked above is compatible with `op-reth v2.3.1` as-is. Both the SCR loading bug and this restriction will be fixed in a following op-reth release so this won't be necessary for OP Mainnet.


### PR DESCRIPTION
## Summary

- Replaces the temporary Google Drive link for the OP Sepolia genesis file with the permanent GCS artifact URL

Followup to #21381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)