### PR TITLE
CODEOWNERS: set team consensus as derivation code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,8 @@
 
 # Expert areas
 
-/op-node/rollup/derive @ethereum-optimism/protocol # exclusive
-/rust/kona/crates/protocol @ethereum-optimism/protocol # exclusive
+/op-node/rollup/derive @ethereum-optimism/consensus # exclusive
+/rust/kona/crates/protocol @ethereum-optimism/consensus # exclusive
 
 /op-deployer    @ethereum-optimism/core-team @ethereum-optimism/monorepo-reviewers
 


### PR DESCRIPTION
Follow up to https://github.com/ethereum-optimism/optimism/pull/21967 to set consensus directory code owners back to team [consensus](https://github.com/orgs/ethereum-optimism/teams/consensus).