### PR TITLE
docs: move rollup deploy-config to reference, frame op-deployer as default deploy path

### DIFF
--- a/docs/public-docs/chain-operators/guides/configuration/getting-started.mdx
+++ b/docs/public-docs/chain-operators/guides/configuration/getting-started.mdx
@@ -17,7 +17,7 @@ Deploying your OP Stack contracts requires creating a deployment configuration
       *   Be aware that many of these values cannot be changed after deployment or require a complex process to update.
           Carefully consider and validate all settings during configuration to avoid issues later.
 
-  *   [Rollup Configuration Documentation](/chain-operators/guides/configuration/rollup)
+  *   [Rollup Deployment Configuration reference](/chain-operators/reference/rollup-deployment-configuration)
 
 
   </Step>

--- a/docs/public-docs/chain-operators/guides/configuration/rollup.mdx
+++ b/docs/public-docs/chain-operators/guides/configuration/rollup.mdx
@@ -1,16 +1,19 @@
 ---
 title: Rollup deployment configuration
-description: Learn about the OP Stack rollup deployment configurations.
+description: Reference for the OP Stack rollup deployment configuration values.
+diataxis: reference
 ---
 
-<Warning>
-    This documentation is out of date.
-</Warning>
+This page is the reference for the deployment configuration values used to deploy an OP Stack chain.
+These values are supplied in the deployment configuration JSON file and set the L1 contract parameters and the L2 genesis state.
+Each entry lists its type, default, recommended value, and standard-configuration requirement.
+
+The authoritative source for these values is the `DeployConfig` struct in [`op-chain-ops/genesis/config.go`](https://github.com/ethereum-optimism/optimism/blob/b003efacdbdf197744ded0e83630ddf82c458c30/op-chain-ops/genesis/config.go).
+The JSON key for each value is the `json:"..."` tag on the corresponding field there; when a value on this page and the source disagree, the source wins.
 
 <Info>
-  The Rollup configuration is an active work in progress and will likely evolve
-  significantly as time goes on. If something isn't working about your
-  configuration, you can refer to the [source code](https://github.com/ethereum-optimism/optimism/blob/develop/op-chain-ops/genesis/config.go).
+  Deploy-config values are largely immutable after a chain is deployed, so this page targets the values you set at genesis.
+  The output-oracle proposal fields (the `l2OutputOracle*` values) describe the legacy `L2OutputOracle` proposal system; chains using [permissionless fault proofs](/op-stack/fault-proofs/explainer) set the fault-proof deployment values instead. [TODO: needs source] Confirm the current fault-proof deploy-config fields (`FaultProofDeployConfig` in `op-chain-ops/genesis/config.go`) that should replace the `l2OutputOracle*` proposal fields for fault-proof chains before publishing.
 </Info>
 
 <Info>
@@ -23,7 +26,7 @@ description: Learn about the OP Stack rollup deployment configurations.
 
 ## Deployment configuration values
 
-These values are provided to the deployment configuration JSON file when 
+These values are provided to the deployment configuration JSON file when
 deploying the L1 contracts.
 
 ### Offset values

--- a/docs/public-docs/chain-operators/reference/rollup-deployment-configuration.mdx
+++ b/docs/public-docs/chain-operators/reference/rollup-deployment-configuration.mdx
@@ -4,16 +4,32 @@ description: Reference for the OP Stack rollup deployment configuration values.
 diataxis: reference
 ---
 
-This page is the reference for the deployment configuration values used to deploy an OP Stack chain.
-These values are supplied in the deployment configuration JSON file and set the L1 contract parameters and the L2 genesis state.
-Each entry lists its type, default, recommended value, and standard-configuration requirement.
+This page is the reference for the values in the `DeployConfig` — the flat JSON
+configuration that sets the L1 contract parameters and the L2 genesis state when
+an OP Stack chain is deployed. Each entry lists its type, default, recommended
+value, and standard-configuration requirement.
+
+<Info>
+  **The recommended way to deploy an OP Stack chain is [OP Deployer](/chain-operators/tools/op-deployer/overview).**
+  OP Deployer takes a declarative [intent file](/chain-operators/tools/op-deployer/usage/init) (`intent.toml`)
+  rather than a hand-written `DeployConfig` JSON, and derives the `DeployConfig`
+  documented here from that intent as part of its deployment pipeline. Most chain
+  operators set the intent file and never edit a `DeployConfig` directly.
+
+  This page documents the underlying `DeployConfig` surface: the exhaustive set of
+  values a deployment ultimately resolves to. Use it to understand what an intent
+  setting maps to, to interpret the `DeployConfig` that OP Deployer can emit for an
+  applied deployment (via `op-deployer inspect deploy-config`), or as background for
+  the lower-level [custom deployments](/chain-operators/tools/op-deployer/reference/custom-deployments)
+  OP Deployer also supports.
+</Info>
 
 The authoritative source for these values is the `DeployConfig` struct in [`op-chain-ops/genesis/config.go`](https://github.com/ethereum-optimism/optimism/blob/b003efacdbdf197744ded0e83630ddf82c458c30/op-chain-ops/genesis/config.go).
 The JSON key for each value is the `json:"..."` tag on the corresponding field there; when a value on this page and the source disagree, the source wins.
 
 <Info>
   Deploy-config values are largely immutable after a chain is deployed, so this page targets the values you set at genesis.
-  The output-oracle proposal fields (the `l2OutputOracle*` values) describe the legacy `L2OutputOracle` proposal system; chains using [permissionless fault proofs](/op-stack/fault-proofs/explainer) set the fault-proof deployment values instead. [TODO: needs source] Confirm the current fault-proof deploy-config fields (`FaultProofDeployConfig` in `op-chain-ops/genesis/config.go`) that should replace the `l2OutputOracle*` proposal fields for fault-proof chains before publishing.
+  The output-oracle proposal fields (the [`l2OutputOracle*` values](#proposal-fields)) describe the legacy `L2OutputOracle` proposal system and apply only to chains still on that system. Chains using [permissionless fault proofs](/op-stack/fault-proofs/explainer) — the standard configuration for new OP Stack chains — set the [fault-proof deployment values](#fault-proofs) instead: `useFaultProofs` together with the `faultGame*`, `preimageOracle*`, `proofMaturityDelaySeconds`, `disputeGameFinalityDelaySeconds`, and `respectedGameType` fields documented in the [Fault proofs](#fault-proofs) section below.
 </Info>
 
 <Info>
@@ -562,9 +578,12 @@ The `minBaseFee` is an absolute minimum expressed in wei.
 
 ### Proposal fields
 
-These fields apply to output root proposals. The
-l2OutputOracleSubmissionInterval is configurable, see the section below for
-guidance.
+These `l2OutputOracle*` fields configure the legacy `L2OutputOracle` proposal
+system and apply only to chains still on that system. Chains using
+[permissionless fault proofs](/op-stack/fault-proofs/explainer) — the standard
+configuration for new chains — set the [Fault proofs](#fault-proofs) fields
+instead. The `l2OutputOracleSubmissionInterval` is configurable; see the entry
+below for guidance.
 
 #### l2OutputOracleStartingBlockNumber
 

--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -988,7 +988,11 @@
     },
     {
       "source": "/operators/chain-operators/configuration/rollup",
-      "destination": "/chain-operators/guides/configuration/rollup"
+      "destination": "/chain-operators/reference/rollup-deployment-configuration"
+    },
+    {
+      "source": "/chain-operators/guides/configuration/rollup",
+      "destination": "/chain-operators/reference/rollup-deployment-configuration"
     },
     {
       "source": "/operators/chain-operators/deploy",
@@ -1894,7 +1898,6 @@
                   "chain-operators/guides/configuration/getting-started",
                   "chain-operators/guides/configuration/batcher",
                   "chain-operators/guides/configuration/proposer",
-                  "chain-operators/guides/configuration/rollup",
                   "chain-operators/guides/configuration/op-challenger-config-guide"
                 ]
               },
@@ -2009,6 +2012,7 @@
             "pages": [
               "chain-operators/reference/architecture",
               "chain-operators/reference/opcm",
+              "chain-operators/reference/rollup-deployment-configuration",
               "chain-operators/reference/standard-configuration"
             ]
           },


### PR DESCRIPTION
## What changed

Takes the rollup deploy-config structural fix a step past a frontmatter flip: it **moves the page into the first-class `chain-operators/reference/` group** as a genuine Diátaxis **reference** page, and **reframes it around OP Deployer as the recommended deploy path**.

The page is a pure catalogue of `DeployConfig` values (each entry has Type / Default / Recommended / Notes / Standard Config Requirement, no procedural steps) — austere lookup material that belonged in `reference/`, not the how-to `guides/` folder. It documents the *legacy/underlying* config surface: the older way a chain's config was hand-written, which OP Deployer now derives from a declarative intent file.

Specifically:

**Structural (Diátaxis: `reference`)**
- `git mv chain-operators/guides/configuration/rollup.mdx → chain-operators/reference/rollup-deployment-configuration.mdx` (history preserved).
- `docs.json`: removed it from the Configuration guides group, added it to the chain-operators **Reference** group; added a redirect from the old `guides/configuration/rollup` path and repointed the legacy `/operators/...` redirect — both now resolve to the new reference path.
- Fixed the inbound link in `guides/configuration/getting-started.mdx`.
- `diataxis: reference` frontmatter present on the page.

**Content (OP Deployer positioning + TODO resolution)**
- Added a lead callout stating **OP Deployer is the recommended way to deploy an OP Stack chain**: it takes a declarative `intent.toml` and *derives* the `DeployConfig` documented here as part of its pipeline; most operators set the intent and never edit a `DeployConfig` directly. The page is now explicitly framed as the underlying config surface (what an intent setting maps to / what `op-deployer inspect deploy-config` emits), with cross-links to the OP Deployer overview, `init`, and custom-deployments reference.
- **Resolved the shipped `[TODO: needs source]`** (no placeholder text remains anywhere in the doc): the legacy `l2OutputOracle*` proposal fields (`OutputOracleDeployConfig`) apply only to chains still on the `L2OutputOracle` system; fault-proof chains — the standard configuration for new chains — set the `FaultProofDeployConfig` fields (`useFaultProofs`, `faultGame*`, `preimageOracle*`, `proofMaturityDelaySeconds`, `disputeGameFinalityDelaySeconds`, `respectedGameType`), which the page **already catalogues** under its Fault proofs section. The two sections now cross-link, and the Proposal fields section is labelled legacy.

## Why

This is the flagship instance of the docs' dominant structural pattern: OP has no first-class `reference` format, so reference-grade config catalogues hide inside how-to `guides/`. Deploy-config values are largely immutable post-deployment, so operators return here to look them up — a reference page in the reference home, framed around the current recommended tooling, is the right shape. The old page shipped with a page-wide "out of date" warning and a `[TODO]`; both undermined a reference page's core job (being trustworthy) and are now gone.

## Grounding

- `op-chain-ops/genesis/config.go` — `DeployConfig` (authoritative struct for these JSON keys), `OutputOracleDeployConfig` (legacy `l2OutputOracle*` proposal fields), `FaultProofDeployConfig` (`useFaultProofs`, `faultGame*`, etc.).
- `op-deployer/pkg/deployer/state/deploy_config.go` — `CombineDeployConfig(intent, chainIntent, state, chainState)`: OP Deployer derives the `genesis.DeployConfig` from the intent + state. This is the concrete intent → DeployConfig relationship the reframing rests on.
- `op-deployer/pkg/deployer/inspect/flags.go` — the `inspect deploy-config` subcommand that emits the resolved `DeployConfig` for an applied deployment.
- OP Deployer public docs cross-referenced: `overview`, `usage/init` (intent file), `reference/custom-deployments`.
- Source link on the page pinned to commit `b003efacdb` so the reference doesn't drift with `develop`.

## Reviewer checklist

- [ ] `diataxis: reference` frontmatter is present and correct.
- [ ] The move + redirects are sound: old `guides/configuration/rollup` and legacy `/operators/...` both redirect to `/chain-operators/reference/rollup-deployment-configuration`, and the page appears once in the Reference nav group.
- [ ] The OP Deployer framing is accurate — intent file is the recommended path, this page is the underlying `DeployConfig` surface (`CombineDeployConfig`).
- [ ] The fault-proof vs. legacy-proposal caveat matches `OutputOracleDeployConfig` / `FaultProofDeployConfig` in source.
- [ ] The pinned source link and cross-links resolve; renders correctly in `mintlify dev`.

## Context

This PR is from the `docs-improver` experiment — continuous, structural (Diátaxis) improvement of the public docs, one small review-ready PR at a time. Overview: [`projects/docs-improver/README.md`](https://github.com/ethereum-optimism/solutions/blob/main/projects/docs-improver/README.md).

Addresses Diátaxis backlog finding `e28d611368d7accb` (high).
Tracks ethereum-optimism/solutions#874

🤖 Drafted by the docs-improver agent — review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
