### PR TITLE
op-reth: export OpLocalPayloadAttributesBuilder

### DIFF
--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -74,8 +74,24 @@ use url::Url;
 use reth_optimism_payload_builder::OpPayloadAttrs;
 
 /// Builds [`OpPayloadAttrs`] for local/dev-mode payload generation.
-struct OpLocalPayloadAttributesBuilder {
+///
+/// Public so that downstream nodes wrapping [`OpNode`] can implement
+/// [`DebugNode`] for their own node types. [`DebugNode`] is implemented here only
+/// for [`OpNode`] (bounded on `Types = Self`), so a wrapper node — which supplies
+/// its own [`NodeTypes`] — cannot reuse that impl and must return an attributes
+/// builder of its own. Without this being nameable, the only option is to
+/// duplicate the dev-mode attribute logic below, including the dummy
+/// `TX_SET_L1_BLOCK` system transaction.
+#[derive(Debug, Clone)]
+pub struct OpLocalPayloadAttributesBuilder {
     chain_spec: Arc<OpChainSpec>,
+}
+
+impl OpLocalPayloadAttributesBuilder {
+    /// Creates a builder that generates dev-mode payload attributes for `chain_spec`.
+    pub const fn new(chain_spec: Arc<OpChainSpec>) -> Self {
+        Self { chain_spec }
+    }
 }
 
 impl PayloadAttributesBuilder<OpPayloadAttrs> for OpLocalPayloadAttributesBuilder {
@@ -405,7 +421,7 @@ where
     fn local_payload_attributes_builder(
         chain_spec: &Self::ChainSpec,
     ) -> impl PayloadAttributesBuilder<<Self::Payload as PayloadTypes>::PayloadAttributes> {
-        OpLocalPayloadAttributesBuilder { chain_spec: Arc::new(chain_spec.clone()) }
+        OpLocalPayloadAttributesBuilder::new(Arc::new(chain_spec.clone()))
     }
 }
 


### PR DESCRIPTION
## Why

`DebugNode` is implemented for `OpNode` alone, bounded on `N: FullNodeComponents<Types = Self>`. A node that wraps `OpNode` but supplies its own `NodeTypes` cannot satisfy that bound, so it must provide its own `DebugNode` impl in order to call `launch_with_debug_capabilities()` — and without that, `--debug.rpc-consensus-url`, `--debug.etherscan`, and `--dev` are silently inert.

`--dev` is the sharp one: `dev.dev` is also read outside the debug launcher (`rpc.rs` installs the dev-signer accounts, plus the `is_dev()` helpers), so without the `DebugNodeLauncher` a wrapper node comes up *looking* like a dev node — unlocked accounts, transactions accepted into the pool — while the `LocalMiner` never spawns and no block is ever produced.

Such an impl must return something implementing `PayloadAttributesBuilder<OpPayloadAttrs>`. `OpLocalPayloadAttributesBuilder` is the only type in this repo that does, and it was private — leaving downstream nodes to duplicate the dev-mode attribute logic, dummy `TX_SET_L1_BLOCK` system transaction included. That copy would silently drift from this one.

Concrete consumer: `op-reth-premium`'s node types, which wrap `OpNode` and substitute the payload service builder.

## What

- `OpLocalPayloadAttributesBuilder` becomes `pub`, with a `new()` constructor; the `chain_spec` field stays private.
- Derives `Debug`/`Clone` to satisfy the workspace's `missing-debug-implementations` lint.
- The in-module construction site goes through the constructor.

`lib.rs` already does `pub use node::*;`, so no explicit re-export is needed.

## Risk

None — additive visibility change, no behaviour change. `cargo clippy -p reth-optimism-node --all-targets -- -D warnings` and `cargo +nightly-2026-02-20 fmt --all --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)