### PR TITLE
op-service: cover MergeJSON precedence and error paths

### DIFF
--- a/op-service/jsonutil/merge_test.go
+++ b/op-service/jsonutil/merge_test.go
@@ -28,9 +28,82 @@ func TestMergeJSON(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.EqualValues(t, out, testStruct{
+	require.EqualValues(t, testStruct{
 		"world",
 		42,
 		false,
+	}, out)
+}
+
+func TestMergeJSONOverridePrecedence(t *testing.T) {
+	type testStruct struct {
+		A string `json:"a"`
+		B int    `json:"b"`
+		C bool   `json:"c"`
+	}
+
+	out, err := MergeJSON(
+		testStruct{
+			A: "initial",
+			B: 1,
+			C: false,
+		},
+		map[string]any{
+			"a": "first",
+			"b": 2,
+		},
+		nil,
+		map[string]any{
+			"a": "last",
+			"c": true,
+		},
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, testStruct{
+		A: "last",
+		B: 2,
+		C: true,
+	}, out)
+}
+
+func TestMergeJSONErrors(t *testing.T) {
+	t.Run("input marshal error", func(t *testing.T) {
+		type testStruct struct {
+			Bad chan int `json:"bad"`
+		}
+
+		out, err := MergeJSON(testStruct{Bad: make(chan int)})
+		require.Error(t, err)
+		require.Zero(t, out)
+	})
+
+	t.Run("input must marshal to object", func(t *testing.T) {
+		out, err := MergeJSON("not an object")
+		require.Error(t, err)
+		require.Empty(t, out)
+	})
+
+	t.Run("override marshal error", func(t *testing.T) {
+		type testStruct struct {
+			A string `json:"a"`
+		}
+
+		out, err := MergeJSON(testStruct{A: "ok"}, map[string]any{
+			"a": func() {},
+		})
+		require.Error(t, err)
+		require.Zero(t, out)
+	})
+
+	t.Run("override decode error", func(t *testing.T) {
+		type testStruct struct {
+			B int `json:"b"`
+		}
+
+		out, err := MergeJSON(testStruct{B: 1}, map[string]any{
+			"b": "not an int",
+		})
+		require.Error(t, err)
+		require.Zero(t, out)
 	})
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Adds focused unit coverage for `jsonutil.MergeJSON`.

The new tests lock down override precedence, including nil override maps, and cover the existing error behavior for invalid input values, non-object inputs, invalid override values, and failed decode back into the target type.

This is a test-only change and does not modify production behavior.



**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->
`go test ./op-service/jsonutil -count=1`

MergeJSON now has 100% function coverage.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
