### PR TITLE
fix(kona/protocol): bump brotli-decompressor to 5.0.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2083,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6352,6 +6352,7 @@ dependencies = [
  "arbitrary",
  "async-trait",
  "brotli",
+ "brotli-decompressor",
  "derive_more",
  "kona-genesis",
  "kona-registry",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -563,6 +563,9 @@ test-fuzz = "7.2.5"
 # ==================== COMPRESSION ====================
 alloc-no-stdlib = "2.0.4"
 brotli = { version = "8.0.2", default-features = false }
+# Floor at 5.0.1, which fixes a silently-dropped RFC 7932 §9.2 padding error
+# (dropbox/rust-brotli-decompressor#44) that otherwise diverges from op-node.
+brotli-decompressor = { version = "5.0.1", default-features = false }
 getrandom = "0.3.4"
 lz4 = "1.28.1"
 lz4_flex = { version = "0.12", default-features = false }

--- a/rust/kona/crates/protocol/protocol/Cargo.toml
+++ b/rust/kona/crates/protocol/protocol/Cargo.toml
@@ -40,7 +40,7 @@ unsigned-varint.workspace = true
 derive_more = { workspace = true, features = ["display"] }
 
 # Compression
-brotli.workspace = true
+brotli-decompressor.workspace = true
 miniz_oxide.workspace = true
 alloc-no-stdlib.workspace = true
 
@@ -84,7 +84,7 @@ std = [
 	"alloy-rpc-types-engine/std",
 	"alloy-rpc-types-eth/std",
 	"alloy-serde?/std",
-	"brotli/std",
+	"brotli-decompressor/std",
 	"derive_more/std",
 	"kona-genesis/std",
 	"miniz_oxide/std",

--- a/rust/kona/crates/protocol/protocol/src/brotli.rs
+++ b/rust/kona/crates/protocol/protocol/src/brotli.rs
@@ -2,7 +2,7 @@
 
 use alloc::{vec, vec::Vec};
 use alloc_no_stdlib::*;
-use brotli::{BrotliResult, *};
+use brotli_decompressor::{BrotliResult, *};
 use core::ops;
 
 /// A brotli decompression error.
@@ -14,7 +14,7 @@ pub enum BrotliDecompressionError {
 }
 
 /// Decompresses the given bytes data using the Brotli decompressor implemented
-/// in the [`brotli`](https://crates.io/crates/brotli) crate.
+/// in the [`brotli-decompressor`](https://crates.io/crates/brotli-decompressor) crate.
 #[allow(clippy::large_stack_frames)]
 pub fn decompress_brotli(
     data: &[u8],
@@ -44,7 +44,7 @@ pub fn decompress_brotli(
     // Per spec, if decompressed data exceeds the limit, the output is truncated
     // to max_rlp_bytes_per_channel bytes (not rejected).
     loop {
-        let result = brotli::BrotliDecompressStream(
+        let result = brotli_decompressor::BrotliDecompressStream(
             &mut available_in,
             &mut input_offset,
             data,

--- a/rust/kona/crates/protocol/protocol/src/brotli.rs
+++ b/rust/kona/crates/protocol/protocol/src/brotli.rs
@@ -229,4 +229,57 @@ mod test {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), data);
     }
+
+    #[test]
+    fn test_brotli_rejects_padding_2_corruption() {
+        // Regression test for a consensus-divergence vector fixed upstream in
+        // brotli-decompressor v5.0.1 (dropbox/rust-brotli-decompressor#44).
+        //
+        // RFC 7932 §9.2 requires the unused bits in the final byte of a brotli
+        // stream to be zero. A missing `break` in the decoder's
+        // BROTLI_STATE_METABLOCK_DONE arm let the resulting PADDING_2 error fall
+        // through into BROTLI_STATE_DONE, where WriteRingBuffer overwrote it with
+        // SUCCESS — so corrupt streams decoded as `Ok` with the (uncorrupted)
+        // plaintext. The C reference (libbrotlidec) and Go (andybalholm/brotli,
+        // used by op-node) both reject these as PADDING_2, so the buggy Rust
+        // behavior was a Go vs Rust derivation divergence: op-node rejects the
+        // channel while kona would have accepted it.
+        //
+        // With the fix the decoder returns `ResultFailure` with zero bytes
+        // written, which `decompress_brotli` surfaces as an error. The vectors
+        // below are the same ones used by the upstream test in #44.
+
+        // Valid encoding of "the quick brown fox jumps over the lazy dog twice
+        // for redundancy and length" produced by libbrotlidec at quality 5.
+        let valid: &[u8] = &[
+            0x1b, 0x4a, 0x00, 0x00, 0xc4, 0xf4, 0xa4, 0x69, 0xbd, 0x79, 0x25, 0x2d, 0x22, 0xb4,
+            0x52, 0xea, 0x83, 0x0d, 0x38, 0x70, 0x68, 0xb2, 0x71, 0xc0, 0x41, 0x76, 0x1e, 0x36,
+            0xc6, 0xce, 0x13, 0x84, 0xe8, 0x36, 0xf2, 0x2a, 0x0c, 0xe7, 0x89, 0x68, 0x7a, 0x04,
+            0x49, 0x2f, 0xaa, 0xf7, 0x31, 0xa1, 0x9b, 0x0d, 0x48, 0xb7, 0xf0, 0x1f, 0x48, 0x33,
+            0x42, 0xa5, 0x9c, 0x31, 0x26, 0x97, 0xa9, 0xc6, 0xbe, 0x67, 0x85, 0x52, 0x02,
+        ];
+        let limit = MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize;
+
+        // Sanity: the unmodified stream decodes successfully.
+        let decompressed = decompress_brotli(valid, limit).expect("valid stream must decode");
+        assert_eq!(
+            decompressed,
+            b"the quick brown fox jumps over the lazy dog twice for redundancy and length",
+        );
+
+        // Each bit flip drives the decoder into an end-of-stream state that
+        // violates the RFC 7932 §9.2 byte-alignment padding rule. A
+        // spec-conformant decoder must reject all of them; v5.0.0 accepted them.
+        for &(offset, xor) in &[(13usize, 0x01u8), (23, 0x01), (33, 0x55)] {
+            let mut corrupt = valid.to_vec();
+            corrupt[offset] ^= xor;
+
+            let result = decompress_brotli(&corrupt, limit);
+            assert!(
+                matches!(result, Err(BrotliDecompressionError::DecompressionFailed(_))),
+                "padding-bit corruption at offset {offset} xor {xor:#x} must be rejected, \
+                 got {result:?}",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Requires `brotli-decompressor` `>= 5.0.1` (up from the previously-resolved `5.0.0`), which pulls in [dropbox/rust-brotli-decompressor#44](https://github.com/dropbox/rust-brotli-decompressor/pull/44).

That PR fixes a missing `break` in the decoder's `BROTLI_STATE_METABLOCK_DONE` arm: the RFC 7932 §9.2 padding check (the unused bits in the final byte must be zero) set `BROTLI_DECODER_ERROR_FORMAT_PADDING_2` but fell through into `BROTLI_STATE_DONE`, where `WriteRingBuffer` unconditionally overwrote `result` with `SUCCESS`. So corrupt brotli streams decoded as `Ok` with output.

Go (`andybalholm/brotli`, used by op-node) and the C reference (`libbrotlidec`) both reject these streams as `PADDING_2`, so **5.0.0 was a Go-vs-Rust derivation divergence vector**: op-node rejects the channel while kona would have accepted it — the same class of consensus risk as #19333.

## How the version is pinned

Rather than a lockfile-only bump (which a future lockfile regeneration could undo), `brotli-decompressor` is now a **direct** workspace dependency floored at `^5.0.1`, so it can never resolve below the fix. kona's decoder already only used the decode API (`BrotliDecompressStream`, `BrotliState`, `BrotliResult`, `HuffmanCode`), all of which live in `brotli-decompressor`, so production now depends on it directly. The full `brotli` crate is demoted to a **dev-dependency** — tests still need it for compression (`BrotliCompress`), which `brotli-decompressor` (decode-only) doesn't provide.

## Why no wrapper change is needed

`decompress_brotli` deliberately returns `Ok(partial)` on errors to match op-node's streaming decode (mirroring the zlib path, which keeps partial output so batches decoded before an error point are still accepted). I checked whether the bump alone changes kona's behavior:

| | `decompress_brotli(corrupt)` | streaming `Reader` |
|---|---|---|
| **5.0.0** | `Ok(75)` — accepts ❌ | `Ok(75 bytes)` |
| **5.0.1** | `Err(DecompressionFailed)` — rejects ✅ | `Err(InvalidData)`, **0 bytes** |

In 5.0.1 the fix's `break` skips the final `WriteRingBuffer`, so the decoder reports `ResultFailure` with **`written == 0`**. Kona's existing `written == 0 => Err` arm already catches that, and it matches the streaming Reader (both yield 0 bytes + error), so consensus parity is preserved. No change to the decompression loop.

## Test

Adds `test_brotli_rejects_padding_2_corruption` using the same vectors as the upstream #44 test. It fails on 5.0.0 (corrupt data accepted as `Ok`) and passes on 5.0.1 (rejected).

## Test plan

- [x] `cargo test -p kona-protocol --all-features --lib brotli::` — 6/6 pass (incl. the #20598 streaming-parity test, unaffected)
- [x] `cargo test -p kona-protocol --all-features --lib batch::reader` — 4/4 pass
- [x] `cargo check -p kona-protocol --no-default-features` — no_std build compiles without the `brotli` crate
- [x] `cargo clippy -p kona-protocol --all-features --all-targets` — clean
- [x] `cargo +nightly fmt -p kona-protocol --check` — clean
- [x] Verified RED/GREEN by toggling the `brotli-decompressor` pin between 5.0.0 and 5.0.1

Note: the sibling `rollup-boost` and `op-rbuilder` workspaces still pin `brotli-decompressor` 5.0.0; they use brotli for flashblocks transport (not consensus-critical), so they're intentionally left out of this kona-scoped change.

Closes #21181

🤖 Generated with [Claude Code](https://claude.com/claude-code)
