### PR TITLE
docs(ai): list dev workflow guide in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ More detailed guidance for AI agents can be found in:
 - [docs/ai/contract-dev.md](docs/ai/contract-dev.md) - Smart contract development
 - [docs/ai/dispute-game-investigation.md](docs/ai/dispute-game-investigation.md) - Investigating fault dispute games: challenger disagreements, excessive moves, self-contradiction, proposal validity, diagnosing the responsible op-node, and the bond outcome (read-only)
 - [docs/ai/flake-prevention.md](docs/ai/flake-prevention.md) - Guidance for preventing flaky tests
+- [docs/ai/dev-workflow.md](docs/ai/dev-workflow.md) - General development workflow: pinned tools via mise, Just usage, pre-PR checks, and CI caveats
 - [docs/ai/go-dev.md](docs/ai/go-dev.md) - Go service development
 - [docs/ai/rust-dev.md](docs/ai/rust-dev.md) - Rust development (kona, op-reth, alloy crates)
 - [docs/ai/derivation.md](docs/ai/derivation.md) - Derivation pipeline development (op-node, kona-node)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Adds `docs/ai/dev-workflow.md` to the `AGENTS.md` Additional Documentation list.

The file already documents shared development workflow guidance for AI agents, including pinned tools via `mise`, Just usage, pre-PR checks, and CI caveats. This change makes that existing guide discoverable from the main agent entrypoint and completes the `docs/ai/*.md` index coverage.



**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

- `test -f docs/ai/dev-workflow.md`
- `git diff --check -- AGENTS.md`
- Confirmed all `docs/ai/*.md` files are listed in `AGENTS.md`

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
