### PR TITLE
docs(node-operators): add Chainstack Self-Hosted to node-from-docker next steps

### DIFF
--- a/docs/public-docs/node-operators/tutorials/node-from-docker.mdx
+++ b/docs/public-docs/node-operators/tutorials/node-from-docker.mdx
@@ -230,3 +230,4 @@ Syncing from scratch is fine for OP Sepolia (~30–50 GB, hours) but slow for OP
 *   [Node Metrics and Monitoring Guide](/node-operators/guides/monitoring/metrics) — wire up Prometheus/Grafana against the metrics port.
 *   [Node Troubleshooting Guide](/node-operators/guides/troubleshooting) — if you run into problems.
 *   [Building and running an OP Stack node from source](/node-operators/tutorials/run-node-from-source) — if you need a custom build or want to inspect the source.
+*   [Deploy with Chainstack Self-Hosted](https://docs.chainstack.com/docs/self-hosted/introduction) — free web UI and CLI that deploys op-reth and op-node on your own Kubernetes cluster, with snapshot bootstrap and built-in monitoring. No Chainstack account required.


### PR DESCRIPTION
Adds a "Next steps" link to Chainstack Self-Hosted — a free web UI and CLI that deploys the same official op-reth + op-node images this tutorial uses, on your own Kubernetes/cloud/on-prem infrastructure, with snapshot bootstrap and built-in monitoring. No account required.

Optimism is a supported deployment in Chainstack Self-Hosted (OP-Reth + OP-Node, with snapshot bootstrap): https://docs.chainstack.com/docs/self-hosted/supported-clients-and-protocols

This mirrors the entry already on ethereum.org's "Guided setup" section of its run-a-node page. Same clients, easier ops layer — not a competing stack.

Disclosure: I work at Chainstack; this is Chainstack's tooling. Happy to adjust wording or placement.
