### PR TITLE
ci(contracts-bedrock): cache submodules and pull them outside the test step

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -320,14 +320,46 @@ commands:
         type: string
         default: "0.8.15,0.8.19,0.8.25,0.8.28"
     steps:
-      - install-solc-compilers
+      - install-solc-compilers:
+          solc_versions: <<parameters.solc_versions>>
+      - run:
+          name: Record submodule pins for cache key
+          # Read the gitlink commit SHAs straight from the committed tree. The
+          # cache must key on dependency *pins*, not .gitmodules (which only holds
+          # URLs/paths and would serve stale libs across a bump). ls-tree reads the
+          # tree, so no clone is needed to compute the key.
+          command: git ls-tree -r HEAD packages/contracts-bedrock/lib | awk '$2 == "commit" { print $3, $4 }' > .contracts-submodule-pins
+      - restore_cache:
+          keys:
+            - contracts-submodules-v1-{{ checksum ".contracts-submodule-pins" }}
+            # Fall back to any prior cache so a pin bump fetches only the delta
+            # instead of a full cold clone; --force below reconciles the worktree.
+            - contracts-submodules-v1-
       - run:
           name: Install dependencies
           command: |
             # Manually craft the submodule update command in order to take advantage
-            # of the -j parameter, which speeds it up a lot.
+            # of the -j parameter, which speeds it up a lot. --force reconciles a
+            # worktree restored from a partial (fallback-key) cache hit.
             git submodule update --init --recursive --single-branch --force -j 8
           working_directory: packages/contracts-bedrock
+      - run:
+          name: Verify submodules are clean before caching
+          # Never persist a half-updated tree under the exact pin key: bail if any
+          # submodule is still uninitialized (-), out of sync (+), or conflicted (U).
+          command: |
+            if git submodule status --recursive | grep -E '^[-+U]'; then
+              echo "Submodules are not clean; refusing to save cache."
+              exit 1
+            fi
+      - save_cache:
+          key: contracts-submodules-v1-{{ checksum ".contracts-submodule-pins" }}
+          paths:
+            # Submodule object stores (including nested) live under the repo-root
+            # .git/modules; the worktrees live under lib/. Cache both so the
+            # restored `git submodule update` is a near no-op, not a re-fetch.
+            - .git/modules
+            - packages/contracts-bedrock/lib
 
   # Notifies us on Slack a build fails on develop
   notify-failures-on-develop:
@@ -1028,7 +1060,11 @@ jobs:
           working_directory: packages/contracts-bedrock
       - check-changed:
           patterns: <<parameters.check_changed_patterns>>
-      - install-solc-compilers
+      # Install solc + submodules in their own (cached) step. Previously this job
+      # had no submodule step, so `forge test` cloned ~19 submodules lazily inside
+      # the "Run tests" step, where the clone shared that step's no_output_timeout
+      # and a quiet setup stall could reap the whole step before any test ran.
+      - install-contracts-dependencies
       - run:
           name: Print dependencies
           command: just dep-status


### PR DESCRIPTION
## Problem

`contracts-bedrock-tests` (e.g. the `CUSTOM_GAS_TOKEN` feature variant) is the one contracts job that **never explicitly installs submodules** — it calls bare `install-solc-compilers` and relies on `forge test` to lazily run `git submodule update --init --recursive` for itself.

Because that lazy clone happens *inside* the `Run tests` step, the ~19 (nested) submodule clones share that step's `no_output_timeout: 20m`. If the setup phase goes quiet for 20 minutes (network/disk stall right at the clone→`forge build` handoff), CircleCI's no-output watchdog reaps the whole step **before a single test runs**.

This is exactly what happened on develop in [job 5229042](https://circleci.com/gh/ethereum-optimism/optimism/5229042): 6,777 of 6,820 output lines were submodule-clone progress, the last line was the final nested submodule reporting `Resolving deltas: 100% done`, then 20 minutes of silence → `Too long with no output (exceeded 20m0s)`. The next develop run passed, confirming it was an environmental stall, not a code failure — but the job's structure makes it recurrable.

## Fix

Two changes, both in `.circleci/continue/main.yml`:

1. **Move submodule install out of the test step.** `contracts-bedrock-tests` now calls `install-contracts-dependencies` instead of bare `install-solc-compilers`, so solc + submodules install in their own step and `Run tests` gets a clean 20m budget for tests only. Solc behavior is unchanged (same default versions; the command's `solc_versions` param now actually propagates, which it silently didn't before).

2. **Cache the submodules** inside `install-contracts-dependencies` (benefits all 11 callers):
   - Key on a checksum of the recorded **gitlink pin SHAs** (`git ls-tree` of `packages/contracts-bedrock/lib`), *not* `.gitmodules` — `.gitmodules` only holds URLs/paths and wouldn't bust the cache when a dependency pin is bumped.
   - Cache both the object store (repo-root `.git/modules`, which holds nested submodule objects too) and the worktrees (`packages/contracts-bedrock/lib`), so the restored `git submodule update` is a near no-op rather than a re-fetch.
   - A fallback key lets a pin bump fetch only the delta instead of a cold clone; the existing `--force` reconciles the worktree.
   - The save is guarded behind a clean `git submodule status`, so a half-updated tree is never persisted under the exact pin key (CircleCI caches are immutable).

## Notes / risk

- Healthy runs are unaffected by the verify step (clean status → no-op).
- Worst case for the cache is "no speedup" (re-fetch), not breakage.
- Cache key busts precisely on a dependency pin change.
