### PR TITLE
fix: harden op-challenger, op-rbuilder and rollup-boost images with Wolfi base

### DIFF
--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -308,7 +308,7 @@ RUN mkdir -p /musl && cp -a /lib/ld-musl-*.so.1 /lib/libc.musl-*.so.1 /musl/
 
 # Also produce an op-challenger loaded with kona
 FROM $CHALLENGER_TARGET_BASE_IMAGE AS op-challenger-target
-RUN n=0; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
+RUN attempt=1; delay=1; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do [ "$attempt" -ge 11 ] && exit 1; echo "apk add attempt $attempt/11 failed; retrying in ${delay}s" >&2; sleep "$delay"; attempt=$((attempt+1)); delay=$((delay*2)); [ "$delay" -le 60 ] || delay=60; done
 COPY --from=musl-libs /musl/ /lib/
 COPY --from=op-challenger-builder /app/op-challenger/bin/op-challenger /usr/local/bin/
 # Copy in cannon

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -9,8 +9,9 @@
 # It will default to the target platform.
 ARG TARGET_BASE_IMAGE=chainguard/static:latest
 
-# The ubuntu target base image is used for the op-challenger build with kona.
-ARG UBUNTU_TARGET_BASE_IMAGE=ubuntu:24.04
+# op-challenger runs on Wolfi: glibc for kona-host, busybox for the chart's
+# /bin/sh entrypoint, plus a bundled musl loader for the musl-linked cannon embeds.
+ARG CHALLENGER_TARGET_BASE_IMAGE=chainguard/wolfi-base:latest@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795
 
 # builder_foundry does not need to be built on $BUILDPLATFORM, as foundry produces static binaries.
 FROM alpine:3.21 AS builder_foundry
@@ -300,9 +301,15 @@ USER 0
 COPY --from=op-node-builder /app/op-node/bin/op-node /usr/local/bin/
 CMD ["op-node"]
 
-# Also produce an op-challenger loaded with kona using ubuntu
-FROM $UBUNTU_TARGET_BASE_IMAGE AS op-challenger-target
-RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 install -y --no-install-recommends musl openssl ca-certificates && rm -rf /var/lib/apt/lists/*
+# The historical multicannon embeds are Alpine/musl-linked and Wolfi ships no musl
+# package, so bundle the loader+libc (as the melange multicannon pipeline does).
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d AS musl-libs
+RUN mkdir -p /musl && cp -a /lib/ld-musl-*.so.1 /lib/libc.musl-*.so.1 /musl/
+
+# Also produce an op-challenger loaded with kona
+FROM $CHALLENGER_TARGET_BASE_IMAGE AS op-challenger-target
+RUN n=0; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
+COPY --from=musl-libs /musl/ /lib/
 COPY --from=op-challenger-builder /app/op-challenger/bin/op-challenger /usr/local/bin/
 # Copy in cannon
 COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/

--- a/rust/op-rbuilder/Dockerfile
+++ b/rust/op-rbuilder/Dockerfile
@@ -136,14 +136,16 @@ RUN case "$TARGETPLATFORM" in \
     cargo build --release --locked --features="$FEATURES" --package=${RBUILDER_BIN} --target "${ARCH_TAG}"
 
 # Runtime container for rbuilder
-FROM gcr.io/distroless/cc-debian13:latest@sha256:8b5d1db6d2253036a53cb8362d3e3fa82a7caf84c247772c46a023166c64e977 AS rbuilder-runtime
+FROM chainguard/wolfi-base:latest@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795 AS rbuilder-runtime
+RUN n=0; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
 ARG RBUILDER_BIN
 WORKDIR /app
 COPY --from=rbuilder /workspace/op-rbuilder/target/release/${RBUILDER_BIN} /app/rbuilder
 ENTRYPOINT ["/app/rbuilder"]
 
 # Reproducible runtime container for rbuilder
-FROM gcr.io/distroless/cc-debian13:latest@sha256:8b5d1db6d2253036a53cb8362d3e3fa82a7caf84c247772c46a023166c64e977 AS rbuilder-reproducible-runtime
+FROM chainguard/wolfi-base:latest@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795 AS rbuilder-reproducible-runtime
+RUN n=0; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
 ARG RBUILDER_BIN
 WORKDIR /app
 COPY --from=rbuilder-reproducible /workspace/op-rbuilder/target/*/release/${RBUILDER_BIN} /app/rbuilder

--- a/rust/op-rbuilder/Dockerfile
+++ b/rust/op-rbuilder/Dockerfile
@@ -137,7 +137,7 @@ RUN case "$TARGETPLATFORM" in \
 
 # Runtime container for rbuilder
 FROM chainguard/wolfi-base:latest@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795 AS rbuilder-runtime
-RUN n=0; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
+RUN attempt=1; delay=1; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do [ "$attempt" -ge 11 ] && exit 1; echo "apk add attempt $attempt/11 failed; retrying in ${delay}s" >&2; sleep "$delay"; attempt=$((attempt+1)); delay=$((delay*2)); [ "$delay" -le 60 ] || delay=60; done
 ARG RBUILDER_BIN
 WORKDIR /app
 COPY --from=rbuilder /workspace/op-rbuilder/target/release/${RBUILDER_BIN} /app/rbuilder
@@ -145,7 +145,7 @@ ENTRYPOINT ["/app/rbuilder"]
 
 # Reproducible runtime container for rbuilder
 FROM chainguard/wolfi-base:latest@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795 AS rbuilder-reproducible-runtime
-RUN n=0; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
+RUN attempt=1; delay=1; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do [ "$attempt" -ge 11 ] && exit 1; echo "apk add attempt $attempt/11 failed; retrying in ${delay}s" >&2; sleep "$delay"; attempt=$((attempt+1)); delay=$((delay*2)); [ "$delay" -le 60 ] || delay=60; done
 ARG RBUILDER_BIN
 WORKDIR /app
 COPY --from=rbuilder-reproducible /workspace/op-rbuilder/target/*/release/${RBUILDER_BIN} /app/rbuilder

--- a/rust/rollup-boost/Dockerfile
+++ b/rust/rollup-boost/Dockerfile
@@ -85,10 +85,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #
 # Runtime container
 #
-FROM debian:trixie-slim
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+FROM chainguard/wolfi-base:latest@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795
+RUN n=0; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
 WORKDIR /app
 
 ARG SERVICE_NAME

--- a/rust/rollup-boost/Dockerfile
+++ b/rust/rollup-boost/Dockerfile
@@ -86,7 +86,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # Runtime container
 #
 FROM chainguard/wolfi-base:latest@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795
-RUN n=0; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do n=$((n+1)); [ "$n" -ge 15 ] && exit 1; echo "apk add retry $n/15 in 20s" >&2; sleep 20; done
+RUN attempt=1; delay=1; until apk add --no-cache ca-certificates-bundle ca-certificates busybox glibc libgcc libstdc++ openssl; do [ "$attempt" -ge 11 ] && exit 1; echo "apk add attempt $attempt/11 failed; retrying in ${delay}s" >&2; sleep "$delay"; attempt=$((attempt+1)); delay=$((delay*2)); [ "$delay" -le 60 ] || delay=60; done
 WORKDIR /app
 
 ARG SERVICE_NAME


### PR DESCRIPTION
## Summary

Swap the runtime base image of three service Dockerfiles for a digest-pinned
`chainguard/wolfi-base`, plus the same minimal package set the apko-built images
already use. Keeps the existing Dockerfile workflow (easy for service owners to
review and adopt) while applying the same hardening principles as the parallel
apko path added in #21557.

- `ops/docker/op-stack-go/Dockerfile` (op-challenger target): `ubuntu:24.04` → `chainguard/wolfi-base`
- `rust/rollup-boost/Dockerfile`: `debian:trixie-slim` → `chainguard/wolfi-base`
- `rust/op-rbuilder/Dockerfile`: `gcr.io/distroless/cc-debian13` → `chainguard/wolfi-base` (both runtime stages)

Rust/kona binaries are glibc-dynamic, so Wolfi's `glibc`/`libgcc`/`libstdc++`
are a drop-in. op-challenger additionally bundles the musl loader+libc from an
`alpine` stage so its musl-linked multicannon embeds still exec — Wolfi ships no
`musl` package, so this mirrors what the melange multicannon pipeline already does.
Bases are pinned by digest. `apk add` uses bounded exponential backoff, with 11 attempts and a 60-second cap, to tolerate transient CDN failures without masking persistent errors.

## Vulnerability + size comparison

`grype 0.107.0`, `linux/arm64`, current develop image vs the Wolfi image
(final runtime = base + packages + the same binaries):

| Image | Base before → after | Vulns before | Vulns after | Size |
|---|---|---:|---:|---|
| `op-challenger` | ubuntu:24.04 → wolfi | 120 (0C/4H/90M/23L/2N) | **10** (0/4/5/0/0) | 420→303 MB |
| `op-rbuilder` | distroless/cc-debian13 → wolfi | 27 (2/10/6/2/7) | **0** | 257→232 MB |
| `rollup-boost` | debian:trixie-slim → wolfi | 162 (7/20/45/4/50) | **0** | 200→82 MB |
