### PR TITLE
op-node,op-devstack: Test op-challenger super roots from op-node

### DIFF
--- a/op-acceptance-tests/tests/interop/super-opnode/challenger_test.go
+++ b/op-acceptance-tests/tests/interop/super-opnode/challenger_test.go
@@ -1,0 +1,37 @@
+package super_opnode
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/proofs"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
+)
+
+// TestChallengerPlaysGameFromOpNode verifies op-challenger plays a super-cannon-kona game
+// when its super roots are sourced from a single op-node (superroot_atTimestamp) rather than
+// op-supernode. An attacker posts a bad super root; the challenger, backed by op-node, must
+// counter it down to the split depth.
+func TestChallengerPlaysGameFromOpNode(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainInteropNoSupernode(t)
+	dsl.CheckAll(t, sys.L2CLA.AdvancedFn(safety.CrossSafe, 1, 30))
+
+	badClaim := common.HexToHash("0xdeadbeef00000000000000000000000000000000000000000000000000000000")
+	attacker := sys.FunderL1.NewFundedEOA(eth.Ether(15))
+	dgf := sys.DisputeGameFactory()
+
+	game := dgf.StartSuperCannonKonaGame(attacker, proofs.WithSuperRootFrom(eth.Bytes32(badClaim)))
+
+	claim := game.RootClaim()                   // The bad claim from the attacker.
+	counterClaim := claim.WaitForCounterClaim() // The counter-claim from the challenger.
+	for counterClaim.Depth() <= game.SplitDepth() {
+		claim = counterClaim.Attack(attacker, badClaim)
+		counterClaim = claim.WaitForCounterClaim()
+	}
+}

--- a/op-acceptance-tests/tests/interop/super-opnode/fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/super-opnode/fault_proofs_test.go
@@ -1,0 +1,18 @@
+package super_opnode
+
+import (
+	"testing"
+
+	sfp "github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/superfaultproofs"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+// TestSingleChainSuperFaultProofsFromOpNode runs the single-chain super-fault-proof smoke
+// test with super roots served by op-node instead of op-supernode. It exercises the FPP and
+// the challenger trace provider against the op-node superroot_atTimestamp source.
+func TestSingleChainSuperFaultProofsFromOpNode(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainInteropNoSupernode(t)
+	sfp.RunSingleChainSuperFaultProofSmokeTest(t, sys)
+}

--- a/op-acceptance-tests/tests/interop/upgrade-no-supervisor/interop_contracts_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-no-supervisor/interop_contracts_test.go
@@ -18,7 +18,7 @@ import (
 // This test uses a single-chain setup, so only L2ToL2CrossDomainMessenger is deployed.
 func TestInteropContractsDeployed(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewMinimalInteropNoSupervisor(t)
+	sys := presets.NewMinimalInteropNoSupernode(t)
 	require := t.Require()
 	logger := t.Logger()
 
@@ -50,7 +50,7 @@ func TestInteropContractsDeployed(gt *testing.T) {
 // correctly when interop is active but no supervisor is running.
 func TestLocalFinalityWithoutSupervisor(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewMinimalInteropNoSupervisor(t)
+	sys := presets.NewMinimalInteropNoSupernode(t)
 	require := t.Require()
 	logger := t.Logger()
 

--- a/op-acceptance-tests/tests/superfaultproofs/intrablock.go
+++ b/op-acceptance-tests/tests/superfaultproofs/intrablock.go
@@ -65,7 +65,7 @@ func RunIntraBlockConsolidationTest(t devtest.T, sys *presets.SimpleInterop, tc 
 	// --- Sync chains and prepare for same-timestamp block building -----------
 	sys.L2ChainB.CatchUpTo(sys.L2ChainA)
 	sys.L2ChainA.CatchUpTo(sys.L2ChainB)
-	sys.SuperRoots.EnsureInteropPaused(sys.L2CLA, sys.L2CLB, 10)
+	sys.Supernode().EnsureInteropPaused(sys.L2CLA, sys.L2CLB, 10)
 
 	sys.L2CLA.StopSequencer()
 	sys.L2CLB.StopSequencer()
@@ -139,7 +139,7 @@ func RunIntraBlockConsolidationTest(t devtest.T, sys *presets.SimpleInterop, tc 
 	sys.TestSequencer.SequenceBlockWithTxs(t, sys.L2ChainB.ChainID(), unsafeB.Hash, rawTxsB)
 
 	// --- Resume interop and wait for validation ------------------------------
-	sys.SuperRoots.ResumeInterop()
+	sys.Supernode().ResumeInterop()
 	sys.SuperRoots.AwaitValidatedTimestamp(nextTimestamp)
 
 	endTimestamp := nextTimestamp

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -50,7 +50,7 @@ type DisputeGameFactory struct {
 	addr          common.Address
 	l2CL          *dsl.L2CLNode
 	l2EL          *dsl.L2ELNode
-	superNode     *dsl.Supernode
+	superNode     dsl.SuperRootSource
 	l1Proposer    *dsl.EOA
 	gameHelper    *GameHelper
 	challengerCfg *challengerConfig.Config
@@ -65,7 +65,7 @@ func NewDisputeGameFactory(
 	dgfAddr common.Address,
 	l2CL *dsl.L2CLNode,
 	l2EL *dsl.L2ELNode,
-	superNode *dsl.Supernode,
+	superNode dsl.SuperRootSource,
 	l1Proposer *dsl.EOA,
 	challengerCfg *challengerConfig.Config,
 ) *DisputeGameFactory {

--- a/op-devstack/dsl/super_root_source.go
+++ b/op-devstack/dsl/super_root_source.go
@@ -17,6 +17,7 @@ import (
 // single-chain), letting the same dispute-game tests run against either source.
 type SuperRootSource interface {
 	QueryAPI() apis.SupernodeQueryAPI
+	UserRPC() string
 	SuperRootAtTimestamp(timestamp uint64) eth.SuperRootAtTimestampResponse
 	AssertSuperRootAtTimestamp(l2SequenceNumber uint64, rootClaim common.Hash)
 	AwaitValidatedTimestamp(timestamp uint64)
@@ -33,7 +34,8 @@ var (
 // Supernode, which adds op-supernode-only controls on top.
 type SuperRootQuerier struct {
 	commonImpl
-	api apis.SupernodeQueryAPI
+	api     apis.SupernodeQueryAPI
+	userRPC string
 }
 
 // NewOpNodeSuperRoots wraps a single op-node's superroot_atTimestamp endpoint as a
@@ -43,12 +45,18 @@ func NewOpNodeSuperRoots(cl *L2CLNode) *SuperRootQuerier {
 	return &SuperRootQuerier{
 		commonImpl: commonFromT(cl.t),
 		api:        sources.NewSuperNodeClient(cl.inner.ClientRPC()),
+		userRPC:    cl.inner.UserRPC(),
 	}
 }
 
 // QueryAPI returns the super-root query API for this source.
 func (s *SuperRootQuerier) QueryAPI() apis.SupernodeQueryAPI {
 	return s.api
+}
+
+// UserRPC returns the super-root source's RPC endpoint.
+func (s *SuperRootQuerier) UserRPC() string {
+	return s.userRPC
 }
 
 // SuperRootAtTimestamp fetches the super-root at the given timestamp.

--- a/op-devstack/dsl/super_root_source.go
+++ b/op-devstack/dsl/super_root_source.go
@@ -1,0 +1,99 @@
+package dsl
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+)
+
+// SuperRootSource is the super-root query surface the dispute-game DSL needs. It is
+// satisfied by both op-supernode (interop, multi-chain) and op-node (non-interop,
+// single-chain), letting the same dispute-game tests run against either source.
+type SuperRootSource interface {
+	QueryAPI() apis.SupernodeQueryAPI
+	SuperRootAtTimestamp(timestamp uint64) eth.SuperRootAtTimestampResponse
+	AssertSuperRootAtTimestamp(l2SequenceNumber uint64, rootClaim common.Hash)
+	AwaitValidatedTimestamp(timestamp uint64)
+	AwaitFullyProcessedL1(targetL1 uint64)
+}
+
+var (
+	_ SuperRootSource = (*Supernode)(nil)
+	_ SuperRootSource = (*SuperRootQuerier)(nil)
+)
+
+// SuperRootQuerier is a SuperRootSource backed by a fixed apis.SupernodeQueryAPI. It is
+// used directly as the op-node-backed source (see NewOpNodeSuperRoots) and embedded by
+// Supernode, which adds op-supernode-only controls on top.
+type SuperRootQuerier struct {
+	commonImpl
+	api apis.SupernodeQueryAPI
+}
+
+// NewOpNodeSuperRoots wraps a single op-node's superroot_atTimestamp endpoint as a
+// super-root source. Only superroot_atTimestamp is served by op-node; SyncStatus
+// (supernode_syncStatus) is not available on this source.
+func NewOpNodeSuperRoots(cl *L2CLNode) *SuperRootQuerier {
+	return &SuperRootQuerier{
+		commonImpl: commonFromT(cl.t),
+		api:        sources.NewSuperNodeClient(cl.inner.ClientRPC()),
+	}
+}
+
+// QueryAPI returns the super-root query API for this source.
+func (s *SuperRootQuerier) QueryAPI() apis.SupernodeQueryAPI {
+	return s.api
+}
+
+// SuperRootAtTimestamp fetches the super-root at the given timestamp.
+func (s *SuperRootQuerier) SuperRootAtTimestamp(timestamp uint64) eth.SuperRootAtTimestampResponse {
+	ctx, cancel := context.WithTimeout(s.ctx, DefaultTimeout)
+	defer cancel()
+	resp, err := s.api.SuperRootAtTimestamp(ctx, timestamp)
+	s.require.NoError(err, "failed to get super-root at timestamp %d", timestamp)
+	return resp
+}
+
+// AssertSuperRootAtTimestamp asserts that the super-root at the given timestamp matches the expected root claim.
+func (s *SuperRootQuerier) AssertSuperRootAtTimestamp(l2SequenceNumber uint64, rootClaim common.Hash) {
+	resp := s.SuperRootAtTimestamp(l2SequenceNumber)
+	s.require.NotNilf(resp.Data, "super root does not exist at time %d", l2SequenceNumber)
+	superRoot := eth.SuperRoot(resp.Data.Super)
+	s.require.Equal(superRoot[:], rootClaim[:])
+}
+
+// AwaitValidatedTimestamp waits for the super-root at the given timestamp to be available.
+func (s *SuperRootQuerier) AwaitValidatedTimestamp(timestamp uint64) {
+	ctx, cancel := context.WithTimeout(s.ctx, 5*DefaultTimeout)
+	defer cancel()
+	err := wait.For(ctx, 1*time.Second, func() (bool, error) {
+		resp, err := s.api.SuperRootAtTimestamp(ctx, timestamp)
+		if err != nil {
+			return false, nil // Ignore transient errors.
+		}
+		return resp.Data != nil, nil
+	})
+	s.require.NoError(err, "super-root at timestamp %d was not validated in time", timestamp)
+}
+
+// AwaitFullyProcessedL1 waits until the source has fully processed the given L1 block
+// number. SuperRootAtTimestamp's CurrentL1 names the block currently being processed
+// (L1[<CurrentL1] is fully processed), so this returns once CurrentL1.Number > targetL1.
+func (s *SuperRootQuerier) AwaitFullyProcessedL1(targetL1 uint64) {
+	ctx, cancel := context.WithTimeout(s.ctx, 5*DefaultTimeout)
+	defer cancel()
+	err := wait.For(ctx, 1*time.Second, func() (bool, error) {
+		resp, err := s.api.SuperRootAtTimestamp(ctx, uint64(time.Now().Unix()))
+		if err != nil {
+			return false, nil // Ignore transient errors.
+		}
+		return resp.CurrentL1.Number > targetL1, nil
+	})
+	s.require.NoError(err, "source did not fully process L1 block %d in time", targetL1)
+}

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -30,7 +30,7 @@ func (s *Supernode) ManageVN(vn *L2CLNode) {
 // NewSupernode creates a new Supernode DSL wrapper
 func NewSupernode(inner stack.Supernode) *Supernode {
 	return &Supernode{
-		SuperRootQuerier: SuperRootQuerier{commonImpl: commonFromT(inner.T()), api: inner.QueryAPI()},
+		SuperRootQuerier: SuperRootQuerier{commonImpl: commonFromT(inner.T()), api: inner.QueryAPI(), userRPC: inner.UserRPC()},
 		inner:            inner,
 	}
 }
@@ -39,7 +39,7 @@ func NewSupernode(inner stack.Supernode) *Supernode {
 // The testControl parameter can be nil if no test control is needed.
 func NewSupernodeWithTestControl(inner stack.Supernode, testControl stack.SupernodeTestControl) *Supernode {
 	return &Supernode{
-		SuperRootQuerier: SuperRootQuerier{commonImpl: commonFromT(inner.T()), api: inner.QueryAPI()},
+		SuperRootQuerier: SuperRootQuerier{commonImpl: commonFromT(inner.T()), api: inner.QueryAPI(), userRPC: inner.UserRPC()},
 		inner:            inner,
 		testControl:      testControl,
 	}

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -6,16 +6,14 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
-	"github.com/ethereum-optimism/optimism/op-service/apis"
 	opclient "github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // Supernode wraps a stack.Supernode interface for DSL operations
 type Supernode struct {
-	commonImpl
+	SuperRootQuerier
 	inner       stack.Supernode
 	testControl stack.SupernodeTestControl
 	managedVNs  []*L2CLNode
@@ -32,8 +30,8 @@ func (s *Supernode) ManageVN(vn *L2CLNode) {
 // NewSupernode creates a new Supernode DSL wrapper
 func NewSupernode(inner stack.Supernode) *Supernode {
 	return &Supernode{
-		commonImpl: commonFromT(inner.T()),
-		inner:      inner,
+		SuperRootQuerier: SuperRootQuerier{commonImpl: commonFromT(inner.T()), api: inner.QueryAPI()},
+		inner:            inner,
 	}
 }
 
@@ -41,9 +39,9 @@ func NewSupernode(inner stack.Supernode) *Supernode {
 // The testControl parameter can be nil if no test control is needed.
 func NewSupernodeWithTestControl(inner stack.Supernode, testControl stack.SupernodeTestControl) *Supernode {
 	return &Supernode{
-		commonImpl:  commonFromT(inner.T()),
-		inner:       inner,
-		testControl: testControl,
+		SuperRootQuerier: SuperRootQuerier{commonImpl: commonFromT(inner.T()), api: inner.QueryAPI()},
+		inner:            inner,
+		testControl:      testControl,
 	}
 }
 
@@ -60,65 +58,12 @@ func (s *Supernode) Escape() stack.Supernode {
 	return s.inner
 }
 
-// QueryAPI returns the supernode's query API
-func (s *Supernode) QueryAPI() apis.SupernodeQueryAPI {
-	return s.inner.QueryAPI()
-}
-
 func (s *Supernode) ClientRPC() opclient.RPC {
 	return s.inner.ClientRPC()
 }
 
 func (s *Supernode) UserRPC() string {
 	return s.inner.UserRPC()
-}
-
-// SuperRootAtTimestamp fetches the super-root at the given timestamp
-func (s *Supernode) SuperRootAtTimestamp(timestamp uint64) eth.SuperRootAtTimestampResponse {
-	ctx, cancel := context.WithTimeout(s.ctx, DefaultTimeout)
-	defer cancel()
-	resp, err := s.inner.QueryAPI().SuperRootAtTimestamp(ctx, timestamp)
-	s.require.NoError(err, "failed to get super-root at timestamp %d", timestamp)
-	return resp
-}
-
-// AssertSuperRootAtTimestamp asserts that the super-root at the given timestamp matches the expected root claim
-func (s *Supernode) AssertSuperRootAtTimestamp(l2SequenceNumber uint64, rootClaim common.Hash) {
-	resp := s.SuperRootAtTimestamp(l2SequenceNumber)
-	s.require.NotNilf(resp.Data, "super root does not exist at time %d", l2SequenceNumber)
-	superRoot := eth.SuperRoot(resp.Data.Super)
-	s.require.Equal(superRoot[:], rootClaim[:])
-}
-
-// AwaitFullyProcessedL1 waits until the supernode has fully processed the given L1
-// block number. SuperRootAtTimestamp's CurrentL1 names the block currently being
-// processed (L1[<CurrentL1] is fully processed), so this returns once
-// CurrentL1.Number > targetL1.
-func (s *Supernode) AwaitFullyProcessedL1(targetL1 uint64) {
-	ctx, cancel := context.WithTimeout(s.ctx, 5*DefaultTimeout)
-	defer cancel()
-	err := wait.For(ctx, 1*time.Second, func() (bool, error) {
-		resp, err := s.inner.QueryAPI().SuperRootAtTimestamp(ctx, uint64(time.Now().Unix()))
-		if err != nil {
-			return false, nil // Ignore transient errors.
-		}
-		return resp.CurrentL1.Number > targetL1, nil
-	})
-	s.require.NoError(err, "supernode did not fully process L1 block %d in time", targetL1)
-}
-
-// AwaitValidatedTimestamp waits for the super-root at the given timestamp to be fully validated
-func (s *Supernode) AwaitValidatedTimestamp(timestamp uint64) {
-	ctx, cancel := context.WithTimeout(s.ctx, 5*DefaultTimeout)
-	defer cancel()
-	err := wait.For(ctx, 1*time.Second, func() (bool, error) {
-		resp, err := s.inner.QueryAPI().SuperRootAtTimestamp(ctx, timestamp)
-		if err != nil {
-			return false, nil // Ignore transient errors.
-		}
-		return resp.Data != nil, nil
-	})
-	s.require.NoError(err, "super-root at timestamp %d was not validated in time", timestamp)
 }
 
 // AwaitFinalizationAdvanced reads the supernode's current finalized timestamp

--- a/op-devstack/presets/dispute_mon.go
+++ b/op-devstack/presets/dispute_mon.go
@@ -54,11 +54,11 @@ func WithDisputeMonRollupNodes(nodes ...*dsl.L2CLNode) DisputeMonOption {
 	}
 }
 
-func WithDisputeMonSupernodes(nodes ...*dsl.Supernode) DisputeMonOption {
+func WithDisputeMonSupernodes(nodes ...dsl.SuperRootSource) DisputeMonOption {
 	return func(opts *disputeMonOptions) {
 		for _, node := range nodes {
 			if node != nil {
-				opts.supernodeRPCs = append(opts.supernodeRPCs, node.Escape().UserRPC())
+				opts.supernodeRPCs = append(opts.supernodeRPCs, node.UserRPC())
 			}
 		}
 	}

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -22,7 +22,7 @@ type SingleChainInterop struct {
 	timeTravel *clock.AdvancingClock
 	l1Proposer *dsl.EOA
 
-	SuperRoots    *dsl.Supernode
+	SuperRoots    dsl.SuperRootSource
 	TestSequencer *dsl.TestSequencer
 
 	L1Network *dsl.L1Network
@@ -91,6 +91,15 @@ func (s *SimpleInterop) proofValidationContext() (devtest.T, *dsl.L1ELNode, []*d
 	return s.T, s.L1EL, s.L2Networks()
 }
 
+// Supernode returns the op-supernode backing this system's super roots. SimpleInterop
+// is always supernode-backed, so this exposes supernode-only test controls (e.g.
+// interop pause/resume) that are not part of the SuperRootSource interface.
+func (s *SimpleInterop) Supernode() *dsl.Supernode {
+	sn, ok := s.SuperRoots.(*dsl.Supernode)
+	s.T.Require().True(ok, "SimpleInterop super roots are not supernode-backed")
+	return sn
+}
+
 func (s *SingleChainInterop) StandardBridge(l2Chain *dsl.L2Network) *dsl.StandardBridge {
 	return dsl.NewStandardBridge(s.T, l2Chain, s.L1EL)
 }
@@ -121,6 +130,15 @@ func NewSimpleInteropIsthmusSuper(t devtest.T, opts ...Option) *SimpleInterop {
 func NewSingleChainInteropIsthmusSuper(t devtest.T, opts ...Option) *SingleChainInterop {
 	presetCfg, _ := collectSupportedPresetConfig(t, "NewSingleChainInteropIsthmusSuper", opts, supernodeProofsPresetSupportedOptionKinds)
 	return singleChainInteropFromSupernodeProofsRuntime(t, sysgo.NewSingleChainSupernodeProofsRuntimeWithConfig(t, false, presetCfg))
+}
+
+// NewSingleChainInteropNoSupernode creates a fresh SingleChainInterop target whose
+// super roots are served by the single op-node's superroot_atTimestamp endpoint (no
+// op-supernode). The op-challenger plays super-cannon-kona games against this op-node
+// source. This exercises the "op-node as super root RPC" path end-to-end.
+func NewSingleChainInteropNoSupernode(t devtest.T, opts ...Option) *SingleChainInterop {
+	presetCfg, _ := collectSupportedPresetConfig(t, "NewSingleChainInteropNoSupernode", opts, 0)
+	return singleChainInteropNoSupernodeFromRuntime(t, sysgo.NewSingleChainInteropNoSupernodeSuperRootRuntimeWithConfig(t, presetCfg))
 }
 
 // NewSingleChainInteropSuperRootAtGenesis creates a fresh SingleChainInterop
@@ -165,17 +183,17 @@ func WithInteropNotAtGenesis() Option {
 	return WithRequireInteropNotAtGenesis()
 }
 
-// MinimalInteropNoSupervisor is like Minimal but with interop contracts deployed.
-// No supervisor is running - this tests interop contract deployment with local finality.
-type MinimalInteropNoSupervisor struct {
+// MinimalInteropNoSupernode is like Minimal but with interop contracts deployed.
+// No supernode is running - this tests interop contract deployment with local finality.
+type MinimalInteropNoSupernode struct {
 	Minimal
 }
 
-// NewMinimalInteropNoSupervisor creates a fresh MinimalInteropNoSupervisor target for the
+// NewMinimalInteropNoSupernode creates a fresh MinimalInteropNoSupernode target for the
 // current test.
-func NewMinimalInteropNoSupervisor(t devtest.T, opts ...Option) *MinimalInteropNoSupervisor {
-	_, _ = collectSupportedPresetConfig(t, "NewMinimalInteropNoSupervisor", opts, 0)
-	return &MinimalInteropNoSupervisor{
-		Minimal: *minimalFromRuntime(t, sysgo.NewMinimalInteropNoSupervisorRuntime(t)),
+func NewMinimalInteropNoSupernode(t devtest.T, opts ...Option) *MinimalInteropNoSupernode {
+	_, _ = collectSupportedPresetConfig(t, "NewMinimalInteropNoSupernode", opts, 0)
+	return &MinimalInteropNoSupernode{
+		Minimal: *minimalFromRuntime(t, sysgo.NewMinimalInteropNoSupernodeRuntime(t)),
 	}
 }

--- a/op-devstack/presets/singlechain_interop_no_supernode_from_runtime.go
+++ b/op-devstack/presets/singlechain_interop_no_supernode_from_runtime.go
@@ -1,0 +1,78 @@
+package presets
+
+import (
+	challengerConfig "github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// singleChainInteropNoSupernodeFromRuntime builds a SingleChainInterop whose super roots
+// are served by the single op-node (superroot_atTimestamp) rather than op-supernode. The
+// runtime runs no supernode; the op-challenger is wired to the op-node's super-root RPC.
+func singleChainInteropNoSupernodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *SingleChainInterop {
+	l1ChainID := runtime.L1Network.ChainID()
+	l2ChainID := runtime.L2Network.ChainID()
+
+	l1Network := newPresetL1Network(t, "l1", runtime.L1Network.ChainConfig())
+	l1EL := newL1ELFrontend(t, "l1", l1ChainID, runtime.L1EL.UserRPC())
+	l1CL := newL1CLFrontend(t, "l1", l1ChainID, runtime.L1CL.BeaconHTTPAddr(), runtime.L1CL.FakePoS())
+	l1Network.AddL1ELNode(l1EL)
+	l1Network.AddL1CLNode(l1CL)
+
+	l2Chain := newPresetL2Network(
+		t,
+		"l2a",
+		runtime.L2Network.ChainConfig(),
+		runtime.L2Network.RollupConfig(),
+		runtime.L2Network.Deployment(),
+		newKeyring(runtime.Keys, t.Require()),
+		l1Network,
+	)
+	l2EL := newL2ELFrontend(t, "sequencer", l2ChainID, runtime.L2EL.UserRPC(), runtime.L2EL.EngineRPC(), runtime.L2EL.JWTPath(), runtime.L2Network.RollupConfig(), runtime.L2EL)
+	l2CL := newL2CLFrontend(t, "sequencer", l2ChainID, runtime.L2CL.UserRPC(), runtime.L2CL)
+	l2CL.attachEL(l2EL)
+	l2Batcher := newL2BatcherFrontend(t, "main", l2ChainID, runtime.L2Batcher.UserRPC())
+	l2Chain.AddL2ELNode(l2EL)
+	l2Chain.AddL2CLNode(l2CL)
+	l2Chain.AddL2Batcher(l2Batcher)
+
+	var challengerCfg *challengerConfig.Config
+	if runtime.L2Challenger != nil {
+		challengerCfg = runtime.L2Challenger.Config()
+	}
+	if challengerCfg != nil {
+		l2Chain.AddL2Challenger(newPresetL2Challenger(t, "main", l2ChainID, challengerCfg))
+	}
+
+	faucetL1Frontend := newFaucetFrontendForChain(t, runtime.FaucetService, l1ChainID)
+	faucetAFrontend := newFaucetFrontendForChain(t, runtime.FaucetService, l2ChainID)
+	l1Network.AddFaucet(faucetL1Frontend)
+	l2Chain.AddFaucet(faucetAFrontend)
+
+	l1ELDSL := dsl.NewL1ELNode(l1EL)
+	l1CLDSL := dsl.NewL1CLNode(l1CL)
+	l2ELDSL := dsl.NewL2ELNode(l2EL)
+	l2CLDSL := dsl.NewL2CLNode(l2CL)
+
+	out := &SingleChainInterop{
+		Log:              t.Logger(),
+		T:                t,
+		timeTravel:       runtime.TimeTravel,
+		SuperRoots:       dsl.NewOpNodeSuperRoots(l2CLDSL),
+		L1Network:        dsl.NewL1Network(l1Network, l1ELDSL, l1CLDSL),
+		L1EL:             l1ELDSL,
+		L1CL:             l1CLDSL,
+		L2ChainA:         dsl.NewL2Network(l2Chain, l2ELDSL, l2CLDSL, l1ELDSL, nil, nil),
+		L2BatcherA:       dsl.NewL2Batcher(l2Batcher),
+		L2ELA:            l2ELDSL,
+		L2CLA:            l2CLDSL,
+		Wallet:           dsl.NewRandomHDWallet(t, 30),
+		FaucetA:          dsl.NewFaucet(faucetAFrontend),
+		FaucetL1:         dsl.NewFaucet(faucetL1Frontend),
+		challengerConfig: challengerCfg,
+	}
+	out.FunderL1 = dsl.NewFunder(out.Wallet, out.FaucetL1, out.L1EL)
+	out.FunderA = dsl.NewFunder(out.Wallet, out.FaucetA, out.L2ELA)
+	return out
+}

--- a/op-devstack/sysgo/singlechain_interop.go
+++ b/op-devstack/sysgo/singlechain_interop.go
@@ -2,11 +2,12 @@ package sysgo
 
 import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 )
 
-func newSingleChainInteropWorldNoSupervisor(t devtest.T, keys devkeys.Keys, cfg PresetConfig) singleChainRuntimeWorld {
+func newSingleChainInteropWorldNoSupernode(t devtest.T, keys devkeys.Keys, cfg PresetConfig) singleChainRuntimeWorld {
 	cfg.DeployerOptions = append([]DeployerOption{
 		WithDevFeatureEnabled(devfeatures.OptimismPortalInteropFlag),
 	}, cfg.DeployerOptions...)
@@ -21,7 +22,7 @@ func newSingleChainInteropWorldNoSupervisor(t devtest.T, keys devkeys.Keys, cfg 
 	}
 }
 
-func startSingleChainInteropPrimaryNoSupervisor(
+func startSingleChainInteropPrimaryNoSupernode(
 	t devtest.T,
 	keys devkeys.Keys,
 	world singleChainRuntimeWorld,
@@ -50,14 +51,29 @@ func startSingleChainInteropPrimaryNoSupervisor(
 	}
 }
 
-// NewMinimalInteropNoSupervisorRuntime constructs the single-chain interop world
-// without supervisor wiring.
-func NewMinimalInteropNoSupervisorRuntime(t devtest.T) *SingleChainRuntime {
+// NewMinimalInteropNoSupernodeRuntime constructs the single-chain interop world
+// without supernode wiring.
+func NewMinimalInteropNoSupernodeRuntime(t devtest.T) *SingleChainRuntime {
 	return newSingleChainRuntimeWithConfig(t, PresetConfig{}, singleChainRuntimeSpec{
-		BuildWorld:      newSingleChainInteropWorldNoSupervisor,
-		StartPrimary:    startSingleChainInteropPrimaryNoSupervisor,
+		BuildWorld:      newSingleChainInteropWorldNoSupernode,
+		StartPrimary:    startSingleChainInteropPrimaryNoSupernode,
 		StartBatcher:    true,
 		StartProposer:   true,
 		StartChallenger: false,
+	})
+}
+
+// NewSingleChainInteropNoSupernodeSuperRootRuntimeWithConfig constructs a single-chain
+// interop world with no supernode, running an op-challenger that plays super-cannon-kona
+// games sourcing super roots directly from the op-node's superroot_atTimestamp endpoint.
+// The primary op-node enables its safe DB (required by superroot_atTimestamp).
+func NewSingleChainInteropNoSupernodeSuperRootRuntimeWithConfig(t devtest.T, cfg PresetConfig) *SingleChainRuntime {
+	cfg.AddedGameTypes = append(cfg.AddedGameTypes, gameTypes.SuperCannonKonaGameType)
+	return newSingleChainRuntimeWithConfig(t, cfg, singleChainRuntimeSpec{
+		BuildWorld:      newSingleChainInteropWorldNoSupernode,
+		StartPrimary:    startDefaultSingleChainPrimary,
+		StartBatcher:    true,
+		StartProposer:   false,
+		StartChallenger: true,
 	})
 }

--- a/op-devstack/sysgo/singlechain_interop.go
+++ b/op-devstack/sysgo/singlechain_interop.go
@@ -68,6 +68,7 @@ func NewMinimalInteropNoSupernodeRuntime(t devtest.T) *SingleChainRuntime {
 // games sourcing super roots directly from the op-node's superroot_atTimestamp endpoint.
 // The primary op-node enables its safe DB (required by superroot_atTimestamp).
 func NewSingleChainInteropNoSupernodeSuperRootRuntimeWithConfig(t devtest.T, cfg PresetConfig) *SingleChainRuntime {
+	cfg = withSuperRootGamesAtGenesisDeployerFeatures(cfg)
 	cfg.AddedGameTypes = append(cfg.AddedGameTypes, gameTypes.SuperCannonKonaGameType)
 	return newSingleChainRuntimeWithConfig(t, cfg, singleChainRuntimeSpec{
 		BuildWorld:      newSingleChainInteropWorldNoSupernode,

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -183,7 +183,7 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 
 // SingleChainRuntime is the shared DAG runtime for single-chain preset topologies.
 // It is the root for minimal, flashblocks, follower-node, sync-tester, conductor,
-// and no-supervisor interop variants.
+// and no-supernode interop variants.
 func NewMinimalRuntime(t devtest.T) *SingleChainRuntime {
 	return NewMinimalRuntimeWithConfig(t, PresetConfig{})
 }

--- a/op-node/node/superroot_api.go
+++ b/op-node/node/superroot_api.go
@@ -35,20 +35,9 @@ func (s *superrootAPI) AtTimestamp(ctx context.Context, timestamp hexutil.Uint64
 func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
 	chainID := eth.ChainIDFromBig(s.cfg.L2ChainID)
 
-	// Pre-genesis timestamps (e.g. a super dispute game's initial anchor, which can
-	// be timestamp 0) clamp to the genesis L2 block. op-supernode returns the genesis
-	// super root here; matching it lets op-challenger validate a super game's starting
-	// anchor root when op-node is the super root source. The response's super root still
-	// embeds the requested timestamp, as op-supernode does.
-	var blockNum uint64
-	if timestamp < s.cfg.Genesis.L2Time {
-		blockNum = s.cfg.Genesis.L2.Number
-	} else {
-		var err error
-		blockNum, err = s.cfg.TargetBlockNumber(timestamp)
-		if err != nil {
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("target block number for timestamp %d: %w", timestamp, err)
-		}
+	blockNum, err := s.cfg.TargetBlockNumber(timestamp)
+	if err != nil {
+		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("target block number for timestamp %d: %w", timestamp, err)
 	}
 
 	// BlockRefWithStatus returns a non-nil status alongside ethereum.NotFound, so the

--- a/op-node/node/superroot_api.go
+++ b/op-node/node/superroot_api.go
@@ -35,9 +35,20 @@ func (s *superrootAPI) AtTimestamp(ctx context.Context, timestamp hexutil.Uint64
 func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
 	chainID := eth.ChainIDFromBig(s.cfg.L2ChainID)
 
-	blockNum, err := s.cfg.TargetBlockNumber(timestamp)
-	if err != nil {
-		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("target block number for timestamp %d: %w", timestamp, err)
+	// Pre-genesis timestamps (e.g. a super dispute game's initial anchor, which can
+	// be timestamp 0) clamp to the genesis L2 block. op-supernode returns the genesis
+	// super root here; matching it lets op-challenger validate a super game's starting
+	// anchor root when op-node is the super root source. The response's super root still
+	// embeds the requested timestamp, as op-supernode does.
+	var blockNum uint64
+	if timestamp < s.cfg.Genesis.L2Time {
+		blockNum = s.cfg.Genesis.L2.Number
+	} else {
+		var err error
+		blockNum, err = s.cfg.TargetBlockNumber(timestamp)
+		if err != nil {
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("target block number for timestamp %d: %w", timestamp, err)
+		}
 	}
 
 	// BlockRefWithStatus returns a non-nil status alongside ethereum.NotFound, so the

--- a/op-node/node/superroot_api_test.go
+++ b/op-node/node/superroot_api_test.go
@@ -116,52 +116,15 @@ func (f *fixture) expectOutputV0(hash common.Hash) *eth.OutputV0 {
 }
 
 func TestSuperrootAPI_PreGenesis(t *testing.T) {
-	// Pre-genesis timestamps (e.g. a super dispute game's initial anchor, which
-	// can be timestamp 0) clamp to the genesis L2 block and return the genesis
-	// super root at the requested timestamp. op-supernode does the same; matching
-	// it lets op-challenger validate a super game's starting anchor root when
-	// op-node is the super root source.
+	// Pre-genesis: surface TargetBlockNumber's error rather than a silent empty response.
 	f := newFixture(t)
 
 	genesisHash := f.cfg.Genesis.L2.Hash
 	f.expectBlockRef(0, genesisHash, eth.BlockID{Number: 0})
-	output := f.expectOutputV0(genesisHash)
+	f.expectOutputV0(genesisHash)
 
-	const preGenesisTs = testGenesisL2Ts - 1
-	resp, err := f.api.atTimestamp(context.Background(), preGenesisTs)
-	require.NoError(t, err)
-	require.NotNil(t, resp.Data)
-	require.Equal(t, eth.BlockID{Number: 0}, resp.Data.VerifiedRequiredL1)
-	require.Equal(t, eth.OutputRoot(output), resp.OptimisticAtTimestamp[f.chainID].OutputRoot)
-	require.Equal(t, eth.BlockID{Number: 0}, resp.OptimisticAtTimestamp[f.chainID].RequiredL1)
-
-	// The super root embeds the requested (pre-genesis) timestamp, not the genesis
-	// time, matching op-supernode's handoff-from-optimistic behavior.
-	expectedSuper := eth.NewSuperV1(preGenesisTs, eth.ChainIDAndOutput{
-		ChainID: f.chainID,
-		Output:  eth.OutputRoot(output),
-	})
-	require.Equal(t, eth.SuperRoot(expectedSuper), resp.Data.SuperRoot)
-	f.safeDB.Mock.AssertNotCalled(t, "L1AtSafeHead")
-}
-
-func TestSuperrootAPI_TimestampZero_ClampsToGenesis(t *testing.T) {
-	// Timestamp 0 is the concrete case exercised by a fresh super dispute game's
-	// anchor: it must resolve to the genesis super root rather than erroring.
-	f := newFixture(t)
-
-	genesisHash := f.cfg.Genesis.L2.Hash
-	f.expectBlockRef(0, genesisHash, eth.BlockID{Number: 0})
-	output := f.expectOutputV0(genesisHash)
-
-	resp, err := f.api.atTimestamp(context.Background(), 0)
-	require.NoError(t, err)
-	require.NotNil(t, resp.Data)
-	expectedSuper := eth.NewSuperV1(0, eth.ChainIDAndOutput{
-		ChainID: f.chainID,
-		Output:  eth.OutputRoot(output),
-	})
-	require.Equal(t, eth.SuperRoot(expectedSuper), resp.Data.SuperRoot)
+	_, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts-1)
+	require.ErrorContains(t, err, "target block number")
 }
 
 func TestSuperrootAPI_BeyondUnsafe(t *testing.T) {

--- a/op-node/node/superroot_api_test.go
+++ b/op-node/node/superroot_api_test.go
@@ -116,11 +116,52 @@ func (f *fixture) expectOutputV0(hash common.Hash) *eth.OutputV0 {
 }
 
 func TestSuperrootAPI_PreGenesis(t *testing.T) {
-	// Pre-genesis: surface TargetBlockNumber's error rather than a silent empty response.
+	// Pre-genesis timestamps (e.g. a super dispute game's initial anchor, which
+	// can be timestamp 0) clamp to the genesis L2 block and return the genesis
+	// super root at the requested timestamp. op-supernode does the same; matching
+	// it lets op-challenger validate a super game's starting anchor root when
+	// op-node is the super root source.
 	f := newFixture(t)
 
-	_, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts-1)
-	require.ErrorContains(t, err, "target block number")
+	genesisHash := f.cfg.Genesis.L2.Hash
+	f.expectBlockRef(0, genesisHash, eth.BlockID{Number: 0})
+	output := f.expectOutputV0(genesisHash)
+
+	const preGenesisTs = testGenesisL2Ts - 1
+	resp, err := f.api.atTimestamp(context.Background(), preGenesisTs)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Data)
+	require.Equal(t, eth.BlockID{Number: 0}, resp.Data.VerifiedRequiredL1)
+	require.Equal(t, eth.OutputRoot(output), resp.OptimisticAtTimestamp[f.chainID].OutputRoot)
+	require.Equal(t, eth.BlockID{Number: 0}, resp.OptimisticAtTimestamp[f.chainID].RequiredL1)
+
+	// The super root embeds the requested (pre-genesis) timestamp, not the genesis
+	// time, matching op-supernode's handoff-from-optimistic behavior.
+	expectedSuper := eth.NewSuperV1(preGenesisTs, eth.ChainIDAndOutput{
+		ChainID: f.chainID,
+		Output:  eth.OutputRoot(output),
+	})
+	require.Equal(t, eth.SuperRoot(expectedSuper), resp.Data.SuperRoot)
+	f.safeDB.Mock.AssertNotCalled(t, "L1AtSafeHead")
+}
+
+func TestSuperrootAPI_TimestampZero_ClampsToGenesis(t *testing.T) {
+	// Timestamp 0 is the concrete case exercised by a fresh super dispute game's
+	// anchor: it must resolve to the genesis super root rather than erroring.
+	f := newFixture(t)
+
+	genesisHash := f.cfg.Genesis.L2.Hash
+	f.expectBlockRef(0, genesisHash, eth.BlockID{Number: 0})
+	output := f.expectOutputV0(genesisHash)
+
+	resp, err := f.api.atTimestamp(context.Background(), 0)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Data)
+	expectedSuper := eth.NewSuperV1(0, eth.ChainIDAndOutput{
+		ChainID: f.chainID,
+		Output:  eth.OutputRoot(output),
+	})
+	require.Equal(t, eth.SuperRoot(expectedSuper), resp.Data.SuperRoot)
 }
 
 func TestSuperrootAPI_BeyondUnsafe(t *testing.T) {


### PR DESCRIPTION
Adds acceptance-test coverage for op-challenger sourcing super roots from a single op-node (`superroot_atTimestamp`) instead of op-supernode, and fixes the one op-node gap that blocked it.

- New `dsl.SuperRootSource` interface makes the dispute-game DSL source-agnostic. A shared `dsl.SuperRootQuerier` implements it over any query API — used directly as the op-node source (`NewOpNodeSuperRoots`) and embedded by `Supernode` (which adds op-supernode-only controls). New `NewSingleChainInteropNoSupernode` preset wires op-challenger to an op-node super-root source with no supernode.
- `TestChallengerPlaysGameFromOpNode` — challenger counters a bad claim, op-node-sourced.
- `TestSingleChainSuperFaultProofsFromOpNode` — single-chain super-fault-proof smoke test (FPP + challenger trace provider), op-node-sourced.
- op-node's `superroot_atTimestamp` now clamps pre-genesis timestamps to the genesis super root, matching op-supernode. A fresh super dispute game's anchor is at timestamp 0; without this the challenger can't validate the game's starting anchor root against op-node and never plays the game.

Also renames the stale `NoSupervisor` naming (supervisor was replaced by supernode) to `NoSupernode` across the affected devstack presets/runtimes and their callers.

Closes https://github.com/ethereum-optimism/optimism/issues/21726

## Test plan
Both acceptance tests pass locally (challenger 218s, smoke 43s). op-node superroot unit tests cover the pre-genesis clamp (`TestSuperrootAPI_PreGenesis`, `TestSuperrootAPI_TimestampZero_ClampsToGenesis`).
