### PR TITLE
rust: retry the eth69 teardown SIGSEGV flake, alert Slack on recurrence

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -284,6 +284,54 @@ jobs:
           path: <<parameters.directory>>/target/nextest/default/junit.xml
           destination: junit
           when: always
+      # A retried flake (e.g. the eth69 teardown SIGSEGV, #20973) passes on rerun and
+      # leaves the job GREEN, so nothing else surfaces it — CircleCI does not parse
+      # nextest's <flakyFailure> element, so store_test_results/Insights stay blind. Detect
+      # it ourselves and ping Slack. Every occurrence is a rare, precious data point (the
+      # crash has never reproduced locally), so alert on every branch, not just develop —
+      # a stack lost on a PR run is a stack lost. Fork PRs get no SLACK_ACCESS_TOKEN and
+      # self-skip. Only tests with a retry override can emit <flakyFailure>, so today this
+      # fires only for the one tracked flake. This step must never fail the job (the retry
+      # passing is the whole point).
+      - run:
+          name: Alert Slack on a flaky retry
+          when: always
+          working_directory: <<parameters.directory>>
+          command: |
+            junit="target/nextest/default/junit.xml"
+            # Split the missing-file and no-flake cases: if the path ever drifts (profile
+            # or target-dir change) the alert must announce it's broken, not look healthy.
+            if [ ! -f "$junit" ]; then
+              echo "junit report not found at $junit — flake alerting is broken, fix the path"; exit 0
+            fi
+            # Match <flaky, covering both <flakyFailure> (test abort/failure, e.g. the SIGSEGV)
+            # and <flakyError> (exec error / timeout, if the teardown bug ever hangs); still
+            # ignores <rerunFailure> (all attempts failed → the job is already red).
+            if ! grep -q '<flaky' "$junit"; then
+              echo "no flaky retries recorded"; exit 0
+            fi
+            if [ -z "${SLACK_ACCESS_TOKEN:-}" ]; then
+              echo "flaky retry detected but SLACK_ACCESS_TOKEN is unset; cannot notify"; exit 0
+            fi
+            # testcase name precedes its <flaky...> child; collect the distinct ones. The
+            # `|| true` keeps a tool hiccup from failing the job (the step's whole contract).
+            tests=$(awk -F'"' '/<testcase /{n=$2} /<flaky/{print n}' "$junit" | sort -u | paste -sd, - || true)
+            [ -n "$tests" ] || tests="unknown"
+            text=":rotating_light: <@U04J4QNR84S> <@U09HDPERU78> nextest flaky retry on job $CIRCLE_JOB (branch ${CIRCLE_BRANCH:-?}): $tests passed only after a crash/failed attempt (likely the #20973 teardown SIGSEGV). Backtrace is in the junit artifact: $CIRCLE_BUILD_URL"
+            # <@U04J4QNR84S> = @seb, <@U09HDPERU78> = @einar. Form-encode the body
+            # (--data-urlencode) instead of hand-building JSON: $CIRCLE_BRANCH is
+            # user-controlled and a git ref may contain " or \, which would break the JSON.
+            # Bearer token via a stdin header (-H @-) keeps it out of the process table.
+            # Slack returns HTTP 200 with {"ok":false,...} on auth/channel errors, which -sf
+            # would miss, so check "ok" explicitly. This must never fail the job.
+            resp=$(printf 'Authorization: Bearer %s\n' "$SLACK_ACCESS_TOKEN" \
+              | curl -s --max-time 30 -H @- https://slack.com/api/chat.postMessage \
+                  --data-urlencode "channel=C03N11M0BBN" \
+                  --data-urlencode "text=$text" \
+                  --data-urlencode "unfurl_links=false") || resp='{"ok":false,"error":"curl transport failure"}'
+            echo "slack response: $resp"
+            echo "$resp" | grep -q '"ok":true' || echo "SLACK POST FAILED (non-fatal) — check token/channel/mentions"
+            exit 0
       - rust-save-build-cache: *tests-cache-args
 
   # Cross-language differential test: runs the Go and Rust dumps of the Interop
@@ -799,7 +847,15 @@ workflows:
           name: rust-deny
           directory: rust
           command: "just deny"
-          context: *rust-ci-context
+          # Not the shared *rust-ci-context anchor: this job and the two cargo-test jobs
+          # below additionally need the `slack` context (SLACK_ACCESS_TOKEN) — rust-deny to
+          # ping @protocol-oncall on a develop failure (below), the test jobs for the
+          # flaky-retry alert. Scoped to just these three; the 20+ lint/build jobs on
+          # *rust-ci-context have no business holding a Slack bot token.
+          context: &rust-ci-context-slack
+            - circleci-repo-readonly-authenticated-github-token
+            - sccache-gcs-optimism
+            - slack
           # cargo-deny (advisory/license/ban audit) only gates develop, not
           # PRs/branches. It is intentionally not part of required-rust-ci.
           filters:
@@ -819,7 +875,8 @@ workflows:
       - rust-ci-cargo-tests:
           name: rust-tests
           directory: rust
-          context: *rust-ci-context
+          # Adds the `slack` context for the flaky-retry alert step (anchor on rust-deny).
+          context: *rust-ci-context-slack
 
       - interop-deposits-go-rust-diff:
           name: interop-deposits-diff
@@ -891,7 +948,8 @@ workflows:
           directory: rust
           command: "--justfile op-reth/justfile test-integration"
           cache_profile: debug
-          context: *rust-ci-context
+          # Adds the `slack` context for the flaky-retry alert step (anchor on rust-deny).
+          context: *rust-ci-context-slack
 
       # -----------------------------------------------------------------------
       # Kona crate-specific jobs (lint, FPVM builds, host-client offline)

--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -1,13 +1,16 @@
 # Nextest configuration for the `rust/` workspace.
 
 [profile.default]
-# No test retries: a flaky test should fail loudly and get fixed, not be
-# retried away.
+# No test retries by default: a flaky test should fail loudly and get fixed, not
+# be retried away. The sole exception is the eth69 teardown-SIGSEGV override at the
+# bottom of this file (#20973) — a narrowly-scoped stopgap for a crash that happens
+# *after* the test has already passed.
 # Flag tests slower than 30s and terminate any that hang past ~2 minutes.
 slow-timeout = { period = "30s", terminate-after = 4 }
 
-# Emit a JUnit report so CircleCI `store_test_results` can surface individual
-# test outcomes (written to `target/nextest/default/junit.xml`).
+# Emit a JUnit report so CircleCI `store_test_results` can surface individual test
+# outcomes (written to `target/nextest/default/junit.xml`). The cargo-test job also
+# greps it for a `<flakyFailure>` to detect the eth69 retry below and alert Slack.
 [profile.default.junit]
 path = "junit.xml"
 
@@ -25,3 +28,24 @@ slow-timeout = { period = "2m", terminate-after = 10 }
 [[profile.default.overrides]]
 filter = "binary(e2e_testsuite)"
 slow-timeout = { period = "2m", terminate-after = 3 }
+
+# `p2p_version::peers_negotiate_eth_69` intermittently dies with SIGSEGV *after* its body
+# has passed — the assertions succeed and nextest prints `test result: ok`, then the binary
+# segfaults during teardown, failing the run purely on the signal exit and ejecting unrelated
+# PRs from the merge queue. Retrying is sound *because* the crash is teardown-only: nextest
+# reruns in a fresh process, re-establishing every assertion rather than papering over a
+# failure. This deliberately contradicts the no-retries policy above — it is a stopgap for
+# an unresolved crash tracked in #20973; remove it once that is fixed.
+#
+# The retry turns the red job green, so the cargo-test CI job greps this JUnit report for the
+# `<flakyFailure>` and pings Slack (CircleCI does not parse that element, so its Tests tab and
+# Insights stay blind — the detection is ours).
+#
+# `test(=exact)`, not `binary_id(...)`: nextest validates override filters against the whole
+# workspace binary namespace, so a future crate/binary rename would hard-error every run in
+# `rust/`; the exact-match predicate degrades to a no-op instead. The `=` is load-bearing —
+# bare `test(...)` is a substring match, so a sibling like `peers_negotiate_eth_69_disconnect`
+# would silently inherit the retry.
+[[profile.default.overrides]]
+filter = 'test(=p2p_version::peers_negotiate_eth_69)'
+retries = 2


### PR DESCRIPTION
Rebased onto develop after #22076 (nextest-config consolidation + `store_test_results`), so this is now just the eth69-specific bits on top: the **retry override**, the **Slack alert**, and the **`slack` context** the alert needs.

Stops `p2p_version::peers_negotiate_eth_69` from ejecting unrelated PRs from the merge queue, without silently hiding the flake. Mitigation only — the crash is unresolved, see #20973.

The test dies with SIGSEGV *after* its body has passed: assertions succeed, nextest prints `test result: ok`, then the binary segfaults during teardown and the run fails purely on the signal exit. Five recurrences since 2026-05.

**Retry.** Sound here because the crash is teardown-only: every assertion has already succeeded, and nextest reruns in a fresh process, so a pass on retry re-establishes them rather than masking a failure. This is a deliberate, single-test exception to the workspace's no-retries policy (noted inline).

**Keeping it visible — via Slack, not Insights.** A retry turns the red job green, which would let recurrences (and the #21910 backtrace) pass unnoticed. CircleCI does not parse nextest's `<flakyFailure>` element, so `store_test_results` / Insights / `/ci-flakes` stay blind to a flaky-pass (verified — op-claude's ci-flakes only reads results of *failed* jobs and would trend this toward "fixed"). So the job greps the JUnit for `<flakyFailure>` itself and pings Slack (`@seb`, `@einar`); the JUnit that #22076 already uploads as an artifact carries the backtrace. Alerts on **every** branch — the crash has never reproduced locally, so each occurrence is a rare shot at a stack. Fork PRs get no token and self-skip; only a retry-override test can emit `<flakyFailure>`, so today it fires for this flake only. **Verified live end-to-end** (real post, `ok:true`, both mentions resolved).

**Slack context.** The token lives in a dedicated `slack` context, so the two cargo-test jobs get a context list including it (not the shared `*rust-ci-context` that 20+ lint/build jobs use). Same gap had silently disabled **`rust-deny`'s own `@protocol-oncall` ping** — moved it onto the slack context too, so it notifies as its comment promises (re-enables a dormant ping).

#21910 stacks on this and adds the crash handler, so a recurrence's Slack ping points at a JUnit artifact containing a faulting stack.

🤖 *Co-created with Claude Opus 4.8 (1M context)*
