### PR TITLE
Remove cannon image builds

### DIFF
--- a/.github/images.json
+++ b/.github/images.json
@@ -95,14 +95,6 @@
       "target": "op-test-sequencer",
       "paths": ["op-test-sequencer/**"]
     },
-    "cannon": {
-      "type": "go",
-      "check": "go",
-      "mode": "bake",
-      "bake_file": "docker-bake.hcl",
-      "target": "cannon",
-      "paths": ["cannon/**", "op-preimage/**"]
-    },
     "op-deployer": {
       "type": "go",
       "check": "go",
@@ -182,14 +174,6 @@
       "bake_file": "docker-bake.hcl",
       "target": "rollup-boost",
       "paths": ["rust/**"]
-    },
-    "cannon-builder": {
-      "type": "rust",
-      "check": "none",
-      "mode": "bake",
-      "bake_file": "docker-bake.hcl",
-      "target": "cannon-builder",
-      "paths": ["rust/kona/docker/cannon/**"]
     },
     "ci-base-clang": {
       "check": "none",


### PR DESCRIPTION
## Summary
- remove standalone `cannon` and `cannon-builder` entries from `.github/images.json`
- keep existing op-challenger image build behavior unchanged