### PR TITLE
ci: introduce a known CVE to validate the dependency-review gate (DO NOT MERGE)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,9 @@ go 1.26.0
 
 toolchain go1.26.5
 
+// DELIBERATE test-only vulnerable dependency (GHSA-r277-6w6q-xmqw, Critical) to validate the dependency-review gate. DO NOT MERGE.
+require github.com/getkin/kin-openapi v0.143.0
+
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/Masterminds/semver/v3 v3.3.1


### PR DESCRIPTION
**Test PR — do not merge.** Validates #22079.

Adds `github.com/getkin/kin-openapi v0.143.0`, which carries a **Critical** advisory (`GHSA-r277-6w6q-xmqw`), on top of the dependency-review-gate branch. Expectation: the **`dependency-review`** check should **fail** (it introduces a Critical dependency), proving the gate blocks new High/Critical CVEs.

Other CI checks (Go build/tidy) are expected to fail too since the require is intentionally unused/unbuildable — irrelevant to this test. I'll close this PR once the gate result is confirmed.