### PR TITLE
test(op-acceptance): settle light-seq cross-safe before EL safe assert

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -177,7 +177,12 @@ func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2
 	}, 8, 20)
 	sys.Supernode.AwaitValidatedTimestamp(sys.L2B.TimestampForBlockNum(settledBlock))
 	// The tx is in a derived-safe block on the supernode; the light sequencer must agree there.
-	// Wait for the light seq EL's safe head to reach it.
+	// The fresh tx re-diverges the light sequencer from upstream, so the follow-source loop must
+	// reconcile again. It advances the light CL's cross-safe roughly one block per two poll cycles
+	// (every other forceReset resets local-safe to genesis before re-adopting upstream, #21119), so
+	// settle on the CL's cross-safe reaching settledBlock before polling the EL: the EL's safe
+	// forkchoice pointer only moves once the CL emits the FCU for that cross-safe head.
+	sys.L2BCL.Reached(safety.CrossSafe, settledBlock, 45)
 	sys.L2BSupernodeEL.AssertTxInBlock(settledBlock, settledTxHash)
 	sys.L2ELB.Reached(eth.Safe, settledBlock, 30)
 	sys.L2ELB.AssertTxInBlock(settledBlock, settledTxHash)


### PR DESCRIPTION
## Summary

De-flakes `TestSupernodeLightSequencerInteropInvalidMessageReplacement` (job `memory-all-opn-op-reth`, ~2.4% fail rate — 2/82 job runs over 200 `develop` pipelines; most recent failure was pipeline 129922).

## Root cause

The light op-node is both a **sequencer** and a **follow-source follower**. After the invalid-message reorg, the fresh transfer sent by `ResendUntilSafe` re-diverges the light sequencer's unsafe head from the supernode's upstream safe chain. `EngineController.FollowSource` reorgs onto the upstream via `forceReset` (the #21119 / #21155 fix), but the sequencer rebuilds a block on its own fork before the next ~2s upstream poll lands the FCU — so recovery becomes a **ratcheting oscillation**: every other poll cycle adopts the upstream safe head, the alternate cycle resets `local-safe` back to genesis before re-adopting. Net advance is ~1 block per two cycles (~4s/block).

The final assertion `sys.L2ELB.Reached(eth.Safe, settledBlock, 30)` gives the light EL's `safe` forkchoice pointer 60s (30 × 2s) to reach the target. On a shard that loses the race, that budget can expire with the EL's safe still short of `settledBlock`, even though the supernode's own L1-derived safe head is well ahead. In pipeline 129922 the light EL safe was pinned at 26 (target 30) while the supernode's derived safe reached 61.

Convergence is **bounded, not stalled** — the sibling chain converged in the same run — so this is a race to be settled, not a liveness bug to work around.

## Fix

Gate on the light CL's cross-safe reaching `settledBlock` before polling the EL:

```go
sys.L2BCL.Reached(safety.CrossSafe, settledBlock, 45)
```

The EL's `safe` forkchoice pointer only advances once the CL emits the FCU for that cross-safe head, so waiting for the CL to converge first removes the race. The 45-attempt (90s) budget is sized to the measured ~4s/block oscillation rate. This mirrors the existing cross-safe settle gate earlier in the scenario.

## Follow-up (not in this PR)

This is a test-side fix. The underlying follow-source ↔ sequencer oscillation still costs real light-sequencer followers a wasted reset on every other poll cycle during divergence recovery; making `FollowSource`'s `forceReset` resist being clobbered by the next sequencer build would roughly halve convergence time. Worth a separate op-node issue.

## Testing

- `go vet` and `gofmt` clean.
- **Not run locally**: this test requires a built `op-reth` binary; runtime validation is via CI. Given the ~2.4% base rate, CI green across re-runs is the meaningful signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)