### PR TITLE
[codex] contracts-bedrock: reject deposits in CrossL2Inbox

### DIFF
--- a/op-acceptance-tests/tests/interop/message/deposit_inbox_test.go
+++ b/op-acceptance-tests/tests/interop/message/deposit_inbox_test.go
@@ -1,0 +1,73 @@
+package msg
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestDepositCannotValidateMessage(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSimpleInterop(t)
+	require := t.Require()
+	ctx := t.Ctx()
+
+	sys.L1Network.WaitForOnline()
+	alice := sys.FunderL1.NewFundedEOA(eth.OneEther)
+
+	inbox := bindings.NewBindings[bindings.CrossL2Inbox]()
+	calldata, err := inbox.ValidateMessage(messages.Identifier{}, eth.Bytes32{}).EncodeInputLambda()
+	require.NoError(err, "failed to encode validateMessage calldata")
+
+	portal := bindings.NewBindings[bindings.OptimismPortal2](
+		bindings.WithClient(sys.L1EL.EthClient()),
+		bindings.WithTo(sys.L2ChainA.DepositContractAddr()),
+		bindings.WithTest(t),
+	)
+	minGas, err := contractio.Read(portal.MinimumGasLimit(uint64(len(calldata))), ctx)
+	require.NoError(err, "failed to read minimum deposit gas limit")
+	deposit := portal.DepositTransaction(
+		predeploys.CrossL2InboxAddr,
+		eth.ZeroWei,
+		max(100_000, minGas),
+		false,
+		calldata,
+	)
+	l1Receipt := contract.Write(alice, deposit)
+
+	var l2Deposit *ethtypes.DepositTx
+	for _, log := range l1Receipt.Logs {
+		if l2Deposit, err = derive.UnmarshalDepositLogEvent(log); err == nil {
+			break
+		}
+	}
+	require.NotNil(l2Deposit, "no TransactionDeposited event in L1 receipt")
+
+	l2Tx := ethtypes.NewTx(l2Deposit)
+	sys.L2ELA.WaitL1OriginReached(eth.Unsafe, bigs.Uint64Strict(l1Receipt.BlockNumber), 120)
+	l2Receipt := sys.L2ELA.WaitForReceipt(l2Tx.Hash())
+	require.Equal(ethtypes.ReceiptStatusFailed, l2Receipt.Status, "deposit unexpectedly validated a message")
+
+	trace := new(wait.TxTrace)
+	err = sys.L2ELA.EthClient().RPC().CallContext(ctx, trace, "debug_traceTransaction", hexutil.Bytes(l2Tx.Hash().Bytes()), map[string]any{
+		"enableReturnData": true,
+		"tracer":           "callTracer",
+		"tracerConfig":     map[string]any{},
+	})
+	require.NoError(err, "failed to trace L2 deposit")
+	want := crypto.Keccak256([]byte("NoExecutingDeposits()"))[:4]
+	require.Equal(want, []byte(trace.Output), "deposit reverted for an unexpected reason")
+}

--- a/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol
@@ -12,6 +12,7 @@ struct Identifier {
 }
 
 interface ICrossL2Inbox {
+    error NoExecutingDeposits();
     error NotInAccessList();
     error BlockNumberTooHigh();
     error TimestampTooHigh();

--- a/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
+++ b/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
@@ -166,6 +166,11 @@
   },
   {
     "inputs": [],
+    "name": "NoExecutingDeposits",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "NotInAccessList",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -48,8 +48,8 @@
     "sourceCodeHash": "0x7c83a95f65cfd963af0caf90579e8f8544e3f883a48bc803720ec251c72aeffe"
   },
   "src/L2/CrossL2Inbox.sol:CrossL2Inbox": {
-    "initCodeHash": "0x56f868e561c4abe539043f98b16aad9305479e68fd03ece2233249b0c73a24ea",
-    "sourceCodeHash": "0x7c6d362a69a480a06a079542a7fd2ce48cb1dd80d6b9043fba60218569371349"
+    "initCodeHash": "0x9ee5b918a1f073b7438f1bd8731c9e6374c2b8ff01ae852531a676e89dd56c06",
+    "sourceCodeHash": "0xb88b40d3e46666609c63650ef57b02f49143f2979e0a782d44a2d7e044228a70"
   },
   "src/L2/ETHLiquidity.sol:ETHLiquidity": {
     "initCodeHash": "0x3c32ddabff34450afd940aa8cf852783576c3ae2d453b66386c3ed3baa0d7a57",

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -29,6 +29,9 @@ struct Identifier {
 ///      in the tx's access list. Nodes pre-check message validity before execution. The checksum
 ///      combines the message's `Identifier` and `msgHash` with type-3 bit masking.
 contract CrossL2Inbox is ISemver {
+    /// @notice Thrown when trying to validate a cross chain message in a deposit transaction.
+    error NoExecutingDeposits();
+
     /// @notice Thrown when trying to validate a cross chain message with a checksum
     ///         that is invalid or was not provided in the transaction's access list to set the slot
     ///         as warm.
@@ -47,8 +50,8 @@ contract CrossL2Inbox is ISemver {
     error LogIndexTooHigh();
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.2
-    string public constant version = "1.0.2";
+    /// @custom:semver 1.1.0
+    string public constant version = "1.1.0";
 
     /// @notice The mask for the most significant bits of the checksum.
     /// @dev    Used to set the most significant byte to zero.
@@ -74,6 +77,9 @@ contract CrossL2Inbox is ISemver {
     /// @param _id      Identifier of the message.
     /// @param _msgHash Hash of the message payload to call target with.
     function validateMessage(Identifier calldata _id, bytes32 _msgHash) external {
+        // Deposits have a zero gas price. When the base fee is positive, user transactions cannot.
+        if (block.basefee > 0 && tx.gasprice == 0) revert NoExecutingDeposits();
+
         bytes32 checksum = calculateChecksum(_id, _msgHash);
         (bool isWarm,) = _isWarm(checksum);
         if (!isWarm) revert NotInAccessList();

--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -59,6 +59,21 @@ abstract contract CrossL2Inbox_TestInit is CommonTest {
 /// @title CrossL2Inbox_ValidateMessage_Test
 /// @notice Tests the `validateMessage` function of the `CrossL2Inbox` contract.
 contract CrossL2Inbox_ValidateMessage_Test is CrossL2Inbox_TestInit {
+    /// @notice Test that `validateMessage` reverts when executed in a deposit transaction.
+    function testFuzz_validateMessage_depositTransaction_reverts(
+        Identifier memory _id,
+        bytes32 _messageHash
+    )
+        external
+    {
+        _id.blockNumber = bound(_id.blockNumber, 0, type(uint64).max);
+        _id.logIndex = bound(_id.logIndex, 0, type(uint32).max);
+        _id.timestamp = bound(_id.timestamp, 0, type(uint64).max);
+
+        vm.expectRevert(ICrossL2Inbox.NoExecutingDeposits.selector);
+        crossL2Inbox.validateMessage(_id, _messageHash);
+    }
+
     /// @notice Test that `validateMessage` reverts when the slot is not warm.
     function testFuzz_validateMessage_accessList_reverts(Identifier memory _id, bytes32 _messageHash) external {
         // Bound values types to ensure they are not too large
@@ -70,6 +85,7 @@ contract CrossL2Inbox_ValidateMessage_Test is CrossL2Inbox_TestInit {
         vm.cool(address(crossL2Inbox));
 
         // Expect revert
+        vm.txGasPrice(block.basefee);
         vm.expectRevert(ICrossL2Inbox.NotInAccessList.selector);
         crossL2Inbox.validateMessage(_id, _messageHash);
     }
@@ -216,6 +232,7 @@ contract CrossL2Inbox_ValidateMessage_Test is CrossL2Inbox_TestInit {
         _id.timestamp = bound(_id.timestamp, 0, type(uint64).max);
 
         // Try and retry the message without any access list
+        vm.txGasPrice(block.basefee);
         vm.expectCall(address(crossL2Inbox), abi.encodeCall(ICrossL2Inbox.validateMessage, (_id, _messageHash)), 2);
         validateMessageRelayer.validateAndRetry(_id, _messageHash);
     }


### PR DESCRIPTION
## Summary

- reject `CrossL2Inbox.validateMessage` when execution has a positive base fee and a zero transaction gas price
- expose `NoExecutingDeposits`, bump the contract version to `1.1.0`, and update ABI/semver snapshots
- add focused Solidity coverage and a DevStack acceptance test that sends an L1 deposit directly to the inbox and checks the exact revert selector

## Rationale

Deposit transactions expose `tx.gasprice == 0`. End-user transactions have an effective gas price at least as large as the block base fee, so when `block.basefee > 0`, the combination uniquely identifies deposit execution.

The existing access-list warmth requirement already prevents deposits from validating messages implicitly. This adds an explicit defense-in-depth check and a stable error before the access-list validation.

## Impact

Deposits that call `validateMessage` now revert early with `NoExecutingDeposits`. End-user transactions on positive-base-fee chains are unaffected. The base-fee condition avoids classifying zero-gas-price user transactions as deposits on chains configured with a zero base fee.

## Validation

- `just test-dev --match-path test/L2/CrossL2Inbox.t.sol` (12 passed)
- `just snapshots`
- `just snapshots-check-no-build`
- `just interfaces-check-no-build`
- `go test ./op-acceptance-tests/tests/interop/message -run '^$'`
- the DevStack test compiles and reaches the EL fixture gate locally; full execution requires the op-reth lane because Karst fixtures skip op-geth, and no op-reth binary is installed in this environment
