### PR TITLE
op-supernode: Rewind interop accepted state when L2 safe head reorgs

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -1103,6 +1103,9 @@ func (m *algoMockChain) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockI
 	}
 	return m.optimisticL2, m.optimisticL1, nil
 }
+func (m *algoMockChain) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
+	return eth.L2BlockRef{}, nil
+}
 func (m *algoMockChain) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
 	return eth.Bytes32{}, nil
 }

--- a/op-supernode/supernode/activity/interop/decide_test.go
+++ b/op-supernode/supernode/activity/interop/decide_test.go
@@ -42,6 +42,15 @@ func TestCheckPreconditions(t *testing.T) {
 			want: ptrDecision(DecisionRewind),
 		},
 		{
+			name: "rewind when L2 frontier reorged",
+			obs: RoundObservation{
+				ChainsReady:   true,
+				L1Consistent:  true,
+				L2NeedsRewind: true,
+			},
+			want: ptrDecision(DecisionRewind),
+		},
+		{
 			name: "wait when frontier L1 inconsistent",
 			obs: RoundObservation{
 				ChainsReady:  true,

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -645,12 +645,9 @@ func (i *Interop) observeRound() (RoundObservation, error) {
 			return obs, nil
 		}
 
-		// A verifier is the authority for its own safe head, so the last verified
-		// L2 frontier must still be canonical. If it is not, the EL was driven off
-		// the safe chain out from under the accepted frontier (e.g. it adopted a
-		// non-safe-descendant sequencer gossip payload without rolling back; see
-		// optimism-private#577). Advancing would seal a block whose parent no
-		// longer matches the logsDB tip, so rewind the accepted frontier instead.
+		// The verifier owns its safe head, so the last verified L2 frontier must
+		// stay canonical. If it doesn't, advancing would seal a block whose parent
+		// no longer matches the logsDB tip; rewind the accepted frontier instead.
 		reorged, err := i.lastVerifiedFrontierReorged(obs.LastVerified.L2Heads)
 		if err != nil {
 			return obs, fmt.Errorf("L2 frontier canonicality check: %w", err)
@@ -678,23 +675,21 @@ func (i *Interop) observeRound() (RoundObservation, error) {
 }
 
 // lastVerifiedFrontierReorged reports whether any chain's last verified L2 head
-// is no longer the canonical block at that height. In a supernode the verifier
-// alone drives its safe head, so a mismatch means the EL left the safe chain
-// underneath the accepted frontier. Any read error is returned so the round
-// backs off and retries rather than advancing on unproven canonicality.
+// is no longer canonical at that height. A read error is returned so the round
+// backs off rather than advancing on unproven canonicality.
 func (i *Interop) lastVerifiedFrontierReorged(heads map[eth.ChainID]eth.BlockID) (bool, error) {
 	for chainID, head := range heads {
 		chain, ok := i.chains[chainID]
 		if !ok {
 			continue
 		}
-		out, err := chain.OutputV0AtBlockNumber(i.ctx, head.Number)
+		ref, err := chain.L2BlockRefByNumber(i.ctx, head.Number)
 		if err != nil {
 			return false, fmt.Errorf("chain %s: resolve canonical block %d: %w", chainID, head.Number, err)
 		}
-		if out.BlockHash != head.Hash {
+		if ref.Hash != head.Hash {
 			i.log.Warn("last verified L2 head is no longer canonical; rewinding accepted frontier",
-				"chain", chainID, "verifiedHead", head, "canonical", out.BlockHash)
+				"chain", chainID, "verifiedHead", head, "canonical", ref.Hash)
 			return true, nil
 		}
 	}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -81,6 +81,7 @@ type RoundObservation struct {
 	L1Heads        map[eth.ChainID]eth.BlockID
 	L1Consistent   bool
 	L1NeedsRewind  bool
+	L2NeedsRewind  bool
 	Paused         bool
 }
 
@@ -498,6 +499,10 @@ func checkPreconditions(obs RoundObservation) *StepOutput {
 		output := StepOutput{Decision: DecisionRewind}
 		return &output
 	}
+	if obs.L2NeedsRewind {
+		output := StepOutput{Decision: DecisionRewind}
+		return &output
+	}
 	if !obs.L1Consistent {
 		output := StepOutput{Decision: DecisionWait}
 		return &output
@@ -639,6 +644,21 @@ func (i *Interop) observeRound() (RoundObservation, error) {
 			obs.L1NeedsRewind = true
 			return obs, nil
 		}
+
+		// A verifier is the authority for its own safe head, so the last verified
+		// L2 frontier must still be canonical. If it is not, the EL was driven off
+		// the safe chain out from under the accepted frontier (e.g. it adopted a
+		// non-safe-descendant sequencer gossip payload without rolling back; see
+		// optimism-private#577). Advancing would seal a block whose parent no
+		// longer matches the logsDB tip, so rewind the accepted frontier instead.
+		reorged, err := i.lastVerifiedFrontierReorged(obs.LastVerified.L2Heads)
+		if err != nil {
+			return obs, fmt.Errorf("L2 frontier canonicality check: %w", err)
+		}
+		if reorged {
+			obs.L2NeedsRewind = true
+			return obs, nil
+		}
 	}
 
 	// Check the new frontier independently from the accepted L1 head. If the
@@ -655,6 +675,30 @@ func (i *Interop) observeRound() (RoundObservation, error) {
 	obs.L1Consistent = same
 
 	return obs, nil
+}
+
+// lastVerifiedFrontierReorged reports whether any chain's last verified L2 head
+// is no longer the canonical block at that height. In a supernode the verifier
+// alone drives its safe head, so a mismatch means the EL left the safe chain
+// underneath the accepted frontier. Any read error is returned so the round
+// backs off and retries rather than advancing on unproven canonicality.
+func (i *Interop) lastVerifiedFrontierReorged(heads map[eth.ChainID]eth.BlockID) (bool, error) {
+	for chainID, head := range heads {
+		chain, ok := i.chains[chainID]
+		if !ok {
+			continue
+		}
+		out, err := chain.OutputV0AtBlockNumber(i.ctx, head.Number)
+		if err != nil {
+			return false, fmt.Errorf("chain %s: resolve canonical block %d: %w", chainID, head.Number, err)
+		}
+		if out.BlockHash != head.Hash {
+			i.log.Warn("last verified L2 head is no longer canonical; rewinding accepted frontier",
+				"chain", chainID, "verifiedHead", head, "canonical", out.BlockHash)
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // verify runs the heavy I/O: log loading, message verification, and cycle detection.

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1590,6 +1590,61 @@ func TestInterop_ProgressAndRecord_L1InconsistencyTriggersRewind(t *testing.T) {
 	require.Empty(t, mock.rewindEngineCalls, "L1 drift rewinds accepted Supernode state only")
 }
 
+// TestInterop_ProgressAndRecord_L2FrontierReorgTriggersRewind advances twice
+// through progressAndRecord, then makes the last verified L2 head non-canonical
+// (its number now resolves to a different hash, as when the EL is driven off the
+// safe chain by non-safe-descendant gossip). observeRound must detect the stale
+// frontier and drive a rewind of accepted state — verifiedDB trimmed, WAL
+// cleared, engines untouched — instead of advancing into an impossible append.
+func TestInterop_ProgressAndRecord_L2FrontierReorgTriggersRewind(t *testing.T) {
+	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
+					WithActivation(100).
+					WithChain(10, func(m *mockChainContainer) {
+			m.currentL1 = eth.BlockRef{Number: 1000, Hash: common.HexToHash("0xL1")}
+			m.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
+		}).
+		Build()
+
+	mock := h.Mock(10)
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
+	}
+	h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+		return Result{}, nil
+	}
+
+	for i := 0; i < 2; i++ {
+		_, err := h.interop.progressAndRecord()
+		require.NoError(t, err)
+	}
+	lastTS, ok := h.interop.verifiedDB.LastTimestamp()
+	require.True(t, ok)
+	require.Equal(t, uint64(102), lastTS)
+
+	// The last verified head at block N was sealed with hash BigToHash(N) (what
+	// OptimisticAt reports). Make the canonical block at that number resolve to a
+	// different hash, simulating the safe head being reorged out from under the
+	// accepted frontier. observeRound must now choose DecisionRewind.
+	mock.outputV0Override = func(_ context.Context, num uint64) (*eth.OutputV0, error) {
+		return &eth.OutputV0{BlockHash: common.HexToHash("0xreorg")}, nil
+	}
+
+	made, err := h.interop.progressAndRecord()
+	require.NoError(t, err)
+	require.False(t, made, "rewind does not advance the verified timestamp")
+
+	// Rewind removed the last-committed entry and left the earlier one in place.
+	lastTS, ok = h.interop.verifiedDB.LastTimestamp()
+	require.True(t, ok)
+	require.Equal(t, uint64(101), lastTS)
+
+	pending, err := h.interop.verifiedDB.GetPendingTransition()
+	require.NoError(t, err)
+	require.Nil(t, pending, "WAL cleared after successful rewind")
+
+	require.Empty(t, mock.rewindEngineCalls, "L2 frontier reorg rewinds accepted Supernode state only")
+}
+
 func TestInterop_ProgressAndRecord_StaleFrontierL1Waits(t *testing.T) {
 	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
 					WithActivation(100).

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1590,12 +1590,10 @@ func TestInterop_ProgressAndRecord_L1InconsistencyTriggersRewind(t *testing.T) {
 	require.Empty(t, mock.rewindEngineCalls, "L1 drift rewinds accepted Supernode state only")
 }
 
-// TestInterop_ProgressAndRecord_L2FrontierReorgTriggersRewind advances twice
-// through progressAndRecord, then makes the last verified L2 head non-canonical
-// (its number now resolves to a different hash, as when the EL is driven off the
-// safe chain by non-safe-descendant gossip). observeRound must detect the stale
-// frontier and drive a rewind of accepted state — verifiedDB trimmed, WAL
-// cleared, engines untouched — instead of advancing into an impossible append.
+// TestInterop_ProgressAndRecord_L2FrontierReorgTriggersRewind advances twice,
+// then makes the last verified L2 head resolve to a different hash (a safe-head
+// reorg under the frontier). observeRound must rewind accepted state — verifiedDB
+// trimmed, WAL cleared, engines untouched — not advance into an impossible append.
 func TestInterop_ProgressAndRecord_L2FrontierReorgTriggersRewind(t *testing.T) {
 	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
 					WithActivation(100).
@@ -1621,12 +1619,11 @@ func TestInterop_ProgressAndRecord_L2FrontierReorgTriggersRewind(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, uint64(102), lastTS)
 
-	// The last verified head at block N was sealed with hash BigToHash(N) (what
-	// OptimisticAt reports). Make the canonical block at that number resolve to a
-	// different hash, simulating the safe head being reorged out from under the
-	// accepted frontier. observeRound must now choose DecisionRewind.
-	mock.outputV0Override = func(_ context.Context, num uint64) (*eth.OutputV0, error) {
-		return &eth.OutputV0{BlockHash: common.HexToHash("0xreorg")}, nil
+	// Verified heads are sealed with hash BigToHash(N) (what OptimisticAt reports).
+	// Make the canonical block at that number resolve to a different hash so the
+	// frontier is non-canonical; observeRound must now choose DecisionRewind.
+	mock.l2BlockRefByNumberOverride = func(_ context.Context, num uint64) (eth.L2BlockRef, error) {
+		return eth.L2BlockRef{Number: num, Hash: common.HexToHash("0xreorg")}, nil
 	}
 
 	made, err := h.interop.progressAndRecord()
@@ -1828,7 +1825,8 @@ type mockChainContainer struct {
 	resumeErr           error
 	callLog             *callLog // shared ordered call log across mocks
 
-	outputV0Override func(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error)
+	outputV0Override           func(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error)
+	l2BlockRefByNumberOverride func(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 
 	// timestampToBlockNumberOverride lets tests decouple TimestampToBlockNumber
 	// from the default ts==blockNum identity. Used by
@@ -2130,6 +2128,12 @@ func (m *mockChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockN
 		MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmockmsg")),
 		BlockHash:                common.BigToHash(new(big.Int).SetUint64(l2BlockNum)),
 	}, nil
+}
+func (m *mockChainContainer) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
+	if m.l2BlockRefByNumberOverride != nil {
+		return m.l2BlockRefByNumberOverride(ctx, num)
+	}
+	return eth.L2BlockRef{Number: num, Hash: common.BigToHash(new(big.Int).SetUint64(num))}, nil
 }
 func (m *mockChainContainer) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
 	return nil, nil

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -67,6 +67,10 @@ func (m *mockCC) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockID, eth.
 	return eth.BlockID{}, eth.BlockID{}, nil
 }
 
+func (m *mockCC) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
+	return eth.L2BlockRef{}, nil
+}
+
 func (m *mockCC) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
 	if m.outputErr != nil {
 		return eth.Bytes32{}, m.outputErr

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -73,6 +73,9 @@ func (m *mockCC) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockID, eth.
 	}
 	return m.optL2, m.optL1, nil
 }
+func (m *mockCC) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
+	return eth.L2BlockRef{}, nil
+}
 func (m *mockCC) OutputRootAtL2BlockHash(ctx context.Context, blockHash common.Hash) (eth.Bytes32, error) {
 	m.byHashCalled++
 	if m.byHashErr != nil {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -81,6 +81,10 @@ type ChainContainer interface {
 	FirstSafeHeadTimestamp(ctx context.Context) (uint64, error)
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
+	// L2BlockRefByNumber returns the canonical L2 block reference at the given
+	// number. Lightweight (no output-root or state-proof computation); returns
+	// ethereum.NotFound if the EL has no canonical block at that number.
+	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 	// OutputRootAtL2BlockHash returns the L2 output root for the canonical
 	// block at the given hash. Post-Isthmus the root is derived from the
 	// header alone; pre-Isthmus it falls back to eth_getProof on state at

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -128,4 +128,11 @@ func (c *simpleChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2Bloc
 	return c.engine.OutputV0AtBlockNumber(ctx, l2BlockNum)
 }
 
+func (c *simpleChainContainer) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
+	if c.engine == nil {
+		return eth.L2BlockRef{}, engine_controller.ErrNoEngineClient
+	}
+	return c.engine.L2BlockRefByNumber(ctx, num)
+}
+
 var _ rollup.SuperAuthority = (*simpleChainContainer)(nil)


### PR DESCRIPTION
## What

Adds an L2 frontier canonicality guard to the interop verifier's decision loop. When the last verified L2 head is no longer canonical on a chain, `observeRound` now emits `DecisionRewind` instead of `DecisionAdvance`.

## Why

During the Reorg-4 rehearsal, working supernodes wedged forever retrying an impossible `persistFrontierLogs` append with `ErrParentHashMismatch`:

```
persist frontier logs: chain 420120178: block 191137 parent hash 0x56b58e… does not match logsDB last sealed block hash 0x755661…
```

Reaching that error inside `DecisionAdvance` is an invariant violation, not a recoverable round error. `DecisionAdvance` assumes the previous frontier is verified and canonical and appends its child; a parent mismatch means the decision was made against a fork the sealed logsDB tip is not on.

Root cause: the interop verifier is the sole authority for its own safe head, so the canonical block at the last verified height should always equal the verified head. It stopped matching because the verifier's EL was driven off the safe chain by a non-safe-descendant sequencer gossip payload it adopted without rolling back (a separate EL/CL-layer defect). Once canonical `191136` changed underneath the accepted frontier, the decision loop kept choosing `DecisionAdvance` toward the new-fork `191137` because `observeRound` only guarded **L1** inclusion canonicality — it never re-checked that the last verified **L2** frontier was still canonical.

The repair machinery already exists (`buildRewindPlan` / `applyRewindPlan` for `DecisionRewind`, wired to rewind verifiedDB + logsDB to the previous verified head); it was simply never reached for an L2-only reorg. This PR closes that gap: detect the stale frontier and route into the existing rewind path, which walks the accepted frontier back one timestamp per round until it reconverges on the canonical common ancestor, after which normal advance re-seals the replacement branch.

This is defense-in-depth. The underlying invariant break — a verifier's safe head being reorgable by gossip — must be fixed at the EL/CL layer; absent that bug the supernode's canonical view always matches verifiedDB and this guard never fires.

## Changes

- `RoundObservation.L2NeedsRewind` + `checkPreconditions` maps it to `DecisionRewind`.
- `observeRound` checks each last-verified L2 head against `L2BlockRefByNumber` (a lightweight block-ref lookup — no output-root or state-proof computation); any read error backs the round off rather than advancing on unproven canonicality.
- `L2BlockRefByNumber` added to the `ChainContainer` interface (delegates to the engine controller, already used internally); test mocks updated.
- Tests: `checkPreconditions` case + end-to-end `TestInterop_ProgressAndRecord_L2FrontierReorgTriggersRewind` (verifiedDB trimmed, WAL cleared, engines untouched).

## Not covered

Live logsDB reconciliation on a `DecisionAdvance` that still slips through, `proxyd-cl` freshness/monotonicity policy, and Reth ExEx WAL consistency remain separate workstreams.

## Test plan

```
go test ./op-supernode/... -count=1
```
