### PR TITLE
op-deployer: remove stale issue 20912 TODOs

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -246,8 +246,6 @@ func DeployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 		GasLimit:                cfg.GasLimit,
 		DisputeGameType:         cfg.DisputeGameType,
 		DisputeAbsolutePrestate: selectedAbsolutePrestate,
-		// TODO(#20912): Replace this placeholder with a real proposal before enabling
-		// permissionless interopgen deployments. The generated recipe currently uses PERMISSIONED_CANNON.
 		StartingAnchorRoot: opcm.Proposal{
 			Root:             opcm.DefaultStartingAnchorRoot.Root,
 			L2SequenceNumber: common.Big0,

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x2650f2af1df017387e1f1aa6273decc4c46dd4f3ac7f0910c6f0edc92aef4747"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x4eee827f6732de7777cc51830bc05d22b5970f8f98667158fb582aa8df9371db",
-    "sourceCodeHash": "0xe550799f715c5b019123cd0def8c62188512e2224455d01a828bd64af144d706"
+    "initCodeHash": "0x0a6a9baa9913e6feb0c0d1606f037c22205cbe83e709de3c9ca0ba03a0301037",
+    "sourceCodeHash": "0xf37254fcca4a499b6487c6fc5fba880ef2dbd785cea505321deee5fcb28c4d06"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -158,9 +158,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 7.2.2
+    /// @custom:semver 7.2.3
     function version() public pure returns (string memory) {
-        return "7.2.2";
+        return "7.2.3";
     }
 
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -789,8 +789,6 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             }
 
             if (_cfg.disputeGameConfigs[i].enabled && (isCannonGame || isCannonKonaGame || isSuperCannonKonaGame)) {
-                // TODO(#20912): Remove once deploy pipelines provide real anchor roots.
-                // A permissionless initial deployment must not use the placeholder anchor root.
                 if (
                     _isInitialDeployment
                         && _cfg.startingAnchorRoot.root.raw() == Constants.PLACEHOLDER_STARTING_ANCHOR_ROOT


### PR DESCRIPTION
**Description**

Removes stale TODO references that reopened #20912. Bumps OPContractsManagerV2 from 7.2.2 to 7.2.3 and regenerates the semver lock. No behavior, ABI, or storage changes.

**Additional context**

The remaining genesis output-root work is tracked by #21963.

**Metadata**

Closes #20912
