### PR TITLE
fix(op-proposer): scan common game metadata

### DIFF
--- a/op-proposer/contracts/disputegamefactory.go
+++ b/op-proposer/contracts/disputegamefactory.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -22,7 +23,9 @@ const (
 	methodCreateGame  = "create"
 	methodVersion     = "version"
 
-	methodClaim = "claimData"
+	methodGameCreator = "gameCreator"
+	methodRootClaim   = "rootClaim"
+	methodClaim       = "claimData"
 )
 
 type gameMetadata struct {
@@ -136,13 +139,28 @@ func (f *DisputeGameFactory) gameAtIndex(ctx context.Context, idx uint64) (gameM
 	gameContract := batching.NewBoundContract(f.gameABI, address)
 	cCtx, cancel = context.WithTimeout(ctx, f.networkTimeout)
 	defer cancel()
-	result, err = f.caller.SingleCall(cCtx, rpcblock.Latest, gameContract.Call(methodClaim, big.NewInt(0)))
-	if err != nil {
-		return gameMetadata{}, fmt.Errorf("failed to load root claim of game %v: %w", idx, err)
+	results, metadataErr := f.caller.Call(cCtx, rpcblock.Latest,
+		gameContract.Call(methodGameCreator),
+		gameContract.Call(methodRootClaim),
+	)
+	var claimant common.Address
+	var claim common.Hash
+	if metadataErr == nil {
+		claimant = results[0].GetAddress(0)
+		claim = results[1].GetHash(0)
+	} else {
+		cCtx, cancel = context.WithTimeout(ctx, f.networkTimeout)
+		defer cancel()
+		result, legacyErr := f.caller.SingleCall(cCtx, rpcblock.Latest, gameContract.Call(methodClaim, big.NewInt(0)))
+		if legacyErr != nil {
+			return gameMetadata{}, fmt.Errorf("failed to load game metadata for game %v: %w", idx, errors.Join(
+				fmt.Errorf("common getters failed: %w", metadataErr),
+				fmt.Errorf("legacy claimData(0) failed: %w", legacyErr),
+			))
+		}
+		claimant = result.GetAddress(2)
+		claim = result.GetHash(4)
 	}
-	// We don't need most of the claim data, only the claim and the claimant which is the game proposer
-	claimant := result.GetAddress(2)
-	claim := result.GetHash(4)
 
 	return gameMetadata{
 		GameType:  gameType,

--- a/op-proposer/contracts/disputegamefactory_test.go
+++ b/op-proposer/contracts/disputegamefactory_test.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"context"
+	"errors"
 	"math"
 	"math/big"
 	"testing"
@@ -28,6 +29,7 @@ func TestHasProposedSince(t *testing.T) {
 	}{
 		{"FaultDisputeGame", snapshots.LoadFaultDisputeGameABI()},
 		{"SuperFaultDisputeGame", snapshots.LoadSuperFaultDisputeGameABI()},
+		{"SuperPermissionedDisputeGame", snapshots.LoadSuperPermissionedDisputeGameABI()},
 	}
 
 	for _, contractType := range gameContractTypes {
@@ -200,6 +202,45 @@ func TestHasProposedSince(t *testing.T) {
 			require.Equal(t, common.Hash{0xdd}, claim)
 		})
 	}
+
+	t.Run("HistoricalFaultDisputeGameWithoutGameCreator", func(t *testing.T) {
+		stubRpc, factory := setupDisputeGameFactoryTest(t)
+		expectedProposalTime := time.Unix(1100, 0)
+		expectedClaim := common.Hash{0xcc}
+		gameAddress := common.Address{0x44}
+
+		stubRpc.SetResponse(factoryAddr, methodGameCount, rpcblock.Latest, nil, []interface{}{big.NewInt(1)})
+		stubRpc.SetResponse(factoryAddr, methodGameAtIndex, rpcblock.Latest, []interface{}{big.NewInt(0)}, []interface{}{
+			uint32(0),
+			uint64(expectedProposalTime.Unix()),
+			gameAddress,
+		})
+
+		historicalABI := snapshots.LoadFaultDisputeGameABI()
+		// SetError packs the configured ABI outputs before returning the RPC error. The historical
+		// contract rejects this selector, so model its response as output-less.
+		gameCreator := historicalABI.Methods["gameCreator"]
+		gameCreator.Outputs = nil
+		historicalABI.Methods["gameCreator"] = gameCreator
+		stubRpc.AddContract(gameAddress, historicalABI)
+		stubRpc.SetError(gameAddress, "gameCreator", rpcblock.Latest, nil, errors.New("execution reverted: function selector was not recognized"))
+		stubRpc.SetResponse(gameAddress, "rootClaim", rpcblock.Latest, nil, []interface{}{expectedClaim})
+		stubRpc.SetResponse(gameAddress, "claimData", rpcblock.Latest, []interface{}{big.NewInt(0)}, []interface{}{
+			uint32(math.MaxUint32),
+			common.Address{},
+			proposerAddr,
+			big.NewInt(1000),
+			expectedClaim,
+			big.NewInt(1),
+			big.NewInt(100),
+		})
+
+		proposed, proposalTime, claim, err := factory.HasProposedSince(context.Background(), proposerAddr, cutOffTime, 0)
+		require.NoError(t, err)
+		require.True(t, proposed)
+		require.Equal(t, expectedProposalTime, proposalTime)
+		require.Equal(t, expectedClaim, claim)
+	})
 }
 
 func TestProposalTx(t *testing.T) {
@@ -226,18 +267,8 @@ func withClaims(stubRpc *batchingTest.AbiBasedRpc, gameAbi *abi.ABI, games ...ga
 			game.Address,
 		})
 		stubRpc.AddContract(game.Address, gameAbi)
-		// Note: If this method ABI changes, the proposer will need to be updated to handle both the old and new versions
-		// since existing dispute games are never changed and the proposer may need to load a game using an old version
-		// to find its last proposal.
-		stubRpc.SetResponse(game.Address, methodClaim, rpcblock.Latest, []interface{}{big.NewInt(0)}, []interface{}{
-			uint32(math.MaxUint32), // Parent address (none for root claim)
-			common.Address{},       // Countered by
-			game.Proposer,          // Claimant
-			big.NewInt(1000),       // Bond
-			common.Hash{0xdd},      // Claim
-			big.NewInt(1),          // Position (gindex 1 for root position)
-			big.NewInt(100),        // Clock
-		})
+		stubRpc.SetResponse(game.Address, "gameCreator", rpcblock.Latest, nil, []interface{}{game.Proposer})
+		stubRpc.SetResponse(game.Address, "rootClaim", rpcblock.Latest, nil, []interface{}{common.Hash{0xdd}})
 	}
 }
 


### PR DESCRIPTION
Uses the common `gameCreator()` and `rootClaim()` getters when the proposer scans dispute-game history, allowing the same throttling path to work across fault, super-fault, and super-permissioned games.

Retains compatibility with historical fault games that predate `gameCreator()` by falling back to `claimData(0)`. Split from ethereum-optimism/optimism#21689 so this compatibility prerequisite can land before the default changes.

Tested with `mise exec -- go test ./op-proposer/contracts -count=1`.