### PR TITLE
feat(op-deployer): depset and prestate gen

### DIFF
--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -30,6 +30,7 @@ const (
 	VerifierTypeFlagName     = flags.VerifierTypeFlagName
 	VerifierUrlFlagName      = flags.VerifierUrlFlagName
 	UseForgeFlagName         = flags.UseForgeFlagName
+	PrestateFlagName         = flags.PrestateFlagName
 )
 
 var (
@@ -136,6 +137,13 @@ var (
 		EnvVars: PrefixEnvVar("USE_FORGE"),
 		Value:   false,
 	}
+	PrestateFlag = &cli.StringFlag{
+		Name: PrestateFlagName,
+		Usage: "absolute prestate hash for the fault dispute game. When set, it is written to state for " +
+			"every chain, taking precedence over any faultGameAbsolutePrestate intent override. " +
+			"Required for permissionless game types.",
+		EnvVars: PrefixEnvVar("DISPUTE_ABSOLUTE_PRESTATE"),
+	}
 )
 
 var GlobalFlags = append([]cli.Flag{CacheDirFlag}, oplog.CLIFlags(EnvVarPrefix)...)
@@ -151,6 +159,7 @@ var PrepareFlags = []cli.Flag{
 	WorkdirFlag,
 	PrivateKeyFlag,
 	L1RPCURLFlag,
+	PrestateFlag,
 }
 
 var ApplyFlags = []cli.Flag{

--- a/op-deployer/pkg/deployer/flags/names.go
+++ b/op-deployer/pkg/deployer/flags/names.go
@@ -24,6 +24,7 @@ const (
 	VerifierTypeFlagName     = "verifier"
 	VerifierUrlFlagName      = "verifier-url"
 	UseForgeFlagName         = "use-forge"
+	PrestateFlagName         = "dispute-absolute-prestate"
 )
 
 func DefaultCacheDir() string {

--- a/op-deployer/pkg/deployer/pipeline/interop_depset.go
+++ b/op-deployer/pkg/deployer/pipeline/interop_depset.go
@@ -9,17 +9,23 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
+// BuildInteropDepSet builds the interop dependency set for the given chains. It is
+// shared between the legacy apply pipeline and the prepare flow so both produce the
+// same depset.
+func BuildInteropDepSet(chains []*state.ChainIntent) (*depset.StaticConfigDependencySet, error) {
+	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
+	for _, chain := range chains {
+		id := eth.ChainIDFromBytes32(chain.ID)
+		deps[id] = &depset.StaticConfigDependency{}
+	}
+	return depset.NewStaticConfigDependencySet(deps)
+}
+
 func GenerateInteropDepset(_ context.Context, pEnv *Env, globalIntent *state.Intent, st *state.State) error {
 	lgr := pEnv.Logger.New("stage", "generate-interop-depset")
 
 	lgr.Info("Creating interop dependency set...")
-	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
-	for _, chain := range globalIntent.Chains {
-		id := eth.ChainIDFromBytes32(chain.ID)
-		deps[id] = &depset.StaticConfigDependency{}
-	}
-
-	interopDepSet, err := depset.NewStaticConfigDependencySet(deps)
+	interopDepSet, err := BuildInteropDepSet(globalIntent.Chains)
 	if err != nil {
 		return fmt.Errorf("failed to create interop dependency set: %w", err)
 	}

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"strings"
 
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
@@ -16,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -38,8 +40,13 @@ type PrepareConfig struct {
 	L1RPCUrl string
 	// CacheDir is where downloaded artifacts are cached.
 	CacheDir string
+	// Prestate is the absolute prestate hash to write to state. When set it takes
+	// precedence over any faultGameAbsolutePrestate intent override. It may be empty,
+	// in which case the prestate is resolved from the intent (if present at all).
+	Prestate string
 
 	privateKeyECDSA *ecdsa.PrivateKey
+	prestate        common.Hash
 }
 
 func (c *PrepareConfig) Check() error {
@@ -62,6 +69,14 @@ func (c *PrepareConfig) Check() error {
 
 	if c.L1RPCUrl == "" {
 		return fmt.Errorf("l1 RPC URL must be specified")
+	}
+
+	if c.Prestate != "" {
+		prestate := common.HexToHash(c.Prestate)
+		if prestate == (common.Hash{}) {
+			return fmt.Errorf("prestate must be a non-zero hash, got %q", c.Prestate)
+		}
+		c.prestate = prestate
 	}
 
 	return nil
@@ -88,6 +103,7 @@ func newPrepareConfig(cliCtx *cli.Context, l log.Logger) PrepareConfig {
 		PrivateKey: cliCtx.String(PrivateKeyFlagName),
 		L1RPCUrl:   cliCtx.String(L1RPCURLFlagName),
 		CacheDir:   cliCtx.String(CacheDirFlagName),
+		Prestate:   cliCtx.String(PrestateFlagName),
 	}
 }
 
@@ -145,7 +161,32 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 		return fmt.Errorf("failed to load DeployOPChain script: %w", err)
 	}
 
+	interopDepSet, err := pipeline.BuildInteropDepSet(intent.Chains)
+	if err != nil {
+		return fmt.Errorf("failed to build interop dependency set: %w", err)
+	}
+	st.InteropDepSet = interopDepSet
+
 	for _, chain := range intent.Chains {
+		// Resolve the absolute prestate and enforce the permissionless gate before
+		// predicting, so a misconfigured chain fails fast. A permissionless game type
+		// requires a resolved prestate; a permissioned-only chain may leave it unset.
+		prestate, err := resolvePrestate(cfg.prestate, intent, chain)
+		if err != nil {
+			return fmt.Errorf("failed to resolve prestate for chain %s: %w", chain.ID.Hex(), err)
+		}
+
+		permissionless, err := isPermissionlessDeployment(intent, chain)
+		if err != nil {
+			return fmt.Errorf("failed to resolve game type for chain %s: %w", chain.ID.Hex(), err)
+		}
+		if permissionless && prestate == (common.Hash{}) {
+			return fmt.Errorf(
+				"chain %s enables a permissionless game type but no prestate was resolved; pass --%s or set the %s intent override",
+				chain.ID.Hex(), PrestateFlagName, faultGameAbsolutePrestateKey,
+			)
+		}
+
 		dci, err := makePredictionInput(intent, st, chain)
 		if err != nil {
 			return fmt.Errorf("failed to build prediction input for chain %s: %w", chain.ID.Hex(), err)
@@ -158,6 +199,11 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 
 		// Record the predicted addresses into the chain state marked as not deployed yet.
 		st.SetChainContracts(chain.ID, pipeline.OpChainContractsFromDeployOutput(out), false)
+
+		if prestate != (common.Hash{}) {
+			st.SetChainPrestate(chain.ID, prestate)
+			cfg.Logger.Info("resolved prestate", "chain", chain.ID.Hex(), "prestate", prestate)
+		}
 
 		cfg.Logger.Info(
 			"predicted L1 addresses",
@@ -176,6 +222,63 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 	}
 
 	return nil
+}
+
+// faultGameAbsolutePrestateKey is the deploy-override key that carries the absolute
+// prestate in the intent. It matches the json/toml tag of ChainProofParams.DisputeAbsolutePrestate.
+const faultGameAbsolutePrestateKey = "faultGameAbsolutePrestate"
+
+// isPermissionlessDeployment reports whether the chain's resolved respected game type
+// runs a permissionless fault dispute game (which requires a real absolute prestate).
+// The game type is resolved from the standard default merged with the intent overrides,
+// matching how the deploy resolves it.
+func isPermissionlessDeployment(intent *state.Intent, chain *state.ChainIntent) (bool, error) {
+	proofParams, err := jsonutil.MergeJSON(
+		state.ChainProofParams{DisputeGameType: standard.DisputeGameType},
+		intent.GlobalDeployOverrides,
+		chain.DeployOverrides,
+	)
+	if err != nil {
+		return false, fmt.Errorf("error merging proof params from overrides: %w", err)
+	}
+	return isPermissionlessGameType(proofParams.DisputeGameType), nil
+}
+
+func isPermissionlessGameType(gameType uint32) bool {
+	switch gameTypes.GameType(gameType) {
+	case gameTypes.PermissionedGameType, gameTypes.SuperPermissionedGameType:
+		return false
+	default:
+		return true
+	}
+}
+
+// resolvePrestate resolves the absolute prestate for a chain. A non-zero flag value
+// takes precedence; otherwise it looks for a faultGameAbsolutePrestate override on the
+// chain first and then the global overrides. It returns the zero hash when no prestate
+// is declared anywhere, which is valid for permissioned-only deployments.
+func resolvePrestate(flagPrestate common.Hash, intent *state.Intent, chain *state.ChainIntent) (common.Hash, error) {
+	if flagPrestate != (common.Hash{}) {
+		return flagPrestate, nil
+	}
+
+	for _, overrides := range []map[string]any{chain.DeployOverrides, intent.GlobalDeployOverrides} {
+		raw, ok := overrides[faultGameAbsolutePrestateKey]
+		if !ok {
+			continue
+		}
+		s, ok := raw.(string)
+		if !ok {
+			return common.Hash{}, fmt.Errorf("%s override must be a hex string, got %T", faultGameAbsolutePrestateKey, raw)
+		}
+		prestate := common.HexToHash(s)
+		if prestate == (common.Hash{}) {
+			return common.Hash{}, fmt.Errorf("%s override must be a non-zero hash, got %q", faultGameAbsolutePrestateKey, s)
+		}
+		return prestate, nil
+	}
+
+	return common.Hash{}, nil
 }
 
 // makePredictionInput builds the DeployOPChain input for the prediction dry-run.

--- a/op-deployer/pkg/deployer/prepare_test.go
+++ b/op-deployer/pkg/deployer/prepare_test.go
@@ -107,4 +107,105 @@ func TestPrepareConfigCheck(t *testing.T) {
 	missingL1RPC := valid
 	missingL1RPC.L1RPCUrl = ""
 	require.ErrorContains(t, missingL1RPC.Check(), "l1 RPC URL must be specified")
+
+	validPrestate := valid
+	validPrestate.Prestate = "0xabc123"
+	require.NoError(t, validPrestate.Check())
+	require.Equal(t, common.HexToHash("0xabc123"), validPrestate.prestate)
+
+	zeroPrestate := valid
+	zeroPrestate.Prestate = "0x0"
+	require.ErrorContains(t, zeroPrestate.Check(), "prestate must be a non-zero hash")
+}
+
+func TestResolvePrestate(t *testing.T) {
+	flagPrestate := common.HexToHash("0x1111")
+	chainOverride := common.HexToHash("0x2222")
+	globalOverride := common.HexToHash("0x3333")
+
+	chain := func(override *common.Hash) *state.ChainIntent {
+		c := &state.ChainIntent{ID: common.HexToHash("0x0a")}
+		if override != nil {
+			c.DeployOverrides = map[string]any{faultGameAbsolutePrestateKey: override.Hex()}
+		}
+		return c
+	}
+	intent := func(override *common.Hash) *state.Intent {
+		i := &state.Intent{}
+		if override != nil {
+			i.GlobalDeployOverrides = map[string]any{faultGameAbsolutePrestateKey: override.Hex()}
+		}
+		return i
+	}
+
+	t.Run("flag takes precedence over overrides", func(t *testing.T) {
+		got, err := resolvePrestate(flagPrestate, intent(&globalOverride), chain(&chainOverride))
+		require.NoError(t, err)
+		require.Equal(t, flagPrestate, got)
+	})
+
+	t.Run("chain override takes precedence over global", func(t *testing.T) {
+		got, err := resolvePrestate(common.Hash{}, intent(&globalOverride), chain(&chainOverride))
+		require.NoError(t, err)
+		require.Equal(t, chainOverride, got)
+	})
+
+	t.Run("falls back to global override", func(t *testing.T) {
+		got, err := resolvePrestate(common.Hash{}, intent(&globalOverride), chain(nil))
+		require.NoError(t, err)
+		require.Equal(t, globalOverride, got)
+	})
+
+	t.Run("returns zero when nothing is declared", func(t *testing.T) {
+		got, err := resolvePrestate(common.Hash{}, intent(nil), chain(nil))
+		require.NoError(t, err)
+		require.Equal(t, common.Hash{}, got)
+	})
+
+	t.Run("rejects non-string override", func(t *testing.T) {
+		i := &state.Intent{GlobalDeployOverrides: map[string]any{faultGameAbsolutePrestateKey: 123}}
+		_, err := resolvePrestate(common.Hash{}, i, chain(nil))
+		require.ErrorContains(t, err, "must be a hex string")
+	})
+
+	t.Run("rejects zero-hash override", func(t *testing.T) {
+		i := &state.Intent{GlobalDeployOverrides: map[string]any{faultGameAbsolutePrestateKey: "0x0"}}
+		_, err := resolvePrestate(common.Hash{}, i, chain(nil))
+		require.ErrorContains(t, err, "must be a non-zero hash")
+	})
+}
+
+func TestIsPermissionlessGameType(t *testing.T) {
+	require.False(t, isPermissionlessGameType(1)) // PermissionedGameType
+	require.False(t, isPermissionlessGameType(5)) // SuperPermissionedGameType
+	require.True(t, isPermissionlessGameType(0))  // CannonGameType
+	require.True(t, isPermissionlessGameType(8))  // CannonKonaGameType
+}
+
+func TestIsPermissionlessDeployment(t *testing.T) {
+	chain := &state.ChainIntent{ID: common.HexToHash("0x0a")}
+
+	t.Run("default is permissioned", func(t *testing.T) {
+		got, err := isPermissionlessDeployment(&state.Intent{}, chain)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("global override to cannon is permissionless", func(t *testing.T) {
+		intent := &state.Intent{GlobalDeployOverrides: map[string]any{"respectedGameType": uint32(0)}}
+		got, err := isPermissionlessDeployment(intent, chain)
+		require.NoError(t, err)
+		require.True(t, got)
+	})
+
+	t.Run("chain override takes precedence over global", func(t *testing.T) {
+		intent := &state.Intent{GlobalDeployOverrides: map[string]any{"respectedGameType": uint32(0)}}
+		permissionedChain := &state.ChainIntent{
+			ID:              common.HexToHash("0x0a"),
+			DeployOverrides: map[string]any{"respectedGameType": uint32(1)},
+		}
+		got, err := isPermissionlessDeployment(intent, permissionedChain)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
 }

--- a/op-deployer/pkg/deployer/state/state.go
+++ b/op-deployer/pkg/deployer/state/state.go
@@ -98,6 +98,12 @@ type ChainState struct {
 	// by the prediction step of the prepare command.
 	Deployed bool `json:"deployed"`
 
+	// Prestate is the absolute prestate hash resolved for this chain's fault dispute game.
+	// It is written by the prepare command (from a flag or intent override) and must be
+	// present before OPCM.deploy() when a permissionless game type is enabled. It is the
+	// zero hash when unset (e.g. permissioned-only deployments).
+	Prestate common.Hash `json:"prestate,omitempty"`
+
 	AdditionalDisputeGames []AdditionalDisputeGameState `json:"additionalDisputeGames"`
 
 	Allocs *GzipData[foundry.ForgeAllocs] `json:"allocs"`
@@ -121,6 +127,22 @@ func (s *State) SetChainContracts(id common.Hash, contracts addresses.OpChainCon
 		ID:               id,
 		OpChainContracts: contracts,
 		Deployed:         deployed,
+	})
+}
+
+// SetChainPrestate records the resolved absolute prestate for a chain. It creates
+// the chain entry if it does not exist and otherwise updates it in place, preserving
+// any other fields already set by other stages.
+func (s *State) SetChainPrestate(id common.Hash, prestate common.Hash) {
+	for _, chain := range s.Chains {
+		if chain.ID == id {
+			chain.Prestate = prestate
+			return
+		}
+	}
+	s.Chains = append(s.Chains, &ChainState{
+		ID:       id,
+		Prestate: prestate,
 	})
 }
 

--- a/op-deployer/pkg/deployer/state/state_test.go
+++ b/op-deployer/pkg/deployer/state/state_test.go
@@ -46,6 +46,32 @@ func TestState_SetChainContracts(t *testing.T) {
 	require.Equal(t, common.HexToHash("0xdead"), got.StartBlock.Hash)
 }
 
+func TestState_SetChainPrestate(t *testing.T) {
+	chainA := common.HexToHash("0x0a")
+	prestate := common.HexToHash("0xabc123")
+
+	s := &State{}
+
+	// Setting on an absent chain appends a new entry.
+	s.SetChainPrestate(chainA, prestate)
+	require.Len(t, s.Chains, 1)
+	require.Equal(t, prestate, s.Chains[0].Prestate)
+
+	// Setting on an existing chain updates in place and preserves other fields.
+	var contracts addresses.OpChainContracts
+	contracts.SystemConfigProxy = common.HexToAddress("0xa1")
+	s.SetChainContracts(chainA, contracts, false)
+	newPrestate := common.HexToHash("0xdef456")
+	s.SetChainPrestate(chainA, newPrestate)
+	require.Len(t, s.Chains, 1)
+	require.Equal(t, newPrestate, s.Chains[0].Prestate)
+	require.Equal(t, common.HexToAddress("0xa1"), s.Chains[0].SystemConfigProxy, "other fields must be preserved")
+
+	// SetChainContracts must preserve a previously set prestate.
+	s.SetChainContracts(chainA, contracts, true)
+	require.Equal(t, newPrestate, s.Chains[0].Prestate, "prestate must survive a contracts update")
+}
+
 func TestBlockRef_Deserialize(t *testing.T) {
 	tests := []struct {
 		name                 string


### PR DESCRIPTION
**Description**

Moves interop depset and prestate handling ahead of the OP chain deploy, as part of the new prepare path.

**Tests**

Unit tests covering the new logic:
- resolvePrestate — flag/chain-override/global-override precedence, zero/non-string rejection, and the unset case.
- isPermissionlessGameType / isPermissionlessDeployment — game-type classification and resolution from intent overrides.
- state.SetChainPrestate — create/update-in-place and prestate preservation across a SetChainContracts update.
- PrepareConfig.Check — validation of the prestate flag.

No end-to-end test of a full permissionless prepare run yet; the gate and resolution are covered at the unit level, and the real OPCM.deploy() broadcast step (where a defensive presence check will also live) is not built yet.

**Additional context**

The prestate hash must be available before OPCM.deploy() in the new flow, so depset + prestate are produced during prepare. This issue's scope is resolving and writing a supplied prestate (from intent or CLI) — not computing one; absolute-prestate generation remains separate tooling.

**Metadata**

- Fixes #20911
