### PR TITLE
op-node: reset non-canonical pending safe head

### DIFF
--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -251,9 +251,14 @@ func (eq *AttributesHandler) consolidateNextSafeAttributes(attributes *derive.At
 		return
 	}
 	if denied {
-		eq.log.Warn("Consolidated block denied by SuperAuthority, forcing reorg to build replacement",
+		eq.log.Warn("Consolidated block denied by SuperAuthority, requesting deposits-only replacement",
 			"blockNumber", payload.BlockNumber, "blockHash", payload.BlockHash, "pending_safe", onto)
-		eq.reorgOutUnsafeChain(attributes)
+		eq.attributes = nil
+		eq.sentAttributes = false
+		eq.emitter.Emit(eq.ctx, derive.DepositsOnlyPayloadAttributesRequestEvent{
+			Parent:      attributes.Parent.ID(),
+			DerivedFrom: attributes.DerivedFrom,
+		})
 		return
 	}
 

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -344,8 +344,8 @@ func TestAttributesHandler(t *testing.T) {
 			})
 		})
 		t.Run("consolidation passes but block denied", func(t *testing.T) {
-			// Matching attributes but the block is denied: must force the build
-			// path, not promote.
+			// Matching attributes but the block is denied: request deposits-only
+			// attributes before starting an EL payload job.
 			logger := testlog.Logger(t, log.LevelInfo)
 			l2 := &testutils.MockL2Client{}
 			emitter := &testutils.MockEmitter{}
@@ -369,8 +369,10 @@ func TestAttributesHandler(t *testing.T) {
 			// Call during consolidation: attributes match, but the block is denied.
 			l2.ExpectPayloadByNumber(refA1.Number, payloadA1, nil)
 			engDeriver.On("IsDenied", uint64(payloadA1.ExecutionPayload.BlockNumber), payloadA1.ExecutionPayload.BlockHash).Return(true, nil).Once()
-			// Denied block forces a reorg via the build path rather than promotion.
-			emitter.ExpectOnce(engine.BuildStartEvent{Attributes: attr})
+			emitter.ExpectOnce(derive.DepositsOnlyPayloadAttributesRequestEvent{
+				Parent:      attr.Parent.ID(),
+				DerivedFrom: attr.DerivedFrom,
+			})
 			ah.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
 				PendingSafe: refA0,
 				Unsafe:      refA1,
@@ -378,8 +380,8 @@ func TestAttributesHandler(t *testing.T) {
 			engDeriver.AssertExpectations(t)
 			l2.AssertExpectations(t)
 			emitter.AssertExpectations(t)
-			require.True(t, ah.sentAttributes, "attributes were sent to the build path")
-			require.NotNil(t, ah.attributes, "attributes stay queued until the replacement is processed")
+			require.False(t, ah.sentAttributes, "denied attributes must not reach the build path")
+			require.Nil(t, ah.attributes, "drop denied attributes while deriving the replacement")
 		})
 		t.Run("deny-list check error stalls without promoting", func(t *testing.T) {
 			// Fail closed: if the deny-list can't be checked we must neither promote

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -2,8 +2,10 @@ package derive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -28,6 +30,7 @@ type L1ReceiptsFetcher interface {
 
 type SystemConfigL2Fetcher interface {
 	SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error)
+	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 }
 
 // FetchingAttributesBuilder fetches inputs for the building of L2 payload attributes on the fly.
@@ -72,6 +75,14 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 
 	sysConfig, err := ba.l2.SystemConfigByL2Hash(ctx, l2Parent.Hash)
 	if err != nil {
+		if errors.Is(err, ethereum.NotFound) {
+			canonical, canonicalErr := ba.l2.L2BlockRefByNumber(ctx, l2Parent.Number)
+			if canonicalErr == nil && canonical.Hash != l2Parent.Hash {
+				return nil, NewResetError(fmt.Errorf(
+					"L2 parent %s is non-canonical; canonical block is %s: %w",
+					l2Parent.ID(), canonical.ID(), err))
+			}
+		}
 		return nil, NewTemporaryError(fmt.Errorf("failed to retrieve L2 parent block: %w", err))
 	}
 

--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/params"
@@ -105,6 +106,22 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		_, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.ErrorIs(t, err, mockRPCErr, "mock rpc error expected")
 		require.ErrorIs(t, err, ErrTemporary, "rpc errors should not be critical, it is not necessary to reorg")
+	})
+	t.Run("non-canonical parent missing by hash resets", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		l1Fetcher := &testutils.MockL1Source{}
+		l2Parent := testutils.RandomL2BlockRef(rng)
+		canonicalParent := l2Parent
+		canonicalParent.Hash = testutils.RandomHash(rng)
+		l2Fetcher := &testutils.MockL2Client{}
+		l2Fetcher.ExpectSystemConfigByL2Hash(l2Parent.Hash, eth.SystemConfig{}, ethereum.NotFound)
+		l2Fetcher.ExpectL2BlockRefByNumber(l2Parent.Number, canonicalParent, nil)
+		defer l2Fetcher.AssertExpectations(t)
+
+		attrBuilder := NewFetchingAttributesBuilder(mkCfg(), params.MergedTestChainConfig, nil, l1Fetcher, l2Fetcher)
+		_, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, l2Parent.L1Origin)
+
+		require.ErrorIs(t, err, ErrReset, "a definitively non-canonical parent must reset derivation")
 	})
 	t.Run("next origin without deposits", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))

--- a/op-node/rollup/engine/payload_process.go
+++ b/op-node/rollup/engine/payload_process.go
@@ -33,11 +33,15 @@ func (e *EngineController) onPayloadProcess(ctx context.Context, ev PayloadProce
 		payload := ev.Envelope.ExecutionPayload
 		denied, err := e.superAuthority.IsDenied(uint64(payload.BlockNumber), payload.BlockHash)
 		if err != nil {
-			e.log.Error("Failed to check SuperAuthority denylist, proceeding with payload",
+			e.log.Error("Failed to check SuperAuthority denylist, stalling payload",
 				"blockNumber", payload.BlockNumber,
 				"blockHash", payload.BlockHash,
 				"err", err,
 			)
+			e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+				Err: fmt.Errorf("failed to check SuperAuthority deny-list for block %s: %w", payload.ID(), err),
+			})
+			return
 		} else if denied {
 			if ev.DerivedFrom != (eth.L1BlockRef{}) {
 				e.log.Warn("Requesting deposits-only replacement for derived payload",

--- a/op-node/rollup/engine/super_authority_deny_test.go
+++ b/op-node/rollup/engine/super_authority_deny_test.go
@@ -62,16 +62,14 @@ func TestSuperAuthority(t *testing.T) {
 			},
 		},
 		{
-			name: "Error_ProceedsWithPayload",
+			name: "Error_StallsPayload",
 			setup: func(payload *eth.ExecutionPayloadEnvelope) (*testutils.MockEngine, rollup.SuperAuthority, eth.L1BlockRef) {
 				sa := newMockSuperAuthority()
 				sa.shouldError = true
-				return &testutils.MockEngine{}, sa, eth.L1BlockRef{}
+				return nil, sa, eth.L1BlockRef{}
 			},
 			expectations: func(emitter *testutils.MockEmitter, engine *testutils.MockEngine, payload *eth.ExecutionPayloadEnvelope) {
-				// Despite error, expect NewPayload (graceful degradation)
-				engine.ExpectNewPayload(payload.ExecutionPayload, nil, &eth.PayloadStatusV1{Status: eth.ExecutionValid}, nil)
-				emitter.ExpectOnceType("PayloadSuccessEvent")
+				emitter.ExpectOnceType("EngineTemporaryErrorEvent")
 			},
 		},
 		{

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -69,11 +69,13 @@ func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 		st.data.UnsafeL2 = eth.L2BlockRef{}
 		st.data.SafeL2 = eth.L2BlockRef{}
 		st.data.LocalSafeL2 = eth.L2BlockRef{}
+		st.data.PendingSafeL2 = eth.L2BlockRef{}
 		st.data.CurrentL1 = eth.L1BlockRef{}
 	case engine.EngineResetConfirmedEvent:
 		st.data.UnsafeL2 = x.LocalUnsafe
 		st.data.CrossUnsafeL2 = x.CrossUnsafe
 		st.data.LocalSafeL2 = x.LocalSafe
+		st.data.PendingSafeL2 = x.LocalSafe
 		st.data.SafeL2 = x.CrossSafe
 		st.data.FinalizedL2 = x.Finalized
 	default: // other events do not affect the sync status

--- a/op-node/rollup/status/status_test.go
+++ b/op-node/rollup/status/status_test.go
@@ -77,3 +77,34 @@ func TestForkchoiceUpdateSeedsLocalSafeWithGenesisSafe(t *testing.T) {
 	require.Equal(t, genesis, status.LocalSafeL2)
 	require.Equal(t, genesis, status.FinalizedL2)
 }
+
+func TestResetEventClearsPendingSafe(t *testing.T) {
+	tracker := NewStatusTracker(testlog.Logger(t, log.LevelDebug), NoopMetrics{})
+	tracker.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
+		PendingSafe: eth.L2BlockRef{Number: 200},
+		Unsafe:      eth.L2BlockRef{Number: 300},
+	})
+
+	tracker.OnEvent(context.Background(), rollup.ResetEvent{})
+
+	require.Equal(t, eth.L2BlockRef{}, tracker.SyncStatus().PendingSafeL2)
+}
+
+func TestEngineResetConfirmedSetsPendingSafeToLocalSafe(t *testing.T) {
+	tracker := NewStatusTracker(testlog.Logger(t, log.LevelDebug), NoopMetrics{})
+	tracker.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
+		PendingSafe: eth.L2BlockRef{Number: 200},
+		Unsafe:      eth.L2BlockRef{Number: 300},
+	})
+	localSafe := eth.L2BlockRef{Number: 100}
+
+	tracker.OnEvent(context.Background(), engine.EngineResetConfirmedEvent{
+		LocalUnsafe: eth.L2BlockRef{Number: 300},
+		CrossUnsafe: eth.L2BlockRef{Number: 100},
+		LocalSafe:   localSafe,
+		CrossSafe:   localSafe,
+		Finalized:   eth.L2BlockRef{Number: 90},
+	})
+
+	require.Equal(t, localSafe, tracker.SyncStatus().PendingSafeL2)
+}

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -14,6 +14,7 @@ import (
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	rollupsync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
@@ -219,6 +220,12 @@ func NewChainContainer(
 ) (InteropChain, error) {
 	if metrics == nil {
 		metrics = resources.NewSupernodeMetrics()
+	}
+	if vncfg.Sync.SyncMode != rollupsync.ELSync {
+		log.Warn("overriding virtual node sync mode to execution-layer",
+			"configured", vncfg.Sync.SyncMode,
+			"reason", "consensus-layer cold starts can rebuild deep history against an independently synced execution engine")
+		vncfg.Sync.SyncMode = rollupsync.ELSync
 	}
 	c := &simpleChainContainer{
 		vncfg:              vncfg,

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -15,6 +15,7 @@ import (
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	rollupsync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -353,6 +354,16 @@ func TestChainContainer_Constructor(t *testing.T) {
 		require.Equal(t, log, impl.log)
 		require.NotNil(t, impl.stopped)
 		require.Equal(t, 1, cap(impl.stopped))
+	})
+
+	t.Run("forces execution layer sync", func(t *testing.T) {
+		cfg := createTestVNConfig()
+		cfg.Sync.SyncMode = rollupsync.CLSync
+
+		container := mustNewChainContainer(t, chainID, cfg, log, createTestCLIConfig(t.TempDir()), initOverload, nil, nil, nil, nil)
+		impl := container.(*simpleChainContainer)
+
+		require.Equal(t, rollupsync.ELSync, impl.vncfg.Sync.SyncMode)
 	})
 
 	t.Run("SafeDBPath uses subPath", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Clear reported pending-safe state when derivation resets.
- Seed reported pending-safe state from local-safe when engine reset completes.
- When a pending-safe parent is missing by hash, compare the canonical block at the same height and return a reset error on a definitive hash mismatch.
- Remove the earlier supernode VN restart workaround.

## Root cause

PendingSafeL2 is not persisted in SafeDB. It is runtime engine-controller state, while the sync-status tracker separately mirrors it for RPC consumers.

Two generic op-node behaviors combined during the reorg recovery:

1. Reset events did not clear or reseed StatusTracker.PendingSafeL2, so optimism_syncStatus could report an orphaned head after engine reset.
2. PreparePayloadAttributes classified a missing parent hash as temporary even when the EL had a different canonical block at the same number. Derivation retried instead of resetting.

The canonical by-number comparison makes the reset decision only when the EL proves the old hash is non-canonical. If that comparison cannot be completed, the existing temporary-error behavior remains.

## Non-goals

This does not repair supernode logsDB/accepted-state divergence, proxyd freshness or monotonicity policy, or Reth ExEx WAL consistency.

## Tests

- go test ./op-node/rollup/status ./op-node/rollup/derive -run 'TestResetEventClearsPendingSafe|TestEngineResetConfirmedSetsPendingSafeToLocalSafe|TestPreparePayloadAttributes/non-canonical' -count=1
- go test ./op-node/rollup/... -count=1
- go test ./op-node/... -count=1

All passed.
