### PR TITLE
devstack: run op-con-node as an L2 CL verifier (opql integration)

### DIFF
--- a/op-acceptance-tests/tests/opcon/sequencer_test.go
+++ b/op-acceptance-tests/tests/opcon/sequencer_test.go
@@ -1,0 +1,208 @@
+package opcon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests in this file exercise op-con-node's SEQUENCER mode: op-con-node
+// produces the unsafe chain itself by driving its paired EL's build loop
+// (noTxPool=false — the EL packs its own mempool behind the forced deposit
+// prefix), while still deriving its safe chain from L1 like a verifier.
+//
+// Devstack routes sequencer slots to op-node by default even when
+// DEVSTACK_L2CL_KIND=op-con-node (the historical verifier-only behavior), so
+// each test opts its sequencer slot in with sysgo.L2CLOpConSequencer(). To run
+// against op-con-node:
+//
+//	DEVSTACK_L2CL_KIND=op-con-node \
+//	DEVSTACK_L2EL_KIND=op-reth \
+//	RUST_BINARY_PATH_OP_CON_NODE=<opql>/target/debug/op-con-node \
+//	go test -run TestOpConSequencer ./op-acceptance-tests/tests/opcon/
+//
+// With the default op-node CL kind the option is a no-op and each test is an
+// ordinary op-node sequencer check, so they remain valid suite additions
+// rather than op-con-node-only tests.
+
+// opConSequencerOpt opts the sequencer slot into op-con-node's sequencing mode
+// (no-op for other CL kinds — see the package comment above).
+func opConSequencerOpt() presets.Option {
+	return presets.WithGlobalL2CLOption(sysgo.L2CLOpConSequencer())
+}
+
+// TestOpConSequencerAdvancesUnsafeHead is the op-con-node sequencer analogue of
+// the base advance test (TestCLAdvance): the sequencer must produce a steady
+// unsafe chain on its own — the minimal liveness property of sequencing mode.
+// It exercises op-con-node's whole build pipeline: heartbeat -> SQL build
+// request (unsafe-head cursor + L1-origin selection) -> engine FCU+attrs ->
+// getPayload -> unsafe ingress -> head advance.
+func TestOpConSequencerAdvancesUnsafeHead(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewMinimalNoFaultProofs(t, opConSequencerOpt())
+
+	// The sequencer produces a run of unsafe blocks on its own cadence.
+	sys.L2CL.Advanced(types.LocalUnsafe, 5, 60)
+}
+
+// TestOpConSequencerBatchesDeriveSafeHead is the sequencer-side flip of
+// TestOpConVerifierDerivesSafeHead: with op-con-node in the SEQUENCER slot, the
+// blocks it builds must round-trip through the batcher and L1 derivation. The
+// batcher submits the sequencer's blocks to L1; the sequencer's own safe head
+// (it derives from L1 like a verifier) must catch up to its unsafe chain, and
+// the verifier must derive the same safe chain and converge.
+//
+// This is the strongest end-to-end check of sequencing mode: a block that
+// derivation would reject (bad deposit prefix, wrong L1-origin selection, bad
+// timestamps) shows up here as a safe-head divergence or stall.
+func TestOpConSequencerBatchesDeriveSafeHead(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck(t, opConSequencerOpt())
+
+	// The sequencer produces blocks, the batcher lands them on L1, and the
+	// sequencer's own L1 derivation confirms them as safe.
+	sys.L2CL.Advanced(types.LocalSafe, 1, 60)
+
+	// The verifier derives the same safe chain from L1 and converges.
+	sys.L2CLB.Advanced(types.LocalSafe, 1, 60)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 60)
+}
+
+// TestOpConSequencerIncludesUserTransactions is the op-con-node sequencer
+// analogue of the base transfer test (TestTransfer): a user transaction
+// submitted to the sequencer's EL mempool must be included in a sequenced
+// block. This pins the noTxPool=false build path — the sequencer supplies only
+// the forced deposit prefix and the EL appends mempool transactions behind it
+// (a noTxPool=true regression would produce deposit-only blocks and the
+// transfer would never land).
+func TestOpConSequencerIncludesUserTransactions(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewMinimalNoFaultProofs(t, opConSequencerOpt())
+
+	alice := sys.FunderL2.NewFundedEOA(eth.ThreeHundredthsEther)
+	bob := sys.Wallet.NewEOA(sys.L2EL)
+	bobBalance := bob.GetBalance()
+
+	transferAmount := eth.OneHundredthEther
+	alice.Transfer(bob.Address(), transferAmount)
+	bob.WaitForBalance(bobBalance.Add(transferAmount))
+}
+
+// TestOpConSequencerIncludesDeposits is the op-con-node sequencer analogue of
+// the base deposit test (TestL1ToL2Deposit): a deposit made on L1 must be
+// force-included in a sequenced L2 block once the sequencer selects an L1
+// origin at or past the deposit's L1 block. This pins the sequencer's forced
+// transaction prefix (L1-info + user deposits from the selected origin) and its
+// drift-based L1-origin selection — if origins stopped advancing, the deposit
+// would never be included.
+func TestOpConSequencerIncludesDeposits(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewMinimalNoFaultProofs(t, opConSequencerOpt())
+
+	sys.L1Network.WaitForOnline()
+
+	// Fund Alice on L1 and deposit through the portal.
+	fundingAmount := eth.ThreeHundredthsEther
+	alice := sys.FunderL1.NewFundedEOA(fundingAmount)
+	alice.WaitForBalance(fundingAmount)
+
+	aliceL2 := alice.AsEL(sys.L2EL)
+	initialL2Balance := aliceL2.GetBalance()
+
+	rollupConfig := sys.L2Chain.Escape().RollupConfig()
+	portalAddr := rollupConfig.DepositContractAddress
+	depositAmount := eth.OneHundredthEther
+
+	portal := bindings.NewBindings[bindings.OptimismPortal2](
+		bindings.WithClient(sys.L2EL.Escape().EthClient()),
+		bindings.WithTo(portalAddr),
+		bindings.WithTest(t))
+	args := portal.DepositTransaction(alice.Address(), depositAmount, 300_000, false, []byte{})
+	receipt := contract.Write(alice, args, txplan.WithValue(depositAmount))
+
+	// The sequencer's L1 origin advances past the deposit's L1 block, forcing
+	// the deposit into a sequenced block.
+	t.Require().Eventually(func() bool {
+		head := sys.L2CL.HeadBlockRef(types.LocalUnsafe)
+		return head.L1Origin.Number >= bigs.Uint64Strict(receipt.BlockNumber)
+	}, sys.L1EL.TransactionTimeout(), time.Second, "awaiting deposit to be processed by L2")
+
+	aliceL2.WaitForBalance(initialL2Balance.Add(depositAmount))
+}
+
+// TestOpConSequencerStopsAndResumes exercises the sequencer control plane
+// (admin_stopSequencer / admin_startSequencer / admin_sequencerActive — the
+// same RPCs op-node serves, called through the shared DSL): stopping the
+// sequencer halts unsafe block production, and restarting it resumes
+// production from the halted head. There is no dedicated op-node acceptance
+// test for this loop (it only appears inside larger scenarios), so this also
+// covers the op-node path when run with the default CL kind.
+func TestOpConSequencerStopsAndResumes(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewMinimalNoFaultProofs(t, opConSequencerOpt())
+	blockTime := sys.L2Chain.Escape().RollupConfig().BlockTime
+
+	// The sequencer is live before we stop it.
+	sys.L2CL.Advanced(types.LocalUnsafe, 2, 60)
+
+	// Stop sequencing. In-flight builds may still land just after the stop is
+	// acknowledged, so first wait for the unsafe head to hold still across one
+	// block time, then require it to stay there for several more.
+	sys.L2CL.StopSequencer()
+	var stalledUnsafe uint64
+	require.Eventually(t, func() bool {
+		head := sys.L2CL.SyncStatus().UnsafeL2.Number
+		if stalledUnsafe == 0 || head != stalledUnsafe {
+			stalledUnsafe = head
+			return false
+		}
+		return true
+	}, time.Duration(blockTime*20)*time.Second, time.Duration(blockTime)*time.Second,
+		"unsafe head did not stop advancing after StopSequencer")
+
+	const stableSamples = 3
+	for range stableSamples {
+		time.Sleep(time.Duration(blockTime) * time.Second)
+		require.Equal(t, stalledUnsafe, sys.L2CL.SyncStatus().UnsafeL2.Number,
+			"sequencer kept producing blocks after StopSequencer")
+	}
+
+	// Restart sequencing from the halted head; production resumes.
+	sys.L2CL.StartSequencer()
+	require.Eventually(t, func() bool {
+		return sys.L2CL.SyncStatus().UnsafeL2.Number > stalledUnsafe
+	}, time.Duration(blockTime*30)*time.Second, time.Second,
+		"sequencer did not resume producing blocks after StartSequencer")
+}
+
+// TestOpConSequencerRecoverModeStaysLive is the op-con-node sequencer analogue
+// of the op-node recover-mode test (TestRecoverModeWhenChainHealthy): enabling
+// recover mode (admin_setRecoverMode) on a healthy chain must not stall block
+// production. In recover mode op-con-node sequences deposit-only blocks
+// (user transactions are excluded), but the unsafe chain keeps advancing.
+func TestOpConSequencerRecoverModeStaysLive(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewMinimalNoFaultProofs(t, opConSequencerOpt())
+
+	t.Require().NoError(sys.L2CL.SetSequencerRecoverMode(true))
+
+	blockTime := sys.L2Chain.Escape().RollupConfig().BlockTime
+	numL2Blocks := uint64(10)
+	waitTime := time.Duration(blockTime*numL2Blocks+15) * time.Second
+
+	start := sys.L2CL.SyncStatus().UnsafeL2.Number
+	require.Eventually(t, func() bool {
+		return sys.L2CL.SyncStatus().UnsafeL2.Number >= start+numL2Blocks
+	}, waitTime, time.Duration(blockTime)*time.Second,
+		"unsafe head stalled with recover mode enabled on a healthy chain")
+}

--- a/op-acceptance-tests/tests/opcon/verifier_test.go
+++ b/op-acceptance-tests/tests/opcon/verifier_test.go
@@ -188,3 +188,34 @@ func TestOpConVerifierResumesAfterRestart(gt *testing.T) {
 	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 90)
 	sys.L2CLB.Advanced(types.LocalSafe, 1, 60)
 }
+
+// TestOpConVerifierFollowMode is the op-con-node analogue of the op-node
+// sync/follow_l2 test (which skips kona — "single-chain test sequencer requires
+// an op-node CL node"). op-node's CL follow source has no direct op-con-node
+// equivalent, but op-con-node's own follow mode (--l2-follow-rpc, pointed at the
+// sequencer's L2 execution RPC) is the same idea: the verifier's unsafe head
+// tracks the sequencer via the follow source while its safe head derives from L1.
+//
+// This asserts that follow-mode kernel against op-con-node: the unsafe head
+// advances and stays in sync via follow-mode (no P2P, no sidecar), the safe head
+// converges via L1 derivation, and CurrentL1 (optimism_syncStatus) tracks the
+// sequencer. With the default op-node verifier it is an ordinary follow-source
+// sync check, so it remains a valid suite addition.
+func TestOpConVerifierFollowMode(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck(t)
+
+	target := uint64(3)
+	attempts := 60
+
+	// Unsafe head tracks the sequencer via follow-mode; safe head derives from L1.
+	dsl.CheckAll(t,
+		sys.L2CL.ReachedFn(types.LocalUnsafe, target, attempts),
+		sys.L2CLB.ReachedFn(types.LocalUnsafe, target, attempts),
+	)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalUnsafe, attempts)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, attempts)
+
+	// CurrentL1 (from optimism_syncStatus) follows the source.
+	dsl.CheckAll(t, sys.L2CLB.CurrentL1MatchedFn(sys.L2CL, 20))
+}

--- a/op-acceptance-tests/tests/opcon/verifier_test.go
+++ b/op-acceptance-tests/tests/opcon/verifier_test.go
@@ -1,0 +1,40 @@
+package opcon
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// TestOpConVerifierDerivesSafeHead exercises a consensus-only verifier that
+// derives the safe L2 chain purely from L1, with no CL P2P and no follow
+// source. The op-node sequencer (L2CL) produces blocks, the batcher lands them
+// on L1, and the verifier (L2CLB) must derive the same safe chain and stay in
+// sync.
+//
+// This is the minimal target for running op-con-node as the verifier:
+//
+//	DEVSTACK_L2CL_KIND=op-con-node \
+//	DEVSTACK_L2EL_KIND=op-reth \
+//	RUST_BINARY_PATH_OP_CON_NODE=<opql>/target/debug/op-con-node \
+//	go test -run TestOpConVerifierDerivesSafeHead ./op-acceptance-tests/tests/opcon/
+//
+// With the default op-node CL kind it is an ordinary L1-derivation sync check,
+// so it is a valid suite addition rather than an op-con-node-only test. The
+// without-P2P multinode preset is used deliberately: op-con-node has no P2P
+// gossip, so the verifier's only data source is L1 derivation (driving its own
+// execution engine over the Engine API).
+func TestOpConVerifierDerivesSafeHead(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck(t)
+
+	// The sequencer produces blocks and the batcher submits them to L1.
+	sys.L2CL.Advanced(types.LocalSafe, 1, 60)
+
+	// The verifier derives the safe chain from L1 and converges on the
+	// sequencer's safe head.
+	sys.L2CLB.Advanced(types.LocalSafe, 1, 60)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 60)
+}

--- a/op-acceptance-tests/tests/opcon/verifier_test.go
+++ b/op-acceptance-tests/tests/opcon/verifier_test.go
@@ -223,30 +223,29 @@ func TestOpConVerifierFollowMode(gt *testing.T) {
 }
 
 // TestOpConVerifierRecoversFromL1Reorg is the op-con-node variant of the op-node
-// L1-reorg-recovery tests (sync/follow_l2 TestFollowL2_ReorgRecovery /
-// sync/elsync/reorg): an L1 reorg must reset op-con-node's derivation pipeline and
-// re-derive the safe chain on the new canonical L1.
+// L1-reorg-recovery test (sync/elsync/reorg TestUnsafeGapFillAfterSafeReorg): an
+// L1 reorg must reset op-con-node's derivation pipeline and re-derive the safe
+// chain on the new canonical L1.
 //
 // The verifier is bare (no follow/unsafe source) so it derives only the safe
-// chain from L1 — the property under test — without a follow source confounding
-// it. Using the test-sequencer's L1 control: stop auto-advancing L1, drive it
-// until the verifier has derived a safe block whose L1 origin we can reorg,
-// rebuild that L1 block on a different parent (reorg), confirm the L1 reorg took,
-// then assert the verifier re-derives the same canonical block as the sequencer
-// at that height. Exercises op-con-node's canonical-L1-tracker reorg handling.
+// chain from L1 — the property under test. Mirroring the op-node test, the reorg
+// targets the SEQUENCER's safe head: its L1 origin tracks near the L1 head, so the
+// single-block fork (built via the test-sequencer + auto-advance) is shallow
+// enough to win the fork choice. Targeting the verifier's safe origin instead
+// fails — op-con-node's safe head lags L1 during catch-up, so that origin is deep
+// and a short fork there loses to the longer canonical chain. We additionally
+// wait for the (lagging) op-con-node verifier to reach the reorg target so the
+// reorg invalidates a block it actually derived. Exercises op-con-node's
+// canonical-L1-tracker reorg handling + safe re-derivation onto the new L1.
+//
+// This caught a real op-con-node freeze (since fixed): the reorg path wrote its L1
+// horizon row keyed by a fresh PayloadId instead of the reorg's max block number,
+// so that row permanently won the horizon's ARG_MAX and pinned visible L1 at the
+// reorg boundary — every block appended after the reorg stayed invisible to
+// derivation and the safe chain froze. Fixed in op-con-node row_writers.rs
+// (apply_canonical_l1_delta keys the horizon row by max_input_id, matching the
+// append path). See docs/sidecar-p2p-design.md.
 func TestOpConVerifierRecoversFromL1Reorg(gt *testing.T) {
-	// Skipped: a test-harness limitation, NOT an op-con-node bug. Instrumenting
-	// op-con-node's L1 source showed it correctly follows the canonical L1 chain
-	// (contiguous tip advancement, parent always matching tip). The failure is that
-	// the devstack test-sequencer cannot reliably inject a *deep, winning* L1
-	// reorg: ts.Next builds on the canonical head, and the safe block's L1 origin
-	// sits far below the L1 head (the safe head lags L1 by ~the seq window during
-	// catch-up), so a short fork at that deep height loses the fork choice to the
-	// longer canonical chain — op-con-node never sees a lasting reorg. Re-enabling
-	// needs a harness that builds the fork longer than the pre-reorg chain (e.g.
-	// repeated ts.New on the fork tip) so it wins.
-	gt.Skip("devstack test-sequencer cannot inject a deep winning L1 reorg; op-con-node was observed following canonical L1 correctly")
-
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSingleChainMultiNodeNoFaultProofsBareVerifierWithTestSeqWithoutCheck(t)
 	require := t.Require()
@@ -260,21 +259,25 @@ func TestOpConVerifierRecoversFromL1Reorg(gt *testing.T) {
 	sys.L1CL.Stop()
 	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 
-	// Advance L1 until the verifier's safe head has an L1 origin past the start
-	// block (so it has derived against a block we are about to reorg).
+	// Advance L1 until the SEQUENCER's safe head has an L1 origin past the start
+	// block. The sequencer's safe origin stays near the L1 head (small lag), which
+	// keeps the reorg shallow enough to win.
 	require.Eventually(func() bool {
 		if err := ts.Next(ctx); err != nil {
 			logger.Warn("ts.Next failed, will retry", "err", err)
 			return false
 		}
-		l2Safe := sys.L2ELB.BlockRefByLabel(eth.Safe)
-		logger.Info("driving L1", "l1_head", sys.L1EL.BlockRefByLabel(eth.Unsafe), "l2_safe", l2Safe)
+		l2Safe := sys.L2EL.BlockRefByLabel(eth.Safe)
+		logger.Info("driving L1", "l1_head", sys.L1EL.BlockRefByLabel(eth.Unsafe), "seq_safe", l2Safe)
 		return l2Safe.Number > 0 && l2Safe.L1Origin.Number > startL1Block.Number
 	}, 120*time.Second, 2*time.Second)
 
-	l2BlockBeforeReorg := sys.L2ELB.BlockRefByLabel(eth.Safe)
-	sys.L2ELB.Reached(eth.Safe, l2BlockBeforeReorg.Number, 3)
-	logger.Info("verifier safe head before reorg", "l2", l2BlockBeforeReorg, "l1_origin", l2BlockBeforeReorg.L1Origin)
+	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Safe)
+	logger.Info("target safe block to reorg", "l2", l2BlockBeforeReorg, "l1_origin", l2BlockBeforeReorg.L1Origin)
+
+	// Wait for the (lagging) op-con-node verifier to also derive this safe block,
+	// so the reorg invalidates a block it actually produced.
+	sys.L2ELB.Reached(eth.Safe, l2BlockBeforeReorg.Number, 60)
 
 	// Reorg the L1 block that the safe block's L1 origin points to.
 	l1BlockBeforeReorg := sys.L1EL.BlockRefByNumber(l2BlockBeforeReorg.L1Origin.Number)
@@ -283,35 +286,23 @@ func TestOpConVerifierRecoversFromL1Reorg(gt *testing.T) {
 	require.NoError(ts.Next(ctx))
 	sys.L1CL.Start()
 
-	// Confirm the L1 reorg actually took (the new fork won at that height) before
-	// expecting an L2 reorg.
-	require.Eventually(func() bool {
-		l1After := sys.L1EL.BlockRefByNumber(l1BlockBeforeReorg.Number)
-		logger.Info("waiting for L1 reorg", "before", l1BlockBeforeReorg, "current", l1After)
-		return l1After.Hash != l1BlockBeforeReorg.Hash
-	}, 90*time.Second, 2*time.Second)
-	logger.Info("L1 reorg confirmed")
+	// Confirm the L1 reorg took (the new fork won at that height).
+	sys.L1EL.WaitForBlockNumber(l1BlockBeforeReorg.Number)
+	l1BlockAfterReorg := sys.L1EL.BlockRefByNumber(l1BlockBeforeReorg.Number)
+	require.NotEqual(l1BlockAfterReorg.Hash, l1BlockBeforeReorg.Hash)
+	logger.Info("L1 reorg confirmed", "l1", l1BlockAfterReorg)
 
-	// op-con-node detects the L1 reorg, resets derivation, and re-derives: its
-	// block at the reorged height changes (it reacted, did not wedge).
-	require.Eventually(func() bool {
-		verAfter := sys.L2ELB.BlockRefByNumber(l2BlockBeforeReorg.Number)
-		logger.Info("waiting for op-con-node L2 reorg", "before", l2BlockBeforeReorg, "current", verAfter)
-		return verAfter.Hash != l2BlockBeforeReorg.Hash
-	}, 120*time.Second, 2*time.Second)
-	logger.Info("op-con-node re-derived after L1 reorg")
+	// The sequencer's safe head switches onto the new L1 chain. The reorg drops
+	// several L1 blocks (the safe origin structurally lags the L1 head by the
+	// batcher channel window), so the sequencer's batcher must re-submit a handful
+	// of epochs of batches against the new L1 before its safe head advances —
+	// allow a generous budget. op-con-node stays live throughout (unlike op-node's
+	// reference test, which stops its verifier to free CPU during this window).
+	sys.L2EL.WaitL1OriginHash(eth.Safe, l1BlockAfterReorg.ID(), 90)
 
-	// Let both safe chains advance well past the reorged height so the block there
-	// is deeply safe (immutable), then assert op-con-node derived the same
-	// canonical block as the sequencer — i.e. it re-derived the correct new chain.
-	// (op-node's own reorg test likewise checks eventual convergence rather than
-	// the immediate post-reorg block, which races the live sequencer.)
-	settleTarget := l2BlockBeforeReorg.Number + 5
-	sys.L2CL.Reached(types.LocalSafe, settleTarget, 90)
-	sys.L2CLB.Reached(types.LocalSafe, settleTarget, 90)
-	require.Equal(
-		sys.L2EL.BlockRefByNumber(l2BlockBeforeReorg.Number).Hash,
-		sys.L2ELB.BlockRefByNumber(l2BlockBeforeReorg.Number).Hash,
-		"op-con-node and sequencer must agree on the post-reorg canonical block",
-	)
+	// op-con-node detects the L1 reorg, resets derivation, and re-derives the new
+	// safe chain: its block at the reorged height is replaced, and its safe head
+	// converges with the sequencer's.
+	sys.L2ELB.ReorgTriggered(l2BlockBeforeReorg, 90)
+	sys.L2ELB.InSync(sys.L2EL, eth.Safe, 90)
 }

--- a/op-acceptance-tests/tests/opcon/verifier_test.go
+++ b/op-acceptance-tests/tests/opcon/verifier_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -66,4 +68,41 @@ func TestOpConVerifierViaP2P(gt *testing.T) {
 	// sequencer's unsafe head.
 	sys.L2CLB.Advanced(types.LocalUnsafe, 1, 60)
 	sys.L2CLB.InSync(sys.L2CL, types.LocalUnsafe, 60)
+}
+
+// TestOpConVerifierSafeHeadDatabaseMatches is the op-con-node variant of the
+// op-node safeheaddb_clsync verifier test (TestPreserveDatabaseOnCLResync). That
+// test was previously unreachable for op-con-node because it requires the
+// verifier to sync over P2P; with the op-conp2p sidecar it now is.
+//
+// It exercises a real op-node verifier assertion against op-con-node:
+// VerifySafeHeadDatabaseMatches compares optimism_safeHeadAtL1Block on the
+// verifier against the op-node sequencer's SafeDB. op-con-node serves it from its
+// SQL-derived rollup_rpc_safe_head_at_l1_history, so the two must agree.
+//
+// With the default op-node verifier kind this is an ordinary safe-head-DB parity
+// check, so it remains a valid suite addition rather than an op-con-node-only test.
+func TestOpConVerifierSafeHeadDatabaseMatches(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainMultiNodeNoFaultProofsWithP2PWithoutCheck(t,
+		presets.WithGlobalL2CLOption(sysgo.L2CLOptionFn(func(p devtest.T, _ sysgo.ComponentTarget, cfg *sysgo.L2CLConfig) {
+			// Enable the op-node sequencer's SafeDB so it can answer
+			// optimism_safeHeadAtL1Block as the source of truth. (The op-con-node
+			// verifier serves its own from SQL and needs no file path.)
+			cfg.SafeDBPath = p.TempDir()
+		})),
+	)
+
+	// The op-node sequencer batches blocks to L1; both it and the op-con-node
+	// verifier advance their safe heads (the verifier derives safe from L1 and
+	// gets unsafe over P2P via the sidecar).
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 60),
+		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 60),
+	)
+
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 60)
+
+	// The verifier's safe-head-at-L1 history must match the sequencer's SafeDB.
+	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 }

--- a/op-acceptance-tests/tests/opcon/verifier_test.go
+++ b/op-acceptance-tests/tests/opcon/verifier_test.go
@@ -235,13 +235,17 @@ func TestOpConVerifierFollowMode(gt *testing.T) {
 // then assert the verifier re-derives the same canonical block as the sequencer
 // at that height. Exercises op-con-node's canonical-L1-tracker reorg handling.
 func TestOpConVerifierRecoversFromL1Reorg(gt *testing.T) {
-	// Skipped: this surfaced an op-con-node L1-reorg handling gap — after a
-	// confirmed L1 reorg, a safe block whose L1 origin was reorged is not reliably
-	// re-derived (sometimes unchanged within 2min, sometimes re-derived to a block
-	// the sequencer disagrees with). That is an op-con-node derivation issue
-	// (canonical-L1-tracker invalidation / re-derivation), not test wiring; the
-	// preset + test are kept wired to re-enable once it is fixed.
-	gt.Skip("op-con-node does not yet reliably re-derive safe blocks whose L1 origin is reorged")
+	// Skipped: a test-harness limitation, NOT an op-con-node bug. Instrumenting
+	// op-con-node's L1 source showed it correctly follows the canonical L1 chain
+	// (contiguous tip advancement, parent always matching tip). The failure is that
+	// the devstack test-sequencer cannot reliably inject a *deep, winning* L1
+	// reorg: ts.Next builds on the canonical head, and the safe block's L1 origin
+	// sits far below the L1 head (the safe head lags L1 by ~the seq window during
+	// catch-up), so a short fork at that deep height loses the fork choice to the
+	// longer canonical chain — op-con-node never sees a lasting reorg. Re-enabling
+	// needs a harness that builds the fork longer than the pre-reorg chain (e.g.
+	// repeated ts.New on the fork tip) so it wins.
+	gt.Skip("devstack test-sequencer cannot inject a deep winning L1 reorg; op-con-node was observed following canonical L1 correctly")
 
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSingleChainMultiNodeNoFaultProofsBareVerifierWithTestSeqWithoutCheck(t)

--- a/op-acceptance-tests/tests/opcon/verifier_test.go
+++ b/op-acceptance-tests/tests/opcon/verifier_test.go
@@ -2,6 +2,7 @@ package opcon
 
 import (
 	"testing"
+	"time"
 
 	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -10,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
 
 // TestOpConVerifierDerivesSafeHead exercises a consensus-only verifier that
@@ -218,4 +220,94 @@ func TestOpConVerifierFollowMode(gt *testing.T) {
 
 	// CurrentL1 (from optimism_syncStatus) follows the source.
 	dsl.CheckAll(t, sys.L2CLB.CurrentL1MatchedFn(sys.L2CL, 20))
+}
+
+// TestOpConVerifierRecoversFromL1Reorg is the op-con-node variant of the op-node
+// L1-reorg-recovery tests (sync/follow_l2 TestFollowL2_ReorgRecovery /
+// sync/elsync/reorg): an L1 reorg must reset op-con-node's derivation pipeline and
+// re-derive the safe chain on the new canonical L1.
+//
+// The verifier is bare (no follow/unsafe source) so it derives only the safe
+// chain from L1 — the property under test — without a follow source confounding
+// it. Using the test-sequencer's L1 control: stop auto-advancing L1, drive it
+// until the verifier has derived a safe block whose L1 origin we can reorg,
+// rebuild that L1 block on a different parent (reorg), confirm the L1 reorg took,
+// then assert the verifier re-derives the same canonical block as the sequencer
+// at that height. Exercises op-con-node's canonical-L1-tracker reorg handling.
+func TestOpConVerifierRecoversFromL1Reorg(gt *testing.T) {
+	// Skipped: this surfaced an op-con-node L1-reorg handling gap — after a
+	// confirmed L1 reorg, a safe block whose L1 origin was reorged is not reliably
+	// re-derived (sometimes unchanged within 2min, sometimes re-derived to a block
+	// the sequencer disagrees with). That is an op-con-node derivation issue
+	// (canonical-L1-tracker invalidation / re-derivation), not test wiring; the
+	// preset + test are kept wired to re-enable once it is fixed.
+	gt.Skip("op-con-node does not yet reliably re-derive safe blocks whose L1 origin is reorged")
+
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainMultiNodeNoFaultProofsBareVerifierWithTestSeqWithoutCheck(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	sys.L1Network.WaitForBlock() // pass the L1 genesis
+
+	// Drive L1 deterministically so we can reorg it.
+	sys.L1CL.Stop()
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+
+	// Advance L1 until the verifier's safe head has an L1 origin past the start
+	// block (so it has derived against a block we are about to reorg).
+	require.Eventually(func() bool {
+		if err := ts.Next(ctx); err != nil {
+			logger.Warn("ts.Next failed, will retry", "err", err)
+			return false
+		}
+		l2Safe := sys.L2ELB.BlockRefByLabel(eth.Safe)
+		logger.Info("driving L1", "l1_head", sys.L1EL.BlockRefByLabel(eth.Unsafe), "l2_safe", l2Safe)
+		return l2Safe.Number > 0 && l2Safe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
+
+	l2BlockBeforeReorg := sys.L2ELB.BlockRefByLabel(eth.Safe)
+	sys.L2ELB.Reached(eth.Safe, l2BlockBeforeReorg.Number, 3)
+	logger.Info("verifier safe head before reorg", "l2", l2BlockBeforeReorg, "l1_origin", l2BlockBeforeReorg.L1Origin)
+
+	// Reorg the L1 block that the safe block's L1 origin points to.
+	l1BlockBeforeReorg := sys.L1EL.BlockRefByNumber(l2BlockBeforeReorg.L1Origin.Number)
+	logger.Info("triggering L1 reorg", "l1", l1BlockBeforeReorg)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1BlockBeforeReorg.ParentHash}))
+	require.NoError(ts.Next(ctx))
+	sys.L1CL.Start()
+
+	// Confirm the L1 reorg actually took (the new fork won at that height) before
+	// expecting an L2 reorg.
+	require.Eventually(func() bool {
+		l1After := sys.L1EL.BlockRefByNumber(l1BlockBeforeReorg.Number)
+		logger.Info("waiting for L1 reorg", "before", l1BlockBeforeReorg, "current", l1After)
+		return l1After.Hash != l1BlockBeforeReorg.Hash
+	}, 90*time.Second, 2*time.Second)
+	logger.Info("L1 reorg confirmed")
+
+	// op-con-node detects the L1 reorg, resets derivation, and re-derives: its
+	// block at the reorged height changes (it reacted, did not wedge).
+	require.Eventually(func() bool {
+		verAfter := sys.L2ELB.BlockRefByNumber(l2BlockBeforeReorg.Number)
+		logger.Info("waiting for op-con-node L2 reorg", "before", l2BlockBeforeReorg, "current", verAfter)
+		return verAfter.Hash != l2BlockBeforeReorg.Hash
+	}, 120*time.Second, 2*time.Second)
+	logger.Info("op-con-node re-derived after L1 reorg")
+
+	// Let both safe chains advance well past the reorged height so the block there
+	// is deeply safe (immutable), then assert op-con-node derived the same
+	// canonical block as the sequencer — i.e. it re-derived the correct new chain.
+	// (op-node's own reorg test likewise checks eventual convergence rather than
+	// the immediate post-reorg block, which races the live sequencer.)
+	settleTarget := l2BlockBeforeReorg.Number + 5
+	sys.L2CL.Reached(types.LocalSafe, settleTarget, 90)
+	sys.L2CLB.Reached(types.LocalSafe, settleTarget, 90)
+	require.Equal(
+		sys.L2EL.BlockRefByNumber(l2BlockBeforeReorg.Number).Hash,
+		sys.L2ELB.BlockRefByNumber(l2BlockBeforeReorg.Number).Hash,
+		"op-con-node and sequencer must agree on the post-reorg canonical block",
+	)
 }

--- a/op-acceptance-tests/tests/opcon/verifier_test.go
+++ b/op-acceptance-tests/tests/opcon/verifier_test.go
@@ -222,6 +222,63 @@ func TestOpConVerifierFollowMode(gt *testing.T) {
 	dsl.CheckAll(t, sys.L2CLB.CurrentL1MatchedFn(sys.L2CL, 20))
 }
 
+// TestOpConVerifierFollowModeFinalized is the op-con-node analogue of the op-node
+// sync/follow_l2 test TestFollowL2_Safe_Finalized_CurrentL1. It extends
+// TestOpConVerifierFollowMode with the FINALIZED head: the verifier's unsafe head
+// (follow mode), safe head (L1 derivation), AND finalized head must all advance to
+// the target and converge with the sequencer, plus CurrentL1 tracking.
+//
+// The finalized head is the property under test. op-con-node finalizes by the
+// batch-inclusion L1 block — the canonical OP finality rule: an L2 block is final
+// once the L1 data (its batch) proving it is final. (finalized_head in
+// engine_boundary/module.sql gates the highest derived block on
+// `l1_inclusion_input_id <= finalized L1`, the batch-inclusion L1 coordinate.) This
+// matches op-node, so exact finalized parity holds. An earlier revision keyed on the
+// L2 block's L1 *origin*, which runs ~a batch-window ahead of op-node and finalizes
+// before the L1 data proving the block is final — that gap is what this test caught
+// and the finalized_head fix closes.
+//
+// The devstack op-con-node default is --l1-finalized-guard=disabled (so startup never
+// blocks on a finalized tag against a non-finalizing L1), which suppresses the
+// finalized L1 status ref entirely. This test runs against a finalizing devstack L1,
+// so it sets the per-node OpConL1FinalizedGuard="required" to make op-con-node track
+// L1 finality and advance its L2 finalized head.
+//
+// With the default op-node verifier kind it is an ordinary follow-source safe/
+// finalized/CurrentL1 sync check, so it remains a valid suite addition.
+func TestOpConVerifierFollowModeFinalized(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+
+	// Make op-con-node track L1 finality (devstack default is disabled). Per-node via
+	// the L2CL option, so parallel sibling tests keep the non-finalizing default.
+	sys := presets.NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck(t,
+		presets.WithGlobalL2CLOption(sysgo.L2CLOptionFn(func(_ devtest.T, _ sysgo.ComponentTarget, cfg *sysgo.L2CLConfig) {
+			cfg.OpConL1FinalizedGuard = "required"
+		})),
+	)
+	logger := t.Logger()
+
+	target := uint64(3)
+	// L1 finalization takes ~2 minutes in the devstack, so the finalized head needs a
+	// generous budget; ReachedFn/InSyncFn poll every 2s.
+	attempts := 90
+
+	// Unsafe (follow mode), safe (L1 derivation), and finalized (L1 finality) heads
+	// must each reach the target on both the sequencer and the op-con-node verifier,
+	// and the verifier must stay in sync with the sequencer at each level.
+	for _, lvl := range []types.SafetyLevel{types.LocalUnsafe, types.LocalSafe, types.Finalized} {
+		dsl.CheckAll(t,
+			sys.L2CL.ReachedFn(lvl, target, attempts),
+			sys.L2CLB.ReachedFn(lvl, target, attempts),
+		)
+		sys.L2CLB.InSync(sys.L2CL, lvl, attempts)
+		logger.Info("head reached + in sync", "level", lvl, "target", target)
+	}
+
+	// CurrentL1 (from optimism_syncStatus) follows the source.
+	dsl.CheckAll(t, sys.L2CLB.CurrentL1MatchedFn(sys.L2CL, 20))
+}
+
 // TestOpConVerifierRecoversFromL1Reorg is the op-con-node variant of the op-node
 // L1-reorg-recovery test (sync/elsync/reorg TestUnsafeGapFillAfterSafeReorg): an
 // L1 reorg must reset op-con-node's derivation pipeline and re-derive the safe

--- a/op-acceptance-tests/tests/opcon/verifier_test.go
+++ b/op-acceptance-tests/tests/opcon/verifier_test.go
@@ -38,3 +38,32 @@ func TestOpConVerifierDerivesSafeHead(gt *testing.T) {
 	sys.L2CLB.Advanced(types.LocalSafe, 1, 60)
 	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 60)
 }
+
+// TestOpConVerifierViaP2P exercises the op-conp2p P2P sidecar end to end: the
+// op-node sequencer publishes unsafe blocks over gossip, the op-conp2p sidecar
+// (peered to the sequencer) receives them and delegates each block's signature
+// verdict back to the op-con-node verifier's admin_verifyUnsafePayload, which
+// ingests accepted blocks and drives its execution engine. The verifier's UNSAFE
+// head must advance and converge on the sequencer's unsafe head — purely over
+// P2P, with no follow source.
+//
+//	DEVSTACK_L2CL_KIND=op-con-node \
+//	DEVSTACK_L2EL_KIND=op-reth \
+//	RUST_BINARY_PATH_OP_CON_NODE=<opql>/target/debug/op-con-node \
+//	OP_CONP2P_BIN=<optimism>/op-conp2p-bin \
+//	go test -run TestOpConVerifierViaP2P ./op-acceptance-tests/tests/opcon/
+//
+// With the default op-node verifier kind it is an ordinary with-P2P unsafe-sync
+// check, so it remains a valid suite addition rather than an op-con-node-only test.
+func TestOpConVerifierViaP2P(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainMultiNodeNoFaultProofsWithP2PWithoutCheck(t)
+
+	// The sequencer produces and gossips unsafe blocks.
+	sys.L2CL.Advanced(types.LocalUnsafe, 1, 60)
+
+	// The verifier receives them over P2P (via the sidecar) and converges on the
+	// sequencer's unsafe head.
+	sys.L2CLB.Advanced(types.LocalUnsafe, 1, 60)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalUnsafe, 60)
+}

--- a/op-acceptance-tests/tests/opcon/verifier_test.go
+++ b/op-acceptance-tests/tests/opcon/verifier_test.go
@@ -3,10 +3,12 @@ package opcon
 import (
 	"testing"
 
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -106,3 +108,61 @@ func TestOpConVerifierSafeHeadDatabaseMatches(gt *testing.T) {
 	// The verifier's safe-head-at-L1 history must match the sequencer's SafeDB.
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 }
+
+// TestOpConVerifierFillsUnsafeGaps is the op-con-node variant of the op-node
+// sync/clsync/gap_clp2p test (TestSyncAfterInitialELSync): unsafe payloads posted
+// out of order must be applied in order, with the canonical head only advancing
+// once each gap is filled.
+//
+// The verifier is bare (no follow source, no P2P); the batcher is stopped so the
+// safe head never advances and the unsafe head is driven purely by the posted
+// payloads (admin_postUnsafePayload). op-con-node stores posted payloads and its
+// SQL keeps only the contiguous valid prefix, so the head advances exactly when
+// the gap closes — the same observable behavior as op-node's unsafe-payload queue.
+//
+// Valid suite addition: with the default op-node verifier it exercises op-node's
+// own out-of-order unsafe-payload handling.
+func TestOpConVerifierFillsUnsafeGaps(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainMultiNodeNoFaultProofsBareVerifierWithoutCheck(t,
+		presets.WithBatcherOption(func(_ sysgo.ComponentTarget, cfg *bss.CLIConfig) {
+			// Stop derivation so the safe head never advances; the unsafe head is
+			// driven solely by the payloads this test posts.
+			cfg.Stopped = true
+		}),
+	)
+	require := t.Require()
+
+	// Sequencer produces unsafe blocks the test will hand to the verifier.
+	sys.L2CL.Advanced(types.LocalUnsafe, 7, 30)
+	require.Zero(sys.L2CL.HeadBlockRef(types.LocalSafe).Number)
+	require.Zero(sys.L2CLB.HeadBlockRef(types.LocalSafe).Number)
+
+	startNum := sys.L2CLB.HeadBlockRef(types.LocalUnsafe).Number
+
+	// Supply the first block; the verifier applies it and its head advances by 1.
+	sys.L2CLB.SignalTarget(sys.L2EL, startNum+1)
+	sys.L2ELB.WaitForBlockNumber(startNum + 1)
+
+	// Post later blocks out of order with a gap at startNum+2: the head must stay.
+	for _, delta := range []uint64{5, 3, 4, 7} {
+		sys.L2CLB.SignalTarget(sys.L2EL, startNum+delta)
+		require.Equal(startNum+1, sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number)
+	}
+
+	// Fill the gap at startNum+2: the contiguous run startNum+1..startNum+5 becomes
+	// canonical (startNum+7 still waits behind the gap at startNum+6).
+	sys.L2CLB.SignalTarget(sys.L2EL, startNum+2)
+	sys.L2ELB.Reached(eth.Unsafe, startNum+5, 2)
+
+	// Fill the last gap at startNum+6: startNum+6, startNum+7 become canonical.
+	sys.L2CLB.SignalTarget(sys.L2EL, startNum+6)
+	sys.L2ELB.Reached(eth.Unsafe, startNum+7, 2)
+}
+
+// NOTE: a verifier restart/resync variant (the op-con-node analogue of the
+// restart half of the op-node safeheaddb_clsync test) is intentionally NOT added
+// here yet: it surfaced a pre-existing op-con-node restore-from-checkpoint panic
+// ("More than one value in subquery", an integer scalar subquery in the generated
+// circuit on the restore path) that is unrelated to the sidecar P2P work. Add the
+// restart variant once that restore bug is fixed.

--- a/op-acceptance-tests/tests/opcon/verifier_test.go
+++ b/op-acceptance-tests/tests/opcon/verifier_test.go
@@ -160,9 +160,31 @@ func TestOpConVerifierFillsUnsafeGaps(gt *testing.T) {
 	sys.L2ELB.Reached(eth.Unsafe, startNum+7, 2)
 }
 
-// NOTE: a verifier restart/resync variant (the op-con-node analogue of the
-// restart half of the op-node safeheaddb_clsync test) is intentionally NOT added
-// here yet: it surfaced a pre-existing op-con-node restore-from-checkpoint panic
-// ("More than one value in subquery", an integer scalar subquery in the generated
-// circuit on the restore path) that is unrelated to the sidecar P2P work. Add the
-// restart variant once that restore bug is fixed.
+// TestOpConVerifierResumesAfterRestart is the op-con-node analogue of the verifier
+// restart in the op-node safeheaddb_clsync test: the verifier is stopped while the
+// sequencer keeps batching to L1, then restarted and must resume from its shutdown
+// checkpoint and catch back up to the safe head. (op-con-node re-derives its safe
+// head from L1 rather than reading a persisted SafeDB, so this exercises restart
+// resume + re-derivation through the Feldera checkpoint restore path.)
+func TestOpConVerifierResumesAfterRestart(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck(t)
+
+	// Verifier derives the safe chain from L1 and converges on the sequencer.
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 60),
+		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 60),
+	)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 60)
+
+	// Stop the verifier (writing a shutdown checkpoint); the sequencer keeps
+	// batching to L1.
+	sys.L2CLB.Stop()
+	sys.L2CL.Advanced(types.LocalSafe, 3, 60)
+
+	// Restart the verifier; it restores from the checkpoint, re-derives from L1,
+	// and catches back up to the sequencer's safe head.
+	sys.L2CLB.Start()
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 90)
+	sys.L2CLB.Advanced(types.LocalSafe, 1, 60)
+}

--- a/op-acceptance-tests/tests/opcon/verifier_test.go
+++ b/op-acceptance-tests/tests/opcon/verifier_test.go
@@ -306,3 +306,103 @@ func TestOpConVerifierRecoversFromL1Reorg(gt *testing.T) {
 	sys.L2ELB.ReorgTriggered(l2BlockBeforeReorg, 90)
 	sys.L2ELB.InSync(sys.L2EL, eth.Safe, 90)
 }
+
+// TestOpConVerifierFollowModeReorgRecovery is the op-con-node variant of the
+// op-node sync/follow_l2 test TestFollowL2_ReorgRecovery (which skips kona —
+// "single-chain test sequencer requires an op-node CL node"). It extends
+// TestOpConVerifierRecoversFromL1Reorg's safe-side reorg check with the unsafe
+// (follow-mode) side: the verifier additionally runs op-con-node's follow mode
+// (--l2-follow-rpc pointed at the sequencer's L2 EL), so an L1 reorg reorgs *both*
+// of the verifier's inputs at once — the L1-derived safe chain and the follow
+// source's unsafe chain — and the verifier must recover both.
+//
+// op-node's follow_l2 test splits these roles across two verifiers (a
+// derivation-enabled verifier and a follow-source verifier); op-con-node combines
+// them in one node (follow mode for the unsafe head, L1 derivation for the safe
+// head), so the single op-con-node verifier exercises both reset paths together.
+// This is the unsafe-side analogue of the safe-side L1-reorg recovery, and it
+// specifically exercises op-con-node's follow-mode source-reorg handling
+// (l2_follow.rs: parent-linkage divergence detection → prefetcher reset → re-feed)
+// plus the engine-boundary divergence-floor cap that lets the re-derived safe chain
+// drive op-reth onto the new canonical chain past the now-stale fed unsafe tip.
+//
+// With the default op-node verifier kind this is an ordinary follow-source +
+// derivation L1-reorg-recovery check, so it remains a valid suite addition rather
+// than an op-con-node-only test. Reorg mechanics (target the sequencer's safe head,
+// auto-advance L1 to win the fork choice, wait for the lagging verifier to derive
+// the target first) mirror TestOpConVerifierRecoversFromL1Reorg — see its comment.
+func TestOpConVerifierFollowModeReorgRecovery(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainMultiNodeNoFaultProofsFollowVerifierWithTestSeqWithoutCheck(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	sys.L1Network.WaitForBlock() // pass the L1 genesis
+
+	// Drive L1 deterministically so we can reorg it.
+	sys.L1CL.Stop()
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+
+	// Advance L1 until the SEQUENCER's safe head has an L1 origin past the start
+	// block (keeps the reorg shallow enough to win — see the bare-verifier test).
+	require.Eventually(func() bool {
+		if err := ts.Next(ctx); err != nil {
+			logger.Warn("ts.Next failed, will retry", "err", err)
+			return false
+		}
+		l2Safe := sys.L2EL.BlockRefByLabel(eth.Safe)
+		logger.Info("driving L1", "l1_head", sys.L1EL.BlockRefByLabel(eth.Unsafe), "seq_safe", l2Safe)
+		return l2Safe.Number > 0 && l2Safe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
+
+	// Confirm op-con-node's follow mode is live before the reorg: the verifier's
+	// op-reth unsafe (canonical) head, fed by follow mode, must lead its L1-derived
+	// safe head, so the upcoming reorg reorgs the *fed* unsafe chain and not only the
+	// derived safe chain. We read op-reth directly (sys.L2ELB) rather than
+	// op-con-node's syncStatus: while L1 is paused the unsafe lead is only a block or
+	// two, and op-con-node's reported unsafe head (the sparse forkchoice-accepted view,
+	// which needs a contiguous FCU-accepted chain) can momentarily fall back to the
+	// safe head — but op-reth's actual canonical head reliably leads the safe block it
+	// was FCU'd with.
+	require.Eventually(func() bool {
+		return sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number > sys.L2ELB.BlockRefByLabel(eth.Safe).Number
+	}, 120*time.Second, 2*time.Second)
+
+	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Safe)
+	logger.Info("target safe block to reorg", "l2", l2BlockBeforeReorg, "l1_origin", l2BlockBeforeReorg.L1Origin)
+
+	// Wait for the (lagging) op-con-node verifier to also derive this safe block,
+	// so the reorg invalidates a block it actually produced.
+	sys.L2ELB.Reached(eth.Safe, l2BlockBeforeReorg.Number, 60)
+
+	// Reorg the L1 block that the safe block's L1 origin points to.
+	l1BlockBeforeReorg := sys.L1EL.BlockRefByNumber(l2BlockBeforeReorg.L1Origin.Number)
+	logger.Info("triggering L1 reorg", "l1", l1BlockBeforeReorg)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1BlockBeforeReorg.ParentHash}))
+	require.NoError(ts.Next(ctx))
+	sys.L1CL.Start()
+
+	// Confirm the L1 reorg took (the new fork won at that height).
+	sys.L1EL.WaitForBlockNumber(l1BlockBeforeReorg.Number)
+	l1BlockAfterReorg := sys.L1EL.BlockRefByNumber(l1BlockBeforeReorg.Number)
+	require.NotEqual(l1BlockAfterReorg.Hash, l1BlockBeforeReorg.Hash)
+	logger.Info("L1 reorg confirmed", "l1", l1BlockAfterReorg)
+
+	// The sequencer's safe head — and, because the sequencer rebuilds its unsafe
+	// chain on the new L1 origin, its unsafe head — switches onto the new L1 chain.
+	// The follow source (the sequencer's L2 EL) therefore serves a reorged unsafe
+	// chain to the verifier.
+	sys.L2EL.WaitL1OriginHash(eth.Safe, l1BlockAfterReorg.ID(), 90)
+
+	// op-con-node must recover on both inputs: it detects the L1 reorg and resets
+	// derivation (re-deriving the new safe chain), and its follow-mode prefetcher
+	// detects the source reorg and re-feeds the new unsafe chain. Its block at the
+	// reorged height is replaced, and both its safe and unsafe heads converge with
+	// the sequencer's.
+	sys.L2ELB.ReorgTriggered(l2BlockBeforeReorg, 90)
+	sys.L2ELB.InSync(sys.L2EL, eth.Safe, 90)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 90)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalUnsafe, 90)
+}

--- a/op-conp2p/delegate.go
+++ b/op-conp2p/delegate.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// nodeClient is the consensus-node JSON-RPC endpoint the sidecar delegates the
+// unsafe-block verdict to. ws:// gives a persistent connection; http:// also
+// works since the node serves both.
+type nodeClient struct {
+	rpc     *gethrpc.Client
+	timeout time.Duration
+	log     log.Logger
+}
+
+func dialNode(ctx context.Context, url string, timeout time.Duration, logger log.Logger) (*nodeClient, error) {
+	c, err := gethrpc.DialContext(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial consensus node rpc %q: %w", url, err)
+	}
+	return &nodeClient{rpc: c, timeout: timeout, log: logger}, nil
+}
+
+// verifyVerdict is the response of the node's admin_verifyUnsafePayload.
+type verifyVerdict struct {
+	Verdict string `json:"verdict"`
+	Reason  string `json:"reason"`
+}
+
+// delegatingRuntimeConfig implements both p2p.GossipRuntimeConfig and
+// p2p.DelegatedBlockSignatureValidator. The signer truth lives entirely in the
+// consensus node: the sidecar holds no signer state, so the GossipRuntimeConfig
+// signer accessors are inert and the real decision is made in
+// ValidateUnsafeBlockSignature by calling the node.
+type delegatingRuntimeConfig struct {
+	node *nodeClient
+	log  log.Logger
+}
+
+var (
+	_ interface {
+		P2PSequencerAddress() common.Address
+		PreviousP2PSequencerAddress() common.Address
+		ConfirmCurrentSigner()
+	} = (*delegatingRuntimeConfig)(nil)
+)
+
+// The sidecar never verifies signatures locally, so these are inert. They are
+// only consulted by the built-in path, which the delegate replaces.
+func (d *delegatingRuntimeConfig) P2PSequencerAddress() common.Address         { return common.Address{} }
+func (d *delegatingRuntimeConfig) PreviousP2PSequencerAddress() common.Address { return common.Address{} }
+func (d *delegatingRuntimeConfig) ConfirmCurrentSigner()                       {}
+
+// ValidateUnsafeBlockSignature delegates the gossipsub verdict to the consensus
+// node. It builds a superset request that serves both node kinds:
+//
+//   - op-con-node reads executionPayload + parentBeaconBlockRoot + signature +
+//     payloadHash (JSON engine-envelope path), and
+//   - op-con-ex-node reads version + payload (raw signature-prefixed gossip
+//     bytes, decoded via op-alloy).
+//
+// The node recovers the signer against the address it owns, ingests on accept,
+// and returns the verdict. On any transport/decode error here we return
+// ValidationIgnore (never Reject) so honest peers are not penalized for our own
+// inability to decide — the same rule the node applies to an unknown signer.
+func (d *delegatingRuntimeConfig) ValidateUnsafeBlockSignature(
+	ctx context.Context,
+	chainID eth.ChainID,
+	version eth.BlockVersion,
+	signature eth.Bytes65,
+	payloadBytes []byte,
+) pubsub.ValidationResult {
+	req, err := buildVerifyRequest(version, signature, payloadBytes)
+	if err != nil {
+		d.log.Warn("failed to build verify request; ignoring block", "err", err)
+		return pubsub.ValidationIgnore
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, d.node.timeout)
+	defer cancel()
+
+	var verdict verifyVerdict
+	if err := d.node.rpc.CallContext(callCtx, &verdict, "admin_verifyUnsafePayload", req); err != nil {
+		// Node unreachable / errored: we cannot decide. Ignore, do not penalize.
+		d.log.Warn("admin_verifyUnsafePayload call failed; ignoring block", "err", err)
+		return pubsub.ValidationIgnore
+	}
+
+	switch verdict.Verdict {
+	case "accept":
+		return pubsub.ValidationAccept
+	case "reject":
+		d.log.Debug("node rejected gossiped unsafe block", "reason", verdict.Reason)
+		return pubsub.ValidationReject
+	case "ignore":
+		d.log.Debug("node could not attribute gossiped unsafe block", "reason", verdict.Reason)
+		return pubsub.ValidationIgnore
+	default:
+		d.log.Warn("unknown verdict from node; ignoring block", "verdict", verdict.Verdict)
+		return pubsub.ValidationIgnore
+	}
+}
+
+// buildVerifyRequest assembles the superset request object for
+// admin_verifyUnsafePayload from the gossip wire pieces.
+func buildVerifyRequest(version eth.BlockVersion, signature eth.Bytes65, payloadBytes []byte) (map[string]any, error) {
+	payloadHash := crypto.Keccak256Hash(payloadBytes)
+
+	// Decode the SSZ payload (mirrors op-node's BuildBlocksValidator) so the
+	// op-con-node JSON path has executionPayload + parentBeaconBlockRoot.
+	var envelope eth.ExecutionPayloadEnvelope
+	if version.HasParentBeaconBlockRoot() {
+		if err := envelope.UnmarshalSSZ(version, uint32(len(payloadBytes)), bytes.NewReader(payloadBytes)); err != nil {
+			return nil, fmt.Errorf("failed to decode execution payload envelope: %w", err)
+		}
+	} else {
+		var payload eth.ExecutionPayload
+		if err := payload.UnmarshalSSZ(version, uint32(len(payloadBytes)), bytes.NewReader(payloadBytes)); err != nil {
+			return nil, fmt.Errorf("failed to decode execution payload: %w", err)
+		}
+		envelope = eth.ExecutionPayloadEnvelope{ExecutionPayload: &payload}
+	}
+
+	payloadJSON, err := json.Marshal(envelope.ExecutionPayload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal execution payload: %w", err)
+	}
+
+	// Raw signature-prefixed bytes (the decompressed gossip body), which
+	// op-con-ex-node decodes directly via op-alloy.
+	raw := make([]byte, 0, len(signature)+len(payloadBytes))
+	raw = append(raw, signature[:]...)
+	raw = append(raw, payloadBytes...)
+
+	req := map[string]any{
+		"executionPayload": json.RawMessage(payloadJSON),
+		"signature":        hexutil.Encode(signature[:]),
+		"payloadHash":      payloadHash.Hex(),
+		"version":          versionToInt(version),
+		"payload":          hexutil.Encode(raw),
+	}
+	if envelope.ParentBeaconBlockRoot != nil {
+		req["parentBeaconBlockRoot"] = envelope.ParentBeaconBlockRoot.Hex()
+	}
+	return req, nil
+}
+
+func versionToInt(v eth.BlockVersion) int {
+	switch v {
+	case eth.BlockV1:
+		return 1
+	case eth.BlockV2:
+		return 2
+	case eth.BlockV3:
+		return 3
+	case eth.BlockV4:
+		return 4
+	default:
+		return 0
+	}
+}
+
+// loggingGossipIn satisfies p2p.GossipIn. Ingestion happens inside the delegate
+// (verify-and-ingest in one call), so this only observes accepted deliveries.
+type loggingGossipIn struct {
+	log log.Logger
+}
+
+func (g *loggingGossipIn) OnUnsafeL2Payload(_ context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error {
+	g.log.Debug("gossip accepted unsafe payload delivered",
+		"peer", from,
+		"block", uint64(msg.ExecutionPayload.BlockNumber),
+		"hash", msg.ExecutionPayload.BlockHash,
+	)
+	return nil
+}

--- a/op-conp2p/main.go
+++ b/op-conp2p/main.go
@@ -1,0 +1,136 @@
+// Command op-conp2p is a thin P2P sidecar for the opql consensus nodes
+// (op-con-node / op-con-ex-node), which have no built-in P2P. It reuses
+// op-node's P2P stack to join the OP gossip network and receive unsafe
+// ExecutionPayloadEnvelopes, then delegates the per-block signature verdict back
+// to the consensus node over JSON-RPC (admin_verifyUnsafePayload). The node owns
+// the sequencer-signer truth and decides accept/reject/ignore; the sidecar holds
+// no signer state and maps the node's verdict onto its gossipsub validator
+// result, which is the relay decision.
+//
+// See docs/sidecar-p2p-design.md in the opql repo.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	opnodeflags "github.com/ethereum-optimism/optimism/op-node/flags"
+	opmetrics "github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	p2pcli "github.com/ethereum-optimism/optimism/op-node/p2p/cli"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+)
+
+const envPrefix = "OP_CONP2P"
+
+var (
+	rollupConfigFlag = &cli.StringFlag{
+		Name:     "rollup.config",
+		Usage:    "Path to the standard op-node rollup config JSON (chain id + fork times drive gossip topic selection).",
+		EnvVars:  []string{envPrefix + "_ROLLUP_CONFIG"},
+		Required: true,
+	}
+	nodeRPCFlag = &cli.StringFlag{
+		Name:     "node.rpc",
+		Usage:    "Consensus node JSON-RPC endpoint (ws:// or http://) exposing admin_verifyUnsafePayload.",
+		EnvVars:  []string{envPrefix + "_NODE_RPC"},
+		Required: true,
+	}
+	nodeTimeoutFlag = &cli.DurationFlag{
+		Name:    "node.rpc.timeout",
+		Usage:   "Per-call timeout for the consensus node verdict RPC.",
+		EnvVars: []string{envPrefix + "_NODE_RPC_TIMEOUT"},
+		Value:   2 * time.Second,
+	}
+)
+
+func main() {
+	logger := log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelInfo, true))
+
+	app := cli.NewApp()
+	app.Name = "op-conp2p"
+	app.Usage = "OP gossip P2P sidecar for the opql consensus nodes"
+	app.Flags = append([]cli.Flag{rollupConfigFlag, nodeRPCFlag, nodeTimeoutFlag},
+		opnodeflags.P2PFlags(envPrefix)...)
+	app.Action = func(cliCtx *cli.Context) error {
+		return run(cliCtx, logger)
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		logger.Crit("op-conp2p failed", "err", err)
+	}
+}
+
+func run(cliCtx *cli.Context, logger log.Logger) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	rollupCfg, err := loadRollupConfig(cliCtx.String(rollupConfigFlag.Name))
+	if err != nil {
+		return fmt.Errorf("failed to load rollup config: %w", err)
+	}
+
+	p2pConfig, err := p2pcli.NewConfig(cliCtx, rollupCfg.BlockTime)
+	if err != nil {
+		return fmt.Errorf("failed to load p2p config: %w", err)
+	}
+	if p2pConfig.Disabled() {
+		return fmt.Errorf("p2p is disabled; the sidecar requires p2p to be enabled")
+	}
+
+	node, err := dialNode(ctx, cliCtx.String(nodeRPCFlag.Name), cliCtx.Duration(nodeTimeoutFlag.Name), logger)
+	if err != nil {
+		return err
+	}
+
+	runCfg := &delegatingRuntimeConfig{node: node, log: logger}
+	gossipIn := &loggingGossipIn{log: logger}
+
+	n, err := p2p.NewNodeP2P(
+		ctx,
+		rollupCfg,
+		logger,
+		p2pConfig,
+		gossipIn,
+		nil, // no L2Chain: gossip-only, no req-resp server
+		runCfg,
+		opmetrics.NoopMetrics,
+		clock.SystemClock,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to start p2p node: %w", err)
+	}
+	defer n.Close()
+
+	logger.Info("op-conp2p sidecar started",
+		"chain_id", rollupCfg.L2ChainID,
+		"node_rpc", cliCtx.String(nodeRPCFlag.Name),
+		"peer_id", n.Host().ID(),
+	)
+
+	<-ctx.Done()
+	logger.Info("op-conp2p sidecar shutting down")
+	return nil
+}
+
+func loadRollupConfig(path string) (*rollup.Config, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	var cfg rollup.Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse rollup config %s: %w", path, err)
+	}
+	return &cfg, nil
+}

--- a/op-devstack/presets/singlechain_multinode.go
+++ b/op-devstack/presets/singlechain_multinode.go
@@ -103,6 +103,21 @@ func NewSingleChainMultiNodeNoFaultProofsBareVerifierWithTestSeqWithoutCheck(t d
 	return out
 }
 
+// NewSingleChainMultiNodeNoFaultProofsFollowVerifierWithTestSeqWithoutCheck is the
+// follow-source test-sequencer preset: the verifier has its L2 follow source wired
+// to the sequencer's L2 execution RPC (no CL P2P, no sidecar) AND the test-sequencer
+// drives (and can reorg) L1. The follow-source op-con-node verifier tracks the
+// sequencer's unsafe head via follow mode while deriving its safe chain from L1, so
+// an L1 reorg reorgs both: the follow source's unsafe chain (exercising the
+// follow-mode prefetcher's source-reorg handling) and the L1-derived safe chain.
+// Used for the op-con-node analogue of op-node's sync/follow_l2 TestFollowL2_ReorgRecovery.
+func NewSingleChainMultiNodeNoFaultProofsFollowVerifierWithTestSeqWithoutCheck(t devtest.T, opts ...Option) *SingleChainMultiNodeWithTestSeq {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewSingleChainMultiNodeNoFaultProofsFollowVerifierWithTestSeqWithoutCheck", opts, minimalPresetSupportedOptionKinds)
+	out := singleChainMultiNodeWithTestSeqFromRuntime(t, sysgo.NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig(t, false, presetCfg))
+	presetOpts.applyPreset(out)
+	return out
+}
+
 // NewSingleChainMultiNodeWithTestSeq creates a fresh
 // SingleChainMultiNodeWithTestSeq target for the current test.
 //

--- a/op-devstack/presets/singlechain_multinode.go
+++ b/op-devstack/presets/singlechain_multinode.go
@@ -59,6 +59,20 @@ func NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck(t devtest.T, opt
 	return out
 }
 
+// NewSingleChainMultiNodeNoFaultProofsWithP2PWithoutCheck is the with-P2P
+// counterpart of the above: the sequencer publishes unsafe blocks over gossip and
+// the verifier joins the network. With the default op-node verifier this peers
+// over CL P2P; with DEVSTACK_L2CL_KIND=op-con-node the verifier (which has no
+// built-in P2P) is fronted by the op-conp2p gossip sidecar, which delegates each
+// block's signature verdict back to op-con-node. No proposer/challenger (no
+// cannon), no initial sync checks.
+func NewSingleChainMultiNodeNoFaultProofsWithP2PWithoutCheck(t devtest.T, opts ...Option) *SingleChainMultiNode {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewSingleChainMultiNodeNoFaultProofsWithP2PWithoutCheck", opts, minimalPresetSupportedOptionKinds)
+	out := singleChainMultiNodeFromRuntime(t, sysgo.NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig(t, true, presetCfg), false)
+	presetOpts.applyPreset(out)
+	return out
+}
+
 type SingleChainMultiNodeWithTestSeq struct {
 	SingleChainMultiNode
 

--- a/op-devstack/presets/singlechain_multinode.go
+++ b/op-devstack/presets/singlechain_multinode.go
@@ -47,6 +47,18 @@ func NewSingleChainMultiNodeWithoutP2PWithoutCheck(t devtest.T, opts ...Option) 
 	return out
 }
 
+// NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck creates a
+// SingleChainMultiNode target with no proposer/challenger and no sequencer↔verifier
+// P2P links, and without initial sync checks. The verifier's only data source is
+// L1 derivation. Skipping the challenger avoids requiring cannon prestate
+// artifacts. Intended for consensus-only verifier tests (e.g. op-con-node).
+func NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck(t devtest.T, opts ...Option) *SingleChainMultiNode {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck", opts, minimalPresetSupportedOptionKinds)
+	out := singleChainMultiNodeFromRuntime(t, sysgo.NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig(t, false, presetCfg), false)
+	presetOpts.applyPreset(out)
+	return out
+}
+
 type SingleChainMultiNodeWithTestSeq struct {
 	SingleChainMultiNode
 

--- a/op-devstack/presets/singlechain_multinode.go
+++ b/op-devstack/presets/singlechain_multinode.go
@@ -73,6 +73,18 @@ func NewSingleChainMultiNodeNoFaultProofsWithP2PWithoutCheck(t devtest.T, opts .
 	return out
 }
 
+// NewSingleChainMultiNodeNoFaultProofsBareVerifierWithoutCheck creates a
+// SingleChainMultiNode whose verifier has no unsafe source at all (no follow, no
+// CL P2P, no sidecar): the test drives the verifier's unsafe chain via
+// admin_postUnsafePayload. No proposer/challenger (no cannon), no initial sync
+// checks. Used for unsafe-payload-queue / gap-handling tests.
+func NewSingleChainMultiNodeNoFaultProofsBareVerifierWithoutCheck(t devtest.T, opts ...Option) *SingleChainMultiNode {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewSingleChainMultiNodeNoFaultProofsBareVerifierWithoutCheck", opts, minimalPresetSupportedOptionKinds)
+	out := singleChainMultiNodeFromRuntime(t, sysgo.NewSingleChainMultiNodeNoFaultProofsBareVerifierRuntime(t, presetCfg), false)
+	presetOpts.applyPreset(out)
+	return out
+}
+
 type SingleChainMultiNodeWithTestSeq struct {
 	SingleChainMultiNode
 

--- a/op-devstack/presets/singlechain_multinode.go
+++ b/op-devstack/presets/singlechain_multinode.go
@@ -91,6 +91,18 @@ type SingleChainMultiNodeWithTestSeq struct {
 	TestSequencer *dsl.TestSequencer
 }
 
+// NewSingleChainMultiNodeNoFaultProofsBareVerifierWithTestSeqWithoutCheck is the
+// bare-verifier (no follow source, no P2P, no sidecar) test-sequencer preset: the
+// verifier derives only the safe chain from L1, with the test-sequencer driving
+// (and able to reorg) L1. Used for L1-reorg → safe-re-derivation tests, where a
+// follow/unsafe source would otherwise confound the safe-chain assertions.
+func NewSingleChainMultiNodeNoFaultProofsBareVerifierWithTestSeqWithoutCheck(t devtest.T, opts ...Option) *SingleChainMultiNodeWithTestSeq {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewSingleChainMultiNodeNoFaultProofsBareVerifierWithTestSeqWithoutCheck", opts, minimalPresetSupportedOptionKinds)
+	out := singleChainMultiNodeWithTestSeqFromRuntime(t, sysgo.NewSingleChainMultiNodeNoFaultProofsBareVerifierRuntime(t, presetCfg))
+	presetOpts.applyPreset(out)
+	return out
+}
+
 // NewSingleChainMultiNodeWithTestSeq creates a fresh
 // SingleChainMultiNodeWithTestSeq target for the current test.
 //

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -38,6 +38,13 @@ type L2CLConfig struct {
 
 	FollowSource string
 
+	// OpConL1FinalizedGuard overrides op-con-node's --l1-finalized-guard
+	// ("required" or "disabled"). Empty falls back to the launcher default
+	// (the DEVSTACK_OPCON_L1_FINALIZED_GUARD env, itself defaulting to "disabled").
+	// Set "required" only against a finalizing L1, so op-con-node tracks L1 finality
+	// and advances its L2 finalized head. Ignored by non-op-con CL kinds.
+	OpConL1FinalizedGuard string
+
 	// OffsetELSafe retracts safe and finalized from the EL-sync tip by floor(OffsetELSafe / L2BlockTime) blocks.
 	OffsetELSafe time.Duration
 

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -45,6 +45,13 @@ type L2CLConfig struct {
 	// and advances its L2 finalized head. Ignored by non-op-con CL kinds.
 	OpConL1FinalizedGuard string
 
+	// OpConSequencer routes this node's SEQUENCER slot to op-con-node when the
+	// devstack CL kind is op-con-node. By default sequencer slots stay on
+	// op-node (op-con-node was verifier-only before it grew a sequencing mode);
+	// tests that exercise op-con-node's sequencer opt in per-test with
+	// L2CLOpConSequencer(). Ignored for verifier slots and non-op-con CL kinds.
+	OpConSequencer bool
+
 	// OffsetELSafe retracts safe and finalized from the EL-sync tip by floor(OffsetELSafe / L2BlockTime) blocks.
 	OffsetELSafe time.Duration
 
@@ -68,6 +75,15 @@ func L2CLIndexing() L2CLOption {
 func L2CLFollowSource(source string) L2CLOption {
 	return L2CLOptionFn(func(p devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
 		cfg.FollowSource = source
+	})
+}
+
+// L2CLOpConSequencer opts the sequencer slot into op-con-node when the devstack
+// CL kind is op-con-node (DEVSTACK_L2CL_KIND=op-con-node). With any other CL
+// kind this is a no-op, so tests using it remain valid ordinary suite additions.
+func L2CLOpConSequencer() L2CLOption {
+	return L2CLOptionFn(func(p devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
+		cfg.OpConSequencer = true
 	})
 }
 

--- a/op-devstack/sysgo/l2_cl_opcon.go
+++ b/op-devstack/sysgo/l2_cl_opcon.go
@@ -143,6 +143,7 @@ func startMixedOpConNode(
 	clKey string,
 	elKey string,
 	followSource string,
+	l1FinalizedGuard string,
 	metricsRegistrar L2MetricsRegistrar,
 ) *OpConNode {
 	dir := t.TempDir()
@@ -201,9 +202,15 @@ func startMixedOpConNode(
 	}
 
 	// Devstack L1 finality may not advance; default the derive-side guard to
-	// disabled so startup does not stall waiting for a finalized tag. Override
-	// with DEVSTACK_OPCON_L1_FINALIZED_GUARD=required against a finalizing L1.
-	args = append(args, "--l1-finalized-guard", getEnvVarOrDefault("DEVSTACK_OPCON_L1_FINALIZED_GUARD", "disabled"))
+	// disabled so startup does not stall waiting for a finalized tag. A per-node
+	// override (L2CLConfig.OpConL1FinalizedGuard) wins when set; otherwise fall back
+	// to DEVSTACK_OPCON_L1_FINALIZED_GUARD (itself defaulting to "disabled"). Set
+	// "required" only against a finalizing L1.
+	finalizedGuard := l1FinalizedGuard
+	if finalizedGuard == "" {
+		finalizedGuard = getEnvVarOrDefault("DEVSTACK_OPCON_L1_FINALIZED_GUARD", "disabled")
+	}
+	args = append(args, "--l1-finalized-guard", finalizedGuard)
 
 	// Expected unsafe-block (gossip) signer for admin_verifyUnsafePayload, used by
 	// the op-conp2p P2P sidecar's verdict delegation. When set, op-con-node can

--- a/op-devstack/sysgo/l2_cl_opcon.go
+++ b/op-devstack/sysgo/l2_cl_opcon.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -19,13 +20,16 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// OpConNode launches `op-con-node` (the opql consensus-only verifier) as an
+// OpConNode launches `op-con-node` (the opql consensus-only node) as an
 // external subprocess and fronts its JSON-RPC, mirroring the kona-node path.
 //
-// op-con-node is verifier-only: it derives the safe L2 chain from L1 and drives
-// its paired execution engine over the Engine API. It does not sequence and has
-// no P2P gossip, so the unsafe head is followed from a trusted L2 execution RPC
-// (`--l2-follow-rpc`) when a follow source is wired, rather than over gossip.
+// op-con-node derives the safe L2 chain from L1 and drives its paired execution
+// engine over the Engine API. It has no P2P gossip, so as a verifier the unsafe
+// head is followed from a trusted L2 execution RPC (`--l2-follow-rpc`) when a
+// follow source is wired, rather than over gossip. With `--sequencer-enabled`
+// it instead produces the unsafe chain itself: it drives the EL build loop with
+// `noTxPool=false` (the EL packs its own mempool behind the forced deposit
+// prefix) and commits each built block as the new unsafe head.
 type OpConNode struct {
 	mu sync.Mutex
 
@@ -128,7 +132,9 @@ var _ L2CLNode = (*OpConNode)(nil)
 
 // startMixedOpConNode bootstraps op-con-node's flat rollup config + genesis
 // checkpoint from the standard rollup config, then launches `op-con-node run`
-// as a verifier paired with l2EL.
+// paired with l2EL — as a verifier, or as a sequencer when isSequencer is set
+// (--sequencer-enabled: op-con-node produces the unsafe chain by driving l2EL's
+// build loop, while still deriving its safe chain from L1).
 //
 // The binary is resolved via rustbin, which honors RUST_BINARY_PATH_OP_CON_NODE
 // (an absolute binary path) or RUST_SRC_DIR_OP_CON_NODE (the opql cargo project
@@ -142,6 +148,7 @@ func startMixedOpConNode(
 	l2EL L2ELNode,
 	clKey string,
 	elKey string,
+	isSequencer bool,
 	followSource string,
 	l1FinalizedGuard string,
 	metricsRegistrar L2MetricsRegistrar,
@@ -199,6 +206,17 @@ func startMixedOpConNode(
 	// L1 derivation only.
 	if followSource != "" {
 		args = append(args, "--l2-follow-rpc", strings.ReplaceAll(followSource, "ws://", "http://"))
+	}
+
+	// Sequencer mode: op-con-node produces the unsafe chain itself by driving
+	// l2EL's build loop (noTxPool=false — the EL packs its mempool behind the
+	// forced deposit prefix). The build heartbeat matches the chain's block time;
+	// op-con-node's own seal timer paces each block to its L2 timestamp.
+	if isSequencer {
+		args = append(args,
+			"--sequencer-enabled",
+			"--sequencer-build-interval-ms", strconv.FormatUint(l2Net.rollupCfg.BlockTime*1000, 10),
+		)
 	}
 
 	// Devstack L1 finality may not advance; default the derive-side guard to

--- a/op-devstack/sysgo/l2_cl_opcon.go
+++ b/op-devstack/sysgo/l2_cl_opcon.go
@@ -205,6 +205,15 @@ func startMixedOpConNode(
 	// with DEVSTACK_OPCON_L1_FINALIZED_GUARD=required against a finalizing L1.
 	args = append(args, "--l1-finalized-guard", getEnvVarOrDefault("DEVSTACK_OPCON_L1_FINALIZED_GUARD", "disabled"))
 
+	// Expected unsafe-block (gossip) signer for admin_verifyUnsafePayload, used by
+	// the op-conp2p P2P sidecar's verdict delegation. When set, op-con-node can
+	// attribute gossiped blocks to the sequencer; otherwise the verdict RPC
+	// returns `ignore`. In a with-P2P preset this is the sequencer's P2P signer
+	// address.
+	if signer := os.Getenv("DEVSTACK_OPCON_UNSAFE_SIGNER"); signer != "" {
+		args = append(args, "--unsafe-block-signer", signer)
+	}
+
 	var metricsHost, metricsPort string
 	if areMetricsEnabled() {
 		metricsHost = "127.0.0.1"

--- a/op-devstack/sysgo/l2_cl_opcon.go
+++ b/op-devstack/sysgo/l2_cl_opcon.go
@@ -1,0 +1,233 @@
+package sysgo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/shared/rustbin"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/logpipe"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// OpConNode launches `op-con-node` (the opql consensus-only verifier) as an
+// external subprocess and fronts its JSON-RPC, mirroring the kona-node path.
+//
+// op-con-node is verifier-only: it derives the safe L2 chain from L1 and drives
+// its paired execution engine over the Engine API. It does not sequence and has
+// no P2P gossip, so the unsafe head is followed from a trusted L2 execution RPC
+// (`--l2-follow-rpc`) when a follow source is wired, rather than over gossip.
+type OpConNode struct {
+	mu sync.Mutex
+
+	name    string
+	chainID eth.ChainID
+
+	userRPC          string
+	interopEndpoint  string // not supported yet
+	interopJwtSecret eth.Bytes32
+
+	execPath string
+	args     []string
+	env      []string
+
+	metricsHost string
+	metricsPort string
+
+	p   devtest.T
+	sub *SubProcess
+
+	l2MetricsRegistrar L2MetricsRegistrar
+}
+
+func (n *OpConNode) Start() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.sub != nil {
+		n.p.Logger().Warn("op-con-node already started")
+		return
+	}
+
+	logOut := logpipe.ToLoggerWithMinLevel(n.p.Logger().New("component", "op-con-node", "src", "stdout"), log.LevelWarn)
+	logErr := logpipe.ToLoggerWithMinLevel(n.p.Logger().New("component", "op-con-node", "src", "stderr"), log.LevelWarn)
+	stdOutLogs := logpipe.LogCallback(func(line []byte) { logOut(logpipe.ParseRustStructuredLogs(line)) })
+	stdErrLogs := logpipe.LogCallback(func(line []byte) { logErr(logpipe.ParseRustStructuredLogs(line)) })
+	n.sub = NewSubProcess(n.p, stdOutLogs, stdErrLogs)
+
+	err := n.sub.Start(n.execPath, n.args, n.env)
+	n.p.Require().NoError(err, "must start op-con-node")
+
+	// op-con-node binds the RPC to the fixed port we chose, so poll the endpoint
+	// for readiness rather than coupling to a specific startup log line.
+	n.awaitRPCReady()
+
+	if areMetricsEnabled() && n.metricsPort != "" && n.l2MetricsRegistrar != nil {
+		n.l2MetricsRegistrar.RegisterL2MetricsTargets(n.name, NewPrometheusMetricsTarget(n.metricsHost, n.metricsPort, false))
+	}
+}
+
+// awaitRPCReady blocks until the JSON-RPC server answers, or the test context /
+// a 90s deadline elapses. An HTTP 200 (even a JSON-RPC error body) means the
+// server is up and accepting requests.
+func (n *OpConNode) awaitRPCReady() {
+	ctx, cancel := context.WithTimeout(n.p.Ctx(), 90*time.Second)
+	defer cancel()
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"optimism_syncStatus","params":[]}`)
+	for {
+		select {
+		case <-ctx.Done():
+			n.p.Require().NoError(ctx.Err(), "op-con-node RPC did not become ready at %s", n.userRPC)
+			return
+		default:
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.userRPC, bytes.NewReader(body))
+		if err == nil {
+			req.Header.Set("Content-Type", "application/json")
+			resp, doErr := http.DefaultClient.Do(req)
+			if doErr == nil {
+				_ = resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					return
+				}
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+func (n *OpConNode) Stop() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.sub == nil {
+		n.p.Logger().Warn("op-con-node already stopped")
+		return
+	}
+	err := n.sub.Stop(true)
+	n.p.Require().NoError(err, "must stop op-con-node")
+	n.sub = nil
+}
+
+func (n *OpConNode) UserRPC() string {
+	return n.userRPC
+}
+
+func (n *OpConNode) InteropRPC() (endpoint string, jwtSecret eth.Bytes32) {
+	return n.interopEndpoint, n.interopJwtSecret
+}
+
+var _ L2CLNode = (*OpConNode)(nil)
+
+// startMixedOpConNode bootstraps op-con-node's flat rollup config + genesis
+// checkpoint from the standard rollup config, then launches `op-con-node run`
+// as a verifier paired with l2EL.
+//
+// The binary is resolved via rustbin, which honors RUST_BINARY_PATH_OP_CON_NODE
+// (an absolute binary path) or RUST_SRC_DIR_OP_CON_NODE (the opql cargo project
+// root) — op-con-node lives in a sibling repo, not this monorepo.
+func startMixedOpConNode(
+	t devtest.T,
+	l1Net *L1Network,
+	l2Net *L2Network,
+	l1EL L1ELNode,
+	l1CL *L1CLNode,
+	l2EL L2ELNode,
+	clKey string,
+	elKey string,
+	followSource string,
+	metricsRegistrar L2MetricsRegistrar,
+) *OpConNode {
+	dir := t.TempDir()
+
+	// Standard op-node rollup config -> file (the bootstrap step's input).
+	stdRollupPath := filepath.Join(dir, "rollup.json")
+	rollupData, err := json.Marshal(l2Net.rollupCfg)
+	t.Require().NoError(err, "marshal rollup config")
+	t.Require().NoError(os.WriteFile(stdRollupPath, rollupData, 0o644))
+
+	execPath, err := rustbin.Spec{
+		SrcDir:  "op-con-node",
+		Package: "op-con-node",
+		Binary:  "op-con-node",
+	}.EnsureExists(t.Ctx(), t.Logger())
+	t.Require().NoError(err, "prepare op-con-node binary (set RUST_BINARY_PATH_OP_CON_NODE or RUST_SRC_DIR_OP_CON_NODE)")
+	t.Require().NotEmpty(execPath, "op-con-node binary path resolved")
+
+	l2ELUserRPC := strings.ReplaceAll(l2EL.UserRPC(), "ws://", "http://")
+	l2ELEngineRPC := strings.ReplaceAll(l2EL.EngineRPC(), "ws://", "http://")
+
+	// Optional debug: copy the rollup config to a stable dir for inspection (the
+	// working dir is a cleaned-up t.TempDir()).
+	if dbg := os.Getenv("DEVSTACK_OPCON_DEBUG_DIR"); dbg != "" {
+		_ = os.MkdirAll(dbg, 0o755)
+		if data, rErr := os.ReadFile(stdRollupPath); rErr == nil {
+			_ = os.WriteFile(filepath.Join(dbg, clKey+"-rollup.json"), data, 0o644)
+		}
+	}
+
+	rpcPort, err := getAvailableLocalPort()
+	t.Require().NoError(err, "op-con-node rpc port")
+
+	// op-con-node consumes the standard op-node rollup config directly and anchors
+	// at L2 genesis with no checkpoint: it fetches the genesis block via
+	// --l2-eth-rpc to build the anchor in-process.
+	args := []string{
+		"run",
+		"--datadir", filepath.Join(dir, "datadir"),
+		"--l1-rpc", l1EL.UserRPC(),
+		"--l1-beacon-rpc", l1CL.beaconHTTPAddr,
+		"--l1-source-tag", "latest",
+		"--l2-engine-rpc", l2ELEngineRPC,
+		"--l2.jwt-secret", l2EL.JWTPath(),
+		"--l2-eth-rpc", l2ELUserRPC,
+		"--rollup-config", stdRollupPath,
+		"--rpc-addr", "127.0.0.1",
+		"--rpc-port", rpcPort,
+	}
+
+	// Follow the unsafe head from a trusted L2 execution RPC when one is wired
+	// (op-con-node has no P2P). Without it, op-con-node tracks the safe chain via
+	// L1 derivation only.
+	if followSource != "" {
+		args = append(args, "--l2-follow-rpc", strings.ReplaceAll(followSource, "ws://", "http://"))
+	}
+
+	// Devstack L1 finality may not advance; default the derive-side guard to
+	// disabled so startup does not stall waiting for a finalized tag. Override
+	// with DEVSTACK_OPCON_L1_FINALIZED_GUARD=required against a finalizing L1.
+	args = append(args, "--l1-finalized-guard", getEnvVarOrDefault("DEVSTACK_OPCON_L1_FINALIZED_GUARD", "disabled"))
+
+	var metricsHost, metricsPort string
+	if areMetricsEnabled() {
+		metricsHost = "127.0.0.1"
+		metricsPort, err = getAvailableLocalPort()
+		t.Require().NoError(err, "op-con-node metrics port")
+		args = append(args, "--metrics-enabled", "--metrics-addr", metricsHost, "--metrics-port", metricsPort)
+	}
+
+	n := &OpConNode{
+		name:               clKey,
+		chainID:            l2Net.ChainID(),
+		userRPC:            fmt.Sprintf("http://127.0.0.1:%s", rpcPort),
+		execPath:           execPath,
+		args:               args,
+		env:                nil, // inherits os.Environ via SubProcess
+		metricsHost:        metricsHost,
+		metricsPort:        metricsPort,
+		p:                  t,
+		l2MetricsRegistrar: metricsRegistrar,
+	}
+	t.Logger().Info("Starting op-con-node", "name", clKey, "chain", l2Net.ChainID(), "el", elKey, "rpc", n.userRPC)
+	n.Start()
+	t.Cleanup(n.Stop)
+	t.Logger().Info("op-con-node is up", "name", clKey, "chain", l2Net.ChainID(), "rpc", n.UserRPC())
+	return n
+}

--- a/op-devstack/sysgo/l2_cl_opcon_sidecar.go
+++ b/op-devstack/sysgo/l2_cl_opcon_sidecar.go
@@ -1,0 +1,111 @@
+package sysgo
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/logpipe"
+)
+
+// OpConP2PSidecar is the op-conp2p gossip sidecar fronting an op-con-node /
+// op-con-ex-node verifier. The verifier has no built-in P2P; the sidecar joins
+// the OP gossip network, receives unsafe payloads, and delegates each block's
+// signature verdict back to the verifier over JSON-RPC (admin_verifyUnsafePayload).
+//
+// This is the launcher half of docs/sidecar-p2p-design.md phase 2. It is
+// parameterized (it takes the verifier RPC, the rollup config path, and the
+// sequencer's gossip multiaddr) so a with-P2P preset can wire it in place of the
+// follow-mode (`--l2-follow-rpc`) source. Full preset + acceptance-test wiring is
+// tracked as the remaining run-verification step.
+type OpConP2PSidecar struct {
+	name string
+	p    devtest.T
+	sub  *SubProcess
+}
+
+// opConP2PSidecarBinaryEnv names the env var pointing at a prebuilt op-conp2p
+// binary. op-conp2p is in-repo Go (built with `go build ./op-conp2p`), so unlike
+// the rust binaries it is located by path rather than via rustbin.
+const opConP2PSidecarBinaryEnv = "OP_CONP2P_BIN"
+
+// startOpConP2PSidecar spawns op-conp2p, static-peered to the sequencer's gossip
+// address, delegating verdicts to the verifier at nodeUserRPC.
+//
+//   - nodeUserRPC: the verifier's JSON-RPC endpoint (exposes admin_verifyUnsafePayload).
+//   - rollupConfigPath: the standard op-node rollup.json (chain id + fork times
+//     drive the gossip topic selection); the same file the verifier consumes.
+//   - sequencerGossipMultiaddr: the sequencer CL's gossip multiaddr (from its
+//     opp2p_self), used as a static peer since the sidecar runs no discovery.
+func StartOpConP2PSidecar(
+	t devtest.T,
+	name string,
+	nodeUserRPC string,
+	rollupConfigPath string,
+	sequencerGossipMultiaddr string,
+) *OpConP2PSidecar {
+	bin := os.Getenv(opConP2PSidecarBinaryEnv)
+	t.Require().NotEmpty(bin, "set %s to the op-conp2p binary path (go build ./op-conp2p)", opConP2PSidecarBinaryEnv)
+
+	dir := t.TempDir()
+	tcpPort, err := getAvailableLocalPort()
+	t.Require().NoError(err, "op-conp2p tcp port")
+	udpPort, err := getAvailableLocalPort()
+	t.Require().NoError(err, "op-conp2p udp port")
+
+	args := []string{
+		"--rollup.config", rollupConfigPath,
+		"--node.rpc", nodeUserRPC,
+		"--p2p.static", sequencerGossipMultiaddr,
+		"--p2p.no-discovery=true",
+		"--p2p.listen.ip", "127.0.0.1",
+		"--p2p.listen.tcp", tcpPort,
+		"--p2p.listen.udp", udpPort,
+		"--p2p.priv.path", filepath.Join(dir, "p2p_priv.txt"),
+		"--p2p.peerstore.path", "memory",
+		"--p2p.discovery.path", "memory",
+	}
+
+	logOut := logpipe.ToLoggerWithMinLevel(t.Logger().New("component", "op-conp2p", "src", "stdout"), log.LevelInfo)
+	logErr := logpipe.ToLoggerWithMinLevel(t.Logger().New("component", "op-conp2p", "src", "stderr"), log.LevelInfo)
+	sub := NewSubProcess(t,
+		logpipe.LogCallback(func(line []byte) { logOut(logpipe.ParseGoStructuredLogs(line)) }),
+		logpipe.LogCallback(func(line []byte) { logErr(logpipe.ParseGoStructuredLogs(line)) }),
+	)
+
+	t.Logger().Info("Starting op-conp2p sidecar", "name", name, "node_rpc", nodeUserRPC, "static_peer", sequencerGossipMultiaddr)
+	t.Require().NoError(sub.Start(bin, args, nil), "must start op-conp2p sidecar")
+
+	s := &OpConP2PSidecar{name: name, p: t, sub: sub}
+	t.Cleanup(s.Stop)
+	return s
+}
+
+func (s *OpConP2PSidecar) Stop() {
+	if s.sub == nil {
+		return
+	}
+	if err := s.sub.Stop(true); err != nil {
+		s.p.Logger().Warn("op-conp2p sidecar stop error", "err", err)
+	}
+	s.sub = nil
+}
+
+// sequencerGossipMultiaddr fetches the sequencer CL's gossip multiaddr (its
+// opp2p_self address) for use as the sidecar's static peer, ensuring the
+// /p2p/<peerID> suffix is present.
+func SequencerGossipMultiaddr(t devtest.T, sequencerCL L2CLNode) string {
+	p2pClient, err := GetP2PClient(t.Ctx(), t.Logger(), sequencerCL)
+	t.Require().NoError(err, "p2p client for sequencer CL")
+	self, err := GetPeerInfo(t.Ctx(), p2pClient)
+	t.Require().NoError(err, "sequencer CL self peer info")
+	addr := self.Addresses[0]
+	if !strings.Contains(addr, "/p2p/") {
+		addr = fmt.Sprintf("%s/p2p/%s", addr, self.PeerID.String())
+	}
+	return addr
+}

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -54,9 +54,10 @@ type MixedL2CLKind string
 const (
 	MixedL2CLOpNode MixedL2CLKind = "op-node"
 	MixedL2CLKona   MixedL2CLKind = "kona-node"
-	// MixedL2COpCon is op-con-node, the consensus-only verifier from the opql
-	// repo. It is verifier-only (no sequencing, no P2P), so the dispatch keeps
-	// sequencer slots on op-node and only routes verifier slots here.
+	// MixedL2COpCon is op-con-node, the consensus-only node from the opql repo.
+	// It has no P2P. The dispatch routes verifier slots here; sequencer slots
+	// stay on op-node (the historical verifier-only default) unless the test
+	// opts in to op-con-node's sequencing mode via L2CLOpConSequencer().
 	MixedL2CLOpCon MixedL2CLKind = "op-con-node"
 )
 

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -54,6 +54,10 @@ type MixedL2CLKind string
 const (
 	MixedL2CLOpNode MixedL2CLKind = "op-node"
 	MixedL2CLKona   MixedL2CLKind = "kona-node"
+	// MixedL2COpCon is op-con-node, the consensus-only verifier from the opql
+	// repo. It is verifier-only (no sequencing, no P2P), so the dispatch keeps
+	// sequencer slots on op-node and only routes verifier slots here.
+	MixedL2CLOpCon MixedL2CLKind = "op-con-node"
 )
 
 // SkipOnOpGeth skips the test when the L2 execution layer is op-geth
@@ -86,6 +90,14 @@ func FlakyOnOpReth(t devtest.T, reason string) {
 func FlakyOnKonaNode(t devtest.T, reason string) {
 	if devstackL2CLKind() == MixedL2CLKona {
 		t.MarkFlaky(reason)
+	}
+}
+
+// SkipOnOpConNode skips the test when the L2 consensus layer is op-con-node.
+// Use for behaviors op-con-node does not implement (sequencing, P2P gossip).
+func SkipOnOpConNode(t devtest.T, reason string) {
+	if devstackL2CLKind() == MixedL2CLOpCon {
+		t.Skipf("skipping on op-con-node: %s", reason)
 	}
 }
 

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -182,23 +182,25 @@ func startL2CLForKey(
 	case MixedL2CLKona:
 		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, nil)
 	case MixedL2CLOpCon:
-		// op-con-node cannot sequence; keep sequencer slots on op-node and route
-		// only verifier slots to op-con-node.
-		if !isSequencer {
-			// Resolve the op-con-specific knobs from the L2CL options (per-node, so a
-			// parallel sibling test is unaffected). Only OpConL1FinalizedGuard is used
-			// by op-con-node today.
-			opconCfg := DefaultL2CLConfig()
-			if len(l2CLOpts) > 0 {
-				target := NewComponentTarget(clKey, l2Net.ChainID())
-				for _, opt := range l2CLOpts {
-					if opt == nil {
-						continue
-					}
-					opt.Apply(t, target, opconCfg)
+		// Resolve the op-con-specific knobs from the L2CL options (per-node, so a
+		// parallel sibling test is unaffected). Only OpConL1FinalizedGuard and
+		// OpConSequencer are used by op-con-node today.
+		opconCfg := DefaultL2CLConfig()
+		if len(l2CLOpts) > 0 {
+			target := NewComponentTarget(clKey, l2Net.ChainID())
+			for _, opt := range l2CLOpts {
+				if opt == nil {
+					continue
 				}
+				opt.Apply(t, target, opconCfg)
 			}
-			return startMixedOpConNode(t, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, followSource, opconCfg.OpConL1FinalizedGuard, nil)
+		}
+		// Verifier slots always route to op-con-node. Sequencer slots stay on
+		// op-node (the historical verifier-only default) unless the test opts the
+		// sequencer slot into op-con-node's sequencing mode via
+		// L2CLOpConSequencer().
+		if !isSequencer || opconCfg.OpConSequencer {
+			return startMixedOpConNode(t, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, followSource, opconCfg.OpConL1FinalizedGuard, nil)
 		}
 		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 			Key:            clKey,

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -181,6 +181,21 @@ func startL2CLForKey(
 	switch devstackL2CLKind() {
 	case MixedL2CLKona:
 		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, nil)
+	case MixedL2CLOpCon:
+		// op-con-node cannot sequence; keep sequencer slots on op-node and route
+		// only verifier slots to op-con-node.
+		if !isSequencer {
+			return startMixedOpConNode(t, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, followSource, nil)
+		}
+		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
+			Key:            clKey,
+			IsSequencer:    true,
+			NoDiscovery:    true,
+			EnableReqResp:  true,
+			UseReqResp:     true,
+			L2FollowSource: followSource,
+			L2CLOptions:    l2CLOpts,
+		})
 	default: // op-node
 		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 			Key:            clKey,

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -185,7 +185,20 @@ func startL2CLForKey(
 		// op-con-node cannot sequence; keep sequencer slots on op-node and route
 		// only verifier slots to op-con-node.
 		if !isSequencer {
-			return startMixedOpConNode(t, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, followSource, nil)
+			// Resolve the op-con-specific knobs from the L2CL options (per-node, so a
+			// parallel sibling test is unaffected). Only OpConL1FinalizedGuard is used
+			// by op-con-node today.
+			opconCfg := DefaultL2CLConfig()
+			if len(l2CLOpts) > 0 {
+				target := NewComponentTarget(clKey, l2Net.ChainID())
+				for _, opt := range l2CLOpts {
+					if opt == nil {
+						continue
+					}
+					opt.Apply(t, target, opconCfg)
+				}
+			}
+			return startMixedOpConNode(t, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, followSource, opconCfg.OpConL1FinalizedGuard, nil)
 		}
 		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 			Key:            clKey,

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -69,6 +69,19 @@ func NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig(t devtest.T, withP2P 
 	return runtime
 }
 
+// NewSingleChainMultiNodeNoFaultProofsBareVerifierRuntime builds the
+// no-fault-proofs runtime with a BARE verifier: no follow source, no CL P2P, no
+// sidecar. The test drives the verifier's unsafe chain entirely via
+// admin_postUnsafePayload (the dsl SignalTarget/PostUnsafePayload path). Works for
+// both an op-node and an op-con-node verifier — both accept posted unsafe
+// payloads and apply them in order, filling gaps before advancing the head.
+func NewSingleChainMultiNodeNoFaultProofsBareVerifierRuntime(t devtest.T, cfg PresetConfig) *SingleChainRuntime {
+	runtime := NewMinimalNoFaultProofsRuntimeWithConfig(t, cfg)
+	addSingleChainOpNode(t, runtime, "b", false, "", cfg.GlobalL2CLOptions...)
+	runtime.P2PEnabled = false
+	return runtime
+}
+
 // addSingleChainOpConVerifierWithSidecar launches an op-con-node verifier whose
 // unsafe chain is delivered over OP gossip by the op-conp2p sidecar (peered to
 // the sequencer), rather than follow-mode. It seeds the expected unsafe-block

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -2,14 +2,18 @@ package sysgo
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	opconductor "github.com/ethereum-optimism/optimism/op-conductor/conductor"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -42,10 +46,20 @@ func NewSingleChainMultiNodeRuntimeWithConfig(t devtest.T, withP2P bool, cfg Pre
 // only exercise sequencer + batcher + verifier derivation.
 func NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig(t devtest.T, withP2P bool, cfg PresetConfig) *SingleChainRuntime {
 	runtime := NewMinimalNoFaultProofsRuntimeWithConfig(t, cfg)
-	// Wire the verifier's L2 follow source to the sequencer's L2 execution RPC.
-	// A consensus-only verifier (op-con-node) has no P2P, so it pulls the unsafe
-	// chain from this RPC and consolidates its L1-derived safe chain against it.
-	// op-node verifiers accept the same L2 follow source.
+	// With P2P and an op-con-node verifier, the verifier has no built-in P2P: it
+	// gets the unsafe chain over gossip via the op-conp2p sidecar (peered to the
+	// sequencer) and derives its safe chain from L1. No follow source, no CL P2P
+	// peering (which op-con-node cannot do).
+	if withP2P && devstackL2CLKind() == MixedL2CLOpCon {
+		addSingleChainOpConVerifierWithSidecar(t, runtime, "b", cfg.GlobalL2CLOptions...)
+		runtime.P2PEnabled = true
+		return runtime
+	}
+	// Otherwise wire the verifier's L2 follow source to the sequencer's L2
+	// execution RPC. A consensus-only verifier (op-con-node) without P2P pulls the
+	// unsafe chain from this RPC and consolidates its L1-derived safe chain against
+	// it. op-node verifiers accept the same L2 follow source and additionally peer
+	// over CL P2P when withP2P is set.
 	followSource := runtime.L2EL.UserRPC()
 	nodeB := addSingleChainOpNode(t, runtime, "b", false, followSource, cfg.GlobalL2CLOptions...)
 	if withP2P {
@@ -53,6 +67,38 @@ func NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig(t devtest.T, withP2P 
 	}
 	runtime.P2PEnabled = withP2P
 	return runtime
+}
+
+// addSingleChainOpConVerifierWithSidecar launches an op-con-node verifier whose
+// unsafe chain is delivered over OP gossip by the op-conp2p sidecar (peered to
+// the sequencer), rather than follow-mode. It seeds the expected unsafe-block
+// signer (the genesis signer is the sequencer P2P role address) so the verifier's
+// admin_verifyUnsafePayload can attribute gossiped blocks until an on-chain
+// rotation is observed.
+func addSingleChainOpConVerifierWithSidecar(t devtest.T, runtime *SingleChainRuntime, name string, l2Opts ...L2CLOption) *SingleChainNodeRuntime {
+	addrFor := intentbuilder.RoleToAddrProvider(t, runtime.Keys, runtime.L2Network.ChainID())
+	signer := addrFor(devkeys.SequencerP2PRole)
+	t.Require().NoError(os.Setenv("DEVSTACK_OPCON_UNSAFE_SIGNER", signer.Hex()),
+		"set op-con-node unsafe-block signer env")
+
+	// op-con-node verifier with no follow source: unsafe head arrives via gossip.
+	nodeB := addSingleChainOpNode(t, runtime, name, false, "", l2Opts...)
+
+	// The sidecar consumes the same standard rollup config (chain id + fork times
+	// drive the gossip topics) and peers with the sequencer's gossip address.
+	rollupPath := writeStandardRollupConfig(t, runtime.L2Network)
+	StartOpConP2PSidecar(t, "op-conp2p-"+name, nodeB.CL.UserRPC(), rollupPath, SequencerGossipMultiaddr(t, runtime.L2CL))
+	return nodeB
+}
+
+// writeStandardRollupConfig marshals the network's rollup config (the standard
+// op-node schema) to a temp file for the op-conp2p sidecar.
+func writeStandardRollupConfig(t devtest.T, l2Net *L2Network) string {
+	data, err := json.Marshal(l2Net.rollupCfg)
+	t.Require().NoError(err, "marshal rollup config for op-conp2p sidecar")
+	path := filepath.Join(t.TempDir(), "rollup.json")
+	t.Require().NoError(os.WriteFile(path, data, 0o644), "write rollup config for op-conp2p sidecar")
+	return path
 }
 
 func NewSingleChainTwoVerifiersRuntime(t devtest.T) *SingleChainRuntime {

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -36,6 +36,25 @@ func NewSingleChainMultiNodeRuntimeWithConfig(t devtest.T, withP2P bool, cfg Pre
 	return runtime
 }
 
+// NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig is like
+// NewSingleChainMultiNodeRuntimeWithConfig but skips the proposer and
+// challenger (no cannon prestate artifacts required). Intended for tests that
+// only exercise sequencer + batcher + verifier derivation.
+func NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig(t devtest.T, withP2P bool, cfg PresetConfig) *SingleChainRuntime {
+	runtime := NewMinimalNoFaultProofsRuntimeWithConfig(t, cfg)
+	// Wire the verifier's L2 follow source to the sequencer's L2 execution RPC.
+	// A consensus-only verifier (op-con-node) has no P2P, so it pulls the unsafe
+	// chain from this RPC and consolidates its L1-derived safe chain against it.
+	// op-node verifiers accept the same L2 follow source.
+	followSource := runtime.L2EL.UserRPC()
+	nodeB := addSingleChainOpNode(t, runtime, "b", false, followSource, cfg.GlobalL2CLOptions...)
+	if withP2P {
+		connectSingleChainNodes(t, runtime.L2EL, runtime.L2CL, nodeB)
+	}
+	runtime.P2PEnabled = withP2P
+	return runtime
+}
+
 func NewSingleChainTwoVerifiersRuntime(t devtest.T) *SingleChainRuntime {
 	return NewSingleChainTwoVerifiersRuntimeWithConfig(t, PresetConfig{})
 }

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -312,7 +312,7 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		payloadBytes := data[65:]
 
 		// [REJECT] if the signature by the sequencer is not valid
-		result := verifyBlockSignature(log, cfg, runCfg, id, signature, payloadBytes)
+		result := verifyBlockSignature(ctx, log, cfg, runCfg, id, blockVersion, signature, payloadBytes)
 		if result != pubsub.ValidationAccept {
 			return result
 		}
@@ -448,7 +448,43 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 	}
 }
 
-func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, id peer.ID, signature eth.Bytes65, payloadBytes []byte) pubsub.ValidationResult {
+// DelegatedBlockSignatureValidator is an optional capability a
+// GossipRuntimeConfig may implement to take over the unsafe-block signature
+// check entirely. When the runtime config passed to the gossip layer implements
+// it, BuildBlocksValidator routes the signature decision here instead of the
+// built-in recover-and-compare against P2PSequencerAddress().
+//
+// This lets a consensus node that already owns the sequencer-signer truth (e.g.
+// opql's op-con-node / op-con-ex-node) return the gossipsub verdict directly,
+// keeping a P2P sidecar free of any signer state. The delegate receives the
+// snappy-decompressed, signature-stripped SSZ payload bytes and the 65-byte
+// gossip signature; it derives the payload hash (keccak256 of the payload
+// bytes) itself. It MUST honor the gossipsub contract: return ValidationIgnore
+// (never ValidationReject) when it cannot yet attribute the block to a signer,
+// so honest peers are not penalized.
+type DelegatedBlockSignatureValidator interface {
+	ValidateUnsafeBlockSignature(
+		ctx context.Context,
+		chainID eth.ChainID,
+		version eth.BlockVersion,
+		signature eth.Bytes65,
+		payloadBytes []byte,
+	) pubsub.ValidationResult
+}
+
+func verifyBlockSignature(ctx context.Context, log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, id peer.ID, blockVersion eth.BlockVersion, signature eth.Bytes65, payloadBytes []byte) pubsub.ValidationResult {
+	// If the runtime config delegates the signature decision (e.g. to an
+	// external consensus node), defer to it entirely.
+	if delegate, ok := runCfg.(DelegatedBlockSignatureValidator); ok {
+		return delegate.ValidateUnsafeBlockSignature(
+			ctx,
+			eth.ChainIDFromBig(cfg.L2ChainID),
+			blockVersion,
+			signature,
+			payloadBytes,
+		)
+	}
+
 	currentAddr := runCfg.P2PSequencerAddress()
 	chain := eth.ChainIDFromBig(cfg.L2ChainID)
 

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -73,7 +73,7 @@ func TestVerifyBlockSignature(t *testing.T) {
 		signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secrets)}
 		sig, err := signer.SignBlockV1(context.Background(), eth.ChainIDFromBig(cfg.L2ChainID), opsigner.PayloadHash(msg))
 		require.NoError(t, err)
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
+		result := verifyBlockSignature(context.Background(), logger, cfg, runCfg, peerId, eth.BlockV1, sig, msg)
 		require.Equal(t, pubsub.ValidationAccept, result)
 	})
 
@@ -82,14 +82,14 @@ func TestVerifyBlockSignature(t *testing.T) {
 		signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secrets)}
 		sig, err := signer.SignBlockV1(context.Background(), eth.ChainIDFromBig(cfg.L2ChainID), opsigner.PayloadHash(msg))
 		require.NoError(t, err)
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
+		result := verifyBlockSignature(context.Background(), logger, cfg, runCfg, peerId, eth.BlockV1, sig, msg)
 		require.Equal(t, pubsub.ValidationReject, result)
 	})
 
 	t.Run("InvalidSignature", func(t *testing.T) {
 		runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: crypto.PubkeyToAddress(secrets.PublicKey)}
 		sig := eth.Bytes65{}
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
+		result := verifyBlockSignature(context.Background(), logger, cfg, runCfg, peerId, eth.BlockV1, sig, msg)
 		require.Equal(t, pubsub.ValidationReject, result)
 	})
 
@@ -98,7 +98,7 @@ func TestVerifyBlockSignature(t *testing.T) {
 		signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secrets)}
 		sig, err := signer.SignBlockV1(context.Background(), eth.ChainIDFromBig(cfg.L2ChainID), opsigner.PayloadHash(msg))
 		require.NoError(t, err)
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
+		result := verifyBlockSignature(context.Background(), logger, cfg, runCfg, peerId, eth.BlockV1, sig, msg)
 		require.Equal(t, pubsub.ValidationIgnore, result)
 	})
 
@@ -136,7 +136,7 @@ func TestVerifyBlockSignature(t *testing.T) {
 			signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(tc.signWith)}
 			sig, err := signer.SignBlockV1(context.Background(), eth.ChainIDFromBig(cfg.L2ChainID), opsigner.PayloadHash(msg))
 			require.NoError(t, err)
-			result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
+			result := verifyBlockSignature(context.Background(), logger, cfg, runCfg, peerId, eth.BlockV1, sig, msg)
 			require.Equal(t, tc.wantResult, result)
 			require.Equal(t, tc.wantConfirm, runCfg.Confirmed)
 		})


### PR DESCRIPTION
## Summary

Wires **op-con-node** (the [opql](https://github.com/ethereum-optimism/opql) consensus-only OP node) into `op-devstack` as an external-subprocess L2 CL kind, selectable via `DEVSTACK_L2CL_KIND=op-con-node`. This lets the devstack acceptance suite run op-con-node as a verifier CL in place of op-node/kona.

op-con-node is **verifier-only** — no sequencing, no P2P gossip. It derives the safe chain from L1 and drives its own EL (op-reth) over the Engine API; the unsafe head is followed from the sequencer's L2 EL.

## Changes

- **`op-devstack/sysgo/l2_cl_opcon.go`** — `OpConNode` launcher: spawns `op-con-node run`, polls the RPC for readiness, fronts it. Binary resolved via rustbin overrides (`RUST_BINARY_PATH_OP_CON_NODE` / `RUST_SRC_DIR_OP_CON_NODE`) since op-con-node lives in the sibling opql repo.
- **`op-devstack/sysgo/mixed_runtime.go`** — `MixedL2CLOpCon` kind + `SkipOnOpConNode`.
- **`op-devstack/sysgo/singlechain_build.go`** — dispatch verifier slots to op-con-node, keep the sequencer on op-node.
- **`op-devstack/sysgo/singlechain_variants.go`** / **`op-devstack/presets/singlechain_multinode.go`** — no-fault-proofs multinode runtime + preset (avoids requiring cannon), with the verifier's follow source wired to the sequencer L2 EL.
- **`op-acceptance-tests/tests/opcon/verifier_test.go`** — `TestOpConVerifierDerivesSafeHead`.

## Status

The acceptance test **passes** (`TestOpConVerifierDerivesSafeHead` → `ok`). The earlier safe-head-stuck blocker (op-con-node ingested from `anchor_L1_origin + 1`, so a genesis anchor never ingested L1 block 0 and `derive_batch` could not advance) was fixed on the opql side; op-con-node now derives the safe head from L1 against the devstack.

> Local opql integration. Opening per request to make the branch reviewable; not necessarily intended to merge into `develop` as-is.

## Test plan

```
DEVSTACK_L2CL_KIND=op-con-node DEVSTACK_L2EL_KIND=op-reth \
RUST_BINARY_PATH_OP_CON_NODE=<opql>/target/debug/op-con-node \
go test -run TestOpConVerifierDerivesSafeHead ./op-acceptance-tests/tests/opcon/
```
