### PR TITLE
kona: reject leading 0x00 span-batch tx-type byte

### DIFF
--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -532,6 +532,31 @@ func TestSpanBatchReadTxDataInvalid(t *testing.T) {
 	require.ErrorContains(t, err, "tx RLP prefix type must be list")
 }
 
+// TestSpanBatchReadTxDataLeadingZero locks the op-node side of the op-node<->kona span-batch
+// decode invariant on the shared conformance vector [00 c1 05]. A leading 0x00 is an EIP-2718
+// type identifier of 0, so op-node keeps the byte rather than reading it as a prefixless legacy
+// tx, then rejects it as an unsupported typed-tx envelope (dropping the batch). kona must reach
+// the same verdict; if one side accepts the element as a legacy tx while the other drops the
+// batch, a byzantine batcher can fork the two derivation implementations on identical L1 bytes.
+func TestSpanBatchReadTxDataLeadingZero(t *testing.T) {
+	// 0x00 type byte followed by a valid one-element RLP list (0xc1 0x05).
+	vec := []byte{0x00, 0xc1, 0x05}
+
+	// ReadTxData keeps the leading 0x00 and reports it as legacy type (byte value 0) — unlike
+	// kona, which swallows the 0x00 and decodes the following bytes as a legacy tx.
+	r := bytes.NewReader(vec)
+	txData, txType, err := ReadTxData(r)
+	require.NoError(t, err)
+	require.Equal(t, int(types.LegacyTxType), txType)
+	require.Equal(t, vec, txData)
+
+	// The kept 0x00 is not a supported typed-tx envelope, so the element (and thus the batch) is
+	// rejected here.
+	var sbtx spanBatchTx
+	err = sbtx.UnmarshalBinary(txData)
+	require.ErrorIs(t, err, types.ErrTxTypeNotSupported)
+}
+
 func TestSpanBatchMaxTxData(t *testing.T) {
 	rng := rand.New(rand.NewSource(0x177288))
 

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -532,29 +532,32 @@ func TestSpanBatchReadTxDataInvalid(t *testing.T) {
 	require.ErrorContains(t, err, "tx RLP prefix type must be list")
 }
 
-// TestSpanBatchReadTxDataLeadingZero locks the op-node side of the op-node<->kona span-batch
-// decode invariant on the shared conformance vector [00 c1 05]. A leading 0x00 is an EIP-2718
-// type identifier of 0, so op-node keeps the byte rather than reading it as a prefixless legacy
-// tx, then rejects it as an unsupported typed-tx envelope (dropping the batch). kona must reach
-// the same verdict; if one side accepts the element as a legacy tx while the other drops the
-// batch, a byzantine batcher can fork the two derivation implementations on identical L1 bytes.
+// TestSpanBatchReadTxDataLeadingZero locks op-node's decode of the shared conformance vector
+// [00 c3 80 80 80]: a valid legacy span-batch tx (an RLP list of value, gas_price, data) with a
+// 0x00 EIP-2718 type byte prepended. op-node keeps the 0x00 and rejects it as an unsupported
+// typed-tx envelope, dropping the batch, even though the unprefixed payload decodes as a valid
+// legacy tx. The kona decoder must reach the same verdict, or the two derivations fork on
+// identical L1 bytes.
 func TestSpanBatchReadTxDataLeadingZero(t *testing.T) {
-	// 0x00 type byte followed by a valid one-element RLP list (0xc1 0x05).
-	vec := []byte{0x00, 0xc1, 0x05}
+	payload := []byte{0xc3, 0x80, 0x80, 0x80}
+	prefixed := append([]byte{0x00}, payload...)
 
-	// ReadTxData keeps the leading 0x00 and reports it as legacy type (byte value 0) — unlike
-	// kona, which swallows the 0x00 and decodes the following bytes as a legacy tx.
-	r := bytes.NewReader(vec)
+	// The unprefixed payload is a valid legacy tx.
+	var legacy spanBatchTx
+	require.NoError(t, legacy.UnmarshalBinary(payload))
+	require.Equal(t, uint8(types.LegacyTxType), legacy.Type())
+
+	// ReadTxData keeps the leading 0x00 and reports legacy type.
+	r := bytes.NewReader(prefixed)
 	txData, txType, err := ReadTxData(r)
 	require.NoError(t, err)
 	require.Equal(t, int(types.LegacyTxType), txType)
-	require.Equal(t, vec, txData)
+	require.Equal(t, prefixed, txData)
 
 	// The kept 0x00 is not a supported typed-tx envelope, so the element (and thus the batch) is
-	// rejected here.
+	// rejected.
 	var sbtx spanBatchTx
-	err = sbtx.UnmarshalBinary(txData)
-	require.ErrorIs(t, err, types.ErrTxTypeNotSupported)
+	require.ErrorIs(t, sbtx.UnmarshalBinary(txData), types.ErrTxTypeNotSupported)
 }
 
 func TestSpanBatchMaxTxData(t *testing.T) {

--- a/rust/kona/crates/protocol/protocol/src/utils.rs
+++ b/rust/kona/crates/protocol/protocol/src/utils.rs
@@ -153,7 +153,8 @@ const EIP2718_MAX_TX_TYPE: u8 = 0x7F;
 pub fn read_tx_data(r: &mut &[u8]) -> Result<(Vec<u8>, OpTxType), SpanBatchError> {
     let first_byte =
         *r.first().ok_or(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))?;
-    let tx_type_id = if first_byte <= EIP2718_MAX_TX_TYPE {
+    let has_type_prefix = first_byte <= EIP2718_MAX_TX_TYPE;
+    let tx_type_id = if has_type_prefix {
         r.advance(1);
         first_byte
     } else {
@@ -179,6 +180,14 @@ pub fn read_tx_data(r: &mut &[u8]) -> Result<(Vec<u8>, OpTxType), SpanBatchError
     let tx_type = match OpTxType::try_from(tx_type_id) {
         // Deposits are not valid span-batch transactions, and an unknown byte is invalid too.
         Ok(OpTxType::Deposit) | Err(_) => {
+            return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType));
+        }
+        // A consumed type prefix that resolves to `Legacy` is a leading `0x00`: not a valid
+        // typed envelope, since legacy transactions carry no prefix. op-node keeps the byte and
+        // rejects it in `decodeTyped`, so we must reject it here — otherwise a byzantine batcher
+        // could post one span-batch element that kona decodes as a legacy tx and op-node drops,
+        // diverging the two derivation implementations.
+        Ok(OpTxType::Legacy) if has_type_prefix => {
             return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType));
         }
         Ok(ty) => ty,
@@ -589,6 +598,37 @@ mod tests {
         let mut data: &[u8] = &[0xf8, 0x64, 0x00, 0x00, 0x00];
         let err = read_tx_data(&mut data).unwrap_err();
         assert_eq!(err, SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData));
+    }
+
+    #[test]
+    fn test_read_tx_data_rejects_leading_zero_type_byte() {
+        // A leading `0x00` is an EIP-2718 type identifier of 0, not the RLP list header of a
+        // legacy transaction. op-node keeps the byte and rejects it (`decodeTyped` has no case
+        // for `0x00`), so kona must reject it too — decoding the following bytes as a legacy tx
+        // would fork the two derivation implementations. `[0x00, 0xc1, 0x05]` is the shared
+        // cross-client conformance vector: `0xc1 0x05` alone is a valid one-element RLP list.
+        let mut data: &[u8] = &[0x00, 0xc1, 0x05];
+        let err = read_tx_data(&mut data).unwrap_err();
+        assert_eq!(err, SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType));
+    }
+
+    #[test]
+    fn test_read_tx_data_accepts_prefixless_legacy() {
+        // A first byte > 0x7F is the RLP list header of a legacy tx (no type prefix); it must
+        // still decode as `Legacy` with the bytes returned verbatim.
+        let mut data: &[u8] = &[0xc1, 0x05];
+        let (tx_data, tx_type) = read_tx_data(&mut data).unwrap();
+        assert_eq!(tx_type, OpTxType::Legacy);
+        assert_eq!(tx_data, vec![0xc1, 0x05]);
+    }
+
+    #[test]
+    fn test_read_tx_data_accepts_typed() {
+        // A valid EIP-2718 type byte (0x02 = EIP-1559) is kept and re-prepended to the payload.
+        let mut data: &[u8] = &[0x02, 0xc1, 0x05];
+        let (tx_data, tx_type) = read_tx_data(&mut data).unwrap();
+        assert_eq!(tx_type, OpTxType::Eip1559);
+        assert_eq!(tx_data, vec![0x02, 0xc1, 0x05]);
     }
 
     #[test]

--- a/rust/kona/crates/protocol/protocol/src/utils.rs
+++ b/rust/kona/crates/protocol/protocol/src/utils.rs
@@ -145,8 +145,10 @@ fn encode_scalar(blob_base_fee_scalar: u32, base_fee_scalar: u32) -> U256 {
     buf.into()
 }
 
-/// Maximum EIP-2718 transaction-type byte. A leading byte above this is the RLP list header of a
-/// legacy transaction rather than a type identifier.
+/// Maximum EIP-2718 transaction-type byte. A larger leading byte is not a type identifier but the
+/// start of a prefixless legacy transaction — a bare RLP list, whose header is `0xc0..=0xfe`. Any
+/// other high byte (an RLP string `0x80..=0xbf`, or reserved `0xff`) is rejected by the list check
+/// in [`read_tx_data`].
 const EIP2718_MAX_TX_TYPE: u8 = 0x7F;
 
 /// Reads transaction data from a reader.
@@ -601,25 +603,44 @@ mod tests {
     }
 
     #[test]
+    fn test_read_tx_data_accepts_prefixless_legacy() {
+        use crate::SpanBatchTransactionData;
+        use alloy_rlp::Decodable;
+
+        // A first byte > 0x7F is not a type id, so it is read as a prefixless legacy tx. `c3 80 80
+        // 80` is a schema-valid legacy element — an RLP list of the three legacy fields (value,
+        // gas_price, data), here all zero/empty: read_tx_data returns it verbatim and it decodes
+        // end-to-end as a legacy tx.
+        let mut data: &[u8] = &[0xc3, 0x80, 0x80, 0x80];
+        let (tx_data, tx_type) = read_tx_data(&mut data).unwrap();
+        assert_eq!(tx_type, OpTxType::Legacy);
+        assert_eq!(tx_data, vec![0xc3, 0x80, 0x80, 0x80]);
+        SpanBatchTransactionData::decode(&mut tx_data.as_slice())
+            .expect("prefixless legacy payload decodes into a legacy tx");
+    }
+
+    #[test]
     fn test_read_tx_data_rejects_leading_zero_type_byte() {
-        // A leading `0x00` is an EIP-2718 type identifier of 0, not the RLP list header of a
-        // legacy transaction. op-node keeps the byte and rejects it (`decodeTyped` has no case
-        // for `0x00`), so kona must reject it too — decoding the following bytes as a legacy tx
-        // would fork the two derivation implementations. `[0x00, 0xc1, 0x05]` is the shared
-        // cross-client conformance vector: `0xc1 0x05` alone is a valid one-element RLP list.
-        let mut data: &[u8] = &[0x00, 0xc1, 0x05];
+        // The shared op-node<->kona conformance vector: the valid legacy element from
+        // `test_read_tx_data_accepts_prefixless_legacy` with a `0x00` EIP-2718 type byte prepended.
+        // `0x00` names no valid typed envelope, so it must be rejected. Swallowing the `0x00` and
+        // decoding the rest as that legacy tx — while op-node keeps the `0x00` and drops the batch
+        // — would fork the two derivation implementations end-to-end.
+        let mut data: &[u8] = &[0x00, 0xc3, 0x80, 0x80, 0x80];
         let err = read_tx_data(&mut data).unwrap_err();
         assert_eq!(err, SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType));
     }
 
     #[test]
-    fn test_read_tx_data_accepts_prefixless_legacy() {
-        // A first byte > 0x7F is the RLP list header of a legacy tx (no type prefix); it must
-        // still decode as `Legacy` with the bytes returned verbatim.
-        let mut data: &[u8] = &[0xc1, 0x05];
-        let (tx_data, tx_type) = read_tx_data(&mut data).unwrap();
-        assert_eq!(tx_type, OpTxType::Legacy);
-        assert_eq!(tx_data, vec![0xc1, 0x05]);
+    fn test_read_tx_data_rejects_non_list_high_first_byte() {
+        // Not every byte > 0x7F is a legacy list header: 0x80..=0xbf are RLP strings and 0xff is
+        // reserved. These are read as prefixless legacy candidates but rejected by the RLP list
+        // check, so only genuine list headers (0xc0..=0xfe) survive.
+        for first in [0x80u8, 0xbf, 0xff] {
+            let mut data: &[u8] = &[first];
+            let err = read_tx_data(&mut data).unwrap_err();
+            assert_eq!(err, SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Aligns kona's span-batch `read_tx_data` with op-node on a leading `0x00` tx-type byte.

`read_tx_data` consumed a leading `0x00` as an EIP-2718 type prefix and, because `OpTxType::try_from(0x00) = Legacy`, decoded the *following* bytes as a legacy transaction. op-node instead keeps the `0x00` and rejects it as an unsupported typed-tx envelope (`decodeTyped` has no `0x00` case), so the two derivation implementations disagreed on identical span-batch bytes.

The fix rejects a *consumed* type prefix that resolves to `Legacy`: a legacy tx has no prefix, so its first byte is an RLP list header (`0xc0..`), never a type identifier. Prefixless legacy txs are unchanged. After this, kona's accepted tx-type set (`legacy`, `0x01`, `0x02`, `0x04`, `0x7D`) matches op-node's `decodeTyped` exactly.

Consensus-affecting (derivation): deploying to a live chain requires a new kona-client release + prestate.

Adds `[00 c3 80 80 80]` as a shared conformance vector on both the kona and op-node decoders — a valid legacy tx (three empty fields) that both clients reject once a `0x00` type byte is prepended.

🤖 *Generated by Claude Opus 4.8 (1M context)*
