### PR TITLE
Check NUT pre-fork state snapshots

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -195,13 +195,14 @@ commands:
       Identity coords, reader service account, and bucket come from the
       sccache-gcs-optimism CircleCI context; the read-only reader is the default
       for every ref and develop overrides to the writer. The write/read split is
-      enforced by GCP Workload Identity on the signed CircleCI OIDC vcs-ref claim,
-      so a non-develop ref impersonating the writer is denied by GCP; this only
-      selects the SA. sccache is preinstalled in the ci-base-clang image.
+      enforced by GCP Workload Identity on the signed CircleCI OIDC vcs-ref
+      claim, so a non-develop ref impersonating the writer is denied by GCP;
+      this only selects the SA. sccache is preinstalled in the ci-base-clang
+      image.
 
-      Not fail-open: if the sccache server can't start, the job fails so a broken
-      cache is fixed rather than silently masked. Requires the context (so every
-      job invoking this command must carry sccache-gcs-optimism).
+      Not fail-open: if the sccache server can't start, the job fails so a
+      broken cache is fixed rather than silently masked. Requires the context
+      (so every job invoking this command must carry sccache-gcs-optimism).
     parameters:
       enabled:
         description: "Master switch for the GCS compile cache."
@@ -351,13 +352,15 @@ commands:
           mentions: "<< parameters.mentions >>"
 
   apt-install:
-    description: "apt-get update + install, with retries to tolerate transient Ubuntu mirror sync failures."
+    description: "apt-get update + install, with retries to tolerate transient
+      Ubuntu mirror sync failures."
     parameters:
       packages:
         description: "Space-separated list of apt packages to install."
         type: string
       extra_flags:
-        description: "Extra flags to pass to apt-get install (e.g. '--no-install-recommends')."
+        description: "Extra flags to pass to apt-get install (e.g.
+          '--no-install-recommends')."
         type: string
         default: ""
     steps:
@@ -386,7 +389,8 @@ commands:
           packages: "zstd"
 
   get-target-branch:
-    description: "Determine the PR target branch and export TARGET_BRANCH for subsequent steps"
+    description: "Determine the PR target branch and export TARGET_BRANCH for
+      subsequent steps"
     steps:
       - run:
           name: Determine target branch for this pipeline
@@ -399,10 +403,12 @@ commands:
           working_directory: packages/contracts-bedrock
 
   setup-features:
-    description: "Set up dev and system feature environment variables. Features are auto-classified based on system_features registry."
+    description: "Set up dev and system feature environment variables. Features are
+      auto-classified based on system_features registry."
     parameters:
       features:
-        description: "Comma-separated list of features (can mix dev and system features, e.g., 'OPTIMISM_PORTAL_INTEROP,CUSTOM_GAS_TOKEN')"
+        description: "Comma-separated list of features (can mix dev and system features,
+          e.g., 'OPTIMISM_PORTAL_INTEROP,CUSTOM_GAS_TOKEN')"
         type: string
         default: ""
       system_features:
@@ -477,14 +483,16 @@ commands:
       - restore_cache:
           name: Restore << parameters.directory >> dependency cache (shared)
           keys:
-            - rust-deps-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}
+            - rust-deps-v<< parameters.version >>-{{ checksum "<<
+              parameters.directory >>/Cargo.lock" }}
       # Toolchain (.rustup + cargo-installed bins) keyed on the toolchain pins,
       # not Cargo.lock, so a dependency bump no longer discards and re-downloads
       # the Rust toolchain. Shared across all jobs.
       - restore_cache:
           name: Restore Rust toolchain cache (shared)
           keys:
-            - rust-toolchain-v<< parameters.version >>-{{ checksum "mise.toml" }}-{{ checksum "rust/rust-toolchain.toml" }}
+            - rust-toolchain-v<< parameters.version >>-{{ checksum "mise.toml"
+              }}-{{ checksum "rust/rust-toolchain.toml" }}
 
   rust-save-build-cache:
     description: "Save the dependency and toolchain caches for a Rust workspace"
@@ -523,13 +531,15 @@ commands:
           command: 'command -v sccache >/dev/null 2>&1 && sccache --show-stats || true'
           when: always
       - save_cache:
-          key: rust-deps-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}
+          key: rust-deps-v<< parameters.version >>-{{ checksum "<< parameters.directory
+            >>/Cargo.lock" }}
           name: Save << parameters.directory >> dependency cache (shared)
           paths:
             - /data/mise-data/.cargo/registry
             - /data/mise-data/.cargo/git
       - save_cache:
-          key: rust-toolchain-v<< parameters.version >>-{{ checksum "mise.toml" }}-{{ checksum "rust/rust-toolchain.toml" }}
+          key: rust-toolchain-v<< parameters.version >>-{{ checksum "mise.toml" }}-{{
+            checksum "rust/rust-toolchain.toml" }}
           name: Save Rust toolchain cache (shared)
           paths:
             - /data/mise-data/.cargo/bin
@@ -569,7 +579,8 @@ commands:
         # Default true: most rust jobs build op-reth's chainspec, whose build.rs
         # regenerates the gitignored superchain archive from this submodule. Only
         # no-build lint jobs (fmt/typos/deny/zepter/no-std) opt out with false.
-        description: "Init the superchain-registry submodule (op-reth chainspec's build.rs reads it)."
+        description: "Init the superchain-registry submodule (op-reth chainspec's
+          build.rs reads it)."
         type: boolean
         default: true
     steps:
@@ -754,9 +765,12 @@ jobs:
             - persist_to_workspace:
                 root: "."
                 paths:
-                  - "<< parameters.directory >>/target/<< parameters.profile >>/kona-*"
-                  - "<< parameters.directory >>/target/<< parameters.profile >>/op-*"
-                  - "<< parameters.directory >>/target/<< parameters.profile >>/rollup-boost"
+                  - "<< parameters.directory >>/target/<< parameters.profile
+                    >>/kona-*"
+                  - "<< parameters.directory >>/target/<< parameters.profile
+                    >>/op-*"
+                  - "<< parameters.directory >>/target/<< parameters.profile
+                    >>/rollup-boost"
 
   # Build a single Rust binary from a vendored (non-submodule) directory.
   rust-build-vendored:
@@ -769,15 +783,18 @@ jobs:
         type: string
       hash_paths:
         description: >
-          Space-separated git paths whose tree hash keys the binary cache. MUST cover the full
-          dependency closure the binary compiles, not just `directory`: these vendored workspaces
-          path-depend on sibling crates under rust/ (e.g. alloy-op-evm, op-revm, op-reth), so hashing
-          only `directory` reuses a stale binary when a dependency outside it changes. Defaults to
-          `directory`. Keep in sync with the workspace's `path = "../<crate>"` dependencies.
+          Space-separated git paths whose tree hash keys the binary cache. MUST
+          cover the full dependency closure the binary compiles, not just
+          `directory`: these vendored workspaces path-depend on sibling crates
+          under rust/ (e.g. alloy-op-evm, op-revm, op-reth), so hashing only
+          `directory` reuses a stale binary when a dependency outside it
+          changes. Defaults to `directory`. Keep in sync with the workspace's
+          `path = "../<crate>"` dependencies.
         type: string
         default: ""
       binaries:
-        description: "Space-separated list of binary names to copy from target/release into the cache"
+        description: "Space-separated list of binary names to copy from target/release
+          into the cache"
         type: string
       build_command:
         description: "Cargo build command to run"
@@ -825,7 +842,9 @@ jobs:
       - restore_cache:
           name: Restore << parameters.directory >> cache
           keys:
-            - rust-<< parameters.directory >>-v9-{{ checksum ".circleci-cache/expected-submod-sha.txt" }}-{{ checksum ".circleci-cache/expected-binaries.txt" }}
+            - rust-<< parameters.directory >>-v9-{{ checksum
+              ".circleci-cache/expected-submod-sha.txt" }}-{{ checksum
+              ".circleci-cache/expected-binaries.txt" }}
       - run:
           name: Build << parameters.directory >> (if needed)
           command: |
@@ -876,7 +895,9 @@ jobs:
             done
           no_output_timeout: 30m
       - save_cache:
-          key: rust-<< parameters.directory >>-v9-{{ checksum ".circleci-cache/expected-submod-sha.txt" }}-{{ checksum ".circleci-cache/expected-binaries.txt" }}
+          key: rust-<< parameters.directory >>-v9-{{ checksum
+            ".circleci-cache/expected-submod-sha.txt" }}-{{ checksum
+            ".circleci-cache/expected-binaries.txt" }}
           name: Save << parameters.directory >> cache
           paths:
             - ".circleci-cache/rust-binaries"
@@ -1049,7 +1070,8 @@ jobs:
         type: string
         default: contracts-bedrock
       features:
-        description: Comma-separated list of features to enable (e.g., "OPTIMISM_PORTAL_INTEROP", "CUSTOM_GAS_TOKEN")
+        description: Comma-separated list of features to enable (e.g.,
+          "OPTIMISM_PORTAL_INTEROP", "CUSTOM_GAS_TOKEN")
         type: string
         default: ""
     steps:
@@ -1188,7 +1210,8 @@ jobs:
         type: env_var_name
         default: OP_CI_MAINNET_L1_ARCHIVE_RPC_URL
       features:
-        description: Comma-separated list of features to enable (e.g., "OPTIMISM_PORTAL_INTEROP", "CUSTOM_GAS_TOKEN")
+        description: Comma-separated list of features to enable (e.g.,
+          "OPTIMISM_PORTAL_INTEROP", "CUSTOM_GAS_TOKEN")
         type: string
         default: ""
     steps:
@@ -1221,7 +1244,8 @@ jobs:
           working_directory: packages/contracts-bedrock
       - restore_cache:
           name: Restore forked state
-          key: forked-state-contracts-bedrock-tests-upgrade-{{ checksum "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
+          key: forked-state-contracts-bedrock-tests-upgrade-{{ checksum
+            "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
       - setup-features:
           features: <<parameters.features>>
       - go-restore-cache:
@@ -1252,7 +1276,8 @@ jobs:
           namespace: contracts-bedrock-coverage
       - save_cache:
           name: Save forked state
-          key: forked-state-contracts-bedrock-tests-upgrade-{{ checksum "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
+          key: forked-state-contracts-bedrock-tests-upgrade-{{ checksum
+            "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
           when: always
           paths:
             - "~/.foundry/cache"
@@ -1281,7 +1306,8 @@ jobs:
         type: string
         default: ci
       features:
-        description: Comma-separated list of features to enable (e.g., "OPTIMISM_PORTAL_INTEROP", "CUSTOM_GAS_TOKEN")
+        description: Comma-separated list of features to enable (e.g.,
+          "OPTIMISM_PORTAL_INTEROP", "CUSTOM_GAS_TOKEN")
         type: string
         default: ""
     docker:
@@ -1318,7 +1344,8 @@ jobs:
           working_directory: packages/contracts-bedrock
       - restore_cache:
           name: Restore forked state
-          key: forked-state-contracts-bedrock-tests-upgrade-<<parameters.fork_op_chain>>-<<parameters.fork_base_chain>>-{{ checksum "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
+          key: forked-state-contracts-bedrock-tests-upgrade-<<parameters.fork_op_chain>>-<<parameters.fork_base_chain>>-{{
+            checksum "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
       - setup-features:
           features: <<parameters.features>>
       - run:
@@ -1350,7 +1377,8 @@ jobs:
           namespace: contracts-bedrock-tests-upgrade
       - save_cache:
           name: Save forked state
-          key: forked-state-contracts-bedrock-tests-upgrade-<<parameters.fork_op_chain>>-<<parameters.fork_base_chain>>-{{ checksum "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
+          key: forked-state-contracts-bedrock-tests-upgrade-<<parameters.fork_op_chain>>-<<parameters.fork_base_chain>>-{{
+            checksum "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
           when: always
           paths:
             - "~/.foundry/cache"
@@ -1458,7 +1486,8 @@ jobs:
           working_directory: packages/contracts-bedrock
       - restore_cache:
           name: Restore forked L2 state
-          key: forked-state-l2-<<parameters.fork_op_chain>>-{{ checksum "packages/contracts-bedrock/l2ForkBlockNumber.txt" }}
+          key: forked-state-l2-<<parameters.fork_op_chain>>-{{ checksum
+            "packages/contracts-bedrock/l2ForkBlockNumber.txt" }}
       - setup-features:
           features: <<parameters.features>>
       - run:
@@ -1486,7 +1515,8 @@ jobs:
           namespace: contracts-bedrock-tests-l2-fork
       - save_cache:
           name: Save forked L2 state
-          key: forked-state-l2-<<parameters.fork_op_chain>>-{{ checksum "packages/contracts-bedrock/l2ForkBlockNumber.txt" }}
+          key: forked-state-l2-<<parameters.fork_op_chain>>-{{ checksum
+            "packages/contracts-bedrock/l2ForkBlockNumber.txt" }}
           when: always
           paths:
             - "~/.foundry/cache"
@@ -1576,7 +1606,9 @@ jobs:
           command: sudo apt-get install -y ripgrep
       - run:
           name: Check TODO issues
-          command: ./ops/scripts/todo-checker.sh --verbose --strict <<#parameters.check_closed>> --check-closed <</parameters.check_closed>>
+          command: ./ops/scripts/todo-checker.sh --verbose --strict
+            <<#parameters.check_closed>> --check-closed
+            <</parameters.check_closed>>
       - notify-failures-on-develop
 
   go-lint:
@@ -1719,7 +1751,7 @@ jobs:
   check-nut-prefork-states:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: large.gen2
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -1917,7 +1949,8 @@ jobs:
         type: integer
         default: 1
       acceptance_test_jobs:
-        description: "Override ACCEPTANCE_TEST_JOBS (go test -p) for this run; empty leaves the justfile default in place"
+        description: "Override ACCEPTANCE_TEST_JOBS (go test -p) for this run; empty
+          leaves the justfile default in place"
         type: string
         default: ""
     docker:
@@ -2282,7 +2315,7 @@ jobs:
           oidc_token_file_path: /tmp/oidc_token.json
       - utils/checkout-with-mise:
           enable-mise-cache: true
-      - attach_workspace: { at: "." }
+      - attach_workspace: {at: "."}
       # goreleaser compiles the Go release binaries on the host.
       - restore-go-mod-cache
       - run:
@@ -2327,8 +2360,10 @@ jobs:
       image: ubuntu-2204:2024.08.1
     steps:
       - utils/github-stale:
-          stale-issue-message: "This issue has been automatically marked as stale and will be closed in 5 days if no updates"
-          stale-pr-message: "This pr has been automatically marked as stale and will be closed in 5 days if no updates"
+          stale-issue-message: "This issue has been automatically marked as stale and will
+            be closed in 5 days if no updates"
+          stale-pr-message: "This pr has been automatically marked as stale and will be
+            closed in 5 days if no updates"
           close-issue-message: "This issue was closed as stale.  Please reopen if this is a mistake"
           close-pr-message: "This PR was closed as stale.  Please reopen if this is a mistake"
           days-before-issue-stale: 999
@@ -2562,7 +2597,8 @@ workflows:
           # Full vendored-crate closure op-rbuilder compiles (its `path = "../<crate>"` deps and
           # their shared siblings). Without op-reth/op-revm/alloy-op-evm/etc. here, a change to one
           # of those reuses a stale op-rbuilder binary in the sysgo acceptance jobs.
-          hash_paths: "rust/op-rbuilder rust/rollup-boost rust/op-reth rust/op-revm rust/op-alloy rust/alloy-op-evm rust/alloy-op-hardforks"
+          hash_paths: "rust/op-rbuilder rust/rollup-boost rust/op-reth rust/op-revm
+            rust/op-alloy rust/alloy-op-evm rust/alloy-op-hardforks"
           binaries: "op-rbuilder"
           build_command: cargo build --release -p op-rbuilder --bin op-rbuilder
           needs_clang: true
@@ -2574,7 +2610,8 @@ workflows:
           directory: rust/rollup-boost
           # rollup-boost path-depends on op-reth/op-alloy (and their siblings transitively); hash the
           # same shared vendored-crate closure so a sibling change rebuilds it instead of going stale.
-          hash_paths: "rust/op-rbuilder rust/rollup-boost rust/op-reth rust/op-revm rust/op-alloy rust/alloy-op-evm rust/alloy-op-hardforks"
+          hash_paths: "rust/op-rbuilder rust/rollup-boost rust/op-reth rust/op-revm
+            rust/op-alloy rust/alloy-op-evm rust/alloy-op-hardforks"
           binaries: "rollup-boost"
           build_command: cargo build --release -p rollup-boost --bin rollup-boost
           context:
@@ -2872,10 +2909,13 @@ workflows:
     jobs:
       - close-issue:
           label_name: "auto-close-trivial-contribution"
-          message: "Thank you for your interest in contributing!
-            At this time, we are not accepting contributions that primarily fix spelling, stylistic, or grammatical errors in documentation, code, or elsewhere.
-            Please check our [contribution guidelines](https://github.com/ethereum-optimism/optimism/blob/develop/CONTRIBUTING.md#contributions-related-to-spelling-and-grammar) for more information.
-            This issue will be closed now."
+          message: "Thank you for your interest in contributing! At this time, we are not
+            accepting contributions that primarily fix spelling, stylistic, or
+            grammatical errors in documentation, code, or elsewhere. Please
+            check our [contribution
+            guidelines](https://github.com/ethereum-optimism/optimism/blob/deve\
+            lop/CONTRIBUTING.md#contributions-related-to-spelling-and-grammar)
+            for more information. This issue will be closed now."
           context:
             - circleci-repo-optimism
 
@@ -2935,7 +2975,8 @@ workflows:
           name: contracts-bedrock-tests-heavy-fuzz-modified <<matrix.features>>
           requires:
             - prep-go-modules
-          test_list: git diff origin/develop...HEAD --name-only --diff-filter=AM -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
+          test_list: git diff origin/develop...HEAD --name-only --diff-filter=AM --
+            './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
           test_timeout: 1h
           test_profile: ciheavy
           features: <<matrix.features>>

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1716,6 +1716,25 @@ jobs:
       - go-save-cache:
           namespace: check-nut-locks
 
+  check-nut-prefork-states:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: large.gen2
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+          enable-mise-cache: true
+      - attach_workspace:
+          at: .
+      - go-restore-cache:
+          namespace: check-nut-prefork-states
+      - run:
+          name: check NUT pre-fork states
+          command: |
+            just _check-nut-prefork-states
+      - go-save-cache:
+          namespace: check-nut-prefork-states
+
   nut-provenance-verify:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
@@ -2442,6 +2461,13 @@ workflows:
             - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
+      - check-nut-prefork-states:
+          requires:
+            - contracts-bedrock-build
+            - prep-superchain
+            - prep-go-modules
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - nut-provenance-verify:
           requires:
             - prep-go-modules
@@ -2625,6 +2651,7 @@ workflows:
             - check-generated-mocks-op-service: terminal
             # Misc checks that run on the merge queue.
             - check-nut-locks: terminal
+            - check-nut-prefork-states: terminal
             - check-op-geth-version: terminal
             - op-deployer-forge-version: terminal
             - l2-chains-sync-check: terminal

--- a/justfile
+++ b/justfile
@@ -418,6 +418,24 @@ build-rust-release:
 check-nut-locks:
   go run ./ops/scripts/check-nut-locks
 
+# Checks that committed NUT pre-fork states regenerate without drift. Assumes required build artifacts are present.
+[script('bash')]
+_check-nut-prefork-states:
+  set -euo pipefail
+  shopt -s nullglob
+  for state in op-core/nuts/state/*_state.json; do
+    fork="$(basename "$state" _state.json)"
+    if [ "$fork" = "jovian" ]; then
+      continue
+    fi
+    just _nut-prefork-state-for "$fork"
+  done
+  git diff --exit-code -- op-core/nuts/state/*_state.json
+
+# Checks that committed NUT pre-fork states regenerate without drift.
+check-nut-prefork-states: build-contracts build-superchain-go
+  just _check-nut-prefork-states
+
 # Snapshots current-upgrade-bundle.json as a fork's NUT bundle and updates the lock file.
 nut-snapshot-for fork:
   go run ./ops/scripts/nut-snapshot-for {{fork}}
@@ -427,9 +445,12 @@ nut-provenance-verify fork:
   go run ./ops/scripts/nut-provenance-verify {{fork}}
 
 # Generates op-core/nuts/state/<fork>_state.json (predecessor state + frozen <fork> bundle).
-nut-prefork-state-for fork:
-  OP_E2E_GEN_PREFORK_STATE={{fork}} go test -run TestGenerateForkState ./rust/kona/tests/proofs/
+_nut-prefork-state-for fork:
+  OP_E2E_GEN_PREFORK_STATE={{fork}} go test -count=1 -run TestGenerateForkState ./rust/kona/tests/proofs/
 
+# Generates op-core/nuts/state/<fork>_state.json (predecessor state + frozen <fork> bundle).
+nut-prefork-state-for fork: build-contracts build-superchain-go
+  just _nut-prefork-state-for {{fork}}
 
 # Checks that TODO comments have corresponding issues.
 todo-checker:

--- a/op-core/nuts/README.md
+++ b/op-core/nuts/README.md
@@ -63,6 +63,7 @@ Requires `forge` for the provenance check (step 2).
 ### CI checks
 
 - **`check-nut-locks`** — Verifies all bundle hashes match their lock entries, all entries have a commit, every `*_nut_bundle.json` file has a corresponding lock entry, and each locked fork has a committed pre-fork state (`op-core/nuts/state/<fork>_state.json`). Runs in CI on every PR.
+- **`check-nut-prefork-states`** — Regenerates every committed non-seed `op-core/nuts/state/<fork>_state.json` file and fails if any committed state snapshot drifts.
 
 ## fork_lock.toml schema
 

--- a/op-core/nuts/state/README.md
+++ b/op-core/nuts/state/README.md
@@ -60,6 +60,15 @@ bundle, so current tooling is fine despite the ABI drift above.
 compile time, so `<prev>_state.json` must be on disk before generating
 `<fork>_state.json`.
 
+To verify every committed fork state is up to date, run:
+
+```bash
+just check-nut-prefork-states
+```
+
+This regenerates committed non-seed fork states and fails if the committed JSON
+changes.
+
 ## Determinism
 
 **Composed states** (`karst_state` and later) are byte-reproducible given the


### PR DESCRIPTION
Adds a `check-nut-prefork-states` check that regenerates committed non-seed NUT pre-fork state snapshots and fails if the committed `op-core/nuts/state/*_state.json` files drift.

CI calls the artifact-only `_check-nut-prefork-states` Just target after `contracts-bedrock-build` and `prep-superchain`, so it reuses existing contract and superchain workspace artifacts instead of rebuilding them. The public `check-nut-prefork-states` target remains self-contained for local use.

Validation:
- `just _check-nut-prefork-states`
- `just check-nut-prefork-states`
- `just check-nut-locks`
- `bash .circleci/scripts/merge-configs.sh`
- `bash .circleci/scripts/test-decision-tree.sh`
