### PR TITLE
feat(op-supernode): HTTP-backed remote interop nodes

### DIFF
--- a/op-supernode/config/config.go
+++ b/op-supernode/config/config.go
@@ -32,6 +32,10 @@ type CLIConfig struct {
 	// DependencySetPath is the path to a JSON dependency-set file shared by every chain
 	// managed by the supernode. Empty means fall back to per-chain registry lookup.
 	DependencySetPath string
+	// RemoteNodes lists remote interop nodes as "<chainID>=<url>" specs. Each names a
+	// chain the supernode does not drive, whose finalized initiating messages are polled
+	// from the URL via the remote-node HTTP protocol. Parsed in supernode.New.
+	RemoteNodes []string
 }
 
 func (c *CLIConfig) Check() error {
@@ -77,6 +81,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		RawCtx:                  ctx,
 		InteropLogBackfillDepth: ctx.Duration("interop.log-backfill-depth"),
 		DependencySetPath:       ctx.Path(flags.DependencySet.Name),
+		RemoteNodes:             ctx.StringSlice(flags.RemoteNodes.Name),
 	}
 	if ctx.IsSet("interop.activation-timestamp") {
 		ts := ctx.Uint64("interop.activation-timestamp")

--- a/op-supernode/flags/flags.go
+++ b/op-supernode/flags/flags.go
@@ -74,6 +74,11 @@ var (
 		EnvVars:   prefixEnvVars("DEPENDENCY_SET"),
 		TakesFile: true,
 	}
+	RemoteNodes = &cli.StringSliceFlag{
+		Name:    "interop.remote-nodes",
+		Usage:   "Remote interop nodes as <chainID>=<url> pairs (repeatable or comma-separated). Each is a chain the supernode does not drive: it polls the URL for that chain's finalized initiating messages via the remote-node HTTP protocol, so driven chains can reference them as executing messages.",
+		EnvVars: prefixEnvVars("INTEROP_REMOTE_NODES"),
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -85,6 +90,7 @@ var optionalFlags = []cli.Flag{
 	L1HTTPPollInterval,
 	DisableP2P,
 	DependencySet,
+	RemoteNodes,
 }
 
 // activityFlags holds flags registered by activity packages via RegisterActivityFlags.

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -173,11 +173,13 @@ func (i *Interop) verifyExecutingMessage(executingChain eth.ChainID, executingTi
 			executingChain, executingTimestamp, i.activationTimestamp, ErrExecutedTooEarly)
 	}
 
-	initChain, ok := i.chains[execMsg.ChainID]
+	// The initiating chain may be a driven chain or a remote (adapter-backed) source;
+	// both can originate initiating messages, so consult both for its block time.
+	initChainBlockTime, ok := i.initiatingBlockTime(execMsg.ChainID)
 	if !ok {
 		return fmt.Errorf("initiating chain %s not registered: %w", execMsg.ChainID, ErrUnknownChain)
 	}
-	if execMsg.Timestamp < i.activationTimestamp+initChain.BlockTime() {
+	if execMsg.Timestamp < i.activationTimestamp+initChainBlockTime {
 		return fmt.Errorf("initiating chain %s timestamp %d < activation %d + blockTime: %w",
 			execMsg.ChainID, execMsg.Timestamp, i.activationTimestamp, ErrInitiatedTooEarly)
 	}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -177,6 +177,11 @@ type Interop struct {
 	verifiedDB *VerifiedDB
 	logsDBs    map[eth.ChainID]LogsDB
 
+	// remoteNodes holds the finalized-only, adapter-backed ingesters for chains the
+	// supernode does not drive. Their initiating messages land in logsDBs (keyed by
+	// chain ID) so driven chains can reference them as executing messages.
+	remoteNodes map[eth.ChainID]*remoteNode
+
 	mu      sync.RWMutex
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -300,6 +305,7 @@ func New(
 		chains:              chains,
 		verifiedDB:          verifiedDB,
 		logsDBs:             logsDBs,
+		remoteNodes:         make(map[eth.ChainID]*remoteNode),
 		dataDir:             dataDir,
 		activationTimestamp: activationTimestamp,
 		messageExpiryWindow: messageExpiryWindow,
@@ -326,6 +332,8 @@ func (i *Interop) Start(ctx context.Context) error {
 	i.ctx, i.cancel = context.WithCancel(ctx)
 	i.started = true
 	i.mu.Unlock()
+
+	i.startRemoteNodes()
 
 	i.tryInitFromVerifiedDB()
 	return i.runLoop()

--- a/op-supernode/supernode/activity/interop/remote_engine_test.go
+++ b/op-supernode/supernode/activity/interop/remote_engine_test.go
@@ -1,0 +1,151 @@
+package interop
+
+import (
+	"context"
+	"encoding/binary"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+
+	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote/remotetest"
+)
+
+// encodeExecutingMessageLog builds a CrossL2Inbox ExecutingMessage log identifying the
+// given initiating message — the inverse of messages.DecodeExecutingMessageLog. The 160-byte
+// data layout is: [12 zero][20 origin] [24 zero][8 blockNumber] [28 zero][4 logIndex]
+// [24 zero][8 timestamp] [32 chainID].
+func encodeExecutingMessageLog(id messages.Identifier, payloadHash common.Hash) *types.Log {
+	data := make([]byte, 32*5)
+	copy(data[12:32], id.Origin.Bytes())
+	binary.BigEndian.PutUint64(data[56:64], id.BlockNumber)
+	binary.BigEndian.PutUint32(data[92:96], id.LogIndex)
+	binary.BigEndian.PutUint64(data[120:128], id.Timestamp)
+	cid := id.ChainID.Bytes32()
+	copy(data[128:160], cid[:])
+	return &types.Log{
+		Address: params.InteropCrossL2InboxAddress,
+		Topics:  []common.Hash{messages.ExecutingMessageEventTopic, payloadHash},
+		Data:    data,
+	}
+}
+
+// TestEngineVerifiesExecutingMessageFromRemoteNode is an engine-level end-to-end test: a
+// driven chain emits a real CrossL2Inbox executing-message log that references an
+// initiating message served by the mock remote node over HTTP. The log is sealed through
+// the production processBlockLogs path (real DecodeExecutingMessageLog) and validated by
+// the real verifyInteropMessages engine — proving an actual executing message, sourced by
+// a remote node, is accepted, and that a tampered reference is rejected.
+func TestEngineVerifiesExecutingMessageFromRemoteNode(t *testing.T) {
+	t.Parallel()
+
+	const (
+		activation = uint64(1000)
+		blockTime  = uint64(1)
+	)
+	remoteID := eth.ChainIDFromUInt64(8453)
+	drivenID := eth.ChainIDFromUInt64(10)
+
+	// Remote node: serve a deterministic chain over HTTP and ingest its block 1 into a real
+	// logsDB via the real HTTPAdapter. Block 1's timestamp = activation + blockTime = 1001.
+	chain := remotetest.New(remotetest.Config{
+		ChainID: remoteID, BlockTime: blockTime, MsgsPerBlock: 1, StartTimestamp: activation,
+	})
+	srv := httptest.NewServer(chain.Handler())
+	defer srv.Close()
+
+	remoteDB, err := openLogsDB(testLogger(), remoteID, t.TempDir())
+	require.NoError(t, err)
+	defer func() { _ = remoteDB.Close() }()
+	node := &remoteNode{
+		log:     testLogger(),
+		adapter: remote.NewHTTPAdapter(remoteID, srv.URL, srv.Client()),
+		db:      remoteDB,
+		poll:    defaultRemotePollInterval,
+	}
+	ingested, err := node.ingestOnce(context.Background())
+	require.NoError(t, err)
+	require.True(t, ingested)
+
+	const initBlock, initLogIdx = uint64(1), uint32(0)
+	initTimestamp := activation + blockTime // 1001
+
+	// The executing message identifies remote block 1, log 0.
+	initID := messages.Identifier{
+		Origin:      chain.Origin(initBlock, initLogIdx),
+		BlockNumber: initBlock,
+		LogIndex:    initLogIdx,
+		Timestamp:   initTimestamp,
+		ChainID:     remoteID,
+	}
+
+	// runRound seals a driven block carrying the given executing-message log through the
+	// production decode+seal path, runs the real verifyInteropMessages engine, and reports
+	// whether the driven chain was flagged invalid.
+	runRound := func(t *testing.T, logEntry *types.Log) (Result, bool) {
+		t.Helper()
+		drivenDB, err := openLogsDB(testLogger(), drivenID, t.TempDir())
+		require.NoError(t, err)
+		defer func() { _ = drivenDB.Close() }()
+
+		const drivenBlockNum = uint64(5)
+		drivenHash := common.HexToHash("0xd0e5")
+		l1Block := eth.BlockID{Number: 40, Hash: common.HexToHash("0x1")}
+		drivenChain := newMockChainWithL1(drivenID, l1Block, eth.BlockID{Number: drivenBlockNum, Hash: drivenHash})
+
+		i := &Interop{
+			log:                 testLogger(),
+			ctx:                 context.Background(),
+			activationTimestamp: activation,
+			messageExpiryWindow: defaultMessageExpiryWindow,
+			logsDBs:             map[eth.ChainID]LogsDB{drivenID: drivenDB, remoteID: remoteDB},
+			chains:              map[eth.ChainID]cc.InteropChain{drivenID: drivenChain},
+			remoteNodes:         map[eth.ChainID]*remoteNode{remoteID: node},
+		}
+
+		// Seal the driven block through the production decode+seal path.
+		blockInfo := &mockBlockInfo{
+			hash:       drivenHash,
+			parentHash: common.HexToHash("0xd0e4"),
+			number:     drivenBlockNum,
+			timestamp:  initTimestamp, // the executing block's timestamp
+		}
+		require.NoError(t, i.processBlockLogs(drivenDB, blockInfo, types.Receipts{
+			&types.Receipt{Logs: []*types.Log{logEntry}},
+		}))
+
+		// The log must actually decode to one executing message, so "accepted" below
+		// reflects a validated message rather than an empty (vacuously valid) block.
+		_, _, execMsgs, err := drivenDB.OpenBlock(drivenBlockNum)
+		require.NoError(t, err)
+		require.Len(t, execMsgs, 1, "driven block must carry exactly one decoded executing message")
+
+		blocks := map[eth.ChainID]eth.BlockID{drivenID: {Number: drivenBlockNum, Hash: drivenHash}}
+		result, err := i.verifyInteropMessages(initTimestamp, blocks, l1HeadsFromMocks(i.chains, blocks), nil)
+		require.NoError(t, err)
+		_, invalid := result.InvalidHeads[drivenID]
+		return result, invalid
+	}
+
+	t.Run("valid executing message is accepted", func(t *testing.T) {
+		logEntry := encodeExecutingMessageLog(initID, chain.PayloadHash(initBlock, initLogIdx))
+		result, invalid := runRound(t, logEntry)
+		require.False(t, invalid, "executing message referencing the remote node must be accepted")
+		require.Contains(t, result.L2Heads, drivenID)
+	})
+
+	t.Run("tampered reference is rejected", func(t *testing.T) {
+		// Wrong payload hash → the derived checksum no longer matches what the remote node
+		// sealed → conflict → invalid head.
+		logEntry := encodeExecutingMessageLog(initID, common.HexToHash("0xbadbad"))
+		_, invalid := runRound(t, logEntry)
+		require.True(t, invalid, "executing message with a tampered reference must be rejected")
+	})
+}

--- a/op-supernode/supernode/activity/interop/remote_node.go
+++ b/op-supernode/supernode/activity/interop/remote_node.go
@@ -1,0 +1,145 @@
+package interop
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+)
+
+// defaultRemotePollInterval bounds how often a remote node is polled for its next
+// finalized block when the adapter does not report a block time.
+const defaultRemotePollInterval = 2 * time.Second
+
+// remoteNode is the finalized-only analogue of a driving virtual node. Instead of
+// running a consensus client, it polls a remote.Adapter (in production, an HTTP client
+// pointed at a remote endpoint) for finalized blocks and seals their initiating messages
+// into the chain's LogsDB, so driven chains can reference them as executing messages.
+type remoteNode struct {
+	log     log.Logger
+	adapter remote.Adapter
+	db      LogsDB
+	poll    time.Duration
+}
+
+// AddRemoteNode registers a remote chain represented by the given adapter. It opens a
+// LogsDB for the adapter's chain (keyed by chain ID, the same map executing-message
+// validation reads from) and prepares an ingester that Start launches. It must be called
+// after New and before Start. The chain must not already be a driven chain.
+func (i *Interop) AddRemoteNode(adapter remote.Adapter) error {
+	chainID := adapter.ChainID()
+	if _, ok := i.chains[chainID]; ok {
+		return fmt.Errorf("chain %s is already a driven chain", chainID)
+	}
+	if _, ok := i.remoteNodes[chainID]; ok {
+		return fmt.Errorf("remote node for chain %s already registered", chainID)
+	}
+	db, err := openLogsDB(i.log, chainID, i.dataDir)
+	if err != nil {
+		return fmt.Errorf("open logsDB for remote chain %s: %w", chainID, err)
+	}
+	poll := defaultRemotePollInterval
+	if bt := adapter.BlockTime(); bt > 0 {
+		poll = time.Duration(bt) * time.Second
+	}
+	i.logsDBs[chainID] = db
+	i.remoteNodes[chainID] = &remoteNode{
+		log:     i.log.New("remote_chain", chainID.String()),
+		adapter: adapter,
+		db:      db,
+		poll:    poll,
+	}
+	i.log.Info("registered remote node", "chain", chainID, "blockTime", adapter.BlockTime())
+	return nil
+}
+
+// startRemoteNodes launches one background ingester per registered remote node. Each
+// runs until i.ctx is cancelled (Stop), then exits; the LogsDBs they write to are closed
+// by Stop's logsDBs cleanup.
+func (i *Interop) startRemoteNodes() {
+	for chainID, node := range i.remoteNodes {
+		i.log.Info("starting remote node ingester", "chain", chainID)
+		go node.run(i.ctx)
+	}
+}
+
+// run polls the adapter on a ticker, ingesting one finalized block per tick until the
+// context is cancelled.
+func (n *remoteNode) run(ctx context.Context) {
+	ticker := time.NewTicker(n.poll)
+	defer ticker.Stop()
+	for {
+		if _, err := n.ingestOnce(ctx); err != nil && ctx.Err() == nil {
+			n.log.Warn("remote node ingest failed, will retry", "err", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// ingestOnce pulls the next finalized block from the adapter and seals it into the
+// LogsDB. It returns (true, nil) if a block was ingested, (false, nil) if no new block
+// is finalized yet, or (false, err) on failure. The resume cursor is the LogsDB's latest
+// sealed block, so ingestion is idempotent across restarts.
+func (n *remoteNode) ingestOnce(ctx context.Context) (bool, error) {
+	var after uint64
+	if latest, ok := n.db.LatestSealedBlock(); ok {
+		after = latest.Number
+	}
+	blk, ok, err := n.adapter.NextFinalized(ctx, after)
+	if err != nil {
+		return false, fmt.Errorf("fetch next finalized after %d: %w", after, err)
+	}
+	if !ok {
+		return false, nil
+	}
+	if blk.Number != after+1 {
+		return false, fmt.Errorf("adapter returned non-contiguous block %d, expected %d", blk.Number, after+1)
+	}
+	if err := sealRemoteBlock(n.db, blk); err != nil {
+		return false, fmt.Errorf("seal remote block %d: %w", blk.Number, err)
+	}
+	n.log.Debug("ingested finalized remote block",
+		"number", blk.Number, "messages", len(blk.Messages), "timestamp", blk.Timestamp)
+	return true, nil
+}
+
+// sealRemoteBlock writes a remote chain's finalized block into its LogsDB. It mirrors
+// processBlockLogs but takes pre-extracted, normalized initiating messages instead of
+// receipts, and records no executing messages (a remote chain contributes initiating
+// messages only). Block numbering starts at 1; block 0 is the implicit genesis.
+func sealRemoteBlock(db LogsDB, blk *remote.FinalizedBlock) error {
+	if blk.Number == 0 {
+		return fmt.Errorf("remote block number must be >= 1 (block 0 is genesis)")
+	}
+	parentBlock := eth.BlockID{Hash: blk.ParentHash, Number: blk.Number - 1}
+	for _, m := range blk.Messages {
+		if err := db.AddLog(m.LogHash, parentBlock, m.LogIndex, nil); err != nil {
+			return fmt.Errorf("add log %d: %w", m.LogIndex, err)
+		}
+	}
+	if err := db.SealBlock(blk.ParentHash, eth.BlockID{Hash: blk.Hash, Number: blk.Number}, blk.Timestamp); err != nil {
+		return fmt.Errorf("seal block: %w", err)
+	}
+	return nil
+}
+
+// initiatingBlockTime returns the block time of a chain that can originate initiating
+// messages — either a driven chain or a registered remote node — and whether such a
+// chain is known.
+func (i *Interop) initiatingBlockTime(chainID eth.ChainID) (uint64, bool) {
+	if c, ok := i.chains[chainID]; ok {
+		return c.BlockTime(), true
+	}
+	if node, ok := i.remoteNodes[chainID]; ok {
+		return node.adapter.BlockTime(), true
+	}
+	return 0, false
+}

--- a/op-supernode/supernode/activity/interop/remote_node_test.go
+++ b/op-supernode/supernode/activity/interop/remote_node_test.go
@@ -1,0 +1,164 @@
+package interop
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	coreinterop "github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote/remotetest"
+)
+
+// newRemoteNode wires a deterministic test server to a real HTTPAdapter and the ingester,
+// returning the ingester, the fake chain (for ExpectedChecksum), and a LogsDB to seal into.
+func newRemoteNode(t *testing.T, cfg remotetest.Config) (*remoteNode, *remotetest.Chain, LogsDB) {
+	chain := remotetest.New(cfg)
+	srv := httptest.NewServer(chain.Handler())
+	t.Cleanup(srv.Close)
+
+	db, err := openLogsDB(testLogger(), cfg.ChainID, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	adapter := remote.NewHTTPAdapter(cfg.ChainID, srv.URL, srv.Client())
+	return &remoteNode{log: testLogger(), adapter: adapter, db: db, poll: defaultRemotePollInterval}, chain, db
+}
+
+// TestRemoteNodeIngestAndContains exercises the full path against a real LogsDB: the
+// ingester polls the remote node over HTTP, seals the fabricated initiating messages, and
+// they become referenceable via the checksum the chain advertises (positive), while a
+// wrong checksum is rejected (negative).
+func TestRemoteNodeIngestAndContains(t *testing.T) {
+	t.Parallel()
+	const (
+		activation   = uint64(1000)
+		blockTime    = uint64(2)
+		msgsPerBlock = 2
+	)
+	chainID := eth.ChainIDFromUInt64(8453)
+	node, chain, db := newRemoteNode(t, remotetest.Config{
+		ChainID: chainID, BlockTime: blockTime, MsgsPerBlock: msgsPerBlock, StartTimestamp: activation,
+	})
+
+	// Ingest two finalized blocks; the LogsDB resume cursor advances each time.
+	for n := uint64(1); n <= 2; n++ {
+		ingested, err := node.ingestOnce(context.Background())
+		require.NoError(t, err)
+		require.True(t, ingested)
+		latest, ok := db.LatestSealedBlock()
+		require.True(t, ok)
+		require.Equal(t, n, latest.Number)
+	}
+
+	// Every fabricated message is referenceable via its advertised checksum.
+	for n := uint64(1); n <= 2; n++ {
+		ts := activation + n*blockTime
+		for logIdx := uint32(0); logIdx < msgsPerBlock; logIdx++ {
+			seal, err := db.Contains(messages.ContainsQuery{
+				BlockNum:  n,
+				LogIdx:    logIdx,
+				Timestamp: ts,
+				Checksum:  chain.ExpectedChecksum(n, logIdx),
+			})
+			require.NoError(t, err, "block %d log %d should be referenceable", n, logIdx)
+			require.Equal(t, n, seal.Number)
+			require.Equal(t, ts, seal.Timestamp)
+		}
+	}
+
+	// A wrong checksum at a real (block, log) position is a conflict.
+	_, err := db.Contains(messages.ContainsQuery{
+		BlockNum:  1,
+		LogIdx:    0,
+		Timestamp: activation + blockTime,
+		Checksum:  messages.MessageChecksum(common.HexToHash("0xbad")),
+	})
+	require.ErrorIs(t, err, coreinterop.ErrConflict)
+}
+
+func TestAddRemoteNode(t *testing.T) {
+	// newInteropTestHarness calls t.Parallel() internally.
+	h := newInteropTestHarness(t).WithActivation(1000).WithChain(10, nil).Build()
+	require.NotNil(t, h.interop)
+
+	remoteID := eth.ChainIDFromUInt64(8453)
+	adapter := remote.NewHTTPAdapter(remoteID, "http://example.invalid", nil)
+
+	require.NoError(t, h.interop.AddRemoteNode(adapter))
+	require.Contains(t, h.interop.remoteNodes, remoteID)
+	require.Contains(t, h.interop.logsDBs, remoteID, "remote logsDB must be registered for executing-message validation to read it")
+
+	// Duplicate remote registration fails.
+	require.Error(t, h.interop.AddRemoteNode(adapter))
+
+	// A driven chain cannot also be a remote node.
+	require.Error(t, h.interop.AddRemoteNode(remote.NewHTTPAdapter(eth.ChainIDFromUInt64(10), "http://example.invalid", nil)))
+}
+
+// TestVerifyExecutingMessageReferencesRemoteNode is the end-to-end check: a driven chain
+// references a remote node's initiating message as an executing message, through the real
+// verifyExecutingMessage path (including the remote block-time fallback). The remote
+// node's messages arrive over HTTP from the test server.
+func TestVerifyExecutingMessageReferencesRemoteNode(t *testing.T) {
+	// newInteropTestHarness calls t.Parallel() internally.
+	const (
+		drivenChain = 10
+		remoteChain = 8453
+		activation  = uint64(1000)
+		blockTime   = uint64(2)
+	)
+	h := newInteropTestHarness(t).WithActivation(activation).WithChain(drivenChain, nil).Build()
+	require.NotNil(t, h.interop)
+
+	remoteID := eth.ChainIDFromUInt64(remoteChain)
+	chain := remotetest.New(remotetest.Config{
+		ChainID: remoteID, BlockTime: blockTime, MsgsPerBlock: 1, StartTimestamp: activation,
+	})
+	srv := httptest.NewServer(chain.Handler())
+	defer srv.Close()
+	require.NoError(t, h.interop.AddRemoteNode(remote.NewHTTPAdapter(remoteID, srv.URL, srv.Client())))
+
+	// Ingest one finalized block from the remote node (also populates the adapter's
+	// cached block time, used by the activation invariant below).
+	node := h.interop.remoteNodes[remoteID]
+	require.NotNil(t, node)
+	ingested, err := node.ingestOnce(context.Background())
+	require.NoError(t, err)
+	require.True(t, ingested)
+
+	const initBlock, initLogIdx = uint64(1), uint32(0)
+	initTimestamp := activation + blockTime // block 1 timestamp = 1002
+
+	execMsg := &messages.ExecutingMessage{
+		ChainID:   remoteID,
+		BlockNum:  initBlock,
+		LogIdx:    initLogIdx,
+		Timestamp: initTimestamp,
+		Checksum:  chain.ExpectedChecksum(initBlock, initLogIdx),
+	}
+	drivenID := eth.ChainIDFromUInt64(drivenChain)
+
+	// Positive: valid executing message referencing the remote node passes.
+	require.NoError(t, h.interop.verifyExecutingMessage(drivenID, initTimestamp+50, 0, execMsg, nil),
+		"valid executing message referencing a remote node must pass")
+
+	// Negative: a wrong checksum is a conflict.
+	bad := *execMsg
+	bad.Checksum = messages.MessageChecksum(common.HexToHash("0xdeadbeef"))
+	err = h.interop.verifyExecutingMessage(drivenID, initTimestamp+50, 0, &bad, nil)
+	require.ErrorIs(t, err, coreinterop.ErrConflict)
+
+	// Negative: referencing a block the remote node has not ingested yet fails.
+	future := *execMsg
+	future.BlockNum = 99
+	future.Timestamp = activation + 99*blockTime
+	future.Checksum = chain.ExpectedChecksum(99, 0)
+	require.Error(t, h.interop.verifyExecutingMessage(drivenID, future.Timestamp+50, 0, &future, nil),
+		"referencing a not-yet-ingested remote block must fail")
+}

--- a/op-supernode/supernode/remote/adapter.go
+++ b/op-supernode/supernode/remote/adapter.go
@@ -1,0 +1,82 @@
+// Package remote provides the plugin boundary for ingesting initiating messages
+// from chains that the supernode does NOT drive.
+//
+// A driven chain is represented by an in-process virtual node that runs a full
+// op-node and seals that chain's logs into a LogsDB. A *remote* chain, by
+// contrast, is represented only by an [Adapter]: a small plugin that exposes the
+// chain's FINALIZED initiating messages, already normalized into the canonical
+// form the interop verifier needs. The supernode ingests those messages into a
+// LogsDB so the driven chains in the interop set can reference them as executing
+// messages — without the supernode running a consensus client for the remote
+// chain.
+//
+// This lets an operator plug in any external chain node software. The production
+// Adapter is [HTTPAdapter]: point it at a URL and the supernode polls that endpoint
+// for the chain's finalized initiating messages, so the wire protocol — not a Go
+// type — is the real plugin boundary (serve the right responses in any language and
+// you are done). The remotetest package provides a deterministic test server for it.
+package remote
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// InitiatingMessage is a single initiating (cross-chain) message emitted by a
+// remote chain, normalized to the minimum the interop verifier needs to make it
+// referenceable by an executing message on another chain. It is also the JSON wire
+// type a remote node serves (see [HTTPAdapter]).
+//
+// LogHash is the canonical content hash of the originating log — identical to
+// what messages.LogToLogHash produces for a real EVM log. The verifier derives
+// the referenceable checksum from (LogHash, block number, LogIndex, block
+// timestamp, chain ID).
+type InitiatingMessage struct {
+	// LogIndex is the position of this message's log within its block. Indices
+	// must be contiguous and start at 0: the verifier indexes messages at exactly
+	// these positions.
+	LogIndex uint32 `json:"logIndex"`
+	// LogHash is the canonical content hash of the originating log.
+	LogHash common.Hash `json:"logHash"`
+}
+
+// FinalizedBlock is one finalized block's worth of initiating messages from a
+// remote chain, and the JSON wire type a remote node serves. Because remote chains
+// are ingested finalized-only, blocks are assumed irreversible: there is no
+// reorg/rewind path for them.
+type FinalizedBlock struct {
+	Number     uint64      `json:"number"`
+	Hash       common.Hash `json:"hash"`
+	ParentHash common.Hash `json:"parentHash"`
+	Timestamp  uint64      `json:"timestamp"`
+	// Messages are the initiating messages in this block, ordered by ascending
+	// LogIndex starting at 0. May be empty (a block with no cross-chain messages).
+	Messages []InitiatingMessage `json:"messages"`
+}
+
+// Adapter is the plugin boundary: an implementation wraps any external chain node
+// software and exposes that chain's finalized initiating messages. An adapter is
+// only ever consulted by a single ingester goroutine, so implementations need not
+// be safe for concurrent use.
+type Adapter interface {
+	// ChainID identifies the remote chain. It must be a member of the interop
+	// dependency set for its messages to be referenceable.
+	ChainID() eth.ChainID
+
+	// BlockTime is the remote chain's block time in seconds. The verifier uses it
+	// for the interop activation invariant (a message must be at least one block
+	// past activation on its own chain).
+	BlockTime() uint64
+
+	// NextFinalized returns the next finalized block after block number `after`
+	// (i.e. block number after+1), or ok=false if that block is not finalized yet.
+	// `after` is 0 before any block has been ingested, so the first returned block
+	// has Number == 1; block 0 is the implicit genesis and carries no messages.
+	NextFinalized(ctx context.Context, after uint64) (blk *FinalizedBlock, ok bool, err error)
+
+	// Close releases any resources held by the adapter.
+	Close() error
+}

--- a/op-supernode/supernode/remote/http_adapter.go
+++ b/op-supernode/supernode/remote/http_adapter.go
@@ -1,0 +1,90 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// HTTPAdapter is the production [Adapter]: it reads a remote chain's finalized
+// initiating messages from an HTTP endpoint. Point it at any server that speaks the
+// remote-node protocol below — that server is the real plugin boundary, so a remote
+// chain can be backed by any node software, in any language, as long as it responds
+// correctly.
+//
+// Protocol:
+//
+//	GET {baseURL}/finalized?after={N}
+//	200 application/json: {"blockTime": <secs>, "block": <FinalizedBlock>|null}
+//	  - block is the finalized block with Number == N+1, or null if no block after N
+//	    is finalized yet (the client then waits and retries).
+//	  - blockTime is the remote chain's block time in seconds (always present); it is
+//	    cached and surfaced via BlockTime for the interop activation invariant.
+type HTTPAdapter struct {
+	chainID   eth.ChainID
+	baseURL   string
+	client    *http.Client
+	blockTime atomic.Uint64
+}
+
+// finalizedResponse is the wire envelope returned by GET /finalized.
+type finalizedResponse struct {
+	BlockTime uint64          `json:"blockTime"`
+	Block     *FinalizedBlock `json:"block"`
+}
+
+var _ Adapter = (*HTTPAdapter)(nil)
+
+// NewHTTPAdapter builds an HTTPAdapter for the given chain and base URL. A nil client
+// uses http.DefaultClient.
+func NewHTTPAdapter(chainID eth.ChainID, baseURL string, client *http.Client) *HTTPAdapter {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &HTTPAdapter{
+		chainID: chainID,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		client:  client,
+	}
+}
+
+func (a *HTTPAdapter) ChainID() eth.ChainID { return a.chainID }
+
+// BlockTime returns the remote chain's block time as last reported by the endpoint, or
+// 0 before the first successful response. Since a message can only be referenced after
+// its block has been ingested, a non-zero value is always available by validation time.
+func (a *HTTPAdapter) BlockTime() uint64 { return a.blockTime.Load() }
+
+func (a *HTTPAdapter) NextFinalized(ctx context.Context, after uint64) (*FinalizedBlock, bool, error) {
+	url := fmt.Sprintf("%s/finalized?after=%d", a.baseURL, after)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, fmt.Errorf("GET %s: unexpected status %d", url, resp.StatusCode)
+	}
+	var out finalizedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, false, fmt.Errorf("decode response from %s: %w", url, err)
+	}
+	if out.BlockTime > 0 {
+		a.blockTime.Store(out.BlockTime)
+	}
+	if out.Block == nil {
+		return nil, false, nil
+	}
+	return out.Block, true, nil
+}
+
+func (a *HTTPAdapter) Close() error { return nil }

--- a/op-supernode/supernode/remote/http_adapter_test.go
+++ b/op-supernode/supernode/remote/http_adapter_test.go
@@ -1,0 +1,40 @@
+package remote_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+)
+
+func TestHTTPAdapterErrorOnNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	adapter := remote.NewHTTPAdapter(eth.ChainIDFromUInt64(10), srv.URL, srv.Client())
+	_, ok, err := adapter.NextFinalized(context.Background(), 0)
+	require.Error(t, err)
+	require.False(t, ok)
+}
+
+func TestHTTPAdapterNullBlockIsNotAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"blockTime":2,"block":null}`))
+	}))
+	defer srv.Close()
+
+	adapter := remote.NewHTTPAdapter(eth.ChainIDFromUInt64(10), srv.URL, srv.Client())
+	blk, ok, err := adapter.NextFinalized(context.Background(), 5)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, blk)
+	require.Equal(t, uint64(2), adapter.BlockTime(), "blockTime is cached even when no block is returned")
+}

--- a/op-supernode/supernode/remote/remotetest/server.go
+++ b/op-supernode/supernode/remote/remotetest/server.go
@@ -1,0 +1,171 @@
+// Package remotetest provides a deterministic HTTP server implementing the remote-node
+// protocol (see remote.HTTPAdapter), for use in tests. Production code never imports it;
+// it lets a test point a real remote.HTTPAdapter at an httptest.Server that serves a
+// fabricated finalized-block stream — "serve the right responses and you're good."
+package remotetest
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+)
+
+const (
+	defaultBlockTime    = uint64(2)
+	defaultMsgsPerBlock = 1
+)
+
+// Config configures a [Chain].
+type Config struct {
+	// ChainID of the simulated remote chain. Required.
+	ChainID eth.ChainID
+	// BlockTime in seconds, reported to the client. Defaults to 2 when zero.
+	BlockTime uint64
+	// MsgsPerBlock is the number of dummy initiating messages fabricated per block.
+	// Defaults to 1 when zero.
+	MsgsPerBlock int
+	// StartTimestamp anchors the simulated chain's clock: block N has timestamp
+	// StartTimestamp + N*BlockTime. Set this to the interop activation timestamp so
+	// block 1 lands exactly one block past activation (the earliest referenceable point).
+	StartTimestamp uint64
+	// Head, when non-zero, is the highest finalized block number: requests for a block
+	// beyond it get "block": null, so tests can exercise the "nothing new yet" path.
+	// Zero means the chain is unbounded (always has the next block).
+	Head uint64
+}
+
+// Chain is a deterministic fake remote chain. The same (ChainID, block, log index)
+// always maps to the same log hash and timestamp, so [Chain.ExpectedChecksum] reproduces
+// exactly the checksum the LogsDB recomputes when validating a referencing executing
+// message.
+type Chain struct {
+	cfg Config
+}
+
+// New builds a Chain, applying defaults for unset fields.
+func New(cfg Config) *Chain {
+	if cfg.BlockTime == 0 {
+		cfg.BlockTime = defaultBlockTime
+	}
+	if cfg.MsgsPerBlock <= 0 {
+		cfg.MsgsPerBlock = defaultMsgsPerBlock
+	}
+	return &Chain{cfg: cfg}
+}
+
+func (c *Chain) BlockTime() uint64 { return c.cfg.BlockTime }
+
+// Handler returns an http.Handler implementing GET /finalized?after={N}. Wrap it in
+// httptest.NewServer and point a remote.HTTPAdapter at the server's URL.
+func (c *Chain) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/finalized", func(w http.ResponseWriter, r *http.Request) {
+		after, err := strconv.ParseUint(r.URL.Query().Get("after"), 10, 64)
+		if err != nil {
+			http.Error(w, "invalid 'after' query param", http.StatusBadRequest)
+			return
+		}
+		resp := struct {
+			BlockTime uint64                 `json:"blockTime"`
+			Block     *remote.FinalizedBlock `json:"block"`
+		}{BlockTime: c.cfg.BlockTime}
+
+		n := after + 1
+		if c.cfg.Head == 0 || n <= c.cfg.Head {
+			resp.Block = c.Block(n)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	return mux
+}
+
+// Block returns the deterministic finalized block at the given height (>= 1).
+func (c *Chain) Block(n uint64) *remote.FinalizedBlock {
+	blk := &remote.FinalizedBlock{
+		Number:     n,
+		Hash:       c.blockHash(n),
+		ParentHash: c.parentHash(n),
+		Timestamp:  c.blockTimestamp(n),
+		Messages:   make([]remote.InitiatingMessage, 0, c.cfg.MsgsPerBlock),
+	}
+	for i := 0; i < c.cfg.MsgsPerBlock; i++ {
+		blk.Messages = append(blk.Messages, remote.InitiatingMessage{
+			LogIndex: uint32(i),
+			LogHash:  c.logHash(n, uint32(i)),
+		})
+	}
+	return blk
+}
+
+// ExpectedChecksum returns the message checksum an executing message must carry to
+// reference the dummy initiating message at (blockNum, logIdx). It mirrors exactly what
+// raftwallogdb.DB.Contains recomputes from the sealed log hash, block timestamp and
+// chain ID.
+func (c *Chain) ExpectedChecksum(blockNum uint64, logIdx uint32) messages.MessageChecksum {
+	return messages.ChecksumArgs{
+		BlockNumber: blockNum,
+		LogIndex:    logIdx,
+		Timestamp:   c.blockTimestamp(blockNum),
+		ChainID:     c.cfg.ChainID,
+		LogHash:     c.logHash(blockNum, logIdx),
+	}.Checksum()
+}
+
+func (c *Chain) blockTimestamp(n uint64) uint64 {
+	return c.cfg.StartTimestamp + n*c.cfg.BlockTime
+}
+
+func (c *Chain) blockHash(n uint64) common.Hash {
+	return c.tag("mock-remote-block", n, 0)
+}
+
+// parentHash links block n to its parent. For n == 1 the parent is a synthetic, non-zero
+// genesis hash (block 0); for n > 1 it is the prior block's hash, so the LogsDB
+// parent-linkage invariants hold.
+func (c *Chain) parentHash(n uint64) common.Hash {
+	if n <= 1 {
+		return c.tag("mock-remote-genesis", 0, 0)
+	}
+	return c.blockHash(n - 1)
+}
+
+// logHash is the canonical content hash the remote node serves and the LogsDB stores.
+// It is derived from a fabricated (payloadHash, origin) preimage so a real CrossL2Inbox
+// executing-message log — which carries payloadHash and origin separately — can reference
+// it: messages.DecodeExecutingMessageLog recomputes exactly this hash.
+func (c *Chain) logHash(n uint64, logIdx uint32) common.Hash {
+	return messages.PayloadHashToLogHash(c.PayloadHash(n, logIdx), c.Origin(n, logIdx))
+}
+
+// Origin is the deterministic originating-contract address for the message at
+// (blockNum, logIdx). A referencing executing message must carry this address.
+func (c *Chain) Origin(blockNum uint64, logIdx uint32) common.Address {
+	return common.BytesToAddress(c.tag("mock-remote-origin", blockNum, uint64(logIdx)).Bytes())
+}
+
+// PayloadHash is the deterministic initiating-message payload hash for (blockNum, logIdx).
+// A referencing executing message carries this as the CrossL2Inbox event's indexed topic.
+func (c *Chain) PayloadHash(blockNum uint64, logIdx uint32) common.Hash {
+	return c.tag("mock-remote-payload", blockNum, uint64(logIdx))
+}
+
+// tag derives a deterministic, domain-separated hash from the chain ID and two numbers,
+// so distinct (domain, n, k) tuples never collide.
+func (c *Chain) tag(domain string, n, k uint64) common.Hash {
+	cid := c.cfg.ChainID.Bytes32()
+	buf := make([]byte, 0, len(domain)+len(cid)+16)
+	buf = append(buf, domain...)
+	buf = append(buf, cid[:]...)
+	buf = binary.BigEndian.AppendUint64(buf, n)
+	buf = binary.BigEndian.AppendUint64(buf, k)
+	return crypto.Keccak256Hash(buf)
+}

--- a/op-supernode/supernode/remote/remotetest/server_test.go
+++ b/op-supernode/supernode/remote/remotetest/server_test.go
@@ -1,0 +1,48 @@
+package remotetest_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote/remotetest"
+)
+
+// TestServerServesProtocol drives the test server through a real remote.HTTPAdapter and
+// confirms the round trip: contiguous, linked blocks; blockTime is reported; and a
+// bounded Head produces the "nothing new yet" (ok=false) response.
+func TestServerServesProtocol(t *testing.T) {
+	chain := remotetest.New(remotetest.Config{
+		ChainID:        eth.ChainIDFromUInt64(8453),
+		BlockTime:      2,
+		MsgsPerBlock:   3,
+		StartTimestamp: 1000,
+		Head:           2,
+	})
+	srv := httptest.NewServer(chain.Handler())
+	defer srv.Close()
+
+	adapter := remote.NewHTTPAdapter(eth.ChainIDFromUInt64(8453), srv.URL, srv.Client())
+
+	b1, ok, err := adapter.NextFinalized(context.Background(), 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), b1.Number)
+	require.Equal(t, uint64(1002), b1.Timestamp)
+	require.Len(t, b1.Messages, 3)
+	require.Equal(t, uint64(2), adapter.BlockTime(), "blockTime should be cached from the response")
+
+	b2, ok, err := adapter.NextFinalized(context.Background(), 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, b1.Hash, b2.ParentHash, "block 2 must link to block 1")
+
+	// Head == 2, so there is no block 3 yet.
+	_, ok, err = adapter.NextFinalized(context.Background(), 2)
+	require.NoError(t, err)
+	require.False(t, ok)
+}

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	supernodeactivity "github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/supernode"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/superroot"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	rpc "github.com/ethereum/go-ethereum/rpc"
@@ -125,6 +127,10 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		}
 		interopActivity = interop.New(log.New("activity", "interop"), *interopActivationTimestamp, msgExpiryWindow, s.chains, cfg.DataDir, s.l1Client, cfg.InteropLogBackfillDepth, s.supernodeMetrics)
 		verifiedReader = interopActivity
+
+		if err := registerRemoteNodes(log, interopActivity, cfg); err != nil {
+			return nil, fmt.Errorf("failed to register remote interop nodes: %w", err)
+		}
 	}
 
 	// Order in this slice governs Start/Stop ordering; interop is appended
@@ -157,6 +163,39 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		s.metrics = resources.NewMetricsService(log, cfg.MetricsConfig.ListenAddr, cfg.MetricsConfig.ListenPort, s.metricsFanIn)
 	}
 	return s, nil
+}
+
+// registerRemoteNodes attaches the configured remote interop nodes to the interop
+// activity. A remote node is a chain the supernode does not drive: the supernode polls
+// the configured URL (the remote-node HTTP protocol) for that chain's finalized
+// initiating messages so driven chains can reference them. The wire protocol is the
+// plugin boundary — any node software that serves it can back a remote chain.
+func registerRemoteNodes(log gethlog.Logger, act *interop.Interop, cfg *config.CLIConfig) error {
+	for _, spec := range cfg.RemoteNodes {
+		chainID, rawURL, err := parseRemoteNodeSpec(spec)
+		if err != nil {
+			return err
+		}
+		if err := act.AddRemoteNode(remote.NewHTTPAdapter(chainID, rawURL, nil)); err != nil {
+			return fmt.Errorf("remote node %s: %w", chainID, err)
+		}
+		log.Info("attached remote node", "chain", chainID, "url", rawURL)
+	}
+	return nil
+}
+
+// parseRemoteNodeSpec parses a "<chainID>=<url>" spec. It splits on the first '=' so URLs
+// may themselves contain '=' (e.g. query parameters).
+func parseRemoteNodeSpec(spec string) (eth.ChainID, string, error) {
+	eq := strings.IndexByte(spec, '=')
+	if eq <= 0 || eq == len(spec)-1 {
+		return eth.ChainID{}, "", fmt.Errorf("invalid --interop.remote-nodes entry %q, want <chainID>=<url>", spec)
+	}
+	id, err := strconv.ParseUint(spec[:eq], 10, 64)
+	if err != nil {
+		return eth.ChainID{}, "", fmt.Errorf("invalid chain ID in --interop.remote-nodes entry %q: %w", spec, err)
+	}
+	return eth.ChainIDFromUInt64(id), spec[eq+1:], nil
 }
 
 func resolveInteropActivationTimestamp(override *uint64, vnCfgs map[eth.ChainID]*opnodecfg.Config) (*uint64, error) {


### PR DESCRIPTION
## What

Adds a **remote node** to `op-supernode`: a participant in the interop set that the supernode does **not** drive. Instead of running a consensus client for the chain, the supernode **polls a remote HTTP endpoint** for that chain's **finalized** initiating messages and seals them into the chain's `LogsDB`. The chains the supernode actually drives can then reference those messages as **executing messages**, exactly as they reference messages originating from driven chains.

The **wire protocol is the plugin boundary** — point a remote node at any server, in any language, that responds correctly:

```
GET {baseURL}/finalized?after={N}
200 application/json:
  { "blockTime": 2,
    "block": { "number": N+1, "hash": "0x..", "parentHash": "0x..",
               "timestamp": 1002, "messages": [ {"logIndex":0,"logHash":"0x.."} ] } }
  // "block": null  ⇒ nothing finalized after N yet
```

Only a real HTTP **client** ships in the binary — there is no mock in production.

## Design

- **`op-supernode/supernode/remote`** (production):
  - `Adapter` — the internal seam the ingester polls.
  - `FinalizedBlock` / `InitiatingMessage` — **normalized initiating messages** grouped into a finalized block; these are also the JSON wire types.
  - `HTTPAdapter` — the production adapter: configured with a URL, polls the protocol above, caches the reported `blockTime`.
- **`interop.remoteNode` + `Interop.AddRemoteNode`** (production) — the ingester: polls an `Adapter` and seals finalized blocks into the per-chain `LogsDB`, mirroring the driven-chain `processBlockLogs` path. **Finalized-only ⇒ no reorg/rewind handling.** Ingesters run as background goroutines started in `Start`.
- **`verifyExecutingMessage`** resolves the *initiating* chain's block time from either a driven chain or a registered remote node (the single behavioral edit to the validation path). Remote nodes only ever appear on the initiating/source side.
- **Config:** `--interop.remote-nodes <chainID>=<url>` (repeatable / comma-separated). The supernode builds an `HTTPAdapter` per entry and registers it.
- **`remote/remotetest`** (test-only) — a deterministic `http.Handler` implementing the protocol. Tests wrap it in `httptest.Server` and point a real `HTTPAdapter` at it, so the production HTTP path is exercised end-to-end. The Go linker keeps it out of release builds.

### Why the served messages are referenceable

`raftwallogdb.DB.Contains` recomputes the message checksum from the **stored log hash** + the DB's chain ID + the sealed block's timestamp. So whatever a remote node serves is referenceable by an executing message that carries the derived checksum — the supernode trusts the (finalized) remote node for its own chain's content.

## Tests

- `remote`: `HTTPAdapter` happy path against the test server (contiguous, linked blocks; `blockTime` cached; `block:null` ⇒ not-yet-finalized), plus non-200 and null-block handling.
- `interop`:
  - `TestRemoteNodeIngestAndContains` — server → `HTTPAdapter` → ingester → `LogsDB.Contains` round-trip (positive) + wrong-checksum rejection (negative), against a real `raftwallogdb`.
  - `TestAddRemoteNode` — registration, duplicate/driven-chain guards.
  - `TestVerifyExecutingMessageReferencesRemoteNode` — a driven chain references a remote node's message (served over HTTP) through the real `verifyExecutingMessage` path (positive + negative).
  - **`TestEngineVerifiesExecutingMessageFromRemoteNode` (engine-level e2e)** — a driven chain emits a **real `CrossL2Inbox` executing-message log** referencing a remote-node-served initiating message; the log is sealed through the production `processBlockLogs` path (real `DecodeExecutingMessageLog`) and validated by the real `verifyInteropMessages` engine. Asserts the block is **accepted** when the reference is valid (and that the block actually carries one decoded executing message, so acceptance isn't vacuous), and **flagged invalid** when the reference is tampered.

`go build ./op-supernode/...`, `go vet`, and `gofmt` are clean; adjacent `config`/`flags`/`supernode` package tests pass.

## Notes / follow-ups

- No real chains/binaries yet: the engine-level e2e drives the real verification engine (`processBlockLogs` → `verifyInteropMessages`) with mock chains. A full devstack e2e (real op-node/op-geth driven L2 + in-process supernode + `remotetest` server, with a real tx emitting the executing message) is a natural follow-up; the supernode already runs in-process in op-e2e / op-devstack.
- The protocol is intentionally minimal (single polling endpoint). Auth, batching (multiple blocks per response), and a metadata/handshake endpoint are natural extensions.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
