### PR TITLE
op-service: preserve trusted RPC block hashes

### DIFF
--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -235,6 +235,26 @@ func (s *EthClient) headerCall(ctx context.Context, method string, id rpcBlockID
 	return header, nil
 }
 
+func (s *EthClient) infoCall(ctx context.Context, method string, id rpcBlockID) (eth.BlockInfo, error) {
+	var rpcHdr *RPCHeader
+	err := s.client.CallContext(ctx, &rpcHdr, method, id.Arg(), false) // headers are just blocks without txs
+	if err != nil {
+		return nil, eth.MaybeAsNotFoundErr(err)
+	}
+	if rpcHdr == nil {
+		return nil, ethereum.NotFound
+	}
+	header, err := rpcHdr.Header(s.trustRPC, s.mustBePostMerge)
+	if err != nil {
+		return nil, err
+	}
+	if err := id.CheckID(rpcHdr.BlockID()); err != nil {
+		return nil, fmt.Errorf("fetched block header does not match requested ID: %w", err)
+	}
+	s.headersCache.Add(rpcHdr.Hash, header)
+	return eth.HeaderBlockInfoTrusted(rpcHdr.Hash, header), nil
+}
+
 // blockCall fetches a header + transactions (eth_getBlockBy* with fullTx=true),
 // verifies the header and block-level data (txs root, withdrawals), caches
 // both, and returns them. Source of truth for both HeaderAndTxsBy* and
@@ -338,19 +358,11 @@ func (s *EthClient) InfoByHash(ctx context.Context, hash common.Hash) (eth.Block
 }
 
 func (s *EthClient) InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error) {
-	header, err := s.HeaderByNumber(ctx, number)
-	if err != nil {
-		return nil, err
-	}
-	return eth.HeaderBlockInfo(header), nil
+	return s.infoCall(ctx, "eth_getBlockByNumber", numberID(number))
 }
 
 func (s *EthClient) InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error) {
-	header, err := s.HeaderByLabel(ctx, label)
-	if err != nil {
-		return nil, err
-	}
-	return eth.HeaderBlockInfo(header), nil
+	return s.infoCall(ctx, "eth_getBlockByNumber", label)
 }
 
 func (s *EthClient) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -144,6 +144,25 @@ func TestEthClient_InfoByNumber(t *testing.T) {
 	m.Mock.AssertExpectations(t)
 }
 
+func TestEthClient_InfoByNumberTrustsRPCHash(t *testing.T) {
+	m := new(mockRPC)
+	_, rhdr := randHeader()
+	rhdr.Hash = common.HexToHash("0x1234")
+	n := rhdr.Number
+	ctx := context.Background()
+	m.On("CallContext", ctx, new(*RPCHeader),
+		"eth_getBlockByNumber", []any{n.String(), false}).Run(func(args mock.Arguments) {
+		*args[1].(**RPCHeader) = rhdr
+	}).Return([]error{nil})
+	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindStandard))
+	require.NoError(t, err)
+	info, err := s.InfoByNumber(ctx, uint64(n))
+	require.NoError(t, err)
+	require.Equal(t, rhdr.Hash, info.Hash())
+	require.NotEqual(t, rhdr.computeBlockHash(), info.Hash())
+	m.Mock.AssertExpectations(t)
+}
+
 func TestEthClient_WrongInfoByNumber(t *testing.T) {
 	m := new(mockRPC)
 	_, rhdr := randHeader()


### PR DESCRIPTION
## Summary
- Use the block hash returned by the trusted L1 RPC block-info response instead of recomputing a local header hash from response fields.
- Keep the change scoped to op-service L1 block info reads.
- Add regression coverage for preserving the RPC-provided block hash.

## Motivation
Some L1 RPC providers are the canonical trust boundary for block metadata returned to the client. Preserving the provider-returned hash avoids divergence caused by locally reconstructing the hash from a lossy or differently-shaped RPC response.

## Verification
```bash
GOTOOLCHAIN=local go test ./op-service/sources
```
