### PR TITLE
fix(op-chain-ops): match any revision id in script revert-panic guard

### DIFF
--- a/op-chain-ops/script/script.go
+++ b/op-chain-ops/script/script.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"regexp"
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script/addresses"
@@ -365,25 +366,36 @@ func (h *Host) prelude(from common.Address, to *common.Address) {
 	h.env.StateDB().Prepare(rules, from, evmC.Coinbase, to, activePrecompiles, nil)
 }
 
+// expectedRevertPanicRe matches the panic go-ethereum's state journal raises when a
+// snapshot revision cannot be reverted, e.g. "revision id 36 cannot be reverted".
+// Forge scripts trigger this as ordinary control flow, so Host.Call swallows it into
+// a regular revert error.
+var expectedRevertPanicRe = regexp.MustCompile(`revision id \d+ cannot be reverted`)
+
+// isExpectedRevertPanic reports whether a recovered panic value is the expected
+// state-snapshot revert that Host.Call turns into an "execution reverted" error
+// rather than re-panicking. The panic value may be a string or an error.
+func isExpectedRevertPanic(r any) bool {
+	var msg string
+	switch v := r.(type) {
+	case string:
+		msg = v
+	case error:
+		msg = v.Error()
+	default:
+		return false
+	}
+	return expectedRevertPanicRe.MatchString(strings.ToLower(msg))
+}
+
 // Call calls a contract in the EVM. The state changes persist.
 func (h *Host) Call(from common.Address, to common.Address, input []byte, gas uint64, value *uint256.Int) (returnData []byte, leftOverGas uint64, err error) {
 	h.prelude(from, &to)
 
 	defer func() {
 		if r := recover(); r != nil {
-			// Try to get the panic message as a string. It could be a plain string
-			// or an error type (e.g., from errors.New or fmt.Errorf).
-			var rStr string
-			var ok bool
-			if rStr, ok = r.(string); !ok {
-				// Not a string, try error interface
-				if rErr, errOk := r.(error); errOk {
-					rStr = rErr.Error()
-					ok = true
-				}
-			}
-			if !ok || !strings.Contains(strings.ToLower(rStr), "revision id 1") {
-				fmt.Println("panic", rStr)
+			if !isExpectedRevertPanic(r) {
+				fmt.Println("panic", r)
 				panic(r)
 			}
 

--- a/op-chain-ops/script/script_revert_panic_test.go
+++ b/op-chain-ops/script/script_revert_panic_test.go
@@ -1,0 +1,35 @@
+package script
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsExpectedRevertPanic(t *testing.T) {
+	tests := []struct {
+		name string
+		r    any
+		want bool
+	}{
+		{"revision id 1 error", fmt.Errorf("revision id 1 cannot be reverted"), true},
+		// Regression: a revision id not starting with "1" must still be recognised.
+		// The previous literal "revision id 1" substring match dropped these and re-panicked.
+		{"revision id 36 error", fmt.Errorf("revision id 36 cannot be reverted"), true},
+		{"revision id 200 string", "revision id 200 cannot be reverted", true},
+		{"revision id 9 error", errors.New("revision id 9 cannot be reverted"), true},
+		{"uppercase message", errors.New("Revision ID 7 cannot be reverted"), true},
+		{"unrelated string", "something else blew up", false},
+		{"unrelated error", errors.New("out of gas"), false},
+		{"revision id without number", errors.New("revision id cannot be reverted"), false},
+		{"non-string non-error", 42, false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isExpectedRevertPanic(tt.r))
+		})
+	}
+}


### PR DESCRIPTION
## Description

`Host.Call` (`op-chain-ops/script/script.go`) wraps forge-script execution in a `recover()` that is meant to swallow one specific, *expected* panic: the go-ethereum state-journal `revision id <N> cannot be reverted`, which forge scripts trigger as ordinary control flow during snapshot reverts. Everything else is re-panicked.

The guard matched the panic message against the **literal substring `"revision id 1"`**:

```go
if !ok || !strings.Contains(strings.ToLower(rStr), "revision id 1") {
    panic(r)
}
```

That only recognises revision ids that begin with `1` (`1`, `10`–`19`, `1xx`…). Any other id slips past the handler and re-panics. This surfaces as a **data-dependent flake**: the OPCM v2 upgrade path reaches `revision id 36`, which doesn't match, so the recover re-throws and crashes `op-deployer/pkg/deployer/integration_test` (`TestEndToEndApply/OPCMV2_deployment`, `TestEndToEndBootstrapApplyWithUpgrade` and its upgrade subtests) whenever the run lands on a non-`1` revision id.

The literal was introduced in March 2025 (commit `2767cb95d19`).

## Fix

Extract the predicate into `isExpectedRevertPanic` and match the full pattern via regexp:

```go
var expectedRevertPanicRe = regexp.MustCompile(`revision id \d+ cannot be reverted`)
```

This recognises any revision id while still being specific to the expected revert panic (it won't swallow unrelated panics). Behaviour for ids starting with `1` is unchanged.

## Tests

`TestIsExpectedRevertPanic` (new) covers the regression directly — ids not starting with `1` (`36`, `200`, `9`), an uppercase message, and non-matching panics (unrelated string/error, a `revision id` with no number, non-string/non-error values). Verified red/green: the test fails against the old literal match (`revision id 36/200/9` → not recognised) and passes with the regex.

- `go test ./op-chain-ops/script/ -run TestIsExpectedRevertPanic` ✅
- `go build ./op-chain-ops/script/` + `go vet` ✅

## Context

Found while diagnosing CI on #21356 (an unrelated docs/types PR) — the failure there was this pre-existing bug, not that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
