### PR TITLE
ci: check SP1 guest lock before building ELFs, refresh stale guest lockfile

### DIFF
--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -238,6 +238,11 @@ jobs:
           paths:
             - ~/.sp1/toolchains
       - run:
+          # Check the committed guest lock before build-elfs-native regenerates it in place and masks drift.
+          name: Check SP1 guest lock
+          working_directory: rust
+          command: just check-sp1-guest-lock
+      - run:
           name: Build SP1 guest ELFs
           working_directory: rust/kona/sp1
           no_output_timeout: 40m

--- a/rust/kona/sp1/justfile
+++ b/rust/kona/sp1/justfile
@@ -97,7 +97,8 @@ _build-elf NAME MODE:
       fi
     fi
 
-    args=(--ignore-rust-version --elf-name "{{NAME}}-elf" --workspace-directory "$root" --output-directory "{{justfile_directory()}}/elf")
+    # --locked appears to be a no-op in upstream cargo-prove (regenerates the lock anyway).
+    args=(--locked --ignore-rust-version --elf-name "{{NAME}}-elf" --workspace-directory "$root" --output-directory "{{justfile_directory()}}/elf")
     if [[ "{{MODE}}" == "docker" ]]; then
       mkdir -p "{{justfile_directory()}}/programs/target/elf-compilation/docker"
       args=(--docker --tag "{{SP1_TAG}}" "${args[@]}")

--- a/rust/kona/sp1/programs/Cargo.lock
+++ b/rust/kona/sp1/programs/Cargo.lock
@@ -1665,7 +1665,6 @@ dependencies = [
  "derive_more",
  "op-revm",
  "serde",
- "serde_repr",
  "thiserror",
 ]
 
@@ -3199,17 +3198,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The SP1 guest workspace lockfile (`rust/kona/sp1/programs/Cargo.lock`) drifted from its path-dependency manifests and CI failed to catch it.

- `kona-genesis` dropped its `serde_repr` dependency in #21938, but the path-dependent SP1 guest lockfile was not refreshed. `just check-sp1-guest-lock` (`cargo metadata --locked`) fails on the committed lockfile.
- CI *does* run `check-sp1-guest-lock` (via `just lint-sp1-guest`), but in the `kona-build-sp1-elfs` job it ran **after** `build-elfs-native`, which runs `cargo prove build` without honoring `--locked` and regenerates the guest lockfile in place. The downstream lock check therefore always validated a freshly-regenerated lockfile, and the stale committed one slipped through.

## Changes

1. **Check the lock before the build** — a dedicated `just check-sp1-guest-lock` step now runs *before* `build-elfs-native`, so a stale committed lockfile fails CI before the build can regenerate it. The full `just lint-sp1-guest` stays *after* the build, since its clippy pass needs the generated ELF vkeys.
2. **`--locked` on the guest ELF builds** — pass `--locked` to `cargo prove build` (native and docker). This is currently a no-op: upstream `cargo-prove` accepts `--locked` but regenerates the lockfile regardless (verified locally in both modes). Kept so the guard takes effect once upstream honors the flag.
3. **Refresh the lockfile** — `just lock-sp1-guest` drops the now-unused `serde_repr` entry.

## Verification

Pushed in two commits to demonstrate the guard against real CI:
- **Commit 1** (`99c8288`, guard only, lockfile still stale) — `kona-build-sp1-elfs` **failed at the new `Check SP1 guest lock` step**, before the ELF build ([job 5363983](https://circleci.com/gh/ethereum-optimism/optimism/5363983)), with `error: SP1 guest Cargo.lock ... is out of date`. Confirmed on CI.
- **Commit 2** (`41cdd88`, lockfile refresh) — expected to pass; ELF build in progress.