### PR TITLE
chore(ci): raise fuzz no_output_timeout to 60m for diagnostics

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1593,7 +1593,10 @@ jobs:
           namespace: fuzz-<<parameters.package_name>>
       - run:
           name: Fuzz
-          no_output_timeout: 15m
+          # TEMPORARY (diagnostic): raised from 15m so CircleCI doesn't kill a slow
+          # or hung fuzz run before it produces output. Lets us tell a genuine
+          # slowdown apart from the Go 1.26 fuzzing deadline race. Revert after.
+          no_output_timeout: 60m
           command: |
             just fuzz
           working_directory: "<<parameters.package_name>>"


### PR DESCRIPTION
## What

Temporarily raises `no_output_timeout` on the `fuzz-golang` job from **15m → 60m** (covers all six fuzz jobs: op-node, op-service, op-chain-ops, op-challenger, cannon-fuzz, op-e2e-fuzz).

## Why

Go-fuzz jobs began failing fleet-wide on 2026-06-23, the first full day after **#21452 bumped Go 1.24.13 → 1.26.4** (merged 6/22). Most failures are `context deadline exceeded` raised at exactly `-fuzztime`, while the worker was running at full throughput — the signature of the Go 1.26 fuzzing deadline race ([golang/go#75804](https://github.com/golang/go/issues/75804)). The earlier `-parallel=1` fix (#21517) addressed CPU oversubscription and cannot affect a runtime deadline-reporting race.

This change is **diagnostic, not a fix**: it removes CircleCI's 15m kill as a confounding variable so a genuinely slow or hung run (e.g. `op-e2e-fuzz`, whose p95 sits at the 900s wall) runs to completion and emits output we can inspect — letting us separate a real slowdown from the spurious deadline race.

## Follow-up

To be reverted once we have the data. The real remediation for the deadline race is tracked separately (revert/pin Go, switch affected jobs to count-based, or wait for the upstream Go patch).