### PR TITLE
ci: add beta parallel apko image builds

### DIFF
--- a/.github/images.apko.json
+++ b/.github/images.apko.json
@@ -1,0 +1,347 @@
+{
+  "shared_paths": [
+    ".github/images.apko.json",
+    ".github/workflows/build-images.apko.yaml",
+    "melange/pipelines/**",
+    "melange/op-stack-go.yaml",
+    "melange/op-stack-rust.yaml",
+    "melange/multicannon.yaml"
+  ],
+  "shared_go_paths": [
+    "go.mod",
+    "go.sum",
+    "op-service/**",
+    "op-core/**",
+    "op-chain-ops/**"
+  ],
+  "shared_rust_paths": [
+    "rust/**"
+  ],
+  "melange_archs": [
+    "x86_64",
+    "aarch64"
+  ],
+  "apko_archs": "amd64,arm64",
+  "release": {
+    "tag_regex": "^([^/]+)/(v.+)$",
+    "service_match": 1,
+    "version_match": 2,
+    "publish_tag": "${version}",
+    "source_ref": "${ref_name}"
+  },
+  "default_runners": {
+    "x86_64": "ubuntu-24.04",
+    "aarch64": "ubuntu-24.04-arm"
+  },
+  "smoke_runners": {
+    "amd64": "ubuntu-slim",
+    "arm64": "ubuntu-24.04-arm"
+  },
+  "melange": {
+    "op-stack-go": {
+      "config": "melange/op-stack-go.yaml"
+    },
+    "op-stack-rust": {
+      "config": "melange/op-stack-rust.yaml",
+      "source": {
+        "repository": "ethereum-optimism/optimism",
+        "path": "."
+      },
+      "source_submodules": "recursive",
+      "runners": {
+        "x86_64": "oplabs-ubuntu-x86",
+        "aarch64": "oplabs-ubuntu-arm"
+      },
+      "use_gha_cache": true,
+      "cache_key_files": [
+        "rust/Cargo.lock",
+        "rust/op-rbuilder/Cargo.lock",
+        "rust/rollup-boost/Cargo.lock"
+      ]
+    },
+    "multicannon": {
+      "config": "melange/multicannon.yaml"
+    },
+    "op-deployer": {
+      "config": "melange/op-deployer.yaml",
+      "source": {
+        "repository": "ethereum-optimism/optimism",
+        "path": "."
+      },
+      "source_submodules": "recursive"
+    }
+  },
+  "images": {
+    "op-node": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-node/**"
+      ],
+      "nexus_paths": [
+        "apko/op-node.yaml"
+      ],
+      "smoke_test": "op-node --help"
+    },
+    "op-batcher": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-batcher/**"
+      ],
+      "nexus_paths": [
+        "apko/op-batcher.yaml"
+      ],
+      "smoke_test": "op-batcher --help"
+    },
+    "op-proposer": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-proposer/**"
+      ],
+      "nexus_paths": [
+        "apko/op-proposer.yaml"
+      ],
+      "smoke_test": "op-proposer --help"
+    },
+    "op-conductor": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-conductor/**",
+        "op-node/**"
+      ],
+      "nexus_paths": [
+        "apko/op-conductor.yaml"
+      ],
+      "smoke_test": "op-conductor --help"
+    },
+    "op-dispute-mon": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-dispute-mon/**"
+      ],
+      "nexus_paths": [
+        "apko/op-dispute-mon.yaml"
+      ],
+      "smoke_test": "op-dispute-mon --help"
+    },
+    "op-dripper": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-dripper/**"
+      ],
+      "nexus_paths": [
+        "apko/op-dripper.yaml"
+      ],
+      "smoke_test": "op-dripper --help"
+    },
+    "op-faucet": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-faucet/**"
+      ],
+      "nexus_paths": [
+        "apko/op-faucet.yaml"
+      ],
+      "smoke_test": "op-faucet --help"
+    },
+    "op-interop-filter": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-interop-filter/**"
+      ],
+      "nexus_paths": [
+        "apko/op-interop-filter.yaml"
+      ],
+      "smoke_test": "op-interop-filter --help"
+    },
+    "op-interop-mon": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-interop-mon/**"
+      ],
+      "nexus_paths": [
+        "apko/op-interop-mon.yaml"
+      ],
+      "smoke_test": "op-interop-mon --help"
+    },
+    "op-supernode": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-supernode/**",
+        "op-node/**"
+      ],
+      "nexus_paths": [
+        "apko/op-supernode.yaml"
+      ],
+      "smoke_test": "op-supernode --help"
+    },
+    "op-test-sequencer": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-test-sequencer/**"
+      ],
+      "nexus_paths": [
+        "apko/op-test-sequencer.yaml"
+      ],
+      "smoke_test": "op-test-sequencer --help"
+    },
+    "da-server": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go"
+      ],
+      "paths": [
+        "op-alt-da/**"
+      ],
+      "nexus_paths": [
+        "apko/da-server.yaml"
+      ],
+      "smoke_test": "da-server --help"
+    },
+    "op-challenger": {
+      "type": "go",
+      "needs_melange": [
+        "op-stack-go",
+        "multicannon",
+        "op-stack-rust"
+      ],
+      "paths": [
+        "op-challenger/**",
+        "cannon/**",
+        "op-preimage/**",
+        "rust/kona/**"
+      ],
+      "nexus_paths": [
+        "apko/op-challenger.yaml"
+      ],
+      "smoke_test": "op-challenger --help,cannon --help,kona-host --help"
+    },
+    "kona-node": {
+      "type": "rust",
+      "needs_melange": [
+        "op-stack-rust"
+      ],
+      "paths": [
+        "rust/**"
+      ],
+      "nexus_paths": [
+        "apko/kona-node.yaml"
+      ],
+      "smoke_test": "kona-node --help"
+    },
+    "kona-host": {
+      "type": "rust",
+      "needs_melange": [
+        "op-stack-rust"
+      ],
+      "paths": [
+        "rust/**"
+      ],
+      "nexus_paths": [
+        "apko/kona-host.yaml"
+      ],
+      "smoke_test": "kona-host --help"
+    },
+    "kona-client": {
+      "type": "rust",
+      "needs_melange": [
+        "op-stack-rust"
+      ],
+      "paths": [
+        "rust/**"
+      ],
+      "nexus_paths": [
+        "apko/kona-client.yaml"
+      ],
+      "smoke_test": "kona-client --help"
+    },
+    "op-reth": {
+      "type": "rust",
+      "needs_melange": [
+        "op-stack-rust"
+      ],
+      "paths": [
+        "rust/**"
+      ],
+      "nexus_paths": [
+        "apko/op-reth.yaml"
+      ],
+      "smoke_test": "op-reth --help"
+    },
+    "op-rbuilder": {
+      "type": "rust",
+      "needs_melange": [
+        "op-stack-rust"
+      ],
+      "paths": [
+        "rust/**"
+      ],
+      "nexus_paths": [
+        "apko/op-rbuilder.yaml"
+      ],
+      "smoke_test": "/app/rbuilder --help"
+    },
+    "rollup-boost": {
+      "type": "rust",
+      "needs_melange": [
+        "op-stack-rust"
+      ],
+      "paths": [
+        "rust/**"
+      ],
+      "nexus_paths": [
+        "apko/rollup-boost.yaml"
+      ],
+      "smoke_test": "rollup-boost --help"
+    },
+    "op-deployer": {
+      "type": "go",
+      "needs_melange": [
+        "op-deployer"
+      ],
+      "paths": [
+        "op-deployer/**",
+        "packages/contracts-bedrock/**"
+      ],
+      "nexus_paths": [
+        "melange/op-deployer.yaml",
+        "apko/op-deployer.yaml",
+        "melange/pipelines/op-deployer/embed-artifacts.yaml",
+        "melange/pipelines/op-deployer/install-forge.yaml"
+      ],
+      "smoke_test": "op-deployer --help,forge --version"
+    }
+  }
+}

--- a/.github/images.apko.json
+++ b/.github/images.apko.json
@@ -246,7 +246,7 @@
       "nexus_paths": [
         "apko/op-challenger.yaml"
       ],
-      "smoke_test": "op-challenger --help,cannon --help,kona-host --help"
+      "smoke_test": "op-challenger --help,cannon --help,cannon load-elf --type multithreaded64-5 --help,kona-host --help"
     },
     "kona-node": {
       "type": "rust",

--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@303276b8684655b2af1e878f0317c522826b5857
+        uses: ethereum-optimism/factory/actions/apko-plan@71a5f61d2b308d705de4a8959d89156755f68db3
         with:
           config: .github/images.apko.json
 
@@ -73,7 +73,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@303276b8684655b2af1e878f0317c522826b5857
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -105,7 +105,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@303276b8684655b2af1e878f0317c522826b5857
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -128,7 +128,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@303276b8684655b2af1e878f0317c522826b5857
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus

--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@32cc2090b11d510e3babad942b62b99defccfca1
+        uses: ethereum-optimism/factory/actions/apko-plan@87e34efc71b58de6aacf901002dbfdabf65aad17
         with:
           config: .github/images.apko.json
 
@@ -73,7 +73,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@32cc2090b11d510e3babad942b62b99defccfca1
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@87e34efc71b58de6aacf901002dbfdabf65aad17
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -86,6 +86,7 @@ jobs:
       source-submodules: ${{ matrix.source_submodules }}
       use-gha-cache: ${{ matrix.use_gha_cache }}
       cache-key-files: ${{ matrix.cache_key_files }}
+      cargo-profile: ${{ github.event_name == 'pull_request' && 'fast-build' || 'maxperf' }}
 
   apko:
     name: apko (${{ matrix.service }})
@@ -104,7 +105,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@32cc2090b11d510e3babad942b62b99defccfca1
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@87e34efc71b58de6aacf901002dbfdabf65aad17
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -127,7 +128,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@32cc2090b11d510e3babad942b62b99defccfca1
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@87e34efc71b58de6aacf901002dbfdabf65aad17
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus

--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -1,0 +1,136 @@
+# Stage 1: plan -> melange matrix from .github/images.apko.json
+# Stage 2: apko matrix from same image config.
+# Stage 3: smoke test matrix from image smoke_test entries.
+name: build-images.apko
+
+on:
+  push:
+    branches:
+      - develop
+    tags:
+      - "*/v*"
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - "op-*/**"
+      - "cannon/**"
+      - "packages/contracts-bedrock/**"
+      - "rust/**"
+      - "go.mod"
+      - "go.sum"
+      - "apko/**"
+      - "melange/**"
+      - ".github/workflows/build-images.apko.yaml"
+      - ".github/images.apko.json"
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  SOURCE_DATE_EPOCH: 0
+  REGISTRY: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus
+
+jobs:
+  plan:
+    name: plan
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    outputs:
+      melange_matrix_json: ${{ steps.plan.outputs.melange_matrix_json }}
+      apko_matrix_json: ${{ steps.plan.outputs.apko_matrix_json }}
+      smoke_matrix_json: ${{ steps.plan.outputs.smoke_matrix_json }}
+      has_builds: ${{ steps.plan.outputs.has_builds }}
+      is_release: ${{ steps.plan.outputs.is_release }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
+
+      - name: Plan melange, apko, and smoke matrices
+        id: plan
+        uses: ethereum-optimism/factory/actions/apko-plan@32cc2090b11d510e3babad942b62b99defccfca1
+        with:
+          config: .github/images.apko.json
+
+  melange:
+    name: melange (${{ matrix.stack }}, ${{ matrix.arch }})
+    needs: plan
+    if: needs.plan.outputs.has_builds == 'true' && needs.plan.outputs.melange_matrix_json != '[]'
+    strategy:
+      fail-fast: true
+      matrix:
+        include: ${{ fromJson(needs.plan.outputs.melange_matrix_json) }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@32cc2090b11d510e3babad942b62b99defccfca1
+    with:
+      stack: ${{ matrix.stack }}
+      arch: ${{ matrix.arch }}
+      runner: ${{ matrix.runner }}
+      melange-config: ${{ matrix.melange_config }}
+      source-repository: ${{ matrix.source_repository }}
+      source-ref: ${{ matrix.source_ref }}
+      source-path: ${{ matrix.source_path }}
+      checkout-source: ${{ matrix.checkout_source }}
+      source-submodules: ${{ matrix.source_submodules }}
+      use-gha-cache: ${{ matrix.use_gha_cache }}
+      cache-key-files: ${{ matrix.cache_key_files }}
+
+  apko:
+    name: apko (${{ matrix.service }})
+    needs: [plan, melange]
+    if: |
+      always() &&
+      needs.plan.outputs.has_builds == 'true' &&
+      (needs.melange.result == 'success' || needs.melange.result == 'skipped')
+    strategy:
+      fail-fast: true
+      matrix:
+        include: ${{ fromJson(needs.plan.outputs.apko_matrix_json) }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+      actions: read
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@32cc2090b11d510e3babad942b62b99defccfca1
+    with:
+      service: ${{ matrix.service }}
+      needs-melange-apks: ${{ matrix.needs_melange_apks }}
+      registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus
+      publish-tag: ${{ matrix.publish_tag }}
+      archs: ${{ matrix.archs }}
+
+  smoke-test:
+    name: smoke test (${{ matrix.service }}, ${{ matrix.arch }})
+    needs: [plan, apko]
+    if: |
+      always() &&
+      needs.plan.outputs.has_builds == 'true' &&
+      needs.plan.outputs.smoke_matrix_json != '[]' &&
+      needs.apko.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.plan.outputs.smoke_matrix_json) }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@32cc2090b11d510e3babad942b62b99defccfca1
+    with:
+      service: ${{ matrix.service }}
+      registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus
+      arch: ${{ matrix.arch }}
+      runner: ${{ matrix.runner }}
+      smoke-test: ${{ matrix.smoke_test }}

--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@87e34efc71b58de6aacf901002dbfdabf65aad17
+        uses: ethereum-optimism/factory/actions/apko-plan@303276b8684655b2af1e878f0317c522826b5857
         with:
           config: .github/images.apko.json
 
@@ -73,7 +73,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@87e34efc71b58de6aacf901002dbfdabf65aad17
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@303276b8684655b2af1e878f0317c522826b5857
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -105,7 +105,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@87e34efc71b58de6aacf901002dbfdabf65aad17
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@303276b8684655b2af1e878f0317c522826b5857
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -128,7 +128,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@87e34efc71b58de6aacf901002dbfdabf65aad17
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@303276b8684655b2af1e878f0317c522826b5857
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus

--- a/apko/cannon.yaml
+++ b/apko/cannon.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - cannon@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Root, matching the upstream image.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["cannon"], resolved via PATH).
+cmd: cannon
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: cannon

--- a/apko/da-server.yaml
+++ b/apko/da-server.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - da-server@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Root, matching the upstream image.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["da-server"], resolved via PATH).
+cmd: da-server
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: da-server

--- a/apko/kona-client.yaml
+++ b/apko/kona-client.yaml
@@ -1,0 +1,37 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - ca-certificates
+    - busybox
+    - glibc
+    - libgcc
+    - libstdc++
+    - openssl
+    - kona-client@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: kona
+      gid: 10001
+  users:
+    - username: kona
+      uid: 10001
+      gid: 10001
+  # uid 10001, matching the upstream image.
+  run-as: 10001
+
+entrypoint:
+  command: /usr/local/bin/kona-client
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: kona-client

--- a/apko/kona-host.yaml
+++ b/apko/kona-host.yaml
@@ -1,0 +1,37 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - ca-certificates
+    - busybox
+    - glibc
+    - libgcc
+    - libstdc++
+    - openssl
+    - kona-host@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: kona
+      gid: 10001
+  users:
+    - username: kona
+      uid: 10001
+      gid: 10001
+  # uid 10001, matching the upstream image.
+  run-as: 10001
+
+entrypoint:
+  command: /usr/local/bin/kona-host
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: kona-host

--- a/apko/kona-node.yaml
+++ b/apko/kona-node.yaml
@@ -1,0 +1,37 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - ca-certificates
+    - busybox
+    - glibc
+    - libgcc
+    - libstdc++
+    - openssl
+    - kona-node@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: kona
+      gid: 10001
+  users:
+    - username: kona
+      uid: 10001
+      gid: 10001
+  # uid 10001, matching the upstream image.
+  run-as: 10001
+
+entrypoint:
+  command: /usr/local/bin/kona-node
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: kona-node

--- a/apko/op-batcher.yaml
+++ b/apko/op-batcher.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-batcher@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Root, matching the upstream image.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-batcher"], resolved via PATH).
+cmd: op-batcher
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-batcher

--- a/apko/op-challenger.yaml
+++ b/apko/op-challenger.yaml
@@ -1,0 +1,54 @@
+# Multi-binary image: bundles op-challenger + multicannon + kona-host.
+# needs-melange-apks: op-stack-go, multicannon, op-stack-rust.
+# Mirrors monorepo op-challenger-target: multiplexer only (no loose embed files).
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    # ca-certificates provides update-ca-certificates binary (ca-certificates-bundle is cert data only).
+    # Required: the chart's /init/entrypoint.sh calls update-ca-certificates before exec.
+    - ca-certificates
+    - wolfi-baselayout
+    # busybox provides /bin/sh — the k8s chart launches op-challenger via
+    # command: ["/bin/sh", "/init/entrypoint.sh"], which fails on a shell-less image.
+    - busybox
+    - glibc
+    - libgcc
+    - libstdc++
+    - openssl
+    - op-challenger@local
+    - multicannon@local
+    - kona-host@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  # Matches the monorepo op-challenger-target env. OP_CHALLENGER_CANNON_SERVER
+  # (op-program) is gone; the cannon-kona and asterisc-kona servers are kona-host.
+  OP_CHALLENGER_CANNON_BIN: /usr/local/bin/cannon
+  OP_CHALLENGER_ASTERISC_KONA_SERVER: /usr/local/bin/kona-host
+  OP_CHALLENGER_CANNON_KONA_SERVER: /usr/local/bin/kona-host
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Run as root to match the monorepo op-challenger-target (ubuntu base, no USER
+  # directive). Also required for the chart's root-owned op-challenger-data PVC
+  # (no fsGroup) — nonroot 65532 would be permission-denied.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-challenger"], resolved via PATH).
+cmd: op-challenger
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-challenger

--- a/apko/op-conductor.yaml
+++ b/apko/op-conductor.yaml
@@ -1,0 +1,35 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-conductor@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Run as root for drop-in parity: the chart's StatefulSet sets no fsGroup and
+  # the existing raft PVC is root-owned, so nonroot uid 65532 gets
+  # permission-denied. The deployed image also runs as root. Revert to 65532
+  # once the chart adds fsGroup: 65532.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-conductor"], resolved via PATH).
+cmd: op-conductor
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-conductor

--- a/apko/op-deployer.yaml
+++ b/apko/op-deployer.yaml
@@ -1,0 +1,37 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-deployer@local
+
+archs:
+  - amd64
+  - arm64
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  FORGE_ENV: alpine
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Root, matching the upstream image.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-deployer"], resolved via PATH).
+cmd: op-deployer
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-deployer

--- a/apko/op-dispute-mon.yaml
+++ b/apko/op-dispute-mon.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-dispute-mon@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Root, matching the upstream image.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-dispute-mon"], resolved via PATH).
+cmd: op-dispute-mon
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-dispute-mon

--- a/apko/op-dripper.yaml
+++ b/apko/op-dripper.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-dripper@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Root, matching the upstream image.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-dripper"], resolved via PATH).
+cmd: op-dripper
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-dripper

--- a/apko/op-faucet.yaml
+++ b/apko/op-faucet.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-faucet@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Root, matching the upstream image.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-faucet"], resolved via PATH).
+cmd: op-faucet
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-faucet

--- a/apko/op-interop-filter.yaml
+++ b/apko/op-interop-filter.yaml
@@ -1,0 +1,35 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-interop-filter@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Run as root for drop-in parity: the chart's StatefulSet sets no fsGroup and
+  # the existing raft-wal PVC data is root-owned, so nonroot uid 65532 gets
+  # permission-denied (and bricks the original on restore). The deployed image
+  # also runs as root. Revert to 65532 once the chart adds fsGroup: 65532.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-interop-filter"], resolved via PATH).
+cmd: op-interop-filter
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-interop-filter

--- a/apko/op-interop-mon.yaml
+++ b/apko/op-interop-mon.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-interop-mon@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Root, matching the upstream image.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-interop-mon"], resolved via PATH).
+cmd: op-interop-mon
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-interop-mon

--- a/apko/op-node.yaml
+++ b/apko/op-node.yaml
@@ -1,0 +1,35 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-node@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Run as root for drop-in parity: the chart's StatefulSet sets no fsGroup and
+  # the existing chain-data PVC is root-owned, so nonroot uid 65532 gets
+  # permission-denied. The deployed image also runs as root. Revert to 65532
+  # once the chart adds fsGroup: 65532.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-node"], resolved via PATH).
+cmd: op-node
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-node

--- a/apko/op-proposer.yaml
+++ b/apko/op-proposer.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-proposer@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Root, matching the upstream image.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-proposer"], resolved via PATH).
+cmd: op-proposer
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-proposer

--- a/apko/op-rbuilder.yaml
+++ b/apko/op-rbuilder.yaml
@@ -1,0 +1,40 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - ca-certificates
+    - busybox
+    - glibc
+    - libgcc
+    - libstdc++
+    - openssl
+    - op-rbuilder@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Run as root for drop-in parity: the chart's StatefulSet sets no fsGroup and
+  # the existing chain-data PVC is root-owned, so nonroot uid 65532 gets
+  # permission-denied. The deployed image also runs as root. Revert to 65532
+  # once the chart adds fsGroup: 65532.
+  run-as: 0
+
+entrypoint:
+  command: /app/rbuilder
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-rbuilder

--- a/apko/op-reth.yaml
+++ b/apko/op-reth.yaml
@@ -1,0 +1,40 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - ca-certificates
+    - busybox
+    - glibc
+    - libgcc
+    - libstdc++
+    - openssl
+    - op-reth@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Run as root for drop-in parity: the chart's StatefulSet sets no fsGroup and
+  # the existing chain-data PVC is root-owned, so nonroot uid 65532 gets
+  # permission-denied. The deployed image also runs as root. Revert to 65532
+  # once the chart adds fsGroup: 65532.
+  run-as: 0
+
+entrypoint:
+  command: /usr/local/bin/op-reth
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-reth

--- a/apko/op-supernode.yaml
+++ b/apko/op-supernode.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-supernode@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Root, matching the upstream image.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-supernode"], resolved via PATH).
+cmd: op-supernode
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-supernode

--- a/apko/op-test-sequencer.yaml
+++ b/apko/op-test-sequencer.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-test-sequencer@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Root, matching the upstream image.
+  run-as: 0
+
+# No entrypoint, bare-name cmd: matches the upstream image contract
+# (CMD ["op-test-sequencer"], resolved via PATH).
+cmd: op-test-sequencer
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: op-test-sequencer

--- a/apko/rollup-boost.yaml
+++ b/apko/rollup-boost.yaml
@@ -1,0 +1,40 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - ca-certificates
+    - busybox
+    - glibc
+    - libgcc
+    - libstdc++
+    - openssl
+    - rollup-boost@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # Run as root for drop-in parity: the chart's StatefulSet sets no fsGroup and
+  # the existing chain-data PVC is root-owned, so nonroot uid 65532 gets
+  # permission-denied. The deployed image also runs as root. Revert to 65532
+  # once the chart adds fsGroup: 65532.
+  run-as: 0
+
+entrypoint:
+  command: /usr/local/bin/rollup-boost
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: rollup-boost

--- a/melange/cannon.yaml
+++ b/melange/cannon.yaml
@@ -1,0 +1,36 @@
+# Standalone cannon image (monorepo cannon-target): multicannon + loose embed files.
+# Same embed staging and multiplexer build as multicannon; additionally copies
+# cannon-0..8 onto /usr/local/bin/ like the Dockerfile's second COPY.
+package:
+  name: cannon
+  version: "0.0.0"
+  epoch: 0
+  description: cannon — OP Stack fault proof VM
+  copyright:
+    - license: MIT
+  options:
+    no-depends: true
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - git
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: cannon/build-multicannon
+  - runs: |
+      set -euo pipefail
+      cd cannon
+      cp multicannon/embeds/cannon-* "${{targets.contextdir}}/usr/local/bin/"
+      chmod 755 "${{targets.contextdir}}"/usr/local/bin/cannon-*
+  - uses: strip

--- a/melange/multicannon.yaml
+++ b/melange/multicannon.yaml
@@ -1,0 +1,30 @@
+# Multicannon multiplexer only (monorepo op-challenger-target cannon COPY).
+# Historical embeds: melange/pipelines/cannon/build-multicannon.yaml
+package:
+  name: multicannon
+  version: "0.0.0"
+  epoch: 0
+  description: cannon multicannon multiplexer (embedded VMs, no loose embed files)
+  copyright:
+    - license: MIT
+  options:
+    no-depends: true
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - git
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: cannon/build-multicannon
+  - uses: strip

--- a/melange/op-deployer.yaml
+++ b/melange/op-deployer.yaml
@@ -1,0 +1,48 @@
+package:
+  name: op-deployer
+  version: "0.0.0"
+  epoch: 0
+  description: op-deployer — OP Stack deployment tool
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - bash
+      - curl
+      - go-1.26
+      - git
+      - jq
+      - yq
+      - zip
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: op-stack-go/sync-superchain
+
+  - uses: op-deployer/install-forge
+
+  # Compile contracts-bedrock and pack the artifacts op-deployer embeds via
+  # //go:embed — must exist before `go build`, or `op-deployer apply` fails at
+  # runtime with "artifacts.tzst: file does not exist".
+  - uses: op-deployer/embed-artifacts
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./op-deployer/cmd/op-deployer
+      output: op-deployer
+      go-package: go-1.26
+      # /usr/local/bin, where upstream's images install binaries.
+      prefix: usr/local
+      ldflags: -s -w -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+
+  - uses: strip

--- a/melange/op-stack-go.yaml
+++ b/melange/op-stack-go.yaml
@@ -1,0 +1,226 @@
+# Consolidated build for every Go service of the optimism monorepo. One
+# melange run, one source checkout, one shared GOMODCACHE/GOCACHE: the module
+# dependency graph compiles once and every later subpackage build is
+# incremental, instead of 13 independent CI legs each recompiling it from
+# scratch.
+#
+# Each subpackage emits its own APK under the same name the per-service
+# configs used (op-node, op-batcher, ...), so the apko/*.yaml image configs
+# keep pulling e.g. `op-node@local` unchanged. The op-stack-go package itself
+# is an empty meta package.
+#
+# op-deployer is NOT here: it needs a submodule checkout and package-local
+# Forge install to embed contract artifacts (see melange/op-deployer.yaml).
+package:
+  name: op-stack-go
+  version: "0.0.0"
+  epoch: 0
+  description: op-stack-go — meta package for the optimism monorepo Go services
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - bash
+      - git
+      - go-1.26
+      - jq
+      - yq
+      - zip
+  environment:
+    CGO_ENABLED: "0"
+
+# op-core/superchain embed prep runs once before any subpackage go/build.
+pipeline:
+  - uses: op-stack-go/sync-superchain
+
+subpackages:
+  - name: op-node
+    description: op-node — OP Stack rollup node
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-node/cmd
+          output: op-node
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: op-batcher
+    description: op-batcher — OP Stack transaction batcher
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-batcher/cmd
+          output: op-batcher
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: op-proposer
+    description: op-proposer — OP Stack output proposer
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-proposer/cmd
+          output: op-proposer
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: op-conductor
+    description: op-conductor — OP Stack sequencer conductor
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-conductor/cmd
+          output: op-conductor
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: op-challenger
+    description: op-challenger — OP Stack fault dispute challenger
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-challenger/cmd
+          output: op-challenger
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: op-dispute-mon
+    description: op-dispute-mon — OP Stack dispute monitor
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-dispute-mon/cmd
+          output: op-dispute-mon
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: op-dripper
+    description: op-dripper — OP Stack drippie executor
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-dripper/cmd
+          output: op-dripper
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: op-faucet
+    description: op-faucet — OP Stack faucet service
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-faucet/cmd
+          output: op-faucet
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: op-interop-filter
+    description: op-interop-filter — OP Stack interop message filter
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-interop-filter/cmd
+          output: op-interop-filter
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: op-interop-mon
+    description: op-interop-mon — OP Stack interop monitor
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-interop-mon/cmd
+          output: op-interop-mon
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: op-supernode
+    description: op-supernode — OP Stack supernode
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-supernode/cmd
+          output: op-supernode
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: op-test-sequencer
+    description: op-test-sequencer — OP Stack test sequencer
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-test-sequencer/cmd
+          output: op-test-sequencer
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip
+
+  - name: da-server
+    description: da-server — OP Stack alt-DA server
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./op-alt-da/cmd/daserver
+          output: da-server
+          go-package: go-1.26
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      - uses: strip

--- a/melange/op-stack-rust.yaml
+++ b/melange/op-stack-rust.yaml
@@ -1,0 +1,139 @@
+# Consolidated build for the Rust services of the optimism monorepo. kona and
+# op-reth live in the same cargo workspace (rust/) with a single Cargo.lock,
+# so one melange run shares the whole common dependency graph (alloy,
+# op-alloy, revm, ...) across all four binaries instead of compiling it once
+# per CI leg. Subpackage builds run sequentially in one sandbox with a shared
+# target dir: the first build does the heavy lifting, the rest are
+# incremental.
+#
+# Each binary is its own subpackage/APK so images pull only what they run:
+# the kona image bundles all three kona binaries, while op-challenger pulls
+# just kona-host. The op-stack-rust package itself is an empty meta package.
+package:
+  name: op-stack-rust
+  version: "0.0.0"
+  epoch: 0
+  description: op-stack-rust — meta package for the optimism monorepo Rust services
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - cargo-auditable
+      - rust
+      - openssl-dev
+      - perl
+      - clang-19
+      - libclang-cpp-19
+      # opt-in mold linking when the cargo/build pipeline uses it.
+      - mold
+  environment:
+    # One profile for the whole workspace: a single setting means shared
+    # dependency crates compile once across subpackages. CARGO_HOME and
+    # CARGO_TARGET_DIR point at /var/cache/melange; melange/pipelines/cargo/build
+    # derives a per-modroot target subdir from the base. GHA cache restores
+    # melange-cache/ before each op-stack-rust job.
+    # opt-level 0 for faster CI builds. NOTE: op-reth and kona-node are
+    # hot-path chain components — raise this before shipping a prod image, as
+    # an unoptimized binary is significantly slower at runtime.
+    CARGO_HOME: /var/cache/melange/cargo
+    CARGO_TARGET_DIR: /var/cache/melange/target
+    CARGO_PROFILE_RELEASE_OPT_LEVEL: "0"
+    CARGO_PROFILE_RELEASE_LTO: "off"
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
+    CARGO_PROFILE_RELEASE_DEBUG: "0"
+
+subpackages:
+  # The first subpackage builds ALL four packages in one cargo invocation:
+  # one scheduler pass over the whole workspace graph keeps every core busy
+  # instead of serializing four builds. The shared target dir persists across
+  # subpackages, so the later three cargo runs are no-op fingerprint checks
+  # followed by an install.
+  - name: op-reth
+    description: op-reth — OP Stack Reth execution client
+    pipeline:
+      - uses: cargo/build
+        with:
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          modroot: rust
+          output: op-reth
+          opts: --release --locked --package op-reth --package kona-node --package kona-host --package kona-client
+      - uses: strip
+
+  - name: kona-node
+    description: kona-node — OP Stack Kona rollup node
+    pipeline:
+      - uses: cargo/build
+        with:
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          modroot: rust
+          output: kona-node
+          opts: --release --locked --package kona-node
+      - uses: strip
+
+  - name: kona-host
+    description: kona-host — OP Stack Kona fault proof host
+    pipeline:
+      - uses: cargo/build
+        with:
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          modroot: rust
+          output: kona-host
+          opts: --release --locked --package kona-host
+      - uses: strip
+
+  - name: kona-client
+    description: kona-client — OP Stack Kona fault proof client
+    pipeline:
+      - uses: cargo/build
+        with:
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          modroot: rust
+          output: kona-client
+          opts: --release --locked --package kona-client
+      - uses: strip
+
+  # The monorepo vendors op-rbuilder and rollup-boost as NESTED workspaces
+  # (own Cargo.toml + Cargo.lock, not members of the main rust/ workspace), and
+  # upstream's build-images workflow publishes both from these copies. They
+  # share this leg's checkout but not the main workspace's dependency build.
+  - name: op-rbuilder
+    description: op-rbuilder — OP Stack block builder (monorepo vendored copy)
+    pipeline:
+      - uses: cargo/build
+        with:
+          prefix: usr/local
+          modroot: rust/op-rbuilder
+          output: op-rbuilder
+          opts: --release --locked --package op-rbuilder
+      # Upstream's op-rbuilder image ships the binary as /app/rbuilder (its
+      # Dockerfile heritage); match it for drop-in parity.
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/app"
+          mv "${{targets.contextdir}}/usr/local/bin/op-rbuilder" \
+             "${{targets.contextdir}}/app/rbuilder"
+      - uses: strip
+
+  - name: rollup-boost
+    description: rollup-boost — OP Stack block builder multiplexer (monorepo vendored copy)
+    pipeline:
+      - uses: cargo/build
+        with:
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          modroot: rust/rollup-boost
+          output: rollup-boost
+          opts: --release --locked --package rollup-boost
+      - uses: strip

--- a/melange/op-stack-rust.yaml
+++ b/melange/op-stack-rust.yaml
@@ -36,20 +36,13 @@ environment:
       # opt-in mold linking when the cargo/build pipeline uses it.
       - mold
   environment:
-    # One profile for the whole workspace: a single setting means shared
-    # dependency crates compile once across subpackages. CARGO_HOME and
+    # The workflow selects MELANGE_CARGO_PROFILE for the main rust/ workspace:
+    # fast-build for PRs and maxperf for develop/tag builds. CARGO_HOME and
     # CARGO_TARGET_DIR point at /var/cache/melange; melange/pipelines/cargo/build
     # derives a per-modroot target subdir from the base. GHA cache restores
     # melange-cache/ before each op-stack-rust job.
-    # opt-level 0 for faster CI builds. NOTE: op-reth and kona-node are
-    # hot-path chain components — raise this before shipping a prod image, as
-    # an unoptimized binary is significantly slower at runtime.
     CARGO_HOME: /var/cache/melange/cargo
     CARGO_TARGET_DIR: /var/cache/melange/target
-    CARGO_PROFILE_RELEASE_OPT_LEVEL: "0"
-    CARGO_PROFILE_RELEASE_LTO: "off"
-    CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
-    CARGO_PROFILE_RELEASE_DEBUG: "0"
 
 subpackages:
   # The first subpackage builds ALL four packages in one cargo invocation:
@@ -66,7 +59,8 @@ subpackages:
           prefix: usr/local
           modroot: rust
           output: op-reth
-          opts: --release --locked --package op-reth --package kona-node --package kona-host --package kona-client
+          profile: "${MELANGE_CARGO_PROFILE}"
+          opts: --locked --package op-reth --package kona-node --package kona-host --package kona-client
       - uses: strip
 
   - name: kona-node
@@ -78,7 +72,8 @@ subpackages:
           prefix: usr/local
           modroot: rust
           output: kona-node
-          opts: --release --locked --package kona-node
+          profile: "${MELANGE_CARGO_PROFILE}"
+          opts: --locked --package kona-node
       - uses: strip
 
   - name: kona-host
@@ -90,7 +85,8 @@ subpackages:
           prefix: usr/local
           modroot: rust
           output: kona-host
-          opts: --release --locked --package kona-host
+          profile: "${MELANGE_CARGO_PROFILE}"
+          opts: --locked --package kona-host
       - uses: strip
 
   - name: kona-client
@@ -102,7 +98,8 @@ subpackages:
           prefix: usr/local
           modroot: rust
           output: kona-client
-          opts: --release --locked --package kona-client
+          profile: "${MELANGE_CARGO_PROFILE}"
+          opts: --locked --package kona-client
       - uses: strip
 
   # The monorepo vendors op-rbuilder and rollup-boost as NESTED workspaces

--- a/melange/pipelines/cannon/build-multicannon.yaml
+++ b/melange/pipelines/cannon/build-multicannon.yaml
@@ -1,0 +1,94 @@
+name: Stage cannon embeds and build the multicannon multiplexer.
+
+# Shared by melange/multicannon.yaml (multicannon@local) and melange/cannon.yaml
+# (cannon@local). Pulls historical cannon VM binaries from published images,
+# builds cannon-8 from source, then links the multiplexer.
+
+needs:
+  packages:
+    - busybox
+    - crane
+    - git
+    - go-1.26
+
+pipeline:
+  - runs: |
+      set -euo pipefail
+
+      export GOMODCACHE=/var/cache/melange/gomodcache
+      # Untracked embed files would pollute VCS-stamped build metadata.
+      mkdir -p "${HOME}/.config/git"
+      echo '**' > "${HOME}/.config/git/ignore"
+
+      GITCOMMIT=$(git rev-parse HEAD 2>/dev/null || echo unknown)
+      GITDATE=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      LDFLAGS="-s -w -X main.GitCommit=${GITCOMMIT} -X main.GitDate=${GITDATE}"
+
+      # Keep in sync with cannon/mipsevm/versions/version.go and cannon justfile.
+      EMBED_VERSION=8
+
+      cd cannon
+
+      ARCH="${{build.arch}}"
+      case "$ARCH" in
+        x86_64)
+          PLATFORM=linux/amd64
+          MUSL_ARCH=x86_64
+          ;;
+        aarch64)
+          PLATFORM=linux/arm64
+          MUSL_ARCH=aarch64
+          ;;
+        *)
+          echo "unsupported arch: $ARCH" >&2
+          exit 1
+          ;;
+      esac
+
+      PREFETCH="multicannon/embeds-prefetch/${ARCH}"
+      mkdir -p "$PREFETCH"
+
+      REG=us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon
+
+      fetch() { # <tag> <path-in-image> <embed-name>
+        local tag="$1" path="$2" name="$3"
+        path="${path#/}"
+        crane export --platform "$PLATFORM" "${REG}:${tag}" - \
+          | tar -xO "$path" > "${PREFETCH}/${name}"
+        chmod 755 "${PREFETCH}/${name}"
+      }
+
+      fetch v1.0.0 /usr/local/bin/cannon   cannon-0
+      fetch v1.3.0 /usr/local/bin/cannon-1 cannon-1
+      fetch v1.4.0 /usr/local/bin/cannon-2 cannon-2
+      fetch v1.2.0 /usr/local/bin/cannon-3 cannon-3
+      fetch v1.3.0 /usr/local/bin/cannon-4 cannon-4
+      fetch v1.4.0 /usr/local/bin/cannon-5 cannon-5
+      fetch v1.4.0 /usr/local/bin/cannon-6 cannon-6
+      fetch v1.6.0 /usr/local/bin/cannon-7 cannon-7
+
+      # The historical cannon binaries are Alpine/musl linked. Wolfi does not
+      # publish a musl package in the repository used by these apko configs, so
+      # bundle the matching loader/libc from the upstream cannon image.
+      MUSL_ROOT="${PREFETCH}/musl-root"
+      mkdir -p "$MUSL_ROOT" "${{targets.contextdir}}/usr/lib"
+      crane export --platform "$PLATFORM" "${REG}:v1.6.0" - \
+        | tar -C "$MUSL_ROOT" -xf - \
+            "lib/ld-musl-${MUSL_ARCH}.so.1" \
+            "lib/libc.musl-${MUSL_ARCH}.so.1"
+      cp "${MUSL_ROOT}/lib/ld-musl-${MUSL_ARCH}.so.1" \
+        "${{targets.contextdir}}/usr/lib/"
+      cp "${MUSL_ROOT}/lib/libc.musl-${MUSL_ARCH}.so.1" \
+        "${{targets.contextdir}}/usr/lib/"
+      chmod 755 "${{targets.contextdir}}/usr/lib/ld-musl-${MUSL_ARCH}.so.1" \
+        "${{targets.contextdir}}/usr/lib/libc.musl-${MUSL_ARCH}.so.1"
+
+      mkdir -p multicannon/embeds
+      cp "$PREFETCH"/cannon-* multicannon/embeds/
+      chmod 755 multicannon/embeds/cannon-*
+
+      go build -o "multicannon/embeds/cannon-${EMBED_VERSION}" \
+        -ldflags "${LDFLAGS}" -trimpath .
+
+      go build -o "${{targets.contextdir}}/usr/local/bin/cannon" \
+        -ldflags "${LDFLAGS}" -trimpath ./multicannon

--- a/melange/pipelines/cargo/build.yaml
+++ b/melange/pipelines/cargo/build.yaml
@@ -22,6 +22,13 @@ inputs:
     description: |
       Options to pass to cargo build. Defaults to release
 
+  profile:
+    default: ""
+    required: false
+    description: |
+      Cargo profile to pass as --profile. When set, opts must not include
+      --release or --profile.
+
   modroot:
     default: "."
     required: false
@@ -74,8 +81,54 @@ pipeline:
       cache_root="${CARGO_TARGET_DIR:-/var/cache/melange/target}"
       modroot_slug=$(echo "${{inputs.modroot}}" | tr '/' '_')
       export CARGO_TARGET_DIR="${cache_root}/${modroot_slug}"
-      OUTPUT_PATH="${CARGO_TARGET_DIR}/release"
       mkdir -p "$CARGO_TARGET_DIR"
+
+      build_opts="${{inputs.opts}}"
+      profile="${{inputs.profile}}"
+      profile_flag=""
+      if [ -n "$profile" ]; then
+        case " $build_opts " in
+          *" --release "*|*" --profile "*|*" --profile="*)
+            echo "profile input cannot be combined with --release or --profile in opts" >&2
+            exit 1
+            ;;
+        esac
+        profile_flag="--profile $profile"
+      else
+        case " $build_opts " in
+          *" --release "*|*" --profile "*|*" --profile="*) ;;
+          *) profile_flag="--release" ;;
+        esac
+      fi
+
+      output_profile=""
+      set -- $profile_flag $build_opts
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --profile)
+            shift
+            output_profile="${1:-}"
+            ;;
+          --profile=*)
+            output_profile="${1#--profile=}"
+            ;;
+          --release)
+            output_profile="release"
+            ;;
+        esac
+        [ "$#" -eq 0 ] || shift
+      done
+
+      if [ -n "$output_profile" ]; then
+        OUTPUT_PATH="${CARGO_TARGET_DIR}/${output_profile}"
+      else
+        output_dir="${{inputs.output-dir}}"
+        case "$output_dir" in
+          /*) OUTPUT_PATH="$output_dir" ;;
+          target/*) OUTPUT_PATH="${CARGO_TARGET_DIR}/${output_dir#target/}" ;;
+          *) OUTPUT_PATH="${CARGO_TARGET_DIR}/${output_dir}" ;;
+        esac
+      fi
 
       jobs_flag=""
       if [ -n "${{inputs.jobs}}" ]; then
@@ -88,7 +141,7 @@ pipeline:
       fi
 
       RUSTFLAGS="${{inputs.rustflags}}" $run_wrap cargo auditable build \
-        ${{inputs.opts}} $jobs_flag
+        $profile_flag $build_opts $jobs_flag
 
       if [ -n "${{inputs.output}}" ]; then
         install -Dm755 "${OUTPUT_PATH}/${{inputs.output}}" "${INSTALL_PATH}/${{inputs.output}}"

--- a/melange/pipelines/cargo/build.yaml
+++ b/melange/pipelines/cargo/build.yaml
@@ -1,0 +1,97 @@
+name: Compile an auditable rust binary with Cargo
+
+# Overrides the built-in cargo/build when --pipeline-dir points here. Writes
+# CARGO_HOME and compile artifacts under /var/cache/melange so melange
+# --cache-dir and GHA actions/cache persist Rust builds across CI runs.
+
+needs:
+  packages:
+    - build-base
+    - busybox
+    - cargo-auditable
+    - rust
+
+inputs:
+  output:
+    description: |
+      Filename to use when writing the binary. The final install location inside
+      the apk will be in prefix / install-dir / output
+
+  opts:
+    default: --release
+    description: |
+      Options to pass to cargo build. Defaults to release
+
+  modroot:
+    default: "."
+    required: false
+    description: |
+      Top directory of the rust package, this is where the target package lives.
+      Before building, the cargo pipeline wil cd into this directory. Defaults
+      to current working directory
+
+  rustflags:
+    default: ""
+    required: false
+    description: |
+      Rustc flags to be passed to pass to all compiler invocations that Cargo performs.
+      In contrast with cargo rustc, this is useful for passing a flag to all compiler instances.
+      This string is split by whitespace.
+
+  prefix:
+    default: usr
+    description: |
+      Installation prefix. Defaults to usr
+
+  install-dir:
+    description: |
+      Directory where binaries will be installed
+    default: bin
+
+  output-dir:
+    description: |
+      Directory where the binaris will be placed after building. Defaults to target/release
+    default: target/release
+
+  jobs:
+    description: |
+      Override the number of parallel jobs. It defaults to the number of CPUs.
+
+pipeline:
+  - runs: |
+      set -e
+
+      export CARGO_HOME="${CARGO_HOME:-/var/cache/melange/cargo}"
+      mkdir -p "$CARGO_HOME"
+
+      INSTALL_PATH="${{targets.contextdir}}/${{inputs.prefix}}/${{inputs.install-dir}}"
+
+      cd "${{inputs.modroot}}"
+
+      # Honor CARGO_TARGET_DIR from the melange config (base under
+      # /var/cache/melange). Derive one tree per modroot so main-workspace
+      # subpackages share rust/ and nested workspaces stay separate.
+      cache_root="${CARGO_TARGET_DIR:-/var/cache/melange/target}"
+      modroot_slug=$(echo "${{inputs.modroot}}" | tr '/' '_')
+      export CARGO_TARGET_DIR="${cache_root}/${modroot_slug}"
+      OUTPUT_PATH="${CARGO_TARGET_DIR}/release"
+      mkdir -p "$CARGO_TARGET_DIR"
+
+      jobs_flag=""
+      if [ -n "${{inputs.jobs}}" ]; then
+        jobs_flag="--jobs ${{inputs.jobs}}"
+      fi
+
+      run_wrap=""
+      if command -v mold >/dev/null 2>&1; then
+        run_wrap="mold -run"
+      fi
+
+      RUSTFLAGS="${{inputs.rustflags}}" $run_wrap cargo auditable build \
+        ${{inputs.opts}} $jobs_flag
+
+      if [ -n "${{inputs.output}}" ]; then
+        install -Dm755 "${OUTPUT_PATH}/${{inputs.output}}" "${INSTALL_PATH}/${{inputs.output}}"
+      else
+        install -Dm755 "${OUTPUT_PATH}"/* -t "${INSTALL_PATH}"
+      fi

--- a/melange/pipelines/op-deployer/embed-artifacts.yaml
+++ b/melange/pipelines/op-deployer/embed-artifacts.yaml
@@ -1,0 +1,44 @@
+name: Compile contracts-bedrock and pack op-deployer's embedded contract artifacts.
+
+# op-deployer embeds the compiled L1 contract artifacts in its binary via
+# //go:embed (pkg/deployer/artifacts/forge-artifacts/artifacts.tzst). The plain
+# go build ships the embed dir with only its README, so the binary builds but
+# `op-deployer apply` fails at runtime with "artifacts.tzst: file does not
+# exist". This reproduces the upstream op-deployer justfile `build-contracts` +
+# `copy-contract-artifacts` steps so the embed target exists before `go build`.
+#
+# Requires op-deployer/install-forge to run first and git (contracts-bedrock
+# pulls its Solidity deps as submodules, checked out alongside the source).
+
+needs:
+  packages:
+    - go-1.26
+    - git
+
+inputs:
+  contracts-dir:
+    description: "contracts-bedrock directory, relative to the source root"
+    default: "packages/contracts-bedrock"
+  mktar-pkg:
+    description: "Go package path for the mktar artifact-packing tool"
+    default: "./op-deployer/pkg/deployer/artifacts/cmd/mktar"
+  artifacts-out:
+    description: "embed target for artifacts.tzst, relative to the source root"
+    default: "op-deployer/pkg/deployer/artifacts/forge-artifacts/artifacts.tzst"
+
+pipeline:
+  - runs: |
+      set -euo pipefail
+      forge_bin="${{targets.contextdir}}/usr/local/bin/forge"
+      if [ ! -x "$forge_bin" ]; then
+        forge_bin="forge"
+      fi
+      "$forge_bin" --version
+      # Compile contracts-bedrock (mirrors `just build-no-tests`).
+      ( cd "${{inputs.contracts-dir}}" && "$forge_bin" build --skip "/**/test/**" )
+      # Pack the compiled artifacts into the embedded tarball (mirrors
+      # `just copy-contract-artifacts`).
+      go run "${{inputs.mktar-pkg}}" \
+        -base "${{inputs.contracts-dir}}" \
+        -out "${{inputs.artifacts-out}}" \
+        --exclude="*.t.sol"

--- a/melange/pipelines/op-deployer/install-forge.yaml
+++ b/melange/pipelines/op-deployer/install-forge.yaml
@@ -1,0 +1,48 @@
+name: Install pinned Forge from Optimism's op-deployer version metadata.
+
+needs:
+  packages:
+    - busybox
+    - ca-certificates-bundle
+    - curl
+    - jq
+
+inputs:
+  version-json:
+    description: "Forge version metadata, relative to the source root"
+    default: "op-deployer/pkg/deployer/forge/version.json"
+
+pipeline:
+  - runs: |
+      set -euo pipefail
+
+      case "${{build.arch}}" in
+        x86_64) foundry_platform=alpine_amd64 ;;
+        aarch64) foundry_platform=alpine_arm64 ;;
+        *) echo "unsupported melange arch for Forge: ${{build.arch}}" >&2; exit 1 ;;
+      esac
+
+      version_file="${{inputs.version-json}}"
+      version="$(jq -r '.forge // empty' "$version_file")"
+      checksum="$(jq -r --arg platform "$foundry_platform" '.checksums[$platform] // empty' "$version_file")"
+      if [ -z "$version" ] || [ -z "$checksum" ]; then
+        echo "missing Forge version or checksum for $foundry_platform in $version_file" >&2
+        exit 1
+      fi
+
+      archive="foundry_${version}_${foundry_platform}.tar.gz"
+      url="https://github.com/foundry-rs/foundry/releases/download/${version}/${archive}"
+      work="$(mktemp -d)"
+      trap 'rm -rf "$work"' EXIT
+
+      curl -fsSL --retry 3 -o "$work/$archive" "$url"
+      printf '%s  %s\n' "$checksum" "$work/$archive" | sha256sum -c -
+      tar -xzf "$work/$archive" -C "$work"
+
+      forge_path="$(find "$work" -type f -name forge | head -n1)"
+      if [ -z "$forge_path" ] || [ ! -x "$forge_path" ]; then
+        echo "Forge binary not found in $archive" >&2
+        exit 1
+      fi
+
+      install -Dm755 "$forge_path" "${{targets.contextdir}}/usr/local/bin/forge"

--- a/melange/pipelines/op-stack-go/sync-superchain.yaml
+++ b/melange/pipelines/op-stack-go/sync-superchain.yaml
@@ -1,0 +1,31 @@
+name: Build op-core/superchain/superchain-configs.zip before Go compiles.
+
+# op-core/superchain //go:embeds a gitignored superchain-configs.zip. Without it,
+# any Go binary that transitively links the package fails at compile time with
+# "pattern superchain-configs.zip: no matching files found".
+#
+# Mirrors optimism ops/docker/op-stack-go/Dockerfile (RUN sync-superchain.sh)
+# and `just build-superchain-go`: init the superchain-registry submodule, then
+# regenerate the zip and verify against the committed .sha256.
+
+needs:
+  packages:
+    - bash
+    - git
+    - jq
+    - yq
+    - zip
+
+inputs:
+  submodule-path:
+    description: superchain-registry submodule path, relative to the source root
+    default: superchain-registry
+  sync-script:
+    description: sync-superchain.sh path, relative to the source root
+    default: op-core/superchain/sync-superchain.sh
+
+pipeline:
+  - runs: |
+      set -euo pipefail
+      git submodule update --init --depth 1 "${{inputs.submodule-path}}"
+      bash "${{inputs.sync-script}}"

--- a/pipelines
+++ b/pipelines
@@ -1,0 +1,1 @@
+melange/pipelines


### PR DESCRIPTION
## Summary

- add a parallel apko image build workflow while keeping the existing Docker-based image workflow unchanged
- add melange and apko configuration for the covered images
- publish apko images to a separate image namespace to avoid collisions with the existing image outputs
- select the Rust cargo profile dynamically so PR builds use the fast profile and non-PR builds use the max-performance profile
- keep tag behavior aligned with the existing image build flow

## Vulnerability comparison

Measured with `grype 0.107.0` against the Docker images from `develop` (`8fd06d3cc3e7a872b542476f60cebddf22c97159`) and the apko images from this PR's workflow (`7604390b200a9ff5ffbdce9b2a56e26c25820206`). Both amd64 and arm64 were measured; counts were identical across platforms, so the table is collapsed per image.

Totals include all severities reported by Grype. `C/H/M/L` is Critical/High/Medium/Low.

| Image | Docker total | apko total | Change | Reduction | Docker C/H/M/L | apko C/H/M/L |
|---|---:|---:|---:|---:|---:|---:|
| `da-server` | 0 | 0 | 0 | n/a | 0/0/0/0 | 0/0/0/0 |
| `kona-client` | 9 | 9 | 0 | 0.0% | 0/5/2/2 | 0/5/2/2 |
| `kona-host` | 12 | 12 | 0 | 0.0% | 0/7/3/2 | 0/7/3/2 |
| `kona-node` | 12 | 12 | 0 | 0.0% | 0/7/3/2 | 0/7/3/2 |
| `op-batcher` | 1 | 1 | 0 | 0.0% | 0/0/1/0 | 0/0/1/0 |
| `op-challenger` | 114 | 13 | -101 | 88.6% | 0/0/89/23 | 0/7/4/2 |
| `op-conductor` | 8 | 8 | 0 | 0.0% | 0/1/7/0 | 0/1/7/0 |
| `op-deployer` | 0 | 0 | 0 | n/a | 0/0/0/0 | 0/0/0/0 |
| `op-dispute-mon` | 1 | 1 | 0 | 0.0% | 0/0/1/0 | 0/0/1/0 |
| `op-dripper` | 1 | 1 | 0 | 0.0% | 0/0/1/0 | 0/0/1/0 |
| `op-faucet` | 1 | 1 | 0 | 0.0% | 0/0/1/0 | 0/0/1/0 |
| `op-interop-filter` | 1 | 1 | 0 | 0.0% | 0/0/1/0 | 0/0/1/0 |
| `op-interop-mon` | 1 | 1 | 0 | 0.0% | 0/0/1/0 | 0/0/1/0 |
| `op-node` | 8 | 8 | 0 | 0.0% | 0/1/7/0 | 0/1/7/0 |
| `op-proposer` | 1 | 1 | 0 | 0.0% | 0/0/1/0 | 0/0/1/0 |
| `op-rbuilder` | 27 | 5 | -22 | 81.5% | 2/10/6/2 | 0/3/1/1 |
| `op-reth` | 9 | 9 | 0 | 0.0% | 0/5/2/2 | 0/5/2/2 |
| `op-supernode` | 8 | 8 | 0 | 0.0% | 0/1/7/0 | 0/1/7/0 |
| `op-test-sequencer` | 8 | 8 | 0 | 0.0% | 0/1/7/0 | 0/1/7/0 |
| `rollup-boost` | 142 | 2 | -140 | 98.6% | 5/14/33/4 | 0/0/1/1 |
