### PR TITLE
op-reth: Bound the validator resync and reorg waits in proofs e2e tests

### DIFF
--- a/rust/op-reth/tests/proofs/core/resyncing_test.go
+++ b/rust/op-reth/tests/proofs/core/resyncing_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -50,7 +51,11 @@ func TestResyncing(gt *testing.T) {
 
 	time.Sleep(3 * time.Second)
 
-	err = wait.For(t.Ctx(), 2*time.Second, func() (bool, error) {
+	// Bound the wait. Resync takes ~25s in CI, so 5 minutes is ample slack for a slow machine
+	// while a validator that never comes back fails here instead of consuming the package timeout.
+	resyncCtx, cancelResync := context.WithTimeout(t.Ctx(), 5*time.Minute)
+	defer cancelResync()
+	err = wait.For(resyncCtx, 2*time.Second, func() (bool, error) {
 		status := sys.L2CLValidator.SyncStatus()
 		return status.UnsafeL2.Number > blockNumbers[len(blockNumbers)-1], nil
 	})

--- a/rust/op-reth/tests/proofs/reorg/reorg_test.go
+++ b/rust/op-reth/tests/proofs/reorg/reorg_test.go
@@ -1,6 +1,7 @@
 package reorg
 
 import (
+	"context"
 	"math/big"
 	"testing"
 	"time"
@@ -170,8 +171,11 @@ func TestReorgUsingAccountProof(gt *testing.T) {
 	latestBlock := sys.L2Chain.WaitForBlock()
 	utils.WaitForProofsStoreBlock(t, sys.RethWithProofL2ELNode().Escape().L2EthClient(), latestBlock.Number)
 
-	// verify that the L2A validator has reorged and reached the latest block
-	err := wait.For(t.Ctx(), 2*time.Second, func() (bool, error) {
+	// verify that the L2A validator has reorged and reached the latest block. Bounded so a
+	// validator that never converges fails here instead of consuming the package timeout.
+	reorgCtx, cancelReorg := context.WithTimeout(t.Ctx(), 5*time.Minute)
+	defer cancelReorg()
+	err := wait.For(reorgCtx, 2*time.Second, func() (bool, error) {
 		blockRef, err := sys.L2ELValidatorNode().Escape().EthClient().BlockRefByNumber(ctx, latestBlock.Number)
 		if err != nil {
 			// this could happen if the validator is still syncing after reorg


### PR DESCRIPTION
`TestResyncing` polls for the validator to catch up with `wait.For(t.Ctx(), ...)` — a 2s poll interval but no deadline of its own, so it inherits the suite context. When the validator EL dies on restart the poll never succeeds and the test spins until `go test -timeout 40m` fires, taking the rest of the package with it.

That is what happened in [job 5377323](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/131101/workflows/c4eec838-598e-4cf9-905d-40dfa1b72bb5/jobs/5377323): op-reth exited 3.5s after restart with `Persistence service failed: ProviderError(UnexpectedStaticFileTxNumber(Transactions, 0, 1))`, `TestResyncing` then ran for 2333s, and `TestMain` + `TestStorageProofUsingSimpleStorageContract` were reported as failures when the package timed out. Same signature on 2026-07-09 (job 5288587, artifact confirms the identical crash) and 2026-06-22 (job 5241474) — 3 occurrences in the last 90 days.

This does not fix the op-reth crash, which is upstream reth in the static-file consistency check on restart. It stops one dead process from burning the whole package budget and mis-attributing the failure to whichever test ran next.

`TestReorgUsingAccountProof` has the same unbounded wait for validator convergence, so it gets the same treatment. Both are bounded at 5 minutes — `TestResyncing` takes 25s median / 37s max across 40 recent green CI runs, so there is ~8x slack on the slowest observed full-test time, and the package normally finishes in about 3 minutes against a 40 minute budget.

## Test plan

Local, with a prebuilt `op-reth`:

- `./rust/op-reth/tests/proofs/core/` — full package PASS (225s); `TestResyncing` alone PASS (43.6s).
- `./rust/op-reth/tests/proofs/reorg/` — PASS (68.7s).
- Bound verified to fire: with the predicate temporarily made unsatisfiable and the timeout set to 20s, the test failed at 59s with `context deadline exceeded` / `Validator L2 CL failed to resync to latest block` instead of hanging.
