### PR TITLE
op-supernode: gate unsafe ingestion during invalidation recovery

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -173,6 +173,11 @@ type EngineController struct {
 	// SuperAuthority for payload validation (may be nil when not in supernode context)
 	superAuthority rollup.SuperAuthority
 
+	// Last observed state of the unsafe-ingestion deny gate, so entering and
+	// leaving invalidation recovery is logged once rather than per payload.
+	// See unsafeDenyGatingActive.
+	unsafeDenyGated bool
+
 	// crossSafeCache holds the last canonical cross-safe head; consulted by
 	// crossSafeFallback when the verifier is unavailable or returns a reorg
 	// signal, so a transient outage doesn't drop cross-safe to FinalizedHead.
@@ -755,13 +760,39 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 // unsafeDenyGatingActive reports whether unsafe-payload ingestion is blocked
 // by the SuperAuthority deny list: from the moment a block is denied until the
 // finalized head passes the highest denied height, so unsafe sync cannot
-// re-adopt the invalidated branch. Callers must hold e.mu.
+// re-adopt the invalidated branch.
+//
+// Both ingestion paths consult it. AddUnsafePayload keeps new arrivals out of
+// the queue; insertUnsafePayload guards the ELSync direct-insert path and the
+// driver gap-fill, and drains the queue there so payloads buffered before the
+// invalidation don't outlive the window and get gap-filled once it closes.
+//
+// A deny-list read error fails open: a wedged unsafe pipeline is worse than
+// looping invalidation until the DB heals. It is always logged.
+//
+// Callers must hold e.mu.
 func (e *EngineController) unsafeDenyGatingActive() bool {
 	if e.superAuthority == nil {
 		return false
 	}
-	maxDenied, ok := e.superAuthority.MaxDeniedHeight()
-	return ok && maxDenied > e.FinalizedHead().Number
+	maxDenied, ok, err := e.superAuthority.MaxDeniedHeight()
+	if err != nil {
+		e.log.Error("Failed to read max denied height, allowing unsafe ingestion", "err", err)
+		return false
+	}
+	finalized := e.FinalizedHead()
+	active := ok && maxDenied > finalized.Number
+	if active != e.unsafeDenyGated {
+		e.unsafeDenyGated = active
+		if active {
+			e.log.Warn("Gating unsafe ingestion during invalidation recovery",
+				"maxDeniedHeight", maxDenied, "finalized", finalized)
+		} else {
+			e.log.Warn("Resuming unsafe ingestion, finality passed the invalidation",
+				"maxDeniedHeight", maxDenied, "finalized", finalized)
+		}
+	}
+	return active
 }
 
 func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef) error {
@@ -781,13 +812,18 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 			return derive.NewTemporaryError(fmt.Errorf("failed to fetch finalized head: %w", err))
 		}
 	}
-	// See unsafeDenyGatingActive: no unsafe ingestion during invalidation
-	// recovery. Guards the ELSync direct-insert path and the queue gap-fill;
-	// AddUnsafePayload keeps gated payloads out of the queue in the first place
-	// so none survive the window to be gap-filled after it closes.
+	// See unsafeDenyGatingActive: no unsafe ingestion during invalidation recovery.
 	if e.unsafeDenyGatingActive() {
 		e.log.Debug("Dropping unsafe payload during invalidation recovery",
 			"block", envelope.ExecutionPayload.ID())
+		// Drain what was buffered before the gate activated. A rewind leaves the
+		// queue holding denied-branch payloads far ahead of the new unsafe head,
+		// which DropInapplicableUnsafePayloads never removes; the driver's gap
+		// ticker reaches this path on every tick while such an entry is queued,
+		// so draining here keeps them from surviving the window.
+		for e.unsafePayloads.Pop() != nil {
+		}
+		e.metrics.RecordUnsafePayloadsBuffer(uint64(e.unsafePayloads.Len()), e.unsafePayloads.MemSize(), eth.BlockID{})
 		return nil
 	}
 
@@ -1387,9 +1423,7 @@ func (e *EngineController) AddUnsafePayload(ctx context.Context, envelope *eth.E
 
 	e.log.Debug("Received payload", "payload", envelope.ExecutionPayload.ID())
 
-	// Keep gated payloads out of the queue entirely: a queued denied-branch
-	// payload would outlive the recovery window and be gap-filled into the
-	// engine the moment the gate lifts.
+	// See unsafeDenyGatingActive: no unsafe ingestion during invalidation recovery.
 	if e.unsafeDenyGatingActive() {
 		e.log.Debug("Dropping unsafe payload during invalidation recovery",
 			"block", envelope.ExecutionPayload.ID())

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -752,6 +752,18 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 	return e.insertUnsafePayload(ctx, envelope, ref)
 }
 
+// unsafeDenyGatingActive reports whether unsafe-payload ingestion is blocked
+// by the SuperAuthority deny list: from the moment a block is denied until the
+// finalized head passes the highest denied height, so unsafe sync cannot
+// re-adopt the invalidated branch. Callers must hold e.mu.
+func (e *EngineController) unsafeDenyGatingActive() bool {
+	if e.superAuthority == nil {
+		return false
+	}
+	maxDenied, ok := e.superAuthority.MaxDeniedHeight()
+	return ok && maxDenied > e.FinalizedHead().Number
+}
+
 func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef) error {
 	// Check if there is a finalized head once when doing EL sync. If so, transition to CL sync
 	if e.syncStatus == syncStatusWillStartEL {
@@ -769,6 +781,16 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 			return derive.NewTemporaryError(fmt.Errorf("failed to fetch finalized head: %w", err))
 		}
 	}
+	// See unsafeDenyGatingActive: no unsafe ingestion during invalidation
+	// recovery. Guards the ELSync direct-insert path and the queue gap-fill;
+	// AddUnsafePayload keeps gated payloads out of the queue in the first place
+	// so none survive the window to be gap-filled after it closes.
+	if e.unsafeDenyGatingActive() {
+		e.log.Debug("Dropping unsafe payload during invalidation recovery",
+			"block", envelope.ExecutionPayload.ID())
+		return nil
+	}
+
 	// Insert the payload & then call FCU
 	newPayloadStart := time.Now()
 	status, err := e.engine.NewPayload(ctx, envelope.ExecutionPayload, envelope.ParentBeaconBlockRoot)
@@ -1364,6 +1386,15 @@ func (e *EngineController) AddUnsafePayload(ctx context.Context, envelope *eth.E
 	defer e.mu.Unlock()
 
 	e.log.Debug("Received payload", "payload", envelope.ExecutionPayload.ID())
+
+	// Keep gated payloads out of the queue entirely: a queued denied-branch
+	// payload would outlive the recovery window and be gap-filled into the
+	// engine the moment the gate lifts.
+	if e.unsafeDenyGatingActive() {
+		e.log.Debug("Dropping unsafe payload during invalidation recovery",
+			"block", envelope.ExecutionPayload.ID())
+		return
+	}
 
 	if err := e.unsafePayloads.Push(envelope); err != nil {
 		e.log.Warn("Could not add unsafe payload", "id", envelope.ExecutionPayload.ID(), "timestamp", uint64(envelope.ExecutionPayload.Timestamp), "err", err)

--- a/op-node/rollup/engine/super_authority_mock_test.go
+++ b/op-node/rollup/engine/super_authority_mock_test.go
@@ -48,6 +48,16 @@ func (m *mockSuperAuthority) IsDenied(blockNumber uint64, payloadHash common.Has
 	return false, nil
 }
 
+func (m *mockSuperAuthority) MaxDeniedHeight() (uint64, bool) {
+	var max uint64
+	for num := range m.deniedBlocks {
+		if num > max {
+			max = num
+		}
+	}
+	return max, max != 0
+}
+
 func (m *mockSuperAuthority) FullyVerifiedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {
 	return rollup.VerifierHead{
 		Block:     m.fullyVerifiedL2Head,

--- a/op-node/rollup/engine/super_authority_mock_test.go
+++ b/op-node/rollup/engine/super_authority_mock_test.go
@@ -25,6 +25,8 @@ type mockSuperAuthority struct {
 
 	deniedBlocks map[uint64]common.Hash
 	shouldError  bool
+	// When set, MaxDeniedHeight fails with this error instead of reading deniedBlocks.
+	maxDeniedHeightErr error
 }
 
 func newMockSuperAuthority() *mockSuperAuthority {
@@ -48,14 +50,17 @@ func (m *mockSuperAuthority) IsDenied(blockNumber uint64, payloadHash common.Has
 	return false, nil
 }
 
-func (m *mockSuperAuthority) MaxDeniedHeight() (uint64, bool) {
-	var max uint64
+func (m *mockSuperAuthority) MaxDeniedHeight() (uint64, bool, error) {
+	if m.maxDeniedHeightErr != nil {
+		return 0, false, m.maxDeniedHeightErr
+	}
+	var maxHeight uint64
 	for num := range m.deniedBlocks {
-		if num > max {
-			max = num
+		if num > maxHeight {
+			maxHeight = num
 		}
 	}
-	return max, max != 0
+	return maxHeight, maxHeight != 0, nil
 }
 
 func (m *mockSuperAuthority) FullyVerifiedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {

--- a/op-node/rollup/engine/unsafe_ingestion_deny_test.go
+++ b/op-node/rollup/engine/unsafe_ingestion_deny_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -106,6 +107,68 @@ func TestAddUnsafePayloadNotQueuedDuringRecovery(t *testing.T) {
 	payload, _ := ec.PeekUnsafePayload()
 	require.Nil(t, payload, "payload must not be queued during recovery")
 
+	emitter.AssertExpectations(t)
+}
+
+// A payload queued before the invalidation must not survive the recovery
+// window: an invalidation rewind leaves the queue holding denied-branch
+// payloads far ahead of the new unsafe head, which
+// DropInapplicableUnsafePayloads never removes. The driver's gap ticker peeks
+// (never pops) such an entry, so without the drain in insertUnsafePayload it
+// would be gap-filled into the engine on the first tick after the gate lifts.
+func TestQueuedPayloadDrainedDuringRecovery(t *testing.T) {
+	cfg, refA0, _, _ := buildSimpleCfgAndPayload(t)
+	engine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := newMockSuperAuthority()
+
+	ec := newUnsafeIngestionEC(t, cfg, engine, sa, emitter, refA0)
+
+	// Pre-invalidation: the payload is accepted into the queue as normal.
+	payload5, ref5 := gapPayload(refA0, cfg)
+	emitter.ExpectOnceType("ForkchoiceUpdateEvent")
+	ec.AddUnsafePayload(context.Background(), payload5)
+	require.Equal(t, payload5, ec.unsafePayloads.Peek(), "payload must be queued before the invalidation")
+
+	// The invalidation lands, and the driver's gap ticker re-inserts the peeked
+	// payload. It is dropped, and the queue is drained with it.
+	sa.denyBlock(2, common.Hash{0xba, 0xd0})
+	require.NoError(t, ec.InsertUnsafePayload(context.Background(), payload5, ref5))
+	require.Equal(t, refA0, ec.UnsafeL2Head(), "unsafe head must not advance during recovery")
+	require.Zero(t, ec.unsafePayloads.Len(), "pre-invalidation payload must not survive the recovery window")
+
+	// Finality passes the denied height and the gate lifts. Nothing is left in
+	// the queue for the gap ticker to feed the engine.
+	ec.SetFinalizedHead(eth.L2BlockRef{
+		Hash:   common.Hash{0x02},
+		Number: 2,
+		Time:   refA0.Time + 2*cfg.BlockTime,
+	})
+	require.Zero(t, ec.unsafePayloads.Len(), "queue must still be empty once the gate lifts")
+
+	engine.AssertExpectations(t)
+	emitter.AssertExpectations(t)
+}
+
+// A deny-list read error fails open: wedging unsafe ingestion on a transient DB
+// fault is worse than looping invalidation until it heals.
+func TestUnsafeDenyGatingFailsOpenOnReadError(t *testing.T) {
+	cfg, refA0, _, _ := buildSimpleCfgAndPayload(t)
+	engine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := newMockSuperAuthority()
+	sa.denyBlock(2, common.Hash{0xba, 0xd0})
+	sa.maxDeniedHeightErr = errors.New("denylist read failed")
+
+	ec := newUnsafeIngestionEC(t, cfg, engine, sa, emitter, refA0)
+
+	payload5, ref5 := gapPayload(refA0, cfg)
+	expectGapFillSyncing(engine, payload5, ref5, refA0.Hash, refA0.Hash)
+
+	err := ec.InsertUnsafePayload(context.Background(), payload5, ref5)
+	require.ErrorIs(t, err, derive.ErrTemporary, "ingestion proceeds when the deny-list read fails")
+
+	engine.AssertExpectations(t)
 	emitter.AssertExpectations(t)
 }
 

--- a/op-node/rollup/engine/unsafe_ingestion_deny_test.go
+++ b/op-node/rollup/engine/unsafe_ingestion_deny_test.go
@@ -1,0 +1,184 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Tests for invalidation-recovery gating in insertUnsafePayload: while any
+// denied height is above the finalized head, all unsafe payloads are dropped
+// and the chain advances via derivation only.
+
+func newUnsafeIngestionEC(t *testing.T, cfg *rollup.Config, engine *testutils.MockEngine, sa rollup.SuperAuthority, emitter *testutils.MockEmitter, unsafeHead eth.L2BlockRef) *EngineController {
+	t.Helper()
+	ec := NewEngineController(
+		context.Background(),
+		engine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		cfg,
+		&sync.Config{SyncMode: sync.CLSync},
+		&testutils.MockL1Source{},
+		emitter,
+		sa,
+	)
+	ec.SetUnsafeHead(unsafeHead)
+	ec.SetLocalSafeHead(unsafeHead)
+	ec.SetFinalizedHead(unsafeHead)
+	return ec
+}
+
+// expectGapFillSyncing sets up the stock gap-fill interaction: NewPayload then
+// an FCU that kicks the EL into sync, both answering SYNCING.
+func expectGapFillSyncing(engine *testutils.MockEngine, payload *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, safeHash, finalizedHash common.Hash) {
+	engine.ExpectNewPayload(payload.ExecutionPayload, nil, &eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, nil)
+	engine.ExpectForkchoiceUpdate(&eth.ForkchoiceState{
+		HeadBlockHash:      ref.Hash,
+		SafeBlockHash:      safeHash,
+		FinalizedBlockHash: finalizedHash,
+	}, nil, &eth.ForkchoiceUpdatedResult{
+		PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing},
+	}, nil)
+}
+
+func gapPayload(refA0 eth.L2BlockRef, cfg *rollup.Config) (*eth.ExecutionPayloadEnvelope, eth.L2BlockRef) {
+	ref5 := eth.L2BlockRef{
+		Hash:       common.Hash{0x05},
+		Number:     refA0.Number + 5,
+		ParentHash: common.Hash{0x04},
+		Time:       refA0.Time + 5*cfg.BlockTime,
+	}
+	payload5 := &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{
+		ParentHash:  ref5.ParentHash,
+		BlockNumber: eth.Uint64Quantity(ref5.Number),
+		Timestamp:   eth.Uint64Quantity(ref5.Time),
+		BlockHash:   ref5.Hash,
+	}}
+	return payload5, ref5
+}
+
+func TestInsertUnsafePayloadDroppedDuringRecovery(t *testing.T) {
+	cfg, refA0, refA1, payloadA1 := buildSimpleCfgAndPayload(t)
+	engine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := newMockSuperAuthority()
+	// A denied height above finalized (0) puts the controller in recovery.
+	sa.denyBlock(2, common.Hash{0xba, 0xd0})
+
+	ec := newUnsafeIngestionEC(t, cfg, engine, sa, emitter, refA0)
+
+	// Every unsafe payload is dropped without engine interaction — even a
+	// contiguous extension of the current head.
+	require.NoError(t, ec.InsertUnsafePayload(context.Background(), payloadA1, refA1))
+	require.Equal(t, refA0, ec.UnsafeL2Head(), "unsafe head must not advance during recovery")
+
+	// A far-ahead gap payload (the EL-sync trigger) is dropped too.
+	payload5, ref5 := gapPayload(refA0, cfg)
+	require.NoError(t, ec.InsertUnsafePayload(context.Background(), payload5, ref5))
+	require.Equal(t, refA0, ec.UnsafeL2Head(), "unsafe head must not advance during recovery")
+
+	engine.AssertExpectations(t)
+	emitter.AssertExpectations(t)
+}
+
+func TestAddUnsafePayloadNotQueuedDuringRecovery(t *testing.T) {
+	cfg, refA0, _, payloadA1 := buildSimpleCfgAndPayload(t)
+	emitter := &testutils.MockEmitter{}
+	sa := newMockSuperAuthority()
+	sa.denyBlock(2, common.Hash{0xba, 0xd0})
+
+	ec := newUnsafeIngestionEC(t, cfg, &testutils.MockEngine{}, sa, emitter, refA0)
+
+	// A gated payload must not even enter the queue — a queued denied-branch
+	// payload would be gap-filled into the engine once the window closes.
+	ec.AddUnsafePayload(context.Background(), payloadA1)
+	payload, _ := ec.PeekUnsafePayload()
+	require.Nil(t, payload, "payload must not be queued during recovery")
+
+	emitter.AssertExpectations(t)
+}
+
+func TestInsertUnsafePayloadProceedsWithoutDenials(t *testing.T) {
+	cfg, refA0, _, _ := buildSimpleCfgAndPayload(t)
+	engine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := newMockSuperAuthority()
+
+	ec := newUnsafeIngestionEC(t, cfg, engine, sa, emitter, refA0)
+
+	// With an empty deny list, the normal gap-fill path runs. SYNCING on the
+	// FCU stays a temporary error in CLSync mode.
+	payload5, ref5 := gapPayload(refA0, cfg)
+	expectGapFillSyncing(engine, payload5, ref5, refA0.Hash, refA0.Hash)
+
+	err := ec.InsertUnsafePayload(context.Background(), payload5, ref5)
+	require.ErrorIs(t, err, derive.ErrTemporary)
+
+	engine.AssertExpectations(t)
+	emitter.AssertExpectations(t)
+}
+
+func TestInsertUnsafePayloadGatingClearsAfterFinality(t *testing.T) {
+	cfg, refA0, _, _ := buildSimpleCfgAndPayload(t)
+	engine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	sa := newMockSuperAuthority()
+	// The only denied height is at or below finalized: the denied branch is
+	// dead by construction, the recovery window is over, and unsafe sync must
+	// behave stock again.
+	sa.denyBlock(2, common.Hash{0xba, 0xd0})
+
+	ec := newUnsafeIngestionEC(t, cfg, engine, sa, emitter, refA0)
+	finalized := eth.L2BlockRef{
+		Hash:   common.Hash{0x02},
+		Number: 2,
+		Time:   refA0.Time + 2*cfg.BlockTime,
+	}
+	ec.SetFinalizedHead(finalized)
+
+	payload5, ref5 := gapPayload(refA0, cfg)
+	expectGapFillSyncing(engine, payload5, ref5, refA0.Hash, finalized.Hash)
+
+	err := ec.InsertUnsafePayload(context.Background(), payload5, ref5)
+	require.ErrorIs(t, err, derive.ErrTemporary)
+
+	engine.AssertExpectations(t)
+	emitter.AssertExpectations(t)
+}
+
+func TestInsertUnsafePayloadNilAuthorityUnaffected(t *testing.T) {
+	cfg, refA0, refA1, payloadA1 := buildSimpleCfgAndPayload(t)
+	engine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+
+	// Plain op-nodes (no SuperAuthority) keep stock behavior.
+	ec := newUnsafeIngestionEC(t, cfg, engine, nil, emitter, refA0)
+
+	engine.ExpectNewPayload(payloadA1.ExecutionPayload, nil, &eth.PayloadStatusV1{Status: eth.ExecutionValid}, nil)
+	engine.ExpectForkchoiceUpdate(&eth.ForkchoiceState{
+		HeadBlockHash:      refA1.Hash,
+		SafeBlockHash:      refA0.Hash,
+		FinalizedBlockHash: refA0.Hash,
+	}, nil, &eth.ForkchoiceUpdatedResult{
+		PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid},
+	}, nil)
+	emitter.ExpectOnceType("UnsafeUpdateEvent")
+	emitter.ExpectOnceType("ForkchoiceUpdateEvent")
+
+	require.NoError(t, ec.InsertUnsafePayload(context.Background(), payloadA1, refA1))
+	require.Equal(t, refA1, ec.UnsafeL2Head())
+
+	engine.AssertExpectations(t)
+	emitter.AssertExpectations(t)
+}

--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -71,8 +71,9 @@ type SuperAuthority interface {
 
 	// MaxDeniedHeight returns the highest denied block height, and whether any
 	// denial exists. Consulted on every unsafe payload insert, so it must be
-	// cheap (a local lookup, no network I/O).
-	MaxDeniedHeight() (uint64, bool)
+	// cheap (a local lookup, no network I/O). A read error is returned rather
+	// than reported as "no denials", so callers can log it.
+	MaxDeniedHeight() (uint64, bool, error)
 }
 
 // SafeHeadListener is called when the safe head is updated.

--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -68,6 +68,11 @@ type SuperAuthority interface {
 	// IsDenied reports whether a payload hash is denied at the given block
 	// number. Errors are logged but not fatal.
 	IsDenied(blockNumber uint64, payloadHash common.Hash) (bool, error)
+
+	// MaxDeniedHeight returns the highest denied block height, and whether any
+	// denial exists. Consulted on every unsafe payload insert, so it must be
+	// cheap (a local lookup, no network I/O).
+	MaxDeniedHeight() (uint64, bool)
 }
 
 // SafeHeadListener is called when the safe head is updated.

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -80,21 +80,23 @@ func OpenDenyList(dataDir string) (*DenyList, error) {
 }
 
 // MaxDeniedHeight returns the highest denied block height, and whether any
-// denial exists (genesis cannot be denied, so 0 means none).
-func (d *DenyList) MaxDeniedHeight() (uint64, bool) {
+// denial exists (genesis cannot be denied, so 0 means none). A read error is
+// returned rather than reported as "no denials", so the caller can decide how
+// to treat it and log it.
+func (d *DenyList) MaxDeniedHeight() (uint64, bool, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	var max uint64
+	var maxHeight uint64
 	err := d.db.View(func(tx *bolt.Tx) error {
 		if k, _ := tx.Bucket(denyListBucketName).Cursor().Last(); k != nil {
-			max = binary.BigEndian.Uint64(k)
+			maxHeight = binary.BigEndian.Uint64(k)
 		}
 		return nil
 	})
 	if err != nil {
-		return 0, false
+		return 0, false, fmt.Errorf("failed to read max denied height: %w", err)
 	}
-	return max, max != 0
+	return maxHeight, maxHeight != 0, nil
 }
 
 // heightToKey converts a block height to a big-endian byte key.

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -79,6 +79,24 @@ func OpenDenyList(dataDir string) (*DenyList, error) {
 	return &DenyList{db: db}, nil
 }
 
+// MaxDeniedHeight returns the highest denied block height, and whether any
+// denial exists (genesis cannot be denied, so 0 means none).
+func (d *DenyList) MaxDeniedHeight() (uint64, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	var max uint64
+	err := d.db.View(func(tx *bolt.Tx) error {
+		if k, _ := tx.Bucket(denyListBucketName).Cursor().Last(); k != nil {
+			max = binary.BigEndian.Uint64(k)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, false
+	}
+	return max, max != 0
+}
+
 // heightToKey converts a block height to a big-endian byte key.
 // Using big-endian ensures lexicographic ordering matches numeric ordering.
 func heightToKey(height uint64) []byte {

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -410,9 +410,13 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		return false, fmt.Errorf("failed to add block to deny list: %w", err)
 	}
 
+	// validParent is the canonical block the chain must sit on once the
+	// invalidated block is removed: the WAL-captured parent at height-1.
+	validParent := parentPayload.ExecutionPayload.ID()
 	c.log.Info("added block to deny list",
-		"height", height,
-		"payloadHash", payloadHash,
+		"invalidatedBlock", eth.BlockID{Hash: payloadHash, Number: height},
+		"rewindToValidParent", validParent,
+		"decisionTimestamp", decisionTimestamp,
 	)
 
 	if c.metrics != nil {
@@ -447,7 +451,10 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		return false, fmt.Errorf("failed to get current block at height %d: %w", height, err)
 	}
 
-	c.log.Warn("initiating rewind after block invalidation", "height", height, "hash", payloadHash)
+	c.log.Warn("initiating rewind after block invalidation",
+		"invalidatedBlock", eth.BlockID{Hash: payloadHash, Number: height},
+		"rewindToValidParent", validParent,
+	)
 
 	if err := c.RewindEngine(ctx, parentPayload, invalidatedBlock); err != nil {
 		return false, fmt.Errorf("failed to rewind engine: %w", err)
@@ -471,7 +478,14 @@ func (c *simpleChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (
 	if c.denyList == nil {
 		return nil, fmt.Errorf("deny list not initialized")
 	}
-	return c.denyList.PruneAtOrAfterTimestamp(timestamp)
+	removed, err := c.denyList.PruneAtOrAfterTimestamp(timestamp)
+	if err == nil && len(removed) > 0 {
+		c.log.Info("pruned deny list entries whose decision basis was reorged out",
+			"decisionTimestamp", timestamp,
+			"removed", removed,
+		)
+	}
+	return removed, err
 }
 
 func (c *simpleChainContainer) HasDeniedAtOrAfterTimestamp(timestamp uint64) (bool, error) {

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -1090,3 +1090,30 @@ func TestDenyList_GetDeniedRecords_IncludesRoots(t *testing.T) {
 	require.Equal(t, out2.MessagePasserStorageRoot, recordMap[hash2].MessagePasserStorageRoot)
 	require.Equal(t, uint64(11), recordMap[hash2].DecisionTimestamp)
 }
+
+func TestDenyList_MaxDeniedHeight(t *testing.T) {
+	t.Parallel()
+
+	dl, err := OpenDenyList(t.TempDir())
+	require.NoError(t, err)
+	defer dl.Close()
+
+	_, any := dl.MaxDeniedHeight()
+	require.False(t, any, "empty deny list has no max height")
+
+	require.NoError(t, dl.Add(100, common.HexToHash("0xaaaa"), 10, eth.Bytes32{}, eth.Bytes32{}))
+	require.NoError(t, dl.Add(500, common.HexToHash("0xbbbb"), 20, eth.Bytes32{}, eth.Bytes32{}))
+	require.NoError(t, dl.Add(300, common.HexToHash("0xcccc"), 30, eth.Bytes32{}, eth.Bytes32{}))
+
+	max, any := dl.MaxDeniedHeight()
+	require.True(t, any)
+	require.Equal(t, uint64(500), max)
+
+	// Pruning the highest entries lowers the max.
+	removed, err := dl.PruneAtOrAfterTimestamp(20)
+	require.NoError(t, err)
+	require.Len(t, removed, 2)
+	max, any = dl.MaxDeniedHeight()
+	require.True(t, any)
+	require.Equal(t, uint64(100), max)
+}

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -1098,22 +1098,25 @@ func TestDenyList_MaxDeniedHeight(t *testing.T) {
 	require.NoError(t, err)
 	defer dl.Close()
 
-	_, any := dl.MaxDeniedHeight()
+	_, any, err := dl.MaxDeniedHeight()
+	require.NoError(t, err)
 	require.False(t, any, "empty deny list has no max height")
 
 	require.NoError(t, dl.Add(100, common.HexToHash("0xaaaa"), 10, eth.Bytes32{}, eth.Bytes32{}))
 	require.NoError(t, dl.Add(500, common.HexToHash("0xbbbb"), 20, eth.Bytes32{}, eth.Bytes32{}))
 	require.NoError(t, dl.Add(300, common.HexToHash("0xcccc"), 30, eth.Bytes32{}, eth.Bytes32{}))
 
-	max, any := dl.MaxDeniedHeight()
+	maxHeight, any, err := dl.MaxDeniedHeight()
+	require.NoError(t, err)
 	require.True(t, any)
-	require.Equal(t, uint64(500), max)
+	require.Equal(t, uint64(500), maxHeight)
 
 	// Pruning the highest entries lowers the max.
 	removed, err := dl.PruneAtOrAfterTimestamp(20)
 	require.NoError(t, err)
 	require.Len(t, removed, 2)
-	max, any = dl.MaxDeniedHeight()
+	maxHeight, any, err = dl.MaxDeniedHeight()
+	require.NoError(t, err)
 	require.True(t, any)
-	require.Equal(t, uint64(100), max)
+	require.Equal(t, uint64(100), maxHeight)
 }

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -103,6 +103,15 @@ func (c *simpleChainContainer) IsDenied(height uint64, payloadHash common.Hash) 
 	return c.denyList.Contains(height, payloadHash)
 }
 
+// MaxDeniedHeight returns the highest denied block height and whether any
+// denial exists.
+func (c *simpleChainContainer) MaxDeniedHeight() (uint64, bool) {
+	if c.denyList == nil {
+		return 0, false
+	}
+	return c.denyList.MaxDeniedHeight()
+}
+
 // GetDeniedOutput returns the reconstructed OutputV0 for a denied block.
 func (c *simpleChainContainer) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
 	if c.denyList == nil {

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -105,9 +105,9 @@ func (c *simpleChainContainer) IsDenied(height uint64, payloadHash common.Hash) 
 
 // MaxDeniedHeight returns the highest denied block height and whether any
 // denial exists.
-func (c *simpleChainContainer) MaxDeniedHeight() (uint64, bool) {
+func (c *simpleChainContainer) MaxDeniedHeight() (uint64, bool, error) {
 	if c.denyList == nil {
-		return 0, false
+		return 0, false, nil
 	}
 	return c.denyList.MaxDeniedHeight()
 }


### PR DESCRIPTION
## Description

Fixes the supernode rewind race / livelock observed on `interop-reorg-2` (2026-07-21, ~21:14–21:56 UTC), where the same invalid Chain B block `515624` was invalidated repeatedly, each cycle freezing and resetting the VNs of **both** chains and walking local-safe back a full sequencing window (~40k blocks, safe-head sawtooth).

> **Stack** (bottom → top): **this PR** → #21992 (sequencer-state persistence + harness fixes) → #21993 (acceptance-test repro). Split out from #21951 (kept intact for reference) so the production fix is reviewable on its own; the end-to-end red/green repro lands at the top of the stack.

### Root cause

The deny list is only enforced on the derivation path (`onPayloadProcess` → deposits-only replacement) and the sequencer build path. **Unsafe ingestion — the clsync queue and the driver gap-fill (`checkForGapInUnsafeQueue`) — never consults it.** After an invalidation rewind + deposits-only replacement:

1. Gossip keeps delivering the sequencer's far-ahead unsafe tip, which descends from the *original* (denied, EVM-valid) block.
2. The gap-fill force-inserts that far-ahead payload; `NewPayload` returns `SYNCING` (tolerated in CLSync precisely to trigger EL sync), and the follow-up FCU points the EL at the denied branch.
3. The EL backfills and canonicalizes the denied ancestry — undoing the replacement — while interim `SYNCING` FCU responses trigger `ResetError` → `FindL2Heads` → sequencing-window-deep local-safe walkback on every chain.
4. The verifier's frontier re-observes the same invalid executing message on the re-canonicalized block → same invalidation → loop.

(The companion hole on the consolidation path — a re-adopted denied block being promoted to local-safe because attributes match — is fixed separately in #21970. The two fixes are complementary layers: #21970 makes invalidation idempotent in derivation; this PR stops unsafe sync from re-adopting the denied branch and causing the reset storm at all.)

### The fix

Unsafe ingestion is gated while the highest denied height is above the finalized head — from the moment of an invalidation until finality passes it. Gated payloads are refused at **queue entry** (`AddUnsafePayload`, so none survive the window to be gap-filled after it closes) and at **insert** (`insertUnsafePayload`, covering the ELSync direct path). During the window the chain advances via (deny-list-checked) derivation only. Finality is the earliest provably-safe exit: while the denied branch can still be canonicalized, a far-ahead FCU would push the EL into a sync ending in an inconsistent forkchoice and another reset. Outside the window the cost is one local deny-list read per insert and unsafe sync behaves byte-for-byte stock; plain op-nodes (nil `SuperAuthority`) are unaffected. Plumbing: `SuperAuthority.MaxDeniedHeight()` backed by a bbolt `Cursor().Last()` read on the supernode `DenyList`.

### Commits

1. **`op-supernode: drop unsafe payloads during invalidation recovery`** — the fix, with unit tests.
2. **`op-supernode: enrich invalidation logs with rewind target`** — invalidation logs now name blocks by role — `invalidatedBlock` and `rewindToValidParent`, each a full `hash:number` pair — plus the decision timestamp. Also logs pruned deny-list entries when an L1 reorg removes their decision basis (previously silent).

### Operational notes

- During the recovery window (~an L1 finality delay) VN unsafe heads intentionally sit at the replacement block and advance at derivation speed, even if the sequencer heals instantly.
- After recovery, sequencing is disabled on every chain in the supernode (see #21992, directly above in the stack). Deployments where the supernode is the active sequencer need an operator or conductor-like automation to re-enable it, same as a restarted production sequencer op-node.

### Tests

- Engine controller units: payloads dropped at queue entry and insert during recovery (contiguous + gap); stock behavior with an empty deny list; stock behavior restored once finality passes the denied height; nil-authority path unchanged.
- `DenyList.MaxDeniedHeight` across add/prune.
- End-to-end red/green repro (`TestSupernodeDoesNotReadoptInvalidatedBlock`) lands at the top of this stack; it needs the devstack harness fixes in the middle PR.

### Metadata

- Incident write-up: Notion "Supernode Rewind Race Condition" (interop-reorg-2, 2026-07-21)
- Split from #21951

🤖 Generated with [Claude Code](https://claude.com/claude-code)
