### PR TITLE
superchain: load keep_karst_upgrade_gas from registry into op-node

### DIFF
--- a/op-core/superchain/types.go
+++ b/op-core/superchain/types.go
@@ -50,7 +50,11 @@ type HardforkConfig struct {
 	IsthmusTime  *uint64 `toml:"isthmus_time"`
 	JovianTime   *uint64 `toml:"jovian_time"`
 	KarstTime    *uint64 `toml:"karst_time"`
-	LagoonTime   *uint64 `toml:"lagoon_time"`
+	// KeepKarstUpgradeGas opts out of the fix for the Karst upgrade-gas leak. It is a behavioral
+	// flag, not a scheduled time: set for chains that activated Karst with the leak baked into
+	// their history, so the inflated activation-block gas limit is kept on every later block.
+	KeepKarstUpgradeGas bool    `toml:"keep_karst_upgrade_gas"`
+	LagoonTime          *uint64 `toml:"lagoon_time"`
 	// Optional Forks
 	PectraBlobScheduleTime *uint64 `toml:"pectra_blob_schedule_time,omitempty"`
 }

--- a/op-node/chaincfg/chains_test.go
+++ b/op-node/chaincfg/chains_test.go
@@ -79,6 +79,7 @@ var mainnetCfg = rollup.Config{
 	IsthmusTime:            u64Ptr(1746806401),
 	JovianTime:             u64Ptr(1764691201),
 	KarstTime:              u64Ptr(1783526401),
+	KeepKarstUpgradeGas:    true,
 	ChainOpConfig:          defaultOpConfig,
 }
 
@@ -120,6 +121,7 @@ var sepoliaCfg = rollup.Config{
 	IsthmusTime:            u64Ptr(1744905600),
 	JovianTime:             u64Ptr(1763568001),
 	KarstTime:              u64Ptr(1781712001),
+	KeepKarstUpgradeGas:    true,
 	ChainOpConfig:          defaultOpConfig,
 }
 

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -102,4 +102,5 @@ func applyHardforks(cfg *Config, hardforks superchain.HardforkConfig) {
 	cfg.LagoonTime = hardforks.LagoonTime
 	cfg.JovianTime = hardforks.JovianTime
 	cfg.KarstTime = hardforks.KarstTime
+	cfg.KeepKarstUpgradeGas = hardforks.KeepKarstUpgradeGas
 }

--- a/op-node/rollup/superchain_test.go
+++ b/op-node/rollup/superchain_test.go
@@ -22,8 +22,16 @@ func TestApplyHardforks(t *testing.T) {
 	// Set all hardforks
 	hardforkVal := reflect.ValueOf(&hardforkCfg).Elem()
 	for i := 0; i < hardforkVal.NumField(); i++ {
-		val := uint64(i + 10) // +10 just so they're all arbitrary non-zero values
-		hardforkVal.Field(i).Set(reflect.ValueOf(&val))
+		field := hardforkVal.Field(i)
+		switch field.Kind() {
+		case reflect.Ptr: // *uint64 fork-activation times
+			val := uint64(i + 10) // +10 just so they're all arbitrary non-zero values
+			field.Set(reflect.ValueOf(&val))
+		case reflect.Bool: // behavioral flags, e.g. KeepKarstUpgradeGas
+			field.SetBool(true)
+		default:
+			t.Fatalf("unexpected hard fork field kind %v for %v", field.Kind(), hardforkVal.Type().Field(i).Name)
+		}
 	}
 
 	applyHardforks(&cfg, hardforkCfg)
@@ -38,7 +46,11 @@ func requireAllHardforksSetCorrectly(t *testing.T, cfg Config, hardforkCfg super
 	for i := 0; i < hardforkVal.NumField(); i++ {
 		hardforkField := hardforkType.Field(i)
 		cfgField := cfgVal.FieldByName(hardforkField.Name)
-		require.Equalf(t, hardforkVal.Field(i).Elem(), cfgField.Elem(), "missing hard fork field %v", hardforkField.Name)
+		if hardforkField.Type.Kind() == reflect.Ptr {
+			require.Equalf(t, hardforkVal.Field(i).Elem(), cfgField.Elem(), "missing hard fork field %v", hardforkField.Name)
+		} else {
+			require.Equalf(t, hardforkVal.Field(i).Interface(), cfgField.Interface(), "missing hard fork field %v", hardforkField.Name)
+		}
 	}
 	// Regolith is always activated at genesis
 	require.NotNil(t, cfg.RegolithTime)


### PR DESCRIPTION
## Problem

An op-node started with `--network=op-sepolia` (or `op-mainnet`) loads `keep_karst_upgrade_gas` as **false**, even though the superchain-registry sets `keep_karst_upgrade_gas = true` for those chains. As a result op-node subtracts the Karst upgrade gas at the post-activation block and **diverges from canonical history** — the flag had to be supplied by hand via `--override.keep-karst-upgrade-gas=true`.

### Root cause

op-node's superchain-registry decoder silently dropped the key:

- `superchain.HardforkConfig` (`op-core/superchain/types.go`) had no field for `keep_karst_upgrade_gas`, and the decoder (`BurntSushi/toml`) ignores unknown keys without erroring.
- `applyHardforks` (`op-node/rollup/superchain.go`) never copied it into the rollup config.

This was an op-node-only gap. #21441 wired the flag into kona (its `HardForkConfig` reads it from the embedded registry) and added the op-node `rollup.Config` field + the `--override.keep-karst-upgrade-gas` CLI flag, but never extended the Go SCR-loading path.

## Fix

- Add `KeepKarstUpgradeGas` to `superchain.HardforkConfig` so the TOML key is decoded.
- Copy it in `applyHardforks` alongside the fork-time fields.

## Testing

Test-first: added `KeepKarstUpgradeGas: true` to the expected SCR-loaded `sepoliaCfg` and `mainnetCfg` in `TestGetRollupConfig` (both carry the flag in the embedded registry).

- **Baseline (before fix): FAILS** — `KeepKarstUpgradeGas: expected true, actual false` for both sepolia and mainnet, confirming the registry value was being dropped.
- **After fix: passes.**

The reflection-based `TestApplyHardforks` is updated to handle the new non-pointer `bool` field (the old loop assumed every field was `*uint64`).

`go build`, `gofmt`, and the `op-core/superchain` / `op-node/rollup` / `op-node/chaincfg` test packages are all green locally.

## Effect

op-sepolia and op-mainnet nodes started from the network preset now load `keep_karst_upgrade_gas=true` from the registry, the startup banner prints it, and the `--override.keep-karst-upgrade-gas` workaround is no longer required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)