### PR TITLE
devstack: configure L1 fork from environment

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2021,6 +2021,10 @@ jobs:
 
   op-acceptance-tests:
     parameters:
+      l1_fork:
+        description: "L1 fork active at genesis"
+        type: string
+        default: "prague"
       l2_cl_kind:
         description: "L2 consensus layer client (op-node or kona-node)"
         type: string
@@ -2076,8 +2080,9 @@ jobs:
             # keeps these jobs off the slow kona-build-sp1-elfs critical path;
             # kona-build-sp1-elfs is gated directly via ci-gate instead.
       - run:
-          name: Configure L2 stack
+          name: Configure devstack
           command: |
+            echo "export DEVSTACK_L1_FORK=<<parameters.l1_fork>>" >> "$BASH_ENV"
             echo "export DEVSTACK_L2CL_KIND=<<parameters.l2_cl_kind>>" >> "$BASH_ENV"
             echo "export DEVSTACK_L2EL_KIND=<<parameters.l2_el_kind>>" >> "$BASH_ENV"
       # Restore cached Go modules (downloaded once by prep-go-modules) plus the
@@ -2743,7 +2748,11 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
       # IN-MEMORY - op-node/op-reth
       - op-acceptance-tests:
-          name: memory-all-opn-op-reth
+          name: memory-all-opn-op-reth-<<matrix.l1_fork>>
+          matrix:
+            parameters:
+              l1_fork: &acceptance_l1_forks
+                - prague
           l2_el_kind: op-reth
           parallelism: 2
           acceptance_test_jobs: "8"
@@ -2762,7 +2771,10 @@ workflows:
             - prep-superchain
       # IN-MEMORY - kona/op-reth
       - op-acceptance-tests:
-          name: memory-all-kona-op-reth
+          name: memory-all-kona-op-reth-<<matrix.l1_fork>>
+          matrix:
+            parameters:
+              l1_fork: *acceptance_l1_forks
           l2_cl_kind: kona-node
           l2_el_kind: op-reth
           parallelism: 2
@@ -2792,8 +2804,8 @@ workflows:
             - semgrep-scan-local: terminal
             - semgrep-test: terminal
             - go-tests-short: terminal
-            - memory-all-opn-op-reth: terminal
-            - memory-all-kona-op-reth: terminal
+            - memory-all-opn-op-reth-prague: terminal
+            - memory-all-kona-op-reth-prague: terminal
             - kona-build-sp1-elfs: terminal
             # Go test/lint jobs previously fanned in via the bedrock-go-tests helper.
             - cannon-go-lint-and-test: terminal

--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -101,7 +101,7 @@ and returns a typed output that the test then may use.
 
 - `DEVSTACK_KEYS_SALT`: Seeds the keys generated with `NewHDWallet`. This is useful for "isolating" test runs, and might be needed to reproduce CI and/or acceptance test runs. It can be any string, including the empty one to use the "usual" devkeys.
 - `DEVNET_EXPECT_PRECONDITIONS_MET`: This can be set of force test failures when their pre-conditions are not met, which would otherwise result in them being skipped. This is helpful in particular for runs that do intend to run specific tests (as opposed to whatever is available). `op-acceptor` does set that variable, for example.
-- `DEVSTACK_L1_FORK=prague` selects the L1 fork active at genesis. Ethereum upgrade names (`dencun`, `pectra`, `fusaka`) and geth execution-fork names (`cancun`, `prague`, `osaka`) are accepted. If unset, Prague remains the default.
+- `DEVSTACK_L1_FORK=prague` selects the L1 fork active at genesis. Ethereum upgrade names (`pectra`, `fusaka`) and geth execution-fork names (`prague`, `osaka`) are accepted. If unset, Prague remains the default.
 - `DEVSTACK_MONOREPO_ROOT`: Absolute path to a monorepo checkout. Used by out-of-tree acceptance suites (which depend on this module by git rev) so contract-artifact resolution can find `packages/contracts-bedrock` outside the cwd-relative walk. In-tree runs don't need it.
 
 ### Rust stack env vars:

--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -101,6 +101,7 @@ and returns a typed output that the test then may use.
 
 - `DEVSTACK_KEYS_SALT`: Seeds the keys generated with `NewHDWallet`. This is useful for "isolating" test runs, and might be needed to reproduce CI and/or acceptance test runs. It can be any string, including the empty one to use the "usual" devkeys.
 - `DEVNET_EXPECT_PRECONDITIONS_MET`: This can be set of force test failures when their pre-conditions are not met, which would otherwise result in them being skipped. This is helpful in particular for runs that do intend to run specific tests (as opposed to whatever is available). `op-acceptor` does set that variable, for example.
+- `DEVSTACK_L1_FORK=prague` selects the L1 fork active at genesis. Ethereum upgrade names (`dencun`, `pectra`, `fusaka`) and geth execution-fork names (`cancun`, `prague`, `osaka`) are accepted. If unset, Prague remains the default.
 - `DEVSTACK_MONOREPO_ROOT`: Absolute path to a monorepo checkout. Used by out-of-tree acceptance suites (which depend on this module by git rev) so contract-artifact resolution can find `packages/contracts-bedrock` outside the cwd-relative walk. In-tree runs don't need it.
 
 ### Rust stack env vars:

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -2,7 +2,9 @@ package sysgo
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 	"math/big"
+	"os"
 	"path/filepath"
 	"slices"
 	"time"
@@ -46,6 +48,7 @@ func FunderKey(keys devkeys.Keys) (*ecdsa.PrivateKey, error) {
 }
 
 const devFeatureBitmapKey = "devFeatureBitmap"
+const DevstackL1ForkEnvVar = "DEVSTACK_L1_FORK"
 
 // proxyImplementationSlot is the EIP-1967 proxy implementation storage slot used
 // by every L2 predeploy proxy (`bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1)`).
@@ -78,6 +81,22 @@ func WithDefaultBPOBlobSchedule(_ devtest.T, _ devkeys.Keys, builder intentbuild
 		BPO3:   params.DefaultBPO3BlobConfig,
 		BPO4:   params.DefaultBPO4BlobConfig,
 	})
+}
+
+// parseL1Fork accepts Ethereum upgrade names and their geth execution-layer names.
+func parseL1Fork(value string) (forks.Fork, error) {
+	fork, ok := map[string]forks.Fork{
+		"dencun": forks.Cancun,
+		"cancun": forks.Cancun,
+		"pectra": forks.Prague,
+		"prague": forks.Prague,
+		"fusaka": forks.Osaka,
+		"osaka":  forks.Osaka,
+	}[value]
+	if ok {
+		return fork, nil
+	}
+	return 0, fmt.Errorf("unsupported L1 fork %q", value)
 }
 
 func WithKarstAtOffset(offset *uint64) DeployerOption {
@@ -260,7 +279,13 @@ func WithCommons(l1ChainID eth.ChainID) DeployerOption {
 		l1StartTimestamp := uint64(time.Now().Unix()) + 1
 		l1Config.WithTimestamp(l1StartTimestamp)
 
-		l1Config.WithL1ForkAtGenesis(forks.Prague) // activate pectra on L1
+		l1Fork := forks.Prague // activate Pectra on L1 by default
+		if value := os.Getenv(DevstackL1ForkEnvVar); value != "" {
+			var err error
+			l1Fork, err = parseL1Fork(value)
+			p.Require().NoError(err, "invalid %s", DevstackL1ForkEnvVar)
+		}
+		l1Config.WithL1ForkAtGenesis(l1Fork)
 
 		funderAddr, err := keys.Address(devkeys.UserKey(funderMnemonicIndex))
 		p.Require().NoError(err, "need funder addr")

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -86,8 +86,6 @@ func WithDefaultBPOBlobSchedule(_ devtest.T, _ devkeys.Keys, builder intentbuild
 // parseL1Fork accepts Ethereum upgrade names and their geth execution-layer names.
 func parseL1Fork(value string) (forks.Fork, error) {
 	fork, ok := map[string]forks.Fork{
-		"dencun": forks.Cancun,
-		"cancun": forks.Cancun,
 		"pectra": forks.Prague,
 		"prague": forks.Prague,
 		"fusaka": forks.Osaka,
@@ -280,7 +278,7 @@ func WithCommons(l1ChainID eth.ChainID) DeployerOption {
 		l1Config.WithTimestamp(l1StartTimestamp)
 
 		l1Fork := forks.Prague // activate Pectra on L1 by default
-		if value := os.Getenv(DevstackL1ForkEnvVar); value != "" {
+		if value, ok := os.LookupEnv(DevstackL1ForkEnvVar); ok {
 			var err error
 			l1Fork, err = parseL1Fork(value)
 			p.Require().NoError(err, "invalid %s", DevstackL1ForkEnvVar)

--- a/op-devstack/sysgo/deployer_test.go
+++ b/op-devstack/sysgo/deployer_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params/forks"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
@@ -67,6 +69,68 @@ func TestWithLocalContractSourcesAt(t *testing.T) {
 	expected := artifacts.MustNewFileLocator(artifactsDir)
 	require.True(t, expected.Equal(intent.L1ContractsLocator))
 	require.True(t, expected.Equal(intent.L2ContractsLocator))
+}
+
+func TestParseL1Fork(t *testing.T) {
+	tests := map[string]forks.Fork{
+		"dencun": forks.Cancun,
+		"cancun": forks.Cancun,
+		"pectra": forks.Prague,
+		"prague": forks.Prague,
+		"fusaka": forks.Osaka,
+		"osaka":  forks.Osaka,
+	}
+	for input, expected := range tests {
+		t.Run(input, func(t *testing.T) {
+			actual, err := parseL1Fork(input)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+		})
+	}
+
+	for _, input := range []string{"frontier", "Fusaka", " osaka ", "bpo-1"} {
+		t.Run("reject "+input, func(t *testing.T) {
+			_, err := parseL1Fork(input)
+			require.EqualError(t, err, `unsupported L1 fork "`+input+`"`)
+		})
+	}
+}
+
+func TestDevstackL1ForkEnv(t *testing.T) {
+	t.Setenv(DevstackL1ForkEnvVar, "fusaka")
+	builder := newValidIntentBuilder()
+	builder.WithL1ContractsLocator(artifacts.EmbeddedLocator)
+	builder.WithL2ContractsLocator(artifacts.EmbeddedLocator)
+	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+
+	applyConfigCommons(devtest.SerialT(t), keys, DefaultL1ID, builder)
+
+	intent, err := builder.Build()
+	require.NoError(t, err)
+	require.NotNil(t, intent.L1DevGenesisParams.OsakaTimeOffset)
+	require.Zero(t, *intent.L1DevGenesisParams.OsakaTimeOffset)
+}
+
+func TestDeployerOptionsOverrideDevstackL1Fork(t *testing.T) {
+	t.Setenv(DevstackL1ForkEnvVar, "fusaka")
+	builder := newValidIntentBuilder()
+	builder.WithL1ContractsLocator(artifacts.EmbeddedLocator)
+	builder.WithL2ContractsLocator(artifacts.EmbeddedLocator)
+	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+	dt := devtest.SerialT(t)
+
+	applyConfigCommons(dt, keys, DefaultL1ID, builder)
+	applyConfigDeployerOptions(dt, keys, builder, []DeployerOption{
+		WithForkAtL1Genesis(forks.Prague),
+	})
+
+	intent, err := builder.Build()
+	require.NoError(t, err)
+	require.NotNil(t, intent.L1DevGenesisParams.PragueTimeOffset)
+	require.Zero(t, *intent.L1DevGenesisParams.PragueTimeOffset)
+	require.Nil(t, intent.L1DevGenesisParams.OsakaTimeOffset)
 }
 
 func newValidIntentBuilder() intentbuilder.Builder {

--- a/op-devstack/sysgo/deployer_test.go
+++ b/op-devstack/sysgo/deployer_test.go
@@ -73,8 +73,6 @@ func TestWithLocalContractSourcesAt(t *testing.T) {
 
 func TestParseL1Fork(t *testing.T) {
 	tests := map[string]forks.Fork{
-		"dencun": forks.Cancun,
-		"cancun": forks.Cancun,
 		"pectra": forks.Prague,
 		"prague": forks.Prague,
 		"fusaka": forks.Osaka,
@@ -88,7 +86,7 @@ func TestParseL1Fork(t *testing.T) {
 		})
 	}
 
-	for _, input := range []string{"frontier", "Fusaka", " osaka ", "bpo-1"} {
+	for _, input := range []string{"", "dencun", "cancun", "frontier", "Fusaka", " osaka ", "bpo-1"} {
 		t.Run("reject "+input, func(t *testing.T) {
 			_, err := parseL1Fork(input)
 			require.EqualError(t, err, `unsupported L1 fork "`+input+`"`)
@@ -97,19 +95,37 @@ func TestParseL1Fork(t *testing.T) {
 }
 
 func TestDevstackL1ForkEnv(t *testing.T) {
-	t.Setenv(DevstackL1ForkEnvVar, "fusaka")
-	builder := newValidIntentBuilder()
-	builder.WithL1ContractsLocator(artifacts.EmbeddedLocator)
-	builder.WithL2ContractsLocator(artifacts.EmbeddedLocator)
-	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
-	require.NoError(t, err)
+	tests := map[string]bool{
+		"pectra": false,
+		"prague": false,
+		"fusaka": true,
+		"osaka":  true,
+	}
+	for input, osakaAtGenesis := range tests {
+		t.Run(input, func(t *testing.T) {
+			t.Setenv(DevstackL1ForkEnvVar, input)
+			builder := newValidIntentBuilder()
+			builder.WithL1ContractsLocator(artifacts.EmbeddedLocator)
+			builder.WithL2ContractsLocator(artifacts.EmbeddedLocator)
+			keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+			require.NoError(t, err)
 
-	applyConfigCommons(devtest.SerialT(t), keys, DefaultL1ID, builder)
+			applyConfigCommons(devtest.SerialT(t), keys, DefaultL1ID, builder)
 
-	intent, err := builder.Build()
-	require.NoError(t, err)
-	require.NotNil(t, intent.L1DevGenesisParams.OsakaTimeOffset)
-	require.Zero(t, *intent.L1DevGenesisParams.OsakaTimeOffset)
+			intent, err := builder.Build()
+			require.NoError(t, err)
+			require.NotNil(t, intent.L1DevGenesisParams.PragueTimeOffset)
+			require.Zero(t, *intent.L1DevGenesisParams.PragueTimeOffset)
+			if osakaAtGenesis {
+				require.NotNil(t, intent.L1DevGenesisParams.OsakaTimeOffset)
+				require.Zero(t, *intent.L1DevGenesisParams.OsakaTimeOffset)
+			} else {
+				require.Nil(t, intent.L1DevGenesisParams.OsakaTimeOffset)
+			}
+			require.Nil(t, intent.L1DevGenesisParams.BPO1TimeOffset)
+			require.Nil(t, intent.L1DevGenesisParams.BPO2TimeOffset)
+		})
+	}
 }
 
 func TestDeployerOptionsOverrideDevstackL1Fork(t *testing.T) {

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params/forks"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
@@ -108,22 +107,7 @@ func applyConfigLocalContractSources(t devtest.T, _ devkeys.Keys, builder intent
 }
 
 func applyConfigCommons(t devtest.T, keys devkeys.Keys, l1ChainID eth.ChainID, builder intentbuilder.Builder) {
-	_, l1Config := builder.WithL1(l1ChainID)
-
-	l1StartTimestamp := uint64(time.Now().Unix()) + 1
-	l1Config.WithTimestamp(l1StartTimestamp)
-	l1Config.WithL1ForkAtGenesis(forks.Prague)
-
-	funderAddr, err := keys.Address(devkeys.UserKey(funderMnemonicIndex))
-	t.Require().NoError(err, "need funder addr")
-	l1Config.WithPrefundedAccount(funderAddr, *eth.BillionEther.ToU256())
-
-	addrFor := intentbuilder.RoleToAddrProvider(t, keys, l1ChainID)
-	_, superCfg := builder.WithSuperchain()
-	intentbuilder.WithDevkeySuperRoles(t, keys, l1ChainID, superCfg)
-	l1Config.WithPrefundedAccount(addrFor(devkeys.SuperchainProxyAdminOwner), *millionEth)
-	l1Config.WithPrefundedAccount(addrFor(devkeys.SuperchainConfigGuardianKey), *millionEth)
-	l1Config.WithPrefundedAccount(addrFor(devkeys.L1ProxyAdminOwnerRole), *millionEth)
+	WithCommons(l1ChainID)(t, keys, builder)
 }
 
 func applyConfigPrefundedL2(t devtest.T, keys devkeys.Keys, l1ChainID, l2ChainID eth.ChainID, builder intentbuilder.Builder) {


### PR DESCRIPTION
## Summary

- add `DEVSTACK_L1_FORK` with strict fork-name parsing while preserving Prague as the devstack default
- route single-chain setup through the environment-aware common configuration
- exercise the CI plumbing with a one-entry Prague acceptance-test matrix
- keep per-test deployer options able to override the coarse environment setting

This is PR 1 of 3. It intentionally does not change the acceptance-test fork or the default used by `op-e2e` and other devstack consumers.

## Validation

- `go test ./op-devstack/sysgo`
- `.circleci/scripts/merge-configs.sh`
- `.circleci/scripts/test-decision-tree.sh` (18/18 cases)
