### PR TITLE
op-node: Apply SuperAuthority deny-list check on consolidation path

### DIFF
--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -27,6 +28,8 @@ type EngineController interface {
 	RequestForkchoiceUpdate(ctx context.Context)
 	RequestPendingSafeUpdate(ctx context.Context)
 	IsEngineInitialELSyncing() bool
+	// IsDenied reports whether the given payload is on the SuperAuthority deny-list.
+	IsDenied(blockNumber uint64, payloadHash common.Hash) (bool, error)
 }
 
 type L2 interface {
@@ -230,19 +233,46 @@ func (eq *AttributesHandler) consolidateNextSafeAttributes(attributes *derive.At
 		eq.log.Warn("L2 reorg: existing unsafe block does not match derived attributes from L1",
 			"err", err, "unsafe", envelope.ExecutionPayload.ID(), "pending_safe", onto)
 
-		eq.sentAttributes = true
-		// geth cannot wind back a chain without reorging to a new, previously non-canonical, block
-		eq.emitter.Emit(eq.ctx, engine.BuildStartEvent{Attributes: attributes})
+		eq.reorgOutUnsafeChain(attributes)
 		return
-	} else {
-		ref, err := derive.PayloadToBlockRef(eq.cfg, envelope.ExecutionPayload)
-		if err != nil {
-			eq.log.Error("Failed to compute block-ref from execution payload")
-			return
-		}
-		eq.engineController.TryUpdatePendingSafe(eq.ctx, ref, attributes.Concluding, attributes.DerivedFrom)
-		eq.engineController.TryUpdateLocalSafe(eq.ctx, ref, attributes.Concluding, attributes.DerivedFrom)
 	}
 
+	// A denied block can re-enter the canonical chain via unsafe sync; the
+	// build-path deny check only runs on a consolidation mismatch, so gate here
+	// too. On a deny, force the build path (as with a mismatch) to reorg it out.
+	payload := envelope.ExecutionPayload
+	denied, err := eq.engineController.IsDenied(uint64(payload.BlockNumber), payload.BlockHash)
+	if err != nil {
+		// Fail closed: without a deny-list result we cannot promote the block, and
+		// we must not reorg either. Stall and retry on the next safe-head poke.
+		eq.emitter.Emit(eq.ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("failed to check SuperAuthority deny-list for block %s during consolidation: %w", payload.ID(), err),
+		})
+		return
+	}
+	if denied {
+		eq.log.Warn("Consolidated block denied by SuperAuthority, forcing reorg to build replacement",
+			"blockNumber", payload.BlockNumber, "blockHash", payload.BlockHash, "pending_safe", onto)
+		eq.reorgOutUnsafeChain(attributes)
+		return
+	}
+
+	ref, err := derive.PayloadToBlockRef(eq.cfg, envelope.ExecutionPayload)
+	if err != nil {
+		eq.log.Error("Failed to compute block-ref from execution payload")
+		return
+	}
+	eq.engineController.TryUpdatePendingSafe(eq.ctx, ref, attributes.Concluding, attributes.DerivedFrom)
+	eq.engineController.TryUpdateLocalSafe(eq.ctx, ref, attributes.Concluding, attributes.DerivedFrom)
+
 	// unsafe head stays the same, we did not reorg the chain.
+}
+
+// reorgOutUnsafeChain forces derivation to rebuild the block, reorging out the
+// existing canonical block (which did not match the derived attributes, or was
+// denied). geth cannot wind back a chain without reorging to a new, previously
+// non-canonical, block.
+func (eq *AttributesHandler) reorgOutUnsafeChain(attributes *derive.AttributesWithParent) {
+	eq.sentAttributes = true
+	eq.emitter.Emit(eq.ctx, engine.BuildStartEvent{Attributes: attributes})
 }

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -2,6 +2,7 @@ package attributes
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"math/rand" // nosemgrep
 	"testing"
@@ -310,6 +311,8 @@ func TestAttributesHandler(t *testing.T) {
 
 				// Call during consolidation.
 				l2.ExpectPayloadByNumber(refA1.Number, payloadA1, nil)
+				// Not denied, so consolidation may promote it.
+				engDeriver.On("IsDenied", uint64(payloadA1.ExecutionPayload.BlockNumber), payloadA1.ExecutionPayload.BlockHash).Return(false, nil).Once()
 
 				// AttributesHandler will call EngDeriver methods for updating pending safe and local safe
 				engDeriver.On("TryUpdatePendingSafe", ah.ctx, refA1, concluding, refB).Return()
@@ -339,6 +342,81 @@ func TestAttributesHandler(t *testing.T) {
 			t.Run("is not last span", func(t *testing.T) {
 				fn(t, false)
 			})
+		})
+		t.Run("consolidation passes but block denied", func(t *testing.T) {
+			// Matching attributes but the block is denied: must force the build
+			// path, not promote.
+			logger := testlog.Logger(t, log.LevelInfo)
+			l2 := &testutils.MockL2Client{}
+			emitter := &testutils.MockEmitter{}
+			engDeriver := &MockEngineController{}
+			ah := NewAttributesHandler(logger, cfg, context.Background(), l2, engDeriver)
+			ah.AttachEmitter(emitter)
+
+			attr := &derive.AttributesWithParent{
+				Attributes:  attrA1.Attributes, // attributes match block A1
+				Parent:      attrA1.Parent,
+				Concluding:  true,
+				DerivedFrom: refB,
+			}
+			emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
+			engDeriver.On("RequestPendingSafeUpdate", context.Background()).Once()
+			ah.OnEvent(context.Background(), derive.DerivedAttributesEvent{Attributes: attr})
+			engDeriver.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+			require.NotNil(t, ah.attributes, "queued up derived attributes")
+
+			// Call during consolidation: attributes match, but the block is denied.
+			l2.ExpectPayloadByNumber(refA1.Number, payloadA1, nil)
+			engDeriver.On("IsDenied", uint64(payloadA1.ExecutionPayload.BlockNumber), payloadA1.ExecutionPayload.BlockHash).Return(true, nil).Once()
+			// Denied block forces a reorg via the build path rather than promotion.
+			emitter.ExpectOnce(engine.BuildStartEvent{Attributes: attr})
+			ah.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
+				PendingSafe: refA0,
+				Unsafe:      refA1,
+			})
+			engDeriver.AssertExpectations(t)
+			l2.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+			require.True(t, ah.sentAttributes, "attributes were sent to the build path")
+			require.NotNil(t, ah.attributes, "attributes stay queued until the replacement is processed")
+		})
+		t.Run("deny-list check error stalls without promoting", func(t *testing.T) {
+			// Fail closed: if the deny-list can't be checked we must neither promote
+			// nor reorg; stall and retry.
+			logger := testlog.Logger(t, log.LevelInfo)
+			l2 := &testutils.MockL2Client{}
+			emitter := &testutils.MockEmitter{}
+			engDeriver := &MockEngineController{}
+			ah := NewAttributesHandler(logger, cfg, context.Background(), l2, engDeriver)
+			ah.AttachEmitter(emitter)
+
+			attr := &derive.AttributesWithParent{
+				Attributes:  attrA1.Attributes, // attributes match block A1
+				Parent:      attrA1.Parent,
+				Concluding:  true,
+				DerivedFrom: refB,
+			}
+			emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
+			engDeriver.On("RequestPendingSafeUpdate", context.Background()).Once()
+			ah.OnEvent(context.Background(), derive.DerivedAttributesEvent{Attributes: attr})
+			engDeriver.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+			require.NotNil(t, ah.attributes, "queued up derived attributes")
+
+			// Attributes match, but the deny-list check fails.
+			l2.ExpectPayloadByNumber(refA1.Number, payloadA1, nil)
+			engDeriver.On("IsDenied", uint64(payloadA1.ExecutionPayload.BlockNumber), payloadA1.ExecutionPayload.BlockHash).Return(false, errors.New("authority unavailable")).Once()
+			// No TryUpdate* and no BuildStartEvent: just a temporary error to retry.
+			emitter.ExpectOnceType("EngineTemporaryErrorEvent")
+			ah.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
+				PendingSafe: refA0,
+				Unsafe:      refA1,
+			})
+			engDeriver.AssertExpectations(t)
+			l2.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+			require.NotNil(t, ah.attributes, "attributes stay queued so consolidation retries")
 		})
 		t.Run("not found during EL sync stalls without reset", func(t *testing.T) {
 			logger := testlog.Logger(t, log.LevelInfo)

--- a/op-node/rollup/attributes/testutils.go
+++ b/op-node/rollup/attributes/testutils.go
@@ -3,8 +3,10 @@ package attributes
 import (
 	"context"
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type MockEngineController struct {
@@ -32,4 +34,9 @@ func (m *MockEngineController) RequestPendingSafeUpdate(ctx context.Context) {
 func (m *MockEngineController) IsEngineInitialELSyncing() bool {
 	out := m.Mock.MethodCalled("IsEngineInitialELSyncing")
 	return out.Bool(0)
+}
+
+func (m *MockEngineController) IsDenied(blockNumber uint64, payloadHash common.Hash) (bool, error) {
+	out := m.Mock.MethodCalled("IsDenied", blockNumber, payloadHash)
+	return out.Bool(0), out.Error(1)
 }

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -1099,6 +1099,15 @@ func (e *EngineController) RequestPendingSafeUpdate(ctx context.Context) {
 	})
 }
 
+// IsDenied reports whether the payload is on the SuperAuthority deny-list;
+// false when no SuperAuthority is registered.
+func (e *EngineController) IsDenied(blockNumber uint64, payloadHash common.Hash) (bool, error) {
+	if e.superAuthority == nil {
+		return false, nil
+	}
+	return e.superAuthority.IsDenied(blockNumber, payloadHash)
+}
+
 // TryUpdatePendingSafe updates the pending safe head if the new reference is newer, acquiring lock
 func (e *EngineController) TryUpdatePendingSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef) {
 	e.mu.Lock()

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -175,6 +175,10 @@ func (fakeEngController) RequestPendingSafeUpdate(ctx context.Context) {}
 
 func (fakeEngController) IsEngineInitialELSyncing() bool { return false }
 
+func (fakeEngController) IsDenied(blockNumber uint64, payloadHash common.Hash) (bool, error) {
+	return false, nil
+}
+
 // TestSequencer_StartStop runs through start/stop state back and forth to test state changes.
 func TestSequencer_StartStop(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelError)


### PR DESCRIPTION
## What

The SuperAuthority deny-list check only lived on the build/insert path (`engine/payload_process.go`), which is reached only when derivation has to *build* a block. It was never applied on the consolidation path (`attributes/attributes.go`).

That left a hole: if optimistic unsafe sync has already re-adopted a denied block as canonical, derivation replays and finds the pending-safe head behind the unsafe head. Instead of rebuilding, `consolidateNextSafeAttributes` fetches the existing canonical block and compares attributes. The derived attributes come from the same L1 batches the invalid block was built from, so they match byte-for-byte, and the block is promoted straight to pending-safe/local-safe via `TryUpdatePendingSafe`/`TryUpdateLocalSafe` — with no deny-list check anywhere on that path.

## Change

- Add `IsDenied(blockNumber, payloadHash)` to `engine.EngineController` (returns `false` when no SuperAuthority is registered) and to the `attributes.EngineController` interface.
- In `consolidateNextSafeAttributes`, after attributes match the existing canonical block, check the deny-list. On a deny, force the build path (emit `BuildStartEvent`) exactly as a consolidation mismatch does, so the engine reorgs the invalid block out and the existing deposits-only replacement machinery in `onPayloadProcess` takes over. On a deny-list read error, log and proceed (mirrors the build-path behavior).

## Test plan

- New subtest `consolidation passes but block denied` asserts a denied, otherwise-matching block emits `BuildStartEvent` and is not promoted.
- Existing consolidation tests updated to stub `IsDenied` → `false`.
- `go test ./rollup/attributes/ ./rollup/engine/ ./rollup/sequencing/` passes.