### PR TITLE
op-reth: fix secure flashblocks-url bug

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13402,6 +13402,7 @@ dependencies = [
  "reth-tasks",
  "reth-trie-common",
  "ringbuffer",
+ "rustls",
  "serde_json",
  "test-case",
  "tokio",

--- a/rust/op-rbuilder/Cargo.lock
+++ b/rust/op-rbuilder/Cargo.lock
@@ -11438,6 +11438,7 @@ dependencies = [
  "reth-tasks",
  "reth-trie-common",
  "ringbuffer",
+ "rustls",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.28.0",

--- a/rust/op-reth/crates/flashblocks/Cargo.toml
+++ b/rust/op-reth/crates/flashblocks/Cargo.toml
@@ -41,7 +41,7 @@ op-alloy-rpc-types-engine = { workspace = true, features = ["k256"] }
 # io
 tokio.workspace = true
 tokio-tungstenite.workspace = true
-rustls = { workspace = true, features = ["ring"] }
+rustls = { workspace = true, features = ["aws-lc-rs"] }
 serde_json.workspace = true
 url.workspace = true
 futures-util.workspace = true

--- a/rust/op-reth/crates/flashblocks/Cargo.toml
+++ b/rust/op-reth/crates/flashblocks/Cargo.toml
@@ -41,6 +41,7 @@ op-alloy-rpc-types-engine = { workspace = true, features = ["k256"] }
 # io
 tokio.workspace = true
 tokio-tungstenite.workspace = true
+rustls = { workspace = true, features = ["ring"] }
 serde_json.workspace = true
 url.workspace = true
 futures-util.workspace = true

--- a/rust/op-reth/crates/flashblocks/src/ws/stream.rs
+++ b/rust/op-reth/crates/flashblocks/src/ws/stream.rs
@@ -292,7 +292,7 @@ mod tests {
         }
         let after = rustls::crypto::CryptoProvider::get_default();
         assert!(
-            std::ptr::eq(first.as_deref().unwrap(), after.as_deref().unwrap()),
+            std::ptr::eq(first.unwrap(), after.unwrap()),
             "repeated calls must not replace the provider"
         );
     }

--- a/rust/op-reth/crates/flashblocks/src/ws/stream.rs
+++ b/rust/op-reth/crates/flashblocks/src/ws/stream.rs
@@ -231,10 +231,29 @@ impl WsConnect for WsConnector {
     type Sink = WsSink;
 
     async fn connect(&mut self, ws_url: Url) -> eyre::Result<(WsSink, WsStream)> {
+        ensure_crypto_provider();
+
         let (stream, _response) = connect_async(ws_url.as_str()).await?;
 
         Ok(stream.split())
     }
+}
+
+/// Installs a process-level rustls [`CryptoProvider`] for `wss://` (TLS) connections.
+///
+/// `rustls` cannot automatically select a provider when more than one is present in the
+/// dependency graph (both `aws-lc-rs` and `ring` are), so it panics on the first TLS handshake
+/// unless a default has been installed. We install the `ring` provider once, but only if no other
+/// component already installed one, so this stays idempotent and non-clobbering.
+///
+/// [`CryptoProvider`]: rustls::crypto::CryptoProvider
+fn ensure_crypto_provider() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        if rustls::crypto::CryptoProvider::get_default().is_none() {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        }
+    });
 }
 
 #[cfg(test)]

--- a/rust/op-reth/crates/flashblocks/src/ws/stream.rs
+++ b/rust/op-reth/crates/flashblocks/src/ws/stream.rs
@@ -243,17 +243,23 @@ impl WsConnect for WsConnector {
 ///
 /// `rustls` cannot automatically select a provider when more than one is present in the
 /// dependency graph (both `aws-lc-rs` and `ring` are), so it panics on the first TLS handshake
-/// unless a default has been installed. We install the `ring` provider once, but only if no other
-/// component already installed one, so this stays idempotent and non-clobbering.
+/// unless a default has been installed. We install the `aws-lc-rs` provider once, but only if no
+/// other component already installed one, so this stays idempotent and non-clobbering.
+///
+/// `aws-lc-rs` is chosen over `ring` because it is the provider most likely to have already been
+/// installed by an upstream dependency (`rustls-webpki` and others pull it in). Since
+/// [`install_default`] is process-global and first-wins, matching `aws-lc-rs` minimizes the chance
+/// this lazy install races with and disagrees with whatever a dependency installed first.
 ///
 /// [`CryptoProvider`]: rustls::crypto::CryptoProvider
+/// [`install_default`]: rustls::crypto::CryptoProvider::install_default
 fn ensure_crypto_provider() {
-    static INIT: std::sync::Once = std::sync::Once::new();
-    INIT.call_once(|| {
+    static INIT: std::sync::LazyLock<()> = std::sync::LazyLock::new(|| {
         if rustls::crypto::CryptoProvider::get_default().is_none() {
-            let _ = rustls::crypto::ring::default_provider().install_default();
+            let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         }
     });
+    std::sync::LazyLock::force(&INIT);
 }
 
 #[cfg(test)]
@@ -266,6 +272,30 @@ mod tests {
         Error,
         protocol::frame::{Frame, coding::CloseCode},
     };
+
+    #[test]
+    fn ensure_crypto_provider_installs_a_default() {
+        ensure_crypto_provider();
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_some(),
+            "a process-level CryptoProvider should be installed after the call"
+        );
+    }
+
+    #[test]
+    fn ensure_crypto_provider_is_idempotent() {
+        // Must not panic on repeated calls, and the installed provider must not change.
+        ensure_crypto_provider();
+        let first = rustls::crypto::CryptoProvider::get_default();
+        for _ in 0..5 {
+            ensure_crypto_provider();
+        }
+        let after = rustls::crypto::CryptoProvider::get_default();
+        assert!(
+            std::ptr::eq(first.as_deref().unwrap(), after.as_deref().unwrap()),
+            "repeated calls must not replace the provider"
+        );
+    }
 
     /// A `FakeConnector` creates [`FakeStream`].
     ///

--- a/rust/rollup-boost/Cargo.lock
+++ b/rust/rollup-boost/Cargo.lock
@@ -9215,6 +9215,7 @@ dependencies = [
  "reth-tasks",
  "reth-trie-common",
  "ringbuffer",
+ "rustls",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.28.0",


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

Using a wss:// flashblocks-url made op-reth incapable of consuming flashblocks.
(real example under "Tests")

**Tests**

Before this PR - image: `us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.4.0-rc.1@sha256:062e63cc089247c752bfdfbd73e41cbffafa0a863ad3c5b1c3082745eafdb883`

```
thread 'tokio-rt' (126) panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustls-0.23.38/src/crypto/mod.rs:249:14:

Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
See the documentation of the CryptoProvider type for more information.

stack backtrace:
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

After this PR - image ->. a dev image built out of this PR

```
ts=2026-07-20T18:17:53.110994958Z level=trace target=flashblocks message="Tracking new flashblock sequence" number=154486349
ts=2026-07-20T18:17:53.123299801Z level=trace target=flashblocks message="Received followup flashblock" number=154486349 index=1 block_count=1
ts=2026-07-20T18:17:53.300376716Z level=trace target=flashblocks message="Received followup flashblock" number=154486349 index=2 block_count=2
ts=2026-07-20T18:17:53.717216357Z level=trace target=flashblocks message="Received followup flashblock" number=154486349 index=3 block_count=3
ts=2026-07-20T18:17:53.794249824Z level=trace target=flashblocks message="Received followup flashblock" number=154486349 index=4 block_count=4
ts=2026-07-20T18:17:54.04807122Z level=trace target=flashblocks message="Received followup flashblock" number=154486349 index=5 block_count=5
ts=2026-07-20T18:17:54.360373022Z level=trace target=flashblocks message="Received followup flashblock" number=154486349 index=6 block_count=6
ts=2026-07-20T18:17:54.583414845Z level=trace target=flashblocks message="Received followup flashblock" number=154486349 index=7 block_count=7
ts=2026-07-20T18:17:54.882467569Z level=trace target=flashblocks message="Received followup flashblock" number=154486349 index=8 block_count=8
ts=2026-07-20T18:17:55.099626737Z level=trace target=flashblocks message="Caching completed flashblock sequence" block_number=154486349 parent_hash=0x01e7ef4d89239ecbc3f168d2e4d0687fe73420357e41e30226b3f8d25d078f86 cache_size=0
ts=2026-07-20T18:17:55.099658522Z level=trace target=flashblocks message="Tracking new flashblock sequence" number=154486350
ts=2026-07-20T18:17:55.128566873Z level=trace target=flashblocks message="Received followup flashblock" number=154486350 index=1 block_count=1
ts=2026-07-20T18:17:55.342771028Z level=trace target=flashblocks message="Received followup flashblock" number=154486350 index=2 block_count=2
ts=2026-07-20T18:17:55.54628312Z level=trace target=flashblocks message="Received followup flashblock" number=154486350 index=3 block_count=3
ts=2026-07-20T18:17:55.810380694Z level=trace target=flashblocks message="Received followup flashblock" number=154486350 index=4 block_count=4
ts=2026-07-20T18:17:56.065106553Z level=trace target=flashblocks message="Received followup flashblock" number=154486350 index=5 block_count=5
ts=2026-07-20T18:17:56.31335616Z level=trace target=flashblocks message="Received followup flashblock" number=154486350 index=6 block

```

