### PR TITLE
fix(op-node): tolerate EL-expired genesis history during L2 config validation

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -538,7 +538,7 @@ func initL2(ctx context.Context, cfg *config.Config, node *OpNode) (*sources.Eng
 		return nil, nil, nil, fmt.Errorf("failed to create Engine client: %w", err)
 	}
 
-	if err := cfg.Rollup.ValidateL2Config(ctx, l2Source, cfg.Sync.SyncMode == sync.ELSync); err != nil {
+	if err := cfg.Rollup.ValidateL2Config(ctx, node.log, l2Source, cfg.Sync.SyncMode == sync.ELSync); err != nil {
 		return nil, nil, nil, err
 	}
 

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -17,7 +17,13 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 )
+
+// historyPrunedErrCode is the JSON-RPC error code an execution engine returns when the requested
+// block predates its earliest retained history (EIP-4444 history expiry). reth returns this for
+// any block below its earliest available history height.
+const historyPrunedErrCode = 4444
 
 var (
 	ErrBlockTimeZero                 = errors.New("block time cannot be 0")
@@ -192,7 +198,7 @@ func (cfg *Config) ValidateL1Config(ctx context.Context, logger log.Logger, clie
 }
 
 // ValidateL2Config checks L2 config variables for errors.
-func (cfg *Config) ValidateL2Config(ctx context.Context, client L2Client, skipL2GenesisBlockHash bool) error {
+func (cfg *Config) ValidateL2Config(ctx context.Context, logger log.Logger, client L2Client, skipL2GenesisBlockHash bool) error {
 	// Validate the L2 Client Chain ID
 	if err := cfg.CheckL2ChainID(ctx, client); err != nil {
 		return err
@@ -202,7 +208,7 @@ func (cfg *Config) ValidateL2Config(ctx context.Context, client L2Client, skipL2
 	if skipL2GenesisBlockHash {
 		return nil
 	}
-	if err := cfg.CheckL2GenesisBlockHash(ctx, client); err != nil {
+	if err := cfg.CheckL2GenesisBlockHash(ctx, logger, client); err != nil {
 		return err
 	}
 
@@ -282,15 +288,29 @@ func (cfg *Config) CheckL2ChainID(ctx context.Context, client L2Client) error {
 }
 
 // CheckL2GenesisBlockHash checks that the configured L2 genesis block hash is valid for the given client.
-func (cfg *Config) CheckL2GenesisBlockHash(ctx context.Context, client L2Client) error {
+func (cfg *Config) CheckL2GenesisBlockHash(ctx context.Context, logger log.Logger, client L2Client) error {
 	l2GenesisBlockRef, err := client.L2BlockRefByNumber(ctx, cfg.Genesis.L2.Number)
 	if err != nil {
+		// The execution engine may no longer retain the genesis block, either because it was never
+		// found or because history expiry has pruned it. The genesis block hash is fully determined
+		// by the rollup config, so accept the configured value rather than failing initialization.
+		if errors.Is(eth.MaybeAsNotFoundErr(err), ethereum.NotFound) || isHistoryPrunedErr(err) {
+			logger.Warn("L2 genesis block not retained by execution engine, skipping validity check", "err", err)
+			return nil
+		}
 		return fmt.Errorf("failed to get L2 genesis blockhash: %w", err)
 	}
 	if l2GenesisBlockRef.Hash != cfg.Genesis.L2.Hash {
 		return fmt.Errorf("incorrect L2 genesis block hash %s, expected %s", l2GenesisBlockRef.Hash, cfg.Genesis.L2.Hash)
 	}
 	return nil
+}
+
+// isHistoryPrunedErr reports whether err is the JSON-RPC error an execution engine returns when the
+// requested block has been pruned by history expiry (see historyPrunedErrCode).
+func isHistoryPrunedErr(err error) bool {
+	var rpcErr rpc.Error
+	return errors.As(err, &rpcErr) && rpcErr.ErrorCode() == historyPrunedErrCode
 }
 
 // Check verifies that the given configuration makes sense

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -378,6 +379,7 @@ func TestActivations(t *testing.T) {
 type mockL2Client struct {
 	chainID *big.Int
 	Hash    common.Hash
+	err     error
 }
 
 func (m *mockL2Client) ChainID(context.Context) (*big.Int, error) {
@@ -385,11 +387,21 @@ func (m *mockL2Client) ChainID(context.Context) (*big.Int, error) {
 }
 
 func (m *mockL2Client) L2BlockRefByNumber(ctx context.Context, number uint64) (eth.L2BlockRef, error) {
+	if m.err != nil {
+		return eth.L2BlockRef{}, m.err
+	}
 	return eth.L2BlockRef{
 		Hash:   m.Hash,
 		Number: 100,
 	}, nil
 }
+
+// historyPrunedRPCError implements rpc.Error with the EIP-4444 history-pruned error code,
+// matching what an execution engine with history expiry returns for an expired block.
+type historyPrunedRPCError struct{}
+
+func (historyPrunedRPCError) Error() string  { return "pruned history unavailable" }
+func (historyPrunedRPCError) ErrorCode() int { return historyPrunedErrCode }
 
 func TestValidateL2Config(t *testing.T) {
 	config := randConfig()
@@ -397,7 +409,7 @@ func TestValidateL2Config(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x01}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL2Config(context.TODO(), &mockClient, false)
+	err := config.ValidateL2Config(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient, false)
 	assert.NoError(t, err)
 }
 
@@ -407,10 +419,10 @@ func TestValidateL2ConfigInvalidChainIdFails(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x01}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL2Config(context.TODO(), &mockClient, false)
+	err := config.ValidateL2Config(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient, false)
 	assert.Error(t, err)
 	config.L2ChainID = big.NewInt(99)
-	err = config.ValidateL2Config(context.TODO(), &mockClient, false)
+	err = config.ValidateL2Config(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient, false)
 	assert.Error(t, err)
 }
 
@@ -420,10 +432,10 @@ func TestValidateL2ConfigInvalidGenesisHashFails(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x00}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL2Config(context.TODO(), &mockClient, false)
+	err := config.ValidateL2Config(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient, false)
 	assert.Error(t, err)
 	config.Genesis.L2.Hash = [32]byte{0x02}
-	err = config.ValidateL2Config(context.TODO(), &mockClient, false)
+	err = config.ValidateL2Config(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient, false)
 	assert.Error(t, err)
 }
 
@@ -433,10 +445,10 @@ func TestValidateL2ConfigInvalidGenesisHashSkippedWhenRequested(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x00}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL2Config(context.TODO(), &mockClient, true)
+	err := config.ValidateL2Config(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient, true)
 	assert.NoError(t, err)
 	config.Genesis.L2.Hash = [32]byte{0x02}
-	err = config.ValidateL2Config(context.TODO(), &mockClient, true)
+	err = config.ValidateL2Config(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient, true)
 	assert.NoError(t, err)
 }
 
@@ -456,13 +468,29 @@ func TestCheckL2BlockRefByNumber(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x01}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.CheckL2GenesisBlockHash(context.TODO(), &mockClient)
+	err := config.CheckL2GenesisBlockHash(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient)
 	assert.NoError(t, err)
 	mockClient.Hash = common.Hash{0x02}
-	err = config.CheckL2GenesisBlockHash(context.TODO(), &mockClient)
+	err = config.CheckL2GenesisBlockHash(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient)
 	assert.Error(t, err)
 	mockClient.Hash = common.Hash{0x00}
-	err = config.CheckL2GenesisBlockHash(context.TODO(), &mockClient)
+	err = config.CheckL2GenesisBlockHash(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient)
+	assert.Error(t, err)
+
+	// A history-pruned execution engine can no longer serve the genesis block; the configured
+	// genesis hash is authoritative, so the check is skipped rather than failing.
+	mockClient = mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}, err: historyPrunedRPCError{}}
+	err = config.CheckL2GenesisBlockHash(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient)
+	assert.NoError(t, err)
+
+	// A NotFound result is likewise tolerated.
+	mockClient = mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}, err: ethereum.NotFound}
+	err = config.CheckL2GenesisBlockHash(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient)
+	assert.NoError(t, err)
+
+	// Any other fetch error still fails the check.
+	mockClient = mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}, err: errors.New("connection refused")}
+	err = config.CheckL2GenesisBlockHash(context.TODO(), testlog.Logger(t, log.LvlInfo), &mockClient)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
## Problem

Fixes #21584.

After upgrading op-reth from v2.3.1 to v2.3.2, op-node fails to initialize under consensus-layer sync:

```
failed to init L2: failed to get L2 genesis blockhash: failed to determine L2BlockRef of height 0,
could not get payload: pruned history unavailable
```

### Root cause

op-reth v2.3.2 bumped its upstream `reth` dependency from rev `7680d6d8` to tag `v2.3.0`. That bump pulled in reth PR [#24760](https://github.com/paradigmxyz/reth/pull/24760) ("fix(provider): reject expired recovered blocks"), which added an unconditional history-expiry guard to `DatabaseProvider::recovered_block`:

```rust
let earliest_available = self.static_file_provider.earliest_history_height();
if block_number < earliest_available {
    return Err(ProviderError::BlockExpired { requested: block_number, earliest_available })
}
```

`eth_getBlockByNumber` resolves blocks through `recovered_block` (sender recovery for the `from` field), so on a **pruned EL** — one whose lowest retained `Transactions` static-file jar starts above block 0 — `eth_getBlockByNumber("0x0")` now returns RPC error `4444` instead of the genesis block. (The prior `block()` guard, present since v2.3.1, never affected this path, which is why v2.3.1 worked.)

`earliest_history_height` exceeds 0 whenever the operator runs with transaction-body/history pruning (reth's `bodies_history` prune config / a full node): once the tip passes the first ~500k-block static-file jar plus the prune distance, the pruner deletes the genesis-containing jar as a unit. The genesis transactions are legitimately gone — this is not an op-reth bug.

## Fix

The genesis block hash is fully determined by the rollup config, so op-node should not require the EL to retain genesis history. When `CheckL2GenesisBlockHash` cannot fetch genesis — either `ethereum.NotFound` or the history-pruned RPC code (`4444`) — it now logs a warning and accepts the configured genesis hash rather than failing init. This mirrors the existing `CheckL1GenesisBlockHash` behavior, which already tolerates an unavailable L1 genesis block.

- Threaded a logger through `ValidateL2Config` / `CheckL2GenesisBlockHash` to match the L1 sibling's `(ctx, logger, client, …)` signature.
- Real fetch errors (e.g. connection failures) still fail the check.

Scope note: init only needs the genesis block, which this handles. `FindL2Heads` also fetches blocks from the EL, but on a node old enough to have pruned past the first jar it stops within ~a sequence window of the tip, well short of the expired range.

## Testing

`TestCheckL2BlockRefByNumber` extended with three cases: history-pruned → accept, `NotFound` → accept, other error → fail. Full `op-node/rollup` package suite passes; build, `gofmt`, and `vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)