### PR TITLE
op-challenger: Remove Cannon from default game types

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -167,7 +167,7 @@ func TestSuperRootRpcCompatibility(t *testing.T) {
 
 func TestGameTypes(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
-		expectedDefault := []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.CannonKonaGameType}
+		expectedDefault := []gameTypes.GameType{gameTypes.CannonKonaGameType}
 		cfg := configForArgs(t, addRequiredArgsForMultipleGameTypesExcept(expectedDefault, "--game-types"))
 		require.Equal(t, expectedDefault, cfg.GameTypes)
 	})

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -95,7 +95,7 @@ var (
 		Aliases: []string{"trace-type"}, // For backwards compatibility
 		Usage:   "The game types to support. Valid options: " + openum.EnumStringer(gameTypes.PlayableGameTypes),
 		EnvVars: prefixEnvVars("GAME_TYPES", "TRACE_TYPE"),
-		Value:   cli.NewStringSlice(gameTypes.CannonGameType.String(), gameTypes.CannonKonaGameType.String()),
+		Value:   cli.NewStringSlice(gameTypes.CannonKonaGameType.String()),
 	}
 	DatadirFlag = &cli.StringFlag{
 		Name:    "datadir",


### PR DESCRIPTION
Removes Cannon from op-challenger's default `--game-types` value, leaving Cannon Kona as the sole default. Explicit Cannon configuration remains supported.

Tests:
- `cd op-challenger && mise exec -- just test`
- `mise exec -- just lint-go`