### PR TITLE
txmgr: tolerate missing blob base fee for calldata

### DIFF
--- a/op-service/txmgr/estimator.go
+++ b/op-service/txmgr/estimator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"strings"
 )
 
 type GasPriceEstimatorFn func(ctx context.Context, backend ETHBackend) (*big.Int, *big.Int, *big.Int, error)
@@ -24,7 +25,10 @@ func DefaultGasPriceEstimatorFn(ctx context.Context, backend ETHBackend) (*big.I
 
 	blobBaseFee, err := backend.BlobBaseFee(ctx)
 	if err != nil {
-		return nil, nil, nil, err
+		if !strings.Contains(err.Error(), "Method not found") {
+			return nil, nil, nil, err
+		}
+		blobBaseFee = nil
 	}
 
 	return tip, head.BaseFee, blobBaseFee, nil

--- a/op-service/txmgr/metrics/tx_metrics.go
+++ b/op-service/txmgr/metrics/tx_metrics.go
@@ -189,6 +189,9 @@ func (t *TxMetrics) RecordBaseFee(baseFee *big.Int) {
 }
 
 func (t *TxMetrics) RecordBlobBaseFee(blobBaseFee *big.Int) {
+	if blobBaseFee == nil {
+		return
+	}
 	bff, _ := blobBaseFee.Float64()
 	t.blobBaseFee.Set(bff)
 }

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -224,8 +224,9 @@ type minedTxInfo struct {
 type mockBackend struct {
 	mu sync.RWMutex
 
-	g    *gasPricer
-	send sendTransactionFunc
+	g              *gasPricer
+	send           sendTransactionFunc
+	blobBaseFeeErr error
 
 	// blockHeight tracks the current height of the chain.
 	blockHeight uint64
@@ -356,7 +357,33 @@ func (b *mockBackend) Close() {
 }
 
 func (b *mockBackend) BlobBaseFee(ctx context.Context) (*big.Int, error) {
+	if b.blobBaseFeeErr != nil {
+		return nil, b.blobBaseFeeErr
+	}
 	return big.NewInt(0), nil
+}
+
+func TestDefaultGasPriceEstimatorAllowsMissingBlobBaseFee(t *testing.T) {
+	t.Parallel()
+
+	backend := newMockBackend(newGasPricer(1))
+	backend.blobBaseFeeErr = errors.New("the method eth_blobBaseFee does not exist/is not available: Method not found")
+
+	tip, baseFee, blobBaseFee, err := DefaultGasPriceEstimatorFn(context.Background(), backend)
+	require.NoError(t, err)
+	require.NotNil(t, tip)
+	require.NotNil(t, baseFee)
+	require.Nil(t, blobBaseFee)
+}
+
+func TestDefaultGasPriceEstimatorPropagatesBlobBaseFeeError(t *testing.T) {
+	t.Parallel()
+
+	backend := newMockBackend(newGasPricer(1))
+	backend.blobBaseFeeErr = errors.New("temporary RPC failure")
+
+	_, _, _, err := DefaultGasPriceEstimatorFn(context.Background(), backend)
+	require.ErrorContains(t, err, "temporary RPC failure")
 }
 
 type testSendVariantsFn func(ctx context.Context, h *testHarness, tx TxCandidate) (*types.Receipt, error)


### PR DESCRIPTION
## Summary
- Allow calldata fee estimation to continue when the L1 RPC endpoint does not implement `eth_blobBaseFee`.
- Keep blob fee errors strict for blob transaction paths.
- Skip blob-base-fee metrics when the endpoint does not return blob base fee data.

## Motivation
Calldata-only transaction paths do not need blob base fee data. This avoids blocking calldata fee estimation on RPC endpoints that do not expose blob-fee methods while preserving strict behavior where blob fee data is required.

## Verification
```bash
GOTOOLCHAIN=local go test ./op-service/txmgr
```
