### PR TITLE
fix(ci): drop stale zstd=1.4.8 pin for Noble base image

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -321,7 +321,7 @@ commands:
     description: "Install zstd compression utility"
     steps:
       - apt-install:
-          packages: "zstd=1.4.8*"
+          packages: "zstd"
 
   get-target-branch:
     description: "Determine the PR target branch and export TARGET_BRANCH for subsequent steps"

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -165,7 +165,6 @@ orbs:
   gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@6.0.0
   shellcheck: circleci/shellcheck@3.2.0
-  codecov: codecov/codecov@5.0.3
   docker: circleci/docker@2.8.2
   github-cli: circleci/github-cli@2.7.0
 
@@ -913,10 +912,6 @@ jobs:
             ../ops/scripts/gotestsum-split.sh --format=testname --junitfile=../tmp/test-results/cannon-64.xml --jsonfile=../tmp/testlogs/log-64.json \
             -- -timeout=$TIMEOUT -parallel=$(nproc) -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage-64.out ./...
           working_directory: cannon
-      - codecov/upload:
-          disable_search: true
-          files: ./cannon/coverage-64.out
-          flags: cannon-go-tests-64
       - store_test_results:
           path: ./tmp/test-results
       - store_artifacts:
@@ -1247,10 +1242,6 @@ jobs:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
           working_directory: packages/contracts-bedrock
           when: on_fail
-      - codecov/upload:
-          disable_search: true
-          files: ./packages/contracts-bedrock/lcov-all.info
-          flags: contracts-bedrock-tests
       - save_cache:
           name: Save forked state
           key: forked-state-contracts-bedrock-tests-upgrade-{{ checksum "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
@@ -1870,9 +1861,6 @@ jobs:
             <<parameters.environment_overrides>>
             export TEST_TIMEOUT=<<parameters.test_timeout>>
             just go-tests-fraud-proofs-ci
-      - codecov/upload:
-          disable_search: true
-          files: ./coverage.out
       - store_test_results:
           path: ./tmp/test-results
       - run:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -6,7 +6,6 @@ version: 2.1
 orbs:
   utils: ethereum-optimism/circleci-utils@1.0.27
   gcp-cli: circleci/gcp-cli@3.0.1
-  codecov: codecov/codecov@5.0.3
 
 parameters:
   c-default_docker_image:
@@ -849,10 +848,6 @@ jobs:
           no_output_timeout: 40m
           command: |
             just llvm-cov-tests
-      - codecov/upload:
-          disable_search: true
-          files: rust/kona/lcov.info
-          flags: unit
       - rust-save-build-cache: *kona-coverage-cache
 
   # Kona Link Checker

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -315,7 +315,7 @@ commands:
     description: "Install zstd compression utility"
     steps:
       - apt-install:
-          packages: "zstd=1.4.8*"
+          packages: "zstd"
 
   gcp-oidc-authenticate:
     description: "Authenticate with GCP using a CircleCI OIDC token."

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -713,6 +713,7 @@ jobs:
             git stash || true
             git fetch origin $BASE_BRANCH
             git checkout origin/$BASE_BRANCH
+            git submodule update --init superchain-registry
 
             # Generate vectors on base
             cargo run --bin op-reth --features "dev" --manifest-path rust/op-reth/bin/Cargo.toml -- test-vectors compact --write

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	opbindings "github.com/ethereum-optimism/optimism/op-e2e/bindings"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
@@ -114,11 +116,18 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 			require.NoError(t, err)
 			proxyAdmin, err := standard.SuperchainProxyAdminAddrFor(l1ChainID)
 			require.NoError(t, err)
+			proxyAdminContract, err := opbindings.NewProxyAdmin(proxyAdmin, client)
+			require.NoError(t, err)
+			superchainConfigImpl, err := proxyAdminContract.GetProxyImplementation(
+				&bind.CallOpts{Context: ctx},
+				superCfg.SuperchainConfigAddr,
+			)
+			require.NoError(t, err)
 
 			expDeployment := &addresses.SuperchainContracts{
 				SuperchainProxyAdminImpl: proxyAdmin,
 				SuperchainConfigProxy:    superCfg.SuperchainConfigAddr,
-				SuperchainConfigImpl:     common.HexToAddress("0xb08Cc720F511062537ca78BdB0AE691F04F5a957"),
+				SuperchainConfigImpl:     superchainConfigImpl,
 			}
 
 			// Tagged locator will reuse the existing superchain and OPCM

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12725,13 +12725,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "munge",
  "ptr_meta",
@@ -12744,9 +12744,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14005,7 +14005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -14,6 +14,9 @@ ignore = [
   "RUSTSEC-2024-0436",
   # bincode is unmaintained but still functional; transitive dep from reth-nippy-jar and test-fuzz.
   "RUSTSEC-2025-0141",
+  # proc-macro-error2 is unmaintained (no vulnerability, no patched release exists).
+  # Build-time-only dep via alloy-sol-macro; latest alloy-core still pins it.
+  "RUSTSEC-2026-0173",
 ]
 
 # This section is considered when running `cargo deny check bans`.

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -17,6 +17,12 @@ ignore = [
   # proc-macro-error2 is unmaintained (no vulnerability, no patched release exists).
   # Build-time-only dep via alloy-sol-macro; latest alloy-core still pins it.
   "RUSTSEC-2026-0173",
+  # hickory-proto <0.26.1 NSEC3 closest-encloser DNSSEC validation unbounded loop;
+  # transitive via reth-network -> reth-dns-discovery. Pending upstream bump.
+  "RUSTSEC-2026-0118",
+  # hickory-proto <0.26.1 O(n^2) name-compression CPU exhaustion in BinEncoder;
+  # transitive via reth-network -> reth-dns-discovery. Pending upstream bump.
+  "RUSTSEC-2026-0119",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
cimg/base:2026.03 (Ubuntu Noble) ships zstd 1.5.5, not 1.4.8. The version pin caused apt to fail with exit 100 on every publish-contract-artifacts-on-tag run since rc.4.

Matches the fix already on develop (`35df2da78e`).