### PR TITLE
acceptance: test Glamsterdam L1 transition

### DIFF
--- a/docs/ai/opgeth-decoupling.md
+++ b/docs/ai/opgeth-decoupling.md
@@ -422,6 +422,10 @@ wrapping) — small design task, metric names/labels must be preserved. `rpc.Jso
 `op-core/predeploys`) — ride the §2-style call-site swaps (#20263 family). Derive current sites
 by grepping the symbol; listed file snapshots go stale.
 
+**Cutover check:** revisit `op-batcher/batcher.maxFloorDataGas`; check whether the then-current
+upstream `core.FloorDataGas` can replace its local pre- and post-Amsterdam floor calculations while
+preserving the conservative maximum across both rule sets.
+
 ---
 
 ## 16. `op-chain-ops/script` + op-deployer — Rust script engine

--- a/mise.toml
+++ b/mise.toml
@@ -42,7 +42,7 @@ mold = { version = "2.41.0", os = ["linux"] }
 
 # Go dependencies
 "go:github.com/ethereum/go-ethereum/cmd/abigen" = "1.15.10"
-"go:github.com/ethereum/go-ethereum/cmd/geth" = "0c8cefdf344e263b94cd80bcc8a002c63f3b4ed1" # Glamsterdam development commit.
+"go:github.com/ethereum/go-ethereum/cmd/geth" = "e9bac5fac00d77fe87e4c1a28c48ee57cda942cc" # Glamsterdam development commit.
 
 # Python dependencies
 "pipx:slither-analyzer" = "0.10.2"

--- a/mise.toml
+++ b/mise.toml
@@ -42,7 +42,7 @@ mold = { version = "2.41.0", os = ["linux"] }
 
 # Go dependencies
 "go:github.com/ethereum/go-ethereum/cmd/abigen" = "1.15.10"
-"go:github.com/ethereum/go-ethereum/cmd/geth" = "1.16.4"    # Osaka testnet release.
+"go:github.com/ethereum/go-ethereum/cmd/geth" = "0c8cefdf344e263b94cd80bcc8a002c63f3b4ed1" # Glamsterdam development commit.
 
 # Python dependencies
 "pipx:slither-analyzer" = "0.10.2"

--- a/op-acceptance-tests/tests/glamsterdam_test.go
+++ b/op-acceptance-tests/tests/glamsterdam_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
@@ -55,7 +56,7 @@ func TestSafeHeadAdvancesAcrossGlamsterdam(gt *testing.T) {
 	waitForHalfFullBlock(t, sys.L2EL, eth.Safe, threshold, "post-Glamsterdam")
 }
 
-func TestGlamsterdamP2P(gt *testing.T) {
+func TestGlamsterdamP2PUnsafeBlockBecomesSafe(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSingleChainMultiNode(t,
 		glamsterdamL1Geth(t),
@@ -88,8 +89,19 @@ func TestGlamsterdamP2P(gt *testing.T) {
 		sys.L2EL.ReachedFn(eth.Safe, target, 120),
 		sys.L2ELB.ReachedFn(eth.Safe, target, 120),
 	)
+	t.Require().NoError(sys.L2CLB.MatchedFn(sys.L2CL, safety.CrossSafe, 30)(),
+		"sequencer and verifier must match after the P2P block becomes safe")
 	t.Require().Equal(sequencerBlock.ID(), sys.L2EL.BlockRefByNumber(target).ID())
 	t.Require().Equal(sequencerBlock.ID(), sys.L2ELB.BlockRefByNumber(target).ID())
+
+	stoppedUnsafeHash := sys.L2CL.StopSequencer()
+	t.Require().NoError(sys.L2CLB.MatchedFn(sys.L2CL, safety.LocalUnsafe, 30)(),
+		"verifier must catch up to the sequencer's final unsafe head")
+	sequencerUnsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	verifierUnsafe := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	t.Require().Equal(stoppedUnsafeHash, sequencerUnsafe.Hash)
+	t.Require().Equal(sequencerUnsafe.ID(), verifierUnsafe.ID(),
+		"sequencer and verifier must finish on the same unsafe chain")
 }
 
 func waitForHalfFullBlock(t devtest.T, el *dsl.L2ELNode, label eth.BlockLabel, threshold uint64, phase string) {

--- a/op-acceptance-tests/tests/glamsterdam_test.go
+++ b/op-acceptance-tests/tests/glamsterdam_test.go
@@ -16,13 +16,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
-func TestSafeHeadsAdvanceAcrossGlamsterdam(gt *testing.T) {
+func TestSafeHeadAdvancesAcrossGlamsterdam(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSingleChainMultiNodeWithoutCheck(t,
+	sys := presets.NewMinimal(t,
 		glamsterdamL1Geth(t),
 		presets.WithDeployerOptions(
 			sysgo.WithForkAtL1Genesis(forks.BPO5),
@@ -37,6 +38,12 @@ func TestSafeHeadsAdvanceAcrossGlamsterdam(gt *testing.T) {
 	t.Require().Greater(*l1Config.AmsterdamTime, l1Genesis.Time,
 		"Glamsterdam must activate after L1 genesis to exercise the fork transition")
 
+	threshold := sys.L2Chain.Escape().RollupConfig().Genesis.SystemConfig.GasLimit/2 + 1
+	waitForHalfFullBlock(t, sys.L2EL, eth.Unsafe, threshold, "pre-Glamsterdam")
+	preForkL1 := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+	t.Require().Less(preForkL1.Time, *l1Config.AmsterdamTime,
+		"load must begin before Glamsterdam activates")
+
 	postForkL1 := sys.L1EL.WaitForTime(*l1Config.AmsterdamTime)
 	postForkHeader, err := sys.L1EL.EthClient().HeaderByHash(t.Ctx(), postForkL1.Hash)
 	t.Require().NoError(err)
@@ -44,25 +51,56 @@ func TestSafeHeadsAdvanceAcrossGlamsterdam(gt *testing.T) {
 	t.Require().NotNil(postForkHeader.BlockAccessListHash,
 		"post-Glamsterdam L1 block must include a block access list hash")
 
-	dsl.CheckAll(t,
-		sys.L2EL.L1OriginReachedFn(eth.Safe, postForkL1.Number, 120),
-		sys.L2ELB.L1OriginReachedFn(eth.Safe, postForkL1.Number, 120),
+	sys.L2EL.WaitL1OriginReached(eth.Safe, postForkL1.Number, 120)
+	waitForHalfFullBlock(t, sys.L2EL, eth.Safe, threshold, "post-Glamsterdam")
+}
+
+func TestGlamsterdamP2P(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainMultiNode(t,
+		glamsterdamL1Geth(t),
+		presets.WithDeployerOptions(sysgo.WithForkAtL1Genesis(forks.Amsterdam)),
 	)
 
-	threshold := sys.L2Chain.Escape().RollupConfig().Genesis.SystemConfig.GasLimit/2 + 1
-	for name, el := range map[string]*dsl.L2ELNode{
-		"sequencer": sys.L2EL,
-		"verifier":  sys.L2ELB,
-	} {
-		el.WaitForLabel(eth.Safe, func(info eth.BlockInfo) (bool, error) {
-			if info.GasUsed() >= threshold {
-				t.Logger().Info("Found half-full post-Glamsterdam safe block",
-					"node", name, "block", eth.ToBlockID(info), "gasUsed", info.GasUsed(), "threshold", threshold)
-				return true, nil
-			}
-			return false, nil
-		})
-	}
+	l1Config := sys.L1Network.Escape().ChainConfig()
+	t.Require().NotNil(l1Config.AmsterdamTime)
+	l1Genesis := sys.L1EL.BlockRefByNumber(0)
+	t.Require().LessOrEqual(*l1Config.AmsterdamTime, l1Genesis.Time,
+		"Glamsterdam must be active at L1 genesis")
+
+	alice := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	bob := sys.Wallet.NewEOA(sys.L2EL)
+	sys.L2Batcher.Stop()
+
+	transfer := alice.Transfer(bob.Address(), eth.OneWei)
+	receipt := transfer.Included.Value()
+	target := bigs.Uint64Strict(receipt.BlockNumber)
+	sequencerBlock := sys.L2EL.BlockRefByNumber(target)
+	t.Require().Equal(receipt.BlockHash, sequencerBlock.Hash)
+
+	t.Require().NoError(sys.L2ELB.ReachedFn(eth.Unsafe, target, 30)())
+	verifierBlock := sys.L2ELB.BlockRefByNumber(target)
+	t.Require().Equal(sequencerBlock.ID(), verifierBlock.ID(),
+		"verifier must receive the unbatched block over P2P")
+
+	sys.L2Batcher.Start()
+	dsl.CheckAll(t,
+		sys.L2EL.ReachedFn(eth.Safe, target, 120),
+		sys.L2ELB.ReachedFn(eth.Safe, target, 120),
+	)
+	t.Require().Equal(sequencerBlock.ID(), sys.L2EL.BlockRefByNumber(target).ID())
+	t.Require().Equal(sequencerBlock.ID(), sys.L2ELB.BlockRefByNumber(target).ID())
+}
+
+func waitForHalfFullBlock(t devtest.T, el *dsl.L2ELNode, label eth.BlockLabel, threshold uint64, phase string) {
+	el.WaitForLabel(label, func(info eth.BlockInfo) (bool, error) {
+		if info.GasUsed() >= threshold {
+			t.Logger().Info("Found half-full block",
+				"phase", phase, "block", eth.ToBlockID(info), "gasUsed", info.GasUsed(), "threshold", threshold)
+			return true, nil
+		}
+		return false, nil
+	})
 }
 
 func glamsterdamL1Geth(t devtest.T) presets.Option {
@@ -71,7 +109,7 @@ func glamsterdamL1Geth(t devtest.T) presets.Option {
 	return presets.WithL1Geth(strings.TrimSpace(string(out)))
 }
 
-func spamGlamsterdamTxs(sys *presets.SingleChainMultiNode) {
+func spamGlamsterdamTxs(sys *presets.Minimal) {
 	l2BlockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
 	eoas := loadtest.FundEOAs(sys.T, eth.ThousandEther, 2, l2BlockTime, sys.L2EL, sys.Wallet, sys.FunderL2)
 

--- a/op-acceptance-tests/tests/glamsterdam_test.go
+++ b/op-acceptance-tests/tests/glamsterdam_test.go
@@ -66,8 +66,7 @@ func TestSafeHeadsAdvanceAcrossGlamsterdam(gt *testing.T) {
 }
 
 func glamsterdamL1Geth(t devtest.T) presets.Option {
-	const gethTool = "go:github.com/ethereum/go-ethereum/cmd/geth@0c8cefdf344e263b94cd80bcc8a002c63f3b4ed1"
-	out, err := exec.CommandContext(t.Ctx(), "mise", "x", gethTool, "--", "which", "geth").Output()
+	out, err := exec.CommandContext(t.Ctx(), "mise", "which", "geth").Output()
 	t.Require().NoError(err, "resolve mise-installed Glamsterdam geth")
 	return presets.WithL1Geth(strings.TrimSpace(string(out)))
 }

--- a/op-acceptance-tests/tests/glamsterdam_test.go
+++ b/op-acceptance-tests/tests/glamsterdam_test.go
@@ -12,9 +12,12 @@ import (
 	"github.com/ethereum/go-ethereum/params/forks"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/loadtest"
+	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/shared/rustbin"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -24,11 +27,15 @@ import (
 
 func TestSafeHeadAdvancesAcrossGlamsterdam(gt *testing.T) {
 	t := devtest.ParallelT(gt)
+	prepareGlamsterdamOpReth(t)
 	sys := presets.NewMinimal(t,
 		glamsterdamL1Geth(t),
+		glamsterdamBlobBatcher(),
 		presets.WithDeployerOptions(
 			sysgo.WithForkAtL1Genesis(forks.BPO5),
-			sysgo.WithForkAtL1Offset(forks.Amsterdam, 30),
+			// Leave enough time for the devstack to start, fund the load generators, and
+			// produce a loaded block before activating Glamsterdam.
+			sysgo.WithForkAtL1Offset(forks.Amsterdam, 120),
 		),
 	)
 	spamGlamsterdamTxs(sys)
@@ -40,7 +47,7 @@ func TestSafeHeadAdvancesAcrossGlamsterdam(gt *testing.T) {
 		"Glamsterdam must activate after L1 genesis to exercise the fork transition")
 
 	threshold := sys.L2Chain.Escape().RollupConfig().Genesis.SystemConfig.GasLimit/2 + 1
-	waitForHalfFullBlock(t, sys.L2EL, eth.Unsafe, threshold, "pre-Glamsterdam")
+	sys.L2EL.WaitForGasUsed(eth.Unsafe, threshold, 2*time.Minute)
 	preForkL1 := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 	t.Require().Less(preForkL1.Time, *l1Config.AmsterdamTime,
 		"load must begin before Glamsterdam activates")
@@ -53,13 +60,14 @@ func TestSafeHeadAdvancesAcrossGlamsterdam(gt *testing.T) {
 		"post-Glamsterdam L1 block must include a block access list hash")
 
 	sys.L2EL.WaitL1OriginReached(eth.Safe, postForkL1.Number, 120)
-	waitForHalfFullBlock(t, sys.L2EL, eth.Safe, threshold, "post-Glamsterdam")
+	sys.L2EL.WaitForGasUsed(eth.Safe, threshold, 2*time.Minute)
 }
 
 func TestGlamsterdamP2PUnsafeBlockBecomesSafe(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSingleChainMultiNode(t,
 		glamsterdamL1Geth(t),
+		glamsterdamBlobBatcher(),
 		presets.WithDeployerOptions(sysgo.WithForkAtL1Genesis(forks.Amsterdam)),
 	)
 
@@ -104,21 +112,27 @@ func TestGlamsterdamP2PUnsafeBlockBecomesSafe(gt *testing.T) {
 		"sequencer and verifier must finish on the same unsafe chain")
 }
 
-func waitForHalfFullBlock(t devtest.T, el *dsl.L2ELNode, label eth.BlockLabel, threshold uint64, phase string) {
-	el.WaitForLabel(label, func(info eth.BlockInfo) (bool, error) {
-		if info.GasUsed() >= threshold {
-			t.Logger().Info("Found half-full block",
-				"phase", phase, "block", eth.ToBlockID(info), "gasUsed", info.GasUsed(), "threshold", threshold)
-			return true, nil
-		}
-		return false, nil
-	})
-}
-
 func glamsterdamL1Geth(t devtest.T) presets.Option {
 	out, err := exec.CommandContext(t.Ctx(), "mise", "which", "geth").Output()
 	t.Require().NoError(err, "resolve mise-installed Glamsterdam geth")
 	return presets.WithL1Geth(strings.TrimSpace(string(out)))
+}
+
+func prepareGlamsterdamOpReth(t devtest.T) {
+	_, err := (rustbin.Spec{
+		SrcDir:  "rust",
+		Package: "op-reth",
+		Binary:  "op-reth",
+	}).EnsureExists(t.Ctx(), t.Logger())
+	t.Require().NoError(err, "prepare op-reth before starting the L1 fork activation clock")
+}
+
+func glamsterdamBlobBatcher() presets.Option {
+	return presets.WithBatcherOption(func(_ sysgo.ComponentTarget, cfg *batcher.CLIConfig) {
+		// Amsterdam changes calldata floor-gas accounting. Blob batches keep this test focused
+		// on L1 Engine API and derivation behavior across the fork.
+		cfg.DataAvailabilityType = flags.BlobsType
+	})
 }
 
 func spamGlamsterdamTxs(sys *presets.Minimal) {

--- a/op-acceptance-tests/tests/glamsterdam_test.go
+++ b/op-acceptance-tests/tests/glamsterdam_test.go
@@ -1,0 +1,111 @@
+package tests
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params/forks"
+
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/loadtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+)
+
+func TestSafeHeadsAdvanceAcrossGlamsterdam(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainMultiNodeWithoutCheck(t,
+		glamsterdamL1Geth(t),
+		presets.WithDeployerOptions(
+			sysgo.WithForkAtL1Genesis(forks.BPO5),
+			sysgo.WithForkAtL1Offset(forks.Amsterdam, 30),
+		),
+	)
+	spamGlamsterdamTxs(sys)
+
+	l1Config := sys.L1Network.Escape().ChainConfig()
+	t.Require().NotNil(l1Config.AmsterdamTime)
+	l1Genesis := sys.L1EL.BlockRefByNumber(0)
+	t.Require().Greater(*l1Config.AmsterdamTime, l1Genesis.Time,
+		"Glamsterdam must activate after L1 genesis to exercise the fork transition")
+
+	postForkL1 := sys.L1EL.WaitForTime(*l1Config.AmsterdamTime)
+	postForkHeader, err := sys.L1EL.EthClient().HeaderByHash(t.Ctx(), postForkL1.Hash)
+	t.Require().NoError(err)
+	t.Require().NotNil(postForkHeader.SlotNumber, "post-Glamsterdam L1 block must include a slot number")
+	t.Require().NotNil(postForkHeader.BlockAccessListHash,
+		"post-Glamsterdam L1 block must include a block access list hash")
+
+	dsl.CheckAll(t,
+		sys.L2EL.L1OriginReachedFn(eth.Safe, postForkL1.Number, 120),
+		sys.L2ELB.L1OriginReachedFn(eth.Safe, postForkL1.Number, 120),
+	)
+
+	threshold := sys.L2Chain.Escape().RollupConfig().Genesis.SystemConfig.GasLimit/2 + 1
+	for name, el := range map[string]*dsl.L2ELNode{
+		"sequencer": sys.L2EL,
+		"verifier":  sys.L2ELB,
+	} {
+		el.WaitForLabel(eth.Safe, func(info eth.BlockInfo) (bool, error) {
+			if info.GasUsed() >= threshold {
+				t.Logger().Info("Found half-full post-Glamsterdam safe block",
+					"node", name, "block", eth.ToBlockID(info), "gasUsed", info.GasUsed(), "threshold", threshold)
+				return true, nil
+			}
+			return false, nil
+		})
+	}
+}
+
+func glamsterdamL1Geth(t devtest.T) presets.Option {
+	const gethTool = "go:github.com/ethereum/go-ethereum/cmd/geth@0c8cefdf344e263b94cd80bcc8a002c63f3b4ed1"
+	out, err := exec.CommandContext(t.Ctx(), "mise", "x", gethTool, "--", "which", "geth").Output()
+	t.Require().NoError(err, "resolve mise-installed Glamsterdam geth")
+	return presets.WithL1Geth(strings.TrimSpace(string(out)))
+}
+
+func spamGlamsterdamTxs(sys *presets.SingleChainMultiNode) {
+	l2BlockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
+	eoas := loadtest.FundEOAs(sys.T, eth.ThousandEther, 2, l2BlockTime, sys.L2EL, sys.Wallet, sys.FunderL2)
+
+	// Deploy a four-byte infinite-loop runtime. Calls consume their gas limit while adding almost
+	// no batch data, so the load schedule fills blocks without delaying derivation itself.
+	const gasBurnerInitCode = "0x6004600c60003960046000f35b600056"
+	deployed, err := eoas[0].Include(sys.T,
+		txplan.WithData(common.FromHex(gasBurnerInitCode)),
+		txplan.WithGasLimit(100_000),
+	)
+	sys.T.Require().NoError(err)
+	gasBurnerAddr := deployed.Receipt.ContractAddress
+	sys.T.Require().NotEqual(common.Address{}, gasBurnerAddr)
+
+	eoasRR := loadtest.NewRoundRobin(eoas)
+	spammer := loadtest.SpammerFunc(func(t devtest.T) error {
+		_, err := eoasRR.Get().Include(t,
+			txplan.WithTo(&gasBurnerAddr),
+			txplan.WithGasLimit(16_000_000),
+		)
+		return err
+	})
+	schedule := loadtest.NewBurst(l2BlockTime, loadtest.WithBaseRPS(2))
+
+	ctx, cancel := context.WithCancel(sys.T.Ctx())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	sys.T.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+	go func() {
+		defer wg.Done()
+		schedule.Run(sys.T.WithCtx(ctx), spammer)
+	}()
+}

--- a/op-acceptance-tests/tests/glamsterdam_test.go
+++ b/op-acceptance-tests/tests/glamsterdam_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/params/forks"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/loadtest"
-	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
-	"github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
@@ -30,7 +28,6 @@ func TestSafeHeadAdvancesAcrossGlamsterdam(gt *testing.T) {
 	prepareGlamsterdamOpReth(t)
 	sys := presets.NewMinimal(t,
 		glamsterdamL1Geth(t),
-		glamsterdamBlobBatcher(),
 		presets.WithDeployerOptions(
 			sysgo.WithForkAtL1Genesis(forks.BPO5),
 			// Leave enough time for the devstack to start, fund the load generators, and
@@ -67,7 +64,6 @@ func TestGlamsterdamP2PUnsafeBlockBecomesSafe(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSingleChainMultiNode(t,
 		glamsterdamL1Geth(t),
-		glamsterdamBlobBatcher(),
 		presets.WithDeployerOptions(sysgo.WithForkAtL1Genesis(forks.Amsterdam)),
 	)
 
@@ -125,14 +121,6 @@ func prepareGlamsterdamOpReth(t devtest.T) {
 		Binary:  "op-reth",
 	}).EnsureExists(t.Ctx(), t.Logger())
 	t.Require().NoError(err, "prepare op-reth before starting the L1 fork activation clock")
-}
-
-func glamsterdamBlobBatcher() presets.Option {
-	return presets.WithBatcherOption(func(_ sysgo.ComponentTarget, cfg *batcher.CLIConfig) {
-		// Amsterdam changes calldata floor-gas accounting. Blob batches keep this test focused
-		// on L1 Engine API and derivation behavior across the fork.
-		cfg.DataAvailabilityType = flags.BlobsType
-	})
 }
 
 func spamGlamsterdamTxs(sys *presets.Minimal) {

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	_ "net/http/pprof"
 	"sync"
@@ -1005,15 +1006,47 @@ type TxSender[T any] interface {
 // sendTx uses the txmgr queue to send the given transaction candidate after setting its
 // gaslimit. It will block if the txmgr queue has reached its MaxPendingTransactions limit.
 func (l *BatchSubmitter) sendTx(txdata txData, isCancel bool, candidate *txmgr.TxCandidate, queue TxSender[txRef], receiptsCh chan txmgr.TxReceipt[txRef]) {
-	floorDataGas, err := core.FloorDataGas(candidate.TxData)
+	gasLimit, err := maxFloorDataGas(candidate.TxData)
 	if err != nil {
-		// We log instead of return an error here because the txmgr will do its own gas estimation.
-		l.Log.Warn("Failed to calculate floor data gas", "err", err)
+		// We log instead of returning an error here because the txmgr will do its own gas estimation.
+		l.Log.Warn("Failed to calculate batch transaction gas limit", "err", err)
 	} else {
-		candidate.GasLimit = floorDataGas
+		candidate.GasLimit = gasLimit
 	}
 
 	queue.Send(txRef{id: txdata.ID(), isCancel: isCancel, isBlob: txdata.asBlob}, *candidate, receiptsCh)
+}
+
+// maxFloorDataGas returns a gas limit valid under both the pre-Amsterdam EIP-7623 rules and
+// Amsterdam's EIP-2780/EIP-7976 rules. The pre-Amsterdam floor also exceeds Amsterdam's regular
+// intrinsic gas whenever it exceeds the Amsterdam floor, so the larger floor is sufficient.
+func maxFloorDataGas(data []byte) (uint64, error) {
+	preAmsterdam, err := core.FloorDataGas(data)
+	if err != nil {
+		return 0, err
+	}
+	amsterdam, err := amsterdamFloorDataGas(data)
+	if err != nil {
+		return 0, err
+	}
+	return max(preAmsterdam, amsterdam), nil
+}
+
+// NOTE: we can probably replace this function with core.FloorDataGas once our geth dependency
+// includes the Amsterdam calculation.
+func amsterdamFloorDataGas(data []byte) (uint64, error) {
+	const (
+		amsterdamTxBaseGas               = uint64(12_000 + 3_000) // EIP-2780: TX_BASE_COST + COLD_ACCOUNT_ACCESS
+		amsterdamCalldataFloorGasPerByte = uint64(64)             // EIP-7976: 4 tokens per byte at 16 gas per token
+	)
+	return addGas(amsterdamTxBaseGas, uint64(len(data)), amsterdamCalldataFloorGasPerByte)
+}
+
+func addGas(base, count, cost uint64) (uint64, error) {
+	if count > (math.MaxUint64-base)/cost {
+		return 0, core.ErrGasUintOverflow
+	}
+	return base + count*cost, nil
 }
 
 func (l *BatchSubmitter) blobTxCandidate(data txData) (*txmgr.TxCandidate, error) {

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -159,33 +159,40 @@ func (q *MockTxQueue) Load(id string) txmgr.TxCandidate {
 	return c.(txmgr.TxCandidate)
 }
 
-func TestBatchSubmitter_sendTx_FloorDataGas(t *testing.T) {
+func TestBatchSubmitter_sendTx_GasLimit(t *testing.T) {
 	bs, _ := setup(t, nil)
 
-	q := new(MockTxQueue)
-
-	txData := txData{
-		frames: []frameData{
-			{
-				data: []byte{0x01, 0x02, 0x03}, // 3 nonzero bytes = 12 tokens https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7623.md
-			},
+	tests := []struct {
+		name     string
+		data     []byte
+		expected uint64
+	}{
+		{
+			name:     "PreAmsterdamFloorIsHigher",
+			data:     []byte{0x01, 0x02, 0x03},
+			expected: params.TxGas + 3*params.TxTokenPerNonZeroByte*params.TxCostFloorPerToken,
+		},
+		{
+			name:     "AmsterdamFloorIsHigher",
+			data:     make([]byte, 371),
+			expected: 15_000 + 371*64,
 		},
 	}
-	candidate := txmgr.TxCandidate{
-		To:     &bs.RollupConfig.BatchInboxAddress,
-		TxData: txData.CallData(),
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := new(MockTxQueue)
+			txData := txData{frames: []frameData{{data: tt.data}}}
+			candidate := txmgr.TxCandidate{
+				To:     &bs.RollupConfig.BatchInboxAddress,
+				TxData: tt.data,
+			}
+
+			bs.sendTx(txData, false, &candidate, q, make(chan txmgr.TxReceipt[txRef]))
+
+			candidateOut := q.Load(txData.ID().String())
+			require.Equal(t, tt.expected, candidateOut.GasLimit)
+		})
 	}
-
-	bs.sendTx(txData,
-		false,
-		&candidate,
-		q,
-		make(chan txmgr.TxReceipt[txRef]))
-
-	candidateOut := q.Load(txData.ID().String())
-
-	expectedFloorDataGas := uint64(21_000 + 12*10)
-	require.GreaterOrEqual(t, candidateOut.GasLimit, expectedFloorDataGas)
 }
 
 type handlerFailureMode string

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -73,6 +74,47 @@ func (el *L2ELNode) BlockRefByHash(hash common.Hash) eth.L2BlockRef {
 	block, err := el.inner.L2EthClient().L2BlockRefByHash(ctx, hash)
 	el.require.NoError(err, "block not found using block hash")
 	return block
+}
+
+// WaitForGasUsed waits for the head at label to use at least minGasUsed gas.
+// Transient block-label lookup failures are retried until timeout.
+func (el *L2ELNode) WaitForGasUsed(label eth.BlockLabel, minGasUsed uint64, timeout time.Duration) eth.BlockInfo {
+	ctx, cancel := context.WithTimeout(el.ctx, timeout)
+	defer cancel()
+
+	logger := el.log.With("name", el.inner.Name(), "chain", el.ChainID(), "label", label,
+		"minimum_gas_used", minGasUsed, "timeout", timeout)
+	logger.Info("Waiting for L2 block gas usage")
+
+	var lastBlock eth.BlockInfo
+	var lastLookupErr error
+	err := wait.For(ctx, 200*time.Millisecond, func() (bool, error) {
+		block, err := el.inner.EthClient().InfoByLabel(ctx, label)
+		if err != nil {
+			lastLookupErr = err
+			logger.Warn("Block-label lookup failed; will retry", "err", err)
+			return false, nil
+		}
+
+		lastBlock = block
+		lastLookupErr = nil
+		if block.GasUsed() >= minGasUsed {
+			logger.Info("L2 block gas usage reached", "block", eth.ToBlockID(block), "gas_used", block.GasUsed())
+			return true, nil
+		}
+		logger.Info("L2 block gas usage not reached", "block", eth.ToBlockID(block), "gas_used", block.GasUsed())
+		return false, nil
+	})
+	if err != nil {
+		lastObservation := "no block observed"
+		if lastBlock != nil {
+			lastObservation = fmt.Sprintf("block %s used %d gas", eth.ToBlockID(lastBlock), lastBlock.GasUsed())
+		}
+		el.require.NoError(err,
+			"expected %s block on chain %s to use at least %d gas within %s; last observation: %s; last lookup error: %v",
+			label, el.ChainID(), minGasUsed, timeout, lastObservation, lastLookupErr)
+	}
+	return lastBlock
 }
 
 // AdvancedOption configures an AdvancedFn call.

--- a/op-devstack/sysgo/l1_runtime.go
+++ b/op-devstack/sysgo/l1_runtime.go
@@ -173,6 +173,7 @@ func startSubprocessL1WithClock(t devtest.T, l1Net *L1Network, jwtPath string, l
 		"--verbosity", "5",
 		"--miner.recommit", "2s",
 		"--gcmode", "archive",
+		"--syncmode", "full",
 	}
 	require.NoError(sub.Start(execPath, args, nil), "must start geth subprocess")
 


### PR DESCRIPTION
## Summary

- pin an upstream Glamsterdam-capable Geth commit in `mise.toml` and run the subprocess L1 in full sync mode
- use a single-node minimal preset to activate Amsterdam after genesis and verify safe-head derivation under sustained pre- and post-fork L2 load
- verify post-fork L1 headers include the Amsterdam slot-number and block-access-list fields
- add a separate Amsterdam-at-genesis P2P test that:
  - stops the batcher and verifies an unbatched unsafe block reaches the verifier over P2P
  - restarts the batcher and verifies both nodes converge after the block becomes safe
  - stops the sequencer and verifies both nodes finish on the same unsafe chain

This is PR 3 of 3, stacked on #21920.

## Validation

- `mise which geth`
- `geth version` (`v1.17.5-unstable`)
- `go test ./op-acceptance-tests/tests -run '^$'`
- `go vet ./op-acceptance-tests/tests`
- acceptance-test flake Semgrep rules

The full subprocess transition and P2P scenarios are left to acceptance CI, which provides the required built dependencies.

Fixes https://github.com/ethereum-optimism/protocol-team/issues/249
