### PR TITLE
fix(op-node): drop stale light sequencer builds after follow reset

### DIFF
--- a/op-node/rollup/engine/build_start.go
+++ b/op-node/rollup/engine/build_start.go
@@ -22,6 +22,12 @@ func (e *EngineController) onBuildStart(ctx context.Context, ev BuildStartEvent)
 	rpcCtx, cancel := context.WithTimeout(e.ctx, buildStartTimeout)
 	defer cancel()
 
+	if ev.Attributes.DerivedFrom == (eth.L1BlockRef{}) && ev.Attributes.Parent != e.unsafeHead {
+		e.log.Warn("dropping stale sequencer build start after unsafe head changed",
+			"attributes_parent", ev.Attributes.Parent, "unsafe", e.unsafeHead)
+		return
+	}
+
 	if ev.Attributes.DerivedFrom != (eth.L1BlockRef{}) &&
 		e.pendingSafeHead.Hash != ev.Attributes.Parent.Hash {
 		// Warn about small reorgs, happens when pending safe head is getting rolled back

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -1230,16 +1230,25 @@ func (e *EngineController) forceReset(ctx context.Context, localUnsafe, crossUns
 		e.emitter.Emit(ctx, derive.ConfirmPipelineResetEvent{})
 	}
 
-	if signalOnlySeq {
-		// Intentionally not propagating ForkchoiceUpdateEvent to other event Deriver avoiding side effects.
-		// If we do tryUpdateEngine instead, it will eventually emit ForkchoiceUpdateEvent, causing block building
-		// to never begin. Use fine grained ForkchoiceUpdateInitEvent to only propagate info to the sequencer component.
+	notifySequencer := func() {
 		e.emitter.Emit(ctx, ForkchoiceUpdateInitEvent{
 			UnsafeL2Head:    e.unsafeHead,
 			SafeL2Head:      e.SafeL2Head(),
 			FinalizedL2Head: e.FinalizedHead(),
 		})
+	}
+	if signalOnlySeq {
+		// Intentionally not propagating ForkchoiceUpdateEvent to other event Deriver avoiding side effects.
+		// If we do tryUpdateEngine instead, it will eventually emit ForkchoiceUpdateEvent, causing block building
+		// to never begin. Use fine grained ForkchoiceUpdateInitEvent to only propagate info to the sequencer component.
+		notifySequencer()
 	} else {
+		if e.originSelectorResetter != nil {
+			// A reset can ask an EL-sync engine to follow a head it has not fully imported yet.
+			// In that case tryUpdateEngine may return SYNCING without emitting ForkchoiceUpdateEvent,
+			// so update the sequencer's view of the reset head explicitly before it resumes.
+			notifySequencer()
+		}
 		// Time to apply the changes to the underlying engine
 		e.tryUpdateEngine(ctx)
 	}
@@ -1497,6 +1506,15 @@ func (e *EngineController) FollowSource(eSafeBlockRef, eLocalSafeRef, eFinalized
 	logger.Info("Follow Source: Process external refs")
 
 	if e.unsafeHead.Number < eLocalSafeRef.Number {
+		// A follow-mode sequencer can still have an in-flight build on its old unsafe
+		// head while the followed source advances beyond it. Reset instead of taking
+		// the verifier's soft path so the sequencer drops work on the orphaned head
+		// before it can be submitted to the EL.
+		if e.originSelectorResetter != nil {
+			logger.Warn("Follow Source: Reset onto upstream chain ahead of active sequencer")
+			e.forceReset(e.ctx, eLocalSafeRef, eLocalSafeRef, eLocalSafeRef, eSafeBlockRef, eFinalizedRef, false)
+			return
+		}
 		// EL Sync target may be updated
 		logger.Debug("Follow Source: EL Sync: External local safe ahead of current unsafe")
 		followExternalRefs(true)

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum"
@@ -975,6 +976,136 @@ func TestFollowSource_SequencerExternalLocalSafeAheadForcesReset(t *testing.T) {
 	require.Equal(t, block3, initEvents[0].SafeL2Head)
 	require.Equal(t, block2, initEvents[0].FinalizedL2Head)
 	mockEngine.AssertExpectations(t)
+}
+
+func TestBuildStartDropsStaleSequencerBuildAfterFollowSourceReset(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(28029))
+	l1Origin := testutils.RandomBlockRef(rng)
+	mk := func(num uint64, parent common.Hash) eth.L2BlockRef {
+		return eth.L2BlockRef{
+			Hash: testutils.RandomHash(rng), Number: num,
+			ParentHash: parent, Time: l1Origin.Time + num,
+			L1Origin: l1Origin.ID(), SequenceNumber: num,
+		}
+	}
+	block27 := mk(27, testutils.RandomHash(rng))
+	oldParent28 := mk(28, block27.Hash)
+	upstream29 := mk(29, oldParent28.Hash)
+
+	interopTime := uint64(0)
+	cfg := &rollup.Config{LagoonTime: &interopTime}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	var emitted []event.Event
+	emitter.ExpectMaybeRun(func(ev event.Event) {
+		emitted = append(emitted, ev)
+	})
+
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+		metrics.NoopMetrics, cfg, &sync.Config{L2FollowSourceEndpoint: "http://localhost"}, &testutils.MockL1Source{}, emitter, nil)
+	originResetter := &recordingOriginResetter{}
+	ec.SetOriginSelectorResetter(originResetter)
+
+	// The sequencer has already emitted a BuildStartEvent for block 29 on top of
+	// oldParent28, but the engine event has not handled it yet.
+	ec.unsafeHead = oldParent28
+	ec.SetLocalSafeHead(block27)
+	ec.SetDeprecatedSafeHead(block27)
+	ec.SetFinalizedHead(block27)
+	ec.lastForkchoice = eth.ForkchoiceState{
+		HeadBlockHash:      oldParent28.Hash,
+		SafeBlockHash:      block27.Hash,
+		FinalizedBlockHash: block27.Hash,
+	}
+	staleBuildStart := BuildStartEvent{Attributes: &derive.AttributesWithParent{
+		Attributes: &eth.PayloadAttributes{Timestamp: eth.Uint64Quantity(oldParent28.Time + cfg.BlockTime)},
+		Parent:     oldParent28,
+	}}
+
+	// FollowSource is a direct driver call, not an event. It can reset the engine
+	// to the upstream local-safe head before the already-queued BuildStartEvent is
+	// delivered to EngineController.onBuildStart.
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      upstream29.Hash,
+			SafeBlockHash:      upstream29.Hash,
+			FinalizedBlockHash: block27.Hash,
+		}, nil,
+		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil,
+	)
+	ec.FollowSource(upstream29, upstream29, block27)
+	require.Equal(t, upstream29, ec.unsafeHead)
+	require.Equal(t, 1, originResetter.resets)
+
+	emittedBeforeStaleBuild := len(emitted)
+
+	// Handling the stale sequencer-originated BuildStartEvent must not call
+	// startPayload/ForkchoiceUpdate with oldParent28 as the FCU head, and must not
+	// emit BuildInvalidEvent or a critical invalid-build path.
+	ec.onBuildStart(context.Background(), staleBuildStart)
+
+	require.Len(t, emitted, emittedBeforeStaleBuild)
+	mockEngine.AssertNumberOfCalls(t, "ForkchoiceUpdate", 1)
+	mockEngine.AssertExpectations(t)
+}
+
+func TestBuildStartDropsStaleSequencerBuildForMismatchedUnsafeHead(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(2829))
+	l1Origin := testutils.RandomBlockRef(rng)
+	mk := func(num uint64, parent common.Hash) eth.L2BlockRef {
+		return eth.L2BlockRef{
+			Hash: testutils.RandomHash(rng), Number: num,
+			ParentHash: parent, Time: l1Origin.Time + num,
+			L1Origin: l1Origin.ID(), SequenceNumber: num,
+		}
+	}
+	block27 := mk(27, testutils.RandomHash(rng))
+	oldParent28 := mk(28, block27.Hash)
+	sameHeightReplacement28 := mk(28, block27.Hash)
+	upstream29 := mk(29, sameHeightReplacement28.Hash)
+
+	tests := []struct {
+		name        string
+		currentHead eth.L2BlockRef
+	}{
+		{
+			name:        "same height replacement",
+			currentHead: sameHeightReplacement28,
+		},
+		{
+			name:        "advanced upstream head",
+			currentHead: upstream29,
+		},
+		{
+			name:        "lower-number reset",
+			currentHead: block27,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockEngine := &testutils.MockEngine{}
+			emitter := &testutils.MockEmitter{}
+			emitter.ExpectMaybeRun(func(ev event.Event) {
+				require.Failf(t, "unexpected event", "stale sequencer build start emitted %T: %v", ev, ev)
+			})
+			ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+				metrics.NoopMetrics, &rollup.Config{BlockTime: 1}, &sync.Config{}, &testutils.MockL1Source{}, emitter, nil)
+			ec.unsafeHead = tt.currentHead
+			ec.SetLocalSafeHead(block27)
+			ec.SetDeprecatedSafeHead(block27)
+			ec.SetFinalizedHead(block27)
+
+			ec.onBuildStart(context.Background(), BuildStartEvent{Attributes: &derive.AttributesWithParent{
+				Attributes: &eth.PayloadAttributes{Timestamp: eth.Uint64Quantity(oldParent28.Time + 1)},
+				Parent:     oldParent28,
+			}})
+
+			mockEngine.AssertNotCalled(t, "ForkchoiceUpdate", mock.Anything, mock.Anything, mock.Anything)
+			mockEngine.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+		})
+	}
 }
 
 // TestFollowSource_VerifierDivergenceStaysSoft verifies a follow-mode VERIFIER (no origin-

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -911,6 +911,72 @@ func TestFollowSource_SequencerDivergenceForcesReset(t *testing.T) {
 	mockEngine.AssertExpectations(t)
 }
 
+func TestFollowSource_SequencerExternalLocalSafeAheadForcesReset(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(90210))
+	l1Origin := testutils.RandomBlockRef(rng)
+	mk := func(num uint64, parent common.Hash) eth.L2BlockRef {
+		return eth.L2BlockRef{
+			Hash: testutils.RandomHash(rng), Number: num,
+			ParentHash: parent, Time: l1Origin.Time + num,
+			L1Origin: l1Origin.ID(), SequenceNumber: num,
+		}
+	}
+	block1 := mk(1, testutils.RandomHash(rng))
+	block2 := mk(2, block1.Hash)
+	block3 := mk(3, block2.Hash)
+	currentBlock4 := mk(4, block3.Hash)
+	extBlock5 := mk(5, currentBlock4.Hash)
+
+	interopTime := uint64(0)
+	cfg := &rollup.Config{LagoonTime: &interopTime}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	var initEvents []ForkchoiceUpdateInitEvent
+	emitter.Mock.On("Emit", mock.Anything).Maybe().Run(func(args mock.Arguments) {
+		if ev, ok := args.Get(0).(ForkchoiceUpdateInitEvent); ok {
+			initEvents = append(initEvents, ev)
+		}
+	})
+
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+		metrics.NoopMetrics, cfg, &sync.Config{L2FollowSourceEndpoint: "http://localhost"}, &testutils.MockL1Source{}, emitter, nil)
+
+	originResetter := &recordingOriginResetter{}
+	ec.SetOriginSelectorResetter(originResetter)
+
+	ec.unsafeHead = currentBlock4
+	ec.SetLocalSafeHead(block1)
+	ec.SetDeprecatedSafeHead(block1)
+	ec.SetFinalizedHead(block1)
+	ec.lastForkchoice = eth.ForkchoiceState{
+		HeadBlockHash:      currentBlock4.Hash,
+		SafeBlockHash:      block1.Hash,
+		FinalizedBlockHash: block1.Hash,
+	}
+
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      extBlock5.Hash,
+			SafeBlockHash:      block3.Hash,
+			FinalizedBlockHash: block2.Hash,
+		}, nil,
+		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil,
+	)
+
+	ec.FollowSource(block3, extBlock5, block2)
+
+	require.Equal(t, 1, originResetter.resets, "sequencer must reset origins when upstream local-safe advances beyond its unsafe head")
+	require.Equal(t, extBlock5, ec.unsafeHead, "unsafe head must jump to the upstream local-safe head")
+	require.Equal(t, extBlock5, ec.localSafeHead, "local safe must jump to the upstream local-safe head")
+	require.Equal(t, block3, ec.deprecatedSafeHead, "cross safe must follow the upstream cross-safe head")
+	require.Equal(t, block2, ec.deprecatedFinalizedHead, "finalized head must follow the upstream finalized head")
+	require.Len(t, initEvents, 1, "sequencer must be told the reset head even when the FCU path is async/syncing")
+	require.Equal(t, extBlock5, initEvents[0].UnsafeL2Head)
+	require.Equal(t, block3, initEvents[0].SafeL2Head)
+	require.Equal(t, block2, initEvents[0].FinalizedL2Head)
+	mockEngine.AssertExpectations(t)
+}
+
 // TestFollowSource_VerifierDivergenceStaysSoft verifies a follow-mode VERIFIER (no origin-
 // selector resetter) keeps the soft follow path on divergence WITHOUT resetting origins —
 // there is no competing block production. The #21119 fix must not change this path.

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -476,8 +476,9 @@ func (d *Sequencer) onForkchoiceUpdate(x engine.ForkchoiceUpdateEvent) {
 		d.setLatestHead(x.UnsafeL2Head)
 		return
 	}
-	// Drop stale block-building job if the chain has moved past it already.
-	if d.latest != (BuildingState{}) && d.latest.Onto.Number < x.UnsafeL2Head.Number {
+	// Drop stale block-building jobs if the chain head changed underneath us. This
+	// includes ordinary advancement, same-height reorgs, and resets to an older head.
+	if d.latest != (BuildingState{}) && d.latest.Onto != (eth.L2BlockRef{}) && d.latest.Onto != x.UnsafeL2Head {
 		d.log.Debug("Dropping stale/completed block-building job",
 			"state", d.latest.Onto, "unsafe_head", x.UnsafeL2Head)
 		// The cleared state will block further BuildStarted/BuildSealed responses from continuing the stale build job.

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -260,22 +260,51 @@ func TestSequencer_StartStop(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestSequencerForkchoiceUpdateDropsStaleSameHeightBuild(t *testing.T) {
-	seq, _ := createSequencer(testlog.Logger(t, log.LevelError))
+func TestSequencerForkchoiceUpdateDropsStaleBuild(t *testing.T) {
 	oldHead := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 5}
-	newHead := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 5}
-
-	seq.active.Store(true)
-	seq.latestHead = oldHead
-	seq.latest = BuildingState{
-		Onto: oldHead,
-		Info: eth.PayloadInfo{ID: eth.PayloadID{0x01}},
+	tests := []struct {
+		name       string
+		newHead    eth.L2BlockRef
+		latestInfo eth.PayloadInfo
+	}{
+		{
+			name:       "same height replacement before build starts",
+			newHead:    eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 5},
+			latestInfo: eth.PayloadInfo{ID: eth.PayloadID{}},
+		},
+		{
+			name:       "same height replacement after build starts",
+			newHead:    eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 5},
+			latestInfo: eth.PayloadInfo{ID: eth.PayloadID{0x01}},
+		},
+		{
+			name:       "lower-number reset after build starts",
+			newHead:    eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 4},
+			latestInfo: eth.PayloadInfo{ID: eth.PayloadID{0x02}},
+		},
+		{
+			name:       "advanced upstream head after build starts",
+			newHead:    eth.L2BlockRef{Hash: common.Hash{0xee}, Number: 6},
+			latestInfo: eth.PayloadInfo{ID: eth.PayloadID{0x03}},
+		},
 	}
 
-	seq.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{UnsafeL2Head: newHead})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seq, _ := createSequencer(testlog.Logger(t, log.LevelError))
+			seq.active.Store(true)
+			seq.latestHead = oldHead
+			seq.latest = BuildingState{
+				Onto: oldHead,
+				Info: tt.latestInfo,
+			}
 
-	require.Equal(t, BuildingState{}, seq.latest)
-	require.Equal(t, newHead, seq.latestHead)
+			seq.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{UnsafeL2Head: tt.newHead})
+
+			require.Equal(t, BuildingState{}, seq.latest)
+			require.Equal(t, tt.newHead, seq.latestHead)
+		})
+	}
 }
 
 // TestSequencer_StaleBuild stops the sequencer after block-building,

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -260,6 +260,24 @@ func TestSequencer_StartStop(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSequencerForkchoiceUpdateDropsStaleSameHeightBuild(t *testing.T) {
+	seq, _ := createSequencer(testlog.Logger(t, log.LevelError))
+	oldHead := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 5}
+	newHead := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 5}
+
+	seq.active.Store(true)
+	seq.latestHead = oldHead
+	seq.latest = BuildingState{
+		Onto: oldHead,
+		Info: eth.PayloadInfo{ID: eth.PayloadID{0x01}},
+	}
+
+	seq.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{UnsafeL2Head: newHead})
+
+	require.Equal(t, BuildingState{}, seq.latest)
+	require.Equal(t, newHead, seq.latestHead)
+}
+
 // TestSequencer_StaleBuild stops the sequencer after block-building,
 // but before processing the block locally,
 // and then continues it again, to check if the async-gossip gets cleared,


### PR DESCRIPTION
Fixes ethereum-optimism/optimism#21635.

`TestSupernodeLightSequencerInteropInvalidMessageReplacement` can flake when follow-mode light sequencers process an upstream local-safe head that advances beyond their current unsafe head. The old path handled that as a soft verifier-style update, so the sequencer could keep queued build work for an orphaned parent. If op-reth imported the upstream chain first, that stale build could hit `missing parent header`, trip the deposit-only invalid-build path, stop the light sequencer, and leave the EL safe head stuck below the test target.

This changes follow-source handling for active sequencers to force-reset on upstream local-safe advance/divergence, sends the sequencer reset notification on the normal reset path, clears stale sequencer build state on any unsafe-head mismatch, and drops stale queued sequencer build-start events at the engine boundary before `startPayload`.

Flake count: CircleCI Insights reported 1 recorded flake for `TestSupernodeLightSequencerInteropInvalidMessageReplacement`.

Targeted verification:
- `go test ./op-node/rollup/engine ./op-node/rollup/sequencing -count=1`
- fix agent: engine stale-build regressions `-count=100` passed; sequencer stale-build regression `-count=100` passed
- reviewer: targeted engine/sequencer regressions passed

The direct acceptance test was attempted locally but blocked before behavior by missing `packages/contracts-bedrock/forge-artifacts` in the worktree.