### PR TITLE
feat(op-alloy): cap PostExec gas_refund_entries length

### DIFF
--- a/rust/op-alloy/crates/consensus/src/post_exec.rs
+++ b/rust/op-alloy/crates/consensus/src/post_exec.rs
@@ -22,6 +22,16 @@ pub const POST_EXEC_TX_TYPE_ID: u8 = 0x7D;
 /// Current format version for [`PostExecPayload`].
 pub const POST_EXEC_PAYLOAD_VERSION: u8 = 1;
 
+/// Maximum number of [`SDMGasEntry`] entries a [`PostExecPayload`] may carry.
+///
+/// A *valid* block already bounds the entry count: every entry must target a distinct, non-deposit,
+/// non-post-exec transaction whose refund the block actually consumes, so the count cannot exceed
+/// the number of normal transactions (itself bounded by the block gas limit). This cap is
+/// defense-in-depth: it rejects a malformed, oversized payload at decode time — before a verifier
+/// spends the work to execute the whole block only to fail the unconsumed-entries check. The
+/// ceiling is generous; no honest block approaches it.
+pub const MAX_GAS_REFUND_ENTRIES: usize = 8192;
+
 /// Per-transaction gas refund entry within a [`PostExecPayload`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -53,16 +63,19 @@ pub struct PostExecPayload {
     pub gas_refund_entries: Vec<SDMGasEntry>,
 }
 
-// `version` is pinned rather than left arbitrary because `decode_checked` rejects any
-// non-`POST_EXEC_PAYLOAD_VERSION` value, which would break encode/decode roundtrip
-// property tests (and any downstream fuzzer using arbitrary-generated payloads).
+// Generated payloads are kept decodable so encode/decode roundtrip property tests (and any
+// downstream fuzzer using arbitrary-generated payloads) don't spuriously fail: `version` is pinned
+// to the one value `decode_checked` accepts, and the entry count is truncated to the
+// `MAX_GAS_REFUND_ENTRIES` cap `decode_checked` enforces.
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for PostExecPayload {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let mut gas_refund_entries = <Vec<SDMGasEntry>>::arbitrary(u)?;
+        gas_refund_entries.truncate(MAX_GAS_REFUND_ENTRIES);
         Ok(Self {
             version: POST_EXEC_PAYLOAD_VERSION,
             block_number: u64::arbitrary(u)?,
-            gas_refund_entries: <Vec<SDMGasEntry>>::arbitrary(u)?,
+            gas_refund_entries,
         })
     }
 }
@@ -202,7 +215,8 @@ impl PostExecPayload {
         buf.into()
     }
 
-    /// Decode a payload from an RLP stream, validating the payload version.
+    /// Decode a payload from an RLP stream, validating the payload version and bounding the
+    /// gas-refund entry count to [`MAX_GAS_REFUND_ENTRIES`].
     ///
     /// Advances `buf` past the consumed bytes. Unlike [`Self::from_rlp_bytes`], trailing bytes
     /// are left in place for the caller to consume; this is the decoder to use on the EIP-2718
@@ -212,13 +226,16 @@ impl PostExecPayload {
         if payload.version != POST_EXEC_PAYLOAD_VERSION {
             return Err(alloy_rlp::Error::Custom("unsupported post-exec payload version"));
         }
+        if payload.gas_refund_entries.len() > MAX_GAS_REFUND_ENTRIES {
+            return Err(alloy_rlp::Error::Custom("too many post-exec gas refund entries"));
+        }
         Ok(payload)
     }
 
     /// Decode a payload from RLP bytes.
     ///
-    /// Rejects payloads whose `version` is not [`POST_EXEC_PAYLOAD_VERSION`] and rejects any
-    /// trailing bytes after the RLP structure.
+    /// Rejects payloads whose `version` is not [`POST_EXEC_PAYLOAD_VERSION`], whose entry count
+    /// exceeds [`MAX_GAS_REFUND_ENTRIES`], or with any trailing bytes after the RLP structure.
     pub fn from_rlp_bytes(data: &[u8]) -> alloy_rlp::Result<Self> {
         let mut buf = data;
         let payload = Self::decode_checked(&mut buf)?;

--- a/rust/op-alloy/crates/consensus/src/post_exec/tests.rs
+++ b/rust/op-alloy/crates/consensus/src/post_exec/tests.rs
@@ -30,6 +30,34 @@ fn post_exec_payload_rlp_decode_rejects_unknown_version() {
     assert_eq!(err, alloy_rlp::Error::Custom("unsupported post-exec payload version"));
 }
 
+fn payload_with_entries(count: usize) -> PostExecPayload {
+    PostExecPayload {
+        version: POST_EXEC_PAYLOAD_VERSION,
+        block_number: 42,
+        gas_refund_entries: (0..count as u64)
+            .map(|i| SDMGasEntry { index: i, gas_refund: i + 1 })
+            .collect(),
+    }
+}
+
+#[test]
+fn post_exec_payload_rlp_decode_accepts_max_entries() {
+    let payload = payload_with_entries(MAX_GAS_REFUND_ENTRIES);
+    let encoded = payload.to_rlp_bytes();
+    let decoded = PostExecPayload::from_rlp_bytes(encoded.as_ref())
+        .expect("payload at the entry cap must decode");
+    assert_eq!(decoded, payload);
+}
+
+#[test]
+fn post_exec_payload_rlp_decode_rejects_too_many_entries() {
+    let payload = payload_with_entries(MAX_GAS_REFUND_ENTRIES + 1);
+    let encoded = payload.to_rlp_bytes();
+    let err = PostExecPayload::from_rlp_bytes(encoded.as_ref())
+        .expect_err("payload exceeding the entry cap must be rejected");
+    assert_eq!(err, alloy_rlp::Error::Custom("too many post-exec gas refund entries"));
+}
+
 #[test]
 fn post_exec_payload_rlp_decode_rejects_trailing_bytes() {
     let payload = PostExecPayload {
@@ -88,6 +116,27 @@ fn post_exec_tx_eip2718_decode_rejects_unknown_version() {
             err,
             Eip2718Error::RlpError(alloy_rlp::Error::Custom(
                 "unsupported post-exec payload version"
+            ))
+        ),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
+fn post_exec_tx_eip2718_decode_rejects_too_many_entries() {
+    let payload = payload_with_entries(MAX_GAS_REFUND_ENTRIES + 1);
+
+    let mut buf = Vec::new();
+    buf.put_u8(POST_EXEC_TX_TYPE_ID);
+    payload.encode(&mut buf);
+
+    let err = TxPostExec::decode_2718(&mut buf.as_slice())
+        .expect_err("2718 decode must reject an over-cap payload");
+    assert!(
+        matches!(
+            err,
+            Eip2718Error::RlpError(alloy_rlp::Error::Custom(
+                "too many post-exec gas refund entries"
             ))
         ),
         "unexpected error: {err:?}"


### PR DESCRIPTION
## What

Adds a length cap on the `0x7D` PostExec transaction's `gas_refund_entries` list:

- New `pub const MAX_GAS_REFUND_ENTRIES: usize = 8192` in `op-alloy-consensus`.
- Enforced in `PostExecPayload::decode_checked` — the single decode chokepoint that all three decode impls (`Decodable2718::{typed_decode,fallback_decode}`, `Decodable::decode`) and `from_rlp_bytes` route through. Over-cap payloads are rejected with `alloy_rlp::Error::Custom("too many post-exec gas refund entries")`.
- The `arbitrary` impl truncates generated entries to the cap so RLP-roundtrip property tests (e.g. op-reth `OpTransactionSigned` via `add_arbitrary_tests(rlp)`) stay decodable.

## Why

This is a **verifier-side / block-validity** rule (the producer decides refund amounts; the verifier decides admissibility). A *valid* block already bounds the entry count: every entry must target a distinct, non-deposit, non-post-exec tx whose refund the block actually consumes, so the count cannot exceed the number of normal txs (itself bounded by the block gas limit). 8192 is a generous defensive ceiling no honest block approaches.

The cap is **defense-in-depth**: it rejects a malformed, oversized payload at decode time — before a verifier executes the whole block only to fail the unconsumed-entries check.

Notes:
- **Uniform across nodes:** routing through `decode_checked` means op-reth (verify), kona (fault proof), followers, and p2p all reach the same verdict.
- **Fork-safe unconditional reject:** `0x7D` is itself Lagoon-gated, so an over-cap payload can only exist post-activation, where all nodes share the constant.
- **No DA-accounting change:** the `0x7D` stays DA-exempt; each entry is ~18 bytes against a tx that already paid its own DA, so the marginal exemption is negligible. (Policy composition folds into one `u64`/tx, so it does not multiply entry count.)

## Tests

Failing-test-first. Over-cap rejection asserted at both the payload-RLP and EIP-2718 decode levels; at-cap (exactly 8192) acceptance pinned. `op-alloy-consensus` suite green (incl. 3 new tests); clippy + nightly fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)