### PR TITLE
ci: Retry apt-get install downloads

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -387,7 +387,7 @@ commands:
               echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
               sleep 10
             done
-            sudo -E apt-get install -y << parameters.extra_flags >> << parameters.packages >>
+            sudo -E apt-get -o Acquire::Retries=5 install -y << parameters.extra_flags >> << parameters.packages >>
 
   # Kona-specific commands
   install-zstd:


### PR DESCRIPTION
`apt-install` passes `-o Acquire::Retries=5` to `apt-get update` but not to `apt-get install`, so a mirror that drops a connection while fetching a `.deb` fails the step outright — despite the command describing itself as retrying transient mirror failures.

That flaked `kona-host-client-offline-cannon` (job 5379820):

```
Err:32 http://us-east-1.ec2.archive.ubuntu.com/ubuntu noble-updates/universe amd64 clang-18
  Connection failed [IP: 3.209.10.109 80]
E: Failed to fetch .../clang-18_18.1.3-1ubuntu1_amd64.deb  Connection failed
Exited with code exit status 100
```

The mirror was degraded rather than down — the same step fetched 118 MB in 23m13s (84.8 kB/s), and `apt install zstd` in the same job took 633s against its usual few seconds. That is precisely what `Acquire::Retries` covers: *"Number of retries to perform. If this is non-zero APT will retry failed files the given number of times"* ([apt.conf(5)](https://manpages.ubuntu.com/manpages/noble/man5/apt.conf.5.html)). It is an Acquire-layer option, so it applies to package downloads during `install`, not only index downloads during `update`.

One line, and it covers all 12 compiled `apt-install` call sites across `main.yml` and `rust-ci.yml` (clang/llvm for the Rust jobs, zstd, lcov).

## Test plan

- `bash .circleci/scripts/merge-configs.sh` then `circleci config process --pipeline-parameters` with the private orb stubbed and all 23 `c-run_*` params true: compiles clean, and the option appears at all 12 compiled call sites.
- `bash .circleci/scripts/test-decision-tree.sh`: 18 passed.
- Confirmed `apt-get -o Acquire::Retries=5 install` accepts the option (apt 2.8.3 reaches package resolution and objects only to a deliberately fake package name).

The retry itself needs a degraded mirror to observe, so it is documentation-backed rather than reproduced locally.