### PR TITLE
ci: maxperf builds on bench-* tags for regression test

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -6,6 +6,7 @@ on:
       - 'develop'
     tags:
       - '*/v*'
+      - 'op-reth/bench*'
   pull_request:
     branches:
       - 'develop'


### PR DESCRIPTION
**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Add `op-reth/bench-*` to the list of tags that builds maxperf image, to be used for regression testing.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

Matches conventions on https://github.com/ethereum-optimism/benchmarking/pull/242

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

