### PR TITLE
op-core,op-alloy: pin post-exec tx hash to the canonical rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -244,7 +244,7 @@ require (
 	lukechampine.com/blake3 v1.4.1 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101702.3-rc.4
+replace github.com/ethereum/go-ethereum => github.com/nonsense/op-geth v1.101605.1-0.20260721100203-f75014438ad4
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -499,6 +499,8 @@ github.com/naoina/go-stringutil v0.1.0 h1:rCUeRUHjBjGTSHl0VC00jUPLz8/F9dDzYI70Hz
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416 h1:shk/vn9oCoOTmwcouEdwIeOtOGA/ELRUw/GwvxwfT+0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
+github.com/nonsense/op-geth v1.101605.1-0.20260721100203-f75014438ad4 h1:mU8nlGw/yXGej3o2EXOT4rqz77z/CzSNgafEHUKtvNc=
+github.com/nonsense/op-geth v1.101605.1-0.20260721100203-f75014438ad4/go.mod h1:HzvOtk7c9KwFaSxRvUBPFHGSjIjomWtw4iSXX6vruQE=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/op-acceptance-tests/tests/sdm/block_test.go
+++ b/op-acceptance-tests/tests/sdm/block_test.go
@@ -145,6 +145,9 @@ func TestSDMEnabledPayloadAndReplayMatch(gt *testing.T) {
 	t.Require().Greater(len(postExecTx.Input), 0, "post-exec tx input must not be empty")
 	t.Require().Equal(uint64(sdmpkg.SDMTxType), uint64(postExecTx.Type), "post-exec tx type must be 0x7D")
 
+	// Tx-hash parity: op-reth must serve and index under the canonical keccak256(0x7D || Data) hash.
+	assertPostExecTxHashIsCanonical(t, sys.L2EL, postExecTx)
+
 	payload, err := sdmpkg.DecodePayload(postExecTx.Input)
 	t.Require().NoError(err, "post-exec payload must decode")
 	t.Require().Equal(sdmpkg.PostExecPayloadVersion, payload.Version, "post-exec payload version must be 1")

--- a/op-acceptance-tests/tests/sdm/helpers_test.go
+++ b/op-acceptance-tests/tests/sdm/helpers_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/crypto"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/lmittmann/w3"
 )
 
@@ -137,18 +137,16 @@ func findPostExecTransaction(block *sdmpkg.RPCBlock) (*sdmpkg.RPCTransaction, in
 	return sdmpkg.FindPostExecTransaction(block)
 }
 
-// assertPostExecTxHashIsCanonical derives keccak256(0x7D || Data) from the served post-exec tx —
-// the universal typed-tx hash rule (matching TxDeposit) that a Go consumer like op-service/sources
-// computes — and asserts op-reth serves that hash and resolves the tx and receipt under it.
-//
-// op-geth's PostExecTx shim currently hashes keccak256(0x7D || RLP([Data])) instead — a bug — so
-// this would fail against an op-geth EL until that shim and the op-service/sources codec are fixed.
+// assertPostExecTxHashIsCanonical asserts op-reth serves the post-exec tx under the hash the Go
+// PostExecTx.Hash() implementation produces — keccak256(0x7D || Data), the canonical EIP-2718 rule
+// matching TxDeposit — and resolves the tx and receipt under it. Computing the hash via Hash()
+// (rather than a hand-rolled keccak) verifies the Go hasher and op-reth agree, which is the
+// cross-client interop guarantee op-service/sources relies on.
 func assertPostExecTxHashIsCanonical(t devtest.T, l2EL *dsl.L2ELNode, postExecTx *sdmpkg.RPCTransaction) {
-	canonical := append([]byte{sdmpkg.SDMTxType}, []byte(postExecTx.Input)...)
-	wantHash := crypto.Keccak256Hash(canonical)
+	wantHash := gethtypes.NewTx(&gethtypes.PostExecTx{Data: []byte(postExecTx.Input)}).Hash()
 
 	t.Require().Equal(wantHash, postExecTx.Hash,
-		"op-reth-served post-exec tx hash %s must equal keccak256(0x7D || Data) %s (the canonical EIP-2718 rule, matching TxDeposit)",
+		"op-reth-served post-exec tx hash %s must equal PostExecTx.Hash() %s (keccak256(0x7D || Data), matching TxDeposit)",
 		postExecTx.Hash, wantHash)
 
 	rpcClient := l2EL.Escape().L2EthClient().RPC()

--- a/op-acceptance-tests/tests/sdm/helpers_test.go
+++ b/op-acceptance-tests/tests/sdm/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/lmittmann/w3"
 )
 
@@ -134,6 +135,41 @@ func replayBlockWithSDM(t devtest.T, l2EL *dsl.L2ELNode, blockNum uint64) *sdmpk
 
 func findPostExecTransaction(block *sdmpkg.RPCBlock) (*sdmpkg.RPCTransaction, int) {
 	return sdmpkg.FindPostExecTransaction(block)
+}
+
+// assertPostExecTxHashIsCanonical derives keccak256(0x7D || Data) from the served post-exec tx —
+// the universal typed-tx hash rule (matching TxDeposit) that a Go consumer like op-service/sources
+// computes — and asserts op-reth serves that hash and resolves the tx and receipt under it.
+//
+// op-geth's PostExecTx shim currently hashes keccak256(0x7D || RLP([Data])) instead — a bug — so
+// this would fail against an op-geth EL until that shim and the op-service/sources codec are fixed.
+func assertPostExecTxHashIsCanonical(t devtest.T, l2EL *dsl.L2ELNode, postExecTx *sdmpkg.RPCTransaction) {
+	canonical := append([]byte{sdmpkg.SDMTxType}, []byte(postExecTx.Input)...)
+	wantHash := crypto.Keccak256Hash(canonical)
+
+	t.Require().Equal(wantHash, postExecTx.Hash,
+		"op-reth-served post-exec tx hash %s must equal keccak256(0x7D || Data) %s (the canonical EIP-2718 rule, matching TxDeposit)",
+		postExecTx.Hash, wantHash)
+
+	rpcClient := l2EL.Escape().L2EthClient().RPC()
+
+	var txRaw json.RawMessage
+	err := rpcClient.CallContext(t.Ctx(), &txRaw, "eth_getTransactionByHash", wantHash)
+	t.Require().NoError(err, "eth_getTransactionByHash RPC failed for canonical hash %s", wantHash)
+	t.Require().False(isNullJSONResult(txRaw),
+		"op-reth must resolve the post-exec tx under its canonical hash %s", wantHash)
+
+	var receiptRaw json.RawMessage
+	err = rpcClient.CallContext(t.Ctx(), &receiptRaw, "eth_getTransactionReceipt", wantHash)
+	t.Require().NoError(err, "eth_getTransactionReceipt RPC failed for canonical hash %s", wantHash)
+	t.Require().False(isNullJSONResult(receiptRaw),
+		"op-reth must resolve the post-exec receipt under its canonical hash %s", wantHash)
+}
+
+// isNullJSONResult reports whether a raw JSON-RPC result is absent (JSON null or empty), i.e. the
+// queried object was not found.
+func isNullJSONResult(raw json.RawMessage) bool {
+	return len(raw) == 0 || strings.TrimSpace(string(raw)) == "null"
 }
 
 func mustFindReplayTxByHash(t devtest.T, replay *sdmpkg.ReplaySDMBlock, txHash common.Hash) *sdmpkg.ReplaySDMTx {

--- a/op-core/types/post_exec_tx_test.go
+++ b/op-core/types/post_exec_tx_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 )
@@ -32,6 +34,27 @@ func TestPostExecTxMarshalBinaryDifferential(t *testing.T) {
 
 		require.Equal(t, theirs, ours)
 	}
+}
+
+// TestPostExecTxHashGoldenVector pins the cross-client post-exec (0x7D) tx hash: op-geth and
+// op-reth must agree. Both compute keccak256(0x7D || Data), the canonical EIP-2718 rule. Data is
+// RLP(PostExecPayload{version:1, block:42, entries:[{index:3, gasRefund:7}]}) — op-alloy's
+// build_post_exec_tx(42, [{3,7}]) — and opRethTxHash is the value op-alloy's
+// post_exec_tx_hash_is_keccak_of_canonical_encoding pins for TxPostExec::tx_hash. Guards the
+// op-geth Transaction.Hash fix against regression when the op-geth pin moves (the old op-geth
+// returned keccak256(0x7D || RLP([Data])) here).
+func TestPostExecTxHashGoldenVector(t *testing.T) {
+	data := hexutil.MustDecode("0xc6012ac3c20307")
+	const opRethTxHash = "0xcbc64a9665039744307b562634bf760d96f3bed235fecd9e09a1f1276a1823c7"
+
+	gethHash := gethtypes.NewTx(&gethtypes.PostExecTx{Data: data}).Hash()
+	require.Equal(t, opRethTxHash, gethHash.Hex(),
+		"op-geth post-exec tx hash must match op-reth (op-alloy TxPostExec::tx_hash)")
+
+	// The shared value is exactly keccak256 of the canonical encoding op-core produces.
+	canonical, err := (&optypes.PostExecTx{Data: data}).MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, gethHash, crypto.Keccak256Hash(canonical))
 }
 
 func TestUnmarshalPostExecTxRoundTrip(t *testing.T) {

--- a/rust/op-alloy/crates/consensus/src/post_exec/tests.rs
+++ b/rust/op-alloy/crates/consensus/src/post_exec/tests.rs
@@ -54,6 +54,38 @@ fn post_exec_tx_hash_depends_on_block_number() {
     assert_ne!(tx_a.tx_hash(), tx_b.tx_hash());
 }
 
+/// Post-exec tx hash is `keccak256(0x7D || Data)` — the universal `keccak256(EIP-2718 encoding)`
+/// rule, computed identically to [`TxDeposit`]. op-geth's `PostExecTx` instead hashes
+/// `keccak256(0x7D || RLP([Data]))`, which mismatches its own wire encoding (`0x7D || Data`); that
+/// is an op-geth bug to fix in op-geth and the op-service/sources codec, not here.
+#[test]
+fn post_exec_tx_hash_is_keccak_of_canonical_encoding() {
+    use alloy_primitives::{b256, hex};
+
+    let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
+
+    // Canonical payload bytes (== op-geth PostExecTx.Data).
+    let data = hex!("c6012ac3c20307");
+    assert_eq!(tx.input.as_ref(), data.as_slice(), "post-exec input bytes drifted");
+
+    // keccak256(0x7D || Data), derived independently and pinned.
+    let mut canonical = vec![POST_EXEC_TX_TYPE_ID];
+    canonical.extend_from_slice(&data);
+    assert_eq!(tx.tx_hash(), keccak256(&canonical), "tx_hash must be keccak256 of encode_2718");
+    assert_eq!(
+        tx.tx_hash(),
+        b256!("0xcbc64a9665039744307b562634bf760d96f3bed235fecd9e09a1f1276a1823c7"),
+        "post-exec tx hash must be keccak256(0x7D || Data), matching the TxDeposit rule",
+    );
+
+    // Guard against regressing to op-geth's buggy inner-struct rule keccak256(0x7D || RLP([Data])).
+    assert_ne!(
+        tx.tx_hash(),
+        b256!("0xf54f4d695af011e5639b49ec48a5090434fbad09fa56ff572e36c28f691cb126"),
+        "op-reth must not adopt op-geth's buggy keccak256(0x7D || RLP([Data])) hash",
+    );
+}
+
 #[test]
 fn post_exec_tx_eip2718_roundtrip() {
     let tx = build_post_exec_tx(


### PR DESCRIPTION
The post-exec (0x7D) tx hash must be `keccak256(0x7D ‖ Data)` — the canonical EIP-2718 rule every typed tx (incl. `DepositTx`) follows. op-reth/op-alloy already does this; op-geth's `PostExecTx.Hash` diverged (`keccak256(0x7D ‖ RLP([Data]))`), so a Go consumer deriving the hash (op-service/sources, #21907) couldn't resolve the receipt cross-client.

- **op-alloy**: golden vector pinning `TxPostExec::tx_hash == keccak256(0x7D ‖ Data)`.
- **op-acceptance-tests/sdm**: assert op-reth serves/indexes the post-exec tx under that canonical hash.
- **op-core**: golden vector tying op-core, op-geth and op-reth to one value.

The op-geth fix is ethereum-optimism/op-geth#805.

> [!WARNING]
> **Draft — provisional op-geth pin.** `go.mod` points at a personal-fork commit (`nonsense/op-geth@f75014438`). Must be re-pointed to an official op-geth release tag containing #805 before merge; until then the op-core golden vector depends on the fixed op-geth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)