### PR TITLE
ci: bump apko factory pin to include BASH_REMATCH fix

### DIFF
--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@303276b8684655b2af1e878f0317c522826b5857
+        uses: ethereum-optimism/factory/actions/apko-plan@71a5f61d2b308d705de4a8959d89156755f68db3
         with:
           config: .github/images.apko.json
 
@@ -59,7 +59,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@303276b8684655b2af1e878f0317c522826b5857
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -91,7 +91,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@303276b8684655b2af1e878f0317c522826b5857
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -114,7 +114,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@303276b8684655b2af1e878f0317c522826b5857
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus


### PR DESCRIPTION
## Problem

The op-node `v1.19.4-rc.3` release CI failed in the `build-images.apko`
workflow's `plan` job:

```
release tag regex '^([^/]+)/(v.+)$' did not provide capture indexes service=1 version=2 for 'op-node/v1.19.4-rc.3'
```

The regex actually matches the tag. The failure comes from a
`BASH_REMATCH`-clobbering bug in the factory `apko-plan.sh`: the numeric
`service_match`/`version_match` validation (a `[[ =~ ]]` test) ran
*between* the release-tag match and the capture-index guard, overwriting
`BASH_REMATCH` with a zero-group match and tripping the guard on every
release build.

## Fix

Factory commit `7ed7d8fb85` ("fix(apko-plan): preserve BASH_REMATCH after
release tag parsing") reorders the numeric validation before the tag
match. This bumps all four factory references in
`build-images.apko.yaml` from `303276b8` (2026-06-25, pre-fix) to
`71a5f61d`, matching the pins already deployed in the `infra` and
`infrastructure-services` repos.

## Testing

Release-tag parsing is exercised by the workflow itself on the next
tagged build.