### PR TITLE
docs: document supported op-reth pruning (--full), warn against --minimal

### DIFF
--- a/docs/public-docs/node-operators/guides/configuration/execution-clients.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/execution-clients.mdx
@@ -1,12 +1,12 @@
 ---
 title: Execution client configuration
-description: Configure op-reth as your OP Stack execution client. op-geth support ends 2026-05-31.
+description: Configure op-reth as your OP Stack execution client. op-geth reached end-of-support 2026-05-31.
 ---
 
 The execution client provides the EVM runtime and transaction processing for your OP Stack node.
 
 <Warning>
-  **op-geth reaches end-of-support on 2026-05-31 and will not support the L1 Glamsterdam hardfork.** Chains still running op-geth at activation will not follow the canonical chain. Migrate to op-reth — see the [op-geth deprecation notice](/notices/op-geth-deprecation).
+  **op-geth has reached end-of-support (2026-05-31) and does not support the now-active Karst hardfork, so op-geth nodes can no longer follow the canonical chain.** Migrate to op-reth — see the [op-geth deprecation notice](/notices/op-geth-deprecation).
 </Warning>
 
 <Info>
@@ -34,6 +34,10 @@ The execution client provides the EVM runtime and transaction processing for you
     ### Historical proofs
 
     Permissionless chains need ~28 days of historical state for withdrawal proving. Follow the [Running op-reth with Historical Proofs](/node-operators/tutorials/reth-historical-proofs) tutorial to set up the `--proofs-history` (v2) store on op-reth v2.2.3 or later.
+
+    ### Pruning
+
+    op-reth defaults to an archive node. To reclaim disk, prune the state and receipt segments and keep block bodies. Body pruning (`--minimal` or `--prune.bodies.distance`) is unsupported and advised against. See [Pruning op-reth](/node-operators/guides/management/archive-node#pruning-op-reth).
 
     ### Complete reference
 
@@ -74,7 +78,7 @@ This file must be identical for both your execution client and your consensus cl
 ## op-geth (legacy — end of support 2026-05-31)
 
 <Warning>
-  op-geth support ends on **2026-05-31** and **will not support the Glamsterdam hardfork**. For new deployments, use op-reth (above). See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the migration plan.
+  op-geth reached end-of-support on **2026-05-31** and **does not support the now-active Karst hardfork**. For new deployments, use op-reth (above). See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the migration plan.
 </Warning>
 
 <Accordion title="op-geth configuration (legacy)">

--- a/docs/public-docs/node-operators/guides/configuration/legacy-geth.mdx
+++ b/docs/public-docs/node-operators/guides/configuration/legacy-geth.mdx
@@ -85,7 +85,7 @@ Both op-reth and op-geth use the same `--rollup.historicalrpc` flag to route pre
 
   <Tab title="op-geth">
     <Warning>
-      **op-geth reaches end-of-support on 2026-05-31.** New deployments should use op-reth. See the [op-geth deprecation notice](/notices/op-geth-deprecation).
+      **op-geth has reached end-of-support (2026-05-31) and does not support the now-active Karst hardfork.** New deployments should use op-reth. See the [op-geth deprecation notice](/notices/op-geth-deprecation).
     </Warning>
 
     ```bash

--- a/docs/public-docs/node-operators/guides/management/archive-node.mdx
+++ b/docs/public-docs/node-operators/guides/management/archive-node.mdx
@@ -33,7 +33,7 @@ Each section below shows the full set of flags needed on both `op-node` and your
 
 ### op-reth
 
-op-reth retains full state when run without pruning flags, so the standard op-node + op-reth configuration already produces an archive node.
+op-reth retains complete state when run without pruning flags, so the standard op-node + op-reth configuration already produces an archive node.
 
 Set on `op-node`:
 
@@ -41,7 +41,7 @@ Set on `op-node`:
 --syncmode=execution-layer
 ```
 
-Do not pass any `--prune.*` flags to op-reth.
+Do not pass any `--prune.*` flags to op-reth for a complete archive node. If you don't need complete history and want to reclaim disk, see [Pruning op-reth](#pruning-op-reth) below.
 
 ### Nethermind
 
@@ -64,7 +64,7 @@ Enable archive mode on Nethermind using the archive network configuration:
 ### op-geth
 
 <Warning>
-  **op-geth reaches end-of-support on 2026-05-31 and will not support the L1 Glamsterdam hardfork.** New deployments should use op-reth. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
+  **op-geth has reached end-of-support (2026-05-31) and does not support the now-active Karst hardfork, so op-geth nodes can no longer follow the canonical chain.** New deployments should use op-reth. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
 </Warning>
 
 Set on `op-node`:
@@ -83,6 +83,38 @@ Set on `op-geth`:
 <Info>
   Both flags are not the default settings and must be explicitly configured. The `--syncmode=full` flag ensures every block is executed, and `--gcmode=archive` disables state pruning.
 </Info>
+
+## Pruning op-reth
+
+If you don't need a complete archive node, you can prune op-reth to reclaim disk. The recommended approach prunes state and receipts while keeping every block body.
+
+### Recommended: prune state and receipts, keep block bodies
+
+Prune the state and receipt segments and leave block bodies fully intact. Set the same depth on each:
+
+```shell
+--prune.minimum-distance=<depth>
+--prune.receipts.distance=<depth>
+--prune.account-history.distance=<depth>
+--prune.storage-history.distance=<depth>
+```
+
+Recommended `<depth>` (in blocks), matching production:
+
+*   **`22000`** for sequencer-side nodes — covers the 12h sequencing window (≈ 21,600 blocks at a 2s block time).
+*   **`1296000`** (~30 days at 2s) for nodes that need more history.
+
+### Pruning block bodies (unsupported)
+
+op-node's safe derivation reads the L1-info deposit transaction — the first transaction of every block — from the block body at the head placed [`--syncmode.offset-el-safe`](/node-operators/reference/op-node-config#syncmode-offset-el-safe) behind the tip, and possibly further if restoring a safedb. If that body has been pruned, EL sync fails with `l2 block is missing L1 info deposit tx`.
+
+Body pruning is therefore **not supported, and we advise against it** — you run it at your own risk, with no guarantees. It can be made to work if you know what you're doing, subject to one hard requirement: the retained body window must always cover the `--syncmode.offset-el-safe` range. Concretely, set [`--prune.bodies.distance`](/node-operators/reference/op-reth-config#prune-bodies-distance) (in blocks) comfortably **greater than** the offset converted to blocks (the default `12h` ≈ 21,600 at a 2s block time), with margin for the block-time and offset you actually run. And if you restore a safedb, you also have to take the maximum distance to its head into account.
+
+Do not use `--minimal`: it prunes bodies to a fixed 10,064-block window, which is smaller than the default offset and cannot be widened independently.
+
+<Warning>
+  Body pruning is unsupported. If you enable it anyway, `--prune.bodies.distance` must always exceed `--syncmode.offset-el-safe` (in blocks), and additionally the distance to a restoring safedb's head, or execution-layer sync fails with `l2 block is missing L1 info deposit tx`. Prefer pruning only the state and receipt segments above.
+</Warning>
 
 ## How archive sync works
 

--- a/docs/public-docs/node-operators/overview.mdx
+++ b/docs/public-docs/node-operators/overview.mdx
@@ -38,10 +38,10 @@ The following are the supported implementations:
 
 * **[op-reth](https://github.com/ethereum-optimism/optimism/tree/develop/rust/op-reth)** — primary supported execution client.
 * **[Nethermind](https://github.com/NethermindEth/nethermind)** — alternative execution client.
-* **[op-geth](https://github.com/ethereum-optimism/op-geth)** — *deprecated*, end-of-support **2026-05-31**.
+* **[op-geth](https://github.com/ethereum-optimism/op-geth)** — *deprecated*, end-of-support reached **2026-05-31** (does not support the now-active Karst hardfork).
 
 <Warning>
-  **op-geth reaches end-of-support on 2026-05-31 and will not support the L1 Glamsterdam hardfork.** New deployments should use op-reth. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
+  **op-geth has reached end-of-support (2026-05-31) and does not support the now-active Karst hardfork, so op-geth nodes can no longer follow the canonical chain.** New deployments should use op-reth. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
 </Warning>
 
 ## Node Types

--- a/docs/public-docs/node-operators/reference/op-geth-config.mdx
+++ b/docs/public-docs/node-operators/reference/op-geth-config.mdx
@@ -4,7 +4,7 @@ description: Complete reference for all op-geth command-line flags and environme
 ---
 
 <Warning>
-  **op-geth reaches end-of-support on 2026-05-31 and will not support the L1 Glamsterdam hardfork.** This reference page is retained for operators still running op-geth and migrating off. For new deployments, use op-reth — see the [op-reth configuration reference](/node-operators/reference/op-reth-config). See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
+  **op-geth has reached end-of-support (2026-05-31) and does not support the now-active Karst hardfork, so op-geth nodes can no longer follow the canonical chain.** This reference page is retained for operators still running op-geth and migrating off. For new deployments, use op-reth — see the [op-reth configuration reference](/node-operators/reference/op-reth-config). See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
 </Warning>
 
 This page provides detailed documentation for all available op-geth configuration options, organized by functionality.

--- a/docs/public-docs/node-operators/reference/op-geth-json-rpc.mdx
+++ b/docs/public-docs/node-operators/reference/op-geth-json-rpc.mdx
@@ -4,7 +4,7 @@ description: Complete reference for op-geth execution client RPC methods with OP
 ---
 
 <Warning>
-  **op-geth reaches end-of-support on 2026-05-31 and will not support the L1 Glamsterdam hardfork.** This reference page is retained for operators still running op-geth and migrating off. For new deployments, use op-reth — see the [op-reth JSON-RPC reference](/node-operators/reference/op-reth-json-rpc). See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
+  **op-geth has reached end-of-support (2026-05-31) and does not support the now-active Karst hardfork, so op-geth nodes can no longer follow the canonical chain.** This reference page is retained for operators still running op-geth and migrating off. For new deployments, use op-reth — see the [op-reth JSON-RPC reference](/node-operators/reference/op-reth-json-rpc). See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
 </Warning>
 
 `op-geth` is the execution client for the OP Stack, based on Go Ethereum (Geth). It provides the execution layer with Ethereum-equivalent functionality plus OP Stack-specific enhancements for L2 gas accounting and receipts.

--- a/docs/public-docs/node-operators/reference/op-node-config.mdx
+++ b/docs/public-docs/node-operators/reference/op-node-config.mdx
@@ -276,6 +276,22 @@ Blockchain sync mode. Options are "consensus-layer" or "execution-layer". The de
   <Tab title="Environment variable">`OP_NODE_SYNCMODE=consensus-layer`</Tab>
 </Tabs>
 
+### syncmode.offset-el-safe
+
+Only effective with `--syncmode=execution-layer`. After execution-layer sync completes, the safe and finalized heads are set to this duration behind the synced tip (converted to L2 blocks using the rollup block time). The default `12h` matches the OP Mainnet sequencing window.
+
+Setting this to `0` leaves safe and finalized at the synced tip. This is **not recommended and is dangerous**: the offset ensures the node does not label the EL-sync tip as safe/finalized until L1 has had time to confirm it. With `0`, an EL-sync tip that later turns out to be on a reorged (non-canonical) branch can be marked safe/finalized, and safe/finalized are not supposed to reorg. Fix a body-pruning mismatch by enlarging the EL's retained body window instead — see the warning below.
+
+<Warning>
+  op-node reads the L1-info deposit transaction from the block body at the head placed this far behind the tip, so the execution client must retain block bodies at least this far back. Body pruning (op-reth's `--minimal` mode or `--prune.bodies.distance`) is unsupported; if you enable it anyway, keep the retained body window comfortably larger than this offset (in blocks), or EL sync fails with `l2 block is missing L1 info deposit tx`. See [Pruning op-reth](/node-operators/guides/management/archive-node#pruning-op-reth).
+</Warning>
+
+<Tabs>
+  <Tab title="Syntax">`--syncmode.offset-el-safe=<duration>`</Tab>
+  <Tab title="Example">`--syncmode.offset-el-safe=12h`</Tab>
+  <Tab title="Environment variable">`OP_NODE_SYNCMODE_OFFSET_EL_SAFE=12h`</Tab>
+</Tabs>
+
 ## Fork overrides
 
 Manually override fork activation timestamps for testing or custom deployments.
@@ -350,16 +366,6 @@ Manually specify the isthmus fork timestamp, overriding the bundled setting. The
   <Tab title="Environment variable">`OP_NODE_OVERRIDE_ISTHMUS=0`</Tab>
 </Tabs>
 
-### override.lagoon
-
-Manually specify the Lagoon fork timestamp, overriding the bundled setting. The default value is `0`.
-
-<Tabs>
-  <Tab title="Syntax">`--override.lagoon=<value>`</Tab>
-  <Tab title="Example">`--override.lagoon=0`</Tab>
-  <Tab title="Environment variable">`OP_NODE_OVERRIDE_LAGOON=0`</Tab>
-</Tabs>
-
 ### override.jovian
 
 Manually specify the Jovian fork timestamp, overriding the bundled setting. The default value is `0`.
@@ -370,6 +376,26 @@ Manually specify the Jovian fork timestamp, overriding the bundled setting. The 
   <Tab title="Environment variable">`OP_NODE_OVERRIDE_JOVIAN=0`</Tab>
 </Tabs>
 
+### override.karst
+
+Manually specify the Karst fork timestamp, overriding the bundled setting. The default value is `0`.
+
+<Tabs>
+  <Tab title="Syntax">`--override.karst=<value>`</Tab>
+  <Tab title="Example">`--override.karst=0`</Tab>
+  <Tab title="Environment variable">`OP_NODE_OVERRIDE_KARST=0`</Tab>
+</Tabs>
+
+### override.lagoon
+
+Manually specify the Lagoon fork timestamp, overriding the bundled setting. The default value is `0`.
+
+<Tabs>
+  <Tab title="Syntax">`--override.lagoon=<value>`</Tab>
+  <Tab title="Example">`--override.lagoon=0`</Tab>
+  <Tab title="Environment variable">`OP_NODE_OVERRIDE_LAGOON=0`</Tab>
+</Tabs>
+
 ### override.pectrablobschedule
 
 Manually specify the PectraBlobSchedule fork timestamp, overriding the bundled setting. The default value is `0`.
@@ -378,6 +404,16 @@ Manually specify the PectraBlobSchedule fork timestamp, overriding the bundled s
   <Tab title="Syntax">`--override.pectrablobschedule=<value>`</Tab>
   <Tab title="Example">`--override.pectrablobschedule=0`</Tab>
   <Tab title="Environment variable">`OP_NODE_OVERRIDE_PECTRABLOBSCHEDULE=0`</Tab>
+</Tabs>
+
+### override.keep-karst-upgrade-gas
+
+Manually set `keep_karst_upgrade_gas`, overriding the bundled setting. When `true`, the Karst activation block's one-time upgrade gas is kept on every later block. Set this only on chains that already activated Karst with the upgrade-gas leak baked into their history. The default value is `false`.
+
+<Tabs>
+  <Tab title="Syntax">`--override.keep-karst-upgrade-gas=<boolean>`</Tab>
+  <Tab title="Example">`--override.keep-karst-upgrade-gas=false`</Tab>
+  <Tab title="Environment variable">`OP_NODE_OVERRIDE_KEEP_KARST_UPGRADE_GAS=false`</Tab>
 </Tabs>
 
 ## Logging configuration

--- a/docs/public-docs/node-operators/reference/op-reth-config.mdx
+++ b/docs/public-docs/node-operators/reference/op-reth-config.mdx
@@ -1678,6 +1678,10 @@ Derive dev accounts from a fixed mnemonic instead of random ones.
 
 Options for data pruning.
 
+<Warning>
+  On OP Stack nodes, prefer pruning only the state and receipt segments — `--prune.receipts.distance`, `--prune.account-history.distance`, `--prune.storage-history.distance`, and `--prune.minimum-distance` — and leave block bodies intact. Body pruning (`--minimal`, or `--prune.bodies.distance`) is unsupported and advised against; if you enable it anyway, `--prune.bodies.distance` must always exceed op-node's `--syncmode.offset-el-safe` (in blocks), or execution-layer sync fails with `l2 block is missing L1 info deposit tx`. See [Pruning op-reth](/node-operators/guides/management/archive-node#pruning-op-reth).
+</Warning>
+
 ### full
 
 Run full node. Only the most recent [`MINIMUM_UNWIND_SAFE_DISTANCE`] block states are stored

--- a/docs/public-docs/node-operators/tutorials/node-from-docker-simple-optimism-node.mdx
+++ b/docs/public-docs/node-operators/tutorials/node-from-docker-simple-optimism-node.mdx
@@ -4,7 +4,7 @@ description: Run an OP Stack node via the simple-optimism-node Docker wrapper. R
 ---
 
 <Warning>
-  **op-geth reaches end-of-support on 2026-05-31 and will not support the L1 Glamsterdam hardfork.** `simple-optimism-node` currently defaults to op-geth and does not yet support op-reth. For new deployments, use the [direct docker-compose tutorial](/node-operators/tutorials/node-from-docker), which runs the official op-reth + op-node images. This page is retained for operators already using simple-optimism-node and its bundled Grafana dashboard. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
+  **op-geth has reached end-of-support (2026-05-31) and does not support the now-active Karst hardfork, so op-geth nodes can no longer follow the canonical chain.** `simple-optimism-node` currently defaults to op-geth and does not yet support op-reth. For new deployments, use the [direct docker-compose tutorial](/node-operators/tutorials/node-from-docker), which runs the official op-reth + op-node images. This page is retained for operators already using simple-optimism-node and its bundled Grafana dashboard. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
 </Warning>
 
 This page walks through using [`simple-optimism-node`](https://github.com/smartcontracts/simple-optimism-node), a community-maintained Docker wrapper that bundles an OP Stack node together with monitoring (Grafana) and health checks.

--- a/docs/public-docs/node-operators/tutorials/node-from-docker.mdx
+++ b/docs/public-docs/node-operators/tutorials/node-from-docker.mdx
@@ -4,7 +4,7 @@ description: Run an OP Stack node (op-reth + op-node) using the official Docker 
 ---
 
 <Warning>
-  **op-geth reaches end-of-support on 2026-05-31 and will not support the L1 Glamsterdam hardfork.** This tutorial runs op-reth (the primary supported execution client) via Docker. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
+  **op-geth has reached end-of-support (2026-05-31) and does not support the now-active Karst hardfork, so op-geth nodes can no longer follow the canonical chain.** This tutorial runs op-reth (the primary supported execution client) via Docker. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
 </Warning>
 
 This tutorial runs an OP Stack node using the **official op-reth and op-node Docker images** in a single `docker-compose.yml`. No source build required.

--- a/docs/public-docs/node-operators/tutorials/run-node-from-source.mdx
+++ b/docs/public-docs/node-operators/tutorials/run-node-from-source.mdx
@@ -4,7 +4,7 @@ description: Build and run an OP Stack node (op-reth + op-node) from source code
 ---
 
 <Warning>
-  **op-geth reaches end-of-support on 2026-05-31 and will not support the L1 Glamsterdam hardfork.** This tutorial builds and runs op-reth (the primary supported execution client) and Nethermind. op-geth instructions are retained in a legacy section at the bottom for operators mid-migration. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
+  **op-geth has reached end-of-support (2026-05-31) and does not support the now-active Karst hardfork, so op-geth nodes can no longer follow the canonical chain.** This tutorial builds and runs op-reth (the primary supported execution client) and Nethermind. op-geth instructions are retained in a legacy section at the bottom for operators mid-migration. See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the full migration plan.
 </Warning>
 
 This tutorial walks through the full process of building and running an OP Stack node from source — op-node plus an execution client. Building from source is a flexible alternative to using pre-built Docker images and is useful if you need a specific architecture or want to inspect what you're running.
@@ -384,7 +384,7 @@ Blocks and transactions included in OP Mainnet before the Bedrock Upgrade cannot
 ## op-geth (legacy — end of support 2026-05-31)
 
 <Warning>
-  op-geth support ends on **2026-05-31** and **will not support the Glamsterdam hardfork**. For new deployments, use op-reth (above). See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the migration plan.
+  op-geth reached end-of-support on **2026-05-31** and **does not support the now-active Karst hardfork**. For new deployments, use op-reth (above). See the [op-geth deprecation notice](/notices/op-geth-deprecation) for the migration plan.
 </Warning>
 
 <Accordion title="Build and run op-geth (legacy)">

--- a/docs/public-docs/notices/op-geth-deprecation.mdx
+++ b/docs/public-docs/notices/op-geth-deprecation.mdx
@@ -1,6 +1,6 @@
 ---
 title: End of Support for op-geth and op-program
-description: op-geth and op-program will be supported through May 31st, 2026. Start migrating to op-reth and cannon-kona now.
+description: op-geth and op-program have reached end-of-support; neither supports the now-active Karst hardfork. Migrate to op-reth and kona-client.
 lang: en-US
 content_type: notice
 topic: op-geth-deprecation
@@ -17,23 +17,23 @@ As the ecosystem matures, we are transitioning full execution client support to 
 
 ## What this means
 
-- **op-geth is supported through May 31st, 2026.** Security patches and critical bug fixes will continue to be issued during this window, after which support ends.
-- **New feature development, including the next Karst hardfork, will happen on op-reth only.**
-- **op-program is also reaching end-of-support.** The fault proof program is transitioning from **op-program** to **kona-client**.
-- **Current op-program deployments are expected to remain usable until the next hardfork, Karst.** Chain operators will need to migrate to **kona-client** at Karst.
+- **op-geth support ended May 31st, 2026.** Security patches and critical bug fixes were issued through that window; support has now ended.
+- **New feature development, including the Karst hardfork, happens on op-reth only.**
+- **op-program has also reached end-of-support.** The fault proof program has transitioned from **op-program** to **kona-client**.
+- **op-program does not support the now-active Karst hardfork.** Chain operators must migrate to **kona-client**.
 - **kona-node is not required for cannon-kona.** You can run kona proofs with your existing **op-node** setup. kona-node is a separate, optional component and is not part of the fault proof program migration.
 - **op-node** is not being deprecated.
 
 ## Action required
 
-**op-geth will not support the L1 Glamsterdam hardfork.** Chains still running op-geth at activation will not be able to follow the canonical chain.
+**op-geth does not support the now-active Karst hardfork.** Chains still running op-geth can no longer follow the canonical chain.
 
 ### Node Operators
 
 All node operators should migrate to op-reth as soon as possible. For more details, see **op-reth configuration** in the resources section below.
 
 <Warning>
-  op-geth reaches end-of-support in **May 31st, 2026**. Glamsterdam will break compatibility with op-geth.
+  op-geth reached end-of-support on **May 31st, 2026** and does not support the now-active Karst hardfork.
 </Warning>
 
 <Info>
@@ -62,7 +62,7 @@ See [how to run historical proofs with op-reth](https://docs.optimism.io/node-op
 
 ### Permissionless Chain Operators
 
-In parallel, the fault proof program is moving from **op-program** to **kona client**. Current op-program deployments are expected to remain usable until the next hardfork, Karst, when chain operators will need to migrate to **kona-client**. Optimism will handle the onchain prestate updates for managed chains.
+In parallel, the fault proof program has moved from **op-program** to **kona-client**. With the Karst hardfork now active, chain operators must migrate to **kona-client**.
 
 ## Resources
 


### PR DESCRIPTION
Prompted by #21465. Two related docs fixes.

## op-reth pruning

Our docs implied op-reth can't be pruned at all ("require the complete history of the chain"; "Do not pass any `--prune.*` flags"), stricter than what we run in production. This clarifies:

- **Never prune block bodies.** op-node's execution-layer sync reads the L1-info deposit tx (the first tx of every block) from the block body at the head placed `--syncmode.offset-el-safe` behind the tip. `--minimal` and `--prune.bodies.distance` both remove bodies and break EL sync with `l2 block is missing L1 info deposit tx`. `--minimal` is therefore unsupported.
- **Supported pruning:** prune the state/receipt segments only, leaving bodies intact — `--prune.minimum-distance`, `--prune.receipts.distance`, `--prune.account-history.distance`, `--prune.storage-history.distance`, all at the same depth. Recommended depth: `22000` for sequencer-side nodes (covers the 12h sequencing window ≈ 21,600 blocks at 2s), `1296000` (~30 days) otherwise. Adds a **Pruning op-reth** section to the archive-node guide, referenced from the execution-clients guide.
- Documents the previously-undocumented **`--syncmode.offset-el-safe`** flag, warns that lowering it to `0` is dangerous (can mark a reorged EL-sync tip as safe/finalized), and adds the missing **`override.karst`** and **`override.keep-karst-upgrade-gas`** flags (fixing the jovian/lagoon ordering while at it).

## op-geth EOL / Karst

Refreshes the op-geth end-of-support warnings across the node-operator docs and the deprecation notice: past tense (support ended 2026-05-31) and now stating op-geth does not support the now-active Karst hardfork, so op-geth nodes can no longer follow the canonical chain.

Closes #21465

🤖 Generated with [Claude Code](https://claude.com/claude-code)
