### PR TITLE
op-dispute-mon: Cover claim timing metrics

### DIFF
--- a/op-acceptance-tests/tests/interop/dispute-mon/dispute_mon_test.go
+++ b/op-acceptance-tests/tests/interop/dispute-mon/dispute_mon_test.go
@@ -39,12 +39,7 @@ func TestDisputeMonitorForecastsInvalidProposalForChallenger(gt *testing.T) {
 	game := sys.DisputeGameFactory().StartCannonKonaGame(proposer, proofs.WithRootClaim(common.HexToHash("0xdead")))
 	game.WaitForGameStatus(gameTypes.GameStatusInProgress)
 
-	mon := presets.StartDisputeMon(
-		t,
-		sys.L1EL,
-		sys.L2Chain.DisputeGameFactoryProxyAddr(),
-		presets.WithDisputeMonRollupNodes(sys.L2CL),
-	)
+	mon := sys.StartDisputeMon()
 	mon.VerifyState(
 		disputemon.GameCount(gameTypes.CannonKonaGameType, 1),
 		disputemon.FailedGames(0),
@@ -78,12 +73,7 @@ func TestDisputeMonitorReportsReferenceNodeFailure(gt *testing.T) {
 	proposer := sys.FunderL1.NewFundedEOA(eth.OneEther)
 	sys.DisputeGameFactory().StartCannonKonaGame(proposer)
 
-	mon := presets.StartDisputeMon(
-		t,
-		sys.L1EL,
-		sys.L2Chain.DisputeGameFactoryProxyAddr(),
-		presets.WithDisputeMonRollupNodes(sys.L2CL),
-	)
+	mon := sys.StartDisputeMon()
 	baseline := mon.VerifyHealthyOutputFetch(gameTypes.CannonKonaGameType)
 
 	sys.L2CL.Stop()
@@ -180,13 +170,7 @@ func TestDisputeMonitorReportsHonestActorLoss(gt *testing.T) {
 	game.Resolve(counterer)
 	game.WaitForGameStatus(gameTypes.GameStatusChallengerWon)
 
-	mon := presets.StartDisputeMon(
-		t,
-		sys.L1EL,
-		sys.L2Chain.DisputeGameFactoryProxyAddr(),
-		presets.WithDisputeMonRollupNodes(sys.L2CL),
-		presets.WithDisputeMonHonestActors(proposer.Address()),
-	)
+	mon := sys.StartDisputeMon(presets.WithDisputeMonHonestActors(proposer.Address()))
 	mon.VerifyState(
 		disputemon.GameCount(gameTypes.CannonKonaGameType, 1),
 		disputemon.HonestActorInvalidClaims(proposer.Address(), 1),

--- a/op-acceptance-tests/tests/interop/dispute-mon/dispute_mon_test.go
+++ b/op-acceptance-tests/tests/interop/dispute-mon/dispute_mon_test.go
@@ -90,6 +90,39 @@ func TestDisputeMonitorReportsReferenceNodeFailure(gt *testing.T) {
 	mon.VerifyReferenceNodeFailure(baseline)
 }
 
+func TestDisputeMonitorReportsClaimTiming(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewMinimalNoFaultProofs(
+		t,
+		presets.WithTimeTravelEnabled(),
+		presets.WithGameTypeAdded(gameTypes.CannonKonaGameType),
+		presets.WithoutHonestProposer(),
+	)
+
+	proposer := sys.FunderL1.NewFundedEOA(eth.OneEther)
+	game := sys.DisputeGameFactory().StartCannonKonaGame(proposer)
+	mon := sys.StartDisputeMon()
+
+	mon.VerifyState(
+		disputemon.GameCount(gameTypes.CannonKonaGameType, 1),
+		disputemon.FailedGames(0),
+		disputemon.UnresolvedClaimsInFirstHalf(1),
+		disputemon.UnresolvedClaimsInSecondHalf(0),
+		disputemon.ExpiredClaims(0),
+		disputemon.UnexpiredClaims(1),
+		disputemon.ResolvableClaims(0),
+	)
+
+	sys.AdvanceTime(game.MaxClockDuration() + time.Second)
+	mon.VerifyState(
+		disputemon.UnresolvedClaimsInFirstHalf(0),
+		disputemon.UnresolvedClaimsInSecondHalf(1),
+		disputemon.ExpiredClaims(1),
+		disputemon.UnexpiredClaims(0),
+		disputemon.ResolvableClaims(1),
+	)
+}
+
 func TestDisputeMonitorReportsResolvedGameAccounting(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := presets.NewMinimalNoFaultProofs(
@@ -107,18 +140,15 @@ func TestDisputeMonitorReportsResolvedGameAccounting(gt *testing.T) {
 	game.Resolve(proposer)
 	game.WaitForGameStatus(gameTypes.GameStatusDefenderWon)
 
-	mon := presets.StartDisputeMon(
-		t,
-		sys.L1EL,
-		sys.L2Chain.DisputeGameFactoryProxyAddr(),
-		presets.WithDisputeMonRollupNodes(sys.L2CL),
-	)
+	mon := sys.StartDisputeMon()
 	mon.VerifyState(
 		disputemon.GameCount(gameTypes.CannonKonaGameType, 1),
 		disputemon.FailedGames(0),
 
 		disputemon.CompletedBeforeMaxDuration(1),
 		disputemon.ResolvedClaims(1),
+		disputemon.ResolvedClaimsInFirstHalf(0),
+		disputemon.ResolvedClaimsInSecondHalf(1),
 		disputemon.ResolvableClaims(0),
 
 		disputemon.ExactNonWithdrawableCredits(1),

--- a/op-devstack/dsl/disputemon/dispute_mon.go
+++ b/op-devstack/dsl/disputemon/dispute_mon.go
@@ -140,26 +140,50 @@ func CompletedBeforeMaxDuration(expected int) StateExpectation {
 }
 
 func ResolvedClaims(expected int) StateExpectation {
-	return StateExpectation{
-		check: devtestmetrics.GaugeSumEquals(
-			"op_dispute_mon_claims",
-			map[string]string{"resolved": "resolved"},
-			float64(expected),
-		),
-	}
+	return claimCount(map[string]string{"resolved": "resolved"}, expected)
+}
+
+func ResolvedClaimsInFirstHalf(expected int) StateExpectation {
+	return claimCount(map[string]string{
+		"resolved":         "resolved",
+		"game_time_period": "first_half",
+	}, expected)
+}
+
+func ResolvedClaimsInSecondHalf(expected int) StateExpectation {
+	return claimCount(map[string]string{
+		"resolved":         "resolved",
+		"game_time_period": "second_half",
+	}, expected)
+}
+
+func UnresolvedClaimsInFirstHalf(expected int) StateExpectation {
+	return claimCount(map[string]string{
+		"resolved":         "unresolved",
+		"game_time_period": "first_half",
+	}, expected)
+}
+
+func UnresolvedClaimsInSecondHalf(expected int) StateExpectation {
+	return claimCount(map[string]string{
+		"resolved":         "unresolved",
+		"game_time_period": "second_half",
+	}, expected)
+}
+
+func ExpiredClaims(expected int) StateExpectation {
+	return claimCount(map[string]string{"clock": "expired"}, expected)
+}
+
+func UnexpiredClaims(expected int) StateExpectation {
+	return claimCount(map[string]string{"clock": "not_expired"}, expected)
 }
 
 func ResolvableClaims(expected int) StateExpectation {
-	return StateExpectation{
-		check: devtestmetrics.GaugeSumEquals(
-			"op_dispute_mon_claims",
-			map[string]string{
-				"resolved":   "unresolved",
-				"resolvable": "resolvable",
-			},
-			float64(expected),
-		),
-	}
+	return claimCount(map[string]string{
+		"resolved":   "unresolved",
+		"resolvable": "resolvable",
+	}, expected)
 }
 
 func ExpectedNonWithdrawableCredits(expected int) StateExpectation {
@@ -267,6 +291,16 @@ func HonestActorLostBonds(actor common.Address, expectedWei *big.Int) StateExpec
 				"state":                "lost",
 			},
 			weiToEther(expectedWei),
+		),
+	}
+}
+
+func claimCount(labels map[string]string, expected int) StateExpectation {
+	return StateExpectation{
+		check: devtestmetrics.GaugeSumEquals(
+			"op_dispute_mon_claims",
+			labels,
+			float64(expected),
 		),
 	}
 }

--- a/op-devstack/presets/dispute_mon.go
+++ b/op-devstack/presets/dispute_mon.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/disputemon"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -12,6 +13,7 @@ type disputeMonOptions struct {
 	rollupRPCs    []string
 	supernodeRPCs []string
 	honestActors  []common.Address
+	clock         clock.Clock
 }
 
 type DisputeMonOption func(*disputeMonOptions)
@@ -42,12 +44,34 @@ func WithDisputeMonHonestActors(actors ...common.Address) DisputeMonOption {
 	}
 }
 
+func withDisputeMonClock(cl *clock.AdvancingClock) DisputeMonOption {
+	return func(opts *disputeMonOptions) {
+		if cl != nil {
+			opts.clock = cl
+		}
+	}
+}
+
 func (s *SingleChainInterop) StartDisputeMon() *disputemon.DisputeMon {
 	return StartDisputeMon(
 		s.T,
 		s.L1EL,
 		s.L2ChainA.DisputeGameFactoryProxyAddr(),
 		WithDisputeMonSupernodes(s.SuperRoots),
+		withDisputeMonClock(s.timeTravel),
+	)
+}
+
+func (m *Minimal) StartDisputeMon(options ...DisputeMonOption) *disputemon.DisputeMon {
+	options = append([]DisputeMonOption{
+		WithDisputeMonRollupNodes(m.L2CL),
+		withDisputeMonClock(m.timeTravel),
+	}, options...)
+	return StartDisputeMon(
+		m.T,
+		m.L1EL,
+		m.L2Chain.DisputeGameFactoryProxyAddr(),
+		options...,
 	)
 }
 
@@ -74,6 +98,7 @@ func StartDisputeMon(
 		RollupRPCs:         opts.rollupRPCs,
 		SupernodeRPCs:      opts.supernodeRPCs,
 		HonestActors:       opts.honestActors,
+		Clock:              opts.clock,
 	})
 	return disputemon.New(t, runtime.MetricsURL())
 }

--- a/op-devstack/sysgo/dispute_mon.go
+++ b/op-devstack/sysgo/dispute_mon.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	disputeMon "github.com/ethereum-optimism/optimism/op-dispute-mon"
 	disputeMonConfig "github.com/ethereum-optimism/optimism/op-dispute-mon/config"
+	disputeMonService "github.com/ethereum-optimism/optimism/op-dispute-mon/mon"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -18,6 +20,7 @@ type DisputeMonConfig struct {
 	RollupRPCs         []string
 	SupernodeRPCs      []string
 	HonestActors       []common.Address
+	Clock              clock.Clock
 }
 
 type DisputeMonRuntime struct {
@@ -49,8 +52,13 @@ func StartDisputeMon(t devtest.T, input DisputeMonConfig) *DisputeMonRuntime {
 		ListenPort: 0,
 	}
 
+	var serviceOptions []disputeMonService.ServiceOption
+	if input.Clock != nil {
+		serviceOptions = append(serviceOptions, disputeMonService.WithClock(input.Clock))
+	}
+
 	logger := t.Logger().New("component", "op-dispute-mon")
-	service, err := disputeMon.Main(t.Ctx(), logger, &cfg)
+	service, err := disputeMon.Main(t.Ctx(), logger, &cfg, serviceOptions...)
 	require.NoError(err, "create dispute monitor service")
 	metricsAddr := service.MetricsAddr()
 	require.NotNil(metricsAddr, "dispute monitor metrics address")

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -54,13 +54,30 @@ type Service struct {
 	stopped atomic.Bool
 }
 
+// ServiceOption customizes a dispute monitor service.
+type ServiceOption func(*Service)
+
+// WithClock overrides the service clock.
+func WithClock(cl clock.Clock) ServiceOption {
+	return func(service *Service) {
+		if cl != nil {
+			service.cl = cl
+		}
+	}
+}
+
 // NewService creates a new Service.
-func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*Service, error) {
+func NewService(ctx context.Context, logger log.Logger, cfg *config.Config, options ...ServiceOption) (*Service, error) {
 	s := &Service{
 		cl:           clock.SystemClock,
 		logger:       logger,
 		metrics:      metrics.NewMetrics(),
 		honestActors: types.NewHonestActors(cfg.HonestActors),
+	}
+	for _, option := range options {
+		if option != nil {
+			option(s)
+		}
 	}
 
 	if err := s.initFromConfig(ctx, cfg); err != nil {

--- a/op-dispute-mon/monitor.go
+++ b/op-dispute-mon/monitor.go
@@ -9,9 +9,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon"
 )
 
-func Main(ctx context.Context, logger log.Logger, cfg *config.Config) (*mon.Service, error) {
+func Main(ctx context.Context, logger log.Logger, cfg *config.Config, options ...mon.ServiceOption) (*mon.Service, error) {
 	if err := cfg.Check(); err != nil {
 		return nil, err
 	}
-	return mon.NewService(ctx, logger, cfg)
+	return mon.NewService(ctx, logger, cfg, options...)
 }


### PR DESCRIPTION
Adds acceptance coverage for first-half and second-half claim accounting, expiration, and resolvability. Injects the devstack time-travel clock into the in-process dispute monitor so contract state and monitor metrics advance together.

Builds on ethereum-optimism/optimism#21894.

Tested with `go test -v -count=1 -timeout 20m ./op-acceptance-tests/tests/interop/dispute-mon`, race-enabled affected Go package tests, and `just lint-go`.