### PR TITLE
refactor: share jovian base fee calculation

### DIFF
--- a/rust/kona/crates/proof/executor/src/builder/env.rs
+++ b/rust/kona/crates/proof/executor/src/builder/env.rs
@@ -8,11 +8,12 @@ use crate::{
     },
 };
 use alloy_consensus::{BlockHeader, Header};
-use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams};
+use alloy_eips::eip1559::BaseFeeParams;
 use alloy_evm::{EvmEnv, EvmFactory};
 use alloy_primitives::U256;
 use kona_genesis::RollupConfig;
 use kona_mpt::TrieHinter;
+use op_alloy_consensus::calc_jovian_next_block_base_fee;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use op_revm::OpSpecId;
 use revm::{
@@ -63,29 +64,7 @@ where
             return parent.next_block_base_fee(params);
         }
 
-        // Starting from Jovian, we use the maximum of the gas used and the blob gas used to
-        // calculate the next base fee.
-        let gas_used = if parent.blob_gas_used().unwrap_or_default() > parent.gas_used() {
-            parent.blob_gas_used().unwrap_or_default()
-        } else {
-            parent.gas_used()
-        };
-
-        let mut next_block_base_fee = calc_next_block_base_fee(
-            gas_used,
-            parent.gas_limit(),
-            parent.base_fee_per_gas().unwrap_or_default(),
-            params,
-        );
-
-        // If the next block base fee is less than the min base fee, set it to the min base fee.
-        // # Note
-        // Before Jovian activation, the min-base-fee is 0 so this is a no-op.
-        if next_block_base_fee < min_base_fee {
-            next_block_base_fee = min_base_fee;
-        }
-
-        Some(next_block_base_fee)
+        Some(calc_jovian_next_block_base_fee(parent, params, min_base_fee))
     }
 
     /// Prepares a [`BlockEnv`] with the given [`OpPayloadAttributes`].

--- a/rust/op-alloy/crates/consensus/src/eip1559.rs
+++ b/rust/op-alloy/crates/consensus/src/eip1559.rs
@@ -1,6 +1,7 @@
 //! Support for EIP-1559 parameters after holocene.
 
-use alloy_eips::eip1559::BaseFeeParams;
+use alloy_consensus::BlockHeader;
+use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams};
 use alloy_primitives::{B64, Bytes};
 
 const HOLOCENE_EXTRA_DATA_VERSION_BYTE: u8 = 0;
@@ -126,6 +127,43 @@ pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u64), EI
     Ok((elasticity, denominator, u64::from_be_bytes(min_base_fee_bytes)))
 }
 
+/// Calculates the next block base fee according to the OP Stack Jovian rules.
+///
+/// Jovian uses the larger of execution gas and DA footprint gas as the EIP-1559 input, and clamps
+/// the result to the encoded minimum base fee.
+pub fn calc_jovian_next_block_base_fee<H>(
+    parent: &H,
+    base_fee_params: BaseFeeParams,
+    min_base_fee: u64,
+) -> u64
+where
+    H: BlockHeader,
+{
+    let gas_used = core::cmp::max(parent.gas_used(), parent.blob_gas_used().unwrap_or_default());
+    let next_base_fee = calc_next_block_base_fee(
+        gas_used,
+        parent.gas_limit(),
+        parent.base_fee_per_gas().unwrap_or_default(),
+        base_fee_params,
+    );
+
+    core::cmp::max(next_base_fee, min_base_fee)
+}
+
+/// Decodes Jovian EIP-1559 parameters from the parent header and calculates the next block base
+/// fee according to the OP Stack Jovian rules.
+pub fn decode_jovian_next_block_base_fee<H>(parent: &H) -> Result<u64, EIP1559ParamError>
+where
+    H: BlockHeader,
+{
+    // The denominator and elasticity are guaranteed non-zero: `decode_jovian_extra_data` rejects a
+    // zero of either, per the Holocene header rules that Jovian inherits.
+    let (elasticity, denominator, min_base_fee) = decode_jovian_extra_data(parent.extra_data())?;
+    let base_fee_params = BaseFeeParams::new(denominator as u128, elasticity as u128);
+
+    Ok(calc_jovian_next_block_base_fee(parent, base_fee_params, min_base_fee))
+}
+
 /// Encodes the EIP-1559 parameters for the payload,
 /// as well as the minimum base fee.
 pub fn encode_jovian_extra_data(
@@ -180,7 +218,27 @@ pub enum EIP1559ParamError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_consensus::Header;
     use core::str::FromStr;
+
+    const BASE_FEE: u64 = 1_000_000_000;
+    const GAS_LIMIT: u64 = 10_000_000_000;
+
+    fn jovian_parent(gas_used: u64, blob_gas_used: u64, min_base_fee: u64) -> Header {
+        Header {
+            gas_used,
+            gas_limit: GAS_LIMIT,
+            base_fee_per_gas: Some(BASE_FEE),
+            blob_gas_used: Some(blob_gas_used),
+            extra_data: encode_jovian_extra_data(
+                B64::ZERO,
+                BaseFeeParams::new(80, 60),
+                min_base_fee,
+            )
+            .unwrap(),
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn test_get_extra_data_post_holocene() {
@@ -233,6 +291,58 @@ mod tests {
             extra_data.unwrap(),
             Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60, 0, 0, 0, 0, 0, 0, 0, 0])
         );
+    }
+
+    #[test]
+    fn test_calc_jovian_next_block_base_fee_uses_blob_gas_when_larger() {
+        const GAS_USED: u64 = 1_000_000_000;
+        const BLOB_GAS_USED: u64 = 5_000_000_000;
+
+        let parent = jovian_parent(GAS_USED, BLOB_GAS_USED, 0);
+        let base_fee_params = BaseFeeParams::new(80, 60);
+        let expected_base_fee = calc_next_block_base_fee(
+            BLOB_GAS_USED,
+            parent.gas_limit(),
+            parent.base_fee_per_gas().unwrap_or_default(),
+            base_fee_params,
+        );
+
+        assert_eq!(expected_base_fee, calc_jovian_next_block_base_fee(&parent, base_fee_params, 0));
+        assert_ne!(
+            expected_base_fee,
+            calc_next_block_base_fee(
+                GAS_USED,
+                parent.gas_limit(),
+                parent.base_fee_per_gas().unwrap_or_default(),
+                base_fee_params,
+            )
+        );
+    }
+
+    #[test]
+    fn test_calc_jovian_next_block_base_fee_uses_execution_gas_when_larger() {
+        const GAS_USED: u64 = 5_000_000_000;
+        const BLOB_GAS_USED: u64 = 1_000_000_000;
+
+        let parent = jovian_parent(GAS_USED, BLOB_GAS_USED, 0);
+        let base_fee_params = BaseFeeParams::new(80, 60);
+        let expected_base_fee = calc_next_block_base_fee(
+            GAS_USED,
+            parent.gas_limit(),
+            parent.base_fee_per_gas().unwrap_or_default(),
+            base_fee_params,
+        );
+
+        assert_eq!(expected_base_fee, calc_jovian_next_block_base_fee(&parent, base_fee_params, 0));
+    }
+
+    #[test]
+    fn test_decode_jovian_next_block_base_fee_enforces_min_base_fee() {
+        const MIN_BASE_FEE: u64 = 2_000_000_000;
+
+        let parent = jovian_parent(0, 0, MIN_BASE_FEE);
+
+        assert_eq!(MIN_BASE_FEE, decode_jovian_next_block_base_fee(&parent).unwrap());
     }
 
     #[test]

--- a/rust/op-alloy/crates/consensus/src/lib.rs
+++ b/rust/op-alloy/crates/consensus/src/lib.rs
@@ -31,8 +31,9 @@ pub use transaction::{
 
 pub mod eip1559;
 pub use eip1559::{
-    EIP1559ParamError, decode_eip_1559_params, decode_holocene_extra_data,
-    decode_jovian_extra_data, encode_holocene_extra_data, encode_jovian_extra_data,
+    EIP1559ParamError, calc_jovian_next_block_base_fee, decode_eip_1559_params,
+    decode_holocene_extra_data, decode_jovian_extra_data, decode_jovian_next_block_base_fee,
+    encode_holocene_extra_data, encode_jovian_extra_data,
 };
 
 pub mod post_exec;

--- a/rust/op-reth/crates/chainspec/src/basefee.rs
+++ b/rust/op-reth/crates/chainspec/src/basefee.rs
@@ -1,10 +1,9 @@
 //! Base fee related utilities for Optimism chains.
 
-use core::cmp::max;
-
 use alloy_consensus::BlockHeader;
-use alloy_eips::calc_next_block_base_fee;
-use op_alloy_consensus::{EIP1559ParamError, decode_holocene_extra_data, decode_jovian_extra_data};
+use op_alloy_consensus::{
+    EIP1559ParamError, decode_holocene_extra_data, decode_jovian_next_block_base_fee,
+};
 use reth_chainspec::BaseFeeParams;
 
 /// Extracts the Holocene 1599 parameters from the encoded extra data from the parent header.
@@ -36,33 +35,14 @@ pub fn compute_jovian_base_fee<H>(parent: &H) -> Result<u64, EIP1559ParamError>
 where
     H: BlockHeader,
 {
-    // The denominator and elasticity are guaranteed non-zero: `decode_jovian_extra_data` rejects a
-    // zero of either, per the Holocene header rules that Jovian inherits.
-    let (elasticity, denominator, min_base_fee) = decode_jovian_extra_data(parent.extra_data())?;
-    let base_fee_params = BaseFeeParams::new(denominator as u128, elasticity as u128);
-
-    // Starting from Jovian, we use the maximum of the gas used and the blob gas used to calculate
-    // the next base fee.
-    let gas_used = max(parent.gas_used(), parent.blob_gas_used().unwrap_or_default());
-
-    let next_base_fee = calc_next_block_base_fee(
-        gas_used,
-        parent.gas_limit(),
-        parent.base_fee_per_gas().unwrap_or_default(),
-        base_fee_params,
-    );
-
-    if next_base_fee < min_base_fee {
-        return Ok(min_base_fee);
-    }
-
-    Ok(next_base_fee)
+    decode_jovian_next_block_base_fee(parent)
 }
 
 #[cfg(test)]
 mod tests {
     use alloc::sync::Arc;
 
+    use alloy_eips::calc_next_block_base_fee;
     use op_alloy_consensus::encode_jovian_extra_data;
     use reth_chainspec::{ChainSpec, ForkCondition, Hardfork};
     use reth_optimism_forks::OpHardfork;


### PR DESCRIPTION
## Summary

  - Move OP Jovian next-block base fee calculation into `op-alloy-consensus`
  - Reuse the shared helper from Kona executor and op-reth chainspec
  - Add direct tests for Jovian DA-footprint gas selection and minimum base fee clamping

  ## Details

  Jovian base fee calculation extends normal EIP-1559 behavior by:

  - using `max(parent.gas_used, parent.blob_gas_used.unwrap_or_default())`
  - clamping the result to the encoded `min_base_fee`

  This logic existed separately in Kona executor and op-reth chainspec. This PR centralizes it in `op-alloy-consensus`, next to the existing Jovian extra-data encode/decode helpers.