### PR TITLE
fix(contracts): verify super games through runSingle

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -291,7 +291,7 @@ contract VerifyOPCM is Script {
         // Rather than requiring an opcm input parameter, just pass in an empty reference
         // as we really only need this for features that are in development.
         IOPContractsManagerV2 emptyOpcm = IOPContractsManagerV2(address(0));
-        _verifyOpcmContractRef(
+        _verifyContractRef(
             emptyOpcm,
             OpcmContractRef({ field: _name, name: _name, addr: _addr, blueprint: false }),
             _skipConstructorVerification
@@ -588,16 +588,7 @@ contract VerifyOPCM is Script {
         returns (bool)
     {
         bool success = true;
-
-        console.log();
-        console.log(string.concat("Checking Contract: ", _target.field));
-        console.log(string.concat("  Type: ", _target.blueprint ? "Blueprint" : "Implementation"));
-        console.log(string.concat("  Contract: ", _target.name));
-        console.log(string.concat("  Address: ", vm.toString(_target.addr)));
-
-        // Build the expected path to the artifact file.
-        string memory artifactPath = _buildArtifactPath(_target.name);
-        console.log(string.concat("  Expected Runtime Artifact: ", artifactPath));
+        string memory artifactPath = _logContractRef(_target);
 
         // Check if this is a Super dispute game that should be skipped
         if (_isSuperDisputeGameImplementation(_target.name)) {
@@ -627,8 +618,59 @@ contract VerifyOPCM is Script {
             // If feature is enabled, continue with normal verification
         }
 
+        return _verifyContractRefAfterHeader(_opcm, _target, artifactPath, _skipConstructorVerification) && success;
+    }
+
+    /// @notice Verifies a single contract reference without applying OPCM feature gates.
+    /// @param _opcm The OPCM contract used for security-critical value checks.
+    /// @param _target The target contract reference to verify.
+    /// @param _skipConstructorVerification Whether to skip constructor verification.
+    /// @return True if the contract reference is verified, false otherwise.
+    function _verifyContractRef(
+        IOPContractsManagerV2 _opcm,
+        OpcmContractRef memory _target,
+        bool _skipConstructorVerification
+    )
+        internal
+        returns (bool)
+    {
+        string memory artifactPath = _logContractRef(_target);
+        return _verifyContractRefAfterHeader(_opcm, _target, artifactPath, _skipConstructorVerification);
+    }
+
+    /// @notice Logs the standard verification header for a contract reference.
+    /// @param _target The target contract reference to log.
+    /// @return artifactPath_ The expected Foundry artifact path for the target.
+    function _logContractRef(OpcmContractRef memory _target) internal view returns (string memory artifactPath_) {
+        console.log();
+        console.log(string.concat("Checking Contract: ", _target.field));
+        console.log(string.concat("  Type: ", _target.blueprint ? "Blueprint" : "Implementation"));
+        console.log(string.concat("  Contract: ", _target.name));
+        console.log(string.concat("  Address: ", vm.toString(_target.addr)));
+
+        artifactPath_ = _buildArtifactPath(_target.name);
+        console.log(string.concat("  Expected Runtime Artifact: ", artifactPath_));
+    }
+
+    /// @notice Verifies a contract reference after the standard header has already been logged.
+    /// @param _opcm The OPCM contract used for security-critical value checks.
+    /// @param _target The target contract reference to verify.
+    /// @param _artifactPath The expected Foundry artifact path for the target.
+    /// @param _skipConstructorVerification Whether to skip constructor verification.
+    /// @return True if the contract reference is verified, false otherwise.
+    function _verifyContractRefAfterHeader(
+        IOPContractsManagerV2 _opcm,
+        OpcmContractRef memory _target,
+        string memory _artifactPath,
+        bool _skipConstructorVerification
+    )
+        internal
+        returns (bool)
+    {
+        bool success = true;
+
         // Load artifact information (bytecode, immutable refs) for detailed comparison
-        ArtifactInfo memory artifact = _loadArtifactInfo(artifactPath);
+        ArtifactInfo memory artifact = _loadArtifactInfo(_artifactPath);
 
         // Grab the actual code.
         bytes memory actualCode = _target.addr.code;

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -181,8 +181,7 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
             for (uint256 j = 0; j < refsByType[i].length; j++) {
                 VerifyOPCM.OpcmContractRef memory ref = refsByType[i][j];
 
-                // TODO(#17262): Remove this skip once Super dispute games are no longer behind a feature flag
-                if (_isSuperDisputeGameContractRef(ref)) {
+                if (_isSuperDisputeGameContractRef(ref) && !superGamesEnabled()) {
                     continue;
                 }
 


### PR DESCRIPTION
## Summary

Fixes `VerifyOPCM_Run_Test.test_runSingle_succeeds` so Super dispute game contracts are only skipped when the Super-root games feature is disabled.

Also routes `runSingle` through a verifier path that does not apply OPCM feature gates, since `runSingle` verifies an explicit contract address and intentionally uses a placeholder zero-address OPCM.

## Testing

- `git diff --check`
- `mise exec -- just test-dev --match-contract VerifyOPCM_Run_Test`
- `DEV_FEATURE__SUPER_ROOT_GAMES_MIGRATION=true mise exec -- just test-dev --match-contract VerifyOPCM_Run_Test`

## Meta

Fixes https://github.com/ethereum-optimism/optimism/issues/17262