### PR TITLE
op-supernode: honor persisted sequencer state in VN factory

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -777,7 +777,11 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, target *eth.Exe
 	defer c.Resume(context.Background()) //nolint:errcheck
 	c.log.Info("chain_container/RewindEngine: paused container")
 
-	// stop the vn
+	// Stop the vn. op-node persists sequencer.stopped=true on graceful shutdown
+	// and the restarted VN honors it, so every chain (frozen peers included)
+	// exits invalidation recovery with sequencing disabled until an operator
+	// runs admin_startSequencer — internal restarts must not resurrect a
+	// sequencer.
 	err = vn.Stop(ctx)
 	if err != nil {
 		return err

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -3,6 +3,7 @@ package virtual_node
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,6 +23,11 @@ const VIRTUAL_NODE_CHAIN_ID_LABEL = "virtual_node_chain_id"
 
 // defaultInnerNodeFactory is the default factory that creates a real op-node
 func defaultInnerNodeFactory(ctx context.Context, cfg *opnodecfg.Config, log gethlog.Logger, appVersion string, m *opmetrics.Metrics, initOverload *rollupNode.InitializationOverrides) (innerNode, error) {
+	// Honor persisted sequencer state (e.g. an admin stop-sequencer) across VN
+	// restarts, matching the op-node service entrypoint.
+	if err := cfg.LoadPersisted(log); err != nil {
+		return nil, fmt.Errorf("load persisted config: %w", err)
+	}
 	var overrides rollupNode.InitializationOverrides
 	if initOverload != nil {
 		overrides = *initOverload


### PR DESCRIPTION
## Description

The supernode VN factory builds its op-node config programmatically and calls `rollupNode.NewWithOverride` directly, bypassing the op-node CLI entrypoint (`op-node/service.go`) — which is where `cfg.LoadPersisted` applies persisted sequencer state. VNs therefore silently ignored persisted state: a VN restart booted from static config and **re-enabled sequencing that an operator (`admin_stopSequencer`) — or an invalidation rewind — had stopped**. An operator stop must survive a restart; re-enabling requires an explicit `admin_startSequencer`. This matches op-node restart semantics and is a dual-sequencing hazard fix on its own.

Split out from #21951.

> **Stack** (bottom → top): #21991 (gating fix) → **this PR** → #21992 (harness fixes) → #21993 (acceptance-test repro).

### Commits

1. **`op-supernode: honor persisted sequencer state in VN factory`** — the VN factory now calls `cfg.LoadPersisted`, matching the op-node service entrypoint. No-op unless the VN is sequencer-enabled with active config persistence and a recorded state; the only field it can touch is `Driver.SequencerStopped`.
2. **`op-supernode: document sequencing disabled after invalidation rewind`** — comment-only. An invalidation rewind restarts every VN through op-node's graceful shutdown, which persists `sequencer.stopped=true`; with this PR the restarted VNs honor that state, so a supernode that was actively sequencing exits invalidation recovery with sequencing disabled on all chains until an explicit operator/conductor `admin_startSequencer` — intentional: internal restarts must not silently resurrect a sequencer.

### Context in the stack

This silent-resurrection behavior was also masking bugs in the invalidation acceptance tests: a VN restart mid-invalidation resurrected the bootstrap sequencer (dual sequencing with the light CL) and self-healed the chain. #21992 gives devstack real config persistence so tests exercise the production behavior, and #21993's regression test depends on the sequencer *not* resurrecting mid-test.

### Operational note

Deployments where the supernode is the active sequencer need an operator or conductor-like automation to re-enable sequencing after an invalidation rewind (or any VN restart following a stop), same as a restarted production sequencer op-node. The virtual-sequencer acceptance tests play this operator role in #21992.

### Metadata

- Split from #21951

🤖 Generated with [Claude Code](https://claude.com/claude-code)
