### PR TITLE
op-service: make sources the OP-aware eth client

### DIFF
--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -13,6 +13,7 @@ import (
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
@@ -25,7 +26,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -222,13 +222,13 @@ func newReliableEL(el txinclude.EL, blockTime time.Duration, observer txinclude.
 }
 
 // initMsgFromReceipt turns the first log in the receipt into an inititiating message.
-func initMsgFromReceipt(t devtest.T, l2 *L2, receipt *ethtypes.Receipt) (*messages.Message, error) {
+func initMsgFromReceipt(t devtest.T, l2 *L2, receipt *optypes.Receipt) (*messages.Message, error) {
 	ref, err := l2.EL.Escape().EthClient().BlockRefByHash(t.Ctx(), receipt.BlockHash)
 	if err != nil {
 		return nil, fmt.Errorf("get init msg block ref by hash: %w", err)
 	}
 	out := new(txintent.InteropOutput)
-	if err := out.FromReceipt(t.Ctx(), receipt, ref, l2.EL.ChainID()); err != nil {
+	if err := out.FromReceipt(t.Ctx(), &receipt.Receipt, ref, l2.EL.ChainID()); err != nil {
 		return nil, fmt.Errorf("get init msg from receipt: %w", err)
 	}
 	t.Require().NotEmpty(out.Entries)

--- a/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
@@ -94,7 +94,7 @@ func TestRelayWithInvalidMessagesSteady(gt *testing.T) {
 	t.Require().NoError(err)
 	ref := l2A.EL.BlockRefByNumber(bigs.Uint64Strict(initTx.Receipt.BlockNumber))
 	out := new(txintent.InteropOutput)
-	t.Require().NoError(out.FromReceipt(t.Ctx(), initTx.Receipt, ref.BlockRef(), l2A.EL.ChainID()))
+	t.Require().NoError(out.FromReceipt(t.Ctx(), &initTx.Receipt.Receipt, ref.BlockRef(), l2A.EL.ChainID()))
 	t.Require().Len(out.Entries, 1)
 	validInitMsg := out.Entries[0]
 

--- a/op-alt-da/damgr.go
+++ b/op-alt-da/damgr.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-alt-da/bindings"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -38,7 +39,7 @@ var ErrInvalidChallenge = errors.New("invalid challenge")
 // L1Fetcher is the required interface for syncing the DA challenge contract state.
 type L1Fetcher interface {
 	InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error)
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error)
 	L1BlockRefByNumber(context.Context, uint64) (eth.L1BlockRef, error)
 }
 

--- a/op-alt-da/damgr_test.go
+++ b/op-alt-da/damgr_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"testing"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
@@ -209,12 +210,12 @@ func (m *mockL1Fetcher) ExpectInfoAndTxsByHash(hash common.Hash, info eth.BlockI
 	m.Mock.On("InfoAndTxsByHash", hash).Once().Return(info, transactions, err)
 }
 
-func (m *mockL1Fetcher) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+func (m *mockL1Fetcher) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
 	out := m.Mock.Called(blockHash)
-	return *out.Get(0).(*eth.BlockInfo), out.Get(1).(types.Receipts), out.Error(2)
+	return *out.Get(0).(*eth.BlockInfo), out.Get(1).(optypes.Receipts), out.Error(2)
 }
 
-func (m *mockL1Fetcher) ExpectFetchReceipts(hash common.Hash, info eth.BlockInfo, receipts types.Receipts, err error) {
+func (m *mockL1Fetcher) ExpectFetchReceipts(hash common.Hash, info eth.BlockInfo, receipts optypes.Receipts, err error) {
 	m.Mock.On("FetchReceipts", hash).Once().Return(&info, receipts, err)
 }
 
@@ -392,7 +393,7 @@ func TestAdvanceChallengeOrigin(t *testing.T) {
 
 	da := NewAltDAWithState(logger, pcfg, storage, &NoopMetrics{}, state)
 
-	receipts := types.Receipts{&types.Receipt{
+	receipts := optypes.Receipts{{Receipt: types.Receipt{
 		Type:   2,
 		Status: 1,
 		Logs: []*types.Log{
@@ -414,7 +415,7 @@ func TestAdvanceChallengeOrigin(t *testing.T) {
 			},
 		},
 		BlockNumber: big.NewInt(int64(bn)),
-	}}
+	}}}
 	id := eth.BlockID{
 		Number: bn,
 		Hash:   bhash,

--- a/op-chain-ops/cmd/check-karst/karsttest/checks.go
+++ b/op-chain-ops/cmd/check-karst/karsttest/checks.go
@@ -123,7 +123,7 @@ func NewBasePlan(cl *ethclient.Client, key *ecdsa.PrivateKey) txplan.Option {
 		txplan.WithAgainstLatestBlockEthClient(cl),
 		txplan.WithEstimator(cl, true),
 		txplan.WithRetrySubmission(cl, 5, retry.Exponential()),
-		txplan.WithRetryInclusion(cl, 5, retry.Exponential()),
+		txplan.WithRetryInclusion(txplan.FromGethReceipts(cl), 5, retry.Exponential()),
 	)
 }
 
@@ -419,7 +419,7 @@ func CheckEIP7825DepositBypass(
 
 	l2DepositHash := l2DepositTx.Hash()
 	logger.Info("EIP-7825-deposit: waiting for L2 deposit receipt", "tx", l2DepositHash)
-	var l2Receipt *types.Receipt
+	var l2Receipt *optypes.Receipt
 	for {
 		var err error
 		l2Receipt, err = l2.TransactionReceipt(ctx, l2DepositHash)

--- a/op-chain-ops/cmd/check-karst/main.go
+++ b/op-chain-ops/cmd/check-karst/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-karst/karsttest"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
@@ -177,6 +178,17 @@ func makeAllCommand() *cli.Command {
 // aren't needed by the EIP-7934 check.
 type ethclientLatestBlockAdapter struct{ *ethclient.Client }
 
+// TransactionReceipt adapts the go-ethereum receipt to the optypes shape the
+// karst checks consume; the OP extension fields stay nil (the checks read only
+// standard fields).
+func (a *ethclientLatestBlockAdapter) TransactionReceipt(ctx context.Context, txHash common.Hash) (*optypes.Receipt, error) {
+	receipt, err := a.Client.TransactionReceipt(ctx, txHash)
+	if err != nil || receipt == nil {
+		return nil, err
+	}
+	return &optypes.Receipt{Receipt: *receipt}, nil
+}
+
 func (a *ethclientLatestBlockAdapter) InfoAndTxsByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, types.Transactions, error) {
 	if label != eth.Unsafe {
 		return nil, nil, fmt.Errorf("unsupported block label %q (only %q is supported)", label, eth.Unsafe)
@@ -248,7 +260,7 @@ func makeDepositCommand() *cli.Command {
 			}
 
 			if _, err := karsttest.CheckEIP7825DepositBypass(
-				env.ctx, env.logger, env.l2,
+				env.ctx, env.logger, &ethclientLatestBlockAdapter{env.l2},
 				common.HexToAddress(portalHex),
 				crypto.PubkeyToAddress(l1Key.PublicKey),
 				karsttest.NewBasePlan(l1Cl, l1Key),

--- a/op-chain-ops/cmd/receipt-reference-builder/pull.go
+++ b/op-chain-ops/cmd/receipt-reference-builder/pull.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -291,7 +291,7 @@ func processBlockRange(
 	for i := 0; i < len(blocks); i++ {
 		b := blocks[i]
 		matches := 0
-		blockNumber := b.BlockID().Number
+		blockNumber := uint64(b.Number)
 		res := result{
 			BlockNumber: blockNumber,
 			Nonces:      []uint64{},
@@ -319,16 +319,24 @@ func processBlockRange(
 // batchBlockByNumber will batch a list of block numbers into a single batch rpc request
 // it uses the iterative batch call to make the request
 // and returns the results
-func batchBlockByNumber(ctx context.Context, c *ethclient.Client, blockNumbers []rpc.BlockNumber) ([]*sources.RPCBlock, error) {
-	makeBlockByNumberRequest := func(blockNumber rpc.BlockNumber) (*sources.RPCBlock, rpc.BatchElem) {
-		out := new(sources.RPCBlock)
+// rpcBlock is a minimal eth_getBlockBy* result carrying what this tool reads.
+// Transactions decode as op-geth typed transactions: the tool extracts the
+// effective deposit nonce, JSON-only data that op-geth's decoder captures.
+type rpcBlock struct {
+	Number       hexutil.Uint64       `json:"number"`
+	Transactions []*types.Transaction `json:"transactions"`
+}
+
+func batchBlockByNumber(ctx context.Context, c *ethclient.Client, blockNumbers []rpc.BlockNumber) ([]*rpcBlock, error) {
+	makeBlockByNumberRequest := func(blockNumber rpc.BlockNumber) (*rpcBlock, rpc.BatchElem) {
+		out := new(rpcBlock)
 		return out, rpc.BatchElem{
 			Method: "eth_getBlockByNumber",
 			Args:   []any{blockNumber, true},
 			Result: &out,
 		}
 	}
-	batchReq := batching.NewIterativeBatchCall[rpc.BlockNumber, *sources.RPCBlock](
+	batchReq := batching.NewIterativeBatchCall[rpc.BlockNumber, *rpcBlock](
 		blockNumbers,
 		makeBlockByNumberRequest,
 		c.Client().BatchCallContext,

--- a/op-challenger/game/keccak/fetcher/fetcher.go
+++ b/op-challenger/game/keccak/fetcher/fetcher.go
@@ -53,7 +53,7 @@ func (f *InputFetcher) FetchInputs(ctx context.Context, blockHash common.Hash, o
 			return nil, fmt.Errorf("failed to retrieve receipts for block %v: %w", blockNum, err)
 		}
 		for _, rcpt := range receipts {
-			inputData, err := f.extractRelevantLeavesFromReceipt(rcpt, oracle, ident)
+			inputData, err := f.extractRelevantLeavesFromReceipt(&rcpt.Receipt, oracle, ident)
 			if err != nil {
 				return nil, err
 			}

--- a/op-challenger/game/keccak/fetcher/fetcher_test.go
+++ b/op-challenger/game/keccak/fetcher/fetcher_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -287,7 +288,7 @@ func setupFetcherTest(t *testing.T) (*InputFetcher, *stubOracle, *stubL1Source) 
 	}
 	l1Source := &stubL1Source{
 		blocks:     make(map[uint64]common.Hash),
-		rcpts:      make(map[common.Hash]types.Receipts),
+		rcpts:      make(map[common.Hash]optypes.Receipts),
 		txs:        make(map[uint64]types.Transactions),
 		rcptStatus: make(map[common.Hash]uint64),
 		logs:       make(map[common.Hash][]*types.Log),
@@ -358,7 +359,7 @@ type stubL1Source struct {
 	// Map block number to block hash
 	blocks map[uint64]common.Hash
 	// Map block hash to receipts
-	rcpts map[common.Hash]types.Receipts
+	rcpts map[common.Hash]optypes.Receipts
 	// Map block number to tx
 	txs map[uint64]types.Transactions
 	// Map txHash to receipt
@@ -378,7 +379,7 @@ func (s *stubL1Source) BlockRefByNumber(_ context.Context, num uint64) (eth.Bloc
 	}, nil
 }
 
-func (s *stubL1Source) FetchReceipts(_ context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+func (s *stubL1Source) FetchReceipts(_ context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
 	rcpts, ok := s.rcpts[blockHash]
 	if !ok {
 		return nil, nil, errors.New("not found")
@@ -392,7 +393,7 @@ func uint64ToHash(num uint64) common.Hash {
 	return crypto.Keccak256Hash(data)
 }
 
-func (s *stubL1Source) createReceipt(blockNum uint64, status uint64, proposals ...*proposalConfig) *types.Receipt {
+func (s *stubL1Source) createReceipt(blockNum uint64, status uint64, proposals ...*proposalConfig) *optypes.Receipt {
 	// Make the block exist
 	s.blocks[blockNum] = uint64ToHash(blockNum)
 
@@ -420,7 +421,7 @@ func (s *stubL1Source) createReceipt(blockNum uint64, status uint64, proposals .
 		}
 		logs[i] = txLog
 	}
-	rcpt := &types.Receipt{TxHash: uint64ToHash(txId), Status: status, Logs: logs}
+	rcpt := &optypes.Receipt{Receipt: types.Receipt{TxHash: uint64ToHash(txId), Status: status, Logs: logs}}
 	blockHash := s.blocks[blockNum]
 	rcpts := s.rcpts[blockHash]
 	s.rcpts[blockHash] = append(rcpts, rcpt)

--- a/op-core/types/receipt_consensus.go
+++ b/op-core/types/receipt_consensus.go
@@ -25,6 +25,23 @@ type Receipts []*Receipt
 
 var _ types.DerivableList = (Receipts)(nil)
 
+// FromGethReceipts wraps go-ethereum receipts into Receipts. The receipt
+// structs are shallow-copied (reference fields like Logs still alias the
+// source). While go-ethereum resolves to op-geth, the deposit receipt fields
+// are mirrored to the authoritative outer copies so consensus encoding stays
+// correct; those two assignments stop compiling at the final cutover and are
+// removed then.
+func FromGethReceipts(rs types.Receipts) Receipts {
+	out := make(Receipts, len(rs))
+	for i, r := range rs {
+		wrapped := &Receipt{Receipt: *r}
+		wrapped.DepositNonce = r.DepositNonce
+		wrapped.DepositReceiptVersion = r.DepositReceiptVersion
+		out[i] = wrapped
+	}
+	return out
+}
+
 // Geth returns a view of the embedded go-ethereum receipts, for boundaries
 // that operate on standard receipt fields only. The elements alias the
 // receivers' embedded structs — mutations are visible in both.

--- a/op-core/types/transaction_json.go
+++ b/op-core/types/transaction_json.go
@@ -155,7 +155,11 @@ func (p *PostExecTx) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON decodes a post-exec transaction from op-geth's RPC transaction
-// format, applying the same field validation as op-geth.
+// format, applying the same field validation as op-geth, plus one stricter
+// check: the input must not be empty. Empty input would encode to the one-byte
+// value 0x7D, which the binary decoders (UnmarshalPostExecTx, op-geth,
+// op-alloy) all reject — accepting it here would produce a transaction with no
+// canonical encoding.
 func (p *PostExecTx) UnmarshalJSON(input []byte) error {
 	var dec txJSON
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -185,6 +189,9 @@ func (p *PostExecTx) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Input == nil {
 		return errors.New("missing required field 'input' in transaction")
+	}
+	if len(*dec.Input) == 0 {
+		return errors.New("post-exec transaction input must not be empty")
 	}
 	p.Data = *dec.Input
 	return nil

--- a/op-core/types/transaction_json_test.go
+++ b/op-core/types/transaction_json_test.go
@@ -229,6 +229,7 @@ func TestPostExecTxUnmarshalJSONErrors(t *testing.T) {
 		{"non-zero gas", mutate(func(o map[string]json.RawMessage) { o["gas"] = json.RawMessage(`"0x1"`) }), "gas must be 0"},
 		{"non-zero signature", mutate(func(o map[string]json.RawMessage) { o["r"] = json.RawMessage(`"0x1"`) }), "signature must be 0"},
 		{"missing input", mutate(func(o map[string]json.RawMessage) { o["input"] = json.RawMessage(`null`) }), "'input'"},
+		{"empty input", mutate(func(o map[string]json.RawMessage) { o["input"] = json.RawMessage(`"0x"`) }), "input must not be empty"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/op-deployer/pkg/deployer/zk_mock_verifier.go
+++ b/op-deployer/pkg/deployer/zk_mock_verifier.go
@@ -41,7 +41,7 @@ func DeployZKMockVerifier(
 		txplan.WithData(artifact.Bytecode.Object),
 		txplan.WithEstimator(client, true),
 		txplan.WithRetrySubmission(client, 5, retry.Exponential()),
-		txplan.WithRetryInclusion(client, 5, retry.Exponential()),
+		txplan.WithRetryInclusion(txplan.FromGethReceipts(client), 5, retry.Exponential()),
 	)
 	receipt, err := deployTx.Included.Eval(ctx)
 	if err != nil {

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -177,7 +177,7 @@ func (b *StandardBridge) Deposit(amount eth.ETH, from *EOA) Deposit {
 	b.require.NoError(err, "Could not reconstruct L2 Deposit")
 	l2DepositTxHash := l2DepositTx.Hash()
 	// Give time for L2CL to include the L2 deposit tx
-	var l2DepositReceipt *types.Receipt
+	var l2DepositReceipt *optypes.Receipt
 	b.require.Eventually(func() bool {
 		l2DepositReceipt, err = b.l2Client.TransactionReceipt(b.ctx, l2DepositTxHash)
 		return err == nil
@@ -223,7 +223,7 @@ func (b *StandardBridge) ERC20Deposit(l1TokenAddr common.Address, l2TokenAddr co
 
 	// Give time for L2CL to include the L2 deposit tx
 	sequencingWindowDuration := time.Duration(b.rollupCfg.SeqWindowSize) * b.l1Client.EstimateBlockTime()
-	var l2DepositReceipt *types.Receipt
+	var l2DepositReceipt *optypes.Receipt
 	b.require.Eventually(func() bool {
 		l2DepositReceipt, err = b.l2Client.TransactionReceipt(b.ctx, l2DepositTxHash)
 		return err == nil

--- a/op-devstack/dsl/funder_eoa_test.go
+++ b/op-devstack/dsl/funder_eoa_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
@@ -54,7 +55,7 @@ type funderTestEthClient struct {
 	receiptsReady chan struct{}
 	balances      map[common.Address]*big.Int
 	transactions  []*types.Transaction
-	receipts      map[common.Hash]*types.Receipt
+	receipts      map[common.Hash]*optypes.Receipt
 }
 
 var _ apis.EthClient = (*funderTestEthClient)(nil)
@@ -66,7 +67,7 @@ func newFunderTestEthClient(chainID *big.Int, pendingNonce uint64) *funderTestEt
 		sendsReady:    make(chan struct{}),
 		receiptsReady: make(chan struct{}),
 		balances:      make(map[common.Address]*big.Int),
-		receipts:      make(map[common.Hash]*types.Receipt),
+		receipts:      make(map[common.Hash]*optypes.Receipt),
 	}
 }
 
@@ -124,14 +125,14 @@ func (c *funderTestEthClient) SendTransaction(ctx context.Context, tx *types.Tra
 	to := *tx.To()
 	balance := copyBig(c.balances[to])
 	c.balances[to] = balance.Add(balance, tx.Value())
-	c.receipts[txHash] = &types.Receipt{Status: types.ReceiptStatusSuccessful, TxHash: txHash}
+	c.receipts[txHash] = &optypes.Receipt{Receipt: types.Receipt{Status: types.ReceiptStatusSuccessful, TxHash: txHash}}
 	if len(c.transactions) == 2 {
 		close(c.receiptsReady)
 	}
 	return nil
 }
 
-func (c *funderTestEthClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+func (c *funderTestEthClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*optypes.Receipt, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
@@ -579,7 +580,7 @@ func (el *L2ELNode) ChainBlockID(chainID eth.ChainID, number uint64) (eth.BlockI
 
 // WaitForReceipt waits for a transaction receipt to be available, retrying until found or timeout.
 func (el *L2ELNode) WaitForReceipt(txHash common.Hash) *types.Receipt {
-	var receipt *types.Receipt
+	var receipt *optypes.Receipt
 	err := retry.Do0(el.ctx, 30, &retry.FixedStrategy{Dur: 500 * time.Millisecond}, func() error {
 		var err error
 		receipt, err = el.inner.EthClient().TransactionReceipt(el.ctx, txHash)
@@ -589,7 +590,7 @@ func (el *L2ELNode) WaitForReceipt(txHash common.Hash) *types.Receipt {
 		return nil
 	})
 	el.require.NoError(err, "failed to get receipt for tx %s", txHash.Hex())
-	return receipt
+	return &receipt.Receipt
 }
 
 func (el *L2ELNode) MatchedFn(refNode SyncStatusProvider, lvl safety.Level, attempts int) CheckFunc {

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -76,7 +76,7 @@ func setRespectedGameTypeForRuntime(
 		txplan.WithAgainstLatestBlockEthClient(client),
 		txplan.WithEstimator(client, true),
 		txplan.WithRetrySubmission(client, 5, retry.Exponential()),
-		txplan.WithRetryInclusion(client, 5, retry.Exponential()))
+		txplan.WithRetryInclusion(txplan.FromGethReceipts(client), 5, retry.Exponential()))
 
 	asrBindings := bindings.NewBindings[bindings.AnchorStateRegistry](bindings.WithTo(asrAddr), bindings.WithTest(t))
 	rcpt, err := contractio.Write(asrBindings.SetRespectedGameType(uint32(gameType)), t.Ctx(), txOpts)

--- a/op-devstack/sysgo/pre_genesis_super_game.go
+++ b/op-devstack/sysgo/pre_genesis_super_game.go
@@ -108,7 +108,7 @@ func preparePreGenesisSuperGame(
 		txplan.WithAgainstLatestBlockEthClient(client),
 		txplan.WithEstimator(client, true),
 		txplan.WithRetrySubmission(client, 5, retry.Exponential()),
-		txplan.WithRetryInclusion(client, 5, retry.Exponential()),
+		txplan.WithRetryInclusion(txplan.FromGethReceipts(client), 5, retry.Exponential()),
 	)
 
 	dgf := bindings.NewBindings[bindings.DisputeGameFactory](

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -145,7 +145,7 @@ func delegateCallWithSetCode(
 		// Use the EIP-7825 max transaction gas limit to give the migration maximum room.
 		txplan.WithGasLimit(params.MaxTxGas),
 		txplan.WithRetrySubmission(client, 5, retry.Exponential()),
-		txplan.WithRetryInclusion(client, 10, retry.Exponential()),
+		txplan.WithRetryInclusion(txplan.FromGethReceipts(client), 10, retry.Exponential()),
 	)
 
 	receipt, err := tx.Included.Eval(ctx)

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -13,12 +13,12 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	gnode "github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	opnodemetrics "github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -87,7 +87,7 @@ type L2API interface {
 	GetProof(ctx context.Context, address common.Address, storage []common.Hash, blockTag string) (*eth.AccountResult, error)
 	OutputV0AtBlock(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error)
 
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error)
 	BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error)
 	ChainID(ctx context.Context) (*big.Int, error)
 }

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/client"
@@ -34,14 +34,14 @@ const progressLogInterval = 10 * time.Second
 type EthClient interface {
 	InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error)
 	InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error)
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, gethTypes.Receipts, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error)
 	Close()
 }
 
 type blockFetch struct {
 	blockNum  uint64
 	blockInfo eth.BlockInfo
-	receipts  gethTypes.Receipts
+	receipts  optypes.Receipts
 	err       error
 }
 
@@ -681,7 +681,7 @@ func (c *LogsDBChainIngester) ingestBlockRange(startBlock, endBlock uint64, last
 			// Resolve the number to a hash first, then fetch receipts by hash so
 			// the receipts are pinned to the block identity we are about to write.
 			blockInfo, err := c.ethClient.InfoByNumber(rangeCtx, blockNum)
-			var receipts gethTypes.Receipts
+			var receipts optypes.Receipts
 			if err != nil {
 				err = fmt.Errorf("fetch block info: %w", err)
 			} else {
@@ -822,7 +822,7 @@ func (c *LogsDBChainIngester) recordIngestionProgress(blockNum, head uint64) {
 }
 
 func (c *LogsDBChainIngester) processBlockLogs(blockInfo eth.BlockInfo, blockID eth.BlockID,
-	receipts gethTypes.Receipts, blockNum uint64) (uint32, error) {
+	receipts optypes.Receipts, blockNum uint64) (uint32, error) {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/op-interop-filter/filter/logsdb_dispatch_test.go
+++ b/op-interop-filter/filter/logsdb_dispatch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -74,7 +75,7 @@ func fetchedBlock(num, ts uint64, parent common.Hash) blockFetch {
 	return blockFetch{
 		blockNum:  num,
 		blockInfo: info,
-		receipts:  gethTypes.Receipts{{TxHash: common.Hash{byte(num)}, Logs: []*gethTypes.Log{plainLog(0, num)}}},
+		receipts:  optypes.Receipts{{Receipt: gethTypes.Receipt{TxHash: common.Hash{byte(num)}, Logs: []*gethTypes.Log{plainLog(0, num)}}}},
 	}
 }
 

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -12,6 +12,7 @@ import (
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop"
@@ -351,7 +352,7 @@ func (m *MockEthClient) InfoByNumber(ctx context.Context, number uint64) (eth.Bl
 }
 
 // FetchReceipts implements EthClient.
-func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, gethTypes.Receipts, error) {
+func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -367,11 +368,11 @@ func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash
 	// Find the block info for this hash
 	for _, block := range m.blocksByNumber {
 		if block.Hash() == blockHash {
-			return block, receipts, nil
+			return block, optypes.FromGethReceipts(receipts), nil
 		}
 	}
 
-	return nil, receipts, nil
+	return nil, optypes.FromGethReceipts(receipts), nil
 }
 
 // Close implements EthClient.

--- a/op-interop-mon/monitor/finder.go
+++ b/op-interop-mon/monitor/finder.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/buffer"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -30,7 +31,7 @@ type FinalityCallback func(chainID eth.ChainID, block eth.BlockInfo)
 type FinderClient interface {
 	InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error)
 	InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error)
-	FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, types.Receipts, error)
+	FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, optypes.Receipts, error)
 }
 
 var _ FinderClient = &sources.EthClient{}
@@ -155,7 +156,7 @@ var ErrBlockNotContiguous = errors.New("blocks are not contiguous")
 // it then adds the block to the seenBlocks buffer
 // it returns a sentinel error if the block was not contiguous and
 // a generic error any of the steps fail
-func (t *RPCFinder) processBlock(blockInfo eth.BlockInfo, receipts types.Receipts) error {
+func (t *RPCFinder) processBlock(blockInfo eth.BlockInfo, receipts optypes.Receipts) error {
 	previous := t.seenBlocks.Peek()
 	if previous != nil {
 		// check if the blocks being processed are contiguous
@@ -165,7 +166,7 @@ func (t *RPCFinder) processBlock(blockInfo eth.BlockInfo, receipts types.Receipt
 			return ErrBlockNotContiguous
 		}
 	}
-	jobs := t.toJobs([]*types.Receipt(receipts), t.chainID)
+	jobs := t.toJobs(receipts.Geth(), t.chainID)
 	firstSeen := time.Now()
 	for _, job := range jobs {
 		job.firstSeen = firstSeen

--- a/op-interop-mon/monitor/finder_test.go
+++ b/op-interop-mon/monitor/finder_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum"
@@ -19,7 +20,7 @@ import (
 type mockClient struct {
 	infoByLabel           func(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error)
 	infoByNumber          func(ctx context.Context, number uint64) (eth.BlockInfo, error)
-	fetchReceiptsByNumber func(ctx context.Context, number uint64) (eth.BlockInfo, types.Receipts, error)
+	fetchReceiptsByNumber func(ctx context.Context, number uint64) (eth.BlockInfo, optypes.Receipts, error)
 	err                   error
 }
 
@@ -45,7 +46,7 @@ func (m *mockClient) InfoByNumber(ctx context.Context, number uint64) (eth.Block
 	}
 }
 
-func (m *mockClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, types.Receipts, error) {
+func (m *mockClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, optypes.Receipts, error) {
 	if m.fetchReceiptsByNumber != nil {
 		return m.fetchReceiptsByNumber(ctx, number)
 	} else {
@@ -101,11 +102,11 @@ func TestRPCFinder_processBlock(t *testing.T) {
 
 	finder := NewFinder(eth.ChainIDFromUInt64(1), client, fakeReceiptsToCases, callback, mockFinalizedCallback, 1000, logger)
 
-	receipts := []*types.Receipt{
-		{
+	receipts := optypes.Receipts{
+		{Receipt: types.Receipt{
 			Status: 1,
 			TxHash: common.Hash{0x1},
-		},
+		}},
 	}
 
 	// Add a first block
@@ -153,7 +154,7 @@ func TestProcessBlockSetsExecutingTimestamp(t *testing.T) {
 	)
 
 	blockInfo := eth.HeaderBlockInfo(&types.Header{Number: big.NewInt(5), Time: 1234})
-	require.NoError(t, finder.processBlock(blockInfo, types.Receipts{}))
+	require.NoError(t, finder.processBlock(blockInfo, optypes.Receipts{}))
 	require.NotNil(t, got)
 	require.Equal(t, uint64(1234), got.executingTimestamp)
 }

--- a/op-interop-mon/monitor/updater.go
+++ b/op-interop-mon/monitor/updater.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/locks"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -23,7 +24,7 @@ var ErrLogNotFound = errors.New("log not found")
 var updateInterval = 1 * time.Second
 
 type UpdaterClient interface {
-	FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, types.Receipts, error)
+	FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, optypes.Receipts, error)
 }
 
 var _ UpdaterClient = &sources.EthClient{}
@@ -201,7 +202,7 @@ func (t *RPCUpdater) UpdateJobStatus(job *Job) {
 	// Add the block hash to the job's initiating hashes
 	job.AddInitiatingHash(blockInfo.Hash())
 
-	log, err := t.findLogEvent(receipts, job)
+	log, err := t.findLogEvent(receipts.Geth(), job)
 	if err == ErrLogNotFound {
 		t.log.Warn("initiating log not found", "job", job.String())
 		job.UpdateStatus(jobStatusInvalid)

--- a/op-interop-mon/monitor/updater_test.go
+++ b/op-interop-mon/monitor/updater_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/locks"
 	"github.com/ethereum/go-ethereum/common"
@@ -279,11 +280,11 @@ func TestUpdaterJobStatusUpdate(t *testing.T) {
 			}
 
 			// Configure mock client to return the test receipts
-			client.fetchReceiptsByNumber = func(ctx context.Context, number uint64) (eth.BlockInfo, ethtypes.Receipts, error) {
+			client.fetchReceiptsByNumber = func(ctx context.Context, number uint64) (eth.BlockInfo, optypes.Receipts, error) {
 				if tt.receipts == nil {
 					return nil, nil, errors.New("mock error")
 				}
-				return eth.HeaderBlockInfo(&ethtypes.Header{}), tt.receipts, nil
+				return eth.HeaderBlockInfo(&ethtypes.Header{}), optypes.FromGethReceipts(tt.receipts), nil
 			}
 
 			// Update job status
@@ -370,9 +371,9 @@ func TestUpdaterValidityInvariants(t *testing.T) {
 			expiry := locks.RWMapFromMap(map[eth.ChainID]eth.NumberAndHash{})
 			updater := NewUpdater(eth.ChainIDFromUInt64(1), client, expiry, tt.expiryWindow, logger)
 
-			client.fetchReceiptsByNumber = func(ctx context.Context, number uint64) (eth.BlockInfo, ethtypes.Receipts, error) {
+			client.fetchReceiptsByNumber = func(ctx context.Context, number uint64) (eth.BlockInfo, optypes.Receipts, error) {
 				blk := eth.HeaderBlockInfo(&ethtypes.Header{Number: big.NewInt(100), Time: tt.blockTime})
-				return blk, ethtypes.Receipts{{Logs: []*ethtypes.Log{validLog}}}, nil
+				return blk, optypes.FromGethReceipts(ethtypes.Receipts{{Logs: []*ethtypes.Log{validLog}}}), nil
 			}
 
 			job := &Job{

--- a/op-node/metrics/metered/metered_l1fetcher.go
+++ b/op-node/metrics/metered/metered_l1fetcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -19,7 +20,7 @@ type L1Fetcher interface {
 	L1BlockRefByNumber(context.Context, uint64) (eth.L1BlockRef, error)
 	L1BlockRefByHash(context.Context, common.Hash) (eth.L1BlockRef, error)
 	InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error)
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error)
 	InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error)
 }
 
@@ -63,7 +64,7 @@ func (m *MeteredL1Fetcher) InfoAndTxsByHash(ctx context.Context, hash common.Has
 	return m.inner.InfoAndTxsByHash(ctx, hash)
 }
 
-func (m *MeteredL1Fetcher) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+func (m *MeteredL1Fetcher) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
 	defer m.recordTime("FetchReceipts")()
 	return m.inner.FetchReceipts(ctx, blockHash)
 }

--- a/op-node/metrics/metered/metered_l1fetcher_test.go
+++ b/op-node/metrics/metered/metered_l1fetcher_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
@@ -85,8 +86,8 @@ func TestDurationRecorded(t *testing.T) {
 		{
 			method: "FetchReceipts",
 			call: func(t *testing.T, fetcher *MeteredL1Fetcher, inner *testutils.MockL1Source) {
-				rcpts := types.Receipts{
-					&types.Receipt{},
+				rcpts := optypes.Receipts{
+					&optypes.Receipt{},
 				}
 				inner.ExpectFetchReceipts(hash, info, rcpts, expectedErr)
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/node/runcfg"
@@ -56,7 +57,7 @@ type L1Client interface {
 	InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error)
 	InfoAndTxsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, types.Transactions, error)
 	InfoAndTxsByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, types.Transactions, error)
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error)
 	GetProof(ctx context.Context, address common.Address, storage []common.Hash, blockTag string) (*eth.AccountResult, error)
 	GetStorageAt(ctx context.Context, address common.Address, storageSlot common.Hash, blockTag string) (common.Hash, error)
 	ReadStorageAt(ctx context.Context, address common.Address, storageSlot common.Hash, blockHash common.Hash) (common.Hash, error)
@@ -80,7 +81,7 @@ type L1Source interface {
 	ReadStorageAt(ctx context.Context, address common.Address, storageSlot common.Hash, blockHash common.Hash) (common.Hash, error)
 	InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error)
 	InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error)
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error)
 	Close()
 }
 

--- a/op-node/rollup/derive/altda_data_source_test.go
+++ b/op-node/rollup/derive/altda_data_source_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -119,7 +120,7 @@ func TestAltDADataSource(t *testing.T) {
 		l1Refs = append(l1Refs, ref)
 		logger.Info("new l1 block", "ref", ref)
 		// called for each l1 block to sync challenges
-		l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
+		l1F.ExpectFetchReceipts(ref.Hash, nil, optypes.Receipts{}, nil)
 
 		// pick a random number of commitments to include in the l1 block
 		c := rng.Intn(4)
@@ -207,7 +208,7 @@ func TestAltDADataSource(t *testing.T) {
 			logger.Info("re deriving block", "ref", ref, "i", i)
 
 			if i == len(l1Refs)-1 {
-				l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
+				l1F.ExpectFetchReceipts(ref.Hash, nil, optypes.Receipts{}, nil)
 			}
 			// once past the l1 head, continue generating new l1 refs
 		} else {
@@ -222,7 +223,7 @@ func TestAltDADataSource(t *testing.T) {
 			l1Refs = append(l1Refs, ref)
 			logger.Info("new l1 block", "ref", ref)
 			// called for each l1 block to sync challenges
-			l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
+			l1F.ExpectFetchReceipts(ref.Hash, nil, optypes.Receipts{}, nil)
 
 			// pick a random number of commitments to include in the l1 block
 			c := rng.Intn(4)
@@ -352,7 +353,7 @@ func TestAltDADataSourceStall(t *testing.T) {
 		ParentHash: parent.Hash,
 		Time:       parent.Time + l1Time,
 	}
-	l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
+	l1F.ExpectFetchReceipts(ref.Hash, nil, optypes.Receipts{}, nil)
 	// mock input commitments in l1 transactions
 	input := testutils.RandomData(rng, 2000)
 	comm, _ := storage.SetInput(ctx, input)
@@ -392,7 +393,7 @@ func TestAltDADataSourceStall(t *testing.T) {
 		Hash:   testutils.RandomHash(rng),
 	}
 	l1F.ExpectL1BlockRefByNumber(nextRef.Number, nextRef, nil)
-	l1F.ExpectFetchReceipts(nextRef.Hash, nil, types.Receipts{}, nil)
+	l1F.ExpectFetchReceipts(nextRef.Hash, nil, optypes.Receipts{}, nil)
 
 	// not enough data
 	_, err = src.Next(ctx)
@@ -475,7 +476,7 @@ func TestAltDADataSourceInvalidData(t *testing.T) {
 		ParentHash: parent.Hash,
 		Time:       parent.Time + l1Time,
 	}
-	l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
+	l1F.ExpectFetchReceipts(ref.Hash, nil, optypes.Receipts{}, nil)
 	// mock input commitments in l1 transactions with an oversized input
 	input := testutils.RandomData(rng, altda.MaxInputSize+1)
 	comm, _ := storage.SetInput(ctx, input)

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -23,7 +24,7 @@ type DependencySet interface {
 // L1ReceiptsFetcher fetches L1 header info and receipts for the payload attributes derivation (the info tx and deposits)
 type L1ReceiptsFetcher interface {
 	InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error)
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error)
 }
 
 type SystemConfigL2Fetcher interface {
@@ -89,7 +90,7 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 					epoch, info.ParentHash(), l2Parent.L1Origin))
 		}
 
-		deposits, err := DeriveDeposits(receipts, ba.rollupCfg.DepositContractAddress)
+		deposits, err := DeriveDeposits(receipts.Geth(), ba.rollupCfg.DepositContractAddress)
 		if err != nil {
 			// deposits may never be ignored. Failing to process them is a critical error.
 			return nil, NewCriticalError(fmt.Errorf("failed to derive some deposits: %w", err))
@@ -97,7 +98,7 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 
 		// errors from UpdateSystemConfigWithL1Receipts are ignored as they represent malformed or invalid updates
 		// and there is no recovery mechanism for malformed updates, we must process past them.
-		_ = UpdateSystemConfigWithL1Receipts(&sysConfig, receipts, ba.rollupCfg, info.Time())
+		_ = UpdateSystemConfigWithL1Receipts(&sysConfig, receipts.Geth(), ba.rollupCfg, info.Time())
 
 		l1Info = info
 		depositTxs = deposits

--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -163,7 +163,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 
 		l2Txs := append(append(make([]eth.Data, 0), l1InfoTx), usedDepositTxs...)
 
-		l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, receipts, nil)
+		l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, optypes.FromGethReceipts(receipts), nil)
 		attrBuilder := NewFetchingAttributesBuilder(cfg, params.MergedTestChainConfig, nil, l1Fetcher, l1CfgFetcher)
 		attrs, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.NoError(t, err)
@@ -242,7 +242,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		l2Txs = append(l2Txs, l1InfoTx)
 		l2Txs = append(l2Txs, userDepositTxs...)
 
-		l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, receipts, nil)
+		l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, optypes.FromGethReceipts(receipts), nil)
 		attrBuilder := NewFetchingAttributesBuilder(cfg, params.MergedTestChainConfig, depSet, l1Fetcher, l1CfgFetcher)
 		attrs, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.NoError(t, err)

--- a/op-node/rollup/derive/l1_traversal.go
+++ b/op-node/rollup/derive/l1_traversal.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -19,7 +19,7 @@ import (
 
 type L1BlockRefByNumberFetcher interface {
 	L1BlockRefByNumber(context.Context, uint64) (eth.L1BlockRef, error)
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error)
 }
 
 type L1Traversal struct {
@@ -75,7 +75,7 @@ func (l1t *L1Traversal) AdvanceL1Block(ctx context.Context) error {
 	if err != nil {
 		return NewTemporaryError(fmt.Errorf("failed to fetch receipts of L1 block %s (parent: %s) for L1 sysCfg update: %w", nextL1Origin, origin, err))
 	}
-	if err := UpdateSystemConfigWithL1Receipts(&l1t.sysCfg, receipts, l1t.cfg, nextL1Origin.Time); err != nil {
+	if err := UpdateSystemConfigWithL1Receipts(&l1t.sysCfg, receipts.Geth(), l1t.cfg, nextL1Origin.Time); err != nil {
 		// if UpdateSystemConfigWithL1Receipts returns an error, it is because one or more of the receipts are malformed or invalid
 		// failure to apply is just informational, so we just log the error and continue
 		l1t.log.Warn("failed to fully update L1 sysCfg with receipts from block", "block", nextL1Origin, "error", err)

--- a/op-node/rollup/derive/l1_traversal_test.go
+++ b/op-node/rollup/derive/l1_traversal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -125,7 +126,7 @@ func TestL1TraversalAdvance(t *testing.T) {
 				// TODO: don't need full L1 info in receipts fetching API maybe?
 			}
 			if test.l1Receipts != nil {
-				src.ExpectFetchReceipts(test.nextBlock.Hash, info, test.l1Receipts, nil)
+				src.ExpectFetchReceipts(test.nextBlock.Hash, info, optypes.FromGethReceipts(test.l1Receipts), nil)
 			}
 
 			cfg := &rollup.Config{

--- a/op-node/rollup/derive/payload_util_test.go
+++ b/op-node/rollup/derive/payload_util_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-core/forks"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/ptr"
@@ -164,7 +165,7 @@ func TestPayloadToSystemConfigUpgradeGas(t *testing.T) {
 				Data: logData,
 			}},
 		}}
-		l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, receipts, nil)
+		l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, optypes.FromGethReceipts(receipts), nil)
 
 		attrBuilder := NewFetchingAttributesBuilder(cfg, params.MergedTestChainConfig, nil, l1Fetcher, l1CfgFetcher)
 		attrs, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)

--- a/op-service/apis/eth.go
+++ b/op-service/apis/eth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 )
@@ -43,6 +44,31 @@ type EthHeader interface {
 	HeaderAndTxsByHash(ctx context.Context, hash common.Hash) (*types.Header, types.Transactions, error)
 }
 
+// EthL2BlockTxs partitions an L2 block's transactions by class: the OP Stack
+// synthetic transactions (0x7E deposits, 0x7D post-exec) are routed to
+// op-core/types structs, and the remainder — standard Ethereum transactions —
+// decode as go-ethereum types on any block. Use these instead of InfoAndTxsBy*
+// for L2 blocks, whose full transaction lists upstream go-ethereum cannot
+// decode.
+type EthL2BlockTxs interface {
+	// InfoAndUserTxsByHash returns a block's standard Ethereum transactions,
+	// excluding the OP Stack synthetic classes.
+	InfoAndUserTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error)
+
+	InfoAndUserTxsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, types.Transactions, error)
+
+	// InfoAndDepositsByHash returns a block's deposit (0x7E) transactions.
+	InfoAndDepositsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, []*optypes.DepositTx, error)
+
+	InfoAndDepositsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, []*optypes.DepositTx, error)
+
+	// InfoAndFirstDepositByHash returns a block's first transaction decoded as
+	// a deposit — the L1-info deposit of an L2 block.
+	InfoAndFirstDepositByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, *optypes.DepositTx, error)
+
+	InfoAndFirstDepositByNumber(ctx context.Context, number uint64) (eth.BlockInfo, *optypes.DepositTx, error)
+}
+
 type EthPayload interface {
 	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
 
@@ -55,12 +81,15 @@ type ReceiptsFetcher interface {
 	// FetchReceipts returns a block info and all of the receipts associated with transactions in the block.
 	// It verifies the receipt hash in the block header against the receipt hash of the fetched receipts
 	// to ensure that the execution engine did not fail to return any receipts.
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	// The OP Stack extension fields are populated when the fetch method carries
+	// them (JSON methods; the raw consensus-encoded path has no fee metadata).
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error)
 }
 
 type ReceiptFetcher interface {
-	// TransactionReceipt returns a receipt associated with transaction.
-	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+	// TransactionReceipt returns a receipt associated with transaction, with
+	// the OP Stack extension fields populated when present in the response.
+	TransactionReceipt(ctx context.Context, txHash common.Hash) (*optypes.Receipt, error)
 }
 
 type ExecutionWitness interface {
@@ -167,5 +196,6 @@ type EthClient interface {
 type EthExtendedClient interface {
 	EthClient
 	EthPayload
+	EthL2BlockTxs
 	ReceiptsFetcher
 }

--- a/op-service/eth/receipts.go
+++ b/op-service/eth/receipts.go
@@ -7,6 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 )
 
 // EncodeReceipts encodes a list of receipts into raw receipts. Some non-consensus meta-data may be lost.
@@ -24,12 +26,15 @@ func EncodeReceipts(elems []*types.Receipt) ([]hexutil.Bytes, error) {
 
 // DecodeRawReceipts decodes receipts and adds additional blocks metadata.
 // The contract-deployment addresses are not set however (high cost, depends on nonce values, unused by op-node).
-func DecodeRawReceipts(block BlockID, rawReceipts []hexutil.Bytes, txHashes []common.Hash) ([]*types.Receipt, error) {
-	result := make([]*types.Receipt, len(rawReceipts))
+// The OP JSON-only fee fields (L1GasPrice, OperatorFeeScalar, ...) are not part
+// of the consensus encoding and remain nil; the consensus-encoded deposit
+// receipt fields (DepositNonce, DepositReceiptVersion) are decoded.
+func DecodeRawReceipts(block BlockID, rawReceipts []hexutil.Bytes, txHashes []common.Hash) (optypes.Receipts, error) {
+	result := make(optypes.Receipts, len(rawReceipts))
 	totalIndex := uint(0)
 	prevCumulativeGasUsed := uint64(0)
 	for i, r := range rawReceipts {
-		var x types.Receipt
+		var x optypes.Receipt
 		if err := x.UnmarshalBinary(r); err != nil {
 			return nil, fmt.Errorf("failed to decode receipt %d: %w", i, err)
 		}

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -131,9 +132,9 @@ type EthClient struct {
 
 	log log.Logger
 
-	// cache transactions in bundles per block hash
-	// common.Hash -> types.Transactions
-	transactionsCache *caching.LRUCache[common.Hash, types.Transactions]
+	// cache transactions in bundles per block hash, in canonical binary encoding
+	// common.Hash -> RawTransactions
+	transactionsCache *caching.LRUCache[common.Hash, RawTransactions]
 
 	// cache block headers of blocks by hash
 	// common.Hash -> *types.Header
@@ -168,7 +169,7 @@ func NewEthClient(client client.RPC, log log.Logger, metrics caching.Metrics, co
 		trustRPC:          config.TrustRPC,
 		mustBePostMerge:   config.MustBePostMerge,
 		log:               log,
-		transactionsCache: caching.NewLRUCache[common.Hash, types.Transactions](metrics, "txs", config.TransactionsCacheSize),
+		transactionsCache: caching.NewLRUCache[common.Hash, RawTransactions](metrics, "txs", config.TransactionsCacheSize),
 		headersCache:      caching.NewLRUCache[common.Hash, *types.Header](metrics, "headers", config.HeadersCacheSize),
 		payloadsCache:     caching.NewLRUCache[common.Hash, *eth.ExecutionPayloadEnvelope](metrics, "payloads", config.PayloadsCacheSize),
 		blockRefsCache:    caching.NewLRUCache[common.Hash, eth.L1BlockRef](metrics, "blockrefs", config.BlockRefsCacheSize),
@@ -237,9 +238,9 @@ func (s *EthClient) headerCall(ctx context.Context, method string, id rpcBlockID
 
 // blockCall fetches a header + transactions (eth_getBlockBy* with fullTx=true),
 // verifies the header and block-level data (txs root, withdrawals), caches
-// both, and returns them. Source of truth for both HeaderAndTxsBy* and
-// InfoAndTxsBy*.
-func (s *EthClient) blockCall(ctx context.Context, method string, id rpcBlockID) (*types.Header, types.Transactions, error) {
+// both, and returns them. Transactions stay in their canonical binary
+// encoding. Source of truth for every block-body accessor.
+func (s *EthClient) blockCall(ctx context.Context, method string, id rpcBlockID) (*types.Header, RawTransactions, error) {
 	var block *RPCBlock
 	err := s.client.CallContext(ctx, &block, method, id.Arg(), true)
 	if err != nil {
@@ -317,16 +318,35 @@ func (s *EthClient) HeaderByLabel(ctx context.Context, label eth.BlockLabel) (*t
 	return s.headerCall(ctx, "eth_getBlockByNumber", label)
 }
 
-// HeaderAndTxsByHash returns the *types.Header and transactions for the given
-// block hash. Source of truth for block fetching: HeaderAndTxs* and
-// InfoAndTxs* both flow through this and blockCall.
-func (s *EthClient) HeaderAndTxsByHash(ctx context.Context, hash common.Hash) (*types.Header, types.Transactions, error) {
+// headerAndRawTxsByHash returns the header and canonical binary-encoded
+// transactions for the given block hash, from cache when possible.
+func (s *EthClient) headerAndRawTxsByHash(ctx context.Context, hash common.Hash) (*types.Header, RawTransactions, error) {
 	if header, ok := s.headersCache.Get(hash); ok {
 		if txs, ok := s.transactionsCache.Get(hash); ok {
 			return header, txs, nil
 		}
 	}
 	return s.blockCall(ctx, "eth_getBlockByHash", hashID(hash))
+}
+
+// HeaderAndTxsByHash returns the *types.Header and transactions for the given
+// block hash.
+//
+// The transactions are decoded into go-ethereum types: for L2 blocks — which
+// contain OP Stack synthetic transactions — use the class-partitioned
+// accessors (InfoAndUserTxsBy*, InfoAndDepositsBy*, InfoAndFirstDepositBy*)
+// instead, as this decode only handles them while the build resolves
+// go-ethereum to op-geth.
+func (s *EthClient) HeaderAndTxsByHash(ctx context.Context, hash common.Hash) (*types.Header, types.Transactions, error) {
+	header, rawTxs, err := s.headerAndRawTxsByHash(ctx, hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	txs, err := rawTxs.Geth()
+	if err != nil {
+		return nil, nil, err
+	}
+	return header, txs, nil
 }
 
 func (s *EthClient) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
@@ -353,6 +373,9 @@ func (s *EthClient) InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.
 	return eth.HeaderBlockInfo(header), nil
 }
 
+// InfoAndTxsByHash returns the block info and decoded go-ethereum
+// transactions. See HeaderAndTxsByHash for the L2 caveat — L2 block bodies
+// should be read via the class-partitioned accessors.
 func (s *EthClient) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
 	header, txs, err := s.HeaderAndTxsByHash(ctx, hash)
 	if err != nil {
@@ -361,22 +384,118 @@ func (s *EthClient) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth
 	return eth.HeaderBlockInfoTrusted(hash, header), txs, nil
 }
 
+// InfoAndTxsByNumber is InfoAndTxsByHash by block number; same L2 caveat.
 func (s *EthClient) InfoAndTxsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, types.Transactions, error) {
 	// can't hit the cache when querying by number due to reorgs.
-	header, txs, err := s.blockCall(ctx, "eth_getBlockByNumber", numberID(number))
+	header, rawTxs, err := s.blockCall(ctx, "eth_getBlockByNumber", numberID(number))
+	if err != nil {
+		return nil, nil, err
+	}
+	txs, err := rawTxs.Geth()
 	if err != nil {
 		return nil, nil, err
 	}
 	return eth.HeaderBlockInfo(header), txs, nil
 }
 
+// InfoAndTxsByLabel is InfoAndTxsByHash by block label; same L2 caveat.
 func (s *EthClient) InfoAndTxsByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, types.Transactions, error) {
 	// can't hit the cache when querying the head due to reorgs / changes.
-	header, txs, err := s.blockCall(ctx, "eth_getBlockByNumber", label)
+	header, rawTxs, err := s.blockCall(ctx, "eth_getBlockByNumber", label)
+	if err != nil {
+		return nil, nil, err
+	}
+	txs, err := rawTxs.Geth()
 	if err != nil {
 		return nil, nil, err
 	}
 	return eth.HeaderBlockInfo(header), txs, nil
+}
+
+// InfoAndUserTxsByHash returns the block info and the block's standard
+// Ethereum transactions, excluding the OP Stack synthetic classes (0x7E
+// deposits and 0x7D post-exec). The returned list decodes with upstream
+// go-ethereum on any block, L2 included.
+func (s *EthClient) InfoAndUserTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
+	header, rawTxs, err := s.headerAndRawTxsByHash(ctx, hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	txs, err := rawTxs.UserTxs()
+	if err != nil {
+		return nil, nil, err
+	}
+	return eth.HeaderBlockInfoTrusted(hash, header), txs, nil
+}
+
+// InfoAndUserTxsByNumber is InfoAndUserTxsByHash by block number.
+func (s *EthClient) InfoAndUserTxsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, types.Transactions, error) {
+	// can't hit the cache when querying by number due to reorgs.
+	header, rawTxs, err := s.blockCall(ctx, "eth_getBlockByNumber", numberID(number))
+	if err != nil {
+		return nil, nil, err
+	}
+	txs, err := rawTxs.UserTxs()
+	if err != nil {
+		return nil, nil, err
+	}
+	return eth.HeaderBlockInfo(header), txs, nil
+}
+
+// InfoAndDepositsByHash returns the block info and the block's deposit (0x7E)
+// transactions as op-core structs.
+func (s *EthClient) InfoAndDepositsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, []*optypes.DepositTx, error) {
+	header, rawTxs, err := s.headerAndRawTxsByHash(ctx, hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	deposits, err := rawTxs.Deposits()
+	if err != nil {
+		return nil, nil, err
+	}
+	return eth.HeaderBlockInfoTrusted(hash, header), deposits, nil
+}
+
+// InfoAndDepositsByNumber is InfoAndDepositsByHash by block number.
+func (s *EthClient) InfoAndDepositsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, []*optypes.DepositTx, error) {
+	header, rawTxs, err := s.blockCall(ctx, "eth_getBlockByNumber", numberID(number))
+	if err != nil {
+		return nil, nil, err
+	}
+	deposits, err := rawTxs.Deposits()
+	if err != nil {
+		return nil, nil, err
+	}
+	return eth.HeaderBlockInfo(header), deposits, nil
+}
+
+// InfoAndFirstDepositByHash returns the block info and the block's first
+// transaction decoded as a deposit — the L1-info deposit of an L2 block. It
+// returns ErrMissingFirstDeposit if the block has no transactions or the
+// first one is not a deposit.
+func (s *EthClient) InfoAndFirstDepositByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, *optypes.DepositTx, error) {
+	header, rawTxs, err := s.headerAndRawTxsByHash(ctx, hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	deposit, err := rawTxs.FirstDeposit()
+	if err != nil {
+		return nil, nil, err
+	}
+	return eth.HeaderBlockInfoTrusted(hash, header), deposit, nil
+}
+
+// InfoAndFirstDepositByNumber is InfoAndFirstDepositByHash by block number.
+func (s *EthClient) InfoAndFirstDepositByNumber(ctx context.Context, number uint64) (eth.BlockInfo, *optypes.DepositTx, error) {
+	header, rawTxs, err := s.blockCall(ctx, "eth_getBlockByNumber", numberID(number))
+	if err != nil {
+		return nil, nil, err
+	}
+	deposit, err := rawTxs.FirstDeposit()
+	if err != nil {
+		return nil, nil, err
+	}
+	return eth.HeaderBlockInfo(header), deposit, nil
 }
 
 func (s *EthClient) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
@@ -396,7 +515,7 @@ func (s *EthClient) PayloadByLabel(ctx context.Context, label eth.BlockLabel) (*
 
 // FetchReceiptsByNumber returns a block info and all of the receipts associated with transactions in the block.
 // It fetches the block hash and calls FetchReceipts.
-func (s *EthClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, types.Receipts, error) {
+func (s *EthClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, optypes.Receipts, error) {
 	blockHash, err := s.InfoByNumber(ctx, number)
 	if err != nil {
 		return nil, nil, fmt.Errorf("querying block: %w", err)
@@ -407,23 +526,28 @@ func (s *EthClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (e
 // FetchReceipts returns a block info and all of the receipts associated with transactions in the block.
 // It verifies the receipt hash in the block header against the receipt hash of the fetched receipts
 // to ensure that the execution engine did not fail to return any receipts.
-func (s *EthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
-	info, txs, err := s.InfoAndTxsByHash(ctx, blockHash)
+func (s *EthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
+	// Tx hashes are computed from the raw encodings: decoding the txs into
+	// go-ethereum types would fail on the OP Stack synthetic tx classes of L2
+	// blocks under upstream go-ethereum.
+	header, rawTxs, err := s.headerAndRawTxsByHash(ctx, blockHash)
 	if err != nil {
 		return nil, nil, fmt.Errorf("querying block: %w", err)
 	}
+	info := eth.HeaderBlockInfoTrusted(blockHash, header)
 
-	txHashes, _ := eth.TransactionsToHashes(txs), eth.ToBlockID(info)
-	receipts, err := s.recProvider.FetchReceipts(ctx, info, txHashes)
+	receipts, err := s.recProvider.FetchReceipts(ctx, info, rawTxs.Hashes())
 	if err != nil {
 		return nil, nil, err
 	}
 	return info, receipts, nil
 }
 
-// TransactionReceipt returns a receipt associated with transaction.
-func (s *EthClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
-	var r *types.Receipt
+// TransactionReceipt returns a receipt associated with transaction. The
+// OP Stack extension fields (L1GasPrice, OperatorFeeScalar, ...) are populated
+// when present in the response.
+func (s *EthClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*optypes.Receipt, error) {
+	var r *optypes.Receipt
 	err := s.client.CallContext(ctx, &r, "eth_getTransactionReceipt", txHash)
 	if err == nil && r == nil {
 		return nil, ethereum.NotFound

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -213,7 +213,7 @@ func TestEthClient_WrongInfoByHash(t *testing.T) {
 
 func newEthClientWithCaches(metrics caching.Metrics, cacheSize int) *EthClient {
 	return &EthClient{
-		transactionsCache: caching.NewLRUCache[common.Hash, types.Transactions](metrics, "txs", cacheSize),
+		transactionsCache: caching.NewLRUCache[common.Hash, RawTransactions](metrics, "txs", cacheSize),
 		headersCache:      caching.NewLRUCache[common.Hash, *types.Header](metrics, "headers", cacheSize),
 		payloadsCache:     caching.NewLRUCache[common.Hash, *eth.ExecutionPayloadEnvelope](metrics, "payloads", cacheSize),
 	}

--- a/op-service/sources/raw_transaction.go
+++ b/op-service/sources/raw_transaction.go
@@ -1,0 +1,214 @@
+package sources
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
+)
+
+// RawTransaction is a canonical binary-encoded transaction — a typed-tx
+// envelope, or the RLP of a legacy transaction — that (un)marshals the
+// eth_getBlockBy* JSON transaction-object form. The OP Stack synthetic classes
+// (0x7E deposit, 0x7D post-exec) are codec'd by op-core/types; everything else
+// by go-ethereum. Keeping block transactions in this form lets an L2 block
+// round-trip without go-ethereum's types.Transaction ever holding an OP
+// synthetic transaction: the transactions-trie leaf of a typed transaction IS
+// its opaque encoding, and class-specific access decodes on demand.
+type RawTransaction hexutil.Bytes
+
+// Type returns the EIP-2718 transaction type byte, or types.LegacyTxType for
+// legacy (RLP-list) payloads and empty input.
+func (tx RawTransaction) Type() byte {
+	if len(tx) == 0 || tx[0] > 0x7f {
+		return types.LegacyTxType
+	}
+	return tx[0]
+}
+
+// Hash returns the transaction hash: the keccak-256 hash of the canonical
+// encoding — legacy RLP, or the EIP-2718 typed-tx envelope.
+func (tx RawTransaction) Hash() common.Hash {
+	return crypto.Keccak256Hash(tx)
+}
+
+// UnmarshalJSON decodes an RPC transaction object into its canonical binary
+// encoding, routing by the EIP-2718 type field. A JSON null decodes to an
+// empty RawTransaction, which block verification rejects.
+func (tx *RawTransaction) UnmarshalJSON(input []byte) error {
+	if string(input) == "null" {
+		*tx = nil
+		return nil
+	}
+	var peek struct {
+		Type *hexutil.Uint64 `json:"type"`
+	}
+	if err := json.Unmarshal(input, &peek); err != nil {
+		return err
+	}
+	var typ uint64 // an absent type field means a legacy transaction
+	if peek.Type != nil {
+		typ = uint64(*peek.Type)
+	}
+	var raw []byte
+	var err error
+	// Dispatch on the full type value: a value with a matching low byte but
+	// out of byte range (e.g. 0x17e) must not route to an OP codec — the
+	// default arm rejects it like op-geth does.
+	switch typ {
+	case uint64(optypes.DepositTxType):
+		var d optypes.DepositTx
+		if err := json.Unmarshal(input, &d); err != nil {
+			return fmt.Errorf("invalid deposit tx: %w", err)
+		}
+		raw, err = d.MarshalBinary()
+	case uint64(optypes.PostExecTxType):
+		var p optypes.PostExecTx
+		if err := json.Unmarshal(input, &p); err != nil {
+			return fmt.Errorf("invalid post-exec tx: %w", err)
+		}
+		raw, err = p.MarshalBinary()
+	default:
+		var gtx types.Transaction
+		if err := gtx.UnmarshalJSON(input); err != nil {
+			return err
+		}
+		raw, err = gtx.MarshalBinary()
+	}
+	if err != nil {
+		return fmt.Errorf("failed to encode tx type %#x: %w", typ, err)
+	}
+	*tx = raw
+	return nil
+}
+
+// MarshalJSON encodes the transaction as an RPC transaction object,
+// the inverse of UnmarshalJSON.
+func (tx RawTransaction) MarshalJSON() ([]byte, error) {
+	if len(tx) == 0 {
+		return nil, errors.New("empty transaction bytes")
+	}
+	switch tx.Type() {
+	case optypes.DepositTxType:
+		d, err := optypes.UnmarshalDepositTx(tx)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(d)
+	case optypes.PostExecTxType:
+		p, err := optypes.UnmarshalPostExecTx(tx)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(p)
+	default:
+		var gtx types.Transaction
+		if err := gtx.UnmarshalBinary(tx); err != nil {
+			return nil, err
+		}
+		return gtx.MarshalJSON()
+	}
+}
+
+// RawTransactions is a list of canonical binary-encoded transactions. It
+// implements types.DerivableList: the transactions-trie leaf of a typed
+// transaction is its opaque encoding verbatim, and a legacy transaction's raw
+// form already is its RLP.
+type RawTransactions []RawTransaction
+
+var _ types.DerivableList = (RawTransactions)(nil)
+
+func (txs RawTransactions) Len() int { return len(txs) }
+
+func (txs RawTransactions) EncodeIndex(i int, w *bytes.Buffer) {
+	w.Write(txs[i])
+}
+
+// Hashes returns the transaction hashes.
+func (txs RawTransactions) Hashes() []common.Hash {
+	out := make([]common.Hash, len(txs))
+	for i, tx := range txs {
+		out[i] = tx.Hash()
+	}
+	return out
+}
+
+// Geth decodes all transactions into go-ethereum types.Transactions.
+//
+// Use the class-partitioned accessors instead for L2 blocks: they can contain
+// OP Stack synthetic transactions (0x7E deposits, 0x7D post-exec), which
+// upstream go-ethereum's transaction decoding rejects. This decode works on
+// such blocks only while the build resolves go-ethereum to op-geth.
+func (txs RawTransactions) Geth() (types.Transactions, error) {
+	out := make(types.Transactions, len(txs))
+	for i, raw := range txs {
+		tx := new(types.Transaction)
+		if err := tx.UnmarshalBinary(raw); err != nil {
+			return nil, fmt.Errorf("failed to decode tx %d: %w", i, err)
+		}
+		out[i] = tx
+	}
+	return out, nil
+}
+
+// UserTxs decodes the standard Ethereum transactions of the list — every
+// transaction that is not an OP Stack synthetic (0x7E deposit or 0x7D
+// post-exec) — into go-ethereum types.Transactions.
+func (txs RawTransactions) UserTxs() (types.Transactions, error) {
+	out := make(types.Transactions, 0, len(txs))
+	for i, raw := range txs {
+		if len(raw) == 0 {
+			return nil, fmt.Errorf("tx %d is empty", i)
+		}
+		switch raw.Type() {
+		case optypes.DepositTxType, optypes.PostExecTxType:
+			continue
+		}
+		tx := new(types.Transaction)
+		if err := tx.UnmarshalBinary(raw); err != nil {
+			return nil, fmt.Errorf("failed to decode tx %d: %w", i, err)
+		}
+		out = append(out, tx)
+	}
+	return out, nil
+}
+
+// Deposits decodes the deposit (0x7E) transactions of the list.
+func (txs RawTransactions) Deposits() ([]*optypes.DepositTx, error) {
+	var out []*optypes.DepositTx
+	for i, raw := range txs {
+		if len(raw) == 0 {
+			return nil, fmt.Errorf("tx %d is empty", i)
+		}
+		if raw.Type() != optypes.DepositTxType {
+			continue
+		}
+		d, err := optypes.UnmarshalDepositTx(raw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode deposit tx %d: %w", i, err)
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+// ErrMissingFirstDeposit is returned by first-deposit accessors when a block's
+// first transaction is not an OP Stack deposit (empty blocks, L1 blocks).
+var ErrMissingFirstDeposit = errors.New("block's first transaction is not a deposit")
+
+// FirstDeposit decodes the first transaction of the list as a deposit (0x7E).
+// It returns ErrMissingFirstDeposit if the list is empty or the first
+// transaction is of another type.
+func (txs RawTransactions) FirstDeposit() (*optypes.DepositTx, error) {
+	if len(txs) == 0 || txs[0].Type() != optypes.DepositTxType {
+		return nil, ErrMissingFirstDeposit
+	}
+	return optypes.UnmarshalDepositTx(txs[0])
+}

--- a/op-service/sources/raw_transaction_test.go
+++ b/op-service/sources/raw_transaction_test.go
@@ -1,0 +1,195 @@
+package sources
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+// l2BlockTxs builds the transaction list shape of a Lagoon-era L2 block via
+// op-geth typed transactions: the L1-info deposit first, user transactions of
+// several standard types, and a trailing post-exec transaction.
+func l2BlockTxs(t *testing.T) types.Transactions {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	chainID := big.NewInt(10)
+	signer := types.LatestSignerForChainID(chainID)
+	to := common.HexToAddress("0x4242424242424242424242424242424242424242")
+
+	deposit := types.NewTx(&types.DepositTx{
+		SourceHash: common.HexToHash("0x01"),
+		From:       common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		Mint:       big.NewInt(0),
+		Value:      big.NewInt(0),
+		Gas:        1_000_000,
+		Data:       []byte{0xde, 0xad},
+	})
+	legacy := types.MustSignNewTx(key, signer, &types.LegacyTx{
+		Nonce: 0, GasPrice: big.NewInt(2), Gas: 21000, To: &to, Value: big.NewInt(1),
+	})
+	dynFee := types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
+		ChainID: chainID, Nonce: 1, GasTipCap: big.NewInt(1), GasFeeCap: big.NewInt(5),
+		Gas: 21000, To: &to, Value: big.NewInt(2),
+	})
+	blob := types.MustSignNewTx(key, signer, &types.BlobTx{
+		ChainID: uint256.NewInt(10), Nonce: 2, GasTipCap: uint256.NewInt(1),
+		GasFeeCap: uint256.NewInt(5), Gas: 21000, To: to, BlobFeeCap: uint256.NewInt(1),
+		BlobHashes: []common.Hash{{0x01}},
+	})
+	setCode := types.MustSignNewTx(key, signer, &types.SetCodeTx{
+		ChainID: uint256.NewInt(10), Nonce: 3, GasTipCap: uint256.NewInt(1),
+		GasFeeCap: uint256.NewInt(5), Gas: 50000, To: to,
+		AuthList: []types.SetCodeAuthorization{{ChainID: *uint256.NewInt(10), Address: to, Nonce: 7, V: 1, R: *uint256.NewInt(2), S: *uint256.NewInt(3)}},
+	})
+	postExec := types.NewTx(&types.PostExecTx{Data: []byte{0xc2, 0x80, 0x80}})
+
+	return types.Transactions{deposit, legacy, dynFee, blob, setCode, postExec}
+}
+
+// l2RPCBlockJSON serves an op-geth-marshaled RPC block JSON object for the
+// given transactions, with a consistent transactions root and block hash.
+func l2RPCBlockJSON(t *testing.T, txs types.Transactions) []byte {
+	t.Helper()
+	hdr := RPCHeader{
+		UncleHash: types.EmptyUncleHash,
+		Number:    hexutil.Uint64(123),
+		Time:      hexutil.Uint64(1_700_000_000),
+		GasUsed:   hexutil.Uint64(21_000),
+		BaseFee:   (*hexutil.Big)(big.NewInt(7)),
+		TxHash:    types.DeriveSha(txs, trie.NewStackTrie(nil)),
+	}
+	hdr.Hash = hdr.computeBlockHash()
+
+	obj := map[string]json.RawMessage{}
+	hdrJSON, err := json.Marshal(&hdr)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(hdrJSON, &obj))
+
+	txsJSON := make([]json.RawMessage, len(txs))
+	for i, tx := range txs {
+		txsJSON[i], err = tx.MarshalJSON() // op-geth's marshaling: the RPC wire format
+		require.NoError(t, err)
+	}
+	allTxs, err := json.Marshal(txsJSON)
+	require.NoError(t, err)
+	obj["transactions"] = allTxs
+
+	blockJSON, err := json.Marshal(obj)
+	require.NoError(t, err)
+	return blockJSON
+}
+
+// TestRPCBlockDecodesL2Block asserts that an L2 block's op-geth-marshaled JSON
+// — deposit, standard user txs, and post-exec — decodes into the canonical
+// per-tx binary encodings, verifies against the transactions root, and passes
+// through to the execution payload byte-identically.
+func TestRPCBlockDecodesL2Block(t *testing.T) {
+	txs := l2BlockTxs(t)
+	blockJSON := l2RPCBlockJSON(t, txs)
+
+	var block RPCBlock
+	require.NoError(t, json.Unmarshal(blockJSON, &block))
+	require.Len(t, block.Transactions, len(txs))
+	for i, tx := range txs {
+		theirs, err := tx.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, theirs, []byte(block.Transactions[i]), "tx %d binary encoding", i)
+		require.Equal(t, tx.Hash(), block.Transactions[i].Hash(), "tx %d hash", i)
+	}
+
+	require.NoError(t, block.Verify(), "tx root and block hash must verify")
+
+	envelope, err := block.ExecutionPayloadEnvelope(false)
+	require.NoError(t, err)
+	require.Len(t, envelope.ExecutionPayload.Transactions, len(txs))
+	for i := range txs {
+		require.Equal(t, []byte(block.Transactions[i]), []byte(envelope.ExecutionPayload.Transactions[i]), "payload tx %d passthrough", i)
+	}
+}
+
+// TestRPCBlockJSONRoundTrip asserts marshal(unmarshal(J)) is a fixed point on
+// the transaction objects.
+func TestRPCBlockJSONRoundTrip(t *testing.T) {
+	blockJSON := l2RPCBlockJSON(t, l2BlockTxs(t))
+
+	var block RPCBlock
+	require.NoError(t, json.Unmarshal(blockJSON, &block))
+	remarshaled, err := json.Marshal(&block)
+	require.NoError(t, err)
+	var block2 RPCBlock
+	require.NoError(t, json.Unmarshal(remarshaled, &block2))
+	require.Equal(t, block.Transactions, block2.Transactions)
+	require.Equal(t, block.RPCHeader, block2.RPCHeader)
+}
+
+func TestRawTransactionsPartition(t *testing.T) {
+	txs := l2BlockTxs(t)
+	blockJSON := l2RPCBlockJSON(t, txs)
+	var block RPCBlock
+	require.NoError(t, json.Unmarshal(blockJSON, &block))
+
+	userTxs, err := block.Transactions.UserTxs()
+	require.NoError(t, err)
+	require.Len(t, userTxs, 4, "deposit and post-exec txs are excluded")
+	for i, tx := range userTxs {
+		require.Equal(t, txs[i+1].Hash(), tx.Hash(), "user tx %d", i)
+	}
+
+	deposits, err := block.Transactions.Deposits()
+	require.NoError(t, err)
+	require.Len(t, deposits, 1)
+	require.Equal(t, common.HexToHash("0x01"), deposits[0].SourceHash)
+
+	first, err := block.Transactions.FirstDeposit()
+	require.NoError(t, err)
+	require.Equal(t, deposits[0], first)
+
+	// A list not starting with a deposit has no first deposit.
+	_, err = RawTransactions{block.Transactions[1]}.FirstDeposit()
+	require.ErrorIs(t, err, ErrMissingFirstDeposit)
+	_, err = RawTransactions{}.FirstDeposit()
+	require.ErrorIs(t, err, ErrMissingFirstDeposit)
+
+	// Zero-length entries error rather than classifying as user txs.
+	_, err = RawTransactions{{}}.UserTxs()
+	require.ErrorContains(t, err, "empty")
+	_, err = RawTransactions{{}}.Deposits()
+	require.ErrorContains(t, err, "empty")
+}
+
+// TestRawTransactionJSONEmptyPostExecRejected pins the canonical-encoding
+// contract on decode: a post-exec tx with empty input must fail JSON decode
+// rather than produce the one-byte value 0x7d, which the binary decoders
+// (UnmarshalPostExecTx, op-geth) reject.
+func TestRawTransactionJSONEmptyPostExecRejected(t *testing.T) {
+	var tx RawTransaction
+	err := json.Unmarshal([]byte(`{"type":"0x7d","input":"0x"}`), &tx)
+	require.ErrorContains(t, err, "invalid post-exec tx")
+}
+
+func TestRawTransactionsGeth(t *testing.T) {
+	txs := l2BlockTxs(t)
+	blockJSON := l2RPCBlockJSON(t, txs)
+	var block RPCBlock
+	require.NoError(t, json.Unmarshal(blockJSON, &block))
+
+	decoded, err := block.Transactions.Geth()
+	require.NoError(t, err)
+	require.Len(t, decoded, len(txs))
+	for i, tx := range decoded {
+		require.Equal(t, txs[i].Hash(), tx.Hash())
+	}
+
+	_, err = RawTransactions{{0xff}}.Geth()
+	require.Error(t, err)
+}

--- a/op-service/sources/receipts.go
+++ b/op-service/sources/receipts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
@@ -16,13 +17,13 @@ type ReceiptsProvider interface {
 	// FetchReceipts returns a block info and all of the receipts associated with transactions in the block.
 	// It verifies the receipt hash in the block header against the receipt hash of the fetched receipts
 	// to ensure that the execution engine did not fail to return any receipts.
-	FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (types.Receipts, error)
+	FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (optypes.Receipts, error)
 }
 
 // validateReceipts validates that the receipt contents are valid.
 // Warning: contractAddress is not verified, since it is a more expensive operation for data we do not use.
 // See go-ethereum/crypto.CreateAddress to verify contract deployment address data based on sender and tx nonce.
-func validateReceipts(block eth.BlockID, receiptHash common.Hash, txHashes []common.Hash, receipts []*types.Receipt) error {
+func validateReceipts(block eth.BlockID, receiptHash common.Hash, txHashes []common.Hash, receipts optypes.Receipts) error {
 	if len(receipts) != len(txHashes) {
 		return fmt.Errorf("got %d receipts but expected %d", len(receipts), len(txHashes))
 	}
@@ -84,8 +85,9 @@ func validateReceipts(block eth.BlockID, receiptHash common.Hash, txHashes []com
 
 	// Sanity-check: external L1-RPC sources are notorious for not returning all receipts,
 	// or returning them out-of-order. Verify the receipts against the expected receipt-hash.
+	// The optypes.Receipts derivation is deposit-receipt-aware (Canyon nonce+version hashing).
 	hasher := trie.NewStackTrie(nil)
-	computed := types.DeriveSha(types.Receipts(receipts), hasher)
+	computed := types.DeriveSha(receipts, hasher)
 	if receiptHash != computed {
 		return fmt.Errorf("failed to fetch list of receipts: expected receipt root %s but computed %s from retrieved receipts", receiptHash, computed)
 	}

--- a/op-service/sources/receipts_basic.go
+++ b/op-service/sources/receipts_basic.go
@@ -5,14 +5,14 @@ import (
 	"io"
 	"sync"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-type receiptsBatchCall = batching.IterativeBatchCall[common.Hash, *types.Receipt]
+type receiptsBatchCall = batching.IterativeBatchCall[common.Hash, *optypes.Receipt]
 
 type BasicRPCReceiptsFetcher struct {
 	client       rpcClient
@@ -33,7 +33,7 @@ func NewBasicRPCReceiptsFetcher(client rpcClient, maxBatchSize int) *BasicRPCRec
 
 // FetchReceipts fetches receipts for the given block and transaction hashes
 // it does not validate receipts, and expects the caller to do so
-func (f *BasicRPCReceiptsFetcher) FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (types.Receipts, error) {
+func (f *BasicRPCReceiptsFetcher) FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (optypes.Receipts, error) {
 	block := eth.ToBlockID(blockInfo)
 	call := f.getOrCreateBatchCall(block.Hash, txHashes)
 
@@ -60,7 +60,7 @@ func (f *BasicRPCReceiptsFetcher) getOrCreateBatchCall(blockHash common.Hash, tx
 	if call, ok := f.calls[blockHash]; ok {
 		return call
 	}
-	call := batching.NewIterativeBatchCall[common.Hash, *types.Receipt](
+	call := batching.NewIterativeBatchCall[common.Hash, *optypes.Receipt](
 		txHashes,
 		makeReceiptRequest,
 		f.client.BatchCallContext,
@@ -77,8 +77,8 @@ func (f *BasicRPCReceiptsFetcher) deleteBatchCall(blockHash common.Hash) {
 	delete(f.calls, blockHash)
 }
 
-func makeReceiptRequest(txHash common.Hash) (*types.Receipt, rpc.BatchElem) {
-	out := new(types.Receipt)
+func makeReceiptRequest(txHash common.Hash) (*optypes.Receipt, rpc.BatchElem) {
+	out := new(optypes.Receipt)
 	return out, rpc.BatchElem{
 		Method: "eth_getTransactionReceipt",
 		Args:   []any{txHash},

--- a/op-service/sources/receipts_basic_test.go
+++ b/op-service/sources/receipts_basic_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -64,8 +65,8 @@ func TestBasicRPCReceiptsFetcher_Reuse(t *testing.T) {
 				txHash := el.Args[0].(common.Hash)
 				if response[txHash] {
 					// The IterativeBatchCall expects that the values are written
-					// to the fields of the allocated *types.Receipt.
-					**(el.Result.(**types.Receipt)) = *recMap[txHash]
+					// to the fields of the allocated receipt.
+					**(el.Result.(**optypes.Receipt)) = optypes.Receipt{Receipt: *recMap[txHash]}
 				} else {
 					err = errors.Join(err, fmt.Errorf("receipt[%d] error, hash %x", i, txHash))
 				}
@@ -91,7 +92,7 @@ func TestBasicRPCReceiptsFetcher_Reuse(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(recs)
 	for i, rec := range recs {
-		requireEqualReceipt(t, receipts[i], rec)
+		requireEqualReceipt(t, receipts[i], &rec.Receipt)
 	}
 	require.EqualValues(3, numCalls.Load())
 }
@@ -126,8 +127,8 @@ func TestBasicRPCReceiptsFetcher_Concurrency(t *testing.T) {
 					if el.Method == "eth_getTransactionReceipt" {
 						txHash := el.Args[0].(common.Hash)
 						// The IterativeBatchCall expects that the values are written
-						// to the fields of the allocated *types.Receipt.
-						**(el.Result.(**types.Receipt)) = *recMap[txHash]
+						// to the fields of the allocated receipt.
+						**(el.Result.(**optypes.Receipt)) = optypes.Receipt{Receipt: *recMap[txHash]}
 					}
 				}
 			}).
@@ -156,7 +157,7 @@ func runConcurrentFetchingTest(t *testing.T, rp ReceiptsProvider, numFetchers in
 
 	// start n fetchers
 	type fetchResult struct {
-		rs  types.Receipts
+		rs  optypes.Receipts
 		err error
 	}
 	fetchResults := make(chan fetchResult, numFetchers)
@@ -180,7 +181,7 @@ func runConcurrentFetchingTest(t *testing.T, rp ReceiptsProvider, numFetchers in
 			require.NoError(f.err)
 			require.Len(f.rs, len(receipts))
 			for j, r := range receipts {
-				requireEqualReceipt(t, r, f.rs[j])
+				requireEqualReceipt(t, r, &f.rs[j].Receipt)
 			}
 		case <-ctx.Done():
 			t.Fatal("Test timeout")

--- a/op-service/sources/receipts_caching.go
+++ b/op-service/sources/receipts_caching.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"sync"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -15,7 +15,7 @@ import (
 // ReceiptsProvider. It also avoids duplicate in-flight requests per block hash.
 type CachingReceiptsProvider struct {
 	inner ReceiptsProvider
-	cache *caching.LRUCache[common.Hash, types.Receipts]
+	cache *caching.LRUCache[common.Hash, optypes.Receipts]
 
 	// lock fetching process for each block hash to avoid duplicate requests
 	fetching   map[common.Hash]*sync.Mutex
@@ -25,7 +25,7 @@ type CachingReceiptsProvider struct {
 func NewCachingReceiptsProvider(inner ReceiptsProvider, m caching.Metrics, cacheSize int) *CachingReceiptsProvider {
 	return &CachingReceiptsProvider{
 		inner:    inner,
-		cache:    caching.NewLRUCache[common.Hash, types.Receipts](m, "receipts", cacheSize),
+		cache:    caching.NewLRUCache[common.Hash, optypes.Receipts](m, "receipts", cacheSize),
 		fetching: make(map[common.Hash]*sync.Mutex),
 	}
 }
@@ -53,7 +53,7 @@ func (p *CachingReceiptsProvider) deleteFetchingLock(blockHash common.Hash) {
 
 // FetchReceipts fetches receipts for the given block and transaction hashes
 // it expects that the inner FetchReceipts implementation handles validation
-func (p *CachingReceiptsProvider) FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (types.Receipts, error) {
+func (p *CachingReceiptsProvider) FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (optypes.Receipts, error) {
 	block := eth.ToBlockID(blockInfo)
 	if r, ok := p.cache.Get(block.Hash); ok {
 		return r, nil

--- a/op-service/sources/receipts_caching_test.go
+++ b/op-service/sources/receipts_caching_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -17,10 +17,10 @@ type mockReceiptsProvider struct {
 	mock.Mock
 }
 
-func (m *mockReceiptsProvider) FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (types.Receipts, error) {
+func (m *mockReceiptsProvider) FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (optypes.Receipts, error) {
 	block := eth.ToBlockID(blockInfo)
 	args := m.Called(ctx, block, txHashes)
-	return args.Get(0).(types.Receipts), args.Error(1)
+	return args.Get(0).(optypes.Receipts), args.Error(1)
 }
 
 func TestCachingReceiptsProvider_Caching(t *testing.T) {
@@ -33,7 +33,7 @@ func TestCachingReceiptsProvider_Caching(t *testing.T) {
 	defer done()
 
 	mrp.On("FetchReceipts", ctx, blockid, txHashes).
-		Return(types.Receipts(receipts), error(nil)).
+		Return(optypes.FromGethReceipts(receipts), error(nil)).
 		Once() // receipts should be cached after first fetch
 
 	bInfo, _, _ := block.Info(true, true)
@@ -41,7 +41,7 @@ func TestCachingReceiptsProvider_Caching(t *testing.T) {
 		gotRecs, err := rp.FetchReceipts(ctx, bInfo, txHashes)
 		require.NoError(t, err)
 		for i, gotRec := range gotRecs {
-			requireEqualReceipt(t, receipts[i], gotRec)
+			requireEqualReceipt(t, receipts[i], &gotRec.Receipt)
 		}
 	}
 	mrp.AssertExpectations(t)
@@ -55,7 +55,7 @@ func TestCachingReceiptsProvider_Concurrency(t *testing.T) {
 	rp := NewCachingReceiptsProvider(mrp, nil, 1)
 
 	mrp.On("FetchReceipts", mock.Anything, blockid, txHashes).
-		Return(types.Receipts(receipts), error(nil)).
+		Return(optypes.FromGethReceipts(receipts), error(nil)).
 		Once() // receipts should be cached after first fetch
 
 	runConcurrentFetchingTest(t, rp, 32, receipts, block)

--- a/op-service/sources/receipts_op_test.go
+++ b/op-service/sources/receipts_op_test.go
@@ -1,0 +1,189 @@
+package sources
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/trie"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/ptr"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+// opL2BlockAndReceipts builds a minimal L2 block — one deposit tx and one user
+// tx — with receipts carrying the OP Stack extension fields, all consistent
+// with the block's transactions root, receipts root, and block hash so that
+// untrusted-RPC validation passes.
+func opL2BlockAndReceipts(t *testing.T) (*RPCBlock, []*types.Receipt) {
+	t.Helper()
+	txs := l2BlockTxs(t)[:2] // deposit + legacy user tx
+	rawTxs := mustRawTransactions(txs)
+
+	logIdx := uint(0)
+	mkLog := func(addr byte) []*types.Log {
+		l := &types.Log{Address: common.Address{addr}, Topics: []common.Hash{{addr}}, Index: logIdx}
+		logIdx++
+		return []*types.Log{l}
+	}
+	depositReceipt := &types.Receipt{
+		Type:                  optypes.DepositTxType,
+		Status:                types.ReceiptStatusSuccessful,
+		CumulativeGasUsed:     21_000,
+		Logs:                  mkLog(1),
+		DepositNonce:          ptr.New(uint64(7)),
+		DepositReceiptVersion: ptr.New(types.CanyonDepositReceiptVersion),
+	}
+	depositReceipt.Bloom = types.CreateBloom(depositReceipt)
+	userReceipt := &types.Receipt{
+		Type:                types.LegacyTxType,
+		Status:              types.ReceiptStatusSuccessful,
+		CumulativeGasUsed:   42_000,
+		Logs:                mkLog(2),
+		L1GasPrice:          big.NewInt(42_000_000_000),
+		L1BlobBaseFee:       big.NewInt(123_456),
+		L1Fee:               big.NewInt(77_000),
+		L1BaseFeeScalar:     ptr.New(uint64(5227)),
+		L1BlobBaseFeeScalar: ptr.New(uint64(1_014_213)),
+		OperatorFeeScalar:   ptr.New(uint64(9)),
+		OperatorFeeConstant: ptr.New(uint64(9000)),
+	}
+	userReceipt.Bloom = types.CreateBloom(userReceipt)
+	receipts := []*types.Receipt{depositReceipt, userReceipt}
+
+	block := &RPCBlock{
+		RPCHeader: RPCHeader{
+			UncleHash:   types.EmptyUncleHash,
+			Number:      hexutil.Uint64(101),
+			Time:        hexutil.Uint64(1_700_000_000),
+			GasUsed:     hexutil.Uint64(42_000),
+			BaseFee:     (*hexutil.Big)(big.NewInt(7)),
+			TxHash:      types.DeriveSha(rawTxs, trie.NewStackTrie(nil)),
+			ReceiptHash: types.DeriveSha(types.Receipts(receipts), trie.NewStackTrie(nil)),
+		},
+		Transactions: rawTxs,
+	}
+	block.Hash = block.computeBlockHash()
+
+	// Backfill the derived receipt metadata that validation checks.
+	prevGas := uint64(0)
+	for i, r := range receipts {
+		r.TxHash = rawTxs[i].Hash()
+		r.BlockHash = block.Hash
+		r.BlockNumber = new(big.Int).SetUint64(uint64(block.Number))
+		r.TransactionIndex = uint(i)
+		r.GasUsed = r.CumulativeGasUsed - prevGas
+		prevGas = r.CumulativeGasUsed
+		for _, l := range r.Logs {
+			l.BlockHash = block.Hash
+			l.BlockNumber = uint64(block.Number)
+			l.TxHash = r.TxHash
+			l.TxIndex = uint(i)
+		}
+	}
+	return block, receipts
+}
+
+func opReceiptsTestClient(t *testing.T, m *mock.Mock, kind RPCProviderKind) *EthClient {
+	t.Helper()
+	srv := rpc.NewServer()
+	t.Cleanup(srv.Stop)
+	require.NoError(t, srv.RegisterName("eth", &ethBackend{Mock: m}))
+	require.NoError(t, srv.RegisterName("debug", &debugBackend{Mock: m}))
+
+	cfg := DefaultEthClientConfig(10)
+	cfg.RPCProviderKind = kind
+	cfg.MustBePostMerge = false
+	cfg.MethodResetDuration = time.Minute
+	ethCl, err := NewEthClient(client.NewBaseRPCClient(rpc.DialInProc(srv)), testlog.Logger(t, log.LevelError), nil, cfg)
+	require.NoError(t, err)
+	t.Cleanup(ethCl.Close)
+	return ethCl
+}
+
+// TestFetchReceiptsOPFields asserts that L2 receipts fetched over the JSON
+// method carry the OP Stack extension fields, and that the deposit-aware
+// receipts-root validation passes with untrusted RPC.
+func TestFetchReceiptsOPFields(t *testing.T) {
+	block, receipts := opL2BlockAndReceipts(t)
+	m := new(mock.Mock)
+	ethCl := opReceiptsTestClient(t, m, RPCKindStandard)
+
+	m.On("eth_getBlockByHash", block.Hash, true).Once().Return(block)
+	m.On("eth_getBlockReceipts", block.Hash.String()).Once().Return(receipts, new(error))
+
+	_, got, err := ethCl.FetchReceipts(context.Background(), block.Hash)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	require.Equal(t, receipts[0].DepositNonce, got[0].DepositNonce)
+	require.Equal(t, receipts[0].DepositReceiptVersion, got[0].DepositReceiptVersion)
+	require.Equal(t, receipts[1].L1GasPrice, got[1].L1GasPrice)
+	require.Equal(t, receipts[1].L1BlobBaseFee, got[1].L1BlobBaseFee)
+	require.Equal(t, receipts[1].L1Fee, got[1].L1Fee)
+	require.Equal(t, receipts[1].L1BaseFeeScalar, got[1].L1BaseFeeScalar)
+	require.Equal(t, receipts[1].L1BlobBaseFeeScalar, got[1].L1BlobBaseFeeScalar)
+	require.Equal(t, receipts[1].OperatorFeeScalar, got[1].OperatorFeeScalar)
+	require.Equal(t, receipts[1].OperatorFeeConstant, got[1].OperatorFeeConstant)
+	m.AssertExpectations(t)
+}
+
+// TestFetchReceiptsRawPath asserts the consensus-encoded receipts path
+// (debug_getRawReceipts): a deposit receipt decodes with its consensus fields
+// (nonce+version) and the deposit-aware root validation passes; the JSON-only
+// fee fields are structurally absent and stay nil.
+func TestFetchReceiptsRawPath(t *testing.T) {
+	block, receipts := opL2BlockAndReceipts(t)
+	m := new(mock.Mock)
+	ethCl := opReceiptsTestClient(t, m, RPCKindQuickNode)
+
+	var raw []hexutil.Bytes
+	for _, r := range receipts {
+		data, err := r.MarshalBinary()
+		require.NoError(t, err)
+		raw = append(raw, data)
+	}
+	m.On("eth_getBlockByHash", block.Hash, true).Once().Return(block)
+	m.On("debug_getRawReceipts", block.Hash.String()).Once().Return(raw, new(error))
+
+	_, got, err := ethCl.FetchReceipts(context.Background(), block.Hash)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	require.Equal(t, receipts[0].DepositNonce, got[0].DepositNonce)
+	require.Equal(t, receipts[0].DepositReceiptVersion, got[0].DepositReceiptVersion)
+	require.Nil(t, got[1].L1GasPrice, "JSON-only fee fields are not in the consensus encoding")
+	require.Nil(t, got[1].OperatorFeeScalar)
+	m.AssertExpectations(t)
+}
+
+// TestTransactionReceiptOPFields asserts the single-receipt fetch decodes the
+// OP Stack extension fields.
+func TestTransactionReceiptOPFields(t *testing.T) {
+	_, receipts := opL2BlockAndReceipts(t)
+	m := new(mock.Mock)
+	ethCl := opReceiptsTestClient(t, m, RPCKindStandard)
+
+	userReceipt := receipts[1]
+	m.On("eth_getTransactionReceipt", userReceipt.TxHash).Once().Return(userReceipt, new(error))
+
+	got, err := ethCl.TransactionReceipt(context.Background(), userReceipt.TxHash)
+	require.NoError(t, err)
+	require.Equal(t, userReceipt.L1GasPrice, got.L1GasPrice)
+	require.Equal(t, userReceipt.L1Fee, got.L1Fee)
+	require.Equal(t, userReceipt.OperatorFeeScalar, got.OperatorFeeScalar)
+	require.Equal(t, userReceipt.OperatorFeeConstant, got.OperatorFeeConstant)
+	require.Equal(t, userReceipt.GasUsed, got.GasUsed)
+	m.AssertExpectations(t)
+}

--- a/op-service/sources/receipts_rpc.go
+++ b/op-service/sources/receipts_rpc.go
@@ -9,10 +9,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -70,7 +70,7 @@ func NewRPCReceiptsFetcher(client rpcClient, log log.Logger, config RPCReceiptsC
 	}
 }
 
-func (f *RPCReceiptsFetcher) FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (result types.Receipts, err error) {
+func (f *RPCReceiptsFetcher) FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (result optypes.Receipts, err error) {
 	m := f.PickReceiptsMethod(len(txHashes))
 	block := eth.ToBlockID(blockInfo)
 	switch m {
@@ -114,7 +114,7 @@ func (f *RPCReceiptsFetcher) FetchReceipts(ctx context.Context, blockInfo eth.Bl
 
 // receiptsWrapper is a decoding type util. Alchemy in particular wraps the receipts array result.
 type receiptsWrapper struct {
-	Receipts []*types.Receipt `json:"receipts"`
+	Receipts []*optypes.Receipt `json:"receipts"`
 }
 
 func (f *RPCReceiptsFetcher) PickReceiptsMethod(txCount int) ReceiptsFetchingMethod {

--- a/op-service/sources/receipts_test.go
+++ b/op-service/sources/receipts_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -57,7 +58,7 @@ type alchemyBackend struct {
 
 func (b *alchemyBackend) GetTransactionReceipts(p blockHashParameter) (*receiptsWrapper, error) {
 	out := b.Mock.MethodCalled("alchemy_getTransactionReceipts", p.BlockHash.String())
-	return &receiptsWrapper{Receipts: out[0].([]*types.Receipt)}, *out[1].(*error)
+	return &receiptsWrapper{Receipts: optypes.FromGethReceipts(out[0].([]*types.Receipt))}, *out[1].(*error)
 }
 
 type debugBackend struct {
@@ -174,7 +175,7 @@ func (tc *ReceiptsTestCase) Run(t *testing.T) {
 			require.NoError(t, req.err, "error")
 			require.Equal(t, block.Hash, info.Hash(), fmt.Sprintf("req %d blockhash", i))
 			for j, rec := range req.result {
-				requireEqualReceipt(t, rec, result[j], "req %d result %d", i, j)
+				requireEqualReceipt(t, rec, &result[j].Receipt, "req %d result %d", i, j)
 			}
 		} else {
 			require.Error(t, req.err, "error")
@@ -183,6 +184,20 @@ func (tc *ReceiptsTestCase) Run(t *testing.T) {
 	}
 
 	m.AssertExpectations(t)
+}
+
+// mustRawTransactions encodes go-ethereum transactions into their canonical
+// binary form for RPCBlock fixtures.
+func mustRawTransactions(txs types.Transactions) RawTransactions {
+	out := make(RawTransactions, len(txs))
+	for i, tx := range txs {
+		raw, err := tx.MarshalBinary()
+		if err != nil {
+			panic(err)
+		}
+		out[i] = raw
+	}
+	return out
 }
 
 func randomRpcBlockAndReceipts(rng *rand.Rand, txCount uint64) (*RPCBlock, []*types.Receipt) {
@@ -207,7 +222,7 @@ func randomRpcBlockAndReceipts(rng *rand.Rand, txCount uint64) (*RPCBlock, []*ty
 			BaseFee:     (*hexutil.Big)(block.BaseFee()),
 			Hash:        block.Hash(),
 		},
-		Transactions: block.Transactions(),
+		Transactions: mustRawTransactions(block.Transactions()),
 	}, receipts
 }
 
@@ -340,7 +355,7 @@ func TestEthClient_FetchReceipts(t *testing.T) {
 }
 
 func TestVerifyReceipts(t *testing.T) {
-	validData := func() (eth.BlockID, common.Hash, []common.Hash, []*types.Receipt) {
+	validData := func() (eth.BlockID, common.Hash, []common.Hash, optypes.Receipts) {
 		block := eth.BlockID{
 			Hash:   common.HexToHash("0x40fb7cc5fbc1ec594230a60648a442412116d50ae43d517ea458d8ea4e60bd1b"),
 			Number: 9998910,
@@ -351,7 +366,7 @@ func TestVerifyReceipts(t *testing.T) {
 			common.HexToHash("0x2de33b18143039dcdf88cb62c3f3dd8f3f5d9f29807edfd3b0507246c55f9cb8"),
 			common.HexToHash("0xb6a381d3c31df47da82ac807c3000ae4adf55e981715f56d13a27b220de20198"),
 		}
-		receipts := []*types.Receipt{
+		gethReceipts := []*types.Receipt{
 			{
 				Type:              2,
 				Status:            0,
@@ -437,7 +452,8 @@ func TestVerifyReceipts(t *testing.T) {
 				TransactionIndex:  3,
 			},
 		}
-		receiptsHash := types.DeriveSha(types.Receipts(receipts), trie.NewStackTrie(nil))
+		receipts := optypes.FromGethReceipts(gethReceipts)
+		receiptsHash := types.DeriveSha(receipts, trie.NewStackTrie(nil))
 		return block, receiptsHash, txHashes, receipts
 	}
 

--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -159,8 +159,8 @@ func (hdr *RPCHeader) BlockID() eth.BlockID {
 
 type RPCBlock struct {
 	RPCHeader
-	Transactions []*types.Transaction `json:"transactions"`
-	Withdrawals  *types.Withdrawals   `json:"withdrawals,omitempty"`
+	Transactions RawTransactions    `json:"transactions"`
+	Withdrawals  *types.Withdrawals `json:"withdrawals,omitempty"`
 }
 
 func (block *RPCBlock) Verify() error {
@@ -168,18 +168,18 @@ func (block *RPCBlock) Verify() error {
 		return fmt.Errorf("failed to verify block hash: computed %s but RPC said %s", computed, block.Hash)
 	}
 	for i, tx := range block.Transactions {
-		if tx == nil {
-			return fmt.Errorf("block tx %d is nil", i)
+		if len(tx) == 0 {
+			return fmt.Errorf("block tx %d is nil or empty", i)
 		}
 	}
-	if computed := types.DeriveSha(types.Transactions(block.Transactions), trie.NewStackTrie(nil)); block.TxHash != computed {
+	if computed := types.DeriveSha(block.Transactions, trie.NewStackTrie(nil)); block.TxHash != computed {
 		return fmt.Errorf("failed to verify transactions list: computed %s but RPC said %s", computed, block.TxHash)
 	}
 
 	// Withdrawals validation is different between L1 and L2.
 	// It is possible to determine that it is an L2 block if the first transaction is a deposit.
 	// The genesis block does not have transactions, but does have a known fee-recipient predeploy address.
-	isL2 := (len(block.Transactions) > 0 && optypes.IsDepositTx(block.Transactions[0])) ||
+	isL2 := (len(block.Transactions) > 0 && block.Transactions[0].Type() == optypes.DepositTxType) ||
 		(block.Number == 0 && block.Coinbase == predeploys.SequencerFeeVaultAddr)
 	if isL2 {
 		if err := block.validateL2Withdrawals(block.Withdrawals, block.WithdrawalsRoot); err != nil {
@@ -223,7 +223,7 @@ func (block *RPCBlock) validateL2Withdrawals(withdrawals *types.Withdrawals, wit
 	return nil
 }
 
-func (block *RPCBlock) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInfo, types.Transactions, error) {
+func (block *RPCBlock) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInfo, RawTransactions, error) {
 	if mustBePostMerge {
 		if err := block.checkPostMerge(); err != nil {
 			return nil, nil, err
@@ -256,15 +256,11 @@ func (block *RPCBlock) ExecutionPayloadEnvelope(trustCache bool) (*eth.Execution
 	var baseFee uint256.Int
 	baseFee.SetFromBig((*big.Int)(block.BaseFee))
 
-	// Unfortunately eth_getBlockByNumber either returns full transactions, or only tx-hashes.
-	// There is no option for encoded transactions.
+	// Transactions are already held in their canonical binary encoding;
+	// the payload's opaque form is a straight copy.
 	opaqueTxs := make([]hexutil.Bytes, len(block.Transactions))
 	for i, tx := range block.Transactions {
-		data, err := tx.MarshalBinary()
-		if err != nil {
-			return nil, fmt.Errorf("failed to encode tx %d from RPC: %w", i, err)
-		}
-		opaqueTxs[i] = data
+		opaqueTxs[i] = hexutil.Bytes(tx)
 	}
 
 	payload := &eth.ExecutionPayload{

--- a/op-service/sources/types_test.go
+++ b/op-service/sources/types_test.go
@@ -133,7 +133,7 @@ func TestBlockToExecutionPayloadIncludesEcotoneProperties(t *testing.T) {
 
 	block := RPCBlock{
 		RPCHeader:    rhdr,
-		Transactions: types.Transactions{},
+		Transactions: RawTransactions{},
 		Withdrawals:  &types.Withdrawals{},
 	}
 

--- a/op-service/testutils/mock_eth_client.go
+++ b/op-service/testutils/mock_eth_client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -76,6 +77,60 @@ func (m *MockEthClient) ExpectInfoAndTxsByLabel(label eth.BlockLabel, info eth.B
 	m.Mock.On("InfoAndTxsByLabel", label).Once().Return(info, transactions, err)
 }
 
+func (m *MockEthClient) InfoAndUserTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
+	out := m.Mock.Called(hash)
+	return out.Get(0).(eth.BlockInfo), out.Get(1).(types.Transactions), out.Error(2)
+}
+
+func (m *MockEthClient) ExpectInfoAndUserTxsByHash(hash common.Hash, info eth.BlockInfo, transactions types.Transactions, err error) {
+	m.Mock.On("InfoAndUserTxsByHash", hash).Once().Return(info, transactions, err)
+}
+
+func (m *MockEthClient) InfoAndUserTxsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, types.Transactions, error) {
+	out := m.Mock.Called(number)
+	return out.Get(0).(eth.BlockInfo), out.Get(1).(types.Transactions), out.Error(2)
+}
+
+func (m *MockEthClient) ExpectInfoAndUserTxsByNumber(number uint64, info eth.BlockInfo, transactions types.Transactions, err error) {
+	m.Mock.On("InfoAndUserTxsByNumber", number).Once().Return(info, transactions, err)
+}
+
+func (m *MockEthClient) InfoAndDepositsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, []*optypes.DepositTx, error) {
+	out := m.Mock.Called(hash)
+	return out.Get(0).(eth.BlockInfo), out.Get(1).([]*optypes.DepositTx), out.Error(2)
+}
+
+func (m *MockEthClient) ExpectInfoAndDepositsByHash(hash common.Hash, info eth.BlockInfo, deposits []*optypes.DepositTx, err error) {
+	m.Mock.On("InfoAndDepositsByHash", hash).Once().Return(info, deposits, err)
+}
+
+func (m *MockEthClient) InfoAndDepositsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, []*optypes.DepositTx, error) {
+	out := m.Mock.Called(number)
+	return out.Get(0).(eth.BlockInfo), out.Get(1).([]*optypes.DepositTx), out.Error(2)
+}
+
+func (m *MockEthClient) ExpectInfoAndDepositsByNumber(number uint64, info eth.BlockInfo, deposits []*optypes.DepositTx, err error) {
+	m.Mock.On("InfoAndDepositsByNumber", number).Once().Return(info, deposits, err)
+}
+
+func (m *MockEthClient) InfoAndFirstDepositByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, *optypes.DepositTx, error) {
+	out := m.Mock.Called(hash)
+	return out.Get(0).(eth.BlockInfo), out.Get(1).(*optypes.DepositTx), out.Error(2)
+}
+
+func (m *MockEthClient) ExpectInfoAndFirstDepositByHash(hash common.Hash, info eth.BlockInfo, deposit *optypes.DepositTx, err error) {
+	m.Mock.On("InfoAndFirstDepositByHash", hash).Once().Return(info, deposit, err)
+}
+
+func (m *MockEthClient) InfoAndFirstDepositByNumber(ctx context.Context, number uint64) (eth.BlockInfo, *optypes.DepositTx, error) {
+	out := m.Mock.Called(number)
+	return out.Get(0).(eth.BlockInfo), out.Get(1).(*optypes.DepositTx), out.Error(2)
+}
+
+func (m *MockEthClient) ExpectInfoAndFirstDepositByNumber(number uint64, info eth.BlockInfo, deposit *optypes.DepositTx, err error) {
+	m.Mock.On("InfoAndFirstDepositByNumber", number).Once().Return(info, deposit, err)
+}
+
 func (m *MockEthClient) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
 	out := m.Mock.Called(hash)
 	return out.Get(0).(*types.Header), out.Error(1)
@@ -139,12 +194,12 @@ func (m *MockEthClient) ExpectPayloadByLabel(label eth.BlockLabel, payload *eth.
 	m.Mock.On("PayloadByLabel", label).Once().Return(payload, err)
 }
 
-func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
 	out := m.Mock.Called(blockHash)
-	return *out.Get(0).(*eth.BlockInfo), out.Get(1).(types.Receipts), out.Error(2)
+	return *out.Get(0).(*eth.BlockInfo), out.Get(1).(optypes.Receipts), out.Error(2)
 }
 
-func (m *MockEthClient) ExpectFetchReceipts(hash common.Hash, info eth.BlockInfo, receipts types.Receipts, err error) {
+func (m *MockEthClient) ExpectFetchReceipts(hash common.Hash, info eth.BlockInfo, receipts optypes.Receipts, err error) {
 	m.Mock.On("FetchReceipts", hash).Once().Return(&info, receipts, err)
 }
 

--- a/op-service/txinclude/interfaces.go
+++ b/op-service/txinclude/interfaces.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"time"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -18,7 +19,7 @@ type Includer interface {
 
 type IncludedTx struct {
 	Transaction *types.Transaction
-	Receipt     *types.Receipt
+	Receipt     *optypes.Receipt
 }
 
 // EL represents an EVM execution layer.
@@ -41,7 +42,7 @@ func NewReliableEL(el EL, blockTime time.Duration) EL {
 }
 
 type ReceiptGetter interface {
-	TransactionReceipt(context.Context, common.Hash) (*types.Receipt, error)
+	TransactionReceipt(context.Context, common.Hash) (*optypes.Receipt, error)
 }
 
 type Sender interface {

--- a/op-service/txinclude/monitor.go
+++ b/op-service/txinclude/monitor.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 )
 
 // Monitor is a ReceiptGetter that will continue looking for a receipt even when
@@ -34,7 +35,7 @@ var transientErrs = []error{
 	errors.New("transaction indexing is in progress"), // op-geth wording (not exported).
 }
 
-func (m *Monitor) TransactionReceipt(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
+func (m *Monitor) TransactionReceipt(ctx context.Context, hash common.Hash) (*optypes.Receipt, error) {
 	for {
 		receipt, err := m.inner.TransactionReceipt(ctx, hash)
 		if err == nil {

--- a/op-service/txinclude/monitor_test.go
+++ b/op-service/txinclude/monitor_test.go
@@ -6,20 +6,20 @@ import (
 	"testing"
 	"time"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
 // mockReceiptGetter implements ReceiptGetter for testing
 type mockReceiptGetter struct {
-	receipt *types.Receipt
+	receipt *optypes.Receipt
 	errs    []error
 	calls   uint64
 }
 
-func (m *mockReceiptGetter) TransactionReceipt(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
+func (m *mockReceiptGetter) TransactionReceipt(ctx context.Context, hash common.Hash) (*optypes.Receipt, error) {
 	call := m.calls
 	m.calls++
 	if call < uint64(len(m.errs)) {
@@ -30,7 +30,7 @@ func (m *mockReceiptGetter) TransactionReceipt(ctx context.Context, hash common.
 
 func TestMonitorReceiptFound(t *testing.T) {
 	inner := &mockReceiptGetter{
-		receipt: &types.Receipt{},
+		receipt: &optypes.Receipt{},
 	}
 	monitor := NewMonitor(inner, time.Millisecond)
 	receipt, err := monitor.TransactionReceipt(context.Background(), inner.receipt.TxHash)
@@ -45,7 +45,7 @@ func TestMonitorTransientError(t *testing.T) {
 			errors.New("transaction indexing in progress"),
 			errors.New("transaction indexing is in progress"),
 		},
-		receipt: &types.Receipt{},
+		receipt: &optypes.Receipt{},
 	}
 	receipt, err := NewMonitor(inner, time.Millisecond).TransactionReceipt(context.Background(), inner.receipt.TxHash)
 	require.NoError(t, err)

--- a/op-service/txinclude/persistent_test.go
+++ b/op-service/txinclude/persistent_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/accounting"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txinclude"
@@ -24,10 +25,10 @@ type mockEL struct {
 	// receiptReadyCh will be closed when the receipt can be sent.
 	// mockEL doesn't always close it: it may last the life of the test.
 	receiptReadyCh chan struct{}
-	receipt        *types.Receipt
+	receipt        *optypes.Receipt
 }
 
-func newMockEL(sendTxErrs []error, receipt *types.Receipt) *mockEL {
+func newMockEL(sendTxErrs []error, receipt *optypes.Receipt) *mockEL {
 	return &mockEL{
 		sendTxErrs:     sendTxErrs,
 		receiptReadyCh: make(chan struct{}),
@@ -51,7 +52,7 @@ func (m *mockEL) SendTransaction(ctx context.Context, tx *types.Transaction) err
 	return nil
 }
 
-func (m *mockEL) TransactionReceipt(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
+func (m *mockEL) TransactionReceipt(ctx context.Context, hash common.Hash) (*optypes.Receipt, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -73,11 +74,11 @@ func TestPersistentSuccessfulTxInclusion(t *testing.T) {
 	}
 	want := &txinclude.IncludedTx{
 		Transaction: types.NewTx(original),
-		Receipt: &types.Receipt{
+		Receipt: &optypes.Receipt{Receipt: types.Receipt{
 			Status:            types.ReceiptStatusSuccessful,
 			GasUsed:           original.Gas,
 			EffectiveGasPrice: original.GasFeeCap,
-		},
+		}},
 	}
 
 	el := newMockEL(nil, want.Receipt)
@@ -101,11 +102,11 @@ func TestPersistentFixesNonceTooLow(t *testing.T) {
 			Gas:       original.Gas,
 			Nonce:     original.Nonce + 2,
 		}),
-		Receipt: &types.Receipt{
+		Receipt: &optypes.Receipt{Receipt: types.Receipt{
 			Status:            types.ReceiptStatusSuccessful,
 			GasUsed:           original.Gas,
 			EffectiveGasPrice: original.GasFeeCap,
-		},
+		}},
 	}
 
 	el := newMockEL([]error{core.ErrNonceTooLow, core.ErrNonceTooLow}, want.Receipt)
@@ -125,11 +126,11 @@ func TestPersistentNoChangeOnUnderpriced(t *testing.T) {
 	}
 	want := &txinclude.IncludedTx{
 		Transaction: types.NewTx(original),
-		Receipt: &types.Receipt{
+		Receipt: &optypes.Receipt{Receipt: types.Receipt{
 			Status:            types.ReceiptStatusSuccessful,
 			GasUsed:           original.Gas,
 			EffectiveGasPrice: original.GasFeeCap,
-		},
+		}},
 	}
 
 	el := newMockEL([]error{txpool.ErrUnderpriced, txpool.ErrReplaceUnderpriced}, want.Receipt)

--- a/op-service/txinclude/txbudget_test.go
+++ b/op-service/txinclude/txbudget_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	opfees "github.com/ethereum-optimism/optimism/op-core/fees"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/accounting"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
@@ -103,10 +104,12 @@ func TestTxBudgetIncluded(t *testing.T) {
 		BlobFeeCap: uint256.NewInt(1),
 		BlobHashes: []common.Hash{{}},
 	})
-	receipt := &types.Receipt{
-		EffectiveGasPrice:   eth.WeiU64(effectiveGasPrice).ToBig(),
-		GasUsed:             gasUsed,
-		Type:                types.DynamicFeeTxType,
+	receipt := &optypes.Receipt{
+		Receipt: types.Receipt{
+			EffectiveGasPrice: eth.WeiU64(effectiveGasPrice).ToBig(),
+			GasUsed:           gasUsed,
+			Type:              types.DynamicFeeTxType,
+		},
 		L1GasPrice:          l1GasPrice,
 		L1BaseFeeScalar:     ptr(uint64(1)),
 		L1BlobBaseFee:       l1BlobBaseFee,

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -295,7 +295,29 @@ func WithRetrySubmission(cl TransactionSubmitter, maxAttempts int, strategy retr
 }
 
 type ReceiptGetter interface {
+	TransactionReceipt(ctx context.Context, txHash common.Hash) (*optypes.Receipt, error)
+}
+
+// GethReceiptGetter is the receipt getter shape of go-ethereum clients
+// (e.g. *ethclient.Client).
+type GethReceiptGetter interface {
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+}
+
+// FromGethReceipts adapts a go-ethereum receipt getter to ReceiptGetter.
+// The OP Stack extension fields stay nil — suitable for L1 clients.
+func FromGethReceipts(cl GethReceiptGetter) ReceiptGetter {
+	return gethReceiptGetter{inner: cl}
+}
+
+type gethReceiptGetter struct{ inner GethReceiptGetter }
+
+func (g gethReceiptGetter) TransactionReceipt(ctx context.Context, txHash common.Hash) (*optypes.Receipt, error) {
+	receipt, err := g.inner.TransactionReceipt(ctx, txHash)
+	if err != nil || receipt == nil {
+		return nil, err
+	}
+	return &optypes.Receipt{Receipt: *receipt}, nil
 }
 
 // WithAssumedInclusion assumes inclusion at the time of evaluation,
@@ -304,7 +326,11 @@ func WithAssumedInclusion(cl ReceiptGetter) Option {
 	return func(tx *PlannedTx) {
 		tx.Included.DependOn(&tx.Signed, &tx.Submitted)
 		tx.Included.Fn(func(ctx context.Context) (*types.Receipt, error) {
-			return cl.TransactionReceipt(ctx, tx.Signed.Value().Hash())
+			receipt, err := cl.TransactionReceipt(ctx, tx.Signed.Value().Hash())
+			if err != nil {
+				return nil, err
+			}
+			return &receipt.Receipt, nil
 		})
 	}
 }
@@ -313,7 +339,11 @@ func WithRetryInclusion(cl ReceiptGetter, maxAttempts int, strategy retry.Strate
 	return func(tx *PlannedTx) {
 		tx.Included.DependOn(&tx.Signed, &tx.Submitted)
 		tx.Included.Fn(func(ctx context.Context) (*types.Receipt, error) {
-			return cl.TransactionReceipt(ctx, tx.Signed.Value().Hash())
+			receipt, err := cl.TransactionReceipt(ctx, tx.Signed.Value().Hash())
+			if err != nil {
+				return nil, err
+			}
+			return &receipt.Receipt, nil
 		})
 		tx.Included.Wrap(func(fn plan.Fn[*types.Receipt]) plan.Fn[*types.Receipt] {
 			return func(ctx context.Context) (*types.Receipt, error) {

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
@@ -1109,8 +1109,8 @@ func (m *algoMockChain) OutputRootAtL2BlockHash(ctx context.Context, blockHash c
 func (m *algoMockChain) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputV0, error) {
 	return nil, nil
 }
-func (m *algoMockChain) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
-	return nil, types.Receipts{}, nil
+func (m *algoMockChain) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, optypes.Receipts, error) {
+	return nil, optypes.Receipts{}, nil
 }
 func (m *algoMockChain) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
 	return &eth.SyncStatus{}, nil

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -1946,7 +1946,7 @@ func (m *mockChainContainer) OutputRootAtL2BlockHash(ctx context.Context, blockH
 func (m *mockChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputV0, error) {
 	return nil, nil
 }
-func (m *mockChainContainer) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
+func (m *mockChainContainer) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, optypes.Receipts, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	ts := blockID.Number
@@ -1970,7 +1970,7 @@ func (m *mockChainContainer) FetchReceipts(ctx context.Context, blockID eth.Bloc
 		number:     blockID.Number,
 		timestamp:  ts,
 	}
-	return blockInfo, types.Receipts{}, nil
+	return blockInfo, optypes.Receipts{}, nil
 }
 func (m *mockChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
 	m.mu.Lock()

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -195,7 +195,7 @@ func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.C
 			return fmt.Errorf("chain %s: fetch receipts %d: %w", cid, num, err)
 		}
 
-		if err := i.sealBlockDataIntoLogsDB(cid, bid, blockInfo, receipts, blockInfo.Time(), true); err != nil {
+		if err := i.sealBlockDataIntoLogsDB(cid, bid, blockInfo, receipts.Geth(), blockInfo.Time(), true); err != nil {
 			return err
 		}
 

--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -98,7 +98,7 @@ func (i *Interop) sealFetchedBlockIntoLogsDB(chainID eth.ChainID, blockID eth.Bl
 	if err != nil {
 		return fmt.Errorf("chain %s: failed to fetch receipts for block %v: %w", chainID, blockID, err)
 	}
-	return i.sealBlockDataIntoLogsDB(chainID, blockID, blockInfo, receipts, ts, false)
+	return i.sealBlockDataIntoLogsDB(chainID, blockID, blockInfo, receipts.Geth(), ts, false)
 }
 
 // sealBlockDataIntoLogsDB seals logs for an already-fetched block using ts for verifyCanAddTimestamp.

--- a/op-supernode/supernode/activity/interop/verification_view.go
+++ b/op-supernode/supernode/activity/interop/verification_view.go
@@ -38,7 +38,7 @@ func (i *Interop) resolveFrontierVerificationView(blocksAtTS map[eth.ChainID]eth
 		if err != nil {
 			return nil, fmt.Errorf("chain %s: failed to fetch receipts for frontier block %s: %w", chainID, blockID, err)
 		}
-		view.blocks[chainID] = buildFrontierBlockView(chainID, blockInfo, receipts)
+		view.blocks[chainID] = buildFrontierBlockView(chainID, blockInfo, receipts.Geth())
 	}
 	return view, nil
 }

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"testing"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -82,7 +82,7 @@ func (m *mockCC) L1ForL2(ctx context.Context, l2Block eth.BlockID) (eth.BlockID,
 	return eth.BlockID{}, nil
 }
 
-func (m *mockCC) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
+func (m *mockCC) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, optypes.Receipts, error) {
 	return nil, nil, nil
 }
 

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"testing"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -92,7 +92,7 @@ func (m *mockCC) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*e
 	}
 	return &eth.OutputV0{}, nil
 }
-func (m *mockCC) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
+func (m *mockCC) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, optypes.Receipts, error) {
 	return nil, nil, nil
 }
 func (m *mockCC) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
@@ -25,7 +26,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -92,7 +92,7 @@ type ChainContainer interface {
 	VerifierCurrentL1() (eth.BlockID, bool)
 	// FetchReceipts fetches the receipts for a given block by hash.
 	// Returns block info and receipts, or an error if the block or receipts cannot be fetched.
-	FetchReceipts(ctx context.Context, blockHash eth.BlockID) (eth.BlockInfo, types.Receipts, error)
+	FetchReceipts(ctx context.Context, blockHash eth.BlockID) (eth.BlockInfo, optypes.Receipts, error)
 	// BlockTime returns the block time in seconds for this chain.
 	BlockTime() uint64
 	// PruneDeniedAtOrAfterTimestamp removes deny-list entries with DecisionTimestamp >= timestamp.
@@ -699,7 +699,7 @@ func (c *simpleChainContainer) PayloadByNumber(ctx context.Context, number uint6
 	return c.engine.PayloadByNumber(ctx, number)
 }
 
-func (c *simpleChainContainer) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
+func (c *simpleChainContainer) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, optypes.Receipts, error) {
 	if c.engine == nil {
 		return nil, nil, engine_controller.ErrNoEngineClient
 	}

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
@@ -25,7 +26,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -251,7 +251,7 @@ func (m *mockEngineController) OutputV0ByBlockHash(ctx context.Context, blockHas
 	return nil, nil
 }
 
-func (m *mockEngineController) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+func (m *mockEngineController) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
 	return nil, nil, nil
 }
 

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -11,7 +12,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 )
 
@@ -38,7 +38,7 @@ type EngineController interface {
 	// consult the live EL to discover the target.
 	Rewind(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error
 	// FetchReceipts fetches the receipts for a given block by hash.
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error)
 	// Close releases any underlying RPC resources.
 	Close() error
 }
@@ -53,7 +53,7 @@ type l2Provider interface {
 	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
 	ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
 	NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error)
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error)
 	Close()
 }
 
@@ -202,7 +202,7 @@ func (e *simpleEngineController) PayloadByNumber(ctx context.Context, number uin
 	return e.l2.PayloadByNumber(ctx, number)
 }
 
-func (e *simpleEngineController) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+func (e *simpleEngineController) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
 	if e.l2 == nil {
 		return nil, nil, ErrNoEngineClient
 	}

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
@@ -6,12 +6,12 @@ import (
 	"math/big"
 	"testing"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -272,7 +272,7 @@ func (m *mockL2) ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceStat
 	}
 	return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil
 }
-func (m *mockL2) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+func (m *mockL2) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
 	return nil, nil, nil
 }
 func (m *mockL2) Close() {

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -7,13 +7,13 @@ import (
 	"sync"
 	"testing"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -326,7 +326,7 @@ func (m *mockEngineForInvalidation) PayloadByNumber(ctx context.Context, number 
 	return nil, nil
 }
 
-func (m *mockEngineForInvalidation) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+func (m *mockEngineForInvalidation) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
 	return nil, nil, nil
 }
 


### PR DESCRIPTION
Part of #20264. Second of three stacked PRs (on #21907); the follow-up migrates op-batcher to payload-based block loading.

`op-service/sources` becomes the canonical OP-aware eth client: L2 blocks and receipts no longer flow through go-ethereum's typed JSON decoding, which under upstream go-ethereum rejects OP synthetic txs (`0x7E` deposits, `0x7D` post-exec) and silently drops the OP receipt fee fields.

**Blocks** — `RPCBlock` holds transactions as `RawTransactions` (canonical per-tx binary; JSON-codec'd by class via op-core/types resp. go-ethereum). Tx-root verification recomputes over the raw bytes; the payload conversion passes them through verbatim. New class-partitioned accessors on `apis.EthExtendedClient`: `InfoAndUserTxsBy{Hash,Number}` (synthetic classes excluded → upstream-decodable on any block), `InfoAndDepositsBy{Hash,Number}`, `InfoAndFirstDepositBy{Hash,Number}`. `InfoAndTxsBy*` keeps its signature (L1-safe; L2 decode only while go-ethereum resolves to op-geth — call sites migrate in #20265).

**Receipts** — `apis.{ReceiptFetcher,ReceiptsFetcher}` return `*optypes.Receipt`/`optypes.Receipts`, populated by the JSON fetch methods; the `debug_getRawReceipts` path uses the OP-aware consensus decode (fee fields nil there, as today). Receipts-root validation is now deposit-receipt-aware (Canyon nonce+version). Tx hashes for receipt fetching derive from the raw tx bytes. `txinclude`/`txplan` receipt currency moves to optypes, with `PlannedTx.Included` kept on `*types.Receipt` so txintent and its ~100 consumers stay untouched. The parallel same-signature interfaces across op-node, op-alt-da, op-supernode, op-interop-mon/filter, op-challenger, and the check tools move in lockstep; standard-field consumers convert via `Receipts.Geth()`.

Test note: op-deployer test packages fail locally without built forge artifacts (pre-existing environment dependency, unrelated).

🤖 *Co-created with Claude Fable 5*
