### PR TITLE
op-node/op-service: swap ChainOpConfig to op-core/params + HardforkConfig interface for BlockAsPayload

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -19,6 +19,7 @@ import (
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
+	opcoreparams "github.com/ethereum-optimism/optimism/op-core/params"
 	opparams "github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -1098,7 +1099,7 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *eth.BlockRef, l2GenesisBlockHa
 		return nil, errors.New("SystemConfigProxy cannot be address(0)")
 	}
 
-	chainOpConfig := &params.OptimismConfig{
+	chainOpConfig := &opcoreparams.OptimismConfig{
 		EIP1559Elasticity:        d.EIP1559Elasticity,
 		EIP1559Denominator:       d.EIP1559Denominator,
 		EIP1559DenominatorCanyon: &d.EIP1559DenominatorCanyon,

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -14,12 +14,12 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/stretchr/testify/require"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	opparams "github.com/ethereum-optimism/optimism/op-core/params"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -286,7 +286,7 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 		LagoonTime:             deployConf.LagoonTime(uint64(deployConf.L1GenesisBlockTimestamp)),
 		KeepKarstUpgradeGas:    deployConf.KeepKarstUpgradeGas,
 		AltDAConfig:            pcfg,
-		ChainOpConfig: &params.OptimismConfig{
+		ChainOpConfig: &opparams.OptimismConfig{
 			EIP1559Elasticity:        deployConf.EIP1559Elasticity,
 			EIP1559Denominator:       deployConf.EIP1559Denominator,
 			EIP1559DenominatorCanyon: &deployConf.EIP1559DenominatorCanyon,

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -47,6 +47,7 @@ import (
 	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	opparams "github.com/ethereum-optimism/optimism/op-core/params"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/config/secrets"
@@ -729,7 +730,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 			KarstTime:              cfg.DeployConfig.KarstTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
 			LagoonTime:             cfg.DeployConfig.LagoonTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
 			AltDAConfig:            rollupAltDAConfig,
-			ChainOpConfig: &params.OptimismConfig{
+			ChainOpConfig: &opparams.OptimismConfig{
 				EIP1559Elasticity:        cfg.DeployConfig.EIP1559Elasticity,
 				EIP1559Denominator:       cfg.DeployConfig.EIP1559Denominator,
 				EIP1559DenominatorCanyon: &cfg.DeployConfig.EIP1559DenominatorCanyon,

--- a/op-node/chaincfg/chains_test.go
+++ b/op-node/chaincfg/chains_test.go
@@ -4,10 +4,10 @@ import (
 	"math/big"
 	"testing"
 
+	opparams "github.com/ethereum-optimism/optimism/op-core/params"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,7 +57,7 @@ func TestKarstUpgradeGasCompatibilityByNetwork(t *testing.T) {
 	}
 }
 
-var defaultOpConfig = &params.OptimismConfig{
+var defaultOpConfig = &opparams.OptimismConfig{
 	EIP1559Elasticity:        6,
 	EIP1559Denominator:       50,
 	EIP1559DenominatorCanyon: u64Ptr(250),

--- a/op-node/rollup/attributes/engine_consolidate_test.go
+++ b/op-node/rollup/attributes/engine_consolidate_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-core/eip1559"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
+	opparams "github.com/ethereum-optimism/optimism/op-core/params"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -21,7 +21,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
-var defaultOpConfig = &params.OptimismConfig{
+var defaultOpConfig = &opparams.OptimismConfig{
 	EIP1559Elasticity:        6,
 	EIP1559Denominator:       50,
 	EIP1559DenominatorCanyon: ptr(uint64(250)),

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -11,6 +11,7 @@ import (
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
+	opparams "github.com/ethereum-optimism/optimism/op-core/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -166,7 +167,7 @@ type Config struct {
 	// It is used during safe chain consolidation to translate zero SystemConfig EIP1559
 	// parameters to the protocol values, like the execution layer does.
 	// If missing, it is loaded by the op-node from the embedded superchain config at startup.
-	ChainOpConfig *params.OptimismConfig `json:"chain_op_config,omitempty"`
+	ChainOpConfig *opparams.OptimismConfig `json:"chain_op_config,omitempty"`
 
 	// Optional Features
 

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum-optimism/optimism/op-core/forks"
+	opparams "github.com/ethereum-optimism/optimism/op-core/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/ptr"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -57,6 +58,11 @@ func randConfig() *Config {
 		BatchInboxAddress:      randAddr(),
 		DepositContractAddress: randAddr(),
 		L1SystemConfigAddress:  randAddr(),
+		ChainOpConfig: &opparams.OptimismConfig{
+			EIP1559Elasticity:        6,
+			EIP1559Denominator:       50,
+			EIP1559DenominatorCanyon: ptr.New(uint64(250)),
+		},
 	}
 }
 
@@ -67,6 +73,35 @@ func TestConfigJSON(t *testing.T) {
 	var roundTripped Config
 	assert.NoError(t, json.Unmarshal(data, &roundTripped))
 	assert.Equal(t, &roundTripped, config)
+}
+
+// TestConfigChainOpConfigJSONWireFormat pins the on-the-wire serialization of the
+// ChainOpConfig field. Its type moved from op-geth's params.OptimismConfig to
+// op-core/params.OptimismConfig; the JSON must remain byte-for-byte identical.
+func TestConfigChainOpConfigJSONWireFormat(t *testing.T) {
+	config := randConfig()
+	config.ChainOpConfig = &opparams.OptimismConfig{
+		EIP1559Elasticity:        6,
+		EIP1559Denominator:       50,
+		EIP1559DenominatorCanyon: ptr.New(uint64(250)),
+	}
+	data, err := json.Marshal(config)
+	require.NoError(t, err)
+	require.Contains(t, string(data),
+		`"chain_op_config":{"eip1559Elasticity":6,"eip1559Denominator":50,"eip1559DenominatorCanyon":250}`)
+
+	// The optional canyon denominator is omitted when unset (omitempty).
+	config.ChainOpConfig.EIP1559DenominatorCanyon = nil
+	data, err = json.Marshal(config)
+	require.NoError(t, err)
+	require.Contains(t, string(data),
+		`"chain_op_config":{"eip1559Elasticity":6,"eip1559Denominator":50}`)
+
+	// The field is dropped entirely when nil (omitempty).
+	config.ChainOpConfig = nil
+	data, err = json.Marshal(config)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "chain_op_config")
 }
 
 type mockL1Client struct {

--- a/op-node/superchain/superchain.go
+++ b/op-node/superchain/superchain.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/params"
-
+	opparams "github.com/ethereum-optimism/optimism/op-core/params"
 	registry "github.com/ethereum-optimism/optimism/op-core/superchain"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -42,7 +41,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*rollup.Config, error) {
 // unit-tested directly: feeding a fully-populated ChainConfig through it and checking the result
 // catches any registry field that fails to reach Config.
 func rollupConfigFromRegistry(chConfig *registry.ChainConfig, superConfig registry.Superchain) *rollup.Config {
-	chOpConfig := &params.OptimismConfig{
+	chOpConfig := &opparams.OptimismConfig{
 		EIP1559Elasticity:        chConfig.Optimism.EIP1559Elasticity,
 		EIP1559Denominator:       chConfig.Optimism.EIP1559Denominator,
 		EIP1559DenominatorCanyon: chConfig.Optimism.EIP1559DenominatorCanyon,

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/holiman/uint256"
 )
@@ -435,10 +434,17 @@ func (envelope *ExecutionPayloadEnvelope) CheckBlockHash() (actual common.Hash, 
 	return blockHash, blockHash == payload.BlockHash
 }
 
+// HardforkConfig reports whether the OP-Stack hardforks relevant to payload conversion are active
+// at a given L2 block timestamp. It is satisfied by rollup.Config.
+type HardforkConfig interface {
+	IsCanyon(timestamp uint64) bool
+	IsIsthmus(timestamp uint64) bool
+}
+
 // BlockAsPayload converts a [*types.Block] to an [ExecutionPayload]. It can only be used to convert
 // OP-Stack blocks, as it follows Canyon and Isthmus rules to set the Withdrawals and
 // WithdrawalsRoot fields.
-func BlockAsPayload(bl *types.Block, config *params.ChainConfig) (*ExecutionPayload, error) {
+func BlockAsPayload(bl *types.Block, config HardforkConfig) (*ExecutionPayload, error) {
 	baseFee, overflow := uint256.FromBig(bl.BaseFee())
 	if overflow {
 		return nil, fmt.Errorf("invalid base fee in block: %s", bl.BaseFee())
@@ -486,7 +492,7 @@ func BlockAsPayload(bl *types.Block, config *params.ChainConfig) (*ExecutionPayl
 	return payload, nil
 }
 
-func BlockAsPayloadEnv(bl *types.Block, config *params.ChainConfig) (*ExecutionPayloadEnvelope, error) {
+func BlockAsPayloadEnv(bl *types.Block, config HardforkConfig) (*ExecutionPayloadEnvelope, error) {
 	payload, err := BlockAsPayload(bl, config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
§5 of `docs/ai/opgeth-decoupling.md`: remove op-service's direct dependency on op-geth's `params.ChainConfig` for OP-hardfork detection, and move `ChainOpConfig` off op-geth's `params.OptimismConfig`.

- `rollup.Config.ChainOpConfig`: `*params.OptimismConfig` → `*opparams.OptimismConfig` (`op-core/params`). JSON tags are identical, so the `chain_op_config` wire format is unchanged (pinned by a new `rollup.Config` marshal test + the existing `TestOptimismConfigJSONWireCompat` byte-for-byte guard vs op-geth).
- `eth.BlockAsPayload` / `BlockAsPayloadEnv`: the `*params.ChainConfig` parameter becomes a local `HardforkConfig` interface (`IsCanyon`, `IsIsthmus`). `rollup.Config` and op-geth's `ChainConfig` both satisfy it, so every caller compiles unchanged.
- Every `ChainOpConfig` construction site is switched to the op-core type (superchain, genesis, op-e2e setups, test fixtures). Field-access readers are type-agnostic and untouched.

No behavior change. No new hardfork fields were needed — `rollup.Config` already carries the full schedule, and `HardforkConfig` only needs the two predicates it already has.

Verification: `go build ./...` green; `op-node/{rollup,chaincfg,rollup/attributes,superchain}`, `op-service/eth`, `op-core/params` tests pass; op-e2e / kona-proof consumer packages vet clean.

Closes #20270

🤖 Generated by Claude Code