### PR TITLE
feat(kona-safedb): port op-node SafeDB to Rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6479,6 +6479,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "kona-safedb"
+version = "0.1.0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "kona-protocol",
+ "mockall",
+ "rocksdb",
+ "rstest",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "kona-serde"
 version = "0.2.2"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -266,6 +266,7 @@ kona-sources = { path = "kona/crates/node/sources", version = "0.1.2", default-f
 kona-node-service = { path = "kona/crates/node/service", version = "0.1.3", default-features = false }
 kona-disc = { path = "kona/crates/node/disc", version = "0.1.2", default-features = false }
 kona-gossip = { path = "kona/crates/node/gossip", version = "0.1.2", default-features = false }
+kona-safedb = { path = "kona/crates/node/safedb", version = "0.1.0", default-features = false }
 
 # Providers
 kona-providers-alloy = { path = "kona/crates/providers/providers-alloy", version = "0.3.3", default-features = false }

--- a/rust/kona/crates/node/safedb/Cargo.toml
+++ b/rust/kona/crates/node/safedb/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "kona-safedb"
+version = "0.1.0"
+description = "Derivation safe-head database for the OP Stack rollup node"
+
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Kona
+kona-protocol.workspace = true
+
+# Alloy
+alloy-eips.workspace = true
+alloy-primitives.workspace = true
+
+# Storage
+rocksdb = { workspace = true, features = ["snappy"], optional = true }
+
+# Misc
+tracing.workspace = true
+thiserror.workspace = true
+mockall.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true
+tempfile.workspace = true
+
+[features]
+default = []
+# Enables the on-disk [`SafeDb`] backend. Off by default so that consumers needing only the
+# `SafeDbV1` trait (or `DisabledDb`) avoid the rocksdb/libclang build dependency.
+rocksdb = ["dep:rocksdb"]

--- a/rust/kona/crates/node/safedb/README.md
+++ b/rust/kona/crates/node/safedb/README.md
@@ -1,0 +1,20 @@
+# `kona-safedb`
+
+A derivation safe-head database for the OP Stack rollup node.
+
+`SafeDb` records, for each L1 block that advanced the L2 safe head, a mapping from the L1
+block to the L2 safe head derived as of that L1 block. It is a Rust port of the `op-node`
+`safedb` package and is used by systems — such as fault proofs and interop — that need a
+high-quality record of derivation progress.
+
+The crate exposes:
+
+- [`SafeDbV1`] — the database interface, backed by either a real store or a no-op.
+- [`DisabledDb`] — a no-op implementation for hosts that do not record derivation.
+- `SafeDb` — a [`rocksdb`]-backed implementation that persists records to disk, available
+  behind the non-default `rocksdb` feature (off by default so that consumers needing only the
+  trait avoid the rocksdb/libclang build dependency).
+
+[`SafeDbV1`]: crate::SafeDbV1
+[`DisabledDb`]: crate::DisabledDb
+[`rocksdb`]: https://docs.rs/rocksdb

--- a/rust/kona/crates/node/safedb/src/disabled.rs
+++ b/rust/kona/crates/node/safedb/src/disabled.rs
@@ -1,0 +1,53 @@
+//! A no-op [`SafeDbV1`] implementation for hosts that do not record derivation.
+
+use crate::{
+    error::SafeDbError,
+    traits::{SafeDbV1, SafeHeadRecord},
+};
+use alloy_eips::BlockNumHash;
+use kona_protocol::L2BlockInfo;
+
+/// A [`SafeDbV1`] that records nothing and reports itself disabled.
+///
+/// Writes succeed as no-ops so callers need not branch on whether recording is enabled, while
+/// reads return [`SafeDbError::NotEnabled`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DisabledDb;
+
+impl SafeDbV1 for DisabledDb {
+    fn enabled(&self) -> bool {
+        false
+    }
+
+    fn safe_head_updated(
+        &self,
+        _safe_head: L2BlockInfo,
+        _l1_head: BlockNumHash,
+    ) -> Result<(), SafeDbError> {
+        Ok(())
+    }
+
+    fn safe_head_reset(&self, _safe_head: L2BlockInfo) -> Result<(), SafeDbError> {
+        Ok(())
+    }
+
+    fn safe_head_at_l1(&self, _l1_block_num: u64) -> Result<SafeHeadRecord, SafeDbError> {
+        Err(SafeDbError::NotEnabled)
+    }
+
+    fn first_entry(&self) -> Result<SafeHeadRecord, SafeDbError> {
+        Err(SafeDbError::NotEnabled)
+    }
+
+    fn last_entry(&self) -> Result<SafeHeadRecord, SafeDbError> {
+        Err(SafeDbError::NotEnabled)
+    }
+
+    fn l1_at_safe_head(&self, _target_l2_num: u64) -> Result<SafeHeadRecord, SafeDbError> {
+        Err(SafeDbError::NotEnabled)
+    }
+
+    fn close(&self) -> Result<(), SafeDbError> {
+        Ok(())
+    }
+}

--- a/rust/kona/crates/node/safedb/src/encoding.rs
+++ b/rust/kona/crates/node/safedb/src/encoding.rs
@@ -1,0 +1,62 @@
+//! Byte-exact key/value encoding for the safe-head database.
+//!
+//! Keys and values match the `op-node` `safedb` layout exactly so that databases are
+//! interchangeable between the Go and Rust implementations.
+
+use crate::error::SafeDbError;
+use alloy_eips::BlockNumHash;
+use alloy_primitives::B256;
+
+/// Prefix byte distinguishing the "safe head by L1 block number" column.
+///
+/// Keys are prefixed with a constant byte to allow differentiating columns within the data.
+pub(crate) const KEY_PREFIX_SAFE_BY_L1_BLOCK_NUM: u8 = 0;
+
+/// Length in bytes of an encoded key: one prefix byte plus a big-endian `u64`.
+pub(crate) const KEY_LEN: usize = 9;
+
+/// Length in bytes of an encoded value: two 32-byte hashes plus a big-endian `u64`.
+pub(crate) const VALUE_LEN: usize = 72;
+
+/// Encodes the key for the given L1 block number.
+pub(crate) fn safe_by_l1_block_num_key(l1_block_num: u64) -> [u8; KEY_LEN] {
+    let mut key = [0u8; KEY_LEN];
+    key[0] = KEY_PREFIX_SAFE_BY_L1_BLOCK_NUM;
+    key[1..].copy_from_slice(&l1_block_num.to_be_bytes());
+    key
+}
+
+/// Returns the maximum possible key, used as the exclusive upper bound for range operations.
+pub(crate) fn max_key() -> [u8; KEY_LEN] {
+    safe_by_l1_block_num_key(u64::MAX)
+}
+
+/// Encodes the value pairing an L1 block with the L2 safe head derived as of that block.
+pub(crate) fn safe_by_l1_block_num_value(l1: BlockNumHash, l2: BlockNumHash) -> [u8; VALUE_LEN] {
+    let mut val = [0u8; VALUE_LEN];
+    val[0..32].copy_from_slice(l1.hash.as_slice());
+    val[32..64].copy_from_slice(l2.hash.as_slice());
+    val[64..].copy_from_slice(&l2.number.to_be_bytes());
+    val
+}
+
+/// Decodes a key/value pair back into the L1 block and its recorded L2 safe head.
+///
+/// The L1 block number lives in the key while both hashes and the L2 number live in the value.
+pub(crate) fn decode_safe_by_l1_block_num(
+    key: &[u8],
+    val: &[u8],
+) -> Result<(BlockNumHash, BlockNumHash), SafeDbError> {
+    if key.len() != KEY_LEN || val.len() != VALUE_LEN || key[0] != KEY_PREFIX_SAFE_BY_L1_BLOCK_NUM {
+        return Err(SafeDbError::InvalidEntry);
+    }
+    let l1 = BlockNumHash {
+        hash: B256::from_slice(&val[0..32]),
+        number: u64::from_be_bytes(key[1..KEY_LEN].try_into().expect("checked length")),
+    };
+    let l2 = BlockNumHash {
+        hash: B256::from_slice(&val[32..64]),
+        number: u64::from_be_bytes(val[64..VALUE_LEN].try_into().expect("checked length")),
+    };
+    Ok((l1, l2))
+}

--- a/rust/kona/crates/node/safedb/src/error.rs
+++ b/rust/kona/crates/node/safedb/src/error.rs
@@ -1,0 +1,32 @@
+//! Error type for the safe-head database.
+
+/// Errors returned by [`SafeDbV1`](crate::SafeDbV1) implementations.
+#[derive(Debug, thiserror::Error)]
+pub enum SafeDbError {
+    /// No matching entry was found.
+    #[error("not found")]
+    NotFound,
+    /// A stored key/value pair did not match the expected layout.
+    #[error("invalid db entry")]
+    InvalidEntry,
+    /// The database has been closed.
+    #[error("safe db closed")]
+    Closed,
+    /// The safe-head database is not enabled on this host.
+    #[error("safe head database not enabled")]
+    NotEnabled,
+    /// The requested L2 target is above the latest recorded safe head, or the database is empty.
+    ///
+    /// This condition is transient: the target may become available as derivation advances.
+    #[error("l1 at safe head not found")]
+    L1AtSafeHeadNotFound,
+    /// The requested L2 target predates recorded history.
+    ///
+    /// This condition is permanent: the relevant records have been pruned or were never recorded.
+    #[error("l1 at safe head history unavailable")]
+    L1AtSafeHeadUnavailable,
+    /// An error originating from the underlying key/value store.
+    #[cfg(feature = "rocksdb")]
+    #[error(transparent)]
+    Backend(#[from] rocksdb::Error),
+}

--- a/rust/kona/crates/node/safedb/src/lib.rs
+++ b/rust/kona/crates/node/safedb/src/lib.rs
@@ -1,0 +1,29 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/ethereum-optimism/optimism/develop/rust/kona/assets/square.png",
+    html_favicon_url = "https://raw.githubusercontent.com/ethereum-optimism/optimism/develop/rust/kona/assets/favicon.ico",
+    issue_tracker_base_url = "https://github.com/ethereum-optimism/optimism/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+mod disabled;
+mod error;
+mod traits;
+
+#[cfg(feature = "rocksdb")]
+mod encoding;
+#[cfg(feature = "rocksdb")]
+mod safe_db;
+
+#[cfg(test)]
+mod tests;
+
+pub use disabled::DisabledDb;
+pub use error::SafeDbError;
+pub use traits::{SafeDbV1, SafeHeadRecord};
+
+#[cfg(feature = "rocksdb")]
+pub use safe_db::SafeDb;
+
+#[cfg(test)]
+pub use traits::MockSafeDbV1;

--- a/rust/kona/crates/node/safedb/src/safe_db.rs
+++ b/rust/kona/crates/node/safedb/src/safe_db.rs
@@ -1,0 +1,214 @@
+//! A [`rocksdb`]-backed [`SafeDbV1`] implementation.
+
+use crate::{
+    encoding::{
+        decode_safe_by_l1_block_num, max_key, safe_by_l1_block_num_key, safe_by_l1_block_num_value,
+    },
+    error::SafeDbError,
+    traits::{SafeDbV1, SafeHeadRecord},
+};
+use alloy_eips::BlockNumHash;
+use kona_protocol::L2BlockInfo;
+use rocksdb::{DB, DBRawIterator, Options, ReadOptions, WriteBatch, WriteOptions};
+use std::{
+    path::Path,
+    sync::{PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
+
+/// A safe-head database that persists records to a [`rocksdb`] store.
+///
+/// The store is held behind an [`RwLock`] so that [`SafeDb::close`] can drop it while ensuring
+/// no read iterator is still borrowing it, mirroring the read/write exclusion of the Go
+/// implementation.
+#[derive(Debug)]
+pub struct SafeDb {
+    inner: RwLock<Option<DB>>,
+}
+
+impl SafeDb {
+    /// Opens (creating if necessary) a safe-head database at `path`.
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, SafeDbError> {
+        let mut options = Options::default();
+        options.create_if_missing(true);
+        let db = DB::open(&options, path)?;
+        Ok(Self { inner: RwLock::new(Some(db)) })
+    }
+
+    fn read_guard(&self) -> RwLockReadGuard<'_, Option<DB>> {
+        self.inner.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn write_guard(&self) -> RwLockWriteGuard<'_, Option<DB>> {
+        self.inner.write().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Write options that fsync each write, matching the Go implementation's synchronous writes.
+fn sync_write_options() -> WriteOptions {
+    let mut options = WriteOptions::default();
+    options.set_sync(true);
+    options
+}
+
+/// Read options bounding iteration to the "safe head by L1 block number" column.
+///
+/// The upper bound is exclusive, matching the Go implementation's `IterRange`. Without these
+/// bounds an iterator would walk into any other column a future schema adds.
+fn column_read_options() -> ReadOptions {
+    let mut options = ReadOptions::default();
+    options.set_iterate_lower_bound(safe_by_l1_block_num_key(0).to_vec());
+    options.set_iterate_upper_bound(max_key().to_vec());
+    options
+}
+
+/// Decodes the entry the iterator is currently positioned on.
+fn current_entry(iter: &DBRawIterator<'_>) -> Result<(BlockNumHash, BlockNumHash), SafeDbError> {
+    let key = iter.key().ok_or(SafeDbError::InvalidEntry)?;
+    let value = iter.value().ok_or(SafeDbError::InvalidEntry)?;
+    decode_safe_by_l1_block_num(key, value)
+}
+
+impl SafeDbV1 for SafeDb {
+    fn enabled(&self) -> bool {
+        true
+    }
+
+    fn safe_head_updated(
+        &self,
+        safe_head: L2BlockInfo,
+        l1_head: BlockNumHash,
+    ) -> Result<(), SafeDbError> {
+        let guard = self.write_guard();
+        let db = guard.as_ref().ok_or(SafeDbError::Closed)?;
+        tracing::info!(
+            l2_number = safe_head.block_info.number,
+            l1_number = l1_head.number,
+            "Record local safe head"
+        );
+        let mut batch = WriteBatch::default();
+        batch.put(
+            safe_by_l1_block_num_key(l1_head.number),
+            safe_by_l1_block_num_value(l1_head, safe_head.block_info.id()),
+        );
+        db.write_opt(batch, &sync_write_options())?;
+        Ok(())
+    }
+
+    fn safe_head_reset(&self, safe_head: L2BlockInfo) -> Result<(), SafeDbError> {
+        let guard = self.write_guard();
+        let db = guard.as_ref().ok_or(SafeDbError::Closed)?;
+        tracing::info!(l2_number = safe_head.block_info.number, "Resetting safe head db");
+
+        let mut iter = db.raw_iterator_opt(column_read_options());
+        iter.seek(safe_by_l1_block_num_key(safe_head.l1_origin.number));
+        while iter.valid() {
+            let (l1_block, l2_block) = current_entry(&iter)?;
+            if l2_block.number >= safe_head.block_info.number {
+                // Clone the boundary key before `prev()` invalidates the borrow.
+                let boundary_key = iter.key().ok_or(SafeDbError::InvalidEntry)?.to_vec();
+                iter.prev();
+                let has_prev_entry = iter.valid();
+                if !has_prev_entry {
+                    iter.status()?;
+                }
+
+                let mut batch = WriteBatch::default();
+                batch.delete_range(boundary_key.as_slice(), max_key().as_slice());
+                // If a previous entry exists, the boundary L1 block is a real recorded
+                // transition, so re-record the reset safe head there. If it does not, we cannot
+                // know whether the reset head became safe at that L1 block or merely before our
+                // records begin, so we leave it unrecorded.
+                if has_prev_entry {
+                    batch.put(
+                        boundary_key.as_slice(),
+                        safe_by_l1_block_num_value(l1_block, safe_head.block_info.id()).as_slice(),
+                    );
+                }
+                db.write_opt(batch, &sync_write_options())?;
+                return Ok(());
+            }
+            iter.next();
+        }
+        iter.status()?;
+        Ok(())
+    }
+
+    fn safe_head_at_l1(&self, l1_block_num: u64) -> Result<SafeHeadRecord, SafeDbError> {
+        let guard = self.read_guard();
+        let db = guard.as_ref().ok_or(SafeDbError::Closed)?;
+        let mut iter = db.raw_iterator_opt(column_read_options());
+        // Largest key <= l1_block_num, equivalent to the Go `SeekLT(l1_block_num + 1)`.
+        iter.seek_for_prev(safe_by_l1_block_num_key(l1_block_num));
+        if !iter.valid() {
+            iter.status()?;
+            return Err(SafeDbError::NotFound);
+        }
+        let (l1, safe_head) = current_entry(&iter)?;
+        Ok(SafeHeadRecord { l1, safe_head })
+    }
+
+    fn first_entry(&self) -> Result<SafeHeadRecord, SafeDbError> {
+        let guard = self.read_guard();
+        let db = guard.as_ref().ok_or(SafeDbError::Closed)?;
+        let mut iter = db.raw_iterator_opt(column_read_options());
+        iter.seek_to_first();
+        if !iter.valid() {
+            iter.status()?;
+            return Err(SafeDbError::NotFound);
+        }
+        let (l1, safe_head) = current_entry(&iter)?;
+        Ok(SafeHeadRecord { l1, safe_head })
+    }
+
+    fn last_entry(&self) -> Result<SafeHeadRecord, SafeDbError> {
+        let guard = self.read_guard();
+        let db = guard.as_ref().ok_or(SafeDbError::Closed)?;
+        let mut iter = db.raw_iterator_opt(column_read_options());
+        iter.seek_to_last();
+        if !iter.valid() {
+            iter.status()?;
+            return Err(SafeDbError::NotFound);
+        }
+        let (l1, safe_head) = current_entry(&iter)?;
+        Ok(SafeHeadRecord { l1, safe_head })
+    }
+
+    fn l1_at_safe_head(&self, target_l2_num: u64) -> Result<SafeHeadRecord, SafeDbError> {
+        let guard = self.read_guard();
+        let db = guard.as_ref().ok_or(SafeDbError::Closed)?;
+        let mut iter = db.raw_iterator_opt(column_read_options());
+
+        iter.seek_to_last();
+        if !iter.valid() {
+            iter.status()?;
+            return Err(SafeDbError::L1AtSafeHeadNotFound);
+        }
+        let (mut cursor_l1, mut cursor_l2) = current_entry(&iter)?;
+        if target_l2_num > cursor_l2.number {
+            return Err(SafeDbError::L1AtSafeHeadNotFound);
+        }
+        loop {
+            iter.prev();
+            if !iter.valid() {
+                iter.status()?;
+                break;
+            }
+            let (prev_l1, prev_l2) = current_entry(&iter)?;
+            if prev_l2.number < target_l2_num {
+                return Ok(SafeHeadRecord { l1: cursor_l1, safe_head: cursor_l2 });
+            }
+            cursor_l1 = prev_l1;
+            cursor_l2 = prev_l2;
+        }
+        if cursor_l2.number == target_l2_num {
+            return Ok(SafeHeadRecord { l1: cursor_l1, safe_head: cursor_l2 });
+        }
+        Err(SafeDbError::L1AtSafeHeadUnavailable)
+    }
+
+    fn close(&self) -> Result<(), SafeDbError> {
+        let mut guard = self.write_guard();
+        *guard = None;
+        Ok(())
+    }
+}

--- a/rust/kona/crates/node/safedb/src/tests.rs
+++ b/rust/kona/crates/node/safedb/src/tests.rs
@@ -1,0 +1,376 @@
+//! Unit tests for the safe-head database.
+
+#[cfg(feature = "rocksdb")]
+mod encoding {
+    use crate::{
+        encoding::{
+            KEY_LEN, decode_safe_by_l1_block_num, safe_by_l1_block_num_key,
+            safe_by_l1_block_num_value,
+        },
+        error::SafeDbError,
+    };
+    use alloy_eips::BlockNumHash;
+    use alloy_primitives::{B256, b256};
+    use rstest::rstest;
+
+    fn l1() -> BlockNumHash {
+        BlockNumHash {
+            hash: b256!("0100000000000000000000000000000000000000000000000000000000000000"),
+            number: 84298,
+        }
+    }
+
+    fn l2() -> BlockNumHash {
+        BlockNumHash {
+            hash: b256!("0200000000000000000000000000000000000000000000000000000000000000"),
+            number: 3224,
+        }
+    }
+
+    #[test]
+    fn roundtrip() {
+        let key = safe_by_l1_block_num_key(l1().number);
+        let val = safe_by_l1_block_num_value(l1(), l2());
+        let (actual_l1, actual_l2) = decode_safe_by_l1_block_num(&key, &val).unwrap();
+        assert_eq!(l1(), actual_l1);
+        assert_eq!(l2(), actual_l2);
+    }
+
+    #[rstest]
+    #[case::empty_key(vec![], valid_value())]
+    #[case::too_short_key(vec![1, 2, 3, 4], valid_value())]
+    #[case::too_long_key(too_long_key(), valid_value())]
+    #[case::wrong_key_prefix(wrong_prefix_key(), valid_value())]
+    #[case::empty_value(valid_key().to_vec(), vec![])]
+    #[case::too_short_value(valid_key().to_vec(), vec![1, 2, 3, 4])]
+    #[case::too_long_value(valid_key().to_vec(), too_long_value())]
+    fn invalid_entries(#[case] key: Vec<u8>, #[case] val: Vec<u8>) {
+        assert!(matches!(decode_safe_by_l1_block_num(&key, &val), Err(SafeDbError::InvalidEntry)));
+    }
+
+    #[test]
+    fn key_layout_is_exact() {
+        // One prefix byte (0x00) followed by the big-endian L1 block number. This exact layout
+        // is what makes an on-disk database interchangeable with the Go implementation.
+        let key = safe_by_l1_block_num_key(0x0102_0304_0506_0708);
+        assert_eq!(key, [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+    }
+
+    #[test]
+    fn value_layout_is_exact() {
+        let l1 = BlockNumHash { hash: B256::repeat_byte(0xab), number: 0 };
+        let l2 = BlockNumHash { hash: B256::repeat_byte(0xcd), number: 0x1122_3344_5566_7788 };
+        let value = safe_by_l1_block_num_value(l1, l2);
+
+        let mut expected = [0u8; 72];
+        expected[0..32].fill(0xab);
+        expected[32..64].fill(0xcd);
+        expected[64..72].copy_from_slice(&0x1122_3344_5566_7788u64.to_be_bytes());
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn keys_follow_natural_byte_ordering() {
+        let vals: [u64; 7] = [
+            0,
+            1,
+            u32::MAX as u64 - 1,
+            u32::MAX as u64,
+            u32::MAX as u64 + 1,
+            u64::MAX - 1,
+            u64::MAX,
+        ];
+        for window in vals.windows(2) {
+            let prev = safe_by_l1_block_num_key(window[0]);
+            let cur = safe_by_l1_block_num_key(window[1]);
+            assert!(prev < cur, "expected key for {} to be less than {}", window[0], window[1]);
+        }
+    }
+
+    fn valid_key() -> [u8; KEY_LEN] {
+        safe_by_l1_block_num_key(l1().number)
+    }
+
+    fn valid_value() -> Vec<u8> {
+        safe_by_l1_block_num_value(l1(), l2()).to_vec()
+    }
+
+    fn too_long_key() -> Vec<u8> {
+        let mut key = valid_key().to_vec();
+        key.push(2);
+        key
+    }
+
+    fn wrong_prefix_key() -> Vec<u8> {
+        let mut key = valid_key();
+        key[0] = 49;
+        key.to_vec()
+    }
+
+    fn too_long_value() -> Vec<u8> {
+        let mut val = valid_value();
+        val.push(2);
+        val
+    }
+}
+
+#[cfg(feature = "rocksdb")]
+mod safe_db {
+    use crate::{SafeDb, SafeDbError, SafeDbV1, SafeHeadRecord};
+    use alloy_eips::BlockNumHash;
+    use alloy_primitives::B256;
+    use kona_protocol::{BlockInfo, L2BlockInfo};
+    use rstest::rstest;
+    use tempfile::TempDir;
+
+    fn hash(a: u8, b: u8) -> B256 {
+        let mut bytes = [0u8; 32];
+        bytes[0] = a;
+        bytes[1] = b;
+        B256::from(bytes)
+    }
+
+    fn id(a: u8, b: u8, number: u64) -> BlockNumHash {
+        BlockNumHash { hash: hash(a, b), number }
+    }
+
+    fn l2(a: u8, b: u8, number: u64, l1_origin_number: u64) -> L2BlockInfo {
+        L2BlockInfo {
+            block_info: BlockInfo {
+                hash: hash(a, b),
+                number,
+                parent_hash: B256::ZERO,
+                timestamp: 0,
+            },
+            l1_origin: BlockNumHash { hash: B256::ZERO, number: l1_origin_number },
+            seq_num: 0,
+        }
+    }
+
+    fn open() -> (TempDir, SafeDb) {
+        let dir = TempDir::new().unwrap();
+        let db = SafeDb::new(dir.path()).unwrap();
+        (dir, db)
+    }
+
+    fn assert_record(record: SafeHeadRecord, l1: BlockNumHash, safe_head: BlockNumHash) {
+        assert_eq!(record.l1, l1);
+        assert_eq!(record.safe_head, safe_head);
+    }
+
+    #[test]
+    fn store_safe_heads() {
+        let dir = TempDir::new().unwrap();
+        let l2a = l2(0x02, 0xaa, 20, 0);
+        let l2b = l2(0x02, 0xbb, 25, 0);
+        let l1a = id(0x01, 0xaa, 100);
+        let l1b = id(0x01, 0xbb, 150);
+
+        let verify = |db: &SafeDb| {
+            assert!(matches!(db.safe_head_at_l1(l1a.number - 1), Err(SafeDbError::NotFound)));
+            assert_record(db.safe_head_at_l1(l1a.number).unwrap(), l1a, l2a.block_info.id());
+            assert_record(db.safe_head_at_l1(l1a.number + 1).unwrap(), l1a, l2a.block_info.id());
+            assert_record(db.safe_head_at_l1(l1b.number).unwrap(), l1b, l2b.block_info.id());
+            assert_record(db.safe_head_at_l1(l1b.number + 1).unwrap(), l1b, l2b.block_info.id());
+        };
+
+        let db = SafeDb::new(dir.path()).unwrap();
+        db.safe_head_updated(l2a, l1a).unwrap();
+        db.safe_head_updated(l2b, l1b).unwrap();
+        verify(&db);
+
+        // Close and reopen to confirm the data is durable.
+        db.close().unwrap();
+        let reopened = SafeDb::new(dir.path()).unwrap();
+        verify(&reopened);
+    }
+
+    #[test]
+    fn safe_head_at_l1_empty_database() {
+        let (_dir, db) = open();
+        assert!(matches!(db.safe_head_at_l1(100), Err(SafeDbError::NotFound)));
+    }
+
+    #[test]
+    fn first_entry_empty_database() {
+        let (_dir, db) = open();
+        assert!(matches!(db.first_entry(), Err(SafeDbError::NotFound)));
+    }
+
+    #[test]
+    fn first_entry_returns_lowest_l1() {
+        let (_dir, db) = open();
+        let l2a = l2(0x02, 0xaa, 20, 0);
+        let l2b = l2(0x02, 0xbb, 25, 0);
+        let l1a = id(0x01, 0xaa, 100);
+        let l1b = id(0x01, 0xbb, 150);
+
+        // Insert out of order to confirm we return the lowest L1, not the first-inserted entry.
+        db.safe_head_updated(l2b, l1b).unwrap();
+        db.safe_head_updated(l2a, l1a).unwrap();
+
+        assert_record(db.first_entry().unwrap(), l1a, l2a.block_info.id());
+    }
+
+    #[test]
+    fn first_entry_stable_after_reset_ahead() {
+        let (_dir, db) = open();
+        let l1a = id(0x01, 0xaa, 100);
+        let l1b = id(0x01, 0xbb, 150);
+        let l2a = l2(0x02, 0xaa, 20, l1a.number);
+        let l2b = l2(0x02, 0xbb, 25, l1b.number);
+
+        db.safe_head_updated(l2a, l1a).unwrap();
+        db.safe_head_updated(l2b, l1b).unwrap();
+
+        // Resetting to l2b truncates entries at or after it; the l2a entry must remain first.
+        db.safe_head_reset(l2b).unwrap();
+
+        assert_record(db.first_entry().unwrap(), l1a, l2a.block_info.id());
+    }
+
+    #[test]
+    fn truncate_on_safe_head_reset() {
+        let (_dir, db) = open();
+        let l2a = l2(0x02, 0xaa, 20, 60);
+        let l2b = l2(0x02, 0xbb, 22, 90);
+        let l2c = l2(0x02, 0xcc, 25, 110);
+        let l2d = l2(0x02, 0xdd, 30, 120);
+        let l1a = id(0x01, 0xaa, 100);
+        let l1b = id(0x01, 0xbb, 150);
+        let l1c = id(0x01, 0xcc, 160);
+
+        db.safe_head_updated(l2a, l1a).unwrap();
+        db.safe_head_updated(l2c, l1b).unwrap();
+        db.safe_head_updated(l2d, l1c).unwrap();
+
+        // Reset to between the existing entries.
+        db.safe_head_reset(l2b).unwrap();
+
+        // Only the reset safe head is now safe at the previous L1 block number.
+        assert_record(db.safe_head_at_l1(l1b.number).unwrap(), l1b, l2b.block_info.id());
+        assert_record(db.safe_head_at_l1(l1c.number).unwrap(), l1b, l2b.block_info.id());
+        // l2a is still safe from its original update.
+        assert_record(db.safe_head_at_l1(l1a.number).unwrap(), l1a, l2a.block_info.id());
+    }
+
+    #[test]
+    fn truncate_on_safe_head_reset_before_first_entry() {
+        let (_dir, db) = open();
+        let l2b = l2(0x02, 0xbb, 22, 90);
+        let l2c = l2(0x02, 0xcc, 25, 110);
+        let l2d = l2(0x02, 0xdd, 30, 120);
+        let l1a = id(0x01, 0xaa, 100);
+        let l1b = id(0x01, 0xbb, 150);
+        let l1c = id(0x01, 0xcc, 160);
+
+        db.safe_head_updated(l2c, l1b).unwrap();
+        db.safe_head_updated(l2d, l1c).unwrap();
+
+        // Reset to before all existing entries removes everything.
+        db.safe_head_reset(l2b).unwrap();
+
+        assert!(matches!(db.safe_head_at_l1(l1a.number), Err(SafeDbError::NotFound)));
+        assert!(matches!(db.safe_head_at_l1(l1b.number), Err(SafeDbError::NotFound)));
+        assert!(matches!(db.safe_head_at_l1(l1c.number), Err(SafeDbError::NotFound)));
+    }
+
+    #[test]
+    fn truncate_on_safe_head_reset_after_last_entry() {
+        let (_dir, db) = open();
+        let l2a = l2(0x02, 0xaa, 20, 60);
+        let l2b = l2(0x02, 0xbb, 22, 90);
+        let l2c = l2(0x02, 0xcc, 25, 110);
+        let l1a = id(0x01, 0xaa, 100);
+        let l1b = id(0x01, 0xbb, 150);
+        let l1c = id(0x01, 0xcc, 160);
+
+        db.safe_head_updated(l2a, l1a).unwrap();
+        db.safe_head_updated(l2b, l1b).unwrap();
+        db.safe_head_updated(l2c, l1c).unwrap();
+
+        let verify = |db: &SafeDb| {
+            assert_record(db.safe_head_at_l1(l1a.number).unwrap(), l1a, l2a.block_info.id());
+            assert_record(db.safe_head_at_l1(l1b.number).unwrap(), l1b, l2b.block_info.id());
+            assert_record(db.safe_head_at_l1(l1c.number).unwrap(), l1c, l2c.block_info.id());
+        };
+        verify(&db);
+
+        // Reset to an L2 block after all entries with an origin after all L1 entries.
+        db.safe_head_reset(l2(0x02, 0xdd, 30, l1c.number + 1)).unwrap();
+        verify(&db);
+
+        // Reset to an L2 block after all entries with an origin before some L1 entries.
+        db.safe_head_reset(l2(0x02, 0xdd, 30, l1b.number - 1)).unwrap();
+        verify(&db);
+    }
+
+    fn populated_l1_at_safe_head_db() -> (TempDir, SafeDb) {
+        let (dir, db) = open();
+        db.safe_head_updated(l2(0x02, 0xaa, 500, 0), id(0x01, 0xaa, 100)).unwrap();
+        db.safe_head_updated(l2(0x02, 0xbb, 510, 0), id(0x01, 0xbb, 110)).unwrap();
+        db.safe_head_updated(l2(0x02, 0xcc, 520, 0), id(0x01, 0xcc, 120)).unwrap();
+        (dir, db)
+    }
+
+    #[derive(Debug)]
+    enum Expected {
+        Record(BlockNumHash, BlockNumHash),
+        NotFound,
+        Unavailable,
+    }
+
+    #[rstest]
+    #[case::target_equals_first(500, Expected::Record(id(0x01, 0xaa, 100), id(0x02, 0xaa, 500)))]
+    #[case::target_between_entries(505, Expected::Record(id(0x01, 0xbb, 110), id(0x02, 0xbb, 510)))]
+    #[case::target_equals_recorded(510, Expected::Record(id(0x01, 0xbb, 110), id(0x02, 0xbb, 510)))]
+    #[case::target_equals_latest(520, Expected::Record(id(0x01, 0xcc, 120), id(0x02, 0xcc, 520)))]
+    #[case::target_above_latest(521, Expected::NotFound)]
+    #[case::target_below_first(499, Expected::Unavailable)]
+    fn l1_at_safe_head(#[case] target: u64, #[case] expected: Expected) {
+        let (_dir, db) = populated_l1_at_safe_head_db();
+        match (db.l1_at_safe_head(target), expected) {
+            (Ok(record), Expected::Record(l1, safe_head)) => assert_record(record, l1, safe_head),
+            (Err(SafeDbError::L1AtSafeHeadNotFound), Expected::NotFound) |
+            (Err(SafeDbError::L1AtSafeHeadUnavailable), Expected::Unavailable) => {}
+            (result, expected) => panic!("unexpected result {result:?} for {expected:?}"),
+        }
+    }
+
+    #[test]
+    fn l1_at_safe_head_empty_database() {
+        let (_dir, db) = open();
+        assert!(matches!(db.l1_at_safe_head(500), Err(SafeDbError::L1AtSafeHeadNotFound)));
+    }
+
+    #[test]
+    fn operations_after_close_report_closed() {
+        let (_dir, db) = open();
+        db.close().unwrap();
+        assert!(matches!(db.safe_head_at_l1(100), Err(SafeDbError::Closed)));
+        // Close is idempotent.
+        db.close().unwrap();
+    }
+
+    #[test]
+    fn open_on_locked_path_returns_backend_error() {
+        // rocksdb holds an exclusive lock on an open database directory, so a second open of the
+        // same path surfaces a backend error.
+        let (dir, _held) = open();
+        assert!(matches!(SafeDb::new(dir.path()), Err(SafeDbError::Backend(_))));
+    }
+}
+
+mod disabled {
+    use crate::{DisabledDb, SafeDbError, SafeDbV1};
+
+    #[test]
+    fn l1_at_safe_head_disabled() {
+        assert!(matches!(DisabledDb.l1_at_safe_head(500), Err(SafeDbError::NotEnabled)));
+    }
+
+    #[test]
+    fn reports_disabled() {
+        assert!(!DisabledDb.enabled());
+    }
+}

--- a/rust/kona/crates/node/safedb/src/traits.rs
+++ b/rust/kona/crates/node/safedb/src/traits.rs
@@ -1,0 +1,57 @@
+//! The safe-head database interface.
+
+use crate::error::SafeDbError;
+use alloy_eips::BlockNumHash;
+use kona_protocol::L2BlockInfo;
+
+/// A recorded pairing of an L1 block and the L2 safe head derived as of that block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SafeHeadRecord {
+    /// The L1 block at which the safe head became safe.
+    pub l1: BlockNumHash,
+    /// The L2 safe head derived as of [`SafeHeadRecord::l1`].
+    pub safe_head: BlockNumHash,
+}
+
+/// The first version of the safe-head database interface.
+///
+/// Implementations record, per L1 block, the L2 safe head that derivation reached as of that
+/// block, and answer queries in both directions (L1 → safe head and safe head → L1).
+///
+/// Methods are synchronous: the backing store is queried in-process, and a future actor is
+/// expected to own a single instance and serialize access to it.
+#[cfg_attr(test, mockall::automock)]
+pub trait SafeDbV1 {
+    /// Reports whether this database actively records and serves derivation data.
+    fn enabled(&self) -> bool;
+
+    /// Records that `safe_head` became safe as of `l1_head`.
+    ///
+    /// `l1_head` is the first L1 block containing all data required to derive `safe_head`.
+    fn safe_head_updated(
+        &self,
+        safe_head: L2BlockInfo,
+        l1_head: BlockNumHash,
+    ) -> Result<(), SafeDbError>;
+
+    /// Truncates records so that `safe_head` is once again the recorded tip.
+    ///
+    /// All entries that made an L2 block at or after `safe_head` safe are removed.
+    fn safe_head_reset(&self, safe_head: L2BlockInfo) -> Result<(), SafeDbError>;
+
+    /// Returns the safe head recorded as of the highest L1 block at or below `l1_block_num`.
+    fn safe_head_at_l1(&self, l1_block_num: u64) -> Result<SafeHeadRecord, SafeDbError>;
+
+    /// Returns the lowest recorded entry.
+    fn first_entry(&self) -> Result<SafeHeadRecord, SafeDbError>;
+
+    /// Returns the highest recorded entry (the database tip).
+    fn last_entry(&self) -> Result<SafeHeadRecord, SafeDbError>;
+
+    /// Returns the earliest L1 block at which the recorded safe head reached at least
+    /// `target_l2_num`, along with the safe head recorded at that L1 block.
+    fn l1_at_safe_head(&self, target_l2_num: u64) -> Result<SafeHeadRecord, SafeDbError>;
+
+    /// Closes the database, releasing the underlying store.
+    fn close(&self) -> Result<(), SafeDbError>;
+}


### PR DESCRIPTION
## Summary

Adds the **`kona-safedb`** crate — a 1-to-1 Rust port of the op-node `safedb` package. It records, per L1 block, the L2 safe head that derivation reached as of that block, used by systems (fault proofs, interop) that need a high-quality derivation record. kona-node previously had no equivalent.

The on-disk key/value encoding is byte-exact with the Go implementation, so a database is interchangeable between the two.

## What's included

- **`SafeDbV1` trait** — the versioned database interface, mockable via `#[cfg_attr(test, mockall::automock)]` (generates `MockSafeDbV1`).
- **`SafeDb`** — rocksdb-backed implementation. All Go methods ported: `safe_head_updated`, `safe_head_reset`, `safe_head_at_l1`, `first_entry`, `last_entry`, `l1_at_safe_head`, `enabled`, `close`.
- **`DisabledDb`** — no-op implementation (port of `disabled.go`).
- The rocksdb backend is behind a **non-default `rocksdb` feature**, so consumers needing only the trait/`DisabledDb` avoid the rocksdb/libclang build dependency. Default `cargo build --workspace` does not pull rocksdb; `--all-features` (used by CI test/clippy) builds and exercises everything.
- Iterators are bounded to the key column, mirroring the Go `IterRange`.

## Testing

- Full Go test suite ported (store/reopen persistence, reset truncation edge cases, `l1_at_safe_head` table, decode/ordering).
- Added exact-byte-layout tests (locking cross-impl interop) and a backend-error test.
- `--all-features`: 30 tests pass. Default: build is warning-free. `clippy --all-features -D warnings`, `cargo doc -D warnings`, `cargo +nightly fmt --check`, and `cargo hack check --feature-powerset` all clean.

## Out of scope (follow-up)

Node integration — `SafeHeadListener`-style derivation hook, the `optimism_safeHeadAtL1` RPC handler, and the CLI/config flag to enable it. The `SafeDbV1` trait is the seam those will build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)