### PR TITLE
op-node: reset non-canonical pending safe head

### DIFF
--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -2,8 +2,10 @@ package derive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -28,6 +30,7 @@ type L1ReceiptsFetcher interface {
 
 type SystemConfigL2Fetcher interface {
 	SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error)
+	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 }
 
 // FetchingAttributesBuilder fetches inputs for the building of L2 payload attributes on the fly.
@@ -72,6 +75,14 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 
 	sysConfig, err := ba.l2.SystemConfigByL2Hash(ctx, l2Parent.Hash)
 	if err != nil {
+		if errors.Is(err, ethereum.NotFound) {
+			canonical, canonicalErr := ba.l2.L2BlockRefByNumber(ctx, l2Parent.Number)
+			if canonicalErr == nil && canonical.Hash != l2Parent.Hash {
+				return nil, NewResetError(fmt.Errorf(
+					"L2 parent %s is non-canonical; canonical block is %s: %w",
+					l2Parent.ID(), canonical.ID(), err))
+			}
+		}
 		return nil, NewTemporaryError(fmt.Errorf("failed to retrieve L2 parent block: %w", err))
 	}
 

--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/params"
@@ -105,6 +106,22 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		_, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.ErrorIs(t, err, mockRPCErr, "mock rpc error expected")
 		require.ErrorIs(t, err, ErrTemporary, "rpc errors should not be critical, it is not necessary to reorg")
+	})
+	t.Run("non-canonical parent missing by hash resets", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		l1Fetcher := &testutils.MockL1Source{}
+		l2Parent := testutils.RandomL2BlockRef(rng)
+		canonicalParent := l2Parent
+		canonicalParent.Hash = testutils.RandomHash(rng)
+		l2Fetcher := &testutils.MockL2Client{}
+		l2Fetcher.ExpectSystemConfigByL2Hash(l2Parent.Hash, eth.SystemConfig{}, ethereum.NotFound)
+		l2Fetcher.ExpectL2BlockRefByNumber(l2Parent.Number, canonicalParent, nil)
+		defer l2Fetcher.AssertExpectations(t)
+
+		attrBuilder := NewFetchingAttributesBuilder(mkCfg(), params.MergedTestChainConfig, nil, l1Fetcher, l2Fetcher)
+		_, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, l2Parent.L1Origin)
+
+		require.ErrorIs(t, err, ErrReset, "a definitively non-canonical parent must reset derivation")
 	})
 	t.Run("next origin without deposits", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -69,11 +69,13 @@ func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 		st.data.UnsafeL2 = eth.L2BlockRef{}
 		st.data.SafeL2 = eth.L2BlockRef{}
 		st.data.LocalSafeL2 = eth.L2BlockRef{}
+		st.data.PendingSafeL2 = eth.L2BlockRef{}
 		st.data.CurrentL1 = eth.L1BlockRef{}
 	case engine.EngineResetConfirmedEvent:
 		st.data.UnsafeL2 = x.LocalUnsafe
 		st.data.CrossUnsafeL2 = x.CrossUnsafe
 		st.data.LocalSafeL2 = x.LocalSafe
+		st.data.PendingSafeL2 = x.LocalSafe
 		st.data.SafeL2 = x.CrossSafe
 		st.data.FinalizedL2 = x.Finalized
 	default: // other events do not affect the sync status

--- a/op-node/rollup/status/status_test.go
+++ b/op-node/rollup/status/status_test.go
@@ -77,3 +77,34 @@ func TestForkchoiceUpdateSeedsLocalSafeWithGenesisSafe(t *testing.T) {
 	require.Equal(t, genesis, status.LocalSafeL2)
 	require.Equal(t, genesis, status.FinalizedL2)
 }
+
+func TestResetEventClearsPendingSafe(t *testing.T) {
+	tracker := NewStatusTracker(testlog.Logger(t, log.LevelDebug), NoopMetrics{})
+	tracker.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
+		PendingSafe: eth.L2BlockRef{Number: 200},
+		Unsafe:      eth.L2BlockRef{Number: 300},
+	})
+
+	tracker.OnEvent(context.Background(), rollup.ResetEvent{})
+
+	require.Equal(t, eth.L2BlockRef{}, tracker.SyncStatus().PendingSafeL2)
+}
+
+func TestEngineResetConfirmedSetsPendingSafeToLocalSafe(t *testing.T) {
+	tracker := NewStatusTracker(testlog.Logger(t, log.LevelDebug), NoopMetrics{})
+	tracker.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
+		PendingSafe: eth.L2BlockRef{Number: 200},
+		Unsafe:      eth.L2BlockRef{Number: 300},
+	})
+	localSafe := eth.L2BlockRef{Number: 100}
+
+	tracker.OnEvent(context.Background(), engine.EngineResetConfirmedEvent{
+		LocalUnsafe: eth.L2BlockRef{Number: 300},
+		CrossUnsafe: eth.L2BlockRef{Number: 100},
+		LocalSafe:   localSafe,
+		CrossSafe:   localSafe,
+		Finalized:   eth.L2BlockRef{Number: 90},
+	})
+
+	require.Equal(t, localSafe, tracker.SyncStatus().PendingSafeL2)
+}


### PR DESCRIPTION
## Summary

- Clear reported pending-safe state when derivation resets.
- Seed reported pending-safe state from local-safe when engine reset completes.
- When a pending-safe parent is missing by hash, compare the canonical block at the same height and return a reset error on a definitive hash mismatch.
- Remove the earlier supernode VN restart workaround.

## Root cause

PendingSafeL2 is not persisted in SafeDB. It is runtime engine-controller state, while the sync-status tracker separately mirrors it for RPC consumers.

Two generic op-node behaviors combined during the reorg recovery:

1. Reset events did not clear or reseed StatusTracker.PendingSafeL2, so optimism_syncStatus could report an orphaned head after engine reset.
2. PreparePayloadAttributes classified a missing parent hash as temporary even when the EL had a different canonical block at the same number. Derivation retried instead of resetting.

The canonical by-number comparison makes the reset decision only when the EL proves the old hash is non-canonical. If that comparison cannot be completed, the existing temporary-error behavior remains.

## Non-goals

This does not repair supernode logsDB/accepted-state divergence, proxyd freshness or monotonicity policy, or Reth ExEx WAL consistency.

## Tests

- go test ./op-node/rollup/status ./op-node/rollup/derive -run 'TestResetEventClearsPendingSafe|TestEngineResetConfirmedSetsPendingSafeToLocalSafe|TestPreparePayloadAttributes/non-canonical' -count=1
- go test ./op-node/rollup/... -count=1
- go test ./op-node/... -count=1

All passed.
