### PR TITLE
op-deployer: automatically update the default genesis fork

### DIFF
--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -2,9 +2,13 @@ package standard
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
+	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
+	opparams "github.com/ethereum-optimism/optimism/op-core/params"
 	"github.com/ethereum-optimism/optimism/op-core/superchain"
 
 	"github.com/ethereum-optimism/superchain-registry/validation"
@@ -155,11 +159,52 @@ func L2ProxyAdminOwner(chainID uint64) (common.Address, error) {
 }
 
 // DefaultHardforkSchedule is used to determine which hardforks should be activated by default.
+// It activates, at genesis, the most recent fork that has an activation timestamp scheduled on
+// OP Mainnet.
 func DefaultHardforkSchedule() *genesis.UpgradeScheduleDeployConfig {
 	sched := &genesis.UpgradeScheduleDeployConfig{}
-	sched.ActivateForkAtGenesis(forks.Karst)
+	sched.ActivateForkAtGenesis(defaultHardfork())
 
 	return sched
+}
+
+var defaultHardfork = sync.OnceValue(func() forks.Name {
+	chain, err := superchain.GetChain(opparams.OPMainnetChainID)
+	if err != nil {
+		panic(fmt.Errorf("get op mainnet chain: %w", err))
+	}
+	chainConfig, err := chain.Config()
+	if err != nil {
+		panic(fmt.Errorf("load op mainnet chain config: %w", err))
+	}
+	return latestScheduledMainlineFork(chainConfig.Hardforks)
+})
+
+func latestScheduledMainlineFork(config superchain.HardforkConfig) forks.Name {
+	configValue := reflect.ValueOf(config)
+	mainlineForks := forks.From(forks.Canyon)
+	for i := len(mainlineForks) - 1; i >= 0; i-- {
+		fork := mainlineForks[i]
+		// HardforkConfig fields follow the <ForkName>Time convention. Looking them up
+		// from forks.All keeps this selection current when a new mainline fork is added.
+		field := configValue.FieldByNameFunc(func(name string) bool {
+			return strings.EqualFold(strings.TrimSuffix(name, "Time"), string(fork))
+		})
+		if !field.IsValid() {
+			panic(fmt.Sprintf("mainline fork %q is missing from superchain.HardforkConfig", fork))
+		}
+		activationTime, ok := field.Interface().(*uint64)
+		if !ok {
+			panic(fmt.Sprintf("superchain.HardforkConfig field for %q must be *uint64", fork))
+		}
+		if activationTime != nil {
+			return fork
+		}
+	}
+
+	// Regolith is active at genesis for every registry-backed rollup config, but its
+	// activation is implicit and is therefore not represented in HardforkConfig.
+	return forks.Regolith
 }
 
 func mustHexBigFromHex(hex string) *hexutil.Big {

--- a/op-deployer/pkg/deployer/standard/standard_test.go
+++ b/op-deployer/pkg/deployer/standard/standard_test.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-core/superchain"
+	"github.com/ethereum-optimism/optimism/op-service/ptr"
+
 	"github.com/ethereum-optimism/superchain-registry/validation"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -15,6 +19,7 @@ import (
 
 func TestDefaultHardforkSchedule(t *testing.T) {
 	sched := DefaultHardforkSchedule()
+	require.NotSame(t, sched, DefaultHardforkSchedule())
 	require.NotNil(t, sched.RegolithTime(0))
 	require.NotNil(t, sched.CanyonTime(0))
 	require.NotNil(t, sched.DeltaTime(0))
@@ -26,6 +31,45 @@ func TestDefaultHardforkSchedule(t *testing.T) {
 	require.NotNil(t, sched.JovianTime(0))
 	require.NotNil(t, sched.KarstTime(0))
 	require.Nil(t, sched.LagoonTime(0))
+}
+
+func TestLatestScheduledMainlineFork(t *testing.T) {
+	tests := []struct {
+		name   string
+		config superchain.HardforkConfig
+		want   forks.Name
+	}{
+		{name: "regolith", want: forks.Regolith},
+		{
+			name: "delta",
+			config: superchain.HardforkConfig{
+				CanyonTime: ptr.New(uint64(0)),
+				DeltaTime:  ptr.New(uint64(0)),
+			},
+			want: forks.Delta,
+		},
+		{
+			name: "latest mainline fork wins",
+			config: superchain.HardforkConfig{
+				CanyonTime: ptr.New(uint64(0)),
+				LagoonTime: ptr.New(uint64(0)),
+			},
+			want: forks.Lagoon,
+		},
+		{
+			name: "optional fork is ignored",
+			config: superchain.HardforkConfig{
+				PectraBlobScheduleTime: ptr.New(uint64(0)),
+			},
+			want: forks.Regolith,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, latestScheduledMainlineFork(tt.config))
+		})
+	}
 }
 
 func TestStandardAddresses(t *testing.T) {


### PR DESCRIPTION
This way we don't need to remember to update it.
