### PR TITLE
docs: add NodeFlare to the OP Stack RPC directory

### DIFF
--- a/docs/public-docs/app-developers/reference/rpc-providers.mdx
+++ b/docs/public-docs/app-developers/reference/rpc-providers.mdx
@@ -169,6 +169,14 @@ The following providers offer production-grade RPC access to OP Stack networks. 
 
 **Supported Mainnets**: OP Mainnet, Base, Lisk
 
+### NodeFlare
+
+**Description**: [NodeFlare](https://nodeflare.app) offers [free public endpoints (no API key) and a free keyed tier](https://nodeflare.app/chains) served from its own multi-region bare-metal nodes for the following networks:
+
+**Supported Testnets**: None
+
+**Supported Mainnets**: OP Mainnet, Base, Unichain, Soneium, Ink, Mode, BoB, Zircuit
+
 ### Nodies DLB
 
 **Description**: [Nodies DLB](https://www.nodies.app/) offers [free and paid plans](https://www.nodies.app/pricing) for the following [networks](https://docs.nodies.app/overview/supported-blockchains):


### PR DESCRIPTION
Adds NodeFlare to the RPC directory (`docs/public-docs/app-developers/reference/rpc-providers.mdx`) per the directory governance section — provider-submitted PR, alphabetical placement.

NodeFlare runs its own multi-region bare-metal nodes for 8 OP-Stack(-derived) mainnets — OP Mainnet, Base, Unichain, Soneium, Ink, Mode, BOB and Zircuit — each with a free public endpoint (no API key, e.g. `https://rpc.nodeflare.app/op/public`) and a free keyed tier including `eth_getLogs` and debug/trace methods. All endpoints are live and verifiable via `eth_chainId`.

