### PR TITLE
op-service: serialize call fee caps

### DIFF
--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -567,6 +567,12 @@ func ToCallArg(msg ethereum.CallMsg) interface{} {
 	if msg.GasPrice != nil {
 		arg["gasPrice"] = (*hexutil.Big)(msg.GasPrice)
 	}
+	if msg.GasFeeCap != nil {
+		arg["maxFeePerGas"] = (*hexutil.Big)(msg.GasFeeCap)
+	}
+	if msg.GasTipCap != nil {
+		arg["maxPriorityFeePerGas"] = (*hexutil.Big)(msg.GasTipCap)
+	}
 	if msg.AccessList != nil {
 		arg["accessList"] = msg.AccessList
 	}

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -104,6 +104,36 @@ func randHeader() (*types.Header, *RPCHeader) {
 	return hdr, rhdr
 }
 
+func TestToCallArgIncludesFeeFields(t *testing.T) {
+	to := common.Address{0x01}
+	accessList := types.AccessList{
+		{Address: common.Address{0x02}, StorageKeys: []common.Hash{{0x03}}},
+	}
+	msg := ethereum.CallMsg{
+		From:       common.Address{0x04},
+		To:         &to,
+		Gas:        123_456,
+		GasPrice:   big.NewInt(1),
+		GasFeeCap:  big.NewInt(2),
+		GasTipCap:  big.NewInt(3),
+		Value:      big.NewInt(4),
+		Data:       []byte{0x05, 0x06},
+		AccessList: accessList,
+	}
+
+	arg, ok := ToCallArg(msg).(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, msg.From, arg["from"])
+	require.Equal(t, msg.To, arg["to"])
+	require.Equal(t, hexutil.Uint64(msg.Gas), arg["gas"])
+	require.Equal(t, (*hexutil.Big)(msg.GasPrice), arg["gasPrice"])
+	require.Equal(t, (*hexutil.Big)(msg.GasFeeCap), arg["maxFeePerGas"])
+	require.Equal(t, (*hexutil.Big)(msg.GasTipCap), arg["maxPriorityFeePerGas"])
+	require.Equal(t, (*hexutil.Big)(msg.Value), arg["value"])
+	require.Equal(t, hexutil.Bytes(msg.Data), arg["data"])
+	require.Equal(t, accessList, arg["accessList"])
+}
+
 func TestEthClient_InfoByHash(t *testing.T) {
 	m := new(mockRPC)
 	_, rhdr := randHeader()

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -389,8 +389,6 @@ func WithReader(cl Reader) Option {
 		tx.Read.DependOn(
 			&tx.Sender,
 			&tx.To,
-			&tx.GasFeeCap,
-			&tx.GasTipCap,
 			&tx.Value,
 			&tx.Data,
 			&tx.AccessList,
@@ -402,8 +400,8 @@ func WithReader(cl Reader) Option {
 				To:         tx.To.Value(),
 				Gas:        0, // auto estimated by the node
 				GasPrice:   nil,
-				GasFeeCap:  tx.GasFeeCap.Value(),
-				GasTipCap:  tx.GasTipCap.Value(),
+				GasFeeCap:  nil,
+				GasTipCap:  nil,
 				Value:      tx.Value.Value(),
 				Data:       tx.Data.Value(),
 				AccessList: tx.AccessList.Value(),

--- a/op-service/txplan/txplan_test.go
+++ b/op-service/txplan/txplan_test.go
@@ -6,10 +6,13 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 func TestPlannedTx_Defaults(t *testing.T) {
@@ -48,4 +51,50 @@ func TestPlannedTx_Defaults(t *testing.T) {
 
 		require.Equal(t, big.NewInt(42), tx.Value())
 	}
+}
+
+type mockReader struct {
+	msg         ethereum.CallMsg
+	blockNumber rpc.BlockNumber
+}
+
+func (m *mockReader) Call(_ context.Context, msg ethereum.CallMsg, blockNumber rpc.BlockNumber) ([]byte, error) {
+	m.msg = msg
+	m.blockNumber = blockNumber
+	return []byte{0x01}, nil
+}
+
+func TestWithReaderDoesNotUseDefaultFeeCaps(t *testing.T) {
+	reader := new(mockReader)
+	to := common.Address{0x01}
+	from := common.Address{0x02}
+	accessList := types.AccessList{
+		{Address: common.Address{0x03}, StorageKeys: []common.Hash{{0x04}}},
+	}
+	block := types.NewBlock(&types.Header{Number: big.NewInt(7), BaseFee: big.NewInt(8)}, nil, nil, nil, types.DefaultBlockConfig)
+
+	ptx := NewPlannedTx(
+		WithReader(reader),
+		WithSender(from),
+		WithTo(&to),
+		WithValue(eth.WeiU64(9)),
+		WithData([]byte{0x0a}),
+	)
+	ptx.AccessList.Set(accessList)
+	ptx.AgainstBlock.Set(eth.BlockToInfo(block))
+
+	output, err := ptx.Read.Eval(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x01}, output)
+
+	require.Equal(t, from, reader.msg.From)
+	require.Equal(t, &to, reader.msg.To)
+	require.Zero(t, reader.msg.Gas)
+	require.Nil(t, reader.msg.GasPrice)
+	require.Nil(t, reader.msg.GasFeeCap)
+	require.Nil(t, reader.msg.GasTipCap)
+	require.Equal(t, big.NewInt(9), reader.msg.Value)
+	require.Equal(t, []byte{0x0a}, reader.msg.Data)
+	require.Equal(t, accessList, reader.msg.AccessList)
+	require.Equal(t, rpc.BlockNumber(7), reader.blockNumber)
 }


### PR DESCRIPTION
Summary
- serialize maxFeePerGas and maxPriorityFeePerGas in sources.EthClient call args
- keep txplan read-only eth_call requests from inheriting default EIP-1559 fee caps
- add coverage for call arg fee serialization and read call fee fields

This keeps eth_estimateGas requests from dropping EIP-1559 fee caps before they reach the RPC client, while avoiding default txplan fees on read-only eth_call requests.

Validation
- mise exec -- just build-superchain-go
- mise exec -- go test ./op-service/sources ./op-service/txplan