### PR TITLE
op-core: wire op-node onto op-core/eip1559 and txinclude onto op-core/fees

### DIFF
--- a/docs/ai/opgeth-decoupling.md
+++ b/docs/ai/opgeth-decoupling.md
@@ -4,11 +4,27 @@ This document analyses the dependencies of the optimism monorepo Go services on 
 APIs, and proposes decoupling strategies for each. The goal is to depend on upstream go-ethereum
 instead of op-geth without opening upstream PRs.
 
-**In scope:** op-node, op-service, op-batcher, op-proposer, op-challenger, op-faucet,
-op-supernode, cannon, and the integration / acceptance test suites (op-e2e,
-op-acceptance-tests, op-devstack).
+**Scope: the whole monorepo.** Every Go component that links op-geth — whether as a binary
+dependency or as a library — must end up building against upstream go-ethereum. Each falls into
+one of three fates:
 
-**Out of scope:**
+1. **Swap to `op-core/*` (+ upstream go-ethereum)** — code that stays in Go and used op-geth only
+   for OP-specific types/helpers. The bulk: op-node, op-service, op-batcher, op-proposer,
+   op-challenger, op-faucet, op-supernode, cannon; the test suites (op-e2e, op-acceptance-tests,
+   op-devstack); `op-chain-ops/genesis` (#21281) and the `op-chain-ops/cmd/check-*` per-fork
+   checker family (check-jovian, check-karst, … — stay for now); and **op-sync-tester** — a
+   CL-sync EL *mock* that does **no execution** (it proxies a real op-reth EL and gates
+   visibility), whose one non-swap bit, the OP-aware `PayloadID` hash, is tracked in #21525.
+2. **Migrate execution to op-reth** — anything that builds or executes blocks. op-acceptance-tests
+   sequences op-reth-only for Karst+ (#21182); op-e2e/actions moves onto an op-reth-test-engine
+   subprocess EL (#20415, #21196).
+3. **Delete** — geth-as-library tools with no remaining need: op-simulate and op-run-block
+   (#21282), to be reimplemented in Rust against op-reth if ever needed again.
+
+Once every component is in fate 1, 2, or 3, the go.mod `replace` flips to upstream go-ethereum
+(#20266).
+
+**Replaced, not decoupled** (separate efforts, not op-core swaps):
 - **op-program** (client and host) — depends on op-geth state execution; kona supersedes it
   (in the monorepo at `rust/kona`).
 - **op-supervisor** — deprecated, being replaced by op-supernode.

--- a/docs/ai/opgeth-decoupling.md
+++ b/docs/ai/opgeth-decoupling.md
@@ -60,7 +60,13 @@ Because everything in `op-core/` is implicitly OP-Stack-specific, new types drop
 | `params.ChainConfig` with OP extensions | `op-core/params.ChainConfig` (imported as `opparams.ChainConfig`) |
 | `params.LoadOPStackChainConfig` | `op-core/params.FromSuperchainConfig` |
 | `superutil.LoadOPStackChainConfigFromChainID` | `op-core/params.LoadChainConfigFromChainID` |
-| `eip1559.ValidateOptimismExtraData` | `op-core/eip1559.ValidateExtraData` |
+| `eip1559.{Validate,Decode,Encode}OptimismExtraData` | kept verbatim in `op-core/eip1559` |
+
+**Exception (eip1559 extraData wrappers):** the `{Validate,Decode,Encode}OptimismExtraData`
+fork-dispatching helpers keep their names. Here "Optimism" names the OP-specific extraData
+*format* (the Holocene/Jovian 1559-parameter encoding), not a redundant package prefix, and
+dropping it would collide with the per-fork `Validate*ExtraData` helpers. Keeping the names
+also makes the op-node swap a pure import-path change.
 
 **Exception:** `params.OptimismConfig` keeps its name. The field is `ChainConfig.Optimism
 *OptimismConfig` — the type pairs with the field name, which is load-bearing for JSON wire
@@ -288,8 +294,11 @@ receipt := tx.Receipt  // *types.Receipt, fetched via ethclient.TransactionRecei
 if receipt.L1BaseFeeScalar != nil {
     l1BaseFeeScalar := new(big.Int).SetUint64(*receipt.L1BaseFeeScalar)
     l1BlobBaseFeeScalar := new(big.Int).SetUint64(*receipt.L1BlobBaseFeeScalar)
-    costFunc := types.NewL1CostFuncFjord(receipt.L1GasPrice, receipt.L1BlobBaseFee, ...)
-    l1Cost, _ := costFunc(tx.Transaction.RollupCostData())
+    // fees already wired to op-core; receipt fields (read here) still come from op-geth.
+    l1Cost := opfees.L1CostFjord(opfees.TxRollupCostData(tx.Transaction), opfees.L1FeeParams{
+        L1BaseFee: receipt.L1GasPrice, L1BlobBaseFee: receipt.L1BlobBaseFee,
+        BaseFeeScalar: l1BaseFeeScalar, BlobFeeScalar: l1BlobBaseFeeScalar,
+    })
     actualCost.Add(actualCost, l1Cost)
 }
 // operatorCost
@@ -358,16 +367,16 @@ uses only the Fjord-era subset:
 - `types.RollupCostData` — struct carrying `Zeroes`, `Ones`, `FastLzSize` byte counts
 - `types.NewRollupCostData(data []byte) RollupCostData` — compute RCD from tx calldata
 - `types.NewL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, baseFeeScalar, blobFeeScalar *big.Int)` —
-  returns `func(RollupCostData, blockTime uint64) *big.Int`
+  returns `func(RollupCostData) (fee, calldataGasUsed *big.Int)`
 - `(RollupCostData).EstimatedDASize()` — used by op-batcher for DA size estimation
 
-Call sites:
+Call sites (pre-migration):
 - `op-service/txinclude/txbudget.go` — L1 cost calc + **inline operator-fee arithmetic**
-- `op-service/txinclude/isthmus_cost_oracle.go` — pre-estimate L1 cost + **same inline
-  operator-fee arithmetic** (duplicated from txbudget.go)
+- `op-service/txinclude/cost_oracle.go` (formerly `isthmus_cost_oracle.go`) — pre-estimate L1
+  cost + **same inline operator-fee arithmetic** (duplicated from txbudget.go)
 - `op-batcher/batcher/types.go` — `tx.RollupCostData()` for DA size estimation
 
-The two `txinclude` files share this snippet verbatim (modulo source fields) for operator fee:
+The two `txinclude` files shared this snippet verbatim (modulo source fields) for operator fee:
 
 ```go
 operatorCost := new(big.Int).SetUint64(gasUsed)
@@ -376,8 +385,8 @@ operatorCost = operatorCost.Div(operatorCost, oneMillion)
 operatorCost = operatorCost.Add(operatorCost, new(big.Int).SetUint64(constant))
 ```
 
-Note: `txbudget.go:95` has a TODO noting the Jovian formula will change this (multiplies by 100
-instead of dividing by a million). A single shared helper also gives us one place to switch.
+A single shared helper gave us one place to switch when Jovian changed the formula (multiply
+by 100 instead of dividing by a million) — see the Jovian/Isthmus split below.
 
 ### Proposed decoupling
 
@@ -391,24 +400,61 @@ type RollupCostData struct { Zeroes, Ones, FastLzSize uint64 }
 func NewRollupCostData(data []byte) RollupCostData { /* copied verbatim */ }
 func (r RollupCostData) EstimatedDASize() *big.Int { /* copied verbatim */ }
 
-type L1CostFunc func(RollupCostData, blockTime uint64) *big.Int
+// The L1 DA cost is exposed as plain free functions per era — no closures, no L1CostFunc type.
+// op-geth uses closure factories (NewL1CostFunc*) because its EVM builds one cost func per
+// block and calls it per-tx (reuse pays off); the monorepo always constructs-and-calls-once,
+// so the closures earn nothing. This also matches the era spread to L1CostBedrock, which was
+// already a free function. The per-block fee params travel in a struct so the four same-typed
+// *big.Int args can't be transposed. Two things op-geth's signature carried are dropped: the
+// calldataGasUsed second return (only its EVM receipts need it; we never did) and the blockTime
+// arg (only its time-dispatching factory needs it — see NewL1CostFunc(config, statedb) — and we
+// dispatch by era at the call site, not by time).
+type L1FeeParams struct{ L1BaseFee, L1BlobBaseFee, BaseFeeScalar, BlobFeeScalar *big.Int }
 
-func NewL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, baseFeeScalar, blobFeeScalar *big.Int) L1CostFunc
+func L1CostBedrock(rollupDataGas uint64, l1BaseFee, overhead, scalar *big.Int) *big.Int
+func L1CostEcotone(rcd RollupCostData, p L1FeeParams) *big.Int
+func L1CostFjord(rcd RollupCostData, p L1FeeParams) *big.Int
 
-// Replaces inline math duplicated across txbudget.go and isthmus_cost_oracle.go.
-// Isthmus formula: (gasUsed * scalar / 1_000_000) + constant.
-// Jovian formula will be switched here when activated (see TODO in txbudget.go).
-func OperatorCost(gasUsed, scalar, constant uint64) *big.Int
+// Replaces the inline operator-fee math duplicated across txbudget.go and cost_oracle.go.
+// Both formulas are exported; consumers pick per their needs.
+// Isthmus: (gasUsed * scalar / 1_000_000) + constant.
+// Jovian:  (gasUsed * scalar * 100) + constant.
+func OperatorCostIsthmus(gasUsed, scalar, constant uint64) *big.Int
+func OperatorCostJovian(gasUsed, scalar, constant uint64) *big.Int
 
-// Replaces the (tx *types.Transaction).RollupCostData() method from op-geth.
-func TxRollupCostData(tx *types.Transaction) RollupCostData {
-    return NewRollupCostData(tx.Data()) // + any blob/tx-type adjustments per op-geth
-}
+// Replaces the (tx *types.Transaction).RollupCostData() method from op-geth: deposits incur
+// no DA cost, and the cost data is derived from the full binary-encoded tx, not just calldata.
+func TxRollupCostData(tx *types.Transaction) RollupCostData
 ```
 
 Computation is pure arithmetic on byte counts and `*big.Int`. No dependency on
 `op-core/types`, no dependency on go-ethereum beyond `common`, `uint256` and `math/big`.
 Graph: `op-core/fees` and `op-core/types` are siblings — no cycle possible.
+
+### Status
+
+The package landed in #20261. Wiring the `op-service/txinclude` consumers (this issue) also
+simplified the L1-cost API to free functions — `opfees.L1CostFjord(rcd, opfees.L1FeeParams{…})`
+— dropping the closure factories, the `L1CostFunc` type, and op-geth's vestigial
+`calldataGasUsed` return and `blockTime` arg (see the API sketch above). `txbudget.go` and
+`cost_oracle.go` (formerly `isthmus_cost_oracle.go`) use `opfees.L1CostFjord`,
+`opfees.TxRollupCostData`, and `opfees.OperatorCostJovian`. Both txinclude sites use the
+**Jovian** operator-fee formula unconditionally: it is exact on Jovian chains (all production
+chains) and strictly ≥ the Isthmus formula, so on a pre-Jovian chain it only over-estimates,
+which over-reserves budget rather than under-budgeting.
+
+The op-core API is **monorepo-best, not op-geth-faithful** — the names/shapes diverge freely;
+only the *computed values* must match. That equivalence is pinned by **live differential
+tests** in `op-core/fees` that compare against op-geth's exported functions while the build
+still resolves go-ethereum to op-geth: `TestL1CostBedrockParity` (vs `types.L1Cost`),
+`TestFjordL1CostParity` (vs `types.NewL1CostFuncFjord`), and `TestTxRollupCostDataParity` (vs
+`(*types.Transaction).RollupCostData`). Ecotone has only a value-pin (`TestEcotoneL1CostFunc`):
+op-geth's Ecotone constructor is unexported, so a live diff isn't cheaply possible. These
+differential tests are removed at the final cutover when the op-geth dependency is dropped.
+
+The remaining `tx.RollupCostData()` call site, `op-batcher/batcher/types.go`, swaps to
+`opfees.TxRollupCostData` as part of the op-batcher → `op-service/sources` migration (§11), not
+the fees wiring.
 
 ---
 
@@ -586,15 +632,33 @@ carry all OP hardfork timestamps from the registry, rather than going through `*
 op-geth adds `eip1559_optimism.go` with self-contained functions for Holocene/Jovian parameter
 encoding. Used in op-node:
 
-- `rollup/derive/payload_util.go` – `EncodeHolocene1559Params`
-- `rollup/interop/indexing/attributes.go` – `EncodeHolocene1559Params`, `DecodeJovianExtraData`
-- `rollup/attributes/engine_consolidate.go` – `DecodeHolocene1559Params`
+- `rollup/derive/payload_util.go` – `ValidateOptimismExtraData`, `DecodeOptimismExtraData`,
+  `EncodeHolocene1559Params`
+- `rollup/attributes/engine_consolidate.go` – `ValidateOptimismExtraData`,
+  `DecodeOptimismExtraData`, `ValidateHolocene1559Params`, `DecodeHolocene1559Params`
+- `rollup/derive/system_config.go` – `ValidateHolocene1559Params`
 
-Signatures operate on `[]byte` and `uint64` scalars only. No go-ethereum type dependencies.
+(The `rollup/interop/indexing/attributes.go` site listed in earlier drafts no longer uses
+eip1559.) Signatures operate on `[]byte` and `uint64` scalars only. No go-ethereum type
+dependencies.
+
+The op-e2e action helpers (`l1_miner.go`, `engineapi/block_processor.go`,
+`engineapi/l2_engine_api.go`) additionally use `EncodeOptimismExtraData` and
+`DecodeHoloceneExtraData`; those migrate with the test suites in §13.
 
 ### Proposed decoupling
 
-**Move to `op-core/eip1559/`**. Copy verbatim; the only import is `errors`.
+**Move to `op-core/eip1559/`**, copied verbatim; the only import is `errors`.
+
+### Status
+
+The package landed in #20268 with a subset of the helpers. Wiring op-node onto it (this issue)
+added the one symbol op-node needed that the initial extraction omitted —
+`ValidateOptimismExtraData` (the fork-dispatching validator that pairs with the already-present
+`DecodeOptimismExtraData`). All four op-node files now import `op-core/eip1559` and no op-node
+code imports `go-ethereum/consensus/misc/eip1559`. `EncodeOptimismExtraData` and
+`DecodeHoloceneExtraData` are still absent from `op-core/eip1559`; add them when §13 migrates
+the op-e2e helpers.
 
 ---
 
@@ -1021,8 +1085,8 @@ This is a bounded follow-up, unblocked by `op-core/params` + `GethChainConfig()`
 | `IsDepositTx()` free function | `core/types/transaction.go` | `op-core/types/` | Trivial |
 | `IsSystemTx()`, `SourceHash()`, `Mint()` helpers | `core/types/transaction.go` | `op-core/types/` | Low |
 | `PostExecTx` type + `MarshalBinary`, `PostExecTxType` constant, `IsPostExecTx()` | `core/types/post_exec_tx.go` | `op-core/types/` | Low |
-| `RollupCostData`, `NewRollupCostData`, `EstimatedDASize`, `NewL1CostFuncFjord`, `L1CostFunc` | `core/types/rollup_cost.go` | `op-core/fees/` | Low |
-| `OperatorCost(gasUsed, scalar, constant)` — new helper | n/a (deduplicates inline math) | `op-core/fees/` | Trivial |
+| `RollupCostData`, `NewRollupCostData`, `EstimatedDASize`; L1 cost as free funcs `L1Cost{Bedrock,Ecotone,Fjord}` + `L1FeeParams` (no `L1CostFunc` type) | `core/types/rollup_cost.go` | `op-core/fees/` | Low |
+| `OperatorCost{Isthmus,Jovian}(gasUsed, scalar, constant)` — replaces inline math | n/a (deduplicates inline math) | `op-core/fees/` | Trivial |
 | `TxRollupCostData(tx)` — replaces method | `core/types/transaction.go` | `op-core/fees/` | Trivial |
 | `Receipt` (receipt L1-cost fields) | `core/types/receipt_opstack.go` | `op-core/types/` | Medium |
 | `OptimismConfig` struct | `params/config.go` | `op-core/params/` | Trivial |

--- a/docs/ai/opgeth-decoupling.md
+++ b/docs/ai/opgeth-decoupling.md
@@ -24,11 +24,6 @@ one of three fates:
 Once every component is in fate 1, 2, or 3, the go.mod `replace` flips to upstream go-ethereum
 (#20266).
 
-**Replaced, not decoupled** (separate efforts, not op-core swaps):
-- **op-program** (client and host) — depends on op-geth state execution; kona supersedes it
-  (in the monorepo at `rust/kona`).
-- **op-supervisor** — deprecated, being replaced by op-supernode.
-
 The op-geth diff vs. upstream go-ethereum (currently based on v1.17.2) can be summarised in three
 kinds of change:
 
@@ -897,13 +892,6 @@ The only fields read from receipts are `receipt.Logs` (standard upstream — see
 interface accepts arbitrary bytes — it never decodes OP Stack types. **Zero blockchain-layer
 coupling; zero migration needed.**
 
-### Out of scope: `op-program/`, `op-supervisor/`
-
-**op-program** (client and host) depends on op-geth state execution (`core/state`, `core/vm`,
-etc.). The replacement lives in-tree at `rust/kona` (client + host), a Rust implementation
-of the fault-proof program. **op-supervisor** is deprecated and being replaced by op-supernode
-(§12).
-
 ---
 
 ## 13. Tests: `op-e2e`, `op-acceptance-tests`, `op-devstack`
@@ -1061,10 +1049,9 @@ patterns.
 
 A distinction the rest of this plan leaves implicit: removing op-geth has two parts.
 
-1. **op-geth as the execution *engine*** — op-program's state execution and the in-process
-   op-geth EL in op-e2e action tests / `op-e2e/opgeth/`. These are deleted or replaced by
-   op-reth/kona. Their need for a concrete go-ethereum config is **temporary** and served by
-   `GethChainConfig()` until they go away.
+1. **op-geth as the execution *engine*** — the in-process op-geth EL in op-e2e action tests /
+   `op-e2e/opgeth/`. These are deleted or replaced by op-reth. Their need for a concrete
+   go-ethereum config is **temporary** and served by `GethChainConfig()` until they go away.
 2. **op-geth as a *library* in offline tooling** — `op-chain-ops/genesis.BuildL2Genesis` (genesis
    state-root + `genesis.json`) and the block-replay tools. These **stay**, and they genuinely
    need a go-ethereum config carrying the OP fields. This tooling is in scope: it must eventually

--- a/op-core/eip1559/eip1559.go
+++ b/op-core/eip1559/eip1559.go
@@ -17,6 +17,19 @@ type ForkChecker interface {
 	IsJovian(time uint64) bool
 }
 
+// ValidateOptimismExtraData validates the Optimism extra data.
+// It uses the fork schedule and block time to determine which rules apply.
+func ValidateOptimismExtraData(fc ForkChecker, time uint64, extraData []byte) error {
+	if fc.IsJovian(time) {
+		return ValidateJovianExtraData(extraData)
+	} else if fc.IsHolocene(time) {
+		return ValidateHoloceneExtraData(extraData)
+	} else if len(extraData) > 0 { // pre-Holocene, apart from the genesis block
+		return errors.New("extraData must be empty before Holocene")
+	}
+	return nil
+}
+
 // DecodeOptimismExtraData decodes the Optimism extra data.
 // It uses the config and parent time to determine how to do the decoding.
 // The extraData is expected to already be valid.

--- a/op-core/eip1559/eip1559_test.go
+++ b/op-core/eip1559/eip1559_test.go
@@ -56,6 +56,9 @@ type forkChecker struct {
 func (f forkChecker) IsHolocene(uint64) bool { return f.holocene }
 func (f forkChecker) IsJovian(uint64) bool   { return f.jovian }
 
+// TestValidateOptimismExtraData covers the fork dispatch only: that the schedule selects the
+// right per-fork validator. Each validator's own edge cases are covered by its dedicated test
+// (e.g. TestValidateHoloceneExtraData).
 func TestValidateOptimismExtraData(t *testing.T) {
 	holoceneExtra := EncodeHoloceneExtraData(250, 6)
 	jovianExtra := EncodeJovianExtraData(250, 6, 7)
@@ -67,33 +70,29 @@ func TestValidateOptimismExtraData(t *testing.T) {
 		expected string
 	}{
 		{
-			name:  "pre-Holocene empty (valid)",
+			name:  "pre-Holocene requires empty",
 			fc:    forkChecker{},
 			extra: nil,
 		},
 		{
-			name:     "pre-Holocene non-empty (invalid)",
+			name:     "pre-Holocene rejects non-empty",
 			fc:       forkChecker{},
 			extra:    []byte{0x00},
 			expected: "extraData must be empty before Holocene",
 		},
 		{
-			name:  "Holocene valid",
+			name:  "Holocene routes to Holocene validator",
 			fc:    forkChecker{holocene: true},
 			extra: holoceneExtra,
 		},
 		{
-			name:     "Holocene wrong length",
-			fc:       forkChecker{holocene: true},
-			extra:    []byte{0x00},
-			expected: "holocene extraData should be 9 bytes, got 1",
-		},
-		{
-			name:  "Jovian valid",
+			name:  "Jovian routes to Jovian validator",
 			fc:    forkChecker{holocene: true, jovian: true},
 			extra: jovianExtra,
 		},
 		{
+			// Holocene-sized extraData is valid length for Holocene but wrong for Jovian, so a
+			// Jovian-active check rejecting it confirms dispatch to the Jovian validator.
 			name:     "Jovian rejects Holocene-sized extraData",
 			fc:       forkChecker{holocene: true, jovian: true},
 			extra:    holoceneExtra,

--- a/op-core/eip1559/eip1559_test.go
+++ b/op-core/eip1559/eip1559_test.go
@@ -48,6 +48,72 @@ func TestValidateHolocene1559Params(t *testing.T) {
 	}
 }
 
+type forkChecker struct {
+	holocene bool
+	jovian   bool
+}
+
+func (f forkChecker) IsHolocene(uint64) bool { return f.holocene }
+func (f forkChecker) IsJovian(uint64) bool   { return f.jovian }
+
+func TestValidateOptimismExtraData(t *testing.T) {
+	holoceneExtra := EncodeHoloceneExtraData(250, 6)
+	jovianExtra := EncodeJovianExtraData(250, 6, 7)
+
+	tests := []struct {
+		name     string
+		fc       forkChecker
+		extra    []byte
+		expected string
+	}{
+		{
+			name:  "pre-Holocene empty (valid)",
+			fc:    forkChecker{},
+			extra: nil,
+		},
+		{
+			name:     "pre-Holocene non-empty (invalid)",
+			fc:       forkChecker{},
+			extra:    []byte{0x00},
+			expected: "extraData must be empty before Holocene",
+		},
+		{
+			name:  "Holocene valid",
+			fc:    forkChecker{holocene: true},
+			extra: holoceneExtra,
+		},
+		{
+			name:     "Holocene wrong length",
+			fc:       forkChecker{holocene: true},
+			extra:    []byte{0x00},
+			expected: "holocene extraData should be 9 bytes, got 1",
+		},
+		{
+			name:  "Jovian valid",
+			fc:    forkChecker{holocene: true, jovian: true},
+			extra: jovianExtra,
+		},
+		{
+			name:     "Jovian rejects Holocene-sized extraData",
+			fc:       forkChecker{holocene: true, jovian: true},
+			extra:    holoceneExtra,
+			expected: "Jovian extraData should be 17 bytes, got 9",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateOptimismExtraData(tc.fc, 0, tc.extra)
+			if tc.expected == "" && err != nil {
+				t.Errorf("Expected no error, but got: %v", err)
+			}
+			if tc.expected != "" && (err == nil || err.Error() != tc.expected) {
+				t.Errorf("Expected error: %s, but got: %v", tc.expected, err)
+			}
+		})
+	}
+}
+
 func TestValidateHoloceneExtraData(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/op-core/fees/fees.go
+++ b/op-core/fees/fees.go
@@ -40,9 +40,15 @@ type RollupCostData struct {
 	FastLzSize   uint64
 }
 
-// L1CostFunc returns the data-availability fee charged to the sender of a non-deposit
-// transaction. It returns nil when no DA fee applies.
-type L1CostFunc func(rcd RollupCostData, blockTime uint64) *big.Int
+// L1FeeParams holds the L1 base fee, blob base fee, and their scalars used to price a
+// transaction's data availability under Ecotone and Fjord. They are read together from the
+// L1-block-info attributes (or the L1Block / gas-price-oracle predeploys).
+type L1FeeParams struct {
+	L1BaseFee     *big.Int
+	L1BlobBaseFee *big.Int
+	BaseFeeScalar *big.Int
+	BlobFeeScalar *big.Int
+}
 
 // NewRollupCostData computes the RollupCostData for the given L1 transaction bytes.
 func NewRollupCostData(data []byte) (out RollupCostData) {
@@ -82,22 +88,19 @@ func L1CostBedrock(rollupDataGas uint64, l1BaseFee, overhead, scalar *big.Int) *
 	return fee
 }
 
-// NewL1CostFuncEcotone returns an L1CostFunc for the Ecotone upgrade (excluding the very
-// first Ecotone block, which still uses the Bedrock function). The returned function ignores
-// blockTime: the fee parameters are fixed at construction.
-func NewL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseFeeScalar *big.Int) L1CostFunc {
-	return func(costData RollupCostData, _ uint64) *big.Int {
-		// Ecotone L1 cost function, computed as
-		//   calldataGas * (l1BaseFee*16*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar) / 16e6
-		// for better integer-arithmetic precision.
-		calldataGasUsed := bedrockCalldataGasUsed(costData)
-		calldataCostPerByte := new(big.Int).Mul(l1BaseFee, sixteen)
-		calldataCostPerByte.Mul(calldataCostPerByte, l1BaseFeeScalar)
-		blobCostPerByte := new(big.Int).Mul(l1BlobBaseFee, l1BlobBaseFeeScalar)
-		fee := new(big.Int).Add(calldataCostPerByte, blobCostPerByte)
-		fee.Mul(fee, calldataGasUsed)
-		return fee.Div(fee, ecotoneDivisor)
-	}
+// L1CostEcotone returns the Ecotone-era data-availability fee for a transaction (excluding the
+// very first Ecotone block, which still uses [L1CostBedrock]).
+func L1CostEcotone(rcd RollupCostData, p L1FeeParams) *big.Int {
+	// Ecotone L1 cost function, computed as
+	//   calldataGas * (l1BaseFee*16*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar) / 16e6
+	// for better integer-arithmetic precision.
+	calldataGasUsed := bedrockCalldataGasUsed(rcd)
+	calldataCostPerByte := new(big.Int).Mul(p.L1BaseFee, sixteen)
+	calldataCostPerByte.Mul(calldataCostPerByte, p.BaseFeeScalar)
+	blobCostPerByte := new(big.Int).Mul(p.L1BlobBaseFee, p.BlobFeeScalar)
+	fee := new(big.Int).Add(calldataCostPerByte, blobCostPerByte)
+	fee.Mul(fee, calldataGasUsed)
+	return fee.Div(fee, ecotoneDivisor)
 }
 
 // bedrockCalldataGasUsed returns the calldata gas of a transaction under the EIP-2028 schedule.
@@ -106,22 +109,19 @@ func bedrockCalldataGasUsed(costData RollupCostData) *big.Int {
 	return new(big.Int).SetUint64(calldataGas)
 }
 
-// NewL1CostFuncFjord returns an L1CostFunc for the Fjord upgrade. The returned function
-// ignores blockTime: the fee parameters are fixed at construction.
-func NewL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, baseFeeScalar, blobFeeScalar *big.Int) L1CostFunc {
-	return func(costData RollupCostData, _ uint64) *big.Int {
-		// Fjord L1 cost function:
-		//   l1FeeScaled   = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee
-		//   estimatedSize = max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
-		//   l1Cost        = estimatedSize * l1FeeScaled / 1e12
-		scaledL1BaseFee := new(big.Int).Mul(baseFeeScalar, l1BaseFee)
-		calldataCostPerByte := new(big.Int).Mul(scaledL1BaseFee, sixteen)
-		blobCostPerByte := new(big.Int).Mul(blobFeeScalar, l1BlobBaseFee)
-		l1FeeScaled := new(big.Int).Add(calldataCostPerByte, blobCostPerByte)
-		estimatedSize := costData.estimatedDASizeScaled()
-		l1CostScaled := new(big.Int).Mul(estimatedSize, l1FeeScaled)
-		return new(big.Int).Div(l1CostScaled, fjordDivisor)
-	}
+// L1CostFjord returns the Fjord-era data-availability fee for a transaction.
+func L1CostFjord(rcd RollupCostData, p L1FeeParams) *big.Int {
+	// Fjord L1 cost function:
+	//   l1FeeScaled   = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee
+	//   estimatedSize = max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
+	//   l1Cost        = estimatedSize * l1FeeScaled / 1e12
+	scaledL1BaseFee := new(big.Int).Mul(p.BaseFeeScalar, p.L1BaseFee)
+	calldataCostPerByte := new(big.Int).Mul(scaledL1BaseFee, sixteen)
+	blobCostPerByte := new(big.Int).Mul(p.BlobFeeScalar, p.L1BlobBaseFee)
+	l1FeeScaled := new(big.Int).Add(calldataCostPerByte, blobCostPerByte)
+	estimatedSize := rcd.estimatedDASizeScaled()
+	l1CostScaled := new(big.Int).Mul(estimatedSize, l1FeeScaled)
+	return new(big.Int).Div(l1CostScaled, fjordDivisor)
 }
 
 // OperatorCostIsthmus computes the Isthmus operator fee charged to a transaction:

--- a/op-core/fees/fees_test.go
+++ b/op-core/fees/fees_test.go
@@ -50,28 +50,38 @@ func TestL1CostBedrockParity(t *testing.T) {
 	}
 }
 
-// TestEcotoneL1CostFunc pins NewL1CostFuncEcotone to op-geth's TestEcotoneL1CostFunc reference
+// TestEcotoneL1CostFunc pins L1CostEcotone to op-geth's TestEcotoneL1CostFunc reference
 // (rollup_cost_test.go): baseFee=1000*1e6, blobBaseFee=10*1e6, scalars 2 and 3, and a calldata
-// gas of 480 (op-geth's ecotoneGas; here 30 non-zero bytes) yield ecotoneFee == 960900.
+// gas of 480 (op-geth's ecotoneGas; here 30 non-zero bytes) yield ecotoneFee == 960900. A live
+// differential (as for Fjord below) isn't possible: op-geth's Ecotone constructor is unexported.
 func TestEcotoneL1CostFunc(t *testing.T) {
-	costFunc := NewL1CostFuncEcotone(big.NewInt(1000*1e6), big.NewInt(10*1e6), big.NewInt(2), big.NewInt(3))
-	c := costFunc(RollupCostData{Ones: 30}, 0)
+	c := L1CostEcotone(RollupCostData{Ones: 30}, L1FeeParams{
+		L1BaseFee:     big.NewInt(1000 * 1e6),
+		L1BlobBaseFee: big.NewInt(10 * 1e6),
+		BaseFeeScalar: big.NewInt(2),
+		BlobFeeScalar: big.NewInt(3),
+	})
 	require.Equal(t, big.NewInt(960900), c)
 }
 
 func TestFjordL1CostFuncMinimumBounds(t *testing.T) {
-	costFunc := NewL1CostFuncFjord(fjordBaseFee, fjordBlobBaseFee, fjordBaseFeeScalar, fjordBlobBaseFeeScalar)
+	params := L1FeeParams{
+		L1BaseFee:     fjordBaseFee,
+		L1BlobBaseFee: fjordBlobBaseFee,
+		BaseFeeScalar: fjordBaseFeeScalar,
+		BlobFeeScalar: fjordBlobBaseFeeScalar,
+	}
 
 	// FastLZ sizes below the regression's minimum all clamp to the minimum-size fee.
 	// -42.5856 + 0.8365*{110,150,170} all stay below the 100-byte floor.
 	for _, fastLzSize := range []uint64{100, 150, 170} {
-		c := costFunc(RollupCostData{FastLzSize: fastLzSize}, 0)
+		c := L1CostFjord(RollupCostData{FastLzSize: fastLzSize}, params)
 		require.Equal(t, fjordFee, c, "fastLzSize=%d should clamp to the minimum fee", fastLzSize)
 	}
 
 	// Larger transactions exceed the minimum and cost strictly more.
 	for _, fastLzSize := range []uint64{171, 175, 200} {
-		c := costFunc(RollupCostData{FastLzSize: fastLzSize}, 0)
+		c := L1CostFjord(RollupCostData{FastLzSize: fastLzSize}, params)
 		require.Positive(t, c.Cmp(fjordFee), "fastLzSize=%d should exceed the minimum fee", fastLzSize)
 	}
 }
@@ -79,15 +89,33 @@ func TestFjordL1CostFuncMinimumBounds(t *testing.T) {
 // TestFjordL1CostSolidityParity pins the Fjord cost function to the same reference output as
 // op-geth's Solidity-parity test.
 func TestFjordL1CostSolidityParity(t *testing.T) {
-	costFunc := NewL1CostFuncFjord(big.NewInt(2*1e6), big.NewInt(3*1e6), big.NewInt(20), big.NewInt(15))
-	c := costFunc(RollupCostData{FastLzSize: 235}, 0)
+	c := L1CostFjord(RollupCostData{FastLzSize: 235}, L1FeeParams{
+		L1BaseFee:     big.NewInt(2 * 1e6),
+		L1BlobBaseFee: big.NewInt(3 * 1e6),
+		BaseFeeScalar: big.NewInt(20),
+		BlobFeeScalar: big.NewInt(15),
+	})
 	require.Equal(t, big.NewInt(105484), c)
 }
 
-func TestFjordL1CostFuncIgnoresBlockTime(t *testing.T) {
-	costFunc := NewL1CostFuncFjord(fjordBaseFee, fjordBlobBaseFee, fjordBaseFeeScalar, fjordBlobBaseFeeScalar)
-	rcd := RollupCostData{FastLzSize: 500}
-	require.Equal(t, costFunc(rcd, 0), costFunc(rcd, 1_000_000_000))
+// TestFjordL1CostParity is a live differential check that L1CostFjord matches op-geth's
+// exported NewL1CostFuncFjord across a range of fee parameters and tx sizes. It runs while the
+// build still resolves go-ethereum to op-geth; remove it when the op-geth dependency is dropped.
+func TestFjordL1CostParity(t *testing.T) {
+	paramSets := []L1FeeParams{
+		{L1BaseFee: fjordBaseFee, L1BlobBaseFee: fjordBlobBaseFee, BaseFeeScalar: fjordBaseFeeScalar, BlobFeeScalar: fjordBlobBaseFeeScalar},
+		{L1BaseFee: big.NewInt(2 * 1e6), L1BlobBaseFee: big.NewInt(3 * 1e6), BaseFeeScalar: big.NewInt(20), BlobFeeScalar: big.NewInt(15)},
+		{L1BaseFee: big.NewInt(1), L1BlobBaseFee: big.NewInt(1), BaseFeeScalar: big.NewInt(1), BlobFeeScalar: big.NewInt(1)},
+		{L1BaseFee: big.NewInt(7 * 1e9), L1BlobBaseFee: big.NewInt(5 * 1e8), BaseFeeScalar: big.NewInt(684000), BlobFeeScalar: big.NewInt(810949)},
+	}
+	for _, fastLzSize := range []uint64{0, 50, 100, 170, 171, 500, 12345} {
+		for _, p := range paramSets {
+			gethFee, _ := types.NewL1CostFuncFjord(p.L1BaseFee, p.L1BlobBaseFee, p.BaseFeeScalar, p.BlobFeeScalar)(
+				types.RollupCostData{FastLzSize: fastLzSize})
+			got := L1CostFjord(RollupCostData{FastLzSize: fastLzSize}, p)
+			require.Zero(t, gethFee.Cmp(got), "fastLzSize=%d params=%+v: op-geth %s, op-core %s", fastLzSize, p, gethFee, got)
+		}
+	}
 }
 
 func TestEstimatedDASize(t *testing.T) {

--- a/op-node/rollup/attributes/engine_consolidate.go
+++ b/op-node/rollup/attributes/engine_consolidate.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-core/eip1559"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"

--- a/op-node/rollup/attributes/engine_consolidate_test.go
+++ b/op-node/rollup/attributes/engine_consolidate_test.go
@@ -4,7 +4,6 @@ import (
 	"math/rand" // nosemgrep
 	"testing"
 
-	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -13,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/eip1559"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"

--- a/op-node/rollup/derive/payload_util.go
+++ b/op-node/rollup/derive/payload_util.go
@@ -4,9 +4,9 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/eip1559"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )

--- a/op-node/rollup/derive/system_config.go
+++ b/op-node/rollup/derive/system_config.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/ethereum-optimism/optimism/op-core/eip1559"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/solabi"

--- a/op-service/txinclude/cost_oracle.go
+++ b/op-service/txinclude/cost_oracle.go
@@ -90,8 +90,12 @@ func (i *CostOracle) SetParams(ctx context.Context) error {
 func (i *CostOracle) OPCost(tx *types.Transaction) *big.Int {
 	params := i.costParams.Load()
 
-	l1CostFunc := types.NewL1CostFuncFjord(params.L1BaseFee, params.L1BlobBaseFee, params.L1BaseFeeScalar, params.L1BlobBaseFeeScalar)
-	l1Cost, _ := l1CostFunc(tx.RollupCostData())
+	l1Cost := opfees.L1CostFjord(opfees.TxRollupCostData(tx), opfees.L1FeeParams{
+		L1BaseFee:     params.L1BaseFee,
+		L1BlobBaseFee: params.L1BlobBaseFee,
+		BaseFeeScalar: params.L1BaseFeeScalar,
+		BlobFeeScalar: params.L1BlobBaseFeeScalar,
+	})
 
 	operatorCost := opfees.OperatorCostJovian(tx.Gas(), bigs.Uint64Strict(params.OperatorFeeScalar), bigs.Uint64Strict(params.OperatorFeeConstant))
 

--- a/op-service/txinclude/txbudget.go
+++ b/op-service/txinclude/txbudget.go
@@ -89,8 +89,12 @@ func (b *TxBudget) AfterIncluded(budgetedCost eth.ETH, tx *IncludedTx) {
 	if receipt.L1BaseFeeScalar != nil {
 		l1BaseFeeScalar := new(big.Int).SetUint64(*receipt.L1BaseFeeScalar)
 		l1BlobBaseFeeScalar := new(big.Int).SetUint64(*receipt.L1BlobBaseFeeScalar)
-		costFunc := types.NewL1CostFuncFjord(receipt.L1GasPrice, receipt.L1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseFeeScalar)
-		l1Cost, _ := costFunc(tx.Transaction.RollupCostData())
+		l1Cost := opfees.L1CostFjord(opfees.TxRollupCostData(tx.Transaction), opfees.L1FeeParams{
+			L1BaseFee:     receipt.L1GasPrice,
+			L1BlobBaseFee: receipt.L1BlobBaseFee,
+			BaseFeeScalar: l1BaseFeeScalar,
+			BlobFeeScalar: l1BlobBaseFeeScalar,
+		})
 		actualCost.Add(actualCost, l1Cost)
 	}
 

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -24,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/ethereum-optimism/optimism/op-core/eip1559"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/session"


### PR DESCRIPTION
Completes the **eip1559** and **fees** parts of #20271 — moves op-node, op-sync-tester, and `op-service/txinclude` off op-geth onto `op-core/eip1559` and `op-core/fees`. (The superchain part was #21487.)

- **eip1559**: swap op-node's and op-sync-tester's import paths to `op-core/eip1559`; add the missing `ValidateOptimismExtraData` there.
- **fees**: `txinclude` now uses `opfees`. While wiring it, simplified the `op-core/fees` L1-cost API to **free functions** (`L1CostEcotone`/`L1CostFjord` + an `L1FeeParams` struct, matching the existing `L1CostBedrock`) — dropping the closure factories, the `L1CostFunc` type, and op-geth's vestigial `calldataGasUsed` return + `blockTime` arg, none of which the monorepo uses.

The op-core fee API is monorepo-best, not op-geth-faithful: only computed values must match, pinned by live differential tests (`TestFjordL1CostParity` / `TestL1CostBedrockParity` / `TestTxRollupCostDataParity` vs op-geth) that are removed at the final cutover.

The decoupling doc's scope section is rewritten to the whole-monorepo / three-fates framing (swap-to-op-core / execution-to-op-reth / delete).

Follow-ups tracked elsewhere: op-sync-tester's OP-aware `PayloadID` hash (#21525), op-batcher `RollupCostData` swap (§11), test-suite migration (§13), `op-e2e/system/fees` → action tests (#21507).

Closes #21500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
