### PR TITLE
op-core: move registry chain-config loading from params into superchain

### DIFF
--- a/docs/ai/opgeth-decoupling.md
+++ b/docs/ai/opgeth-decoupling.md
@@ -210,9 +210,8 @@ reads on go-ethereum's `*params.ChainConfig` go through `rollup.Config` or
 
 ## 6. `params/superchain.go` – `LoadOPStackChainConfig` — **DONE**
 
-Moved to `op-core/params.FromSuperchainConfig`; the by-chain-ID loader
-(`LoadChainConfigFromChainID`, ex-superutil) lives in `op-core/params` too. §7 has the layering
-rationale.
+Moved to `op-core/superchain`: `(*superchain.ChainConfig).OpChainConfig()` plus the by-chain-ID
+loader `superchain.LoadOpChainConfig` (ex-superutil). §7 has the layering rationale.
 
 ---
 
@@ -223,10 +222,13 @@ repo-root `superchain-registry` submodule by `sync-superchain.sh`; the zip is gi
 by a committed `.sha256`). `op-service/superutil` was deleted; all consumers import
 `op-core/superchain`.
 
-Layering decision worth remembering: the by-chain-ID loader lives in **`op-core/params`**, not
-`op-core/superchain`, because `params.FromSuperchainConfig` takes a `superchain.ChainConfig` —
-putting the loader in `superchain` would create an import cycle. `op-core/superchain` stays a
-pure registry leaf.
+Layering decision worth remembering: `op-core/params` holds pure config types and must stay
+free of `op-core/superchain`, which embeds the bundle — anything in its build closure needs the
+bundle generated before it compiles, and external module consumers (the superchain-registry ops
+tooling) cannot generate it at all. The registry→`ChainConfig` conversion (`OpChainConfig`,
+`LoadOpChainConfig`) therefore lives in **`op-core/superchain`**, which imports `op-core/params`
+one-way. Transitive guard tests in `op-node/rollup`, `op-chain-ops/script`, and
+`op-fetcher/pkg/fetcher/fetch/script` enforce the boundary (`op-service/testutils/depguard`).
 
 `rollup.Config` carries the full OP hardfork schedule itself (loaded from the registry,
 bypassing any geth `ChainConfig`); future forks extend `rollup.Config` directly. Any remaining

--- a/op-chain-ops/cmd/op-simulate/main.go
+++ b/op-chain-ops/cmd/op-simulate/main.go
@@ -33,7 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	opparams "github.com/ethereum-optimism/optimism/op-core/params"
+	"github.com/ethereum-optimism/optimism/op-core/superchain"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
@@ -183,7 +183,7 @@ func fetchChainConfig(ctx context.Context, cl *rpc.Client) (*params.ChainConfig,
 	// if we recognize the chain ID, we can get the chain config
 	id := (*big.Int)(&idResult)
 	if id.IsUint64() {
-		cfg, err := opparams.LoadChainConfigFromChainID(bigs.Uint64Strict(id))
+		cfg, err := superchain.LoadOpChainConfig(bigs.Uint64Strict(id))
 		if err == nil {
 			return cfg.GethChainConfig(), nil
 		}

--- a/op-chain-ops/genesis/deps_test.go
+++ b/op-chain-ops/genesis/deps_test.go
@@ -1,0 +1,18 @@
+package genesis
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/testutils/depguard"
+)
+
+// TestNoSuperchainImport keeps op-chain-ops/genesis free of op-core/superchain
+// in its whole build closure. That package embeds the generated, gitignored
+// superchain config bundle, which is absent from a clean module download — and
+// the superchain-registry's ops tooling consumes this package as a Go module
+// dependency, so any path to the bundle breaks its build. genesis imports
+// op-core/params directly, so it sits one import away from the bundle boundary.
+func TestNoSuperchainImport(t *testing.T) {
+	depguard.RequireNoTransitiveImport(t, ".",
+		"github.com/ethereum-optimism/optimism/op-core/superchain")
+}

--- a/op-chain-ops/script/deps_test.go
+++ b/op-chain-ops/script/deps_test.go
@@ -1,0 +1,17 @@
+package script
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/testutils/depguard"
+)
+
+// TestNoSuperchainImport keeps op-chain-ops/script free of op-core/superchain in
+// its whole build closure. That package embeds the generated, gitignored
+// superchain config bundle, which is absent from a clean module download — and
+// the superchain-registry's ops tooling consumes this package as a Go module
+// dependency, so any path to the bundle breaks its build.
+func TestNoSuperchainImport(t *testing.T) {
+	depguard.RequireNoTransitiveImport(t, ".",
+		"github.com/ethereum-optimism/optimism/op-core/superchain")
+}

--- a/op-core/params/chain_config.go
+++ b/op-core/params/chain_config.go
@@ -1,5 +1,10 @@
 // Package params holds the OP-Stack-specific chain configuration types. Consumers
 // import it as opparams.
+//
+// This package must stay free of op-core/superchain, which embeds the generated
+// registry bundle: packages that only need config types (notably op-node/rollup)
+// must not pull the bundle into their build closure. The registry-backed loading
+// lives in op-core/superchain, which imports this package one-way.
 package params
 
 import (

--- a/op-core/params/geth.go
+++ b/op-core/params/geth.go
@@ -1,52 +1,13 @@
 package params
 
 import (
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	gethparams "github.com/ethereum/go-ethereum/params"
 
-	"github.com/ethereum-optimism/optimism/op-core/superchain"
 	"github.com/ethereum-optimism/optimism/op-service/ptr"
 )
-
-// FromSuperchainConfig builds an OP-Stack ChainConfig from a superchain registry
-// chain config. It replaces op-geth's params.LoadOPStackChainConfig.
-func FromSuperchainConfig(chConfig *superchain.ChainConfig) *ChainConfig {
-	hardforks := chConfig.Hardforks
-	out := &ChainConfig{
-		ChainID:      new(big.Int).SetUint64(chConfig.ChainID),
-		BedrockBlock: common.Big0,
-		RegolithTime: ptr.New(uint64(0)),
-		CanyonTime:   hardforks.CanyonTime,
-		EcotoneTime:  hardforks.EcotoneTime,
-		FjordTime:    hardforks.FjordTime,
-		GraniteTime:  hardforks.GraniteTime,
-		HoloceneTime: hardforks.HoloceneTime,
-		IsthmusTime:  hardforks.IsthmusTime,
-		JovianTime:   hardforks.JovianTime,
-		KarstTime:    hardforks.KarstTime,
-		LagoonTime:   hardforks.LagoonTime,
-	}
-
-	if chConfig.Optimism != nil {
-		out.Optimism = &OptimismConfig{
-			EIP1559Elasticity:  chConfig.Optimism.EIP1559Elasticity,
-			EIP1559Denominator: chConfig.Optimism.EIP1559Denominator,
-		}
-		if chConfig.Optimism.EIP1559DenominatorCanyon != nil {
-			out.Optimism.EIP1559DenominatorCanyon = ptr.New(*chConfig.Optimism.EIP1559DenominatorCanyon)
-		}
-	}
-
-	// OP Mainnet treats its Bedrock-migration block as genesis.
-	if chConfig.ChainID == OPMainnetChainID {
-		out.BedrockBlock = big.NewInt(OPMainnetGenesisBlockNum)
-	}
-
-	return out
-}
 
 // GethChainConfig returns the equivalent go-ethereum params.ChainConfig. It exists
 // for code that drives a go-ethereum EVM, genesis, or block processor and therefore
@@ -110,22 +71,4 @@ func (c *ChainConfig) GethChainConfig() *gethparams.ChainConfig {
 	}
 
 	return out
-}
-
-// LoadChainConfigFromChainID loads the OP-Stack ChainConfig for the given L2 chain
-// ID from the embedded superchain registry.
-//
-// This by-chain-ID convenience lives here, rather than in op-core/superchain,
-// so that op-core/superchain stays a pure registry leaf: op-core/params imports
-// op-core/superchain (one-way), which keeps the two packages free of an import cycle.
-func LoadChainConfigFromChainID(chainID uint64) (*ChainConfig, error) {
-	chain, err := superchain.GetChain(chainID)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get chain %d from superchain registry: %w", chainID, err)
-	}
-	chConfig, err := chain.Config()
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve chain %d config: %w", chainID, err)
-	}
-	return FromSuperchainConfig(chConfig), nil
 }

--- a/op-core/superchain/params.go
+++ b/op-core/superchain/params.go
@@ -1,0 +1,61 @@
+package superchain
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	opparams "github.com/ethereum-optimism/optimism/op-core/params"
+	"github.com/ethereum-optimism/optimism/op-service/ptr"
+)
+
+// OpChainConfig builds an OP-Stack chain config from the registry chain config.
+func (c *ChainConfig) OpChainConfig() *opparams.ChainConfig {
+	hardforks := c.Hardforks
+	out := &opparams.ChainConfig{
+		ChainID:      new(big.Int).SetUint64(c.ChainID),
+		BedrockBlock: common.Big0,
+		RegolithTime: ptr.New(uint64(0)),
+		CanyonTime:   hardforks.CanyonTime,
+		EcotoneTime:  hardforks.EcotoneTime,
+		FjordTime:    hardforks.FjordTime,
+		GraniteTime:  hardforks.GraniteTime,
+		HoloceneTime: hardforks.HoloceneTime,
+		IsthmusTime:  hardforks.IsthmusTime,
+		JovianTime:   hardforks.JovianTime,
+		KarstTime:    hardforks.KarstTime,
+		LagoonTime:   hardforks.LagoonTime,
+	}
+
+	if c.Optimism != nil {
+		out.Optimism = &opparams.OptimismConfig{
+			EIP1559Elasticity:  c.Optimism.EIP1559Elasticity,
+			EIP1559Denominator: c.Optimism.EIP1559Denominator,
+		}
+		if c.Optimism.EIP1559DenominatorCanyon != nil {
+			out.Optimism.EIP1559DenominatorCanyon = ptr.New(*c.Optimism.EIP1559DenominatorCanyon)
+		}
+	}
+
+	// OP Mainnet treats its Bedrock-migration block as genesis.
+	if c.ChainID == opparams.OPMainnetChainID {
+		out.BedrockBlock = big.NewInt(opparams.OPMainnetGenesisBlockNum)
+	}
+
+	return out
+}
+
+// LoadOpChainConfig loads the OP-Stack chain config for the given L2 chain ID
+// from the embedded superchain registry.
+func LoadOpChainConfig(chainID uint64) (*opparams.ChainConfig, error) {
+	chain, err := GetChain(chainID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get chain %d from superchain registry: %w", chainID, err)
+	}
+	chConfig, err := chain.Config()
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve chain %d config: %w", chainID, err)
+	}
+	return chConfig.OpChainConfig(), nil
+}

--- a/op-core/superchain/params_test.go
+++ b/op-core/superchain/params_test.go
@@ -1,4 +1,4 @@
-package params_test
+package superchain
 
 import (
 	"testing"
@@ -9,9 +9,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 )
 
-func TestLoadChainConfigFromChainID(t *testing.T) {
+func TestLoadOpChainConfig(t *testing.T) {
 	t.Run("mainnet", func(t *testing.T) {
-		cfg, err := opparams.LoadChainConfigFromChainID(opparams.OPMainnetChainID)
+		cfg, err := LoadOpChainConfig(opparams.OPMainnetChainID)
 		require.NoError(t, err)
 		require.Equal(t, uint64(opparams.OPMainnetChainID), bigs.Uint64Strict(cfg.ChainID))
 		require.NotNil(t, cfg.Optimism)
@@ -22,7 +22,7 @@ func TestLoadChainConfigFromChainID(t *testing.T) {
 	})
 
 	t.Run("nonexistent chain", func(t *testing.T) {
-		cfg, err := opparams.LoadChainConfigFromChainID(23409527340)
+		cfg, err := LoadOpChainConfig(23409527340)
 		require.Error(t, err)
 		require.Nil(t, cfg)
 	})

--- a/op-fetcher/pkg/fetcher/fetch/deps_test.go
+++ b/op-fetcher/pkg/fetcher/fetch/deps_test.go
@@ -1,0 +1,17 @@
+package fetch
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/testutils/depguard"
+)
+
+// TestNoSuperchainImport keeps op-fetcher's fetch package free of
+// op-core/superchain in its whole build closure. That package embeds the
+// generated, gitignored superchain config bundle, which is absent from a clean
+// module download — and the superchain-registry's ops tooling consumes this
+// package as a Go module dependency, so any path to the bundle breaks its build.
+func TestNoSuperchainImport(t *testing.T) {
+	depguard.RequireNoTransitiveImport(t, ".",
+		"github.com/ethereum-optimism/optimism/op-core/superchain")
+}

--- a/op-fetcher/pkg/fetcher/fetch/script/deps_test.go
+++ b/op-fetcher/pkg/fetcher/fetch/script/deps_test.go
@@ -1,0 +1,17 @@
+package script
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/testutils/depguard"
+)
+
+// TestNoSuperchainImport keeps op-fetcher's script package free of
+// op-core/superchain in its whole build closure. That package embeds the
+// generated, gitignored superchain config bundle, which is absent from a clean
+// module download — and the superchain-registry's ops tooling consumes this
+// package as a Go module dependency, so any path to the bundle breaks its build.
+func TestNoSuperchainImport(t *testing.T) {
+	depguard.RequireNoTransitiveImport(t, ".",
+		"github.com/ethereum-optimism/optimism/op-core/superchain")
+}

--- a/op-node/rollup/deps_test.go
+++ b/op-node/rollup/deps_test.go
@@ -1,10 +1,9 @@
 package rollup
 
 import (
-	"go/build"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/depguard"
 )
 
 // TestNoSuperchainImport keeps op-node/rollup decoupled from op-core/superchain.
@@ -12,14 +11,10 @@ import (
 // in its build closure must generate the bundle before it compiles. op-node/rollup
 // is imported by dozens of packages that only need its types, so it must stay
 // bundle-free. Config loading that reads the registry lives in op-node/superchain.
+//
+// The check is transitive: a direct-import check misses the bundle sneaking in
+// through an intermediate package.
 func TestNoSuperchainImport(t *testing.T) {
-	pkg, err := build.ImportDir(".", 0)
-	require.NoError(t, err)
-
-	const forbidden = "github.com/ethereum-optimism/optimism/op-core/superchain"
-	imports := append([]string{}, pkg.Imports...)
-	imports = append(imports, pkg.TestImports...)
-	imports = append(imports, pkg.XTestImports...)
-	require.NotContains(t, imports, forbidden,
-		"op-node/rollup must not import op-core/superchain; registry-backed config loading belongs in op-node/superchain")
+	depguard.RequireNoTransitiveImport(t, ".",
+		"github.com/ethereum-optimism/optimism/op-core/superchain")
 }

--- a/op-service/testutils/depguard/depguard.go
+++ b/op-service/testutils/depguard/depguard.go
@@ -1,0 +1,80 @@
+// Package depguard provides test helpers to assert that a package's transitive
+// build closure stays free of forbidden imports.
+package depguard
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+)
+
+// RequireNoTransitiveImport asserts that no package matched by pattern
+// transitively imports any of the forbidden import paths. On failure it reports
+// an offending import chain, e.g. "a -> b -> forbidden/pkg". Direct-import-only
+// checks miss dependencies introduced through an intermediate package; this
+// walks the full closure.
+//
+// Only the production build closure is walked: the guarded invariant protects
+// packages that import the matched package, and they never build its test files.
+func RequireNoTransitiveImport(t testing.TB, pattern string, forbidden ...string) {
+	t.Helper()
+	chains, err := findForbiddenChains(pattern, forbidden...)
+	require.NoError(t, err)
+	require.Empty(t, chains, "forbidden transitive import(s):\n%s", strings.Join(chains, "\n"))
+}
+
+func findForbiddenChains(pattern string, forbidden ...string) ([]string, error) {
+	cfg := &packages.Config{Mode: packages.NeedName | packages.NeedImports | packages.NeedDeps}
+	pkgs, err := packages.Load(cfg, pattern)
+	if err != nil {
+		return nil, err
+	}
+	if len(pkgs) == 0 {
+		return []string{"pattern " + pattern + " matched no packages"}, nil
+	}
+	// A root that failed to load (e.g. a typo'd pattern yielding a stub package)
+	// has an empty import graph and would silently pass the guard.
+	for _, p := range pkgs {
+		for _, e := range p.Errors {
+			return nil, fmt.Errorf("loading %s: %s", p.PkgPath, e.Msg)
+		}
+	}
+
+	forbiddenSet := make(map[string]struct{}, len(forbidden))
+	for _, f := range forbidden {
+		forbiddenSet[f] = struct{}{}
+	}
+
+	// A package already visited on a non-offending trail can be skipped: every
+	// forbidden path reachable through it was found on the first visit.
+	seen := make(map[string]bool)
+	var chains []string
+	var walk func(p *packages.Package, trail []string)
+	walk = func(p *packages.Package, trail []string) {
+		if seen[p.ID] {
+			return
+		}
+		seen[p.ID] = true
+		trail = append(trail, p.PkgPath)
+		if _, ok := forbiddenSet[p.PkgPath]; ok {
+			chains = append(chains, strings.Join(trail, " -> "))
+			return
+		}
+		imports := make([]string, 0, len(p.Imports))
+		for path := range p.Imports {
+			imports = append(imports, path)
+		}
+		sort.Strings(imports)
+		for _, path := range imports {
+			walk(p.Imports[path], trail)
+		}
+	}
+	for _, p := range pkgs {
+		walk(p, nil)
+	}
+	return chains, nil
+}

--- a/op-service/testutils/depguard/depguard_test.go
+++ b/op-service/testutils/depguard/depguard_test.go
@@ -1,0 +1,45 @@
+package depguard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	// Imported only by this test file, to pin that test imports are exempt.
+	_ "github.com/ethereum-optimism/optimism/op-service/bigs"
+)
+
+// TestFindForbiddenChains is the positive control for the guard: a broken
+// package loader (e.g. wrong Mode flags yielding an empty import graph) would
+// make every guard test pass silently, so prove the walk actually finds
+// dependencies this package is known to have.
+func TestFindForbiddenChains(t *testing.T) {
+	t.Run("detects known transitive import", func(t *testing.T) {
+		// go/token is not imported directly, only via x/tools/go/packages.
+		chains, err := findForbiddenChains(".", "go/token")
+		require.NoError(t, err)
+		require.NotEmpty(t, chains)
+		require.Contains(t, chains[0], " -> go/token")
+	})
+
+	t.Run("test-only imports are exempt", func(t *testing.T) {
+		// Dependents of a package never build its test files, so the guard
+		// walks only the production closure.
+		chains, err := findForbiddenChains(".", "github.com/ethereum-optimism/optimism/op-service/bigs")
+		require.NoError(t, err)
+		require.Empty(t, chains)
+	})
+
+	t.Run("clean for absent import", func(t *testing.T) {
+		chains, err := findForbiddenChains(".", "example.com/definitely/not/imported")
+		require.NoError(t, err)
+		require.Empty(t, chains)
+	})
+
+	t.Run("broken pattern cannot silently pass", func(t *testing.T) {
+		chains, err := findForbiddenChains("./no-such-package", "go/token")
+		if err == nil {
+			require.NotEmpty(t, chains)
+		}
+	})
+}


### PR DESCRIPTION
Removes the `op-core/superchain` (embedded `superchain-configs.zip`) dependency that #21789 reintroduced into `op-node/rollup`'s build closure via `op-core/params/load.go`, which broke the superchain-registry ops tooling build chain (superchain-registry#1290 — it consumes `op-chain-ops/script` / `op-fetcher/.../script` as module deps and cannot generate the gitignored bundle).

- `FromSuperchainConfig` + `LoadChainConfigFromChainID` move to `op-core/superchain` as `(*ChainConfig).OpChainConfig()` + `LoadOpChainConfig()`, flipping the one-way import to `superchain → params` (pure types at the bottom, registry above). `GethChainConfig` stays in `op-core/params` — geth-only, no bundle. Loader bodies unchanged; only caller (`op-simulate`) repointed.
- New transitive-import guard `op-service/testutils/depguard` (with positive-control self-tests so a broken loader can't silently green all guards; production closure only — dependents never build a package's test files). Wired into `op-node/rollup` — whose direct-import-only guard from #21650 missed this — and the SR-imported packages near the bundle boundary: `op-chain-ops/script`, `op-chain-ops/genesis` (already imports `op-core/params`), `op-fetcher/pkg/fetcher/fetch{,/script}`.
- Deliberately unguarded from SR's remaining import surface: `op-service/{eth,jsonutil,testlog}`, `op-chain-ops/addresses` — distant leaves, covered transitively where they sit on guarded paths.

Red/green: the new guards fail on the unmodified tree reporting exactly the issue's chain (`script → op-node/rollup → op-core/params → op-core/superchain`) and pass with the move.

Test plan: `go build ./...`, `just lint-go` (0 issues, tidy clean), full tests of all touched packages, `go list -deps` of both SR script packages verified free of `op-core/superchain`.

Follow-up: repin superchain-registry#1290 to the resulting develop commit after merge.

Fixes #21954

🤖 Generated with [Claude Code](https://claude.com/claude-code)