### PR TITLE
Remove op-geth CI variants

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2566,24 +2566,6 @@ workflows:
             - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
-      # IN-MEMORY (all) - op-node/op-geth
-      - op-acceptance-tests:
-          name: memory-all-opn-op-geth
-          parallelism: 2
-          acceptance_test_jobs: "8"
-          no_output_timeout: 120m
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-            - discord
-          requires:
-            - contracts-bedrock-build
-            - cannon-prestate
-            - rust-binaries-for-sysgo
-            - go-binaries-for-sysgo
-            - prep-go-modules
-            # for the gitignored superchain-configs.zip op-acceptance-tests //go:embeds
-            - prep-superchain
       # IN-MEMORY - op-node/op-reth
       - op-acceptance-tests:
           name: memory-all-opn-op-reth
@@ -2635,7 +2617,6 @@ workflows:
             - semgrep-scan-local: terminal
             - semgrep-test: terminal
             - go-tests-short: terminal
-            - memory-all-opn-op-geth: terminal
             - memory-all-opn-op-reth: terminal
             - memory-all-kona-op-reth: terminal
             # Go test/lint jobs previously fanned in via the bedrock-go-tests helper.

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -226,7 +226,7 @@ workflows:
           matrix:
             parameters:
               devnet_config:
-                ["simple-kona", "simple-kona-geth", "simple-kona-sequencer"]
+                ["simple-kona", "simple-kona-sequencer"]
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
@@ -261,7 +261,6 @@ workflows:
       - required-rust-e2e:
           requires:
             - rust-e2e-simple-kona: terminal
-            - rust-e2e-simple-kona-geth: terminal
             - rust-e2e-simple-kona-sequencer: terminal
             - rust-e2e-restart: terminal
             - op-reth-e2e-sysgo-tests: terminal


### PR DESCRIPTION
Removes the remaining op-geth CI variants from the CircleCI continuation configs:

- Drops `memory-all-opn-op-geth` from the main workflow and `ci-gate` fan-in.
- Drops `simple-kona-geth` from the rust E2E matrix and `required-rust-e2e` fan-in.

Validation:

- `mise exec -- bash .circleci/scripts/merge-configs.sh`
- `mise exec -- bash .circleci/scripts/test-decision-tree.sh`
- `circleci config validate /tmp/merged-config-stubbed.yml` with a local stub for the private CircleCI orb
