### PR TITLE
ci: pin proven APKO factory workflows

### DIFF
--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@71a5f61d2b308d705de4a8959d89156755f68db3
+        uses: ethereum-optimism/factory/actions/apko-plan@be66ac9a9b5ba913c1813548d5ded3534e8f61ee
         with:
           config: .github/images.apko.json
 
@@ -73,7 +73,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@be66ac9a9b5ba913c1813548d5ded3534e8f61ee
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -105,7 +105,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@be66ac9a9b5ba913c1813548d5ded3534e8f61ee
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -128,7 +128,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@be66ac9a9b5ba913c1813548d5ded3534e8f61ee
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus

--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@be66ac9a9b5ba913c1813548d5ded3534e8f61ee
+        uses: ethereum-optimism/factory/actions/apko-plan@303276b8684655b2af1e878f0317c522826b5857
         with:
           config: .github/images.apko.json
 
@@ -73,7 +73,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@be66ac9a9b5ba913c1813548d5ded3534e8f61ee
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@303276b8684655b2af1e878f0317c522826b5857
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -105,7 +105,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@be66ac9a9b5ba913c1813548d5ded3534e8f61ee
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@303276b8684655b2af1e878f0317c522826b5857
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -128,7 +128,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@be66ac9a9b5ba913c1813548d5ded3534e8f61ee
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@303276b8684655b2af1e878f0317c522826b5857
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus


### PR DESCRIPTION
## Summary

Pin the APKO workflow to the previously validated factory workflow set with Cargo profile selection and isolated APK artifacts.

## Validation

- `mise exec -- actionlint .github/workflows/build-images.apko.yaml`
