### PR TITLE
docs(node-from-docker): bump op-reth/op-node to Karst-mandatory versions

### DIFF
--- a/docs/public-docs/node-operators/tutorials/node-from-docker.mdx
+++ b/docs/public-docs/node-operators/tutorials/node-from-docker.mdx
@@ -70,7 +70,7 @@ This tutorial runs an OP Stack node using the **official op-reth and op-node Doc
     ```yaml
     services:
       op-reth:
-        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.2.5
+        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.3.3
         container_name: op-reth
         ports:
           - "8545:8545"          # JSON-RPC HTTP
@@ -99,7 +99,7 @@ This tutorial runs an OP Stack node using the **official op-reth and op-node Doc
         restart: unless-stopped
 
       op-node:
-        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.18.2
+        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.19.1
         container_name: op-node
         depends_on:
           - op-reth


### PR DESCRIPTION
Closes #21619

Updates the docker-compose example from `op-reth:v2.2.5` / `op-node:v1.18.2` to the current mandatory [Karst hardfork releases](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth%2Fv2.3.3) (`v2.3.3` / `v1.19.1`).