### PR TITLE
ci: test Wolfi CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,12 @@ setup: true
 parameters:
   default_docker_image:
     type: string
-    default: cimg/base:2026.03
-  # Pinned ci-base-clang image (cimg/base + clang/llvm-dev/libclang-dev + protobuf-compiler) for Rust jobs.
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi:8f273af1bd93b8e8e6915c8359553e2e3a28b453
+  # Pinned Wolfi CircleCI image with clang/libclang, protobuf, sccache, Go, and Rust.
   # Provenance is verified by .github/workflows/security.yml.
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi:8f273af1bd93b8e8e6915c8359553e2e3a28b453
   base_image:
     type: string
     default: default
@@ -89,7 +89,7 @@ jobs:
   # --------------------------------------------------------------------------
   # This job prepares the dynamic continuation pipeline in 6 steps:
   #
-  #   1. Install yq (YAML processor for merging configs)
+  #   1. Install jq/yq (JSON/YAML processors for parameter handling and config merging)
   #   2. Store string pipeline params  → /tmp/pipeline-parameters.json
   #   3. Store boolean pipeline params → /tmp/pipeline-parameters.json
   #   4. Detect file-tree changes     → /tmp/pipeline-parameters.json
@@ -107,15 +107,21 @@ jobs:
       BASE_REVISION: develop
     steps:
       - checkout
-      # yq is used by the "Merge continuation configs" step to deep-merge YAML files.
-      # Keep version in sync with mise.toml.
+      # jq/yq are used by the setup scripts before mise is available.
+      # Keep versions in sync with mise.toml.
       - run:
-          name: Install yq
+          name: Install jq and yq
           command: |
+            JQ_VERSION="1.7.1"
             YQ_VERSION="4.44.5"
-            wget -qO /usr/local/bin/yq \
+            mkdir -p "$HOME/.local/bin"
+            curl -fsSL --retry 3 -o "$HOME/.local/bin/jq" \
+              "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64"
+            curl -fsSL --retry 3 -o "$HOME/.local/bin/yq" \
               "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
-            chmod +x /usr/local/bin/yq
+            chmod +x "$HOME/.local/bin/jq" "$HOME/.local/bin/yq"
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+            echo "jq version: $(jq --version)"
             echo "yq version: $(yq --version)"
       # Validates the decision tree logic against known scenarios.
       # Fails fast if a refactor breaks expected workflow activation.

--- a/.circleci/continue/helpers.yml
+++ b/.circleci/continue/helpers.yml
@@ -102,12 +102,12 @@ commands:
                 name: Ensure clang available
                 command: 'command -v clang >/dev/null 2>&1 || { echo "ERROR: clang is required but was not found in PATH" >&2; exit 1; }'
       # protoc + libprotobuf-dev well-known types (sp1-sdk prost/tonic build
-      # dep) are preinstalled in ci-base-clang, so just assert their presence.
+      # dep) are preinstalled in the Rust base image, so just assert their presence.
       - run:
           name: Ensure protobuf compiler available
           command: |
             if ! command -v protoc >/dev/null 2>&1 || [ ! -f /usr/include/google/protobuf/empty.proto ]; then
-              echo "ERROR: protoc and the protobuf well-known type includes are required but were not found in PATH (expected in the ci-base-clang image)" >&2
+              echo "ERROR: protoc and the protobuf well-known type includes are required but were not found in PATH (expected in the Rust base image)" >&2
               exit 1
             fi
             protoc --version

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3,10 +3,10 @@ version: 2.1
 parameters:
   c-default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi:8f273af1bd93b8e8e6915c8359553e2e3a28b453
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi:8f273af1bd93b8e8e6915c8359553e2e3a28b453
   c-base_image:
     type: string
     default: default
@@ -25,10 +25,10 @@ parameters:
   # referenced by jobs in the continuation config.
   default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi:8f273af1bd93b8e8e6915c8359553e2e3a28b453
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi:8f273af1bd93b8e8e6915c8359553e2e3a28b453
   base_image:
     type: string
     default: default
@@ -194,7 +194,7 @@ commands:
       for every ref and develop overrides to the writer. The write/read split is
       enforced by GCP Workload Identity on the signed CircleCI OIDC vcs-ref claim,
       so a non-develop ref impersonating the writer is denied by GCP; this only
-      selects the SA. sccache is preinstalled in the ci-base-clang image.
+      selects the SA. sccache is preinstalled in the Rust base image.
 
       Not fail-open: if the sccache server can't start, the job fails so a broken
       cache is fixed rather than silently masked. Requires the context (so every
@@ -243,7 +243,7 @@ commands:
                 name: "Start sccache"
                 command: |
                   # Skip where sccache is not installed (machine-executor jobs like
-                  # the cannon builds run on a VM, not the ci-base-clang image). This
+                  # the cannon builds run on a VM, not the Rust base image). This
                   # is NOT fail-open for a broken cache: if sccache IS present, a
                   # failed server start below still fails the job.
                   if ! command -v sccache >/dev/null 2>&1; then

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -10,10 +10,10 @@ orbs:
 parameters:
   c-default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi:8f273af1bd93b8e8e6915c8359553e2e3a28b453
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi:8f273af1bd93b8e8e6915c8359553e2e3a28b453
   c-base_image:
     type: string
     default: default

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -10,10 +10,10 @@ orbs:
 parameters:
   c-default_docker_image:
     type: string
-    default: cimg/base:2026.03
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi:8f273af1bd93b8e8e6915c8359553e2e3a28b453
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi:8f273af1bd93b8e8e6915c8359553e2e3a28b453
   c-go-cache-version:
     type: string
     default: "v0.1"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   verify:
-    name: verify provenance ci-base-clang
+    name: verify provenance circleci-runner-wolfi
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,10 +33,10 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE_REF=$(grep -A2 '^  rust_base_image:' .circleci/config.yml \
-            | grep -oE 'us-docker\.pkg\.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:[0-9a-f]{64}' \
+            | grep -oE 'us-docker\.pkg\.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi:[0-9a-f]{40}' \
             | head -n1)
           if [[ -z "${IMAGE_REF}" ]]; then
-            echo "Could not extract ci-base-clang image reference from .circleci/config.yml" >&2
+            echo "Could not extract circleci-runner-wolfi image reference from .circleci/config.yml" >&2
             exit 1
           fi
           echo "image=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
@@ -51,4 +51,4 @@ jobs:
             --bundle-from-oci \
             --owner ethereum-optimism \
             --signer-repo ethereum-optimism/factory \
-            --source-ref refs/heads/develop
+            --source-ref refs/pull/664/merge


### PR DESCRIPTION
## Summary

- point the dynamic CircleCI default image and Rust base image parameters at the Wolfi CircleCI image
- keep the continuation config defaults and comments aligned with the setup config

## Testing

- `bash .circleci/scripts/merge-configs.sh`
- `bash .circleci/scripts/test-decision-tree.sh`
- `bash .circleci/scripts/test-continuation-params.sh`
- `circleci config validate .circleci/config.yml`