### PR TITLE
op-node: ignore stale sequencer action after Stop

### DIFF
--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -377,6 +377,10 @@ func (d *Sequencer) onPayloadSuccess(x engine.PayloadSuccessEvent) {
 
 func (d *Sequencer) onSequencerAction(ev SequencerActionEvent) {
 	d.log.Debug("Sequencer action")
+	if !d.active.Load() {
+		d.log.Debug("Ignoring stale sequencer action while inactive")
+		return
+	}
 	payload := d.asyncGossip.Get()
 	if payload != nil {
 		if d.latest.Info.ID == (eth.PayloadID{}) {

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -260,6 +260,61 @@ func TestSequencer_StartStop(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestSequencer_NoActionAfterStop verifies that a sequencer-action event that fires
+// after Stop() (because the driver's timer was already armed before we deactivated)
+// is ignored, rather than starting a new block-building job. Acting on that stale
+// event would issue a forkchoice update reasserting our head and could undo a reorg
+// introduced externally after we stopped. Regression test for issue #20198.
+func TestSequencer_NoActionAfterStop(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	seq, deps := createSequencer(logger)
+	emitter := &testutils.MockEmitter{}
+	seq.AttachEmitter(emitter)
+	deps.conductor.leader = true
+
+	testCtx := context.Background()
+	require.NoError(t, seq.Init(testCtx, false))
+	emitter.AssertExpectations(t)
+
+	// Bring latestSealed and latestHead to the same known block, so Stop() does not
+	// block waiting for the sealed block to catch up to the head.
+	head := eth.L2BlockRef{Hash: common.Hash{0xaa}}
+	envelope := &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{}}
+	emitter.ExpectOnce(engine.PayloadProcessEvent{Envelope: envelope, Ref: head})
+	seq.OnEvent(testCtx, engine.BuildSealedEvent{Envelope: envelope, Ref: head})
+	emitter.AssertExpectations(t)
+	seq.OnEvent(testCtx, engine.ForkchoiceUpdateEvent{UnsafeL2Head: head})
+	require.Equal(t, head.Hash, seq.latestHead.Hash)
+
+	// Start, then stop. While active the sequencer scheduled work; the driver may have
+	// already armed the sequencer-action timer at this point.
+	require.NoError(t, seq.Start(testCtx, head.Hash))
+	require.True(t, seq.Active())
+	_, ok := seq.NextAction()
+	require.True(t, ok, "active sequencer schedules work")
+
+	stopHead, err := seq.Stop(testCtx)
+	require.NoError(t, err)
+	require.Equal(t, head.Hash, stopHead)
+	require.False(t, seq.Active())
+
+	// Provide a valid L1 origin so that, absent the inactive-guard, onSequencerAction
+	// would proceed all the way to emitting a BuildStartEvent — turning a regression
+	// into a clear unexpected-emit failure rather than a panic.
+	deps.l1OriginSelector.l1OriginFn = func(l2Head eth.L2BlockRef) (eth.L1BlockRef, error) {
+		return eth.L1BlockRef{Number: 1000}, nil
+	}
+
+	// Fire the stale action. The MockEmitter has no pending expectations, so any emit
+	// here (i.e. the sequencer acting while stopped) fails the test.
+	seq.OnEvent(testCtx, SequencerActionEvent{})
+	emitter.AssertExpectations(t)
+
+	require.Equal(t, BuildingState{}, seq.latest, "no block-building job started while stopped")
+	_, ok = seq.NextAction()
+	require.False(t, ok, "stopped sequencer schedules no further work")
+}
+
 // TestSequencer_StaleBuild stops the sequencer after block-building,
 // but before processing the block locally,
 // and then continues it again, to check if the async-gossip gets cleared,


### PR DESCRIPTION
## Problem

`Sequencer.Stop()` does not fully stop the sequencer: a sequencer-action timer that the driver armed *before* the stop can still fire once afterwards.

The driver decides whether a sequencer action is wanted in exactly one place — `planSequencerAction()` — and only at the top of each event-loop iteration (`op-node/rollup/driver/driver.go:311`). Once it arms `sequencerTimer` and parks in the `select` (`driver.go:324`), `Stop()` (running in the admin-RPC goroutine) can flip the sequencer's `nextActionOK=false`, but it cannot retract the already-armed timer or force the parked loop to re-plan. When the timer fires, the loop emits `SequencerActionEvent` (`driver.go:326`) before it loops back to re-evaluate — so a *stopped* sequencer runs `onSequencerAction()` one more time, builds a block on its cached `latestHead`, and issues a forkchoice update reasserting that head.

### Why it caused reorg flakes

In the interop reorg acceptance tests, the op-test-sequencer commits a conflicting block **through op-node itself** — `CommitBlock` is op-node's own `EngineController` method (`op-node/rollup/engine/api.go:114`), which inserts the block, sets op-node's engine unsafe head, and forkchoices the EL onto it. The commit is not a rogue external write; op-node makes the block canonical.

The breakage is internal to op-node: the `EngineController` now knows the head is the new block, but the `Sequencer` subsystem still holds its stale cached `latestHead` (updated only asynchronously via `onForkchoiceUpdate`). The stale sequencer action fires in that window and forkchoices the EL back onto the old head — silently undoing a reorg that had already been made canonical.

## Fix

Guard `onSequencerAction()` on `d.active`, mirroring the intent already documented in `Stop()` (which wipes the in-flight building state specifically so a stopped sequencer can't reorg). `Sequencer.OnEvent` and `Sequencer.Stop` both take `d.l`, so this is race-free: a stopped sequencer never processes the action, regardless of how the event was emitted.

I considered a driver-side re-check (`if _, ok := s.sequencer.NextAction(); ok { emit }`) instead. It only *narrows* the window — `Stop()` can still land between the re-check and the emit — whereas the sequencer-side guard is airtight because of the shared lock. The two are complementary; the sequencer guard is the necessary/sufficient correctness fix.

## Why this fixes two issues

Every interop reorg test does the same "stop sequencer → commit a conflicting block through op-node → assert the reorg" dance, and each has had to hand-roll a `SyncStatus().UnsafeL2` quiescence wait to paper over this race. The ones that miss a spot flake:

- **#20198 `TestReorgUnsafeHead`** — its *first* `ReorgExact` (`unsafe_head_test.go:91`) samples the EL head in the raw post-commit window, before `StartSequencer` and before the quiescence wait that only guards its *second* assertion. This is the assertion that failed in CI.
- **#20943 `TestReorgInitExecMsg`** — same pattern, no quiescence guard at all.

Fixing the shared root cause in op-node removes the need for those per-test band-aids.

## Testing

- Added `TestSequencer_NoActionAfterStop` (`op-node/rollup/sequencing/sequencer_test.go`): starts→stops the sequencer, fires a stale `SequencerActionEvent`, and asserts no build job starts and no events are emitted. Confirmed it **fails without the guard** (reaches `startBuildingBlock` → emits `BuildStartEvent`) and passes with it.
- `go test ./op-node/rollup/sequencing/ ./op-node/rollup/driver/` — green.
- `go vet ./op-node/rollup/sequencing/` — clean.

## Reviewer note

This touches core sequencing (consensus-adjacent). The production impact of the pre-fix behavior is limited and self-healing (a stopped sequencer issuing one stale block-building FCU — a wasted/never-sealed build, or a brief local reorg during failover that re-follows the network), but it directly defeats the reorg tests. Would appreciate a sanity check from the sequencing owners on the guard.

Fixes #20198
Fixes #20943

🤖 Generated with [Claude Code](https://claude.com/claude-code)
