### PR TITLE
ci: group version-locked deps in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,21 @@
       "description": "Turn OFF all generic version updates.",
       "matchPackageNames": ["*"],
       "enabled": false
+    },
+    {
+      "description": "Group version-locked OpenTelemetry deps (Rust crates + Go modules) so coupled versions bump together in one buildable PR.",
+      "matchPackageNames": ["/^opentelemetry/", "/^tracing-opentelemetry$/", "/^go\\.opentelemetry\\.io\\//"],
+      "groupName": "opentelemetry"
+    },
+    {
+      "description": "Group Alloy crates so coupled versions bump together.",
+      "matchPackageNames": ["/^alloy/", "/^op-alloy/"],
+      "groupName": "alloy"
+    },
+    {
+      "description": "Group libp2p crates so coupled versions bump together.",
+      "matchPackageNames": ["/^libp2p/"],
+      "groupName": "libp2p"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
Follow-up to the Renovate rollout. Adds `packageRules` that group the **OpenTelemetry**, **Alloy**, and **libp2p** dependency families so their version-locked members bump together in a single PR.

Motivation: bumping one member of these ecosystems in isolation produces an inconsistent `Cargo.lock` that fails the `--locked` build (e.g. the standalone `opentelemetry_sdk` security bump). Grouping keeps each family's update coherent and buildable, while unrelated advisories still get their own isolated PRs.