### PR TITLE
op-challenger, op-dispute-mon: Rename super root RPC config

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -27,7 +27,7 @@ var (
 	network                 = "op-mainnet"
 	testNetwork             = "op-sepolia"
 	l2EthRpc                = "http://example.com:9545"
-	superRpc                = "http://example.com/super"
+	superRootRpc            = "http://example.com/super"
 	cannonBin               = "./bin/cannon"
 	cannonServer            = "./bin/op-program"
 	cannonPreState          = "./pre.json"
@@ -107,9 +107,9 @@ func TestL1Beacon(t *testing.T) {
 	})
 }
 
-func TestSuperNodeRpc(t *testing.T) {
+func TestSuperRootRpc(t *testing.T) {
 	t.Run("RequiredForSuperCannonKona", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag supernode-rpc is required", addRequiredArgsExcept(gameTypes.SuperCannonKonaGameType, "--supernode-rpc"))
+		verifyArgsInvalid(t, "flag superroot-rpc is required", addRequiredArgsExcept(gameTypes.SuperCannonKonaGameType, "--superroot-rpc"))
 	})
 
 	for _, gameType := range gameTypes.SupportedGameTypes {
@@ -119,15 +119,50 @@ func TestSuperNodeRpc(t *testing.T) {
 		}
 
 		t.Run("NotRequiredForGameType-"+gameType.String(), func(t *testing.T) {
-			configForArgs(t, addRequiredArgsExcept(gameType, "--supernode-rpc"))
+			configForArgs(t, addRequiredArgsExcept(gameType, "--superroot-rpc"))
 		})
 	}
 
 	t.Run("Valid-SuperCannonKona", func(t *testing.T) {
 		url := "http://localhost/super"
-		cfg := configForArgs(t, addRequiredArgsExcept(gameTypes.SuperCannonKonaGameType, "--supernode-rpc", "--supernode-rpc", url))
-		require.Equal(t, url, cfg.SuperRPC)
+		cfg := configForArgs(t, addRequiredArgsExcept(gameTypes.SuperCannonKonaGameType, "--superroot-rpc", "--superroot-rpc", url))
+		require.Equal(t, url, cfg.SuperRootRPC)
 	})
+}
+func TestSuperRootRpcCompatibility(t *testing.T) {
+	const url = "http://localhost/super"
+	testCases := []struct {
+		name    string
+		args    []string
+		envName string
+	}{
+		{
+			name: "PrimaryFlag",
+			args: []string{"--superroot-rpc", url},
+		},
+		{
+			name: "LegacyFlagAlias",
+			args: []string{"--supernode-rpc", url},
+		},
+		{
+			name:    "PrimaryEnvVar",
+			envName: "OP_CHALLENGER_SUPERROOT_RPC",
+		},
+		{
+			name:    "LegacyEnvVarAlias",
+			envName: "OP_CHALLENGER_SUPERNODE_RPC",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.envName != "" {
+				t.Setenv(testCase.envName, url)
+			}
+			cfg := configForArgs(t, addRequiredArgsExcept(gameTypes.SuperCannonKonaGameType, "--superroot-rpc", testCase.args...))
+			require.Equal(t, url, cfg.SuperRootRPC)
+		})
+	}
 }
 
 func TestGameTypes(t *testing.T) {
@@ -1050,7 +1085,7 @@ func addRequiredCannonKonaBaseArgs(args map[string]string) {
 
 func addRequiredSuperCannonKonaArgs(args map[string]string) {
 	addRequiredCannonKonaBaseArgs(args)
-	args["--supernode-rpc"] = superRpc
+	args["--superroot-rpc"] = superRootRpc
 }
 
 func toArgList(req map[string]string) []string {

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -34,8 +34,8 @@ var (
 	ErrMissingCannonKonaInfoFreq         = errors.New("missing cannon kona info freq")
 	ErrMissingDepsetConfig               = errors.New("missing network or depset config path")
 
-	ErrMissingRollupRpc = errors.New("missing rollup rpc url")
-	ErrMissingSuperRpc  = errors.New("missing super rpc url")
+	ErrMissingRollupRpc    = errors.New("missing rollup rpc url")
+	ErrMissingSuperRootRpc = errors.New("missing super root RPC URL")
 )
 
 const (
@@ -75,9 +75,9 @@ type Config struct {
 
 	GameTypes []gameTypes.GameType // Type of games supported
 
-	RollupRpc string   // L2 Rollup RPC Url
-	SuperRPC  string   // L2 RPC URL for op-supernode super roots
-	L2Rpcs    []string // L2 RPC Url
+	RollupRpc    string   // L2 Rollup RPC Url
+	SuperRootRPC string   // Super root RPC URL.
+	L2Rpcs       []string // L2 RPC Url
 
 	// Specific to the cannon trace provider
 	Cannon                            vm.Config
@@ -111,7 +111,7 @@ func NewInteropConfig(
 	gameFactoryAddress common.Address,
 	l1EthRpc string,
 	l1BeaconApi string,
-	superRpc string,
+	superRootRpc string,
 	l2Rpcs []string,
 	datadir string,
 	supportedGameTypes ...gameTypes.GameType,
@@ -120,7 +120,7 @@ func NewInteropConfig(
 		L1EthRpc:           l1EthRpc,
 		L1RPCKind:          sources.RPCKindStandard,
 		L1Beacon:           l1BeaconApi,
-		SuperRPC:           superRpc,
+		SuperRootRPC:       superRootRpc,
 		L2Rpcs:             l2Rpcs,
 		GameFactoryAddress: gameFactoryAddress,
 		MaxConcurrency:     uint(runtime.NumCPU()),
@@ -256,8 +256,8 @@ func (c Config) Check() error {
 		}
 	}
 	if c.GameTypeEnabled(gameTypes.SuperCannonKonaGameType) {
-		if c.SuperRPC == "" {
-			return ErrMissingSuperRpc
+		if c.SuperRootRPC == "" {
+			return ErrMissingSuperRootRpc
 		}
 
 		if len(c.CannonKona.Networks) == 0 && c.CannonKona.DepsetConfigPath == "" {

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -29,7 +29,7 @@ var (
 	validDatadir                          = "/tmp/data"
 	validL2Rpc                            = "http://localhost:9545"
 	validRollupRpc                        = "http://localhost:8555"
-	validSuperRpc                         = "http://localhost/super"
+	validSuperRootRpc                     = "http://localhost/super"
 
 	nonExistingFile = "path/to/nonexistent/file"
 
@@ -87,7 +87,7 @@ func applyValidConfigForCannonKona(t *testing.T, cfg *Config) {
 }
 
 func applyValidConfigForSuperCannonKona(t *testing.T, cfg *Config) {
-	cfg.SuperRPC = validSuperRpc
+	cfg.SuperRootRPC = validSuperRootRpc
 	applyValidConfigForCannonKona(t, cfg)
 }
 
@@ -552,19 +552,20 @@ func TestRollupRpcNotRequiredForInterop(t *testing.T) {
 	})
 }
 
-func TestSuperRpc(t *testing.T) {
+func TestSuperRootRpc(t *testing.T) {
 	for _, gameType := range gameTypes.SupportedGameTypes {
 		gameType := gameType
 		if gameType == gameTypes.SuperCannonKonaGameType {
 			t.Run("RequiredFor"+gameType.String(), func(t *testing.T) {
 				config := validConfig(t, gameType)
-				config.SuperRPC = ""
-				require.ErrorIs(t, config.Check(), ErrMissingSuperRpc)
+				config.SuperRootRPC = ""
+				require.ErrorIs(t, config.Check(), ErrMissingSuperRootRpc)
+				require.EqualError(t, config.Check(), "missing super root RPC URL")
 			})
 		} else {
 			t.Run("NotRequiredFor"+gameType.String(), func(t *testing.T) {
 				config := validConfig(t, gameType)
-				config.SuperRPC = ""
+				config.SuperRootRPC = ""
 				require.NoError(t, config.Check())
 			})
 		}

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -63,10 +63,11 @@ var (
 		Usage:   "Address of L1 Beacon API endpoint to use",
 		EnvVars: prefixEnvVars("L1_BEACON"),
 	}
-	SuperNodeRpcFlag = &cli.StringFlag{
-		Name:    "supernode-rpc",
-		Usage:   "Provider URL for supernode roots",
-		EnvVars: prefixEnvVars("SUPERNODE_RPC"),
+	SuperRootRpcFlag = &cli.StringFlag{
+		Name:    "superroot-rpc",
+		Aliases: []string{"supernode-rpc"},
+		Usage:   "HTTP provider URL for a super root RPC source (op-node or op-supernode)",
+		EnvVars: prefixEnvVars("SUPERROOT_RPC", "SUPERNODE_RPC"),
 	}
 	RollupRpcFlag = &cli.StringFlag{
 		Name:    "rollup-rpc",
@@ -277,7 +278,7 @@ var optionalFlags = []cli.Flag{
 	FactoryAddressFlag,
 	GameTypesFlag,
 	MaxConcurrencyFlag,
-	SuperNodeRpcFlag,
+	SuperRootRpcFlag,
 	L2EthRpcFlag,
 	L2ExperimentalEthRpcFlag,
 	MaxPendingTransactionsFlag,
@@ -353,8 +354,8 @@ func CheckCannonBaseFlags(ctx *cli.Context, enabledTypes []gameTypes.GameType) e
 }
 
 func CheckSuperCannonKonaFlags(ctx *cli.Context) error {
-	if !ctx.IsSet(SuperNodeRpcFlag.Name) {
-		return fmt.Errorf("flag %v is required", SuperNodeRpcFlag.Name)
+	if !ctx.IsSet(SuperRootRpcFlag.Name) {
+		return fmt.Errorf("flag %v is required", SuperRootRpcFlag.Name)
 	}
 	if !ctx.IsSet(flags.NetworkFlagName) &&
 		!(RollupConfigFlag.IsSet(ctx, gameTypes.CannonKonaGameType) && L2GenesisFlag.IsSet(ctx, gameTypes.CannonKonaGameType) && DepsetConfigFlag.IsSet(ctx, gameTypes.CannonKonaGameType)) {
@@ -601,7 +602,7 @@ func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, erro
 		MinUpdateInterval:       ctx.Duration(MinUpdateInterval.Name),
 		AdditionalBondClaimants: claimants,
 		RollupRpc:               ctx.String(RollupRpcFlag.Name),
-		SuperRPC:                ctx.String(SuperNodeRpcFlag.Name),
+		SuperRootRPC:            ctx.String(SuperRootRpcFlag.Name),
 		Cannon: vm.Config{
 			VmType:            gameTypes.CannonGameType,
 			L1:                l1EthRpc,

--- a/op-challenger/flags/flags_test.go
+++ b/op-challenger/flags/flags_test.go
@@ -17,6 +17,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+func TestSuperRootRpcFlagCompatibility(t *testing.T) {
+	require.Equal(t, []string{"superroot-rpc", "supernode-rpc"}, SuperRootRpcFlag.Names())
+	require.Equal(t, []string{"OP_CHALLENGER_SUPERROOT_RPC", "OP_CHALLENGER_SUPERNODE_RPC"}, SuperRootRpcFlag.EnvVars)
+}
+
 // TestUniqueFlags asserts that all flag names are unique, to avoid accidental conflicts between the many flags.
 func TestUniqueFlags(t *testing.T) {
 	seenCLI := make(map[string]struct{})
@@ -89,7 +94,11 @@ func TestEnvVarFormat(t *testing.T) {
 			})
 			envFlags := envFlagGetter.GetEnvVars()
 			require.True(t, ok, "must be able to cast the flag to an EnvVar interface")
-			require.Equal(t, 1, len(envFlags), "flags should have exactly one env var")
+			if flagName == SuperRootRpcFlag.Name {
+				require.Len(t, envFlags, 2, "super root RPC flag should keep its legacy env var")
+			} else {
+				require.Len(t, envFlags, 1, "flags should have exactly one env var")
+			}
 			expectedEnvVar := opservice.FlagNameToEnvVarName(flagName, "OP_CHALLENGER")
 			require.Equal(t, expectedEnvVar, envFlags[0])
 		})

--- a/op-challenger/game/client/provider.go
+++ b/op-challenger/game/client/provider.go
@@ -100,9 +100,9 @@ func (c *Provider) SuperchainClients() (*sources.SuperNodeClient, types.SyncVali
 	if c.superNodeClient != nil {
 		return c.superNodeClient, c.superSyncValidator, nil
 	}
-	superNodeClient, err := dial.DialSuperNodeClientWithTimeout(c.ctx, c.logger, c.cfg.SuperRPC)
+	superNodeClient, err := dial.DialSuperNodeClientWithTimeout(c.ctx, c.logger, c.cfg.SuperRootRPC)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to dial supernode: %w", err)
+		return nil, nil, fmt.Errorf("failed to dial super root RPC client: %w", err)
 	}
 	c.superNodeClient = superNodeClient
 	c.superSyncValidator = &NoopSyncStatusValidator{}

--- a/op-challenger/runner/game_inputs.go
+++ b/op-challenger/runner/game_inputs.go
@@ -32,7 +32,7 @@ func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources
 	switch gameType {
 	case gameTypes.SuperCannonKonaGameType:
 		if superNodeClient == nil {
-			return utils.LocalGameInputs{}, fmt.Errorf("game type %s requires supernode rpc to be set", gameType)
+			return utils.LocalGameInputs{}, fmt.Errorf("game type %s requires super root RPC to be set", gameType)
 		}
 		return createGameInputsInterop(ctx, log, superNodeClient, typeName)
 	default:
@@ -167,7 +167,7 @@ func hasNonZeroSafeHead(ctx context.Context, client *sources.RollupClient, l1Num
 func createGameInputsInterop(ctx context.Context, log log.Logger, client *sources.SuperNodeClient, typeName string) (utils.LocalGameInputs, error) {
 	status, err := client.SyncStatus(ctx)
 	if err != nil {
-		return utils.LocalGameInputs{}, fmt.Errorf("failed to get supernode sync status: %w", err)
+		return utils.LocalGameInputs{}, fmt.Errorf("failed to get super root RPC sync status: %w", err)
 	}
 	log.Info("Got sync status", "status", status, "type", typeName)
 

--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -117,11 +117,11 @@ func (r *Runner) Start(ctx context.Context) error {
 		rollupClient = cl
 	}
 	var superNodeClient *sources.SuperNodeClient
-	if r.cfg.SuperRPC != "" {
-		r.log.Info("Dialling supernode client", "url", r.cfg.SuperRPC)
-		cl, err := dial.DialSuperNodeClientWithTimeout(ctx, r.log, r.cfg.SuperRPC)
+	if r.cfg.SuperRootRPC != "" {
+		r.log.Info("Dialling super root RPC client", "url", r.cfg.SuperRootRPC)
+		cl, err := dial.DialSuperNodeClientWithTimeout(ctx, r.log, r.cfg.SuperRootRPC)
 		if err != nil {
-			return fmt.Errorf("failed to dial supernode: %w", err)
+			return fmt.Errorf("failed to dial super root RPC client: %w", err)
 		}
 		superNodeClient = cl
 	}

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -223,8 +223,8 @@ func WithFastGames() Option {
 	}
 }
 
-func NewInteropChallengerConfig(ctx context.Context, dir string, l1Endpoint string, l1Beacon string, supervisorEndpoint string, l2Endpoints []string, options ...Option) (*config.Config, error) {
-	cfg := config.NewInteropConfig(common.Address{}, l1Endpoint, l1Beacon, supervisorEndpoint, l2Endpoints, dir)
+func NewInteropChallengerConfig(ctx context.Context, dir string, l1Endpoint string, l1Beacon string, superRootEndpoint string, l2Endpoints []string, options ...Option) (*config.Config, error) {
+	cfg := config.NewInteropConfig(common.Address{}, l1Endpoint, l1Beacon, superRootEndpoint, l2Endpoints, dir)
 	if err := applyCommonChallengerOpts(ctx, &cfg, options...); err != nil {
 		return nil, err
 	}

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -167,9 +167,9 @@ func WithFactoryAddress(addr common.Address) Option {
 	}
 }
 
-func WithSuperRPC(endpoint string) Option {
+func WithSuperRootRPC(endpoint string) Option {
 	return func(_ context.Context, c *config.Config) error {
-		c.SuperRPC = endpoint
+		c.SuperRootRPC = endpoint
 		return nil
 	}
 }

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -418,7 +418,7 @@ func startMinimalChallenger(
 			sharedchallenger.WithDepset(dependencySet),
 			sharedchallenger.WithCannonKonaInteropConfig(rollupCfgs, l1Net.genesis, l2Geneses),
 			sharedchallenger.WithSuperCannonKonaGameType(),
-			sharedchallenger.WithSuperRPC(l2CL.UserRPC()),
+			sharedchallenger.WithSuperRootRPC(l2CL.UserRPC()),
 		)
 	}
 	cfg, err := sharedchallenger.NewPreInteropChallengerConfig(

--- a/op-dispute-mon/README.md
+++ b/op-dispute-mon/README.md
@@ -26,10 +26,10 @@ shows the available config options and can be accessed by running `./bin/op-disp
   --l1-eth-rpc <L1-Ethereum-RPC-URL> \
   --rollup-rpc <Optimism-Rollup-RPC-URL>,<Secondary-RPC-URL>,<Tertiary-RPC-URL>
 
-# For networks using op-supernode:
+# For networks using super root RPCs:
 ./bin/op-dispute-mon \
   --network <Predefined-Network> \
   --l1-eth-rpc <L1-Ethereum-RPC-URL> \
-  --supernode-rpc <SuperNode-RPC-URL>,<Secondary-RPC-URL>,<Tertiary-RPC-URL>
+  --superroot-rpc <SuperRoot-RPC-URL>,<Secondary-RPC-URL>,<Tertiary-RPC-URL>
 
 ```

--- a/op-dispute-mon/cmd/main.go
+++ b/op-dispute-mon/cmd/main.go
@@ -59,7 +59,7 @@ func run(ctx context.Context, args []string, action ConfiguredLifecycle) error {
 		logger.Info("RPC endpoints",
 			"l1", cfg.L1EthRpc,
 			"rollup", cfg.RollupRpcs,
-			"superNode", cfg.SuperNodeRpcs,
+			"superRoot", cfg.SuperRootRpcs,
 		)
 		return action(ctx.Context, logger, cfg)
 	})

--- a/op-dispute-mon/cmd/main_test.go
+++ b/op-dispute-mon/cmd/main_test.go
@@ -60,13 +60,13 @@ func TestL1EthRpc(t *testing.T) {
 	})
 }
 
-func TestMustSpecifyEitherRollupRpcOrSuperNodeRpc(t *testing.T) {
-	verifyArgsInvalid(t, "flag rollup-rpc or supernode-rpc is required", addRequiredArgsExcept("--rollup-rpc"))
+func TestMustSpecifyEitherRollupRpcOrSuperRootRpc(t *testing.T) {
+	verifyArgsInvalid(t, "flag rollup-rpc or superroot-rpc is required", addRequiredArgsExcept("--rollup-rpc"))
 }
 
 func TestRollupRpc(t *testing.T) {
-	t.Run("NotRequiredIfSuperNodeRpcSupplied", func(t *testing.T) {
-		configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--supernode-rpc", "http://localhost/supernode"))
+	t.Run("NotRequiredIfSuperRootRpcSupplied", func(t *testing.T) {
+		configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--superroot-rpc", "http://localhost/superroot"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -83,24 +83,51 @@ func TestRollupRpc(t *testing.T) {
 	})
 }
 
-func TestSuperNodeRpc(t *testing.T) {
+func TestSuperRootRpc(t *testing.T) {
 	t.Run("NotRequiredIfRollupRpcSupplied", func(t *testing.T) {
 		// rollup-rpc is in the default args.
-		configForArgs(t, addRequiredArgsExcept("--supernode-rpc"))
+		configForArgs(t, addRequiredArgsExcept("--superroot-rpc"))
 	})
 
-	t.Run("Valid", func(t *testing.T) {
-		url := "http://example.com:9999"
-		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--supernode-rpc", url))
-		require.Equal(t, []string{url}, cfg.SuperNodeRpcs)
-	})
+	const url1 = "http://example1.com:9999"
+	const url2 = "http://example2.com:8888"
+	testCases := []struct {
+		name     string
+		args     []string
+		envName  string
+		expected []string
+	}{
+		{
+			name:     "PrimaryFlag",
+			args:     []string{"--superroot-rpc", url1, "--superroot-rpc", url2},
+			expected: []string{url1, url2},
+		},
+		{
+			name:     "LegacyFlagAlias",
+			args:     []string{"--supernode-rpc", url1, "--supernode-rpc", url2},
+			expected: []string{url1, url2},
+		},
+		{
+			name:     "PrimaryEnvVar",
+			envName:  "OP_DISPUTE_MON_SUPERROOT_RPC",
+			expected: []string{url1},
+		},
+		{
+			name:     "LegacyEnvVarAlias",
+			envName:  "OP_DISPUTE_MON_SUPERNODE_RPC",
+			expected: []string{url1},
+		},
+	}
 
-	t.Run("MultipleValues", func(t *testing.T) {
-		url1 := "http://example1.com:9999"
-		url2 := "http://example2.com:8888"
-		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--supernode-rpc", url1, "--supernode-rpc", url2))
-		require.Equal(t, []string{url1, url2}, cfg.SuperNodeRpcs)
-	})
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.envName != "" {
+				t.Setenv(testCase.envName, url1)
+			}
+			cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", testCase.args...))
+			require.Equal(t, testCase.expected, cfg.SuperRootRpcs)
+		})
+	}
 }
 
 func TestGameFactoryAddress(t *testing.T) {

--- a/op-dispute-mon/config/config.go
+++ b/op-dispute-mon/config/config.go
@@ -14,7 +14,7 @@ import (
 var (
 	ErrMissingL1EthRPC              = errors.New("missing l1 eth rpc url")
 	ErrMissingGameFactoryAddress    = errors.New("missing game factory address")
-	ErrMissingRollupAndSuperNodeRpc = errors.New("must specify rollup rpc or super node rpc")
+	ErrMissingRollupAndSuperRootRpc = errors.New("must specify rollup RPC or super root RPC")
 	ErrMissingMaxConcurrency        = errors.New("missing max concurrency")
 )
 
@@ -40,7 +40,7 @@ type Config struct {
 
 	HonestActors    []common.Address // List of honest actors to monitor claims for.
 	RollupRpcs      []string         // The rollup node RPC URLs.
-	SuperNodeRpcs   []string         // The super node RPC URLs.
+	SuperRootRpcs   []string         // The super root RPC URLs.
 	MonitorInterval time.Duration    // Frequency to check for new games to monitor.
 	GameWindow      time.Duration    // Maximum window to look for games to monitor.
 	IgnoredGames    []common.Address // Games to exclude from monitoring
@@ -50,19 +50,19 @@ type Config struct {
 	PprofConfig   oppprof.CLIConfig
 }
 
-func NewInteropConfig(gameFactoryAddress common.Address, l1EthRpc string, superNodeRpcs []string) Config {
-	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, nil, superNodeRpcs)
+func NewInteropConfig(gameFactoryAddress common.Address, l1EthRpc string, superRootRpcs []string) Config {
+	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, nil, superRootRpcs)
 }
 
 func NewConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpcs []string) Config {
 	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, rollupRpcs, nil)
 }
 
-func NewCombinedConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpcs []string, superNodeRpcs []string) Config {
+func NewCombinedConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpcs []string, superRootRpcs []string) Config {
 	return Config{
 		L1EthRpc:           l1EthRpc,
 		RollupRpcs:         rollupRpcs,
-		SuperNodeRpcs:      superNodeRpcs,
+		SuperRootRpcs:      superRootRpcs,
 		GameFactoryAddress: gameFactoryAddress,
 
 		MonitorInterval: DefaultMonitorInterval,
@@ -78,8 +78,8 @@ func (c Config) Check() error {
 	if c.L1EthRpc == "" {
 		return ErrMissingL1EthRPC
 	}
-	if len(c.RollupRpcs) == 0 && len(c.SuperNodeRpcs) == 0 {
-		return ErrMissingRollupAndSuperNodeRpc
+	if len(c.RollupRpcs) == 0 && len(c.SuperRootRpcs) == 0 {
+		return ErrMissingRollupAndSuperRootRpc
 	}
 	if c.GameFactoryAddress == (common.Address{}) {
 		return ErrMissingGameFactoryAddress

--- a/op-dispute-mon/config/config_test.go
+++ b/op-dispute-mon/config/config_test.go
@@ -12,7 +12,7 @@ var (
 	validL1EthRpc           = "http://localhost:8545"
 	validGameFactoryAddress = common.Address{0x23}
 	validRollupRpcs         = []string{"http://localhost:8555"}
-	validSuperNodeRpcs      = []string{"http://localhost:8999"}
+	validSuperRootRpcs      = []string{"http://localhost:8999"}
 )
 
 func validConfig() Config {
@@ -35,24 +35,25 @@ func TestGameFactoryAddressRequired(t *testing.T) {
 	require.ErrorIs(t, config.Check(), ErrMissingGameFactoryAddress)
 }
 
-func TestRollupRpcOrSuperNodeRpcRequired(t *testing.T) {
+func TestRollupRpcOrSuperRootRpcRequired(t *testing.T) {
 	config := validConfig()
 	config.RollupRpcs = nil
-	config.SuperNodeRpcs = nil
-	require.ErrorIs(t, config.Check(), ErrMissingRollupAndSuperNodeRpc)
+	config.SuperRootRpcs = nil
+	require.ErrorIs(t, config.Check(), ErrMissingRollupAndSuperRootRpc)
+	require.EqualError(t, config.Check(), "must specify rollup RPC or super root RPC")
 }
 
-func TestRollupRpcNotRequiredWhenSuperNodeRpcSet(t *testing.T) {
+func TestRollupRpcNotRequiredWhenSuperRootRpcSet(t *testing.T) {
 	config := validConfig()
 	config.RollupRpcs = nil
-	config.SuperNodeRpcs = validSuperNodeRpcs
+	config.SuperRootRpcs = validSuperRootRpcs
 	require.NoError(t, config.Check())
 }
 
-func TestSuperNodeRpcNotRequiredWhenRollupRpcSet(t *testing.T) {
+func TestSuperRootRpcNotRequiredWhenRollupRpcSet(t *testing.T) {
 	config := validConfig()
 	config.RollupRpcs = validRollupRpcs
-	config.SuperNodeRpcs = nil
+	config.SuperRootRpcs = nil
 	require.NoError(t, config.Check())
 }
 
@@ -62,22 +63,22 @@ func TestMaxConcurrencyRequired(t *testing.T) {
 	require.ErrorIs(t, config.Check(), ErrMissingMaxConcurrency)
 }
 
-func TestMultipleSuperNodeRpcs(t *testing.T) {
+func TestMultipleSuperRootRpcs(t *testing.T) {
 	config := validConfig()
 	config.RollupRpcs = nil
-	config.SuperNodeRpcs = []string{"http://localhost:8999", "http://localhost:9000", "http://localhost:9001"}
+	config.SuperRootRpcs = []string{"http://localhost:8999", "http://localhost:9000", "http://localhost:9001"}
 	require.NoError(t, config.Check())
 }
 
 func TestInteropConfig(t *testing.T) {
 	gameFactoryAddr := common.Address{0x42}
 	l1RPC := "http://localhost:8545"
-	superNodeRpcs := []string{"http://localhost:8999", "http://localhost:9000"}
+	superRootRpcs := []string{"http://localhost:8999", "http://localhost:9000"}
 
-	config := NewInteropConfig(gameFactoryAddr, l1RPC, superNodeRpcs)
+	config := NewInteropConfig(gameFactoryAddr, l1RPC, superRootRpcs)
 	require.Equal(t, gameFactoryAddr, config.GameFactoryAddress)
 	require.Equal(t, l1RPC, config.L1EthRpc)
-	require.Equal(t, superNodeRpcs, config.SuperNodeRpcs)
+	require.Equal(t, superRootRpcs, config.SuperRootRpcs)
 	require.Nil(t, config.RollupRpcs)
 	require.NoError(t, config.Check())
 }
@@ -86,12 +87,12 @@ func TestCombinedConfig(t *testing.T) {
 	gameFactoryAddr := common.Address{0x42}
 	l1RPC := "http://localhost:8545"
 	rollupRpcs := []string{"http://localhost:8555"}
-	superNodeRpcs := []string{"http://localhost:8999"}
+	superRootRpcs := []string{"http://localhost:8999"}
 
-	config := NewCombinedConfig(gameFactoryAddr, l1RPC, rollupRpcs, superNodeRpcs)
+	config := NewCombinedConfig(gameFactoryAddr, l1RPC, rollupRpcs, superRootRpcs)
 	require.Equal(t, gameFactoryAddr, config.GameFactoryAddress)
 	require.Equal(t, l1RPC, config.L1EthRpc)
 	require.Equal(t, rollupRpcs, config.RollupRpcs)
-	require.Equal(t, superNodeRpcs, config.SuperNodeRpcs)
+	require.Equal(t, superRootRpcs, config.SuperRootRpcs)
 	require.NoError(t, config.Check())
 }

--- a/op-dispute-mon/flags/flags.go
+++ b/op-dispute-mon/flags/flags.go
@@ -21,8 +21,12 @@ const (
 	envVarPrefix = "OP_DISPUTE_MON"
 )
 
-func prefixEnvVars(name string) []string {
-	return opservice.PrefixEnvVar(envVarPrefix, name)
+func prefixEnvVars(names ...string) []string {
+	envs := make([]string, 0, len(names))
+	for _, name := range names {
+		envs = append(envs, envVarPrefix+"_"+name)
+	}
+	return envs
 }
 
 var (
@@ -38,10 +42,11 @@ var (
 		Usage:   "HTTP provider URL for the rollup node. Multiple URLs can be specified for redundancy.",
 		EnvVars: prefixEnvVars("ROLLUP_RPC"),
 	}
-	SuperNodeRpcFlag = &cli.StringSliceFlag{
-		Name:    "supernode-rpc",
-		Usage:   "HTTP provider URL for super nodes. Multiple URLs can be specified for redundancy.",
-		EnvVars: prefixEnvVars("SUPERNODE_RPC"),
+	SuperRootRpcFlag = &cli.StringSliceFlag{
+		Name:    "superroot-rpc",
+		Aliases: []string{"supernode-rpc"},
+		Usage:   "HTTP provider URLs for super root RPC sources (op-node or op-supernode). Multiple URLs can be specified for redundancy.",
+		EnvVars: prefixEnvVars("SUPERROOT_RPC", "SUPERNODE_RPC"),
 	}
 	GameFactoryAddressFlag = &cli.StringFlag{
 		Name:    "game-factory-address",
@@ -92,7 +97,7 @@ var requiredFlags = []cli.Flag{
 // optionalFlags is a list of unchecked cli flags
 var optionalFlags = []cli.Flag{
 	RollupRpcFlag,
-	SuperNodeRpcFlag,
+	SuperRootRpcFlag,
 	GameFactoryAddressFlag,
 	NetworkFlag,
 	HonestActorsFlag,
@@ -119,8 +124,8 @@ func CheckRequired(ctx *cli.Context) error {
 			return fmt.Errorf("flag %s is required", f.Names()[0])
 		}
 	}
-	if len(ctx.StringSlice(RollupRpcFlag.Name)) == 0 && len(ctx.StringSlice(SuperNodeRpcFlag.Name)) == 0 {
-		return fmt.Errorf("flag %s or %s is required", RollupRpcFlag.Name, SuperNodeRpcFlag.Name)
+	if len(ctx.StringSlice(RollupRpcFlag.Name)) == 0 && len(ctx.StringSlice(SuperRootRpcFlag.Name)) == 0 {
+		return fmt.Errorf("flag %s or %s is required", RollupRpcFlag.Name, SuperRootRpcFlag.Name)
 	}
 	return nil
 }
@@ -169,7 +174,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 		L1EthRpc:           ctx.String(L1EthRpcFlag.Name),
 		GameFactoryAddress: gameFactoryAddress,
 		RollupRpcs:         ctx.StringSlice(RollupRpcFlag.Name),
-		SuperNodeRpcs:      ctx.StringSlice(SuperNodeRpcFlag.Name),
+		SuperRootRpcs:      ctx.StringSlice(SuperRootRpcFlag.Name),
 
 		HonestActors:    actors,
 		MonitorInterval: ctx.Duration(MonitorIntervalFlag.Name),

--- a/op-dispute-mon/flags/flags_test.go
+++ b/op-dispute-mon/flags/flags_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+func TestSuperRootRpcFlagCompatibility(t *testing.T) {
+	require.Equal(t, []string{"superroot-rpc", "supernode-rpc"}, SuperRootRpcFlag.Names())
+	require.Equal(t, []string{"OP_DISPUTE_MON_SUPERROOT_RPC", "OP_DISPUTE_MON_SUPERNODE_RPC"}, SuperRootRpcFlag.EnvVars)
+}
+
 // TestUniqueFlags asserts that all flag names are unique, to avoid accidental conflicts between the many flags.
 func TestUniqueFlags(t *testing.T) {
 	seenCLI := make(map[string]struct{})
@@ -74,7 +79,11 @@ func TestEnvVarFormat(t *testing.T) {
 			})
 			envFlags := envFlagGetter.GetEnvVars()
 			require.True(t, ok, "must be able to cast the flag to an EnvVar interface")
-			require.Equal(t, 1, len(envFlags), "flags should have exactly one env var")
+			if flagName == SuperRootRpcFlag.Name {
+				require.Len(t, envFlags, 2, "super root RPC flag should keep its legacy env var")
+			} else {
+				require.Len(t, envFlags, 1, "flags should have exactly one env var")
+			}
 			expectedEnvVar := opservice.FlagNameToEnvVarName(flagName, envVarPrefix)
 			require.Equal(t, expectedEnvVar, envFlags[0])
 		})

--- a/op-dispute-mon/mon/extract/super_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	ErrSuperNodeRpcRequired     = errors.New("super node rpc required")
-	ErrAllSuperNodesUnavailable = errors.New("all super nodes returned errors")
+	ErrSuperRootRpcRequired        = errors.New("super root RPC required")
+	ErrAllSuperRootRpcsUnavailable = errors.New("all super root RPC sources returned errors")
 )
 
 type SuperRootProvider interface {
@@ -51,7 +51,7 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Bloc
 		return nil
 	}
 	if len(e.clients) == 0 {
-		return fmt.Errorf("%w but required for game type %v", ErrSuperNodeRpcRequired, game.GameType)
+		return fmt.Errorf("%w but required for game type %v", ErrSuperRootRpcRequired, game.GameType)
 	}
 
 	game.NodeEndpointTotalCount = len(e.clients)
@@ -117,7 +117,7 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Bloc
 
 	// If all results were errors, return an error
 	if len(validResults) == 0 {
-		return fmt.Errorf("failed to get super root at timestamp: %w", ErrAllSuperNodesUnavailable)
+		return fmt.Errorf("failed to get super root at timestamp: %w", ErrAllSuperRootRpcsUnavailable)
 	}
 
 	// If all remaining nodes returned "not found", we disagree with any claim.

--- a/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
@@ -34,7 +34,8 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			NodeEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
-		require.ErrorIs(t, err, ErrSuperNodeRpcRequired)
+		require.ErrorIs(t, err, ErrSuperRootRpcRequired)
+		require.ErrorContains(t, err, "super root RPC required")
 	})
 
 	t.Run("SkipOutputRootGameTypes", func(t *testing.T) {
@@ -43,7 +44,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			gameType := gameType
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
 				validator, _, metrics := setupSuperValidatorTest(t)
-				validator.clients = nil // Should not error even though there's no super node client
+				validator.clients = nil // Should not error even though there's no super root RPC client
 				game := &types.EnrichedGameData{
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
@@ -95,7 +96,8 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			NodeEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
-		require.ErrorIs(t, err, ErrAllSuperNodesUnavailable)
+		require.ErrorIs(t, err, ErrAllSuperRootRpcsUnavailable)
+		require.ErrorContains(t, err, "all super root RPC sources returned errors")
 		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
 		require.False(t, game.AgreeWithClaim)
 		require.Zero(t, metrics.fetchTime)
@@ -230,7 +232,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.Error(t, err)
-		require.ErrorIs(t, err, ErrAllSuperNodesUnavailable)
+		require.ErrorIs(t, err, ErrAllSuperRootRpcsUnavailable)
 		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
 		require.False(t, game.AgreeWithClaim)
 		require.Zero(t, metrics.fetchTime)
@@ -624,7 +626,7 @@ func TestSuperNodeEndpointTracking(t *testing.T) {
 		}
 
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
-		require.ErrorIs(t, err, ErrSuperNodeRpcRequired)
+		require.ErrorIs(t, err, ErrSuperRootRpcRequired)
 
 		// Verify all counts remain zero when no endpoints
 		require.Equal(t, 0, game.NodeEndpointTotalCount)

--- a/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
@@ -21,7 +21,7 @@ import (
 func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ErrorWhenNoSuperNodeClient", func(t *testing.T) {
+	t.Run("ErrorWhenNoSuperRootProvider", func(t *testing.T) {
 		validator, _, _ := setupSuperValidatorTest(t)
 		validator.clients = nil // Set to nil to test the error case
 		game := &types.EnrichedGameData{
@@ -216,8 +216,8 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		require.Zero(t, metrics.fetchTime)
 	})
 
-	t.Run("AllSuperNodesReturnError", func(t *testing.T) {
-		validator, clients, metrics := setupMultiSuperNodeTest(t, 3)
+	t.Run("AllSuperRootRpcsReturnError", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSuperRootTest(t, 3)
 		for _, client := range clients {
 			client.outputErr = errors.New("boom")
 		}
@@ -238,8 +238,8 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		require.Zero(t, metrics.fetchTime)
 	})
 
-	t.Run("AllSuperNodesReturnNotFound", func(t *testing.T) {
-		validator, clients, metrics := setupMultiSuperNodeTest(t, 3)
+	t.Run("AllSuperRootRpcsReturnNotFound", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSuperRootTest(t, 3)
 		for _, client := range clients {
 			client.notFound = true
 		}
@@ -259,8 +259,8 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		require.Zero(t, metrics.fetchTime)
 	})
 
-	t.Run("SomeSuperNodesOutOfSync", func(t *testing.T) {
-		validator, clients, metrics := setupMultiSuperNodeTest(t, 3)
+	t.Run("SomeSuperRootRpcsOutOfSync", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSuperRootTest(t, 3)
 		clients[0].notFound = true
 		clients[1].outputErr = nil
 		clients[2].outputErr = nil
@@ -280,8 +280,8 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		require.NotZero(t, metrics.fetchTime)
 	})
 
-	t.Run("SuperNodesDiverged", func(t *testing.T) {
-		validator, clients, metrics := setupMultiSuperNodeTest(t, 3)
+	t.Run("SuperRootRpcsDiverged", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSuperRootTest(t, 3)
 		divergedRoot := common.HexToHash("0x5678")
 		clients[0].superRoot = mockRootClaim
 		clients[1].superRoot = divergedRoot
@@ -302,8 +302,8 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		require.NotZero(t, metrics.fetchTime)
 	})
 
-	t.Run("AllSuperNodesAgree", func(t *testing.T) {
-		validator, clients, metrics := setupMultiSuperNodeTest(t, 3)
+	t.Run("AllSuperRootRpcsAgree", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSuperRootTest(t, 3)
 		clients[0].derivedFromL1BlockNum = 200
 		clients[1].derivedFromL1BlockNum = 199
 		clients[2].derivedFromL1BlockNum = 201
@@ -324,7 +324,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	})
 
 	t.Run("MixedResponses_FoundNodesMatchClaimAndSafe", func(t *testing.T) {
-		validator, clients, metrics := setupMultiSuperNodeTest(t, 4)
+		validator, clients, metrics := setupMultiSuperRootTest(t, 4)
 		clients[0].notFound = true
 		clients[1].notFound = true
 		clients[2].superRoot = mockRootClaim
@@ -348,7 +348,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	})
 
 	t.Run("MixedResponses_FoundNodesDontMatchClaim", func(t *testing.T) {
-		validator, clients, metrics := setupMultiSuperNodeTest(t, 3)
+		validator, clients, metrics := setupMultiSuperRootTest(t, 3)
 		differentRoot := common.HexToHash("0x9999")
 		clients[0].notFound = true
 		clients[1].superRoot = differentRoot
@@ -372,7 +372,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	})
 
 	t.Run("AllNodesAgree_SuperRootMatchesClaim_NoneReportSafe", func(t *testing.T) {
-		validator, clients, metrics := setupMultiSuperNodeTest(t, 3)
+		validator, clients, metrics := setupMultiSuperRootTest(t, 3)
 
 		for _, client := range clients {
 			client.superRoot = mockRootClaim
@@ -396,7 +396,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	})
 
 	t.Run("AllNodesAgree_SuperRootDifferentFromClaim", func(t *testing.T) {
-		validator, clients, metrics := setupMultiSuperNodeTest(t, 3)
+		validator, clients, metrics := setupMultiSuperRootTest(t, 3)
 
 		differentRoot := common.HexToHash("0xdifferent")
 		for _, client := range clients {
@@ -421,31 +421,31 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	})
 }
 
-func setupSuperValidatorTest(t *testing.T) (*SuperAgreementEnricher, *stubSuperNodeClient, *stubOutputMetrics) {
+func setupSuperValidatorTest(t *testing.T) (*SuperAgreementEnricher, *stubSuperRootProvider, *stubOutputMetrics) {
 	logger := testlog.Logger(t, log.LvlInfo)
-	client := &stubSuperNodeClient{derivedFromL1BlockNum: 0, superRoot: mockRootClaim}
+	client := &stubSuperRootProvider{derivedFromL1BlockNum: 0, superRoot: mockRootClaim}
 	metrics := &stubOutputMetrics{}
 	validator := NewSuperAgreementEnricher(logger, metrics, []SuperRootProvider{client}, clock.NewDeterministicClock(time.Unix(9824924, 499)))
 	return validator, client, metrics
 }
 
-func setupMultiSuperNodeTest(t *testing.T, numNodes int) (*SuperAgreementEnricher, []*stubSuperNodeClient, *stubOutputMetrics) {
+func setupMultiSuperRootTest(t *testing.T, numNodes int) (*SuperAgreementEnricher, []*stubSuperRootProvider, *stubOutputMetrics) {
 	logger := testlog.Logger(t, log.LvlInfo)
-	clients := make([]*stubSuperNodeClient, numNodes)
-	superNodeClients := make([]SuperRootProvider, numNodes)
+	clients := make([]*stubSuperRootProvider, numNodes)
+	providers := make([]SuperRootProvider, numNodes)
 	for i := range clients {
-		clients[i] = &stubSuperNodeClient{
+		clients[i] = &stubSuperRootProvider{
 			derivedFromL1BlockNum: 0,
 			superRoot:             mockRootClaim,
 		}
-		superNodeClients[i] = clients[i]
+		providers[i] = clients[i]
 	}
 	metrics := &stubOutputMetrics{}
-	validator := NewSuperAgreementEnricher(logger, metrics, superNodeClients, clock.NewDeterministicClock(time.Unix(9824924, 499)))
+	validator := NewSuperAgreementEnricher(logger, metrics, providers, clock.NewDeterministicClock(time.Unix(9824924, 499)))
 	return validator, clients, metrics
 }
 
-type stubSuperNodeClient struct {
+type stubSuperRootProvider struct {
 	requestedTimestamp    uint64
 	outputErr             error
 	notFound              bool
@@ -453,7 +453,7 @@ type stubSuperNodeClient struct {
 	superRoot             common.Hash
 }
 
-func (s *stubSuperNodeClient) SuperRootAtTimestamp(_ context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
+func (s *stubSuperRootProvider) SuperRootAtTimestamp(_ context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
 	s.requestedTimestamp = uint64(timestamp)
 	if s.outputErr != nil {
 		return eth.SuperRootAtTimestampResponse{}, s.outputErr
@@ -470,10 +470,10 @@ func (s *stubSuperNodeClient) SuperRootAtTimestamp(_ context.Context, timestamp 
 	}, nil
 }
 
-// TestSuperNodeEndpointTracking verifies that all endpoint tracking fields are properly populated
-func TestSuperNodeEndpointTracking(t *testing.T) {
+// TestSuperRootEndpointTracking verifies that all endpoint tracking fields are properly populated
+func TestSuperRootEndpointTracking(t *testing.T) {
 	t.Run("TrackErrorsCorrectly", func(t *testing.T) {
-		validator, clients, _ := setupMultiSuperNodeTest(t, 3)
+		validator, clients, _ := setupMultiSuperRootTest(t, 3)
 		clients[0].outputErr = errors.New("error1")
 		clients[1].outputErr = errors.New("error2")
 		clients[2].superRoot = mockRootClaim
@@ -501,7 +501,7 @@ func TestSuperNodeEndpointTracking(t *testing.T) {
 	})
 
 	t.Run("TrackNotFoundCount", func(t *testing.T) {
-		validator, clients, _ := setupMultiSuperNodeTest(t, 3)
+		validator, clients, _ := setupMultiSuperRootTest(t, 3)
 		clients[0].notFound = true
 		clients[1].notFound = true
 		clients[2].superRoot = mockRootClaim
@@ -526,7 +526,7 @@ func TestSuperNodeEndpointTracking(t *testing.T) {
 	})
 
 	t.Run("TrackSafeUnsafeCounts", func(t *testing.T) {
-		validator, clients, _ := setupMultiSuperNodeTest(t, 4)
+		validator, clients, _ := setupMultiSuperRootTest(t, 4)
 		// Two clients report safe (derivedFromL1BlockNum <= game.L1HeadNum)
 		clients[0].superRoot = mockRootClaim
 		clients[0].derivedFromL1BlockNum = 100 // Safe
@@ -559,7 +559,7 @@ func TestSuperNodeEndpointTracking(t *testing.T) {
 	})
 
 	t.Run("TrackDivergentSuperRoots", func(t *testing.T) {
-		validator, clients, _ := setupMultiSuperNodeTest(t, 3)
+		validator, clients, _ := setupMultiSuperRootTest(t, 3)
 		divergedRoot := common.HexToHash("0xdivergent")
 		clients[0].superRoot = mockRootClaim
 		clients[0].derivedFromL1BlockNum = 100
@@ -586,7 +586,7 @@ func TestSuperNodeEndpointTracking(t *testing.T) {
 	})
 
 	t.Run("TrackMixedAvailability", func(t *testing.T) {
-		validator, clients, _ := setupMultiSuperNodeTest(t, 3)
+		validator, clients, _ := setupMultiSuperRootTest(t, 3)
 		clients[0].notFound = true
 		clients[1].superRoot = mockRootClaim
 		clients[1].derivedFromL1BlockNum = 100

--- a/op-dispute-mon/mon/extract/super_permissioned_integration_test.go
+++ b/op-dispute-mon/mon/extract/super_permissioned_integration_test.go
@@ -42,7 +42,7 @@ func TestExtractorChecksSuperPermissionedGame(t *testing.T) {
 			},
 		}, nil
 	}
-	superNode := &stubSuperNodeClient{
+	provider := &stubSuperRootProvider{
 		derivedFromL1BlockNum: l1HeadNum,
 		superRoot:             mockRootClaim,
 	}
@@ -62,7 +62,7 @@ func TestExtractorChecksSuperPermissionedGame(t *testing.T) {
 		NewBondEnricher(),
 		NewBalanceEnricher(),
 		NewL1HeadBlockNumEnricher(&stubBlockFetcher{num: l1HeadNum}),
-		NewSuperAgreementEnricher(logger, metrics, []SuperRootProvider{superNode}, clock.NewDeterministicClock(time.Unix(9824924, 499))),
+		NewSuperAgreementEnricher(logger, metrics, []SuperRootProvider{provider}, clock.NewDeterministicClock(time.Unix(9824924, 499))),
 	)
 
 	games, ignored, failed, err := extractor.Extract(context.Background(), blockHash, 0)
@@ -80,7 +80,7 @@ func TestExtractorChecksSuperPermissionedGame(t *testing.T) {
 	require.Empty(t, game.Claims)
 	require.True(t, game.AgreeWithClaim)
 	require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-	require.Equal(t, l2SequenceNumber, superNode.requestedTimestamp)
+	require.Equal(t, l2SequenceNumber, provider.requestedTimestamp)
 	require.NotZero(t, metrics.fetchTime)
 	require.Nil(t, game.ETHCollateral)
 	require.Equal(t, common.Address{}, game.WETHContract)

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -41,7 +41,7 @@ type Service struct {
 
 	game             *extract.GameCallerCreator
 	rollupClients    []*sources.RollupClient
-	superNodeClients []*sources.SuperNodeClient
+	superRootClients []*sources.SuperNodeClient
 
 	l1RPC    rpcclient.RPC
 	l1Client *sources.L1Client
@@ -85,8 +85,8 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	if err := s.initOutputRollupClient(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to init rollup client: %w", err)
 	}
-	if err := s.initSuperNodeClients(ctx, cfg); err != nil {
-		return fmt.Errorf("failed to init super node clients: %w", err)
+	if err := s.initSuperRootClients(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to init super root clients: %w", err)
 	}
 
 	s.initGameCallerCreator() // Must be called before initForecast
@@ -112,8 +112,8 @@ func (s *Service) outputRollupClients() []extract.OutputRollupClient {
 }
 
 func (s *Service) asSuperRootProviders() []extract.SuperRootProvider {
-	clients := make([]extract.SuperRootProvider, len(s.superNodeClients))
-	for i, client := range s.superNodeClients {
+	clients := make([]extract.SuperRootProvider, len(s.superRootClients))
+	for i, client := range s.superRootClients {
 		clients[i] = client
 	}
 	return clients
@@ -133,16 +133,16 @@ func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config
 	return nil
 }
 
-func (s *Service) initSuperNodeClients(ctx context.Context, cfg *config.Config) error {
-	if len(cfg.SuperNodeRpcs) == 0 {
+func (s *Service) initSuperRootClients(ctx context.Context, cfg *config.Config) error {
+	if len(cfg.SuperRootRpcs) == 0 {
 		return nil
 	}
-	for _, rpc := range cfg.SuperNodeRpcs {
+	for _, rpc := range cfg.SuperRootRpcs {
 		client, err := dial.DialSuperNodeClientWithTimeout(ctx, s.logger, rpc, rpcclient.WithLazyDial())
 		if err != nil {
-			return fmt.Errorf("failed to dial super node client %s: %w", rpc, err)
+			return fmt.Errorf("failed to dial super root client %s: %w", rpc, err)
 		}
-		s.superNodeClients = append(s.superNodeClients, client)
+		s.superRootClients = append(s.superRootClients, client)
 	}
 	return nil
 }


### PR DESCRIPTION
Renames the canonical `--supernode-rpc` option to `--superroot-rpc` in op-challenger and op-dispute-mon, and replaces their `SUPERNODE_RPC` environment variables with `SUPERROOT_RPC`, preserving every legacy name as an alias. Carries the super root terminology through config, startup logging, error messages, op-devstack wiring, and the op-dispute-mon README.

Tested with:
- `mise exec -- go test ./op-dispute-mon/... -count=1`
- `mise exec -- go test ./op-challenger/... -count=1`
- `mise exec -- go test ./op-devstack/shared/challenger ./op-devstack/sysgo -run '^$' -count=1`
- `mise exec -- just ./op-dispute-mon/op-dispute-mon`
- `mise exec -- just ./op-challenger/op-challenger`
- `mise exec -- just lint-go`
- `op-dispute-mon/bin/op-dispute-mon --help`
- `op-challenger/bin/op-challenger --help`