### PR TITLE
fix(op-reth): enable superchain-configs for reth-optimism-evm tests

### DIFF
--- a/rust/op-reth/crates/evm/Cargo.toml
+++ b/rust/op-reth/crates/evm/Cargo.toml
@@ -51,6 +51,7 @@ reth-revm = { workspace = true, features = ["test-utils"] }
 alloy-genesis.workspace = true
 serde_json.workspace = true
 reth-optimism-primitives = { workspace = true, features = ["arbitrary"] }
+reth-optimism-chainspec = { workspace = true, features = ["superchain-configs"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
## Problem

`cargo check -p reth-optimism-evm --tests` fails to compile:

```
error[E0432]: unresolved import `reth_optimism_chainspec::OP_MAINNET`
error[E0599]: no function or associated item named `optimism_mainnet` found for struct `OpChainSpecBuilder`
```

The crate's test modules reference `OP_MAINNET` and `OpChainSpecBuilder::optimism_mainnet()`, both of which were moved behind the `superchain-configs` feature of `reth-optimism-chainspec` during the superchain decoupling work (#21397 / #21487). That feature is not enabled by default, so the lib compiles but `--tests` does not.

## Fix

Add a dev-dependency on `reth-optimism-chainspec` with `superchain-configs` enabled, so the tests compile against the real OP Mainnet chain spec. Test semantics are unchanged (still exercising regolith/canyon activation against OP Mainnet); only the test build's feature surface changes.

## Verification

- `cargo check -p reth-optimism-evm --tests` → passes
- `cargo test -p reth-optimism-evm` → 29 passed; 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)