### PR TITLE
op-supernode: clarify chain rewind observability

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -752,23 +752,38 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, target *eth.Exe
 	if target == nil || target.ExecutionPayload == nil {
 		return engine_controller.ErrRewindNilTarget
 	}
+	start := time.Now()
+	if c.metrics != nil {
+		defer func() {
+			c.metrics.ChainRewindDuration.WithLabelValues(c.chainID.String()).Observe(time.Since(start).Seconds())
+		}()
+	}
+	recordFailure := func(stage string) {
+		if c.metrics != nil {
+			c.metrics.ChainRewindFailures.WithLabelValues(c.chainID.String(), stage).Inc()
+		}
+	}
 	timestamp := uint64(target.ExecutionPayload.Timestamp)
 	if !c.resetting.CompareAndSwap(false, true) {
+		recordFailure("setup")
 		return fmt.Errorf("reset already in progress")
 	}
 	defer c.resetting.Store(false)
 
 	vn := c.getVN()
 	if vn == nil {
+		recordFailure("setup")
 		return fmt.Errorf("virtual node not initialized")
 	}
 	if c.engine == nil {
+		recordFailure("setup")
 		return fmt.Errorf("engine not initialized")
 	}
 
 	// Pause the container to stop it restarting the vn when we kill it
 	err := c.Pause(ctx)
 	if err != nil {
+		recordFailure("pause")
 		return err
 	}
 	// Always resume the container on return, even if we exit early due to context cancellation
@@ -780,6 +795,7 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, target *eth.Exe
 	// stop the vn
 	err = vn.Stop(ctx)
 	if err != nil {
+		recordFailure("stop_vn")
 		return err
 	}
 	c.log.Info("chain_container/RewindEngine: stopped vn")
@@ -789,6 +805,7 @@ retryLoop:
 		err = c.engine.Rewind(ctx, target)
 		switch {
 		case isCriticalRewindError(err):
+			recordFailure("engine_rewind")
 			c.log.Error("chain_container/RewindEngine: critical error", "err", err)
 			return err
 		case err == nil:
@@ -805,6 +822,7 @@ retryLoop:
 			c.log.Error("chain_container/RewindEngine: temporary error", "err", err)
 			select {
 			case <-ctx.Done():
+				recordFailure("engine_rewind")
 				return ctx.Err()
 			case <-time.After(time.Second):
 			}
@@ -819,6 +837,7 @@ retryLoop:
 	// resume the chain container to trigger a new vn to be started
 	err = c.Resume(ctx)
 	if err != nil {
+		recordFailure("resume")
 		return err
 	}
 
@@ -828,6 +847,7 @@ retryLoop:
 	// that window 503s on the router gate. Symmetric with the post-Resume
 	// barrier in interop.applyPendingTransition.
 	if err := c.WaitReady(ctx); err != nil {
+		recordFailure("wait_ready")
 		return fmt.Errorf("RewindEngine: VN not ready after resume: %w", err)
 	}
 	c.log.Info("chain_container/RewindEngine: resumed container, VN ready")

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -867,6 +867,54 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 		require.False(t, c.pause.Load(), "Container should be resumed after rewind")
 	})
 
+	t.Run("records rewind duration", func(t *testing.T) {
+		mockVN := newMockVirtualNode()
+		mockEngine := newMockEngineController()
+		mockEngine.rewindFunc = func(ctx context.Context, target *eth.ExecutionPayloadEnvelope) error {
+			mockVN.setState(virtual_node.VNStateRunning)
+			return nil
+		}
+		metrics := resources.NewSupernodeMetrics()
+		chainID := eth.ChainIDFromUInt64(420)
+		c := &simpleChainContainer{
+			chainID: chainID,
+			log:     createTestLogger(t),
+			engine:  mockEngine,
+			vn:      mockVN,
+			metrics: metrics,
+		}
+
+		require.NoError(t, c.RewindEngine(context.Background(), makeTarget(12345), eth.BlockRef{}))
+
+		observer := metrics.ChainRewindDuration.WithLabelValues(chainID.String())
+		histogram, ok := observer.(prometheus.Metric)
+		require.True(t, ok)
+		var metric dto.Metric
+		require.NoError(t, histogram.Write(&metric))
+		require.Equal(t, uint64(1), metric.GetHistogram().GetSampleCount())
+	})
+
+	t.Run("records engine rewind failure", func(t *testing.T) {
+		metrics := resources.NewSupernodeMetrics()
+		chainID := eth.ChainIDFromUInt64(420)
+		c := &simpleChainContainer{
+			chainID: chainID,
+			log:     createTestLogger(t),
+			engine: &mockEngineController{
+				rewindErr: engine_controller.ErrRewindTargetMismatch,
+			},
+			vn:      newMockVirtualNode(),
+			metrics: metrics,
+		}
+
+		err := c.RewindEngine(context.Background(), makeTarget(12345), eth.BlockRef{})
+		require.ErrorIs(t, err, engine_controller.ErrRewindTargetMismatch)
+
+		var metric dto.Metric
+		require.NoError(t, metrics.ChainRewindFailures.WithLabelValues(chainID.String(), "engine_rewind").Write(&metric))
+		require.Equal(t, float64(1), metric.GetCounter().GetValue())
+	})
+
 	t.Run("rejects nil target without touching the engine", func(t *testing.T) {
 		mockVN := newMockVirtualNode()
 		mockEngine := newMockEngineController()

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -416,8 +416,9 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	// invalidated block is removed: the WAL-captured parent at height-1.
 	validParent := parentPayload.ExecutionPayload.ID()
 	c.log.Info("added block to deny list",
+		"chainID", c.chainID,
 		"invalidatedBlock", eth.BlockID{Hash: payloadHash, Number: height},
-		"rewindToValidParent", validParent,
+		"lastValidParentBlock", validParent,
 		"decisionTimestamp", decisionTimestamp,
 	)
 
@@ -453,20 +454,30 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		return false, fmt.Errorf("failed to get current block at height %d: %w", height, err)
 	}
 
+	rewindFrom, rewindFromErr := c.engine.L2BlockRefByLabel(ctx, eth.Unsafe)
 	c.log.Warn("initiating rewind after block invalidation",
+		"chainID", c.chainID,
 		"invalidatedBlock", eth.BlockID{Hash: payloadHash, Number: height},
-		"rewindToValidParent", validParent,
+		"lastValidParentBlock", validParent,
 	)
 
 	if err := c.RewindEngine(ctx, parentPayload, invalidatedBlock); err != nil {
 		return false, fmt.Errorf("failed to rewind engine: %w", err)
 	}
 
-	priorTimestamp := uint64(parentPayload.ExecutionPayload.Timestamp)
-	c.log.Info("rewind completed after block invalidation",
-		"invalidatedHeight", height,
-		"rewindToTimestamp", priorTimestamp,
-	)
+	completionFields := []interface{}{
+		"chainID", c.chainID,
+		"invalidatedBlock", eth.BlockID{Hash: payloadHash, Number: height},
+		"lastValidParentBlock", validParent,
+		"rewindTargetBlock", validParent,
+	}
+	if rewindFromErr == nil && rewindFrom.Number >= validParent.Number {
+		completionFields = append(completionFields,
+			"rewindFromBlock", rewindFrom.ID(),
+			"rewindDepthBlocks", rewindFrom.Number-validParent.Number,
+		)
+	}
+	c.log.Info("chain rewind completed", completionFields...)
 
 	// Record rewind depth: invalidated block was at `height`, rewound to height-1.
 	if c.metrics != nil {

--- a/op-supernode/supernode/resources/supernode_metrics.go
+++ b/op-supernode/supernode/resources/supernode_metrics.go
@@ -16,6 +16,8 @@ type SupernodeMetrics struct {
 	InteropRewinds              prometheus.Counter
 	InteropVerificationDuration prometheus.Histogram
 	ChainRewindDepthBlocks      *prometheus.HistogramVec
+	ChainRewindDuration         *prometheus.HistogramVec
+	ChainRewindFailures         *prometheus.CounterVec
 	DenyListEntries             *prometheus.CounterVec
 	LogBackfillProgress         *prometheus.GaugeVec
 	LogBackfillRetries          *prometheus.CounterVec
@@ -73,6 +75,17 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 			Help:      "Depth in blocks of chain rewinds triggered by invalidation.",
 			Buckets:   []float64{1, 2, 5, 10, 50, 100, 500},
 		}, []string{"chain_id"}),
+		ChainRewindDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "supernode",
+			Name:      "chain_rewind_duration_seconds",
+			Help:      "Duration in seconds of chain rewind attempts.",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
+		}, []string{"chain_id"}),
+		ChainRewindFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "supernode",
+			Name:      "chain_rewind_failures_total",
+			Help:      "Total number of failed chain rewind attempts by stage.",
+		}, []string{"chain_id", "stage"}),
 		DenyListEntries: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "supernode",
 			Name:      "denylist_entries_total",
@@ -109,6 +122,8 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 		m.InteropRewinds,
 		m.InteropVerificationDuration,
 		m.ChainRewindDepthBlocks,
+		m.ChainRewindDuration,
+		m.ChainRewindFailures,
 		m.DenyListEntries,
 		m.LogBackfillProgress,
 		m.LogBackfillRetries,


### PR DESCRIPTION
.<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This pull request adds new metrics and logging improvements to the chain rewind logic, making it easier to monitor and debug chain rewinds in the `op-supernode` service. The main changes are the introduction of duration and failure metrics for chain rewinds, enhanced logging with more context, and corresponding tests to ensure metrics are recorded correctly.

### Metrics and Observability Improvements

* Added `ChainRewindDuration` and `ChainRewindFailures` Prometheus metrics to `SupernodeMetrics`, tracking the duration and failure counts of chain rewind operations, respectively.
* Updated `RewindEngine` in `chain_container.go` to record the duration of each rewind and increment failure counters at specific failure stages.
* Added unit tests to verify that rewind duration and failure metrics are recorded as expected.

### Logging Enhancements

* Improved log messages in `InvalidateBlock` to include `chainID` and clarified field names for better traceability and consistency.

These changes improve the reliability and observability of chain rewind operations, making it easier to diagnose issues and monitor system health
**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
