### PR TITLE
feat(op-supernode): honor explicit per-chain p2p key path

### DIFF
--- a/op-supernode/cmd/p2p.go
+++ b/op-supernode/cmd/p2p.go
@@ -24,7 +24,13 @@ func withNamespacedP2P(vcli *flags.VirtualCLI, datadir string, namespace string)
 	if err := os.MkdirAll(p2pDir, 0o700); err != nil {
 		return fmt.Errorf("failed creating p2p dir for chain %s: %w", namespace, err)
 	}
-	vcli.WithStringOverride(opnodeflags.P2PPrivPathName, filepath.Join(p2pDir, "opnode_p2p_priv.txt"))
+	// Honor an explicit per-chain p2p key path (e.g. a read-only mounted static
+	// key) when set; otherwise namespace the key into the chain's datadir. A
+	// vn.all value is intentionally not honored: one shared path would collide
+	// across every virtual node, same reasoning as the listen ports below.
+	if !vcli.IsChainSet(opnodeflags.P2PPrivPathName) {
+		vcli.WithStringOverride(opnodeflags.P2PPrivPathName, filepath.Join(p2pDir, "opnode_p2p_priv.txt"))
+	}
 	vcli.WithStringOverride(opnodeflags.PeerstorePathName, filepath.Join(p2pDir, "peerstore_db"))
 	vcli.WithStringOverride(opnodeflags.DiscoveryPathName, filepath.Join(p2pDir, "discovery_db"))
 	// Default listen ports to 0 (dynamic) to prevent collisions when the user

--- a/op-supernode/cmd/p2p.go
+++ b/op-supernode/cmd/p2p.go
@@ -24,10 +24,6 @@ func withNamespacedP2P(vcli *flags.VirtualCLI, datadir string, namespace string)
 	if err := os.MkdirAll(p2pDir, 0o700); err != nil {
 		return fmt.Errorf("failed creating p2p dir for chain %s: %w", namespace, err)
 	}
-	// Honor an explicit per-chain p2p key path (e.g. a read-only mounted static
-	// key) when set; otherwise namespace the key into the chain's datadir. A
-	// vn.all value is intentionally not honored: one shared path would collide
-	// across every virtual node, same reasoning as the listen ports below.
 	if !vcli.IsChainSet(opnodeflags.P2PPrivPathName) {
 		vcli.WithStringOverride(opnodeflags.P2PPrivPathName, filepath.Join(p2pDir, "opnode_p2p_priv.txt"))
 	}

--- a/op-supernode/cmd/p2p_test.go
+++ b/op-supernode/cmd/p2p_test.go
@@ -121,6 +121,31 @@ func TestWithNamespacedP2P_CreatesP2PDir(t *testing.T) {
 	require.True(t, info.IsDir(), "expected p2p dir at %s", expected)
 }
 
+func TestWithNamespacedP2P_NamespacesPrivPathByDefault(t *testing.T) {
+	dataDir := t.TempDir()
+	ns := fmt.Sprintf("%d", testChainID)
+	vcli := newVCLI(t, nil)
+	require.NoError(t, withNamespacedP2P(vcli, dataDir, ns))
+
+	require.Equal(t,
+		filepath.Join(dataDir, ns, "p2p", "opnode_p2p_priv.txt"),
+		vcli.String(opnodeflags.P2PPrivPathName))
+}
+
+func TestWithNamespacedP2P_HonoursPerChainPrivPath(t *testing.T) {
+	privName := fmt.Sprintf("%s%d.%s", flags.VNFlagNamePrefix, testChainID, opnodeflags.P2PPrivPathName)
+	keyPath := fmt.Sprintf("/etc/op-supernode/p2p-node-key-%d.txt", testChainID)
+
+	flagSet := append(portFlags(), &cli.StringFlag{Name: privName})
+	ctx := newCtx(t, flagSet, []string{"--" + privName + "=" + keyPath})
+	vcli := flags.NewVirtualCLI(ctx, testChainID)
+
+	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID)))
+
+	// Explicit per-chain path is honored, not clobbered by the namespaced default.
+	require.Equal(t, keyPath, vcli.String(opnodeflags.P2PPrivPathName))
+}
+
 func TestWithNoP2P_AlwaysForcesListenPortsToZero(t *testing.T) {
 	// Even when the user pinned ports, withNoP2P should zero them out because
 	// P2P is being disabled outright.


### PR DESCRIPTION
## Summary

`withNamespacedP2P` unconditionally overrode `--vn.<chainID>.p2p.priv.path`, so a statically supplied per-chain p2p key was always ignored in favor of an auto-generated key under the datadir (`<datadir>/<chainID>/p2p/opnode_p2p_priv.txt`). This made it impossible to pin a stable peer ID per virtual node via config.

This guards the override with `IsChainSet`: an explicit per-chain path is now honored (e.g. a read-only mounted static key), falling back to the namespaced datadir default when unset. A `vn.all` value is intentionally still **not** honored — one shared path would collide across every virtual node, matching the existing listen-port handling.

## Companion changes
- `ethereum-optimism/optimism-charts`: per-chain `chains.<id>.nodeKey` → mounts `/etc/op-supernode/p2p-node-key-<id>.txt` and sets `OP_SUPERNODE_VN_<id>_P2P_PRIV_PATH`.
- `infrastructure-services/netchef`: generates a deterministic per-chain key and emits `chains.<id>.nodeKey`.

## Test
Adds `TestWithNamespacedP2P_NamespacesPrivPathByDefault` and `TestWithNamespacedP2P_HonoursPerChainPrivPath`.