### PR TITLE
cleanup(contracts): rename super permissioned game type

### DIFF
--- a/docs/public-docs/chain-operators/tutorials/merge-shared-dispute-game.mdx
+++ b/docs/public-docs/chain-operators/tutorials/merge-shared-dispute-game.mdx
@@ -71,7 +71,7 @@ The portal-derived lookups return the chain's current `DisputeGameFactory`, `Anc
 
 `migrate` reads each chain's `DelayedWETH` directly from `SystemConfig.delayedWETH()` at execution time, so there is nothing to capture for it here.
 
-**Init bonds.** The migration registers two super game types on the new shared factory: `SUPER_PERMISSIONED_CANNON` (game type `5`) and `SUPER_CANNON_KONA` (game type `9`). Use `0.08 ether` (`80000000000000000` wei) as the `initBond` for both.
+**Init bonds.** The migration registers two super game types on the new shared factory: `SUPER_PERMISSIONED` (game type `5`) and `SUPER_CANNON_KONA` (game type `9`). Use `0.08 ether` (`80000000000000000` wei) as the `initBond` for both.
 
 **Release artifacts and infrastructure.**
 
@@ -79,11 +79,9 @@ The portal-derived lookups return the chain's current `DisputeGameFactory`, `Anc
 | --- | --- |
 | `OPCM` address for the migrate-feature container | The same OPCM the chains ran for the prerequisite `OPCMv2.upgrade()`. The container has `OPTIMISM_PORTAL_INTEROP` set in `devFeatureBitmap`, which is what enables both `Features.INTEROP` and `Features.ETH_LOCKBOX` on each `SystemConfig`. |
 | `SUPER_CANNON_KONA` absolute prestate hash | `validation/standard/standard-prestates.toml` in `superchain-registry`. Use the entry with `type="interop"` for the OPCM release version. |
-| `SUPER_PERMISSIONED_CANNON` absolute prestate hash | Same file, same `type="interop"` entry. The two super game types share the kona-interop prestate. |
 | Prestate artifact URL | The `cannon-kona-prestates-url` server, with the kona-interop prestate uploaded ahead of the migration. |
 | Shared `op-supernode` RPC URL | Your infrastructure team. The instance must derive **exactly `chainA` and `chainB`** (and no other chains). The shared `op-proposer`, `op-challenger`, and `op-dispute-mon` for the merged factory all point at this same instance. The per-chain single-chain supernodes already in use stay attached to their per-chain drain instances and are not replaced. |
-| Privileged `proposer` for `SUPER_PERMISSIONED_CANNON` | The address that may post proposals to the permissioned super game. `op-proposer` is configured to sign with this key. |
-| Privileged `challenger` for `SUPER_PERMISSIONED_CANNON` | The address that may counter proposals on the permissioned super game. Typically a multisig — countering a permissioned proposal is a manual intervention step that is not needed in normal operation. **Not** the key `op-challenger` signs with: `op-challenger` runs with a separate, unprivileged wallet and can still resolve permissioned games permissionlessly. |
+| Privileged `proposer` for `SUPER_PERMISSIONED` | The address that may post proposals to the permissioned super game. `op-proposer` is configured to sign with this key. |
 
 ### Verify the Preconditions
 
@@ -130,7 +128,7 @@ Run every check below. Each one corresponds to an invariant the migrator enforce
   # Expect: 9 for both.
   ```
 
-* **Confirm the shared supernode derives exactly the two merging chains.** Verify with your infrastructure team that the instance behind `$SUPERNODE_RPC` has `chainA` and `chainB` in its dependency set and **no** other chains. A supernode that also tracks an unrelated chain (or an interop cluster that includes one) computes super roots over that broader set, and those roots will not match what the shared `SUPER_CANNON_KONA` and `SUPER_PERMISSIONED_CANNON` games verify. The per-chain drain instances continue to use their existing single-chain supernodes; do not repoint them at the shared one.
+* **Confirm the shared supernode derives exactly the two merging chains.** Verify with your infrastructure team that the instance behind `$SUPERNODE_RPC` has `chainA` and `chainB` in its dependency set and **no** other chains. A supernode that also tracks an unrelated chain (or an interop cluster that includes one) computes super roots over that broader set, and those roots will not match what the shared `SUPER_CANNON_KONA` and `SUPER_PERMISSIONED` games verify. The per-chain drain instances continue to use their existing single-chain supernodes; do not repoint them at the shared one.
 * **Confirm the shared supernode is in sync.** It must report a finalized L2 head within both chains' expected finality windows:
 
   ```bash
@@ -139,11 +137,10 @@ Run every check below. Each one corresponds to an invariant the migrator enforce
 
   If the supernode is materially behind either chain, postpone the migration.
 
-* **Confirm the prestate server serves both super prestates.**
+* **Confirm the prestate server serves the `SUPER_CANNON_KONA` prestate.**
 
   ```bash
   curl -fI "$PRESTATE_URL/$SUPER_CANNON_KONA_PRESTATE.bin.gz"
-  curl -fI "$PRESTATE_URL/$SUPER_PERMISSIONED_PRESTATE.bin.gz"
   ```
 
 * **Note the chain B `DelayedWETH` divergence.** `migrate` reuses chain A's `DelayedWETH` for the new shared super games and does not touch chain B's. After migration, chain B's `SystemConfig.delayedWETH()` still references chain B's old `DelayedWETH`, which is no longer attached to any super game. Future `OPCMv2.upgrade()` calls against chain B that read `SystemConfig.delayedWETH()` will therefore reference a different contract than the shared games use. Track this in your operational runbook so future upgrades do not surprise you. The bonds posted by chain B's still-in-flight pre-migration games continue to claim out of chain B's old `DelayedWETH`, so the divergence does not block the drain described in [Drain Pre-Migration Games and Reclaim Bonds](#drain-pre-migration-games-and-reclaim-bonds).
@@ -245,7 +242,7 @@ startingRespectedGameType = 9
 # Both super game types must be registered. The migration validator requires it.
 # The template assembles the on-chain DisputeGameConfig.gameArgs bytes from these
 # fields: abi.encode(absolutePrestate) for game type 9, and
-# abi.encode(absolutePrestate, proposer, challenger) for game type 5.
+# abi.encode(proposer) for game type 5.
 
 [[disputeGameConfigs]]
 gameType = 9                             # SUPER_CANNON_KONA
@@ -254,12 +251,10 @@ initBond = 80000000000000000             # match the value gathered in the input
 absolutePrestate = "0x<super-cannon-kona prestate>"
 
 [[disputeGameConfigs]]
-gameType = 5                             # SUPER_PERMISSIONED_CANNON
+gameType = 5                             # SUPER_PERMISSIONED
 enabled = true
 initBond = 80000000000000000
-absolutePrestate = "0x<super-permissioned-cannon prestate>"
 proposer = "0x<privileged proposer>"
-challenger = "0x<privileged challenger>"
 
 expectedValidationErrors = ""            # fill in after the dry run if any structurally expected codes appear
 ```
@@ -277,7 +272,7 @@ The validator behind `OPContractsManagerMigrationValidator` returns a comma-sepa
 
 | Code | Meaning |
 | --- | --- |
-| `MIG-DGF-10` | `SUPER_PERMISSIONED_CANNON` is not registered on the shared factory. |
+| `MIG-DGF-10` | `SUPER_PERMISSIONED` is not registered on the shared factory. |
 | `MIG-DGF-20` | `SUPER_CANNON_KONA` is not registered on the shared factory. |
 | `MIG-DGF-30` | `CANNON` is still registered on the shared factory. |
 | `MIG-DGF-40` | `PERMISSIONED_CANNON` is still registered on the shared factory. |
@@ -291,13 +286,13 @@ The validator behind `OPContractsManagerMigrationValidator` returns a comma-sepa
 | `MIG-CHAIN-{i}-20` | Chain `i`'s per-chain factory still has `CANNON` registered. |
 | `MIG-CHAIN-{i}-30` | Chain `i`'s per-chain factory still has `PERMISSIONED_CANNON` registered. |
 | `MIG-CHAIN-{i}-40` | Chain `i`'s per-chain factory still has `CANNON_KONA` registered. |
-| `MIG-CHAIN-{i}-60` | Chain `i`'s per-chain factory still has `SUPER_PERMISSIONED_CANNON` registered. |
+| `MIG-CHAIN-{i}-60` | Chain `i`'s per-chain factory still has `SUPER_PERMISSIONED` registered. |
 | `MIG-CHAIN-{i}-70` | Chain `i`'s per-chain factory still has `SUPER_CANNON_KONA` registered. |
 | `MIG-CHAIN-{i}-80` | Shared lockbox does not list chain `i`'s portal as authorized. |
 | `MIG-CHAIN-{i}-90` | Chain `i`'s portal `ethLockbox` does not equal the shared lockbox. |
 | `MIG-CHAIN-{i}-100` | Chain `i`'s `SystemConfig` does not have `Features.INTEROP` enabled. |
 | `MIG-CHAIN-{i}-110` | Chain `i`'s `SystemConfig` does not have `Features.ETH_LOCKBOX` enabled. |
-| `MIG-SPDG-*` or `MIG-SCKDG-*` | Super game drill-down. The first prefix covers `SUPER_PERMISSIONED_CANNON` and the second covers `SUPER_CANNON_KONA`. Subcodes include `-GARGS-10` and `-GARGS-30` for game-args shape and `weth` mismatches, plus `-130` and `-140` for proposer or challenger mismatches on the permissioned type. The migration validator also delegates to the standard validator for each super game, so every standard code (MIPS, prestate, depths, clocks, `AnchorStateRegistry` pointer) appears with the same prefix. |
+| `MIG-SPDG-*` or `MIG-SCKDG-*` | Super game drill-down. The first prefix covers `SUPER_PERMISSIONED` and the second covers `SUPER_CANNON_KONA`. `MIG-SPDG-*` subcodes cover the simplified permissioned game's args, proposer, and `AnchorStateRegistry`; `MIG-SCKDG-*` covers the fault-proof game checks. |
 
 ## Execute the Migration
 
@@ -366,7 +361,7 @@ cast call $SHARED_ASR 'retirementTimestamp()(uint64)' --rpc-url $L1_RPC
 # Expect: equal to the migration block's timestamp
 
 # Game implementations registered on the shared factory
-cast call $SHARED_DGF 'gameImpls(uint32)(address)' 5 --rpc-url $L1_RPC   # SUPER_PERMISSIONED_CANNON
+cast call $SHARED_DGF 'gameImpls(uint32)(address)' 5 --rpc-url $L1_RPC   # SUPER_PERMISSIONED
 cast call $SHARED_DGF 'gameImpls(uint32)(address)' 9 --rpc-url $L1_RPC   # SUPER_CANNON_KONA
 # Expect both: non-zero
 

--- a/docs/public-docs/chain-operators/tutorials/upgrade-chain-to-super-roots.mdx
+++ b/docs/public-docs/chain-operators/tutorials/upgrade-chain-to-super-roots.mdx
@@ -8,7 +8,7 @@ description: Runbook for upgrading an OP Stack chain from output-root dispute ga
 
 <Warning>This guide depends on the interop feature, which is still in development. Do not follow it on production chains.</Warning>
 
-This runbook walks you through upgrading a single OP Stack chain from output-root dispute games (`PERMISSIONED_CANNON`, `CANNON` or `CANNON_KONA`) to super-root dispute games (`SUPER_PERMISSIONED_CANNON` or `SUPER_CANNON_KONA`). It runs as a single `opcm.upgrade` call against the chain's existing per-chain `AnchorStateRegistry` and `DisputeGameFactory`. The chain's permission model is preserved: a permissioned chain stays permissioned with `SUPER_PERMISSIONED_CANNON` only; a permissionless chain runs both super game types with `SUPER_CANNON_KONA` as the respected one. Differences between the two are called out inline.
+This runbook walks you through upgrading a single OP Stack chain from output-root dispute games (`PERMISSIONED_CANNON`, `CANNON` or `CANNON_KONA`) to super-root dispute games (`SUPER_PERMISSIONED` or `SUPER_CANNON_KONA`). It runs as a single `opcm.upgrade` call against the chain's existing per-chain `AnchorStateRegistry` and `DisputeGameFactory`. The chain's permission model is preserved: a permissioned chain stays permissioned with `SUPER_PERMISSIONED` only; a permissionless chain runs both super game types with `SUPER_CANNON_KONA` as the respected one. Differences between the two are called out inline.
 
 By the end you will have a chain proposing super-root claims via `op-proposer` against an `op-supernode`, defending them via `op-challenger`, monitored by `op-dispute-mon`, and rejecting creation of new pre-migration games at the factory. Every pre-migration dispute game already in flight continues to resolve, and proven withdrawals are not invalidated.
 
@@ -66,7 +66,7 @@ Read the values you need from `chain.json`:
 
 **Chain type.** The upgrade preserves the chain's existing permission model. `chain.json` reports the current respected game type at `.faultProofs.respectedGameType`:
 
-* `1` (`PERMISSIONED_CANNON`) — chain is **permissioned**. The new respected game type is `5` (`SUPER_PERMISSIONED_CANNON`).
+* `1` (`PERMISSIONED_CANNON`) — chain is **permissioned**. The new respected game type is `5` (`SUPER_PERMISSIONED`).
 * `0` (`CANNON`) or `8` (`CANNON_KONA`) — chain is **permissionless**. The new respected game type is `9` (`SUPER_CANNON_KONA`).
 
 **Init bond.** The `OPCMUpgradeV800` template applies a single `initBond` value (in wei) to every enabled super game type. `0.08 ether` (`80000000000000000` wei) is the standard value used on existing chains.
@@ -85,7 +85,7 @@ Read the values you need from `chain.json`:
 Before you change any configuration:
 
 * **Confirm the template injects `overrides.cfg.startingAnchorRoot`.** Open `superchain-ops/src/template/OPCMUpgradeV800.sol` and check `_buildExtraInstructions`. As of writing it only injects `overrides.cfg.startingRespectedGameType` and `PermittedProxyDeployment`. Without an `overrides.cfg.startingAnchorRoot` override, OPCM falls back to the existing on-chain `startingAnchorRoot`, which on a pre-upgrade chain is an output-root-shaped value with a block-number `l2SequenceNumber` — not a valid super-root anchor. The template must be extended to read a starting super-root anchor from TOML and add it as a third extra instruction. Fix the template before continuing.
-* **Confirm the `op-supernode` tracks only this chain.** `op-proposer`, `op-challenger`, and `op-dispute-mon` must point at a supernode instance whose dependency set contains only this chain's L2 chain ID. A supernode that also tracks other chains computes super roots across all of them, and those roots will not match what this chain's `SUPER_CANNON_KONA` / `SUPER_PERMISSIONED_CANNON` games verify. If the same physical operator also runs supernodes for other chains (or an interop cluster), stand up a dedicated single-chain supernode instance for this upgrade.
+* **Confirm the `op-supernode` tracks only this chain.** `op-proposer`, `op-challenger`, and `op-dispute-mon` must point at a supernode instance whose dependency set contains only this chain's L2 chain ID. A supernode that also tracks other chains computes super roots across all of them, and those roots will not match what this chain's `SUPER_CANNON_KONA` / `SUPER_PERMISSIONED` games verify. If the same physical operator also runs supernodes for other chains (or an interop cluster), stand up a dedicated single-chain supernode instance for this upgrade.
 * **Verify the `op-supernode` is healthy.** Confirm it reports a finalized L2 head within the chain's expected finality window:
 
   ```bash
@@ -164,8 +164,8 @@ templateName = "OPCMUpgradeV800"
 
 [[opcmUpgrades]]
 chainId = <chain id>
-# Kona-interop super prestate, used by both SUPER_PERMISSIONED_CANNON and
-# SUPER_CANNON_KONA. The `-interop` variant supports super roots and works whether
+# Kona-interop super prestate, used by SUPER_CANNON_KONA. The `-interop` variant
+# supports super roots and works whether
 # or not interop is enabled or scheduled on the chain.
 cannonKonaPrestate = "0x<kona-interop super prestate>"
 expectedValidationErrors = ""   # fill in after the dry run
@@ -243,7 +243,7 @@ cast call <DGF> 'gameImpls(uint32)(address)' 8 --rpc-url $L1_RPC   # CANNON_KONA
 ### Permissionless Chain Checks
 
 ```bash
-cast call <DGF> 'gameImpls(uint32)(address)' 5 --rpc-url $L1_RPC   # SUPER_PERMISSIONED_CANNON
+cast call <DGF> 'gameImpls(uint32)(address)' 5 --rpc-url $L1_RPC   # SUPER_PERMISSIONED
 cast call <DGF> 'gameImpls(uint32)(address)' 9 --rpc-url $L1_RPC   # SUPER_CANNON_KONA
 # Expect both: non-zero
 
@@ -255,7 +255,7 @@ cast call <DGF> 'initBonds(uint32)(uint256)' 9 --rpc-url $L1_RPC
 ### Permissioned Chain Checks
 
 ```bash
-cast call <DGF> 'gameImpls(uint32)(address)' 5 --rpc-url $L1_RPC   # SUPER_PERMISSIONED_CANNON
+cast call <DGF> 'gameImpls(uint32)(address)' 5 --rpc-url $L1_RPC   # SUPER_PERMISSIONED
 # Expect: non-zero
 
 cast call <DGF> 'initBonds(uint32)(uint256)' 5 --rpc-url $L1_RPC

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -927,7 +927,7 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 							{
 								Enabled:  false,
 								InitBond: big.NewInt(0),
-								GameType: embedded.GameTypeSuperPermCannon,
+								GameType: embedded.GameTypeSuperPermissioned,
 							},
 							{
 								Enabled:  false,

--- a/op-deployer/pkg/deployer/integration_test/cli/manage_add_game_type_v2_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/manage_add_game_type_v2_test.go
@@ -166,7 +166,7 @@ func TestManageAddGameTypeV2_Integration(t *testing.T) {
 				{
 					Enabled:  false,
 					InitBond: big.NewInt(0),
-					GameType: embedded.GameTypeSuperPermCannon,
+					GameType: embedded.GameTypeSuperPermissioned,
 				},
 				{
 					Enabled:  false,

--- a/op-deployer/pkg/deployer/integration_test/shared/shared.go
+++ b/op-deployer/pkg/deployer/integration_test/shared/shared.go
@@ -270,7 +270,7 @@ func buildV2OPCMUpgradeConfig(t *testing.T, prank, opcmAddr, systemConfigProxy c
 		{
 			Enabled:  false,
 			InitBond: big.NewInt(0),
-			GameType: embedded.GameTypeSuperPermCannon,
+			GameType: embedded.GameTypeSuperPermissioned,
 		},
 		{
 			Enabled:  false,

--- a/op-deployer/pkg/deployer/upgrade/embedded/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/embedded/upgrade.go
@@ -18,7 +18,7 @@ type GameType uint32
 const (
 	GameTypeCannon             GameType = 0
 	GameTypePermissionedCannon GameType = 1
-	GameTypeSuperPermCannon    GameType = 5
+	GameTypeSuperPermissioned  GameType = 5
 	GameTypeCannonKona         GameType = 8
 	GameTypeSuperCannonKona    GameType = 9
 	GameTypeZKDisputeGame      GameType = 10
@@ -158,7 +158,7 @@ func (u *UpgradeOPChainInput) EncodedUpgradeInputV2() ([]byte, error) {
 				if err != nil {
 					return nil, fmt.Errorf("failed to encode permissioned game config: %w", err)
 				}
-			case GameTypeSuperPermCannon:
+			case GameTypeSuperPermissioned:
 				if gameConfig.SuperPermissionedDisputeGameConfig == nil {
 					return nil, fmt.Errorf("superPermissionedDisputeGameConfig is required for game type %d", gameConfig.GameType)
 				}

--- a/op-deployer/pkg/deployer/upgrade/embedded/upgrade_test.go
+++ b/op-deployer/pkg/deployer/upgrade/embedded/upgrade_test.go
@@ -177,14 +177,14 @@ func TestEncodedUpgradeInputV2_GameTypeConfigValidation(t *testing.T) {
 			shouldPass:    false,
 		},
 		{
-			name: "SUPER_PERMISSIONED_CANNON requires SuperPermissionedDisputeGameConfig",
+			name: "SUPER_PERMISSIONED requires SuperPermissionedDisputeGameConfig",
 			gameConfig: DisputeGameConfig{
 				Enabled:  true,
 				InitBond: big.NewInt(1000),
-				GameType: GameTypeSuperPermCannon,
+				GameType: GameTypeSuperPermissioned,
 				// Missing SuperPermissionedDisputeGameConfig
 			},
-			errorContains: fmt.Sprintf("superPermissionedDisputeGameConfig is required for game type %d", GameTypeSuperPermCannon),
+			errorContains: fmt.Sprintf("superPermissionedDisputeGameConfig is required for game type %d", GameTypeSuperPermissioned),
 			shouldPass:    false,
 		},
 		{
@@ -349,11 +349,11 @@ func TestEncodedUpgradeInputV2_GameTypeConfigValidation(t *testing.T) {
 			shouldPass: true,
 		},
 		{
-			name: "SUPER_PERMISSIONED_CANNON with correct SuperPermissionedDisputeGameConfig",
+			name: "SUPER_PERMISSIONED with correct SuperPermissionedDisputeGameConfig",
 			gameConfig: DisputeGameConfig{
 				Enabled:  true,
 				InitBond: big.NewInt(1000),
-				GameType: GameTypeSuperPermCannon,
+				GameType: GameTypeSuperPermissioned,
 				SuperPermissionedDisputeGameConfig: &SuperPermissionedDisputeGameConfig{
 					Proposer: common.HexToAddress("0x1111111111111111111111111111111111111111"),
 				},
@@ -629,7 +629,7 @@ func TestEncodedUpgradeInputV2_GameArgsEncoding(t *testing.T) {
 					{
 						Enabled:  true,
 						InitBond: big.NewInt(1000),
-						GameType: GameTypeSuperPermCannon,
+						GameType: GameTypeSuperPermissioned,
 						SuperPermissionedDisputeGameConfig: &SuperPermissionedDisputeGameConfig{
 							Proposer: proposer,
 						},

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -152,7 +152,7 @@ func addGameTypesForRuntime(
 	dummyCannonPrestate := common.HexToHash(sharedchallenger.DummyPermissionedPrestate)
 
 	// OPCMv2 requires all 6 game configs in order:
-	// CANNON, PERMISSIONED_CANNON, CANNON_KONA, SUPER_PERMISSIONED_CANNON, SUPER_CANNON_KONA, ZK_DISPUTE_GAME.
+	// CANNON, PERMISSIONED_CANNON, CANNON_KONA, SUPER_PERMISSIONED, SUPER_CANNON_KONA, ZK_DISPUTE_GAME.
 	// The CANNON (legacy) game type is permanently disabled, but its config slot must remain present
 	// and in order for the OPCMv2 upgrade.
 	configs := []embedded.DisputeGameConfig{
@@ -182,7 +182,7 @@ func addGameTypesForRuntime(
 				AbsolutePrestate: cannonKonaPrestate,
 			},
 		},
-		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypeSuperPermCannon},
+		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypeSuperPermissioned},
 		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypeSuperCannonKona},
 		{
 			Enabled:             enabled[gameTypes.ZKDisputeGameType],

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -158,7 +158,7 @@ func NewTwoL2SupernodeProofsRuntimeWithConfig(t devtest.T, lagoonAtGenesis bool,
 }
 
 // NewSingleChainSupernodeProofsRuntimeWithConfig deploys a single chain with
-// SuperPermissionedCannon at genesis, then uses opcm.upgrade to add the
+// SuperPermissioned at genesis, then uses opcm.upgrade to add the
 // permissionless super games and set the real starting anchor root.
 // lagoonAtGenesis controls whether Lagoon activates interop at genesis.
 func NewSingleChainSupernodeProofsRuntimeWithConfig(t devtest.T, lagoonAtGenesis bool, cfg PresetConfig) *MultiChainRuntime {

--- a/op-devstack/sysgo/multichain_super_at_genesis.go
+++ b/op-devstack/sysgo/multichain_super_at_genesis.go
@@ -15,7 +15,7 @@ func withSuperRootGamesAtGenesisDeployerFeatures(cfg PresetConfig) PresetConfig 
 }
 
 // NewSingleChainSuperRootAtGenesisRuntimeWithConfig builds a single-chain
-// supernode runtime with SUPER_PERMISSIONED_CANNON installed in the
+// supernode runtime with SUPER_PERMISSIONED installed in the
 // permissioned slot at initial deploy.
 func NewSingleChainSuperRootAtGenesisRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiChainRuntime {
 	cfg = withSuperRootGamesAtGenesisDeployerFeatures(cfg)

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -249,7 +249,7 @@ func migrateSuperRootsWithProposal(
 			{
 				Enabled:  true,
 				InitBond: new(big.Int),
-				GameType: superPermissionedCannonGameType,
+				GameType: superPermissionedGameType,
 				GameArgs: superPermissionedGameArgs,
 			},
 			{
@@ -310,8 +310,8 @@ func getAbsolutePrestate(t devtest.CommonT, prestatePath string) common.Hash {
 }
 
 const (
-	superPermissionedCannonGameType = 5
-	superCannonKonaGameType         = 9
+	superPermissionedGameType = 5
+	superCannonKonaGameType   = 9
 )
 
 var (

--- a/op-devstack/sysgo/superroot_via_upgrade.go
+++ b/op-devstack/sysgo/superroot_via_upgrade.go
@@ -83,7 +83,7 @@ func buildSuperRootUpgradeGameConfigs(
 		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypePermissionedCannon},
 		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypeCannonKona},
 		{
-			Enabled: true, InitBond: new(big.Int), GameType: embedded.GameTypeSuperPermCannon,
+			Enabled: true, InitBond: new(big.Int), GameType: embedded.GameTypeSuperPermissioned,
 			SuperPermissionedDisputeGameConfig: &embedded.SuperPermissionedDisputeGameConfig{
 				Proposer: proposer,
 			},

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -300,7 +300,7 @@ contract Deploy is Deployer {
         );
         GameType permGameType = DevFeatures.isDevFeatureEnabled(
             cfg.devFeatureBitmap(), DevFeatures.SUPER_ROOT_GAMES_MIGRATION
-        ) ? GameTypes.SUPER_PERMISSIONED_CANNON : GameTypes.PERMISSIONED_CANNON;
+        ) ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON;
         ChainAssertions.checkDisputeGameFactory(
             IDisputeGameFactory(impls.DisputeGameFactory), address(0), address(0), false, permGameType
         );
@@ -406,7 +406,7 @@ contract Deploy is Deployer {
         disputeGameConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: true,
             initBond: 0,
-            gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+            gameType: GameTypes.SUPER_PERMISSIONED,
             gameArgs: abi.encode(
                 IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: cfg.l2OutputOracleProposer() })
             )
@@ -439,7 +439,7 @@ contract Deploy is Deployer {
                 root: Hash.wrap(cfg.faultGameGenesisOutputRoot()),
                 l2SequenceNumber: uint64(cfg.faultGameGenesisBlock())
             }),
-            startingRespectedGameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+            startingRespectedGameType: GameTypes.SUPER_PERMISSIONED,
             basefeeScalar: cfg.basefeeScalar(),
             blobBasefeeScalar: cfg.blobbasefeeScalar(),
             gasLimit: uint64(cfg.l2GenesisBlockGasLimit()),
@@ -488,7 +488,7 @@ contract Deploy is Deployer {
         disputeGameConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: false,
             initBond: 0,
-            gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+            gameType: GameTypes.SUPER_PERMISSIONED,
             gameArgs: bytes("")
         });
         disputeGameConfigs[4] = IOPContractsManagerUtils.DisputeGameConfig({

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -776,7 +776,7 @@ contract DeployImplementations is Script {
         ChainAssertions.checkDelayedWETHImpl(_output.delayedWETHImpl, _input.withdrawalDelaySeconds);
         GameType permGameType = DevFeatures.isDevFeatureEnabled(
             _input.devFeatureBitmap, DevFeatures.SUPER_ROOT_GAMES_MIGRATION
-        ) ? GameTypes.SUPER_PERMISSIONED_CANNON : GameTypes.PERMISSIONED_CANNON;
+        ) ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON;
         ChainAssertions.checkDisputeGameFactory(
             _output.disputeGameFactoryImpl, address(0), address(0), false, permGameType
         );

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -164,18 +164,18 @@ contract DeployOPChain is Script {
             gameArgs: bytes("")
         });
 
-        // Config 3: SUPER_PERMISSIONED_CANNON — enabled only in super-root mode.
+        // Config 3: SUPER_PERMISSIONED — enabled only in super-root mode.
         disputeGameConfigs[3] = isSuperRoot
             ? IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: true,
                 initBond: 0,
-                gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+                gameType: GameTypes.SUPER_PERMISSIONED,
                 gameArgs: abi.encode(superPdgConfig)
             })
             : IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: false,
                 initBond: 0,
-                gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+                gameType: GameTypes.SUPER_PERMISSIONED,
                 gameArgs: bytes("")
             });
 
@@ -203,7 +203,7 @@ contract DeployOPChain is Script {
             unsafeBlockSigner: _input.unsafeBlockSigner,
             batcher: _input.batcher,
             startingAnchorRoot: ScriptConstants.DEFAULT_OUTPUT_ROOT(),
-            startingRespectedGameType: isSuperRoot ? GameTypes.SUPER_PERMISSIONED_CANNON : GameTypes.PERMISSIONED_CANNON,
+            startingRespectedGameType: isSuperRoot ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON,
             basefeeScalar: _input.basefeeScalar,
             blobBasefeeScalar: _input.blobBaseFeeScalar,
             gasLimit: _input.gasLimit,
@@ -222,7 +222,7 @@ contract DeployOPChain is Script {
         view
         returns (Output memory output_)
     {
-        GameType permGameType = isSuperRoot ? GameTypes.SUPER_PERMISSIONED_CANNON : GameTypes.PERMISSIONED_CANNON;
+        GameType permGameType = isSuperRoot ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON;
         address permissionedDgImpl = address(_chainContracts.disputeGameFactory.gameImpls(permGameType));
 
         output_ = Output({
@@ -362,7 +362,7 @@ contract DeployOPChain is Script {
             ? opcmV2.implementations().superPermissionedDisputeGameImpl
             : opcmV2.implementations().permissionedDisputeGameImpl;
 
-        GameType permGameType = isSuperRoot ? GameTypes.SUPER_PERMISSIONED_CANNON : GameTypes.PERMISSIONED_CANNON;
+        GameType permGameType = isSuperRoot ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON;
         ChainAssertions.checkDisputeGameFactory(
             _o.disputeGameFactoryProxy, _i.opChainProxyAdminOwner, expectedPDGImpl, true, permGameType
         );

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x131109ddbd9fdd69b0ff987da574fbea5ffdf23ae7ff30cee6f10e62b0832025",
-    "sourceCodeHash": "0xe72fec448b7145656be07ebb22bcbf27e9e57ab163956b2ece70bb89c102bee5"
+    "initCodeHash": "0xb55a34bc040757b18629342340c9f5dea138e921b77fdf4a53d5b43cb01aec55",
+    "sourceCodeHash": "0x90df469615acb1d55af0a9774c2fb38763cde6948a76378b21ee6566e78da539"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x02f8cfb0213d614c34c12904f0d06b4f8fad14f7d127b3b780f9d5cc5ebba72a",
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x2650f2af1df017387e1f1aa6273decc4c46dd4f3ac7f0910c6f0edc92aef4747"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x3823112f729f99c7e94bd5a17cb34fc7b720a2cab5b071d92c7c8c402604890c",
-    "sourceCodeHash": "0xe859ca5810eea955d018f35e9220fdc5b74b130f645fef67834cfbb69782564a"
+    "initCodeHash": "0xfa7d85fbf5f1d26c4f264dbde9bd4fcb186818441ef6e096ad628f43f308f44e",
+    "sourceCodeHash": "0xd2382fa63191a6f313c685fc91609006e94e643031b2d3787921358a652f28bc"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0xf1fb169c6dd4eceb5cec6ed6dfa3affc45970e5a01e00827d06af1f9e8df026d",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -46,8 +46,8 @@ import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 2.10.2
-    string public constant version = "2.10.2";
+    /// @custom:semver 2.10.3
+    string public constant version = "2.10.3";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;
@@ -509,7 +509,7 @@ contract OPContractsManagerStandardValidator is ISemver {
         view
         returns (string memory)
     {
-        if (_gameType.raw() == GameTypes.SUPER_PERMISSIONED_CANNON.raw()) {
+        if (_gameType.raw() == GameTypes.SUPER_PERMISSIONED.raw()) {
             return assertValidSuperPermissionedDisputeGame(_errors, _sysCfg, _admin, _proposer, _errorPrefix);
         }
 
@@ -595,7 +595,7 @@ contract OPContractsManagerStandardValidator is ISemver {
         returns (string memory)
     {
         require(
-            _gameType.raw() != GameTypes.SUPER_PERMISSIONED_CANNON.raw(),
+            _gameType.raw() != GameTypes.SUPER_PERMISSIONED.raw(),
             "OPContractsManagerStandardValidator: SPDG is not permissionless"
         );
 
@@ -676,7 +676,7 @@ contract OPContractsManagerStandardValidator is ISemver {
     {
         errors_ = _initialErrors;
         IDisputeGameFactory _factory = IDisputeGameFactory(_sysCfg.disputeGameFactory());
-        address gameAddress = address(_factory.gameImpls(GameTypes.SUPER_PERMISSIONED_CANNON));
+        address gameAddress = address(_factory.gameImpls(GameTypes.SUPER_PERMISSIONED));
 
         if (gameAddress == address(0)) {
             errors_ = internalRequire(false, string.concat(_errorPrefix, "-10"), errors_);
@@ -684,10 +684,10 @@ contract OPContractsManagerStandardValidator is ISemver {
             return (gameImpl_, errors_, failed_);
         }
 
-        bytes memory gameArgsBytes = _factory.gameArgs(GameTypes.SUPER_PERMISSIONED_CANNON);
+        bytes memory gameArgsBytes = _factory.gameArgs(GameTypes.SUPER_PERMISSIONED);
         bool lenCheckFailed;
         (errors_, lenCheckFailed) =
-            assertGameArgsLength(errors_, gameArgsBytes, GameTypes.SUPER_PERMISSIONED_CANNON, _errorPrefix);
+            assertGameArgsLength(errors_, gameArgsBytes, GameTypes.SUPER_PERMISSIONED, _errorPrefix);
         if (lenCheckFailed) {
             failed_ = true;
             return (gameImpl_, errors_, failed_);
@@ -720,7 +720,7 @@ contract OPContractsManagerStandardValidator is ISemver {
     function expectedGameImpl(GameType _gameType) internal view returns (address) {
         uint32 raw = _gameType.raw();
         if (raw == GameTypes.PERMISSIONED_CANNON.raw()) return permissionedDisputeGameImpl;
-        if (raw == GameTypes.SUPER_PERMISSIONED_CANNON.raw()) return superPermissionedDisputeGameImpl;
+        if (raw == GameTypes.SUPER_PERMISSIONED.raw()) return superPermissionedDisputeGameImpl;
         if (raw == GameTypes.SUPER_CANNON.raw()) return superFaultDisputeGameImpl;
         if (raw == GameTypes.SUPER_CANNON_KONA.raw()) return superFaultDisputeGameImpl;
         if (raw == GameTypes.ZK_DISPUTE_GAME.raw()) return zkDisputeGameImpl;
@@ -913,7 +913,7 @@ contract OPContractsManagerStandardValidator is ISemver {
             _errors = assertValidPermissionedDisputeGame(
                 _errors,
                 _input.sysCfg,
-                GameTypes.SUPER_PERMISSIONED_CANNON,
+                GameTypes.SUPER_PERMISSIONED,
                 _input.cannonPrestate,
                 _input.l2ChainID,
                 _proxyAdmin,
@@ -1031,7 +1031,7 @@ contract OPContractsManagerStandardValidator is ISemver {
             bool ok = LibGameArgs.isValidZKArgs(_gameArgsBytes);
             _errors = internalRequire(ok, string.concat(_errorPrefix, "-10"), _errors);
             return (_errors, !ok);
-        } else if (rawGameType == GameTypes.SUPER_PERMISSIONED_CANNON.raw()) {
+        } else if (rawGameType == GameTypes.SUPER_PERMISSIONED.raw()) {
             bool ok = LibGameArgs.isValidSuperPermissionedArgs(_gameArgsBytes);
             _errors = internalRequire(ok, string.concat(_errorPrefix, "-10"), _errors);
             return (_errors, !ok);

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrationValidator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrationValidator.sol
@@ -205,7 +205,7 @@ contract OPContractsManagerMigrationValidator {
     }
 
     /// @notice Validates the shape of the shared DGF — correct game types registered/unregistered.
-    ///         Post-migration interop requires SUPER_PERMISSIONED_CANNON and SUPER_CANNON_KONA
+    ///         Post-migration interop requires SUPER_PERMISSIONED and SUPER_CANNON_KONA
     ///         registered; all legacy game types (CANNON, PERMISSIONED_CANNON, CANNON_KONA,
     ///         SUPER_CANNON) unregistered.
     function assertValidSharedDGFShape(
@@ -216,9 +216,8 @@ contract OPContractsManagerMigrationValidator {
         view
         returns (string memory)
     {
-        _errors = internalRequire(
-            address(_dgf.gameImpls(GameTypes.SUPER_PERMISSIONED_CANNON)) != address(0), "MIG-DGF-10", _errors
-        );
+        _errors =
+            internalRequire(address(_dgf.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0), "MIG-DGF-10", _errors);
         _errors =
             internalRequire(address(_dgf.gameImpls(GameTypes.SUPER_CANNON_KONA)) != address(0), "MIG-DGF-20", _errors);
         _errors = internalRequire(address(_dgf.gameImpls(GameTypes.CANNON)) == address(0), "MIG-DGF-30", _errors);
@@ -267,10 +266,10 @@ contract OPContractsManagerMigrationValidator {
         returns (string memory)
     {
         // If game impl is address(0), skip — already caught by shape checks.
-        address gameImplAddr = address(_p.dgf.gameImpls(GameTypes.SUPER_PERMISSIONED_CANNON));
+        address gameImplAddr = address(_p.dgf.gameImpls(GameTypes.SUPER_PERMISSIONED));
         if (gameImplAddr == address(0)) return _errors;
 
-        bytes memory gameArgsBytes = _p.dgf.gameArgs(GameTypes.SUPER_PERMISSIONED_CANNON);
+        bytes memory gameArgsBytes = _p.dgf.gameArgs(GameTypes.SUPER_PERMISSIONED);
         bool argsOk = LibGameArgs.isValidSuperPermissionedArgs(gameArgsBytes);
         _errors = internalRequire(argsOk, string.concat(_p.prefix, "-GARGS-10"), _errors);
         if (!argsOk) return _errors;
@@ -502,7 +501,7 @@ contract OPContractsManagerMigrationValidator {
                     _errors
                 );
                 _errors = internalRequire(
-                    address(perChainDGF.gameImpls(GameTypes.SUPER_PERMISSIONED_CANNON)) == address(0),
+                    address(perChainDGF.gameImpls(GameTypes.SUPER_PERMISSIONED)) == address(0),
                     string.concat("MIG-CHAIN-", idx, "-60"),
                     _errors
                 );

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -111,7 +111,7 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         // SUPER_CANNON is retired in favor of SUPER_CANNON_KONA.
         if (
             _input.startingRespectedGameType.raw() != GameTypes.SUPER_CANNON_KONA.raw()
-                && _input.startingRespectedGameType.raw() != GameTypes.SUPER_PERMISSIONED_CANNON.raw()
+                && _input.startingRespectedGameType.raw() != GameTypes.SUPER_PERMISSIONED.raw()
         ) {
             revert OPContractsManagerMigrator_InvalidStartingRespectedGameType();
         }
@@ -408,7 +408,7 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         existingDGF.setImplementation(GameTypes.CANNON, IDisputeGame(address(0)), hex"");
         existingDGF.setImplementation(GameTypes.SUPER_CANNON, IDisputeGame(address(0)), hex"");
         existingDGF.setImplementation(GameTypes.PERMISSIONED_CANNON, IDisputeGame(address(0)), hex"");
-        existingDGF.setImplementation(GameTypes.SUPER_PERMISSIONED_CANNON, IDisputeGame(address(0)), hex"");
+        existingDGF.setImplementation(GameTypes.SUPER_PERMISSIONED, IDisputeGame(address(0)), hex"");
         existingDGF.setImplementation(GameTypes.CANNON_KONA, IDisputeGame(address(0)), hex"");
         existingDGF.setImplementation(GameTypes.SUPER_CANNON_KONA, IDisputeGame(address(0)), hex"");
         existingDGF.setImplementation(GameTypes.ZK_DISPUTE_GAME, IDisputeGame(address(0)), hex"");

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -396,7 +396,7 @@ contract OPContractsManagerUtils {
             return IDisputeGame(impls.permissionedDisputeGameImpl);
         } else if (_gameType.raw() == GameTypes.CANNON_KONA.raw()) {
             return IDisputeGame(impls.faultDisputeGameImpl);
-        } else if (_gameType.raw() == GameTypes.SUPER_PERMISSIONED_CANNON.raw()) {
+        } else if (_gameType.raw() == GameTypes.SUPER_PERMISSIONED.raw()) {
             return IDisputeGame(impls.superPermissionedDisputeGameImpl);
         } else if (_gameType.raw() == GameTypes.SUPER_CANNON_KONA.raw()) {
             return IDisputeGame(impls.superFaultDisputeGameImpl);
@@ -455,7 +455,7 @@ contract OPContractsManagerUtils {
                 parsedInputArgs.proposer,
                 parsedInputArgs.challenger
             );
-        } else if (rawGT == GameTypes.SUPER_PERMISSIONED_CANNON.raw()) {
+        } else if (rawGT == GameTypes.SUPER_PERMISSIONED.raw()) {
             IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig memory parsedInputArgs =
                 abi.decode(_gcfg.gameArgs, (IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig));
             return abi.encodePacked(address(_anchorStateRegistry), parsedInputArgs.proposer);

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -158,9 +158,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 7.1.22
+    /// @custom:semver 7.1.23
     function version() public pure returns (string memory) {
-        return "7.1.22";
+        return "7.1.23";
     }
 
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -700,7 +700,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         validGameTypes[0] = GameTypes.CANNON;
         validGameTypes[1] = GameTypes.PERMISSIONED_CANNON;
         validGameTypes[2] = GameTypes.CANNON_KONA;
-        validGameTypes[3] = GameTypes.SUPER_PERMISSIONED_CANNON;
+        validGameTypes[3] = GameTypes.SUPER_PERMISSIONED;
         validGameTypes[4] = GameTypes.SUPER_CANNON_KONA;
         validGameTypes[5] = GameTypes.ZK_DISPUTE_GAME;
 
@@ -723,16 +723,16 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             }
 
             if (
-                _cfg.disputeGameConfigs[i].gameType.raw() == GameTypes.SUPER_PERMISSIONED_CANNON.raw()
+                _cfg.disputeGameConfigs[i].gameType.raw() == GameTypes.SUPER_PERMISSIONED.raw()
                     && _cfg.disputeGameConfigs[i].initBond != 0
             ) {
                 revert OPContractsManagerV2_InvalidGameConfigs();
             }
 
             // If game is enabled, we must have a non-zero init bond, except
-            // SUPER_PERMISSIONED_CANNON which does not use bonds.
+            // SUPER_PERMISSIONED which does not use bonds.
             if (
-                _cfg.disputeGameConfigs[i].gameType.raw() != GameTypes.SUPER_PERMISSIONED_CANNON.raw()
+                _cfg.disputeGameConfigs[i].gameType.raw() != GameTypes.SUPER_PERMISSIONED.raw()
                     && _cfg.disputeGameConfigs[i].enabled && _cfg.disputeGameConfigs[i].initBond == 0
             ) {
                 revert OPContractsManagerV2_InvalidGameConfigs();
@@ -740,7 +740,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
             // Check if this is a permissioned type.
             bool isPermissioned = validGameTypes[i].raw() == GameTypes.PERMISSIONED_CANNON.raw()
-                || validGameTypes[i].raw() == GameTypes.SUPER_PERMISSIONED_CANNON.raw();
+                || validGameTypes[i].raw() == GameTypes.SUPER_PERMISSIONED.raw();
 
             // During initial deployment, only permissioned types can be enabled, because no
             // prestate exists for permissionless games.

--- a/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
@@ -168,9 +168,8 @@ contract StandardValidatorUtils {
             internalRequire(address(dgf.gameImpls(GameTypes.PERMISSIONED_CANNON)) == address(0), "PDDG-SHAPE", _errors);
         _errors = internalRequire(address(dgf.gameImpls(GameTypes.CANNON_KONA)) == address(0), "CKDG-SHAPE", _errors);
         _errors = internalRequire(address(dgf.gameImpls(GameTypes.SUPER_CANNON)) == address(0), "SCDG-SHAPE", _errors);
-        _errors = internalRequire(
-            address(dgf.gameImpls(GameTypes.SUPER_PERMISSIONED_CANNON)) != address(0), "SPDG-SHAPE", _errors
-        );
+        _errors =
+            internalRequire(address(dgf.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0), "SPDG-SHAPE", _errors);
         _errors =
             internalRequire(address(dgf.gameImpls(GameTypes.SUPER_CANNON_KONA)) != address(0), "SCKDG-SHAPE", _errors);
         return _errors;
@@ -187,9 +186,8 @@ contract StandardValidatorUtils {
     {
         IDisputeGameFactory dgf = IDisputeGameFactory(_sysCfg.disputeGameFactory());
         _errors = internalRequire(address(dgf.gameImpls(GameTypes.SUPER_CANNON)) == address(0), "SCDG-NOSHAPE", _errors);
-        _errors = internalRequire(
-            address(dgf.gameImpls(GameTypes.SUPER_PERMISSIONED_CANNON)) == address(0), "SPDG-NOSHAPE", _errors
-        );
+        _errors =
+            internalRequire(address(dgf.gameImpls(GameTypes.SUPER_PERMISSIONED)) == address(0), "SPDG-NOSHAPE", _errors);
         _errors =
             internalRequire(address(dgf.gameImpls(GameTypes.SUPER_CANNON_KONA)) == address(0), "SCKDG-NOSHAPE", _errors);
         // TODO: add ZKDG-NOSHAPE check here once the super-root ZKDisputeGame is ready to be used
@@ -266,10 +264,10 @@ contract StandardValidatorUtils {
         _errors = internalRequire(_factory.owner() == _l1PAOMultisig, "DF-30", _errors);
         _errors = internalRequire(IProxyAdminOwnedBase(address(_factory)).proxyAdmin() == _admin, "DF-40", _errors);
         // At least one permissioned game must be registered — either the legacy
-        // PERMISSIONED_CANNON or the super-root SUPER_PERMISSIONED_CANNON.
+        // PERMISSIONED_CANNON or the super-root SUPER_PERMISSIONED.
         _errors = internalRequire(
             address(_factory.gameImpls(GameTypes.PERMISSIONED_CANNON)) != address(0)
-                || address(_factory.gameImpls(GameTypes.SUPER_PERMISSIONED_CANNON)) != address(0),
+                || address(_factory.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0),
             "DF-50",
             _errors
         );

--- a/packages/contracts-bedrock/src/dispute/lib/Types.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Types.sol
@@ -66,8 +66,8 @@ library GameTypes {
     /// @notice A dispute game type that uses the cannon vm (Super Roots).
     GameType internal constant SUPER_CANNON = GameType.wrap(4);
 
-    /// @notice A dispute game type that uses the permissioned cannon vm (Super Roots).
-    GameType internal constant SUPER_PERMISSIONED_CANNON = GameType.wrap(5);
+    /// @notice A permissioned dispute game type for Super Roots.
+    GameType internal constant SUPER_PERMISSIONED = GameType.wrap(5);
 
     /// @notice A dispute game type that uses OP Succinct
     GameType internal constant OP_SUCCINCT = GameType.wrap(6);
@@ -98,7 +98,7 @@ library GameTypes {
     /// @notice Returns true if the game type uses super roots.
     function isSuperGame(GameType _gameType) internal pure returns (bool) {
         uint32 raw = _gameType.raw();
-        return raw == SUPER_CANNON.raw() || raw == SUPER_PERMISSIONED_CANNON.raw() || raw == SUPER_ASTERISC_KONA.raw()
+        return raw == SUPER_CANNON.raw() || raw == SUPER_PERMISSIONED.raw() || raw == SUPER_ASTERISC_KONA.raw()
             || raw == SUPER_CANNON_KONA.raw() || raw == ZK_DISPUTE_GAME.raw();
     }
 }

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -281,7 +281,7 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest {
             disputeGameConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: false,
                 initBond: 0,
-                gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+                gameType: GameTypes.SUPER_PERMISSIONED,
                 gameArgs: hex""
             });
             disputeGameConfigs[4] = IOPContractsManagerUtils.DisputeGameConfig({
@@ -974,14 +974,14 @@ contract OPContractsManagerStandardValidator_DisputeGameFactory_Test is OPContra
     }
 
     /// @notice Tests that the validate function returns DF-50 when neither PERMISSIONED_CANNON nor
-    ///         SUPER_PERMISSIONED_CANNON has a registered implementation in the DGF.
+    ///         SUPER_PERMISSIONED has a registered implementation in the DGF.
     function test_validate_disputeGameFactoryNoPermissionedGame_succeeds() public {
         vm.mockCall(
             address(disputeGameFactory),
             abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.PERMISSIONED_CANNON)),
             abi.encode(address(0))
         );
-        // SUPER_PERMISSIONED_CANNON is not registered in non-super mode, so DF-50 fires.
+        // SUPER_PERMISSIONED is not registered in non-super mode, so DF-50 fires.
         // PDDG-NOSHAPE fires because PERMISSIONED_CANNON is not registered in non-super mode.
         // PDDG-10 also fires because PERMISSIONED_CANNON impl is null.
         assertEq("DF-50,PDDG-NOSHAPE,PDDG-10", _validate(true));
@@ -997,11 +997,11 @@ contract OPContractsManagerStandardValidator_DisputeGameFactory_Test is OPContra
         assertEq("SCDG-NOSHAPE", _validate(true));
     }
 
-    /// @notice Tests that SPDG-NOSHAPE fires when SUPER_PERMISSIONED_CANNON has a registered impl in non-super mode.
-    function test_validate_nonSuperModeSuperPermissionedCannonRegistered_succeeds() public {
+    /// @notice Tests that SPDG-NOSHAPE fires when SUPER_PERMISSIONED has a registered impl in non-super mode.
+    function test_validate_nonSuperModeSuperPermissionedRegistered_succeeds() public {
         vm.mockCall(
             address(disputeGameFactory),
-            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED)),
             abi.encode(address(0xdead))
         );
         assertEq("SPDG-NOSHAPE", _validate(true));
@@ -1026,7 +1026,7 @@ contract OPContractsManagerStandardValidator_DisputeGameFactory_Test is OPContra
         );
         vm.mockCall(
             address(disputeGameFactory),
-            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED)),
             abi.encode(address(0xdead))
         );
         vm.mockCall(
@@ -1051,7 +1051,7 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
             abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.PERMISSIONED_CANNON)),
             abi.encode(address(0))
         );
-        // DF-50 also fires because neither PERMISSIONED_CANNON nor SUPER_PERMISSIONED_CANNON is registered.
+        // DF-50 also fires because neither PERMISSIONED_CANNON nor SUPER_PERMISSIONED is registered.
         // PDDG-NOSHAPE fires because PERMISSIONED_CANNON is not registered in non-super mode.
         assertEq("DF-50,PDDG-NOSHAPE,PDDG-10", _validate(true));
     }
@@ -1743,10 +1743,13 @@ contract OPContractsManagerStandardValidator_Versions_Test is OPContractsManager
 
 /// @title OPContractsManagerStandardValidator_SuperMode_TestInit
 /// @notice Base contract for super mode StandardValidator tests. Requires SUPER_ROOT_GAMES_MIGRATION flag.
-///         After setUp, the chain has both SUPER_PERMISSIONED_CANNON and SUPER_CANNON_KONA enabled.
+///         After setUp, the chain has both SUPER_PERMISSIONED and SUPER_CANNON_KONA enabled.
 abstract contract OPContractsManagerStandardValidator_SuperMode_TestInit is SuperGameTestInit {
     /// @notice The l2ChainId.
     uint256 l2ChainId;
+
+    /// @notice The cannon prestate expected by legacy Cannon validation inputs.
+    Claim cannonPrestate;
 
     /// @notice The DisputeGameFactory instance.
     IDisputeGameFactory dgf;
@@ -1770,12 +1773,12 @@ abstract contract OPContractsManagerStandardValidator_SuperMode_TestInit is Supe
         proposer = deploy.cfg().l2OutputOracleProposer();
         challenger = deploy.cfg().l2OutputOracleChallenger();
 
-        // The deploy created SUPER_PERMISSIONED_CANNON (enabled) + SUPER_CANNON_KONA (disabled).
+        // The deploy created SUPER_PERMISSIONED (enabled) + SUPER_CANNON_KONA (disabled).
         // Run an upgrade to also enable SUPER_CANNON_KONA so that full validation passes.
         _enableSuperCannonKona();
     }
 
-    /// @notice Runs an upgrade that enables SUPER_CANNON_KONA alongside SUPER_PERMISSIONED_CANNON.
+    /// @notice Runs an upgrade that enables SUPER_CANNON_KONA alongside SUPER_PERMISSIONED.
     function _enableSuperCannonKona() internal override {
         address owner = proxyAdmin.owner();
 
@@ -1806,7 +1809,7 @@ abstract contract OPContractsManagerStandardValidator_SuperMode_TestInit is Supe
         disputeGameConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: true,
             initBond: 0,
-            gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+            gameType: GameTypes.SUPER_PERMISSIONED,
             gameArgs: abi.encode(IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: proposer }))
         });
         disputeGameConfigs[4] = IOPContractsManagerUtils.DisputeGameConfig({
@@ -1826,7 +1829,7 @@ abstract contract OPContractsManagerStandardValidator_SuperMode_TestInit is Supe
             new IOPContractsManagerUtils.ExtraInstruction[](1);
         extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
             key: "overrides.cfg.startingRespectedGameType",
-            data: abi.encode(GameTypes.SUPER_PERMISSIONED_CANNON)
+            data: abi.encode(GameTypes.SUPER_PERMISSIONED)
         });
 
         prankDelegateCall(owner);
@@ -1917,14 +1920,14 @@ contract OPContractsManagerStandardValidator_SuperRootDisputeGames_Test is
         assertEq("SCDG-SHAPE", _validate(true));
     }
 
-    /// @notice Tests that disabling SUPER_PERMISSIONED_CANNON triggers SPDG-SHAPE.
+    /// @notice Tests that disabling SUPER_PERMISSIONED triggers SPDG-SHAPE.
     function test_validate_superPermissionedCannonNotRegistered_succeeds() public {
         vm.mockCall(
             address(disputeGameFactory),
-            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED)),
             abi.encode(address(0))
         );
-        // DF-50 also fires because neither PERMISSIONED_CANNON nor SUPER_PERMISSIONED_CANNON is registered.
+        // DF-50 also fires because neither PERMISSIONED_CANNON nor SUPER_PERMISSIONED is registered.
         assertEq("DF-50,SPDG-SHAPE,SPDG-10", _validate(true));
     }
 
@@ -1940,24 +1943,24 @@ contract OPContractsManagerStandardValidator_SuperRootDisputeGames_Test is
 }
 
 /// @title OPContractsManagerStandardValidator_SuperPermissionedDisputeGame_Test
-/// @notice Tests SPDG error codes for the SUPER_PERMISSIONED_CANNON game validation.
+/// @notice Tests SPDG error codes for the SUPER_PERMISSIONED game validation.
 contract OPContractsManagerStandardValidator_SuperPermissionedDisputeGame_Test is
     OPContractsManagerStandardValidator_SuperMode_TestInit
 {
-    /// @notice Tests SPDG-10 when SUPER_PERMISSIONED_CANNON implementation is null.
+    /// @notice Tests SPDG-10 when SUPER_PERMISSIONED implementation is null.
     function test_validate_superPermissionedDisputeGameNullImplementation_succeeds() public {
         vm.mockCall(
             address(disputeGameFactory),
-            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED)),
             abi.encode(address(0))
         );
-        // DF-50 also fires because neither PERMISSIONED_CANNON nor SUPER_PERMISSIONED_CANNON is registered.
+        // DF-50 also fires because neither PERMISSIONED_CANNON nor SUPER_PERMISSIONED is registered.
         assertEq("DF-50,SPDG-SHAPE,SPDG-10", _validate(true));
     }
 
-    /// @notice Tests SPDG-20 when SUPER_PERMISSIONED_CANNON version is invalid.
+    /// @notice Tests SPDG-20 when SUPER_PERMISSIONED version is invalid.
     function test_validate_superPermissionedDisputeGameInvalidVersion_succeeds() public {
-        address spdgImpl = address(disputeGameFactory.gameImpls(GameTypes.SUPER_PERMISSIONED_CANNON));
+        address spdgImpl = address(disputeGameFactory.gameImpls(GameTypes.SUPER_PERMISSIONED));
         BadVersionReturner bad = new BadVersionReturner(standardValidator, ISemver(spdgImpl), "0.0.0");
         bytes32 slot = bytes32(
             ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "superPermissionedDisputeGameImpl").slot
@@ -1966,18 +1969,18 @@ contract OPContractsManagerStandardValidator_SuperPermissionedDisputeGame_Test i
         assertEq("SPDG-20", _validate(true));
     }
 
-    /// @notice Tests SPDG-GARGS-10 when SUPER_PERMISSIONED_CANNON game args are invalid.
+    /// @notice Tests SPDG-GARGS-10 when SUPER_PERMISSIONED game args are invalid.
     function test_validate_superPermissionedDisputeGameInvalidGameArgs_succeeds() public {
         vm.mockCall(
             address(dgf),
-            abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.SUPER_PERMISSIONED)),
             abi.encode(hex"123456")
         );
 
         assertEq("SPDG-GARGS-10", _validate(true));
     }
 
-    /// @notice Tests SPDG-ANCHORP-* when SUPER_PERMISSIONED_CANNON's simplified ASR arg is invalid.
+    /// @notice Tests SPDG-ANCHORP-* when SUPER_PERMISSIONED's simplified ASR arg is invalid.
     function test_validate_superPermissionedDisputeGameInvalidASR_succeeds() public {
         address badASR = address(0xbad);
         DisputeGames.mockSuperPermissionedGameASR(dgf, badASR);
@@ -1997,7 +2000,7 @@ contract OPContractsManagerStandardValidator_SuperPermissionedDisputeGame_Test i
         assertEq("SPDG-ANCHORP-10,SPDG-ANCHORP-20", _validate(true));
     }
 
-    /// @notice Tests SPDG-120 when SUPER_PERMISSIONED_CANNON's anchor root is zero.
+    /// @notice Tests SPDG-120 when SUPER_PERMISSIONED's anchor root is zero.
     function test_validate_superPermissionedDisputeGameZeroAnchorRoot_succeeds() public {
         address spdgASR = DisputeGames.superPermissionedGameAnchorStateRegistry(dgf);
         vm.mockCall(spdgASR, abi.encodeCall(IAnchorStateRegistry.getAnchorRoot, ()), abi.encode(bytes32(0), uint256(0)));
@@ -2005,7 +2008,7 @@ contract OPContractsManagerStandardValidator_SuperPermissionedDisputeGame_Test i
         assertEq("SPDG-120,SCKDG-120", _validate(true));
     }
 
-    /// @notice Tests SPDG-140 when SUPER_PERMISSIONED_CANNON proposer is invalid.
+    /// @notice Tests SPDG-140 when SUPER_PERMISSIONED proposer is invalid.
     function test_validate_superPermissionedDisputeGameInvalidProposer_succeeds() public {
         DisputeGames.mockSuperPermissionedGameProposer(dgf, address(0xbad));
         assertEq("SPDG-140", _validate(true));
@@ -2215,7 +2218,7 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
             configs[3] = IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: false,
                 initBond: 0,
-                gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+                gameType: GameTypes.SUPER_PERMISSIONED,
                 gameArgs: hex""
             });
             configs[4] = IOPContractsManagerUtils.DisputeGameConfig({

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1921,7 +1921,7 @@ contract OPContractsManagerStandardValidator_SuperRootDisputeGames_Test is
     }
 
     /// @notice Tests that disabling SUPER_PERMISSIONED triggers SPDG-SHAPE.
-    function test_validate_superPermissionedCannonNotRegistered_succeeds() public {
+    function test_validate_superPermissionedNotRegistered_succeeds() public {
         vm.mockCall(
             address(disputeGameFactory),
             abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED)),

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -108,7 +108,7 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
         sharedLockbox = IETHLockbox(portal1.ethLockbox());
 
         // Discover WETH from the permissionless super game args. The simplified
-        // SUPER_PERMISSIONED_CANNON no longer carries WETH in its game args.
+        // SUPER_PERMISSIONED no longer carries WETH in its game args.
         LibGameArgs.GameArgs memory args = LibGameArgs.decode(sharedDGF.gameArgs(GameTypes.SUPER_CANNON_KONA));
         sharedWETH = args.weth;
     }
@@ -156,7 +156,7 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
         dgConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: superRoot,
             initBond: 0,
-            gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+            gameType: GameTypes.SUPER_PERMISSIONED,
             gameArgs: superRoot
                 ? abi.encode(IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: initialProposer }))
                 : bytes("")
@@ -182,7 +182,7 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
             unsafeBlockSigner: makeAddr("migrateUnsafeBlockSigner"),
             batcher: makeAddr("migrateBatcher"),
             startingAnchorRoot: Proposal({ root: Hash.wrap(bytes32(hex"1234")), l2SequenceNumber: 123 }),
-            startingRespectedGameType: superRoot ? GameTypes.SUPER_PERMISSIONED_CANNON : GameTypes.PERMISSIONED_CANNON,
+            startingRespectedGameType: superRoot ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON,
             basefeeScalar: 1368,
             blobBasefeeScalar: 801949,
             gasLimit: 60_000_000,
@@ -226,7 +226,7 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
         disputeGameConfigs[0] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: true,
             initBond: 0,
-            gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+            gameType: GameTypes.SUPER_PERMISSIONED,
             gameArgs: abi.encode(IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: proposer }))
         });
         disputeGameConfigs[1] = IOPContractsManagerUtils.DisputeGameConfig({
@@ -240,7 +240,7 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
             chainSystemConfigs: chainSystemConfigs,
             disputeGameConfigs: disputeGameConfigs,
             startingAnchorRoot: Proposal({ root: Hash.wrap(bytes32(hex"ABBA")), l2SequenceNumber: 1234 }),
-            startingRespectedGameType: GameTypes.SUPER_PERMISSIONED_CANNON
+            startingRespectedGameType: GameTypes.SUPER_PERMISSIONED
         });
     }
 
@@ -339,11 +339,11 @@ contract OPContractsManagerMigrationValidator_ValidateMigration_Test is
 /// @title OPContractsManagerMigrationValidator_DGFShape_Test
 /// @notice Negative tests for MIG-DGF-10 through MIG-DGF-60.
 contract OPContractsManagerMigrationValidator_DGFShape_Test is OPContractsManagerMigrationValidator_TestInit {
-    /// @notice MIG-DGF-10: SUPER_PERMISSIONED_CANNON not registered on shared DGF.
-    function test_validate_dgf10SuperPermCannonMissing_succeeds() public {
+    /// @notice MIG-DGF-10: SUPER_PERMISSIONED not registered on shared DGF.
+    function test_validate_dgf10SuperPermissionedMissing_succeeds() public {
         vm.mockCall(
             address(sharedDGF),
-            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED)),
             abi.encode(address(0))
         );
         // SPDG validation skipped (impl is 0), per-chain skipped (can't derive shared ASR).
@@ -421,7 +421,7 @@ contract OPContractsManagerMigrationValidator_SPDG_Test is OPContractsManagerMig
     function test_validate_spdgGargs10InvalidArgsLength_succeeds() public {
         vm.mockCall(
             address(sharedDGF),
-            abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.SUPER_PERMISSIONED)),
             abi.encode(hex"deadbeef")
         );
         // Per-chain also can't decode SPDG args, skips per-chain checks.
@@ -759,7 +759,7 @@ contract OPContractsManagerMigrationValidator_SharedLockbox_Test is OPContractsM
 
 /// @title OPContractsManagerMigrationValidator_SharedDelayedWETH_Test
 /// @notice Negative tests covering shared DelayedWETH invariants. The simplified
-///         SUPER_PERMISSIONED_CANNON no longer carries WETH, so these errors surface through
+///         SUPER_PERMISSIONED no longer carries WETH, so these errors surface through
 ///         SUPER_CANNON_KONA only.
 contract OPContractsManagerMigrationValidator_SharedDelayedWETH_Test is
     OPContractsManagerMigrationValidator_TestInit
@@ -899,7 +899,7 @@ contract OPContractsManagerMigrationValidator_PerChainDGF_Test is OPContractsMan
         );
         vm.mockCall(
             fakeDGF,
-            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED)),
             abi.encode(address(0))
         );
         vm.mockCall(
@@ -949,12 +949,12 @@ contract OPContractsManagerMigrationValidator_PerChainDGF_Test is OPContractsMan
         assertEq("MIG-CHAIN-1-50", _validateMigration(true));
     }
 
-    /// @notice MIG-CHAIN-1-60: Per-chain DGF has SUPER_PERMISSIONED_CANNON still registered.
-    function test_validate_chain160SuperPermCannonNotCleared_succeeds() public {
+    /// @notice MIG-CHAIN-1-60: Per-chain DGF has SUPER_PERMISSIONED still registered.
+    function test_validate_chain160SuperPermissionedNotCleared_succeeds() public {
         _mockPerChainDGF();
         vm.mockCall(
             fakeDGF,
-            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED)),
             abi.encode(address(0xdead))
         );
         assertEq("MIG-CHAIN-1-60", _validateMigration(true));

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -90,7 +90,7 @@ contract OPContractsManagerV2_TestInit is CommonTest {
                 break;
             } else if (
                 _deployConfig.disputeGameConfigs[i].enabled
-                    && _deployConfig.disputeGameConfigs[i].gameType.raw() == GameTypes.SUPER_PERMISSIONED_CANNON.raw()
+                    && _deployConfig.disputeGameConfigs[i].gameType.raw() == GameTypes.SUPER_PERMISSIONED.raw()
             ) {
                 IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig memory parsedArgs = abi.decode(
                     _deployConfig.disputeGameConfigs[i].gameArgs,
@@ -299,7 +299,7 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
             IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: false,
                 initBond: 0,
-                gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+                gameType: GameTypes.SUPER_PERMISSIONED,
                 gameArgs: bytes("")
             })
         );
@@ -1224,7 +1224,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         internal
         returns (GameType targetGameType_)
     {
-        targetGameType_ = _isPermissionless ? GameTypes.SUPER_CANNON_KONA : GameTypes.SUPER_PERMISSIONED_CANNON;
+        targetGameType_ = _isPermissionless ? GameTypes.SUPER_CANNON_KONA : GameTypes.SUPER_PERMISSIONED;
 
         // Use a sequence number higher than the current anchor root so the ASR accepts it.
         (, uint256 currentSeqNum) = anchorStateRegistry.getAnchorRoot();
@@ -1264,7 +1264,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
             IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: true,
                 initBond: 0,
-                gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+                gameType: GameTypes.SUPER_PERMISSIONED,
                 gameArgs: abi.encode(IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: _proposer }))
             })
         );
@@ -1333,8 +1333,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         uint32 originalRaw = originalGameType.raw();
         if (
             originalRaw == GameTypes.SUPER_CANNON.raw() || originalRaw == GameTypes.SUPER_CANNON_KONA.raw()
-                || originalRaw == GameTypes.SUPER_PERMISSIONED_CANNON.raw()
-                || originalRaw == GameTypes.SUPER_ASTERISC_KONA.raw()
+                || originalRaw == GameTypes.SUPER_PERMISSIONED.raw() || originalRaw == GameTypes.SUPER_ASTERISC_KONA.raw()
         ) {
             vm.skip(true, "Skipping: fork chain already migrated to SUPER_ game type");
         }
@@ -1371,8 +1370,8 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
 
         // Verify new super game type is registered.
         assertTrue(
-            address(disputeGameFactory.gameImpls(GameTypes.SUPER_PERMISSIONED_CANNON)) != address(0),
-            "SUPER_PERMISSIONED_CANNON not registered"
+            address(disputeGameFactory.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0),
+            "SUPER_PERMISSIONED not registered"
         );
         if (isPermissionless) {
             assertTrue(
@@ -1407,8 +1406,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         uint32 originalRaw = originalGameType.raw();
         if (
             originalRaw == GameTypes.SUPER_CANNON.raw() || originalRaw == GameTypes.SUPER_CANNON_KONA.raw()
-                || originalRaw == GameTypes.SUPER_PERMISSIONED_CANNON.raw()
-                || originalRaw == GameTypes.SUPER_ASTERISC_KONA.raw()
+                || originalRaw == GameTypes.SUPER_PERMISSIONED.raw() || originalRaw == GameTypes.SUPER_ASTERISC_KONA.raw()
         ) {
             vm.skip(true, "Skipping: fork chain already upgraded to SUPER_ game type");
         }
@@ -1454,8 +1452,8 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         assertEq(anchorStateRegistry.respectedGameType().raw(), targetGameType.raw(), "second upgrade: game type");
         assertEq(address(anchorStateRegistry.anchorGame()), address(0), "second upgrade: anchor game");
         assertTrue(
-            address(disputeGameFactory.gameImpls(GameTypes.SUPER_PERMISSIONED_CANNON)) != address(0),
-            "second upgrade: SUPER_PERMISSIONED_CANNON"
+            address(disputeGameFactory.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0),
+            "second upgrade: SUPER_PERMISSIONED"
         );
         assertEq(
             address(disputeGameFactory.gameImpls(GameTypes.CANNON)), address(0), "second upgrade: CANNON still disabled"
@@ -1735,7 +1733,7 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         deployConfig.startingAnchorRoot = Proposal({ root: Hash.wrap(bytes32(hex"1234")), l2SequenceNumber: 123 });
         bool superRoot = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
         deployConfig.startingRespectedGameType =
-            superRoot ? GameTypes.SUPER_PERMISSIONED_CANNON : GameTypes.PERMISSIONED_CANNON;
+            superRoot ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON;
         deployConfig.basefeeScalar = 1368;
         deployConfig.blobBasefeeScalar = 801949;
         deployConfig.gasLimit = 60_000_000;
@@ -1750,7 +1748,7 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         });
 
         // Set up dispute game configs. All 7 game types are required.
-        // In super root mode, SUPER_PERMISSIONED_CANNON is enabled; otherwise PERMISSIONED_CANNON.
+        // In super root mode, SUPER_PERMISSIONED is enabled; otherwise PERMISSIONED_CANNON.
         address initialChallenger = makeAddr("deployChallenger");
         address initialProposer = makeAddr("deployProposer");
         IOPContractsManagerUtils.PermissionedDisputeGameConfig memory pdgConfig = IOPContractsManagerUtils
@@ -1790,7 +1788,7 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
             IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: superRoot,
                 initBond: 0,
-                gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+                gameType: GameTypes.SUPER_PERMISSIONED,
                 gameArgs: superRoot ? abi.encode(superPdgConfig) : bytes("")
             })
         );
@@ -1975,7 +1973,7 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
     /// @notice PERMISSIONED_CANNON as respected game type succeeds during deploy.
     function test_deploy_permissionedCannonRespectedGameType_succeeds() public {
         bool superRoot = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
-        GameType permType = superRoot ? GameTypes.SUPER_PERMISSIONED_CANNON : GameTypes.PERMISSIONED_CANNON;
+        GameType permType = superRoot ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON;
         deployConfig.startingRespectedGameType = permType;
         string memory expectedErrors = superRoot ? "SCKDG-SHAPE,SCKDG-10" : "CKDG-NOSHAPE,PLDG-10,CKDG-10";
         IOPContractsManagerV2.ChainContracts memory cts = runDeployV2(deployConfig, bytes(""), expectedErrors);
@@ -2111,7 +2109,7 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         dgConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: superRoot,
             initBond: 0,
-            gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+            gameType: GameTypes.SUPER_PERMISSIONED,
             gameArgs: superRoot
                 ? abi.encode(IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: initialProposer }))
                 : bytes("")
@@ -2146,7 +2144,7 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
             unsafeBlockSigner: makeAddr("migrateUnsafeBlockSigner"),
             batcher: makeAddr("migrateBatcher"),
             startingAnchorRoot: Proposal({ root: Hash.wrap(bytes32(hex"1234")), l2SequenceNumber: 123 }),
-            startingRespectedGameType: superRoot ? GameTypes.SUPER_PERMISSIONED_CANNON : GameTypes.PERMISSIONED_CANNON,
+            startingRespectedGameType: superRoot ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON,
             basefeeScalar: 1368,
             blobBasefeeScalar: 801949,
             gasLimit: 60_000_000,
@@ -2195,7 +2193,7 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         disputeGameConfigs[0] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: true,
             initBond: 0,
-            gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+            gameType: GameTypes.SUPER_PERMISSIONED,
             gameArgs: abi.encode(IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: proposer }))
         });
 
@@ -2203,7 +2201,7 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
             chainSystemConfigs: chainSystemConfigs,
             disputeGameConfigs: disputeGameConfigs,
             startingAnchorRoot: Proposal({ root: Hash.wrap(bytes32(hex"ABBA")), l2SequenceNumber: 1234 }),
-            startingRespectedGameType: GameTypes.SUPER_PERMISSIONED_CANNON
+            startingRespectedGameType: GameTypes.SUPER_PERMISSIONED
         });
     }
 
@@ -2260,7 +2258,7 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         _assertGameIsEmpty(_disputeGameFactory, GameTypes.CANNON, "CANNON");
         _assertGameIsEmpty(_disputeGameFactory, GameTypes.SUPER_CANNON, "SUPER_CANNON");
         _assertGameIsEmpty(_disputeGameFactory, GameTypes.PERMISSIONED_CANNON, "PERMISSIONED_CANNON");
-        _assertGameIsEmpty(_disputeGameFactory, GameTypes.SUPER_PERMISSIONED_CANNON, "SUPER_PERMISSIONED_CANNON");
+        _assertGameIsEmpty(_disputeGameFactory, GameTypes.SUPER_PERMISSIONED, "SUPER_PERMISSIONED");
         _assertGameIsEmpty(_disputeGameFactory, GameTypes.CANNON_KONA, "CANNON_KONA");
         _assertGameIsEmpty(_disputeGameFactory, GameTypes.SUPER_CANNON_KONA, "SUPER_CANNON_KONA");
         _assertGameIsEmpty(_disputeGameFactory, GameTypes.ZK_DISPUTE_GAME, "ZK_DISPUTE_GAME");
@@ -2372,9 +2370,9 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
 
         // Check that the init bonds are set correctly on the new DisputeGameFactory.
         assertEq(
-            IDisputeGameFactory(asr.disputeGameFactory()).initBonds(GameTypes.SUPER_PERMISSIONED_CANNON),
+            IDisputeGameFactory(asr.disputeGameFactory()).initBonds(GameTypes.SUPER_PERMISSIONED),
             0,
-            "SUPER_PERMISSIONED_CANNON init bond mismatch"
+            "SUPER_PERMISSIONED init bond mismatch"
         );
         {
             IDisputeGameFactory sharedDGF = IDisputeGameFactory(asr.disputeGameFactory());
@@ -2585,11 +2583,11 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
     /// @notice Tests that the migration function reverts when the starting respected game type is invalid.
     /// @param _gameTypeRaw The raw game type value to test.
     function testFuzz_migrate_invalidStartingRespectedGameType_reverts(uint32 _gameTypeRaw) public {
-        // Only SUPER_CANNON_KONA and SUPER_PERMISSIONED_CANNON are valid. SUPER_CANNON (4) is a
+        // Only SUPER_CANNON_KONA and SUPER_PERMISSIONED are valid. SUPER_CANNON (4) is a
         // fuzz-reachable invalid input; see test_migrate_superCannonStartingRespectedGameType_reverts
         // for the direct assertion.
         vm.assume(_gameTypeRaw != GameTypes.SUPER_CANNON_KONA.raw());
-        vm.assume(_gameTypeRaw != GameTypes.SUPER_PERMISSIONED_CANNON.raw());
+        vm.assume(_gameTypeRaw != GameTypes.SUPER_PERMISSIONED.raw());
 
         IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
 
@@ -2613,7 +2611,7 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
     }
 
     /// @notice Tests that the migration function succeeds with SUPER_CANNON_KONA as the starting
-    ///         respected game type. The default input registers SUPER_PERMISSIONED_CANNON;
+    ///         respected game type. The default input registers SUPER_PERMISSIONED;
     ///         this test appends a SUPER_CANNON_KONA config so the respected type has a matching impl.
     function test_migrate_superCannonKonaStartingRespectedGameType_succeeds() public {
         IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
@@ -2736,7 +2734,7 @@ contract OPContractsManagerV2_FeatBatchUpgrade_Test is OPContractsManagerV2_Test
         baseConfig.disputeGameConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: false,
             initBond: 0,
-            gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+            gameType: GameTypes.SUPER_PERMISSIONED,
             gameArgs: bytes("")
         });
         baseConfig.disputeGameConfigs[4] = IOPContractsManagerUtils.DisputeGameConfig({

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -282,8 +282,8 @@ abstract contract DisputeGameFactory_TestInit is CommonTest {
             _args: DeployUtils.encodeConstructor(abi.encodeCall(ISuperPermissionedDisputeGame.__constructor__, ()))
         });
         vm.startPrank(disputeGameFactory.owner());
-        disputeGameFactory.setImplementation(GameTypes.SUPER_PERMISSIONED_CANNON, IDisputeGame(gameImpl_), _implArgs);
-        disputeGameFactory.setInitBond(GameTypes.SUPER_PERMISSIONED_CANNON, 0);
+        disputeGameFactory.setImplementation(GameTypes.SUPER_PERMISSIONED, IDisputeGame(gameImpl_), _implArgs);
+        disputeGameFactory.setInitBond(GameTypes.SUPER_PERMISSIONED, 0);
         vm.stopPrank();
     }
 

--- a/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
@@ -43,17 +43,17 @@ abstract contract SuperPermissionedDisputeGame_TestInit is DisputeGameFactory_Te
         gameImpl = ISuperPermissionedDisputeGame(impl);
 
         vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.setRespectedGameType(GameTypes.SUPER_PERMISSIONED_CANNON);
+        anchorStateRegistry.setRespectedGameType(GameTypes.SUPER_PERMISSIONED);
 
         vm.prank(PROPOSER, PROPOSER);
         gameProxy = ISuperPermissionedDisputeGame(
-            payable(address(disputeGameFactory.create(GameTypes.SUPER_PERMISSIONED_CANNON, rootClaim, extraData)))
+            payable(address(disputeGameFactory.create(GameTypes.SUPER_PERMISSIONED, rootClaim, extraData)))
         );
     }
 
     function _createGame(address _sender, Claim _claim, bytes memory _extraData) internal returns (address proxy_) {
         vm.prank(_sender, _sender);
-        proxy_ = address(disputeGameFactory.create(GameTypes.SUPER_PERMISSIONED_CANNON, _claim, _extraData));
+        proxy_ = address(disputeGameFactory.create(GameTypes.SUPER_PERMISSIONED, _claim, _extraData));
     }
 }
 
@@ -70,7 +70,7 @@ contract SuperPermissionedDisputeGame_Initialize_Test is SuperPermissionedDisput
         assertEq(gameProxy.resolvedAt().raw(), block.timestamp);
         assertTrue(gameProxy.wasRespectedGameTypeWhenCreated());
         assertEq(gameProxy.gameCreator(), PROPOSER);
-        assertEq(gameProxy.gameType().raw(), GameTypes.SUPER_PERMISSIONED_CANNON.raw());
+        assertEq(gameProxy.gameType().raw(), GameTypes.SUPER_PERMISSIONED.raw());
         assertEq(gameProxy.rootClaim().raw(), rootClaim.raw());
         assertEq(gameProxy.extraData(), extraData);
         assertEq(address(gameProxy.anchorStateRegistry()), address(anchorStateRegistry));

--- a/packages/contracts-bedrock/test/dispute/lib/Types.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/Types.t.sol
@@ -27,9 +27,7 @@ contract Types_IsSuperGame_Test is Test {
     /// @notice Tests that all expected super game types are recognized.
     function test_isSuperGame_allSuperTypes_succeeds() public pure {
         assertTrue(GameTypes.isSuperGame(GameTypes.SUPER_CANNON), "SUPER_CANNON must be a super game");
-        assertTrue(
-            GameTypes.isSuperGame(GameTypes.SUPER_PERMISSIONED_CANNON), "SUPER_PERMISSIONED_CANNON must be a super game"
-        );
+        assertTrue(GameTypes.isSuperGame(GameTypes.SUPER_PERMISSIONED), "SUPER_PERMISSIONED must be a super game");
         assertTrue(GameTypes.isSuperGame(GameTypes.SUPER_ASTERISC_KONA), "SUPER_ASTERISC_KONA must be a super game");
         assertTrue(GameTypes.isSuperGame(GameTypes.SUPER_CANNON_KONA), "SUPER_CANNON_KONA must be a super game");
         assertTrue(GameTypes.isSuperGame(GameTypes.ZK_DISPUTE_GAME), "ZK_DISPUTE_GAME must be a super game");

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -168,7 +168,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         // Check dispute game deployments
         // Validate permissionedDisputeGame (PDG) address
         GameType permGameType = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
-            ? GameTypes.SUPER_PERMISSIONED_CANNON
+            ? GameTypes.SUPER_PERMISSIONED
             : GameTypes.PERMISSIONED_CANNON;
         IOPContractsManagerContainer.Implementations memory impls = IOPContractsManagerV2(opcmAddr).implementations();
         address expectedPDGAddress = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
@@ -209,7 +209,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         returns (IPermissionedDisputeGame)
     {
         GameType permGameType = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
-            ? GameTypes.SUPER_PERMISSIONED_CANNON
+            ? GameTypes.SUPER_PERMISSIONED
             : GameTypes.PERMISSIONED_CANNON;
         return IPermissionedDisputeGame(address(doo.disputeGameFactoryProxy.gameImpls(permGameType)));
     }
@@ -242,7 +242,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
 
         GameType permType = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
-            ? GameTypes.SUPER_PERMISSIONED_CANNON
+            ? GameTypes.SUPER_PERMISSIONED
             : GameTypes.PERMISSIONED_CANNON;
         address expectedPermissioned = address(doo.disputeGameFactoryProxy.gameImpls(permType));
         assertEq(address(doo.permissionedDisputeGame), expectedPermissioned, "PDG impl");
@@ -286,7 +286,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         );
 
         bool isSuperRoot = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
-        GameType permType = isSuperRoot ? GameTypes.SUPER_PERMISSIONED_CANNON : GameTypes.PERMISSIONED_CANNON;
+        GameType permType = isSuperRoot ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON;
         GameType konaType = isSuperRoot ? GameTypes.SUPER_CANNON_KONA : GameTypes.CANNON_KONA;
 
         // The legacy permissioned game keeps the default bond. The super permissioned game

--- a/packages/contracts-bedrock/test/setup/DisputeGames.sol
+++ b/packages/contracts-bedrock/test/setup/DisputeGames.sol
@@ -122,7 +122,7 @@ library DisputeGames {
 
     function superPermissionedGameProposer(IDisputeGameFactory _dgf) internal view returns (address proposer_) {
         LibGameArgs.SuperPermissionedGameArgs memory gameArgs =
-            LibGameArgs.decodeSuperPermissioned(_dgf.gameArgs(GameTypes.SUPER_PERMISSIONED_CANNON));
+            LibGameArgs.decodeSuperPermissioned(_dgf.gameArgs(GameTypes.SUPER_PERMISSIONED));
         proposer_ = gameArgs.proposer;
     }
 
@@ -132,7 +132,7 @@ library DisputeGames {
         returns (address anchorStateRegistry_)
     {
         LibGameArgs.SuperPermissionedGameArgs memory gameArgs =
-            LibGameArgs.decodeSuperPermissioned(_dgf.gameArgs(GameTypes.SUPER_PERMISSIONED_CANNON));
+            LibGameArgs.decodeSuperPermissioned(_dgf.gameArgs(GameTypes.SUPER_PERMISSIONED));
         anchorStateRegistry_ = gameArgs.anchorStateRegistry;
     }
 
@@ -216,25 +216,25 @@ library DisputeGames {
     }
 
     function mockSuperPermissionedGameProposer(IDisputeGameFactory _dgf, address _proposer) internal {
-        bytes memory gameArgsData = _dgf.gameArgs(GameTypes.SUPER_PERMISSIONED_CANNON);
+        bytes memory gameArgsData = _dgf.gameArgs(GameTypes.SUPER_PERMISSIONED);
         LibGameArgs.SuperPermissionedGameArgs memory gameArgs = LibGameArgs.decodeSuperPermissioned(gameArgsData);
         gameArgs.proposer = _proposer;
 
         vm.mockCall(
             address(_dgf),
-            abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.SUPER_PERMISSIONED)),
             abi.encode(LibGameArgs.encodeSuperPermissioned(gameArgs))
         );
     }
 
     function mockSuperPermissionedGameASR(IDisputeGameFactory _dgf, address _asr) internal {
-        bytes memory gameArgsData = _dgf.gameArgs(GameTypes.SUPER_PERMISSIONED_CANNON);
+        bytes memory gameArgsData = _dgf.gameArgs(GameTypes.SUPER_PERMISSIONED);
         LibGameArgs.SuperPermissionedGameArgs memory gameArgs = LibGameArgs.decodeSuperPermissioned(gameArgsData);
         gameArgs.anchorStateRegistry = _asr;
 
         vm.mockCall(
             address(_dgf),
-            abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.SUPER_PERMISSIONED)),
             abi.encode(LibGameArgs.encodeSuperPermissioned(gameArgs))
         );
     }

--- a/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
@@ -255,8 +255,7 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
             bool isPermissionless = originalRaw == GameTypes.CANNON.raw() || originalRaw == GameTypes.CANNON_KONA.raw();
 
             // Determine the target SUPER_* game type.
-            GameType targetGameType =
-                isPermissionless ? GameTypes.SUPER_CANNON_KONA : GameTypes.SUPER_PERMISSIONED_CANNON;
+            GameType targetGameType = isPermissionless ? GameTypes.SUPER_CANNON_KONA : GameTypes.SUPER_PERMISSIONED;
 
             // Read the current anchor root sequence number so we can set a higher one.
             (, uint256 currentAnchorSeqNum) = asr.getAnchorRoot();
@@ -285,7 +284,7 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
             disputeGameConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: true,
                 initBond: 0,
-                gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+                gameType: GameTypes.SUPER_PERMISSIONED,
                 gameArgs: abi.encode(IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: proposer }))
             });
             if (isPermissionless) {
@@ -369,7 +368,7 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
             disputeGameConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: false,
                 initBond: 0,
-                gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+                gameType: GameTypes.SUPER_PERMISSIONED,
                 gameArgs: hex""
             });
             disputeGameConfigs[4] = IOPContractsManagerUtils.DisputeGameConfig({
@@ -433,9 +432,8 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
         // With super root migration, standard game types are zeroed; read from SUPER_ variants.
         IDisputeGameFactory disputeGameFactory =
             IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
-        GameType permGameType = Config.devFeatureSuperRootGamesMigration()
-            ? GameTypes.SUPER_PERMISSIONED_CANNON
-            : GameTypes.PERMISSIONED_CANNON;
+        GameType permGameType =
+            Config.devFeatureSuperRootGamesMigration() ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON;
         address permissionedDisputeGame = address(disputeGameFactory.gameImpls(permGameType));
         artifacts.save("PermissionedDisputeGame", permissionedDisputeGame);
 

--- a/packages/contracts-bedrock/test/setup/PastUpgrades.sol
+++ b/packages/contracts-bedrock/test/setup/PastUpgrades.sol
@@ -226,11 +226,11 @@ library PastUpgrades {
             )
         });
 
-        // SUPER_PERMISSIONED_CANNON (disabled)
+        // SUPER_PERMISSIONED (disabled)
         disputeGameConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: false,
             initBond: 0,
-            gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+            gameType: GameTypes.SUPER_PERMISSIONED,
             gameArgs: hex""
         });
 

--- a/packages/contracts-bedrock/test/setup/SuperGameTestInit.sol
+++ b/packages/contracts-bedrock/test/setup/SuperGameTestInit.sol
@@ -12,13 +12,10 @@ import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
 
 /// @title SuperGameTestInit
-/// @notice Shared base for tests that need super game mode (SUPER_PERMISSIONED_CANNON + SUPER_CANNON_KONA).
+/// @notice Shared base for tests that need super game mode (SUPER_PERMISSIONED + SUPER_CANNON_KONA).
 ///         Provides common state variables and the upgrade helper used by both MigrationValidator
 ///         and StandardValidator super mode test suites.
 abstract contract SuperGameTestInit is CommonTest {
-    /// @notice The cannon prestate (used by SUPER_PERMISSIONED_CANNON).
-    Claim cannonPrestate;
-
     /// @notice The cannonKona prestate (used by SUPER_CANNON_KONA).
     Claim cannonKonaPrestate = Claim.wrap(bytes32(keccak256("cannonKonaPrestate")));
 
@@ -28,7 +25,7 @@ abstract contract SuperGameTestInit is CommonTest {
     /// @notice The challenger role.
     address challenger;
 
-    /// @notice Runs an upgrade that enables SUPER_CANNON_KONA alongside SUPER_PERMISSIONED_CANNON.
+    /// @notice Runs an upgrade that enables SUPER_CANNON_KONA alongside SUPER_PERMISSIONED.
     function _enableSuperCannonKona() internal virtual {
         address owner = proxyAdmin.owner();
 
@@ -59,7 +56,7 @@ abstract contract SuperGameTestInit is CommonTest {
         disputeGameConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: true,
             initBond: 0,
-            gameType: GameTypes.SUPER_PERMISSIONED_CANNON,
+            gameType: GameTypes.SUPER_PERMISSIONED,
             gameArgs: abi.encode(IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: proposer }))
         });
         disputeGameConfigs[4] = IOPContractsManagerUtils.DisputeGameConfig({
@@ -79,7 +76,7 @@ abstract contract SuperGameTestInit is CommonTest {
             new IOPContractsManagerUtils.ExtraInstruction[](1);
         extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
             key: "overrides.cfg.startingRespectedGameType",
-            data: abi.encode(GameTypes.SUPER_PERMISSIONED_CANNON)
+            data: abi.encode(GameTypes.SUPER_PERMISSIONED)
         });
 
         prankDelegateCall(owner);


### PR DESCRIPTION
## Summary

- Rename `SUPER_PERMISSIONED_CANNON` to `SUPER_PERMISSIONED` while preserving game type value `5`
- Update OPCM deploy, upgrade, validation, devstack, op-deployer, tests, and docs references
- Move the legacy Cannon prestate fixture out of the shared super-game test helper
- Bump affected contract patch versions and update `semver-lock.json`

fixes https://github.com/ethereum-optimism/optimism/issues/20933