### PR TITLE
docs: add SolidRPC to RPC directory

### DIFF
--- a/docs/public-docs/app-developers/reference/rpc-providers.mdx
+++ b/docs/public-docs/app-developers/reference/rpc-providers.mdx
@@ -209,6 +209,14 @@ The following providers offer production-grade RPC access to OP Stack networks. 
 
 **Supported Mainnets**: OP Mainnet, Base
 
+### SolidRPC
+
+**Description**: [SolidRPC](https://solidrpc.io/) offers [free and paid plans](https://solidrpc.io/docs/pricing) for the following [networks](https://solidrpc.io/docs/networks):
+
+**Supported Testnets**: OP Sepolia, Base Sepolia, Lisk Sepolia, Unichain Sepolia, Zora Sepolia
+
+**Supported Mainnets**: OP Mainnet, Base, Ink, Unichain, World, Lisk, Zora
+
 ### Tenderly
 
 **Description**: [Tenderly](https://tenderly.co/) offers [free and paid plans](https://tenderly.co/pricing) for the following [networks](https://docs.tenderly.co/node/rpc-reference):


### PR DESCRIPTION
**Description**

Adds SolidRPC to the OP Stack production RPC provider directory.

The listing includes the OP Stack networks currently supported by SolidRPC:

- Mainnets: OP Mainnet, Base, Ink, Unichain, World Chain, Lisk, and Zora
- Testnets: OP Sepolia, Base Sepolia, Lisk Sepolia, Unichain Sepolia, and Zora Sepolia

**Tests**

Documentation-only change.

- Verified the listed networks against the current SolidRPC network catalog
- Ran `git diff --check`

**Additional context**

- Website: https://solidrpc.io
- Documentation: https://solidrpc.io/docs
- Supported networks: https://solidrpc.io/docs/networks
- Pricing: https://solidrpc.io/docs/pricing

SolidRPC provides authenticated EVM JSON-RPC endpoints over HTTPS with full and archive access where available.

**Metadata**

No related issue.