### PR TITLE
op-node,alloy-op-hardforks,kona: add EIP-8130 fork toggles

### DIFF
--- a/op-node/rollup/toggles.go
+++ b/op-node/rollup/toggles.go
@@ -43,3 +43,13 @@ func (c *Config) IsInteropActivationBlock(l2BlockTime uint64) bool {
 	}
 	return c.IsLagoonActivationBlock(l2BlockTime)
 }
+
+// IsEip8130 gates EIP-8130 account-abstraction transactions: when false, batches carrying
+// 0x79 transactions are rejected during derivation.
+//
+// EIP-8130 is not yet assigned to a network upgrade, so this returns false unconditionally
+// and no schedule activates the feature. Replace the body with the carrying fork's accessor
+// once that upgrade is chosen.
+func (c *Config) IsEip8130(time uint64) bool {
+	return false
+}

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -1076,6 +1076,22 @@ func TestConfig_IsSDM(t *testing.T) {
 	require.True(t, cfg.IsSDM(101))
 }
 
+// TestConfig_IsEip8130 pins the dark-launch state: EIP-8130 is not yet assigned to a network
+// upgrade, so no fork schedule may activate it. Wiring the toggle to a fork must be a deliberate
+// edit, not something scheduling an upgrade can trigger.
+func TestConfig_IsEip8130(t *testing.T) {
+	var cfg Config
+	require.False(t, cfg.IsEip8130(0))
+
+	activation := uint64(100)
+	for _, fork := range scheduleableForks {
+		cfg.SetActivationTime(fork, &activation)
+	}
+	require.False(t, cfg.IsEip8130(99))
+	require.False(t, cfg.IsEip8130(100))
+	require.False(t, cfg.IsEip8130(101))
+}
+
 // TestConfig_ActivationBlockAndForFork combines tests for IsActivationBlock and IsActivationBlockForFork.
 func TestConfig_ActivationBlockAndForFork(t *testing.T) {
 	for _, fork := range scheduleableForks {

--- a/rust/alloy-op-hardforks/src/lib.rs
+++ b/rust/alloy-op-hardforks/src/lib.rs
@@ -317,6 +317,18 @@ pub trait OpHardforks: EthereumHardforks {
     fn is_interop_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.is_lagoon_active_at_timestamp(timestamp)
     }
+
+    /// Returns `true` if the [EIP-8130] account-abstraction feature is active at the given block
+    /// timestamp.
+    ///
+    /// EIP-8130 is not yet assigned to a hard fork, so this returns `false` unconditionally
+    /// and no fork schedule activates the feature. Replace the body with the carrying fork's accessor
+    /// the body with the carrying fork's accessor once that upgrade is chosen.
+    ///
+    /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+    fn is_eip8130_active_at_timestamp(&self, _timestamp: u64) -> bool {
+        false
+    }
 }
 
 /// A type allowing to configure activation [`ForkCondition`]s for a given list of

--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -366,6 +366,19 @@ impl RollupConfig {
             !self.is_interop_active(timestamp.saturating_sub(self.block_time))
     }
 
+    /// Returns true if the [EIP-8130] account-abstraction feature is active at the given
+    /// timestamp.
+    ///
+    /// EIP-8130 is not yet assigned to a hardfork, so this returns false unconditionally and no
+    /// fork schedule activates the feature. Replace the body with the carrying fork's accessor
+    /// once that upgrade is chosen. EIP-8130 code should gate on this, not on a raw fork accessor,
+    /// so that flip happens in one place.
+    ///
+    /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+    pub const fn is_eip8130_active(&self, _timestamp: u64) -> bool {
+        false
+    }
+
     /// Returns true if a DA Challenge proxy Address is provided in the rollup config and the
     /// address is not zero.
     pub fn is_alt_da_enabled(&self) -> bool {
@@ -787,6 +800,22 @@ mod tests {
         assert_eq!(config.is_interop_active(120), config.is_lagoon_active(120));
         assert!(config.is_first_interop_block(120));
         assert!(!config.is_first_interop_block(122));
+    }
+
+    /// Pins the dark-launch state: EIP-8130 is not yet assigned to a hardfork, so no fork schedule
+    /// may activate it. Wiring the gate to a fork must be a deliberate edit, not something
+    /// scheduling an upgrade can trigger.
+    #[test]
+    fn test_eip8130_is_not_activated_by_any_fork() {
+        let mut config = RollupConfig { block_time: 2, ..Default::default() };
+        assert!(!config.is_eip8130_active(0));
+
+        config.hardforks.jovian_time = Some(100);
+        config.hardforks.karst_time = Some(100);
+        config.hardforks.lagoon_time = Some(100);
+        assert!(!config.is_eip8130_active(99));
+        assert!(!config.is_eip8130_active(100));
+        assert!(!config.is_eip8130_active(101));
     }
 
     #[test]


### PR DESCRIPTION
**Description**

Adds the feature predicate that will gate [EIP-8130](https://eips.ethereum.org/EIPS/eip-8130)
account-abstraction transactions, in each of the three places that need one:

- `op-node/rollup/toggles.go`: `Config.IsEip8130`
- `rust/alloy-op-hardforks`: `OpHardforks::is_eip8130_active_at_timestamp`
- `rust/kona/crates/protocol/genesis`: `RollupConfig::is_eip8130_active`

All three return `false` unconditionally. EIP-8130 is not yet assigned to a network upgrade, so no
fork schedule activates it and this PR is a behavioral no-op. The predicates exist now so that the
implementation PRs that follow have a single place to gate on, and so that assigning EIP-8130 to an
upgrade later is one edit per client rather than one per call site.

Each predicate follows the pattern already established by its siblings.

**Tests**

Two tests, one per language, both pinning the dark-launch invariant rather than just the return
value: scheduling every known fork must not activate EIP-8130. This is what catches an accidental
wiring to a fork accessor, which would otherwise be a silent activation.

- `TestConfig_IsEip8130` (`op-node/rollup/types_test.go`) iterates `scheduleableForks`, sets every
  activation time, and asserts the predicate stays false either side of the boundary.
- `test_eip8130_is_not_activated_by_any_fork` (`kona/crates/protocol/genesis/src/rollup.rs`) sets
  Jovian, Karst, and Lagoon and asserts the same.

Verified locally: `gofmt`, `go vet ./op-node/rollup/`, `go test ./op-node/rollup/`,
`cargo clippy -p alloy-op-hardforks -p kona-genesis --all-features --all-targets -- -D warnings`,
`cargo +nightly fmt --check`, and `cargo check -p reth-optimism-forks -p reth-optimism-chainspec`
to confirm the new defaulted trait method doesn't break op-reth. `Cargo.lock` is unchanged.

**Additional context**

**Known limitation.** Because `toggles.go` is source-edit-only, `false` means EIP-8130 cannot be
activated anywhere, including devnets and e2e. That is fine while the work is unit-testable but
becomes blocking once execution needs a running chain to test against.

**Metadata**

Spec: `specs/experimental/eip-8130.md` in ethereum-optimism/specs.

<!-- No tracking issue yet; add "Fixes #NNN" if one is filed. -->