### PR TITLE
fix(op-proposer): select proposal source by root format

### DIFF
--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -15,22 +15,33 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
 
-var (
-	ErrMissingRollupRpc    = errors.New("missing rollup rpc")
-	ErrMissingSuperNodeRpc = errors.New("missing supernode rpc")
-	ErrMissingSource       = errors.New("missing proposal source rpc (rollup or supernode)")
-	ErrConflictingSource   = errors.New("must specify exactly one of rollup rpc or supernode rpc")
+type proposalRootFormat uint8
 
-	// preInteropGameTypes are game types that enforce having a rollup rpc.
-	// It is ok if this list isn't complete, unknown game types will allow either rollup or supernode.
-	// We just want to reduce foot-guns during the migration period.
-	preInteropGameTypes = []uint32{0, 1, 2, 3, 6, 254, 255, 1337}
-
-	// postInteropGameTypes are game types that enforce having a supernode rpc.
-	// It is ok if this list isn't complete, unknown game types will allow either rollup or supernode.
-	// We just want to reduce foot-guns during the migration period.
-	postInteropGameTypes = []uint32{4, 5}
+const (
+	unknownRootFormat proposalRootFormat = iota
+	outputRootFormat
+	superRootFormat
 )
+
+var (
+	ErrMissingRollupRpc  = errors.New("missing rollup rpc")
+	ErrMissingSource     = errors.New("missing proposal source rpc (rollup or supernode)")
+	ErrConflictingSource = errors.New("must specify exactly one of rollup rpc or supernode rpc")
+
+	outputRootGameTypes = []uint32{0, 1, 2, 3, 6, 8, 254, 255, 1337}
+	superRootGameTypes  = []uint32{5, 9}
+)
+
+func proposalRootFormatForGameType(gameType uint32) proposalRootFormat {
+	switch {
+	case slices.Contains(outputRootGameTypes, gameType):
+		return outputRootFormat
+	case slices.Contains(superRootGameTypes, gameType):
+		return superRootFormat
+	default:
+		return unknownRootFormat
+	}
+}
 
 // CLIConfig is a well typed config that is parsed from the CLI params.
 // This also contains config options for auxiliary services.
@@ -115,15 +126,10 @@ func (c *CLIConfig) Check() error {
 	if sourceCount > 1 {
 		return ErrConflictingSource
 	}
-	// Require rollup RPC for pre interop game types
-	if c.DGFAddress != "" && slices.Contains(preInteropGameTypes, c.DisputeGameType) && c.RollupRpc == "" {
+	if proposalRootFormatForGameType(c.DisputeGameType) == outputRootFormat && c.RollupRpc == "" {
 		return ErrMissingRollupRpc
 	}
-	// Require supernode RPC for post interop game types
-	if c.DGFAddress != "" && slices.Contains(postInteropGameTypes, c.DisputeGameType) && len(c.SuperNodeRpcs) == 0 {
-		return ErrMissingSuperNodeRpc
-	}
-	// For unknown game types, allow any source, but require at least one.
+	// All game types require a proposal source.
 	if sourceCount == 0 {
 		return ErrMissingSource
 	}

--- a/op-proposer/proposer/config_test.go
+++ b/op-proposer/proposer/config_test.go
@@ -1,6 +1,7 @@
 package proposer
 
 import (
+	"fmt"
 	"testing"
 
 	proposerFlags "github.com/ethereum-optimism/optimism/op-proposer/flags"
@@ -39,12 +40,10 @@ func TestNewConfigReadsSuperNodeRpcs(t *testing.T) {
 	}, cfg.SuperNodeRpcs)
 }
 
-func TestRollupRpc(t *testing.T) {
-	for _, gameType := range preInteropGameTypes {
-		t.Run("RequiredWithPreInteropGame", func(t *testing.T) {
+func TestRootFormatRPCValidation(t *testing.T) {
+	for _, gameType := range []uint32{0, 1, 2, 3, 6, 8, 254, 255, 1337} {
+		t.Run(fmt.Sprintf("OutputRootGameType-%d-RequiresRollupRPC", gameType), func(t *testing.T) {
 			cfg := validConfig()
-			cfg.DGFAddress = common.Address{0xaa}.Hex()
-			cfg.ProposalInterval = 20
 			cfg.RollupRpc = ""
 			cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
 			cfg.DisputeGameType = gameType
@@ -52,33 +51,17 @@ func TestRollupRpc(t *testing.T) {
 		})
 	}
 
-	t.Run("NotRequiredForOtherGameTypes", func(t *testing.T) {
-		cfg := validConfig()
-		cfg.DGFAddress = common.Address{0xaa}.Hex()
-		cfg.ProposalInterval = 20
-		cfg.RollupRpc = ""
-		cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
-		cfg.DisputeGameType = 492743
-		require.NoError(t, cfg.Check())
-	})
-}
-
-func TestSuperNodeRpc(t *testing.T) {
-	for _, gameType := range postInteropGameTypes {
-		t.Run("RequiredWithPostInteropGame", func(t *testing.T) {
+	for _, gameType := range []uint32{5, 9} {
+		t.Run(fmt.Sprintf("SuperRootGameType-%d-AcceptsRollupRPC", gameType), func(t *testing.T) {
 			cfg := validConfig()
-			cfg.DGFAddress = common.Address{0xaa}.Hex()
-			cfg.ProposalInterval = 20
 			cfg.RollupRpc = "http://localhost:8882/rollup"
 			cfg.SuperNodeRpcs = nil
 			cfg.DisputeGameType = gameType
-			require.ErrorIs(t, cfg.Check(), ErrMissingSuperNodeRpc)
+			require.NoError(t, cfg.Check())
 		})
 
-		t.Run("AllowedWithPostInteropGame", func(t *testing.T) {
+		t.Run(fmt.Sprintf("SuperRootGameType-%d-AcceptsSuperNodeRPC", gameType), func(t *testing.T) {
 			cfg := validConfig()
-			cfg.DGFAddress = common.Address{0xaa}.Hex()
-			cfg.ProposalInterval = 20
 			cfg.RollupRpc = ""
 			cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
 			cfg.DisputeGameType = gameType
@@ -86,15 +69,23 @@ func TestSuperNodeRpc(t *testing.T) {
 		})
 	}
 
-	t.Run("AllowedForOtherGameTypes", func(t *testing.T) {
-		cfg := validConfig()
-		cfg.DGFAddress = common.Address{0xaa}.Hex()
-		cfg.ProposalInterval = 20
-		cfg.RollupRpc = ""
-		cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
-		cfg.DisputeGameType = 492743
-		require.NoError(t, cfg.Check())
-	})
+	for _, gameType := range []uint32{4, 492743} {
+		t.Run(fmt.Sprintf("UnknownGameType-%d-AcceptsRollupRPC", gameType), func(t *testing.T) {
+			cfg := validConfig()
+			cfg.RollupRpc = "http://localhost:8882/rollup"
+			cfg.SuperNodeRpcs = nil
+			cfg.DisputeGameType = gameType
+			require.NoError(t, cfg.Check())
+		})
+
+		t.Run(fmt.Sprintf("UnknownGameType-%d-AcceptsSuperNodeRPC", gameType), func(t *testing.T) {
+			cfg := validConfig()
+			cfg.RollupRpc = ""
+			cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+			cfg.DisputeGameType = gameType
+			require.NoError(t, cfg.Check())
+		})
+	}
 }
 
 func TestDisallowRollupAndSuperNodeRPC(t *testing.T) {

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -129,8 +129,37 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 	}
 	ps.L1Client = l1Client
 
+	return ps.initProposalSource(ctx, cfg)
+}
+
+func (ps *ProposerService) initProposalSource(ctx context.Context, cfg *CLIConfig) error {
+	rootFormat := proposalRootFormatForGameType(cfg.DisputeGameType)
+	useSuperRootSource := rootFormat == superRootFormat ||
+		(rootFormat == unknownRootFormat && len(cfg.SuperNodeRpcs) != 0)
+
+	if useSuperRootSource {
+		urls := cfg.SuperNodeRpcs
+		if cfg.RollupRpc != "" {
+			urls = strings.Split(cfg.RollupRpc, ",")
+		}
+		clients := make([]source.SuperNodeClient, 0, len(urls))
+		for _, url := range urls {
+			cl, err := dial.DialSuperNodeClientWithTimeout(ctx, ps.Log, url,
+				client.WithRPCRecorder(ps.Metrics.NewRecorder("supernode")))
+			if err != nil {
+				return fmt.Errorf("failed to dial super root RPC client (%v): %w", url, err)
+			}
+			clients = append(clients, cl)
+		}
+		ps.ProposalSource = source.NewSuperNodeProposalSource(ps.Log, clients...)
+		return nil
+	}
+
 	if cfg.RollupRpc != "" {
-		var rollupProvider dial.RollupProvider
+		var (
+			rollupProvider dial.RollupProvider
+			err            error
+		)
 		if strings.Contains(cfg.RollupRpc, ",") {
 			rollupUrls := strings.Split(cfg.RollupRpc, ",")
 			rollupProvider, err = dial.NewActiveL2RollupProvider(ctx, rollupUrls, cfg.ActiveSequencerCheckDuration, dial.DefaultDialTimeout, ps.Log)
@@ -141,23 +170,10 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 			return fmt.Errorf("failed to build L2 endpoint provider: %w", err)
 		}
 		ps.ProposalSource = source.NewRollupProposalSource(rollupProvider)
+		return nil
 	}
-	if len(cfg.SuperNodeRpcs) != 0 {
-		var clients []source.SuperNodeClient
-		for _, url := range cfg.SuperNodeRpcs {
-			cl, err := dial.DialSuperNodeClientWithTimeout(ctx, ps.Log, url,
-				client.WithRPCRecorder(ps.Metrics.NewRecorder("supernode")))
-			if err != nil {
-				return fmt.Errorf("failed to dial supernode RPC client (%v): %w", url, err)
-			}
-			clients = append(clients, cl)
-		}
-		ps.ProposalSource = source.NewSuperNodeProposalSource(ps.Log, clients...)
-	}
-	if ps.ProposalSource == nil {
-		return ErrMissingSource
-	}
-	return nil
+
+	return ErrMissingSource
 }
 
 func (ps *ProposerService) initMetrics(cfg *CLIConfig) {

--- a/op-proposer/proposer/service_test.go
+++ b/op-proposer/proposer/service_test.go
@@ -1,0 +1,96 @@
+package proposer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+type jsonRPCRequest struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+}
+
+func TestProposalSourceUsesRootFormat(t *testing.T) {
+	testCases := []struct {
+		name           string
+		gameType       uint32
+		useRollupRPC   bool
+		expectedMethod string
+	}{
+		{name: "CannonKonaRollup", gameType: 8, useRollupRPC: true, expectedMethod: "optimism_outputAtBlock"},
+		{name: "SuperPermissionedRollup", gameType: 5, useRollupRPC: true, expectedMethod: "superroot_atTimestamp"},
+		{name: "SuperCannonKonaRollup", gameType: 9, useRollupRPC: true, expectedMethod: "superroot_atTimestamp"},
+		{name: "SuperCannonKonaSuperNode", gameType: 9, expectedMethod: "superroot_atTimestamp"},
+		{name: "UnknownRollupFallback", gameType: 492743, useRollupRPC: true, expectedMethod: "optimism_outputAtBlock"},
+		{name: "UnknownSuperNodeFallback", gameType: 492743, expectedMethod: "superroot_atTimestamp"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server, methods := recordingRPCServer(t)
+			cfg := validConfig()
+			cfg.L1EthRpc = server.URL
+			cfg.DisputeGameType = testCase.gameType
+			if testCase.useRollupRPC {
+				cfg.RollupRpc = server.URL
+				cfg.SuperNodeRpcs = nil
+			} else {
+				cfg.RollupRpc = ""
+				cfg.SuperNodeRpcs = []string{server.URL}
+			}
+
+			service := ProposerService{
+				Log:     testlog.Logger(t, log.LevelInfo),
+				Metrics: metrics.NoopMetrics,
+			}
+			require.NoError(t, service.initRPCClients(context.Background(), cfg))
+			t.Cleanup(func() {
+				service.L1Client.Close()
+				service.ProposalSource.Close()
+			})
+
+			_, err := service.ProposalSource.ProposalAtSequenceNum(context.Background(), 123)
+			require.Error(t, err)
+
+			select {
+			case method := <-methods:
+				require.Equal(t, testCase.expectedMethod, method)
+			case <-time.After(time.Second):
+				t.Fatal("proposal source did not make an RPC request")
+			}
+		})
+	}
+}
+
+func recordingRPCServer(t *testing.T) (*httptest.Server, <-chan string) {
+	t.Helper()
+	methods := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		methods <- request.Method
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      request.ID,
+			"error": map[string]any{
+				"code":    -32000,
+				"message": "recorded",
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+	return server, methods
+}


### PR DESCRIPTION
Select proposal adapters from the dispute game root format instead of the configured RPC flag. Type 8 now uses output roots; types 5 and 9 use `superroot_atTimestamp` from either a rollup RPC or supernode RPC, while unknown game types retain the existing flag-based fallback.

Adds configuration and JSON-RPC method-selection regressions.

Closes ethereum-optimism/optimism#21710

Tested with `go test ./op-proposer/... -count=1` and `just ./op-proposer/op-proposer`.