### PR TITLE
docs: update social thumbnail styling

### DIFF
--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -7,6 +7,10 @@
     "light": "#FF0420",
     "dark": "#FF0420"
   },
+  "thumbnails": {
+    "appearance": "dark",
+    "background": "/public/img/og-background.svg"
+  },
   "favicon": "/public/favicon.png",
   "metadata": {
     "apple-touch-icon": "/public/apple-touch-icon.png"

--- a/docs/public-docs/public/img/og-background.svg
+++ b/docs/public-docs/public/img/og-background.svg
@@ -1,0 +1,3 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#111111"/>
+</svg>


### PR DESCRIPTION
# Problem

The current docs thumbnails do not match our redesigned visual direction.

![Current production docs thumbnail](https://optimism-373f39ad.mintlify.app/mintlify-assets/_next/image?url=%2F_mintlify%2Fapi%2Fog%3Fdivision%3DFeatures%26title%3DDeploy%2Ba%2BCustom%2BGas%2BToken%2Bchain%26description%3DLearn%2Bhow%2Bto%2Bdeploy%2Ba%2BCustom%2BGas%2BToken%2Bchain%2Busing%2BOP%2BDeployer.%26logoLight%3Dhttps%253A%252F%252Fmintcdn.com%252Foptimism-373f39ad%252FVw5vY8zA-CRjBsUF%252Fpublic%252Flogos%252FLockup_docs_dark.svg%253Ffit%253Dmax%2526auto%253Dformat%2526n%253DVw5vY8zA-CRjBsUF%2526q%253D85%2526s%253Da1ab18aecbec09fe5ad40222ce76f00c%26logoDark%3Dhttps%253A%252F%252Fmintcdn.com%252Foptimism-373f39ad%252FVw5vY8zA-CRjBsUF%252Fpublic%252Flogos%252FLockup_docs_light.svg%253Ffit%253Dmax%2526auto%253Dformat%2526n%253DVw5vY8zA-CRjBsUF%2526q%253D85%2526s%253Dedf965cc513f1a46b1897e2a6494b43b%26primaryColor%3D%2523FF0420%26lightColor%3D%2523FF0420%26darkColor%3D%2523FF0420%26backgroundLight%3D%2523ffffff%26backgroundDark%3D%25230e090b&w=1200&q=100)

# Solution

The updated docs thumbnails use the new dark Optimism treatment while preserving page-specific content.

![Updated preview docs thumbnail](https://optimism-373f39ad-kevin-update-docs-thumbnails.mintlify.app/mintlify-assets/_next/image?url=%2F_mintlify%2Fapi%2Fog%3Fdivision%3DFeatures%26appearance%3Ddark%26title%3DDeploy%2Ba%2BCustom%2BGas%2BToken%2Bchain%26description%3DLearn%2Bhow%2Bto%2Bdeploy%2Ba%2BCustom%2BGas%2BToken%2Bchain%2Busing%2BOP%2BDeployer.%26logoLight%3Dhttps%253A%252F%252Fmintcdn.com%252Foptimism-373f39ad-kevin-update-docs-thumbnails%252FksRU-0EV7apIwKcH%252Fpublic%252Flogos%252FLockup_docs_dark.svg%253Ffit%253Dmax%2526auto%253Dformat%2526n%253DksRU-0EV7apIwKcH%2526q%253D85%2526s%253D35a4ca39f887450a647ddbc3681cb61c%26logoDark%3Dhttps%253A%252F%252Fmintcdn.com%252Foptimism-373f39ad-kevin-update-docs-thumbnails%252FksRU-0EV7apIwKcH%252Fpublic%252Flogos%252FLockup_docs_light.svg%253Ffit%253Dmax%2526auto%253Dformat%2526n%253DksRU-0EV7apIwKcH%2526q%253D85%2526s%253D49e93a1d15a96da6a3f821fd326ada10%26primaryColor%3D%2523FF0420%26lightColor%3D%2523FF0420%26darkColor%3D%2523FF0420%26backgroundLight%3D%2523ffffff%26backgroundDark%3D%25230e090b%26background%3Dhttps%253A%252F%252Fmintcdn.com%252Foptimism-373f39ad-kevin-update-docs-thumbnails%252FksRU-0EV7apIwKcH%252Fpublic%252Fimg%252Fog-background.svg%253Ffit%253Dmax%2526auto%253Dformat%2526n%253DksRU-0EV7apIwKcH%2526q%253D85%2526s%253Df784a4c77df318831356e5f8d34988fa&w=1200&q=100)
