### PR TITLE
op-acceptance-tests: port op-e2e conductor system coverage

### DIFF
--- a/docs/ai/writing-acceptance-tests.md
+++ b/docs/ai/writing-acceptance-tests.md
@@ -6,15 +6,17 @@ Guidance for AI agents writing new acceptance tests in the Optimism monorepo. Fo
 
 An acceptance test exists to describe a user-visible behaviour of the OP Stack and fail loudly when that behaviour breaks. A reader who is not a domain expert should be able to open any test in `op-acceptance-tests/tests/` and understand what the system is supposed to do, without running anything.
 
-Tests express *requirements*. The DSL expresses *how those requirements are checked*. When the technical details change, the DSL is updated once and every test benefits — including tests added in the future. When a test is flaky, the fix usually belongs in the DSL (a better wait, a missing precondition), not in the test.
+Tests express *requirements*. The DSL exposes reusable domain operations and hides transport details, asynchronous waits, and other mechanics. Tests retain scenario-specific policy and assertions so a reader can see what behaviour is required without opening the DSL. When shared mechanics change, the DSL is updated once and every test benefits. When a test is flaky, the fix usually belongs in a reusable wait or precondition rather than in timing code in the test.
 
 This guide covers both sides: how to write a test that reads as a requirement, and how to grow the DSL so future tests stay that way.
 
 ## Guiding Principles
 
-### Keep Tests Simple, Even If That Makes the DSL Complex
+### Keep Tests Simple Without Hiding the Requirement
 
-Complexity in a test is duplicated across every test that follows. Complexity in the DSL is centralised and encapsulated. Push difficulty downward.
+Complex reusable mechanics in a test are duplicated across every test that follows. Centralise those mechanics in the DSL and push transport details, retries, and stable domain operations downward.
+
+Do not move an entire one-off verification into the DSL merely to shorten a test. A method that chooses the inputs, defines the expected policy, and performs every assertion can hide the requirement it is meant to clarify. The test should still make the action and expected outcome visible.
 
 The DSL is not plain English and should not try to be. Its domain experts are test authors, not non-technical readers. A statement should clearly describe *what* it is doing without reading like a sentence.
 
@@ -22,7 +24,7 @@ The DSL is not plain English and should not try to be. Its domain experts are te
 
 The "language" of the DSL emerges from consistent naming and structure. Follow established patterns even when a new one would be marginally nicer for your specific test — the cognitive cost of divergent patterns outweighs the win.
 
-If the pattern you need does not exist, extend the DSL rather than invent a one-off in the test file.
+If a reusable operation or wait is missing, extend the DSL rather than reaching into raw clients. If only a verification policy is shared by one or a few tests in the same package, prefer a package-local test helper over adding it to the repository-wide DSL.
 
 ### One Behaviour Per Test
 
@@ -37,7 +39,7 @@ func TestTransferChargesGasToSender(gt *testing.T) { ... }
 func TestTransferMovesFundsAndChargesGasAndUpdatesNonce(gt *testing.T) { ... }
 ```
 
-When two behaviours always change together, the second is part of the first behaviour's definition — fold it into an action or verification method on the DSL, not a second assertion in the test body.
+When two behaviours always change together, the second is part of the first behaviour's definition — keep them in the same assertion flow. If that flow is reused, place it at the narrowest useful scope rather than automatically adding it to the DSL.
 
 ### Plain-English Test Names
 
@@ -76,7 +78,7 @@ func TestSomething(gt *testing.T) {
 }
 ```
 
-Keep the test body at this level. If you find yourself reaching into low-level clients, RPC calls, or raw receipts to build assertions, that is a signal the DSL needs a new method — not that the test needs more lines.
+Keep the test body at this level. If you find yourself reaching into low-level clients, RPC calls, or raw receipts, that is a signal the DSL is missing an operation or typed API. The resulting value or error may still be asserted in the test when that assertion is the behaviour under test.
 
 ## DSL Patterns to Follow
 
@@ -90,13 +92,35 @@ As a test author, this means you should be able to call an action once and trust
 
 ### Verification Methods Include Waits
 
-Verification methods in the DSL do the fetching, waiting, retrying, *and* asserting. Tests should never need to build their own wait/retry loops around a raw getter.
+When a verification belongs in the DSL, it does the fetching, waiting, retrying, *and* asserting. Tests should never need to build their own wait/retry loops around a raw getter. This does not mean every assertion needs a DSL verification method: scenario-specific assertions can remain in the test or a package-local helper while using DSL operations and wait primitives.
 
 Use verification methods only to assert the behaviour the test is actually covering. Do **not** re-verify that setup worked — that belongs inside the setup action method. Extra verifications in the test body obscure intent and increase the number of places that need updating when behaviour changes.
 
-### Prefer Verification Methods Over Getters
+### Put Verification at the Narrowest Useful Scope
 
-The system state is asynchronous; fetching raw values and asserting on them creates flakes. A verification method bundles the fetch with a bounded wait and an assertion.
+Choose where a verification lives based on how broadly it is useful:
+
+- Used by one test: keep the assertion in that test, or in a small file-local helper if needed for readability.
+- Used by a few tests in one package: share it in a package-local `_test.go` helper.
+- Used across packages, or representing a stable domain invariant: make it a DSL verification method.
+
+Even repeated verification often belongs at package scope because acceptance-test policy is usually shared only by closely related tests. The DSL should provide the thin capability underneath it. For example, expose typed methods for calling a proxied sequencer API, but let the proxy acceptance test choose which API families to probe and assert which calls must succeed or fail.
+
+Avoid DSL methods that encode a whole test in a name such as `VerifyAllProxyBehaviour`. They obscure which calls define coverage and make unrelated tests depend on scenario-specific policy.
+
+```go
+// Avoid: the test's coverage policy is hidden inside a repository-wide helper.
+leader.VerifyProxyServesAllRequiredAPIs()
+
+// Better: the DSL exposes the capability; the test shows the requirement.
+api := leader.SequencerAPI()
+_, err := api.SyncStatus()
+require.NoError(t, err)
+```
+
+### Prefer Waiting Operations Over Snapshot Getters
+
+The system state is asynchronous; fetching raw values and immediately asserting on them creates flakes. A reusable verification method can bundle the fetch with a bounded wait and an assertion; a package-local verification helper can compose the same DSL wait primitives.
 
 ```go
 // Avoid: async state fetched and compared directly
@@ -176,7 +200,7 @@ If you find yourself wanting one of these to make a test pass, the real fix is a
 
 DSL methods (including ones you add) should log what they are doing. Waiters should log what they are waiting for and the current state of the system on every poll cycle. When an acceptance test fails in CI, the logs are often the only evidence — make them speak.
 
-Inside a test body, prefer expressive DSL calls over scattered `t.Log` statements. If you need a comment or log line to explain what a block of test code is doing, the DSL method is either poorly named or missing.
+Inside a test body, prefer expressive DSL calls over scattered `t.Log` statements. If you need a comment or log line to explain mechanics, the underlying DSL capability or a package-local helper may be poorly named or missing. Comments that explain why an outcome matters should remain in the test.
 
 ## Self-Sufficient Failures
 
@@ -190,7 +214,7 @@ Re-running to "see what happened" is a sign the failure artefact is missing.
 
 ## Test Smells
 
-Smells are signals that the DSL is at the wrong level of abstraction for this test. They are not hard rules — they are invitations to stop and consider whether the DSL should grow.
+Smells are signals that test support is at the wrong level of abstraction. They are not hard rules — they are invitations to consider whether a reusable capability belongs in the DSL or scenario-specific composition belongs in a package-local helper.
 
 ### Comment + Code Block
 
@@ -236,11 +260,13 @@ If two tests open with the same ten lines of boilerplate, that boilerplate belon
 
 Write a new DSL method when:
 
-- A comment is needed to explain what a block of test code is doing.
-- Two tests need the same setup or wait pattern.
-- A test hand-rolls a `require.Eventually` or retry loop.
+- A reusable domain operation or typed API is missing.
+- Multiple packages need the same setup, wait, or stable domain invariant.
+- A test hand-rolls a `require.Eventually` or retry loop that belongs in a reusable wait primitive.
 - A test reaches past the DSL into low-level clients, RPCs, or internal packages.
-- Adding the method would let the test read at the level "describe a behaviour" rather than "drive the implementation".
+- Adding the method would let the test read at the level "describe a behaviour" rather than "drive the implementation" without hiding the expected outcome.
+
+Do not add a DSL method solely because one or two tests in the same package share an assertion. Prefer a package-local test helper for that verification and add only the underlying reusable capability to the DSL.
 
 When extending the DSL, apply the same patterns this guide prescribes for tests: action methods check/act/assert, verification methods wait internally, optional args use the opts-struct vararg pattern, and no method should require the caller to add their own wait or retry loop.
 
@@ -252,6 +278,7 @@ When extending the DSL, apply the same patterns this guide prescribes for tests:
 - [ ] No test-only branches added to production code to make this test pass.
 - [ ] Setup is not re-verified in the test body.
 - [ ] Fixtures are deterministic.
-- [ ] Waits and assertions go through DSL methods, not raw clients.
-- [ ] If a new pattern was needed, it was added to the DSL, not inlined in the test.
+- [ ] Tests use DSL operations and wait primitives rather than raw clients or hand-rolled retries.
+- [ ] Scenario-specific assertions remain visible in the test or a package-local helper.
+- [ ] Reusable capabilities live in the DSL; package-local verification policy does not leak into it.
 - [ ] Assertion and log messages are actionable — a CI failure can be diagnosed from logs alone.

--- a/op-acceptance-tests/tests/base/conductor/cluster_startup_test.go
+++ b/op-acceptance-tests/tests/base/conductor/cluster_startup_test.go
@@ -1,0 +1,22 @@
+package conductor
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// TestConductorClusterStartsWithOneActiveSequencer verifies the core HA
+// startup guarantee: a freshly formed conductor cluster elects a single Raft
+// leader and only that leader's sequencer produces blocks; the follower
+// sequencers stay stopped.
+func TestConductorClusterStartsWithOneActiveSequencer(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
+
+	sys := presets.NewMinimalWithConductors(t)
+
+	sys.Conductors.VerifyOneActiveSequencer()
+}

--- a/op-acceptance-tests/tests/base/conductor/disaster_recovery_test.go
+++ b/op-acceptance-tests/tests/base/conductor/disaster_recovery_test.go
@@ -1,0 +1,47 @@
+package conductor
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// TestDisasterRecoveryLeaderOverride verifies the disaster-recovery escape
+// hatch: when the conductor cluster loses Raft quorum no sequencer may start
+// through the normal leadership path, but an operator can override leadership
+// on a surviving node and force it to resume sequencing.
+func TestDisasterRecoveryLeaderOverride(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
+
+	sys := presets.NewMinimalWithConductors(t)
+
+	leader := sys.Conductors.VerifyOneActiveSequencer()
+	followers := sys.Conductors.Followers()
+	survivor, casualty := followers[0], followers[1]
+
+	// The disaster: two of the three conductors die, so the survivor can never
+	// win an election, and the active sequencer's node dies with its
+	// conductor, halting the chain. The casualty conductor goes first so the
+	// still-live cluster cannot elect it in between.
+	casualty.Stop()
+	leader.Stop()
+	leader.Sequencer().Stop()
+
+	// Without Raft leadership the survivor's node refuses to sequence.
+	survivor.Sequencer().VerifyStartSequencerRefused("sequencer is not the leader")
+
+	// The operator override forces the survivor into non-HA mode: its node
+	// stops consulting the conductor and its conductor reports leadership to
+	// downstream users (e.g. proxied batcher traffic).
+	survivor.Sequencer().OverrideLeader()
+	survivor.OverrideLeader(true)
+	survivor.Sequencer().StartSequencer()
+
+	// The chain is live again under the surviving sequencer, and the
+	// overridden conductor serves proxied traffic as if it were the leader.
+	survivor.Sequencer().AdvancedUnsafe(2, 30)
+	survivor.VerifyProxyServesSequencerAPIs()
+}

--- a/op-acceptance-tests/tests/base/conductor/failover_test.go
+++ b/op-acceptance-tests/tests/base/conductor/failover_test.go
@@ -1,0 +1,26 @@
+package conductor
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// TestFailoverOnActiveSequencerFailure verifies the HA failover guarantee:
+// when the active sequencer's node dies, its conductor detects the failure via
+// health monitoring and hands leadership to a healthy cluster member, whose
+// sequencer takes over block production.
+func TestFailoverOnActiveSequencerFailure(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
+
+	sys := presets.NewMinimalWithConductors(t, presets.WithConductorFastHealthChecks())
+
+	leader := sys.Conductors.VerifyOneActiveSequencer()
+	leader.Sequencer().Stop()
+
+	survivors := sys.Conductors.Without(leader)
+	survivors.VerifyOneActiveSequencer()
+}

--- a/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
+++ b/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
@@ -25,3 +25,22 @@ func TestLeadershipTransferMovesActiveSequencer(gt *testing.T) {
 	target.VerifySequencerActive()
 	leader.VerifySequencerInactive()
 }
+
+// TestUnsafeChainAdvancesAfterLeadershipTransfer verifies that block
+// production survives a leadership transfer: the unsafe chain keeps advancing
+// under the new leader and every sequencer node converges on the same
+// canonical chain.
+func TestUnsafeChainAdvancesAfterLeadershipTransfer(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
+
+	sys := presets.NewMinimalWithConductors(t)
+
+	leader := sys.Conductors.Leader()
+	target := sys.Conductors.Followers()[0]
+	leader.TransferLeadershipTo(target)
+
+	// A handful of blocks is enough to prove sustained production by the new
+	// leader rather than a single lucky head advance.
+	sys.Conductors.VerifyUnsafeChainAdvancesAndConverges(3)
+}

--- a/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
+++ b/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
@@ -1,142 +1,27 @@
 package conductor
 
 import (
-	"context"
-	"fmt"
 	"testing"
-	"time"
 
-	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
-	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
-	"github.com/ethereum-optimism/optimism/op-service/clock"
-	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/require"
 )
 
-type conductorWithInfo struct {
-	*dsl.Conductor
-	info consensus.ServerInfo
-}
-
-// TestConductorLeadershipTransfer checks if the leadership transfer works correctly on the conductors
-func TestConductorLeadershipTransfer(gt *testing.T) {
+// TestLeadershipTransferMovesActiveSequencer verifies that manually
+// transferring Raft leadership also moves the active sequencer: the old
+// leader's sequencer stops sequencing and the transfer target's starts.
+func TestLeadershipTransferMovesActiveSequencer(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	// Example error with kona-node:
-	//
-	// --- FAIL: TestConductorLeadershipTransfer (63.04s)
-	// panic: interface conversion: sysgo.L2CLNode is *sysgo.KonaNode, not *sysgo.OpNode [recovered]
-	//    panic: interface conversion: sysgo.L2CLNode is *sysgo.KonaNode, not *sysgo.OpNode
-	sysgo.SkipOnKonaNode(t, "not supported")
-	logger := testlog.Logger(t, log.LevelInfo).With("Test", "TestConductorLeadershipTransfer")
+	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
 
 	sys := presets.NewMinimalWithConductors(t)
-	tracer := t.Tracer()
-	ctx := t.Ctx()
-	logger.Info("Started Conductor Leadership Transfer test")
-	require.NotEmpty(t, sys.ConductorSets, "expected at least one L2 conductor set")
 
-	ctx, span := tracer.Start(ctx, "test chains")
-	defer span.End()
+	leader := sys.Conductors.Leader()
+	target := sys.Conductors.Followers()[0]
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
+	leader.TransferLeadershipTo(target)
 
-	// Test all L2 chains in the system
-	for l2Chain, conductors := range sys.ConductorSets {
-		require.NotEmpty(t, conductors, "expected conductors in L2 chain", "chainId", l2Chain.String())
-		chainId := l2Chain.String()
-
-		_, span = tracer.Start(ctx, fmt.Sprintf("test chain %s", chainId))
-		defer span.End()
-
-		membership := conductors[0].FetchClusterMembership()
-		require.Equal(t, len(membership.Servers), len(conductors), "cluster membership does not match the number of conductors", "chainId", chainId)
-
-		idToConductor := make(map[string]conductorWithInfo)
-		for _, conductor := range conductors {
-			idToConductor[conductor.String()] = conductorWithInfo{conductor, consensus.ServerInfo{}}
-		}
-		for _, memberInfo := range membership.Servers {
-			conductor, ok := idToConductor[memberInfo.ID]
-			require.True(t, ok, "unknown conductor in cluster membership", "unknown conductor id", memberInfo.ID, "chainId", chainId)
-			conductor.info = memberInfo
-			idToConductor[memberInfo.ID] = conductor
-		}
-
-		leaderInfo, err := conductors[0].Escape().RpcAPI().LeaderWithID(ctx)
-		require.NoError(t, err, "failed to get current conductor info", "chainId", chainId)
-
-		leaderConductor := idToConductor[leaderInfo.ID]
-
-		voters := []conductorWithInfo{leaderConductor}
-		for _, member := range membership.Servers {
-			if member.ID == leaderInfo.ID || member.Suffrage == consensus.Nonvoter {
-				continue
-			}
-
-			voters = append(voters, idToConductor[member.ID])
-		}
-
-		if len(voters) == 1 {
-			t.Skip("only one voter found in the cluster, skipping leadership transfer test")
-			continue
-		}
-
-		t.Run(fmt.Sprintf("L2_Chain_%s", chainId), func(tt devtest.T) {
-			numOfLeadershipTransfers := len(voters)
-			for i := 0; i < numOfLeadershipTransfers; i++ {
-				// the modulo operation is used to wrap around the list of voters whenever i or i+1 becomes >= len(voters)
-				oldLeaderIndex, newLeaderIndex := i%len(voters), (i+1)%len(voters)
-				oldLeader, newLeader := voters[oldLeaderIndex], voters[newLeaderIndex]
-
-				require.NoError(tt, clock.SystemClock.SleepCtx(ctx, 3*time.Second)) // nosemgrep: flake-sleep-in-test -- intentional inter-transfer pause; no deterministic chain event to wait on
-
-				testTransferLeadershipAndCheck(t, oldLeader, newLeader)
-			}
-		})
-	}
-}
-
-// testTransferLeadershipAndCheck tests conductor's leadership transfer from one leader to another
-func testTransferLeadershipAndCheck(t devtest.T, oldLeader, targetLeader conductorWithInfo) {
-
-	t.Run(fmt.Sprintf("Conductor_%s_to_%s", oldLeader, targetLeader), func(tt devtest.T) {
-		// ensure that the current and target leader are healthy and unpaused before transferring leadership
-		require.Eventually(tt, func() bool { return oldLeader.FetchSequencerHealthy() },
-			30*time.Second, 500*time.Millisecond, "current leader's sequencer is not healthy, id: %s", oldLeader)
-		require.Eventually(tt, func() bool { return targetLeader.FetchSequencerHealthy() },
-			30*time.Second, 500*time.Millisecond, "target leader's sequencer is not healthy, id: %s", targetLeader)
-		require.Eventually(tt, func() bool { return !oldLeader.FetchPaused() },
-			30*time.Second, 500*time.Millisecond, "current leader's sequencer is paused, id: %s", oldLeader)
-		require.Eventually(tt, func() bool { return !targetLeader.FetchPaused() },
-			30*time.Second, 500*time.Millisecond, "target leader's sequencer is paused, id: %s", targetLeader)
-
-		// ensure that the current leader is the leader before transferring leadership
-		require.Eventually(tt, func() bool { return oldLeader.IsLeader() },
-			30*time.Second, 500*time.Millisecond, "current leader was not found to be the leader")
-		require.Eventually(tt, func() bool { return !targetLeader.IsLeader() },
-			30*time.Second, 500*time.Millisecond, "target leader was already found to be the leader")
-
-		oldLeader.TransferLeadershipTo(targetLeader.info)
-
-		require.Eventually(
-			tt,
-			func() bool { return targetLeader.IsLeader() },
-			5*time.Second, 1*time.Second, "target leader was not found to be the leader",
-		)
-
-		require.False(tt, oldLeader.IsLeader(), "old leader was still found to be the leader")
-
-		// sometimes leadership transfer can cause a very brief period of unhealthiness,
-		// but eventually, they should be healthy again
-		require.Eventually(
-			tt,
-			func() bool { return oldLeader.FetchSequencerHealthy() && targetLeader.FetchSequencerHealthy() },
-			3*time.Second, 1*time.Second, "at least one of the sequencers was found to be unhealthy",
-		)
-	})
+	target.VerifySequencerActive()
+	leader.VerifySequencerInactive()
 }

--- a/op-acceptance-tests/tests/base/conductor/membership_test.go
+++ b/op-acceptance-tests/tests/base/conductor/membership_test.go
@@ -1,0 +1,42 @@
+package conductor
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// TestConductorClusterMembershipChanges verifies an operator can take a
+// conductor out of the Raft cluster and add it back — the flow used when
+// replacing a sequencer machine — with the cluster membership reflecting each
+// change.
+func TestConductorClusterMembershipChanges(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
+
+	sys := presets.NewMinimalWithConductors(t)
+
+	leader := sys.Conductors.Leader()
+	member := sys.Conductors.Followers()[0]
+
+	leader.RemoveFromCluster(member)
+	leader.AddVoterToCluster(member)
+}
+
+// TestConductorRejectsStaleMembershipVersion verifies the optimistic
+// concurrency guard on membership changes: a change submitted against an
+// outdated configuration version is refused and leaves the membership
+// untouched.
+func TestConductorRejectsStaleMembershipVersion(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
+
+	sys := presets.NewMinimalWithConductors(t)
+
+	leader := sys.Conductors.Leader()
+	member := sys.Conductors.Followers()[0]
+
+	leader.VerifyMembershipChangeRejectsStaleVersion(member)
+}

--- a/op-acceptance-tests/tests/base/conductor/proxy_test.go
+++ b/op-acceptance-tests/tests/base/conductor/proxy_test.go
@@ -1,0 +1,26 @@
+package conductor
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// TestConductorProxyServesOnlyLeader verifies the conductor RPC proxy
+// contract that batchers and proposers rely on to follow the active
+// sequencer: the leader's conductor forwards execution, rollup, and admin
+// requests to its sequencer, while a follower's conductor refuses them.
+func TestConductorProxyServesOnlyLeader(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
+
+	sys := presets.NewMinimalWithConductors(t)
+
+	leader := sys.Conductors.Leader()
+	follower := sys.Conductors.Followers()[0]
+
+	leader.VerifyProxyServesSequencerAPIs()
+	follower.VerifyProxyRefusesSequencerAPIs()
+}

--- a/op-devstack/dsl/conductor.go
+++ b/op-devstack/dsl/conductor.go
@@ -11,17 +11,10 @@ import (
 
 type ConductorSet []*Conductor
 
-func NewConductorSet(inner []stack.Conductor) ConductorSet {
-	conductors := make([]*Conductor, len(inner))
-	for i, c := range inner {
-		conductors[i] = NewConductor(c)
-	}
-	return conductors
-}
-
 type Conductor struct {
 	commonImpl
-	inner stack.Conductor
+	inner     stack.Conductor
+	sequencer *L2CLNode
 }
 
 func NewConductor(inner stack.Conductor) *Conductor {
@@ -29,6 +22,18 @@ func NewConductor(inner stack.Conductor) *Conductor {
 		commonImpl: commonFromT(inner.T()),
 		inner:      inner,
 	}
+}
+
+// AttachSequencer links the L2CL node whose sequencer this conductor manages.
+// Preset wiring calls this once at construction time.
+func (c *Conductor) AttachSequencer(cl *L2CLNode) {
+	c.sequencer = cl
+}
+
+// Sequencer returns the L2CL node whose sequencer this conductor manages.
+func (c *Conductor) Sequencer() *L2CLNode {
+	c.require.NotNil(c.sequencer, "conductor %s has no sequencer node attached", c)
+	return c.sequencer
 }
 
 func (c *Conductor) String() string {

--- a/op-devstack/dsl/conductor.go
+++ b/op-devstack/dsl/conductor.go
@@ -2,6 +2,7 @@ package dsl
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
@@ -9,7 +10,85 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 )
 
+// conductorSettleAttempts bounds the polling loops that wait for cluster-wide
+// conditions (leadership, sequencer active-state). Polls are 2s apart.
+const conductorSettleAttempts = 30
+
 type ConductorSet []*Conductor
+
+// common returns the shared test plumbing of the set. The preset always
+// constructs non-empty sets; an empty set is a wiring bug, not a test failure.
+func (s ConductorSet) common() commonImpl {
+	if len(s) == 0 {
+		panic("empty conductor set: preset wiring is broken")
+	}
+	return s[0].commonImpl
+}
+
+// leaderAndFollowers samples Raft leadership across the set once, requiring
+// exactly one leader. It returns errors instead of asserting so polling
+// callers can treat transient RPC failures and unsettled elections as retries.
+func (s ConductorSet) leaderAndFollowers() (*Conductor, []*Conductor, error) {
+	var leader *Conductor
+	followers := make([]*Conductor, 0, len(s))
+	for _, c := range s {
+		isLeader, err := c.isLeader()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to check leadership of %s: %w", c, err)
+		}
+		if !isLeader {
+			followers = append(followers, c)
+			continue
+		}
+		if leader != nil {
+			return nil, nil, fmt.Errorf("multiple Raft leaders: %s and %s", leader, c)
+		}
+		leader = c
+	}
+	if leader == nil {
+		return nil, nil, fmt.Errorf("no Raft leader among %d conductors", len(s))
+	}
+	return leader, followers, nil
+}
+
+// VerifyOneActiveSequencer waits until the cluster has exactly one Raft leader
+// and verifies that only the leader's sequencer is active — the core HA
+// guarantee that exactly one node sequences at any time. It returns the
+// leader's conductor.
+func (s ConductorSet) VerifyOneActiveSequencer() *Conductor {
+	c := s.common()
+	var leader *Conductor
+	err := retry.Do0(c.ctx, conductorSettleAttempts, retry.Fixed(2*time.Second), func() error {
+		l, followers, err := s.leaderAndFollowers()
+		if err != nil {
+			c.log.Info("Waiting for conductor cluster to settle on a single Raft leader", "err", err)
+			return err
+		}
+		active, err := l.Sequencer().sequencerActive()
+		if err != nil {
+			return err
+		}
+		if !active {
+			c.log.Info("Waiting for leader's sequencer to become active", "leader", l)
+			return fmt.Errorf("leader %s sequencer is not active", l)
+		}
+		for _, f := range followers {
+			active, err := f.Sequencer().sequencerActive()
+			if err != nil {
+				return err
+			}
+			if active {
+				c.log.Info("Waiting for follower's sequencer to become inactive", "follower", f)
+				return fmt.Errorf("follower %s sequencer is active", f)
+			}
+		}
+		leader = l
+		return nil
+	})
+	c.require.NoError(err, "expected exactly one active sequencer, the Raft leader's")
+	c.log.Info("Verified exactly one active sequencer", "leader", leader)
+	return leader
+}
 
 type Conductor struct {
 	commonImpl
@@ -94,12 +173,19 @@ func (c *Conductor) FetchPaused() bool {
 
 func (c *Conductor) IsLeader() bool {
 	c.log.Debug("Checking if conductor is leader")
-	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
-	defer cancel()
-	leader, err := c.inner.RpcAPI().Leader(ctx)
+	leader, err := c.isLeader()
 	c.require.NoError(err, "Failed to check if conductor is leader")
 	c.log.Info("Checked if conductor is leader", "leader", leader)
 	return leader
+}
+
+// isLeader reports Raft leadership and returns the RPC error, if any. Internal
+// callers in retry loops use this so a transient RPC failure counts as a retry
+// rather than an instant FailNow.
+func (c *Conductor) isLeader() (bool, error) {
+	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+	defer cancel()
+	return c.inner.RpcAPI().Leader(ctx)
 }
 
 func (c *Conductor) TransferLeadershipTo(targetLeaderInfo consensus.ServerInfo) {

--- a/op-devstack/dsl/conductor.go
+++ b/op-devstack/dsl/conductor.go
@@ -239,6 +239,40 @@ func (c *Conductor) isLeader() (bool, error) {
 	return c.inner.RpcAPI().Leader(ctx)
 }
 
+// Stop shuts down the conductor service via its admin RPC and waits until the
+// conductor stops serving RPC. The service cannot be restarted; tests use this
+// to take cluster members out, e.g. to simulate loss of Raft quorum.
+func (c *Conductor) Stop() {
+	c.log.Info("Stopping conductor", "conductor", c)
+	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+	defer cancel()
+	err := c.inner.RpcAPI().Stop(ctx)
+	c.require.NoErrorf(err, "failed to stop conductor %s", c)
+	err = retry.Do0(c.ctx, conductorSettleAttempts, retry.Fixed(2*time.Second), func() error {
+		if _, err := c.isLeader(); err == nil {
+			return fmt.Errorf("conductor %s is still serving RPC after stop", c)
+		}
+		return nil
+	})
+	c.require.NoErrorf(err, "conductor %s never stopped serving RPC", c)
+	c.log.Info("Stopped conductor", "conductor", c)
+}
+
+// OverrideLeader forces this conductor to report itself as leader regardless
+// of actual Raft state, or clears the override again with false. This is the
+// disaster-recovery escape hatch used when the cluster cannot form a quorum.
+func (c *Conductor) OverrideLeader(override bool) {
+	c.log.Info("Setting conductor leader override", "conductor", c, "override", override)
+	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+	defer cancel()
+	err := c.inner.RpcAPI().OverrideLeader(ctx, override)
+	c.require.NoErrorf(err, "failed to set leader override of conductor %s to %v", c, override)
+	overridden, err := c.inner.RpcAPI().LeaderOverridden(ctx)
+	c.require.NoErrorf(err, "failed to read back leader override of conductor %s", c)
+	c.require.Equalf(override, overridden, "conductor %s did not report the leader override just set", c)
+	c.log.Info("Set conductor leader override", "conductor", c, "override", override)
+}
+
 // proxiedSequencerAPIProbes names one representative request per API family
 // op-conductor proxies for the leader: execution (eth_*), rollup (optimism_*),
 // and node admin (admin_*).

--- a/op-devstack/dsl/conductor.go
+++ b/op-devstack/dsl/conductor.go
@@ -51,6 +51,38 @@ func (s ConductorSet) leaderAndFollowers() (*Conductor, []*Conductor, error) {
 	return leader, followers, nil
 }
 
+// awaitLeadership waits until the cluster agrees on exactly one Raft leader.
+func (s ConductorSet) awaitLeadership() (*Conductor, []*Conductor) {
+	c := s.common()
+	var leader *Conductor
+	var followers []*Conductor
+	err := retry.Do0(c.ctx, conductorSettleAttempts, retry.Fixed(2*time.Second), func() error {
+		l, f, err := s.leaderAndFollowers()
+		if err != nil {
+			c.log.Info("Waiting for conductor cluster to settle on a single Raft leader", "err", err)
+			return err
+		}
+		leader, followers = l, f
+		return nil
+	})
+	c.require.NoError(err, "conductor cluster did not settle on a single Raft leader")
+	return leader, followers
+}
+
+// Leader waits until the cluster agrees on exactly one Raft leader and returns
+// that conductor.
+func (s ConductorSet) Leader() *Conductor {
+	leader, _ := s.awaitLeadership()
+	return leader
+}
+
+// Followers waits until the cluster agrees on exactly one Raft leader and
+// returns all other conductors.
+func (s ConductorSet) Followers() []*Conductor {
+	_, followers := s.awaitLeadership()
+	return followers
+}
+
 // VerifyOneActiveSequencer waits until the cluster has exactly one Raft leader
 // and verifies that only the leader's sequencer is active — the core HA
 // guarantee that exactly one node sequences at any time. It returns the
@@ -137,38 +169,17 @@ func (c *Conductor) FetchClusterMembership() *consensus.ClusterMembership {
 	return clusterMembership
 }
 
-func (c *Conductor) FetchLeader() *consensus.ServerInfo {
-	c.log.Debug("Fetching leader information")
-	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
-	defer cancel()
-	leaderInfo, err := retry.Do[*consensus.ServerInfo](ctx, 2, retry.Fixed(500*time.Millisecond), func() (*consensus.ServerInfo, error) {
-		leaderInfo, err := c.inner.RpcAPI().LeaderWithID(c.ctx)
-		return leaderInfo, err
-	})
-	c.require.NoError(err, "Failed to fetch leader information")
-	c.log.Info("Fetched leader information",
-		"leaderInfo", leaderInfo)
-	return leaderInfo
-}
-
-func (c *Conductor) FetchSequencerHealthy() bool {
-	c.log.Debug("Fetching sequencer healthy status")
-	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
-	defer cancel()
-	healthy, err := c.inner.RpcAPI().SequencerHealthy(ctx)
-	c.require.NoError(err, "Failed to fetch sequencer healthy status")
-	c.log.Info("Fetched sequencer healthy status", "healthy", healthy)
-	return healthy
-}
-
-func (c *Conductor) FetchPaused() bool {
-	c.log.Debug("Fetching paused status")
-	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
-	defer cancel()
-	paused, err := c.inner.RpcAPI().Paused(ctx)
-	c.require.NoError(err, "Failed to fetch paused status")
-	c.log.Info("Fetched paused status", "paused", paused)
-	return paused
+// clusterMemberInfo returns the Raft ServerInfo of the cluster member with the
+// given ID (conductor names double as Raft server IDs in the presets).
+func (c *Conductor) clusterMemberInfo(id string) consensus.ServerInfo {
+	membership := c.FetchClusterMembership()
+	for _, member := range membership.Servers {
+		if member.ID == id {
+			return member
+		}
+	}
+	c.require.FailNowf("unknown cluster member", "no member %q in cluster membership %v", id, membership.Servers)
+	return consensus.ServerInfo{}
 }
 
 func (c *Conductor) IsLeader() bool {
@@ -188,11 +199,99 @@ func (c *Conductor) isLeader() (bool, error) {
 	return c.inner.RpcAPI().Leader(ctx)
 }
 
-func (c *Conductor) TransferLeadershipTo(targetLeaderInfo consensus.ServerInfo) {
-	c.log.Debug("Transferring leadership to target leader", "targetLeaderID", targetLeaderInfo.ID, "targetLeaderAddr", targetLeaderInfo.Addr)
+// waitForLeadership waits until this conductor's Raft leadership matches want.
+func (c *Conductor) waitForLeadership(want bool) {
+	err := retry.Do0(c.ctx, conductorSettleAttempts, retry.Fixed(2*time.Second), func() error {
+		leader, err := c.isLeader()
+		if err != nil {
+			return err
+		}
+		if leader != want {
+			c.log.Info("Waiting for conductor leadership state", "conductor", c, "want", want, "current", leader)
+			return fmt.Errorf("conductor %s leadership is %v, want %v", c, leader, want)
+		}
+		return nil
+	})
+	c.require.NoErrorf(err, "conductor %s never reached leadership=%v", c, want)
+}
+
+// sequencerHealthy reports this conductor's view of its sequencer's health and
+// returns the RPC error, if any, so polling callers can retry on transient
+// failures.
+func (c *Conductor) sequencerHealthy() (bool, error) {
 	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
 	defer cancel()
-	err := c.inner.RpcAPI().TransferLeaderToServer(ctx, targetLeaderInfo.ID, targetLeaderInfo.Addr)
-	c.require.NoError(err, "Failed to transfer leadership to target leader", "targetLeaderID", targetLeaderInfo.ID)
-	c.log.Info("Transferred leadership to target leader", "targetLeaderID", targetLeaderInfo.ID)
+	return c.inner.RpcAPI().SequencerHealthy(ctx)
+}
+
+// VerifySequencerHealthy waits until this conductor reports its sequencer as
+// healthy. Leadership changes may cause brief unhealthiness; this rides those
+// out.
+func (c *Conductor) VerifySequencerHealthy() {
+	err := retry.Do0(c.ctx, conductorSettleAttempts, retry.Fixed(2*time.Second), func() error {
+		healthy, err := c.sequencerHealthy()
+		if err != nil {
+			return err
+		}
+		if !healthy {
+			c.log.Info("Waiting for sequencer to become healthy", "conductor", c)
+			return fmt.Errorf("conductor %s reports unhealthy sequencer", c)
+		}
+		return nil
+	})
+	c.require.NoErrorf(err, "conductor %s never reported a healthy sequencer", c)
+	c.log.Info("Verified sequencer is healthy", "conductor", c)
+}
+
+// VerifySequencerActive waits until the sequencer managed by this conductor
+// reports that it is actively sequencing.
+func (c *Conductor) VerifySequencerActive() {
+	c.verifySequencerActive(true)
+}
+
+// VerifySequencerInactive waits until the sequencer managed by this conductor
+// reports that it has stopped sequencing.
+func (c *Conductor) VerifySequencerInactive() {
+	c.verifySequencerActive(false)
+}
+
+func (c *Conductor) verifySequencerActive(want bool) {
+	err := retry.Do0(c.ctx, conductorSettleAttempts, retry.Fixed(2*time.Second), func() error {
+		active, err := c.Sequencer().sequencerActive()
+		if err != nil {
+			return err
+		}
+		if active != want {
+			c.log.Info("Waiting for sequencer active-state", "conductor", c, "want", want, "current", active)
+			return fmt.Errorf("sequencer of %s active is %v, want %v", c, active, want)
+		}
+		return nil
+	})
+	c.require.NoErrorf(err, "sequencer of conductor %s never reached active=%v", c, want)
+	c.log.Info("Verified sequencer active-state", "conductor", c, "active", want)
+}
+
+// TransferLeadershipTo transfers Raft leadership from this conductor to the
+// target conductor. It waits for the preconditions op-conductor requires (this
+// conductor leads and actively sequences, the target is healthy), then
+// performs the transfer and waits until the target has taken over leadership.
+//
+// Sequencer active-state transitions are deliberately not asserted here so
+// tests can verify them explicitly; see VerifySequencerActive and
+// VerifySequencerInactive.
+func (c *Conductor) TransferLeadershipTo(target *Conductor) {
+	c.log.Info("Transferring leadership", "from", c, "to", target)
+	c.waitForLeadership(true)
+	c.VerifySequencerActive()
+	target.VerifySequencerHealthy()
+
+	info := c.clusterMemberInfo(target.String())
+	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+	defer cancel()
+	err := c.inner.RpcAPI().TransferLeaderToServer(ctx, info.ID, info.Addr)
+	c.require.NoErrorf(err, "failed to transfer leadership from %s to %s", c, target)
+
+	target.waitForLeadership(true)
+	c.waitForLeadership(false)
+	c.log.Info("Transferred leadership", "from", c, "to", target)
 }

--- a/op-devstack/dsl/conductor.go
+++ b/op-devstack/dsl/conductor.go
@@ -2,6 +2,7 @@ package dsl
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -236,6 +237,50 @@ func (c *Conductor) isLeader() (bool, error) {
 	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
 	defer cancel()
 	return c.inner.RpcAPI().Leader(ctx)
+}
+
+// proxiedSequencerAPIProbes names one representative request per API family
+// op-conductor proxies for the leader: execution (eth_*), rollup (optimism_*),
+// and node admin (admin_*).
+var proxiedSequencerAPIProbes = []struct {
+	method string
+	args   []any
+}{
+	{method: "eth_getBlockByNumber", args: []any{"latest", false}},
+	{method: "optimism_syncStatus"},
+	{method: "admin_sequencerActive"},
+}
+
+// VerifyProxyServesSequencerAPIs verifies this conductor's RPC endpoint
+// forwards execution, rollup, and admin requests to its sequencer. Conductors
+// only proxy for the leader, so this asserts the leader-facing side of the
+// proxy contract; batchers and proposers rely on it to follow the active
+// sequencer.
+func (c *Conductor) VerifyProxyServesSequencerAPIs() {
+	for _, probe := range proxiedSequencerAPIProbes {
+		ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+		var result json.RawMessage
+		err := c.inner.ProxyRPC().CallContext(ctx, &result, probe.method, probe.args...)
+		cancel()
+		c.require.NoErrorf(err, "expected conductor %s to proxy %s to its sequencer", c, probe.method)
+	}
+	c.log.Info("Verified conductor proxies sequencer APIs", "conductor", c)
+}
+
+// VerifyProxyRefusesSequencerAPIs verifies this conductor's RPC endpoint
+// refuses to proxy sequencer requests, as it must while it is not the leader —
+// otherwise a batcher following the conductor endpoints could read from a
+// stale sequencer.
+func (c *Conductor) VerifyProxyRefusesSequencerAPIs() {
+	for _, probe := range proxiedSequencerAPIProbes {
+		ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+		var result json.RawMessage
+		err := c.inner.ProxyRPC().CallContext(ctx, &result, probe.method, probe.args...)
+		cancel()
+		c.require.ErrorContainsf(err, "refusing to proxy request to non-leader sequencer",
+			"expected conductor %s to refuse proxying %s", c, probe.method)
+	}
+	c.log.Info("Verified conductor refuses to proxy sequencer APIs", "conductor", c)
 }
 
 // waitForLeadership waits until this conductor's Raft leadership matches want.

--- a/op-devstack/dsl/conductor.go
+++ b/op-devstack/dsl/conductor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 )
 
@@ -120,6 +121,32 @@ func (s ConductorSet) VerifyOneActiveSequencer() *Conductor {
 	c.require.NoError(err, "expected exactly one active sequencer, the Raft leader's")
 	c.log.Info("Verified exactly one active sequencer", "leader", leader)
 	return leader
+}
+
+// VerifyUnsafeChainAdvancesAndConverges waits until every conductor-managed
+// sequencer node advances its unsafe head by at least delta blocks, and until
+// all nodes agree on the canonical unsafe chain. Together these prove the
+// active sequencer keeps producing blocks and its peers follow the same chain,
+// e.g. after a leadership change.
+func (s ConductorSet) VerifyUnsafeChainAdvancesAndConverges(delta uint64) {
+	c := s.common()
+	c.log.Info("Verifying the unsafe chain advances on all sequencer nodes and converges", "delta", delta)
+	advanceChecks := make([]CheckFunc, 0, len(s))
+	for _, con := range s {
+		advanceChecks = append(advanceChecks, con.Sequencer().AdvancedFn(safety.LocalUnsafe, delta, conductorSettleAttempts))
+	}
+	CheckAll(c.t, advanceChecks...)
+
+	// Check convergence only after every node has advanced. Running these
+	// checks in parallel with the advancement checks would let them pass at the
+	// shared pre-transfer head without verifying any newly produced block.
+	ref := s[0].Sequencer()
+	convergenceChecks := make([]CheckFunc, 0, len(s)-1)
+	for _, con := range s[1:] {
+		convergenceChecks = append(convergenceChecks, con.Sequencer().InSyncFn(ref, safety.LocalUnsafe, conductorSettleAttempts))
+	}
+	CheckAll(c.t, convergenceChecks...)
+	c.log.Info("Verified the unsafe chain advances on all sequencer nodes and converges", "delta", delta)
 }
 
 type Conductor struct {

--- a/op-devstack/dsl/conductor.go
+++ b/op-devstack/dsl/conductor.go
@@ -26,6 +26,18 @@ func (s ConductorSet) common() commonImpl {
 	return s[0].commonImpl
 }
 
+// Without returns the set without the given conductor, e.g. the survivors of
+// an injected failure.
+func (s ConductorSet) Without(exclude *Conductor) ConductorSet {
+	out := make(ConductorSet, 0, len(s))
+	for _, c := range s {
+		if c != exclude {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
 // leaderAndFollowers samples Raft leadership across the set once, requiring
 // exactly one leader. It returns errors instead of asserting so polling
 // callers can treat transient RPC failures and unsettled elections as retries.

--- a/op-devstack/dsl/conductor.go
+++ b/op-devstack/dsl/conductor.go
@@ -239,6 +239,77 @@ func (c *Conductor) isLeader() (bool, error) {
 	return c.inner.RpcAPI().Leader(ctx)
 }
 
+// verifyClusterMembership waits until the presence of the given server ID in
+// the cluster membership matches want.
+func (c *Conductor) verifyClusterMembership(id string, want bool) {
+	err := retry.Do0(c.ctx, conductorSettleAttempts, retry.Fixed(2*time.Second), func() error {
+		ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+		defer cancel()
+		membership, err := c.inner.RpcAPI().ClusterMembership(ctx)
+		if err != nil {
+			return err
+		}
+		present := false
+		for _, member := range membership.Servers {
+			if member.ID == id {
+				present = true
+				break
+			}
+		}
+		if present != want {
+			c.log.Info("Waiting for cluster membership", "conductor", c, "member", id, "want", want, "present", present)
+			return fmt.Errorf("membership of %s is %v, want %v", id, present, want)
+		}
+		return nil
+	})
+	c.require.NoErrorf(err, "cluster membership never reflected member %s present=%v", id, want)
+}
+
+// RemoveFromCluster removes the target conductor from the Raft cluster, using
+// the current configuration version. This is a leader-only operation.
+func (c *Conductor) RemoveFromCluster(target *Conductor) {
+	c.log.Info("Removing conductor from cluster", "leader", c, "target", target)
+	membership := c.FetchClusterMembership()
+	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+	defer cancel()
+	err := c.inner.RpcAPI().RemoveServer(ctx, target.String(), membership.Version)
+	c.require.NoErrorf(err, "failed to remove %s from the cluster", target)
+	c.verifyClusterMembership(target.String(), false)
+	c.log.Info("Removed conductor from cluster", "leader", c, "target", target)
+}
+
+// AddVoterToCluster adds the target conductor to the Raft cluster as a voter,
+// using the current configuration version. This is a leader-only operation.
+func (c *Conductor) AddVoterToCluster(target *Conductor) {
+	c.log.Info("Adding conductor to cluster as voter", "leader", c, "target", target)
+	membership := c.FetchClusterMembership()
+	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+	defer cancel()
+	err := c.inner.RpcAPI().AddServerAsVoter(ctx, target.String(), target.Escape().ConsensusEndpoint(), membership.Version)
+	c.require.NoErrorf(err, "failed to add %s to the cluster as voter", target)
+	c.verifyClusterMembership(target.String(), true)
+	c.log.Info("Added conductor to cluster as voter", "leader", c, "target", target)
+}
+
+// VerifyMembershipChangeRejectsStaleVersion attempts to remove the target
+// conductor using an outdated configuration version and asserts op-conductor
+// refuses the change and leaves the membership untouched. The version check is
+// the optimistic-concurrency guard operators rely on when automating
+// membership changes.
+func (c *Conductor) VerifyMembershipChangeRejectsStaleVersion(target *Conductor) {
+	membership := c.FetchClusterMembership()
+	ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+	defer cancel()
+	err := c.inner.RpcAPI().RemoveServer(ctx, target.String(), membership.Version-1)
+	c.require.ErrorContainsf(err, "configuration changed since",
+		"expected removal of %s with a stale configuration version to be refused", target)
+	after := c.FetchClusterMembership()
+	c.require.Equalf(len(membership.Servers), len(after.Servers),
+		"membership must be unchanged after refused removal of %s", target)
+	c.verifyClusterMembership(target.String(), true)
+	c.log.Info("Verified stale-version membership change is rejected", "conductor", c, "target", target)
+}
+
 // Stop shuts down the conductor service via its admin RPC and waits until the
 // conductor stops serving RPC. The service cannot be restarted; tests use this
 // to take cluster members out, e.g. to simulate loss of Raft quorum.

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -139,6 +139,15 @@ func (cl *L2CLNode) SetSequencerRecoverMode(b bool) error {
 	return cl.inner.RollupAPI().SetRecoverMode(cl.ctx, b)
 }
 
+// sequencerActive fetches the sequencer active-state and returns the RPC
+// error, if any. Internal callers in retry/eventually loops use this so a
+// transient RPC timeout counts as a retry rather than an instant FailNow.
+func (cl *L2CLNode) sequencerActive() (bool, error) {
+	ctx, cancel := context.WithTimeout(cl.ctx, DefaultTimeout)
+	defer cancel()
+	return cl.inner.RollupAPI().SequencerActive(ctx)
+}
+
 // syncStatus fetches the L2CL sync status and returns the RPC error, if any.
 // Internal callers in retry/eventually loops use this so a transient RPC timeout
 // counts as a retry rather than an instant FailNow.

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -139,6 +139,26 @@ func (cl *L2CLNode) SetSequencerRecoverMode(b bool) error {
 	return cl.inner.RollupAPI().SetRecoverMode(cl.ctx, b)
 }
 
+// OverrideLeader disables the node's conductor interactions so its sequencer
+// can run in non-HA mode during disaster recovery. The override cannot be
+// cleared through the node's admin API.
+func (cl *L2CLNode) OverrideLeader() {
+	err := cl.inner.RollupAPI().OverrideLeader(cl.ctx)
+	cl.require.NoError(err, "Expected to be able to override conductor leadership on the node")
+	cl.log.Info("Overrode conductor leadership on node", "chain", cl.ChainID())
+}
+
+// VerifyStartSequencerRefused attempts to start the sequencer at the node's
+// current unsafe head and asserts the request is refused with an error
+// containing errContains — e.g. a conductor-managed node refusing to sequence
+// while its conductor is not the Raft leader.
+func (cl *L2CLNode) VerifyStartSequencerRefused(errContains string) {
+	unsafe := cl.HeadBlockRef(safety.LocalUnsafe)
+	err := cl.inner.RollupAPI().StartSequencer(cl.ctx, unsafe.Hash)
+	cl.require.ErrorContains(err, errContains, "expected StartSequencer to be refused")
+	cl.log.Info("StartSequencer was refused as expected", "chain", cl.ChainID(), "err", err)
+}
+
 // sequencerActive fetches the sequencer active-state and returns the RPC
 // error, if any. Internal callers in retry/eventually loops use this so a
 // transient RPC timeout counts as a retry rather than an instant FailNow.

--- a/op-devstack/presets/minimal_with_conductors.go
+++ b/op-devstack/presets/minimal_with_conductors.go
@@ -10,6 +10,11 @@ import (
 type MinimalWithConductors struct {
 	*Minimal
 
+	// Conductors are the conductors of the single L2 chain, one per sequencer
+	// node. Each conductor is linked to the L2CL node it manages (see
+	// dsl.Conductor.Sequencer).
+	Conductors dsl.ConductorSet
+
 	ConductorSets map[eth.ChainID]dsl.ConductorSet
 }
 

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -38,6 +38,7 @@ const (
 	optionKindSupernodeVNSequencerForBootstrap
 	optionKindZKDisputeGame
 	optionKindZKProposer
+	optionKindConductorFastHealthChecks
 )
 
 const allOptionKinds = optionKindDeployer |
@@ -66,7 +67,8 @@ const allOptionKinds = optionKindDeployer |
 	optionKindInteropAtGenesis |
 	optionKindSupernodeVNSequencerForBootstrap |
 	optionKindZKDisputeGame |
-	optionKindZKProposer
+	optionKindZKProposer |
+	optionKindConductorFastHealthChecks
 
 var optionKindLabels = []struct {
 	kind  optionKinds
@@ -99,6 +101,7 @@ var optionKindLabels = []struct {
 	{kind: optionKindSupernodeVNSequencerForBootstrap, label: "supernode VN sequencer for bootstrap"},
 	{kind: optionKindZKDisputeGame, label: "ZK dispute game"},
 	{kind: optionKindZKProposer, label: "ZK proposer options"},
+	{kind: optionKindConductorFastHealthChecks, label: "conductor fast health checks"},
 }
 
 func (k optionKinds) String() string {
@@ -157,7 +160,8 @@ const minimalPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindProofValidation |
 	optionKindSkipHonestProposer
 
-const minimalWithConductorsPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds
+const minimalWithConductorsPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds |
+	optionKindConductorFastHealthChecks
 
 const simpleWithSyncTesterPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds |
 	optionKindGlobalSyncTesterEL

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -386,6 +386,19 @@ func WithoutHonestChallenger() Option {
 	}
 }
 
+// WithConductorFastHealthChecks runs conductor health checks every second so
+// health-based failover reacts to sequencer failures within test timescales.
+// The default conductor preset effectively disables health monitoring (hourly
+// checks) to keep manual leadership operations deterministic.
+func WithConductorFastHealthChecks() Option {
+	return option{
+		kinds: optionKindConductorFastHealthChecks,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			cfg.ConductorFastHealthChecks = true
+		},
+	}
+}
+
 // WithInteropAtGenesis activates the Lagoon hardfork at genesis on the L2 chain and provisions
 // a DependencySet for op-node startup without a supervisor. Required by presets that exercise
 // interop-gated consensus features (e.g. SDM PostExec).

--- a/op-devstack/presets/rpc_frontends.go
+++ b/op-devstack/presets/rpc_frontends.go
@@ -524,8 +524,9 @@ func (r *supernodeFrontend) Running() bool {
 
 type conductorFrontend struct {
 	presetCommon
-	chainID eth.ChainID
-	api     conductorRpc.API
+	chainID   eth.ChainID
+	api       conductorRpc.API
+	rpcClient opclient.RPC
 }
 
 var _ stack.Conductor = (*conductorFrontend)(nil)
@@ -536,6 +537,7 @@ func newPresetConductor(t devtest.T, name string, chainID eth.ChainID, rpcCl *ge
 		presetCommon: newPresetCommon(t, name),
 		chainID:      chainID,
 		api:          conductorRpc.NewAPIClient(rpcCl),
+		rpcClient:    opclient.NewBaseRPCClient(rpcCl),
 	}
 }
 
@@ -545,6 +547,10 @@ func (r *conductorFrontend) ChainID() eth.ChainID {
 
 func (r *conductorFrontend) RpcAPI() conductorRpc.API {
 	return r.api
+}
+
+func (r *conductorFrontend) ProxyRPC() opclient.RPC {
+	return r.rpcClient
 }
 
 type testSequencerFrontend struct {

--- a/op-devstack/presets/rpc_frontends.go
+++ b/op-devstack/presets/rpc_frontends.go
@@ -524,20 +524,22 @@ func (r *supernodeFrontend) Running() bool {
 
 type conductorFrontend struct {
 	presetCommon
-	chainID   eth.ChainID
-	api       conductorRpc.API
-	rpcClient opclient.RPC
+	chainID           eth.ChainID
+	api               conductorRpc.API
+	rpcClient         opclient.RPC
+	consensusEndpoint string
 }
 
 var _ stack.Conductor = (*conductorFrontend)(nil)
 
-func newPresetConductor(t devtest.T, name string, chainID eth.ChainID, rpcCl *gethrpc.Client) *conductorFrontend {
+func newPresetConductor(t devtest.T, name string, chainID eth.ChainID, rpcCl *gethrpc.Client, consensusEndpoint string) *conductorFrontend {
 	t = t.WithCtx(stack.ContextWithChainID(t.Ctx(), chainID))
 	return &conductorFrontend{
-		presetCommon: newPresetCommon(t, name),
-		chainID:      chainID,
-		api:          conductorRpc.NewAPIClient(rpcCl),
-		rpcClient:    opclient.NewBaseRPCClient(rpcCl),
+		presetCommon:      newPresetCommon(t, name),
+		chainID:           chainID,
+		api:               conductorRpc.NewAPIClient(rpcCl),
+		rpcClient:         opclient.NewBaseRPCClient(rpcCl),
+		consensusEndpoint: consensusEndpoint,
 	}
 }
 
@@ -551,6 +553,10 @@ func (r *conductorFrontend) RpcAPI() conductorRpc.API {
 
 func (r *conductorFrontend) ProxyRPC() opclient.RPC {
 	return r.rpcClient
+}
+
+func (r *conductorFrontend) ConsensusEndpoint() string {
+	return r.consensusEndpoint
 }
 
 type testSequencerFrontend struct {

--- a/op-devstack/presets/singlechain_from_runtime.go
+++ b/op-devstack/presets/singlechain_from_runtime.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
-	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -264,23 +263,36 @@ func minimalWithConductorsFromRuntime(t devtest.T, runtime *sysgo.SingleChainRun
 	l2ChainID := runtime.L2Network.ChainID()
 	t.Require().NotNil(runtime.Conductors, "missing conductor support")
 
-	cAName := "sequencer"
-	cBName := "b"
-	cCName := "c"
-	cA := newConductorFrontend(t, cAName, l2ChainID, runtime.Conductors[cAName].HTTPEndpoint())
-	cB := newConductorFrontend(t, cBName, l2ChainID, runtime.Conductors[cBName].HTTPEndpoint())
-	cC := newConductorFrontend(t, cCName, l2ChainID, runtime.Conductors[cCName].HTTPEndpoint())
 	l2Net, ok := minimal.L2Chain.Escape().(*presetL2Network)
 	t.Require().True(ok, "expected preset L2 network")
-	l2Net.AddConductor(cA)
-	l2Net.AddConductor(cB)
-	l2Net.AddConductor(cC)
 
-	conductors := []stack.Conductor{cA, cB, cC}
+	// The primary sequencer node frontends already exist on Minimal; build
+	// frontends for the other two sequencer nodes the conductors manage.
+	sequencerCLs := map[string]*dsl.L2CLNode{"sequencer": minimal.L2CL}
+	for _, name := range []string{"b", "c"} {
+		node := runtime.Nodes[name]
+		t.Require().NotNilf(node, "missing single-chain node %s", name)
+		el := newL2ELFrontend(t, name, l2ChainID, node.EL.UserRPC(), node.EL.EngineRPC(), node.EL.JWTPath(), runtime.L2Network.RollupConfig(), node.EL)
+		cl := newL2CLFrontend(t, name, l2ChainID, node.CL.UserRPC(), node.CL)
+		cl.attachEL(el)
+		l2Net.AddL2ELNode(el)
+		l2Net.AddL2CLNode(cl)
+		sequencerCLs[name] = dsl.NewL2CLNode(cl)
+	}
+	conductors := make(dsl.ConductorSet, 0, len(sequencerCLs))
+	for _, name := range []string{"sequencer", "b", "c"} {
+		frontend := newConductorFrontend(t, name, l2ChainID, runtime.Conductors[name].HTTPEndpoint())
+		l2Net.AddConductor(frontend)
+		conductor := dsl.NewConductor(frontend)
+		conductor.AttachSequencer(sequencerCLs[name])
+		conductors = append(conductors, conductor)
+	}
+
 	return &MinimalWithConductors{
-		Minimal: minimal,
+		Minimal:    minimal,
+		Conductors: conductors,
 		ConductorSets: map[eth.ChainID]dsl.ConductorSet{
-			l2ChainID: dsl.NewConductorSet(conductors),
+			l2ChainID: conductors,
 		},
 	}
 }

--- a/op-devstack/presets/singlechain_from_runtime.go
+++ b/op-devstack/presets/singlechain_from_runtime.go
@@ -279,6 +279,11 @@ func minimalWithConductorsFromRuntime(t devtest.T, runtime *sysgo.SingleChainRun
 		l2Net.AddL2CLNode(cl)
 		sequencerCLs[name] = dsl.NewL2CLNode(cl)
 	}
+	// Keep the p2p mesh intact across node restarts mid-test (e.g. failover tests).
+	sequencerCLs["b"].ManagePeer(sequencerCLs["sequencer"])
+	sequencerCLs["c"].ManagePeer(sequencerCLs["sequencer"])
+	sequencerCLs["c"].ManagePeer(sequencerCLs["b"])
+
 	conductors := make(dsl.ConductorSet, 0, len(sequencerCLs))
 	for _, name := range []string{"sequencer", "b", "c"} {
 		frontend := newConductorFrontend(t, name, l2ChainID, runtime.Conductors[name].HTTPEndpoint())

--- a/op-devstack/presets/singlechain_from_runtime.go
+++ b/op-devstack/presets/singlechain_from_runtime.go
@@ -286,7 +286,7 @@ func minimalWithConductorsFromRuntime(t devtest.T, runtime *sysgo.SingleChainRun
 
 	conductors := make(dsl.ConductorSet, 0, len(sequencerCLs))
 	for _, name := range []string{"sequencer", "b", "c"} {
-		frontend := newConductorFrontend(t, name, l2ChainID, runtime.Conductors[name].HTTPEndpoint())
+		frontend := newConductorFrontend(t, name, l2ChainID, runtime.Conductors[name].HTTPEndpoint(), runtime.Conductors[name].ConsensusEndpoint())
 		l2Net.AddConductor(frontend)
 		conductor := dsl.NewConductor(frontend)
 		conductor.AttachSequencer(sequencerCLs[name])

--- a/op-devstack/presets/sysgo_runtime.go
+++ b/op-devstack/presets/sysgo_runtime.go
@@ -139,11 +139,11 @@ func newSupernodeFrontend(t devtest.T, name string, userRPC string, control ...s
 	return supernode
 }
 
-func newConductorFrontend(t devtest.T, name string, chainID eth.ChainID, rpcEndpoint string) *conductorFrontend {
+func newConductorFrontend(t devtest.T, name string, chainID eth.ChainID, rpcEndpoint string, consensusEndpoint string) *conductorFrontend {
 	rpcCl, err := rpc.DialContext(t.Ctx(), rpcEndpoint)
 	t.Require().NoError(err)
 	t.Cleanup(rpcCl.Close)
-	return newPresetConductor(t, name, chainID, rpcCl)
+	return newPresetConductor(t, name, chainID, rpcCl, consensusEndpoint)
 }
 
 func newTestSequencerFrontend(t devtest.T, name string, adminRPC string, controlRPCs map[eth.ChainID]string, jwtSecret [32]byte) *testSequencerFrontend {

--- a/op-devstack/stack/conductor.go
+++ b/op-devstack/stack/conductor.go
@@ -2,6 +2,7 @@ package stack
 
 import (
 	conductorRpc "github.com/ethereum-optimism/optimism/op-conductor/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -10,4 +11,10 @@ type Conductor interface {
 	ChainID() eth.ChainID
 
 	RpcAPI() conductorRpc.API
+
+	// ProxyRPC exposes the conductor's RPC endpoint for raw calls. With RPC
+	// proxying enabled, op-conductor forwards execution (eth_*), rollup
+	// (optimism_*), and admin (admin_*) requests to its sequencer while it is
+	// the leader, so batchers and proposers can follow the active sequencer.
+	ProxyRPC() client.RPC
 }

--- a/op-devstack/stack/conductor.go
+++ b/op-devstack/stack/conductor.go
@@ -17,4 +17,8 @@ type Conductor interface {
 	// (optimism_*), and admin (admin_*) requests to its sequencer while it is
 	// the leader, so batchers and proposers can follow the active sequencer.
 	ProxyRPC() client.RPC
+
+	// ConsensusEndpoint is the Raft consensus address of this conductor, used
+	// when (re-)adding it to a cluster.
+	ConsensusEndpoint() string
 }

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -81,6 +81,13 @@ type PresetConfig struct {
 	// sequencers stopped, so the VN can bootstrap the chain the light sequencers EL-sync
 	// from before a test hands off sequencing to them.
 	SupernodeVNSequencerForBootstrap bool
+	// ConductorFastHealthChecks runs conductor health checks every second
+	// instead of the effectively-disabled hourly default, so conductor-driven
+	// failover reacts to sequencer failures within test timescales. Health
+	// stays purely liveness-based: the unsafe/safe staleness windows remain at
+	// an hour so chain-progression hiccups under CI load cannot flip a healthy
+	// sequencer to unhealthy.
+	ConductorFastHealthChecks bool
 }
 
 func NewPresetConfig() PresetConfig {

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -2,6 +2,7 @@ package sysgo
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"encoding/hex"
 	"flag"
 	"fmt"
@@ -34,6 +35,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	sequencerConfig "github.com/ethereum-optimism/optimism/op-test-sequencer/config"
 	testmetrics "github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
@@ -278,6 +280,17 @@ type l2CLNodeStartConfig struct {
 	SequencerStopped bool
 }
 
+// renewableP2PSignerSetup mints a fresh signer on every SetupSigner call, so
+// an op-node that is stopped and started again (which closes the previous
+// signer) can keep signing gossip after the restart.
+type renewableP2PSignerSetup struct {
+	priv *ecdsa.PrivateKey
+}
+
+func (s *renewableP2PSignerSetup) SetupSigner(context.Context) (p2p.Signer, error) {
+	return opsigner.NewLocalSigner(s.priv), nil
+}
+
 func startL2CLNode(
 	t devtest.T,
 	keys devkeys.Keys,
@@ -342,10 +355,10 @@ func startL2CLNode(
 	if cfg.IsSequencer {
 		p2pKey, err := keys.Secret(devkeys.SequencerP2PRole.Key(l2Net.ChainID().ToBig()))
 		require.NoError(err, "need p2p key for sequencer")
-		p2pKeyHex := hex.EncodeToString(crypto.FromECDSA(p2pKey))
-		require.NoError(fs.Set(opNodeFlags.SequencerP2PKeyName, p2pKeyHex))
-		p2pSignerSetup, err = p2pcli.LoadSignerSetup(cliCtx, logger)
-		require.NoError(err, "failed to load p2p signer")
+		// Not a PreparedSigner: the node closes its signer on shutdown, and a
+		// PreparedSigner would hand the closed instance back to a restarted
+		// node, leaving it unable to sign gossip ("signer is closed").
+		p2pSignerSetup = &renewableP2PSignerSetup{priv: p2pKey}
 	}
 	p2pConfig, err := p2pcli.NewConfig(cliCtx, l2Net.rollupCfg.BlockTime)
 	require.NoError(err, "failed to load p2p config")

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -118,6 +118,37 @@ func startDefaultSingleChainPrimary(
 	}
 }
 
+// startStoppedSingleChainPrimary builds an op-node sequencer that is inactive
+// from its first start. Conductor presets use this to ensure no node can create
+// an independent unsafe fork before the Raft cluster and p2p mesh are ready.
+func startStoppedSingleChainPrimary(
+	t devtest.T,
+	keys devkeys.Keys,
+	world singleChainRuntimeWorld,
+	l1EL *L1Geth,
+	l1CL *L1CLNode,
+	jwtPath string,
+	jwtSecret [32]byte,
+	cfg PresetConfig,
+) singleChainPrimaryRuntime {
+	t.Require().Nil(world.Interop, "conductor primary does not support interop")
+	safeDBPath := filepath.Join(t.TempDirWithPrefix("l2-safe-db-"+world.L2Network.ChainID().String()), "safe-head.db")
+	l2CLOptions := []L2CLOption{L2CLOptionFn(func(_ devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
+		cfg.SafeDBPath = safeDBPath
+	})}
+	l2CLOptions = append(l2CLOptions, cfg.GlobalL2CLOptions...)
+	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, NewELNodeIdentity(0))
+	l2CL := startL2CLNode(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
+		Key:              "sequencer",
+		IsSequencer:      true,
+		NoDiscovery:      true,
+		EnableReqResp:    true,
+		L2CLOptions:      l2CLOptions,
+		SequencerStopped: true,
+	})
+	return singleChainPrimaryRuntime{EL: l2EL, CL: l2CL}
+}
+
 func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleChainRuntimeSpec) *SingleChainRuntime {
 	require := t.Require()
 

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -10,6 +10,7 @@ import (
 
 	opconductor "github.com/ethereum-optimism/optimism/op-conductor/conductor"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -109,18 +110,39 @@ func NewMinimalWithConductorsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *S
 	// challenger, and rust e2e jobs do not build cannon artifacts.
 	runtime := newSingleChainRuntimeWithConfig(t, cfg, singleChainRuntimeSpec{
 		BuildWorld:      newDefaultSingleChainWorld,
-		StartPrimary:    startDefaultSingleChainPrimary,
+		StartPrimary:    startStoppedSingleChainPrimary,
 		StartBatcher:    true,
 		StartProposer:   true,
 		StartChallenger: false,
 	})
-	nodeB := addSingleChainOpNode(t, runtime, "b", true, "", cfg.GlobalL2CLOptions...)
-	nodeC := addSingleChainOpNode(t, runtime, "c", true, "", cfg.GlobalL2CLOptions...)
+	nodeB := addStoppedSingleChainSequencerNode(t, runtime, "b", cfg.GlobalL2CLOptions...)
+	nodeC := addStoppedSingleChainSequencerNode(t, runtime, "c", cfg.GlobalL2CLOptions...)
 
-	conductorA := startConductorNode(t, "sequencer", runtime.L2Network, runtime.L2CL.(*OpNode), runtime.L2EL, true, false)
+	primaryCL := runtime.L2CL.(*OpNode)
+	conductorA := startConductorNode(t, "sequencer", runtime.L2Network, primaryCL, runtime.L2EL, true, false)
 	conductorB := startConductorNode(t, "b", runtime.L2Network, nodeB.CL.(*OpNode), nodeB.EL, false, true)
 	conductorC := startConductorNode(t, "c", runtime.L2Network, nodeC.CL.(*OpNode), nodeC.EL, false, true)
-	startConductorCluster(t, conductorA, []*Conductor{conductorB, conductorC})
+
+	// Mesh the sequencer CL nodes over p2p, as in a production HA deployment:
+	// the active sequencer gossips unsafe blocks to the followers, which keeps
+	// them close enough to the raft-committed head for the conductor to start
+	// them on leadership changes (op-conductor only backfills a single missing
+	// block). EL p2p is not needed — unsafe blocks reach the follower ELs via
+	// CL gossip and the engine API. Peering must happen after
+	// startConductorNode, which restarts each op-node and would drop earlier
+	// connections.
+	connectSingleChainCLPeer(t, runtime.L2CL, nodeB.CL)
+	connectSingleChainCLPeer(t, runtime.L2CL, nodeC.CL)
+	connectSingleChainCLPeer(t, nodeB.CL, nodeC.CL)
+	runtime.P2PEnabled = true
+
+	startConductorCluster(
+		t,
+		conductorA,
+		primaryCL,
+		[]*Conductor{conductorB, conductorC},
+		[]*OpNode{nodeB.CL.(*OpNode), nodeC.CL.(*OpNode)},
+	)
 
 	runtime.Conductors = map[string]*Conductor{
 		"sequencer": conductorA,
@@ -170,6 +192,30 @@ func addSingleChainOpNode(
 	l2EL := startL2ELForKey(t, runtime.L2Network, jwtPath, jwtSecret, name, NewELNodeIdentity(0))
 	l2CL := startL2CLForKey(t, runtime.Keys, runtime.L1Network, runtime.L2Network, runtime.L1EL, runtime.L1CL, l2EL, jwtSecret, name, name, isSequencer, followSource, l2Opts)
 	node := newSingleChainNodeRuntime(name, isSequencer, l2EL, l2CL)
+	runtime.Nodes[name] = node
+	return node
+}
+
+// addStoppedSingleChainSequencerNode builds an op-node sequencer that cannot
+// create an unsafe fork before its conductor cluster is ready.
+func addStoppedSingleChainSequencerNode(
+	t devtest.T,
+	runtime *SingleChainRuntime,
+	name string,
+	l2Opts ...L2CLOption,
+) *SingleChainNodeRuntime {
+	jwtPath := runtime.L2EL.JWTPath()
+	jwtSecret := readJWTSecretFromPath(t, jwtPath)
+	l2EL := startL2ELForKey(t, runtime.L2Network, jwtPath, jwtSecret, name, NewELNodeIdentity(0))
+	l2CL := startL2CLNode(t, runtime.Keys, runtime.L1Network, runtime.L2Network, runtime.L1EL, runtime.L1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
+		Key:              name,
+		IsSequencer:      true,
+		NoDiscovery:      true,
+		EnableReqResp:    true,
+		L2CLOptions:      l2Opts,
+		SequencerStopped: true,
+	})
+	node := newSingleChainNodeRuntime(name, true, l2EL, l2CL)
 	runtime.Nodes[name] = node
 	return node
 }
@@ -319,8 +365,15 @@ func startConductorNode(
 	return out
 }
 
-func startConductorCluster(t devtest.T, bootstrap *Conductor, members []*Conductor) {
+func startConductorCluster(
+	t devtest.T,
+	bootstrap *Conductor,
+	bootstrapNode *OpNode,
+	members []*Conductor,
+	memberNodes []*OpNode,
+) {
 	require := t.Require()
+	require.Len(memberNodes, len(members), "each conductor member must have a sequencer node")
 	ctx, cancel := context.WithTimeout(t.Ctx(), 90*time.Second)
 	defer cancel()
 
@@ -356,6 +409,53 @@ func startConductorCluster(t devtest.T, bootstrap *Conductor, members []*Conduct
 		return nil
 	})
 	require.NoError(err, "conductor cluster did not converge to expected membership")
+
+	// A fresh Raft FSM holds no unsafe payload, so a conductor refuses to
+	// start a sequencer on its own (ErrNoUnsafeHead). Seed sequencing manually
+	// on the bootstrap node — exactly how an operator bootstraps a production
+	// HA cluster. All sequencers started stopped, so they share the same initial
+	// head and cannot create competing forks before this point.
+	rollupClient, err := dial.DialRollupClientWithTimeout(ctx, t.Logger(), bootstrapNode.UserRPC())
+	require.NoError(err, "failed to dial bootstrap sequencer node")
+	initialStatus, err := rollupClient.SyncStatus(ctx)
+	require.NoError(err, "failed to fetch bootstrap sequencer sync status")
+	require.NoError(rollupClient.StartSequencer(ctx, initialStatus.UnsafeL2.Hash), "failed to start sequencing on bootstrap node")
+	err = retry.Do0(ctx, 90, retry.Fixed(500*time.Millisecond), func() error {
+		status, err := rollupClient.SyncStatus(ctx)
+		if err != nil {
+			return err
+		}
+		if status.UnsafeL2.Number <= initialStatus.UnsafeL2.Number {
+			return fmt.Errorf("bootstrap sequencer has not sealed a block yet, unsafe head at %d", status.UnsafeL2.Number)
+		}
+		return nil
+	})
+	require.NoError(err, "bootstrap sequencer never sealed its first block")
+
+	// Freeze the seed head and require every follower to have processed that
+	// exact canonical block before conductor control loops can start. Without
+	// this barrier, a failover can elect a follower that is unable to start on
+	// the Raft-committed head.
+	seedHash, err := rollupClient.StopSequencer(ctx)
+	require.NoError(err, "failed to stop bootstrap sequencer after seeding")
+	seedStatus, err := rollupClient.SyncStatus(ctx)
+	require.NoError(err, "failed to fetch seeded bootstrap sequencer sync status")
+	require.Equal(seedHash, seedStatus.UnsafeL2.Hash, "bootstrap sequencer stopped at an unexpected unsafe head")
+	for i, node := range memberNodes {
+		memberClient, err := dial.DialRollupClientWithTimeout(ctx, t.Logger(), node.UserRPC())
+		require.NoErrorf(err, "failed to dial sequencer node %s", members[i].ServerID())
+		err = retry.Do0(ctx, 90, retry.Fixed(500*time.Millisecond), func() error {
+			status, err := memberClient.SyncStatus(ctx)
+			if err != nil {
+				return err
+			}
+			if status.UnsafeL2.ID() != seedStatus.UnsafeL2.ID() {
+				return fmt.Errorf("sequencer %s unsafe head is %s, want seeded head %s", members[i].ServerID(), status.UnsafeL2, seedStatus.UnsafeL2)
+			}
+			return nil
+		})
+		require.NoErrorf(err, "sequencer %s never reached the seeded unsafe head", members[i].ServerID())
+	}
 
 	cluster := append([]*Conductor{bootstrap}, members...)
 	for _, conductor := range cluster {

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -118,10 +118,11 @@ func NewMinimalWithConductorsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *S
 	nodeB := addStoppedSingleChainSequencerNode(t, runtime, "b", cfg.GlobalL2CLOptions...)
 	nodeC := addStoppedSingleChainSequencerNode(t, runtime, "c", cfg.GlobalL2CLOptions...)
 
+	healthCheck := conductorHealthCheckConfig(cfg.ConductorFastHealthChecks)
 	primaryCL := runtime.L2CL.(*OpNode)
-	conductorA := startConductorNode(t, "sequencer", runtime.L2Network, primaryCL, runtime.L2EL, true, false)
-	conductorB := startConductorNode(t, "b", runtime.L2Network, nodeB.CL.(*OpNode), nodeB.EL, false, true)
-	conductorC := startConductorNode(t, "c", runtime.L2Network, nodeC.CL.(*OpNode), nodeC.EL, false, true)
+	conductorA := startConductorNode(t, "sequencer", runtime.L2Network, primaryCL, runtime.L2EL, true, false, healthCheck)
+	conductorB := startConductorNode(t, "b", runtime.L2Network, nodeB.CL.(*OpNode), nodeB.EL, false, true, healthCheck)
+	conductorC := startConductorNode(t, "c", runtime.L2Network, nodeC.CL.(*OpNode), nodeC.EL, false, true, healthCheck)
 
 	// Mesh the sequencer CL nodes over p2p, as in a production HA deployment:
 	// the active sequencer gossips unsafe blocks to the followers, which keeps
@@ -273,6 +274,30 @@ func startSyncTesterELNode(
 	return node
 }
 
+// conductorHealthCheckConfig returns the conductor health-monitor settings.
+// By default checks effectively never run (hourly), keeping manual leadership
+// operations deterministic. With fast=true, checks run every second so that a
+// dead sequencer node flips its conductor to unhealthy and triggers failover;
+// the staleness windows stay at an hour so health remains purely
+// liveness-based, and MinPeerCount is 1 (op-conductor rejects 0) — each node
+// keeps at least one peer of the three-node mesh even after one node dies.
+func conductorHealthCheckConfig(fast bool) opconductor.HealthCheckConfig {
+	if fast {
+		return opconductor.HealthCheckConfig{
+			Interval:       1,
+			UnsafeInterval: 3600,
+			SafeInterval:   3600,
+			MinPeerCount:   1,
+		}
+	}
+	return opconductor.HealthCheckConfig{
+		Interval:       3600,
+		UnsafeInterval: 3600,
+		SafeInterval:   3600,
+		MinPeerCount:   1,
+	}
+}
+
 func startConductorNode(
 	t devtest.T,
 	conductorName string,
@@ -281,6 +306,7 @@ func startConductorNode(
 	l2EL L2ELNode,
 	bootstrap bool,
 	paused bool,
+	healthCheck opconductor.HealthCheckConfig,
 ) *Conductor {
 	require := t.Require()
 	serverID := conductorName
@@ -321,14 +347,9 @@ func startConductorNode(
 		NodeRPC:                 opNode.UserRPC(),
 		ExecutionRPC:            l2EL.UserRPC(),
 		Paused:                  paused,
-		HealthCheck: opconductor.HealthCheckConfig{
-			Interval:       3600,
-			UnsafeInterval: 3600,
-			SafeInterval:   3600,
-			MinPeerCount:   1,
-		},
-		RollupCfg:      *l2Net.rollupCfg,
-		RPCEnableProxy: false,
+		HealthCheck:             healthCheck,
+		RollupCfg:               *l2Net.rollupCfg,
+		RPCEnableProxy:          false,
 		LogConfig: oplog.CLIConfig{
 			Level:  log.LevelInfo,
 			Format: oplog.FormatText,

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -349,7 +349,7 @@ func startConductorNode(
 		Paused:                  paused,
 		HealthCheck:             healthCheck,
 		RollupCfg:               *l2Net.rollupCfg,
-		RPCEnableProxy:          false,
+		RPCEnableProxy:          true,
 		LogConfig: oplog.CLIConfig{
 			Level:  log.LevelInfo,
 			Format: oplog.FormatText,

--- a/rust/kona/tests/node/common/conductor_test.go
+++ b/rust/kona/tests/node/common/conductor_test.go
@@ -1,128 +1,30 @@
 package node
 
 import (
-	"context"
-	"fmt"
 	"testing"
-	"time"
 
-	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
-	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
-	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	node_utils "github.com/ethereum-optimism/optimism/rust/kona/tests/node/utils"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/require"
 )
 
-type conductorWithInfo struct {
-	*dsl.Conductor
-	info consensus.ServerInfo
-}
-
-// TestConductorLeadershipTransfer checks if the leadership transfer works correctly on the conductors
+// TestConductorLeadershipTransfer rotates Raft leadership through every
+// conductor in the cluster and verifies that the active sequencer follows
+// leadership on each transfer.
 func TestConductorLeadershipTransfer(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	logger := testlog.Logger(t, log.LevelInfo).With("Test", "TestConductorLeadershipTransfer")
 
 	sys := node_utils.NewMixedOpKonaWithConductors(t)
-	tracer := t.Tracer()
-	ctx := t.Ctx()
-	logger.Info("Started Conductor Leadership Transfer test")
 
 	for _, conductors := range sys.ConductorSets {
-		t.Gate().Greater(len(conductors), 0, "Expected at least one conductor in the system")
+		leader := conductors.Leader()
+		// Rotate through every follower and finally back to the original
+		// leader, so each cluster member leads once.
+		ring := append(conductors.Followers(), leader)
+		for _, target := range ring {
+			leader.TransferLeadershipTo(target)
+			target.VerifySequencerActive()
+			leader.VerifySequencerInactive()
+			leader = target
+		}
 	}
-
-	ctx, span := tracer.Start(ctx, "test chains")
-	defer span.End()
-
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	// Test all L2 chains in the system
-	for l2Chain, conductors := range sys.ConductorSets {
-		chainId := l2Chain.String()
-
-		_, span = tracer.Start(ctx, fmt.Sprintf("test chain %s", chainId))
-		defer span.End()
-
-		membership := conductors[0].FetchClusterMembership()
-		require.Equal(t, len(membership.Servers), len(conductors), "cluster membership does not match the number of conductors", "chainId", chainId)
-
-		idToConductor := make(map[string]conductorWithInfo)
-		for _, conductor := range conductors {
-			idToConductor[conductor.String()] = conductorWithInfo{conductor, consensus.ServerInfo{}}
-		}
-		for _, memberInfo := range membership.Servers {
-			conductor, ok := idToConductor[memberInfo.ID]
-			require.True(t, ok, "unknown conductor in cluster membership", "unknown conductor id", memberInfo.ID, "chainId", chainId)
-			conductor.info = memberInfo
-			idToConductor[memberInfo.ID] = conductor
-		}
-
-		leaderInfo, err := conductors[0].Escape().RpcAPI().LeaderWithID(ctx)
-		require.NoError(t, err, "failed to get current conductor info", "chainId", chainId)
-
-		leaderConductor := idToConductor[leaderInfo.ID]
-
-		voters := []conductorWithInfo{leaderConductor}
-		for _, member := range membership.Servers {
-			if member.ID == leaderInfo.ID || member.Suffrage == consensus.Nonvoter {
-				continue
-			}
-
-			voters = append(voters, idToConductor[member.ID])
-		}
-
-		if len(voters) == 1 {
-			t.Skip("only one voter found in the cluster, skipping leadership transfer test")
-			continue
-		}
-
-		t.Run(fmt.Sprintf("L2_Chain_%s", chainId), func(tt devtest.T) {
-			numOfLeadershipTransfers := len(voters)
-			for i := range numOfLeadershipTransfers {
-				oldLeaderIndex, newLeaderIndex := i%len(voters), (i+1)%len(voters)
-				oldLeader, newLeader := voters[oldLeaderIndex], voters[newLeaderIndex]
-
-				time.Sleep(3 * time.Second)
-
-				testTransferLeadershipAndCheck(t, oldLeader, newLeader)
-			}
-		})
-	}
-}
-
-// testTransferLeadershipAndCheck tests conductor's leadership transfer from one leader to another
-func testTransferLeadershipAndCheck(t devtest.T, oldLeader, targetLeader conductorWithInfo) {
-	t.Run(fmt.Sprintf("Conductor_%s_to_%s", oldLeader, targetLeader), func(tt devtest.T) {
-		// ensure that the current and target leader are healthy and unpaused before transferring leadership
-		require.True(tt, oldLeader.FetchSequencerHealthy(), "current leader's sequencer is not healthy, id", oldLeader)
-		require.True(tt, targetLeader.FetchSequencerHealthy(), "target leader's sequencer is not healthy, id", targetLeader)
-		require.False(tt, oldLeader.FetchPaused(), "current leader's sequencer is paused, id", oldLeader)
-		require.False(tt, targetLeader.FetchPaused(), "target leader's sequencer is paused, id", targetLeader)
-
-		// ensure that the current leader is the leader before transferring leadership
-		require.True(tt, oldLeader.IsLeader(), "current leader was not found to be the leader")
-		require.False(tt, targetLeader.IsLeader(), "target leader was already found to be the leader")
-
-		oldLeader.TransferLeadershipTo(targetLeader.info)
-
-		require.Eventually(
-			tt,
-			func() bool { return targetLeader.IsLeader() },
-			5*time.Second, 1*time.Second, "target leader was not found to be the leader",
-		)
-
-		require.False(tt, oldLeader.IsLeader(), "old leader was still found to be the leader")
-
-		// sometimes leadership transfer can cause a very brief period of unhealthiness,
-		// but eventually, they should be healthy again
-		require.Eventually(
-			tt,
-			func() bool { return oldLeader.FetchSequencerHealthy() && targetLeader.FetchSequencerHealthy() },
-			3*time.Second, 1*time.Second, "at least one of the sequencers was found to be unhealthy",
-		)
-	})
 }


### PR DESCRIPTION
## Description

Ports the user-visible conductor behaviors covered by `op-e2e/system/conductor` into `op-acceptance-tests`, with one focused test per behavior:

| Behavior | Test |
| --- | --- |
| Cluster starts with exactly one active sequencer | `TestConductorClusterStartsWithOneActiveSequencer` |
| Manual transfer moves the active sequencer | `TestLeadershipTransferMovesActiveSequencer` |
| Block production and hash convergence after transfer | `TestUnsafeChainAdvancesAfterLeadershipTransfer` |
| Health-based failover on sequencer death | `TestFailoverOnActiveSequencerFailure` |
| Disaster-recovery leader override | `TestDisasterRecoveryLeaderOverride` |
| Conductor RPC proxy serves only the leader | `TestConductorProxyServesOnlyLeader` |
| Membership add/remove round trip | `TestConductorClusterMembershipChanges` |
| Stale configuration-version rejection | `TestConductorRejectsStaleMembershipVersion` |

The legacy `op-e2e/system/conductor` suite remains because it still exercises batcher-through-conductor integration, safe-head health behavior, and lower-level RPC cases that are not fully replaced by this PR.

### Devstack fixes

Porting the tests exposed two setup bugs:

- The conductor preset could remain at genesis because a fresh Raft FSM has no unsafe payload. It now starts every sequencer stopped, seeds sequencing on the bootstrap node, freezes that head, and waits for every follower to reach the exact same block before conductor control resumes. This also prevents startup from creating incompatible unsafe forks.
- Restarted op-nodes reused a closed `PreparedSigner` and could no longer publish signed gossip. The signer setup now creates a fresh signer for every node start.

Supporting changes link every `dsl.Conductor` to its managed node, mesh the conductor-managed nodes over CL p2p, enable conductor RPC proxying, and add an opt-in fast health-check configuration for the failover test. The acceptance-test guidance also clarifies that reusable capabilities belong in the DSL while scenario-specific verification should remain in tests or package-local helpers.

All new tests skip kona-node until conductor support lands in #21906.

## Tests

```bash
RUST_JIT_BUILD=1 go test -count=1 -parallel 2 -timeout 20m ./op-acceptance-tests/tests/base/conductor/
RUST_JIT_BUILD=1 go test -count=3 -parallel 2 -timeout 20m \
  -run '^(TestFailoverOnActiveSequencerFailure|TestUnsafeChainAdvancesAfterLeadershipTransfer)$' \
  ./op-acceptance-tests/tests/base/conductor/
```

The full package passed in 120s; the targeted three-run stability check passed in 101s. Relevant Go packages also compile independently at every commit in the series.

## Metadata

- Fixes #21902
- Toward #21906


