### PR TITLE
feat(op-reth): extract OpNode::standard_pool_builder for reuse

### DIFF
--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -248,6 +248,24 @@ impl OpNode {
         self
     }
 
+    /// The pool builder configured the way every OP node's pool expects: tx-conditional support,
+    /// interop endpoints and quorum, and the shared interop failsafe gate.
+    ///
+    /// Generic over the pooled-transaction type so a downstream node can start from this base and
+    /// chain [`with_ordering`](OpPoolBuilder::with_ordering) /
+    /// [`with_validator_wrapper`](OpPoolBuilder::with_validator_wrapper) to swap in a custom `T`,
+    /// ordering, or validator wrapper.
+    pub fn standard_pool_builder<T>(&self) -> OpPoolBuilder<T> {
+        OpPoolBuilder::<T>::default()
+            .with_enable_tx_conditional(self.args.enable_tx_conditional)
+            .with_interop(
+                self.args.interop_http.clone(),
+                self.args.interop_min_responses,
+                self.args.interop_safety_level,
+            )
+            .with_interop_failsafe(self.interop_failsafe.clone())
+    }
+
     /// Returns the components for the given [`RollupArgs`].
     pub fn components<Node>(&self) -> OpNodeComponentBuilder<Node>
     where
@@ -258,16 +276,7 @@ impl OpNode {
         ComponentsBuilder::default()
             .node_types::<Node>()
             .executor(OpExecutorBuilder::default())
-            .pool(
-                OpPoolBuilder::default()
-                    .with_enable_tx_conditional(self.args.enable_tx_conditional)
-                    .with_interop(
-                        self.args.interop_http.clone(),
-                        self.args.interop_min_responses,
-                        self.args.interop_safety_level,
-                    )
-                    .with_interop_failsafe(self.interop_failsafe.clone()),
-            )
+            .pool(self.standard_pool_builder())
             .payload(BasicPayloadServiceBuilder::new(
                 OpPayloadBuilder::new(compute_pending_block)
                     .with_da_config(self.da_config.clone())
@@ -1715,3 +1724,54 @@ where
 
 /// Network primitive types used by Optimism networks.
 pub type OpNetworkPrimitives = BasicNetworkPrimitives<OpPrimitives, OpPooledTransaction>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_pool_builder_forwards_base_config() {
+        let args = RollupArgs {
+            enable_tx_conditional: true,
+            interop_http: vec!["http://interop.local".to_string()],
+            interop_min_responses: Some(2),
+            interop_safety_level: SafetyLevel::CrossSafe,
+            ..Default::default()
+        };
+        let node = OpNode::new(args.clone());
+
+        let pool = node.standard_pool_builder::<OpPooledTransaction>();
+
+        assert_eq!(pool.enable_tx_conditional, args.enable_tx_conditional);
+        assert_eq!(pool.interop_endpoints, args.interop_http);
+        assert_eq!(pool.interop_min_responses, args.interop_min_responses);
+        assert_eq!(pool.interop_safety_level, args.interop_safety_level);
+
+        assert!(!pool.interop_failsafe.enabled(), "failsafe starts disabled");
+        node.interop_failsafe.set(true);
+        assert!(
+            pool.interop_failsafe.enabled(),
+            "pool must observe writes to the node's interop failsafe gate"
+        );
+        node.interop_failsafe.set(false);
+        assert!(
+            !pool.interop_failsafe.enabled(),
+            "pool must observe the gate being cleared, proving a single shared handle"
+        );
+    }
+
+    #[test]
+    fn standard_pool_builder_preserves_base_config_when_chaining_seams() {
+        let node = OpNode::new(RollupArgs { enable_tx_conditional: true, ..Default::default() });
+
+        let pool = node
+            .standard_pool_builder::<OpPooledTransaction>()
+            .with_ordering(CoinbaseTipOrdering::<OpPooledTransaction>::default())
+            .with_validator_wrapper(IdentityValidatorWrapper);
+
+        assert!(pool.enable_tx_conditional, "base config must survive chaining the seams");
+
+        let _: &CoinbaseTipOrdering<OpPooledTransaction> = &pool.ordering;
+        let _: &IdentityValidatorWrapper = &pool.validator_wrapper;
+    }
+}


### PR DESCRIPTION
## Summary

Extract the base pool-builder configuration out of `OpNode::components` into a reusable, generic method `OpNode::standard_pool_builder<T>`, so a downstream node can reuse the exact base config and only chain its own `with_ordering` / `with_validator_wrapper` on top.

Previously the base config (tx-conditional, interop endpoints and quorum, shared interop failsafe gate) was inlined in `components()`. A downstream node (e.g. op-reth-premium) that wants a policy-typed pool had to hand-copy every base `with_` call, which risks **silently dropping one** as the base config grows — as nearly happened with `with_interop_failsafe`, where a txpool writer and payload reader on different failsafe handles would desync.

## Change

```rust
pub fn standard_pool_builder<T>(&self) -> OpPoolBuilder<T> {
    OpPoolBuilder::<T>::default()
        .with_enable_tx_conditional(self.args.enable_tx_conditional)
        .with_interop(
            self.args.interop_http.clone(),
            self.args.interop_min_responses,
            self.args.interop_safety_level,
        )
        .with_interop_failsafe(self.interop_failsafe.clone())
}
```

- `components()` now calls `.pool(self.standard_pool_builder())`, `T` defaulting to `OpPooledTransaction` — **behavior is unchanged**.
- Generic over the pooled-tx type `T` on purpose: a downstream node's pool builder may be `OpPoolBuilder<CustomTx, ...>`, not the default, so a non-generic helper couldn't be chained. It composes with the `with_ordering` / `with_validator_wrapper` seams added in #21531.
- The base `with_` calls now live in exactly one place; a future base `with_` flows to every consumer on the next pin bump instead of being silently missed.

## Tests

- `standard_pool_builder_forwards_base_config` — sets every base field to a non-default value and asserts each is forwarded; proves the interop failsafe is a **single shared handle** by writing through the node and observing through the pool in both directions.
- `standard_pool_builder_preserves_base_config_when_chaining_seams` — asserts base config survives after chaining `with_ordering` / `with_validator_wrapper`, and that the chained ordering/validator members land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
