### PR TITLE
op-node/op-service/op-batcher: swap DepositTx + Transaction-method helpers to op-core

### DIFF
--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -15,6 +15,7 @@ import (
 	dtest "github.com/ethereum-optimism/optimism/op-node/rollup/derive/test"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -118,7 +119,7 @@ func newMiniL2BlockWithChainIDNumberParentAndL1Information(numTx int, chainID *b
 	}
 
 	txs := make([]*types.Transaction, 0, 1+numTx)
-	txs = append(txs, types.NewTx(l1InfoTx))
+	txs = append(txs, testutils.TxFromDeposit(l1InfoTx))
 	for i := 0; i < numTx; i++ {
 		// Create DynamicFeeTx with random data that's harder to compress
 		randomData := make([]byte, 100+i*10) // Variable size data

--- a/op-batcher/batcher/types.go
+++ b/op-batcher/batcher/types.go
@@ -1,6 +1,8 @@
 package batcher
 
 import (
+	opfees "github.com/ethereum-optimism/optimism/op-core/fees"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -24,7 +26,7 @@ func (b *SizedBlock) RawSize() uint64 {
 		b.rawSize = uint64(70)
 		for _, tx := range b.Transactions() {
 			// Deposit transactions are not included in batches
-			if tx.IsDepositTx() {
+			if optypes.IsDepositTx(tx) {
 				continue
 			}
 			// Add 2 for the overhead of encoding the tx bytes in a RLP list
@@ -39,11 +41,11 @@ func (b *SizedBlock) EstimatedDABytes() uint64 {
 		daSize := uint64(70) // estimated overhead of batch metadata
 		for _, tx := range b.Transactions() {
 			// Deposit transactions are not included in batches
-			if tx.IsDepositTx() {
+			if optypes.IsDepositTx(tx) {
 				continue
 			}
 			// It is safe to assume that the estimated DA size is always a uint64
-			daSize += bigs.Uint64Strict(tx.RollupCostData().EstimatedDASize())
+			daSize += bigs.Uint64Strict(opfees.TxRollupCostData(tx).EstimatedDASize())
 		}
 		b.estimatedDABytes = daSize
 	}

--- a/op-chain-ops/cmd/check-karst/karsttest/checks.go
+++ b/op-chain-ops/cmd/check-karst/karsttest/checks.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
-	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -418,7 +417,7 @@ func CheckEIP7825DepositBypass(
 		return 0, fmt.Errorf("L2 deposit tx gas: got %d, want %d", l2DepositTx.Gas, depositGasLimit)
 	}
 
-	l2DepositHash := testutils.TxFromDeposit(l2DepositTx).Hash()
+	l2DepositHash := l2DepositTx.Hash()
 	logger.Info("EIP-7825-deposit: waiting for L2 deposit receipt", "tx", l2DepositHash)
 	var l2Receipt *types.Receipt
 	for {

--- a/op-chain-ops/cmd/check-karst/karsttest/checks.go
+++ b/op-chain-ops/cmd/check-karst/karsttest/checks.go
@@ -21,11 +21,13 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -402,7 +404,7 @@ func CheckEIP7825DepositBypass(
 	}
 	logger.Info("EIP-7825-deposit: L1 deposit included", "block", l1Receipt.BlockNumber, "tx", l1Receipt.TxHash)
 
-	var l2DepositTx *types.DepositTx
+	var l2DepositTx *optypes.DepositTx
 	for _, log := range l1Receipt.Logs {
 		var unmarshalErr error
 		if l2DepositTx, unmarshalErr = derive.UnmarshalDepositLogEvent(log); unmarshalErr == nil {
@@ -416,7 +418,7 @@ func CheckEIP7825DepositBypass(
 		return 0, fmt.Errorf("L2 deposit tx gas: got %d, want %d", l2DepositTx.Gas, depositGasLimit)
 	}
 
-	l2DepositHash := types.NewTx(l2DepositTx).Hash()
+	l2DepositHash := testutils.TxFromDeposit(l2DepositTx).Hash()
 	logger.Info("EIP-7825-deposit: waiting for L2 deposit receipt", "tx", l2DepositHash)
 	var l2Receipt *types.Receipt
 	for {

--- a/op-chain-ops/cmd/deposit-hash/main.go
+++ b/op-chain-ops/cmd/deposit-hash/main.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -52,8 +51,7 @@ func main() {
 			if err != nil {
 				log.Crit("Failed to parse deposit event", "err", err)
 			}
-			tx := testutils.TxFromDeposit(reconstructedDep)
-			fmt.Println("L2 Tx Hash", tx.Hash().String())
+			fmt.Println("L2 Tx Hash", reconstructedDep.Hash().String())
 		}
 	}
 

--- a/op-chain-ops/cmd/deposit-hash/main.go
+++ b/op-chain-ops/cmd/deposit-hash/main.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -52,7 +52,7 @@ func main() {
 			if err != nil {
 				log.Crit("Failed to parse deposit event", "err", err)
 			}
-			tx := types.NewTx(reconstructedDep)
+			tx := testutils.TxFromDeposit(reconstructedDep)
 			fmt.Println("L2 Tx Hash", tx.Hash().String())
 		}
 	}

--- a/op-core/types/deposit_tx.go
+++ b/op-core/types/deposit_tx.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -47,6 +48,18 @@ func (d *DepositTx) MarshalBinary() ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+// Hash returns the transaction hash: the keccak-256 hash of the canonical
+// EIP-2718 encoding. A well-formed deposit cannot fail to encode, so an encoding
+// error is unreachable and panics; this keeps the signature free of an error
+// return, matching how a transaction hash is used at call sites.
+func (d *DepositTx) Hash() common.Hash {
+	raw, err := d.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	return crypto.Keccak256Hash(raw)
 }
 
 // UnmarshalDepositTx decodes a deposit transaction from its EIP-2718 encoding.

--- a/op-core/types/deposit_tx_test.go
+++ b/op-core/types/deposit_tx_test.go
@@ -140,6 +140,17 @@ func TestDepositTxMarshalBinaryDifferential(t *testing.T) {
 	}
 }
 
+// TestDepositHashParity asserts DepositTx.Hash is identical to op-geth's
+// types.Transaction.Hash for the same deposit. It will be removed in the final
+// cutover, when the op-geth dependency is replaced with upstream go-ethereum.
+func TestDepositHashParity(t *testing.T) {
+	for _, tc := range depositTxTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.gethTx().Hash(), tc.tx.Hash())
+		})
+	}
+}
+
 func TestUnmarshalDepositTxRoundTrip(t *testing.T) {
 	for _, tc := range depositTxTestCases() {
 		t.Run(tc.name, func(t *testing.T) {

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -172,7 +171,7 @@ func (b *StandardBridge) Deposit(amount eth.ETH, from *EOA) Deposit {
 	idx := len(l1DepositReceipt.Logs) - 1
 	l2DepositTx, err := derive.UnmarshalDepositLogEvent(l1DepositReceipt.Logs[idx])
 	b.require.NoError(err, "Could not reconstruct L2 Deposit")
-	l2DepositTxHash := testutils.TxFromDeposit(l2DepositTx).Hash()
+	l2DepositTxHash := l2DepositTx.Hash()
 	// Give time for L2CL to include the L2 deposit tx
 	var l2DepositReceipt *types.Receipt
 	b.require.Eventually(func() bool {
@@ -216,7 +215,7 @@ func (b *StandardBridge) ERC20Deposit(l1TokenAddr common.Address, l2TokenAddr co
 	}
 	b.require.NotNil(l2DepositTx, "Could not find L2 deposit transaction in logs")
 
-	l2DepositTxHash := testutils.TxFromDeposit(l2DepositTx).Hash()
+	l2DepositTxHash := l2DepositTx.Hash()
 
 	// Give time for L2CL to include the L2 deposit tx
 	sequencingWindowDuration := time.Duration(b.rollupCfg.SeqWindowSize) * b.l1Client.EstimateBlockTime()

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	nodebindings "github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
@@ -20,6 +21,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -170,7 +172,7 @@ func (b *StandardBridge) Deposit(amount eth.ETH, from *EOA) Deposit {
 	idx := len(l1DepositReceipt.Logs) - 1
 	l2DepositTx, err := derive.UnmarshalDepositLogEvent(l1DepositReceipt.Logs[idx])
 	b.require.NoError(err, "Could not reconstruct L2 Deposit")
-	l2DepositTxHash := types.NewTx(l2DepositTx).Hash()
+	l2DepositTxHash := testutils.TxFromDeposit(l2DepositTx).Hash()
 	// Give time for L2CL to include the L2 deposit tx
 	var l2DepositReceipt *types.Receipt
 	b.require.Eventually(func() bool {
@@ -206,7 +208,7 @@ func (b *StandardBridge) ERC20Deposit(l1TokenAddr common.Address, l2TokenAddr co
 
 	// Wait for the deposit to be processed on the L2
 	// Find the deposit log to get the L2 deposit transaction
-	var l2DepositTx *types.DepositTx
+	var l2DepositTx *optypes.DepositTx
 	for _, log := range depositReceipt.Logs {
 		if l2DepositTx, err = derive.UnmarshalDepositLogEvent(log); err == nil {
 			break
@@ -214,7 +216,7 @@ func (b *StandardBridge) ERC20Deposit(l1TokenAddr common.Address, l2TokenAddr co
 	}
 	b.require.NotNil(l2DepositTx, "Could not find L2 deposit transaction in logs")
 
-	l2DepositTxHash := types.NewTx(l2DepositTx).Hash()
+	l2DepositTxHash := testutils.TxFromDeposit(l2DepositTx).Hash()
 
 	// Give time for L2CL to include the L2 deposit tx
 	sequencingWindowDuration := time.Duration(b.rollupCfg.SeqWindowSize) * b.l1Client.EstimateBlockTime()

--- a/op-devstack/dsl/deposit_eoa.go
+++ b/op-devstack/dsl/deposit_eoa.go
@@ -3,6 +3,7 @@ package dsl
 import (
 	"math/rand"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -50,7 +51,7 @@ func (d *DepositEOA) DepositTx(to common.Address, calldata []byte) *ethtypes.Rec
 	t.Require().NoError(err, "L1 deposit tx failed")
 	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l1Receipt.Status, "L1 deposit tx reverted")
 
-	var l2DepositTx *ethtypes.DepositTx
+	var l2DepositTx *optypes.DepositTx
 	for _, log := range l1Receipt.Logs {
 		if l2DepositTx, err = derive.UnmarshalDepositLogEvent(log); err == nil {
 			break
@@ -59,7 +60,7 @@ func (d *DepositEOA) DepositTx(to common.Address, calldata []byte) *ethtypes.Rec
 	t.Require().NotNil(l2DepositTx, "no TransactionDeposited event in L1 receipt")
 
 	d.l2EL.WaitL1OriginReached(eth.Unsafe, bigs.Uint64Strict(l1Receipt.BlockNumber), 120)
-	l2Receipt := d.l2EL.WaitForReceipt(ethtypes.NewTx(l2DepositTx).Hash())
+	l2Receipt := d.l2EL.WaitForReceipt(testutils.TxFromDeposit(l2DepositTx).Hash())
 	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l2Receipt.Status, "deposit tx failed on L2")
 	return l2Receipt
 }

--- a/op-devstack/dsl/deposit_eoa.go
+++ b/op-devstack/dsl/deposit_eoa.go
@@ -60,7 +60,7 @@ func (d *DepositEOA) DepositTx(to common.Address, calldata []byte) *ethtypes.Rec
 	t.Require().NotNil(l2DepositTx, "no TransactionDeposited event in L1 receipt")
 
 	d.l2EL.WaitL1OriginReached(eth.Unsafe, bigs.Uint64Strict(l1Receipt.BlockNumber), 120)
-	l2Receipt := d.l2EL.WaitForReceipt(testutils.TxFromDeposit(l2DepositTx).Hash())
+	l2Receipt := d.l2EL.WaitForReceipt(l2DepositTx.Hash())
 	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l2Receipt.Status, "deposit tx failed on L2")
 	return l2Receipt
 }

--- a/op-e2e/actions/helpers/user.go
+++ b/op-e2e/actions/helpers/user.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
-	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
 type L1Bindings struct {
@@ -430,8 +429,7 @@ func (s *CrossLayerUser) CheckDepositTx(t Testing, l1TxHash common.Hash, index i
 		require.Less(t, index, len(depositReceipt.Logs), "must have enough logs in receipt")
 		reconstructedDep, err := derive.UnmarshalDepositLogEvent(depositReceipt.Logs[index])
 		require.NoError(t, err, "Could not reconstruct L2 Deposit")
-		l2Tx := testutils.TxFromDeposit(reconstructedDep)
-		s.L2.CheckReceipt(t, l2Success, l2Tx.Hash())
+		s.L2.CheckReceipt(t, l2Success, reconstructedDep.Hash())
 	}
 }
 
@@ -443,8 +441,7 @@ func (s *CrossLayerUser) GetLastDepositL2Receipt(t Testing) (*types.Receipt, err
 	depositL1Receipt := s.L1.CheckReceipt(t, true, s.lastL1DepositTxHash)
 	reconstructedDep, err := derive.UnmarshalDepositLogEvent(depositL1Receipt.Logs[0])
 	require.NoError(t, err, "Could not reconstruct L2 Deposit")
-	l2Tx := testutils.TxFromDeposit(reconstructedDep)
-	return s.L2.CheckReceipt(t, true, l2Tx.Hash()), nil
+	return s.L2.CheckReceipt(t, true, reconstructedDep.Hash()), nil
 }
 
 func (s *CrossLayerUser) getLastWithdrawalParams(t Testing) (*withdrawals.ProvenWithdrawalParameters, error) {

--- a/op-e2e/actions/helpers/user.go
+++ b/op-e2e/actions/helpers/user.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
 type L1Bindings struct {
@@ -429,7 +430,7 @@ func (s *CrossLayerUser) CheckDepositTx(t Testing, l1TxHash common.Hash, index i
 		require.Less(t, index, len(depositReceipt.Logs), "must have enough logs in receipt")
 		reconstructedDep, err := derive.UnmarshalDepositLogEvent(depositReceipt.Logs[index])
 		require.NoError(t, err, "Could not reconstruct L2 Deposit")
-		l2Tx := types.NewTx(reconstructedDep)
+		l2Tx := testutils.TxFromDeposit(reconstructedDep)
 		s.L2.CheckReceipt(t, l2Success, l2Tx.Hash())
 	}
 }
@@ -442,7 +443,7 @@ func (s *CrossLayerUser) GetLastDepositL2Receipt(t Testing) (*types.Receipt, err
 	depositL1Receipt := s.L1.CheckReceipt(t, true, s.lastL1DepositTxHash)
 	reconstructedDep, err := derive.UnmarshalDepositLogEvent(depositL1Receipt.Logs[0])
 	require.NoError(t, err, "Could not reconstruct L2 Deposit")
-	l2Tx := types.NewTx(reconstructedDep)
+	l2Tx := testutils.TxFromDeposit(reconstructedDep)
 	return s.L2.CheckReceipt(t, true, l2Tx.Hash()), nil
 }
 

--- a/op-e2e/opgeth/op_geth_test.go
+++ b/op-e2e/opgeth/op_geth_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
 var (
@@ -411,7 +412,7 @@ func TestPreregolith(t *testing.T) {
 			systemTx.IsSystemTransaction = true
 			require.NoError(t, err)
 
-			_, err = opGeth.AddL2Block(ctx, types.NewTx(systemTx))
+			_, err = opGeth.AddL2Block(ctx, testutils.TxFromDeposit(systemTx))
 			require.NoError(t, err, "should allow blocks containing system tx")
 		})
 	}
@@ -604,7 +605,7 @@ func TestRegolith(t *testing.T) {
 			systemTx.IsSystemTransaction = true
 			require.NoError(t, err)
 
-			_, err = opGeth.AddL2Block(ctx, types.NewTx(systemTx))
+			_, err = opGeth.AddL2Block(ctx, testutils.TxFromDeposit(systemTx))
 			require.ErrorIs(t, err, ErrForkChoiceUpdated, "should reject blocks containing system tx")
 		})
 

--- a/op-e2e/system/bridge/bridge_test.go
+++ b/op-e2e/system/bridge/bridge_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -105,7 +104,7 @@ func TestERC20BridgeDeposits(t *testing.T) {
 
 	depositTx, err := derive.UnmarshalDepositLogEvent(&depositEvent.Raw)
 	require.NoError(t, err)
-	_, err = wait.ForReceiptOK(context.Background(), l2Client, testutils.TxFromDeposit(depositTx).Hash())
+	_, err = wait.ForReceiptOK(context.Background(), l2Client, depositTx.Hash())
 	require.NoError(t, err)
 
 	// Ensure that the deposit went through

--- a/op-e2e/system/bridge/bridge_test.go
+++ b/op-e2e/system/bridge/bridge_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -104,7 +105,7 @@ func TestERC20BridgeDeposits(t *testing.T) {
 
 	depositTx, err := derive.UnmarshalDepositLogEvent(&depositEvent.Raw)
 	require.NoError(t, err)
-	_, err = wait.ForReceiptOK(context.Background(), l2Client, types.NewTx(depositTx).Hash())
+	_, err = wait.ForReceiptOK(context.Background(), l2Client, testutils.TxFromDeposit(depositTx).Hash())
 	require.NoError(t, err)
 
 	// Ensure that the deposit went through

--- a/op-e2e/system/helpers/tx_helper.go
+++ b/op-e2e/system/helpers/tx_helper.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -59,8 +58,7 @@ func SendDepositTx(t *testing.T, cfg e2esys.SystemConfig, l1Client *ethclient.Cl
 	idx := len(l1Receipt.Logs) - 1
 	reconstructedDep, err := derive.UnmarshalDepositLogEvent(l1Receipt.Logs[idx])
 	require.NoError(t, err, "Could not reconstruct L2 Deposit")
-	tx = testutils.TxFromDeposit(reconstructedDep)
-	l2Receipt, err := wait.ForReceipt(ctx, l2Client, tx.Hash(), l2Opts.ExpectedStatus)
+	l2Receipt, err := wait.ForReceipt(ctx, l2Client, reconstructedDep.Hash(), l2Opts.ExpectedStatus)
 	require.NoError(t, err, "Waiting for deposit tx on L2")
 	t.Logf("SendDepositTx: arrived on L2")
 	return l2Receipt

--- a/op-e2e/system/helpers/tx_helper.go
+++ b/op-e2e/system/helpers/tx_helper.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -58,7 +59,7 @@ func SendDepositTx(t *testing.T, cfg e2esys.SystemConfig, l1Client *ethclient.Cl
 	idx := len(l1Receipt.Logs) - 1
 	reconstructedDep, err := derive.UnmarshalDepositLogEvent(l1Receipt.Logs[idx])
 	require.NoError(t, err, "Could not reconstruct L2 Deposit")
-	tx = types.NewTx(reconstructedDep)
+	tx = testutils.TxFromDeposit(reconstructedDep)
 	l2Receipt, err := wait.ForReceipt(ctx, l2Client, tx.Hash(), l2Opts.ExpectedStatus)
 	require.NoError(t, err, "Waiting for deposit tx on L2")
 	t.Logf("SendDepositTx: arrived on L2")

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -122,7 +122,7 @@ func singularBatchToBlock(rollupCfg *rollup.Config, batch *derive.SingularBatch)
 	if err != nil {
 		return nil, fmt.Errorf("could not build L1 Info transaction: %w", err)
 	}
-	txs := []*types.Transaction{types.NewTx(l1InfoTx)}
+	txs := []*types.Transaction{testutils.TxFromDeposit(l1InfoTx)}
 	for i, opaqueTx := range batch.Transactions {
 		var tx types.Transaction
 		err = tx.UnmarshalBinary(opaqueTx)

--- a/op-node/cmd/interop-deposits-dump/main.go
+++ b/op-node/cmd/interop-deposits-dump/main.go
@@ -6,8 +6,8 @@ import (
 	"math/big"
 	"os"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 func main() {
@@ -20,28 +20,24 @@ func main() {
 		fmt.Printf("activate=%v\n", activate)
 		fmt.Printf("gas=0x%016x\n", gas)
 		for i, raw := range txs {
-			var tx types.Transaction
-			if err := tx.UnmarshalBinary([]byte(raw)); err != nil {
-				fmt.Fprintf(os.Stderr, "go: tx %d unmarshal: %v\n", i, err)
-				os.Exit(1)
-			}
-			if !tx.IsDepositTx() {
-				fmt.Fprintf(os.Stderr, "go: tx %d is not a deposit tx (type=%d)\n", i, tx.Type())
+			dep, err := optypes.UnmarshalDepositTx([]byte(raw))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "go: tx %d is not a deposit tx: %v\n", i, err)
 				os.Exit(1)
 			}
 			to := "create"
-			if t := tx.To(); t != nil {
-				to = fmt.Sprintf("0x%x", t.Bytes())
+			if dep.To != nil {
+				to = fmt.Sprintf("0x%x", dep.To.Bytes())
 			}
 			fmt.Printf("--- tx %d ---\n", i)
-			fmt.Printf("source_hash=0x%x\n", tx.SourceHash().Bytes())
-			fmt.Printf("from=0x%x\n", tx.From().Bytes())
+			fmt.Printf("source_hash=0x%x\n", dep.SourceHash.Bytes())
+			fmt.Printf("from=0x%x\n", dep.From.Bytes())
 			fmt.Printf("to=%s\n", to)
-			fmt.Printf("mint=0x%032x\n", bigOrZero(tx.Mint()))
-			fmt.Printf("value=0x%064x\n", bigOrZero(tx.Value()))
-			fmt.Printf("gas_limit=0x%016x\n", tx.Gas())
-			fmt.Printf("is_system_tx=%v\n", tx.IsSystemTx())
-			fmt.Printf("data=0x%x\n", tx.Data())
+			fmt.Printf("mint=0x%032x\n", bigOrZero(dep.Mint))
+			fmt.Printf("value=0x%064x\n", bigOrZero(dep.Value))
+			fmt.Printf("gas_limit=0x%016x\n", dep.Gas)
+			fmt.Printf("is_system_tx=%v\n", dep.IsSystemTransaction)
+			fmt.Printf("data=0x%x\n", dep.Data)
 		}
 	}
 }

--- a/op-node/rollup/attributes/engine_consolidate_test.go
+++ b/op-node/rollup/attributes/engine_consolidate_test.go
@@ -628,7 +628,7 @@ func TestGetMissingTxnHashes(t *testing.T) {
 	for i := 0; i < len(depositTxs); i++ {
 		rng := rand.New(rand.NewSource(1234 + int64(i)))
 		safeDeposit := testutils.GenerateDeposit(testutils.RandomHash(rng), rng)
-		depositTxs[i] = types.NewTx(safeDeposit)
+		depositTxs[i] = testutils.TxFromDeposit(safeDeposit)
 	}
 
 	tests := []struct {

--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
@@ -489,9 +489,9 @@ func TestPreparePayloadAttributes(t *testing.T) {
 	})
 }
 
-func encodeDeposits(deposits []*types.DepositTx) (out []eth.Data, err error) {
+func encodeDeposits(deposits []*optypes.DepositTx) (out []eth.Data, err error) {
 	for i, tx := range deposits {
-		opaqueTx, err := types.NewTx(tx).MarshalBinary()
+		opaqueTx, err := tx.MarshalBinary()
 		if err != nil {
 			return nil, fmt.Errorf("bad deposit %d: %w", i, err)
 		}

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -189,7 +190,7 @@ func checkSequencerTxData(log log.Logger, txIndex int, txBytes []byte, isIsthmus
 		return BatchDrop
 	}
 	switch txBytes[0] {
-	case types.DepositTxType:
+	case optypes.DepositTxType:
 		log.Warn("sequencers may not embed any deposits into batch data, but found tx that has one", "tx_index", txIndex)
 		return BatchDrop
 	case types.SetCodeTxType:
@@ -402,7 +403,7 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 				log.Warn("transaction data must not be empty, but found empty tx", "tx_index", i)
 				return BatchDrop
 			}
-			if txBytes[0] == types.DepositTxType {
+			if txBytes[0] == optypes.DepositTxType {
 				log.Warn("sequencers may not embed any deposits into batch data, but found tx that has one", "tx_index", i)
 				return BatchDrop
 			}
@@ -430,7 +431,7 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 			// execution payload has deposit TXs, but batch does not.
 			depositCount := 0
 			for _, tx := range safeBlockTxs {
-				if tx[0] == types.DepositTxType {
+				if tx[0] == optypes.DepositTxType {
 					depositCount++
 				}
 			}

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive/params"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -230,7 +231,7 @@ func BlockToSingularBatch(rollupCfg *rollup.Config, block *types.Block) (*Singul
 
 	opaqueTxs := make([]hexutil.Bytes, 0, len(block.Transactions()))
 	for i, tx := range block.Transactions() {
-		if tx.Type() == types.DepositTxType {
+		if tx.Type() == optypes.DepositTxType {
 			continue
 		}
 		otx, err := tx.MarshalBinary()
@@ -241,7 +242,7 @@ func BlockToSingularBatch(rollupCfg *rollup.Config, block *types.Block) (*Singul
 	}
 
 	l1InfoTx := block.Transactions()[0]
-	if l1InfoTx.Type() != types.DepositTxType {
+	if l1InfoTx.Type() != optypes.DepositTxType {
 		return nil, nil, ErrNotDepositTx
 	}
 	l1Info, err := L1BlockInfoFromBytes(rollupCfg, block.Time(), l1InfoTx.Data())

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -96,7 +97,7 @@ type DataSourceConfig struct {
 //  3. the transaction has a valid signature from the batcher address
 func isValidBatchTx(tx *types.Transaction, l1Signer types.Signer, batchInboxAddr, batcherAddr common.Address, logger log.Logger) bool {
 	// For now, we want to disallow the SetCodeTx type or any future types.
-	if tx.Type() > types.BlobTxType && tx.Type() != types.DepositTxType {
+	if tx.Type() > types.BlobTxType && tx.Type() != optypes.DepositTxType {
 		return false
 	}
 

--- a/op-node/rollup/derive/deposit_log.go
+++ b/op-node/rollup/derive/deposit_log.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -33,7 +34,7 @@ var (
 //	);
 //
 // Additionally, the event log-index and
-func UnmarshalDepositLogEvent(ev *types.Log) (*types.DepositTx, error) {
+func UnmarshalDepositLogEvent(ev *types.Log) (*optypes.DepositTx, error) {
 	if len(ev.Topics) != 4 {
 		return nil, fmt.Errorf("expected 4 event topics (event identity, indexed from, indexed to, indexed version), got %d", len(ev.Topics))
 	}
@@ -74,7 +75,7 @@ func UnmarshalDepositLogEvent(ev *types.Log) (*types.DepositTx, error) {
 	// and then padded to 32 bytes by the EVM.
 	opaqueData := ev.Data[64 : 64+opaqueContentLength.Uint64()]
 
-	var dep types.DepositTx
+	var dep optypes.DepositTx
 
 	source := UserDepositSource{
 		L1BlockHash: ev.BlockHash,
@@ -97,7 +98,7 @@ func UnmarshalDepositLogEvent(ev *types.Log) (*types.DepositTx, error) {
 	return &dep, nil
 }
 
-func unmarshalDepositVersion0(dep *types.DepositTx, to common.Address, opaqueData []byte) error {
+func unmarshalDepositVersion0(dep *optypes.DepositTx, to common.Address, opaqueData []byte) error {
 	if len(opaqueData) < 32+32+8+1 {
 		return fmt.Errorf("unexpected opaqueData length: %d", len(opaqueData))
 	}
@@ -143,7 +144,7 @@ func unmarshalDepositVersion0(dep *types.DepositTx, to common.Address, opaqueDat
 
 // MarshalDepositLogEvent returns an EVM log entry that encodes a TransactionDeposited event from the deposit contract.
 // This is the reverse of the deposit transaction derivation.
-func MarshalDepositLogEvent(depositContractAddr common.Address, deposit *types.DepositTx) (*types.Log, error) {
+func MarshalDepositLogEvent(depositContractAddr common.Address, deposit *optypes.DepositTx) (*types.Log, error) {
 	toBytes := common.Hash{}
 	if deposit.To != nil {
 		toBytes = eth.AddressAsLeftPaddedHash(*deposit.To)
@@ -191,7 +192,7 @@ func MarshalDepositLogEvent(depositContractAddr common.Address, deposit *types.D
 	}, nil
 }
 
-func marshalDepositVersion0(deposit *types.DepositTx) ([]byte, error) {
+func marshalDepositVersion0(deposit *optypes.DepositTx) ([]byte, error) {
 	opaqueData := make([]byte, 32+32+8+1, 32+32+8+1+len(deposit.Data))
 	offset := 0
 

--- a/op-node/rollup/derive/deposit_log_test.go
+++ b/op-node/rollup/derive/deposit_log_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -50,10 +51,10 @@ type receiptData struct {
 	DepositLogs []bool
 }
 
-func makeReceipts(rng *rand.Rand, blockHash common.Hash, depositContractAddr common.Address, testReceipts []receiptData) ([]*types.Receipt, []*types.DepositTx, error) {
+func makeReceipts(rng *rand.Rand, blockHash common.Hash, depositContractAddr common.Address, testReceipts []receiptData) ([]*types.Receipt, []*optypes.DepositTx, error) {
 	logIndex := uint(0)
 	receipts := []*types.Receipt{}
-	expectedDeposits := []*types.DepositTx{}
+	expectedDeposits := []*optypes.DepositTx{}
 	for txIndex, rData := range testReceipts {
 		var logs []*types.Log
 		status := types.ReceiptStatusSuccessful
@@ -71,7 +72,7 @@ func makeReceipts(rng *rand.Rand, blockHash common.Hash, depositContractAddr com
 				}
 				ev, err = MarshalDepositLogEvent(depositContractAddr, dep)
 				if err != nil {
-					return []*types.Receipt{}, []*types.DepositTx{}, err
+					return []*types.Receipt{}, []*optypes.DepositTx{}, err
 				}
 			} else {
 				ev = testutils.GenerateLog(testutils.RandomAddress(rng), nil, nil)

--- a/op-node/rollup/derive/deposit_log_tob_test.go
+++ b/op-node/rollup/derive/deposit_log_tob_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/fuzzerutils"
 	"github.com/ethereum/go-ethereum/common"
@@ -13,7 +14,7 @@ import (
 )
 
 // fuzzReceipts is similar to makeReceipts except it uses the fuzzer to populate DepositTx fields.
-func fuzzReceipts(typeProvider *fuzz.Fuzzer, blockHash common.Hash, depositContractAddr common.Address) (receipts []*types.Receipt, expectedDeposits []*types.DepositTx) {
+func fuzzReceipts(typeProvider *fuzz.Fuzzer, blockHash common.Hash, depositContractAddr common.Address) (receipts []*types.Receipt, expectedDeposits []*optypes.DepositTx) {
 	// Determine how many receipts to generate (capped)
 	var receiptCount uint64
 	typeProvider.Fuzz(&receiptCount)
@@ -60,7 +61,7 @@ func fuzzReceipts(typeProvider *fuzz.Fuzzer, blockHash common.Hash, depositContr
 				typeProvider.Fuzz(&fuzzedDepositInfo)
 
 				// Create our deposit transaction
-				dep := &types.DepositTx{
+				dep := &optypes.DepositTx{
 					SourceHash:          source.SourceHash(),
 					From:                *fuzzedDepositInfo.FromAddr,
 					To:                  fuzzedDepositInfo.ToAddr,

--- a/op-node/rollup/derive/deposit_source.go
+++ b/op-node/rollup/derive/deposit_source.go
@@ -2,15 +2,10 @@ package derive
 
 import (
 	"encoding/binary"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-
-	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 )
-
-var OptimisticBlockDepositSenderAddress = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0002")
 
 type UserDepositSource struct {
 	L1BlockHash common.Hash
@@ -83,21 +78,4 @@ func (dep *InvalidatedBlockSource) SourceHash() common.Hash {
 	binary.BigEndian.PutUint64(domainInput[32-8:32], InvalidatedBlockSourceDomain)
 	copy(domainInput[32:], dep.OutputRoot[:])
 	return crypto.Keccak256Hash(domainInput[:])
-}
-
-// InvalidatedBlockSourceDepositTx builds the system deposit transaction that marks an
-// optimistic block as invalidated. The output-root preimage is embedded as the tx data.
-func InvalidatedBlockSourceDepositTx(outputRootPreimage []byte) *optypes.DepositTx {
-	outputRoot := crypto.Keccak256Hash(outputRootPreimage)
-	src := InvalidatedBlockSource{OutputRoot: outputRoot}
-	return &optypes.DepositTx{
-		SourceHash:          src.SourceHash(),
-		From:                OptimisticBlockDepositSenderAddress,
-		To:                  &common.Address{}, // to the zero address, no EVM execution.
-		Mint:                big.NewInt(0),
-		Value:               big.NewInt(0),
-		Gas:                 36_000,
-		IsSystemTransaction: false,
-		Data:                outputRootPreimage,
-	}
 }

--- a/op-node/rollup/derive/deposit_source.go
+++ b/op-node/rollup/derive/deposit_source.go
@@ -5,8 +5,9 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 )
 
 var OptimisticBlockDepositSenderAddress = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0002")
@@ -86,10 +87,10 @@ func (dep *InvalidatedBlockSource) SourceHash() common.Hash {
 
 // InvalidatedBlockSourceDepositTx builds the system deposit transaction that marks an
 // optimistic block as invalidated. The output-root preimage is embedded as the tx data.
-func InvalidatedBlockSourceDepositTx(outputRootPreimage []byte) *types.Transaction {
+func InvalidatedBlockSourceDepositTx(outputRootPreimage []byte) *optypes.DepositTx {
 	outputRoot := crypto.Keccak256Hash(outputRootPreimage)
 	src := InvalidatedBlockSource{OutputRoot: outputRoot}
-	return types.NewTx(&types.DepositTx{
+	return &optypes.DepositTx{
 		SourceHash:          src.SourceHash(),
 		From:                OptimisticBlockDepositSenderAddress,
 		To:                  &common.Address{}, // to the zero address, no EVM execution.
@@ -98,5 +99,5 @@ func InvalidatedBlockSourceDepositTx(outputRootPreimage []byte) *types.Transacti
 		Gas:                 36_000,
 		IsSystemTransaction: false,
 		Data:                outputRootPreimage,
-	})
+	}
 }

--- a/op-node/rollup/derive/deposits.go
+++ b/op-node/rollup/derive/deposits.go
@@ -7,11 +7,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 )
 
 // UserDeposits transforms the L2 block-height and L1 receipts into the transaction inputs for a full L2 block
-func UserDeposits(receipts []*types.Receipt, depositContractAddr common.Address) ([]*types.DepositTx, error) {
-	var out []*types.DepositTx
+func UserDeposits(receipts []*types.Receipt, depositContractAddr common.Address) ([]*optypes.DepositTx, error) {
+	var out []*optypes.DepositTx
 	var result error
 	for i, rec := range receipts {
 		if rec.Status != types.ReceiptStatusSuccessful {
@@ -39,7 +41,7 @@ func DeriveDeposits(receipts []*types.Receipt, depositContractAddr common.Addres
 	}
 	encodedTxs := make([]hexutil.Bytes, 0, len(userDeposits))
 	for i, tx := range userDeposits {
-		opaqueTx, err := types.NewTx(tx).MarshalBinary()
+		opaqueTx, err := tx.MarshalBinary()
 		if err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to encode user tx %d", i))
 		} else {

--- a/op-node/rollup/derive/ecotone_upgrade_transactions.go
+++ b/op-node/rollup/derive/ecotone_upgrade_transactions.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/solabi"
 )
 
@@ -44,7 +44,7 @@ var (
 func EcotoneNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns := make([]hexutil.Bytes, 0, 6)
 
-	deployL1BlockTransaction, err := types.NewTx(&types.DepositTx{
+	deployL1BlockTransaction, err := (&optypes.DepositTx{
 		SourceHash:          deployL1BlockSource.SourceHash(),
 		From:                L1BlockDeployerAddress,
 		To:                  nil,
@@ -61,7 +61,7 @@ func EcotoneNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 
 	upgradeTxns = append(upgradeTxns, deployL1BlockTransaction)
 
-	deployGasPriceOracle, err := types.NewTx(&types.DepositTx{
+	deployGasPriceOracle, err := (&optypes.DepositTx{
 		SourceHash:          deployGasPriceOracleSource.SourceHash(),
 		From:                GasPriceOracleDeployerAddress,
 		To:                  nil,
@@ -78,7 +78,7 @@ func EcotoneNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 
 	upgradeTxns = append(upgradeTxns, deployGasPriceOracle)
 
-	updateL1BlockProxy, err := types.NewTx(&types.DepositTx{
+	updateL1BlockProxy, err := (&optypes.DepositTx{
 		SourceHash:          updateL1BlockProxySource.SourceHash(),
 		From:                common.Address{},
 		To:                  &predeploys.L1BlockAddr,
@@ -95,7 +95,7 @@ func EcotoneNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 
 	upgradeTxns = append(upgradeTxns, updateL1BlockProxy)
 
-	updateGasPriceOracleProxy, err := types.NewTx(&types.DepositTx{
+	updateGasPriceOracleProxy, err := (&optypes.DepositTx{
 		SourceHash:          updateGasPriceOracleSource.SourceHash(),
 		From:                common.Address{},
 		To:                  &predeploys.GasPriceOracleAddr,
@@ -112,7 +112,7 @@ func EcotoneNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 
 	upgradeTxns = append(upgradeTxns, updateGasPriceOracleProxy)
 
-	enableEcotone, err := types.NewTx(&types.DepositTx{
+	enableEcotone, err := (&optypes.DepositTx{
 		SourceHash:          enableEcotoneSource.SourceHash(),
 		From:                L1InfoDepositerAddress,
 		To:                  &predeploys.GasPriceOracleAddr,
@@ -127,7 +127,7 @@ func EcotoneNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 	}
 	upgradeTxns = append(upgradeTxns, enableEcotone)
 
-	deployEIP4788, err := types.NewTx(&types.DepositTx{
+	deployEIP4788, err := (&optypes.DepositTx{
 		From:                EIP4788From,
 		To:                  nil, // contract-deployment tx
 		Mint:                big.NewInt(0),

--- a/op-node/rollup/derive/fjord_upgrade_transactions.go
+++ b/op-node/rollup/derive/fjord_upgrade_transactions.go
@@ -4,9 +4,9 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -35,7 +35,7 @@ func FjordNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns := make([]hexutil.Bytes, 0, 3)
 
 	// Deploy Gas Price Oracle transaction
-	deployGasPriceOracle, err := types.NewTx(&types.DepositTx{
+	deployGasPriceOracle, err := (&optypes.DepositTx{
 		SourceHash:          deployFjordGasPriceOracleSource.SourceHash(),
 		From:                GasPriceOracleFjordDeployerAddress,
 		To:                  nil,
@@ -52,7 +52,7 @@ func FjordNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 
 	upgradeTxns = append(upgradeTxns, deployGasPriceOracle)
 
-	updateGasPriceOracleProxy, err := types.NewTx(&types.DepositTx{
+	updateGasPriceOracleProxy, err := (&optypes.DepositTx{
 		SourceHash:          updateFjordGasPriceOracleSource.SourceHash(),
 		From:                common.Address{},
 		To:                  &predeploys.GasPriceOracleAddr,
@@ -69,7 +69,7 @@ func FjordNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 
 	upgradeTxns = append(upgradeTxns, updateGasPriceOracleProxy)
 
-	enableFjord, err := types.NewTx(&types.DepositTx{
+	enableFjord, err := (&optypes.DepositTx{
 		SourceHash:          enableFjordSource.SourceHash(),
 		From:                L1InfoDepositerAddress,
 		To:                  &predeploys.GasPriceOracleAddr,

--- a/op-node/rollup/derive/interop_activation_transactions.go
+++ b/op-node/rollup/derive/interop_activation_transactions.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -80,7 +80,7 @@ func interopSetFeatureTx() (hexutil.Bytes, error) {
 	data = append(data, featureBytes[:]...)
 
 	addr := predeploys.L1BlockAddr
-	return types.NewTx(&types.DepositTx{
+	return (&optypes.DepositTx{
 		SourceHash:          interopSetFeatureSource.SourceHash(),
 		From:                L1InfoDepositerAddress,
 		To:                  &addr,
@@ -98,7 +98,7 @@ func interopSetFeatureTx() (hexutil.Bytes, error) {
 func interopETHLiquidityFundingTx() (hexutil.Bytes, error) {
 	addr := predeploys.ETHLiquidityAddr
 	amount := InteropETHLiquidityFundingAmount()
-	return types.NewTx(&types.DepositTx{
+	return (&optypes.DepositTx{
 		SourceHash:          interopETHLiquidityFundSrc.SourceHash(),
 		From:                L1InfoDepositerAddress,
 		To:                  &addr,

--- a/op-node/rollup/derive/isthmus_upgrade_transactions.go
+++ b/op-node/rollup/derive/isthmus_upgrade_transactions.go
@@ -4,9 +4,9 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -46,7 +46,7 @@ func IsthmusNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns := make([]hexutil.Bytes, 0, 8)
 
 	// Deploy L1 Block transaction
-	deployL1BlockTransaction, err := types.NewTx(&types.DepositTx{
+	deployL1BlockTransaction, err := (&optypes.DepositTx{
 		SourceHash:          deployIsthmusL1BlockSource.SourceHash(),
 		From:                L1BlockIsthmusDeployerAddress,
 		To:                  nil,
@@ -64,7 +64,7 @@ func IsthmusNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns = append(upgradeTxns, deployL1BlockTransaction)
 
 	// Deploy Gas Price Oracle transaction
-	deployGasPriceOracle, err := types.NewTx(&types.DepositTx{
+	deployGasPriceOracle, err := (&optypes.DepositTx{
 		SourceHash:          deployIsthmusGasPriceOracleSource.SourceHash(),
 		From:                GasPriceOracleIsthmusDeployerAddress,
 		To:                  nil,
@@ -82,7 +82,7 @@ func IsthmusNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns = append(upgradeTxns, deployGasPriceOracle)
 
 	// Deploy Operator Fee vault transaction
-	deployOperatorFeeVault, err := types.NewTx(&types.DepositTx{
+	deployOperatorFeeVault, err := (&optypes.DepositTx{
 		SourceHash:          deployOperatorFeeVaultSource.SourceHash(),
 		From:                OperatorFeeVaultDeployerAddress,
 		To:                  nil,
@@ -100,7 +100,7 @@ func IsthmusNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns = append(upgradeTxns, deployOperatorFeeVault)
 
 	// Deploy L1 Block Proxy upgrade transaction
-	updateL1BlockProxy, err := types.NewTx(&types.DepositTx{
+	updateL1BlockProxy, err := (&optypes.DepositTx{
 		SourceHash:          updateIsthmusL1BlockProxySource.SourceHash(),
 		From:                common.Address{},
 		To:                  &predeploys.L1BlockAddr,
@@ -118,7 +118,7 @@ func IsthmusNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns = append(upgradeTxns, updateL1BlockProxy)
 
 	// Deploy Gas Price Oracle Proxy upgrade transaction
-	updateGasPriceOracleProxy, err := types.NewTx(&types.DepositTx{
+	updateGasPriceOracleProxy, err := (&optypes.DepositTx{
 		SourceHash:          updateIsthmusGasPriceOracleSource.SourceHash(),
 		From:                common.Address{},
 		To:                  &predeploys.GasPriceOracleAddr,
@@ -136,7 +136,7 @@ func IsthmusNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns = append(upgradeTxns, updateGasPriceOracleProxy)
 
 	// Deploy Operator Fee Vault Proxy upgrade transaction
-	updateOperatorFeeVaultProxy, err := types.NewTx(&types.DepositTx{
+	updateOperatorFeeVaultProxy, err := (&optypes.DepositTx{
 		SourceHash:          updateOperatorFeeVaultSource.SourceHash(),
 		From:                common.Address{},
 		To:                  &predeploys.OperatorFeeVaultAddr,
@@ -154,7 +154,7 @@ func IsthmusNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns = append(upgradeTxns, updateOperatorFeeVaultProxy)
 
 	// Enable Isthmus transaction
-	enableIsthmus, err := types.NewTx(&types.DepositTx{
+	enableIsthmus, err := (&optypes.DepositTx{
 		SourceHash:          enableIsthmusSource.SourceHash(),
 		From:                L1InfoDepositerAddress,
 		To:                  &predeploys.GasPriceOracleAddr,
@@ -171,7 +171,7 @@ func IsthmusNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 
 	upgradeTxns = append(upgradeTxns, enableIsthmus)
 
-	deployHistoricalBlockHashesContract, err := types.NewTx(&types.DepositTx{
+	deployHistoricalBlockHashesContract, err := (&optypes.DepositTx{
 		SourceHash:          blockHashDeployerSource.SourceHash(),
 		From:                predeploys.EIP2935ContractDeployer,
 		To:                  nil,

--- a/op-node/rollup/derive/jovian_upgrade_transactions.go
+++ b/op-node/rollup/derive/jovian_upgrade_transactions.go
@@ -5,9 +5,9 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -37,7 +37,7 @@ var (
 )
 
 func DAFootprintNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
-	deployL1Block, err := types.NewTx(&types.DepositTx{
+	deployL1Block, err := (&optypes.DepositTx{
 		SourceHash:          deployJovianL1BlockSource.SourceHash(),
 		From:                L1BlockJovianDeployerAddress,
 		To:                  nil,
@@ -51,7 +51,7 @@ func DAFootprintNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 		return nil, fmt.Errorf("build tx to deploy L1 block transaction: %w", err)
 	}
 
-	updateL1BlockProxy, err := types.NewTx(&types.DepositTx{
+	updateL1BlockProxy, err := (&optypes.DepositTx{
 		SourceHash:          updateJovianL1BlockProxySource.SourceHash(),
 		From:                common.Address{},
 		To:                  &predeploys.L1BlockAddr,
@@ -72,7 +72,7 @@ func OperatorFeeFixUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns := make([]hexutil.Bytes, 0, 8)
 
 	// Deploy Gas Price Oracle transaction
-	deployGasPriceOracle, err := types.NewTx(&types.DepositTx{
+	deployGasPriceOracle, err := (&optypes.DepositTx{
 		SourceHash:          deployJovianGasPriceOracleSource.SourceHash(),
 		From:                GasPriceOracleJovianDeployerAddress,
 		To:                  nil,
@@ -90,7 +90,7 @@ func OperatorFeeFixUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns = append(upgradeTxns, deployGasPriceOracle)
 
 	// Deploy Gas Price Oracle Proxy upgrade transaction
-	updateGasPriceOracleProxy, err := types.NewTx(&types.DepositTx{
+	updateGasPriceOracleProxy, err := (&optypes.DepositTx{
 		SourceHash:          updateJovianGasPriceOracleSource.SourceHash(),
 		From:                common.Address{},
 		To:                  &predeploys.GasPriceOracleAddr,
@@ -108,7 +108,7 @@ func OperatorFeeFixUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns = append(upgradeTxns, updateGasPriceOracleProxy)
 
 	// Enable Jovian transaction
-	enableJovian, err := types.NewTx(&types.DepositTx{
+	enableJovian, err := (&optypes.DepositTx{
 		SourceHash:          enableJovianSource.SourceHash(),
 		From:                L1InfoDepositerAddress,
 		To:                  &predeploys.GasPriceOracleAddr,

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -9,11 +9,11 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/solabi"
@@ -481,7 +481,7 @@ func L1BlockInfoFromBytes(rollupCfg *rollup.Config, l2BlockTime uint64, data []b
 
 // L1InfoDeposit creates a L1 Info deposit transaction based on the L1 block,
 // and the L2 block-height difference with the start of the epoch.
-func L1InfoDeposit(rollupCfg *rollup.Config, l1ChainConfig *params.ChainConfig, sysCfg eth.SystemConfig, seqNumber uint64, block eth.BlockInfo, l2Timestamp uint64) (*types.DepositTx, error) {
+func L1InfoDeposit(rollupCfg *rollup.Config, l1ChainConfig *params.ChainConfig, sysCfg eth.SystemConfig, seqNumber uint64, block eth.BlockInfo, l2Timestamp uint64) (*optypes.DepositTx, error) {
 	l1BlockInfo := L1BlockInfo{
 		Number:         block.NumberU64(),
 		Time:           block.Time(),
@@ -567,7 +567,7 @@ func L1InfoDeposit(rollupCfg *rollup.Config, l1ChainConfig *params.ChainConfig, 
 	}
 	// Set a very large gas limit with `IsSystemTransaction` to ensure
 	// that the L1 Attributes Transaction does not run out of gas.
-	out := &types.DepositTx{
+	out := &optypes.DepositTx{
 		SourceHash:          source.SourceHash(),
 		From:                L1InfoDepositerAddress,
 		To:                  &L1BlockAddress,
@@ -591,8 +591,7 @@ func L1InfoDepositBytes(rollupCfg *rollup.Config, l1ChainConfig *params.ChainCon
 	if err != nil {
 		return nil, fmt.Errorf("failed to create L1 info tx: %w", err)
 	}
-	l1Tx := types.NewTx(dep)
-	opaqueL1Tx, err := l1Tx.MarshalBinary()
+	opaqueL1Tx, err := dep.MarshalBinary()
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode L1 info tx: %w", err)
 	}

--- a/op-node/rollup/derive/l2block_util.go
+++ b/op-node/rollup/derive/l2block_util.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -43,7 +44,7 @@ func L2BlockToBlockRef(rollupCfg *rollup.Config, block L2BlockRefSource) (eth.L2
 			return eth.L2BlockRef{}, fmt.Errorf("l2 block is missing L1 info deposit tx, block hash: %s", hash)
 		}
 		tx := txs[0]
-		if tx.Type() != types.DepositTxType {
+		if tx.Type() != optypes.DepositTxType {
 			return eth.L2BlockRef{}, fmt.Errorf("first payload tx has unexpected tx type: %d", tx.Type())
 		}
 		info, err := L1BlockInfoFromBytes(rollupCfg, block.Time(), tx.Data())

--- a/op-node/rollup/derive/payload_util.go
+++ b/op-node/rollup/derive/payload_util.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-core/eip1559"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -32,7 +33,7 @@ func PayloadToBlockRef(rollupCfg *rollup.Config, payload *eth.ExecutionPayload) 
 		if err := tx.UnmarshalBinary(payload.Transactions[0]); err != nil {
 			return eth.L2BlockRef{}, fmt.Errorf("failed to decode first tx to read l1 info from: %w", err)
 		}
-		if tx.Type() != types.DepositTxType {
+		if tx.Type() != optypes.DepositTxType {
 			return eth.L2BlockRef{}, fmt.Errorf("first payload tx has unexpected tx type: %d", tx.Type())
 		}
 		info, err := L1BlockInfoFromBytes(rollupCfg, uint64(payload.Timestamp), tx.Data())
@@ -93,7 +94,7 @@ func PayloadToSystemConfig(rollupCfg *rollup.Config, payload *eth.ExecutionPaylo
 	if err := tx.UnmarshalBinary(payload.Transactions[0]); err != nil {
 		return eth.SystemConfig{}, fmt.Errorf("failed to decode first tx to read l1 info from: %w", err)
 	}
-	if tx.Type() != types.DepositTxType {
+	if tx.Type() != optypes.DepositTxType {
 		return eth.SystemConfig{}, fmt.Errorf("first payload tx has unexpected tx type: %d", tx.Type())
 	}
 	info, err := L1BlockInfoFromBytes(rollupCfg, uint64(payload.Timestamp), tx.Data())

--- a/op-node/rollup/derive/test/random.go
+++ b/op-node/rollup/derive/test/random.go
@@ -29,9 +29,9 @@ func RandomL2Block(rng *rand.Rand, txCount int, t time.Time) (*types.Block, []*t
 		panic("L1InfoDeposit: " + err.Error())
 	}
 	if t.IsZero() {
-		return testutils.RandomBlockPrependTxs(rng, txCount, types.NewTx(l1InfoTx))
+		return testutils.RandomBlockPrependTxs(rng, txCount, testutils.TxFromDeposit(l1InfoTx))
 	} else {
-		return testutils.RandomBlockPrependTxsWithTime(rng, txCount, uint64(t.Unix()), types.NewTx(l1InfoTx))
+		return testutils.RandomBlockPrependTxsWithTime(rng, txCount, uint64(t.Unix()), testutils.TxFromDeposit(l1InfoTx))
 	}
 
 }

--- a/op-node/rollup/derive/upgrade_transaction.go
+++ b/op-node/rollup/derive/upgrade_transaction.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-core/nuts"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // Network Upgrade Transactions (NUTs) are read from a JSON file and
@@ -89,7 +89,7 @@ func (b *nutBundle) toDepositTransactions() ([]hexutil.Bytes, error) {
 		// so both implementations derive the same UpgradeDepositSource hashes.
 		qualifiedIntent := fmt.Sprintf("%s %d: %s", capitalizeForkName(b.ForkName), i, nutTx.Intent)
 		source := UpgradeDepositSource{Intent: qualifiedIntent}
-		depTx := &types.DepositTx{
+		depTx := &optypes.DepositTx{
 			SourceHash:          source.SourceHash(),
 			From:                nutTx.From,
 			To:                  nutTx.To,
@@ -100,7 +100,7 @@ func (b *nutBundle) toDepositTransactions() ([]hexutil.Bytes, error) {
 			Data:                nutTx.Data,
 		}
 
-		encoded, err := types.NewTx(depTx).MarshalBinary()
+		encoded, err := depTx.MarshalBinary()
 		if err != nil {
 			return nil, fmt.Errorf("tx %d: failed to marshal deposit tx: %w", i, err)
 		}

--- a/op-node/rollup/engine/build_seal.go
+++ b/op-node/rollup/engine/build_seal.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -133,7 +133,7 @@ func isDepositTx(opaqueTx eth.Data) (bool, error) {
 	if len(opaqueTx) == 0 {
 		return false, errors.New("empty transaction")
 	}
-	return opaqueTx[0] == types.DepositTxType, nil
+	return opaqueTx[0] == optypes.DepositTxType, nil
 }
 
 // lastDeposit finds the index of last deposit at the start of the transactions.
@@ -160,7 +160,7 @@ func sanityCheckPayload(payload *eth.ExecutionPayload) error {
 	if len(payload.Transactions) == 0 {
 		return errors.New("no transactions in returned payload")
 	}
-	if payload.Transactions[0][0] != types.DepositTxType {
+	if payload.Transactions[0][0] != optypes.DepositTxType {
 		return fmt.Errorf("first transaction was not deposit tx. Got %v", payload.Transactions[0][0])
 	}
 	// Ensure that the deposits are first

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -18,6 +18,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/holiman/uint256"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 )
 
 type ErrorCode int
@@ -533,7 +535,7 @@ type PayloadAttributes struct {
 // type. Empty transactions are also considered non-Deposit transactions.
 func (a *PayloadAttributes) IsDepositsOnly() bool {
 	for _, tx := range a.Transactions {
-		if len(tx) == 0 || tx[0] != types.DepositTxType {
+		if len(tx) == 0 || tx[0] != optypes.DepositTxType {
 			return false
 		}
 	}
@@ -546,7 +548,7 @@ func (a *PayloadAttributes) WithDepositsOnly() *PayloadAttributes {
 	clone := *a
 	depositTxs := make([]Data, 0, len(a.Transactions))
 	for _, tx := range a.Transactions {
-		if len(tx) > 0 && tx[0] == types.DepositTxType {
+		if len(tx) > 0 && tx[0] == optypes.DepositTxType {
 			depositTxs = append(depositTxs, tx)
 		}
 	}

--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -178,7 +179,7 @@ func (block *RPCBlock) Verify() error {
 	// Withdrawals validation is different between L1 and L2.
 	// It is possible to determine that it is an L2 block if the first transaction is a deposit.
 	// The genesis block does not have transactions, but does have a known fee-recipient predeploy address.
-	isL2 := (len(block.Transactions) > 0 && block.Transactions[0].IsDepositTx()) ||
+	isL2 := (len(block.Transactions) > 0 && optypes.IsDepositTx(block.Transactions[0])) ||
 		(block.Number == 0 && block.Coinbase == predeploys.SequencerFeeVaultAddr)
 	if isL2 {
 		if err := block.validateL2Withdrawals(block.Withdrawals, block.WithdrawalsRoot); err != nil {

--- a/op-service/testutils/deposits.go
+++ b/op-service/testutils/deposits.go
@@ -42,19 +42,20 @@ func GenerateDeposit(sourceHash common.Hash, rng *rand.Rand) *optypes.DepositTx 
 // TxFromDeposit wraps an op-core deposit tx in a go-ethereum *types.Transaction for
 // test paths that feed deposits into block or tx-list builders still typed on
 // *types.Transaction. Callers that only need the deposit's hash use
-// (*optypes.DepositTx).Hash() instead. It round-trips through the canonical encoding,
-// so it depends on go-ethereum still decoding the deposit tx type; it is removed once
-// the test suites move off *types.Transaction for deposits.
+// (*optypes.DepositTx).Hash() instead. It constructs op-geth's deposit tx directly
+// from the identical fields; it is removed once the test suites move off
+// *types.Transaction for deposits.
 func TxFromDeposit(dep *optypes.DepositTx) *types.Transaction {
-	raw, err := dep.MarshalBinary()
-	if err != nil {
-		panic(err)
-	}
-	var tx types.Transaction
-	if err := tx.UnmarshalBinary(raw); err != nil {
-		panic(err)
-	}
-	return &tx
+	return types.NewTx(&types.DepositTx{
+		SourceHash:          dep.SourceHash,
+		From:                dep.From,
+		To:                  dep.To,
+		Mint:                dep.Mint,
+		Value:               dep.Value,
+		Gas:                 dep.Gas,
+		IsSystemTransaction: dep.IsSystemTransaction,
+		Data:                dep.Data,
+	})
 }
 
 // Generates an EVM log entry with the given topics and data.

--- a/op-service/testutils/deposits.go
+++ b/op-service/testutils/deposits.go
@@ -39,10 +39,12 @@ func GenerateDeposit(sourceHash common.Hash, rng *rand.Rand) *optypes.DepositTx 
 	return dep
 }
 
-// TxFromDeposit wraps an op-core deposit tx in a go-ethereum *types.Transaction, for
-// tests that still build blocks from *types.Transaction. It round-trips through the
-// canonical encoding, so it depends on go-ethereum still decoding the deposit tx type;
-// it is removed once the test suites move off *types.Transaction for deposits.
+// TxFromDeposit wraps an op-core deposit tx in a go-ethereum *types.Transaction for
+// test paths that feed deposits into block or tx-list builders still typed on
+// *types.Transaction. Callers that only need the deposit's hash use
+// (*optypes.DepositTx).Hash() instead. It round-trips through the canonical encoding,
+// so it depends on go-ethereum still decoding the deposit tx type; it is removed once
+// the test suites move off *types.Transaction for deposits.
 func TxFromDeposit(dep *optypes.DepositTx) *types.Transaction {
 	raw, err := dep.MarshalBinary()
 	if err != nil {

--- a/op-service/testutils/deposits.go
+++ b/op-service/testutils/deposits.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 )
 
 // Returns a DepositEvent customized on the basis of the id parameter.
-func GenerateDeposit(sourceHash common.Hash, rng *rand.Rand) *types.DepositTx {
+func GenerateDeposit(sourceHash common.Hash, rng *rand.Rand) *optypes.DepositTx {
 	dataLen := rng.Int63n(10_000)
 	data := make([]byte, dataLen)
 	rng.Read(data)
@@ -24,7 +26,7 @@ func GenerateDeposit(sourceHash common.Hash, rng *rand.Rand) *types.DepositTx {
 		mint = RandomETH(rng, 200)
 	}
 
-	dep := &types.DepositTx{
+	dep := &optypes.DepositTx{
 		SourceHash:          sourceHash,
 		From:                RandomAddress(rng),
 		To:                  to,
@@ -35,6 +37,22 @@ func GenerateDeposit(sourceHash common.Hash, rng *rand.Rand) *types.DepositTx {
 		IsSystemTransaction: false,
 	}
 	return dep
+}
+
+// TxFromDeposit wraps an op-core deposit tx in a go-ethereum *types.Transaction, for
+// tests that still build blocks from *types.Transaction. It round-trips through the
+// canonical encoding, so it depends on go-ethereum still decoding the deposit tx type;
+// it is removed once the test suites move off *types.Transaction for deposits.
+func TxFromDeposit(dep *optypes.DepositTx) *types.Transaction {
+	raw, err := dep.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	var tx types.Transaction
+	if err := tx.UnmarshalBinary(raw); err != nil {
+		panic(err)
+	}
+	return &tx
 }
 
 // Generates an EVM log entry with the given topics and data.

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/plan"
 )
@@ -594,7 +595,7 @@ func (tx *PlannedTx) Defaults() {
 				R:          nil,
 				S:          nil,
 			}, nil
-		case types.DepositTxType:
+		case optypes.DepositTxType:
 			return nil, errors.New("deposit tx not supported")
 		default:
 			return nil, fmt.Errorf("unrecognized tx type: %d", tx.Type.Value())


### PR DESCRIPTION
Wires op-node, op-service and op-batcher (plus their downstream op-e2e / op-devstack / op-chain-ops callers) onto the landed `op-core/types` and `op-core/fees` packages. Implements §1 and §2 of `docs/ai/opgeth-decoupling.md`.

No production code in op-node / op-service / op-batcher still constructs or decodes go-ethereum's `types.DepositTx`, nor calls the fork `*types.Transaction` methods.

- `types.NewTx(&types.DepositTx{...}).MarshalBinary()` → `(&optypes.DepositTx{...}).MarshalBinary()`
- `UnmarshalDepositLogEvent` / `UserDeposits` / `L1InfoDeposit` / `MarshalDepositLogEvent` / `GenerateDeposit` / `InvalidatedBlockSourceDepositTx` return op-core `DepositTx`
- `tx.IsDepositTx()` → `optypes.IsDepositTx(tx)`; `tx.RollupCostData()` → `opfees.TxRollupCostData(tx)`; `types.DepositTxType` → `optypes.DepositTxType`
- `interop-deposits-dump` decodes via `optypes.UnmarshalDepositTx` and reads struct fields
- new `optypes.DepositTx.Hash()` (= keccak256 of the canonical encoding, pinned by a `TestDepositHashParity` differential test); hash-only deposit callers use it directly
- `testutils.TxFromDeposit` bridges op-core deposits to `*types.Transaction` only for test paths that feed deposits into block/tx-list builders (removed at cutover)

Behaviour is byte-identical, pinned by the existing `op-core/types` and `op-core/fees` differential tests.

Closes #20269

🤖 Generated by Claude Code