### PR TITLE
op-supernode: Fail startup when deny list cannot be opened

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -243,12 +243,11 @@ func NewChainContainer(
 		}
 	}
 	// Initialize the deny list for block invalidation
-	denyListPath := c.subPath("denylist")
-	if denyList, err := OpenDenyList(denyListPath); err != nil {
-		log.Error("failed to open deny list", "err", err)
-	} else {
-		c.denyList = denyList
+	denyList, err := OpenDenyList(c.subPath("denylist"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open deny list for chain %s: %w", chainID, err)
 	}
+	c.denyList = denyList
 	// Set up the interop engine controller. The connection is dialed lazily, so setup never
 	// blocks on or fails because of an unreachable L2 engine at startup -- the client connects
 	// on first use and reconnects on demand. This is what lets interop recover once the EL comes

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math/big"
 	"net/http"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -504,6 +505,26 @@ func TestChainContainer_EngineControllerSetupErrorFailsConstruction(t *testing.T
 
 	_, err := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 	require.ErrorIs(t, err, setupErr)
+}
+
+// TestChainContainer_DenyListOpenErrorFailsConstruction verifies that a failure
+// to open the deny list aborts construction rather than being swallowed. The
+// deny list is what stops a node from adopting invalidated blocks as safe, so a
+// chain must not start unable to consult it.
+func TestChainContainer_DenyListOpenErrorFailsConstruction(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+	vncfg := createTestVNConfig() // no L2 endpoint, so construction reaches the deny list open
+	log := createTestLogger(t)
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	// Point DataDir at a regular file so the deny list directory cannot be created.
+	dataDir := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(dataDir, []byte("x"), 0o600))
+	cfg := createTestCLIConfig(dataDir)
+
+	_, err := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "deny list")
 }
 
 func TestChainContainerIsRPCReady(t *testing.T) {


### PR DESCRIPTION
## What

Follow-up to ethereum-optimism/optimism#21970 ([review thread](https://github.com/ethereum-optimism/optimism/pull/21970#discussion_r3638885190)).

`NewChainContainer` opened the SuperAuthority deny list with log-and-continue: on failure it logged an error and ran on with `denyList == nil`. That left a node permanently degraded — unable to consult the deny list for the entire process lifetime — with only a startup log line to show for it.

## Change

Make a deny-list open failure fatal at construction, mirroring the existing engine-controller setup failure a few lines below. If the deny list is load-bearing enough to stall derivation over (as the consolidation check in #21970 now does), it is load-bearing enough to refuse to start without.

## Test plan

- New `TestChainContainer_DenyListOpenErrorFailsConstruction` points `DataDir` at a regular file so the deny-list directory cannot be created, and asserts construction returns an error.
- `go test ./op-supernode/supernode/chain_container/` passes; `op-golangci-lint` clean.
