### PR TITLE
op-acceptance-tests: use Rust binary path for SP1 executor

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2010,7 +2010,7 @@ jobs:
             echo "export RUST_BINARY_PATH_OP_RETH=$ROOT_DIR/rust/target/release/op-reth" >> "$BASH_ENV"
             echo "export RUST_BINARY_PATH_OP_RBUILDER=$BIN_DIR/op-rbuilder" >> "$BASH_ENV"
             echo "export RUST_BINARY_PATH_ROLLUP_BOOST=$BIN_DIR/rollup-boost" >> "$BASH_ENV"
-            echo "export KONA_SP1_SUPER_RANGE_NATIVE_EXECUTOR_PATH=$BIN_DIR/kona-sp1-super-range-executor" >> "$BASH_ENV"
+            echo "export RUST_BINARY_PATH_KONA_SP1_SUPER_RANGE_EXECUTOR=$BIN_DIR/kona-sp1-super-range-executor" >> "$BASH_ENV"
       - run:
           name: Configure L2 stack
           command: |

--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -114,8 +114,8 @@ func TestInteropFaultProofs_MessageExpiry(gt *testing.T) {
 
 func proofRunners() []sfp.ProofRunner {
 	runners := []sfp.ProofRunner{sfp.NewKonaProofRunner()}
-	if executorPath := os.Getenv(sfp.KonaSP1SuperRangeNativeExecutorPathEnv); executorPath != "" {
-		runners = append(runners, sfp.NewSP1NativeProofRunner(executorPath))
+	if os.Getenv("RUST_BINARY_PATH_KONA_SP1_SUPER_RANGE_EXECUTOR") != "" || os.Getenv("RUST_JIT_BUILD") != "" {
+		runners = append(runners, sfp.NewSP1NativeProofRunner())
 	}
 	return runners
 }

--- a/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
+++ b/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
@@ -14,10 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// KonaSP1SuperRangeNativeExecutorPathEnv configures the native-core executor used by the serial
-// interop fault-proof acceptance scenarios.
-const KonaSP1SuperRangeNativeExecutorPathEnv = "KONA_SP1_SUPER_RANGE_NATIVE_EXECUTOR_PATH"
-
 // ProofRunner executes the proof checks attached to one shared interop scenario.
 // Implementations are constructed here so scenario internals remain private.
 type ProofRunner interface {
@@ -50,8 +46,8 @@ func NewKonaProofRunner() ProofRunner {
 
 // NewSP1NativeProofRunner constructs the fast runner that replays witnesses through the shared
 // native range and consolidation cores.
-func NewSP1NativeProofRunner(executorPath string) ProofRunner {
-	return sp1ProofRunner{executorPath: executorPath, nativeCore: true}
+func NewSP1NativeProofRunner() ProofRunner {
+	return sp1ProofRunner{nativeCore: true}
 }
 
 // NewSP1FullProofRunner constructs the opt-in full-ELF runner used by the single smoke test.
@@ -95,7 +91,20 @@ func (konaProofRunner) run(t devtest.T, sys *presets.SimpleInterop, data *scenar
 }
 
 func (r sp1ProofRunner) run(t devtest.T, sys *presets.SimpleInterop, data *scenarioProofData) {
-	t.Require().NotEmpty(r.executorPath, "SP1 super-range executor path is required")
+	executorPath := r.executorPath
+	if r.nativeCore {
+		var err error
+		executorPath, err = rustbin.Spec{
+			SrcDir:  "rust/kona",
+			Package: "kona-sp1-super-range-executor",
+			Binary:  "kona-sp1-super-range-executor",
+		}.EnsureExists(t.Ctx(), t.Logger())
+		t.Require().NoError(err, "locate kona-sp1 super-range executor")
+		if err != nil {
+			return
+		}
+	}
+	t.Require().NotEmpty(executorPath, "SP1 super-range executor path is required")
 	t.Require().NotNil(data.zkCheckpoint, "SP1 runner requires a ZK checkpoint")
 	name := "SP1FullELF"
 	if r.nativeCore {
@@ -110,7 +119,7 @@ func (r sp1ProofRunner) run(t devtest.T, sys *presets.SimpleInterop, data *scena
 			args = append(args, "--native-core")
 		}
 		t.Require().True(
-			rustbin.RunKonaSP1SuperRange(t, t.Logger(), r.executorPath, t.TempDir(), args...),
+			rustbin.RunKonaSP1SuperRange(t, t.Logger(), executorPath, t.TempDir(), args...),
 			"expected kona-sp1 super-range executor to accept timestamp %d",
 			checkpoint.endTimestamp,
 		)

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -348,18 +348,19 @@ func ApplyPipeline(
 	}
 
 	pEnv := &pipeline.Env{
-		StateWriter:  opts.StateWriter,
-		L1ScriptHost: l1Host,
-		L1Client:     l1Client,
-		Logger:       opts.Logger,
-		Broadcaster:  bcaster,
-		Deployer:     deployer,
-		Scripts:      opcmScripts,
-		ForgeClient:  forgeClient,
-		UseForge:     opts.UseForge,
-		L1RPCUrl:     opts.L1RPCUrl,
-		PrivateKey:   opts.PrivateKey,
-		Context:      ctx,
+		StateWriter:               opts.StateWriter,
+		L1ScriptHost:              l1Host,
+		L1Client:                  l1Client,
+		Logger:                    opts.Logger,
+		Broadcaster:               bcaster,
+		Deployer:                  deployer,
+		Scripts:                   opcmScripts,
+		ForgeClient:               forgeClient,
+		UseForge:                  opts.UseForge,
+		AllowUnoptimizedContracts: opts.DeploymentTarget == DeploymentTargetGenesis,
+		L1RPCUrl:                  opts.L1RPCUrl,
+		PrivateKey:                opts.PrivateKey,
+		Context:                   ctx,
 	}
 
 	pline := []pipelineStage{

--- a/op-deployer/pkg/deployer/pipeline/env.go
+++ b/op-deployer/pkg/deployer/pipeline/env.go
@@ -34,9 +34,12 @@ type Env struct {
 	Scripts      *opcm.Scripts
 	ForgeClient  *forge.Client
 	UseForge     bool
-	L1RPCUrl     string
-	PrivateKey   string
-	Context      context.Context
+	// AllowUnoptimizedContracts permits contract artifacts that exceed the EIP-170 code-size limit.
+	// It is only enabled for genesis-mode deployments, which execute scripts against an in-memory host.
+	AllowUnoptimizedContracts bool
+	L1RPCUrl                  string
+	PrivateKey                string
+	Context                   context.Context
 }
 
 type StateWriter interface {

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
@@ -62,11 +63,16 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 
 	lgr.Info("generating L2 genesis", "id", chainID.Hex())
 
+	hostOpts := []script.HostOption{}
+	if pEnv.AllowUnoptimizedContracts {
+		hostOpts = append(hostOpts, script.WithNoMaxCodeSize())
+	}
 	host, err := env.DefaultScriptHost(
 		broadcaster.NoopBroadcaster(),
 		pEnv.Logger,
 		pEnv.Deployer,
 		bundle.L2,
+		hostOpts...,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create L2 script host: %w", err)


### PR DESCRIPTION
## Summary

Replace the custom SP1 native-executor environment variable with the standard Rust binary-path mechanism.

This change also allows the development L2Genesis contract (`just forge-build-dev`) which may have a large code size to be used during acceptance-tests.

- CircleCI now provides `RUST_BINARY_PATH_KONA_SP1_SUPER_RANGE_EXECUTOR`.
- Native SP1 proof tests resolve the executor through `rustbin.Spec`.
- `RUST_JIT_BUILD=1` now enables and builds the executor on demand for the relevant local serial proof tests.