### PR TITLE
sdm: add configurable post-exec refund policy seam

### DIFF
--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -39,8 +39,8 @@ use revm::{
 };
 
 use crate::post_exec::{
-    PostExecEvm, PostExecEvmFactoryAdapter, PostExecEvmFactoryHooks, PostExecTxContext,
-    PostExecTxKind, WarmingRefundEvent, WarmingState,
+    PostExecEvm, PostExecEvmFactoryAdapter, PostExecEvmFactoryHooks, PostExecExecutedTx,
+    PostExecTxContext, PostExecTxKind, WarmingRefundEvent,
 };
 
 mod canyon;
@@ -232,8 +232,11 @@ impl PostExecState {
         }
     }
 
-    /// Whether a `Verify` block had a post-exec payload but no trailing `0x7D`.
-    /// Per-tx settlement can consume all verifier entries, so check this separately.
+    /// Whether a `Verify` block claims a post-exec payload yet never carried the trailing `0x7D`.
+    ///
+    /// Per-tx settlement drains the verifier entries as the refunded txs commit, so an absent
+    /// `0x7D` is invisible to the unconsumed-entries check — only this flag proves the producer
+    /// actually committed the claimed refunds on-chain.
     const fn missing_post_exec_tx(&self) -> bool {
         matches!(self, Self::Verifying { saw_post_exec_tx: false, .. })
     }
@@ -435,16 +438,13 @@ where
     E: PostExecEvm,
     R: OpReceiptBuilder,
 {
-    /// Snapshot the block-scoped warming state from the underlying EVM's inspector.
-    ///
-    /// Builders that execute a block across multiple flashblock executors carry this into the next
-    /// flashblock's executor so block-scoped warming refunds match a single canonical pass.
-    pub fn warming_state(&self) -> WarmingState {
+    /// Snapshot refund state to carry across subblock executors.
+    pub fn warming_state(&self) -> E::Snapshot {
         self.evm.warming_state()
     }
 
-    /// Seed the underlying EVM's inspector with warming state captured from a prior flashblock.
-    pub fn seed_warming_state(&mut self, state: WarmingState) {
+    /// Seed refund state captured from a prior subblock.
+    pub fn seed_warming_state(&mut self, state: E::Snapshot) {
         self.evm.seed_warming_state(state);
     }
 }
@@ -838,11 +838,20 @@ where
         // Commit-only paths (block import, `debug_replaySDMBlock` derivation) never see that
         // warmth, so the producer's payload would diverge from derivation.
         //
-        // Snapshot warming before execution and restore it when the tx isn't committed. Only
-        // `Producing` mode tracks warming, so we clone the maps solely on that path.
+        // Snapshot warming before execution and restore it when the tx isn't committed or when
+        // execution fails after post-exec tracking has started. Only `Producing` mode tracks
+        // warming, so we clone the maps solely on that path.
         let warming_snapshot = self.post_exec.is_producing().then(|| self.warming_state());
 
-        let output = self.execute_transaction_without_commit(tx)?;
+        let output = match self.execute_transaction_without_commit(tx) {
+            Ok(output) => output,
+            Err(err) => {
+                if let Some(snapshot) = warming_snapshot {
+                    self.seed_warming_state(snapshot);
+                }
+                return Err(err);
+            }
+        };
 
         if !f(&output).should_commit() {
             if let Some(snapshot) = warming_snapshot {
@@ -956,8 +965,8 @@ where
 
         let evm_gas_used = result.result.tx_gas_used();
         let (post_exec_refund, warming_events) = if self.post_exec.is_producing() {
-            let post_exec_result = self.evm.take_last_post_exec_tx_result();
-            let refund = post_exec_result.refund_total;
+            let PostExecExecutedTx { refund_total: refund, refund_events } =
+                self.evm.take_last_post_exec_tx_result();
             // The inspector's accumulated refund must never exceed the tx's evm_gas_used. If
             // it does, we'd emit an `SDMGasEntry` that any honest verifier would reject
             // at pre-execution ("payload refund exceeds evm_gas_used"), so the sequencer
@@ -968,7 +977,7 @@ where
                     "produced refund {refund} exceeds evm_gas_used {evm_gas_used} for tx index {tx_index}",
                 )));
             }
-            (refund, post_exec_result.refund_events)
+            (refund, refund_events)
         } else {
             (
                 self.verifier_post_exec_refund_for_tx(tx_index, is_deposit, false, evm_gas_used)?,

--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -439,13 +439,13 @@ where
     R: OpReceiptBuilder,
 {
     /// Snapshot refund state to carry across subblock executors.
-    pub fn warming_state(&self) -> E::Snapshot {
-        self.evm.warming_state()
+    pub fn refund_snapshot(&self) -> E::Snapshot {
+        self.evm.refund_snapshot()
     }
 
     /// Seed refund state captured from a prior subblock.
-    pub fn seed_warming_state(&mut self, state: E::Snapshot) {
-        self.evm.seed_warming_state(state);
+    pub fn seed_refund_snapshot(&mut self, state: E::Snapshot) {
+        self.evm.seed_refund_snapshot(state);
     }
 }
 
@@ -841,13 +841,13 @@ where
         // Snapshot warming before execution and restore it when the tx isn't committed or when
         // execution fails after post-exec tracking has started. Only `Producing` mode tracks
         // warming, so we clone the maps solely on that path.
-        let warming_snapshot = self.post_exec.is_producing().then(|| self.warming_state());
+        let warming_snapshot = self.post_exec.is_producing().then(|| self.refund_snapshot());
 
         let output = match self.execute_transaction_without_commit(tx) {
             Ok(output) => output,
             Err(err) => {
                 if let Some(snapshot) = warming_snapshot {
-                    self.seed_warming_state(snapshot);
+                    self.seed_refund_snapshot(snapshot);
                 }
                 return Err(err);
             }
@@ -855,7 +855,7 @@ where
 
         if !f(&output).should_commit() {
             if let Some(snapshot) = warming_snapshot {
-                self.seed_warming_state(snapshot);
+                self.seed_refund_snapshot(snapshot);
             }
             return Ok(None);
         }

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -994,6 +994,64 @@ mod sdm {
         );
     }
 
+    // A contract created by one tx must be warmed for a later tx that genuinely cold-accesses it,
+    // so the later tx earns its warming rebate. The `create` hook records the address via
+    // `CreateInputs::created_address`, which `revm` memoizes (`OnceCell`) from the canonical
+    // pre-bump nonce before the hook runs — so the address is always correct regardless of the
+    // nonce the inspector passes (this is why the "CREATE-address staleness" concern does not arise
+    // against the pinned revm). This guards the end-to-end property: created contract -> warmed ->
+    // later cold access rebated.
+    #[test]
+    fn test_created_contract_address_is_warmed_for_a_later_tx() {
+        const BLOCK_GAS_LIMIT: u64 = 2_000_000;
+
+        // Probe the canonical address the CREATE produces (revm computes it from the pre-bump
+        // nonce). Sender and nonce match the real run below, so the address is identical.
+        let created = {
+            let mut probe_fixture = SDMExecutorFixture::new(
+                DEFAULT_DA_FOOTPRINT_GAS_SCALAR,
+                BLOCK_GAS_LIMIT,
+                JOVIAN_TIMESTAMP,
+            );
+            let mut probe = probe_fixture.executor_with_post_exec_mode(PostExecMode::Produce);
+            let mut created = None;
+            probe
+                .execute_transaction_with_result_closure(&create_tx(0), |res| {
+                    if let ExecutionResult::Success {
+                        output: Output::Create(_, Some(addr)), ..
+                    } = &res.result().result
+                    {
+                        created = Some(*addr);
+                    }
+                })
+                .expect("probe create tx");
+            created.expect("create produced a contract address")
+        };
+
+        // Real run: tx0 creates the contract; tx1 cold-`BALANCE`-touches it through a probe.
+        let probe = Address::from([0x8c; 20]);
+        let mut fixture = SDMExecutorFixture::new(
+            DEFAULT_DA_FOOTPRINT_GAS_SCALAR,
+            BLOCK_GAS_LIMIT,
+            JOVIAN_TIMESTAMP,
+        );
+        fixture.db.insert_account(probe, balance_probe_account(&[created]));
+        let mut producer = fixture.executor_with_post_exec_mode(PostExecMode::Produce);
+        producer.execute_transaction(&create_tx(0)).expect("tx0 creates the contract");
+        producer
+            .execute_transaction(&legacy_tx(1, probe))
+            .expect("tx1 cold-touches the created contract");
+
+        let created_event = all_warming_events(&producer)
+            .into_iter()
+            .find(|event| event.address == created)
+            .expect("tx1 must earn a warming rebate for the contract created by tx0");
+        assert_eq!(created_event.claiming_tx_index, 1, "rebate is claimed by tx1");
+        assert_eq!(created_event.first_warmed_by_tx_index, 0, "contract was warmed by tx0");
+        assert_eq!(created_event.amount, 2_500, "warm-account rebate amount");
+        assert_eq!(created_event.slot, None, "account rebate has no storage slot");
+    }
+
     // End-to-end companion to the inspector-level settlement test: the OP fee vaults (L1/base-fee/
     // operator-fee recipients) are warmed by the protocol's per-tx fee settlement write in
     // `transact_raw`, not by a user opcode access, so no cold EIP-2929 access is ever paid for
@@ -1280,15 +1338,19 @@ mod sdm {
         );
     }
 
-    /// A `Verify` block must include `0x7D` even when normal txs consume every verifier entry;
-    /// otherwise the payload-vs-block byte check is skipped.
+    /// A `Verify` block whose normal txs apply the claimed refunds but which never carries the
+    /// trailing `0x7D` post-exec tx must be rejected. Per-tx settlement drains each verifier entry
+    /// as the refunded tx commits, so the unconsumed-entries check above passes — the presence of
+    /// the synthetic `0x7D` is the only thing proving the producer actually committed those refunds
+    /// on-chain. Without this guard the block validates while diverging from one that includes the
+    /// tx, and the `0x7D`'s payload-vs-block byte check is skipped entirely.
     #[test]
     fn test_finish_rejects_verify_block_missing_post_exec_tx() {
         const BLOCK_GAS_LIMIT: u64 = 100_000;
         let target = Address::from([0x11; 20]);
         let tx0 = legacy_tx(0, target);
         let tx1 = legacy_tx(1, target);
-        // Make tx1 consume its verifier entry during normal settlement.
+        // Refund the second tx so its verifier entry is consumed during normal settlement.
         let entries = full_refund_for_second_tx(BLOCK_GAS_LIMIT, &tx0, &tx1);
 
         let mut fixture = SDMExecutorFixture::new(
@@ -1304,7 +1366,7 @@ mod sdm {
             "the refunded tx must already have drained every verifier entry",
         );
 
-        // No 0x7D ran, so only the missing-tx guard can catch this.
+        // The 0x7D was never executed, so the unconsumed-entries check cannot catch this.
         let Err(err) = verifier.finish() else {
             panic!("a Verify block that applies refunds but omits the 0x7D must be rejected");
         };
@@ -1331,6 +1393,97 @@ mod sdm {
         assert_invalid_post_exec(
             err,
             "unexpected post-exec tx at index 0: SDM not active for this block",
+        );
+    }
+
+    #[derive(Debug, Default)]
+    struct ErroringRefundInspector {
+        block_state: u64,
+    }
+
+    impl<CTX, INTR: revm::interpreter::InterpreterTypes> revm::Inspector<CTX, INTR>
+        for ErroringRefundInspector
+    {
+    }
+
+    impl crate::post_exec::PostExecRefundInspector for ErroringRefundInspector {
+        type Snapshot = u64;
+
+        fn begin_tx(&mut self, _ctx: PostExecTxContext) {
+            self.block_state += 1;
+        }
+
+        fn note_account_touch(&mut self, _address: Address) {
+            self.block_state += 1;
+        }
+
+        fn finish_tx(&mut self) -> crate::post_exec::PostExecExecutedTx {
+            crate::post_exec::PostExecExecutedTx {
+                refund_total: u64::MAX,
+                refund_events: Vec::new(),
+            }
+        }
+
+        fn snapshot(&self) -> Self::Snapshot {
+            self.block_state
+        }
+
+        fn restore(&mut self, snapshot: Self::Snapshot) {
+            self.block_state = snapshot;
+        }
+    }
+
+    // An execution error after post-exec tracking starts must restore the same snapshot used for
+    // declined candidates. Today the reachable post-warming errors are fatal block-validation
+    // errors, but payload-builder code may catch some execution errors and continue; restoring here
+    // prevents those skipped txs from leaving phantom producer-only warming behind.
+    #[test]
+    fn test_execution_error_restores_warming_snapshot() {
+        let mut fixture = SDMExecutorFixture::default();
+        let ctx = Context::mainnet()
+            .with_tx(crate::OpTx(OpTransaction::builder().build_fill()))
+            .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
+            .with_chain(L1BlockInfo::default())
+            .with_db(&mut fixture.db)
+            .with_chain(L1BlockInfo {
+                operator_fee_scalar: Some(U256::from(2)),
+                operator_fee_constant: Some(U256::from(50)),
+                ..Default::default()
+            })
+            .with_block(BlockEnv {
+                timestamp: U256::from(fixture.jovian_timestamp),
+                gas_limit: fixture.gas_limit,
+                basefee: fixture.base_fee,
+                beneficiary: fixture.beneficiary,
+                ..Default::default()
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::JOVIAN);
+        let evm = OpEvm::<_, _, _, crate::OpTx, ErroringRefundInspector>::new(
+            ctx.build_op_with_inspector(NoOpInspector {}),
+            true,
+        );
+        let mut producer = OpBlockExecutor::new(
+            evm,
+            OpBlockExecutionCtx::default(),
+            &fixture.op_chain_hardforks,
+            &fixture.receipt_builder,
+        )
+        .with_post_exec_mode(PostExecMode::Produce);
+
+        let err = producer
+            .execute_transaction_with_commit_condition(
+                &legacy_tx(0, Address::from([0x55; 20])),
+                |_| CommitChanges::Yes,
+            )
+            .expect_err("custom refund inspector must force a post-exec validation error");
+        assert_invalid_post_exec(
+            err,
+            "produced refund 18446744073709551615 exceeds evm_gas_used 21000 for tx index 0",
+        );
+        assert_eq!(
+            producer.warming_state(),
+            0,
+            "post-exec snapshot must be restored when execution returns an error",
         );
     }
 

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -1443,7 +1443,6 @@ mod sdm {
         let ctx = Context::mainnet()
             .with_tx(crate::OpTx(OpTransaction::builder().build_fill()))
             .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
-            .with_chain(L1BlockInfo::default())
             .with_db(&mut fixture.db)
             .with_chain(L1BlockInfo {
                 operator_fee_scalar: Some(U256::from(2)),
@@ -1481,7 +1480,7 @@ mod sdm {
             "produced refund 18446744073709551615 exceeds evm_gas_used 21000 for tx index 0",
         );
         assert_eq!(
-            producer.warming_state(),
+            producer.refund_snapshot(),
             0,
             "post-exec snapshot must be restored when execution returns an error",
         );

--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -205,13 +205,13 @@ where
     }
 
     /// Snapshot refund state to carry across subblock executors.
-    pub fn warming_state(&self) -> R::Snapshot {
-        self.inner.0.inspector.warming_state()
+    pub fn refund_snapshot(&self) -> R::Snapshot {
+        self.inner.0.inspector.refund_snapshot()
     }
 
     /// Seed refund state captured from a prior subblock.
-    pub fn seed_warming_state(&mut self, state: R::Snapshot) {
-        self.inner.0.inspector.seed_warming_state(state);
+    pub fn seed_refund_snapshot(&mut self, state: R::Snapshot) {
+        self.inner.0.inspector.seed_refund_snapshot(state);
     }
 }
 
@@ -230,12 +230,12 @@ where
         Self::take_last_post_exec_tx_result(self)
     }
 
-    fn warming_state(&self) -> Self::Snapshot {
-        Self::warming_state(self)
+    fn refund_snapshot(&self) -> Self::Snapshot {
+        Self::refund_snapshot(self)
     }
 
-    fn seed_warming_state(&mut self, state: Self::Snapshot) {
-        Self::seed_warming_state(self, state);
+    fn seed_refund_snapshot(&mut self, state: Self::Snapshot) {
+        Self::seed_refund_snapshot(self, state);
     }
 }
 
@@ -265,20 +265,20 @@ where
         evm.take_last_post_exec_tx_result()
     }
 
-    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
+    fn refund_snapshot<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,
     {
-        evm.warming_state()
+        evm.refund_snapshot()
     }
 
-    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
+    fn seed_refund_snapshot<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,
     {
-        evm.seed_warming_state(state);
+        evm.seed_refund_snapshot(state);
     }
 }
 

--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -56,6 +56,13 @@ pub mod post_exec;
 /// The OP EVM context type.
 pub type OpEvmContext<DB> = Context<BlockEnv, OpTx, CfgEnv<OpSpecId>, DB, Journal<DB>, L1BlockInfo>;
 
+type OpEvmInner<DB, I, P, R> = op_revm::OpEvm<
+    OpEvmContext<DB>,
+    post_exec::PostExecCompositeInspector<I, R>,
+    EthInstructions<EthInterpreter, OpEvmContext<DB>>,
+    P,
+>;
+
 /// OP EVM implementation.
 ///
 /// This is a wrapper type around the `revm` evm with optional [`Inspector`] (tracing)
@@ -64,21 +71,21 @@ pub type OpEvmContext<DB> = Context<BlockEnv, OpTx, CfgEnv<OpSpecId>, DB, Journa
 ///
 /// The `Tx` type parameter controls the transaction environment type. By default it uses
 /// [`OpTx`] which wraps [`OpTransaction<TxEnv>`] and implements the necessary foreign traits.
+///
+/// The `R` type parameter is the post-exec refund inspector embedded alongside the user inspector
+/// `I` (see [`post_exec::PostExecCompositeInspector`]). It is fixed by the EVM factory and defaults
+/// to [`SDMWarmingInspector`](post_exec::SDMWarmingInspector).
 #[allow(missing_debug_implementations)] // missing revm::OpContext Debug impl
-pub struct OpEvm<DB: Database, I, P = OpPrecompiles, Tx = OpTx> {
-    inner: op_revm::OpEvm<
-        OpEvmContext<DB>,
-        post_exec::PostExecCompositeInspector<I>,
-        EthInstructions<EthInterpreter, OpEvmContext<DB>>,
-        P,
-    >,
+pub struct OpEvm<DB: Database, I, P = OpPrecompiles, Tx = OpTx, R = post_exec::SDMWarmingInspector>
+{
+    inner: OpEvmInner<DB, I, P, R>,
     inspect: bool,
     post_exec_tracking_active: bool,
     last_tx_post_exec_result: post_exec::PostExecExecutedTx,
     _tx: PhantomData<Tx>,
 }
 
-impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
+impl<DB: Database, I, P, Tx, R> OpEvm<DB, I, P, Tx, R> {
     /// Consumes self and return the inner EVM instance.
     pub fn into_inner(
         self,
@@ -112,7 +119,7 @@ impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
     }
 }
 
-impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
+impl<DB: Database, I, P, Tx, R: Default> OpEvm<DB, I, P, Tx, R> {
     /// Creates a new OP EVM instance.
     ///
     /// The `inspect` argument determines whether the configured [`Inspector`] of the given
@@ -148,7 +155,40 @@ impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
             _tx: PhantomData,
         }
     }
+}
 
+impl<DB: Database, I, Tx, R: Default> OpEvm<DB, I, PrecompilesMap, Tx, R> {
+    /// Creates an OP EVM with the standard OP context and precompiles.
+    ///
+    /// This is shared by factories that differ only in their fixed post-exec refund inspector.
+    /// The `inspect` argument controls whether `inspector` is invoked during execution.
+    pub fn from_env(
+        db: DB,
+        input: EvmEnv<OpSpecId, BlockEnv>,
+        inspector: I,
+        inspect: bool,
+    ) -> Self {
+        let spec_id = input.cfg_env.spec;
+        let inner = Context::mainnet()
+            .with_tx(OpTx(OpTransaction::builder().build_fill()))
+            .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
+            .with_chain(L1BlockInfo::default())
+            .with_db(db)
+            .with_block(input.block_env)
+            .with_cfg(input.cfg_env)
+            .build_op_with_inspector(inspector)
+            .with_precompiles(PrecompilesMap::from_static(
+                OpPrecompiles::new_with_spec(spec_id).precompiles(),
+            ));
+
+        Self::new(inner, inspect)
+    }
+}
+
+impl<DB: Database, I, P, Tx, R> OpEvm<DB, I, P, Tx, R>
+where
+    R: post_exec::PostExecRefundInspector,
+{
     /// Begin post-exec tracking for the next transaction.
     pub fn begin_post_exec_tx(&mut self, ctx: post_exec::PostExecTxContext) {
         self.post_exec_tracking_active = true;
@@ -164,21 +204,24 @@ impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
         core::mem::take(&mut self.last_tx_post_exec_result)
     }
 
-    /// Snapshot the block-scoped warming state for carry-forward across flashblock executors.
-    pub fn warming_state(&self) -> post_exec::WarmingState {
+    /// Snapshot refund state to carry across subblock executors.
+    pub fn warming_state(&self) -> R::Snapshot {
         self.inner.0.inspector.warming_state()
     }
 
-    /// Seed the block-scoped warming state captured from a prior flashblock's executor.
-    pub fn seed_warming_state(&mut self, state: post_exec::WarmingState) {
+    /// Seed refund state captured from a prior subblock.
+    pub fn seed_warming_state(&mut self, state: R::Snapshot) {
         self.inner.0.inspector.seed_warming_state(state);
     }
 }
 
-impl<DB: Database, I, P, Tx> post_exec::PostExecEvm for OpEvm<DB, I, P, Tx>
+impl<DB: Database, I, P, Tx, R> post_exec::PostExecEvm for OpEvm<DB, I, P, Tx, R>
 where
     Self: Evm,
+    R: post_exec::PostExecRefundInspector,
 {
+    type Snapshot = R::Snapshot;
+
     fn begin_post_exec_tx(&mut self, ctx: post_exec::PostExecTxContext) {
         Self::begin_post_exec_tx(self, ctx);
     }
@@ -187,11 +230,11 @@ where
         Self::take_last_post_exec_tx_result(self)
     }
 
-    fn warming_state(&self) -> post_exec::WarmingState {
+    fn warming_state(&self) -> Self::Snapshot {
         Self::warming_state(self)
     }
 
-    fn seed_warming_state(&mut self, state: post_exec::WarmingState) {
+    fn seed_warming_state(&mut self, state: Self::Snapshot) {
         Self::seed_warming_state(self, state);
     }
 }
@@ -200,6 +243,10 @@ impl<Tx> post_exec::PostExecEvmFactoryHooks for OpEvmFactory<Tx>
 where
     Tx: IntoTxEnv<Tx> + Into<OpTransaction<TxEnv>> + Default + Clone + Debug,
 {
+    // The factory fixes the EVM's default refund inspector (`SDMWarmingInspector`), whose
+    // carry-forward state is `WarmingState`.
+    type Snapshot = post_exec::WarmingState;
+
     fn begin_post_exec_tx<DB, I>(evm: &mut Self::Evm<DB, I>, ctx: post_exec::PostExecTxContext)
     where
         DB: Database,
@@ -218,7 +265,7 @@ where
         evm.take_last_post_exec_tx_result()
     }
 
-    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> post_exec::WarmingState
+    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,
@@ -226,7 +273,7 @@ where
         evm.warming_state()
     }
 
-    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: post_exec::WarmingState)
+    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,
@@ -235,7 +282,7 @@ where
     }
 }
 
-impl<DB: Database, I, P, Tx> Deref for OpEvm<DB, I, P, Tx> {
+impl<DB: Database, I, P, Tx, R> Deref for OpEvm<DB, I, P, Tx, R> {
     type Target = OpEvmContext<DB>;
 
     #[inline]
@@ -244,19 +291,20 @@ impl<DB: Database, I, P, Tx> Deref for OpEvm<DB, I, P, Tx> {
     }
 }
 
-impl<DB: Database, I, P, Tx> DerefMut for OpEvm<DB, I, P, Tx> {
+impl<DB: Database, I, P, Tx, R> DerefMut for OpEvm<DB, I, P, Tx, R> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.ctx_mut()
     }
 }
 
-impl<DB, I, P, Tx> Evm for OpEvm<DB, I, P, Tx>
+impl<DB, I, P, Tx, R> Evm for OpEvm<DB, I, P, Tx, R>
 where
     DB: Database,
     I: Inspector<OpEvmContext<DB>>,
     P: PrecompileProvider<OpEvmContext<DB>, Output = InterpreterResult>,
     Tx: IntoTxEnv<Tx> + Into<OpTransaction<TxEnv>>,
+    R: Inspector<OpEvmContext<DB>> + post_exec::PostExecRefundInspector,
 {
     type DB = DB;
     type Tx = Tx;
@@ -386,20 +434,7 @@ where
         db: DB,
         input: EvmEnv<OpSpecId, BlockEnv>,
     ) -> Self::Evm<DB, NoOpInspector> {
-        let spec_id = input.cfg_env.spec;
-        let inner = Context::mainnet()
-            .with_tx(OpTx(OpTransaction::builder().build_fill()))
-            .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
-            .with_chain(L1BlockInfo::default())
-            .with_db(db)
-            .with_block(input.block_env)
-            .with_cfg(input.cfg_env)
-            .build_op_with_inspector(NoOpInspector {})
-            .with_precompiles(PrecompilesMap::from_static(
-                OpPrecompiles::new_with_spec(spec_id).precompiles(),
-            ));
-
-        OpEvm::new(inner, false)
+        OpEvm::from_env(db, input, NoOpInspector {}, false)
     }
 
     fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
@@ -408,20 +443,7 @@ where
         input: EvmEnv<OpSpecId, BlockEnv>,
         inspector: I,
     ) -> Self::Evm<DB, I> {
-        let spec_id = input.cfg_env.spec;
-        let inner = Context::mainnet()
-            .with_tx(OpTx(OpTransaction::builder().build_fill()))
-            .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
-            .with_chain(L1BlockInfo::default())
-            .with_db(db)
-            .with_block(input.block_env)
-            .with_cfg(input.cfg_env)
-            .build_op_with_inspector(inspector)
-            .with_precompiles(PrecompilesMap::from_static(
-                OpPrecompiles::new_with_spec(spec_id).precompiles(),
-            ));
-
-        OpEvm::new(inner, true)
+        OpEvm::from_env(db, input, inspector, true)
     }
 }
 

--- a/rust/alloy-op-evm/src/post_exec/inspector.rs
+++ b/rust/alloy-op-evm/src/post_exec/inspector.rs
@@ -60,7 +60,11 @@ pub enum PostExecTxKind {
 }
 
 impl PostExecTxKind {
-    const fn claims_refunds(self) -> bool {
+    /// Whether a transaction of this kind may claim post-exec refunds.
+    ///
+    /// Only a [`Normal`](Self::Normal) transaction claims. Deposits and the trailing post-exec
+    /// transaction only warm state. External producer policies can reuse this classification.
+    pub const fn claims_refunds(self) -> bool {
         matches!(self, Self::Normal)
     }
 }
@@ -77,9 +81,9 @@ pub struct PostExecTxContext {
 /// Extracted result for the most recently executed transaction.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PostExecExecutedTx {
-    /// Total refund for the tx.
+    /// Consensus-facing total refund for the tx.
     pub refund_total: u64,
-    /// Exact attribution events for the tx.
+    /// Optional diagnostic attribution events for the tx.
     pub refund_events: Vec<WarmingRefundEvent>,
 }
 
@@ -146,14 +150,9 @@ impl CurrentTxState {
 
 /// Block-scoped warming provenance snapshotted from an [`SDMWarmingInspector`].
 ///
-/// SDM warming refunds are *block*-scoped: once a tx warms an account/slot, a later tx's touch of
-/// the same account/slot becomes refundable. A builder that executes a block across several
-/// independent flashblock executors (each with its own fresh inspector) would otherwise reset this
-/// warming at every flashblock boundary and diverge from a single canonical pass. Carrying this
-/// state from one flashblock's inspector into the next (via [`SDMWarmingInspector::warming_state`]
-/// and [`SDMWarmingInspector::seed_warming_state`]) keeps the per-flashblock refund set identical
-/// to whole-block execution. The carried provenance only feeds attribution events, so its
-/// flashblock-local tx indices do not affect the consensus `SDMGasEntry` set.
+/// Warming refunds are block-scoped. Carrying this state between subblock inspectors makes their
+/// refunds match one canonical execution. Provenance only feeds diagnostics; subblock-local
+/// transaction indices do not affect the consensus `SDMGasEntry` set.
 #[derive(Debug, Clone, Default)]
 pub struct WarmingState {
     /// Account -> index of the tx that first warmed it.
@@ -333,6 +332,31 @@ impl SDMWarmingInspector {
     }
 }
 
+impl super::PostExecRefundInspector for SDMWarmingInspector {
+    type Snapshot = WarmingState;
+
+    fn begin_tx(&mut self, ctx: PostExecTxContext) {
+        self.current_tx.begin(ctx);
+    }
+
+    fn note_account_touch(&mut self, address: Address) {
+        self.observe_account_touch(address, false);
+    }
+
+    #[allow(clippy::use_self)] // Explicitly delegate to the inherent method, not this trait method.
+    fn finish_tx(&mut self) -> PostExecExecutedTx {
+        SDMWarmingInspector::finish_tx(self)
+    }
+
+    fn snapshot(&self) -> WarmingState {
+        self.warming_state()
+    }
+
+    fn restore(&mut self, snapshot: WarmingState) {
+        self.seed_warming_state(snapshot);
+    }
+}
+
 impl<CTX> Inspector<CTX> for SDMWarmingInspector
 where
     CTX: ContextTr<Journal: JournalExt>,
@@ -392,6 +416,11 @@ where
         let caller = inputs.caller();
         self.observe_account_touch(caller, true);
 
+        // `CreateInputs::created_address` memoizes its result (`OnceCell`): the canonical create
+        // frame computes and caches the address from the *pre-bump* creator nonce before this hook
+        // runs, so the value below is the correct created address regardless of the nonce we pass.
+        // The journal-nonce read is only a best-effort fallback for the (currently unreached) case
+        // where the cache is not yet populated; it cannot make the recorded address stale.
         let created_address = match inputs.scheme() {
             CreateScheme::Create => {
                 let nonce = context
@@ -428,20 +457,26 @@ where
     }
 }
 
-/// Composite inspector that always includes the [`SDMWarmingInspector`] alongside a
-/// caller-provided inner inspector, fanning every hook to both.
+/// Composite inspector that always includes a refund inspector `R` alongside a caller-provided
+/// inner inspector `I`, fanning every hook to both.
+///
+/// `R` is fixed by the EVM factory (it defaults to [`SDMWarmingInspector`]); the always-present
+/// refund inspector is what lets `OpEvm<DB, I, R>` expose post-exec hooks for *any* user inspector
+/// `I` — as `alloy_evm`'s `BlockExecutorFactory` requires.
 #[derive(Debug, Clone)]
-pub struct PostExecCompositeInspector<I> {
+pub struct PostExecCompositeInspector<I, R = SDMWarmingInspector> {
     inner: I,
-    post_exec: SDMWarmingInspector,
+    post_exec: R,
 }
 
-impl<I> PostExecCompositeInspector<I> {
-    /// Creates a new composite inspector.
+impl<I, R: Default> PostExecCompositeInspector<I, R> {
+    /// Creates a new composite inspector with a default-constructed refund inspector.
     pub fn new(inner: I) -> Self {
-        Self { inner, post_exec: SDMWarmingInspector::default() }
+        Self { inner, post_exec: R::default() }
     }
+}
 
+impl<I, R> PostExecCompositeInspector<I, R> {
     /// Returns the wrapped user inspector.
     pub const fn inner(&self) -> &I {
         &self.inner
@@ -456,20 +491,22 @@ impl<I> PostExecCompositeInspector<I> {
     pub fn into_inner(self) -> I {
         self.inner
     }
+}
 
+impl<I, R: super::PostExecRefundInspector> PostExecCompositeInspector<I, R> {
     /// Begin tracking the next transaction.
     pub fn begin_post_exec_tx(&mut self, ctx: PostExecTxContext) {
         self.post_exec.begin_tx(ctx);
     }
 
-    /// Snapshots the block-scoped warming state for carry-forward across flashblock executors.
-    pub fn warming_state(&self) -> WarmingState {
-        self.post_exec.warming_state()
+    /// Snapshot refund state to carry across subblock executors.
+    pub fn warming_state(&self) -> R::Snapshot {
+        self.post_exec.snapshot()
     }
 
-    /// Seeds the block-scoped warming state captured from a prior flashblock's inspector.
-    pub fn seed_warming_state(&mut self, state: WarmingState) {
-        self.post_exec.seed_warming_state(state);
+    /// Seed refund state captured from a prior subblock.
+    pub fn seed_warming_state(&mut self, state: R::Snapshot) {
+        self.post_exec.restore(state);
     }
 
     /// Notes an account touch that happened outside opcode stepping.
@@ -483,11 +520,11 @@ impl<I> PostExecCompositeInspector<I> {
     }
 }
 
-impl<CTX, INTR, I> Inspector<CTX, INTR> for PostExecCompositeInspector<I>
+impl<CTX, INTR, I, R> Inspector<CTX, INTR> for PostExecCompositeInspector<I, R>
 where
     INTR: revm::interpreter::InterpreterTypes,
     I: Inspector<CTX, INTR>,
-    SDMWarmingInspector: Inspector<CTX, INTR>,
+    R: Inspector<CTX, INTR>,
 {
     fn initialize_interp(&mut self, interp: &mut Interpreter<INTR>, context: &mut CTX) {
         self.inner.initialize_interp(interp, context);
@@ -530,10 +567,7 @@ where
         // outcome, so inner's return value is authoritative.
         let inner = self.inner.call(context, inputs);
         let post_exec = self.post_exec.call(context, inputs);
-        debug_assert!(
-            post_exec.is_none(),
-            "SDMWarmingInspector must not synthesize a call outcome",
-        );
+        debug_assert!(post_exec.is_none(), "refund inspector must not synthesize a call outcome",);
         inner
     }
 
@@ -555,10 +589,7 @@ where
         // See `call` above: always observe; inner's outcome wins.
         let inner = self.inner.create(context, inputs);
         let post_exec = self.post_exec.create(context, inputs);
-        debug_assert!(
-            post_exec.is_none(),
-            "SDMWarmingInspector must not synthesize a create outcome",
-        );
+        debug_assert!(post_exec.is_none(), "refund inspector must not synthesize a create outcome",);
         inner
     }
 

--- a/rust/alloy-op-evm/src/post_exec/inspector.rs
+++ b/rust/alloy-op-evm/src/post_exec/inspector.rs
@@ -500,12 +500,12 @@ impl<I, R: super::PostExecRefundInspector> PostExecCompositeInspector<I, R> {
     }
 
     /// Snapshot refund state to carry across subblock executors.
-    pub fn warming_state(&self) -> R::Snapshot {
+    pub fn refund_snapshot(&self) -> R::Snapshot {
         self.post_exec.snapshot()
     }
 
     /// Seed refund state captured from a prior subblock.
-    pub fn seed_warming_state(&mut self, state: R::Snapshot) {
+    pub fn seed_refund_snapshot(&mut self, state: R::Snapshot) {
         self.post_exec.restore(state);
     }
 

--- a/rust/alloy-op-evm/src/post_exec/mod.rs
+++ b/rust/alloy-op-evm/src/post_exec/mod.rs
@@ -1,6 +1,9 @@
 //! Post-exec execution extensions.
 
 mod inspector;
+mod refund;
+
+pub use refund::PostExecRefundInspector;
 
 use alloc::vec::Vec;
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory};
@@ -20,26 +23,30 @@ use crate::block::{OpBlockExecutor, receipt_builder::OpReceiptBuilder};
 
 /// Extension trait for EVMs that can track post-exec per-transaction warming results.
 pub trait PostExecEvm: alloy_evm::Evm {
+    /// Opaque block-scoped refund state.
+    type Snapshot: Clone;
+
     /// Begin post-exec tracking for the next transaction.
     fn begin_post_exec_tx(&mut self, ctx: PostExecTxContext);
 
     /// Take the extracted post-exec result for the most recently executed transaction.
     fn take_last_post_exec_tx_result(&mut self) -> PostExecExecutedTx;
 
-    /// Snapshot the block-scoped warming state for carry-forward across flashblock executors.
-    fn warming_state(&self) -> WarmingState;
+    /// Snapshot refund state to carry across subblock executors.
+    fn warming_state(&self) -> Self::Snapshot;
 
-    /// Seed the block-scoped warming state captured from a prior flashblock's executor.
-    fn seed_warming_state(&mut self, state: WarmingState);
+    /// Seed refund state captured from a prior subblock.
+    fn seed_warming_state(&mut self, state: Self::Snapshot);
 }
 
 /// Extension trait for EVM factories whose produced EVMs support post-exec tracking.
 ///
-/// This bridges generic custom [`EvmFactory`] implementations into the concrete [`PostExecEvm`]
-/// bound used by the OP block executor. The adapter keeps post-exec capability explicit on the EVM
-/// itself without requiring the compiler to prove that every `EvmFactory::Evm<DB, I>` associated
-/// type directly implements [`PostExecEvm`].
+/// This exposes factory hooks through [`PostExecEvm`] without constraining every generic EVM
+/// associated type directly.
 pub trait PostExecEvmFactoryHooks: EvmFactory {
+    /// Opaque block-scoped refund state produced by this factory.
+    type Snapshot: Clone;
+
     /// Begin post-exec tracking for the next transaction.
     fn begin_post_exec_tx<DB, I>(evm: &mut Self::Evm<DB, I>, ctx: PostExecTxContext)
     where
@@ -52,14 +59,14 @@ pub trait PostExecEvmFactoryHooks: EvmFactory {
         DB: Database,
         I: Inspector<Self::Context<DB>>;
 
-    /// Snapshot the block-scoped warming state for carry-forward across flashblock executors.
-    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> WarmingState
+    /// Snapshot refund state to carry across subblock executors.
+    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>;
 
-    /// Seed the block-scoped warming state captured from a prior flashblock's executor.
-    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: WarmingState)
+    /// Seed refund state captured from a prior subblock.
+    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>;
@@ -164,6 +171,8 @@ where
     DB: Database,
     I: Inspector<F::Context<DB>>,
 {
+    type Snapshot = F::Snapshot;
+
     fn begin_post_exec_tx(&mut self, ctx: PostExecTxContext) {
         F::begin_post_exec_tx(&mut self.inner, ctx);
     }
@@ -172,11 +181,11 @@ where
         F::take_last_post_exec_tx_result(&mut self.inner)
     }
 
-    fn warming_state(&self) -> WarmingState {
+    fn warming_state(&self) -> Self::Snapshot {
         F::warming_state(&self.inner)
     }
 
-    fn seed_warming_state(&mut self, state: WarmingState) {
+    fn seed_warming_state(&mut self, state: Self::Snapshot) {
         F::seed_warming_state(&mut self.inner, state);
     }
 }
@@ -244,6 +253,9 @@ where
 
 /// Extension trait for block executors that collect post-exec payload entries.
 pub trait PostExecExecutorExt {
+    /// Opaque block-scoped refund state.
+    type Snapshot: Clone;
+
     /// Returns the accumulated post-exec entries for the current block without clearing them.
     fn post_exec_entries(&self) -> &[SDMGasEntry];
 
@@ -253,11 +265,11 @@ pub trait PostExecExecutorExt {
     /// Take the exact per-transaction warming refund attribution events aligned with receipts.
     fn take_warming_events_by_tx(&mut self) -> Vec<Vec<WarmingRefundEvent>>;
 
-    /// Snapshot the block-scoped warming state for carry-forward across flashblock executors.
-    fn warming_state(&self) -> WarmingState;
+    /// Snapshot refund state to carry across subblock executors.
+    fn warming_state(&self) -> Self::Snapshot;
 
-    /// Seed the block-scoped warming state captured from a prior flashblock's executor.
-    fn seed_warming_state(&mut self, state: WarmingState);
+    /// Seed refund state captured from a prior subblock.
+    fn seed_warming_state(&mut self, state: Self::Snapshot);
 }
 
 impl<E, R, Spec> PostExecExecutorExt for OpBlockExecutor<E, R, Spec>
@@ -266,6 +278,8 @@ where
     R: OpReceiptBuilder,
     Spec: alloy_op_hardforks::OpHardforks + Clone,
 {
+    type Snapshot = E::Snapshot;
+
     fn post_exec_entries(&self) -> &[SDMGasEntry] {
         Self::post_exec_entries(self)
     }
@@ -278,11 +292,11 @@ where
         Self::take_warming_events_by_tx(self)
     }
 
-    fn warming_state(&self) -> WarmingState {
+    fn warming_state(&self) -> Self::Snapshot {
         Self::warming_state(self)
     }
 
-    fn seed_warming_state(&mut self, state: WarmingState) {
+    fn seed_warming_state(&mut self, state: Self::Snapshot) {
         Self::seed_warming_state(self, state);
     }
 }

--- a/rust/alloy-op-evm/src/post_exec/mod.rs
+++ b/rust/alloy-op-evm/src/post_exec/mod.rs
@@ -33,10 +33,10 @@ pub trait PostExecEvm: alloy_evm::Evm {
     fn take_last_post_exec_tx_result(&mut self) -> PostExecExecutedTx;
 
     /// Snapshot refund state to carry across subblock executors.
-    fn warming_state(&self) -> Self::Snapshot;
+    fn refund_snapshot(&self) -> Self::Snapshot;
 
     /// Seed refund state captured from a prior subblock.
-    fn seed_warming_state(&mut self, state: Self::Snapshot);
+    fn seed_refund_snapshot(&mut self, state: Self::Snapshot);
 }
 
 /// Extension trait for EVM factories whose produced EVMs support post-exec tracking.
@@ -60,13 +60,13 @@ pub trait PostExecEvmFactoryHooks: EvmFactory {
         I: Inspector<Self::Context<DB>>;
 
     /// Snapshot refund state to carry across subblock executors.
-    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
+    fn refund_snapshot<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>;
 
     /// Seed refund state captured from a prior subblock.
-    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
+    fn seed_refund_snapshot<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>;
@@ -181,12 +181,12 @@ where
         F::take_last_post_exec_tx_result(&mut self.inner)
     }
 
-    fn warming_state(&self) -> Self::Snapshot {
-        F::warming_state(&self.inner)
+    fn refund_snapshot(&self) -> Self::Snapshot {
+        F::refund_snapshot(&self.inner)
     }
 
-    fn seed_warming_state(&mut self, state: Self::Snapshot) {
-        F::seed_warming_state(&mut self.inner, state);
+    fn seed_refund_snapshot(&mut self, state: Self::Snapshot) {
+        F::seed_refund_snapshot(&mut self.inner, state);
     }
 }
 
@@ -266,10 +266,10 @@ pub trait PostExecExecutorExt {
     fn take_warming_events_by_tx(&mut self) -> Vec<Vec<WarmingRefundEvent>>;
 
     /// Snapshot refund state to carry across subblock executors.
-    fn warming_state(&self) -> Self::Snapshot;
+    fn refund_snapshot(&self) -> Self::Snapshot;
 
     /// Seed refund state captured from a prior subblock.
-    fn seed_warming_state(&mut self, state: Self::Snapshot);
+    fn seed_refund_snapshot(&mut self, state: Self::Snapshot);
 }
 
 impl<E, R, Spec> PostExecExecutorExt for OpBlockExecutor<E, R, Spec>
@@ -292,11 +292,11 @@ where
         Self::take_warming_events_by_tx(self)
     }
 
-    fn warming_state(&self) -> Self::Snapshot {
-        Self::warming_state(self)
+    fn refund_snapshot(&self) -> Self::Snapshot {
+        Self::refund_snapshot(self)
     }
 
-    fn seed_warming_state(&mut self, state: Self::Snapshot) {
-        Self::seed_warming_state(self, state);
+    fn seed_refund_snapshot(&mut self, state: Self::Snapshot) {
+        Self::seed_refund_snapshot(self, state);
     }
 }

--- a/rust/alloy-op-evm/src/post_exec/refund.rs
+++ b/rust/alloy-op-evm/src/post_exec/refund.rs
@@ -18,9 +18,24 @@ use super::{PostExecExecutedTx, PostExecTxContext};
 ///
 /// **Not consensus.** The executor reads [`PostExecExecutedTx::refund_total`] via
 /// [`finish_tx`](Self::finish_tx) and bounds it by the structural `refund <= evm_gas_used` rule —
-/// it never observes how the refund was computed. A buggy or proprietary producer can therefore
-/// only ever yield an *economically* different refund, never an *invalid* block.
+/// it never observes how the refund was computed. Verifiers run the default inspector and discard
+/// its refund, so a proprietary producer policy can never make a verifier accept an *invalid*
+/// block. It can, however, produce a *self-rejecting* block: the seam requires the implementor to
+/// be side-effect-free w.r.t. EVM state (see the [`Inspector`](revm::Inspector) rule below); a
+/// violation just fails the producer's own block, never verifier acceptance.
 /// [`PostExecExecutedTx::refund_events`] are optional diagnostics and may be empty.
+///
+/// # Implementor contract
+/// - [`finish_tx`](Self::finish_tx) is called exactly once per [`begin_tx`](Self::begin_tx),
+///   **including when the EVM call itself errors** (`transact_raw` runs its finish block before
+///   propagating). Implementors must tolerate finishing a failed tx.
+/// - [`begin_tx`](Self::begin_tx) must fully reset per-transaction state.
+///   [`snapshot`](Self::snapshot)/[`restore`](Self::restore) only cover block-scoped carry-forward,
+///   so a failed or declined candidate relies on the next `begin_tx` for per-tx cleanup.
+/// - The implementor's [`Inspector`](revm::Inspector) impl must never synthesize call/create
+///   outcomes and must not mutate EVM state (enforced in debug builds by `debug_assert!`s in
+///   `PostExecCompositeInspector`). A non-observing implementor can satisfy the `Inspector` bound
+///   with an empty impl.
 pub trait PostExecRefundInspector {
     /// Opaque block-scoped state carried across subblocks and candidate rollback.
     type Snapshot: Clone;

--- a/rust/alloy-op-evm/src/post_exec/refund.rs
+++ b/rust/alloy-op-evm/src/post_exec/refund.rs
@@ -1,0 +1,46 @@
+//! The producer-side refund inspector contract.
+//!
+//! The seam between consensus and producer refund strategy. The block executor consumes
+//! [`PostExecExecutedTx::refund_total`]; refund events are optional diagnostics. Verification,
+//! settlement, and the `0x7D` consensus type never run a refund inspector.
+
+use alloy_primitives::Address;
+
+use super::{PostExecExecutedTx, PostExecTxContext};
+
+/// Per-transaction refund source, installed as the EVM's post-exec inspector during block
+/// production.
+///
+/// An implementor is also a [`revm::Inspector`] (it observes execution to compute the refund), but
+/// that bound is applied at the EVM construction site rather than as a supertrait here: the refund
+/// methods below are context-free, so requiring `Inspector<CTX>` on the trait would make them
+/// uncallable from the EVM's context-free post-exec hooks.
+///
+/// **Not consensus.** The executor reads [`PostExecExecutedTx::refund_total`] via
+/// [`finish_tx`](Self::finish_tx) and bounds it by the structural `refund <= evm_gas_used` rule —
+/// it never observes how the refund was computed. A buggy or proprietary producer can therefore
+/// only ever yield an *economically* different refund, never an *invalid* block.
+/// [`PostExecExecutedTx::refund_events`] are optional diagnostics and may be empty.
+pub trait PostExecRefundInspector {
+    /// Opaque block-scoped state carried across subblocks and candidate rollback.
+    type Snapshot: Clone;
+
+    /// Begin observing the next transaction.
+    fn begin_tx(&mut self, ctx: PostExecTxContext);
+
+    /// Record a protocol-level account touch (e.g. the per-tx fee-vault settlement write) that
+    /// happens outside opcode stepping. The current tx never claims a refund for it, but recording
+    /// it lets a *later* tx that genuinely accesses the account via an opcode earn its rebate.
+    fn note_account_touch(&mut self, address: Address);
+
+    /// Finish the current transaction. The result's aggregate refund is consensus-facing; its
+    /// attribution events are optional diagnostics.
+    fn finish_tx(&mut self) -> PostExecExecutedTx;
+
+    /// Snapshot the block-scoped carry-forward state.
+    fn snapshot(&self) -> Self::Snapshot;
+
+    /// Restore block-scoped carry-forward state previously captured by
+    /// [`snapshot`](Self::snapshot).
+    fn restore(&mut self, snapshot: Self::Snapshot);
+}

--- a/rust/kona/bin/client/src/fpvm_evm/factory.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/factory.rs
@@ -67,20 +67,20 @@ where
         evm.take_last_post_exec_tx_result()
     }
 
-    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
+    fn refund_snapshot<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,
     {
-        evm.warming_state()
+        evm.refund_snapshot()
     }
 
-    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
+    fn seed_refund_snapshot<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,
     {
-        evm.seed_warming_state(state);
+        evm.seed_refund_snapshot(state);
     }
 }
 

--- a/rust/kona/bin/client/src/fpvm_evm/factory.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/factory.rs
@@ -49,6 +49,8 @@ where
     H: HintWriterClient + Clone + Send + Sync + 'static,
     O: PreimageOracleClient + Clone + Send + Sync + 'static,
 {
+    type Snapshot = WarmingState;
+
     fn begin_post_exec_tx<DB, I>(evm: &mut Self::Evm<DB, I>, ctx: PostExecTxContext)
     where
         DB: Database,
@@ -65,7 +67,7 @@ where
         evm.take_last_post_exec_tx_result()
     }
 
-    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> WarmingState
+    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,
@@ -73,7 +75,7 @@ where
         evm.warming_state()
     }
 
-    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: WarmingState)
+    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,

--- a/rust/kona/sp1/crates/client/src/precompiles/factory.rs
+++ b/rust/kona/sp1/crates/client/src/precompiles/factory.rs
@@ -36,20 +36,20 @@ impl PostExecEvmFactoryHooks for ZkvmOpEvmFactory {
         evm.take_last_post_exec_tx_result()
     }
 
-    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
+    fn refund_snapshot<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,
     {
-        evm.warming_state()
+        evm.refund_snapshot()
     }
 
-    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
+    fn seed_refund_snapshot<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,
     {
-        evm.seed_warming_state(state);
+        evm.seed_refund_snapshot(state);
     }
 }
 

--- a/rust/kona/sp1/crates/client/src/precompiles/factory.rs
+++ b/rust/kona/sp1/crates/client/src/precompiles/factory.rs
@@ -18,6 +18,8 @@ use revm::{
 pub struct ZkvmOpEvmFactory;
 
 impl PostExecEvmFactoryHooks for ZkvmOpEvmFactory {
+    type Snapshot = WarmingState;
+
     fn begin_post_exec_tx<DB, I>(evm: &mut Self::Evm<DB, I>, ctx: PostExecTxContext)
     where
         DB: Database,
@@ -34,7 +36,7 @@ impl PostExecEvmFactoryHooks for ZkvmOpEvmFactory {
         evm.take_last_post_exec_tx_result()
     }
 
-    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> WarmingState
+    fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,
@@ -42,7 +44,7 @@ impl PostExecEvmFactoryHooks for ZkvmOpEvmFactory {
         evm.warming_state()
     }
 
-    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: WarmingState)
+    fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
     where
         DB: Database,
         I: Inspector<Self::Context<DB>>,

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/context.rs
@@ -20,6 +20,7 @@ use reth_node_api::PayloadBuilderError;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::{
     ConfigurePostExecEvm, OpEvmConfig, OpNextBlockEnvAttributes, PostExecExecutorExt, PostExecMode,
+    WarmingState,
 };
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::OpPayloadBuilderAttributes;
@@ -344,7 +345,7 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
     ) -> Result<
         impl BlockBuilder<
             Primitives = reth_optimism_primitives::OpPrimitives,
-            Executor: PostExecExecutorExt
+            Executor: PostExecExecutorExt<Snapshot = WarmingState>
                           + AlloyBlockExecutor<
                 Transaction = OpTransactionSigned,
                 Receipt = OpReceipt,

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -445,7 +445,7 @@ where
             info.extra.post_exec_entries = post_exec_entries;
             // Carry the base block's warming provenance (deposits + builder tx) into the first
             // flashblock executor; subsequent flashblocks chain off this in build_next_flashblock.
-            info.extra.warming_state = builder.executor().warming_state();
+            info.extra.warming_state = builder.executor().refund_snapshot();
 
             (info, payload, fb_payload)
         };
@@ -706,7 +706,7 @@ where
         // from op-reth's single canonical pass. Recaptured after the build below.
         builder
             .executor_mut()
-            .seed_warming_state(core::mem::take(&mut info.extra.warming_state));
+            .seed_refund_snapshot(core::mem::take(&mut info.extra.warming_state));
         let mut target_gas_for_batch = ctx.extra_ctx.target_gas_for_batch;
         let mut target_da_for_batch = ctx.extra_ctx.target_da_for_batch;
         let mut target_da_footprint_for_batch = ctx.extra_ctx.target_da_footprint_for_batch;
@@ -856,7 +856,7 @@ where
             Ok((new_payload, mut fb_payload)) => {
                 info.extra.post_exec_entries = post_exec_entries;
                 // Carry this flashblock's accumulated warming provenance into the next flashblock.
-                info.extra.warming_state = builder.executor().warming_state();
+                info.extra.warming_state = builder.executor().refund_snapshot();
                 fb_payload.index = flashblock_index;
                 fb_payload.base = None;
 
@@ -1143,7 +1143,7 @@ fn current_post_exec_entries<Builder>(
 ) -> Vec<SDMGasEntry>
 where
     Builder: BlockBuilder,
-    Builder::Executor: PostExecExecutorExt<Snapshot = WarmingState>,
+    Builder::Executor: PostExecExecutorExt,
 {
     offset_post_exec_entries(
         &info.extra.post_exec_entries,

--- a/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/rust/op-rbuilder/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -689,7 +689,7 @@ where
     where
         Builder:
             reth_evm::execute::BlockBuilder<Primitives = reth_optimism_primitives::OpPrimitives>,
-        Builder::Executor: PostExecExecutorExt
+        Builder::Executor: PostExecExecutorExt<Snapshot = WarmingState>
             + AlloyBlockExecutor<
                 Transaction = OpTransactionSigned,
                 Receipt = OpReceipt,
@@ -1143,7 +1143,7 @@ fn current_post_exec_entries<Builder>(
 ) -> Vec<SDMGasEntry>
 where
     Builder: BlockBuilder,
-    Builder::Executor: PostExecExecutorExt,
+    Builder::Executor: PostExecExecutorExt<Snapshot = WarmingState>,
 {
     offset_post_exec_entries(
         &info.extra.post_exec_entries,
@@ -1231,7 +1231,7 @@ fn execute_pre_steps<'a, DB, ExtraCtx>(
     (
         impl reth_evm::execute::BlockBuilder<
             Primitives = reth_optimism_primitives::OpPrimitives,
-            Executor: PostExecExecutorExt
+            Executor: PostExecExecutorExt<Snapshot = WarmingState>
                           + AlloyBlockExecutor<
                 Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
                 Result: PreRefundGasUsed,

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -110,20 +110,27 @@ impl<ChainSpec: EthChainSpec<Header = Header> + OpHardforks> OpEvmConfig<ChainSp
     }
 }
 
+impl<ChainSpec, N: NodePrimitives, R, EvmFactory> OpEvmConfig<ChainSpec, N, R, EvmFactory> {
+    /// Creates a new [`OpEvmConfig`] with an explicit EVM factory.
+    pub fn new_with_evm_factory(
+        chain_spec: Arc<ChainSpec>,
+        receipt_builder: R,
+        evm_factory: EvmFactory,
+    ) -> Self {
+        Self {
+            block_assembler: OpBlockAssembler::new(chain_spec.clone()),
+            executor_factory: OpBlockExecutorFactory::new(receipt_builder, chain_spec, evm_factory),
+            _pd: core::marker::PhantomData,
+        }
+    }
+}
+
 impl<ChainSpec: EthChainSpec<Header = Header> + OpHardforks, N: NodePrimitives, R>
     OpEvmConfig<ChainSpec, N, R>
 {
     /// Creates a new [`OpEvmConfig`] with the given chain spec.
     pub fn new(chain_spec: Arc<ChainSpec>, receipt_builder: R) -> Self {
-        Self {
-            block_assembler: OpBlockAssembler::new(chain_spec.clone()),
-            executor_factory: OpBlockExecutorFactory::new(
-                receipt_builder,
-                chain_spec,
-                OpEvmFactory::<OpTx>::default(),
-            ),
-            _pd: core::marker::PhantomData,
-        }
+        Self::new_with_evm_factory(chain_spec, receipt_builder, OpEvmFactory::<OpTx>::default())
     }
 }
 

--- a/rust/op-reth/crates/evm/src/post_exec_ext.rs
+++ b/rust/op-reth/crates/evm/src/post_exec_ext.rs
@@ -4,7 +4,9 @@ use alloy_evm::{FromRecoveredTx, FromTxWithEncoded, block::BlockExecutor};
 use alloy_op_evm::{
     OpBlockExecutor, PreRefundGasUsed,
     block::{OpTxEnv, receipt_builder::OpReceiptBuilder},
-    post_exec::{PostExecEvmFactoryAdapter, PostExecEvmFactoryHooks, PostExecExecutorExt},
+    post_exec::{
+        PostExecEvmFactoryAdapter, PostExecEvmFactoryHooks, PostExecExecutorExt, WarmingState,
+    },
 };
 use core::fmt::Debug;
 use op_alloy_consensus::OpTransaction as OpConsensusTransaction;
@@ -23,7 +25,13 @@ use revm::{context::BlockEnv, database::State};
 use crate::{OpBlockExecutorFactory, OpEvmConfig, OpEvmFactory, OpTx, PostExecMode};
 
 /// Optimism-specific EVM helpers that expose post-exec-aware executors and builders.
+#[allow(clippy::type_complexity)]
 pub trait ConfigurePostExecEvm: ConfigureEvm {
+    /// Opaque block-scoped carry-forward state of the refund inspector the produced executors run.
+    /// Matches [`PostExecExecutorExt::Snapshot`] of those executors (it is [`WarmingState`] for the
+    /// default [`SDMWarmingInspector`](alloy_op_evm::post_exec::SDMWarmingInspector)).
+    type Snapshot: Clone;
+
     /// Returns a block executor for the given block with explicit post-exec entry access.
     ///
     /// # Errors
@@ -38,7 +46,7 @@ pub trait ConfigurePostExecEvm: ConfigureEvm {
         impl BlockExecutor<
             Transaction = <Self::Primitives as NodePrimitives>::SignedTx,
             Receipt = <Self::Primitives as NodePrimitives>::Receipt,
-        > + PostExecExecutorExt
+        > + PostExecExecutorExt<Snapshot = Self::Snapshot>
         + 'a,
         Self::Error,
     >;
@@ -57,7 +65,7 @@ pub trait ConfigurePostExecEvm: ConfigureEvm {
     ) -> Result<
         impl BlockBuilder<
             Primitives = Self::Primitives,
-            Executor: PostExecExecutorExt
+            Executor: PostExecExecutorExt<Snapshot = Self::Snapshot>
                           + BlockExecutor<
                 Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
                 Result: PreRefundGasUsed,
@@ -88,6 +96,8 @@ where
         + 'static,
     Self: Send + Sync + Unpin + Clone + 'static,
 {
+    type Snapshot = WarmingState;
+
     fn post_exec_executor_for_block<'a, DB: Database>(
         &'a self,
         db: &'a mut State<DB>,
@@ -97,7 +107,7 @@ where
         impl BlockExecutor<
             Transaction = <Self::Primitives as NodePrimitives>::SignedTx,
             Receipt = <Self::Primitives as NodePrimitives>::Receipt,
-        > + PostExecExecutorExt
+        > + PostExecExecutorExt<Snapshot = Self::Snapshot>
         + 'a,
         Self::Error,
     > {
@@ -121,7 +131,7 @@ where
     ) -> Result<
         impl BlockBuilder<
             Primitives = Self::Primitives,
-            Executor: PostExecExecutorExt
+            Executor: PostExecExecutorExt<Snapshot = Self::Snapshot>
                           + BlockExecutor<
                 Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
                 Result: PreRefundGasUsed,
@@ -192,6 +202,8 @@ where
         + 'static,
     Self: Send + Sync + Unpin + Clone + 'static,
 {
+    type Snapshot = F::Snapshot;
+
     fn post_exec_executor_for_block<'a, DB: Database>(
         &'a self,
         db: &'a mut State<DB>,
@@ -201,7 +213,7 @@ where
         impl BlockExecutor<
             Transaction = <Self::Primitives as NodePrimitives>::SignedTx,
             Receipt = <Self::Primitives as NodePrimitives>::Receipt,
-        > + PostExecExecutorExt
+        > + PostExecExecutorExt<Snapshot = Self::Snapshot>
         + 'a,
         Self::Error,
     > {
@@ -225,7 +237,7 @@ where
     ) -> Result<
         impl BlockBuilder<
             Primitives = Self::Primitives,
-            Executor: PostExecExecutorExt
+            Executor: PostExecExecutorExt<Snapshot = Self::Snapshot>
                           + BlockExecutor<
                 Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
                 Result: PreRefundGasUsed,

--- a/rust/op-reth/crates/node/tests/it/builder.rs
+++ b/rust/op-reth/crates/node/tests/it/builder.rs
@@ -150,20 +150,20 @@ fn test_setup_custom_precompiles() {
             evm.take_last_post_exec_tx_result()
         }
 
-        fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
+        fn refund_snapshot<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
         where
             DB: Database,
             I: Inspector<Self::Context<DB>>,
         {
-            evm.warming_state()
+            evm.refund_snapshot()
         }
 
-        fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
+        fn seed_refund_snapshot<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
         where
             DB: Database,
             I: Inspector<Self::Context<DB>>,
         {
-            evm.seed_warming_state(state);
+            evm.seed_refund_snapshot(state);
         }
     }
 

--- a/rust/op-reth/crates/node/tests/it/builder.rs
+++ b/rust/op-reth/crates/node/tests/it/builder.rs
@@ -132,6 +132,8 @@ fn test_setup_custom_precompiles() {
     }
 
     impl PostExecEvmFactoryHooks for UniEvmFactory {
+        type Snapshot = WarmingState;
+
         fn begin_post_exec_tx<DB, I>(evm: &mut Self::Evm<DB, I>, ctx: PostExecTxContext)
         where
             DB: Database,
@@ -148,7 +150,7 @@ fn test_setup_custom_precompiles() {
             evm.take_last_post_exec_tx_result()
         }
 
-        fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> WarmingState
+        fn warming_state<DB, I>(evm: &Self::Evm<DB, I>) -> Self::Snapshot
         where
             DB: Database,
             I: Inspector<Self::Context<DB>>,
@@ -156,7 +158,7 @@ fn test_setup_custom_precompiles() {
             evm.warming_state()
         }
 
-        fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: WarmingState)
+        fn seed_warming_state<DB, I>(evm: &mut Self::Evm<DB, I>, state: Self::Snapshot)
         where
             DB: Database,
             I: Inspector<Self::Context<DB>>,

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -472,7 +472,11 @@ impl<Txs> OpBuilder<'_, Txs> {
         // scalar.
         db.load_cache_account(L1_BLOCK_CONTRACT).map_err(BlockExecutionError::other)?;
 
-        // Snapshot the runtime-mutable mode so EVM setup and `0x7D` appending agree.
+        // Snapshot the post-exec mode once for the whole build. The opt-in flag behind
+        // `sdm_production_enabled` is mutable at runtime (admin RPC); reading it again when
+        // deciding whether to append the `0x7D` below could disagree with the mode the EVM
+        // was built in, yielding a block whose refunded state has no matching post-exec tx
+        // (or vice versa).
         let post_exec_mode = ctx.post_exec_mode()?;
         let produce_post_exec = matches!(post_exec_mode, PostExecMode::Produce);
 
@@ -510,7 +514,9 @@ impl<Txs> OpBuilder<'_, Txs> {
             }
         }
 
-        // Only `Produce` appends `0x7D`; derived blocks verify any embedded tx instead.
+        // Only `Produce` mode appends a post-exec tx, and only locally-sequenced blocks reach it; a
+        // derived block (force_empty) is `Verify`/`Disabled` and already carries its own `0x7D`, so
+        // appending would duplicate it. See `post_exec_mode`.
         let sdm_refund_gas = if produce_post_exec {
             let block_number = builder.evm_mut().block().number().saturating_to();
             let entries = builder.executor_mut().take_post_exec_entries();
@@ -905,8 +911,12 @@ where
         is_better_payload(self.best_payload.as_ref(), total_fees)
     }
 
-    /// Prepares a [`BlockBuilder`] using this payload's current post-exec mode.
-    /// Use [`Self::block_builder_with_mode`] when the caller already snapped the mode.
+    /// Prepares a [`BlockBuilder`] for the next block, resolving the post-exec mode from this
+    /// payload's context.
+    ///
+    /// Callers that also decide whether to append the trailing `0x7D` must instead resolve
+    /// [`Self::post_exec_mode`] once and pass it to [`Self::block_builder_with_mode`], so a
+    /// concurrent opt-in toggle cannot change the mode between EVM construction and the append.
     pub fn block_builder<'a, DB: Database>(
         &'a self,
         db: &'a mut State<DB>,
@@ -920,7 +930,8 @@ where
         self.block_builder_with_mode(db, self.post_exec_mode()?)
     }
 
-    /// Prepares a [`BlockBuilder`] with a caller-supplied post-exec mode.
+    /// Like [`Self::block_builder`] but builds against a caller-supplied [`PostExecMode`], so a
+    /// single snapshot drives both EVM construction and any later post-exec decision.
     pub fn block_builder_with_mode<'a, DB: Database>(
         &'a self,
         db: &'a mut State<DB>,

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -342,11 +342,16 @@ fn rebuilds_derived_block_with_embedded_post_exec_tx_regardless_of_opt_in() {
     }
 }
 
-/// `block_builder_with_mode` must use the supplied mode snapshot, not the live opt-in.
-/// Mismatch both ways to prove `Produce` still accepts `0x7D` and `Disabled` rejects it.
+/// `block_builder_with_mode` must build against the supplied snapshot and never re-read the
+/// opt-in. `build()` resolves [`OpPayloadBuilderCtx::post_exec_mode`] exactly once and reuses that
+/// snapshot for both EVM construction and the later decision to append the `0x7D`; re-reading the
+/// runtime-mutable opt-in for the append could disagree with the mode the EVM was built in, leaving
+/// a block whose refunded state has no matching post-exec tx (or vice versa). We assert the builder
+/// honors the passed mode by deliberately mismatching it against the live opt-in: `Produce` with
+/// the opt-in OFF accepts an embedded `0x7D`, while `Disabled` with the opt-in ON rejects it.
 #[test]
 fn block_builder_with_mode_honors_snapshot_over_live_opt_in() {
-    // Snapshot pins Produce with opt-in off.
+    // Opt-in OFF, but the snapshot pins Produce: the embedded 0x7D must be accepted.
     let produce_ctx = interop_ctx(false, false, Some(Vec::new()));
     let provider = StateProviderTest::default();
     let mut db = State::builder()
@@ -360,7 +365,7 @@ fn block_builder_with_mode_honors_snapshot_over_live_opt_in() {
         .execute_sequencer_transactions(&mut builder, None)
         .expect("Produce snapshot accepts the embedded 0x7D even with the opt-in off");
 
-    // Snapshot pins Disabled with opt-in on.
+    // Opt-in ON, but the snapshot pins Disabled: the embedded 0x7D must be rejected.
     let disabled_ctx = interop_ctx(false, true, Some(Vec::new()));
     let provider = StateProviderTest::default();
     let mut db = State::builder()

--- a/rust/op-reth/examples/custom-node/src/evm/alloy.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/alloy.rs
@@ -50,12 +50,12 @@ where
         Self::take_last_post_exec_tx_result(self)
     }
 
-    fn warming_state(&self) -> Self::Snapshot {
-        self.inner.warming_state()
+    fn refund_snapshot(&self) -> Self::Snapshot {
+        self.inner.refund_snapshot()
     }
 
-    fn seed_warming_state(&mut self, state: Self::Snapshot) {
-        self.inner.seed_warming_state(state);
+    fn seed_refund_snapshot(&mut self, state: Self::Snapshot) {
+        self.inner.seed_refund_snapshot(state);
     }
 }
 

--- a/rust/op-reth/examples/custom-node/src/evm/alloy.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/alloy.rs
@@ -40,6 +40,8 @@ impl<DB: Database, I, P> alloy_op_evm::post_exec::PostExecEvm for CustomEvm<DB, 
 where
     Self: Evm,
 {
+    type Snapshot = alloy_op_evm::post_exec::WarmingState;
+
     fn begin_post_exec_tx(&mut self, ctx: alloy_op_evm::post_exec::PostExecTxContext) {
         Self::begin_post_exec_tx(self, ctx);
     }
@@ -48,11 +50,11 @@ where
         Self::take_last_post_exec_tx_result(self)
     }
 
-    fn warming_state(&self) -> alloy_op_evm::post_exec::WarmingState {
+    fn warming_state(&self) -> Self::Snapshot {
         self.inner.warming_state()
     }
 
-    fn seed_warming_state(&mut self, state: alloy_op_evm::post_exec::WarmingState) {
+    fn seed_warming_state(&mut self, state: Self::Snapshot) {
         self.inner.seed_warming_state(state);
     }
 }

--- a/rust/op-reth/examples/custom-node/src/evm/config.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/config.rs
@@ -213,6 +213,8 @@ where
 }
 
 impl ConfigurePostExecEvm for CustomEvmConfig {
+    type Snapshot = alloy_op_evm::post_exec::WarmingState;
+
     fn post_exec_executor_for_block<'a, DB: Database>(
         &'a self,
         db: &'a mut State<DB>,
@@ -220,7 +222,7 @@ impl ConfigurePostExecEvm for CustomEvmConfig {
         post_exec_mode: PostExecMode,
     ) -> Result<
         impl BlockExecutor<Transaction = CustomTransaction, Receipt = OpReceipt>
-        + PostExecExecutorExt
+        + PostExecExecutorExt<Snapshot = Self::Snapshot>
         + 'a,
         Self::Error,
     > {
@@ -254,7 +256,7 @@ impl ConfigurePostExecEvm for CustomEvmConfig {
     ) -> Result<
         impl BlockBuilder<
             Primitives = CustomNodePrimitives,
-            Executor: PostExecExecutorExt
+            Executor: PostExecExecutorExt<Snapshot = Self::Snapshot>
                           + alloy_evm::block::BlockExecutor<
                 Evm: alloy_evm::Evm<DB: core::ops::DerefMut<Target = State<DB>>>,
                 Result: PreRefundGasUsed,

--- a/rust/op-reth/examples/custom-node/src/evm/executor.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/executor.rs
@@ -17,7 +17,7 @@ use alloy_evm::{
 use alloy_op_evm::{
     OpBlockExecutionCtx, OpBlockExecutor, OpEvmContext,
     block::OpTxResult,
-    post_exec::{PostExecEvm, PostExecExecutorExt, WarmingRefundEvent, WarmingState},
+    post_exec::{PostExecEvm, PostExecExecutorExt, WarmingRefundEvent},
 };
 use op_alloy_consensus::SDMGasEntry;
 use reth_op::{OpReceipt, OpTxType, chainspec::OpChainSpec, node::OpRethReceiptBuilder};
@@ -86,6 +86,8 @@ impl<E> PostExecExecutorExt for CustomBlockExecutor<E>
 where
     E: PostExecEvm,
 {
+    type Snapshot = E::Snapshot;
+
     fn post_exec_entries(&self) -> &[SDMGasEntry] {
         self.inner.post_exec_entries()
     }
@@ -98,11 +100,11 @@ where
         self.inner.take_warming_events_by_tx()
     }
 
-    fn warming_state(&self) -> WarmingState {
+    fn warming_state(&self) -> Self::Snapshot {
         self.inner.warming_state()
     }
 
-    fn seed_warming_state(&mut self, state: WarmingState) {
+    fn seed_warming_state(&mut self, state: Self::Snapshot) {
         self.inner.seed_warming_state(state);
     }
 }

--- a/rust/op-reth/examples/custom-node/src/evm/executor.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/executor.rs
@@ -100,12 +100,12 @@ where
         self.inner.take_warming_events_by_tx()
     }
 
-    fn warming_state(&self) -> Self::Snapshot {
-        self.inner.warming_state()
+    fn refund_snapshot(&self) -> Self::Snapshot {
+        self.inner.refund_snapshot()
     }
 
-    fn seed_warming_state(&mut self, state: Self::Snapshot) {
-        self.inner.seed_warming_state(state);
+    fn seed_refund_snapshot(&mut self, state: Self::Snapshot) {
+        self.inner.seed_refund_snapshot(state);
     }
 }
 


### PR DESCRIPTION
Makes the producer refund inspector configurable through the EVM factory while preserving existing public SDM behavior.

Without this, optimism-premium must either use the hardcoded public refund policy or fork the EVM/executor machinery; its own `sdm-policy` implementation cannot be cleanly installed.

Refund state is carried across subblocks and restored for rejected or failed candidates. Replay and verification remain unchanged and do not invoke the producer policy.