### PR TITLE
op-deployer: fix missing Superchain Deployment after prepare

### DIFF
--- a/op-deployer/pkg/deployer/integration_test/cli/e2e_prepare_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/e2e_prepare_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"context"
+	"math/big"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/integration_test/shared"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIPrepareCommitsSuperchainDeployment applies a superchain live, then prepares another chain
+// against the OPCM that apply deployed.
+func TestCLIPrepareCommitsSuperchainDeployment(t *testing.T) {
+	runner := NewCLITestRunnerWithNetwork(t)
+
+	applyDir := runner.GetWorkDir()
+	l1ChainID := uint64(devnet.DefaultChainID)
+	l1ChainIDBig := new(big.Int).SetUint64(l1ChainID)
+
+	dk, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+
+	// init supplies the artifact locators. prepare must predict against the same ones apply
+	// deployed the OPCM from.
+	initIntent, _ := cliInitIntent(t, runner, l1ChainID, []common.Hash{uint256.NewInt(1).Bytes32()})
+	l1Loc, l2Loc := initIntent.L1ContractsLocator, initIntent.L2ContractsLocator
+
+	applyIntent, applyState := shared.NewIntent(t, l1ChainIDBig, dk, uint256.NewInt(1), l1Loc, l2Loc, standard.GasLimit)
+	writePrepareWorkdir(t, applyDir, applyIntent, applyState)
+
+	runner.ExpectSuccessWithNetwork(t, []string{
+		"apply",
+		"--deployment-target", "live",
+		"--workdir", applyDir,
+	}, nil)
+
+	applied, err := pipeline.ReadState(applyDir)
+	require.NoError(t, err)
+	require.NotNil(t, applied.SuperchainDeployment)
+	require.NotNil(t, applied.SuperchainRoles)
+	require.NotNil(t, applied.ImplementationsDeployment)
+	opcmAddr := applied.ImplementationsDeployment.OpcmV2Impl
+	require.NotEqual(t, common.Address{}, opcmAddr)
+
+	newWorkdir := func(t *testing.T, superchainConfigProxy common.Address) string {
+		workdir := t.TempDir()
+		intent, st := shared.NewIntent(t, l1ChainIDBig, dk, uint256.NewInt(2), l1Loc, l2Loc, standard.GasLimit)
+		intent.OPCMAddress = &opcmAddr
+		intent.SuperchainConfigProxy = &superchainConfigProxy
+		// The intent may not carry superchain roles alongside a pinned OPCM; they are read
+		// off the chain instead.
+		intent.SuperchainRoles = nil
+		writePrepareWorkdir(t, workdir, intent, st)
+		return workdir
+	}
+
+	t.Run("commits the superchain deployment", func(t *testing.T) {
+		workdir := newWorkdir(t, applied.SuperchainDeployment.SuperchainConfigProxy)
+
+		runner.ExpectSuccessWithNetwork(t, []string{"prepare", "--workdir", workdir}, nil)
+
+		prepared, err := pipeline.ReadState(workdir)
+		require.NoError(t, err)
+		require.True(t, prepared.Prepared)
+
+		// The read must reproduce what apply recorded when it deployed the superchain.
+		require.NotNil(t, prepared.SuperchainDeployment)
+		require.Equal(t, *applied.SuperchainDeployment, *prepared.SuperchainDeployment)
+
+		// prepare deploys no implementations, so it must not claim any.
+		require.Nil(t, prepared.ImplementationsDeployment)
+
+		// The committed proxy must match the frozen intent the continuation deploys from.
+		require.NotNil(t, prepared.PreparedDeployment)
+		require.NotNil(t, prepared.PreparedDeployment.Intent.SuperchainConfigProxy)
+		require.Equal(
+			t,
+			*prepared.PreparedDeployment.Intent.SuperchainConfigProxy,
+			prepared.SuperchainDeployment.SuperchainConfigProxy,
+		)
+
+		// Only the roles the superchain exposes on chain are readable, which excludes Challenger.
+		require.NotNil(t, prepared.SuperchainRoles)
+		require.Equal(
+			t,
+			applied.SuperchainRoles.SuperchainProxyAdminOwner,
+			prepared.SuperchainRoles.SuperchainProxyAdminOwner,
+		)
+		require.Equal(t, applied.SuperchainRoles.SuperchainGuardian, prepared.SuperchainRoles.SuperchainGuardian)
+		require.Equal(t, common.Address{}, prepared.SuperchainRoles.Challenger)
+	})
+
+	t.Run("writes no state when the superchain cannot be read", func(t *testing.T) {
+		workdir := newWorkdir(t, common.Address{'n', 'o', 'c', 'o', 'd', 'e'})
+
+		_, err := runner.RunWithNetwork(context.Background(), []string{"prepare", "--workdir", workdir}, nil)
+		require.ErrorContains(t, err, "superchainConfigProxy has no code")
+
+		unwritten, err := pipeline.ReadState(workdir)
+		require.NoError(t, err)
+		require.False(t, unwritten.Prepared)
+		require.Nil(t, unwritten.SuperchainDeployment)
+		require.Nil(t, unwritten.SuperchainRoles)
+		require.Nil(t, unwritten.PreparedDeployment)
+	})
+}
+
+func writePrepareWorkdir(t *testing.T, workdir string, intent *state.Intent, st *state.State) {
+	t.Helper()
+	require.NoError(t, intent.WriteToFile(filepath.Join(workdir, "intent.toml")))
+	require.NoError(t, st.WriteToFile(filepath.Join(workdir, "state.json")))
+}

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -180,6 +180,24 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 		return fmt.Errorf("failed to create forked L1 script host: %w", err)
 	}
 
+	superDeployment, superRoles, err := pipeline.PopulateSuperchainState(
+		&pipeline.Env{Logger: cfg.Logger, L1ScriptHost: l1Host},
+		opcmAddr,
+		*intent.SuperchainConfigProxy,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to read superchain deployment: %w", err)
+	}
+	if superDeployment.SuperchainConfigProxy != *intent.SuperchainConfigProxy {
+		return fmt.Errorf(
+			"superchain config proxy mismatch: read %s, intent %s",
+			superDeployment.SuperchainConfigProxy,
+			*intent.SuperchainConfigProxy,
+		)
+	}
+	st.SuperchainDeployment = superDeployment
+	st.SuperchainRoles = superRoles
+
 	deployScript, err := opcm.NewDeployOPChainScript(l1Host)
 	if err != nil {
 		return fmt.Errorf("failed to load DeployOPChain script: %w", err)

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -188,13 +188,6 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to read superchain deployment: %w", err)
 	}
-	if superDeployment.SuperchainConfigProxy != *intent.SuperchainConfigProxy {
-		return fmt.Errorf(
-			"superchain config proxy mismatch: read %s, intent %s",
-			superDeployment.SuperchainConfigProxy,
-			*intent.SuperchainConfigProxy,
-		)
-	}
 	st.SuperchainDeployment = superDeployment
 	st.SuperchainRoles = superRoles
 

--- a/op-deployer/pkg/deployer/prepare_test.go
+++ b/op-deployer/pkg/deployer/prepare_test.go
@@ -534,9 +534,10 @@ func TestPredictionDryRun_Permissionless(t *testing.T) {
 			}
 			predictState := &state.State{Version: 1, Create2Salt: tt.salt}
 
-			// runPrediction mirrors Prepare: a fresh fork of the live L1 with a no-op
-			// broadcaster, running the DeployOPChain script with the prediction input.
-			runPrediction := func(mutate func(*opcm.DeployOPChainInput)) opcm.DeployOPChainOutput {
+			runPrediction := func(
+				beforePredict func(*script.Host),
+				mutate func(*opcm.DeployOPChainInput),
+			) opcm.DeployOPChainOutput {
 				predictHost, err := opdenv.DefaultForkedScriptHost(
 					ctx,
 					broadcaster.NoopBroadcaster(),
@@ -546,6 +547,10 @@ func TestPredictionDryRun_Permissionless(t *testing.T) {
 					l1RPC,
 				)
 				require.NoError(t, err)
+
+				if beforePredict != nil {
+					beforePredict(predictHost)
+				}
 
 				deployScript, err := opcm.NewDeployOPChainScript(predictHost)
 				require.NoError(t, err)
@@ -561,7 +566,7 @@ func TestPredictionDryRun_Permissionless(t *testing.T) {
 				return out
 			}
 
-			out := runPrediction(nil)
+			out := runPrediction(nil, nil)
 			require.NotEqual(t, common.Address{}, out.SystemConfigProxy)
 			require.NotEqual(t, common.Address{}, out.OptimismPortalProxy)
 			require.NotEqual(t, common.Address{}, out.DisputeGameFactoryProxy)
@@ -571,10 +576,31 @@ func TestPredictionDryRun_Permissionless(t *testing.T) {
 			require.NotEqual(t, common.Address{}, out.PermissionedDisputeGame)
 
 			// A different placeholder anchor root must produce identical predicted addresses.
-			outDifferentRoot := runPrediction(func(dci *opcm.DeployOPChainInput) {
+			outDifferentRoot := runPrediction(nil, func(dci *opcm.DeployOPChainInput) {
 				dci.StartingAnchorRoot.Root = common.Hash{0xaa}
 			})
 			require.Equal(t, out, outDifferentRoot)
+
+			// Prepare reads the live superchain deployment on the prediction host before
+			// predicting
+			outAfterSuperchainRead := runPrediction(func(predictHost *script.Host) {
+				superDeployment, superRoles, err := pipeline.PopulateSuperchainState(
+					&pipeline.Env{Logger: lgr, L1ScriptHost: predictHost},
+					opcmAddr,
+					superchainConfigProxy,
+				)
+				require.NoError(t, err)
+				require.Equal(t, superchainConfigProxy, superDeployment.SuperchainConfigProxy)
+				require.NotEqual(t, common.Address{}, superDeployment.SuperchainProxyAdminImpl)
+				require.NotEqual(t, common.Address{}, superDeployment.SuperchainConfigImpl)
+				require.Equal(
+					t,
+					superchainIntent.SuperchainRoles.SuperchainProxyAdminOwner,
+					superRoles.SuperchainProxyAdminOwner,
+				)
+				require.Equal(t, superchainIntent.SuperchainRoles.SuperchainGuardian, superRoles.SuperchainGuardian)
+			}, nil)
+			require.Equal(t, out, outAfterSuperchainRead)
 		})
 	}
 }


### PR DESCRIPTION
## Context

Some consumers read `State.SuperchainDeployment` from the prepared `state.json`, but `prepare` does not set it as it resolves the `SuperchainConfigProxy` only in the intent, where it feeds the prediction dry-run.

## Fix

`prepare` reads the live Superchain off the fork it already creates, using the same script apply's live init uses, and commits `SuperchainDeployment` and `SuperchainRoles` into the state. If `SuperchainConfigProxy` read from the intent is not the same as the one on-chain, the whole step reverts.