### PR TITLE
feat(op-reth): gate payload builder on interop failsafe

### DIFF
--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -209,9 +209,8 @@ pub struct OpNode {
     /// Local operator opt-in for SDM `PostExec` production. Shared (via Arc clones) between the
     /// payload builder and the `admin_setSdmPostExecOptIn` RPC handler.
     pub sdm_post_exec_opt_in: SdmPostExecOptIn,
-    /// Interop failsafe gate. Shared (via clones) between the txpool's interop filter client,
-    /// which sets it, and the payload builder, which reads it to exclude interop txs while it
-    /// is active.
+    /// Interop failsafe gate, shared between the txpool's interop filter client (writer) and the
+    /// payload builder (reader, to exclude interop txs while it is active).
     pub interop_failsafe: InteropFailsafe,
 }
 
@@ -1092,8 +1091,7 @@ pub struct OpPoolBuilder<T = crate::txpool::OpPooledTransaction> {
     pub interop_min_responses: Option<usize>,
     /// Safety level for interop filter validation.
     pub interop_safety_level: SafetyLevel,
-    /// Shared interop failsafe gate. The interop filter client writes it; the payload builder
-    /// reads it. Threaded in so both observe the same live state.
+    /// Shared interop failsafe gate, passed to the interop filter client this builder constructs.
     pub interop_failsafe: InteropFailsafe,
     /// Marker for the pooled transaction type.
     _pd: core::marker::PhantomData<T>,
@@ -1158,8 +1156,7 @@ impl<T> OpPoolBuilder<T> {
         self
     }
 
-    /// Shares the interop failsafe gate with the pool builder, so the interop filter client it
-    /// constructs writes the same flag the payload builder reads.
+    /// Shares the interop failsafe gate, written by the interop filter client this builder builds.
     pub fn with_interop_failsafe(mut self, interop_failsafe: InteropFailsafe) -> Self {
         self.interop_failsafe = interop_failsafe;
         self
@@ -1324,8 +1321,7 @@ pub struct OpPayloadBuilder<Txs = ()> {
     pub gas_limit_config: OpGasLimitConfig,
     /// Operator opt-in flag for SDM `PostExec` production. Shared with the admin RPC.
     pub sdm_post_exec_opt_in: SdmPostExecOptIn,
-    /// Interop failsafe gate. Shared with the txpool interop filter client; read by the payload
-    /// builder to exclude interop txs from blocks while it is active.
+    /// Interop failsafe gate, read by the builder to exclude interop txs while it is active.
     pub interop_failsafe: InteropFailsafe,
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
     ///
@@ -1377,8 +1373,7 @@ impl OpPayloadBuilder {
         self
     }
 
-    /// Provide the shared interop failsafe gate, read by the builder to exclude interop txs while
-    /// the failsafe is active.
+    /// Provide the shared interop failsafe gate read by the builder.
     #[must_use]
     pub fn with_interop_failsafe(mut self, interop_failsafe: InteropFailsafe) -> Self {
         self.interop_failsafe = interop_failsafe;

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -52,7 +52,9 @@ use reth_optimism_rpc::{
     witness::{DebugExecutionWitnessApiServer, OpDebugPostExecApiServer, OpDebugWitnessApi},
 };
 use reth_optimism_storage::OpStorage;
-use reth_optimism_txpool::{OpPool, OpPooledTx, interop_filter::InteropFilterClient};
+use reth_optimism_txpool::{
+    OpPool, OpPooledTx, interop::InteropFailsafe, interop_filter::InteropFilterClient,
+};
 use reth_primitives_traits::header::HeaderMut;
 use reth_provider::{CanonStateSubscriptions, providers::ProviderFactoryBuilder};
 use reth_rpc_api::{
@@ -207,6 +209,10 @@ pub struct OpNode {
     /// Local operator opt-in for SDM `PostExec` production. Shared (via Arc clones) between the
     /// payload builder and the `admin_setSdmPostExecOptIn` RPC handler.
     pub sdm_post_exec_opt_in: SdmPostExecOptIn,
+    /// Interop failsafe gate. Shared (via clones) between the txpool's interop filter client,
+    /// which sets it, and the payload builder, which reads it to exclude interop txs while it
+    /// is active.
+    pub interop_failsafe: InteropFailsafe,
 }
 
 /// A [`ComponentsBuilder`] with its generic arguments set to a stack of Optimism specific builders.
@@ -227,6 +233,7 @@ impl OpNode {
             da_config: OpDAConfig::default(),
             gas_limit_config: OpGasLimitConfig::default(),
             sdm_post_exec_opt_in: SdmPostExecOptIn::default(),
+            interop_failsafe: InteropFailsafe::default(),
         }
     }
 
@@ -259,13 +266,15 @@ impl OpNode {
                         self.args.interop_http.clone(),
                         self.args.interop_min_responses,
                         self.args.interop_safety_level,
-                    ),
+                    )
+                    .with_interop_failsafe(self.interop_failsafe.clone()),
             )
             .payload(BasicPayloadServiceBuilder::new(
                 OpPayloadBuilder::new(compute_pending_block)
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone())
                     .with_sdm_post_exec_opt_in(self.sdm_post_exec_opt_in.clone())
+                    .with_interop_failsafe(self.interop_failsafe.clone())
                     .with_max_uncompressed_block_size(self.args.max_uncompressed_block_size),
             ))
             .network(OpNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
@@ -1083,6 +1092,9 @@ pub struct OpPoolBuilder<T = crate::txpool::OpPooledTransaction> {
     pub interop_min_responses: Option<usize>,
     /// Safety level for interop filter validation.
     pub interop_safety_level: SafetyLevel,
+    /// Shared interop failsafe gate. The interop filter client writes it; the payload builder
+    /// reads it. Threaded in so both observe the same live state.
+    pub interop_failsafe: InteropFailsafe,
     /// Marker for the pooled transaction type.
     _pd: core::marker::PhantomData<T>,
 }
@@ -1095,6 +1107,7 @@ impl<T> Default for OpPoolBuilder<T> {
             interop_endpoints: Vec::new(),
             interop_min_responses: None,
             interop_safety_level: SafetyLevel::CrossUnsafe,
+            interop_failsafe: InteropFailsafe::default(),
             _pd: Default::default(),
         }
     }
@@ -1108,6 +1121,7 @@ impl<T> Clone for OpPoolBuilder<T> {
             interop_endpoints: self.interop_endpoints.clone(),
             interop_min_responses: self.interop_min_responses,
             interop_safety_level: self.interop_safety_level,
+            interop_failsafe: self.interop_failsafe.clone(),
             _pd: core::marker::PhantomData,
         }
     }
@@ -1141,6 +1155,13 @@ impl<T> OpPoolBuilder<T> {
         self.interop_endpoints = interop_endpoints;
         self.interop_min_responses = interop_min_responses;
         self.interop_safety_level = interop_safety_level;
+        self
+    }
+
+    /// Shares the interop failsafe gate with the pool builder, so the interop filter client it
+    /// constructs writes the same flag the payload builder reads.
+    pub fn with_interop_failsafe(mut self, interop_failsafe: InteropFailsafe) -> Self {
+        self.interop_failsafe = interop_failsafe;
         self
     }
 }
@@ -1180,7 +1201,8 @@ where
                 self.interop_endpoints.clone(),
                 ctx.chain_spec().chain_id(),
             )
-            .minimum_safety(self.interop_safety_level);
+            .minimum_safety(self.interop_safety_level)
+            .failsafe(self.interop_failsafe.clone());
             if let Some(min) = self.interop_min_responses {
                 builder = builder.min_responses(min);
             }
@@ -1302,6 +1324,9 @@ pub struct OpPayloadBuilder<Txs = ()> {
     pub gas_limit_config: OpGasLimitConfig,
     /// Operator opt-in flag for SDM `PostExec` production. Shared with the admin RPC.
     pub sdm_post_exec_opt_in: SdmPostExecOptIn,
+    /// Interop failsafe gate. Shared with the txpool interop filter client; read by the payload
+    /// builder to exclude interop txs from blocks while it is active.
+    pub interop_failsafe: InteropFailsafe,
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
     ///
     /// `None` disables the limit. See
@@ -1319,6 +1344,7 @@ impl OpPayloadBuilder {
             da_config: OpDAConfig::default(),
             gas_limit_config: OpGasLimitConfig::default(),
             sdm_post_exec_opt_in: SdmPostExecOptIn::default(),
+            interop_failsafe: InteropFailsafe::default(),
             max_uncompressed_block_size: None,
         }
     }
@@ -1350,6 +1376,14 @@ impl OpPayloadBuilder {
         self.sdm_post_exec_opt_in = sdm_post_exec_opt_in;
         self
     }
+
+    /// Provide the shared interop failsafe gate, read by the builder to exclude interop txs while
+    /// the failsafe is active.
+    #[must_use]
+    pub fn with_interop_failsafe(mut self, interop_failsafe: InteropFailsafe) -> Self {
+        self.interop_failsafe = interop_failsafe;
+        self
+    }
 }
 
 impl<Txs> OpPayloadBuilder<Txs> {
@@ -1361,6 +1395,7 @@ impl<Txs> OpPayloadBuilder<Txs> {
             da_config,
             gas_limit_config,
             sdm_post_exec_opt_in,
+            interop_failsafe,
             max_uncompressed_block_size,
             ..
         } = self;
@@ -1370,6 +1405,7 @@ impl<Txs> OpPayloadBuilder<Txs> {
             da_config,
             gas_limit_config,
             sdm_post_exec_opt_in,
+            interop_failsafe,
             max_uncompressed_block_size,
         }
     }
@@ -1421,6 +1457,7 @@ where
                 da_config: self.da_config.clone(),
                 gas_limit_config: self.gas_limit_config.clone(),
                 sdm_post_exec_opt_in: self.sdm_post_exec_opt_in.clone(),
+                interop_failsafe: self.interop_failsafe.clone(),
                 max_uncompressed_block_size: self.max_uncompressed_block_size,
             },
         )

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -978,11 +978,9 @@ where
         let tx_da_limit = self.builder_config.da_config.max_da_tx_size();
         let max_uncompressed_block_size = self.builder_config.max_uncompressed_block_size;
         let base_fee = builder.evm_mut().block().basefee();
-        // Snapshot the interop failsafe once for this build. When the supervisor failsafe is
-        // active, no interop transaction may be sealed into an unsafe block. Gating here, rather
-        // than relying solely on asynchronous pool eviction, means a tx that bypassed the interop
-        // filter (e.g. a private or locally-submitted tx) is still excluded the moment the gate
-        // flips on, and the builder no longer races pool eviction to drain interop txs.
+        // Snapshot the interop failsafe once for this build. Gating here, rather than relying on
+        // async pool eviction, excludes interop txs that bypassed the filter (e.g. private or
+        // local txs) and avoids racing eviction to drain the pool.
         let interop_failsafe_active = self.builder_config.interop_failsafe.enabled();
 
         while let Some(tx) = best_txs.next(()) {
@@ -1029,8 +1027,7 @@ where
                 continue;
             }
 
-            // While the interop failsafe is active, exclude every interop tx (identified by its
-            // CrossL2Inbox access list) regardless of whether it carries an interop deadline.
+            // While the failsafe is active, exclude every interop tx regardless of its deadline.
             if interop_failsafe_active && is_interop_tx(&*tx) {
                 best_txs.mark_invalid(tx.signer(), tx.nonce());
                 continue;

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -35,7 +35,7 @@ use reth_optimism_primitives::{L2_TO_L1_MESSAGE_PASSER_ADDRESS, OpTransaction};
 use reth_optimism_txpool::{
     OpPooledTx,
     estimated_da_size::DataAvailabilitySized,
-    interop::{MaybeInteropTransaction, is_valid_interop},
+    interop::{MaybeInteropTransaction, is_interop_tx, is_valid_interop},
 };
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::{BuildNextEnv, BuiltPayloadExecutedBlock};
@@ -978,6 +978,12 @@ where
         let tx_da_limit = self.builder_config.da_config.max_da_tx_size();
         let max_uncompressed_block_size = self.builder_config.max_uncompressed_block_size;
         let base_fee = builder.evm_mut().block().basefee();
+        // Snapshot the interop failsafe once for this build. When the supervisor failsafe is
+        // active, no interop transaction may be sealed into an unsafe block. Gating here, rather
+        // than relying solely on asynchronous pool eviction, means a tx that bypassed the interop
+        // filter (e.g. a private or locally-submitted tx) is still excluded the moment the gate
+        // flips on, and the builder no longer races pool eviction to drain interop txs.
+        let interop_failsafe_active = self.builder_config.interop_failsafe.enabled();
 
         while let Some(tx) = best_txs.next(()) {
             let interop = tx.interop_deadline();
@@ -1019,6 +1025,13 @@ where
 
             // A sequencer's block should never contain blob or deposit transactions from the pool.
             if tx.is_eip4844() || tx.is_deposit() {
+                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                continue;
+            }
+
+            // While the interop failsafe is active, exclude every interop tx (identified by its
+            // CrossL2Inbox access list) regardless of whether it carries an interop deadline.
+            if interop_failsafe_active && is_interop_tx(&*tx) {
                 best_txs.mark_invalid(tx.signer(), tx.nonce());
                 continue;
             }

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -22,8 +22,10 @@ use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
 use reth_optimism_evm::{OpEvmConfig, PostExecMode};
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_optimism_txpool::{
-    OpPooledTransaction, OpPooledTx, conditional::MaybeConditionalTransaction,
-    estimated_da_size::DataAvailabilitySized, interop::MaybeInteropTransaction,
+    OpPooledTransaction, OpPooledTx,
+    conditional::MaybeConditionalTransaction,
+    estimated_da_size::DataAvailabilitySized,
+    interop::{InteropFailsafe, MaybeInteropTransaction},
     interop_filter::CROSS_L2_INBOX_ADDRESS,
 };
 use reth_payload_builder_primitives::PayloadBuilderError;
@@ -645,7 +647,9 @@ fn miner_fee_uses_pool_wrapper_tip() {
 
 /// With the failsafe active the builder excludes interop txs but keeps normal txs; with it off the
 /// same interop tx is included — proving the gate is flag-driven, not a blanket exclusion, and does
-/// not depend on the pool's interop-deadline marker.
+/// not depend on the pool's interop-deadline marker. Clearing the flag and rebuilding includes the
+/// interop tx again, proving the exclusion is a per-build decision and the `mark_invalid` it
+/// triggers does not stick across builds.
 #[test]
 fn execute_best_transactions_excludes_interop_txs_when_failsafe_active() {
     let signer = Address::repeat_byte(0x11);
@@ -657,21 +661,32 @@ fn execute_best_transactions_excludes_interop_txs_when_failsafe_active() {
     let gas_limit = 1_000_000;
     let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().regolith_activated().build());
 
-    // Failsafe off: both the normal and the interop tx are included.
-    let ctx = payload_builder_ctx(chain_spec.clone(), gas_limit);
-    let (_info, included) = run_execute_best_transactions_with_ctx(
-        ctx,
-        signer,
-        vec![normal.clone(), interop.clone()],
-        None,
-        None,
-    );
-    assert_eq!(included, vec![normal_hash, interop_hash]);
+    // One shared handle drives every build, mirroring the single failsafe threaded through node
+    // setup; toggling it is what flips the gate, not building a fresh config each time.
+    let failsafe = InteropFailsafe::default();
+    let build = |failsafe: &InteropFailsafe| {
+        let mut ctx = payload_builder_ctx(chain_spec.clone(), gas_limit);
+        ctx.builder_config.interop_failsafe = failsafe.clone();
+        let (_info, included) = run_execute_best_transactions_with_ctx(
+            ctx,
+            signer,
+            vec![normal.clone(), interop.clone()],
+            None,
+            None,
+        );
+        included
+    };
 
-    // Failsafe on: the interop tx is excluded, the normal tx is still included.
-    let ctx = payload_builder_ctx(chain_spec, gas_limit);
-    ctx.builder_config.interop_failsafe.set(true);
-    let (_info, included) =
-        run_execute_best_transactions_with_ctx(ctx, signer, vec![normal, interop], None, None);
-    assert_eq!(included, vec![normal_hash]);
+    // Failsafe off: both the normal and the interop tx are included.
+    failsafe.set(false);
+    assert_eq!(build(&failsafe), vec![normal_hash, interop_hash]);
+
+    // Failsafe on: the interop tx is excluded (marked invalid), the normal tx is still included.
+    failsafe.set(true);
+    assert_eq!(build(&failsafe), vec![normal_hash]);
+
+    // Failsafe cleared again: the same interop tx is included once more, confirming the previous
+    // build's `mark_invalid` did not permanently exclude it.
+    failsafe.set(false);
+    assert_eq!(build(&failsafe), vec![normal_hash, interop_hash]);
 }

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -166,9 +166,9 @@ fn op_pooled_tx(nonce: u64, signer: Address, recipient: Address) -> OpPooledTran
     OpPooledTransaction::new(Recovered::new_unchecked(tx, signer), encoded_len)
 }
 
-/// Builds an interop pool tx: an EIP-1559 tx whose access list targets `CROSS_L2_INBOX_ADDRESS`
-/// with a storage key, matching the intrinsic detection used by `is_interop_tx`. The gas limit
-/// covers the access-list intrinsic cost so the tx executes when the failsafe is off.
+/// Builds an interop pool tx: a `CROSS_L2_INBOX_ADDRESS` access-list entry makes `is_interop_tx`
+/// match it; the gas limit covers the access-list intrinsic cost so it executes when failsafe is
+/// off.
 fn op_interop_pooled_tx(nonce: u64, signer: Address, recipient: Address) -> OpPooledTransaction {
     let tx: OpTransactionSigned = TxEip1559 {
         chain_id: 8453,
@@ -643,10 +643,9 @@ fn miner_fee_uses_pool_wrapper_tip() {
     assert_ne!(info.total_fees, natural_fees);
 }
 
-/// When the interop failsafe is active, the builder must exclude interop transactions (detected by
-/// their `CrossL2Inbox` access list) while still including normal transactions. With the failsafe
-/// off, the same interop tx is included — proving the gate is conditional on the flag rather than a
-/// blanket exclusion, and that it does not depend on the pool's interop-deadline marker.
+/// With the failsafe active the builder excludes interop txs but keeps normal txs; with it off the
+/// same interop tx is included — proving the gate is flag-driven, not a blanket exclusion, and does
+/// not depend on the pool's interop-deadline marker.
 #[test]
 fn execute_best_transactions_excludes_interop_txs_when_failsafe_active() {
     let signer = Address::repeat_byte(0x11);

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -8,7 +8,7 @@ use alloy_consensus::{
 };
 use alloy_eips::{
     eip2718::{Encodable2718, WithEncoded},
-    eip2930::AccessList,
+    eip2930::{AccessList, AccessListItem},
     eip7702::SignedAuthorization,
 };
 use alloy_evm::RecoveredTx;
@@ -24,6 +24,7 @@ use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_optimism_txpool::{
     OpPooledTransaction, OpPooledTx, conditional::MaybeConditionalTransaction,
     estimated_da_size::DataAvailabilitySized, interop::MaybeInteropTransaction,
+    interop_filter::CROSS_L2_INBOX_ADDRESS,
 };
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_util::PayloadTransactionsFixed;
@@ -165,6 +166,31 @@ fn op_pooled_tx(nonce: u64, signer: Address, recipient: Address) -> OpPooledTran
     OpPooledTransaction::new(Recovered::new_unchecked(tx, signer), encoded_len)
 }
 
+/// Builds an interop pool tx: an EIP-1559 tx whose access list targets `CROSS_L2_INBOX_ADDRESS`
+/// with a storage key, matching the intrinsic detection used by `is_interop_tx`. The gas limit
+/// covers the access-list intrinsic cost so the tx executes when the failsafe is off.
+fn op_interop_pooled_tx(nonce: u64, signer: Address, recipient: Address) -> OpPooledTransaction {
+    let tx: OpTransactionSigned = TxEip1559 {
+        chain_id: 8453,
+        nonce,
+        gas_limit: 100_000,
+        max_fee_per_gas: 1,
+        max_priority_fee_per_gas: 1,
+        to: TxKind::Call(recipient),
+        value: U256::ZERO,
+        access_list: AccessList(vec![AccessListItem {
+            address: CROSS_L2_INBOX_ADDRESS,
+            storage_keys: vec![B256::ZERO],
+        }]),
+        ..Default::default()
+    }
+    .into_signed(Signature::test_signature())
+    .into();
+    let encoded_len = tx.encode_2718_len();
+
+    OpPooledTransaction::new(Recovered::new_unchecked(tx, signer), encoded_len)
+}
+
 fn tx_hashes<'a>(txs: impl IntoIterator<Item = &'a Recovered<OpTransactionSigned>>) -> Vec<TxHash> {
     txs.into_iter().map(|tx| *TxHashRef::tx_hash(tx)).collect()
 }
@@ -181,7 +207,23 @@ where
     let gas_limit = 1_000_000;
     let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().regolith_activated().build());
     let ctx = payload_builder_ctx(chain_spec, gas_limit);
+    run_execute_best_transactions_with_ctx(ctx, signer, txs, gas_limit_cap, committed_txs)
+}
 
+fn run_execute_best_transactions_with_ctx<T>(
+    ctx: OpPayloadBuilderCtx<
+        OpEvmConfig<OpChainSpec, OpPrimitives>,
+        OpChainSpec,
+        OpPayloadBuilderAttributes<OpTransactionSigned>,
+    >,
+    signer: Address,
+    txs: Vec<T>,
+    gas_limit_cap: Option<u64>,
+    committed_txs: Option<&mut Vec<Recovered<OpTransactionSigned>>>,
+) -> (ExecutionInfo, Vec<TxHash>)
+where
+    T: PoolTransaction<Consensus = OpTransactionSigned> + OpPooledTx,
+{
     let mut state_provider = StateProviderTest::default();
     state_provider.insert_account(
         signer,
@@ -599,4 +641,38 @@ fn miner_fee_uses_pool_wrapper_tip() {
     // somebody later tweaks the helper's fee fields and happens to land on `forced_priority_fee`.
     assert_eq!(info.total_fees, expected_fees);
     assert_ne!(info.total_fees, natural_fees);
+}
+
+/// When the interop failsafe is active, the builder must exclude interop transactions (detected by
+/// their `CrossL2Inbox` access list) while still including normal transactions. With the failsafe
+/// off, the same interop tx is included — proving the gate is conditional on the flag rather than a
+/// blanket exclusion, and that it does not depend on the pool's interop-deadline marker.
+#[test]
+fn execute_best_transactions_excludes_interop_txs_when_failsafe_active() {
+    let signer = Address::repeat_byte(0x11);
+    let normal = op_pooled_tx(0, signer, Address::repeat_byte(0x22));
+    let interop = op_interop_pooled_tx(1, signer, Address::repeat_byte(0x33));
+    let normal_hash = *normal.hash();
+    let interop_hash = *interop.hash();
+
+    let gas_limit = 1_000_000;
+    let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().regolith_activated().build());
+
+    // Failsafe off: both the normal and the interop tx are included.
+    let ctx = payload_builder_ctx(chain_spec.clone(), gas_limit);
+    let (_info, included) = run_execute_best_transactions_with_ctx(
+        ctx,
+        signer,
+        vec![normal.clone(), interop.clone()],
+        None,
+        None,
+    );
+    assert_eq!(included, vec![normal_hash, interop_hash]);
+
+    // Failsafe on: the interop tx is excluded, the normal tx is still included.
+    let ctx = payload_builder_ctx(chain_spec, gas_limit);
+    ctx.builder_config.interop_failsafe.set(true);
+    let (_info, included) =
+        run_execute_best_transactions_with_ctx(ctx, signer, vec![normal, interop], None, None);
+    assert_eq!(included, vec![normal_hash]);
 }

--- a/rust/op-reth/crates/payload/src/config.rs
+++ b/rust/op-reth/crates/payload/src/config.rs
@@ -15,8 +15,8 @@ pub struct OpBuilderConfig {
     pub gas_limit_config: OpGasLimitConfig,
     /// Local SDM `PostExec` production opt-in. Shared with the admin RPC.
     pub sdm_post_exec_opt_in: SdmPostExecOptIn,
-    /// Interop failsafe gate. Shared with the interop filter client, which sets it; the payload
-    /// builder reads it and excludes interop transactions from blocks while it is enabled.
+    /// Interop failsafe gate. Set by the interop filter client; read by the builder to exclude
+    /// interop txs from blocks while it is enabled.
     pub interop_failsafe: InteropFailsafe,
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
     ///

--- a/rust/op-reth/crates/payload/src/config.rs
+++ b/rust/op-reth/crates/payload/src/config.rs
@@ -1,5 +1,6 @@
 //! Additional configuration for the OP builder
 
+use reth_optimism_txpool::interop::InteropFailsafe;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicU64, Ordering},
@@ -14,6 +15,9 @@ pub struct OpBuilderConfig {
     pub gas_limit_config: OpGasLimitConfig,
     /// Local SDM `PostExec` production opt-in. Shared with the admin RPC.
     pub sdm_post_exec_opt_in: SdmPostExecOptIn,
+    /// Interop failsafe gate. Shared with the interop filter client, which sets it; the payload
+    /// builder reads it and excludes interop transactions from blocks while it is enabled.
+    pub interop_failsafe: InteropFailsafe,
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
     ///
     /// `None` disables the limit (the historical behavior). When set, the payload builder stops
@@ -32,6 +36,7 @@ impl OpBuilderConfig {
             da_config,
             gas_limit_config,
             sdm_post_exec_opt_in: SdmPostExecOptIn::default(),
+            interop_failsafe: InteropFailsafe::default(),
             max_uncompressed_block_size: None,
         }
     }

--- a/rust/op-reth/crates/txpool/src/interop.rs
+++ b/rust/op-reth/crates/txpool/src/interop.rs
@@ -8,12 +8,9 @@ use std::sync::{
 
 use crate::interop_filter::CROSS_L2_INBOX_ADDRESS;
 
-/// Returns true if the transaction's access list targets `CROSS_L2_INBOX_ADDRESS`
-/// with at least one storage key.
-///
-/// Detection is intrinsic to the transaction (its access list) rather than the pool's
-/// interop-deadline marker, so it identifies interop transactions even when they never went
-/// through interop validation (e.g. private or locally-submitted transactions).
+/// Returns true if the transaction's access list targets `CROSS_L2_INBOX_ADDRESS` with at least
+/// one storage key. Detection is intrinsic to the tx, so it also catches interop txs that never
+/// went through interop validation (e.g. private or locally-submitted txs).
 pub fn is_interop_tx<T>(tx: &T) -> bool
 where
     T: Transaction,
@@ -26,13 +23,9 @@ where
         .unwrap_or(false)
 }
 
-/// Shareable interop failsafe gate.
-///
-/// `false` on construction. The interop filter client writes it (the background poll task and the
-/// admission fast-path), while the payload builder reads it. When enabled, no interop transaction
-/// may be admitted to the pool or sealed into a block. Cloning shares the underlying flag, so a
-/// single handle threaded through node setup keeps the filter (writer) and the builder (reader) in
-/// sync.
+/// Shareable interop failsafe gate. The interop filter client writes it; the payload builder reads
+/// it to exclude interop txs while it is enabled. Cloning shares the flag, so one handle keeps the
+/// writer and reader in sync.
 #[derive(Debug, Clone, Default)]
 pub struct InteropFailsafe {
     inner: Arc<AtomicBool>,

--- a/rust/op-reth/crates/txpool/src/interop.rs
+++ b/rust/op-reth/crates/txpool/src/interop.rs
@@ -1,15 +1,22 @@
 //! Additional support for pooled interop transactions.
 
 use alloy_consensus::Transaction;
-use reth_transaction_pool::PoolTransaction;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 use crate::interop_filter::CROSS_L2_INBOX_ADDRESS;
 
 /// Returns true if the transaction's access list targets `CROSS_L2_INBOX_ADDRESS`
 /// with at least one storage key.
-pub(crate) fn is_interop_tx<T>(tx: &T) -> bool
+///
+/// Detection is intrinsic to the transaction (its access list) rather than the pool's
+/// interop-deadline marker, so it identifies interop transactions even when they never went
+/// through interop validation (e.g. private or locally-submitted transactions).
+pub fn is_interop_tx<T>(tx: &T) -> bool
 where
-    T: PoolTransaction + Transaction,
+    T: Transaction,
 {
     tx.access_list()
         .map(|al| {
@@ -17,6 +24,30 @@ where
                 .any(|item| item.address == CROSS_L2_INBOX_ADDRESS && !item.storage_keys.is_empty())
         })
         .unwrap_or(false)
+}
+
+/// Shareable interop failsafe gate.
+///
+/// `false` on construction. The interop filter client writes it (the background poll task and the
+/// admission fast-path), while the payload builder reads it. When enabled, no interop transaction
+/// may be admitted to the pool or sealed into a block. Cloning shares the underlying flag, so a
+/// single handle threaded through node setup keeps the filter (writer) and the builder (reader) in
+/// sync.
+#[derive(Debug, Clone, Default)]
+pub struct InteropFailsafe {
+    inner: Arc<AtomicBool>,
+}
+
+impl InteropFailsafe {
+    /// Returns the current failsafe state.
+    pub fn enabled(&self) -> bool {
+        self.inner.load(Ordering::Acquire)
+    }
+
+    /// Sets the failsafe state.
+    pub fn set(&self, enabled: bool) {
+        self.inner.store(enabled, Ordering::Release);
+    }
 }
 
 /// Helper trait that allows attaching an interop deadline.

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     InvalidCrossTx,
+    interop::InteropFailsafe,
     interop_filter::{
         ExecutingDescriptor, InteropTxValidatorError,
         metrics::{
@@ -28,7 +29,7 @@ use std::{
     future::IntoFuture,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicU64, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -261,14 +262,20 @@ impl InteropFilterClient {
 
     /// Returns the cached failsafe state.
     pub fn is_failsafe_enabled(&self) -> bool {
-        self.inner.failsafe_enabled.load(Ordering::Acquire)
+        self.inner.failsafe.enabled()
+    }
+
+    /// Returns a clone of the shared failsafe handle, so other components (e.g. the payload
+    /// builder) can read the same live state this client writes.
+    pub fn failsafe(&self) -> InteropFailsafe {
+        self.inner.failsafe.clone()
     }
 
     /// Applies a freshly polled failsafe state to the cached flag (read live by the admission
     /// fast-path and the block-event handler) and the gauge. Split out of [`Self::query_failsafe`]
     /// so the live, restart-free state transition can be exercised in tests without an RPC.
     pub(crate) fn apply_failsafe_state(&self, enabled: bool) {
-        self.inner.failsafe_enabled.store(enabled, Ordering::Release);
+        self.inner.failsafe.set(enabled);
         self.inner.metrics.set_failsafe_enabled(enabled);
     }
 
@@ -395,8 +402,10 @@ pub(crate) struct InteropFilterClientInner {
     timeout: Duration,
     /// Metrics for tracking interop RPC operations.
     metrics: InteropMetrics,
-    /// Cached failsafe state (OR across endpoints), polled by the background failsafe task.
-    failsafe_enabled: AtomicBool,
+    /// Cached failsafe state (OR across endpoints), polled by the background failsafe task. Shared
+    /// (via [`InteropFailsafe`] clones) with the payload builder so it can gate block building on
+    /// the same live state.
+    failsafe: InteropFailsafe,
     /// Reference instant for rate-limiting the degraded-quorum log.
     created_at: Instant,
     /// Millis (since [`created_at`](Self::created_at)) of the last degraded-quorum log; `0` means
@@ -421,6 +430,8 @@ pub struct InteropFilterClientBuilder {
     timeout: Duration,
     /// Minimum [`SafetyLevel`] of cross-chain transactions accepted by this client.
     safety: SafetyLevel,
+    /// Optional externally-shared failsafe handle. When `None`, the client creates its own.
+    failsafe: Option<InteropFailsafe>,
 }
 
 impl InteropFilterClientBuilder {
@@ -432,7 +443,15 @@ impl InteropFilterClientBuilder {
             chain_id,
             timeout: DEFAULT_REQUEST_TIMEOUT,
             safety: SafetyLevel::CrossUnsafe,
+            failsafe: None,
         }
+    }
+
+    /// Shares an externally-owned failsafe handle with the client, so other components (e.g. the
+    /// payload builder) read the same live state. Defaults to a freshly-created handle when unset.
+    pub fn failsafe(mut self, failsafe: InteropFailsafe) -> Self {
+        self.failsafe = Some(failsafe);
+        self
     }
 
     /// Configures a custom timeout
@@ -460,7 +479,7 @@ impl InteropFilterClientBuilder {
     /// endpoints. This is a startup-boundary validation, matching the existing
     /// `.expect("building interop filter client")` failure mode.
     pub async fn build(self) -> InteropFilterClient {
-        let Self { endpoints, min_responses, chain_id, timeout, safety } = self;
+        let Self { endpoints, min_responses, chain_id, timeout, safety, failsafe } = self;
 
         assert!(!endpoints.is_empty(), "interop filter client requires at least one endpoint");
         let min_responses = min_responses.unwrap_or(endpoints.len());
@@ -496,7 +515,7 @@ impl InteropFilterClientBuilder {
                 safety,
                 timeout,
                 metrics,
-                failsafe_enabled: AtomicBool::new(false),
+                failsafe: failsafe.unwrap_or_default(),
                 created_at: Instant::now(),
                 last_degraded_log_ms: AtomicU64::new(0),
             }),
@@ -999,7 +1018,7 @@ mod tests {
         let b = MockEndpoint::start(Verdict::Valid, Failsafe::Error).await;
         let client = client_for(&[&a, &b], None).await;
         // Seed a known cached value, then confirm an all-error poll leaves it unchanged and errors.
-        client.inner.failsafe_enabled.store(true, Ordering::Release);
+        client.inner.failsafe.set(true);
         assert!(client.query_failsafe().await.is_err());
         assert!(client.is_failsafe_enabled(), "cache should be unchanged when no endpoint replies");
     }

--- a/rust/op-reth/crates/txpool/src/interop_filter/client.rs
+++ b/rust/op-reth/crates/txpool/src/interop_filter/client.rs
@@ -265,8 +265,8 @@ impl InteropFilterClient {
         self.inner.failsafe.enabled()
     }
 
-    /// Returns a clone of the shared failsafe handle, so other components (e.g. the payload
-    /// builder) can read the same live state this client writes.
+    /// Returns a clone of the shared failsafe handle, so other components can read the state this
+    /// client writes.
     pub fn failsafe(&self) -> InteropFailsafe {
         self.inner.failsafe.clone()
     }
@@ -403,8 +403,7 @@ pub(crate) struct InteropFilterClientInner {
     /// Metrics for tracking interop RPC operations.
     metrics: InteropMetrics,
     /// Cached failsafe state (OR across endpoints), polled by the background failsafe task. Shared
-    /// (via [`InteropFailsafe`] clones) with the payload builder so it can gate block building on
-    /// the same live state.
+    /// with the payload builder so it gates block building on the same state.
     failsafe: InteropFailsafe,
     /// Reference instant for rate-limiting the degraded-quorum log.
     created_at: Instant,
@@ -447,8 +446,8 @@ impl InteropFilterClientBuilder {
         }
     }
 
-    /// Shares an externally-owned failsafe handle with the client, so other components (e.g. the
-    /// payload builder) read the same live state. Defaults to a freshly-created handle when unset.
+    /// Shares an externally-owned failsafe handle with the client. Defaults to a fresh handle when
+    /// unset.
     pub fn failsafe(mut self, failsafe: InteropFailsafe) -> Self {
         self.failsafe = Some(failsafe);
         self


### PR DESCRIPTION
## What & why

The op-reth payload builder never read the supervisor interop failsafe. During a failsafe window it kept sealing interop txs into unsafe blocks until async pool eviction caught up, and it never excluded interop txs that bypassed the filter (e.g. private or locally-submitted txs). This is a divergence from op-geth's miner, which gates production on the failsafe — and op-geth is the implementation being removed, so op-reth must own this gate.

## Change

- Add a shared `InteropFailsafe` handle (`Arc<AtomicBool>`) in `reth-optimism-txpool`, mirroring the existing `SdmPostExecOptIn` pattern.
- `InteropFilterClient` (the writer) now stores/updates this shared handle, with a builder `.failsafe(...)` option to inject it; `OpBuilderConfig` (the reader) carries a clone.
- The build loop in `execute_best_transactions` excludes every interop tx while the failsafe is active, detected intrinsically via its `CrossL2Inbox` access list (`is_interop_tx`) rather than the pool's interop-deadline marker — so interop txs that never went through the filter are caught too.
- One shared handle is threaded through node setup: `OpNode` → `OpPoolBuilder` (writer, via the filter client) and the `OpPayloadBuilder` service builder → `OpBuilderConfig` (reader).

The flag is read once per build (a consistent snapshot for the block); this does not change failsafe-detection latency (still bounded by the ~1s filter poll) — it closes the race where an in-flight build seals interop txs before pool eviction drains them, and covers interop txs that bypassed the filter.

Ref: RETH-3 / hardening H5.