### PR TITLE
fix(op-node): sync Karst gas compatibility configs

### DIFF
--- a/op-core/superchain/strict_decode_test.go
+++ b/op-core/superchain/strict_decode_test.go
@@ -2,7 +2,6 @@ package superchain
 
 import (
 	"path"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,8 +12,7 @@ import (
 // TestAllEmbeddedConfigsDecodeStrictly loads every embedded chain and superchain config with the
 // strict decoder. It fails if any config carries a key the Go structs do not model — the exact
 // drift that let keep_karst_upgrade_gas be silently dropped. A superchain-registry bump that adds a
-// field therefore cannot merge until the structs are updated to consume it (or, for the superchain,
-// until the key is added to legacySuperchainKeys as a conscious decision).
+// field therefore cannot merge until the structs are updated to consume it.
 func TestAllEmbeddedConfigsDecodeStrictly(t *testing.T) {
 	networks := map[string]struct{}{}
 	for _, ch := range BuiltInConfigs.Chains {
@@ -34,38 +32,7 @@ func TestAllEmbeddedConfigsDecodeStrictly(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 			var sc Superchain
-			require.NoError(t, jsonutil.DecodeTOMLStrict(f, &sc, isLegacySuperchainKey))
+			require.NoError(t, jsonutil.DecodeTOMLStrict(f, &sc, nil))
 		})
 	}
-}
-
-// TestSuperchainDecodeToleratesLegacyProtocolVersionsAddr documents why the superchain decode
-// allow-lists protocol_versions_addr: the Superchain struct deliberately no longer models that
-// legacy key, and the embedded superchain.toml files still carry it, so strict decoding must
-// tolerate it — while still rejecting a genuinely unknown key.
-func TestSuperchainDecodeToleratesLegacyProtocolVersionsAddr(t *testing.T) {
-	const legacy = `
-name = "Legacy"
-protocol_versions_addr = "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
-superchain_config_addr = "0x95703e0982140D16f8ebA6d158FccEde42f04a4C"
-op_contracts_manager_addr = "0x0000000000000000000000000000000000000001"
-safer_safes_addr = "0xA8447329e52F64AED2bFc9E7a2506F7D369f483a"
-
-[L1]
-chain_id = 1
-`
-	var sc Superchain
-	require.NoError(t, jsonutil.DecodeTOMLStrict(strings.NewReader(legacy), &sc, isLegacySuperchainKey))
-	require.Equal(t, "Legacy", sc.Name)
-
-	const unknown = `
-name = "Legacy"
-some_new_key = true
-
-[L1]
-chain_id = 1
-`
-	err := jsonutil.DecodeTOMLStrict(strings.NewReader(unknown), &Superchain{}, isLegacySuperchainKey)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "some_new_key")
 }

--- a/op-core/superchain/superchain-configs.zip.sha256
+++ b/op-core/superchain/superchain-configs.zip.sha256
@@ -1,1 +1,1 @@
-91e5a7bf4d6f9a5fb555ff6747075e87f6e4d12d053aced5127d19b297543ae6  superchain-configs.zip
+84368507642df8e4d64dc089c443633ee4d511ce3f72f913a7780feea1dab582  superchain-configs.zip

--- a/op-core/superchain/superchain.go
+++ b/op-core/superchain/superchain.go
@@ -3,21 +3,11 @@ package superchain
 import (
 	"fmt"
 	"path"
-	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 )
-
-// legacySuperchainKeys are keys still present in the embedded superchain.toml files that the
-// Superchain struct deliberately no longer models. They are tolerated by the strict decoder so a
-// genuinely new/unexpected key is still rejected while this known legacy field is not.
-var legacySuperchainKeys = []string{"protocol_versions_addr"}
-
-func isLegacySuperchainKey(key string) bool {
-	return slices.Contains(legacySuperchainKeys, key)
-}
 
 type Superchain struct {
 	Name                   string         `toml:"name"`
@@ -52,7 +42,7 @@ func (c *ChainConfigLoader) GetSuperchain(network string) (Superchain, error) {
 		return sc, err
 	}
 
-	if err := jsonutil.DecodeTOMLStrict(zr, &sc, isLegacySuperchainKey); err != nil {
+	if err := jsonutil.DecodeTOMLStrict(zr, &sc, nil); err != nil {
 		return sc, fmt.Errorf("error decoding superchain config: %w", err)
 	}
 

--- a/op-node/chaincfg/chains_test.go
+++ b/op-node/chaincfg/chains_test.go
@@ -36,6 +36,27 @@ func TestGetRollupConfig(t *testing.T) {
 	}
 }
 
+func TestKarstUpgradeGasCompatibilityByNetwork(t *testing.T) {
+	// These values preserve each chain's behavior when it activated Karst.
+	tests := []struct {
+		network string
+		want    bool
+	}{
+		{network: "mode-mainnet", want: false},
+		{network: "metal-mainnet", want: false},
+		{network: "zora-mainnet", want: false},
+		{network: "op-mainnet", want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.network, func(t *testing.T) {
+			cfg, err := GetRollupConfig(test.network)
+			require.NoError(t, err)
+			require.Equal(t, test.want, cfg.KeepKarstUpgradeGas)
+		})
+	}
+}
+
 var defaultOpConfig = &params.OptimismConfig{
 	EIP1559Elasticity:        6,
 	EIP1559Denominator:       50,

--- a/rust/kona/crates/protocol/registry/etc/configs.json
+++ b/rust/kona/crates/protocol/registry/etc/configs.json
@@ -1325,8 +1325,7 @@
             "holocene_time": 1736445601,
             "isthmus_time": 1746806401,
             "jovian_time": 1764691201,
-            "karst_time": 1783526401,
-            "keep_karst_upgrade_gas": true
+            "karst_time": 1783526401
           },
           "optimism": {
             "eip1559Elasticity": 6,
@@ -2014,8 +2013,7 @@
             "holocene_time": 1736445601,
             "isthmus_time": 1746806401,
             "jovian_time": 1764691201,
-            "karst_time": 1783526401,
-            "keep_karst_upgrade_gas": true
+            "karst_time": 1783526401
           },
           "optimism": {
             "eip1559Elasticity": 6,
@@ -2622,8 +2620,7 @@
             "holocene_time": 1736445601,
             "isthmus_time": 1746806401,
             "jovian_time": 1764691201,
-            "karst_time": 1783526401,
-            "keep_karst_upgrade_gas": true
+            "karst_time": 1783526401
           },
           "optimism": {
             "eip1559Elasticity": 6,

--- a/rust/op-reth/crates/chainspec/res/superchain-configs.tar.sha256
+++ b/rust/op-reth/crates/chainspec/res/superchain-configs.tar.sha256
@@ -1,1 +1,1 @@
-98412f1cb8a8504bb071c8dbf9655456881617bd3590b464bbb6620a4fcfed1d  superchain-configs.tar
+ef284935bffc4c2145a1e9db4febf3729b35bf8ef254cdc58ad174d90f015cf8  superchain-configs.tar


### PR DESCRIPTION
## Summary

- bump the Superchain Registry gitlink to `e31d568`, which includes ethereum-optimism/superchain-registry#1281
- regenerate the embedded Go, Kona, and op-reth registry artifacts
- lock the historical Karst gas behavior for Mode, Metal, Zora, and OP Mainnet in the op-node network-loading path

## Root cause and impact

Mode, Metal, and Zora sequencers activated Karst without `keep_karst_upgrade_gas` configured, so their canonical behavior is `false`. The prior embedded registry data set those chains to `true`; op-node operators using `--network` could therefore derive a different post-activation gas limit and halt safe-head progression.

This change intentionally makes Mode, Metal, and Zora resolve to `false`. OP Mainnet remains `true`. It removes the need for an explicit override when using the affected built-in network configs.

## Validation

- `go test ./op-node/chaincfg ./op-node/superchain ./op-core/superchain`
- `cargo nextest run -p kona-registry`
- `cargo nextest run -p reth-optimism-chainspec --features superchain-configs`
- reran `JUST_UNSTABLE=1 just sync-superchain e31d568ed411f467a5465052acba97e117d5c6d1` and confirmed stable generated hashes
- `git diff --check`