### PR TITLE
fix(alloy-op-evm): upgrade legacy tx type when setting access list

### DIFF
--- a/rust/alloy-op-evm/src/tx.rs
+++ b/rust/alloy-op-evm/src/tx.rs
@@ -269,6 +269,41 @@ impl TransactionEnvMut for OpTx {
     }
 
     fn set_access_list(&mut self, access_list: alloy_eips::eip2930::AccessList) {
-        self.0.base.access_list = access_list;
+        // Delegate to `TxEnv` so a legacy tx type is upgraded to EIP-2930: revm neither prices
+        // nor prewarms an access list on a legacy-typed transaction.
+        self.0.base.set_access_list(access_list);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_eips::eip2930::AccessListItem;
+    use op_revm::transaction::deposit::DEPOSIT_TRANSACTION_TYPE;
+    use revm::context_interface::TransactionType;
+
+    /// A single-entry access list, distinct from the empty default so the test can assert it was
+    /// actually written through.
+    fn sample_access_list() -> alloy_eips::eip2930::AccessList {
+        alloy_eips::eip2930::AccessList(vec![AccessListItem {
+            address: Address::from([0x11; 20]),
+            storage_keys: vec![B256::from([0x22; 32])],
+        }])
+    }
+
+    #[test_case::test_case(TransactionType::Legacy as u8, TransactionType::Eip2930 as u8; "legacy_upgrades_to_eip2930")]
+    #[test_case::test_case(TransactionType::Eip1559 as u8, TransactionType::Eip1559 as u8; "eip1559_is_unchanged")]
+    #[test_case::test_case(DEPOSIT_TRANSACTION_TYPE, DEPOSIT_TRANSACTION_TYPE; "deposit_is_unchanged")]
+    fn set_access_list_upgrades_legacy_tx_type(tx_type: u8, expected_tx_type: u8) {
+        let mut tx = OpTx(OpTransaction {
+            base: TxEnv { tx_type, ..Default::default() },
+            ..Default::default()
+        });
+        let access_list = sample_access_list();
+
+        tx.set_access_list(access_list.clone());
+
+        assert_eq!(tx.0.base.tx_type, expected_tx_type);
+        assert_eq!(tx.0.base.access_list, access_list);
     }
 }


### PR DESCRIPTION
## Summary

`OpTx::set_access_list` assigned `self.0.base.access_list` directly, bypassing `TxEnv::set_access_list`, which also upgrades `tx_type` Legacy → Eip2930 when a list is attached. revm treats an access list on a legacy-typed transaction as inert (no EIP-2930 intrinsic pricing, no prewarming), so `eth_createAccessList`'s "transact again to get the exact gas used" re-run was a byte-for-byte repeat of the first run — op-reth reported the **without-list** gas while handing back the list. Ethereum reth (whose `TxEnv` upgrades) and geth/op-geth report the **with-list** gas.

Delegate to the base impl so the upgrade applies.

## Root cause

- For list-less requests, the RPC tx env derives `TxType::Legacy` (`minimal_tx_type()`).
- reth's `create_access_list_with` sets the discovered list via `set_access_list` and re-transacts for the exact gas (semantics introduced in paradigmxyz/reth#10416 / paradigmxyz/reth#10422).
- The base `TransactionEnvMut for TxEnv` (alloy-evm) upgrades Legacy → Eip2930 in `set_access_list`; the `OpTx` wrapper impl assigned the field directly and lost the upgrade. revm then ignores the list for the legacy type (intrinsic pricing gated in revm-context-interface `gas_params.rs::initial_tx_gas_for_tx`; prewarming gated in revm-handler `pre_execution.rs`).
- reth previously carried a delegating `TransactionEnv for OpTransaction<T>` impl that inherited the upgrade correctly; it was dropped in the `TransactionEnvMut` migration (paradigmxyz/reth#23218), and the rewritten wrapper impl here reached into the field instead.

Observable symptom and a one-command public repro (including an empty-`accessList` probe that flips the answer) are in the linked issue.

## Testing

- New table-driven regression test in `tx.rs` (`test-case`, already a dev-dependency): Legacy upgrades to Eip2930; Eip1559 unchanged; deposit (0x7e) unchanged; the list is stored in all cases.
- Ran locally (crate-scoped): `cargo test -p alloy-op-evm --all-features`, `cargo clippy -p alloy-op-evm --all-features --all-targets --locked -- -D warnings`, and nightly `cargo fmt --all -- --check` per `rust/rustfmt.toml` — all clean. `Cargo.lock` untouched.
- Cross-checked behaviorally on OP mainnet: with this semantics, `eth_createAccessList.gasUsed` equals `debug_traceCall` of the same request with the returned list attached (and matches Ethereum-mainnet reth of the same version).

Fixes #21682
