### PR TITLE
docs(releases): consolidate Mintlify release-notes PRs and fix Latest tags

### DIFF
--- a/docs/public-docs/releases/kona-client.mdx
+++ b/docs/public-docs/releases/kona-client.mdx
@@ -22,7 +22,7 @@ rss: true
 
 </Update>
 
-<Update label="May 25, 2026" description="v1.5.2" tags={["Latest", "Stable"]}>
+<Update label="May 25, 2026" description="v1.5.2" tags={["Stable"]}>
 
 ## Overview
 

--- a/docs/public-docs/releases/kona-host.mdx
+++ b/docs/public-docs/releases/kona-host.mdx
@@ -22,7 +22,7 @@ rss: true
 
 </Update>
 
-<Update label="May 25, 2026" description="v1.5.2" tags={["Latest", "Stable"]}>
+<Update label="May 25, 2026" description="v1.5.2" tags={["Stable"]}>
 
 ## Overview
 

--- a/docs/public-docs/releases/proxyd.mdx
+++ b/docs/public-docs/releases/proxyd.mdx
@@ -23,7 +23,7 @@ rss: true
 
 </Update>
 
-<Update label="June 12, 2026" description="v4.28.1" tags={["Latest", "Stable"]}>
+<Update label="June 12, 2026" description="v4.28.1" tags={["Stable"]}>
 
 ## Changelog
 * 5a090ab3309c610c054bb65568a900713359b1a0 fix(proxyd): instrumentation of unserviceable requests metric (#657)


### PR DESCRIPTION
## Summary

Consolidates the 8 open Mintlify bot release-notes PRs into one and resolves the merge conflicts they all have against `develop`.

Closes #21493, #21492, #21486, #21473, #21454, #21440, #21371, #21304.

## What was going on

Each of those PRs is a daily Mintlify regeneration of `docs/public-docs/releases/`. The release **content** they add — kona-client/kona-host **v1.6.0**, proxyd **v4.29.0**, and the intermediate proxyd entries (v4.27.5, v4.28.0, v4.28.1) — is **already merged into `develop`**, which is exactly why every one of them now reports `CONFLICTING`.

The only real drift left is a **duplicate `Latest` tag**: on `develop`, both the newest release *and* the one before it are tagged `Latest` in each file.

## The fix

Verified against the live GitHub release tags that the genuine latest are:

| Component | Latest (GitHub) |
|-----------|-----------------|
| kona-client | `v1.6.0` (Jun 19) |
| kona-host | `v1.6.0` (Jun 19) |
| proxyd | `v4.29.0` (Jun 15, `isLatest: true`) |

So this PR demotes the superseded entries (`kona v1.5.2`, `proxyd v4.28.1`) from `["Latest", "Stable"]` to `["Stable"]`, leaving a single `Latest` per component. All releases present in the docs already match GitHub and are in chronological order — nothing needed to be added.

Net diff: 3 files, 3 lines.

## Note

These `.mdx` files are auto-generated by `scripts/generate-releases.ts`. The duplicate-`Latest` output suggests the generator keeps the prior `Latest` tag when prepending a new release; worth a follow-up fix to the script so the bot stops reintroducing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)