### PR TITLE
op-interop-filter: expose passthrough status RPC

### DIFF
--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -125,6 +125,7 @@ func NewBackend(parentCtx context.Context, params BackendParams) *Backend {
 	if b.failsafeLogInterval <= 0 {
 		b.failsafeLogInterval = defaultFailsafeLogInterval
 	}
+	b.metrics.RecordPassthroughEnabled(b.passthrough)
 
 	// Initialize so the first benign refresh (state == off) does not log a
 	// spurious "cleared" transition.
@@ -197,6 +198,11 @@ func (b *Backend) Stop(ctx context.Context) error {
 // OR the cross-validator has an error.
 func (b *Backend) FailsafeEnabled() bool {
 	return b.manualFailsafe.Load() || len(b.GetChainErrors()) > 0 || b.crossValidator.Error() != nil
+}
+
+// PassthroughEnabled returns whether passthrough mode is enabled.
+func (b *Backend) PassthroughEnabled() bool {
+	return b.passthrough
 }
 
 // SetFailsafeEnabled sets the manual failsafe override.

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -57,6 +57,11 @@ func (a *AdminFrontend) GetFailsafeEnabled(ctx context.Context) (bool, error) {
 	return a.backend.FailsafeEnabled(), nil
 }
 
+// GetPassthroughEnabled returns whether passthrough mode is enabled.
+func (a *AdminFrontend) GetPassthroughEnabled(ctx context.Context) (bool, error) {
+	return a.backend.PassthroughEnabled(), nil
+}
+
 // SetFailsafeEnabled enables or disables failsafe mode
 func (a *AdminFrontend) SetFailsafeEnabled(ctx context.Context, enabled bool) error {
 	a.backend.SetFailsafeEnabled(enabled)

--- a/op-interop-filter/filter/logsdb_integration_backend_test.go
+++ b/op-interop-filter/filter/logsdb_integration_backend_test.go
@@ -109,6 +109,35 @@ func TestIntegration_Backend_RPCSetFailsafe_UpdatesMetric(t *testing.T) {
 		"admin_setFailsafeEnabled(false) must flip the metric off")
 }
 
+func TestIntegration_Backend_RPCGetPassthroughEnabled(t *testing.T) {
+	t.Parallel()
+
+	bk := twoChainBackend(t, 1)
+	admin := &AdminFrontend{backend: bk.Backend}
+
+	enabled, err := admin.GetPassthroughEnabled(context.Background())
+	require.NoError(t, err)
+	require.False(t, enabled)
+
+	bk.passthrough = true
+	enabled, err = admin.GetPassthroughEnabled(context.Background())
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
+
+func TestIntegration_Backend_PassthroughMetric(t *testing.T) {
+	t.Parallel()
+
+	bk := newSeededBackend(t, backendOpts{
+		Passthrough: true,
+		Specs: []seedSpec{
+			{ChainID: 901, Blocks: []seedBlock{{Num: 100, Ts: 1200}}},
+			{ChainID: 902, Blocks: []seedBlock{{Num: 100, Ts: 1200}}},
+		},
+	})
+	require.True(t, bk.metrics.passthroughMetric())
+}
+
 func TestIntegration_Backend_AutoFailsafe_UpdatesMetric(t *testing.T) {
 	t.Parallel()
 

--- a/op-interop-filter/filter/logsdb_integration_helpers_test.go
+++ b/op-interop-filter/filter/logsdb_integration_helpers_test.go
@@ -487,14 +487,15 @@ func (sb *seededBackend) requireAccepted(execChain eth.ChainID, execTs uint64, a
 // =============================================================================
 
 type capturingMetrics struct {
-	mu              sync.Mutex
-	rejections      map[string]int
-	reorgs          map[uint64]int
-	blockSealed     map[uint64]int64
-	logsAdded       map[uint64]int64
-	chainHead       map[uint64]uint64
-	failsafeGauge   bool
-	failsafeReasons map[string]bool
+	mu               sync.Mutex
+	rejections       map[string]int
+	reorgs           map[uint64]int
+	blockSealed      map[uint64]int64
+	logsAdded        map[uint64]int64
+	chainHead        map[uint64]uint64
+	failsafeGauge    bool
+	passthroughGauge bool
+	failsafeReasons  map[string]bool
 }
 
 func newCapturingMetrics() *capturingMetrics {
@@ -532,6 +533,10 @@ func (m *capturingMetrics) RecordFailsafeEnabled(enabled bool) {
 	m.locked(func() { m.failsafeGauge = enabled })
 }
 
+func (m *capturingMetrics) RecordPassthroughEnabled(enabled bool) {
+	m.locked(func() { m.passthroughGauge = enabled })
+}
+
 func (m *capturingMetrics) RecordFailsafeReason(reason string, active bool) {
 	m.locked(func() { m.failsafeReasons[reason] = active })
 }
@@ -541,6 +546,12 @@ func (m *capturingMetrics) failsafeMetric() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.failsafeGauge
+}
+
+func (m *capturingMetrics) passthroughMetric() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.passthroughGauge
 }
 
 // failsafeReasonActive returns the last value recorded for the given reason.

--- a/op-interop-filter/metrics/metrics.go
+++ b/op-interop-filter/metrics/metrics.go
@@ -14,6 +14,7 @@ type Metricer interface {
 	RecordInfo(version string)
 	RecordUp()
 	RecordFailsafeEnabled(enabled bool)
+	RecordPassthroughEnabled(enabled bool)
 	RecordFailsafeReason(reason string, active bool)
 	RecordChainHead(chainID uint64, blockNum uint64)
 	RecordChainTip(chainID uint64, blockNum uint64)
@@ -37,6 +38,7 @@ type Metrics struct {
 	info                     *prometheus.GaugeVec
 	up                       prometheus.Gauge
 	failsafeEnabled          prometheus.Gauge
+	passthroughEnabled       prometheus.Gauge
 	failsafeReason           *prometheus.GaugeVec
 	chainHead                *prometheus.GaugeVec
 	checkAccessTotal         *prometheus.CounterVec
@@ -88,6 +90,12 @@ func NewMetrics(procName string) *Metrics {
 			Namespace: ns,
 			Name:      "failsafe_enabled",
 			Help:      "1 if failsafe is enabled",
+		}),
+
+		passthroughEnabled: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "passthrough_enabled",
+			Help:      "1 if passthrough mode is enabled",
 		}),
 
 		failsafeReason: factory.NewGaugeVec(prometheus.GaugeOpts{
@@ -195,6 +203,14 @@ func (m *Metrics) RecordFailsafeEnabled(enabled bool) {
 	}
 }
 
+func (m *Metrics) RecordPassthroughEnabled(enabled bool) {
+	if enabled {
+		m.passthroughEnabled.Set(1)
+	} else {
+		m.passthroughEnabled.Set(0)
+	}
+}
+
 func (m *Metrics) RecordFailsafeReason(reason string, active bool) {
 	v := 0.0
 	if active {
@@ -263,6 +279,7 @@ type noopMetrics struct{}
 func (n *noopMetrics) RecordInfo(version string)                               {}
 func (n *noopMetrics) RecordUp()                                               {}
 func (n *noopMetrics) RecordFailsafeEnabled(enabled bool)                      {}
+func (n *noopMetrics) RecordPassthroughEnabled(enabled bool)                   {}
 func (n *noopMetrics) RecordFailsafeReason(reason string, active bool)         {}
 func (n *noopMetrics) RecordChainHead(chainID uint64, blockNum uint64)         {}
 func (n *noopMetrics) RecordChainTip(chainID uint64, blockNum uint64)          {}


### PR DESCRIPTION
## Summary

- add read-only `admin_getPassthroughEnabled` RPC
- expose configured passthrough state on public and JWT-protected admin endpoints
- add coverage for enabled and disabled states

## Validation

- `go test ./op-interop-filter/filter -count=1`
- `just --unstable lint-go`