### PR TITLE
feat(kona/node): implement syncmode.offset-el-safe for op-node parity

### DIFF
--- a/rust/kona/bin/node/src/commands/node.rs
+++ b/rust/kona/bin/node/src/commands/node.rs
@@ -22,7 +22,7 @@ use kona_registry::{L1Config, scr_rollup_config_by_alloy_ident};
 use op_alloy_network::Optimism;
 use op_alloy_provider::ext::engine::OpEngineApi;
 use serde_json::from_reader;
-use std::{fs::File, io::Write, path::PathBuf, sync::Arc};
+use std::{fs::File, io::Write, path::PathBuf, sync::Arc, time::Duration};
 use strum::IntoEnumIterator;
 use tracing::{debug, error, info};
 
@@ -311,6 +311,7 @@ impl NodeCommand {
             l2_jwt_secret: jwt_secret,
             l1_url: self.l1_rpc_args.l1_eth_rpc.clone(),
             mode: self.node_mode,
+            offset_el_safe: Duration::from_secs(self.l2_client_args.offset_el_safe),
         };
 
         let dependency_set = self.load_dependency_set(&cfg)?;

--- a/rust/kona/bin/node/src/flags/engine/providers.rs
+++ b/rust/kona/bin/node/src/flags/engine/providers.rs
@@ -8,6 +8,10 @@ const DEFAULT_L2_ENGINE_TIMEOUT: u64 = 30_000;
 const DEFAULT_L2_TRUST_RPC: bool = true;
 const DEFAULT_L1_TRUST_RPC: bool = true;
 
+/// Default for `--syncmode.offset-el-safe`, in seconds. 12h matches the OP Mainnet sequencing
+/// window and op-node's default.
+const DEFAULT_OFFSET_EL_SAFE_SECS: u64 = 12 * 60 * 60;
+
 /// L1 client arguments.
 #[derive(Clone, Debug, clap::Args)]
 pub struct L1ClientArgs {
@@ -80,6 +84,18 @@ pub struct L2ClientArgs {
         default_value_t = DEFAULT_L2_TRUST_RPC
     )]
     pub l2_trust_rpc: bool,
+    /// After execution-layer sync completes, set the safe and finalized heads to this many seconds
+    /// behind the synced tip (converted to L2 blocks via the rollup block time, rounding up). This
+    /// forces derivation to re-derive the most recent window before it is considered safe. Set to
+    /// `0` to disable. Defaults to 12h (the OP Mainnet sequencing window), matching op-node's
+    /// `--syncmode.offset-el-safe`.
+    #[arg(
+        long = "syncmode.offset-el-safe",
+        env = "KONA_NODE_SYNCMODE_OFFSET_EL_SAFE",
+        default_value_t = DEFAULT_OFFSET_EL_SAFE_SECS,
+        value_name = "SECONDS"
+    )]
+    pub offset_el_safe: u64,
 }
 
 impl Default for L2ClientArgs {
@@ -90,6 +106,7 @@ impl Default for L2ClientArgs {
             l2_engine_jwt_encoded: None,
             l2_engine_timeout: DEFAULT_L2_ENGINE_TIMEOUT,
             l2_trust_rpc: DEFAULT_L2_TRUST_RPC,
+            offset_el_safe: DEFAULT_OFFSET_EL_SAFE_SECS,
         }
     }
 }

--- a/rust/kona/crates/node/engine/src/lib.rs
+++ b/rust/kona/crates/node/engine/src/lib.rs
@@ -71,7 +71,10 @@ mod metrics;
 pub use metrics::Metrics;
 
 mod sync;
-pub use sync::{L2ForkchoiceState, SyncStartError, find_starting_forkchoice};
+pub use sync::{
+    L2ForkchoiceState, SyncStartError, duration_to_blocks, find_starting_forkchoice,
+    offset_block_num,
+};
 
 #[cfg(any(test, feature = "test-utils"))]
 /// Utilities that are useful when creating unit tests using structs within this library.

--- a/rust/kona/crates/node/engine/src/sync/forkchoice.rs
+++ b/rust/kona/crates/node/engine/src/sync/forkchoice.rs
@@ -7,7 +7,7 @@ use alloy_transport::TransportResult;
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
 use op_alloy_network::Optimism;
-use std::fmt::Display;
+use std::{fmt::Display, time::Duration};
 
 /// An unsafe, safe, and finalized [`L2BlockInfo`] returned by the
 /// [`crate::find_starting_forkchoice`] function.
@@ -78,6 +78,94 @@ impl L2ForkchoiceState {
 
         Ok(Self { un_safe, safe, finalized })
     }
+
+    /// Fetches the forkchoice state to install after **execution-layer (EL) sync** completes.
+    ///
+    /// This mirrors op-node's behavior for `--syncmode.offset-el-safe`: the unsafe head stays at
+    /// the synced tip, while the safe and finalized heads are retracted by
+    /// `ceil(offset / block_time)` blocks (see [`offset_block_num`]). Retracting forces derivation
+    /// to re-derive the most recent `offset` worth of blocks before they are considered safe,
+    /// rather than trusting the optimistically-synced tip.
+    ///
+    /// To avoid re-deriving the offset window on every restart (kona has no persisted safe head),
+    /// the safe and finalized heads are never retracted below the EL's currently-reported safe and
+    /// finalized heads (read via [`Self::current`]).
+    ///
+    /// This relies on a property of kona's EL-sync forkchoice updates: the safe and finalized heads
+    /// are only ever advanced by *derivation*, never during EL sync (P2P-driven `InsertTask`s send
+    /// forkchoice updates with the safe/finalized heads left at their default). So while the chain
+    /// is being optimistically synced the EL is told `safe = finalized = 0x0` and reports no
+    /// safe/finalized tag; [`Self::current`] then falls back to genesis. Hence on the **initial**
+    /// post-EL-sync reset the EL heads are genesis and the offset applies in full, whereas on a
+    /// **later restart** the EL has the safe/finalized heads that derivation previously committed
+    /// (already at or above the offset head), so nothing is re-derived.
+    pub async fn for_el_sync<EngineClient_: EngineClient>(
+        cfg: &RollupConfig,
+        engine_client: &EngineClient_,
+        offset: Duration,
+    ) -> Result<Self, SyncStartError> {
+        let current = Self::current(cfg, engine_client).await?;
+        let tip = current.un_safe;
+
+        let target =
+            offset_block_num(offset, cfg.block_time, tip.block_info.number, cfg.genesis.l2.number);
+        let offset_ref = if target < tip.block_info.number {
+            let block_id = BlockId::Number(target.into());
+            let block = engine_client
+                .get_l2_block(block_id)
+                .full()
+                .await?
+                .ok_or(SyncStartError::BlockNotFound(block_id))?;
+            L2BlockInfo::from_block_and_genesis(&block.into_consensus(), &cfg.genesis)?
+        } else {
+            tip
+        };
+
+        Ok(current.with_el_sync_offset(offset_ref))
+    }
+
+    /// Applies the EL-sync offset head to the current forkchoice, never retracting the safe or
+    /// finalized heads below where they already are. Pure helper split out of [`Self::for_el_sync`]
+    /// to keep the head-selection logic unit-testable without an engine client.
+    const fn with_el_sync_offset(self, offset_ref: L2BlockInfo) -> Self {
+        let safe = if self.safe.block_info.number >= offset_ref.block_info.number {
+            self.safe
+        } else {
+            offset_ref
+        };
+        let finalized = if self.finalized.block_info.number >= offset_ref.block_info.number {
+            self.finalized
+        } else {
+            offset_ref
+        };
+        Self { un_safe: self.un_safe, safe, finalized }
+    }
+}
+
+/// Returns `ceil(offset / block_time)` as a block count.
+///
+/// Ceiling division is used so the retraction always covers the full requested duration. A zero
+/// offset or zero block time yields `0`. Sub-second remainders are truncated, matching op-node's
+/// `DurationToBlocks`.
+pub const fn duration_to_blocks(offset: Duration, block_time: u64) -> u64 {
+    if offset.is_zero() || block_time == 0 {
+        return 0;
+    }
+    let secs = offset.as_secs();
+    secs.div_ceil(block_time)
+}
+
+/// Returns the block number that is `offset` behind `head`, clamped so it never goes below
+/// `genesis`. Returns `head` unchanged when the offset is zero or `head` is already at or below
+/// `genesis`. Mirrors op-node's `OffsetBlockNum`.
+pub const fn offset_block_num(offset: Duration, block_time: u64, head: u64, genesis: u64) -> u64 {
+    let n = duration_to_blocks(offset, block_time);
+    if n == 0 || head <= genesis {
+        return head;
+    }
+    let max_retract = head - genesis;
+    let n = if n > max_retract { max_retract } else { n };
+    head - n
 }
 
 /// Wrapper function around [`EngineClient::get_l2_block`] to handle compatibility issues with geth
@@ -98,5 +186,96 @@ async fn get_block_compat<EngineClient_: EngineClient>(
             }
         }
         r => r,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kona_protocol::BlockInfo;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::zero_offset(Duration::ZERO, 2, 0)]
+    #[case::zero_block_time(Duration::from_secs(3600), 0, 0)]
+    #[case::rounds_up(Duration::from_secs(3), 2, 2)]
+    #[case::exact_multiple(Duration::from_secs(4), 2, 2)]
+    #[case::rounds_up_larger_block_time(Duration::from_secs(15), 4, 4)]
+    #[case::exact_multiple_larger_block_time(Duration::from_secs(16), 4, 4)]
+    #[case::sub_second_truncates(Duration::from_millis(500), 1, 0)]
+    #[case::twelve_hours(Duration::from_secs(12 * 3600), 2, 21600)]
+    fn test_duration_to_blocks(
+        #[case] offset: Duration,
+        #[case] block_time: u64,
+        #[case] expected: u64,
+    ) {
+        assert_eq!(duration_to_blocks(offset, block_time), expected);
+    }
+
+    #[rstest]
+    #[case::zero_offset(Duration::ZERO, 2, 100, 0, 100)]
+    #[case::head_at_genesis(Duration::from_secs(10), 2, 0, 0, 0)]
+    #[case::head_below_genesis(Duration::from_secs(10), 2, 5, 10, 5)]
+    #[case::retracts_five_blocks(Duration::from_secs(10), 2, 100, 0, 95)]
+    #[case::clamped_at_genesis(Duration::from_secs(1000 * 3600), 2, 10, 0, 0)]
+    #[case::retracts_exactly_to_genesis(Duration::from_secs(10), 2, 15, 10, 10)]
+    #[case::rounds_up(Duration::from_secs(15), 4, 100, 0, 96)]
+    fn test_offset_block_num(
+        #[case] offset: Duration,
+        #[case] block_time: u64,
+        #[case] head: u64,
+        #[case] genesis: u64,
+        #[case] expected: u64,
+    ) {
+        assert_eq!(offset_block_num(offset, block_time, head, genesis), expected);
+    }
+
+    /// Builds an [`L2BlockInfo`] carrying only the block number, which is all the EL-sync
+    /// head-selection logic inspects.
+    fn block_at(number: u64) -> L2BlockInfo {
+        L2BlockInfo { block_info: BlockInfo { number, ..Default::default() }, ..Default::default() }
+    }
+
+    #[test]
+    fn with_el_sync_offset_retracts_to_offset_head_on_initial_sync() {
+        // On the initial EL sync the EL reports genesis (0) for safe and finalized, so both
+        // retract to the offset head while the unsafe head stays at the tip.
+        let current = L2ForkchoiceState {
+            un_safe: block_at(1000),
+            safe: block_at(0),
+            finalized: block_at(0),
+        };
+        let result = current.with_el_sync_offset(block_at(900));
+        assert_eq!(result.un_safe.block_info.number, 1000);
+        assert_eq!(result.safe.block_info.number, 900);
+        assert_eq!(result.finalized.block_info.number, 900);
+    }
+
+    #[test]
+    fn with_el_sync_offset_never_retracts_below_current_heads() {
+        // On a restart the EL already reports safe/finalized at or above the offset head, so they
+        // are left untouched and the offset window is not re-derived.
+        let current = L2ForkchoiceState {
+            un_safe: block_at(1000),
+            safe: block_at(950),
+            finalized: block_at(920),
+        };
+        let result = current.with_el_sync_offset(block_at(900));
+        assert_eq!(result.un_safe.block_info.number, 1000);
+        assert_eq!(result.safe.block_info.number, 950);
+        assert_eq!(result.finalized.block_info.number, 920);
+    }
+
+    #[test]
+    fn with_el_sync_offset_advances_finalized_to_offset_when_behind() {
+        // Mixed case: safe is ahead of the offset head (kept), finalized is behind (advanced).
+        let current = L2ForkchoiceState {
+            un_safe: block_at(1000),
+            safe: block_at(950),
+            finalized: block_at(800),
+        };
+        let result = current.with_el_sync_offset(block_at(900));
+        assert_eq!(result.safe.block_info.number, 950);
+        assert_eq!(result.finalized.block_info.number, 900);
     }
 }

--- a/rust/kona/crates/node/engine/src/sync/mod.rs
+++ b/rust/kona/crates/node/engine/src/sync/mod.rs
@@ -4,7 +4,7 @@ use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
 
 mod forkchoice;
-pub use forkchoice::L2ForkchoiceState;
+pub use forkchoice::{L2ForkchoiceState, duration_to_blocks, offset_block_num};
 
 mod error;
 pub use error::SyncStartError;

--- a/rust/kona/crates/node/engine/src/task_queue/core.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/core.rs
@@ -3,12 +3,12 @@
 use super::EngineTaskExt;
 use crate::{
     EngineClient, EngineState, EngineSyncStateUpdate, EngineTask, EngineTaskError,
-    EngineTaskErrorSeverity, Metrics, SyncStartError, SynchronizeTask, SynchronizeTaskError,
-    find_starting_forkchoice, task_queue::EngineTaskErrors,
+    EngineTaskErrorSeverity, L2ForkchoiceState, Metrics, SyncStartError, SynchronizeTask,
+    SynchronizeTaskError, find_starting_forkchoice, task_queue::EngineTaskErrors,
 };
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
-use std::{collections::BinaryHeap, sync::Arc};
+use std::{collections::BinaryHeap, sync::Arc, time::Duration};
 use thiserror::Error;
 use tokio::sync::watch::Sender;
 
@@ -69,18 +69,33 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         self.task_queue_length.send_replace(self.tasks.len());
     }
 
-    /// Resets the engine by finding a plausible sync starting point via
-    /// [`find_starting_forkchoice`]. The state will be updated to the starting point, and a
-    /// forkchoice update will be enqueued in order to reorg the execution layer.
+    /// Resets the engine by finding a plausible sync starting point. The state will be updated to
+    /// the starting point, and a forkchoice update will be enqueued in order to reorg the execution
+    /// layer.
+    ///
+    /// When `offset_el_safe` is `Some`, this is the reset that runs once **execution-layer sync**
+    /// completes: the starting point comes from [`L2ForkchoiceState::for_el_sync`], retracting the
+    /// safe/finalized heads by the configured offset. Otherwise the standard sync-start search via
+    /// [`find_starting_forkchoice`] is used.
     pub async fn reset(
         &mut self,
         client: Arc<EngineClient_>,
         config: Arc<RollupConfig>,
+        offset_el_safe: Option<Duration>,
     ) -> Result<L2BlockInfo, EngineResetError> {
         // Clear any outstanding tasks to prepare for the reset.
         self.clear();
 
-        let mut start = find_starting_forkchoice(&config, client.as_ref()).await?;
+        let find_start = || async {
+            match offset_el_safe {
+                Some(offset) => {
+                    L2ForkchoiceState::for_el_sync(&config, client.as_ref(), offset).await
+                }
+                None => find_starting_forkchoice(&config, client.as_ref()).await,
+            }
+        };
+
+        let mut start = find_start().await?;
 
         // Retry to synchronize the engine until we succeeds or a critical error occurs.
         while let Err(err) = SynchronizeTask::new(
@@ -102,7 +117,7 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
                 EngineTaskErrorSeverity::Flush |
                 EngineTaskErrorSeverity::Reset => {
                     warn!(target: "engine", ?err, "Forkchoice update failed during reset. Trying again...");
-                    start = find_starting_forkchoice(&config, client.as_ref()).await?;
+                    start = find_start().await?;
                 }
                 EngineTaskErrorSeverity::Critical => {
                     return Err(EngineResetError::Forkchoice(err));

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -11,7 +11,7 @@ use kona_engine::{
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tokio::sync::{mpsc, watch};
 
 /// A request handled by the [`EngineActor`].
@@ -44,6 +44,10 @@ where
     derivation_client: DerivationClient,
     /// Whether the EL sync is complete. This should only ever go from false to true.
     el_sync_complete: bool,
+    /// How far behind the synced tip the safe and finalized heads are retracted once
+    /// execution-layer sync completes (`--syncmode.offset-el-safe`). A zero duration disables the
+    /// retraction. Only ever applied on the post-EL-sync reset.
+    offset_el_safe: Duration,
     /// The last safe head update sent.
     last_safe_head_sent: L2BlockInfo,
     /// A channel to use to relay the current unsafe head.
@@ -75,11 +79,13 @@ where
         engine: Engine<EngineClient_>,
         unsafe_head_tx: Option<watch::Sender<L2BlockInfo>>,
         inbound_request_rx: mpsc::Receiver<EngineActorRequest>,
+        offset_el_safe: Duration,
     ) -> Self {
         Self {
             client,
             derivation_client,
             el_sync_complete: false,
+            offset_el_safe,
             engine,
             last_safe_head_sent: L2BlockInfo::default(),
             rollup: config,
@@ -89,9 +95,14 @@ where
     }
 
     /// Resets the inner [`Engine`] and propagates the reset to the derivation actor.
-    async fn reset(&mut self) -> Result<(), EngineError> {
+    ///
+    /// `offset_el_safe` is `Some` only for the reset that runs once execution-layer sync completes,
+    /// where the safe/finalized heads are retracted by the configured offset. All other resets pass
+    /// `None` and use the standard sync-start search.
+    async fn reset(&mut self, offset_el_safe: Option<Duration>) -> Result<(), EngineError> {
         // Reset the engine.
-        let l2_safe_head = self.engine.reset(self.client.clone(), self.rollup.clone()).await?;
+        let l2_safe_head =
+            self.engine.reset(self.client.clone(), self.rollup.clone(), offset_el_safe).await?;
 
         // Signal the derivation actor to reset.
         let signal = Signal::Reset(ResetSignal { l2_safe_head });
@@ -122,7 +133,7 @@ where
                     }
                     EngineTaskErrorSeverity::Reset => {
                         warn!(target: "engine", ?err, "Received reset request");
-                        self.reset().await?;
+                        self.reset(None).await?;
                     }
                     EngineTaskErrorSeverity::Flush => {
                         // This error is encountered when the payload is marked INVALID
@@ -163,9 +174,11 @@ where
 
         // Reset the engine if the sync state does not already know about a finalized block.
         if self.engine.state().sync_state.finalized_head() == L2BlockInfo::default() {
-            // If the sync status is finished, we can reset the engine and start derivation.
+            // If the sync status is finished, we can reset the engine and start derivation. This is
+            // the only reset that applies the `--syncmode.offset-el-safe` retraction.
             info!(target: "engine", "Performing initial engine reset");
-            self.reset().await?;
+            let offset_el_safe = self.offset_el_safe;
+            self.reset(Some(offset_el_safe)).await?;
         } else {
             info!(target: "engine", "finalized head is not default, so not resetting");
         }
@@ -270,7 +283,7 @@ where
             EngineActorRequest::Reset(reset_request) => {
                 warn!(target: "engine", "Received reset request");
 
-                let reset_res = self.reset().await;
+                let reset_res = self.reset(None).await;
 
                 // Send the result.
                 let response_payload = reset_res

--- a/rust/kona/crates/node/service/src/actors/engine/config.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/config.rs
@@ -4,7 +4,7 @@ use alloy_rpc_types_engine::JwtSecret;
 use kona_engine::{EngineClientBuilder, OpEngineClient};
 use kona_genesis::RollupConfig;
 use op_alloy_network::Optimism;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use url::Url;
 
 /// Configuration for the Engine Actor.
@@ -25,6 +25,13 @@ pub struct EngineConfig {
     /// When the node is in sequencer mode, the engine actor will receive requests to build blocks
     /// from the sequencer actor.
     pub mode: NodeMode,
+
+    /// After execution-layer sync completes, the safe and finalized heads are retracted to this
+    /// duration behind the synced tip (converted to L2 blocks via the rollup block time, rounding
+    /// up). This forces derivation to re-derive the most recent `offset_el_safe` worth of blocks
+    /// before they are considered safe. A zero duration disables the retraction. Mirrors op-node's
+    /// `--syncmode.offset-el-safe`.
+    pub offset_el_safe: Duration,
 }
 
 impl EngineConfig {

--- a/rust/kona/crates/node/service/src/service/node.rs
+++ b/rust/kona/crates/node/service/src/service/node.rs
@@ -248,6 +248,7 @@ impl RollupNode {
             engine,
             unsafe_head_tx_opt,
             engine_request_rx,
+            self.engine_config.offset_el_safe,
         );
 
         let rpc_actor = EngineRpcActor::new(


### PR DESCRIPTION
## Overview

Implements `--syncmode.offset-el-safe` for **kona-node**, porting op-node [#21033](https://github.com/ethereum-optimism/optimism/pull/21033).

After execution-layer (EL) sync completes, the unsafe head stays at the synced tip while the safe and finalized heads are retracted by `ceil(offset / block_time)` blocks (default 12h, the OP Mainnet sequencing window). This forces derivation to re-derive the most recent window before it is considered safe, rather than trusting the optimistically-synced tip.

Closes #21243.

## How it works

- **Helpers** (`duration_to_blocks`, `offset_block_num`) mirror op-node's `DurationToBlocks` / `OffsetBlockNum` — ceiling division, genesis clamp, sub-second truncation.
- **`L2ForkchoiceState::for_el_sync`** computes the post-EL-sync heads: `unsafe = tip`, `safe = finalized = block(tip - n)`, but **never retracted below the EL's currently-reported safe/finalized heads**.
- The offset is threaded through `Engine::reset` as `Option<Duration>` and applied **only** on the post-EL-sync reset; the drain-triggered and explicit-Reset paths keep the standard `find_starting_forkchoice` search.

## No repeated re-derivation across restarts (without a safedb)

kona has no persisted safe head, so the never-retract guard clamps against the EL's reported heads. This works because kona advances safe/finalized **only through derivation, never during EL sync** (P2P-driven inserts send forkchoice updates with `safe = finalized = 0x0`):

- **Initial sync** — the EL reports no safe/finalized tag, so `current()` falls back to genesis → the offset applies in full.
- **Later restart** — the EL already holds the heads derivation previously committed (at or above the offset head) → nothing is re-derived.

This satisfies the acceptance criterion without porting op-node's safedb-resume path (N/A in kona).

## Design notes

- The op-node "ineffective unless `--syncmode=execution-layer` → warn and ignore" handling has no kona equivalent: kona has no separate CL sync mode, and the offset is only ever applied in the post-EL-sync reset path, so it is inherently effective only after EL sync.
- The CLI flag is **seconds-based** (`u64`, default `43200`), consistent with kona's existing `Duration` flags (`sequencer.rs`, `p2p.rs`), rather than op-node's humantime `12h`. Open to switching to humantime for CLI parity if preferred.

## Testing

- Unit tests for `duration_to_blocks` / `offset_block_num` mirror op-node's `TestDurationToBlocks` / `TestOffsetBlockNum`.
- Unit tests for the never-retract head selection: initial-sync retraction, restart no-retract, and the mixed (advance-finalized-only) case.
- `cargo clippy` (`-D warnings`) and `rustdoc` (`-D warnings`) clean on the touched crates; engine + service lib test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)