### PR TITLE
chore(docker): retry package installs and network fetches in CI builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ More detailed guidance for AI agents can be found in:
 
 - [docs/ai/ci-ops.md](docs/ai/ci-ops.md) - CI/CD operations
 - [docs/ai/ci-config-review.md](docs/ai/ci-config-review.md) - Reviewing changes to CI config (`.circleci/`, `.github/workflows/`): gate coverage, required checks, path filtering, caching, plus general CircleCI/GHA best practices
+- [docs/ai/docker.md](docs/ai/docker.md) - Docker image builds: making every external fetch (apt/apk/curl/wget) retry so registry/CDN blips don't flake CI
 - [docs/ai/contract-dev.md](docs/ai/contract-dev.md) - Smart contract development
 - [docs/ai/dispute-game-investigation.md](docs/ai/dispute-game-investigation.md) - Investigating fault dispute games: challenger disagreements, excessive moves, self-contradiction, proposal validity, diagnosing the responsible op-node, and the bond outcome (read-only)
 - [docs/ai/flake-prevention.md](docs/ai/flake-prevention.md) - Guidance for preventing flaky tests

--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -7,8 +7,9 @@ ENV GOFLAGS=-mod=readonly
 # Install just from GitHub releases to match the version pinned in mise.toml.
 # The Alpine package is too old and doesn't support the [script] attribute
 # used in testdata justfiles.
-RUN apk add --no-cache bash curl && \
-    curl -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin --tag 1.46.0
+# apk has no built-in download retry; loop so a transient CDN drop doesn't flake CI (~5 min budget).
+RUN n=0; until apk add --no-cache bash curl; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done && \
+    curl -sSf --retry 5 --retry-all-errors --retry-delay 2 https://just.systems/install.sh | bash -s -- --to /usr/local/bin --tag 1.46.0
 
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum

--- a/docs/ai/ci-ops.md
+++ b/docs/ai/ci-ops.md
@@ -2,6 +2,8 @@
 
 This document provides guidance for AI agents working with CI/CD operational tasks in the Optimism monorepo.
 
+For Docker image build failures — especially flaky `apt`/`apk`/`curl` downloads from package registries and CDNs — see [docker.md](docker.md).
+
 ## Diagnosing a CI failure on a feature branch
 
 Before assuming a red check is caused by your change, rule out a failure the branch

--- a/docs/ai/docker.md
+++ b/docs/ai/docker.md
@@ -1,0 +1,56 @@
+# Docker Builds
+
+Guidance for writing and editing Dockerfiles in the monorepo.
+
+The overriding rule: **every external network fetch must retry.** The package registries
+and CDNs these builds depend on — `dl-cdn.alpinelinux.org`, `apk.cgr.dev`, the Debian/Ubuntu
+mirrors, GitHub releases — intermittently drop connections or return transient server errors.
+Unwrapped, each one is a CI flake.
+
+Use each tool's own retry mechanism; there is no shared retry script to keep in sync.
+
+## apt / apt-get
+
+Add `-o Acquire::Retries=8` to every invocation (`update`, `upgrade`, `install`):
+
+```dockerfile
+RUN apt-get -o Acquire::Retries=8 update \
+ && apt-get -o Acquire::Retries=8 install -y --no-install-recommends ca-certificates
+```
+
+## curl / wget
+
+Use the built-in retry flags. They may appear before or after the URL:
+
+```dockerfile
+RUN curl -fL --retry 5 --retry-all-errors --retry-delay 2 -o out.tgz "$URL"
+RUN wget --tries=5 --waitretry=5 --retry-connrefused -O out.tgz "$URL"
+```
+
+`--retry-all-errors` requires curl ≥ 7.71 (true for every base image used here). For a
+`curl ... | sh` install, the retry still covers the download of the script.
+
+## apk
+
+apk has no built-in download retry, so wrap it in a bounded loop that **exits non-zero when
+the budget is exhausted** — so a genuine breakage (e.g. a renamed package) still fails the
+build instead of being masked:
+
+```dockerfile
+# ~5 min budget: up to 15 attempts, 20s apart.
+RUN n=0; until apk add --no-cache ca-certificates openssl; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
+```
+
+Do **not** write `for i in ...; do apk add ... && break; done` — that loop exits `0` even when
+every attempt failed, masking real errors.
+
+Keep `--no-cache`: it makes each build pull the latest package index, and a BuildKit cache
+mount would defeat that. apk is the registry that flakes most in CI, which is why it gets the
+most generous (~5 min) budget.
+
+## Checklist when touching a Dockerfile
+
+- Every `apt-get`/`apt` install carries `-o Acquire::Retries=8`.
+- Every `curl`/`wget` carries its retry flags.
+- Every `apk add` is wrapped in the retry loop above.
+- Retries wrap only network steps — never build/compile steps.

--- a/op-up/Dockerfile
+++ b/op-up/Dockerfile
@@ -3,7 +3,7 @@ ENTRYPOINT ["/op-up"]
 COPY op-up /op-up
 
 # Install ca-certificates so that HTTPS requests work
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 install -y ca-certificates
 
 # Symlink onto the PATH
 RUN ln -s /op-up /usr/local/bin/op-up

--- a/ops/docker/ci-base-clang/Dockerfile
+++ b/ops/docker/ci-base-clang/Dockerfile
@@ -16,9 +16,9 @@ USER root
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update \
- && apt-get upgrade -y \
- && apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=8 update \
+ && apt-get -o Acquire::Retries=8 upgrade -y \
+ && apt-get -o Acquire::Retries=8 install -y --no-install-recommends \
       clang \
       llvm-dev \
       libclang-dev \
@@ -34,7 +34,7 @@ RUN set -eux; \
       *) echo "Unsupported TARGETARCH: ${TARGETARCH}"; exit 1 ;; \
     esac; \
     ASSET="sccache-v${SCCACHE_VERSION}-${ARCH_TAG}"; \
-    curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${ASSET}.tar.gz" -o /tmp/sccache.tgz; \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${ASSET}.tar.gz" -o /tmp/sccache.tgz; \
     echo "${EXPECTED_SHA256}  /tmp/sccache.tgz" | sha256sum -c -; \
     tar -xzf /tmp/sccache.tgz -C /tmp; \
     install "/tmp/${ASSET}/sccache" /usr/local/bin/sccache; \

--- a/ops/docker/deployment-utils/Dockerfile
+++ b/ops/docker/deployment-utils/Dockerfile
@@ -10,14 +10,14 @@ ENV PATH=/root/.cargo/bin:/root/.foundry/bin:$PATH
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SHELL=/bin/bash
 
-RUN apt-get update && apt-get install -y curl git jq build-essential
+RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 install -y curl git jq build-essential
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh && \
+RUN curl --proto '=https' --tlsv1.2 -sSf --retry 5 --retry-all-errors --retry-delay 2 https://sh.rustup.rs > rustup.sh && \
   chmod +x ./rustup.sh && \
   sh rustup.sh -y
 
 RUN source $HOME/.profile && rustup update nightly
-RUN curl -L https://foundry.paradigm.xyz | bash
+RUN curl -L --retry 5 --retry-all-errors --retry-delay 2 https://foundry.paradigm.xyz | bash
 RUN foundryup
 
 FROM debian:12.7-slim
@@ -25,7 +25,7 @@ FROM debian:12.7-slim
 ENV PATH=/root/.cargo/bin:/root/.foundry/bin:$PATH
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y bash curl jq
+RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 install -y bash curl jq
 
 SHELL ["/bin/bash", "-c"]
 

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -18,7 +18,8 @@ FROM alpine:3.21 AS builder_foundry
 # Build args are only-available in top-level by default, so we'll need to declare it inside the stage too
 ARG TARGETARCH
 
-RUN apk add --no-cache curl bash git jq
+# apk has no built-in download retry; loop so a transient CDN drop doesn't flake CI (~5 min budget).
+RUN n=0; until apk add --no-cache curl bash git jq; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
 
 COPY ./op-deployer/pkg/deployer/forge/version.json /tmp/op-deployer-versions.json
 
@@ -33,7 +34,7 @@ RUN <<-EOF
     DOWNLOAD_PATH="/tmp/forge.tar.gz"
 
     # Download the artifact archive
-    curl -fL -o ${DOWNLOAD_PATH} "${FOUNDRY_URL}"
+    curl -fL --retry 5 --retry-all-errors --retry-delay 2 -o ${DOWNLOAD_PATH} "${FOUNDRY_URL}"
 
     # Ensure the checksum matches our expectations
     ACTUAL_SHA="$(sha256sum "${DOWNLOAD_PATH}" | awk '{print $1}')"
@@ -55,7 +56,8 @@ FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS builder
 # silently mutate them. Fails the build if the lockfile is out of date.
 ENV GOFLAGS=-mod=readonly
 
-RUN apk add --no-cache curl tar gzip make gcc musl-dev linux-headers git jq yq-go zip bash just
+# apk has no built-in download retry; loop so a transient CDN drop doesn't flake CI (~5 min budget).
+RUN n=0; until apk add --no-cache curl tar gzip make gcc musl-dev linux-headers git jq yq-go zip bash just; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
 
 ARG TARGETARCH
 
@@ -181,7 +183,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 FROM --platform=$BUILDPLATFORM golang:1.26.4-bookworm AS op-deployer-contracts
 ARG BUILDARCH
 ENV GOFLAGS=-mod=readonly
-RUN apt-get update && apt-get install -y --no-install-recommends curl jq git && rm -rf /var/lib/apt/lists/*
+RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 install -y --no-install-recommends curl jq git && rm -rf /var/lib/apt/lists/*
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
 WORKDIR /app
@@ -194,7 +196,7 @@ RUN <<-EOF
     FOUNDRY_PLATFORM=linux_${BUILDARCH}
     FOUNDRY_URL="https://github.com/foundry-rs/foundry/releases/download/${FOUNDRY_VERSION}/foundry_${FOUNDRY_VERSION}_${FOUNDRY_PLATFORM}.tar.gz"
     DOWNLOAD_PATH="/tmp/forge.tar.gz"
-    curl -fL -o "${DOWNLOAD_PATH}" "${FOUNDRY_URL}"
+    curl -fL --retry 5 --retry-all-errors --retry-delay 2 -o "${DOWNLOAD_PATH}" "${FOUNDRY_URL}"
     ACTUAL_SHA="$(sha256sum "${DOWNLOAD_PATH}" | awk '{print $1}')"
     EXPECTED_SHA="$(jq -r --arg arch "${FOUNDRY_PLATFORM}" '.checksums[$arch]' op-deployer/pkg/deployer/forge/version.json)"
     [ "${ACTUAL_SHA}" = "${EXPECTED_SHA}" ] || (echo "Forge checksum mismatch: Expected $EXPECTED_SHA, got $ACTUAL_SHA" && exit 1)
@@ -237,7 +239,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 FROM --platform=$BUILDPLATFORM rust:1.94 AS kona-host-builder
 ARG TARGETARCH
 # Install build dependencies and cross-compilation toolchains
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 install -y --no-install-recommends \
   build-essential \
   libssl-dev \
   clang \
@@ -280,7 +282,7 @@ CMD ["op-node"]
 
 # Also produce an op-challenger loaded with kona using ubuntu
 FROM $UBUNTU_TARGET_BASE_IMAGE AS op-challenger-target
-RUN apt-get update && apt-get install -y --no-install-recommends musl openssl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 install -y --no-install-recommends musl openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=op-challenger-builder /app/op-challenger/bin/op-challenger /usr/local/bin/
 # Copy in cannon
 COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/

--- a/rust/kona/docker/apps/kona_app_generic.dockerfile
+++ b/rust/kona/docker/apps/kona_app_generic.dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:22.04 AS dep-setup-stage
 SHELL ["/bin/bash", "-c"]
 
 # Install deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 install -y --no-install-recommends \
   build-essential \
   git \
   curl \
@@ -19,11 +19,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install rust
 ENV RUST_VERSION=1.94
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal
+RUN curl https://sh.rustup.rs -sSf --retry 5 --retry-all-errors --retry-delay 2 | bash -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install cargo-binstall
-RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+RUN curl -L --proto '=https' --tlsv1.2 -sSf --retry 5 --retry-all-errors --retry-delay 2 https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
 RUN cargo binstall cargo-chef cargo-auditable -y
 
@@ -100,12 +100,8 @@ ARG UID=10001
 ARG GID=10001
 
 # Install ca-certificates, openssl, libstdc++ for TLS + C++ runtime support.
-RUN apk add --no-cache \
-  ca-certificates \
-  openssl \
-  libstdc++ \
-  bash \
-  shadow
+# apk has no built-in download retry; loop so a transient CDN drop doesn't flake CI (~5 min budget).
+RUN n=0; until apk add --no-cache ca-certificates openssl libstdc++ bash shadow; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
 
 RUN update-ca-certificates
 

--- a/rust/kona/docker/asterisc/asterisc.dockerfile
+++ b/rust/kona/docker/asterisc/asterisc.dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # todo: pin `nightly` version
 ENV RUST_VERSION nightly
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
+RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 install --assume-yes --no-install-recommends \
   ca-certificates \
   build-essential \
   curl \
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
   git
 
 # Install Rustup and Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain ${RUST_VERSION} --component rust-src
+RUN curl https://sh.rustup.rs -sSf --retry 5 --retry-all-errors --retry-delay 2 | bash -s -- -y --default-toolchain ${RUST_VERSION} --component rust-src
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Set up the env vars to instruct rustc to use the correct compiler and linker

--- a/rust/kona/docker/cannon/cannon.dockerfile
+++ b/rust/kona/docker/cannon/cannon.dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # MIPS64 cross-compilation toolchain — the only thing that must be frozen
 # in a Docker image because apt package versions are not deterministically pinnable.
 # Everything else (Rust, Go, mise, just) is installed on top from pinned version sources.
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
+RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 install --assume-yes --no-install-recommends \
   ca-certificates \
   build-essential \
   curl \

--- a/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -11,7 +11,9 @@
 
 FROM golang:1.26.4-alpine3.22 AS cannon-build
 
-RUN apk add --no-cache bash just
+# apk has no built-in download retry; loop so a transient CDN drop doesn't flake CI (~5 min budget).
+# Retrying the identical apk add does not affect the reproducible cannon/prestate output.
+RUN n=0; until apk add --no-cache bash just; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
 
 COPY go.mod go.sum /app/
 COPY cannon/ /app/cannon/

--- a/rust/kona/docker/recipes/kona-node-dev/kona-node/kona-node.dockerfile
+++ b/rust/kona/docker/recipes/kona-node-dev/kona-node/kona-node.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-RUN apt-get update -y && apt-get upgrade -y && apt install -y ca-certificates
+RUN apt-get -o Acquire::Retries=8 update -y && apt-get -o Acquire::Retries=8 upgrade -y && apt-get -o Acquire::Retries=8 install -y ca-certificates
 
 WORKDIR /
 

--- a/rust/op-reth/DockerfileOp
+++ b/rust/op-reth/DockerfileOp
@@ -4,7 +4,7 @@ WORKDIR /app
 LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
 LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
 
-RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 -y upgrade && apt-get -o Acquire::Retries=8 install -y libclang-dev pkg-config
 RUN cargo install cargo-auditable
 
 # Builds a cargo-chef plan
@@ -45,7 +45,8 @@ RUN cp /app/target/$BUILD_PROFILE/op-reth /app/op-reth
 
 FROM chainguard/wolfi-base:latest AS runtime
 
-RUN apk add --no-cache ca-certificates openssl libstdc++ strace
+# apk has no built-in download retry; loop so a transient CDN drop doesn't flake CI (~5 min budget).
+RUN n=0; until apk add --no-cache ca-certificates openssl libstdc++ strace; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
 
 WORKDIR /app
 COPY --from=builder /app/op-reth /usr/local/bin/


### PR DESCRIPTION
## What

CI Docker image builds regularly flake because package installs fail to download when a registry/CDN drops a connection or returns a server error — e.g. [this run](https://github.com/ethereum-optimism/optimism/actions/runs/27793231993/job/82247396136), and an `apk.cgr.dev` (Chainguard) server error observed on this PR's own first build.

This makes the network steps resilient using **each tool's own retry mechanism** — no shared script to keep in sync across Dockerfiles:

- **apt** → `-o Acquire::Retries=8` on every `apt-get`/`apt` invocation (apt's built-in download retry, with backoff).
- **curl / wget** → `--retry 5 --retry-all-errors --retry-delay 2`.
- **apk** (the only tool with no built-in retry) → a one-line `until` loop, ~15 attempts × 20s apart (~5 min budget), that **exits non-zero if it never succeeds** so a genuine breakage (e.g. a renamed package) still fails rather than being masked.

`apk --no-cache` is kept intentionally so builds still pull the latest package versions each time. Reliability is favoured over speed: the apk registries (`dl-cdn.alpinelinux.org`, `apk.cgr.dev`) are the ones actually observed flaking, and they get the generous ~5 min window.

Covers `ops/docker/*`, `op-up`, `cannon`, `rust/op-reth`, and the `rust/kona/docker/*` images. The vendored `rust/op-rbuilder` and `rust/rollup-boost` Dockerfiles are intentionally excluded (slated for deprecation per `docs/ai/rust-dev.md`).

Also adds `docs/ai/docker.md` documenting the rule (every external fetch in a Dockerfile must retry), referenced from the `AGENTS.md` doc index and cross-linked from `docs/ai/ci-ops.md`.

## Test plan

No Docker available locally to build the images. Verified:
- The apk `until` loop in POSIX `sh`: silent exit 0 on first-try success, exits 0 when a command recovers mid-sequence, and exits **non-zero** (not masked) after the full attempt budget is exhausted.
- `Acquire::Retries` is a real apt option; `-o Acquire::Retries=8` is valid in any position relative to the subcommand.
- The apk loop uses only POSIX constructs and runs under the default `/bin/sh` of every base image it's used in (alpine / golang-alpine / wolfi); no `SHELL ["/bin/bash"]` directive is in effect in those stages.
- `--retry-all-errors` is supported by the curl in every base image used (curl ≥ 7.71).

Real validation is the CI Docker builds on this PR.

### History
An earlier revision used a shared `retry` shell shim (heredoc / `retry-tool` stage). That was replaced with built-in retries to avoid duplicating/maintaining the script across the many Dockerfiles and heterogeneous build contexts.