### PR TITLE
ci: validate CircleCI schedule triggers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,7 @@ jobs:
           name: Detect file tree changes and store in JSON file
           command: .circleci/scripts/collect-params.sh detect
           environment:
+            c-circleci_changed: "^\\.circleci/"
             c-contracts_changed: "^(packages/contracts-bedrock|op-core/forks|op-core/nuts|\\.circleci|\\.github|ops/check-changed)/|^(package\\.json|mise\\.toml)$"
             c-docs_changes_detected: "^docs/public-docs/"
             c-rust_changes_detected: "^(rust|op-e2e|\\.circleci)/"
@@ -215,7 +216,7 @@ jobs:
               scheduled_pipeline)
                 case "${SCHEDULE_NAME}" in
                   build_four_hours) run scheduled_todo_issues scheduled_cannon_full_tests ;;
-                  build_daily)      run scheduled_preimage_reproducibility scheduled_stale_check scheduled_heavy_fuzz_tests scheduled_daily_tests ;;
+                  build_daily)      run scheduled_preimage_reproducibility scheduled_stale_check scheduled_heavy_fuzz_tests scheduled_daily_tests circleci_schedule_trigger_check ;;
                   build_weekly)     run scheduled_kona_link_checker ;;
                 esac
                 ;;
@@ -256,6 +257,9 @@ jobs:
                       run rust_ci_gate_short
                       run rust_e2e_gate_skip
                     fi
+                    if is_true circleci_changed; then
+                      run circleci_schedule_trigger_check
+                    fi
                   fi
 
                 # 2. Merge queue (pre-merge validation)
@@ -272,6 +276,9 @@ jobs:
                   else
                     run rust_ci_gate_short
                     run rust_e2e_gate_skip
+                  fi
+                  if is_true circleci_changed; then
+                    run circleci_schedule_trigger_check
                   fi
 
                 # 3. After merge (develop push)

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -132,6 +132,9 @@ parameters:
   c-run_ci_gate_skip:
     type: boolean
     default: false
+  c-run_circleci_schedule_trigger_check:
+    type: boolean
+    default: false
   c-run_publish_contract_artifacts:
     type: boolean
     default: false
@@ -681,6 +684,17 @@ jobs:
     steps:
       - utils/ci-gate:
           always-succeed: << parameters.always-succeed >>
+
+  circleci-schedule-trigger-check:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small.gen2
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - run:
+          name: Check CircleCI schedule triggers
+          command: bun .circleci/scripts/test-schedule-triggers.js
 
   # Build a single Rust binary from a workspace. Will cache the binary by default.
   rust-build-binary:
@@ -2926,6 +2940,14 @@ workflows:
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token
+
+  circleci-schedule-trigger-check-workflow:
+    when: << pipeline.parameters.c-run_circleci_schedule_trigger_check >>
+    jobs:
+      - circleci-schedule-trigger-check:
+          context:
+            - circleci-api-token
+
   close-issue-workflow:
     when: << pipeline.parameters.c-run_close_issue >>
     jobs:

--- a/.circleci/scripts/test-decision-tree.sh
+++ b/.circleci/scripts/test-decision-tree.sh
@@ -45,7 +45,20 @@ run_scenario() {
   local schedule="${5}"
   local json_seed="${6}"
   shift 6
-  local expected=("$@")
+  local expected=()
+  local unexpected=()
+  local collect_expected=true
+  for wf in "$@"; do
+    if [[ "${wf}" == "--not" ]]; then
+      collect_expected=false
+      continue
+    fi
+    if ${collect_expected}; then
+      expected+=("${wf}")
+    else
+      unexpected+=("${wf}")
+    fi
+  done
 
   # Seed the JSON
   echo "${json_seed}" > "${OUTPUT}"
@@ -70,6 +83,14 @@ run_scenario() {
     val=$(echo "${_json}" | jq -r ".\"c-run_${wf}\" // false")
     if [[ "${val}" != "true" ]]; then
       echo "  FAIL: expected c-run_${wf}=true, got ${val}"
+      all_pass=false
+    fi
+  done
+  for wf in "${unexpected[@]}"; do
+    local val
+    val=$(echo "${_json}" | jq -r ".\"c-run_${wf}\" // false")
+    if [[ "${val}" != "false" ]]; then
+      echo "  FAIL: expected c-run_${wf}=false, got ${val}"
       all_pass=false
     fi
   done
@@ -130,8 +151,15 @@ run_scenario \
 run_scenario \
   "PR (feature branch), nothing changed" \
   "webhook" "feat/my-thing" "" "" \
-  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": false, "c-only_docs_changes": false}' \
-  main release contracts_feature_tests_short rust_ci_gate_short rust_e2e_gate_skip
+  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-circleci_changed": false, "c-docs_changes_detected": false, "c-only_docs_changes": false}' \
+  main release contracts_feature_tests_short rust_ci_gate_short rust_e2e_gate_skip \
+  --not circleci_schedule_trigger_check
+
+run_scenario \
+  "PR (feature branch), CircleCI changed" \
+  "webhook" "feat/my-thing" "" "" \
+  '{"c-rust_changes_detected": true, "c-contracts_changed": true, "c-circleci_changed": true, "c-docs_changes_detected": false, "c-only_docs_changes": false}' \
+  main release contracts_feature_tests rust_ci rust_e2e_ci circleci_schedule_trigger_check
 
 run_scenario \
   "Merge queue, rust changed" \
@@ -167,7 +195,7 @@ run_scenario \
   "Scheduled: build_daily" \
   "scheduled_pipeline" "" "" "build_daily" \
   '{}' \
-  scheduled_preimage_reproducibility scheduled_stale_check scheduled_heavy_fuzz_tests scheduled_daily_tests
+  scheduled_preimage_reproducibility scheduled_stale_check scheduled_heavy_fuzz_tests scheduled_daily_tests circleci_schedule_trigger_check
 
 run_scenario \
   "Scheduled: build_weekly" \

--- a/.circleci/scripts/test-schedule-triggers.js
+++ b/.circleci/scripts/test-schedule-triggers.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env bun
+import { $ } from "bun";
+import { readdirSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "../..");
+const configPath = path.join(repoRoot, ".circleci/config.yml");
+const continuationDir = path.join(repoRoot, ".circleci/continue");
+const apiBase = process.env.CIRCLECI_API_BASE ?? "https://circleci.com/api/v2";
+const projectSlug =
+  process.env.CIRCLECI_PROJECT_SLUG ??
+  `gh/${process.env.CIRCLE_PROJECT_USERNAME ?? "ethereum-optimism"}/${process.env.CIRCLE_PROJECT_REPONAME ?? "optimism"}`;
+const tokenVar = process.env.CIRCLECI_API_TOKEN_ENV ?? "CIRCLE_API_TOKEN";
+
+function sorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function difference(left, right) {
+  const rightSet = new Set(right);
+  return sorted([...left].filter((value) => !rightSet.has(value)));
+}
+
+function printList(title, values) {
+  console.log(title);
+  for (const value of sorted(values)) {
+    console.log(`  - ${value}`);
+  }
+}
+
+function failWithList(message, values) {
+  console.error(`ERROR: ${message}`);
+  for (const value of sorted(values)) {
+    console.error(`  - ${value}`);
+  }
+  process.exit(1);
+}
+
+async function yqText(expression, file) {
+  return await $`yq -r ${expression} ${file}`.text();
+}
+
+async function extractDecisionTree() {
+  const stepName = "Compute workflow conditions from pipeline parameters and store in JSON file";
+  const expression = `.jobs.prepare-continuation-config.steps[] | select(.run.name == "${stepName}") | .run.command`;
+  const decisionTree = await yqText(expression, configPath);
+  if (decisionTree.trim() === "") {
+    console.error(`ERROR: Could not extract decision tree from ${configPath}`);
+    process.exit(1);
+  }
+  return decisionTree;
+}
+
+function extractScheduleMappings(decisionTree) {
+  const scheduledCase = decisionTree.match(/scheduled_pipeline\)\s*\n([\s\S]*?)\n\s*;;/);
+  if (!scheduledCase) {
+    return [];
+  }
+
+  const mappings = [];
+  const armPattern = /^\s*([A-Za-z0-9_-]+)\)\s+run\s+([^;]+?)\s*;;/gm;
+  for (const match of scheduledCase[1].matchAll(armPattern)) {
+    mappings.push({
+      scheduleName: match[1],
+      workflows: match[2].trim().split(/\s+/),
+    });
+  }
+  return mappings;
+}
+
+async function extractContinuationParams() {
+  const files = readdirSync(continuationDir)
+    .filter((file) => file.endsWith(".yml"))
+    .map((file) => path.join(continuationDir, file));
+  const params = new Set();
+  const expression = '.workflows | to_entries[] | select(.value.when | type == "!!str") | .value.when';
+
+  for (const file of files) {
+    const output = await yqText(expression, file);
+    for (const line of output.split("\n")) {
+      const match = line.match(/^<<\s*pipeline\.parameters\.(c-run_[A-Za-z0-9_]+)\s*>>$/);
+      if (match) {
+        params.add(match[1]);
+      }
+    }
+  }
+
+  return sorted(params);
+}
+
+async function fetchJsonWithRetry(url, token) {
+  const maxAttempts = 4;
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const response = await fetch(url, {
+      headers: {
+        "Circle-Token": token,
+      },
+    }).then(
+      (result) => result,
+      (error) => {
+        lastError = error;
+        return undefined;
+      },
+    );
+
+    if (response?.ok) {
+      return await response.json();
+    }
+
+    if (response) {
+      lastError = new Error(`HTTP ${response.status}: ${await response.text()}`);
+    }
+
+    if (attempt < maxAttempts) {
+      await Bun.sleep(2000);
+    }
+  }
+
+  throw lastError;
+}
+
+async function fetchScheduleNames(token) {
+  const maxPages = 10;
+  const schedules = new Set();
+  let pageToken = "";
+
+  for (let pageNumber = 1; pageNumber <= maxPages; pageNumber++) {
+    const url = new URL(`${apiBase}/project/${projectSlug}/schedule`);
+    if (pageToken !== "") {
+      url.searchParams.set("page-token", pageToken);
+    }
+
+    const page = await fetchJsonWithRetry(url.toString(), token);
+    for (const item of page.items ?? []) {
+      if (typeof item.name === "string") {
+        schedules.add(item.name);
+      }
+    }
+
+    pageToken = page.next_page_token ?? "";
+    if (pageToken === "") {
+      return sorted(schedules);
+    }
+  }
+
+  console.error(`ERROR: CircleCI schedule API returned more than ${maxPages} pages`);
+  process.exit(1);
+}
+const mappings = extractScheduleMappings(await extractDecisionTree());
+if (mappings.length === 0) {
+  console.error(`ERROR: no scheduled_pipeline schedule mappings found in ${configPath}`);
+  process.exit(1);
+}
+
+const configuredSchedules = sorted(mappings.map((mapping) => mapping.scheduleName));
+const mappedParams = sorted(mappings.flatMap((mapping) => mapping.workflows.map((workflow) => `c-run_${workflow}`)));
+const allContinuationParams = await extractContinuationParams();
+const scheduledContinuationParams = sorted(allContinuationParams.filter((param) => param.startsWith("c-run_scheduled_")));
+
+printList("Configured CircleCI schedule names:", configuredSchedules);
+printList("Scheduled continuation workflow params:", scheduledContinuationParams);
+
+const unknownMappedParams = difference(mappedParams, allContinuationParams);
+if (unknownMappedParams.length > 0) {
+  failWithList("scheduled_pipeline enables params that do not gate any continuation workflow:", unknownMappedParams);
+}
+
+const unmappedScheduledParams = difference(scheduledContinuationParams, mappedParams);
+if (unmappedScheduledParams.length > 0) {
+  failWithList("scheduled continuation workflows are not enabled by any configured schedule:", unmappedScheduledParams);
+}
+
+const token = process.env[tokenVar];
+if (!token) {
+  console.error(`ERROR: ${tokenVar} is not set; cannot query CircleCI schedule triggers`);
+  process.exit(1);
+}
+
+const actualSchedules = await fetchScheduleNames(token);
+printList(`CircleCI schedule names for ${projectSlug}:`, actualSchedules);
+
+const missingSchedules = difference(configuredSchedules, actualSchedules);
+if (missingSchedules.length > 0) {
+  failWithList("configured schedule names do not exist in CircleCI:", missingSchedules);
+}
+
+console.log("Live CircleCI schedule trigger checks passed.");


### PR DESCRIPTION
Adds a CircleCI schedule-trigger validation script and wires it into CI where schedule wiring can drift.

The Bun script uses the repo-pinned `yq` to read CircleCI YAML, checks that scheduled continuation workflows are reachable from the setup decision tree, then queries the CircleCI schedule API with retry and verifies the configured schedule names exist. The check runs as a non-blocking `circleci-schedule-trigger-check` workflow on PRs that touch `.circleci/`, and on the `build_daily` scheduled pipeline so trigger drift is caught after external schedule changes.

Validation:
- `mise exec -- bun build .circleci/scripts/test-schedule-triggers.js --outfile=/tmp/test-schedule-triggers.js`
- `mise exec -- shellcheck .circleci/scripts/test-decision-tree.sh`
- `mise exec -- bash .circleci/scripts/test-decision-tree.sh`
- `mise exec -- bash .circleci/scripts/merge-configs.sh`
- `mise exec -- bash .circleci/scripts/test-continuation-params.sh /tmp/merged-config.yml`
- `mise exec -- semgrep scan --timeout=100 --config .semgrep/rules/ --error .`
- live local run of `bun .circleci/scripts/test-schedule-triggers.js` with `CIRCLE_API_TOKEN` set
