### PR TITLE
refactor(kona): reuse shared OP EVM env builder

### DIFF
--- a/rust/alloy-op-evm/src/env.rs
+++ b/rust/alloy-op-evm/src/env.rs
@@ -233,6 +233,49 @@ mod tests {
         }
     }
 
+    /// The `BLOBBASEFEE` opcode must always be 1 on the OP Stack. Post-Jovian the header's
+    /// `blobGasUsed` carries the block's DA footprint, which must not influence the blob env. The
+    /// footprint here is from op-mainnet block 152635937.
+    #[test]
+    fn evm_env_for_op_next_block_pins_blob_gasprice_to_one() {
+        let parent_header = Header {
+            number: 100,
+            timestamp: 1_000_000,
+            gas_limit: 60_000_000,
+            base_fee_per_gas: Some(1_000_000_000),
+            blob_gas_used: Some(30_406_400),
+            excess_blob_gas: Some(0),
+            ..Default::default()
+        };
+
+        let evm_env = evm_env_for_op_next_block(
+            &parent_header,
+            NextEvmEnvAttributes {
+                timestamp: parent_header.timestamp + 2,
+                suggested_fee_recipient: Default::default(),
+                prev_randao: Default::default(),
+                gas_limit: parent_header.gas_limit,
+                slot_number: None,
+            },
+            1_000_000_000,
+            FakeHardfork::isthmus(),
+            10,
+        );
+
+        let blob = evm_env
+            .block_env
+            .blob_excess_gas_and_price
+            .expect("blob env should be present for Isthmus");
+        assert_eq!(
+            blob.blob_gasprice, 1,
+            "BLOBBASEFEE must be pinned to 1 on the OP Stack regardless of the parent DA footprint"
+        );
+        assert_eq!(
+            blob.excess_blob_gas, 0,
+            "excess blob gas must be pinned to 0 regardless of the parent DA footprint"
+        );
+    }
+
     #[test_case::test_case(FakeHardfork::karst(), OpSpecId::KARST; "Karst")]
     #[test_case::test_case(FakeHardfork::lagoon(), OpSpecId::INTEROP; "Lagoon")]
     #[test_case::test_case(FakeHardfork::jovian(), OpSpecId::JOVIAN; "Jovian")]

--- a/rust/kona/crates/proof/executor/src/builder/core.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core.rs
@@ -257,7 +257,6 @@ where
             attrs.payload_attributes.timestamp,
         )?;
         let evm_env = self.evm_env(
-            self.config.spec_id(attrs.payload_attributes.timestamp),
             self.trie_db.parent_block_header(),
             &attrs,
             &base_fee_params,

--- a/rust/kona/crates/proof/executor/src/builder/env.rs
+++ b/rust/kona/crates/proof/executor/src/builder/env.rs
@@ -9,16 +9,14 @@ use crate::{
 };
 use alloy_consensus::{BlockHeader, Header};
 use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams};
-use alloy_evm::{EvmEnv, EvmFactory};
-use alloy_primitives::U256;
+use alloy_evm::{EvmEnv, EvmFactory, eth::NextEvmEnvAttributes};
+use alloy_op_evm::evm_env_for_op_next_block;
 use kona_genesis::RollupConfig;
 use kona_mpt::TrieHinter;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use op_revm::OpSpecId;
-use revm::{
-    context::{BlockEnv, CfgEnv},
-    context_interface::block::BlobExcessGasAndPrice,
-};
+#[cfg(test)]
+use revm::context::BlockEnv;
 
 impl<P, H, Evm, R> StatelessL2Builder<'_, P, H, Evm, R>
 where
@@ -35,22 +33,7 @@ where
         base_fee_params: &BaseFeeParams,
         min_base_fee: u64,
     ) -> ExecutorResult<EvmEnv<OpSpecId>> {
-        let block_env = self.prepare_block_env(
-            spec_id,
-            parent_header,
-            payload_attrs,
-            base_fee_params,
-            min_base_fee,
-        )?;
-        let cfg_env = self.evm_cfg_env(payload_attrs.payload_attributes.timestamp);
-        Ok(EvmEnv::new(cfg_env, block_env))
-    }
-
-    /// Returns the active [`CfgEnv`] for the executor.
-    pub(crate) fn evm_cfg_env(&self, timestamp: u64) -> CfgEnv<OpSpecId> {
-        CfgEnv::new()
-            .with_chain_id(self.config.l2_chain_id.id())
-            .with_spec_and_mainnet_gas_params(self.config.spec_id(timestamp))
+        self.prepare_evm_env(spec_id, parent_header, payload_attrs, base_fee_params, min_base_fee)
     }
 
     fn next_block_base_fee(
@@ -89,6 +72,7 @@ where
     }
 
     /// Prepares a [`BlockEnv`] with the given [`OpPayloadAttributes`].
+    #[cfg(test)]
     pub(crate) fn prepare_block_env(
         &self,
         spec_id: OpSpecId,
@@ -97,27 +81,37 @@ where
         base_fee_params: &BaseFeeParams,
         min_base_fee: u64,
     ) -> ExecutorResult<BlockEnv> {
-        // On the OP Stack the BLOBBASEFEE opcode is always 1 from Ecotone onward. Post-Jovian the
-        // header's `blobGasUsed` field carries the block's DA footprint, so it must not feed the
-        // EIP-4844 excess-blob-gas rule; pin the blob env instead.
-        let blob_excess_gas_and_price = spec_id
-            .is_enabled_in(OpSpecId::ECOTONE)
-            .then_some(BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice: 1 });
+        Ok(self
+            .prepare_evm_env(spec_id, parent_header, payload_attrs, base_fee_params, min_base_fee)?
+            .block_env)
+    }
 
+    fn prepare_evm_env(
+        &self,
+        _spec_id: OpSpecId,
+        parent_header: &Header,
+        payload_attrs: &OpPayloadAttributes,
+        base_fee_params: &BaseFeeParams,
+        min_base_fee: u64,
+    ) -> ExecutorResult<EvmEnv<OpSpecId>> {
         let next_block_base_fee = self
             .next_block_base_fee(*base_fee_params, parent_header, min_base_fee)
             .unwrap_or_default();
+        let gas_limit = payload_attrs.gas_limit.ok_or(ExecutorError::MissingGasLimit)?;
 
-        Ok(BlockEnv {
-            number: U256::from(parent_header.number + 1),
-            beneficiary: payload_attrs.payload_attributes.suggested_fee_recipient,
-            timestamp: U256::from(payload_attrs.payload_attributes.timestamp),
-            gas_limit: payload_attrs.gas_limit.ok_or(ExecutorError::MissingGasLimit)?,
-            basefee: next_block_base_fee,
-            prevrandao: Some(payload_attrs.payload_attributes.prev_randao),
-            blob_excess_gas_and_price,
-            ..Default::default()
-        })
+        Ok(evm_env_for_op_next_block(
+            parent_header,
+            NextEvmEnvAttributes {
+                timestamp: payload_attrs.payload_attributes.timestamp,
+                suggested_fee_recipient: payload_attrs.payload_attributes.suggested_fee_recipient,
+                prev_randao: payload_attrs.payload_attributes.prev_randao,
+                gas_limit,
+                slot_number: None,
+            },
+            next_block_base_fee,
+            self.config,
+            self.config.l2_chain_id.id(),
+        ))
     }
 
     /// Returns the active base fee parameters for the parent header.
@@ -171,7 +165,8 @@ mod tests {
     /// footprint here is from op-mainnet block 152635937.
     #[test]
     fn prepare_block_env_pins_blob_gasprice_to_one() {
-        let config = RollupConfig::default();
+        let mut config = RollupConfig::default();
+        config.hardforks.isthmus_time = Some(0);
         let parent_header = Header {
             number: 100,
             timestamp: 1_000_000,

--- a/rust/kona/crates/proof/executor/src/builder/env.rs
+++ b/rust/kona/crates/proof/executor/src/builder/env.rs
@@ -15,8 +15,6 @@ use kona_genesis::RollupConfig;
 use kona_mpt::TrieHinter;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use op_revm::OpSpecId;
-#[cfg(test)]
-use revm::context::BlockEnv;
 
 impl<P, H, Evm, R> StatelessL2Builder<'_, P, H, Evm, R>
 where
@@ -27,13 +25,29 @@ where
     /// Returns the active [`EvmEnv`] for the executor.
     pub(crate) fn evm_env(
         &self,
-        spec_id: OpSpecId,
         parent_header: &Header,
         payload_attrs: &OpPayloadAttributes,
         base_fee_params: &BaseFeeParams,
         min_base_fee: u64,
     ) -> ExecutorResult<EvmEnv<OpSpecId>> {
-        self.prepare_evm_env(spec_id, parent_header, payload_attrs, base_fee_params, min_base_fee)
+        let next_block_base_fee = self
+            .next_block_base_fee(*base_fee_params, parent_header, min_base_fee)
+            .unwrap_or_default();
+        let gas_limit = payload_attrs.gas_limit.ok_or(ExecutorError::MissingGasLimit)?;
+
+        Ok(evm_env_for_op_next_block(
+            parent_header,
+            NextEvmEnvAttributes {
+                timestamp: payload_attrs.payload_attributes.timestamp,
+                suggested_fee_recipient: payload_attrs.payload_attributes.suggested_fee_recipient,
+                prev_randao: payload_attrs.payload_attributes.prev_randao,
+                gas_limit,
+                slot_number: None,
+            },
+            next_block_base_fee,
+            self.config,
+            self.config.l2_chain_id.id(),
+        ))
     }
 
     fn next_block_base_fee(
@@ -71,49 +85,6 @@ where
         Some(next_block_base_fee)
     }
 
-    /// Prepares a [`BlockEnv`] with the given [`OpPayloadAttributes`].
-    #[cfg(test)]
-    pub(crate) fn prepare_block_env(
-        &self,
-        spec_id: OpSpecId,
-        parent_header: &Header,
-        payload_attrs: &OpPayloadAttributes,
-        base_fee_params: &BaseFeeParams,
-        min_base_fee: u64,
-    ) -> ExecutorResult<BlockEnv> {
-        Ok(self
-            .prepare_evm_env(spec_id, parent_header, payload_attrs, base_fee_params, min_base_fee)?
-            .block_env)
-    }
-
-    fn prepare_evm_env(
-        &self,
-        _spec_id: OpSpecId,
-        parent_header: &Header,
-        payload_attrs: &OpPayloadAttributes,
-        base_fee_params: &BaseFeeParams,
-        min_base_fee: u64,
-    ) -> ExecutorResult<EvmEnv<OpSpecId>> {
-        let next_block_base_fee = self
-            .next_block_base_fee(*base_fee_params, parent_header, min_base_fee)
-            .unwrap_or_default();
-        let gas_limit = payload_attrs.gas_limit.ok_or(ExecutorError::MissingGasLimit)?;
-
-        Ok(evm_env_for_op_next_block(
-            parent_header,
-            NextEvmEnvAttributes {
-                timestamp: payload_attrs.payload_attributes.timestamp,
-                suggested_fee_recipient: payload_attrs.payload_attributes.suggested_fee_recipient,
-                prev_randao: payload_attrs.payload_attributes.prev_randao,
-                gas_limit,
-                slot_number: None,
-            },
-            next_block_base_fee,
-            self.config,
-            self.config.l2_chain_id.id(),
-        ))
-    }
-
     /// Returns the active base fee parameters for the parent header.
     /// Returns the min-base-fee as the second element of the tuple.
     ///
@@ -148,72 +119,5 @@ where
                 Ok((config.chain_op_config.pre_canyon_params(), 0))
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::NoopTrieDBProvider;
-    use alloy_consensus::{Header, Sealable};
-    use alloy_op_evm::OpEvmFactory;
-    use alloy_rpc_types_engine::PayloadAttributes;
-    use kona_mpt::NoopTrieHinter;
-
-    /// The `BLOBBASEFEE` opcode must always be 1 on the OP Stack. Post-Jovian the header's
-    /// `blobGasUsed` carries the block's DA footprint, which must not influence the blob env. The
-    /// footprint here is from op-mainnet block 152635937.
-    #[test]
-    fn prepare_block_env_pins_blob_gasprice_to_one() {
-        let mut config = RollupConfig::default();
-        config.hardforks.isthmus_time = Some(0);
-        let parent_header = Header {
-            number: 100,
-            timestamp: 1_000_000,
-            gas_limit: 60_000_000,
-            base_fee_per_gas: Some(1_000_000_000),
-            blob_gas_used: Some(30_406_400),
-            excess_blob_gas: Some(0),
-            ..Default::default()
-        };
-
-        let builder = StatelessL2Builder::new(
-            &config,
-            OpEvmFactory::<alloy_op_evm::OpTx>::default(),
-            alloy_op_evm::block::OpAlloyReceiptBuilder::default(),
-            NoopTrieDBProvider,
-            NoopTrieHinter,
-            parent_header.clone().seal_slow(),
-        );
-
-        let payload_attrs = OpPayloadAttributes {
-            payload_attributes: PayloadAttributes {
-                timestamp: parent_header.timestamp + 2,
-                ..Default::default()
-            },
-            gas_limit: Some(parent_header.gas_limit),
-            ..Default::default()
-        };
-
-        let block_env = builder
-            .prepare_block_env(
-                OpSpecId::ISTHMUS,
-                &parent_header,
-                &payload_attrs,
-                &BaseFeeParams::new(250, 6),
-                0,
-            )
-            .expect("prepare_block_env should succeed");
-
-        let blob =
-            block_env.blob_excess_gas_and_price.expect("blob env should be present for Isthmus");
-        assert_eq!(
-            blob.blob_gasprice, 1,
-            "BLOBBASEFEE must be pinned to 1 on the OP Stack regardless of the parent DA footprint"
-        );
-        assert_eq!(
-            blob.excess_blob_gas, 0,
-            "excess blob gas must be pinned to 0 regardless of the parent DA footprint"
-        );
     }
 }


### PR DESCRIPTION

  ## Summary

  Refactor Kona's stateless executor to build the next-block EVM environment through
  `alloy_op_evm::evm_env_for_op_next_block` instead of locally assembling `CfgEnv` and `BlockEnv`.

  This keeps Kona's proof-specific inputs and validation in place:

  - next block base fee is still computed from Kona's active base fee params, including Jovian min-base-fee handling
  - missing payload gas limit still returns `ExecutorError::MissingGasLimit`
  - payload attributes are mapped into `NextEvmEnvAttributes`

  ## Motivation

  Kona was duplicating consensus-sensitive OP EVM environment construction that already exists in `alloy-
  op-evm` and is used by op-reth.

  Reusing the shared helper reduces the chance of future drift between the fault proof executor and
  execution clients. In particular, OP-specific blob env behavior, such as pinning `BLOBBASEFEE` to 1 for
  Ecotone+, now comes from the same helper path instead of being reimplemented locally in Kona.

as a refactor on top of this https://github.com/ethereum-optimism/optimism/pull/21328
