### PR TITLE
docker: exclude .git from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,13 @@
 .github
 .vscode
 
+# The .git dir (~2GB with submodules) is never COPY'd by any build using this
+# context (e.g. the kona reproducible-prestate build). Excluding it keeps that
+# multi-GB tree out of the build context transfer. Builds that need git metadata
+# pass it via GIT_COMMIT/GIT_DATE build args instead.
+.git
+**/.git
+
 .env
 .envrc
 **/.env


### PR DESCRIPTION
## Overview

The kona reproducible-prestate build (`rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile`) uses the monorepo root as its build context and has no dedicated `Dockerfile.dockerignore`, so it falls back to the root `.dockerignore`. That file did not exclude `.git`, so the ~1.9 GB `.git` tree (including submodules) was scanned and transferred into the build context on every prestate build — even though nothing `COPY`s it.

This excludes `.git` / `**/.git` at the root to keep that multi-GB tree out of the context transfer.

## Why this is safe

BuildKit uses a single ignore file per build (a `<dockerfile>.dockerignore` sidecar if present, otherwise the context-root `.dockerignore`) — it does **not** merge them. So this root change only affects root-context builds that lack a sidecar:

- **op-stack-go images** pass git metadata via `GIT_COMMIT` / `GIT_DATE` build args and have their own allowlist `Dockerfile.dockerignore`, so they're unaffected and already excluded `.git`.
- **rollup-boost**, whose `build.rs` reads `.git` via `vergen_git2`, has its own `.dockerignore` that re-includes `.git` (`!/.git`) — also unaffected.
- The kona prestate build never `COPY`s `.git`, so excluding it only trims context-transfer time without changing any output (the reproducible prestate hash is derived from the workspace source + NUT bundles + superchain-registry data, not `.git`).

## Stacking

Stacked on #21645 (`joshklop/rust-versioning`) — base is that branch so the diff here is just the `.dockerignore` change. Merge/rebase after #21645 lands.