### PR TITLE
(docs) post karst activation cleanup

### DIFF
--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -120,12 +120,14 @@ Update the following components:
 * If your chain does not have the flag, the latest releases mean you are not affected and no action is required.
 * If your chain already activated Karst, it **must** use `keep_karst_upgrade_gas = true`. Some chains that have not yet activated Karst (including mainnet chains) also have the flag set — check the list below to see whether yours is affected.
 
-The chains with `keep_karst_upgrade_gas = true` (the [canonical list](https://github.com/ethereum-optimism/superchain-registry/pull/1259/files)) are:
+The chains with `keep_karst_upgrade_gas = true` is:
 
 * **Mainnet:** `OP`, `Ink`, `Metal`, `Mode`, `Soneium`, `Unichain`, `Zora`
-* **Sepolia:** `OP`, `Ink`, `Lisk`, `Metal`, `Mode`, `Soneium (Minato)`, `Unichain`, `Zora`
+* **Sepolia:** `OP`, `Ink`, `Lisk`, `Soneium (Minato)`, `Unichain`
 
-Sepolia chains have already activated Karst, so the action is due now.
+Metal, Mode, and Zora Mainnet did not have this value configured on their sequencers during Karst activation.
+So they inherited the default value of `keep_karst_upgrade_gas = false`.
+Node operators will not be able to utilize the `--network` flag on `op-node` until a subsequent node is releases are cut with these changes being [updated](https://github.com/ethereum-optimism/superchain-registry/pull/1281) in the superchain-registry.
 
 #### Restoring the gas limit
 

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -123,8 +123,8 @@ Update the following components:
 The chains with `keep_karst_upgrade_gas = true` are:
 
 
-* **Mainnet:** `OP`, `Ink`, `Lisk`, `Soneium (Minato)`, `Unichain`
-* **Sepolia:** `OP`, `Ink`, `Metal`, `Mode`, `Soneium`, `Unichain`, `Zora`
+* **Mainnet:** `OP`, `Ink`, `Soneium (Minato)`, `Unichain`
+* **Sepolia:** `OP`, `Ink`, `Lisk`, `Metal`, `Mode`, `Soneium`, `Unichain`, `Zora`
 
 Metal, Mode, and Zora Mainnet did not have this value configured on their sequencers during Karst activation.
 So they inherited the default value of `keep_karst_upgrade_gas = false`.

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -120,14 +120,17 @@ Update the following components:
 * If your chain does not have the flag, the latest releases mean you are not affected and no action is required.
 * If your chain already activated Karst, it **must** use `keep_karst_upgrade_gas = true`. Some chains that have not yet activated Karst (including mainnet chains) also have the flag set — check the list below to see whether yours is affected.
 
-The chains with `keep_karst_upgrade_gas = true` is:
+The chains with `keep_karst_upgrade_gas = true` are:
+
 
 * **Mainnet:** `OP`, `Ink`, `Metal`, `Mode`, `Soneium`, `Unichain`, `Zora`
 * **Sepolia:** `OP`, `Ink`, `Lisk`, `Soneium (Minato)`, `Unichain`
 
 Metal, Mode, and Zora Mainnet did not have this value configured on their sequencers during Karst activation.
 So they inherited the default value of `keep_karst_upgrade_gas = false`.
-Node operators will not be able to utilize the `--network` flag on `op-node` until a subsequent node is releases are cut with these changes being [updated](https://github.com/ethereum-optimism/superchain-registry/pull/1281) in the superchain-registry.
+
+Node operators will not be able to utilize the `--network` flag on `op-node` until a subsequent node release is cut with these changes being [updated](https://github.com/ethereum-optimism/superchain-registry/pull/1281) in the superchain-registry.
+
 
 #### Restoring the gas limit
 

--- a/docs/public-docs/notices/upgrade-19.mdx
+++ b/docs/public-docs/notices/upgrade-19.mdx
@@ -122,8 +122,8 @@ Update the following components:
 
 The chains with `keep_karst_upgrade_gas = true` is:
 
-* **Mainnet:** `OP`, `Ink`, `Metal`, `Mode`, `Soneium`, `Unichain`, `Zora`
-* **Sepolia:** `OP`, `Ink`, `Lisk`, `Soneium (Minato)`, `Unichain`
+* **Mainnet:** `OP`, `Ink`, `Lisk`, `Soneium (Minato)`, `Unichain`
+* **Sepolia:** `OP`, `Ink`, `Metal`, `Mode`, `Soneium`, `Unichain`, `Zora`
 
 Metal, Mode, and Zora Mainnet did not have this value configured on their sequencers during Karst activation.
 So they inherited the default value of `keep_karst_upgrade_gas = false`.

--- a/docs/public-docs/op-stack/features/l2-contract-manager.mdx
+++ b/docs/public-docs/op-stack/features/l2-contract-manager.mdx
@@ -3,10 +3,6 @@ title: L2 Contract Manager
 description: Learn how the L2 Contract Manager (L2CM) enables governance-approved L2 smart contract upgrades through the consensus layer.
 ---
 
-<Info>
-  This feature ships with [Upgrade 19](/notices/upgrade-19). It is non-functional until the upgrade is approved by governance and activated on Mainnet.
-</Info>
-
 The L2 Contract Manager (L2CM) is a new mechanism that enables governance-approved upgrades to L2 smart contracts (predeploys) as part of a network upgrade. L2CM executes predeploy upgrades atomically and in a structured, auditable way — eliminating the need for individual multisig transactions per contract and reducing upgrade complexity for the entire OP Stack ecosystem.
 
 ## Overview

--- a/docs/public-docs/op-stack/features/osaka-on-l2.mdx
+++ b/docs/public-docs/op-stack/features/osaka-on-l2.mdx
@@ -3,10 +3,6 @@ title: Osaka on L2
 description: Learn about the Osaka EIP activations on L2, including the EIP-7825 per-transaction gas limit and precompile gas changes.
 ---
 
-<Info>
-  This feature ships with [Upgrade 19](/notices/upgrade-19). It is non-functional until the upgrade is approved by governance and activated on Mainnet.
-</Info>
-
 Upgrade 19 activates a subset of the Osaka EIPs on L2 — specifically the changes that are applicable to OP Stack chains. Not every Osaka EIP is relevant to L2 execution; only those that affect L2 transaction processing or precompile behavior are included.
 
 The activated changes introduce a per-transaction gas limit and updated gas costs for two precompiles.


### PR DESCRIPTION
Removing u19 callouts
Fixing the u19 notice page to denote that Mode, Metal, and Zora Mainnet did not use the keep_karst_upgrade_gas flag
