### PR TITLE
fix(kona,security): close three unauthenticated kona attack surfaces

### DIFF
--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -541,6 +541,9 @@ func startMixedKonaNode(
 		propagateEnvVarOrDefault("KONA_NODE_RPC_ADDR", "127.0.0.1"),
 		propagateEnvVarOrDefault("KONA_NODE_RPC_PORT", "0"),
 		propagateEnvVarOrDefault("KONA_NODE_RPC_WS_ENABLED", "true"),
+		// Acceptance tests drive the sequencer via the admin API (StartSequencer, etc.), which
+		// kona only registers when admin is enabled. op-node's devstack node enables it too.
+		propagateEnvVarOrDefault("KONA_NODE_RPC_ENABLE_ADMIN", "true"),
 		propagateEnvVarOrDefault("KONA_METRICS_ADDR", ""),
 		propagateEnvVarOrDefault("KONA_LOG_LEVEL", "3"),
 		propagateEnvVarOrDefault("KONA_LOG_STDOUT_FORMAT", "json"),

--- a/rust/kona/bin/node/src/flags/rpc.rs
+++ b/rust/kona/bin/node/src/flags/rpc.rs
@@ -19,7 +19,11 @@ pub struct RpcArgs {
     #[arg(long = "rpc.no-restart", default_value = "false", env = "KONA_NODE_RPC_NO_RESTART")]
     pub no_restart: bool,
     /// RPC listening address.
-    #[arg(long = "rpc.addr", default_value = "0.0.0.0", env = "KONA_NODE_RPC_ADDR")]
+    ///
+    /// Defaults to `127.0.0.1` (localhost only). Operators who need to expose the RPC server
+    /// on other interfaces should set this explicitly, and should also decide whether
+    /// `--rpc.enable-admin` is appropriate for that exposure.
+    #[arg(long = "rpc.addr", default_value = "127.0.0.1", env = "KONA_NODE_RPC_ADDR")]
     pub listen_addr: IpAddr,
     /// RPC listening port.
     #[arg(long = "port", alias = "rpc.port", default_value = "9545", env = "KONA_NODE_RPC_PORT")]

--- a/rust/kona/bin/node/src/flags/rpc.rs
+++ b/rust/kona/bin/node/src/flags/rpc.rs
@@ -20,10 +20,11 @@ pub struct RpcArgs {
     pub no_restart: bool,
     /// RPC listening address.
     ///
-    /// Defaults to `127.0.0.1` (localhost only). Operators who need to expose the RPC server
-    /// on other interfaces should set this explicitly, and should also decide whether
-    /// `--rpc.enable-admin` is appropriate for that exposure.
-    #[arg(long = "rpc.addr", default_value = "127.0.0.1", env = "KONA_NODE_RPC_ADDR")]
+    /// Defaults to `0.0.0.0`: the node is released as a Docker image, where binding `127.0.0.1`
+    /// makes the RPC unreachable from outside the container. Privileged methods are not exposed
+    /// by this alone — the admin API is registered only with `--rpc.enable-admin` — but operators
+    /// placing the node on an untrusted network should still firewall the port.
+    #[arg(long = "rpc.addr", default_value = "0.0.0.0", env = "KONA_NODE_RPC_ADDR")]
     pub listen_addr: IpAddr,
     /// RPC listening port.
     #[arg(long = "port", alias = "rpc.port", default_value = "9545", env = "KONA_NODE_RPC_PORT")]
@@ -87,5 +88,16 @@ mod tests {
         let mut expected = RpcArgs::default();
         mutate(&mut expected);
         assert_eq!(cli, expected);
+    }
+
+    #[test]
+    fn rpc_addr_defaults_to_all_interfaces() {
+        // 0.0.0.0 is intentional: released as a Docker image, where 127.0.0.1 is unreachable.
+        assert_eq!(RpcArgs::default().listen_addr, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    }
+
+    #[test]
+    fn admin_api_disabled_by_default() {
+        assert!(!RpcArgs::default().enable_admin);
     }
 }

--- a/rust/kona/crates/node/gossip/src/config.rs
+++ b/rust/kona/crates/node/gossip/src/config.rs
@@ -139,10 +139,8 @@ fn compute_message_id(msg: &Message) -> MessageId {
             },
         )
     } else {
-        warn!(
-            target: "cfg",
-            "Rejecting oversized snappy header before decompression (MAX_GOSSIP_SIZE)"
-        );
+        // Oversized/malformed frame: take the invalid-snappy domain without logging. This path is
+        // driven by unauthenticated remote input, so it must not be able to spam warnings.
         let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
         sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())[..20]
             .to_vec()

--- a/rust/kona/crates/node/gossip/src/config.rs
+++ b/rust/kona/crates/node/gossip/src/config.rs
@@ -101,22 +101,49 @@ pub fn default_config() -> Config {
 }
 
 /// Computes the [`MessageId`] of a `gossipsub` message.
+///
+/// # Security
+///
+/// The snappy frame header is validated against [`MAX_GOSSIP_SIZE`] BEFORE any allocation.
+/// Without this pre-check, `snap::raw::Decoder::decompress_vec` pre-allocates
+/// `vec![0; decompress_len(input)]` — up to `u32::MAX` (~4 GiB) — before inspecting any
+/// frame content. A 7-byte attacker-controlled snappy frame declaring `u32::MAX`
+/// decompressed length would OOM-kill the process. This function is invoked as
+/// gossipsub's `message_id_fn` on every inbound PUBLISH before signature validation, so the
+/// primitive is unauthenticated and remotely reachable.
+///
+/// Op-node's parallel `BuildMsgIdFn` (in `op-node/p2p/gossip.go`) performs the same
+/// pre-check via `snappy.DecodedLen(pmsg.Data)` bounded to `maxGossipSize`.
 fn compute_message_id(msg: &Message) -> MessageId {
-    let mut decoder = Decoder::new();
-    let id = decoder.decompress_vec(&msg.data).map_or_else(
-        |_| {
-            warn!(target: "cfg", "Failed to decompress message, using invalid snappy");
-            let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
-            sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())
-                [..20]
-                .to_vec()
-        },
-        |data| {
-            let domain_valid_snappy: Vec<u8> = vec![0x1, 0x0, 0x0, 0x0];
-            sha256([domain_valid_snappy.as_slice(), data.as_slice()].concat().as_slice())[..20]
-                .to_vec()
-        },
-    );
+    let bounded_ok = snap::raw::decompress_len(&msg.data)
+        .ok()
+        .filter(|&n| n <= MAX_GOSSIP_SIZE);
+
+    let id = if bounded_ok.is_some() {
+        let mut decoder = Decoder::new();
+        decoder.decompress_vec(&msg.data).map_or_else(
+            |_| {
+                warn!(target: "cfg", "Failed to decompress message, using invalid snappy");
+                let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
+                sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())
+                    [..20]
+                    .to_vec()
+            },
+            |data| {
+                let domain_valid_snappy: Vec<u8> = vec![0x1, 0x0, 0x0, 0x0];
+                sha256([domain_valid_snappy.as_slice(), data.as_slice()].concat().as_slice())[..20]
+                    .to_vec()
+            },
+        )
+    } else {
+        warn!(
+            target: "cfg",
+            "Rejecting oversized snappy header before decompression (MAX_GOSSIP_SIZE)"
+        );
+        let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
+        sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())[..20]
+            .to_vec()
+    };
 
     MessageId(id)
 }
@@ -160,5 +187,34 @@ mod tests {
         let id = compute_message_id(&msg);
         let hashed = sha256(&[&[0x1, 0x0, 0x0, 0x0], [1, 2, 3, 4, 5].as_slice()].concat());
         assert_eq!(id.0, hashed[..20].to_vec());
+    }
+
+    /// Regression: a 7-byte snappy frame declaring `u32::MAX` decompressed length must be
+    /// rejected before any allocation. Prior versions of `compute_message_id` would call
+    /// `decompress_vec` unconditionally, triggering a ~4 GiB pre-allocation and OOM-killing
+    /// the process. The bomb payload is verbatim `[0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0x00, 0x41]`.
+    #[test]
+    fn compute_message_id_rejects_snappy_bomb_without_alloc() {
+        // Header: varint(u32::MAX) + literal-chunk-tag + one literal byte.
+        let bomb = vec![0xFFu8, 0xFF, 0xFF, 0xFF, 0x0F, 0x00, 0x41];
+        assert_eq!(
+            snap::raw::decompress_len(&bomb).unwrap(),
+            u32::MAX as usize,
+            "sanity: bomb header must declare u32::MAX"
+        );
+        assert!(bomb.len() <= MAX_GOSSIP_SIZE);
+
+        let msg = Message {
+            source: None,
+            data: bomb.clone(),
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw("test"),
+        };
+
+        // If this test triggers a 4 GiB allocation, the guard is broken.
+        let id = compute_message_id(&msg);
+        // Bomb takes the oversized-header rejection branch: hash uses invalid-snappy domain.
+        let expected = sha256(&[&[0x0, 0x0, 0x0, 0x0], bomb.as_slice()].concat());
+        assert_eq!(id.0, expected[..20].to_vec());
     }
 }

--- a/rust/kona/crates/node/gossip/src/config.rs
+++ b/rust/kona/crates/node/gossip/src/config.rs
@@ -100,26 +100,29 @@ pub fn default_config() -> Config {
     default_config_builder().build().expect("default gossipsub config must be valid")
 }
 
+/// Returns the snappy-declared decompressed length of `data` if it is within
+/// [`MAX_GOSSIP_SIZE`], or `None` when the frame header is malformed or declares a larger size.
+///
+/// Only the snappy frame header (a varint) is decoded; the decompressed buffer is never
+/// allocated. Gossip receive paths call this to reject oversized frames before running a
+/// decompressor, which would otherwise pre-allocate `vec![0; decompress_len(input)]` — up to
+/// `u32::MAX` (~4 GiB) — from a tiny attacker-controlled frame. These paths are reachable by
+/// unauthenticated remote peers, so the bound must be enforced before decompression.
+///
+/// Op-node applies the same `snappy.DecodedLen(...) <= maxGossipSize` bound in both its
+/// gossipsub `message_id_fn` and its topic validator (in `op-node/p2p/gossip.go`).
+pub(crate) fn snappy_decompressed_len_within_bound(data: &[u8]) -> Option<usize> {
+    snap::raw::decompress_len(data).ok().filter(|&n| n <= MAX_GOSSIP_SIZE)
+}
+
 /// Computes the [`MessageId`] of a `gossipsub` message.
 ///
-/// # Security
-///
-/// The snappy frame header is validated against [`MAX_GOSSIP_SIZE`] BEFORE any allocation.
-/// Without this pre-check, `snap::raw::Decoder::decompress_vec` pre-allocates
-/// `vec![0; decompress_len(input)]` — up to `u32::MAX` (~4 GiB) — before inspecting any
-/// frame content. A 7-byte attacker-controlled snappy frame declaring `u32::MAX`
-/// decompressed length would OOM-kill the process. This function is invoked as
-/// gossipsub's `message_id_fn` on every inbound PUBLISH before signature validation, so the
-/// primitive is unauthenticated and remotely reachable.
-///
-/// Op-node's parallel `BuildMsgIdFn` (in `op-node/p2p/gossip.go`) performs the same
-/// pre-check via `snappy.DecodedLen(pmsg.Data)` bounded to `maxGossipSize`.
+/// Oversized or malformed snappy frames are rejected via [`snappy_decompressed_len_within_bound`]
+/// before decompression and take the invalid-snappy domain, matching op-node's `BuildMsgIdFn`.
+/// This is invoked as gossipsub's `message_id_fn` on every inbound PUBLISH before signature
+/// validation, so the input is unauthenticated.
 fn compute_message_id(msg: &Message) -> MessageId {
-    let bounded_ok = snap::raw::decompress_len(&msg.data)
-        .ok()
-        .filter(|&n| n <= MAX_GOSSIP_SIZE);
-
-    let id = if bounded_ok.is_some() {
+    let id = if snappy_decompressed_len_within_bound(&msg.data).is_some() {
         let mut decoder = Decoder::new();
         decoder.decompress_vec(&msg.data).map_or_else(
             |_| {
@@ -189,12 +192,12 @@ mod tests {
         assert_eq!(id.0, hashed[..20].to_vec());
     }
 
-    /// Regression: a 7-byte snappy frame declaring `u32::MAX` decompressed length must be
-    /// rejected before any allocation. Prior versions of `compute_message_id` would call
-    /// `decompress_vec` unconditionally, triggering a ~4 GiB pre-allocation and OOM-killing
-    /// the process. The bomb payload is verbatim `[0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0x00, 0x41]`.
+    /// The classic 7-byte snappy bomb declaring `u32::MAX` decompressed length takes the
+    /// invalid-snappy branch rather than being decompressed. The bound is enforced by
+    /// [`snappy_decompressed_len_within_bound`], which reads only the frame header — see
+    /// `snappy_len_bound_rejects_oversize_without_allocating` for the allocation-free guarantee.
     #[test]
-    fn compute_message_id_rejects_snappy_bomb_without_alloc() {
+    fn compute_message_id_rejects_declared_oversize_bomb() {
         // Header: varint(u32::MAX) + literal-chunk-tag + one literal byte.
         let bomb = vec![0xFFu8, 0xFF, 0xFF, 0xFF, 0x0F, 0x00, 0x41];
         assert_eq!(
@@ -202,7 +205,6 @@ mod tests {
             u32::MAX as usize,
             "sanity: bomb header must declare u32::MAX"
         );
-        assert!(bomb.len() <= MAX_GOSSIP_SIZE);
 
         let msg = Message {
             source: None,
@@ -211,10 +213,69 @@ mod tests {
             topic: libp2p::gossipsub::TopicHash::from_raw("test"),
         };
 
-        // If this test triggers a 4 GiB allocation, the guard is broken.
         let id = compute_message_id(&msg);
         // Bomb takes the oversized-header rejection branch: hash uses invalid-snappy domain.
         let expected = sha256(&[&[0x0, 0x0, 0x0, 0x0], bomb.as_slice()].concat());
         assert_eq!(id.0, expected[..20].to_vec());
+    }
+
+    /// Proves the bound actually gates decompression (distinguishing this implementation from
+    /// an unbounded one): a frame that *validly* decompresses to more than [`MAX_GOSSIP_SIZE`]
+    /// takes the invalid-snappy domain, not the valid-snappy domain an unbounded implementation
+    /// would produce after decompressing it.
+    #[test]
+    fn compute_message_id_rejects_oversize_frame_via_invalid_snappy() {
+        let over = snap::raw::Encoder::new().compress_vec(&vec![0u8; MAX_GOSSIP_SIZE + 1]).unwrap();
+        // The compressed frame is tiny, so the gossipsub transmit-size limit does not stop it.
+        assert!(over.len() <= MAX_GOSSIP_SIZE);
+
+        let msg = Message {
+            source: None,
+            data: over.clone(),
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw("test"),
+        };
+        let id = compute_message_id(&msg);
+
+        // Bounded path: invalid-snappy domain over the raw (still-compressed) bytes.
+        let bounded = sha256(&[[0x0u8, 0x0, 0x0, 0x0].as_slice(), over.as_slice()].concat());
+        assert_eq!(id.0, bounded[..20].to_vec());
+
+        // The id an unbounded implementation would produce (decompress, then valid-snappy
+        // domain) must NOT be the one returned.
+        let decompressed = snap::raw::Decoder::new().decompress_vec(&over).unwrap();
+        let unbounded =
+            sha256(&[[0x1u8, 0x0, 0x0, 0x0].as_slice(), decompressed.as_slice()].concat());
+        assert_ne!(id.0, unbounded[..20].to_vec());
+    }
+
+    #[test]
+    fn snappy_len_bound_rejects_oversize_without_allocating() {
+        // A 7-byte frame declaring `u32::MAX` decompressed length. `decompress_len` reads only
+        // the varint header, so the declared buffer is never allocated to evaluate the bound.
+        let bomb = vec![0xFFu8, 0xFF, 0xFF, 0xFF, 0x0F, 0x00, 0x41];
+        assert_eq!(snap::raw::decompress_len(&bomb).unwrap(), u32::MAX as usize);
+        assert_eq!(snappy_decompressed_len_within_bound(&bomb), None);
+
+        // A genuine frame that decompresses to one byte over the limit is also rejected.
+        let over = snap::raw::Encoder::new().compress_vec(&vec![0u8; MAX_GOSSIP_SIZE + 1]).unwrap();
+        assert_eq!(snappy_decompressed_len_within_bound(&over), None);
+
+        // A truncated varint header is malformed and rejected.
+        assert_eq!(snappy_decompressed_len_within_bound(&[0xFF]), None);
+
+        // Empty input declares a zero-length payload, which is within bound (downstream
+        // decoding still rejects it); it must not error out here.
+        assert_eq!(snappy_decompressed_len_within_bound(&[]), Some(0));
+    }
+
+    #[test]
+    fn snappy_len_bound_accepts_up_to_and_including_max() {
+        // Exactly `MAX_GOSSIP_SIZE` is within bound (inclusive), matching op-node.
+        let at_max = snap::raw::Encoder::new().compress_vec(&vec![0u8; MAX_GOSSIP_SIZE]).unwrap();
+        assert_eq!(snappy_decompressed_len_within_bound(&at_max), Some(MAX_GOSSIP_SIZE));
+
+        let small = snap::raw::Encoder::new().compress_vec(&[1, 2, 3, 4, 5]).unwrap();
+        assert_eq!(snappy_decompressed_len_within_bound(&small), Some(5));
     }
 }

--- a/rust/kona/crates/node/gossip/src/handler.rs
+++ b/rust/kona/crates/node/gossip/src/handler.rs
@@ -51,7 +51,8 @@ impl Handler for BlockHandler {
         // buffer of the declared length (up to ~4 GiB) from a tiny frame. Mirrors op-node's
         // gossip topic validator, which rejects `outLen > maxGossipSize` before decompressing.
         if snappy_decompressed_len_within_bound(&msg.data).is_none() {
-            warn!(target: "gossip", "Rejecting oversized snappy frame before decoding (MAX_GOSSIP_SIZE)");
+            // Reject without logging: this is unauthenticated remote input and must not be able to
+            // spam warnings just by being invalid.
             return (MessageAcceptance::Reject, None);
         }
 

--- a/rust/kona/crates/node/gossip/src/handler.rs
+++ b/rust/kona/crates/node/gossip/src/handler.rs
@@ -1,6 +1,6 @@
 //! Block Handler
 
-use crate::HandlerEncodeError;
+use crate::{HandlerEncodeError, config::snappy_decompressed_len_within_bound};
 use alloy_primitives::{Address, B256};
 use kona_genesis::RollupConfig;
 use libp2p::gossipsub::{IdentTopic, Message, MessageAcceptance, TopicHash};
@@ -46,6 +46,15 @@ impl Handler for BlockHandler {
     /// Checks validity of a [`OpNetworkPayloadEnvelope`] received over P2P gossip.
     /// If valid, sends the [`OpNetworkPayloadEnvelope`] to the block update channel.
     fn handle(&mut self, msg: Message) -> (MessageAcceptance, Option<OpNetworkPayloadEnvelope>) {
+        // Reject frames whose snappy header declares a decompressed size over MAX_GOSSIP_SIZE
+        // before decoding. `OpNetworkPayloadEnvelope::decode_v*` otherwise pre-allocates a
+        // buffer of the declared length (up to ~4 GiB) from a tiny frame. Mirrors op-node's
+        // gossip topic validator, which rejects `outLen > maxGossipSize` before decompressing.
+        if snappy_decompressed_len_within_bound(&msg.data).is_none() {
+            warn!(target: "gossip", "Rejecting oversized snappy frame before decoding (MAX_GOSSIP_SIZE)");
+            return (MessageAcceptance::Reject, None);
+        }
+
         let decoded = if msg.topic == self.blocks_v1_topic.hash() {
             OpNetworkPayloadEnvelope::decode_v1(&msg.data)
         } else if msg.topic == self.blocks_v2_topic.hash() {

--- a/rust/kona/crates/node/rpc/src/admin.rs
+++ b/rust/kona/crates/node/rpc/src/admin.rs
@@ -63,6 +63,13 @@ where
         &self,
         payload: OpExecutionPayloadEnvelope,
     ) -> RpcResult<()> {
+        // Restrict unsafe-payload injection to sequencer mode, matching every other admin
+        // method in this trait. Without this check, any client that reaches the RPC port
+        // could inject a forged execution payload as the local unsafe head, poisoning the
+        // node's view of L2 state without going through P2P validation.
+        if self.sequencer_admin_client.is_none() {
+            return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+        }
         kona_macros::inc!(gauge, kona_gossip::Metrics::RPC_CALLS, "method" => "admin_postUnsafePayload");
         self.network_sender
             .send(NetworkAdminQuery::PostUnsafePayload { payload })

--- a/rust/kona/crates/node/rpc/src/admin.rs
+++ b/rust/kona/crates/node/rpc/src/admin.rs
@@ -63,13 +63,6 @@ where
         &self,
         payload: OpExecutionPayloadEnvelope,
     ) -> RpcResult<()> {
-        // Restrict unsafe-payload injection to sequencer mode, matching every other admin
-        // method in this trait. Without this check, any client that reaches the RPC port
-        // could inject a forged execution payload as the local unsafe head, poisoning the
-        // node's view of L2 state without going through P2P validation.
-        if self.sequencer_admin_client.is_none() {
-            return Err(ErrorObject::from(ErrorCode::MethodNotFound));
-        }
         kona_macros::inc!(gauge, kona_gossip::Metrics::RPC_CALLS, "method" => "admin_postUnsafePayload");
         self.network_sender
             .send(NetworkAdminQuery::PostUnsafePayload { payload })

--- a/rust/kona/crates/node/rpc/src/config.rs
+++ b/rust/kona/crates/node/rpc/src/config.rs
@@ -21,6 +21,11 @@ pub struct RpcBuilder {
 }
 
 impl RpcBuilder {
+    /// Returns whether the admin API namespace is enabled.
+    pub const fn enable_admin(&self) -> bool {
+        self.enable_admin
+    }
+
     /// Returns whether `WebSocket` RPC endpoint is enabled
     pub const fn ws_enabled(&self) -> bool {
         self.ws_enabled

--- a/rust/kona/crates/node/service/src/service/node.rs
+++ b/rust/kona/crates/node/service/src/service/node.rs
@@ -391,9 +391,16 @@ impl RollupNode {
         modules
             .merge(P2pRpc::new(p2p_rpc_tx).into_rpc())
             .map_err(|e| format!("Failed to register p2p module: {e:?}"))?;
-        modules
-            .merge(AdminRpc::new(sequencer_admin_client, network_admin_tx).into_rpc())
-            .map_err(|e| format!("Failed to register admin module: {e:?}"))?;
+        // Only register the admin API namespace when the operator explicitly enables it via
+        // `--rpc.enable-admin`. Op-node's admin API is opt-in by the same flag; Kona previously
+        // merged the admin module unconditionally, which — combined with the default
+        // `--rpc.addr=0.0.0.0` bind — exposed `admin_postUnsafePayload` and sequencer control
+        // methods to any anonymous TCP client that could route to the RPC port.
+        if config.enable_admin() {
+            modules
+                .merge(AdminRpc::new(sequencer_admin_client, network_admin_tx).into_rpc())
+                .map_err(|e| format!("Failed to register admin module: {e:?}"))?;
+        }
         modules
             .merge(RollupRpc::new(engine_rpc_client.clone(), l1_watcher_queries_tx).into_rpc())
             .map_err(|e| format!("Failed to register rollup module: {e:?}"))?;

--- a/rust/kona/crates/node/service/src/service/node.rs
+++ b/rust/kona/crates/node/service/src/service/node.rs
@@ -391,16 +391,12 @@ impl RollupNode {
         modules
             .merge(P2pRpc::new(p2p_rpc_tx).into_rpc())
             .map_err(|e| format!("Failed to register p2p module: {e:?}"))?;
-        // Only register the admin API namespace when the operator explicitly enables it via
-        // `--rpc.enable-admin`. Op-node's admin API is opt-in by the same flag; Kona previously
-        // merged the admin module unconditionally, which — combined with the default
-        // `--rpc.addr=0.0.0.0` bind — exposed `admin_postUnsafePayload` and sequencer control
-        // methods to any anonymous TCP client that could route to the RPC port.
-        if config.enable_admin() {
-            modules
-                .merge(AdminRpc::new(sequencer_admin_client, network_admin_tx).into_rpc())
-                .map_err(|e| format!("Failed to register admin module: {e:?}"))?;
-        }
+        merge_admin_module(
+            &mut modules,
+            config.enable_admin(),
+            sequencer_admin_client,
+            network_admin_tx,
+        )?;
         modules
             .merge(RollupRpc::new(engine_rpc_client.clone(), l1_watcher_queries_tx).into_rpc())
             .map_err(|e| format!("Failed to register rollup module: {e:?}"))?;
@@ -547,5 +543,51 @@ impl RollupNode {
             ]
         );
         Ok(())
+    }
+}
+
+/// Registers the admin API namespace on `modules`, but only when `enable_admin` is set.
+///
+/// The admin API is opt-in via `--rpc.enable-admin`, matching op-node's admin namespace.
+fn merge_admin_module(
+    modules: &mut RpcModule<()>,
+    enable_admin: bool,
+    sequencer_admin_client: Option<QueuedSequencerAdminAPIClient>,
+    network_admin_tx: mpsc::Sender<NetworkAdminQuery>,
+) -> Result<(), String> {
+    if enable_admin {
+        modules
+            .merge(AdminRpc::new(sequencer_admin_client, network_admin_tx).into_rpc())
+            .map_err(|e| format!("Failed to register admin module: {e:?}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn admin_method_names(enable_admin: bool) -> Vec<String> {
+        let mut modules = RpcModule::new(());
+        let (network_admin_tx, _rx) = mpsc::channel(1);
+        merge_admin_module(&mut modules, enable_admin, None, network_admin_tx)
+            .expect("admin module registration");
+        modules.method_names().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn admin_module_registered_only_when_enabled() {
+        // Without `--rpc.enable-admin`, no admin methods are exposed.
+        assert!(
+            admin_method_names(false).is_empty(),
+            "admin namespace must not be registered when disabled"
+        );
+
+        // With it enabled, the sequencer-control and payload-injection methods the acceptance
+        // suite relies on are present.
+        let enabled = admin_method_names(true);
+        for method in ["admin_postUnsafePayload", "admin_startSequencer", "admin_stopSequencer"] {
+            assert!(enabled.iter().any(|m| m == method), "missing {method}");
+        }
     }
 }

--- a/rust/kona/crates/protocol/protocol/src/batch/bits.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/bits.rs
@@ -25,19 +25,22 @@ impl SpanBatchBits {
     /// Decodes a standard span-batch bitlist from a reader.
     /// The bitlist is encoded as big-endian integer, left-padded with zeroes to a multiple of 8
     /// bits. The encoded bitlist cannot be longer than `bit_length`.
+    ///
+    /// # Consensus-critical
+    ///
+    /// Op-node's `decodeSpanBatchBits` (in `op-node/rollup/derive/span_batch_util.go`) uses
+    /// `io.ReadFull` and returns `io.ErrUnexpectedEOF` on short input. Kona must reject the
+    /// same input to avoid cross-client L2 state divergence. A previous version of this
+    /// function silently zero-padded truncated input; that behavior caused Kona to derive a
+    /// different L2 state than op-node for the same L1 calldata.
     pub fn decode(b: &mut &[u8], bit_length: usize) -> Result<Self, SpanBatchError> {
         let buffer_len = bit_length / 8 + if bit_length.is_multiple_of(8) { 0 } else { 1 };
-        let bits = if b.len() < buffer_len {
-            let mut bits = vec![0; buffer_len];
-            bits[..b.len()].copy_from_slice(b);
-            b.advance(b.len());
-            bits
-        } else {
-            let v = b[..buffer_len].to_vec();
-            b.advance(buffer_len);
-            v
-        };
-        let sb_bits = Self(bits);
+        if b.len() < buffer_len {
+            return Err(SpanBatchError::BitfieldTooShort);
+        }
+        let v = b[..buffer_len].to_vec();
+        b.advance(buffer_len);
+        let sb_bits = Self(v);
 
         if sb_bits.bit_len() > bit_length {
             return Err(SpanBatchError::BitfieldTooLong);
@@ -227,5 +230,32 @@ mod test {
         assert_eq!(bits.get_bit(17), Some(1));
         assert_eq!(bits.get_bit(32), None);
         assert_eq!(bits.0.len(), 3);
+    }
+
+    /// Regression: `decode` must reject truncated input rather than silently zero-padding.
+    ///
+    /// Op-node's `decodeSpanBatchBits` returns `io.ErrUnexpectedEOF` for the same input; Kona
+    /// must reject to avoid cross-client L2 state divergence.
+    #[test]
+    fn decode_rejects_truncated_input() {
+        let mut empty: &[u8] = &[];
+        assert!(matches!(
+            SpanBatchBits::decode(&mut empty, 1),
+            Err(SpanBatchError::BitfieldTooShort)
+        ));
+
+        let mut short: &[u8] = &[0xFF];
+        assert!(matches!(
+            SpanBatchBits::decode(&mut short, 16),
+            Err(SpanBatchError::BitfieldTooShort)
+        ));
+    }
+
+    /// Sanity check: full-length input is accepted verbatim.
+    #[test]
+    fn decode_accepts_full_input() {
+        let mut buf: &[u8] = &[0x01];
+        let out = SpanBatchBits::decode(&mut buf, 1).expect("full input accepted");
+        assert_eq!(out.as_ref(), &[0x01]);
     }
 }

--- a/rust/kona/crates/protocol/protocol/src/batch/bits.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/bits.rs
@@ -28,11 +28,10 @@ impl SpanBatchBits {
     ///
     /// # Consensus-critical
     ///
-    /// Op-node's `decodeSpanBatchBits` (in `op-node/rollup/derive/span_batch_util.go`) uses
-    /// `io.ReadFull` and returns `io.ErrUnexpectedEOF` on short input. Kona must reject the
-    /// same input to avoid cross-client L2 state divergence. A previous version of this
-    /// function silently zero-padded truncated input; that behavior caused Kona to derive a
-    /// different L2 state than op-node for the same L1 calldata.
+    /// Truncated input is rejected with [`SpanBatchError::BitfieldTooShort`] rather than
+    /// zero-padded. Op-node's `decodeSpanBatchBits` (in `op-node/rollup/derive/span_batch_util.go`)
+    /// uses `io.ReadFull` and returns `io.ErrUnexpectedEOF` on short input; Kona must reject the
+    /// same input to avoid cross-client L2 state divergence.
     pub fn decode(b: &mut &[u8], bit_length: usize) -> Result<Self, SpanBatchError> {
         let buffer_len = bit_length / 8 + if bit_length.is_multiple_of(8) { 0 } else { 1 };
         if b.len() < buffer_len {

--- a/rust/kona/crates/protocol/protocol/src/batch/errors.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/errors.rs
@@ -9,6 +9,9 @@ pub enum SpanBatchError {
     /// The bit field is too long
     #[error("The bit field is too long")]
     BitfieldTooLong,
+    /// The bit field is shorter than the declared bit length
+    #[error("The bit field is shorter than the declared bit length")]
+    BitfieldTooShort,
     /// Empty Span Batch
     #[error("Empty span batch")]
     EmptySpanBatch,


### PR DESCRIPTION
Supersedes #21713 — carries @MattHintz's three security commits (authorship preserved) and completes/corrects them in two follow-up commits.

Three unauthenticated attack surfaces in the kona (Rust) consensus client:

- **B1 — truncated span-batch bitlist** (cross-client L2 state divergence). Landed as-is from #21713; verified it matches op-node's `decodeSpanBatchBits` (short-input rejection + over-length check) and is strictly convergent.
- **B2 — gossipsub snappy-bomb OOM.** #21713 only bounded the `message_id` function, but every inbound message is *also* decoded via `OpNetworkPayloadEnvelope::decode_v*`, which the same tiny frame still OOMs. Now bounded before decode in the block handler, mirroring op-node (which bounds both its message-id fn and its topic validator).
- **B3 — admin RPC exposure.** Kept: gate the admin namespace on `--rpc.enable-admin`. Reverted two parts of #21713: the sequencer-only gate on `admin_postUnsafePayload` (node-level injection, not sequencer control — op-node exposes it on any admin-enabled node), and the `--rpc.addr` default change to `127.0.0.1`. We keep `0.0.0.0`: the node ships as a Docker image where `127.0.0.1` is unreachable from outside the container, and opt-in admin (not the bind address) is the exposure control — see #16487. Added the missing devstack companion (`KONA_NODE_RPC_ENABLE_ADMIN=true`) so the required `memory-all-kona-op-reth` acceptance gate keeps passing.

The delta over #21713 is in commits `21566df` and `1e071b4`. Snappy-bomb and admin-gating regression tests are mutation-verified sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
