### PR TITLE
fix(op-preimage): preserve read and write close errors

### DIFF
--- a/op-preimage/filechan.go
+++ b/op-preimage/filechan.go
@@ -46,10 +46,10 @@ func (rw *ReadWritePair) Writer() *os.File {
 func (rw *ReadWritePair) Close() error {
 	var combinedErr error
 	if err := rw.r.Close(); err != nil {
-		combinedErr = errors.Join(fmt.Errorf("failed to close reader: %w", err))
+		combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to close reader: %w", err))
 	}
 	if err := rw.w.Close(); err != nil {
-		combinedErr = errors.Join(fmt.Errorf("failed to close writer: %w", err))
+		combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to close writer: %w", err))
 	}
 	return combinedErr
 }

--- a/op-preimage/filechan_test.go
+++ b/op-preimage/filechan_test.go
@@ -1,0 +1,25 @@
+package preimage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadWritePairCloseJoinsReaderAndWriterErrors(t *testing.T) {
+	reader, err := os.CreateTemp(t.TempDir(), "reader")
+	require.NoError(t, err)
+	writer, err := os.CreateTemp(t.TempDir(), "writer")
+	require.NoError(t, err)
+
+	require.NoError(t, reader.Close())
+	require.NoError(t, writer.Close())
+
+	err = NewReadWritePair(reader, writer).Close()
+	require.Error(t, err)
+
+	errMsg := err.Error()
+	require.Contains(t, errMsg, "failed to close reader")
+	require.Contains(t, errMsg, "failed to close writer")
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Fixes `ReadWritePair.Close` so it preserves close errors from both the reader and writer.

Previously, if closing both files failed, the writer close error replaced the reader close error. This change joins each close error into the accumulated error so callers can see both failures.



**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

- `go test ./op-preimage`
- `git diff --check`
- 

**Additional context**

<!--
Add any other context about the problem you're solving.
-->


This is a small, focused fix with a regression test. It follows the same low-risk pattern as #21480: narrow scope, clear motivation, and simple local verification.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
