### PR TITLE
contracts-bedrock: fix readMem/readMemUnchecked @return NatSpec

### DIFF
--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Memory.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Memory.sol
@@ -13,7 +13,7 @@ library MIPS64Memory {
     /// @param _memRoot The current memory root
     /// @param _addr The address to read from.
     /// @param _proofOffset The offset of the memory proof in calldata.
-    /// @return out_ The hashed MIPS state.
+    /// @return out_ The 64-bit word read from memory.
     function readMem(bytes32 _memRoot, uint64 _addr, uint256 _proofOffset) internal pure returns (uint64 out_) {
         bool valid;
         (out_, valid) = readMemUnchecked(_memRoot, _addr, _proofOffset);
@@ -26,8 +26,8 @@ library MIPS64Memory {
     /// @param _memRoot The current memory root
     /// @param _addr The address to read from.
     /// @param _proofOffset The offset of the memory proof in calldata.
-    /// @return out_ The hashed MIPS state.
-    ///         valid_ Whether the proof is valid.
+    /// @return out_ The 64-bit word read from memory.
+    /// @return valid_ Whether the proof is valid.
     function readMemUnchecked(
         bytes32 _memRoot,
         uint64 _addr,


### PR DESCRIPTION
Fixes #13436.

The `@return out_` NatSpec on `MIPS64Memory.readMem` and `readMemUnchecked` incorrectly read `The hashed MIPS state.` — a copy-paste from an unrelated function. Both functions are documented as `@notice Reads a 64-bit word from memory.` and return `uint64 out_` (the word read from memory), so the return description is corrected to `The 64-bit word read from memory.`

This is the Spearbit audit finding referenced in the issue. Documentation-only change; the `valid_` return line on `readMemUnchecked` is unchanged.
