### PR TITLE
test(op-devstack): support explicit super game routing

### DIFF
--- a/op-acceptance-tests/tests/interop/super-at-genesis/super_dispute_game_at_initial_deployment_test.go
+++ b/op-acceptance-tests/tests/interop/super-at-genesis/super_dispute_game_at_initial_deployment_test.go
@@ -16,7 +16,9 @@ func TestSuperPermissionedDisputeGameInstalledAtInitialDeployment(gt *testing.T)
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainInteropSuperRootAtGenesis(t)
 
-	sys.StandardBridge(sys.L2ChainA).VerifyRespectedGameType(gameTypes.SuperPermissionedGameType)
+	bridge := sys.StandardBridge(sys.L2ChainA)
+	bridge.VerifyRespectedGameType(gameTypes.SuperPermissionedGameType)
+	t.Require().Zero(bridge.GameResolutionDelay(), "SuperPermissioned games resolve during initialization")
 	sys.DisputeGameFactory().VerifyGameImplPresent(gameTypes.SuperPermissionedGameType)
 	sys.DisputeGameFactory().VerifyGameImplAbsent(gameTypes.PermissionedGameType)
 }

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -102,6 +102,9 @@ func NewStandardBridge(t devtest.T, l2Network *L2Network, l1EL *L1ELNode) *Stand
 
 func (b *StandardBridge) GameResolutionDelay() time.Duration {
 	gameType := b.RespectedGameType()
+	if gameTypes.GameType(gameType) == gameTypes.SuperPermissionedGameType {
+		return 0
+	}
 	gameImplAddr, err := contractio.Read(b.disputeGameFactory.GameImpls(gameType), b.ctx)
 	b.require.NoErrorf(err, "failed to get implementation for game type %v", gameType)
 	game := bindings.NewBindings[bindings.FaultDisputeGame](bindings.WithClient(b.l1Client.EthClient()), bindings.WithTo(gameImplAddr), bindings.WithTest(b.t))

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -75,6 +75,9 @@ func (g *FaultDisputeGame) L2SequenceNumber() uint64 {
 }
 
 func (g *FaultDisputeGame) StartingL2SequenceNumber() uint64 {
+	if g.GameType() == gameTypes.SuperCannonKonaGameType {
+		return contract.Read(g.game.StartingSequenceNumber())
+	}
 	return contract.Read(g.game.StartingBlockNumber())
 }
 

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -167,6 +167,13 @@ func WithFactoryAddress(addr common.Address) Option {
 	}
 }
 
+func WithSuperRPC(endpoint string) Option {
+	return func(_ context.Context, c *config.Config) error {
+		c.SuperRPC = endpoint
+		return nil
+	}
+}
+
 // WithPermissionedCannonConfig wires the Cannon VM config used by the PermissionedCannon game
 // type. The legacy fault-proof program is no longer referenced — the prestate is a dummy and the
 // server is unused.

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -104,7 +104,8 @@ func addGameTypesForRuntime(
 
 	l1PAO, l1PAOKey := resolveL1ProxyAdminOwner(t, keys, l1ChainID)
 
-	chainOps := devkeys.ChainOperatorKeys(l1ChainID.ToBig())
+	// Operator roles are scoped to the OP chain, even though the game contracts use them on L1.
+	chainOps := devkeys.ChainOperatorKeys(l2Net.ChainID().ToBig())
 	proposer, err := keys.Address(chainOps(devkeys.ProposerRole))
 	require.NoError(err, "failed to get proposer address")
 	challenger, err := keys.Address(chainOps(devkeys.ChallengerRole))
@@ -117,6 +118,7 @@ func addGameTypesForRuntime(
 	initBond := eth.GWei(80_000_000).ToBig() // 0.08 ETH
 
 	cannonKonaPrestate := PrestateForGameType(t, gameTypes.CannonKonaGameType)
+	superCannonKonaPrestate := PrestateForGameType(t, gameTypes.SuperCannonKonaGameType)
 
 	// Download the contracts artifacts once; reused for the mock verifier deploy and the upgrade.
 	artifactsFS, err := artifacts.Download(t.Ctx(), LocalArtifacts(t), ioutil.NoopProgressor(), t.TempDir())
@@ -168,8 +170,22 @@ func addGameTypesForRuntime(
 				AbsolutePrestate: cannonKonaPrestate,
 			},
 		},
-		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypeSuperPermissioned},
-		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypeSuperCannonKona},
+		{
+			Enabled:  enabled[gameTypes.SuperPermissionedGameType],
+			InitBond: new(big.Int),
+			GameType: embedded.GameTypeSuperPermissioned,
+			SuperPermissionedDisputeGameConfig: &embedded.SuperPermissionedDisputeGameConfig{
+				Proposer: proposer,
+			},
+		},
+		{
+			Enabled:  enabled[gameTypes.SuperCannonKonaGameType],
+			InitBond: initBond,
+			GameType: embedded.GameTypeSuperCannonKona,
+			FaultDisputeGameConfig: &embedded.FaultDisputeGameConfig{
+				AbsolutePrestate: superCannonKonaPrestate,
+			},
+		},
 		{
 			Enabled:             enabled[gameTypes.ZKDisputeGameType],
 			InitBond:            initBond,
@@ -214,6 +230,8 @@ func PrestateForGameType(t devtest.CommonT, gameType gameTypes.GameType) common.
 	switch gameType {
 	case gameTypes.CannonKonaGameType:
 		return getCannonKonaAbsolutePrestate(t)
+	case gameTypes.SuperCannonKonaGameType:
+		return getAbsolutePrestate(t, "rust/kona/prestate-artifacts-cannon-interop/prestate-proof.json")
 	default:
 		t.Require().Fail("no prestate available for game type", gameType)
 		return common.Hash{}

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -2,6 +2,7 @@ package sysgo
 
 import (
 	"context"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -11,6 +12,8 @@ import (
 	opchallenger "github.com/ethereum-optimism/optimism/op-challenger"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	challengermetrics "github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	sharedchallenger "github.com/ethereum-optimism/optimism/op-devstack/shared/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/setuputils"
@@ -61,7 +64,10 @@ func newSingleChainNodeRuntime(name string, isSequencer bool, el L2ELNode, cl L2
 
 func newDefaultSingleChainWorld(t devtest.T, keys devkeys.Keys, cfg PresetConfig) singleChainRuntimeWorld {
 	if cfg.InteropAtGenesis {
-		l1Net, l2Net, depSet, fullCfgSet := buildSingleChainWorldWithInterop(t, keys, true, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...)
+		deployerOpts := append([]DeployerOption{
+			WithDevFeatureEnabled(devfeatures.OptimismPortalInteropFlag),
+		}, cfg.DeployerOptions...)
+		l1Net, l2Net, depSet, fullCfgSet := buildSingleChainWorldWithInterop(t, keys, true, cfg.LocalContractArtifactsPath, deployerOpts...)
 		return singleChainRuntimeWorld{
 			L1Network: l1Net,
 			L2Network: l2Net,
@@ -88,6 +94,11 @@ func startDefaultSingleChainPrimary(
 	jwtSecret [32]byte,
 	cfg PresetConfig,
 ) singleChainPrimaryRuntime {
+	safeDBPath := filepath.Join(t.TempDirWithPrefix("l2-safe-db-"+world.L2Network.ChainID().String()), "safe-head.db")
+	l2CLOptions := []L2CLOption{L2CLOptionFn(func(_ devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
+		cfg.SafeDBPath = safeDBPath
+	})}
+	l2CLOptions = append(l2CLOptions, cfg.GlobalL2CLOptions...)
 	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, NewELNodeIdentity(0))
 	if world.Interop != nil {
 		l2CL := startL2CLNode(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
@@ -96,11 +107,11 @@ func startDefaultSingleChainPrimary(
 			NoDiscovery:   true,
 			EnableReqResp: true,
 			DependencySet: world.Interop.DependencySet,
-			L2CLOptions:   cfg.GlobalL2CLOptions,
+			L2CLOptions:   l2CLOptions,
 		})
 		return singleChainPrimaryRuntime{EL: l2EL, CL: l2CL}
 	}
-	l2CL := startSequencerCL(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, cfg.GlobalL2CLOptions)
+	l2CL := startSequencerCL(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLOptions)
 	return singleChainPrimaryRuntime{
 		EL: l2EL,
 		CL: l2CL,
@@ -132,6 +143,8 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 		l2Batcher = startMinimalBatcher(t, keys, world.L2Network, l1EL, primary.CL, primary.EL, cfg.BatcherOptions...)
 	}
 
+	applyMinimalGameTypeOptions(t, keys, world.L1Network, world.L2Network, l1EL, cfg.AddedGameTypes, cfg.RespectedGameTypes)
+
 	var l2Proposer *L2Proposer
 	if spec.StartProposer {
 		l2Proposer = startMinimalProposer(t, keys, world.L2Network, l1EL, primary.CL, cfg.ProposerOptions...)
@@ -139,10 +152,8 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 
 	var l2Challenger *L2Challenger
 	if spec.StartChallenger {
-		l2Challenger = startMinimalChallenger(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, primary.EL, primary.CL)
+		l2Challenger = startMinimalChallenger(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, primary.EL, primary.CL, cfg.AddedGameTypes)
 	}
-
-	applyMinimalGameTypeOptions(t, keys, world.L1Network, world.L2Network, l1EL, cfg.AddedGameTypes, cfg.RespectedGameTypes)
 
 	testSequencer := startTestSequencerForRPCs(t, keys, "test-sequencer", jwtPath, jwtSecret, world.L1Network, l1EL, l1CL, world.L2Network.ChainID(), primary.EL.UserRPC(), primary.CL.UserRPC())
 	testSequencerRuntime := newTestSequencerRuntime(testSequencer, spec.TestSequencer)
@@ -320,13 +331,20 @@ func startMinimalProposer(
 		DisputeGameType:              1,
 		ActiveSequencerCheckDuration: 5 * time.Second,
 		WaitNodeSync:                 false,
-		RollupRpc:                    l2CL.UserRPC(),
 	}
 	for _, opt := range proposerOpts {
 		if opt == nil {
 			continue
 		}
 		opt(NewComponentTarget("main", l2Net.ChainID()), proposerCLIConfig)
+	}
+	switch proposerCLIConfig.DisputeGameType {
+	case superPermissionedGameType, superCannonKonaGameType:
+		proposerCLIConfig.RollupRpc = ""
+		proposerCLIConfig.SuperNodeRpcs = []string{l2CL.UserRPC()}
+	default:
+		proposerCLIConfig.SuperNodeRpcs = nil
+		proposerCLIConfig.RollupRpc = l2CL.UserRPC()
 	}
 
 	proposer, err := ps.ProposerServiceFromCLIConfig(t.Ctx(), "0.0.1", proposerCLIConfig, logger)
@@ -357,6 +375,7 @@ func startMinimalChallenger(
 	l1CL *L1CLNode,
 	l2EL L2ELNode,
 	l2CL L2CLNode,
+	addedGameTypes []gameTypes.GameType,
 ) *L2Challenger {
 	require := t.Require()
 	challengerSecret, err := keys.Secret(devkeys.ChallengerRole.Key(l2Net.ChainID().ToBig()))
@@ -373,8 +392,29 @@ func startMinimalChallenger(
 		sharedchallenger.WithPermissionedCannonConfig(rollupCfgs, l1Net.genesis, l2Geneses),
 		sharedchallenger.WithPermissionedGameType(),
 		sharedchallenger.WithFastGames(),
-		sharedchallenger.WithCannonKonaConfig(rollupCfgs, l1Net.genesis, l2Geneses),
-		sharedchallenger.WithCannonKonaGameType(),
+	}
+	var cannonKonaEnabled, superCannonKonaEnabled bool
+	for _, gameType := range addedGameTypes {
+		cannonKonaEnabled = cannonKonaEnabled || gameType == gameTypes.CannonKonaGameType
+		superCannonKonaEnabled = superCannonKonaEnabled || gameType == gameTypes.SuperCannonKonaGameType
+	}
+	require.False(cannonKonaEnabled && superCannonKonaEnabled, "minimal challenger cannot use Cannon Kona and Super Cannon Kona simultaneously")
+	if !superCannonKonaEnabled {
+		options = append(options,
+			sharedchallenger.WithCannonKonaConfig(rollupCfgs, l1Net.genesis, l2Geneses),
+			sharedchallenger.WithCannonKonaGameType(),
+		)
+	} else {
+		dependencySet, err := depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
+			l2Net.ChainID(): {},
+		})
+		require.NoError(err)
+		options = append(options,
+			sharedchallenger.WithDepset(dependencySet),
+			sharedchallenger.WithCannonKonaInteropConfig(rollupCfgs, l1Net.genesis, l2Geneses),
+			sharedchallenger.WithSuperCannonKonaGameType(),
+			sharedchallenger.WithSuperRPC(l2CL.UserRPC()),
+		)
 	}
 	cfg, err := sharedchallenger.NewPreInteropChallengerConfig(
 		t.Ctx(),


### PR DESCRIPTION
Prepares the devstack runtime to exercise super dispute games before the default-on cutover in ethereum-optimism/optimism#21689.

Existing explicit configuration now routes game types 5 and 9 through the super proposal source, configures type 9 challengers with the super RPC and dependency set, and enables requested super game configurations during runtime upgrades. Empty/default configuration remains on the legacy output-root proposer and Cannon-Kona challenger. The change also supplies SafeDB by default while preserving caller overrides and adds the type-specific bridge/sequence-number DSL behavior.

Runtime upgrade proposer and challenger addresses are derived from the L2 chain ID. These are chain-operator identities for the OP chain, even though the dispute games using the addresses are deployed on L1. This matches the proposer/challenger services and the deployment-time L1 prefunding, which both derive those roles from the L2 chain ID.

This does not enable `SUPER_ROOT_GAMES_MIGRATION`, change feature defaults, modify allocations, or update contract/generated artifacts.

Checks:
- `mise exec -- go test -count=1 ./op-devstack/dsl/...`
- `mise exec -- go test -count=1 ./op-devstack/shared/challenger ./op-devstack/sysgo`
- `mise exec -- just test -run '^TestSuperPermissionedDisputeGameInstalledAtInitialDeployment$' ./op-acceptance-tests/tests/interop/super-at-genesis`