### PR TITLE
contracts-bedrock: support post-migration fork live setup

### DIFF
--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -122,8 +122,8 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
     {
         // Get initial proposer/challenger from existing DGF.
         bool superRoot = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
-        address initialChallenger = _initialPermissionedGameChallenger(superRoot);
-        address initialProposer = _initialPermissionedGameProposer(superRoot);
+        address initialChallenger = _initialPermissionedGameChallenger();
+        address initialProposer = _initialPermissionedGameProposer();
 
         IOPContractsManagerUtils.DisputeGameConfig[] memory dgConfigs =
             new IOPContractsManagerUtils.DisputeGameConfig[](6);
@@ -202,11 +202,11 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
         cts_ = opcmV2.deploy(deployConfig);
     }
 
-    function _initialPermissionedGameChallenger(bool) internal view returns (address challenger_) {
+    function _initialPermissionedGameChallenger() internal view returns (address challenger_) {
         challenger_ = DisputeGames.permissionedGameChallenger(disputeGameFactory);
     }
 
-    function _initialPermissionedGameProposer(bool) internal view returns (address proposer_) {
+    function _initialPermissionedGameProposer() internal view returns (address proposer_) {
         proposer_ = DisputeGames.permissionedGameProposer(disputeGameFactory);
     }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -202,10 +202,8 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
         cts_ = opcmV2.deploy(deployConfig);
     }
 
-    function _initialPermissionedGameChallenger(bool _superRoot) internal view returns (address challenger_) {
-        if (!_superRoot) return DisputeGames.permissionedGameChallenger(disputeGameFactory);
-
-        challenger_ = address(0);
+    function _initialPermissionedGameChallenger(bool) internal view returns (address challenger_) {
+        challenger_ = DisputeGames.permissionedGameChallenger(disputeGameFactory);
     }
 
     function _initialPermissionedGameProposer(bool) internal view returns (address proposer_) {

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -208,10 +208,8 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
         challenger_ = address(0);
     }
 
-    function _initialPermissionedGameProposer(bool _superRoot) internal view returns (address proposer_) {
-        if (!_superRoot) return DisputeGames.permissionedGameProposer(disputeGameFactory);
-
-        proposer_ = DisputeGames.superPermissionedGameProposer(disputeGameFactory);
+    function _initialPermissionedGameProposer(bool) internal view returns (address proposer_) {
+        proposer_ = DisputeGames.permissionedGameProposer(disputeGameFactory);
     }
 
     /// @notice Creates the default migration input with both SPDG and SCKDG.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -33,6 +33,7 @@ import { IOPContractsManagerMigrator } from "interfaces/L1/opcm/IOPContractsMana
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IZKVerifier } from "interfaces/dispute/zk/IZKVerifier.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
@@ -489,6 +490,23 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
         public
     {
         _runOpcmV2UpgradeAndChecks(opcmV2, _delegateCaller, _revertBytes, _expectedValidatorErrors);
+    }
+
+    /// @notice Reloads fork-live contract handles after rerunning ForkL1Live, which may overwrite artifacts.
+    function _reloadForkLiveContracts() internal {
+        systemConfig = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
+        optimismPortal2 = IOptimismPortal2(payable(artifacts.mustGetAddress("OptimismPortalProxy")));
+        ethLockbox = IETHLockbox(artifacts.getAddress("ETHLockboxProxy"));
+        superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
+        disputeGameFactory = IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
+        anchorStateRegistry = IAnchorStateRegistry(artifacts.mustGetAddress("AnchorStateRegistryProxy"));
+        delayedWeth = IDelayedWETH(artifacts.mustGetAddress("DelayedWETHProxy"));
+        opcmV2 = IOPContractsManagerV2(artifacts.mustGetAddress("OPContractsManagerV2"));
+        proxyAdmin = IProxyAdmin(artifacts.mustGetAddress("ProxyAdmin"));
+        proxyAdminOwner = proxyAdmin.owner();
+        superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig)));
+        superchainProxyAdminOwner = superchainProxyAdmin.owner();
+        setSystemConfig(systemConfig);
     }
 
     /// @notice Extracts the absolute prestate embedded in a dispute game config.
@@ -1491,6 +1509,37 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
                 })
             );
         }
+    }
+
+    /// @notice Tests that future fork-live setup still works after the current upgrade has already been applied.
+    function test_forkLiveSetup_currentUpgradeAlreadyApplied_succeeds() public {
+        skipIfNotForkTest("FutureForkLiveSetup: only runs in forked tests");
+
+        if (isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)) {
+            GameType originalGameType = optimismPortal2.respectedGameType();
+            if (GameTypes.isSuperGame(originalGameType)) {
+                vm.skip(true, "Skipping: fork chain already upgraded to SUPER_ game type");
+            }
+
+            uint32 originalRaw = originalGameType.raw();
+            bool isPermissionless = originalRaw == GameTypes.CANNON.raw() || originalRaw == GameTypes.CANNON_KONA.raw();
+            address currentProposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
+            _setupSuperRootConfigs(isPermissionless, currentProposer);
+        }
+
+        // First apply the current upgrade. The fork state now represents a future live chain
+        // where this upgrade has already landed.
+        runCurrentUpgradeV2(chainPAO);
+
+        // Rerun the same setup path normal fork-live tests use. This must rediscover addresses
+        // from the already-upgraded state and reapply the current upgrade idempotently.
+        deploy.cfg().setUseUpgradedFork(true);
+        forkL1Live.run();
+        _reloadForkLiveContracts();
+
+        // Reapply through the upgrade test helper too, so StandardValidator runs after rereading
+        // fork-live artifacts from the already-upgraded state.
+        runCurrentUpgradeV2(chainPAO);
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -352,15 +352,8 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
     )
         internal
     {
-        // Grab values before we upgrade, to be checked later.
-        address initialChallenger;
+        address initialChallenger = DisputeGames.permissionedGameChallenger(disputeGameFactory);
         address initialProposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
-        if (
-            !isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
-                || address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)) != address(0)
-        ) {
-            initialChallenger = DisputeGames.permissionedGameChallenger(disputeGameFactory);
-        }
 
         // Execute the SuperchainConfig upgrade.
         prankDelegateCall(superchainPAO);
@@ -1522,13 +1515,9 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         skipIfNotForkTest("FutureForkLiveSetup: only runs in forked tests");
 
         if (isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)) {
-            GameType originalGameType = optimismPortal2.respectedGameType();
-            if (GameTypes.isSuperGame(originalGameType)) {
-                vm.skip(true, "Skipping: fork chain already upgraded to SUPER_ game type");
-            }
-
-            uint32 originalRaw = originalGameType.raw();
-            bool isPermissionless = originalRaw == GameTypes.CANNON.raw() || originalRaw == GameTypes.CANNON_KONA.raw();
+            uint32 originalRaw = optimismPortal2.respectedGameType().raw();
+            bool isPermissionless = originalRaw == GameTypes.CANNON.raw() || originalRaw == GameTypes.CANNON_KONA.raw()
+                || originalRaw == GameTypes.SUPER_CANNON_KONA.raw();
             address currentProposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
             _setupSuperRootConfigs(isPermissionless, currentProposer);
         }
@@ -2233,10 +2222,8 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         cts_ = opcmV2.deploy(deployConfig);
     }
 
-    function _initialPermissionedGameChallenger(bool _superRoot) internal view returns (address challenger_) {
-        if (!_superRoot) return DisputeGames.permissionedGameChallenger(disputeGameFactory);
-
-        challenger_ = address(0);
+    function _initialPermissionedGameChallenger(bool) internal view returns (address challenger_) {
+        challenger_ = DisputeGames.permissionedGameChallenger(disputeGameFactory);
     }
 
     function _initialPermissionedGameProposer(bool) internal view returns (address proposer_) {

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -352,9 +352,19 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
     )
         internal
     {
-        // Grab some values before we upgrade, to be checked later
-        address initialChallenger = DisputeGames.permissionedGameChallenger(disputeGameFactory);
-        address initialProposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
+        // Grab values before we upgrade, to be checked later. Once the super-root migration has
+        // already been applied, the legacy PERMISSIONED_CANNON slot is cleared.
+        address initialChallenger;
+        address initialProposer;
+        if (
+            isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
+                && address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)) == address(0)
+        ) {
+            initialProposer = DisputeGames.superPermissionedGameProposer(disputeGameFactory);
+        } else {
+            initialChallenger = DisputeGames.permissionedGameChallenger(disputeGameFactory);
+            initialProposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
+        }
 
         // Execute the SuperchainConfig upgrade.
         prankDelegateCall(superchainPAO);

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -2133,8 +2133,8 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
     {
         // Set up dispute game configs first since they're needed for the struct literal.
         bool superRoot = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
-        address initialChallenger = _initialPermissionedGameChallenger(superRoot);
-        address initialProposer = _initialPermissionedGameProposer(superRoot);
+        address initialChallenger = _initialPermissionedGameChallenger();
+        address initialProposer = _initialPermissionedGameProposer();
         IOPContractsManagerUtils.DisputeGameConfig[] memory dgConfigs =
             new IOPContractsManagerUtils.DisputeGameConfig[](6);
         dgConfigs[0] = IOPContractsManagerUtils.DisputeGameConfig({
@@ -2222,11 +2222,11 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         cts_ = opcmV2.deploy(deployConfig);
     }
 
-    function _initialPermissionedGameChallenger(bool) internal view returns (address challenger_) {
+    function _initialPermissionedGameChallenger() internal view returns (address challenger_) {
         challenger_ = DisputeGames.permissionedGameChallenger(disputeGameFactory);
     }
 
-    function _initialPermissionedGameProposer(bool) internal view returns (address proposer_) {
+    function _initialPermissionedGameProposer() internal view returns (address proposer_) {
         proposer_ = DisputeGames.permissionedGameProposer(disputeGameFactory);
     }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -352,18 +352,14 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
     )
         internal
     {
-        // Grab values before we upgrade, to be checked later. Once the super-root migration has
-        // already been applied, the legacy PERMISSIONED_CANNON slot is cleared.
+        // Grab values before we upgrade, to be checked later.
         address initialChallenger;
-        address initialProposer;
+        address initialProposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
         if (
-            isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
-                && address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)) == address(0)
+            !isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
+                || address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)) != address(0)
         ) {
-            initialProposer = DisputeGames.superPermissionedGameProposer(disputeGameFactory);
-        } else {
             initialChallenger = DisputeGames.permissionedGameChallenger(disputeGameFactory);
-            initialProposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
         }
 
         // Execute the SuperchainConfig upgrade.
@@ -2243,10 +2239,8 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         challenger_ = address(0);
     }
 
-    function _initialPermissionedGameProposer(bool _superRoot) internal view returns (address proposer_) {
-        if (!_superRoot) return DisputeGames.permissionedGameProposer(disputeGameFactory);
-
-        proposer_ = DisputeGames.superPermissionedGameProposer(disputeGameFactory);
+    function _initialPermissionedGameProposer(bool) internal view returns (address proposer_) {
+        proposer_ = DisputeGames.permissionedGameProposer(disputeGameFactory);
     }
 
     /// @notice Helper function to create the default migration input.

--- a/packages/contracts-bedrock/test/setup/DisputeGames.sol
+++ b/packages/contracts-bedrock/test/setup/DisputeGames.sol
@@ -110,6 +110,12 @@ library DisputeGames {
     }
 
     function permissionedGameProposer(IDisputeGameFactory _dgf) internal view returns (address proposer_) {
+        if (address(_dgf.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0)) {
+            LibGameArgs.SuperPermissionedGameArgs memory gameArgs =
+                LibGameArgs.decodeSuperPermissioned(_dgf.gameArgs(GameTypes.SUPER_PERMISSIONED));
+            return gameArgs.proposer;
+        }
+
         GameType gameType = GameTypes.PERMISSIONED_CANNON;
         (bool gameArgsExist, bytes memory gameArgsData) = _getGameArgs(_dgf, gameType);
         if (gameArgsExist) {
@@ -118,12 +124,6 @@ library DisputeGames {
         } else {
             proposer_ = IPermissionedDisputeGame(address(_dgf.gameImpls(gameType))).proposer();
         }
-    }
-
-    function superPermissionedGameProposer(IDisputeGameFactory _dgf) internal view returns (address proposer_) {
-        LibGameArgs.SuperPermissionedGameArgs memory gameArgs =
-            LibGameArgs.decodeSuperPermissioned(_dgf.gameArgs(GameTypes.SUPER_PERMISSIONED));
-        proposer_ = gameArgs.proposer;
     }
 
     function superPermissionedGameAnchorStateRegistry(IDisputeGameFactory _dgf)

--- a/packages/contracts-bedrock/test/setup/DisputeGames.sol
+++ b/packages/contracts-bedrock/test/setup/DisputeGames.sol
@@ -99,6 +99,10 @@ library DisputeGames {
     }
 
     function permissionedGameChallenger(IDisputeGameFactory _dgf) internal view returns (address challenger_) {
+        if (address(_dgf.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0)) {
+            return address(0);
+        }
+
         GameType gameType = GameTypes.PERMISSIONED_CANNON;
         (bool gameArgsExist, bytes memory gameArgsData) = _getGameArgs(_dgf, gameType);
         if (gameArgsExist) {

--- a/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
@@ -231,13 +231,6 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
             || raw == GameTypes.SUPER_CANNON_KONA.raw();
     }
 
-    function _migrationProposer(IDisputeGameFactory _disputeGameFactory) internal view returns (address) {
-        if (address(_disputeGameFactory.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0)) {
-            return DisputeGames.superPermissionedGameProposer(_disputeGameFactory);
-        }
-        return DisputeGames.permissionedGameProposer(_disputeGameFactory);
-    }
-
     /// @notice Calls to the Deploy.s.sol contract etched by Setup.sol to a deterministic address, sets up the
     /// environment, and deploys new implementations.
     function _deployNewImplementations() internal {
@@ -290,7 +283,7 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
             IAnchorStateRegistry asr = IAnchorStateRegistry(artifacts.mustGetAddress("AnchorStateRegistryProxy"));
             GameType originalGameType = asr.respectedGameType();
             bool isPermissionless = _isPermissionlessGameType(originalGameType);
-            address proposer = _migrationProposer(disputeGameFactory);
+            address proposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
 
             // Determine the target SUPER_* game type.
             GameType targetGameType = isPermissionless ? GameTypes.SUPER_CANNON_KONA : GameTypes.SUPER_PERMISSIONED;

--- a/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
@@ -175,23 +175,67 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
         artifacts.save("MipsSingleton", vm.parseJsonAddress(addressesJson, string.concat("$.", chainId, ".MIPS")));
         IDisputeGameFactory disputeGameFactory =
             IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
-        // The PermissionedDisputeGame and PermissionedDelayedWETHProxy are not listed in the registry for OP, so we
-        // look it up onchain.
-        address permissionedGameImpl = address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON));
+        // The permissioned game is not always listed in the registry for OP, so look it up onchain.
+        GameType permissionedGameType = _registeredPermissionedGameType(disputeGameFactory);
+        address permissionedGameImpl = address(disputeGameFactory.gameImpls(permissionedGameType));
         artifacts.save("PermissionedDisputeGame", permissionedGameImpl);
 
-        // Get DelayedWETH for PERMISSIONED games
-        IDelayedWETH permissionedDelayedWeth =
-            DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.PERMISSIONED_CANNON);
+        // Get DelayedWETH for legacy PERMISSIONED games. SUPER_PERMISSIONED games do not have WETH args.
+        IDelayedWETH permissionedDelayedWeth = permissionedGameType.raw() == GameTypes.PERMISSIONED_CANNON.raw()
+            ? DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.PERMISSIONED_CANNON)
+            : IDelayedWETH(payable(address(0)));
         artifacts.save("PermissionedDelayedWETHProxy", address(permissionedDelayedWeth));
 
-        // Get DelayedWETH for the live permissionless game.
-        IDelayedWETH permissionlessDelayedWeth =
-            DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.CANNON_KONA);
-
-        // The SR seems out-of-date, so pull the DelayedWETH addresses from the games.
+        // The SR seems out-of-date, so pull the DelayedWETH addresses from the live permissionless game.
+        IDelayedWETH permissionlessDelayedWeth = DisputeGames.getGameImplDelayedWeth(
+            disputeGameFactory, _registeredPermissionlessGameType(disputeGameFactory)
+        );
         artifacts.save("DelayedWETHProxy", address(permissionlessDelayedWeth));
         artifacts.save("DelayedWETHImpl", EIP1967Helper.getImplementation(address(permissionlessDelayedWeth)));
+    }
+
+    function _registeredPermissionedGameType(IDisputeGameFactory _disputeGameFactory)
+        internal
+        view
+        returns (GameType)
+    {
+        if (address(_disputeGameFactory.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0)) {
+            return GameTypes.SUPER_PERMISSIONED;
+        }
+        if (address(_disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)) != address(0)) {
+            return GameTypes.PERMISSIONED_CANNON;
+        }
+        revert("ForkL1Live: no permissioned game registered");
+    }
+
+    function _registeredPermissionlessGameType(IDisputeGameFactory _disputeGameFactory)
+        internal
+        view
+        returns (GameType)
+    {
+        if (address(_disputeGameFactory.gameImpls(GameTypes.SUPER_CANNON_KONA)) != address(0)) {
+            return GameTypes.SUPER_CANNON_KONA;
+        }
+        if (address(_disputeGameFactory.gameImpls(GameTypes.CANNON_KONA)) != address(0)) {
+            return GameTypes.CANNON_KONA;
+        }
+        if (address(_disputeGameFactory.gameImpls(GameTypes.CANNON)) != address(0)) {
+            return GameTypes.CANNON;
+        }
+        revert("ForkL1Live: no permissionless game registered");
+    }
+
+    function _isPermissionlessGameType(GameType _gameType) internal pure returns (bool) {
+        uint32 raw = _gameType.raw();
+        return raw == GameTypes.CANNON.raw() || raw == GameTypes.CANNON_KONA.raw()
+            || raw == GameTypes.SUPER_CANNON_KONA.raw();
+    }
+
+    function _migrationProposer(IDisputeGameFactory _disputeGameFactory) internal view returns (address) {
+        if (address(_disputeGameFactory.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0)) {
+            return DisputeGames.superPermissionedGameProposer(_disputeGameFactory);
+        }
+        return DisputeGames.permissionedGameProposer(_disputeGameFactory);
     }
 
     /// @notice Calls to the Deploy.s.sol contract etched by Setup.sol to a deterministic address, sets up the
@@ -234,11 +278,8 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
             );
         }
 
-        // Grab the existing PermissionedDisputeGame parameters.
         IDisputeGameFactory disputeGameFactory =
             IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
-        address challenger = DisputeGames.permissionedGameChallenger(disputeGameFactory);
-        address proposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
 
         // Prepare the upgrade input based on whether we're doing a super root migration.
         IOPContractsManagerUtils.DisputeGameConfig[] memory disputeGameConfigs;
@@ -248,8 +289,8 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
             // Read the current respected game type from the ASR.
             IAnchorStateRegistry asr = IAnchorStateRegistry(artifacts.mustGetAddress("AnchorStateRegistryProxy"));
             GameType originalGameType = asr.respectedGameType();
-            uint32 originalRaw = originalGameType.raw();
-            bool isPermissionless = originalRaw == GameTypes.CANNON.raw() || originalRaw == GameTypes.CANNON_KONA.raw();
+            bool isPermissionless = _isPermissionlessGameType(originalGameType);
+            address proposer = _migrationProposer(disputeGameFactory);
 
             // Determine the target SUPER_* game type.
             GameType targetGameType = isPermissionless ? GameTypes.SUPER_CANNON_KONA : GameTypes.SUPER_PERMISSIONED;
@@ -327,6 +368,8 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
                 data: abi.encode(targetGameType)
             });
         } else {
+            address challenger = DisputeGames.permissionedGameChallenger(disputeGameFactory);
+            address proposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
             // Standard upgrade path: CANNON disabled, remaining legacy types enabled, super types disabled.
             // Order must match validGameTypes in OPContractsManagerV2._assertValidFullConfig().
             disputeGameConfigs = new IOPContractsManagerUtils.DisputeGameConfig[](6);
@@ -443,9 +486,9 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
         artifacts.save("ETHLockboxProxy", lockboxAddress);
 
         // Get the new DelayedWETH address and save it (might be a new proxy).
-        GameType wethGameType = Config.devFeatureSuperRootGamesMigration() ? GameTypes.SUPER_CANNON_KONA : permGameType;
-        IDelayedWETH newDelayedWeth =
-            IDelayedWETH(payable(LibGameArgs.decode(disputeGameFactory.gameArgs(wethGameType)).weth));
+        IDelayedWETH newDelayedWeth = DisputeGames.getGameImplDelayedWeth(
+            disputeGameFactory, _registeredPermissionlessGameType(disputeGameFactory)
+        );
         artifacts.save("DelayedWETHProxy", address(newDelayedWeth));
         artifacts.save("DelayedWETHImpl", EIP1967Helper.getImplementation(address(newDelayedWeth)));
     }


### PR DESCRIPTION
Adds a fork-live lifecycle regression test for rerunning setup after the current upgrade has already landed, then fixes fork-live discovery for post-SUPER_ROOT_GAMES_MIGRATION state.

The setup path now resolves active permissioned and permissionless game registrations from the DGF instead of hard-coding legacy game types. Test helpers also treat SUPER_PERMISSIONED as the active permissioned game shape for proposer/challenger lookup.