### PR TITLE
test(contracts): skip past NUT bundles already applied on the forked chain

### DIFF
--- a/packages/contracts-bedrock/test/L2/fork/L2ForkUpgrade.t.sol
+++ b/packages/contracts-bedrock/test/L2/fork/L2ForkUpgrade.t.sol
@@ -107,12 +107,9 @@ contract L2ForkUpgrade_TestInit is CommonTest {
     }
 
     /// @notice Returns true when the current bundle has already been applied to the forked chain.
-    ///         Uses two checks: ConditionalDeployer exists (Karst ran) and this bundle's
-    ///         L2ContractsManager was deployed at its expected address.
     function _isCurrentBundleAlreadyApplied() internal view returns (bool) {
-        if (Predeploys.CONDITIONAL_DEPLOYER.code.length == 0) return false;
         address l2cm = PastNUTBundles.extractL2CM(_currentBundleTxns(), Constants.CURRENT_BUNDLE_PATH);
-        return l2cm.code.length > 0;
+        return PastNUTBundles.isBundleApplied(l2cm);
     }
 
     /// @notice Copies the cached current bundle transactions from storage to memory.

--- a/packages/contracts-bedrock/test/setup/PastNUTBundles.sol
+++ b/packages/contracts-bedrock/test/setup/PastNUTBundles.sol
@@ -182,7 +182,7 @@ library PastNUTBundles {
         NetworkUpgradeTxns.NetworkUpgradeTxn[] memory _currentTxns
     )
         internal
-        pure
+        view
         returns (bool skip_, string memory reason_, address priorL2CM_)
     {
         priorL2CM_ = extractL2CM(_priorTxns, _entry.path);
@@ -192,6 +192,19 @@ library PastNUTBundles {
             return (true, "L2CM matches current", priorL2CM_);
         }
 
+        // Skip prior bundles whose effects are already present on the fork.
+        if (isBundleApplied(priorL2CM_)) {
+            return (true, "already applied on fork", priorL2CM_);
+        }
+
         return (false, "", priorL2CM_);
+    }
+
+    /// @notice Returns whether a NUT bundle, identified by its L2ContractsManager, is already
+    ///         present on the forked chain.
+    /// @param _l2cm The bundle's L2ContractsManager address.
+    /// @return applied_ Whether the bundle's effects are already present on the fork.
+    function isBundleApplied(address _l2cm) internal view returns (bool applied_) {
+        applied_ = Predeploys.CONDITIONAL_DEPLOYER.code.length != 0 && _l2cm.code.length != 0;
     }
 }

--- a/packages/contracts-bedrock/test/setup/PastNUTBundles.t.sol
+++ b/packages/contracts-bedrock/test/setup/PastNUTBundles.t.sol
@@ -26,6 +26,9 @@ abstract contract PastNUTBundles_TestInit is Test {
 
     /// @notice L2ContractsManager address encoded by the committed Karst NUT bundle.
     address internal constant KARST_L2CM = 0x5398A70Eb0929dd7bfc73c59E7137d8C7CDF6669;
+
+    /// @notice L2ContractsManager address encoded by the committed Lagoon NUT bundle.
+    address internal constant LAGOON_L2CM = 0x82c0BB44c86bBB1620583890B2af560382AA83c8;
 }
 
 /// @title PastNUTBundles_OrderTarget
@@ -311,6 +314,55 @@ contract PastNUTBundles_applyPastBundles_Test is PastNUTBundles_TestInit {
         PastNUTBundles.applyPastBundles(currentTxns, script, entries);
     }
 
+    /// @notice A prior bundle already applied to the fork is skipped.
+    function testFuzz_applyPastBundles_skipsWhenAlreadyApplied_succeeds(address _l2cm) public {
+        vm.assume(_l2cm != address(0) && _l2cm != KARST_L2CM);
+        ExecuteNUTBundle script = new ExecuteNUTBundle();
+
+        NetworkUpgradeTxns.NetworkUpgradeTxn[] memory currentTxns = new NetworkUpgradeTxns.NetworkUpgradeTxn[](1);
+        currentTxns[0] = NetworkUpgradeTxns.NetworkUpgradeTxn({
+            data: abi.encodeCall(IL2ProxyAdmin.upgradePredeploys, (_l2cm)),
+            from: address(0),
+            gasLimit: 0,
+            intent: "L2ProxyAdmin Upgrade Predeploys",
+            to: Predeploys.PROXY_ADMIN
+        });
+
+        PastNUTBundles.NUTBundle[] memory entries = new PastNUTBundles.NUTBundle[](1);
+        entries[0] = PastNUTBundles.NUTBundle({ fork: "karst", path: KARST_BUNDLE_PATH });
+
+        // Simulate a fork that already activated Karst
+        vm.etch(Predeploys.CONDITIONAL_DEPLOYER, hex"01");
+        vm.etch(KARST_L2CM, hex"01");
+
+        // The executor must not run
+        vm.expectCall(address(script), abi.encodePacked(ExecuteNUTBundle.executeAll.selector), 0);
+        PastNUTBundles.applyPastBundles(currentTxns, script, entries);
+    }
+
+    /// @notice A prior bundle whose L2CM is absent is still applied even when the ConditionalDeployer
+    ///         predeploy already has code since a fork later than that prior bundle's activation deploys
+    ///         the ConditionalDeployer without applying every earlier prior bundle.
+    function test_applyPastBundles_appliesWhenOnlyConditionalDeployerPresent_succeeds() public {
+        ExecuteNUTBundle script = new ExecuteNUTBundle();
+
+        NetworkUpgradeTxns.NetworkUpgradeTxn[] memory karstTxns = NetworkUpgradeTxns.readArtifact(KARST_BUNDLE_PATH);
+        NetworkUpgradeTxns.NetworkUpgradeTxn[] memory lagoonTxns = NetworkUpgradeTxns.readArtifact(LAGOON_BUNDLE_PATH);
+
+        PastNUTBundles.NUTBundle[] memory entries = new PastNUTBundles.NUTBundle[](1);
+        entries[0] = PastNUTBundles.NUTBundle({ fork: "lagoon", path: LAGOON_BUNDLE_PATH });
+
+        // ConditionalDeployer has code (Karst ran) but the Lagoon L2CM does not: Lagoon is not yet
+        // applied, so its bundle must still be executed.
+        vm.etch(Predeploys.CONDITIONAL_DEPLOYER, hex"01");
+        assertEq(LAGOON_L2CM.code.length, 0, "Lagoon L2CM should have no code in this test");
+
+        vm.mockCall(address(script), abi.encodePacked(ExecuteNUTBundle.executeAll.selector), "");
+        // current == karst so the prior Lagoon entry is not skipped by the "L2CM matches current" rule.
+        vm.expectCall(address(script), abi.encodeCall(ExecuteNUTBundle.executeAll, (lagoonTxns)), 1);
+        PastNUTBundles.applyPastBundles(karstTxns, script, entries);
+    }
+
     /// @notice Multiple entries are evaluated independently: entries with matching L2CMs are
     ///         skipped while entries with different L2CMs are applied.
     function test_applyPastBundles_multipleEntriesSkipOneApplyOther_succeeds() public {
@@ -328,5 +380,35 @@ contract PastNUTBundles_applyPastBundles_Test is PastNUTBundles_TestInit {
         vm.expectCall(address(script), abi.encodeCall(ExecuteNUTBundle.executeAll, (lagoonTxns)), 1);
 
         PastNUTBundles.applyPastBundles(karstTxns, script, entries);
+    }
+}
+
+/// @title PastNUTBundles_isBundleApplied_Test
+contract PastNUTBundles_isBundleApplied_Test is PastNUTBundles_TestInit {
+    /// @notice Fresh pre-Karst fork which has neither signal present, so no bundle is considered applied.
+    function testFuzz_isBundleApplied_neitherPresent_succeeds(address _l2cm) public view {
+        vm.assume(_l2cm.code.length == 0);
+        assertFalse(PastNUTBundles.isBundleApplied(_l2cm));
+    }
+
+    /// @notice ConditionalDeployer present but the bundle's L2CM absent in which a later fork deployed the
+    ///         ConditionalDeployer without applying this bundle and not considered applied.
+    function testFuzz_isBundleApplied_onlyConditionalDeployer_succeeds(address _l2cm) public {
+        vm.assume(_l2cm != Predeploys.CONDITIONAL_DEPLOYER && _l2cm.code.length == 0);
+        vm.etch(Predeploys.CONDITIONAL_DEPLOYER, hex"01");
+        assertFalse(PastNUTBundles.isBundleApplied(_l2cm));
+    }
+
+    /// @notice L2CM present but ConditionalDeployer absent so not considered applied.
+    function test_isBundleApplied_onlyL2CM_succeeds() public {
+        vm.etch(KARST_L2CM, hex"01");
+        assertFalse(PastNUTBundles.isBundleApplied(KARST_L2CM));
+    }
+
+    /// @notice Post-activation fork in which both CD and L2CM present, so the bundle is considered applied.
+    function test_isBundleApplied_bothPresent_succeeds() public {
+        vm.etch(Predeploys.CONDITIONAL_DEPLOYER, hex"01");
+        vm.etch(KARST_L2CM, hex"01");
+        assertTrue(PastNUTBundles.isBundleApplied(KARST_L2CM));
     }
 }


### PR DESCRIPTION
## Context
L2 fork tests fork the chain at its latest block and replay prior NUT bundles. Replaying `Karst` now reverts with CreateCollision: its first tx is a non-idempotent CREATE2 of the ConditionalDeployer impl, which already exists once the live chain activates `Karst`.

The repo hasn't changed. The forked chain crossed `Karst` activation, and the tests fork at HEAD, so the replay started colliding.

**The fix**: skip a prior bundle whose effects are already on the fork. New `PastNUTBundles.isBundleApplied` requires that both the ConditionalDeployer predeploy and the bundle's own L2ContractsManager have code. The ConditionalDeployer alone isn't enough, since a later fork deploys it without applying every earlier bundle. Same check already used for the current bundle in `L2ForkUpgrade.t.sol`. It is now shared.