### PR TITLE
test(contracts): select active dispute game fixtures

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2986,7 +2986,7 @@ workflows:
                 - main
                 - CUSTOM_GAS_TOKEN
                 - OPTIMISM_PORTAL_INTEROP
-                - ZK_DISPUTE_GAME
+                - ZK_DISPUTE_GAME,SUPER_ROOT_GAMES_MIGRATION
                 - SUPER_ROOT_GAMES_MIGRATION
                 # TODO(#20084): Remove these commented out jobs when removing the L2CM feature toggle.
                 #   L2CM is enabled by default, so we do not need to explicitly enable it and run these additional jobs.
@@ -3148,22 +3148,22 @@ workflows:
             - contracts-bedrock-tests main: terminal
             - contracts-bedrock-tests CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-tests OPTIMISM_PORTAL_INTEROP: terminal
-            - contracts-bedrock-tests ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-tests ZK_DISPUTE_GAME,SUPER_ROOT_GAMES_MIGRATION: terminal
             - contracts-bedrock-tests SUPER_ROOT_GAMES_MIGRATION: terminal
             - contracts-bedrock-tests-heavy-fuzz-modified main: terminal
             - contracts-bedrock-tests-heavy-fuzz-modified CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-tests-heavy-fuzz-modified OPTIMISM_PORTAL_INTEROP: terminal
-            - contracts-bedrock-tests-heavy-fuzz-modified ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-tests-heavy-fuzz-modified ZK_DISPUTE_GAME,SUPER_ROOT_GAMES_MIGRATION: terminal
             - contracts-bedrock-tests-heavy-fuzz-modified SUPER_ROOT_GAMES_MIGRATION: terminal
             - contracts-bedrock-coverage main: terminal
             - contracts-bedrock-coverage CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-coverage OPTIMISM_PORTAL_INTEROP: terminal
-            - contracts-bedrock-coverage ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-coverage ZK_DISPUTE_GAME,SUPER_ROOT_GAMES_MIGRATION: terminal
             - contracts-bedrock-coverage SUPER_ROOT_GAMES_MIGRATION: terminal
             - contracts-bedrock-tests-upgrade op-mainnet main: terminal
             - contracts-bedrock-tests-upgrade op-mainnet CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-tests-upgrade op-mainnet OPTIMISM_PORTAL_INTEROP: terminal
-            - contracts-bedrock-tests-upgrade op-mainnet ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-tests-upgrade op-mainnet ZK_DISPUTE_GAME,SUPER_ROOT_GAMES_MIGRATION: terminal
             - contracts-bedrock-tests-upgrade op-mainnet SUPER_ROOT_GAMES_MIGRATION: terminal
             - contracts-bedrock-tests-upgrade op-mainnet: terminal
             - contracts-bedrock-tests-upgrade ink-mainnet: terminal

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -2074,9 +2074,9 @@ contract OPContractsManagerStandardValidator_ZKDisputeGame_Test is OPContractsMa
 }
 
 /// @title OPContractsManagerStandardValidator_ZKMode_TestInit
-/// @notice Base contract for ZK dispute game validator tests.
-///         Skips unless DEV_FEATURE__ZK_DISPUTE_GAME is enabled.
-///         Deploys the chain with a ZK dispute game via OPCM so the full validation path is exercised.
+/// @notice Base contract for post-super-root-migration ZK dispute game validator tests.
+///         Requires both ZK_DISPUTE_GAME and SUPER_ROOT_GAMES_MIGRATION.
+///         Configures super games plus a ZK dispute game through OPCM.
 abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonTest {
     /// @notice The l2ChainId from the deploy config.
     uint256 l2ChainId;
@@ -2090,22 +2090,19 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
     /// @notice The proposer role from the deploy config.
     address proposer;
 
-    /// @notice The challenger role from the deploy config.
-    address challenger;
-
     /// @notice The DisputeGameFactory instance.
     IDisputeGameFactory dgf;
 
     /// @notice The OPContractsManagerStandardValidator instance.
     IOPContractsManagerStandardValidator standardValidator;
 
-    /// @notice Sets up the ZK-mode test suite. Skips if the ZK feature is not enabled.
+    /// @notice Sets up the ZK-mode test suite. Skips unless both required dev features are enabled.
     function setUp() public virtual override {
         if (!Config.devFeatureZkDisputeGame()) {
             vm.skip(true, "Skipping: DEV_FEATURE__ZK_DISPUTE_GAME is not enabled");
         }
-        if (Config.devFeatureSuperRootGamesMigration()) {
-            vm.skip(true, "Skipping: standard configs incompatible with SUPER_ROOT_GAMES_MIGRATION");
+        if (!Config.devFeatureSuperRootGamesMigration()) {
+            vm.skip(true, "Skipping: DEV_FEATURE__SUPER_ROOT_GAMES_MIGRATION is not enabled");
         }
         super.setUp();
 
@@ -2117,24 +2114,13 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
         vm.etch(address(0xBEEF), hex"01");
 
         if (isL1ForkTest()) {
-            // In fork mode read the actual values from the deployed contracts so _validate()
-            // is consistent with the real on-chain state.
-            GameType permissionlessGameType = DisputeGames.permissionlessGameType(dgf);
+            // Fork setup migrates the chain to super games before this fixture runs.
             LibGameArgs.GameArgs memory permissionlessGameArgs =
-                LibGameArgs.decode(dgf.gameArgs(permissionlessGameType));
+                LibGameArgs.decode(dgf.gameArgs(GameTypes.SUPER_CANNON_KONA));
             cannonKonaPrestate = Claim.wrap(permissionlessGameArgs.absolutePrestate);
+            cannonPrestate = cannonKonaPrestate;
             l2ChainId = permissionlessGameArgs.l2ChainId;
             proposer = DisputeGames.permissionedGameProposer(dgf);
-
-            GameType permissionedGameType = DisputeGames.permissionedGameType(dgf);
-            if (GameTypes.isSuperGame(permissionedGameType)) {
-                cannonPrestate = cannonKonaPrestate;
-            } else {
-                LibGameArgs.GameArgs memory permissionedGameArgs =
-                    LibGameArgs.decode(dgf.gameArgs(permissionedGameType));
-                cannonPrestate = Claim.wrap(permissionedGameArgs.absolutePrestate);
-                l2ChainId = permissionedGameArgs.l2ChainId;
-            }
 
             // ZK game is not deployed on mainnet. Mock it using the same ASR and WETH as the active
             // permissionless game (same on-chain infrastructure) so _assertValidZKGameArgs passes its checks.
@@ -2159,11 +2145,19 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
                 abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.ZK_DISPUTE_GAME)),
                 abi.encode(zkArgs)
             );
+
+            address l1PAOMultisig = standardValidator.l1PAOMultisig();
+            vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(l1PAOMultisig));
+            vm.mockCall(address(dgf), abi.encodeCall(IDisputeGameFactory.owner, ()), abi.encode(l1PAOMultisig));
+            vm.mockCall(
+                permissionlessGameArgs.weth,
+                abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()),
+                abi.encode(l1PAOMultisig)
+            );
         } else {
             l2ChainId = deploy.cfg().l2ChainID();
-            cannonPrestate = Claim.wrap(keccak256("cannonPrestate"));
+            cannonPrestate = cannonKonaPrestate;
             proposer = deploy.cfg().l2OutputOracleProposer();
-            challenger = deploy.cfg().l2OutputOracleChallenger();
 
             address owner = proxyAdmin.owner();
 
@@ -2179,36 +2173,30 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
                 gameArgs: hex""
             });
             configs[1] = IOPContractsManagerUtils.DisputeGameConfig({
-                enabled: true,
-                initBond: DEFAULT_DISPUTE_GAME_INIT_BOND,
+                enabled: false,
+                initBond: 0,
                 gameType: GameTypes.PERMISSIONED_CANNON,
-                gameArgs: abi.encode(
-                    IOPContractsManagerUtils.PermissionedDisputeGameConfig({
-                        absolutePrestate: cannonPrestate,
-                        proposer: proposer,
-                        challenger: challenger
-                    })
-                )
+                gameArgs: hex""
             });
             configs[2] = IOPContractsManagerUtils.DisputeGameConfig({
+                enabled: false,
+                initBond: 0,
+                gameType: GameTypes.CANNON_KONA,
+                gameArgs: hex""
+            });
+            configs[3] = IOPContractsManagerUtils.DisputeGameConfig({
+                enabled: true,
+                initBond: 0,
+                gameType: GameTypes.SUPER_PERMISSIONED,
+                gameArgs: abi.encode(IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: proposer }))
+            });
+            configs[4] = IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: true,
                 initBond: DEFAULT_DISPUTE_GAME_INIT_BOND,
-                gameType: GameTypes.CANNON_KONA,
+                gameType: GameTypes.SUPER_CANNON_KONA,
                 gameArgs: abi.encode(
                     IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonKonaPrestate })
                 )
-            });
-            configs[3] = IOPContractsManagerUtils.DisputeGameConfig({
-                enabled: false,
-                initBond: 0,
-                gameType: GameTypes.SUPER_PERMISSIONED,
-                gameArgs: hex""
-            });
-            configs[4] = IOPContractsManagerUtils.DisputeGameConfig({
-                enabled: false,
-                initBond: 0,
-                gameType: GameTypes.SUPER_CANNON_KONA,
-                gameArgs: hex""
             });
             configs[5] = IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: true,
@@ -2229,7 +2217,7 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
                 new IOPContractsManagerUtils.ExtraInstruction[](1);
             extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
                 key: "overrides.cfg.startingRespectedGameType",
-                data: abi.encode(GameTypes.CANNON_KONA)
+                data: abi.encode(GameTypes.SUPER_CANNON_KONA)
             });
 
             prankDelegateCall(owner);
@@ -2266,14 +2254,15 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
 
 /// @title OPContractsManagerStandardValidator_ZKValidation_Test
 /// @notice Tests for the ZK dispute game validation path in the standard validator.
-///         Only runs when DEV_FEATURE__ZK_DISPUTE_GAME is enabled.
+///         Only runs when ZK_DISPUTE_GAME and SUPER_ROOT_GAMES_MIGRATION are enabled.
 contract OPContractsManagerStandardValidator_ZKValidation_Test is
     OPContractsManagerStandardValidator_ZKMode_TestInit
 {
-    /// @notice Tests that validate succeeds when the ZK game is properly configured.
-    function test_validate_zkDisputeGame_succeeds() public view {
-        string memory errors = _validate(false);
-        assertEq(errors, "");
+    /// @notice Tests that ZK validation succeeds after the super-root migration.
+    function test_validate_zkDisputeGameAfterSuperRootMigration_succeeds() public view {
+        IOptimismPortal2 portal = IOptimismPortal2(payable(systemConfig.optimismPortal()));
+        assertTrue(GameTypes.isSuperGame(portal.anchorStateRegistry().respectedGameType()));
+        assertEq("", _validate(false));
     }
 
     // Note: Tests for address(0) game implementation are skipped since this is treated as valid

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -2115,8 +2115,9 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
 
         if (isL1ForkTest()) {
             // Fork setup migrates the chain to super games before this fixture runs.
+            GameType permissionlessGameType = DisputeGames.permissionlessGameType(dgf);
             LibGameArgs.GameArgs memory permissionlessGameArgs =
-                LibGameArgs.decode(dgf.gameArgs(GameTypes.SUPER_CANNON_KONA));
+                LibGameArgs.decode(dgf.gameArgs(permissionlessGameType));
             cannonKonaPrestate = Claim.wrap(permissionlessGameArgs.absolutePrestate);
             cannonPrestate = cannonKonaPrestate;
             l2ChainId = permissionlessGameArgs.l2ChainId;

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1722,12 +1722,15 @@ abstract contract OPContractsManagerStandardValidator_SuperMode_TestInit is Supe
 
         l2ChainId = deploy.cfg().l2ChainID();
         cannonPrestate = Claim.wrap(bytes32(deploy.cfg().faultGameAbsolutePrestate()));
-        proposer = deploy.cfg().l2OutputOracleProposer();
-        challenger = deploy.cfg().l2OutputOracleChallenger();
+        if (isL1ForkTest()) {
+            proposer = DisputeGames.permissionedGameProposer(dgf);
+        } else {
+            proposer = deploy.cfg().l2OutputOracleProposer();
+        }
 
-        // The deploy created SUPER_PERMISSIONED (enabled) + SUPER_CANNON_KONA (disabled).
-        // Run an upgrade to also enable SUPER_CANNON_KONA so that full validation passes.
         _enableSuperCannonKona();
+
+        _mockSuperModeForkL1PAOOwnership();
     }
 
     /// @notice Runs an upgrade that enables SUPER_CANNON_KONA alongside SUPER_PERMISSIONED.
@@ -1798,6 +1801,20 @@ abstract contract OPContractsManagerStandardValidator_SuperMode_TestInit is Supe
             )
         );
         assertTrue(success, "super mode upgrade failed");
+    }
+
+    /// @notice Normalizes fork ownership to the L1 PAO expected by the validator.
+    function _mockSuperModeForkL1PAOOwnership() internal {
+        if (!isL1ForkTest()) return;
+
+        address l1PAOMultisig = standardValidator.l1PAOMultisig();
+        vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(l1PAOMultisig));
+        vm.mockCall(
+            address(disputeGameFactory), abi.encodeCall(IDisputeGameFactory.owner, ()), abi.encode(l1PAOMultisig)
+        );
+
+        LibGameArgs.GameArgs memory gameArgs = LibGameArgs.decode(dgf.gameArgs(GameTypes.SUPER_CANNON_KONA));
+        vm.mockCall(gameArgs.weth, abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(l1PAOMultisig));
     }
 
     /// @notice Runs the OPContractsManagerStandardValidator.validate function.
@@ -2008,6 +2025,13 @@ contract OPContractsManagerStandardValidator_SuperPermissionlessDisputeGame_Test
         vm.mockCall(badVM, abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(StandardConstants.MIPS_VERSION));
         assertEq("SCKDG-VM-10,SCKDG-VM-20", _validate(true));
     }
+
+    /// @notice Tests SCKDG-DWETH-30 when SUPER_CANNON_KONA DelayedWETH owner is invalid.
+    function test_validate_superPermissionlessDisputeGameInvalidWethOwner_succeeds() public {
+        LibGameArgs.GameArgs memory gameArgs = LibGameArgs.decode(dgf.gameArgs(GameTypes.SUPER_CANNON_KONA));
+        vm.mockCall(gameArgs.weth, abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(address(0xbad)));
+        assertEq("SCKDG-DWETH-30", _validate(true));
+    }
 }
 
 /// @title OPContractsManagerStandardValidator_ZKDisputeGame_Test
@@ -2095,17 +2119,25 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
         if (isL1ForkTest()) {
             // In fork mode read the actual values from the deployed contracts so _validate()
             // is consistent with the real on-chain state.
-            LibGameArgs.GameArgs memory pddgArgs = LibGameArgs.decode(dgf.gameArgs(GameTypes.PERMISSIONED_CANNON));
-            cannonPrestate = Claim.wrap(pddgArgs.absolutePrestate);
-            l2ChainId = pddgArgs.l2ChainId;
-            proposer = pddgArgs.proposer;
-            challenger = pddgArgs.challenger;
+            GameType permissionlessGameType = DisputeGames.permissionlessGameType(dgf);
+            LibGameArgs.GameArgs memory permissionlessGameArgs =
+                LibGameArgs.decode(dgf.gameArgs(permissionlessGameType));
+            cannonKonaPrestate = Claim.wrap(permissionlessGameArgs.absolutePrestate);
+            l2ChainId = permissionlessGameArgs.l2ChainId;
+            proposer = DisputeGames.permissionedGameProposer(dgf);
 
-            LibGameArgs.GameArgs memory cannonKonaArgs = LibGameArgs.decode(dgf.gameArgs(GameTypes.CANNON_KONA));
-            cannonKonaPrestate = Claim.wrap(cannonKonaArgs.absolutePrestate);
+            GameType permissionedGameType = DisputeGames.permissionedGameType(dgf);
+            if (GameTypes.isSuperGame(permissionedGameType)) {
+                cannonPrestate = cannonKonaPrestate;
+            } else {
+                LibGameArgs.GameArgs memory permissionedGameArgs =
+                    LibGameArgs.decode(dgf.gameArgs(permissionedGameType));
+                cannonPrestate = Claim.wrap(permissionedGameArgs.absolutePrestate);
+                l2ChainId = permissionedGameArgs.l2ChainId;
+            }
 
-            // ZK game is not deployed on mainnet. Mock it using the same ASR and WETH as CANNON_KONA
-            // (same on-chain infrastructure) so _assertValidZKGameArgs passes its checks.
+            // ZK game is not deployed on mainnet. Mock it using the same ASR and WETH as the active
+            // permissionless game (same on-chain infrastructure) so _assertValidZKGameArgs passes its checks.
             // ZK_DISPUTE_GAME is a super game: chain scoping comes from the SuperRootProof
             // preimage, so the 140-byte layout has no l2ChainId field.
             bytes memory zkArgs = abi.encodePacked(
@@ -2114,8 +2146,8 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
                 uint64(7 days),
                 uint64(3 days),
                 uint256(0.08 ether),
-                cannonKonaArgs.anchorStateRegistry,
-                cannonKonaArgs.weth
+                permissionlessGameArgs.anchorStateRegistry,
+                permissionlessGameArgs.weth
             );
             vm.mockCall(
                 address(dgf),

--- a/packages/contracts-bedrock/test/setup/DisputeGames.sol
+++ b/packages/contracts-bedrock/test/setup/DisputeGames.sol
@@ -98,6 +98,20 @@ library DisputeGames {
         revert DisputeGames_UnsupportedGameArg(_gameArg);
     }
 
+    function permissionedGameType(IDisputeGameFactory _dgf) internal view returns (GameType gameType_) {
+        if (address(_dgf.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0)) {
+            return GameTypes.SUPER_PERMISSIONED;
+        }
+        return GameTypes.PERMISSIONED_CANNON;
+    }
+
+    function permissionlessGameType(IDisputeGameFactory _dgf) internal view returns (GameType gameType_) {
+        if (address(_dgf.gameImpls(GameTypes.SUPER_CANNON_KONA)) != address(0)) {
+            return GameTypes.SUPER_CANNON_KONA;
+        }
+        return GameTypes.CANNON_KONA;
+    }
+
     function permissionedGameChallenger(IDisputeGameFactory _dgf) internal view returns (address challenger_) {
         if (address(_dgf.gameImpls(GameTypes.SUPER_PERMISSIONED)) != address(0)) {
             return address(0);

--- a/packages/contracts-bedrock/test/setup/DisputeGames.t.sol
+++ b/packages/contracts-bedrock/test/setup/DisputeGames.t.sol
@@ -6,7 +6,7 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { DisputeGames } from "test/setup/DisputeGames.sol";
 
 // Libraries
-import { GameTypes } from "src/dispute/lib/Types.sol";
+import { GameType, GameTypes } from "src/dispute/lib/Types.sol";
 
 // Interfaces
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
@@ -50,5 +50,90 @@ contract DisputeGames_PermissionlessGameInitBondForUpgrade_Test is CommonTest {
             disputeGameFactory, GameTypes.CANNON_KONA, DEFAULT_DISPUTE_GAME_INIT_BOND
         );
         assertEq(bond, STALE_INIT_BOND, "live bond must be used when the game is registered");
+    }
+}
+
+contract DisputeGames_GameType_Test is CommonTest {
+    function test_permissionedGameType_legacyEnabled_succeeds() public {
+        _disableGameTypes(GameTypes.PERMISSIONED_CANNON, GameTypes.SUPER_PERMISSIONED);
+        _enableGameType(GameTypes.PERMISSIONED_CANNON);
+
+        assertEq(
+            GameType.unwrap(DisputeGames.permissionedGameType(disputeGameFactory)),
+            GameType.unwrap(GameTypes.PERMISSIONED_CANNON)
+        );
+    }
+
+    function test_permissionedGameType_superEnabled_succeeds() public {
+        _disableGameTypes(GameTypes.PERMISSIONED_CANNON, GameTypes.SUPER_PERMISSIONED);
+        _enableGameType(GameTypes.PERMISSIONED_CANNON);
+        _enableGameType(GameTypes.SUPER_PERMISSIONED);
+
+        assertEq(
+            GameType.unwrap(DisputeGames.permissionedGameType(disputeGameFactory)),
+            GameType.unwrap(GameTypes.SUPER_PERMISSIONED)
+        );
+    }
+
+    function test_permissionedGameType_superDisabledWithStaleArgs_succeeds() public {
+        _disableGameTypes(GameTypes.PERMISSIONED_CANNON, GameTypes.SUPER_PERMISSIONED);
+        _enableGameType(GameTypes.PERMISSIONED_CANNON);
+        _enableGameType(GameTypes.SUPER_PERMISSIONED);
+
+        vm.prank(disputeGameFactory.owner());
+        disputeGameFactory.setImplementation(GameTypes.SUPER_PERMISSIONED, IDisputeGame(address(0)));
+
+        assertEq(
+            GameType.unwrap(DisputeGames.permissionedGameType(disputeGameFactory)),
+            GameType.unwrap(GameTypes.PERMISSIONED_CANNON)
+        );
+    }
+
+    function test_permissionlessGameType_legacyEnabled_succeeds() public {
+        _disableGameTypes(GameTypes.CANNON_KONA, GameTypes.SUPER_CANNON_KONA);
+        _enableGameType(GameTypes.CANNON_KONA);
+
+        assertEq(
+            GameType.unwrap(DisputeGames.permissionlessGameType(disputeGameFactory)),
+            GameType.unwrap(GameTypes.CANNON_KONA)
+        );
+    }
+
+    function test_permissionlessGameType_superEnabled_succeeds() public {
+        _disableGameTypes(GameTypes.CANNON_KONA, GameTypes.SUPER_CANNON_KONA);
+        _enableGameType(GameTypes.CANNON_KONA);
+        _enableGameType(GameTypes.SUPER_CANNON_KONA);
+
+        assertEq(
+            GameType.unwrap(DisputeGames.permissionlessGameType(disputeGameFactory)),
+            GameType.unwrap(GameTypes.SUPER_CANNON_KONA)
+        );
+    }
+
+    function test_permissionlessGameType_superDisabledWithStaleArgs_succeeds() public {
+        _disableGameTypes(GameTypes.CANNON_KONA, GameTypes.SUPER_CANNON_KONA);
+        _enableGameType(GameTypes.CANNON_KONA);
+        _enableGameType(GameTypes.SUPER_CANNON_KONA);
+
+        vm.prank(disputeGameFactory.owner());
+        disputeGameFactory.setImplementation(GameTypes.SUPER_CANNON_KONA, IDisputeGame(address(0)));
+
+        assertEq(
+            GameType.unwrap(DisputeGames.permissionlessGameType(disputeGameFactory)),
+            GameType.unwrap(GameTypes.CANNON_KONA)
+        );
+    }
+
+    function _disableGameTypes(GameType _legacyGameType, GameType _superGameType) internal {
+        address owner = disputeGameFactory.owner();
+        vm.startPrank(owner);
+        disputeGameFactory.setImplementation(_legacyGameType, IDisputeGame(address(0)), hex"");
+        disputeGameFactory.setImplementation(_superGameType, IDisputeGame(address(0)), hex"");
+        vm.stopPrank();
+    }
+
+    function _enableGameType(GameType _gameType) internal {
+        vm.prank(disputeGameFactory.owner());
+        disputeGameFactory.setImplementation(_gameType, IDisputeGame(address(1)), hex"01");
     }
 }


### PR DESCRIPTION
Makes contract test fixtures derive permissioned and permissionless game configuration from registered implementations, preferring super games when active while ignoring stale args for disabled implementations. Fork-oriented StandardValidator setup now follows the active game configuration and covers invalid SuperCannonKona DelayedWETH ownership.

Split from ethereum-optimism/optimism#21689. This is test-only preparation and does not change feature defaults or production bytecode.

Tested with the focused DisputeGames, StandardValidator default, super-root, and ZK suites. Live fork tests were not run because `ETH_RPC_URL` is unavailable.