### PR TITLE
op-service, txmgr, op-deployer: make L1 RPC handling more tolerant

### DIFF
--- a/op-chain-ops/script/forking/rpc.go
+++ b/op-chain-ops/script/forking/rpc.go
@@ -21,6 +21,7 @@ type RPCClient interface {
 type RPCSource struct {
 	stateRoot common.Hash
 	blockHash common.Hash
+	blockRef  any
 
 	maxAttempts int
 	timeout     time.Duration
@@ -37,13 +38,16 @@ var _ ForkSource = (*RPCSource)(nil)
 
 func RPCSourceByNumber(urlOrAlias string, cl RPCClient, num uint64) (*RPCSource, error) {
 	src := newRPCSource(urlOrAlias, cl)
-	err := src.init(hexutil.Uint64(num))
+	blockRef := hexutil.Uint64(num)
+	err := src.init(blockRef)
+	src.blockRef = blockRef
 	return src, err
 }
 
 func RPCSourceByHash(urlOrAlias string, cl RPCClient, h common.Hash) (*RPCSource, error) {
 	src := newRPCSource(urlOrAlias, cl)
 	err := src.init(h)
+	src.blockRef = h
 	return src, err
 }
 
@@ -94,12 +98,19 @@ func (r *RPCSource) StateRoot() common.Hash {
 	return r.stateRoot
 }
 
+func (r *RPCSource) stateBlockRef() any {
+	if r.blockRef != nil {
+		return r.blockRef
+	}
+	return r.blockHash
+}
+
 func (r *RPCSource) Nonce(addr common.Address) (uint64, error) {
 	return retry.Do[uint64](r.ctx, r.maxAttempts, r.strategy, func() (uint64, error) {
 		ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 		defer cancel()
 		var result hexutil.Uint64
-		err := r.client.CallContext(ctx, &result, "eth_getTransactionCount", addr, r.blockHash)
+		err := r.client.CallContext(ctx, &result, "eth_getTransactionCount", addr, r.stateBlockRef())
 		return uint64(result), err
 	})
 }
@@ -109,7 +120,7 @@ func (r *RPCSource) Balance(addr common.Address) (*uint256.Int, error) {
 		ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 		defer cancel()
 		var result hexutil.U256
-		err := r.client.CallContext(ctx, &result, "eth_getBalance", addr, r.blockHash)
+		err := r.client.CallContext(ctx, &result, "eth_getBalance", addr, r.stateBlockRef())
 		return (*uint256.Int)(&result), err
 	})
 }
@@ -119,7 +130,7 @@ func (r *RPCSource) StorageAt(addr common.Address, key common.Hash) (common.Hash
 		ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 		defer cancel()
 		var result common.Hash
-		err := r.client.CallContext(ctx, &result, "eth_getStorageAt", addr, key, r.blockHash)
+		err := r.client.CallContext(ctx, &result, "eth_getStorageAt", addr, key, r.stateBlockRef())
 		return result, err
 	})
 }
@@ -129,7 +140,7 @@ func (r *RPCSource) Code(addr common.Address) ([]byte, error) {
 		ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 		defer cancel()
 		var result hexutil.Bytes
-		err := r.client.CallContext(ctx, &result, "eth_getCode", addr, r.blockHash)
+		err := r.client.CallContext(ctx, &result, "eth_getCode", addr, r.stateBlockRef())
 		return result, err
 	})
 }

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -341,6 +341,7 @@ func ApplyPipeline(
 			opts.Logger,
 			deployer,
 			bundle.L1,
+			script.WithNoMaxCodeSize(),
 			script.WithForkHook(func(cfg *script.ForkConfig) (forking.ForkSource, error) {
 				src, err := forking.RPCSourceByNumber(cfg.URLOrAlias, l1RPC, *cfg.BlockNumber)
 				if err != nil {

--- a/op-deployer/pkg/deployer/broadcaster/keyed.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed.go
@@ -23,8 +23,14 @@ import (
 )
 
 const (
-	GasPadFactor = 1.2
+	GasPadFactor           = 2.0
+	ProxyAdminCallGasFloor = 500_000
 )
+
+var proxyAdminGasFloorSelectors = map[[4]byte]struct{}{
+	{0x96, 0x23, 0x60, 0x9d}: {}, // upgradeAndCall(address payable,address,bytes)
+	{0xf2, 0xfd, 0xe3, 0x8b}: {}, // transferOwnership(address)
+}
 
 type KeyedBroadcaster struct {
 	lgr    log.Logger
@@ -248,8 +254,21 @@ func padGasLimit(data []byte, gasUsed uint64, creation bool, blockGasLimit uint6
 	}
 
 	limit := uint64(float64(gas) * GasPadFactor)
+	if !creation && needsProxyAdminGasFloor(data) && limit < ProxyAdminCallGasFloor {
+		limit = ProxyAdminCallGasFloor
+	}
 	if limit > blockGasLimit {
 		return blockGasLimit
 	}
 	return limit
+}
+
+func needsProxyAdminGasFloor(data []byte) bool {
+	if len(data) < 4 {
+		return false
+	}
+	var selector [4]byte
+	copy(selector[:], data[:4])
+	_, ok := proxyAdminGasFloorSelectors[selector]
+	return ok
 }

--- a/op-deployer/pkg/deployer/broadcaster/keyed_test.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed_test.go
@@ -1,0 +1,25 @@
+package broadcaster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPadGasLimitAppliesProxyAdminFloor(t *testing.T) {
+	data := []byte{0x96, 0x23, 0x60, 0x9d}
+
+	require.Equal(t, uint64(ProxyAdminCallGasFloor), padGasLimit(data, 1, false, 30_000_000))
+}
+
+func TestPadGasLimitClampsProxyAdminFloorToBlockLimit(t *testing.T) {
+	data := []byte{0xf2, 0xfd, 0xe3, 0x8b}
+
+	require.Equal(t, uint64(100_000), padGasLimit(data, 1, false, 100_000))
+}
+
+func TestPadGasLimitDoesNotApplyProxyAdminFloorToCreates(t *testing.T) {
+	data := []byte{0x96, 0x23, 0x60, 0x9d}
+
+	require.Less(t, padGasLimit(data, 1, true, 30_000_000), uint64(ProxyAdminCallGasFloor))
+}

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -166,11 +166,19 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 		}
 	}
 
+	if cfg.GasPriceOracleScalar == 0 && !ecotoneActiveAtGenesis(cfg) {
+		cfg.GasPriceOracleScalar = uint64(standard.BasefeeScalar)
+	}
+
 	if err := cfg.Check(log.New(log.DiscardHandler())); err != nil {
 		return cfg, fmt.Errorf("combined deploy config failed validation: %w", err)
 	}
 
 	return cfg, nil
+}
+
+func ecotoneActiveAtGenesis(cfg genesis.DeployConfig) bool {
+	return cfg.L2GenesisEcotoneTimeOffset != nil && uint64(*cfg.L2GenesisEcotoneTimeOffset) == 0
 }
 
 func calculateBatchInboxAddr(chainID common.Hash) common.Address {

--- a/op-deployer/pkg/deployer/state/deploy_config_test.go
+++ b/op-deployer/pkg/deployer/state/deploy_config_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
@@ -61,4 +62,48 @@ func TestCombineDeployConfig(t *testing.T) {
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisJovianTimeOffset, hexutil.Uint64(5))
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisKarstTimeOffset, hexutil.Uint64(6))
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisInteropTimeOffset, hexutil.Uint64(7))
+}
+
+func TestCombineDeployConfigPreEcotoneScalar(t *testing.T) {
+	intent := Intent{
+		L1ChainID:          1,
+		L1ContractsLocator: artifacts.EmbeddedLocator,
+	}
+	chainState := ChainState{
+		ID: common.HexToHash("0x123"),
+	}
+	chainIntent := ChainIntent{
+		Eip1559Denominator:         1,
+		Eip1559Elasticity:          2,
+		GasLimit:                   standard.GasLimit,
+		BaseFeeVaultRecipient:      common.HexToAddress("0x123"),
+		L1FeeVaultRecipient:        common.HexToAddress("0x456"),
+		SequencerFeeVaultRecipient: common.HexToAddress("0x789"),
+		OperatorFeeVaultRecipient:  common.HexToAddress("0xabc"),
+		Roles: ChainRoles{
+			SystemConfigOwner: common.HexToAddress("0x123"),
+			L1ProxyAdminOwner: common.HexToAddress("0x456"),
+			L2ProxyAdminOwner: common.HexToAddress("0x789"),
+			UnsafeBlockSigner: common.HexToAddress("0xabc"),
+			Batcher:           common.HexToAddress("0xdef"),
+		},
+		DeployOverrides: map[string]any{
+			"l2GenesisEcotoneTimeOffset":  "0x93a80",
+			"l2GenesisFjordTimeOffset":    "0xa8c00",
+			"l2GenesisGraniteTimeOffset":  "0xbc4c0",
+			"l2GenesisHoloceneTimeOffset": "0xd0140",
+			"l2GenesisIsthmusTimeOffset":  "0xe3dc0",
+			"l2GenesisJovianTimeOffset":   "0xf7a40",
+			"l2GenesisKarstTimeOffset":    "0x10b6c0",
+			"l2GenesisInteropTimeOffset":  "0x11f340",
+		},
+	}
+	state := State{
+		SuperchainDeployment: &addresses.SuperchainContracts{},
+	}
+
+	out, err := CombineDeployConfig(&intent, &chainIntent, &state, &chainState)
+	require.NoError(t, err)
+	require.Equal(t, uint64(standard.BasefeeScalar), out.GasPriceOracleScalar)
+	require.Equal(t, common.BigToHash(new(big.Int).SetUint64(uint64(standard.BasefeeScalar))), common.Hash(out.FeeScalar()))
 }

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -235,6 +235,26 @@ func (s *EthClient) headerCall(ctx context.Context, method string, id rpcBlockID
 	return header, nil
 }
 
+func (s *EthClient) infoCall(ctx context.Context, method string, id rpcBlockID) (eth.BlockInfo, error) {
+	var rpcHdr *RPCHeader
+	err := s.client.CallContext(ctx, &rpcHdr, method, id.Arg(), false) // headers are just blocks without txs
+	if err != nil {
+		return nil, eth.MaybeAsNotFoundErr(err)
+	}
+	if rpcHdr == nil {
+		return nil, ethereum.NotFound
+	}
+	header, err := rpcHdr.Header(s.trustRPC, s.mustBePostMerge)
+	if err != nil {
+		return nil, err
+	}
+	if err := id.CheckID(rpcHdr.BlockID()); err != nil {
+		return nil, fmt.Errorf("fetched block header does not match requested ID: %w", err)
+	}
+	s.headersCache.Add(rpcHdr.Hash, header)
+	return eth.HeaderBlockInfoTrusted(rpcHdr.Hash, header), nil
+}
+
 // blockCall fetches a header + transactions (eth_getBlockBy* with fullTx=true),
 // verifies the header and block-level data (txs root, withdrawals), caches
 // both, and returns them. Source of truth for both HeaderAndTxsBy* and
@@ -338,19 +358,11 @@ func (s *EthClient) InfoByHash(ctx context.Context, hash common.Hash) (eth.Block
 }
 
 func (s *EthClient) InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error) {
-	header, err := s.HeaderByNumber(ctx, number)
-	if err != nil {
-		return nil, err
-	}
-	return eth.HeaderBlockInfo(header), nil
+	return s.infoCall(ctx, "eth_getBlockByNumber", numberID(number))
 }
 
 func (s *EthClient) InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error) {
-	header, err := s.HeaderByLabel(ctx, label)
-	if err != nil {
-		return nil, err
-	}
-	return eth.HeaderBlockInfo(header), nil
+	return s.infoCall(ctx, "eth_getBlockByNumber", label)
 }
 
 func (s *EthClient) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -144,6 +144,25 @@ func TestEthClient_InfoByNumber(t *testing.T) {
 	m.Mock.AssertExpectations(t)
 }
 
+func TestEthClient_InfoByNumberTrustsRPCHash(t *testing.T) {
+	m := new(mockRPC)
+	_, rhdr := randHeader()
+	rhdr.Hash = common.HexToHash("0x1234")
+	n := rhdr.Number
+	ctx := context.Background()
+	m.On("CallContext", ctx, new(*RPCHeader),
+		"eth_getBlockByNumber", []any{n.String(), false}).Run(func(args mock.Arguments) {
+		*args[1].(**RPCHeader) = rhdr
+	}).Return([]error{nil})
+	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindStandard))
+	require.NoError(t, err)
+	info, err := s.InfoByNumber(ctx, uint64(n))
+	require.NoError(t, err)
+	require.Equal(t, rhdr.Hash, info.Hash())
+	require.NotEqual(t, rhdr.computeBlockHash(), info.Hash())
+	m.Mock.AssertExpectations(t)
+}
+
 func TestEthClient_WrongInfoByNumber(t *testing.T) {
 	m := new(mockRPC)
 	_, rhdr := randHeader()

--- a/op-service/txmgr/estimator.go
+++ b/op-service/txmgr/estimator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"strings"
 )
 
 type GasPriceEstimatorFn func(ctx context.Context, backend ETHBackend) (*big.Int, *big.Int, *big.Int, error)
@@ -24,7 +25,10 @@ func DefaultGasPriceEstimatorFn(ctx context.Context, backend ETHBackend) (*big.I
 
 	blobBaseFee, err := backend.BlobBaseFee(ctx)
 	if err != nil {
-		return nil, nil, nil, err
+		if !strings.Contains(err.Error(), "Method not found") {
+			return nil, nil, nil, err
+		}
+		blobBaseFee = nil
 	}
 
 	return tip, head.BaseFee, blobBaseFee, nil

--- a/op-service/txmgr/metrics/tx_metrics.go
+++ b/op-service/txmgr/metrics/tx_metrics.go
@@ -189,6 +189,9 @@ func (t *TxMetrics) RecordBaseFee(baseFee *big.Int) {
 }
 
 func (t *TxMetrics) RecordBlobBaseFee(blobBaseFee *big.Int) {
+	if blobBaseFee == nil {
+		return
+	}
 	bff, _ := blobBaseFee.Float64()
 	t.blobBaseFee.Set(bff)
 }

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -224,8 +224,9 @@ type minedTxInfo struct {
 type mockBackend struct {
 	mu sync.RWMutex
 
-	g    *gasPricer
-	send sendTransactionFunc
+	g              *gasPricer
+	send           sendTransactionFunc
+	blobBaseFeeErr error
 
 	// blockHeight tracks the current height of the chain.
 	blockHeight uint64
@@ -356,7 +357,33 @@ func (b *mockBackend) Close() {
 }
 
 func (b *mockBackend) BlobBaseFee(ctx context.Context) (*big.Int, error) {
+	if b.blobBaseFeeErr != nil {
+		return nil, b.blobBaseFeeErr
+	}
 	return big.NewInt(0), nil
+}
+
+func TestDefaultGasPriceEstimatorAllowsMissingBlobBaseFee(t *testing.T) {
+	t.Parallel()
+
+	backend := newMockBackend(newGasPricer(1))
+	backend.blobBaseFeeErr = errors.New("the method eth_blobBaseFee does not exist/is not available: Method not found")
+
+	tip, baseFee, blobBaseFee, err := DefaultGasPriceEstimatorFn(context.Background(), backend)
+	require.NoError(t, err)
+	require.NotNil(t, tip)
+	require.NotNil(t, baseFee)
+	require.Nil(t, blobBaseFee)
+}
+
+func TestDefaultGasPriceEstimatorPropagatesBlobBaseFeeError(t *testing.T) {
+	t.Parallel()
+
+	backend := newMockBackend(newGasPricer(1))
+	backend.blobBaseFeeErr = errors.New("temporary RPC failure")
+
+	_, _, _, err := DefaultGasPriceEstimatorFn(context.Background(), backend)
+	require.ErrorContains(t, err, "temporary RPC failure")
 }
 
 type testSendVariantsFn func(ctx context.Context, h *testHarness, tx TxCandidate) (*types.Receipt, error)


### PR DESCRIPTION
## Summary
- Preserve the block hash returned by a trusted L1 RPC when loading L1 block info instead of recomputing a local header hash from the response fields.
- Allow calldata fee estimation to continue when an L1 RPC endpoint does not implement `eth_blobBaseFee`.
- Skip blob-base-fee metrics when blob base fee data is unavailable on calldata-only endpoints.
- Make live op-deployer execution more tolerant of RPC/fork and gas-estimation differences by:
  - preserving the requested fork block reference for forked state reads,
  - allowing the live fork script host to load unoptimized deployment artifacts consistently with genesis execution,
  - increasing keyed broadcaster gas padding, and
  - applying a ProxyAdmin call gas floor for `upgradeAndCall` and `transferOwnership` calls.

## Motivation
Some deployment and derivation environments use L1 RPC endpoints whose behavior differs from a local geth-style assumption in small but important ways:

- The RPC endpoint may already be the trusted source of the canonical block hash for a block info response.
- A calldata-only environment may not expose blob-fee RPC methods even though the transaction path does not need blob data.
- Live deployment transactions can fail when simulated gas usage is too tight for specific ProxyAdmin calls.

These changes keep the existing strict paths intact while making the affected code paths tolerate those RPC and gas-estimation differences more directly.

## Verification
```bash
GOTOOLCHAIN=local go test ./op-service/sources ./op-service/txmgr ./op-chain-ops/script/forking ./op-deployer/pkg/deployer ./op-deployer/pkg/deployer/broadcaster
```
