### PR TITLE
op-proposer: resolve respected game type automatically

### DIFF
--- a/op-proposer/README.md
+++ b/op-proposer/README.md
@@ -32,9 +32,16 @@ with an inclusion-proof of a withdrawn message (as registered in the L2 withdraw
 go run ./op-proposer/cmd \
         --l1-eth-rpc http://l1:8545 \
       --rollup-rpc http://op-node:8545 \
-      --game-factory-address=changeme \
-      --game-type=changeme
+      --network=changeme \
+      --game-type=auto
 ```
+
+`--network` resolves the SystemConfig address for known chains, and the proposer uses
+SystemConfig to load the current DisputeGameFactory and AnchorStateRegistry addresses
+on each proposal cycle. If `--network` is not set, `--system-config-address` can
+supply both addresses. The legacy `--game-factory-address` flag is still supported;
+when `--game-type=auto` is used, provide either `--network` or
+`--system-config-address` so the AnchorStateRegistry can be loaded dynamically.
 
 See [Proposer Configuration docs] for customization of the transaction-management,
 and usage of a remote signer to isolate the proposer secret key.

--- a/op-proposer/contracts/anchorstateregistry.go
+++ b/op-proposer/contracts/anchorstateregistry.go
@@ -1,0 +1,38 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const methodRespectedGameType = "respectedGameType"
+
+type AnchorStateRegistry struct {
+	caller         *batching.MultiCaller
+	contract       *batching.BoundContract
+	networkTimeout time.Duration
+}
+
+func NewAnchorStateRegistry(addr common.Address, caller *batching.MultiCaller, networkTimeout time.Duration) *AnchorStateRegistry {
+	return &AnchorStateRegistry{
+		caller:         caller,
+		contract:       batching.NewBoundContract(snapshots.LoadAnchorStateRegistryABI(), addr),
+		networkTimeout: networkTimeout,
+	}
+}
+
+func (a *AnchorStateRegistry) RespectedGameType(ctx context.Context) (uint32, error) {
+	cCtx, cancel := context.WithTimeout(ctx, a.networkTimeout)
+	defer cancel()
+	result, err := a.caller.SingleCall(cCtx, rpcblock.Latest, a.contract.Call(methodRespectedGameType))
+	if err != nil {
+		return 0, fmt.Errorf("failed to get respected game type: %w", err)
+	}
+	return result.GetUint32(0), nil
+}

--- a/op-proposer/contracts/anchorstateregistry_test.go
+++ b/op-proposer/contracts/anchorstateregistry_test.go
@@ -1,0 +1,26 @@
+package contracts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnchorStateRegistryRespectedGameType(t *testing.T) {
+	asrAddr := common.Address{0x11, 0x22}
+	stubRpc := batchingTest.NewAbiBasedRpc(t, asrAddr, snapshots.LoadAnchorStateRegistryABI())
+	stubRpc.SetResponse(asrAddr, methodRespectedGameType, rpcblock.Latest, nil, []interface{}{uint32(9)})
+
+	caller := batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize)
+	asr := NewAnchorStateRegistry(asrAddr, caller, time.Minute)
+	gameType, err := asr.RespectedGameType(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, uint32(9), gameType)
+}

--- a/op-proposer/contracts/systemconfig.go
+++ b/op-proposer/contracts/systemconfig.go
@@ -1,0 +1,73 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	methodDisputeGameFactory  = "disputeGameFactory"
+	methodOptimismPortal      = "optimismPortal"
+	methodAnchorStateRegistry = "anchorStateRegistry"
+)
+
+type SystemConfig struct {
+	caller         *batching.MultiCaller
+	contract       *batching.BoundContract
+	networkTimeout time.Duration
+}
+
+func NewSystemConfig(addr common.Address, caller *batching.MultiCaller, networkTimeout time.Duration) *SystemConfig {
+	return &SystemConfig{
+		caller:         caller,
+		contract:       batching.NewBoundContract(snapshots.LoadSystemConfigABI(), addr),
+		networkTimeout: networkTimeout,
+	}
+}
+
+func (s *SystemConfig) DisputeGameFactory(ctx context.Context) (common.Address, error) {
+	cCtx, cancel := context.WithTimeout(ctx, s.networkTimeout)
+	defer cancel()
+	result, err := s.caller.SingleCall(cCtx, rpcblock.Latest, s.contract.Call(methodDisputeGameFactory))
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to get dispute game factory from system config: %w", err)
+	}
+	return result.GetAddress(0), nil
+}
+
+func (s *SystemConfig) AnchorStateRegistry(ctx context.Context) (common.Address, error) {
+	cCtx, cancel := context.WithTimeout(ctx, s.networkTimeout)
+	defer cancel()
+	result, err := s.caller.SingleCall(cCtx, rpcblock.Latest, s.contract.Call(methodOptimismPortal))
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to get optimism portal from system config: %w", err)
+	}
+	portal := result.GetAddress(0)
+	portalContract := batching.NewBoundContract(snapshots.LoadOptimismPortal2ABI(), portal)
+
+	cCtx, cancel = context.WithTimeout(ctx, s.networkTimeout)
+	defer cancel()
+	result, err = s.caller.SingleCall(cCtx, rpcblock.Latest, portalContract.Call(methodAnchorStateRegistry))
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to get anchor state registry from optimism portal %v: %w", portal, err)
+	}
+	return result.GetAddress(0), nil
+}
+
+func (s *SystemConfig) ProposerAddresses(ctx context.Context) (common.Address, common.Address, error) {
+	dgf, err := s.DisputeGameFactory(ctx)
+	if err != nil {
+		return common.Address{}, common.Address{}, err
+	}
+	asr, err := s.AnchorStateRegistry(ctx)
+	if err != nil {
+		return common.Address{}, common.Address{}, err
+	}
+	return dgf, asr, nil
+}

--- a/op-proposer/contracts/systemconfig_test.go
+++ b/op-proposer/contracts/systemconfig_test.go
@@ -1,0 +1,33 @@
+package contracts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemConfigProposerAddresses(t *testing.T) {
+	systemConfigAddr := common.Address{0x11}
+	portalAddr := common.Address{0x22}
+	dgfAddr := common.Address{0x33}
+	asrAddr := common.Address{0x44}
+	stubRpc := batchingTest.NewAbiBasedRpc(t, systemConfigAddr, snapshots.LoadSystemConfigABI())
+	stubRpc.AddContract(portalAddr, snapshots.LoadOptimismPortal2ABI())
+	stubRpc.SetResponse(systemConfigAddr, methodDisputeGameFactory, rpcblock.Latest, nil, []interface{}{dgfAddr})
+	stubRpc.SetResponse(systemConfigAddr, methodOptimismPortal, rpcblock.Latest, nil, []interface{}{portalAddr})
+	stubRpc.SetResponse(portalAddr, methodAnchorStateRegistry, rpcblock.Latest, nil, []interface{}{asrAddr})
+
+	caller := batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize)
+	systemConfig := NewSystemConfig(systemConfigAddr, caller, time.Minute)
+	dgf, asr, err := systemConfig.ProposerAddresses(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, dgfAddr, dgf)
+	require.Equal(t, asrAddr, asr)
+}

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -7,6 +7,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	opflags "github.com/ethereum-optimism/optimism/op-service/flags"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
@@ -37,6 +38,7 @@ var (
 		Usage:   "HTTP provider URLs for the supernode instances. Multiple URLs can be provided to automatically fail over.",
 		EnvVars: prefixEnvVars("SUPERNODE_RPCS"),
 	}
+	NetworkFlag = opflags.CLINetworkFlag(EnvVarPrefix, "")
 
 	// Optional flags
 	PollIntervalFlag = &cli.DurationFlag{
@@ -55,15 +57,20 @@ var (
 		Usage:   "Address of the DisputeGameFactory contract",
 		EnvVars: prefixEnvVars("GAME_FACTORY_ADDRESS"),
 	}
+	SystemConfigAddressFlag = &cli.StringFlag{
+		Name:    "system-config-address",
+		Usage:   "Address of the SystemConfig contract. Used to resolve the DisputeGameFactory and AnchorStateRegistry addresses.",
+		EnvVars: prefixEnvVars("SYSTEM_CONFIG_ADDRESS"),
+	}
 	ProposalIntervalFlag = &cli.DurationFlag{
 		Name:    "proposal-interval",
 		Usage:   "Interval between submitting L2 output proposals when the dispute game factory address is set",
 		EnvVars: prefixEnvVars("PROPOSAL_INTERVAL"),
 	}
-	DisputeGameTypeFlag = &cli.UintFlag{
+	DisputeGameTypeFlag = &cli.StringFlag{
 		Name:    "game-type",
-		Usage:   "Dispute game type to create via the configured DisputeGameFactory",
-		Value:   0,
+		Usage:   "Dispute game type to create via the configured DisputeGameFactory. Set to \"auto\" to use the current respected game type.",
+		Value:   "auto",
 		EnvVars: prefixEnvVars("GAME_TYPE"),
 	}
 	ActiveSequencerCheckDurationFlag = &cli.DurationFlag{
@@ -93,7 +100,9 @@ var optionalFlags = []cli.Flag{
 	PollIntervalFlag,
 	AllowNonFinalizedFlag,
 	L2OutputHDPathFlag,
+	NetworkFlag,
 	DisputeGameFactoryAddressFlag,
+	SystemConfigAddressFlag,
 	ProposalIntervalFlag,
 	DisputeGameTypeFlag,
 	ActiveSequencerCheckDurationFlag,

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -2,12 +2,17 @@ package proposer
 
 import (
 	"errors"
+	"fmt"
 	"slices"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-proposer/flags"
+	opflags "github.com/ethereum-optimism/optimism/op-service/flags"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
@@ -31,6 +36,8 @@ var (
 	// We just want to reduce foot-guns during the migration period.
 	postInteropGameTypes = []uint32{4, 5}
 )
+
+const DisputeGameTypeAuto = "auto"
 
 // CLIConfig is a well typed config that is parsed from the CLI params.
 // This also contains config options for auxiliary services.
@@ -68,11 +75,23 @@ type CLIConfig struct {
 	// DGFAddress is the DisputeGameFactory contract address.
 	DGFAddress string
 
+	// SystemConfigAddress is the SystemConfig contract address.
+	SystemConfigAddress string
+
+	// Network is a predefined superchain registry network name.
+	Network string
+
 	// ProposalInterval is the delay between submitting L2 output proposals when the DGFAddress is set.
 	ProposalInterval time.Duration
 
 	// DisputeGameType is the type of dispute game to create when submitting an output proposal.
 	DisputeGameType uint32
+
+	// DisputeGameTypeAuto enables resolving the current respected game type from L1.
+	DisputeGameTypeAuto bool
+
+	// DisputeGameTypeRaw is the CLI value before parsing.
+	DisputeGameTypeRaw string
 
 	// ActiveSequencerCheckDuration is the duration between checks to determine the active sequencer endpoint.
 	ActiveSequencerCheckDuration time.Duration
@@ -95,14 +114,28 @@ func (c *CLIConfig) Check() error {
 		return err
 	}
 
-	if c.DGFAddress == "" {
-		return errors.New("`DisputeGameFactory` is required")
+	if c.Network != "" {
+		chain := chaincfg.ChainByName(c.Network)
+		if chain == nil {
+			return fmt.Errorf("unknown network %q", c.Network)
+		}
 	}
-	if c.DGFAddress != "" && c.ProposalInterval == 0 {
-		return errors.New("the `DisputeGameFactory` address was provided but the `ProposalInterval` was not set")
+	hasDGFSource := c.DGFAddress != "" || c.SystemConfigAddress != "" || c.Network != ""
+	if !hasDGFSource {
+		return errors.New("`DisputeGameFactory`, `SystemConfig`, or `network` is required")
 	}
-	if c.ProposalInterval != 0 && c.DGFAddress == "" {
-		return errors.New("the `ProposalInterval` was provided but the `DisputeGameFactory` address was not set")
+	if hasDGFSource && c.ProposalInterval == 0 {
+		return errors.New("the `DisputeGameFactory`, `SystemConfig`, or `network` was provided but the `ProposalInterval` was not set")
+	}
+	if c.ProposalInterval != 0 && !hasDGFSource {
+		return errors.New("the `ProposalInterval` was provided but none of `DisputeGameFactory`, `SystemConfig`, or `network` was set")
+	}
+	gameType, gameTypeAuto, err := c.ResolveDisputeGameType()
+	if err != nil {
+		return err
+	}
+	if gameTypeAuto && c.SystemConfigAddress == "" && c.Network == "" {
+		return errors.New("`SystemConfig` or `network` is required when `game-type` is auto")
 	}
 	// Check for conflicting RPC sources - only one should be specified
 	sourceCount := 0
@@ -116,11 +149,11 @@ func (c *CLIConfig) Check() error {
 		return ErrConflictingSource
 	}
 	// Require rollup RPC for pre interop game types
-	if c.DGFAddress != "" && slices.Contains(preInteropGameTypes, c.DisputeGameType) && c.RollupRpc == "" {
+	if hasDGFSource && !gameTypeAuto && slices.Contains(preInteropGameTypes, gameType) && c.RollupRpc == "" {
 		return ErrMissingRollupRpc
 	}
 	// Require supernode RPC for post interop game types
-	if c.DGFAddress != "" && slices.Contains(postInteropGameTypes, c.DisputeGameType) && len(c.SuperNodeRpcs) == 0 {
+	if hasDGFSource && !gameTypeAuto && slices.Contains(postInteropGameTypes, gameType) && len(c.SuperNodeRpcs) == 0 {
 		return ErrMissingSuperNodeRpc
 	}
 	// For unknown game types, allow any source, but require at least one.
@@ -131,8 +164,25 @@ func (c *CLIConfig) Check() error {
 	return nil
 }
 
+func (c *CLIConfig) ResolveDisputeGameType() (uint32, bool, error) {
+	value := strings.TrimSpace(c.DisputeGameTypeRaw)
+	if value == "" {
+		return c.DisputeGameType, c.DisputeGameTypeAuto, nil
+	}
+	if strings.EqualFold(value, DisputeGameTypeAuto) {
+		return 0, true, nil
+	}
+	gameType, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid `game-type` %q: expected uint32 or %q", value, DisputeGameTypeAuto)
+	}
+	return uint32(gameType), false, nil
+}
+
 // NewConfig parses the Config from the provided flags or environment variables.
 func NewConfig(ctx *cli.Context) *CLIConfig {
+	gameTypeRaw := ctx.String(flags.DisputeGameTypeFlag.Name)
+	gameType, gameTypeAuto, _ := (&CLIConfig{DisputeGameTypeRaw: gameTypeRaw}).ResolveDisputeGameType()
 	return &CLIConfig{
 		L1EthRpc:                     ctx.String(flags.L1EthRpcFlag.Name),
 		RollupRpc:                    ctx.String(flags.RollupRpcFlag.Name),
@@ -145,8 +195,12 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		MetricsConfig:                opmetrics.ReadCLIConfig(ctx),
 		PprofConfig:                  oppprof.ReadCLIConfig(ctx),
 		DGFAddress:                   ctx.String(flags.DisputeGameFactoryAddressFlag.Name),
+		SystemConfigAddress:          ctx.String(flags.SystemConfigAddressFlag.Name),
+		Network:                      ctx.String(opflags.NetworkFlagName),
 		ProposalInterval:             ctx.Duration(flags.ProposalIntervalFlag.Name),
-		DisputeGameType:              uint32(ctx.Uint(flags.DisputeGameTypeFlag.Name)),
+		DisputeGameType:              gameType,
+		DisputeGameTypeAuto:          gameTypeAuto,
+		DisputeGameTypeRaw:           gameTypeRaw,
 		ActiveSequencerCheckDuration: ctx.Duration(flags.ActiveSequencerCheckDurationFlag.Name),
 		WaitNodeSync:                 ctx.Bool(flags.WaitNodeSyncFlag.Name),
 	}

--- a/op-proposer/proposer/config_test.go
+++ b/op-proposer/proposer/config_test.go
@@ -39,6 +39,62 @@ func TestNewConfigReadsSuperNodeRpcs(t *testing.T) {
 	}, cfg.SuperNodeRpcs)
 }
 
+func TestNewConfigReadsAutoDisputeGameType(t *testing.T) {
+	var cfg *CLIConfig
+	app := cli.NewApp()
+	app.Flags = proposerFlags.Flags
+	app.Action = func(ctx *cli.Context) error {
+		cfg = NewConfig(ctx)
+		return nil
+	}
+	err := app.Run([]string{"op-proposer"})
+	require.NoError(t, err)
+	require.True(t, cfg.DisputeGameTypeAuto)
+	require.Equal(t, uint32(0), cfg.DisputeGameType)
+}
+
+func TestNewConfigReadsNumericDisputeGameType(t *testing.T) {
+	var cfg *CLIConfig
+	app := cli.NewApp()
+	app.Flags = proposerFlags.Flags
+	app.Action = func(ctx *cli.Context) error {
+		cfg = NewConfig(ctx)
+		return nil
+	}
+	err := app.Run([]string{
+		"op-proposer",
+		"--game-type", "9",
+	})
+	require.NoError(t, err)
+	require.False(t, cfg.DisputeGameTypeAuto)
+	require.Equal(t, uint32(9), cfg.DisputeGameType)
+}
+
+func TestNewConfigReadsNetworkAndSystemConfig(t *testing.T) {
+	var cfg *CLIConfig
+	app := cli.NewApp()
+	app.Flags = proposerFlags.Flags
+	app.Action = func(ctx *cli.Context) error {
+		cfg = NewConfig(ctx)
+		return nil
+	}
+	systemConfig := common.Address{0xab, 0xcd}.Hex()
+	err := app.Run([]string{
+		"op-proposer",
+		"--network", "op-sepolia",
+		"--system-config-address", systemConfig,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "op-sepolia", cfg.Network)
+	require.Equal(t, systemConfig, cfg.SystemConfigAddress)
+}
+
+func TestInvalidDisputeGameType(t *testing.T) {
+	cfg := validConfig()
+	cfg.DisputeGameTypeRaw = "invalid"
+	require.ErrorContains(t, cfg.Check(), "invalid `game-type`")
+}
+
 func TestRollupRpc(t *testing.T) {
 	for _, gameType := range preInteropGameTypes {
 		t.Run("RequiredWithPreInteropGame", func(t *testing.T) {
@@ -112,6 +168,43 @@ func TestRequireSomeRPCSourceForUnknownGameTypes(t *testing.T) {
 	cfg.SuperNodeRpcs = nil
 	cfg.DisputeGameType = 492743
 	require.ErrorIs(t, cfg.Check(), ErrMissingSource)
+}
+
+func TestAutoGameTypeAllowsAnySingleRPCSource(t *testing.T) {
+	cfg := validConfig()
+	cfg.DisputeGameTypeRaw = "auto"
+	cfg.DisputeGameTypeAuto = true
+	cfg.SystemConfigAddress = common.Address{0x11}.Hex()
+	cfg.RollupRpc = ""
+	cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+	require.NoError(t, cfg.Check())
+}
+
+func TestAutoGameTypeRequiresSystemConfigOrNetwork(t *testing.T) {
+	cfg := validConfig()
+	cfg.DisputeGameTypeRaw = "auto"
+	cfg.DisputeGameTypeAuto = true
+	cfg.SystemConfigAddress = ""
+	cfg.Network = ""
+	require.ErrorContains(t, cfg.Check(), "`SystemConfig` or `network` is required")
+}
+
+func TestAutoGameTypeAllowsSystemConfig(t *testing.T) {
+	cfg := validConfig()
+	cfg.DGFAddress = ""
+	cfg.SystemConfigAddress = common.Address{0x12}.Hex()
+	cfg.DisputeGameTypeRaw = "auto"
+	cfg.DisputeGameTypeAuto = true
+	require.NoError(t, cfg.Check())
+}
+
+func TestAutoGameTypeAllowsNetwork(t *testing.T) {
+	cfg := validConfig()
+	cfg.DGFAddress = ""
+	cfg.Network = networkWithSystemConfig(t)
+	cfg.DisputeGameTypeRaw = "auto"
+	cfg.DisputeGameTypeAuto = true
+	require.NoError(t, cfg.Check())
 }
 
 func validConfig() *CLIConfig {

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -41,6 +41,47 @@ type DGFContract interface {
 	ProposalTx(ctx context.Context, gameType uint32, outputRoot common.Hash, extraData []byte) (txmgr.TxCandidate, error)
 }
 
+type ASRContract interface {
+	RespectedGameType(ctx context.Context) (uint32, error)
+}
+
+type proposerContractResolver interface {
+	DisputeGameFactory(ctx context.Context) (DGFContract, error)
+	AnchorStateRegistry(ctx context.Context) (ASRContract, error)
+}
+
+type defaultProposerContractResolver struct {
+	cfg         ProposerConfig
+	multicaller *batching.MultiCaller
+}
+
+func (r *defaultProposerContractResolver) DisputeGameFactory(ctx context.Context) (DGFContract, error) {
+	if r.cfg.DisputeGameFactoryAddr != nil {
+		return contracts.NewDisputeGameFactory(*r.cfg.DisputeGameFactoryAddr, r.multicaller, r.cfg.NetworkTimeout), nil
+	}
+	if r.cfg.SystemConfigAddr == nil {
+		return nil, errors.New("missing DisputeGameFactory address")
+	}
+	systemConfig := contracts.NewSystemConfig(*r.cfg.SystemConfigAddr, r.multicaller, r.cfg.NetworkTimeout)
+	addr, err := systemConfig.DisputeGameFactory(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve DisputeGameFactory from SystemConfig %v: %w", *r.cfg.SystemConfigAddr, err)
+	}
+	return contracts.NewDisputeGameFactory(addr, r.multicaller, r.cfg.NetworkTimeout), nil
+}
+
+func (r *defaultProposerContractResolver) AnchorStateRegistry(ctx context.Context) (ASRContract, error) {
+	if r.cfg.SystemConfigAddr == nil {
+		return nil, errors.New("missing SystemConfig address")
+	}
+	systemConfig := contracts.NewSystemConfig(*r.cfg.SystemConfigAddr, r.multicaller, r.cfg.NetworkTimeout)
+	addr, err := systemConfig.AnchorStateRegistry(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve AnchorStateRegistry from SystemConfig %v: %w", *r.cfg.SystemConfigAddr, err)
+	}
+	return contracts.NewAnchorStateRegistry(addr, r.multicaller, r.cfg.NetworkTimeout), nil
+}
+
 type RollupClient interface {
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error)
@@ -70,7 +111,7 @@ type L2OutputSubmitter struct {
 
 	running atomic.Bool
 
-	dgfContract DGFContract
+	contractResolver proposerContractResolver
 }
 
 // NewL2OutputSubmitter creates a new L2 Output Submitter
@@ -85,7 +126,7 @@ func NewL2OutputSubmitter(setup DriverSetup) (_ *L2OutputSubmitter, err error) {
 		}
 	}()
 
-	if setup.Cfg.DisputeGameFactoryAddr == nil {
+	if setup.Cfg.DisputeGameFactoryAddr == nil && setup.Cfg.SystemConfigAddr == nil {
 		return nil, errors.New("missing DisputeGameFactory address")
 	}
 
@@ -93,14 +134,25 @@ func NewL2OutputSubmitter(setup DriverSetup) (_ *L2OutputSubmitter, err error) {
 }
 
 func newDGFSubmitter(ctx context.Context, cancel context.CancelFunc, setup DriverSetup) (*L2OutputSubmitter, error) {
-	dgfCaller := contracts.NewDisputeGameFactory(*setup.Cfg.DisputeGameFactoryAddr, setup.Multicaller, setup.Cfg.NetworkTimeout)
-
-	version, err := dgfCaller.Version(ctx)
-	if err != nil {
-		cancel()
-		return nil, err
+	resolver := &defaultProposerContractResolver{
+		cfg:         setup.Cfg,
+		multicaller: setup.Multicaller,
 	}
-	log.Info("Connected to DisputeGameFactory", "address", setup.Cfg.DisputeGameFactoryAddr, "version", version)
+	if setup.Cfg.DisputeGameFactoryAddr != nil {
+		dgfCaller, err := resolver.DisputeGameFactory(ctx)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		version, err := dgfCaller.Version(ctx)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		log.Info("Connected to DisputeGameFactory", "address", setup.Cfg.DisputeGameFactoryAddr, "version", version)
+	} else {
+		log.Info("Configured dynamic DisputeGameFactory resolution", "system_config", *setup.Cfg.SystemConfigAddr)
+	}
 
 	return &L2OutputSubmitter{
 		DriverSetup: setup,
@@ -108,7 +160,7 @@ func newDGFSubmitter(ctx context.Context, cancel context.CancelFunc, setup Drive
 		ctx:         ctx,
 		cancel:      cancel,
 
-		dgfContract: dgfCaller,
+		contractResolver: resolver,
 	}, nil
 }
 
@@ -162,8 +214,16 @@ func (l *L2OutputSubmitter) StopL2OutputSubmitting() error {
 // The passed context is expected to be a lifecycle context. A network timeout
 // context will be derived from it.
 func (l *L2OutputSubmitter) FetchDGFOutput(ctx context.Context) (source.Proposal, bool, error) {
+	dgfContract, err := l.contractResolver.DisputeGameFactory(ctx)
+	if err != nil {
+		return source.Proposal{}, false, err
+	}
+	gameType, err := l.disputeGameType(ctx)
+	if err != nil {
+		return source.Proposal{}, false, err
+	}
 	cutoff := time.Now().Add(-l.Cfg.ProposalInterval)
-	proposedRecently, proposalTime, claim, err := l.dgfContract.HasProposedSince(ctx, l.Txmgr.From(), cutoff, l.Cfg.DisputeGameType)
+	proposedRecently, proposalTime, claim, err := dgfContract.HasProposedSince(ctx, l.Txmgr.From(), cutoff, gameType)
 	if err != nil {
 		return source.Proposal{}, false, fmt.Errorf("could not check for recent proposal: %w", err)
 	}
@@ -226,9 +286,33 @@ func (l *L2OutputSubmitter) FetchOutput(ctx context.Context, block uint64) (sour
 }
 
 func (l *L2OutputSubmitter) ProposeL2OutputDGFTxCandidate(ctx context.Context, output source.Proposal) (txmgr.TxCandidate, error) {
+	dgfContract, err := l.contractResolver.DisputeGameFactory(ctx)
+	if err != nil {
+		return txmgr.TxCandidate{}, err
+	}
+	gameType, err := l.disputeGameType(ctx)
+	if err != nil {
+		return txmgr.TxCandidate{}, err
+	}
 	cCtx, cancel := context.WithTimeout(ctx, l.Cfg.NetworkTimeout)
 	defer cancel()
-	return l.dgfContract.ProposalTx(cCtx, l.Cfg.DisputeGameType, output.Root, output.ExtraData())
+	return dgfContract.ProposalTx(cCtx, gameType, output.Root, output.ExtraData())
+}
+
+func (l *L2OutputSubmitter) disputeGameType(ctx context.Context) (uint32, error) {
+	if !l.Cfg.DisputeGameTypeAuto {
+		return l.Cfg.DisputeGameType, nil
+	}
+	asrContract, err := l.contractResolver.AnchorStateRegistry(ctx)
+	if err != nil {
+		return 0, err
+	}
+	gameType, err := asrContract.RespectedGameType(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to resolve respected game type: %w", err)
+	}
+	l.Log.Debug("Resolved respected game type", "gameType", gameType)
+	return gameType, nil
 }
 
 // sendTransaction creates & sends transactions through the underlying transaction manager.

--- a/op-proposer/proposer/driver_test.go
+++ b/op-proposer/proposer/driver_test.go
@@ -2,6 +2,7 @@ package proposer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -24,19 +25,57 @@ import (
 
 type StubDGFContract struct {
 	hasProposedCount int
+	proposalGameType uint32
+	proposalTxCount  int
 }
 
-func (m *StubDGFContract) HasProposedSince(_ context.Context, _ common.Address, _ time.Time, _ uint32) (bool, time.Time, common.Hash, error) {
+func (m *StubDGFContract) HasProposedSince(_ context.Context, _ common.Address, _ time.Time, gameType uint32) (bool, time.Time, common.Hash, error) {
 	m.hasProposedCount++
+	m.proposalGameType = gameType
 	return false, time.Unix(1000, 0), common.Hash{0xdd}, nil
 }
 
-func (m *StubDGFContract) ProposalTx(_ context.Context, _ uint32, _ common.Hash, _ []byte) (txmgr.TxCandidate, error) {
+func (m *StubDGFContract) ProposalTx(_ context.Context, gameType uint32, _ common.Hash, _ []byte) (txmgr.TxCandidate, error) {
+	m.proposalGameType = gameType
+	m.proposalTxCount++
 	return txmgr.TxCandidate{}, nil
 }
 
 func (m *StubDGFContract) Version(_ context.Context) (string, error) {
 	panic("not implemented")
+}
+
+type StubASRContract struct {
+	respectedGameType uint32
+}
+
+func (m *StubASRContract) RespectedGameType(_ context.Context) (uint32, error) {
+	return m.respectedGameType, nil
+}
+
+type StubContractResolver struct {
+	dgfContracts []DGFContract
+	asrContracts []ASRContract
+	dgfCalls     int
+	asrCalls     int
+}
+
+func (m *StubContractResolver) DisputeGameFactory(context.Context) (DGFContract, error) {
+	if len(m.dgfContracts) == 0 {
+		return nil, errors.New("missing DisputeGameFactory contract")
+	}
+	index := min(m.dgfCalls, len(m.dgfContracts)-1)
+	m.dgfCalls++
+	return m.dgfContracts[index], nil
+}
+
+func (m *StubContractResolver) AnchorStateRegistry(context.Context) (ASRContract, error) {
+	if len(m.asrContracts) == 0 {
+		return nil, errors.New("missing AnchorStateRegistry contract")
+	}
+	index := min(m.asrCalls, len(m.asrContracts)-1)
+	m.asrCalls++
+	return m.asrContracts[index], nil
 }
 
 type mockRollupEndpointProvider struct {
@@ -84,7 +123,11 @@ func setup(t *testing.T) (*L2OutputSubmitter, *mockRollupEndpointProvider, *Stub
 		cancel:      cancel,
 	}
 	mockDGFContract := new(StubDGFContract)
-	l2OutputSubmitter.dgfContract = mockDGFContract
+	mockASRContract := new(StubASRContract)
+	l2OutputSubmitter.contractResolver = &StubContractResolver{
+		dgfContracts: []DGFContract{mockDGFContract},
+		asrContracts: []ASRContract{mockASRContract},
+	}
 
 	txmgr.On("Send", mock.Anything, mock.Anything).
 		Return(&types.Receipt{Status: uint64(1), TxHash: common.Hash{}}, nil).
@@ -131,4 +174,45 @@ func TestL2OutputSubmitter_OutputRetry(t *testing.T) {
 	require.Len(t, logs.FindLogs(testlog.NewMessageContainsFilter("Error getting proposal")), numFails)
 	require.NotNil(t, logs.FindLog(testlog.NewMessageFilter("Proposer tx successfully published")))
 	require.NotNil(t, logs.FindLog(testlog.NewMessageFilter("loop returning")))
+}
+
+func TestProposeL2OutputDGFTxCandidateUsesRespectedGameType(t *testing.T) {
+	ps, _, dgfContract, _, _ := setup(t)
+	ps.Cfg.DisputeGameTypeAuto = true
+	ps.contractResolver = &StubContractResolver{
+		dgfContracts: []DGFContract{dgfContract},
+		asrContracts: []ASRContract{&StubASRContract{respectedGameType: 9}},
+	}
+
+	err := ps.sendTransaction(context.Background(), source.Proposal{Root: common.Hash{0xaa}})
+	require.NoError(t, err)
+	require.Equal(t, uint32(9), dgfContract.proposalGameType)
+}
+
+func TestProposeL2OutputDGFTxCandidateResolvesContractsEveryCall(t *testing.T) {
+	ps, _, _, txmgr, _ := setup(t)
+	txmgr.ExpectedCalls = nil
+	ps.Cfg.DisputeGameTypeAuto = true
+	firstDGF := new(StubDGFContract)
+	secondDGF := new(StubDGFContract)
+	resolver := &StubContractResolver{
+		dgfContracts: []DGFContract{firstDGF, secondDGF},
+		asrContracts: []ASRContract{
+			&StubASRContract{respectedGameType: 9},
+			&StubASRContract{respectedGameType: 10},
+		},
+	}
+	ps.contractResolver = resolver
+
+	_, err := ps.ProposeL2OutputDGFTxCandidate(context.Background(), source.Proposal{Root: common.Hash{0xaa}})
+	require.NoError(t, err)
+	_, err = ps.ProposeL2OutputDGFTxCandidate(context.Background(), source.Proposal{Root: common.Hash{0xbb}})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, resolver.dgfCalls)
+	require.Equal(t, 2, resolver.asrCalls)
+	require.Equal(t, 1, firstDGF.proposalTxCount)
+	require.Equal(t, uint32(9), firstDGF.proposalGameType)
+	require.Equal(t, 1, secondDGF.proposalTxCount)
+	require.Equal(t, uint32(10), secondDGF.proposalGameType)
 }

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer/rpc"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer/source"
@@ -39,7 +40,9 @@ type ProposerConfig struct {
 	ProposalInterval time.Duration
 
 	DisputeGameFactoryAddr *common.Address
+	SystemConfigAddr       *common.Address
 	DisputeGameType        uint32
+	DisputeGameTypeAuto    bool
 
 	// AllowNonFinalized enables the proposal of safe, but non-finalized L2 blocks.
 	// The L1 block-hash embedded in the proposal TX is checked and should ensure the proposal
@@ -95,9 +98,10 @@ func (ps *ProposerService) initFromCLIConfig(ctx context.Context, version string
 	ps.AllowNonFinalized = cfg.AllowNonFinalized
 	ps.WaitNodeSync = cfg.WaitNodeSync
 
-	ps.initDGF(cfg)
-
 	if err := ps.initRPCClients(ctx, cfg); err != nil {
+		return err
+	}
+	if err := ps.initDGF(cfg); err != nil {
 		return err
 	}
 	if err := ps.initTxManager(cfg); err != nil {
@@ -221,15 +225,67 @@ func (ps *ProposerService) initMetricsServer(cfg *CLIConfig) error {
 	return nil
 }
 
-func (ps *ProposerService) initDGF(cfg *CLIConfig) {
-	dgfAddress, err := opservice.ParseAddress(cfg.DGFAddress)
+func (ps *ProposerService) initDGF(cfg *CLIConfig) error {
+	gameType, gameTypeAuto, err := cfg.ResolveDisputeGameType()
 	if err != nil {
-		// Return no error & set no DGF related configuration fields.
-		return
+		return err
 	}
-	ps.DisputeGameFactoryAddr = &dgfAddress
+	dgfAddress, systemConfigAddress, err := resolveProposerAddressConfig(cfg, gameTypeAuto)
+	if err != nil {
+		return err
+	}
+	ps.DisputeGameFactoryAddr = dgfAddress
+	ps.SystemConfigAddr = systemConfigAddress
 	ps.ProposalInterval = cfg.ProposalInterval
-	ps.DisputeGameType = cfg.DisputeGameType
+	ps.DisputeGameType = gameType
+	ps.DisputeGameTypeAuto = gameTypeAuto
+	return nil
+}
+
+func resolveProposerAddressConfig(cfg *CLIConfig, gameTypeAuto bool) (*common.Address, *common.Address, error) {
+	var dgfAddress *common.Address
+	if cfg.DGFAddress != "" {
+		dgf, err := opservice.ParseAddress(cfg.DGFAddress)
+		if err != nil {
+			return nil, nil, err
+		}
+		dgfAddress = &dgf
+	}
+	systemConfigAddress, err := resolveSystemConfigAddress(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	if dgfAddress == nil {
+		if systemConfigAddress == nil {
+			return nil, nil, errors.New("missing DisputeGameFactory address")
+		}
+	}
+	if gameTypeAuto && systemConfigAddress == nil {
+		return nil, nil, errors.New("missing SystemConfig address")
+	}
+	return dgfAddress, systemConfigAddress, nil
+}
+
+func resolveSystemConfigAddress(cfg *CLIConfig) (*common.Address, error) {
+	if cfg.SystemConfigAddress != "" {
+		systemConfig, err := opservice.ParseAddress(cfg.SystemConfigAddress)
+		if err != nil {
+			return nil, err
+		}
+		return &systemConfig, nil
+	}
+	if cfg.Network == "" {
+		return nil, nil
+	}
+	chain := chaincfg.ChainByName(cfg.Network)
+	if chain == nil {
+		return nil, fmt.Errorf("unknown network %q", cfg.Network)
+	}
+	if chain.Addresses.SystemConfigProxy == nil {
+		return nil, nil
+	}
+	systemConfig := *chain.Addresses.SystemConfigProxy
+	return &systemConfig, nil
 }
 
 func (ps *ProposerService) initDriver() error {

--- a/op-proposer/proposer/service_test.go
+++ b/op-proposer/proposer/service_test.go
@@ -1,0 +1,70 @@
+package proposer
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveProposerAddressConfigUsesSystemConfig(t *testing.T) {
+	cfg := validConfig()
+	cfg.DGFAddress = ""
+	cfg.SystemConfigAddress = common.Address{0x11}.Hex()
+
+	dgfAddress, systemConfigAddress, err := resolveProposerAddressConfig(cfg, true)
+	require.NoError(t, err)
+	require.Nil(t, dgfAddress)
+	require.Equal(t, common.HexToAddress(cfg.SystemConfigAddress), *systemConfigAddress)
+}
+
+func TestResolveProposerAddressConfigUsesNetworkSystemConfig(t *testing.T) {
+	network := networkWithSystemConfig(t)
+	chain := chaincfg.ChainByName(network)
+	require.NotNil(t, chain)
+	require.NotNil(t, chain.Addresses.SystemConfigProxy)
+
+	cfg := validConfig()
+	cfg.DGFAddress = ""
+	cfg.Network = network
+
+	dgfAddress, systemConfigAddress, err := resolveProposerAddressConfig(cfg, true)
+	require.NoError(t, err)
+	require.Nil(t, dgfAddress)
+	require.Equal(t, *chain.Addresses.SystemConfigProxy, *systemConfigAddress)
+}
+
+func TestResolveProposerAddressConfigAllowsExplicitOverrides(t *testing.T) {
+	cfg := validConfig()
+	cfg.SystemConfigAddress = common.Address{0x11}.Hex()
+	dgfOverride := common.Address{0xaa}.Hex()
+	cfg.DGFAddress = dgfOverride
+
+	dgfAddress, systemConfigAddress, err := resolveProposerAddressConfig(cfg, true)
+	require.NoError(t, err)
+	require.Equal(t, common.HexToAddress(dgfOverride), *dgfAddress)
+	require.Equal(t, common.HexToAddress(cfg.SystemConfigAddress), *systemConfigAddress)
+}
+
+func TestResolveProposerAddressConfigRequiresSystemConfigForAuto(t *testing.T) {
+	cfg := validConfig()
+
+	_, _, err := resolveProposerAddressConfig(cfg, true)
+	require.ErrorContains(t, err, "missing SystemConfig address")
+}
+
+func networkWithSystemConfig(t *testing.T) string {
+	t.Helper()
+	for _, network := range chaincfg.AvailableNetworks() {
+		chain := chaincfg.ChainByName(network)
+		if chain == nil {
+			continue
+		}
+		if chain.Addresses.SystemConfigProxy != nil {
+			return network
+		}
+	}
+	t.Fatal("expected at least one known network with SystemConfigProxy")
+	return ""
+}

--- a/packages/contracts-bedrock/snapshots/abi_loader.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader.go
@@ -34,6 +34,9 @@ var delayedWETH []byte
 //go:embed abi/SystemConfig.json
 var systemConfig []byte
 
+//go:embed abi/OptimismPortal2.json
+var optimismPortal2 []byte
+
 //go:embed abi/CrossL2Inbox.json
 var crossL2Inbox []byte
 
@@ -73,6 +76,10 @@ func LoadDelayedWETHABI() *abi.ABI {
 
 func LoadSystemConfigABI() *abi.ABI {
 	return loadABI(systemConfig)
+}
+
+func LoadOptimismPortal2ABI() *abi.ABI {
+	return loadABI(optimismPortal2)
 }
 
 func LoadCrossL2InboxABI() *abi.ABI {

--- a/packages/contracts-bedrock/snapshots/abi_loader_test.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader_test.go
@@ -19,6 +19,9 @@ func TestLoadABIs(t *testing.T) {
 		{"PreimageOracle", LoadPreimageOracleABI},
 		{"MIPS", LoadMIPSABI},
 		{"DelayedWETH", LoadDelayedWETHABI},
+		{"SystemConfig", LoadSystemConfigABI},
+		{"OptimismPortal2", LoadOptimismPortal2ABI},
+		{"AnchorStateRegistry", LoadAnchorStateRegistryABI},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
Updates op-proposer so the default dispute game type is resolved from the current AnchorStateRegistry respected game type.

The proposer can now use `--network` or `--system-config-address` to resolve SystemConfig, then reload the current DisputeGameFactory and AnchorStateRegistry on each proposal cycle so upgrades are picked up without restarting. Explicit numeric `--game-type` values still behave as before, and `--game-factory-address` remains supported for backwards compatibility.

Validated with:
- `mise exec -- go test ./op-proposer/...`
- `mise exec -- go test ./packages/contracts-bedrock/snapshots`
- `git diff --check`
