### PR TITLE
kona: Build all cannon prestate variants in a single build

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2094,9 +2094,8 @@ jobs:
             # chainList.json from the checkout (baked into the binary via include_str!)
             cp rust/kona/crates/protocol/registry/etc/chainList.json /tmp/prestate-debug/chainList.json
 
-            # The kona-client ELF binaries (for offline inspection with strings/objdump)
-            cp rust/kona/prestate-artifacts-cannon/kona-client-elf /tmp/prestate-debug/kona-client-elf-cannon 2>/dev/null || true
-            cp rust/kona/prestate-artifacts-cannon-interop/kona-client-elf /tmp/prestate-debug/kona-client-elf-cannon-interop 2>/dev/null || true
+            # The kona-client ELFs (for offline inspection with strings/objdump)
+            cp rust/kona/prestate-elfs/* /tmp/prestate-debug/
       - store_artifacts:
           path: /tmp/prestate-debug
           destination: prestate-debug

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2086,19 +2086,6 @@ jobs:
       - run:
           name: Build prestates
           command: just reproducible-prestate
-      - run:
-          name: Capture kona prestate debug artifacts
-          command: |
-            mkdir -p /tmp/prestate-debug
-
-            # chainList.json from the checkout (baked into the binary via include_str!)
-            cp rust/kona/crates/protocol/registry/etc/chainList.json /tmp/prestate-debug/chainList.json
-
-            # The kona-client ELFs (for offline inspection with strings/objdump)
-            cp rust/kona/prestate-elfs/* /tmp/prestate-debug/
-      - store_artifacts:
-          path: /tmp/prestate-debug
-          destination: prestate-debug
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -726,16 +726,23 @@ jobs:
             # array first: piping into `while` would swallow a failed/empty table
             # as a zero-upload success, and would hand the loop body's stdin to
             # gsutil.
-            VARIANTS=$(just kona-prestate-variants)
-            # -n before mapfile: a here-string of "" still yields one (empty)
-            # element, so the count alone would not catch an empty table.
-            [ -n "${VARIANTS}" ] || { echo "no prestate variants to publish" >&2; exit 1; }
-            mapfile -t ENTRIES <<<"${VARIANTS}"
+            #
+            # No bash here-strings or heredocs anywhere in a CircleCI command:
+            # a doubled left angle bracket opens a parameter tag before any
+            # shell sees it, and an unclosed one kills the whole continuation.
+            # Via a temp file rather than process substitution, so a failing
+            # just still fails the step instead of reading as an empty table.
+            VARIANTS_FILE=$(mktemp)
+            just kona-prestate-variants > "${VARIANTS_FILE}"
+            mapfile -t ENTRIES < "${VARIANTS_FILE}"
+            rm -f "${VARIANTS_FILE}"
             (( ${#ENTRIES[@]} > 0 )) || { echo "no prestate variants to publish" >&2; exit 1; }
 
             for ENTRY in "${ENTRIES[@]}"; do
-              read -r VARIANT DIR <<<"${ENTRY}"
-              [ -n "${DIR}" ] || { echo "empty artifacts dir for '${VARIANT}'" >&2; exit 1; }
+              VARIANT=${ENTRY%% *}
+              DIR=${ENTRY##* }
+              [ -n "${VARIANT}" ] && [ -n "${DIR}" ] && [ "${VARIANT}" != "${DIR}" ] || {
+                echo "malformed variant entry '${ENTRY}'" >&2; exit 1; }
               PRESTATE_HASH=$(jq -er .pre "kona/${DIR}/prestate-proof.json")
               echo "Publishing ${VARIANT} prestate ${PRESTATE_HASH}"
               OBJECT="${PRESTATE_HASH}"

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -725,7 +725,8 @@ jobs:
             # build can't disagree about where a variant landed. Read it into an
             # array first: piping into `while` would swallow a failed/empty table
             # as a zero-upload success, and would hand the loop body's stdin to
-            # gsutil.
+            # gsutil. Accumulated with `while read` rather than `mapfile` to keep
+            # one idiom with the justfile, which also runs on macOS bash 3.2.
             #
             # No bash here-strings or heredocs anywhere in a CircleCI command:
             # a doubled left angle bracket opens a parameter tag before any
@@ -734,7 +735,8 @@ jobs:
             # just still fails the step instead of reading as an empty table.
             VARIANTS_FILE=$(mktemp)
             just kona-prestate-variants > "${VARIANTS_FILE}"
-            mapfile -t ENTRIES < "${VARIANTS_FILE}"
+            ENTRIES=()
+            while IFS= read -r ENTRY; do ENTRIES+=("${ENTRY}"); done < "${VARIANTS_FILE}"
             rm -f "${VARIANTS_FILE}"
             (( ${#ENTRIES[@]} > 0 )) || { echo "no prestate variants to publish" >&2; exit 1; }
 

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -722,9 +722,21 @@ jobs:
             set -euo pipefail
             BRANCH_NAME=$(echo "<< pipeline.git.branch >>" | tr '/' '-')
             # Variant -> artifacts dir comes from the justfile so CI and the
-            # build can't disagree about where a variant landed.
-            just kona-prestate-variants | while read -r VARIANT DIR; do
-              PRESTATE_HASH=$(jq -r .pre "kona/${DIR}/prestate-proof.json")
+            # build can't disagree about where a variant landed. Read it into an
+            # array first: piping into `while` would swallow a failed/empty table
+            # as a zero-upload success, and would hand the loop body's stdin to
+            # gsutil.
+            VARIANTS=$(just kona-prestate-variants)
+            # -n before mapfile: a here-string of "" still yields one (empty)
+            # element, so the count alone would not catch an empty table.
+            [ -n "${VARIANTS}" ] || { echo "no prestate variants to publish" >&2; exit 1; }
+            mapfile -t ENTRIES <<<"${VARIANTS}"
+            (( ${#ENTRIES[@]} > 0 )) || { echo "no prestate variants to publish" >&2; exit 1; }
+
+            for ENTRY in "${ENTRIES[@]}"; do
+              read -r VARIANT DIR <<<"${ENTRY}"
+              [ -n "${DIR}" ] || { echo "empty artifacts dir for '${VARIANT}'" >&2; exit 1; }
+              PRESTATE_HASH=$(jq -er .pre "kona/${DIR}/prestate-proof.json")
               echo "Publishing ${VARIANT} prestate ${PRESTATE_HASH}"
               OBJECT="${PRESTATE_HASH}"
               if [ -n "<< pipeline.git.branch >>" ]; then
@@ -737,7 +749,7 @@ jobs:
               fi
               gsutil cp "kona/${DIR}/prestate.bin.gz" "gs://oplabs-network-data/proofs/kona/cannon/${OBJECT}.bin.gz"
             done
-            echo "Successfully published prestates artifacts to GCS"
+            echo "Successfully published ${#ENTRIES[@]} prestate artifacts to GCS"
       # No cache save: builds in Docker, host registry stays empty.
 
   required-rust-ci:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -686,14 +686,6 @@ jobs:
 
   # Kona Publish Prestate Artifacts
   kona-publish-prestate-artifacts:
-    parameters:
-      kind:
-        description: The kind of prestate (cannon)
-        type: string
-        default: "cannon"
-      version:
-        description: The version to build (kona-client, kona-client-int)
-        type: string
     machine:
       image: <<pipeline.parameters.c-base_image>>
       docker_layer_caching: true
@@ -704,11 +696,11 @@ jobs:
       - apt-install:
           packages: "clang llvm-dev libclang-dev"
           extra_flags: "--no-install-recommends"
-      # No sccache here: the prestate is built reproducibly in Docker
-      # (just build-kona-reproducible-prestate-variant), so the host never
-      # compiles and the job doesn't need the sccache-gcs-optimism context. That
-      # context also defines GCP_SERVICE_ACCOUNT_EMAIL, which would otherwise
-      # shadow the oplabs-network-data publisher SA used by the upload below.
+      # No sccache here: the prestates are built reproducibly in Docker
+      # (just build-kona-reproducible-prestate), so the host never compiles and
+      # the job doesn't need the sccache-gcs-optimism context. That context also
+      # defines GCP_SERVICE_ACCOUNT_EMAIL, which would otherwise shadow the
+      # oplabs-network-data publisher SA used by the upload below.
       - rust-prepare-and-restore-cache:
           directory: rust
           profile: release
@@ -721,25 +713,30 @@ jobs:
           name: Generate prestate artifacts
           working_directory: rust
           no_output_timeout: 60m
-          command: |
-            just build-kona-reproducible-prestate-variant "<<parameters.version>>" "prestate-artifacts-<<parameters.kind>>"
+          command: just build-kona-reproducible-prestate
 
       - run:
           name: Upload prestates to GCS
-          working_directory: rust/kona
+          working_directory: rust
           command: |
-            PRESTATE_HASH=$(jq -r .pre ./prestate-artifacts-<<parameters.kind>>/prestate-proof.json)
+            set -euo pipefail
             BRANCH_NAME=$(echo "<< pipeline.git.branch >>" | tr '/' '-')
-            echo "Publishing ${PRESTATE_HASH} as ${BRANCH_NAME}"
-            if [ -n "<< pipeline.git.branch >>" ]; then
-              echo "Publishing commit hash data"
-              INFO_FILE=$(mktemp)
-              (echo "Commit=<< pipeline.git.revision >>" && echo "Prestate: ${PRESTATE_HASH}") > "${INFO_FILE}"
-              gsutil cp "${INFO_FILE}" "gs://oplabs-network-data/proofs/kona/<<parameters.kind>>/${BRANCH_NAME}-<<parameters.version>>.bin.gz.txt"
-              rm "${INFO_FILE}"
-              PRESTATE_HASH="${BRANCH_NAME}-<<parameters.version>>"
-            fi
-            gsutil cp ./prestate-artifacts-<<parameters.kind>>/prestate.bin.gz "gs://oplabs-network-data/proofs/kona/<<parameters.kind>>/${PRESTATE_HASH}.bin.gz"
+            # Variant -> artifacts dir comes from the justfile so CI and the
+            # build can't disagree about where a variant landed.
+            just kona-prestate-variants | while read -r VARIANT DIR; do
+              PRESTATE_HASH=$(jq -r .pre "kona/${DIR}/prestate-proof.json")
+              echo "Publishing ${VARIANT} prestate ${PRESTATE_HASH}"
+              OBJECT="${PRESTATE_HASH}"
+              if [ -n "<< pipeline.git.branch >>" ]; then
+                echo "Publishing commit hash data"
+                INFO_FILE=$(mktemp)
+                (echo "Commit=<< pipeline.git.revision >>" && echo "Prestate: ${PRESTATE_HASH}") > "${INFO_FILE}"
+                gsutil cp "${INFO_FILE}" "gs://oplabs-network-data/proofs/kona/cannon/${BRANCH_NAME}-${VARIANT}.bin.gz.txt"
+                rm "${INFO_FILE}"
+                OBJECT="${BRANCH_NAME}-${VARIANT}"
+              fi
+              gsutil cp "kona/${DIR}/prestate.bin.gz" "gs://oplabs-network-data/proofs/kona/cannon/${OBJECT}.bin.gz"
+            done
             echo "Successfully published prestates artifacts to GCS"
       # No cache save: builds in Docker, host registry stays empty.
 
@@ -988,10 +985,6 @@ workflows:
     when: << pipeline.parameters.c-run_kona_publish_prestates >>
     jobs:
       - kona-publish-prestate-artifacts:
-          name: kona-publish-<<matrix.version>>
-          matrix:
-            parameters:
-              version: ["kona-client", "kona-client-int"]
           context:
             - circleci-repo-readonly-authenticated-github-token
             - oplabs-network-optimism-io-bucket
@@ -1001,10 +994,6 @@ workflows:
     when: << pipeline.parameters.c-run_release >>
     jobs:
       - kona-publish-prestate-artifacts:
-          name: kona-publish-<<matrix.version>>
-          matrix:
-            parameters:
-              version: ["kona-client", "kona-client-int"]
           context:
             - circleci-repo-readonly-authenticated-github-token
             - oplabs-network-optimism-io-bucket

--- a/cannon/README.md
+++ b/cannon/README.md
@@ -37,7 +37,7 @@ just cannon
 
 # Transform the MIPS kona client binary into the first VM state.
 # This outputs state.bin.gz (VM state) and meta.json (for debug symbols).
-./bin/cannon load-elf --type singlethreaded-2 --path=../rust/kona/prestate-elfs/kona-client
+./bin/cannon load-elf --type singlethreaded-2 --path=../rust/target/mips64-unknown-none/release-client-lto/kona-client
 
 # Run cannon emulator (with example inputs).
 # The kona host command is passed into cannon (after the --) and runs as a

--- a/cannon/README.md
+++ b/cannon/README.md
@@ -37,7 +37,7 @@ just cannon
 
 # Transform the MIPS kona client binary into the first VM state.
 # This outputs state.bin.gz (VM state) and meta.json (for debug symbols).
-./bin/cannon load-elf --type singlethreaded-2 --path=../rust/target/mips64-unknown-none/release-client-lto/kona-client
+./bin/cannon load-elf --type multithreaded64-5 --path=../rust/target/mips64-unknown-none/release-client-lto/kona-client
 
 # Run cannon emulator (with example inputs).
 # The kona host command is passed into cannon (after the --) and runs as a

--- a/cannon/README.md
+++ b/cannon/README.md
@@ -37,7 +37,7 @@ just cannon
 
 # Transform the MIPS kona client binary into the first VM state.
 # This outputs state.bin.gz (VM state) and meta.json (for debug symbols).
-./bin/cannon load-elf --type singlethreaded-2 --path=../rust/kona/prestate-artifacts-cannon/kona-client-elf
+./bin/cannon load-elf --type singlethreaded-2 --path=../rust/kona/prestate-elfs/kona-client
 
 # Run cannon emulator (with example inputs).
 # The kona host command is passed into cannon (after the --) and runs as a

--- a/docs/ai/ci-config-review.md
+++ b/docs/ai/ci-config-review.md
@@ -174,16 +174,22 @@ here. Treat items 1–4 as **blocking**.
    but mind what the restructure costs:
 
    ```sh
-   mapfile -t ARR < <(cmd)          # no '<<', but swallows cmd's exit status:
+   ARR=(); while IFS= read -r L; do ARR+=("$L"); done < <(cmd)
+                                    # no '<<', but swallows cmd's exit status:
                                     # a failing cmd reads as an empty array
    TMP=$(mktemp); cmd > "$TMP"      # keeps set -e, and keeps the stream off the
-   mapfile -t ARR < "$TMP"          # loop body's stdin. Prefer this.
+   ARR=(); while IFS= read -r L; do ARR+=("$L"); done < "$TMP"   # Prefer this.
    rm -f "$TMP"
    (( ${#ARR[@]} > 0 )) || { echo "empty" >&2; exit 1; }
    ```
 
    Process substitution trades the `<<` bug for a swallowed-exit-status bug, so
    assert on the result either way. For a heredoc, write the body to a temp file.
+
+   Read the lines with `while read`, not `mapfile`: `mapfile` is a bash 4
+   builtin, and macOS ships bash 3.2, so any snippet copied from a CI command
+   into a justfile recipe would break local runs. Same for the rest of bash 4
+   (`declare -A`, `${var^^}`, `local -n`).
 
 ## General best practices
 

--- a/docs/ai/ci-config-review.md
+++ b/docs/ai/ci-config-review.md
@@ -153,6 +153,25 @@ here. Treat items 1–4 as **blocking**.
    Validation catches schema and missing-`requires:`-target errors, not semantics
    (items 1–6).
 
+   **`validate` is not enough — use `process` with pipeline parameters.** Jobs
+   reachable only from a `when: << pipeline.parameters.c-run_* >>` workflow are
+   skipped when the parameter is false, which is the default, so a job that fails
+   to compile validates clean. Process the merged config with the gated params
+   turned on:
+
+   ```sh
+   printf '{"c-run_release":true,"c-run_kona_publish_prestates":true}' > /tmp/pp.json
+   circleci config process --pipeline-parameters /tmp/pp.json /tmp/merged-config.yml
+   ```
+
+   **Never write `<<` inside a `command:`.** CircleCI 2.1 treats `<<` as a
+   parameter-tag opener before any shell sees it, so bash here-strings (`<<<`) and
+   heredocs (`<<EOF`) fail the whole continuation with `Unclosed '<<' tag` — and a
+   continuation that fails to compile produces *no* workflows at all, so every
+   check silently disappears from the PR instead of going red. Escape as `\<<` if
+   you truly need the literal, or restructure to avoid it: `mapfile -t ARR <
+   <(cmd)` for a here-string, a temp file for a heredoc.
+
 ## General best practices
 
 Repo is CircleCI-primary; GitHub Actions footprint is small but these apply there.

--- a/docs/ai/ci-config-review.md
+++ b/docs/ai/ci-config-review.md
@@ -168,9 +168,22 @@ here. Treat items 1–4 as **blocking**.
    parameter-tag opener before any shell sees it, so bash here-strings (`<<<`) and
    heredocs (`<<EOF`) fail the whole continuation with `Unclosed '<<' tag` — and a
    continuation that fails to compile produces *no* workflows at all, so every
-   check silently disappears from the PR instead of going red. Escape as `\<<` if
-   you truly need the literal, or restructure to avoid it: `mapfile -t ARR <
-   <(cmd)` for a here-string, a temp file for a heredoc.
+   check silently disappears from the PR instead of going red. This bites shell
+   comments too: a comment merely *mentioning* the token fails compilation.
+   Escape as `\<<` if you truly need the literal, or restructure to avoid it —
+   but mind what the restructure costs:
+
+   ```sh
+   mapfile -t ARR < <(cmd)          # no '<<', but swallows cmd's exit status:
+                                    # a failing cmd reads as an empty array
+   TMP=$(mktemp); cmd > "$TMP"      # keeps set -e, and keeps the stream off the
+   mapfile -t ARR < "$TMP"          # loop body's stdin. Prefer this.
+   rm -f "$TMP"
+   (( ${#ARR[@]} > 0 )) || { echo "empty" >&2; exit 1; }
+   ```
+
+   Process substitution trades the `<<` bug for a swallowed-exit-status bug, so
+   assert on the result either way. For a heredoc, write the body to a temp file.
 
 ## General best practices
 

--- a/justfile
+++ b/justfile
@@ -237,18 +237,18 @@ op-interop-filter:
 cannon:
   cd cannon && just cannon
 
-# Builds reproducible prestate for kona.
+# Builds the reproducible kona prestates (all variants).
 reproducible-prestate-kona:
   cd rust && just build-kona-reproducible-prestate
 
-# Builds the reproducible kona prestate and prints its hash.
+# Builds the reproducible kona prestates and prints their hashes.
 [script('bash')]
 reproducible-prestate:
   set -euo pipefail
   (cd rust && just build-kona-reproducible-prestate)
   (cd rust && just output-kona-prestate-hash)
 
-# Builds the cannon prestate.
+# Builds the kona prestates natively (hashes will not match release builds).
 cannon-prestates:
   cd rust && just build-kona-prestates
 

--- a/rust/justfile
+++ b/rust/justfile
@@ -589,11 +589,16 @@ KONA_PRESTATE_VARIANTS := "kona-client:prestate-artifacts-cannon kona-client-int
 # the only place the table is split: every consumer, in this justfile and out,
 # reads these lines. A malformed entry fails here rather than downstream of an
 # `rm -rf` built from an empty field.
+#
+# Output is all-or-nothing: the whole table is validated before anything is
+# printed, so a consumer reading this through a pipe or process substitution —
+# where the exit status is not visible — can treat "no lines" as the only
+# failure mode, rather than silently acting on a truncated table.
 kona-prestate-variants:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    count=0
+    lines=()
     for pair in {{KONA_PRESTATE_VARIANTS}}; do
       variant="${pair%%:*}"
       dir="${pair#*:}"
@@ -601,10 +606,10 @@ kona-prestate-variants:
         echo "malformed KONA_PRESTATE_VARIANTS entry '${pair}', want '<cargo bin>:<artifacts dir>'" >&2
         exit 1
       fi
-      echo "${variant} ${dir}"
-      count=$((count + 1))
+      lines+=("${variant} ${dir}")
     done
-    (( count > 0 )) || { echo "KONA_PRESTATE_VARIANTS is empty" >&2; exit 1; }
+    (( ${#lines[@]} > 0 )) || { echo "KONA_PRESTATE_VARIANTS is empty" >&2; exit 1; }
+    printf '%s\n' "${lines[@]}"
 
 # Build the kona-client ELFs for the MIPS64 cannon target. Always builds every
 # variant: they are bins of the same package resolving to the same features, so

--- a/rust/justfile
+++ b/rust/justfile
@@ -710,7 +710,11 @@ generate-kona-prestates CANNON_BIN ELF_DIR OUT_ROOT:
 
     variants=$(just kona-prestate-variants)
     [[ -n "$variants" ]] || { echo "no prestate variants" >&2; exit 1; }
-    mapfile -t entries <<<"$variants"
+    # Collect the lines before looping, so the loop body doesn't inherit the
+    # variant list on its stdin. Accumulated with `while read` rather than
+    # `mapfile`: that's a bash 4 builtin, and macOS ships bash 3.2.
+    entries=()
+    while IFS= read -r entry; do entries+=("$entry"); done <<<"$variants"
 
     for entry in "${entries[@]}"; do
       read -r variant dir <<<"$entry"
@@ -757,7 +761,10 @@ build-kona-reproducible-prestate:
 
     variants=$(just kona-prestate-variants)
     [[ -n "$variants" ]] || { echo "no prestate variants" >&2; exit 1; }
-    mapfile -t entries <<<"$variants"
+    # Array first, not a `while read` loop around the body: see
+    # generate-kona-prestates. No `mapfile` — bash 4 only, missing on macOS.
+    entries=()
+    while IFS= read -r entry; do entries+=("$entry"); done <<<"$variants"
 
     # Export to a staging dir rather than straight over KONA_DIR: --output is a
     # filesystem write of the target stage, so it must not be aimed at the crate
@@ -823,7 +830,8 @@ output-kona-prestate-hash:
 
     variants=$(just kona-prestate-variants)
     [[ -n "$variants" ]] || { echo "no prestate variants" >&2; exit 1; }
-    mapfile -t entries <<<"$variants"
+    entries=()
+    while IFS= read -r entry; do entries+=("$entry"); done <<<"$variants"
 
     echo "-------------------- Kona Prestates --------------------"
     echo ""

--- a/rust/justfile
+++ b/rust/justfile
@@ -576,11 +576,32 @@ docs-preview:
 
 KONA_DIR := justfile_directory() / "kona"
 MIPS64_TARGET_SPEC := justfile_directory() / "kona/docker/cannon/mips64-unknown-none.json"
+MIPS64_ELF_DIR := justfile_directory() / "target/mips64-unknown-none/release-client-lto"
 
-# Build kona-client for the MIPS64 cannon target
-build-kona-client-elf VARIANT:
+# Prestate variants, as `<cargo bin>:<artifacts dir>` pairs. Single source of
+# truth for the native and the reproducible Docker builds.
+KONA_PRESTATE_VARIANTS := "kona-client:prestate-artifacts-cannon kona-client-int:prestate-artifacts-cannon-interop"
+
+# Print the prestate variants as `<cargo bin> <artifacts dir>` lines, so
+# tooling outside this justfile can iterate them without redeclaring the table.
+kona-prestate-variants:
+    @for pair in {{KONA_PRESTATE_VARIANTS}}; do echo "${pair%%:*} ${pair#*:}"; done
+
+# Build kona-client ELFs for the MIPS64 cannon target. Defaults to every
+# prestate variant. The variants are bins of the same package resolving to the
+# same features, so one cargo invocation compiles the shared dependency graph
+# once instead of once per variant.
+build-kona-client-elf *VARIANTS:
     #!/usr/bin/env bash
     set -euo pipefail
+
+    variants=({{VARIANTS}})
+    if [[ ${#variants[@]} -eq 0 ]]; then
+      for pair in {{KONA_PRESTATE_VARIANTS}}; do variants+=("${pair%%:*}"); done
+    fi
+
+    bins=()
+    for variant in "${variants[@]}"; do bins+=(--bin "$variant"); done
 
     # Ensure nightly toolchain with rust-src is installed
     just install-nightly
@@ -598,14 +619,26 @@ build-kona-client-elf VARIANT:
       export KONA_CUSTOM_CONFIGS=true
     fi
 
-    echo "Building kona-client ELF (variant: {{VARIANT}})..."
+    echo "Building kona-client ELFs: ${variants[*]}"
     cargo build \
       -Zbuild-std=core,alloc \
       -Zjson-target-spec \
       -p kona-client \
-      --bin {{VARIANT}} \
+      "${bins[@]}" \
       --locked \
       --profile release-client-lto
+
+# Copy the built kona-client ELFs into DEST. The Docker build needs this: it
+# builds into a cache mount, which does not survive the layer it is mounted in.
+stage-kona-client-elfs DEST:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    mkdir -p "{{DEST}}"
+    for pair in {{KONA_PRESTATE_VARIANTS}}; do
+      variant="${pair%%:*}"
+      cp "{{MIPS64_ELF_DIR}}/${variant}" "{{DEST}}/${variant}"
+    done
 
 # Lint kona-std-fpvm for the MIPS64 cannon target
 lint-kona-cannon:
@@ -623,70 +656,71 @@ lint-kona-cannon:
 
     cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -Zjson-target-spec -- -D warnings
 
-# Build all kona prestates (runs natively — use build-kona-reproducible-prestate for Docker)
-build-kona-prestates: build-kona-cannon-prestate build-kona-interop-prestate
-
-build-kona-cannon-prestate:
-    @just build-kona-prestate kona-client prestate-artifacts-cannon
-
-build-kona-interop-prestate:
-    @just build-kona-prestate kona-client-int prestate-artifacts-cannon-interop
-
-# Build a single kona prestate variant
-build-kona-prestate VARIANT OUTPUT_DIR:
+# Build all kona prestates natively. Use build-kona-reproducible-prestate for
+# a hash that matches CI and release builds.
+build-kona-prestates:
     #!/usr/bin/env bash
     set -euo pipefail
-
-    OUTPUT="{{KONA_DIR}}/{{OUTPUT_DIR}}"
-    mkdir -p "$OUTPUT"
 
     echo "=== Building cannon ==="
     # cannon/justfile imports ../justfiles/go.just which imports git.just.
     # These relative imports resolve from cannon/'s directory, so we cd there
     # and call just directly — NOT via rust/justfile delegation.
-    cd "{{justfile_directory()}}/../cannon"
-    just cannon
-    CANNON_BIN="$(pwd)/bin/cannon"
+    (cd "{{justfile_directory()}}/../cannon" && just cannon)
 
-    echo "=== Building kona-client ELF (variant: {{VARIANT}}) ==="
-    cd "{{justfile_directory()}}"
-    just build-kona-client-elf {{VARIANT}}
+    echo "=== Building kona-client ELFs ==="
+    just build-kona-client-elf
+    # Same location the Docker build exports to, so the ELFs are findable
+    # regardless of which build produced them.
+    just stage-kona-client-elfs "{{KONA_DIR}}/prestate-elfs"
 
-    # Locate the built ELF
-    ELF="{{justfile_directory()}}/target/mips64-unknown-none/release-client-lto/{{VARIANT}}"
+    just generate-kona-prestates \
+      "{{justfile_directory()}}/../cannon/bin/cannon" \
+      "{{MIPS64_ELF_DIR}}" \
+      "{{KONA_DIR}}"
 
-    echo "=== Generating prestate ==="
-    "$CANNON_BIN" load-elf \
-      --path="$ELF" \
-      --out="$OUTPUT/prestate.bin.gz" \
-      --meta="$OUTPUT/meta.json" \
-      --type multithreaded64-5
-
-    "$CANNON_BIN" run \
-      --proof-at "=0" \
-      --stop-at "=1" \
-      --input "$OUTPUT/prestate.bin.gz" \
-      --meta "$OUTPUT/meta.json" \
-      --proof-fmt "$OUTPUT/%d.json" \
-      --output ""
-
-    mv "$OUTPUT/0.json" "$OUTPUT/prestate-proof.json"
-
-    # Copy with hash-based name for challenger lookup
-    HASH=$(jq -r .pre "$OUTPUT/prestate-proof.json")
-    cp "$OUTPUT/prestate.bin.gz" "$OUTPUT/${HASH}.bin.gz"
-    echo "Prestate for {{VARIANT}}: ${HASH}"
-
-# Build a single reproducible kona prestate variant via Docker.
-# Cannon is built from source as a stage within the Dockerfile.
-# Build context is the monorepo root.
-# Set KONA_CUSTOM_CONFIGS_DIR to bake custom chain configs into the prestate.
-build-kona-reproducible-prestate-variant VARIANT OUTPUT_DIR:
+# Generate the cannon prestate for every variant from already-built ELFs.
+# CANNON_BIN: the cannon executable. ELF_DIR: holds one ELF per variant, named
+# after its cargo bin. OUT_ROOT: parent of the per-variant artifacts dirs.
+generate-kona-prestates CANNON_BIN ELF_DIR OUT_ROOT:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    MONOREPO_ROOT="{{justfile_directory()}}/.."
-    OUTPUT="{{KONA_DIR}}/{{OUTPUT_DIR}}"
+    for pair in {{KONA_PRESTATE_VARIANTS}}; do
+      variant="${pair%%:*}"
+      output="{{OUT_ROOT}}/${pair#*:}"
+      mkdir -p "$output"
+
+      echo "=== Generating prestate for ${variant} ==="
+      "{{CANNON_BIN}}" load-elf \
+        --path="{{ELF_DIR}}/${variant}" \
+        --out="$output/prestate.bin.gz" \
+        --meta="$output/meta.json" \
+        --type multithreaded64-5
+
+      "{{CANNON_BIN}}" run \
+        --proof-at "=0" \
+        --stop-at "=1" \
+        --input "$output/prestate.bin.gz" \
+        --meta "$output/meta.json" \
+        --proof-fmt "$output/%d.json" \
+        --output ""
+
+      mv "$output/0.json" "$output/prestate-proof.json"
+
+      # Copy with hash-based name for challenger lookup
+      hash=$(jq -r .pre "$output/prestate-proof.json")
+      cp "$output/prestate.bin.gz" "$output/${hash}.bin.gz"
+      echo "Prestate for ${variant}: ${hash}"
+    done
+
+# Build every reproducible kona prestate via Docker, in a single build so the
+# shared dependency graph is compiled once. Cannon is built from source as a
+# stage within the Dockerfile. Build context is the monorepo root.
+# Set KONA_CUSTOM_CONFIGS_DIR to bake custom chain configs into the prestates.
+build-kona-reproducible-prestate:
+    #!/usr/bin/env bash
+    set -euo pipefail
 
     # The Dockerfile always copies from the `kona-custom-configs` named build
     # context, so point it at an empty temp dir when no configs are requested.
@@ -695,48 +729,51 @@ build-kona-reproducible-prestate-variant VARIANT OUTPUT_DIR:
         echo "KONA_CUSTOM_CONFIGS_DIR=${KONA_CUSTOM_CONFIGS_DIR} is not a directory" >&2
         exit 1
       fi
-      CUSTOM_CONFIGS_CONTEXT="${KONA_CUSTOM_CONFIGS_DIR}"
-      CUSTOM_CONFIGS_FLAG=true
+      custom_configs_context="${KONA_CUSTOM_CONFIGS_DIR}"
+      custom_configs_flag=true
     else
-      CUSTOM_CONFIGS_CONTEXT=$(mktemp -d)
-      trap 'rm -rf "${CUSTOM_CONFIGS_CONTEXT}"' EXIT
-      CUSTOM_CONFIGS_FLAG=false
+      custom_configs_context=$(mktemp -d)
+      trap 'rm -rf "${custom_configs_context}"' EXIT
+      custom_configs_flag=false
     fi
+
+    # Docker only overwrites the files it exports, so drop previous artifacts:
+    # a stale hash-named preimage left beside the new one is indistinguishable
+    # from the real output.
+    just clean-kona-prestates
 
     docker build \
       --platform linux/amd64 \
-      --build-arg VARIANT={{VARIANT}} \
-      --build-arg KONA_CUSTOM_CONFIGS="${CUSTOM_CONFIGS_FLAG}" \
-      --build-context kona-custom-configs="${CUSTOM_CONFIGS_CONTEXT}" \
-      --output "$OUTPUT" \
+      --build-arg KONA_CUSTOM_CONFIGS="${custom_configs_flag}" \
+      --build-context kona-custom-configs="${custom_configs_context}" \
+      --output "{{KONA_DIR}}" \
       --progress plain \
       -f "{{KONA_DIR}}/docker/fpvm-prestates/cannon-repro.dockerfile" \
-      "$MONOREPO_ROOT"
+      "{{justfile_directory()}}/.."
 
-    # Add hash-named copy for challenger lookup
-    HASH=$(jq -r .pre "$OUTPUT/prestate-proof.json")
-    cp "$OUTPUT/prestate.bin.gz" "$OUTPUT/${HASH}.bin.gz"
-    echo "Prestate for {{VARIANT}}: ${HASH}"
-
-# Build all reproducible kona prestates via Docker
-build-kona-reproducible-prestate:
-    @just build-kona-reproducible-prestate-variant kona-client prestate-artifacts-cannon
-    @just build-kona-reproducible-prestate-variant kona-client-int prestate-artifacts-cannon-interop
+    for pair in {{KONA_PRESTATE_VARIANTS}}; do
+      echo "Prestate for ${pair%%:*}: $(jq -r .pre "{{KONA_DIR}}/${pair#*:}/prestate-proof.json")"
+    done
 
 output-kona-prestate-hash:
-    @echo "-------------------- Kona Prestates --------------------"
-    @echo ""
-    @echo "Cannon Absolute prestate hash:"
-    @jq -r .pre {{KONA_DIR}}/prestate-artifacts-cannon/prestate-proof.json
-    @echo ""
-    @echo "Cannon Interop Absolute prestate hash:"
-    @jq -r .pre {{KONA_DIR}}/prestate-artifacts-cannon-interop/prestate-proof.json
-    @echo ""
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "-------------------- Kona Prestates --------------------"
+    echo ""
+    for pair in {{KONA_PRESTATE_VARIANTS}}; do
+      echo "${pair%%:*} absolute prestate hash:"
+      jq -r .pre "{{KONA_DIR}}/${pair#*:}/prestate-proof.json"
+      echo ""
+    done
 
 reproducible-kona-prestate: build-kona-reproducible-prestate output-kona-prestate-hash
 
 clean-kona-prestates:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  rm -rf "{{KONA_DIR}}/build"
-  rm -rf "{{KONA_DIR}}/prestate-artifacts-cannon" "{{KONA_DIR}}/prestate-artifacts-cannon-interop"
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    rm -rf "{{KONA_DIR}}/build" "{{KONA_DIR}}/prestate-elfs"
+    for pair in {{KONA_PRESTATE_VARIANTS}}; do
+      rm -rf "{{KONA_DIR}}/${pair#*:}"
+    done

--- a/rust/justfile
+++ b/rust/justfile
@@ -578,30 +578,48 @@ KONA_DIR := justfile_directory() / "kona"
 MIPS64_TARGET_SPEC := justfile_directory() / "kona/docker/cannon/mips64-unknown-none.json"
 MIPS64_ELF_DIR := justfile_directory() / "target/mips64-unknown-none/release-client-lto"
 
-# Prestate variants, as `<cargo bin>:<artifacts dir>` pairs. Single source of
-# truth for the native and the reproducible Docker builds.
+# Prestate variants, as `<cargo bin>:<artifacts dir>` pairs. The build side
+# derives everything from this; the artifacts dir names are additionally
+# hardcoded by rust/kona/.gitignore, ops/prestate-reproducibility/build-prestates.sh,
+# .circleci/continue/rust-e2e.yml, op-e2e/config/init.go and
+# op-devstack/{shared/challenger,sysgo}, so renaming one means updating those too.
 KONA_PRESTATE_VARIANTS := "kona-client:prestate-artifacts-cannon kona-client-int:prestate-artifacts-cannon-interop"
 
-# Print the prestate variants as `<cargo bin> <artifacts dir>` lines, so
-# tooling outside this justfile can iterate them without redeclaring the table.
+# Print the prestate variants as `<cargo bin> <artifacts dir>` lines. This is
+# the only place the table is split: every consumer, in this justfile and out,
+# reads these lines. A malformed entry fails here rather than downstream of an
+# `rm -rf` built from an empty field.
 kona-prestate-variants:
-    @for pair in {{KONA_PRESTATE_VARIANTS}}; do echo "${pair%%:*} ${pair#*:}"; done
-
-# Build kona-client ELFs for the MIPS64 cannon target. Defaults to every
-# prestate variant. The variants are bins of the same package resolving to the
-# same features, so one cargo invocation compiles the shared dependency graph
-# once instead of once per variant.
-build-kona-client-elf *VARIANTS:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    variants=({{VARIANTS}})
-    if [[ ${#variants[@]} -eq 0 ]]; then
-      for pair in {{KONA_PRESTATE_VARIANTS}}; do variants+=("${pair%%:*}"); done
-    fi
+    count=0
+    for pair in {{KONA_PRESTATE_VARIANTS}}; do
+      variant="${pair%%:*}"
+      dir="${pair#*:}"
+      if [[ -z "$variant" || -z "$dir" || "$variant" == "$pair" ]]; then
+        echo "malformed KONA_PRESTATE_VARIANTS entry '${pair}', want '<cargo bin>:<artifacts dir>'" >&2
+        exit 1
+      fi
+      echo "${variant} ${dir}"
+      count=$((count + 1))
+    done
+    (( count > 0 )) || { echo "KONA_PRESTATE_VARIANTS is empty" >&2; exit 1; }
 
+# Build the kona-client ELFs for the MIPS64 cannon target. Always builds every
+# variant: they are bins of the same package resolving to the same features, so
+# one cargo invocation compiles the shared dependency graph once instead of once
+# per variant, and the second binary costs only its own LTO link. Building a
+# subset would also leave the other variant's stale ELF in the target dir for
+# stage-kona-client-elfs and generate-kona-prestates to pick up.
+build-kona-client-elfs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    variants=$(just kona-prestate-variants)
+    [[ -n "$variants" ]] || { echo "no prestate variants" >&2; exit 1; }
     bins=()
-    for variant in "${variants[@]}"; do bins+=(--bin "$variant"); done
+    while read -r variant _; do bins+=(--bin "$variant"); done <<<"$variants"
 
     # Ensure nightly toolchain with rust-src is installed
     just install-nightly
@@ -619,7 +637,7 @@ build-kona-client-elf *VARIANTS:
       export KONA_CUSTOM_CONFIGS=true
     fi
 
-    echo "Building kona-client ELFs: ${variants[*]}"
+    echo "Building kona-client ELFs"
     cargo build \
       -Zbuild-std=core,alloc \
       -Zjson-target-spec \
@@ -635,11 +653,12 @@ stage-kona-client-elfs DEST:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    variants=$(just kona-prestate-variants)
+    [[ -n "$variants" ]] || { echo "no prestate variants" >&2; exit 1; }
     mkdir -p "{{DEST}}"
-    for pair in {{KONA_PRESTATE_VARIANTS}}; do
-      variant="${pair%%:*}"
+    while read -r variant _; do
       cp "{{MIPS64_ELF_DIR}}/${variant}" "{{DEST}}/${variant}"
-    done
+    done <<<"$variants"
 
 # Lint kona-std-fpvm for the MIPS64 cannon target
 lint-kona-cannon:
@@ -670,7 +689,7 @@ build-kona-prestates:
     (cd "{{justfile_directory()}}/../cannon" && just cannon)
 
     echo "=== Building kona-client ELFs ==="
-    just build-kona-client-elf
+    just build-kona-client-elfs
 
     just generate-kona-prestates \
       "{{justfile_directory()}}/../cannon/bin/cannon" \
@@ -684,9 +703,19 @@ generate-kona-prestates CANNON_BIN ELF_DIR OUT_ROOT:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    for pair in {{KONA_PRESTATE_VARIANTS}}; do
-      variant="${pair%%:*}"
-      output="{{OUT_ROOT}}/${pair#*:}"
+    variants=$(just kona-prestate-variants)
+    [[ -n "$variants" ]] || { echo "no prestate variants" >&2; exit 1; }
+    mapfile -t entries <<<"$variants"
+
+    for entry in "${entries[@]}"; do
+      read -r variant dir <<<"$entry"
+      [[ -n "$dir" ]] || { echo "empty artifacts dir for '${variant}'" >&2; exit 1; }
+      output="{{OUT_ROOT}}/${dir}"
+
+      # Clear the variant's dir immediately before writing it: a hash-named
+      # preimage left over from a previous build is indistinguishable from this
+      # build's output. Nothing is removed until we are about to replace it.
+      rm -rf "$output"
       mkdir -p "$output"
 
       echo "=== Generating prestate for ${variant} ==="
@@ -706,8 +735,9 @@ generate-kona-prestates CANNON_BIN ELF_DIR OUT_ROOT:
 
       mv "$output/0.json" "$output/prestate-proof.json"
 
-      # Copy with hash-based name for challenger lookup
-      hash=$(jq -r .pre "$output/prestate-proof.json")
+      # Copy with hash-based name for challenger lookup. -e so a missing or
+      # null .pre fails here instead of producing a "null.bin.gz".
+      hash=$(jq -er .pre "$output/prestate-proof.json")
       cp "$output/prestate.bin.gz" "$output/${hash}.bin.gz"
       echo "Prestate for ${variant}: ${hash}"
     done
@@ -720,6 +750,26 @@ build-kona-reproducible-prestate:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    variants=$(just kona-prestate-variants)
+    [[ -n "$variants" ]] || { echo "no prestate variants" >&2; exit 1; }
+    mapfile -t entries <<<"$variants"
+
+    # Export to a staging dir rather than straight over KONA_DIR: --output is a
+    # filesystem write of the target stage, so it must not be aimed at the crate
+    # source root. Each variant is checked and swapped into place only once the
+    # build has actually produced it, so a failed build leaves the previous
+    # prestates intact.
+    export_dir=$(mktemp -d)
+    tmp_configs_context=""
+    cleanup() {
+      rm -rf "${export_dir}"
+      # Only ever the temp dir we made — never a caller's KONA_CUSTOM_CONFIGS_DIR.
+      if [[ -n "${tmp_configs_context}" ]]; then
+        rm -rf "${tmp_configs_context}"
+      fi
+    }
+    trap cleanup EXIT
+
     # The Dockerfile always copies from the `kona-custom-configs` named build
     # context, so point it at an empty temp dir when no configs are requested.
     if [[ -n "${KONA_CUSTOM_CONFIGS_DIR:-}" ]]; then
@@ -730,38 +780,53 @@ build-kona-reproducible-prestate:
       custom_configs_context="${KONA_CUSTOM_CONFIGS_DIR}"
       custom_configs_flag=true
     else
-      custom_configs_context=$(mktemp -d)
-      trap 'rm -rf "${custom_configs_context}"' EXIT
+      tmp_configs_context=$(mktemp -d)
+      custom_configs_context="${tmp_configs_context}"
       custom_configs_flag=false
     fi
 
-    # Docker only overwrites the files it exports, so drop previous artifacts:
-    # a stale hash-named preimage left beside the new one is indistinguishable
-    # from the real output.
-    just clean-kona-prestates
-
     docker build \
       --platform linux/amd64 \
+      --target export-stage \
       --build-arg KONA_CUSTOM_CONFIGS="${custom_configs_flag}" \
       --build-context kona-custom-configs="${custom_configs_context}" \
-      --output "{{KONA_DIR}}" \
+      --output "${export_dir}" \
       --progress plain \
       -f "{{KONA_DIR}}/docker/fpvm-prestates/cannon-repro.dockerfile" \
       "{{justfile_directory()}}/.."
 
-    for pair in {{KONA_PRESTATE_VARIANTS}}; do
-      echo "Prestate for ${pair%%:*}: $(jq -r .pre "{{KONA_DIR}}/${pair#*:}/prestate-proof.json")"
+    for entry in "${entries[@]}"; do
+      read -r variant dir <<<"$entry"
+      if [[ ! -s "${export_dir}/${dir}/prestate-proof.json" ]]; then
+        echo "build exported no prestate for ${variant} (expected ${dir}/prestate-proof.json)" >&2
+        exit 1
+      fi
+    done
+
+    for entry in "${entries[@]}"; do
+      read -r variant dir <<<"$entry"
+      [[ -n "$dir" ]] || { echo "empty artifacts dir for '${variant}'" >&2; exit 1; }
+      rm -rf "{{KONA_DIR}}/${dir}"
+      mv "${export_dir}/${dir}" "{{KONA_DIR}}/${dir}"
+      hash=$(jq -er .pre "{{KONA_DIR}}/${dir}/prestate-proof.json")
+      echo "Prestate for ${variant}: ${hash}"
     done
 
 output-kona-prestate-hash:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    variants=$(just kona-prestate-variants)
+    [[ -n "$variants" ]] || { echo "no prestate variants" >&2; exit 1; }
+    mapfile -t entries <<<"$variants"
+
     echo "-------------------- Kona Prestates --------------------"
     echo ""
-    for pair in {{KONA_PRESTATE_VARIANTS}}; do
-      echo "${pair%%:*} absolute prestate hash:"
-      jq -r .pre "{{KONA_DIR}}/${pair#*:}/prestate-proof.json"
+    for entry in "${entries[@]}"; do
+      read -r variant dir <<<"$entry"
+      hash=$(jq -er .pre "{{KONA_DIR}}/${dir}/prestate-proof.json")
+      echo "${variant} absolute prestate hash:"
+      echo "${hash}"
       echo ""
     done
 
@@ -771,7 +836,9 @@ clean-kona-prestates:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    rm -rf "{{KONA_DIR}}/build"
-    for pair in {{KONA_PRESTATE_VARIANTS}}; do
-      rm -rf "{{KONA_DIR}}/${pair#*:}"
-    done
+    variants=$(just kona-prestate-variants)
+    [[ -n "$variants" ]] || { echo "no prestate variants" >&2; exit 1; }
+    while read -r _ dir; do
+      [[ -n "$dir" ]] || { echo "empty artifacts dir in variant table" >&2; exit 1; }
+      rm -rf "{{KONA_DIR}}/${dir}"
+    done <<<"$variants"

--- a/rust/justfile
+++ b/rust/justfile
@@ -628,8 +628,9 @@ build-kona-client-elf *VARIANTS:
       --locked \
       --profile release-client-lto
 
-# Copy the built kona-client ELFs into DEST. The Docker build needs this: it
-# builds into a cache mount, which does not survive the layer it is mounted in.
+# Copy the built kona-client ELFs into DEST. Only the Docker build needs this:
+# it builds into a cache mount, which does not survive the layer it is mounted
+# in, so the prestate stage cannot read the ELFs from the cargo target dir.
 stage-kona-client-elfs DEST:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -670,9 +671,6 @@ build-kona-prestates:
 
     echo "=== Building kona-client ELFs ==="
     just build-kona-client-elf
-    # Same location the Docker build exports to, so the ELFs are findable
-    # regardless of which build produced them.
-    just stage-kona-client-elfs "{{KONA_DIR}}/prestate-elfs"
 
     just generate-kona-prestates \
       "{{justfile_directory()}}/../cannon/bin/cannon" \
@@ -773,7 +771,7 @@ clean-kona-prestates:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    rm -rf "{{KONA_DIR}}/build" "{{KONA_DIR}}/prestate-elfs"
+    rm -rf "{{KONA_DIR}}/build"
     for pair in {{KONA_PRESTATE_VARIANTS}}; do
       rm -rf "{{KONA_DIR}}/${pair#*:}"
     done

--- a/rust/kona/.gitignore
+++ b/rust/kona/.gitignore
@@ -35,7 +35,6 @@ out.json
 
 # Prestate artifacts
 prestate-artifacts-*
-prestate-elfs/
 
 # IDE specific
 .idea

--- a/rust/kona/.gitignore
+++ b/rust/kona/.gitignore
@@ -35,6 +35,7 @@ out.json
 
 # Prestate artifacts
 prestate-artifacts-*
+prestate-elfs/
 
 # IDE specific
 .idea

--- a/rust/kona/docker/fpvm-prestates/README.md
+++ b/rust/kona/docker/fpvm-prestates/README.md
@@ -13,10 +13,13 @@ Cannon is built from the local monorepo source.
 just reproducible-prestate-kona
 ```
 
-This builds both supported variants:
+A single Docker build produces both supported variants:
 
 - `kona-client` into `rust/kona/prestate-artifacts-cannon`
 - `kona-client-int` into `rust/kona/prestate-artifacts-cannon-interop`
+
+The stripped-of-context MIPS ELFs are also exported to `rust/kona/prestate-elfs`
+for offline inspection. They are not an input to anything.
 
 ### Build reproducible prestate artifacts for custom chains
 
@@ -24,6 +27,5 @@ To create a reproducible kona-client prestate build that supports custom or devn
 
 ```sh
 cd rust
-KONA_CUSTOM_CONFIGS_DIR=<custom_config_dir> \
-  just build-kona-reproducible-prestate-variant <kona-client|kona-client-int> <artifacts_output_dir>
+KONA_CUSTOM_CONFIGS_DIR=<custom_config_dir> just build-kona-reproducible-prestate
 ```

--- a/rust/kona/docker/fpvm-prestates/README.md
+++ b/rust/kona/docker/fpvm-prestates/README.md
@@ -18,9 +18,6 @@ A single Docker build produces both supported variants:
 - `kona-client` into `rust/kona/prestate-artifacts-cannon`
 - `kona-client-int` into `rust/kona/prestate-artifacts-cannon-interop`
 
-The stripped-of-context MIPS ELFs are also exported to `rust/kona/prestate-elfs`
-for offline inspection. They are not an input to anything.
-
 ### Build reproducible prestate artifacts for custom chains
 
 To create a reproducible kona-client prestate build that supports custom or devnet chain configurations that are not in the superchain-registry:

--- a/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -26,13 +26,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     cd /app/cannon && just cannon
 
 ################################################################
-#    Build kona-client ELF + generate prestate                 #
+#    Build kona-client ELFs + generate prestates                #
 ################################################################
 
 FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon-builder:v2.0.0 AS kona-build-env
 SHELL ["/bin/bash", "-c"]
-
-ARG VARIANT=kona-client
 
 # --- Layer 1: mise + pinned toolchains ---
 # mise's rust plugin bootstraps rustup at a pinned version and installs
@@ -97,37 +95,29 @@ ARG KONA_CUSTOM_CONFIGS=false
 COPY --from=kona-custom-configs / /usr/local/kona-custom-configs
 ENV KONA_CUSTOM_CONFIGS=${KONA_CUSTOM_CONFIGS}
 
-# --- Layer 5: Build kona-client ELF ---
+# --- Layer 5: Build the kona-client ELFs ---
 # build-kona-client-elf sets CARGO_BUILD_TARGET to the corrected target spec
-# from the source tree, overriding cannon-builder's baked-in spec.
+# from the source tree, overriding cannon-builder's baked-in spec. Every
+# variant is built in one cargo invocation so the shared dependency graph is
+# compiled once; stage-kona-client-elfs then lifts the ELFs out of the target
+# cache mount, which does not outlive this layer.
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/app/rust/target \
     cd /app/rust && \
     if [ "$KONA_CUSTOM_CONFIGS" = "true" ]; then \
       export KONA_CUSTOM_CONFIGS_DIR=/usr/local/kona-custom-configs; \
     fi && \
-    just build-kona-client-elf ${VARIANT} && \
-    cp /app/rust/target/mips64-unknown-none/release-client-lto/${VARIANT} /app/kona-elf
+    just build-kona-client-elf && \
+    just stage-kona-client-elfs /app/elf
 
 ################################################################
-#   Generate prestate                                          #
+#   Generate prestates                                          #
 ################################################################
 
 FROM kona-build-env AS prestate-build
 
 COPY --from=cannon-build /app/cannon/bin/cannon /app/cannon
-RUN /app/cannon load-elf \
-      --path=/app/kona-elf \
-      --out=/app/prestate.bin.gz \
-      --type multithreaded64-5 && \
-    /app/cannon run \
-      --proof-at "=0" \
-      --stop-at "=1" \
-      --input /app/prestate.bin.gz \
-      --meta /app/meta.json \
-      --proof-fmt "/app/%d.json" \
-      --output "" && \
-    mv /app/0.json /app/prestate-proof.json
+RUN cd /app/rust && just generate-kona-prestates /app/cannon /app/elf /app/out
 
 ################################################################
 #                       Export Artifacts                       #
@@ -135,6 +125,9 @@ RUN /app/cannon load-elf \
 
 FROM scratch AS export-stage
 
-COPY --from=prestate-build /app/prestate.bin.gz .
-COPY --from=prestate-build /app/prestate-proof.json .
-COPY --from=prestate-build /app/meta.json .
+# One directory per variant, named as the justfile's KONA_PRESTATE_VARIANTS
+# says, so `--output rust/kona` lands them where every consumer expects.
+COPY --from=prestate-build /app/out/ .
+# ELFs are exported outside prestate-artifacts-* so they stay out of the
+# CircleCI workspace; they exist for offline inspection (strings/objdump).
+COPY --from=prestate-build /app/elf/ ./prestate-elfs/

--- a/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -96,7 +96,7 @@ COPY --from=kona-custom-configs / /usr/local/kona-custom-configs
 ENV KONA_CUSTOM_CONFIGS=${KONA_CUSTOM_CONFIGS}
 
 # --- Layer 5: Build the kona-client ELFs ---
-# build-kona-client-elf sets CARGO_BUILD_TARGET to the corrected target spec
+# build-kona-client-elfs sets CARGO_BUILD_TARGET to the corrected target spec
 # from the source tree, overriding cannon-builder's baked-in spec. Every
 # variant is built in one cargo invocation so the shared dependency graph is
 # compiled once; stage-kona-client-elfs then lifts the ELFs out of the target
@@ -107,7 +107,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     if [ "$KONA_CUSTOM_CONFIGS" = "true" ]; then \
       export KONA_CUSTOM_CONFIGS_DIR=/usr/local/kona-custom-configs; \
     fi && \
-    just build-kona-client-elf && \
+    just build-kona-client-elfs && \
     just stage-kona-client-elfs /app/elf
 
 ################################################################

--- a/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -53,7 +53,7 @@ RUN mise trust && mise install rust go just jq
 
 # Rustup's cargo/rustc proxies go ahead of mise shims on PATH. Any
 # cargo call then resolves to the rustup proxy directly and respects
-# RUSTUP_TOOLCHAIN (set by build-kona-client-elf). If it went through
+# RUSTUP_TOOLCHAIN (set by build-kona-client-elfs). If it went through
 # the mise shim instead, mise would re-set RUSTUP_TOOLCHAIN to the
 # active rust from mise.toml (stable 1.95) and build the wrong
 # toolchain into the prestate.

--- a/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -128,6 +128,3 @@ FROM scratch AS export-stage
 # One directory per variant, named as the justfile's KONA_PRESTATE_VARIANTS
 # says, so `--output rust/kona` lands them where every consumer expects.
 COPY --from=prestate-build /app/out/ .
-# ELFs are exported outside prestate-artifacts-* so they stay out of the
-# CircleCI workspace; they exist for offline inspection (strings/objdump).
-COPY --from=prestate-build /app/elf/ ./prestate-elfs/

--- a/rust/kona/justfile
+++ b/rust/kona/justfile
@@ -132,9 +132,10 @@ build-native *args='':
   #!/usr/bin/env bash
   cargo build --workspace $@
 
-# Build `kona-client` for the `cannon` target using the reproducible build environment.
-# The bind mount of {{KONA_ROOT}}/../.. exposes the monorepo at /workdir, so the
-# kona-hardforks build script's ancestor walk for op-core/nuts/bundles succeeds.
+# Build the `kona-client` ELFs for the `cannon` target using the reproducible
+# build environment. The bind mount of {{KONA_ROOT}}/../.. exposes the monorepo
+# at /workdir, so the kona-hardforks build script's ancestor walk for
+# op-core/nuts/bundles succeeds.
 build-cannon-client: build-kona-env
   #!/usr/bin/env bash
   set -euo pipefail
@@ -142,7 +143,7 @@ build-cannon-client: build-kona-env
     -v {{KONA_ROOT}}/../..:/workdir \
     -w /workdir/rust \
     kona-cannon-env:local \
-    just build-kona-client-elf kona-client
+    just build-kona-client-elfs
 
 
 # Check for unused dependencies in the crate graph.


### PR DESCRIPTION
The reproducible prestate build ran one `docker build` per variant. Both variants are bins of the same package resolving to the same features, so the second build recompiled the whole dependency graph — 169 crates, including `core` and `compiler_builtins` — for nothing. In a representative `cannon-prestate` run the two cargo layers cost 181s + 157s of the job's 388s `Build prestates` step.

Build every variant in one docker build and one cargo invocation (`--bin kona-client --bin kona-client-int`). The variant table (cargo bin -> artifacts dir) now lives in one place in `rust/justfile` and drives the native build, the Docker build and the publish job, so the layout can't drift between them. `kona-publish-prestate-artifacts` drops its matrix and publishes both variants from one build.

Output paths are unchanged.

The second commit removes the `cannon-prestate` job's "Capture kona prestate debug artifacts" step. It was added in #19655 to debug #19654, which was fixed and closed in March; #19889 then dropped the ELFs from the Dockerfile export stage, so the copy has been silently doing nothing ever since — `2>/dev/null || true` hid the missing file, and the job's only stored artifact was `chainList.json`, which is just a copy of a file already in the tree at that revision. `cannon/README.md` pointed at the same deleted path; its instructions use the native build, so it now points at the cargo target dir.

## Measured

`Build prestates` **388.3s -> 231.6s** (-40%), same `large` 4-vCPU box; job total ~465s -> ~311s. Better than predicted: the single cargo layer finished in 2m55s for *both* bins versus 2m57s for one before, because the second fat-LTO link overlapped the first.

Prestate hashes are unchanged from the develop baseline (job 5377599, two separate builds):

| variant | develop | this PR |
|---|---|---|
| `kona-client` | `0x03b17294...cadeae` | `0x03b17294...cadeae` |
| `kona-client-int` | `0x0366f15c...c320b` | `0x0366f15c...c320b` |

## Test plan

The change rests on `--bin A --bin B` producing the same binaries as two separate invocations. Verified with a throwaway two-bin crate built under the prestate profile (`lto = "fat"`, `codegen-units = 1`, `panic = "abort"`, `strip = "none"`): both binaries are byte-identical whether built together or separately. CI then confirmed it end to end on the real build (hashes above).

Downstream consumers of the workspace artifacts pass: `memory-all-opn-op-reth`, `memory-all-kona-op-reth`, `kona-proof-action-single`.

`preimage-reproducibility` is unaffected: `build_prestates()` does `git checkout --force <tag>` and runs that checkout's own justfile, so every existing tag still builds the old way. For a future tag containing this change, the script's contract still holds — `just --show reproducible-prestate` resolves, and both `rust/kona/prestate-artifacts-cannon{,-interop}/{prestate-proof.json,prestate.bin.gz}` are produced.

Also checked locally:
- `just generate-kona-prestates` against a stub cannon produces the expected per-variant layout with the right ELF routed to each dir.
- `just build-kona-client-elf` emits `--bin kona-client --bin kona-client-int` by default and honours explicit variants, so `rust/kona/justfile`'s `build-cannon-client` still builds only `kona-client`.
- The merged CircleCI config diff contains only the intended hunks.
