### PR TITLE
op-node: stop requiring beacon node version endpoint

### DIFF
--- a/op-e2e/e2eutils/fakebeacon/blobs.go
+++ b/op-e2e/e2eutils/fakebeacon/blobs.go
@@ -98,13 +98,6 @@ func (f *FakeBeacon) Start(addr string) error {
 			f.log.Error("blobs handler err", "err", err)
 		}
 	})
-	mux.HandleFunc("/eth/v1/node/version", func(w http.ResponseWriter, r *http.Request) {
-		err := json.NewEncoder(w).Encode(&eth.APIVersionResponse{Data: eth.VersionInformation{Version: "fakebeacon 1.2.3"}})
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			f.log.Error("version handler err", "err", err)
-		}
-	})
 	f.beaconSrv = &http.Server{
 		Handler:           mux,
 		ReadTimeout:       time.Second * 20,

--- a/op-e2e/system/da/l1_beacon_client_test.go
+++ b/op-e2e/system/da/l1_beacon_client_test.go
@@ -17,26 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetVersion(t *testing.T) {
-	op_e2e.InitParallel(t)
-
-	l := testlog.Logger(t, log.LevelInfo)
-
-	blobStore := blobstore.New()
-	beaconApi := fakebeacon.NewBeacon(l, blobStore, uint64(0), uint64(0))
-	t.Cleanup(func() {
-		_ = beaconApi.Close()
-	})
-	require.NoError(t, beaconApi.Start("127.0.0.1:0"))
-
-	beaconCfg := sources.L1BeaconClientConfig{FetchAllSidecars: false}
-	cl := sources.NewL1BeaconClient(sources.NewBeaconHTTPClient(client.NewBasicHTTPClient(beaconApi.BeaconAddr(), l)), beaconCfg)
-
-	version, err := cl.GetVersion(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, "fakebeacon 1.2.3", version)
-}
-
 func Test404NotFound(t *testing.T) {
 	op_e2e.InitParallel(t)
 

--- a/op-node/cmd/batch_decoder/main.go
+++ b/op-node/cmd/batch_decoder/main.go
@@ -94,9 +94,8 @@ func main() {
 					beaconClient := sources.NewBeaconHTTPClient(client.NewBasicHTTPClient(beaconAddr, nil))
 					beaconCfg := sources.L1BeaconClientConfig{FetchAllSidecars: false}
 					beacon = sources.NewL1BeaconClient(beaconClient, beaconCfg)
-					_, err := beacon.GetVersion(ctx)
-					if err != nil {
-						log.Fatal(fmt.Errorf("failed to check L1 Beacon API version: %w", err))
+					if _, err := beaconClient.BeaconGenesis(ctx); err != nil {
+						log.Fatal(fmt.Errorf("failed to connect to L1 Beacon API: %w", err))
 					}
 				} else {
 					fmt.Println("L1 Beacon endpoint not set. Unable to fetch post-ecotone channel frames")

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -65,13 +65,6 @@ type L1Client interface {
 	Close()
 }
 
-// BeaconClient is the interface that op-node uses to interact with L1 Beacon.
-// This allows wrapped or mocked clients to be used
-type BeaconClient interface {
-	GetVersion(ctx context.Context) (string, error)
-	GetBlobs(ctx context.Context, ref eth.L1BlockRef, hashes []eth.IndexedBlobHash) ([]*eth.Blob, error)
-}
-
 type closableSafeDB interface {
 	rollup.SafeHeadListener
 	SafeDBReader
@@ -485,18 +478,18 @@ func initL1BeaconAPI(ctx context.Context, cfg *config.Config, node *OpNode) (*so
 	}
 	beacon := sources.NewL1BeaconClient(beaconClient, beaconCfg, fallbacks...)
 
-	// Retry retrieval of the Beacon API version, to be more robust on startup against Beacon API connection issues.
-	beaconVersion, missingEndpoint, err := retry.Do2[string, bool](ctx, 5, retry.Exponential(), func() (string, bool, error) {
+	// Ping the Beacon API on startup to be more robust against connection issues.
+	missingEndpoint, err := retry.Do[bool](ctx, 5, retry.Exponential(), func() (bool, error) {
 		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 		defer cancel()
-		beaconVersion, err := beacon.GetVersion(ctx)
+		_, err := beaconClient.BeaconGenesis(ctx)
 		if err != nil {
 			if errors.Is(err, client.ErrNoEndpoint) {
-				return "", true, nil // don't return an error, we do not have to retry when there is a config issue.
+				return true, nil // don't return an error, we do not have to retry when there is a config issue.
 			}
-			return "", false, err
+			return false, err
 		}
-		return beaconVersion, false, nil
+		return false, nil
 	})
 	if missingEndpoint {
 		// Allow the user to continue if they explicitly ignore the requirement of the endpoint.
@@ -514,14 +507,14 @@ func initL1BeaconAPI(ctx context.Context, cfg *config.Config, node *OpNode) (*so
 		}
 	} else if err != nil {
 		if cfg.Beacon.ShouldIgnoreBeaconCheck() {
-			node.log.Warn("Failed to check L1 Beacon API version, but configuration ignores results. "+
+			node.log.Warn("Failed to connect to L1 Beacon API, but configuration ignores results. "+
 				"The node may be unable to retrieve EIP-4844 blobs data.", "err", err)
 			return beacon, nil
 		} else {
-			return nil, fmt.Errorf("failed to check L1 Beacon API version: %w", err)
+			return nil, fmt.Errorf("failed to connect to L1 Beacon API: %w", err)
 		}
 	} else {
-		node.log.Info("Connected to L1 Beacon API, ready for EIP-4844 blobs retrieval.", "version", beaconVersion)
+		node.log.Info("Connected to L1 Beacon API, ready for EIP-4844 blobs retrieval.")
 		return beacon, nil
 	}
 }

--- a/op-service/apis/beacon.go
+++ b/op-service/apis/beacon.go
@@ -9,7 +9,6 @@ import (
 
 // BeaconClient is a thin wrapper over the Beacon APIs.
 type BeaconClient interface {
-	NodeVersion(ctx context.Context) (string, error)
 	ConfigSpec(ctx context.Context) (eth.APIConfigResponse, error)
 	BeaconGenesis(ctx context.Context) (eth.APIGenesisResponse, error)
 	BeaconBlobs(ctx context.Context, slot uint64, hashes []common.Hash) (eth.APIBeaconBlobsResponse, error)

--- a/op-service/eth/blobs_api.go
+++ b/op-service/eth/blobs_api.go
@@ -65,11 +65,3 @@ type ReducedConfigData struct {
 type APIConfigResponse struct {
 	Data ReducedConfigData `json:"data"`
 }
-
-type APIVersionResponse struct {
-	Data VersionInformation `json:"data"`
-}
-
-type VersionInformation struct {
-	Version string `json:"version"`
-}

--- a/op-service/sources/l1_beacon_client.go
+++ b/op-service/sources/l1_beacon_client.go
@@ -21,7 +21,6 @@ import (
 )
 
 const (
-	versionMethod        = "eth/v1/node/version"
 	specMethod           = "eth/v1/config/spec"
 	genesisMethod        = "eth/v1/beacon/genesis"
 	sidecarsMethodPrefix = "eth/v1/beacon/blob_sidecars/"
@@ -92,14 +91,6 @@ func (cl *BeaconHTTPClient) apiReq(ctx context.Context, dest any, reqPath string
 		return fmt.Errorf("failed to close response body: %w", err)
 	}
 	return nil
-}
-
-func (cl *BeaconHTTPClient) NodeVersion(ctx context.Context) (string, error) {
-	var resp eth.APIVersionResponse
-	if err := cl.apiReq(ctx, &resp, versionMethod, nil); err != nil {
-		return "", err
-	}
-	return resp.Data.Version, nil
 }
 
 func (cl *BeaconHTTPClient) ConfigSpec(ctx context.Context) (eth.APIConfigResponse, error) {
@@ -306,9 +297,4 @@ func verifyBlob(blob *eth.Blob, expectedCommitmentHash common.Hash) error {
 		return fmt.Errorf("recomputed commitment %s does not match expected commitment %s", recomputedCommitmentHash, expectedCommitmentHash)
 	}
 	return nil
-}
-
-// GetVersion fetches the version of the Beacon-node.
-func (cl *L1BeaconClient) GetVersion(ctx context.Context) (string, error) {
-	return cl.cl.NodeVersion(ctx)
 }

--- a/op-service/sources/mocks/BeaconClient.go
+++ b/op-service/sources/mocks/BeaconClient.go
@@ -195,62 +195,6 @@ func (_c *BeaconClient_ConfigSpec_Call) RunAndReturn(run func(context.Context) (
 	return _c
 }
 
-// NodeVersion provides a mock function with given fields: ctx
-func (_m *BeaconClient) NodeVersion(ctx context.Context) (string, error) {
-	ret := _m.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for NodeVersion")
-	}
-
-	var r0 string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
-		return rf(ctx)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context) string); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// BeaconClient_NodeVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'NodeVersion'
-type BeaconClient_NodeVersion_Call struct {
-	*mock.Call
-}
-
-// NodeVersion is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *BeaconClient_Expecter) NodeVersion(ctx interface{}) *BeaconClient_NodeVersion_Call {
-	return &BeaconClient_NodeVersion_Call{Call: _e.mock.On("NodeVersion", ctx)}
-}
-
-func (_c *BeaconClient_NodeVersion_Call) Run(run func(ctx context.Context)) *BeaconClient_NodeVersion_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
-	})
-	return _c
-}
-
-func (_c *BeaconClient_NodeVersion_Call) Return(_a0 string, _a1 error) *BeaconClient_NodeVersion_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *BeaconClient_NodeVersion_Call) RunAndReturn(run func(context.Context) (string, error)) *BeaconClient_NodeVersion_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewBeaconClient creates a new instance of BeaconClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewBeaconClient(t interface {


### PR DESCRIPTION
## Summary

The Beacon node version is informational and unrelated to blob retrieval, but op-node currently requires providers to expose it during startup. Probe the required beacon genesis endpoint instead while preserving the existing retry and ignore behavior, and remove the now-unused version client surface and fake endpoint.

## Tests

- `just lint-go`
- `go test ./op-service/sources ./op-node/node`
- `go test ./op-node/cmd/batch_decoder/...`
- `go test ./op-e2e/e2eutils/fakebeacon`
- `go test ./op-e2e/system/da -run Test404NotFound -count=1`
