### PR TITLE
fix(op-reth): report op-reth's own version instead of upstream reth's

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -89,6 +89,10 @@ variable "OP_INTEROP_MON_VERSION" {
   default = "${GIT_VERSION}"
 }
 
+variable "OP_RETH_VERSION" {
+  default = "${GIT_VERSION}"
+}
+
 
 target "op-node" {
   dockerfile = "ops/docker/op-stack-go/Dockerfile"
@@ -354,6 +358,8 @@ target "op-reth" {
   args = {
     BUILD_PROFILE = "maxperf"
     FEATURES = ""
+    GIT_COMMIT = "${GIT_COMMIT}"
+    OP_RETH_VERSION = "${OP_RETH_VERSION}"
   }
   platforms = split(",", PLATFORMS)
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-reth:${tag}"]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9511,6 +9511,7 @@ dependencies = [
  "reth-cli-util",
  "reth-db",
  "reth-node-builder",
+ "reth-node-core",
  "reth-optimism-chainspec",
  "reth-optimism-cli",
  "reth-optimism-consensus",
@@ -9521,6 +9522,8 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-optimism-rpc",
  "tracing",
+ "vergen",
+ "vergen-git2",
 ]
 
 [[package]]

--- a/rust/op-reth/DockerfileOp
+++ b/rust/op-reth/DockerfileOp
@@ -38,6 +38,17 @@ COPY . .
 # context; the git-free build.rs resolves it at /superchain-registry.
 COPY --from=superchain-registry superchain /superchain-registry/superchain
 
+# This build context (`rust/`) has no `.git`, so op-reth's build.rs can't discover its own commit
+# or release tag. Thread both in as build args (docker-bake.hcl / CI set them) so op-reth reports
+# a real commit and version instead of a placeholder. GIT_COMMIT is the commit SHA; OP_RETH_VERSION
+# is the per-image GIT_VERSION — the `op-reth/v*` release tag with its prefix stripped, e.g.
+# `v2.3.3`. Declared after `cargo chef cook` above so changing them doesn't bust the dep cache.
+ARG GIT_COMMIT=""
+ENV GIT_COMMIT=$GIT_COMMIT
+
+ARG OP_RETH_VERSION=""
+ENV OP_RETH_VERSION=$OP_RETH_VERSION
+
 RUN cargo auditable build --profile $BUILD_PROFILE --locked --features "$FEATURES" --bin op-reth --manifest-path /app/op-reth/bin/Cargo.toml
 
 RUN ls -la /app/target/$BUILD_PROFILE/op-reth

--- a/rust/op-reth/bin/Cargo.toml
+++ b/rust/op-reth/bin/Cargo.toml
@@ -20,11 +20,16 @@ reth-optimism-payload-builder.workspace = true
 reth-optimism-primitives.workspace = true
 reth-optimism-forks.workspace = true
 reth-node-builder.workspace = true
+reth-node-core.workspace = true
 reth-db.workspace = true
 
 clap = { workspace = true, features = ["derive", "env"] }
 tracing.workspace = true
 eyre.workspace = true
+
+[build-dependencies]
+vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }
+vergen-git2.workspace = true
 
 [lints]
 workspace = true

--- a/rust/op-reth/bin/build.rs
+++ b/rust/op-reth/bin/build.rs
@@ -1,0 +1,95 @@
+//! Emits `OP_RETH_*` build-time env vars consumed by `src/version.rs`, so that op-reth's
+//! reported version/commit reflects its own release rather than the pinned upstream `reth`
+//! crate's. Adapted from reth's `crates/node/core/build.rs`.
+
+use std::{env, error::Error};
+use vergen::{BuildBuilder, CargoBuilder, Emitter};
+use vergen_git2::Git2Builder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut emitter = Emitter::default();
+
+    let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
+    emitter.add_instructions(&build_builder)?;
+
+    let cargo_builder = CargoBuilder::default().features(true).target_triple(true).build()?;
+    emitter.add_instructions(&cargo_builder)?;
+
+    let git_builder =
+        Git2Builder::default().describe(false, true, None).dirty(true).sha(false).build()?;
+    emitter.add_instructions(&git_builder)?;
+
+    emitter.emit_and_set()?;
+    let sha = env::var("VERGEN_GIT_SHA")?;
+    let sha_short = &sha[0..7];
+
+    let is_dirty = env::var("VERGEN_GIT_DIRTY")? == "true";
+    // > git describe --always --tags
+    // if not on a tag: v0.2.0-beta.3-82-g1939939b
+    // if on a tag: v0.2.0-beta.3
+    let not_on_tag = env::var("VERGEN_GIT_DESCRIBE")?.ends_with(&format!("-g{sha_short}"));
+    let version_suffix = if is_dirty || not_on_tag { "-dev" } else { "" };
+    println!("cargo:rustc-env=OP_RETH_VERSION_SUFFIX={version_suffix}");
+
+    // Set short SHA
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha[..8]);
+
+    // Set the build profile
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
+    println!("cargo:rustc-env=OP_RETH_BUILD_PROFILE={profile}");
+
+    // Set formatted version strings
+    let pkg_version = env!("CARGO_PKG_VERSION");
+
+    // The short version information for op-reth.
+    // - The latest version from Cargo.toml
+    // - The short SHA of the latest commit.
+    // Example: 1.11.3 (defa64b2)
+    println!("cargo:rustc-env=OP_RETH_SHORT_VERSION={pkg_version}{version_suffix} ({sha_short})");
+
+    // LONG_VERSION
+    // The long version information for op-reth.
+    //
+    // - The latest version from Cargo.toml + version suffix (if any)
+    // - The full SHA of the latest commit
+    // - The build datetime
+    // - The build features
+    // - The build profile
+    //
+    // Example:
+    //
+    // ```text
+    // Version: 1.11.3
+    // Commit SHA: defa64b2
+    // Build Timestamp: 2023-05-19T01:47:19.815651705Z
+    // Build Features: jemalloc
+    // Build Profile: maxperf
+    // ```
+    println!("cargo:rustc-env=OP_RETH_LONG_VERSION_0=Version: {pkg_version}{version_suffix}");
+    println!("cargo:rustc-env=OP_RETH_LONG_VERSION_1=Commit SHA: {sha}");
+    println!(
+        "cargo:rustc-env=OP_RETH_LONG_VERSION_2=Build Timestamp: {}",
+        env::var("VERGEN_BUILD_TIMESTAMP")?
+    );
+    println!(
+        "cargo:rustc-env=OP_RETH_LONG_VERSION_3=Build Features: {}",
+        env::var("VERGEN_CARGO_FEATURES")?
+    );
+    println!("cargo:rustc-env=OP_RETH_LONG_VERSION_4=Build Profile: {profile}");
+
+    // The version information for op-reth formatted for P2P (devp2p).
+    // - The latest version from Cargo.toml
+    // - The target triple
+    //
+    // Example: op-reth/v1.11.3-428a6dc2f/aarch64-apple-darwin
+    println!(
+        "cargo:rustc-env=OP_RETH_P2P_CLIENT_VERSION={}",
+        format_args!(
+            "op-reth/v{pkg_version}-{sha_short}/{}",
+            env::var("VERGEN_CARGO_TARGET_TRIPLE")?
+        )
+    );
+
+    Ok(())
+}

--- a/rust/op-reth/bin/build.rs
+++ b/rust/op-reth/bin/build.rs
@@ -1,10 +1,50 @@
 //! Emits `OP_RETH_*` build-time env vars consumed by `src/version.rs`, so that op-reth's
 //! reported version/commit reflects its own release rather than the pinned upstream `reth`
 //! crate's. Adapted from reth's `crates/node/core/build.rs`.
+//!
+//! op-reth's release version is the monorepo's `op-reth/v*` git tag (e.g. `op-reth/v2.3.3`), not
+//! this crate's Cargo.toml `version`: op-reth isn't published to crates.io, and its Cargo version
+//! tracks the vendored `reth-optimism-*` library crates (1.11.x), not op-reth's own releases. We
+//! read it from `git describe` when `.git` is available, and from the `OP_RETH_VERSION` build arg
+//! otherwise — op-reth's Docker build context (`rust/`) deliberately excludes `.git`, so
+//! docker-bake.hcl threads in the commit (`GIT_COMMIT`) and the tag (`OP_RETH_VERSION`, sourced
+//! from the per-image `GIT_VERSION`) as build args.
 
 use std::{env, error::Error};
 use vergen::{BuildBuilder, CargoBuilder, Emitter};
 use vergen_git2::Git2Builder;
+
+/// vergen's placeholder for a git instruction it couldn't resolve — emitted (instead of failing
+/// the build) when there's no `.git`, as in op-reth's Docker build context.
+const VERGEN_IDEMPOTENT_OUTPUT: &str = "VERGEN_IDEMPOTENT_OUTPUT";
+
+/// Release version reported when neither a reachable `op-reth/v*` tag nor an `OP_RETH_VERSION`
+/// build arg is available (a shallow/tagless checkout, or a non-release Docker build). Always
+/// paired with a `-dev` suffix so it's never mistaken for a real `0.0.0` release.
+const DEV_VERSION: &str = "0.0.0";
+
+/// Parses a `git describe --tags --match 'op-reth/v*'` string into `(base_version, on_tag)`:
+/// - `op-reth/v2.3.3`             -> `Some(("2.3.3", true))`
+/// - `op-reth/v2.3.3-12-gaf90f02` -> `Some(("2.3.3", false))` (12 commits past the tag)
+/// - `op-reth/v2.3.3-rc.1`        -> `Some(("2.3.3-rc.1", true))`
+/// - anything else (e.g. vergen's `VERGEN_IDEMPOTENT_OUTPUT` when `.git` is absent) -> `None`
+fn parse_describe(describe: &str) -> Option<(&str, bool)> {
+    let rest = describe.strip_prefix("op-reth/v")?;
+    // `git describe` appends `-<commits>-g<sha>` once HEAD moves past the tag. Split from the
+    // right so multi-segment prerelease tags (`2.3.3-rc.1`) survive, then strip that suffix.
+    let mut it = rest.rsplitn(3, '-');
+    match (it.next(), it.next(), it.next()) {
+        (Some(sha), Some(commits), Some(base))
+            if commits.bytes().all(|b| b.is_ascii_digit())
+                && sha
+                    .strip_prefix('g')
+                    .is_some_and(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_hexdigit())) =>
+        {
+            Some((base, false))
+        }
+        _ => Some((rest, true)),
+    }
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut emitter = Emitter::default();
@@ -15,43 +55,84 @@ fn main() -> Result<(), Box<dyn Error>> {
     let cargo_builder = CargoBuilder::default().features(true).target_triple(true).build()?;
     emitter.add_instructions(&cargo_builder)?;
 
-    let git_builder =
-        Git2Builder::default().describe(false, true, None).dirty(true).sha(false).build()?;
+    // `describe(tags, dirty, matches)`: match `op-reth/v*` so `VERGEN_GIT_DESCRIBE` reflects
+    // op-reth's own release tag rather than whatever tag (op-node, cannon, ...) is nearest in this
+    // shared monorepo. `tags = true` to also see lightweight tags; `dirty = false` keeps the
+    // describe string clean for parsing — the separate `.dirty(true)` still emits
+    // `VERGEN_GIT_DIRTY`, which we fold into the `-dev` suffix below.
+    let git_builder = Git2Builder::default()
+        .describe(true, false, Some("op-reth/v*"))
+        .dirty(true)
+        .sha(false)
+        .build()?;
     emitter.add_instructions(&git_builder)?;
 
     emitter.emit_and_set()?;
-    let sha = env::var("VERGEN_GIT_SHA")?;
-    let sha_short = &sha[0..7];
 
-    let is_dirty = env::var("VERGEN_GIT_DIRTY")? == "true";
-    // > git describe --always --tags
-    // if not on a tag: v0.2.0-beta.3-82-g1939939b
-    // if on a tag: v0.2.0-beta.3
-    let not_on_tag = env::var("VERGEN_GIT_DESCRIBE")?.ends_with(&format!("-g{sha_short}"));
-    let version_suffix = if is_dirty || not_on_tag { "-dev" } else { "" };
+    let discovered_sha = env::var("VERGEN_GIT_SHA")?;
+    let describe = env::var("VERGEN_GIT_DESCRIBE").unwrap_or_default();
+
+    // With no `.git` in the Docker context, vergen can't discover the commit or the tag;
+    // docker-bake.hcl threads both in as build args. Prefer discovered values, fall back to args.
+    let git_commit_arg = env::var("GIT_COMMIT").unwrap_or_default();
+    let is_real_sha =
+        git_commit_arg.len() >= 8 && git_commit_arg.chars().all(|c| c.is_ascii_hexdigit());
+    // `OP_RETH_VERSION` (from bake's per-image `GIT_VERSION`) is the tag with its `op-reth/`
+    // prefix stripped, e.g. `v2.3.3`; a non-release build passes an untagged marker instead.
+    let version_arg = env::var("OP_RETH_VERSION").unwrap_or_default();
+    let arg_version = version_arg.strip_prefix('v').unwrap_or(&version_arg);
+    let arg_is_release = arg_version.starts_with(|c: char| c.is_ascii_digit());
+    println!("cargo:rerun-if-env-changed=GIT_COMMIT");
+    println!("cargo:rerun-if-env-changed=OP_RETH_VERSION");
+
+    let (sha, pkg_version, version_suffix) = if discovered_sha != VERGEN_IDEMPOTENT_OUTPUT {
+        // `.git` was discoverable: take both the commit and the release version from it.
+        let is_dirty = env::var("VERGEN_GIT_DIRTY")? == "true";
+        let (base, on_tag) = parse_describe(&describe).unwrap_or((DEV_VERSION, false));
+        (discovered_sha, base.to_string(), if is_dirty || !on_tag { "-dev" } else { "" })
+    } else if is_real_sha {
+        // Docker: no `.git`, but the build args carry the real commit and (for release builds) the
+        // tag. Images are built from a clean checkout of that exact tagged commit, so there's no
+        // dirty/off-tag state to detect.
+        if arg_is_release {
+            (git_commit_arg, arg_version.to_string(), "")
+        } else {
+            (git_commit_arg, DEV_VERSION.to_string(), "-dev")
+        }
+    } else {
+        // No `.git` to discover and no usable `GIT_COMMIT` arg — don't ship a truncated vergen
+        // placeholder as though it were a real commit/version.
+        ("unknown".to_string(), DEV_VERSION.to_string(), "-dev")
+    };
+    // Match reth's convention: 7-char SHA in the human/P2P version strings.
+    let sha_short = &sha[..sha.len().min(7)];
     println!("cargo:rustc-env=OP_RETH_VERSION_SUFFIX={version_suffix}");
 
-    // Set short SHA
-    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha[..8]);
+    // Re-emit the (possibly arg-sourced) SHA under vergen's own env var names, overriding what
+    // `emit_and_set` printed, so `src/version.rs`'s `env!("VERGEN_GIT_SHA*")` pick up corrections.
+    println!("cargo:rustc-env=VERGEN_GIT_SHA={sha}");
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha[..sha.len().min(8)]);
+
+    // Re-export the resolved op-reth release version for `src/version.rs`, whose
+    // `cargo_pkg_version` field feeds `engine_getClientVersionV1`. Suffix-free, mirroring reth's
+    // own `cargo_pkg_version` (the `-dev` marker only rides along in the formatted strings below).
+    println!("cargo:rustc-env=OP_RETH_PKG_VERSION={pkg_version}");
 
     // Set the build profile
     let out_dir = env::var("OUT_DIR").unwrap();
     let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
     println!("cargo:rustc-env=OP_RETH_BUILD_PROFILE={profile}");
 
-    // Set formatted version strings
-    let pkg_version = env!("CARGO_PKG_VERSION");
-
     // The short version information for op-reth.
-    // - The latest version from Cargo.toml
+    // - op-reth's release version (from the `op-reth/v*` git tag)
     // - The short SHA of the latest commit.
-    // Example: 1.11.3 (defa64b2)
+    // Example: 2.3.3 (af90f02)
     println!("cargo:rustc-env=OP_RETH_SHORT_VERSION={pkg_version}{version_suffix} ({sha_short})");
 
     // LONG_VERSION
     // The long version information for op-reth.
     //
-    // - The latest version from Cargo.toml + version suffix (if any)
+    // - op-reth's release version (from the git tag) + version suffix (if any)
     // - The full SHA of the latest commit
     // - The build datetime
     // - The build features
@@ -60,8 +141,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Example:
     //
     // ```text
-    // Version: 1.11.3
-    // Commit SHA: defa64b2
+    // Version: 2.3.3
+    // Commit SHA: af90f026ce05f8...
     // Build Timestamp: 2023-05-19T01:47:19.815651705Z
     // Build Features: jemalloc
     // Build Profile: maxperf
@@ -79,10 +160,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-env=OP_RETH_LONG_VERSION_4=Build Profile: {profile}");
 
     // The version information for op-reth formatted for P2P (devp2p).
-    // - The latest version from Cargo.toml
+    // - op-reth's release version (from the `op-reth/v*` git tag)
     // - The target triple
     //
-    // Example: op-reth/v1.11.3-428a6dc2f/aarch64-apple-darwin
+    // Example: op-reth/v2.3.3-af90f02/aarch64-apple-darwin
     println!(
         "cargo:rustc-env=OP_RETH_P2P_CLIENT_VERSION={}",
         format_args!(

--- a/rust/op-reth/bin/src/main.rs
+++ b/rust/op-reth/bin/src/main.rs
@@ -5,6 +5,8 @@ use reth_optimism_cli::{Cli, chainspec::OpChainSpecParser};
 use reth_optimism_node::{args::RollupArgs, proof_history};
 use tracing::info;
 
+mod version;
+
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
@@ -21,6 +23,11 @@ fn main() {
             std::env::set_var("RUST_BACKTRACE", "1");
         }
     }
+
+    // Must run before anything reads `reth_node_core::version::version_metadata()` (the CLI
+    // parser below, RPC server setup, and p2p handshake all do), so that op-reth reports its
+    // own version instead of the pinned upstream reth crate's.
+    let _ = reth_node_core::version::try_init_version_metadata(version::op_reth_version_metadata());
 
     if let Err(err) =
         Cli::<OpChainSpecParser, RollupArgs>::parse().run(async move |builder, args| {

--- a/rust/op-reth/bin/src/version.rs
+++ b/rust/op-reth/bin/src/version.rs
@@ -17,7 +17,10 @@ use std::borrow::Cow;
 pub(crate) fn op_reth_version_metadata() -> RethCliVersionConsts {
     RethCliVersionConsts {
         name_client: Cow::Borrowed(OP_NAME_CLIENT),
-        cargo_pkg_version: Cow::Borrowed(env!("CARGO_PKG_VERSION")),
+        // op-reth's release version (from the `op-reth/v*` git tag), resolved in `build.rs` — not
+        // `CARGO_PKG_VERSION`, which tracks the vendored reth-optimism library crates. Feeds
+        // `engine_getClientVersionV1` and the DB client version.
+        cargo_pkg_version: Cow::Borrowed(env!("OP_RETH_PKG_VERSION")),
         vergen_git_sha_long: Cow::Borrowed(env!("VERGEN_GIT_SHA")),
         vergen_git_sha: Cow::Borrowed(env!("VERGEN_GIT_SHA_SHORT")),
         vergen_build_timestamp: Cow::Borrowed(env!("VERGEN_BUILD_TIMESTAMP")),

--- a/rust/op-reth/bin/src/version.rs
+++ b/rust/op-reth/bin/src/version.rs
@@ -1,0 +1,41 @@
+//! Version metadata for the `op-reth` binary.
+//!
+//! `reth-node-core` exposes a global [`RethCliVersionConsts`] singleton (read by the CLI
+//! `--version` output, `web3_clientVersion`, `engine_getClientVersionV1`, and the p2p `Hello`
+//! handshake identity) that otherwise defaults to the pinned upstream `reth` crate's own
+//! version and commit, since `reth-node-core` computes it from its own compile-time env vars.
+//! [`try_init_version_metadata`] must be called once, before that singleton is first read, to
+//! override it with `op-reth`'s own version and commit info.
+//!
+//! [`try_init_version_metadata`]: reth_node_core::version::try_init_version_metadata
+
+use reth_node_core::version::RethCliVersionConsts;
+use reth_optimism_node::OP_NAME_CLIENT;
+use std::borrow::Cow;
+
+/// Builds the `op-reth`-specific version metadata, sourced from env vars emitted by `build.rs`.
+pub(crate) fn op_reth_version_metadata() -> RethCliVersionConsts {
+    RethCliVersionConsts {
+        name_client: Cow::Borrowed(OP_NAME_CLIENT),
+        cargo_pkg_version: Cow::Borrowed(env!("CARGO_PKG_VERSION")),
+        vergen_git_sha_long: Cow::Borrowed(env!("VERGEN_GIT_SHA")),
+        vergen_git_sha: Cow::Borrowed(env!("VERGEN_GIT_SHA_SHORT")),
+        vergen_build_timestamp: Cow::Borrowed(env!("VERGEN_BUILD_TIMESTAMP")),
+        vergen_cargo_target_triple: Cow::Borrowed(env!("VERGEN_CARGO_TARGET_TRIPLE")),
+        vergen_cargo_features: Cow::Borrowed(env!("VERGEN_CARGO_FEATURES")),
+        short_version: Cow::Borrowed(env!("OP_RETH_SHORT_VERSION")),
+        long_version: Cow::Owned(format!(
+            "{}\n{}\n{}\n{}\n{}",
+            env!("OP_RETH_LONG_VERSION_0"),
+            env!("OP_RETH_LONG_VERSION_1"),
+            env!("OP_RETH_LONG_VERSION_2"),
+            env!("OP_RETH_LONG_VERSION_3"),
+            env!("OP_RETH_LONG_VERSION_4"),
+        )),
+        build_profile_name: Cow::Borrowed(env!("OP_RETH_BUILD_PROFILE")),
+        p2p_client_version: Cow::Borrowed(env!("OP_RETH_P2P_CLIENT_VERSION")),
+        // `extra_data` isn't read anywhere in op-reth today; op-reth's payload builder computes
+        // its own OP Stack extra-data bytes instead.
+        ..Default::default()
+    }
+}


### PR DESCRIPTION
## Summary
- `web3_clientVersion`, `engine_getClientVersionV1`, the CLI `--version` output, and the p2p `Hello` handshake identity all read a global singleton in `reth-node-core` that defaults to the pinned upstream `reth` crate's own version/commit. op-reth never overrode it, so all of these reported reth's version instead of op-reth's.
- Add a `build.rs` to the `op-reth` binary crate that emits op-reth-specific version/commit env vars (mirroring `reth-node-core`'s own `build.rs`, and `op-rbuilder`'s existing adaptation of it), and initialize the singleton with them via `try_init_version_metadata()` before the CLI is parsed.

## Test plan
- [x] `cargo build -p op-reth --bin op-reth` and confirmed `op-reth --version` now reports op-reth's own version + the monorepo's commit SHA instead of upstream reth's.
- [x] Ran `op-reth node --dev` locally and confirmed `web3_clientVersion` returns `op-reth/v<version>-<sha>/<target>` instead of `reth/v...`.
- [x] `cargo clippy -p op-reth --bin op-reth -- -D warnings` and `cargo +nightly fmt -p op-reth --check` are clean.