### PR TITLE
ci(kona-sp1): verify guest crypto patches

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -762,14 +762,13 @@ jobs:
           directory: rust
           profile: release
 
-  # fmt-check + clippy for the nested SP1 guest-program workspace. programs/range
-  # and programs/aggregation live in their own Cargo workspace with a private
-  # [patch.crates-io] table for the SP1 crypto forks, so they are NOT members of
-  # the root rust/ workspace and are not covered by rust-fmt / rust-clippy. This
-  # runs `just lint-sp1-guest` (same recipe `just lint` runs locally) on the host
-  # toolchain (no SP1 cargo-prove / RISC-V target required) so guest-side fmt and
-  # clippy regressions are caught on PRs. Clippy compiles the crates, so it also
-  # serves as the guest compile check.
+  # Dependency-patch verification, fmt-check, and clippy for the nested SP1
+  # guest-program workspace. The guest programs live in their own Cargo workspace
+  # with a private [patch.crates-io] table for the SP1 crypto forks, so they are NOT
+  # members of the root rust/ workspace and are not covered by rust-fmt / rust-clippy.
+  # This runs `just lint-sp1-guest` (same recipe `just lint` runs locally) on the
+  # host toolchain (no SP1 cargo-prove / RISC-V target required). Clippy compiles
+  # the crates, so it also serves as the guest compile check.
   rust-ci-sp1-guest-checks:
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
@@ -781,7 +780,7 @@ jobs:
           directory: rust/kona/sp1/programs
           prefix: rust/kona/sp1/programs-checks
       - run:
-          name: fmt-check + clippy SP1 guest programs
+          name: Verify patches + fmt-check + clippy SP1 guest programs
           working_directory: rust
           environment:
             RUSTFLAGS: -Dwarnings

--- a/rust/justfile
+++ b/rust/justfile
@@ -118,8 +118,9 @@ fmt-fix: fmt-fix-sp1-guest
 lint-clippy:
   cargo clippy --workspace --all-features --all-targets -- -D warnings
 
-# lock check + fmt-check + clippy for the SP1 guest program workspace (shared by `just lint` and CI)
-lint-sp1-guest: check-sp1-guest-lock fmt-check-sp1-guest lint-clippy-sp1-guest
+# lock + precompile-patch checks, fmt-check, and clippy for the SP1 guest program workspace
+# (shared by `just lint` and CI)
+lint-sp1-guest: check-sp1-guest-lock check-sp1-guest-precompile-patches fmt-check-sp1-guest lint-clippy-sp1-guest
 
 # Runs before the `--locked` clippy so a kona-only dependency change produces a
 # clear fix hint instead of cargo's cryptic "cannot update the lock file because
@@ -134,6 +135,67 @@ check-sp1-guest-lock:
     echo "       Fix: run \`just lock-sp1-guest\` from rust/ and commit the updated lockfile." >&2
     exit 1
   fi
+
+# Cargo only warns when a [patch.crates-io] entry is unused. Assert that every
+# crypto crate used by each guest program resolves exclusively to its SP1 fork.
+[script('bash')]
+check-sp1-guest-precompile-patches:
+  set -euo pipefail
+
+  common_patches=(
+    "sha2 RustCrypto-hashes"
+    "sha3 RustCrypto-hashes"
+    "crypto-bigint RustCrypto-bigint"
+    "k256 elliptic-curves"
+    "p256 elliptic-curves"
+  )
+
+  verify_program_patches() {
+    local program="$1"
+    shift
+
+    local dependency_tree
+    dependency_tree=$(cargo tree \
+      --manifest-path {{SP1_GUEST_MANIFEST}} \
+      --locked \
+      --package "$program" \
+      --edges normal \
+      --prefix none \
+      --format '{p}')
+
+    local patch package repository expected_source dependency found
+    for patch in "$@"; do
+      read -r package repository <<< "$patch"
+      expected_source="https://github.com/sp1-patches/${repository}?"
+      found=false
+
+      while IFS= read -r dependency; do
+        [[ "$dependency" == "$package v"* ]] || continue
+        found=true
+
+        if [[ "$dependency" != *"$expected_source"* ]]; then
+          echo "error: $program resolves an unpatched $package dependency:" >&2
+          echo "       $dependency" >&2
+          echo "       Expected every $package dependency to resolve from $expected_source" >&2
+          exit 1
+        fi
+      done <<< "$dependency_tree"
+
+      if [[ "$found" != true ]]; then
+        echo "error: $program does not resolve the expected $package dependency." >&2
+        exit 1
+      fi
+    done
+  }
+
+  # The range guests execute the L2 EVM, so they must also use the patched
+  # substrate-bn backend selected by revm's `bn` feature.
+  verify_program_patches kona-sp1-range "${common_patches[@]}" "substrate-bn bn"
+  verify_program_patches kona-sp1-super-range "${common_patches[@]}" "substrate-bn bn"
+
+  # Aggregation guests verify proofs but do not execute L2 EVM precompiles.
+  verify_program_patches kona-sp1-aggregation "${common_patches[@]}"
+  verify_program_patches kona-sp1-super-aggregation "${common_patches[@]}"
 
 # Resolves without --locked (minimal change), so it only touches entries that
 # actually moved rather than bumping unrelated guest deps.

--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -74,16 +74,17 @@ workflow behavior is not yet reproduced:
 
 ### Guest Precompile Patches
 
-The guest programs (`programs/range` and `programs/aggregation`) are isolated in
-`programs/Cargo.toml`, a nested Cargo workspace with its own `Cargo.lock` and
-`[patch.crates-io]` table. That workspace patches `sha2`, `sha3`,
-`crypto-bigint`, `k256`, `p256`, and `substrate-bn` to the SP1 forks, so the
-generated ELFs get zkVM precompile-accelerated crypto without changing the host
-`rust/` workspace dependency graph.
+The guest programs under `programs/` are isolated in `programs/Cargo.toml`, a
+nested Cargo workspace with its own `Cargo.lock` and `[patch.crates-io]` table.
+That workspace patches `sha2`, `sha3`, `crypto-bigint`, `k256`, `p256`, and
+`substrate-bn` to the SP1 forks, so the generated ELFs get zkVM
+precompile-accelerated crypto without changing the host `rust/` workspace
+dependency graph.
 
-The range guest also enables `revm`'s `bn` feature in the nested workspace. That
-forwards to `revm-precompile`'s `substrate-bn` backend for EIP-196/197 bn128
-precompiles. EIP-2537 BLS pairing still uses arkworks and is not SP1 accelerated.
+The EVM-executing range and super-range guests also enable `revm`'s `bn` feature
+in the nested workspace. That forwards to `revm-precompile`'s `substrate-bn`
+backend for EIP-196/197 bn128 precompiles. EIP-2537 BLS pairing still uses
+arkworks and is not SP1 accelerated.
 
 ## Usage
 

--- a/rust/kona/sp1/programs/Cargo.lock
+++ b/rust/kona/sp1/programs/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "kona-proof",
  "kona-sp1-client-utils",
  "kona-sp1-ethereum-client-utils",
+ "revm",
  "rkyv",
  "sp1-zkvm",
 ]

--- a/rust/kona/sp1/programs/super-range/Cargo.toml
+++ b/rust/kona/sp1/programs/super-range/Cargo.toml
@@ -13,6 +13,11 @@ anyhow.workspace = true
 kona-proof.workspace = true
 kona-sp1-client-utils.workspace = true
 kona-sp1-ethereum-client-utils.workspace = true
+
+# Feature anchor only: revm's `bn` forwards to revm-precompile/bn
+# (substrate-bn backend) in the guest build.
+revm.workspace = true
+
 rkyv.workspace = true
 sp1-zkvm.workspace = true
 


### PR DESCRIPTION
## Summary

Cargo only warns when a `[patch.crates-io]` entry is unused, which makes it possible for an SP1 guest to silently resolve the crates.io implementation instead of the accelerated fork.

This adds a CI check over each guest’s locked dependency tree and verifies that:

- `sha2`, `sha3`, `crypto-bigint`, `k256`, and `p256` resolve from their SP1 forks for all four guest programs.
- `substrate-bn` resolves from its SP1 fork for the EVM-executing `range` and `super-range` programs.
- No unpatched instance of those packages appears alongside the patched version.

The check runs as part of the existing required `rust-sp1-guest-checks` job.

This is intentionally a dependency-resolution check. Runtime syscall and cycle-count verification would still require building and executing the zkVM ELFs. Which we could follow up to strengthen the patched crypto in another PR.

## Meta

fixes https://github.com/ethereum-optimism/optimism/issues/18416