### PR TITLE
fix(op-proposer): filter games before loading metadata

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/proposer_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/proposer_test.go
@@ -3,6 +3,8 @@ package proofs
 import (
 	"testing"
 
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 )
@@ -17,4 +19,18 @@ func TestProposer(gt *testing.T) {
 	rootClaim := newGame.RootClaim().Value()
 	l2SequenceNumber := newGame.L2SequenceNumber()
 	sys.SuperRoots.AssertSuperRootAtTimestamp(l2SequenceNumber, rootClaim)
+}
+
+func TestSuperPermissionedProposerCreatesRepeatedGames(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSimpleInterop(t, presets.WithProposerGameType(gameTypes.SuperPermissionedGameType))
+
+	dgf := sys.DisputeGameFactory()
+	firstGame := dgf.WaitForGame()
+	firstGame.VerifyGameType(gameTypes.SuperPermissionedGameType)
+	firstGame.VerifyStatus(gameTypes.GameStatusDefenderWon)
+
+	secondGame := dgf.WaitForGame()
+	secondGame.VerifyGameType(gameTypes.SuperPermissionedGameType)
+	secondGame.VerifyStatus(gameTypes.GameStatusDefenderWon)
 }

--- a/op-acceptance-tests/tests/interop/proofs/proposer_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/proposer_test.go
@@ -28,9 +28,9 @@ func TestSuperPermissionedProposerCreatesRepeatedGames(gt *testing.T) {
 	dgf := sys.DisputeGameFactory()
 	firstGame := dgf.WaitForGame()
 	firstGame.VerifyGameType(gameTypes.SuperPermissionedGameType)
-	firstGame.VerifyStatus(gameTypes.GameStatusDefenderWon)
+	firstGame.WaitForGameStatus(gameTypes.GameStatusDefenderWon)
 
 	secondGame := dgf.WaitForGame()
 	secondGame.VerifyGameType(gameTypes.SuperPermissionedGameType)
-	secondGame.VerifyStatus(gameTypes.GameStatusDefenderWon)
+	secondGame.WaitForGameStatus(gameTypes.GameStatusDefenderWon)
 }

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -58,6 +58,13 @@ func (g *FaultDisputeGame) GameType() gameTypes.GameType {
 	return gameTypes.GameType(contract.Read(g.game.GameType()))
 }
 
+func (g *FaultDisputeGame) VerifyGameType(expected gameTypes.GameType) {
+	actual := g.GameType()
+	g.require.Equalf(expected, actual,
+		"game type mismatch: expected %s (%d), got %s (%d)",
+		expected, uint32(expected), actual, uint32(actual))
+}
+
 func (g *FaultDisputeGame) MaxDepth() challengerTypes.Depth {
 	return challengerTypes.Depth(bigs.Uint64Strict(contract.Read(g.game.MaxGameDepth())))
 }
@@ -135,6 +142,11 @@ func (g *FaultDisputeGame) requiredBond(pos challengerTypes.Position) eth.ETH {
 func (g *FaultDisputeGame) status() gameTypes.GameStatus {
 	status := contract.Read(g.game.Status())
 	return gameTypes.GameStatus(status)
+}
+
+func (g *FaultDisputeGame) VerifyStatus(expected gameTypes.GameStatus) {
+	actual := g.status()
+	g.require.Equalf(expected, actual, "game status mismatch: expected %s, got %s", expected, actual)
 }
 
 func (g *FaultDisputeGame) newClaim(claimIndex uint64, claim bindings.Claim) *Claim {

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -144,9 +144,17 @@ func (g *FaultDisputeGame) status() gameTypes.GameStatus {
 	return gameTypes.GameStatus(status)
 }
 
-func (g *FaultDisputeGame) VerifyStatus(expected gameTypes.GameStatus) {
-	actual := g.status()
-	g.require.Equalf(expected, actual, "game status mismatch: expected %s, got %s", expected, actual)
+func (g *FaultDisputeGame) WaitForGameStatus(expected gameTypes.GameStatus) {
+	g.t.Logf("Waiting for game %v to have status %v", g.Address, expected)
+	timedCtx, cancel := context.WithTimeout(g.t.Ctx(), defaultTimeout)
+	defer cancel()
+
+	var actual gameTypes.GameStatus
+	err := wait.For(timedCtx, time.Second, func() (bool, error) {
+		actual = g.status()
+		return actual == expected, nil
+	})
+	g.require.NoErrorf(err, "game status mismatch: expected %s, got %s", expected, actual)
 }
 
 func (g *FaultDisputeGame) newClaim(claimIndex uint64, claim bindings.Claim) *Claim {

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
@@ -139,6 +140,11 @@ func (g *FaultDisputeGame) requiredBond(pos challengerTypes.Position) eth.ETH {
 	return eth.WeiBig(contract.Read(g.game.GetRequiredBond((*bindings.Uint128)(pos.ToGIndex()))))
 }
 
+func (g *FaultDisputeGame) readStatus(ctx context.Context) (gameTypes.GameStatus, error) {
+	status, err := contractio.Read(g.game.Status(), ctx)
+	return gameTypes.GameStatus(status), err
+}
+
 func (g *FaultDisputeGame) status() gameTypes.GameStatus {
 	status := contract.Read(g.game.Status())
 	return gameTypes.GameStatus(status)
@@ -150,11 +156,17 @@ func (g *FaultDisputeGame) WaitForGameStatus(expected gameTypes.GameStatus) {
 	defer cancel()
 
 	var actual gameTypes.GameStatus
+	var lastReadErr error
 	err := wait.For(timedCtx, time.Second, func() (bool, error) {
-		actual = g.status()
+		actual, lastReadErr = g.readStatus(timedCtx)
+		if lastReadErr != nil {
+			g.t.Logf("Game %v status unavailable while waiting for %v: %v", g.Address, expected, lastReadErr)
+			return false, nil
+		}
+		g.t.Logf("Game %v has status %v, waiting for %v", g.Address, actual, expected)
 		return actual == expected, nil
 	})
-	g.require.NoErrorf(err, "game status mismatch: expected %s, got %s", expected, actual)
+	g.require.NoErrorf(err, "game %v status mismatch: expected %s, got %s; last read error: %v", g.Address, expected, actual, lastReadErr)
 }
 
 func (g *FaultDisputeGame) newClaim(claimIndex uint64, claim bindings.Claim) *Claim {

--- a/op-proposer/contracts/disputegamefactory.go
+++ b/op-proposer/contracts/disputegamefactory.go
@@ -28,12 +28,15 @@ const (
 	methodClaim       = "claimData"
 )
 
-type gameMetadata struct {
+type gameInfo struct {
 	GameType  uint32
 	Timestamp time.Time
 	Address   common.Address
-	Proposer  common.Address
-	Claim     common.Hash
+}
+
+type proposalMetadata struct {
+	Proposer common.Address
+	Claim    common.Hash
 }
 
 type DisputeGameFactory struct {
@@ -87,9 +90,15 @@ func (f *DisputeGameFactory) HasProposedSince(ctx context.Context, proposer comm
 			// Reached a game that is before the expected cutoff, so we haven't found a suitable proposal
 			return false, time.Time{}, common.Hash{}, nil
 		}
-		if game.GameType == gameType && game.Proposer == proposer {
-			// Found a matching proposal
-			return true, game.Timestamp, game.Claim, nil
+		if game.GameType == gameType {
+			metadata, err := f.loadGameMetadata(ctx, game.Address)
+			if err != nil {
+				return false, time.Time{}, common.Hash{}, fmt.Errorf("failed to get metadata for dispute game %d: %w", idx, err)
+			}
+			if metadata.Proposer == proposer {
+				// Found a matching proposal
+				return true, game.Timestamp, metadata.Claim, nil
+			}
 		}
 		if idx == 0 { // Need to check here rather than in the for condition to avoid underflow
 			// Checked every game and didn't find a match
@@ -125,19 +134,23 @@ func (f *DisputeGameFactory) gameCount(ctx context.Context) (uint64, error) {
 	return bigs.Uint64Strict(result.GetBigInt(0)), nil
 }
 
-func (f *DisputeGameFactory) gameAtIndex(ctx context.Context, idx uint64) (gameMetadata, error) {
+func (f *DisputeGameFactory) gameAtIndex(ctx context.Context, idx uint64) (gameInfo, error) {
 	cCtx, cancel := context.WithTimeout(ctx, f.networkTimeout)
 	defer cancel()
 	result, err := f.caller.SingleCall(cCtx, rpcblock.Latest, f.contract.Call(methodGameAtIndex, new(big.Int).SetUint64(idx)))
 	if err != nil {
-		return gameMetadata{}, fmt.Errorf("failed to load game %v: %w", idx, err)
+		return gameInfo{}, fmt.Errorf("failed to load game %v: %w", idx, err)
 	}
-	gameType := result.GetUint32(0)
-	timestamp := result.GetUint64(1)
-	address := result.GetAddress(2)
+	return gameInfo{
+		GameType:  result.GetUint32(0),
+		Timestamp: time.Unix(int64(result.GetUint64(1)), 0),
+		Address:   result.GetAddress(2),
+	}, nil
+}
 
+func (f *DisputeGameFactory) loadGameMetadata(ctx context.Context, address common.Address) (proposalMetadata, error) {
 	gameContract := batching.NewBoundContract(f.gameABI, address)
-	cCtx, cancel = context.WithTimeout(ctx, f.networkTimeout)
+	cCtx, cancel := context.WithTimeout(ctx, f.networkTimeout)
 	defer cancel()
 	results, metadataErr := f.caller.Call(cCtx, rpcblock.Latest,
 		gameContract.Call(methodGameCreator),
@@ -153,20 +166,17 @@ func (f *DisputeGameFactory) gameAtIndex(ctx context.Context, idx uint64) (gameM
 		defer cancel()
 		result, legacyErr := f.caller.SingleCall(cCtx, rpcblock.Latest, gameContract.Call(methodClaim, big.NewInt(0)))
 		if legacyErr != nil {
-			return gameMetadata{}, fmt.Errorf("failed to load game metadata for game %v: %w", idx, errors.Join(
+			return proposalMetadata{}, errors.Join(
 				fmt.Errorf("common getters failed: %w", metadataErr),
 				fmt.Errorf("legacy claimData(0) failed: %w", legacyErr),
-			))
+			)
 		}
 		claimant = result.GetAddress(2)
 		claim = result.GetHash(4)
 	}
 
-	return gameMetadata{
-		GameType:  gameType,
-		Timestamp: time.Unix(int64(timestamp), 0),
-		Address:   address,
-		Proposer:  claimant,
-		Claim:     claim,
+	return proposalMetadata{
+		Proposer: claimant,
+		Claim:    claim,
 	}, nil
 }

--- a/op-proposer/contracts/disputegamefactory_test.go
+++ b/op-proposer/contracts/disputegamefactory_test.go
@@ -20,6 +20,13 @@ import (
 var factoryAddr = common.Address{0xff, 0xff}
 var proposerAddr = common.Address{0xaa, 0xbb}
 
+type gameMetadata struct {
+	GameType  uint32
+	Timestamp time.Time
+	Address   common.Address
+	Proposer  common.Address
+}
+
 func TestHasProposedSince(t *testing.T) {
 	cutOffTime := time.Unix(1000, 0)
 
@@ -241,6 +248,77 @@ func TestHasProposedSince(t *testing.T) {
 		require.Equal(t, expectedProposalTime, proposalTime)
 		require.Equal(t, expectedClaim, claim)
 	})
+	t.Run("SkipsNonMatchingGamesWithoutCallingThem", func(t *testing.T) {
+		stubRpc, factory := setupDisputeGameFactoryTest(t)
+		expectedProposalTime := time.Unix(1100, 0)
+		expectedClaim := common.Hash{0xdd}
+		matchingGame := gameMetadata{
+			GameType:  0,
+			Timestamp: expectedProposalTime,
+			Address:   common.Address{0x51},
+			Proposer:  proposerAddr,
+		}
+		withoutClaimData := gameMetadata{
+			GameType:  5,
+			Timestamp: time.Unix(1200, 0),
+			Address:   common.Address{0x52},
+		}
+		incompatible := gameMetadata{
+			GameType:  10,
+			Timestamp: time.Unix(1300, 0),
+			Address:   common.Address{0x53},
+		}
+
+		withGameList(stubRpc, matchingGame, withoutClaimData, incompatible)
+		withGameMetadata(stubRpc, matchingGame.Address, snapshots.LoadFaultDisputeGameABI(), proposerAddr, expectedClaim)
+		stubRpc.AddContract(withoutClaimData.Address, snapshots.LoadSuperPermissionedDisputeGameABI())
+		stubRpc.AddContract(incompatible.Address, &abi.ABI{})
+
+		proposed, proposalTime, claim, err := factory.HasProposedSince(context.Background(), proposerAddr, cutOffTime, 0)
+		require.NoError(t, err)
+		require.True(t, proposed)
+		require.Equal(t, expectedProposalTime, proposalTime)
+		require.Equal(t, expectedClaim, claim)
+	})
+
+	t.Run("MatchesSuperPermissionedGameType", func(t *testing.T) {
+		stubRpc, factory := setupDisputeGameFactoryTest(t)
+		expectedProposalTime := time.Unix(1100, 0)
+		expectedClaim := common.Hash{0xee}
+		game := gameMetadata{
+			GameType:  5,
+			Timestamp: expectedProposalTime,
+			Address:   common.Address{0x54},
+			Proposer:  proposerAddr,
+		}
+
+		withGameList(stubRpc, game)
+		withGameMetadata(stubRpc, game.Address, snapshots.LoadSuperPermissionedDisputeGameABI(), proposerAddr, expectedClaim)
+
+		proposed, proposalTime, claim, err := factory.HasProposedSince(context.Background(), proposerAddr, cutOffTime, 5)
+		require.NoError(t, err)
+		require.True(t, proposed)
+		require.Equal(t, expectedProposalTime, proposalTime)
+		require.Equal(t, expectedClaim, claim)
+	})
+
+	t.Run("StopsAtCutOffWithoutCallingGame", func(t *testing.T) {
+		stubRpc, factory := setupDisputeGameFactoryTest(t)
+		game := gameMetadata{
+			GameType:  0,
+			Timestamp: cutOffTime.Add(-time.Second),
+			Address:   common.Address{0x55},
+		}
+
+		withGameList(stubRpc, game)
+
+		proposed, proposalTime, claim, err := factory.HasProposedSince(context.Background(), proposerAddr, cutOffTime, 0)
+		require.NoError(t, err)
+		require.False(t, proposed)
+		require.Equal(t, time.Time{}, proposalTime)
+		require.Equal(t, common.Hash{}, claim)
+	})
+
 }
 
 func TestProposalTx(t *testing.T) {
@@ -259,6 +337,13 @@ func TestProposalTx(t *testing.T) {
 }
 
 func withClaims(stubRpc *batchingTest.AbiBasedRpc, gameAbi *abi.ABI, games ...gameMetadata) {
+	withGameList(stubRpc, games...)
+	for _, game := range games {
+		withGameMetadata(stubRpc, game.Address, gameAbi, game.Proposer, common.Hash{0xdd})
+	}
+}
+
+func withGameList(stubRpc *batchingTest.AbiBasedRpc, games ...gameMetadata) {
 	stubRpc.SetResponse(factoryAddr, methodGameCount, rpcblock.Latest, nil, []interface{}{big.NewInt(int64(len(games)))})
 	for i, game := range games {
 		stubRpc.SetResponse(factoryAddr, methodGameAtIndex, rpcblock.Latest, []interface{}{big.NewInt(int64(i))}, []interface{}{
@@ -266,10 +351,13 @@ func withClaims(stubRpc *batchingTest.AbiBasedRpc, gameAbi *abi.ABI, games ...ga
 			uint64(game.Timestamp.Unix()),
 			game.Address,
 		})
-		stubRpc.AddContract(game.Address, gameAbi)
-		stubRpc.SetResponse(game.Address, "gameCreator", rpcblock.Latest, nil, []interface{}{game.Proposer})
-		stubRpc.SetResponse(game.Address, "rootClaim", rpcblock.Latest, nil, []interface{}{common.Hash{0xdd}})
 	}
+}
+
+func withGameMetadata(stubRpc *batchingTest.AbiBasedRpc, gameAddress common.Address, gameABI *abi.ABI, proposer common.Address, claim common.Hash) {
+	stubRpc.AddContract(gameAddress, gameABI)
+	stubRpc.SetResponse(gameAddress, "gameCreator", rpcblock.Latest, nil, []interface{}{proposer})
+	stubRpc.SetResponse(gameAddress, "rootClaim", rpcblock.Latest, nil, []interface{}{claim})
 }
 
 func setupDisputeGameFactoryTest(t *testing.T) (*batchingTest.AbiBasedRpc, *DisputeGameFactory) {


### PR DESCRIPTION
Completes the remaining scope of ethereum-optimism/optimism#21680 after ethereum-optimism/optimism#21741 by separating factory tuple reads from proxy metadata reads. `HasProposedSince` now filters cutoff and game type before any game-proxy call, while retaining the `claimData(0)` fallback for matching historical games.

Adds mixed-ABI unit coverage and a two-proposal `SuperPermissionedDisputeGame` acceptance test.

Tests:
- `go test ./op-proposer/contracts -count=1`
- `go vet ./op-proposer/contracts ./op-devstack/dsl/proofs ./op-acceptance-tests/tests/interop/proofs`
- `RUST_JIT_BUILD=1 just test -run TestSuperPermissionedProposerCreatesRepeatedGames ./op-acceptance-tests/tests/interop/proofs`