### PR TITLE
refactor(kona): make sp1 range core natively testable

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7853,6 +7853,7 @@ dependencies = [
  "kona-proof",
  "kona-sp1-client-utils",
  "kona-sp1-elfs",
+ "kona-sp1-ethereum-client-utils",
  "kona-sp1-ethereum-host-utils",
  "kona-sp1-host-utils",
  "sp1-sdk",

--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -109,6 +109,12 @@ the `range-executor` binary (which embeds the `range` ELF), and runs the test wi
 `KONA_SP1_RANGE_EXECUTOR_PATH` set. The test skips when that variable is unset, so the
 heavy SP1 toolchain is only required when explicitly running the SP1 action tests.
 
+For faster coverage of the range-program logic, the same executor also supports
+`--native-core`. This mode still generates the real witness, but runs the shared range
+core natively instead of executing the SP1 ELF. Use the default SP1 execute path for a
+small smoke test of the ELF, SP1 stdin, and public-values boundary; use `--native-core`
+when broad action-test coverage would otherwise multiply SP1 emulator cost.
+
 The test covers both an honest claim and an invalid claim. Note the invalid-claim path is
 driven by **corrupting the claim in the witness**, not by passing a wrong claimed output
 root: witness generation runs on the configured `--claimed-l2-output-root`, and the

--- a/rust/kona/sp1/crates/client/src/lib.rs
+++ b/rust/kona/sp1/crates/client/src/lib.rs
@@ -7,6 +7,8 @@ pub use oracle::BlobStore;
 
 pub mod precompiles;
 
+pub mod range;
+
 pub mod types;
 
 extern crate alloc;

--- a/rust/kona/sp1/crates/client/src/range.rs
+++ b/rust/kona/sp1/crates/client/src/range.rs
@@ -1,0 +1,218 @@
+//! Shared range-program execution logic.
+
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use anyhow::{Result, anyhow};
+use kona_proof::{l1::OracleL1ChainProvider, l2::OracleL2ChainProvider};
+
+use crate::{
+    BlobStore,
+    boot::BootInfoStruct,
+    witness::{
+        executor::{WitnessExecutor, get_inputs_for_pipeline},
+        preimage_store::PreimageStore,
+    },
+};
+
+/// Executes the range program with the given [`WitnessExecutor`], [`PreimageStore`], and
+/// [`BlobStore`].
+pub async fn run_range_program<E>(
+    executor: E,
+    oracle: Arc<PreimageStore>,
+    beacon: BlobStore,
+) -> Result<BootInfoStruct>
+where
+    E: WitnessExecutor<
+            O = PreimageStore,
+            B = BlobStore,
+            L1 = OracleL1ChainProvider<PreimageStore>,
+            L2 = OracleL2ChainProvider<PreimageStore>,
+        > + Send
+        + Sync,
+{
+    let (boot_info, input) = get_inputs_for_pipeline(oracle.clone()).await?;
+    let boot_info = match input {
+        Some((cursor, l1_provider, l2_provider)) => {
+            let rollup_config = Arc::new(boot_info.rollup_config.clone());
+            let l1_config = Arc::new(boot_info.l1_config.clone());
+
+            let pipeline = executor
+                .create_pipeline(
+                    rollup_config,
+                    l1_config,
+                    cursor.clone(),
+                    oracle,
+                    beacon,
+                    l1_provider,
+                    l2_provider.clone(),
+                )
+                .await?;
+
+            executor.run(boot_info, pipeline, cursor, l2_provider).await?
+        }
+        None => boot_info,
+    };
+
+    Ok(BootInfoStruct::from(boot_info))
+}
+
+/// Ensures a committed range-program output matches the requested claim.
+pub fn ensure_committed_boot_info_matches_claim(
+    boot: &BootInfoStruct,
+    claimed_output_root: B256,
+    claimed_block_number: u64,
+) -> Result<()> {
+    if boot.l2PostRoot != claimed_output_root || boot.l2BlockNumber != claimed_block_number {
+        return Err(anyhow!(
+            "range program committed L2 root {committed_root} at block #{committed_block}, but requested {claimed_root} at block #{claimed_block}",
+            committed_root = boot.l2PostRoot,
+            committed_block = boot.l2BlockNumber,
+            claimed_root = claimed_output_root,
+            claimed_block = claimed_block_number,
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_consensus::Header;
+    use alloy_primitives::{Address, B256, Bytes, keccak256};
+    use alloy_rlp::Encodable;
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use kona_derive::{DataAvailabilityProvider, PipelineResult};
+    use kona_driver::PipelineCursor;
+    use kona_genesis::{L1ChainConfig, RollupConfig};
+    use kona_preimage::PreimageKey;
+    use kona_proof::{
+        block_on,
+        l1::{OracleL1ChainProvider, OraclePipeline},
+        l2::OracleL2ChainProvider,
+    };
+    use kona_protocol::BlockInfo;
+    use spin::RwLock;
+
+    use super::{ensure_committed_boot_info_matches_claim, run_range_program};
+    use crate::{
+        BlobStore,
+        witness::{executor::WitnessExecutor, preimage_store::PreimageStore},
+    };
+
+    #[derive(Clone, Debug)]
+    struct UnusedDataAvailabilityProvider;
+
+    #[async_trait]
+    impl DataAvailabilityProvider for UnusedDataAvailabilityProvider {
+        type Item = Bytes;
+
+        async fn next(
+            &mut self,
+            _block_ref: &BlockInfo,
+            _batcher_addr: Address,
+        ) -> PipelineResult<Self::Item> {
+            unreachable!("zero-step range tests must not construct a data availability provider")
+        }
+
+        fn clear(&mut self) {}
+    }
+
+    #[derive(Debug)]
+    struct UnusedExecutor;
+
+    #[async_trait]
+    impl WitnessExecutor for UnusedExecutor {
+        type O = PreimageStore;
+        type B = BlobStore;
+        type L1 = OracleL1ChainProvider<Self::O>;
+        type L2 = OracleL2ChainProvider<Self::O>;
+        type DA = UnusedDataAvailabilityProvider;
+
+        async fn create_pipeline(
+            &self,
+            _rollup_config: Arc<RollupConfig>,
+            _l1_config: Arc<L1ChainConfig>,
+            _cursor: Arc<RwLock<PipelineCursor>>,
+            _oracle: Arc<Self::O>,
+            _beacon: Self::B,
+            _l1_provider: Self::L1,
+            _l2_provider: Self::L2,
+        ) -> Result<OraclePipeline<Self::O, Self::L1, Self::L2, Self::DA>> {
+            unreachable!("zero-step range tests must not construct a pipeline")
+        }
+    }
+
+    fn b256(fill: u8) -> B256 {
+        B256::from([fill; 32])
+    }
+
+    fn zero_step_oracle(claimed_root: B256) -> (Arc<PreimageStore>, B256, u64) {
+        let safe_head = Header { number: 3, ..Default::default() };
+        let safe_head_hash = safe_head.hash_slow();
+
+        let mut output_preimage = [0u8; 128];
+        output_preimage[96..128].copy_from_slice(safe_head_hash.as_slice());
+        let agreed_root = B256::from(keccak256(output_preimage));
+
+        let mut oracle = PreimageStore::default();
+        oracle.save_preimage(PreimageKey::new_local(1), b256(0x11).as_slice().to_vec()).unwrap();
+        oracle.save_preimage(PreimageKey::new_local(2), agreed_root.as_slice().to_vec()).unwrap();
+        oracle.save_preimage(PreimageKey::new_local(3), claimed_root.as_slice().to_vec()).unwrap();
+        oracle
+            .save_preimage(PreimageKey::new_local(4), safe_head.number.to_be_bytes().to_vec())
+            .unwrap();
+        oracle.save_preimage(PreimageKey::new_local(5), 10u64.to_be_bytes().to_vec()).unwrap();
+        oracle
+            .save_preimage(PreimageKey::new_keccak256(*agreed_root), output_preimage.to_vec())
+            .unwrap();
+
+        let mut header_rlp = Vec::new();
+        safe_head.encode(&mut header_rlp);
+        oracle.save_preimage(PreimageKey::new_keccak256(*safe_head_hash), header_rlp).unwrap();
+
+        (Arc::new(oracle), agreed_root, safe_head.number)
+    }
+
+    #[test]
+    fn run_range_program_commits_zero_step_claim() {
+        let (_, agreed_root, _) = zero_step_oracle(B256::ZERO);
+        let (oracle, agreed_root, safe_head_number) = zero_step_oracle(agreed_root);
+
+        let boot = block_on(run_range_program(UnusedExecutor, oracle, BlobStore::default()))
+            .expect("zero-step range program should succeed");
+
+        assert_eq!(boot.l2PostRoot, agreed_root);
+        assert_eq!(boot.l2BlockNumber, safe_head_number);
+    }
+
+    #[test]
+    fn run_range_program_rejects_zero_step_root_mismatch() {
+        let (oracle, agreed_root, _) = zero_step_oracle(B256::ZERO);
+        assert_ne!(agreed_root, B256::ZERO);
+
+        let err = block_on(run_range_program(UnusedExecutor, oracle, BlobStore::default()))
+            .expect_err("zero-step root mismatch must fail");
+
+        assert!(err.to_string().contains("does not match agreed output root"));
+    }
+
+    #[test]
+    fn committed_boot_info_must_match_requested_claim() {
+        let root = b256(0x22);
+        let block_number = 7;
+        let (_, agreed_root, _) = zero_step_oracle(B256::ZERO);
+        let (oracle, _, _) = zero_step_oracle(agreed_root);
+        let boot = block_on(run_range_program(UnusedExecutor, oracle, BlobStore::default()))
+            .expect("zero-step range program should succeed");
+
+        let err = ensure_committed_boot_info_matches_claim(&boot, root, block_number)
+            .expect_err("mismatched committed boot info must fail");
+        let msg = err.to_string();
+
+        assert!(msg.contains(&root.to_string()), "missing claimed root in: {msg}");
+        assert!(msg.contains("#7"), "missing claimed block number in: {msg}");
+    }
+}

--- a/rust/kona/sp1/crates/range-executor/Cargo.toml
+++ b/rust/kona/sp1/crates/range-executor/Cargo.toml
@@ -17,6 +17,7 @@ sp1-sdk.workspace = true
 # invalid-claim (soundness) test path.
 kona-sp1-client-utils = { workspace = true, features = ["test-tamper-witness"] }
 kona-sp1-elfs.workspace = true
+kona-sp1-ethereum-client-utils.workspace = true
 kona-sp1-ethereum-host-utils.workspace = true
 kona-sp1-host-utils.workspace = true
 

--- a/rust/kona/sp1/crates/range-executor/src/main.rs
+++ b/rust/kona/sp1/crates/range-executor/src/main.rs
@@ -1,15 +1,16 @@
-//! Runs the kona-sp1 `range` guest program in SP1 **execute** mode (no proving) against a real
-//! chain's witness, so the program can be exercised end-to-end by op-e2e action tests.
+//! Runs the kona-sp1 `range` program against a real chain's witness, so it can be exercised by
+//! op-e2e action tests.
 //!
 //! The flow mirrors the native fault-proof program harness:
 //! 1. Parse the same [`SingleChainHost`] boot inputs the native kona-host accepts.
 //! 2. Run the kona-host preimage server and collect the witness with the SP1 witness generator.
-//! 3. Execute the `range` ELF over that witness in the SP1 zkVM emulator.
+//! 3. Execute the `range` ELF over that witness in the SP1 zkVM emulator, or run the shared range
+//!    core natively when `--native-core` is set.
 //! 4. Read the committed [`BootInfoStruct`] and confirm it matches the claimed transition.
 //!
 //! Exit codes (matching the native harness convention, where exit 1 == "claim rejected"):
-//! - `0`: the claimed state transition is valid (guest executed and committed the claim).
-//! - `1`: the claimed state transition is invalid (the guest rejected it).
+//! - `0`: the claimed state transition is valid.
+//! - `1`: the claimed state transition is invalid.
 //! - `2`: an infrastructure error prevented evaluation (witness generation failed, ELF missing,
 //!   etc.) — distinct from a claim verdict.
 
@@ -22,11 +23,13 @@ use kona_preimage::{BidirectionalChannel, PreimageKey};
 use kona_proof::boot::L2_CLAIM_KEY;
 use kona_sp1_client_utils::{
     boot::BootInfoStruct,
+    range::{ensure_committed_boot_info_matches_claim, run_range_program},
     witness::{DefaultWitnessData, WitnessData},
 };
+use kona_sp1_ethereum_client_utils::executor::ETHDAWitnessExecutor;
 use kona_sp1_ethereum_host_utils::witness_generator::ETHDAWitnessGenerator;
 use kona_sp1_host_utils::witness_generation::WitnessGenerator;
-use sp1_sdk::{Elf, Prover, ProverClient, SP1Stdin};
+use sp1_sdk::{Elf, Prover, ProverClient};
 
 /// Exit code signalling a valid claim.
 const EXIT_VALID: u8 = 0;
@@ -35,12 +38,12 @@ const EXIT_INVALID: u8 = 1;
 /// Exit code signalling an infrastructure error (no claim verdict was reached).
 const EXIT_INFRA: u8 = 2;
 
-/// Runs the kona-sp1 `range` guest in SP1 execute mode against a chain's witness.
+/// Runs the kona-sp1 `range` program against a chain's witness.
 #[derive(Parser, Debug)]
 #[command(
     name = "kona-sp1-range-executor",
     about = "Generate a witness for a single-chain state transition and run the kona-sp1 range \
-             guest in SP1 execute mode, validating the claimed output root."
+             program, validating the claimed output root."
 )]
 struct Cli {
     #[command(subcommand)]
@@ -51,8 +54,8 @@ struct Cli {
 /// oracle-server command builder can target this binary.
 #[derive(clap::Subcommand, Debug)]
 enum Command {
-    /// Generate the witness for a single-chain state transition and run the range guest in SP1
-    /// execute mode, validating the claimed output root.
+    /// Generate the witness for a single-chain state transition and run the range program,
+    /// validating the claimed output root.
     Single(SingleArgs),
 }
 
@@ -72,13 +75,18 @@ struct SingleArgs {
     /// path: the guest re-derives the real root, finds it does not match, and aborts (exit 1).
     #[arg(long)]
     corrupt_claimed_root: bool,
+    /// Run the shared range-program core natively after witness generation instead of executing
+    /// the SP1 ELF. This is useful for fast action-test coverage; the default path still runs
+    /// the full SP1 execute smoke test.
+    #[arg(long)]
+    native_core: bool,
 }
 
 /// The claim verdict reached by running the guest.
 enum Verdict {
-    /// The guest accepted and committed the claimed state transition.
+    /// The range program accepted the claimed state transition.
     Valid,
-    /// The guest rejected the claimed state transition.
+    /// The range program rejected the claimed state transition.
     Invalid,
 }
 
@@ -90,7 +98,7 @@ fn main() -> ExitCode {
     let claimed_output_root = host.claimed_l2_output_root;
     let claimed_block_number = host.claimed_l2_block_number;
 
-    if kona_sp1_elfs::RANGE_ELF.is_empty() {
+    if !args.native_core && kona_sp1_elfs::RANGE_ELF.is_empty() {
         return infra(
             "RANGE_ELF is an empty placeholder; build the guest ELFs first with \
              `cd rust/kona/sp1 && just build-elfs`"
@@ -106,6 +114,7 @@ fn main() -> ExitCode {
     match runtime.block_on(run(
         host,
         args.corrupt_claimed_root,
+        args.native_core,
         claimed_output_root,
         claimed_block_number,
     )) {
@@ -115,14 +124,58 @@ fn main() -> ExitCode {
     }
 }
 
-/// Generates the witness, runs the `range` ELF in SP1 execute mode, and reports the claim verdict.
+/// Generates the witness, evaluates the range program, and reports the claim verdict.
 async fn run(
     host: SingleChainHost,
     corrupt_claimed_root: bool,
+    native_core: bool,
     claimed_output_root: B256,
     claimed_block_number: u64,
 ) -> anyhow::Result<Verdict> {
-    let stdin = generate_stdin(host, corrupt_claimed_root).await?;
+    let witness = generate_witness(host, corrupt_claimed_root).await?;
+
+    if native_core {
+        return run_native_core(witness, claimed_output_root, claimed_block_number).await;
+    }
+
+    run_sp1_execute(witness, claimed_output_root, claimed_block_number).await
+}
+
+/// Runs the shared range-program core natively, bypassing SP1 execute while preserving witness
+/// loading and claim validation.
+async fn run_native_core(
+    witness: DefaultWitnessData,
+    claimed_output_root: B256,
+    claimed_block_number: u64,
+) -> anyhow::Result<Verdict> {
+    let (oracle, beacon) = witness.get_oracle_and_blob_provider().await?;
+    let boot = match run_range_program(ETHDAWitnessExecutor::new(), oracle, beacon).await {
+        Ok(boot) => boot,
+        Err(err) => {
+            tracing::info!("range core execution failed (claim rejected): {err}");
+            return Ok(Verdict::Invalid);
+        }
+    };
+
+    if !committed_boot_info_matches_claim(&boot, claimed_output_root, claimed_block_number) {
+        return Ok(Verdict::Invalid);
+    }
+
+    tracing::info!(
+        l2_block_number = boot.l2BlockNumber,
+        l2_post_root = %boot.l2PostRoot,
+        "range core validated the claimed state transition",
+    );
+    Ok(Verdict::Valid)
+}
+
+/// Runs the `range` ELF in SP1 execute mode and reports the claim verdict.
+async fn run_sp1_execute(
+    witness: DefaultWitnessData,
+    claimed_output_root: B256,
+    claimed_block_number: u64,
+) -> anyhow::Result<Verdict> {
+    let stdin = ETHDAWitnessGenerator::new().get_sp1_stdin(witness)?;
 
     // `build()` and `execute(..)` are async; the latter runs the zkVM emulator (no proving).
     let client = ProverClient::builder().cpu().build().await;
@@ -150,14 +203,7 @@ async fn run(
     // mismatch here is unexpected (a witness-integrity guard rather than an independent
     // verdict).
     let boot: BootInfoStruct = public_values.read();
-    if boot.l2PostRoot != claimed_output_root || boot.l2BlockNumber != claimed_block_number {
-        tracing::error!(
-            committed_root = %boot.l2PostRoot,
-            committed_block = boot.l2BlockNumber,
-            %claimed_output_root,
-            claimed_block_number,
-            "range guest committed boot info that does not match the requested claim",
-        );
+    if !committed_boot_info_matches_claim(&boot, claimed_output_root, claimed_block_number) {
         return Ok(Verdict::Invalid);
     }
 
@@ -169,16 +215,33 @@ async fn run(
     Ok(Verdict::Valid)
 }
 
-/// Generates the witness for the configured state transition and encodes it as SP1 stdin.
+/// Returns whether committed range-program output matches the requested claim.
+fn committed_boot_info_matches_claim(
+    boot: &BootInfoStruct,
+    claimed_output_root: B256,
+    claimed_block_number: u64,
+) -> bool {
+    if let Err(err) =
+        ensure_committed_boot_info_matches_claim(boot, claimed_output_root, claimed_block_number)
+    {
+        tracing::error!(
+            "range program committed boot info that does not match the requested claim: {err}"
+        );
+        return false;
+    }
+    true
+}
+
+/// Generates the witness for the configured state transition.
 ///
 /// This mirrors the witness-generation sequence in `OPSuccinctHost::run`
 /// (`kona-sp1-host-utils`); keep the `start_server`/`abort` semantics in sync with it. We drive the
 /// preimage server directly here rather than going through `SingleChainOPSuccinctHost`, which would
 /// require an RPC-configured `OPSuccinctDataFetcher` we do not need.
-async fn generate_stdin(
+async fn generate_witness(
     host: SingleChainHost,
     corrupt_claimed_root: bool,
-) -> anyhow::Result<SP1Stdin> {
+) -> anyhow::Result<DefaultWitnessData> {
     let witness_generator = ETHDAWitnessGenerator::new();
 
     let preimage = BidirectionalChannel::new()?;
@@ -196,7 +259,7 @@ async fn generate_stdin(
         witness
     };
 
-    witness_generator.get_sp1_stdin(witness)
+    Ok(witness)
 }
 
 /// Overwrites the claimed-output-root boot preimage in the witness with a value guaranteed to

--- a/rust/kona/sp1/programs/range/src/main.rs
+++ b/rust/kona/sp1/programs/range/src/main.rs
@@ -12,7 +12,6 @@ sp1_zkvm::entrypoint!(main);
 use kona_sp1_client_utils::witness::{DefaultWitnessData, WitnessData};
 use kona_sp1_ethereum_client_utils::executor::ETHDAWitnessExecutor;
 use rkyv::rancor::Error;
-use std::sync::Arc;
 
 /// Entrypoint to the range program.
 fn main() {
@@ -29,19 +28,16 @@ fn main() {
             .await
             .expect("Failed to load oracle and blob provider");
 
-        run_range_program(ETHDAWitnessExecutor::new(), oracle, beacon).await;
+        let boot_info = kona_sp1_client_utils::range::run_range_program(
+            ETHDAWitnessExecutor::new(),
+            oracle,
+            beacon,
+        )
+        .await
+        .expect("Failed to run range program");
+        sp1_zkvm::io::commit(&boot_info);
     });
 }
-
-use kona_proof::{l1::OracleL1ChainProvider, l2::OracleL2ChainProvider};
-use kona_sp1_client_utils::{
-    BlobStore,
-    boot::BootInfoStruct,
-    witness::{
-        executor::{WitnessExecutor, get_inputs_for_pipeline},
-        preimage_store::PreimageStore,
-    },
-};
 
 /// Sets up tracing for the range program
 #[cfg(feature = "tracing-subscriber")]
@@ -51,46 +47,4 @@ pub fn setup_tracing() {
 
     let subscriber = tracing_subscriber::fmt().with_max_level(Level::INFO).finish();
     tracing::subscriber::set_global_default(subscriber).map_err(|e| anyhow!(e)).unwrap();
-}
-
-/// Executes the range program with the given [`WitnessExecutor`], [`PreimageStore`], and
-/// [`BlobStore`].
-pub async fn run_range_program<E>(executor: E, oracle: Arc<PreimageStore>, beacon: BlobStore)
-where
-    E: WitnessExecutor<
-            O = PreimageStore,
-            B = BlobStore,
-            L1 = OracleL1ChainProvider<PreimageStore>,
-            L2 = OracleL2ChainProvider<PreimageStore>,
-        > + Send
-        + Sync,
-{
-    ////////////////////////////////////////////////////////////////
-    //                          PROLOGUE                          //
-    ////////////////////////////////////////////////////////////////
-    let (boot_info, input) = get_inputs_for_pipeline(oracle.clone()).await.unwrap();
-    let boot_info = match input {
-        Some((cursor, l1_provider, l2_provider)) => {
-            let rollup_config = Arc::new(boot_info.rollup_config.clone());
-            let l1_config = Arc::new(boot_info.l1_config.clone());
-
-            let pipeline = executor
-                .create_pipeline(
-                    rollup_config,
-                    l1_config,
-                    cursor.clone(),
-                    oracle,
-                    beacon,
-                    l1_provider,
-                    l2_provider.clone(),
-                )
-                .await
-                .unwrap();
-
-            executor.run(boot_info, pipeline, cursor, l2_provider).await.unwrap()
-        }
-        None => boot_info,
-    };
-
-    sp1_zkvm::io::commit(&BootInfoStruct::from(boot_info));
 }

--- a/rust/kona/tests/proofs/helpers/env.go
+++ b/rust/kona/tests/proofs/helpers/env.go
@@ -178,6 +178,16 @@ func WithCorruptClaim() FixtureInputParam {
 	}
 }
 
+// WithSP1NativeCore instructs the SP1 range executor to generate the witness and then run the
+// shared range-program core natively instead of executing the SP1 ELF. This is useful for broad,
+// faster kona-sp1 coverage; keep at least one default SP1 execute test for ELF/IO smoke coverage.
+// Has no effect on the native fault-proof program.
+func WithSP1NativeCore() FixtureInputParam {
+	return func(f *FixtureInputs) {
+		f.SP1NativeCore = true
+	}
+}
+
 // RunFaultProofProgram runs the fault proof program for each state transition from genesis up to the provided l2 block num.
 func (env *L2FaultProofEnv) RunFaultProofProgramFromGenesis(t helpers.Testing, finalL2BlockNum uint64, checkResult CheckResult, fixtureInputParams ...FixtureInputParam) {
 	l2ClaimBlockNum := uint64(0)

--- a/rust/kona/tests/proofs/helpers/fixture.go
+++ b/rust/kona/tests/proofs/helpers/fixture.go
@@ -38,4 +38,9 @@ type FixtureInputs struct {
 	// the generated witness so the guest rejects it (the invalid-claim soundness path). Ignored by
 	// the native fault-proof program. Not part of the serialized fixture.
 	CorruptClaim bool `toml:"-"`
+
+	// SP1NativeCore, when set, instructs the SP1 range executor to generate the witness and then run
+	// the shared range-program core natively instead of executing the SP1 ELF. Ignored by the native
+	// fault-proof program. Not part of the serialized fixture.
+	SP1NativeCore bool `toml:"-"`
 }

--- a/rust/kona/tests/proofs/helpers/runner.go
+++ b/rust/kona/tests/proofs/helpers/runner.go
@@ -57,9 +57,9 @@ func RunSP1RangeProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Mine
 }
 
 // runProgram prepares the chain inputs (beacon, configs, L2 endpoints) for a single state
-// transition and dispatches them to the given program runner. allowCorruptClaim must be true only
-// for runners that honor WithCorruptClaim (currently the SP1 range executor).
-func runProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Miner, run ProgramRunner, allowCorruptClaim bool, checkResult CheckResult, fixtureInputParams ...FixtureInputParam) {
+// transition and dispatches them to the given program runner. allowSP1Options must be true only
+// for runners that honor SP1-only fixture options (currently the SP1 range executor).
+func runProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Miner, run ProgramRunner, allowSP1Options bool, checkResult CheckResult, fixtureInputParams ...FixtureInputParam) {
 	l1Head := l1.L1Chain().CurrentBlock()
 
 	fixtureInputs := &FixtureInputs{
@@ -69,10 +69,10 @@ func runProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Miner, run P
 		apply(fixtureInputs)
 	}
 	require.Greater(t, len(fixtureInputs.L2Sources), 0, "Must specify at least one L2 source")
-	// WithCorruptClaim only affects the SP1 range executor; the native fault-proof program ignores
-	// it, so passing it to RunFaultProofProgram is a mistake that would silently pass. Fail loudly.
-	require.False(t, fixtureInputs.CorruptClaim && !allowCorruptClaim,
-		"WithCorruptClaim() is only honored by RunSP1RangeProgram; the native fault-proof program ignores it")
+	// SP1-only fixture options are ignored by the native fault-proof program, so passing them to
+	// RunFaultProofProgram is a mistake that would silently pass. Fail loudly.
+	require.False(t, (fixtureInputs.CorruptClaim || fixtureInputs.SP1NativeCore) && !allowSP1Options,
+		"SP1-only fixture options are only honored by RunSP1RangeProgram; the native fault-proof program ignores them")
 
 	// Run the program from the state transition from L2 block l2ClaimBlockNum - 1 -> l2ClaimBlockNum.
 	workDir := t.TempDir()

--- a/rust/kona/tests/proofs/helpers/sp1.go
+++ b/rust/kona/tests/proofs/helpers/sp1.go
@@ -29,15 +29,17 @@ func SP1RangeExecutorPath() string {
 	return sp1RangeExecutorPath
 }
 
-// RunRangeExecutor runs the kona-sp1 range guest in SP1 execute mode for the state transition
-// described by fixtureInputs. It mirrors RunKonaNative but, instead of running the native client,
-// generates the witness and executes the range ELF. It returns ErrClaimNotValid when the guest
-// rejects the claim.
+// RunRangeExecutor runs the kona-sp1 range program for the state transition described by
+// fixtureInputs. It mirrors RunKonaNative but, instead of running the native client, generates the
+// witness and executes the range ELF (or the shared native range core when SP1NativeCore is set).
+// It returns ErrClaimNotValid when the program rejects the claim.
 //
 // fixtureInputs.L2Claim must be the real/honest output root: witness generation runs on it, and a
 // wrong root is rejected host-side before the guest runs (surfacing as an infra error, not a claim
 // verdict). To test an invalid claim, keep the honest claim and set fixtureInputs.CorruptClaim
 // (see WithCorruptClaim), which tampers the claim in the witness so the guest rejects it.
+// Set fixtureInputs.SP1NativeCore (see WithSP1NativeCore) to run the shared range-program core
+// natively instead of executing the SP1 ELF.
 func RunRangeExecutor(
 	t helpers.Testing,
 	workDir string,
@@ -76,6 +78,9 @@ func RunRangeExecutor(
 	var extraArgs []string
 	if fixtureInputs.CorruptClaim {
 		extraArgs = append(extraArgs, "--corrupt-claimed-root")
+	}
+	if fixtureInputs.SP1NativeCore {
+		extraArgs = append(extraArgs, "--native-core")
 	}
 
 	if !rustbin.RunKonaSP1Range(t, logger, &vmCfg, workDir, &inputs, extraArgs...) {


### PR DESCRIPTION
Refactors the kona-sp1 range program so most of its logic can be exercised natively without paying the SP1 execute cost for every coverage case. Otherwise, it takes approx 30 seconds on my machine to run a simple action test with the sp1 (riscv emulated) executor. 

The SP1 guest remains the ELF/stdin/public-values boundary, while the derivation and execution core is shared with native tests and a new fast executor mode.