### PR TITLE
fix(ctb): skip interop L2 genesis upgrade tests under custom gas token

### DIFF
--- a/packages/contracts-bedrock/scripts/libraries/UpgradeUtils.sol
+++ b/packages/contracts-bedrock/scripts/libraries/UpgradeUtils.sol
@@ -33,7 +33,7 @@ library UpgradeUtils {
     /// @dev Calibration: see `_buildImplementationDeploymentConfigs` in GenerateNUTBundle.s.sol.
     /// @return Gas limits struct.
     function gasLimits() internal pure returns (GasLimits memory) {
-        return GasLimits({ l2cmDeployment: 8_700_000, upgradeExecution: 3_700_000 });
+        return GasLimits({ l2cmDeployment: 8_700_000, upgradeExecution: 4_000_000 });
     }
 
     /// @notice Computes the intrinsic gas cost for a NUT bundle transaction.

--- a/packages/contracts-bedrock/snapshots/upgrades/current-upgrade-bundle.json
+++ b/packages/contracts-bedrock/snapshots/upgrades/current-upgrade-bundle.json
@@ -195,7 +195,7 @@
     {
       "data": "0x7c36f37e00000000000000000000000029146c055de75aea9cd5aacd101f9a0c70bc1a6f",
       "from": "0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001",
-      "gasLimit": 3700000,
+      "gasLimit": 4000000,
       "intent": "L2ProxyAdmin Upgrade Predeploys",
       "to": "0x4200000000000000000000000000000000000018"
     }

--- a/packages/contracts-bedrock/test/L2/L2GenesisForkUpgrade.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2GenesisForkUpgrade.t.sol
@@ -149,6 +149,8 @@ abstract contract L2GenesisForkUpgrade_Interop_TestInit is L2GenesisForkUpgrade_
     function setUp() public virtual override {
         super.enableInterop();
         L2GenesisForkUpgrade_TestInit.setUp();
+        // Interop and custom gas token are not a supported combination.
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
     }
 
     function _executeCurrentBundle() internal virtual override {


### PR DESCRIPTION
#21346 changed how we organize predeploys and how the L2CM upgrade path runs.

For interop + CGT that breaks a gas limit buffer requirement we've set somewhat arbitrarily. 

So this PR: 
1. disables the interop gas limit test when CGT is enabled because it's not valid
2. bumps the gas limit of the upgrade call anyways because it doesn't hurt.

Robot writeup follows:

## Summary

`L2GenesisForkUpgrade_Interop_GasProfile_Test` was failing in the `CUSTOM_GAS_TOKEN` feature job:

```
Bundle gas limit must exceed 1.5x max(intrinsic+body, EIP-7623 floor)
for L2ProxyAdmin Upgrade Predeploys: 3700000 < 3840178
```

The failure is specific to the **interop + custom gas token** combination, which is not a supported configuration. Interop alone passes at the 3.7M budget; layering CGT on top adds the CGT predeploy variant, making `L2ProxyAdmin.upgradePredeploys()` heavier and pushing the recommended limit (3,840,178) past the budget.

## Changes

- Skip all interop genesis upgrade variants when `CUSTOM_GAS_TOKEN` is enabled, via `skipIfSysFeatureEnabled` in the shared `L2GenesisForkUpgrade_Interop_TestInit`.
- Bump `upgradeExecution` gas limit 3.7M -> 4M for headroom (regenerated NUT bundle snapshot accordingly).

## Verification

`FOUNDRY_PROFILE=ci`:
- With CGT: all 5 interop variants skip.
- Without CGT: interop `gasProfile` + `isolatedGas` pass.
- NUT bundle snapshot regenerates with no drift.