### PR TITLE
op-challenger: never load the absolute prestate for permissioned games

### DIFF
--- a/op-challenger/README.md
+++ b/op-challenger/README.md
@@ -56,9 +56,11 @@ proofs. The `permissioned` game type (configured via the `--cannon-*` flags)
 is played only by trusted actors and resolves at the output-root level without
 ever reaching `step()`, so it does not run a fault-proof program and its server
 binary may be omitted when only the `permissioned` game type is configured. For
-the same reason the absolute prestate is never used, so the challenger never
-loads it for permissioned games and resolves them even when their (often
-placeholder) prestate is not published via `--prestates-url`.
+the same reason the absolute prestate is never used: the challenger never loads
+it for permissioned games, resolves them even when their (often placeholder)
+prestate is not published via `--prestates-url`, and the prestate flags
+(`--cannon-prestate` / `--prestates-url`) may likewise be omitted when only the
+`permissioned` game type is configured.
 
 #### Devnet Management Commands
 

--- a/op-challenger/README.md
+++ b/op-challenger/README.md
@@ -56,9 +56,9 @@ proofs. The `permissioned` game type (configured via the `--cannon-*` flags)
 is played only by trusted actors and resolves at the output-root level without
 ever reaching `step()`, so it does not run a fault-proof program and its server
 binary may be omitted when only the `permissioned` game type is configured. For
-the same reason the absolute prestate is never used, so a permissioned game is
-still resolved even when its (often placeholder) prestate cannot be found via
-`--prestates-url`.
+the same reason the absolute prestate is never used, so the challenger never
+loads it for permissioned games and resolves them even when their (often
+placeholder) prestate is not published via `--prestates-url`.
 
 #### Devnet Management Commands
 

--- a/op-challenger/README.md
+++ b/op-challenger/README.md
@@ -55,7 +55,10 @@ below can then be used to create and interact with games.
 proofs. The `permissioned` game type (configured via the `--cannon-*` flags)
 is played only by trusted actors and resolves at the output-root level without
 ever reaching `step()`, so it does not run a fault-proof program and its server
-binary may be omitted when only the `permissioned` game type is configured.
+binary may be omitted when only the `permissioned` game type is configured. For
+the same reason the absolute prestate is never used, so a permissioned game is
+still resolved even when its (often placeholder) prestate cannot be found via
+`--prestates-url`.
 
 #### Devnet Management Commands
 

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -609,7 +609,18 @@ func TestCannonRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Required", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag prestates-url/cannon-prestates-url or cannon-prestate is required", addRequiredArgsExcept(gameType, "--cannon-prestate"))
+				if gameType == gameTypes.PermissionedGameType {
+					// The permissioned game never loads the VM prestate.
+					configForArgs(t, addRequiredArgsExcept(gameType, "--cannon-prestate"))
+				} else {
+					verifyArgsInvalid(t, "flag prestates-url/cannon-prestates-url or cannon-prestate is required", addRequiredArgsExcept(gameType, "--cannon-prestate"))
+				}
+			})
+
+			t.Run("RequiredWhenCannonAndPermissionedBothEnabled", func(t *testing.T) {
+				gameTypesArg := fmt.Sprintf("%v,%v", gameTypes.CannonGameType.String(), gameTypes.PermissionedGameType.String())
+				args := addRequiredArgsExceptArr(gameTypes.CannonGameType, []string{"--game-types", "--cannon-prestate"}, "--game-types", gameTypesArg)
+				verifyArgsInvalid(t, "flag prestates-url/cannon-prestates-url or cannon-prestate is required", args)
 			})
 
 			t.Run("Valid", func(t *testing.T) {
@@ -624,7 +635,12 @@ func TestCannonRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Required", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag prestates-url/cannon-prestates-url or cannon-prestate is required", addRequiredArgsExcept(gameType, "--cannon-prestate"))
+				if gameType == gameTypes.PermissionedGameType {
+					// The permissioned game never loads the VM prestate.
+					configForArgs(t, addRequiredArgsExcept(gameType, "--cannon-prestate"))
+				} else {
+					verifyArgsInvalid(t, "flag prestates-url/cannon-prestates-url or cannon-prestate is required", addRequiredArgsExcept(gameType, "--cannon-prestate"))
+				}
 			})
 
 			t.Run("Valid", func(t *testing.T) {
@@ -649,7 +665,12 @@ func TestCannonRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("RequiredIfCannonPrestatesBaseURLNotSet", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag prestates-url/cannon-prestates-url or cannon-prestate is required", addRequiredArgsExceptArr(gameType, allPrestateOptions))
+				if gameType == gameTypes.PermissionedGameType {
+					// The permissioned game never loads the VM prestate.
+					configForArgs(t, addRequiredArgsExceptArr(gameType, allPrestateOptions))
+				} else {
+					verifyArgsInvalid(t, "flag prestates-url/cannon-prestates-url or cannon-prestate is required", addRequiredArgsExceptArr(gameType, allPrestateOptions))
+				}
 			})
 
 			t.Run("Invalid", func(t *testing.T) {

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -251,10 +251,10 @@ func (c Config) Check() error {
 		if c.RollupRpc == "" {
 			return ErrMissingRollupRpc
 		}
-		// The permissioned game never reaches step() so does not run op-program; only the
-		// legacy Cannon game type requires the op-program server binary.
-		requireServer := c.GameTypeEnabled(gameTypes.CannonGameType)
-		if err := c.validateBaseCannonOptions(requireServer); err != nil {
+		// The permissioned game never reaches step() so does not run op-program or load the
+		// absolute prestate; both are only required by the legacy Cannon game type.
+		cannonEnabled := c.GameTypeEnabled(gameTypes.CannonGameType)
+		if err := c.validateBaseCannonOptions(cannonEnabled, cannonEnabled); err != nil {
 			return err
 		}
 	}
@@ -300,11 +300,11 @@ func (c Config) Check() error {
 	return nil
 }
 
-func (c Config) validateBaseCannonOptions(requireServer bool) error {
+func (c Config) validateBaseCannonOptions(requireServer bool, requirePreState bool) error {
 	if err := c.Cannon.Check(requireServer); err != nil {
 		return fmt.Errorf("cannon: %w", err)
 	}
-	if c.CannonAbsolutePreState == "" && c.CannonAbsolutePreStateBaseURL == nil {
+	if requirePreState && c.CannonAbsolutePreState == "" && c.CannonAbsolutePreStateBaseURL == nil {
 		return ErrMissingCannonAbsolutePreState
 	}
 	if c.Cannon.SnapshotFreq == 0 {

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -247,14 +247,11 @@ func (c Config) Check() error {
 	if c.MaxConcurrency == 0 {
 		return ErrMaxConcurrencyZero
 	}
-	if c.GameTypeEnabled(gameTypes.CannonGameType) || c.GameTypeEnabled(gameTypes.PermissionedGameType) {
+	if slices.ContainsFunc(gameTypes.CannonFamilyGameTypes, c.GameTypeEnabled) {
 		if c.RollupRpc == "" {
 			return ErrMissingRollupRpc
 		}
-		// The permissioned game never reaches step() so does not run op-program or load the
-		// absolute prestate; both are only required by the legacy Cannon game type.
-		cannonEnabled := c.GameTypeEnabled(gameTypes.CannonGameType)
-		if err := c.validateBaseCannonOptions(cannonEnabled, cannonEnabled); err != nil {
+		if err := c.validateBaseCannonOptions(); err != nil {
 			return err
 		}
 	}
@@ -300,11 +297,16 @@ func (c Config) Check() error {
 	return nil
 }
 
-func (c Config) validateBaseCannonOptions(requireServer bool, requirePreState bool) error {
-	if err := c.Cannon.Check(requireServer); err != nil {
+func (c Config) validateBaseCannonOptions() error {
+	// Permissioned games never reach step() so do not run op-program or load the absolute
+	// prestate; both are only required when an enabled game type can reach step().
+	canReachStep := slices.ContainsFunc(gameTypes.CannonFamilyGameTypes, func(t gameTypes.GameType) bool {
+		return c.GameTypeEnabled(t) && !t.IsPermissioned()
+	})
+	if err := c.Cannon.Check(canReachStep); err != nil {
 		return fmt.Errorf("cannon: %w", err)
 	}
-	if requirePreState && c.CannonAbsolutePreState == "" && c.CannonAbsolutePreStateBaseURL == nil {
+	if canReachStep && c.CannonAbsolutePreState == "" && c.CannonAbsolutePreStateBaseURL == nil {
 		return ErrMissingCannonAbsolutePreState
 	}
 	if c.Cannon.SnapshotFreq == 0 {

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -211,7 +211,12 @@ func TestCannonRequiredArgs(t *testing.T) {
 			config := validConfig(t, gameType)
 			config.CannonAbsolutePreState = ""
 			config.CannonAbsolutePreStateBaseURL = nil
-			require.ErrorIs(t, config.Check(), ErrMissingCannonAbsolutePreState)
+			if gameType == gameTypes.PermissionedGameType {
+				// The permissioned game never loads the VM prestate.
+				require.NoError(t, config.Check())
+			} else {
+				require.ErrorIs(t, config.Check(), ErrMissingCannonAbsolutePreState)
+			}
 		})
 
 		t.Run(fmt.Sprintf("TestCannonAbsolutePreState-%v", gameType), func(t *testing.T) {
@@ -336,6 +341,16 @@ func TestCannonServerRequiredWhenCannonAndPermissionedBothEnabled(t *testing.T) 
 		config.Cannon.Server = nonExistingFile
 		require.ErrorIs(t, config.Check(), vm.ErrMissingServer)
 	})
+}
+
+// The absolute prestate is still required when both the cannon and permissioned game types
+// are enabled, because the cannon game loads it even though the permissioned game does not.
+func TestCannonAbsolutePreStateRequiredWhenCannonAndPermissionedBothEnabled(t *testing.T) {
+	config := validConfig(t, gameTypes.CannonGameType)
+	config.GameTypes = []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.PermissionedGameType}
+	config.CannonAbsolutePreState = ""
+	config.CannonAbsolutePreStateBaseURL = nil
+	require.ErrorIs(t, config.Check(), ErrMissingCannonAbsolutePreState)
 }
 
 func TestCannonKonaRequiredArgs(t *testing.T) {

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -325,7 +325,7 @@ func checkOutputProviderFlags(ctx *cli.Context) error {
 	return nil
 }
 
-func CheckCannonBaseFlags(ctx *cli.Context, requireServer bool) error {
+func CheckCannonBaseFlags(ctx *cli.Context, requireServer bool, requirePreState bool) error {
 	if ctx.IsSet(flags.NetworkFlagName) &&
 		(RollupConfigFlag.IsSet(ctx, gameTypes.CannonGameType) || L2GenesisFlag.IsSet(ctx, gameTypes.CannonGameType) || L1GenesisFlag.IsSet(ctx, gameTypes.CannonGameType) || ctx.Bool(CannonL2CustomFlag.Name)) {
 		return fmt.Errorf("flag %v can not be used with %v, %v, %v or %v",
@@ -341,7 +341,7 @@ func CheckCannonBaseFlags(ctx *cli.Context, requireServer bool) error {
 	if requireServer && !ctx.IsSet(CannonServerFlag.Name) {
 		return fmt.Errorf("flag %s is required", CannonServerFlag.Name)
 	}
-	if !PreStatesURLFlag.IsSet(ctx, gameTypes.CannonGameType) && !ctx.IsSet(CannonPreStateFlag.Name) {
+	if requirePreState && !PreStatesURLFlag.IsSet(ctx, gameTypes.CannonGameType) && !ctx.IsSet(CannonPreStateFlag.Name) {
 		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.EitherFlagName(gameTypes.CannonGameType), CannonPreStateFlag.Name)
 	}
 	return nil
@@ -371,7 +371,7 @@ func CheckSuperCannonKonaFlags(ctx *cli.Context) error {
 	return nil
 }
 
-func CheckCannonFlags(ctx *cli.Context, requireServer bool) error {
+func CheckCannonFlags(ctx *cli.Context, requireServer bool, requirePreState bool) error {
 	if err := checkOutputProviderFlags(ctx); err != nil {
 		return err
 	}
@@ -380,7 +380,7 @@ func CheckCannonFlags(ctx *cli.Context, requireServer bool) error {
 		return fmt.Errorf("flag %v or %v and %v is required",
 			flags.NetworkFlagName, RollupConfigFlag.EitherFlagName(gameTypes.CannonGameType), L2GenesisFlag.EitherFlagName(gameTypes.CannonGameType))
 	}
-	if err := CheckCannonBaseFlags(ctx, requireServer); err != nil {
+	if err := CheckCannonBaseFlags(ctx, requireServer, requirePreState); err != nil {
 		return err
 	}
 	return nil
@@ -431,10 +431,10 @@ func CheckRequired(ctx *cli.Context, types []gameTypes.GameType) error {
 	for _, gameType := range types {
 		switch gameType {
 		case gameTypes.CannonGameType, gameTypes.PermissionedGameType:
-			// The permissioned game never reaches step() so does not run op-program; only the
-			// legacy Cannon game type requires the op-program server binary.
-			requireServer := slices.Contains(types, gameTypes.CannonGameType)
-			if err := CheckCannonFlags(ctx, requireServer); err != nil {
+			// The permissioned game never reaches step() so does not run op-program or load the
+			// absolute prestate; both are only required by the legacy Cannon game type.
+			cannonEnabled := slices.Contains(types, gameTypes.CannonGameType)
+			if err := CheckCannonFlags(ctx, cannonEnabled, cannonEnabled); err != nil {
 				return err
 			}
 		case gameTypes.CannonKonaGameType:

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -325,7 +325,12 @@ func checkOutputProviderFlags(ctx *cli.Context) error {
 	return nil
 }
 
-func CheckCannonBaseFlags(ctx *cli.Context, requireServer bool, requirePreState bool) error {
+func CheckCannonBaseFlags(ctx *cli.Context, enabledTypes []gameTypes.GameType) error {
+	// Permissioned games never reach step() so do not run op-program or load the
+	// absolute prestate; both are only required when an enabled game type can reach step().
+	canReachStep := slices.ContainsFunc(enabledTypes, func(t gameTypes.GameType) bool {
+		return slices.Contains(gameTypes.CannonFamilyGameTypes, t) && !t.IsPermissioned()
+	})
 	if ctx.IsSet(flags.NetworkFlagName) &&
 		(RollupConfigFlag.IsSet(ctx, gameTypes.CannonGameType) || L2GenesisFlag.IsSet(ctx, gameTypes.CannonGameType) || L1GenesisFlag.IsSet(ctx, gameTypes.CannonGameType) || ctx.Bool(CannonL2CustomFlag.Name)) {
 		return fmt.Errorf("flag %v can not be used with %v, %v, %v or %v",
@@ -338,10 +343,10 @@ func CheckCannonBaseFlags(ctx *cli.Context, requireServer bool, requirePreState 
 	if !ctx.IsSet(CannonBinFlag.Name) {
 		return fmt.Errorf("flag %s is required", CannonBinFlag.Name)
 	}
-	if requireServer && !ctx.IsSet(CannonServerFlag.Name) {
+	if canReachStep && !ctx.IsSet(CannonServerFlag.Name) {
 		return fmt.Errorf("flag %s is required", CannonServerFlag.Name)
 	}
-	if requirePreState && !PreStatesURLFlag.IsSet(ctx, gameTypes.CannonGameType) && !ctx.IsSet(CannonPreStateFlag.Name) {
+	if canReachStep && !PreStatesURLFlag.IsSet(ctx, gameTypes.CannonGameType) && !ctx.IsSet(CannonPreStateFlag.Name) {
 		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.EitherFlagName(gameTypes.CannonGameType), CannonPreStateFlag.Name)
 	}
 	return nil
@@ -371,7 +376,7 @@ func CheckSuperCannonKonaFlags(ctx *cli.Context) error {
 	return nil
 }
 
-func CheckCannonFlags(ctx *cli.Context, requireServer bool, requirePreState bool) error {
+func CheckCannonFlags(ctx *cli.Context, enabledTypes []gameTypes.GameType) error {
 	if err := checkOutputProviderFlags(ctx); err != nil {
 		return err
 	}
@@ -380,7 +385,7 @@ func CheckCannonFlags(ctx *cli.Context, requireServer bool, requirePreState bool
 		return fmt.Errorf("flag %v or %v and %v is required",
 			flags.NetworkFlagName, RollupConfigFlag.EitherFlagName(gameTypes.CannonGameType), L2GenesisFlag.EitherFlagName(gameTypes.CannonGameType))
 	}
-	if err := CheckCannonBaseFlags(ctx, requireServer, requirePreState); err != nil {
+	if err := CheckCannonBaseFlags(ctx, enabledTypes); err != nil {
 		return err
 	}
 	return nil
@@ -431,10 +436,7 @@ func CheckRequired(ctx *cli.Context, types []gameTypes.GameType) error {
 	for _, gameType := range types {
 		switch gameType {
 		case gameTypes.CannonGameType, gameTypes.PermissionedGameType:
-			// The permissioned game never reaches step() so does not run op-program or load the
-			// absolute prestate; both are only required by the legacy Cannon game type.
-			cannonEnabled := slices.Contains(types, gameTypes.CannonGameType)
-			if err := CheckCannonFlags(ctx, cannonEnabled, cannonEnabled); err != nil {
+			if err := CheckCannonFlags(ctx, types); err != nil {
 				return err
 			}
 		case gameTypes.CannonKonaGameType:

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -58,14 +58,14 @@ func RegisterGameTypes(
 		if err != nil {
 			return err
 		}
-		registerTasks = append(registerTasks, NewCannonRegisterTask(gameTypes.CannonGameType, logger, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewCannonRegisterTask(gameTypes.CannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.GameTypeEnabled(gameTypes.CannonKonaGameType) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
 		if err != nil {
 			return err
 		}
-		registerTasks = append(registerTasks, NewCannonKonaRegisterTask(gameTypes.CannonKonaGameType, logger, cfg, m, vm.NewKonaExecutor(), l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewCannonKonaRegisterTask(gameTypes.CannonKonaGameType, cfg, m, vm.NewKonaExecutor(), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.GameTypeEnabled(gameTypes.SuperCannonKonaGameType) {
 		superNodeProvider, syncValidator, err := clients.SuperchainClients()
@@ -79,7 +79,7 @@ func RegisterGameTypes(
 		if err != nil {
 			return err
 		}
-		registerTasks = append(registerTasks, NewCannonRegisterTask(gameTypes.PermissionedGameType, logger, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewCannonRegisterTask(gameTypes.PermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.GameTypeEnabled(gameTypes.FastGameType) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -58,14 +58,14 @@ func RegisterGameTypes(
 		if err != nil {
 			return err
 		}
-		registerTasks = append(registerTasks, NewCannonRegisterTask(gameTypes.CannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewCannonRegisterTask(gameTypes.CannonGameType, logger, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.GameTypeEnabled(gameTypes.CannonKonaGameType) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
 		if err != nil {
 			return err
 		}
-		registerTasks = append(registerTasks, NewCannonKonaRegisterTask(gameTypes.CannonKonaGameType, cfg, m, vm.NewKonaExecutor(), l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewCannonKonaRegisterTask(gameTypes.CannonKonaGameType, logger, cfg, m, vm.NewKonaExecutor(), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.GameTypeEnabled(gameTypes.SuperCannonKonaGameType) {
 		superNodeProvider, syncValidator, err := clients.SuperchainClients()
@@ -79,7 +79,7 @@ func RegisterGameTypes(
 		if err != nil {
 			return err
 		}
-		registerTasks = append(registerTasks, NewCannonRegisterTask(gameTypes.PermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewCannonRegisterTask(gameTypes.PermissionedGameType, logger, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.GameTypeEnabled(gameTypes.FastGameType) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()

--- a/op-challenger/game/fault/register_task.go
+++ b/op-challenger/game/fault/register_task.go
@@ -2,6 +2,7 @@ package fault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -122,26 +123,34 @@ func newCannonVMRegisterTaskWithConfig(
 	preState string,
 ) *RegisterTask {
 	stateConverter := cannon.NewStateConverter(cfg.Cannon)
+	// Don't validate the absolute prestate or genesis output root for permissioned games
+	// Only trusted actors participate in these games so they aren't expected to reach the step() call and
+	// are often configured without valid prestates but the challenger should still resolve the games.
+	skipPrestateValidation := gameType == gameTypes.PermissionedGameType
+	getBottomPrestateProvider := cachePrestates(
+		gameType,
+		stateConverter,
+		m,
+		preStateBaseURL,
+		preState,
+		filepath.Join(cfg.Datadir, vmCfg.VmType.String()+"-prestates"),
+		func(ctx context.Context, path string) faultTypes.PrestateProvider {
+			return vm.NewPrestateProvider(path, stateConverter)
+		})
+	if skipPrestateValidation {
+		// Permissioned games never reach step() so their VM prestate is never actually used. Since they
+		// are often configured with a placeholder prestate that isn't published (e.g. when using
+		// --prestates-url), fall back to an empty placeholder provider rather than failing to resolve the game.
+		getBottomPrestateProvider = tolerateMissingPrestate(getBottomPrestateProvider, stateConverter)
+	}
 	return &RegisterTask{
-		gameType:      gameType,
-		syncValidator: syncValidator,
-		// Don't validate the absolute prestate or genesis output root for permissioned games
-		// Only trusted actors participate in these games so they aren't expected to reach the step() call and
-		// are often configured without valid prestates but the challenger should still resolve the games.
-		skipPrestateValidation: gameType == gameTypes.PermissionedGameType,
+		gameType:               gameType,
+		syncValidator:          syncValidator,
+		skipPrestateValidation: skipPrestateValidation,
 		getTopPrestateProvider: func(ctx context.Context, prestateBlock uint64) (faultTypes.PrestateProvider, error) {
 			return outputs.NewPrestateProvider(rollupClient, prestateBlock), nil
 		},
-		getBottomPrestateProvider: cachePrestates(
-			gameType,
-			stateConverter,
-			m,
-			preStateBaseURL,
-			preState,
-			filepath.Join(cfg.Datadir, vmCfg.VmType.String()+"-prestates"),
-			func(ctx context.Context, path string) faultTypes.PrestateProvider {
-				return vm.NewPrestateProvider(path, stateConverter)
-			}),
+		getBottomPrestateProvider: getBottomPrestateProvider,
 		newTraceAccessor: func(
 			logger log.Logger,
 			m metrics.Metricer,
@@ -202,6 +211,22 @@ func cachePrestates(
 			return newPrestateProvider(ctx, prestatePath), nil
 		})
 	return prestateProviderCache.GetOrCreate
+}
+
+// tolerateMissingPrestate wraps a bottom prestate provider so that an unavailable prestate is not fatal.
+// The returned provider yields an empty placeholder when the source can't find the prestate, which is safe
+// for game types that never reach step() and so never use the VM prestate (i.e. permissioned games).
+func tolerateMissingPrestate(
+	source func(ctx context.Context, prestateHash common.Hash) (faultTypes.PrestateProvider, error),
+	stateConverter vm.StateConverter,
+) func(ctx context.Context, prestateHash common.Hash) (faultTypes.PrestateProvider, error) {
+	return func(ctx context.Context, prestateHash common.Hash) (faultTypes.PrestateProvider, error) {
+		provider, err := source(ctx, prestateHash)
+		if errors.Is(err, prestates.ErrPrestateUnavailable) {
+			return vm.NewPrestateProvider("", stateConverter), nil
+		}
+		return provider, err
+	}
 }
 
 func (e *RegisterTask) Register(

--- a/op-challenger/game/fault/register_task.go
+++ b/op-challenger/game/fault/register_task.go
@@ -125,7 +125,7 @@ func newCannonVMRegisterTaskWithConfig(
 	// Don't validate the absolute prestate or genesis output root for permissioned games
 	// Only trusted actors participate in these games so they aren't expected to reach the step() call and
 	// are often configured without valid prestates but the challenger should still resolve the games.
-	skipPrestateValidation := gameType == gameTypes.PermissionedGameType
+	skipPrestateValidation := gameType.IsPermissioned()
 	var getBottomPrestateProvider func(ctx context.Context, prestateHash common.Hash) (faultTypes.PrestateProvider, error)
 	if skipPrestateValidation {
 		// Permissioned games never reach step() so their VM prestate is never actually used. Since they

--- a/op-challenger/game/fault/register_task.go
+++ b/op-challenger/game/fault/register_task.go
@@ -2,7 +2,6 @@ package fault
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -102,17 +101,16 @@ func newSuperCannonVMRegisterTaskWithConfig(
 	}
 }
 
-func NewCannonRegisterTask(gameType gameTypes.GameType, logger log.Logger, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator gameTypes.SyncValidator) *RegisterTask {
-	return newCannonVMRegisterTaskWithConfig(gameType, logger, cfg, m, serverExecutor, l2Client, rollupClient, syncValidator, cfg.Cannon, cfg.CannonAbsolutePreStateBaseURL, cfg.CannonAbsolutePreState)
+func NewCannonRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator gameTypes.SyncValidator) *RegisterTask {
+	return newCannonVMRegisterTaskWithConfig(gameType, cfg, m, serverExecutor, l2Client, rollupClient, syncValidator, cfg.Cannon, cfg.CannonAbsolutePreStateBaseURL, cfg.CannonAbsolutePreState)
 }
 
-func NewCannonKonaRegisterTask(gameType gameTypes.GameType, logger log.Logger, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator gameTypes.SyncValidator) *RegisterTask {
-	return newCannonVMRegisterTaskWithConfig(gameType, logger, cfg, m, serverExecutor, l2Client, rollupClient, syncValidator, cfg.CannonKona, cfg.CannonKonaAbsolutePreStateBaseURL, cfg.CannonKonaAbsolutePreState)
+func NewCannonKonaRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator gameTypes.SyncValidator) *RegisterTask {
+	return newCannonVMRegisterTaskWithConfig(gameType, cfg, m, serverExecutor, l2Client, rollupClient, syncValidator, cfg.CannonKona, cfg.CannonKonaAbsolutePreStateBaseURL, cfg.CannonKonaAbsolutePreState)
 }
 
 func newCannonVMRegisterTaskWithConfig(
 	gameType gameTypes.GameType,
-	logger log.Logger,
 	cfg *config.Config,
 	m caching.Metrics,
 	serverExecutor vm.OracleServerExecutor,
@@ -128,21 +126,25 @@ func newCannonVMRegisterTaskWithConfig(
 	// Only trusted actors participate in these games so they aren't expected to reach the step() call and
 	// are often configured without valid prestates but the challenger should still resolve the games.
 	skipPrestateValidation := gameType == gameTypes.PermissionedGameType
-	getBottomPrestateProvider := cachePrestates(
-		gameType,
-		stateConverter,
-		m,
-		preStateBaseURL,
-		preState,
-		filepath.Join(cfg.Datadir, vmCfg.VmType.String()+"-prestates"),
-		func(ctx context.Context, path string) faultTypes.PrestateProvider {
-			return vm.NewPrestateProvider(path, stateConverter)
-		})
+	var getBottomPrestateProvider func(ctx context.Context, prestateHash common.Hash) (faultTypes.PrestateProvider, error)
 	if skipPrestateValidation {
 		// Permissioned games never reach step() so their VM prestate is never actually used. Since they
 		// are often configured with a placeholder prestate that isn't published (e.g. when using
-		// --prestates-url), fall back to an empty placeholder provider rather than failing to resolve the game.
-		getBottomPrestateProvider = tolerateMissingPrestate(logger.New("gameType", gameType), getBottomPrestateProvider, stateConverter)
+		// --prestates-url), don't attempt to load the prestate at all and use an empty placeholder provider.
+		getBottomPrestateProvider = func(_ context.Context, _ common.Hash) (faultTypes.PrestateProvider, error) {
+			return vm.NewPrestateProvider("", stateConverter), nil
+		}
+	} else {
+		getBottomPrestateProvider = cachePrestates(
+			gameType,
+			stateConverter,
+			m,
+			preStateBaseURL,
+			preState,
+			filepath.Join(cfg.Datadir, vmCfg.VmType.String()+"-prestates"),
+			func(ctx context.Context, path string) faultTypes.PrestateProvider {
+				return vm.NewPrestateProvider(path, stateConverter)
+			})
 	}
 	return &RegisterTask{
 		gameType:               gameType,
@@ -212,24 +214,6 @@ func cachePrestates(
 			return newPrestateProvider(ctx, prestatePath), nil
 		})
 	return prestateProviderCache.GetOrCreate
-}
-
-// tolerateMissingPrestate wraps a bottom prestate provider so that an unavailable prestate is not fatal.
-// The returned provider yields an empty placeholder when the source can't find the prestate, which is safe
-// for game types that never reach step() and so never use the VM prestate (i.e. permissioned games).
-func tolerateMissingPrestate(
-	logger log.Logger,
-	source func(ctx context.Context, prestateHash common.Hash) (faultTypes.PrestateProvider, error),
-	stateConverter vm.StateConverter,
-) func(ctx context.Context, prestateHash common.Hash) (faultTypes.PrestateProvider, error) {
-	return func(ctx context.Context, prestateHash common.Hash) (faultTypes.PrestateProvider, error) {
-		provider, err := source(ctx, prestateHash)
-		if errors.Is(err, prestates.ErrPrestateUnavailable) {
-			logger.Warn("Prestate unavailable, using empty placeholder", "prestateHash", prestateHash, "err", err)
-			return vm.NewPrestateProvider("", stateConverter), nil
-		}
-		return provider, err
-	}
 }
 
 func (e *RegisterTask) Register(

--- a/op-challenger/game/fault/register_task.go
+++ b/op-challenger/game/fault/register_task.go
@@ -102,16 +102,17 @@ func newSuperCannonVMRegisterTaskWithConfig(
 	}
 }
 
-func NewCannonRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator gameTypes.SyncValidator) *RegisterTask {
-	return newCannonVMRegisterTaskWithConfig(gameType, cfg, m, serverExecutor, l2Client, rollupClient, syncValidator, cfg.Cannon, cfg.CannonAbsolutePreStateBaseURL, cfg.CannonAbsolutePreState)
+func NewCannonRegisterTask(gameType gameTypes.GameType, logger log.Logger, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator gameTypes.SyncValidator) *RegisterTask {
+	return newCannonVMRegisterTaskWithConfig(gameType, logger, cfg, m, serverExecutor, l2Client, rollupClient, syncValidator, cfg.Cannon, cfg.CannonAbsolutePreStateBaseURL, cfg.CannonAbsolutePreState)
 }
 
-func NewCannonKonaRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator gameTypes.SyncValidator) *RegisterTask {
-	return newCannonVMRegisterTaskWithConfig(gameType, cfg, m, serverExecutor, l2Client, rollupClient, syncValidator, cfg.CannonKona, cfg.CannonKonaAbsolutePreStateBaseURL, cfg.CannonKonaAbsolutePreState)
+func NewCannonKonaRegisterTask(gameType gameTypes.GameType, logger log.Logger, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator gameTypes.SyncValidator) *RegisterTask {
+	return newCannonVMRegisterTaskWithConfig(gameType, logger, cfg, m, serverExecutor, l2Client, rollupClient, syncValidator, cfg.CannonKona, cfg.CannonKonaAbsolutePreStateBaseURL, cfg.CannonKonaAbsolutePreState)
 }
 
 func newCannonVMRegisterTaskWithConfig(
 	gameType gameTypes.GameType,
+	logger log.Logger,
 	cfg *config.Config,
 	m caching.Metrics,
 	serverExecutor vm.OracleServerExecutor,
@@ -141,7 +142,7 @@ func newCannonVMRegisterTaskWithConfig(
 		// Permissioned games never reach step() so their VM prestate is never actually used. Since they
 		// are often configured with a placeholder prestate that isn't published (e.g. when using
 		// --prestates-url), fall back to an empty placeholder provider rather than failing to resolve the game.
-		getBottomPrestateProvider = tolerateMissingPrestate(getBottomPrestateProvider, stateConverter)
+		getBottomPrestateProvider = tolerateMissingPrestate(logger.New("gameType", gameType), getBottomPrestateProvider, stateConverter)
 	}
 	return &RegisterTask{
 		gameType:               gameType,
@@ -217,12 +218,14 @@ func cachePrestates(
 // The returned provider yields an empty placeholder when the source can't find the prestate, which is safe
 // for game types that never reach step() and so never use the VM prestate (i.e. permissioned games).
 func tolerateMissingPrestate(
+	logger log.Logger,
 	source func(ctx context.Context, prestateHash common.Hash) (faultTypes.PrestateProvider, error),
 	stateConverter vm.StateConverter,
 ) func(ctx context.Context, prestateHash common.Hash) (faultTypes.PrestateProvider, error) {
 	return func(ctx context.Context, prestateHash common.Hash) (faultTypes.PrestateProvider, error) {
 		provider, err := source(ctx, prestateHash)
 		if errors.Is(err, prestates.ErrPrestateUnavailable) {
+			logger.Warn("Prestate unavailable, using empty placeholder", "prestateHash", prestateHash, "err", err)
 			return vm.NewPrestateProvider("", stateConverter), nil
 		}
 		return provider, err

--- a/op-challenger/game/fault/register_task_test.go
+++ b/op-challenger/game/fault/register_task_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
@@ -30,27 +31,30 @@ func TestCannonRegisterTask_BottomPrestateProvider(t *testing.T) {
 	// where the (placeholder) prestate for a permissioned game is not published.
 	baseURL, err := url.Parse("file:///nonexistent-prestates/")
 	require.NoError(t, err)
-	cfg := &config.Config{
-		Datadir:                       t.TempDir(),
-		Cannon:                        vm.Config{VmType: gameTypes.CannonGameType},
-		CannonAbsolutePreStateBaseURL: baseURL,
+	newCfg := func(t *testing.T) *config.Config {
+		return &config.Config{
+			Datadir:                       t.TempDir(),
+			Cannon:                        vm.Config{VmType: gameTypes.CannonGameType},
+			CannonAbsolutePreStateBaseURL: baseURL,
+		}
 	}
 	requiredPrestate := common.Hash{0xaa}
 
-	t.Run("permissioned game tolerates missing prestate", func(t *testing.T) {
-		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
-		task := NewCannonRegisterTask(gameTypes.PermissionedGameType, logger, cfg, metrics.NoopMetrics, nil, nil, nil, nil)
+	t.Run("permissioned game uses placeholder prestate without loading it", func(t *testing.T) {
+		cfg := newCfg(t)
+		task := NewCannonRegisterTask(gameTypes.PermissionedGameType, cfg, metrics.NoopMetrics, nil, nil, nil, nil)
 		provider, err := task.getBottomPrestateProvider(context.Background(), requiredPrestate)
 		require.NoError(t, err)
-		require.NotNil(t, provider)
-		require.NotNil(t, logs.FindLog(
-			testlog.NewLevelFilter(log.LevelWarn),
-			testlog.NewMessageContainsFilter("Prestate unavailable")))
+		vmProvider, ok := provider.(*vm.PrestateProvider)
+		require.True(t, ok)
+		require.Empty(t, vmProvider.PrestatePath())
+		// No load is ever attempted, so the prestates dir the downloader would create must not exist
+		require.NoDirExists(t, filepath.Join(cfg.Datadir, "cannon-prestates"))
 	})
 
 	t.Run("cannon game requires prestate", func(t *testing.T) {
-		logger := testlog.Logger(t, log.LvlInfo)
-		task := NewCannonRegisterTask(gameTypes.CannonGameType, logger, cfg, metrics.NoopMetrics, nil, nil, nil, nil)
+		cfg := newCfg(t)
+		task := NewCannonRegisterTask(gameTypes.CannonGameType, cfg, metrics.NoopMetrics, nil, nil, nil, nil)
 		_, err := task.getBottomPrestateProvider(context.Background(), requiredPrestate)
 		require.ErrorIs(t, err, prestates.ErrPrestateUnavailable)
 	})

--- a/op-challenger/game/fault/register_task_test.go
+++ b/op-challenger/game/fault/register_task_test.go
@@ -3,10 +3,14 @@ package fault
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/prestates"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/registry"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
@@ -20,6 +24,32 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCannonRegisterTask_BottomPrestateProvider(t *testing.T) {
+	// A base URL that never resolves a prestate, matching a challenger configured with --prestates-url
+	// where the (placeholder) prestate for a permissioned game is not published.
+	baseURL, err := url.Parse("file:///nonexistent-prestates/")
+	require.NoError(t, err)
+	cfg := &config.Config{
+		Datadir:                       t.TempDir(),
+		Cannon:                        vm.Config{VmType: gameTypes.CannonGameType},
+		CannonAbsolutePreStateBaseURL: baseURL,
+	}
+	requiredPrestate := common.Hash{0xaa}
+
+	t.Run("permissioned game tolerates missing prestate", func(t *testing.T) {
+		task := NewCannonRegisterTask(gameTypes.PermissionedGameType, cfg, metrics.NoopMetrics, nil, nil, nil, nil)
+		provider, err := task.getBottomPrestateProvider(context.Background(), requiredPrestate)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+	})
+
+	t.Run("cannon game requires prestate", func(t *testing.T) {
+		task := NewCannonRegisterTask(gameTypes.CannonGameType, cfg, metrics.NoopMetrics, nil, nil, nil, nil)
+		_, err := task.getBottomPrestateProvider(context.Background(), requiredPrestate)
+		require.ErrorIs(t, err, prestates.ErrPrestateUnavailable)
+	})
+}
 
 func TestRegisterOracle_MissingGameImpl(t *testing.T) {
 	// Test versions with and without game args support

--- a/op-challenger/game/fault/register_task_test.go
+++ b/op-challenger/game/fault/register_task_test.go
@@ -38,14 +38,19 @@ func TestCannonRegisterTask_BottomPrestateProvider(t *testing.T) {
 	requiredPrestate := common.Hash{0xaa}
 
 	t.Run("permissioned game tolerates missing prestate", func(t *testing.T) {
-		task := NewCannonRegisterTask(gameTypes.PermissionedGameType, cfg, metrics.NoopMetrics, nil, nil, nil, nil)
+		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+		task := NewCannonRegisterTask(gameTypes.PermissionedGameType, logger, cfg, metrics.NoopMetrics, nil, nil, nil, nil)
 		provider, err := task.getBottomPrestateProvider(context.Background(), requiredPrestate)
 		require.NoError(t, err)
 		require.NotNil(t, provider)
+		require.NotNil(t, logs.FindLog(
+			testlog.NewLevelFilter(log.LevelWarn),
+			testlog.NewMessageContainsFilter("Prestate unavailable")))
 	})
 
 	t.Run("cannon game requires prestate", func(t *testing.T) {
-		task := NewCannonRegisterTask(gameTypes.CannonGameType, cfg, metrics.NoopMetrics, nil, nil, nil, nil)
+		logger := testlog.Logger(t, log.LvlInfo)
+		task := NewCannonRegisterTask(gameTypes.CannonGameType, logger, cfg, metrics.NoopMetrics, nil, nil, nil, nil)
 		_, err := task.getBottomPrestateProvider(context.Background(), requiredPrestate)
 		require.ErrorIs(t, err, prestates.ErrPrestateUnavailable)
 	})

--- a/op-challenger/game/types/game_type.go
+++ b/op-challenger/game/types/game_type.go
@@ -28,6 +28,17 @@ const (
 	UnknownGameType           GameType = math.MaxUint32 // Not supported by op-challenger
 )
 
+// IsPermissioned returns true for game types played only by trusted actors.
+// These games resolve at the proposal level without ever reaching step(), so
+// they never run the fault proof VM or load its absolute prestate.
+func (g GameType) IsPermissioned() bool {
+	return g == PermissionedGameType || g == SuperPermissionedGameType
+}
+
+// CannonFamilyGameTypes are the game types that share the cannon VM
+// configuration (the --cannon-* flags).
+var CannonFamilyGameTypes = []GameType{CannonGameType, PermissionedGameType}
+
 // SupportedGameTypes is the list of game types that are supported by op-challenger.
 // Game type codes may be reserved that are not supported by op-challenger.
 var SupportedGameTypes = []GameType{

--- a/op-challenger/game/types/game_type_test.go
+++ b/op-challenger/game/types/game_type_test.go
@@ -41,6 +41,22 @@ func TestSupportedGameTypeFromString_RejectsSuperPermissioned(t *testing.T) {
 	require.Equal(t, UnknownGameType, result)
 }
 
+func TestIsPermissioned(t *testing.T) {
+	permissioned := []GameType{PermissionedGameType, SuperPermissionedGameType}
+	for _, gameType := range permissioned {
+		t.Run(gameType.String(), func(t *testing.T) {
+			require.True(t, gameType.IsPermissioned())
+		})
+	}
+
+	notPermissioned := []GameType{CannonGameType, CannonKonaGameType, SuperCannonKonaGameType, ZKDisputeGameType, FastGameType, AlphabetGameType}
+	for _, gameType := range notPermissioned {
+		t.Run(gameType.String(), func(t *testing.T) {
+			require.False(t, gameType.IsPermissioned())
+		})
+	}
+}
+
 func TestKnownStringForAllSupportedGameTypes(t *testing.T) {
 	for _, gameType := range SupportedGameTypes {
 		t.Run(gameType.String(), func(t *testing.T) {


### PR DESCRIPTION
Fixes #21470.

When a permissioned game (type 1) is configured with `--prestates-url`, op-challenger fetches the game's absolute prestate from that URL keyed by hash. Permissioned games are often configured with a placeholder prestate that isn't published there, so the fetch fails and op-challenger errors out creating the game player — even though it should still resolve the game. (With `--cannon-prestate <file>` this doesn't happen because the single-file source ignores the hash, hence the `--cannon-prestate=any-string` workaround.)

Permissioned games are played only by trusted actors, resolve at the output-root level, and never reach `step()`, so their VM prestate is never actually used. Per review feedback, the challenger now never loads the prestate for permissioned games at all (rather than only tolerating a failed fetch):

- The bottom prestate provider for the permissioned game type is an unconditional empty placeholder — no fetch, no cache, no error path. Cannon and other game types still hard-fail on a missing prestate.
- The prestate flags (`--cannon-prestate` / `--prestates-url`) are no longer required when only the permissioned game type is enabled, at both the CLI-flags and config validation layers, mirroring the existing op-program server relaxation. They are still required whenever the cannon game type is enabled.
- New `GameType.IsPermissioned()` and `CannonFamilyGameTypes` in `game/types` centralize the "permissioned ⇒ never reaches step()" property (already covering the upcoming SuperPermissionedGameType) and the cannon flag-family membership; the validators derive their own requirements from them instead of taking caller-supplied booleans.
- Tests pin: permissioned games get the placeholder without any load attempt; cannon still errors on a missing prestate; prestate flags are optional for permissioned-only configs but still required when cannon and permissioned are both enabled (config and CLI layers).
- README documents the behavior.
