### PR TITLE
fix(kona-sp1): make BlobStore soundness self-contained

### DIFF
--- a/rust/kona/sp1/crates/client/src/oracle/blob_provider.rs
+++ b/rust/kona/sp1/crates/client/src/oracle/blob_provider.rs
@@ -16,6 +16,9 @@ pub struct BlobStore {
 
 impl From<BlobData> for BlobStore {
     fn from(value: BlobData) -> Self {
+        assert_eq!(value.blobs.len(), value.commitments.len());
+        assert_eq!(value.commitments.len(), value.proofs.len());
+
         let blobs: Vec<_> =
             value.blobs.iter().map(|b| kzg_rs::Blob::from_slice(&b.0).unwrap()).collect();
         let versioned_blobs = value
@@ -23,7 +26,6 @@ impl From<BlobData> for BlobStore {
             .iter()
             .map(|c| kzg_to_versioned_hash(c.as_slice()))
             .zip(blobs.iter().map(|b| Blob::from(b.0)))
-            .rev()
             .collect();
 
         match kzg_rs::KzgProof::verify_blob_kzg_proof_batch(
@@ -52,10 +54,71 @@ impl BlobProvider for BlobStore {
     ) -> Result<Vec<Box<Blob>>, Self::Error> {
         Ok(blob_hashes
             .iter()
-            .filter_map(|hash| {
-                let (blob_hash, blob) = self.versioned_blobs.pop().unwrap();
-                (*hash == blob_hash).then(|| Box::new(blob))
+            .map(|hash| {
+                let pos = self
+                    .versioned_blobs
+                    .iter()
+                    .position(|(stored_hash, _)| stored_hash == hash)
+                    .unwrap_or_else(|| {
+                        panic!("requested blob hash not present in BlobStore: {hash}")
+                    });
+                let (_, blob) = self.versioned_blobs.swap_remove(pos);
+                Box::new(blob)
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::witness::BlobData;
+    use kona_proof::block_on;
+    use kona_protocol::BlockInfo;
+
+    // Looking up blobs must be by versioned hash, not by position in the
+    // internal `versioned_blobs` vec — derivation does not guarantee that
+    // requested hashes arrive in the same order they were packed in the
+    // witness.
+    #[test]
+    fn out_of_order_request_returns_all_blobs() {
+        let hash_a = B256::repeat_byte(0xAA);
+        let hash_b = B256::repeat_byte(0xBB);
+        let mut blob_a = Blob::default();
+        blob_a[0] = 0xAA;
+        let mut blob_b = Blob::default();
+        blob_b[0] = 0xBB;
+
+        let mut store = BlobStore { versioned_blobs: vec![(hash_b, blob_b), (hash_a, blob_a)] };
+
+        let result =
+            block_on(store.get_and_validate_blobs(&BlockInfo::default(), &[hash_b, hash_a]))
+                .expect("get_and_validate_blobs failed");
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(*result[0], blob_b);
+        assert_eq!(*result[1], blob_a);
+    }
+
+    #[test]
+    #[should_panic(expected = "requested blob hash not present in BlobStore")]
+    fn missing_hash_request_panics() {
+        let hash_a = B256::repeat_byte(0xAA);
+        let hash_missing = B256::repeat_byte(0xCC);
+        let mut store = BlobStore { versioned_blobs: vec![(hash_a, Blob::default())] };
+        let _ = block_on(store.get_and_validate_blobs(&BlockInfo::default(), &[hash_missing]));
+    }
+
+    // `kzg_rs::verify_blob_kzg_proof_batch` short-circuits at zero blobs
+    // without checking lengths, so we must catch the mismatch locally.
+    #[test]
+    #[should_panic(expected = "assertion `left == right` failed")]
+    fn from_blob_data_length_mismatch_panics() {
+        let bd = BlobData {
+            blobs: vec![],
+            commitments: vec![kzg_rs::Bytes48([0u8; 48])],
+            proofs: vec![],
+        };
+        let _ = BlobStore::from(bd);
     }
 }


### PR DESCRIPTION
## Summary

Closes #21490. Moves two soundness-adjacent invariants in `rust/kona/sp1/crates/client/src/oracle/blob_provider.rs` from implicit contracts (`kzg_rs`'s batch verifier + an undocumented host packing order) to local asserts.

* `assert_eq!` on the three `BlobData` lengths at the top of `From<BlobData>`. `kzg_rs::verify_blob_kzg_proof_batch` short-circuits at 0/1 blobs without comparing input lengths, so a malformed witness could previously produce a degenerate empty store.
* By-hash lookup (linear scan + `swap_remove`) in `get_and_validate_blobs`, panicking on miss instead of silently dropping the request. Removes the dependency on the host packing blobs in `kona-derive`'s request order.
* Drop the now-dead `.rev()` in `From<BlobData>` (only needed to make LIFO `pop()` walk in request order).

In the SP1 guest, both new panics surface as "invalid proof", which is the correct outcome for a witness that cannot satisfy derivation's request.

## Behavior change to flag

If a host ever returned the correct *set* of blobs but in the wrong *order*, the old code silently returned an empty `Vec` and derivation errored. With by-hash lookup, that same case now succeeds. Strictly more correct, but observably different. Honest hosts (`OnlineBlobStore` in `rust/kona/sp1/crates/host/src/witness_generation/online_blob_store.rs`) always pack in request order with matching lengths, so no impact for real proof runs.

## No forged-proof path before

Versioned-hash anchoring at retrieval and the honest host's packing kept the line; the invariants just lived outside this file.

## Test plan

Three new unit tests in `blob_provider.rs`. All fail on baseline `cf2ce0979a` with the expected symptoms and pass after the fix:

- [x] `out_of_order_request_returns_all_blobs` - baseline returns empty Vec (assertion fails with `left: 0, right: 2`); post-fix returns blobs in request order.
- [x] `missing_hash_request_panics` - `#[should_panic]`; baseline silently drops the request (no panic), post-fix panics with `requested blob hash not present in BlobStore`.
- [x] `from_blob_data_length_mismatch_panics` - `#[should_panic]`; baseline short-circuits through `kzg_rs` with `Ok(true)` (no panic), post-fix panics on the new `assert_eq!`.
- [x] `cargo nextest run -p kona-sp1-client-utils`: 11/11 passing (3 new + 8 existing).
- [x] `cargo +nightly-2026-02-20 fmt --all --check`: clean.
- [x] `cargo clippy -p kona-sp1-client-utils --all-targets`: no warnings from changed file. (Pre-existing `missing_const_for_fn` warnings in `kona-derive` are unrelated and exist on baseline.)