### PR TITLE
feat(kona-protocol): support extended transaction envelopes in L2BlockInfo

### DIFF
--- a/rust/kona/crates/protocol/protocol/src/block.rs
+++ b/rust/kona/crates/protocol/protocol/src/block.rs
@@ -9,7 +9,7 @@ use alloy_rpc_types_engine::{CancunPayloadFields, PraguePayloadFields};
 use alloy_rpc_types_eth::Block as RpcBlock;
 use derive_more::Display;
 use kona_genesis::ChainGenesis;
-use op_alloy_consensus::{OpBlock, OpTxEnvelope};
+use op_alloy_consensus::{OpBlock, OpTransaction};
 use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadSidecar, OpPayloadError};
 
 /// Block Header Info
@@ -177,7 +177,7 @@ impl L2BlockInfo {
     }
 
     /// Constructs an [`L2BlockInfo`] from a given OP [`Block`] and [`ChainGenesis`].
-    pub fn from_block_and_genesis<T: Typed2718 + AsRef<OpTxEnvelope>>(
+    pub fn from_block_and_genesis<T: Typed2718 + OpTransaction>(
         block: &Block<T>,
         genesis: &ChainGenesis,
     ) -> Result<Self, FromBlockError> {
@@ -193,7 +193,7 @@ impl L2BlockInfo {
                 return Err(FromBlockError::MissingL1InfoDeposit(block_info.hash));
             }
 
-            let tx = block.body.transactions[0].as_ref();
+            let tx = &block.body.transactions[0];
             let Some(tx) = tx.as_deposit() else {
                 return Err(FromBlockError::FirstTxNonDeposit(tx.ty()));
             };
@@ -242,7 +242,7 @@ mod tests {
     use alloc::string::ToString;
     use alloy_consensus::{Header, TxEnvelope};
     use alloy_primitives::b256;
-    use op_alloy_consensus::OpBlock;
+    use op_alloy_consensus::{OpBlock, OpTxEnvelope};
 
     #[test]
     fn test_rpc_block_into_info() {

--- a/rust/kona/crates/protocol/protocol/src/block.rs
+++ b/rust/kona/crates/protocol/protocol/src/block.rs
@@ -339,6 +339,49 @@ mod tests {
         assert_eq!(derived, expected);
     }
 
+    /// A non-`OpTxEnvelope` wrapper (here `Recovered<OpTxEnvelope>`, the shape a downstream caller
+    /// holds) must derive an identical [`L2BlockInfo`] to the bare-envelope path.
+    #[test]
+    fn test_from_block_and_genesis_wrapper_parity() {
+        use crate::test_utils::RAW_BEDROCK_INFO_TX;
+        use alloc::{vec, vec::Vec};
+        use alloy_consensus::transaction::Recovered;
+        use alloy_primitives::Address;
+
+        let genesis = ChainGenesis {
+            l1: BlockNumHash { hash: B256::from([4; 32]), number: 2 },
+            l2: BlockNumHash { hash: B256::from([5; 32]), number: 1 },
+            ..Default::default()
+        };
+        let deposit =
+            OpTxEnvelope::Deposit(alloy_primitives::Sealed::new(op_alloy_consensus::TxDeposit {
+                input: alloy_primitives::Bytes::from(&RAW_BEDROCK_INFO_TX),
+                ..Default::default()
+            }));
+        let header = alloy_consensus::Header { number: 3, timestamp: 1, ..Default::default() };
+
+        // Baseline: bare `OpTxEnvelope`.
+        let base_block: OpBlock = alloy_consensus::Block {
+            header: header.clone(),
+            body: alloy_consensus::BlockBody {
+                transactions: vec![deposit.clone()],
+                ..Default::default()
+            },
+        };
+        let baseline = L2BlockInfo::from_block_and_genesis(&base_block, &genesis).unwrap();
+
+        // Same block, first tx wrapped in `Recovered<OpTxEnvelope>`.
+        let wrapped_txs: Vec<Recovered<OpTxEnvelope>> =
+            vec![Recovered::new_unchecked(deposit, Address::ZERO)];
+        let wrapped_block = alloy_consensus::Block {
+            header,
+            body: alloy_consensus::BlockBody { transactions: wrapped_txs, ..Default::default() },
+        };
+        let wrapped = L2BlockInfo::from_block_and_genesis(&wrapped_block, &genesis).unwrap();
+
+        assert_eq!(wrapped, baseline);
+    }
+
     #[test]
     fn test_from_block_error_partial_eq() {
         assert_eq!(FromBlockError::InvalidGenesisHash, FromBlockError::InvalidGenesisHash);

--- a/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
@@ -79,6 +79,20 @@ impl OpTransaction for OpTxEnvelope {
     }
 }
 
+impl<T: OpTransaction> OpTransaction for alloy_consensus::transaction::Recovered<T> {
+    fn is_deposit(&self) -> bool {
+        self.inner().is_deposit()
+    }
+
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        self.inner().as_deposit()
+    }
+
+    fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>> {
+        self.inner().as_post_exec()
+    }
+}
+
 impl<B, T> OpTransaction for Extended<B, T>
 where
     B: OpTransaction,

--- a/rust/op-alloy/crates/rpc-types/src/transaction.rs
+++ b/rust/op-alloy/crates/rpc-types/src/transaction.rs
@@ -1,10 +1,12 @@
 //! Optimism specific types related to transactions.
 
-use alloy_consensus::{Transaction as TransactionTrait, Typed2718, transaction::Recovered};
+use alloy_consensus::{Sealed, Transaction as TransactionTrait, Typed2718, transaction::Recovered};
 use alloy_eips::{Encodable2718, eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, B256, BlockHash, Bytes, ChainId, TxKind, U256};
 use alloy_serde::OtherFields;
-use op_alloy_consensus::{OpTransaction, OpTxEnvelope, transaction::OpTransactionInfo};
+use op_alloy_consensus::{
+    OpTransaction, OpTxEnvelope, TxDeposit, TxPostExec, transaction::OpTransactionInfo,
+};
 use serde::{Deserialize, Serialize};
 
 mod request;
@@ -198,6 +200,20 @@ impl From<OpTransactionFields> for OtherFields {
 impl<T> AsRef<T> for Transaction<T> {
     fn as_ref(&self) -> &T {
         self.inner.as_ref()
+    }
+}
+
+impl<T: OpTransaction> OpTransaction for Transaction<T> {
+    fn is_deposit(&self) -> bool {
+        self.inner.as_ref().is_deposit()
+    }
+
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        self.inner.as_ref().as_deposit()
+    }
+
+    fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>> {
+        self.inner.as_ref().as_post_exec()
     }
 }
 

--- a/rust/op-alloy/crates/rpc-types/src/transaction.rs
+++ b/rust/op-alloy/crates/rpc-types/src/transaction.rs
@@ -203,6 +203,9 @@ impl<T> AsRef<T> for Transaction<T> {
     }
 }
 
+// Deposit classification MUST come from the inner consensus tx, never the `deposit_nonce` /
+// `deposit_receipt_version` RPC side fields (an untrusted peer can set those independently of the
+// inner `type`). Keeps it consistent with the delegated `Typed2718::ty()`; guarded by the test.
 impl<T: OpTransaction> OpTransaction for Transaction<T> {
     fn is_deposit(&self) -> bool {
         self.inner.as_ref().is_deposit()
@@ -408,5 +411,47 @@ mod tests {
         assert_eq!(value.get("from"), Some(&serde_json::to_value(Address::ZERO).unwrap()));
         assert!(value.get("gasRefundEntries").is_none());
         assert!(value.get("version").is_none());
+    }
+
+    /// Deposit classification on the rpc wrapper derives from the inner consensus tx, never the
+    /// `depositReceiptVersion`/`depositNonce` side fields — including across the serde round-trip,
+    /// where a peer can attach `depositReceiptVersion` to a non-deposit tx.
+    #[test]
+    fn deposit_classification_ignores_side_fields() {
+        use alloy_consensus::{Sealable, SignableTransaction, TxEip1559, Typed2718};
+        use alloy_primitives::Signature;
+
+        let deposit = Transaction::from_transaction(
+            Recovered::new_unchecked(
+                OpTxEnvelope::Deposit(TxDeposit::default().seal_slow()),
+                Address::ZERO,
+            ),
+            OpTransactionInfo::default(),
+        );
+        assert!(OpTransaction::is_deposit(&deposit));
+        assert_eq!(OpTransaction::as_deposit(&deposit).is_some(), deposit.ty() == 0x7e);
+
+        let eip1559 = Transaction::from_transaction(
+            Recovered::new_unchecked(
+                OpTxEnvelope::Eip1559(
+                    TxEip1559::default().into_signed(Signature::test_signature()),
+                ),
+                Address::ZERO,
+            ),
+            OpTransactionInfo::default(),
+        );
+        assert!(!OpTransaction::is_deposit(&eip1559));
+
+        // `depositReceiptVersion` injected on the non-deposit tx survives deserialization (unlike
+        // `depositNonce`, it is not filtered) but must not flip classification.
+        let mut value = serde_json::to_value(&eip1559).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("depositReceiptVersion".into(), serde_json::json!("0x1"));
+        let tx = serde_json::from_value::<Transaction>(value).unwrap();
+        assert_eq!(tx.deposit_receipt_version, Some(1));
+        assert!(!OpTransaction::is_deposit(&tx));
+        assert!(OpTransaction::as_deposit(&tx).is_none());
     }
 }


### PR DESCRIPTION
Follow-up to #21275. Relaxes `L2BlockInfo::from_block_and_genesis` off OpTxEnvelope so a downstream chain (Celo, CIP-64 envelope) can reuse kona-driver unmodified.

- **`kona-protocol`**: relax `L2BlockInfo::from_block_and_genesis` from `T: Typed2718 + AsRef<OpTxEnvelope>` to `T: Typed2718 + OpTransaction`, reading the first tx via `tx.as_deposit()`. That's all the function needs, and `AsRef<OpTxEnvelope>` is unimplementable for extended envelopes (no inner `OpTxEnvelope` to borrow).
- **`op-alloy`** (in-monorepo): add delegating blanket `OpTransaction` impls for `Recovered<T>` and the rpc `Transaction<T>` wrapper, mirroring the existing `Extended<B, T>` impl. No in-tree caller passes these (all lower to `OpTxEnvelope` first); they exist so a downstream envelope gets `OpTransaction for Recovered<_>` / `Transaction<_>` for free once it implements `OpTransaction`.

These impls can't live downstream — the orphan rule forbids `impl OpTransaction for Recovered<CeloEnvelope>` from a downstream crate (both trait and wrapper are foreign, the local envelope is covered).

## API impact

Semver-visible: a `T` implementing `AsRef<OpTxEnvelope>` but not `OpTransaction` no longer compiles. `OpTransaction` is already impl'd for `OpTxEnvelope` and `Extended<B, T>`, so typical callers are unaffected.

## Tests

- `deposit_classification_ignores_side_fields` (op-alloy): the rpc wrapper classifies deposits from the inner consensus tx, not the `depositReceiptVersion`/`depositNonce` side fields — including across the serde round-trip, where a peer can attach `depositReceiptVersion` to a non-deposit tx. (Documents a pre-existing, harmless deserializer asymmetry: `depositNonce` is filtered on non-deposits, `depositReceiptVersion` isn't.)
- `test_from_block_and_genesis_wrapper_parity` (kona-protocol): same block as `OpTxEnvelope` vs `Recovered<OpTxEnvelope>` derives identical `L2BlockInfo`.