### PR TITLE
contracts-bedrock: Resolve each proxy's own ProxyAdmin during upgrade

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
@@ -7,6 +7,7 @@ import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IZKVerifier } from "interfaces/dispute/zk/IZKVerifier.sol";
 import { Claim, Duration, GameType } from "src/dispute/lib/Types.sol";
 
@@ -163,6 +164,8 @@ interface IOPContractsManagerUtils {
         external
         view
         returns (bytes memory);
+
+    function systemConfigFor(ISystemConfig _default, address _target) external view returns (ISystemConfig);
 
     function __constructor__(IOPContractsManagerContainer _contractsContainer) external;
 }

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x2650f2af1df017387e1f1aa6273decc4c46dd4f3ac7f0910c6f0edc92aef4747"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x040a04fdf1e241db9e6e7494563ed00a20772f584547095dd2618ff6d70b300b",
-    "sourceCodeHash": "0xc27676825b0f0bf06cba627715b4a2679ff661196e1a59e91581258e7a350a58"
+    "initCodeHash": "0x103326138105481c4c6a9788d9094d4433a3785cdcedfc3db3992b3867dcd8bc",
+    "sourceCodeHash": "0xa161ec6c2e739fc834b66d57d2b0871cda3b843ec090abcd400cd7873fd67818"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x2650f2af1df017387e1f1aa6273decc4c46dd4f3ac7f0910c6f0edc92aef4747"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x0a6a9baa9913e6feb0c0d1606f037c22205cbe83e709de3c9ca0ba03a0301037",
-    "sourceCodeHash": "0xf37254fcca4a499b6487c6fc5fba880ef2dbd785cea505321deee5fcb28c4d06"
+    "initCodeHash": "0x040a04fdf1e241db9e6e7494563ed00a20772f584547095dd2618ff6d70b300b",
+    "sourceCodeHash": "0xc27676825b0f0bf06cba627715b4a2679ff661196e1a59e91581258e7a350a58"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -19,6 +19,8 @@ import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
 /// @title OPContractsManagerUtils
 /// @notice OPContractsManagerUtils is a contract that provides utility functions for the OPContractsManager.
@@ -394,6 +396,26 @@ contract OPContractsManagerUtils {
             return address(admin_) == address(0) ? _defaultAdmin : admin_;
         } catch {
             return _defaultAdmin;
+        }
+    }
+
+    /// @notice Resolves the SystemConfig a proxy is already bound to, so an upgrade driven by one
+    ///         member of an interop set does not re-point the shared contracts (ETHLockbox,
+    ///         AnchorStateRegistry, DelayedWETH) at the caller's SystemConfig. migrate() binds those
+    ///         to the first member chain's SystemConfig. Per-chain contracts report the caller's own
+    ///         SystemConfig, so behavior is unchanged for them. Falls back to _default for a
+    ///         freshly-deployed proxy that can't report one yet. Ref: #21731.
+    /// @dev The contracts exposing systemConfig() share no common base interface; IETHLockbox is
+    ///      only the source of the (identical) selector.
+    /// @param _default Fallback SystemConfig for not-yet-initialized proxies.
+    /// @param _target The proxy whose bound SystemConfig should be resolved.
+    /// @return The bound SystemConfig.
+    function systemConfigFor(ISystemConfig _default, address _target) external view returns (ISystemConfig) {
+        // eip150-safe
+        try IETHLockbox(_target).systemConfig() returns (ISystemConfig systemConfig_) {
+            return address(systemConfig_) == address(0) ? _default : systemConfig_;
+        } catch {
+            return _default;
         }
     }
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -18,6 +18,7 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
 
 /// @title OPContractsManagerUtils
 /// @notice OPContractsManagerUtils is a contract that provides utility functions for the OPContractsManager.
@@ -298,7 +299,7 @@ contract OPContractsManagerUtils {
     }
 
     /// @notice Upgrades a contract by resetting the initialized slot and calling the initializer.
-    /// @param _proxyAdmin The proxy admin of the contract.
+    /// @param _proxyAdmin Fallback ProxyAdmin, used when the target can't report its own.
     /// @param _target The target of the contract.
     /// @param _implementation The implementation of the contract.
     /// @param _data The data to call the initializer with.
@@ -314,6 +315,13 @@ contract OPContractsManagerUtils {
     )
         external
     {
+        // Route the upgrade through the ProxyAdmin that actually administers the target rather
+        // than assuming the caller's. After an interop migration a chain set shares an ETHLockbox,
+        // DisputeGameFactory, AnchorStateRegistry and DelayedWETH that are all administered by the
+        // first chain's ProxyAdmin, so an upgrade driven by any other member would otherwise
+        // revert on the shared contracts' proxy admin-slot check. Ref: #21731.
+        _proxyAdmin = _adminFor(_proxyAdmin, _target);
+
         // Check to make sure that we're not downgrading. Downgrades aren't inherently dangerous
         // but we also don't test for them so we don't really know if a specific downgrade will be
         // dangerous or not. It's easier to just revert instead.
@@ -371,6 +379,22 @@ contract OPContractsManagerUtils {
         // No v5 state was written, so restore the real implementation. A plain upgrade (not
         // upgradeAndCall) leaves the initializer state from above intact and does not re-run it.
         _proxyAdmin.upgrade(payable(_target), _implementation);
+    }
+
+    /// @notice Resolves the ProxyAdmin that administers a proxy from its self-reported admin
+    ///         (ProxyAdminOwnedBase), so upgrades route correctly when a chain set spans distinct
+    ///         ProxyAdmins. Falls back to _defaultAdmin for a freshly-deployed proxy that can't
+    ///         report one yet, which is always administered by the ProxyAdmin that deployed it.
+    /// @param _defaultAdmin Fallback ProxyAdmin for not-yet-initialized proxies.
+    /// @param _target The proxy whose administering ProxyAdmin should be resolved.
+    /// @return The administering ProxyAdmin.
+    function _adminFor(IProxyAdmin _defaultAdmin, address _target) internal view returns (IProxyAdmin) {
+        // eip150-safe
+        try IProxyAdminOwnedBase(_target).proxyAdmin() returns (IProxyAdmin admin_) {
+            return address(admin_) == address(0) ? _defaultAdmin : admin_;
+        } catch {
+            return _defaultAdmin;
+        }
     }
 
     /// @notice Returns the implementations for the contracts.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
@@ -10,6 +10,7 @@ import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 
 /// @title OPContractsManagerUtilsCaller
 /// @notice OPContractsManagerUtilsCaller is an abstract contract that exists to hide all of the
@@ -186,6 +187,17 @@ abstract contract OPContractsManagerUtilsCaller {
             abi.encodeCall(
                 IOPContractsManagerUtils.upgrade, (_proxyAdmin, _target, _implementation, _data, _slot, _offset)
             )
+        );
+    }
+
+    /// @notice Resolves the SystemConfig a target proxy is already bound to, falling back to
+    ///         _default when it can't report one. See OPContractsManagerUtils.systemConfigFor.
+    /// @param _default Fallback SystemConfig for not-yet-initialized proxies.
+    /// @param _target The proxy whose bound SystemConfig should be resolved.
+    /// @return The bound SystemConfig.
+    function _systemConfigFor(ISystemConfig _default, address _target) internal view returns (ISystemConfig) {
+        return abi.decode(
+            _staticcall(abi.encodeCall(IOPContractsManagerUtils.systemConfigFor, (_default, _target))), (ISystemConfig)
         );
     }
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -1030,25 +1030,6 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         return _cts;
     }
 
-    /// @notice Resolves the SystemConfig that a proxy is already bound to, so an upgrade driven by
-    ///         one member of an interop set does not re-point the shared contracts (ETHLockbox,
-    ///         AnchorStateRegistry, DelayedWETH) at the caller's SystemConfig. migrate() binds
-    ///         those to the first member chain's SystemConfig. Per-chain contracts report the
-    ///         caller's own SystemConfig, so behavior is unchanged for them. Falls back to
-    ///         _default for a freshly-deployed proxy that can't report one yet. Ref: #21731.
-    /// @dev The contracts exposing systemConfig() share no common base interface, so the target is
-    ///      called low-level; IETHLockbox is only the source of the (identical) selector.
-    /// @param _default Fallback SystemConfig for not-yet-initialized proxies.
-    /// @param _target The proxy whose bound SystemConfig should be resolved.
-    /// @return The bound SystemConfig.
-    function _systemConfigFor(ISystemConfig _default, address _target) internal view returns (ISystemConfig) {
-        // eip150-safe
-        (bool success, bytes memory data) = _target.staticcall(abi.encodeCall(IETHLockbox.systemConfig, ()));
-        if (!success || data.length != 32) return _default;
-        ISystemConfig systemConfig = abi.decode(data, (ISystemConfig));
-        return address(systemConfig) == address(0) ? _default : systemConfig;
-    }
-
     /// @notice Helper for making the SystemConfig initializer arguments. This is the only
     ///         initializer that needs a helper function because we get stack-too-deep.
     /// @param _cfg The full config.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -21,6 +21,7 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
@@ -854,11 +855,17 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             revert OPContractsManagerV2_InvalidUpgradeSequence(_cts.systemConfig.lastUsedOPCMVersion(), _version());
         }
 
+        // Each proxy is upgraded through the ProxyAdmin that actually administers it (resolved
+        // per-target via _adminFor), since post-interop-migration the shared contracts are
+        // administered by the first chain's ProxyAdmin, not the caller's. Ref: #21731.
         // Update the SystemConfig.
         // SystemConfig initializer is the only one large enough to require a separate function to
         // avoid stack-too-deep errors.
         _upgrade(
-            _cts.proxyAdmin, address(_cts.systemConfig), impls.systemConfigImpl, _makeSystemConfigInitArgs(_cfg, _cts)
+            _adminFor(_cts.proxyAdmin, _cts.systemConfig),
+            address(_cts.systemConfig),
+            impls.systemConfigImpl,
+            _makeSystemConfigInitArgs(_cfg, _cts)
         );
 
         // Update the OptimismPortal. If a chain already uses ETHLockbox, preserve that lockbox
@@ -869,7 +876,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         }
         IETHLockbox portalLockbox = isEthLockboxEnabled ? _cts.ethLockbox : IETHLockbox(address(0));
         _upgrade(
-            _cts.proxyAdmin,
+            _adminFor(_cts.proxyAdmin, _cts.optimismPortal),
             address(_cts.optimismPortal),
             impls.optimismPortalImpl,
             abi.encodeCall(IOptimismPortal.initialize, (_cts.systemConfig, _cts.anchorStateRegistry, portalLockbox))
@@ -884,7 +891,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             IOptimismPortal[] memory portals = new IOptimismPortal[](1);
             portals[0] = _cts.optimismPortal;
             _upgrade(
-                _cts.proxyAdmin,
+                _adminFor(_cts.proxyAdmin, _cts.ethLockbox),
                 address(_cts.ethLockbox),
                 impls.ethLockboxImpl,
                 abi.encodeCall(IETHLockbox.initialize, (_cts.systemConfig, portals))
@@ -894,7 +901,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         // Update the L1CrossDomainMessenger.
         // NOTE: L1CrossDomainMessenger initializer is at slot 0, offset 20.
         _upgrade(
-            _cts.proxyAdmin,
+            _adminFor(_cts.proxyAdmin, _cts.l1CrossDomainMessenger),
             address(_cts.l1CrossDomainMessenger),
             impls.l1CrossDomainMessengerImpl,
             abi.encodeCall(IL1CrossDomainMessenger.initialize, (_cts.systemConfig, _cts.optimismPortal)),
@@ -904,7 +911,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the L1StandardBridge.
         _upgrade(
-            _cts.proxyAdmin,
+            _adminFor(_cts.proxyAdmin, _cts.l1StandardBridge),
             address(_cts.l1StandardBridge),
             impls.l1StandardBridgeImpl,
             abi.encodeCall(IL1StandardBridge.initialize, (_cts.l1CrossDomainMessenger, _cts.systemConfig))
@@ -912,7 +919,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the L1ERC721Bridge.
         _upgrade(
-            _cts.proxyAdmin,
+            _adminFor(_cts.proxyAdmin, _cts.l1ERC721Bridge),
             address(_cts.l1ERC721Bridge),
             impls.l1ERC721BridgeImpl,
             abi.encodeCall(IL1ERC721Bridge.initialize, (_cts.l1CrossDomainMessenger, _cts.systemConfig))
@@ -920,7 +927,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the OptimismMintableERC20Factory.
         _upgrade(
-            _cts.proxyAdmin,
+            _adminFor(_cts.proxyAdmin, _cts.optimismMintableERC20Factory),
             address(_cts.optimismMintableERC20Factory),
             impls.optimismMintableERC20FactoryImpl,
             abi.encodeCall(IOptimismMintableERC20Factory.initialize, (address(_cts.l1StandardBridge)))
@@ -928,7 +935,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the DisputeGameFactory.
         _upgrade(
-            _cts.proxyAdmin,
+            _adminFor(_cts.proxyAdmin, _cts.disputeGameFactory),
             address(_cts.disputeGameFactory),
             impls.disputeGameFactoryImpl,
             abi.encodeCall(IDisputeGameFactory.initialize, (address(this)))
@@ -936,7 +943,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the DelayedWETH.
         _upgrade(
-            _cts.proxyAdmin,
+            _adminFor(_cts.proxyAdmin, _cts.delayedWETH),
             address(_cts.delayedWETH),
             impls.delayedWETHImpl,
             abi.encodeCall(IDelayedWETH.initialize, (_cts.systemConfig))
@@ -944,7 +951,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the AnchorStateRegistry.
         _upgrade(
-            _cts.proxyAdmin,
+            _adminFor(_cts.proxyAdmin, _cts.anchorStateRegistry),
             address(_cts.anchorStateRegistry),
             impls.anchorStateRegistryImpl,
             abi.encodeCall(
@@ -1021,6 +1028,22 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Return contracts as the execution output.
         return _cts;
+    }
+
+    /// @notice Resolves the ProxyAdmin that administers a proxy from its self-reported admin
+    ///         (ProxyAdminOwnedBase), so upgrades route correctly when a set spans distinct
+    ///         ProxyAdmins (post-interop-migration). Falls back to _defaultAdmin for a
+    ///         freshly-deployed proxy that can't yet report one. Ref: #21731.
+    /// @param _defaultAdmin Fallback ProxyAdmin for not-yet-initialized proxies.
+    /// @param _target The proxy whose administering ProxyAdmin should be resolved.
+    /// @return The administering ProxyAdmin.
+    function _adminFor(IProxyAdmin _defaultAdmin, IProxyAdminOwnedBase _target) internal view returns (IProxyAdmin) {
+        // eip150-safe
+        try _target.proxyAdmin() returns (IProxyAdmin admin_) {
+            return address(admin_) == address(0) ? _defaultAdmin : admin_;
+        } catch {
+            return _defaultAdmin;
+        }
     }
 
     /// @notice Helper for making the SystemConfig initializer arguments. This is the only

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -21,7 +21,6 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
@@ -159,9 +158,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 7.2.3
+    /// @custom:semver 7.2.4
     function version() public pure returns (string memory) {
-        return "7.2.3";
+        return "7.2.4";
     }
 
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -855,17 +854,11 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             revert OPContractsManagerV2_InvalidUpgradeSequence(_cts.systemConfig.lastUsedOPCMVersion(), _version());
         }
 
-        // Each proxy is upgraded through the ProxyAdmin that actually administers it (resolved
-        // per-target via _adminFor), since post-interop-migration the shared contracts are
-        // administered by the first chain's ProxyAdmin, not the caller's. Ref: #21731.
         // Update the SystemConfig.
         // SystemConfig initializer is the only one large enough to require a separate function to
         // avoid stack-too-deep errors.
         _upgrade(
-            _adminFor(_cts.proxyAdmin, _cts.systemConfig),
-            address(_cts.systemConfig),
-            impls.systemConfigImpl,
-            _makeSystemConfigInitArgs(_cfg, _cts)
+            _cts.proxyAdmin, address(_cts.systemConfig), impls.systemConfigImpl, _makeSystemConfigInitArgs(_cfg, _cts)
         );
 
         // Update the OptimismPortal. If a chain already uses ETHLockbox, preserve that lockbox
@@ -876,7 +869,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         }
         IETHLockbox portalLockbox = isEthLockboxEnabled ? _cts.ethLockbox : IETHLockbox(address(0));
         _upgrade(
-            _adminFor(_cts.proxyAdmin, _cts.optimismPortal),
+            _cts.proxyAdmin,
             address(_cts.optimismPortal),
             impls.optimismPortalImpl,
             abi.encodeCall(IOptimismPortal.initialize, (_cts.systemConfig, _cts.anchorStateRegistry, portalLockbox))
@@ -891,17 +884,19 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             IOptimismPortal[] memory portals = new IOptimismPortal[](1);
             portals[0] = _cts.optimismPortal;
             _upgrade(
-                _adminFor(_cts.proxyAdmin, _cts.ethLockbox),
+                _cts.proxyAdmin,
                 address(_cts.ethLockbox),
                 impls.ethLockboxImpl,
-                abi.encodeCall(IETHLockbox.initialize, (_cts.systemConfig, portals))
+                abi.encodeCall(
+                    IETHLockbox.initialize, (_systemConfigFor(_cts.systemConfig, address(_cts.ethLockbox)), portals)
+                )
             );
         }
 
         // Update the L1CrossDomainMessenger.
         // NOTE: L1CrossDomainMessenger initializer is at slot 0, offset 20.
         _upgrade(
-            _adminFor(_cts.proxyAdmin, _cts.l1CrossDomainMessenger),
+            _cts.proxyAdmin,
             address(_cts.l1CrossDomainMessenger),
             impls.l1CrossDomainMessengerImpl,
             abi.encodeCall(IL1CrossDomainMessenger.initialize, (_cts.systemConfig, _cts.optimismPortal)),
@@ -911,7 +906,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the L1StandardBridge.
         _upgrade(
-            _adminFor(_cts.proxyAdmin, _cts.l1StandardBridge),
+            _cts.proxyAdmin,
             address(_cts.l1StandardBridge),
             impls.l1StandardBridgeImpl,
             abi.encodeCall(IL1StandardBridge.initialize, (_cts.l1CrossDomainMessenger, _cts.systemConfig))
@@ -919,7 +914,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the L1ERC721Bridge.
         _upgrade(
-            _adminFor(_cts.proxyAdmin, _cts.l1ERC721Bridge),
+            _cts.proxyAdmin,
             address(_cts.l1ERC721Bridge),
             impls.l1ERC721BridgeImpl,
             abi.encodeCall(IL1ERC721Bridge.initialize, (_cts.l1CrossDomainMessenger, _cts.systemConfig))
@@ -927,7 +922,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the OptimismMintableERC20Factory.
         _upgrade(
-            _adminFor(_cts.proxyAdmin, _cts.optimismMintableERC20Factory),
+            _cts.proxyAdmin,
             address(_cts.optimismMintableERC20Factory),
             impls.optimismMintableERC20FactoryImpl,
             abi.encodeCall(IOptimismMintableERC20Factory.initialize, (address(_cts.l1StandardBridge)))
@@ -935,7 +930,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the DisputeGameFactory.
         _upgrade(
-            _adminFor(_cts.proxyAdmin, _cts.disputeGameFactory),
+            _cts.proxyAdmin,
             address(_cts.disputeGameFactory),
             impls.disputeGameFactoryImpl,
             abi.encodeCall(IDisputeGameFactory.initialize, (address(this)))
@@ -943,20 +938,25 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the DelayedWETH.
         _upgrade(
-            _adminFor(_cts.proxyAdmin, _cts.delayedWETH),
+            _cts.proxyAdmin,
             address(_cts.delayedWETH),
             impls.delayedWETHImpl,
-            abi.encodeCall(IDelayedWETH.initialize, (_cts.systemConfig))
+            abi.encodeCall(IDelayedWETH.initialize, (_systemConfigFor(_cts.systemConfig, address(_cts.delayedWETH))))
         );
 
         // Update the AnchorStateRegistry.
         _upgrade(
-            _adminFor(_cts.proxyAdmin, _cts.anchorStateRegistry),
+            _cts.proxyAdmin,
             address(_cts.anchorStateRegistry),
             impls.anchorStateRegistryImpl,
             abi.encodeCall(
                 IAnchorStateRegistry.initialize,
-                (_cts.systemConfig, _cts.disputeGameFactory, _cfg.startingAnchorRoot, _cfg.startingRespectedGameType)
+                (
+                    _systemConfigFor(_cts.systemConfig, address(_cts.anchorStateRegistry)),
+                    _cts.disputeGameFactory,
+                    _cfg.startingAnchorRoot,
+                    _cfg.startingRespectedGameType
+                )
             )
         );
 
@@ -1030,20 +1030,23 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         return _cts;
     }
 
-    /// @notice Resolves the ProxyAdmin that administers a proxy from its self-reported admin
-    ///         (ProxyAdminOwnedBase), so upgrades route correctly when a set spans distinct
-    ///         ProxyAdmins (post-interop-migration). Falls back to _defaultAdmin for a
-    ///         freshly-deployed proxy that can't yet report one. Ref: #21731.
-    /// @param _defaultAdmin Fallback ProxyAdmin for not-yet-initialized proxies.
-    /// @param _target The proxy whose administering ProxyAdmin should be resolved.
-    /// @return The administering ProxyAdmin.
-    function _adminFor(IProxyAdmin _defaultAdmin, IProxyAdminOwnedBase _target) internal view returns (IProxyAdmin) {
+    /// @notice Resolves the SystemConfig that a proxy is already bound to, so an upgrade driven by
+    ///         one member of an interop set does not re-point the shared contracts (ETHLockbox,
+    ///         AnchorStateRegistry, DelayedWETH) at the caller's SystemConfig. migrate() binds
+    ///         those to the first member chain's SystemConfig. Per-chain contracts report the
+    ///         caller's own SystemConfig, so behavior is unchanged for them. Falls back to
+    ///         _default for a freshly-deployed proxy that can't report one yet. Ref: #21731.
+    /// @dev The contracts exposing systemConfig() share no common base interface, so the target is
+    ///      called low-level; IETHLockbox is only the source of the (identical) selector.
+    /// @param _default Fallback SystemConfig for not-yet-initialized proxies.
+    /// @param _target The proxy whose bound SystemConfig should be resolved.
+    /// @return The bound SystemConfig.
+    function _systemConfigFor(ISystemConfig _default, address _target) internal view returns (ISystemConfig) {
         // eip150-safe
-        try _target.proxyAdmin() returns (IProxyAdmin admin_) {
-            return address(admin_) == address(0) ? _defaultAdmin : admin_;
-        } catch {
-            return _defaultAdmin;
-        }
+        (bool success, bytes memory data) = _target.staticcall(abi.encodeCall(IETHLockbox.systemConfig, ()));
+        if (!success || data.length != 32) return _default;
+        ISystemConfig systemConfig = abi.decode(data, (ISystemConfig));
+        return address(systemConfig) == address(0) ? _default : systemConfig;
     }
 
     /// @notice Helper for making the SystemConfig initializer arguments. This is the only

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -3306,6 +3306,18 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
             "shared DisputeGameFactory should be administered by the first chain's ProxyAdmin"
         );
 
+        // Sanity: the shared contracts are bound to the FIRST chain's SystemConfig, which is not
+        // the SystemConfig a chain-2 upgrade is driven by.
+        assertTrue(
+            address(chainContracts1.systemConfig) != address(chainContracts2.systemConfig),
+            "member chains should have distinct SystemConfigs"
+        );
+        assertEq(
+            address(sharedAsr.systemConfig()),
+            address(chainContracts1.systemConfig),
+            "shared AnchorStateRegistry should be bound to the first chain's SystemConfig"
+        );
+
         // The common ProxyAdmin owner owns both chains' ProxyAdmins.
         address pao = chainContracts1.proxyAdmin.owner();
         assertEq(chainContracts2.proxyAdmin.owner(), pao, "both ProxyAdmins should share an owner");
@@ -3336,6 +3348,32 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
             EIP1967Helper.getImplementation(address(sharedWeth)),
             impls.delayedWETHImpl,
             "shared DelayedWETH not at target impl"
+        );
+
+        // Upgrading a non-first member must not re-point the shared contracts at that member's
+        // SystemConfig — they stay bound to the first chain's SystemConfig set up by migrate().
+        assertEq(
+            address(sharedAsr.systemConfig()),
+            address(chainContracts1.systemConfig),
+            "shared AnchorStateRegistry re-pointed to another chain's SystemConfig"
+        );
+        assertEq(
+            address(sharedLockbox.systemConfig()),
+            address(chainContracts1.systemConfig),
+            "shared ETHLockbox re-pointed to another chain's SystemConfig"
+        );
+        assertEq(
+            address(sharedWeth.systemConfig()),
+            address(chainContracts1.systemConfig),
+            "shared DelayedWETH re-pointed to another chain's SystemConfig"
+        );
+
+        // Per-chain contracts remain bound to their own chain's SystemConfig.
+        IOptimismPortal2 portal2 = IOptimismPortal2(payable(chainContracts2.systemConfig.optimismPortal()));
+        assertEq(
+            address(portal2.systemConfig()),
+            address(chainContracts2.systemConfig),
+            "chain 2 OptimismPortal should stay bound to chain 2's SystemConfig"
         );
     }
 }

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -3214,6 +3214,130 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         // Execute the migration, expect revert.
         _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InteropNotEnabled.selector);
     }
+
+    /// @notice Builds the dispute game configs for upgrading a migrated super-permissioned
+    ///         interop chain. Order must match validGameTypes in
+    ///         OPContractsManagerV2._assertValidFullConfig(): only SUPER_PERMISSIONED is enabled,
+    ///         matching the respected game type the migration installs on the shared registry.
+    /// @return configs_ The dispute game configs.
+    function _interopUpgradeGameConfigs()
+        internal
+        returns (IOPContractsManagerUtils.DisputeGameConfig[] memory configs_)
+    {
+        address proposer = makeAddr("superProposer");
+        configs_ = new IOPContractsManagerUtils.DisputeGameConfig[](6);
+        configs_[0] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.CANNON,
+            gameArgs: bytes("")
+        });
+        configs_[1] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.PERMISSIONED_CANNON,
+            gameArgs: bytes("")
+        });
+        configs_[2] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.CANNON_KONA,
+            gameArgs: bytes("")
+        });
+        configs_[3] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: true,
+            initBond: 0,
+            gameType: GameTypes.SUPER_PERMISSIONED,
+            gameArgs: abi.encode(IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({ proposer: proposer }))
+        });
+        configs_[4] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.SUPER_CANNON_KONA,
+            gameArgs: bytes("")
+        });
+        configs_[5] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.ZK_DISPUTE_GAME,
+            gameArgs: bytes("")
+        });
+    }
+
+    /// @notice Runs the current OPCM upgrade for a migrated super-permissioned interop chain.
+    /// @param _systemConfig The chain's SystemConfig.
+    /// @param _pao The ProxyAdmin owner that must delegatecall the upgrade.
+    function _upgradeInteropChain(ISystemConfig _systemConfig, address _pao) internal {
+        IOPContractsManagerV2.UpgradeInput memory input;
+        input.systemConfig = _systemConfig;
+        input.disputeGameConfigs = _interopUpgradeGameConfigs();
+
+        prankDelegateCall(_pao);
+        (bool success,) = address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.upgrade, (input)));
+        assertTrue(success, "interop member chain upgrade failed");
+    }
+
+    /// @notice Regression test for ethereum-optimism/optimism#21731. After an interop migration
+    ///         the member chains share ETHLockbox / DisputeGameFactory / AnchorStateRegistry /
+    ///         DelayedWETH, all administered by the first chain's ProxyAdmin. upgrade() must resolve
+    ///         each proxy's own ProxyAdmin so upgrading a non-first member chain does not revert on
+    ///         the shared contracts' proxy admin-slot check. On develop this reverts for chain 2.
+    function test_upgrade_interopMemberChains_succeeds() public {
+        // Migrate the two-chain interop set.
+        _enableEthLockboxes();
+        _doMigration(_getDefaultMigrateInput());
+
+        // Resolve the shared infra established by the migration.
+        IOptimismPortal2 portal1 = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
+        IAnchorStateRegistry sharedAsr = portal1.anchorStateRegistry();
+        IDisputeGameFactory sharedDgf = sharedAsr.disputeGameFactory();
+        IETHLockbox sharedLockbox = portal1.ethLockbox();
+        IDelayedWETH sharedWeth = IDelayedWETH(payable(chainContracts1.systemConfig.delayedWETH()));
+
+        // Sanity: the members have distinct ProxyAdmins, but the shared contracts are administered
+        // by the first chain's ProxyAdmin — the exact condition that breaks the naive upgrade path.
+        assertTrue(
+            address(chainContracts1.proxyAdmin) != address(chainContracts2.proxyAdmin),
+            "member chains should have distinct ProxyAdmins"
+        );
+        assertEq(
+            address(sharedDgf.proxyAdmin()),
+            address(chainContracts1.proxyAdmin),
+            "shared DisputeGameFactory should be administered by the first chain's ProxyAdmin"
+        );
+
+        // The common ProxyAdmin owner owns both chains' ProxyAdmins.
+        address pao = chainContracts1.proxyAdmin.owner();
+        assertEq(chainContracts2.proxyAdmin.owner(), pao, "both ProxyAdmins should share an owner");
+
+        // Upgrade BOTH member chains, including the non-first chain (chain 2). Neither may revert.
+        _upgradeInteropChain(chainContracts1.systemConfig, pao);
+        _upgradeInteropChain(chainContracts2.systemConfig, pao);
+
+        // Each chain's upgrade idempotently re-applies the shared-contract upgrades, so the shared
+        // contracts must end at the current target implementations.
+        IOPContractsManagerContainer.Implementations memory impls = opcmV2.implementations();
+        assertEq(
+            EIP1967Helper.getImplementation(address(sharedDgf)),
+            impls.disputeGameFactoryImpl,
+            "shared DisputeGameFactory not at target impl"
+        );
+        assertEq(
+            EIP1967Helper.getImplementation(address(sharedAsr)),
+            impls.anchorStateRegistryImpl,
+            "shared AnchorStateRegistry not at target impl"
+        );
+        assertEq(
+            EIP1967Helper.getImplementation(address(sharedLockbox)),
+            impls.ethLockboxImpl,
+            "shared ETHLockbox not at target impl"
+        );
+        assertEq(
+            EIP1967Helper.getImplementation(address(sharedWeth)),
+            impls.delayedWETHImpl,
+            "shared DelayedWETH not at target impl"
+        );
+    }
 }
 
 /// @title OPContractsManagerV2_FeatBatchUpgrade_Test


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#21731. After an interop migration, a chain set shares `ETHLockbox`, `DisputeGameFactory`, `AnchorStateRegistry`, and `DelayedWETH`. Those are administered by the **first** chain's `ProxyAdmin` and bound to the **first** chain's `SystemConfig`. The upgrade path routed every proxy upgrade through the *calling* chain's `ProxyAdmin` and re-initialized every contract with the *calling* chain's `SystemConfig`, so `upgrade()` was wrong for any member chain other than the first.

## Per-target ProxyAdmin resolution

`OPContractsManagerUtils.upgrade` resolves the `ProxyAdmin` that actually administers the target, instead of assuming the caller's:

- Reads the target proxy's self-reported admin through `ProxyAdminOwnedBase.proxyAdmin()`. Per-chain contracts resolve to the chain's own `ProxyAdmin` (unchanged behavior); the shared interop contracts resolve to the first chain's `ProxyAdmin`, so the admin-slot check passes.
- Falls back to the passed-in `ProxyAdmin` when the target proxy has no implementation set yet (a freshly deployed proxy during an initial deployment or a permitted proxy deployment) — such a proxy can't report its admin and is always administered by the `ProxyAdmin` that just deployed it.
- The common L1 `ProxyAdmin` owner owns every `ProxyAdmin`, so `onlyOwner` passes regardless of which one is selected.

This lives in `upgrade()` rather than at each `OPContractsManagerV2._apply` call site for two reasons. It's where the admin is actually used (`getProxyImplementation`, `upgrade`, `upgradeAndCall`), and resolving at eleven call sites cost 246 bytes of `OPContractsManagerV2`'s 319-byte EIP-170 headroom, which combined with the change below put it 185 bytes over the limit. It also extends the same protection to `OPContractsManagerMigrator`. No existing caller changes behavior: every one already passes either the target's own `ProxyAdmin` or the deployer of a fresh proxy.

## Per-target SystemConfig resolution

Letting a non-first member reach the shared contracts exposes a second cross-chain hazard. `migrate()` binds them to `chainSystemConfigs[0]`, and `ETHLockbox` / `AnchorStateRegistry` / `DelayedWETH` all assign `systemConfig` unconditionally in their initializers while `upgrade()` resets the initialized slot. Chain B's `upgrade()` would therefore silently re-point all three at B's `SystemConfig`.

`_systemConfigFor(default, target)` is symmetric with the admin resolution: read the target's self-reported `systemConfig()`, fall back to the caller's when the proxy can't report one. It is applied to those three initializers only. Per-chain contracts (`OptimismPortal`, `L1CrossDomainMessenger`, `L1StandardBridge`, `L1ERC721Bridge`) are resolved *from* `_cts.systemConfig` in the first place, so routing them through the helper would be a no-op that only weakens the "upgrade normalizes state" property.

The target is called low-level because the contracts exposing `systemConfig()` share no common base interface (unlike the admin path, which has `IProxyAdminOwnedBase`); `IETHLockbox` is only the source of the identical selector.

## Tradeoff

This upgrades **all** contracts (per-chain + shared) on every member chain's `upgrade()` call, so the shared contracts get re-upgraded idempotently on each member's upgrade. This relies on the initializers being idempotent — re-running the same release does not reset anchors, games, withdrawals, balances, or authorizations. The dispute-game config loop (`setImplementation` / `setInitBond`) is `onlyOwner` on the DGF and already worked; it likewise re-applies idempotently.

## Testing

`test_upgrade_interopMemberChains_succeeds` (2-chain migrate fixture) migrates the interop set, then upgrades **both** members — including the non-first chain — asserting:

- neither `upgrade()` reverts, and the shared DGF / ASR / ETHLockbox / DelayedWETH end at the target implementations (this reverts on `develop` for chain 2);
- the shared ASR / ETHLockbox / DelayedWETH still report chain 1's `SystemConfig` afterwards (fails without `_systemConfigFor`, verified by mutation);
- chain 2's `OptimismPortal` still reports chain 2's `SystemConfig`, so the per-chain path is unaffected.

Run with `DEV_FEATURE__OPTIMISM_PORTAL_INTEROP=true`.

Bumps OPCM `@custom:semver` to 7.2.4 (bytecode change; `develop` already shipped 7.2.3). `OPContractsManagerV2` lands at 24,522 of the 24,576-byte runtime limit.
