### PR TITLE
fix(op-challenger): make game-proposal-outputs.sh actually work

### DIFF
--- a/op-challenger/scripts/game-proposal-outputs.sh
+++ b/op-challenger/scripts/game-proposal-outputs.sh
@@ -52,7 +52,9 @@ SEL_STATUS="0x200d2ed2"    # status() -> uint8 (0=IN_PROGRESS,1=CHALLENGER_WINS,
 SEL_COUNT="0x4d1975b4"     # gameCount()
 SEL_AT="0xbb8aa1fc"        # gameAtIndex(uint256) -> (gameType, timestamp, proxy)
 
-rpc() { # rpc <url> <method> <params-json> -> .result (string), retries
+rpc() { # rpc <url> <method> <params-json> -> .result, retries
+        # String results print raw (hex callers consume them directly); object/array
+        # results print as JSON so callers can re-parse with json.load.
   local url="$1" m="$2" p="$3" resp out attempt
   for ((attempt = 1; attempt <= RETRIES; attempt++)); do
     resp=$(curl -s -m 25 -X POST "$url" -H 'content-type: application/json' \
@@ -61,7 +63,9 @@ rpc() { # rpc <url> <method> <params-json> -> .result (string), retries
 try: d=json.load(sys.stdin)
 except Exception: print("RETRY"); sys.exit()
 r=d.get("result")
-print(r if r is not None else "ERR:"+json.dumps(d.get("error","no result")))' 2>/dev/null)
+if r is None: print("ERR:"+json.dumps(d.get("error","no result")))
+elif isinstance(r,str): print(r)
+else: print(json.dumps(r))' 2>/dev/null)
     [[ "$out" == "RETRY" || -z "$out" ]] && { sleep 1; continue; }
     printf '%s' "$out"; return 0
   done


### PR DESCRIPTION
## What

`op-challenger/scripts/game-proposal-outputs.sh` is currently non-functional: every `outputRoot`, `l1Head`, and `safeHead` column comes back `ERR`.

The `rpc()` helper printed object/array results with bare `print(r)`, which emits a Python `repr` (single-quoted) instead of JSON. The callers that re-parse the output with `json.load` — `eth_getBlockByHash`, `optimism_outputAtBlock`, `optimism_safeHeadAtL1Block` — then fail to parse it. Only the string-returning calls (`l2BlockNumber()`, `status()`) survived, which is why the L2 block column populated but everything sourced from the op-node didn't.

## Fix

Print string results raw (hex callers consume them directly) and JSON-encode object/array results so they round-trip through `json.load`.

## Test

Ran against a live op-node for soneium-minato-sepolia (both `--factory --last N` and explicit-game-address forms). All columns now populate with correct values, cross-checked against an independent reimplementation of the same RPC calls:

```
game                                         status  l2block    outputRoot(ours)                                                   l1Head     safeHead(ours)
0x3ddfb3c5ecb18fe5f4dcffe052cbec3c3853344e   IN_PROG 29541759   0xede109637900d069eab8a7dfcced76725b303df0cb0feb4c1890903173c9da62 11127878   29542323 ...
```