### PR TITLE
op-devstack: Wait for the destination chain before sending executing messages

### DIFF
--- a/op-acceptance-tests/tests/interop/filter/interop_filter_test.go
+++ b/op-acceptance-tests/tests/interop/filter/interop_filter_test.go
@@ -82,8 +82,8 @@ func TestInteropFilter_IngressRejectsInvalid(gt *testing.T) {
 		txplan.WithTo(&bobAddr),
 		txplan.WithValue(eth.GWei(1)),
 		txplan.WithAccessList(accessList),
-		// The entry names no message, so there is nothing to wait for. The node is what has to
-		// reject this tx.
+		// The fabricated entry does not decode as a message, so the wait cannot be planned. The
+		// node is what has to reject this tx.
 		txintent.WithoutInteropDependencyWait(),
 		txplan.WithGasLimit(100_000),
 	)

--- a/op-acceptance-tests/tests/interop/filter/interop_filter_test.go
+++ b/op-acceptance-tests/tests/interop/filter/interop_filter_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
@@ -81,6 +82,9 @@ func TestInteropFilter_IngressRejectsInvalid(gt *testing.T) {
 		txplan.WithTo(&bobAddr),
 		txplan.WithValue(eth.GWei(1)),
 		txplan.WithAccessList(accessList),
+		// The entry names no message, so there is nothing to wait for. The node is what has to
+		// reject this tx.
+		txintent.WithoutInteropDependencyWait(),
 		txplan.WithGasLimit(100_000),
 	)
 

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -52,8 +52,7 @@ func planCall(t devtest.T, call txintent.Call) txplan.Option {
 
 func planExecMsg(t devtest.T, initMsg *messages.Message) txplan.Option {
 	t.Require().NotNil(initMsg)
-	// The EOA plan waits for the destination chain to build past initMsg before planning the tx:
-	// see txintent.WithInteropDependencyWait.
+	// The EOA plan waits for the chain to reach initMsg: see txintent.WithInteropDependencyWait.
 	return planCall(t, &txintent.ExecTrigger{
 		Executor: predeploys.CrossL2InboxAddr,
 		Msg:      *initMsg,

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/accounting"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/plan"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txinclude"
@@ -51,44 +50,13 @@ func planCall(t devtest.T, call txintent.Call) txplan.Option {
 	return txplan.Combine(plan...)
 }
 
-type BlockRefByLabel interface {
-	BlockRefByLabel(context.Context, eth.BlockLabel) (eth.BlockRef, error)
-}
-
-func planExecMsg(t devtest.T, initMsg *messages.Message, blockTime time.Duration, el BlockRefByLabel) txplan.Option {
+func planExecMsg(t devtest.T, initMsg *messages.Message) txplan.Option {
 	t.Require().NotNil(initMsg)
-	return txplan.Combine(planCall(t, &txintent.ExecTrigger{
+	// The EOA plan waits for the destination chain to build past initMsg before planning the tx:
+	// see txintent.WithInteropDependencyWait.
+	return planCall(t, &txintent.ExecTrigger{
 		Executor: predeploys.CrossL2InboxAddr,
 		Msg:      *initMsg,
-	}), func(tx *txplan.PlannedTx) {
-		tx.AgainstBlock.Wrap(func(fn plan.Fn[eth.BlockInfo]) plan.Fn[eth.BlockInfo] {
-			// The tx is invalid until we know it will be included at a higher timestamp than any
-			// of the initiating messages, modulo reorgs. Wait to plan the relay tx against a
-			// target block until the timestamp elapses. NOTE: this should be `>=`, but the mempool
-			// filtering in op-geth currently uses the unsafe head's timestamp instead of the
-			// pending timestamp. See https://github.com/ethereum-optimism/op-geth/issues/603.
-			// TODO(16371): if every txintent.Call had a Plan() method, this Option could be
-			// included with ExecTrigger.
-			for {
-				ref, err := el.BlockRefByLabel(t.Ctx(), eth.Unsafe)
-				if err != nil {
-					return func(context.Context) (eth.BlockInfo, error) {
-						return nil, fmt.Errorf("get block ref by label: %w", err)
-					}
-				}
-				if ref.Time > initMsg.Identifier.Timestamp {
-					break
-				}
-				select {
-				case <-time.After(blockTime):
-				case <-t.Ctx().Done():
-					return func(context.Context) (eth.BlockInfo, error) {
-						return nil, t.Ctx().Err()
-					}
-				}
-			}
-			return fn
-		})
 	})
 }
 

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/accounting"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/plan"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txinclude"
@@ -51,44 +50,13 @@ func planCall(t devtest.T, call txintent.Call) txplan.Option {
 	return txplan.Combine(plan...)
 }
 
-type BlockRefByLabel interface {
-	BlockRefByLabel(context.Context, eth.BlockLabel) (eth.BlockRef, error)
-}
-
-func planExecMsg(t devtest.T, initMsg *messages.Message, blockTime time.Duration, el BlockRefByLabel) txplan.Option {
+func planExecMsg(t devtest.T, initMsg *messages.Message) txplan.Option {
 	t.Require().NotNil(initMsg)
-	return txplan.Combine(planCall(t, &txintent.ExecTrigger{
+	// The EOA plan waits for the destination chain to build past initMsg before planning the tx:
+	// see txintent.WithInteropDependencyWait.
+	return planCall(t, &txintent.ExecTrigger{
 		Executor: predeploys.CrossL2InboxAddr,
 		Msg:      *initMsg,
-	}), func(tx *txplan.PlannedTx) {
-		tx.AgainstBlock.Wrap(func(fn plan.Fn[eth.BlockInfo]) plan.Fn[eth.BlockInfo] {
-			// The tx is invalid until we know it will be included at a higher timestamp than any
-			// of the initiating messages, modulo reorgs. Wait to plan the relay tx against a
-			// target block until the timestamp elapses. NOTE: this should be `>=`, but the mempool
-			// filtering in op-geth currently uses the unsafe head's timestamp instead of the
-			// pending timestamp. See https://github.com/ethereum-optimism/op-geth/issues/603.
-			// TODO(16371): if every txintent.Call had a Plan() method, this Option could be
-			// included with ExecTrigger.
-			for {
-				ref, err := el.BlockRefByLabel(t.Ctx(), eth.Unsafe)
-				if err != nil {
-					return func(context.Context) (eth.BlockInfo, error) {
-						return nil, fmt.Errorf("get block ref by label: %w", err)
-					}
-				}
-				if ref.Time > initMsg.Identifier.Timestamp {
-					break
-				}
-				select {
-				case <-time.After(blockTime):
-				case <-t.Ctx().Done():
-					return func(context.Context) (eth.BlockInfo, error) {
-						return nil, t.Ctx().Err()
-					}
-				}
-			}
-			return fn
-		})
 	})
 }
 

--- a/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
@@ -70,7 +70,7 @@ func NewInvalidExecMsgSpammer(t devtest.T, l2 *L2, validInitMsg messages.Message
 
 func (ie *InvalidExecMsgSpammer) Spam(t devtest.T) error {
 	invalidInitMsg := ie.makeInvalidFns.Get()(ie.validInitMsg)
-	execMsg := planExecMsg(t, &invalidInitMsg, ie.l2.BlockTime, ie.l2.EL.Escape().EthClient())
+	execMsg := planExecMsg(t, &invalidInitMsg)
 	if _, err := ie.eoa.Include(t, execMsg); err == nil {
 		t.Require().Failf("included invalid executing message", "message: %v", invalidInitMsg)
 	} else if !strings.Contains(err.Error(), core.ErrTxFilteredOut.Error()) { // TODO(13408): we should be able to use errors.Is.

--- a/op-acceptance-tests/tests/interop/loadtest/max_execute_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/max_execute_test.go
@@ -74,7 +74,7 @@ func (e *ExecMsgSpammer) Spam(t devtest.T) error {
 	// Get an initiating message from the source and execute it.
 	initMsg := e.source.Get()
 	start := time.Now()
-	tx, err := e.l2.Include(t, planExecMsg(t, initMsg, e.l2.BlockTime, e.l2.EL.Escape().EthClient()))
+	tx, err := e.l2.Include(t, planExecMsg(t, initMsg))
 	if err != nil {
 		return fmt.Errorf("include exec msg: %w", err)
 	}

--- a/op-acceptance-tests/tests/interop/loadtest/relay_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/relay_test.go
@@ -41,7 +41,7 @@ func (r *RelaySpammer) Spam(t devtest.T) error {
 	}
 
 	startExec := time.Now()
-	if _, err = r.dest.Include(t, planExecMsg(t, initMsg, r.dest.BlockTime, r.dest.EL.Escape().EthClient())); err != nil {
+	if _, err = r.dest.Include(t, planExecMsg(t, initMsg)); err != nil {
 		return err
 	}
 	endExec := time.Now()

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -283,7 +283,6 @@ func TestInitExecMultipleMsg(gt *testing.T) {
 	// Two events in tx so use every index
 	indexes := []int{0, 1}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
-	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)
@@ -326,7 +325,6 @@ func TestExecSameMsgTwice(gt *testing.T) {
 	// Single event in tx so indexes are 0, 0
 	indexes := []int{0, 0}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
-	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)
@@ -379,7 +377,6 @@ func TestExecDifferentTopicCount(gt *testing.T) {
 	// Five events in tx so use every index
 	indexes := []int{0, 1, 2, 3, 4}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
-	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)
@@ -430,7 +427,6 @@ func TestExecMsgOpaqueData(gt *testing.T) {
 	// Two events in tx so use every index
 	indexes := []int{0, 1}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
-	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)
@@ -479,7 +475,6 @@ func TestExecMsgDifferEventIndexInSingleTx(gt *testing.T) {
 	// first, random or last event of a tx.
 	indexes := []int{0, 1 + rng.Intn(eventCnt-1), eventCnt - 1}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
-	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)
@@ -607,8 +602,11 @@ func TestExecMessageInvalidAttributes(gt *testing.T) {
 
 	for _, faults := range faultsLists {
 		logger.Info("Attempt to validate message with invalid attribute", "faults", faults)
-		// Intent to validate message on chain B
-		txC := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](chuck.Plan())
+		// Intent to validate message on chain B.
+		// The identifiers are fabricated, so their timestamps do not describe a block chain A will
+		// ever build. There is nothing to wait for, and randomTimestamp is unreachable.
+		txC := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
+			chuck.Plan(), txintent.WithoutInteropDependencyWait())
 		txC.Content.DependOn(&txA.Result)
 
 		// Random select event index in tx for injecting faults
@@ -636,7 +634,6 @@ func TestExecMessageInvalidAttributes(gt *testing.T) {
 	// Three events in tx so use every index
 	indexes := []int{0, 1, 2}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
-	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -283,6 +283,7 @@ func TestInitExecMultipleMsg(gt *testing.T) {
 	// Two events in tx so use every index
 	indexes := []int{0, 1}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
+	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)
@@ -325,6 +326,7 @@ func TestExecSameMsgTwice(gt *testing.T) {
 	// Single event in tx so indexes are 0, 0
 	indexes := []int{0, 0}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
+	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)
@@ -377,6 +379,7 @@ func TestExecDifferentTopicCount(gt *testing.T) {
 	// Five events in tx so use every index
 	indexes := []int{0, 1, 2, 3, 4}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
+	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)
@@ -427,6 +430,7 @@ func TestExecMsgOpaqueData(gt *testing.T) {
 	// Two events in tx so use every index
 	indexes := []int{0, 1}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
+	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)
@@ -475,6 +479,7 @@ func TestExecMsgDifferEventIndexInSingleTx(gt *testing.T) {
 	// first, random or last event of a tx.
 	indexes := []int{0, 1 + rng.Intn(eventCnt-1), eventCnt - 1}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
+	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)
@@ -631,6 +636,7 @@ func TestExecMessageInvalidAttributes(gt *testing.T) {
 	// Three events in tx so use every index
 	indexes := []int{0, 1, 2}
 	txB.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &txA.Result, indexes))
+	bob.WaitForInitMessages(&txA.Result)
 
 	receiptB, err := txB.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(err)

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -603,8 +603,7 @@ func TestExecMessageInvalidAttributes(gt *testing.T) {
 	for _, faults := range faultsLists {
 		logger.Info("Attempt to validate message with invalid attribute", "faults", faults)
 		// Intent to validate message on chain B.
-		// The identifiers are fabricated, so their timestamps do not describe a block chain A will
-		// ever build. There is nothing to wait for, and randomTimestamp is unreachable.
+		// The identifiers are fabricated, so their timestamps name blocks chain A will never build.
 		txC := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
 			chuck.Plan(), txintent.WithoutInteropDependencyWait())
 		txC.Content.DependOn(&txA.Result)

--- a/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
@@ -100,7 +100,6 @@ func TestReorgInitExecMsg(gt *testing.T) {
 		execTx.Content.DependOn(&initTx.Result)
 		// single event in tx so index is 0. ExecuteIndexed returns a lambda to transform InteropOutput to a new ExecTrigger
 		execTx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initTx.Result, 0))
-		bob.WaitForInitMessages(&initTx.Result)
 		var err error
 		execReceipt, err = execTx.PlannedTx.Included.Eval(ctx)
 		require.NoError(t, err)

--- a/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
@@ -100,6 +100,7 @@ func TestReorgInitExecMsg(gt *testing.T) {
 		execTx.Content.DependOn(&initTx.Result)
 		// single event in tx so index is 0. ExecuteIndexed returns a lambda to transform InteropOutput to a new ExecTrigger
 		execTx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initTx.Result, 0))
+		bob.WaitForInitMessages(&initTx.Result)
 		var err error
 		execReceipt, err = execTx.PlannedTx.Included.Eval(ctx)
 		require.NoError(t, err)

--- a/op-chain-ops/interopbridge/bridge.go
+++ b/op-chain-ops/interopbridge/bridge.go
@@ -9,6 +9,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -27,6 +28,10 @@ import (
 // is the caller's context deadline; this is just large enough not to give up
 // before that deadline ends the retries.
 const maxRelayRetries = 1024
+
+// headPollInterval is how often the destination head is re-read while waiting for it to reach
+// the messages a tx executes.
+const headPollInterval = time.Second
 
 // sendETHFn is the SuperchainETHBridge.sendETH(to, chainId) entrypoint.
 var sendETHFn = w3.MustNewFunc("sendETH(address,uint256)", "bytes32")
@@ -63,7 +68,29 @@ func BridgePlan(cl apis.EthClient, key *ecdsa.PrivateKey) txplan.Option {
 		txplan.WithRetrySubmission(cl, maxRelayRetries, retry.Exponential()),
 		txplan.WithRetryInclusion(cl, maxRelayRetries, retry.Exponential()),
 		txplan.WithBlockInclusionInfo(cl),
+		txintent.WithInteropDependencyWait(awaitTime(cl)),
 	)
+}
+
+// awaitTime blocks until the chain's unsafe head reaches minTime. Head lookups fail transiently
+// on a live chain, so a failure is only reported if the head never reaches minTime.
+func awaitTime(cl apis.EthBlockRef) txintent.AwaitTimeFn {
+	return func(ctx context.Context, minTime uint64) error {
+		for {
+			head, err := cl.BlockRefByLabel(ctx, eth.Unsafe)
+			if err == nil && head.Time >= minTime {
+				return nil
+			}
+			select {
+			case <-ctx.Done():
+				if err != nil {
+					return fmt.Errorf("head lookup failed: %w: %w", err, ctx.Err())
+				}
+				return fmt.Errorf("head is %d at timestamp %d: %w", head.Number, head.Time, ctx.Err())
+			case <-time.After(headPollInterval):
+			}
+		}
+	}
 }
 
 // BridgeETH sends amount of ETH from key's account on src to recipient on dst via

--- a/op-chain-ops/interopbridge/bridge_test.go
+++ b/op-chain-ops/interopbridge/bridge_test.go
@@ -1,0 +1,71 @@
+package interopbridge
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// stubBlockRefs replies to head lookups with the next scripted result.
+type stubBlockRefs struct {
+	results []stubHead
+	calls   int
+}
+
+type stubHead struct {
+	time uint64
+	err  error
+}
+
+func (s *stubBlockRefs) BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockRef, error) {
+	next := s.results[min(s.calls, len(s.results)-1)]
+	s.calls++
+	if next.err != nil {
+		return eth.BlockRef{}, next.err
+	}
+	return eth.BlockRef{Number: uint64(s.calls), Time: next.time}, nil
+}
+
+func (s *stubBlockRefs) BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error) {
+	panic("not used")
+}
+
+func (s *stubBlockRefs) BlockRefByHash(ctx context.Context, hash common.Hash) (eth.BlockRef, error) {
+	panic("not used")
+}
+
+func TestAwaitTime(t *testing.T) {
+	t.Run("returns once the head reaches the time", func(t *testing.T) {
+		cl := &stubBlockRefs{results: []stubHead{{time: 99}, {time: 100}}}
+		require.NoError(t, awaitTime(cl)(context.Background(), 100))
+		require.Equal(t, 2, cl.calls)
+	})
+
+	t.Run("keeps waiting after a lookup failure", func(t *testing.T) {
+		cl := &stubBlockRefs{results: []stubHead{{err: errors.New("no reply")}, {time: 100}}}
+		require.NoError(t, awaitTime(cl)(context.Background(), 100))
+		require.Equal(t, 2, cl.calls)
+	})
+
+	t.Run("reports the head it was still waiting on", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := awaitTime(&stubBlockRefs{results: []stubHead{{time: 99}}})(ctx, 100)
+		require.ErrorIs(t, err, context.Canceled)
+		require.ErrorContains(t, err, "timestamp 99")
+	})
+
+	t.Run("reports the lookup failure it was still retrying", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		lookupErr := errors.New("no reply")
+		err := awaitTime(&stubBlockRefs{results: []stubHead{{err: lookupErr}}})(ctx, 100)
+		require.ErrorIs(t, err, lookupErr)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}

--- a/op-chain-ops/interopsmoke/smoke.go
+++ b/op-chain-ops/interopsmoke/smoke.go
@@ -180,7 +180,6 @@ func (u *remoteUser) plan() txplan.Option {
 		txplan.WithRetrySubmission(u.chain.ethClient, 5, retry.Exponential()),
 		txplan.WithRetryInclusion(u.chain.ethClient, 5, retry.Exponential()),
 		txplan.WithBlockInclusionInfo(u.chain.ethClient),
-		// Must come after WithAgainstLatestBlock, which it wraps.
 		txintent.WithInteropDependencyWait(u.waitForTime),
 	)
 }
@@ -237,7 +236,6 @@ func (u *remoteUser) sendRandomInitMessage(ctx context.Context, rng *rand.Rand, 
 	return &initMessage{Tx: tx, Receipt: receipt}, nil
 }
 
-// waitForTime waits for this chain to build a block with a timestamp of at least minTime.
 func (u *remoteUser) waitForTime(ctx context.Context, minTime uint64) error {
 	return waitForHead(ctx, u.chain, fmt.Sprintf("timestamp >= %d", minTime), func(head eth.BlockRef) bool {
 		return head.Time >= minTime
@@ -1276,8 +1274,8 @@ func waitForHeadAtLeast(ctx context.Context, chain *remoteChain, target uint64) 
 	})
 }
 
-// waitForHead polls the unsafe head until ready accepts it. A failed lookup is treated as
-// transient — these are live chains — and only reported if the head never becomes ready.
+// waitForHead polls the unsafe head until ready accepts it. Lookup failures are transient on a
+// live chain, so they are only reported if the head never becomes ready.
 func waitForHead(ctx context.Context, chain *remoteChain, want string, ready func(eth.BlockRef) bool) error {
 	deadline := time.Now().Add(smokeWaitTimeout)
 	for {

--- a/op-chain-ops/interopsmoke/smoke.go
+++ b/op-chain-ops/interopsmoke/smoke.go
@@ -180,6 +180,8 @@ func (u *remoteUser) plan() txplan.Option {
 		txplan.WithRetrySubmission(u.chain.ethClient, 5, retry.Exponential()),
 		txplan.WithRetryInclusion(u.chain.ethClient, 5, retry.Exponential()),
 		txplan.WithBlockInclusionInfo(u.chain.ethClient),
+		// Must come after WithAgainstLatestBlock, which it wraps.
+		txintent.WithInteropDependencyWait(u.waitForTime),
 	)
 }
 
@@ -235,16 +237,14 @@ func (u *remoteUser) sendRandomInitMessage(ctx context.Context, rng *rand.Rand, 
 	return &initMessage{Tx: tx, Receipt: receipt}, nil
 }
 
-// waitForTimestamp waits for this chain to build past the given timestamp. An executing message is
-// invalid when its block is not newer than the message it references, and op-geth filters pending
-// executing messages against the unsafe head.
-func (u *remoteUser) waitForTimestamp(ctx context.Context, timestamp uint64) error {
+// waitForTime waits for this chain to build a block with a timestamp of at least minTime.
+func (u *remoteUser) waitForTime(ctx context.Context, minTime uint64) error {
 	for {
 		head, err := u.chain.ethClient.InfoByLabel(ctx, eth.Unsafe)
 		if err != nil {
 			return fmt.Errorf("failed to get unsafe head of %s: %w", u.chain.name, err)
 		}
-		if head.Time() > timestamp {
+		if head.Time() >= minTime {
 			return nil
 		}
 		select {
@@ -256,17 +256,6 @@ func (u *remoteUser) waitForTimestamp(ctx context.Context, timestamp uint64) err
 }
 
 func (u *remoteUser) sendExecMessage(ctx context.Context, initMsg *initMessage) (*execMessage, error) {
-	result, err := initMsg.Tx.Result.Eval(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if len(result.Entries) == 0 {
-		return nil, fmt.Errorf("init tx produced no interop entries")
-	}
-	if err := u.waitForTimestamp(ctx, result.Entries[0].Identifier.Timestamp); err != nil {
-		return nil, err
-	}
-
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)
 	tx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initMsg.Tx.Result, 0))
@@ -292,9 +281,6 @@ func (u *remoteUser) sendInvalidExecMessage(ctx context.Context, initMsg *initMe
 
 	msg := result.Entries[0]
 	msg.Identifier.LogIndex++
-	if err := u.waitForTimestamp(ctx, msg.Identifier.Timestamp); err != nil {
-		return nil, err
-	}
 
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)

--- a/op-chain-ops/interopsmoke/smoke.go
+++ b/op-chain-ops/interopsmoke/smoke.go
@@ -1276,9 +1276,8 @@ func waitForHeadAtLeast(ctx context.Context, chain *remoteChain, target uint64) 
 	})
 }
 
-// waitForHead polls the unsafe head of the chain until ready accepts it. A failure to read the head
-// is transient by assumption: these are live chains, so it is retried until the timeout, and only
-// reported if the head never became ready.
+// waitForHead polls the unsafe head until ready accepts it. A failed lookup is treated as
+// transient — these are live chains — and only reported if the head never becomes ready.
 func waitForHead(ctx context.Context, chain *remoteChain, want string, ready func(eth.BlockRef) bool) error {
 	deadline := time.Now().Add(smokeWaitTimeout)
 	for {

--- a/op-chain-ops/interopsmoke/smoke.go
+++ b/op-chain-ops/interopsmoke/smoke.go
@@ -235,7 +235,38 @@ func (u *remoteUser) sendRandomInitMessage(ctx context.Context, rng *rand.Rand, 
 	return &initMessage{Tx: tx, Receipt: receipt}, nil
 }
 
+// waitForTimestamp waits for this chain to build past the given timestamp. An executing message is
+// invalid when its block is not newer than the message it references, and op-geth filters pending
+// executing messages against the unsafe head.
+func (u *remoteUser) waitForTimestamp(ctx context.Context, timestamp uint64) error {
+	for {
+		head, err := u.chain.ethClient.InfoByLabel(ctx, eth.Unsafe)
+		if err != nil {
+			return fmt.Errorf("failed to get unsafe head of %s: %w", u.chain.name, err)
+		}
+		if head.Time() > timestamp {
+			return nil
+		}
+		select {
+		case <-time.After(250 * time.Millisecond):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
 func (u *remoteUser) sendExecMessage(ctx context.Context, initMsg *initMessage) (*execMessage, error) {
+	result, err := initMsg.Tx.Result.Eval(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(result.Entries) == 0 {
+		return nil, fmt.Errorf("init tx produced no interop entries")
+	}
+	if err := u.waitForTimestamp(ctx, result.Entries[0].Identifier.Timestamp); err != nil {
+		return nil, err
+	}
+
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)
 	tx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initMsg.Tx.Result, 0))
@@ -261,6 +292,9 @@ func (u *remoteUser) sendInvalidExecMessage(ctx context.Context, initMsg *initMe
 
 	msg := result.Entries[0]
 	msg.Identifier.LogIndex++
+	if err := u.waitForTimestamp(ctx, msg.Identifier.Timestamp); err != nil {
+		return nil, err
+	}
 
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)

--- a/op-chain-ops/interopsmoke/smoke.go
+++ b/op-chain-ops/interopsmoke/smoke.go
@@ -239,20 +239,9 @@ func (u *remoteUser) sendRandomInitMessage(ctx context.Context, rng *rand.Rand, 
 
 // waitForTime waits for this chain to build a block with a timestamp of at least minTime.
 func (u *remoteUser) waitForTime(ctx context.Context, minTime uint64) error {
-	for {
-		head, err := u.chain.ethClient.InfoByLabel(ctx, eth.Unsafe)
-		if err != nil {
-			return fmt.Errorf("failed to get unsafe head of %s: %w", u.chain.name, err)
-		}
-		if head.Time() >= minTime {
-			return nil
-		}
-		select {
-		case <-time.After(250 * time.Millisecond):
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
+	return waitForHead(ctx, u.chain, fmt.Sprintf("timestamp >= %d", minTime), func(head eth.BlockRef) bool {
+		return head.Time >= minTime
+	})
 }
 
 func (u *remoteUser) sendExecMessage(ctx context.Context, initMsg *initMessage) (*execMessage, error) {
@@ -1282,10 +1271,19 @@ func waitForNextBlock(ctx context.Context, chain *remoteChain) (eth.BlockRef, er
 }
 
 func waitForHeadAtLeast(ctx context.Context, chain *remoteChain, target uint64) error {
+	return waitForHead(ctx, chain, fmt.Sprintf("head >= %d", target), func(head eth.BlockRef) bool {
+		return head.Number >= target
+	})
+}
+
+// waitForHead polls the unsafe head of the chain until ready accepts it. A failure to read the head
+// is transient by assumption: these are live chains, so it is retried until the timeout, and only
+// reported if the head never became ready.
+func waitForHead(ctx context.Context, chain *remoteChain, want string, ready func(eth.BlockRef) bool) error {
 	deadline := time.Now().Add(smokeWaitTimeout)
 	for {
 		head, err := chain.ethClient.BlockRefByLabel(ctx, eth.Unsafe)
-		if err == nil && head.Number >= target {
+		if err == nil && ready(head) {
 			return nil
 		}
 		if err := ctx.Err(); err != nil {
@@ -1293,9 +1291,10 @@ func waitForHeadAtLeast(ctx context.Context, chain *remoteChain, target uint64) 
 		}
 		if time.Now().After(deadline) {
 			if err != nil {
-				return fmt.Errorf("timed out waiting for %s head >= %d: %w", chain.name, target, err)
+				return fmt.Errorf("timed out waiting for %s %s: %w", chain.name, want, err)
 			}
-			return fmt.Errorf("timed out waiting for %s head >= %d; current head is %d", chain.name, target, head.Number)
+			return fmt.Errorf("timed out waiting for %s %s; head is %d at timestamp %d",
+				chain.name, want, head.Number, head.Time)
 		}
 		time.Sleep(time.Second)
 	}

--- a/op-chain-ops/interopsmoke/smoke.go
+++ b/op-chain-ops/interopsmoke/smoke.go
@@ -202,20 +202,9 @@ func (u *remoteUser) sendRandomInitMessage(ctx context.Context, rng *rand.Rand, 
 
 // waitForTime waits for this chain to build a block with a timestamp of at least minTime.
 func (u *remoteUser) waitForTime(ctx context.Context, minTime uint64) error {
-	for {
-		head, err := u.chain.ethClient.InfoByLabel(ctx, eth.Unsafe)
-		if err != nil {
-			return fmt.Errorf("failed to get unsafe head of %s: %w", u.chain.name, err)
-		}
-		if head.Time() >= minTime {
-			return nil
-		}
-		select {
-		case <-time.After(250 * time.Millisecond):
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
+	return waitForHead(ctx, u.chain, fmt.Sprintf("timestamp >= %d", minTime), func(head eth.BlockRef) bool {
+		return head.Time >= minTime
+	})
 }
 
 func (u *remoteUser) sendExecMessage(ctx context.Context, initMsg *initMessage) (*execMessage, error) {
@@ -681,10 +670,19 @@ func waitForNextBlock(ctx context.Context, chain *remoteChain) (eth.BlockRef, er
 }
 
 func waitForHeadAtLeast(ctx context.Context, chain *remoteChain, target uint64) error {
+	return waitForHead(ctx, chain, fmt.Sprintf("head >= %d", target), func(head eth.BlockRef) bool {
+		return head.Number >= target
+	})
+}
+
+// waitForHead polls the unsafe head of the chain until ready accepts it. A failure to read the head
+// is transient by assumption: these are live chains, so it is retried until the timeout, and only
+// reported if the head never became ready.
+func waitForHead(ctx context.Context, chain *remoteChain, want string, ready func(eth.BlockRef) bool) error {
 	deadline := time.Now().Add(smokeWaitTimeout)
 	for {
 		head, err := chain.ethClient.BlockRefByLabel(ctx, eth.Unsafe)
-		if err == nil && head.Number >= target {
+		if err == nil && ready(head) {
 			return nil
 		}
 		if err := ctx.Err(); err != nil {
@@ -692,9 +690,10 @@ func waitForHeadAtLeast(ctx context.Context, chain *remoteChain, target uint64) 
 		}
 		if time.Now().After(deadline) {
 			if err != nil {
-				return fmt.Errorf("timed out waiting for %s head >= %d: %w", chain.name, target, err)
+				return fmt.Errorf("timed out waiting for %s %s: %w", chain.name, want, err)
 			}
-			return fmt.Errorf("timed out waiting for %s head >= %d; current head is %d", chain.name, target, head.Number)
+			return fmt.Errorf("timed out waiting for %s %s; head is %d at timestamp %d",
+				chain.name, want, head.Number, head.Time)
 		}
 		time.Sleep(time.Second)
 	}

--- a/op-chain-ops/interopsmoke/smoke.go
+++ b/op-chain-ops/interopsmoke/smoke.go
@@ -675,9 +675,8 @@ func waitForHeadAtLeast(ctx context.Context, chain *remoteChain, target uint64) 
 	})
 }
 
-// waitForHead polls the unsafe head of the chain until ready accepts it. A failure to read the head
-// is transient by assumption: these are live chains, so it is retried until the timeout, and only
-// reported if the head never became ready.
+// waitForHead polls the unsafe head until ready accepts it. A failed lookup is treated as
+// transient — these are live chains — and only reported if the head never becomes ready.
 func waitForHead(ctx context.Context, chain *remoteChain, want string, ready func(eth.BlockRef) bool) error {
 	deadline := time.Now().Add(smokeWaitTimeout)
 	for {

--- a/op-chain-ops/interopsmoke/smoke.go
+++ b/op-chain-ops/interopsmoke/smoke.go
@@ -143,6 +143,8 @@ func (u *remoteUser) plan() txplan.Option {
 		txplan.WithRetrySubmission(u.chain.ethClient, 5, retry.Exponential()),
 		txplan.WithRetryInclusion(u.chain.ethClient, 5, retry.Exponential()),
 		txplan.WithBlockInclusionInfo(u.chain.ethClient),
+		// Must come after WithAgainstLatestBlock, which it wraps.
+		txintent.WithInteropDependencyWait(u.waitForTime),
 	)
 }
 
@@ -198,16 +200,14 @@ func (u *remoteUser) sendRandomInitMessage(ctx context.Context, rng *rand.Rand, 
 	return &initMessage{Tx: tx, Receipt: receipt}, nil
 }
 
-// waitForTimestamp waits for this chain to build past the given timestamp. An executing message is
-// invalid when its block is not newer than the message it references, and op-geth filters pending
-// executing messages against the unsafe head.
-func (u *remoteUser) waitForTimestamp(ctx context.Context, timestamp uint64) error {
+// waitForTime waits for this chain to build a block with a timestamp of at least minTime.
+func (u *remoteUser) waitForTime(ctx context.Context, minTime uint64) error {
 	for {
 		head, err := u.chain.ethClient.InfoByLabel(ctx, eth.Unsafe)
 		if err != nil {
 			return fmt.Errorf("failed to get unsafe head of %s: %w", u.chain.name, err)
 		}
-		if head.Time() > timestamp {
+		if head.Time() >= minTime {
 			return nil
 		}
 		select {
@@ -219,17 +219,6 @@ func (u *remoteUser) waitForTimestamp(ctx context.Context, timestamp uint64) err
 }
 
 func (u *remoteUser) sendExecMessage(ctx context.Context, initMsg *initMessage) (*execMessage, error) {
-	result, err := initMsg.Tx.Result.Eval(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if len(result.Entries) == 0 {
-		return nil, fmt.Errorf("init tx produced no interop entries")
-	}
-	if err := u.waitForTimestamp(ctx, result.Entries[0].Identifier.Timestamp); err != nil {
-		return nil, err
-	}
-
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)
 	tx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initMsg.Tx.Result, 0))
@@ -255,9 +244,6 @@ func (u *remoteUser) sendInvalidExecMessage(ctx context.Context, initMsg *initMe
 
 	msg := result.Entries[0]
 	msg.Identifier.LogIndex++
-	if err := u.waitForTimestamp(ctx, msg.Identifier.Timestamp); err != nil {
-		return nil, err
-	}
 
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)

--- a/op-chain-ops/interopsmoke/smoke.go
+++ b/op-chain-ops/interopsmoke/smoke.go
@@ -198,7 +198,38 @@ func (u *remoteUser) sendRandomInitMessage(ctx context.Context, rng *rand.Rand, 
 	return &initMessage{Tx: tx, Receipt: receipt}, nil
 }
 
+// waitForTimestamp waits for this chain to build past the given timestamp. An executing message is
+// invalid when its block is not newer than the message it references, and op-geth filters pending
+// executing messages against the unsafe head.
+func (u *remoteUser) waitForTimestamp(ctx context.Context, timestamp uint64) error {
+	for {
+		head, err := u.chain.ethClient.InfoByLabel(ctx, eth.Unsafe)
+		if err != nil {
+			return fmt.Errorf("failed to get unsafe head of %s: %w", u.chain.name, err)
+		}
+		if head.Time() > timestamp {
+			return nil
+		}
+		select {
+		case <-time.After(250 * time.Millisecond):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
 func (u *remoteUser) sendExecMessage(ctx context.Context, initMsg *initMessage) (*execMessage, error) {
+	result, err := initMsg.Tx.Result.Eval(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(result.Entries) == 0 {
+		return nil, fmt.Errorf("init tx produced no interop entries")
+	}
+	if err := u.waitForTimestamp(ctx, result.Entries[0].Identifier.Timestamp); err != nil {
+		return nil, err
+	}
+
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)
 	tx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initMsg.Tx.Result, 0))
@@ -224,6 +255,9 @@ func (u *remoteUser) sendInvalidExecMessage(ctx context.Context, initMsg *initMe
 
 	msg := result.Entries[0]
 	msg.Identifier.LogIndex++
+	if err := u.waitForTimestamp(ctx, msg.Identifier.Timestamp); err != nil {
+		return nil, err
+	}
 
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)

--- a/op-chain-ops/interopsmoke/smoke_test.go
+++ b/op-chain-ops/interopsmoke/smoke_test.go
@@ -1,10 +1,17 @@
 package interopsmoke
 
 import (
+	"context"
+	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 func TestValidateInvalidMessageOptions(t *testing.T) {
@@ -83,4 +90,45 @@ func TestFirstLogFrom(t *testing.T) {
 	if got := firstLogFrom(nil, eventLogger); got != -1 {
 		t.Fatalf("no logs = %d, want -1", got)
 	}
+}
+
+// stubEthClient answers BlockRefByLabel from refs. Every other method panics on a nil interface,
+// which keeps the stub honest: waitForHead must not reach for anything else.
+type stubEthClient struct {
+	apis.EthClient
+	refs func() (eth.BlockRef, error)
+}
+
+func (s *stubEthClient) BlockRefByLabel(context.Context, eth.BlockLabel) (eth.BlockRef, error) {
+	return s.refs()
+}
+
+func TestWaitForHead(t *testing.T) {
+	atTime := func(minTime uint64) func(eth.BlockRef) bool {
+		return func(head eth.BlockRef) bool { return head.Time >= minTime }
+	}
+
+	t.Run("retries a failed head lookup", func(t *testing.T) {
+		calls := 0
+		chain := &remoteChain{name: "chainA", ethClient: &stubEthClient{refs: func() (eth.BlockRef, error) {
+			calls++
+			if calls == 1 {
+				return eth.BlockRef{}, errors.New("transient rpc failure")
+			}
+			return eth.BlockRef{Number: 2, Time: 20}, nil
+		}}}
+
+		require.NoError(t, waitForHead(context.Background(), chain, "timestamp >= 20", atTime(20)))
+		require.Equal(t, 2, calls, "should have retried past the failure")
+	})
+
+	t.Run("returns the context error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		chain := &remoteChain{name: "chainA", ethClient: &stubEthClient{refs: func() (eth.BlockRef, error) {
+			cancel()
+			return eth.BlockRef{}, errors.New("transient rpc failure")
+		}}}
+
+		require.ErrorIs(t, waitForHead(ctx, chain, "timestamp >= 20", atTime(20)), context.Canceled)
+	})
 }

--- a/op-chain-ops/interopsmoke/smoke_test.go
+++ b/op-chain-ops/interopsmoke/smoke_test.go
@@ -92,8 +92,7 @@ func TestFirstLogFrom(t *testing.T) {
 	}
 }
 
-// stubEthClient answers BlockRefByLabel from refs. Every other method panics on a nil interface,
-// which keeps the stub honest: waitForHead must not reach for anything else.
+// stubEthClient answers BlockRefByLabel from refs; every other method nil-panics.
 type stubEthClient struct {
 	apis.EthClient
 	refs func() (eth.BlockRef, error)

--- a/op-chain-ops/interopsmoke/smoke_test.go
+++ b/op-chain-ops/interopsmoke/smoke_test.go
@@ -29,8 +29,7 @@ func TestValidateInvalidMessageOptions(t *testing.T) {
 	}
 }
 
-// stubEthClient answers BlockRefByLabel from refs. Every other method panics on a nil interface,
-// which keeps the stub honest: waitForHead must not reach for anything else.
+// stubEthClient answers BlockRefByLabel from refs; every other method nil-panics.
 type stubEthClient struct {
 	apis.EthClient
 	refs func() (eth.BlockRef, error)

--- a/op-chain-ops/interopsmoke/smoke_test.go
+++ b/op-chain-ops/interopsmoke/smoke_test.go
@@ -1,6 +1,15 @@
 package interopsmoke
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
 
 func TestValidateInvalidMessageOptions(t *testing.T) {
 	for _, tc := range []struct {
@@ -18,4 +27,45 @@ func TestValidateInvalidMessageOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+// stubEthClient answers BlockRefByLabel from refs. Every other method panics on a nil interface,
+// which keeps the stub honest: waitForHead must not reach for anything else.
+type stubEthClient struct {
+	apis.EthClient
+	refs func() (eth.BlockRef, error)
+}
+
+func (s *stubEthClient) BlockRefByLabel(context.Context, eth.BlockLabel) (eth.BlockRef, error) {
+	return s.refs()
+}
+
+func TestWaitForHead(t *testing.T) {
+	atTime := func(minTime uint64) func(eth.BlockRef) bool {
+		return func(head eth.BlockRef) bool { return head.Time >= minTime }
+	}
+
+	t.Run("retries a failed head lookup", func(t *testing.T) {
+		calls := 0
+		chain := &remoteChain{name: "chainA", ethClient: &stubEthClient{refs: func() (eth.BlockRef, error) {
+			calls++
+			if calls == 1 {
+				return eth.BlockRef{}, errors.New("transient rpc failure")
+			}
+			return eth.BlockRef{Number: 2, Time: 20}, nil
+		}}}
+
+		require.NoError(t, waitForHead(context.Background(), chain, "timestamp >= 20", atTime(20)))
+		require.Equal(t, 2, calls, "should have retried past the failure")
+	})
+
+	t.Run("returns the context error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		chain := &remoteChain{name: "chainA", ethClient: &stubEthClient{refs: func() (eth.BlockRef, error) {
+			cancel()
+			return eth.BlockRef{}, errors.New("transient rpc failure")
+		}}}
+
+		require.ErrorIs(t, waitForHead(ctx, chain, "timestamp >= 20", atTime(20)), context.Canceled)
+	})
 }

--- a/op-core/interop/messages/messages.go
+++ b/op-core/interop/messages/messages.go
@@ -495,21 +495,25 @@ func EncodeAccessList(accesses []Access) []common.Hash {
 
 // DecodeAccessList returns the accesses a transaction declares, i.e. the messages it executes.
 // Entries for any address other than the CrossL2Inbox are not accesses, and are ignored.
+//
+// The CrossL2Inbox entries form one stream, as the node reads them: an access may be split across
+// duplicate CrossL2Inbox tuples, so the tuples are concatenated in order before being parsed.
 func DecodeAccessList(accessList ethTypes.AccessList) ([]Access, error) {
-	var out []Access
+	var entries []common.Hash
 	for _, tuple := range accessList {
 		if tuple.Address != predeploys.CrossL2InboxAddr {
 			continue
 		}
-		entries := tuple.StorageKeys
-		for len(entries) > 0 {
-			remaining, access, err := ParseAccess(entries)
-			if err != nil {
-				return nil, err
-			}
-			entries = remaining
-			out = append(out, access)
+		entries = append(entries, tuple.StorageKeys...)
+	}
+	var out []Access
+	for len(entries) > 0 {
+		remaining, access, err := ParseAccess(entries)
+		if err != nil {
+			return nil, err
 		}
+		entries = remaining
+		out = append(out, access)
 	}
 	return out, nil
 }

--- a/op-core/interop/messages/messages.go
+++ b/op-core/interop/messages/messages.go
@@ -14,6 +14,7 @@ import (
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -490,4 +491,25 @@ func EncodeAccessList(accesses []Access) []common.Hash {
 		out = append(out, common.Hash(acc.Checksum))
 	}
 	return out
+}
+
+// DecodeAccessList returns the accesses a transaction declares, i.e. the messages it executes.
+// Entries for any address other than the CrossL2Inbox are not accesses, and are ignored.
+func DecodeAccessList(accessList ethTypes.AccessList) ([]Access, error) {
+	var out []Access
+	for _, tuple := range accessList {
+		if tuple.Address != predeploys.CrossL2InboxAddr {
+			continue
+		}
+		entries := tuple.StorageKeys
+		for len(entries) > 0 {
+			remaining, access, err := ParseAccess(entries)
+			if err != nil {
+				return nil, err
+			}
+			entries = remaining
+			out = append(out, access)
+		}
+	}
+	return out, nil
 }

--- a/op-core/interop/messages/messages_test.go
+++ b/op-core/interop/messages/messages_test.go
@@ -3,6 +3,7 @@ package messages
 import (
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -597,6 +598,21 @@ func TestDecodeAccessList(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, accesses, result)
+	})
+
+	t.Run("split across tuples", func(t *testing.T) {
+		entries := EncodeAccessList(accesses)
+		for split := 1; split < len(entries); split++ {
+			t.Run(fmt.Sprintf("after entry %d", split), func(t *testing.T) {
+				result, err := DecodeAccessList(ethTypes.AccessList{
+					{Address: predeploys.CrossL2InboxAddr, StorageKeys: entries[:split]},
+					{Address: common.Address{0xaa}, StorageKeys: []common.Hash{{0x01}}},
+					{Address: predeploys.CrossL2InboxAddr, StorageKeys: entries[split:]},
+				})
+				require.NoError(t, err)
+				require.Equal(t, accesses, result)
+			})
+		}
 	})
 
 	t.Run("ignores other addresses", func(t *testing.T) {

--- a/op-core/interop/messages/messages_test.go
+++ b/op-core/interop/messages/messages_test.go
@@ -572,3 +572,55 @@ func TestEncodeAccessList(t *testing.T) {
 		require.Equal(t, accObjects, result, "roundtrip of random entries should work")
 	})
 }
+
+func TestDecodeAccessList(t *testing.T) {
+	accesses := []Access{
+		{BlockNumber: testBlockNumber, Timestamp: testTimestamp, LogIndex: testLogIndex,
+			ChainID: testChainID, Checksum: MessageChecksum(testChecksum)},
+		{BlockNumber: testBlockNumber + 1, Timestamp: testTimestamp + 2, LogIndex: 0,
+			ChainID: eth.ChainIDFromBytes32([32]byte{0: 0xff}), Checksum: MessageChecksum(testChecksum)},
+	}
+
+	t.Run("roundtrip", func(t *testing.T) {
+		result, err := DecodeAccessList(ethTypes.AccessList{{
+			Address:     predeploys.CrossL2InboxAddr,
+			StorageKeys: EncodeAccessList(accesses),
+		}})
+		require.NoError(t, err)
+		require.Equal(t, accesses, result)
+	})
+
+	t.Run("across tuples", func(t *testing.T) {
+		result, err := DecodeAccessList(ethTypes.AccessList{
+			{Address: predeploys.CrossL2InboxAddr, StorageKeys: EncodeAccessList(accesses[:1])},
+			{Address: predeploys.CrossL2InboxAddr, StorageKeys: EncodeAccessList(accesses[1:])},
+		})
+		require.NoError(t, err)
+		require.Equal(t, accesses, result)
+	})
+
+	t.Run("ignores other addresses", func(t *testing.T) {
+		result, err := DecodeAccessList(ethTypes.AccessList{{
+			Address:     common.Address{0xaa},
+			StorageKeys: []common.Hash{{0x01}},
+		}})
+		require.NoError(t, err)
+		require.Empty(t, result)
+	})
+
+	t.Run("unknown entry type", func(t *testing.T) {
+		_, err := DecodeAccessList(ethTypes.AccessList{{
+			Address:     predeploys.CrossL2InboxAddr,
+			StorageKeys: []common.Hash{{0: 0x09}},
+		}})
+		require.ErrorIs(t, err, errUnexpectedEntryType)
+	})
+
+	t.Run("truncated", func(t *testing.T) {
+		_, err := DecodeAccessList(ethTypes.AccessList{{
+			Address:     predeploys.CrossL2InboxAddr,
+			StorageKeys: []common.Hash{{0: PrefixLookup}},
+		}})
+		require.ErrorIs(t, err, errExpectedEntry)
+	})
+}

--- a/op-devstack/dsl/el.go
+++ b/op-devstack/dsl/el.go
@@ -1,6 +1,7 @@
 package dsl
 
 import (
+	"context"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
@@ -11,6 +12,7 @@ import (
 type ELNode interface {
 	ChainID() eth.ChainID
 	WaitForTime(timestamp uint64) eth.BlockRef
+	AwaitTime(ctx context.Context, timestamp uint64) error
 	stackEL() stack.ELNode
 }
 
@@ -38,10 +40,19 @@ func (el *elNode) WaitForBlock() eth.BlockRef {
 }
 
 func (el *elNode) WaitForLabel(label eth.BlockLabel, predicate func(eth.BlockInfo) (bool, error)) eth.BlockInfo {
+	block, err := el.awaitLabel(el.ctx, label, predicate)
+	el.require.NoError(err, "Failed to find block")
+	return block
+}
+
+// awaitLabel is WaitForLabel for callers that must handle the failure themselves rather than fail
+// the test, e.g. a wait running inside a tx plan, where the caller treats a stuck chain as a
+// failure of that tx.
+func (el *elNode) awaitLabel(ctx context.Context, label eth.BlockLabel, predicate func(eth.BlockInfo) (bool, error)) (eth.BlockInfo, error) {
 	var block eth.BlockInfo
-	err := wait.For(el.ctx, 200*time.Millisecond, func() (bool, error) {
+	err := wait.For(ctx, 200*time.Millisecond, func() (bool, error) {
 		var err error
-		block, err = el.inner.EthClient().InfoByLabel(el.ctx, label)
+		block, err = el.inner.EthClient().InfoByLabel(ctx, label)
 		if err != nil {
 			return false, err
 		}
@@ -53,8 +64,7 @@ func (el *elNode) WaitForLabel(label eth.BlockLabel, predicate func(eth.BlockInf
 		}
 		return ok, err
 	})
-	el.require.NoError(err, "Failed to find block")
-	return block
+	return block, err
 }
 
 func (el *elNode) WaitForLabelRef(label eth.BlockLabel, predicate func(eth.BlockInfo) (bool, error)) eth.BlockRef {
@@ -110,9 +120,19 @@ func (el *elNode) waitForNextBlock(blocksFromNow uint64) eth.BlockRef {
 
 // WaitForTime waits until the chain has reached or surpassed the given timestamp.
 func (el *elNode) WaitForTime(timestamp uint64) eth.BlockRef {
-	return el.WaitForUnsafeRef(func(info eth.BlockInfo) (bool, error) {
+	return el.WaitForUnsafeRef(reachedTime(timestamp))
+}
+
+// AwaitTime is WaitForTime for callers that must handle the failure themselves. See awaitLabel.
+func (el *elNode) AwaitTime(ctx context.Context, timestamp uint64) error {
+	_, err := el.awaitLabel(ctx, eth.Unsafe, reachedTime(timestamp))
+	return err
+}
+
+func reachedTime(timestamp uint64) func(eth.BlockInfo) (bool, error) {
+	return func(info eth.BlockInfo) (bool, error) {
 		return info.Time() >= timestamp, nil
-	})
+	}
 }
 
 func (el *elNode) stackEL() stack.ELNode {

--- a/op-devstack/dsl/el.go
+++ b/op-devstack/dsl/el.go
@@ -2,6 +2,7 @@ package dsl
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
@@ -46,16 +47,21 @@ func (el *elNode) WaitForLabel(label eth.BlockLabel, predicate func(eth.BlockInf
 }
 
 // awaitLabel is WaitForLabel for callers that must handle the failure themselves rather than fail
-// the test, e.g. a wait running inside a tx plan, where the caller treats a stuck chain as a
-// failure of that tx.
+// the test.
 func (el *elNode) awaitLabel(ctx context.Context, label eth.BlockLabel, predicate func(eth.BlockInfo) (bool, error)) (eth.BlockInfo, error) {
 	var block eth.BlockInfo
+	var lastLookupErr error
 	err := wait.For(ctx, 200*time.Millisecond, func() (bool, error) {
-		var err error
-		block, err = el.inner.EthClient().InfoByLabel(ctx, label)
+		info, err := el.inner.EthClient().InfoByLabel(ctx, label)
 		if err != nil {
-			return false, err
+			// Transient against a live chain, so keep polling; only report it if the target is
+			// never reached.
+			lastLookupErr = err
+			el.log.Debug("Block lookup failed", "chain", el.ChainID(), "err", err)
+			return false, nil
 		}
+		lastLookupErr = nil
+		block = info
 		ok, err := predicate(block)
 		if ok {
 			el.log.Info("Target block reached", "chain", el.ChainID(), "block", eth.ToBlockID(block))
@@ -64,6 +70,9 @@ func (el *elNode) awaitLabel(ctx context.Context, label eth.BlockLabel, predicat
 		}
 		return ok, err
 	})
+	if err != nil && lastLookupErr != nil {
+		return block, fmt.Errorf("%w (last block lookup failed: %w)", err, lastLookupErr)
+	}
 	return block, err
 }
 

--- a/op-devstack/dsl/el.go
+++ b/op-devstack/dsl/el.go
@@ -10,6 +10,7 @@ import (
 
 type ELNode interface {
 	ChainID() eth.ChainID
+	WaitForTime(timestamp uint64) eth.BlockRef
 	stackEL() stack.ELNode
 }
 

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -14,6 +14,7 @@ import (
 	e2eBindings "github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/plan"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
@@ -322,11 +323,31 @@ func WithExpectRevert() ExecMessageOpt {
 	}
 }
 
+// WaitForInitMessages waits for this EOA's chain to reach the timestamp of the given initiating
+// messages. An executing message is invalid when its block is older than the message it
+// references, which happens whenever the destination chain lags the source chain.
+func (u *EOA) WaitForInitMessages(result *plan.Lazy[*txintent.InteropOutput]) {
+	out, err := result.Eval(u.ctx)
+	u.t.Require().NoError(err, "failed to evaluate init result")
+	u.waitForMessages(out.Entries)
+}
+
+func (u *EOA) waitForMessages(msgs []messages.Message) {
+	var timestamp uint64
+	for _, msg := range msgs {
+		timestamp = max(timestamp, msg.Identifier.Timestamp)
+	}
+	// Strictly newer: op-geth filters executing messages against the unsafe head timestamp rather
+	// than the pending block. See https://github.com/ethereum-optimism/op-geth/issues/603.
+	u.el.WaitForTime(timestamp + 1)
+}
+
 func (u *EOA) SendExecMessage(initMsg *InitMessage, opts ...ExecMessageOpt) *ExecMessage {
 	var cfg execMessageConfig
 	for _, o := range opts {
 		o(&cfg)
 	}
+	u.WaitForInitMessages(&initMsg.Tx.Result)
 	planOpts := append([]txplan.Option{u.Plan()}, cfg.txOpts...)
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](txplan.Combine(planOpts...))
 	tx.Content.DependOn(&initMsg.Tx.Result)
@@ -352,6 +373,7 @@ func (u *EOA) SendExecMessage(initMsg *InitMessage, opts ...ExecMessageOpt) *Exe
 // transaction bytes and tx hash. The raw bytes are suitable for injection via
 // TestSequencer.SequenceBlockWithTxs, bypassing mempool filtering.
 func (u *EOA) PrepareExecTx(initMsg *InitMessage) (rawTx []byte, txHash common.Hash) {
+	u.WaitForInitMessages(&initMsg.Tx.Result)
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.Plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)
 	tx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initMsg.Tx.Result, 0))
@@ -372,6 +394,7 @@ func (u *EOA) SendInvalidExecMessage(initMsg *InitMessage) *ExecMessage {
 	// Get the message and modify it to be invalid by incrementing the log index
 	msg := result.Entries[0]
 	msg.Identifier.LogIndex++
+	u.waitForMessages([]messages.Message{msg})
 
 	// Create the exec trigger with the invalid message
 	execTrigger := &txintent.ExecTrigger{
@@ -426,6 +449,7 @@ func (u *EOA) SendPackedExecMessages(dependOn *txintent.IntentTx[*txintent.Multi
 	for idx := range len(result.Entries) {
 		indexes = append(indexes, idx)
 	}
+	u.waitForMessages(result.Entries)
 	tx.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &dependOn.Result, indexes))
 	receipt, err := tx.PlannedTx.Included.Eval(u.ctx)
 	if err != nil {

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -14,7 +14,6 @@ import (
 	e2eBindings "github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/plan"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
@@ -151,6 +150,11 @@ func (u *EOA) Plan() txplan.Option {
 		txplan.WithRetrySubmission(elClient, 5, retry.Exponential()),
 		txplan.WithRetryInclusion(elClient, 5, retry.Exponential()),
 		txplan.WithBlockInclusionInfo(elClient),
+		// Must come after WithAgainstLatestBlock, which it wraps.
+		txintent.WithInteropDependencyWait(func(_ context.Context, minTime uint64) error {
+			u.el.WaitForTime(minTime)
+			return nil
+		}),
 	)
 }
 
@@ -323,31 +327,11 @@ func WithExpectRevert() ExecMessageOpt {
 	}
 }
 
-// WaitForInitMessages waits for this EOA's chain to reach the timestamp of the given initiating
-// messages. An executing message is invalid when its block is older than the message it
-// references, which happens whenever the destination chain lags the source chain.
-func (u *EOA) WaitForInitMessages(result *plan.Lazy[*txintent.InteropOutput]) {
-	out, err := result.Eval(u.ctx)
-	u.t.Require().NoError(err, "failed to evaluate init result")
-	u.waitForMessages(out.Entries)
-}
-
-func (u *EOA) waitForMessages(msgs []messages.Message) {
-	var timestamp uint64
-	for _, msg := range msgs {
-		timestamp = max(timestamp, msg.Identifier.Timestamp)
-	}
-	// Strictly newer: op-geth filters executing messages against the unsafe head timestamp rather
-	// than the pending block. See https://github.com/ethereum-optimism/op-geth/issues/603.
-	u.el.WaitForTime(timestamp + 1)
-}
-
 func (u *EOA) SendExecMessage(initMsg *InitMessage, opts ...ExecMessageOpt) *ExecMessage {
 	var cfg execMessageConfig
 	for _, o := range opts {
 		o(&cfg)
 	}
-	u.WaitForInitMessages(&initMsg.Tx.Result)
 	planOpts := append([]txplan.Option{u.Plan()}, cfg.txOpts...)
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](txplan.Combine(planOpts...))
 	tx.Content.DependOn(&initMsg.Tx.Result)
@@ -373,7 +357,6 @@ func (u *EOA) SendExecMessage(initMsg *InitMessage, opts ...ExecMessageOpt) *Exe
 // transaction bytes and tx hash. The raw bytes are suitable for injection via
 // TestSequencer.SequenceBlockWithTxs, bypassing mempool filtering.
 func (u *EOA) PrepareExecTx(initMsg *InitMessage) (rawTx []byte, txHash common.Hash) {
-	u.WaitForInitMessages(&initMsg.Tx.Result)
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.Plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)
 	tx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initMsg.Tx.Result, 0))
@@ -394,7 +377,6 @@ func (u *EOA) SendInvalidExecMessage(initMsg *InitMessage) *ExecMessage {
 	// Get the message and modify it to be invalid by incrementing the log index
 	msg := result.Entries[0]
 	msg.Identifier.LogIndex++
-	u.waitForMessages([]messages.Message{msg})
 
 	// Create the exec trigger with the invalid message
 	execTrigger := &txintent.ExecTrigger{
@@ -449,7 +431,6 @@ func (u *EOA) SendPackedExecMessages(dependOn *txintent.IntentTx[*txintent.Multi
 	for idx := range len(result.Entries) {
 		indexes = append(indexes, idx)
 	}
-	u.waitForMessages(result.Entries)
 	tx.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &dependOn.Result, indexes))
 	receipt, err := tx.PlannedTx.Included.Eval(u.ctx)
 	if err != nil {
@@ -589,8 +570,12 @@ func (p *SameTimestampPair) SubmitInit() *txplan.PlannedTx {
 // SubmitExecTo returns a planned exec transaction to the given EOA's chain,
 // referencing this init. The test harness assigns deterministic nonces and
 // includes the signed tx directly.
+//
+// The init is not on chain yet, so there is nothing to wait for: the referenced block is one the
+// harness has not sequenced, and waiting for it would block the tx that produces it.
 func (p *SameTimestampPair) SubmitExecTo(executor *EOA) *txplan.PlannedTx {
-	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](executor.Plan())
+	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
+		executor.Plan(), txintent.WithoutInteropDependencyWait())
 	tx.Content.Set(&txintent.ExecTrigger{
 		Executor: predeploys.CrossL2InboxAddr,
 		Msg:      p.Message,
@@ -605,7 +590,9 @@ func (p *SameTimestampPair) SubmitExecTo(executor *EOA) *txplan.PlannedTx {
 func (p *SameTimestampPair) SubmitInvalidExecTo(executor *EOA) *txplan.PlannedTx {
 	invalidMsg := MakeInvalidLogIndex(p.Message)
 
-	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](executor.Plan())
+	// See SubmitExecTo for why this does not wait for the referenced message.
+	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
+		executor.Plan(), txintent.WithoutInteropDependencyWait())
 	tx.Content.Set(&txintent.ExecTrigger{
 		Executor: predeploys.CrossL2InboxAddr,
 		Msg:      invalidMsg,
@@ -658,8 +645,11 @@ func PrecomputeExecEventMessage(
 // SubmitExecForMessage returns a planned exec transaction referencing the given message.
 // Unlike SameTimestampPair.SubmitExecTo, this can reference any message including
 // precomputed exec event messages for exec-referencing-exec chains.
+//
+// See SubmitExecTo for why this does not wait for the referenced message.
 func SubmitExecForMessage(msg messages.Message, executor *EOA) *txplan.PlannedTx {
-	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](executor.Plan())
+	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
+		executor.Plan(), txintent.WithoutInteropDependencyWait())
 	tx.Content.Set(&txintent.ExecTrigger{
 		Executor: predeploys.CrossL2InboxAddr,
 		Msg:      msg,

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -150,11 +150,9 @@ func (u *EOA) Plan() txplan.Option {
 		txplan.WithRetrySubmission(elClient, 5, retry.Exponential()),
 		txplan.WithRetryInclusion(elClient, 5, retry.Exponential()),
 		txplan.WithBlockInclusionInfo(elClient),
-		// Must come after WithAgainstLatestBlock, which it wraps.
-		txintent.WithInteropDependencyWait(func(_ context.Context, minTime uint64) error {
-			u.el.WaitForTime(minTime)
-			return nil
-		}),
+		// Must come after WithAgainstLatestBlock, which it wraps. AwaitTime rather than
+		// WaitForTime: a stuck chain fails this tx, it does not fail the whole test.
+		txintent.WithInteropDependencyWait(u.el.AwaitTime),
 	)
 }
 

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -150,8 +150,7 @@ func (u *EOA) Plan() txplan.Option {
 		txplan.WithRetrySubmission(elClient, 5, retry.Exponential()),
 		txplan.WithRetryInclusion(elClient, 5, retry.Exponential()),
 		txplan.WithBlockInclusionInfo(elClient),
-		// Must come after WithAgainstLatestBlock, which it wraps. AwaitTime rather than
-		// WaitForTime: a stuck chain fails this tx, it does not fail the whole test.
+		// AwaitTime rather than WaitForTime: a stuck chain fails this tx, not the whole test.
 		txintent.WithInteropDependencyWait(u.el.AwaitTime),
 	)
 }

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -571,8 +571,7 @@ func (p *SameTimestampPair) SubmitInit() *txplan.PlannedTx {
 // referencing this init. The test harness assigns deterministic nonces and
 // includes the signed tx directly.
 //
-// The init is not on chain yet, so there is nothing to wait for: the referenced block is one the
-// harness has not sequenced, and waiting for it would block the tx that produces it.
+// The init is not on chain yet: waiting for it would block the tx that produces it.
 func (p *SameTimestampPair) SubmitExecTo(executor *EOA) *txplan.PlannedTx {
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
 		executor.Plan(), txintent.WithoutInteropDependencyWait())
@@ -590,7 +589,7 @@ func (p *SameTimestampPair) SubmitExecTo(executor *EOA) *txplan.PlannedTx {
 func (p *SameTimestampPair) SubmitInvalidExecTo(executor *EOA) *txplan.PlannedTx {
 	invalidMsg := MakeInvalidLogIndex(p.Message)
 
-	// See SubmitExecTo for why this does not wait for the referenced message.
+	// See SubmitExecTo for why there is nothing to wait for.
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
 		executor.Plan(), txintent.WithoutInteropDependencyWait())
 	tx.Content.Set(&txintent.ExecTrigger{
@@ -646,7 +645,7 @@ func PrecomputeExecEventMessage(
 // Unlike SameTimestampPair.SubmitExecTo, this can reference any message including
 // precomputed exec event messages for exec-referencing-exec chains.
 //
-// See SubmitExecTo for why this does not wait for the referenced message.
+// See SubmitExecTo for why there is nothing to wait for.
 func SubmitExecForMessage(msg messages.Message, executor *EOA) *txplan.PlannedTx {
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
 		executor.Plan(), txintent.WithoutInteropDependencyWait())

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -14,7 +14,6 @@ import (
 	e2eBindings "github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/plan"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
@@ -151,6 +150,11 @@ func (u *EOA) Plan() txplan.Option {
 		txplan.WithRetrySubmission(elClient, 5, retry.Exponential()),
 		txplan.WithRetryInclusion(elClient, 5, retry.Exponential()),
 		txplan.WithBlockInclusionInfo(elClient),
+		// Must come after WithAgainstLatestBlock, which it wraps.
+		txintent.WithInteropDependencyWait(func(_ context.Context, minTime uint64) error {
+			u.el.WaitForTime(minTime)
+			return nil
+		}),
 	)
 }
 
@@ -324,31 +328,11 @@ func WithExpectRevert() ExecMessageOpt {
 	}
 }
 
-// WaitForInitMessages waits for this EOA's chain to reach the timestamp of the given initiating
-// messages. An executing message is invalid when its block is older than the message it
-// references, which happens whenever the destination chain lags the source chain.
-func (u *EOA) WaitForInitMessages(result *plan.Lazy[*txintent.InteropOutput]) {
-	out, err := result.Eval(u.ctx)
-	u.t.Require().NoError(err, "failed to evaluate init result")
-	u.waitForMessages(out.Entries)
-}
-
-func (u *EOA) waitForMessages(msgs []messages.Message) {
-	var timestamp uint64
-	for _, msg := range msgs {
-		timestamp = max(timestamp, msg.Identifier.Timestamp)
-	}
-	// Strictly newer: op-geth filters executing messages against the unsafe head timestamp rather
-	// than the pending block. See https://github.com/ethereum-optimism/op-geth/issues/603.
-	u.el.WaitForTime(timestamp + 1)
-}
-
 func (u *EOA) SendExecMessage(initMsg *InitMessage, opts ...ExecMessageOpt) *ExecMessage {
 	var cfg execMessageConfig
 	for _, o := range opts {
 		o(&cfg)
 	}
-	u.WaitForInitMessages(&initMsg.Tx.Result)
 	planOpts := append([]txplan.Option{u.Plan()}, cfg.txOpts...)
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](txplan.Combine(planOpts...))
 	tx.Content.DependOn(&initMsg.Tx.Result)
@@ -374,7 +358,6 @@ func (u *EOA) SendExecMessage(initMsg *InitMessage, opts ...ExecMessageOpt) *Exe
 // transaction bytes and tx hash. The raw bytes are suitable for injection via
 // TestSequencer.SequenceBlockWithTxs, bypassing mempool filtering.
 func (u *EOA) PrepareExecTx(initMsg *InitMessage) (rawTx []byte, txHash common.Hash) {
-	u.WaitForInitMessages(&initMsg.Tx.Result)
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.Plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)
 	tx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initMsg.Tx.Result, 0))
@@ -395,7 +378,6 @@ func (u *EOA) SendInvalidExecMessage(initMsg *InitMessage) *ExecMessage {
 	// Get the message and modify it to be invalid by incrementing the log index
 	msg := result.Entries[0]
 	msg.Identifier.LogIndex++
-	u.waitForMessages([]messages.Message{msg})
 
 	// Create the exec trigger with the invalid message
 	execTrigger := &txintent.ExecTrigger{
@@ -450,7 +432,6 @@ func (u *EOA) SendPackedExecMessages(dependOn *txintent.IntentTx[*txintent.Multi
 	for idx := range len(result.Entries) {
 		indexes = append(indexes, idx)
 	}
-	u.waitForMessages(result.Entries)
 	tx.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &dependOn.Result, indexes))
 	receipt, err := tx.PlannedTx.Included.Eval(u.ctx)
 	if err != nil {
@@ -590,8 +571,12 @@ func (p *SameTimestampPair) SubmitInit() *txplan.PlannedTx {
 // SubmitExecTo returns a planned exec transaction to the given EOA's chain,
 // referencing this init. The test harness assigns deterministic nonces and
 // includes the signed tx directly.
+//
+// The init is not on chain yet, so there is nothing to wait for: the referenced block is one the
+// harness has not sequenced, and waiting for it would block the tx that produces it.
 func (p *SameTimestampPair) SubmitExecTo(executor *EOA) *txplan.PlannedTx {
-	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](executor.Plan())
+	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
+		executor.Plan(), txintent.WithoutInteropDependencyWait())
 	tx.Content.Set(&txintent.ExecTrigger{
 		Executor: predeploys.CrossL2InboxAddr,
 		Msg:      p.Message,
@@ -606,7 +591,9 @@ func (p *SameTimestampPair) SubmitExecTo(executor *EOA) *txplan.PlannedTx {
 func (p *SameTimestampPair) SubmitInvalidExecTo(executor *EOA) *txplan.PlannedTx {
 	invalidMsg := MakeInvalidLogIndex(p.Message)
 
-	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](executor.Plan())
+	// See SubmitExecTo for why this does not wait for the referenced message.
+	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
+		executor.Plan(), txintent.WithoutInteropDependencyWait())
 	tx.Content.Set(&txintent.ExecTrigger{
 		Executor: predeploys.CrossL2InboxAddr,
 		Msg:      invalidMsg,
@@ -659,8 +646,11 @@ func PrecomputeExecEventMessage(
 // SubmitExecForMessage returns a planned exec transaction referencing the given message.
 // Unlike SameTimestampPair.SubmitExecTo, this can reference any message including
 // precomputed exec event messages for exec-referencing-exec chains.
+//
+// See SubmitExecTo for why this does not wait for the referenced message.
 func SubmitExecForMessage(msg messages.Message, executor *EOA) *txplan.PlannedTx {
-	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](executor.Plan())
+	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
+		executor.Plan(), txintent.WithoutInteropDependencyWait())
 	tx.Content.Set(&txintent.ExecTrigger{
 		Executor: predeploys.CrossL2InboxAddr,
 		Msg:      msg,

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -14,6 +14,7 @@ import (
 	e2eBindings "github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/plan"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
@@ -323,11 +324,31 @@ func WithExpectRevert() ExecMessageOpt {
 	}
 }
 
+// WaitForInitMessages waits for this EOA's chain to reach the timestamp of the given initiating
+// messages. An executing message is invalid when its block is older than the message it
+// references, which happens whenever the destination chain lags the source chain.
+func (u *EOA) WaitForInitMessages(result *plan.Lazy[*txintent.InteropOutput]) {
+	out, err := result.Eval(u.ctx)
+	u.t.Require().NoError(err, "failed to evaluate init result")
+	u.waitForMessages(out.Entries)
+}
+
+func (u *EOA) waitForMessages(msgs []messages.Message) {
+	var timestamp uint64
+	for _, msg := range msgs {
+		timestamp = max(timestamp, msg.Identifier.Timestamp)
+	}
+	// Strictly newer: op-geth filters executing messages against the unsafe head timestamp rather
+	// than the pending block. See https://github.com/ethereum-optimism/op-geth/issues/603.
+	u.el.WaitForTime(timestamp + 1)
+}
+
 func (u *EOA) SendExecMessage(initMsg *InitMessage, opts ...ExecMessageOpt) *ExecMessage {
 	var cfg execMessageConfig
 	for _, o := range opts {
 		o(&cfg)
 	}
+	u.WaitForInitMessages(&initMsg.Tx.Result)
 	planOpts := append([]txplan.Option{u.Plan()}, cfg.txOpts...)
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](txplan.Combine(planOpts...))
 	tx.Content.DependOn(&initMsg.Tx.Result)
@@ -353,6 +374,7 @@ func (u *EOA) SendExecMessage(initMsg *InitMessage, opts ...ExecMessageOpt) *Exe
 // transaction bytes and tx hash. The raw bytes are suitable for injection via
 // TestSequencer.SequenceBlockWithTxs, bypassing mempool filtering.
 func (u *EOA) PrepareExecTx(initMsg *InitMessage) (rawTx []byte, txHash common.Hash) {
+	u.WaitForInitMessages(&initMsg.Tx.Result)
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.Plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)
 	tx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initMsg.Tx.Result, 0))
@@ -373,6 +395,7 @@ func (u *EOA) SendInvalidExecMessage(initMsg *InitMessage) *ExecMessage {
 	// Get the message and modify it to be invalid by incrementing the log index
 	msg := result.Entries[0]
 	msg.Identifier.LogIndex++
+	u.waitForMessages([]messages.Message{msg})
 
 	// Create the exec trigger with the invalid message
 	execTrigger := &txintent.ExecTrigger{
@@ -427,6 +450,7 @@ func (u *EOA) SendPackedExecMessages(dependOn *txintent.IntentTx[*txintent.Multi
 	for idx := range len(result.Entries) {
 		indexes = append(indexes, idx)
 	}
+	u.waitForMessages(result.Entries)
 	tx.Content.Fn(txintent.ExecuteIndexeds(predeploys.MultiCall3Addr, predeploys.CrossL2InboxAddr, &dependOn.Result, indexes))
 	receipt, err := tx.PlannedTx.Included.Eval(u.ctx)
 	if err != nil {

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -572,8 +572,7 @@ func (p *SameTimestampPair) SubmitInit() *txplan.PlannedTx {
 // referencing this init. The test harness assigns deterministic nonces and
 // includes the signed tx directly.
 //
-// The init is not on chain yet, so there is nothing to wait for: the referenced block is one the
-// harness has not sequenced, and waiting for it would block the tx that produces it.
+// The init is not on chain yet: waiting for it would block the tx that produces it.
 func (p *SameTimestampPair) SubmitExecTo(executor *EOA) *txplan.PlannedTx {
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
 		executor.Plan(), txintent.WithoutInteropDependencyWait())
@@ -591,7 +590,7 @@ func (p *SameTimestampPair) SubmitExecTo(executor *EOA) *txplan.PlannedTx {
 func (p *SameTimestampPair) SubmitInvalidExecTo(executor *EOA) *txplan.PlannedTx {
 	invalidMsg := MakeInvalidLogIndex(p.Message)
 
-	// See SubmitExecTo for why this does not wait for the referenced message.
+	// See SubmitExecTo for why there is nothing to wait for.
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
 		executor.Plan(), txintent.WithoutInteropDependencyWait())
 	tx.Content.Set(&txintent.ExecTrigger{
@@ -647,7 +646,7 @@ func PrecomputeExecEventMessage(
 // Unlike SameTimestampPair.SubmitExecTo, this can reference any message including
 // precomputed exec event messages for exec-referencing-exec chains.
 //
-// See SubmitExecTo for why this does not wait for the referenced message.
+// See SubmitExecTo for why there is nothing to wait for.
 func SubmitExecForMessage(msg messages.Message, executor *EOA) *txplan.PlannedTx {
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](
 		executor.Plan(), txintent.WithoutInteropDependencyWait())

--- a/op-service/txintent/interop_wait.go
+++ b/op-service/txintent/interop_wait.go
@@ -59,7 +59,8 @@ func WithoutInteropDependencyWait() txplan.Option {
 func executedMessagesMinTime(accessList types.AccessList) (uint64, error) {
 	executed, err := messages.DecodeAccessList(accessList)
 	if err != nil {
-		return 0, fmt.Errorf("parsing CrossL2Inbox access-list: %w", err)
+		return 0, fmt.Errorf("tx executes a malformed CrossL2Inbox access-list (%w); "+
+			"if that is deliberate, add txintent.WithoutInteropDependencyWait()", err)
 	}
 	var latest uint64
 	for _, msg := range executed {

--- a/op-service/txintent/interop_wait.go
+++ b/op-service/txintent/interop_wait.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
-	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/plan"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -19,24 +18,12 @@ type interopWaitDisabled struct{}
 // WaitForTime blocks until the chain has built a block with a timestamp of at least minTime.
 type WaitForTime func(ctx context.Context, minTime uint64) error
 
-// WithInteropDependencyWait holds back planning a tx until the chain it is sent to has built past
-// every initiating message the tx executes. An executing message is only valid in a block that is
-// strictly newer than the messages it references, so without this the tx is filtered out of the
-// mempool, or its block is replaced during consolidation, whenever the destination chain lags the
-// source chain.
+// WithInteropDependencyWait holds back planning a tx until the chain it is sent to has reached
+// every message the tx executes, read from its access-list. A block executing a message newer than
+// itself is invalid, and is replaced during consolidation.
 //
-// The messages are read from the tx access-list, so this covers every executing message however it
-// was built: ExecuteIndexed, ExecuteIndexeds, a hand-written ExecTrigger, an ExecTrigger embedded
-// in another trigger, or an access-list set directly on the tx. Transactions that do not execute
-// any message are unaffected.
-//
-// This wraps the AgainstBlock stage, so it must be applied after the Option that resolves
-// AgainstBlock (i.e. txplan.WithAgainstLatestBlock). Planning the tx against a block that already
-// contains the dependency also means gas estimation, fee and nonce lookups all see it.
-//
-// Waiting is meaningless for a tx that references a message which does not exist yet, e.g. one
-// built for a block a test sequencer has not sequenced. Those must be combined with
-// WithoutInteropDependencyWait.
+// Wraps the AgainstBlock stage, so it must be applied after the Option that resolves it.
+// For a tx referencing a message that does not exist yet, see WithoutInteropDependencyWait.
 func WithInteropDependencyWait(wait WaitForTime) txplan.Option {
 	return func(tx *txplan.PlannedTx) {
 		tx.AgainstBlock.DependOn(&tx.AccessList)
@@ -60,36 +47,23 @@ func WithInteropDependencyWait(wait WaitForTime) txplan.Option {
 	}
 }
 
-// WithoutInteropDependencyWait opts a tx out of WithInteropDependencyWait. Use it for a tx that
-// references a message which is not on the source chain yet, and so can never be waited for: the
-// wait would block until the tx is submitted, which is what would produce the message.
+// WithoutInteropDependencyWait opts out of WithInteropDependencyWait, for a tx referencing a
+// message that does not exist yet: the wait would block on the tx that produces it.
 func WithoutInteropDependencyWait() txplan.Option {
 	return txplan.WithFlag(interopWaitDisabled{})
 }
 
-// executedMessagesMinTime returns the timestamp an executing tx's own block must reach for the
-// messages in the given access-list to be valid, or 0 if it does not execute any message.
+// executedMessagesMinTime returns the timestamp the chain must reach before the tx can be planned,
+// or 0 if the tx executes no message. An equal timestamp is valid, and the tx cannot land before
+// the next block anyway, so the head only has to reach the newest message, not pass it.
 func executedMessagesMinTime(accessList types.AccessList) (uint64, error) {
+	executed, err := messages.DecodeAccessList(accessList)
+	if err != nil {
+		return 0, fmt.Errorf("parsing CrossL2Inbox access-list: %w", err)
+	}
 	var latest uint64
-	for _, tuple := range accessList {
-		if tuple.Address != predeploys.CrossL2InboxAddr {
-			continue
-		}
-		entries := tuple.StorageKeys
-		for len(entries) > 0 {
-			remaining, access, err := messages.ParseAccess(entries)
-			if err != nil {
-				return 0, fmt.Errorf("parsing CrossL2Inbox access-list: %w", err)
-			}
-			entries = remaining
-			latest = max(latest, access.Timestamp)
-		}
+	for _, msg := range executed {
+		latest = max(latest, msg.Timestamp)
 	}
-	if latest == 0 {
-		return 0, nil
-	}
-	// Strictly newer, hence the +1: op-geth filters pending executing messages against the unsafe
-	// head timestamp rather than the pending block's.
-	// See https://github.com/ethereum-optimism/op-geth/issues/603.
-	return latest + 1, nil
+	return latest, nil
 }

--- a/op-service/txintent/interop_wait.go
+++ b/op-service/txintent/interop_wait.go
@@ -15,19 +15,23 @@ import (
 // interopWaitDisabled flags a tx that must not wait for the messages it executes.
 type interopWaitDisabled struct{}
 
-// WaitForTime blocks until the chain has built a block with a timestamp of at least minTime.
-type WaitForTime func(ctx context.Context, minTime uint64) error
+// AwaitTimeFn blocks until the chain has built a block with a timestamp of at least minTime.
+type AwaitTimeFn func(ctx context.Context, minTime uint64) error
 
 // WithInteropDependencyWait holds back planning a tx until the chain it is sent to has reached
 // every message the tx executes, read from its access-list. A block executing a message newer than
 // itself is invalid, and is replaced during consolidation.
 //
-// Wraps the AgainstBlock stage, so it must be applied after the Option that resolves it.
+// Wraps the AgainstBlock stage, so it must be applied after the Option that resolves it, and
+// panics otherwise: a later Fn would replace the wrapper and drop the wait silently.
 // For a tx referencing a message that does not exist yet, see WithoutInteropDependencyWait.
-func WithInteropDependencyWait(wait WaitForTime) txplan.Option {
+func WithInteropDependencyWait(wait AwaitTimeFn) txplan.Option {
 	return func(tx *txplan.PlannedTx) {
 		tx.AgainstBlock.DependOn(&tx.AccessList)
 		tx.AgainstBlock.Wrap(func(fn plan.Fn[eth.BlockInfo]) plan.Fn[eth.BlockInfo] {
+			if fn == nil {
+				panic("WithInteropDependencyWait must be applied after the Option resolving AgainstBlock")
+			}
 			return func(ctx context.Context) (eth.BlockInfo, error) {
 				if tx.HasFlag(interopWaitDisabled{}) {
 					return fn(ctx)

--- a/op-service/txintent/interop_wait.go
+++ b/op-service/txintent/interop_wait.go
@@ -1,0 +1,95 @@
+package txintent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/plan"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+)
+
+// interopWaitDisabled flags a tx that must not wait for the messages it executes.
+type interopWaitDisabled struct{}
+
+// WaitForTime blocks until the chain has built a block with a timestamp of at least minTime.
+type WaitForTime func(ctx context.Context, minTime uint64) error
+
+// WithInteropDependencyWait holds back planning a tx until the chain it is sent to has built past
+// every initiating message the tx executes. An executing message is only valid in a block that is
+// strictly newer than the messages it references, so without this the tx is filtered out of the
+// mempool, or its block is replaced during consolidation, whenever the destination chain lags the
+// source chain.
+//
+// The messages are read from the tx access-list, so this covers every executing message however it
+// was built: ExecuteIndexed, ExecuteIndexeds, a hand-written ExecTrigger, an ExecTrigger embedded
+// in another trigger, or an access-list set directly on the tx. Transactions that do not execute
+// any message are unaffected.
+//
+// This wraps the AgainstBlock stage, so it must be applied after the Option that resolves
+// AgainstBlock (i.e. txplan.WithAgainstLatestBlock). Planning the tx against a block that already
+// contains the dependency also means gas estimation, fee and nonce lookups all see it.
+//
+// Waiting is meaningless for a tx that references a message which does not exist yet, e.g. one
+// built for a block a test sequencer has not sequenced. Those must be combined with
+// WithoutInteropDependencyWait.
+func WithInteropDependencyWait(wait WaitForTime) txplan.Option {
+	return func(tx *txplan.PlannedTx) {
+		tx.AgainstBlock.DependOn(&tx.AccessList)
+		tx.AgainstBlock.Wrap(func(fn plan.Fn[eth.BlockInfo]) plan.Fn[eth.BlockInfo] {
+			return func(ctx context.Context) (eth.BlockInfo, error) {
+				if tx.HasFlag(interopWaitDisabled{}) {
+					return fn(ctx)
+				}
+				minTime, err := executedMessagesMinTime(tx.AccessList.Value())
+				if err != nil {
+					return nil, err
+				}
+				if minTime > 0 {
+					if err := wait(ctx, minTime); err != nil {
+						return nil, fmt.Errorf("waiting for chain to reach timestamp %d: %w", minTime, err)
+					}
+				}
+				return fn(ctx)
+			}
+		})
+	}
+}
+
+// WithoutInteropDependencyWait opts a tx out of WithInteropDependencyWait. Use it for a tx that
+// references a message which is not on the source chain yet, and so can never be waited for: the
+// wait would block until the tx is submitted, which is what would produce the message.
+func WithoutInteropDependencyWait() txplan.Option {
+	return txplan.WithFlag(interopWaitDisabled{})
+}
+
+// executedMessagesMinTime returns the timestamp an executing tx's own block must reach for the
+// messages in the given access-list to be valid, or 0 if it does not execute any message.
+func executedMessagesMinTime(accessList types.AccessList) (uint64, error) {
+	var latest uint64
+	for _, tuple := range accessList {
+		if tuple.Address != predeploys.CrossL2InboxAddr {
+			continue
+		}
+		entries := tuple.StorageKeys
+		for len(entries) > 0 {
+			remaining, access, err := messages.ParseAccess(entries)
+			if err != nil {
+				return 0, fmt.Errorf("parsing CrossL2Inbox access-list: %w", err)
+			}
+			entries = remaining
+			latest = max(latest, access.Timestamp)
+		}
+	}
+	if latest == 0 {
+		return 0, nil
+	}
+	// Strictly newer, hence the +1: op-geth filters pending executing messages against the unsafe
+	// head timestamp rather than the pending block's.
+	// See https://github.com/ethereum-optimism/op-geth/issues/603.
+	return latest + 1, nil
+}

--- a/op-service/txintent/interop_wait_test.go
+++ b/op-service/txintent/interop_wait_test.go
@@ -104,6 +104,6 @@ func TestInteropDependencyWait(t *testing.T) {
 			Address:     predeploys.CrossL2InboxAddr,
 			StorageKeys: []common.Hash{{0x01}},
 		}})
-		require.ErrorContains(t, err, "parsing CrossL2Inbox access-list")
+		require.ErrorContains(t, err, "malformed CrossL2Inbox access-list")
 	})
 }

--- a/op-service/txintent/interop_wait_test.go
+++ b/op-service/txintent/interop_wait_test.go
@@ -1,0 +1,112 @@
+package txintent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+)
+
+func execTriggerAt(timestamp uint64) *ExecTrigger {
+	return &ExecTrigger{
+		Executor: predeploys.CrossL2InboxAddr,
+		Msg: messages.Message{
+			Identifier: messages.Identifier{
+				Origin:      common.Address{0xaa},
+				BlockNumber: 10,
+				LogIndex:    1,
+				Timestamp:   timestamp,
+				ChainID:     eth.ChainIDFromUInt64(901),
+			},
+			PayloadHash: common.Hash{0xbb},
+		},
+	}
+}
+
+// waitRecorder returns the base plan options installing the dependency wait, and the timestamps
+// the tx waited for.
+func waitRecorder() ([]txplan.Option, *[]uint64) {
+	waited := new([]uint64)
+	return []txplan.Option{
+		func(tx *txplan.PlannedTx) {
+			tx.AgainstBlock.Fn(func(context.Context) (eth.BlockInfo, error) {
+				return nil, nil
+			})
+		},
+		WithInteropDependencyWait(func(_ context.Context, minTime uint64) error {
+			*waited = append(*waited, minTime)
+			return nil
+		}),
+	}, waited
+}
+
+// planAgainstBlock evaluates the AgainstBlock stage of an intent executing the given call,
+// and reports the timestamps the tx waited for.
+func planAgainstBlock(t *testing.T, call Call, opts ...txplan.Option) []uint64 {
+	t.Helper()
+	base, waited := waitRecorder()
+	tx := NewIntent[Call, *InteropOutput](append(base, opts...)...)
+	tx.Content.Set(call)
+	_, err := tx.PlannedTx.AgainstBlock.Eval(context.Background())
+	require.NoError(t, err)
+	return *waited
+}
+
+func TestInteropDependencyWait(t *testing.T) {
+	t.Run("waits past the executed message", func(t *testing.T) {
+		require.Equal(t, []uint64{1001}, planAgainstBlock(t, execTriggerAt(1000)))
+	})
+
+	t.Run("waits past the newest of several executed messages", func(t *testing.T) {
+		multi := &MultiTrigger{
+			Emitter: predeploys.MultiCall3Addr,
+			Calls:   []Call{execTriggerAt(1000), execTriggerAt(1200), execTriggerAt(900)},
+		}
+		require.Equal(t, []uint64{1201}, planAgainstBlock(t, multi))
+	})
+
+	t.Run("does not wait when no message is executed", func(t *testing.T) {
+		init := &InitTrigger{Emitter: common.Address{0xcc}, Topics: [][32]byte{{0x01}}, OpaqueData: []byte{0x02}}
+		require.Empty(t, planAgainstBlock(t, init))
+	})
+
+	t.Run("does not wait when opted out", func(t *testing.T) {
+		waited := planAgainstBlock(t, execTriggerAt(1000), WithoutInteropDependencyWait())
+		require.Empty(t, waited)
+	})
+
+	// The interop load test builds exec txs as a plain tx with the access-list set by an Option
+	// applied after the plan, rather than as an intent.
+	t.Run("waits for an access-list set after the plan", func(t *testing.T) {
+		accessList, err := execTriggerAt(1000).AccessList()
+		require.NoError(t, err)
+		base, waited := waitRecorder()
+		tx := txplan.NewPlannedTx(append(base, txplan.WithAccessList(accessList))...)
+		_, err = tx.AgainstBlock.Eval(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, []uint64{1001}, *waited)
+	})
+
+	t.Run("ignores access-list entries of other contracts", func(t *testing.T) {
+		minTime, err := executedMessagesMinTime(types.AccessList{
+			{Address: common.Address{0xdd}, StorageKeys: []common.Hash{{0x01}}},
+		})
+		require.NoError(t, err)
+		require.Zero(t, minTime)
+	})
+
+	t.Run("reports a malformed CrossL2Inbox access-list", func(t *testing.T) {
+		_, err := executedMessagesMinTime(types.AccessList{{
+			Address:     predeploys.CrossL2InboxAddr,
+			StorageKeys: []common.Hash{{0x01}},
+		}})
+		require.ErrorContains(t, err, "parsing CrossL2Inbox access-list")
+	})
+}

--- a/op-service/txintent/interop_wait_test.go
+++ b/op-service/txintent/interop_wait_test.go
@@ -30,8 +30,7 @@ func execTriggerAt(timestamp uint64) *ExecTrigger {
 	}
 }
 
-// waitRecorder returns the base plan options installing the dependency wait, and the timestamps
-// the tx waited for.
+// waitRecorder returns plan options installing the dependency wait, and what it waited for.
 func waitRecorder() ([]txplan.Option, *[]uint64) {
 	waited := new([]uint64)
 	return []txplan.Option{
@@ -47,8 +46,7 @@ func waitRecorder() ([]txplan.Option, *[]uint64) {
 	}, waited
 }
 
-// planAgainstBlock evaluates the AgainstBlock stage of an intent executing the given call,
-// and reports the timestamps the tx waited for.
+// planAgainstBlock evaluates the AgainstBlock stage of an intent executing call.
 func planAgainstBlock(t *testing.T, call Call, opts ...txplan.Option) []uint64 {
 	t.Helper()
 	base, waited := waitRecorder()
@@ -60,16 +58,16 @@ func planAgainstBlock(t *testing.T, call Call, opts ...txplan.Option) []uint64 {
 }
 
 func TestInteropDependencyWait(t *testing.T) {
-	t.Run("waits past the executed message", func(t *testing.T) {
-		require.Equal(t, []uint64{1001}, planAgainstBlock(t, execTriggerAt(1000)))
+	t.Run("waits for the executed message", func(t *testing.T) {
+		require.Equal(t, []uint64{1000}, planAgainstBlock(t, execTriggerAt(1000)))
 	})
 
-	t.Run("waits past the newest of several executed messages", func(t *testing.T) {
+	t.Run("waits for the newest of several executed messages", func(t *testing.T) {
 		multi := &MultiTrigger{
 			Emitter: predeploys.MultiCall3Addr,
 			Calls:   []Call{execTriggerAt(1000), execTriggerAt(1200), execTriggerAt(900)},
 		}
-		require.Equal(t, []uint64{1201}, planAgainstBlock(t, multi))
+		require.Equal(t, []uint64{1200}, planAgainstBlock(t, multi))
 	})
 
 	t.Run("does not wait when no message is executed", func(t *testing.T) {
@@ -82,8 +80,7 @@ func TestInteropDependencyWait(t *testing.T) {
 		require.Empty(t, waited)
 	})
 
-	// The interop load test builds exec txs as a plain tx with the access-list set by an Option
-	// applied after the plan, rather than as an intent.
+	// The interop load test sets the access-list with an Option applied after the plan.
 	t.Run("waits for an access-list set after the plan", func(t *testing.T) {
 		accessList, err := execTriggerAt(1000).AccessList()
 		require.NoError(t, err)
@@ -91,7 +88,7 @@ func TestInteropDependencyWait(t *testing.T) {
 		tx := txplan.NewPlannedTx(append(base, txplan.WithAccessList(accessList))...)
 		_, err = tx.AgainstBlock.Eval(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, []uint64{1001}, *waited)
+		require.Equal(t, []uint64{1000}, *waited)
 	})
 
 	t.Run("ignores access-list entries of other contracts", func(t *testing.T) {

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -22,6 +22,7 @@ import (
 
 	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/locks"
 	"github.com/ethereum-optimism/optimism/op-service/plan"
 )
 
@@ -60,6 +61,27 @@ type PlannedTx struct {
 	BlobFeeCap plan.Lazy[*uint256.Int]                 // resolves to nil if not a blob tx
 	BlobHashes plan.Lazy[[]common.Hash]                // resolves to nil if not a blob tx
 	Sidecar    plan.Lazy[*types.BlobTxSidecar]         // resolves to nil if not a blob tx
+
+	flags locks.RWMap[Flag, struct{}]
+}
+
+// Flag is an opaque marker one Option sets and another reads, so Options can coordinate
+// without knowing each other's arguments or the order they are applied in.
+// Flags are read when the tx is evaluated, so that order does not matter.
+// Use a zero-size unexported type from the package that owns the flag as its value,
+// so flags from different packages cannot collide.
+type Flag any
+
+// WithFlag sets a flag on the tx. See Flag.
+func WithFlag(f Flag) Option {
+	return func(tx *PlannedTx) {
+		tx.flags.Set(f, struct{}{})
+	}
+}
+
+// HasFlag returns whether the given flag was set on this tx.
+func (ptx *PlannedTx) HasFlag(f Flag) bool {
+	return ptx.flags.Has(f)
 }
 
 func (ptx *PlannedTx) String() string {

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -65,14 +65,12 @@ type PlannedTx struct {
 	flags locks.RWMap[Flag, struct{}]
 }
 
-// Flag is an opaque marker one Option sets and another reads, so Options can coordinate
-// without knowing each other's arguments or the order they are applied in.
-// Flags are read when the tx is evaluated, so that order does not matter.
-// Use a zero-size unexported type from the package that owns the flag as its value,
-// so flags from different packages cannot collide.
+// Flag is an opaque marker one Option sets and another reads at eval time, letting Options
+// coordinate regardless of the order they are applied in.
+// Use an unexported zero-size type from the owning package so flags cannot collide.
 type Flag any
 
-// WithFlag sets a flag on the tx. See Flag.
+// WithFlag sets a flag on the tx.
 func WithFlag(f Flag) Option {
 	return func(tx *PlannedTx) {
 		tx.flags.Set(f, struct{}{})


### PR DESCRIPTION
An executing message whose block predates the initiating message it references is invalid, so consolidation replaces the block. Nothing waited for the destination chain to catch up before sending the exec tx, so whenever it lagged the source chain the test got a replaced block.

That is what failed `TestInteropFaultProofs_DepositMessage/SP1NativeCore` on [pipeline 131101](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/131101/workflows/e0ef036d-80b8-44fc-b399-9faa9abbbd17/jobs/5377289): the supernode invalidated the exec message with `initiating timestamp 1785190020 > executing timestamp 1785190016`, leaving one optimistic root replaced where the checkpoint expected none.

The wait is a tx-planning concern rather than something each test asserts, so it lives in the plan. `txintent.WithInteropDependencyWait` holds back the `AgainstBlock` stage until the chain has built past every message the tx executes, reading those messages from the tx access list via the new `messages.DecodeAccessList`. That covers every executing message however it was built. `EOA.Plan`, interopsmoke's `remoteUser.plan` and interopbridge's `BridgePlan` install it, which is every path that sends one, so a new test gets it from `alice.Plan()` with nothing to remember. This replaces the inline wait in the interop load test and its `TODO(16371)`.

Opting out is explicit, and only for a tx referencing a message that does not exist yet, where waiting would block the tx that produces it: the `SameTimestampPair` submit helpers and `TestExecMessageInvalidAttributes`.

## Test plan

Acceptance tests against a local `op-reth`, all passing: `interop/message` (full package, covering every raw `txintent` exec site and the opt-out), `interop/reorgs`, `supernode/interop/same_timestamp_invalid`, and `TestSupernodeInterop`.

New unit tests pin the wait target, the opt-out, access-list decoding (including an access split across duplicate `CrossL2Inbox` tuples), and both interopsmoke and interopbridge retrying a transient head lookup. `just lint-go` is clean.

