### PR TITLE
op-proposer: create super-root ZK dispute games

### DIFF
--- a/op-acceptance-tests/tests/proofs/zk/setup_test.go
+++ b/op-acceptance-tests/tests/proofs/zk/setup_test.go
@@ -38,17 +38,31 @@ func loadSuperAggregationVKey(t devtest.T) common.Hash {
 	return vkey
 }
 
+// newSystem builds the ZK proofs system with the honest proposer disabled so
+// tests keep manual control over game creation.
 func newSystem(t devtest.T) (*presets.SimpleInterop, common.Hash) {
 	vkey := loadSuperAggregationVKey(t)
+	opts := append(zkPresetOptions(vkey), presets.WithoutHonestProposer())
+	return presets.NewSimpleInterop(t, opts...), vkey
+}
+
+// newProposerSystem builds the ZK proofs system with the production op-proposer
+// running against the ZK dispute game type.
+func newProposerSystem(t devtest.T) (*presets.SimpleInterop, common.Hash) {
+	vkey := loadSuperAggregationVKey(t)
+	return presets.NewSimpleInterop(t, zkPresetOptions(vkey)...), vkey
+}
+
+func zkPresetOptions(vkey common.Hash) []presets.Option {
 	zkCfg := sysgo.ZKDisputeGameConfig{
 		ProgramVKey:          vkey,
 		MaxChallengeDuration: zkChallengeDuration,
 		MaxProveDuration:     zkProveDuration,
 	}
-	return presets.NewSimpleInterop(t,
+	return []presets.Option{
 		presets.WithZKDisputeGame(zkCfg),
 		presets.WithTimeTravelEnabled(),
-		presets.WithDisputeGameFinalityDelaySeconds(uint64(zkFinalityDelay/time.Second)),
+		presets.WithDisputeGameFinalityDelaySeconds(uint64(zkFinalityDelay / time.Second)),
 		presets.WithDeployerOptions(sysgo.WithJovianAtGenesis),
-	), vkey
+	}
 }

--- a/op-acceptance-tests/tests/proofs/zk/zk_proposer_test.go
+++ b/op-acceptance-tests/tests/proofs/zk/zk_proposer_test.go
@@ -1,0 +1,60 @@
+package zk
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// The live proposer keeps creating games while these tests run (including
+// during time travel), so assertions only reference the specific games
+// returned by WaitForZKGameCount and never assume a total game count.
+
+func TestProposerCreatesRootZKGame(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys, _ := newProposerSystem(t)
+	factory := sys.DisputeGameFactory()
+	_, anchorSequence := sys.AnchorStateRegistry(sys.L2ChainA).AnchorRoot()
+
+	game0 := factory.WaitForZKGameCount(1)
+
+	t.Require().Equal(uint32(math.MaxUint32), game0.ParentIndex(),
+		"first proposer game must be a root game using the max-uint32 parent sentinel")
+	t.Require().Greater(game0.L2SequenceNumber(), anchorSequence,
+		"root game must propose a sequence number beyond the anchor")
+}
+
+func TestProposerChainsSecondZKGameOnFirst(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys, _ := newProposerSystem(t)
+	factory := sys.DisputeGameFactory()
+
+	game0 := factory.WaitForZKGameCount(1)
+	game1 := factory.WaitForZKGameCount(2)
+
+	t.Require().Equal(uint32(0), game1.ParentIndex(),
+		"second proposer game must chain on the first game at factory index 0")
+	t.Require().Greater(game1.L2SequenceNumber(), game0.L2SequenceNumber(),
+		"second game must propose a sequence number beyond its parent")
+}
+
+func TestProposerCreatedGameResolvesDefenderWon(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys, _ := newProposerSystem(t)
+	factory := sys.DisputeGameFactory()
+	resolver := sys.FunderL1.NewFundedEOA(eth.OneEther)
+
+	game0 := factory.WaitForZKGameCount(1)
+	advanceL1To(sys, game0.ClaimData().Deadline+1)
+
+	// TODO(#21415): Let op-challenger resolve and close the unchallenged proposal.
+	t.Require().Equal(gameTypes.GameStatusDefenderWon, game0.Resolve(resolver),
+		"unchallenged proposer game must resolve in favour of the defender")
+	advanceL1To(sys, game0.ResolvedAt()+uint64(zkFinalityDelay/time.Second)+1)
+	game0.Close(resolver)
+	sys.AnchorStateRegistry(sys.L2ChainA).WaitForAnchorRoot(game0)
+}

--- a/op-challenger/game/fault/contracts/gameargs/gameargs.go
+++ b/op-challenger/game/fault/contracts/gameargs/gameargs.go
@@ -102,3 +102,20 @@ func Parse(args []byte) (GameArgs, error) {
 	}
 	return output, nil
 }
+
+// ParseZK decodes the packed ZK game args layout produced by Pack (and
+// LibGameArgs.sol's ZK_ARGS_LENGTH = 140 byte encoding).
+func ParseZK(args []byte) (ZKGameArgs, error) {
+	if len(args) != ZKArgsLength {
+		return ZKGameArgs{}, fmt.Errorf("%w: invalid length (%v)", ErrInvalidGameArgs, len(args))
+	}
+	return ZKGameArgs{
+		AbsolutePrestate:     common.BytesToHash(args[0:32]),
+		Verifier:             common.BytesToAddress(args[32:52]),
+		MaxChallengeDuration: binary.BigEndian.Uint64(args[52:60]),
+		MaxProveDuration:     binary.BigEndian.Uint64(args[60:68]),
+		ChallengerBond:       new(big.Int).SetBytes(args[68:100]),
+		AnchorStateRegistry:  common.BytesToAddress(args[100:120]),
+		Weth:                 common.BytesToAddress(args[120:140]),
+	}, nil
+}

--- a/op-challenger/game/fault/contracts/gameargs/gameargs_test.go
+++ b/op-challenger/game/fault/contracts/gameargs/gameargs_test.go
@@ -82,6 +82,39 @@ func TestZKGameArgsPack(t *testing.T) {
 	require.Equal(t, weth[:], got[120:140])
 }
 
+func TestParseZK(t *testing.T) {
+	t.Run("Invalid-ZeroLength", func(t *testing.T) {
+		_, err := ParseZK([]byte{})
+		require.ErrorIs(t, err, ErrInvalidGameArgs)
+	})
+
+	t.Run("Invalid-TooShort", func(t *testing.T) {
+		_, err := ParseZK(make([]byte, ZKArgsLength-1))
+		require.ErrorIs(t, err, ErrInvalidGameArgs)
+	})
+
+	t.Run("Invalid-TooLong", func(t *testing.T) {
+		_, err := ParseZK(make([]byte, ZKArgsLength+1))
+		require.ErrorIs(t, err, ErrInvalidGameArgs)
+	})
+
+	t.Run("Valid-RoundTrip", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1))
+		expected := ZKGameArgs{
+			AbsolutePrestate:     testutils.RandomHash(rng),
+			Verifier:             testutils.RandomAddress(rng),
+			MaxChallengeDuration: 3600,
+			MaxProveDuration:     7200,
+			ChallengerBond:       big.NewInt(1e18),
+			AnchorStateRegistry:  testutils.RandomAddress(rng),
+			Weth:                 testutils.RandomAddress(rng),
+		}
+		actual, err := ParseZK(expected.Pack())
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+}
+
 func fullGameArgs() GameArgs {
 	rng := rand.New(rand.NewSource(0))
 	return GameArgs{

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -3,6 +3,7 @@ package proofs
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"math"
 	"math/big"
 	"net/url"
@@ -236,6 +237,25 @@ func (f *DisputeGameFactory) WaitForGame() *FaultDisputeGame {
 	}, time.Minute*10, time.Second*5)
 
 	return f.GameAtIndex(initialCount)
+}
+
+// WaitForZKGameCount waits until the factory holds at least count games and the
+// game at index count-1 is a ZK dispute game, then returns that game.
+func (f *DisputeGameFactory) WaitForZKGameCount(count int64) *ZKGame {
+	f.require.Positive(count, "game count must be at least 1")
+	f.require.LessOrEqual(count, int64(math.MaxUint32), "game index must fit in uint32")
+	idx := count - 1
+	f.t.Require().Eventually(func() bool {
+		gameCount := f.GameCount()
+		f.log.Info("Waiting for ZK game", "want", count, "current", gameCount)
+		if gameCount < count {
+			return false
+		}
+		gameInfo := contract.Read(f.dgf.GameAtIndex(big.NewInt(idx)))
+		return gameTypes.GameType(gameInfo.GameType) == gameTypes.ZKDisputeGameType
+	}, 2*time.Minute, time.Second,
+		fmt.Sprintf("dispute game factory did not reach %d games with a ZK game at index %d", count, idx))
+	return f.ZKGameAtIndex(uint32(idx))
 }
 
 func (f *DisputeGameFactory) StartSuperCannonKonaGame(eoa *dsl.EOA, opts ...GameOpt) *SuperFaultDisputeGame {

--- a/op-devstack/dsl/proofs/zk_dispute_game.go
+++ b/op-devstack/dsl/proofs/zk_dispute_game.go
@@ -1,7 +1,6 @@
 package proofs
 
 import (
-	"encoding/binary"
 	"math/big"
 
 	challengerContracts "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
@@ -162,30 +161,11 @@ func (g *ZKGame) Close(eoa *dsl.EOA) {
 func (f *DisputeGameFactory) ZKGameImpl() *ZKDisputeGame {
 	impl := f.GameImpl(gameTypes.ZKDisputeGameType)
 	raw := f.GameArgs(gameTypes.ZKDisputeGameType)
-	f.require.Len(raw, gameargs.ZKArgsLength, "ZK game args must be exactly %d bytes", gameargs.ZKArgsLength)
-
-	var prestate common.Hash
-	copy(prestate[:], raw[0:32])
-
-	var verifier common.Address
-	copy(verifier[:], raw[32:52])
-
-	var asr common.Address
-	copy(asr[:], raw[100:120])
-
-	var weth common.Address
-	copy(weth[:], raw[120:140])
+	args, err := gameargs.ParseZK(raw)
+	f.require.NoError(err, "failed to parse ZK game args")
 
 	return &ZKDisputeGame{
 		Address: impl.Address,
-		Args: gameargs.ZKGameArgs{
-			AbsolutePrestate:     prestate,
-			Verifier:             verifier,
-			MaxChallengeDuration: binary.BigEndian.Uint64(raw[52:60]),
-			MaxProveDuration:     binary.BigEndian.Uint64(raw[60:68]),
-			ChallengerBond:       new(big.Int).SetBytes(raw[68:100]),
-			AnchorStateRegistry:  asr,
-			Weth:                 weth,
-		},
+		Args:    args,
 	}
 }

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -85,9 +85,26 @@ func attachSupernodeSuperProofs(t devtest.T, runtime *MultiChainRuntime, cfg Pre
 				sharedDGF,
 				*cfg.ZKDisputeGame,
 			)
-			// TODO(#21463): Start the production proposer once it supports super ZK games.
 			// TODO(#21415): Start the production challenger once it supports the new ZK game API.
-			// Acceptance tests currently drive the game lifecycle explicitly through the DSL.
+			// Game creation is driven by the real proposer below (unless SkipHonestProposer);
+			// challenge and resolution are still driven by the acceptance tests.
+			if !cfg.SkipHonestProposer {
+				proposerOpts := append([]ProposerOption{
+					func(_ ComponentTarget, c *ps.CLIConfig) {
+						c.DisputeGameType = uint32(gameTypes.ZKDisputeGameType)
+					},
+				}, cfg.ProposerOptions...)
+				_ = startSuperProposer(
+					t,
+					runtime.Keys,
+					"main",
+					proofChain.Network.ChainID(),
+					runtime.L1EL,
+					proofChain.Network,
+					runtime.Supernode.UserRPC(),
+					proposerOpts...,
+				)
+			}
 			return runtime
 		}
 	}

--- a/op-proposer/contracts/disputegamefactory.go
+++ b/op-proposer/contracts/disputegamefactory.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
@@ -22,10 +24,25 @@ const (
 	methodInitBonds   = "initBonds"
 	methodCreateGame  = "create"
 	methodVersion     = "version"
+	methodGameArgs    = "gameArgs"
 
 	methodGameCreator = "gameCreator"
 	methodRootClaim   = "rootClaim"
 	methodClaim       = "claimData"
+
+	// ZKDisputeGame methods used for parent selection.
+	methodStatus           = "status"
+	methodL2SequenceNumber = "l2SequenceNumber"
+
+	// AnchorStateRegistry methods used for parent selection.
+	methodGetAnchorRoot     = "getAnchorRoot"
+	methodIsGameBlacklisted = "isGameBlacklisted"
+	methodIsGameRetired     = "isGameRetired"
+
+	// gameStatusChallengerWins is the CHALLENGER_WINS variant of the GameStatus
+	// enum in packages/contracts-bedrock/src/dispute/lib/Types.sol
+	// (0 = IN_PROGRESS, 1 = CHALLENGER_WINS, 2 = DEFENDER_WINS).
+	gameStatusChallengerWins = uint8(1)
 )
 
 type gameInfo struct {
@@ -43,6 +60,8 @@ type DisputeGameFactory struct {
 	caller         *batching.MultiCaller
 	contract       *batching.BoundContract
 	gameABI        *abi.ABI
+	zkGameABI      *abi.ABI
+	asrABI         *abi.ABI
 	networkTimeout time.Duration
 }
 
@@ -52,10 +71,17 @@ func NewDisputeGameFactory(addr common.Address, caller *batching.MultiCaller, ne
 	// is actually needed, proposer always uses the latest FaultDisputeGameABI. Compatibility with other ABIs is tested
 	// in disputegamefactory_test.go
 	gameABI := snapshots.LoadFaultDisputeGameABI()
+	// The ZK game and anchor state registry ABIs are only used when proposing
+	// ZK dispute games (parent selection); they are loaded unconditionally to
+	// match the gameABI pattern above.
+	zkGameABI := snapshots.LoadZKDisputeGameABI()
+	asrABI := snapshots.LoadAnchorStateRegistryABI()
 	return &DisputeGameFactory{
 		caller:         caller,
 		contract:       batching.NewBoundContract(factoryABI, addr),
 		gameABI:        gameABI,
+		zkGameABI:      zkGameABI,
+		asrABI:         asrABI,
 		networkTimeout: networkTimeout,
 	}
 }
@@ -179,4 +205,134 @@ func (f *DisputeGameFactory) loadGameMetadata(ctx context.Context, address commo
 		Proposer: claimant,
 		Claim:    claim,
 	}, nil
+}
+
+// singleCall performs one contract read with its own network timeout.
+func (f *DisputeGameFactory) singleCall(ctx context.Context, call batching.Call) (*batching.CallResult, error) {
+	cCtx, cancel := context.WithTimeout(ctx, f.networkTimeout)
+	defer cancel()
+	return f.caller.SingleCall(cCtx, rpcblock.Latest, call)
+}
+
+// batchCall performs one batched contract read with its own network timeout.
+func (f *DisputeGameFactory) batchCall(ctx context.Context, calls ...batching.Call) ([]*batching.CallResult, error) {
+	cCtx, cancel := context.WithTimeout(ctx, f.networkTimeout)
+	defer cancel()
+	return f.caller.Call(cCtx, rpcblock.Latest, calls...)
+}
+
+// SelectZKParent picks the parent game index for a new ZK dispute game
+// proposal. It walks factory games newest-to-oldest and returns the first
+// candidate that ZKDisputeGame.initialize() would accept as a parent
+// (see ZKDisputeGame.sol): same game type, status != CHALLENGER_WINS, not
+// blacklisted, not retired, and an L2 sequence number strictly above the
+// anchor. If no candidate qualifies it returns parentIndex = math.MaxUint32,
+// anchoring the new game at the anchor state registry's anchor root.
+// The returned starting sequence number is the value the new proposal's
+// sequence number must strictly exceed: the chosen parent's, or the anchor's
+// when there is no parent.
+func (f *DisputeGameFactory) SelectZKParent(ctx context.Context, gameType uint32) (uint32, uint64, error) {
+	asr, err := f.zkAnchorStateRegistry(ctx, gameType)
+	if err != nil {
+		return 0, 0, err
+	}
+	anchorSeq, err := f.anchorSequenceNumber(ctx, asr)
+	if err != nil {
+		return 0, 0, err
+	}
+	gameCount, err := f.gameCount(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get dispute game count: %w", err)
+	}
+
+	// Walk games newest-to-oldest, paging gameAtIndex reads through the
+	// multicaller. Unlike HasProposedSince this walk has no time cutoff, so
+	// one-call-per-index would stall the proposer for minutes on a mature
+	// factory with no ZK games yet (the bootstrap case).
+	pageSize := uint64(f.caller.BatchSize())
+	for end := gameCount; end > 0; {
+		start := uint64(0)
+		if end > pageSize {
+			start = end - pageSize
+		}
+		calls := make([]batching.Call, 0, end-start)
+		for idx := end; idx > start; idx-- {
+			calls = append(calls, f.contract.Call(methodGameAtIndex, new(big.Int).SetUint64(idx-1)))
+		}
+		results, err := f.batchCall(ctx, calls...)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to load games %v-%v: %w", start, end-1, err)
+		}
+		for i, result := range results {
+			idx := end - 1 - uint64(i)
+			if result.GetUint32(0) != gameType {
+				continue
+			}
+			gameAddr := result.GetAddress(2)
+			ok, seqNum, err := f.isValidZKParent(ctx, asr, gameAddr, gameType, anchorSeq)
+			if err != nil {
+				return 0, 0, fmt.Errorf("failed to check ZK parent candidate %v: %w", idx, err)
+			}
+			if !ok {
+				continue
+			}
+			if idx > math.MaxUint32 {
+				return 0, 0, fmt.Errorf("valid parent game index %v does not fit in uint32", idx)
+			}
+			return uint32(idx), seqNum, nil
+		}
+		end = start
+	}
+	// No acceptable parent: propose a root game anchored at the anchor root.
+	return math.MaxUint32, anchorSeq, nil
+}
+
+// isValidZKParent replicates the parent checks in ZKDisputeGame.initialize():
+// status != CHALLENGER_WINS, not blacklisted, not retired, and an L2 sequence
+// number strictly above the anchor. The game type is checked by the caller.
+func (f *DisputeGameFactory) isValidZKParent(ctx context.Context, asr *batching.BoundContract, gameAddr common.Address, gameType uint32, anchorSeq uint64) (bool, uint64, error) {
+	game := batching.NewBoundContract(f.zkGameABI, gameAddr)
+	results, err := f.batchCall(ctx,
+		game.Call(methodStatus),
+		game.Call(methodL2SequenceNumber),
+		asr.Call(methodIsGameBlacklisted, gameAddr),
+		asr.Call(methodIsGameRetired, gameAddr),
+	)
+	if err != nil {
+		return false, 0, fmt.Errorf("failed to load ZK parent candidate state: %w", err)
+	}
+	status := results[0].GetUint8(0)
+	seqNum := bigs.Uint64Strict(results[1].GetBigInt(0))
+	blacklisted := results[2].GetBool(0)
+	retired := results[3].GetBool(0)
+	valid := status != gameStatusChallengerWins && !blacklisted && !retired && seqNum > anchorSeq
+	return valid, seqNum, nil
+}
+
+// zkAnchorStateRegistry resolves the anchor state registry for the given game
+// type from the factory's registered game args.
+func (f *DisputeGameFactory) zkAnchorStateRegistry(ctx context.Context, gameType uint32) (*batching.BoundContract, error) {
+	result, err := f.singleCall(ctx, f.contract.Call(methodGameArgs, gameType))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch game args for game type %v: %w", gameType, err)
+	}
+	args, err := gameargs.ParseZK(result.GetBytes(0))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ZK game args for game type %v: %w", gameType, err)
+	}
+	return batching.NewBoundContract(f.asrABI, args.AnchorStateRegistry), nil
+}
+
+// anchorSequenceNumber reads the anchor root and returns its L2 sequence
+// number, rejecting an unset anchor (game creation would revert with
+// AnchorRootNotFound).
+func (f *DisputeGameFactory) anchorSequenceNumber(ctx context.Context, asr *batching.BoundContract) (uint64, error) {
+	result, err := f.singleCall(ctx, asr.Call(methodGetAnchorRoot))
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch anchor root: %w", err)
+	}
+	if result.GetHash(0) == (common.Hash{}) {
+		return 0, errors.New("anchor state registry has no anchor root")
+	}
+	return bigs.Uint64Strict(result.GetBigInt(1)), nil
 }

--- a/op-proposer/contracts/disputegamefactory_test.go
+++ b/op-proposer/contracts/disputegamefactory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
@@ -37,6 +38,7 @@ func TestHasProposedSince(t *testing.T) {
 		{"FaultDisputeGame", snapshots.LoadFaultDisputeGameABI()},
 		{"SuperFaultDisputeGame", snapshots.LoadSuperFaultDisputeGameABI()},
 		{"SuperPermissionedDisputeGame", snapshots.LoadSuperPermissionedDisputeGameABI()},
+		{"ZKDisputeGame", snapshots.LoadZKDisputeGameABI()},
 	}
 
 	for _, contractType := range gameContractTypes {
@@ -334,6 +336,189 @@ func TestProposalTx(t *testing.T) {
 	stubRpc.VerifyTxCandidate(tx)
 	require.NotNil(t, tx.Value)
 	require.Truef(t, bond.Cmp(tx.Value) == 0, "Expected bond %v but was %v", bond, tx.Value)
+}
+
+type zkTestGame struct {
+	gameType    uint32
+	addr        common.Address
+	status      uint8
+	seqNum      uint64
+	blacklisted bool
+	retired     bool
+}
+
+const zkGameType = uint32(10)
+
+var zkAsrAddr = common.Address{0xa5, 0x12}
+
+func TestSelectZKParent(t *testing.T) {
+	const anchorSeq = uint64(1000)
+
+	validGame := func(addr byte, seqNum uint64) zkTestGame {
+		return zkTestGame{gameType: zkGameType, addr: common.Address{addr}, seqNum: seqNum}
+	}
+
+	tests := []struct {
+		name           string
+		games          []zkTestGame
+		expectedParent uint32
+		expectedSeq    uint64
+	}{
+		{
+			name:           "NoGames",
+			games:          nil,
+			expectedParent: math.MaxUint32,
+			expectedSeq:    anchorSeq,
+		},
+		{
+			name:           "PicksNewestValid",
+			games:          []zkTestGame{validGame(0x01, 1100), validGame(0x02, 1200)},
+			expectedParent: 1,
+			expectedSeq:    1200,
+		},
+		{
+			name: "SkipsChallengerWins",
+			games: []zkTestGame{
+				validGame(0x01, 1100),
+				{gameType: zkGameType, addr: common.Address{0x02}, seqNum: 1200, status: gameStatusChallengerWins},
+			},
+			expectedParent: 0,
+			expectedSeq:    1100,
+		},
+		{
+			name: "SkipsBlacklisted",
+			games: []zkTestGame{
+				validGame(0x01, 1100),
+				{gameType: zkGameType, addr: common.Address{0x02}, seqNum: 1200, blacklisted: true},
+			},
+			expectedParent: 0,
+			expectedSeq:    1100,
+		},
+		{
+			name: "SkipsRetired",
+			games: []zkTestGame{
+				validGame(0x01, 1100),
+				{gameType: zkGameType, addr: common.Address{0x02}, seqNum: 1200, retired: true},
+			},
+			expectedParent: 0,
+			expectedSeq:    1100,
+		},
+		{
+			name: "SkipsAtOrBelowAnchor",
+			games: []zkTestGame{
+				validGame(0x01, 1100),
+				{gameType: zkGameType, addr: common.Address{0x02}, seqNum: anchorSeq},
+			},
+			expectedParent: 0,
+			expectedSeq:    1100,
+		},
+		{
+			name: "SkipsOtherGameTypes",
+			games: []zkTestGame{
+				validGame(0x01, 1100),
+				// Non-ZK games have no stubbed contract; touching them fails the test.
+				{gameType: 4, addr: common.Address{0x02}},
+				{gameType: 5, addr: common.Address{0x03}},
+			},
+			expectedParent: 0,
+			expectedSeq:    1100,
+		},
+		{
+			name: "AllInvalid",
+			games: []zkTestGame{
+				{gameType: zkGameType, addr: common.Address{0x01}, seqNum: 1100, retired: true},
+				{gameType: zkGameType, addr: common.Address{0x02}, seqNum: 1200, status: gameStatusChallengerWins},
+			},
+			expectedParent: math.MaxUint32,
+			expectedSeq:    anchorSeq,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stubRpc, factory := setupDisputeGameFactoryTest(t)
+			withZKGameArgs(stubRpc, zkAsrAddr)
+			withAnchorRoot(stubRpc, common.Hash{0xa1}, anchorSeq)
+			withZKGames(stubRpc, test.games...)
+
+			parentIdx, startingSeq, err := factory.SelectZKParent(context.Background(), zkGameType)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedParent, parentIdx)
+			require.Equal(t, test.expectedSeq, startingSeq)
+		})
+	}
+
+	t.Run("WalksAcrossPages", func(t *testing.T) {
+		stubRpc, factory := setupDisputeGameFactoryTest(t)
+		withZKGameArgs(stubRpc, zkAsrAddr)
+		withAnchorRoot(stubRpc, common.Hash{0xa1}, anchorSeq)
+		// More games than one multicaller batch (DefaultBatchSize=100), with the
+		// only valid ZK parent in the oldest page.
+		games := make([]zkTestGame, batching.DefaultBatchSize+50)
+		for i := range games {
+			games[i] = zkTestGame{gameType: 4, addr: common.Address{0x10, byte(i / 256), byte(i % 256)}}
+		}
+		games[5] = zkTestGame{gameType: zkGameType, addr: common.Address{0x05}, seqNum: 1100}
+		withZKGames(stubRpc, games...)
+
+		parentIdx, startingSeq, err := factory.SelectZKParent(context.Background(), zkGameType)
+		require.NoError(t, err)
+		require.Equal(t, uint32(5), parentIdx)
+		require.Equal(t, uint64(1100), startingSeq)
+	})
+
+	t.Run("ZeroAnchorRoot", func(t *testing.T) {
+		stubRpc, factory := setupDisputeGameFactoryTest(t)
+		withZKGameArgs(stubRpc, zkAsrAddr)
+		withAnchorRoot(stubRpc, common.Hash{}, anchorSeq)
+
+		_, _, err := factory.SelectZKParent(context.Background(), zkGameType)
+		require.ErrorContains(t, err, "no anchor root")
+	})
+
+	t.Run("BadGameArgs", func(t *testing.T) {
+		stubRpc, factory := setupDisputeGameFactoryTest(t)
+		stubRpc.SetResponse(factoryAddr, methodGameArgs, rpcblock.Latest, []interface{}{zkGameType}, []interface{}{[]byte{0x01, 0x02}})
+
+		_, _, err := factory.SelectZKParent(context.Background(), zkGameType)
+		require.ErrorIs(t, err, gameargs.ErrInvalidGameArgs)
+	})
+}
+
+func withZKGameArgs(stubRpc *batchingTest.AbiBasedRpc, asrAddr common.Address) {
+	args := gameargs.ZKGameArgs{
+		AbsolutePrestate:     common.Hash{0x01},
+		Verifier:             common.Address{0x02},
+		MaxChallengeDuration: 30,
+		MaxProveDuration:     30,
+		ChallengerBond:       big.NewInt(1),
+		AnchorStateRegistry:  asrAddr,
+		Weth:                 common.Address{0x03},
+	}
+	stubRpc.SetResponse(factoryAddr, methodGameArgs, rpcblock.Latest, []interface{}{zkGameType}, []interface{}{args.Pack()})
+}
+
+func withAnchorRoot(stubRpc *batchingTest.AbiBasedRpc, root common.Hash, seqNum uint64) {
+	stubRpc.AddContract(zkAsrAddr, snapshots.LoadAnchorStateRegistryABI())
+	stubRpc.SetResponse(zkAsrAddr, methodGetAnchorRoot, rpcblock.Latest, nil, []interface{}{root, new(big.Int).SetUint64(seqNum)})
+}
+
+func withZKGames(stubRpc *batchingTest.AbiBasedRpc, games ...zkTestGame) {
+	stubRpc.SetResponse(factoryAddr, methodGameCount, rpcblock.Latest, nil, []interface{}{big.NewInt(int64(len(games)))})
+	for i, game := range games {
+		stubRpc.SetResponse(factoryAddr, methodGameAtIndex, rpcblock.Latest, []interface{}{big.NewInt(int64(i))}, []interface{}{
+			game.gameType,
+			uint64(1000 + i),
+			game.addr,
+		})
+		if game.gameType != zkGameType {
+			continue
+		}
+		stubRpc.AddContract(game.addr, snapshots.LoadZKDisputeGameABI())
+		stubRpc.SetResponse(game.addr, methodStatus, rpcblock.Latest, nil, []interface{}{game.status})
+		stubRpc.SetResponse(game.addr, methodL2SequenceNumber, rpcblock.Latest, nil, []interface{}{new(big.Int).SetUint64(game.seqNum)})
+		stubRpc.SetResponse(zkAsrAddr, methodIsGameBlacklisted, rpcblock.Latest, []interface{}{game.addr}, []interface{}{game.blacklisted})
+		stubRpc.SetResponse(zkAsrAddr, methodIsGameRetired, rpcblock.Latest, []interface{}{game.addr}, []interface{}{game.retired})
+	}
 }
 
 func withClaims(stubRpc *batchingTest.AbiBasedRpc, gameAbi *abi.ABI, games ...gameMetadata) {

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -29,7 +29,7 @@ var (
 	// postInteropGameTypes are game types that enforce having a super root RPC.
 	// It is ok if this list isn't complete, unknown game types will allow either rollup or super root RPCs.
 	// We just want to reduce foot-guns during the migration period.
-	postInteropGameTypes = []uint32{4, 5}
+	postInteropGameTypes = []uint32{4, 5, ZKDisputeGameType}
 )
 
 // CLIConfig is a well typed config that is parsed from the CLI params.

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -40,6 +40,10 @@ type DGFContract interface {
 	Version(ctx context.Context) (string, error)
 	HasProposedSince(ctx context.Context, proposer common.Address, cutoff time.Time, gameType uint32) (bool, time.Time, common.Hash, error)
 	ProposalTx(ctx context.Context, gameType uint32, outputRoot common.Hash, extraData []byte) (txmgr.TxCandidate, error)
+	// SelectZKParent returns the parent game index for a new ZK dispute game
+	// (math.MaxUint32 for a root game) and the starting L2 sequence number the
+	// new proposal must strictly exceed.
+	SelectZKParent(ctx context.Context, gameType uint32) (uint32, uint64, error)
 }
 
 type RollupClient interface {
@@ -201,6 +205,26 @@ func (l *L2OutputSubmitter) FetchDGFOutput(ctx context.Context) (source.Proposal
 		return source.Proposal{}, false, nil
 	}
 
+	if l.Cfg.DisputeGameType == ZKDisputeGameType {
+		// Select the parent game the new ZK game will build on. The parent can
+		// turn invalid (e.g. blacklisted) between selection and tx inclusion;
+		// game creation then reverts in initialize() and the next tick
+		// re-selects, the same at-most-one-wasted-tx failure mode the proposer
+		// already has for reorgs.
+		parentIdx, startingSeq, err := l.dgfContract.SelectZKParent(ctx, l.Cfg.DisputeGameType)
+		if err != nil {
+			return source.Proposal{}, false, fmt.Errorf("could not select ZK parent game: %w", err)
+		}
+		if output.SequenceNum <= startingSeq {
+			// ZKDisputeGame.initialize() rejects proposals at or before the
+			// starting proposal's sequence number; wait for the next tick.
+			l.Log.Debug("Skipping ZK proposal: sequence number not beyond starting proposal",
+				"sequence_num", output.SequenceNum, "starting_sequence_num", startingSeq, "parent_index", parentIdx)
+			return source.Proposal{}, false, nil
+		}
+		output.ZKParentIndex = &parentIdx
+	}
+
 	l.Log.Info("No proposals found for at least proposal interval, submitting proposal now", "proposalInterval", l.Cfg.ProposalInterval)
 
 	return output, true, nil
@@ -232,15 +256,40 @@ func (l *L2OutputSubmitter) FetchOutput(ctx context.Context, block uint64) (sour
 	return proposal, nil
 }
 
+// proposalExtraData is the single place the dispute game extraData shape is
+// decided. ZK dispute games prepend the parent game index selected by the
+// driver to the super root proof; every other game type uses the proposal
+// source's encoding unchanged.
+func (l *L2OutputSubmitter) proposalExtraData(output source.Proposal) ([]byte, error) {
+	if l.Cfg.DisputeGameType != ZKDisputeGameType {
+		return output.ExtraData(), nil
+	}
+	if !output.IsSuperRootProposal() {
+		return nil, errors.New("ZK dispute game proposals require a super root proposal source")
+	}
+	if output.ZKParentIndex == nil {
+		return nil, errors.New("ZK dispute game proposal is missing a parent game index")
+	}
+	return zkExtraData(*output.ZKParentIndex, output.Super.Marshal()), nil
+}
+
 func (l *L2OutputSubmitter) ProposeL2OutputDGFTxCandidate(ctx context.Context, output source.Proposal) (txmgr.TxCandidate, error) {
+	extraData, err := l.proposalExtraData(output)
+	if err != nil {
+		return txmgr.TxCandidate{}, err
+	}
 	cCtx, cancel := context.WithTimeout(ctx, l.Cfg.NetworkTimeout)
 	defer cancel()
-	return l.dgfContract.ProposalTx(cCtx, l.Cfg.DisputeGameType, output.Root, output.ExtraData())
+	return l.dgfContract.ProposalTx(cCtx, l.Cfg.DisputeGameType, output.Root, extraData)
 }
 
 // sendTransaction creates & sends transactions through the underlying transaction manager.
 func (l *L2OutputSubmitter) sendTransaction(ctx context.Context, output source.Proposal) error {
-	l.Log.Info("Proposing output root", "output", output.Root, "sequenceNum", output.SequenceNum, "extraData", output.ExtraData())
+	extraData, err := l.proposalExtraData(output)
+	if err != nil {
+		return err
+	}
+	l.Log.Info("Proposing output root", "output", output.Root, "sequenceNum", output.SequenceNum, "extraData", extraData)
 
 	candidate, err := l.ProposeL2OutputDGFTxCandidate(ctx, output)
 	if err != nil {

--- a/op-proposer/proposer/driver_test.go
+++ b/op-proposer/proposer/driver_test.go
@@ -24,9 +24,16 @@ import (
 )
 
 type StubDGFContract struct {
-	hasProposedCount int
-	proposedRecently bool
-	cutoff           time.Time
+	hasProposedCount    int
+	proposedRecently    bool
+	cutoff              time.Time
+	selectZKParentCount int
+	zkParentIndex       uint32
+	zkStartingSeq       uint64
+	zkParentErr         error
+	proposalTxGameType  uint32
+	proposalTxRoot      common.Hash
+	proposalTxExtraData []byte
 }
 
 func (m *StubDGFContract) HasProposedSince(_ context.Context, _ common.Address, cutoff time.Time, _ uint32) (bool, time.Time, common.Hash, error) {
@@ -35,8 +42,16 @@ func (m *StubDGFContract) HasProposedSince(_ context.Context, _ common.Address, 
 	return m.proposedRecently, time.Unix(1000, 0), common.Hash{0xdd}, nil
 }
 
-func (m *StubDGFContract) ProposalTx(_ context.Context, _ uint32, _ common.Hash, _ []byte) (txmgr.TxCandidate, error) {
+func (m *StubDGFContract) ProposalTx(_ context.Context, gameType uint32, outputRoot common.Hash, extraData []byte) (txmgr.TxCandidate, error) {
+	m.proposalTxGameType = gameType
+	m.proposalTxRoot = outputRoot
+	m.proposalTxExtraData = extraData
 	return txmgr.TxCandidate{}, nil
+}
+
+func (m *StubDGFContract) SelectZKParent(_ context.Context, _ uint32) (uint32, uint64, error) {
+	m.selectZKParentCount++
+	return m.zkParentIndex, m.zkStartingSeq, m.zkParentErr
 }
 
 func (m *StubDGFContract) Version(_ context.Context) (string, error) {
@@ -172,4 +187,130 @@ func TestL2OutputSubmitter_OutputRetry(t *testing.T) {
 	require.Len(t, logs.FindLogs(testlog.NewMessageContainsFilter("Error getting proposal")), numFails)
 	require.NotNil(t, logs.FindLog(testlog.NewMessageFilter("Proposer tx successfully published")))
 	require.NotNil(t, logs.FindLog(testlog.NewMessageFilter("loop returning")))
+}
+
+type stubProposalSource struct {
+	proposal source.Proposal
+	status   source.SyncStatus
+}
+
+func (s *stubProposalSource) ProposalAtSequenceNum(_ context.Context, _ uint64) (source.Proposal, error) {
+	return s.proposal, nil
+}
+
+func (s *stubProposalSource) SyncStatus(_ context.Context) (source.SyncStatus, error) {
+	return s.status, nil
+}
+
+func (s *stubProposalSource) Close() {}
+
+func superProposal(seqNum uint64) source.Proposal {
+	return source.Proposal{
+		Root:        common.Hash{0xaa},
+		SequenceNum: seqNum,
+		Super: &eth.SuperV1{
+			Timestamp: seqNum,
+			Chains: []eth.ChainIDAndOutput{
+				{ChainID: eth.ChainIDFromUInt64(900), Output: eth.Bytes32{0x01}},
+				{ChainID: eth.ChainIDFromUInt64(901), Output: eth.Bytes32{0x02}},
+			},
+		},
+	}
+}
+
+func zkSubmitter(t *testing.T, dgfContract *StubDGFContract, seqNum uint64) *L2OutputSubmitter {
+	txmgr := txmgrmocks.NewTxManager(t)
+	txmgr.On("From").Return(common.Address{0xab}).Maybe()
+	return &L2OutputSubmitter{
+		DriverSetup: DriverSetup{
+			Log: testlog.Logger(t, log.LevelDebug),
+			Cfg: ProposerConfig{
+				ProposalInterval:  time.Minute,
+				DisputeGameType:   ZKDisputeGameType,
+				AllowNonFinalized: true,
+				NetworkTimeout:    time.Minute,
+			},
+			Txmgr: txmgr,
+			ProposalSource: &stubProposalSource{
+				proposal: superProposal(seqNum),
+				status:   source.SyncStatus{SafeL2: seqNum},
+			},
+		},
+		dgfContract: dgfContract,
+	}
+}
+
+func TestL2OutputSubmitter_FetchDGFOutput_ZKSkipsWhenSequenceNotBeyondStarting(t *testing.T) {
+	dgfContract := &StubDGFContract{zkParentIndex: 3, zkStartingSeq: 500}
+	submitter := zkSubmitter(t, dgfContract, 500)
+
+	_, shouldPropose, err := submitter.FetchDGFOutput(t.Context())
+	require.NoError(t, err)
+	require.False(t, shouldPropose)
+	require.Equal(t, 1, dgfContract.selectZKParentCount)
+}
+
+func TestL2OutputSubmitter_FetchDGFOutput_ZKSetsParentIndex(t *testing.T) {
+	dgfContract := &StubDGFContract{zkParentIndex: 3, zkStartingSeq: 400}
+	submitter := zkSubmitter(t, dgfContract, 500)
+
+	output, shouldPropose, err := submitter.FetchDGFOutput(t.Context())
+	require.NoError(t, err)
+	require.True(t, shouldPropose)
+	require.NotNil(t, output.ZKParentIndex)
+	require.Equal(t, uint32(3), *output.ZKParentIndex)
+}
+
+func TestL2OutputSubmitter_FetchDGFOutput_ZKParentSelectionError(t *testing.T) {
+	expectedErr := fmt.Errorf("boom")
+	dgfContract := &StubDGFContract{zkParentErr: expectedErr}
+	submitter := zkSubmitter(t, dgfContract, 500)
+
+	_, _, err := submitter.FetchDGFOutput(t.Context())
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestProposeL2OutputDGFTxCandidate_ZKExtraData(t *testing.T) {
+	dgfContract := &StubDGFContract{}
+	submitter := zkSubmitter(t, dgfContract, 500)
+	output := superProposal(500)
+	parentIdx := uint32(7)
+	output.ZKParentIndex = &parentIdx
+
+	_, err := submitter.ProposeL2OutputDGFTxCandidate(t.Context(), output)
+	require.NoError(t, err)
+	require.Equal(t, ZKDisputeGameType, dgfContract.proposalTxGameType)
+	require.Equal(t, output.Root, dgfContract.proposalTxRoot)
+
+	expected := append([]byte{0x00, 0x00, 0x00, 0x07}, output.Super.Marshal()...)
+	require.Equal(t, expected, dgfContract.proposalTxExtraData)
+}
+
+func TestProposeL2OutputDGFTxCandidate_ZKRequiresParentIndex(t *testing.T) {
+	dgfContract := &StubDGFContract{}
+	submitter := zkSubmitter(t, dgfContract, 500)
+
+	_, err := submitter.ProposeL2OutputDGFTxCandidate(t.Context(), superProposal(500))
+	require.ErrorContains(t, err, "missing a parent game index")
+}
+
+func TestProposeL2OutputDGFTxCandidate_ZKRequiresSuperRootProposal(t *testing.T) {
+	dgfContract := &StubDGFContract{}
+	submitter := zkSubmitter(t, dgfContract, 500)
+	parentIdx := uint32(0)
+	output := source.Proposal{Root: common.Hash{0xaa}, SequenceNum: 500, ZKParentIndex: &parentIdx}
+
+	_, err := submitter.ProposeL2OutputDGFTxCandidate(t.Context(), output)
+	require.ErrorContains(t, err, "require a super root proposal source")
+}
+
+func TestProposeL2OutputDGFTxCandidate_NonZKUnchanged(t *testing.T) {
+	dgfContract := &StubDGFContract{}
+	submitter := zkSubmitter(t, dgfContract, 500)
+	submitter.Cfg.DisputeGameType = 4
+	output := superProposal(500)
+
+	_, err := submitter.ProposeL2OutputDGFTxCandidate(t.Context(), output)
+	require.NoError(t, err)
+	require.Equal(t, output.Super.Marshal(), dgfContract.proposalTxExtraData)
 }

--- a/op-proposer/proposer/source/source.go
+++ b/op-proposer/proposer/source/source.go
@@ -20,6 +20,11 @@ type Proposal struct {
 
 	CurrentL1 eth.BlockID
 
+	// ZKParentIndex is the parent game index for ZK dispute game proposals.
+	// It is derived from L1 dispute-game-factory state and set by the driver,
+	// never by a proposal source. It is nil for all other proposal types.
+	ZKParentIndex *uint32
+
 	// Legacy provides data that is only available when retrieving data from a single rollup node.
 	// It should only be used for optional logs and metrics.
 	Legacy LegacyProposalData

--- a/op-proposer/proposer/zk.go
+++ b/op-proposer/proposer/zk.go
@@ -1,0 +1,19 @@
+package proposer
+
+import "encoding/binary"
+
+// ZKDisputeGameType is the dispute game type for the super-root ZK dispute
+// game. It mirrors op-challenger/game/types.ZKDisputeGameType; op-proposer
+// follows its convention of raw uint32 game types (see postInteropGameTypes).
+const ZKDisputeGameType uint32 = 10
+
+// zkExtraData encodes the extraData for a ZKDisputeGame creation:
+// a 4-byte big-endian parent game index followed by the super root proof
+// (the marshaled super root pre-image). See the extraData layout documented
+// in ZKDisputeGame.sol and the CWIA getters parentIndex()/l2SequenceNumber().
+func zkExtraData(parentIndex uint32, superRootProof []byte) []byte {
+	extraData := make([]byte, 4+len(superRootProof))
+	binary.BigEndian.PutUint32(extraData[:4], parentIndex)
+	copy(extraData[4:], superRootProof)
+	return extraData
+}

--- a/op-proposer/proposer/zk_test.go
+++ b/op-proposer/proposer/zk_test.go
@@ -1,0 +1,24 @@
+package proposer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestZKExtraData(t *testing.T) {
+	t.Run("ParentIndex", func(t *testing.T) {
+		extraData := zkExtraData(1, []byte{0xbe, 0xef})
+		require.Equal(t, []byte{0x00, 0x00, 0x00, 0x01, 0xbe, 0xef}, extraData)
+	})
+
+	t.Run("RootGameSentinel", func(t *testing.T) {
+		extraData := zkExtraData(0xffffffff, []byte{0x01})
+		require.Equal(t, []byte{0xff, 0xff, 0xff, 0xff, 0x01}, extraData)
+	})
+
+	t.Run("EmptyProof", func(t *testing.T) {
+		extraData := zkExtraData(0x01020304, nil)
+		require.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, extraData)
+	})
+}


### PR DESCRIPTION
## Summary

Teach op-proposer the ZKDisputeGame (game type 10) create path (closes #21414, first slice of #21463). The defend path (challenge detection, proof requests, prove/resolve) is out of scope and stays in #21463.

- **Parent selection.** `SelectZKParent` walks factory games newest to oldest with paged multicall reads and picks the first parent `ZKDisputeGame.initialize()` would accept. Challenged-but-undecided parents are legal parents; refusing to build on locally-invalid games is defend-path policy (#21463 / #21445).
- **extraData.** ZK proposals submit `create(10, superRootHash, parentIndex || superRootProof)`. The root claim is unchanged supernode output (`keccak256(superRootProof)`). A tick is skipped when the safe timestamp is not strictly beyond the starting sequence number, so an honest proposer can never hit the `initialize()` ordering revert.
- **Single decision point.** `proposalExtraData` is the only place the game-shape decision is made; non-ZK game types keep the exact previous encoding (locked by a unit test), and the proposal log now reports the bytes actually submitted.
- **gameargs.ParseZK** (inverse of `Pack`); the devstack `ZKGameImpl` hand parser is replaced with it.
- **Config.** Game type 10 joins `postInteropGameTypes`, requiring a super-root RPC
- **Devstack + acceptance.** ZK presets now start the production proposer with game type 10 (honoring `SkipHonestProposer`); the four existing lifecycle tests opt out to keep manual control. Three new acceptance tests drive the real binary.

## Test plan

- `go test ./op-proposer/...` and `go test ./op-challenger/game/fault/contracts/gameargs/...`: 11 `SelectZKParent` cases (including a cross-page walk), driver ZK branch tests, extraData goldens, ZK ABI added to the `HasProposedSince` compatibility table, `ParseZK` round trip.
- Acceptance (`op-acceptance-tests/tests/proofs/zk`, verified locally): `TestProposerCreatesRootZKGame`, `TestProposerChainsSecondZKGameOnFirst`, `TestProposerCreatedGameResolvesDefenderWon` all pass: the real proposer creates a root game, chains a second on it with a strictly increasing sequence number, and the game resolves `DEFENDER_WINS` and anchors.
- Regression: the four pre-existing ZK lifecycle tests pass (now with the honest proposer explicitly disabled); `op-e2e/actions/proposer` passes (non-ZK create path unchanged end to end).

## Notes

- Tiny conflict with #21983 (challenger side) in `multichain_proofs.go` and the ZK acceptance setup; whichever lands second rebases. The merged ZK devstack branch should start both the challenger and the proposer. After #21983 lands, `TestProposerCreatedGameResolvesDefenderWon` should switch from manual `Resolve` to waiting on the honest challenger's resolution.