### PR TITLE
fix(op-reth): install default rustls CryptoProvider for flashblocks TLS

### DIFF
--- a/rust/op-reth/bin/Cargo.toml
+++ b/rust/op-reth/bin/Cargo.toml
@@ -23,6 +23,7 @@ reth-node-builder.workspace = true
 reth-db.workspace = true
 
 clap = { workspace = true, features = ["derive", "env"] }
+rustls = { workspace = true, features = ["aws_lc_rs", "std"] }
 tracing.workspace = true
 eyre.workspace = true
 

--- a/rust/op-reth/bin/src/main.rs
+++ b/rust/op-reth/bin/src/main.rs
@@ -15,6 +15,13 @@ static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 fn main() {
     reth_cli_util::sigsegv_handler::install();
 
+    // rustls 0.23 no longer auto-selects a process-level CryptoProvider when
+    // multiple provider features are present in the dependency graph. Install one
+    // explicitly before any TLS is used (e.g. the flashblocks wss connection),
+    // otherwise op-reth panics on startup. See
+    // https://github.com/ethereum-optimism/optimism/issues/19322
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
     if std::env::var_os("RUST_BACKTRACE").is_none() {
         unsafe {


### PR DESCRIPTION
## Description

op-reth panics on startup when it opens the flashblocks websocket (`wss://`) connection:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

rustls 0.23 no longer auto-selects a process-level `CryptoProvider` when more than one provider feature is present in the dependency graph. The panic kills the flashblocks service, so pre-confirmation RPCs such as `eth_sendRawTransactionSync` never receive flashblocks and time out (~30s) even though the transaction is mined normally.

This installs the `aws-lc-rs` default provider in `main()` before any TLS is used, matching reth's default provider selection.

## Tests

Built op-reth with this patch and ran it against Unichain mainnet and sepolia. Confirmed:
- no `CryptoProvider` panic on startup
- the flashblocks websocket connects and flashblock metrics increment
- `eth_sendRawTransactionSync` returns within pre-confirmation latency instead of timing out after 30s

## Additional context

Same root cause and fix as #20145, which was auto-closed as stale. This variant uses the `aws-lc-rs` provider.

## Metadata

Fixes #19322