### PR TITLE
kona-sp1: add native super-range acceptance test parity

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -777,6 +777,32 @@ jobs:
                   - "<< parameters.directory >>/target/<< parameters.profile
                     >>/rollup-boost"
 
+  # Build the SP1 super-range executor into a dedicated workspace artifact.
+  # Keeping its persisted copy out of rust/target prevents it from overlapping
+  # the broad kona-* layer persisted by concurrent full-workspace builds.
+  rust-build-sp1-super-range-executor:
+    docker:
+      - image: <<pipeline.parameters.c-rust_base_image>>
+    resource_class: xlarge.gen2
+    steps:
+      - rust-build:
+          directory: rust
+          profile: release
+          features: all
+          package: kona-sp1-super-range-executor
+          binary: kona-sp1-super-range-executor
+          save_cache: false
+      - run:
+          name: Stage SP1 super-range executor
+          command: |
+            BIN_DIR=".circleci-cache/rust-binaries"
+            mkdir -p "$BIN_DIR"
+            cp rust/target/release/kona-sp1-super-range-executor "$BIN_DIR/"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ".circleci-cache/rust-binaries/kona-sp1-super-range-executor"
+
   # Build a single Rust binary from a vendored (non-submodule) directory.
   rust-build-vendored:
     docker:
@@ -1984,6 +2010,7 @@ jobs:
             echo "export RUST_BINARY_PATH_OP_RETH=$ROOT_DIR/rust/target/release/op-reth" >> "$BASH_ENV"
             echo "export RUST_BINARY_PATH_OP_RBUILDER=$BIN_DIR/op-rbuilder" >> "$BASH_ENV"
             echo "export RUST_BINARY_PATH_ROLLUP_BOOST=$BIN_DIR/rollup-boost" >> "$BASH_ENV"
+            echo "export KONA_SP1_SUPER_RANGE_NATIVE_EXECUTOR_PATH=$BIN_DIR/kona-sp1-super-range-executor" >> "$BASH_ENV"
       - run:
           name: Configure L2 stack
           command: |
@@ -2596,6 +2623,11 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - sccache-gcs-optimism
+      - rust-build-sp1-super-range-executor:
+          name: rust-sp1-super-range-executor
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - sccache-gcs-optimism
       - rust-build-vendored: &rust-build-op-rbuilder
           name: rust-build-op-rbuilder
           directory: rust/op-rbuilder
@@ -2627,6 +2659,7 @@ workflows:
       - rust-binaries-for-sysgo:
           requires:
             - rust-workspace-binaries
+            - rust-sp1-super-range-executor
             - rust-build-op-rbuilder
             - rust-build-rollup-boost
       - go-binaries-for-sysgo:

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -24,6 +24,9 @@ parameters:
   c-run_rust_e2e_gate_skip:
     type: boolean
     default: false
+  c-run_scheduled_sp1_elf_smoke:
+    type: boolean
+    default: false
 
 # ============================================================================
 # RUST E2E JOBS
@@ -265,6 +268,62 @@ jobs:
           command: just check-range-vkeys
       - rust-save-build-cache: *sp1-guest-checks-cache-args
 
+  sp1-super-range-elf-smoke:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    # Full SP1 ELF execution peaked near 13 GiB locally. Keep it isolated on a
+    # 32 GB runner instead of competing with parallel acceptance tests.
+    resource_class: 2xlarge.gen2
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+          enable-mise-cache: true
+      - attach_workspace:
+          at: .
+      - go-restore-cache:
+          namespace: sp1-super-range-elf-smoke
+      - run:
+          name: Run SP1 super-range ELF smoke
+          no_output_timeout: 30m
+          command: |
+            ROOT_DIR="$(pwd)"
+            RESULTS_DIR="$ROOT_DIR/tmp/test-results"
+            LOG_DIR="$ROOT_DIR/tmp/testlogs/sp1-super-range-elf"
+            mkdir -p "$RESULTS_DIR" "$LOG_DIR"
+
+            export DEVSTACK_L2CL_KIND=op-node
+            export DEVSTACK_L2EL_KIND=op-reth
+            export RUST_BINARY_PATH_OP_RETH="$ROOT_DIR/rust/target/release/op-reth"
+            export RUST_BINARY_PATH_KONA_HOST="$ROOT_DIR/rust/target/release/kona-host"
+            export KONA_SP1_SUPER_RANGE_ELF_EXECUTOR_PATH="$ROOT_DIR/.circleci-cache/rust-binaries/kona-sp1-super-range-executor"
+            export KONA_SP1_ELF_DIR="$ROOT_DIR/rust/kona/sp1/elf"
+
+            test -x "$RUST_BINARY_PATH_OP_RETH"
+            test -x "$RUST_BINARY_PATH_KONA_HOST"
+            test -x "$KONA_SP1_SUPER_RANGE_ELF_EXECUTOR_PATH"
+            test -x "$ROOT_DIR/cannon/bin/cannon"
+            test -s "$ROOT_DIR/rust/kona/prestate-artifacts-cannon-interop/prestate.bin.gz"
+            test -s "$KONA_SP1_ELF_DIR/super-range-elf"
+
+            gotestsum \
+              --format=testname \
+              --junitfile="$RESULTS_DIR/sp1-super-range-elf.xml" \
+              --jsonfile="$LOG_DIR/go-test.json" \
+              -- \
+              -count=1 \
+              -timeout=30m \
+              -run '^TestSP1SuperRangeELFExecutionValidCrossChainMessageSmoke$' \
+              ./op-acceptance-tests/tests/interop/proofs/sp1
+      - go-save-cache:
+          namespace: sp1-super-range-elf-smoke
+      - store_test_results:
+          path: tmp/test-results
+      - store_artifacts:
+          path: tmp/testlogs/sp1-super-range-elf
+          when: always
+      - notify-failures-on-develop:
+          mentions: "@proofs-team"
+
   required-rust-e2e:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
@@ -361,3 +420,59 @@ workflows:
           always-succeed: true
           context:
             - circleci-api-token
+
+  scheduled-sp1-elf-smoke:
+    when: << pipeline.parameters.c-run_scheduled_sp1_elf_smoke >>
+    jobs:
+      - prep-go-modules:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - prep-superchain:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - contracts-bedrock-build:
+          build_args: --deny-warnings --skip test
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - prep-go-modules
+      - rust-build-binary:
+          # The default Rust workspace members include both op-reth and kona-host,
+          # which the shared proofs preset starts or configures.
+          name: sp1-elf-smoke-rust-binaries
+          directory: rust
+          profile: release
+          persist_to_workspace: true
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - sccache-gcs-optimism
+      - rust-build-sp1-super-range-executor:
+          name: sp1-elf-smoke-executor
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - sccache-gcs-optimism
+      - kona-build-sp1-elfs:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - sccache-gcs-optimism
+      - cannon-prestate:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - go-binaries-for-sysgo:
+          requires:
+            - prep-go-modules
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - sp1-super-range-elf-smoke:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          requires:
+            - prep-go-modules
+            - prep-superchain
+            - contracts-bedrock-build
+            - sp1-elf-smoke-rust-binaries
+            - sp1-elf-smoke-executor
+            - kona-build-sp1-elfs
+            - cannon-prestate
+            - go-binaries-for-sysgo

--- a/.circleci/routing.yml
+++ b/.circleci/routing.yml
@@ -21,6 +21,7 @@ schedules:
     - scheduled_stale_check
     - scheduled_heavy_fuzz_tests
     - scheduled_daily_tests
+    - scheduled_sp1_elf_smoke
     - circleci_schedule_trigger_check
 
 # API triggers: dispatch flag -> workflows enabled when that flag is set.

--- a/.circleci/scripts/test-decision-tree.sh
+++ b/.circleci/scripts/test-decision-tree.sh
@@ -175,7 +175,7 @@ run_scenario \
   "Scheduled: build_daily" \
   "scheduled_pipeline" "" "" "build_daily" \
   '{}' \
-  scheduled_preimage_reproducibility scheduled_stale_check scheduled_heavy_fuzz_tests scheduled_daily_tests circleci_schedule_trigger_check
+  scheduled_preimage_reproducibility scheduled_stale_check scheduled_heavy_fuzz_tests scheduled_daily_tests scheduled_sp1_elf_smoke circleci_schedule_trigger_check
 
 run_scenario \
   "API: main_dispatch (no github event)" \

--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -1,6 +1,7 @@
 package serial
 
 import (
+	"os"
 	"testing"
 
 	sfp "github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/superfaultproofs"
@@ -13,7 +14,7 @@ import (
 func TestInteropFaultProofs(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t)
-	sfp.RunSuperFaultProofTest(t, sys)
+	sfp.RunSuperFaultProofTest(t, sys, proofRunners()...)
 }
 
 func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
@@ -29,19 +30,19 @@ func TestInteropFaultProofs_ActivationBoundary(gt *testing.T) {
 	sys := presets.NewSimpleInterop(t,
 		presets.WithSuggestedInteropActivationOffset(6),
 	)
-	sfp.RunInteropActivationBoundaryTest(t, sys)
+	sfp.RunInteropActivationBoundaryTest(t, sys, proofRunners()...)
 }
 
 func TestInteropFaultProofs_ConsolidateValidCrossChainMessage(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t)
-	sfp.RunConsolidateValidCrossChainMessageTest(t, sys)
+	sfp.RunConsolidateValidCrossChainMessageTest(t, sys, proofRunners()...)
 }
 
 func TestInteropFaultProofs_DepositMessage(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
-	sfp.RunDepositMessageTest(t, sys)
+	sfp.RunDepositMessageTest(t, sys, proofRunners()...)
 }
 
 func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
@@ -53,7 +54,7 @@ func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 			sysgo.DefaultL2BID: 2,
 		}),
 	)
-	sfp.RunVariedBlockTimesTest(t, sys)
+	sfp.RunVariedBlockTimesTest(t, sys, proofRunners()...)
 }
 
 func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
@@ -65,13 +66,13 @@ func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 			sysgo.DefaultL2BID: 1,
 		}),
 	)
-	sfp.RunVariedBlockTimesTest(t, sys)
+	sfp.RunVariedBlockTimesTest(t, sys, proofRunners()...)
 }
 
 func TestInteropFaultProofs_InvalidBlock(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
-	sfp.RunInvalidBlockTest(t, sys)
+	sfp.RunInvalidBlockTest(t, sys, proofRunners()...)
 }
 
 func TestInteropFaultProofs_IntraBlock(gt *testing.T) {
@@ -79,7 +80,7 @@ func TestInteropFaultProofs_IntraBlock(gt *testing.T) {
 		gt.Run(tc.Name, func(gt *testing.T) {
 			t := devtest.SerialT(gt)
 			sys := presets.NewSimpleInterop(t)
-			sfp.RunIntraBlockConsolidationTest(t, sys, tc)
+			sfp.RunIntraBlockConsolidationTest(t, sys, tc, proofRunners()...)
 		})
 	}
 }
@@ -87,7 +88,7 @@ func TestInteropFaultProofs_IntraBlock(gt *testing.T) {
 func TestInteropFaultProofs_DepositMessage_InvalidExecution(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
-	sfp.RunDepositMessageInvalidExecutionTest(t, sys)
+	sfp.RunDepositMessageInvalidExecutionTest(t, sys, proofRunners()...)
 }
 
 func TestInteropFaultProofs_SuperrootOptimisticPairing(gt *testing.T) {
@@ -108,5 +109,13 @@ func TestInteropFaultProofs_MessageExpiry(gt *testing.T) {
 	sys := presets.NewSimpleInterop(t,
 		presets.WithMessageExpiryWindow(messageExpiryWindow),
 	)
-	sfp.RunMessageExpiryTest(t, sys, messageExpiryWindow)
+	sfp.RunMessageExpiryTest(t, sys, messageExpiryWindow, proofRunners()...)
+}
+
+func proofRunners() []sfp.ProofRunner {
+	runners := []sfp.ProofRunner{sfp.NewKonaProofRunner()}
+	if executorPath := os.Getenv(sfp.KonaSP1SuperRangeNativeExecutorPathEnv); executorPath != "" {
+		runners = append(runners, sfp.NewSP1NativeProofRunner(executorPath))
+	}
+	return runners
 }

--- a/op-acceptance-tests/tests/interop/proofs/sp1/super_range_elf_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/sp1/super_range_elf_test.go
@@ -1,0 +1,23 @@
+package sp1
+
+import (
+	"os"
+	"testing"
+
+	sfp "github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/superfaultproofs"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+const konaSP1SuperRangeELFExecutorPathEnv = "KONA_SP1_SUPER_RANGE_ELF_EXECUTOR_PATH"
+
+func TestSP1SuperRangeELFExecutionValidCrossChainMessageSmoke(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	executorPath := os.Getenv(konaSP1SuperRangeELFExecutorPathEnv)
+	if executorPath == "" {
+		t.Skip("kona-sp1 super-range ELF executor not provided; set " + konaSP1SuperRangeELFExecutorPathEnv)
+	}
+
+	sys := presets.NewSimpleInterop(t)
+	sfp.RunConsolidateValidCrossChainMessageTest(t, sys, sfp.NewSP1FullProofRunner(executorPath))
+}

--- a/op-acceptance-tests/tests/superfaultproofs/activation_boundary.go
+++ b/op-acceptance-tests/tests/superfaultproofs/activation_boundary.go
@@ -1,11 +1,9 @@
 package superfaultproofs
 
 import (
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 // RunInteropActivationBoundaryTest verifies that the fault proof system
@@ -17,7 +15,7 @@ import (
 // The system must be configured with a non-zero interop activation offset
 // (via WithSuggestedInteropActivationOffset) so that early blocks are
 // pre-interop and later blocks are post-interop.
-func RunInteropActivationBoundaryTest(t devtest.T, sys *presets.SimpleInterop) {
+func RunInteropActivationBoundaryTest(t devtest.T, sys *presets.SimpleInterop, runners ...ProofRunner) {
 	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
 
 	chains := orderedChains(sys)
@@ -97,17 +95,9 @@ func RunInteropActivationBoundaryTest(t devtest.T, sys *presets.SimpleInterop) {
 		},
 	}
 
-	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
-	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
-
-	for _, test := range tests {
-		t.Run(test.Name+"-fpp", func(t devtest.T) {
-			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
-				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
-				test.ClaimTimestamp, test.ExpectValid)
-		})
-		t.Run(test.Name+"-challenger", func(t devtest.T) {
-			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
-		})
-	}
+	runScenarioProofs(t, sys, &scenarioProofData{
+		fpvmTransitions:    tests,
+		fpvmStartTimestamp: startTimestamp,
+		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, false, runners),
+	}, runners...)
 }

--- a/op-acceptance-tests/tests/superfaultproofs/intrablock.go
+++ b/op-acceptance-tests/tests/superfaultproofs/intrablock.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"math/rand"
 
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
@@ -17,8 +16,9 @@ import (
 
 // IntraBlockTestCase describes a single intra-block scenario.
 type IntraBlockTestCase struct {
-	Name     string
-	BuildTxs func(s *intraBlockSetup) (txsA, txsB []*txplan.PlannedTx)
+	Name              string
+	ExpectReplacement bool
+	BuildTxs          func(s *intraBlockSetup) (txsA, txsB []*txplan.PlannedTx)
 }
 
 // intraBlockSetup holds shared state for building same-timestamp transactions.
@@ -47,7 +47,7 @@ func (s *intraBlockSetup) prepareInitB(logIdx uint32) *dsl.SameTimestampPair {
 // It builds one block per chain at the same timestamp with the given transaction
 // set, waits for the supernode to validate and replace invalid blocks, then
 // verifies the consolidation transition via kona and the challenger trace provider.
-func RunIntraBlockConsolidationTest(t devtest.T, sys *presets.SimpleInterop, tc *IntraBlockTestCase) {
+func RunIntraBlockConsolidationTest(t devtest.T, sys *presets.SimpleInterop, tc *IntraBlockTestCase, runners ...ProofRunner) {
 	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
 	t.Require().NotNil(sys.TestSequencer, "test sequencer is required for same-timestamp block building")
 
@@ -195,19 +195,11 @@ func RunIntraBlockConsolidationTest(t devtest.T, sys *presets.SimpleInterop, tc 
 		})
 	}
 
-	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
-	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
-
-	for _, test := range tests {
-		t.Run(test.Name+"-fpp", func(t devtest.T) {
-			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
-				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
-				test.ClaimTimestamp, test.ExpectValid)
-		})
-		t.Run(test.Name+"-challenger", func(t devtest.T) {
-			runChallengerProviderTest(t, queryAPI, gameDepth, startTimestamp, test.ClaimTimestamp, test)
-		})
-	}
+	runScenarioProofs(t, sys, &scenarioProofData{
+		fpvmTransitions:    tests,
+		fpvmStartTimestamp: startTimestamp,
+		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, tc.ExpectReplacement, runners),
+	}, runners...)
 }
 
 // IntraBlockCases returns all intra-block test scenarios.
@@ -219,7 +211,8 @@ func IntraBlockCases() []*IntraBlockTestCase {
 			// Init(A) + valid Exec(B→A) on chain A,
 			// Init(B) + invalid Exec(A→B) on chain B.
 			// Chain B is invalid (bad exec), chain A is transitively invalid.
-			Name: "CascadeInvalid",
+			Name:              "CascadeInvalid",
+			ExpectReplacement: true,
 			BuildTxs: func(s *intraBlockSetup) ([]*txplan.PlannedTx, []*txplan.PlannedTx) {
 				pairA := s.prepareInitA(0)
 				pairB := s.prepareInitB(0)
@@ -231,7 +224,8 @@ func IntraBlockCases() []*IntraBlockTestCase {
 			// Same as CascadeInvalid but with chains swapped.
 			// Init(A) + invalid Exec(B→A) on chain A,
 			// Init(B) + valid Exec(A→B) on chain B.
-			Name: "SwapCascadeInvalid",
+			Name:              "SwapCascadeInvalid",
+			ExpectReplacement: true,
 			BuildTxs: func(s *intraBlockSetup) ([]*txplan.PlannedTx, []*txplan.PlannedTx) {
 				pairA := s.prepareInitA(0)
 				pairB := s.prepareInitB(0)
@@ -257,7 +251,8 @@ func IntraBlockCases() []*IntraBlockTestCase {
 			// ExecA references a fabricated init at B's position (wrong origin),
 			// ExecB references ExecA's ExecutingMessage event.
 			// Both are invalid: ExecA references wrong origin, ExecB depends on invalid ExecA.
-			Name: "CyclicDependencyInvalid",
+			Name:              "CyclicDependencyInvalid",
+			ExpectReplacement: true,
 			BuildTxs: func(s *intraBlockSetup) ([]*txplan.PlannedTx, []*txplan.PlannedTx) {
 				// Fabricate a pending init message at ExecB's expected position.
 				// ExecA will reference this, but the actual log at (chainB, blockNumB, logIdx=0)
@@ -337,7 +332,8 @@ func IntraBlockCases() []*IntraBlockTestCase {
 		},
 		{
 			// Same-chain invalid: Init + invalid Exec on chain A, empty chain B.
-			Name: "SameChainInvalid",
+			Name:              "SameChainInvalid",
+			ExpectReplacement: true,
 			BuildTxs: func(s *intraBlockSetup) ([]*txplan.PlannedTx, []*txplan.PlannedTx) {
 				pair := s.prepareInitA(0)
 				return []*txplan.PlannedTx{pair.SubmitInit(), pair.SubmitInvalidExecTo(s.alice)},

--- a/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
+++ b/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
@@ -1,0 +1,230 @@
+package superfaultproofs
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/shared/rustbin"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// KonaSP1SuperRangeNativeExecutorPathEnv configures the native-core executor used by the serial
+// interop fault-proof acceptance scenarios.
+const KonaSP1SuperRangeNativeExecutorPathEnv = "KONA_SP1_SUPER_RANGE_NATIVE_EXECUTOR_PATH"
+
+// ProofRunner executes the proof checks attached to one shared interop scenario.
+// Implementations are constructed here so scenario internals remain private.
+type ProofRunner interface {
+	run(t devtest.T, sys *presets.SimpleInterop, data *scenarioProofData)
+}
+
+type scenarioProofData struct {
+	fpvmTransitions    []*transitionTest
+	fpvmStartTimestamp uint64
+	zkCheckpoint       *zkCheckpoint
+}
+
+type zkCheckpoint struct {
+	endTimestamp      uint64
+	trustedL1Head     eth.BlockID
+	expectReplacement bool
+}
+
+type konaProofRunner struct{}
+
+type sp1ProofRunner struct {
+	executorPath string
+	nativeCore   bool
+}
+
+// NewKonaProofRunner constructs the existing Kona FPVM and challenger runner.
+func NewKonaProofRunner() ProofRunner {
+	return konaProofRunner{}
+}
+
+// NewSP1NativeProofRunner constructs the fast runner that replays witnesses through the shared
+// native range and consolidation cores.
+func NewSP1NativeProofRunner(executorPath string) ProofRunner {
+	return sp1ProofRunner{executorPath: executorPath, nativeCore: true}
+}
+
+// NewSP1FullProofRunner constructs the opt-in full-ELF runner used by the single smoke test.
+func NewSP1FullProofRunner(executorPath string) ProofRunner {
+	return sp1ProofRunner{executorPath: executorPath}
+}
+
+func runScenarioProofs(t devtest.T, sys *presets.SimpleInterop, data *scenarioProofData, runners ...ProofRunner) {
+	if len(runners) == 0 {
+		runners = []ProofRunner{NewKonaProofRunner()}
+	}
+	for _, runner := range runners {
+		runner.run(t, sys, data)
+	}
+}
+
+func hasSP1Runner(runners []ProofRunner) bool {
+	for _, runner := range runners {
+		if _, ok := runner.(sp1ProofRunner); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (konaProofRunner) run(t devtest.T, sys *presets.SimpleInterop, data *scenarioProofData) {
+	t.Require().NotEmpty(data.fpvmTransitions, "Kona runner requires FPVM transition cases")
+	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
+	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
+	for _, test := range data.fpvmTransitions {
+		t.Run(test.Name+"-fpp", func(t devtest.T) {
+			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
+				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
+				test.ClaimTimestamp, test.ExpectValid)
+		})
+		t.Run(test.Name+"-challenger", func(t devtest.T) {
+			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth,
+				data.fpvmStartTimestamp, test.ClaimTimestamp, test)
+		})
+	}
+}
+
+func (r sp1ProofRunner) run(t devtest.T, sys *presets.SimpleInterop, data *scenarioProofData) {
+	t.Require().NotEmpty(r.executorPath, "SP1 super-range executor path is required")
+	t.Require().NotNil(data.zkCheckpoint, "SP1 runner requires a ZK checkpoint")
+	name := "SP1FullELF"
+	if r.nativeCore {
+		name = "SP1NativeCore"
+	}
+	t.Run(name, func(t devtest.T) {
+		checkpoint := data.zkCheckpoint
+		validateZKCheckpoint(t, sys, checkpoint)
+		cfg := sys.L2ChainA.Escape().L2Challengers()[0].Config().CannonKona
+		args := superRangeExecutorArgs(t, sys, cfg, checkpoint.trustedL1Head, checkpoint.endTimestamp)
+		if r.nativeCore {
+			args = append(args, "--native-core")
+		}
+		t.Require().True(
+			rustbin.RunKonaSP1SuperRange(t, t.Logger(), r.executorPath, t.TempDir(), args...),
+			"expected kona-sp1 super-range executor to accept timestamp %d",
+			checkpoint.endTimestamp,
+		)
+	})
+}
+
+func newZKCheckpoint(t devtest.T, sys *presets.SimpleInterop, endTimestamp uint64, expectReplacement bool) *zkCheckpoint {
+	resp := sys.SuperRoots.SuperRootAtTimestamp(endTimestamp)
+	t.Require().NotNil(resp.Data, "expected verified super-root data at timestamp %d", endTimestamp)
+	return &zkCheckpoint{
+		endTimestamp:      endTimestamp,
+		trustedL1Head:     resp.Data.VerifiedRequiredL1,
+		expectReplacement: expectReplacement,
+	}
+}
+
+func newZKCheckpointForRunners(
+	t devtest.T,
+	sys *presets.SimpleInterop,
+	endTimestamp uint64,
+	expectReplacement bool,
+	runners []ProofRunner,
+) *zkCheckpoint {
+	if !hasSP1Runner(runners) {
+		return nil
+	}
+	return newZKCheckpoint(t, sys, endTimestamp, expectReplacement)
+}
+
+func validateZKCheckpoint(t devtest.T, sys *presets.SimpleInterop, checkpoint *zkCheckpoint) {
+	resp := sys.SuperRoots.SuperRootAtTimestamp(checkpoint.endTimestamp)
+	t.Require().NotNil(resp.Data, "expected verified super-root data at timestamp %d", checkpoint.endTimestamp)
+	t.Require().Equal(checkpoint.trustedL1Head, resp.Data.VerifiedRequiredL1,
+		"verified required L1 changed for timestamp %d", checkpoint.endTimestamp)
+	t.Require().NotEmpty(resp.ChainIDs, "dependency set must contain at least one chain")
+	t.Require().Len(resp.OptimisticAtTimestamp, len(resp.ChainIDs),
+		"every dependency-set chain must have an optimistic output")
+
+	verified, ok := resp.Data.Super.(*eth.SuperV1)
+	t.Require().True(ok, "verified super-root data must be SuperV1")
+	if !ok {
+		return
+	}
+	t.Require().Equal(checkpoint.endTimestamp, verified.Timestamp)
+	t.Require().Len(verified.Chains, len(resp.ChainIDs),
+		"verified super root must contain every dependency-set chain")
+
+	verifiedRoots := make(map[eth.ChainID]eth.Bytes32, len(verified.Chains))
+	for _, output := range verified.Chains {
+		verifiedRoots[output.ChainID] = output.Output
+	}
+	trustedL1 := sys.L1EL.BlockRefByNumber(checkpoint.trustedL1Head.Number)
+	t.Require().Equal(checkpoint.trustedL1Head.Hash, trustedL1.Hash,
+		"trusted L1 head must be canonical at block %d", checkpoint.trustedL1Head.Number)
+	canonicalL1Hashes := map[uint64]common.Hash{
+		trustedL1.Number: trustedL1.Hash,
+	}
+
+	replacements := 0
+	for _, chainID := range resp.ChainIDs {
+		optimistic, exists := resp.OptimisticAtTimestamp[chainID]
+		t.Require().Truef(exists, "missing optimistic output for chain %s", chainID)
+		if !exists {
+			continue
+		}
+		t.Require().NotNilf(optimistic.Output, "missing optimistic output preimage for chain %s", chainID)
+		t.Require().LessOrEqualf(optimistic.RequiredL1.Number, checkpoint.trustedL1Head.Number,
+			"optimistic output for chain %s requires L1 block %d after trusted head %d",
+			chainID, optimistic.RequiredL1.Number, checkpoint.trustedL1Head.Number)
+		canonicalHash, exists := canonicalL1Hashes[optimistic.RequiredL1.Number]
+		if !exists {
+			canonical := sys.L1EL.BlockRefByNumber(optimistic.RequiredL1.Number)
+			canonicalHash = canonical.Hash
+			canonicalL1Hashes[canonical.Number] = canonical.Hash
+		}
+		t.Require().Equalf(optimistic.RequiredL1.Hash, canonicalHash,
+			"optimistic output for chain %s is not supported by the trusted L1 chain", chainID)
+		verifiedRoot, exists := verifiedRoots[chainID]
+		t.Require().Truef(exists, "verified super root missing chain %s", chainID)
+		if optimistic.OutputRoot != verifiedRoot {
+			replacements++
+		}
+	}
+	if checkpoint.expectReplacement {
+		t.Require().Positive(replacements, "expected at least one optimistic root replacement")
+	} else {
+		t.Require().Zero(replacements, "canonical checkpoint must have matching optimistic and verified roots")
+	}
+}
+
+func superRangeExecutorArgs(
+	t devtest.T,
+	sys *presets.SimpleInterop,
+	cfg vm.Config,
+	l1Head eth.BlockID,
+	endTimestamp uint64,
+) []string {
+	t.Require().Len(cfg.RollupConfigPaths, 2, "SP1 super-range requires both rollup configs")
+	t.Require().NotEmpty(cfg.DepsetConfigPath, "SP1 super-range requires a dependency-set config")
+	args := []string{
+		"--supernode-address", sys.SuperRoots.UserRPC(),
+		"--l1-node-address", sys.L1EL.Escape().UserRPC(),
+		"--l1-beacon-address", sys.L1CL.BeaconHTTPAddr(),
+		"--l2-node-addresses", strings.Join([]string{
+			sys.L2ELA.Escape().UserRPC(),
+			sys.L2ELB.Escape().UserRPC(),
+		}, ","),
+		"--l1-head", l1Head.Hash.Hex(),
+		"--end-timestamp", strconv.FormatUint(endTimestamp, 10),
+		"--rollup-config-paths", strings.Join(cfg.RollupConfigPaths, ","),
+		"--depset-cfg", cfg.DepsetConfigPath,
+	}
+	if cfg.L1GenesisPath != "" {
+		args = append(args, "--l1-config-path", cfg.L1GenesisPath)
+	}
+	return args
+}

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -852,8 +852,8 @@ func RunUnsafeProposalTest(t devtest.T, sys *presets.SimpleInterop) {
 }
 
 // RunSuperFaultProofTest encapsulates the basic super fault proof test flow.
-func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
-	runFaultProofTest(t, sys)
+func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop, runners ...ProofRunner) {
+	runFaultProofTest(t, sys, runners...)
 }
 
 // RunVariedBlockTimesTest verifies that the super fault proof system works
@@ -862,7 +862,7 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 //
 // The system must be configured with varied block times before calling this
 // function (e.g. via presets.WithL2BlockTimes).
-func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
+func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop, runners ...ProofRunner) {
 	chains := orderedChains(sys)
 	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
 
@@ -870,14 +870,14 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	t.Require().NotEqual(chains[0].Cfg.BlockTime, chains[1].Cfg.BlockTime,
 		"this test requires chains with different block times")
 
-	runFaultProofTest(t, sys)
+	runFaultProofTest(t, sys, runners...)
 }
 
 // runFaultProofTest is the shared body for RunSuperFaultProofTest and
 // RunVariedBlockTimesTest. It takes exclusive control of L2 block production
 // via TestSequencer and per-chain Batcher.Start/Stop, then exercises the
 // proof game over a deterministically-built chain state.
-func runFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
+func runFaultProofTest(t devtest.T, sys *presets.SimpleInterop, runners ...ProofRunner) {
 	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
 
 	chains := orderedChains(sys)
@@ -924,6 +924,14 @@ func runFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	// block data and both halves return the same valid TransitionState.
 	boundaryTimestamp := endTimestamp + 1
 	extendChainsExpectingBoundaryBlock(t, sys, chains, boundaryTimestamp)
+	zkEndTimestamp := endTimestamp
+	if chains[0].Cfg.BlockTime != chains[1].Cfg.BlockTime && hasSP1Runner(runners) {
+		// The FPVM boundary cases deliberately retain l1HeadCurrent, which predates
+		// the faster chain's boundary batch. The ZK checkpoint instead uses the
+		// fully supported boundary so it exercises the scheduled no-op transition.
+		sys.SuperRoots.AwaitValidatedTimestamp(boundaryTimestamp)
+		zkEndTimestamp = boundaryTimestamp
+	}
 
 	// Build expected transition states.
 	start := superRootAtTimestamp(t, chains, startTimestamp)
@@ -948,19 +956,11 @@ func runFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 		chains, end, endNext, endTimestamp, l1HeadCurrent,
 		firstOptimisticNext, secondOptimisticNext)...)
 
-	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
-	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
-
-	for _, test := range tests {
-		t.Run(test.Name+"-fpp", func(t devtest.T) {
-			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
-				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
-				test.ClaimTimestamp, test.ExpectValid)
-		})
-		t.Run(test.Name+"-challenger", func(t devtest.T) {
-			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
-		})
-	}
+	runScenarioProofs(t, sys, &scenarioProofData{
+		fpvmTransitions:    tests,
+		fpvmStartTimestamp: startTimestamp,
+		zkCheckpoint:       newZKCheckpointForRunners(t, sys, zkEndTimestamp, false, runners),
+	}, runners...)
 }
 
 // RunPreForkActivationTest verifies that super-root transitions produce
@@ -1061,7 +1061,7 @@ func RunPreForkActivationTest(t devtest.T, sys *presets.SimpleInterop) {
 	}
 }
 
-func RunConsolidateValidCrossChainMessageTest(t devtest.T, sys *presets.SimpleInterop) {
+func RunConsolidateValidCrossChainMessageTest(t devtest.T, sys *presets.SimpleInterop, runners ...ProofRunner) {
 	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
 	rng := rand.New(rand.NewSource(1234))
 
@@ -1112,22 +1112,14 @@ func RunConsolidateValidCrossChainMessageTest(t devtest.T, sys *presets.SimpleIn
 		},
 	}
 
-	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
-	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
-	for _, test := range tests {
-		t.Run(test.Name+"-fpp", func(t devtest.T) {
-			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
-				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
-				test.ClaimTimestamp, test.ExpectValid)
-		})
-
-		t.Run(test.Name+"-challenger", func(t devtest.T) {
-			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
-		})
-	}
+	runScenarioProofs(t, sys, &scenarioProofData{
+		fpvmTransitions:    tests,
+		fpvmStartTimestamp: startTimestamp,
+		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, false, runners),
+	}, runners...)
 }
 
-func RunInvalidBlockTest(t devtest.T, sys *presets.SimpleInterop) {
+func RunInvalidBlockTest(t devtest.T, sys *presets.SimpleInterop, runners ...ProofRunner) {
 	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
 	rng := rand.New(rand.NewSource(1234))
 
@@ -1275,19 +1267,11 @@ func RunInvalidBlockTest(t devtest.T, sys *presets.SimpleInterop) {
 		},
 	}
 
-	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
-	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
-	for _, test := range tests {
-		t.Run(test.Name+"-fpp", func(t devtest.T) {
-			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
-				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
-				test.ClaimTimestamp, test.ExpectValid)
-		})
-
-		t.Run(test.Name+"-challenger", func(t devtest.T) {
-			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
-		})
-	}
+	runScenarioProofs(t, sys, &scenarioProofData{
+		fpvmTransitions:    tests,
+		fpvmStartTimestamp: startTimestamp,
+		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, true, runners),
+	}, runners...)
 }
 
 // RunMessageExpiryTest verifies that when a cross-chain message expires (the
@@ -1298,7 +1282,7 @@ func RunInvalidBlockTest(t devtest.T, sys *presets.SimpleInterop) {
 //
 // msgExpiryWindow is the configured message expiry window in seconds; it must
 // match the value passed to WithMessageExpiryWindow when creating the system.
-func RunMessageExpiryTest(t devtest.T, sys *presets.SimpleInterop, msgExpiryWindow uint64) {
+func RunMessageExpiryTest(t devtest.T, sys *presets.SimpleInterop, msgExpiryWindow uint64, runners ...ProofRunner) {
 	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
 	rng := rand.New(rand.NewSource(1234))
 
@@ -1415,24 +1399,16 @@ func RunMessageExpiryTest(t devtest.T, sys *presets.SimpleInterop, msgExpiryWind
 		},
 	}
 
-	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
-	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
-	for _, test := range tests {
-		t.Run(test.Name+"-fpp", func(t devtest.T) {
-			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
-				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
-				test.ClaimTimestamp, test.ExpectValid)
-		})
-
-		t.Run(test.Name+"-challenger", func(t devtest.T) {
-			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
-		})
-	}
+	runScenarioProofs(t, sys, &scenarioProofData{
+		fpvmTransitions:    tests,
+		fpvmStartTimestamp: startTimestamp,
+		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, true, runners),
+	}, runners...)
 }
 
 // RunDepositMessageTest verifies that the fault proof system correctly handles
 // consolidation when a cross-chain message is initiated via an L1 deposit transaction.
-func RunDepositMessageTest(t devtest.T, sys *presets.SimpleInterop) {
+func RunDepositMessageTest(t devtest.T, sys *presets.SimpleInterop, runners ...ProofRunner) {
 	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
 	rng := rand.New(rand.NewSource(5678))
 
@@ -1486,26 +1462,18 @@ func RunDepositMessageTest(t devtest.T, sys *presets.SimpleInterop) {
 		},
 	}
 
-	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
-	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
-	for _, test := range tests {
-		t.Run(test.Name+"-fpp", func(t devtest.T) {
-			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
-				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
-				test.ClaimTimestamp, test.ExpectValid)
-		})
-
-		t.Run(test.Name+"-challenger", func(t devtest.T) {
-			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
-		})
-	}
+	runScenarioProofs(t, sys, &scenarioProofData{
+		fpvmTransitions:    tests,
+		fpvmStartTimestamp: startTimestamp,
+		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, false, runners),
+	}, runners...)
 }
 
 // RunDepositMessageInvalidExecutionTest verifies that the fault proof system correctly
 // detects an invalid executing message when the initiating message was sent via an L1
 // deposit transaction. The executing message uses an invalid identifier, so consolidation
 // must replace the optimistic block with the cross-safe result.
-func RunDepositMessageInvalidExecutionTest(t devtest.T, sys *presets.SimpleInterop) {
+func RunDepositMessageInvalidExecutionTest(t devtest.T, sys *presets.SimpleInterop, runners ...ProofRunner) {
 	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
 	rng := rand.New(rand.NewSource(9012))
 
@@ -1575,17 +1543,9 @@ func RunDepositMessageInvalidExecutionTest(t devtest.T, sys *presets.SimpleInter
 		},
 	}
 
-	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
-	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
-	for _, test := range tests {
-		t.Run(test.Name+"-fpp", func(t devtest.T) {
-			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
-				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
-				test.ClaimTimestamp, test.ExpectValid)
-		})
-
-		t.Run(test.Name+"-challenger", func(t devtest.T) {
-			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
-		})
-	}
+	runScenarioProofs(t, sys, &scenarioProofData{
+		fpvmTransitions:    tests,
+		fpvmStartTimestamp: startTimestamp,
+		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, true, runners),
+	}, runners...)
 }

--- a/op-devstack/shared/rustbin/kona_host_native.go
+++ b/op-devstack/shared/rustbin/kona_host_native.go
@@ -1,9 +1,11 @@
 package rustbin
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
@@ -37,11 +39,29 @@ func RunKonaSP1Range(t require.TestingT, logger log.Logger, vmConfig *vm.Config,
 	return runOracleServer(t, logger, "kona-sp1-range-executor", args, dir)
 }
 
+// RunKonaSP1SuperRange runs the kona-sp1 super-range executor. Returns false if the guest
+// rejects the synthesized super-range claim and true otherwise.
+func RunKonaSP1SuperRange(t require.TestingT, logger log.Logger, executorPath string, dir string, args ...string) bool {
+	require.NotEmpty(t, executorPath)
+	argv := append([]string{executorPath}, args...)
+	return runOracleServer(t, logger, "kona-sp1-super-range-executor", argv, dir)
+}
+
 // runOracleServer executes a kona oracle-server binary and interprets its exit code: exit 1 means
 // the program rejected the claim (returns false), exit 0 means it accepted (returns true), and any
 // other failure fails the test.
 func runOracleServer(t require.TestingT, logger log.Logger, component string, args []string, dir string) bool {
-	cmd := exec.Command(args[0], args[1:]...)
+	exePath, err := exec.LookPath(args[0])
+	require.NoError(t, err, "resolve %s executable", component)
+	exePath, err = filepath.Abs(exePath)
+	require.NoError(t, err, "make %s executable path absolute", component)
+
+	contextualT, ok := t.(interface{ Ctx() context.Context })
+	require.True(t, ok, "%s test handle must provide a context", component)
+	if !ok {
+		return false
+	}
+	cmd := exec.CommandContext(contextualT.Ctx(), exePath, args[1:]...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "KONA_LOG_STDOUT_FORMAT=json", "NO_COLOR=1")
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7793,6 +7793,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "kona-sp1-super-range-executor"
+version = "0.0.1"
+dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "async-trait",
+ "clap",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "kona-host",
+ "kona-interop",
+ "kona-preimage",
+ "kona-proof",
+ "kona-protocol",
+ "kona-sp1-client-utils",
+ "kona-sp1-elfs",
+ "kona-sp1-ethereum-client-utils",
+ "kona-sp1-host-utils",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "sp1-sdk",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
 name = "kona-std-fpvm"
 version = "0.2.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "kona/sp1/crates/ethereum/host",
   "kona/sp1/crates/host",
   "kona/sp1/crates/range-executor",
+  "kona/sp1/crates/super-range-executor",
 
   # Op-Alloy
   "op-alloy/crates/*",

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -156,8 +156,6 @@ pub enum InteropHostError {
 impl InteropHost {
     /// Starts the [`InteropHost`] application.
     pub async fn start(self) -> Result<(), InteropHostError> {
-        self.require_dependency_set_if_interop_scheduled()?;
-
         if self.server {
             let hint = FileChannel::new(FileDescriptor::HintRead, FileDescriptor::HintWrite);
             let preimage =
@@ -181,7 +179,7 @@ impl InteropHost {
     }
 
     /// Starts the preimage server, communicating with the client over the provided channels.
-    async fn start_server<C>(
+    pub async fn start_server<C>(
         &self,
         hint: C,
         preimage: C,
@@ -189,6 +187,8 @@ impl InteropHost {
     where
         C: Channel + Send + Sync + 'static,
     {
+        self.require_dependency_set_if_interop_scheduled()?;
+
         let kv_store = self.create_key_value_store()?;
 
         let task_handle = if self.is_offline() {
@@ -423,6 +423,35 @@ mod tests {
             BTreeMap::from([(10u64, rollup_config_with_lagoon_time(None))]);
 
         assert!(require_dependency_set_for_configs(&configs, &None).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_start_server_requires_dependency_set_when_interop_scheduled() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let rollup_config_path = temp_dir.path().join("rollup.json");
+        std::fs::write(
+            &rollup_config_path,
+            serde_json::to_string(&rollup_config_with_lagoon_time(Some(42))).unwrap(),
+        )
+        .unwrap();
+
+        let host = InteropHost {
+            server: true,
+            rollup_config_paths: Some(vec![rollup_config_path]),
+            ..Default::default()
+        };
+        let hint = BidirectionalChannel::new().unwrap();
+        let preimage = BidirectionalChannel::new().unwrap();
+
+        let err = host.start_server(hint.host, preimage.host).await.unwrap_err();
+
+        match err {
+            InteropHostError::InteropWithoutDependencySet { chain_id, lagoon_time } => {
+                assert_eq!(chain_id, 0);
+                assert_eq!(lagoon_time, Some(42));
+            }
+            other => panic!("expected InteropWithoutDependencySet, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rust/kona/bin/host/src/interop/handler.rs
+++ b/rust/kona/bin/host/src/interop/handler.rs
@@ -343,7 +343,7 @@ impl HintHandler for InteropHintHandler {
             HintType::L2StateNode => {
                 ensure!(hint.data.len() == 40, "Invalid hint data length");
 
-                let hash: B256 = hint.data.as_ref().try_into()?;
+                let hash = B256::from_slice(&hint.data[..32]);
                 let chain_id = u64::from_be_bytes(hint.data[32..40].try_into()?);
 
                 // Fetch the preimage from the L2 chain provider.

--- a/rust/kona/sp1/crates/ethereum/client/src/super_consolidation.rs
+++ b/rust/kona/sp1/crates/ethereum/client/src/super_consolidation.rs
@@ -11,8 +11,9 @@ use kona_interop::DependencySet;
 use kona_preimage::{CommsClient, PreimageKey};
 use kona_proof::l2::OracleL2ChainProvider;
 use kona_proof_interop::{
-    BootInfo as InteropBootInfo, OptimisticBlock as InteropOptimisticBlock, OracleInteropProvider,
-    PreState, SuperchainConsolidator, TRANSITION_STATE_MAX_STEPS, TransitionState,
+    BootInfo as InteropBootInfo, HintType, OptimisticBlock as InteropOptimisticBlock,
+    OracleInteropProvider, PreState, SuperchainConsolidator, TRANSITION_STATE_MAX_STEPS,
+    TransitionState,
 };
 use kona_registry::HashMap as RegistryHashMap;
 use kona_sp1_client_utils::{
@@ -214,8 +215,16 @@ where
             actual = optimistic_output_block_hash,
             expected = optimistic_block.block_hash,
         );
+        HintType::L2BlockData
+            .with_data(&[
+                cross_safe_head_hash.as_slice(),
+                optimistic_block.block_hash.as_slice(),
+                chain_id.to_be_bytes().as_ref(),
+            ])
+            .send(oracle.as_ref())
+            .await?;
         let local_safe_header =
-            fetch_l2_header(oracle.as_ref(), optimistic_block.block_hash).await?;
+            fetch_l2_header(oracle.as_ref(), optimistic_block.block_hash, chain_id).await?;
         ensure!(
             local_safe_header.timestamp <= timestamp,
             "consolidation optimistic block timestamp {actual} is after super-root timestamp {expected}",

--- a/rust/kona/sp1/crates/ethereum/client/src/super_range.rs
+++ b/rust/kona/sp1/crates/ethereum/client/src/super_range.rs
@@ -17,6 +17,7 @@ use kona_proof::{
     BootInfo, FlushableCache, l1::OracleL1ChainProvider, l2::OracleL2ChainProvider,
     sync::new_oracle_pipeline_cursor,
 };
+use kona_proof_interop::HintType;
 use kona_registry::{DEPENDENCY_SETS, L1_CONFIGS, ROLLUP_CONFIGS};
 use kona_sp1_client_utils::{
     boot::BootInfoStruct,
@@ -333,7 +334,7 @@ where
     let claimed_block_hash = transition.optimistic_block.block_hash;
 
     let safe_head_hash = fetch_output_block_hash(oracle, expected_pre_root).await?;
-    let safe_head = fetch_l2_header(oracle, safe_head_hash).await?;
+    let safe_head = fetch_l2_header(oracle, safe_head_hash, chain_id).await?;
     let output_claimed_block_hash = fetch_output_block_hash(oracle, claimed_output_root).await?;
     ensure!(
         output_claimed_block_hash == claimed_block_hash,
@@ -341,7 +342,15 @@ where
         actual = output_claimed_block_hash,
         expected = claimed_block_hash,
     );
-    let claimed_header = fetch_l2_header(oracle, claimed_block_hash).await?;
+    HintType::L2BlockData
+        .with_data(&[
+            safe_head_hash.as_slice(),
+            claimed_block_hash.as_slice(),
+            chain_id.to_be_bytes().as_ref(),
+        ])
+        .send(oracle)
+        .await?;
+    let claimed_header = fetch_l2_header(oracle, claimed_block_hash, chain_id).await?;
 
     let next_l2_timestamp = safe_head
         .timestamp
@@ -439,7 +448,12 @@ where
         expected = transition.optimistic_block.block_hash,
     );
 
-    let header = fetch_l2_header(oracle, block_hash).await?;
+    let header = fetch_l2_header(
+        oracle,
+        block_hash,
+        optimistic_chain_id_as_u64(&transition.optimistic_block)?,
+    )
+    .await?;
     ensure!(
         header.number == committed_boot_info.l2BlockNumber,
         "range witness committed block #{actual}, but output root header is block #{expected}",
@@ -534,10 +548,18 @@ where
 }
 
 /// Fetches and decodes an L2 header through the interop hint path.
-pub async fn fetch_l2_header<O>(oracle: &O, block_hash: B256) -> anyhow::Result<Header>
+pub async fn fetch_l2_header<O>(
+    oracle: &O,
+    block_hash: B256,
+    chain_id: u64,
+) -> anyhow::Result<Header>
 where
     O: CommsClient,
 {
+    HintType::L2BlockHeader
+        .with_data(&[block_hash.as_slice(), chain_id.to_be_bytes().as_ref()])
+        .send(oracle)
+        .await?;
     let header_rlp = oracle
         .get(PreimageKey::new_keccak256(*block_hash))
         .await

--- a/rust/kona/sp1/crates/super-range-executor/Cargo.toml
+++ b/rust/kona/sp1/crates/super-range-executor/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "kona-sp1-super-range-executor"
+version = "0.0.1"
+publish = false
+license.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "kona-sp1-super-range-executor"
+path = "src/main.rs"
+
+[dependencies]
+sp1-sdk.workspace = true
+
+# local
+kona-sp1-client-utils.workspace = true
+kona-sp1-elfs.workspace = true
+kona-sp1-ethereum-client-utils.workspace = true
+kona-sp1-host-utils.workspace = true
+
+# kona
+kona-host = { workspace = true, features = ["interop"] }
+kona-interop = { workspace = true, features = ["serde"] }
+kona-preimage = { workspace = true, features = ["std"] }
+kona-proof.workspace = true
+kona-protocol.workspace = true
+
+# alloy
+alloy-primitives.workspace = true
+
+# rpc / serialization
+jsonrpsee-http-client.workspace = true
+jsonrpsee-core.workspace = true
+rkyv.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+# general
+anyhow.workspace = true
+async-trait.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
+
+[lints]
+workspace = true

--- a/rust/kona/sp1/crates/super-range-executor/src/lib.rs
+++ b/rust/kona/sp1/crates/super-range-executor/src/lib.rs
@@ -1,8 +1,9 @@
 //! Super-range SP1 executor support.
 //!
-//! The executor queries `superroot_atTimestamp` for the typed super-range inputs, collects a
-//! witness by running the shared native range logic against the interop preimage server, and then
-//! executes the real `super-range` SP1 ELF over that witness.
+//! The executor queries `superroot_atTimestamp` for typed super-range inputs and collects real
+//! range and consolidation witnesses using the shared native cores. It then replays those
+//! witnesses either through the shared cores with `--native-core` or through the real
+//! `super-range` SP1 ELF.
 
 use std::{
     collections::BTreeMap,
@@ -83,8 +84,6 @@ pub enum Verdict {
 /// A full synthesized super-range execution bundle.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SynthesizedExecution {
-    /// The timestamp immediately before `inputs.span.start`.
-    pub previous_timestamp: u64,
     /// Typed inputs for the SP1 guest's range mode.
     pub range_inputs: SuperRangeInputs,
     /// Typed inputs for the SP1 guest's consolidation mode.
@@ -336,7 +335,6 @@ pub fn synthesize_execution(
     consolidation_inputs.validate()?;
 
     Ok(SynthesizedExecution {
-        previous_timestamp,
         range_inputs,
         consolidation_inputs,
         preloaded_preimages,
@@ -1036,7 +1034,6 @@ mod tests {
         let synthesized =
             synthesize_execution(101, b256(0xaa), 8, &previous, &current).expect("synthesizes");
 
-        assert_eq!(synthesized.previous_timestamp, 100);
         assert_eq!(synthesized.range_inputs.span, TimestampSpan { start: 101, end: 101 });
         assert_eq!(synthesized.range_inputs.chain_ids, vec![U256::from(10), U256::from(20)]);
         assert_eq!(

--- a/rust/kona/sp1/crates/super-range-executor/src/lib.rs
+++ b/rust/kona/sp1/crates/super-range-executor/src/lib.rs
@@ -1,0 +1,1221 @@
+//! Super-range SP1 executor support.
+//!
+//! The executor queries `superroot_atTimestamp` for the typed super-range inputs, collects a
+//! witness by running the shared native range logic against the interop preimage server, and then
+//! executes the real `super-range` SP1 ELF over that witness.
+
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Debug},
+    path::PathBuf,
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
+
+use alloy_primitives::{B256, Bytes, U256, keccak256};
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use async_trait::async_trait;
+use jsonrpsee_core::{client::ClientT, rpc_params};
+use jsonrpsee_http_client::{HttpClient, HttpClientBuilder};
+use kona_host::{DataFormat, interop::InteropHost};
+use kona_preimage::{
+    BidirectionalChannel, HintWriter, HintWriterClient, NativeChannel, OracleReader, PreimageKey,
+    PreimageOracleClient, errors::PreimageOracleResult,
+};
+use kona_proof::{CachingOracle, FlushableCache, l1::OracleBlobProvider};
+use kona_sp1_client_utils::{
+    super_root::{
+        SuperConsolidationInputs, SuperConsolidationOutputs, SuperConsolidationTransitionInput,
+        SuperInteropInputs, SuperInteropOutputs, SuperOptimisticBlock, SuperOutputRoot,
+        SuperRangeInputs, SuperRangeOutputs, SuperRangeTransition, SuperRootProof, TimestampSpan,
+        encode_super_root_proof, hash_super_root_proof,
+    },
+    witness::{BlobData, DefaultWitnessData, WitnessData, preimage_store::PreimageStore},
+};
+use kona_sp1_ethereum_client_utils::{
+    super_consolidation::build_consolidation_outputs, super_range::build_range_outputs,
+};
+use kona_sp1_host_utils::witness_generation::{OnlineBlobStore, PreimageWitnessCollector};
+use serde::Deserialize;
+use sp1_sdk::{Elf, Prover, ProverClient, SP1PublicValues, SP1Stdin};
+
+/// Exit code signalling a valid super-range claim.
+pub const EXIT_VALID: u8 = 0;
+/// Exit code signalling an invalid super-range claim.
+pub const EXIT_INVALID: u8 = 1;
+/// Exit code signalling an infrastructure failure before a verdict was reached.
+pub const EXIT_INFRA: u8 = 2;
+
+/// CLI/runtime configuration for one super-range execution.
+#[derive(Clone, Debug)]
+pub struct RunConfig {
+    /// Replay collected witnesses through the shared native cores instead of executing the guest.
+    pub native_core: bool,
+    /// Supernode JSON-RPC endpoint.
+    pub supernode_address: String,
+    /// L1 execution JSON-RPC endpoint.
+    pub l1_node_address: String,
+    /// L1 beacon API endpoint.
+    pub l1_beacon_address: String,
+    /// L2 execution JSON-RPC endpoints.
+    pub l2_node_addresses: Vec<String>,
+    /// Trusted L1 head hash to derive against.
+    pub l1_head: B256,
+    /// Superchain timestamp to prove.
+    pub end_timestamp: u64,
+    /// Optional rollup config JSON files passed through to `InteropHost`.
+    pub rollup_config_paths: Option<Vec<PathBuf>>,
+    /// Optional L1 config JSON file passed through to `InteropHost`.
+    pub l1_config_path: Option<PathBuf>,
+    /// Optional dependency-set JSON file passed through to `InteropHost`.
+    pub dependency_set_path: Option<PathBuf>,
+}
+
+/// Verdict from executing the SP1 guest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Verdict {
+    /// The guest accepted the synthesized super-range inputs and witness.
+    Valid,
+    /// The guest rejected the synthesized super-range inputs or committed unexpected output.
+    Invalid,
+}
+
+/// A full synthesized super-range execution bundle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SynthesizedExecution {
+    /// The timestamp immediately before `inputs.span.start`.
+    pub previous_timestamp: u64,
+    /// Typed inputs for the SP1 guest's range mode.
+    pub range_inputs: SuperRangeInputs,
+    /// Typed inputs for the SP1 guest's consolidation mode.
+    pub consolidation_inputs: SuperConsolidationInputs,
+    /// Preimages that must be available before host hinting can discover the rest of the witness.
+    pub preloaded_preimages: Vec<(PreimageKey, Vec<u8>)>,
+    /// The current response's super-root hash, used as the host post-state claim.
+    pub current_super_root: B256,
+    /// The previous super-root proof, encoded as the host agreed pre-state.
+    pub previous_super_root_proof_bytes: Vec<u8>,
+}
+
+/// Runs the full two-pass super-range executor.
+pub async fn run(config: RunConfig) -> Result<Verdict> {
+    let super_range_elf = if config.native_core {
+        None
+    } else {
+        let bytes =
+            kona_sp1_elfs::load_elf("super-range-elf").context("super-range ELF unavailable")?;
+        Some(Arc::<[u8]>::from(bytes))
+    };
+
+    let client = HttpClientBuilder::default()
+        .build(&config.supernode_address)
+        .with_context(|| format!("failed to connect to supernode {}", config.supernode_address))?;
+    let previous_timestamp = config
+        .end_timestamp
+        .checked_sub(1)
+        .ok_or_else(|| anyhow!("end timestamp 0 has no previous super-root timestamp"))?;
+    let previous = fetch_superroot_at_timestamp(&client, previous_timestamp).await?;
+    let current = fetch_superroot_at_timestamp(&client, config.end_timestamp).await?;
+    let l1_head_number = fetch_l1_head_number(&config.l1_node_address, config.l1_head).await?;
+
+    let synthesized = synthesize_execution(
+        config.end_timestamp,
+        config.l1_head,
+        l1_head_number,
+        &previous,
+        &current,
+    )
+    .context("failed to synthesize super-range inputs")?;
+    let range_host = build_interop_host(&config, &synthesized)?;
+    let (range_witness, native_range_outputs) = collect_range_witness(
+        range_host,
+        &synthesized.range_inputs,
+        &synthesized.preloaded_preimages,
+    )
+    .await?;
+
+    let replayed_range_outputs = match replay_range(
+        config.native_core,
+        &synthesized.range_inputs,
+        range_witness,
+        super_range_elf.clone(),
+    )
+    .await
+    {
+        Ok(outputs) => outputs,
+        Err(err) => {
+            tracing::info!("super-range range replay failed (claim rejected): {err}");
+            return Ok(Verdict::Invalid);
+        }
+    };
+
+    if replayed_range_outputs != native_range_outputs {
+        tracing::error!(
+            expected = ?native_range_outputs,
+            actual = ?replayed_range_outputs,
+            "super-range replay output differs from native witness-discovery pass",
+        );
+        return Ok(Verdict::Invalid);
+    }
+
+    ensure_range_outputs_match_inputs(&replayed_range_outputs, &synthesized.range_inputs)?;
+
+    let consolidation_host = build_interop_host(&config, &synthesized)?;
+    let (consolidation_witness, native_consolidation_outputs) = collect_consolidation_witness(
+        consolidation_host,
+        &synthesized.consolidation_inputs,
+        &synthesized.preloaded_preimages,
+    )
+    .await?;
+
+    let replayed_consolidation_outputs = match replay_consolidation(
+        config.native_core,
+        &synthesized.consolidation_inputs,
+        consolidation_witness,
+        super_range_elf,
+    )
+    .await
+    {
+        Ok(outputs) => outputs,
+        Err(err) => {
+            tracing::info!("super-range consolidation replay failed (claim rejected): {err}");
+            return Ok(Verdict::Invalid);
+        }
+    };
+
+    if replayed_consolidation_outputs != native_consolidation_outputs {
+        tracing::error!(
+            expected = ?native_consolidation_outputs,
+            actual = ?replayed_consolidation_outputs,
+            "super-range consolidation replay output differs from native witness-discovery pass",
+        );
+        return Ok(Verdict::Invalid);
+    }
+
+    ensure_consolidation_outputs_match_inputs(
+        &replayed_consolidation_outputs,
+        &synthesized.consolidation_inputs,
+    )?;
+    tracing::info!(
+        timestamp = config.end_timestamp,
+        chain_count = synthesized.range_inputs.chain_ids.len(),
+        native_core = config.native_core,
+        "super-range program validated the optimistic transitions and consolidation",
+    );
+    Ok(Verdict::Valid)
+}
+
+/// Fetches `superroot_atTimestamp` from the supplied supernode client.
+pub async fn fetch_superroot_at_timestamp(
+    client: &HttpClient,
+    timestamp: u64,
+) -> Result<SuperRootAtTimestampResponse> {
+    client
+        .request("superroot_atTimestamp", rpc_params![format!("0x{timestamp:x}")])
+        .await
+        .with_context(|| format!("superroot_atTimestamp({timestamp}) failed"))
+}
+
+/// Builds one-timestamp super-range inputs from adjacent supernode responses.
+pub fn synthesize_execution(
+    end_timestamp: u64,
+    l1_head: B256,
+    l1_head_number: u64,
+    previous: &SuperRootAtTimestampResponse,
+    current: &SuperRootAtTimestampResponse,
+) -> Result<SynthesizedExecution> {
+    let previous_timestamp = end_timestamp
+        .checked_sub(1)
+        .ok_or_else(|| anyhow!("end timestamp 0 has no previous super-root timestamp"))?;
+    let previous_data = previous
+        .data
+        .as_ref()
+        .ok_or_else(|| anyhow!("previous superroot_atTimestamp response has no data"))?;
+    let current_data = current
+        .data
+        .as_ref()
+        .ok_or_else(|| anyhow!("current superroot_atTimestamp response has no data"))?;
+
+    ensure!(
+        previous_data.super_v1.timestamp == previous_timestamp,
+        "previous super-root timestamp {} does not match expected {previous_timestamp}",
+        previous_data.super_v1.timestamp,
+    );
+    ensure!(
+        current_data.super_v1.timestamp == end_timestamp,
+        "current super-root timestamp {} does not match expected {end_timestamp}",
+        current_data.super_v1.timestamp,
+    );
+
+    let chain_ids = response_chain_ids(current)?;
+    ensure_chain_ids_match_super(&chain_ids, &previous_data.super_v1, "previous")?;
+    ensure_chain_ids_match_super(&chain_ids, &current_data.super_v1, "current")?;
+
+    let previous_proof = proof_from_super_v1(&previous_data.super_v1)?;
+    let previous_super_root = hash_super_root_proof(&previous_proof)?;
+    ensure!(
+        previous_super_root == previous_data.super_root,
+        "previous super-root proof hashes to {previous_super_root}, response reports {}",
+        previous_data.super_root,
+    );
+
+    let current_proof = proof_from_super_v1(&current_data.super_v1)?;
+    let current_super_root = hash_super_root_proof(&current_proof)?;
+    ensure!(
+        current_super_root == current_data.super_root,
+        "current super-root proof hashes to {current_super_root}, response reports {}",
+        current_data.super_root,
+    );
+
+    let mut preloaded_preimages = Vec::new();
+    preload_super_root_proof(&mut preloaded_preimages, &previous_proof)?;
+    preload_super_root_proof(&mut preloaded_preimages, &current_proof)?;
+
+    let mut claimed_transitions = Vec::with_capacity(chain_ids.len());
+    for &chain_id in &chain_ids {
+        let current_output = output_entry(current, chain_id, "current")?;
+        ensure_required_l1_within_head(current_output.required_l1, l1_head_number, chain_id)?;
+        let (current_root, current_preimage) =
+            checked_output_preimage(current_output, chain_id, "current")?;
+        preloaded_preimages.push((PreimageKey::new_keccak256(*current_root), current_preimage));
+
+        claimed_transitions.push(SuperRangeTransition {
+            timestamp: end_timestamp,
+            optimistic_block: SuperOptimisticBlock {
+                chain_id: U256::from(chain_id),
+                block_hash: current_output
+                    .output
+                    .as_ref()
+                    .expect("checked output exists")
+                    .block_hash,
+                output_root: current_root,
+            },
+        });
+    }
+
+    for &chain_id in &chain_ids {
+        let previous_output = output_entry(previous, chain_id, "previous")?;
+        ensure_required_l1_within_head(previous_output.required_l1, l1_head_number, chain_id)?;
+        let (previous_root, previous_preimage) =
+            checked_output_preimage(previous_output, chain_id, "previous")?;
+        let proof_root = previous_proof
+            .super_root
+            .output_roots
+            .iter()
+            .find(|root| root.chain_id == chain_id)
+            .map(|root| root.output_root)
+            .ok_or_else(|| anyhow!("previous proof missing chain {chain_id}"))?;
+        ensure!(
+            previous_root == proof_root,
+            "previous optimistic output root {previous_root} for chain {chain_id} does not match previous super-root proof output {proof_root}",
+        );
+        preloaded_preimages.push((PreimageKey::new_keccak256(*previous_root), previous_preimage));
+    }
+
+    let range_inputs = SuperRangeInputs {
+        span: TimestampSpan::new(end_timestamp, end_timestamp)?,
+        l1_head,
+        chain_ids: chain_ids.iter().copied().map(U256::from).collect(),
+        previous_super_root_proofs: vec![previous_proof.clone()],
+        claimed_transitions,
+    };
+    range_inputs.validate()?;
+
+    let consolidation_inputs = SuperConsolidationInputs {
+        span: TimestampSpan::new(end_timestamp, end_timestamp)?,
+        previous_super_root,
+        transitions: vec![SuperConsolidationTransitionInput {
+            optimistic_blocks: range_inputs
+                .claimed_transitions
+                .iter()
+                .map(|transition| transition.optimistic_block)
+                .collect(),
+            claimed_super_root_proof: current_proof,
+        }],
+    };
+    consolidation_inputs.validate()?;
+
+    Ok(SynthesizedExecution {
+        previous_timestamp,
+        range_inputs,
+        consolidation_inputs,
+        preloaded_preimages,
+        current_super_root,
+        previous_super_root_proof_bytes: encode_super_root_proof(&previous_proof)?,
+    })
+}
+
+/// Encodes super-range SP1 stdin as typed inputs followed by rkyv witness bytes.
+pub fn build_super_range_stdin(
+    inputs: &SuperRangeInputs,
+    witness: DefaultWitnessData,
+) -> Result<SP1Stdin> {
+    build_super_interop_stdin(SuperInteropInputs::Range(inputs.clone()), witness)
+}
+
+/// Encodes consolidation-mode SP1 stdin as typed inputs followed by rkyv witness bytes.
+pub fn build_super_consolidation_stdin(
+    inputs: &SuperConsolidationInputs,
+    witness: DefaultWitnessData,
+) -> Result<SP1Stdin> {
+    build_super_interop_stdin(SuperInteropInputs::Consolidation(inputs.clone()), witness)
+}
+
+fn build_super_interop_stdin(
+    inputs: SuperInteropInputs,
+    witness: DefaultWitnessData,
+) -> Result<SP1Stdin> {
+    let mut stdin = SP1Stdin::new();
+    stdin.write(&inputs);
+    let witness_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&witness)?;
+    stdin.write_slice(&witness_bytes);
+    Ok(stdin)
+}
+
+/// Decodes the public output committed by the super-range guest.
+pub fn decode_super_range_public_values(
+    public_values: &mut SP1PublicValues,
+) -> Result<SuperRangeOutputs> {
+    ensure!(!public_values.as_slice().is_empty(), "super-range guest committed no output");
+    match public_values.read::<SuperInteropOutputs>() {
+        SuperInteropOutputs::Range(outputs) => Ok(outputs),
+        SuperInteropOutputs::Consolidation(_) => {
+            bail!("super-range guest committed consolidation output in range mode")
+        }
+    }
+}
+
+/// Decodes the consolidation output committed by the super-range guest.
+pub fn decode_super_consolidation_public_values(
+    public_values: &mut SP1PublicValues,
+) -> Result<SuperConsolidationOutputs> {
+    ensure!(!public_values.as_slice().is_empty(), "super-range guest committed no output");
+    match public_values.read::<SuperInteropOutputs>() {
+        SuperInteropOutputs::Consolidation(outputs) => Ok(outputs),
+        SuperInteropOutputs::Range(_) => {
+            bail!("super-range guest committed range output in consolidation mode")
+        }
+    }
+}
+
+async fn execute_sp1_range(
+    inputs: &SuperRangeInputs,
+    witness: DefaultWitnessData,
+    super_range_elf: Arc<[u8]>,
+) -> Result<SuperRangeOutputs> {
+    let stdin = build_super_range_stdin(inputs, witness)?;
+    let client = ProverClient::builder().cpu().build().await;
+    let elf = Elf::Dynamic(super_range_elf);
+    let (mut public_values, _report) = client.execute(elf, stdin).await?;
+    decode_super_range_public_values(&mut public_values)
+}
+
+async fn execute_sp1_consolidation(
+    inputs: &SuperConsolidationInputs,
+    witness: DefaultWitnessData,
+    super_range_elf: Arc<[u8]>,
+) -> Result<SuperConsolidationOutputs> {
+    let stdin = build_super_consolidation_stdin(inputs, witness)?;
+    let client = ProverClient::builder().cpu().build().await;
+    let elf = Elf::Dynamic(super_range_elf);
+    let (mut public_values, _report) = client.execute(elf, stdin).await?;
+    decode_super_consolidation_public_values(&mut public_values)
+}
+
+async fn replay_range(
+    native_core: bool,
+    inputs: &SuperRangeInputs,
+    witness: DefaultWitnessData,
+    super_range_elf: Option<Arc<[u8]>>,
+) -> Result<SuperRangeOutputs> {
+    if !native_core {
+        return execute_sp1_range(
+            inputs,
+            witness,
+            super_range_elf.expect("super-range ELF is loaded for SP1 execution"),
+        )
+        .await;
+    }
+    let (oracle, beacon) = witness.get_oracle_and_blob_provider().await?;
+    build_range_outputs(inputs.clone(), oracle, beacon).await
+}
+
+async fn replay_consolidation(
+    native_core: bool,
+    inputs: &SuperConsolidationInputs,
+    witness: DefaultWitnessData,
+    super_range_elf: Option<Arc<[u8]>>,
+) -> Result<SuperConsolidationOutputs> {
+    if !native_core {
+        return execute_sp1_consolidation(
+            inputs,
+            witness,
+            super_range_elf.expect("super-range ELF is loaded for SP1 execution"),
+        )
+        .await;
+    }
+    let (oracle, _) = witness.get_oracle_and_blob_provider().await?;
+    build_consolidation_outputs(inputs.clone(), oracle).await
+}
+
+fn ensure_range_outputs_match_inputs(
+    outputs: &SuperRangeOutputs,
+    inputs: &SuperRangeInputs,
+) -> Result<()> {
+    let expected_previous_super_roots = inputs
+        .previous_super_root_proofs
+        .iter()
+        .map(hash_super_root_proof)
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    ensure!(outputs.span == inputs.span, "guest output span does not match inputs");
+    ensure!(outputs.l1_head == inputs.l1_head, "guest output L1 head does not match inputs");
+    ensure!(
+        outputs.previous_super_roots == expected_previous_super_roots,
+        "guest output previous super roots do not match inputs",
+    );
+    ensure!(
+        outputs.transitions == inputs.claimed_transitions,
+        "guest output transitions do not match inputs",
+    );
+    Ok(())
+}
+
+fn ensure_consolidation_outputs_match_inputs(
+    outputs: &SuperConsolidationOutputs,
+    inputs: &SuperConsolidationInputs,
+) -> Result<()> {
+    ensure!(outputs.span == inputs.span, "guest consolidation span does not match inputs");
+    ensure!(
+        outputs.previous_super_root == inputs.previous_super_root,
+        "guest consolidation previous super root does not match inputs",
+    );
+    ensure!(
+        outputs.transitions.len() == inputs.transitions.len(),
+        "guest consolidation transition count does not match inputs",
+    );
+    for (output, input) in outputs.transitions.iter().zip(&inputs.transitions) {
+        let expected_super_root = hash_super_root_proof(&input.claimed_super_root_proof)?;
+        ensure!(
+            output.timestamp == input.claimed_super_root_proof.super_root.timestamp,
+            "guest consolidation transition timestamp does not match input claim",
+        );
+        ensure!(
+            output.optimistic_blocks == input.optimistic_blocks,
+            "guest consolidation optimistic blocks do not match inputs",
+        );
+        ensure!(
+            output.super_root == expected_super_root,
+            "guest consolidation super root {} does not match claimed {expected_super_root}",
+            output.super_root,
+        );
+    }
+    Ok(())
+}
+
+async fn collect_range_witness(
+    host: InteropHost,
+    inputs: &SuperRangeInputs,
+    preloaded_preimages: &[(PreimageKey, Vec<u8>)],
+) -> Result<(DefaultWitnessData, SuperRangeOutputs)> {
+    collect_witness(preloaded_preimages, host, |oracle, beacon| {
+        let inputs = inputs.clone();
+        async move { build_range_outputs(inputs, oracle, beacon).await }
+    })
+    .await
+}
+
+async fn collect_consolidation_witness(
+    host: InteropHost,
+    inputs: &SuperConsolidationInputs,
+    preloaded_preimages: &[(PreimageKey, Vec<u8>)],
+) -> Result<(DefaultWitnessData, SuperConsolidationOutputs)> {
+    collect_witness(preloaded_preimages, host, |oracle, _beacon| {
+        let inputs = inputs.clone();
+        async move { build_consolidation_outputs(inputs, oracle).await }
+    })
+    .await
+}
+
+async fn collect_witness<T, F, Fut>(
+    preloaded_preimages: &[(PreimageKey, Vec<u8>)],
+    host: InteropHost,
+    run_native: F,
+) -> Result<(DefaultWitnessData, T)>
+where
+    F: FnOnce(
+        Arc<PreimageWitnessCollector<SeededOracleBase>>,
+        OnlineBlobStore<OracleBlobProvider<SeededOracleBase>>,
+    ) -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let preimage = BidirectionalChannel::new()?;
+    let hint = BidirectionalChannel::new()?;
+
+    let mut seeded_store = PreimageStore::default();
+    for (key, value) in preloaded_preimages {
+        seeded_store.save_preimage(*key, value.clone())?;
+    }
+
+    let preimage_witness_store = Arc::new(Mutex::new(seeded_store.clone()));
+    let blob_data = Arc::new(Mutex::new(BlobData::default()));
+    let host_oracle =
+        CachingOracle::new(2048, OracleReader::new(preimage.client), HintWriter::new(hint.client));
+    let seeded_oracle = SeededOracle::new(host_oracle, Arc::new(seeded_store));
+    let preimage_oracle = Arc::new(seeded_oracle);
+    let oracle = Arc::new(PreimageWitnessCollector {
+        preimage_oracle: preimage_oracle.clone(),
+        preimage_witness_store: preimage_witness_store.clone(),
+    });
+    let beacon = OnlineBlobStore {
+        provider: OracleBlobProvider::new(preimage_oracle),
+        store: blob_data.clone(),
+    };
+
+    let server_task = host.start_server(hint.host, preimage.host).await?;
+    let native_outputs = run_native(oracle, beacon).await;
+    server_task.abort();
+    let native_outputs = native_outputs?;
+
+    let witness = DefaultWitnessData::from_parts(
+        preimage_witness_store
+            .lock()
+            .map_err(|_| anyhow!("failed to acquire preimage witness store lock"))?
+            .clone(),
+        blob_data.lock().map_err(|_| anyhow!("failed to acquire blob data lock"))?.clone(),
+    );
+    Ok((witness, native_outputs))
+}
+
+fn build_interop_host(
+    config: &RunConfig,
+    synthesized: &SynthesizedExecution,
+) -> Result<InteropHost> {
+    ensure!(!config.l2_node_addresses.is_empty(), "at least one L2 node address is required",);
+    Ok(InteropHost {
+        l1_head: config.l1_head,
+        agreed_l2_pre_state: Bytes::from(synthesized.previous_super_root_proof_bytes.clone()),
+        claimed_l2_post_state: synthesized.current_super_root,
+        claimed_l2_timestamp: config.end_timestamp,
+        l2_node_addresses: Some(config.l2_node_addresses.clone()),
+        l1_node_address: Some(config.l1_node_address.clone()),
+        l1_beacon_address: Some(config.l1_beacon_address.clone()),
+        data_dir: None,
+        data_format: DataFormat::Directory,
+        native: false,
+        server: true,
+        rollup_config_paths: config.rollup_config_paths.clone(),
+        l1_config_path: config.l1_config_path.clone(),
+        dependency_set_path: config.dependency_set_path.clone(),
+    })
+}
+
+async fn fetch_l1_head_number(l1_node_address: &str, l1_head: B256) -> Result<u64> {
+    let client = HttpClientBuilder::default()
+        .build(l1_node_address)
+        .with_context(|| format!("failed to connect to L1 node {l1_node_address}"))?;
+    let block: Option<RpcBlock> = client
+        .request("eth_getBlockByHash", rpc_params![format!("{l1_head}"), false])
+        .await
+        .with_context(|| format!("failed to fetch L1 head {l1_head}"))?;
+    let block = block.ok_or_else(|| anyhow!("L1 head {l1_head} not found"))?;
+    ensure!(
+        block.hash == l1_head,
+        "L1 head lookup returned hash {}, expected {l1_head}",
+        block.hash,
+    );
+    Ok(block.number)
+}
+
+fn response_chain_ids(response: &SuperRootAtTimestampResponse) -> Result<Vec<u64>> {
+    ensure!(!response.chain_ids.is_empty(), "supernode response has no chain IDs");
+    let mut out = Vec::with_capacity(response.chain_ids.len());
+    for chain_id in &response.chain_ids {
+        out.push(chain_id.as_u64()?);
+    }
+    ensure_strictly_increasing_u64s(&out, "supernode response chain IDs")?;
+    Ok(out)
+}
+
+fn ensure_chain_ids_match_super(chain_ids: &[u64], super_v1: &SuperV1, label: &str) -> Result<()> {
+    let super_chain_ids =
+        super_v1.chains.iter().map(|chain| chain.chain_id.as_u64()).collect::<Result<Vec<_>>>()?;
+    ensure!(
+        chain_ids == super_chain_ids,
+        "{label} super-root chain IDs {super_chain_ids:?} do not match response chain IDs {chain_ids:?}",
+    );
+    Ok(())
+}
+
+fn proof_from_super_v1(super_v1: &SuperV1) -> Result<SuperRootProof> {
+    let output_roots = super_v1
+        .chains
+        .iter()
+        .map(|chain| Ok(SuperOutputRoot::new(chain.chain_id.as_u64()?, chain.output)))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(SuperRootProof::new(super_v1.timestamp, output_roots))
+}
+
+fn preload_super_root_proof(
+    preloaded_preimages: &mut Vec<(PreimageKey, Vec<u8>)>,
+    proof: &SuperRootProof,
+) -> Result<()> {
+    let encoded = encode_super_root_proof(proof)?;
+    let hash = hash_super_root_proof(proof)?;
+    preloaded_preimages.push((PreimageKey::new_keccak256(*hash), encoded));
+    Ok(())
+}
+
+fn output_entry<'a>(
+    response: &'a SuperRootAtTimestampResponse,
+    chain_id: u64,
+    label: &str,
+) -> Result<&'a OutputWithRequiredL1> {
+    response.optimistic_at_timestamp.get(&ChainId(U256::from(chain_id))).ok_or_else(|| {
+        anyhow!("missing optimistic output for chain {chain_id} in {label} response")
+    })
+}
+
+fn ensure_required_l1_within_head(
+    required_l1: BlockId,
+    l1_head_number: u64,
+    chain_id: u64,
+) -> Result<()> {
+    ensure!(
+        required_l1.number <= l1_head_number,
+        "required L1 block {} for chain {chain_id} is after supplied L1 head {l1_head_number}",
+        required_l1.number,
+    );
+    Ok(())
+}
+
+fn checked_output_preimage(
+    output: &OutputWithRequiredL1,
+    chain_id: u64,
+    label: &str,
+) -> Result<(B256, Vec<u8>)> {
+    let output_v0 = output.output.as_ref().ok_or_else(|| {
+        anyhow!("missing optimistic OutputV0 for chain {chain_id} in {label} response")
+    })?;
+    let preimage = output_v0.marshal();
+    let computed = B256::from(keccak256(&preimage));
+    ensure!(
+        computed == output.output_root,
+        "{label} output root for chain {chain_id} hashes to {computed}, response reports {}",
+        output.output_root,
+    );
+    Ok((computed, preimage))
+}
+
+fn ensure_strictly_increasing_u64s(values: &[u64], label: &str) -> Result<()> {
+    for pair in values.windows(2) {
+        ensure!(
+            pair[0] < pair[1],
+            "{label} must be strictly increasing, got {} then {}",
+            pair[0],
+            pair[1],
+        );
+    }
+    Ok(())
+}
+
+#[derive(Clone)]
+struct SeededOracle<P> {
+    inner: P,
+    seeds: Arc<PreimageStore>,
+}
+
+type SeededOracleBase =
+    SeededOracle<CachingOracle<OracleReader<NativeChannel>, HintWriter<NativeChannel>>>;
+
+impl<P> SeededOracle<P> {
+    const fn new(inner: P, seeds: Arc<PreimageStore>) -> Self {
+        Self { inner, seeds }
+    }
+}
+
+impl<P> Debug for SeededOracle<P>
+where
+    P: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SeededOracle").field("inner", &self.inner).finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl<P> PreimageOracleClient for SeededOracle<P>
+where
+    P: PreimageOracleClient + Send + Sync,
+{
+    async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
+        match self.seeds.get(key).await {
+            Ok(value) => Ok(value),
+            Err(_) => self.inner.get(key).await,
+        }
+    }
+
+    async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
+        match self.seeds.get(key).await {
+            Ok(value) if value.len() == buf.len() => {
+                buf.copy_from_slice(&value);
+                Ok(())
+            }
+            _ => self.inner.get_exact(key, buf).await,
+        }
+    }
+}
+
+#[async_trait]
+impl<P> HintWriterClient for SeededOracle<P>
+where
+    P: HintWriterClient + Send + Sync,
+{
+    async fn write(&self, hint: &str) -> PreimageOracleResult<()> {
+        self.inner.write(hint).await
+    }
+}
+
+impl<P> FlushableCache for SeededOracle<P>
+where
+    P: FlushableCache,
+{
+    fn flush(&self) {
+        self.inner.flush();
+    }
+}
+
+/// Decoded response from `superroot_atTimestamp`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct SuperRootAtTimestampResponse {
+    /// Latest L1 block currently being processed by the supernode.
+    pub current_l1: BlockId,
+    /// Optimistic outputs keyed by decimal or hex chain ID.
+    #[serde(default)]
+    pub optimistic_at_timestamp: BTreeMap<ChainId, OutputWithRequiredL1>,
+    /// Dependency-set chain IDs sorted ascending by the supernode.
+    #[serde(default)]
+    pub chain_ids: Vec<ChainId>,
+    /// Validated super-root data for the requested timestamp.
+    pub data: Option<SuperRootResponseData>,
+}
+
+/// Decoded super-root data section.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct SuperRootResponseData {
+    /// Required L1 block for fully verified data.
+    pub verified_required_l1: BlockId,
+    /// Super-root proof preimage.
+    #[serde(rename = "super")]
+    pub super_v1: SuperV1,
+    /// Super-root hash.
+    pub super_root: B256,
+}
+
+/// Decoded `eth.SuperV1`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct SuperV1 {
+    /// Super-root timestamp.
+    #[serde(deserialize_with = "deserialize_u64_or_hex")]
+    pub timestamp: u64,
+    /// Per-chain output roots.
+    pub chains: Vec<ChainIdAndOutput>,
+}
+
+/// Decoded `eth.ChainIDAndOutput`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct ChainIdAndOutput {
+    /// Chain ID.
+    #[serde(rename = "ChainID")]
+    pub chain_id: ChainId,
+    /// Output root.
+    #[serde(rename = "Output")]
+    pub output: B256,
+}
+
+/// Decoded `eth.OutputWithRequiredL1`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct OutputWithRequiredL1 {
+    /// Output-root preimage, if the supernode supplied one.
+    pub output: Option<OutputV0>,
+    /// Output-root hash.
+    pub output_root: B256,
+    /// Minimum required L1 block.
+    pub required_l1: BlockId,
+}
+
+/// Decoded `eth.OutputV0`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct OutputV0 {
+    /// L2 state root.
+    #[serde(rename = "stateRoot")]
+    pub state_root: B256,
+    /// `L2ToL1MessagePasser` storage root.
+    #[serde(rename = "messagePasserStorageRoot")]
+    pub message_passer_storage_root: B256,
+    /// L2 block hash.
+    #[serde(rename = "blockHash")]
+    pub block_hash: B256,
+}
+
+impl OutputV0 {
+    fn marshal(&self) -> Vec<u8> {
+        let mut out = vec![0u8; 128];
+        out[32..64].copy_from_slice(self.state_root.as_slice());
+        out[64..96].copy_from_slice(self.message_passer_storage_root.as_slice());
+        out[96..128].copy_from_slice(self.block_hash.as_slice());
+        out
+    }
+}
+
+/// Decoded `eth.BlockID`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize)]
+pub struct BlockId {
+    /// Block hash.
+    pub hash: B256,
+    /// Block number.
+    #[serde(deserialize_with = "deserialize_u64_or_hex")]
+    pub number: u64,
+}
+
+/// JSON map key for `eth.ChainID`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ChainId(pub U256);
+
+impl ChainId {
+    fn as_u64(self) -> Result<u64> {
+        if self.0 > U256::from(u64::MAX) {
+            bail!("chain ID {} does not fit in u64", self.0);
+        }
+        Ok(self.0.saturating_to::<u64>())
+    }
+}
+
+impl<'de> Deserialize<'de> for ChainId {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(ChainIdVisitor)
+    }
+}
+
+struct ChainIdVisitor;
+
+impl serde::de::Visitor<'_> for ChainIdVisitor {
+    type Value = ChainId;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a decimal or 0x-prefixed chain ID")
+    }
+
+    fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(ChainId(U256::from(value)))
+    }
+
+    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        parse_u256(value).map(ChainId).map_err(E::custom)
+    }
+}
+
+fn deserialize_u64_or_hex<'de, D>(deserializer: D) -> std::result::Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserializer.deserialize_any(U64Visitor)
+}
+
+struct U64Visitor;
+
+impl serde::de::Visitor<'_> for U64Visitor {
+    type Value = u64;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON number or 0x-prefixed quantity")
+    }
+
+    fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(value)
+    }
+
+    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        parse_u64(value).map_err(E::custom)
+    }
+}
+
+fn parse_u64(value: &str) -> Result<u64> {
+    value.strip_prefix("0x").map_or_else(
+        || value.parse::<u64>().with_context(|| format!("invalid decimal quantity {value}")),
+        |hex| u64::from_str_radix(hex, 16).with_context(|| format!("invalid hex quantity {value}")),
+    )
+}
+
+fn parse_u256(value: &str) -> Result<U256> {
+    value.strip_prefix("0x").map_or_else(
+        || U256::from_str(value).with_context(|| format!("invalid decimal U256 {value}")),
+        |hex| U256::from_str_radix(hex, 16).with_context(|| format!("invalid hex U256 {value}")),
+    )
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+struct RpcBlock {
+    hash: B256,
+    #[serde(deserialize_with = "deserialize_u64_or_hex")]
+    number: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kona_preimage::errors::PreimageOracleError;
+
+    fn b256(fill: u8) -> B256 {
+        B256::from([fill; 32])
+    }
+
+    fn block(number: u64) -> BlockId {
+        BlockId { hash: b256(number as u8), number }
+    }
+
+    fn output(block_hash: B256) -> OutputV0 {
+        OutputV0 { state_root: b256(0x11), message_passer_storage_root: b256(0x22), block_hash }
+    }
+
+    fn output_entry(block_hash: B256, required_l1: u64) -> OutputWithRequiredL1 {
+        let output = output(block_hash);
+        let output_root = B256::from(keccak256(output.marshal()));
+        OutputWithRequiredL1 { output: Some(output), output_root, required_l1: block(required_l1) }
+    }
+
+    fn response(
+        timestamp: u64,
+        chain_ids: &[u64],
+        required_l1: u64,
+    ) -> SuperRootAtTimestampResponse {
+        let mut optimistic_at_timestamp = BTreeMap::new();
+        let mut chains = Vec::new();
+        for &chain_id in chain_ids {
+            let entry = output_entry(b256(chain_id as u8), required_l1);
+            optimistic_at_timestamp.insert(ChainId(U256::from(chain_id)), entry.clone());
+            chains.push(ChainIdAndOutput {
+                chain_id: ChainId(U256::from(chain_id)),
+                output: entry.output_root,
+            });
+        }
+        let super_v1 = SuperV1 { timestamp, chains };
+        let proof = proof_from_super_v1(&super_v1).expect("proof builds");
+        let super_root = hash_super_root_proof(&proof).expect("proof hashes");
+        SuperRootAtTimestampResponse {
+            current_l1: block(required_l1 + 1),
+            optimistic_at_timestamp,
+            chain_ids: chain_ids.iter().copied().map(|id| ChainId(U256::from(id))).collect(),
+            data: Some(SuperRootResponseData {
+                verified_required_l1: block(required_l1),
+                super_v1,
+                super_root,
+            }),
+        }
+    }
+
+    #[test]
+    fn synthesize_execution_orders_chains_and_preloads_outputs() {
+        let previous = response(100, &[10, 20], 7);
+        let current = response(101, &[10, 20], 8);
+
+        let synthesized =
+            synthesize_execution(101, b256(0xaa), 8, &previous, &current).expect("synthesizes");
+
+        assert_eq!(synthesized.previous_timestamp, 100);
+        assert_eq!(synthesized.range_inputs.span, TimestampSpan { start: 101, end: 101 });
+        assert_eq!(synthesized.range_inputs.chain_ids, vec![U256::from(10), U256::from(20)]);
+        assert_eq!(
+            synthesized.range_inputs.previous_super_root_proofs[0].super_root.timestamp,
+            100,
+        );
+        assert_eq!(synthesized.range_inputs.claimed_transitions.len(), 2);
+        assert_eq!(
+            synthesized
+                .range_inputs
+                .claimed_transitions
+                .iter()
+                .map(|transition| transition.optimistic_block.chain_id)
+                .collect::<Vec<_>>(),
+            vec![U256::from(10), U256::from(20)],
+        );
+        assert_eq!(synthesized.preloaded_preimages.len(), 6);
+    }
+
+    #[test]
+    fn synthesize_execution_uses_optimistic_range_inputs_and_verified_consolidation_claim() {
+        let previous = response(100, &[10, 20], 7);
+        let mut current = response(101, &[10, 20], 8);
+        let replacement_shaped = output_entry(b256(0xfe), 8);
+        current.optimistic_at_timestamp.insert(ChainId(U256::from(20)), replacement_shaped.clone());
+
+        let synthesized =
+            synthesize_execution(101, b256(0xaa), 8, &previous, &current).expect("synthesizes");
+
+        assert_eq!(
+            synthesized.range_inputs.claimed_transitions[1].optimistic_block.output_root,
+            replacement_shaped.output_root,
+        );
+        assert_eq!(
+            synthesized.consolidation_inputs.transitions[0].optimistic_blocks[1].output_root,
+            replacement_shaped.output_root,
+        );
+        assert_eq!(
+            synthesized.consolidation_inputs.transitions[0]
+                .claimed_super_root_proof
+                .super_root
+                .output_roots[1]
+                .output_root,
+            current.data.as_ref().unwrap().super_v1.chains[1].output,
+        );
+        assert_ne!(
+            replacement_shaped.output_root,
+            current.data.as_ref().unwrap().super_v1.chains[1].output,
+        );
+    }
+
+    #[test]
+    fn synthesize_execution_rejects_unsorted_chain_ids() {
+        let previous = response(100, &[10, 20], 7);
+        let current = response(101, &[20, 10], 8);
+
+        let err = synthesize_execution(101, b256(0xaa), 8, &previous, &current).unwrap_err();
+
+        assert!(err.to_string().contains("strictly increasing"));
+    }
+
+    #[test]
+    fn synthesize_execution_rejects_missing_optimistic_output() {
+        let previous = response(100, &[10, 20], 7);
+        let mut current = response(101, &[10, 20], 8);
+        current.optimistic_at_timestamp.remove(&ChainId(U256::from(20)));
+
+        let err = synthesize_execution(101, b256(0xaa), 8, &previous, &current).unwrap_err();
+
+        assert!(err.to_string().contains("missing optimistic output for chain 20"));
+    }
+
+    #[test]
+    fn synthesize_execution_rejects_required_l1_after_l1_head() {
+        let previous = response(100, &[10, 20], 7);
+        let current = response(101, &[10, 20], 9);
+
+        let err = synthesize_execution(101, b256(0xaa), 8, &previous, &current).unwrap_err();
+
+        assert!(err.to_string().contains("after supplied L1 head"));
+    }
+
+    #[test]
+    fn decodes_supernode_json_shapes() {
+        let json = r#"{
+            "current_l1":{"hash":"0x0101010101010101010101010101010101010101010101010101010101010101","number":9},
+            "optimistic_at_timestamp":{
+                "10":{
+                    "output":{
+                        "stateRoot":"0x1111111111111111111111111111111111111111111111111111111111111111",
+                        "messagePasserStorageRoot":"0x2222222222222222222222222222222222222222222222222222222222222222",
+                        "blockHash":"0x3333333333333333333333333333333333333333333333333333333333333333"
+                    },
+                    "output_root":"0x4444444444444444444444444444444444444444444444444444444444444444",
+                    "required_l1":{"hash":"0x0505050505050505050505050505050505050505050505050505050505050505","number":8}
+                }
+            },
+            "chain_ids":["10"],
+            "data":{
+                "verified_required_l1":{"hash":"0x0505050505050505050505050505050505050505050505050505050505050505","number":8},
+                "super":{
+                    "timestamp":"0x65",
+                    "chains":[{"ChainID":"10","Output":"0x4444444444444444444444444444444444444444444444444444444444444444"}]
+                },
+                "super_root":"0x6666666666666666666666666666666666666666666666666666666666666666"
+            }
+        }"#;
+
+        let decoded: SuperRootAtTimestampResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(decoded.current_l1.number, 9);
+        assert_eq!(decoded.chain_ids, vec![ChainId(U256::from(10))]);
+        assert_eq!(decoded.data.unwrap().super_v1.timestamp, 101);
+    }
+
+    #[test]
+    fn stdin_and_public_values_round_trip_range_outputs() {
+        let previous = response(100, &[10], 7);
+        let current = response(101, &[10], 8);
+        let synthesized =
+            synthesize_execution(101, b256(0xaa), 8, &previous, &current).expect("synthesizes");
+        let witness = DefaultWitnessData::default();
+
+        let _stdin =
+            build_super_range_stdin(&synthesized.range_inputs, witness).expect("stdin encodes");
+
+        let outputs = SuperRangeOutputs {
+            span: synthesized.range_inputs.span,
+            l1_head: synthesized.range_inputs.l1_head,
+            previous_super_roots: synthesized
+                .range_inputs
+                .previous_super_root_proofs
+                .iter()
+                .map(hash_super_root_proof)
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap(),
+            transitions: synthesized.range_inputs.claimed_transitions.clone(),
+        };
+        let mut public_values = SP1PublicValues::new();
+        public_values.write(&SuperInteropOutputs::Range(outputs.clone()));
+
+        assert_eq!(decode_super_range_public_values(&mut public_values).unwrap(), outputs);
+    }
+
+    #[test]
+    fn seeded_oracle_prefers_preloaded_preimages() {
+        let mut seeds = PreimageStore::default();
+        let value = b"seeded".to_vec();
+        let key = PreimageKey::new_keccak256(*B256::from(keccak256(&value)));
+        seeds.save_preimage(key, value.clone()).unwrap();
+        let oracle = SeededOracle::new(FailingOracle, Arc::new(seeds));
+
+        let got = kona_proof::block_on(oracle.get(key)).unwrap();
+
+        assert_eq!(got, value);
+    }
+
+    #[derive(Clone, Debug)]
+    struct FailingOracle;
+
+    #[async_trait]
+    impl PreimageOracleClient for FailingOracle {
+        async fn get(&self, _key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
+            Err(PreimageOracleError::InvalidPreimageKey)
+        }
+
+        async fn get_exact(&self, _key: PreimageKey, _buf: &mut [u8]) -> PreimageOracleResult<()> {
+            Err(PreimageOracleError::InvalidPreimageKey)
+        }
+    }
+
+    #[async_trait]
+    impl HintWriterClient for FailingOracle {
+        async fn write(&self, _hint: &str) -> PreimageOracleResult<()> {
+            Ok(())
+        }
+    }
+
+    impl FlushableCache for FailingOracle {
+        fn flush(&self) {}
+    }
+}

--- a/rust/kona/sp1/crates/super-range-executor/src/main.rs
+++ b/rust/kona/sp1/crates/super-range-executor/src/main.rs
@@ -1,0 +1,93 @@
+//! CLI entrypoint for the kona-sp1 super-range executor.
+
+use std::{path::PathBuf, process::ExitCode};
+
+use alloy_primitives::B256;
+use clap::Parser;
+use kona_sp1_super_range_executor::{
+    EXIT_INFRA, EXIT_INVALID, EXIT_VALID, RunConfig, Verdict, run,
+};
+
+/// Runs the kona-sp1 super-range program against live supernode data.
+#[derive(Parser, Debug)]
+#[command(
+    name = "kona-sp1-super-range-executor",
+    about = "Collect a super-range witness from the interop preimage server and execute the \
+             kona-sp1 super-range ELF."
+)]
+struct Cli {
+    /// Replay the collected witnesses through the shared native cores instead of executing the
+    /// SP1 guest ELF.
+    #[arg(long)]
+    native_core: bool,
+    /// Supernode JSON-RPC endpoint.
+    #[arg(long, env = "SUPER_NODE_ADDRESS")]
+    supernode_address: String,
+    /// L1 execution JSON-RPC endpoint.
+    #[arg(long, env)]
+    l1_node_address: String,
+    /// L1 beacon API endpoint.
+    #[arg(long, env)]
+    l1_beacon_address: String,
+    /// L2 execution JSON-RPC endpoints, comma-separated.
+    #[arg(long, value_delimiter = ',', env)]
+    l2_node_addresses: Vec<String>,
+    /// Trusted L1 head hash.
+    #[arg(long, env)]
+    l1_head: B256,
+    /// Superchain timestamp to prove.
+    #[arg(long, env)]
+    end_timestamp: u64,
+    /// Rollup config JSON paths, comma-separated.
+    #[arg(long, alias = "rollup-cfgs", value_delimiter = ',', env)]
+    rollup_config_paths: Option<Vec<PathBuf>>,
+    /// L1 config JSON path.
+    #[arg(long, alias = "l1-cfg", env)]
+    l1_config_path: Option<PathBuf>,
+    /// Dependency-set JSON path.
+    #[arg(long, alias = "depset-cfg", env)]
+    dependency_set_path: Option<PathBuf>,
+}
+
+fn main() -> ExitCode {
+    init_tracing();
+    let cli = Cli::parse();
+
+    let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+        Ok(runtime) => runtime,
+        Err(err) => return infra(format!("failed to build tokio runtime: {err}")),
+    };
+
+    let config = RunConfig {
+        native_core: cli.native_core,
+        supernode_address: cli.supernode_address,
+        l1_node_address: cli.l1_node_address,
+        l1_beacon_address: cli.l1_beacon_address,
+        l2_node_addresses: cli.l2_node_addresses,
+        l1_head: cli.l1_head,
+        end_timestamp: cli.end_timestamp,
+        rollup_config_paths: cli.rollup_config_paths,
+        l1_config_path: cli.l1_config_path,
+        dependency_set_path: cli.dependency_set_path,
+    };
+
+    match runtime.block_on(run(config)) {
+        Ok(Verdict::Valid) => ExitCode::from(EXIT_VALID),
+        Ok(Verdict::Invalid) => ExitCode::from(EXIT_INVALID),
+        Err(err) => infra(format!("failed to evaluate super-range claim: {err:?}")),
+    }
+}
+
+fn infra(message: String) -> ExitCode {
+    tracing::error!("{message}");
+    eprintln!("{message}");
+    ExitCode::from(EXIT_INFRA)
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .try_init();
+}

--- a/rust/kona/sp1/justfile
+++ b/rust/kona/sp1/justfile
@@ -3,9 +3,17 @@ default:
 
 SP1_TAG := "v6.3.1"
 
-# Build the range-executor host binary for SP1 action tests (requires build-elfs first).
+# Build the range-executor host binary, used by the SP1 execute action tests to run the range guest
+# in SP1 execute mode. The binary loads the range guest ELF at runtime, so build the ELFs before
+# running it (build-elfs).
 build-range-executor:
     cd ../.. && cargo build -p kona-sp1-range-executor --release
+
+# Build the super-range-executor host binary, used by acceptance smoke tests to run the
+# super-range guest in SP1 execute mode. The binary loads the guest ELF at runtime, so build the
+# ELFs first (build-elfs) and set KONA_SP1_ELF_DIR before running it without --native-core.
+build-super-range-executor:
+    cd ../.. && cargo build -p kona-sp1-super-range-executor --release
 
 # Build all ELF files.
 # ELF builds use the nested guest workspace with SP1 precompile-patched crypto,


### PR DESCRIPTION
## Summary

Run SP1 super-range acceptance checks natively alongside the existing FPVM scenarios. The native executor collects real witnesses, replays them through the shared range and consolidation cores, and verifies canonical and replacement outcomes across the required interop scenarios.

CircleCI builds and runs the native executor in both acceptance variants. Full program ELF execution remains limited to one opt-in cross-chain smoke test and that test runs daily in CI.

## Meta

Fixes https://github.com/ethereum-optimism/optimism/issues/21624