### PR TITLE
test(op-devstack): funder waits for balance >= target, not exact

### DIFF
--- a/op-acceptance-tests/tests/base/deposit/deposit_test.go
+++ b/op-acceptance-tests/tests/base/deposit/deposit_test.go
@@ -33,7 +33,6 @@ func TestL1ToL2Deposit(gt *testing.T) {
 	alice := sys.FunderL1.NewFundedEOA(fundingAmount)
 	t.Log("Alice L1 address", alice.Address())
 
-	alice.WaitForBalance(fundingAmount)
 	initialBalance := alice.GetBalance()
 	t.Log("Alice L1 balance", initialBalance)
 

--- a/op-acceptance-tests/tests/base/faucet_test.go
+++ b/op-acceptance-tests/tests/base/faucet_test.go
@@ -29,7 +29,7 @@ func TestFaucetFund(gt *testing.T) {
 
 	_, span = tracer.Start(ctx, "wait for balance")
 	t.Logger().InfoContext(ctx, "funds transferred", "amount", fundAmount)
-	alice.WaitForBalance(eth.WeiBig(l1Balance.ToBig().Add(l1Balance.ToBig(), fundAmount.ToBig())))
-	bob.WaitForBalance(eth.WeiBig(l2Balance.ToBig().Add(l2Balance.ToBig(), fundAmount.ToBig())))
+	alice.WaitForBalanceAtLeast(eth.WeiBig(l1Balance.ToBig().Add(l1Balance.ToBig(), fundAmount.ToBig())))
+	bob.WaitForBalanceAtLeast(eth.WeiBig(l2Balance.ToBig().Add(l2Balance.ToBig(), fundAmount.ToBig())))
 	span.End()
 }

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -232,6 +232,16 @@ func (u *EOA) WaitForBalance(v eth.ETH) {
 	}, u.el.stackEL().TransactionTimeout(), time.Second, "awaiting balance to be updated")
 }
 
+// WaitForBalanceAtLeast waits until the balance is at least v. Prefer this over
+// WaitForBalance when the caller only cares about a lower bound (e.g. funding):
+// an exact wait hangs forever if the wallet is over-funded, which happens when a
+// faucet request is retried and more than one funding tx lands.
+func (u *EOA) WaitForBalanceAtLeast(v eth.ETH) {
+	u.t.Require().Eventuallyf(func() bool {
+		return !u.balance().Lt(v)
+	}, u.el.stackEL().TransactionTimeout(), time.Second, "awaiting balance to reach at least %s", v)
+}
+
 func (u *EOA) DeployEventLogger() common.Address {
 	tx := txplan.NewPlannedTx(u.Plan(), txplan.WithData(common.FromHex(txIntentBindings.EventloggerBin)))
 	res, err := tx.Included.Eval(u.ctx)

--- a/op-devstack/dsl/funder.go
+++ b/op-devstack/dsl/funder.go
@@ -55,7 +55,7 @@ func (f *Funder) Fund(wallet *EOA, amount eth.ETH) eth.ETH {
 	currentBalance := wallet.balance()
 	f.faucet.Fund(wallet.Address(), amount)
 	finalBalance := currentBalance.Add(amount)
-	wallet.WaitForBalance(finalBalance)
+	wallet.WaitForBalanceAtLeast(finalBalance)
 	return finalBalance
 }
 
@@ -69,7 +69,7 @@ func (f *Funder) FundAtLeast(wallet *EOA, amount eth.ETH) eth.ETH {
 		missing := amount.Sub(currentBalance)
 		f.faucet.Fund(wallet.Address(), missing)
 		finalBalance := currentBalance.Add(missing)
-		wallet.WaitForBalance(finalBalance)
+		wallet.WaitForBalanceAtLeast(finalBalance)
 		return finalBalance
 	}
 	return currentBalance

--- a/op-devstack/dsl/operator_fee.go
+++ b/op-devstack/dsl/operator_fee.go
@@ -218,7 +218,6 @@ func (of *OperatorFee) RestoreOriginalConfig() {
 func RunOperatorFeeTest(t devtest.T, l2Chain *L2Network, l1EL *L1ELNode, funderL1, funderL2 *Funder) {
 	fundAmount := eth.OneTenthEther
 	alice := funderL2.NewFundedEOA(fundAmount)
-	alice.WaitForBalance(fundAmount)
 	bob := funderL2.NewFundedEOA(eth.ZeroWei)
 
 	operatorFee := NewOperatorFee(t, l2Chain, l1EL)


### PR DESCRIPTION
## Problem

`TestPreNoInbox` (job `memory-all-opn-op-reth`) failed with:

```
op-acceptance-tests/tests/interop/upgrade/pre_test.go:88
  → op-devstack/dsl/funder.go (FundAtLeast → WaitForBalance)
  → op-devstack/dsl/eoa.go
Error: Condition never satisfied
Messages: awaiting balance to be updated
```

Line 88 funds a fresh EOA (`bob`) with 0.01 ETH on chain B. The wait for its balance never completed and the test timed out.

## Root cause: faucet retry funds the account twice

`dsl.Faucet.Fund` retries `RequestETH` up to 3×. `Funder.Fund` / `FundAtLeast` then wait for the EOA balance to become **exactly** the expected post-funding value (`WaitForBalance`, `==`).

In the failing run:

1. The op-reth sequencer for chain 902 stalled ~22s (`Cannot seal block, payload ID is unknown` / `Sequencer temporarily could not seal block`), producing no blocks.
2. The faucet published its funding tx at **nonce 0** (`03f306…`). The stall made the client-side `RequestETH` exceed its deadline (`context deadline exceeded`), but that nonce-0 tx stayed in the mempool.
3. The retry issued a **new** faucet tx at **nonce 1** (`e915bb…`).
4. When the sequencer recovered, **block 81 sealed with `txs=2`** — both the nonce-0 and nonce-1 transfers landed. (A nonce-1 tx cannot be included unless nonce 0 is too.)
5. `bob` therefore received the funding amount **twice → 0.02 ETH**, while `WaitForBalance` waited for exactly 0.01 ETH. The exact-match condition can never be satisfied, so it blocked until `TransactionTimeout` and failed.

`alice` on chain 901, which hit no stall, funded with a single nonce-0 tx and passed — confirming the double-submit only occurs when the sequencer stalls long enough to trip the faucet retry.

Tracked in #17298 (this is a distinct cause from the activation-boundary flake that issue's existing mitigation addressed).

## Fix

- Add `EOA.WaitForBalanceAtLeast` — waits for `balance >= v`.
- `Fund` / `FundAtLeast` use it: a funder only cares that the wallet has *enough*, so over-funding (from a retry) is harmless rather than a permanent hang.
- Remove redundant exact `WaitForBalance` calls that immediately followed `NewFundedEOA` and re-introduced the same hang one line later, in `RunOperatorFeeTest` (`operator_fee.go`) and `TestL1ToL2Deposit` (`deposit_test.go`). `NewFundedEOA` already waits for the balance, so these were dead weight; the deposit test derives its balance math from `GetBalance()`, which stays correct even when over-funded.
- `TestFaucetFund` (`faucet_test.go`) funds via `FundNoWait` (the raw `Faucet.Fund` retry path) and then waits on recipient (increasing) balances, so it is vulnerable to the same double-fund hang. Switch both waits to `WaitForBalanceAtLeast`; `>=` is safe because the balance starts below the target, and the test only needs to assert the funds arrived.
- Keep exact-match `WaitForBalance` where it is a meaningful assertion and `>=` would be wrong: **sender-side** waits whose expected balance is *below* the starting balance (e.g. `deposit_test.go`'s post-deposit L1 balance, `transfer_test.go`) — a `>=` wait would return immediately and defeat the check — and the deposit's exact L2 credit.

### Note on testing

I did not add a reproducing test: the trigger is a nondeterministic op-reth sequencer stall + faucet client-timeout race, and `WaitForBalance` needs a live EL, so there's no unit-level seam to force the double-fund deterministically. The fix is grounded in the CI-log evidence above (block 81 `txs=2`; faucet nonce 0 + nonce 1 both to the EOA) and the plain logic that an exact `==` wait cannot be satisfied under over-funding while `>=` can.

A deeper follow-up (out of scope here) is making the faucet retry idempotent so it doesn't submit a second funded tx at a new nonce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)