### PR TITLE
test(op-e2e): prepare production super-root proposal source

### DIFF
--- a/op-e2e/actions/helpers/l2_proposer.go
+++ b/op-e2e/actions/helpers/l2_proposer.go
@@ -3,8 +3,6 @@ package helpers
 import (
 	"context"
 	"crypto/ecdsa"
-	"encoding/binary"
-	"errors"
 	"math/big"
 	"time"
 
@@ -26,7 +24,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer/source"
-	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
@@ -96,7 +93,7 @@ func (f fakeTxMgr) SuggestGasPriceCaps(context.Context) (*big.Int, *big.Int, *bi
 	panic("unimplemented")
 }
 
-func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Client, rollupCl *sources.RollupClient) *L2Proposer {
+func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Client, proposalSource source.ProposalSource) *L2Proposer {
 	proposerConfig := proposer.ProposerConfig{
 		PollInterval:           time.Second,
 		NetworkTimeout:         time.Second,
@@ -105,8 +102,7 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 		DisputeGameType:        cfg.DisputeGameType,
 		AllowNonFinalized:      cfg.AllowNonFinalized,
 	}
-	rollupProvider, err := dial.NewStaticL2RollupProviderFromExistingRollup(rollupCl)
-	require.NoError(t, err)
+	t.Cleanup(proposalSource.Close)
 
 	driverSetup := proposer.DriverSetup{
 		Log:            log,
@@ -115,7 +111,7 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 		Txmgr:          fakeTxMgr{from: crypto.PubkeyToAddress(cfg.ProposerKey.PublicKey), chainID: cfg.ChainID},
 		L1Client:       l1,
 		Multicaller:    batching.NewMultiCaller(l1.Client(), batching.DefaultBatchSize),
-		ProposalSource: source.NewRollupProposalSource(rollupProvider),
+		ProposalSource: proposalSource,
 	}
 
 	dr, err := proposer.NewL2OutputSubmitter(driverSetup)
@@ -198,12 +194,7 @@ func (p *L2Proposer) fetchNextOutput(t Testing) (source.Proposal, bool, error) {
 	if err != nil || !shouldPropose {
 		return source.Proposal{}, false, err
 	}
-	if output.IsSuperRootProposal() {
-		return source.Proposal{}, false, errors.New("unexpected super root proposal")
-	}
-	encodedBlockNumber := make([]byte, 32)
-	binary.BigEndian.PutUint64(encodedBlockNumber[24:], output.SequenceNum)
-	game, err := p.disputeGameFactory.Games(&bind.CallOpts{}, p.driver.Cfg.DisputeGameType, output.Root, encodedBlockNumber)
+	game, err := p.disputeGameFactory.Games(&bind.CallOpts{}, p.driver.Cfg.DisputeGameType, output.Root, output.ExtraData())
 	if err != nil {
 		return source.Proposal{}, false, err
 	}

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -218,6 +218,29 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	return rollupNode
 }
 
+type proposerSuperRootSafeDB struct{}
+
+func (proposerSuperRootSafeDB) SafeHeadAtL1(context.Context, uint64) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, errors.New("safe head at L1 is unsupported by the action proposer superroot API")
+}
+
+func (proposerSuperRootSafeDB) L1AtSafeHead(context.Context, uint64) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, nil
+}
+
+func (proposerSuperRootSafeDB) FirstEntry(context.Context) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, errors.New("first safe head entry is unsupported by the action proposer superroot API")
+}
+
+func (proposerSuperRootSafeDB) LastEntry(context.Context) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, errors.New("last safe head entry is unsupported by the action proposer superroot API")
+}
+
+func (s *L2Verifier) EnableProposerSuperRootAPI(t Testing) {
+	api := node.NewSuperrootAPI(s.RollupCfg, s.Eng, &l2VerifierBackend{verifier: s}, proposerSuperRootSafeDB{})
+	require.NoError(t, s.rpc.RegisterName("superroot", api))
+}
+
 type l2VerifierBackend struct {
 	verifier *L2Verifier
 }

--- a/op-e2e/actions/proposer/l2_proposer_test.go
+++ b/op-e2e/actions/proposer/l2_proposer_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindingspreview"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-proposer/proposer/source"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
@@ -46,6 +48,9 @@ func runProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64, allocType c
 	miner, seqEngine, sequencer := actionsHelpers.SetupSequencerTest(t, sd, log)
 
 	rollupSeqCl := sequencer.RollupClient()
+	rollupProvider, err := dial.NewStaticL2RollupProviderFromExistingRollup(rollupSeqCl)
+	require.NoError(t, err)
+	proposalSource := source.NewRollupProposalSource(rollupProvider)
 	batcher := actionsHelpers.NewL2Batcher(log, sd.RollupCfg, actionsHelpers.DefaultBatcherCfg(dp),
 		rollupSeqCl, miner.EthClient(), seqEngine.EthClient(), seqEngine.EngineClient(t, sd.RollupCfg))
 
@@ -62,7 +67,7 @@ func runProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64, allocType c
 		AllowNonFinalized:      true,
 		AllocType:              allocType,
 		ChainID:                eth.ChainIDFromBig(sd.L1Cfg.Config.ChainID),
-	}, miner.EthClient(), rollupSeqCl)
+	}, miner.EthClient(), proposalSource)
 
 	// L1 block
 	miner.ActEmptyBlock(t)

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-proposer/contracts"
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer/source"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
@@ -50,6 +51,7 @@ type DriverSetup struct {
 	Log         log.Logger
 	Metr        metrics.Metricer
 	Cfg         ProposerConfig
+	Clock       clock.Clock
 	Txmgr       txmgr.TxManager
 	L1Client    L1Client
 	Multicaller *batching.MultiCaller
@@ -162,14 +164,19 @@ func (l *L2OutputSubmitter) StopL2OutputSubmitting() error {
 // The passed context is expected to be a lifecycle context. A network timeout
 // context will be derived from it.
 func (l *L2OutputSubmitter) FetchDGFOutput(ctx context.Context) (source.Proposal, bool, error) {
-	cutoff := time.Now().Add(-l.Cfg.ProposalInterval)
+	proposerClock := l.Clock
+	if proposerClock == nil {
+		proposerClock = clock.SystemClock
+	}
+	now := proposerClock.Now()
+	cutoff := now.Add(-l.Cfg.ProposalInterval)
 	proposedRecently, proposalTime, claim, err := l.dgfContract.HasProposedSince(ctx, l.Txmgr.From(), cutoff, l.Cfg.DisputeGameType)
 	if err != nil {
 		return source.Proposal{}, false, fmt.Errorf("could not check for recent proposal: %w", err)
 	}
 
 	if proposedRecently {
-		l.Log.Debug("Duration since last game not past proposal interval", "duration", time.Since(proposalTime))
+		l.Log.Debug("Duration since last game not past proposal interval", "duration", now.Sub(proposalTime))
 		return source.Proposal{}, false, nil
 	}
 

--- a/op-proposer/proposer/driver_test.go
+++ b/op-proposer/proposer/driver_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer/source"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -24,11 +25,14 @@ import (
 
 type StubDGFContract struct {
 	hasProposedCount int
+	proposedRecently bool
+	cutoff           time.Time
 }
 
-func (m *StubDGFContract) HasProposedSince(_ context.Context, _ common.Address, _ time.Time, _ uint32) (bool, time.Time, common.Hash, error) {
+func (m *StubDGFContract) HasProposedSince(_ context.Context, _ common.Address, cutoff time.Time, _ uint32) (bool, time.Time, common.Hash, error) {
 	m.hasProposedCount++
-	return false, time.Unix(1000, 0), common.Hash{0xdd}, nil
+	m.cutoff = cutoff
+	return m.proposedRecently, time.Unix(1000, 0), common.Hash{0xdd}, nil
 }
 
 func (m *StubDGFContract) ProposalTx(_ context.Context, _ uint32, _ common.Hash, _ []byte) (txmgr.TxCandidate, error) {
@@ -96,6 +100,43 @@ func setup(t *testing.T) (*L2OutputSubmitter, *mockRollupEndpointProvider, *Stub
 		})
 
 	return &l2OutputSubmitter, ep, mockDGFContract, txmgr, logs
+}
+
+func TestL2OutputSubmitter_FetchDGFOutputCutoffUsesClock(t *testing.T) {
+	const proposalInterval = 15 * time.Minute
+	fetchCutoff := func(t *testing.T, proposerClock clock.Clock) time.Time {
+		dgfContract := &StubDGFContract{proposedRecently: true}
+		txmgr := txmgrmocks.NewTxManager(t)
+		txmgr.On("From").Return(common.Address{0xab}).Once()
+		submitter := &L2OutputSubmitter{
+			DriverSetup: DriverSetup{
+				Log:   testlog.Logger(t, log.LevelDebug),
+				Cfg:   ProposerConfig{ProposalInterval: proposalInterval},
+				Clock: proposerClock,
+				Txmgr: txmgr,
+			},
+			dgfContract: dgfContract,
+		}
+
+		_, shouldPropose, err := submitter.FetchDGFOutput(t.Context())
+		require.NoError(t, err)
+		require.False(t, shouldPropose)
+		return dgfContract.cutoff
+	}
+
+	t.Run("InjectedClock", func(t *testing.T) {
+		now := time.Unix(1_234_567, 0)
+		cutoff := fetchCutoff(t, clock.NewDeterministicClock(now))
+		require.Equal(t, now.Add(-proposalInterval), cutoff)
+	})
+
+	t.Run("NilClockUsesSystemTime", func(t *testing.T) {
+		before := time.Now().Add(-proposalInterval)
+		cutoff := fetchCutoff(t, nil)
+		after := time.Now().Add(-proposalInterval)
+		require.False(t, cutoff.Before(before), "cutoff must not predate the call")
+		require.False(t, cutoff.After(after), "cutoff must not postdate the call")
+	})
 }
 
 func TestL2OutputSubmitter_OutputRetry(t *testing.T) {


### PR DESCRIPTION
Extracts the pre-activation portions of ethereum-optimism/optimism#21738 onto `develop`.

The action proposer accepts a production `ProposalSource`, while the current test explicitly keeps using `RollupProposalSource` and submitting legacy output roots. The action verifier retains an opt-in, SafeDB-backed `EnableProposerSuperRootAPI` helper for the later super-root test, but this PR does not register, query, or assert against that API. The proposer driver also accepts an optional clock for deterministic proposal-interval tests, with `SystemClock` as the production default.

This does not change feature defaults, allocations, respected game types, or submitted proposal format.

Tested with:
- `mise exec -- go test ./op-proposer/proposer -count=1`
- `mise exec -- go test ./op-e2e/actions/proposer -run '^TestProposerBatchType$' -count=1`