### PR TITLE
op-deployer: set legacy scalar for delayed Ecotone

### DIFF
--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -166,11 +166,19 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 		}
 	}
 
+	if cfg.GasPriceOracleScalar == 0 && !ecotoneActiveAtGenesis(cfg) {
+		cfg.GasPriceOracleScalar = uint64(standard.BasefeeScalar)
+	}
+
 	if err := cfg.Check(log.New(log.DiscardHandler())); err != nil {
 		return cfg, fmt.Errorf("combined deploy config failed validation: %w", err)
 	}
 
 	return cfg, nil
+}
+
+func ecotoneActiveAtGenesis(cfg genesis.DeployConfig) bool {
+	return cfg.L2GenesisEcotoneTimeOffset != nil && uint64(*cfg.L2GenesisEcotoneTimeOffset) == 0
 }
 
 func calculateBatchInboxAddr(chainID common.Hash) common.Address {

--- a/op-deployer/pkg/deployer/state/deploy_config_test.go
+++ b/op-deployer/pkg/deployer/state/deploy_config_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
@@ -61,4 +62,48 @@ func TestCombineDeployConfig(t *testing.T) {
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisJovianTimeOffset, hexutil.Uint64(5))
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisKarstTimeOffset, hexutil.Uint64(6))
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisInteropTimeOffset, hexutil.Uint64(7))
+}
+
+func TestCombineDeployConfigPreEcotoneScalar(t *testing.T) {
+	intent := Intent{
+		L1ChainID:          1,
+		L1ContractsLocator: artifacts.EmbeddedLocator,
+	}
+	chainState := ChainState{
+		ID: common.HexToHash("0x123"),
+	}
+	chainIntent := ChainIntent{
+		Eip1559Denominator:         1,
+		Eip1559Elasticity:          2,
+		GasLimit:                   standard.GasLimit,
+		BaseFeeVaultRecipient:      common.HexToAddress("0x123"),
+		L1FeeVaultRecipient:        common.HexToAddress("0x456"),
+		SequencerFeeVaultRecipient: common.HexToAddress("0x789"),
+		OperatorFeeVaultRecipient:  common.HexToAddress("0xabc"),
+		Roles: ChainRoles{
+			SystemConfigOwner: common.HexToAddress("0x123"),
+			L1ProxyAdminOwner: common.HexToAddress("0x456"),
+			L2ProxyAdminOwner: common.HexToAddress("0x789"),
+			UnsafeBlockSigner: common.HexToAddress("0xabc"),
+			Batcher:           common.HexToAddress("0xdef"),
+		},
+		DeployOverrides: map[string]any{
+			"l2GenesisEcotoneTimeOffset":  "0x93a80",
+			"l2GenesisFjordTimeOffset":    "0xa8c00",
+			"l2GenesisGraniteTimeOffset":  "0xbc4c0",
+			"l2GenesisHoloceneTimeOffset": "0xd0140",
+			"l2GenesisIsthmusTimeOffset":  "0xe3dc0",
+			"l2GenesisJovianTimeOffset":   "0xf7a40",
+			"l2GenesisKarstTimeOffset":    "0x10b6c0",
+			"l2GenesisInteropTimeOffset":  "0x11f340",
+		},
+	}
+	state := State{
+		SuperchainDeployment: &addresses.SuperchainContracts{},
+	}
+
+	out, err := CombineDeployConfig(&intent, &chainIntent, &state, &chainState)
+	require.NoError(t, err)
+	require.Equal(t, uint64(standard.BasefeeScalar), out.GasPriceOracleScalar)
+	require.Equal(t, common.BigToHash(new(big.Int).SetUint64(uint64(standard.BasefeeScalar))), common.Hash(out.FeeScalar()))
 }


### PR DESCRIPTION
## Summary
- Set the legacy GasPriceOracle scalar when op-deployer generates a delayed/pre-Ecotone chain config.
- Keep generated delayed-Ecotone configs compatible with Bedrock-era scalar encoding until Ecotone activates.
- Add deploy-config regression coverage for the delayed-Ecotone scalar path.

## Motivation
When Ecotone is scheduled in the future, generated genesis/system config values still need to be valid for pre-Ecotone execution. This avoids producing a config that can fail before the scheduled fork is active.

## Verification
```bash
GOTOOLCHAIN=local go test ./op-deployer/pkg/deployer/state
```
