### PR TITLE
op-devstack: Fix flaky super root readiness in acceptance tests

### DIFF
--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -155,21 +155,26 @@ func getSupernodeSuperRoot(t devtest.T, supernode *SuperNode, timestamp uint64) 
 func getSuperRoot(t devtest.T, endpoint string, timestamp uint64) eth.Bytes32 {
 	client, err := dial.DialSuperNodeClientWithTimeout(t.Ctx(), t.Logger(), endpoint)
 	t.Require().NoError(err)
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(t.Ctx(), 2*time.Minute)
+	defer cancel()
+
+	var resp eth.SuperRootAtTimestampResponse
 	err = wait.For(ctx, time.Second, func() (bool, error) {
-		resp, err := client.SuperRootAtTimestamp(ctx, timestamp)
+		candidate, err := client.SuperRootAtTimestamp(ctx, timestamp)
 		if err != nil {
 			t.Logf("DEBUG: Failed to get super root at timestamp %d: err: %v", timestamp, err)
-			return false, err
+			return false, nil
 		}
-		return resp.Data != nil, nil
+		if candidate.Data == nil {
+			return false, nil
+		}
+		resp = candidate
+		return true, nil
 	})
 	cancel()
 	t.Require().NoError(err, "waiting for superroot to be ready failed")
-
-	resp, err := client.SuperRootAtTimestamp(t.Ctx(), timestamp)
-	t.Require().NoError(err, "super root at timestamp failed")
 	t.Require().NotNil(resp.Data, "super root data must be present")
 	return resp.Data.SuperRoot
 }

--- a/op-devstack/sysgo/superroot_test.go
+++ b/op-devstack/sysgo/superroot_test.go
@@ -1,0 +1,51 @@
+package sysgo
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type transientSuperRootService struct {
+	calls                atomic.Int32
+	firstRequestCanceled chan error
+}
+
+func (s *transientSuperRootService) AtTimestamp(ctx context.Context, _ hexutil.Uint64) (eth.SuperRootAtTimestampResponse, error) {
+	switch s.calls.Add(1) {
+	case 1:
+		<-ctx.Done()
+		s.firstRequestCanceled <- ctx.Err()
+		return eth.SuperRootAtTimestampResponse{}, ctx.Err()
+	case 2:
+		return eth.SuperRootAtTimestampResponse{
+			Data: &eth.SuperRootResponseData{SuperRoot: eth.Bytes32{1}},
+		}, nil
+	default:
+		<-ctx.Done()
+		return eth.SuperRootAtTimestampResponse{}, ctx.Err()
+	}
+}
+
+func TestGetSuperRootReusesSuccessfulPollResponse(t *testing.T) {
+	service := &transientSuperRootService{
+		firstRequestCanceled: make(chan error, 1),
+	}
+	rpcServer := rpc.NewServer()
+	require.NoError(t, rpcServer.RegisterName("superroot", service))
+	server := httptest.NewServer(rpcServer)
+	t.Cleanup(server.Close)
+
+	root := getSuperRoot(devtest.SerialT(t), server.URL, 1)
+	require.ErrorIs(t, <-service.firstRequestCanceled, context.Canceled)
+	require.Equal(t, eth.Bytes32{1}, root)
+	require.Equal(t, int32(2), service.calls.Load())
+}


### PR DESCRIPTION
## What

Fixes a flaky failure in `TestSingleChainSuperFaultProofsFromOpNode` (and any test routing super-root reads through `sysgo.getSuperRoot`).

## Root cause

`getSuperRoot` polled `superroot_atTimestamp` inside a two-minute `wait.For`, but its callback returned the first RPC error, and `wait.For` aborts immediately on a callback error. Each RPC has a 10s `BaseRPCClient` deadline. Under constrained CI, op-node's driver event loop could not accept the synchronous `BlockRefWithStatus` `stateReq` handshake within 10s, so one transient per-call timeout defeated the intended two-minute readiness window.

Observed in CI job `memory-all-kona-op-reth` ([5356259](https://app.circleci.com/jobs/github/ethereum-optimism/optimism/5356259)): components started ~`03:13:28.119`; the failing request began ~`03:13:39.135` and hit its 10s deadline at exactly `03:13:49.135` with `Post "http://127.0.0.1:40461": context deadline exceeded`; cleanup brought the total to 29.35s.

## Why flaky, not consistent

The trigger is op-node event-loop scheduling under load: `stateReq` competes with derivation/drain work. Favorable ordering accepts the request within 10s; the constrained memory job did not. The chain kept advancing during the failed request, confirming transient contention rather than a stuck node.

## Fix

- Treat individual RPC errors and nil data as not-ready states within the existing two-minute context.
- Reuse the successful polled response and return its root directly, removing a redundant post-readiness RPC that reopened the same 10s race window.

## Testing

Added `TestGetSuperRootReusesSuccessfulPollResponse`, a real HTTP JSON-RPC regression that forces production-timeout → success → blocking-redundant-call and asserts first-request cancellation, the returned root, and exactly two calls.

- The residual redundant-call race reproduced 2/2 on the intermediate approach and passes 10/10 after the fix.
- Focused acceptance `TestSingleChainSuperFaultProofsFromOpNode` passes.

Fixes ethereum-optimism/optimism#21952