### PR TITLE
op-deployer: estimate broadcast gas against the target chain (Glamsterdam/EIP-8037)

### DIFF
--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 
@@ -203,6 +204,7 @@ type ApplyPipelineOpts struct {
 	DeployMockSP1Verifier bool
 	PrivateKey            string
 	Workdir               string
+	ReceiptQueryInterval  time.Duration
 }
 
 func ApplyPipeline(
@@ -251,11 +253,12 @@ func ApplyPipeline(
 		signer := opcrypto.SignerFnFromBind(opcrypto.PrivateKeySignerFn(opts.DeployerPrivateKey, chainID))
 
 		bcaster, err = broadcaster.NewKeyedBroadcaster(broadcaster.KeyedBroadcasterOpts{
-			Logger:  opts.Logger,
-			ChainID: new(big.Int).SetUint64(intent.L1ChainID),
-			Client:  l1Client,
-			Signer:  signer,
-			From:    deployer,
+			Logger:               opts.Logger,
+			ChainID:              new(big.Int).SetUint64(intent.L1ChainID),
+			Client:               l1Client,
+			Signer:               signer,
+			From:                 deployer,
+			ReceiptQueryInterval: opts.ReceiptQueryInterval,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create broadcaster: %w", err)

--- a/op-deployer/pkg/deployer/broadcaster/keyed.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed.go
@@ -28,21 +28,27 @@ type KeyedBroadcaster struct {
 }
 
 type KeyedBroadcasterOpts struct {
-	Logger  log.Logger
-	ChainID *big.Int
-	Client  *ethclient.Client
-	Signer  opcrypto.SignerFn
-	From    common.Address
+	Logger               log.Logger
+	ChainID              *big.Int
+	Client               *ethclient.Client
+	Signer               opcrypto.SignerFn
+	From                 common.Address
+	ReceiptQueryInterval time.Duration
 }
 
 func NewKeyedBroadcaster(cfg KeyedBroadcasterOpts) (*KeyedBroadcaster, error) {
+	receiptQueryInterval := cfg.ReceiptQueryInterval
+	if receiptQueryInterval == 0 {
+		receiptQueryInterval = time.Second
+	}
+
 	mgrCfg := &txmgr.Config{
 		Backend:                   cfg.Client,
 		ChainID:                   cfg.ChainID,
 		TxSendTimeout:             5 * time.Minute,
 		TxNotInMempoolTimeout:     time.Minute,
 		NetworkTimeout:            10 * time.Second,
-		ReceiptQueryInterval:      time.Second,
+		ReceiptQueryInterval:      receiptQueryInterval,
 		NumConfirmations:          1,
 		SafeAbortNonceTooLowCount: 3,
 		Signer:                    cfg.Signer,

--- a/op-deployer/pkg/deployer/broadcaster/keyed.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed.go
@@ -2,7 +2,6 @@ package broadcaster
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -17,20 +16,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-)
-
-const (
-	GasPadFactor = 1.2
 )
 
 type KeyedBroadcaster struct {
 	lgr    log.Logger
 	mgr    txmgr.TxManager
 	bcasts []script.Broadcast
-	client *ethclient.Client
 	mtx    sync.Mutex
 }
 
@@ -84,9 +77,8 @@ func NewKeyedBroadcaster(cfg KeyedBroadcasterOpts) (*KeyedBroadcaster, error) {
 	}
 
 	return &KeyedBroadcaster{
-		lgr:    cfg.Logger,
-		mgr:    mgr,
-		client: cfg.Client,
+		lgr: cfg.Logger,
+		mgr: mgr,
 	}, nil
 }
 
@@ -110,86 +102,58 @@ func (t *KeyedBroadcaster) Broadcast(ctx context.Context) ([]BroadcastResult, er
 		return nil, nil
 	}
 
-	results := make([]BroadcastResult, len(bcasts))
-	futures := make([]<-chan txmgr.SendResponse, len(bcasts))
-	ids := make([]common.Hash, len(bcasts))
-
-	latestBlock, err := t.client.BlockByNumber(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get latest block: %w", err)
-	}
-
+	results := make([]BroadcastResult, 0, len(bcasts))
 	for i, bcast := range bcasts {
-		futures[i], ids[i] = t.broadcast(ctx, bcast, latestBlock.GasLimit())
-		t.lgr.Info(
-			"transaction broadcasted",
-			"id", ids[i],
-			"nonce", bcast.Nonce,
-		)
-	}
-	var txErr error
-	var completed int
-	for i, fut := range futures {
-		bcastRes := <-fut
-		completed++
-		outRes := BroadcastResult{
-			Broadcast: bcasts[i],
-		}
+		id := bcast.ID()
+		t.lgr.Info("broadcasting transaction", "id", id, "nonce", bcast.Nonce)
 
-		if bcastRes.Err == nil {
-			outRes.Receipt = bcastRes.Receipt
-			outRes.TxHash = bcastRes.Receipt.TxHash
-
-			if bcastRes.Receipt.Status == 0 {
-				failErr := fmt.Errorf("transaction failed: %s", outRes.Receipt.TxHash.String())
-				txErr = errors.Join(txErr, failErr)
-				outRes.Err = failErr
-				t.lgr.Error(
-					"transaction failed on chain",
-					"id", ids[i],
-					"completed", completed,
-					"total", len(bcasts),
-					"hash", outRes.Receipt.TxHash.String(),
-					"nonce", outRes.Broadcast.Nonce,
-				)
-			} else {
-				t.lgr.Info(
-					"transaction confirmed",
-					"id", ids[i],
-					"completed", completed,
-					"total", len(bcasts),
-					"hash", outRes.Receipt.TxHash.String(),
-					"nonce", outRes.Broadcast.Nonce,
-					"creation", outRes.Receipt.ContractAddress,
-				)
-			}
-		} else {
-			txErr = errors.Join(txErr, bcastRes.Err)
-			outRes.Err = bcastRes.Err
+		// A zero gas limit makes txmgr estimate against the target chain. Waiting
+		// for confirmation ensures the next estimate sees this transaction's state.
+		receipt, err := t.mgr.Send(ctx, asTxCandidate(bcast, 0))
+		outRes := BroadcastResult{Broadcast: bcast, Receipt: receipt, Err: err}
+		if err != nil {
 			t.lgr.Error(
 				"transaction failed",
-				"id", ids[i],
-				"completed", completed,
+				"id", id,
+				"completed", i+1,
 				"total", len(bcasts),
-				"err", bcastRes.Err,
+				"err", err,
 			)
+			results = append(results, outRes)
+			return results, err
 		}
 
-		results[i] = outRes
+		outRes.TxHash = receipt.TxHash
+		if receipt.Status == 0 {
+			failErr := fmt.Errorf("transaction failed: %s", receipt.TxHash)
+			outRes.Err = failErr
+			t.lgr.Error(
+				"transaction failed on chain",
+				"id", id,
+				"completed", i+1,
+				"total", len(bcasts),
+				"hash", receipt.TxHash,
+				"nonce", bcast.Nonce,
+			)
+			results = append(results, outRes)
+			return results, failErr
+		}
+
+		t.lgr.Info(
+			"transaction confirmed",
+			"id", id,
+			"completed", i+1,
+			"total", len(bcasts),
+			"hash", receipt.TxHash,
+			"nonce", bcast.Nonce,
+			"creation", receipt.ContractAddress,
+		)
+		results = append(results, outRes)
 	}
-	return results, txErr
+	return results, nil
 }
 
-func (t *KeyedBroadcaster) broadcast(ctx context.Context, bcast script.Broadcast, blockGasLimit uint64) (<-chan txmgr.SendResponse, common.Hash) {
-	ch := make(chan txmgr.SendResponse, 1)
-
-	id := bcast.ID()
-	candidate := asTxCandidate(bcast, blockGasLimit)
-	t.mgr.SendAsync(ctx, candidate, ch)
-	return ch, id
-}
-
-func asTxCandidate(bcast script.Broadcast, blockGasLimit uint64) txmgr.TxCandidate {
+func asTxCandidate(bcast script.Broadcast, gasLimit uint64) txmgr.TxCandidate {
 	value := ((*uint256.Int)(bcast.Value)).ToBig()
 	var candidate txmgr.TxCandidate
 	switch bcast.Type {
@@ -199,13 +163,13 @@ func asTxCandidate(bcast script.Broadcast, blockGasLimit uint64) txmgr.TxCandida
 			TxData:   bcast.Input,
 			To:       to,
 			Value:    value,
-			GasLimit: padGasLimit(bcast.Input, bcast.GasUsed, false, blockGasLimit),
+			GasLimit: gasLimit,
 		}
 	case script.BroadcastCreate:
 		candidate = txmgr.TxCandidate{
 			TxData:   bcast.Input,
 			To:       nil,
-			GasLimit: padGasLimit(bcast.Input, bcast.GasUsed, true, blockGasLimit),
+			GasLimit: gasLimit,
 		}
 	case script.BroadcastCreate2:
 		txData := make([]byte, len(bcast.Salt)+len(bcast.Input))
@@ -216,39 +180,10 @@ func asTxCandidate(bcast script.Broadcast, blockGasLimit uint64) txmgr.TxCandida
 			TxData:   txData,
 			To:       &script.DeterministicDeployerAddress,
 			Value:    value,
-			GasLimit: padGasLimit(bcast.Input, bcast.GasUsed, true, blockGasLimit),
+			GasLimit: gasLimit,
 		}
 	default:
 		panic(fmt.Sprintf("unrecognized broadcast type: '%s'", bcast.Type))
 	}
 	return candidate
-}
-
-// padGasLimit calculates the gas limit for a transaction based on the intrinsic gas and the gas used by
-// the underlying call. Values are multiplied by a pad factor to account for any discrepancies. The output
-// is clamped to the block gas limit since Geth will reject transactions that exceed it before letting them
-// into the mempool.
-func padGasLimit(data []byte, gasUsed uint64, creation bool, blockGasLimit uint64) uint64 {
-	intrinsicGas, err := core.IntrinsicGas(data, nil, nil, creation, true, true, false)
-	// This method never errors - we should look into it if it does.
-	if err != nil {
-		panic(err)
-	}
-
-	floorDataGas, err := core.FloorDataGas(data)
-	// We should never cause an overflow here.
-	if err != nil {
-		panic(err)
-	}
-
-	gas := intrinsicGas + gasUsed
-	if floorDataGas > gas {
-		gas = floorDataGas
-	}
-
-	limit := uint64(float64(gas) * GasPadFactor)
-	if limit > blockGasLimit {
-		return blockGasLimit
-	}
-	return limit
 }

--- a/op-deployer/pkg/deployer/broadcaster/keyed_test.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed_test.go
@@ -1,0 +1,106 @@
+package broadcaster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	txmocks "github.com/ethereum-optimism/optimism/op-service/txmgr/mocks"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyedBroadcasterSendsSequentiallyWithGasEstimation(t *testing.T) {
+	bcasts := []script.Broadcast{
+		{
+			Type:  script.BroadcastCreate,
+			Input: []byte{0x60, 0x00},
+			Value: (*hexutil.U256)(new(uint256.Int)),
+		},
+		{
+			Type:  script.BroadcastCall,
+			To:    common.Address{'T'},
+			Input: []byte{0x12, 0x34},
+			Value: (*hexutil.U256)(new(uint256.Int)),
+		},
+	}
+
+	mgr := txmocks.NewTxManager(t)
+	next := 0
+	mgr.On("Send", mock.Anything, mock.Anything).Return(
+		func(_ context.Context, candidate txmgr.TxCandidate) (*types.Receipt, error) {
+			require.Less(t, next, len(bcasts))
+			require.Zero(t, candidate.GasLimit)
+			require.Equal(t, []byte(bcasts[next].Input), candidate.TxData)
+			if bcasts[next].Type == script.BroadcastCreate {
+				require.Nil(t, candidate.To)
+			} else {
+				require.Equal(t, bcasts[next].To, *candidate.To)
+			}
+
+			next++
+			return &types.Receipt{
+				Status: types.ReceiptStatusSuccessful,
+				TxHash: common.Hash{byte(next)},
+			}, nil
+		},
+	)
+
+	broadcaster := &KeyedBroadcaster{
+		lgr:    testlog.Logger(t, log.LevelError),
+		mgr:    mgr,
+		bcasts: bcasts,
+	}
+	results, err := broadcaster.Broadcast(context.Background())
+	require.NoError(t, err)
+	require.Len(t, results, len(bcasts))
+	require.Equal(t, len(bcasts), next)
+	for i, result := range results {
+		require.Equal(t, bcasts[i], result.Broadcast)
+		require.Equal(t, common.Hash{byte(i + 1)}, result.TxHash)
+		require.NoError(t, result.Err)
+	}
+}
+
+func TestKeyedBroadcasterStopsAfterFailure(t *testing.T) {
+	bcasts := []script.Broadcast{
+		{Type: script.BroadcastCall, To: common.Address{'A'}, Value: (*hexutil.U256)(new(uint256.Int))},
+		{Type: script.BroadcastCall, To: common.Address{'B'}, Value: (*hexutil.U256)(new(uint256.Int))},
+		{Type: script.BroadcastCall, To: common.Address{'C'}, Value: (*hexutil.U256)(new(uint256.Int))},
+	}
+	sendErr := errors.New("send failed")
+
+	mgr := txmocks.NewTxManager(t)
+	calls := 0
+	mgr.On("Send", mock.Anything, mock.Anything).Return(
+		func(_ context.Context, _ txmgr.TxCandidate) (*types.Receipt, error) {
+			calls++
+			if calls == 2 {
+				return nil, sendErr
+			}
+			return &types.Receipt{
+				Status: types.ReceiptStatusSuccessful,
+				TxHash: common.Hash{byte(calls)},
+			}, nil
+		},
+	)
+
+	broadcaster := &KeyedBroadcaster{
+		lgr:    testlog.Logger(t, log.LevelError),
+		mgr:    mgr,
+		bcasts: bcasts,
+	}
+	results, err := broadcaster.Broadcast(context.Background())
+	require.ErrorIs(t, err, sendErr)
+	require.Len(t, results, 2)
+	require.Equal(t, 2, calls)
+	require.ErrorIs(t, results[1].Err, sendErr)
+}

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -56,7 +56,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testCustomGasLimit = uint64(90_123_456)
+const (
+	testCustomGasLimit       = uint64(90_123_456)
+	testReceiptQueryInterval = 50 * time.Millisecond
+)
 
 type deployerKey struct{}
 
@@ -231,14 +234,15 @@ func TestEndToEndApply(t *testing.T) {
 		require.NoError(t, deployer.ApplyPipeline(
 			ctx,
 			deployer.ApplyPipelineOpts{
-				DeploymentTarget:   deployer.DeploymentTargetLive,
-				L1RPCUrl:           l1RPC,
-				DeployerPrivateKey: pk,
-				Intent:             intent,
-				State:              st,
-				Logger:             lgr,
-				StateWriter:        pipeline.NoopStateWriter(),
-				CacheDir:           testCacheDir,
+				DeploymentTarget:     deployer.DeploymentTargetLive,
+				L1RPCUrl:             l1RPC,
+				DeployerPrivateKey:   pk,
+				Intent:               intent,
+				State:                st,
+				Logger:               lgr,
+				StateWriter:          pipeline.NoopStateWriter(),
+				CacheDir:             testCacheDir,
+				ReceiptQueryInterval: testReceiptQueryInterval,
 			},
 		))
 
@@ -249,14 +253,15 @@ func TestEndToEndApply(t *testing.T) {
 		require.NoError(t, deployer.ApplyPipeline(
 			ctx,
 			deployer.ApplyPipelineOpts{
-				DeploymentTarget:   deployer.DeploymentTargetLive,
-				L1RPCUrl:           l1RPC,
-				DeployerPrivateKey: pk,
-				Intent:             intent,
-				State:              st,
-				Logger:             lgr,
-				StateWriter:        pipeline.NoopStateWriter(),
-				CacheDir:           testCacheDir,
+				DeploymentTarget:     deployer.DeploymentTargetLive,
+				L1RPCUrl:             l1RPC,
+				DeployerPrivateKey:   pk,
+				Intent:               intent,
+				State:                st,
+				Logger:               lgr,
+				StateWriter:          pipeline.NoopStateWriter(),
+				CacheDir:             testCacheDir,
+				ReceiptQueryInterval: testReceiptQueryInterval,
 			},
 		))
 
@@ -297,14 +302,15 @@ func TestEndToEndApply(t *testing.T) {
 		}
 
 		require.NoError(t, deployer.ApplyPipeline(ctx, deployer.ApplyPipelineOpts{
-			DeploymentTarget:   deployer.DeploymentTargetLive,
-			L1RPCUrl:           l1RPC,
-			DeployerPrivateKey: pk,
-			Intent:             intent,
-			State:              st,
-			Logger:             lgr,
-			StateWriter:        pipeline.NoopStateWriter(),
-			CacheDir:           testCacheDir,
+			DeploymentTarget:     deployer.DeploymentTargetLive,
+			L1RPCUrl:             l1RPC,
+			DeployerPrivateKey:   pk,
+			Intent:               intent,
+			State:                st,
+			Logger:               lgr,
+			StateWriter:          pipeline.NoopStateWriter(),
+			CacheDir:             testCacheDir,
+			ReceiptQueryInterval: testReceiptQueryInterval,
 		}))
 
 		systemConfig := st.Chains[0].SystemConfigProxy
@@ -349,14 +355,15 @@ func TestEndToEndApply(t *testing.T) {
 		require.NoError(t, deployer.ApplyPipeline(
 			ctx,
 			deployer.ApplyPipelineOpts{
-				DeploymentTarget:   deployer.DeploymentTargetLive,
-				L1RPCUrl:           l1RPC,
-				DeployerPrivateKey: pk,
-				Intent:             intent,
-				State:              st,
-				Logger:             lgr,
-				StateWriter:        pipeline.NoopStateWriter(),
-				CacheDir:           testCacheDir,
+				DeploymentTarget:     deployer.DeploymentTargetLive,
+				L1RPCUrl:             l1RPC,
+				DeployerPrivateKey:   pk,
+				Intent:               intent,
+				State:                st,
+				Logger:               lgr,
+				StateWriter:          pipeline.NoopStateWriter(),
+				CacheDir:             testCacheDir,
+				ReceiptQueryInterval: testReceiptQueryInterval,
 			},
 		))
 


### PR DESCRIPTION
## Summary

op-deployer currently sets keyed transaction gas limits from its Cancun-era script simulator. Post-Cancun repricing such as EIP-8037 can make those limits too low for the target L1.

This PR:

- leaves `GasLimit` unset so txmgr estimates gas against the target chain;
- sends transactions sequentially, ensuring each estimate includes state created by earlier broadcasts;
- stops after a failed transaction because later broadcasts may depend on it.

The Solidity simulation still generates and validates the transaction plan, but its `GasUsed` value no longer determines keyed transaction gas limits. This relies on #22217, which lets the target node choose the estimation ceiling.

Sequential submission is slower than the previous parallel approach, but avoids estimating dependent transactions against stale state.

Closes ethereum-optimism/protocol-team#269.

Related: [protocol-team#219](https://github.com/ethereum-optimism/protocol-team/issues/219).

## Tests

```bash
go test ./op-deployer/pkg/deployer/broadcaster
go test ./op-service/txmgr
```

A full post-Glamsterdam `bootstrap` + `apply` run remains before final review.
