### PR TITLE
test(contracts-bedrock): fix txGasPrice fuzz range in DataAvailabilityChallenge resolve tests

### DIFF
--- a/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
+++ b/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
@@ -530,7 +530,7 @@ contract DataAvailabilityChallenge_Resolve_Test is DataAvailabilityChallenge_Tes
         uint256 challengedBlockNumber,
         uint256 resolverRefundPercentage,
         uint64 bondSize,
-        uint128 txGasPrice
+        uint64 txGasPrice
     )
         public
     {
@@ -574,11 +574,11 @@ contract DataAvailabilityChallenge_Resolve_Test is DataAvailabilityChallenge_Tes
         uint256 zeroAddressBalanceBeforeResolve = address(0).balance;
 
         // Assert challenger balance after bond distribution
-        uint256 resolutionCost = (
-            dataAvailabilityChallenge.fixedResolutionCost()
-                + preImage.length * dataAvailabilityChallenge.variableResolutionCost()
-                    / dataAvailabilityChallenge.variableResolutionCostPrecision()
-        ) * block.basefee;
+        uint256 resolutionCost =
+            (dataAvailabilityChallenge.fixedResolutionCost()
+                    + preImage.length
+                    * dataAvailabilityChallenge.variableResolutionCost()
+                    / dataAvailabilityChallenge.variableResolutionCostPrecision()) * block.basefee;
         uint256 challengerRefund = bondSize > resolutionCost ? bondSize - resolutionCost : 0;
         uint256 resolverRefund = resolutionCost * dataAvailabilityChallenge.resolverRefundPercentage() / 100;
         resolverRefund = resolverRefund > resolutionCost ? resolutionCost : resolverRefund;
@@ -626,7 +626,7 @@ contract DataAvailabilityChallenge_Resolve_Test is DataAvailabilityChallenge_Tes
         bytes memory wrongPreImage,
         uint256 challengedBlockNumber,
         uint256 resolverRefundPercentage,
-        uint128 txGasPrice
+        uint64 txGasPrice
     )
         public
     {


### PR DESCRIPTION
## Description

The `txGasPrice` fuzz parameter in `DataAvailabilityChallenge`'s resolve tests
is typed as `uint128`, but the `vm.txGasPrice` cheatcode requires the gas price
to be less than `2^64`. The fuzzer generates values above `2^64`, and the test
reverts before exercising any real logic.

This affects two tests in `test/L1/DataAvailabilityChallenge.t.sol`:
- `test_resolve_succeeds`
- `test_resolve_invalidInputData_reverts`

## Fix

Narrow the `txGasPrice` parameter type from `uint128` to `uint64`. Since
`uint64`'s max value is `2^64 - 1`, every value the fuzzer generates now
satisfies the cheatcode's `< 2^64` constraint.

This fixes the issue at the type level rather than filtering with
`vm.assume(txGasPrice < 2**64)`. An `assume` would reject roughly all
(`1 - 1/2^64`) generated inputs, exhausting the fuzzer's rejection budget
(`max_test_rejects`) and producing no meaningful runs.

## Tests

`forge test --match-contract DataAvailabilityChallenge_Resolve_Test` passes
(6 passed, 0 failed). No production code is changed; this is a test-only fix.
