### PR TITLE
op-e2e: Skip permissioned game test when the game type is unregistered

### DIFF
--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -192,6 +192,19 @@ func (h *FactoryHelper) StartOutputCannonGame(ctx context.Context, l2Node string
 	return h.startOutputCannonGameOfType(ctx, l2Node, l2BlockNumber, rootClaim, cannonKonaGameType, opts...)
 }
 
+// SkipIfPermissionedGameNotRegistered skips the test unless the DisputeGameFactory has an
+// implementation for the legacy permissioned game type. Super root games replace it, so it is only
+// registered while the super root games migration is disabled.
+// TODO(#21662): Remove along with the permissioned game tests when super root games can no longer
+// be disabled.
+func (h *FactoryHelper) SkipIfPermissionedGameNotRegistered(ctx context.Context) {
+	impl, err := h.Factory.GameImpls(&bind.CallOpts{Context: ctx}, permissionedGameType)
+	h.Require.NoError(err, "failed to load permissioned game implementation")
+	if impl == (common.Address{}) {
+		h.T.Skip("permissioned game type is not registered, super root games are enabled")
+	}
+}
+
 func (h *FactoryHelper) StartPermissionedGame(ctx context.Context, l2Node string, l2BlockNumber uint64, rootClaim common.Hash, opts ...GameOpt) *OutputCannonGameHelper {
 	return h.startOutputCannonGameOfType(ctx, l2Node, l2BlockNumber, rootClaim, permissionedGameType, opts...)
 }

--- a/op-e2e/faultproofs/permissioned_test.go
+++ b/op-e2e/faultproofs/permissioned_test.go
@@ -19,6 +19,7 @@ func TestPermissionedGameType(t *testing.T) {
 	t.Cleanup(sys.Close)
 
 	gameFactory := disputegame.NewFactoryHelper(t, ctx, sys, disputegame.WithFactoryPrivKey(sys.Cfg.Secrets.Proposer))
+	gameFactory.SkipIfPermissionedGameNotRegistered(ctx)
 
 	game := gameFactory.StartPermissionedGame(ctx, "sequencer", 1, common.Hash{0x01, 0xaa})
 


### PR DESCRIPTION
`TestPermissionedGameType` fails on `develop` since super root games became the default ([#21689](https://github.com/ethereum-optimism/optimism/pull/21689)): the initial deploy selector `PERMISSIONED_CANNON` now resolves to `SUPER_PERMISSIONED`, so the DisputeGameFactory in the op-e2e allocs has no implementation for game type 1 and `create` reverts with `NoImplementation(1)` (`0x031c6de4`).

Skip the test when the factory has no implementation registered, rather than keying off the dev feature flag — `IsDevFeatureEnabled` short-circuits to `true` for `SuperRootGamesMigration`, so a flag-based guard would be an unconditional skip. Checking the factory keeps the test running if super root games are toggled back off.

The check is at the top of the test body so it's visible, not hidden inside `StartPermissionedGame`.

## Test plan

`go test ./op-e2e/faultproofs/ -run TestPermissionedGameType`:
- With current artifacts (super root games enabled): `--- SKIP: TestPermissionedGameType` — `permissioned game type is not registered, super root games are enabled`.
- With pre-#21689 artifacts (game type 1 registered): the skip does not fire and the test proceeds to create the game and start the challenger.
