### PR TITLE
ci,contributing: drop the single-commit subject check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -29,16 +29,3 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: bash .github/scripts/check-pr-title.sh "$PR_TITLE"
-      # squash_merge_commit_title is COMMIT_OR_PR_TITLE: a single-commit PR is
-      # squashed under its commit subject, not the PR title, so that subject
-      # must satisfy the format too.
-      - name: Check single-commit subject
-        if: github.event.pull_request.commits == 1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          set -euo pipefail
-          subject=$(gh pr view "$PR_URL" --json commits --jq '.commits[0].messageHeadline')
-          echo "single-commit PR; a squash merge will use the commit subject"
-          bash .github/scripts/check-pr-title.sh "$subject"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ The scope names the component, subsystem, or area the change touches — for exa
 
 Do not use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) type prefixes (`feat:`, `fix:`, `chore(scope):`, ...). The part of the codebase a commit touches is what readers of the log — contributors, debuggers, incident responders — actually scan for, and a well-written description already conveys whether a change is a fix or a feature. See [Stop Using Conventional Commits](https://sumnerevans.com/posts/software-engineering/stop-using-conventional-commits/) for the full rationale.
 
-PRs are squash-merged, so CI validates the PR title against this format (and the commit subject for single-commit PRs, since GitHub uses it as the squash title). The exact rules live in [`.github/scripts/check-pr-title.sh`](.github/scripts/check-pr-title.sh).
+PRs are squash-merged with the PR title as the commit subject, so CI validates the PR title against this format. The exact rules live in [`.github/scripts/check-pr-title.sh`](.github/scripts/check-pr-title.sh).
 
 ### Response time
 


### PR DESCRIPTION
## Description

Follow-up to #21855. With `squash_merge_commit_title` changed to `PR_TITLE`, the squash subject is always the PR title regardless of commit count, so the special-case validation of the commit subject on single-commit PRs is no longer needed. The workflow is now a pure PR-title check, and the CONTRIBUTING note is simplified to match.

⚠️ Merge only once the admins have flipped `squash_merge_commit_title` to `PR_TITLE` — until then, single-commit PRs still land under their commit subject, which this check would no longer validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)