### PR TITLE
docs: wire rollup-config fields through op-node and kona

### DIFF
--- a/docs/ai/derivation.md
+++ b/docs/ai/derivation.md
@@ -45,6 +45,32 @@ Other recurring concerns:
 - **Safe head advancement**: updating the safe L2 head as derivation progresses.
 - **Reorg handling**: rewinding derivation state on L1 reorgs.
 
+## Rollup config
+
+Both clients derive against a `rollup.Config` (Go) / `RollupConfig` (Rust) loaded from the
+[superchain-registry](https://github.com/ethereum-optimism/superchain-registry). Adding a
+field that comes from the registry means wiring it through **every** ingestion enumeration on
+**both** clients — not just the config struct and the op-deployer/deploy-config
+(`DeployConfig.RollupConfig`) path:
+
+- **op-node (Go)**: the TOML-decoded `superchain.HardforkConfig` (`op-core/superchain`) **and**
+  the `superchain.ChainConfig` → `rollup.Config` conversion in `op-node/rollup/superchain.go`
+  (`applyHardforks` / `rollupConfigFromRegistry`). Miss either and a chain loaded via
+  `--network` silently omits the field.
+- **kona (Rust)**: `HardForkConfig` / `ChainConfig::as_rollup_config`
+  (`rust/kona/crates/protocol/genesis`).
+
+The failure mode is silent: the TOML/serde decoders **drop keys that no struct field models**, so
+a registry field left unwired is read and thrown away with no error. Two guards catch it:
+
+- **Strict decoding** rejects unknown keys — `jsonutil.DecodeTOMLStrict` (Go, used by
+  `op-core/superchain`) and `#[serde(deny_unknown_fields)]` (kona's `ChainConfig` /
+  `HardForkConfig`). A registry bump that adds an unmodeled field then fails to load instead of
+  dropping it.
+- **A reflection completeness test** (`TestRollupConfigFromRegistry_AllFieldsSet`) asserts every
+  `rollup.Config` field is populated from a fully-populated `ChainConfig`, catching a field that
+  is modeled but never copied in the conversion.
+
 ## Invariants
 
 - **Deterministic derivation**: the same L1 data always produces the same L2 chain.

--- a/docs/ai/derivation.md
+++ b/docs/ai/derivation.md
@@ -47,7 +47,8 @@ Other recurring concerns:
 
 ## Rollup config
 
-Both clients derive against a `rollup.Config` (Go) / `RollupConfig` (Rust) loaded from the
+Both clients' derivation rules are configured by consensus parameters in `rollup.Config` (Go) /
+`RollupConfig` (Rust), which can be loaded from the
 [superchain-registry](https://github.com/ethereum-optimism/superchain-registry). Adding a
 field that comes from the registry means wiring it through **every** ingestion enumeration on
 **both** clients — not just the config struct and the op-deployer/deploy-config
@@ -55,18 +56,19 @@ field that comes from the registry means wiring it through **every** ingestion e
 
 - **op-node (Go)**: the TOML-decoded `superchain.HardforkConfig` (`op-core/superchain`) **and**
   the `superchain.ChainConfig` → `rollup.Config` conversion in `op-node/rollup/superchain.go`
-  (`applyHardforks` / `rollupConfigFromRegistry`). Miss either and a chain loaded via
-  `--network` silently omits the field.
+  (`applyHardforks` / `rollupConfigFromRegistry`).
 - **kona (Rust)**: `HardForkConfig` / `ChainConfig::as_rollup_config`
   (`rust/kona/crates/protocol/genesis`).
 
-The failure mode is silent: the TOML/serde decoders **drop keys that no struct field models**, so
-a registry field left unwired is read and thrown away with no error. Two guards catch it:
+Both steps used to drop an unwired field silently — the TOML/serde decoders ignored keys that no
+struct field modeled, and the conversion left the `rollup.Config` field at its zero value — so a
+chain loaded via `--network` derived against a config quietly missing the field. Two guards now
+make that loud:
 
-- **Strict decoding** rejects unknown keys — `jsonutil.DecodeTOMLStrict` (Go, used by
-  `op-core/superchain`) and `#[serde(deny_unknown_fields)]` (kona's `ChainConfig` /
-  `HardForkConfig`). A registry bump that adds an unmodeled field then fails to load instead of
-  dropping it.
+- **Strict decoding** rejects registry keys that no struct field models —
+  `jsonutil.DecodeTOMLStrict` (Go, used by `op-core/superchain`) and
+  `#[serde(deny_unknown_fields)]` (kona's `ChainConfig` / `HardForkConfig`). A registry bump that
+  adds an unmodeled field fails to load until the struct consumes it.
 - **A reflection completeness test** (`TestRollupConfigFromRegistry_AllFieldsSet`) asserts every
   `rollup.Config` field is populated from a fully-populated `ChainConfig`, catching a field that
   is modeled but never copied in the conversion.

--- a/docs/ai/derivation.md
+++ b/docs/ai/derivation.md
@@ -60,10 +60,7 @@ field that comes from the registry means wiring it through **every** ingestion e
 - **kona (Rust)**: `HardForkConfig` / `ChainConfig::as_rollup_config`
   (`rust/kona/crates/protocol/genesis`).
 
-Both steps used to drop an unwired field silently — the TOML/serde decoders ignored keys that no
-struct field modeled, and the conversion left the `rollup.Config` field at its zero value — so a
-chain loaded via `--network` derived against a config quietly missing the field. Two guards now
-make that loud:
+Two guards fail loudly on a field left unwired:
 
 - **Strict decoding** rejects registry keys that no struct field models —
   `jsonutil.DecodeTOMLStrict` (Go, used by `op-core/superchain`) and


### PR DESCRIPTION
Adds a "Rollup config" section to `docs/ai/derivation.md` capturing the lesson from #21566 / #21648.

A rollup-config field that comes from the superchain-registry must be wired through **every** ingestion enumeration on **both** clients — op-node's `superchain.HardforkConfig` + `applyHardforks`/`rollupConfigFromRegistry`, and kona's `HardForkConfig`/`as_rollup_config` — not just the config struct and the deploy-config path. Both steps used to drop an unwired field silently; #21648 added the guards that now make it loud (strict decoding via `jsonutil.DecodeTOMLStrict` / serde `deny_unknown_fields`, plus the reflection completeness test), and the section documents both the wiring and the guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)