### PR TITLE
fix(op-reth): drain Prometheus metric buckets in op-proofs CLI

### DIFF
--- a/rust/op-reth/crates/cli/src/commands/op_proofs/mod.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/mod.rs
@@ -3,6 +3,7 @@
 use clap::{Parser, Subcommand};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::CliNodeTypes;
+use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
 use std::sync::Arc;
@@ -26,6 +27,13 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> Command<C> {
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {
+        // Drain the Prometheus recorder's per-metric `AtomicBucket`s on a 5s tick.
+        // The buckets are append-only; without this, `reth_trie::trie::StateRoot::calculate`
+        // (run per backfilled/initialized block) leaks ~3 KB/block via histogram observations
+        // and OOMs on chain-sized runs. See paradigmxyz/reth#12664. op-proofs subcommands have no endpoint, so
+        // we spawn upkeep here directly. Idempotent — safe under repeated invocation.
+        install_prometheus_recorder().spawn_upkeep();
+
         match self.command {
             Subcommands::Init(cmd) => cmd.execute::<N>(runtime).await,
             Subcommands::Backfill(cmd) => cmd.execute::<N>(runtime).await,

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/mod.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/mod.rs
@@ -30,8 +30,9 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> Command<C> {
         // Drain the Prometheus recorder's per-metric `AtomicBucket`s on a 5s tick.
         // The buckets are append-only; without this, `reth_trie::trie::StateRoot::calculate`
         // (run per backfilled/initialized block) leaks ~3 KB/block via histogram observations
-        // and OOMs on chain-sized runs. See paradigmxyz/reth#12664. op-proofs subcommands have no endpoint, so
-        // we spawn upkeep here directly. Idempotent — safe under repeated invocation.
+        // and OOMs on chain-sized runs. See paradigmxyz/reth#12664. op-proofs subcommands have no
+        // endpoint, so we spawn upkeep here directly. Idempotent — safe under repeated
+        // invocation.
         install_prometheus_recorder().spawn_upkeep();
 
         match self.command {


### PR DESCRIPTION
**Description**

During a 1.2 M-block backfill the process RSS grew unboundedly. `AtomicBucket` is the in-memory buffer behind every Prometheus histogram emitted by the trie code; it grows on every observation and is only drained by `PrometheusHandle::run_upkeep()`. paradigmxyz/reth#12283 tracked the same symptom in the node binary and was closed by paradigmxyz/reth#12664, which introduced `spawn_upkeep()` and called it from `start_prometheus_endpoint`. `op-proofs` never reaches that path, so the fix in reth didn't take effect for it.

**Tests**

- [ ] Testing on mainnet

**Additional context**

NA

**Metadata**

Closes #21569 