### PR TITLE
op-devstack: default the L1 EL to a geth subprocess

### DIFF
--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -109,8 +109,8 @@ and returns a typed output that the test then may use.
 - `OP_RETH_EXEC_PATH=/home/USERHERE/projects/reth/target/release/op-reth` to select the op-reth executable to run
 
 ### Go stack env vars:
-- `DEVSTACK_L1EL_KIND=geth` to select geth as default L1 EL node
-- `SYSGO_GETH_EXEC_PATH=/path/to/geth` to select the geth executable to run
+- The L1 EL runs as a `geth` subprocess by default. Set `DEVSTACK_L1EL_KIND=in-process` to opt back into the in-process op-geth library node.
+- `SYSGO_GETH_EXEC_PATH=/path/to/geth` to select the geth executable to run (optional; defaults to the mise-pinned `geth` on PATH)
 
 ### Metrics env vars:
 - `SYSGO_METRICS_ENABLED` set to `true` to enable metrics to be exposed via prometheus and grafana for all running components that expose metrics (default: `false`)

--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -109,7 +109,7 @@ and returns a typed output that the test then may use.
 - `OP_RETH_EXEC_PATH=/home/USERHERE/projects/reth/target/release/op-reth` to select the op-reth executable to run
 
 ### Go stack env vars:
-- The L1 EL runs as a `geth` subprocess by default. Set `DEVSTACK_L1EL_KIND=in-process` to opt back into the in-process op-geth library node.
+- The L1 EL runs as a `geth` subprocess.
 - `SYSGO_GETH_EXEC_PATH=/path/to/geth` to select the geth executable to run (optional; defaults to the mise-pinned `geth` on PATH)
 
 ### Metrics env vars:

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -196,7 +196,6 @@ func WithL1Geth(execPath string) Option {
 	return option{
 		kinds: optionKindL1EL,
 		applyFn: func(cfg *sysgo.PresetConfig) {
-			cfg.L1ELKind = "geth"
 			cfg.L1GethExecPath = execPath
 		},
 	}

--- a/op-devstack/sysgo/l1_nodes.go
+++ b/op-devstack/sysgo/l1_nodes.go
@@ -3,7 +3,6 @@ package sysgo
 import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -18,7 +17,6 @@ type L1Geth struct {
 	chainID  eth.ChainID
 	userRPC  string
 	authRPC  string
-	l1Geth   *geth.GethInstance
 	blobPath string
 }
 

--- a/op-devstack/sysgo/l1_runtime.go
+++ b/op-devstack/sysgo/l1_runtime.go
@@ -31,17 +31,9 @@ func writeJWTSecret(t devtest.T) (string, [32]byte) {
 }
 
 func startL1(t devtest.T, l1Net *L1Network, jwtPath string) (*L1Geth, *L1CLNode) {
-	return startL1WithClock(t, l1Net, jwtPath, clock.SystemClock)
+	return startL1WithClockConfig(t, l1Net, jwtPath, clock.SystemClock, PresetConfig{})
 }
 
-func startL1WithClock(t devtest.T, l1Net *L1Network, jwtPath string, l1Clock clock.Clock) (*L1Geth, *L1CLNode) {
-	return startL1WithClockConfig(t, l1Net, jwtPath, l1Clock, PresetConfig{})
-}
-
-// startL1WithClockConfig starts the L1: a geth subprocess (the execution layer)
-// driven by an in-process fake PoS + fake beacon that stand in for the L1
-// consensus layer. The geth binary is resolved from PresetConfig.L1GethExecPath
-// / SYSGO_GETH_EXEC_PATH, falling back to the mise-pinned `geth` on PATH.
 func startL1WithClockConfig(t devtest.T, l1Net *L1Network, jwtPath string, l1Clock clock.Clock, cfg PresetConfig) (*L1Geth, *L1CLNode) {
 	require := t.Require()
 	l1ChainID := l1Net.ChainID()
@@ -129,22 +121,7 @@ func startL1WithClockConfig(t devtest.T, l1Net *L1Network, jwtPath string, l1Clo
 		"--verbosity", "5",
 		"--miner.recommit", "2s",
 		"--gcmode", "archive",
-		// Cap geth's cache far below its multi-GB default (ethconfig defaults to a
-		// 2 GiB database cache alone). The fake L1 is tiny — a few dozen blocks —
-		// so it needs almost none, and acceptance tests run many devstacks
-		// concurrently (each now with its own L1 geth subprocess). At geth's
-		// default cache, that concurrency exhausts the CI runner's memory and the
-		// job is OOM-killed. The removed in-process node ran with an unset
-		// (near-zero) cache; this restores that footprint.
-		"--cache", "128",
-		// Pin the gas ceiling to the genesis gas limit so the L1 gas limit stays
-		// constant. The fake-PoS L1 builder bumps a reorg block's gas limit by
-		// +100 to force a distinct block hash (op-test-sequencer's
-		// builders/fakepos/job.go). If geth is left to drift the gas limit upward
-		// toward its default ceiling (60M), a block already stepped +delta plus
-		// that +100 exceeds the ±parentGasLimit/1024 bound and geth rejects it as
-		// a bad block, killing the L1 node. A constant ceiling keeps the +100 well
-		// within bounds (matching the in-process node's Miner.GasCeil intent).
+		"--cache", "0", // Default is multiple gigabytes, which puts way too much load on CI boxes.
 		"--miner.gaslimit", strconv.FormatUint(l1Net.genesis.GasLimit, 10),
 	}
 	require.NoError(sub.Start(execPath, args, nil), "must start geth subprocess")

--- a/op-devstack/sysgo/l1_runtime.go
+++ b/op-devstack/sysgo/l1_runtime.go
@@ -19,12 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-const DevstackL1ELKindEnvVar = "DEVSTACK_L1EL_KIND"
-
-// DevstackL1ELInProcessKind opts the L1 EL back into the in-process op-geth
-// library node. Subprocess geth is the default (see useSubprocessL1Geth).
-const DevstackL1ELInProcessKind = "in-process"
-
 const GethExecPathEnvVar = "SYSGO_GETH_EXEC_PATH"
 
 func writeJWTSecret(t devtest.T) (string, [32]byte) {
@@ -35,66 +29,19 @@ func writeJWTSecret(t devtest.T) (string, [32]byte) {
 	return jwtPath, jwtSecret
 }
 
-func startInProcessL1(t devtest.T, l1Net *L1Network, jwtPath string) (*L1Geth, *L1CLNode) {
-	return startInProcessL1WithClock(t, l1Net, jwtPath, clock.SystemClock)
+func startL1(t devtest.T, l1Net *L1Network, jwtPath string) (*L1Geth, *L1CLNode) {
+	return startL1WithClock(t, l1Net, jwtPath, clock.SystemClock)
 }
 
-func startInProcessL1WithClock(t devtest.T, l1Net *L1Network, jwtPath string, l1Clock clock.Clock) (*L1Geth, *L1CLNode) {
-	return startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, PresetConfig{})
+func startL1WithClock(t devtest.T, l1Net *L1Network, jwtPath string, l1Clock clock.Clock) (*L1Geth, *L1CLNode) {
+	return startL1WithClockConfig(t, l1Net, jwtPath, l1Clock, PresetConfig{})
 }
 
-func startInProcessL1WithClockConfig(t devtest.T, l1Net *L1Network, jwtPath string, l1Clock clock.Clock, cfg PresetConfig) (*L1Geth, *L1CLNode) {
-	if useSubprocessL1Geth(cfg) {
-		return startSubprocessL1WithClock(t, l1Net, jwtPath, l1Clock, cfg)
-	}
-
-	require := t.Require()
-	l1ChainID := l1Net.ChainID()
-
-	blobPath := t.TempDirWithPrefix("l1-el")
-	bcn := fakebeacon.NewBeacon(t.Logger().New("component", "l1cl"), blobstore.New(), l1Net.genesis.Timestamp, l1Net.blockTime)
-	t.Cleanup(func() {
-		_ = bcn.Close()
-	})
-	require.NoError(bcn.Start("127.0.0.1:0"))
-	beaconAddr := bcn.BeaconAddr()
-	require.NotEmpty(beaconAddr, "beacon API listener must be up")
-
-	l1Geth, fp, err := geth.InitL1(
-		l1Net.blockTime,
-		20,
-		l1Net.genesis,
-		l1Clock,
-		filepath.Join(blobPath, "l1_el"),
-		bcn,
-		geth.WithAuth(jwtPath),
-	)
-	require.NoError(err)
-	require.NoError(l1Geth.Node.Start())
-	t.Cleanup(func() {
-		t.Logger().Info("Closing L1 geth")
-		_ = l1Geth.Close()
-	})
-
-	l1EL := &L1Geth{
-		name:     "l1",
-		chainID:  l1ChainID,
-		userRPC:  l1Geth.Node.HTTPEndpoint(),
-		authRPC:  l1Geth.Node.HTTPAuthEndpoint(),
-		l1Geth:   l1Geth,
-		blobPath: blobPath,
-	}
-	l1CL := &L1CLNode{
-		name:           "l1",
-		chainID:        l1ChainID,
-		beaconHTTPAddr: beaconAddr,
-		beacon:         bcn,
-		fakepos:        &FakePoS{fakepos: fp, p: t},
-	}
-	return l1EL, l1CL
-}
-
-func startSubprocessL1WithClock(t devtest.T, l1Net *L1Network, jwtPath string, l1Clock clock.Clock, cfg PresetConfig) (*L1Geth, *L1CLNode) {
+// startL1WithClockConfig starts the L1: a geth subprocess (the execution layer)
+// driven by an in-process fake PoS + fake beacon that stand in for the L1
+// consensus layer. The geth binary is resolved from PresetConfig.L1GethExecPath
+// / SYSGO_GETH_EXEC_PATH, falling back to the mise-pinned `geth` on PATH.
+func startL1WithClockConfig(t devtest.T, l1Net *L1Network, jwtPath string, l1Clock clock.Clock, cfg PresetConfig) (*L1Geth, *L1CLNode) {
 	require := t.Require()
 	l1ChainID := l1Net.ChainID()
 
@@ -232,17 +179,6 @@ func startSubprocessL1WithClock(t devtest.T, l1Net *L1Network, jwtPath string, l
 		fakepos:        fp,
 	}
 	return l1EL, l1CL
-}
-
-// useSubprocessL1Geth reports whether the L1 EL should run as a geth subprocess.
-// Subprocess is the default; set PresetConfig.L1ELKind or DEVSTACK_L1EL_KIND to
-// "in-process" to opt back into the in-process op-geth library node.
-func useSubprocessL1Geth(cfg PresetConfig) bool {
-	kind := cfg.L1ELKind
-	if kind == "" {
-		kind = os.Getenv(DevstackL1ELKindEnvVar)
-	}
-	return kind != DevstackL1ELInProcessKind
 }
 
 func readJWTSecret(t devtest.T, jwtPath string) [32]byte {

--- a/op-devstack/sysgo/l1_runtime.go
+++ b/op-devstack/sysgo/l1_runtime.go
@@ -21,6 +21,10 @@ import (
 
 const DevstackL1ELKindEnvVar = "DEVSTACK_L1EL_KIND"
 
+// DevstackL1ELInProcessKind opts the L1 EL back into the in-process op-geth
+// library node. Subprocess geth is the default (see useSubprocessL1Geth).
+const DevstackL1ELInProcessKind = "in-process"
+
 const GethExecPathEnvVar = "SYSGO_GETH_EXEC_PATH"
 
 func writeJWTSecret(t devtest.T) (string, [32]byte) {
@@ -96,9 +100,13 @@ func startSubprocessL1WithClock(t devtest.T, l1Net *L1Network, jwtPath string, l
 
 	execPath := cfg.L1GethExecPath
 	if execPath == "" {
-		var ok bool
-		execPath, ok = os.LookupEnv(GethExecPathEnvVar)
-		require.True(ok, "%s must be set when %s=geth", GethExecPathEnvVar, DevstackL1ELKindEnvVar)
+		execPath = os.Getenv(GethExecPathEnvVar)
+	}
+	if execPath == "" {
+		// Fall back to the mise-pinned geth binary on PATH.
+		lookedUp, err := exec.LookPath("geth")
+		require.NoError(err, "no %s set and no `geth` found on PATH (expected the mise-pinned geth)", GethExecPathEnvVar)
+		execPath = lookedUp
 	}
 	_, err := os.Stat(execPath)
 	require.NotErrorIs(err, os.ErrNotExist, "geth executable must exist")
@@ -226,12 +234,15 @@ func startSubprocessL1WithClock(t devtest.T, l1Net *L1Network, jwtPath string, l
 	return l1EL, l1CL
 }
 
+// useSubprocessL1Geth reports whether the L1 EL should run as a geth subprocess.
+// Subprocess is the default; set PresetConfig.L1ELKind or DEVSTACK_L1EL_KIND to
+// "in-process" to opt back into the in-process op-geth library node.
 func useSubprocessL1Geth(cfg PresetConfig) bool {
 	kind := cfg.L1ELKind
 	if kind == "" {
 		kind = os.Getenv(DevstackL1ELKindEnvVar)
 	}
-	return kind == "geth"
+	return kind != DevstackL1ELInProcessKind
 }
 
 func readJWTSecret(t devtest.T, jwtPath string) [32]byte {

--- a/op-devstack/sysgo/l1_runtime.go
+++ b/op-devstack/sysgo/l1_runtime.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -128,6 +129,15 @@ func startL1WithClockConfig(t devtest.T, l1Net *L1Network, jwtPath string, l1Clo
 		"--verbosity", "5",
 		"--miner.recommit", "2s",
 		"--gcmode", "archive",
+		// Pin the gas ceiling to the genesis gas limit so the L1 gas limit stays
+		// constant. The fake-PoS L1 builder bumps a reorg block's gas limit by
+		// +100 to force a distinct block hash (op-test-sequencer's
+		// builders/fakepos/job.go). If geth is left to drift the gas limit upward
+		// toward its default ceiling (60M), a block already stepped +delta plus
+		// that +100 exceeds the ±parentGasLimit/1024 bound and geth rejects it as
+		// a bad block, killing the L1 node. A constant ceiling keeps the +100 well
+		// within bounds (matching the in-process node's Miner.GasCeil intent).
+		"--miner.gaslimit", strconv.FormatUint(l1Net.genesis.GasLimit, 10),
 	}
 	require.NoError(sub.Start(execPath, args, nil), "must start geth subprocess")
 

--- a/op-devstack/sysgo/l1_runtime.go
+++ b/op-devstack/sysgo/l1_runtime.go
@@ -129,6 +129,14 @@ func startL1WithClockConfig(t devtest.T, l1Net *L1Network, jwtPath string, l1Clo
 		"--verbosity", "5",
 		"--miner.recommit", "2s",
 		"--gcmode", "archive",
+		// Cap geth's cache far below its multi-GB default (ethconfig defaults to a
+		// 2 GiB database cache alone). The fake L1 is tiny — a few dozen blocks —
+		// so it needs almost none, and acceptance tests run many devstacks
+		// concurrently (each now with its own L1 geth subprocess). At geth's
+		// default cache, that concurrency exhausts the CI runner's memory and the
+		// job is OOM-killed. The removed in-process node ran with an unset
+		// (near-zero) cache; this restores that footprint.
+		"--cache", "128",
 		// Pin the gas ceiling to the genesis gas limit so the L1 gas limit stays
 		// constant. The fake-PoS L1 builder bumps a reorg block's gas limit by
 		// +100 to force a distinct block hash (op-test-sequencer's

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -203,7 +203,7 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 		l1Net, l2Net = buildSingleChainWorld(t, keys, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...)
 	}
 	jwtPath, jwtSecret := writeJWTSecret(t)
-	l1EL, l1CL := startInProcessL1(t, l1Net, jwtPath)
+	l1EL, l1CL := startL1(t, l1Net, jwtPath)
 
 	metricsRegistrar := mixedNoopMetricsRegistrar{}
 

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -172,7 +172,7 @@ func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, lagoonAtGenesis bool,
 		timeTravelClock = clock.NewAdvancingClock()
 		l1Clock = timeTravelClock
 	}
-	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
+	l1EL, l1CL := startL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
 	l2EL := startSupernodeEL(t, l2Net, jwtPath, jwtSecret)
 
 	var depSetStatic *depset.StaticConfigDependencySet
@@ -247,7 +247,7 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 		timeTravelClock = clock.NewAdvancingClock()
 		l1Clock = timeTravelClock
 	}
-	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
+	l1EL, l1CL := startL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
 	if cfg.PreGenesisSuperGame != nil {
 		preparePreGenesisSuperGame(t, keys, wb, l1Net, l1EL, migration, cfg.PreGenesisSuperGame, l2ANet, l2BNet)
 	}

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -23,7 +23,6 @@ type PresetConfig struct {
 	OpRethOptions              []OpRethOption
 	GlobalL2CLOptions          []L2CLOption
 	GlobalSyncTesterELOptions  []SyncTesterELOption
-	L1ELKind                   string
 	L1GethExecPath             string
 	AddedGameTypes             []gameTypes.GameType
 	RespectedGameTypes         []gameTypes.GameType

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -122,7 +122,7 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 		timeTravelClock = clock.NewAdvancingClock()
 		l1Clock = timeTravelClock
 	}
-	l1EL, l1CL := startInProcessL1WithClockConfig(t, world.L1Network, jwtPath, l1Clock, cfg)
+	l1EL, l1CL := startL1WithClockConfig(t, world.L1Network, jwtPath, l1Clock, cfg)
 
 	primary := spec.StartPrimary(t, keys, world, l1EL, l1CL, jwtPath, jwtSecret, cfg)
 	primaryNode := newSingleChainNodeRuntime("sequencer", true, primary.EL, primary.CL)

--- a/op-devstack/sysgo/singlechain_supernode_synctester_variant.go
+++ b/op-devstack/sysgo/singlechain_supernode_synctester_variant.go
@@ -54,7 +54,7 @@ func NewSingleSupernodeWithSyncTesterRuntimeWithConfig(t devtest.T, cfg PresetCo
 		timeTravelClock = clock.NewAdvancingClock()
 		l1Clock = timeTravelClock
 	}
-	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
+	l1EL, l1CL := startL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
 
 	l2EL := startSequencerEL(t, l2Net, jwtPath, jwtSecret, NewELNodeIdentity(0))
 	l2CL := startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{


### PR DESCRIPTION
## Summary

Defaults the op-devstack L1 execution layer to a **geth subprocess** instead of the in-process op-geth library node.

- The geth binary is resolved from `PresetConfig.L1GethExecPath` → `SYSGO_GETH_EXEC_PATH` → the mise-pinned `geth` on PATH. Previously the subprocess path hard-failed unless `SYSGO_GETH_EXEC_PATH` was set.
- Subprocess is now the default; the in-process op-geth node remains available via `DEVSTACK_L1EL_KIND=in-process` (or `PresetConfig.L1ELKind`).
- Existing `DEVSTACK_L1EL_KIND=geth` and the `WithL1Geth(path)` preset option still resolve to subprocess, unchanged.

This is a stepping stone toward running the devstack L1 against an external EL binary (reth): it makes the subprocess launch path the norm so swapping the binary becomes a localized change.

## Caveats

- Every devstack test now spawns a `geth` subprocess + `geth init` (marginal cost on top of the already-subprocess op-reth L2).
- The fallback binary is the mise-pinned upstream go-ethereum (`1.16.4`, "Osaka testnet release"), which caps L1 fork support at that pin.

## Testing

- `op-devstack/...` builds; `l1_runtime.go` gofmt-clean; sysgo unit tests pass.
- Confirmed the mise-pinned `geth` resolves on PATH (the fallback target).
- Full acceptance-test run not yet performed (heavy deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)