### PR TITLE
op-acceptance-tests: regression test for supernode invalidated-block re-adoption

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalidation_readoption_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalidation_readoption_test.go
@@ -1,0 +1,83 @@
+package reorg
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
+)
+
+// TestSupernodeDoesNotReadoptInvalidatedBlock covers invalidation recovery when the
+// sequencer is far ahead on the invalid branch — as on a live network, where the
+// sequencer does not follow the supernode's deny list and keeps extending the
+// invalid chain that unsafe sync then delivers back to the supernode's VNs.
+//
+// WHEN: an invalid Executing Message is included on chain B, and the light sequencer
+// builds many more blocks on top of it before the supernode invalidates it
+// THEN:
+//   - The invalid block is replaced (deposits-only) as usual
+//   - The far-ahead invalid branch must NOT be re-adopted from unsafe sync: the
+//     replacement stays canonical while verification durably passes it
+func TestSupernodeDoesNotReadoptInvalidatedBlock(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	// op-reth only: the light-sequencer invalid-message path does not recover on op-geth (#21119).
+	sysgo.SkipOnOpGeth(t, "light-sequencer invalid-message path is op-reth only (#21119)")
+	// Short sequencing window: with the chain B sequencer stalled below, the chain only
+	// advances once the window expires and derivation force-fills deposits-only blocks.
+	// Light CLs sequence from genesis; the batcher follows them (production wiring).
+	sys := presets.NewTwoL2SupernodeLightSequencerInterop(t, 0,
+		presets.WithDeployerOptions(sysgo.WithSequencingWindow(10)),
+	)
+
+	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
+	bob := sys.FunderB.NewFundedEOA(eth.OneEther)
+	eventLoggerA := alice.DeployEventLogger()
+	sys.L2B.CatchUpTo(sys.L2A)
+	sys.L2A.CatchUpTo(sys.L2B)
+
+	sys.Supernode.EnsureInteropPaused(sys.L2ACL, sys.L2BCL, 10)
+
+	rng := rand.New(rand.NewSource(12345))
+	initMsg := alice.SendRandomInitMessage(rng, eventLoggerA, 2, 10)
+	sys.L2B.WaitForBlock()
+	execMsg := bob.SendInvalidExecMessage(initMsg)
+	invalidBlockNumber := bigs.Uint64Strict(execMsg.BlockNumber())
+	invalidBlockHash := execMsg.BlockHash()
+	invalidBlockTimestamp := sys.L2B.TimestampForBlockNum(invalidBlockNumber)
+
+	// Before invalidation begins: the invalid block must be derived (its replacement is
+	// requested from the derivation path), and the sequencer must be far ahead on the
+	// invalid branch with the supernode VN following it.
+	sys.L2BSupernodeCL.Reached(safety.LocalSafe, invalidBlockNumber, 30)
+	const farAhead = 20
+	sys.L2ELB.Reached(eth.Unsafe, invalidBlockNumber+farAhead, 60)
+	sys.L2BSupernodeEL.Reached(eth.Unsafe, invalidBlockNumber+farAhead, 60)
+
+	// Capture the far-ahead tip of the invalid branch while it is still canonical, then
+	// stop the chain B sequencer. On a live network the sequencer does not honor the
+	// supernode's deny list and keeps extending the invalid branch; the local light
+	// sequencer instead heals within seconds by following the supernode's safe head,
+	// which would mask the recovery behavior under test. Stopping it and re-delivering
+	// the captured tip after the replacement models the live-network condition exactly.
+	farTipOnInvalidBranch := sys.L2ELB.PayloadByNumber(invalidBlockNumber + farAhead)
+	sys.L2BCL.StopSequencer()
+
+	sys.Supernode.ResumeInterop()
+
+	sys.L2BSupernodeEL.AwaitBlockReplaced(invalidBlockNumber, invalidBlockHash, 90)
+	sys.L2BSupernodeCL.PostUnsafePayload(farTipOnInvalidBranch)
+
+	// Verification must get well past the replacement while the just-delivered invalid
+	// branch is never re-adopted as canonical.
+	sys.Supernode.AwaitValidatedTimestampWithoutReadoption(
+		invalidBlockTimestamp+10, sys.L2BSupernodeEL, invalidBlockNumber, invalidBlockHash)
+
+	// The settled replacement must not contain the invalid exec-message tx.
+	sys.L2BSupernodeEL.Reached(eth.Safe, invalidBlockNumber, 30)
+	sys.L2BSupernodeEL.AssertTxNotInBlock(invalidBlockNumber, execMsg.Receipt.TxHash)
+}

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -194,6 +194,31 @@ func (el *L2ELNode) ReachedFn(label eth.BlockLabel, target uint64, attempts int)
 	}
 }
 
+// AwaitBlockReplaced waits until the canonical block at blockNumber has a hash
+// different from oldHash (tolerating temporary absence mid-rewind) and returns it.
+func (el *L2ELNode) AwaitBlockReplaced(blockNumber uint64, oldHash common.Hash, attempts int) eth.L2BlockRef {
+	logger := el.log.With("name", el.inner.Name(), "block", blockNumber, "old_hash", oldHash)
+	logger.Info("Expecting canonical block to be replaced")
+	var replacement eth.L2BlockRef
+	err := retry.Do0(el.ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
+		func() error {
+			ctx, cancel := context.WithTimeout(el.ctx, DefaultTimeout)
+			defer cancel()
+			head, err := el.inner.L2EthClient().L2BlockRefByNumber(ctx, blockNumber)
+			if err != nil {
+				return err
+			}
+			if head.Hash == oldHash {
+				return fmt.Errorf("block %d still has hash %s", blockNumber, oldHash)
+			}
+			replacement = head
+			logger.Info("block replaced", "new_hash", head.Hash)
+			return nil
+		})
+	el.require.NoErrorf(err, "canonical block %d was not replaced (expected hash to change from %s)", blockNumber, oldHash)
+	return replacement
+}
+
 func (el *L2ELNode) BlockRefByNumber(num uint64) eth.L2BlockRef {
 	ctx, cancel := context.WithTimeout(el.ctx, DefaultTimeout)
 	defer cancel()

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -2,7 +2,10 @@ package dsl
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
@@ -355,4 +358,28 @@ func (s *Supernode) EnsureInteropPaused(clA, clB *L2CLNode, pauseOffset uint64) 
 	s.t.Error("EnsureInteropPaused: failed to find unverified timestamp within 100 timestamps")
 	s.t.FailNow()
 	return pauseTimestamp
+}
+
+// AwaitValidatedTimestampWithoutReadoption waits like AwaitValidatedTimestamp, while
+// requiring that the canonical block at blockNumber on el never has deniedHash on any
+// poll. Used after an invalidation to assert verification durably passes the
+// replacement without unsafe sync re-adopting the invalidated block.
+func (s *Supernode) AwaitValidatedTimestampWithoutReadoption(timestamp uint64, el *L2ELNode, blockNumber uint64, deniedHash common.Hash) {
+	// Generous window: with the sequencer stalled, the chain only advances via
+	// derivation once the sequencing window expires.
+	ctx, cancel := context.WithTimeout(s.ctx, 12*DefaultTimeout)
+	defer cancel()
+	api := s.inner.QueryAPI()
+	err := wait.For(ctx, 1*time.Second, func() (bool, error) {
+		head, err := el.inner.L2EthClient().L2BlockRefByNumber(ctx, blockNumber)
+		if err == nil && head.Hash == deniedHash {
+			return false, fmt.Errorf("invalidated block %d re-adopted as canonical on %s", blockNumber, el.inner.Name())
+		}
+		resp, err := api.SuperRootAtTimestamp(ctx, timestamp)
+		if err != nil {
+			return false, nil // Ignore transient errors.
+		}
+		return resp.Data != nil, nil
+	})
+	s.require.NoErrorf(err, "verification did not pass timestamp %d while holding replacement of block %d", timestamp, blockNumber)
 }


### PR DESCRIPTION
## Description

End-to-end regression test for the interop-reorg-2 invalidation livelock (Notion: "Supernode Rewind Race Condition", 2026-07-21). Split out from #21951; top of the stack.

> **Stack** (bottom → top): #21991 (gating fix) → #21992 (sequencer-state persistence + harness fixes) → **this PR**.

### What it tests

`TestSupernodeDoesNotReadoptInvalidatedBlock` (light-sequencer preset): an invalid executing message is included on chain B, the sequencer builds ~20 blocks ahead on the invalid branch, and after the supernode invalidates the block and builds its deposits-only replacement, the captured far-ahead descendant of the invalid block is delivered back over unsafe sync — as live-network gossip does when the sequencer does not follow the deny list (the in-test light sequencer heals too fast to model this, so it is stalled and the captured tip re-posted). The test asserts verification durably passes the replacement while the invalid block is **never** re-adopted as canonical — polled every second, so even transient re-adoption fails the test.

Without the gating fix at the bottom of this stack, this test fails: the delivered descendant triggers an engine sync that re-canonicalizes the denied branch (`invalidated block re-adopted as canonical`). It also needs both harness fixes in the middle of the stack — without real sequencer-state persistence the bootstrap sequencer resurrects mid-test and self-heals the chain, masking the bug; the from-genesis light-sequencer wiring matches production (batcher follows the light CL, not the VN).

### New DSL

- `L2ELNode.AwaitBlockReplaced` — waits until the canonical block at a height has a hash different from the invalidated one (tolerating temporary absence mid-rewind).
- `Supernode.AwaitValidatedTimestampWithoutReadoption` — waits for verification to pass a timestamp while requiring that the canonical block at the invalidated height never carries the denied hash on any poll.

### Metadata

- Split from #21951

🤖 Generated with [Claude Code](https://claude.com/claude-code)
