### PR TITLE
contracts-bedrock: Skip shared-contract upgrades for non-owning chains post-interop-migration

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x2650f2af1df017387e1f1aa6273decc4c46dd4f3ac7f0910c6f0edc92aef4747"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x4eee827f6732de7777cc51830bc05d22b5970f8f98667158fb582aa8df9371db",
-    "sourceCodeHash": "0xe550799f715c5b019123cd0def8c62188512e2224455d01a828bd64af144d706"
+    "initCodeHash": "0x4f7744df5236711fd0a64aacb98e084ffe03daf66d3c3c3cf2b18aad26918994",
+    "sourceCodeHash": "0xc53a5a9388f49fcffb3d8dc963e985ab4a0457592c37c2c28093205d9932fefc"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -21,6 +21,7 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
@@ -158,9 +159,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 7.2.2
+    /// @custom:semver 7.2.3
     function version() public pure returns (string memory) {
-        return "7.2.2";
+        return "7.2.3";
     }
 
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -881,8 +882,12 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         // iterating over some sort of array because it's easier to implement and understand.
 
         // We upgrade/initialize the ETHLockbox if this is an initial deployment or if it's an
-        // upgrade and the ETH_LOCKBOX feature is enabled.
-        if (_isInitialDeployment || _cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
+        // upgrade and the ETH_LOCKBOX feature is enabled. Skip if this chain's ProxyAdmin does not
+        // administer it (shared across an interop set post-migration). Ref: #21731.
+        if (
+            (_isInitialDeployment || _cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX))
+                && (_isInitialDeployment || _isAdminOf(address(_cts.ethLockbox), _cts.proxyAdmin))
+        ) {
             IOptimismPortal[] memory portals = new IOptimismPortal[](1);
             portals[0] = _cts.optimismPortal;
             _upgrade(
@@ -928,70 +933,92 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             abi.encodeCall(IOptimismMintableERC20Factory.initialize, (address(_cts.l1StandardBridge)))
         );
 
+        // The DisputeGameFactory, DelayedWETH, and AnchorStateRegistry are shared across an interop
+        // set and administered by the first chain's ProxyAdmin, so a non-first chain's ProxyAdmin
+        // cannot upgrade them. Skip any shared proxy this chain's ProxyAdmin doesn't administer;
+        // they're upgraded once, during the first chain's upgrade() call. Ref: #21731.
+        bool ownsDisputeGameFactory =
+            _isInitialDeployment || _isAdminOf(address(_cts.disputeGameFactory), _cts.proxyAdmin);
+
         // Update the DisputeGameFactory.
-        _upgrade(
-            _cts.proxyAdmin,
-            address(_cts.disputeGameFactory),
-            impls.disputeGameFactoryImpl,
-            abi.encodeCall(IDisputeGameFactory.initialize, (address(this)))
-        );
-
-        // Update the DelayedWETH.
-        _upgrade(
-            _cts.proxyAdmin,
-            address(_cts.delayedWETH),
-            impls.delayedWETHImpl,
-            abi.encodeCall(IDelayedWETH.initialize, (_cts.systemConfig))
-        );
-
-        // Update the AnchorStateRegistry.
-        _upgrade(
-            _cts.proxyAdmin,
-            address(_cts.anchorStateRegistry),
-            impls.anchorStateRegistryImpl,
-            abi.encodeCall(
-                IAnchorStateRegistry.initialize,
-                (_cts.systemConfig, _cts.disputeGameFactory, _cfg.startingAnchorRoot, _cfg.startingRespectedGameType)
-            )
-        );
-
-        // Update the DisputeGame config and implementations.
-        // NOTE: We assert in _assertValidFullConfig that we have a configuration for all valid game
-        // types so we can be confident that we're setting/unsetting everything we care about.
-        for (uint256 i = 0; i < _cfg.disputeGameConfigs.length; i++) {
-            // Game implementation and arguments default to empty values. If the game is disabled,
-            // we'll use these empty values to unset the game in the factory.
-            IDisputeGame gameImpl = IDisputeGame(address(0));
-            bytes memory gameArgs = bytes("");
-
-            // If the game is enabled, grab the implementation and craft the game arguments.
-            if (_cfg.disputeGameConfigs[i].enabled) {
-                gameImpl = _getGameImpl(_cfg.disputeGameConfigs[i].gameType);
-                if (address(gameImpl) == address(0) || address(gameImpl).code.length == 0) {
-                    revert OPContractsManagerV2_ZeroGameImplementation(_cfg.disputeGameConfigs[i].gameType);
-                }
-                gameArgs = _makeGameArgs(
-                    _cfg.l2ChainId, _cts.anchorStateRegistry, _cts.delayedWETH, _cfg.disputeGameConfigs[i]
-                );
-            }
-
-            // Set the game implementation and arguments.
-            // NOTE: If the game is disabled, we'll set the implementation to address(0) and the
-            // arguments to bytes(""), disabling the game.
-            _cts.disputeGameFactory.setImplementation(_cfg.disputeGameConfigs[i].gameType, gameImpl, gameArgs);
-            _cts.disputeGameFactory.setInitBond(
-                _cfg.disputeGameConfigs[i].gameType, _cfg.disputeGameConfigs[i].initBond
+        if (ownsDisputeGameFactory) {
+            _upgrade(
+                _cts.proxyAdmin,
+                address(_cts.disputeGameFactory),
+                impls.disputeGameFactoryImpl,
+                abi.encodeCall(IDisputeGameFactory.initialize, (address(this)))
             );
         }
 
-        // SUPER_CANNON has been retired from OPCMv2's deploy/upgrade allow-list. Some chains may
-        // still have a non-zero gameImpls(SUPER_CANNON) registered from a prior OPCM. Clear it
-        // unconditionally so the post-upgrade state matches the StandardValidator's expectation
-        // (SCDG-SHAPE / SCDG-NOSHAPE both require gameImpls(SUPER_CANNON) == address(0)). On
-        // initial deployment the DisputeGameFactory was just initialized and the slot is already
-        // zero, so this is a no-op state-wise (only emits a redundant event).
-        _cts.disputeGameFactory.setImplementation(GameTypes.SUPER_CANNON, IDisputeGame(address(0)), hex"");
-        _cts.disputeGameFactory.setInitBond(GameTypes.SUPER_CANNON, 0);
+        // Update the DelayedWETH.
+        if (_isInitialDeployment || _isAdminOf(address(_cts.delayedWETH), _cts.proxyAdmin)) {
+            _upgrade(
+                _cts.proxyAdmin,
+                address(_cts.delayedWETH),
+                impls.delayedWETHImpl,
+                abi.encodeCall(IDelayedWETH.initialize, (_cts.systemConfig))
+            );
+        }
+
+        // Update the AnchorStateRegistry.
+        if (_isInitialDeployment || _isAdminOf(address(_cts.anchorStateRegistry), _cts.proxyAdmin)) {
+            _upgrade(
+                _cts.proxyAdmin,
+                address(_cts.anchorStateRegistry),
+                impls.anchorStateRegistryImpl,
+                abi.encodeCall(
+                    IAnchorStateRegistry.initialize,
+                    (
+                        _cts.systemConfig,
+                        _cts.disputeGameFactory,
+                        _cfg.startingAnchorRoot,
+                        _cfg.startingRespectedGameType
+                    )
+                )
+            );
+        }
+
+        // Update the DisputeGame config and implementations. These mutate the shared
+        // DisputeGameFactory, so they only run when this chain's ProxyAdmin administers it. Ref: #21731.
+        // NOTE: We assert in _assertValidFullConfig that we have a configuration for all valid game
+        // types so we can be confident that we're setting/unsetting everything we care about.
+        if (ownsDisputeGameFactory) {
+            for (uint256 i = 0; i < _cfg.disputeGameConfigs.length; i++) {
+                // Game implementation and arguments default to empty values. If the game is
+                // disabled, we'll use these empty values to unset the game in the factory.
+                IDisputeGame gameImpl = IDisputeGame(address(0));
+                bytes memory gameArgs = bytes("");
+
+                // If the game is enabled, grab the implementation and craft the game arguments.
+                if (_cfg.disputeGameConfigs[i].enabled) {
+                    gameImpl = _getGameImpl(_cfg.disputeGameConfigs[i].gameType);
+                    if (address(gameImpl) == address(0) || address(gameImpl).code.length == 0) {
+                        revert OPContractsManagerV2_ZeroGameImplementation(_cfg.disputeGameConfigs[i].gameType);
+                    }
+                    gameArgs = _makeGameArgs(
+                        _cfg.l2ChainId, _cts.anchorStateRegistry, _cts.delayedWETH, _cfg.disputeGameConfigs[i]
+                    );
+                }
+
+                // Set the game implementation and arguments.
+                // NOTE: If the game is disabled, we'll set the implementation to address(0) and the
+                // arguments to bytes(""), disabling the game.
+                _cts.disputeGameFactory.setImplementation(_cfg.disputeGameConfigs[i].gameType, gameImpl, gameArgs);
+                _cts.disputeGameFactory.setInitBond(
+                    _cfg.disputeGameConfigs[i].gameType, _cfg.disputeGameConfigs[i].initBond
+                );
+            }
+
+            // SUPER_CANNON has been retired from OPCMv2's deploy/upgrade allow-list. Some chains
+            // may still have a non-zero gameImpls(SUPER_CANNON) registered from a prior OPCM.
+            // Clear it unconditionally so the post-upgrade state matches the StandardValidator's
+            // expectation (SCDG-SHAPE / SCDG-NOSHAPE both require gameImpls(SUPER_CANNON) ==
+            // address(0)). On initial deployment the DisputeGameFactory was just initialized and
+            // the slot is already zero, so this is a no-op state-wise (only emits a redundant
+            // event).
+            _cts.disputeGameFactory.setImplementation(GameTypes.SUPER_CANNON, IDisputeGame(address(0)), hex"");
+            _cts.disputeGameFactory.setInitBond(GameTypes.SUPER_CANNON, 0);
+        }
 
         // If the custom gas token feature was requested, enable it in the SystemConfig.
         // If the cgt is enabled, we skip this step.
@@ -1023,6 +1050,16 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Return contracts as the execution output.
         return _cts;
+    }
+
+    /// @notice Returns whether _proxyAdmin administers _target, read from the proxy's self-reported
+    ///         ProxyAdmin (ProxyAdminOwnedBase). Only valid once the proxy has an implementation
+    ///         set (not during initial deployment). Ref: #21731.
+    /// @param _target The proxy to inspect.
+    /// @param _proxyAdmin The ProxyAdmin to compare against.
+    /// @return True if _proxyAdmin administers _target.
+    function _isAdminOf(address _target, IProxyAdmin _proxyAdmin) internal view returns (bool) {
+        return address(IProxyAdminOwnedBase(_target).proxyAdmin()) == address(_proxyAdmin);
     }
 
     /// @notice Helper for making the SystemConfig initializer arguments. This is the only

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -3214,6 +3214,144 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         // Execute the migration, expect revert.
         _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InteropNotEnabled.selector);
     }
+
+    /// @notice Builds a post-interop-migration upgrade input for a member chain. After migration
+    ///         the respected game type is SUPER_PERMISSIONED, so we enable that game type and
+    ///         disable the rest.
+    /// @param _systemConfig The member chain's SystemConfig.
+    /// @return input_ The upgrade input.
+    function _postMigrationUpgradeInput(ISystemConfig _systemConfig)
+        internal
+        returns (IOPContractsManagerV2.UpgradeInput memory input_)
+    {
+        address proposer = makeAddr("superProposer");
+        IOPContractsManagerUtils.DisputeGameConfig[] memory dgConfigs =
+            new IOPContractsManagerUtils.DisputeGameConfig[](6);
+        dgConfigs[0] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.CANNON,
+            gameArgs: bytes("")
+        });
+        dgConfigs[1] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.PERMISSIONED_CANNON,
+            gameArgs: bytes("")
+        });
+        dgConfigs[2] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.CANNON_KONA,
+            gameArgs: bytes("")
+        });
+        dgConfigs[3] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: true,
+            initBond: 0,
+            gameType: GameTypes.SUPER_PERMISSIONED,
+            gameArgs: abi.encode(IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: proposer }))
+        });
+        dgConfigs[4] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.SUPER_CANNON_KONA,
+            gameArgs: bytes("")
+        });
+        dgConfigs[5] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.ZK_DISPUTE_GAME,
+            gameArgs: abi.encode(
+                IOPContractsManagerUtils.ZKDisputeGameConfig({
+                    absolutePrestate: Claim.wrap(bytes32(0)),
+                    verifier: IZKVerifier(address(0)),
+                    maxChallengeDuration: Duration.wrap(0),
+                    maxProveDuration: Duration.wrap(0),
+                    challengerBond: 0
+                })
+            )
+        });
+
+        IOPContractsManagerUtils.ExtraInstruction[] memory extra = new IOPContractsManagerUtils.ExtraInstruction[](1);
+        extra[0] =
+            IOPContractsManagerUtils.ExtraInstruction({ key: "PermittedProxyDeployment", data: bytes("DelayedWETH") });
+
+        input_.systemConfig = _systemConfig;
+        input_.disputeGameConfigs = dgConfigs;
+        input_.extraInstructions = extra;
+    }
+
+    /// @notice Regression test for ethereum-optimism/optimism#21731. After an interop migration the
+    ///         shared contracts (ETHLockbox, DisputeGameFactory, DelayedWETH, AnchorStateRegistry)
+    ///         are administered by the first chain's ProxyAdmin. upgrade() must succeed for every
+    ///         member chain — including non-first chains — by skipping the shared contracts it does
+    ///         not administer, while the shared contracts are upgraded exactly once via the first
+    ///         chain's call.
+    function test_upgrade_afterMigrationNonFirstChain_succeeds() public {
+        _enableEthLockboxes();
+        _doMigration(_getDefaultMigrateInput());
+
+        // Resolve the shared infra established by the migration.
+        IOptimismPortal2 portal1 = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
+        IAnchorStateRegistry sharedAsr = portal1.anchorStateRegistry();
+        IDisputeGameFactory sharedDgf = sharedAsr.disputeGameFactory();
+        IETHLockbox sharedLockbox = portal1.ethLockbox();
+        address sharedDelayedWeth = chainContracts1.systemConfig.delayedWETH();
+
+        // The shared contracts are administered by chain 1's ProxyAdmin, not chain 2's. This is
+        // exactly the condition that made upgrade() revert for chain 2 before the fix.
+        assertEq(
+            EIP1967Helper.getAdmin(address(sharedDgf)),
+            address(chainContracts1.proxyAdmin),
+            "shared DGF not admined by chain 1 ProxyAdmin"
+        );
+        assertTrue(
+            address(chainContracts1.proxyAdmin) != address(chainContracts2.proxyAdmin),
+            "chains unexpectedly share a ProxyAdmin"
+        );
+
+        IOPContractsManagerContainer.Implementations memory impls = opcmV2.implementations();
+        address pao = chainContracts1.proxyAdmin.owner();
+
+        // Upgrade the first chain, which owns (administers) the shared contracts.
+        prankDelegateCall(pao);
+        (bool ok1,) = address(opcmV2).delegatecall(
+            abi.encodeCall(IOPContractsManagerV2.upgrade, (_postMigrationUpgradeInput(chainContracts1.systemConfig)))
+        );
+        assertTrue(ok1, "first chain upgrade failed");
+
+        // The shared contracts were upgraded to the target implementations during that call.
+        assertEq(EIP1967Helper.getImplementation(address(sharedDgf)), impls.disputeGameFactoryImpl, "DGF impl");
+        assertEq(EIP1967Helper.getImplementation(address(sharedAsr)), impls.anchorStateRegistryImpl, "ASR impl");
+        assertEq(EIP1967Helper.getImplementation(address(sharedLockbox)), impls.ethLockboxImpl, "lockbox impl");
+        assertEq(EIP1967Helper.getImplementation(sharedDelayedWeth), impls.delayedWETHImpl, "delayedWETH impl");
+
+        // Upgrade the non-first chain. Before the fix this reverted because chain 2's ProxyAdmin
+        // does not administer the shared proxies. It must now succeed by skipping them.
+        prankDelegateCall(pao);
+        (bool ok2,) = address(opcmV2).delegatecall(
+            abi.encodeCall(IOPContractsManagerV2.upgrade, (_postMigrationUpgradeInput(chainContracts2.systemConfig)))
+        );
+        assertTrue(ok2, "non-first chain upgrade failed");
+
+        // The non-first chain's own per-chain contracts were upgraded...
+        assertEq(
+            EIP1967Helper.getImplementation(address(chainContracts2.systemConfig)),
+            impls.systemConfigImpl,
+            "chain 2 SystemConfig impl"
+        );
+        assertEq(
+            EIP1967Helper.getImplementation(chainContracts2.systemConfig.optimismPortal()),
+            impls.optimismPortalImpl,
+            "chain 2 OptimismPortal impl"
+        );
+
+        // ...while the shared contracts were left untouched by chain 2's call (still at target).
+        assertEq(EIP1967Helper.getImplementation(address(sharedDgf)), impls.disputeGameFactoryImpl, "DGF impl changed");
+        assertEq(EIP1967Helper.getImplementation(address(sharedAsr)), impls.anchorStateRegistryImpl, "ASR impl changed");
+        assertEq(EIP1967Helper.getImplementation(address(sharedLockbox)), impls.ethLockboxImpl, "lockbox impl changed");
+        assertEq(EIP1967Helper.getImplementation(sharedDelayedWeth), impls.delayedWETHImpl, "delayedWETH impl changed");
+    }
 }
 
 /// @title OPContractsManagerV2_FeatBatchUpgrade_Test


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#21731. After an interop migration, `OPContractsManagerV2.upgrade()` could only upgrade the first chain in an interop set — every other member chain reverted.

The shared contracts (ETHLockbox, DisputeGameFactory, DelayedWETH, AnchorStateRegistry) are administered by a single ProxyAdmin — the one belonging to the first chain in the set — while each member chain keeps its own distinct ProxyAdmin. `_apply` routed every proxy upgrade through the calling chain's ProxyAdmin, so `ProxyAdmin.upgrade` reverted on the EIP-1967 admin check for any chain that didn't own the shared proxies.

## Approach: skip on ProxyAdmin mismatch

Each shared-contract upgrade — and the DisputeGameFactory config mutations (`setImplementation`/`setInitBond`, including the SUPER_CANNON clear) — is now gated on the target self-reporting the calling chain's ProxyAdmin as its admin, via the `proxyAdmin()` getter every target inherits from `ProxyAdminOwnedBase` (a plain self-read). Per-chain contracts always match and always upgrade; shared contracts match only for the first chain, so they are upgraded exactly **once**, during the first chain's `upgrade()` call. Non-owning chains simply skip them (no version-equality guard).

Initial deployments short-circuit the check, since a freshly-deployed proxy has no implementation to self-report its admin yet and is always administered by this ProxyAdmin.

### Tradeoff

Because shared contracts are upgraded only during the first chain's call, an interop **set should be upgraded together** (all member chains, first chain included) for cross-chain version consistency. This function does not enforce set-wide consistency; that is a property of upgrading the whole set together.

## Testing

- New regression test `test_upgrade_afterMigrationNonFirstChain_succeeds` migrates the 2-chain interop fixture, then runs `upgrade()` for both member chains (including the non-first chain) and asserts neither reverts, that the shared DGF/ASR/ETHLockbox/DelayedWETH end at the target implementations, and that the non-first chain's own per-chain contracts upgrade while the shared contracts are left untouched. On `develop` this reverts for chain 2.
- `OPContractsManagerV2.t.sol` (default + `DEV_FEATURE__OPTIMISM_PORTAL_INTEROP`), `OPContractsManagerUtils.t.sol`, and `OPContractsManagerStandardValidator.t.sol` all pass.
- Snapshots + semver-lock regenerated; OPCM `@custom:semver` bumped 7.2.2 → 7.2.3.

Ref: ethereum-optimism/optimism#21731