### PR TITLE
test(contracts): fix OptimismMintableERC20Factory CREATE2 prediction across compiler profiles

### DIFF
--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
@@ -12,6 +12,7 @@ import { OptimismMintableERC20Factory } from "src/universal/OptimismMintableERC2
 
 // Libraries
 import { SemverComp } from "src/libraries/SemverComp.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Interfaces
 import { IProxy } from "interfaces/universal/IProxy.sol";
@@ -35,7 +36,7 @@ abstract contract OptimismMintableERC20Factory_TestInit is CommonTest {
         returns (address)
     {
         bytes memory constructorArgs = abi.encode(address(l2StandardBridge), _remote, _name, _symbol, _decimals);
-        bytes memory bytecode = abi.encodePacked(type(OptimismMintableERC20).creationCode, constructorArgs);
+        bytes memory bytecode = abi.encodePacked(DeployUtils.getCode("OptimismMintableERC20"), constructorArgs);
         bytes32 salt = keccak256(abi.encode(_remote, _name, _symbol, _decimals));
         bytes32 hash = keccak256(
             abi.encodePacked(bytes1(0xff), address(l2OptimismMintableERC20Factory), salt, keccak256(bytecode))


### PR DESCRIPTION
## Problem

All five `contracts-bedrock-tests` CI variants (`main`, `ZK_DISPUTE_GAME`, `SUPER_ROOT_GAMES_MIGRATION`, `OPTIMISM_PORTAL_INTEROP`, `CUSTOM_GAS_TOKEN`) fail on the same three fuzz tests in `test/universal/OptimismMintableERC20Factory.t.sol`:

- `testFuzz_createStandardL2Token_validParams_succeeds`
- `testFuzz_createOptimismMintableERC20WithDecimals_validParams_succeeds`
- `testFuzz_createOptimismMintableERC20_validParams_succeeds`

Each fails with `log != expected log` (`runs: 0`), i.e. a `vm.expectEmit` mismatch, even on trivial inputs.

## Root cause

The `_calculateTokenAddress` helper predicts the child token's CREATE2 address using `type(OptimismMintableERC20).creationCode`. The deployer, salt, and constructor `bridge` arg all match the factory — the only divergence is the creation code itself:

- The test's compilation unit transitively imports dispute-restricted contracts (`...t.sol` → `CommonTest` → `Setup` → `DisputeGames.sol`). `type(C).creationCode` embeds `OptimismMintableERC20` as a subobject compiled with the **referencing unit's** optimizer settings, so it resolves to the **dispute profile** (`optimizer_runs = 5000`).
- L2 genesis etches the factory predeploy from the **default-profile** artifact (`optimizer_runs = 999999`).

Different creation code → different keccak → predicted address ≠ the address the factory actually deploys → the `expectEmit` checks fail.

This was triggered by #21477 ("l2genesis: integrate l2cm"), which routed predeploy code through `DeployUtils.getDeployedCode` (pinning the default-profile artifact). Verified by bisect: the three tests pass on the parent commit and fail at #21477. The predeploy side is correct — production genesis should use the default profile — so the test's prediction is the side to fix.

## Fix

Use `DeployUtils.getCode("OptimismMintableERC20")`, which pins the default-profile artifact (the same code genesis uses), instead of `type(...).creationCode`. This matches the existing pattern in `test/L2/OptimismMintableERC721Factory.t.sol`.

## Verification

With the CI-pinned forge 1.2.3, the three tests pass in both default and feature (`DEV_FEATURE__L2CM=true DEV_FEATURE__ZK_DISPUTE_GAME=true`) configurations (64 runs each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)