### PR TITLE
ci: Use mold linker for Rust workspace builds

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -677,16 +677,12 @@ commands:
               export FEATURES="--all-features"
             fi
 
-            # Use the mold linker (preinstalled in ci-base-clang) to cut final link
-            # time. `mold -run` intercepts the linker at exec time, so it needs no
-            # RUSTFLAGS change and does not perturb the sccache compile-cache key.
-            # Falls back to the default linker if mold is unavailable.
-            cd << parameters.directory >>
-            if command -v mold >/dev/null 2>&1; then
-              mold -run cargo build $PROFILE $TARGET $PACKAGE $FEATURES $BINARY
-            else
-              cargo build $PROFILE $TARGET $PACKAGE $FEATURES $BINARY
-            fi
+            # Use the mold linker (pinned via mise; also present in ci-base-clang)
+            # to cut final link time. `mold -run` intercepts the linker at exec
+            # time, so it needs no RUSTFLAGS change and does not perturb the sccache
+            # compile-cache key. The CI env is controlled, so a missing mold must
+            # fail loudly rather than silently falling back to the default linker.
+            cd << parameters.directory >> && mold -run cargo build $PROFILE $TARGET $PACKAGE $FEATURES $BINARY
           no_output_timeout: 30m
       - when:
           condition: << parameters.save_cache >>

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -677,7 +677,16 @@ commands:
               export FEATURES="--all-features"
             fi
 
-            cd << parameters.directory >> && cargo build $PROFILE $TARGET $PACKAGE $FEATURES $BINARY
+            # Use the mold linker (preinstalled in ci-base-clang) to cut final link
+            # time. `mold -run` intercepts the linker at exec time, so it needs no
+            # RUSTFLAGS change and does not perturb the sccache compile-cache key.
+            # Falls back to the default linker if mold is unavailable.
+            cd << parameters.directory >>
+            if command -v mold >/dev/null 2>&1; then
+              mold -run cargo build $PROFILE $TARGET $PACKAGE $FEATURES $BINARY
+            else
+              cargo build $PROFILE $TARGET $PACKAGE $FEATURES $BINARY
+            fi
           no_output_timeout: 30m
       - when:
           condition: << parameters.save_cache >>

--- a/mise.toml
+++ b/mise.toml
@@ -22,6 +22,11 @@ make = "4.4.1"
 
 svm-rs = "0.5.19"
 
+# Fast linker used for Rust link steps in CI (see .circleci rust-build). Linux
+# only: mold ships no macOS build, so gate on os to keep `mise install` green on
+# developer Macs. Pinned here so CI's linker version is fixed and reproducible.
+mold = { version = "2.41.0", os = ["linux"] }
+
 # Rust tooling
 "github:crate-ci/cargo-release" = { version = "1.1.2" }
 


### PR DESCRIPTION
Wraps the shared `rust-build` cargo invocation with `mold -run` (mold is already preinstalled in the ci-base-clang image). Linking is the largest uncacheable cost of `rust-workspace-binaries`, the PR critical path — sccache caches codegen but never the final link. `mold -run` intercepts the linker at exec time, so it needs no RUSTFLAGS change and does not perturb the sccache compile-cache key; it falls back to the default linker if mold is absent. Draft to measure the effect on `rust-workspace-binaries` runtime.