### PR TITLE
refactor(kona): dedup derivation prologue into kona-proof (#21658)

### DIFF
--- a/rust/kona/bin/client/src/single.rs
+++ b/rust/kona/bin/client/src/single.rs
@@ -72,7 +72,7 @@ where
                 boot.claimed_l2_output_root,
             ));
         }
-        Err(SyncStartError::ClaimedRootMismatch { safe_head }) => {
+        Err(SyncStartError::ClaimedRootMismatch { safe_head, .. }) => {
             error!(
                 target: "client",
                 claimed = boot.claimed_l2_block_number,

--- a/rust/kona/bin/client/src/single.rs
+++ b/rust/kona/bin/client/src/single.rs
@@ -2,21 +2,19 @@
 
 use crate::fpvm_evm::FpvmOpEvmFactory;
 use alloc::sync::Arc;
-use alloy_consensus::Sealed;
 use alloy_op_evm::post_exec::PostExecEvmFactoryAdapter;
 use alloy_primitives::B256;
 use core::fmt::Debug;
 use kona_derive::{EthereumDataSource, PipelineErrorKind};
 use kona_driver::{Driver, DriverError};
-use kona_executor::{ExecutorError, TrieDBProvider};
+use kona_executor::ExecutorError;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use kona_proof::{
     BootInfo, CachingOracle,
     errors::OracleProviderError,
     executor::KonaExecutor,
-    l1::{OracleBlobProvider, OracleL1ChainProvider, OraclePipeline},
-    l2::OracleL2ChainProvider,
-    sync::{fetch_safe_head_hash, new_oracle_pipeline_cursor},
+    l1::{OracleBlobProvider, OraclePipeline},
+    sync::{DerivationInputs, SyncStartError, prepare_derivation},
 };
 use thiserror::Error;
 use tracing::{error, info};
@@ -54,45 +52,31 @@ where
     let oracle =
         Arc::new(CachingOracle::new(ORACLE_LRU_SIZE, oracle_client.clone(), hint_client.clone()));
     let boot = BootInfo::load(oracle.as_ref()).await?;
-    let l1_config = boot.l1_config;
-    let rollup_config = Arc::new(boot.rollup_config);
-    let safe_head_hash = fetch_safe_head_hash(oracle.as_ref(), boot.agreed_l2_output_root).await?;
-
-    let mut l1_provider = OracleL1ChainProvider::new(boot.l1_head, oracle.clone());
-    let mut l2_provider =
-        OracleL2ChainProvider::new(safe_head_hash, rollup_config.clone(), oracle.clone());
+    let rollup_config = Arc::new(boot.rollup_config.clone());
     let beacon = OracleBlobProvider::new(oracle.clone());
 
-    // Fetch the safe head's block header.
-    let safe_head = l2_provider
-        .header_by_hash(safe_head_hash)
-        .map(|header| Sealed::new_unchecked(header, safe_head_hash))?;
-
-    // If the claimed L2 block number is less than the safe head of the L2 chain, the claim is
-    // invalid.
-    if boot.claimed_l2_block_number < safe_head.number {
-        error!(
-            target: "client",
-            claimed = boot.claimed_l2_block_number,
-            safe = safe_head.number,
-            "Claimed L2 block number is less than the safe head",
-        );
-        return Err(FaultProofProgramError::InvalidClaim(
-            boot.agreed_l2_output_root,
-            boot.claimed_l2_output_root,
-        ));
-    }
-
-    // If the claim targets the safe head block itself, then no derivation is required. This can
-    // happen at trace-extension leaves where the trace is capped at the root-claim block number.
-    //
-    // In this case, the only valid output root is the agreed output root (a zero-step transition).
-    if boot.claimed_l2_block_number == safe_head.number {
-        if boot.claimed_l2_output_root != boot.agreed_l2_output_root {
+    // Run the shared sync-start prologue: validate the claim against the safe head and either
+    // detect a zero-step trace extension or build the derivation inputs.
+    let inputs = match prepare_derivation(&boot, rollup_config.clone(), oracle.clone()).await {
+        Ok(inputs) => inputs,
+        Err(SyncStartError::Oracle(e)) => return Err(e.into()),
+        Err(SyncStartError::ClaimedBlockBeforeSafeHead { claimed, safe_head }) => {
+            error!(
+                target: "client",
+                claimed,
+                safe = safe_head,
+                "Claimed L2 block number is less than the safe head",
+            );
+            return Err(FaultProofProgramError::InvalidClaim(
+                boot.agreed_l2_output_root,
+                boot.claimed_l2_output_root,
+            ));
+        }
+        Err(SyncStartError::ClaimedRootMismatch { safe_head }) => {
             error!(
                 target: "client",
                 claimed = boot.claimed_l2_block_number,
-                safe = safe_head.number,
+                safe = safe_head,
                 expected_output_root = ?boot.agreed_l2_output_root,
                 claimed_output_root = ?boot.claimed_l2_output_root,
                 "Claimed output root does not match agreed output root at safe head",
@@ -102,32 +86,17 @@ where
                 boot.claimed_l2_output_root,
             ));
         }
+    };
 
-        info!(
-            target: "client",
-            "Trace extension detected. State transition is already agreed upon.",
-        );
-        return Ok(());
-    }
+    let (cursor, l1_provider, l2_provider) = match inputs {
+        // The claim targets the safe head and matches the agreed output root: nothing to derive.
+        DerivationInputs::TraceExtension => return Ok(()),
+        DerivationInputs::Derive { cursor, l1_provider, l2_provider } => {
+            (cursor, l1_provider, l2_provider)
+        }
+    };
 
-    ////////////////////////////////////////////////////////////////
-    //                   DERIVATION & EXECUTION                   //
-    ////////////////////////////////////////////////////////////////
-
-    // Create a new derivation driver with the given boot information and oracle.
-    let cursor = new_oracle_pipeline_cursor(
-        rollup_config.as_ref(),
-        safe_head,
-        boot.agreed_l2_output_root,
-        &mut l1_provider,
-        &mut l2_provider,
-    )
-    .await
-    .map_err(|e| {
-        error!(target: "client", "Failed to create pipeline cursor: {:?}", e);
-        e
-    })?;
-    l2_provider.set_cursor(cursor.clone());
+    let l1_config = boot.l1_config;
 
     let evm_factory =
         PostExecEvmFactoryAdapter::new(FpvmOpEvmFactory::new(hint_client, oracle_client));

--- a/rust/kona/crates/proof/proof/src/sync.rs
+++ b/rust/kona/crates/proof/proof/src/sync.rs
@@ -1,16 +1,21 @@
 //! Sync Start
 
-use crate::{HintType, errors::OracleProviderError};
+use crate::{
+    BootInfo, HintType, errors::OracleProviderError, l1::OracleL1ChainProvider,
+    l2::OracleL2ChainProvider,
+};
 use alloc::sync::Arc;
 use alloy_consensus::{Header, Sealed};
 use alloy_primitives::B256;
 use core::fmt::Debug;
 use kona_derive::ChainProvider;
 use kona_driver::{PipelineCursor, TipCursor};
+use kona_executor::TrieDBProvider;
 use kona_preimage::{CommsClient, PreimageKey};
 use kona_protocol::BatchValidationProvider;
 use kona_registry::RollupConfig;
 use spin::RwLock;
+use thiserror::Error;
 
 /// Constructs a [`PipelineCursor`] from the caching oracle, boot info, and providers.
 pub async fn new_oracle_pipeline_cursor<L1, L2>(
@@ -78,11 +83,129 @@ where
     output_preimage[96..128].try_into().map_err(OracleProviderError::SliceConversion)
 }
 
+/// An error raised by [`prepare_derivation`] while validating a claim and building the derivation
+/// inputs during sync start.
+///
+/// Distinguishes oracle/data failures from claim-validation failures so each caller can map the
+/// variant onto its own error type (e.g. an `InvalidClaim` for the native fault-proof program).
+#[derive(Error, Debug)]
+pub enum SyncStartError {
+    /// An oracle-backed provider or preimage lookup failed.
+    #[error(transparent)]
+    Oracle(#[from] OracleProviderError),
+    /// The claimed L2 block number is behind the agreed safe head, so the claim cannot be valid.
+    #[error("Claimed L2 block number {claimed} is less than the safe head {safe_head}")]
+    ClaimedBlockBeforeSafeHead {
+        /// The claimed (disputed) L2 block number.
+        claimed: u64,
+        /// The agreed safe head L2 block number.
+        safe_head: u64,
+    },
+    /// The claim targets the safe head block itself (a zero-step transition), but the claimed
+    /// output root does not match the agreed output root.
+    #[error("Claimed output root does not match agreed output root at safe head {safe_head}")]
+    ClaimedRootMismatch {
+        /// The safe head L2 block number the claim targets.
+        safe_head: u64,
+    },
+}
+
+/// The outcome of [`prepare_derivation`]: either the claim is already agreed (no derivation needed)
+/// or the derivation inputs required to run the pipeline.
+#[derive(Debug)]
+pub enum DerivationInputs<O>
+where
+    O: CommsClient,
+{
+    /// The claim targets the current safe head and matches the agreed output root: a zero-step
+    /// "trace extension" transition that requires no derivation.
+    TraceExtension,
+    /// The claim is ahead of the safe head; derivation must run over these inputs.
+    Derive {
+        /// The initialized derivation pipeline cursor.
+        cursor: Arc<RwLock<PipelineCursor>>,
+        /// The oracle-backed L1 chain provider.
+        l1_provider: OracleL1ChainProvider<O>,
+        /// The oracle-backed L2 chain provider, with its cursor set.
+        l2_provider: OracleL2ChainProvider<O>,
+    },
+}
+
+/// Runs the sync-start prologue shared by the native fault-proof program and kona-sp1.
+///
+/// Given loaded boot info and an oracle, this:
+/// 1. resolves the agreed safe head hash and header,
+/// 2. rejects a claim whose block number is behind the safe head,
+/// 3. short-circuits a zero-step "trace extension" claim (claim == safe head), and
+/// 4. otherwise builds the pipeline cursor and returns the L1/L2 providers ready for derivation.
+///
+/// Callers map [`SyncStartError`] onto their own error type. This is the single source of truth for
+/// the claim-validation and trace-extension logic that both derivation paths depend on.
+pub async fn prepare_derivation<O>(
+    boot: &BootInfo,
+    rollup_config: Arc<RollupConfig>,
+    oracle: Arc<O>,
+) -> Result<DerivationInputs<O>, SyncStartError>
+where
+    O: CommsClient + Send + Sync + Debug,
+{
+    let safe_head_hash = fetch_safe_head_hash(oracle.as_ref(), boot.agreed_l2_output_root).await?;
+
+    let mut l1_provider = OracleL1ChainProvider::new(boot.l1_head, oracle.clone());
+    let mut l2_provider =
+        OracleL2ChainProvider::new(safe_head_hash, rollup_config.clone(), oracle.clone());
+
+    // Fetch the safe head's block header.
+    let safe_head = l2_provider
+        .header_by_hash(safe_head_hash)
+        .map(|header| Sealed::new_unchecked(header, safe_head_hash))?;
+
+    // If the claimed L2 block number is less than the safe head of the L2 chain, the claim is
+    // invalid.
+    if boot.claimed_l2_block_number < safe_head.number {
+        return Err(SyncStartError::ClaimedBlockBeforeSafeHead {
+            claimed: boot.claimed_l2_block_number,
+            safe_head: safe_head.number,
+        });
+    }
+
+    // If the claim targets the safe head block itself, then no derivation is required. This can
+    // happen at trace-extension leaves where the trace is capped at the root-claim block number.
+    // In this case, the only valid output root is the agreed output root (a zero-step transition).
+    if boot.claimed_l2_block_number == safe_head.number {
+        if boot.claimed_l2_output_root != boot.agreed_l2_output_root {
+            return Err(SyncStartError::ClaimedRootMismatch { safe_head: safe_head.number });
+        }
+
+        info!(
+            target: "client",
+            "Trace extension detected. State transition is already agreed upon.",
+        );
+        return Ok(DerivationInputs::TraceExtension);
+    }
+
+    // Create a new derivation pipeline cursor from the agreed safe head.
+    let cursor = new_oracle_pipeline_cursor(
+        rollup_config.as_ref(),
+        safe_head,
+        boot.agreed_l2_output_root,
+        &mut l1_provider,
+        &mut l2_provider,
+    )
+    .await?;
+    l2_provider.set_cursor(cursor.clone());
+
+    Ok(DerivationInputs::Derive { cursor, l1_provider, l2_provider })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::{boxed::Box, collections::BTreeMap, vec, vec::Vec};
+    use alloc::{boxed::Box, collections::BTreeMap, string::ToString, vec, vec::Vec};
+    use alloy_primitives::keccak256;
+    use alloy_rlp::Encodable;
     use async_trait::async_trait;
+    use kona_genesis::L1ChainConfig;
     use kona_preimage::{
         HintWriterClient, PreimageKeyType, PreimageOracleClient,
         errors::{PreimageOracleError, PreimageOracleResult},
@@ -90,7 +213,7 @@ mod tests {
 
     /// A minimal in-memory [`CommsClient`] serving a single preimage, used to drive
     /// [`fetch_safe_head_hash`] in tests.
-    #[derive(Clone, Default)]
+    #[derive(Clone, Debug, Default)]
     struct MockOracle {
         preimages: BTreeMap<PreimageKey, Vec<u8>>,
     }
@@ -100,6 +223,10 @@ mod tests {
             let mut preimages = BTreeMap::new();
             preimages.insert(key, value);
             Self { preimages }
+        }
+
+        fn insert(&mut self, key: PreimageKey, value: Vec<u8>) {
+            self.preimages.insert(key, value);
         }
     }
 
@@ -183,5 +310,75 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    /// Builds a [`MockOracle`] that serves the agreed output-root preimage (encoding `safe_head`'s
+    /// hash) and the safe-head header RLP, plus the matching [`BootInfo`]. `claimed_block` and
+    /// `claimed_root` drive which [`prepare_derivation`] branch is exercised.
+    fn prologue_fixture(
+        safe_head_number: u64,
+        claimed_block: u64,
+        claimed_root: B256,
+    ) -> (MockOracle, BootInfo) {
+        let safe_head = Header { number: safe_head_number, ..Default::default() };
+        let safe_head_hash = safe_head.hash_slow();
+
+        let mut output_preimage = [0u8; 128];
+        output_preimage[96..128].copy_from_slice(safe_head_hash.as_slice());
+        let agreed_root = B256::from(keccak256(output_preimage));
+
+        let mut oracle =
+            MockOracle::single(PreimageKey::new_keccak256(*agreed_root), output_preimage.to_vec());
+        let mut header_rlp = Vec::new();
+        safe_head.encode(&mut header_rlp);
+        oracle.insert(PreimageKey::new_keccak256(*safe_head_hash), header_rlp);
+
+        let boot = BootInfo {
+            l1_head: b256(0x11),
+            agreed_l2_output_root: agreed_root,
+            claimed_l2_output_root: claimed_root,
+            claimed_l2_block_number: claimed_block,
+            chain_id: 10,
+            rollup_config: RollupConfig::default(),
+            l1_config: L1ChainConfig::default(),
+        };
+
+        (oracle, boot)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_derivation_short_circuits_trace_extension() {
+        // Claim targets the safe head itself and matches the agreed root: zero-step transition.
+        let (oracle, boot) = prologue_fixture(3, 3, B256::ZERO);
+        let boot = BootInfo { claimed_l2_output_root: boot.agreed_l2_output_root, ..boot };
+        let rollup_config = Arc::new(boot.rollup_config.clone());
+
+        let out = prepare_derivation(&boot, rollup_config, Arc::new(oracle)).await.unwrap();
+        assert!(matches!(out, DerivationInputs::TraceExtension));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_derivation_rejects_trace_extension_root_mismatch() {
+        // Claim targets the safe head but the claimed root differs from the agreed root.
+        let (oracle, boot) = prologue_fixture(3, 3, b256(0xCC));
+        assert_ne!(boot.claimed_l2_output_root, boot.agreed_l2_output_root);
+        let rollup_config = Arc::new(boot.rollup_config.clone());
+
+        let err = prepare_derivation(&boot, rollup_config, Arc::new(oracle)).await.unwrap_err();
+        assert!(matches!(err, SyncStartError::ClaimedRootMismatch { safe_head: 3 }));
+        assert!(err.to_string().contains("does not match agreed output root"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_derivation_rejects_claim_before_safe_head() {
+        // Claim targets a block behind the safe head: the claim cannot be valid.
+        let (oracle, boot) = prologue_fixture(3, 2, b256(0xCC));
+        let rollup_config = Arc::new(boot.rollup_config.clone());
+
+        let err = prepare_derivation(&boot, rollup_config, Arc::new(oracle)).await.unwrap_err();
+        assert!(matches!(
+            err,
+            SyncStartError::ClaimedBlockBeforeSafeHead { claimed: 2, safe_head: 3 }
+        ));
     }
 }

--- a/rust/kona/crates/proof/proof/src/sync.rs
+++ b/rust/kona/crates/proof/proof/src/sync.rs
@@ -53,7 +53,7 @@ where
 }
 
 /// Fetches the safe head hash of the L2 chain based on the agreed upon L2 output root in the
-/// [`BootInfo`](crate::BootInfo).
+/// [`BootInfo`].
 ///
 /// Decodes the agreed L2 output root's preimage into its safe head block hash. The preimage is the
 /// 128-byte output-root V0 layout; the safe head hash occupies bytes `[96..128]`. Only version `0`

--- a/rust/kona/crates/proof/proof/src/sync.rs
+++ b/rust/kona/crates/proof/proof/src/sync.rs
@@ -103,8 +103,14 @@ pub enum SyncStartError {
     },
     /// The claim targets the safe head block itself (a zero-step transition), but the claimed
     /// output root does not match the agreed output root.
-    #[error("Claimed output root does not match agreed output root at safe head {safe_head}")]
+    #[error(
+        "Claimed output root {claimed} does not match agreed output root {agreed} at safe head {safe_head}"
+    )]
     ClaimedRootMismatch {
+        /// The claimed (disputed) L2 output root.
+        claimed: B256,
+        /// The agreed L2 output root.
+        agreed: B256,
         /// The safe head L2 block number the claim targets.
         safe_head: u64,
     },
@@ -174,7 +180,11 @@ where
     // In this case, the only valid output root is the agreed output root (a zero-step transition).
     if boot.claimed_l2_block_number == safe_head.number {
         if boot.claimed_l2_output_root != boot.agreed_l2_output_root {
-            return Err(SyncStartError::ClaimedRootMismatch { safe_head: safe_head.number });
+            return Err(SyncStartError::ClaimedRootMismatch {
+                claimed: boot.claimed_l2_output_root,
+                agreed: boot.agreed_l2_output_root,
+                safe_head: safe_head.number,
+            });
         }
 
         info!(
@@ -365,7 +375,7 @@ mod tests {
         let rollup_config = Arc::new(boot.rollup_config.clone());
 
         let err = prepare_derivation(&boot, rollup_config, Arc::new(oracle)).await.unwrap_err();
-        assert!(matches!(err, SyncStartError::ClaimedRootMismatch { safe_head: 3 }));
+        assert!(matches!(err, SyncStartError::ClaimedRootMismatch { safe_head: 3, .. }));
         assert!(err.to_string().contains("does not match agreed output root"));
     }
 

--- a/rust/kona/sp1/crates/client/src/witness/executor.rs
+++ b/rust/kona/sp1/crates/client/src/witness/executor.rs
@@ -3,7 +3,6 @@
 use std::{fmt::Debug, sync::Arc};
 
 use alloy_op_evm::{block::OpAlloyReceiptBuilder, post_exec::PostExecEvmFactoryAdapter};
-use alloy_primitives::Sealed;
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use kona_derive::{
@@ -11,7 +10,6 @@ use kona_derive::{
     SignalReceiver,
 };
 use kona_driver::{Driver, DriverPipeline, PipelineCursor};
-use kona_executor::TrieDBProvider;
 use kona_genesis::{L1ChainConfig, RollupConfig};
 use kona_preimage::CommsClient;
 use kona_proof::{
@@ -19,7 +17,7 @@ use kona_proof::{
     executor::KonaExecutor,
     l1::{OracleL1ChainProvider, OraclePipeline},
     l2::OracleL2ChainProvider,
-    sync::{fetch_safe_head_hash, new_oracle_pipeline_cursor},
+    sync::{DerivationInputs, prepare_derivation},
 };
 use spin::RwLock;
 use tracing::info;
@@ -39,10 +37,6 @@ pub async fn get_inputs_for_pipeline<O>(
 where
     O: CommsClient + FlushableCache + Send + Sync + Debug,
 {
-    ////////////////////////////////////////////////////////////////
-    //                          PROLOGUE                          //
-    ////////////////////////////////////////////////////////////////
-
     let boot = match BootInfo::load(oracle.as_ref()).await {
         Ok(boot) => boot,
         Err(e) => {
@@ -50,63 +44,16 @@ where
         }
     };
 
-    let boot_clone = boot.clone();
+    let rollup_config = Arc::new(boot.rollup_config.clone());
 
-    let rollup_config = Arc::new(boot.rollup_config);
-    let safe_head_hash = fetch_safe_head_hash(oracle.as_ref(), boot.agreed_l2_output_root).await?;
-
-    let mut l1_provider = OracleL1ChainProvider::new(boot.l1_head, oracle.clone());
-    let mut l2_provider =
-        OracleL2ChainProvider::new(safe_head_hash, rollup_config.clone(), oracle.clone());
-
-    // Fetch the safe head's block header.
-    let safe_head = l2_provider
-        .header_by_hash(safe_head_hash)
-        .map(|header| Sealed::new_unchecked(header, safe_head_hash))?;
-
-    // If the claimed L2 block number is less than the safe head of the L2 chain, the claim is
-    // invalid.
-    if boot.claimed_l2_block_number < safe_head.number {
-        return Err(anyhow!(
-            "Claimed L2 block number {claimed} is less than the safe head {safe}",
-            claimed = boot.claimed_l2_block_number,
-            safe = safe_head.number
-        ));
-    }
-
-    if boot.claimed_l2_block_number == safe_head.number {
-        if boot.claimed_l2_output_root != boot.agreed_l2_output_root {
-            return Err(anyhow!(
-                "Claimed output root {claimed} does not match agreed output root {agreed} at safe head {safe}",
-                claimed = boot.claimed_l2_output_root,
-                agreed = boot.agreed_l2_output_root,
-                safe = safe_head.number,
-            ));
+    // Run the shared sync-start prologue. A trace-extension claim needs no derivation; otherwise we
+    // get back the cursor and providers to build the pipeline over.
+    match prepare_derivation(&boot, rollup_config, oracle).await? {
+        DerivationInputs::TraceExtension => Ok((boot, None)),
+        DerivationInputs::Derive { cursor, l1_provider, l2_provider } => {
+            Ok((boot, Some((cursor, l1_provider, l2_provider))))
         }
-
-        info!(
-            target: "client",
-            "Trace extension detected. State transition is already agreed upon.",
-        );
-        return Ok((boot_clone, None));
     }
-
-    ////////////////////////////////////////////////////////////////
-    //                   DERIVATION & EXECUTION                   //
-    ////////////////////////////////////////////////////////////////
-
-    // Create a new derivation driver with the given boot information and oracle.
-    let cursor = new_oracle_pipeline_cursor(
-        rollup_config.as_ref(),
-        safe_head,
-        boot.agreed_l2_output_root,
-        &mut l1_provider,
-        &mut l2_provider,
-    )
-    .await?;
-    l2_provider.set_cursor(cursor.clone());
-
-    Ok((boot_clone, Some((cursor, l1_provider, l2_provider))))
 }
 
 /// The [`WitnessExecutor`] trait defines an interface for constructing and running the derivation


### PR DESCRIPTION
Closes #21658. Third and final dedup from the #18494 thread (after the derivation loop and fetch_safe_head_hash).

## What

The sync-start prologue (resolve safe head, reject a claim behind it, short-circuit a zero-step trace extension,
build the pipeline cursor) was duplicated between the native fault-proof program (bin/client single.rs) and kona-sp1
(get_inputs_for_pipeline). It's consensus-critical validation, so a fix to one path could silently miss the other.

This extracts it into kona_proof::sync::prepare_derivation, the single source of truth. Both callers now delegate to
it.

## Changes

- kona-proof: add prepare_derivation, returning DerivationInputs (TraceExtension | Derive { cursor, l1_provider,
l2_provider }) and SyncStartError (Oracle | ClaimedBlockBeforeSafeHead | ClaimedRootMismatch). Each caller maps the
error onto its own type.
- bin/client: prologue collapses to the helper call; SyncStartError maps to the existing InvalidClaim (structured
error logs preserved).
- kona-sp1: get_inputs_for_pipeline becomes a thin adapter over the helper.

Validation order and the zero-step agreed == claimed check are identical to both originals. One minor diagnostic
change: single.rs's "Failed to create pipeline cursor" wrapper log is dropped (the error still surfaces as
OracleProviderError).

## Testing

- Build + clippy clean; fmt clean on both workspaces.
- 127 unit tests pass, incl. 3 new native prepare_derivation branch tests and the existing kona-sp1 get_inputs
tests.
- Guest ELF rebuilt for riscv64im-succinct-zkvm-elf.
- TestSP1RangeSimpleEmptyChain (honest + junk claim) passes through the real guest.