### PR TITLE
op-node: move follow-source requests off the driver loop

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/stalled_source_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/stalled_source_test.go
@@ -1,0 +1,45 @@
+package follow_l2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// TestLightSequencerKeepsSequencingWhenFollowSourceStalls covers the driver
+// event loop's independence from follow-source RPC latency: when a light CL
+// sequencer's follow-source endpoint becomes unresponsive, the sequencer must
+// keep producing unsafe blocks at its normal cadence.
+//
+// The follow-source requests run on a 2*blocktime ticker and their RPC client
+// has a 10s default call timeout. If the driver services those requests on its
+// main event loop (the regression this test guards against), an unresponsive
+// endpoint blocks the loop for the full call timeout on every tick, freezing
+// block production in >=10s gaps. Run off-loop, a stalled endpoint costs
+// nothing: production must show no gap anywhere near that dead window.
+func TestLightSequencerKeepsSequencingWhenFollowSourceStalls(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+
+	proxies := sysgo.NewStallableFollowSourceProxies()
+	sys := presets.NewTwoL2SupernodeLightSequencerInterop(t, 0,
+		presets.WithSupernodeVNSequencerForBootstrap(),
+		presets.WithGlobalL2CLOption(proxies.L2CLOption()),
+	)
+	sys.BootstrapLightSequencersViaVNHandoff()
+
+	proxies.ForChain(t, sys.L2A.ChainID()).Stall()
+
+	// maxGap sits strictly below the 10s follow-source call timeout (the
+	// guaranteed production dead window when follow requests block the driver
+	// loop) and well above the healthy block cadence. The 30s window spans
+	// several follow ticks, so a stalled request is guaranteed to be in flight
+	// while we observe.
+	sys.L2ELA.KeptAdvancing(eth.Unsafe, 30*time.Second, 8*time.Second)
+
+	t.Require().NotZero(proxies.ForChain(t, sys.L2A.ChainID()).StalledRequests(),
+		"no follow-source request was held by the stalled proxy; the stall did not exercise the follow path")
+}

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/stalled_source_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/stalled_source_test.go
@@ -33,13 +33,23 @@ func TestLightSequencerKeepsSequencingWhenFollowSourceStalls(gt *testing.T) {
 
 	proxies.ForChain(t, sys.L2A.ChainID()).Stall()
 
-	// maxGap sits strictly below the 10s follow-source call timeout (the
-	// guaranteed production dead window when follow requests block the driver
-	// loop) and well above the healthy block cadence. The 30s window spans
-	// several follow ticks, so a stalled request is guaranteed to be in flight
-	// while we observe.
-	sys.L2ELA.KeptAdvancing(eth.Unsafe, 30*time.Second, 8*time.Second)
+	// maxGap of two block intervals requires production to stay at its normal
+	// cadence, not merely avoid a full stall: it fails both the 10s dead window
+	// of an on-loop follow request (the client call timeout) and any degraded
+	// rhythm where individual blocks slip by more than one interval. It cannot
+	// be tightened much further: KeptAdvancing samples at 500ms, so a healthy
+	// 2s cadence can measure as ~3s between observed advances. The 30s window
+	// spans several follow ticks, so a stalled request is guaranteed to be in
+	// flight while we observe.
+	sys.L2ELA.KeptAdvancing(eth.Unsafe, 30*time.Second, 4*time.Second)
 
-	t.Require().NotZero(proxies.ForChain(t, sys.L2A.ChainID()).StalledRequests(),
+	proxy := proxies.ForChain(t, sys.L2A.ChainID())
+	t.Require().NotZero(proxy.StalledRequests(),
 		"no follow-source request was held by the stalled proxy; the stall did not exercise the follow path")
+	// The follow client keeps at most one fetch in flight, coalescing ticks
+	// that fire while a request is blocked. Without that single-flight
+	// behavior, every 2*blocktime tick would open another request against the
+	// stalled endpoint (each surviving up to its 10s call timeout).
+	t.Require().EqualValues(1, proxy.MaxConcurrentStalledRequests(),
+		"expected exactly one follow-source request in flight at a time; the single-flight contract is broken")
 }

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -113,6 +113,47 @@ func (el *L2ELNode) AdvancedFn(label eth.BlockLabel, block uint64, opts ...Advan
 	}
 }
 
+// KeptAdvancingFn returns a CheckFunc that observes the head for the given
+// label over observeFor and fails if the head ever goes longer than maxGap of
+// wall-clock time without advancing to a higher block number. Use it to assert
+// sustained liveness (e.g. continuous block production) rather than eventual
+// progress: AdvancedFn passes as long as the target is reached eventually,
+// while KeptAdvancingFn also fails on a long stall followed by a catch-up burst.
+// Transient lookup errors are tolerated until they persist past maxGap.
+func (el *L2ELNode) KeptAdvancingFn(label eth.BlockLabel, observeFor time.Duration, maxGap time.Duration) CheckFunc {
+	return func() error {
+		start := time.Now()
+		last, err := el.blockRefByLabel(label)
+		if err != nil {
+			return fmt.Errorf("initial %s head lookup failed: %w", label, err)
+		}
+		lastAdvance := start
+		el.log.Info("expecting chain to keep advancing", "chain", el.inner.ChainID(), "label", label,
+			"from", last.Number, "observe_for", observeFor, "max_gap", maxGap)
+		for time.Since(start) < observeFor {
+			if err := clock.SystemClock.SleepCtx(el.ctx, 500*time.Millisecond); err != nil { // nosemgrep: flake-sleep-in-test -- fixed-cadence sampling to measure production gaps; there is no single chain event to wait on
+				return err
+			}
+			head, lookupErr := el.blockRefByLabel(label)
+			if lookupErr != nil {
+				el.log.Warn("head lookup failed; will retry", "chain", el.inner.ChainID(), "label", label, "err", lookupErr)
+			} else if head.Number > last.Number {
+				el.log.Info("chain advanced", "chain", el.inner.ChainID(), "label", label,
+					"block", head.Number, "gap", time.Since(lastAdvance).Round(time.Millisecond))
+				last = head
+				lastAdvance = time.Now()
+			}
+			if gap := time.Since(lastAdvance); gap > maxGap {
+				return fmt.Errorf("chain %s %s head stalled at block %d: no new block for %s (max allowed %s)",
+					el.inner.ChainID(), label, last.Number, gap.Round(time.Millisecond), maxGap)
+			}
+		}
+		el.log.Info("chain kept advancing for the whole observation window",
+			"chain", el.inner.ChainID(), "label", label, "at", last.Number, "observed", observeFor)
+		return nil
+	}
+}
+
 func (el *L2ELNode) NotAdvancedFn(label eth.BlockLabel, attempts int) CheckFunc {
 	return func() error {
 		el.log.Info("expecting chain not to advance", "chain", el.inner.ChainID(), "label", label)
@@ -230,6 +271,10 @@ func (el *L2ELNode) Advanced(label eth.BlockLabel, block uint64) {
 
 func (el *L2ELNode) Reached(label eth.BlockLabel, block uint64, attempts int) {
 	el.require.NoError(el.ReachedFn(label, block, attempts)())
+}
+
+func (el *L2ELNode) KeptAdvancing(label eth.BlockLabel, observeFor time.Duration, maxGap time.Duration) {
+	el.require.NoError(el.KeptAdvancingFn(label, observeFor, maxGap)())
 }
 
 func (el *L2ELNode) NotAdvanced(label eth.BlockLabel, attempts int) {

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -179,6 +179,13 @@ const twoL2SupernodeInteropPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindPreGenesisSuperGame |
 	optionKindSupernodeVNSequencerForBootstrap
 
+// twoL2SupernodeLightSequencerPresetSupportedOptionKinds additionally accepts
+// L2 CL options: the light-sequencer runtime is the only two-L2 supernode
+// variant that wires GlobalL2CLOptions (to the light sequencer CLs), so the
+// option is accepted here and nowhere else to avoid a silent no-op.
+const twoL2SupernodeLightSequencerPresetSupportedOptionKinds = twoL2SupernodeInteropPresetSupportedOptionKinds |
+	optionKindGlobalL2CL
+
 const singleChainWithFlashblocksPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindOPRBuilder |
 	optionKindOpReth |

--- a/op-devstack/presets/twol2.go
+++ b/op-devstack/presets/twol2.go
@@ -184,7 +184,7 @@ func NewTwoL2SupernodeInterop(t devtest.T, delaySeconds uint64, opts ...Option) 
 // NewTwoL2SupernodeLightSequencerInterop creates a two-L2 interop setup where
 // light op-node CLs sequence blocks and the shared supernode derives safe heads.
 func NewTwoL2SupernodeLightSequencerInterop(t devtest.T, delaySeconds uint64, opts ...Option) *TwoL2SupernodeInterop {
-	presetCfg, _ := collectSupportedPresetConfig(t, "NewTwoL2SupernodeLightSequencerInterop", opts, twoL2SupernodeInteropPresetSupportedOptionKinds)
+	presetCfg, _ := collectSupportedPresetConfig(t, "NewTwoL2SupernodeLightSequencerInterop", opts, twoL2SupernodeLightSequencerPresetSupportedOptionKinds)
 	if presetCfg.UseInteropFilter {
 		sysgo.SkipOnOpGeth(t, "interop filter is only supported with op-reth")
 	}

--- a/op-devstack/sysgo/stallable_proxy.go
+++ b/op-devstack/sysgo/stallable_proxy.go
@@ -1,0 +1,156 @@
+package sysgo
+
+import (
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// StallableProxy is a reverse proxy for an HTTP RPC endpoint that can be
+// switched into a stalled mode: while stalled, incoming requests are held
+// open without a response until the client gives up (e.g. its call timeout)
+// or the proxy is resumed. It lets tests simulate an unresponsive upstream
+// without stopping the upstream itself.
+type StallableProxy struct {
+	name   string
+	target *url.URL
+	server *http.Server
+	addr   string
+
+	mu      sync.Mutex
+	stallCh chan struct{} // non-nil while stalled; closed by Resume
+
+	stalledRequests atomic.Int64
+}
+
+// StartStallableProxy starts a StallableProxy in front of targetURL. The proxy
+// begins in passthrough mode and is shut down via test cleanup.
+func StartStallableProxy(p devtest.T, name string, targetURL string) *StallableProxy {
+	target, err := url.Parse(targetURL)
+	p.Require().NoError(err, "invalid stallable proxy target URL %q", targetURL)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	p.Require().NoError(err, "failed to listen for stallable proxy %s", name)
+
+	logger := p.Logger().New("component", "stallable-proxy-"+name)
+	proxy := &StallableProxy{
+		name:   name,
+		target: target,
+		addr:   "http://" + listener.Addr().String(),
+	}
+	rp := httputil.NewSingleHostReverseProxy(target)
+	proxy.server = &http.Server{
+		// Bound only the header-read phase. Read/write timeouts are deliberately
+		// absent: a stalled request must be able to stay open longer than any
+		// client-side call timeout, which is the point of this proxy.
+		ReadHeaderTimeout: 5 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ch := proxy.currentStall(); ch != nil {
+				n := proxy.stalledRequests.Add(1)
+				logger.Info("Stalling proxied request", "target", target, "stalled_requests", n)
+				select {
+				case <-r.Context().Done():
+					// Client gave up (e.g. RPC call timeout) or the server is closing.
+					return
+				case <-ch:
+					// Resumed; serve the request after all.
+				}
+			}
+			rp.ServeHTTP(w, r)
+		}),
+	}
+	go func() {
+		_ = proxy.server.Serve(listener)
+	}()
+	p.Cleanup(func() {
+		_ = proxy.server.Close()
+	})
+	logger.Info("Started stallable proxy", "addr", proxy.addr, "target", target)
+	return proxy
+}
+
+// URL returns the address clients should connect to instead of the target.
+func (p *StallableProxy) URL() string {
+	return p.addr
+}
+
+// Stall holds all new requests open without a response until Resume is called.
+// Idempotent.
+func (p *StallableProxy) Stall() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.stallCh == nil {
+		p.stallCh = make(chan struct{})
+	}
+}
+
+// Resume releases all held requests and returns to passthrough mode. Idempotent.
+func (p *StallableProxy) Resume() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.stallCh != nil {
+		close(p.stallCh)
+		p.stallCh = nil
+	}
+}
+
+// StalledRequests returns the number of requests that have been held by the
+// stall so far. Tests use it to assert traffic actually flowed through the
+// stalled proxy, so a mis-wired proxy cannot pass vacuously.
+func (p *StallableProxy) StalledRequests() int64 {
+	return p.stalledRequests.Load()
+}
+
+func (p *StallableProxy) currentStall() chan struct{} {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.stallCh
+}
+
+// StallableFollowSourceProxies routes the follow-source endpoint of every L2 CL
+// that has one through its own StallableProxy, so tests can stall follow-source
+// RPC traffic per chain while the follow source itself keeps running.
+type StallableFollowSourceProxies struct {
+	mu      sync.Mutex
+	proxies map[eth.ChainID]*StallableProxy
+}
+
+func NewStallableFollowSourceProxies() *StallableFollowSourceProxies {
+	return &StallableFollowSourceProxies{
+		proxies: make(map[eth.ChainID]*StallableProxy),
+	}
+}
+
+// L2CLOption returns the option that interposes a proxy in front of
+// cfg.FollowSource. CLs without a follow source are left untouched.
+func (s *StallableFollowSourceProxies) L2CLOption() L2CLOption {
+	return L2CLOptionFn(func(p devtest.T, target ComponentTarget, cfg *L2CLConfig) {
+		if cfg.FollowSource == "" {
+			return
+		}
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		_, exists := s.proxies[target.ChainID]
+		p.Require().False(exists, "follow-source proxy already registered for chain %s", target.ChainID)
+		proxy := StartStallableProxy(p, "follow-source-"+target.String(), cfg.FollowSource)
+		s.proxies[target.ChainID] = proxy
+		cfg.FollowSource = proxy.URL()
+	})
+}
+
+// ForChain returns the proxy interposed for the given chain's follow-source CL,
+// failing the test if none was wired (e.g. the option was not applied).
+func (s *StallableFollowSourceProxies) ForChain(p devtest.T, chainID eth.ChainID) *StallableProxy {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	proxy, ok := s.proxies[chainID]
+	p.Require().True(ok, "no follow-source proxy wired for chain %s", chainID)
+	return proxy
+}

--- a/op-devstack/sysgo/stallable_proxy.go
+++ b/op-devstack/sysgo/stallable_proxy.go
@@ -1,6 +1,8 @@
 package sysgo
 
 import (
+	"bytes"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -19,15 +21,15 @@ import (
 // or the proxy is resumed. It lets tests simulate an unresponsive upstream
 // without stopping the upstream itself.
 type StallableProxy struct {
-	name   string
-	target *url.URL
 	server *http.Server
 	addr   string
 
 	mu      sync.Mutex
 	stallCh chan struct{} // non-nil while stalled; closed by Resume
 
-	stalledRequests atomic.Int64
+	stalledRequests      atomic.Int64
+	concurrentStalled    atomic.Int64
+	maxConcurrentStalled atomic.Int64
 }
 
 // StartStallableProxy starts a StallableProxy in front of targetURL. The proxy
@@ -41,9 +43,7 @@ func StartStallableProxy(p devtest.T, name string, targetURL string) *StallableP
 
 	logger := p.Logger().New("component", "stallable-proxy-"+name)
 	proxy := &StallableProxy{
-		name:   name,
-		target: target,
-		addr:   "http://" + listener.Addr().String(),
+		addr: "http://" + listener.Addr().String(),
 	}
 	rp := httputil.NewSingleHostReverseProxy(target)
 	proxy.server = &http.Server{
@@ -53,14 +53,32 @@ func StartStallableProxy(p devtest.T, name string, targetURL string) *StallableP
 		ReadHeaderTimeout: 5 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if ch := proxy.currentStall(); ch != nil {
+				// Consume the body before stalling: the net/http server only
+				// watches for client disconnect (canceling r.Context()) once
+				// the request body has been read to EOF. Buffer it so the
+				// request can still be proxied if the stall is resumed.
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					return // client already gone
+				}
+				r.Body = io.NopCloser(bytes.NewReader(body))
 				n := proxy.stalledRequests.Add(1)
-				logger.Info("Stalling proxied request", "target", target, "stalled_requests", n)
+				cur := proxy.concurrentStalled.Add(1)
+				for {
+					prevMax := proxy.maxConcurrentStalled.Load()
+					if cur <= prevMax || proxy.maxConcurrentStalled.CompareAndSwap(prevMax, cur) {
+						break
+					}
+				}
+				logger.Info("Stalling proxied request", "target", target, "stalled_requests", n, "concurrent", cur)
 				select {
 				case <-r.Context().Done():
 					// Client gave up (e.g. RPC call timeout) or the server is closing.
+					proxy.concurrentStalled.Add(-1)
 					return
 				case <-ch:
 					// Resumed; serve the request after all.
+					proxy.concurrentStalled.Add(-1)
 				}
 			}
 			rp.ServeHTTP(w, r)
@@ -106,6 +124,14 @@ func (p *StallableProxy) Resume() {
 // stalled proxy, so a mis-wired proxy cannot pass vacuously.
 func (p *StallableProxy) StalledRequests() int64 {
 	return p.stalledRequests.Load()
+}
+
+// MaxConcurrentStalledRequests returns the highest number of requests that were
+// held open by the stall at the same moment. Tests use it to pin down
+// single-flight client behavior: a client that fires a new request on every
+// tick while an earlier one is still blocked drives this above one.
+func (p *StallableProxy) MaxConcurrentStalledRequests() int64 {
+	return p.maxConcurrentStalled.Load()
 }
 
 func (p *StallableProxy) currentStall() chan struct{} {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -140,7 +141,6 @@ func NewDriver(
 		stateReq:             make(chan chan struct{}),
 		forceReset:           make(chan chan struct{}, 10),
 		driverConfig:         driverCfg,
-		syncConfig:           syncCfg,
 		driverCtx:            driverCtx,
 		driverCancel:         driverCancel,
 		log:                  log,
@@ -173,8 +173,6 @@ type Driver struct {
 	// Driver config: verifier and sequencer settings.
 	// May not be modified after starting the Driver.
 	driverConfig *Config
-
-	syncConfig *sync.Config
 
 	sequencer sequencing.SequencerIface
 
@@ -296,12 +294,15 @@ func (s *Driver) eventLoop() {
 	// from an external source. Since the normal derivation pipeline is inactive, reorg
 	// detection must be performed here instead.
 	var upstreamSyncTickerC <-chan time.Time
+	var upstreamSyncResultCh chan *sources.FollowStatus
 	if followSource {
 		upstreamSyncTickerCheckInterval := time.Duration(s.SyncDeriver.Config.BlockTime) * time.Second * 2
 		upstreamSyncTicker := time.NewTicker(upstreamSyncTickerCheckInterval)
 		upstreamSyncTickerC = upstreamSyncTicker.C
+		upstreamSyncResultCh = make(chan *sources.FollowStatus, 1)
 		defer upstreamSyncTicker.Stop()
 	}
+	upstreamSyncInFlight := false
 
 	for {
 		if s.driverCtx.Err() != nil { // don't try to schedule/handle more work when we are closing.
@@ -333,7 +334,20 @@ func (s *Driver) eventLoop() {
 				s.log.Warn("failed to check for unsafe L2 blocks to sync", "err", err)
 			}
 		case <-upstreamSyncTickerC:
-			s.followUpstream()
+			if !upstreamSyncInFlight && !s.SyncDeriver.Engine.IsEngineInitialELSyncing() {
+				upstreamSyncInFlight = true
+				s.startFollowUpstreamFetch(upstreamSyncResultCh)
+			}
+		case status := <-upstreamSyncResultCh:
+			upstreamSyncInFlight = false
+			if status != nil && !s.SyncDeriver.Engine.IsEngineInitialELSyncing() {
+				if status.CurrentL1 != (eth.L1BlockRef{}) {
+					s.log.Debug("Follow Upstream: Inject L1 Info", "currentL1", status.CurrentL1)
+					s.emitter.Emit(s.driverCtx, derive.DeriverL1StatusEvent{Origin: status.CurrentL1})
+				}
+				s.metrics.RecordFollowSourceRequest("success")
+				s.SyncDeriver.Engine.FollowSource(status.SafeL2, status.LocalSafeL2, status.FinalizedL2)
+			}
 		case <-s.sched.NextDelayedStep():
 			s.sched.AttemptStep(s.driverCtx)
 		case <-s.sched.NextStep():
@@ -469,49 +483,53 @@ func (s *Driver) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPa
 	s.SyncDeriver.OnUnsafeL2Payload(ctx, payload)
 }
 
-// followUpstream reconciles the local engine state with upstream sources when
-// derivation is disabled (UnsafeOnly).
-//
-// In this mode, the driver does not derive L2 from L1. Instead, it:
-// Uses the followTracker to fetch external safe / finalized / CurrentL1,
-// validates that the external state is sane (e.g. finalized is not ahead
-// of safe), and then updates the engine via FollowSource.
-//
-// This function is intended to be called periodically by a ticker and is a
-// no-op while derivation is enabled or the EL is still performing its initial
-// sync.
-func (s *Driver) followUpstream() {
-	if !s.syncConfig.FollowSourceEnabled() {
-		return
-	}
-	if s.SyncDeriver.Engine.IsEngineInitialELSyncing() {
-		// Do not interfere with initial EL Sync and wait until it is done
-		return
-	}
+// startFollowUpstreamFetch runs the upstream request sequence in a background
+// goroutine so the driver event loop stays responsive, and always delivers
+// exactly one result (nil on failure) to resultCh, unless the driver is closing.
+// The event loop relies on that delivery to clear its in-flight flag, and must
+// keep at most one fetch in flight so results cannot arrive out of order.
+func (s *Driver) startFollowUpstreamFetch(resultCh chan<- *sources.FollowStatus) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		status := s.followUpstream()
+		select {
+		case resultCh <- status:
+		case <-s.driverCtx.Done():
+		}
+	}()
+}
+
+// followUpstream fetches and validates external safe, finalized, and CurrentL1
+// references when derivation is disabled (UnsafeOnly). It returns nil if the
+// fetch fails or the external state is inconsistent; a non-nil status has
+// passed all checks. It performs no engine or event side effects — the driver
+// event loop applies those when it receives the returned status.
+func (s *Driver) followUpstream() *sources.FollowStatus {
 	status, err := s.upstreamFollowSource.GetFollowStatus(s.driverCtx)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to fetch status", "err", err)
 		s.metrics.RecordFollowSourceRequest("error_fetch_status")
-		return
+		return nil
 	}
 	s.log.Info("Follow Upstream", "eSafe", status.SafeL2, "eLocalSafe", status.LocalSafeL2, "eFinalized", status.FinalizedL2, "eCurrentL1", status.CurrentL1)
 	if status.SafeL2.Number > status.LocalSafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, safe is ahead of local safe",
 			"safe", status.SafeL2.Number, "localSafe", status.LocalSafeL2.Number)
 		s.metrics.RecordFollowSourceRequest("error_invalid_state")
-		return
+		return nil
 	}
 	if status.FinalizedL2.Number > status.SafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, finalized is ahead of safe", "safe", status.SafeL2.Number, "finalized", status.FinalizedL2.Number)
 		s.metrics.RecordFollowSourceRequest("error_invalid_state")
-		return
+		return nil
 	}
 
 	eLocalSafeL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.LocalSafeL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external local safe head", "err", err)
 		s.metrics.RecordFollowSourceRequest("error_l1_lookup")
-		return
+		return nil
 	}
 	if eLocalSafeL1Origin.Hash != status.LocalSafeL2.L1Origin.Hash {
 		s.log.Warn(
@@ -520,14 +538,14 @@ func (s *Driver) followUpstream() {
 			"expected", status.LocalSafeL2.L1Origin,
 		)
 		s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
-		return
+		return nil
 	}
 
 	eSafeL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.SafeL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external safe head", "err", err)
 		s.metrics.RecordFollowSourceRequest("error_l1_lookup")
-		return
+		return nil
 	}
 	if eSafeL1Origin.Hash != status.SafeL2.L1Origin.Hash {
 		s.log.Warn(
@@ -536,14 +554,14 @@ func (s *Driver) followUpstream() {
 			"expected", status.SafeL2.L1Origin,
 		)
 		s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
-		return
+		return nil
 	}
 
 	eFinalizedL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.FinalizedL2.L1Origin.Number)
 	if err != nil {
 		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external finalized head", "err", err)
 		s.metrics.RecordFollowSourceRequest("error_l1_lookup")
-		return
+		return nil
 	}
 	if eFinalizedL1Origin.Hash != status.FinalizedL2.L1Origin.Hash {
 		s.log.Warn(
@@ -552,7 +570,7 @@ func (s *Driver) followUpstream() {
 			"expected", status.FinalizedL2.L1Origin,
 		)
 		s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
-		return
+		return nil
 	}
 
 	if (status.CurrentL1 == eth.L1BlockRef{}) {
@@ -562,7 +580,7 @@ func (s *Driver) followUpstream() {
 		if err != nil {
 			s.log.Warn("Follow Upstream: Failed to look up external currentL1", "err", err)
 			s.metrics.RecordFollowSourceRequest("error_l1_lookup")
-			return
+			return nil
 		}
 		if eCurrentL1.Hash != status.CurrentL1.Hash {
 			s.log.Warn(
@@ -571,13 +589,8 @@ func (s *Driver) followUpstream() {
 				"expected", status.CurrentL1,
 			)
 			s.metrics.RecordFollowSourceRequest("error_l1_mismatch")
-			return
+			return nil
 		}
-
-		s.log.Debug("Follow Upstream: Inject L1 Info", "currentL1", status.CurrentL1)
-		s.emitter.Emit(s.driverCtx, derive.DeriverL1StatusEvent{Origin: status.CurrentL1})
 	}
-	// Only reach this point if all L1 checks passed
-	s.metrics.RecordFollowSourceRequest("success")
-	s.SyncDeriver.Engine.FollowSource(status.SafeL2, status.LocalSafeL2, status.FinalizedL2)
+	return status
 }

--- a/op-node/rollup/driver/follow_upstream_test.go
+++ b/op-node/rollup/driver/follow_upstream_test.go
@@ -1,0 +1,129 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+type blockingUpstreamFollowSource struct {
+	status  *sources.FollowStatus
+	err     error
+	started chan struct{}
+	release chan struct{}
+	calls   []uint64
+}
+
+func (s *blockingUpstreamFollowSource) GetFollowStatus(ctx context.Context) (*sources.FollowStatus, error) {
+	s.started <- struct{}{}
+	select {
+	case <-s.release:
+		return s.status, s.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (s *blockingUpstreamFollowSource) L1BlockRefByNumber(_ context.Context, number uint64) (eth.L1BlockRef, error) {
+	s.calls = append(s.calls, number)
+	return eth.L1BlockRef{Number: number, Hash: common.Hash{byte(number)}}, nil
+}
+
+// followMetricsStub records follow-source request outcomes; all other Metrics
+// methods panic via the nil embedded interface if called.
+type followMetricsStub struct {
+	Metrics
+	results []string
+}
+
+func (m *followMetricsStub) RecordFollowSourceRequest(result string) {
+	m.results = append(m.results, result)
+}
+
+func TestStartFollowUpstreamFetchIsAsync(t *testing.T) {
+	ref := func(number uint64) eth.BlockID {
+		return eth.BlockID{Number: number, Hash: common.Hash{byte(number)}}
+	}
+	source := &blockingUpstreamFollowSource{
+		status: &sources.FollowStatus{
+			LocalSafeL2: eth.L2BlockRef{Number: 3, L1Origin: ref(1)},
+			SafeL2:      eth.L2BlockRef{Number: 2, L1Origin: ref(2)},
+			FinalizedL2: eth.L2BlockRef{Number: 1, L1Origin: ref(3)},
+			CurrentL1:   eth.L1BlockRef{Number: 4, Hash: common.Hash{4}},
+		},
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	driver := &Driver{
+		driverCtx:            ctx,
+		upstreamFollowSource: source,
+		log:                  testlog.Logger(t, log.LevelError),
+		metrics:              &followMetricsStub{},
+	}
+	resultCh := make(chan *sources.FollowStatus, 1)
+
+	driver.startFollowUpstreamFetch(resultCh)
+	select {
+	case <-source.started:
+	case <-time.After(time.Second):
+		t.Fatal("upstream status request did not start")
+	}
+	select {
+	case <-resultCh:
+		t.Fatal("fetch completed while the upstream request was blocked")
+	default:
+	}
+
+	close(source.release)
+	select {
+	case status := <-resultCh:
+		require.Same(t, source.status, status)
+	case <-time.After(time.Second):
+		t.Fatal("upstream fetch did not complete")
+	}
+	driver.wg.Wait()
+	require.Equal(t, []uint64{1, 2, 3, 4}, source.calls)
+}
+
+// TestStartFollowUpstreamFetchDeliversNilOnError pins the liveness contract the
+// event loop's single-flight flag depends on: a failed fetch must still deliver
+// a (nil) result, so the flag is cleared and follow-source keeps retrying.
+func TestStartFollowUpstreamFetchDeliversNilOnError(t *testing.T) {
+	source := &blockingUpstreamFollowSource{
+		err:     errors.New("upstream unavailable"),
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	close(source.release)
+	metrics := &followMetricsStub{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	driver := &Driver{
+		driverCtx:            ctx,
+		upstreamFollowSource: source,
+		log:                  testlog.Logger(t, log.LevelError),
+		metrics:              metrics,
+	}
+	resultCh := make(chan *sources.FollowStatus, 1)
+
+	driver.startFollowUpstreamFetch(resultCh)
+	select {
+	case status := <-resultCh:
+		require.Nil(t, status)
+	case <-time.After(time.Second):
+		t.Fatal("failed fetch did not deliver a result")
+	}
+	driver.wg.Wait()
+	require.Equal(t, []string{"error_fetch_status"}, metrics.results)
+	require.Empty(t, source.calls)
+}


### PR DESCRIPTION
## Summary

Two commits, structured so the regression is directly demonstrable:

1. **`op-acceptance-tests`: regression test (fails at that commit).** A stallable reverse proxy is interposed in front of a light CL sequencer's follow-source endpoint and switched to hold all requests without responding. The test requires unsafe block production to continue with no gap over 8s during a 30s observation window — strictly below the follow-source client's 10s call timeout (the guaranteed production dead window when follow requests block the driver loop), well above the healthy 2s cadence.
2. **`op-node`: the fix (makes the test pass).** Run the follow-source status + L1 request sequence in a background goroutine, keep at most one fetch in flight (ticks during a fetch are coalesced), and deliver validated status snapshots back to the driver loop, which applies all side effects (L1 status event, success metric, engine `FollowSource`) in the original order.

To see the regression: check out the first commit and run the test — block production freezes the moment the follow tick fires.

## Why

`followUpstream` performs its upstream status request and up to four sequential L1 lookups directly in the driver's main `select` loop. Slow or unresponsive RPCs prevent the loop from servicing sequencer actions and block production. Request order, validation checks, failure metrics, and RPC client timeouts are unchanged; no caching or request deduplication is introduced. Engine reconciliation intentionally stays on the driver loop.

## Verification

Both runs on this machine (macOS, sysgo devstack, op-reth ELs):

- **Without fix** (first commit): `FAIL` in 42s — `chain 901 latest head stalled at block 17: no new block for 8.006s (max allowed 8s)`. The proxy held the follow request, the RPC client timed out at exactly +10s, and production froze for the full window.
- **With fix** (second commit): `PASS` — 15 blocks in the 30s window (perfect 2s cadence) while 3 follow-source requests were held by the stalled proxy (each timing out client-side at 10s, single-flight coalescing the ticks in between).
- `go test -race ./op-node/rollup/driver ./op-node/node` — unit tests pin the async delivery, the L1 request order, and the exactly-one-result-per-fetch liveness contract the single-flight flag depends on.

## Test infra added (first commit)

- `sysgo.StallableProxy` / `StallableFollowSourceProxies`: reverse proxy that can hold requests open on demand, wired via an `L2CLOption` that wraps any CL's follow-source URL; counts held requests so the test cannot pass vacuously
- the light-sequencer preset accepts `GlobalL2CLOptions` (its runtime already plumbed them; only the option-validation mask blocked them)
- `dsl.L2ELNode.KeptAdvancing`: requires a head to advance continuously — unlike `Advanced`, a stall followed by a catch-up burst is a failure

Supersedes #21757 (same op-node change, previously on a fork) with review fixups folded in: removed the now write-only `Driver.syncConfig` field, documented the fetch/apply split contract, added unit tests for the nil-on-failure delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)