### PR TITLE
fix(kona-node): align metrics version with CLI build version

### DIFF
--- a/rust/kona/bin/node/src/metrics/version.rs
+++ b/rust/kona/bin/node/src/metrics/version.rs
@@ -29,7 +29,7 @@ impl VersionInfo {
     /// at compile time.
     pub const fn from_build() -> Self {
         Self {
-            version: crate::version::CARGO_PKG_VERSION,
+            version: crate::version::SHORT_VERSION,
             build_timestamp: crate::version::VERGEN_BUILD_TIMESTAMP,
             cargo_features: crate::version::VERGEN_CARGO_FEATURES,
             git_sha: crate::version::VERGEN_GIT_SHA,
@@ -55,5 +55,17 @@ impl VersionInfo {
 
         let gauge = gauge!("kona_node_info", &labels);
         gauge.set(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_build_uses_cli_short_version() {
+        let info = VersionInfo::from_build();
+
+        assert_eq!(info.version, crate::version::SHORT_VERSION);
     }
 }

--- a/rust/kona/bin/node/src/version.rs
+++ b/rust/kona/bin/node/src/version.rs
@@ -1,8 +1,5 @@
 //! Version information for kona-node.
 
-/// The latest version from Cargo.toml.
-pub(crate) const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
-
 /// The 8 character short SHA of the latest commit.
 pub(crate) const VERGEN_GIT_SHA: &str = env!("VERGEN_GIT_SHA_SHORT");
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Partly for #20832

Updates the `kona_node_info` metrics version label to use the same build-script-generated short version as `kona-node --version`, instead of the raw `CARGO_PKG_VERSION`.

This keeps the metrics-reported version aligned with the build/git-derived version string exposed by the CLI.



**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

- `cargo test -p kona-node from_build_uses_cli_short_version`
- `cargo +nightly fmt -p kona-node --check`


**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
