### PR TITLE
ci: emit scoped-commit titles from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,5 +19,7 @@
   "dependencyDashboardTitle": "Renovate CVE Dashboard",
   "postUpdateOptions": ["gomodTidy"],
   "prConcurrentLimit": 5,
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
+  "semanticCommits": "disabled",
+  "commitMessagePrefix": "deps:"
 }


### PR DESCRIPTION
Follow-up to the Renovate rollout. Renovate's default Conventional Commits titles (`chore(deps):`, `fix(deps):`) fail the repository's Scoped Commits subject check, which rejects conventional type prefixes.

This disables Renovate's semantic-commit formatting and prefixes subjects with a `deps:` scope, so its PR titles become `deps: update module … [security]` and pass the check. After this merges, Renovate rebases its open PRs with conforming titles.