### PR TITLE
op-node: expose hardfork activation metrics

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -419,12 +419,12 @@ func (m *Metrics) RecordHardforkActivationTimes(cfg *rollup.Config) {
 		chainID = cfg.L2ChainID.String()
 	}
 
-	cfg.ForEachFork(func(_ string, logName string, basis rollup.ForkActivationBasis, ts *uint64) {
-		if ts == nil {
+	cfg.ForEachFork(func(fork rollup.Fork) {
+		if fork.Time == nil {
 			return
 		}
-		fork := strings.TrimSuffix(logName, "_time")
-		m.HardforkActivationTime.WithLabelValues(chainID, fork, string(basis)).Set(float64(*ts))
+		label := strings.TrimSuffix(fork.LogName, "_time")
+		m.HardforkActivationTime.WithLabelValues(chainID, label, string(fork.Basis)).Set(float64(*fork.Time))
 	})
 	if cfg.KeepKarstUpgradeGas && cfg.KarstTime != nil {
 		// Behavioral opt-out flag, not a scheduled fork: reported only when set, valued at the

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
@@ -418,25 +419,18 @@ func (m *Metrics) RecordHardforkActivationTimes(cfg *rollup.Config) {
 		chainID = cfg.L2ChainID.String()
 	}
 
-	record := func(fork string, ts *uint64, basis string) {
+	cfg.ForEachFork(func(_ string, logName string, basis rollup.ForkActivationBasis, ts *uint64) {
 		if ts == nil {
 			return
 		}
-		m.HardforkActivationTime.WithLabelValues(chainID, fork, basis).Set(float64(*ts))
+		fork := strings.TrimSuffix(logName, "_time")
+		m.HardforkActivationTime.WithLabelValues(chainID, fork, string(basis)).Set(float64(*ts))
+	})
+	if cfg.KeepKarstUpgradeGas && cfg.KarstTime != nil {
+		// Behavioral opt-out flag, not a scheduled fork: reported only when set, valued at the
+		// Karst activation time it modifies. Absence of the series means the flag is unset.
+		m.HardforkActivationTime.WithLabelValues(chainID, "keep_karst_upgrade_gas", string(rollup.L2TimestampBasis)).Set(float64(*cfg.KarstTime))
 	}
-
-	record("regolith", cfg.RegolithTime, "l2_timestamp")
-	record("canyon", cfg.CanyonTime, "l2_timestamp")
-	record("delta", cfg.DeltaTime, "l2_timestamp")
-	record("ecotone", cfg.EcotoneTime, "l2_timestamp")
-	record("fjord", cfg.FjordTime, "l2_timestamp")
-	record("granite", cfg.GraniteTime, "l2_timestamp")
-	record("holocene", cfg.HoloceneTime, "l2_timestamp")
-	record("isthmus", cfg.IsthmusTime, "l2_timestamp")
-	record("jovian", cfg.JovianTime, "l2_timestamp")
-	record("karst", cfg.KarstTime, "l2_timestamp")
-	record("lagoon", cfg.LagoonTime, "l2_timestamp")
-	record("pectra_blob_schedule", cfg.PectraBlobScheduleTime, "l1_origin_timestamp")
 }
 
 // RecordUp sets the up metric to 1.

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"net"
 	"strconv"
-	"strings"
 	"time"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
@@ -419,17 +418,29 @@ func (m *Metrics) RecordHardforkActivationTimes(cfg *rollup.Config) {
 		chainID = cfg.L2ChainID.String()
 	}
 
-	cfg.ForEachFork(func(fork rollup.Fork) {
-		if fork.Time == nil {
+	record := func(fork string, ts *uint64, basis string) {
+		if ts == nil {
 			return
 		}
-		label := strings.TrimSuffix(fork.LogName, "_time")
-		m.HardforkActivationTime.WithLabelValues(chainID, label, string(fork.Basis)).Set(float64(*fork.Time))
-	})
+		m.HardforkActivationTime.WithLabelValues(chainID, fork, basis).Set(float64(*ts))
+	}
+
+	record("regolith", cfg.RegolithTime, "l2_timestamp")
+	record("canyon", cfg.CanyonTime, "l2_timestamp")
+	record("delta", cfg.DeltaTime, "l2_timestamp")
+	record("ecotone", cfg.EcotoneTime, "l2_timestamp")
+	record("fjord", cfg.FjordTime, "l2_timestamp")
+	record("granite", cfg.GraniteTime, "l2_timestamp")
+	record("holocene", cfg.HoloceneTime, "l2_timestamp")
+	record("isthmus", cfg.IsthmusTime, "l2_timestamp")
+	record("jovian", cfg.JovianTime, "l2_timestamp")
+	record("karst", cfg.KarstTime, "l2_timestamp")
+	record("lagoon", cfg.LagoonTime, "l2_timestamp")
+	record("pectra_blob_schedule", cfg.PectraBlobScheduleTime, "l1_origin_timestamp")
 	if cfg.KeepKarstUpgradeGas && cfg.KarstTime != nil {
 		// Behavioral opt-out flag, not a scheduled fork: reported only when set, valued at the
 		// Karst activation time it modifies. Absence of the series means the flag is unset.
-		m.HardforkActivationTime.WithLabelValues(chainID, "keep_karst_upgrade_gas", string(rollup.L2TimestampBasis)).Set(float64(*cfg.KarstTime))
+		record("keep_karst_upgrade_gas", cfg.KarstTime, "l2_timestamp")
 	}
 }
 

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	ophttp "github.com/ethereum-optimism/optimism/op-service/httputil"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 
@@ -28,6 +29,7 @@ const Namespace = "op_node"
 
 type Metricer interface {
 	RecordInfo(version string)
+	RecordHardforkActivationTimes(cfg *rollup.Config)
 	RecordUp()
 	SetDerivationIdle(status bool)
 	SetSequencerState(active bool)
@@ -73,8 +75,9 @@ type Metricer interface {
 
 // Metrics tracks all the metrics for the op-node.
 type Metrics struct {
-	Info *prometheus.GaugeVec
-	Up   prometheus.Gauge
+	Info                   *prometheus.GaugeVec
+	Up                     prometheus.Gauge
+	HardforkActivationTime *prometheus.GaugeVec
 
 	metrics.RPCMetrics
 
@@ -178,6 +181,11 @@ func NewMetrics(procName string, labels prometheus.Labels) *Metrics {
 			Name:      "up",
 			Help:      "1 if the op node has finished starting up",
 		}),
+		HardforkActivationTime: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "hardfork_activation_timestamp",
+			Help:      "Configured hardfork activation timestamp by fork",
+		}, []string{"chain_id", "fork", "activation_basis"}),
 
 		RPCMetrics: metrics.MakeRPCMetrics(ns, factory),
 
@@ -404,6 +412,33 @@ func (m *Metrics) RecordInfo(version string) {
 	m.Info.WithLabelValues(version).Set(1)
 }
 
+func (m *Metrics) RecordHardforkActivationTimes(cfg *rollup.Config) {
+	chainID := ""
+	if cfg.L2ChainID != nil {
+		chainID = cfg.L2ChainID.String()
+	}
+
+	record := func(fork string, ts *uint64, basis string) {
+		if ts == nil {
+			return
+		}
+		m.HardforkActivationTime.WithLabelValues(chainID, fork, basis).Set(float64(*ts))
+	}
+
+	record("regolith", cfg.RegolithTime, "l2_timestamp")
+	record("canyon", cfg.CanyonTime, "l2_timestamp")
+	record("delta", cfg.DeltaTime, "l2_timestamp")
+	record("ecotone", cfg.EcotoneTime, "l2_timestamp")
+	record("fjord", cfg.FjordTime, "l2_timestamp")
+	record("granite", cfg.GraniteTime, "l2_timestamp")
+	record("holocene", cfg.HoloceneTime, "l2_timestamp")
+	record("isthmus", cfg.IsthmusTime, "l2_timestamp")
+	record("jovian", cfg.JovianTime, "l2_timestamp")
+	record("karst", cfg.KarstTime, "l2_timestamp")
+	record("lagoon", cfg.LagoonTime, "l2_timestamp")
+	record("pectra_blob_schedule", cfg.PectraBlobScheduleTime, "l1_origin_timestamp")
+}
+
 // RecordUp sets the up metric to 1.
 func (m *Metrics) RecordUp() {
 	m.Up.Set(1)
@@ -610,6 +645,9 @@ type noopMetricer struct {
 var NoopMetrics Metricer = new(noopMetricer)
 
 func (n *noopMetricer) RecordInfo(version string) {
+}
+
+func (n *noopMetricer) RecordHardforkActivationTimes(cfg *rollup.Config) {
 }
 
 func (n *noopMetricer) RecordUp() {

--- a/op-node/metrics/metrics_test.go
+++ b/op-node/metrics/metrics_test.go
@@ -31,6 +31,36 @@ func TestRecordHardforkActivationTimes(t *testing.T) {
 	}, got)
 }
 
+func TestRecordHardforkActivationTimesKeepKarstUpgradeGas(t *testing.T) {
+	karst := uint64(1_950_000_000)
+
+	m := NewMetrics("test", nil)
+	m.RecordHardforkActivationTimes(&rollup.Config{
+		L2ChainID:           big.NewInt(10),
+		KarstTime:           &karst,
+		KeepKarstUpgradeGas: true,
+	})
+
+	got, err := gatherHardforkActivationTimes(m)
+	require.NoError(t, err)
+	require.Equal(t, map[string]float64{
+		"10/karst/l2_timestamp":                  float64(karst),
+		"10/keep_karst_upgrade_gas/l2_timestamp": float64(karst),
+	}, got)
+
+	// Flag unset: no keep_karst_upgrade_gas series is emitted.
+	m2 := NewMetrics("test", nil)
+	m2.RecordHardforkActivationTimes(&rollup.Config{
+		L2ChainID: big.NewInt(10),
+		KarstTime: &karst,
+	})
+	got2, err := gatherHardforkActivationTimes(m2)
+	require.NoError(t, err)
+	require.Equal(t, map[string]float64{
+		"10/karst/l2_timestamp": float64(karst),
+	}, got2)
+}
+
 func gatherHardforkActivationTimes(m *Metrics) (map[string]float64, error) {
 	mfs, err := m.registry.Gather()
 	if err != nil {

--- a/op-node/metrics/metrics_test.go
+++ b/op-node/metrics/metrics_test.go
@@ -1,0 +1,57 @@
+package metrics
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordHardforkActivationTimes(t *testing.T) {
+	canyon := uint64(1_708_534_401)
+	pectraBlobSchedule := uint64(1_748_666_000)
+	jovian := uint64(1_900_000_000)
+
+	m := NewMetrics("test", nil)
+	m.RecordHardforkActivationTimes(&rollup.Config{
+		L2ChainID:              big.NewInt(10),
+		CanyonTime:             &canyon,
+		PectraBlobScheduleTime: &pectraBlobSchedule,
+		JovianTime:             &jovian,
+	})
+
+	got, err := gatherHardforkActivationTimes(m)
+	require.NoError(t, err)
+	require.Equal(t, map[string]float64{
+		"10/canyon/l2_timestamp":                      float64(canyon),
+		"10/pectra_blob_schedule/l1_origin_timestamp": float64(pectraBlobSchedule),
+		"10/jovian/l2_timestamp":                      float64(jovian),
+	}, got)
+}
+
+func gatherHardforkActivationTimes(m *Metrics) (map[string]float64, error) {
+	mfs, err := m.registry.Gather()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]float64)
+	for _, mf := range mfs {
+		if mf.GetName() != "op_node_test_hardfork_activation_timestamp" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			out[hardforkActivationMetricKey(metric)] = metric.GetGauge().GetValue()
+		}
+	}
+	return out, nil
+}
+
+func hardforkActivationMetricKey(metric *io_prometheus_client.Metric) string {
+	labels := make(map[string]string)
+	for _, label := range metric.GetLabel() {
+		labels[label.GetName()] = label.GetValue()
+	}
+	return labels["chain_id"] + "/" + labels["fork"] + "/" + labels["activation_basis"]
+}

--- a/op-node/metrics/metrics_test.go
+++ b/op-node/metrics/metrics_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/prometheus/client_model/go"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -297,6 +297,7 @@ func (n *OpNode) init(ctx context.Context, cfg *config.Config, overrides Initial
 	}
 
 	n.metrics.RecordInfo(n.appVersion)
+	n.metrics.RecordHardforkActivationTimes(&cfg.Rollup)
 	n.metrics.RecordUp()
 
 	n.pprofService, err = initPProf(cfg, n)

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -835,8 +835,8 @@ func (c *Config) Description(l2Chains map[string]string) string {
 	banner += fmt.Sprintf("  L1 block: %s %d\n", c.Genesis.L1.Hash, c.Genesis.L1.Number)
 	// Report the upgrade configuration
 	banner += "Post-Bedrock Network Upgrades (timestamp based):\n"
-	c.ForEachFork(func(fork Fork) {
-		banner += fmt.Sprintf("  - %v: %s\n", fork.Name, fmtForkTimeOrUnset(fork.Time))
+	c.forEachFork(func(name string, _ string, time *uint64) {
+		banner += fmt.Sprintf("  - %v: %s\n", name, fmtForkTimeOrUnset(time))
 	})
 	if c.KeepKarstUpgradeGas {
 		// Only reported when set, since it is an opt-out behavioral flag, not a scheduled time.
@@ -876,8 +876,8 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"l1_block_hash", c.Genesis.L1.Hash.String(),
 		"l1_block_number", c.Genesis.L1.Number,
 	}
-	c.ForEachFork(func(fork Fork) {
-		ctx = append(ctx, fork.LogName, fmtForkTimeOrUnset(fork.Time))
+	c.forEachFork(func(_ string, logName string, time *uint64) {
+		ctx = append(ctx, logName, fmtForkTimeOrUnset(time))
 	})
 	if c.KeepKarstUpgradeGas {
 		// Only reported when set, since it is an opt-out behavioral flag, not a scheduled time.
@@ -889,48 +889,22 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 	log.Info("Rollup Config", ctx...)
 }
 
-// ForkActivationBasis describes which timestamp a fork activation time is compared against.
-type ForkActivationBasis string
-
-const (
-	// L2TimestampBasis marks forks that activate based on the L2 block timestamp.
-	L2TimestampBasis ForkActivationBasis = "l2_timestamp"
-	// L1OriginTimestampBasis marks forks that activate based on the L1 origin block timestamp.
-	L1OriginTimestampBasis ForkActivationBasis = "l1_origin_timestamp"
-)
-
-// Fork describes a scheduled hardfork and its configured activation time.
-// New fork metadata belongs here as a field, so the ForEachFork callback signature stays stable.
-type Fork struct {
-	// Name is the human-readable fork name, e.g. "Regolith".
-	Name string
-	// LogName is the snake_case key used in logs and metric labels, e.g. "regolith_time".
-	LogName string
-	// Basis is the timestamp the activation time is compared against.
-	Basis ForkActivationBasis
-	// Time is the configured activation time, or nil if unscheduled.
-	Time *uint64
-}
-
-// ForEachFork invokes the callback for each hardfork in activation order. This is the canonical
-// list of forks — callers that report or inspect fork configuration should use it rather than
-// enumerating fork fields themselves.
-func (c *Config) ForEachFork(callback func(fork Fork)) {
-	callback(Fork{"Regolith", "regolith_time", L2TimestampBasis, c.RegolithTime})
-	callback(Fork{"Canyon", "canyon_time", L2TimestampBasis, c.CanyonTime})
-	callback(Fork{"Delta", "delta_time", L2TimestampBasis, c.DeltaTime})
-	callback(Fork{"Ecotone", "ecotone_time", L2TimestampBasis, c.EcotoneTime})
-	callback(Fork{"Fjord", "fjord_time", L2TimestampBasis, c.FjordTime})
-	callback(Fork{"Granite", "granite_time", L2TimestampBasis, c.GraniteTime})
-	callback(Fork{"Holocene", "holocene_time", L2TimestampBasis, c.HoloceneTime})
+func (c *Config) forEachFork(callback func(name string, logName string, time *uint64)) {
+	callback("Regolith", "regolith_time", c.RegolithTime)
+	callback("Canyon", "canyon_time", c.CanyonTime)
+	callback("Delta", "delta_time", c.DeltaTime)
+	callback("Ecotone", "ecotone_time", c.EcotoneTime)
+	callback("Fjord", "fjord_time", c.FjordTime)
+	callback("Granite", "granite_time", c.GraniteTime)
+	callback("Holocene", "holocene_time", c.HoloceneTime)
 	if c.PectraBlobScheduleTime != nil {
 		// only report if config is set
-		callback(Fork{"Pectra Blob Schedule", "pectra_blob_schedule_time", L1OriginTimestampBasis, c.PectraBlobScheduleTime})
+		callback("Pectra Blob Schedule", "pectra_blob_schedule_time", c.PectraBlobScheduleTime)
 	}
-	callback(Fork{"Isthmus", "isthmus_time", L2TimestampBasis, c.IsthmusTime})
-	callback(Fork{"Jovian", "jovian_time", L2TimestampBasis, c.JovianTime})
-	callback(Fork{"Karst", "karst_time", L2TimestampBasis, c.KarstTime})
-	callback(Fork{"Lagoon", "lagoon_time", L2TimestampBasis, c.LagoonTime})
+	callback("Isthmus", "isthmus_time", c.IsthmusTime)
+	callback("Jovian", "jovian_time", c.JovianTime)
+	callback("Karst", "karst_time", c.KarstTime)
+	callback("Lagoon", "lagoon_time", c.LagoonTime)
 }
 
 func (c *Config) ParseRollupConfig(in io.Reader) error {

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -835,8 +835,8 @@ func (c *Config) Description(l2Chains map[string]string) string {
 	banner += fmt.Sprintf("  L1 block: %s %d\n", c.Genesis.L1.Hash, c.Genesis.L1.Number)
 	// Report the upgrade configuration
 	banner += "Post-Bedrock Network Upgrades (timestamp based):\n"
-	c.ForEachFork(func(name string, _ string, _ ForkActivationBasis, time *uint64) {
-		banner += fmt.Sprintf("  - %v: %s\n", name, fmtForkTimeOrUnset(time))
+	c.ForEachFork(func(fork Fork) {
+		banner += fmt.Sprintf("  - %v: %s\n", fork.Name, fmtForkTimeOrUnset(fork.Time))
 	})
 	if c.KeepKarstUpgradeGas {
 		// Only reported when set, since it is an opt-out behavioral flag, not a scheduled time.
@@ -876,8 +876,8 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"l1_block_hash", c.Genesis.L1.Hash.String(),
 		"l1_block_number", c.Genesis.L1.Number,
 	}
-	c.ForEachFork(func(_ string, logName string, _ ForkActivationBasis, time *uint64) {
-		ctx = append(ctx, logName, fmtForkTimeOrUnset(time))
+	c.ForEachFork(func(fork Fork) {
+		ctx = append(ctx, fork.LogName, fmtForkTimeOrUnset(fork.Time))
 	})
 	if c.KeepKarstUpgradeGas {
 		// Only reported when set, since it is an opt-out behavioral flag, not a scheduled time.
@@ -899,25 +899,38 @@ const (
 	L1OriginTimestampBasis ForkActivationBasis = "l1_origin_timestamp"
 )
 
+// Fork describes a scheduled hardfork and its configured activation time.
+// New fork metadata belongs here as a field, so the ForEachFork callback signature stays stable.
+type Fork struct {
+	// Name is the human-readable fork name, e.g. "Regolith".
+	Name string
+	// LogName is the snake_case key used in logs and metric labels, e.g. "regolith_time".
+	LogName string
+	// Basis is the timestamp the activation time is compared against.
+	Basis ForkActivationBasis
+	// Time is the configured activation time, or nil if unscheduled.
+	Time *uint64
+}
+
 // ForEachFork invokes the callback for each hardfork in activation order. This is the canonical
 // list of forks — callers that report or inspect fork configuration should use it rather than
 // enumerating fork fields themselves.
-func (c *Config) ForEachFork(callback func(name string, logName string, basis ForkActivationBasis, time *uint64)) {
-	callback("Regolith", "regolith_time", L2TimestampBasis, c.RegolithTime)
-	callback("Canyon", "canyon_time", L2TimestampBasis, c.CanyonTime)
-	callback("Delta", "delta_time", L2TimestampBasis, c.DeltaTime)
-	callback("Ecotone", "ecotone_time", L2TimestampBasis, c.EcotoneTime)
-	callback("Fjord", "fjord_time", L2TimestampBasis, c.FjordTime)
-	callback("Granite", "granite_time", L2TimestampBasis, c.GraniteTime)
-	callback("Holocene", "holocene_time", L2TimestampBasis, c.HoloceneTime)
+func (c *Config) ForEachFork(callback func(fork Fork)) {
+	callback(Fork{"Regolith", "regolith_time", L2TimestampBasis, c.RegolithTime})
+	callback(Fork{"Canyon", "canyon_time", L2TimestampBasis, c.CanyonTime})
+	callback(Fork{"Delta", "delta_time", L2TimestampBasis, c.DeltaTime})
+	callback(Fork{"Ecotone", "ecotone_time", L2TimestampBasis, c.EcotoneTime})
+	callback(Fork{"Fjord", "fjord_time", L2TimestampBasis, c.FjordTime})
+	callback(Fork{"Granite", "granite_time", L2TimestampBasis, c.GraniteTime})
+	callback(Fork{"Holocene", "holocene_time", L2TimestampBasis, c.HoloceneTime})
 	if c.PectraBlobScheduleTime != nil {
 		// only report if config is set
-		callback("Pectra Blob Schedule", "pectra_blob_schedule_time", L1OriginTimestampBasis, c.PectraBlobScheduleTime)
+		callback(Fork{"Pectra Blob Schedule", "pectra_blob_schedule_time", L1OriginTimestampBasis, c.PectraBlobScheduleTime})
 	}
-	callback("Isthmus", "isthmus_time", L2TimestampBasis, c.IsthmusTime)
-	callback("Jovian", "jovian_time", L2TimestampBasis, c.JovianTime)
-	callback("Karst", "karst_time", L2TimestampBasis, c.KarstTime)
-	callback("Lagoon", "lagoon_time", L2TimestampBasis, c.LagoonTime)
+	callback(Fork{"Isthmus", "isthmus_time", L2TimestampBasis, c.IsthmusTime})
+	callback(Fork{"Jovian", "jovian_time", L2TimestampBasis, c.JovianTime})
+	callback(Fork{"Karst", "karst_time", L2TimestampBasis, c.KarstTime})
+	callback(Fork{"Lagoon", "lagoon_time", L2TimestampBasis, c.LagoonTime})
 }
 
 func (c *Config) ParseRollupConfig(in io.Reader) error {

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -835,7 +835,7 @@ func (c *Config) Description(l2Chains map[string]string) string {
 	banner += fmt.Sprintf("  L1 block: %s %d\n", c.Genesis.L1.Hash, c.Genesis.L1.Number)
 	// Report the upgrade configuration
 	banner += "Post-Bedrock Network Upgrades (timestamp based):\n"
-	c.forEachFork(func(name string, _ string, time *uint64) {
+	c.ForEachFork(func(name string, _ string, _ ForkActivationBasis, time *uint64) {
 		banner += fmt.Sprintf("  - %v: %s\n", name, fmtForkTimeOrUnset(time))
 	})
 	if c.KeepKarstUpgradeGas {
@@ -876,7 +876,7 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"l1_block_hash", c.Genesis.L1.Hash.String(),
 		"l1_block_number", c.Genesis.L1.Number,
 	}
-	c.forEachFork(func(_ string, logName string, time *uint64) {
+	c.ForEachFork(func(_ string, logName string, _ ForkActivationBasis, time *uint64) {
 		ctx = append(ctx, logName, fmtForkTimeOrUnset(time))
 	})
 	if c.KeepKarstUpgradeGas {
@@ -889,22 +889,35 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 	log.Info("Rollup Config", ctx...)
 }
 
-func (c *Config) forEachFork(callback func(name string, logName string, time *uint64)) {
-	callback("Regolith", "regolith_time", c.RegolithTime)
-	callback("Canyon", "canyon_time", c.CanyonTime)
-	callback("Delta", "delta_time", c.DeltaTime)
-	callback("Ecotone", "ecotone_time", c.EcotoneTime)
-	callback("Fjord", "fjord_time", c.FjordTime)
-	callback("Granite", "granite_time", c.GraniteTime)
-	callback("Holocene", "holocene_time", c.HoloceneTime)
+// ForkActivationBasis describes which timestamp a fork activation time is compared against.
+type ForkActivationBasis string
+
+const (
+	// L2TimestampBasis marks forks that activate based on the L2 block timestamp.
+	L2TimestampBasis ForkActivationBasis = "l2_timestamp"
+	// L1OriginTimestampBasis marks forks that activate based on the L1 origin block timestamp.
+	L1OriginTimestampBasis ForkActivationBasis = "l1_origin_timestamp"
+)
+
+// ForEachFork invokes the callback for each hardfork in activation order. This is the canonical
+// list of forks — callers that report or inspect fork configuration should use it rather than
+// enumerating fork fields themselves.
+func (c *Config) ForEachFork(callback func(name string, logName string, basis ForkActivationBasis, time *uint64)) {
+	callback("Regolith", "regolith_time", L2TimestampBasis, c.RegolithTime)
+	callback("Canyon", "canyon_time", L2TimestampBasis, c.CanyonTime)
+	callback("Delta", "delta_time", L2TimestampBasis, c.DeltaTime)
+	callback("Ecotone", "ecotone_time", L2TimestampBasis, c.EcotoneTime)
+	callback("Fjord", "fjord_time", L2TimestampBasis, c.FjordTime)
+	callback("Granite", "granite_time", L2TimestampBasis, c.GraniteTime)
+	callback("Holocene", "holocene_time", L2TimestampBasis, c.HoloceneTime)
 	if c.PectraBlobScheduleTime != nil {
 		// only report if config is set
-		callback("Pectra Blob Schedule", "pectra_blob_schedule_time", c.PectraBlobScheduleTime)
+		callback("Pectra Blob Schedule", "pectra_blob_schedule_time", L1OriginTimestampBasis, c.PectraBlobScheduleTime)
 	}
-	callback("Isthmus", "isthmus_time", c.IsthmusTime)
-	callback("Jovian", "jovian_time", c.JovianTime)
-	callback("Karst", "karst_time", c.KarstTime)
-	callback("Lagoon", "lagoon_time", c.LagoonTime)
+	callback("Isthmus", "isthmus_time", L2TimestampBasis, c.IsthmusTime)
+	callback("Jovian", "jovian_time", L2TimestampBasis, c.JovianTime)
+	callback("Karst", "karst_time", L2TimestampBasis, c.KarstTime)
+	callback("Lagoon", "lagoon_time", L2TimestampBasis, c.LagoonTime)
 }
 
 func (c *Config) ParseRollupConfig(in io.Reader) error {


### PR DESCRIPTION
## Summary

- add an `op_node_*_hardfork_activation_timestamp` gauge labeled by `chain_id`, `fork`, and `activation_basis`
- record configured op-node hardfork activation times during startup
- cover configured L2 timestamp forks and the L1-origin based Pectra blob schedule field with a focused metrics test

## Motivation

This gives dashboards a direct schedule source for upcoming OP Stack hardforks without polling `optimism_rollupConfig` out of band. Dashboards can compare this metric with existing `op_node_*_refs_time` L2 reference timestamp metrics to show countdowns.

## Local validation Against OP-Sepolia

```
export L1_RPC_URLS=<l1-sepolia-urls>

tmp=$(mktemp -d)
openssl rand -hex 32 > "$tmp/jwt.hex"

docker rm -f op-reth-smoke >/dev/null 2>&1 || true

docker run -d \
  --name op-reth-smoke \
  -p 8551:8551 \
  -p 8545:8545 \
  -p 9001:9001 \
  -v "$tmp/jwt.hex:/jwt.hex:ro" \
  -v op-reth-smoke-db:/db \
  us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:develop \
  node \
  --datadir /db \
  --chain optimism-sepolia \
  --rollup.sequencer-http https://sepolia-sequencer.optimism.io/ \
  --metrics 0.0.0.0:9001 \
  --authrpc.addr 0.0.0.0 \
  --authrpc.port 8551 \
  --authrpc.jwtsecret /jwt.hex \
  --http \
  --http.addr 0.0.0.0 \
  --http.port 8545 \
  --http.api eth,net,web3,debug

until curl -sS --max-time 1 \
  -H 'content-type: application/json' \
  --data '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}' \
  http://127.0.0.1:8551 2>&1 | grep -q 'Authorization header'
do
  sleep 0.5
done

./op-node/bin/op-node \
  --network op-sepolia \
  --l1 "$L1_RPC_URLS" \
  --l1.beacon.ignore=true \
  --l2 http://127.0.0.1:8551 \
  --l2.jwt-secret "$tmp/jwt.hex" \
  --p2p.disable=true \
  --rpc.addr 127.0.0.1 \
  --rpc.port 19545 \
  --metrics.enabled=true \
  --metrics.addr 127.0.0.1 \
  --metrics.port 7300
  ```
  
 ```
curl -fsS http://127.0.0.1:7300/metrics | rg 'op_node_default_hardfork_activation_timestamp'
# HELP op_node_default_hardfork_activation_timestamp Configured hardfork activation timestamp by fork
# TYPE op_node_default_hardfork_activation_timestamp gauge
op_node_default_hardfork_activation_timestamp{activation_basis="l1_origin_timestamp",chain_id="11155420",fork="pectra_blob_schedule"} 1.7424864e+09
op_node_default_hardfork_activation_timestamp{activation_basis="l2_timestamp",chain_id="11155420",fork="canyon"} 1.6999812e+09
op_node_default_hardfork_activation_timestamp{activation_basis="l2_timestamp",chain_id="11155420",fork="delta"} 1.7032032e+09
op_node_default_hardfork_activation_timestamp{activation_basis="l2_timestamp",chain_id="11155420",fork="ecotone"} 1.7085348e+09
op_node_default_hardfork_activation_timestamp{activation_basis="l2_timestamp",chain_id="11155420",fork="fjord"} 1.7169984e+09
op_node_default_hardfork_activation_timestamp{activation_basis="l2_timestamp",chain_id="11155420",fork="granite"} 1.7234784e+09
op_node_default_hardfork_activation_timestamp{activation_basis="l2_timestamp",chain_id="11155420",fork="holocene"} 1.7326332e+09
op_node_default_hardfork_activation_timestamp{activation_basis="l2_timestamp",chain_id="11155420",fork="isthmus"} 1.7449056e+09
op_node_default_hardfork_activation_timestamp{activation_basis="l2_timestamp",chain_id="11155420",fork="jovian"} 1.763568001e+09
op_node_default_hardfork_activation_timestamp{activation_basis="l2_timestamp",chain_id="11155420",fork="karst"} 1.781712001e+09
op_node_default_hardfork_activation_timestamp{activation_basis="l2_timestamp",chain_id="11155420",fork="regolith"} 0
  ```