### PR TITLE
ci: bump factory pins to latest main

### DIFF
--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@ad80f0dba9993ed5a080361538293abeb21c72bd
+        uses: ethereum-optimism/factory/actions/apko-plan@0e7698dcc639d694b5751e7168918aab481a0767
         with:
           config: .github/images.apko.json
 
@@ -59,7 +59,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@ad80f0dba9993ed5a080361538293abeb21c72bd
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@0e7698dcc639d694b5751e7168918aab481a0767
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -91,7 +91,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@ad80f0dba9993ed5a080361538293abeb21c72bd
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@0e7698dcc639d694b5751e7168918aab481a0767
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -114,7 +114,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@ad80f0dba9993ed5a080361538293abeb21c72bd
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@0e7698dcc639d694b5751e7168918aab481a0767
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -53,7 +53,7 @@ jobs:
           ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
       - name: Plan
         id: plan
-        uses: ethereum-optimism/factory/actions/plan@25fa2ff591f9b4801d3dcadffd2b76ec2340cf8a
+        uses: ethereum-optimism/factory/actions/plan@0e7698dcc639d694b5751e7168918aab481a0767
         with:
           config: .github/images.json
       - name: Compute cross-platform check sub-matrices
@@ -104,7 +104,7 @@ jobs:
       fail-fast: true
       matrix:
         include: ${{ fromJson(needs.plan.outputs.matrix_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@25fa2ff591f9b4801d3dcadffd2b76ec2340cf8a
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@0e7698dcc639d694b5751e7168918aab481a0767
     with:
       mode: ${{ matrix.mode }}
       image_name: ${{ matrix.image_name }}


### PR DESCRIPTION
## Summary

Bumps all `ethereum-optimism/factory` action and reusable-workflow pins in `build-images.yaml` and `build-images.apko.yaml` to the latest `main` commit `80fb1914d8f68ea4ac277beff4541cc4a669569f`.

The motivating change is https://github.com/ethereum-optimism/factory/pull/46, which fixes the `actions/plan` step failing with `echo: write error: Broken pipe` under `pipefail` on PRs that change more than 50 files. That failure skipped the downstream image build and smoke-test jobs.

Other factory changes picked up by the bump:
- https://github.com/ethereum-optimism/factory/pull/39 Nexus apko reusable workflows (unused here)
- https://github.com/ethereum-optimism/factory/pull/40 apko-plan `BASH_REMATCH` fix
- https://github.com/ethereum-optimism/factory/pull/42 pass Cargo profile to melange builds
- https://github.com/ethereum-optimism/factory/pull/43 restore isolated melange artifacts