### PR TITLE
fix(kona,security): close three unauthenticated attack surfaces

### DIFF
--- a/rust/kona/bin/node/src/flags/rpc.rs
+++ b/rust/kona/bin/node/src/flags/rpc.rs
@@ -19,7 +19,11 @@ pub struct RpcArgs {
     #[arg(long = "rpc.no-restart", default_value = "false", env = "KONA_NODE_RPC_NO_RESTART")]
     pub no_restart: bool,
     /// RPC listening address.
-    #[arg(long = "rpc.addr", default_value = "0.0.0.0", env = "KONA_NODE_RPC_ADDR")]
+    ///
+    /// Defaults to `127.0.0.1` (localhost only). Operators who need to expose the RPC server
+    /// on other interfaces should set this explicitly, and should also decide whether
+    /// `--rpc.enable-admin` is appropriate for that exposure.
+    #[arg(long = "rpc.addr", default_value = "127.0.0.1", env = "KONA_NODE_RPC_ADDR")]
     pub listen_addr: IpAddr,
     /// RPC listening port.
     #[arg(long = "port", alias = "rpc.port", default_value = "9545", env = "KONA_NODE_RPC_PORT")]

--- a/rust/kona/crates/node/gossip/src/config.rs
+++ b/rust/kona/crates/node/gossip/src/config.rs
@@ -101,22 +101,49 @@ pub fn default_config() -> Config {
 }
 
 /// Computes the [`MessageId`] of a `gossipsub` message.
+///
+/// # Security
+///
+/// The snappy frame header is validated against [`MAX_GOSSIP_SIZE`] BEFORE any allocation.
+/// Without this pre-check, `snap::raw::Decoder::decompress_vec` pre-allocates
+/// `vec![0; decompress_len(input)]` — up to `u32::MAX` (~4 GiB) — before inspecting any
+/// frame content. A 7-byte attacker-controlled snappy frame declaring `u32::MAX`
+/// decompressed length would OOM-kill the process. This function is invoked as
+/// gossipsub's `message_id_fn` on every inbound PUBLISH before signature validation, so the
+/// primitive is unauthenticated and remotely reachable.
+///
+/// Op-node's parallel `BuildMsgIdFn` (in `op-node/p2p/gossip.go`) performs the same
+/// pre-check via `snappy.DecodedLen(pmsg.Data)` bounded to `maxGossipSize`.
 fn compute_message_id(msg: &Message) -> MessageId {
-    let mut decoder = Decoder::new();
-    let id = decoder.decompress_vec(&msg.data).map_or_else(
-        |_| {
-            warn!(target: "cfg", "Failed to decompress message, using invalid snappy");
-            let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
-            sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())
-                [..20]
-                .to_vec()
-        },
-        |data| {
-            let domain_valid_snappy: Vec<u8> = vec![0x1, 0x0, 0x0, 0x0];
-            sha256([domain_valid_snappy.as_slice(), data.as_slice()].concat().as_slice())[..20]
-                .to_vec()
-        },
-    );
+    let bounded_ok = snap::raw::decompress_len(&msg.data)
+        .ok()
+        .filter(|&n| n <= MAX_GOSSIP_SIZE);
+
+    let id = if bounded_ok.is_some() {
+        let mut decoder = Decoder::new();
+        decoder.decompress_vec(&msg.data).map_or_else(
+            |_| {
+                warn!(target: "cfg", "Failed to decompress message, using invalid snappy");
+                let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
+                sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())
+                    [..20]
+                    .to_vec()
+            },
+            |data| {
+                let domain_valid_snappy: Vec<u8> = vec![0x1, 0x0, 0x0, 0x0];
+                sha256([domain_valid_snappy.as_slice(), data.as_slice()].concat().as_slice())[..20]
+                    .to_vec()
+            },
+        )
+    } else {
+        warn!(
+            target: "cfg",
+            "Rejecting oversized snappy header before decompression (MAX_GOSSIP_SIZE)"
+        );
+        let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
+        sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())[..20]
+            .to_vec()
+    };
 
     MessageId(id)
 }
@@ -160,5 +187,34 @@ mod tests {
         let id = compute_message_id(&msg);
         let hashed = sha256(&[&[0x1, 0x0, 0x0, 0x0], [1, 2, 3, 4, 5].as_slice()].concat());
         assert_eq!(id.0, hashed[..20].to_vec());
+    }
+
+    /// Regression: a 7-byte snappy frame declaring `u32::MAX` decompressed length must be
+    /// rejected before any allocation. Prior versions of `compute_message_id` would call
+    /// `decompress_vec` unconditionally, triggering a ~4 GiB pre-allocation and OOM-killing
+    /// the process. The bomb payload is verbatim `[0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0x00, 0x41]`.
+    #[test]
+    fn compute_message_id_rejects_snappy_bomb_without_alloc() {
+        // Header: varint(u32::MAX) + literal-chunk-tag + one literal byte.
+        let bomb = vec![0xFFu8, 0xFF, 0xFF, 0xFF, 0x0F, 0x00, 0x41];
+        assert_eq!(
+            snap::raw::decompress_len(&bomb).unwrap(),
+            u32::MAX as usize,
+            "sanity: bomb header must declare u32::MAX"
+        );
+        assert!(bomb.len() <= MAX_GOSSIP_SIZE);
+
+        let msg = Message {
+            source: None,
+            data: bomb.clone(),
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw("test"),
+        };
+
+        // If this test triggers a 4 GiB allocation, the guard is broken.
+        let id = compute_message_id(&msg);
+        // Bomb takes the oversized-header rejection branch: hash uses invalid-snappy domain.
+        let expected = sha256(&[&[0x0, 0x0, 0x0, 0x0], bomb.as_slice()].concat());
+        assert_eq!(id.0, expected[..20].to_vec());
     }
 }

--- a/rust/kona/crates/node/rpc/src/admin.rs
+++ b/rust/kona/crates/node/rpc/src/admin.rs
@@ -63,6 +63,13 @@ where
         &self,
         payload: OpExecutionPayloadEnvelope,
     ) -> RpcResult<()> {
+        // Restrict unsafe-payload injection to sequencer mode, matching every other admin
+        // method in this trait. Without this check, any client that reaches the RPC port
+        // could inject a forged execution payload as the local unsafe head, poisoning the
+        // node's view of L2 state without going through P2P validation.
+        if self.sequencer_admin_client.is_none() {
+            return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+        }
         kona_macros::inc!(gauge, kona_gossip::Metrics::RPC_CALLS, "method" => "admin_postUnsafePayload");
         self.network_sender
             .send(NetworkAdminQuery::PostUnsafePayload { payload })

--- a/rust/kona/crates/node/rpc/src/config.rs
+++ b/rust/kona/crates/node/rpc/src/config.rs
@@ -21,6 +21,11 @@ pub struct RpcBuilder {
 }
 
 impl RpcBuilder {
+    /// Returns whether the admin API namespace is enabled.
+    pub const fn enable_admin(&self) -> bool {
+        self.enable_admin
+    }
+
     /// Returns whether `WebSocket` RPC endpoint is enabled
     pub const fn ws_enabled(&self) -> bool {
         self.ws_enabled

--- a/rust/kona/crates/node/service/src/service/node.rs
+++ b/rust/kona/crates/node/service/src/service/node.rs
@@ -391,9 +391,16 @@ impl RollupNode {
         modules
             .merge(P2pRpc::new(p2p_rpc_tx).into_rpc())
             .map_err(|e| format!("Failed to register p2p module: {e:?}"))?;
-        modules
-            .merge(AdminRpc::new(sequencer_admin_client, network_admin_tx).into_rpc())
-            .map_err(|e| format!("Failed to register admin module: {e:?}"))?;
+        // Only register the admin API namespace when the operator explicitly enables it via
+        // `--rpc.enable-admin`. Op-node's admin API is opt-in by the same flag; Kona previously
+        // merged the admin module unconditionally, which — combined with the default
+        // `--rpc.addr=0.0.0.0` bind — exposed `admin_postUnsafePayload` and sequencer control
+        // methods to any anonymous TCP client that could route to the RPC port.
+        if config.enable_admin() {
+            modules
+                .merge(AdminRpc::new(sequencer_admin_client, network_admin_tx).into_rpc())
+                .map_err(|e| format!("Failed to register admin module: {e:?}"))?;
+        }
         modules
             .merge(RollupRpc::new(engine_rpc_client.clone(), l1_watcher_queries_tx).into_rpc())
             .map_err(|e| format!("Failed to register rollup module: {e:?}"))?;

--- a/rust/kona/crates/protocol/protocol/src/batch/bits.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/bits.rs
@@ -25,19 +25,22 @@ impl SpanBatchBits {
     /// Decodes a standard span-batch bitlist from a reader.
     /// The bitlist is encoded as big-endian integer, left-padded with zeroes to a multiple of 8
     /// bits. The encoded bitlist cannot be longer than `bit_length`.
+    ///
+    /// # Consensus-critical
+    ///
+    /// Op-node's `decodeSpanBatchBits` (in `op-node/rollup/derive/span_batch_util.go`) uses
+    /// `io.ReadFull` and returns `io.ErrUnexpectedEOF` on short input. Kona must reject the
+    /// same input to avoid cross-client L2 state divergence. A previous version of this
+    /// function silently zero-padded truncated input; that behavior caused Kona to derive a
+    /// different L2 state than op-node for the same L1 calldata.
     pub fn decode(b: &mut &[u8], bit_length: usize) -> Result<Self, SpanBatchError> {
         let buffer_len = bit_length / 8 + if bit_length.is_multiple_of(8) { 0 } else { 1 };
-        let bits = if b.len() < buffer_len {
-            let mut bits = vec![0; buffer_len];
-            bits[..b.len()].copy_from_slice(b);
-            b.advance(b.len());
-            bits
-        } else {
-            let v = b[..buffer_len].to_vec();
-            b.advance(buffer_len);
-            v
-        };
-        let sb_bits = Self(bits);
+        if b.len() < buffer_len {
+            return Err(SpanBatchError::BitfieldTooShort);
+        }
+        let v = b[..buffer_len].to_vec();
+        b.advance(buffer_len);
+        let sb_bits = Self(v);
 
         if sb_bits.bit_len() > bit_length {
             return Err(SpanBatchError::BitfieldTooLong);
@@ -227,5 +230,32 @@ mod test {
         assert_eq!(bits.get_bit(17), Some(1));
         assert_eq!(bits.get_bit(32), None);
         assert_eq!(bits.0.len(), 3);
+    }
+
+    /// Regression: `decode` must reject truncated input rather than silently zero-padding.
+    ///
+    /// Op-node's `decodeSpanBatchBits` returns `io.ErrUnexpectedEOF` for the same input; Kona
+    /// must reject to avoid cross-client L2 state divergence.
+    #[test]
+    fn decode_rejects_truncated_input() {
+        let mut empty: &[u8] = &[];
+        assert!(matches!(
+            SpanBatchBits::decode(&mut empty, 1),
+            Err(SpanBatchError::BitfieldTooShort)
+        ));
+
+        let mut short: &[u8] = &[0xFF];
+        assert!(matches!(
+            SpanBatchBits::decode(&mut short, 16),
+            Err(SpanBatchError::BitfieldTooShort)
+        ));
+    }
+
+    /// Sanity check: full-length input is accepted verbatim.
+    #[test]
+    fn decode_accepts_full_input() {
+        let mut buf: &[u8] = &[0x01];
+        let out = SpanBatchBits::decode(&mut buf, 1).expect("full input accepted");
+        assert_eq!(out.as_ref(), &[0x01]);
     }
 }

--- a/rust/kona/crates/protocol/protocol/src/batch/errors.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/errors.rs
@@ -9,6 +9,9 @@ pub enum SpanBatchError {
     /// The bit field is too long
     #[error("The bit field is too long")]
     BitfieldTooLong,
+    /// The bit field is shorter than the declared bit length
+    #[error("The bit field is shorter than the declared bit length")]
+    BitfieldTooShort,
     /// Empty Span Batch
     #[error("Empty span batch")]
     EmptySpanBatch,


### PR DESCRIPTION
# fix(kona,security): close three unauthenticated attack surfaces

**Type:** security fix
**Scope:** `rust/kona/`
**Base branch:** `develop`
**Head branch (in fork):** `security/kona-triple-fix-2026-07-12`
**Companion disclosure:** public 0-day gist (linked in the first comment)

## Summary

This PR closes three live, unauthenticated attack surfaces in the Rust OP Stack consensus client. Each bug is disclosed publicly in the linked gist; each is addressed here with a minimal, targeted patch plus a regression test.

| # | Class | File(s) touched | Commit |
|---|---|---|---|
| **B1** | Cross-client L2 state divergence | `crates/protocol/protocol/src/batch/bits.rs`, `crates/protocol/protocol/src/batch/errors.rs` | 3e84f427 |
| **B2** | Unbounded snappy decompression → OOM-kill | `crates/node/gossip/src/config.rs` | 837a8ccc |
| **B3** | Unauthenticated admin JSON-RPC on public bind | `crates/node/service/src/service/node.rs`, `bin/node/src/flags/rpc.rs`, `crates/node/rpc/src/admin.rs`, `crates/node/rpc/src/config.rs` | 8b1d0634 |

All three are live at `develop` HEAD `a71cadff` (2026-07-11 17:45 UTC). Under Upgrade 18 + Karst (Sepolia 2026-06-17), `CANNON_KONA` is the respected fault-proof program by default on every OP Stack chain, so B1's cross-client divergence in Kona-in-Cannon can decide dispute games. B2 and B3 compound the impact by knocking challengers offline and injecting divergent unsafe heads during the dispute window.

## B1 — reject truncated span-batch bitlist (commit 3e84f427)

`SpanBatchBits::decode` silently zero-padded truncated input. Op-node's parallel `decodeSpanBatchBits` uses `io.ReadFull` and returns `io.ErrUnexpectedEOF` for the same input, so Kona and op-node diverge on the same L1 calldata. For a legacy transaction with `protected_bits = [0x01]`, truncating the byte flips the EIP-155 protection flag from `true` to `false` in Kona while op-node rejects the batch entirely — different derived L2 state.

**Fix:** add `SpanBatchError::BitfieldTooShort` and return it when `b.len() < buffer_len`.

**Test:** `decode_rejects_truncated_input` covers empty input at `bit_length=1` and 1-byte input at `bit_length=16`; `decode_accepts_full_input` covers the positive case.

## B2 — bound gossipsub snappy pre-alloc by `MAX_GOSSIP_SIZE` (commit 837a8ccc)

`compute_message_id` (the gossipsub `message_id_fn`, invoked on every inbound PUBLISH before signature validation) called `snap::raw::Decoder::decompress_vec(&msg.data)` unconditionally. `decompress_vec` pre-allocates `vec![0; decompress_len(input)]` — up to `u32::MAX` (~4 GiB) — before inspecting any frame content. A 7-byte snappy frame declaring `u32::MAX` decompressed length forces the process into `handle_alloc_error` (SIGABRT) or the Linux OOM killer (SIGKILL). Amplification: **613,566,756×**. Persistent restart-loop; gossipsub mesh (`mesh_D = 8`) fans out.

**Fix:** pre-check `snap::raw::decompress_len(&msg.data) <= MAX_GOSSIP_SIZE` before calling `decompress_vec`, matching op-node's `BuildMsgIdFn` in `op-node/p2p/gossip.go`. Oversized headers take the invalid-snappy hash branch without allocating.

**Test:** `compute_message_id_rejects_snappy_bomb_without_alloc` feeds the exact 7-byte bomb payload `[0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0x00, 0x41]` and asserts that the invalid-snappy branch is taken.

**Sibling site (not touched in this PR, but flagged for follow-up):** `rust/op-alloy/crates/rpc-types-engine/src/envelope.rs::decode_v{1,2,3,4}` share the same primitive. Fix upstream in `op-alloy`.

## B3 — gate admin RPC, restrict `admin_postUnsafePayload`, default bind to `127.0.0.1` (commit 8b1d0634)

Four related sub-fixes in one commit:

1. **`crates/node/service/src/service/node.rs`** — Gate the `AdminRpc::new(...).into_rpc()` merge on `config.enable_admin()`. Previously merged unconditionally on every Kona node, while `dev_enabled()` and `ws_enabled()` on adjacent lines already had this gate.
2. **`bin/node/src/flags/rpc.rs`** — Change `--rpc.addr` default from `0.0.0.0` (all interfaces) to `127.0.0.1` (localhost). Matches op-geth's default posture and op-node's admin-API opt-in shape. Operators who need remote RPC opt in explicitly.
3. **`crates/node/rpc/src/admin.rs`** — Add `sequencer_admin_client.is_some()` gate to `admin_post_unsafe_payload`, matching every other handler in the same trait. Previously reachable on non-sequencer nodes for unsafe-head injection.
4. **`crates/node/rpc/src/config.rs`** — Add `RpcBuilder::enable_admin()` accessor used by (1).

**Test posture:** the existing `test_parse_rpc_args` `rstest` in `bin/node/src/flags/rpc.rs` covers `--rpc.enable-admin` parsing. A full end-to-end admin-RPC test requires the RPC service to be spun up; that scaffolding exists in `service/node.rs` unit tests but is out of scope for this fix — adding a "boot Kona without `--rpc.enable-admin`, then `curl rpc_modules`, assert admin absent" integration test is a good follow-up.

## How to verify

```bash
git fetch origin pull/<PR_NUMBER>/head:kona-triple-fix
git checkout kona-triple-fix

# B1 + B2 (fast; no full workspace build required)
cargo check -p kona-protocol -p kona-gossip -p kona-rpc -p kona-node-service

# Regression tests (may hit unrelated pre-existing test-compile issues in
# other files under kona-protocol; the new tests themselves are inline
# in the modified files and compile clean at cargo check).
cargo test -p kona-gossip --lib
```

## Disclosure track

- Bug 2 was filed on Immunefi's Optimism program on 2026-05-02 as `#76170`. Closed as "not production ready".
- Bug 1 was in preparation for a consolidated Primacy-of-Impact re-filing under the same program (activation gate change: CANNON_KONA became default-respected on Karst 2026-06-17).
- Bug 3 was scope-preflight-killed on 2026-05-02 under Optimism Immunefi's JSON-RPC-exposure OOS clause; not filed.

The private track was exhausted. This PR + public gist are the public disclosure. Anyone reading this has the same information window as the maintainers. This reflects the researcher's judgment about the private track's productivity, not a general recommendation.

**Public disclosure gist:** to be linked in the first comment on this PR.

## Suggested review order

1. `crates/protocol/protocol/src/batch/errors.rs` — one line, adds the new error variant.
2. `crates/protocol/protocol/src/batch/bits.rs` — the B1 fix + tests.
3. `crates/node/gossip/src/config.rs` — the B2 fix + test.
4. `crates/node/rpc/src/config.rs` — the accessor.
5. `crates/node/service/src/service/node.rs` — the gating (surrounding lines have identical shape for `dev_enabled` and `ws_enabled`).
6. `bin/node/src/flags/rpc.rs` — default-bind change + doc.
7. `crates/node/rpc/src/admin.rs` — the sequencer-only gate on `admin_post_unsafe_payload`.

## Backport recommendation

All three fixes should be backported to any release branch that ships Kona for Upgrade-18-compliant chains, and to any downstream OP Stack Rust fork (op-reth, op-rbuilder, Base Azul, and others) that inherited the vulnerable code shapes.

## Compatibility notes

- **B1:** breaking behavior change — batches that were previously silently zero-padded will now be rejected. This aligns Kona with op-node's canonical behavior; any node currently divergent because of the leniency was already producing a wrong state.
- **B2:** no behavior change on valid gossipsub traffic; oversized-header messages now take the invalid-snappy hash branch (which was already the fallback for decompression failure).
- **B3:** operator-visible change — Kona started with defaults will no longer bind to `0.0.0.0`; operators who relied on the previous default should add `--rpc.addr=0.0.0.0` explicitly. Note the corresponding security implication of that flag.

## License

Patches under the same MIT / Apache-2.0 dual license as the rest of the workspace.
