### PR TITLE
op-dispute-mon: classify ZK dispute game as a super-root game

### DIFF
--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -20,7 +20,6 @@ var outputRootGameTypes = []types.GameType{
 	types.AsteriscKonaGameType,
 	types.OPSuccinctGameType,
 	types.CannonKonaGameType,
-	types.ZKDisputeGameType,
 	types.FastGameType,
 	types.AlphabetGameType,
 	types.KailuaGameType,
@@ -30,6 +29,7 @@ var superRootGameTypes = []types.GameType{
 	types.SuperPermissionedGameType,
 	types.SuperAsteriscKonaGameType,
 	types.SuperCannonKonaGameType,
+	types.ZKDisputeGameType,
 }
 
 // EnrichedClaim extends the faultTypes.Claim with additional context.


### PR DESCRIPTION
## Summary

`ZKDisputeGame` is a super-root game, but op-dispute-mon listed `ZKDisputeGameType` in `outputRootGameTypes`. As a result the monitor validated it through the output-root path, comparing a single-chain output root against the game's super-root claim (which can never match), and would fire false `AgreeWithClaim=false` disagreement alerts on every valid ZK game.

## Change

Move `ZKDisputeGameType` from `outputRootGameTypes` to `superRootGameTypes` so it routes through the super-root agreement enricher. One line; the `TestAllSupportedLifecycleGameTypesAreOutputOrSuperRootType` exhaustiveness test is self-adjusting (it asserts membership matches `UsesOutputRoots()`).

## Test plan

- `go test ./op-dispute-mon/mon/...` — pass (incl. the self-adjusting exhaustiveness test).
- `go build ./op-dispute-mon/...` and custom lint — clean.