### PR TITLE
ci: A/B measure Rust CI with sccache disabled

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -651,6 +651,10 @@ commands:
       - run:
           name: Build << parameters.directory >>
           command: |
+            # A/B EXPERIMENT (do not merge): disable the sccache compiler wrapper to
+            # measure sccache's true benefit on the workspace build. sccache server
+            # setup elsewhere is harmless; cargo just won't use it here.
+            export RUSTC_WRAPPER=""
             PWD=$(pwd)
             export CARGO_TARGET_DIR="$PWD/<< parameters.directory >>/target"
             echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"


### PR DESCRIPTION
Experiment (do not merge). Re-runs the clean sccache A/B that #21252 attempted but which was contaminated by the since-removed stale target-dir cache (#21310). Disables the sccache compiler wrapper for the shared `rust-build` cargo build so we can measure sccache's true benefit on `rust-workspace-binaries` vs the sccache-on baseline on develop (~13.5-15 min). Will record the measured durations as a comment and then close.
