### PR TITLE
fix(op-reth cli): enable debug_verbosity/vmodule by gating log reload on the debug namespace

### DIFF
--- a/rust/op-reth/crates/cli/src/app.rs
+++ b/rust/op-reth/crates/cli/src/app.rs
@@ -137,7 +137,12 @@ where
             let otlp_status = runner.block_on(self.cli.traces.init_otlp_tracing(&mut layers))?;
             let otlp_logs_status = runner.block_on(self.cli.traces.init_otlp_logs(&mut layers))?;
 
-            self.guard = Some(self.cli.logs.init_tracing_with_layers(layers, false)?);
+            // Install the runtime-reloadable log filter layer only when the `debug` RPC namespace
+            // is enabled, so `debug_verbosity` / `debug_vmodule` work at runtime. Mirrors the
+            // Ethereum CLI; without this the reload handle is never installed and those methods
+            // fail with `-32603 "Log filter reload not available"` even with `debug` served.
+            let enable_reload = self.cli.command.debug_namespace_enabled();
+            self.guard = Some(self.cli.logs.init_tracing_with_layers(layers, enable_reload)?);
             info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.cli.logs.log_file_directory);
 
             match otlp_status {

--- a/rust/op-reth/crates/cli/src/commands/mod.rs
+++ b/rust/op-reth/crates/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ use reth_cli_commands::{
     node::{self, NoArgs},
     p2p, prune, re_execute, stage,
 };
+use reth_rpc_server_types::RethRpcModule;
 use std::{fmt, sync::Arc};
 
 pub mod import;
@@ -92,5 +93,15 @@ impl<
             Self::ReExecute(cmd) => cmd.chain_spec(),
             Self::OpProofs(cmd) => cmd.chain_spec(),
         }
+    }
+
+    /// Returns `true` if this is a `node` command with the `debug` RPC namespace enabled.
+    ///
+    /// Used to decide whether to install the runtime-reloadable log filter layer that backs the
+    /// `debug_verbosity` / `debug_vmodule` RPC methods. Mirrors the Ethereum CLI
+    /// (`Command::debug_namespace_enabled`); without it those methods return
+    /// `-32603 "Log filter reload not available"` even when the `debug` namespace is served.
+    pub fn debug_namespace_enabled(&self) -> bool {
+        matches!(self, Self::Node(cmd) if cmd.rpc.is_namespace_enabled(RethRpcModule::Debug))
     }
 }

--- a/rust/op-reth/crates/cli/src/lib.rs
+++ b/rust/op-reth/crates/cli/src/lib.rs
@@ -212,4 +212,54 @@ mod test {
             _ => panic!("unexpected command"),
         }
     }
+
+    /// The `debug` RPC namespace gates whether the runtime-reloadable log filter layer is
+    /// installed (backing `debug_verbosity` / `debug_vmodule`). Guards the wiring in
+    /// `CliApp::init_tracing`, which previously hardcoded `false`.
+    ///
+    /// Note: `is_namespace_enabled` treats IPC (on by default) as exposing every namespace, so
+    /// the negative case must also pass `--ipcdisable`.
+    #[test]
+    fn debug_namespace_gates_log_reload() {
+        // `debug` present in --http.api -> reload enabled
+        let with_debug = Cli::<OpChainSpecParser, RollupArgs>::parse_from([
+            "op-reth",
+            "node",
+            "--http",
+            "--http.api",
+            "eth,debug,net",
+        ]);
+        assert!(with_debug.command.debug_namespace_enabled());
+
+        // `debug` present in --ws.api -> reload enabled
+        let with_debug_ws = Cli::<OpChainSpecParser, RollupArgs>::parse_from([
+            "op-reth", "node", "--ws", "--ws.api", "eth,debug",
+        ]);
+        assert!(with_debug_ws.command.debug_namespace_enabled());
+
+        // no `debug` on http/ws AND IPC disabled -> reload disabled
+        let without_debug = Cli::<OpChainSpecParser, RollupArgs>::parse_from([
+            "op-reth",
+            "node",
+            "--http",
+            "--http.api",
+            "eth,net",
+            "--ipcdisable",
+        ]);
+        assert!(!without_debug.command.debug_namespace_enabled());
+
+        // IPC left enabled (default) exposes all namespaces -> reload enabled
+        let ipc_default = Cli::<OpChainSpecParser, RollupArgs>::parse_from([
+            "op-reth",
+            "node",
+            "--http",
+            "--http.api",
+            "eth,net",
+        ]);
+        assert!(ipc_default.command.debug_namespace_enabled());
+
+        // non-node command -> reload disabled
+        let non_node = Cli::<OpChainSpecParser, RollupArgs>::parse_from(["op-reth", "config"]);
+        assert!(!non_node.command.debug_namespace_enabled());
+    }
 }


### PR DESCRIPTION
# PR: fix(op-reth cli): enable `debug_verbosity`/`debug_vmodule` by gating log reload on the debug namespace

**Target:** `ethereum-optimism/optimism` — `rust/op-reth` (branch `develop`)
**Files:** `rust/op-reth/crates/cli/src/{commands/mod.rs, app.rs, lib.rs}` (+67 / −1)

## Summary

`debug_verbosity` and `debug_vmodule` (runtime log-level control, added upstream in reth [#21497](https://github.com/paradigmxyz/reth/pull/21497)) fail on op-reth even when the `debug` RPC namespace is enabled:

```
$ curl -s $RPC -d '{"jsonrpc":"2.0","id":1,"method":"debug_verbosity","params":[3]}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Log filter reload not available"}}
$ curl -s $RPC -d '{"jsonrpc":"2.0","id":1,"method":"debug_vmodule","params":[""]}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Log filter reload not available"}}
```

geth returns `result: null` for the same calls. Note the code is `-32603` (internal error), **not** `-32601` (method not found) — the methods are registered and served; only the runtime reload handle is missing.

## Root cause

The reloadable log-filter layer that backs these methods is installed only when `RethTracer` is initialized with `enable_reload = true`. The Ethereum CLI wires this to whether the `debug` namespace is served:

```rust
// crates/ethereum/cli — Cli::init_tracing
let enable_reload = self.command.debug_namespace_enabled();
self.logs.init_tracing_with_layers(layers, enable_reload)?;
```

op-reth's CLI (`crates/cli/src/app.rs`) has its own `init_tracing` that hardcodes `false`:

```rust
self.guard = Some(self.cli.logs.init_tracing_with_layers(layers, false)?);
```

So the reload handle is never installed → `reth_tracing::log_handle_available()` stays `false` → `set_log_verbosity`/`set_log_vmodule` return `Err("Log filter reload not available")` → `-32603`. This is an omission when the op-reth CLI was split from the shared init path, not an intentional disable.

## Fix

Mirror the Ethereum CLI: add `Commands::debug_namespace_enabled()` and use it in `init_tracing`.

```rust
// commands/mod.rs
pub fn debug_namespace_enabled(&self) -> bool {
    matches!(self, Self::Node(cmd) if cmd.rpc.is_namespace_enabled(RethRpcModule::Debug))
}
// app.rs
let enable_reload = self.cli.command.debug_namespace_enabled();
self.guard = Some(self.cli.logs.init_tracing_with_layers(layers, enable_reload)?);
```

No `Cargo.toml` change: `reth-rpc-server-types` (providing `RethRpcModule` / `RpcServerArgs::is_namespace_enabled`) is already a dependency of the cli crate.

## Behavior

- `debug` reachable on any transport — incl. IPC, which is on by default and `is_namespace_enabled` treats as exposing every namespace — ⇒ reloadable layer installed ⇒ `debug_verbosity(level)` / `debug_vmodule(pattern)` return `null` and take effect at runtime.
- Otherwise (e.g. `--ipcdisable` and no `debug` in http/ws api) ⇒ unchanged, layer not installed.

## Test

Added `debug_namespace_gates_log_reload` unit test (cli crate): `debug` in `--http.api`, in `--ws.api`, absent + `--ipcdisable` (off), default IPC (on), and non-node command (off).

## Downstream verification

Verified on the Mantle devnet: applying this change flips `debug_verbosity([3])` and `debug_vmodule([""])` from `-32603` to `result: null`, matching op-geth. Reference implementation / evidence: mantle-xyz/reth#94.


Closes #21691
