### PR TITLE
fix(sdm): stabilize PostExec consensus surface (Verify 0x7D guard + opt-in TOCTOU)

### DIFF
--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -231,6 +231,12 @@ impl PostExecState {
             _ => Vec::new(),
         }
     }
+
+    /// Whether a `Verify` block had a post-exec payload but no trailing `0x7D`.
+    /// Per-tx settlement can consume all verifier entries, so check this separately.
+    const fn missing_post_exec_tx(&self) -> bool {
+        matches!(self, Self::Verifying { saw_post_exec_tx: false, .. })
+    }
 }
 
 /// Context for OP block execution.
@@ -1113,6 +1119,12 @@ where
                 indexes.len(),
                 indexes,
             )));
+        }
+
+        if self.post_exec.missing_post_exec_tx() {
+            return Err(Self::invalid_post_exec_payload(
+                "post-exec payload present but block carries no post-exec tx",
+            ));
         }
 
         let balance_increments =

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -1263,6 +1263,40 @@ mod sdm {
         );
     }
 
+    /// A `Verify` block must include `0x7D` even when normal txs consume every verifier entry;
+    /// otherwise the payload-vs-block byte check is skipped.
+    #[test]
+    fn test_finish_rejects_verify_block_missing_post_exec_tx() {
+        const BLOCK_GAS_LIMIT: u64 = 100_000;
+        let target = Address::from([0x11; 20]);
+        let tx0 = legacy_tx(0, target);
+        let tx1 = legacy_tx(1, target);
+        // Make tx1 consume its verifier entry during normal settlement.
+        let entries = full_refund_for_second_tx(BLOCK_GAS_LIMIT, &tx0, &tx1);
+
+        let mut fixture = SDMExecutorFixture::new(
+            DEFAULT_DA_FOOTPRINT_GAS_SCALAR,
+            BLOCK_GAS_LIMIT,
+            JOVIAN_TIMESTAMP,
+        );
+        let mut verifier = fixture.verifier(0, entries);
+        verifier.execute_transaction(&tx0).expect("first tx executes");
+        verifier.execute_transaction(&tx1).expect("refunded tx consumes its verifier entry");
+        assert!(
+            verifier.post_exec.remaining_verifier_indexes().is_empty(),
+            "the refunded tx must already have drained every verifier entry",
+        );
+
+        // No 0x7D ran, so only the missing-tx guard can catch this.
+        let Err(err) = verifier.finish() else {
+            panic!("a Verify block that applies refunds but omits the 0x7D must be rejected");
+        };
+        assert_invalid_post_exec(
+            err,
+            "post-exec payload present but block carries no post-exec tx",
+        );
+    }
+
     /// Followers running with SDM disabled must reject any block that carries a post-exec
     /// 0x7D tx. Silently short-circuiting the tx (which is what the pre-guard code did) would
     /// let a producer ship a payload with arbitrary refund entries that no follower validates,

--- a/rust/op-rbuilder/Cargo.lock
+++ b/rust/op-rbuilder/Cargo.lock
@@ -11310,6 +11310,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-node-api",
  "reth-optimism-evm",
+ "reth-optimism-primitives",
  "reth-primitives-traits",
  "revm",
  "serde",

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -466,7 +466,11 @@ impl<Txs> OpBuilder<'_, Txs> {
         // scalar.
         db.load_cache_account(L1_BLOCK_CONTRACT).map_err(BlockExecutionError::other)?;
 
-        let mut builder = ctx.block_builder(&mut db)?;
+        // Snapshot the runtime-mutable mode so EVM setup and `0x7D` appending agree.
+        let post_exec_mode = ctx.post_exec_mode()?;
+        let produce_post_exec = matches!(post_exec_mode, PostExecMode::Produce);
+
+        let mut builder = ctx.block_builder_with_mode(&mut db, post_exec_mode)?;
 
         // 1. apply pre-execution changes
         builder.apply_pre_execution_changes().map_err(|err| {
@@ -494,9 +498,8 @@ impl<Txs> OpBuilder<'_, Txs> {
             }
         }
 
-        // Only locally-sequenced blocks append a post-exec tx; a derived block (force_empty)
-        // already carries its own `0x7D`, so appending would duplicate it. See `post_exec_mode`.
-        let sdm_refund_gas = if !ctx.force_empty() && ctx.sdm_production_enabled() {
+        // Only `Produce` appends `0x7D`; derived blocks verify any embedded tx instead.
+        let sdm_refund_gas = if produce_post_exec {
             let block_number = builder.evm_mut().block().number().saturating_to();
             let entries = builder.executor_mut().take_post_exec_entries();
             let refund_gas = self::sdm_refund_gas(&entries);
@@ -845,7 +848,8 @@ where
         is_better_payload(self.best_payload.as_ref(), total_fees)
     }
 
-    /// Prepares a [`BlockBuilder`] for the next block.
+    /// Prepares a [`BlockBuilder`] using this payload's current post-exec mode.
+    /// Use [`Self::block_builder_with_mode`] when the caller already snapped the mode.
     pub fn block_builder<'a, DB: Database>(
         &'a self,
         db: &'a mut State<DB>,
@@ -856,8 +860,21 @@ where
         > + 'a,
         PayloadBuilderError,
     > {
-        let post_exec_mode = self.post_exec_mode()?;
+        self.block_builder_with_mode(db, self.post_exec_mode()?)
+    }
 
+    /// Prepares a [`BlockBuilder`] with a caller-supplied post-exec mode.
+    pub fn block_builder_with_mode<'a, DB: Database>(
+        &'a self,
+        db: &'a mut State<DB>,
+        post_exec_mode: PostExecMode,
+    ) -> Result<
+        impl BlockBuilder<
+            Primitives = Evm::Primitives,
+            Executor: PostExecExecutorExt + BlockExecutor<Result: PreRefundGasUsed>,
+        > + 'a,
+        PayloadBuilderError,
+    > {
         self.evm_config
             .post_exec_builder_for_next_block(
                 db,

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -330,6 +330,43 @@ fn rebuilds_derived_block_with_embedded_post_exec_tx_regardless_of_opt_in() {
     }
 }
 
+/// `block_builder_with_mode` must use the supplied mode snapshot, not the live opt-in.
+/// Mismatch both ways to prove `Produce` still accepts `0x7D` and `Disabled` rejects it.
+#[test]
+fn block_builder_with_mode_honors_snapshot_over_live_opt_in() {
+    // Snapshot pins Produce with opt-in off.
+    let produce_ctx = interop_ctx(false, false, Some(Vec::new()));
+    let provider = StateProviderTest::default();
+    let mut db = State::builder()
+        .with_database(StateProviderDatabase::new(&provider))
+        .with_bundle_update()
+        .build();
+    let mut builder = produce_ctx
+        .block_builder_with_mode(&mut db, PostExecMode::Produce)
+        .expect("block builder can be created");
+    produce_ctx
+        .execute_sequencer_transactions(&mut builder, None)
+        .expect("Produce snapshot accepts the embedded 0x7D even with the opt-in off");
+
+    // Snapshot pins Disabled with opt-in on.
+    let disabled_ctx = interop_ctx(false, true, Some(Vec::new()));
+    let provider = StateProviderTest::default();
+    let mut db = State::builder()
+        .with_database(StateProviderDatabase::new(&provider))
+        .with_bundle_update()
+        .build();
+    let mut builder = disabled_ctx
+        .block_builder_with_mode(&mut db, PostExecMode::Disabled)
+        .expect("block builder can be created");
+    let err = disabled_ctx
+        .execute_sequencer_transactions(&mut builder, None)
+        .expect_err("Disabled snapshot rejects the embedded 0x7D even with the opt-in on");
+    assert!(
+        format!("{err:?}").contains("SDM not active"),
+        "expected the disabled-mode post-exec rejection, got: {err:?}",
+    );
+}
+
 #[test]
 fn execution_info_pre_refund_limit_uses_evm_gas_not_canonical_gas() {
     let mut info = ExecutionInfo::new();

--- a/rust/rollup-boost/Cargo.lock
+++ b/rust/rollup-boost/Cargo.lock
@@ -9346,6 +9346,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-node-api",
  "reth-optimism-evm",
+ "reth-optimism-primitives",
  "reth-primitives-traits",
  "revm",
  "serde",


### PR DESCRIPTION
## Summary

Two consensus-surface pre-work fixes for the SDM PostExec (`0x7D`) machinery, landed ahead of the SDM → optimism-premium extraction (the §4 *Pre-work (remaining)* items: snapshot `PostExecMode` once, and enforce `saw_post_exec_tx` in `finish()`). Both are small, independently reviewable, and behavior-preserving for valid blocks.

### 1. `fix(alloy-op-evm)`: reject Verify blocks missing the trailing `0x7D`
Reject verifier executions that consume an out-of-band post-exec payload without seeing its 0x7D carrier tx
 
### 2. `fix(op-reth)`: snapshot `PostExecMode` once per build (opt-in TOCTOU)
`build()` read the runtime-mutable SDM production opt-in twice — once inside `block_builder()` (mode selection) and again when deciding to append the `0x7D`. An admin-RPC toggle between the reads could yield a block with refunded state but no `0x7D` (or vice versa). `post_exec_mode()` is now resolved **once** and threaded through the new `block_builder_with_mode()`; the append decision derives from the same snapshot (`matches!(mode, Produce)`), which is exactly equivalent to the old `!force_empty() && sdm_production_enabled()` predicate.

## Testing
- New failing-first test `test_finish_rejects_verify_block_missing_post_exec_tx` (alloy-op-evm) — reproduces the hole on baseline, passes with the guard. Full suite 73/73.
- New regression test `block_builder_with_mode_honors_snapshot_over_live_opt_in` (reth-optimism-payload-builder) — asserts the builder honors the passed snapshot regardless of the live opt-in. Suite 23/23.
- `just fmt-fix` clean · `clippy --workspace --all-features --all-targets` clean.

## Notes
- The opt-in TOCTOU is a race; the fix is structural (the second read is removed), so it isn't a deterministically-reproducible failing unit test — the new test instead locks in the single-snapshot contract.
- Per the plan, a clean baseline rev should be tagged after this lands so premium can repoint its `optimism_rev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)