### PR TITLE
fix(op-rbuilder): gate interop txs during failsafe

### DIFF
--- a/rust/op-rbuilder/crates/op-rbuilder/Cargo.toml
+++ b/rust/op-rbuilder/crates/op-rbuilder/Cargo.toml
@@ -169,7 +169,7 @@ hyper-util = { version = "0.1.11" }
 http-body-util = { version = "0.1.3" }
 
 [features]
-default = ["jemalloc", "docker-tests"]
+default = ["jemalloc", "docker-tests", "interop"]
 
 # Gates the smoke tests under `src/tests/smoke.rs` that cross-validate
 # against an external op-reth via testcontainers (needs the host's

--- a/rust/op-rbuilder/crates/op-rbuilder/Cargo.toml
+++ b/rust/op-rbuilder/crates/op-rbuilder/Cargo.toml
@@ -169,7 +169,7 @@ hyper-util = { version = "0.1.11" }
 http-body-util = { version = "0.1.3" }
 
 [features]
-default = ["jemalloc", "docker-tests", "interop"]
+default = ["jemalloc", "docker-tests"]
 
 # Gates the smoke tests under `src/tests/smoke.rs` that cross-validate
 # against an external op-reth via testcontainers (needs the host's
@@ -207,8 +207,6 @@ testing = [
     "hyper-util",
     "http-body-util",
 ]
-
-interop = []
 
 telemetry = ["reth-tracing-otlp", "opentelemetry"]
 

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
@@ -31,7 +31,7 @@ use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
 use reth_optimism_txpool::{
     conditional::MaybeConditionalTransaction,
     estimated_da_size::DataAvailabilitySized,
-    interop::{MaybeInteropTransaction, is_valid_interop},
+    interop::{InteropFailsafe, MaybeInteropTransaction, is_interop_tx, is_valid_interop},
 };
 use reth_payload_builder::PayloadId;
 use reth_primitives_traits::{InMemorySize, SealedHeader, SignedTransaction};
@@ -166,6 +166,8 @@ pub struct OpPayloadBuilderCtx<ExtraCtx: Debug + Default = ()> {
     /// fallback block, each flashblock, canonical replay — observes the same decision even if
     /// the admin RPC flips the operator opt-in mid-block.
     pub post_exec_mode: PostExecMode,
+    /// Interop failsafe gate shared with the txpool interop filter.
+    pub interop_failsafe: InteropFailsafe,
 }
 
 impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
@@ -490,6 +492,8 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
             number: self.block_number(),
             timestamp: self.attributes().timestamp(),
         };
+        let interop_filter_enabled = cfg!(feature = "interop");
+        let interop_failsafe_active = self.interop_failsafe.enabled();
 
         while let Some(tx) = best_txs.next(()) {
             let interop = tx.interop_deadline();
@@ -529,19 +533,6 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
                 continue;
             }
 
-            // TODO: remove this condition and feature once we are comfortable enabling interop for everything
-            if cfg!(feature = "interop") {
-                // We skip invalid cross chain txs, they would be removed on the next block update in
-                // the maintenance job
-                if let Some(interop) = interop
-                    && !is_valid_interop(interop, self.config.attributes.timestamp())
-                {
-                    log_txn(TxnExecutionResult::InteropFailed);
-                    best_txs.mark_invalid(tx.signer(), tx.nonce());
-                    continue;
-                }
-            }
-
             // ensure we still have capacity for this transaction
             if let Err(result) = info.is_tx_over_limits(
                 tx_da_size,
@@ -565,6 +556,24 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
                 log_txn(TxnExecutionResult::SequencerTransaction);
                 best_txs.mark_invalid(tx.signer(), tx.nonce());
                 continue;
+            }
+
+            if interop_filter_enabled {
+                if interop_failsafe_active && is_interop_tx(&*tx) {
+                    log_txn(TxnExecutionResult::InteropFailed);
+                    best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    continue;
+                }
+
+                // We skip invalid cross chain txs, they would be removed on the next block update in
+                // the maintenance job
+                if let Some(interop) = interop
+                    && !is_valid_interop(interop, self.config.attributes.timestamp())
+                {
+                    log_txn(TxnExecutionResult::InteropFailed);
+                    best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    continue;
+                }
             }
 
             // check if the job was cancelled, if so we can exit early
@@ -712,5 +721,202 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
             bundles_reverted = num_bundles_reverted,
         );
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gas_limiter::args::GasLimiterArgs;
+    use crate::tx::FBPooledTransaction;
+    use alloy_consensus::{
+        Header, SignableTransaction, TxEip1559,
+        transaction::{Recovered, TxHashRef},
+    };
+    use alloy_eips::eip2930::{AccessList, AccessListItem};
+    use alloy_primitives::{Address, B256, Signature, TxHash, TxKind, U256};
+    use reth_evm::ConfigureEvm;
+    use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
+    use reth_optimism_txpool::{OpPooledTransaction, interop_filter::CROSS_L2_INBOX_ADDRESS};
+    use reth_payload_util::PayloadTransactionsFixed;
+    use reth_primitives_traits::{Account, SealedHeader};
+    use reth_revm::{database::StateProviderDatabase, db::State, test_utils::StateProviderTest};
+    use reth_transaction_pool::PoolTransaction;
+
+    fn pooled_tx(
+        nonce: u64,
+        signer: Address,
+        recipient: Address,
+        access_list: AccessList,
+    ) -> FBPooledTransaction {
+        let tx: OpTransactionSigned = TxEip1559 {
+            chain_id: 10,
+            nonce,
+            gas_limit: 100_000,
+            max_fee_per_gas: 20_000_000_000,
+            max_priority_fee_per_gas: 1,
+            to: TxKind::Call(recipient),
+            value: U256::ZERO,
+            access_list,
+            ..Default::default()
+        }
+        .into_signed(Signature::test_signature())
+        .into();
+        let encoded_len = tx.encode_2718_len();
+
+        FBPooledTransaction {
+            inner: OpPooledTransaction::new(Recovered::new_unchecked(tx, signer), encoded_len),
+            reverted_hashes: None,
+            flashblock_number_min: None,
+            flashblock_number_max: None,
+        }
+    }
+
+    fn normal_pooled_tx(nonce: u64, signer: Address, recipient: Address) -> FBPooledTransaction {
+        pooled_tx(nonce, signer, recipient, AccessList::default())
+    }
+
+    fn interop_pooled_tx(nonce: u64, signer: Address, recipient: Address) -> FBPooledTransaction {
+        pooled_tx(
+            nonce,
+            signer,
+            recipient,
+            AccessList(vec![AccessListItem {
+                address: CROSS_L2_INBOX_ADDRESS,
+                storage_keys: vec![B256::ZERO],
+            }]),
+        )
+    }
+
+    fn payload_builder_ctx(
+        chain_spec: Arc<OpChainSpec>,
+        gas_limit: u64,
+        interop_failsafe: InteropFailsafe,
+    ) -> OpPayloadBuilderCtx {
+        let parent = SealedHeader::seal_slow(Header {
+            gas_limit,
+            number: 0,
+            timestamp: 0,
+            ..Default::default()
+        });
+        let attributes = OpPayloadBuilderAttributes {
+            timestamp: 1,
+            gas_limit: Some(gas_limit),
+            ..Default::default()
+        };
+        let block_env_attributes = OpNextBlockEnvAttributes {
+            timestamp: attributes.timestamp(),
+            suggested_fee_recipient: attributes.suggested_fee_recipient(),
+            prev_randao: attributes.prev_randao(),
+            gas_limit: attributes.gas_limit.unwrap_or(parent.gas_limit),
+            parent_beacon_block_root: attributes.parent_beacon_block_root(),
+            extra_data: Default::default(),
+        };
+        let evm_config = OpEvmConfig::optimism(chain_spec.clone());
+        let evm_env = evm_config
+            .next_evm_env(&parent, &block_env_attributes)
+            .expect("next evm env can be created");
+
+        OpPayloadBuilderCtx {
+            evm_config,
+            da_config: Default::default(),
+            gas_limit_config: Default::default(),
+            chain_spec,
+            config: PayloadConfig {
+                parent_header: Arc::new(parent),
+                parent_block_info: None,
+                payload_id: attributes.id,
+                attributes,
+            },
+            evm_env,
+            block_env_attributes,
+            cancel: Default::default(),
+            builder_signer: None,
+            metrics: Default::default(),
+            extra_ctx: (),
+            max_gas_per_txn: None,
+            address_gas_limiter: AddressGasLimiter::new(GasLimiterArgs::default()),
+            post_exec_mode: PostExecMode::Disabled,
+            interop_failsafe,
+        }
+    }
+
+    fn run_execute_best_transactions(
+        ctx: OpPayloadBuilderCtx,
+        signer: Address,
+        txs: Vec<FBPooledTransaction>,
+    ) -> Vec<TxHash> {
+        let mut state_provider = StateProviderTest::default();
+        state_provider.insert_account(
+            signer,
+            Account {
+                balance: U256::MAX,
+                ..Default::default()
+            },
+            None,
+            Default::default(),
+        );
+
+        let mut best_txs = PayloadTransactionsFixed::new(txs);
+        let mut db = State::builder()
+            .with_database(StateProviderDatabase::new(&state_provider))
+            .with_bundle_update()
+            .build();
+        let mut builder = ctx
+            .block_builder_for_next_block(&mut db)
+            .expect("block builder can be created");
+        let mut info: ExecutionInfo = ExecutionInfo::default();
+
+        assert!(
+            ctx.execute_best_transactions(
+                &mut info,
+                &mut builder,
+                &mut best_txs,
+                ctx.block_gas_limit(),
+                None,
+                None,
+            )
+            .expect("best transactions execute")
+            .is_none()
+        );
+
+        info.executed_transactions
+            .iter()
+            .map(TxHashRef::tx_hash)
+            .copied()
+            .collect()
+    }
+
+    #[test]
+    fn execute_best_transactions_excludes_interop_txs_when_failsafe_active() {
+        let signer = Address::repeat_byte(0x11);
+        let normal = normal_pooled_tx(0, signer, Address::repeat_byte(0x22));
+        let interop = interop_pooled_tx(1, signer, Address::repeat_byte(0x33));
+        let normal_hash = *normal.hash();
+        let interop_hash = *interop.hash();
+
+        let gas_limit = 1_000_000;
+        let chain_spec = Arc::new(
+            OpChainSpecBuilder::optimism_mainnet()
+                .regolith_activated()
+                .build(),
+        );
+        let failsafe = InteropFailsafe::default();
+        let build = |failsafe: &InteropFailsafe| {
+            run_execute_best_transactions(
+                payload_builder_ctx(chain_spec.clone(), gas_limit, failsafe.clone()),
+                signer,
+                vec![normal.clone(), interop.clone()],
+            )
+        };
+
+        failsafe.set(false);
+        assert_eq!(build(&failsafe), vec![normal_hash, interop_hash]);
+
+        failsafe.set(true);
+        assert_eq!(build(&failsafe), vec![normal_hash]);
+
+        failsafe.set(false);
+        assert_eq!(build(&failsafe), vec![normal_hash, interop_hash]);
     }
 }

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
@@ -492,7 +492,6 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
             number: self.block_number(),
             timestamp: self.attributes().timestamp(),
         };
-        let interop_filter_enabled = cfg!(feature = "interop");
         let interop_failsafe_active = self.interop_failsafe.enabled();
 
         while let Some(tx) = best_txs.next(()) {
@@ -558,22 +557,20 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
                 continue;
             }
 
-            if interop_filter_enabled {
-                if interop_failsafe_active && is_interop_tx(&*tx) {
-                    log_txn(TxnExecutionResult::InteropFailed);
-                    best_txs.mark_invalid(tx.signer(), tx.nonce());
-                    continue;
-                }
+            if interop_failsafe_active && is_interop_tx(&*tx) {
+                log_txn(TxnExecutionResult::InteropFailed);
+                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                continue;
+            }
 
-                // We skip invalid cross chain txs, they would be removed on the next block update in
-                // the maintenance job
-                if let Some(interop) = interop
-                    && !is_valid_interop(interop, self.config.attributes.timestamp())
-                {
-                    log_txn(TxnExecutionResult::InteropFailed);
-                    best_txs.mark_invalid(tx.signer(), tx.nonce());
-                    continue;
-                }
+            // We skip invalid cross chain txs, they would be removed on the next block update in
+            // the maintenance job
+            if let Some(interop) = interop
+                && !is_valid_interop(interop, self.config.attributes.timestamp())
+            {
+                log_txn(TxnExecutionResult::InteropFailed);
+                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                continue;
             }
 
             // check if the job was cancelled, if so we can exit early
@@ -727,8 +724,7 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::gas_limiter::args::GasLimiterArgs;
-    use crate::tx::FBPooledTransaction;
+    use crate::{gas_limiter::args::GasLimiterArgs, tx::FBPooledTransaction};
     use alloy_consensus::{
         Header, SignableTransaction, TxEip1559,
         transaction::{Recovered, TxHashRef},

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/ctx.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/ctx.rs
@@ -35,6 +35,8 @@ pub(super) struct OpPayloadSyncerCtx {
     metrics: Arc<OpRBuilderMetrics>,
     /// Operator opt-in flag for SDM PostExec production, shared with the admin RPC.
     sdm_post_exec_opt_in: SdmPostExecOptInFlag,
+    /// Interop failsafe gate shared with the txpool interop filter.
+    interop_failsafe: reth_optimism_txpool::interop::InteropFailsafe,
 }
 
 impl OpPayloadSyncerCtx {
@@ -55,6 +57,7 @@ impl OpPayloadSyncerCtx {
             max_gas_per_txn: builder_config.max_gas_per_txn,
             metrics,
             sdm_post_exec_opt_in: builder_config.sdm_post_exec_opt_in.clone(),
+            interop_failsafe: builder_config.interop_failsafe.clone(),
         })
     }
 
@@ -93,6 +96,7 @@ impl OpPayloadSyncerCtx {
             max_gas_per_txn: self.max_gas_per_txn,
             address_gas_limiter: AddressGasLimiter::new(GasLimiterArgs::default()),
             post_exec_mode,
+            interop_failsafe: self.interop_failsafe,
         }
     }
 }

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -331,6 +331,7 @@ where
             max_gas_per_txn: self.config.max_gas_per_txn,
             address_gas_limiter: self.address_gas_limiter.clone(),
             post_exec_mode,
+            interop_failsafe: self.config.interop_failsafe.clone(),
         })
     }
 

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/mod.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/mod.rs
@@ -6,6 +6,7 @@ use core::{
 use reth_node_builder::components::PayloadServiceBuilder;
 use reth_optimism_evm::OpEvmConfig;
 use reth_optimism_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
+use reth_optimism_txpool::interop::InteropFailsafe;
 
 use crate::{
     args::OpRbuilderArgs,
@@ -131,6 +132,9 @@ pub struct BuilderConfig<Specific: Clone> {
     /// Interop gate in [`OpPayloadBuilderCtx::post_exec_mode`]; both must be true to
     /// produce a PostExec tx. Mutated via the `admin_setSdmPostExecOptIn` RPC.
     pub sdm_post_exec_opt_in: crate::sdm_admin::SdmPostExecOptInFlag,
+
+    /// Interop failsafe gate shared between the txpool interop filter and payload builder.
+    pub interop_failsafe: InteropFailsafe,
 }
 
 impl<S: Debug + Clone> core::fmt::Debug for BuilderConfig<S> {
@@ -153,6 +157,7 @@ impl<S: Debug + Clone> core::fmt::Debug for BuilderConfig<S> {
             .field("specific", &self.specific)
             .field("max_gas_per_txn", &self.max_gas_per_txn)
             .field("gas_limiter_config", &self.gas_limiter_config)
+            .field("interop_failsafe_enabled", &self.interop_failsafe.enabled())
             .finish()
     }
 }
@@ -172,6 +177,7 @@ impl<S: Default + Clone> Default for BuilderConfig<S> {
             max_gas_per_txn: None,
             gas_limiter_config: GasLimiterArgs::default(),
             sdm_post_exec_opt_in: Default::default(),
+            interop_failsafe: Default::default(),
         }
     }
 }
@@ -195,6 +201,7 @@ where
             max_gas_per_txn: args.max_gas_per_txn,
             gas_limiter_config: args.gas_limiter.clone(),
             sdm_post_exec_opt_in: Default::default(),
+            interop_failsafe: Default::default(),
             specific: S::try_from(args)?,
         })
     }

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/standard/payload.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/standard/payload.rs
@@ -282,6 +282,7 @@ where
             max_gas_per_txn: self.config.max_gas_per_txn,
             address_gas_limiter: self.address_gas_limiter.clone(),
             post_exec_mode,
+            interop_failsafe: self.config.interop_failsafe.clone(),
         };
 
         let builder = OpBuilder::new(best);

--- a/rust/op-rbuilder/crates/op-rbuilder/src/launcher.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/launcher.rs
@@ -108,6 +108,7 @@ where
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
         let sdm_post_exec_opt_in = builder_config.sdm_post_exec_opt_in.clone();
+        let interop_failsafe = builder_config.interop_failsafe.clone();
         let rollup_args = builder_args.rollup_args;
         let op_node = OpNode::new(rollup_args.clone());
         let reverted_cache = Cache::builder().max_capacity(100).build();
@@ -146,7 +147,8 @@ where
                                 rollup_args.interop_http.clone(),
                                 rollup_args.interop_min_responses,
                                 rollup_args.interop_safety_level,
-                            ),
+                            )
+                            .with_interop_failsafe(interop_failsafe),
                     )
                     .payload(B::new_service(builder_config)?),
             )

--- a/rust/op-rbuilder/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -116,6 +116,7 @@ impl LocalInstance {
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
         let sdm_post_exec_opt_in = builder_config.sdm_post_exec_opt_in.clone();
+        let interop_failsafe = builder_config.interop_failsafe.clone();
 
         let addons: OpAddOns<
             _,
@@ -136,7 +137,7 @@ impl LocalInstance {
             .with_components(
                 op_node
                     .components()
-                    .pool(pool_component(&args))
+                    .pool(pool_component(&args, interop_failsafe))
                     .payload(P::new_service(builder_config)?),
             )
             .with_add_ons(addons)
@@ -382,7 +383,10 @@ fn task_manager() -> Runtime {
     Runtime::test()
 }
 
-fn pool_component(args: &OpRbuilderArgs) -> OpPoolBuilder<FBPooledTransaction> {
+fn pool_component(
+    args: &OpRbuilderArgs,
+    interop_failsafe: reth_optimism_txpool::interop::InteropFailsafe,
+) -> OpPoolBuilder<FBPooledTransaction> {
     let rollup_args = &args.rollup_args;
     OpPoolBuilder::<FBPooledTransaction>::default()
         .with_enable_tx_conditional(
@@ -395,6 +399,7 @@ fn pool_component(args: &OpRbuilderArgs) -> OpPoolBuilder<FBPooledTransaction> {
             rollup_args.interop_min_responses,
             rollup_args.interop_safety_level,
         )
+        .with_interop_failsafe(interop_failsafe)
 }
 
 async fn spawn_attestation_provider() -> eyre::Result<AttestationServer> {


### PR DESCRIPTION
Enables op-rbuilder's existing `interop` feature by default and threads the shared `InteropFailsafe` handle through the custom rbuilder pool and payload-builder paths.

While the feature is enabled, the rbuilder payload loop now mirrors op-reth's failsafe behavior by excluding intrinsic CrossL2Inbox access-list transactions whenever the interop filter reports failsafe active. The feature toggle remains available for non-default builds.