### PR TITLE
docs(ai): add branch CI-failure diagnosis to ci-ops

### DIFF
--- a/docs/ai/ci-ops.md
+++ b/docs/ai/ci-ops.md
@@ -2,6 +2,25 @@
 
 This document provides guidance for AI agents working with CI/CD operational tasks in the Optimism monorepo.
 
+## Diagnosing a CI failure on a feature branch
+
+Before assuming a red check is caused by your change, rule out a failure the branch
+**inherited** — especially a long-lived branch that has drifted from `develop`:
+
+1. **Check the diff scope:** `git diff origin/develop...HEAD --name-only` (three dots).
+   If the failing test exercises code your branch never touches, it almost certainly
+   isn't your regression.
+2. **Check `develop`:** the failure may be a known flake, or a real bug a *later*
+   `develop` commit already fixed — your branch just predates the fix. Look for an open
+   flake issue or a recent fix PR touching the failing area.
+3. **Rebase onto latest `develop`** before deeper debugging — stale branches miss
+   upstream fixes, and a rebase often clears failures that were never about your change.
+
+Worked example (#21356): `go-tests-short` failed on `op-deployer` integration tests on a
+branch that only added a new `op-core/types` package. The diff touched nothing in
+`op-deployer`; the failures were a data-dependent flake already fixed on `develop` by
+#21396. Rebasing made CI green with no change to the branch's own work.
+
 ## TODO Checker Failures
 
 The repo runs a scheduled CircleCI job every 4 hours that validates TODO comments don't reference closed GitHub issues. When this job fails, issues need to be reopened.


### PR DESCRIPTION
## Description

Captures a diagnostic pattern from the `op-core/types` decoupling work (#21356): when CI fails on a long-lived feature branch, rule out a failure the branch **inherited** before assuming it's your regression — check the diff scope (`git diff origin/develop...HEAD --name-only`), look for a fix/known-flake already on `develop`, and rebase, which often clears failures that were never about your change.

Adds a short `## Diagnosing a CI failure on a feature branch` section to `docs/ai/ci-ops.md` with the #21356 worked example (the `go-tests-short` failures there were pre-existing op-deployer flakes already fixed on develop by #21396, not the PR's change).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)