### PR TITLE
fix(kona-sp1): ignore guest dependency MSRV

### DIFF
--- a/rust/kona/sp1/crates/build/src/lib.rs
+++ b/rust/kona/sp1/crates/build/src/lib.rs
@@ -14,6 +14,7 @@ fn build_program(program_name: &str, elf_name: &str, features: Option<Vec<String
         docker: true,
         tag: "v6.2.4".to_string(),
         workspace_directory: Some(".".to_string()),
+        ignore_rust_version: true,
         ..Default::default()
     };
 

--- a/rust/kona/sp1/justfile
+++ b/rust/kona/sp1/justfile
@@ -17,7 +17,7 @@ build-range-elfs:
 
     cd programs/range
     # Mount the monorepo root so kona-hardforks can find op-core/nuts/bundles.
-    ~/.sp1/bin/cargo-prove prove build --elf-name range-elf --docker --tag v6.2.4 --workspace-directory ../../../../.. --output-directory ../../elf
+    ~/.sp1/bin/cargo-prove prove build --ignore-rust-version --elf-name range-elf --docker --tag v6.2.4 --workspace-directory ../../../../.. --output-directory ../../elf
 
 # Build ELF file for aggregation program.
 build-agg-elf:
@@ -25,7 +25,7 @@ build-agg-elf:
 
     cd programs/aggregation
     # Mount the monorepo root so kona-hardforks can find op-core/nuts/bundles.
-    ~/.sp1/bin/cargo-prove prove build --elf-name aggregation-elf --docker --tag v6.2.4 --workspace-directory ../../../../.. --output-directory ../../elf
+    ~/.sp1/bin/cargo-prove prove build --ignore-rust-version --elf-name aggregation-elf --docker --tag v6.2.4 --workspace-directory ../../../../.. --output-directory ../../elf
 
 # Build ELF file for the unified super-root range/consolidation program.
 build-super-range-elf:
@@ -33,7 +33,7 @@ build-super-range-elf:
 
     cd programs/super-range
     # Mount the monorepo root so kona-hardforks can find op-core/nuts/bundles.
-    ~/.sp1/bin/cargo-prove prove build --elf-name super-range-elf --docker --tag v6.2.4 --workspace-directory ../../../../.. --output-directory ../../elf
+    ~/.sp1/bin/cargo-prove prove build --ignore-rust-version --elf-name super-range-elf --docker --tag v6.2.4 --workspace-directory ../../../../.. --output-directory ../../elf
 
 # Build ELF file for the super-aggregation program.
 build-super-aggregation-elf:
@@ -41,4 +41,4 @@ build-super-aggregation-elf:
 
     cd programs/super-aggregation
     # Mount the monorepo root so kona-hardforks can find op-core/nuts/bundles.
-    ~/.sp1/bin/cargo-prove prove build --elf-name super-aggregation-elf --docker --tag v6.2.4 --workspace-directory ../../../../.. --output-directory ../../elf
+    ~/.sp1/bin/cargo-prove prove build --ignore-rust-version --elf-name super-aggregation-elf --docker --tag v6.2.4 --workspace-directory ../../../../.. --output-directory ../../elf


### PR DESCRIPTION
## Summary

- Pass `--ignore-rust-version` to each SP1 guest build.
- Enable the same option in the programmatic ELF build helper.

SP1 6.2.4 ships Rust 1.94, while the monorepo's local guest dependencies declare Rust 1.95. The guest code still compiles successfully with SP1's toolchain once Cargo's declaration check is bypassed.

## Testing

- Verified the unmodified branch fails `mise exec -- just build-range-elfs` at the Rust 1.94/1.95 version gate.
- `mise exec -- just build-range-elfs`
- `mise exec -- cargo check --locked -p kona-sp1-build-utils`
- `mise exec -- just fmt-check`
