### PR TITLE
contracts-bedrock: handle disabled cannon fork state

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xb55a34bc040757b18629342340c9f5dea138e921b77fdf4a53d5b43cb01aec55",
-    "sourceCodeHash": "0x90df469615acb1d55af0a9774c2fb38763cde6948a76378b21ee6566e78da539"
+    "initCodeHash": "0x9a704de7a4137faa533a63249c02268512af5ed4e188d2e1057e3d75f3a550de",
+    "sourceCodeHash": "0xeceae49028d9f20fd3606cfe4fecfd076e24773c2c455df00292608f25f4a934"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x02f8cfb0213d614c34c12904f0d06b4f8fad14f7d127b3b780f9d5cc5ebba72a",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -46,8 +46,8 @@ import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 2.10.3
-    string public constant version = "2.10.3";
+    /// @custom:semver 2.10.4
+    string public constant version = "2.10.4";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;
@@ -944,16 +944,6 @@ contract OPContractsManagerStandardValidator is ISemver {
                 _input.proposer,
                 _overrides,
                 "PDDG"
-            );
-            _errors = assertValidPermissionlessDisputeGame(
-                _errors,
-                _input.sysCfg,
-                GameTypes.CANNON,
-                _input.cannonPrestate,
-                _input.l2ChainID,
-                _proxyAdmin,
-                _overrides,
-                "PLDG"
             );
             _errors = assertValidPermissionlessDisputeGame(
                 _errors,

--- a/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
@@ -185,6 +185,7 @@ contract StandardValidatorUtils {
         returns (string memory)
     {
         IDisputeGameFactory dgf = IDisputeGameFactory(_sysCfg.disputeGameFactory());
+        _errors = internalRequire(address(dgf.gameImpls(GameTypes.CANNON)) == address(0), "PLDG-NOSHAPE", _errors);
         _errors = internalRequire(address(dgf.gameImpls(GameTypes.SUPER_CANNON)) == address(0), "SCDG-NOSHAPE", _errors);
         _errors =
             internalRequire(address(dgf.gameImpls(GameTypes.SUPER_PERMISSIONED)) == address(0), "SPDG-NOSHAPE", _errors);

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -242,7 +242,7 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest {
 
         if (isL1ForkTest()) {
             // Load the FaultDisputeGame once, we'll need it later.
-            fdgImpl = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON)));
+            fdgImpl = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON_KONA)));
         } else {
             // Get the ProxyAdmin owner.
             address owner = proxyAdmin.owner();
@@ -253,10 +253,10 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest {
             IOPContractsManagerUtils.DisputeGameConfig[] memory disputeGameConfigs =
                 new IOPContractsManagerUtils.DisputeGameConfig[](6);
             disputeGameConfigs[0] = IOPContractsManagerUtils.DisputeGameConfig({
-                enabled: true,
-                initBond: DEFAULT_DISPUTE_GAME_INIT_BOND,
+                enabled: false,
+                initBond: 0,
                 gameType: GameTypes.CANNON,
-                gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonPrestate }))
+                gameArgs: hex""
             });
             disputeGameConfigs[1] = IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: true,
@@ -296,6 +296,12 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest {
                 gameType: GameTypes.ZK_DISPUTE_GAME,
                 gameArgs: hex""
             });
+            IOPContractsManagerUtils.ExtraInstruction[] memory extraInstructions =
+                new IOPContractsManagerUtils.ExtraInstruction[](1);
+            extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
+                key: "overrides.cfg.startingRespectedGameType",
+                data: abi.encode(GameTypes.CANNON_KONA)
+            });
 
             // Call upgrade to all games to be enabled.
             prankDelegateCall(owner);
@@ -306,7 +312,7 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest {
                         IOPContractsManagerV2.UpgradeInput({
                             systemConfig: systemConfig,
                             disputeGameConfigs: disputeGameConfigs,
-                            extraInstructions: new IOPContractsManagerUtils.ExtraInstruction[](0)
+                            extraInstructions: extraInstructions
                         })
                     )
                 )
@@ -314,7 +320,7 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest {
             assertTrue(success, "upgrade failed");
 
             // Grab the FaultDisputeGame implementation.
-            fdgImpl = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON)));
+            fdgImpl = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON_KONA)));
         }
     }
 
@@ -398,7 +404,7 @@ contract OPContractsManagerStandardValidator_GeneralOverride_Test is OPContracts
         overrides.l1PAOMultisig = address(0xace);
         overrides.challenger = address(0xbad);
         assertEq(
-            "OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,PROXYA-10,DF-30,PDDG-DWETH-30,PDDG-130,PLDG-DWETH-30,CKDG-DWETH-30",
+            "OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,PROXYA-10,DF-30,PDDG-DWETH-30,PDDG-130,CKDG-DWETH-30",
             _validateWithOverrides(true, overrides)
         );
     }
@@ -433,7 +439,7 @@ contract OPContractsManagerStandardValidator_GeneralOverride_Test is OPContracts
 
         vm.expectRevert(
             bytes(
-                "OPContractsManagerStandardValidator: OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,PROXYA-10,DF-30,PDDG-DWETH-30,PDDG-130,PLDG-DWETH-30,CKDG-DWETH-30"
+                "OPContractsManagerStandardValidator: OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,PROXYA-10,DF-30,PDDG-DWETH-30,PDDG-130,CKDG-DWETH-30"
             )
         );
 
@@ -466,7 +472,7 @@ contract OPContractsManagerStandardValidator_ProxyAdmin_Test is OPContractsManag
         vm.mockCall(
             address(delayedWeth), abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(address(0xbad))
         );
-        assertEq("PROXYA-10,PDDG-DWETH-30,PLDG-DWETH-30,CKDG-DWETH-30", _validate(true));
+        assertEq("PROXYA-10,PDDG-DWETH-30,CKDG-DWETH-30", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right overrides error
@@ -490,7 +496,7 @@ contract OPContractsManagerStandardValidator_ProxyAdmin_Test is OPContractsManag
         IOPContractsManagerStandardValidator.ValidationOverrides memory overrides = _defaultValidationOverrides();
         overrides.l1PAOMultisig = address(0xbad);
         assertEq(
-            "OVERRIDES-L1PAOMULTISIG,PROXYA-10,DF-30,PDDG-DWETH-30,PLDG-DWETH-30,CKDG-DWETH-30",
+            "OVERRIDES-L1PAOMULTISIG,PROXYA-10,DF-30,PDDG-DWETH-30,CKDG-DWETH-30",
             _validateWithOverrides(true, overrides)
         );
     }
@@ -987,6 +993,16 @@ contract OPContractsManagerStandardValidator_DisputeGameFactory_Test is OPContra
         assertEq("DF-50,PDDG-NOSHAPE,PDDG-10", _validate(true));
     }
 
+    /// @notice Tests that PLDG-NOSHAPE fires when CANNON has a registered impl in non-super mode.
+    function test_validate_nonSuperModeCannonRegistered_succeeds() public {
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.CANNON)),
+            abi.encode(address(0xdead))
+        );
+        assertEq("PLDG-NOSHAPE", _validate(true));
+    }
+
     /// @notice Tests that SCDG-NOSHAPE fires when SUPER_CANNON has a registered impl in non-super mode.
     function test_validate_nonSuperModeSuperCannonRegistered_succeeds() public {
         vm.mockCall(
@@ -1149,7 +1165,7 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
     ///         PermissionedDisputeGame VM's state version is invalid.
     function test_validate_permissionedDisputeGameInvalidVMStateVersion_succeeds() public {
         vm.mockCall(address(mips), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(6));
-        assertEq("PDDG-VM-30,PLDG-VM-30,CKDG-VM-30", _validate(true));
+        assertEq("PDDG-VM-30,CKDG-VM-30", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1211,7 +1227,7 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
             abi.encodeCall(IAnchorStateRegistry.getAnchorRoot, ()),
             abi.encode(bytes32(0), 1)
         );
-        assertEq("PDDG-120,PLDG-120,CKDG-120", _validate(true));
+        assertEq("PDDG-120,CKDG-120", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1260,7 +1276,7 @@ contract OPContractsManagerStandardValidator_AnchorStateRegistry_Test is
     ///         AnchorStateRegistry version is invalid.
     function test_validate_anchorStateRegistryInvalidVersion_succeeds() public {
         vm.mockCall(address(anchorStateRegistry), abi.encodeCall(ISemver.version, ()), abi.encode("0.0.1"));
-        assertEq("PDDG-ANCHORP-10,PLDG-ANCHORP-10,CKDG-ANCHORP-10", _validate(true));
+        assertEq("PDDG-ANCHORP-10,CKDG-ANCHORP-10", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1271,7 +1287,7 @@ contract OPContractsManagerStandardValidator_AnchorStateRegistry_Test is
             abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(anchorStateRegistry))),
             abi.encode(address(0xbad))
         );
-        assertEq("PDDG-ANCHORP-20,PLDG-ANCHORP-20,CKDG-ANCHORP-20", _validate(true));
+        assertEq("PDDG-ANCHORP-20,CKDG-ANCHORP-20", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1282,7 +1298,7 @@ contract OPContractsManagerStandardValidator_AnchorStateRegistry_Test is
             address(badDisputeGameFactoryReturner),
             abi.encodeCall(IAnchorStateRegistry.disputeGameFactory, ())
         );
-        assertEq("PDDG-ANCHORP-30,PLDG-ANCHORP-30,CKDG-ANCHORP-30", _validate(true));
+        assertEq("PDDG-ANCHORP-30,CKDG-ANCHORP-30", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1293,7 +1309,7 @@ contract OPContractsManagerStandardValidator_AnchorStateRegistry_Test is
             abi.encodeCall(IAnchorStateRegistry.systemConfig, ()),
             abi.encode(address(0xbad))
         );
-        assertEq("PDDG-ANCHORP-40,PLDG-ANCHORP-40,CKDG-ANCHORP-40", _validate(true));
+        assertEq("PDDG-ANCHORP-40,CKDG-ANCHORP-40", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1304,7 +1320,7 @@ contract OPContractsManagerStandardValidator_AnchorStateRegistry_Test is
             abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()),
             abi.encode(address(0xbad))
         );
-        assertEq("PDDG-ANCHORP-50,PLDG-ANCHORP-50,CKDG-ANCHORP-50", _validate(true));
+        assertEq("PDDG-ANCHORP-50,CKDG-ANCHORP-50", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1313,7 +1329,7 @@ contract OPContractsManagerStandardValidator_AnchorStateRegistry_Test is
         vm.mockCall(
             address(anchorStateRegistry), abi.encodeCall(IAnchorStateRegistry.retirementTimestamp, ()), abi.encode(0)
         );
-        assertEq("PDDG-ANCHORP-60,PLDG-ANCHORP-60,CKDG-ANCHORP-60", _validate(true));
+        assertEq("PDDG-ANCHORP-60,CKDG-ANCHORP-60", _validate(true));
     }
 }
 
@@ -1324,7 +1340,7 @@ contract OPContractsManagerStandardValidator_DelayedWETH_Test is OPContractsMana
     ///         DelayedWETH version is invalid.
     function test_validate_delayedWETHInvalidVersion_succeeds() public {
         vm.mockCall(address(delayedWeth), abi.encodeCall(ISemver.version, ()), abi.encode("0.0.1"));
-        assertEq("PDDG-DWETH-10,PLDG-DWETH-10,CKDG-DWETH-10", _validate(true));
+        assertEq("PDDG-DWETH-10,CKDG-DWETH-10", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1335,7 +1351,7 @@ contract OPContractsManagerStandardValidator_DelayedWETH_Test is OPContractsMana
             abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(delayedWeth))),
             abi.encode(address(0xbad))
         );
-        assertEq("PDDG-DWETH-20,PLDG-DWETH-20,CKDG-DWETH-20", _validate(true));
+        assertEq("PDDG-DWETH-20,CKDG-DWETH-20", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1344,21 +1360,21 @@ contract OPContractsManagerStandardValidator_DelayedWETH_Test is OPContractsMana
         vm.mockCall(
             address(delayedWeth), abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(address(0xbad))
         );
-        assertEq("PDDG-DWETH-30,PLDG-DWETH-30,CKDG-DWETH-30", _validate(true));
+        assertEq("PDDG-DWETH-30,CKDG-DWETH-30", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         DelayedWETH delay is invalid.
     function test_validate_delayedWETHInvalidDelay_succeeds() public {
         vm.mockCall(address(delayedWeth), abi.encodeCall(IDelayedWETH.delay, ()), abi.encode(1000));
-        assertEq("PDDG-DWETH-40,PLDG-DWETH-40,CKDG-DWETH-40", _validate(true));
+        assertEq("PDDG-DWETH-40,CKDG-DWETH-40", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         DelayedWETH systemConfig is invalid.
     function test_validate_delayedWETHInvalidSystemConfig_succeeds() public {
         vm.mockCall(address(delayedWeth), abi.encodeCall(IDelayedWETH.systemConfig, ()), abi.encode(address(0xbad)));
-        assertEq("PDDG-DWETH-50,PLDG-DWETH-50,CKDG-DWETH-50", _validate(true));
+        assertEq("PDDG-DWETH-50,CKDG-DWETH-50", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1367,7 +1383,7 @@ contract OPContractsManagerStandardValidator_DelayedWETH_Test is OPContractsMana
         vm.mockCall(
             address(delayedWeth), abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(address(0xbad))
         );
-        assertEq("PDDG-DWETH-60,PLDG-DWETH-60,CKDG-DWETH-60", _validate(true));
+        assertEq("PDDG-DWETH-60,CKDG-DWETH-60", _validate(true));
     }
 }
 
@@ -1378,38 +1394,27 @@ contract OPContractsManagerStandardValidator_PreimageOracle_Test is OPContractsM
     ///         PreimageOracle version is invalid.
     function test_validate_preimageOracleInvalidVersion_succeeds() public {
         vm.mockCall(address(preimageOracle), abi.encodeCall(ISemver.version, ()), abi.encode("0.0.1"));
-        assertEq("PDDG-PIMGO-10,PLDG-PIMGO-10,CKDG-PIMGO-10", _validate(true));
+        assertEq("PDDG-PIMGO-10,CKDG-PIMGO-10", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         PreimageOracle challengePeriod is invalid.
     function test_validate_preimageOracleInvalidChallengePeriod_succeeds() public {
         vm.mockCall(address(preimageOracle), abi.encodeCall(IPreimageOracle.challengePeriod, ()), abi.encode(1000));
-        assertEq("PDDG-PIMGO-20,PLDG-PIMGO-20,CKDG-PIMGO-20", _validate(true));
+        assertEq("PDDG-PIMGO-20,CKDG-PIMGO-20", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         PreimageOracle minProposalSize is invalid.
     function test_validate_preimageOracleInvalidMinProposalSize_succeeds() public {
         vm.mockCall(address(preimageOracle), abi.encodeCall(IPreimageOracle.minProposalSize, ()), abi.encode(1000));
-        assertEq("PDDG-PIMGO-30,PLDG-PIMGO-30,CKDG-PIMGO-30", _validate(true));
+        assertEq("PDDG-PIMGO-30,CKDG-PIMGO-30", _validate(true));
     }
 }
 
 /// @title OPContractsManagerStandardValidator_FaultDisputeGame_Test
 /// @notice Tests validation of `FaultDisputeGame` configuration
 contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContractsManagerStandardValidator_TestInit {
-    /// @notice Tests that the validate function successfully returns the right error when the
-    ///         FaultDisputeGame (permissionless) Cannon implementation is null.
-    function test_validate_faultDisputeGameNullCannonImplementation_succeeds() public {
-        vm.mockCall(
-            address(disputeGameFactory),
-            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.CANNON)),
-            abi.encode(address(0))
-        );
-        assertEq("PLDG-10", _validate(true));
-    }
-
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         FaultDisputeGame (permissionless) CannonKona implementation is null.
     function test_validate_faultDisputeGameNullCannonKonaImplementation_succeeds() public {
@@ -1428,17 +1433,7 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "faultDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        assertEq("PLDG-20,CKDG-20", _validate(true));
-    }
-
-    /// @notice Tests that the validate function successfully returns the right error when the
-    ///         FaultDisputeGame (permissionless) Cannon game args are invalid.
-    function test_validate_faultDisputeGameInvalidCannonGameArgs_succeeds() public {
-        bytes memory invalidGameArgs = hex"123456";
-        GameType gameType = GameTypes.CANNON;
-        vm.mockCall(address(dgf), abi.encodeCall(IDisputeGameFactory.gameArgs, (gameType)), abi.encode(invalidGameArgs));
-
-        assertEq("PLDG-GARGS-10", _validate(true));
+        assertEq("CKDG-20", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1452,32 +1447,12 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
-    ///         FaultDisputeGame (permissionless) Cannon absolute prestate is invalid.
-    function test_validate_faultDisputeGameInvalidCannonAbsolutePrestate_succeeds() public {
-        bytes32 badPrestate = bytes32(uint256(0xbadbad));
-        DisputeGames.mockGameImplPrestate(dgf, GameTypes.CANNON, badPrestate);
-
-        assertEq("PLDG-40", _validate(true));
-    }
-
-    /// @notice Tests that the validate function successfully returns the right error when the
     ///         FaultDisputeGame (permissionless) CannonKona absolute prestate is invalid.
     function test_validate_faultDisputeGameInvalidCannonKonaAbsolutePrestate_succeeds() public {
         bytes32 badPrestate = cannonPrestate.raw(); // Use the wrong prestate
         DisputeGames.mockGameImplPrestate(dgf, GameTypes.CANNON_KONA, badPrestate);
 
         assertEq("CKDG-40", _validate(true));
-    }
-
-    /// @notice Tests that the validate function successfully returns the right error when the
-    ///         FaultDisputeGame (permissionless) Cannon VM address is invalid.
-    function test_validate_faultDisputeGameInvalidCannonVM_succeeds() public {
-        address badVM = address(0xbad);
-        DisputeGames.mockGameImplVM(dgf, GameTypes.CANNON, badVM);
-        vm.mockCall(badVM, abi.encodeCall(ISemver.version, ()), abi.encode("0.0.0"));
-        vm.mockCall(badVM, abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(StandardConstants.MIPS_VERSION));
-
-        assertEq("PLDG-VM-10,PLDG-VM-20", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1489,13 +1464,6 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
         vm.mockCall(badVM, abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(StandardConstants.MIPS_VERSION));
 
         assertEq("CKDG-VM-10,CKDG-VM-20", _validate(true));
-    }
-
-    /// @notice Tests that the validate function successfully returns the right error when the
-    ///         FaultDisputeGame (permissionless) Cannon ASR address is invalid.
-    function test_validate_faultDisputeGameInvalidCannonASR_succeeds() public {
-        _mockInvalidASR(GameTypes.CANNON);
-        assertEq("PLDG-ANCHORP-10,PLDG-ANCHORP-20", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1523,13 +1491,6 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
         vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.systemConfig, ()), abi.encode(sysCfg));
         vm.mockCall(badASR, abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(proxyAdmin));
         vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.retirementTimestamp, ()), abi.encode(uint64(100)));
-    }
-
-    /// @notice Tests that the validate function successfully returns the right error when the
-    ///         FaultDisputeGame (permissionless) Cannon Weth address is invalid.
-    function test_validate_faultDisputeGameInvalidCannonWeth_succeeds() public {
-        _mockInvalidWeth(GameTypes.CANNON);
-        assertEq("PLDG-DWETH-10,PLDG-DWETH-20", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1564,16 +1525,7 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
     ///         FaultDisputeGame (permissionless) VM's state version is invalid.
     function test_validate_faultDisputeGameInvalidVMStateVersion_succeeds() public {
         vm.mockCall(address(mips), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(6));
-        assertEq("PDDG-VM-30,PLDG-VM-30,CKDG-VM-30", _validate(true));
-    }
-
-    /// @notice Tests that the validate function successfully returns the right error when the
-    ///         FaultDisputeGame (permissionless) Cannon L2 Chain ID is invalid.
-    function test_validate_faultDisputeGameInvalidCannonL2ChainId_succeeds() public {
-        uint256 badChainId = l2ChainId + 1;
-        DisputeGames.mockGameImplL2ChainId(dgf, GameTypes.CANNON, badChainId);
-
-        assertEq("PLDG-60", _validate(true));
+        assertEq("PDDG-VM-30,CKDG-VM-30", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1589,7 +1541,7 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
     ///         FaultDisputeGame (permissionless) L2 Sequence Number is invalid.
     function test_validate_faultDisputeGameInvalidL2SequenceNumber_succeeds() public {
         vm.mockCall(address(fdgImpl), abi.encodeCall(IDisputeGame.l2SequenceNumber, ()), abi.encode(123));
-        assertEq("PLDG-70,CKDG-70", _validate(true));
+        assertEq("CKDG-70", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1598,21 +1550,21 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
         vm.mockCall(
             address(fdgImpl), abi.encodeCall(IFaultDisputeGame.clockExtension, ()), abi.encode(Duration.wrap(1000))
         );
-        assertEq("PLDG-80,CKDG-80", _validate(true));
+        assertEq("CKDG-80", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         FaultDisputeGame (permissionless) splitDepth is invalid.
     function test_validate_faultDisputeGameInvalidSplitDepth_succeeds() public {
         vm.mockCall(address(fdgImpl), abi.encodeCall(IFaultDisputeGame.splitDepth, ()), abi.encode(20));
-        assertEq("PLDG-90,CKDG-90", _validate(true));
+        assertEq("CKDG-90", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         FaultDisputeGame (permissionless) maxGameDepth is invalid.
     function test_validate_faultDisputeGameInvalidMaxGameDepth_succeeds() public {
         vm.mockCall(address(fdgImpl), abi.encodeCall(IFaultDisputeGame.maxGameDepth, ()), abi.encode(50));
-        assertEq("PLDG-100,CKDG-100", _validate(true));
+        assertEq("CKDG-100", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1621,7 +1573,7 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
         vm.mockCall(
             address(fdgImpl), abi.encodeCall(IFaultDisputeGame.maxClockDuration, ()), abi.encode(Duration.wrap(1000))
         );
-        assertEq("PLDG-110,CKDG-110", _validate(true));
+        assertEq("CKDG-110", _validate(true));
     }
 }
 
@@ -2143,17 +2095,16 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
         if (isL1ForkTest()) {
             // In fork mode read the actual values from the deployed contracts so _validate()
             // is consistent with the real on-chain state.
-            LibGameArgs.GameArgs memory cannonArgs = LibGameArgs.decode(dgf.gameArgs(GameTypes.CANNON));
-            cannonPrestate = Claim.wrap(cannonArgs.absolutePrestate);
-            l2ChainId = cannonArgs.l2ChainId;
-
             LibGameArgs.GameArgs memory pddgArgs = LibGameArgs.decode(dgf.gameArgs(GameTypes.PERMISSIONED_CANNON));
+            cannonPrestate = Claim.wrap(pddgArgs.absolutePrestate);
+            l2ChainId = pddgArgs.l2ChainId;
             proposer = pddgArgs.proposer;
             challenger = pddgArgs.challenger;
 
-            cannonKonaPrestate = Claim.wrap(LibGameArgs.decode(dgf.gameArgs(GameTypes.CANNON_KONA)).absolutePrestate);
+            LibGameArgs.GameArgs memory cannonKonaArgs = LibGameArgs.decode(dgf.gameArgs(GameTypes.CANNON_KONA));
+            cannonKonaPrestate = Claim.wrap(cannonKonaArgs.absolutePrestate);
 
-            // ZK game is not deployed on mainnet. Mock it using the same ASR and WETH as CANNON
+            // ZK game is not deployed on mainnet. Mock it using the same ASR and WETH as CANNON_KONA
             // (same on-chain infrastructure) so _assertValidZKGameArgs passes its checks.
             // ZK_DISPUTE_GAME is a super game: chain scoping comes from the SuperRootProof
             // preimage, so the 140-byte layout has no l2ChainId field.
@@ -2163,8 +2114,8 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
                 uint64(7 days),
                 uint64(3 days),
                 uint256(0.08 ether),
-                cannonArgs.anchorStateRegistry,
-                cannonArgs.weth
+                cannonKonaArgs.anchorStateRegistry,
+                cannonKonaArgs.weth
             );
             vm.mockCall(
                 address(dgf),
@@ -2190,10 +2141,10 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
             IOPContractsManagerUtils.DisputeGameConfig[] memory configs =
                 new IOPContractsManagerUtils.DisputeGameConfig[](6);
             configs[0] = IOPContractsManagerUtils.DisputeGameConfig({
-                enabled: true,
-                initBond: DEFAULT_DISPUTE_GAME_INIT_BOND,
+                enabled: false,
+                initBond: 0,
                 gameType: GameTypes.CANNON,
-                gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonPrestate }))
+                gameArgs: hex""
             });
             configs[1] = IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: true,
@@ -2242,6 +2193,13 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
                 )
             });
 
+            IOPContractsManagerUtils.ExtraInstruction[] memory extraInstructions =
+                new IOPContractsManagerUtils.ExtraInstruction[](1);
+            extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
+                key: "overrides.cfg.startingRespectedGameType",
+                data: abi.encode(GameTypes.CANNON_KONA)
+            });
+
             prankDelegateCall(owner);
             (bool success,) = address(opcmV2).delegatecall(
                 abi.encodeCall(
@@ -2250,7 +2208,7 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
                         IOPContractsManagerV2.UpgradeInput({
                             systemConfig: systemConfig,
                             disputeGameConfigs: configs,
-                            extraInstructions: new IOPContractsManagerUtils.ExtraInstruction[](0)
+                            extraInstructions: extraInstructions
                         })
                     )
                 )

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -1028,19 +1028,8 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
             _withdrawalProof: _withdrawalProof
         });
 
-        // Create a new game.
-        IDisputeGame newGame = disputeGameFactory.create{
-            value: disputeGameFactory.initBonds(optimismPortal2.respectedGameType())
-        }(GameType.wrap(0), Claim.wrap(_outputRoot), abi.encode(_proposedBlockNumber + 1));
-
-        // In super mode, the new game's type differs from the respected type, so mock this.
-        if (DisputeGames.isSuperGame(respectedGameType)) {
-            vm.mockCall(
-                address(newGame),
-                abi.encodeCall(IFaultDisputeGame.wasRespectedGameTypeWhenCreated, ()),
-                abi.encode(true)
-            );
-        }
+        // Create a new game with the current respected type.
+        IDisputeGame newGame = _createDisputeGame(respectedGameType, _outputRoot, _proposedBlockNumber + 1);
 
         // Update the respected game type to 0xbeef.
         vm.prank(optimismPortal2.guardian());

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -265,10 +265,10 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
         v2UpgradeInput.systemConfig = systemConfig;
         v2UpgradeInput.disputeGameConfigs.push(
             IOPContractsManagerUtils.DisputeGameConfig({
-                enabled: true,
-                initBond: disputeGameFactory.initBonds(GameTypes.CANNON),
+                enabled: false,
+                initBond: 0,
                 gameType: GameTypes.CANNON,
-                gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonPrestate }))
+                gameArgs: bytes("")
             })
         );
         v2UpgradeInput.disputeGameConfigs.push(
@@ -328,10 +328,43 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
             })
         );
 
-        // Allow the DelayedWETH proxy to be (re)deployed during upgrades if it is missing.
+        _pushPermittedProxyDeploymentInstruction();
+        _pushCannonKonaRespectedGameTypeOverrideIfNeeded();
+    }
+
+    function _pushPermittedProxyDeploymentInstruction() internal {
         v2UpgradeInput.extraInstructions.push(
             IOPContractsManagerUtils.ExtraInstruction({ key: "PermittedProxyDeployment", data: bytes("DelayedWETH") })
         );
+    }
+
+    function _pushCannonKonaRespectedGameTypeOverrideIfNeeded() internal {
+        if (optimismPortal2.anchorStateRegistry().respectedGameType().raw() != GameTypes.CANNON.raw()) {
+            return;
+        }
+        v2UpgradeInput.extraInstructions.push(
+            IOPContractsManagerUtils.ExtraInstruction({
+                key: "overrides.cfg.startingRespectedGameType",
+                data: abi.encode(GameTypes.CANNON_KONA)
+            })
+        );
+    }
+
+    function _clearStartingRespectedGameTypeOverride() internal {
+        bytes32 targetKeyHash = keccak256(bytes("overrides.cfg.startingRespectedGameType"));
+        uint256 writeIndex;
+        for (uint256 readIndex; readIndex < v2UpgradeInput.extraInstructions.length; readIndex++) {
+            if (keccak256(bytes(v2UpgradeInput.extraInstructions[readIndex].key)) == targetKeyHash) {
+                continue;
+            }
+            if (writeIndex != readIndex) {
+                v2UpgradeInput.extraInstructions[writeIndex] = v2UpgradeInput.extraInstructions[readIndex];
+            }
+            writeIndex++;
+        }
+        while (v2UpgradeInput.extraInstructions.length > writeIndex) {
+            v2UpgradeInput.extraInstructions.pop();
+        }
     }
 
     /// @notice Helper function that runs an OPCM V2 upgrade, asserts that the upgrade was successful,
@@ -725,34 +758,35 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
 
     /// @notice Tests that repeatedly upgrading can enable a previously disabled game type.
     function test_upgrade_enableGameType_succeeds() public {
-        uint256 originalBond = disputeGameFactory.initBonds(GameTypes.CANNON);
+        uint256 originalBond = disputeGameFactory.initBonds(GameTypes.CANNON_KONA);
 
-        // First, disable Cannon and clear its bond so the factory entry is removed.
-        // If the chain's current respectedGameType is CANNON, we must override it to
+        // First, disable CannonKona and clear its bond so the factory entry is removed.
+        // If the chain's current respectedGameType is CANNON_KONA, we must override it to
         // PERMISSIONED_CANNON since we can't disable the respected game type.
-        v2UpgradeInput.disputeGameConfigs[0].enabled = false;
-        v2UpgradeInput.disputeGameConfigs[0].initBond = 0;
+        _clearStartingRespectedGameTypeOverride();
+        v2UpgradeInput.disputeGameConfigs[2].enabled = false;
+        v2UpgradeInput.disputeGameConfigs[2].initBond = 0;
         v2UpgradeInput.extraInstructions.push(
             IOPContractsManagerUtils.ExtraInstruction({
                 key: "overrides.cfg.startingRespectedGameType",
                 data: abi.encode(GameTypes.PERMISSIONED_CANNON)
             })
         );
-        runCurrentUpgradeV2(chainPAO, hex"", "PLDG-10");
-        assertEq(address(disputeGameFactory.gameImpls(GameTypes.CANNON)), address(0), "game impl not cleared");
+        runCurrentUpgradeV2(chainPAO, hex"", "CKDG-NOSHAPE,CKDG-10");
+        assertEq(address(disputeGameFactory.gameImpls(GameTypes.CANNON_KONA)), address(0), "game impl not cleared");
 
-        // Re-enable Cannon and restore its bond so that it is re-installed.
-        // Remove the startingRespectedGameType override since CANNON is enabled again.
-        v2UpgradeInput.disputeGameConfigs[0].enabled = true;
-        v2UpgradeInput.disputeGameConfigs[0].initBond = originalBond;
+        // Re-enable CannonKona and restore its bond so that it is re-installed.
+        // Remove the startingRespectedGameType override since CANNON_KONA is enabled again.
+        v2UpgradeInput.disputeGameConfigs[2].enabled = true;
+        v2UpgradeInput.disputeGameConfigs[2].initBond = originalBond;
         v2UpgradeInput.extraInstructions.pop();
         runCurrentUpgradeV2(chainPAO);
         assertEq(
-            address(disputeGameFactory.gameImpls(GameTypes.CANNON)),
+            address(disputeGameFactory.gameImpls(GameTypes.CANNON_KONA)),
             opcmV2.implementations().faultDisputeGameImpl,
             "game impl not restored"
         );
-        assertEq(disputeGameFactory.initBonds(GameTypes.CANNON), originalBond, "init bond not restored");
+        assertEq(disputeGameFactory.initBonds(GameTypes.CANNON_KONA), originalBond, "init bond not restored");
     }
 
     /// @notice Tests that a stale SUPER_CANNON registration left over from a prior OPCM is
@@ -795,39 +829,42 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
 
     /// @notice Tests that disabling a game type removes it from the factory.
     function test_upgrade_disableGameType_succeeds() public {
-        // Establish the baseline where Cannon is enabled.
+        // Establish the baseline where CannonKona is enabled and Cannon is disabled.
         runCurrentUpgradeV2(chainPAO);
+        assertEq(address(disputeGameFactory.gameImpls(GameTypes.CANNON)), address(0), "cannon impl not cleared");
+        assertEq(disputeGameFactory.initBonds(GameTypes.CANNON), 0, "cannon init bond not cleared");
         assertEq(
-            address(disputeGameFactory.gameImpls(GameTypes.CANNON)),
+            address(disputeGameFactory.gameImpls(GameTypes.CANNON_KONA)),
             opcmV2.implementations().faultDisputeGameImpl,
             "initial game impl mismatch"
         );
 
-        // Disable Cannon and zero its bond, then ensure it is removed.
-        // If the chain's current respectedGameType is CANNON, we must override it to
+        // Disable CannonKona and zero its bond, then ensure it is removed.
+        // If the chain's current respectedGameType is CANNON_KONA, we must override it to
         // PERMISSIONED_CANNON since we can't disable the respected game type.
-        v2UpgradeInput.disputeGameConfigs[0].enabled = false;
-        v2UpgradeInput.disputeGameConfigs[0].initBond = 0;
+        _clearStartingRespectedGameTypeOverride();
+        v2UpgradeInput.disputeGameConfigs[2].enabled = false;
+        v2UpgradeInput.disputeGameConfigs[2].initBond = 0;
         v2UpgradeInput.extraInstructions.push(
             IOPContractsManagerUtils.ExtraInstruction({
                 key: "overrides.cfg.startingRespectedGameType",
                 data: abi.encode(GameTypes.PERMISSIONED_CANNON)
             })
         );
-        runCurrentUpgradeV2(chainPAO, hex"", "PLDG-10");
-        assertEq(address(disputeGameFactory.gameImpls(GameTypes.CANNON)), address(0), "game impl not cleared");
-        assertEq(disputeGameFactory.initBonds(GameTypes.CANNON), 0, "init bond not cleared");
-        assertEq(disputeGameFactory.gameArgs(GameTypes.CANNON), bytes(""), "game args not cleared");
+        runCurrentUpgradeV2(chainPAO, hex"", "CKDG-NOSHAPE,CKDG-10");
+        assertEq(address(disputeGameFactory.gameImpls(GameTypes.CANNON_KONA)), address(0), "game impl not cleared");
+        assertEq(disputeGameFactory.initBonds(GameTypes.CANNON_KONA), 0, "init bond not cleared");
+        assertEq(disputeGameFactory.gameArgs(GameTypes.CANNON_KONA), bytes(""), "game args not cleared");
     }
 
-    /// @notice Tests that the upgrade flow can update the Cannon and Permissioned prestate.
+    /// @notice Tests that the upgrade flow can update the CannonKona and Permissioned prestates.
     function test_upgrade_updatePrestate_succeeds() public {
         // Run baseline upgrade and capture the current prestates.
         runCurrentUpgradeV2(chainPAO);
         assertEq(
-            _gameArgsAbsolutePrestate(GameTypes.CANNON),
-            Claim.unwrap(cannonPrestate),
-            "baseline cannon prestate mismatch"
+            _gameArgsAbsolutePrestate(GameTypes.CANNON_KONA),
+            Claim.unwrap(cannonKonaPrestate),
+            "baseline cannon kona prestate mismatch"
         );
         assertEq(
             _gameArgsAbsolutePrestate(GameTypes.PERMISSIONED_CANNON),
@@ -838,10 +875,9 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         // Prepare new prestates.
         Claim newPrestate = Claim.wrap(bytes32(keccak256("new cannon prestate")));
         cannonPrestate = newPrestate;
+        cannonKonaPrestate = newPrestate;
 
         // Update the dispute game configs to point at the new prestates.
-        v2UpgradeInput.disputeGameConfigs[0].gameArgs =
-            abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: newPrestate }));
         v2UpgradeInput.disputeGameConfigs[1].gameArgs = abi.encode(
             IOPContractsManagerUtils.PermissionedDisputeGameConfig({
                 absolutePrestate: newPrestate,
@@ -849,10 +885,16 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
                 challenger: DisputeGames.permissionedGameChallenger(disputeGameFactory)
             })
         );
+        v2UpgradeInput.disputeGameConfigs[2].gameArgs =
+            abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: newPrestate }));
 
         // Run the upgrade again and ensure prestates updated.
         runCurrentUpgradeV2(chainPAO);
-        assertEq(_gameArgsAbsolutePrestate(GameTypes.CANNON), Claim.unwrap(newPrestate), "cannon prestate not updated");
+        assertEq(
+            _gameArgsAbsolutePrestate(GameTypes.CANNON_KONA),
+            Claim.unwrap(newPrestate),
+            "cannon kona prestate not updated"
+        );
         assertEq(
             _gameArgsAbsolutePrestate(GameTypes.PERMISSIONED_CANNON),
             Claim.unwrap(newPrestate),
@@ -870,6 +912,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         v2UpgradeInput.extraInstructions.push(
             IOPContractsManagerUtils.ExtraInstruction({ key: "SomeCustomKey", data: bytes("Data2") })
         );
+        _pushCannonKonaRespectedGameTypeOverrideIfNeeded();
 
         // nosemgrep: sol-style-use-abi-encodecall
         runCurrentUpgradeV2(
@@ -895,7 +938,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
                 data: bytes("DelayedWETH")
             })
         );
-
+        _pushCannonKonaRespectedGameTypeOverrideIfNeeded();
         runCurrentUpgradeV2(chainPAO);
     }
 
@@ -931,6 +974,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         /// This is a hack because fork live has an outdated superchain registry reference that it
         /// pulls the addresses from
         IAnchorStateRegistry anchorStateRegistry = optimismPortal2.anchorStateRegistry();
+        _clearStartingRespectedGameTypeOverride();
         v2UpgradeInput.extraInstructions.push(
             IOPContractsManagerUtils.ExtraInstruction({
                 key: "overrides.cfg.startingRespectedGameType",
@@ -957,6 +1001,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
             abi.encodeCall(IAnchorStateRegistry.respectedGameType, ()),
             abi.encode(GameTypes.CANNON_KONA)
         );
+        _clearStartingRespectedGameTypeOverride();
         v2UpgradeInput.extraInstructions.push(
             IOPContractsManagerUtils.ExtraInstruction({
                 key: "overrides.cfg.startingRespectedGameType",
@@ -975,7 +1020,13 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         /// This is a hack because fork live has an outdated superchain registry reference that it pulls the addresses
         /// from
         IAnchorStateRegistry anchorStateRegistry = optimismPortal2.anchorStateRegistry();
+        vm.mockCall(
+            address(anchorStateRegistry),
+            abi.encodeCall(IAnchorStateRegistry.respectedGameType, ()),
+            abi.encode(GameTypes.CANNON_KONA)
+        );
         GameType before = anchorStateRegistry.respectedGameType();
+        _clearStartingRespectedGameTypeOverride();
         runCurrentUpgradeV2(chainPAO);
         assertEq(
             anchorStateRegistry.respectedGameType().raw(),
@@ -992,6 +1043,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
             abi.encodeCall(IOPContractsManagerContainer.isDevFeatureEnabled, (DevFeatures.CANNON_KONA)),
             abi.encode(true)
         );
+        _clearStartingRespectedGameTypeOverride();
         v2UpgradeInput.disputeGameConfigs[2].enabled = false;
         v2UpgradeInput.disputeGameConfigs[2].initBond = 0;
         v2UpgradeInput.extraInstructions.push(
@@ -1009,6 +1061,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
     /// @notice Tests that the respected game type override is rejected when CANNON_KONA dev feature is off.
     function test_upgrade_respectedGameTypeOverrideWithoutDevFeature_reverts() public {
         skipIfDevFeatureEnabled(DevFeatures.CANNON_KONA);
+        _clearStartingRespectedGameTypeOverride();
         v2UpgradeInput.extraInstructions.push(
             IOPContractsManagerUtils.ExtraInstruction({
                 key: "overrides.cfg.startingRespectedGameType",
@@ -1168,8 +1221,8 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
 
     /// @notice Tests that enabling a game type with a zero container implementation reverts.
     function test_upgrade_enabledGameWithZeroImpl_reverts() public {
-        // Zero out the Cannon implementation in the container
-        // Cannon is always enabled in the default v2UpgradeInput.
+        // Zero out the CannonKona implementation in the container.
+        // CannonKona is enabled in the default v2UpgradeInput.
         IOPContractsManagerContainer.Implementations memory impls = opcmV2.implementations();
         impls.faultDisputeGameImpl = address(0);
 
@@ -1183,7 +1236,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         runCurrentUpgradeV2(
             chainPAO,
             abi.encodeWithSelector(
-                IOPContractsManagerV2.OPContractsManagerV2_ZeroGameImplementation.selector, GameTypes.CANNON
+                IOPContractsManagerV2.OPContractsManagerV2_ZeroGameImplementation.selector, GameTypes.CANNON_KONA
             )
         );
     }
@@ -1305,6 +1358,8 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
                 )
             })
         );
+
+        _clearStartingRespectedGameTypeOverride();
 
         // Add override instructions.
         v2UpgradeInput.extraInstructions.push(
@@ -1821,10 +1876,9 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
     /// @notice Tests that the deploy function succeeds and passes standard validation.
     function test_deploy_succeeds() public {
         // Run the deploy and standard validator checks.
-        // In standard mode, CANNON and CANNON_KONA are disabled → PLDG-10,CKDG-10.
-        // In super root mode, SUPER_CANNON_KONA is disabled → SCKDG-SHAPE,SCKDG-10.
+        // In standard mode, CANNON_KONA is disabled. In super root mode, SUPER_CANNON_KONA is disabled.
         bool superRoot = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
-        string memory expectedErrors = superRoot ? "SCKDG-SHAPE,SCKDG-10" : "CKDG-NOSHAPE,PLDG-10,CKDG-10";
+        string memory expectedErrors = superRoot ? "SCKDG-SHAPE,SCKDG-10" : "CKDG-NOSHAPE,CKDG-10";
         IOPContractsManagerV2.ChainContracts memory cts = runDeployV2(deployConfig, bytes(""), expectedErrors);
 
         // Verify key contracts are deployed.
@@ -1975,7 +2029,7 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         bool superRoot = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
         GameType permType = superRoot ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON;
         deployConfig.startingRespectedGameType = permType;
-        string memory expectedErrors = superRoot ? "SCKDG-SHAPE,SCKDG-10" : "CKDG-NOSHAPE,PLDG-10,CKDG-10";
+        string memory expectedErrors = superRoot ? "SCKDG-SHAPE,SCKDG-10" : "CKDG-NOSHAPE,CKDG-10";
         IOPContractsManagerV2.ChainContracts memory cts = runDeployV2(deployConfig, bytes(""), expectedErrors);
         assertEq(cts.anchorStateRegistry.respectedGameType().raw(), permType.raw(), "respected game type mismatch");
     }

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -207,6 +207,7 @@ abstract contract DisputeGameFactory_TestInit is CommonTest {
         });
 
         _setGame(gameImpl_, GameTypes.CANNON, immutableArgs);
+        _setGame(gameImpl_, GameTypes.CANNON_KONA, immutableArgs);
     }
 
     function changeClaimStatus(Claim _claim, VMStatus _status) public pure returns (Claim out_) {

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -72,7 +72,7 @@ function _dummyClaim() view returns (Claim) {
 /// @notice Base test initializer that can be used by other contracts outside of this test suite.
 abstract contract BaseFaultDisputeGame_TestInit is DisputeGameFactory_TestInit {
     /// @dev The type of the game being tested.
-    GameType internal immutable GAME_TYPE = GameTypes.CANNON;
+    GameType internal immutable GAME_TYPE = GameTypes.CANNON_KONA;
 
     /// @dev The initial bond for the game.
     uint256 internal initBond;
@@ -101,6 +101,9 @@ abstract contract BaseFaultDisputeGame_TestInit is DisputeGameFactory_TestInit {
 
         (address _impl, AlphabetVM _vm,) = setupFaultDisputeGame(absolutePrestate);
         gameImpl = IFaultDisputeGame(_impl);
+
+        vm.prank(systemConfig.guardian());
+        anchorStateRegistry.setRespectedGameType(GAME_TYPE);
 
         // Set the init bond for the given game type.
         initBond = disputeGameFactory.initBonds(GAME_TYPE);

--- a/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
@@ -169,15 +169,12 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
         saveProxyAndImpl("DisputeGameFactory", opToml, ".addresses.DisputeGameFactoryProxy");
 
         // Fault proof non-proxied contracts
-        // For chains that don't have a permissionless game, we save the dispute game and WETH
-        // addresses as the zero address.
         artifacts.save(
             "PreimageOracle", vm.parseJsonAddress(addressesJson, string.concat("$.", chainId, ".PreimageOracle"))
         );
         artifacts.save("MipsSingleton", vm.parseJsonAddress(addressesJson, string.concat("$.", chainId, ".MIPS")));
         IDisputeGameFactory disputeGameFactory =
             IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
-
         // The PermissionedDisputeGame and PermissionedDelayedWETHProxy are not listed in the registry for OP, so we
         // look it up onchain.
         address permissionedGameImpl = address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON));
@@ -188,13 +185,19 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
             DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.PERMISSIONED_CANNON);
         artifacts.save("PermissionedDelayedWETHProxy", address(permissionedDelayedWeth));
 
-        // Get DelayedWETH for PERMISSIONLESS games (CANNON)
+        // Get DelayedWETH for the live permissionless game.
         IDelayedWETH permissionlessDelayedWeth =
-            DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.CANNON);
+            DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.CANNON_KONA);
 
         // The SR seems out-of-date, so pull the DelayedWETH addresses from the games.
         artifacts.save("DelayedWETHProxy", address(permissionlessDelayedWeth));
         artifacts.save("DelayedWETHImpl", EIP1967Helper.getImplementation(address(permissionlessDelayedWeth)));
+    }
+
+    /// @notice Returns true for supported permissionless fault dispute game types.
+    function _isPermissionlessGameType(GameType _gameType) internal pure returns (bool) {
+        uint32 rawGameType = _gameType.raw();
+        return rawGameType == GameTypes.CANNON.raw() || rawGameType == GameTypes.CANNON_KONA.raw();
     }
 
     /// @notice Calls to the Deploy.s.sol contract etched by Setup.sol to a deterministic address, sets up the
@@ -330,18 +333,14 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
                 data: abi.encode(targetGameType)
             });
         } else {
-            // Standard upgrade path: legacy types enabled, super types disabled.
+            // Standard upgrade path: CANNON disabled, remaining legacy types enabled, super types disabled.
             // Order must match validGameTypes in OPContractsManagerV2._assertValidFullConfig().
             disputeGameConfigs = new IOPContractsManagerUtils.DisputeGameConfig[](6);
             disputeGameConfigs[0] = IOPContractsManagerUtils.DisputeGameConfig({
-                enabled: true,
-                initBond: disputeGameFactory.initBonds(GameTypes.CANNON),
+                enabled: false,
+                initBond: 0,
                 gameType: GameTypes.CANNON,
-                gameArgs: abi.encode(
-                    IOPContractsManagerUtils.FaultDisputeGameConfig({
-                        absolutePrestate: Claim.wrap(bytes32(keccak256("cannonPrestate")))
-                    })
-                )
+                gameArgs: bytes("")
             });
             disputeGameConfigs[1] = IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: true,
@@ -384,12 +383,20 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
                 gameArgs: hex""
             });
 
-            // Standard path only needs DelayedWETH proxy deployment permission.
-            extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](1);
+            IAnchorStateRegistry asr = IAnchorStateRegistry(artifacts.mustGetAddress("AnchorStateRegistryProxy"));
+            bool overrideRespectedGameType = asr.respectedGameType().raw() == GameTypes.CANNON.raw();
+
+            extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](overrideRespectedGameType ? 2 : 1);
             extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
                 key: "PermittedProxyDeployment",
                 data: bytes("DelayedWETH")
             });
+            if (overrideRespectedGameType) {
+                extraInstructions[1] = IOPContractsManagerUtils.ExtraInstruction({
+                    key: "overrides.cfg.startingRespectedGameType",
+                    data: abi.encode(GameTypes.CANNON_KONA)
+                });
+            }
         }
 
         vm.prank(_delegateCaller, true);


### PR DESCRIPTION
Updates the contracts fork test harness for post-U19 live network state.

U19 disables the legacy CANNON permissionless game on OP/Ink and leaves CANNON_KONA as the respected live game. The fork setup was still reading DelayedWETH and upgrade init bonds from CANNON, so fork upgrade tests could fail shared setup with invalid game configs.

This changes the harness to select the live permissionless game from AnchorStateRegistry first, fall back across known permissionless game types, and use a default nonzero permissionless init bond when simulating upgrade configs for a game type that is disabled on the live fork.

Validation:
- `mise exec -- forge build`
- `mise exec -- just build-go-ffi`
- `mise exec -- forge test --match-path test/L1/opcm/OPContractsManagerV2.t.sol --match-contract OPContractsManagerV2_Upgrade_Test` (skips without `FORK_TEST`)

Full live-network `just test-upgrade` validation is left to CI because no local `ETH_RPC_URL` archive RPC is configured in this shell.