### PR TITLE
ci: run Go fuzz jobs as seed-only checks

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1592,10 +1592,17 @@ jobs:
       - go-restore-cache:
           namespace: fuzz-<<parameters.package_name>>
       - run:
-          name: Fuzz
+          name: Run fuzz seeds
           no_output_timeout: 15m
           command: |
-            just fuzz
+            case "<<parameters.package_name>>" in
+              op-challenger) go test -count=1 -run=Fuzz -v ./game/keccak/matrix ;;
+              op-node) go test -count=1 -run=Fuzz -v ./rollup/derive ;;
+              op-service) go test -count=1 -run=Fuzz -v ./eth ;;
+              op-chain-ops) go test -count=1 -run=Fuzz -v ./crossdomain ;;
+              cannon) go test -count=1 -run=Fuzz -v ./mipsevm/tests ;;
+              op-e2e) go test -count=1 -run=Fuzz -tags cgo_test -v ./opgeth ;;
+            esac
           working_directory: "<<parameters.package_name>>"
       - go-save-cache:
           namespace: fuzz-<<parameters.package_name>>


### PR DESCRIPTION
## Summary

- run Go fuzz CI jobs as seed-corpus tests with `go test -run=Fuzz` instead of time-bounded fuzz exploration
- keep each job scoped to the same package path covered by the old `just fuzz` target
- keep the `cgo_test` tag for the `op-e2e` fuzz seed job

## Known gap

This is a demonstrator for moving PR / merge-queue CI away from time-bounded `-fuzz` exploration. It does not add or backfill seed corpora.

I checked the current Go fuzz CI package paths and found no committed `testdata/fuzz/...` corpus files. Some targets have inline `f.Add(...)` seeds, but many do not. For targets without either inline seeds or corpus files, `go test -run=Fuzz` runs the fuzz harness setup but does not execute meaningful seed cases.

That is intentional for this PR: it shows the mechanical CI split. Deciding whether to add seeds, keep scheduled fuzz exploration, or retire these fuzz jobs entirely should be a follow-up decision.

## Tests

- `ruby -e 'require "yaml"; YAML.load_file(".circleci/continue/main.yml"); puts "yaml ok"'`
- `GOCACHE=/private/tmp/optimism-go-cache go test -count=1 -run=Fuzz -v ./game/keccak/matrix`
- `GOCACHE=/private/tmp/optimism-go-cache go test -count=1 -run=Fuzz -v ./crossdomain`
- `GOCACHE=/private/tmp/optimism-go-cache go test -count=1 -run=Fuzz -v ./eth`
- `GOCACHE=/private/tmp/optimism-go-cache go test -count=1 -run=Fuzz -v ./rollup/derive`