### PR TITLE
fix(op-deployer): reject genesis-affecting changes on re-apply

### DIFF
--- a/op-deployer/pkg/deployer/integration_test/reapply_genesis_guard_test.go
+++ b/op-deployer/pkg/deployer/integration_test/reapply_genesis_guard_test.go
@@ -1,0 +1,298 @@
+package integration_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"log/slog"
+)
+
+// --- In-process L1 mock so the REAL InitLiveStrategy guard is reached --------------------
+//
+// pipeline.Env.L1Client is a concrete *ethclient.Client. We back one with an in-process
+// JSON-RPC server (no external process) that answers just the two calls the guard makes
+// before the immutability comparison: eth_chainId (ethclient.ChainID) and eth_getCode
+// (ethclient.CodeAt, for the deterministic-deployer presence check).
+
+type guardMockEthService struct{ chainID uint64 }
+
+func (m *guardMockEthService) ChainId() (*hexutil.Big, error) {
+	return (*hexutil.Big)(new(big.Int).SetUint64(m.chainID)), nil
+}
+
+func (m *guardMockEthService) GetCode(_ common.Address, _ string) (hexutil.Bytes, error) {
+	return hexutil.Bytes{0x60, 0x00}, nil // non-empty so the deployer check passes
+}
+
+func newGuardMockL1Client(t *testing.T, chainID uint64) *ethclient.Client {
+	t.Helper()
+	srv := rpc.NewServer()
+	require.NoError(t, srv.RegisterName("eth", &guardMockEthService{chainID: chainID}))
+	t.Cleanup(srv.Stop)
+	client := ethclient.NewClient(rpc.DialInProc(srv))
+	t.Cleanup(client.Close)
+	// sanity: confirm the mock answers the calls the guard relies on.
+	gotID, err := client.ChainID(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, chainID, gotID.Uint64())
+	code, err := client.CodeAt(context.Background(), script.DeterministicDeployerAddress, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, code)
+	return client
+}
+
+// applyGenesisChainForGuard produces a REAL, fully-applied state (allocs + start block) via
+// the in-memory genesis strategy, so the immutability guard's RenderGenesisAndRollup calls
+// have everything they need. Returns the applied intent (a deep-ish copy is the caller's
+// job via mutate funcs) and state.
+func applyGenesisChainForGuard(t *testing.T) (*state.Intent, *state.State) {
+	t.Helper()
+	ctx := context.Background()
+	opts, intent, st := setupGenesisChain(t, devnet.DefaultChainID)
+	require.NoError(t, deployer.ApplyPipeline(ctx, opts))
+	require.NotNil(t, st.AppliedIntent, "apply must record AppliedIntent")
+	require.NotEmpty(t, st.Chains)
+	require.NotNil(t, st.Chains[0].Allocs, "applied chain must have frozen allocs")
+	require.NotNil(t, st.Chains[0].StartBlock, "applied chain must have a start block")
+	return intent, st
+}
+
+// cloneIntentForReapply returns a copy of the applied intent suitable for re-apply, with a
+// freshly copied first ChainIntent so the caller can mutate genesis-affecting fields without
+// touching st.AppliedIntent. (Other fields are shared; tests only mutate the first chain or
+// top-level scalar/override fields, which are reassigned wholesale.)
+func cloneIntentForReapply(applied *state.Intent) *state.Intent {
+	cp := *applied
+	cp.Chains = make([]*state.ChainIntent, len(applied.Chains))
+	for i, c := range applied.Chains {
+		cc := *c
+		cp.Chains[i] = &cc
+	}
+	if applied.GlobalDeployOverrides != nil {
+		cp.GlobalDeployOverrides = make(map[string]any, len(applied.GlobalDeployOverrides))
+		for k, v := range applied.GlobalDeployOverrides {
+			cp.GlobalDeployOverrides[k] = v
+		}
+	}
+	return &cp
+}
+
+func runGuard(t *testing.T, st *state.State, newIntent *state.Intent) error {
+	t.Helper()
+	env := &pipeline.Env{
+		L1Client: newGuardMockL1Client(t, newIntent.L1ChainID),
+		Logger:   testlog.Logger(t, slog.LevelError),
+	}
+	return pipeline.InitLiveStrategy(context.Background(), env, newIntent, st)
+}
+
+// TestReapplyGenesisGuard_RejectsGenesisAffectingChanges drives the REAL guard
+// (pipeline.InitLiveStrategy) against a fully-applied genesis-strategy state and asserts it
+// REJECTS each genesis-affecting re-apply mutation, ACCEPTS legitimate re-applies, and
+// verifies the comparison is deterministic (old-vs-old never falsely triggers).
+func TestReapplyGenesisGuard_RejectsGenesisAffectingChanges(t *testing.T) {
+	op_e2e.InitParallel(t)
+
+	applied, st := applyGenesisChainForGuard(t)
+	chain0 := applied.Chains[0]
+
+	// --- CONTROL 1: an UNCHANGED re-apply must PASS (no false positive, determinism). ---
+	{
+		unchanged := cloneIntentForReapply(applied)
+		require.NoError(t, runGuard(t, st, unchanged),
+			"unchanged re-apply must pass (proves RenderGenesisAndRollup is deterministic)")
+	}
+
+	// --- CONTROL 2: the pre-existing immutable check still works (guard executed). ---
+	{
+		fundFlip := cloneIntentForReapply(applied)
+		fundFlip.FundDevAccounts = !applied.FundDevAccounts
+		err := runGuard(t, st, fundFlip)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fundDevAccounts is immutable",
+			"control: confirms the real guard ran")
+	}
+
+	// --- REJECTIONS: genesis-affecting field mutations. ---
+	// "expect" is the substring of the immutability error that names the changed surface:
+	//   "genesis system config" -> rollup Genesis.SystemConfig differs (batcher, operatorFee, gasLimit)
+	//   "genesis block"         -> the genesis block hash differs (header field changed)
+	rejectCases := []struct {
+		name   string
+		mutate func(in *state.Intent)
+		expect string
+	}{
+		{
+			name:   "roles.batcher",
+			mutate: func(in *state.Intent) { in.Chains[0].Roles.Batcher = common.HexToAddress("0xDEADBEEF") },
+			expect: "genesis system config",
+		},
+		{
+			name:   "operatorFeeScalar",
+			mutate: func(in *state.Intent) { in.Chains[0].OperatorFeeScalar = chain0.OperatorFeeScalar + 7 },
+			expect: "genesis system config",
+		},
+		{
+			name:   "operatorFeeConstant",
+			mutate: func(in *state.Intent) { in.Chains[0].OperatorFeeConstant = chain0.OperatorFeeConstant + 9 },
+			expect: "genesis system config",
+		},
+		{
+			// gasLimit feeds BOTH the genesis header (block hash) and the genesis SystemConfig.
+			// The block-hash check runs first, so the error names the genesis block.
+			name:   "gasLimit",
+			mutate: func(in *state.Intent) { in.Chains[0].GasLimit = chain0.GasLimit + 1_000_000 },
+			expect: "genesis block",
+		},
+		{
+			// A genesis-header override (base fee per gas) changes the genesis block hash.
+			name: "genesis-block GlobalDeployOverride (l2GenesisBlockBaseFeePerGas)",
+			mutate: func(in *state.Intent) {
+				if in.GlobalDeployOverrides == nil {
+					in.GlobalDeployOverrides = map[string]any{}
+				}
+				in.GlobalDeployOverrides["l2GenesisBlockBaseFeePerGas"] = "0x3b9aca01" // 1e9+1
+			},
+			expect: "genesis block",
+		},
+		{
+			// A genesis-SystemConfig override (operator fee scalar) changes the rollup GenesisSystemConfig.
+			name: "genesis-sysconfig chain DeployOverride (gasPriceOracleOperatorFeeScalar)",
+			mutate: func(in *state.Intent) {
+				in.Chains[0].DeployOverrides = map[string]any{"gasPriceOracleOperatorFeeScalar": float64(4242)}
+			},
+			expect: "genesis system config",
+		},
+	}
+	for _, tc := range rejectCases {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			ni := cloneIntentForReapply(applied)
+			tc.mutate(ni)
+			err := runGuard(t, st, ni)
+			require.Error(t, err, "guard must reject genesis-affecting change: %s", tc.name)
+			require.Contains(t, err.Error(), "is immutable", "must be an immutability rejection")
+			require.Contains(t, err.Error(), tc.expect, "rejection should name what changed")
+			t.Logf("rejected %s: %v", tc.name, err)
+		})
+	}
+
+	// --- ACCEPTANCES: legitimate re-applies that do NOT alter genesis. ---
+	acceptCases := []struct {
+		name   string
+		mutate func(in *state.Intent)
+	}{
+		{
+			name: "future hardfork schedule via GlobalDeployOverrides",
+			mutate: func(in *state.Intent) {
+				if in.GlobalDeployOverrides == nil {
+					in.GlobalDeployOverrides = map[string]any{}
+				}
+				// Scheduling the next fork (Karst, the one immediately after the default
+				// genesis-active Jovian) at a far-future offset changes only the genesis
+				// ChainConfig fork time -- NOT the genesis block hash or genesis SystemConfig --
+				// so the guard must allow it. (This is the canonical "legitimate re-apply".)
+				in.GlobalDeployOverrides["l2GenesisKarstTimeOffset"] = "0x7fffffffffffffff"
+			},
+		},
+		{
+			name: "deploy-only proof param override (faultGameMaxDepth)",
+			mutate: func(in *state.Intent) {
+				if in.GlobalDeployOverrides == nil {
+					in.GlobalDeployOverrides = map[string]any{}
+				}
+				in.GlobalDeployOverrides["faultGameMaxDepth"] = float64(73)
+			},
+		},
+	}
+	for _, tc := range acceptCases {
+		t.Run("accept/"+tc.name, func(t *testing.T) {
+			ni := cloneIntentForReapply(applied)
+			tc.mutate(ni)
+			require.NoError(t, runGuard(t, st, ni),
+				"guard must ALLOW non-genesis-affecting change: %s", tc.name)
+			t.Logf("accepted %s", tc.name)
+		})
+	}
+
+	// --- ACCEPTANCE: adding a BRAND-NEW chain on re-apply must be allowed. ---
+	t.Run("accept/brand-new-chain", func(t *testing.T) {
+		ni := cloneIntentForReapply(applied)
+		newChain := *applied.Chains[0]
+		// Give it a distinct chain ID so it is genuinely a new, not-yet-applied chain.
+		newChain.ID = common.BigToHash(uint256.NewInt(0xABCDEF).ToBig())
+		newChain.Roles.Batcher = common.HexToAddress("0xC0FFEE") // arbitrary; new chain isn't frozen
+		ni.Chains = append(ni.Chains, &newChain)
+		require.NoError(t, runGuard(t, st, ni),
+			"adding a brand-new chain on re-apply must be allowed")
+	})
+}
+
+// TestReapplyGenesisGuard_DocumentedResidualGaps adversarially documents what the
+// genesis-output comparison (genesis block hash + genesis SystemConfig) intentionally does
+// NOT catch, so the guard's exact scope is pinned and honestly stated:
+//
+//   - Fields baked only into the FROZEN L2 allocs (e.g. fee-vault recipients stored in
+//     predeploy storage) are not regenerated on re-apply, so old and new genesis OUTPUT are
+//     identical -> not a re-apply divergence at all (true negative).
+//   - Fields that live only in the genesis ChainConfig (e.g. eip1559Denominator) or only in
+//     the broader rollup config (e.g. l2BlockTime) -- but NOT in the genesis block header or
+//     the genesis SystemConfig -- are NOT covered by this comparison. These are residual gaps
+//     of the chosen surface; they are deliberately out of scope here because the genesis
+//     ChainConfig also legitimately changes for future-hardfork scheduling (which must be
+//     allowed). Closing them would require a separate, ordering-aware comparison.
+//
+// If a future change makes any of these alter the genesis block hash or SystemConfig, this
+// test will start failing and should be moved into the rejection set.
+func TestReapplyGenesisGuard_DocumentedResidualGaps(t *testing.T) {
+	op_e2e.InitParallel(t)
+
+	applied, st := applyGenesisChainForGuard(t)
+
+	notCaught := []struct {
+		name   string
+		mutate func(in *state.Intent)
+	}{
+		{
+			name:   "baseFeeVaultRecipient (frozen in allocs; genesis output unchanged)",
+			mutate: func(in *state.Intent) { in.Chains[0].BaseFeeVaultRecipient = common.HexToAddress("0xFEE5") },
+		},
+		{
+			name:   "eip1559Denominator (genesis ChainConfig only; not in block hash or SystemConfig)",
+			mutate: func(in *state.Intent) { in.Chains[0].Eip1559Denominator = in.Chains[0].Eip1559Denominator + 1 },
+		},
+		{
+			name: "l2BlockTime (rollup config only; not in genesis block hash or SystemConfig)",
+			mutate: func(in *state.Intent) {
+				if in.GlobalDeployOverrides == nil {
+					in.GlobalDeployOverrides = map[string]any{}
+				}
+				in.GlobalDeployOverrides["l2BlockTime"] = float64(3)
+			},
+		},
+	}
+	for _, tc := range notCaught {
+		t.Run(tc.name, func(t *testing.T) {
+			ni := cloneIntentForReapply(applied)
+			tc.mutate(ni)
+			err := runGuard(t, st, ni)
+			require.NoError(t, err,
+				"documented residual gap: this comparison does not catch %s", tc.name)
+			t.Logf("NOT caught (documented residual gap): %s", tc.name)
+		})
+	}
+}

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"reflect"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
@@ -100,7 +101,80 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 		return immutableErr("fundDevAccounts", st.AppliedIntent.FundDevAccounts, intent.FundDevAccounts)
 	}
 
-	// TODO: validate individual
+	// Once a chain has been applied, its L2 genesis allocs and its on-chain L1
+	// SystemConfig are frozen: re-apply does not regenerate the L2 genesis
+	// (l2genesis.go only runs when chainState.Allocs == nil) and does not redeploy
+	// the OP chain contracts (opchain.go returns early when already deployed).
+	// However, the genesis file and rollup config emitted by RenderGenesisAndRollup
+	// are computed live from the current intent. If a field that feeds the genesis block
+	// or the genesis SystemConfig changes on re-apply (e.g. gasLimit, roles.batcher,
+	// operatorFeeScalar/Constant, or genesis-affecting deploy overrides), the emitted
+	// genesis/rollup config would silently diverge from the already-deployed chain (the
+	// on-chain SystemConfig holds the OLD value while op-node seeds its view from the NEW
+	// rollup config Genesis.SystemConfig).
+	//
+	// Rather than enumerate individual fields, we compare the actual genesis OUTPUT
+	// produced from the previously-applied intent vs the new intent, for every chain
+	// that exists in both and has already been fully applied. Any difference in the
+	// genesis block hash or the genesis SystemConfig is rejected as an immutable change.
+	// This is precise: it only rejects changes that actually alter the genesis block or
+	// SystemConfig, and it automatically covers future additions to those surfaces.
+	// Changes that do not affect either surface are allowed -- including scheduling a
+	// future hardfork time, L1-only/deploy-only params, brand-new chains, and
+	// not-yet-applied chains.
+	//
+	// Note: this comparison intentionally does NOT cover fields that live only in the
+	// frozen L2 allocs (e.g. fee-vault recipients in predeploy storage, which are not
+	// regenerated on re-apply and therefore cannot diverge here) or fields that live only
+	// in the genesis ChainConfig / broader rollup config but not the block hash or
+	// SystemConfig (e.g. eip1559 params, l2BlockTime). The genesis ChainConfig is excluded
+	// because its fork-activation times legitimately change for future-hardfork scheduling.
+	for _, appliedChain := range st.AppliedIntent.Chains {
+		chainID := appliedChain.ID
+
+		chainState, err := st.Chain(chainID)
+		if err != nil {
+			// No chain state yet for this chain: it has not been applied, so there is
+			// nothing frozen to diverge from. Skip.
+			continue
+		}
+		if chainState.Allocs == nil || chainState.StartBlock == nil {
+			// Chain is not fully applied (L2 genesis/start block not yet produced), so its
+			// genesis is not frozen. Skip; RenderGenesisAndRollup would also be unable to
+			// render it.
+			continue
+		}
+		if _, err := intent.Chain(chainID); err != nil {
+			// Chain present in the applied intent but absent from the new intent (removal).
+			// RenderGenesisAndRollup(new) cannot render it; leave removal handling to other
+			// stages and skip the immutability comparison.
+			continue
+		}
+
+		oldGenesis, oldRollup, err := RenderGenesisAndRollup(st, chainID, st.AppliedIntent)
+		if err != nil {
+			return fmt.Errorf("failed to render genesis for applied intent (chain %s): %w", chainID, err)
+		}
+		newGenesis, newRollup, err := RenderGenesisAndRollup(st, chainID, intent)
+		if err != nil {
+			return fmt.Errorf("failed to render genesis for new intent (chain %s): %w", chainID, err)
+		}
+
+		if oldGenesis.ToBlock().Hash() != newGenesis.ToBlock().Hash() {
+			return immutableErr(
+				fmt.Sprintf("genesis block for chain %s", chainID),
+				oldGenesis.ToBlock().Hash(),
+				newGenesis.ToBlock().Hash(),
+			)
+		}
+		if !reflect.DeepEqual(oldRollup.Genesis.SystemConfig, newRollup.Genesis.SystemConfig) {
+			return immutableErr(
+				fmt.Sprintf("genesis system config for chain %s", chainID),
+				oldRollup.Genesis.SystemConfig,
+				newRollup.Genesis.SystemConfig,
+			)
+		}
+	}
 
 	return nil
 }

--- a/op-deployer/pkg/deployer/state/reapply_drift_consequence_test.go
+++ b/op-deployer/pkg/deployer/state/reapply_drift_consequence_test.go
@@ -1,0 +1,149 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests SKEPTICALLY validate the consequence of the op-deployer re-apply config
+// drift mechanism. The MECHANISM (immutability guard ignores genesis-affecting fields;
+// on-chain SystemConfig + L2 allocs frozen on re-apply; regenerated rollup/genesis read
+// the NEW intent live) is established elsewhere. Here we test the CONSEQUENCE per field:
+// does the NEW regenerated value cause real harm, or is it inert metadata?
+//
+// All tests drive REAL production functions:
+//   - state.CombineDeployConfig            (op-deployer/pkg/deployer/state/deploy_config.go:24)
+//   - genesis.NewL2Genesis                 (op-chain-ops/genesis/genesis.go:29) -- the exact
+//     genesis-header builder used by genesis.BuildL2Genesis inside the pipeline's
+//     RenderGenesisAndRollup (op-deployer/pkg/deployer/pipeline/env.go:128)
+//   - genesis.DeployConfig.GenesisSystemConfig (op-chain-ops/genesis/config.go:1161)
+//   - eth.SystemConfig.OperatorFee         (op-service/eth/types.go:735)
+
+func consequenceBaseChain() ChainIntent {
+	return ChainIntent{
+		ID:                         common.HexToHash("0x123"),
+		Eip1559Denominator:         1,
+		Eip1559Elasticity:          2,
+		GasLimit:                   standard.GasLimit,
+		BaseFeeVaultRecipient:      common.HexToAddress("0x123"),
+		L1FeeVaultRecipient:        common.HexToAddress("0x456"),
+		SequencerFeeVaultRecipient: common.HexToAddress("0x789"),
+		OperatorFeeVaultRecipient:  common.HexToAddress("0xabc"),
+		Roles: ChainRoles{
+			SystemConfigOwner: common.HexToAddress("0x123"),
+			L1ProxyAdminOwner: common.HexToAddress("0x456"),
+			L2ProxyAdminOwner: common.HexToAddress("0x789"),
+			UnsafeBlockSigner: common.HexToAddress("0xabc"),
+			Batcher:           common.HexToAddress("0xBA7C0E"),
+		},
+		OperatorFeeScalar:   100,
+		OperatorFeeConstant: 200,
+	}
+}
+
+func consequenceBaseIntent() Intent {
+	return Intent{
+		L1ChainID:          1,
+		L1ContractsLocator: artifacts.EmbeddedLocator,
+	}
+}
+
+// buildGenesisHeaderHash runs the REAL pipeline building blocks (CombineDeployConfig ->
+// NewL2Genesis -> ToBlock) and returns the genesis BLOCK HASH. This mirrors the genesis
+// header that RenderGenesisAndRollup produces; we use NewL2Genesis (the header builder)
+// directly instead of BuildL2Genesis to avoid needing a full 2048-predeploy alloc set,
+// since gasLimit only affects the header, not the alloc accounts.
+func buildGenesisHeaderHash(t *testing.T, intent Intent, chain ChainIntent) (common.Hash, eth.SystemConfig) {
+	t.Helper()
+	chainState := ChainState{ID: chain.ID}
+	st := State{SuperchainDeployment: &addresses.SuperchainContracts{}}
+
+	cfg, err := CombineDeployConfig(&intent, &chain, &st, &chainState)
+	require.NoError(t, err)
+
+	// L2GenesisBlockNumber/timestamp inputs are deterministic from a zero start ref.
+	startRef := eth.BlockRef{}
+	g, err := genesis.NewL2Genesis(&cfg, &startRef)
+	require.NoError(t, err)
+
+	return g.ToBlock().Hash(), cfg.GenesisSystemConfig()
+}
+
+// TestReapplyDrift_GasLimit_ChangesGenesisBlockHash
+//
+// VERDICT INPUT for the gasLimit field: re-applying with a changed gasLimit produces a
+// DIFFERENT genesis block hash. A regenerated rollup.json/genesis would not match the
+// already-running chain's genesis -> new nodes computing genesis would disagree.
+func TestReapplyDrift_GasLimit_ChangesGenesisBlockHash(t *testing.T) {
+	intent := consequenceBaseIntent()
+
+	oldChain := consequenceBaseChain()
+	oldChain.GasLimit = 30_000_000
+
+	newChain := consequenceBaseChain()
+	newChain.GasLimit = 60_000_000 // CHANGED on re-apply
+
+	oldHash, oldSys := buildGenesisHeaderHash(t, intent, oldChain)
+	newHash, newSys := buildGenesisHeaderHash(t, intent, newChain)
+
+	require.NotEqual(t, oldHash, newHash,
+		"gasLimit change MUST alter the genesis block hash (header.GasLimit feeds the hash)")
+	require.EqualValues(t, 30_000_000, oldSys.GasLimit)
+	require.EqualValues(t, 60_000_000, newSys.GasLimit)
+
+	t.Logf("gasLimit drift: genesis block hash %s (gasLimit 30M) -> %s (gasLimit 60M); "+
+		"GenesisSystemConfig.GasLimit %d -> %d. A regenerated genesis would not match the "+
+		"running chain's original genesis hash.", oldHash, newHash, oldSys.GasLimit, newSys.GasLimit)
+}
+
+// TestReapplyDrift_OperatorFee_DoesNotChangeGenesisBlockHash_ButChangesRollupSystemConfig
+//
+// VERDICT INPUT for operatorFee and batcher: these are NOT in the genesis block header,
+// so they do NOT change the genesis block hash (no chain-join failure from them). BUT they
+// DO change the rollup config's GenesisSystemConfig, which (per consumer-authority tracing)
+// is the value op-node SEEDS its system-config view from at genesis -- so the NEW value is
+// effective, while the frozen on-chain L1 SystemConfig holds the OLD value.
+func TestReapplyDrift_OperatorFee_DoesNotChangeGenesisBlockHash_ButChangesRollupSystemConfig(t *testing.T) {
+	intent := consequenceBaseIntent()
+
+	oldChain := consequenceBaseChain()
+	newChain := consequenceBaseChain()
+	newChain.OperatorFeeScalar = 999
+	newChain.OperatorFeeConstant = 888
+	newChain.Roles.Batcher = common.HexToAddress("0xDEADBEEF")
+
+	oldHash, oldSys := buildGenesisHeaderHash(t, intent, oldChain)
+	newHash, newSys := buildGenesisHeaderHash(t, intent, newChain)
+
+	// operatorFee + batcher are NOT header fields -> genesis block hash unchanged.
+	require.Equal(t, oldHash, newHash,
+		"operatorFee/batcher are not in the genesis header; genesis block hash is unaffected by them")
+
+	// ... but the rollup config's GenesisSystemConfig DOES carry the NEW values.
+	require.EqualValues(t, 100, oldSys.OperatorFee().Scalar)
+	require.EqualValues(t, 200, oldSys.OperatorFee().Constant)
+	require.Equal(t, common.HexToAddress("0xBA7C0E"), oldSys.BatcherAddr)
+
+	require.EqualValues(t, 999, newSys.OperatorFee().Scalar,
+		"NEW operatorFeeScalar lands in rollup GenesisSystemConfig (op-node seeds from here)")
+	require.EqualValues(t, 888, newSys.OperatorFee().Constant,
+		"NEW operatorFeeConstant lands in rollup GenesisSystemConfig")
+	require.Equal(t, common.HexToAddress("0xDEADBEEF"), newSys.BatcherAddr,
+		"NEW batcher lands in rollup GenesisSystemConfig")
+
+	t.Logf("operatorFee/batcher drift: genesis block hash UNCHANGED (%s); but rollup "+
+		"GenesisSystemConfig changed -> batcher %s->%s, operatorFeeScalar %d->%d, "+
+		"operatorFeeConstant %d->%d. op-node seeds its sysConfig from this value at genesis "+
+		"(PayloadToSystemConfig -> rollupCfg.Genesis.SystemConfig), so NEW is effective while "+
+		"on-chain L1 SystemConfig stays OLD.",
+		oldHash, oldSys.BatcherAddr, newSys.BatcherAddr,
+		oldSys.OperatorFee().Scalar, newSys.OperatorFee().Scalar,
+		oldSys.OperatorFee().Constant, newSys.OperatorFee().Constant)
+}


### PR DESCRIPTION
**Description**

Once a chain has been applied, its L2 genesis allocs and on-chain SystemConfig are
frozen: re-apply does not regenerate the L2 genesis and does not redeploy the OP chain
contracts. The genesis and rollup config emitted by RenderGenesisAndRollup, however, are
computed live from the current intent. A re-apply that changed a genesis-affecting field
(gasLimit, roles.batcher, operatorFeeScalar/Constant, or a genesis-affecting deploy
override) would silently emit a genesis and rollup config that diverge from the
already-deployed chain, since op-node seeds its system config from the rollup config
Genesis.SystemConfig while the on-chain SystemConfig keeps the original value.

The InitLiveStrategy immutability check previously validated only L1ChainID and
FundDevAccounts. It now also compares, for each already-applied chain still present in the
new intent, the genesis output produced from the applied intent versus the new intent, and
rejects any change to the genesis block hash or the genesis SystemConfig. The change is
confined to op-deployer/pkg/deployer/pipeline/init.go.

**Tests**

- Added integration_test/reapply_genesis_guard_test.go, which drives the real
  InitLiveStrategy through an in-process JSON-RPC L1 against a genesis-strategy-applied
  state, and asserts both directions:
  - REJECTS a re-apply that changes roles.batcher, operatorFeeScalar, operatorFeeConstant,
    gasLimit, a genesis-block deploy override, or a genesis-SystemConfig deploy override.
  - ACCEPTS an unchanged re-apply, a brand-new chain, a future-hardfork schedule, and a
    deploy-only parameter, confirming no false positives on legitimate flows.
- Added state/reapply_drift_consequence_test.go, which pins the underlying behavior: a
  gasLimit change alters the genesis block hash, while operatorFee/batcher changes alter
  the rollup Genesis.SystemConfig.
- Verified no regression: the existing genesis-strategy apply tests (TestApplyGenesisStrategy,
  TestGlobalOverrides, TestProofParamOverrides, TestIntentConfiguration, TestInvalidL2Genesis)
  pass, and go vet is clean. Remaining failures in the full op-deployer suite are pre-existing
  environment issues (missing L1 RPC URLs, missing prebuilt artifacts) unrelated to this change.

**Additional context**

The comparison is intentionally scoped to the genesis block hash and the genesis
SystemConfig, the surfaces that have a frozen on-chain counterpart. It deliberately does not
reject changes that do not affect those surfaces, so legitimate re-apply flows such as
scheduling a future hardfork or changing deploy-only parameters are still allowed.

Two surfaces are knowingly out of scope and documented in a pinning test: fee-vault
recipients (baked into the frozen L2 allocs, so they cannot diverge through this path) and
eip1559 denominator/elasticity and l2BlockTime (in the genesis ChainConfig or the broader
rollup config, not the block hash or SystemConfig). The genesis ChainConfig is excluded
because its fork-activation times legitimately change for future-hardfork scheduling, so a
broader compare would reintroduce false positives.
