### PR TITLE
ci: fix apko factory pin to include cargo-profile input

### DIFF
--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@71a5f61d2b308d705de4a8959d89156755f68db3
+        uses: ethereum-optimism/factory/actions/apko-plan@ad80f0dba9993ed5a080361538293abeb21c72bd
         with:
           config: .github/images.apko.json
 
@@ -59,7 +59,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@ad80f0dba9993ed5a080361538293abeb21c72bd
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -91,7 +91,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@ad80f0dba9993ed5a080361538293abeb21c72bd
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -114,7 +114,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@ad80f0dba9993ed5a080361538293abeb21c72bd
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus


### PR DESCRIPTION
#22012 bumped the apko factory pin to `71a5f61d` to pick up the BASH_REMATCH fix, but that commit predates the `cargo-profile` input on `melange-build.yaml`. `build-images.apko` passes `cargo-profile: maxperf`, so GitHub rejects the workflow at startup (`startup_failure`, zero jobs) on every push, tag, and scheduled run since 2026-07-24. This is what broke the image builds for the `op-reth/v2.4.1-rc.4` and sibling release tags.

Bump the pin to `ad80f0db` (current factory `main`), which contains both the BASH_REMATCH fix (factory #40) and the `cargo-profile` input (factory #42), plus the isolated melange artifacts restore (factory #43). `cargo-profile: maxperf` stays in place.