### PR TITLE
op-node: expose hardfork activation metrics

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	ophttp "github.com/ethereum-optimism/optimism/op-service/httputil"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 
@@ -28,6 +29,7 @@ const Namespace = "op_node"
 
 type Metricer interface {
 	RecordInfo(version string)
+	RecordHardforkActivationTimes(cfg *rollup.Config)
 	RecordUp()
 	SetDerivationIdle(status bool)
 	SetSequencerState(active bool)
@@ -73,8 +75,9 @@ type Metricer interface {
 
 // Metrics tracks all the metrics for the op-node.
 type Metrics struct {
-	Info *prometheus.GaugeVec
-	Up   prometheus.Gauge
+	Info                   *prometheus.GaugeVec
+	Up                     prometheus.Gauge
+	HardforkActivationTime *prometheus.GaugeVec
 
 	metrics.RPCMetrics
 
@@ -178,6 +181,11 @@ func NewMetrics(procName string, labels prometheus.Labels) *Metrics {
 			Name:      "up",
 			Help:      "1 if the op node has finished starting up",
 		}),
+		HardforkActivationTime: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "hardfork_activation_timestamp",
+			Help:      "Configured hardfork activation timestamp by fork",
+		}, []string{"chain_id", "fork", "activation_basis"}),
 
 		RPCMetrics: metrics.MakeRPCMetrics(ns, factory),
 
@@ -404,6 +412,33 @@ func (m *Metrics) RecordInfo(version string) {
 	m.Info.WithLabelValues(version).Set(1)
 }
 
+func (m *Metrics) RecordHardforkActivationTimes(cfg *rollup.Config) {
+	chainID := ""
+	if cfg.L2ChainID != nil {
+		chainID = cfg.L2ChainID.String()
+	}
+
+	record := func(fork string, ts *uint64, basis string) {
+		if ts == nil {
+			return
+		}
+		m.HardforkActivationTime.WithLabelValues(chainID, fork, basis).Set(float64(*ts))
+	}
+
+	record("regolith", cfg.RegolithTime, "l2_timestamp")
+	record("canyon", cfg.CanyonTime, "l2_timestamp")
+	record("delta", cfg.DeltaTime, "l2_timestamp")
+	record("ecotone", cfg.EcotoneTime, "l2_timestamp")
+	record("fjord", cfg.FjordTime, "l2_timestamp")
+	record("granite", cfg.GraniteTime, "l2_timestamp")
+	record("holocene", cfg.HoloceneTime, "l2_timestamp")
+	record("isthmus", cfg.IsthmusTime, "l2_timestamp")
+	record("jovian", cfg.JovianTime, "l2_timestamp")
+	record("karst", cfg.KarstTime, "l2_timestamp")
+	record("lagoon", cfg.LagoonTime, "l2_timestamp")
+	record("pectra_blob_schedule", cfg.PectraBlobScheduleTime, "l1_origin_timestamp")
+}
+
 // RecordUp sets the up metric to 1.
 func (m *Metrics) RecordUp() {
 	m.Up.Set(1)
@@ -610,6 +645,9 @@ type noopMetricer struct {
 var NoopMetrics Metricer = new(noopMetricer)
 
 func (n *noopMetricer) RecordInfo(version string) {
+}
+
+func (n *noopMetricer) RecordHardforkActivationTimes(cfg *rollup.Config) {
 }
 
 func (n *noopMetricer) RecordUp() {

--- a/op-node/metrics/metrics_test.go
+++ b/op-node/metrics/metrics_test.go
@@ -1,0 +1,57 @@
+package metrics
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordHardforkActivationTimes(t *testing.T) {
+	canyon := uint64(1_708_534_401)
+	pectraBlobSchedule := uint64(1_748_666_000)
+	jovian := uint64(1_900_000_000)
+
+	m := NewMetrics("test", nil)
+	m.RecordHardforkActivationTimes(&rollup.Config{
+		L2ChainID:              big.NewInt(10),
+		CanyonTime:             &canyon,
+		PectraBlobScheduleTime: &pectraBlobSchedule,
+		JovianTime:             &jovian,
+	})
+
+	got, err := gatherHardforkActivationTimes(m)
+	require.NoError(t, err)
+	require.Equal(t, map[string]float64{
+		"10/canyon/l2_timestamp":                      float64(canyon),
+		"10/pectra_blob_schedule/l1_origin_timestamp": float64(pectraBlobSchedule),
+		"10/jovian/l2_timestamp":                      float64(jovian),
+	}, got)
+}
+
+func gatherHardforkActivationTimes(m *Metrics) (map[string]float64, error) {
+	mfs, err := m.registry.Gather()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]float64)
+	for _, mf := range mfs {
+		if mf.GetName() != "op_node_test_hardfork_activation_timestamp" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			out[hardforkActivationMetricKey(metric)] = metric.GetGauge().GetValue()
+		}
+	}
+	return out, nil
+}
+
+func hardforkActivationMetricKey(metric *io_prometheus_client.Metric) string {
+	labels := make(map[string]string)
+	for _, label := range metric.GetLabel() {
+		labels[label.GetName()] = label.GetValue()
+	}
+	return labels["chain_id"] + "/" + labels["fork"] + "/" + labels["activation_basis"]
+}

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -297,6 +297,7 @@ func (n *OpNode) init(ctx context.Context, cfg *config.Config, overrides Initial
 	}
 
 	n.metrics.RecordInfo(n.appVersion)
+	n.metrics.RecordHardforkActivationTimes(&cfg.Rollup)
 	n.metrics.RecordUp()
 
 	n.pprofService, err = initPProf(cfg, n)


### PR DESCRIPTION
## Summary

- add an `op_node_*_hardfork_activation_timestamp` gauge labeled by `chain_id`, `fork`, and `activation_basis`
- record configured op-node hardfork activation times during startup
- cover configured L2 timestamp forks and the L1-origin based Pectra blob schedule field with a focused metrics test

## Motivation

This gives dashboards a direct schedule source for upcoming OP Stack hardforks without polling `optimism_rollupConfig` out of band. Dashboards can compare this metric with existing `op_node_*_refs_time` L2 reference timestamp metrics to show countdowns.

## Validation

- `go test ./op-node/metrics -run TestRecordHardforkActivationTimes -count=1`
- `JUST_UNSTABLE=1 just sync-superchain`
- `go test ./op-node/metrics ./op-node/node`