### PR TITLE
op-reth: flush buffered proof tail on shutdown

### DIFF
--- a/rust/op-reth/crates/trie/src/engine/runner.rs
+++ b/rust/op-reth/crates/trie/src/engine/runner.rs
@@ -226,8 +226,10 @@ where
             self.maybe_start_save();
         }
 
-        debug!(target: "trie::engine::runner", "Collector engine shutting down, draining in-flight persist");
-        self.state.drain_persistence();
+        debug!(target: "trie::engine::runner", "Collector engine shutting down, flushing buffered state");
+        if let Err(err) = self.state.flush_persistence() {
+            error!(target: "trie::engine::runner", ?err, "Failed to flush buffered state on shutdown");
+        }
         debug!(target: "trie::engine::runner", "Collector engine stopped");
     }
 }

--- a/rust/op-reth/crates/trie/src/engine/state.rs
+++ b/rust/op-reth/crates/trie/src/engine/state.rs
@@ -212,6 +212,18 @@ where
         self.persistence.wait(&self.memory);
     }
 
+    /// Persist all buffered blocks, including a below-threshold tail.
+    pub(crate) fn flush_persistence(&mut self) -> Result<(), EngineError> {
+        self.drain_persistence();
+        if self.memory.is_empty() {
+            return Ok(());
+        }
+
+        self.advance_persistence()?;
+        self.drain_persistence();
+        Ok(())
+    }
+
     /// Drain any in-flight save, unwind the persistence service to `to`, then
     /// unwind the in-memory buffer to match.
     pub(crate) fn unwind(&mut self, to: BlockWithParent) -> Result<(), EngineError> {
@@ -248,7 +260,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{OpProofsInitProvider, db::MdbxProofsStorage};
+    use crate::{BlockStateDiff, OpProofsInitProvider, db::MdbxProofsStorage};
     use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
     use alloy_primitives::B256;
     use reth_chainspec::MAINNET;
@@ -327,5 +339,19 @@ mod tests {
         state.sync_target = 1_000_000;
         state.unwind(unwind_target(1)).expect("unwind");
         assert_eq!(state.sync_target, 0);
+    }
+
+    #[test]
+    fn flush_persistence_saves_below_threshold_tail() {
+        let mut state = make_engine_state();
+        state.memory.insert(
+            BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x01))),
+            BlockStateDiff::default(),
+        );
+
+        state.flush_persistence().expect("flush buffered proof block");
+
+        assert!(state.memory.is_empty());
+        assert_eq!(state.storage.provider_ro().unwrap().get_latest_block().unwrap().number, 1);
     }
 }


### PR DESCRIPTION
Closes #22089.

`Engine::run` previously waited only for an already in-flight proof-history persistence job when its action channel disconnected. If fewer blocks than the persistence threshold remained buffered, a clean shutdown dropped that tail even though the ExEx had already emitted `FinishedHeight` for it. On restart, the ExEx WAL did not replay those blocks and the persisted proof window stayed permanently behind the execution tip.

This change drains any existing save, schedules the remaining memory buffer and waits for that final save before the collector thread exits. The regression test covers a one-block tail below the normal five-block threshold and verifies that it reaches persistent storage.