### PR TITLE
docs: relabel node architecture overview as explanation

### DIFF
--- a/docs/public-docs/node-operators/reference/architecture/architecture.mdx
+++ b/docs/public-docs/node-operators/reference/architecture/architecture.mdx
@@ -1,9 +1,12 @@
 ---
 title: Node architecture
-description: Learn about node architecture.
+description: Understand how the components of an OP Stack node fit together.
+diataxis: explanation
 ---
 
-This page reviews node architecture for all nodes running on OP Stack networks. All OP Mainnet nodes are composed of two core software services, the Rollup Node and the Execution Client.
+This page explains how an OP Stack node is put together: what its components are, what each one is responsible for, and how they relate to the equivalent parts of an Ethereum node. It is background reading to build a mental model before you run a node — for the steps to actually stand one up, see the [Next steps](#next-steps) below.
+
+Every node on an OP Stack network is composed of two core software services, the Rollup Node and the Execution Client.
 OP Mainnet also optionally supports a third component, Legacy Geth, that can serve stateful queries for blocks and transactions created before the [Bedrock Upgrade](https://web.archive.org/web/20230608050602/https://blog.oplabs.co/introducing-optimism-bedrock/).
 
 ## Node flow diagram


### PR DESCRIPTION
## What

Declares the Diátaxis quadrant of the node architecture overview (`node-operators/reference/architecture/architecture.mdx`) as **explanation** in YAML frontmatter (`diataxis: explanation`) and reframes the opening line to read as an explainer.

## Why

The page sits under `reference/architecture/`, so its folder claims it is **reference**. But the page's entire job is to build a mental model of what an OP Stack node is made of — the Rollup Node, the Execution Client (op-geth / Nethermind), and Legacy Geth — and how those components map onto the equivalent parts of an Ethereum node. It uses analogies ("largely analogous to a consensus client"), explains the *why* behind Legacy Geth and the Bedrock migration, and links forward to the run-a-node tutorials. It has no austere lookup structure: no flag/value catalogue, no API surface, no config tables. By Diátaxis that makes it **explanation**, not reference.

Making the taxonomy explicit in frontmatter (rather than leaving it implied by the folder) is the durable, lint-able record of the correct classification — the basis for a future declared-vs-folder CI check.

### Scope

- **Structural relabel only.** No technical claims were changed — accuracy is a separate concern owned by `public-docs-audit`. "reviews node architecture" → "explains how a node is put together"; "All OP Mainnet nodes are composed of" → "Every node on an OP Stack network is composed of" (same fact).
- Kept the file in place — no physical move — to avoid URL/redirect churn on a single-page relabel.

Addresses first-pass Diátaxis finding `29e16495fff55db0` (mislabel, `reference → explanation`, verified).

## Reviewer checklist

- [ ] `diataxis: explanation` is the correct quadrant for this page
- [ ] The reframed opening reads as an explainer and stays accurate
- [ ] No technical claim was altered
- [ ] Comfortable declaring the quadrant in frontmatter without physically moving the file (relabel-in-place)

## Context

This PR is one step of a continuous, structural docs-improvement experiment (Diátaxis: right *kind* of page, not content accuracy). Overview: [`projects/docs-improver/README.md`](https://github.com/ethereum-optimism/solutions/blob/main/projects/docs-improver/README.md).

Tracks ethereum-optimism/solutions#814

🤖 Drafted by the docs-improver agent — review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
