### PR TITLE
op-devstack: add external L2 CL factory

### DIFF
--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -161,6 +161,14 @@ func (el *L2ELNode) BlockRefByNumber(num uint64) eth.L2BlockRef {
 	return block
 }
 
+// VerifyNotReorged asserts that the block at ref's height still has ref's
+// hash. An unchanged block transitively pins all of its ancestors.
+func (el *L2ELNode) VerifyNotReorged(ref eth.L2BlockRef) {
+	el.log.Info("Verifying block not reorged", "name", el.inner.Name(), "block", ref)
+	got := el.BlockRefByNumber(ref.Number)
+	el.require.Equalf(ref.Hash, got.Hash, "block %d was reorged: expected hash %s, now %s", ref.Number, ref.Hash, got.Hash)
+}
+
 // GasLimitAtBlock returns the gas limit of the block at the given number.
 func (el *L2ELNode) GasLimitAtBlock(num uint64) uint64 {
 	return uint64(el.PayloadByNumber(num).ExecutionPayload.GasLimit)

--- a/op-devstack/presets/minimal_from_runtime.go
+++ b/op-devstack/presets/minimal_from_runtime.go
@@ -74,3 +74,11 @@ func minimalFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *Minimal
 	out.FunderL2 = dsl.NewFunder(out.Wallet, out.FaucetL2, out.L2EL)
 	return out
 }
+
+// MinimalFromRuntime projects a composable sysgo runtime into the standard
+// single-chain DSL before any optional follower nodes are attached. It is
+// useful for delayed-join scenarios that need to interact with the primary
+// node or batcher first.
+func MinimalFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *Minimal {
+	return minimalFromRuntime(t, runtime)
+}

--- a/op-devstack/presets/minimal_from_runtime.go
+++ b/op-devstack/presets/minimal_from_runtime.go
@@ -29,10 +29,14 @@ func minimalFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *Minimal
 	l2EL := newL2ELFrontend(t, "sequencer", l2ChainID, runtime.L2EL.UserRPC(), runtime.L2EL.EngineRPC(), runtime.L2EL.JWTPath(), runtime.L2Network.RollupConfig(), runtime.L2EL)
 	l2CL := newL2CLFrontend(t, "sequencer", l2ChainID, runtime.L2CL.UserRPC(), runtime.L2CL)
 	l2CL.attachEL(l2EL)
-	l2Batcher := newL2BatcherFrontend(t, "main", l2ChainID, runtime.L2Batcher.UserRPC())
 	l2Chain.AddL2ELNode(l2EL)
 	l2Chain.AddL2CLNode(l2CL)
-	l2Chain.AddL2Batcher(l2Batcher)
+	var l2BatcherDSL *dsl.L2Batcher
+	if runtime.L2Batcher != nil {
+		l2Batcher := newL2BatcherFrontend(t, "main", l2ChainID, runtime.L2Batcher.UserRPC())
+		l2Chain.AddL2Batcher(l2Batcher)
+		l2BatcherDSL = dsl.NewL2Batcher(l2Batcher)
+	}
 
 	var challengerCfg *challengerConfig.Config
 	if runtime.L2Challenger != nil {
@@ -62,7 +66,7 @@ func minimalFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *Minimal
 		L1EL:             l1ELDSL,
 		L1CL:             l1CLDSL,
 		L2Chain:          dsl.NewL2Network(l2Chain, l2ELDSL, l2CLDSL, l1ELDSL, nil, nil),
-		L2Batcher:        dsl.NewL2Batcher(l2Batcher),
+		L2Batcher:        l2BatcherDSL,
 		L2EL:             l2ELDSL,
 		L2CL:             l2CLDSL,
 		Wallet:           dsl.NewRandomHDWallet(t, 30), // Random for test isolation

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -17,6 +17,7 @@ const (
 	optionKindOPRBuilder
 	optionKindOpReth
 	optionKindGlobalL2CL
+	optionKindL2CLFactory
 	optionKindGlobalSyncTesterEL
 	optionKindL1EL
 	optionKindAddedGameType
@@ -43,6 +44,7 @@ const allOptionKinds = optionKindDeployer |
 	optionKindOPRBuilder |
 	optionKindOpReth |
 	optionKindGlobalL2CL |
+	optionKindL2CLFactory |
 	optionKindGlobalSyncTesterEL |
 	optionKindL1EL |
 	optionKindAddedGameType |
@@ -72,6 +74,7 @@ var optionKindLabels = []struct {
 	{kind: optionKindOPRBuilder, label: "builder options"},
 	{kind: optionKindOpReth, label: "op-reth options"},
 	{kind: optionKindGlobalL2CL, label: "L2 CL options"},
+	{kind: optionKindL2CLFactory, label: "L2 CL factory"},
 	{kind: optionKindGlobalSyncTesterEL, label: "sync tester EL options"},
 	{kind: optionKindL1EL, label: "L1 EL options"},
 	{kind: optionKindAddedGameType, label: "added game types"},
@@ -129,6 +132,7 @@ const minimalPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindBatcher |
 	optionKindProposer |
 	optionKindGlobalL2CL |
+	optionKindL2CLFactory |
 	optionKindL1EL |
 	optionKindAddedGameType |
 	optionKindRespectedGameType |

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -140,9 +140,15 @@ const minimalPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindAfterBuild |
 	optionKindProofValidation
 
-const minimalWithConductorsPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds
+// The conductors runtime type-asserts every CL to *OpNode for conductor
+// wiring, so an L2 CL factory handling any slot would panic. No factory
+// support until that runtime is factory-aware.
+const minimalWithConductorsPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds &^ optionKindL2CLFactory
 
-const simpleWithSyncTesterPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds |
+// The sync-tester runtime starts its verifier through startL2CLNode directly,
+// so a factory would silently be skipped for that slot. No factory support
+// until every slot consults the factory.
+const simpleWithSyncTesterPresetSupportedOptionKinds = (minimalPresetSupportedOptionKinds &^ optionKindL2CLFactory) |
 	optionKindGlobalSyncTesterEL
 
 // singleSupernodeWithSyncTesterPresetSupportedOptionKinds covers exactly what

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -155,6 +155,22 @@ func WithGlobalL2CLOption(opt sysgo.L2CLOption) Option {
 	}
 }
 
+// WithL2CLFactory injects an external, product-neutral L2 consensus-client
+// factory. The factory is consulted independently for every node slot and may
+// decline individual slots to retain the preset's normal client selection.
+func WithL2CLFactory(factory sysgo.L2CLFactory) Option {
+	var kinds optionKinds
+	if factory != nil {
+		kinds = optionKindL2CLFactory
+	}
+	return option{
+		kinds: kinds,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			cfg.L2CLFactory = factory
+		},
+	}
+}
+
 // WithSupernodeVerifierSyncMode overrides the supernode VN's sync mode.
 func WithSupernodeVerifierSyncMode(mode nodeSync.Mode) Option {
 	return option{

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -88,6 +88,14 @@ func collectPresetConfig(opts []Option) (sysgo.PresetConfig, CombinedOption) {
 	return cfg, combined
 }
 
+// PresetConfigFromOptions applies ordinary preset options for callers using
+// the lower-level sysgo composition APIs. Frontend-only AfterBuild hooks are
+// intentionally not run; callers may apply those after projecting a runtime.
+func PresetConfigFromOptions(opts ...Option) sysgo.PresetConfig {
+	cfg, _ := collectPresetConfig(opts)
+	return cfg
+}
+
 func WithDeployerOptions(opts ...sysgo.DeployerOption) Option {
 	var kinds optionKinds
 	for _, opt := range opts {

--- a/op-devstack/presets/options_test.go
+++ b/op-devstack/presets/options_test.go
@@ -37,12 +37,22 @@ func TestOptionKindsFromCompositeOptions(t *testing.T) {
 		require.Zero(t, WithLocalContractSourcesAt("").optionKinds())
 		require.Zero(t, WithBatcherOption(nil).optionKinds())
 		require.Zero(t, WithGlobalL2CLOption(nil).optionKinds())
+		require.Zero(t, WithL2CLFactory(nil).optionKinds())
 		require.Zero(t, WithGlobalSyncTesterELOption(nil).optionKinds())
 		require.Zero(t, WithProposerOption(nil).optionKinds())
 		require.Zero(t, WithOPRBuilderOption(nil).optionKinds())
 		require.Zero(t, WithPreGenesisSuperGame().optionKinds())
 		require.Zero(t, AfterBuild(nil).optionKinds())
 	})
+}
+
+func TestWithL2CLFactory(t *testing.T) {
+	factory := sysgo.L2CLFactoryFn(func(devtest.T, sysgo.L2CLLaunchContext) (sysgo.L2CLNode, bool) {
+		return nil, false
+	})
+	cfg, _ := collectPresetConfig([]Option{WithL2CLFactory(factory)})
+	require.NotNil(t, cfg.L2CLFactory)
+	require.Equal(t, optionKindL2CLFactory, WithL2CLFactory(factory).optionKinds())
 }
 
 func TestWithLocalContractSourcesAt(t *testing.T) {

--- a/op-devstack/presets/options_test.go
+++ b/op-devstack/presets/options_test.go
@@ -46,10 +46,14 @@ func TestOptionKindsFromCompositeOptions(t *testing.T) {
 	})
 }
 
-func TestWithL2CLFactory(t *testing.T) {
-	factory := sysgo.L2CLFactoryFn(func(devtest.T, sysgo.L2CLLaunchContext) (sysgo.L2CLNode, bool) {
+func declineAllL2CLFactory() sysgo.L2CLFactory {
+	return sysgo.L2CLFactoryFn(func(devtest.T, sysgo.L2CLLaunchContext) (sysgo.L2CLNode, bool) {
 		return nil, false
 	})
+}
+
+func TestWithL2CLFactory(t *testing.T) {
+	factory := declineAllL2CLFactory()
 	cfg, _ := collectPresetConfig([]Option{WithL2CLFactory(factory)})
 	require.NotNil(t, cfg.L2CLFactory)
 	require.Equal(t, optionKindL2CLFactory, WithL2CLFactory(factory).optionKinds())
@@ -83,6 +87,24 @@ func TestUnsupportedPresetOptionKinds(t *testing.T) {
 			supported: minimalPresetSupportedOptionKinds,
 			opts:      WithL1Geth("/tmp/geth"),
 			want:      0,
+		},
+		{
+			name:      "minimal allows L2 CL factory",
+			supported: minimalPresetSupportedOptionKinds,
+			opts:      WithL2CLFactory(declineAllL2CLFactory()),
+			want:      0,
+		},
+		{
+			name:      "minimal with conductors rejects L2 CL factory",
+			supported: minimalWithConductorsPresetSupportedOptionKinds,
+			opts:      WithL2CLFactory(declineAllL2CLFactory()),
+			want:      optionKindL2CLFactory,
+		},
+		{
+			name:      "simple with sync tester rejects L2 CL factory",
+			supported: simpleWithSyncTesterPresetSupportedOptionKinds,
+			opts:      WithL2CLFactory(declineAllL2CLFactory()),
+			want:      optionKindL2CLFactory,
 		},
 		{
 			name:      "flashblocks allows builder and deployer adapters",

--- a/op-devstack/presets/singlechain_from_runtime.go
+++ b/op-devstack/presets/singlechain_from_runtime.go
@@ -162,6 +162,14 @@ func SingleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRunt
 	return singleChainMultiNodeFromRuntime(t, runtime, runSyncChecks)
 }
 
+// SingleChainMultiNodeWithTestSeqFromRuntime projects a composed sysgo runtime
+// into the standard multi-node DSL surface with its test sequencer attached.
+// Callers can use this with NewSingleChainRuntime to select exactly the
+// services needed by deterministic sequencing tests.
+func SingleChainMultiNodeWithTestSeqFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *SingleChainMultiNodeWithTestSeq {
+	return singleChainMultiNodeWithTestSeqFromRuntime(t, runtime)
+}
+
 func singleChainMultiNodeWithTestSeqFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *SingleChainMultiNodeWithTestSeq {
 	preset := singleChainMultiNodeFromRuntime(t, runtime, false)
 	testSequencer := newTestSequencerFrontend(

--- a/op-devstack/presets/singlechain_from_runtime.go
+++ b/op-devstack/presets/singlechain_from_runtime.go
@@ -155,6 +155,13 @@ func dumpVerifierELSyncing(t devtest.T, verifierEL *dsl.L2ELNode) {
 	t.Logger().Warn("Verifier EL eth_syncing snapshot at sync-check failure", "eth_syncing", string(raw))
 }
 
+// SingleChainMultiNodeFromRuntime projects a composed sysgo runtime into the
+// standard DSL surface. Callers can compose mixed, delayed-join, or fan-out
+// layouts through product-neutral sysgo APIs before creating the frontend.
+func SingleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime, runSyncChecks bool) *SingleChainMultiNode {
+	return singleChainMultiNodeFromRuntime(t, runtime, runSyncChecks)
+}
+
 func singleChainMultiNodeWithTestSeqFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *SingleChainMultiNodeWithTestSeq {
 	preset := singleChainMultiNodeFromRuntime(t, runtime, false)
 	testSequencer := newTestSequencerFrontend(

--- a/op-devstack/presets/singlechain_multinode.go
+++ b/op-devstack/presets/singlechain_multinode.go
@@ -47,10 +47,49 @@ func NewSingleChainMultiNodeWithoutP2PWithoutCheck(t devtest.T, opts ...Option) 
 	return out
 }
 
+// NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck creates a
+// sequencer, batcher, and verifier without proposer/challenger services,
+// preconfigured CL P2P, or initial sync checks.
+func NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck(t devtest.T, opts ...Option) *SingleChainMultiNode {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewSingleChainMultiNodeNoFaultProofsWithoutP2PWithoutCheck", opts, minimalPresetSupportedOptionKinds)
+	out := singleChainMultiNodeFromRuntime(t, sysgo.NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig(t, false, presetCfg), false)
+	presetOpts.applyPreset(out)
+	return out
+}
+
+// NewSingleChainMultiNodeNoFaultProofsBareVerifierWithoutCheck creates a
+// verifier with no follow source, CL P2P, proposer, challenger, or initial sync
+// checks.
+func NewSingleChainMultiNodeNoFaultProofsBareVerifierWithoutCheck(t devtest.T, opts ...Option) *SingleChainMultiNode {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewSingleChainMultiNodeNoFaultProofsBareVerifierWithoutCheck", opts, minimalPresetSupportedOptionKinds)
+	out := singleChainMultiNodeFromRuntime(t, sysgo.NewSingleChainMultiNodeNoFaultProofsBareVerifierRuntime(t, presetCfg), false)
+	presetOpts.applyPreset(out)
+	return out
+}
+
 type SingleChainMultiNodeWithTestSeq struct {
 	SingleChainMultiNode
 
 	TestSequencer *dsl.TestSequencer
+}
+
+// NewSingleChainMultiNodeNoFaultProofsBareVerifierWithTestSeqWithoutCheck adds
+// the test sequencer to the bare-verifier topology.
+func NewSingleChainMultiNodeNoFaultProofsBareVerifierWithTestSeqWithoutCheck(t devtest.T, opts ...Option) *SingleChainMultiNodeWithTestSeq {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewSingleChainMultiNodeNoFaultProofsBareVerifierWithTestSeqWithoutCheck", opts, minimalPresetSupportedOptionKinds)
+	out := singleChainMultiNodeWithTestSeqFromRuntime(t, sysgo.NewSingleChainMultiNodeNoFaultProofsBareVerifierRuntime(t, presetCfg))
+	presetOpts.applyPreset(out)
+	return out
+}
+
+// NewSingleChainMultiNodeNoFaultProofsFollowVerifierWithTestSeqWithoutCheck
+// adds the test sequencer to a verifier that follows the primary execution
+// endpoint while deriving from L1.
+func NewSingleChainMultiNodeNoFaultProofsFollowVerifierWithTestSeqWithoutCheck(t devtest.T, opts ...Option) *SingleChainMultiNodeWithTestSeq {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewSingleChainMultiNodeNoFaultProofsFollowVerifierWithTestSeqWithoutCheck", opts, minimalPresetSupportedOptionKinds)
+	out := singleChainMultiNodeWithTestSeqFromRuntime(t, sysgo.NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig(t, false, presetCfg))
+	presetOpts.applyPreset(out)
+	return out
 }
 
 // NewSingleChainMultiNodeWithTestSeq creates a fresh

--- a/op-devstack/presets/sysgo_runtime.go
+++ b/op-devstack/presets/sysgo_runtime.go
@@ -3,6 +3,7 @@ package presets
 import (
 	"os"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	gn "github.com/ethereum/go-ethereum/node"
@@ -149,6 +150,10 @@ func newConductorFrontend(t devtest.T, name string, chainID eth.ChainID, rpcEndp
 func newTestSequencerFrontend(t devtest.T, name string, adminRPC string, controlRPCs map[eth.ChainID]string, jwtSecret [32]byte) *testSequencerFrontend {
 	opts := []client.RPCOption{
 		client.WithLazyDial(),
+		// Test-sequencer control calls may synchronously drive an external CL and
+		// EL through a full block transition. Hosted devstack machines can exceed
+		// the generic RPC client's 10-second default while doing that work.
+		client.WithCallTimeout(time.Minute),
 		client.WithGethRPCOptions(rpc.WithHTTPAuth(gn.NewJWTAuth(jwtSecret))),
 	}
 

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -5,12 +5,62 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum/go-ethereum/core"
 )
 
 type L2CLNode interface {
 	stack.Lifecycle
 	UserRPC() string
+}
+
+// L2CLRole describes the responsibility of a consensus-layer node slot.
+type L2CLRole string
+
+const (
+	L2CLRoleSequencer L2CLRole = "sequencer"
+	L2CLRoleVerifier  L2CLRole = "verifier"
+)
+
+// L2CLLaunchContext is the product-neutral input required to launch an
+// externally implemented L2 consensus client. It exposes endpoints and
+// immutable network configuration instead of concrete sysgo backends.
+type L2CLLaunchContext struct {
+	Target ComponentTarget
+	Role   L2CLRole
+
+	L1UserRPC   string
+	L1BeaconRPC string
+	L2UserRPC   string
+	L2EngineRPC string
+	L2JWTPath   string
+
+	L1Genesis    *core.Genesis
+	L2Genesis    *core.Genesis
+	RollupConfig *rollup.Config
+	FollowSource string
+	Config       L2CLConfig
+
+	// RegisterMetrics may be nil when the preset does not collect component
+	// metrics. External clients may call it with ordinary Prometheus targets.
+	RegisterMetrics func(serviceName string, endpoints ...PrometheusMetricsTarget)
+}
+
+// L2CLFactory may provide an external implementation for an individual L2 CL
+// slot. Returning handled=false preserves the preset's ordinary op-node/Kona
+// selection for that slot, enabling mixed-client topologies without a global
+// registry or process environment selector.
+type L2CLFactory interface {
+	CreateL2CL(t devtest.T, ctx L2CLLaunchContext) (node L2CLNode, handled bool)
+}
+
+type L2CLFactoryFn func(t devtest.T, ctx L2CLLaunchContext) (node L2CLNode, handled bool)
+
+var _ L2CLFactory = L2CLFactoryFn(nil)
+
+func (fn L2CLFactoryFn) CreateL2CL(t devtest.T, ctx L2CLLaunchContext) (L2CLNode, bool) {
+	return fn(t, ctx)
 }
 
 type L2CLConfig struct {

--- a/op-devstack/sysgo/l2_cl_factory_test.go
+++ b/op-devstack/sysgo/l2_cl_factory_test.go
@@ -1,0 +1,67 @@
+package sysgo
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeExternalL2CL struct {
+	starts int
+	stops  int
+}
+
+func (n *fakeExternalL2CL) Start() { n.starts++ }
+func (n *fakeExternalL2CL) Stop()  { n.stops++ }
+func (n *fakeExternalL2CL) UserRPC() string {
+	return "http://127.0.0.1:9545"
+}
+func (n *fakeExternalL2CL) InteropRPC() (string, eth.Bytes32) { return "", eth.Bytes32{} }
+
+func TestL2CLFactorySupportsPerSlotSelectionAndRestart(t *testing.T) {
+	dt := devtest.SerialT(t)
+	var seen []L2CLLaunchContext
+	nodes := make(map[string]*fakeExternalL2CL)
+	factory := L2CLFactoryFn(func(_ devtest.T, ctx L2CLLaunchContext) (L2CLNode, bool) {
+		seen = append(seen, ctx)
+		if ctx.Target.Name == "stock" {
+			return nil, false
+		}
+		node := &fakeExternalL2CL{}
+		nodes[ctx.Target.Name] = node
+		return node, true
+	})
+
+	sequencer, handled := factory.CreateL2CL(dt, L2CLLaunchContext{
+		Target: NewComponentTarget("sequencer", eth.ChainIDFromUInt64(901)),
+		Role:   L2CLRoleSequencer,
+	})
+	require.True(t, handled)
+	sequencer.Start()
+	sequencer.Stop()
+	sequencer.Start()
+
+	verifier, handled := factory.CreateL2CL(dt, L2CLLaunchContext{
+		Target: NewComponentTarget("late-verifier", eth.ChainIDFromUInt64(901)),
+		Role:   L2CLRoleVerifier,
+	})
+	require.True(t, handled)
+	verifier.Start()
+
+	_, handled = factory.CreateL2CL(dt, L2CLLaunchContext{
+		Target: NewComponentTarget("stock", eth.ChainIDFromUInt64(901)),
+		Role:   L2CLRoleVerifier,
+	})
+	require.False(t, handled)
+
+	require.Equal(t, []string{"sequencer", "late-verifier", "stock"}, []string{
+		seen[0].Target.Name,
+		seen[1].Target.Name,
+		seen[2].Target.Name,
+	})
+	require.Equal(t, 2, nodes["sequencer"].starts)
+	require.Equal(t, 1, nodes["sequencer"].stops)
+	require.Equal(t, 1, nodes["late-verifier"].starts)
+}

--- a/op-devstack/sysgo/l2_cl_p2p_util.go
+++ b/op-devstack/sysgo/l2_cl_p2p_util.go
@@ -42,6 +42,24 @@ func GetPeerInfo(ctx context.Context, p2pClient *sources.P2PClient) (*apis.PeerI
 	return peerInfo, nil
 }
 
+// L2CLGossipMultiaddr returns a dialable gossip address for any L2 consensus
+// client implementing the standard P2P RPC surface.
+func L2CLGossipMultiaddr(ctx context.Context, logger log.Logger, node L2CLNode) (string, error) {
+	client, err := GetP2PClient(ctx, logger, node)
+	if err != nil {
+		return "", err
+	}
+	self, err := GetPeerInfo(ctx, client)
+	if err != nil {
+		return "", err
+	}
+	addr := self.Addresses[0]
+	if !strings.Contains(addr, "/p2p/") {
+		addr = fmt.Sprintf("%s/p2p/%s", addr, self.PeerID.String())
+	}
+	return addr, nil
+}
+
 func GetPeers(ctx context.Context, p2pClient *sources.P2PClient) (*apis.PeerDump, error) {
 	peerDump, err := retry.Do(ctx, 3, retry.Exponential(), func() (*apis.PeerDump, error) {
 		return p2pClient.Peers(ctx, true)

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -22,6 +22,7 @@ type PresetConfig struct {
 	OPRBuilderOptions          []OPRBuilderNodeOption
 	OpRethOptions              []OpRethOption
 	GlobalL2CLOptions          []L2CLOption
+	L2CLFactory                L2CLFactory
 	GlobalSyncTesterELOptions  []SyncTesterELOption
 	L1ELKind                   string
 	L1GethExecPath             string

--- a/op-devstack/sysgo/runtime_state.go
+++ b/op-devstack/sysgo/runtime_state.go
@@ -72,6 +72,9 @@ type SingleChainInteropSupport struct {
 
 type SingleChainRuntime struct {
 	Keys devkeys.Keys
+	// L2CLFactory is retained so delayed and additional node slots use the
+	// same explicit client selection as the primary.
+	L2CLFactory L2CLFactory
 
 	L1Network *L1Network
 	L2Network *L2Network

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -185,15 +185,16 @@ func startL2CLForKey(
 	l2CLOpts []L2CLOption,
 	factory L2CLFactory,
 ) L2CLNode {
-	target := NewComponentTarget(clKey, l2Net.ChainID())
-	resolvedCfg := DefaultL2CLConfig()
-	resolvedCfg.IsSequencer = isSequencer
-	resolvedCfg.FollowSource = followSource
-	for _, opt := range l2CLOpts {
-		if opt != nil {
-			opt.Apply(t, target, resolvedCfg)
-		}
+	startCfg := l2CLNodeStartConfig{
+		Key:            clKey,
+		IsSequencer:    isSequencer,
+		NoDiscovery:    true,
+		EnableReqResp:  true,
+		L2FollowSource: followSource,
+		L2CLOptions:    l2CLOpts,
 	}
+	target := NewComponentTarget(clKey, l2Net.ChainID())
+	resolvedCfg := resolveL2CLNodeConfig(t, target, startCfg)
 	if factory != nil {
 		role := L2CLRoleVerifier
 		if isSequencer {
@@ -210,7 +211,7 @@ func startL2CLForKey(
 			L1Genesis:    l1Net.Genesis(),
 			L2Genesis:    l2Net.genesis,
 			RollupConfig: l2Net.RollupConfig(),
-			FollowSource: followSource,
+			FollowSource: resolvedCfg.FollowSource,
 			Config:       *resolvedCfg,
 		})
 		if handled {
@@ -222,14 +223,8 @@ func startL2CLForKey(
 	case MixedL2CLKona:
 		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, nil, nil)
 	default: // op-node
-		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
-			Key:            clKey,
-			IsSequencer:    isSequencer,
-			NoDiscovery:    true,
-			EnableReqResp:  true,
-			L2FollowSource: followSource,
-			L2CLOptions:    l2CLOpts,
-		})
+		startCfg.ResolvedConfig = resolvedCfg
+		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, startCfg)
 	}
 }
 
@@ -325,11 +320,34 @@ type l2CLNodeStartConfig struct {
 	L2FollowSource string
 	DependencySet  depset.DependencySet
 	L2CLOptions    []L2CLOption
+	// ResolvedConfig, when set, is used as the effective config instead of
+	// resolving defaults + L2CLOptions again. startL2CLForKey sets it so
+	// options with side effects (e.g. proxy registration) apply exactly once
+	// across the factory context and the op-node fallback.
+	ResolvedConfig *L2CLConfig
 	// SyncMode overrides the sequencer and verifier sync modes; defaults to CLSync if unset.
 	SyncMode nodeSync.Mode
 	// SequencerStopped starts the sequencer in the stopped state (it must be
 	// activated later via the StartSequencer RPC). Only meaningful when IsSequencer.
 	SequencerStopped bool
+}
+
+// resolveL2CLNodeConfig produces the effective L2CLConfig for a node slot:
+// start-config fields first, then L2CLOptions on top. Options may carry side
+// effects (e.g. registering follow-source proxies), so a slot's config must be
+// resolved at most once.
+func resolveL2CLNodeConfig(t devtest.T, target ComponentTarget, startCfg l2CLNodeStartConfig) *L2CLConfig {
+	cfg := DefaultL2CLConfig()
+	cfg.IsSequencer = startCfg.IsSequencer
+	cfg.NoDiscovery = startCfg.NoDiscovery
+	cfg.EnableReqRespSync = startCfg.EnableReqResp
+	cfg.FollowSource = startCfg.L2FollowSource
+	for _, opt := range startCfg.L2CLOptions {
+		if opt != nil {
+			opt.Apply(t, target, cfg)
+		}
+	}
+	return cfg
 }
 
 func startL2CLNode(
@@ -344,19 +362,9 @@ func startL2CLNode(
 	startCfg l2CLNodeStartConfig,
 ) *OpNode {
 	require := t.Require()
-	cfg := DefaultL2CLConfig()
-	cfg.IsSequencer = startCfg.IsSequencer
-	cfg.NoDiscovery = startCfg.NoDiscovery
-	cfg.EnableReqRespSync = startCfg.EnableReqResp
-	cfg.FollowSource = startCfg.L2FollowSource
-	if len(startCfg.L2CLOptions) > 0 {
-		l2CLTarget := NewComponentTarget(startCfg.Key, l2Net.ChainID())
-		for _, opt := range startCfg.L2CLOptions {
-			if opt == nil {
-				continue
-			}
-			opt.Apply(t, l2CLTarget, cfg)
-		}
+	cfg := startCfg.ResolvedConfig
+	if cfg == nil {
+		cfg = resolveL2CLNodeConfig(t, NewComponentTarget(startCfg.Key, l2Net.ChainID()), startCfg)
 	}
 
 	if startCfg.SyncMode != 0 {

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -497,6 +497,8 @@ func startL2CLNode(
 	return l2CL
 }
 
+// startTestSequencer only needs the CL's user RPC, so any L2CLNode — op-node,
+// Kona, or factory-provided — that serves the standard rollup RPC surface works.
 func startTestSequencer(
 	t devtest.T,
 	keys devkeys.Keys,
@@ -507,7 +509,7 @@ func startTestSequencer(
 	l1CL *L1CLNode,
 	l2EL L2ELNode,
 	l2Net *L2Network,
-	l2CL *OpNode,
+	l2CL L2CLNode,
 ) *testSequencer {
 	require := t.Require()
 	logger := t.Logger().New("component", "test-sequencer")

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -183,7 +183,41 @@ func startL2CLForKey(
 	isSequencer bool,
 	followSource string,
 	l2CLOpts []L2CLOption,
+	factory L2CLFactory,
 ) L2CLNode {
+	target := NewComponentTarget(clKey, l2Net.ChainID())
+	resolvedCfg := DefaultL2CLConfig()
+	resolvedCfg.IsSequencer = isSequencer
+	resolvedCfg.FollowSource = followSource
+	for _, opt := range l2CLOpts {
+		if opt != nil {
+			opt.Apply(t, target, resolvedCfg)
+		}
+	}
+	if factory != nil {
+		role := L2CLRoleVerifier
+		if isSequencer {
+			role = L2CLRoleSequencer
+		}
+		node, handled := factory.CreateL2CL(t, L2CLLaunchContext{
+			Target:       target,
+			Role:         role,
+			L1UserRPC:    l1EL.UserRPC(),
+			L1BeaconRPC:  l1CL.BeaconHTTPAddr(),
+			L2UserRPC:    l2EL.UserRPC(),
+			L2EngineRPC:  l2EL.EngineRPC(),
+			L2JWTPath:    l2EL.JWTPath(),
+			L1Genesis:    l1Net.Genesis(),
+			L2Genesis:    l2Net.genesis,
+			RollupConfig: l2Net.RollupConfig(),
+			FollowSource: followSource,
+			Config:       *resolvedCfg,
+		})
+		if handled {
+			t.Require().NotNil(node, "L2 CL factory handled %s but returned a nil node", target)
+			return node
+		}
+	}
 	switch devstackL2CLKind() {
 	case MixedL2CLKona:
 		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, nil, nil)
@@ -278,8 +312,9 @@ func startSequencerCL(
 	l2EL L2ELNode,
 	jwtSecret [32]byte,
 	l2CLOpts []L2CLOption,
+	factory L2CLFactory,
 ) L2CLNode {
-	return startL2CLForKey(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, "sequencer", "sequencer", true, "", l2CLOpts)
+	return startL2CLForKey(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, "sequencer", "sequencer", true, "", l2CLOpts, factory)
 }
 
 type l2CLNodeStartConfig struct {

--- a/op-devstack/sysgo/singlechain_build_test.go
+++ b/op-devstack/sysgo/singlechain_build_test.go
@@ -1,0 +1,34 @@
+package sysgo
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveL2CLNodeConfig(t *testing.T) {
+	dt := devtest.SerialT(t)
+	applies := 0
+	opt := L2CLOptionFn(func(_ devtest.T, target ComponentTarget, cfg *L2CLConfig) {
+		applies++
+		// Start-config fields are set before options run, so options can
+		// observe and override them.
+		require.True(t, cfg.NoDiscovery)
+		require.Equal(t, "verifier", target.Name)
+		cfg.FollowSource = "http://proxy.invalid"
+	})
+	startCfg := l2CLNodeStartConfig{
+		Key:            "verifier",
+		NoDiscovery:    true,
+		EnableReqResp:  true,
+		L2FollowSource: "http://origin.invalid",
+		L2CLOptions:    []L2CLOption{nil, opt},
+	}
+	cfg := resolveL2CLNodeConfig(dt, NewComponentTarget("verifier", eth.ChainIDFromUInt64(901)), startCfg)
+	require.Equal(t, 1, applies, "options must be applied exactly once")
+	require.Equal(t, "http://proxy.invalid", cfg.FollowSource, "option rewrite of the follow source must win")
+	require.True(t, cfg.EnableReqRespSync)
+	require.False(t, cfg.IsSequencer)
+}

--- a/op-devstack/sysgo/singlechain_flashblocks.go
+++ b/op-devstack/sysgo/singlechain_flashblocks.go
@@ -44,7 +44,7 @@ func startFlashblocksSingleChainPrimary(
 			DependencySet: world.Interop.DependencySet,
 		})
 	} else {
-		l2CL = startSequencerCL(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, rollupBoost, jwtSecret, nil)
+		l2CL = startSequencerCL(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, rollupBoost, jwtSecret, nil, cfg.L2CLFactory)
 	}
 
 	return singleChainPrimaryRuntime{

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -53,6 +53,16 @@ type singleChainRuntimeSpec struct {
 	TestSequencer   string
 }
 
+// SingleChainRuntimeOptions controls which product-neutral services surround
+// the primary L2 node. Additional L2 nodes can be attached later with
+// AddSingleChainNode.
+type SingleChainRuntimeOptions struct {
+	StartBatcher    bool
+	StartProposer   bool
+	StartChallenger bool
+	TestSequencer   string
+}
+
 func newSingleChainNodeRuntime(name string, isSequencer bool, el L2ELNode, cl L2CLNode) *SingleChainNodeRuntime {
 	return &SingleChainNodeRuntime{
 		Name:        name,
@@ -111,7 +121,7 @@ func startDefaultSingleChainPrimary(
 		})
 		return singleChainPrimaryRuntime{EL: l2EL, CL: l2CL}
 	}
-	l2CL := startSequencerCL(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLOptions)
+	l2CL := startSequencerCL(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLOptions, cfg.L2CLFactory)
 	return singleChainPrimaryRuntime{
 		EL: l2EL,
 		CL: l2CL,
@@ -161,6 +171,7 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 
 	return &SingleChainRuntime{
 		Keys:          keys,
+		L2CLFactory:   cfg.L2CLFactory,
 		L1Network:     world.L1Network,
 		L2Network:     world.L2Network,
 		L1EL:          l1EL,
@@ -195,6 +206,20 @@ func NewMinimalRuntimeWithConfig(t devtest.T, cfg PresetConfig) *SingleChainRunt
 		StartBatcher:    true,
 		StartProposer:   true,
 		StartChallenger: true,
+	})
+}
+
+// NewSingleChainRuntime constructs a composable single-chain runtime using the
+// default world and primary-node builders. It is the low-level counterpart to
+// the opinionated presets and supports delayed-join and mixed-client layouts.
+func NewSingleChainRuntime(t devtest.T, cfg PresetConfig, opts SingleChainRuntimeOptions) *SingleChainRuntime {
+	return newSingleChainRuntimeWithConfig(t, cfg, singleChainRuntimeSpec{
+		BuildWorld:      newDefaultSingleChainWorld,
+		StartPrimary:    startDefaultSingleChainPrimary,
+		StartBatcher:    opts.StartBatcher,
+		StartProposer:   opts.StartProposer,
+		StartChallenger: opts.StartChallenger,
+		TestSequencer:   opts.TestSequencer,
 	})
 }
 

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -162,8 +162,6 @@ func connectSingleChainCLPeer(t devtest.T, sourceCL, targetCL L2CLNode) {
 }
 
 func replaceSingleChainTestSequencer(t devtest.T, runtime *SingleChainRuntime, name string, node *SingleChainNodeRuntime) {
-	l2CL, ok := node.CL.(*OpNode)
-	t.Require().True(ok, "single-chain test sequencer requires an op-node CL node")
 	testSequencer := startTestSequencer(
 		t,
 		runtime.Keys,
@@ -174,7 +172,7 @@ func replaceSingleChainTestSequencer(t devtest.T, runtime *SingleChainRuntime, n
 		runtime.L1CL,
 		node.EL,
 		runtime.L2Network,
-		l2CL,
+		node.CL,
 	)
 	runtime.TestSequencer = newTestSequencerRuntime(testSequencer, name)
 }

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -36,6 +36,28 @@ func NewSingleChainMultiNodeRuntimeWithConfig(t devtest.T, withP2P bool, cfg Pre
 	return runtime
 }
 
+// NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig creates a primary,
+// batcher, and verifier without starting proposer or challenger services.
+func NewSingleChainMultiNodeNoFaultProofsRuntimeWithConfig(t devtest.T, withP2P bool, cfg PresetConfig) *SingleChainRuntime {
+	runtime := NewMinimalNoFaultProofsRuntimeWithConfig(t, cfg)
+	nodeB := addSingleChainOpNode(t, runtime, "b", false, runtime.L2EL.UserRPC(), cfg.GlobalL2CLOptions...)
+	if withP2P {
+		connectSingleChainNodes(t, runtime.L2EL, runtime.L2CL, nodeB)
+	}
+	runtime.P2PEnabled = withP2P
+	return runtime
+}
+
+// NewSingleChainMultiNodeNoFaultProofsBareVerifierRuntime creates a verifier
+// without a follow source or preconfigured P2P link. Tests may supply unsafe
+// payloads explicitly while the verifier derives its safe chain from L1.
+func NewSingleChainMultiNodeNoFaultProofsBareVerifierRuntime(t devtest.T, cfg PresetConfig) *SingleChainRuntime {
+	runtime := NewMinimalNoFaultProofsRuntimeWithConfig(t, cfg)
+	addSingleChainOpNode(t, runtime, "b", false, "", cfg.GlobalL2CLOptions...)
+	runtime.P2PEnabled = false
+	return runtime
+}
+
 func NewSingleChainTwoVerifiersRuntime(t devtest.T) *SingleChainRuntime {
 	return NewSingleChainTwoVerifiersRuntimeWithConfig(t, PresetConfig{})
 }
@@ -168,10 +190,24 @@ func addSingleChainOpNode(
 	jwtPath := runtime.L2EL.JWTPath()
 	jwtSecret := readJWTSecretFromPath(t, jwtPath)
 	l2EL := startL2ELForKey(t, runtime.L2Network, jwtPath, jwtSecret, name, NewELNodeIdentity(0))
-	l2CL := startL2CLForKey(t, runtime.Keys, runtime.L1Network, runtime.L2Network, runtime.L1EL, runtime.L1CL, l2EL, jwtSecret, name, name, isSequencer, followSource, l2Opts)
+	l2CL := startL2CLForKey(t, runtime.Keys, runtime.L1Network, runtime.L2Network, runtime.L1EL, runtime.L1CL, l2EL, jwtSecret, name, name, isSequencer, followSource, l2Opts, runtime.L2CLFactory)
 	node := newSingleChainNodeRuntime(name, isSequencer, l2EL, l2CL)
 	runtime.Nodes[name] = node
 	return node
+}
+
+// AddSingleChainNode adds a sequencer or verifier slot to an existing runtime.
+// The runtime's injected L2CLFactory is consulted for the new slot, making the
+// helper suitable for mixed-client, fan-out, and delayed-join layouts.
+func AddSingleChainNode(
+	t devtest.T,
+	runtime *SingleChainRuntime,
+	name string,
+	isSequencer bool,
+	followSource string,
+	l2Opts ...L2CLOption,
+) *SingleChainNodeRuntime {
+	return addSingleChainOpNode(t, runtime, name, isSequencer, followSource, l2Opts...)
 }
 
 func startSyncTesterService(t devtest.T, chainRPCs map[eth.ChainID]string) *SyncTesterService {

--- a/op-devstack/sysgo/subproc.go
+++ b/op-devstack/sysgo/subproc.go
@@ -97,6 +97,35 @@ func (sp *SubProcess) StopControlled(ctx context.Context, interruptWait time.Dur
 	return sp.stop(ctx, true, interruptWait, killWait)
 }
 
+// Kill force-terminates the subprocess without first sending an interrupt.
+// This models a crash for lifecycle tests while still waiting for process I/O
+// to drain, so the same SubProcess may be started again safely.
+func (sp *SubProcess) Kill() error {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	if sp.cmd == nil {
+		return nil
+	}
+
+	select {
+	case <-sp.exited:
+		// The process already exited; only cleanup remains.
+	default:
+		sp.p.Logger().Info("Killing sub-process")
+		if err := sp.cmd.Process.Kill(); err != nil {
+			select {
+			case <-sp.exited:
+				// It exited between the readiness check and Kill.
+			default:
+				return fmt.Errorf("kill sub-process: %w", err)
+			}
+		}
+	}
+
+	<-sp.exited
+	return sp.completeStopLocked(true, sp.waitErr)
+}
+
 func (sp *SubProcess) stop(ctx context.Context, interrupt bool, interruptWait time.Duration, killWait time.Duration) error {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()

--- a/op-devstack/sysgo/subproc.go
+++ b/op-devstack/sysgo/subproc.go
@@ -112,13 +112,12 @@ func (sp *SubProcess) Kill() error {
 		// The process already exited; only cleanup remains.
 	default:
 		sp.p.Logger().Info("Killing sub-process")
-		if err := sp.cmd.Process.Kill(); err != nil {
-			select {
-			case <-sp.exited:
-				// It exited between the readiness check and Kill.
-			default:
-				return fmt.Errorf("kill sub-process: %w", err)
-			}
+		// os.ErrProcessDone means the process exited between the check above
+		// and Kill, possibly with cmd.Wait still draining stdout/stderr (so
+		// exited is not closed yet). Treat it as an exit race and fall through
+		// to wait for exited, so cleanup runs and the process can restart.
+		if err := sp.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return fmt.Errorf("kill sub-process: %w", err)
 		}
 	}
 

--- a/op-devstack/sysgo/subproc_test.go
+++ b/op-devstack/sysgo/subproc_test.go
@@ -38,6 +38,9 @@ func TestSubProcess(gt *testing.T) {
 	gt.Log("Restarting, second run")
 	capt.Clear()
 	testSleep(gt, capt, sp)
+	gt.Log("Force-killing and restarting")
+	capt.Clear()
+	testKill(gt, capt, sp)
 	gt.Log("Trying a different command now")
 	capt.Clear()
 	testEcho(gt, capt, sp)
@@ -83,6 +86,15 @@ func TestSubProcessConcurrentStop(gt *testing.T) {
 	require.NoError(gt, <-errCh)
 
 	require.NoError(gt, sp.Start("/bin/echo", []string{"restart ok"}, []string{}))
+	require.NoError(gt, sp.Stop(false))
+}
+
+func testKill(gt *testing.T, capt *testlog.CapturingHandler, sp *SubProcess) {
+	require.NoError(gt, sp.Start("/bin/sleep", []string{"10000000000"}, []string{}))
+	require.NoError(gt, sp.Kill())
+	require.NotNil(gt, capt.FindLog(testlog.NewMessageFilter("Killing sub-process")))
+
+	require.NoError(gt, sp.Start("/bin/echo", []string{"restart after kill"}, []string{}))
 	require.NoError(gt, sp.Stop(false))
 }
 

--- a/op-devstack/sysgo/subproc_test.go
+++ b/op-devstack/sysgo/subproc_test.go
@@ -2,6 +2,9 @@ package sysgo
 
 import (
 	"context"
+	"errors"
+	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -86,6 +89,47 @@ func TestSubProcessConcurrentStop(gt *testing.T) {
 	require.NoError(gt, <-errCh)
 
 	require.NoError(gt, sp.Start("/bin/echo", []string{"restart ok"}, []string{}))
+	require.NoError(gt, sp.Stop(false))
+}
+
+// TestSubProcessKillExitRace covers Kill racing with process exit: the shell
+// exits immediately, but an orphaned child keeps the inherited stdout/stderr
+// pipes open, so the OS-level process is done while cmd.Wait is still draining
+// and exited is not yet closed. Kill must treat the resulting ErrProcessDone
+// as an exit, complete cleanup, and leave the SubProcess restartable.
+func TestSubProcessKillExitRace(gt *testing.T) {
+	tLog := testlog.Logger(gt, log.LevelInfo)
+	logger, _ := testlog.CaptureLogger(gt, log.LevelInfo)
+
+	onFailNow := func(v bool) {
+		panic("fail")
+	}
+	onSkipNow := func() {
+		panic("skip")
+	}
+	p := devtest.NewP(context.Background(), logger, onFailNow, onSkipNow)
+	gt.Cleanup(p.Close)
+
+	logCallback := logpipe.LogCallback(func(line []byte) {
+		tLog.Info("Sub-process logged message", "line", string(line))
+	})
+	sp := NewSubProcess(p, logCallback, logCallback)
+
+	require.NoError(gt, sp.Start("/bin/sh", []string{"-c", "/bin/sleep 2 & exit 0"}, []string{}))
+	// Wait until the shell has been reaped (its os.Process reports done) while
+	// the orphaned sleep still holds the pipes open, keeping exited un-closed.
+	require.Eventually(gt, func() bool {
+		return errors.Is(sp.cmd.Process.Signal(syscall.Signal(0)), os.ErrProcessDone)
+	}, 10*time.Second, 10*time.Millisecond)
+	select {
+	case <-sp.Exited():
+		gt.Fatal("expected cmd.Wait to still be draining the orphaned child's pipes")
+	default:
+	}
+
+	require.NoError(gt, sp.Kill())
+
+	require.NoError(gt, sp.Start("/bin/echo", []string{"restart after kill race"}, []string{}))
 	require.NoError(gt, sp.Stop(false))
 }
 

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -73,6 +73,22 @@ type GossipRuntimeConfig interface {
 	ConfirmCurrentSigner()
 }
 
+// DelegatedBlockSignatureValidator lets an external consensus implementation
+// own unsafe-block signer resolution and validation. Implementations may use
+// product-specific or dynamically sourced signer state; returning Accept,
+// Reject, or Ignore has the same semantics as the built-in runtime-config
+// validator. When this interface is absent, gossip validation retains the
+// standard current/previous signer behavior above.
+type DelegatedBlockSignatureValidator interface {
+	ValidateUnsafeBlockSignature(
+		ctx context.Context,
+		chainID eth.ChainID,
+		version eth.BlockVersion,
+		signature eth.Bytes65,
+		payloadBytes []byte,
+	) pubsub.ValidationResult
+}
+
 //go:generate mockery --name GossipMetricer
 type GossipMetricer interface {
 	RecordGossipEvent(evType int32)
@@ -322,7 +338,7 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		payloadBytes := data[65:]
 
 		// [REJECT] if the signature by the sequencer is not valid
-		result := verifyBlockSignature(log, cfg, runCfg, id, signature, payloadBytes)
+		result := validateBlockSignature(ctx, log, cfg, runCfg, blockVersion, id, signature, payloadBytes)
 		if result != pubsub.ValidationAccept {
 			return result
 		}
@@ -456,6 +472,28 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		message.ValidatorData = &envelope
 		return pubsub.ValidationAccept
 	}
+}
+
+func validateBlockSignature(
+	ctx context.Context,
+	log log.Logger,
+	cfg *rollup.Config,
+	runCfg GossipRuntimeConfig,
+	blockVersion eth.BlockVersion,
+	id peer.ID,
+	signature eth.Bytes65,
+	payloadBytes []byte,
+) pubsub.ValidationResult {
+	if validator, ok := runCfg.(DelegatedBlockSignatureValidator); ok {
+		return validator.ValidateUnsafeBlockSignature(
+			ctx,
+			eth.ChainIDFromBig(cfg.L2ChainID),
+			blockVersion,
+			signature,
+			payloadBytes,
+		)
+	}
+	return verifyBlockSignature(log, cfg, runCfg, id, signature, payloadBytes)
 }
 
 func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, id peer.ID, signature eth.Bytes65, payloadBytes []byte) pubsub.ValidationResult {

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -337,10 +337,16 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		signature := eth.Bytes65(data[:65])
 		payloadBytes := data[65:]
 
-		// [REJECT] if the signature by the sequencer is not valid
-		result := validateBlockSignature(ctx, log, cfg, runCfg, blockVersion, id, signature, payloadBytes)
-		if result != pubsub.ValidationAccept {
-			return result
+		// The built-in signature check is pure, so reject bad signatures before
+		// doing the more expensive payload validation below. A delegated validator
+		// may call an external consensus implementation with side effects; defer it
+		// until every product-neutral payload check has succeeded.
+		delegatedValidator, delegated := runCfg.(DelegatedBlockSignatureValidator)
+		if !delegated {
+			result := verifyBlockSignature(log, cfg, runCfg, id, signature, payloadBytes)
+			if result != pubsub.ValidationAccept {
+				return result
+			}
 		}
 
 		var envelope eth.ExecutionPayloadEnvelope
@@ -464,6 +470,22 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 			return pubsub.ValidationIgnore
 		}
 
+		// Delegate only after all structural, temporal, fork, hash, and duplicate
+		// checks have passed. Implementations are allowed to consult an external
+		// consensus service, so no local rejection may occur after acceptance.
+		if delegated {
+			result := delegatedValidator.ValidateUnsafeBlockSignature(
+				ctx,
+				eth.ChainIDFromBig(cfg.L2ChainID),
+				blockVersion,
+				signature,
+				payloadBytes,
+			)
+			if result != pubsub.ValidationAccept {
+				return result
+			}
+		}
+
 		// mark it as seen. (note: with concurrent validation more than 5 blocks may be marked as seen still,
 		// but validator concurrency is limited anyway)
 		seen.markSeen(payload.BlockHash)
@@ -472,28 +494,6 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		message.ValidatorData = &envelope
 		return pubsub.ValidationAccept
 	}
-}
-
-func validateBlockSignature(
-	ctx context.Context,
-	log log.Logger,
-	cfg *rollup.Config,
-	runCfg GossipRuntimeConfig,
-	blockVersion eth.BlockVersion,
-	id peer.ID,
-	signature eth.Bytes65,
-	payloadBytes []byte,
-) pubsub.ValidationResult {
-	if validator, ok := runCfg.(DelegatedBlockSignatureValidator); ok {
-		return validator.ValidateUnsafeBlockSignature(
-			ctx,
-			eth.ChainIDFromBig(cfg.L2ChainID),
-			blockVersion,
-			signature,
-			payloadBytes,
-		)
-	}
-	return verifyBlockSignature(log, cfg, runCfg, id, signature, payloadBytes)
 }
 
 func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, id peer.ID, signature eth.Bytes65, payloadBytes []byte) pubsub.ValidationResult {

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -73,22 +73,6 @@ type GossipRuntimeConfig interface {
 	ConfirmCurrentSigner()
 }
 
-// DelegatedBlockSignatureValidator lets an external consensus implementation
-// own unsafe-block signer resolution and validation. Implementations may use
-// product-specific or dynamically sourced signer state; returning Accept,
-// Reject, or Ignore has the same semantics as the built-in runtime-config
-// validator. When this interface is absent, gossip validation retains the
-// standard current/previous signer behavior above.
-type DelegatedBlockSignatureValidator interface {
-	ValidateUnsafeBlockSignature(
-		ctx context.Context,
-		chainID eth.ChainID,
-		version eth.BlockVersion,
-		signature eth.Bytes65,
-		payloadBytes []byte,
-	) pubsub.ValidationResult
-}
-
 //go:generate mockery --name GossipMetricer
 type GossipMetricer interface {
 	RecordGossipEvent(evType int32)
@@ -337,16 +321,10 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		signature := eth.Bytes65(data[:65])
 		payloadBytes := data[65:]
 
-		// The built-in signature check is pure, so reject bad signatures before
-		// doing the more expensive payload validation below. A delegated validator
-		// may call an external consensus implementation with side effects; defer it
-		// until every product-neutral payload check has succeeded.
-		delegatedValidator, delegated := runCfg.(DelegatedBlockSignatureValidator)
-		if !delegated {
-			result := verifyBlockSignature(log, cfg, runCfg, id, signature, payloadBytes)
-			if result != pubsub.ValidationAccept {
-				return result
-			}
+		// [REJECT] if the signature by the sequencer is not valid
+		result := verifyBlockSignature(log, cfg, runCfg, id, signature, payloadBytes)
+		if result != pubsub.ValidationAccept {
+			return result
 		}
 
 		var envelope eth.ExecutionPayloadEnvelope
@@ -468,22 +446,6 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 			// [IGNORE] if the block has already been seen
 			log.Warn("validated already seen message again")
 			return pubsub.ValidationIgnore
-		}
-
-		// Delegate only after all structural, temporal, fork, hash, and duplicate
-		// checks have passed. Implementations are allowed to consult an external
-		// consensus service, so no local rejection may occur after acceptance.
-		if delegated {
-			result := delegatedValidator.ValidateUnsafeBlockSignature(
-				ctx,
-				eth.ChainIDFromBig(cfg.L2ChainID),
-				blockVersion,
-				signature,
-				payloadBytes,
-			)
-			if result != pubsub.ValidationAccept {
-				return result
-			}
 		}
 
 		// mark it as seen. (note: with concurrent validation more than 5 blocks may be marked as seen still,

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -143,60 +143,6 @@ func TestVerifyBlockSignature(t *testing.T) {
 	}
 }
 
-type recordingSignatureValidator struct {
-	testutils.MockRuntimeConfig
-	result    pubsub.ValidationResult
-	called    bool
-	chainID   eth.ChainID
-	version   eth.BlockVersion
-	signature eth.Bytes65
-	payload   []byte
-}
-
-func (v *recordingSignatureValidator) ValidateUnsafeBlockSignature(
-	_ context.Context,
-	chainID eth.ChainID,
-	version eth.BlockVersion,
-	signature eth.Bytes65,
-	payloadBytes []byte,
-) pubsub.ValidationResult {
-	v.called = true
-	v.chainID = chainID
-	v.version = version
-	v.signature = signature
-	v.payload = append([]byte(nil), payloadBytes...)
-	return v.result
-}
-
-func TestBlocksValidatorDefersDelegationUntilPayloadIsValid(t *testing.T) {
-	cfg := &rollup.Config{L2ChainID: big.NewInt(100)}
-	validator := &recordingSignatureValidator{result: pubsub.ValidationAccept}
-	secret, err := crypto.GenerateKey()
-	require.NoError(t, err)
-	signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secret)}
-	gossipConfig := &mockGossipSetupConfigurablesWithThreshold{threshold: 60 * time.Second}
-	blocksValidator := BuildBlocksValidator(
-		testlog.Logger(t, log.LevelCrit), cfg, validator, eth.BlockV2, gossipConfig, clock.SystemClock,
-	)
-
-	payload := createExecutionPayload(types.Withdrawals{}, nil, nil, nil)
-	payload.BlockHash = common.HexToHash("0xdead")
-	invalidData, err := createSignedP2Payload(payload, signer, cfg.L2ChainID)
-	require.NoError(t, err)
-	invalidMessage := &pubsub.Message{Message: &pubsub_pb.Message{Data: invalidData}}
-	require.Equal(t, pubsub.ValidationReject, blocksValidator(context.Background(), peer.ID("external-cl"), invalidMessage))
-	require.False(t, validator.called, "delegate must not observe a payload rejected locally")
-
-	payload.BlockHash, _ = (&eth.ExecutionPayloadEnvelope{ExecutionPayload: payload}).CheckBlockHash()
-	validData, err := createSignedP2Payload(payload, signer, cfg.L2ChainID)
-	require.NoError(t, err)
-	validMessage := &pubsub.Message{Message: &pubsub_pb.Message{Data: validData}}
-	require.Equal(t, pubsub.ValidationAccept, blocksValidator(context.Background(), peer.ID("external-cl"), validMessage))
-	require.True(t, validator.called)
-	require.Equal(t, eth.ChainIDFromBig(cfg.L2ChainID), validator.chainID)
-	require.Equal(t, eth.BlockV2, validator.version)
-}
-
 type MarshalSSZ interface {
 	MarshalSSZ(w io.Writer) (n int, err error)
 }

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -168,60 +168,33 @@ func (v *recordingSignatureValidator) ValidateUnsafeBlockSignature(
 	return v.result
 }
 
-func TestValidateBlockSignatureDelegatesWhenSupported(t *testing.T) {
-	logger := testlog.Logger(t, log.LevelCrit)
+func TestBlocksValidatorDefersDelegationUntilPayloadIsValid(t *testing.T) {
 	cfg := &rollup.Config{L2ChainID: big.NewInt(100)}
-	signature := eth.Bytes65{1, 2, 3}
-	payload := []byte("delegated payload")
 	validator := &recordingSignatureValidator{result: pubsub.ValidationAccept}
-
-	result := validateBlockSignature(
-		context.Background(),
-		logger,
-		cfg,
-		validator,
-		eth.BlockV4,
-		peer.ID("external-cl"),
-		signature,
-		payload,
-	)
-
-	require.Equal(t, pubsub.ValidationAccept, result)
-	require.True(t, validator.called)
-	require.Equal(t, eth.ChainIDFromBig(cfg.L2ChainID), validator.chainID)
-	require.Equal(t, eth.BlockV4, validator.version)
-	require.Equal(t, signature, validator.signature)
-	require.Equal(t, payload, validator.payload)
-}
-
-func TestValidateBlockSignatureUsesBuiltInFallback(t *testing.T) {
-	logger := testlog.Logger(t, log.LevelCrit)
-	cfg := &rollup.Config{L2ChainID: big.NewInt(100)}
-	payload := []byte("standard payload")
 	secret, err := crypto.GenerateKey()
 	require.NoError(t, err)
 	signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secret)}
-	signature, err := signer.SignBlockV1(
-		context.Background(),
-		eth.ChainIDFromBig(cfg.L2ChainID),
-		opsigner.PayloadHash(payload),
+	gossipConfig := &mockGossipSetupConfigurablesWithThreshold{threshold: 60 * time.Second}
+	blocksValidator := BuildBlocksValidator(
+		testlog.Logger(t, log.LevelCrit), cfg, validator, eth.BlockV2, gossipConfig, clock.SystemClock,
 	)
+
+	payload := createExecutionPayload(types.Withdrawals{}, nil, nil, nil)
+	payload.BlockHash = common.HexToHash("0xdead")
+	invalidData, err := createSignedP2Payload(payload, signer, cfg.L2ChainID)
 	require.NoError(t, err)
-	runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: crypto.PubkeyToAddress(secret.PublicKey)}
+	invalidMessage := &pubsub.Message{Message: &pubsub_pb.Message{Data: invalidData}}
+	require.Equal(t, pubsub.ValidationReject, blocksValidator(context.Background(), peer.ID("external-cl"), invalidMessage))
+	require.False(t, validator.called, "delegate must not observe a payload rejected locally")
 
-	result := validateBlockSignature(
-		context.Background(),
-		logger,
-		cfg,
-		runCfg,
-		eth.BlockV3,
-		peer.ID("standard-cl"),
-		signature,
-		payload,
-	)
-
-	require.Equal(t, pubsub.ValidationAccept, result)
-	require.True(t, runCfg.Confirmed)
+	payload.BlockHash, _ = (&eth.ExecutionPayloadEnvelope{ExecutionPayload: payload}).CheckBlockHash()
+	validData, err := createSignedP2Payload(payload, signer, cfg.L2ChainID)
+	require.NoError(t, err)
+	validMessage := &pubsub.Message{Message: &pubsub_pb.Message{Data: validData}}
+	require.Equal(t, pubsub.ValidationAccept, blocksValidator(context.Background(), peer.ID("external-cl"), validMessage))
+	require.True(t, validator.called)
+	require.Equal(t, eth.ChainIDFromBig(cfg.L2ChainID), validator.chainID)
+	require.Equal(t, eth.BlockV2, validator.version)
 }
 
 type MarshalSSZ interface {

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -143,6 +143,87 @@ func TestVerifyBlockSignature(t *testing.T) {
 	}
 }
 
+type recordingSignatureValidator struct {
+	testutils.MockRuntimeConfig
+	result    pubsub.ValidationResult
+	called    bool
+	chainID   eth.ChainID
+	version   eth.BlockVersion
+	signature eth.Bytes65
+	payload   []byte
+}
+
+func (v *recordingSignatureValidator) ValidateUnsafeBlockSignature(
+	_ context.Context,
+	chainID eth.ChainID,
+	version eth.BlockVersion,
+	signature eth.Bytes65,
+	payloadBytes []byte,
+) pubsub.ValidationResult {
+	v.called = true
+	v.chainID = chainID
+	v.version = version
+	v.signature = signature
+	v.payload = append([]byte(nil), payloadBytes...)
+	return v.result
+}
+
+func TestValidateBlockSignatureDelegatesWhenSupported(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelCrit)
+	cfg := &rollup.Config{L2ChainID: big.NewInt(100)}
+	signature := eth.Bytes65{1, 2, 3}
+	payload := []byte("delegated payload")
+	validator := &recordingSignatureValidator{result: pubsub.ValidationAccept}
+
+	result := validateBlockSignature(
+		context.Background(),
+		logger,
+		cfg,
+		validator,
+		eth.BlockV4,
+		peer.ID("external-cl"),
+		signature,
+		payload,
+	)
+
+	require.Equal(t, pubsub.ValidationAccept, result)
+	require.True(t, validator.called)
+	require.Equal(t, eth.ChainIDFromBig(cfg.L2ChainID), validator.chainID)
+	require.Equal(t, eth.BlockV4, validator.version)
+	require.Equal(t, signature, validator.signature)
+	require.Equal(t, payload, validator.payload)
+}
+
+func TestValidateBlockSignatureUsesBuiltInFallback(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelCrit)
+	cfg := &rollup.Config{L2ChainID: big.NewInt(100)}
+	payload := []byte("standard payload")
+	secret, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secret)}
+	signature, err := signer.SignBlockV1(
+		context.Background(),
+		eth.ChainIDFromBig(cfg.L2ChainID),
+		opsigner.PayloadHash(payload),
+	)
+	require.NoError(t, err)
+	runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: crypto.PubkeyToAddress(secret.PublicKey)}
+
+	result := validateBlockSignature(
+		context.Background(),
+		logger,
+		cfg,
+		runCfg,
+		eth.BlockV3,
+		peer.ID("standard-cl"),
+		signature,
+		payload,
+	)
+
+	require.Equal(t, pubsub.ValidationAccept, result)
+	require.True(t, runCfg.Confirmed)
+}
+
 type MarshalSSZ interface {
 	MarshalSSZ(w io.Writer) (n int, err error)
 }

--- a/op-service/txintent/bindings/SystemConfig.go
+++ b/op-service/txintent/bindings/SystemConfig.go
@@ -17,6 +17,7 @@ type SystemConfig struct {
 
 	// Write functions
 	SetOperatorFeeScalars func(operatorFeeScalar uint32, operatorFeeConstant uint64) TypedCall[any] `sol:"setOperatorFeeScalars"`
+	SetGasLimit           func(gasLimit uint64) TypedCall[any]                                      `sol:"setGasLimit"`
 	SetGasConfig          func(overhead *big.Int, scalar *big.Int) TypedCall[any]                   `sol:"setGasConfig"`
 	SetGasConfigEcotone   func(basefeeScalar uint32, blobbasefeeScalar uint32) TypedCall[any]       `sol:"setGasConfigEcotone"`
 }


### PR DESCRIPTION
## Summary

Add product-neutral devstack extension points for externally implemented L2 consensus clients.

This branch is based directly on `develop`. It replaces the earlier two-PR stack: OPQL-specific acceptance code never landed on `develop`, so there is no product cleanup diff to merge there. The private OPQL repository owns the product adapter, tests, topology logic, environment handling, and sidecar.

## Public API

- add `L2CLFactory`, `L2CLFactoryFn`, and `L2CLLaunchContext`
- expose per-slot sequencer/verifier role, L1/L2 endpoints, JWT path, genesis/rollup configuration, follow source, neutral `L2CLConfig`, and optional metrics registration
- add `presets.WithL2CLFactory` and retain the factory for delayed/additional nodes
- let a factory accept individual slots or decline them to preserve normal op-node/Kona selection
- expose neutral runtime composition/projection helpers for mixed, delayed-join, restart, fan-out, and deterministic test-sequencer layouts
- expose generic no-fault-proof multinode/bare-verifier layouts, forced subprocess termination, and a block-persistence assertion for lifecycle tests
- expose a neutral L2 CL gossip multiaddress helper and the existing SystemConfig `setGasLimit` contract binding needed by generic configuration tests

There is no global registry or environment-based external-client selector. The public code contains no OPQL binary names, flags, configuration fields, or product-specific packages.

## Validation

- `go test ./op-devstack/sysgo ./op-devstack/presets ./op-devstack/dsl ./op-service/txintent/bindings`
- verified `op-acceptance-tests/tests/opcon` and `op-conp2p` do not exist on this branch
- product-name scan across `op-devstack` and `op-acceptance-tests` passes

The factory is exercised with a fake external CL implementation, including per-slot selection and restart behavior. Existing op-node/Kona behavior remains the fallback when no factory is provided or a factory declines a slot.

Private consumer: https://github.com/ethereum-optimism/opql/pull/368

## Review follow-up

- Resolve `L2CLOptions` exactly once per slot and pass the option-resolved follow source (and effective config) to factory launch contexts, so non-idempotent options like `StallableFollowSourceProxies` are safe with the factory fallback (52720d1b21).
- Stop advertising factory support through `NewMinimalWithConductors` and `SimpleWithSyncTester`; both now reject `WithL2CLFactory` at option validation instead of failing during construction (52720d1b21).
- Make the single-chain test sequencer accept any `L2CLNode`, so `NewSingleChainTwoVerifiersWithoutCheck` works with factory-provided (and Kona) CL nodes (d93e619d2a).
- Fix `SubProcess.Kill` racing a self-exiting process while its pipes drain: `ErrProcessDone` is now treated as an exit race, cleanup completes, and the process can restart (d93e619d2a).
- Drop the delegated gossip-signature validation hook — the factory does not require op-node changes, and this PR no longer touches op-node (54dc8ae0d5).
