### PR TITLE
docs: revisit op-geth decoupling plan — widen scope, trim to strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ More detailed guidance for AI agents can be found in:
 - [docs/ai/devfeatures.md](docs/ai/devfeatures.md) - The `DevFeatures` bitmap system gating in-development smart contract features: where the bitmap is supplied, composed, propagated, and read. Only relevant for contract development and op-deployer — not needed for client (op-node / op-reth / kona) work
 - [docs/ai/acceptance-tests.md](docs/ai/acceptance-tests.md) - Building and running acceptance tests locally
 - [docs/ai/writing-acceptance-tests.md](docs/ai/writing-acceptance-tests.md) - Writing new acceptance tests: DSL patterns, naming, what to avoid
-- [docs/ai/opgeth-decoupling.md](docs/ai/opgeth-decoupling.md) - op-geth decoupling plan: consult when migrating OP Stack–specific code out of op-geth into `op-core/*` so the monorepo can depend on upstream go-ethereum (scope: op-node, op-service, op-batcher, op-proposer, op-challenger, op-faucet, op-supernode, cannon, op-e2e, op-acceptance-tests, op-devstack)
+- [docs/ai/opgeth-decoupling.md](docs/ai/opgeth-decoupling.md) - op-geth decoupling plan: consult when doing any op-geth decoupling work — migrating OP Stack–specific code out of op-geth into `op-core/*`, retiring op-geth-backed execution in tests/tooling, or removing fork-only API uses — so the monorepo can depend on upstream go-ethereum (scope: the whole monorepo — single go.mod; tracking issue #20257)
 
 ## External References
 

--- a/docs/ai/opgeth-decoupling.md
+++ b/docs/ai/opgeth-decoupling.md
@@ -2,29 +2,48 @@
 
 This document analyses the dependencies of the optimism monorepo Go services on op-geth–specific
 APIs, and proposes decoupling strategies for each. The goal is to depend on upstream go-ethereum
-instead of op-geth without opening upstream PRs.
+instead of op-geth without opening upstream PRs. Tracking issue: #20257. Last full revisit:
+2026-07 (verified by an upstream-build spike; added §§15–19).
 
-**Scope: the whole monorepo.** Every Go component that links op-geth — whether as a binary
-dependency or as a library — must end up building against upstream go-ethereum. Each falls into
-one of three fates:
+Sections are numbered stably (§0–§19) because issues reference them. Done sections keep their
+context and decisions but not their implementation detail — the landed code in `op-core/*` is its
+own reference. Work-list detail (exact files, counts) is deliberately absent: it goes stale, and
+an agent re-derives it in minutes from the grep recipes given per section.
 
-1. **Swap to `op-core/*` (+ upstream go-ethereum)** — code that stays in Go and used op-geth only
-   for OP-specific types/helpers. The bulk: op-node, op-service, op-batcher, op-proposer,
+**Scope: the whole monorepo.** The monorepo is a **single Go module** with one go-ethereum
+`replace` directive, so at the flip *everything* in the tree must build — and behave — against
+upstream go-ethereum; components can only leave scope by deletion. Each component falls into one
+of three fates:
+
+1. **Swap to `op-core/*` (+ upstream go-ethereum)** — code that stays in Go; where it used
+   op-geth-specific types/helpers they swap to `op-core/*`, and some members need no changes at
+   all (§12). The bulk: op-node, op-service, op-batcher, op-proposer,
    op-challenger, op-faucet, op-supernode, cannon; the test suites (op-e2e, op-acceptance-tests,
-   op-devstack); `op-chain-ops/genesis` (#21281) and the `op-chain-ops/cmd/check-*` per-fork
-   checker family (check-jovian, check-karst, … — stay for now); and **op-sync-tester** — a
+   op-devstack) and the Go proof tests under `rust/kona/tests/proofs/`; `op-chain-ops/genesis`
+   (#21281) and the surviving `op-chain-ops/cmd/check-*` checkers (§18); **op-sync-tester** — a
    CL-sync EL *mock* that does **no execution** (it proxies a real op-reth EL and gates
-   visibility), whose one non-swap bit, the OP-aware `PayloadID` hash, is tracked in #21525.
-2. **Migrate execution to op-reth** — anything that builds or executes blocks. op-acceptance-tests
-   sequences op-reth-only for Karst+ (#21182); op-e2e/actions moves onto an op-reth-test-engine
-   subprocess EL (#20415, #21196).
-3. **Delete** — geth-as-library tools with no remaining need: op-simulate and op-run-block
-   (#21282), to be reimplemented in Rust against op-reth if ever needed again.
+   visibility), whose one non-swap bit, the OP-aware `PayloadID` hash, is tracked in #21525; and
+   the **fork's infrastructure extensions** to geth's `log`/`rpc` packages, re-homed into owned
+   op-service layers (§15).
+2. **Migrate execution to op-reth / Rust** — anything that builds or executes blocks, or needs
+   fork-only EVM hooks. op-acceptance-tests sequences op-reth-only for Karst+ (#21182);
+   op-e2e/actions moves onto an op-reth-test-engine subprocess EL (#20415, #21196); op-e2e system
+   tests and op-devstack/sysgo retire their in-process op-geth L2 EL (§17); and
+   `op-chain-ops/script` + op-deployer move to a Rust script engine (§16).
+3. **Delete** — geth-as-library tools with no remaining need, to be reimplemented in Rust against
+   op-reth if ever needed again: op-simulate and op-run-block (#21282), `op-wheel/cheat` and the
+   stale pre-Holocene `check-*` tools (§18).
 
 Once every component is in fate 1, 2, or 3, the go.mod `replace` flips to upstream go-ethereum
-(#20266).
+(#20266). A scheduled **CI ratchet** job rehearses the flip continuously (see §19).
 
-The op-geth diff vs. upstream go-ethereum (currently based on v1.17.2) can be summarised in three
+**Compile-compat is necessary, not sufficient.** Upstream go-ethereum does not implement the OP
+state transition, so code can compile and silently behave wrongly. The classifying question for
+every geth-as-library consumer: *does it execute OP state transitions?* Yes → op-reth or delete
+(fate 2/3). No — plain-EVM script execution, storage-level surgery, header/RLP work → upstream is
+behaviorally fine (fate 1).
+
+The op-geth diff vs. upstream go-ethereum (currently based on v1.17.2) can be summarised in four
 kinds of change:
 
 1. **New standalone types/files** – `DepositTx`, `PostExecTx`, `RollupCostData`, the
@@ -32,1121 +51,480 @@ kinds of change:
 2. **Fields/methods added to existing upstream types** – `Transaction` methods (`IsDepositTx`,
    `SourceHash`, `Mint`, `IsSystemTx`, `RollupCostData`), `Receipt` L1-cost fields, `ChainConfig`
    OP hardfork fields and methods, `PayloadAttributes` extensions.
-3. **Config/CLI wiring** – how op-geth starts: not relevant to the monorepo.
+3. **Infrastructure hooks in general-purpose packages** – `log` context methods, `rpc` recording
+   hooks, EVM override hooks in `vm.Config` (§15, §16). Having a fork made "just add a hook to
+   geth" cheap; the decoupling converts each such shortcut into a layer we own or a feature
+   decision.
+4. **Config/CLI wiring** – how op-geth starts: not relevant to the monorepo.
 
 ---
 
 ## Target package layout in the monorepo
 
-All op-geth-specific code will be extracted into `op-core/`, with new packages living directly
-under that directory (alongside the existing `op-core/forks/` and `op-core/predeploys/`):
+All op-geth-specific code lives in `op-core/` packages (alongside the pre-existing
+`op-core/forks/` and `op-core/predeploys/`). **All of these have landed:**
 
-| Source (op-geth) | Destination (monorepo) |
-|---|---|
-| `core/types/deposit_tx.go`, `receipt_opstack.go` | `op-core/types/` |
-| `core/types/rollup_cost.go` (L1 cost + operator-fee math) | `op-core/fees/` |
-| `params/config_op.go`, `params/superchain.go` (`OptimismConfig` + `LoadChainConfig` only) | `op-core/params/` |
-| `superchain/` package + `sync-superchain.sh` | `op-core/superchain/` |
-| `op-service/superutil/` | merged into `op-core/superchain/` |
-| `consensus/misc/eip1559/eip1559_optimism.go` | `op-core/eip1559/` |
+| op-geth source | Monorepo package | Content |
+|---|---|---|
+| `core/types/deposit_tx.go`, `post_exec_tx.go`, `receipt_opstack.go` | `op-core/types/` | `DepositTx`, `PostExecTx`, `Receipt` + helpers |
+| `core/types/rollup_cost.go` | `op-core/fees/` | L1 cost + operator-fee math |
+| `params/config_op.go`, `params/superchain.go` | `op-core/params/` | `OptimismConfig`, standalone `ChainConfig`, loaders |
+| `superchain/` + `sync-superchain.sh` | `op-core/superchain/` | embedded registry (absorbed `op-service/superutil`) |
+| `consensus/misc/eip1559/eip1559_optimism.go` | `op-core/eip1559/` | Holocene/Jovian extraData helpers |
 
-**Not carried over** — the protocol-versions signalling mechanism was deprecated and removed
-in step 0 (see §0): `eth/catalyst/superchain.go` (`SuperchainSignal`,
-`LogProtocolVersionSupport`), `params.ProtocolVersion*` types and constants,
-`params.OPStackSupport`.
+### Design principles (apply to all future op-core additions)
 
-(The `NetworkNames` map from `params/superchain.go` is used for L1-chain-name lookups in
-`op-node/rollup/types.go` log/error messages — unrelated to protocol versions — and will move to
-`op-core/superchain/` alongside the registry data in §7.)
-
-### Naming conventions
-
-Because everything in `op-core/` is implicitly OP-Stack-specific, new types drop the
-`Optimism` / `OPStack` prefix:
-
-| Op-geth name | New name in monorepo |
-|---|---|
-| `types.Receipt` with OP extensions | `op-core/types.Receipt` (imported as `optypes.Receipt`) |
-| `types.RollupCostData`, `NewL1CostFuncFjord`, etc. | `op-core/fees.*` (imported as `opfees`) |
-| `params.ChainConfig` with OP extensions | `op-core/params.ChainConfig` (imported as `opparams.ChainConfig`) |
-| `params.LoadOPStackChainConfig` | `op-core/params.FromSuperchainConfig` |
-| `superutil.LoadOPStackChainConfigFromChainID` | `op-core/params.LoadChainConfigFromChainID` |
-| `eip1559.{Validate,Decode,Encode}OptimismExtraData` | kept verbatim in `op-core/eip1559` |
-
-**Exception (eip1559 extraData wrappers):** the `{Validate,Decode,Encode}OptimismExtraData`
-fork-dispatching helpers keep their names. Here "Optimism" names the OP-specific extraData
-*format* (the Holocene/Jovian 1559-parameter encoding), not a redundant package prefix, and
-dropping it would collide with the per-fork `Validate*ExtraData` helpers. Keeping the names
-also makes the op-node swap a pure import-path change.
-
-**Exception:** `params.OptimismConfig` keeps its name. The field is `ChainConfig.Optimism
-*OptimismConfig` — the type pairs with the field name, which is load-bearing for JSON wire
-format.
-
-Files that need both upstream and monorepo variants use import aliases like `optypes`,
-`opparams`:
-
-```go
-import (
-    "github.com/ethereum/go-ethereum/params"
-    opparams "github.com/ethereum-optimism/optimism/op-core/params"
-)
-```
+- **Monorepo-best, not op-geth-faithful.** Names and shapes diverge freely; only *computed
+  values* and *wire formats* must match. Equivalence is pinned by **live differential tests**
+  that compare against op-geth while the build still resolves go-ethereum to the fork; all
+  differential tests are deleted at the cutover (§ #20266).
+- **Naming**: inside `op-core/` the `Optimism`/`OPStack` prefix is dropped (redundant), with two
+  deliberate exceptions: `OptimismConfig` (pairs with the JSON-wire-load-bearing
+  `ChainConfig.Optimism` field name) and the `{Validate,Decode,Encode}OptimismExtraData` helpers
+  (there "Optimism" names the extraData *format* and avoids collision with per-fork helpers).
+- Files needing both upstream and monorepo variants use import aliases `optypes`, `opparams`,
+  `opfees`.
+- **Wire compatibility** where types serialise: JSON tags identical to op-geth
+  (`OptimismConfig`), byte-identical encodings (`DepositTx`: `0x7E || RLP(struct)`), verified by
+  the differential tests.
 
 ---
 
 ## 0. Remove ProtocolVersions watching from op-node — **DONE**
 
-The protocol-versions signalling mechanism — op-node watching the L1 `ProtocolVersions` contract,
-reporting deltas via metrics, signalling the engine over `engine_signalSuperchainV1`, and halting
-the node when outdated — was a deprecated feature. Rather than port its op-geth types
-(`params.ProtocolVersion*`, `catalyst.SuperchainSignal`, `catalyst.LogProtocolVersionSupport`,
-`params.OPStackSupport`) into `op-core`, the feature was removed entirely. This shrank the
-surface to decouple and avoided carrying dead code into `op-core`.
+Rather than port the deprecated protocol-versions signalling mechanism (op-node watching the L1
+`ProtocolVersions` contract, `engine_signalSuperchainV1`, halt-when-outdated) into `op-core`, the
+feature was **removed entirely** — op-node, kona/op-reth, contracts, and all Go wiring (#20258,
+#20311, #20317, #20441, #20527). This shrank the surface to decouple and avoided carrying dead
+code.
 
-Landed across:
-- #20258 — op-node watching/halting removal.
-- #20311 — `op-node/node/superchain.go` deletion + flag/runcfg/metrics cleanup.
-- #20317 — Rust kona ProtocolVersions support removal.
-- #20441 — final Go cleanup: `params.OPStackSupport`, `addresses.SuperchainContracts`,
-  op-deployer / op-chain-ops / op-devstack / op-e2e wiring, the `op-chain-ops/cmd/protocol-version`
-  CLI.
-- #20527 — Solidity contract deletion (`packages/contracts-bedrock/src/L1/ProtocolVersions.sol`)
-  and `OPContractsManagerContainer.Implementations.protocolVersionsImpl` removal; final Go
-  placeholder cleanup that #20441 left behind to keep the Solidity script ABIs in sync.
-
-The remaining superchain registry usages (loading chain config, `NetworkNames`-style lookups)
-continue to work and are addressed in §§6–7.
-
-**Unrelated — left alone** (same "ProtocolVersion" name, different concept):
-- `op-service/apis/p2p.go:46` `ProtocolVersion string` — libp2p peer protocol version string.
-- `op-node/p2p/rpc_server.go:115` — reads libp2p `"ProtocolVersion"` from peerstore.
+Careful when grepping: `op-service/apis/p2p.go` / `op-node/p2p/rpc_server.go` contain an
+unrelated libp2p `ProtocolVersion` string — same name, different concept, left alone.
 
 ---
 
-## 1. `core/types` – OP Stack transaction types (`DepositTx`, `PostExecTx`)
+## 1. `core/types` – OP Stack transaction types (`DepositTx`, `PostExecTx`) — types **DONE**, swaps open
 
-### Current usage
+`op-core/types` ships `DepositTx` (`0x7E || RLP(struct)`) and `PostExecTx` with
+`MarshalBinary`/`Unmarshal*` and differential tests (#20262). Read the package for the API.
 
-`types.DepositTx` (new file in op-geth, type `0x7E`) is used in op-node to construct deposit
-transactions. The **universal pattern** is:
+Two wire facts worth keeping in mind (both encoded in the landed implementation):
 
-```go
-opaqueTx, err := types.NewTx(&types.DepositTx{
-    SourceHash:          source.SourceHash(),
-    From:                someAddr,
-    To:                  nil,
-    Mint:                big.NewInt(0),
-    Value:               big.NewInt(0),
-    Gas:                 375_000,
-    IsSystemTransaction: false,
-    Data:                bytecode,
-}).MarshalBinary()
-```
+- **`PostExecTx` (`0x7D`) has no RLP envelope** — `0x7D || data` verbatim; op-geth treats the
+  payload as opaque bytes (op-alloy/kona parse it as a versioned `PostExecPayload`). The op-core
+  type mirrors the opaque handling.
+- **`PostExecTx` is a canonical block transaction**: on Lagoon+ it can be the *last* tx of a
+  block (sequencer rebates). So an L2 block's tx list is `[L1-info deposit (0x7E), …user txs…,
+  optional post-exec (0x7D)]` — under upstream go-ethereum a full-block decode fails on **both**
+  synthetic types, which is why the OP-aware client (§11) must route both out.
 
-Every call immediately calls `.MarshalBinary()` and discards the `*types.Transaction`. The result
-is always `[]byte` (opaque RLP for the Engine API payload). Locations:
-
-- `op-node/rollup/derive/deposits.go` – `DeriveDeposits` (user deposits from L1 logs)
-- `op-node/rollup/derive/deposit_log.go` – `UnmarshalDepositLogEvent` (returns `*types.DepositTx`)
-- `op-node/rollup/derive/*_upgrade_transactions.go` – Ecotone, Fjord, Holocene, Isthmus, Jovian,
-  Interop (one `types.NewTx(...).MarshalBinary()` per upgrade deposit)
-- `op-node/rollup/interop/indexing/attributes.go` – builds then immediately marshals
-
-The only exception is `DecodeInvalidatedBlockTx` (same file), which decodes an RPC-received tx:
-
-```go
-var tx types.Transaction
-_ = tx.UnmarshalBinary(raw)
-tx.Type()  // checks == types.DepositTxType
-tx.From()  // op-geth specific – returns DepositTx.From field
-tx.Data()  // standard upstream go-ethereum
-```
-
-`types.DepositTxType` (the `0x7E` constant) is used in op-node and op-service to identify
-transactions by type byte.
-
-### Proposed decoupling
-
-**Define `DepositTx` in `op-core/types/deposit_tx.go`**. The wire format is `0x7E || RLP(struct)`,
-matching the spec and what op-geth implements. No dependency on go-ethereum's `TxData` interface.
-
-```go
-const DepositTxType = byte(0x7E)
-
-type DepositTx struct {
-    SourceHash          common.Hash
-    From                common.Address
-    To                  *common.Address
-    Mint                *big.Int
-    Value               *big.Int
-    Gas                 uint64
-    IsSystemTransaction bool
-    Data                []byte
-}
-
-func (d *DepositTx) MarshalBinary() ([]byte, error) { /* 0x7E || RLP(d) */ }
-func UnmarshalDepositTx(raw []byte) (*DepositTx, error) { /* strip 0x7E, decode RLP */ }
-```
-
-**Wire compatibility test**: add a differential test in `op-core/types/deposit_tx_test.go` that
-imports op-geth's `types.DepositTx`, serialises identical structs with both implementations, and
-asserts byte-for-byte equality. This test will be removed when the op-geth dependency is migrated
-to upstream go-ethereum.
-
-For type-checking without op-geth, `tx.Type()` already exists on upstream `*types.Transaction`.
-So:
-
-```go
-func IsDepositTx(tx *types.Transaction) bool { return tx.Type() == DepositTxType }
-```
-
-For `tx.From()` (single call site in `DecodeInvalidatedBlockTx`): replace with
-`UnmarshalDepositTx(rawBytes)` and read `.From` directly.
-
-**All call-sites** that do `types.NewTx(&types.DepositTx{...}).MarshalBinary()` become
-`op-core/types.DepositTx{...}.MarshalBinary()`. The `*types.Transaction` wrapper is eliminated;
-we go straight from struct to `[]byte`.
-
-**`UnmarshalDepositLogEvent`** returns `*types.DepositTx` today; change to return
-`*optypes.DepositTx`. `DeriveDeposits` calls `types.NewTx(dep).MarshalBinary()`; replace
-with `dep.MarshalBinary()`.
-
-### `PostExecTx` (type `0x7D`)
-
-op-geth also adds `types.PostExecTx` (`core/types/post_exec_tx.go`), a synthetic unsigned
-transaction carrying post-execution metadata. Its wire format is `0x7D || data`, where
-`data` is appended **verbatim** — there is no outer RLP envelope around the transaction
-body, unlike the deposit tx's `0x7E || RLP(struct)`. op-geth treats `data` as opaque bytes
-and never parses it; the bytes are in fact an RLP-encoded `PostExecPayload` (a `version`
-plus SDM `gas_refund_entries`) that op-alloy/kona decode and version-check (see
-`rust/kona/crates/protocol/protocol/src/batch/transactions.rs`). Mirroring op-geth's opaque
-handling keeps `op-core/types.PostExecTx` wire-compatible without re-implementing that parse.
-
-`PostExecTx` is **a canonical block transaction**, not a side channel: in the Lagoon
-hardfork it can be the **last transaction of a block**, encoding sequencer rebates. So a
-Lagoon+ L2 block's transaction list is `[L1-info deposit (0x7E), …user txs…, optional
-post-exec (0x7D)]`. This matters for the decode path (§11): under upstream go-ethereum a
-full block's transaction list will fail to decode on **both** the deposit (`0x7E`) and the
-post-exec (`0x7D`) entries, so the OP-aware client must route both out before handing the
-remainder to upstream.
-
-Current usage:
-
-- `op-node/rollup/derive/` — span batch encode/decode (`span_batch_tx.go` has its own
-  `spanBatchPostExecTxData`, `span_batch_txs.go` special-cases the synthetic signature),
-  batch validity checks (`batches.go`), and raw type-byte sniffing (`span_batch.go`).
-  Mostly just the `types.PostExecTxType` constant; one site constructs
-  `types.NewTx(&types.PostExecTx{...})`.
-- `op-chain-ops/pkg/sdm/` and `op-service/sources/flashblock_client.go` — handle post-exec
-  payloads as raw/hex bytes only; no type dependency.
-
-Proposed decoupling: define `PostExecTx` in `op-core/types/` next to `DepositTx`, same
-pattern — `MarshalBinary` / `UnmarshalPostExecTx` plus an `IsPostExecTx` free function,
-with a differential test against op-geth. The span-batch construction site goes straight
-from struct to bytes. Note that op-geth (like upstream) rejects typed-tx envelopes of
-`len <= 1`, so an empty payload cannot round-trip; `UnmarshalPostExecTx` mirrors that.
+**Open work (#20269, #20263):** swap the construction/decoding call sites. The op-geth pattern
+`types.NewTx(&types.DepositTx{...}).MarshalBinary()` becomes
+`optypes.DepositTx{...}.MarshalBinary()` — the `*types.Transaction` wrapper is eliminated, struct
+straight to bytes. `UnmarshalDepositLogEvent` returns `*optypes.DepositTx`. Sites cluster in
+op-node derivation (deposits, one `*_upgrade_transactions.go` per fork — the set grows every
+fork) and span-batch code (`PostExecTxType`); derive the current list with
+`grep -rn 'types\.\(DepositTx\|PostExecTx\)' --include='*.go'` over the go-ethereum import.
 
 ---
 
 ## 2. `core/types` – Transaction methods on RPC-received transactions
 
-### Current usage
+op-geth adds methods to `*types.Transaction` (`IsDepositTx`, `IsSystemTx`, `SourceHash`, `Mint`,
+`RollupCostData`) that the monorepo calls on txs received via Engine API / RPC. `tx.Type()` and
+`tx.Data()` are standard upstream — no change. The replacements exist in `op-core/types` (free
+functions and `UnmarshalDepositTx`-then-read-fields) and `op-core/fees.TxRollupCostData`.
 
-The following methods on `*types.Transaction` are op-geth additions, called on transactions that
-arrive as raw bytes from the Engine API or ethclient RPC:
-
-| Method | Locations | Purpose |
-|--------|-----------|---------|
-| `IsDepositTx()` | op-node `payload_util.go`, op-service `sources/types.go`, op-batcher `types.go` | Detect deposit type (type byte == 0x7E) |
-| `tx.From()` | op-node `interop/indexing/attributes.go:105` | Read `From` field of a deposit tx |
-| `tx.Data()` | op-node `payload_util.go` | Get tx calldata – **exists upstream** |
-| `tx.Type()` | op-node, op-service | Get tx type byte – **exists upstream** |
-| `IsSystemTx()` | op-node `rollup/engine/build_seal.go` | Detect system deposit flag |
-| `SourceHash()` | op-node (multiple derive files) | Read deposit source hash |
-| `Mint()` | op-node | Read deposit mint amount |
-| `RollupCostData()` | op-service `txinclude/`, op-batcher `types.go` | L1 cost estimation |
-
-### Proposed decoupling
-
-- `tx.Type()` and `tx.Data()` are **standard upstream** – no change needed.
-- `IsDepositTx()`: replace with the free function `IsDepositTx(tx)` from `op-core/types`.
-- `tx.From()` (one call site): replace with `UnmarshalDepositTx(rawBytes).From`.
-- `IsSystemTx()`, `SourceHash()`, `Mint()`: call `UnmarshalDepositTx(rawTxBytes)` and read
-  fields from the monorepo struct. Wrap in short helper functions.
-- `RollupCostData()`: replaced by `opfees.TxRollupCostData(tx)` free function in `op-core/fees`
-  (see §4). The computation only requires `tx.Data()` and `tx.Type()`, both upstream.
-
-**These `*types.Transaction` helpers are transition scaffolding, not the destination.**
-`IsDepositTx(tx)`, `SourceHash(tx)`, `Mint(tx)`, `IsSystemTx(tx)`, `IsPostExecTx(tx)` (and
-the differential test) only work while the build still resolves go-ethereum to op-geth,
-where a `*types.Transaction` can carry a `0x7E`/`0x7D` tx. They let §2's call sites drop
-their dependency on op-geth's `Transaction` methods *before* the underlying transaction
-representation changes. After the cutover, an upstream `*types.Transaction` can never hold a
-deposit or post-exec tx, so the helpers would be permanently dead — they are **deleted at
-the cutover (§14), along with the differential test.** The durable shape never wraps an OP
-tx in a `*types.Transaction`: it decodes raw bytes into `optypes.DepositTx` /
-`optypes.PostExecTx` and reads fields off the struct, and code never asks "is this a
-deposit?" of a generic tx because the sources accessors already partition by class (§11).
+**These `*types.Transaction` helpers are transition scaffolding, not the destination.** They only
+work while the build resolves go-ethereum to op-geth (where a `*types.Transaction` can carry a
+`0x7E`/`0x7D` tx); they let call sites drop op-geth's methods *before* the underlying
+representation changes. After the cutover an upstream `*types.Transaction` can never hold a
+deposit or post-exec tx, so **the helpers and their differential tests are deleted at the cutover
+(§ #20266)**. The durable shape never wraps an OP tx in `*types.Transaction`: raw bytes decode
+into `optypes.DepositTx`/`optypes.PostExecTx`, and code never asks "is this a deposit?" of a
+generic tx because the sources accessors already partition by class (§11).
 
 ---
 
-## 3. `core/types` – Receipt L1-cost fields
+## 3. `core/types` – Receipt L1-cost fields — type **DONE**, wiring open
 
-### Current usage
+`op-core/types.Receipt` (landed, #20262) embeds upstream `types.Receipt` and adds op-geth's
+**complete** OP receipt field set (L1 fee fields, operator fee, deposit nonce, DA footprint) with
+a custom JSON unmarshaler and a differential test. Complete deliberately: the e2e/acceptance
+suites read more fields than the one production consumer, and a partial set would silently drop
+fields at cutover — invisible while the replace still points at op-geth.
 
-op-geth adds OP-specific fields to `types.Receipt`. Investigation confirmed they are actively used
-in exactly one non-test location: **`op-service/txinclude/txbudget.go::AfterIncluded`**:
+Production consumer: `op-service/txinclude` reads the fee fields off receipts fetched via RPC.
+**Open work:** its `EL.TransactionReceipt` (and `apis.EthClient` / `FetchReceipts` generally)
+return `*optypes.Receipt` instead of `*types.Receipt` — part of §11 (#20264). Under upstream,
+the standard unmarshaler drops the OP fields silently; only the raw-RPC path through
+`op-service/sources` + `optypes.Receipt` preserves them.
 
-```go
-receipt := tx.Receipt  // *types.Receipt, fetched via ethclient.TransactionReceipt()
-
-// l1Cost
-if receipt.L1BaseFeeScalar != nil {
-    l1BaseFeeScalar := new(big.Int).SetUint64(*receipt.L1BaseFeeScalar)
-    l1BlobBaseFeeScalar := new(big.Int).SetUint64(*receipt.L1BlobBaseFeeScalar)
-    // fees already wired to op-core; receipt fields (read here) still come from op-geth.
-    l1Cost := opfees.L1CostFjord(opfees.TxRollupCostData(tx.Transaction), opfees.L1FeeParams{
-        L1BaseFee: receipt.L1GasPrice, L1BlobBaseFee: receipt.L1BlobBaseFee,
-        BaseFeeScalar: l1BaseFeeScalar, BlobFeeScalar: l1BlobBaseFeeScalar,
-    })
-    actualCost.Add(actualCost, l1Cost)
-}
-// operatorCost
-if receipt.OperatorFeeScalar != nil {
-    // uses *receipt.OperatorFeeScalar and *receipt.OperatorFeeConstant
-}
-```
-
-The receipt travels: `ethclient.TransactionReceipt()` → `EL` interface → `Monitor` → `Persistent`
-→ `IncludedTx.Receipt *types.Receipt`. With upstream go-ethereum, the extra fields would be nil
-since the standard JSON unmarshaler does not know about them.
-
-Fields used: `L1BaseFeeScalar *uint64`, `L1BlobBaseFeeScalar *uint64`, `L1GasPrice *big.Int`,
-`L1BlobBaseFee *big.Int`, `OperatorFeeScalar *uint64`, `OperatorFeeConstant *uint64`.
-
-Note: `op-service/txinclude/isthmus_cost_oracle.go` does **not** fetch receipts. It reads fee
-parameters directly from the L1Block predeploy contract via batch `eth_call`. Receipt fields are
-not involved there.
-
-Also note: op-node does **not** read receipt fields directly. It reads `L1BlockInfo` from the
-deposit transaction calldata in payloads, which encodes the same values.
-
-### Proposed decoupling
-
-**Define `Receipt` in `op-core/types/`**, embedding `types.Receipt` with the extra fields
-and a custom JSON unmarshaler:
-
-```go
-// in op-core/types, called simply Receipt; consumers import as optypes
-type Receipt struct {
-    types.Receipt
-    DepositNonce          *uint64    `json:"depositNonce,omitempty"`
-    DepositReceiptVersion *uint64    `json:"depositReceiptVersion,omitempty"`
-    L1GasPrice            *big.Int   `json:"l1GasPrice,omitempty"`
-    L1BlobBaseFee         *big.Int   `json:"l1BlobBaseFee,omitempty"`
-    L1GasUsed             *big.Int   `json:"l1GasUsed,omitempty"`
-    L1Fee                 *big.Int   `json:"l1Fee,omitempty"`
-    FeeScalar             *big.Float `json:"l1FeeScalar,omitempty"`
-    L1BaseFeeScalar       *uint64    `json:"l1BaseFeeScalar,omitempty"`
-    L1BlobBaseFeeScalar   *uint64    `json:"l1BlobBaseFeeScalar,omitempty"`
-    OperatorFeeScalar     *uint64    `json:"operatorFeeScalar,omitempty"`
-    OperatorFeeConstant   *uint64    `json:"operatorFeeConstant,omitempty"`
-    DAFootprintGasScalar  *uint64    `json:"daFootprintGasScalar,omitempty"`
-}
-```
-
-The type carries op-geth's **complete** OP receipt field set, not just the six fields
-`txinclude` reads: the e2e/acceptance suites also read `L1Fee`, `L1GasUsed`, `DepositNonce`,
-etc. (§13), and a partial set would silently drop those fields from receipt JSON at cutover
-— while the go.mod replace still points at op-geth, the embedded receipt masks the gap, so
-no differential test can catch it.
-
-The `EL` interface in `txinclude` returns `*optypes.Receipt` instead of `*types.Receipt`.
-`IncludedTx.Receipt` becomes `*optypes.Receipt`. This contains all the changes within
-`op-service/txinclude/`.
+Context: op-node itself never reads receipt fields — it reads `L1BlockInfo` from deposit-tx
+calldata; `txinclude`'s cost oracle reads the L1Block predeploy via `eth_call`. Receipts matter
+mainly for txinclude's post-inclusion accounting and the test suites (§13).
 
 ---
 
-## 4. `op-core/fees` – L1 cost and operator-fee math
+## 4. `op-core/fees` – L1 cost and operator-fee math — **DONE** (one site rides §11)
 
-### Current usage
+Landed (#20261) and wired into `op-service/txinclude`. API is monorepo-best (see design
+principles): plain per-era free functions (`L1CostBedrock/Ecotone/Fjord` + `L1FeeParams`) instead
+of op-geth's closure factories, `OperatorCostIsthmus/Jovian` replacing inline math,
+`TxRollupCostData(tx)` replacing the fork's Transaction method. Values pinned by differential
+tests. Notable choice: both txinclude sites use the **Jovian** operator-fee formula
+unconditionally — exact on all production chains, and on pre-Jovian chains it only
+*over*-estimates, which over-reserves budget rather than under-budgeting.
 
-op-geth's `core/types/rollup_cost.go` provides the L1 cost calculation machinery. The monorepo
-uses only the Fjord-era subset:
-
-- `types.RollupCostData` — struct carrying `Zeroes`, `Ones`, `FastLzSize` byte counts
-- `types.NewRollupCostData(data []byte) RollupCostData` — compute RCD from tx calldata
-- `types.NewL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, baseFeeScalar, blobFeeScalar *big.Int)` —
-  returns `func(RollupCostData) (fee, calldataGasUsed *big.Int)`
-- `(RollupCostData).EstimatedDASize()` — used by op-batcher for DA size estimation
-
-Call sites (pre-migration):
-- `op-service/txinclude/txbudget.go` — L1 cost calc + **inline operator-fee arithmetic**
-- `op-service/txinclude/cost_oracle.go` (formerly `isthmus_cost_oracle.go`) — pre-estimate L1
-  cost + **same inline operator-fee arithmetic** (duplicated from txbudget.go)
-- `op-batcher/batcher/types.go` — `tx.RollupCostData()` for DA size estimation
-
-The two `txinclude` files shared this snippet verbatim (modulo source fields) for operator fee:
-
-```go
-operatorCost := new(big.Int).SetUint64(gasUsed)
-operatorCost.Mul(operatorCost, new(big.Int).SetUint64(scalar))
-operatorCost = operatorCost.Div(operatorCost, oneMillion)
-operatorCost = operatorCost.Add(operatorCost, new(big.Int).SetUint64(constant))
-```
-
-A single shared helper gave us one place to switch when Jovian changed the formula (multiply
-by 100 instead of dividing by a million) — see the Jovian/Isthmus split below.
-
-### Proposed decoupling
-
-**Create `op-core/fees/`**, consumers import as `opfees`:
-
-```go
-package fees // in op-core/fees/
-
-type RollupCostData struct { Zeroes, Ones, FastLzSize uint64 }
-
-func NewRollupCostData(data []byte) RollupCostData { /* copied verbatim */ }
-func (r RollupCostData) EstimatedDASize() *big.Int { /* copied verbatim */ }
-
-// The L1 DA cost is exposed as plain free functions per era — no closures, no L1CostFunc type.
-// op-geth uses closure factories (NewL1CostFunc*) because its EVM builds one cost func per
-// block and calls it per-tx (reuse pays off); the monorepo always constructs-and-calls-once,
-// so the closures earn nothing. This also matches the era spread to L1CostBedrock, which was
-// already a free function. The per-block fee params travel in a struct so the four same-typed
-// *big.Int args can't be transposed. Two things op-geth's signature carried are dropped: the
-// calldataGasUsed second return (only its EVM receipts need it; we never did) and the blockTime
-// arg (only its time-dispatching factory needs it — see NewL1CostFunc(config, statedb) — and we
-// dispatch by era at the call site, not by time).
-type L1FeeParams struct{ L1BaseFee, L1BlobBaseFee, BaseFeeScalar, BlobFeeScalar *big.Int }
-
-func L1CostBedrock(rollupDataGas uint64, l1BaseFee, overhead, scalar *big.Int) *big.Int
-func L1CostEcotone(rcd RollupCostData, p L1FeeParams) *big.Int
-func L1CostFjord(rcd RollupCostData, p L1FeeParams) *big.Int
-
-// Replaces the inline operator-fee math duplicated across txbudget.go and cost_oracle.go.
-// Both formulas are exported; consumers pick per their needs.
-// Isthmus: (gasUsed * scalar / 1_000_000) + constant.
-// Jovian:  (gasUsed * scalar * 100) + constant.
-func OperatorCostIsthmus(gasUsed, scalar, constant uint64) *big.Int
-func OperatorCostJovian(gasUsed, scalar, constant uint64) *big.Int
-
-// Replaces the (tx *types.Transaction).RollupCostData() method from op-geth: deposits incur
-// no DA cost, and the cost data is derived from the full binary-encoded tx, not just calldata.
-func TxRollupCostData(tx *types.Transaction) RollupCostData
-```
-
-Computation is pure arithmetic on byte counts and `*big.Int`. No dependency on
-`op-core/types`, no dependency on go-ethereum beyond `common`, `uint256` and `math/big`.
-Graph: `op-core/fees` and `op-core/types` are siblings — no cycle possible.
-
-### Status
-
-The package landed in #20261. Wiring the `op-service/txinclude` consumers (this issue) also
-simplified the L1-cost API to free functions — `opfees.L1CostFjord(rcd, opfees.L1FeeParams{…})`
-— dropping the closure factories, the `L1CostFunc` type, and op-geth's vestigial
-`calldataGasUsed` return and `blockTime` arg (see the API sketch above). `txbudget.go` and
-`cost_oracle.go` (formerly `isthmus_cost_oracle.go`) use `opfees.L1CostFjord`,
-`opfees.TxRollupCostData`, and `opfees.OperatorCostJovian`. Both txinclude sites use the
-**Jovian** operator-fee formula unconditionally: it is exact on Jovian chains (all production
-chains) and strictly ≥ the Isthmus formula, so on a pre-Jovian chain it only over-estimates,
-which over-reserves budget rather than under-budgeting.
-
-The op-core API is **monorepo-best, not op-geth-faithful** — the names/shapes diverge freely;
-only the *computed values* must match. That equivalence is pinned by **live differential
-tests** in `op-core/fees` that compare against op-geth's exported functions while the build
-still resolves go-ethereum to op-geth: `TestL1CostBedrockParity` (vs `types.L1Cost`),
-`TestFjordL1CostParity` (vs `types.NewL1CostFuncFjord`), and `TestTxRollupCostDataParity` (vs
-`(*types.Transaction).RollupCostData`). Ecotone has only a value-pin (`TestEcotoneL1CostFunc`):
-op-geth's Ecotone constructor is unexported, so a live diff isn't cheaply possible. These
-differential tests are removed at the final cutover when the op-geth dependency is dropped.
-
-The remaining `tx.RollupCostData()` call site, `op-batcher/batcher/types.go`, swaps to
-`opfees.TxRollupCostData` as part of the op-batcher → `op-service/sources` migration (§11), not
-the fees wiring.
+Remaining: the `op-batcher` `tx.RollupCostData()` site swaps to `opfees.TxRollupCostData` as part
+of the op-batcher → sources migration (§11), not here.
 
 ---
 
-## 5. `params.ChainConfig` – OP hardfork methods
+## 5. `params.ChainConfig` – OP hardfork methods — package **DONE** (#20260), swaps open (#20270)
 
-### Current usage
+`op-core/params` ships `OptimismConfig`, a **standalone** `ChainConfig`, and `GethChainConfig()`.
 
-op-geth adds OP hardfork timestamp fields to `params.ChainConfig` (`CanyonTime`, `EcotoneTime`,
-`FjordTime`, `GraniteTime`, `HoloceneTime`, `IsthmusTime`, `JovianTime`, `KarstTime`,
-`InteropTime`, `BedrockBlock`) and methods like `IsCanyon(t)`, `IsEcotone(t)`, etc.
+**Why standalone, not embedding upstream's `params.ChainConfig`** (decision worth remembering):
+embedding would promote go-ethereum's OP-unaware EIP-1559 methods (`ElasticityMultiplier`,
+`BaseFeeChangeDenominator`, `LatestFork`), which would read the embedded (nil) fields and
+silently return L1 defaults — a footgun on consensus-relevant fee params, present both during the
+transition and after the cutover. A standalone type cannot promote them. Code that needs a
+concrete go-ethereum config converts explicitly via `GethChainConfig()` (Ethereum schedule
+derived from the OP schedule: Shanghai=Canyon, Cancun=Ecotone, Prague=Isthmus, Osaka=Karst —
+op-geth's own loader is missing Osaka=Karst; the monorepo follows op-reth, which is correct).
 
-**Direct calls on `*params.ChainConfig`** (not through op-node's `rollup.Config` wrapper):
-- `op-service/eth/types.go:BlockAsPayload` – `config.IsCanyon(t)`, `config.IsIsthmus(t)`
+While the build still resolves go-ethereum to op-geth, `GethChainConfig()` also carries the OP
+fork fields and `Optimism` struct on the produced config (in-process test ELs need them). Those
+fields don't exist upstream — **shedding them is a cutover edit** (#20266).
 
-All other hardfork checks in op-node derivation code go through op-node's own `rollup.Config`
-type, which has its own `IsCanyon(t)`, `IsHolocene(t)` etc. Those do not touch
-`params.ChainConfig`.
-
-`rollup.Config.ChainOpConfig *params.OptimismConfig` carries the OP-specific EIP-1559 parameters.
-
-### Proposed decoupling
-
-**Define `OptimismConfig` and a standalone `ChainConfig` in `op-core/params/`.** `ChainConfig`
-is a **standalone** type — it does *not* embed `params.ChainConfig`. Embedding would promote
-go-ethereum's OP-unaware EIP-1559 methods (`ElasticityMultiplier`, `BaseFeeChangeDenominator`,
-`LatestFork`); since the OP fields live on the wrapper, those promoted methods read the embedded
-(nil) fields and silently return L1 defaults — a footgun on consensus-relevant fee params, present
-both during the transition and after the cutover (upstream go-ethereum exposes the same methods).
-A standalone type cannot promote them, so the footgun does not exist. Code that needs a concrete
-go-ethereum config converts explicitly via `GethChainConfig`.
-
-```go
-// op-core/params/chain_config.go
-
-// OptimismConfig holds OP Stack–specific EIP-1559 parameters.
-// Mirrors params.OptimismConfig from op-geth; JSON tags are identical for wire compatibility.
-type OptimismConfig struct {
-    EIP1559Elasticity        uint64  `json:"eip1559Elasticity"`
-    EIP1559Denominator       uint64  `json:"eip1559Denominator"`
-    EIP1559DenominatorCanyon *uint64 `json:"eip1559DenominatorCanyon,omitempty"`
-}
-
-// ChainConfig is the standalone OP-Stack hardfork schedule of a chain.
-type ChainConfig struct {
-    ChainID      *big.Int        `json:"chainId"`
-    Optimism     *OptimismConfig `json:"optimism,omitempty"`
-    BedrockBlock *big.Int        `json:"bedrockBlock,omitempty"`
-    RegolithTime *uint64         `json:"regolithTime,omitempty"`
-    CanyonTime   *uint64         `json:"canyonTime,omitempty"`
-    // ... EcotoneTime … InteropTime
-}
-
-// Fork predicates delegate to a single ActivationTime / SetActivationTime switch
-// pair, matching the rollup.Config pattern (formalisation tracked in #21267). Only
-// the predicates with in-scope consumers are carried — the unused op-geth
-// IsOptimism / IsOptimism<Fork> convenience family is dropped.
-func (c *ChainConfig) IsCanyon(t uint64) bool { return c.IsForkActive(forks.Canyon, t) }
-func (c *ChainConfig) IsBedrock(num *big.Int) bool { /* block-based */ }
-// ... etc.
-
-// GethChainConfig converts to the equivalent go-ethereum params.ChainConfig, for code
-// that drives a go-ethereum EVM, genesis, or block processor. The Ethereum fork schedule
-// is derived from the OP schedule (Shanghai=Canyon, Cancun=Ecotone, Prague=Isthmus,
-// Osaka=Karst). NB: op-geth's LoadOPStackChainConfig is missing Osaka=Karst — the
-// monorepo's mapping follows op-reth, which is correct.
-func (c *ChainConfig) GethChainConfig() *params.ChainConfig
-```
-
-**`rollup.Config.ChainOpConfig`** changes type from `*params.OptimismConfig` to
-`*opparams.OptimismConfig`. JSON field names are identical so wire format is preserved.
-
-**`BlockAsPayload`** in op-service changes its `config *params.ChainConfig` parameter to a
-`HardforkConfig` interface:
-
-```go
-type HardforkConfig interface {
-    IsCanyon(timestamp uint64) bool
-    IsIsthmus(timestamp uint64) bool
-}
-```
-
-`rollup.Config` already satisfies this interface. This removes the only direct dependency on
-`*params.ChainConfig` for hardfork detection in op-service.
+**Open work (#20270):** `rollup.Config.ChainOpConfig` changes type to `*opparams.OptimismConfig`
+(JSON tags identical → wire-compatible); `op-service/eth.BlockAsPayload`'s
+`*params.ChainConfig` parameter becomes a small local `HardforkConfig` interface
+(`IsCanyon`/`IsIsthmus`) that `rollup.Config` already satisfies; remaining direct OP-hardfork
+reads on go-ethereum's `*params.ChainConfig` go through `rollup.Config` or
+`*opparams.ChainConfig`. Grep recipe: files importing `go-ethereum/params` that call
+`Is<OpFork>(` or reference `OptimismConfig`.
 
 ---
 
-## 6. `params/superchain.go` – `LoadOPStackChainConfig`
+## 6. `params/superchain.go` – `LoadOPStackChainConfig` — **DONE**
 
-### Current usage
-
-op-geth's `params/superchain.go` provides several things; after §0 only one of them still has
-users in the monorepo:
-
-- `LoadOPStackChainConfig(chainCfg *superchain.ChainConfig) (*ChainConfig, error)` —
-  used by `op-service/superutil/chain_config.go` and (transitively) `op-node/rollup/superchain.go`.
-
-The `ProtocolVersion*` types, `ProtocolVersionComparison`, `AheadMajor` / `OutdatedMajor`
-constants, `OPStackSupport` variable, and `NetworkNames` map in the same op-geth file were
-**all removed in §0** and are not carried over.
-
-### Proposed decoupling
-
-**Move to `op-core/params/` as `FromSuperchainConfig`** (drops the `OPStack` prefix —
-redundant inside an `op-core` package), alongside `OptimismConfig` (§5). It produces a standalone
-`*opparams.ChainConfig` from the registry data. Consumers that need a concrete go-ethereum config
-(genesis, EVM/block replay) call `(*opparams.ChainConfig).GethChainConfig()` (§5). Details in §7.
+Moved to `op-core/params.FromSuperchainConfig`; the by-chain-ID loader
+(`LoadChainConfigFromChainID`, ex-superutil) lives in `op-core/params` too. §7 has the layering
+rationale.
 
 ---
 
-## 7. `superchain/` package – entirely op-geth specific
+## 7. `superchain/` package — **DONE** (#20267, #21487)
 
-### Current usage
+The registry package moved verbatim to `op-core/superchain` (embedded zip regenerated from the
+repo-root `superchain-registry` submodule by `sync-superchain.sh`; the zip is gitignored, pinned
+by a committed `.sha256`). `op-service/superutil` was deleted; all consumers import
+`op-core/superchain`.
 
-The op-geth `superchain/` package embeds chain configuration data (TOML configs from the
-superchain registry, zipped into `superchain-configs.zip`) and provides `GetChain(chainID)`,
-`GetSuperchain(network)`, and supporting types. Used in:
+Layering decision worth remembering: the by-chain-ID loader lives in **`op-core/params`**, not
+`op-core/superchain`, because `params.FromSuperchainConfig` takes a `superchain.ChainConfig` —
+putting the loader in `superchain` would create an import cycle. `op-core/superchain` stays a
+pure registry leaf.
 
-- `op-node/rollup/superchain.go` – `superchain.GetChain`, `superchain.GetSuperchain`
-- `op-node/chaincfg/chains.go` – `superchain.GetChain`
-- `op-service/superutil/chain_config.go` – `superchain.GetChain` + `params.LoadChainConfig`
-
-The embedded data is synced from the `ethereum-optimism/superchain-registry` git repo via
-`sync-superchain.sh`, which clones the registry at a pinned commit (`superchain-registry-commit.txt`)
-and zips the configs. op-geth does **not** depend on `superchain-registry` as a Go module; the
-data is embedded as a raw binary blob at compile time via `//go:embed`.
-
-### Proposed decoupling
-
-**Move the entire `superchain/` package and `sync-superchain.sh` to `op-core/superchain/`**,
-verbatim from op-geth. This is a self-contained package with no dependencies on other op-geth
-internals (it only imports `BurntSushi/toml`, `klauspost/compress/zstd`, and standard library).
-
-**No new Go module dependency is required**: the data remains embedded exactly as in op-geth. The
-sync script is also copied.
-
-**`op-service/superutil/`'s by-chain-ID loader moves to `op-core/params/`**, *not* into
-`op-core/superchain/`. Because `op-core/params.FromSuperchainConfig` takes a `*op-core/superchain.ChainConfig`,
-`op-core/params` imports `op-core/superchain`. Putting the by-ID loader in `op-core/superchain`
-(so it could call `FromSuperchainConfig`) would make `op-core/superchain` import `op-core/params` back —
-an import cycle. Keeping it in `op-core/params` keeps the edge one-way and `op-core/superchain` a
-pure registry leaf:
-
-```go
-// current (op-service/superutil/chain_config.go, against op-geth):
-func LoadOPStackChainConfigFromChainID(chainID uint64) (*params.ChainConfig, error) {
-    chain, err := superchain.GetChain(chainID)
-    // ...
-    return params.LoadOPStackChainConfig(chainCfg)
-}
-```
-
-becomes, in `op-core/params/`:
-
-```go
-// op-core/params/, importing op-core/superchain (one-way; no cycle):
-func LoadChainConfigFromChainID(chainID uint64) (*ChainConfig, error) {
-    chain, err := superchain.GetChain(chainID)   // op-core/superchain
-    // ...
-    return FromSuperchainConfig(chainCfg)        // local
-}
-```
-
-**Hardfork schedule in `rollup.Config`** (option a.): `rollup.Config` is extended to load and
-carry all OP hardfork timestamps from the registry, rather than going through `*params.ChainConfig`.
-`rollup.Config.ChainOpConfig *params.OptimismConfig` becomes
-`rollup.Config.ChainOpConfig *opparams.OptimismConfig`. The existing hardfork timestamp fields on
-`rollup.Config` already cover most forks; any gaps (KarstTime, InteropTime) are filled in.
+`rollup.Config` carries the full OP hardfork schedule itself (loaded from the registry,
+bypassing any geth `ChainConfig`); future forks extend `rollup.Config` directly. Any remaining
+gaps ride #20270.
 
 ---
 
-## 8. `consensus/misc/eip1559` – Holocene/Jovian helpers
+## 8. `consensus/misc/eip1559` – Holocene/Jovian helpers — op-node **DONE** (#20268), helpers missing for §13/§14/§18
 
-### Current usage
+`op-core/eip1559` landed and op-node is fully switched (no op-node production code imports geth's
+eip1559; one test file still does — a fork-comparison import that goes away at cutover).
+Signatures operate on `[]byte`/`uint64` only.
 
-op-geth adds `eip1559_optimism.go` with self-contained functions for Holocene/Jovian parameter
-encoding. Used in op-node:
-
-- `rollup/derive/payload_util.go` – `ValidateOptimismExtraData`, `DecodeOptimismExtraData`,
-  `EncodeHolocene1559Params`
-- `rollup/attributes/engine_consolidate.go` – `ValidateOptimismExtraData`,
-  `DecodeOptimismExtraData`, `ValidateHolocene1559Params`, `DecodeHolocene1559Params`
-- `rollup/derive/system_config.go` – `ValidateHolocene1559Params`
-
-(The `rollup/interop/indexing/attributes.go` site listed in earlier drafts no longer uses
-eip1559.) Signatures operate on `[]byte` and `uint64` scalars only. No go-ethereum type
-dependencies.
-
-The op-e2e action helpers (`l1_miner.go`, `engineapi/block_processor.go`,
-`engineapi/l2_engine_api.go`) additionally use `EncodeOptimismExtraData` and
-`DecodeHoloceneExtraData`; those migrate with the test suites in §13.
-
-### Proposed decoupling
-
-**Move to `op-core/eip1559/`**, copied verbatim; the only import is `errors`.
-
-### Status
-
-The package landed in #20268 with a subset of the helpers. Wiring op-node onto it (this issue)
-added the one symbol op-node needed that the initial extraction omitted —
-`ValidateOptimismExtraData` (the fork-dispatching validator that pairs with the already-present
-`DecodeOptimismExtraData`). All four op-node files now import `op-core/eip1559` and no op-node
-code imports `go-ethereum/consensus/misc/eip1559`. `EncodeOptimismExtraData` and
-`DecodeHoloceneExtraData` are still absent from `op-core/eip1559`; add them when §13 migrates
-the op-e2e helpers.
+Still absent from `op-core/eip1559`: only `EncodeOptimismExtraData` and `DecodeHoloceneExtraData`
+(the Holocene/Jovian encode helpers are already present) — add them when §13 migrates the op-e2e
+helpers. The geth-eip1559 imports remaining in genesis (§14) and the check-* tools (§18) are pure
+import swaps onto the existing op-core helpers.
 
 ---
 
-## 9. `beacon/engine` – `PayloadID` type alias
+## 9. `beacon/engine` – `PayloadID` type alias — no change needed
 
-### Current usage
-
-`op-service/eth/types.go` defines `type PayloadID = engine.PayloadID` where `engine.PayloadID` is
-`[8]byte`. This is **standard upstream** go-ethereum.
-
-### Proposed decoupling
-
-None needed — keep the `engine.PayloadID` import.
+`engine.PayloadID` is standard upstream. (op-sync-tester's OP-aware PayloadID *hash* is different
+— see #21525.)
 
 ---
 
-## 10. `beacon/engine` – `PayloadAttributes` / `ExecutableData` extensions
+## 10. `beacon/engine` – `PayloadAttributes` / `ExecutableData` extensions — no change needed
 
-### Current status
-
-op-service defines its **own** `PayloadAttributes`, `ExecutionPayload`, and
-`ExecutionPayloadEnvelope` types in `op-service/eth/types.go`. These mirror the Engine API types
-but are entirely monorepo-defined with the OP-specific extra fields.
-
-The conversion function `BlockAsPayload` accesses only:
-
-```go
-bl.Header().WithdrawalsHash   // standard go-ethereum since EIP-4895 / Shanghai
-bl.BeaconRoot()               // standard go-ethereum since EIP-4788 / Cancun
-```
-
-Both fields exist unchanged in upstream go-ethereum.
-
-### Proposed decoupling
-
-None needed. The `BlockAsPayload` function just needs the `HardforkConfig` interface change
-from §5 and will compile against upstream go-ethereum.
+op-service defines its own Engine-API types with the OP extensions. `BlockAsPayload` touches only
+upstream-stable block/header fields; it just needs the `HardforkConfig` change from §5.
 
 ---
 
-## 11. `ethclient` — JSON decoding of L2 blocks and receipts
+## 11. `ethclient` — JSON decoding of L2 blocks and receipts — open (#20264)
 
-### Problem
+Most `ethclient` usage in the monorepo is safe (L1-only, or standard scalar/receipt-log reads).
+Exactly two failure modes appear when go-ethereum resolves upstream, and both only bite against
+**L2** endpoints:
 
-`github.com/ethereum/go-ethereum/ethclient` is used in many places in the monorepo, but **most
-usages are safe**: they only touch L1, standard receipt fields, or scalar values (chain ID,
-balance). The concern is narrower than it looks.
+1. **L2 block decoding fails**: upstream `Transaction.UnmarshalJSON` rejects the deposit
+   (`0x7E`) and post-exec (`0x7D`) txs present in every L2 block.
+2. **OP receipt fields silently drop**: upstream `types.Receipt` doesn't know the L1-cost /
+   operator-fee fields (§3).
 
-Two failure modes when switching to upstream go-ethereum:
+The audited unsafe production paths are the **op-batcher L2 block fetch** (`driver.go`'s
+`L2Client`) and **txinclude receipt fetch**; op-faucet, op-proposer, op-challenger (headers
+only), op-supernode (receipts via sources; reads only `Logs`) and cannon (no blockchain-layer
+coupling at all — see §12) need nothing. Re-derive with
+`grep -rl 'go-ethereum/ethclient'` and classify each client by endpoint.
 
-1. **L2 block decoding fails on deposit transactions.** op-geth's `core/types/transaction_marshalling.go`
-   has a `case DepositTxType:` arm in `Transaction.UnmarshalJSON` that upstream does not have.
-   With upstream go-ethereum, `ethclient.BlockByNumber` / `BlockByHash` / `TransactionByHash`
-   against an L2 endpoint will fail to unmarshal deposit txs ("transaction type not supported").
-2. **Receipt L1-cost/operator-fee fields are silently dropped.** `ethclient.TransactionReceipt`
-   returns `*types.Receipt`. Upstream `types.Receipt` has no `L1GasPrice`, `L1BlobBaseFee`,
-   `L1BaseFeeScalar`, `L1BlobBaseFeeScalar`, `OperatorFeeScalar`, `OperatorFeeConstant`. These
-   JSON fields exist in the RPC response but are dropped by the unmarshaler. (See §3.)
+### Strategy: make `op-service/sources` the canonical OP-aware client — **no wrapper type**
 
-### Call-site survey (in scope: op-node, op-service, op-batcher)
+The sources clients already speak raw JSON-RPC (not `ethclient`). Extend them; do **not**
+introduce an "OP ethclient" or a go-ethereum-style `Transaction`+`TxData` wrapper. The codebase's
+dominant L2-tx currency is already opaque `[]hexutil.Bytes`; where typed access is needed it is
+almost always class-specific, and a wrapper would re-import the signer/hashing machinery we are
+shedding. Instead, partition the `apis.EthClient` accessors by tx class:
 
-Files importing `ethclient`, categorised:
+- `InfoAndUserTxs(...) (eth.BlockInfo, types.Transactions, error)` — **excludes** the synthetic
+  OP types (`0x7E`/`0x7D`); the remainder are standard Ethereum txs, so the list is plain
+  upstream `types.Transactions` and decodes fine post-cutover. Serves the dominant "skip
+  deposits, operate on user txs" pattern (op-batcher DA estimation, most test iterators).
+- `InfoAndDeposits(...) (eth.BlockInfo, []*optypes.DepositTx, error)` — deposits as op-core
+  structs.
+- `InfoAndFirstDeposit(...)` — header + the L1-info deposit only, for hot paths (pattern
+  prototyped in the closed PR #20532; revive).
+- No `InfoAndPostExecTx` **yet, deliberately**: every known consumer of post-exec data reads it
+  from batch/flashblock bytes (span-batch decode, `op-chain-ops/pkg/sdm`, the flashblock
+  client), not from L2 block bodies — block-fetching code only needs the *exclusion* that
+  `InfoAndUserTxs` provides. Add the accessor when a consumer (e.g. a rebate checker) first
+  needs to read the trailing `0x7D` tx off a block.
 
-**Safe — L1-only or standard fields only** (no change needed):
-- `op-node/cmd/genesis/cmd.go`, `op-node/cmd/batch_decoder/*` — L1 `BlockByNumber` / `ChainID`.
-- `op-service/txmgr/cli.go` — `ChainID` only.
-- `op-service/dial/dial.go` — just the `Dial` wrapper; returned client's use-sites are what matter.
-- `op-service/metrics/balance.go`, `op-batcher/metrics/metrics.go` + `noop.go` — `BalanceAt`.
-- `op-service/gnosis/client.go` + `integration_test/helpers.go` — Gnosis Safe (L1).
-- `op-service/bgpo/oracle.go` — blob tip oracle, operates on L1.
-- `op-node/withdrawals/utils.go` — calls `TransactionReceipt` but reads only `receipt.Logs`
-  (standard field). Safe.
-- `op-service/testutils/devnet/anvil.go` — anvil = L1 simulator, no deposit txs.
+`InfoAndTxsBy*` stays as-is for **L1**. Internally `RPCBlock` keeps txs as raw per-tx bytes: the
+transactions-trie root is recomputed directly from those bytes (a typed tx's trie leaf *is* its
+opaque encoding), synthetic-tx detection is a type-byte check, and each class decodes on demand.
 
-**Unsafe — needs migration:**
-- `op-batcher/batcher/driver.go` — `l2Client.BlockByNumber(...)` against the L2 endpoint, via
-  the `L2Client` interface in `driver.go:77` and `EthClientInterface` in
-  `op-service/dial/ethclient_interface.go`. **Will fail on deposit tx decoding under upstream
-  go-ethereum.**
-- `op-service/txinclude/` — `el.TransactionReceipt` (via the `EL` interface in
-  `interfaces.go:44`) returns `*types.Receipt`; fields read in `txbudget.go` require the OP
-  extensions (§3).
+**Index-correlation caveat** (for §13): callers that iterate the full tx list and correlate by
+position with a receipts list misalign once `InfoAndUserTxs` drops the synthetic txs — such
+tests must filter receipts in lockstep or use a paired accessor.
 
-**op-faucet — just works on upstream:**
-- `op-faucet/faucet/backend/faucet.go` — only direct `ethclient` call is `BalanceAt` (L1
-  balance lookup, upstream-safe). No deposit-tx decoding, no OP receipt fields, no
-  `params.OptimismConfig`, no `params.ProtocolVersion`, no `superchain` imports.
-- `op-service/testutils/simulated_eth_client.go` — wraps `ethclient/simulated.Backend`, used
-  by `op-faucet/faucet/backend/faucet_test.go`. Only uses
-  `simulated.{Backend,Client,NewBackend,WithBlockGasLimit}` — all present in upstream
-  go-ethereum.
-
-No migration work needed for op-faucet.
-
-### Proposed decoupling
-
-**Don't create a new "OP ethclient" wrapper package.** Instead:
-
-1. **Reuse and extend `op-service/sources`, and partition the transaction accessors by tx
-   class rather than introducing an `optypes.Transaction` wrapper.** The clients there
-   (`EthClient`, `L1Client`, `L2Client`) already do raw JSON-RPC via `client.RPC` — not via
-   `ethclient`. Their `RPCBlock` type in `op-service/sources/types.go` already deserialises
-   blocks with `[]*types.Transaction` and calls `IsDepositTx()` on L2 blocks. Under upstream
-   go-ethereum that decode breaks on **both** synthetic OP tx types — the L1-info deposit
-   (`0x7E`) and, on Lagoon+ blocks, a trailing post-exec rebate tx (`0x7D`) (§1).
-
-   **Why no wrapper.** The codebase's dominant L2-tx currency is already opaque
-   `[]hexutil.Bytes` (`eth.ExecutionPayload.Transactions`); most of the pipeline never holds
-   typed L2 txs. Where typed access *is* needed, the need is almost always class-specific —
-   "the first tx, as a deposit" or "the user txs, skipping the synthetic ones" — and each
-   class has a clean home type. A go-ethereum-style `Transaction`+`TxData` wrapper would
-   re-import the signer/hashing machinery we are trying to shed, for a list that is read
-   typed-ly in very few places. So instead of a wrapper, split the accessor on
-   `apis.EthClient` (`op-service/apis/eth.go`) by class:
-
-   - `InfoAndUserTxs(...) (eth.BlockInfo, types.Transactions, error)` — **excludes** the
-     synthetic OP types (`0x7E` deposits and `0x7D` post-exec). The remainder are all standard
-     Ethereum tx types, so the returned list is plain **upstream** `types.Transactions` and
-     decodes fine post-cutover. Serves the dominant "skip deposits, operate on user txs"
-     pattern (op-batcher DA estimation; most acceptance-test iterators).
-   - `InfoAndDeposits(...) (eth.BlockInfo, []*optypes.DepositTx, error)` — the deposits, as
-     op-core structs; fields read directly off the struct.
-   - `InfoAndFirstDeposit(...) (eth.BlockInfo, *optypes.DepositTx, error)` — header + the
-     first tx (the L1-info deposit) only, for hot paths that never want the full body. This
-     is exactly the shape prototyped (header-only fetch + first-tx decode) in PR #20532
-     (`HeaderAndFirstTx` / `BlockRefFromHeaderAndDeposit`), which closed unmerged but
-     established the pattern; revive it here.
-
-   `InfoAndTxsBy*` stays as-is for **L1** (no OP tx types there, upstream-safe). Internally,
-   `RPCBlock` keeps the txs as raw per-tx bytes: the transactions-trie root is recomputed
-   directly from those bytes (the trie leaf for a typed tx *is* its opaque `MarshalBinary`
-   encoding), deposit/post-exec detection is a type-byte check, and the partitioned accessors
-   decode each class on demand. A post-exec tx (`0x7D`) is similarly routed to
-   `optypes.PostExecTx`; add an `InfoAndPostExecTx`-style accessor only if a consumer needs to
-   read it (most code only needs to *exclude* it, which `InfoAndUserTxs` already does).
-
-   **Index-correlation caveat.** Some callers iterate the *full* list and correlate by
-   position with the receipts list — e.g. `op-acceptance-tests/tests/jovian/da_footprint.go`
-   does `for i, tx := range txs { if tx.IsDepositTx() { continue }; …receipts[i]… }`. Because
-   `InfoAndUserTxs` drops the synthetic txs, those indices shift relative to a full receipts
-   list and the correlation misaligns. Such tests must filter receipts in lockstep (or use a
-   paired `(userTx, receipt)` accessor). Tracked with the test migration in §13 / #20265.
-
-2. **Migrate `op-batcher/batcher/driver.go` to `op-service/sources.EthClient`.** Its `L2Client`
-   interface (`BlockByNumber` returning `*types.Block`) changes to the `InfoAndUserTxs`
-   accessor above: the batcher only iterates transactions to filter out deposits for DA
-   estimation (`op-batcher/batcher/types.go` — `IsDepositTx()` skip + `RollupCostData()` /
-   `Size()` on the rest), so the user-txs list is exactly what it needs and it no longer
-   touches deposits at all. `tx.RollupCostData()` becomes `opfees.TxRollupCostData(tx)` (§4).
-   Also change `op-service/dial/ethclient_interface.go` so `L2EndpointProvider.EthClient`
-   returns a sources client instead of `*ethclient.Client` (or phase that interface out
-   altogether).
-
-3. **Change `op-service/txinclude/EL.TransactionReceipt` return type to `*optypes.Receipt`**
-   (from §3). The underlying implementation switches from `ethclient.TransactionReceipt` to a
-   raw JSON-RPC call in `op-service/sources` that unmarshals into the extended receipt. Same
-   interface pattern as elsewhere in sources.
-
-### Test implications
-
-- **No production test-double depends on op-geth-specific simulated backend APIs.**
-  `op-service/testutils/simulated_eth_client.go` (used by `op-faucet/faucet/backend/faucet_test.go`)
-  only uses symbols that exist in upstream go-ethereum; it needs no changes.
-- Tests that currently use `ethclient.Dial` against real L1 endpoints (anvil, etc.) are
-  unaffected: anvil is L1 and has no deposit txs, and op-geth's receipt extensions on L1 don't
-  apply.
-- Tests that fetch L2 receipts or blocks via `ethclient` (e.g., in `op-e2e/`) are **out of the
-  current scope** but will need the same treatment if we later bring them into the decoupling.
-  Likely pattern: import the relevant `op-service/sources` client in the tests.
-- op-challenger/op-proposer use `ethclient` for L1 balance metrics and L1/L2 header access. The
-  L2 header path (`op-challenger/game/client/provider.go`) would have the same deposit-tx
-  decoding issue if it fetched full blocks, but headers don't contain transactions so they're
-  fine. These components are out of current scope anyway.
-
-### Summary
-
-Answer to "do we need an extended OP-Stack ethclient?": **No.** The deposit-tx decoding issue
-only bites in two concrete places (batcher L2 block fetch, txinclude receipt fetch), both already
-behind interfaces or trivially migratable to `op-service/sources`. The `op-service/sources`
-clients become the canonical "OP-aware ethclient" — we extend their existing raw-RPC decoding
-rather than introducing a parallel wrapper.
+Concrete migrations in this issue: op-batcher's `L2Client` moves to `InfoAndUserTxs` (it only
+filters deposits for DA estimation; `RollupCostData` → `opfees.TxRollupCostData`);
+`op-service/dial`'s `L2EndpointProvider.EthClient` returns a sources-shaped client (or the
+interface is phased out); txinclude's `EL.TransactionReceipt` → `*optypes.Receipt` via raw RPC.
 
 ---
 
-## 12. `op-proposer`, `op-challenger`, `op-supernode`, `cannon` — near-zero op-geth coupling
+## 12. `op-proposer`, `op-challenger`, `op-supernode`, `cannon` — audited: no migration needed
 
-Audit result: all four are essentially safe to run against upstream go-ethereum with zero or
-near-zero changes.
-
-**`op-proposer`** — pure L1 operations. Imports `types.Header` and `ethereum.CallMsg` only;
-no `types.Transaction` or `types.Receipt` anywhere. All contract calls go through
-`op-service/sources/batching.MultiCaller`. `ethclient.Client` is instantiated but only used for
-upstream-compatible L1 methods (`HeaderByNumber`, `CodeAt`, `CallContract`). Zero uses of
-deposit txs, OP receipt fields, or OP params/hardfork methods. **No migration needed.**
-
-**`op-challenger`** — ~90% L1, one L2 interaction that is safe.
-- The only L2 client access is `op-challenger/game/client/provider.go:24,77` (owns an
-  `ethclient.Client` for L2). The `L2HeaderSource` interface
-  (`op-challenger/game/fault/trace/utils/local.go:22-24`) exposes only `HeaderByNumber`.
-- The sole call site (`op-challenger/game/fault/trace/outputs/provider.go:121`) fetches a
-  header for proof generation — **headers don't contain transactions**, so the deposit-tx
-  decode issue from §11 doesn't apply.
-- L1 work uses `op-service/sources.L1Client` and other sources-based abstractions.
-- Zero uses of `BlockByNumber`/`BlockByHash`/`TransactionByHash`, extended `Receipt` fields,
-  or `DepositTx`.
-- **No migration needed.** If anything in this package ever starts needing L2 block bodies
-  (txs), migrate at that point per §11.
-
-**`op-supernode`** — no direct `ethclient` imports. Receipts are obtained via the monorepo's
-`FetchReceipts(ctx, blockHash) → (eth.BlockInfo, types.Receipts, error)` interface
-(`chain_container/engine_controller/engine_controller.go:28`), backed by `op-service/sources`.
-The only fields read from receipts are `receipt.Logs` (standard upstream — see
-`supernode/activity/interop/logdb.go:265`, `verification_view.go:59`). No uses of
-`DepositTx`, OP receipt fields, `params.OptimismConfig`, `params.ProtocolVersion*`, or the
-`superchain` package. **No migration needed** — implementation changes behind
-`op-service/sources` (§11) are picked up transparently.
-
-**`cannon`** — pure MIPS FPVM. Imports only `common`, `hexutil`, `log` from go-ethereum. No
-`ethclient`, no `types.Block`/`Transaction`/`Receipt`, no `core/types`. The preimage oracle
-interface accepts arbitrary bytes — it never decodes OP Stack types. **Zero blockchain-layer
-coupling; zero migration needed.**
+- **op-proposer** — pure L1; contract calls via `sources/batching.MultiCaller`; no deposit txs,
+  OP receipt fields, or OP params anywhere.
+- **op-challenger** — ~90% L1; its single L2 access fetches *headers* only (no txs → no decode
+  issue). If it ever needs L2 block bodies, migrate per §11 then.
+- **op-supernode** — no direct `ethclient`; receipts via sources interfaces, reads only
+  `receipt.Logs`. Picks up §11 improvements transparently.
+- **cannon** — imports only `common`/`hexutil`/`log`; the preimage oracle treats bytes opaquely.
+  Zero blockchain-layer coupling.
 
 ---
 
-## 13. Tests: `op-e2e`, `op-acceptance-tests`, `op-devstack`
+## 13. Tests: `op-e2e`, `op-acceptance-tests`, `op-devstack` — open (#20265)
 
-### Survey
+Dependency profiles: **op-acceptance-tests** has zero direct `ethclient` imports — everything
+goes through the op-devstack DSL to `apis.EthClient`, so it picks up §11's implementation swap
+automatically (this is why §11 rejects a parallel wrapper type). **op-e2e** uses `ethclient` and
+OP receipt fields directly in dozens of files. **op-devstack**'s DSL layer is clean;
+`sysgo/` calls `ethclient.Dial` directly in a handful of files (mostly L1 contract/dispute-game
+setup).
 
-Two different dependency profiles across the test suites:
+### Strategy
 
-**op-e2e** — 271 Go files, 45 import `ethclient` directly. Uses `types.Receipt` fields widely.
-Central utility: `op-e2e/e2eutils/geth/wait.go` (wait-for-block / wait-for-tx helpers) is
-imported by ~26 test files. Test framework `e2esys.SystemConfig` exposes `L1Client` /
-`L2Client` as `*ethclient.Client`.
+1. **`apis.EthClient.TransactionReceipt` / `FetchReceipts`** return `*optypes.Receipt` (§3);
+   the many test sites reading OP receipt fields keep working unchanged.
+2. **L2 tx iteration** migrates to the class-partitioned accessors from §11 (`InfoAndUserTxs`
+   removes the per-tx `IsDepositTx()` checks entirely). Mind the index-correlation caveat (§11).
+3. **`op-e2e/e2eutils/geth/wait.go`** (the central wait helpers, ~26 importers): none of them
+   semantically need OP specifics — the failure is transport-level (full-block decode on L2).
+   Split into header-only variants (`HeaderByNumber`-based, L2-safe) for the majority of callers
+   that discard the block, keep a full-block variant backed by `apis.EthClient` for the few that
+   read the body; `WaitForTransaction` returns `*optypes.Receipt`.
+4. **`e2esys.SystemConfig.L2Client`** becomes `apis.EthClient`; L1 stays `*ethclient.Client`.
+5. **`op-devstack/sysgo`**: per-call audit; L1 callers stay on `ethclient`, L2 callers migrate
+   to sources.
+6. **Hardfork checks** on geth `*params.ChainConfig` in tests migrate to `*opparams.ChainConfig`
+   (mostly automatic once the loaders return the op-core type).
+7. **`op-e2e/opgeth/` is deleted** (#20275), not migrated — it intentionally exercises op-geth
+   engine internals; op-reth equivalents are introduced separately.
 
-**op-acceptance-tests** — 132 Go files, **0 direct `ethclient` imports**. Everything goes
-through the `op-devstack` DSL (`dsl.L2ELNode`, `dsl.Funder`, etc.). Tests ultimately reach an
-`apis.EthClient` via `sys.L2EL.Escape().EthClient()`. This suite is already half-decoupled.
+### Audit notes
 
-**op-devstack** — 157 Go files. The DSL layer (`dsl/`, `presets/`) exposes `apis.EthClient`
-(interface defined in `op-service/apis/eth.go`, already in our repo, not go-ethereum's). The
-infrastructure layer (`op-devstack/sysgo/`) calls `ethclient.Dial` / `ethclient.NewClient`
-directly in ~7 files — mostly for L1 contract interaction (L1 contract deployment,
-`OptimismPortal2` game-type setup, faultproof dispute-game setup).
-
-### Concrete patterns and scale
-
-| Pattern | Files (e2e + acceptance) | Risk under upstream go-ethereum |
-|---|---|---|
-| `ethclient` / `apis.EthClient` against L1 only (balance, nonce, chainID, receipt logs) | ~majority | Safe |
-| `ethclient.BlockByNumber` / `InfoAndTxsByNumber` against L2 (full block JSON incl. deposit txs) | unknown, needs audit per file | Deposit-tx decode fails — covered by §11 |
-| Read OP-extended receipt fields (`L1Fee`, `L1GasPrice`, `L1BlobBaseFee`, `L1BaseFeeScalar`, `L1BlobBaseFeeScalar`, `OperatorFeeScalar`, `OperatorFeeConstant`, `DepositNonce`) | 21 files (17 e2e + 4 acceptance) | Fields silently drop — covered by §3 |
-| Construct `types.DepositTx` or call `IsDepositTx()` / `SourceHash()` / `Mint()` | 7 files | Covered by §1 / §2 |
-| `params.ChainConfig` OP hardfork checks (`IsCanyon`, `IsIsthmus`, etc.) | ~10-24 files | Covered by §5 once `HardforkConfig` interface lands, or directly on `opparams.ChainConfig` |
-| EIP-1559 Holocene/Jovian extra-data helpers | 2 files (Jovian min-basefee tests) | Covered by §8 |
-| `ethclient/simulated.Backend` for L1 simulation | a handful in `op-e2e/opgeth/` and `op-devstack/sysgo/` | Simulated backend APIs are upstream; no change unless tests exercise L2 deposit paths |
-
-### Key observation: op-acceptance-tests already uses the right shape
-
-Because the DSL routes all client access through `apis.EthClient` (monorepo interface) and
-returns results via DSL result types that embed `*types.Receipt`, every improvement we make to
-the implementation behind `apis.EthClient` automatically benefits all acceptance tests. In
-particular:
-
-- Swapping the implementation from `ethclient`-based to `op-service/sources`-based fixes L2
-  block decoding transparently.
-- Changing the `TransactionReceipt` return type from `*types.Receipt` to
-  `*optypes.Receipt` (from §3) ripples through the DSL result types mechanically.
-
-This reinforces the recommendation in §11: **don't introduce a parallel "OP ethclient" type;
-make `op-service/sources` the canonical implementation of `apis.EthClient`.**
-
-### Proposed decoupling strategy
-
-1. **`apis.EthClient.TransactionReceipt`**: change return type from `*types.Receipt` to
-   `*optypes.Receipt` (from §3). Same for `ReceiptsFetcher.FetchReceipts`.
-   Implementations in `op-service/sources` unmarshal the extended fields; all 21 call sites
-   that read OP receipt fields keep working.
-
-2. **L2 transaction accessors**: rather than make `InfoAndTxsBy*` round-trip OP tx types,
-   add the class-partitioned accessors from §11 — `InfoAndUserTxs` (synthetic `0x7E`/`0x7D`
-   excluded → upstream `types.Transactions`), `InfoAndDeposits` / `InfoAndFirstDeposit`
-   (→ `*optypes.DepositTx`). Tests that fetch the L2 block and iterate migrate to whichever
-   accessor matches their intent; "skip deposits, read user txs" becomes `InfoAndUserTxs`,
-   removing the per-tx `IsDepositTx()` check entirely. `InfoAndTxsBy*` is unchanged for L1.
-
-3. **`op-e2e/e2eutils/geth/wait.go`**: the central wait helpers (`WaitForBlock`,
-   `WaitForBlockToBeSafe`, `WaitForBlockToBeFinalized`, `WaitForTransaction`,
-   `WaitUntilTransactionNotFound`, `WaitForL1OriginOnL2`) take `*ethclient.Client`. **None of
-   these functions semantically require OP-Stack specifics** — they use only standard
-   go-ethereum APIs. The failure mode under upstream is purely transport-level: the
-   transitive `BlockByNumber` / `TransactionByHash` calls decode block bodies, which contain
-   deposit txs when pointed at an L2 endpoint.
-
-   A majority of callers pass the L2 sequencer/verifier client but discard the returned
-   `*types.Block` (`_, err := geth.WaitForBlock(...)` — they only care about the "reached
-   height" side effect). So the simpler fix is to **split these helpers into
-   header-only versus full-block variants**:
-   - `WaitForBlockHeight(num, client)` returning `*types.Header` via `HeaderByNumber`
-     (L2-safe — headers don't contain transactions).
-   - Keep `WaitForBlock` returning `*types.Block` for the handful of callers that use the
-     body (`eip1559params_test.go`, etc.), and migrate it to `apis.EthClient`-backed
-     `sources.EthClient` so deposit txs decode.
-   - `WaitForTransaction` returns `*types.Receipt` — change to `*optypes.Receipt` per §3;
-     callers already reading `receipt.L1Fee` etc. keep working.
-   - `WaitUntilTransactionNotFound`'s `TransactionByHash` call would fail if the target tx
-     is itself a deposit tx under upstream. Audit shows callers use non-deposit user txs, so
-     the simplest patch is to document this and, if needed, switch to a sources-backed path.
-
-4. **`op-e2e/system/e2esys.SystemConfig.L2Client`**: change from `*ethclient.Client` to
-   `apis.EthClient` (backed by `sources.EthClient`). L1 can remain `*ethclient.Client` since
-   it's upstream-safe.
-
-5. **`op-devstack/sysgo/` direct `ethclient.Dial` calls**: audit each file. Calls on the L1
-   endpoint (contract deployment, deposit proxy setup, faultproof dispute-game setup) are
-   safe to leave as-is — L1 receipts and blocks don't contain OP-specific encoding. Any call
-   on an L2 endpoint needs migration to `sources.EthClient`.
-
-6. **Hardfork checks in tests**: tests that call `chainCfg.IsCanyon(t)` on `*params.ChainConfig`
-   migrate to calling the same method on `*opparams.ChainConfig` (from §5). The superchain
-   registry loader (`LoadChainConfigFromChainID`) returns `*opparams.ChainConfig`
-   post-§7, so most test setups get the new type automatically.
-
-7. **`op-e2e/opgeth/` directory**: this is a tightly-coupled engine-API/op-geth test package
-   (block building, fork choice, extra-data validation) — it intentionally exercises op-geth
-   internals. **Plan: delete this package as part of the decoupling.** Equivalent tests against
-   op-reth will be introduced separately. No migration attempt; just excise with the final
-   decoupling. Documented here so future contributors know not to invest in migrating these
-   tests.
-
-### Test implications
-
-- No new test doubles are required beyond what §3 and §11 already introduce.
-- The simulated backend (`ethclient/simulated.Backend`) uses only upstream-stable APIs in
-  current test usage; no migration needed unless we add L2-simulating tests.
-- Tests written against the `op-devstack` DSL (all of op-acceptance-tests) pick up decoupling
-  improvements for free once the `apis.EthClient` implementation is swapped.
-- Tests written directly against `*ethclient.Client` in op-e2e must be migrated in order to:
-  (a) decode L2 blocks containing deposit txs, (b) read OP receipt fields. The `wait.go`
-  migration (item 3 above) is the biggest single unblock.
-
-### Audit: op-e2e direct L2 block/tx fetches
-
-Deep audit of all `BlockByNumber`, `BlockByHash`, `TransactionByHash` call sites in
-`op-e2e/**` (excluding `op-e2e/opgeth/`, which is being removed):
-
-**L2 block/tx fetches — 19 call sites** — these fail under upstream go-ethereum due to
-deposit-tx decoding. Concentrated in:
-- `op-e2e/actions/proofs/isthmus_fork_test.go` (3 sites)
-- `op-e2e/actions/upgrades/ecotone_fork_test.go` (3 sites)
-- `op-e2e/actions/helpers/user.go` (2 sites — `CrossLayerUser`)
-- `op-e2e/faultproofs/cannon_benchmark_test.go` (1 site)
-- `op-e2e/interop/interop_test.go` (1 site)
-- `op-e2e/system/bridge/validity_test.go` (1 site)
-- `op-e2e/system/conductor/system_adminrpc_test.go` (3 sites)
-- `op-e2e/system/fees/` (3 sites across `fees_test.go`, `l1info_test.go`)
-- `op-e2e/system/verifier/legacy_pending_test.go` (2 sites)
-
-Migration: point these through `apis.EthClient` / `sources.EthClient`, or where only height
-matters, switch to `HeaderByNumber`.
-
-**L1 block/tx fetches — 7 call sites** — safe under upstream go-ethereum. No change needed.
-Locations in `e2eutils/disputegame/`, `actions/upgrades/ecotone_fork_test.go`,
-`interop/interop_test.go`, `faultproofs/cannon_benchmark_test.go`, `system/fees/l1info_test.go`.
-
-**Ambiguous utility functions — 7 call sites across 2 files**:
-- `op-e2e/e2eutils/geth/find.go:32` — `FindBlock(client *ethclient.Client, ...)`, generic.
-- `op-e2e/e2eutils/geth/wait.go:44,80,164,176,219,229` — wait helpers (see item 3 above).
-
-These are invoked with both L1 and L2 clients depending on caller. Migration of these
-utilities (header-only split + `apis.EthClient` backing) automatically handles both call
-patterns.
+L2-endpoint full-block/tx fetches were ~20 sites at the 2025 audit — re-derive before working
+(`grep -rn 'BlockByNumber\|BlockByHash\|TransactionByHash' op-e2e/`, classify by target
+endpoint); L1 fetches are safe; the generic utilities (`geth/find.go`, `wait.go`) are fixed once
+via item 3 and cover both call patterns. The simulated backend (`ethclient/simulated`) uses only
+upstream-stable APIs.
 
 ---
 
-## 14. Genesis tooling — op-geth as a *library*, not an engine
+## 14. Genesis tooling — op-geth as a *library*, not an engine — open (#21281, #21282)
 
-A distinction the rest of this plan leaves implicit: removing op-geth has two parts.
+Removing op-geth has two parts: op-geth as the execution *engine* (in-process ELs — deleted or
+replaced by op-reth; §17, #21196) and op-geth as a *library* in offline tooling. The genuine
+in-scope library consumer is **`op-chain-ops/genesis`** (`BuildL2Genesis`: genesis state-root +
+`genesis.json`). `op-simulate`/`op-run-block` are deleted instead (#21282, no importers).
 
-1. **op-geth as the execution *engine*** — the in-process op-geth EL in op-e2e action tests /
-   `op-e2e/opgeth/`. These are deleted or replaced by op-reth. Their need for a concrete
-   go-ethereum config is **temporary** and served by `GethChainConfig()` until they go away.
-2. **op-geth as a *library* in offline tooling** — `op-chain-ops/genesis.BuildL2Genesis` (genesis
-   state-root + `genesis.json`) and the block-replay tools. These **stay**, and they genuinely
-   need a go-ethereum config carrying the OP fields. This tooling is in scope: it must eventually
-   build against **upstream** go-ethereum, not op-geth.
+The only op-geth *diff* the genesis path relies on: for Isthmus+ chains the genesis block's
+`WithdrawalsHash` is the storage root of the `L2ToL1MessagePasser` predeploy (via the upstream
+`GetStorageRoot` primitive) instead of the empty hash. Migration (#21281): genesis builds an
+`opparams.ChainConfig` and serialises *that* into `genesis.json` (it carries the OP fields;
+upstream's config cannot); the block/state-root is computed against upstream via
+`GethChainConfig()`; the ~15-line Isthmus withdrawals-root rule is ported on top of upstream
+`state`/`triedb` + `op-core/predeploys`. This is why `GethChainConfig()` is a real bridge rather
+than throwaway.
 
-   `op-simulate` / `op-run-block` are slated for **deletion** (no importers; reimplement in Rust if
-   ever needed), leaving genesis as the one in-scope geth-as-library consumer.
+---
 
-**Genesis migration to upstream go-ethereum.** The only op-geth *diff* the genesis path relies on is
-one OP rule in `core/genesis.go`: for Isthmus+ chains the genesis block's `WithdrawalsHash` is set
-to the storage root of the `L2ToL1MessagePasser` predeploy (`statedb.GetStorageRoot` — itself an
-upstream primitive), rather than the empty withdrawals hash. Everything else (alloc → state trie,
-`statedb.Commit`, Shanghai/Cancun/Prague header fields) is identical upstream code. The migration:
+## 15. Infrastructure fork extensions — `log` and `rpc`
 
-- `op-chain-ops/genesis` builds an `opparams.ChainConfig` and serialises it as the `genesis.json`
-  `config` (it carries the OP fields + tags; upstream's `ChainConfig` cannot).
-- The genesis **block/state-root** is computed against upstream go-ethereum via `GethChainConfig()`
-  (the Ethereum fork schedule suffices for `ToBlock`), with the ~15-line Isthmus
-  withdrawals-root rule ported into the monorepo on top of upstream `state`/`triedb` + the
-  `L2ToL1MessagePasser` predeploy address.
+op-geth doesn't only add OP *protocol* code; having a fork made it cheap to add general-purpose
+hooks to geth's infrastructure packages, and op-service foundations grew to depend on them. They
+sit under every service, so they break the whole tree at cutover, and two of them are *features*
+rather than symbols. (Found by the 2026-07 upstream-build spike; §19 keeps finding such uses.)
 
-This is a bounded follow-up, unblocked by `op-core/params` + `GethChainConfig()`; it is the reason
-`GethChainConfig()` is a real bridge rather than throwaway.
+**Log context extensions** — fork adds `Logger.SetContext`, `WriteCtx`, `LogAttrs`, and the
+`Trace/…/ErrorContext` methods; `op-service/log`'s logfilter feature and `op-service/testlog`
+build on them. Strategy: **own the log layer** — depending on an internal log API is better
+layering than importing `geth/log` everywhere anyway.
+
+- *Phase 1 (pre-cutover, mechanical, per-component):* `oplog.Logger` becomes a **type alias** of
+  geth `log.Logger`, plus re-exports of the package-level API in use (`Root`, `SetDefault`,
+  `NewLogger`, level parsing). Sweep every `go-ethereum/log` import to `op-service/log` — a
+  no-op rename while the alias holds.
+- *Phase 2 (at cutover):* flip the alias to an owned interface (upstream's method set + the
+  context methods) with an slog-backed implementation. Implement over `slog` — don't copy
+  upstream's LGPL log package; the fork's context-extension logic is OP-authored and ports. The
+  owned interface is a superset of upstream's, so our loggers still satisfy `log.Logger` where we
+  hand one into geth code (e.g. the in-process L1 geth in op-e2e).
+
+**RPC recording hooks** — fork adds `rpc.Recorder`/`RecordedMsg`/`RecordDone`/`WithRecorder`
+inside the geth RPC client *and server*; `op-service/metrics` (RPC metrics), `op-service/rpc`,
+and `op-service/client` build on them. Client-side recording moves into our own client wrappers
+(a seam we own); server-side needs a new interception point (HTTP middleware or handler
+wrapping) — small design task, metric names/labels must be preserved. `rpc.JsonError`
+(op-test-sequencer) is the same family, trivially replaced by a local error type.
+
+**One-off fork symbols** in the same spirit — `Transaction.SetBlobTxSidecar` (op-service/signer),
+`types.NewIsthmusSigner`, the fork-changed `types.NewBlock(…, *BlockConfig)` signature
+(op-service/testutils), `types.LogForStorage` (op-chain-ops/crossdomain; deleted upstream),
+`params.InteropCrossL2InboxAddress` (used by `op-core/interop/messages` — switch to
+`op-core/predeploys`) — ride the §2-style call-site swaps (#20263 family). Derive current sites
+by grepping the symbol; listed file snapshots go stale.
+
+---
+
+## 16. `op-chain-ops/script` + op-deployer — Rust script engine
+
+`op-chain-ops/script` is the Foundry-style in-process forge-script executor; op-deployer runs all
+deployment/genesis scripts through it. Semantically it is **plain L1 EVM** — its chain config
+activates only Ethereum forks (the OP fork fields are explicitly nil) — so by §"scope" rules it
+*could* be fate 1. But its cheatcode mechanism runs on fork-only EVM hooks that upstream has no
+equivalent for: `vm.Config.PrecompileOverrides` (cheatcode precompiles), `vm.Config.CallerOverride`
+(pranks), `vm.Config.NoMaxCodeSize`, and the exported `state.StateUpdate` without which
+`script/forking.ForkDB` cannot implement upstream's `state.Database` (its `Commit` takes an
+*unexported* type). "Swap to op-core" does not exist here.
+
+**Decision: rewrite script execution as a Rust engine reusing foundry crates** (forge is the
+reference executor for these scripts; revm underneath), consumed by op-deployer — subprocess/
+sidecar per the op-reth-test-engine precedent (#20415), or equivalent embedding. Constraints:
+op-deployer keeps working without a system-installed foundry (engine version-pinned and shipped
+with our tooling); cheatcode surface limited to what our scripts use (derive from the cheatcode
+dispatch in `op-chain-ops/script`); parity-gate against the Go engine on reference deployments
+before switching.
+
+**No interim module split.** Splitting op-chain-ops+op-deployer into their own Go module that
+keeps the op-geth replace was considered and rejected: the epic's value only materialises when we
+stop maintaining the op-geth fork entirely — any in-repo module still depending on it keeps the
+fork alive. (The same lens applies to the superchain-registry repo's `ops` module, which pins its
+own op-geth — outside this repo, flagged to that team.)
+
+This is a hard blocker of #20266 and the longest pole alongside #20415/#21196.
+
+---
+
+## 17. In-process op-geth L2 EL in op-e2e system tests and op-devstack/sysgo
+
+Beyond op-e2e/actions (§ scope fate 2, #21196), op-e2e *system* tests and op-devstack/sysgo can
+run op-geth **in-process as the L2 EL**: `op-e2e/e2eutils/geth.InitL2` behind the
+`e2eutils/el.InitL2` factory's `ELKindOpGeth`, and `op-devstack/sysgo/l2_el_opgeth.go`. After the
+go.mod flip these would silently run *upstream* geth as the L2 EL — wrong OP state transition,
+with no compile error to warn us. The in-process **L1** geth miner is unaffected (plain Ethereum
+semantics are exactly right for it under upstream) and stays.
+
+Plan: make op-reth the **only** L2 EL kind — delete `ELKindOpGeth`, `geth.InitL2`,
+`l2_el_opgeth.go`, and the geth-only knob plumbing (`GethOptions`); resolve each geth-pinned test
+case by case (migrate or delete with rationale; derive the pin list by grepping `ELKindOpGeth` /
+`GethOption`). The pre-Regolith tests (#21451: op-reth returns `IsSystemTx` as a string on
+pre-Regolith blocks) fold into this — likely resolved by deleting them and requiring
+bedrock/regolith co-activation. Precedent: #21182 (acceptance tests op-reth-only for Karst+).
+
+---
+
+## 18. Remaining op-chain-ops tools — check-* and op-wheel
+
+**`cmd/check-*` per-fork checkers** verify fork activation on live chains using fork symbols
+(`types.DepositTx`, receipt `DepositReceiptVersion`, L1-cost funcs, `types.CalcDAFootprint`, geth
+`eip1559` Jovian helpers). Plan: **delete the checkers for long-activated forks** (proposal:
+pre-Holocene — team confirms the list on the issue) and **swap the survivors to op-core**, adding
+the one missing symbol family with differential tests — DA-footprint calculation
+(`types.CalcDAFootprint`) to `op-core/fees`; the eip1559 uses are import swaps onto the existing
+`op-core/eip1559` helpers (§8).
+
+**`op-wheel`** splits cleanly: the `engine` commands drive a live EL over Engine-API RPC —
+upstream-safe, stay. The `cheat` commands do offline surgery on **op-geth datadirs** (raw
+`rawdb`/`core/state`, fork-only `StateDB.OpenStorageTrie`, in-process block processing) — not
+upstream-portable, and pointless in an op-reth fleet whose datadirs aren't geth-format. Plan:
+**delete `op-wheel/cheat`** (op-simulate precedent, #21282).
+
+---
+
+## 19. CI ratchet — continuously rehearsing the cutover
+
+A scheduled CI job makes decoupling progress measurable and regression-proof: in a throwaway
+checkout it drops the go-ethereum `replace`, pins upstream at the current op-geth base version,
+runs `go mod tidy` + `go build`/`go vet`, and compares the **set of failing packages** against a
+committed baseline. A failure outside the baseline is a regression (a fork-API use crept into a
+clean package) and fails the job; a baselined package turning green shrinks the baseline — it
+only ever tightens. #20266 becomes executable exactly when the baseline is empty, and the flip PR
+deletes the job. The op-core differential tests are expected baseline members until then (they
+import op-geth-only symbols by design).
 
 ---
 
 ## Summary table
 
-| Area | op-geth source | Target in monorepo | Effort |
-|------|---------------|-------------------|--------|
-| Remove protocol-versions watching (§0) | n/a | deletion in op-node/op-service | Medium |
-| `DepositTx` type + `MarshalBinary` | `core/types/deposit_tx.go` | `op-core/types/` | Medium |
-| `DepositTxType` constant | `core/types/deposit_tx.go` | `op-core/types/` | Trivial |
-| `IsDepositTx()` free function | `core/types/transaction.go` | `op-core/types/` | Trivial |
-| `IsSystemTx()`, `SourceHash()`, `Mint()` helpers | `core/types/transaction.go` | `op-core/types/` | Low |
-| `PostExecTx` type + `MarshalBinary`, `PostExecTxType` constant, `IsPostExecTx()` | `core/types/post_exec_tx.go` | `op-core/types/` | Low |
-| `RollupCostData`, `NewRollupCostData`, `EstimatedDASize`; L1 cost as free funcs `L1Cost{Bedrock,Ecotone,Fjord}` + `L1FeeParams` (no `L1CostFunc` type) | `core/types/rollup_cost.go` | `op-core/fees/` | Low |
-| `OperatorCost{Isthmus,Jovian}(gasUsed, scalar, constant)` — replaces inline math | n/a (deduplicates inline math) | `op-core/fees/` | Trivial |
-| `TxRollupCostData(tx)` — replaces method | `core/types/transaction.go` | `op-core/fees/` | Trivial |
-| `Receipt` (receipt L1-cost fields) | `core/types/receipt_opstack.go` | `op-core/types/` | Medium |
-| `OptimismConfig` struct | `params/config.go` | `op-core/params/` | Trivial |
-| `ChainConfig` (standalone, not embedding upstream) | `params/config.go`, `params/config_op.go` | `op-core/params/` | Medium |
-| `GethChainConfig()` — converter to go-ethereum's `ChainConfig` | n/a (replaces the embed) | `op-core/params/` | Low |
-| `FromSuperchainConfig` (was `LoadChainConfig`) | `params/superchain.go` | `op-core/params/` | Medium |
-| `superchain/` package (data + loader) | `superchain/` | `op-core/superchain/` | Low (copy) |
-| `sync-superchain.sh` | root | `op-core/superchain/` | Trivial |
-| `op-service/superutil/` (by-chain-ID loader) | monorepo | moves to `op-core/params/` (avoids params↔superchain cycle) | Low |
-| EIP-1559 Holocene/Jovian helpers | `consensus/misc/eip1559/eip1559_optimism.go` | `op-core/eip1559/` | Trivial |
-| `HardforkConfig` interface | n/a | `op-service/eth/` (for `BlockAsPayload`) | Trivial |
-| op-batcher L2 block fetch (ethclient → sources) | `op-batcher/batcher/driver.go` | migrate to `sources.EthClient.InfoAndUserTxs` | Medium |
-| op-service/sources L2 tx accessors (partition by class, no tx wrapper) | `op-service/sources/types.go`, `op-service/apis/eth.go` | `InfoAndUserTxs` / `InfoAndDeposits` / `InfoAndFirstDeposit`; raw-bytes `RPCBlock.Transactions` internally | Medium |
-| `apis.EthClient.TransactionReceipt` return type | `op-service/apis/eth.go` | change to `*optypes.Receipt` | Low |
-| `op-e2e/e2eutils/geth/wait.go` — split into header-only + full-block variants | `op-e2e/e2eutils/geth/wait.go` | `HeaderByNumber`-based helpers for height-only callers; migrate block-body callers to `apis.EthClient` | Medium |
-| `op-e2e/system/e2esys.SystemConfig.L2Client` type | `op-e2e/system/e2esys/` | change to `apis.EthClient` | Medium |
-| op-e2e direct L2 block/tx call sites (19 sites, 9 files) | op-e2e/actions,faultproofs,interop,system | migrate to `apis.EthClient` or header-only variant | Medium |
-| `op-devstack/sysgo/` L2 ethclient uses (audit) | `op-devstack/sysgo/*.go` | migrate L2 callers to `sources.EthClient`; L1 stays on `ethclient` | Low-Medium |
-| `op-e2e/opgeth/` package | `op-e2e/opgeth/` | **delete as part of decoupling**; op-reth equivalents introduced separately | Trivial |
-| `beacon/engine.PayloadID` | upstream | no change needed | None |
-| `Header.WithdrawalsHash`, `BeaconRoot()` | upstream since Shanghai/Cancun | no change needed | None |
-| `core.FloorDataGas` | upstream (EIP-7623) | no change needed | None |
-| `txpool.ErrAlreadyReserved` | upstream | no change needed | None |
-| `params.TxGas`, `BlobTxBlobGasPerBlob` | upstream | no change needed | None |
-
-## Implementation notes
-
-### Wire compatibility for `OptimismConfig`
-
-`rollup.Config.ChainOpConfig *params.OptimismConfig` is serialised to JSON (and potentially sent
-over the wire between op-node and other services). The new `*opparams.OptimismConfig` must use
-identical JSON field names. Current op-geth JSON tags:
-
-```go
-EIP1559Elasticity        uint64  `json:"eip1559Elasticity"`
-EIP1559Denominator       uint64  `json:"eip1559Denominator"`
-EIP1559DenominatorCanyon *uint64 `json:"eip1559DenominatorCanyon,omitempty"`
-```
-
-These must be preserved verbatim in `op-core/params.OptimismConfig`.
-
-### DepositTx RLP wire compatibility
-
-The `op-core/types.DepositTx.MarshalBinary` implementation must produce byte-for-byte identical
-output to `types.NewTx(&types.DepositTx{...}).MarshalBinary()` in op-geth. This is verified by
-the differential test mentioned in §1. The wire format is:
-
-```
-0x7E || RLP([sourceHash, from, to, mint, value, gas, isSystemTransaction, data])
-```
-
-with `mint` and `to` following the standard RLP optional-pointer encoding.
-
-### Rollup.Config hardfork schedule
-
-`rollup.Config` already carries timestamp fields for all hardforks up through Karst (merged
-Feb 2026, PR #19250), plus `InteropTime`. The `op-core/params.ChainConfig` loader
-(`FromSuperchainConfig`) populates `rollup.Config` directly from the superchain registry data,
-bypassing `params.ChainConfig`. Any future hardforks will be added to `rollup.Config` directly
-rather than via `params.ChainConfig`.
+| Area | Target | Status |
+|------|--------|--------|
+| ProtocolVersions mechanism (§0) | deleted end-to-end | **done** |
+| `DepositTx` / `PostExecTx` types + helpers (§1, §2) | `op-core/types` | **done** (#20262); call-site swaps open (#20269, #20263) |
+| OP `Receipt` (§3) | `op-core/types.Receipt` | **done**; wiring rides §11 (#20264) |
+| L1-cost / operator-fee math (§4) | `op-core/fees` | **done** (#20261); op-batcher site rides §11 |
+| `OptimismConfig` / standalone `ChainConfig` / `GethChainConfig` (§5) | `op-core/params` | **done** (#20260); swaps + `HardforkConfig` open (#20270) |
+| Superchain registry + loaders (§6, §7) | `op-core/superchain` + `op-core/params` | **done** (#20267, #21487) |
+| eip1559 Holocene/Jovian helpers (§8) | `op-core/eip1559` | **done** for op-node; `EncodeOptimismExtraData`/`DecodeHoloceneExtraData` pending (§13) |
+| `PayloadID`, Engine-API types (§9, §10) | upstream / op-service | no change needed |
+| OP-aware eth client: class-partitioned accessors, `optypes.Receipt` returns, op-batcher + txinclude migration (§11) | `op-service/sources` / `apis.EthClient` | open (#20264) |
+| op-proposer / op-challenger / op-supernode / cannon (§12) | — | audited, no work |
+| Test migration: wait.go split, L2 call sites, `L2Client` type, sysgo audit, delete op-e2e/opgeth (§13) | `apis.EthClient` + header-only variants | open (#20265 + subs) |
+| op-e2e/actions in-process EL | `op-reth-test-engine` subprocess | open (#20415 Rust, #21196 Go) |
+| Genesis tooling (§14) | upstream geth as library + `opparams` | open (#21281) |
+| op-simulate / op-run-block (§14) | delete | open (#21282) |
+| op-sync-tester PayloadID hash | OP-aware `Id()` reimplementation | open (#21525) |
+| Log context extensions (§15) | owned `op-service/log` layer (alias sweep → owned interface) | open |
+| RPC recorder hooks + `JsonError` (§15) | client wrappers + server-side interception | open |
+| One-off fork symbols (§15) | per-symbol swaps, ride #20263 family | open |
+| `op-chain-ops/script` + op-deployer (§16) | **Rust script engine** (foundry crates) | open |
+| In-process op-geth L2 EL in system tests + sysgo (§17) | op-reth-only; folds #21451 | open |
+| `cmd/check-*` (§18) | delete pre-Holocene; swap survivors to op-core | open |
+| `op-wheel/cheat` (§18) | delete (`engine` stays) | open |
+| CI ratchet (§19) | scheduled upstream-build job + tightening baseline | open |
+| Final cutover: flip replace, shed `GethChainConfig` OP fields, delete differential tests + §2 scaffolding | go.mod | open (#20266) |


### PR DESCRIPTION
2026-07 revisit of the op-geth decoupling plan (part of #20257), verified by a spike build against upstream go-ethereum v1.17.2. Doc goes 1152 → ~530 lines.

**Scope widened to the whole monorepo** (single go.mod ⇒ everything must build against upstream at the flip; components only leave scope by deletion), with new sections for the gaps the revisit found:

- §15 fork extensions in geth's `log`/`rpc` packages (own the log layer via alias→owned interface; re-home RPC metrics hooks)
- §16 `op-chain-ops/script` + op-deployer → Rust script engine (fork-only EVM hooks make "swap to op-core" impossible; no interim module split)
- §17 retire the in-process op-geth L2 EL in op-e2e system tests + sysgo (folds #21451)
- §18 check-* checkers (delete stale, swap survivors) and op-wheel/cheat (delete)
- §19 CI ratchet rehearsing the cutover with a tightening baseline

**Trimmed to strategy**: done sections keep decisions/context only (the landed `op-core/*` code is its own reference); work-lists replaced by grep recipes so they can't go stale; summary table restructured as a status index. Section numbers §0–§14 unchanged (issues reference them).

Sub-issues for §15–§19 follow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)