### PR TITLE
op-acceptance-tests: fix SafeHeadProgression flake with progress-aware head waits

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
@@ -28,7 +28,16 @@ import (
 func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := newSupernodeInteropWithTimeTravel(t, 0)
-	attempts := 15 // each attempt is hardcoded with a 2s by the DSL.
+	// Head catch-up in this test is gated both by interop verification of the
+	// backlog and by continued block production, either of which can transiently
+	// stall under CI load (an EL momentarily starved of CPU can halt block
+	// production for tens of seconds before recovering on its own). A fixed
+	// attempt budget turns such a self-recovering stall into a flake. Wait
+	// progress-aware instead: keep a generous budget while the unsafe head keeps
+	// advancing, but fail fast if it stops advancing entirely (a genuine hang
+	// rather than slowness). See dsl.(*L2CLNode).ReachedWithProgressFn.
+	const catchUpMaxWait = 120 * time.Second
+	const catchUpStallTimeout = 40 * time.Second
 
 	finalTargetBlockNum := uint64(10)
 
@@ -50,10 +59,10 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	// check safe heads get to at least that height,
 	// let local safe heads run ahead
 	dsl.CheckAll(t,
-		sys.L2ACL.ReachedFn(safety.LocalSafe, finalTargetBlockNum, attempts),
-		sys.L2BCL.ReachedFn(safety.LocalSafe, finalTargetBlockNum, attempts),
-		sys.L2ACL.ReachedFn(safety.CrossSafe, initialTargetBlockNumA-1, attempts),
-		sys.L2BCL.ReachedFn(safety.CrossSafe, initialTargetBlockNumB-1, attempts),
+		sys.L2ACL.ReachedWithProgressFn(safety.LocalSafe, safety.LocalUnsafe, finalTargetBlockNum, catchUpMaxWait, catchUpStallTimeout),
+		sys.L2BCL.ReachedWithProgressFn(safety.LocalSafe, safety.LocalUnsafe, finalTargetBlockNum, catchUpMaxWait, catchUpStallTimeout),
+		sys.L2ACL.ReachedWithProgressFn(safety.CrossSafe, safety.LocalUnsafe, initialTargetBlockNumA-1, catchUpMaxWait, catchUpStallTimeout),
+		sys.L2BCL.ReachedWithProgressFn(safety.CrossSafe, safety.LocalUnsafe, initialTargetBlockNumB-1, catchUpMaxWait, catchUpStallTimeout),
 	)
 
 	// Expect cross safe and finalized to stall since we paused the interop activity
@@ -79,16 +88,6 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	// Resume interop verification
 	// expect cross safe to catch up on both CL and EL
 	sys.Supernode.ResumeInterop()
-	// Catching up after resume is gated both by interop verification of the
-	// backlog and by continued block production, either of which can transiently
-	// stall under CI load (an EL momentarily starved of CPU can halt block
-	// production for tens of seconds before recovering on its own). A fixed
-	// attempt budget turns such a self-recovering stall into a flake. Wait
-	// progress-aware instead: keep a generous budget while the unsafe head keeps
-	// advancing, but fail fast if it stops advancing entirely (a genuine hang
-	// rather than slowness). See dsl.(*L2CLNode).ReachedWithProgressFn.
-	const catchUpMaxWait = 120 * time.Second
-	const catchUpStallTimeout = 40 * time.Second
 	dsl.CheckAll(t,
 		sys.L2ACL.ReachedWithProgressFn(safety.CrossSafe, safety.LocalUnsafe, finalTargetBlockNum, catchUpMaxWait, catchUpStallTimeout),
 		sys.L2BCL.ReachedWithProgressFn(safety.CrossSafe, safety.LocalUnsafe, finalTargetBlockNum, catchUpMaxWait, catchUpStallTimeout),

--- a/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
@@ -79,11 +79,21 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	// Resume interop verification
 	// expect cross safe to catch up on both CL and EL
 	sys.Supernode.ResumeInterop()
+	// Catching up after resume is gated both by interop verification of the
+	// backlog and by continued block production, either of which can transiently
+	// stall under CI load (an EL momentarily starved of CPU can halt block
+	// production for tens of seconds before recovering on its own). A fixed
+	// attempt budget turns such a self-recovering stall into a flake. Wait
+	// progress-aware instead: keep a generous budget while the unsafe head keeps
+	// advancing, but fail fast if it stops advancing entirely (a genuine hang
+	// rather than slowness). See dsl.(*L2CLNode).ReachedWithProgressFn.
+	const catchUpMaxWait = 120 * time.Second
+	const catchUpStallTimeout = 40 * time.Second
 	dsl.CheckAll(t,
-		sys.L2ACL.ReachedFn(safety.CrossSafe, finalTargetBlockNum, attempts),
-		sys.L2BCL.ReachedFn(safety.CrossSafe, finalTargetBlockNum, attempts),
-		sys.L2ELA.ReachedFn(eth.Safe, finalTargetBlockNum, attempts),
-		sys.L2ELB.ReachedFn(eth.Safe, finalTargetBlockNum, attempts),
+		sys.L2ACL.ReachedWithProgressFn(safety.CrossSafe, safety.LocalUnsafe, finalTargetBlockNum, catchUpMaxWait, catchUpStallTimeout),
+		sys.L2BCL.ReachedWithProgressFn(safety.CrossSafe, safety.LocalUnsafe, finalTargetBlockNum, catchUpMaxWait, catchUpStallTimeout),
+		sys.L2ELA.ReachedWithProgressFn(eth.Safe, eth.Unsafe, finalTargetBlockNum, catchUpMaxWait, catchUpStallTimeout),
+		sys.L2ELB.ReachedWithProgressFn(eth.Safe, eth.Unsafe, finalTargetBlockNum, catchUpMaxWait, catchUpStallTimeout),
 	)
 
 	// check EL labels

--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -162,6 +162,62 @@ func MatchedWithProgressFn(baseNode, refNode SyncStatusProvider, log log.Logger,
 	}
 }
 
+// awaitHeadWithProgress waits for headFn to reach target, distinguishing a
+// self-recovering slowdown from a genuinely stuck chain. It succeeds as soon as
+// headFn reaches target. It fails when either progressFn (a strictly more-live
+// head) has not advanced for stallTimeout — the chain is genuinely wedged, not
+// merely slow — or the overall maxWait elapses. Lookup errors are logged and
+// retried, bounded by the same cutoffs. Polls every 2s.
+//
+// failPrefix opens both failure messages; progressName names the progress head
+// in the stall message. Backs the ReachedWithProgressFn methods of L2CLNode and
+// L2ELNode.
+func awaitHeadWithProgress(ctx context.Context, logger log.Logger, headFn, progressFn func() (uint64, error), target uint64, maxWait, stallTimeout time.Duration, failPrefix, progressName string) error {
+	logger.Info("Expecting head to reach (progress-aware)", "max_wait", maxWait, "stall_timeout", stallTimeout)
+
+	deadline := time.Now().Add(maxWait)
+	lastProgress := uint64(0)
+	if p, err := progressFn(); err == nil {
+		lastProgress = p
+	}
+	lastProgressTime := time.Now()
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		if head, err := headFn(); err != nil {
+			logger.Warn("head lookup failed; will retry", "err", err)
+		} else if head >= target {
+			logger.Info("Head advanced", "target", target)
+			return nil
+		}
+
+		now := time.Now()
+		if p, err := progressFn(); err != nil {
+			logger.Warn("progress-head lookup failed; will retry", "err", err)
+		} else if p > lastProgress {
+			lastProgress = p
+			lastProgressTime = now
+		}
+
+		stalledFor := now.Sub(lastProgressTime)
+		logger.Info("Head sync status (progress-aware)", "progress", lastProgress, "stalled_for", stalledFor)
+		if stalledFor >= stallTimeout {
+			return fmt.Errorf("%s: %s progress stalled at %d for %s", failPrefix, progressName, lastProgress, stalledFor)
+		}
+		if now.After(deadline) {
+			return fmt.Errorf("%s: timeout after %s (progress at %d)", failPrefix, maxWait, lastProgress)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
 // maxInSyncGap is the largest difference (in blocks) between two node heads
 // that InSyncFn will tolerate while still considering the nodes in sync. If
 // the heads are further apart than this the slower node has not caught up yet.

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -305,6 +305,69 @@ func (cl *L2CLNode) ReachedFn(lvl safety.Level, target uint64, attempts int) Che
 	}
 }
 
+// ReachedWithProgressFn waits for the head at lvl to reach target, but instead
+// of a fixed attempt budget it distinguishes a self-recovering slowdown from a
+// genuinely stuck pipeline. It succeeds as soon as lvl reaches target. It fails
+// when either:
+//   - progressLvl (a strictly more-live head, e.g. LocalUnsafe) has not advanced
+//     for stallTimeout — the node is genuinely wedged, not merely slow; or
+//   - the overall maxWait elapses.
+//
+// This is the "reach a target" analogue of MatchedWithProgressFn. Use it for a
+// catch-up wait whose target head is gated by a pipeline that can transiently
+// stall under load (e.g. CrossSafe catching up after interop resumes, where the
+// EL can be briefly starved) without masking a permanent hang: as long as the
+// chain keeps producing blocks the budget stays generous, but a chain that stops
+// advancing entirely fails fast. Polls every 2s.
+func (cl *L2CLNode) ReachedWithProgressFn(lvl, progressLvl safety.Level, target uint64, maxWait, stallTimeout time.Duration) CheckFunc {
+	return func() error {
+		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "progress_label", progressLvl, "target", target)
+		logger.Info("Expecting chain to reach (progress-aware)", "max_wait", maxWait, "stall_timeout", stallTimeout)
+
+		deadline := time.Now().Add(maxWait)
+		lastProgress := uint64(0)
+		if p, err := cl.headBlockRef(progressLvl); err == nil {
+			lastProgress = p.Number
+		}
+		lastProgressTime := time.Now()
+
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			if head, err := cl.headBlockRef(lvl); err != nil {
+				logger.Warn("SyncStatus RPC failed; will retry", "err", err)
+			} else if head.Number >= target {
+				logger.Info("Chain advanced", "target", target)
+				return nil
+			}
+
+			now := time.Now()
+			if p, err := cl.headBlockRef(progressLvl); err != nil {
+				logger.Warn("progress-head lookup failed; will retry", "err", err)
+			} else if p.Number > lastProgress {
+				lastProgress = p.Number
+				lastProgressTime = now
+			}
+
+			stalledFor := now.Sub(lastProgressTime)
+			logger.Info("Chain sync status (progress-aware)", "progress", lastProgress, "stalled_for", stalledFor)
+			if stalledFor >= stallTimeout {
+				return fmt.Errorf("expected head to advance: %s: %s progress stalled at %d for %s", lvl, progressLvl, lastProgress, stalledFor)
+			}
+			if now.After(deadline) {
+				return fmt.Errorf("expected head to advance: %s: timeout after %s (progress at %d)", lvl, maxWait, lastProgress)
+			}
+
+			select {
+			case <-cl.ctx.Done():
+				return cl.ctx.Err()
+			case <-ticker.C:
+			}
+		}
+	}
+}
+
 // ReachedRefFn is same as Reached, but has an additional check to ensure that the block referenced is not reorged
 // Composable with other lambdas to wait in parallel
 func (cl *L2CLNode) ReachedRefFn(lvl safety.Level, target eth.BlockID, attempts int) CheckFunc {

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -322,49 +322,14 @@ func (cl *L2CLNode) ReachedFn(lvl safety.Level, target uint64, attempts int) Che
 func (cl *L2CLNode) ReachedWithProgressFn(lvl, progressLvl safety.Level, target uint64, maxWait, stallTimeout time.Duration) CheckFunc {
 	return func() error {
 		logger := cl.log.With("name", cl.inner.Name(), "chain", cl.ChainID(), "label", lvl, "progress_label", progressLvl, "target", target)
-		logger.Info("Expecting chain to reach (progress-aware)", "max_wait", maxWait, "stall_timeout", stallTimeout)
-
-		deadline := time.Now().Add(maxWait)
-		lastProgress := uint64(0)
-		if p, err := cl.headBlockRef(progressLvl); err == nil {
-			lastProgress = p.Number
-		}
-		lastProgressTime := time.Now()
-
-		ticker := time.NewTicker(2 * time.Second)
-		defer ticker.Stop()
-
-		for {
-			if head, err := cl.headBlockRef(lvl); err != nil {
-				logger.Warn("SyncStatus RPC failed; will retry", "err", err)
-			} else if head.Number >= target {
-				logger.Info("Chain advanced", "target", target)
-				return nil
-			}
-
-			now := time.Now()
-			if p, err := cl.headBlockRef(progressLvl); err != nil {
-				logger.Warn("progress-head lookup failed; will retry", "err", err)
-			} else if p.Number > lastProgress {
-				lastProgress = p.Number
-				lastProgressTime = now
-			}
-
-			stalledFor := now.Sub(lastProgressTime)
-			logger.Info("Chain sync status (progress-aware)", "progress", lastProgress, "stalled_for", stalledFor)
-			if stalledFor >= stallTimeout {
-				return fmt.Errorf("expected head to advance: %s: %s progress stalled at %d for %s", lvl, progressLvl, lastProgress, stalledFor)
-			}
-			if now.After(deadline) {
-				return fmt.Errorf("expected head to advance: %s: timeout after %s (progress at %d)", lvl, maxWait, lastProgress)
-			}
-
-			select {
-			case <-cl.ctx.Done():
-				return cl.ctx.Err()
-			case <-ticker.C:
+		headNum := func(l safety.Level) func() (uint64, error) {
+			return func() (uint64, error) {
+				ref, err := cl.headBlockRef(l)
+				return ref.Number, err
 			}
 		}
+		return awaitHeadWithProgress(cl.ctx, logger, headNum(lvl), headNum(progressLvl), target, maxWait, stallTimeout,
+			fmt.Sprintf("expected head to advance: %s", lvl), progressLvl.String())
 	}
 }
 

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -194,6 +194,63 @@ func (el *L2ELNode) ReachedFn(label eth.BlockLabel, target uint64, attempts int)
 	}
 }
 
+// ReachedWithProgressFn is the progress-aware analogue of ReachedFn: it waits
+// for the head at label to reach target, tolerating a self-recovering slowdown
+// while failing fast on a genuinely stuck node. It succeeds when label reaches
+// target, and fails when either progressLabel (a strictly more-live label, e.g.
+// eth.Unsafe) has not advanced for stallTimeout, or the overall maxWait elapses.
+// Use it for a catch-up wait whose target head is gated by a pipeline that can
+// transiently stall under load (e.g. the EL safe label catching up after interop
+// resumes). Polls every 2s. See L2CLNode.ReachedWithProgressFn.
+func (el *L2ELNode) ReachedWithProgressFn(label, progressLabel eth.BlockLabel, target uint64, maxWait, stallTimeout time.Duration) CheckFunc {
+	return func() error {
+		logger := el.log.With("name", el.inner.Name(), "chain", el.ChainID(), "label", label, "progress_label", progressLabel, "target", target)
+		logger.Info("Expecting L2EL to reach (progress-aware)", "max_wait", maxWait, "stall_timeout", stallTimeout)
+
+		deadline := time.Now().Add(maxWait)
+		lastProgress := uint64(0)
+		if p, err := el.blockRefByLabel(progressLabel); err == nil {
+			lastProgress = p.Number
+		}
+		lastProgressTime := time.Now()
+
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			if head, err := el.blockRefByLabel(label); err != nil {
+				logger.Warn("block-label lookup failed; will retry", "err", err)
+			} else if head.Number >= target {
+				logger.Info("L2EL advanced", "target", target)
+				return nil
+			}
+
+			now := time.Now()
+			if p, err := el.blockRefByLabel(progressLabel); err != nil {
+				logger.Warn("progress-label lookup failed; will retry", "err", err)
+			} else if p.Number > lastProgress {
+				lastProgress = p.Number
+				lastProgressTime = now
+			}
+
+			stalledFor := now.Sub(lastProgressTime)
+			logger.Info("L2EL sync status (progress-aware)", "progress", lastProgress, "stalled_for", stalledFor)
+			if stalledFor >= stallTimeout {
+				return fmt.Errorf("expected head for label=%s to advance to target=%d: %s progress stalled at %d for %s", label, target, progressLabel, lastProgress, stalledFor)
+			}
+			if now.After(deadline) {
+				return fmt.Errorf("expected head for label=%s to advance to target=%d: timeout after %s (progress at %d)", label, target, maxWait, lastProgress)
+			}
+
+			select {
+			case <-el.ctx.Done():
+				return el.ctx.Err()
+			case <-ticker.C:
+			}
+		}
+	}
+}
+
 func (el *L2ELNode) BlockRefByNumber(num uint64) eth.L2BlockRef {
 	ctx, cancel := context.WithTimeout(el.ctx, DefaultTimeout)
 	defer cancel()

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -205,49 +205,14 @@ func (el *L2ELNode) ReachedFn(label eth.BlockLabel, target uint64, attempts int)
 func (el *L2ELNode) ReachedWithProgressFn(label, progressLabel eth.BlockLabel, target uint64, maxWait, stallTimeout time.Duration) CheckFunc {
 	return func() error {
 		logger := el.log.With("name", el.inner.Name(), "chain", el.ChainID(), "label", label, "progress_label", progressLabel, "target", target)
-		logger.Info("Expecting L2EL to reach (progress-aware)", "max_wait", maxWait, "stall_timeout", stallTimeout)
-
-		deadline := time.Now().Add(maxWait)
-		lastProgress := uint64(0)
-		if p, err := el.blockRefByLabel(progressLabel); err == nil {
-			lastProgress = p.Number
-		}
-		lastProgressTime := time.Now()
-
-		ticker := time.NewTicker(2 * time.Second)
-		defer ticker.Stop()
-
-		for {
-			if head, err := el.blockRefByLabel(label); err != nil {
-				logger.Warn("block-label lookup failed; will retry", "err", err)
-			} else if head.Number >= target {
-				logger.Info("L2EL advanced", "target", target)
-				return nil
-			}
-
-			now := time.Now()
-			if p, err := el.blockRefByLabel(progressLabel); err != nil {
-				logger.Warn("progress-label lookup failed; will retry", "err", err)
-			} else if p.Number > lastProgress {
-				lastProgress = p.Number
-				lastProgressTime = now
-			}
-
-			stalledFor := now.Sub(lastProgressTime)
-			logger.Info("L2EL sync status (progress-aware)", "progress", lastProgress, "stalled_for", stalledFor)
-			if stalledFor >= stallTimeout {
-				return fmt.Errorf("expected head for label=%s to advance to target=%d: %s progress stalled at %d for %s", label, target, progressLabel, lastProgress, stalledFor)
-			}
-			if now.After(deadline) {
-				return fmt.Errorf("expected head for label=%s to advance to target=%d: timeout after %s (progress at %d)", label, target, maxWait, lastProgress)
-			}
-
-			select {
-			case <-el.ctx.Done():
-				return el.ctx.Err()
-			case <-ticker.C:
+		headNum := func(l eth.BlockLabel) func() (uint64, error) {
+			return func() (uint64, error) {
+				ref, err := el.blockRefByLabel(l)
+				return ref.Number, err
 			}
 		}
+		return awaitHeadWithProgress(el.ctx, logger, headNum(label), headNum(progressLabel), target, maxWait, stallTimeout,
+			fmt.Sprintf("expected head for label=%s to advance to target=%d", label, target), string(progressLabel))
 	}
 }
 


### PR DESCRIPTION
Fixes the current manifestation of the `TestSupernodeInterop_SafeHeadProgression` flake: the post-resume cross-safe wait added in #20852 (15 attempts × 2s) exhausts its budget when the devnet transiently stalls under CI load, e.g. `operation failed permanently after 15 attempts: expected head to advance: safe` (job 5357345, 2026-07-22).

**Root cause** — whole-devnet CPU starvation on oversubscribed CI (8 parallel acceptance packages × 2 op-reth ELs): in the failing run op-reth went silent ~10s, the unsafe tip froze for ~19.7s, L1 block production froze simultaneously (ruling out an op-reth-internal payload bug; the repeated `Unknown payload` seal failures are a downstream symptom), and cross-safe crept 4→7 while the 30s budget expired. Healthy runs catch up in <5s — the stall self-recovers, so a fixed budget converts slowness into flakes.

**Fix** — new `ReachedWithProgressFn` on the devstack CL/EL DSL (analogue of the existing `MatchedWithProgressFn`): waits up to `maxWait=120s` *while the unsafe tip keeps advancing*, but fails with a legible error after `stallTimeout=40s` of zero unsafe progress. Both the post-resume and the same-class pre-pause `CheckAll` are converted. Not a blind timeout bump: a genuinely hung devnet fails at the 40s stall cutoff at check level (test-level wall time can reach ~120s, since `dsl.CheckAll`'s errgroup has no cancellation).

**Verification** — deterministic fault injection (`SIGSTOP` both op-reth pids for 28s at "interop pause cleared", then `SIGCONT`, with kona-node + op-reth):
- baseline: 4/4 fail with the exact CI symptom;
- fixed: 0/3 fail (stall tolerated, target reached);
- never-`SIGCONT` variant: fails legibly at the 40s stall timeout (`unsafe progress stalled at 14 for 40.00s`), confirming hangs are still caught.
- plain 6×-parallel CPU contention did not reproduce this failure mode (a pathological sustained-load batch instead crashed services and failed later at the finalized check — a different mode; see residual below).

Converted test passes end-to-end on this branch (152s, default clients). Compile/vet/gofmt clean.

**Residual (out of scope)** — the finalized-head `CheckAll` (30 fixed attempts) is the same class and can fail under pathological sustained load; left as-is since finalized advancement is gated on L1 finality, not interop backlog. Progress-signal choice (`LocalUnsafe` rather than `LocalSafe`) follows the existing `MatchedWithProgressFn` precedent.

Closes #20851

🤖 Generated with [Claude Code](https://claude.com/claude-code)