### PR TITLE
fix(op-sync-tester): preserve route setup errors

### DIFF
--- a/op-sync-tester/synctester/backend/backend.go
+++ b/op-sync-tester/synctester/backend/backend.go
@@ -53,7 +53,7 @@ func FromConfig(log log.Logger, m metrics.Metricer, cfg *config.Config, router A
 	b.syncTesters.Range(func(id sttypes.SyncTesterID, st *SyncTester) bool {
 		path := "/chain/" + st.chainID.String() + "/synctest"
 		if err := router.AddRPC(path); err != nil {
-			syncTesterErr = errors.Join(fmt.Errorf("failed to set up synctest route: %w", err))
+			syncTesterErr = errors.Join(syncTesterErr, fmt.Errorf("failed to set up synctest route: %w", err))
 			return true
 		}
 		if err := router.AddAPIToRPC(path, rpc.API{

--- a/op-sync-tester/synctester/backend/backend_test.go
+++ b/op-sync-tester/synctester/backend/backend_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
@@ -22,12 +23,16 @@ type testAPI struct{}
 func (b *testAPI) DummyAPI() {}
 
 type testRouter struct {
-	routes []string
-	apis   map[string][]rpc.API
+	routes    []string
+	apis      map[string][]rpc.API
+	addRPCErr func(route string) error
 }
 
 func (t *testRouter) AddRPC(route string) error {
 	t.routes = append(t.routes, route)
+	if t.addRPCErr != nil {
+		return t.addRPCErr(route)
+	}
 	return nil
 }
 
@@ -76,4 +81,41 @@ func TestBackend(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, b.SyncTesters(), 2)
+}
+
+func TestBackendFromConfigJoinsRouteSetupErrors(t *testing.T) {
+	srv := oprpc.NewServer("127.0.0.1", 0, "")
+	srv.AddAPI(rpc.API{
+		Namespace: "eth",
+		Service:   &testAPI{},
+	})
+	require.NoError(t, srv.Start())
+	t.Cleanup(func() {
+		_ = srv.Stop()
+	})
+
+	cfg := &stconf.Config{
+		SyncTesters: map[sttypes.SyncTesterID]*stconf.SyncTesterEntry{
+			"syncTesterA": {
+				ELRPC:   endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
+				ChainID: eth.ChainIDFromUInt64(1),
+			},
+			"syncTesterB": {
+				ELRPC:   endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
+				ChainID: eth.ChainIDFromUInt64(2),
+			},
+		},
+	}
+	r := &testRouter{
+		routes: make([]string, 0),
+		apis:   make(map[string][]rpc.API),
+		addRPCErr: func(route string) error {
+			return fmt.Errorf("failed route %s", route)
+		},
+	}
+
+	_, err := FromConfig(testlog.Logger(t, log.LevelInfo), &metrics.NoopMetrics{}, cfg, r)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "/chain/1/synctest")
+	require.ErrorContains(t, err, "/chain/2/synctest")
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

`FromConfig` currently replaces the accumulated setup error when `AddRPC` fails while registering sync tester routes. If multiple sync tester route registrations fail, callers only see the last failure.

This updates the route setup error aggregation to join the new `AddRPC` error with the existing accumulated error, matching the later `AddAPIToRPC` error paths. A regression test covers multiple failing route registrations and verifies that both route errors are preserved.



**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

./op-core/superchain/sync-superchain.sh
go test ./op-sync-tester/synctester/backend -run TestBackendFromConfigJoinsRouteSetupErrors -count=1


**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
