### PR TITLE
contracts-bedrock: Resolve shared contract pause state via ETHLockbox

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
@@ -23,9 +22,9 @@ interface IETHLockbox is IProxyAdminOwnedBase, ISemver, IReinitializableBase {
     event LiquidityMigrated(IETHLockbox indexed lockbox, uint256 amount);
     event LiquidityReceived(IETHLockbox indexed lockbox, uint256 amount);
 
-    function initialize(ISystemConfig _systemConfig, IOptimismPortal2[] calldata _portals) external;
-    function systemConfig() external view returns (ISystemConfig);
+    function initialize(ISuperchainConfig _superchainConfig, IOptimismPortal2[] calldata _portals) external;
     function paused() external view returns (bool);
+    function guardian() external view returns (address);
     function authorizedPortals(IOptimismPortal2) external view returns (bool);
     function authorizedLockboxes(IETHLockbox) external view returns (bool);
     function receiveLiquidity() external payable;

--- a/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
-import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 import { GameType, Hash, Proposal } from "src/dispute/lib/Types.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
@@ -29,7 +29,7 @@ interface IAnchorStateRegistry is IProxyAdminOwnedBase {
     function disputeGameFinalityDelaySeconds() external view returns (uint256);
     function disputeGameFactory() external view returns (IDisputeGameFactory);
     function initialize(
-        ISystemConfig _systemConfig,
+        IPauseSource _pauseSource,
         IDisputeGameFactory _disputeGameFactory,
         Proposal memory _startingAnchorRoot,
         GameType _startingRespectedGameType
@@ -48,7 +48,7 @@ interface IAnchorStateRegistry is IProxyAdminOwnedBase {
     function retirementTimestamp() external view returns (uint64);
     function setAnchorState(IDisputeGame _game) external;
     function setRespectedGameType(GameType _gameType) external;
-    function systemConfig() external view returns (ISystemConfig);
+    function pauseSource() external view returns (IPauseSource);
     function updateRetirementTimestamp() external;
     function version() external view returns (string memory);
     function superchainConfig() external view returns (ISuperchainConfig);

--- a/packages/contracts-bedrock/interfaces/dispute/IDelayedWETH.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IDelayedWETH.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
 
@@ -19,11 +19,11 @@ interface IDelayedWETH is IProxyAdminOwnedBase {
     receive() external payable;
 
     function initVersion() external view returns (uint8);
-    function systemConfig() external view returns (ISystemConfig);
+    function pauseSource() external view returns (IPauseSource);
     function delay() external view returns (uint256);
     function hold(address _guy) external;
     function hold(address _guy, uint256 _wad) external;
-    function initialize(ISystemConfig _systemConfig) external;
+    function initialize(IPauseSource _pauseSource) external;
     function recover(uint256 _wad) external;
     function unlock(address _guy, uint256 _wad) external;
     function withdraw(address _guy, uint256 _wad) external;

--- a/packages/contracts-bedrock/interfaces/universal/IPauseSource.sol
+++ b/packages/contracts-bedrock/interfaces/universal/IPauseSource.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+
+/// @title IPauseSource
+/// @notice Interface for the contract that resolves the pause state, the guardian and the
+///         SuperchainConfig for another contract. The address of the IPauseSource is the pause
+///         identifier used against the SuperchainConfig, so an IPauseSource must have the same
+///         scope as the contracts that point at it. SystemConfig implements this for contracts
+///         that belong to exactly one chain. ETHLockbox implements it for contracts that are
+///         shared by every chain authorized on that lockbox.
+interface IPauseSource {
+    function paused() external view returns (bool);
+    function guardian() external view returns (address);
+    function superchainConfig() external view returns (ISuperchainConfig);
+}

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -306,7 +306,7 @@ library ChainAssertions {
         // Check that the contract is initialized
         DeployUtils.assertInitialized({ _contractAddress: address(_ethLockbox), _isProxy: false, _slot: 0, _offset: 0 });
 
-        require(address(_ethLockbox.systemConfig()) == address(0), "CHECK-ELB-50");
+        require(address(_ethLockbox.superchainConfig()) == address(0), "CHECK-ELB-50");
         require(_ethLockbox.authorizedPortals(_portal) == false, "CHECK-ELB-60");
     }
 

--- a/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
+++ b/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
@@ -164,8 +164,8 @@
   {
     "inputs": [
       {
-        "internalType": "contract ISystemConfig",
-        "name": "_systemConfig",
+        "internalType": "contract IPauseSource",
+        "name": "_pauseSource",
         "type": "address"
       },
       {
@@ -355,6 +355,19 @@
   },
   {
     "inputs": [],
+    "name": "pauseSource",
+    "outputs": [
+      {
+        "internalType": "contract IPauseSource",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "paused",
     "outputs": [
       {
@@ -450,19 +463,6 @@
     "outputs": [
       {
         "internalType": "contract ISuperchainConfig",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "systemConfig",
-    "outputs": [
-      {
-        "internalType": "contract ISystemConfig",
         "name": "",
         "type": "address"
       }

--- a/packages/contracts-bedrock/snapshots/abi/DelayedWETH.json
+++ b/packages/contracts-bedrock/snapshots/abi/DelayedWETH.json
@@ -178,8 +178,8 @@
   {
     "inputs": [
       {
-        "internalType": "contract ISystemConfig",
-        "name": "_systemConfig",
+        "internalType": "contract IPauseSource",
+        "name": "_pauseSource",
         "type": "address"
       }
     ],
@@ -196,6 +196,19 @@
         "internalType": "string",
         "name": "",
         "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pauseSource",
+    "outputs": [
+      {
+        "internalType": "contract IPauseSource",
+        "name": "",
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -248,19 +261,6 @@
         "internalType": "string",
         "name": "",
         "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "systemConfig",
-    "outputs": [
-      {
-        "internalType": "contract ISystemConfig",
-        "name": "",
-        "type": "address"
       }
     ],
     "stateMutability": "view",

--- a/packages/contracts-bedrock/snapshots/abi/ETHLockbox.json
+++ b/packages/contracts-bedrock/snapshots/abi/ETHLockbox.json
@@ -70,6 +70,19 @@
   },
   {
     "inputs": [],
+    "name": "guardian",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "initVersion",
     "outputs": [
       {
@@ -84,8 +97,8 @@
   {
     "inputs": [
       {
-        "internalType": "contract ISystemConfig",
-        "name": "_systemConfig",
+        "internalType": "contract ISuperchainConfig",
+        "name": "_superchainConfig",
         "type": "address"
       },
       {
@@ -171,19 +184,6 @@
     "outputs": [
       {
         "internalType": "contract ISuperchainConfig",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "systemConfig",
-    "outputs": [
-      {
-        "internalType": "contract ISystemConfig",
         "name": "",
         "type": "address"
       }

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -4,8 +4,8 @@
     "sourceCodeHash": "0x97888fc27c562c1ee77050e76c81249f4dc41c519c0a7f663740ff582df09045"
   },
   "src/L1/ETHLockbox.sol:ETHLockbox": {
-    "initCodeHash": "0xb2ff8426ab2eb36352f790748963c8e1f7a91caf16bee6a035c2c41bac532836",
-    "sourceCodeHash": "0x870004d5acc24a704277680f09ccca51a020a512e6c6d48cca583a23a0de43a2"
+    "initCodeHash": "0x920f88b97ac272181e05b60f29ff91948cae356c209aa1c4600749711cd88ed3",
+    "sourceCodeHash": "0x97e5cfe90395eed3e3958da835232dc5570cd21f9454c0a5d43f310eb0ad3e6e"
   },
   "src/L1/L1CrossDomainMessenger.sol:L1CrossDomainMessenger": {
     "initCodeHash": "0xc1ec4cfb082f933ed4a705a6d6de874c0fe167683e1f8fcf792fdcfeb767ea0d",
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xa0fdd2178ed863e256f6c70dea683ccea945eeeb21d8e516e47fda9b46f37b8d",
-    "sourceCodeHash": "0xf54d8879da1dd257d73c71ee80b9cc9e5e8a753300ae60a74f3059506bc3d5f4"
+    "initCodeHash": "0xe7e4d3769c9dca2ce560774f0b08ffbbd4da26f1d295886756dbc85e9aa38893",
+    "sourceCodeHash": "0x432206c56692e8b9ce0184bf2170a5fe4f20b43ea38df732e8bb04689a4b5223"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x2650f2af1df017387e1f1aa6273decc4c46dd4f3ac7f0910c6f0edc92aef4747"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x0a6a9baa9913e6feb0c0d1606f037c22205cbe83e709de3c9ca0ba03a0301037",
-    "sourceCodeHash": "0xf37254fcca4a499b6487c6fc5fba880ef2dbd785cea505321deee5fcb28c4d06"
+    "initCodeHash": "0x4a0ec3cd1bf7f50445be70dc346b371946b3554733e74cca923ae2e90195f4cb",
+    "sourceCodeHash": "0x70cfed35129f2fb734ce1ce5c7b657b133b7e339b5aac6d925be95774813f76d"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",
@@ -148,12 +148,12 @@
     "sourceCodeHash": "0xd4f03f13a42027a51be6f6837ba0c12b9991a294777aed918550ec9d2f7c1759"
   },
   "src/dispute/AnchorStateRegistry.sol:AnchorStateRegistry": {
-    "initCodeHash": "0x26126073f886d463e4ddea8aa87b0a693e8a208d4be4d2a5a19208a82eea6c19",
-    "sourceCodeHash": "0xd5323044373e8b70b52b26591d5e7c75c0e1b6613365f1b87fd208c1fb312dc2"
+    "initCodeHash": "0x3a7995826a19fd405e775b18ead4b7c5f4e24a1cf285378b865d87795e92d34c",
+    "sourceCodeHash": "0xe91e56f15063161179771331048ae41c52a3c4e37eb6fe805e3ca228a651e562"
   },
   "src/dispute/DelayedWETH.sol:DelayedWETH": {
-    "initCodeHash": "0xe695ef6bc4edce86e3f9325ef016dc121a882e5ab2b7792aec1ba0b1d098b7f9",
-    "sourceCodeHash": "0xf0a45f727742c86f938345a7c124a73869baa32bffb068573bf0003d17ea7117"
+    "initCodeHash": "0xb07864f07163aab549d648d4415cb33fabcf52561f3e2b70ca95130a755d081c",
+    "sourceCodeHash": "0xda9beaecdc03ac5a3d82a6634917d6b39ca636bb10b04add81f8b3aa0091e926"
   },
   "src/dispute/DisputeGameFactory.sol:DisputeGameFactory": {
     "initCodeHash": "0x080ffb82a16452a42d6e2a78817f60ae2987197b39d3f10f08739d76b70c7435",

--- a/packages/contracts-bedrock/snapshots/storageLayout/AnchorStateRegistry.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/AnchorStateRegistry.json
@@ -15,10 +15,10 @@
   },
   {
     "bytes": "20",
-    "label": "systemConfig",
+    "label": "pauseSource",
     "offset": 2,
     "slot": "0",
-    "type": "contract ISystemConfig"
+    "type": "contract IPauseSource"
   },
   {
     "bytes": "20",

--- a/packages/contracts-bedrock/snapshots/storageLayout/DelayedWETH.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/DelayedWETH.json
@@ -36,9 +36,9 @@
   },
   {
     "bytes": "20",
-    "label": "systemConfig",
+    "label": "pauseSource",
     "offset": 0,
     "slot": "4",
-    "type": "contract ISystemConfig"
+    "type": "contract IPauseSource"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/ETHLockbox.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/ETHLockbox.json
@@ -15,10 +15,10 @@
   },
   {
     "bytes": "20",
-    "label": "systemConfig",
+    "label": "superchainConfig",
     "offset": 2,
     "slot": "0",
-    "type": "contract ISystemConfig"
+    "type": "contract ISuperchainConfig"
   },
   {
     "bytes": "32",

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -14,7 +14,6 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
-import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 
 /// @custom:proxied true
 /// @title ETHLockbox
@@ -63,8 +62,10 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @param amount The amount of ETH received.
     event LiquidityReceived(IETHLockbox indexed lockbox, uint256 amount);
 
-    /// @notice The address of the SystemConfig contract.
-    ISystemConfig public systemConfig;
+    /// @notice The address of the SuperchainConfig contract. The lockbox is its own pause
+    ///         identifier, so every contract that resolves its pause state through this lockbox
+    ///         shares one pause state, regardless of how many chains are authorized on it.
+    ISuperchainConfig public superchainConfig;
 
     /// @notice Mapping of authorized portals.
     mapping(IOptimismPortal => bool) public authorizedPortals;
@@ -73,9 +74,9 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     mapping(IETHLockbox => bool) public authorizedLockboxes;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.3.1
+    /// @custom:semver 2.0.0
     function version() public view virtual returns (string memory) {
-        return "1.3.1";
+        return "2.0.0";
     }
 
     /// @notice Constructs the ETHLockbox contract.
@@ -84,14 +85,10 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     }
 
     /// @notice Initializer.
-    /// @param _systemConfig The address of the SystemConfig contract.
+    /// @param _superchainConfig The address of the SuperchainConfig contract.
     /// @param _portals The addresses of the portals to authorize.
-    /// @dev Note: Multiple chains can share an ETHLockbox contract. In this case, all SystemConfig
-    ///      contracts will point to the same pause identifier (the lockbox itself). Therefore, it
-    ///      doesn't matter which SystemConfig is used here as long as it belongs to one of the
-    ///      chains that share the lockbox.
     function initialize(
-        ISystemConfig _systemConfig,
+        ISuperchainConfig _superchainConfig,
         IOptimismPortal[] calldata _portals
     )
         external
@@ -101,21 +98,22 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
         _assertOnlyProxyAdminOrProxyAdminOwner();
 
         // Now perform initialization logic.
-        systemConfig = _systemConfig;
+        superchainConfig = _superchainConfig;
         for (uint256 i; i < _portals.length; i++) {
             _authorizePortal(_portals[i]);
         }
     }
 
-    /// @notice Getter for the current paused status.
+    /// @notice Getter for the current paused status. The lockbox is paused if either the global
+    ///         pause is active or the pause is active for the lockbox itself.
     function paused() public view returns (bool) {
-        return systemConfig.paused();
+        return superchainConfig.paused(address(0)) || superchainConfig.paused(address(this));
     }
 
-    /// @notice Returns the SuperchainConfig contract.
-    /// @return ISuperchainConfig The SuperchainConfig contract.
-    function superchainConfig() public view returns (ISuperchainConfig) {
-        return systemConfig.superchainConfig();
+    /// @notice Returns the guardian address of the SuperchainConfig.
+    /// @return The guardian address.
+    function guardian() public view returns (address) {
+        return superchainConfig.guardian();
     }
 
     /// @notice Authorizes a portal to lock and unlock ETH.
@@ -221,7 +219,7 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
         _assertSharedProxyAdminOwner(address(_portal));
 
         // Check that the portal has the same superchain config.
-        if (_portal.superchainConfig() != superchainConfig()) revert ETHLockbox_DifferentSuperchainConfig();
+        if (_portal.superchainConfig() != superchainConfig) revert ETHLockbox_DifferentSuperchainConfig();
 
         // Authorize the portal.
         authorizedPortals[_portal] = true;

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -46,8 +46,8 @@ import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 2.12.0
-    string public constant version = "2.12.0";
+    /// @custom:semver 2.13.0
+    string public constant version = "2.13.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;
@@ -444,7 +444,7 @@ contract OPContractsManagerStandardValidator is ISemver {
         _errors =
             internalRequire(getProxyImplementation(_admin, address(_lockbox)) == ethLockboxImpl, "LOCKBOX-20", _errors);
         _errors = internalRequire(getProxyAdmin(address(_lockbox)) == _admin, "LOCKBOX-30", _errors);
-        _errors = internalRequire(_lockbox.systemConfig() == _sysCfg, "LOCKBOX-40", _errors);
+        _errors = internalRequire(_lockbox.superchainConfig() == _sysCfg.superchainConfig(), "LOCKBOX-40", _errors);
         _errors = internalRequire(_lockbox.authorizedPortals(_portal), "LOCKBOX-50", _errors);
         return _errors;
     }

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -20,6 +20,7 @@ import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPort
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { IOPContractsManagerContainer } from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 import { GameType, Proposal } from "src/dispute/lib/Types.sol";
 
 /// @title OPContractsManagerMigrator
@@ -184,10 +185,10 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         );
 
         // Reuse the existing DelayedWETH from chainSystemConfigs[0] rather than deploying a
-        // new one. The migrated chains share a SystemConfig, and by extension share its
-        // DelayedWETH. Deploying a new one would create a divergence — SystemConfig would
-        // still point to the old one, and future upgrades (which load DelayedWETH from
-        // SystemConfig) would reference a different DelayedWETH than the shared DGF games.
+        // new one. Every migrated chain's SystemConfig is repointed at this DelayedWETH below, so
+        // deploying a new one would create a divergence — chain 0's SystemConfig would still point
+        // to the old one, and future upgrades (which load DelayedWETH from SystemConfig) would
+        // reference a different DelayedWETH than the shared DGF games.
         IDelayedWETH delayedWETH = IDelayedWETH(payable(_input.chainSystemConfigs[0].delayedWETH()));
 
         // Separate context to avoid stack too deep (isolate the implementations variable).
@@ -195,16 +196,17 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
             // Grab the implementations.
             IOPContractsManagerContainer.Implementations memory impls = contractsContainer().implementations();
 
-            // Initialize the new ETHLockbox.
-            // NOTE: Shared contracts (ETHLockbox, AnchorStateRegistry, DelayedWETH) are
-            // intentionally initialized with chainSystemConfigs[0]. All chains are validated to
-            // share the same ProxyAdmin owner and SuperchainConfig, so the first chain's
-            // SystemConfig is used as the canonical governance reference for shared contracts.
+            // Initialize the new ETHLockbox. The lockbox is the pause source for every other
+            // shared contract, so it takes the SuperchainConfig directly and is its own pause
+            // identifier. All chains are validated to share the same SuperchainConfig, so reading
+            // it from the first chain is safe.
             _upgrade(
                 proxyDeployArgs.proxyAdmin,
                 address(ethLockbox),
                 impls.ethLockboxImpl,
-                abi.encodeCall(IETHLockbox.initialize, (_input.chainSystemConfigs[0], new IOptimismPortal[](0)))
+                abi.encodeCall(
+                    IETHLockbox.initialize, (_input.chainSystemConfigs[0].superchainConfig(), new IOptimismPortal[](0))
+                )
             );
 
             // Initialize the new DisputeGameFactory.
@@ -215,7 +217,18 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
                 abi.encodeCall(IDisputeGameFactory.initialize, (proxyDeployArgs.proxyAdmin.owner()))
             );
 
-            // Initialize the new AnchorStateRegistry.
+            // Repoint the shared DelayedWETH at the shared ETHLockbox. It currently resolves its
+            // pause state through chain 0's SystemConfig, which is a per-chain contract; the
+            // lockbox has the same scope as the set that shares this DelayedWETH.
+            _upgrade(
+                proxyDeployArgs.proxyAdmin,
+                address(delayedWETH),
+                impls.delayedWETHImpl,
+                abi.encodeCall(IDelayedWETH.initialize, (IPauseSource(address(ethLockbox))))
+            );
+
+            // Initialize the new AnchorStateRegistry against the shared ETHLockbox for the same
+            // reason.
             _upgrade(
                 proxyDeployArgs.proxyAdmin,
                 address(anchorStateRegistry),
@@ -223,7 +236,7 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
                 abi.encodeCall(
                     IAnchorStateRegistry.initialize,
                     (
-                        _input.chainSystemConfigs[0],
+                        IPauseSource(address(ethLockbox)),
                         disputeGameFactory,
                         _input.startingAnchorRoot,
                         _input.startingRespectedGameType
@@ -322,14 +335,22 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         IOPContractsManagerContainer.Implementations memory impls = contractsContainer().implementations();
 
         // Re-initialize the shared AnchorStateRegistry with the new respected game type and anchor
-        // root. _upgrade resets the initialized slot, re-seeding the anchor for the new game.
+        // root. _upgrade resets the initialized slot, re-seeding the anchor for the new game. The
+        // pause source is re-derived from the portal's shared ETHLockbox so that a set migrated by
+        // an older OPCM release, whose registry still points at chain 0's SystemConfig, is fixed up
+        // here too.
         _upgrade(
             sysCfg.proxyAdmin(),
             address(anchorStateRegistry),
             impls.anchorStateRegistryImpl,
             abi.encodeCall(
                 IAnchorStateRegistry.initialize,
-                (sysCfg, disputeGameFactory, _input.startingAnchorRoot, _input.startingRespectedGameType)
+                (
+                    IPauseSource(address(IOptimismPortal(payable(sysCfg.optimismPortal())).ethLockbox())),
+                    disputeGameFactory,
+                    _input.startingAnchorRoot,
+                    _input.startingRespectedGameType
+                )
             )
         );
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -33,6 +33,7 @@ import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { IOPContractsManagerContainer } from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
 import { IOPContractsManagerStandardValidator } from "interfaces/L1/IOPContractsManagerStandardValidator.sol";
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 
 /// @title OPContractsManagerV2
 /// @notice OPContractsManagerV2 is an enhanced version of OPContractsManager. OPContractsManagerV2
@@ -158,9 +159,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 7.2.3
+    /// @custom:semver 7.2.4
     function version() public pure returns (string memory) {
-        return "7.2.3";
+        return "7.2.4";
     }
 
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -868,6 +869,13 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             revert OPContractsManagerV2_InvalidEthLockbox();
         }
         IETHLockbox portalLockbox = isEthLockboxEnabled ? _cts.ethLockbox : IETHLockbox(address(0));
+
+        // Contracts that resolve their pause state must point at a pause source whose scope matches
+        // their own. A chain that uses an ETHLockbox may be sharing those contracts with the rest of
+        // an interop set, in which case the lockbox is the only reference that is correct for every
+        // member. Chains without a lockbox use their own SystemConfig.
+        IPauseSource pauseSource =
+            isEthLockboxEnabled ? IPauseSource(address(_cts.ethLockbox)) : IPauseSource(address(_cts.systemConfig));
         _upgrade(
             _cts.proxyAdmin,
             address(_cts.optimismPortal),
@@ -887,7 +895,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
                 _cts.proxyAdmin,
                 address(_cts.ethLockbox),
                 impls.ethLockboxImpl,
-                abi.encodeCall(IETHLockbox.initialize, (_cts.systemConfig, portals))
+                abi.encodeCall(IETHLockbox.initialize, (_cts.systemConfig.superchainConfig(), portals))
             );
         }
 
@@ -939,7 +947,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             _cts.proxyAdmin,
             address(_cts.delayedWETH),
             impls.delayedWETHImpl,
-            abi.encodeCall(IDelayedWETH.initialize, (_cts.systemConfig))
+            abi.encodeCall(IDelayedWETH.initialize, (pauseSource))
         );
 
         // Update the AnchorStateRegistry.
@@ -949,7 +957,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             impls.anchorStateRegistryImpl,
             abi.encodeCall(
                 IAnchorStateRegistry.initialize,
-                (_cts.systemConfig, _cts.disputeGameFactory, _cfg.startingAnchorRoot, _cfg.startingRespectedGameType)
+                (pauseSource, _cts.disputeGameFactory, _cfg.startingAnchorRoot, _cfg.startingRespectedGameType)
             )
         );
 

--- a/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
@@ -6,6 +6,7 @@ import { LibString } from "@solady/utils/LibString.sol";
 import { GameType, Claim, GameTypes, Hash } from "src/dispute/lib/Types.sol";
 import { Duration } from "src/dispute/lib/LibUDT.sol";
 import { Constants } from "src/libraries/Constants.sol";
+import { Features } from "src/libraries/Features.sol";
 
 // Interfaces
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
@@ -22,6 +23,7 @@ import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 
 uint256 constant EXPECTED_MAX_GAME_DEPTH = 73;
 uint256 constant EXPECTED_SPLIT_DEPTH = 30;
@@ -124,6 +126,18 @@ contract StandardValidatorUtils {
         } else {
             errors_ = string.concat(_errors, ",", _message);
         }
+    }
+
+    /// @notice Returns the pause source that contracts belonging to this chain must point at. A
+    ///         chain using the ETHLockbox may share those contracts with other chains in an interop
+    ///         set, and the lockbox is the only reference that is identical for every member.
+    /// @param _sysCfg The SystemConfig of the chain being validated.
+    /// @return The expected pause source.
+    function expectedPauseSource(ISystemConfig _sysCfg) internal view returns (IPauseSource) {
+        if (!_sysCfg.isFeatureEnabled(Features.ETH_LOCKBOX)) {
+            return IPauseSource(address(_sysCfg));
+        }
+        return IPauseSource(address(IOptimismPortal2(payable(_sysCfg.optimismPortal())).ethLockbox()));
     }
 
     /// @notice Asserts that the SuperchainConfig contract is valid.
@@ -355,7 +369,9 @@ contract StandardValidatorUtils {
         _errors =
             internalRequire(_weth.proxyAdminOwner() == _l1PAOMultisig, string.concat(_errorPrefix, "-30"), _errors);
         _errors = internalRequire(_weth.delay() == _withdrawalDelaySeconds, string.concat(_errorPrefix, "-40"), _errors);
-        _errors = internalRequire(_weth.systemConfig() == _sysCfg, string.concat(_errorPrefix, "-50"), _errors);
+        _errors = internalRequire(
+            _weth.pauseSource() == expectedPauseSource(_sysCfg), string.concat(_errorPrefix, "-50"), _errors
+        );
         _errors = internalRequire(
             IProxyAdminOwnedBase(address(_weth)).proxyAdmin() == _admin, string.concat(_errorPrefix, "-60"), _errors
         );
@@ -390,7 +406,9 @@ contract StandardValidatorUtils {
         _errors = internalRequire(
             address(_asr.disputeGameFactory()) == address(_dgf), string.concat(_errorPrefix, "-30"), _errors
         );
-        _errors = internalRequire(_asr.systemConfig() == _sysCfg, string.concat(_errorPrefix, "-40"), _errors);
+        _errors = internalRequire(
+            _asr.pauseSource() == expectedPauseSource(_sysCfg), string.concat(_errorPrefix, "-40"), _errors
+        );
         _errors = internalRequire(
             IProxyAdminOwnedBase(address(_asr)).proxyAdmin() == _admin, string.concat(_errorPrefix, "-50"), _errors
         );

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -13,7 +13,7 @@ import { GameType, Proposal, Claim, GameStatus, Hash } from "src/dispute/lib/Typ
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
-import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 /// @custom:proxied true
@@ -24,14 +24,16 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 ///         be initialized with a more recent starting state which reduces the amount of required offchain computation.
 contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, ReinitializableBase, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 3.9.0
-    string public constant version = "3.9.0";
+    /// @custom:semver 4.0.0
+    string public constant version = "4.0.0";
 
     /// @notice The dispute game finality delay in seconds.
     uint256 internal immutable DISPUTE_GAME_FINALITY_DELAY_SECONDS;
 
-    /// @notice Address of the SystemConfig contract.
-    ISystemConfig public systemConfig;
+    /// @notice Address of the contract that resolves the pause state and the guardian. Must have
+    ///         the same scope as this registry: the chain's SystemConfig when this registry serves
+    ///         a single chain, or the shared ETHLockbox when it serves an interop set.
+    IPauseSource public pauseSource;
 
     /// @notice Address of the DisputeGameFactory contract.
     IDisputeGameFactory public disputeGameFactory;
@@ -82,12 +84,12 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
     }
 
     /// @notice Initializes the contract.
-    /// @param _systemConfig The address of the SystemConfig contract.
+    /// @param _pauseSource The address of the pause source contract.
     /// @param _disputeGameFactory The address of the DisputeGameFactory contract.
     /// @param _startingAnchorRoot The starting anchor root.
     /// @param _startingRespectedGameType The starting respected game type.
     function initialize(
-        ISystemConfig _systemConfig,
+        IPauseSource _pauseSource,
         IDisputeGameFactory _disputeGameFactory,
         Proposal memory _startingAnchorRoot,
         GameType _startingRespectedGameType
@@ -99,7 +101,7 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
         _assertOnlyProxyAdminOrProxyAdminOwner();
 
         // Now perform initialization logic.
-        systemConfig = _systemConfig;
+        pauseSource = _pauseSource;
         disputeGameFactory = _disputeGameFactory;
         respectedGameType = _startingRespectedGameType;
 
@@ -129,13 +131,13 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
 
     /// @notice Returns whether the contract is paused.
     function paused() public view returns (bool) {
-        return systemConfig.paused();
+        return pauseSource.paused();
     }
 
     /// @notice Returns the SuperchainConfig contract.
     /// @return ISuperchainConfig The SuperchainConfig contract.
     function superchainConfig() public view returns (ISuperchainConfig) {
-        return systemConfig.superchainConfig();
+        return pauseSource.superchainConfig();
     }
 
     /// @notice Returns the dispute game finality delay in seconds.
@@ -362,7 +364,7 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
 
     /// @notice Asserts that the caller is the Guardian.
     function _assertOnlyGuardian() internal view {
-        if (msg.sender != systemConfig.guardian()) {
+        if (msg.sender != pauseSource.guardian()) {
             revert AnchorStateRegistry_Unauthorized();
         }
     }

--- a/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
+++ b/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
@@ -9,7 +9,7 @@ import { ProxyAdminOwnedBase } from "src/universal/ProxyAdminOwnedBase.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 /// @custom:proxied true
@@ -30,8 +30,8 @@ contract DelayedWETH is Initializable, ProxyAdminOwnedBase, ReinitializableBase,
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.5.1
-    string public constant version = "1.5.1";
+    /// @custom:semver 2.0.0
+    string public constant version = "2.0.0";
 
     /// @notice Returns a withdrawal request for the given address.
     mapping(address => mapping(address => WithdrawalRequest)) public withdrawals;
@@ -39,8 +39,10 @@ contract DelayedWETH is Initializable, ProxyAdminOwnedBase, ReinitializableBase,
     /// @notice Withdrawal delay in seconds.
     uint256 internal immutable DELAY_SECONDS;
 
-    /// @notice Address of the SystemConfig contract.
-    ISystemConfig public systemConfig;
+    /// @notice Address of the contract that resolves the pause state. Must have the same scope as
+    ///         this contract: the chain's SystemConfig when this contract serves a single chain, or
+    ///         the shared ETHLockbox when it is shared by an interop set.
+    IPauseSource public pauseSource;
 
     /// @param _delay The delay for withdrawals in seconds.
     constructor(uint256 _delay) ReinitializableBase(1) {
@@ -49,13 +51,13 @@ contract DelayedWETH is Initializable, ProxyAdminOwnedBase, ReinitializableBase,
     }
 
     /// @notice Initializes the contract.
-    /// @param _systemConfig Address of the SystemConfig contract.
-    function initialize(ISystemConfig _systemConfig) external reinitializer(initVersion()) {
+    /// @param _pauseSource Address of the pause source contract.
+    function initialize(IPauseSource _pauseSource) external reinitializer(initVersion()) {
         // Initialization transactions must come from the ProxyAdmin or its owner.
         _assertOnlyProxyAdminOrProxyAdminOwner();
 
         // Now perform initialization logic.
-        systemConfig = _systemConfig;
+        pauseSource = _pauseSource;
     }
 
     /// @notice Returns the withdrawal delay in seconds.
@@ -67,7 +69,7 @@ contract DelayedWETH is Initializable, ProxyAdminOwnedBase, ReinitializableBase,
     /// @notice Returns the SuperchainConfig contract.
     /// @return ISuperchainConfig The SuperchainConfig contract.
     function config() public view returns (ISuperchainConfig) {
-        return systemConfig.superchainConfig();
+        return pauseSource.superchainConfig();
     }
 
     /// @notice Unlocks withdrawals for the sender's account, after a time delay.
@@ -94,7 +96,7 @@ contract DelayedWETH is Initializable, ProxyAdminOwnedBase, ReinitializableBase,
     /// @param _guy Sub-account to withdraw from.
     /// @param _wad The amount of WETH to withdraw.
     function withdraw(address _guy, uint256 _wad) public {
-        require(!systemConfig.paused(), "DelayedWETH: contract is paused");
+        require(!pauseSource.paused(), "DelayedWETH: contract is paused");
         WithdrawalRequest storage wd = withdrawals[msg.sender][_guy];
         require(wd.amount >= _wad, "DelayedWETH: insufficient unlocked withdrawal");
         require(wd.timestamp > 0, "DelayedWETH: withdrawal not unlocked");

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -53,9 +53,8 @@ contract ETHLockbox_Version_Test is ETHLockbox_TestInit {
 contract ETHLockbox_Initialize_Test is ETHLockbox_TestInit {
     /// @notice Tests the superchain config was correctly set during initialization.
     function test_initialize_succeeds() public view {
-        assertEq(address(ethLockbox.systemConfig().superchainConfig()), address(superchainConfig));
-        assertEq(ethLockbox.authorizedPortals(optimismPortal2), true);
         assertEq(address(ethLockbox.superchainConfig()), address(superchainConfig));
+        assertEq(ethLockbox.authorizedPortals(optimismPortal2), true);
     }
 
     /// @notice Tests that the initializer value is correct. Trivial test for normal initialization
@@ -92,14 +91,14 @@ contract ETHLockbox_Initialize_Test is ETHLockbox_TestInit {
         // Call the `initialize` function with the sender
         vm.prank(_sender);
         IOptimismPortal2[] memory _portals = new IOptimismPortal2[](1);
-        ethLockbox.initialize(systemConfig, _portals);
+        ethLockbox.initialize(superchainConfig, _portals);
     }
 
     /// @notice Tests it reverts when the contract is already initialized.
     function test_initialize_alreadyInitialized_reverts() public {
         vm.expectRevert("Initializable: contract is already initialized");
         IOptimismPortal2[] memory _portals = new IOptimismPortal2[](1);
-        ethLockbox.initialize(systemConfig, _portals);
+        ethLockbox.initialize(superchainConfig, _portals);
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -923,9 +923,9 @@ contract OPContractsManagerStandardValidator_ETHLockbox_Test is OPContractsManag
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
-    ///         ETHLockbox systemConfig is invalid.
-    function test_validate_ethLockboxInvalidSystemConfig_succeeds() public {
-        vm.mockCall(address(ethLockbox), abi.encodeCall(IETHLockbox.systemConfig, ()), abi.encode(address(0xbad)));
+    ///         ETHLockbox superchainConfig is invalid.
+    function test_validate_ethLockboxInvalidSuperchainConfig_succeeds() public {
+        vm.mockCall(address(ethLockbox), abi.encodeCall(IETHLockbox.superchainConfig, ()), abi.encode(address(0xbad)));
 
         if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
             assertEq("LOCKBOX-40", _validate(true));
@@ -1129,7 +1129,7 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
             abi.encode(Hash.wrap(bytes32(uint256(0x123))), uint256(123))
         );
         vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.disputeGameFactory, ()), abi.encode(dgf));
-        vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.systemConfig, ()), abi.encode(sysCfg));
+        vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.pauseSource, ()), abi.encode(expectedPauseSource()));
         vm.mockCall(badASR, abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(proxyAdmin));
         vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.retirementTimestamp, ()), abi.encode(uint64(100)));
 
@@ -1155,7 +1155,7 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
         vm.mockCall(
             badWeth, abi.encodeCall(IDelayedWETH.delay, ()), abi.encode(standardValidator.withdrawalDelaySeconds())
         );
-        vm.mockCall(badWeth, abi.encodeCall(IDelayedWETH.systemConfig, ()), abi.encode(sysCfg));
+        vm.mockCall(badWeth, abi.encodeCall(IDelayedWETH.pauseSource, ()), abi.encode(expectedPauseSource()));
         vm.mockCall(badWeth, abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(proxyAdmin));
 
         assertEq("PDDG-DWETH-10,PDDG-DWETH-20", _validate(true));
@@ -1302,11 +1302,11 @@ contract OPContractsManagerStandardValidator_AnchorStateRegistry_Test is
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
-    ///         AnchorStateRegistry systemConfig is invalid.
-    function test_validate_anchorStateRegistryInvalidSystemConfig_succeeds() public {
+    ///         AnchorStateRegistry pauseSource is invalid.
+    function test_validate_anchorStateRegistryInvalidPauseSource_succeeds() public {
         vm.mockCall(
             address(anchorStateRegistry),
-            abi.encodeCall(IAnchorStateRegistry.systemConfig, ()),
+            abi.encodeCall(IAnchorStateRegistry.pauseSource, ()),
             abi.encode(address(0xbad))
         );
         assertEq("PDDG-ANCHORP-40,CKDG-ANCHORP-40", _validate(true));
@@ -1371,9 +1371,9 @@ contract OPContractsManagerStandardValidator_DelayedWETH_Test is OPContractsMana
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
-    ///         DelayedWETH systemConfig is invalid.
-    function test_validate_delayedWETHInvalidSystemConfig_succeeds() public {
-        vm.mockCall(address(delayedWeth), abi.encodeCall(IDelayedWETH.systemConfig, ()), abi.encode(address(0xbad)));
+    ///         DelayedWETH pauseSource is invalid.
+    function test_validate_delayedWETHInvalidPauseSource_succeeds() public {
+        vm.mockCall(address(delayedWeth), abi.encodeCall(IDelayedWETH.pauseSource, ()), abi.encode(address(0xbad)));
         assertEq("PDDG-DWETH-50,CKDG-DWETH-50", _validate(true));
     }
 
@@ -1488,7 +1488,7 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
             abi.encode(Hash.wrap(bytes32(uint256(0x123))), uint256(123))
         );
         vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.disputeGameFactory, ()), abi.encode(dgf));
-        vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.systemConfig, ()), abi.encode(sysCfg));
+        vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.pauseSource, ()), abi.encode(expectedPauseSource()));
         vm.mockCall(badASR, abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(proxyAdmin));
         vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.retirementTimestamp, ()), abi.encode(uint64(100)));
     }
@@ -1517,7 +1517,7 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
         vm.mockCall(
             badWeth, abi.encodeCall(IDelayedWETH.delay, ()), abi.encode(standardValidator.withdrawalDelaySeconds())
         );
-        vm.mockCall(badWeth, abi.encodeCall(IDelayedWETH.systemConfig, ()), abi.encode(sysCfg));
+        vm.mockCall(badWeth, abi.encodeCall(IDelayedWETH.pauseSource, ()), abi.encode(expectedPauseSource()));
         vm.mockCall(badWeth, abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(proxyAdmin));
     }
 
@@ -1962,7 +1962,7 @@ contract OPContractsManagerStandardValidator_SuperPermissionedDisputeGame_Test i
             abi.encode(Hash.wrap(bytes32(uint256(0x123))), uint256(123))
         );
         vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.disputeGameFactory, ()), abi.encode(dgf));
-        vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.systemConfig, ()), abi.encode(sysCfg));
+        vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.pauseSource, ()), abi.encode(expectedPauseSource()));
         vm.mockCall(badASR, abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(proxyAdmin));
         vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.retirementTimestamp, ()), abi.encode(uint64(100)));
 

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -36,6 +36,7 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 
 abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
     address depositor;
@@ -742,7 +743,9 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
         if (_authorizePortal) portals[0] = IOptimismPortal(payable(address(optimismPortal2)));
 
         vm.prank(proxyAdminAddr);
-        Proxy(payable(newProxy)).upgradeToAndCall(impl, abi.encodeCall(IETHLockbox.initialize, (systemConfig, portals)));
+        Proxy(payable(newProxy)).upgradeToAndCall(
+            impl, abi.encodeCall(IETHLockbox.initialize, (superchainConfig, portals))
+        );
 
         lockbox_ = IETHLockbox(payable(newProxy));
     }
@@ -759,12 +762,15 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
         Proposal memory startingAnchorRoot =
             Proposal({ root: Hash.wrap(keccak256("starting-anchor-root")), l2SequenceNumber: 1 });
 
+        // Resolved before the prank because reading it makes an external call.
+        IPauseSource pauseSource = expectedPauseSource();
+
         vm.prank(proxyAdminAddr);
         Proxy(payable(newProxy)).upgradeToAndCall(
             impl,
             abi.encodeCall(
                 IAnchorStateRegistry.initialize,
-                (systemConfig, disputeGameFactory, startingAnchorRoot, GameTypes.SUPER_PERMISSIONED)
+                (pauseSource, disputeGameFactory, startingAnchorRoot, GameTypes.SUPER_PERMISSIONED)
             )
         );
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -493,7 +493,7 @@ contract OPContractsManagerMigrationValidator_SCKDG_Test is OPContractsManagerMi
             abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()),
             abi.encode(standardValidator.l1PAOMultisig())
         );
-        vm.mockCall(badWeth, abi.encodeCall(IDelayedWETH.systemConfig, ()), abi.encode(chainContracts1.systemConfig));
+        vm.mockCall(badWeth, abi.encodeCall(IDelayedWETH.pauseSource, ()), abi.encode(sharedLockbox));
         vm.mockCall(badWeth, abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(sharedProxyAdmin));
         assertEq("MIG-SCKDG-GARGS-30", _validateMigration(true));
     }
@@ -595,14 +595,18 @@ contract OPContractsManagerMigrationValidator_PerChain_Test is OPContractsManage
         assertEq("MIG-CHAIN-1-90", _validateMigration(true));
     }
 
-    /// @notice MIG-LOCKBOX-MISSING: Portal's ethLockbox is address(0).
+    /// @notice MIG-LOCKBOX-MISSING: Portal's ethLockbox is address(0). The shared ASR and
+    ///         DelayedWETH pause-source checks also fire, because the expected pause source is
+    ///         derived from the portal's lockbox and so resolves to address(0) too.
     function test_validate_lockboxMissing_succeeds() public {
         vm.mockCall(
             address(chainContracts1.optimismPortal),
             abi.encodeCall(IOptimismPortal2.ethLockbox, ()),
             abi.encode(address(0))
         );
-        assertEq("MIG-LOCKBOX-MISSING", _validateMigration(true));
+        assertEq(
+            "MIG-SPDG-ANCHORP-40,MIG-SCKDG-DWETH-50,MIG-SCKDG-ANCHORP-40,MIG-LOCKBOX-MISSING", _validateMigration(true)
+        );
     }
 
     /// @notice MIG-CHAIN-0-100: INTEROP feature not enabled.
@@ -615,14 +619,18 @@ contract OPContractsManagerMigrationValidator_PerChain_Test is OPContractsManage
         assertEq("MIG-CHAIN-0-100", _validateMigration(true));
     }
 
-    /// @notice MIG-CHAIN-0-110: ETH_LOCKBOX feature not enabled.
+    /// @notice MIG-CHAIN-0-110: ETH_LOCKBOX feature not enabled. The shared ASR and DelayedWETH
+    ///         pause-source checks also fire, because with the feature disabled the expected pause
+    ///         source falls back to the chain's own SystemConfig.
     function test_validate_chain0110EthLockboxNotEnabled_succeeds() public {
         vm.mockCall(
             address(chainContracts1.systemConfig),
             abi.encodeCall(ISystemConfig.isFeatureEnabled, (Features.ETH_LOCKBOX)),
             abi.encode(false)
         );
-        assertEq("MIG-CHAIN-0-110", _validateMigration(true));
+        assertEq(
+            "MIG-SPDG-ANCHORP-40,MIG-SCKDG-DWETH-50,MIG-SCKDG-ANCHORP-40,MIG-CHAIN-0-110", _validateMigration(true)
+        );
     }
 
     /// @notice MIG-CHAIN-1-120: Second chain's SystemConfig delayedWETH doesn't match shared WETH.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -2941,6 +2941,43 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         );
     }
 
+    /// @notice Tests that the shared contracts resolve their pause state and guardian through the
+    ///         shared ETHLockbox rather than through one member chain's SystemConfig, so that the
+    ///         reference is identical for every migrated chain.
+    function test_migrate_sharedContractsUseLockboxAsPauseSource_succeeds() public {
+        _enableEthLockboxes();
+        _doMigration(_getDefaultMigrateInput());
+
+        IOptimismPortal2 portal1 = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
+        IOptimismPortal2 portal2 = IOptimismPortal2(payable(chainContracts2.systemConfig.optimismPortal()));
+
+        IETHLockbox sharedLockbox = portal1.ethLockbox();
+        IAnchorStateRegistry sharedASR = portal1.anchorStateRegistry();
+        IDelayedWETH sharedWETH = IDelayedWETH(payable(chainContracts1.systemConfig.delayedWETH()));
+
+        // The lockbox holds the SuperchainConfig directly and is its own pause identifier.
+        assertEq(address(sharedLockbox.superchainConfig()), address(superchainConfig), "lockbox superchain config");
+        assertEq(sharedLockbox.guardian(), superchainConfig.guardian(), "lockbox guardian");
+
+        // The shared contracts point at the lockbox, not at either chain's SystemConfig.
+        assertEq(address(sharedASR.pauseSource()), address(sharedLockbox), "ASR pause source");
+        assertEq(address(sharedWETH.pauseSource()), address(sharedLockbox), "DelayedWETH pause source");
+
+        // Both chains resolve the same shared contracts, so that single pause source is correct for
+        // every member of the set rather than only for the chain that supplied it.
+        assertEq(address(portal2.ethLockbox()), address(sharedLockbox), "chain 2 lockbox");
+        assertEq(address(portal2.anchorStateRegistry()), address(sharedASR), "chain 2 ASR");
+        assertEq(chainContracts2.systemConfig.delayedWETH(), address(sharedWETH), "chain 2 DelayedWETH");
+
+        // Pausing the shared lockbox pauses the shared contracts and both chains at once.
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(address(sharedLockbox));
+        assertTrue(sharedLockbox.paused(), "lockbox not paused");
+        assertTrue(sharedASR.paused(), "ASR not paused");
+        assertTrue(chainContracts1.systemConfig.paused(), "chain 1 not paused");
+        assertTrue(chainContracts2.systemConfig.paused(), "chain 2 not paused");
+    }
+
     /// @notice Tests that existing per-chain lockbox liquidity is swept into the shared lockbox.
     function test_migrate_sweepsExistingLockbox_succeeds() public {
         IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -14,6 +14,7 @@ import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 
 /// @title AnchorStateRegistry_TestInit
@@ -21,6 +22,10 @@ import { DevFeatures } from "src/libraries/DevFeatures.sol";
 abstract contract AnchorStateRegistry_TestInit is BaseFaultDisputeGame_TestInit {
     /// @dev A valid l2BlockNumber that comes after the current anchor root block.
     uint256 validL2BlockNumber;
+
+    /// @dev The pause source the registry is expected to hold. Cached because reading it makes an
+    ///      external call, which would consume a pending `vm.prank` or `vm.expectRevert`.
+    IPauseSource pauseSource;
 
     event AnchorUpdated(IFaultDisputeGame indexed game);
     event RespectedGameTypeSet(GameType gameType);
@@ -38,6 +43,7 @@ abstract contract AnchorStateRegistry_TestInit is BaseFaultDisputeGame_TestInit 
         validL2BlockNumber = l2BlockNumber + 1;
         Claim rootClaim = Claim.wrap(Hash.unwrap(root));
         super.init({ rootClaim: rootClaim, absolutePrestate: absolutePrestate, l2BlockNumber: validL2BlockNumber });
+        pauseSource = expectedPauseSource();
     }
 }
 
@@ -63,7 +69,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
         assertEq(l2BlockNumber, 0);
 
         // Verify contract addresses.
-        assert(anchorStateRegistry.systemConfig() == systemConfig);
+        assert(anchorStateRegistry.pauseSource() == expectedPauseSource());
         assert(anchorStateRegistry.disputeGameFactory() == disputeGameFactory);
         assert(anchorStateRegistry.superchainConfig() == superchainConfig);
     }
@@ -104,7 +110,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
 
         vm.prank(proxyAdminOwner);
         anchorStateRegistry.initialize(
-            systemConfig,
+            pauseSource,
             disputeGameFactory,
             Proposal({ root: root, l2SequenceNumber: l2SequenceNumber }),
             startingGameType
@@ -136,7 +142,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
 
         vm.prank(proxyAdminOwner);
         anchorStateRegistry.initialize(
-            systemConfig,
+            pauseSource,
             disputeGameFactory,
             Proposal({ root: root, l2SequenceNumber: l2SequenceNumber }),
             startingGameType
@@ -149,7 +155,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
     function test_initialize_twice_reverts() public {
         vm.expectRevert("Initializable: contract is already initialized");
         anchorStateRegistry.initialize(
-            systemConfig,
+            pauseSource,
             disputeGameFactory,
             Proposal({
                 root: Hash.wrap(0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF),
@@ -179,7 +185,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
         // Call the `initialize` function with the sender
         vm.prank(_sender);
         anchorStateRegistry.initialize(
-            systemConfig,
+            pauseSource,
             disputeGameFactory,
             Proposal({
                 root: Hash.wrap(0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF),
@@ -213,7 +219,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
             Proposal({ root: Hash.wrap(bytes32(uint256(0xBEEF))), l2SequenceNumber: currentSeqNum + 42 });
 
         vm.prank(anchorStateRegistry.proxyAdminOwner());
-        anchorStateRegistry.initialize(systemConfig, disputeGameFactory, newStartingRoot, GameTypes.SUPER_CANNON_KONA);
+        anchorStateRegistry.initialize(pauseSource, disputeGameFactory, newStartingRoot, GameTypes.SUPER_CANNON_KONA);
 
         // anchorGame should be cleared.
         assertEq(address(anchorStateRegistry.anchorGame()), address(0));
@@ -246,7 +252,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
 
         // Re-initialize with the same starting anchor root.
         vm.prank(anchorStateRegistry.proxyAdminOwner());
-        anchorStateRegistry.initialize(systemConfig, disputeGameFactory, currentRoot, GameTypes.SUPER_CANNON_KONA);
+        anchorStateRegistry.initialize(pauseSource, disputeGameFactory, currentRoot, GameTypes.SUPER_CANNON_KONA);
 
         // anchorGame should still be the same.
         assertEq(address(anchorStateRegistry.anchorGame()), anchorGameBefore);
@@ -272,7 +278,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
 
         vm.prank(anchorStateRegistry.proxyAdminOwner());
         anchorStateRegistry.initialize(
-            systemConfig,
+            pauseSource,
             disputeGameFactory,
             Proposal({ root: Hash.wrap(bytes32(uint256(0xBEEF))), l2SequenceNumber: 42 }),
             GameTypes.SUPER_CANNON_KONA
@@ -302,7 +308,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
         vm.prank(anchorStateRegistry.proxyAdminOwner());
         vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_InvalidAnchorGame.selector);
         anchorStateRegistry.initialize(
-            systemConfig,
+            pauseSource,
             disputeGameFactory,
             Proposal({ root: Hash.wrap(bytes32(uint256(0xBEEF))), l2SequenceNumber: 50 }),
             GameTypes.SUPER_CANNON_KONA
@@ -328,7 +334,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
         Proposal memory currentRoot = anchorStateRegistry.getStartingAnchorRoot();
 
         vm.prank(anchorStateRegistry.proxyAdminOwner());
-        anchorStateRegistry.initialize(systemConfig, disputeGameFactory, currentRoot, GameType.wrap(_gameTypeRaw));
+        anchorStateRegistry.initialize(pauseSource, disputeGameFactory, currentRoot, GameType.wrap(_gameTypeRaw));
 
         // respectedGameType must be unchanged.
         assertEq(anchorStateRegistry.respectedGameType().raw(), _gameTypeRaw);

--- a/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
@@ -14,7 +14,7 @@ import "src/dispute/lib/Errors.sol";
 // Interfaces
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
-import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 
 /// @title DelayedWETH_FallbackGasUser_Harness
 /// @notice Contract that burns gas in the fallback function.
@@ -72,8 +72,8 @@ contract DelayedWETH_Initialize_Test is DelayedWETH_TestInit {
     /// @notice Tests that initialization is successful.
     function test_initialize_succeeds() public view {
         assertEq(delayedWeth.proxyAdminOwner(), proxyAdminOwner);
-        assertEq(address(delayedWeth.systemConfig()), address(systemConfig));
-        assertEq(address(delayedWeth.config()), address(systemConfig.superchainConfig()));
+        assertEq(address(delayedWeth.pauseSource()), address(expectedPauseSource()));
+        assertEq(address(delayedWeth.config()), address(superchainConfig));
     }
 
     /// @notice Tests that the initializer value is correct. Trivial test for normal initialization
@@ -109,7 +109,7 @@ contract DelayedWETH_Initialize_Test is DelayedWETH_TestInit {
 
         // Call the `initialize` function with the sender.
         vm.prank(_sender);
-        delayedWeth.initialize(ISystemConfig(address(1234)));
+        delayedWeth.initialize(IPauseSource(address(1234)));
     }
 }
 

--- a/packages/contracts-bedrock/test/opcm/SetDisputeGameImpl.t.sol
+++ b/packages/contracts-bedrock/test/opcm/SetDisputeGameImpl.t.sol
@@ -20,10 +20,10 @@ import { GameType, Proposal, Hash } from "src/dispute/lib/Types.sol";
 // Interfaces
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
-import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 
 contract SetDisputeGameImplInput_Test is Test {
     SetDisputeGameImplInput input;
@@ -119,7 +119,7 @@ contract SetDisputeGameImpl_Test is Test {
             abi.encodeCall(
                 IAnchorStateRegistry.initialize,
                 (
-                    ISystemConfig(address(systemConfigProxy)),
+                    IPauseSource(address(systemConfigProxy)),
                     factory,
                     Proposal({ root: Hash.wrap(0), l2SequenceNumber: 0 }),
                     GameType.wrap(100)

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -27,6 +27,7 @@ import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { Chains } from "scripts/libraries/Chains.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
+import { Features } from "src/libraries/Features.sol";
 
 // Interfaces
 import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
@@ -60,6 +61,7 @@ import { ISuperchainETHBridge } from "interfaces/L2/ISuperchainETHBridge.sol";
 import { IETHLiquidity } from "interfaces/L2/IETHLiquidity.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 import { IWETH98 } from "interfaces/universal/IWETH98.sol";
 import { IGovernanceToken } from "interfaces/governance/IGovernanceToken.sol";
 import { ILegacyMessagePasser } from "interfaces/legacy/ILegacyMessagePasser.sol";
@@ -532,5 +534,14 @@ abstract contract Setup is FeatureFlags {
         labelPreinstall(Preinstalls.BeaconBlockRoots);
         labelPreinstall(Preinstalls.HistoryStorage);
         labelPreinstall(Preinstalls.CreateX);
+    }
+
+    /// @notice Returns the pause source that this chain's contracts are expected to point at. The
+    ///         ETHLockbox is the pause source whenever the chain uses one, because those contracts
+    ///         may be shared with other chains in an interop set.
+    function expectedPauseSource() internal view returns (IPauseSource) {
+        return isSysFeatureEnabled(Features.ETH_LOCKBOX)
+            ? IPauseSource(address(ethLockbox))
+            : IPauseSource(address(systemConfig));
     }
 }

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -21,6 +21,7 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IPauseSource } from "interfaces/universal/IPauseSource.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 
 /// @title Initializer_Test
@@ -109,7 +110,7 @@ contract Initializer_Test is CommonTest {
             InitializeableContract({
                 name: "DelayedWETHImpl",
                 target: EIP1967Helper.getImplementation(address(delayedWeth)),
-                initCalldata: abi.encodeCall(delayedWeth.initialize, (ISystemConfig(address(0))))
+                initCalldata: abi.encodeCall(delayedWeth.initialize, (IPauseSource(address(0))))
             })
         );
         // DelayedWETHProxy
@@ -117,7 +118,7 @@ contract Initializer_Test is CommonTest {
             InitializeableContract({
                 name: "DelayedWETHProxy",
                 target: address(delayedWeth),
-                initCalldata: abi.encodeCall(delayedWeth.initialize, (ISystemConfig(address(0))))
+                initCalldata: abi.encodeCall(delayedWeth.initialize, (IPauseSource(address(0))))
             })
         );
 
@@ -311,7 +312,7 @@ contract Initializer_Test is CommonTest {
                 initCalldata: abi.encodeCall(
                     IAnchorStateRegistry.initialize,
                     (
-                        ISystemConfig(address(0)),
+                        IPauseSource(address(0)),
                         IDisputeGameFactory(address(0)),
                         Proposal({ root: Hash.wrap(bytes32(0)), l2SequenceNumber: 0 }),
                         GameType.wrap(uint32(deploy.cfg().respectedGameType()))
@@ -327,7 +328,7 @@ contract Initializer_Test is CommonTest {
                 initCalldata: abi.encodeCall(
                     IAnchorStateRegistry.initialize,
                     (
-                        ISystemConfig(address(0)),
+                        IPauseSource(address(0)),
                         IDisputeGameFactory(address(0)),
                         Proposal({ root: Hash.wrap(bytes32(0)), l2SequenceNumber: 0 }),
                         GameType.wrap(uint32(deploy.cfg().respectedGameType()))
@@ -341,7 +342,9 @@ contract Initializer_Test is CommonTest {
             InitializeableContract({
                 name: "ETHLockboxImpl",
                 target: EIP1967Helper.getImplementation(address(ethLockbox)),
-                initCalldata: abi.encodeCall(ethLockbox.initialize, (ISystemConfig(address(0)), new IOptimismPortal2[](0)))
+                initCalldata: abi.encodeCall(
+                    ethLockbox.initialize, (ISuperchainConfig(address(0)), new IOptimismPortal2[](0))
+                )
             })
         );
 
@@ -350,7 +353,9 @@ contract Initializer_Test is CommonTest {
             InitializeableContract({
                 name: "ETHLockboxProxy",
                 target: address(ethLockbox),
-                initCalldata: abi.encodeCall(ethLockbox.initialize, (ISystemConfig(address(0)), new IOptimismPortal2[](0)))
+                initCalldata: abi.encodeCall(
+                    ethLockbox.initialize, (ISuperchainConfig(address(0)), new IOptimismPortal2[](0))
+                )
             })
         );
     }


### PR DESCRIPTION
Fixes #22093.

The shared `ETHLockbox`, `AnchorStateRegistry` and `DelayedWETH` of an interop set each stored a pointer to **chain 0's `SystemConfig`** — a per-chain contract — and used it for `paused()`, `guardian()` and `superchainConfig()`. That makes one member the governance root of the whole set, and it makes per-chain `upgrade()` non-idempotent: `_upgradeChain` re-initialises all three with `_cts.systemConfig`, so upgrading chain N silently repoints the set at chain N, and the validator's `_asr.systemConfig() == _sysCfg` predicate can only hold for one member at a time. That is a direct obstacle to the "all chains always upgrade the shared components" resolution in #21731.

Each contract now points at an `IPauseSource` — `paused()` / `guardian()` / `superchainConfig()` — whose scope matches its own:

- `ETHLockbox` holds the `SuperchainConfig` directly, `paused()` keys on `address(this)`, and it gains a `guardian()` passthrough. This also collapses the old 4-hop pause lookup (lockbox → systemConfig → portal → its own address → superchainConfig) to one call on the `unlockETH` path.
- `AnchorStateRegistry` and `DelayedWETH` hold an `IPauseSource`: the shared `ETHLockbox` when the chain uses one, otherwise the chain's own `SystemConfig`. Both satisfy the interface, so chains without a lockbox keep exactly today's behaviour.
- `migrate()` now also repoints the reused chain-0 `DelayedWETH` at the shared lockbox, and `setInteropDisputeGames()` re-derives the pause source from the portal's lockbox, so a set migrated by an older release is fixed up there.
- The validator checks become `_asr.pauseSource() == expectedPauseSource(sysCfg)`, which is true for every member of a migrated set simultaneously.

`ETHLockbox` 1.3.1 → 2.0.0, `AnchorStateRegistry` 3.9.0 → 4.0.0 and `DelayedWETH` 1.5.1 → 2.0.0 are **major** bumps: the `systemConfig()` getter is gone, and `initialize` keeps its selector (`ISystemConfig`, `ISuperchainConfig` and `IPauseSource` all encode as `address`) while the meaning of its first argument changes. Anything calling these initializers must be updated deliberately.

Storage-layout neutral: the field is a plain 20-byte address slot in all three contracts, so only the label and type change in `snapshots/storageLayout`.

Two migration-validator tests gained extra expected error codes: with the lockbox missing or `ETH_LOCKBOX` disabled, the pause-source checks now also fire. That is intended — a shared registry pointing at a lockbox the chain does not acknowledge is a real misconfiguration.

Not addressed here: the shared proxies are still administered by chain 0's `ProxyAdmin`, tracked in #21731.

## Test plan

- `just test-dev` green in three configurations: default, `DEV_FEATURE__OPTIMISM_PORTAL_INTEROP` + `DEV_FEATURE__ZK_DISPUTE_GAME`, and `SYS_FEATURE__CUSTOM_GAS_TOKEN`.
- New `test_migrate_sharedContractsUseLockboxAsPauseSource_succeeds` asserts that after `migrate()` the shared ASR and DelayedWETH point at the shared lockbox, that both chains resolve that same lockbox, and that pausing it pauses both chains at once.

