### PR TITLE
[DO NOT MERGE] scratch: verify eth69 Slack flaky-alert end-to-end

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -289,6 +289,19 @@ jobs:
           path: <<parameters.directory>>/target/nextest
           destination: nextest-junit
           when: always
+      # SCRATCH SELF-TEST — DO NOT MERGE. Injects a synthetic <flakyFailure> after the
+      # artifact/results upload (so those stay clean) to force the Slack step to fire once,
+      # proving token/channel/mentions end to end. Revert before this branch is anything
+      # but a throwaway.
+      - run:
+          name: SCRATCH inject fake flaky result
+          when: always
+          working_directory: <<parameters.directory>>
+          command: |
+            f=target/nextest/default/junit.xml
+            [ -f "$f" ] || printf '<testsuites></testsuites>' > "$f"
+            sed -i 's#</testsuites>#<testsuite name="slack-selftest"><testcase name="SLACK_ALERT_SELFTEST"><flakyFailure message="scratch self-test, ignore"/></testcase></testsuite></testsuites>#' "$f"
+            echo "injected synthetic flakyFailure into $f"
       # A retried flake (e.g. the eth69 teardown SIGSEGV, #20973) passes on rerun and
       # leaves the job GREEN, so nothing else surfaces it — CircleCI does not parse
       # nextest's <flakyFailure> element, so store_test_results/Insights stay blind. Detect

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -273,6 +273,70 @@ jobs:
           working_directory: <<parameters.directory>>
           no_output_timeout: 40m
           command: just <<parameters.command>> <<parameters.flags>>
+      # Upload per-test results (from the [profile.default.junit] config in
+      # rust/.config/nextest.toml) to CircleCI's Tests tab — the first test-results for
+      # rust CI, which previously had none. Normal pass/fail/timing visibility; it does
+      # NOT surface a retried flake (CircleCI ignores nextest's <flakyFailure> element —
+      # hence the Slack step below). Store steps run even after a failed test step by
+      # CircleCI design; the `when` key is ignored on them, so it is not load-bearing.
+      - store_test_results:
+          path: <<parameters.directory>>/target/nextest
+          when: always
+      # Keep the raw JUnit report (written by the [profile.default.junit] config in
+      # rust/.config/nextest.toml) as a downloadable artifact. For a retried flake this is
+      # where the failed attempt's captured stderr — including the crash backtrace — lives.
+      - store_artifacts:
+          path: <<parameters.directory>>/target/nextest
+          destination: nextest-junit
+          when: always
+      # A retried flake (e.g. the eth69 teardown SIGSEGV, #20973) passes on rerun and
+      # leaves the job GREEN, so nothing else surfaces it — CircleCI does not parse
+      # nextest's <flakyFailure> element, so store_test_results/Insights stay blind. Detect
+      # it ourselves and ping Slack. Every occurrence is a rare, precious data point (the
+      # crash has never reproduced locally), so alert on every branch, not just develop —
+      # a stack lost on a PR run is a stack lost. Fork PRs get no SLACK_ACCESS_TOKEN and
+      # self-skip. Only tests with a retry override can emit <flakyFailure>, so today this
+      # fires only for the one tracked flake. This step must never fail the job (the retry
+      # passing is the whole point).
+      - run:
+          name: Alert Slack on a flaky retry
+          when: always
+          working_directory: <<parameters.directory>>
+          command: |
+            junit="target/nextest/default/junit.xml"
+            # Split the missing-file and no-flake cases: if the path ever drifts (profile
+            # or target-dir change) the alert must announce it's broken, not look healthy.
+            if [ ! -f "$junit" ]; then
+              echo "junit report not found at $junit — flake alerting is broken, fix the path"; exit 0
+            fi
+            # Match <flaky, covering both <flakyFailure> (test abort/failure, e.g. the SIGSEGV)
+            # and <flakyError> (exec error / timeout, if the teardown bug ever hangs); still
+            # ignores <rerunFailure> (all attempts failed → the job is already red).
+            if ! grep -q '<flaky' "$junit"; then
+              echo "no flaky retries recorded"; exit 0
+            fi
+            if [ -z "${SLACK_ACCESS_TOKEN:-}" ]; then
+              echo "flaky retry detected but SLACK_ACCESS_TOKEN is unset; cannot notify"; exit 0
+            fi
+            # testcase name precedes its <flaky...> child; collect the distinct ones. The
+            # `|| true` keeps a tool hiccup from failing the job (the step's whole contract).
+            tests=$(awk -F'"' '/<testcase /{n=$2} /<flaky/{print n}' "$junit" | sort -u | paste -sd, - || true)
+            [ -n "$tests" ] || tests="unknown"
+            text=":rotating_light: <@U04J4QNR84S> <@U09HDPERU78> nextest flaky retry on job $CIRCLE_JOB (branch ${CIRCLE_BRANCH:-?}): $tests passed only after a crash/failed attempt (likely the #20973 teardown SIGSEGV). Backtrace is in the nextest-junit artifact: $CIRCLE_BUILD_URL"
+            # <@U04J4QNR84S> = @seb, <@U09HDPERU78> = @einar. Form-encode the body
+            # (--data-urlencode) instead of hand-building JSON: $CIRCLE_BRANCH is
+            # user-controlled and a git ref may contain " or \, which would break the JSON.
+            # Bearer token via a stdin header (-H @-) keeps it out of the process table.
+            # Slack returns HTTP 200 with {"ok":false,...} on auth/channel errors, which -sf
+            # would miss, so check "ok" explicitly. This must never fail the job.
+            resp=$(printf 'Authorization: Bearer %s\n' "$SLACK_ACCESS_TOKEN" \
+              | curl -s --max-time 30 -H @- https://slack.com/api/chat.postMessage \
+                  --data-urlencode "channel=C03N11M0BBN" \
+                  --data-urlencode "text=$text" \
+                  --data-urlencode "unfurl_links=false") || resp='{"ok":false,"error":"curl transport failure"}'
+            echo "slack response: $resp"
+            echo "$resp" | grep -q '"ok":true' || echo "SLACK POST FAILED (non-fatal) — check token/channel/mentions"
+            exit 0
       - rust-save-build-cache: *tests-cache-args
 
   # Cross-language differential test: runs the Go and Rust dumps of the Interop
@@ -788,7 +852,15 @@ workflows:
           name: rust-deny
           directory: rust
           command: "just deny"
-          context: *rust-ci-context
+          # Not the shared *rust-ci-context anchor: this job and the two cargo-test jobs
+          # below additionally need the `slack` context (SLACK_ACCESS_TOKEN) — rust-deny to
+          # ping @protocol-oncall on a develop failure (below), the test jobs for the
+          # flaky-retry alert. Scoped to just these three; the 20+ lint/build jobs on
+          # *rust-ci-context have no business holding a Slack bot token.
+          context: &rust-ci-context-slack
+            - circleci-repo-readonly-authenticated-github-token
+            - sccache-gcs-optimism
+            - slack
           # cargo-deny (advisory/license/ban audit) only gates develop, not
           # PRs/branches. It is intentionally not part of required-rust-ci.
           filters:
@@ -808,7 +880,8 @@ workflows:
       - rust-ci-cargo-tests:
           name: rust-tests
           directory: rust
-          context: *rust-ci-context
+          # Adds the `slack` context for the flaky-retry alert step (anchor on rust-deny).
+          context: *rust-ci-context-slack
 
       - interop-deposits-go-rust-diff:
           name: interop-deposits-diff
@@ -880,7 +953,8 @@ workflows:
           directory: rust
           command: "--justfile op-reth/justfile test-integration"
           cache_profile: debug
-          context: *rust-ci-context
+          # Adds the `slack` context for the flaky-retry alert step (anchor on rust-deny).
+          context: *rust-ci-context-slack
 
       # -----------------------------------------------------------------------
       # Kona crate-specific jobs (lint, FPVM builds, host-client offline)

--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -1,0 +1,42 @@
+# Nextest configuration for the `rust/` workspace.
+#
+# This is the only nextest config monorepo CI reads. `rust/op-reth/.config/nextest.toml`
+# is never loaded: op-reth has no standalone Cargo workspace (its crates are members of
+# `rust/Cargo.toml`), and nextest resolves config relative to the workspace root.
+
+# `p2p_version::peers_negotiate_eth_69` intermittently dies with SIGSEGV *after* its body
+# has passed — the assertions succeed and nextest prints `test result: ok`, then the test
+# binary segfaults during teardown. nextest fails the run purely on the signal exit, which
+# has repeatedly ejected unrelated PRs from the merge queue.
+#
+# Retrying is sound here specifically because the crash is teardown-only: nextest reruns in
+# a fresh process, so a pass on retry re-establishes every assertion from scratch rather
+# than papering over a failed one.
+#
+# The retry turns a red job green, so the recurrence would otherwise go unnoticed.
+# The `[profile.default.junit]` report below records the failed attempt as a
+# `<flakyFailure>` carrying its captured stderr; the cargo-test CI job greps that report
+# and pings Slack on a hit (CircleCI does not parse `<flakyFailure>`, so its Tests tab and
+# Insights stay blind — the detection is ours, not theirs).
+#
+# This is a stopgap, not a fix — the crash mechanism is unresolved and tracked in
+# ethereum-optimism/optimism#20973. Remove this override once it is fixed.
+#
+# On the filter form: a `binary_id(reth-optimism-node::it)` predicate would scope this to
+# one binary, but nextest validates override filters against the whole-workspace binary
+# namespace, so a future crate/binary rename would make it match nothing and hard-error
+# *every* nextest run in `rust/`. A `test(=exact)` predicate degrades gracefully to a
+# no-op instead. The `=` is load-bearing: bare `test(...)` is a substring match, so a
+# later sibling such as `peers_negotiate_eth_69_disconnect` would silently inherit these
+# retries — the accidental flake-masking this override exists to avoid.
+[[profile.default.overrides]]
+filter = 'test(=p2p_version::peers_negotiate_eth_69)'
+retries = 2
+
+# Emit a JUnit report for every nextest run in this workspace. The cargo-test CI job uses
+# it three ways: `store_test_results` for CircleCI's Tests tab (per-test pass/fail/timing —
+# the first test-results for rust CI), a grep for `<flakyFailure>` to detect a retried flake
+# and alert on Slack, and a raw-XML artifact so the failed attempt's captured stderr stays
+# retrievable. Written to `target/nextest/default/junit.xml` (relative to the report dir).
+[profile.default.junit]
+path = "junit.xml"


### PR DESCRIPTION
Throwaway branch to prove the flaky-retry Slack alert from #21909 actually posts (token/channel/mentions) before the first real flake, per review feedback. Injects a synthetic `<flakyFailure>` after the artifact upload so the alert step fires once on this run. **Do not merge — will be deleted once the ping is confirmed.**

🤖 *Co-created with Claude Opus 4.8 (1M context)*