### PR TITLE
ci: add diff-aware dependency review gate

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency Review
+
+# Diff-aware dependency CVE gate: fails a PR only on High/Critical
+# vulnerabilities it *introduces*, using GitHub's Dependency Review API
+# (base vs head diff). It does not report the pre-existing backlog.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-on-pr: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,4 +21,4 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
-          comment-on-pr: true
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,24 +1,10 @@
 name: Dependency Review
 
-# Diff-aware dependency CVE gate: fails a PR only on High/Critical
-# vulnerabilities it *introduces*, using GitHub's Dependency Review API
-# (base vs head diff). It does not report the pre-existing backlog.
-
-on:
-  pull_request:
-
-permissions:
-  contents: read
-  pull-requests: write
+on: pull_request
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Dependency Review
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
-        with:
-          fail-on-severity: high
-          comment-summary-in-pr: on-failure
+    uses: ethereum-optimism/factory/.github/workflows/dependency-review.yaml@0a5a01da201169813de992b8c2dac6e7999f5d51
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
Adds `actions/dependency-review-action` (SHA-pinned) as a `pull_request` check that fails only on **High/Critical** dependency vulnerabilities a PR **introduces**, using GitHub's Dependency Review API (base-vs-head diff).

Why: unlike a whole-lockfile scan, this gates on *ingress* — it does not re-flag the pre-existing backlog on every PR, so unrelated dependency bumps aren't blocked by findings they didn't introduce. Covers Go, npm/pnpm, and Cargo (all already in the repo's dependency graph). Free on this public repo (no Advanced Security license), `GITHUB_TOKEN` only. Complements Renovate, which opens the remediation PRs.

Scope note: this is dependency (SCA) gating only — it does not replace secrets/IaC/SAST/container/cloud scanning. `comment-on-pr` needs `pull-requests: write`, which fork PRs don't get, so on external forks the summary posts to the job log instead of a comment; the gate itself still runs.