### PR TITLE
docs(ai): document the op-core/superchain bundle build/CI prerequisite

### DIFF
--- a/docs/ai/ci-ops.md
+++ b/docs/ai/ci-ops.md
@@ -21,6 +21,37 @@ branch that only added a new `op-core/types` package. The diff touched nothing i
 `op-deployer`; the failures were a data-dependent flake already fixed on `develop` by
 #21396. Rebasing made CI green with no change to the branch's own work.
 
+## Missing `op-core/superchain` bundle (`superchain-configs.zip`)
+
+A CI-only compile error like:
+
+```
+op-core/superchain/chain.go:NN: pattern superchain-configs.zip: no matching files found
+```
+
+means the job builds Go that transitively links `op-core/superchain` without the bundle
+it `//go:embed`s. The zip is **gitignored** and built only by the `prep-superchain` job
+(or `just build-superchain-go` locally), so **every** job that compiles an
+`op-core/superchain` linker must provision it. The linker set is large and grows silently
+— op-node and the other binaries, but also `packages/contracts-bedrock/scripts/go-ffi`,
+`op-e2e`, `op-acceptance-tests`, op-deployer, and the kona/op-reth Go tests — so a
+**Go-only** change can red-wash unrelated-looking jobs (contracts-bedrock, fuzz-golang,
+rust-e2e) all at compile time. It passes locally and in review because the developer
+already has the zip on disk (see [go-dev.md](go-dev.md)).
+
+Provision the bundle in the failing job:
+
+- **`main.yml` jobs** (the `prep-superchain` job lives in that workflow): add
+  `prep-superchain` to the job's `requires` and attach its workspace
+  (`uses_artifacts: true`) — the same pattern `go-tests` uses.
+- **Other workflows** (`rust-ci.yml`, `rust-e2e.yml` — no `prep-superchain` job there):
+  add an in-job `just build-superchain-go` step (verify mode: regenerates from the
+  superchain-registry submodule and asserts the committed `.sha256`).
+- **`just` recipes** that compile such Go (e.g. the contracts `build-go-ffi`): have the
+  recipe run `just build-superchain-go` first.
+
+When adding a new `op-core/superchain` consumer, audit every CI job that compiles it.
+
 ## TODO Checker Failures
 
 The repo runs a scheduled CircleCI job every 4 hours that validates TODO comments don't reference closed GitHub issues. When this job fails, issues need to be reopened.

--- a/docs/ai/ci-ops.md
+++ b/docs/ai/ci-ops.md
@@ -34,7 +34,7 @@ it `//go:embed`s. The zip is **gitignored** and built only by the `prep-supercha
 (or `just build-superchain-go` locally), so **every** job that compiles an
 `op-core/superchain` linker must provision it. The linker set is large and grows silently
 — op-node and the other binaries, but also `packages/contracts-bedrock/scripts/go-ffi`,
-`op-e2e`, `op-acceptance-tests`, op-deployer, and the kona/op-reth Go tests — so a
+`op-e2e`, `op-acceptance-tests`, `op-deployer`, and the `kona`/`op-reth` Go tests — so a
 **Go-only** change can red-wash unrelated-looking jobs (contracts-bedrock, fuzz-golang,
 rust-e2e) all at compile time. It passes locally and in review because the developer
 already has the zip on disk (see [go-dev.md](go-dev.md)).

--- a/docs/ai/go-dev.md
+++ b/docs/ai/go-dev.md
@@ -14,6 +14,30 @@ just ./op-node/op-node
 just build-go
 ```
 
+### The `op-core/superchain` bundle
+
+`op-core/superchain` `//go:embed`s `superchain-configs.zip`, which is **gitignored** (only
+its `.sha256` is committed). Any package that transitively imports it — op-node and most
+binaries, plus `packages/contracts-bedrock/scripts/go-ffi`, `op-e2e`, `op-acceptance-tests`,
+op-deployer, and the kona/op-reth Go tests — won't compile until the bundle is built:
+
+```
+op-core/superchain/chain.go:NN: pattern superchain-configs.zip: no matching files found
+```
+
+The `just` targets handle this: `just build-go`, `just go-tests`, and `just lint-go` all
+depend on `build-superchain-go`, which builds the bundle from the superchain-registry
+submodule and verifies it against the committed `.sha256`. You only hit the embed error on
+a **bare** `go build`/`go test` or a fresh checkout. To prep it manually:
+
+```bash
+just build-superchain-go   # Go bundle only (fast; verify mode)
+just sync-superchain        # all superchain bundles (Go + kona/op-reth Rust) — the registry-bump command
+```
+
+Because the zip is usually already on disk, a missing-bundle problem is invisible locally
+and only surfaces in CI's clean checkout (see [ci-ops.md](ci-ops.md)).
+
 ### Running Tests
 
 ```bash


### PR DESCRIPTION
## Summary

`op-core/superchain` `//go:embed`s a gitignored `superchain-configs.zip` (built only by the `prep-superchain` CI job / `just build-superchain-go` locally), so any package that *transitively* links it fails to compile — `pattern superchain-configs.zip: no matching files found` — until the bundle is built.

This bit #21487 (the op-geth superchain decoupling) hard: a **Go-only** change red-washed a swath of unrelated-looking CI jobs (contracts-bedrock, fuzz-golang, rust-e2e) all at compile time, while passing locally and in review because the developer already has the zip on disk. Documenting it from both angles so the next person finds it:

- **`docs/ai/ci-ops.md`** — the CI-failure symptom + how to provision the bundle per job (attach the `prep-superchain` workspace, an in-job `just build-superchain-go`, or have the recipe build it).
- **`docs/ai/go-dev.md`** — the local-dev angle: the `just` build/test/lint targets prep it automatically (they depend on `build-superchain-go`); for a bare `go build`/`go test` run `just build-superchain-go` (or `just sync-superchain` to prep all Go + Rust bundles).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
