### PR TITLE
[codex] reduce follow-source L1 lookup stalls

### DIFF
--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -469,6 +469,8 @@ func (s *Driver) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPa
 	s.SyncDeriver.OnUnsafeL2Payload(ctx, payload)
 }
 
+const followUpstreamL1Timeout = 2 * time.Second
+
 // followUpstream reconciles the local engine state with upstream sources when
 // derivation is disabled (UnsafeOnly).
 //
@@ -507,70 +509,54 @@ func (s *Driver) followUpstream() {
 		return
 	}
 
-	eLocalSafeL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.LocalSafeL2.L1Origin.Number)
+	l1Numbers := []uint64{
+		status.LocalSafeL2.L1Origin.Number,
+		status.SafeL2.L1Origin.Number,
+		status.FinalizedL2.L1Origin.Number,
+	}
+	if status.CurrentL1 != (eth.L1BlockRef{}) {
+		l1Numbers = append(l1Numbers, status.CurrentL1.Number)
+	}
+
+	// Bound the complete validation round rather than allowing the timeout of each
+	// individual RPC call to accumulate.
+	l1Ctx, cancel := context.WithTimeout(s.driverCtx, followUpstreamL1Timeout)
+	l1Refs, err := fetchL1BlockRefs(l1Ctx, s.upstreamFollowSource, l1Numbers...)
+	cancel()
 	if err != nil {
-		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external local safe head", "err", err)
+		s.log.Warn("Follow Upstream: Failed to look up external L1 origins", "err", err)
 		s.metrics.RecordFollowSourceRequest("error_l1_lookup")
 		return
 	}
-	if eLocalSafeL1Origin.Hash != status.LocalSafeL2.L1Origin.Hash {
+
+	validateL1Origin := func(label string, expected eth.BlockID) bool {
+		actual := l1Refs[expected.Number]
+		if actual.Hash == expected.Hash {
+			return true
+		}
 		s.log.Warn(
-			"Follow Upstream: Invalid external local safe: L1 origin of external local safe head mismatch",
-			"actual", eLocalSafeL1Origin,
-			"expected", status.LocalSafeL2.L1Origin,
+			"Follow Upstream: External L1 origin mismatch",
+			"label", label,
+			"actual", actual,
+			"expected", expected,
 		)
 		s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
-		return
+		return false
 	}
 
-	eSafeL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.SafeL2.L1Origin.Number)
-	if err != nil {
-		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external safe head", "err", err)
-		s.metrics.RecordFollowSourceRequest("error_l1_lookup")
+	if !validateL1Origin("local-safe", status.LocalSafeL2.L1Origin) {
 		return
 	}
-	if eSafeL1Origin.Hash != status.SafeL2.L1Origin.Hash {
-		s.log.Warn(
-			"Follow Upstream: Invalid external safe: L1 origin of external safe head mismatch",
-			"actual", eSafeL1Origin,
-			"expected", status.SafeL2.L1Origin,
-		)
-		s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
+	if !validateL1Origin("safe", status.SafeL2.L1Origin) {
 		return
 	}
-
-	eFinalizedL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.FinalizedL2.L1Origin.Number)
-	if err != nil {
-		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external finalized head", "err", err)
-		s.metrics.RecordFollowSourceRequest("error_l1_lookup")
+	if !validateL1Origin("finalized", status.FinalizedL2.L1Origin) {
 		return
 	}
-	if eFinalizedL1Origin.Hash != status.FinalizedL2.L1Origin.Hash {
-		s.log.Warn(
-			"Follow Upstream: Invalid external finalized: L1 origin of external finalized head mismatch",
-			"actual", eFinalizedL1Origin,
-			"expected", status.FinalizedL2.L1Origin,
-		)
-		s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
-		return
-	}
-
 	if (status.CurrentL1 == eth.L1BlockRef{}) {
 		s.log.Debug("Follow Upstream: CurrentL1 not available")
 	} else {
-		eCurrentL1, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.CurrentL1.Number)
-		if err != nil {
-			s.log.Warn("Follow Upstream: Failed to look up external currentL1", "err", err)
-			s.metrics.RecordFollowSourceRequest("error_l1_lookup")
-			return
-		}
-		if eCurrentL1.Hash != status.CurrentL1.Hash {
-			s.log.Warn(
-				"Follow Upstream: Invalid external CurrentL1: L1 head mismatch",
-				"actual", eCurrentL1,
-				"expected", status.CurrentL1,
-			)
-			s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
+		if !validateL1Origin("current", status.CurrentL1.ID()) {
 			return
 		}
 

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -296,12 +296,15 @@ func (s *Driver) eventLoop() {
 	// from an external source. Since the normal derivation pipeline is inactive, reorg
 	// detection must be performed here instead.
 	var upstreamSyncTickerC <-chan time.Time
+	var upstreamSyncResultCh chan followUpstreamResult
 	if followSource {
 		upstreamSyncTickerCheckInterval := time.Duration(s.SyncDeriver.Config.BlockTime) * time.Second * 2
 		upstreamSyncTicker := time.NewTicker(upstreamSyncTickerCheckInterval)
 		upstreamSyncTickerC = upstreamSyncTicker.C
+		upstreamSyncResultCh = make(chan followUpstreamResult, 1)
 		defer upstreamSyncTicker.Stop()
 	}
+	upstreamSyncInFlight := false
 
 	for {
 		if s.driverCtx.Err() != nil { // don't try to schedule/handle more work when we are closing.
@@ -333,7 +336,13 @@ func (s *Driver) eventLoop() {
 				s.log.Warn("failed to check for unsafe L2 blocks to sync", "err", err)
 			}
 		case <-upstreamSyncTickerC:
-			s.followUpstream()
+			if !upstreamSyncInFlight && !s.SyncDeriver.Engine.IsEngineInitialELSyncing() {
+				upstreamSyncInFlight = true
+				s.startFollowUpstreamFetch(upstreamSyncResultCh)
+			}
+		case result := <-upstreamSyncResultCh:
+			upstreamSyncInFlight = false
+			s.followUpstream(result)
 		case <-s.sched.NextDelayedStep():
 			s.sched.AttemptStep(s.driverCtx)
 		case <-s.sched.NextStep():
@@ -469,8 +478,6 @@ func (s *Driver) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPa
 	s.SyncDeriver.OnUnsafeL2Payload(ctx, payload)
 }
 
-const followUpstreamL1Timeout = 2 * time.Second
-
 // followUpstream reconciles the local engine state with upstream sources when
 // derivation is disabled (UnsafeOnly).
 //
@@ -479,10 +486,9 @@ const followUpstreamL1Timeout = 2 * time.Second
 // validates that the external state is sane (e.g. finalized is not ahead
 // of safe), and then updates the engine via FollowSource.
 //
-// This function is intended to be called periodically by a ticker and is a
-// no-op while derivation is enabled or the EL is still performing its initial
-// sync.
-func (s *Driver) followUpstream() {
+// Network inputs are fetched asynchronously and passed in as an immutable result,
+// while all engine and event updates remain on the driver event loop.
+func (s *Driver) followUpstream(result followUpstreamResult) {
 	if !s.syncConfig.FollowSourceEnabled() {
 		return
 	}
@@ -490,12 +496,12 @@ func (s *Driver) followUpstream() {
 		// Do not interfere with initial EL Sync and wait until it is done
 		return
 	}
-	status, err := s.upstreamFollowSource.GetFollowStatus(s.driverCtx)
-	if err != nil {
-		s.log.Warn("Follow Upstream: Failed to fetch status", "err", err)
+	if result.statusErr != nil || result.status == nil {
+		s.log.Warn("Follow Upstream: Failed to fetch status", "err", result.statusErr)
 		s.metrics.RecordFollowSourceRequest("error_fetch_status")
 		return
 	}
+	status := result.status
 	s.log.Info("Follow Upstream", "eSafe", status.SafeL2, "eLocalSafe", status.LocalSafeL2, "eFinalized", status.FinalizedL2, "eCurrentL1", status.CurrentL1)
 	if status.SafeL2.Number > status.LocalSafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, safe is ahead of local safe",
@@ -509,28 +515,14 @@ func (s *Driver) followUpstream() {
 		return
 	}
 
-	l1Numbers := []uint64{
-		status.LocalSafeL2.L1Origin.Number,
-		status.SafeL2.L1Origin.Number,
-		status.FinalizedL2.L1Origin.Number,
-	}
-	if status.CurrentL1 != (eth.L1BlockRef{}) {
-		l1Numbers = append(l1Numbers, status.CurrentL1.Number)
-	}
-
-	// Bound the complete validation round rather than allowing the timeout of each
-	// individual RPC call to accumulate.
-	l1Ctx, cancel := context.WithTimeout(s.driverCtx, followUpstreamL1Timeout)
-	l1Refs, err := fetchL1BlockRefs(l1Ctx, s.upstreamFollowSource, l1Numbers...)
-	cancel()
-	if err != nil {
-		s.log.Warn("Follow Upstream: Failed to look up external L1 origins", "err", err)
+	if result.l1Err != nil {
+		s.log.Warn("Follow Upstream: Failed to look up external L1 origins", "err", result.l1Err)
 		s.metrics.RecordFollowSourceRequest("error_l1_lookup")
 		return
 	}
 
 	validateL1Origin := func(label string, expected eth.BlockID) bool {
-		actual := l1Refs[expected.Number]
+		actual := result.l1Refs[expected.Number]
 		if actual.Hash == expected.Hash {
 			return true
 		}

--- a/op-node/rollup/driver/follow_source.go
+++ b/op-node/rollup/driver/follow_source.go
@@ -2,9 +2,12 @@ package driver
 
 import (
 	"context"
+	"fmt"
+	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"golang.org/x/sync/errgroup"
 )
 
 // L1FollowSource provides access to L1 block references for upstream following.
@@ -13,7 +16,6 @@ type L1FollowSource interface {
 }
 
 // UpstreamFollowSource combines L1 and L2 follow sources.
-// L2 following may be optionally disabled.
 type UpstreamFollowSource interface {
 	L1FollowSource
 	GetFollowStatus(ctx context.Context) (*sources.FollowStatus, error)
@@ -27,7 +29,7 @@ type L2FollowSource struct {
 var _ UpstreamFollowSource = (*L2FollowSource)(nil)
 
 func NewL2FollowSource(client *sources.FollowClient, l1Source L1FollowSource) *L2FollowSource {
-	if l1Source == nil || client == nil {
+	if client == nil || l1Source == nil {
 		panic("NewL2FollowSource: sources must not be nil")
 	}
 	return &L2FollowSource{l2Source: client, l1Source: l1Source}
@@ -39,4 +41,33 @@ func (fs *L2FollowSource) GetFollowStatus(ctx context.Context) (*sources.FollowS
 
 func (fs *L2FollowSource) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
 	return fs.l1Source.L1BlockRefByNumber(ctx, num)
+}
+
+// fetchL1BlockRefs fetches each unique L1 block number concurrently.
+func fetchL1BlockRefs(ctx context.Context, source L1FollowSource, numbers ...uint64) (map[uint64]eth.L1BlockRef, error) {
+	unique := make(map[uint64]struct{}, len(numbers))
+	for _, number := range numbers {
+		unique[number] = struct{}{}
+	}
+
+	refs := make(map[uint64]eth.L1BlockRef, len(unique))
+	var mu sync.Mutex
+	group, groupCtx := errgroup.WithContext(ctx)
+	for number := range unique {
+		number := number
+		group.Go(func() error {
+			ref, err := source.L1BlockRefByNumber(groupCtx, number)
+			if err != nil {
+				return fmt.Errorf("fetch L1 block %d: %w", number, err)
+			}
+			mu.Lock()
+			refs[number] = ref
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return refs, nil
 }

--- a/op-node/rollup/driver/follow_source.go
+++ b/op-node/rollup/driver/follow_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -41,6 +42,58 @@ func (fs *L2FollowSource) GetFollowStatus(ctx context.Context) (*sources.FollowS
 
 func (fs *L2FollowSource) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
 	return fs.l1Source.L1BlockRefByNumber(ctx, num)
+}
+
+const followUpstreamTimeout = 2 * time.Second
+
+type followUpstreamResult struct {
+	status    *sources.FollowStatus
+	l1Refs    map[uint64]eth.L1BlockRef
+	statusErr error
+	l1Err     error
+}
+
+// startFollowUpstreamFetch fetches upstream inputs without blocking the driver event loop.
+func (s *Driver) startFollowUpstreamFetch(resultCh chan<- followUpstreamResult) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		ctx, cancel := context.WithTimeout(s.driverCtx, followUpstreamTimeout)
+		defer cancel()
+
+		result := s.fetchFollowUpstream(ctx)
+		select {
+		case resultCh <- result:
+		case <-s.driverCtx.Done():
+		}
+	}()
+}
+
+func (s *Driver) fetchFollowUpstream(ctx context.Context) followUpstreamResult {
+	status, err := s.upstreamFollowSource.GetFollowStatus(ctx)
+	result := followUpstreamResult{status: status, statusErr: err}
+	if err != nil {
+		return result
+	}
+	if status == nil {
+		result.statusErr = fmt.Errorf("upstream returned nil follow status")
+		return result
+	}
+	// Avoid L1 lookups when the status will be rejected by the event loop.
+	if status.SafeL2.Number > status.LocalSafeL2.Number || status.FinalizedL2.Number > status.SafeL2.Number {
+		return result
+	}
+
+	l1Numbers := []uint64{
+		status.LocalSafeL2.L1Origin.Number,
+		status.SafeL2.L1Origin.Number,
+		status.FinalizedL2.L1Origin.Number,
+	}
+	if status.CurrentL1 != (eth.L1BlockRef{}) {
+		l1Numbers = append(l1Numbers, status.CurrentL1.Number)
+	}
+	result.l1Refs, result.l1Err = fetchL1BlockRefs(ctx, s.upstreamFollowSource, l1Numbers...)
+	return result
 }
 
 // fetchL1BlockRefs fetches each unique L1 block number concurrently.

--- a/op-node/rollup/driver/follow_source_test.go
+++ b/op-node/rollup/driver/follow_source_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -16,6 +17,23 @@ type blockingL1FollowSource struct {
 	calls   map[uint64]int
 	started chan uint64
 	release <-chan struct{}
+}
+
+type blockingUpstreamFollowSource struct {
+	*blockingL1FollowSource
+	status        *sources.FollowStatus
+	statusStarted chan struct{}
+	statusRelease <-chan struct{}
+}
+
+func (s *blockingUpstreamFollowSource) GetFollowStatus(ctx context.Context) (*sources.FollowStatus, error) {
+	s.statusStarted <- struct{}{}
+	select {
+	case <-s.statusRelease:
+		return s.status, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func (s *blockingL1FollowSource) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
@@ -85,4 +103,71 @@ func TestFetchL1BlockRefsHonorsContext(t *testing.T) {
 
 	_, err := fetchL1BlockRefs(ctx, source, 1, 2)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestStartFollowUpstreamFetchDoesNotBlock(t *testing.T) {
+	statusRelease := make(chan struct{})
+	l1Release := make(chan struct{})
+	close(l1Release)
+	origin := eth.BlockID{Number: 1, Hash: common.Hash{1}}
+	source := &blockingUpstreamFollowSource{
+		blockingL1FollowSource: &blockingL1FollowSource{
+			calls:   make(map[uint64]int),
+			started: make(chan uint64, 1),
+			release: l1Release,
+		},
+		status: &sources.FollowStatus{
+			LocalSafeL2: eth.L2BlockRef{Number: 3, L1Origin: origin},
+			SafeL2:      eth.L2BlockRef{Number: 2, L1Origin: origin},
+			FinalizedL2: eth.L2BlockRef{Number: 1, L1Origin: origin},
+		},
+		statusStarted: make(chan struct{}, 1),
+		statusRelease: statusRelease,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	driver := &Driver{driverCtx: ctx, upstreamFollowSource: source}
+	resultCh := make(chan followUpstreamResult, 1)
+
+	driver.startFollowUpstreamFetch(resultCh)
+	select {
+	case <-source.statusStarted:
+	case <-time.After(time.Second):
+		t.Fatal("upstream status fetch did not start")
+	}
+	select {
+	case <-resultCh:
+		t.Fatal("fetch completed while the upstream request was blocked")
+	default:
+	}
+
+	close(statusRelease)
+	select {
+	case result := <-resultCh:
+		require.NoError(t, result.statusErr)
+		require.NoError(t, result.l1Err)
+		require.Equal(t, eth.L1BlockRef{Number: 1, Hash: common.Hash{1}}, result.l1Refs[1])
+	case <-time.After(time.Second):
+		t.Fatal("upstream fetch did not complete")
+	}
+	driver.wg.Wait()
+}
+
+func TestFetchFollowUpstreamTimeoutIncludesStatusRequest(t *testing.T) {
+	source := &blockingUpstreamFollowSource{
+		blockingL1FollowSource: &blockingL1FollowSource{
+			calls:   make(map[uint64]int),
+			started: make(chan uint64, 1),
+			release: make(chan struct{}),
+		},
+		statusStarted: make(chan struct{}, 1),
+		statusRelease: make(chan struct{}),
+	}
+	driver := &Driver{upstreamFollowSource: source}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	result := driver.fetchFollowUpstream(ctx)
+	require.ErrorIs(t, result.statusErr, context.DeadlineExceeded)
+	require.Empty(t, source.calls)
 }

--- a/op-node/rollup/driver/follow_source_test.go
+++ b/op-node/rollup/driver/follow_source_test.go
@@ -1,0 +1,88 @@
+package driver
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+type blockingL1FollowSource struct {
+	mu      sync.Mutex
+	calls   map[uint64]int
+	started chan uint64
+	release <-chan struct{}
+}
+
+func (s *blockingL1FollowSource) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
+	s.mu.Lock()
+	s.calls[number]++
+	s.mu.Unlock()
+
+	s.started <- number
+	select {
+	case <-s.release:
+		return eth.L1BlockRef{Number: number, Hash: common.Hash{byte(number)}}, nil
+	case <-ctx.Done():
+		return eth.L1BlockRef{}, ctx.Err()
+	}
+}
+
+func TestFetchL1BlockRefsDeduplicatesAndFetchesConcurrently(t *testing.T) {
+	release := make(chan struct{})
+	source := &blockingL1FollowSource{
+		calls:   make(map[uint64]int),
+		started: make(chan uint64, 3),
+		release: release,
+	}
+
+	type result struct {
+		refs map[uint64]eth.L1BlockRef
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		refs, err := fetchL1BlockRefs(context.Background(), source, 1, 2, 1, 3, 2)
+		resultCh <- result{refs: refs, err: err}
+	}()
+
+	started := make(map[uint64]struct{})
+	for range 3 {
+		select {
+		case number := <-source.started:
+			started[number] = struct{}{}
+		case <-time.After(time.Second):
+			close(release)
+			t.Fatal("unique L1 lookups did not start concurrently")
+		}
+	}
+	close(release)
+
+	res := <-resultCh
+	require.NoError(t, res.err)
+	require.Equal(t, map[uint64]struct{}{1: {}, 2: {}, 3: {}}, started)
+	require.Equal(t, eth.L1BlockRef{Number: 1, Hash: common.Hash{1}}, res.refs[1])
+	require.Equal(t, eth.L1BlockRef{Number: 2, Hash: common.Hash{2}}, res.refs[2])
+	require.Equal(t, eth.L1BlockRef{Number: 3, Hash: common.Hash{3}}, res.refs[3])
+
+	source.mu.Lock()
+	defer source.mu.Unlock()
+	require.Equal(t, map[uint64]int{1: 1, 2: 1, 3: 1}, source.calls)
+}
+
+func TestFetchL1BlockRefsHonorsContext(t *testing.T) {
+	source := &blockingL1FollowSource{
+		calls:   make(map[uint64]int),
+		started: make(chan uint64, 2),
+		release: make(chan struct{}),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := fetchL1BlockRefs(ctx, source, 1, 2)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}


### PR DESCRIPTION
## Summary

- deduplicate follow-source L1 origin lookups by block number
- resolve unique origins concurrently against the configured L1 RPC
- fetch upstream status and L1 origins in a single-flight background worker
- cap the complete network-fetch round at two seconds
- apply validated labels and mutate engine state only on the driver event loop

## Why

`followUpstream` previously fetched upstream status and validated local-safe, safe, finalized, and current L1 origins with synchronous calls in the driver's main select loop. Duplicate or slow requests could therefore delay sequencer actions.

The updated path preserves fresh, independent canonical-L1 validation while issuing at most one lookup per unique block number and bounding aggregate lookup latency instead of accumulating the timeout of each call. A single background fetch may be active at a time; completed immutable results return to the driver loop for validation metrics, event emission, and engine reconciliation.

## Impact

Follow-mode sequencers issue fewer L1 network requests when labels share an origin. Upstream and L1 network latency no longer blocks the sequencer timer. A slow fetch round fails after two seconds and retries on a later poll without accepting unverified upstream labels.

## Tests

- `go test ./op-node/rollup/driver ./op-node/node`
- `go test ./op-node/...`
- `just --unstable lint-go`
