### PR TITLE
feat(op-devstack): support op-reth-premium as a drop-in sequencer EL

### DIFF
--- a/op-acceptance-tests/tests/sdm/premium_baseline_test.go
+++ b/op-acceptance-tests/tests/sdm/premium_baseline_test.go
@@ -1,0 +1,89 @@
+package sdm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// premiumBinaryAvailable reports whether the op-reth-premium binary has been provided to the
+// devstack. The premium client lives in a separate repo (optimism-premium), so it cannot be built
+// from the monorepo's Rust workspace; it must be supplied as a pre-built binary
+// (RUST_BINARY_PATH_OP_RETH_PREMIUM) or as a JIT build pointed at the premium checkout
+// (RUST_SRC_DIR_OP_RETH_PREMIUM, with RUST_JIT_BUILD=1). When neither is set the baseline test
+// skips rather than fails, so it is inert in CI that has no premium image.
+func premiumBinaryAvailable() bool {
+	return os.Getenv("RUST_BINARY_PATH_OP_RETH_PREMIUM") != "" ||
+		os.Getenv("RUST_SRC_DIR_OP_RETH_PREMIUM") != ""
+}
+
+// TestPremiumSequencerProducesDerivableBlocks is the premium-sequencer *baseline* regression guard:
+// it boots op-reth-premium as the sequencer EL (running its subblocks producer with SDM disabled,
+// since Interop is not activated) alongside a stock op-reth verifier, and asserts the chain
+// advances and the verifier derives it. It does NOT assert any SDM/0x7D behavior — premium does not
+// produce PostExec blocks yet (production is parked). The point is to catch a premium build that
+// regresses plain block production / follower derivation before the SDM-production tests can run
+// against it.
+//
+// Run it by providing the premium binary, e.g.:
+//
+//	RUST_BINARY_PATH_OP_RETH_PREMIUM=/path/to/op-reth-premium \
+//	  go test ./op-acceptance-tests/tests/sdm/ -run TestPremiumSequencerProducesDerivableBlocks
+func TestPremiumSequencerProducesDerivableBlocks(gt *testing.T) {
+	t := devtest.SerialT(gt)
+
+	if !premiumBinaryAvailable() {
+		t.Skip("op-reth-premium binary not provided; set RUST_BINARY_PATH_OP_RETH_PREMIUM (or RUST_SRC_DIR_OP_RETH_PREMIUM + RUST_JIT_BUILD=1)")
+	}
+
+	// op-node only: premium's subblocks producer is exercised on the standard sequencer path; keep
+	// the CL selection consistent with the rest of the SDM suite (honors DEVSTACK_L2CL_KIND).
+	clKind := sysgo.ResolveMixedL2CLKind()
+
+	runtime := sysgo.NewMixedSingleChainRuntime(t, sysgo.MixedSingleChainPresetConfig{
+		NodeSpecs: []sysgo.MixedSingleChainNodeSpec{
+			{
+				ELKey:       "sequencer-op-reth-premium",
+				CLKey:       "sequencer",
+				ELKind:      sysgo.MixedL2ELOpRethPremium,
+				CLKind:      clKind,
+				IsSequencer: true,
+			},
+			{
+				ELKey:       "verifier-op-reth",
+				CLKey:       "verifier",
+				ELKind:      sysgo.MixedL2ELOpReth,
+				CLKind:      clKind,
+				IsSequencer: false,
+			},
+		},
+		// No InteropAtGenesis: SDM stays off, so premium produces ordinary blocks (no 0x7D). This
+		// is a liveness/derivation baseline, not an SDM-production test.
+	})
+
+	frontends := presets.NewMixedSingleChainFrontends(t, runtime)
+	t.Require().Len(frontends.Nodes, 2, "premium baseline needs a sequencer and a verifier")
+
+	var seqEL, verEL *dsl.L2ELNode
+	for _, node := range frontends.Nodes {
+		if node.Spec.IsSequencer {
+			seqEL = node.EL
+		} else {
+			verEL = node.EL
+		}
+	}
+	t.Require().NotNil(seqEL, "missing premium sequencer EL")
+	t.Require().NotNil(verEL, "missing op-reth verifier EL")
+
+	// The premium sequencer must build blocks, and the stock verifier must follow them: both
+	// unsafe heads advancing past genesis proves premium produces derivable blocks as a drop-in.
+	dsl.CheckAll(t,
+		seqEL.AdvancedFn(eth.Unsafe, 5),
+		verEL.AdvancedFn(eth.Unsafe, 5),
+	)
+}

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -18,6 +18,10 @@ import (
 type OpRethConfig struct {
 	// ExtraArgs are appended to the generated CLI args.
 	ExtraArgs []string
+	// Binary selects the EL binary to launch. Empty means "op-reth". A CLI-compatible superset
+	// (e.g. "op-reth-premium", which accepts every op-reth subcommand/flag plus the --subblocks.*
+	// namespace) may be selected via OpRethWithBinary.
+	Binary string
 }
 
 // DefaultOpRethConfig returns a zero-valued OpRethConfig that callers can mutate via OpRethOptions.
@@ -57,6 +61,16 @@ func (b OpRethOptionBundle) Apply(p devtest.T, target ComponentTarget, cfg *OpRe
 func OpRethWithExtraArgs(args ...string) OpRethOption {
 	return OpRethOptionFn(func(p devtest.T, _ ComponentTarget, cfg *OpRethConfig) {
 		cfg.ExtraArgs = append(cfg.ExtraArgs, args...)
+	})
+}
+
+// OpRethWithBinary selects the EL binary to launch instead of the default "op-reth". The binary
+// must be a CLI superset of op-reth (it is invoked with op-reth's subcommands and flags). Used to
+// boot "op-reth-premium" as a drop-in sequencer; since that binary lives in a separate repo it must
+// be supplied via RUST_BINARY_PATH_OP_RETH_PREMIUM (or RUST_SRC_DIR_OP_RETH_PREMIUM + RUST_JIT_BUILD).
+func OpRethWithBinary(binary string) OpRethOption {
+	return OpRethOptionFn(func(p devtest.T, _ ComponentTarget, cfg *OpRethConfig) {
+		cfg.Binary = binary
 	})
 }
 

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -49,7 +49,17 @@ const (
 	MixedL2ELOpReth   MixedL2ELKind = "op-reth"
 	MixedL2ELOpRethV2 MixedL2ELKind = "op-reth-proof-v2"
 	MixedOpRbuilder   MixedL2ELKind = "op-rbuilder"
+	// MixedL2ELOpRethPremium boots op-reth-premium as a drop-in: it is launched with op-reth's
+	// CLI (a superset) and runs its subblocks producer (--subblocks.enable defaults to true). The
+	// binary must be supplied via RUST_BINARY_PATH_OP_RETH_PREMIUM (separate repo).
+	MixedL2ELOpRethPremium MixedL2ELKind = "op-reth-premium"
 )
+
+// opRethPremiumOpts prepends the binary selection so op-reth-premium is launched in place of
+// op-reth; caller options follow and may further customise (or override) the invocation.
+func opRethPremiumOpts(opts []OpRethOption) []OpRethOption {
+	return append([]OpRethOption{OpRethWithBinary("op-reth-premium")}, opts...)
+}
 
 type MixedL2CLKind string
 
@@ -209,6 +219,8 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 			el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v1", cfg.OpRethOptions...)
 		case MixedL2ELOpRethV2:
 			el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v2", cfg.OpRethOptions...)
+		case MixedL2ELOpRethPremium:
+			el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v1", opRethPremiumOpts(cfg.OpRethOptions)...)
 		default:
 			require.FailNowf("unsupported EL kind", "unsupported mixed EL kind %q", spec.ELKind)
 		}
@@ -345,12 +357,21 @@ func buildMixedOpRethNode(
 
 	tempP2PPath := filepath.Join(tempDir, "p2pkey.txt")
 
+	// Apply options before resolving the binary so OpRethWithBinary can select a CLI-compatible
+	// superset (e.g. op-reth-premium). cfg.ExtraArgs is appended to the CLI further below.
+	opRethCfg := DefaultOpRethConfig()
+	OpRethOptionBundle(opts).Apply(t, NewComponentTarget(key, l2Net.ChainID()), opRethCfg)
+	elBinary := opRethCfg.Binary
+	if elBinary == "" {
+		elBinary = "op-reth"
+	}
+
 	execPath, err := rustbin.Spec{
 		SrcDir:  "rust",
-		Package: "op-reth",
-		Binary:  "op-reth",
+		Package: elBinary,
+		Binary:  elBinary,
 	}.EnsureExists(t.Ctx(), t.Logger())
-	t.Require().NoError(err, "op-reth binary not available (build with 'just build-rust-release' or set RUST_JIT_BUILD=1)")
+	t.Require().NoError(err, "%s binary not available (build with 'just build-rust-release', set RUST_JIT_BUILD=1, or for op-reth-premium set RUST_BINARY_PATH_OP_RETH_PREMIUM)", elBinary)
 
 	args := []string{
 		"node",
@@ -423,8 +444,6 @@ func buildMixedOpRethNode(
 		"--proofs-history.storage-version="+storageVersion,
 	)
 
-	opRethCfg := DefaultOpRethConfig()
-	OpRethOptionBundle(opts).Apply(t, NewComponentTarget(key, l2Net.ChainID()), opRethCfg)
 	args = append(args, opRethCfg.ExtraArgs...)
 
 	return &OpReth{

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -156,6 +156,8 @@ func startL2ELForKey(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [3
 		return startL2ELNode(t, l2Net, jwtPath, jwtSecret, key, identity)
 	case MixedL2ELOpRethV2:
 		return startMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, nil, "v2", opts...)
+	case MixedL2ELOpRethPremium:
+		return startMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, nil, "v1", opRethPremiumOpts(opts)...)
 	case MixedOpRbuilder:
 		return startBuilderEL(t, l2Net, jwtPath, identity)
 	default: // op-reth v1


### PR DESCRIPTION
## What

Lets the devstack boot `op-reth-premium` as a sequencer EL, so acceptance tests can run against the premium client.

- New `MixedL2ELOpRethPremium` EL kind + `OpRethWithBinary` option / `OpRethConfig.Binary`. `buildMixedOpRethNode` now resolves the binary from the config (default `op-reth`) before building args; the rest of the invocation is unchanged.
- Wired into both EL dispatch sites: per-spec (`NewMixedSingleChainRuntime`) and env-driven (`startL2ELForKey`, so `DEVSTACK_L2EL_KIND=op-reth-premium` works).
- New `TestPremiumSequencerProducesDerivableBlocks`: boots a premium sequencer (subblocks producer, SDM off) + stock op-reth verifier, asserts both unsafe heads advance.

## Why this is a clean drop-in

`op-reth-premium` is launched with op-reth's exact CLI: its `run()` uses `reth_optimism_cli::Cli` — the **same** CLI as op-reth's binary, including the `proofs` subcommands — and only **adds** the `--subblocks.*` namespace (`--subblocks.enable` defaults to `true`). So it accepts every subcommand/flag `buildMixedOpRethNode` uses; only the resolved binary differs.

The premium client lives in a separate repo, so it is resolved via the existing `rustbin` env overrides: `RUST_BINARY_PATH_OP_RETH_PREMIUM=/path/to/op-reth-premium` (or `RUST_SRC_DIR_OP_RETH_PREMIUM` + `RUST_JIT_BUILD=1`).

## Scope / caveats

- **Baseline only, not SDM.** Premium does not produce `0x7D` PostExec blocks yet (subblocks SDM production is parked), so this test asserts *liveness + derivation*, not refund behavior. It's the regression guard that premium hasn't broken plain block production before the SDM-production tests can target it.
- **Skip-guarded.** The test skips unless the premium binary is provided, so it is inert in CI without a premium image and cannot fail there.
- **Not yet run end-to-end in this change.** The Go wiring compiles and `go vet`s clean, and the skip path is verified; the full devstack run requires a premium binary (separate repo) and may surface runtime config needs (e.g. the subblocks publisher bind port under parallel runs). Validate with a real `op-reth-premium` before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)