### PR TITLE
fix(ci): stop fuzz jobs from oversubscribing the CPU

### DIFF
--- a/cannon/justfile
+++ b/cannon/justfile
@@ -90,7 +90,8 @@ cannon-stf-verify:
 lint:
     @echo "cannon lint is handled by the root lint-go target"
 
-# Run fuzz tests in parallel
+# Run fuzz tests in parallel. `-parallel=1` keeps one fuzz worker per target so the
+# concurrent `parallel -j 8` doesn't oversubscribe the CPU.
 fuzz:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -99,16 +100,16 @@ fuzz:
         FUZZLDFLAGS="-ldflags=-extldflags=-Wl,-ld_classic"
     fi
     printf "%s\n" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzMulOp ./mipsevm/tests" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzMultOp ./mipsevm/tests" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzMultuOp ./mipsevm/tests" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateSyscallBrk ./mipsevm/tests" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateSyscallMmap ./mipsevm/tests" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateSyscallExitGroup ./mipsevm/tests" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateSyscallFcntl ./mipsevm/tests" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateHintRead ./mipsevm/tests" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStatePreimageRead ./mipsevm/tests" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateHintWrite ./mipsevm/tests" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStatePreimageWrite ./mipsevm/tests" \
-        "go test $FUZZLDFLAGS -run NOTAREALTEST -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateSyscallCloneMT ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzMulOp ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzMultOp ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzMultuOp ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateSyscallBrk ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateSyscallMmap ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateSyscallExitGroup ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateSyscallFcntl ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateHintRead ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStatePreimageRead ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateHintWrite ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStatePreimageWrite ./mipsevm/tests" \
+        "go test $FUZZLDFLAGS -run NOTAREALTEST -parallel=1 -v -fuzztime {{CANNON64_FUZZTIME}} -fuzz=FuzzStateSyscallCloneMT ./mipsevm/tests" \
     | parallel -j 8 {}

--- a/justfiles/go.just
+++ b/justfiles/go.just
@@ -23,8 +23,10 @@ go_build BIN PKG *FLAGS:
 go_test SELECTOR *FLAGS:
     go test -v {{_GORACE_FLAG}} {{FLAGS}} {{SELECTOR}}
 
+# `-parallel=1`: one fuzz worker per target, so concurrent `parallel` runs don't
+# oversubscribe the CPU and starve workers into missing the `-fuzztime` deadline.
 [private]
-go_fuzz FUZZ TIME='10s' PKG='': (go_test PKG _EXTRALDFLAGS "-fuzztime" TIME "-fuzz" FUZZ "-run" "NOTAREALTEST")
+go_fuzz FUZZ TIME='10s' PKG='': (go_test PKG _EXTRALDFLAGS "-parallel" "1" "-fuzztime" TIME "-fuzz" FUZZ "-run" "NOTAREALTEST")
 
 [private]
 go_generate SELECTOR *FLAGS:

--- a/op-e2e/justfile
+++ b/op-e2e/justfile
@@ -54,9 +54,10 @@ pre-test:
 clean:
     rm -rf ../.devnet
 
-# Run fuzz tests
+# Run fuzz tests. `-parallel=1` keeps one fuzz worker per target so the concurrent
+# `parallel` doesn't oversubscribe the CPU.
 fuzz:
-    parallel --line-buffer --tag -N1 "go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz {} ./opgeth" ::: FuzzFjordCostFunction FuzzFastLzGethSolidity FuzzFastLzCgo
+    parallel --line-buffer --tag -N1 "go test -run NOTAREALTEST -parallel=1 -tags cgo_test -v -fuzztime 10s -fuzz {} ./opgeth" ::: FuzzFjordCostFunction FuzzFastLzGethSolidity FuzzFastLzCgo
 
 # Generate contract bindings
 gen-binding CONTRACT:


### PR DESCRIPTION
## Problem

Go fuzz CI jobs (`cannon-fuzz`, `fuzz-golang-*`, `op-e2e-fuzz`) intermittently fail with a bare `context deadline exceeded` at the `-fuzztime` boundary — not a real crash. Three such failures on 2026-06-22 across two jobs (e.g. `FuzzStateHintRead`, `FuzzEncodeDecodeWithdrawal`); ~0 failures in the prior 745+ runs per job.

## Cause

Each fuzz recipe runs N targets concurrently via `parallel`, and each `go test -fuzz` defaults its worker count to `GOMAXPROCS`. On the 8-core CI box that's 8 × 8 = 64 fuzz worker processes. Under that oversubscription a worker can be starved of CPU and miss the fuzztime deadline, which the engine reports as `context deadline exceeded`.

## Fix

Pass `-parallel=1` so each target uses a single fuzz worker — the only parallelism left is across targets (≈ cores, no oversubscription). Applied in the shared `go_fuzz` helper (covers op-node, op-batcher, op-chain-ops, op-service, op-challenger) and the two bespoke recipes (cannon, op-e2e).

The duration `-fuzztime` budgets are unchanged, so wall-time is unaffected (verified locally: identical wall-time, no throughput regression).

This is a CI-scheduling flake reproducible only under contention, so there's no unit-test regression guard.

Closes #21516