### PR TITLE
op-node: move rollup-config loading into op-node/superchain

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1646,7 +1646,9 @@ jobs:
 
   # Builds op-core/superchain/superchain-configs.zip from the pinned commit and
   # makes it available to downstream Go-build jobs via persist_to_workspace.
-  # The zip itself is gitignored; this job is the only place it gets built in CI.
+  # The zip itself is gitignored; this is the only job that persists it to the
+  # workspace. Jobs that don't attach the workspace (the rust-e2e Go tests,
+  # faultproofs, interop-deposits-diff) rebuild it inline via `just build-superchain-go`.
   #
   # Always rebuilds — no cache. The script is fast (depth-1 SR clone + zip
   # ~10s) and most of the job's wall-clock is mise restore anyway. Always

--- a/op-chain-ops/cmd/check-derivation/main.go
+++ b/op-chain-ops/cmd/check-derivation/main.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	clients2 "github.com/ethereum-optimism/optimism/op-chain-ops/clients"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/superchain"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -366,7 +366,7 @@ func checkConsolidation(cliCtx *cli.Context) error {
 	}
 	l2ChainID := new(big.Int).SetUint64(cliCtx.Uint64("l2-chain-id"))
 	l2BlockTime := uint64(2)
-	rollupCfg, err := rollup.LoadOPStackRollupConfig(bigs.Uint64Strict(l2ChainID))
+	rollupCfg, err := superchain.LoadOPStackRollupConfig(bigs.Uint64Strict(l2ChainID))
 	if err == nil {
 		l2BlockTime = rollupCfg.BlockTime
 	} else {

--- a/op-chain-ops/interopgen/config/registry_config.go
+++ b/op-chain-ops/interopgen/config/registry_config.go
@@ -7,8 +7,9 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	coredepset "github.com/ethereum-optimism/optimism/op-core/interop/depset"
-	"github.com/ethereum-optimism/optimism/op-core/superchain"
+	registry "github.com/ethereum-optimism/optimism/op-core/superchain"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/superchain"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -22,7 +23,7 @@ func NewRegistryFullConfigSetSource(l1RPCURL string, networks []string) (*Regist
 	rollupCfgs := make([]*rollup.Config, 0, len(networks))
 	var dependencySet coredepset.DependencySet
 	for _, network := range networks {
-		chainID, err := superchain.ChainIDByName(network)
+		chainID, err := registry.ChainIDByName(network)
 		if err != nil {
 			return nil, err
 		}
@@ -36,7 +37,7 @@ func NewRegistryFullConfigSetSource(l1RPCURL string, networks []string) (*Regist
 			dependencySet = depSet
 		}
 
-		rollupCfg, err := rollup.LoadOPStackRollupConfig(chainID)
+		rollupCfg, err := superchain.LoadOPStackRollupConfig(chainID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load rollup config for network %s: %w", network, err)
 		}

--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -5,8 +5,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ethereum-optimism/optimism/op-core/superchain"
+	registry "github.com/ethereum-optimism/optimism/op-core/superchain"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/superchain"
 )
 
 // OPSepolia loads the op-sepolia rollup config. This is intended for tests that need an arbitrary, valid rollup config.
@@ -24,7 +25,7 @@ func mustLoadRollupConfig(name string) *rollup.Config {
 
 var L2ChainIDToNetworkDisplayName = func() map[string]string {
 	out := make(map[string]string)
-	for _, netCfg := range superchain.Chains {
+	for _, netCfg := range registry.Chains {
 		cfg, err := netCfg.Config()
 		if err != nil {
 			panic(fmt.Errorf("failed to load chain config: %w", err))
@@ -37,7 +38,7 @@ var L2ChainIDToNetworkDisplayName = func() map[string]string {
 // AvailableNetworks returns the selection of network configurations that is available by default.
 func AvailableNetworks() []string {
 	var networks []string
-	for _, cfg := range superchain.Chains {
+	for _, cfg := range registry.Chains {
 		networks = append(networks, cfg.Name+"-"+cfg.Network)
 	}
 	sort.Strings(networks)
@@ -57,10 +58,10 @@ func handleLegacyName(name string) string {
 
 // ChainByName returns a chain, from known available configurations, by name.
 // ChainByName returns nil when the chain name is unknown.
-func ChainByName(name string) *superchain.ChainConfig {
+func ChainByName(name string) *registry.ChainConfig {
 	// Handle legacy name aliases
 	name = handleLegacyName(name)
-	for _, chainCfg := range superchain.Chains {
+	for _, chainCfg := range registry.Chains {
 		if !strings.EqualFold(chainCfg.Name+"-"+chainCfg.Network, name) {
 			continue
 		}
@@ -79,7 +80,7 @@ func GetRollupConfig(name string) (*rollup.Config, error) {
 	if chainCfg == nil {
 		return nil, fmt.Errorf("invalid network: %q", name)
 	}
-	rollupCfg, err := rollup.LoadOPStackRollupConfig(chainCfg.ChainID)
+	rollupCfg, err := superchain.LoadOPStackRollupConfig(chainCfg.ChainID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load rollup config: %w", err)
 	}

--- a/op-node/cmd/batch_decoder/main.go
+++ b/op-node/cmd/batch_decoder/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/cmd/batch_decoder/reassemble"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/superchain"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -104,7 +105,7 @@ func main() {
 				var inbox, sender common.Address
 				if cliCtx.IsSet("l2-chain-id") {
 					l2ChainID := cliCtx.Uint64("l2-chain-id")
-					rcfg, err := rollup.LoadOPStackRollupConfig(l2ChainID)
+					rcfg, err := superchain.LoadOPStackRollupConfig(l2ChainID)
 					if err != nil {
 						return err
 					}
@@ -163,7 +164,7 @@ func main() {
 				var rollupCfg *rollup.Config
 				if cliCtx.IsSet("l2-chain-id") {
 					l2ChainID := new(big.Int).SetUint64(cliCtx.Uint64("l2-chain-id"))
-					cfg, err := rollup.LoadOPStackRollupConfig(bigs.Uint64Strict(l2ChainID))
+					cfg, err := superchain.LoadOPStackRollupConfig(bigs.Uint64Strict(l2ChainID))
 					if err != nil {
 						return err
 					}

--- a/op-node/rollup/deps_test.go
+++ b/op-node/rollup/deps_test.go
@@ -1,0 +1,25 @@
+package rollup
+
+import (
+	"go/build"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoSuperchainImport keeps op-node/rollup decoupled from op-core/superchain.
+// That package embeds the multi-megabyte superchain config bundle, so anything
+// in its build closure must generate the bundle before it compiles. op-node/rollup
+// is imported by dozens of packages that only need its types, so it must stay
+// bundle-free. Config loading that reads the registry lives in op-node/superchain.
+func TestNoSuperchainImport(t *testing.T) {
+	pkg, err := build.ImportDir(".", 0)
+	require.NoError(t, err)
+
+	const forbidden = "github.com/ethereum-optimism/optimism/op-core/superchain"
+	imports := append([]string{}, pkg.Imports...)
+	imports = append(imports, pkg.TestImports...)
+	imports = append(imports, pkg.XTestImports...)
+	require.NotContains(t, imports, forbidden,
+		"op-node/rollup must not import op-core/superchain; registry-backed config loading belongs in op-node/superchain")
+}

--- a/op-node/superchain/superchain.go
+++ b/op-node/superchain/superchain.go
@@ -1,4 +1,8 @@
-package rollup
+// Package superchain loads OP-Stack rollup configs from the superchain-registry.
+// It is kept separate from op-node/rollup so that the many packages depending on
+// the rollup config types do not pull in op-core/superchain, which embeds the
+// multi-megabyte superchain config bundle and must generate it before it compiles.
+package superchain
 
 import (
 	"fmt"
@@ -6,14 +10,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/params"
 
-	"github.com/ethereum-optimism/optimism/op-core/superchain"
+	registry "github.com/ethereum-optimism/optimism/op-core/superchain"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 // LoadOPStackRollupConfig loads the rollup configuration of the requested chain ID from the superchain-registry.
 // Some chains may require a SystemConfigProvider to retrieve any values not part of the registry.
-func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
-	chain, err := superchain.GetChain(chainID)
+func LoadOPStackRollupConfig(chainID uint64) (*rollup.Config, error) {
+	chain, err := registry.GetChain(chainID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get chain %d from superchain registry: %w", chainID, err)
 	}
@@ -23,7 +28,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		return nil, fmt.Errorf("unable to retrieve chain %d config: %w", chainID, err)
 	}
 
-	superConfig, err := superchain.GetSuperchain(chain.Network)
+	superConfig, err := registry.GetSuperchain(chain.Network)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get superchain %q from superchain registry: %w", chain.Network, err)
 	}
@@ -36,7 +41,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 // maps registry fields onto Config, kept separate from the registry lookup so it can be
 // unit-tested directly: feeding a fully-populated ChainConfig through it and checking the result
 // catches any registry field that fails to reach Config.
-func rollupConfigFromRegistry(chConfig *superchain.ChainConfig, superConfig superchain.Superchain) *Config {
+func rollupConfigFromRegistry(chConfig *registry.ChainConfig, superConfig registry.Superchain) *rollup.Config {
 	chOpConfig := &params.OptimismConfig{
 		EIP1559Elasticity:        chConfig.Optimism.EIP1559Elasticity,
 		EIP1559Denominator:       chConfig.Optimism.EIP1559Denominator,
@@ -54,9 +59,9 @@ func rollupConfigFromRegistry(chConfig *superchain.ChainConfig, superConfig supe
 
 	addrs := chConfig.Addresses
 
-	var altDA *AltDAConfig
+	var altDA *rollup.AltDAConfig
 	if chConfig.AltDA != nil {
-		altDA = &AltDAConfig{
+		altDA = &rollup.AltDAConfig{
 			DAChallengeAddress: chConfig.AltDA.DaChallengeContractAddress,
 			DAChallengeWindow:  chConfig.AltDA.DaChallengeWindow,
 			DAResolveWindow:    chConfig.AltDA.DaResolveWindow,
@@ -64,8 +69,8 @@ func rollupConfigFromRegistry(chConfig *superchain.ChainConfig, superConfig supe
 		}
 	}
 
-	cfg := &Config{
-		Genesis: Genesis{
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
 			L1: eth.BlockID{
 				Hash:   chConfig.Genesis.L1.Hash,
 				Number: chConfig.Genesis.L1.Number,
@@ -98,7 +103,7 @@ func rollupConfigFromRegistry(chConfig *superchain.ChainConfig, superConfig supe
 	return cfg
 }
 
-func applyHardforks(cfg *Config, hardforks superchain.HardforkConfig) {
+func applyHardforks(cfg *rollup.Config, hardforks registry.HardforkConfig) {
 	regolithTime := uint64(0)
 	cfg.RegolithTime = &regolithTime
 	cfg.CanyonTime = hardforks.CanyonTime

--- a/op-node/superchain/superchain_test.go
+++ b/op-node/superchain/superchain_test.go
@@ -1,4 +1,4 @@
-package rollup
+package superchain
 
 import (
 	"math/big"
@@ -7,7 +7,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/ethereum-optimism/optimism/op-core/superchain"
+	registry "github.com/ethereum-optimism/optimism/op-core/superchain"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/ptr"
 	"github.com/stretchr/testify/require"
 )
@@ -16,44 +17,44 @@ import (
 // value, so the registry→Config conversion has a source for every Config field. Extend it whenever
 // ChainConfig gains a field, so TestRollupConfigFromRegistry_AllFieldsSet keeps covering the whole
 // conversion.
-func fullyPopulatedChainConfig() *superchain.ChainConfig {
+func fullyPopulatedChainConfig() *registry.ChainConfig {
 	portal := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	sysCfgProxy := common.HexToAddress("0x2222222222222222222222222222222222222222")
 	daChallenge := common.HexToAddress("0x3333333333333333333333333333333333333333")
 
-	return &superchain.ChainConfig{
+	return &registry.ChainConfig{
 		ChainID:           10,
 		BatchInboxAddr:    common.HexToAddress("0xff00000000000000000000000000000000000010"),
 		BlockTime:         2,
 		SeqWindowSize:     3600,
 		MaxSequencerDrift: 600,
-		Optimism: &superchain.OptimismConfig{
+		Optimism: &registry.OptimismConfig{
 			EIP1559Elasticity:        6,
 			EIP1559Denominator:       50,
 			EIP1559DenominatorCanyon: ptr.New(uint64(250)),
 		},
-		AltDA: &superchain.AltDAConfig{
+		AltDA: &registry.AltDAConfig{
 			DaChallengeContractAddress: daChallenge,
 			DaChallengeWindow:          160,
 			DaResolveWindow:            160,
 			DaCommitmentType:           "KeccakCommitment",
 		},
-		Genesis: superchain.GenesisConfig{
+		Genesis: registry.GenesisConfig{
 			L2Time: 1234,
-			L1:     superchain.GenesisRef{Hash: common.HexToHash("0xaa"), Number: 100},
-			L2:     superchain.GenesisRef{Hash: common.HexToHash("0xbb")},
-			SystemConfig: superchain.SystemConfig{
+			L1:     registry.GenesisRef{Hash: common.HexToHash("0xaa"), Number: 100},
+			L2:     registry.GenesisRef{Hash: common.HexToHash("0xbb")},
+			SystemConfig: registry.SystemConfig{
 				BatcherAddr: common.HexToAddress("0x4444444444444444444444444444444444444444"),
 				Overhead:    common.HexToHash("0xbc"),
 				Scalar:      common.HexToHash("0xa6fe0"),
 				GasLimit:    30_000_000,
 			},
 		},
-		Addresses: superchain.AddressesConfig{
+		Addresses: registry.AddressesConfig{
 			OptimismPortalProxy: &portal,
 			SystemConfigProxy:   &sysCfgProxy,
 		},
-		Hardforks: superchain.HardforkConfig{
+		Hardforks: registry.HardforkConfig{
 			CanyonTime:             ptr.New(uint64(1)),
 			DeltaTime:              ptr.New(uint64(2)),
 			EcotoneTime:            ptr.New(uint64(3)),
@@ -75,7 +76,7 @@ func fullyPopulatedChainConfig() *superchain.ChainConfig {
 // the rollup Config.
 func TestRollupConfigFromRegistry(t *testing.T) {
 	chConfig := fullyPopulatedChainConfig()
-	cfg := rollupConfigFromRegistry(chConfig, superchain.Superchain{L1: superchain.L1Config{ChainID: 1}})
+	cfg := rollupConfigFromRegistry(chConfig, registry.Superchain{L1: registry.L1Config{ChainID: 1}})
 
 	require.Equal(t, big.NewInt(10), cfg.L2ChainID)
 	require.Equal(t, big.NewInt(1), cfg.L1ChainID)
@@ -92,7 +93,7 @@ func TestRollupConfigFromRegistry(t *testing.T) {
 // field that the conversion forgets to map stays at its zero value and fails here — the completeness
 // guard for the whole Config, not just the hardforks.
 func TestRollupConfigFromRegistry_AllFieldsSet(t *testing.T) {
-	cfg := rollupConfigFromRegistry(fullyPopulatedChainConfig(), superchain.Superchain{L1: superchain.L1Config{ChainID: 1}})
+	cfg := rollupConfigFromRegistry(fullyPopulatedChainConfig(), registry.Superchain{L1: registry.L1Config{ChainID: 1}})
 
 	v := reflect.ValueOf(*cfg)
 	typ := v.Type()
@@ -104,15 +105,15 @@ func TestRollupConfigFromRegistry_AllFieldsSet(t *testing.T) {
 }
 
 func TestApplyHardforks_NoForks(t *testing.T) {
-	cfg := Config{}
-	hardforks := superchain.HardforkConfig{}
+	cfg := rollup.Config{}
+	hardforks := registry.HardforkConfig{}
 	applyHardforks(&cfg, hardforks)
 	requireAllHardforksSetCorrectly(t, cfg, hardforks)
 }
 
 func TestApplyHardforks(t *testing.T) {
-	cfg := Config{}
-	hardforkCfg := superchain.HardforkConfig{}
+	cfg := rollup.Config{}
+	hardforkCfg := registry.HardforkConfig{}
 
 	// Set all hardforks
 	hardforkVal := reflect.ValueOf(&hardforkCfg).Elem()
@@ -134,7 +135,7 @@ func TestApplyHardforks(t *testing.T) {
 	requireAllHardforksSetCorrectly(t, cfg, hardforkCfg)
 }
 
-func requireAllHardforksSetCorrectly(t *testing.T, cfg Config, hardforkCfg superchain.HardforkConfig) {
+func requireAllHardforksSetCorrectly(t *testing.T, cfg rollup.Config, hardforkCfg registry.HardforkConfig) {
 	hardforkType := reflect.TypeOf(hardforkCfg)
 	hardforkVal := reflect.ValueOf(hardforkCfg)
 	cfgVal := reflect.ValueOf(&cfg).Elem()


### PR DESCRIPTION
Extract `LoadOPStackRollupConfig` (+ `applyHardforks`) from `op-node/rollup` into a new `op-node/superchain` package.

`superchain.go` was the **only** file making `op-node/rollup` transitively depend on `op-core/superchain`, whose `//go:embed superchain-configs.zip` forces the (gitignored, ~3MB) bundle to be generated before the package compiles. `op-node/rollup` is imported by ~50 packages that only need its config types — they no longer pull in the bundle. In particular `op-fetcher/...` and `op-chain-ops/script` are now superchain-free, which unblocks the `superchain-registry` `ops/cmd/codegen` build chain that motivated this.

The five call sites of the moved function are all packages that legitimately read the registry, repointed to `op-node/superchain`. `op-node/rollup/deps_test.go` guards against reintroducing the dependency.

No behavior change — the loader body is unchanged apart from type qualifiers.

Also corrects a now-stale comment on the CI `prep-superchain` job (it is not the only place the zip is built; jobs that don't attach the workspace rebuild it inline).

Note on naming: the new package is `superchain` (matching its path). Where a file also imports the raw `op-core/superchain`, that is aliased `registry`. Happy to rename the package if reviewers prefer avoiding the collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
