### PR TITLE
docs: surface node system requirements on the node-operator overview

### DIFF
--- a/docs/public-docs/node-operators/overview.mdx
+++ b/docs/public-docs/node-operators/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: Node Operator Overview
 description: Learn about running nodes on OP Stack networks.
+diataxis: explanation
 ---
 
 ## Overview
@@ -14,6 +15,20 @@ The information provided in this section covers standard configurations and feat
 Running your own node gives you the benefit of trustless verification, enhanced privacy, and gives you local access to the blockchain.
 However, it also requires time and resources to set up and maintain.
 So you should consider your goals and use cases before deciding to run a node because there are many third-party RPC providers available.
+
+## System requirements
+
+Before you start, check that your machine can handle the network and node type you're targeting.
+Requirements scale with both:
+
+*   **RAM:** 16GB is the suggested minimum for an OP Mainnet node.
+*   **CPU:** A reasonably modern CPU.
+*   **Disk:** An SSD, sized to the network and node type. A full OP Mainnet node needs hundreds of gigabytes and grows steadily; an archive node needs multiple terabytes and grows much faster, so use an NVMe SSD for archive nodes.
+
+Test networks are far lighter than OP Mainnet — an OP Sepolia full node syncs into tens of gigabytes rather than hundreds.
+If you're setting up for the first time, start on OP Sepolia to validate your setup before committing OP Mainnet-scale disk.
+
+For the current OP Mainnet storage figures and their growth rates, see the [hardware requirements](/node-operators/tutorials/run-node-from-source#hardware-requirements) in the from-source tutorial.
 
 ## Node Architecture
 


### PR DESCRIPTION
## What and why

A prospective node operator's first practical question is "what machine do I need?" The docs answer it — but only inside `node-operators/tutorials/run-node-from-source.mdx`. The **recommended getting-started path** (`tutorials/node-from-docker.mdx`) and the **section overview** state no hardware requirements at all, so an operator who follows the recommended Docker path never sees requirements before starting, and the overview — where they decide whether running a node is feasible for them — is silent on it.

This PR adds a concise **System requirements** section to `node-operators/overview.mdx`, surfacing the answer at the orientation point regardless of which install path the reader picks:

- RAM / CPU baseline and full-node vs archive-node SSD sizing.
- A steer that OP Sepolia is far lighter than OP Mainnet, so newcomers can validate their setup before committing Mainnet-scale disk.
- A cross-link to the from-source tutorial's fuller hardware section for the current, dated storage figures — rather than duplicating drift-prone numbers on a second page.

It also declares the page's Diátaxis quadrant (`diataxis: explanation`) in frontmatter, the durable record of the structural classification.

## Source grounding

Every figure is grounded in OP's own current docs:

- RAM (16GB minimum) and "reasonably modern CPU" — `docs/public-docs/node-operators/tutorials/run-node-from-source.mdx:20-21`.
- Full-node (~700GB, steady growth) vs archive-node (~14TB, faster growth, NVMe recommended) disk sizing — `run-node-from-source.mdx:28-29`. The overview states these qualitatively (hundreds of GB vs multiple TB) and links to the dated figures rather than restating exact numbers that would drift independently.
- OP Sepolia is far smaller than OP Mainnet (tens of GB vs hundreds) — `docs/public-docs/node-operators/tutorials/node-from-docker.mdx:181`.

## Reviewer checklist

- [ ] The RAM/CPU/disk summary matches the from-source tutorial's hardware section.
- [ ] The `#hardware-requirements` anchor link resolves to the from-source tutorial heading.
- [ ] Section placement (after "Why Run a Node?", before "Node Architecture") reads as the natural decision point.
- [ ] `diataxis: explanation` is the correct quadrant for this orientation page.

## Reviewer consideration

The exact storage figures in the from-source tutorial are dated "as of June 2025." This PR deliberately links to them rather than copying them onto the overview, so there is one canonical place to refresh. If the team would rather show the numbers inline on the overview too, that is an easy follow-up.

---

Tracks ethereum-optimism/solutions#921 · part of the Diátaxis docs-structure backlog (ethereum-optimism/solutions#790). Context for this experiment: [`projects/docs-improver/README.md`](https://github.com/ethereum-optimism/solutions/blob/main/projects/docs-improver/README.md).

🤖 Drafted by the docs-improver agent — review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
