### PR TITLE
op-deployer: harden live deployment RPC and gas handling

### DIFF
--- a/op-chain-ops/script/forking/rpc.go
+++ b/op-chain-ops/script/forking/rpc.go
@@ -21,6 +21,7 @@ type RPCClient interface {
 type RPCSource struct {
 	stateRoot common.Hash
 	blockHash common.Hash
+	blockRef  any
 
 	maxAttempts int
 	timeout     time.Duration
@@ -37,13 +38,16 @@ var _ ForkSource = (*RPCSource)(nil)
 
 func RPCSourceByNumber(urlOrAlias string, cl RPCClient, num uint64) (*RPCSource, error) {
 	src := newRPCSource(urlOrAlias, cl)
-	err := src.init(hexutil.Uint64(num))
+	blockRef := hexutil.Uint64(num)
+	err := src.init(blockRef)
+	src.blockRef = blockRef
 	return src, err
 }
 
 func RPCSourceByHash(urlOrAlias string, cl RPCClient, h common.Hash) (*RPCSource, error) {
 	src := newRPCSource(urlOrAlias, cl)
 	err := src.init(h)
+	src.blockRef = h
 	return src, err
 }
 
@@ -94,12 +98,19 @@ func (r *RPCSource) StateRoot() common.Hash {
 	return r.stateRoot
 }
 
+func (r *RPCSource) stateBlockRef() any {
+	if r.blockRef != nil {
+		return r.blockRef
+	}
+	return r.blockHash
+}
+
 func (r *RPCSource) Nonce(addr common.Address) (uint64, error) {
 	return retry.Do[uint64](r.ctx, r.maxAttempts, r.strategy, func() (uint64, error) {
 		ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 		defer cancel()
 		var result hexutil.Uint64
-		err := r.client.CallContext(ctx, &result, "eth_getTransactionCount", addr, r.blockHash)
+		err := r.client.CallContext(ctx, &result, "eth_getTransactionCount", addr, r.stateBlockRef())
 		return uint64(result), err
 	})
 }
@@ -109,7 +120,7 @@ func (r *RPCSource) Balance(addr common.Address) (*uint256.Int, error) {
 		ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 		defer cancel()
 		var result hexutil.U256
-		err := r.client.CallContext(ctx, &result, "eth_getBalance", addr, r.blockHash)
+		err := r.client.CallContext(ctx, &result, "eth_getBalance", addr, r.stateBlockRef())
 		return (*uint256.Int)(&result), err
 	})
 }
@@ -119,7 +130,7 @@ func (r *RPCSource) StorageAt(addr common.Address, key common.Hash) (common.Hash
 		ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 		defer cancel()
 		var result common.Hash
-		err := r.client.CallContext(ctx, &result, "eth_getStorageAt", addr, key, r.blockHash)
+		err := r.client.CallContext(ctx, &result, "eth_getStorageAt", addr, key, r.stateBlockRef())
 		return result, err
 	})
 }
@@ -129,7 +140,7 @@ func (r *RPCSource) Code(addr common.Address) ([]byte, error) {
 		ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 		defer cancel()
 		var result hexutil.Bytes
-		err := r.client.CallContext(ctx, &result, "eth_getCode", addr, r.blockHash)
+		err := r.client.CallContext(ctx, &result, "eth_getCode", addr, r.stateBlockRef())
 		return result, err
 	})
 }

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -341,6 +341,7 @@ func ApplyPipeline(
 			opts.Logger,
 			deployer,
 			bundle.L1,
+			script.WithNoMaxCodeSize(),
 			script.WithForkHook(func(cfg *script.ForkConfig) (forking.ForkSource, error) {
 				src, err := forking.RPCSourceByNumber(cfg.URLOrAlias, l1RPC, *cfg.BlockNumber)
 				if err != nil {

--- a/op-deployer/pkg/deployer/broadcaster/keyed.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed.go
@@ -23,8 +23,14 @@ import (
 )
 
 const (
-	GasPadFactor = 1.2
+	GasPadFactor           = 2.0
+	ProxyAdminCallGasFloor = 500_000
 )
+
+var proxyAdminGasFloorSelectors = map[[4]byte]struct{}{
+	{0x96, 0x23, 0x60, 0x9d}: {}, // upgradeAndCall(address payable,address,bytes)
+	{0xf2, 0xfd, 0xe3, 0x8b}: {}, // transferOwnership(address)
+}
 
 type KeyedBroadcaster struct {
 	lgr    log.Logger
@@ -248,8 +254,21 @@ func padGasLimit(data []byte, gasUsed uint64, creation bool, blockGasLimit uint6
 	}
 
 	limit := uint64(float64(gas) * GasPadFactor)
+	if !creation && needsProxyAdminGasFloor(data) && limit < ProxyAdminCallGasFloor {
+		limit = ProxyAdminCallGasFloor
+	}
 	if limit > blockGasLimit {
 		return blockGasLimit
 	}
 	return limit
+}
+
+func needsProxyAdminGasFloor(data []byte) bool {
+	if len(data) < 4 {
+		return false
+	}
+	var selector [4]byte
+	copy(selector[:], data[:4])
+	_, ok := proxyAdminGasFloorSelectors[selector]
+	return ok
 }

--- a/op-deployer/pkg/deployer/broadcaster/keyed_test.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed_test.go
@@ -1,0 +1,25 @@
+package broadcaster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPadGasLimitAppliesProxyAdminFloor(t *testing.T) {
+	data := []byte{0x96, 0x23, 0x60, 0x9d}
+
+	require.Equal(t, uint64(ProxyAdminCallGasFloor), padGasLimit(data, 1, false, 30_000_000))
+}
+
+func TestPadGasLimitClampsProxyAdminFloorToBlockLimit(t *testing.T) {
+	data := []byte{0xf2, 0xfd, 0xe3, 0x8b}
+
+	require.Equal(t, uint64(100_000), padGasLimit(data, 1, false, 100_000))
+}
+
+func TestPadGasLimitDoesNotApplyProxyAdminFloorToCreates(t *testing.T) {
+	data := []byte{0x96, 0x23, 0x60, 0x9d}
+
+	require.Less(t, padGasLimit(data, 1, true, 30_000_000), uint64(ProxyAdminCallGasFloor))
+}


### PR DESCRIPTION
## Summary
- Preserve the requested fork block reference for forked state reads.
- Allow the live fork script host to load unoptimized deployment artifacts consistently with genesis execution.
- Increase keyed broadcaster gas padding.
- Apply a ProxyAdmin call gas floor for `upgradeAndCall` and `transferOwnership` calls.
- Add broadcaster coverage for the gas padding behavior.

## Motivation
Live deployment transactions can fail when forked reads or simulated gas usage are too brittle for specific RPC/provider behavior. These changes make the live deployment path more tolerant while keeping the scope limited to fork reads, artifact loading, and deployment transaction gas handling.

## Verification
```bash
GOTOOLCHAIN=local go test ./op-chain-ops/script/forking ./op-deployer/pkg/deployer ./op-deployer/pkg/deployer/broadcaster
```
