### PR TITLE
docs: reorder create-l2-rollup entry page — prerequisites before setup paths

### DIFF
--- a/docs/public-docs/chain-operators/tutorials/create-l2-rollup/create-l2-rollup.mdx
+++ b/docs/public-docs/chain-operators/tutorials/create-l2-rollup/create-l2-rollup.mdx
@@ -1,6 +1,7 @@
 ---
 title: Creating your own L2 rollup testnet
 description: Learn how to deploy and orchestrate all OP Stack components for a complete testnet deployment.
+diataxis: tutorial
 ---
 
 Welcome to the complete guide for deploying your own OP Stack L2 rollup testnet. This multi-part tutorial will walk you through each component step-by-step, from initial setup to a fully functioning rollup.
@@ -22,52 +23,9 @@ By the end of this tutorial, you'll have a complete OP Stack testnet with:
 *   **Proposer** (op-proposer) submitting state root proposals
 *   **Challenger** (op-challenger) monitoring for disputes
 
-## Quick setup (Recommended)
-
-If you want to get started quickly, you can use the complete working implementation provided in this repository. This automated setup handles all the configuration and deployment steps for you.
-
-<Info>
-  **Complete working example**
-
-  A complete, working implementation is available in the [`create-l2-rollup-example/`](https://github.com/ethereum-optimism/optimism/tree/develop/docs/public-docs/create-l2-rollup-example/) directory. This includes all necessary scripts, Docker Compose configuration, and example environment files.
-</Info>
-
-### Automated setup steps
-
-1.  **Clone and navigate to the code directory:**
-    ```bash
-    git clone https://github.com/ethereum-optimism/optimism.git
-    cd optimism/docs/public-docs/create-l2-rollup-example
-    ```
-
-2.  **Configure your environment:**
-    ```bash
-    cp .example.env .env
-    # Edit .env with your L1_RPC_URL, PRIVATE_KEY, and other settings
-    ```
-
-3.  **Run the automated setup:**
-    ```bash
-    make init    # Download op-deployer
-    make setup   # Deploy contracts and generate configs
-    make up      # Start all services
-    make test-l1 # Verify L1 connectivity
-    make test-l2 # Verify L2 functionality
-    ```
-
-4.  **Monitor your rollup:**
-    ```bash
-    make logs     # View all service logs
-    make status   # Check service health
-    ```
-
-The automated setup uses the standard OP Stack environment variable conventions (prefixed with `OP_*`) and handles all the complex configuration automatically.
-
-## Manual setup (Step-by-Step)
-
-If you prefer to understand each component in detail or need custom configurations, follow the step-by-step guide below.
-
 ## Before you start
+
+Set up the following before you pick a setup path below. Both the automated and manual paths need these dependencies and resources.
 
 ### Software dependencies
 
@@ -152,11 +110,59 @@ You can either use a node provider like [Alchemy](https://www.alchemy.com/) (eas
   **Testnet Only**: This guide is for **testnet deployment only**.
 </Info>
 
+## Choose your path
+
+With your dependencies and resources in place, pick the path that fits how you want to work:
+
+*   **[Automated setup](#automated-setup)** — the fastest way to a running rollup. Uses the complete working implementation in this repository and handles all configuration and deployment for you.
+*   **[Manual setup](#manual-setup)** — walks through each component step-by-step. Choose this if you want to understand each component in detail or need custom configurations.
+
+## Automated setup
+
+If you want to get started quickly, you can use the complete working implementation provided in this repository. This automated setup handles all the configuration and deployment steps for you.
+
 <Info>
-  **Follow in Order**: Each step builds on the previous one. Start with spinning up op-deployer and complete them sequentially for the best experience.
+  **Complete working example**
+
+  A complete, working implementation is available in the [`create-l2-rollup-example/`](https://github.com/ethereum-optimism/optimism/tree/develop/docs/public-docs/create-l2-rollup-example/) directory. This includes all necessary scripts, Docker Compose configuration, and example environment files.
 </Info>
 
-## Directory structure
+### Automated setup steps
+
+1.  **Clone and navigate to the code directory:**
+    ```bash
+    git clone https://github.com/ethereum-optimism/optimism.git
+    cd optimism/docs/public-docs/create-l2-rollup-example
+    ```
+
+2.  **Configure your environment:**
+    ```bash
+    cp .example.env .env
+    # Edit .env with your L1_RPC_URL, PRIVATE_KEY, and other settings
+    ```
+
+3.  **Run the automated setup:**
+    ```bash
+    make init    # Download op-deployer
+    make setup   # Deploy contracts and generate configs
+    make up      # Start all services
+    make test-l1 # Verify L1 connectivity
+    make test-l2 # Verify L2 functionality
+    ```
+
+4.  **Monitor your rollup:**
+    ```bash
+    make logs     # View all service logs
+    make status   # Check service health
+    ```
+
+The automated setup uses the standard OP Stack environment variable conventions (prefixed with `OP_*`) and handles all the complex configuration automatically.
+
+## Manual setup
+
+If you prefer to understand each component in detail or need custom configurations, follow the step-by-step guide below. Each step builds on the previous one, so complete them in order for the best experience.
+
+### Directory structure
 
 To keep your rollup deployment organized, we'll create a dedicated directory structure. All components will be set up within this structure:
 
@@ -175,9 +181,9 @@ Each component's documentation will show you how the directory structure evolves
   Throughout this tutorial, all file paths will be relative to this `rollup` directory structure. Make sure to adjust any commands if you use different directory names.
 </Info>
 
-## Manual Tutorial Overview
+### Manual setup steps
 
-If you're following the manual setup path, this tutorial is organized into sequential steps that build upon each other:
+The manual path is organized into sequential steps that build upon each other:
 
 <Steps>
 <Step title="Spin up op-deployer">
@@ -216,16 +222,12 @@ Configure op-challenger for dispute resolution monitoring
 </Step>
 </Steps>
 
-## Ready to Start?
-
-Now that you understand what you'll be building, let's begin with the first step!
-
-<Card title="Spin up op-deployer" href="/operators/chain-operators/tutorials/create-l2-rollup/op-deployer-setup">
+<Card title="Spin up op-deployer" href="/chain-operators/tutorials/create-l2-rollup/op-deployer-setup">
   Already have your dependencies? Get started and spin up op-deployer
 </Card>
 
 ***
 
-## Need Help?
+## Need help?
 
 *   **Issues**: Report bugs on GitHub


### PR DESCRIPTION
## What

Restructures the entry page of the multi-part **"Creating your own L2 rollup testnet"** tutorial (`docs/public-docs/chain-operators/tutorials/create-l2-rollup/create-l2-rollup.mdx`) so it reads as a clean, linear getting-started flow. This is a structure/signposting pass over the page's existing content — **no deployment command, version, tool name, or technical instruction changed.**

## Why

The entry page is the front door to the chain-operator chain-launch flow, but its section order worked against a first-time reader:

- The prerequisites (`Before you start` — dependency table, sepolia node access, required ~2-3 Sepolia ETH, L1 RPC URL) sat **after** the "recommended" automated path. A reader following that path was told to run `make setup` before ever seeing the requirements they need in place first.
- The headings were jumbled: `Quick setup` → `Manual setup` (a heading with a single orphan sentence) → `Before you start` → `Directory structure` → `Manual Tutorial Overview`. The two setup paths were never presented as a clear choice, and the manual path was split across two sections far apart on the page.
- The closing `Ready to Start?` Card duplicated the first step already in the `<Steps>` list and used a non-canonical `/operators/...` link that only resolved via a redirect double-hop.

### Changes

- Moved `Before you start` **above** both setup paths, so requirements come first (both paths need them).
- Added a `Choose your path` section presenting automated vs manual as an explicit up-front choice.
- Consolidated the manual path into one ordered `Manual setup` section (directory structure + the `<Steps>` walkthrough), removing the duplicate `Ready to Start?` section while keeping its first-step Card at the end of the flow.
- Fixed the Card link to the canonical `/chain-operators/tutorials/create-l2-rollup/op-deployer-setup` path (was `/operators/chain-operators/...`, which every other link on the page already avoids).
- Added `diataxis: tutorial` frontmatter, declaring the page's Diátaxis quadrant.

## Source / grounding

Structure-only change grounded in the page's own existing content; no new technical claims. Verified with the plugin lint helpers: `internal_links_broken: 0` (the previously non-canonical Card link now resolves directly), no render breaks, no missing language tags, all code snippets pass. The one `</Card>` "no matching opener" lint warning is a pre-existing false positive (present identically on `develop`) from the linter's tag scanner on the `<Card>` component — the markup is valid Mintlify.

## Reviewer checklist

- [ ] Section order reads top-to-bottom as a getting-started flow (requirements → choose path → automated → manual).
- [ ] No command, version, or instruction was altered (diff is section moves + the one canonical-link fix).
- [ ] `Choose your path` anchor links resolve to `#automated-setup` and `#manual-setup`.
- [ ] `diataxis: tutorial` frontmatter is correct for this page.
- [ ] Renders cleanly in `mintlify dev`.

## Context

Part of the continuous Diátaxis docs-structure experiment — see [`projects/docs-improver/README.md`](https://github.com/ethereum-optimism/solutions/blob/main/projects/docs-improver/README.md) for what this is.

Tracks ethereum-optimism/solutions#873 · part of the Diátaxis docs-structure backlog (ethereum-optimism/solutions#790).

🤖 Drafted by the docs-improver agent — review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
