### PR TITLE
test(op-e2e): use production super-root proposal source

### DIFF
--- a/op-e2e/actions/helpers/l2_proposer.go
+++ b/op-e2e/actions/helpers/l2_proposer.go
@@ -19,13 +19,12 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer/source"
-	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
@@ -41,7 +40,7 @@ type ProposerCfg struct {
 	AllowNonFinalized      bool
 	AllocType              config.AllocType
 	ChainID                eth.ChainID
-	L2ChainID              eth.ChainID
+	Clock                  clock.Clock
 }
 
 type L2Proposer struct {
@@ -53,8 +52,6 @@ type L2Proposer struct {
 	address                common.Address
 	privKey                *ecdsa.PrivateKey
 	lastTx                 common.Hash
-	l2ChainID              eth.ChainID
-	allocType              config.AllocType
 }
 
 type fakeTxMgr struct {
@@ -97,7 +94,7 @@ func (f fakeTxMgr) SuggestGasPriceCaps(context.Context) (*big.Int, *big.Int, *bi
 	panic("unimplemented")
 }
 
-func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Client, rollupCl *sources.RollupClient) *L2Proposer {
+func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Client, proposalSource source.ProposalSource) *L2Proposer {
 	proposerConfig := proposer.ProposerConfig{
 		PollInterval:           time.Second,
 		NetworkTimeout:         time.Second,
@@ -106,24 +103,23 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 		DisputeGameType:        cfg.DisputeGameType,
 		AllowNonFinalized:      cfg.AllowNonFinalized,
 	}
-	rollupProvider, err := dial.NewStaticL2RollupProviderFromExistingRollup(rollupCl)
-	require.NoError(t, err)
 
+	t.Cleanup(proposalSource.Close)
 	driverSetup := proposer.DriverSetup{
 		Log:            log,
 		Metr:           metrics.NoopMetrics,
 		Cfg:            proposerConfig,
+		Clock:          cfg.Clock,
 		Txmgr:          fakeTxMgr{from: crypto.PubkeyToAddress(cfg.ProposerKey.PublicKey), chainID: cfg.ChainID},
 		L1Client:       l1,
 		Multicaller:    batching.NewMultiCaller(l1.Client(), batching.DefaultBatchSize),
-		ProposalSource: source.NewRollupProposalSource(rollupProvider),
+		ProposalSource: proposalSource,
 	}
 
 	dr, err := proposer.NewL2OutputSubmitter(driverSetup)
 	require.NoError(t, err)
 
 	address := crypto.PubkeyToAddress(cfg.ProposerKey.PublicKey)
-
 	disputeGameFactory, err := bindings.NewDisputeGameFactoryCaller(*cfg.DisputeGameFactoryAddr, l1)
 	require.NoError(t, err)
 
@@ -135,8 +131,6 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 		disputeGameFactoryAddr: cfg.DisputeGameFactoryAddr,
 		address:                address,
 		privKey:                cfg.ProposerKey,
-		allocType:              cfg.AllocType,
-		l2ChainID:              cfg.L2ChainID,
 	}
 }
 
@@ -196,41 +190,18 @@ func estimateGasPending(ctx context.Context, ec *ethclient.Client, msg ethereum.
 }
 
 func (p *L2Proposer) fetchNextOutput(t Testing) (source.Proposal, bool, error) {
-	isSuperPermissioned := gameTypes.GameType(p.driver.Cfg.DisputeGameType) == gameTypes.SuperPermissionedGameType
-	var output source.Proposal
-	if isSuperPermissioned {
-		sequenceNum, err := p.driver.FetchCurrentBlockNumber(t.Ctx())
-		if err != nil || sequenceNum == 0 {
-			return source.Proposal{}, false, err
-		}
-		output, err = p.driver.FetchOutput(t.Ctx(), sequenceNum)
-		if err != nil {
-			return source.Proposal{}, false, err
-		}
-		super := eth.NewSuperV1(output.Legacy.BlockRef.Time, eth.ChainIDAndOutput{
-			ChainID: p.l2ChainID,
-			Output:  eth.Bytes32(output.Root),
-		})
-		output.Root = common.Hash(eth.SuperRoot(super))
-		output.SequenceNum = output.Legacy.BlockRef.Time
-		output.Super = super
-	} else {
-		var shouldPropose bool
-		var err error
-		output, shouldPropose, err = p.driver.FetchDGFOutput(t.Ctx())
-		if err != nil || !shouldPropose {
-			return source.Proposal{}, false, err
-		}
+	output, shouldPropose, err := p.driver.FetchDGFOutput(t.Ctx())
+	if err != nil || !shouldPropose {
+		return output, shouldPropose, err
 	}
 
-	game, err := p.disputeGameFactory.Games(&bind.CallOpts{}, p.driver.Cfg.DisputeGameType, output.Root, output.ExtraData())
+	game, err := p.disputeGameFactory.Games(&bind.CallOpts{Context: t.Ctx()}, p.driver.Cfg.DisputeGameType, output.Root, output.ExtraData())
 	if err != nil {
 		return source.Proposal{}, false, err
 	}
 	if game.Timestamp != 0 {
 		return source.Proposal{}, false, nil
 	}
-
 	return output, true, nil
 }
 

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -98,6 +98,24 @@ type safeDB interface {
 	node.SafeDBReader
 }
 
+type proposerSuperRootSafeDBReader struct{}
+
+func (proposerSuperRootSafeDBReader) SafeHeadAtL1(context.Context, uint64) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, errors.New("action proposer SafeDB reader does not support SafeHeadAtL1")
+}
+
+func (proposerSuperRootSafeDBReader) L1AtSafeHead(context.Context, uint64) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, nil
+}
+
+func (proposerSuperRootSafeDBReader) FirstEntry(context.Context) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, errors.New("action proposer SafeDB reader does not support FirstEntry")
+}
+
+func (proposerSuperRootSafeDBReader) LastEntry(context.Context) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, errors.New("action proposer SafeDB reader does not support LastEntry")
+}
+
 func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	blobsSrc derive.L1BlobsFetcher, altDASrc driver.AltDAIface,
 	eng L2API, cfg *rollup.Config, l1ChainConfig *params.ChainConfig,
@@ -216,6 +234,19 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	}
 	require.NoError(t, gnode.RegisterApis(apis, nil, rollupNode.rpc), "failed to set up APIs")
 	return rollupNode
+}
+
+func (s *L2Verifier) EnableProposerSuperRootAPI(t Testing) {
+	apis := []rpc.API{{
+		Namespace: "superroot",
+		Service: node.NewSuperrootAPI(
+			s.RollupCfg,
+			s.Eng,
+			&l2VerifierBackend{verifier: s},
+			proposerSuperRootSafeDBReader{},
+		),
+	}}
+	require.NoError(t, gnode.RegisterApis(apis, nil, s.rpc), "failed to set up proposer super-root API")
 }
 
 type l2VerifierBackend struct {

--- a/op-e2e/actions/proposer/l2_proposer_test.go
+++ b/op-e2e/actions/proposer/l2_proposer_test.go
@@ -19,8 +19,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindingspreview"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-proposer/proposer/source"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
@@ -42,8 +45,16 @@ func runProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64, allocType c
 	dp := e2eutils.MakeDeployParams(t, params)
 	upgradesHelpers.ApplyDeltaTimeOffset(dp, deltaTimeOffset)
 	sd := e2eutils.Setup(t, dp, actionsHelpers.DefaultAlloc)
+	const (
+		testClockOffset  = 30 * time.Minute
+		proposalInterval = time.Hour
+	)
+	proposerClock := clock.NewDeterministicClock(time.Unix(int64(sd.L1Cfg.Timestamp), 0).Add(testClockOffset))
 	log := testlog.Logger(t, log.LevelDebug)
 	miner, seqEngine, sequencer := actionsHelpers.SetupSequencerTest(t, sd, log)
+	sequencer.EnableProposerSuperRootAPI(t)
+	superNodeClient := sources.NewSuperNodeClient(sequencer.RPCClient())
+	proposalSource := source.NewSuperNodeProposalSource(log, superNodeClient)
 
 	rollupSeqCl := sequencer.RollupClient()
 	batcher := actionsHelpers.NewL2Batcher(log, sd.RollupCfg, actionsHelpers.DefaultBatcherCfg(dp),
@@ -55,15 +66,15 @@ func runProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64, allocType c
 	require.NoError(t, err)
 	proposer := actionsHelpers.NewL2Proposer(t, log, &actionsHelpers.ProposerCfg{
 		DisputeGameFactoryAddr: &sd.DeploymentsL1.DisputeGameFactoryProxy,
-		ProposalInterval:       6 * time.Second,
+		ProposalInterval:       proposalInterval,
 		ProposalRetryInterval:  3 * time.Second,
 		DisputeGameType:        respectedGameType,
 		ProposerKey:            dp.Secrets.Proposer,
 		AllowNonFinalized:      true,
 		AllocType:              allocType,
 		ChainID:                eth.ChainIDFromBig(sd.L1Cfg.Config.ChainID),
-		L2ChainID:              eth.ChainIDFromBig(sd.RollupCfg.L2ChainID),
-	}, miner.EthClient(), rollupSeqCl)
+		Clock:                  proposerClock,
+	}, miner.EthClient(), proposalSource)
 
 	// L1 block
 	miner.ActEmptyBlock(t)
@@ -88,22 +99,36 @@ func runProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64, allocType c
 	sequencer.ActL2PipelineFull(t)
 	proposedL2 := sequencer.SyncStatus().FinalizedL2
 	require.Equal(t, sequencer.SyncStatus().UnsafeL2, proposedL2)
+	status := sequencer.SyncStatus()
+	rpcOutput, err := superNodeClient.SuperRootAtTimestamp(t.Ctx(), proposedL2.Time)
+	require.NoError(t, err)
+	require.Equal(t, status.CurrentL1.ID(), rpcOutput.CurrentL1)
+	require.Equal(t, status.SafeL2.Time, rpcOutput.CurrentSafeTimestamp)
+	require.Equal(t, status.FinalizedL2.Time, rpcOutput.CurrentFinalizedTimestamp)
+	require.Equal(t, []eth.ChainID{eth.ChainIDFromBig(sd.RollupCfg.L2ChainID)}, rpcOutput.ChainIDs)
+	require.NotNil(t, rpcOutput.Data)
+	rpcSuperV1, ok := rpcOutput.Data.Super.(*eth.SuperV1)
+	require.True(t, ok)
+	require.Len(t, rpcSuperV1.Chains, 1)
+	require.Equal(t, proposedL2.Time, rpcSuperV1.Timestamp)
+	require.Equal(t, rpcOutput.Data.SuperRoot, eth.SuperRoot(rpcSuperV1))
+	outputComputed, err := rollupSeqCl.OutputAtBlock(t.Ctx(), proposedL2.Number)
+	require.NoError(t, err)
+	require.Equal(t, outputComputed.OutputRoot, rpcSuperV1.Chains[0].Output)
+	require.Equal(t, eth.ChainIDFromBig(sd.RollupCfg.L2ChainID), rpcSuperV1.Chains[0].ChainID)
 	require.True(t, proposer.CanPropose(t))
 
-	// make proposals until there is nothing left to propose
-	for proposer.CanPropose(t) {
-		proposer.ActMakeProposalTx(t)
-		// include proposal on L1
-		miner.ActL1StartBlock(12)(t)
-		miner.ActL1IncludeTx(dp.Addresses.Proposer)(t)
-		miner.ActL1EndBlock(t)
-		// Check proposal was successful
-		receipt, err := miner.EthClient().TransactionReceipt(t.Ctx(), proposer.LastProposalTx())
-		require.NoError(t, err)
-		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "proposal failed")
-	}
+	proposer.ActMakeProposalTx(t)
+	// include proposal on L1
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTx(dp.Addresses.Proposer)(t)
+	miner.ActL1EndBlock(t)
+	// Check proposal was successful
+	receipt, err := miner.EthClient().TransactionReceipt(t.Ctx(), proposer.LastProposalTx())
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "proposal failed")
 
-	// check that L1 stored the expected output root
+	// Check the created game's timestamp exercises a real, nonzero proposal interval.
 	disputeGameFactoryContract, err := bindings.NewDisputeGameFactory(sd.DeploymentsL1.DisputeGameFactoryProxy, miner.EthClient())
 	require.NoError(t, err)
 	gameCount, err := disputeGameFactoryContract.GameCount(&bind.CallOpts{})
@@ -113,6 +138,39 @@ func runProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64, allocType c
 	require.NoError(t, err)
 	require.Greater(t, len(latestGames), 0, "latest games must be greater than 0")
 	latestGame := latestGames[0]
+	gameTimestamp := time.Unix(int64(latestGame.Timestamp), 0)
+	require.True(t, gameTimestamp.Before(proposerClock.Now()), "test clock must be after the created game's timestamp")
+	require.True(t, gameTimestamp.After(proposerClock.Now().Add(-proposalInterval)), "created game must be inside the nonzero proposal interval")
+
+	clockAdvance := proposalInterval + time.Second
+	proposerClock.AdvanceTime(clockAdvance)
+	require.False(t, proposer.CanPropose(t), "exact duplicate-game lookup must suppress the unchanged proposal after the proposal interval expires")
+	proposerClock.AdvanceTime(-clockAdvance)
+
+	// Advance the finalized L2 head while the first proposal is still inside the proposal interval.
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActL2PipelineFull(t)
+	sequencer.ActBuildToL1Head(t)
+	batcher.ActSubmitAll(t)
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTx(dp.Addresses.Batcher)(t)
+	miner.ActL1EndBlock(t)
+	miner.ActL1SafeNext(t)
+	miner.ActL1SafeNext(t)
+	miner.ActL1FinalizeNext(t)
+	miner.ActL1FinalizeNext(t)
+	sequencer.ActL2PipelineFull(t)
+	sequencer.ActL1SafeSignal(t)
+	sequencer.ActL1FinalizedSignal(t)
+	sequencer.ActL2PipelineFull(t)
+	newFinalizedL2 := sequencer.SyncStatus().FinalizedL2
+	require.Greater(t, newFinalizedL2.Time, proposedL2.Time)
+	newProposal, err := proposalSource.ProposalAtSequenceNum(t.Ctx(), newFinalizedL2.Time)
+	require.NoError(t, err)
+	require.NotEqual(t, common.Hash(rpcOutput.Data.SuperRoot), newProposal.Root, "new finalized L2 head must produce a different proposal root before testing interval throttling")
+	require.False(t, proposer.CanPropose(t), "proposal interval must suppress a different proposal while the first game remains recent")
+
+	// check that L1 stored the expected output root
 	superRoot, err := eth.UnmarshalSuperRoot(latestGame.ExtraData)
 	require.NoError(t, err)
 	superV1, ok := superRoot.(*eth.SuperV1)
@@ -123,8 +181,6 @@ func runProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64, allocType c
 	block, err := seqEngine.EthClient().BlockByNumber(t.Ctx(), new(big.Int).SetUint64(proposedL2.Number))
 	require.NoError(t, err)
 	require.Less(t, block.Time(), latestGame.Timestamp, "output is registered with L1 timestamp of proposal tx, past L2 block")
-	outputComputed, err := sequencer.RollupClient().OutputAtBlock(t.Ctx(), proposedL2.Number)
-	require.NoError(t, err)
 	require.Equal(t, outputComputed.OutputRoot, superV1.Chains[0].Output, "output roots must match")
 	require.Equal(t, eth.Bytes32(latestGame.RootClaim), eth.SuperRoot(superV1), "super roots must match")
 }

--- a/op-e2e/system/proofs/proposer_fp_test.go
+++ b/op-e2e/system/proofs/proposer_fp_test.go
@@ -67,6 +67,7 @@ func TestL2OutputSubmitterFaultProofs(t *testing.T) {
 			require.True(t, ok)
 			gameBlockNumber, err := sys.RollupConfig.TargetBlockNumber(superV1.Timestamp)
 			require.NoError(t, err)
+			// A new game may still predate the target block, so keep polling until a proposal covers it.
 			if gameBlockNumber >= targetBlockNumber {
 				require.GreaterOrEqual(t, gameBlockNumber, targetBlockNumber)
 				require.Len(t, superV1.Chains, 1)

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-proposer/contracts"
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer/source"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
@@ -50,6 +51,7 @@ type DriverSetup struct {
 	Log         log.Logger
 	Metr        metrics.Metricer
 	Cfg         ProposerConfig
+	Clock       clock.Clock
 	Txmgr       txmgr.TxManager
 	L1Client    L1Client
 	Multicaller *batching.MultiCaller
@@ -162,14 +164,19 @@ func (l *L2OutputSubmitter) StopL2OutputSubmitting() error {
 // The passed context is expected to be a lifecycle context. A network timeout
 // context will be derived from it.
 func (l *L2OutputSubmitter) FetchDGFOutput(ctx context.Context) (source.Proposal, bool, error) {
-	cutoff := time.Now().Add(-l.Cfg.ProposalInterval)
+	proposerClock := l.Clock
+	if proposerClock == nil {
+		proposerClock = clock.SystemClock
+	}
+	now := proposerClock.Now()
+	cutoff := now.Add(-l.Cfg.ProposalInterval)
 	proposedRecently, proposalTime, claim, err := l.dgfContract.HasProposedSince(ctx, l.Txmgr.From(), cutoff, l.Cfg.DisputeGameType)
 	if err != nil {
 		return source.Proposal{}, false, fmt.Errorf("could not check for recent proposal: %w", err)
 	}
 
 	if proposedRecently {
-		l.Log.Debug("Duration since last game not past proposal interval", "duration", time.Since(proposalTime))
+		l.Log.Debug("Duration since last game not past proposal interval", "duration", now.Sub(proposalTime))
 		return source.Proposal{}, false, nil
 	}
 


### PR DESCRIPTION
Stacked on ethereum-optimism/optimism#21689.

Updates the action proposer test to use op-node's production single-chain `superroot_atTimestamp` API and op-proposer's `SuperNodeProposalSource` instead of constructing super-root proposals in the test helper. Keeps action-specific transaction submission and exact duplicate suppression, and injects a deterministic proposer clock so proposal-interval coverage is independent of wall time.

Also clarifies why the fault-proof proposer test waits when a newer game exists below the target block.