### PR TITLE
kona,gossip: bind gossip message-id to topic, meter invalid messages

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7102,6 +7102,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-stream",
  "metrics",
+ "metrics-util",
  "multihash",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
@@ -8684,7 +8685,9 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "metrics",
+ "ordered-float",
  "quanta",
  "rand 0.9.4",
  "rand_xoshiro",
@@ -9793,6 +9796,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "outref"

--- a/rust/kona/crates/node/gossip/Cargo.toml
+++ b/rust/kona/crates/node/gossip/Cargo.toml
@@ -61,6 +61,7 @@ multihash.workspace = true
 serde_json.workspace = true
 alloy-eips.workspace = true
 alloy-chains.workspace = true
+metrics-util = { workspace = true, features = ["debugging"] }
 
 rand = { workspace = true, features = ["thread_rng"] }
 arbitrary = { workspace = true, features = ["derive"] }

--- a/rust/kona/crates/node/gossip/src/config.rs
+++ b/rust/kona/crates/node/gossip/src/config.rs
@@ -122,29 +122,28 @@ pub(crate) fn snappy_decompressed_len_within_bound(data: &[u8]) -> Option<usize>
 /// This is invoked as gossipsub's `message_id_fn` on every inbound PUBLISH before signature
 /// validation, so the input is unauthenticated.
 fn compute_message_id(msg: &Message) -> MessageId {
-    let id = if snappy_decompressed_len_within_bound(&msg.data).is_some() {
-        let mut decoder = Decoder::new();
-        decoder.decompress_vec(&msg.data).map_or_else(
-            |_| {
-                warn!(target: "cfg", "Failed to decompress message, using invalid snappy");
-                let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
-                sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())
-                    [..20]
-                    .to_vec()
-            },
-            |data| {
-                let domain_valid_snappy: Vec<u8> = vec![0x1, 0x0, 0x0, 0x0];
-                sha256([domain_valid_snappy.as_slice(), data.as_slice()].concat().as_slice())[..20]
-                    .to_vec()
-            },
-        )
-    } else {
-        // Oversized/malformed frame: take the invalid-snappy domain without logging. This path is
-        // driven by unauthenticated remote input, so it must not be able to spam warnings.
-        let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
-        sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())[..20]
-            .to_vec()
-    };
+    // Only attempt decompression once the header's declared length is within bound, so an oversized
+    // frame never triggers a large allocation (see `snappy_decompressed_len_within_bound`).
+    let decompressed = snappy_decompressed_len_within_bound(&msg.data)
+        .and_then(|_| Decoder::new().decompress_vec(&msg.data).ok());
+
+    let id = decompressed.map_or_else(
+        || {
+            // Oversized or undecompressable frame: take the invalid-snappy domain. Count and
+            // debug-log, never warn — this runs on unauthenticated remote input.
+            kona_macros::inc!(counter, crate::Metrics::MESSAGE_ID_INVALID_SNAPPY);
+            debug!(target: "gossip", len = msg.data.len(), "Snappy frame failed to decompress within bound in message-id");
+            let domain_invalid_snappy = [0u8; 4];
+            sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())
+                [..20]
+                .to_vec()
+        },
+        |data| {
+            let domain_valid_snappy = [0x1u8, 0x0, 0x0, 0x0];
+            sha256([domain_valid_snappy.as_slice(), data.as_slice()].concat().as_slice())[..20]
+                .to_vec()
+        },
+    );
 
     MessageId(id)
 }
@@ -171,7 +170,7 @@ mod tests {
         };
 
         let id = compute_message_id(&msg);
-        let hashed = sha256(&[&[0x0, 0x0, 0x0, 0x0], [1, 2, 3, 4, 5].as_slice()].concat());
+        let hashed = sha256(&[&[0u8; 4], [1, 2, 3, 4, 5].as_slice()].concat());
         assert_eq!(id.0, hashed[..20].to_vec());
     }
 
@@ -213,7 +212,7 @@ mod tests {
 
         let id = compute_message_id(&msg);
         // Bomb takes the oversized-header rejection branch: hash uses invalid-snappy domain.
-        let expected = sha256(&[&[0x0, 0x0, 0x0, 0x0], bomb.as_slice()].concat());
+        let expected = sha256(&[&[0u8; 4], bomb.as_slice()].concat());
         assert_eq!(id.0, expected[..20].to_vec());
     }
 
@@ -236,7 +235,7 @@ mod tests {
         let id = compute_message_id(&msg);
 
         // Bounded path: invalid-snappy domain over the raw (still-compressed) bytes.
-        let bounded = sha256(&[[0x0u8, 0x0, 0x0, 0x0].as_slice(), over.as_slice()].concat());
+        let bounded = sha256(&[[0u8; 4].as_slice(), over.as_slice()].concat());
         assert_eq!(id.0, bounded[..20].to_vec());
 
         // The id an unbounded implementation would produce (decompress, then valid-snappy
@@ -275,5 +274,86 @@ mod tests {
 
         let small = snap::raw::Encoder::new().compress_vec(&[1, 2, 3, 4, 5]).unwrap();
         assert_eq!(snappy_decompressed_len_within_bound(&small), Some(5));
+    }
+
+    #[cfg(feature = "metrics")]
+    fn message_id_invalid_snappy_count(snapshot: metrics_util::debugging::Snapshot) -> u64 {
+        use metrics_util::debugging::DebugValue;
+        for (ckey, _unit, _desc, value) in snapshot.into_vec() {
+            if ckey.key().name() != crate::Metrics::MESSAGE_ID_INVALID_SNAPPY {
+                continue;
+            }
+            if let DebugValue::Counter(c) = value {
+                return c;
+            }
+        }
+        0
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn compute_message_id_records_invalid_snappy_on_decompress_failure() {
+        use metrics_util::debugging::DebuggingRecorder;
+
+        // Declares a 1-byte payload but the body is corrupt, so `decompress_vec` fails.
+        let msg = Message {
+            source: None,
+            data: vec![1, 2, 3, 4, 5],
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw("test"),
+        };
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            let _ = compute_message_id(&msg);
+        });
+
+        assert_eq!(message_id_invalid_snappy_count(snapshotter.snapshot()), 1);
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn compute_message_id_records_invalid_snappy_on_oversize_frame() {
+        use metrics_util::debugging::DebuggingRecorder;
+
+        // A tiny frame that validly declares a decompressed size over the bound.
+        let over = snap::raw::Encoder::new().compress_vec(&vec![0u8; MAX_GOSSIP_SIZE + 1]).unwrap();
+        let msg = Message {
+            source: None,
+            data: over,
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw("test"),
+        };
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            let _ = compute_message_id(&msg);
+        });
+
+        assert_eq!(message_id_invalid_snappy_count(snapshotter.snapshot()), 1);
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn compute_message_id_does_not_record_invalid_snappy_on_valid_frame() {
+        use metrics_util::debugging::DebuggingRecorder;
+
+        let valid = snap::raw::Encoder::new().compress_vec(&[1, 2, 3, 4, 5]).unwrap();
+        let msg = Message {
+            source: None,
+            data: valid,
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw("test"),
+        };
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            let _ = compute_message_id(&msg);
+        });
+
+        assert_eq!(message_id_invalid_snappy_count(snapshotter.snapshot()), 0);
     }
 }

--- a/rust/kona/crates/node/gossip/src/config.rs
+++ b/rust/kona/crates/node/gossip/src/config.rs
@@ -115,42 +115,66 @@ pub(crate) fn snappy_decompressed_len_within_bound(data: &[u8]) -> Option<usize>
     snap::raw::decompress_len(data).ok().filter(|&n| n <= MAX_GOSSIP_SIZE)
 }
 
+/// Message-id domain separator for a frame that decompressed within [`MAX_GOSSIP_SIZE`], matching
+/// op-node's `MessageDomainValidSnappy`.
+const MESSAGE_DOMAIN_VALID_SNAPPY: [u8; 4] = [1, 0, 0, 0];
+
+/// Message-id domain separator for an oversized or undecompressable frame, matching op-node's
+/// `MessageDomainInvalidSnappy`.
+const MESSAGE_DOMAIN_INVALID_SNAPPY: [u8; 4] = [0, 0, 0, 0];
+
 /// Computes the [`MessageId`] of a `gossipsub` message.
 ///
-/// Oversized or malformed snappy frames are rejected via [`snappy_decompressed_len_within_bound`]
-/// before decompression and take the invalid-snappy domain, matching op-node's `BuildMsgIdFn`.
-/// This is invoked as gossipsub's `message_id_fn` on every inbound PUBLISH before signature
-/// validation, so the input is unauthenticated.
+/// Mirrors op-node's `BuildMsgIdFn`: the id is
+/// `sha256(domain || uint64_le(topic.len()) || topic || payload)[..20]`, where `payload` is the
+/// decompressed frame under the valid-snappy domain when it decompresses within
+/// [`MAX_GOSSIP_SIZE`], otherwise the raw frame under the invalid-snappy domain. Binding the topic
+/// keeps a valid frame replayed on the wrong block-version topic from colliding with the real
+/// message's id, which libp2p's cross-topic duplicate cache would otherwise suppress.
+///
+/// Invoked as gossipsub's `message_id_fn` on every inbound PUBLISH before signature validation, so
+/// the input is unauthenticated; oversized frames are bounded via
+/// [`snappy_decompressed_len_within_bound`] before decompression.
 fn compute_message_id(msg: &Message) -> MessageId {
     // Only attempt decompression once the header's declared length is within bound, so an oversized
     // frame never triggers a large allocation (see `snappy_decompressed_len_within_bound`).
     let decompressed = snappy_decompressed_len_within_bound(&msg.data)
         .and_then(|_| Decoder::new().decompress_vec(&msg.data).ok());
 
-    let id = decompressed.map_or_else(
+    let (domain, payload) = decompressed.as_deref().map_or_else(
         || {
-            // Oversized or undecompressable frame: take the invalid-snappy domain. Count and
-            // debug-log, never warn — this runs on unauthenticated remote input.
+            // Oversized or undecompressable frame: invalid-snappy domain. Count and debug-log,
+            // never warn — this runs on unauthenticated remote input.
             kona_macros::inc!(counter, crate::Metrics::MESSAGE_ID_INVALID_SNAPPY);
             debug!(target: "gossip", len = msg.data.len(), "Snappy frame failed to decompress within bound in message-id");
-            let domain_invalid_snappy = [0u8; 4];
-            sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())
-                [..20]
-                .to_vec()
+            (MESSAGE_DOMAIN_INVALID_SNAPPY, msg.data.as_slice())
         },
-        |data| {
-            let domain_valid_snappy = [0x1u8, 0x0, 0x0, 0x0];
-            sha256([domain_valid_snappy.as_slice(), data.as_slice()].concat().as_slice())[..20]
-                .to_vec()
-        },
+        |data| (MESSAGE_DOMAIN_VALID_SNAPPY, data),
     );
 
-    MessageId(id)
+    let topic = msg.topic.as_str().as_bytes();
+    let topic_len = (topic.len() as u64).to_le_bytes();
+    let digest =
+        sha256([domain.as_slice(), topic_len.as_slice(), topic, payload].concat().as_slice());
+
+    MessageId(digest[..20].to_vec())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Recomputes op-node's message-id construction for a topic + payload, used to pin
+    /// `compute_message_id`'s exact byte layout.
+    fn expected_message_id(domain: [u8; 4], topic: &str, payload: &[u8]) -> Vec<u8> {
+        let topic_len = (topic.len() as u64).to_le_bytes();
+        sha256(
+            [domain.as_slice(), topic_len.as_slice(), topic.as_bytes(), payload]
+                .concat()
+                .as_slice(),
+        )[..20]
+            .to_vec()
+    }
 
     #[test]
     fn test_constructs_default_config() {
@@ -170,8 +194,10 @@ mod tests {
         };
 
         let id = compute_message_id(&msg);
-        let hashed = sha256(&[&[0u8; 4], [1, 2, 3, 4, 5].as_slice()].concat());
-        assert_eq!(id.0, hashed[..20].to_vec());
+        assert_eq!(
+            id.0,
+            expected_message_id(MESSAGE_DOMAIN_INVALID_SNAPPY, "test", &[1, 2, 3, 4, 5])
+        );
     }
 
     #[test]
@@ -185,8 +211,58 @@ mod tests {
         };
 
         let id = compute_message_id(&msg);
-        let hashed = sha256(&[&[0x1, 0x0, 0x0, 0x0], [1, 2, 3, 4, 5].as_slice()].concat());
-        assert_eq!(id.0, hashed[..20].to_vec());
+        assert_eq!(
+            id.0,
+            expected_message_id(MESSAGE_DOMAIN_VALID_SNAPPY, "test", &[1, 2, 3, 4, 5])
+        );
+    }
+
+    #[test]
+    fn compute_message_id_binds_topic() {
+        // The same payload on two different block-version topics must produce different ids, so a
+        // valid frame replayed on the wrong topic cannot suppress the real message via libp2p's
+        // cross-topic duplicate cache.
+        let payload = vec![1u8, 2, 3, 4, 5];
+        let make = |topic: &str| Message {
+            source: None,
+            data: payload.clone(),
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw(topic),
+        };
+
+        let id_v1 = compute_message_id(&make("/optimism/10/0/blocks"));
+        let id_v2 = compute_message_id(&make("/optimism/10/1/blocks"));
+        assert_ne!(id_v1.0, id_v2.0, "message id must depend on the topic");
+        assert_eq!(
+            id_v1.0,
+            expected_message_id(MESSAGE_DOMAIN_INVALID_SNAPPY, "/optimism/10/0/blocks", &payload)
+        );
+    }
+
+    /// Golden vectors computed independently of this crate (Python `hashlib`), pinning byte-parity
+    /// with op-node's `BuildMsgIdFn`: `sha256(domain || uint64_le(topic.len()) || topic ||
+    /// payload)`.
+    #[test]
+    fn compute_message_id_matches_op_node_golden_vectors() {
+        let make = |data: Vec<u8>, topic: &str| Message {
+            source: None,
+            data,
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw(topic),
+        };
+
+        // Invalid snappy: raw payload [1,2,3,4,5] (fails decompression), topic "test".
+        assert_eq!(
+            compute_message_id(&make(vec![1, 2, 3, 4, 5], "test")).0,
+            alloy_primitives::hex::decode("b6897dcba59347fedcd694cc0f5117093c9dc727").unwrap(),
+        );
+
+        // Valid snappy: compress([1,2,3,4,5]) decompresses to [1,2,3,4,5], topic "test".
+        let valid = snap::raw::Encoder::new().compress_vec(&[1, 2, 3, 4, 5]).unwrap();
+        assert_eq!(
+            compute_message_id(&make(valid, "test")).0,
+            alloy_primitives::hex::decode("adbe547b27f41294a08a09210a5e8531e83cdc16").unwrap(),
+        );
     }
 
     /// The classic 7-byte snappy bomb declaring `u32::MAX` decompressed length takes the
@@ -212,8 +288,7 @@ mod tests {
 
         let id = compute_message_id(&msg);
         // Bomb takes the oversized-header rejection branch: hash uses invalid-snappy domain.
-        let expected = sha256(&[&[0u8; 4], bomb.as_slice()].concat());
-        assert_eq!(id.0, expected[..20].to_vec());
+        assert_eq!(id.0, expected_message_id(MESSAGE_DOMAIN_INVALID_SNAPPY, "test", &bomb));
     }
 
     /// Proves the bound actually gates decompression (distinguishing this implementation from
@@ -235,15 +310,12 @@ mod tests {
         let id = compute_message_id(&msg);
 
         // Bounded path: invalid-snappy domain over the raw (still-compressed) bytes.
-        let bounded = sha256(&[[0u8; 4].as_slice(), over.as_slice()].concat());
-        assert_eq!(id.0, bounded[..20].to_vec());
+        assert_eq!(id.0, expected_message_id(MESSAGE_DOMAIN_INVALID_SNAPPY, "test", &over));
 
         // The id an unbounded implementation would produce (decompress, then valid-snappy
         // domain) must NOT be the one returned.
         let decompressed = snap::raw::Decoder::new().decompress_vec(&over).unwrap();
-        let unbounded =
-            sha256(&[[0x1u8, 0x0, 0x0, 0x0].as_slice(), decompressed.as_slice()].concat());
-        assert_ne!(id.0, unbounded[..20].to_vec());
+        assert_ne!(id.0, expected_message_id(MESSAGE_DOMAIN_VALID_SNAPPY, "test", &decompressed));
     }
 
     #[test]

--- a/rust/kona/crates/node/gossip/src/handler.rs
+++ b/rust/kona/crates/node/gossip/src/handler.rs
@@ -51,8 +51,10 @@ impl Handler for BlockHandler {
         // buffer of the declared length (up to ~4 GiB) from a tiny frame. Mirrors op-node's
         // gossip topic validator, which rejects `outLen > maxGossipSize` before decompressing.
         if snappy_decompressed_len_within_bound(&msg.data).is_none() {
-            // Reject without logging: this is unauthenticated remote input and must not be able to
-            // spam warnings just by being invalid.
+            // Count for alerting and debug-log for investigation, but never warn: unauthenticated
+            // remote input must not be able to spam warnings just by being invalid.
+            kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "oversized_snappy");
+            debug!(target: "gossip", len = msg.data.len(), "Rejecting oversized snappy frame before decode");
             return (MessageAcceptance::Reject, None);
         }
 
@@ -65,7 +67,10 @@ impl Handler for BlockHandler {
         } else if msg.topic == self.blocks_v4_topic.hash() {
             OpNetworkPayloadEnvelope::decode_v4(&msg.data)
         } else {
-            warn!(target: "gossip", topic = ?msg.topic, "Received block with unknown topic");
+            // Unreachable in practice (the driver only dispatches known block topics), but count
+            // and debug-log it rather than warn if that ever changes.
+            kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "unknown_topic");
+            debug!(target: "gossip", topic = ?msg.topic, "Received block with unknown topic");
             return (MessageAcceptance::Reject, None);
         };
 
@@ -73,12 +78,16 @@ impl Handler for BlockHandler {
             Ok(envelope) => match self.block_valid(&envelope) {
                 Ok(()) => (MessageAcceptance::Accept, Some(envelope)),
                 Err(err) => {
-                    warn!(target: "gossip", ?err, hash = ?envelope.payload_hash, "Received invalid block");
+                    // Already metered by BLOCK_VALIDATION_FAILED; debug-log for investigation
+                    // without letting invalid remote blocks spam warnings.
+                    debug!(target: "gossip", ?err, hash = ?envelope.payload_hash, "Received invalid block");
                     (err.into(), None)
                 }
             },
             Err(err) => {
-                warn!(target: "gossip", ?err, "Failed to decode block");
+                // Undecodable payload from unauthenticated input: count and debug-log, don't warn.
+                kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "decode_error");
+                debug!(target: "gossip", ?err, "Failed to decode block");
                 (MessageAcceptance::Reject, None)
             }
         }
@@ -486,5 +495,109 @@ mod tests {
         };
 
         assert!(matches!(handler.handle(message).0, MessageAcceptance::Accept));
+    }
+
+    #[cfg(feature = "metrics")]
+    fn invalid_message_count(snapshot: metrics_util::debugging::Snapshot, reason: &str) -> u64 {
+        use metrics_util::debugging::DebugValue;
+        for (ckey, _unit, _desc, value) in snapshot.into_vec() {
+            let key = ckey.key();
+            let is_match = key.name() == crate::Metrics::INVALID_MESSAGE &&
+                key.labels().any(|l| l.key() == "reason" && l.value() == reason);
+            if !is_match {
+                continue;
+            }
+            if let DebugValue::Counter(c) = value {
+                return c;
+            }
+        }
+        0
+    }
+
+    #[cfg(feature = "metrics")]
+    fn zero_signer_handler() -> BlockHandler {
+        let (_, unsafe_signer) = tokio::sync::watch::channel(Address::ZERO);
+        BlockHandler::new(
+            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
+            unsafe_signer,
+        )
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn handle_records_invalid_message_metric_for_oversized_snappy() {
+        use metrics_util::debugging::DebuggingRecorder;
+
+        let mut handler = zero_signer_handler();
+        // Tiny frame whose snappy header declares a decompressed size over MAX_GOSSIP_SIZE.
+        let over = snap::raw::Encoder::new()
+            .compress_vec(&vec![0u8; crate::config::MAX_GOSSIP_SIZE + 1])
+            .unwrap();
+        let message = Message {
+            source: None,
+            sequence_number: None,
+            topic: handler.blocks_v1_topic.clone().into(),
+            data: over,
+        };
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let acc = metrics::with_local_recorder(&recorder, || handler.handle(message).0);
+
+        assert!(matches!(acc, MessageAcceptance::Reject));
+        assert_eq!(invalid_message_count(snapshotter.snapshot(), "oversized_snappy"), 1);
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn handle_records_invalid_message_metric_for_decode_error() {
+        use metrics_util::debugging::DebuggingRecorder;
+
+        // A v2-encoded payload published on the v1 topic fails `decode_v1` before validation.
+        let v2 = ExecutionPayloadV2::from_block_slow(&v2_valid_block());
+        let envelope = OpNetworkPayloadEnvelope {
+            payload: OpExecutionPayload::V2(v2),
+            signature: Signature::test_signature(),
+            payload_hash: PayloadHash(B256::ZERO),
+            parent_beacon_block_root: None,
+        };
+        let mut handler = zero_signer_handler();
+        let encoded = handler.encode(handler.blocks_v2_topic.clone(), envelope).unwrap();
+        let message = Message {
+            source: None,
+            sequence_number: None,
+            topic: handler.blocks_v1_topic.clone().into(),
+            data: encoded,
+        };
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let acc = metrics::with_local_recorder(&recorder, || handler.handle(message).0);
+
+        assert!(matches!(acc, MessageAcceptance::Reject));
+        assert_eq!(invalid_message_count(snapshotter.snapshot(), "decode_error"), 1);
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn handle_records_invalid_message_metric_for_unknown_topic() {
+        use metrics_util::debugging::DebuggingRecorder;
+
+        let mut handler = zero_signer_handler();
+        // Valid small snappy frame so the pre-decode bound passes; the topic is not a block topic.
+        let data = snap::raw::Encoder::new().compress_vec(&[1, 2, 3, 4, 5]).unwrap();
+        let message = Message {
+            source: None,
+            sequence_number: None,
+            topic: TopicHash::from_raw("unknown"),
+            data,
+        };
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let acc = metrics::with_local_recorder(&recorder, || handler.handle(message).0);
+
+        assert!(matches!(acc, MessageAcceptance::Reject));
+        assert_eq!(invalid_message_count(snapshotter.snapshot(), "unknown_topic"), 1);
     }
 }

--- a/rust/kona/crates/node/gossip/src/handler.rs
+++ b/rust/kona/crates/node/gossip/src/handler.rs
@@ -51,10 +51,11 @@ impl Handler for BlockHandler {
         // buffer of the declared length (up to ~4 GiB) from a tiny frame. Mirrors op-node's
         // gossip topic validator, which rejects `outLen > maxGossipSize` before decompressing.
         if snappy_decompressed_len_within_bound(&msg.data).is_none() {
-            // Count for alerting and debug-log for investigation, but never warn: unauthenticated
-            // remote input must not be able to spam warnings just by being invalid.
-            kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "oversized_snappy");
-            debug!(target: "gossip", len = msg.data.len(), "Rejecting oversized snappy frame before decode");
+            // The snappy header declares a length that is unreadable or over MAX_GOSSIP_SIZE. Count
+            // for alerting and debug-log for investigation, but never warn: unauthenticated remote
+            // input must not be able to spam warnings just by being invalid.
+            kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "invalid_snappy_length");
+            debug!(target: "gossip", len = msg.data.len(), "Rejecting snappy frame with invalid declared length before decode");
             return (MessageAcceptance::Reject, None);
         }
 
@@ -525,27 +526,32 @@ mod tests {
 
     #[cfg(feature = "metrics")]
     #[test]
-    fn handle_records_invalid_message_metric_for_oversized_snappy() {
+    fn handle_records_invalid_message_metric_for_invalid_snappy_length() {
         use metrics_util::debugging::DebuggingRecorder;
 
-        let mut handler = zero_signer_handler();
-        // Tiny frame whose snappy header declares a decompressed size over MAX_GOSSIP_SIZE.
-        let over = snap::raw::Encoder::new()
+        // Both an over-MAX_GOSSIP_SIZE header and a malformed/truncated header take the pre-decode
+        // reject path and share the `invalid_snappy_length` reason.
+        let oversized = snap::raw::Encoder::new()
             .compress_vec(&vec![0u8; crate::config::MAX_GOSSIP_SIZE + 1])
             .unwrap();
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            topic: handler.blocks_v1_topic.clone().into(),
-            data: over,
-        };
+        let malformed = vec![0xffu8]; // truncated snappy varint header
 
-        let recorder = DebuggingRecorder::new();
-        let snapshotter = recorder.snapshotter();
-        let acc = metrics::with_local_recorder(&recorder, || handler.handle(message).0);
+        for data in [oversized, malformed] {
+            let mut handler = zero_signer_handler();
+            let message = Message {
+                source: None,
+                sequence_number: None,
+                topic: handler.blocks_v1_topic.clone().into(),
+                data,
+            };
 
-        assert!(matches!(acc, MessageAcceptance::Reject));
-        assert_eq!(invalid_message_count(snapshotter.snapshot(), "oversized_snappy"), 1);
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            let acc = metrics::with_local_recorder(&recorder, || handler.handle(message).0);
+
+            assert!(matches!(acc, MessageAcceptance::Reject));
+            assert_eq!(invalid_message_count(snapshotter.snapshot(), "invalid_snappy_length"), 1);
+        }
     }
 
     #[cfg(feature = "metrics")]

--- a/rust/kona/crates/node/gossip/src/metrics/mod.rs
+++ b/rust/kona/crates/node/gossip/src/metrics/mod.rs
@@ -59,8 +59,9 @@ impl Metrics {
     /// validation, by reason.
     ///
     /// The reasons are mutually exclusive per message: the handler's pre-decode snappy bound
-    /// (`oversized_snappy`), envelope decode failures (`decode_error`), and unexpected topics
-    /// (`unknown_topic`). Messages that decode but fail block validation are counted by
+    /// (`invalid_snappy_length`, covering both unreadable and over-`MAX_GOSSIP_SIZE` headers),
+    /// envelope decode failures (`decode_error`), and unexpected topics (`unknown_topic`).
+    /// Messages that decode but fail block validation are counted by
     /// [`Self::BLOCK_VALIDATION_FAILED`] instead; malformed frames caught earlier, in the
     /// gossipsub `message_id` function, are counted by [`Self::MESSAGE_ID_INVALID_SNAPPY`].
     pub const INVALID_MESSAGE: &str = "kona_node_gossip_invalid_message";
@@ -70,7 +71,7 @@ impl Metrics {
     ///
     /// Recorded per receipt — before gossipsub de-duplication and before the block handler runs —
     /// so it counts on a larger denominator than [`Self::INVALID_MESSAGE`] and overlaps that
-    /// counter's `oversized_snappy`/`decode_error` reasons for the same message. It is not a
+    /// counter's `invalid_snappy_length`/`decode_error` reasons for the same message. It is not a
     /// rejection on its own: the message-id function only assigns the message id.
     pub const MESSAGE_ID_INVALID_SNAPPY: &str = "kona_node_gossip_message_id_invalid_snappy";
 
@@ -232,7 +233,7 @@ impl Metrics {
         kona_macros::set!(counter, Self::BLOCK_VERSION, "version", "v4", 0);
 
         // Messages rejected by the block handler before validation, by reason
-        kona_macros::set!(counter, Self::INVALID_MESSAGE, "reason", "oversized_snappy", 0);
+        kona_macros::set!(counter, Self::INVALID_MESSAGE, "reason", "invalid_snappy_length", 0);
         kona_macros::set!(counter, Self::INVALID_MESSAGE, "reason", "decode_error", 0);
         kona_macros::set!(counter, Self::INVALID_MESSAGE, "reason", "unknown_topic", 0);
 

--- a/rust/kona/crates/node/gossip/src/metrics/mod.rs
+++ b/rust/kona/crates/node/gossip/src/metrics/mod.rs
@@ -55,6 +55,25 @@ impl Metrics {
     /// Identifier for the counter that tracks block version distribution.
     pub const BLOCK_VERSION: &str = "kona_node_block_version";
 
+    /// Identifier for the counter that tracks messages the block handler rejected before block
+    /// validation, by reason.
+    ///
+    /// The reasons are mutually exclusive per message: the handler's pre-decode snappy bound
+    /// (`oversized_snappy`), envelope decode failures (`decode_error`), and unexpected topics
+    /// (`unknown_topic`). Messages that decode but fail block validation are counted by
+    /// [`Self::BLOCK_VALIDATION_FAILED`] instead; malformed frames caught earlier, in the
+    /// gossipsub `message_id` function, are counted by [`Self::MESSAGE_ID_INVALID_SNAPPY`].
+    pub const INVALID_MESSAGE: &str = "kona_node_gossip_invalid_message";
+
+    /// Identifier for the counter that tracks inbound frames the gossipsub `message_id` function
+    /// could not decompress within the gossip size bound.
+    ///
+    /// Recorded per receipt — before gossipsub de-duplication and before the block handler runs —
+    /// so it counts on a larger denominator than [`Self::INVALID_MESSAGE`] and overlaps that
+    /// counter's `oversized_snappy`/`decode_error` reasons for the same message. It is not a
+    /// rejection on its own: the message-id function only assigns the message id.
+    pub const MESSAGE_ID_INVALID_SNAPPY: &str = "kona_node_gossip_message_id_invalid_snappy";
+
     /// Initializes metrics for the Gossip stack.
     ///
     /// This does two things:
@@ -116,6 +135,14 @@ impl Metrics {
             "Duration of block validation in seconds"
         );
         metrics::describe_counter!(Self::BLOCK_VERSION, "Distribution of block versions");
+        metrics::describe_counter!(
+            Self::INVALID_MESSAGE,
+            "Number of inbound gossip messages the block handler rejected before block validation, by reason"
+        );
+        metrics::describe_counter!(
+            Self::MESSAGE_ID_INVALID_SNAPPY,
+            "Number of inbound gossip frames the message-id function could not decompress within the size bound"
+        );
     }
 
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
@@ -203,5 +230,13 @@ impl Metrics {
         kona_macros::set!(counter, Self::BLOCK_VERSION, "version", "v2", 0);
         kona_macros::set!(counter, Self::BLOCK_VERSION, "version", "v3", 0);
         kona_macros::set!(counter, Self::BLOCK_VERSION, "version", "v4", 0);
+
+        // Messages rejected by the block handler before validation, by reason
+        kona_macros::set!(counter, Self::INVALID_MESSAGE, "reason", "oversized_snappy", 0);
+        kona_macros::set!(counter, Self::INVALID_MESSAGE, "reason", "decode_error", 0);
+        kona_macros::set!(counter, Self::INVALID_MESSAGE, "reason", "unknown_topic", 0);
+
+        // Malformed frames caught in the message-id function (per receipt, before dedup)
+        kona_macros::set!(counter, Self::MESSAGE_ID_INVALID_SNAPPY, 0);
     }
 }


### PR DESCRIPTION
Follow-up to #21753 (merged). Two things, both from ajsutton's review.

## Message-id topic binding (block-propagation DoS fix)

`compute_message_id` hashed `sha256(domain ‖ payload)`, omitting the topic. libp2p's duplicate cache is global across topics and persists after application-level rejection, so an unauthenticated peer could replay a valid block's bytes on the *wrong* block-version topic — that copy computes the **same** message-id as the real block and, once cached, suppresses the real block as a duplicate for up to 120s.

Fixed to match op-node's `BuildMsgIdFn` exactly: `sha256(domain ‖ uint64_le(topic.len()) ‖ topic ‖ payload)[..20]`. Byte-parity is pinned by independent golden vectors plus a cross-topic regression test.

## Invalid-gossip metrics + debug logs

Replaces `warn!` on the message-validation paths with metrics + `debug!`: unauthenticated input must not be able to spam warnings just by being invalid; metrics are the always-on volume signal, `debug!` (off by default) the opt-in detail.

- `kona_node_gossip_invalid_message{reason}` — block-handler rejections before validation: `invalid_snappy_length` (unreadable or over-`MAX_GOSSIP_SIZE` header), `decode_error`, `unknown_topic` (mutually exclusive per message).
- `kona_node_gossip_message_id_invalid_snappy` — frames the message-id fn could not decompress within the size bound (per receipt, before dedup); its own counter since it overlaps the handler reasons.

Post-decode validation failures stay on the existing `BLOCK_VALIDATION_FAILED`.

🤖 *Co-created with Claude Opus 4.8*
