### PR TITLE
feat(op-reth): expose chain hardfork activation metrics

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13192,6 +13192,8 @@ dependencies = [
  "derive_more 2.1.1",
  "eyre",
  "futures-util",
+ "metrics",
+ "metrics-exporter-prometheus",
  "op-alloy-consensus",
  "page_size",
  "proptest",

--- a/rust/op-rbuilder/Cargo.lock
+++ b/rust/op-rbuilder/Cargo.lock
@@ -11052,6 +11052,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures-util",
+ "metrics",
  "op-alloy-consensus",
  "page_size",
  "reth-chainspec",

--- a/rust/op-reth/crates/cli/Cargo.toml
+++ b/rust/op-reth/crates/cli/Cargo.toml
@@ -32,6 +32,7 @@ reth-fs-util.workspace = true
 
 # so jemalloc metrics can be included
 reth-node-metrics.workspace = true
+metrics.workspace = true
 
 ## optimism
 reth-optimism-primitives.workspace = true
@@ -74,6 +75,7 @@ op-alloy-consensus.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 reth-stages = { workspace = true, features = ["test-utils"] }
+metrics-exporter-prometheus.workspace = true
 
 [build-dependencies]
 reth-optimism-chainspec = { workspace = true, features = ["std", "superchain-configs"] }
@@ -125,4 +127,3 @@ serde = [
     "reth-primitives-traits/serde",
     "reth-optimism-chainspec/serde",
 ]
-

--- a/rust/op-reth/crates/cli/src/app.rs
+++ b/rust/op-reth/crates/cli/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{Cli, Commands};
+use crate::{Cli, Commands, metrics::register_hardfork_activation_metrics};
 use eyre::{Result, eyre};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::launcher::Launcher;
@@ -68,6 +68,9 @@ where
 
         // Install the prometheus recorder to be sure to record all metrics
         install_prometheus_recorder();
+        if let Some(chain_spec) = self.cli.command.chain_spec() {
+            register_hardfork_activation_metrics(chain_spec);
+        }
 
         let components = |spec: Arc<OpChainSpec>| {
             (OpExecutorProvider::optimism(spec.clone()), Arc::new(OpBeaconConsensus::new(spec)))

--- a/rust/op-reth/crates/cli/src/lib.rs
+++ b/rust/op-reth/crates/cli/src/lib.rs
@@ -14,6 +14,8 @@ pub mod app;
 pub mod chainspec;
 /// Optimism CLI commands.
 pub mod commands;
+/// Optimism CLI metrics.
+pub mod metrics;
 /// Module with a codec for reading and encoding receipts in files.
 ///
 /// Enables decoding and encoding `OpGethReceipt` type. See <https://github.com/testinprod-io/op-geth/pull/1>.

--- a/rust/op-reth/crates/cli/src/metrics.rs
+++ b/rust/op-reth/crates/cli/src/metrics.rs
@@ -1,0 +1,93 @@
+//! Metrics registered by the OP-Reth CLI.
+
+use metrics::{describe_gauge, gauge};
+use reth_chainspec::{ForkCondition, Hardforks};
+use reth_optimism_chainspec::{OpChainSpec, OpHardfork};
+
+const HARDFORK_ACTIVATION: &str = "chain_hardfork_activation";
+
+/// Registers activation metrics for the configured chain's L2 (OP Stack) hardforks.
+///
+/// Only [`OpHardfork`] variants are reported; the underlying L1 (Ethereum) hardforks are omitted.
+pub fn register_hardfork_activation_metrics(chain_spec: &OpChainSpec) {
+    describe_gauge!(
+        HARDFORK_ACTIVATION,
+        "Configured chain L2 hardfork activation block or timestamp"
+    );
+
+    for hardfork in OpHardfork::VARIANTS {
+        let Some((activation_basis, value)) = activation(&chain_spec.fork(*hardfork)) else {
+            continue;
+        };
+
+        // Lowercase to match op-node's fork label values (e.g. "canyon").
+        gauge!(
+            HARDFORK_ACTIVATION,
+            "fork" => hardfork.name().to_lowercase(),
+            "activation_basis" => activation_basis
+        )
+        .set(value as f64);
+    }
+}
+
+const fn activation(condition: &ForkCondition) -> Option<(&'static str, u64)> {
+    match condition {
+        ForkCondition::Block(block) => Some(("block", *block)),
+        ForkCondition::TTD { activation_block_number, .. } => {
+            Some(("block", *activation_block_number))
+        }
+        ForkCondition::Timestamp(timestamp) => Some(("timestamp", *timestamp)),
+        ForkCondition::Never => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrics_exporter_prometheus::PrometheusBuilder;
+    use reth_chainspec::{ChainHardforks, EthereumHardfork, ForkCondition, Hardfork};
+    use reth_node_metrics::recorder::try_install_prometheus_recorder_with_builder;
+    use reth_optimism_chainspec::{OP_DEV, OpChainSpecBuilder, OpHardfork};
+
+    #[test]
+    fn registers_only_l2_hardfork_activation_metrics() {
+        let recorder = try_install_prometheus_recorder_with_builder(PrometheusBuilder::new())
+            .unwrap_or_else(|_| reth_node_metrics::recorder::install_prometheus_recorder());
+
+        let chain_spec = OpChainSpecBuilder::default()
+            .chain(OP_DEV.chain)
+            .genesis(OP_DEV.genesis.clone())
+            .with_forks(ChainHardforks::new(vec![
+                // An L1 fork that must not be reported.
+                (EthereumHardfork::Shanghai.boxed(), ForkCondition::Timestamp(20)),
+                (OpHardfork::Bedrock.boxed(), ForkCondition::Block(10)),
+                (OpHardfork::Canyon.boxed(), ForkCondition::Timestamp(30)),
+                (OpHardfork::Regolith.boxed(), ForkCondition::Never),
+            ]))
+            .build();
+
+        register_hardfork_activation_metrics(&chain_spec);
+
+        let exposition = recorder.handle().render();
+        assert!(
+            exposition.contains(
+                r#"reth_chain_hardfork_activation{fork="bedrock",activation_basis="block"} 10"#
+            ),
+            "{exposition}"
+        );
+        assert!(
+            exposition.contains(
+                r#"reth_chain_hardfork_activation{fork="canyon",activation_basis="timestamp"} 30"#
+            ),
+            "{exposition}"
+        );
+        assert!(
+            !exposition.contains(r#"fork="regolith""#),
+            "Never forks must be omitted: {exposition}"
+        );
+        assert!(
+            !exposition.contains(r#"fork="shanghai""#),
+            "L1 (Ethereum) forks must be omitted: {exposition}"
+        );
+    }
+}

--- a/rust/rollup-boost/Cargo.lock
+++ b/rust/rollup-boost/Cargo.lock
@@ -9088,6 +9088,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures-util",
+ "metrics",
  "op-alloy-consensus",
  "page_size",
  "reth-chainspec",


### PR DESCRIPTION
## Description

Registers a `chain_hardfork_activation` gauge from the configured chain spec so the **L2 (OP Stack) hardfork** schedule op-reth is running with is observable in Prometheus (exposed as `reth_chain_hardfork_activation`).

- Only `OpHardfork` variants are reported (bedrock, regolith, canyon, ecotone, fjord, granite, holocene, isthmus, jovian, karst). The underlying L1 (Ethereum) hardforks are intentionally omitted.
- Labeled by `fork` (lowercased fork name, e.g. `canyon`, to match op-node's label values) and `activation_basis` (`block` or `timestamp`).
- `ForkCondition::Never` forks are omitted.
- Registered in the CLI after the Prometheus recorder is installed, using the command's chain spec.

## Tests

- Unit test renders the Prometheus exposition and asserts OP forks are emitted with correct labels, that `Never` forks are excluded, and that an L1 (Ethereum) fork is **not** reported.
- `cargo nextest run -p reth-optimism-cli metrics` passes.

## Smoke test

Booted `op-reth node --chain <chain> --metrics 0.0.0.0:9001` from this branch and scraped the metrics endpoint. The gauge is populated from the chain spec at startup (before node launch), so no op-node / L1 / sync is required. Each chain emits exactly 10 L2 forks; no L1 forks appear.

Timestamp-based OP fork activations (bedrock is block-based; EL coupling verified: shanghai↔canyon etc. are collapsed to the OP name):

| fork | op-mainnet | op-sepolia | zora | unichain |
|------|-----------:|-----------:|-----:|---------:|
| bedrock (block) | 105235063 | 0 | 0 | 0 |
| regolith  | 0 | 0 | 0 | 0 |
| canyon    | 1704992401 | 1699981200 | 1704992401 | 0 |
| ecotone   | 1710374401 | 1708534800 | 1710374401 | 0 |
| fjord     | 1720627201 | 1716998400 | 1720627201 | 0 |
| granite   | 1726070401 | 1723478400 | 1726070401 | 0 |
| holocene  | 1736445601 | 1732633200 | 1736445601 | 1736445601 |
| isthmus   | 1746806401 | 1744905600 | 1746806401 | 1746806401 |
| jovian    | 1764691201 | 1763568001 | 1764691201 | 1764691201 |
| karst     | 1783526401 | 1781712001 | 1783526401 | 1783526401 |

(unichain launched with canyon–granite already active, so they report `0`.)

Example exposition (`op-mainnet`):

```
reth_chain_hardfork_activation{fork="bedrock",activation_basis="block"} 105235063
reth_chain_hardfork_activation{fork="regolith",activation_basis="timestamp"} 0
reth_chain_hardfork_activation{fork="canyon",activation_basis="timestamp"} 1704992401
reth_chain_hardfork_activation{fork="ecotone",activation_basis="timestamp"} 1710374401
reth_chain_hardfork_activation{fork="fjord",activation_basis="timestamp"} 1720627201
reth_chain_hardfork_activation{fork="granite",activation_basis="timestamp"} 1726070401
reth_chain_hardfork_activation{fork="holocene",activation_basis="timestamp"} 1736445601
reth_chain_hardfork_activation{fork="isthmus",activation_basis="timestamp"} 1746806401
reth_chain_hardfork_activation{fork="jovian",activation_basis="timestamp"} 1764691201
reth_chain_hardfork_activation{fork="karst",activation_basis="timestamp"} 1783526401
```

> Note: `op-mainnet` refuses to fully launch without the imported pre-Bedrock state, so its metrics were captured during the startup window (the gauge is registered before that check). `op-sepolia`, `zora`, and `unichain` ran to a steady node.
