### PR TITLE
op-alloy: include post-exec transactions in subblock payloads

### DIFF
--- a/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
@@ -640,7 +640,7 @@ impl PayloadHash {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::b256;
+    use alloy_primitives::{Bytes, b256};
 
     #[test]
     #[cfg(feature = "std")]
@@ -733,14 +733,18 @@ mod tests {
         assert_eq!(data, encoded);
     }
 
-    // Helper function to create a test flashblock
     #[cfg(test)]
-    fn create_test_flashblock(index: u64, with_base: bool) -> OpFlashblockPayload {
+    fn create_test_flashblock(
+        index: u64,
+        with_base: bool,
+        transactions: Vec<Bytes>,
+        post_exec_tx: Option<Bytes>,
+    ) -> OpFlashblockPayload {
         use crate::flashblock::{
             OpFlashblockPayloadBase, OpFlashblockPayloadDelta, OpFlashblockPayloadMetadata,
         };
         use alloc::collections::BTreeMap;
-        use alloy_primitives::{Address, Bloom, Bytes, U256};
+        use alloy_primitives::{Address, Bloom, U256};
         use alloy_rpc_types_engine::PayloadId;
 
         let base = with_base.then(|| OpFlashblockPayloadBase {
@@ -761,11 +765,11 @@ mod tests {
             logs_bloom: Bloom::ZERO,
             gas_used: 21000,
             block_hash: B256::ZERO,
-            transactions: Vec::new(),
+            transactions,
             withdrawals: Vec::new(),
             withdrawals_root: B256::from([1u8; 32]), // Non-zero for Isthmus
             blob_gas_used: Some(0),
-            post_exec_tx: None,
+            post_exec_tx,
         };
 
         let metadata = OpFlashblockPayloadMetadata {
@@ -785,8 +789,8 @@ mod tests {
 
     #[test]
     fn test_from_flashblocks_non_sequential_indices() {
-        let fb1 = create_test_flashblock(0, true);
-        let fb2 = create_test_flashblock(2, false); // Skip index 1
+        let fb1 = create_test_flashblock(0, true, Vec::new(), None);
+        let fb2 = create_test_flashblock(2, false, Vec::new(), None); // Skip index 1
 
         let result = OpExecutionData::from_flashblocks(&[fb1, fb2]);
         assert!(matches!(result, Err(OpFlashblockError::InvalidIndex)));
@@ -794,7 +798,7 @@ mod tests {
 
     #[test]
     fn test_from_flashblocks_missing_base_in_first() {
-        let fb1 = create_test_flashblock(0, false); // First should have base
+        let fb1 = create_test_flashblock(0, false, Vec::new(), None); // First should have base
 
         let result = OpExecutionData::from_flashblocks(&[fb1]);
         assert!(matches!(result, Err(OpFlashblockError::MissingBasePayload)));
@@ -802,8 +806,8 @@ mod tests {
 
     #[test]
     fn test_from_flashblocks_unexpected_base_in_second() {
-        let fb1 = create_test_flashblock(0, true);
-        let fb2 = create_test_flashblock(1, true); // Should not have base
+        let fb1 = create_test_flashblock(0, true, Vec::new(), None);
+        let fb2 = create_test_flashblock(1, true, Vec::new(), None); // Should not have base
 
         let result = OpExecutionData::from_flashblocks(&[fb1, fb2]);
         assert!(matches!(result, Err(OpFlashblockError::UnexpectedBasePayload)));
@@ -811,7 +815,7 @@ mod tests {
 
     #[test]
     fn test_from_flashblocks_single_valid_flashblock() {
-        let fb1 = create_test_flashblock(0, true);
+        let fb1 = create_test_flashblock(0, true, Vec::new(), None);
 
         let result = OpExecutionData::from_flashblocks(&[fb1]);
         assert!(result.is_ok(), "Single valid flashblock should succeed");
@@ -819,9 +823,9 @@ mod tests {
 
     #[test]
     fn test_from_flashblocks_multiple_valid_flashblocks() {
-        let fb1 = create_test_flashblock(0, true);
-        let fb2 = create_test_flashblock(1, false);
-        let fb3 = create_test_flashblock(2, false);
+        let fb1 = create_test_flashblock(0, true, Vec::new(), None);
+        let fb2 = create_test_flashblock(1, false, Vec::new(), None);
+        let fb3 = create_test_flashblock(2, false, Vec::new(), None);
 
         let result = OpExecutionData::from_flashblocks(&[fb1, fb2, fb3]);
         assert!(result.is_ok(), "Multiple valid flashblocks should succeed");
@@ -829,41 +833,47 @@ mod tests {
 
     #[test]
     fn test_from_flashblocks_wrong_first_index() {
-        let fb1 = create_test_flashblock(1, true); // Should be index 0
+        let fb1 = create_test_flashblock(1, true, Vec::new(), None); // Should be index 0
         let result = OpExecutionData::from_flashblocks(&[fb1]);
         assert!(matches!(result, Err(OpFlashblockError::InvalidIndex)));
     }
 
     #[test]
     fn test_from_subblocks_appends_latest_post_exec_tx() {
-        use alloy_primitives::Bytes;
-
-        let mk = |index: u64, with_base: bool, tx: u8, post_exec: Option<Bytes>| {
-            let mut subblock = create_test_flashblock(index, with_base);
-            subblock.diff.transactions = vec![Bytes::from(vec![tx])];
-            subblock.diff.post_exec_tx = post_exec;
-            subblock
-        };
         let older = Bytes::from(vec![0x7d, 0x01]);
         let latest = Bytes::from(vec![0x7d, 0x02]);
 
-        // Without post_exec_tx, materialization only concatenates regular transactions.
-        let none =
-            OpExecutionData::from_flashblocks(&[mk(0, true, 0x01, None), mk(1, false, 0x02, None)])
-                .unwrap();
+        let none = OpExecutionData::from_flashblocks(&[
+            create_test_flashblock(0, true, vec![Bytes::from(vec![0x01])], None),
+            create_test_flashblock(1, false, vec![Bytes::from(vec![0x02])], None),
+        ])
+        .unwrap();
         assert_eq!(none.payload.transactions().len(), 2, "no 0x7D should be appended");
 
-        // The latest subblock replaces prior values and is appended exactly once.
         let materialized = OpExecutionData::from_flashblocks(&[
-            mk(0, true, 0x01, Some(older.clone())),
-            mk(1, false, 0x02, Some(latest.clone())),
-            mk(2, false, 0x03, Some(latest.clone())),
+            create_test_flashblock(0, true, vec![Bytes::from(vec![0x01])], Some(older.clone())),
+            create_test_flashblock(1, false, vec![Bytes::from(vec![0x02])], Some(latest.clone())),
+            create_test_flashblock(2, false, vec![Bytes::from(vec![0x03])], Some(latest.clone())),
         ])
         .unwrap();
         let txs = materialized.payload.transactions();
         assert_eq!(txs.len(), 4, "3 user txs + exactly one trailing 0x7D");
         assert_eq!(txs.last(), Some(&latest), "the latest post_exec_tx must be the trailing tx");
         assert!(!txs.iter().any(|t| t == &older), "the superseded post_exec_tx must not appear");
+    }
+
+    #[test]
+    fn test_from_subblocks_preserves_empty_post_exec_tx() {
+        let empty = Bytes::new();
+        let materialized = OpExecutionData::from_flashblocks(&[create_test_flashblock(
+            0,
+            true,
+            Vec::new(),
+            Some(empty.clone()),
+        )])
+        .unwrap();
+
+        assert_eq!(materialized.payload.transactions().last(), Some(&empty));
     }
 
     // Real-world test case from Unichain Sepolia

--- a/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
@@ -164,10 +164,8 @@ impl OpExecutionData {
     /// - First flashblock (index 0) must have a base payload
     /// - Only the first flashblock may have a base payload
     ///
-    /// SDM-specific `post_exec_tx` validation is intentionally delegated to the normal execution
-    /// payload validation path: this method only materializes the latest out-of-band bytes as the
-    /// trailing transaction. The executor/consensus parser validates the `0x7D` type, decodes the
-    /// payload, checks the block number, and rejects duplicate/non-trailing post-exec txs.
+    /// Materializes the latest out-of-band SDM `post_exec_tx` as the trailing transaction.
+    /// The normal execution-payload path validates its type, payload, and position.
     ///
     /// # Errors
     ///
@@ -237,12 +235,8 @@ impl OpExecutionData {
                 (txs, withdrawals)
             });
 
-        // The SDM post-exec (`0x7D`) tx rides out-of-band in `diff.post_exec_tx` and is never part
-        // of any flashblock's `transactions`; each subblock *replaces* the previous one, so the
-        // last flashblock's `post_exec_tx` is authoritative. Append it exactly once, last —
-        // the position OP consensus requires for the trailing post-exec tx. SDM byte validation is
-        // deliberately left to the downstream execution-payload verifier, so this reconstruction
-        // stays a pure materialization step.
+        // Each subblock replaces the out-of-band SDM transaction. Append the latest value once in
+        // the consensus-required trailing position; normal payload validation verifies its bytes.
         if let Some(post_exec_tx) = diff.post_exec_tx.as_ref() {
             transactions.push(post_exec_tx.clone());
         }
@@ -841,28 +835,25 @@ mod tests {
     }
 
     #[test]
-    fn test_from_flashblocks_appends_latest_post_exec_tx() {
+    fn test_from_subblocks_appends_latest_post_exec_tx() {
         use alloy_primitives::Bytes;
 
-        // Build a flashblock with explicit transactions and an out-of-band post_exec_tx.
         let mk = |index: u64, with_base: bool, tx: u8, post_exec: Option<Bytes>| {
-            let mut fb = create_test_flashblock(index, with_base);
-            fb.diff.transactions = vec![Bytes::from(vec![tx])];
-            fb.diff.post_exec_tx = post_exec;
-            fb
+            let mut subblock = create_test_flashblock(index, with_base);
+            subblock.diff.transactions = vec![Bytes::from(vec![tx])];
+            subblock.diff.post_exec_tx = post_exec;
+            subblock
         };
         let older = Bytes::from(vec![0x7d, 0x01]);
         let latest = Bytes::from(vec![0x7d, 0x02]);
 
-        // No post_exec_tx anywhere: transactions are just the concatenated deltas.
+        // Without post_exec_tx, materialization only concatenates regular transactions.
         let none =
             OpExecutionData::from_flashblocks(&[mk(0, true, 0x01, None), mk(1, false, 0x02, None)])
                 .unwrap();
         assert_eq!(none.payload.transactions().len(), 2, "no 0x7D should be appended");
 
-        // Replace-not-accumulate: only the LAST flashblock's post_exec_tx is appended, exactly
-        // once, at the end; the older one never appears. (Protocol: once Some, every later
-        // subblock is Some.)
+        // The latest subblock replaces prior values and is appended exactly once.
         let materialized = OpExecutionData::from_flashblocks(&[
             mk(0, true, 0x01, Some(older.clone())),
             mk(1, false, 0x02, Some(latest.clone())),

--- a/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
@@ -164,6 +164,11 @@ impl OpExecutionData {
     /// - First flashblock (index 0) must have a base payload
     /// - Only the first flashblock may have a base payload
     ///
+    /// SDM-specific `post_exec_tx` validation is intentionally delegated to the normal execution
+    /// payload validation path: this method only materializes the latest out-of-band bytes as the
+    /// trailing transaction. The executor/consensus parser validates the `0x7D` type, decodes the
+    /// payload, checks the block number, and rejects duplicate/non-trailing post-exec txs.
+    ///
     /// # Errors
     ///
     /// Returns an error if any validation fails.
@@ -225,12 +230,22 @@ impl OpExecutionData {
         let diff = &flashblocks.last().expect("flashblocks must not be empty").diff;
 
         // Collect all transactions and withdrawals from all flashblocks
-        let (transactions, withdrawals) =
+        let (mut transactions, withdrawals) =
             flashblocks.iter().fold((Vec::new(), Vec::new()), |(mut txs, mut withdrawals), p| {
                 txs.extend(p.diff.transactions.iter().cloned());
                 withdrawals.extend(p.diff.withdrawals.iter().copied());
                 (txs, withdrawals)
             });
+
+        // The SDM post-exec (`0x7D`) tx rides out-of-band in `diff.post_exec_tx` and is never part
+        // of any flashblock's `transactions`; each subblock *replaces* the previous one, so the
+        // last flashblock's `post_exec_tx` is authoritative. Append it exactly once, last —
+        // the position OP consensus requires for the trailing post-exec tx. SDM byte validation is
+        // deliberately left to the downstream execution-payload verifier, so this reconstruction
+        // stays a pure materialization step.
+        if let Some(post_exec_tx) = diff.post_exec_tx.as_ref() {
+            transactions.push(post_exec_tx.clone());
+        }
 
         let v3 = ExecutionPayloadV3 {
             blob_gas_used: diff.blob_gas_used.unwrap_or(0),
@@ -756,6 +771,7 @@ mod tests {
             withdrawals: Vec::new(),
             withdrawals_root: B256::from([1u8; 32]), // Non-zero for Isthmus
             blob_gas_used: Some(0),
+            post_exec_tx: None,
         };
 
         let metadata = OpFlashblockPayloadMetadata {
@@ -822,6 +838,41 @@ mod tests {
         let fb1 = create_test_flashblock(1, true); // Should be index 0
         let result = OpExecutionData::from_flashblocks(&[fb1]);
         assert!(matches!(result, Err(OpFlashblockError::InvalidIndex)));
+    }
+
+    #[test]
+    fn test_from_flashblocks_appends_latest_post_exec_tx() {
+        use alloy_primitives::Bytes;
+
+        // Build a flashblock with explicit transactions and an out-of-band post_exec_tx.
+        let mk = |index: u64, with_base: bool, tx: u8, post_exec: Option<Bytes>| {
+            let mut fb = create_test_flashblock(index, with_base);
+            fb.diff.transactions = vec![Bytes::from(vec![tx])];
+            fb.diff.post_exec_tx = post_exec;
+            fb
+        };
+        let older = Bytes::from(vec![0x7d, 0x01]);
+        let latest = Bytes::from(vec![0x7d, 0x02]);
+
+        // No post_exec_tx anywhere: transactions are just the concatenated deltas.
+        let none =
+            OpExecutionData::from_flashblocks(&[mk(0, true, 0x01, None), mk(1, false, 0x02, None)])
+                .unwrap();
+        assert_eq!(none.payload.transactions().len(), 2, "no 0x7D should be appended");
+
+        // Replace-not-accumulate: only the LAST flashblock's post_exec_tx is appended, exactly
+        // once, at the end; the older one never appears. (Protocol: once Some, every later
+        // subblock is Some.)
+        let materialized = OpExecutionData::from_flashblocks(&[
+            mk(0, true, 0x01, Some(older.clone())),
+            mk(1, false, 0x02, Some(latest.clone())),
+            mk(2, false, 0x03, Some(latest.clone())),
+        ])
+        .unwrap();
+        let txs = materialized.payload.transactions();
+        assert_eq!(txs.len(), 4, "3 user txs + exactly one trailing 0x7D");
+        assert_eq!(txs.last(), Some(&latest), "the latest post_exec_tx must be the trailing tx");
+        assert!(!txs.iter().any(|t| t == &older), "the superseded post_exec_tx must not appear");
     }
 
     // Real-world test case from Unichain Sepolia

--- a/rust/op-alloy/crates/rpc-types-engine/src/flashblock/delta.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/flashblock/delta.rs
@@ -41,6 +41,13 @@ pub struct OpFlashblockPayloadDelta {
         )
     )]
     pub blob_gas_used: Option<u64>,
+    /// Latest cumulative SDM post-exec (`0x7D`) transaction for the materialized block view,
+    /// carried out-of-band. Each subblock *replaces* the previous one (latest-wins); it is never
+    /// included in [`transactions`](Self::transactions). Absent on pre-SDM payloads.
+    /// Wire-compatible with `rollup_boost`'s
+    /// `ExecutionPayloadFlashblockDeltaV1::post_exec_tx`.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub post_exec_tx: Option<Bytes>,
 }
 
 #[cfg(test)]
@@ -61,6 +68,7 @@ mod tests {
             withdrawals: vec![],
             withdrawals_root: B256::random(),
             blob_gas_used: Some(123456),
+            post_exec_tx: Some(Bytes::from(vec![0x7d, 0x01])),
         };
 
         let json = serde_json::to_string(&delta).unwrap();
@@ -81,6 +89,7 @@ mod tests {
             withdrawals: vec![],
             withdrawals_root: B256::ZERO,
             blob_gas_used: Some(0),
+            post_exec_tx: None,
         };
 
         let json = serde_json::to_string(&delta).unwrap();
@@ -113,6 +122,7 @@ mod tests {
             withdrawals: vec![withdrawal],
             withdrawals_root: B256::ZERO,
             blob_gas_used: Some(0),
+            post_exec_tx: None,
         };
 
         let json = serde_json::to_string(&delta).unwrap();
@@ -135,6 +145,7 @@ mod tests {
             withdrawals: vec![],
             withdrawals_root: B256::ZERO,
             blob_gas_used: None,
+            post_exec_tx: None,
         };
 
         let json = serde_json::to_string(&delta).unwrap();
@@ -160,6 +171,7 @@ mod tests {
             withdrawals: vec![],
             withdrawals_root: B256::ZERO,
             blob_gas_used: Some(12345),
+            post_exec_tx: None,
         };
 
         let json = serde_json::to_string(&delta).unwrap();
@@ -180,5 +192,33 @@ mod tests {
         assert!(delta.withdrawals.is_empty());
         assert_eq!(delta.withdrawals_root, B256::ZERO);
         assert_eq!(delta.blob_gas_used, None);
+        assert_eq!(delta.post_exec_tx, None);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_delta_post_exec_tx_none_skipped() {
+        // Pre-SDM payloads omit post_exec_tx entirely (wire-compatible with older deltas).
+        let delta = OpFlashblockPayloadDelta::default();
+        let json = serde_json::to_string(&delta).unwrap();
+        assert!(!json.contains("post_exec_tx"));
+        let decoded: OpFlashblockPayloadDelta = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.post_exec_tx, None);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_delta_post_exec_tx_some_roundtrips() {
+        // The 0x7D bytes ride out-of-band in post_exec_tx, serialized as a hex string under the
+        // `post_exec_tx` key (matching rollup-boost + the Go FlashblockClient).
+        let delta = OpFlashblockPayloadDelta {
+            post_exec_tx: Some(Bytes::from(vec![0x7d, 0xaa, 0xbb])),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&delta).unwrap();
+        assert!(json.contains("post_exec_tx"));
+        assert!(json.contains("0x7daabb"));
+        let decoded: OpFlashblockPayloadDelta = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.post_exec_tx, Some(Bytes::from(vec![0x7d, 0xaa, 0xbb])));
     }
 }

--- a/rust/op-alloy/crates/rpc-types-engine/src/flashblock/delta.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/flashblock/delta.rs
@@ -41,11 +41,9 @@ pub struct OpFlashblockPayloadDelta {
         )
     )]
     pub blob_gas_used: Option<u64>,
-    /// Latest cumulative SDM post-exec (`0x7D`) transaction for the materialized block view,
-    /// carried out-of-band. Each subblock *replaces* the previous one (latest-wins); it is never
-    /// included in [`transactions`](Self::transactions). Absent on pre-SDM payloads.
-    /// Wire-compatible with `rollup_boost`'s
-    /// `ExecutionPayloadFlashblockDeltaV1::post_exec_tx`.
+    /// Latest cumulative SDM post-exec (`0x7D`) transaction, carried out of band from
+    /// [`transactions`](Self::transactions). Each subblock replaces the previous value.
+    /// Matches `rollup_boost`'s `ExecutionPayloadFlashblockDeltaV1::post_exec_tx` field.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub post_exec_tx: Option<Bytes>,
 }
@@ -198,7 +196,7 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_delta_post_exec_tx_none_skipped() {
-        // Pre-SDM payloads omit post_exec_tx entirely (wire-compatible with older deltas).
+        // Pre-SDM subblocks omit post_exec_tx for wire compatibility.
         let delta = OpFlashblockPayloadDelta::default();
         let json = serde_json::to_string(&delta).unwrap();
         assert!(!json.contains("post_exec_tx"));
@@ -209,8 +207,7 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_delta_post_exec_tx_some_roundtrips() {
-        // The 0x7D bytes ride out-of-band in post_exec_tx, serialized as a hex string under the
-        // `post_exec_tx` key (matching rollup-boost + the Go FlashblockClient).
+        // Subblocks encode the out-of-band 0x7D bytes as a hex string.
         let delta = OpFlashblockPayloadDelta {
             post_exec_tx: Some(Bytes::from(vec![0x7d, 0xaa, 0xbb])),
             ..Default::default()

--- a/rust/op-alloy/crates/rpc-types-engine/src/flashblock/payload.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/flashblock/payload.rs
@@ -111,6 +111,7 @@ mod tests {
             withdrawals: vec![],
             withdrawals_root: B256::ZERO,
             blob_gas_used: Some(0),
+            post_exec_tx: None,
         };
 
         let metadata = OpFlashblockPayloadMetadata {

--- a/rust/op-reth/crates/flashblocks/src/test_utils.rs
+++ b/rust/op-reth/crates/flashblocks/src/test_utils.rs
@@ -320,6 +320,7 @@ impl TestFlashBlockBuilder {
                 withdrawals: self.withdrawals,
                 withdrawals_root: self.withdrawals_root,
                 blob_gas_used: self.blob_gas_used,
+                post_exec_tx: None,
             },
             metadata: OpFlashblockPayloadMetadata {
                 block_number: self.block_number,

--- a/rust/op-reth/crates/flashblocks/tests/it/harness.rs
+++ b/rust/op-reth/crates/flashblocks/tests/it/harness.rs
@@ -429,6 +429,7 @@ impl TestFlashBlockBuilder {
                 withdrawals: vec![],
                 withdrawals_root: B256::ZERO,
                 blob_gas_used: None,
+                post_exec_tx: None,
             },
             metadata: OpFlashblockPayloadMetadata {
                 block_number: self.block_number,


### PR DESCRIPTION
Adds optional cumulative `post_exec_tx` data to subblock payloads and uses the latest value when materializing a full payload.

Includes coverage for absent, single, and updated post-exec transactions.

This adds wire compatibility only; it does not change SDM policy.