### PR TITLE
ci: pin protobuf-equipped ci-base-clang image, drop per-job protoc install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,11 @@ parameters:
   default_docker_image:
     type: string
     default: cimg/base:2026.03
-  # Pinned ci-base-clang image (cimg/base + clang/llvm-dev/libclang-dev) for Rust jobs.
+  # Pinned ci-base-clang image (cimg/base + clang/llvm-dev/libclang-dev + protobuf-compiler) for Rust jobs.
   # Provenance is verified by .github/workflows/security.yml.
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:d79c625a042269c64b2444ef1edf9bb4a399d1c892caee57f9021be067da5617
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
   base_image:
     type: string
     default: default

--- a/.circleci/continue/helpers.yml
+++ b/.circleci/continue/helpers.yml
@@ -101,30 +101,15 @@ commands:
             - run:
                 name: Ensure clang available
                 command: 'command -v clang >/dev/null 2>&1 || { echo "ERROR: clang is required but was not found in PATH" >&2; exit 1; }'
-      # protoc (sp1-sdk prost/tonic build dep) is now preinstalled in
-      # ci-base-clang. TODO: once a rebuilt image is pinned, drop this fallback
-      # install to a clang-style presence check.
+      # protoc + libprotobuf-dev well-known types (sp1-sdk prost/tonic build
+      # dep) are preinstalled in ci-base-clang, so just assert their presence.
       - run:
           name: Ensure protobuf compiler available
           command: |
-            if command -v protoc >/dev/null 2>&1 && [ -f /usr/include/google/protobuf/empty.proto ]; then
-              protoc --version
-              exit 0
+            if ! command -v protoc >/dev/null 2>&1 || [ ! -f /usr/include/google/protobuf/empty.proto ]; then
+              echo "ERROR: protoc and the protobuf well-known type includes are required but were not found in PATH (expected in the ci-base-clang image)" >&2
+              exit 1
             fi
-
-            for i in 1 2 3; do
-              if sudo -E apt-get -o Acquire::Retries=5 update; then
-                break
-              fi
-              if [ "$i" = "3" ]; then
-                echo "apt-get update failed after 3 attempts" >&2
-                exit 1
-              fi
-              echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
-              sleep 10
-            done
-
-            sudo -E apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev
             protoc --version
       # Shared GCS compile cache (op-rust-sccache).
       - rust-sccache-setup:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -6,7 +6,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:758f67c7212e7d05c3d02c34f26766ef86f657d3bb811da07cc01e37b736ebef
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
   c-base_image:
     type: string
     default: default
@@ -28,7 +28,7 @@ parameters:
     default: cimg/base:2026.03
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:d79c625a042269c64b2444ef1edf9bb4a399d1c892caee57f9021be067da5617
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
   base_image:
     type: string
     default: default

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:758f67c7212e7d05c3d02c34f26766ef86f657d3bb811da07cc01e37b736ebef
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
   c-base_image:
     type: string
     default: default

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:758f67c7212e7d05c3d02c34f26766ef86f657d3bb811da07cc01e37b736ebef
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
   c-go-cache-version:
     type: string
     default: "v0.1"


### PR DESCRIPTION
Follow-up to #21489.

- Pin the rebuilt `ci-base-clang` image (now ships `protobuf-compiler` + `libprotobuf-dev`); digest `sha256:873a6709…` is attested on develop. Also realigns the `c-rust_base_image` fragment defaults, which had drifted to an older digest.
- Replace the per-job `apt-get install protoc` fallback in `rust-prepare` with a presence check.

Validated: `merge-configs.sh`, `circleci config validate` (orb stubbed), `test-decision-tree.sh` (18/0).