### PR TITLE
ci: retire Go fuzz CI jobs

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1579,57 +1579,6 @@ jobs:
           command: ./ops/scripts/todo-checker.sh --verbose --strict <<#parameters.check_closed>> --check-closed <</parameters.check_closed>>
       - notify-failures-on-develop
 
-  fuzz-golang:
-    parameters:
-      package_name:
-        description: Go package name
-        type: string
-      on_changes:
-        description: changed pattern to fire fuzzer on
-        type: string
-      uses_artifacts:
-        description: should load in foundry artifacts
-        type: boolean
-        default: false
-    docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge.gen2
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-          enable-mise-cache: true
-      - check-changed:
-          patterns: "<<parameters.package_name>>"
-      - attach_workspace:
-          at: "."
-          if: ${{ uses_artifacts }}
-      - go-restore-cache:
-          namespace: fuzz-<<parameters.package_name>>
-      - run:
-          name: Run fuzz seeds
-          no_output_timeout: 15m
-          command: |
-            case "<<parameters.package_name>>" in
-              op-challenger) go test -count=1 -run=Fuzz -v ./game/keccak/matrix ;;
-              op-node) go test -count=1 -run=Fuzz -v ./rollup/derive ;;
-              op-service) go test -count=1 -run=Fuzz -v ./eth ;;
-              op-chain-ops) go test -count=1 -run=Fuzz -v ./crossdomain ;;
-              cannon) go test -count=1 -run=Fuzz -v ./mipsevm/tests ;;
-              op-e2e) go test -count=1 -run=Fuzz -tags cgo_test -v ./opgeth ;;
-            esac
-          working_directory: "<<parameters.package_name>>"
-      - go-save-cache:
-          namespace: fuzz-<<parameters.package_name>>
-      - run:
-          name: Copy fuzz artifacts
-          command: |
-            mkdir -p fuzzdata
-            find ./<<parameters.package_name>> -type d -name "fuzz" -exec sh -c 'cp -r "{}"/* fuzzdata/ 2>/dev/null || true' \;
-          when: always
-      - store_artifacts:
-          path: ./fuzzdata
-          when: always
-
   go-lint:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
@@ -2496,46 +2445,6 @@ workflows:
             - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - fuzz-golang:
-          name: fuzz-golang-<<matrix.package_name>>
-          on_changes: <<matrix.package_name>>
-          # attaches prep-superchain's superchain-configs.zip, which several of these packages //go:embed.
-          uses_artifacts: true
-          matrix:
-            parameters:
-              package_name:
-                - op-challenger
-                - op-node
-                - op-service
-                - op-chain-ops
-          requires:
-            - prep-go-modules
-            - prep-superchain
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-      - fuzz-golang:
-          name: cannon-fuzz
-          package_name: cannon
-          on_changes: cannon,packages/contracts-bedrock/src/cannon
-          uses_artifacts: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - contracts-bedrock-build
-            - prep-go-modules
-      - fuzz-golang:
-          name: op-e2e-fuzz
-          package_name: op-e2e
-          on_changes: op-e2e,packages/contracts-bedrock/src
-          uses_artifacts: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - contracts-bedrock-build
-            - cannon-prestate
-            - prep-go-modules
-            # for the gitignored superchain-configs.zip op-e2e //go:embeds
-            - prep-superchain
       - go-tests:
           name: go-tests-short
           parallelism: 12
@@ -2738,13 +2647,6 @@ workflows:
             - l2-chains-sync-check: terminal
             - nut-provenance-verify: terminal
             - diff-fetcher-forge-artifacts: terminal
-            # Fuzz jobs.
-            - cannon-fuzz: terminal
-            - op-e2e-fuzz: terminal
-            - fuzz-golang-op-challenger: terminal
-            - fuzz-golang-op-node: terminal
-            - fuzz-golang-op-service: terminal
-            - fuzz-golang-op-chain-ops: terminal
           context:
             - circleci-api-token
           filters:

--- a/op-node/justfile
+++ b/op-node/justfile
@@ -35,7 +35,7 @@ fuzz:
 	printf "%s\n" \
 		"FuzzL1InfoBedrockRoundTrip" \
 		"FuzzL1InfoEcotoneRoundTrip" \
-		"FuzzL1InfoAgainstContract" \
+		"FuzzL1InfoBedrockAgainstContract" \
 		"FuzzUnmarshallLogEvent" \
 		"FuzzParseFrames" \
 		"FuzzFrameUnmarshalBinary" \


### PR DESCRIPTION
## Summary

Retires the six Go fuzz CI jobs and closes #21636 (follow-up to #21547).

Removed:
- the `fuzz-golang` reusable job definition
- its three invocations: the `fuzz-golang` matrix (`op-challenger`, `op-node`, `op-service`, `op-chain-ops`), plus `cannon-fuzz` and `op-e2e-fuzz`
- the six corresponding `terminal` entries in the `ci-gate` required-status-check fan-in

Also fixes a stale target name in `op-node/justfile` (`FuzzL1InfoAgainstContract` → `FuzzL1InfoBedrockAgainstContract`).

## Why

#21547 already converted these jobs from time-bounded `-fuzztime` exploration to **seed-only** runs (`go test -run=Fuzz`). That is the right call for the merge queue, but as its own "known gap" noted, it leaves the jobs doing almost nothing:

- There is **no committed seed corpus** anywhere in the repo (`find … -path '*testdata/fuzz*'` is empty).
- Most targets have **zero inline `f.Add(...)` seeds**, so `go test -run=Fuzz` sets up the harness and executes no meaningful cases.
- For targets that *do* have seeds, those seed cases are **already exercised** by the normal unit-test jobs — plain `go test` runs each Fuzz target's seed corpus as regular subtests. So the dedicated seed-only jobs are redundant with coverage we already have, at the cost of CI minutes, flake surface, and maintenance.

Evidence of bit-rot: the `op-node` justfile referenced `FuzzL1InfoAgainstContract`, which does not exist (the function is `FuzzL1InfoBedrockAgainstContract`) — so op-node's differential Go-vs-Solidity fuzzer had been silently not running. This PR fixes the name so the target resolves for local `just fuzz` and any future job.

## What is retained

- All `func Fuzz*` functions stay in place and keep running as **seed tests** in the normal unit-test jobs — no coverage lost for anything with a meaningful seed (e.g. `FuzzOBP01`, the fastlz differential pair, the against-contract target).
- The `just fuzz` recipes are kept for local/manual exploration.

## Follow-up (not this PR)

A nightly fuzz job is only worth standing up if paired with (a) a committed seed corpus, (b) meaningful `-fuzztime`, and (c) crash-artifact persistence + alerting. Without those, a nightly job is the same low-value burn on a timer. If desired, that should be a scoped ticket targeting the genuinely high-value differential targets (fastlz, L1-info-against-contract, Fjord cost) and the cannon VM targets — not the mature roundtrip encoders.

## Tests

- `ruby -e 'require "yaml"; YAML.load_file(".circleci/continue/main.yml")'` → OK
- `bash .circleci/scripts/test-decision-tree.sh` → 18 passed, 0 failed
- Reviewed the merged config (`merge-configs.sh`) to confirm `ci-gate` and `nut-provenance-verify` are coherent with no dangling `requires:`/`context:` entries.

Closes #21636

🤖 Generated with [Claude Code](https://claude.com/claude-code)