### PR TITLE
superchain: reject unknown keys when decoding registry configs

### DIFF
--- a/op-core/superchain/chain.go
+++ b/op-core/superchain/chain.go
@@ -13,8 +13,9 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/BurntSushi/toml"
 	"github.com/klauspost/compress/zstd"
+
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 )
 
 //go:embed superchain-configs.zip
@@ -170,7 +171,10 @@ func (c *Chain) populateConfig() {
 	defer configFile.Close()
 
 	var cfg ChainConfig
-	if _, err := toml.NewDecoder(configFile).Decode(&cfg); err != nil {
+	// No allowed-unknown keys: the ChainConfig struct models every field the registry chain
+	// configs carry (TestAllEmbeddedConfigsDecodeStrictly enforces this), so any unmodeled key is a
+	// drift to reject rather than drop.
+	if err := jsonutil.DecodeTOMLStrict(configFile, &cfg, nil); err != nil {
 		c.err = fmt.Errorf("error decoding chain config file %s/%s: %w", c.Network, c.Name, err)
 		return
 	}

--- a/op-core/superchain/strict_decode_test.go
+++ b/op-core/superchain/strict_decode_test.go
@@ -1,0 +1,71 @@
+package superchain
+
+import (
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
+)
+
+// TestAllEmbeddedConfigsDecodeStrictly loads every embedded chain and superchain config with the
+// strict decoder. It fails if any config carries a key the Go structs do not model — the exact
+// drift that let keep_karst_upgrade_gas be silently dropped. A superchain-registry bump that adds a
+// field therefore cannot merge until the structs are updated to consume it (or, for the superchain,
+// until the key is added to legacySuperchainKeys as a conscious decision).
+func TestAllEmbeddedConfigsDecodeStrictly(t *testing.T) {
+	networks := map[string]struct{}{}
+	for _, ch := range BuiltInConfigs.Chains {
+		networks[ch.Network] = struct{}{}
+		t.Run(ch.Network+"/"+ch.Name, func(t *testing.T) {
+			f, err := BuiltInConfigs.configDataReader.Open(path.Join("configs", ch.Network, ch.Name+".toml"))
+			require.NoError(t, err)
+			defer f.Close()
+			var cfg ChainConfig
+			require.NoError(t, jsonutil.DecodeTOMLStrict(f, &cfg, nil))
+		})
+	}
+
+	for network := range networks {
+		t.Run("superchain/"+network, func(t *testing.T) {
+			f, err := BuiltInConfigs.configDataReader.Open(path.Join("configs", network, "superchain.toml"))
+			require.NoError(t, err)
+			defer f.Close()
+			var sc Superchain
+			require.NoError(t, jsonutil.DecodeTOMLStrict(f, &sc, isLegacySuperchainKey))
+		})
+	}
+}
+
+// TestSuperchainDecodeToleratesLegacyProtocolVersionsAddr documents why the superchain decode
+// allow-lists protocol_versions_addr: the Superchain struct deliberately no longer models that
+// legacy key, and the embedded superchain.toml files still carry it, so strict decoding must
+// tolerate it — while still rejecting a genuinely unknown key.
+func TestSuperchainDecodeToleratesLegacyProtocolVersionsAddr(t *testing.T) {
+	const legacy = `
+name = "Legacy"
+protocol_versions_addr = "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
+superchain_config_addr = "0x95703e0982140D16f8ebA6d158FccEde42f04a4C"
+op_contracts_manager_addr = "0x0000000000000000000000000000000000000001"
+safer_safes_addr = "0xA8447329e52F64AED2bFc9E7a2506F7D369f483a"
+
+[L1]
+chain_id = 1
+`
+	var sc Superchain
+	require.NoError(t, jsonutil.DecodeTOMLStrict(strings.NewReader(legacy), &sc, isLegacySuperchainKey))
+	require.Equal(t, "Legacy", sc.Name)
+
+	const unknown = `
+name = "Legacy"
+some_new_key = true
+
+[L1]
+chain_id = 1
+`
+	err := jsonutil.DecodeTOMLStrict(strings.NewReader(unknown), &Superchain{}, isLegacySuperchainKey)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "some_new_key")
+}

--- a/op-core/superchain/superchain.go
+++ b/op-core/superchain/superchain.go
@@ -3,10 +3,21 @@ package superchain
 import (
 	"fmt"
 	"path"
+	"slices"
 
-	"github.com/BurntSushi/toml"
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 )
+
+// legacySuperchainKeys are keys still present in the embedded superchain.toml files that the
+// Superchain struct deliberately no longer models. They are tolerated by the strict decoder so a
+// genuinely new/unexpected key is still rejected while this known legacy field is not.
+var legacySuperchainKeys = []string{"protocol_versions_addr"}
+
+func isLegacySuperchainKey(key string) bool {
+	return slices.Contains(legacySuperchainKeys, key)
+}
 
 type Superchain struct {
 	Name                   string         `toml:"name"`
@@ -41,7 +52,7 @@ func (c *ChainConfigLoader) GetSuperchain(network string) (Superchain, error) {
 		return sc, err
 	}
 
-	if _, err := toml.NewDecoder(zr).Decode(&sc); err != nil {
+	if err := jsonutil.DecodeTOMLStrict(zr, &sc, isLegacySuperchainKey); err != nil {
 		return sc, fmt.Errorf("error decoding superchain config: %w", err)
 	}
 

--- a/op-core/superchain/superchain_test.go
+++ b/op-core/superchain/superchain_test.go
@@ -1,10 +1,8 @@
 package superchain
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/BurntSushi/toml"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -21,26 +19,4 @@ func TestGetSuperchain(t *testing.T) {
 
 	_, err = GetSuperchain("not a network")
 	require.Error(t, err)
-}
-
-// TestSuperchain_DecodeIgnoresLegacyProtocolVersionsAddr proves the TOML
-// decoder silently ignores the legacy `protocol_versions_addr` key. The
-// embedded superchain-registry configs still carry it, so removing the
-// struct field must not break decoding.
-func TestSuperchain_DecodeIgnoresLegacyProtocolVersionsAddr(t *testing.T) {
-	const data = `
-name = "Legacy"
-protocol_versions_addr = "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
-superchain_config_addr = "0x95703e0982140D16f8ebA6d158FccEde42f04a4C"
-op_contracts_manager_addr = "0x0000000000000000000000000000000000000001"
-safer_safes_addr = "0xA8447329e52F64AED2bFc9E7a2506F7D369f483a"
-
-[L1]
-chain_id = 1
-`
-	var sc Superchain
-	_, err := toml.NewDecoder(strings.NewReader(data)).Decode(&sc)
-	require.NoError(t, err)
-	require.Equal(t, "Legacy", sc.Name)
-	require.Equal(t, common.HexToAddress("0x95703e0982140D16f8ebA6d158FccEde42f04a4C"), sc.SuperchainConfigAddr)
 }

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -22,15 +22,25 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve chain %d config: %w", chainID, err)
 	}
-	chOpConfig := &params.OptimismConfig{
-		EIP1559Elasticity:        chConfig.Optimism.EIP1559Elasticity,
-		EIP1559Denominator:       chConfig.Optimism.EIP1559Denominator,
-		EIP1559DenominatorCanyon: chConfig.Optimism.EIP1559DenominatorCanyon,
-	}
 
 	superConfig, err := superchain.GetSuperchain(chain.Network)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get superchain %q from superchain registry: %w", chain.Network, err)
+	}
+
+	return rollupConfigFromRegistry(chConfig, superConfig), nil
+}
+
+// rollupConfigFromRegistry converts a superchain-registry chain config (with its parent
+// superchain, which supplies the L1 chain ID) into a rollup Config. It is the single place that
+// maps registry fields onto Config, kept separate from the registry lookup so it can be
+// unit-tested directly: feeding a fully-populated ChainConfig through it and checking the result
+// catches any registry field that fails to reach Config.
+func rollupConfigFromRegistry(chConfig *superchain.ChainConfig, superConfig superchain.Superchain) *Config {
+	chOpConfig := &params.OptimismConfig{
+		EIP1559Elasticity:        chConfig.Optimism.EIP1559Elasticity,
+		EIP1559Denominator:       chConfig.Optimism.EIP1559Denominator,
+		EIP1559DenominatorCanyon: chConfig.Optimism.EIP1559DenominatorCanyon,
 	}
 
 	sysCfg := chConfig.Genesis.SystemConfig
@@ -85,7 +95,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 	}
 	applyHardforks(cfg, chConfig.Hardforks)
 
-	return cfg, nil
+	return cfg
 }
 
 func applyHardforks(cfg *Config, hardforks superchain.HardforkConfig) {

--- a/op-node/rollup/superchain_test.go
+++ b/op-node/rollup/superchain_test.go
@@ -1,12 +1,107 @@
 package rollup
 
 import (
+	"math/big"
 	"reflect"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/ethereum-optimism/optimism/op-core/superchain"
+	"github.com/ethereum-optimism/optimism/op-service/ptr"
 	"github.com/stretchr/testify/require"
 )
+
+// fullyPopulatedChainConfig returns a chain config with every optional field set to a non-zero
+// value, so the registry→Config conversion has a source for every Config field. Extend it whenever
+// ChainConfig gains a field, so TestRollupConfigFromRegistry_AllFieldsSet keeps covering the whole
+// conversion.
+func fullyPopulatedChainConfig() *superchain.ChainConfig {
+	portal := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	sysCfgProxy := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	daChallenge := common.HexToAddress("0x3333333333333333333333333333333333333333")
+
+	return &superchain.ChainConfig{
+		ChainID:           10,
+		BatchInboxAddr:    common.HexToAddress("0xff00000000000000000000000000000000000010"),
+		BlockTime:         2,
+		SeqWindowSize:     3600,
+		MaxSequencerDrift: 600,
+		Optimism: &superchain.OptimismConfig{
+			EIP1559Elasticity:        6,
+			EIP1559Denominator:       50,
+			EIP1559DenominatorCanyon: ptr.New(uint64(250)),
+		},
+		AltDA: &superchain.AltDAConfig{
+			DaChallengeContractAddress: daChallenge,
+			DaChallengeWindow:          160,
+			DaResolveWindow:            160,
+			DaCommitmentType:           "KeccakCommitment",
+		},
+		Genesis: superchain.GenesisConfig{
+			L2Time: 1234,
+			L1:     superchain.GenesisRef{Hash: common.HexToHash("0xaa"), Number: 100},
+			L2:     superchain.GenesisRef{Hash: common.HexToHash("0xbb")},
+			SystemConfig: superchain.SystemConfig{
+				BatcherAddr: common.HexToAddress("0x4444444444444444444444444444444444444444"),
+				Overhead:    common.HexToHash("0xbc"),
+				Scalar:      common.HexToHash("0xa6fe0"),
+				GasLimit:    30_000_000,
+			},
+		},
+		Addresses: superchain.AddressesConfig{
+			OptimismPortalProxy: &portal,
+			SystemConfigProxy:   &sysCfgProxy,
+		},
+		Hardforks: superchain.HardforkConfig{
+			CanyonTime:             ptr.New(uint64(1)),
+			DeltaTime:              ptr.New(uint64(2)),
+			EcotoneTime:            ptr.New(uint64(3)),
+			FjordTime:              ptr.New(uint64(4)),
+			GraniteTime:            ptr.New(uint64(5)),
+			HoloceneTime:           ptr.New(uint64(6)),
+			IsthmusTime:            ptr.New(uint64(7)),
+			JovianTime:             ptr.New(uint64(8)),
+			KarstTime:              ptr.New(uint64(9)),
+			KeepKarstUpgradeGas:    true,
+			LagoonTime:             ptr.New(uint64(10)),
+			PectraBlobScheduleTime: ptr.New(uint64(11)),
+		},
+	}
+}
+
+// TestRollupConfigFromRegistry exercises the registry→rollup.Config conversion in isolation and
+// checks that key registry fields — including the keep_karst_upgrade_gas behavioral flag — reach
+// the rollup Config.
+func TestRollupConfigFromRegistry(t *testing.T) {
+	chConfig := fullyPopulatedChainConfig()
+	cfg := rollupConfigFromRegistry(chConfig, superchain.Superchain{L1: superchain.L1Config{ChainID: 1}})
+
+	require.Equal(t, big.NewInt(10), cfg.L2ChainID)
+	require.Equal(t, big.NewInt(1), cfg.L1ChainID)
+	require.Equal(t, uint64(2), cfg.BlockTime)
+	require.Equal(t, *chConfig.Addresses.OptimismPortalProxy, cfg.DepositContractAddress)
+	require.Equal(t, *chConfig.Addresses.SystemConfigProxy, cfg.L1SystemConfigAddress)
+	require.Equal(t, uint64(9), *cfg.KarstTime)
+	require.True(t, cfg.KeepKarstUpgradeGas,
+		"keep_karst_upgrade_gas from the registry must be carried into rollup.Config")
+}
+
+// TestRollupConfigFromRegistry_AllFieldsSet feeds a fully-populated chain config through the
+// conversion and asserts every rollup Config field ends up non-zero. A newly added registry-derived
+// field that the conversion forgets to map stays at its zero value and fails here — the completeness
+// guard for the whole Config, not just the hardforks.
+func TestRollupConfigFromRegistry_AllFieldsSet(t *testing.T) {
+	cfg := rollupConfigFromRegistry(fullyPopulatedChainConfig(), superchain.Superchain{L1: superchain.L1Config{ChainID: 1}})
+
+	v := reflect.ValueOf(*cfg)
+	typ := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		require.Falsef(t, v.Field(i).IsZero(),
+			"rollup Config field %q is zero after conversion: map it in rollupConfigFromRegistry, and "+
+				"make sure fullyPopulatedChainConfig provides its source", typ.Field(i).Name)
+	}
+}
 
 func TestApplyHardforks_NoForks(t *testing.T) {
 	cfg := Config{}

--- a/op-service/jsonutil/json.go
+++ b/op-service/jsonutil/json.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 
@@ -57,6 +58,31 @@ func newTOMLDecoder(r io.Reader) Decoder {
 func (d *tomlDecoder) Decode(v interface{}) error {
 	if _, err := toml.NewDecoder(d.r).Decode(v); err != nil {
 		return fmt.Errorf("failed to decode TOML: %w", err)
+	}
+	return nil
+}
+
+// DecodeTOMLStrict decodes TOML from r into v and returns an error if the source contains any key
+// that no field of v captures and allowUnknown does not accept. A nil allowUnknown rejects every
+// unknown key.
+//
+// BurntSushi/toml silently drops unmapped keys by default; this rejects them instead, so a struct
+// is forced to stay in sync with its source — a newly added source key that nothing maps becomes a
+// load error rather than a silently-dropped value. allowUnknown is a predicate rather than a set so
+// callers can choose how to match (slice membership, map lookup, prefix, …).
+func DecodeTOMLStrict(r io.Reader, v any, allowUnknown func(key string) bool) error {
+	md, err := toml.NewDecoder(r).Decode(v)
+	if err != nil {
+		return fmt.Errorf("failed to decode TOML: %w", err)
+	}
+	var unknown []string
+	for _, key := range md.Undecoded() {
+		if k := key.String(); allowUnknown == nil || !allowUnknown(k) {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) > 0 {
+		return fmt.Errorf("unknown TOML keys not represented in the target struct: %s", strings.Join(unknown, ", "))
 	}
 	return nil
 }

--- a/op-service/jsonutil/json_test.go
+++ b/op-service/jsonutil/json_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
@@ -157,4 +158,67 @@ func appendDataToFile(outputPath string, data []byte) error {
 
 	_, err = file.Write(data)
 	return err
+}
+
+func TestDecodeTOMLStrict(t *testing.T) {
+	type inner struct {
+		A int `toml:"a"`
+	}
+	type cfg struct {
+		Name  string `toml:"name"`
+		Inner inner  `toml:"inner"`
+	}
+
+	const clean = `
+name = "x"
+[inner]
+a = 1
+`
+	const withExtra = `
+name = "x"
+extra = true
+`
+
+	t.Run("clean input passes", func(t *testing.T) {
+		var c cfg
+		require.NoError(t, DecodeTOMLStrict(strings.NewReader(clean), &c, nil))
+		require.Equal(t, "x", c.Name)
+		require.Equal(t, 1, c.Inner.A)
+	})
+
+	t.Run("nil predicate rejects unknown key", func(t *testing.T) {
+		var c cfg
+		err := DecodeTOMLStrict(strings.NewReader(withExtra), &c, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "extra")
+	})
+
+	t.Run("nested unknown key reported with dotted path", func(t *testing.T) {
+		var c cfg
+		err := DecodeTOMLStrict(strings.NewReader(`
+[inner]
+a = 1
+b = 2
+`), &c, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "inner.b")
+	})
+
+	t.Run("predicate allows the listed key", func(t *testing.T) {
+		var c cfg
+		allow := func(k string) bool { return k == "extra" }
+		require.NoError(t, DecodeTOMLStrict(strings.NewReader(withExtra), &c, allow))
+		require.Equal(t, "x", c.Name)
+	})
+
+	t.Run("predicate does not allow other keys", func(t *testing.T) {
+		var c cfg
+		allow := func(k string) bool { return k == "extra" }
+		err := DecodeTOMLStrict(strings.NewReader(`
+name = "x"
+other = true
+`), &c, allow)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "other")
+	})
 }

--- a/rust/kona/crates/protocol/genesis/src/chain/config.rs
+++ b/rust/kona/crates/protocol/genesis/src/chain/config.rs
@@ -32,6 +32,10 @@ pub type L1ChainConfig = alloy_genesis::ChainConfig;
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+// Reject any registry key the struct does not model, so a superchain-registry field that is added
+// but not wired up here fails loudly at deserialization (or at KONA_SYNC_SUPERCHAIN=true
+// regeneration) instead of being silently dropped. Mirrors HardForkConfig, which is already strict.
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct ChainConfig {
     /// Chain name (e.g. "Base")
     #[cfg_attr(feature = "serde", serde(rename = "Name", alias = "name"))]
@@ -195,6 +199,7 @@ impl ChainConfig {
 #[cfg(feature = "serde")]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
 
     #[test]
     fn test_chain_config_json() {
@@ -297,6 +302,9 @@ mod tests {
         assert!(!json.contains("interop"), "expected `interop` key to be omitted; got: {json}");
     }
 
+    // Guards the `deny_unknown_fields` attribute on ChainConfig: an otherwise-valid config with one
+    // extra top-level key must be rejected. (The rest of the config must deserialize cleanly so the
+    // parser reaches the unknown key and that is the sole error.)
     #[test]
     fn test_chain_config_unknown_field_json() {
         let raw: &str = r#"
@@ -324,9 +332,9 @@ mod tests {
                 "holocene_time": 1736445601
             },
             "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
+                "eip1559Elasticity": 6,
+                "eip1559Denominator": 50,
+                "eip1559DenominatorCanyon": 250
             },
             "alt_da": null,
             "genesis": {
@@ -378,6 +386,9 @@ mod tests {
         "#;
 
         let err = serde_json::from_str::<ChainConfig>(raw).unwrap_err();
-        assert_eq!(err.classify(), serde_json::error::Category::Data);
+        assert!(
+            err.to_string().contains("unknown field `unknown_field`"),
+            "expected deny_unknown_fields to reject the extra key, got: {err}"
+        );
     }
 }

--- a/rust/kona/crates/protocol/registry/build.rs
+++ b/rust/kona/crates/protocol/registry/build.rs
@@ -97,9 +97,15 @@ fn main() {
                     continue;
                 }
 
-                // Read the config file as a `ChainConfig`
+                // Read the config file as a `ChainConfig`. ChainConfig rejects unknown fields, so a
+                // registry key promoted into the config that ChainConfig does not yet model fails
+                // here rather than being silently dropped.
                 let config = std::fs::read_to_string(config_file_path).unwrap();
-                let config: ChainConfig = toml::from_str(&config).unwrap();
+                let config: ChainConfig = toml::from_str(&config).unwrap_or_else(|e| {
+                    panic!(
+                        "failed to parse superchain-registry chain config {config_file_name}: {e}"
+                    )
+                });
                 superchain.chains.push(config);
             }
             superchains.superchains.push(superchain);


### PR DESCRIPTION
Follow-up to #21566, which had to hand-add `keep_karst_upgrade_gas` to op-node's registry structs after it was silently dropped: the TOML decoder ignores any key no struct field models. This adds the guard that would have caught it, on both clients.

- **op-node**: `jsonutil.DecodeTOMLStrict` rejects any registry TOML key not represented in the target struct (an `allowUnknown func(string) bool` predicate tolerates specific keys). Chain configs allow nothing — `ChainConfig` models every field; the superchain path allow-lists only the deliberately-unmodeled legacy `protocol_versions_addr`. `TestAllEmbeddedConfigsDecodeStrictly` makes a future registry bump that adds an unmodeled field fail until the struct consumes it.
- **op-node**: extract the registry→`rollup.Config` conversion into `rollupConfigFromRegistry`, separate from the registry lookup. `TestRollupConfigFromRegistry_AllFieldsSet` reflects over the result and fails on any zero field, catching a registry-derived field forgotten in the conversion.
- **kona**: add `deny_unknown_fields` to the top-level `ChainConfig`. Its `HardForkConfig` already had it (so the exact bug couldn't recur there), but the top-level struct silently dropped unknown keys. Also fixes `test_chain_config_unknown_field_json`, which only passed because of an unrelated parse error rather than the unknown key.

No behavior change at the pinned superchain-registry commit — every embedded chain and superchain decodes cleanly (op-node) / the embedded `configs.json` deserializes cleanly (kona). The point is that future schema drift fails loudly instead of being silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
