### PR TITLE
op-core: add OP tx JSON codecs and consensus receipt encoding

### DIFF
--- a/op-core/types/post_exec_tx.go
+++ b/op-core/types/post_exec_tx.go
@@ -16,7 +16,10 @@ const PostExecTxType = 0x7D
 // PostExecTxType || Data, where Data is appended verbatim with no outer RLP
 // envelope, matching op-geth's types.PostExecTx wire format. Data is itself an
 // RLP-encoded payload, but op-geth (and this type) treat it as opaque bytes and
-// never parse it.
+// never parse it. NB: the Rust side (op-alloy TxPostExec) parses and validates
+// the payload on decode — malformed payload bytes are accepted here but
+// rejected there, a Go-lenient/Rust-strict wire-acceptance divergence inherited
+// from op-geth's design.
 type PostExecTx struct {
 	Data []byte
 }

--- a/op-core/types/receipt_consensus.go
+++ b/op-core/types/receipt_consensus.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math/big"
+	"unsafe"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -48,6 +50,10 @@ type receiptRLP struct {
 // depositReceiptRLP is the consensus encoding of a deposit (0x7E) receipt.
 // DepositNonce was introduced in Regolith; DepositReceiptVersion in Canyon,
 // indicating that the receipt hash preimage includes the nonce and version.
+// A set version implies a set nonce: post-Canyon execution always produces
+// both. The optional-field encoding of the impossible version-without-nonce
+// state is not defined cross-client (op-alloy skips the absent nonce where
+// this encoding emits an empty element).
 type depositReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
@@ -112,6 +118,40 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	default:
 		types.Receipts{&r.Receipt}.EncodeIndex(0, w)
 	}
+}
+
+// DeriveFields overrides the promoted go-ethereum method, which reads the
+// deposit nonce for contract-address derivation off the embedded receipt —
+// the shadow of the wrapper's authoritative outer field. While go-ethereum
+// resolves to op-geth, the shadows are synced before delegating; the two
+// assignments stop compiling at the final cutover and the method is rewritten
+// then.
+func (r *Receipt) DeriveFields(signer types.Signer, context types.DeriveReceiptContext) {
+	r.Receipt.DepositNonce = r.DepositNonce
+	r.Receipt.DepositReceiptVersion = r.DepositReceiptVersion
+	r.Receipt.DeriveFields(signer, context)
+}
+
+// Size overrides the promoted go-ethereum method, which measures only the
+// embedded receipt: it adds the wrapper's OP Stack extension fields and their
+// pointees, so cache accounting does not undercount wrapped receipts.
+func (r *Receipt) Size() common.StorageSize {
+	size := r.Receipt.Size()
+	size += common.StorageSize(unsafe.Sizeof(*r)) - common.StorageSize(unsafe.Sizeof(r.Receipt))
+	for _, v := range []*big.Int{r.L1GasPrice, r.L1BlobBaseFee, r.L1GasUsed, r.L1Fee} {
+		if v != nil {
+			size += common.StorageSize(unsafe.Sizeof(*v)) + common.StorageSize(v.BitLen()/8)
+		}
+	}
+	for _, v := range []*uint64{r.DepositNonce, r.DepositReceiptVersion, r.L1BaseFeeScalar, r.L1BlobBaseFeeScalar, r.OperatorFeeScalar, r.OperatorFeeConstant, r.DAFootprintGasScalar} {
+		if v != nil {
+			size += common.StorageSize(unsafe.Sizeof(*v))
+		}
+	}
+	if r.FeeScalar != nil {
+		size += common.StorageSize(unsafe.Sizeof(*r.FeeScalar))
+	}
+	return size
 }
 
 // EncodeRLP implements rlp.Encoder, overriding the promoted go-ethereum

--- a/op-core/types/receipt_consensus.go
+++ b/op-core/types/receipt_consensus.go
@@ -113,6 +113,28 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	}
 }
 
+// MarshalBinary returns the consensus encoding of the receipt, routing the
+// OP Stack synthetic receipt types (0x7E deposit, 0x7D post-exec) to this
+// package and everything else to go-ethereum. The deposit encoding reads the
+// authoritative OUTER DepositNonce/DepositReceiptVersion fields and — unlike
+// the receipts-root derivation in EncodeIndex — always includes the nonce when
+// set, matching op-geth's MarshalBinary. Inverse of UnmarshalBinary.
+func (r *Receipt) MarshalBinary() ([]byte, error) {
+	var buf bytes.Buffer
+	switch r.Type {
+	case DepositTxType:
+		buf.WriteByte(DepositTxType)
+		err := rlp.Encode(&buf, &depositReceiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs, r.DepositNonce, r.DepositReceiptVersion})
+		return buf.Bytes(), err
+	case PostExecTxType:
+		buf.WriteByte(PostExecTxType)
+		err := rlp.Encode(&buf, &receiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs})
+		return buf.Bytes(), err
+	default:
+		return r.Receipt.MarshalBinary()
+	}
+}
+
 // UnmarshalBinary decodes the consensus encoding of a receipt, routing the
 // OP Stack synthetic receipt types (0x7E deposit, 0x7D post-exec) to this
 // package and everything else to go-ethereum. The OP JSON-only fee fields

--- a/op-core/types/receipt_consensus.go
+++ b/op-core/types/receipt_consensus.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"io"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -110,6 +111,45 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 		_ = rlp.Encode(w, &receiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs})
 	default:
 		types.Receipts{&r.Receipt}.EncodeIndex(0, w)
+	}
+}
+
+// EncodeRLP implements rlp.Encoder, overriding the promoted go-ethereum
+// encoder so the OP Stack synthetic receipt types encode from this package —
+// the deposit arm reads the authoritative OUTER nonce/version fields. Like
+// go-ethereum, a typed receipt is encoded as an RLP byte string wrapping its
+// consensus envelope; legacy receipts delegate.
+func (r *Receipt) EncodeRLP(w io.Writer) error {
+	switch r.Type {
+	case DepositTxType, PostExecTxType:
+		envelope, err := r.MarshalBinary()
+		if err != nil {
+			return err
+		}
+		return rlp.Encode(w, envelope)
+	default:
+		return r.Receipt.EncodeRLP(w)
+	}
+}
+
+// DecodeRLP implements rlp.Decoder, overriding the promoted go-ethereum
+// decoder so the OP Stack synthetic receipt types route through this
+// package's OP-aware decode. Inverse of EncodeRLP.
+func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
+	kind, _, err := s.Kind()
+	switch {
+	case err != nil:
+		return err
+	case kind == rlp.String:
+		// An EIP-2718 typed receipt, wrapped as an RLP byte string.
+		b, err := s.Bytes()
+		if err != nil {
+			return err
+		}
+		return r.UnmarshalBinary(b)
+	default:
+		// A legacy receipt (RLP list); delegate to go-ethereum.
+		return r.Receipt.DecodeRLP(s)
 	}
 }
 

--- a/op-core/types/receipt_consensus.go
+++ b/op-core/types/receipt_consensus.go
@@ -1,0 +1,155 @@
+package types
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// Receipts implements types.DerivableList so the receipts root of an OP Stack
+// block can be recomputed with types.DeriveSha. The OP Stack synthetic receipt
+// types are encoded by this package; everything else delegates to go-ethereum.
+//
+// The encoding reads the OUTER Receipt fields (DepositNonce,
+// DepositReceiptVersion) — they are authoritative, per the Receipt contract.
+// Receipts must be produced through this package's decoders; a wrapper
+// hand-built around a receipt whose deposit fields live only on the embedded
+// struct encodes without them.
+type Receipts []*Receipt
+
+var _ types.DerivableList = (Receipts)(nil)
+
+// Geth returns a view of the embedded go-ethereum receipts, for boundaries
+// that operate on standard receipt fields only. The elements alias the
+// receivers' embedded structs — mutations are visible in both.
+func (rs Receipts) Geth() types.Receipts {
+	out := make(types.Receipts, len(rs))
+	for i, r := range rs {
+		out[i] = &r.Receipt
+	}
+	return out
+}
+
+// Len returns the number of receipts in the list.
+func (rs Receipts) Len() int { return len(rs) }
+
+// receiptRLP is the consensus encoding of a receipt.
+type receiptRLP struct {
+	PostStateOrStatus []byte
+	CumulativeGasUsed uint64
+	Bloom             types.Bloom
+	Logs              []*types.Log
+}
+
+// depositReceiptRLP is the consensus encoding of a deposit (0x7E) receipt.
+// DepositNonce was introduced in Regolith; DepositReceiptVersion in Canyon,
+// indicating that the receipt hash preimage includes the nonce and version.
+type depositReceiptRLP struct {
+	PostStateOrStatus []byte
+	CumulativeGasUsed uint64
+	Bloom             types.Bloom
+	Logs              []*types.Log
+	DepositNonce      *uint64 `rlp:"optional"`
+	// DepositReceiptVersion is non-nil post-Canyon; the receipt hash
+	// post-Regolith but pre-Canyon inadvertently did not include DepositNonce.
+	DepositReceiptVersion *uint64 `rlp:"optional"`
+}
+
+var (
+	receiptStatusFailedRLP     = []byte{}
+	receiptStatusSuccessfulRLP = []byte{0x01}
+)
+
+func (r *Receipt) statusEncoding() []byte {
+	if len(r.PostState) > 0 {
+		return r.PostState
+	}
+	if r.Status == types.ReceiptStatusFailed {
+		return receiptStatusFailedRLP
+	}
+	return receiptStatusSuccessfulRLP
+}
+
+func (r *Receipt) setStatus(postStateOrStatus []byte) error {
+	switch {
+	case bytes.Equal(postStateOrStatus, receiptStatusSuccessfulRLP):
+		r.Status = types.ReceiptStatusSuccessful
+	case bytes.Equal(postStateOrStatus, receiptStatusFailedRLP):
+		r.Status = types.ReceiptStatusFailed
+	case len(postStateOrStatus) == common.HashLength:
+		r.PostState = postStateOrStatus
+	default:
+		return fmt.Errorf("invalid receipt status %x", postStateOrStatus)
+	}
+	return nil
+}
+
+// EncodeIndex encodes the i'th receipt to w, for receipts-root derivation.
+//
+// The deposit arms must not be changed to delegate to a receipt's MarshalBinary:
+// for a deposit receipt with non-nil DepositNonce but nil DepositReceiptVersion
+// (post-Regolith, pre-Canyon), the hash preimage deliberately EXCLUDES the nonce
+// while MarshalBinary includes it — preserving backwards compatibility of the
+// receipts-root computation, matching op-geth.
+func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
+	r := rs[i]
+	switch r.Type {
+	case DepositTxType:
+		w.WriteByte(DepositTxType)
+		if r.DepositReceiptVersion != nil {
+			// post-Canyon receipt hash computation includes nonce and version
+			_ = rlp.Encode(w, &depositReceiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs, r.DepositNonce, r.DepositReceiptVersion})
+		} else {
+			_ = rlp.Encode(w, &receiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs})
+		}
+	case PostExecTxType:
+		w.WriteByte(PostExecTxType)
+		_ = rlp.Encode(w, &receiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs})
+	default:
+		types.Receipts{&r.Receipt}.EncodeIndex(0, w)
+	}
+}
+
+// UnmarshalBinary decodes the consensus encoding of a receipt, routing the
+// OP Stack synthetic receipt types (0x7E deposit, 0x7D post-exec) to this
+// package and everything else to go-ethereum. The OP JSON-only fee fields
+// (L1GasPrice, OperatorFeeScalar, ...) are not part of the consensus encoding
+// and remain nil.
+func (r *Receipt) UnmarshalBinary(b []byte) error {
+	if len(b) <= 1 {
+		// Legacy receipts are RLP lists (first byte >= 0xc0), so a valid
+		// 1-byte input does not exist; delegate for the canonical error.
+		return r.Receipt.UnmarshalBinary(b)
+	}
+	switch b[0] {
+	case DepositTxType:
+		var data depositReceiptRLP
+		if err := rlp.DecodeBytes(b[1:], &data); err != nil {
+			return err
+		}
+		r.Type = DepositTxType
+		r.DepositNonce = data.DepositNonce
+		r.DepositReceiptVersion = data.DepositReceiptVersion
+		// While go-ethereum resolves to op-geth, the embedded receipt carries
+		// identically-named shadow fields; keep them consistent so op-geth code
+		// reading through Geth() sees the same values. These two assignments
+		// stop compiling at the final cutover and are removed then.
+		r.Receipt.DepositNonce = data.DepositNonce
+		r.Receipt.DepositReceiptVersion = data.DepositReceiptVersion
+		r.CumulativeGasUsed, r.Bloom, r.Logs = data.CumulativeGasUsed, data.Bloom, data.Logs
+		return r.setStatus(data.PostStateOrStatus)
+	case PostExecTxType:
+		var data receiptRLP
+		if err := rlp.DecodeBytes(b[1:], &data); err != nil {
+			return err
+		}
+		r.Type = PostExecTxType
+		r.CumulativeGasUsed, r.Bloom, r.Logs = data.CumulativeGasUsed, data.Bloom, data.Logs
+		return r.setStatus(data.PostStateOrStatus)
+	default:
+		return r.Receipt.UnmarshalBinary(b)
+	}
+}

--- a/op-core/types/receipt_consensus_test.go
+++ b/op-core/types/receipt_consensus_test.go
@@ -171,6 +171,42 @@ func TestReceiptUnmarshalBinaryDifferential(t *testing.T) {
 	}
 }
 
+// TestReceiptMarshalBinaryDifferential asserts the consensus encode against
+// op-geth's MarshalBinary for every encoding arm — including the deposit arm,
+// which (unlike the receipts-root derivation) includes the nonce whenever set.
+// It will be removed in the final cutover, when the op-geth dependency is
+// replaced with upstream go-ethereum.
+func TestReceiptMarshalBinaryDifferential(t *testing.T) {
+	for i, gr := range consensusReceiptCases() {
+		theirs, err := gr.MarshalBinary()
+		require.NoError(t, err)
+
+		r := &optypes.Receipt{Receipt: *gr}
+		r.DepositNonce = gr.DepositNonce
+		r.DepositReceiptVersion = gr.DepositReceiptVersion
+		ours, err := r.MarshalBinary()
+		require.NoErrorf(t, err, "receipt %d (type %#x)", i, gr.Type)
+		require.Equalf(t, theirs, ours, "receipt %d (type %#x)", i, gr.Type)
+	}
+}
+
+// TestReceiptBinaryRoundTrip pins, op-geth-independently, that the wrapper's
+// binary codec round-trips — in particular that a deposit receipt built only
+// through this package's own decoder re-encodes identically (P2 of the #21907
+// review: the encoder must read the outer deposit fields).
+func TestReceiptBinaryRoundTrip(t *testing.T) {
+	for i, gr := range consensusReceiptCases() {
+		raw, err := gr.MarshalBinary()
+		require.NoError(t, err)
+
+		var r optypes.Receipt
+		require.NoError(t, r.UnmarshalBinary(raw))
+		reencoded, err := r.MarshalBinary()
+		require.NoErrorf(t, err, "receipt %d (type %#x)", i, gr.Type)
+		require.Equalf(t, raw, reencoded, "receipt %d (type %#x)", i, gr.Type)
+	}
+}
+
 func TestReceiptUnmarshalBinaryErrors(t *testing.T) {
 	var r optypes.Receipt
 	require.Error(t, r.UnmarshalBinary(nil))

--- a/op-core/types/receipt_consensus_test.go
+++ b/op-core/types/receipt_consensus_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"bytes"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -251,6 +252,48 @@ func TestReceiptUnmarshalBinaryErrors(t *testing.T) {
 	require.Error(t, r.UnmarshalBinary([]byte{optypes.DepositTxType}))
 	require.Error(t, r.UnmarshalBinary([]byte{optypes.DepositTxType, 0xff}))
 	require.Error(t, r.UnmarshalBinary([]byte{optypes.PostExecTxType, 0xff}))
+}
+
+// TestReceiptDeriveFieldsOuterNonce pins that contract-address derivation uses
+// the wrapper's authoritative outer DepositNonce, even when the embedded
+// shadow is unset — the promoted go-ethereum method read the shadow.
+func TestReceiptDeriveFieldsOuterNonce(t *testing.T) {
+	depositTx := gethtypes.NewTx(&gethtypes.DepositTx{
+		From:  common.HexToAddress("0x7777777777777777777777777777777777777777"),
+		To:    nil, // contract creation
+		Value: big.NewInt(0),
+		Gas:   1_000_000,
+	})
+	ctx := gethtypes.DeriveReceiptContext{
+		BlockNumber: 101,
+		BaseFee:     big.NewInt(7),
+		Tx:          depositTx,
+	}
+	signer := gethtypes.LatestSignerForChainID(big.NewInt(10))
+
+	r := &optypes.Receipt{}
+	r.DepositNonce = uint64Ptr(7) // outer only — embedded shadow left nil
+	r.DeriveFields(signer, ctx)
+
+	want := &gethtypes.Receipt{DepositNonce: uint64Ptr(7)}
+	want.DeriveFields(signer, ctx)
+	require.Equal(t, want.ContractAddress, r.ContractAddress,
+		"contract address must derive from the outer deposit nonce")
+}
+
+// TestReceiptSizeCountsExtensions pins that Size accounts for the wrapper's
+// extension fields — the promoted go-ethereum method measured only the
+// embedded receipt.
+func TestReceiptSizeCountsExtensions(t *testing.T) {
+	gr := gethReceipt()
+	bare := &optypes.Receipt{Receipt: *gr}
+	full := &optypes.Receipt{Receipt: *gr}
+	full.L1GasPrice = big.NewInt(42_000_000_000)
+	full.L1Fee = big.NewInt(77_000)
+	full.OperatorFeeScalar = uint64Ptr(7)
+
+	require.Greater(t, uint64(bare.Size()), uint64(gr.Size()), "wrapper overhead counted")
+	require.Greater(t, uint64(full.Size()), uint64(bare.Size()), "pointees counted")
 }
 
 func TestReceiptsGeth(t *testing.T) {

--- a/op-core/types/receipt_consensus_test.go
+++ b/op-core/types/receipt_consensus_test.go
@@ -1,0 +1,192 @@
+package types_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/trie"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
+)
+
+// consensusReceiptCases covers every receipts-root encoding arm: legacy,
+// standard typed, post-exec (0x7D), and the three deposit shapes — plain
+// (pre-Regolith), nonce-only (post-Regolith pre-Canyon, whose hash preimage
+// deliberately EXCLUDES the nonce), and nonce+version (post-Canyon).
+func consensusReceiptCases() []*gethtypes.Receipt {
+	mk := func(typ uint8, status uint64, mut func(*gethtypes.Receipt)) *gethtypes.Receipt {
+		r := &gethtypes.Receipt{
+			Type:              typ,
+			Status:            status,
+			CumulativeGasUsed: 42_000,
+			Logs: []*gethtypes.Log{
+				{
+					Address: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+					Topics:  []common.Hash{common.HexToHash("0x02"), common.HexToHash("0x03")},
+					Data:    []byte{0x01, 0x02},
+				},
+			},
+		}
+		r.Bloom = gethtypes.CreateBloom(r)
+		if mut != nil {
+			mut(r)
+		}
+		return r
+	}
+	return []*gethtypes.Receipt{
+		mk(gethtypes.LegacyTxType, gethtypes.ReceiptStatusSuccessful, nil),
+		mk(gethtypes.DynamicFeeTxType, gethtypes.ReceiptStatusFailed, nil),
+		mk(gethtypes.DynamicFeeTxType, gethtypes.ReceiptStatusSuccessful, func(r *gethtypes.Receipt) {
+			r.Logs = []*gethtypes.Log{}
+			r.Bloom = gethtypes.CreateBloom(r)
+		}),
+		mk(gethtypes.BlobTxType, gethtypes.ReceiptStatusSuccessful, nil),
+		mk(gethtypes.SetCodeTxType, gethtypes.ReceiptStatusSuccessful, nil),
+		mk(gethtypes.PostExecTxType, gethtypes.ReceiptStatusSuccessful, nil),
+		mk(gethtypes.DepositTxType, gethtypes.ReceiptStatusSuccessful, nil),
+		mk(gethtypes.DepositTxType, gethtypes.ReceiptStatusSuccessful, func(r *gethtypes.Receipt) {
+			r.DepositNonce = uint64Ptr(7) // pre-Canyon: nonce set, no version
+		}),
+		mk(gethtypes.DepositTxType, gethtypes.ReceiptStatusFailed, func(r *gethtypes.Receipt) {
+			r.DepositNonce = uint64Ptr(8)
+			r.DepositReceiptVersion = uint64Ptr(gethtypes.CanyonDepositReceiptVersion)
+		}),
+	}
+}
+
+func asOptypesReceipts(t *testing.T, gethReceipts []*gethtypes.Receipt) optypes.Receipts {
+	t.Helper()
+	out := make(optypes.Receipts, len(gethReceipts))
+	for i, gr := range gethReceipts {
+		r := &optypes.Receipt{Receipt: *gr}
+		// Field shadowing: the outer OP fields are authoritative.
+		r.DepositNonce = gr.DepositNonce
+		r.DepositReceiptVersion = gr.DepositReceiptVersion
+		out[i] = r
+	}
+	return out
+}
+
+// TestReceiptsEncodeIndexDifferential asserts that receipts-root derivation
+// over optypes.Receipts matches op-geth's, for every encoding arm. It will be
+// removed in the final cutover, when the op-geth dependency is replaced with
+// upstream go-ethereum.
+func TestReceiptsEncodeIndexDifferential(t *testing.T) {
+	gethReceipts := consensusReceiptCases()
+	ours := asOptypesReceipts(t, gethReceipts)
+
+	theirRoot := gethtypes.DeriveSha(gethtypes.Receipts(gethReceipts), trie.NewStackTrie(nil))
+	ourRoot := gethtypes.DeriveSha(ours, trie.NewStackTrie(nil))
+	require.Equal(t, theirRoot, ourRoot)
+
+	// Also compare per-index encodings, so a mismatch pinpoints the arm.
+	for i, gr := range gethReceipts {
+		var theirs, oursBuf bytes.Buffer
+		gethtypes.Receipts{gr}.EncodeIndex(0, &theirs)
+		ours.EncodeIndex(i, &oursBuf)
+		require.Equalf(t, theirs.Bytes(), oursBuf.Bytes(), "receipt %d (type %#x)", i, gr.Type)
+	}
+}
+
+// TestReceiptsEncodeIndexDepositArms pins the deposit hash-preimage rules
+// without reference to op-geth, so the receipts-root arms stay covered after
+// the differential tests are removed at the cutover:
+//   - pre-Canyon (nonce set, version nil): the preimage EXCLUDES the nonce, so
+//     it must equal the encoding of the same receipt without a nonce;
+//   - post-Canyon (version set): the preimage includes nonce+version, so it
+//     must differ from the pre-Canyon encoding.
+func TestReceiptsEncodeIndexDepositArms(t *testing.T) {
+	var base *gethtypes.Receipt
+	for _, r := range consensusReceiptCases() {
+		if r.Type == gethtypes.DepositTxType && r.DepositNonce != nil && r.DepositReceiptVersion == nil {
+			base = r // pre-Canyon shape: nonce set, version nil
+		}
+	}
+	require.NotNil(t, base)
+
+	encode := func(nonce, version *uint64) []byte {
+		cp := *base
+		r := &optypes.Receipt{Receipt: cp}
+		r.DepositNonce = nonce
+		r.DepositReceiptVersion = version
+		var buf bytes.Buffer
+		optypes.Receipts{r}.EncodeIndex(0, &buf)
+		return buf.Bytes()
+	}
+
+	preCanyon := encode(base.DepositNonce, nil)
+	noNonce := encode(nil, nil)
+	postCanyon := encode(base.DepositNonce, uint64Ptr(gethtypes.CanyonDepositReceiptVersion))
+
+	require.Equal(t, noNonce, preCanyon, "pre-Canyon deposit receipt hash preimage must exclude the nonce")
+	require.NotEqual(t, preCanyon, postCanyon, "post-Canyon deposit receipt hash preimage must include nonce+version")
+}
+
+// TestReceiptsEncodeIndexOuterFieldsAuthoritative pins the Receipt contract
+// that the OUTER deposit fields drive the consensus encoding: a wrapper
+// hand-built around an embedded receipt whose deposit fields were never
+// mirrored to the wrapper encodes without them. Receipts must be produced
+// through this package's decoders.
+func TestReceiptsEncodeIndexOuterFieldsAuthoritative(t *testing.T) {
+	gr := *consensusReceiptCases()[0] // legacy shape, mutate into a deposit
+	gr.Type = gethtypes.DepositTxType
+	gr.DepositNonce = uint64Ptr(7)
+	gr.DepositReceiptVersion = uint64Ptr(gethtypes.CanyonDepositReceiptVersion)
+
+	desynced := &optypes.Receipt{Receipt: gr} // outer deposit fields left nil
+
+	mirrored := &optypes.Receipt{Receipt: gr}
+	mirrored.DepositNonce = gr.DepositNonce
+	mirrored.DepositReceiptVersion = gr.DepositReceiptVersion
+
+	var desyncedBuf, mirroredBuf bytes.Buffer
+	optypes.Receipts{desynced}.EncodeIndex(0, &desyncedBuf)
+	optypes.Receipts{mirrored}.EncodeIndex(0, &mirroredBuf)
+	require.NotEqual(t, mirroredBuf.Bytes(), desyncedBuf.Bytes())
+}
+
+// TestReceiptUnmarshalBinaryDifferential asserts the consensus decode against
+// op-geth's MarshalBinary for every encoding arm. It will be removed in the
+// final cutover, when the op-geth dependency is replaced with upstream
+// go-ethereum.
+func TestReceiptUnmarshalBinaryDifferential(t *testing.T) {
+	for i, gr := range consensusReceiptCases() {
+		raw, err := gr.MarshalBinary()
+		require.NoError(t, err)
+
+		var r optypes.Receipt
+		require.NoErrorf(t, r.UnmarshalBinary(raw), "receipt %d (type %#x)", i, gr.Type)
+
+		require.Equal(t, gr.Type, r.Type)
+		require.Equal(t, gr.Status, r.Status)
+		require.Equal(t, gr.CumulativeGasUsed, r.CumulativeGasUsed)
+		require.Equal(t, gr.Bloom, r.Bloom)
+		require.Equal(t, gr.Logs, r.Logs)
+		require.Equal(t, gr.DepositNonce, r.DepositNonce)
+		require.Equal(t, gr.DepositReceiptVersion, r.DepositReceiptVersion)
+	}
+}
+
+func TestReceiptUnmarshalBinaryErrors(t *testing.T) {
+	var r optypes.Receipt
+	require.Error(t, r.UnmarshalBinary(nil))
+	require.Error(t, r.UnmarshalBinary([]byte{optypes.DepositTxType}))
+	require.Error(t, r.UnmarshalBinary([]byte{optypes.DepositTxType, 0xff}))
+	require.Error(t, r.UnmarshalBinary([]byte{optypes.PostExecTxType, 0xff}))
+}
+
+func TestReceiptsGeth(t *testing.T) {
+	rs := asOptypesReceipts(t, consensusReceiptCases())
+	view := rs.Geth()
+	require.Len(t, view, len(rs))
+	for i := range rs {
+		require.Same(t, &rs[i].Receipt, view[i])
+	}
+	// Mutations through the view are visible on the wrapper.
+	view[0].CumulativeGasUsed = 123
+	require.EqualValues(t, 123, rs[0].CumulativeGasUsed)
+}

--- a/op-core/types/receipt_consensus_test.go
+++ b/op-core/types/receipt_consensus_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 
 	optypes "github.com/ethereum-optimism/optimism/op-core/types"
@@ -204,6 +205,43 @@ func TestReceiptBinaryRoundTrip(t *testing.T) {
 		reencoded, err := r.MarshalBinary()
 		require.NoErrorf(t, err, "receipt %d (type %#x)", i, gr.Type)
 		require.Equalf(t, raw, reencoded, "receipt %d (type %#x)", i, gr.Type)
+	}
+}
+
+// TestReceiptRLPDifferential asserts the rlp.Encoder/Decoder implementation
+// against op-geth's for every encoding arm: identical encoding, and decode
+// equivalence via re-encode. It will be removed in the final cutover, when the
+// op-geth dependency is replaced with upstream go-ethereum.
+func TestReceiptRLPDifferential(t *testing.T) {
+	for i, gr := range consensusReceiptCases() {
+		theirs, err := rlp.EncodeToBytes(gr)
+		require.NoError(t, err)
+
+		r := &optypes.Receipt{Receipt: *gr}
+		r.DepositNonce = gr.DepositNonce
+		r.DepositReceiptVersion = gr.DepositReceiptVersion
+		ours, err := rlp.EncodeToBytes(r)
+		require.NoErrorf(t, err, "receipt %d (type %#x)", i, gr.Type)
+		require.Equalf(t, theirs, ours, "receipt %d (type %#x)", i, gr.Type)
+	}
+}
+
+// TestReceiptRLPRoundTrip pins, op-geth-independently, that rlp round-trips
+// through the wrapper's own codec — including a deposit receipt whose
+// authoritative fields live only on the wrapper.
+func TestReceiptRLPRoundTrip(t *testing.T) {
+	for i, gr := range consensusReceiptCases() {
+		encoded, err := rlp.EncodeToBytes(&optypes.Receipt{Receipt: *gr, DepositNonce: gr.DepositNonce, DepositReceiptVersion: gr.DepositReceiptVersion})
+		require.NoError(t, err)
+
+		var decoded optypes.Receipt
+		require.NoErrorf(t, rlp.DecodeBytes(encoded, &decoded), "receipt %d (type %#x)", i, gr.Type)
+		require.Equal(t, gr.DepositNonce, decoded.DepositNonce)
+		require.Equal(t, gr.DepositReceiptVersion, decoded.DepositReceiptVersion)
+
+		reencoded, err := rlp.EncodeToBytes(&decoded)
+		require.NoError(t, err)
+		require.Equalf(t, encoded, reencoded, "receipt %d (type %#x)", i, gr.Type)
 	}
 }
 

--- a/op-core/types/transaction_json.go
+++ b/op-core/types/transaction_json.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"math/big"
@@ -9,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // txJSON is the JSON representation of OP Stack transactions on the
@@ -83,7 +81,7 @@ func (d *DepositTx) UnmarshalJSON(input []byte) error {
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
-	if dec.Type == nil || byte(*dec.Type) != DepositTxType {
+	if dec.Type == nil || *dec.Type != hexutil.Uint64(DepositTxType) {
 		return errors.New("transaction type is not deposit")
 	}
 	if dec.AccessList != nil || dec.MaxFeePerGas != nil || dec.MaxPriorityFeePerGas != nil {
@@ -123,18 +121,16 @@ func (d *DepositTx) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-// Hash returns the transaction hash as op-geth computes it:
-// keccak256(PostExecTxType || RLP([Data])). Note this is NOT the hash of the
-// canonical envelope — the wire encoding appends Data verbatim (see
-// MarshalBinary), but op-geth hashes typed transactions over the RLP of the
-// inner struct, and for PostExecTx the two differ.
+// Hash returns the transaction hash: the keccak-256 hash of the canonical
+// EIP-2718 encoding — the rule every typed transaction follows, shared with
+// op-reth (see TestPostExecTxHashGoldenVector). See DepositTx.Hash for the
+// panic rationale.
 func (p *PostExecTx) Hash() common.Hash {
-	var buf bytes.Buffer
-	buf.WriteByte(PostExecTxType)
-	if err := rlp.Encode(&buf, p); err != nil {
-		panic(err) // a byte slice cannot fail to RLP-encode
+	raw, err := p.MarshalBinary()
+	if err != nil {
+		panic(err)
 	}
-	return crypto.Keccak256Hash(buf.Bytes())
+	return crypto.Keccak256Hash(raw)
 }
 
 // MarshalJSON encodes the post-exec transaction in op-geth's RPC transaction
@@ -159,7 +155,7 @@ func (p *PostExecTx) UnmarshalJSON(input []byte) error {
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
-	if dec.Type == nil || byte(*dec.Type) != PostExecTxType {
+	if dec.Type == nil || *dec.Type != hexutil.Uint64(PostExecTxType) {
 		return errors.New("transaction type is not post-exec")
 	}
 	if (dec.AccessList != nil && len(*dec.AccessList) != 0) ||

--- a/op-core/types/transaction_json.go
+++ b/op-core/types/transaction_json.go
@@ -55,11 +55,17 @@ func nonZeroSignature(dec *txJSON) bool {
 // round-trip does not preserve it.
 func (d *DepositTx) MarshalJSON() ([]byte, error) {
 	typ := hexutil.Uint64(DepositTxType)
+	// A nil Value is valid for the binary codec and encodes like zero; the JSON
+	// field is required on decode, so normalize nil to zero (as op-geth does).
+	value := d.Value
+	if value == nil {
+		value = new(big.Int)
+	}
 	enc := &txJSON{
 		Type:       &typ,
 		To:         d.To,
 		Gas:        (*hexutil.Uint64)(&d.Gas),
-		Value:      (*hexutil.Big)(d.Value),
+		Value:      (*hexutil.Big)(value),
 		Input:      (*hexutil.Bytes)(&d.Data),
 		SourceHash: &d.SourceHash,
 		From:       &d.From,

--- a/op-core/types/transaction_json.go
+++ b/op-core/types/transaction_json.go
@@ -1,0 +1,189 @@
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// txJSON is the JSON representation of OP Stack transactions on the
+// eth_getBlockBy*/eth_getTransactionBy* wire. It mirrors op-geth's txJSON:
+// fields without omitempty are emitted as null when unset, matching op-geth's
+// encoding byte-for-byte (modulo key order). Fields of other transaction types
+// are carried only to detect and reject their presence.
+type txJSON struct {
+	Type                 *hexutil.Uint64    `json:"type"`
+	Nonce                *hexutil.Uint64    `json:"nonce"`
+	To                   *common.Address    `json:"to"`
+	Gas                  *hexutil.Uint64    `json:"gas"`
+	GasPrice             *hexutil.Big       `json:"gasPrice"`
+	MaxPriorityFeePerGas *hexutil.Big       `json:"maxPriorityFeePerGas"`
+	MaxFeePerGas         *hexutil.Big       `json:"maxFeePerGas"`
+	Value                *hexutil.Big       `json:"value"`
+	Input                *hexutil.Bytes     `json:"input"`
+	AccessList           *[]json.RawMessage `json:"accessList,omitempty"`
+	V                    *hexutil.Big       `json:"v"`
+	R                    *hexutil.Big       `json:"r"`
+	S                    *hexutil.Big       `json:"s"`
+
+	// Deposit transaction fields
+	SourceHash *common.Hash    `json:"sourceHash,omitempty"`
+	From       *common.Address `json:"from,omitempty"`
+	Mint       *hexutil.Big    `json:"mint,omitempty"`
+	IsSystemTx *bool           `json:"isSystemTx,omitempty"`
+
+	// Only used for encoding:
+	Hash common.Hash `json:"hash"`
+}
+
+func isNonZero(v *hexutil.Big) bool {
+	return v != nil && v.ToInt().Sign() != 0
+}
+
+func nonZeroSignature(dec *txJSON) bool {
+	return isNonZero(dec.V) || isNonZero(dec.R) || isNonZero(dec.S)
+}
+
+// MarshalJSON encodes the deposit transaction in op-geth's RPC transaction
+// format, including the transaction hash. The nonce is always null: the
+// effective deposit nonce that mined deposits carry on the RPC wire is not
+// part of this type (or of the canonical encoding), so a decode/encode
+// round-trip does not preserve it.
+func (d *DepositTx) MarshalJSON() ([]byte, error) {
+	typ := hexutil.Uint64(DepositTxType)
+	enc := &txJSON{
+		Type:       &typ,
+		To:         d.To,
+		Gas:        (*hexutil.Uint64)(&d.Gas),
+		Value:      (*hexutil.Big)(d.Value),
+		Input:      (*hexutil.Bytes)(&d.Data),
+		SourceHash: &d.SourceHash,
+		From:       &d.From,
+		IsSystemTx: &d.IsSystemTransaction,
+		Hash:       d.Hash(),
+	}
+	if d.Mint != nil {
+		enc.Mint = (*hexutil.Big)(d.Mint)
+	}
+	return json.Marshal(enc)
+}
+
+// UnmarshalJSON decodes a deposit transaction from op-geth's RPC transaction
+// format, applying the same field validation as op-geth. A nonce field — the
+// effective deposit nonce that post-Regolith RPC responses carry — is accepted
+// and ignored: it is not part of the canonical transaction encoding.
+func (d *DepositTx) UnmarshalJSON(input []byte) error {
+	var dec txJSON
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	if dec.Type == nil || byte(*dec.Type) != DepositTxType {
+		return errors.New("transaction type is not deposit")
+	}
+	if dec.AccessList != nil || dec.MaxFeePerGas != nil || dec.MaxPriorityFeePerGas != nil {
+		return errors.New("unexpected field(s) in deposit transaction")
+	}
+	if isNonZero(dec.GasPrice) {
+		return errors.New("deposit transaction GasPrice must be 0")
+	}
+	if nonZeroSignature(&dec) {
+		return errors.New("deposit transaction signature must be 0 or unset")
+	}
+	d.To = dec.To
+	if dec.Gas == nil {
+		return errors.New("missing required field 'gas' for txdata")
+	}
+	d.Gas = uint64(*dec.Gas)
+	if dec.Value == nil {
+		return errors.New("missing required field 'value' in transaction")
+	}
+	d.Value = (*big.Int)(dec.Value)
+	// mint may be omitted or nil if there is nothing to mint.
+	d.Mint = (*big.Int)(dec.Mint)
+	if dec.Input == nil {
+		return errors.New("missing required field 'input' in transaction")
+	}
+	d.Data = *dec.Input
+	if dec.From == nil {
+		return errors.New("missing required field 'from' in transaction")
+	}
+	d.From = *dec.From
+	if dec.SourceHash == nil {
+		return errors.New("missing required field 'sourceHash' in transaction")
+	}
+	d.SourceHash = *dec.SourceHash
+	// IsSystemTx may be omitted. Defaults to false.
+	d.IsSystemTransaction = dec.IsSystemTx != nil && *dec.IsSystemTx
+	return nil
+}
+
+// Hash returns the transaction hash as op-geth computes it:
+// keccak256(PostExecTxType || RLP([Data])). Note this is NOT the hash of the
+// canonical envelope — the wire encoding appends Data verbatim (see
+// MarshalBinary), but op-geth hashes typed transactions over the RLP of the
+// inner struct, and for PostExecTx the two differ.
+func (p *PostExecTx) Hash() common.Hash {
+	var buf bytes.Buffer
+	buf.WriteByte(PostExecTxType)
+	if err := rlp.Encode(&buf, p); err != nil {
+		panic(err) // a byte slice cannot fail to RLP-encode
+	}
+	return crypto.Keccak256Hash(buf.Bytes())
+}
+
+// MarshalJSON encodes the post-exec transaction in op-geth's RPC transaction
+// format, including the transaction hash.
+func (p *PostExecTx) MarshalJSON() ([]byte, error) {
+	typ := hexutil.Uint64(PostExecTxType)
+	zeroGas := hexutil.Uint64(0)
+	enc := &txJSON{
+		Type:  &typ,
+		Gas:   &zeroGas,
+		Value: (*hexutil.Big)(new(big.Int)),
+		Input: (*hexutil.Bytes)(&p.Data),
+		Hash:  p.Hash(),
+	}
+	return json.Marshal(enc)
+}
+
+// UnmarshalJSON decodes a post-exec transaction from op-geth's RPC transaction
+// format, applying the same field validation as op-geth.
+func (p *PostExecTx) UnmarshalJSON(input []byte) error {
+	var dec txJSON
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	if dec.Type == nil || byte(*dec.Type) != PostExecTxType {
+		return errors.New("transaction type is not post-exec")
+	}
+	if (dec.AccessList != nil && len(*dec.AccessList) != 0) ||
+		dec.Mint != nil || dec.SourceHash != nil || dec.IsSystemTx != nil || dec.To != nil {
+		return errors.New("unexpected field(s) in post-exec transaction")
+	}
+	if dec.From != nil && *dec.From != (common.Address{}) {
+		return errors.New("post-exec transaction from must be zero address or unset")
+	}
+	if dec.Nonce != nil && uint64(*dec.Nonce) != 0 {
+		return errors.New("post-exec transaction nonce must be 0 or unset")
+	}
+	if isNonZero(dec.Value) {
+		return errors.New("post-exec transaction value must be 0")
+	}
+	if dec.Gas != nil && uint64(*dec.Gas) != 0 {
+		return errors.New("post-exec transaction gas must be 0")
+	}
+	if nonZeroSignature(&dec) {
+		return errors.New("post-exec transaction signature must be 0 or unset")
+	}
+	if dec.Input == nil {
+		return errors.New("missing required field 'input' in transaction")
+	}
+	p.Data = *dec.Input
+	return nil
+}

--- a/op-core/types/transaction_json_test.go
+++ b/op-core/types/transaction_json_test.go
@@ -1,0 +1,210 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
+)
+
+func toJSONMap(t *testing.T, data []byte) map[string]json.RawMessage {
+	t.Helper()
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &m))
+	return m
+}
+
+// TestDepositTxJSONDifferential asserts the deposit JSON codec against op-geth's
+// RPC transaction marshaling: op-geth JSON decodes into an identical canonical
+// binary encoding, and our JSON is accepted by op-geth's decoder with an
+// identical result. It will be removed in the final cutover, when the op-geth
+// dependency is replaced with upstream go-ethereum.
+func TestDepositTxJSONDifferential(t *testing.T) {
+	for _, tc := range depositTxTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			gethJSON, err := tc.gethTx().MarshalJSON()
+			require.NoError(t, err)
+
+			// Reject-parity: where op-geth's decoder rejects its own encoding
+			// (e.g. a nil Value marshals to null, which is invalid on decode),
+			// ours must reject too.
+			if err := new(gethtypes.Transaction).UnmarshalJSON(gethJSON); err != nil {
+				require.Error(t, json.Unmarshal(gethJSON, new(optypes.DepositTx)))
+				return
+			}
+
+			// op-geth JSON -> optypes -> binary equals op-geth binary
+			var d optypes.DepositTx
+			require.NoError(t, json.Unmarshal(gethJSON, &d))
+			ours, err := d.MarshalBinary()
+			require.NoError(t, err)
+			theirs, err := tc.gethTx().MarshalBinary()
+			require.NoError(t, err)
+			require.Equal(t, theirs, ours)
+
+			// optypes JSON is object-identical to op-geth's
+			ourJSON, err := json.Marshal(&d)
+			require.NoError(t, err)
+			require.Equal(t, toJSONMap(t, gethJSON), toJSONMap(t, ourJSON))
+
+			// and op-geth's decoder accepts our JSON with the same result
+			var back gethtypes.Transaction
+			require.NoError(t, back.UnmarshalJSON(ourJSON))
+			raw, err := back.MarshalBinary()
+			require.NoError(t, err)
+			require.Equal(t, theirs, raw)
+		})
+	}
+}
+
+// TestDepositTxJSONWithNonceDifferential exercises the post-Regolith RPC shape:
+// op-geth's depositTxWithNonce marshaling carries a non-zero effective nonce,
+// which must be accepted and ignored — it is not part of the canonical
+// encoding. It will be removed in the final cutover, when the op-geth
+// dependency is replaced with upstream go-ethereum.
+func TestDepositTxJSONWithNonceDifferential(t *testing.T) {
+	tc := depositTxTestCases()[0]
+
+	// Route through op-geth's real depositTxWithNonce path: JSON with a nonce
+	// decodes into the nonce-carrying inner type, whose re-marshal is the
+	// post-Regolith RPC response shape.
+	gethJSON, err := tc.gethTx().MarshalJSON()
+	require.NoError(t, err)
+	obj := toJSONMap(t, gethJSON)
+	obj["nonce"] = json.RawMessage(`"0x7"`)
+	withNonceJSON, err := json.Marshal(obj)
+	require.NoError(t, err)
+
+	var gethTx gethtypes.Transaction
+	require.NoError(t, gethTx.UnmarshalJSON(withNonceJSON))
+	nonce := gethTx.EffectiveNonce()
+	require.NotNil(t, nonce)
+	require.EqualValues(t, 7, *nonce) // proves the depositTxWithNonce path
+	rpcJSON, err := gethTx.MarshalJSON()
+	require.NoError(t, err)
+
+	var d optypes.DepositTx
+	require.NoError(t, json.Unmarshal(rpcJSON, &d))
+	ours, err := d.MarshalBinary()
+	require.NoError(t, err)
+	canonical, err := tc.tx.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, canonical, ours)
+}
+
+func TestDepositTxUnmarshalJSONErrors(t *testing.T) {
+	valid := func() map[string]json.RawMessage {
+		gethJSON, err := depositTxTestCases()[0].gethTx().MarshalJSON()
+		require.NoError(t, err)
+		return toJSONMap(t, gethJSON)
+	}
+	mutate := func(mut func(map[string]json.RawMessage)) []byte {
+		obj := valid()
+		mut(obj)
+		data, err := json.Marshal(obj)
+		require.NoError(t, err)
+		return data
+	}
+	cases := []struct {
+		name   string
+		input  []byte
+		errStr string
+	}{
+		{"wrong type", mutate(func(o map[string]json.RawMessage) { o["type"] = json.RawMessage(`"0x2"`) }), "not deposit"},
+		{"missing type", mutate(func(o map[string]json.RawMessage) { delete(o, "type") }), "not deposit"},
+		{"access list present", mutate(func(o map[string]json.RawMessage) { o["accessList"] = json.RawMessage(`[]`) }), "unexpected field"},
+		{"maxFeePerGas present", mutate(func(o map[string]json.RawMessage) { o["maxFeePerGas"] = json.RawMessage(`"0x1"`) }), "unexpected field"},
+		{"non-zero gasPrice", mutate(func(o map[string]json.RawMessage) { o["gasPrice"] = json.RawMessage(`"0x1"`) }), "GasPrice must be 0"},
+		{"non-zero signature", mutate(func(o map[string]json.RawMessage) { o["v"] = json.RawMessage(`"0x1"`) }), "signature must be 0"},
+		{"missing gas", mutate(func(o map[string]json.RawMessage) { delete(o, "gas") }), "'gas'"},
+		{"missing value", mutate(func(o map[string]json.RawMessage) { o["value"] = json.RawMessage(`null`) }), "'value'"},
+		{"missing input", mutate(func(o map[string]json.RawMessage) { o["input"] = json.RawMessage(`null`) }), "'input'"},
+		{"missing from", mutate(func(o map[string]json.RawMessage) { delete(o, "from") }), "'from'"},
+		{"missing sourceHash", mutate(func(o map[string]json.RawMessage) { delete(o, "sourceHash") }), "'sourceHash'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var d optypes.DepositTx
+			require.ErrorContains(t, json.Unmarshal(tc.input, &d), tc.errStr)
+		})
+	}
+}
+
+func postExecGethTx(data []byte) *gethtypes.Transaction {
+	return gethtypes.NewTx(&gethtypes.PostExecTx{Data: data})
+}
+
+// TestPostExecTxJSONDifferential mirrors TestDepositTxJSONDifferential for the
+// 0x7D post-exec transaction. It will be removed in the final cutover, when
+// the op-geth dependency is replaced with upstream go-ethereum.
+func TestPostExecTxJSONDifferential(t *testing.T) {
+	for _, data := range [][]byte{{0x01}, {0xc2, 0x80, 0x80}, make([]byte, 64)} {
+		gethTx := postExecGethTx(data)
+		gethJSON, err := gethTx.MarshalJSON()
+		require.NoError(t, err)
+
+		var p optypes.PostExecTx
+		require.NoError(t, json.Unmarshal(gethJSON, &p))
+		ours, err := p.MarshalBinary()
+		require.NoError(t, err)
+		theirs, err := gethTx.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, theirs, ours)
+
+		require.Equal(t, gethTx.Hash(), p.Hash())
+
+		ourJSON, err := json.Marshal(&p)
+		require.NoError(t, err)
+		require.Equal(t, toJSONMap(t, gethJSON), toJSONMap(t, ourJSON))
+
+		var back gethtypes.Transaction
+		require.NoError(t, back.UnmarshalJSON(ourJSON))
+		raw, err := back.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, theirs, raw)
+	}
+}
+
+func TestPostExecTxUnmarshalJSONErrors(t *testing.T) {
+	valid := func() map[string]json.RawMessage {
+		gethJSON, err := postExecGethTx([]byte{0x01}).MarshalJSON()
+		require.NoError(t, err)
+		return toJSONMap(t, gethJSON)
+	}
+	mutate := func(mut func(map[string]json.RawMessage)) []byte {
+		obj := valid()
+		mut(obj)
+		data, err := json.Marshal(obj)
+		require.NoError(t, err)
+		return data
+	}
+	cases := []struct {
+		name   string
+		input  []byte
+		errStr string
+	}{
+		{"wrong type", mutate(func(o map[string]json.RawMessage) { o["type"] = json.RawMessage(`"0x7e"`) }), "not post-exec"},
+		{"to present", mutate(func(o map[string]json.RawMessage) {
+			o["to"] = json.RawMessage(`"0x4242424242424242424242424242424242424242"`)
+		}), "unexpected field"},
+		{"mint present", mutate(func(o map[string]json.RawMessage) { o["mint"] = json.RawMessage(`"0x1"`) }), "unexpected field"},
+		{"non-zero from", mutate(func(o map[string]json.RawMessage) {
+			o["from"] = json.RawMessage(`"0x4242424242424242424242424242424242424242"`)
+		}), "from must be zero"},
+		{"non-zero nonce", mutate(func(o map[string]json.RawMessage) { o["nonce"] = json.RawMessage(`"0x1"`) }), "nonce must be 0"},
+		{"non-zero value", mutate(func(o map[string]json.RawMessage) { o["value"] = json.RawMessage(`"0x1"`) }), "value must be 0"},
+		{"non-zero gas", mutate(func(o map[string]json.RawMessage) { o["gas"] = json.RawMessage(`"0x1"`) }), "gas must be 0"},
+		{"non-zero signature", mutate(func(o map[string]json.RawMessage) { o["r"] = json.RawMessage(`"0x1"`) }), "signature must be 0"},
+		{"missing input", mutate(func(o map[string]json.RawMessage) { o["input"] = json.RawMessage(`null`) }), "'input'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var p optypes.PostExecTx
+			require.ErrorContains(t, json.Unmarshal(tc.input, &p), tc.errStr)
+		})
+	}
+}

--- a/op-core/types/transaction_json_test.go
+++ b/op-core/types/transaction_json_test.go
@@ -115,6 +115,7 @@ func TestDepositTxUnmarshalJSONErrors(t *testing.T) {
 		errStr string
 	}{
 		{"wrong type", mutate(func(o map[string]json.RawMessage) { o["type"] = json.RawMessage(`"0x2"`) }), "not deposit"},
+		{"truncated type match", mutate(func(o map[string]json.RawMessage) { o["type"] = json.RawMessage(`"0x17e"`) }), "not deposit"},
 		{"missing type", mutate(func(o map[string]json.RawMessage) { delete(o, "type") }), "not deposit"},
 		{"access list present", mutate(func(o map[string]json.RawMessage) { o["accessList"] = json.RawMessage(`[]`) }), "unexpected field"},
 		{"maxFeePerGas present", mutate(func(o map[string]json.RawMessage) { o["maxFeePerGas"] = json.RawMessage(`"0x1"`) }), "unexpected field"},
@@ -188,6 +189,7 @@ func TestPostExecTxUnmarshalJSONErrors(t *testing.T) {
 		errStr string
 	}{
 		{"wrong type", mutate(func(o map[string]json.RawMessage) { o["type"] = json.RawMessage(`"0x7e"`) }), "not post-exec"},
+		{"truncated type match", mutate(func(o map[string]json.RawMessage) { o["type"] = json.RawMessage(`"0x17d"`) }), "not post-exec"},
 		{"to present", mutate(func(o map[string]json.RawMessage) {
 			o["to"] = json.RawMessage(`"0x4242424242424242424242424242424242424242"`)
 		}), "unexpected field"},

--- a/op-core/types/transaction_json_test.go
+++ b/op-core/types/transaction_json_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	optypes "github.com/ethereum-optimism/optimism/op-core/types"
@@ -94,6 +95,32 @@ func TestDepositTxJSONWithNonceDifferential(t *testing.T) {
 	canonical, err := tc.tx.MarshalBinary()
 	require.NoError(t, err)
 	require.Equal(t, canonical, ours)
+}
+
+// TestDepositTxJSONNilValueRoundTrip pins that a nil Value — valid for the
+// binary codec — marshals as zero and round-trips through this type's own
+// JSON codec (a null value would be rejected by UnmarshalJSON).
+func TestDepositTxJSONNilValueRoundTrip(t *testing.T) {
+	d := &optypes.DepositTx{
+		SourceHash: common.HexToHash("0x06"),
+		From:       common.HexToAddress("0x6666666666666666666666666666666666666666"),
+		Value:      nil,
+		Gas:        21000,
+	}
+	data, err := json.Marshal(d)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"value":"0x0"`)
+
+	var decoded optypes.DepositTx
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Zero(t, decoded.Value.Sign())
+
+	// Binary encodings of the nil and decoded-zero forms agree.
+	origBin, err := d.MarshalBinary()
+	require.NoError(t, err)
+	decodedBin, err := decoded.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, origBin, decodedBin)
 }
 
 func TestDepositTxUnmarshalJSONErrors(t *testing.T) {


### PR DESCRIPTION
Part of #20264 (opgeth-decoupling: make op-service/sources the OP-aware eth client). First of three stacked PRs; the follow-ups make `op-service/sources` decode L2 blocks/receipts via these codecs and migrate op-batcher to payload-based block loading.

Adds to `op-core/types`:

- **`DepositTx`/`PostExecTx` JSON codecs** matching op-geth's RPC transaction wire format (validation arms mirrored field-by-field), incl. accepting-and-discarding the post-Regolith effective deposit nonce. `PostExecTx.Hash` follows the canonical EIP-2718 rule, `keccak256(0x7D ‖ Data)` — shared with op-reth and pinned by a cross-client golden vector (cross-client alignment landed via ethereum-optimism/op-geth#805 + #21931).
- **`Receipts`**, a `DerivableList` for receipts-root recomputation with the three OP arms hand-rolled: post-Canyon deposit receipts (nonce+version in the hash preimage), pre-Canyon deposit receipts (nonce deliberately excluded from the root derivation — diverges from `MarshalBinary`, per op-geth), and `0x7D` post-exec receipts.
- **`Receipt` wrapper methods** — OP-aware `MarshalBinary`/`UnmarshalBinary` (the `debug_getRawReceipts` path), `EncodeRLP`/`DecodeRLP`, `DeriveFields`, and `Size`, overriding every promoted go-ethereum method that touches OP state so deposit receipts encode/derive from the authoritative outer `DepositNonce`/`DepositReceiptVersion` fields and `0x7E`/`0x7D` decode survives the upstream cutover.
- **`Receipts.Geth`**, a non-copying view of the embedded upstream receipts.

Everything is pinned byte-for-byte against op-geth by differential tests (removed at the final cutover); the deposit hash-preimage rules and codec round-trips additionally get cutover-surviving tests.

🤖 *Co-created with Claude Fable 5*

