### PR TITLE
refactor(op-proposer): rename super root RPC config

### DIFF
--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -208,7 +208,7 @@ func startSuperProposer(
 		opt(NewComponentTarget(proposerName, proposerChainID), proposerCLIConfig)
 	}
 	require.NotEmpty(supernodeRPC, "need supernode RPC for super proposer")
-	proposerCLIConfig.SuperNodeRpcs = []string{supernodeRPC}
+	proposerCLIConfig.SuperRootRpcs = []string{supernodeRPC}
 
 	proposer, err := ps.ProposerServiceFromCLIConfig(t.Ctx(), "0.0.1", proposerCLIConfig, logger)
 	require.NoError(err)

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -346,9 +346,9 @@ func startMinimalProposer(
 	switch proposerCLIConfig.DisputeGameType {
 	case superPermissionedGameType, superCannonKonaGameType:
 		proposerCLIConfig.RollupRpc = ""
-		proposerCLIConfig.SuperNodeRpcs = []string{l2CL.UserRPC()}
+		proposerCLIConfig.SuperRootRpcs = []string{l2CL.UserRPC()}
 	default:
-		proposerCLIConfig.SuperNodeRpcs = nil
+		proposerCLIConfig.SuperRootRpcs = nil
 		proposerCLIConfig.RollupRpc = l2CL.UserRPC()
 	}
 

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	opservice "github.com/ethereum-optimism/optimism/op-service"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
@@ -16,8 +15,12 @@ import (
 
 const EnvVarPrefix = "OP_PROPOSER"
 
-func prefixEnvVars(name string) []string {
-	return opservice.PrefixEnvVar(EnvVarPrefix, name)
+func prefixEnvVars(names ...string) []string {
+	envs := make([]string, 0, len(names))
+	for _, name := range names {
+		envs = append(envs, EnvVarPrefix+"_"+name)
+	}
+	return envs
 }
 
 var (
@@ -32,10 +35,11 @@ var (
 		Usage:   "HTTP provider URL for the rollup node. A comma-separated list enables the active rollup provider.",
 		EnvVars: prefixEnvVars("ROLLUP_RPC"),
 	}
-	SuperNodeRpcsFlag = &cli.StringSliceFlag{
-		Name:    "supernode-rpcs",
-		Usage:   "HTTP provider URLs for the supernode instances. Multiple URLs can be provided to automatically fail over.",
-		EnvVars: prefixEnvVars("SUPERNODE_RPCS"),
+	SuperRootRpcsFlag = &cli.StringSliceFlag{
+		Name:    "superroot-rpcs",
+		Aliases: []string{"supernode-rpcs"},
+		Usage:   "HTTP provider URLs for super root RPC sources (op-node or op-supernode). Multiple URLs can be provided to automatically fail over.",
+		EnvVars: prefixEnvVars("SUPERROOT_RPCS", "SUPERNODE_RPCS"),
 	}
 
 	// Optional flags
@@ -89,7 +93,7 @@ var requiredFlags = []cli.Flag{
 
 var optionalFlags = []cli.Flag{
 	RollupRpcFlag,
-	SuperNodeRpcsFlag,
+	SuperRootRpcsFlag,
 	PollIntervalFlag,
 	AllowNonFinalizedFlag,
 	L2OutputHDPathFlag,

--- a/op-proposer/flags/flags_test.go
+++ b/op-proposer/flags/flags_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+func TestSuperRootRpcsFlagCompatibility(t *testing.T) {
+	require.Equal(t, []string{"superroot-rpcs", "supernode-rpcs"}, SuperRootRpcsFlag.Names())
+	require.Equal(t, []string{"OP_PROPOSER_SUPERROOT_RPCS", "OP_PROPOSER_SUPERNODE_RPCS"}, SuperRootRpcsFlag.EnvVars)
+}
+
 // TestOptionalFlagsDontSetRequired asserts that all flags deemed optional set
 // the Required field to false.
 func TestOptionalFlagsDontSetRequired(t *testing.T) {
@@ -67,7 +72,11 @@ func TestHasEnvVar(t *testing.T) {
 			})
 			envFlags := envFlagGetter.GetEnvVars()
 			require.True(t, ok, "must be able to cast the flag to an EnvVar interface")
-			require.Equal(t, 1, len(envFlags), "flags should have exactly one env var")
+			if flagName == SuperRootRpcsFlag.Name {
+				require.Len(t, envFlags, 2, "super root RPC flag should keep its legacy env var")
+			} else {
+				require.Len(t, envFlags, 1, "flags should have exactly one env var")
+			}
 		})
 	}
 }
@@ -81,6 +90,7 @@ func TestEnvVarFormat(t *testing.T) {
 			txmgr.FeeLimitMultiplierFlagName,
 			txmgr.TxSendTimeoutFlagName,
 			txmgr.TxNotInMempoolTimeoutFlagName,
+			SuperRootRpcsFlag.Name, // Has a legacy env var for backwards compatibility
 		}
 
 		t.Run(flagName, func(t *testing.T) {

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -17,17 +17,17 @@ import (
 
 var (
 	ErrMissingRollupRpc    = errors.New("missing rollup rpc")
-	ErrMissingSuperNodeRpc = errors.New("missing supernode rpc")
-	ErrMissingSource       = errors.New("missing proposal source rpc (rollup or supernode)")
-	ErrConflictingSource   = errors.New("must specify exactly one of rollup rpc or supernode rpc")
+	ErrMissingSuperRootRpc = errors.New("missing super root rpc")
+	ErrMissingSource       = errors.New("missing proposal source rpc (rollup or super root)")
+	ErrConflictingSource   = errors.New("must specify exactly one of rollup rpc or super root rpc")
 
-	// preInteropGameTypes are game types that enforce having a rollup rpc.
-	// It is ok if this list isn't complete, unknown game types will allow either rollup or supernode.
+	// preInteropGameTypes are game types that enforce having a rollup RPC.
+	// It is ok if this list isn't complete, unknown game types will allow either rollup or super root RPCs.
 	// We just want to reduce foot-guns during the migration period.
 	preInteropGameTypes = []uint32{0, 1, 2, 3, 6, 254, 255, 1337}
 
-	// postInteropGameTypes are game types that enforce having a supernode rpc.
-	// It is ok if this list isn't complete, unknown game types will allow either rollup or supernode.
+	// postInteropGameTypes are game types that enforce having a super root RPC.
+	// It is ok if this list isn't complete, unknown game types will allow either rollup or super root RPCs.
 	// We just want to reduce foot-guns during the migration period.
 	postInteropGameTypes = []uint32{4, 5}
 )
@@ -44,9 +44,9 @@ type CLIConfig struct {
 	// RollupRpc is the HTTP provider URL for the rollup node. A comma-separated list enables the active rollup provider.
 	RollupRpc string
 
-	// SuperNodeRpcs is the list of HTTP provider URLs for supernode instances.
+	// SuperRootRpcs is the list of HTTP provider URLs for super root RPC sources.
 	// Mutually exclusive with RollupRpc.
-	SuperNodeRpcs []string
+	SuperRootRpcs []string
 
 	// PollInterval is the delay between periodic checks on whether it is time to load an output root and propose it.
 	PollInterval time.Duration
@@ -109,19 +109,19 @@ func (c *CLIConfig) Check() error {
 	if c.RollupRpc != "" {
 		sourceCount++
 	}
-	if len(c.SuperNodeRpcs) != 0 {
+	if len(c.SuperRootRpcs) != 0 {
 		sourceCount++
 	}
 	if sourceCount > 1 {
 		return ErrConflictingSource
 	}
-	// Require rollup RPC for pre interop game types
+	// Require rollup RPC for pre interop game types.
 	if c.DGFAddress != "" && slices.Contains(preInteropGameTypes, c.DisputeGameType) && c.RollupRpc == "" {
 		return ErrMissingRollupRpc
 	}
-	// Require supernode RPC for post interop game types
-	if c.DGFAddress != "" && slices.Contains(postInteropGameTypes, c.DisputeGameType) && len(c.SuperNodeRpcs) == 0 {
-		return ErrMissingSuperNodeRpc
+	// Require super root RPC for post interop game types.
+	if c.DGFAddress != "" && slices.Contains(postInteropGameTypes, c.DisputeGameType) && len(c.SuperRootRpcs) == 0 {
+		return ErrMissingSuperRootRpc
 	}
 	// For unknown game types, allow any source, but require at least one.
 	if sourceCount == 0 {
@@ -136,7 +136,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 	return &CLIConfig{
 		L1EthRpc:                     ctx.String(flags.L1EthRpcFlag.Name),
 		RollupRpc:                    ctx.String(flags.RollupRpcFlag.Name),
-		SuperNodeRpcs:                ctx.StringSlice(flags.SuperNodeRpcsFlag.Name),
+		SuperRootRpcs:                ctx.StringSlice(flags.SuperRootRpcsFlag.Name),
 		PollInterval:                 ctx.Duration(flags.PollIntervalFlag.Name),
 		TxMgrConfig:                  txmgr.ReadCLIConfig(ctx),
 		AllowNonFinalized:            ctx.Bool(flags.AllowNonFinalizedFlag.Name),

--- a/op-proposer/proposer/config_test.go
+++ b/op-proposer/proposer/config_test.go
@@ -19,24 +19,65 @@ func TestValidConfigIsValid(t *testing.T) {
 	require.NoError(t, cfg.Check())
 }
 
-func TestNewConfigReadsSuperNodeRpcs(t *testing.T) {
-	var cfg *CLIConfig
-	app := cli.NewApp()
-	app.Flags = proposerFlags.Flags
-	app.Action = func(ctx *cli.Context) error {
-		cfg = NewConfig(ctx)
-		return nil
+func TestNewConfigReadsSuperRootRpcs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		args     []string
+		envName  string
+		expected []string
+	}{
+		{
+			name: "PrimaryFlag",
+			args: []string{
+				"--superroot-rpcs", "http://localhost:8882/superroot-a",
+				"--superroot-rpcs", "http://localhost:8883/superroot-b",
+			},
+			expected: []string{
+				"http://localhost:8882/superroot-a",
+				"http://localhost:8883/superroot-b",
+			},
+		},
+		{
+			name: "LegacyFlagAlias",
+			args: []string{
+				"--supernode-rpcs", "http://localhost:8882/supernode-a",
+				"--supernode-rpcs", "http://localhost:8883/supernode-b",
+			},
+			expected: []string{
+				"http://localhost:8882/supernode-a",
+				"http://localhost:8883/supernode-b",
+			},
+		},
+		{
+			name:     "PrimaryEnvVar",
+			envName:  "OP_PROPOSER_SUPERROOT_RPCS",
+			expected: []string{"http://localhost:8882/superroot"},
+		},
+		{
+			name:     "LegacyEnvVarAlias",
+			envName:  "OP_PROPOSER_SUPERNODE_RPCS",
+			expected: []string{"http://localhost:8882/superroot"},
+		},
 	}
-	err := app.Run([]string{
-		"op-proposer",
-		"--supernode-rpcs", "http://localhost:8882/supernode-a",
-		"--supernode-rpcs", "http://localhost:8883/supernode-b",
-	})
-	require.NoError(t, err)
-	require.Equal(t, []string{
-		"http://localhost:8882/supernode-a",
-		"http://localhost:8883/supernode-b",
-	}, cfg.SuperNodeRpcs)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.envName != "" {
+				t.Setenv(testCase.envName, testCase.expected[0])
+			}
+
+			var cfg *CLIConfig
+			app := cli.NewApp()
+			app.Flags = proposerFlags.Flags
+			app.Action = func(ctx *cli.Context) error {
+				cfg = NewConfig(ctx)
+				return nil
+			}
+			err := app.Run(append([]string{"op-proposer"}, testCase.args...))
+			require.NoError(t, err)
+			require.Equal(t, testCase.expected, cfg.SuperRootRpcs)
+		})
+	}
 }
 
 func TestRollupRpc(t *testing.T) {
@@ -46,7 +87,7 @@ func TestRollupRpc(t *testing.T) {
 			cfg.DGFAddress = common.Address{0xaa}.Hex()
 			cfg.ProposalInterval = 20
 			cfg.RollupRpc = ""
-			cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+			cfg.SuperRootRpcs = []string{"http://localhost:8882/superroot"}
 			cfg.DisputeGameType = gameType
 			require.ErrorIs(t, cfg.Check(), ErrMissingRollupRpc)
 		})
@@ -57,22 +98,22 @@ func TestRollupRpc(t *testing.T) {
 		cfg.DGFAddress = common.Address{0xaa}.Hex()
 		cfg.ProposalInterval = 20
 		cfg.RollupRpc = ""
-		cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+		cfg.SuperRootRpcs = []string{"http://localhost:8882/superroot"}
 		cfg.DisputeGameType = 492743
 		require.NoError(t, cfg.Check())
 	})
 }
 
-func TestSuperNodeRpc(t *testing.T) {
+func TestSuperRootRpc(t *testing.T) {
 	for _, gameType := range postInteropGameTypes {
 		t.Run("RequiredWithPostInteropGame", func(t *testing.T) {
 			cfg := validConfig()
 			cfg.DGFAddress = common.Address{0xaa}.Hex()
 			cfg.ProposalInterval = 20
 			cfg.RollupRpc = "http://localhost:8882/rollup"
-			cfg.SuperNodeRpcs = nil
+			cfg.SuperRootRpcs = nil
 			cfg.DisputeGameType = gameType
-			require.ErrorIs(t, cfg.Check(), ErrMissingSuperNodeRpc)
+			require.ErrorIs(t, cfg.Check(), ErrMissingSuperRootRpc)
 		})
 
 		t.Run("AllowedWithPostInteropGame", func(t *testing.T) {
@@ -80,7 +121,7 @@ func TestSuperNodeRpc(t *testing.T) {
 			cfg.DGFAddress = common.Address{0xaa}.Hex()
 			cfg.ProposalInterval = 20
 			cfg.RollupRpc = ""
-			cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+			cfg.SuperRootRpcs = []string{"http://localhost:8882/superroot"}
 			cfg.DisputeGameType = gameType
 			require.NoError(t, cfg.Check())
 		})
@@ -91,17 +132,17 @@ func TestSuperNodeRpc(t *testing.T) {
 		cfg.DGFAddress = common.Address{0xaa}.Hex()
 		cfg.ProposalInterval = 20
 		cfg.RollupRpc = ""
-		cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+		cfg.SuperRootRpcs = []string{"http://localhost:8882/superroot"}
 		cfg.DisputeGameType = 492743
 		require.NoError(t, cfg.Check())
 	})
 }
 
-func TestDisallowRollupAndSuperNodeRPC(t *testing.T) {
+func TestDisallowRollupAndSuperRootRPC(t *testing.T) {
 	cfg := validConfig()
 	cfg.ProposalInterval = 20
 	cfg.RollupRpc = "http://localhost:8882/rollup"
-	cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+	cfg.SuperRootRpcs = []string{"http://localhost:8882/superroot"}
 	cfg.DisputeGameType = 492743
 	require.ErrorIs(t, cfg.Check(), ErrConflictingSource)
 }
@@ -109,7 +150,7 @@ func TestDisallowRollupAndSuperNodeRPC(t *testing.T) {
 func TestRequireSomeRPCSourceForUnknownGameTypes(t *testing.T) {
 	cfg := validConfig()
 	cfg.RollupRpc = ""
-	cfg.SuperNodeRpcs = nil
+	cfg.SuperRootRpcs = nil
 	cfg.DisputeGameType = 492743
 	require.ErrorIs(t, cfg.Check(), ErrMissingSource)
 }
@@ -118,7 +159,7 @@ func validConfig() *CLIConfig {
 	return &CLIConfig{
 		L1EthRpc:                     "http://localhost:8888/l1",
 		RollupRpc:                    "http://localhost:8888/l2",
-		SuperNodeRpcs:                nil,
+		SuperRootRpcs:                nil,
 		PollInterval:                 100,
 		AllowNonFinalized:            false,
 		TxMgrConfig:                  txmgr.NewCLIConfig("http://localhost:8888/l1", txmgr.DefaultBatcherFlagValues),

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -142,9 +142,9 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 		}
 		ps.ProposalSource = source.NewRollupProposalSource(rollupProvider)
 	}
-	if len(cfg.SuperNodeRpcs) != 0 {
+	if len(cfg.SuperRootRpcs) != 0 {
 		var clients []source.SuperNodeClient
-		for _, url := range cfg.SuperNodeRpcs {
+		for _, url := range cfg.SuperRootRpcs {
 			cl, err := dial.DialSuperNodeClientWithTimeout(ctx, ps.Log, url,
 				client.WithRPCRecorder(ps.Metrics.NewRecorder("supernode")))
 			if err != nil {
@@ -152,7 +152,7 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 			}
 			clients = append(clients, cl)
 		}
-		ps.ProposalSource = source.NewSuperNodeProposalSource(ps.Log, clients...)
+		ps.ProposalSource = source.NewSuperRootProposalSource(ps.Log, clients...)
 	}
 	if ps.ProposalSource == nil {
 		return ErrMissingSource

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -146,9 +146,9 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 		var clients []source.SuperRootClient
 		for _, url := range cfg.SuperRootRpcs {
 			cl, err := dial.DialSuperNodeClientWithTimeout(ctx, ps.Log, url,
-				client.WithRPCRecorder(ps.Metrics.NewRecorder("supernode")))
+				client.WithRPCRecorder(ps.Metrics.NewRecorder("superroot")))
 			if err != nil {
-				return fmt.Errorf("failed to dial supernode RPC client (%v): %w", url, err)
+				return fmt.Errorf("failed to dial super root RPC client (%v): %w", url, err)
 			}
 			clients = append(clients, cl)
 		}

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -143,7 +143,7 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 		ps.ProposalSource = source.NewRollupProposalSource(rollupProvider)
 	}
 	if len(cfg.SuperRootRpcs) != 0 {
-		var clients []source.SuperNodeClient
+		var clients []source.SuperRootClient
 		for _, url := range cfg.SuperRootRpcs {
 			cl, err := dial.DialSuperNodeClientWithTimeout(ctx, ps.Log, url,
 				client.WithRPCRecorder(ps.Metrics.NewRecorder("supernode")))

--- a/op-proposer/proposer/source/source_superroot.go
+++ b/op-proposer/proposer/source/source_superroot.go
@@ -14,8 +14,8 @@ import (
 
 var ErrNoSuperRootData = errors.New("supernode response has no super root data")
 
-// SuperNodeClient is the interface for interacting with an op-supernode.
-type SuperNodeClient interface {
+// SuperRootClient is the interface required from a super root RPC client.
+type SuperRootClient interface {
 	SuperRootAtTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error)
 	Close()
 }
@@ -25,10 +25,10 @@ type SuperNodeClient interface {
 // and falling back to subsequent clients for proposals if earlier ones fail.
 type SuperRootProposalSource struct {
 	log     log.Logger
-	clients []SuperNodeClient
+	clients []SuperRootClient
 }
 
-func NewSuperRootProposalSource(logger log.Logger, clients ...SuperNodeClient) *SuperRootProposalSource {
+func NewSuperRootProposalSource(logger log.Logger, clients ...SuperRootClient) *SuperRootProposalSource {
 	if len(clients) == 0 {
 		panic("no supernode clients provided")
 	}

--- a/op-proposer/proposer/source/source_superroot.go
+++ b/op-proposer/proposer/source/source_superroot.go
@@ -30,7 +30,7 @@ type SuperRootProposalSource struct {
 
 func NewSuperRootProposalSource(logger log.Logger, clients ...SuperRootClient) *SuperRootProposalSource {
 	if len(clients) == 0 {
-		panic("no supernode clients provided")
+		panic("no super root clients provided")
 	}
 	return &SuperRootProposalSource{
 		log:     logger,

--- a/op-proposer/proposer/source/source_superroot.go
+++ b/op-proposer/proposer/source/source_superroot.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var ErrNoSuperRootData = errors.New("supernode response has no super root data")
+var ErrNoSuperRootData = errors.New("superroot RPC response has no super root data")
 
 // SuperRootClient is the interface required from a super root RPC client.
 type SuperRootClient interface {

--- a/op-proposer/proposer/source/source_superroot.go
+++ b/op-proposer/proposer/source/source_superroot.go
@@ -20,25 +20,25 @@ type SuperNodeClient interface {
 	Close()
 }
 
-// SuperNodeProposalSource fetches super root proposals from op-supernode instances.
+// SuperRootProposalSource fetches super root proposals from op-supernode instances.
 // It supports multiple clients for fault tolerance, querying them in parallel for sync status
 // and falling back to subsequent clients for proposals if earlier ones fail.
-type SuperNodeProposalSource struct {
+type SuperRootProposalSource struct {
 	log     log.Logger
 	clients []SuperNodeClient
 }
 
-func NewSuperNodeProposalSource(logger log.Logger, clients ...SuperNodeClient) *SuperNodeProposalSource {
+func NewSuperRootProposalSource(logger log.Logger, clients ...SuperNodeClient) *SuperRootProposalSource {
 	if len(clients) == 0 {
 		panic("no supernode clients provided")
 	}
-	return &SuperNodeProposalSource{
+	return &SuperRootProposalSource{
 		log:     logger,
 		clients: clients,
 	}
 }
 
-type supernodeStatusResult struct {
+type superRootStatusResult struct {
 	idx  int
 	resp eth.SuperRootAtTimestampResponse
 	err  error
@@ -46,17 +46,17 @@ type supernodeStatusResult struct {
 
 // SyncStatus returns the current L1 view and the safe/finalized L2 timestamps as reported by the supernode.
 // The timestamps are precomputed by the supernode as the conservative minimum across the dependency set.
-func (s *SuperNodeProposalSource) SyncStatus(ctx context.Context) (SyncStatus, error) {
+func (s *SuperRootProposalSource) SyncStatus(ctx context.Context) (SyncStatus, error) {
 	now := uint64(time.Now().Unix())
 
 	var wg sync.WaitGroup
-	results := make(chan supernodeStatusResult, len(s.clients))
+	results := make(chan superRootStatusResult, len(s.clients))
 	wg.Add(len(s.clients))
 	for i, client := range s.clients {
 		go func() {
 			defer wg.Done()
 			resp, err := client.SuperRootAtTimestamp(ctx, now)
-			results <- supernodeStatusResult{
+			results <- superRootStatusResult{
 				idx:  i,
 				resp: resp,
 				err:  err,
@@ -96,7 +96,7 @@ func (s *SuperNodeProposalSource) SyncStatus(ctx context.Context) (SyncStatus, e
 
 // ProposalAtSequenceNum fetches the super-root proposal at the given timestamp.
 // It fails over across supernode clients until it finds a response with valid super-root data.
-func (s *SuperNodeProposalSource) ProposalAtSequenceNum(ctx context.Context, timestamp uint64) (Proposal, error) {
+func (s *SuperRootProposalSource) ProposalAtSequenceNum(ctx context.Context, timestamp uint64) (Proposal, error) {
 	var errs []error
 	for i, client := range s.clients {
 		resp, err := client.SuperRootAtTimestamp(ctx, timestamp)
@@ -139,7 +139,7 @@ func (s *SuperNodeProposalSource) ProposalAtSequenceNum(ctx context.Context, tim
 	return Proposal{}, fmt.Errorf("no available proposal sources: %w", errors.Join(errs...))
 }
 
-func (s *SuperNodeProposalSource) Close() {
+func (s *SuperRootProposalSource) Close() {
 	for _, client := range s.clients {
 		client.Close()
 	}

--- a/op-proposer/proposer/source/source_superroot.go
+++ b/op-proposer/proposer/source/source_superroot.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var ErrNoSuperRootData = errors.New("superroot RPC response has no super root data")
+var ErrNoSuperRootData = errors.New("super root RPC response has no super root data")
 
 // SuperRootClient is the interface required from a super root RPC client.
 type SuperRootClient interface {
@@ -20,7 +20,7 @@ type SuperRootClient interface {
 	Close()
 }
 
-// SuperRootProposalSource fetches super root proposals from op-supernode instances.
+// SuperRootProposalSource fetches super root proposals from super root RPC instances.
 // It supports multiple clients for fault tolerance, querying them in parallel for sync status
 // and falling back to subsequent clients for proposals if earlier ones fail.
 type SuperRootProposalSource struct {

--- a/op-proposer/proposer/source/source_superroot_test.go
+++ b/op-proposer/proposer/source/source_superroot_test.go
@@ -237,6 +237,8 @@ func TestSuperRootSource_ProposalAtSequenceNum(t *testing.T) {
 	})
 }
 
+var _ SuperRootClient = (*mockSuperNodeClient)(nil)
+
 type mockSuperNodeClient struct {
 	responses    map[uint64]eth.SuperRootAtTimestampResponse
 	fn           func(context.Context, uint64) (eth.SuperRootAtTimestampResponse, error)

--- a/op-proposer/proposer/source/source_superroot_test.go
+++ b/op-proposer/proposer/source/source_superroot_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSuperNodeSource_SyncStatus(t *testing.T) {
+func TestSuperRootSource_SyncStatus(t *testing.T) {
 	t.Run("Single-Success", func(t *testing.T) {
 		client := &mockSuperNodeClient{
 			fn: func(_ context.Context, _ uint64) (eth.SuperRootAtTimestampResponse, error) {
@@ -24,7 +24,7 @@ func TestSuperNodeSource_SyncStatus(t *testing.T) {
 				}, nil
 			},
 		}
-		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		source := NewSuperRootProposalSource(testlog.Logger(t, log.LvlInfo), client)
 		status, err := source.SyncStatus(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, SyncStatus{
@@ -53,7 +53,7 @@ func TestSuperNodeSource_SyncStatus(t *testing.T) {
 				}, nil
 			},
 		}
-		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client1, client2)
+		source := NewSuperRootProposalSource(testlog.Logger(t, log.LvlInfo), client1, client2)
 		status, err := source.SyncStatus(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, SyncStatus{
@@ -75,7 +75,7 @@ func TestSuperNodeSource_SyncStatus(t *testing.T) {
 			},
 		}
 		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
-		source := NewSuperNodeProposalSource(logger, client1, client2)
+		source := NewSuperRootProposalSource(logger, client1, client2)
 		status, err := source.SyncStatus(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, uint64(123), status.SafeL2)
@@ -83,7 +83,7 @@ func TestSuperNodeSource_SyncStatus(t *testing.T) {
 	})
 }
 
-func TestSuperNodeSource_ProposalAtSequenceNum(t *testing.T) {
+func TestSuperRootSource_ProposalAtSequenceNum(t *testing.T) {
 	chainA := eth.ChainIDFromUInt64(1)
 	chainB := eth.ChainIDFromUInt64(2)
 	timestamp := uint64(599)
@@ -127,7 +127,7 @@ func TestSuperNodeSource_ProposalAtSequenceNum(t *testing.T) {
 				timestamp: response,
 			},
 		}
-		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		source := NewSuperRootProposalSource(testlog.Logger(t, log.LvlInfo), client)
 		actual, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
@@ -138,7 +138,7 @@ func TestSuperNodeSource_ProposalAtSequenceNum(t *testing.T) {
 		client := &mockSuperNodeClient{
 			err: expectedErr,
 		}
-		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		source := NewSuperRootProposalSource(testlog.Logger(t, log.LvlInfo), client)
 		_, err := source.ProposalAtSequenceNum(context.Background(), 294)
 		require.ErrorIs(t, err, expectedErr)
 	})
@@ -155,7 +155,7 @@ func TestSuperNodeSource_ProposalAtSequenceNum(t *testing.T) {
 				},
 			},
 		}
-		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		source := NewSuperRootProposalSource(testlog.Logger(t, log.LvlInfo), client)
 		_, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
 		require.ErrorIs(t, err, ErrNoSuperRootData)
 	})
@@ -167,7 +167,7 @@ func TestSuperNodeSource_ProposalAtSequenceNum(t *testing.T) {
 			},
 		}
 		client2 := &mockSuperNodeClient{}
-		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client1, client2)
+		source := NewSuperRootProposalSource(testlog.Logger(t, log.LvlInfo), client1, client2)
 		actual, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
@@ -185,7 +185,7 @@ func TestSuperNodeSource_ProposalAtSequenceNum(t *testing.T) {
 			},
 		}
 		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
-		source := NewSuperNodeProposalSource(logger, client1, client2)
+		source := NewSuperRootProposalSource(logger, client1, client2)
 		actual, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
@@ -209,7 +209,7 @@ func TestSuperNodeSource_ProposalAtSequenceNum(t *testing.T) {
 			},
 		}
 		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
-		source := NewSuperNodeProposalSource(logger, client1, client2)
+		source := NewSuperRootProposalSource(logger, client1, client2)
 		actual, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
@@ -226,7 +226,7 @@ func TestSuperNodeSource_ProposalAtSequenceNum(t *testing.T) {
 			err: errors.New("test error2"),
 		}
 		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
-		source := NewSuperNodeProposalSource(logger, client1, client2)
+		source := NewSuperRootProposalSource(logger, client1, client2)
 		_, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
 		require.ErrorIs(t, err, client1.err)
 		require.ErrorIs(t, err, client2.err)


### PR DESCRIPTION
Renames `--supernode-rpcs` to `--superroot-rpcs` while preserving the old CLI and environment-variable names as aliases. Carries the terminology through `CLIConfig`, `SuperRootProposalSource`, and the local `SuperRootClient` interface; the concrete `op-service/sources.SuperNodeClient` implementation remains unchanged.

This is naming-only: proposal-source selection remains flag-based and the existing pre-/post-interop game-type validation lists are unchanged.

Tested with `go test ./op-proposer/... -count=1`, `go test ./op-devstack/sysgo -run '^$' -count=1`, and `just ./op-proposer/op-proposer`.

Closes #21710 
Closes https://github.com/ethereum-optimism/optimism/pull/21778