### PR TITLE
alloy-op-evm: don't rebate inner CREATE warming

### DIFF
--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -994,13 +994,82 @@ mod sdm {
         );
     }
 
+    /// Bytecode performing one inner `CREATE2` with empty init code and salt 0, at depth 1:
+    /// `PUSH1 0` x4 (salt, size, offset, value); `CREATE2`; `POP`; `STOP`.
+    fn create2_factory_account() -> AccountInfo {
+        let raw = Bytes::from_static(&[
+            0x60, 0x00, // PUSH1 0  (salt)
+            0x60, 0x00, // PUSH1 0  (size)
+            0x60, 0x00, // PUSH1 0  (offset)
+            0x60, 0x00, // PUSH1 0  (value)
+            0xf5, // CREATE2
+            0x50, // POP
+            0x00, // STOP
+        ]);
+        let code_hash = alloy_primitives::keccak256(&raw);
+        AccountInfo { code_hash, code: Some(Bytecode::new_raw(raw)), ..Default::default() }
+    }
+
+    // An *inner* (depth > 0) CREATE/CREATE2 is not an EIP-2929 metered account access: revm's
+    // `create` instruction charges only create_cost + initcode + memory, never the 2600 cold
+    // account-access surcharge (EIP-2929 lists BALANCE/EXTCODE*/CALL*/SELFDESTRUCT/SLOAD/SSTORE —
+    // CREATE and CREATE2 are absent). The warming rebate is defined as the cold->warm delta
+    // (2600 - 100 = 2500) refunded when a tx paid cold for an address already warm in the block.
+    // A tx that never paid a cold surcharge is owed nothing, so an inner CREATE2 landing on an
+    // address an earlier tx warmed must NOT be rebated. The `create` hook previously suppressed
+    // this only for `top_level`, so the inner case claimed an unearned 2500 per creation; it now
+    // suppresses at any depth.
+    #[test]
+    fn test_inner_create_address_is_not_rebated() {
+        const BLOCK_GAS_LIMIT: u64 = 2_000_000;
+
+        let factory = Address::from([0x7f; 20]);
+        // CREATE2 is nonce-independent: keccak256(0xff ++ factory ++ salt ++ keccak256(init_code)).
+        let created = factory.create2(B256::ZERO, alloy_primitives::keccak256([]));
+
+        let mut fixture = SDMExecutorFixture::new(
+            DEFAULT_DA_FOOTPRINT_GAS_SCALAR,
+            BLOCK_GAS_LIMIT,
+            JOVIAN_TIMESTAMP,
+        );
+        fixture.db.insert_account(factory, create2_factory_account());
+        let mut producer = fixture.executor_with_post_exec_mode(PostExecMode::Produce);
+
+        // tx0 warms `created` (as its intrinsic `to`), recording it in the block warming set.
+        producer
+            .execute_transaction(&legacy_tx(0, created))
+            .expect("tx0 warms the create2 address");
+        // tx1 calls the factory, which CREATE2s at `created` from depth 1.
+        let tx1_gas = producer
+            .execute_transaction(&legacy_tx_with_gas(1, factory, 200_000))
+            .expect("tx1 inner-creates at the warmed address")
+            .tx_gas_used();
+
+        // Positive control: without it the negative assertion below would pass vacuously if the
+        // factory bytecode ever stopped creating. CREATE2 costs 32 000 on top of the 21 000
+        // intrinsic, so this gas floor is only reachable if the create frame actually ran.
+        assert!(
+            tx1_gas > 21_000 + 32_000,
+            "tx1 must have executed a CREATE2, but used only {tx1_gas} gas",
+        );
+
+        let claimed =
+            all_warming_events(&producer).into_iter().find(|event| event.address == created);
+        assert!(
+            claimed.is_none(),
+            "a tx claimed a warming rebate for an inner-CREATE2 address ({created}) it never paid \
+             a cold EIP-2929 access for: {:#?}",
+            producer.warming_events_by_tx,
+        );
+    }
+
     // A contract created by one tx must be warmed for a later tx that genuinely cold-accesses it,
     // so the later tx earns its warming rebate. The `create` hook records the address via
-    // `CreateInputs::created_address`, which `revm` memoizes (`OnceCell`) from the canonical
-    // pre-bump nonce before the hook runs — so the address is always correct regardless of the
-    // nonce the inspector passes (this is why the "CREATE-address staleness" concern does not arise
-    // against the pinned revm). This guards the end-to-end property: created contract -> warmed ->
-    // later cold access rebated.
+    // `CreateInputs::created_address`, whose `OnceCell` the hook *seeds*: it runs before revm's
+    // `frame_init` computes the same value, so revm reuses ours. Both read the identical pre-bump
+    // caller nonce, so the recorded address is the one the EVM deploys to — see the `create` hook
+    // for why that is load-bearing rather than a fallback. This guards the end-to-end property:
+    // created contract -> warmed -> later cold access rebated.
     #[test]
     fn test_created_contract_address_is_warmed_for_a_later_tx() {
         const BLOCK_GAS_LIMIT: u64 = 2_000_000;
@@ -1047,6 +1116,48 @@ mod sdm {
             .find(|event| event.address == created)
             .expect("tx1 must earn a warming rebate for the contract created by tx0");
         assert_eq!(created_event.claiming_tx_index, 1, "rebate is claimed by tx1");
+        assert_eq!(created_event.first_warmed_by_tx_index, 0, "contract was warmed by tx0");
+        assert_eq!(created_event.amount, 2_500, "warm-account rebate amount");
+        assert_eq!(created_event.slot, None, "account rebate has no storage slot");
+    }
+
+    // The inner-depth counterpart of the test above, and the other half of the inner-CREATE fix:
+    // suppressing the creating tx's rebate must not stop the created address from entering the
+    // *block* warming set. A later tx that genuinely cold-accesses an inner-created contract still
+    // earns its rebate — i.e. the fix drops only the unearned claim, not the warming record. A
+    // "simplification" deleting the `observe_account_touch` call in the `create` hook would pass
+    // every other test in this module but fail here.
+    #[test]
+    fn test_inner_created_contract_address_is_warmed_for_a_later_tx() {
+        const BLOCK_GAS_LIMIT: u64 = 2_000_000;
+
+        let factory = Address::from([0x7f; 20]);
+        let created = factory.create2(B256::ZERO, alloy_primitives::keccak256([]));
+        let probe = Address::from([0x8c; 20]);
+
+        let mut fixture = SDMExecutorFixture::new(
+            DEFAULT_DA_FOOTPRINT_GAS_SCALAR,
+            BLOCK_GAS_LIMIT,
+            JOVIAN_TIMESTAMP,
+        );
+        fixture.db.insert_account(factory, create2_factory_account());
+        fixture.db.insert_account(probe, balance_probe_account(&[created]));
+        let mut producer = fixture.executor_with_post_exec_mode(PostExecMode::Produce);
+
+        // tx0 inner-creates at `created` and claims nothing for it (the fix), but must warm it.
+        producer
+            .execute_transaction(&legacy_tx_with_gas(0, factory, 200_000))
+            .expect("tx0 inner-creates the contract");
+        // tx1 cold-`BALANCE`-touches the inner-created contract through the probe.
+        producer
+            .execute_transaction(&legacy_tx(1, probe))
+            .expect("tx1 cold-touches the inner-created contract");
+
+        let created_event = all_warming_events(&producer)
+            .into_iter()
+            .find(|event| event.address == created)
+            .expect("tx1 must earn a warming rebate for the contract inner-created by tx0");
+        assert_eq!(created_event.claiming_tx_index, 1, "rebate is claimed by tx1, not tx0");
         assert_eq!(created_event.first_warmed_by_tx_index, 0, "contract was warmed by tx0");
         assert_eq!(created_event.amount, 2_500, "warm-account rebate amount");
         assert_eq!(created_event.slot, None, "account rebate has no storage slot");

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -845,6 +845,61 @@ mod sdm {
         );
     }
 
+    // Closes the max-input saturation gap the FMA flags under FM2. The settlement identity
+    // `sender_delta == beneficiary_delta + base_fee_delta + operator_fee_delta` must hold
+    // *exactly* at the arithmetic extremes a hostile producer can reach, so that no
+    // `saturating_mul`/`saturating_add` in the deltas path can mask a non-conserving delta and
+    // mint ETH. `refund` is bounded by `evm_gas_used` (u64) and prices by u128, so the widest
+    // product is ~2^192 — inside U256, and therefore never actually saturating.
+    //
+    // Only `effective_gas_price >= basefee` is exercised: below-basefee txs cannot reach
+    // settlement (revm rejects them upstream with GasPriceLessThanBasefee), and the
+    // `beneficiary_gas_price` saturating_sub relies on exactly that.
+    #[test]
+    fn test_post_exec_settlement_conserves_value_at_arithmetic_extremes() {
+        for base_fee in [0u64, 1, 1_000_000_000, u64::MAX] {
+            let mut fixture = SDMExecutorFixture { base_fee, ..Default::default() };
+            let mut executor = fixture.executor();
+
+            for refund in [1u64, 21_000, u64::MAX / 2, u64::MAX] {
+                for gas_price in [u128::from(base_fee), u128::from(base_fee) + 1, u128::MAX] {
+                    let tx = legacy_tx_with_price(0, Address::from([0x11; 20]), 50_000, gas_price);
+                    let deltas = executor
+                        .post_exec_settlement_deltas(&tx, u64::MAX, refund, false, false)
+                        .expect("settlement deltas");
+                    let inputs =
+                        format!("base_fee={base_fee}, refund={refund}, gas_price={gas_price}");
+
+                    // Each leg must equal its exact closed form: the conservation identity alone
+                    // would still hold if two legs clamped by offsetting amounts.
+                    let refund_u256 = U256::from(refund);
+                    assert_eq!(
+                        deltas.base_fee_balance_delta,
+                        refund_u256 * U256::from(base_fee),
+                        "base-fee leg must not saturate ({inputs})",
+                    );
+                    assert_eq!(
+                        deltas.beneficiary_balance_delta,
+                        refund_u256 * U256::from(gas_price - u128::from(base_fee)),
+                        "beneficiary leg must not saturate ({inputs})",
+                    );
+                    assert_eq!(
+                        deltas.sender_balance_delta,
+                        refund_u256 * U256::from(gas_price) + deltas.operator_fee_balance_delta,
+                        "sender credit must not saturate ({inputs})",
+                    );
+                    assert_eq!(
+                        deltas.sender_balance_delta,
+                        deltas.beneficiary_balance_delta +
+                            deltas.base_fee_balance_delta +
+                            deltas.operator_fee_balance_delta,
+                        "settlement must conserve value ({inputs})",
+                    );
+                }
+            }
+        }
+    }
+
     // A settlement debit larger than a recipient's balance invalidates the block via
     // PostExecSettlementUnderflow rather than silently saturating — this is the guard against a
     // malformed/adversarial payload minting ETH out of an underfunded vault.

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -845,16 +845,8 @@ mod sdm {
         );
     }
 
-    // Closes the max-input saturation gap the FMA flags under FM2. The settlement identity
-    // `sender_delta == beneficiary_delta + base_fee_delta + operator_fee_delta` must hold
-    // *exactly* at the arithmetic extremes a hostile producer can reach, so that no
-    // `saturating_mul`/`saturating_add` in the deltas path can mask a non-conserving delta and
-    // mint ETH. `refund` is bounded by `evm_gas_used` (u64) and prices by u128, so the widest
-    // product is ~2^192 — inside U256, and therefore never actually saturating.
-    //
-    // Only `effective_gas_price >= basefee` is exercised: below-basefee txs cannot reach
-    // settlement (revm rejects them upstream with GasPriceLessThanBasefee), and the
-    // `beneficiary_gas_price` saturating_sub relies on exactly that.
+    // Verify valid maximum-width inputs do not saturate settlement arithmetic. Transactions below
+    // base fee are rejected before settlement and are not exercised here.
     #[test]
     fn test_post_exec_settlement_conserves_value_at_arithmetic_extremes() {
         for base_fee in [0u64, 1, 1_000_000_000, u64::MAX] {
@@ -870,8 +862,7 @@ mod sdm {
                     let inputs =
                         format!("base_fee={base_fee}, refund={refund}, gas_price={gas_price}");
 
-                    // Each leg must equal its exact closed form: the conservation identity alone
-                    // would still hold if two legs clamped by offsetting amounts.
+                    // Check each leg; conservation alone can hide offsetting clamps.
                     let refund_u256 = U256::from(refund);
                     assert_eq!(
                         deltas.base_fee_balance_delta,
@@ -882,6 +873,11 @@ mod sdm {
                         deltas.beneficiary_balance_delta,
                         refund_u256 * U256::from(gas_price - u128::from(base_fee)),
                         "beneficiary leg must not saturate ({inputs})",
+                    );
+                    assert_eq!(
+                        deltas.operator_fee_balance_delta,
+                        refund_u256 * U256::from(5 * 100),
+                        "operator-fee leg must not saturate ({inputs})",
                     );
                     assert_eq!(
                         deltas.sender_balance_delta,
@@ -1065,15 +1061,8 @@ mod sdm {
         AccountInfo { code_hash, code: Some(Bytecode::new_raw(raw)), ..Default::default() }
     }
 
-    // An *inner* (depth > 0) CREATE/CREATE2 is not an EIP-2929 metered account access: revm's
-    // `create` instruction charges only create_cost + initcode + memory, never the 2600 cold
-    // account-access surcharge (EIP-2929 lists BALANCE/EXTCODE*/CALL*/SELFDESTRUCT/SLOAD/SSTORE —
-    // CREATE and CREATE2 are absent). The warming rebate is defined as the cold->warm delta
-    // (2600 - 100 = 2500) refunded when a tx paid cold for an address already warm in the block.
-    // A tx that never paid a cold surcharge is owed nothing, so an inner CREATE2 landing on an
-    // address an earlier tx warmed must NOT be rebated. The `create` hook previously suppressed
-    // this only for `top_level`, so the inner case claimed an unearned 2500 per creation; it now
-    // suppresses at any depth.
+    // CREATE and CREATE2 charge no cold-account surcharge, so an inner creation at an address
+    // warmed earlier in the block must not receive the 2,500-gas rebate.
     #[test]
     fn test_inner_create_address_is_not_rebated() {
         const BLOCK_GAS_LIMIT: u64 = 2_000_000;
@@ -1090,23 +1079,14 @@ mod sdm {
         fixture.db.insert_account(factory, create2_factory_account());
         let mut producer = fixture.executor_with_post_exec_mode(PostExecMode::Produce);
 
-        // tx0 warms `created` (as its intrinsic `to`), recording it in the block warming set.
+        // tx0 warms `created`; tx1 creates it through the factory.
         producer
             .execute_transaction(&legacy_tx(0, created))
             .expect("tx0 warms the create2 address");
-        // tx1 calls the factory, which CREATE2s at `created` from depth 1.
         let tx1_gas = producer
             .execute_transaction(&legacy_tx_with_gas(1, factory, 200_000))
             .expect("tx1 inner-creates at the warmed address")
             .tx_gas_used();
-
-        // Positive control: without it the negative assertion below would pass vacuously if the
-        // factory bytecode ever stopped creating. CREATE2 costs 32 000 on top of the 21 000
-        // intrinsic, so this gas floor is only reachable if the create frame actually ran.
-        assert!(
-            tx1_gas > 21_000 + 32_000,
-            "tx1 must have executed a CREATE2, but used only {tx1_gas} gas",
-        );
 
         let claimed =
             all_warming_events(&producer).into_iter().find(|event| event.address == created);
@@ -1116,21 +1096,20 @@ mod sdm {
              a cold EIP-2929 access for: {:#?}",
             producer.warming_events_by_tx,
         );
+
+        // Ensure the factory still executes CREATE2.
+        assert!(
+            tx1_gas > 21_000 + 32_000,
+            "tx1 must have executed a CREATE2, but used only {tx1_gas} gas",
+        );
     }
 
-    // A contract created by one tx must be warmed for a later tx that genuinely cold-accesses it,
-    // so the later tx earns its warming rebate. The `create` hook records the address via
-    // `CreateInputs::created_address`, whose `OnceCell` the hook *seeds*: it runs before revm's
-    // `frame_init` computes the same value, so revm reuses ours. Both read the identical pre-bump
-    // caller nonce, so the recorded address is the one the EVM deploys to — see the `create` hook
-    // for why that is load-bearing rather than a fallback. This guards the end-to-end property:
-    // created contract -> warmed -> later cold access rebated.
+    // A created address remains block-warm, allowing a later cold access to claim its rebate.
     #[test]
     fn test_created_contract_address_is_warmed_for_a_later_tx() {
         const BLOCK_GAS_LIMIT: u64 = 2_000_000;
 
-        // Probe the canonical address the CREATE produces (revm computes it from the pre-bump
-        // nonce). Sender and nonce match the real run below, so the address is identical.
+        // Probe the address produced by the same sender and nonce used below.
         let created = {
             let mut probe_fixture = SDMExecutorFixture::new(
                 DEFAULT_DA_FOOTPRINT_GAS_SCALAR,
@@ -1176,12 +1155,7 @@ mod sdm {
         assert_eq!(created_event.slot, None, "account rebate has no storage slot");
     }
 
-    // The inner-depth counterpart of the test above, and the other half of the inner-CREATE fix:
-    // suppressing the creating tx's rebate must not stop the created address from entering the
-    // *block* warming set. A later tx that genuinely cold-accesses an inner-created contract still
-    // earns its rebate — i.e. the fix drops only the unearned claim, not the warming record. A
-    // "simplification" deleting the `observe_account_touch` call in the `create` hook would pass
-    // every other test in this module but fail here.
+    // Suppressing an inner create's rebate must still leave the address warm for later txs.
     #[test]
     fn test_inner_created_contract_address_is_warmed_for_a_later_tx() {
         const BLOCK_GAS_LIMIT: u64 = 2_000_000;

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -776,7 +776,13 @@ mod sdm {
 
         let tx = legacy_tx_with_price(0, Address::from([0x11; 20]), DEFAULT_GAS_LIMIT, GAS_PRICE);
         let deltas = executor
-            .post_exec_settlement_deltas(&tx, EVM_GAS_USED, REFUND, false, false)
+            .post_exec_settlement_deltas(
+                &tx,
+                EVM_GAS_USED,
+                REFUND,
+                /* is_deposit */ false,
+                /* is_post_exec */ false,
+            )
             .expect("settlement deltas computed");
 
         let refund = U256::from(REFUND);
@@ -827,20 +833,37 @@ mod sdm {
         // Deposit: warms state for later txs but is never refunded.
         assert!(
             is_no_op(
-                executor.post_exec_settlement_deltas(&tx, 50_000, 1_000, true, false).unwrap()
+                executor
+                    .post_exec_settlement_deltas(
+                        &tx, /* evm_gas_used */ 50_000, /* post_exec_refund */ 1_000,
+                        /* is_deposit */ true, /* is_post_exec */ false,
+                    )
+                    .unwrap()
             ),
             "deposits never settle a refund",
         );
         // The post-exec (0x7D) tx itself never claims.
         assert!(
             is_no_op(
-                executor.post_exec_settlement_deltas(&tx, 50_000, 1_000, false, true).unwrap()
+                executor
+                    .post_exec_settlement_deltas(
+                        &tx, /* evm_gas_used */ 50_000, /* post_exec_refund */ 1_000,
+                        /* is_deposit */ false, /* is_post_exec */ true,
+                    )
+                    .unwrap()
             ),
             "the post-exec tx never settles a refund",
         );
         // Zero refund: nothing to settle.
         assert!(
-            is_no_op(executor.post_exec_settlement_deltas(&tx, 50_000, 0, false, false).unwrap()),
+            is_no_op(
+                executor
+                    .post_exec_settlement_deltas(
+                        &tx, /* evm_gas_used */ 50_000, /* post_exec_refund */ 0,
+                        /* is_deposit */ false, /* is_post_exec */ false,
+                    )
+                    .unwrap()
+            ),
             "a zero refund produces no settlement",
         );
     }
@@ -857,7 +880,13 @@ mod sdm {
                 for gas_price in [u128::from(base_fee), u128::from(base_fee) + 1, u128::MAX] {
                     let tx = legacy_tx_with_price(0, Address::from([0x11; 20]), 50_000, gas_price);
                     let deltas = executor
-                        .post_exec_settlement_deltas(&tx, u64::MAX, refund, false, false)
+                        .post_exec_settlement_deltas(
+                            &tx,
+                            /* evm_gas_used */ u64::MAX,
+                            /* post_exec_refund */ refund,
+                            /* is_deposit */ false,
+                            /* is_post_exec */ false,
+                        )
                         .expect("settlement deltas");
                     let inputs =
                         format!("base_fee={base_fee}, refund={refund}, gas_price={gas_price}");

--- a/rust/alloy-op-evm/src/post_exec/inspector.rs
+++ b/rust/alloy-op-evm/src/post_exec/inspector.rs
@@ -416,20 +416,8 @@ where
         let caller = inputs.caller();
         self.observe_account_touch(caller, true);
 
-        // `CreateInputs::created_address` memoizes its result (`OnceCell`), and this hook runs
-        // *before* the create frame is initialized: `inspect_frame_init` dispatches
-        // `Inspector::create` through `frame_start` and only then calls `frame_init`, which is
-        // where revm computes `created_address(old_nonce)` (`revm-handler-41.0.0`
-        // `src/frame.rs:309`). So for `CreateScheme::Create` the nonce read below *seeds*
-        // that cell and revm reuses our value in place of its own `old_nonce` — it is
-        // load-bearing, not a fallback. It is correct because nothing mutates the caller
-        // nonce between this hook and `frame_init`, so both observe the same pre-bump
-        // value, and the caller is always already resident in `evm_state()` (loaded by
-        // `deduct_caller` for a top-level create, or as the executing frame's own account
-        // for an inner one) so `unwrap_or_default()` never fires. Do not collapse this to a
-        // constant nonce: the inspector runs only while producing, so a wrong address here
-        // would deploy the contract where no verifier expects it — a state-root split,
-        // not merely a wrong refund amount.
+        // This hook seeds the created-address cache before frame initialization. CREATE must use
+        // the caller's pre-bump nonce; a wrong value changes the deployed address.
         let created_address = match inputs.scheme() {
             CreateScheme::Create => {
                 let nonce = context
@@ -437,24 +425,15 @@ where
                     .evm_state()
                     .get(&caller)
                     .map(|account| account.info.nonce)
-                    .unwrap_or_default();
+                    .expect("create caller must be loaded before inspection");
                 inputs.created_address(nonce)
             }
-            // Nonce-independent: CREATE2 hashes the salt and init code, Custom carries the address
-            // outright. Enumerated rather than `_` so a future nonce-dependent scheme fails to
-            // compile here instead of silently seeding the cell with nonce 0.
+            // These schemes are nonce-independent. List them so new schemes require review.
             CreateScheme::Create2 { .. } | CreateScheme::Custom { .. } => inputs.created_address(0),
         };
 
-        // A creating tx never pays a cold-account surcharge for the address it creates, at any
-        // depth, so there is no cold->warm delta to rebate. `CREATE`/`CREATE2` are absent from
-        // EIP-2929's metered-opcode list (`BALANCE`, `EXTCODESIZE`/`COPY`/`HASH`, the `CALL`
-        // family, `SELFDESTRUCT`, `SLOAD`, `SSTORE`): the create path charges initcode, create and
-        // memory gas only. For a top-level CREATE the address is additionally the tx's intrinsic
-        // "to", pre-warmed at tx start and billed warm. Either way the address must not earn a
-        // warming rebate for the creating tx, even if an earlier tx warmed it. It is still recorded
-        // in `warmed_accounts` below, so a later tx that accesses it via a metered opcode
-        // (genuinely cold for that tx) still earns its rebate.
+        // CREATE and CREATE2 warm the created address without a cold-account surcharge, so the
+        // creating tx has no cold-to-warm delta to rebate. Keep recording it for later txs.
         self.current_tx.intrinsic_warm_accounts.insert(created_address);
         self.observe_account_touch(created_address, true);
         None

--- a/rust/alloy-op-evm/src/post_exec/inspector.rs
+++ b/rust/alloy-op-evm/src/post_exec/inspector.rs
@@ -162,6 +162,14 @@ pub struct WarmingState {
 }
 
 /// Lightweight inspector that computes post-exec block-warming refunds.
+///
+/// # Known imprecision
+///
+/// The per-transaction sets (`touched_accounts` / `touched_slots`) are not journal-revert-aware: an
+/// access made inside a frame that later reverts still counts as touched for the rest of the
+/// transaction, so a subsequent genuine cold access in that same transaction is denied its rebate.
+/// That is an under-refund — it over-charges the sender and never over-debits a fee vault — so it
+/// is safe to leave as-is. See also the pre-frame-init note on the `create` hook below.
 #[derive(Debug, Clone, Default)]
 pub struct SDMWarmingInspector {
     warmed_accounts: BTreeMap<Address, u64>,
@@ -435,6 +443,16 @@ where
         // CREATE and CREATE2 warm the created address without a cold-account surcharge, so the
         // creating tx has no cold-to-warm delta to rebate. Keep recording it for later txs.
         self.current_tx.intrinsic_warm_accounts.insert(created_address);
+        // This runs before `make_create_frame` does its own checks. On an early failure there
+        // (depth limit, insufficient balance, nonce overflow) revm returns before
+        // `journal.load_account(created_address)`, so it never warms the address — yet the
+        // block-warm set now says it is warm, and a later tx that genuinely cold-accesses
+        // it claims a rebate it did not earn. Left as-is deliberately: producer and
+        // verifier agree, the failing path sinks the 32,000-gas CREATE charge (only the
+        // EIP-8037 state-gas component is returned), and the address must derive from an
+        // account the attacker already controls — so it costs at least 32,000 gas to shift
+        // at most 2,500. A real fix gates on `create_end` and has to decide what
+        // to do about `CreateCollision`, which warms the address but reports none.
         self.observe_account_touch(created_address, true);
         None
     }

--- a/rust/alloy-op-evm/src/post_exec/inspector.rs
+++ b/rust/alloy-op-evm/src/post_exec/inspector.rs
@@ -416,11 +416,20 @@ where
         let caller = inputs.caller();
         self.observe_account_touch(caller, true);
 
-        // `CreateInputs::created_address` memoizes its result (`OnceCell`): the canonical create
-        // frame computes and caches the address from the *pre-bump* creator nonce before this hook
-        // runs, so the value below is the correct created address regardless of the nonce we pass.
-        // The journal-nonce read is only a best-effort fallback for the (currently unreached) case
-        // where the cache is not yet populated; it cannot make the recorded address stale.
+        // `CreateInputs::created_address` memoizes its result (`OnceCell`), and this hook runs
+        // *before* the create frame is initialized: `inspect_frame_init` dispatches
+        // `Inspector::create` through `frame_start` and only then calls `frame_init`, which is
+        // where revm computes `created_address(old_nonce)` (`revm-handler-41.0.0`
+        // `src/frame.rs:309`). So for `CreateScheme::Create` the nonce read below *seeds*
+        // that cell and revm reuses our value in place of its own `old_nonce` — it is
+        // load-bearing, not a fallback. It is correct because nothing mutates the caller
+        // nonce between this hook and `frame_init`, so both observe the same pre-bump
+        // value, and the caller is always already resident in `evm_state()` (loaded by
+        // `deduct_caller` for a top-level create, or as the executing frame's own account
+        // for an inner one) so `unwrap_or_default()` never fires. Do not collapse this to a
+        // constant nonce: the inspector runs only while producing, so a wrong address here
+        // would deploy the contract where no verifier expects it — a state-root split,
+        // not merely a wrong refund amount.
         let created_address = match inputs.scheme() {
             CreateScheme::Create => {
                 let nonce = context
@@ -431,18 +440,22 @@ where
                     .unwrap_or_default();
                 inputs.created_address(nonce)
             }
-            _ => inputs.created_address(0),
+            // Nonce-independent: CREATE2 hashes the salt and init code, Custom carries the address
+            // outright. Enumerated rather than `_` so a future nonce-dependent scheme fails to
+            // compile here instead of silently seeding the cell with nonce 0.
+            CreateScheme::Create2 { .. } | CreateScheme::Custom { .. } => inputs.created_address(0),
         };
 
-        // For a top-level CREATE transaction the created-contract address is the tx's intrinsic
-        // "to" under EIP-2929: it is pre-warmed at tx start, billed warm, never cold. Like a Call
-        // target it must not earn a warming rebate, even if an earlier tx warmed the address. It is
-        // still recorded in `warmed_accounts`, so a later tx that accesses it via a normal opcode
-        // (genuinely cold for that tx) still earns its rebate. Inner (depth > 0) creations are
-        // ordinary execution-time touches and keep claiming.
-        if top_level {
-            self.current_tx.intrinsic_warm_accounts.insert(created_address);
-        }
+        // A creating tx never pays a cold-account surcharge for the address it creates, at any
+        // depth, so there is no cold->warm delta to rebate. `CREATE`/`CREATE2` are absent from
+        // EIP-2929's metered-opcode list (`BALANCE`, `EXTCODESIZE`/`COPY`/`HASH`, the `CALL`
+        // family, `SELFDESTRUCT`, `SLOAD`, `SSTORE`): the create path charges initcode, create and
+        // memory gas only. For a top-level CREATE the address is additionally the tx's intrinsic
+        // "to", pre-warmed at tx start and billed warm. Either way the address must not earn a
+        // warming rebate for the creating tx, even if an earlier tx warmed it. It is still recorded
+        // in `warmed_accounts` below, so a later tx that accesses it via a metered opcode
+        // (genuinely cold for that tx) still earns its rebate.
+        self.current_tx.intrinsic_warm_accounts.insert(created_address);
         self.observe_account_touch(created_address, true);
         None
     }


### PR DESCRIPTION
## Summary

Inner `CREATE`/`CREATE2` operations could claim a 2,500-gas SDM warm-account rebate for the created address. These opcodes warm that address but do not pay EIP-2929's cold-account surcharge, so there is no cold-to-warm delta to refund.

The excess refund over-debited fee vaults. Verifiers apply the producer's refund rather than recomputing it, so affected blocks remained valid.

## Fix

Mark created addresses as non-refundable at every depth while still recording them in the block-warm set. A later transaction that genuinely cold-accesses the address can therefore still claim its rebate.

The same hook seeds revm's cached created address before frame initialization. Its comment now reflects that ordering, missing creator state fails closed, and `CreateScheme` variants are matched explicitly.

## Tests

- Reproduces the inner `CREATE2` over-refund.
- Verifies inner-created addresses remain warm for later transactions.
- Retains top-level CREATE coverage.
- Checks settlement arithmetic and conservation at maximum-width inputs.

`cargo nextest run -p alloy-op-evm`: **82 passed**  
`cargo clippy -p alloy-op-evm --all-features --all-targets -- -D warnings`: **clean**

## Known limitations

Both are now recorded in the code rather than only here, and both are left for a separate change.

- **Per-transaction warming sets are not journal-revert-aware.** A reverted inner create can therefore suppress a later valid rebate in the same transaction. This is an under-refund.
- **Block-warmth is recorded before frame initialization.** The `create` hook runs before `make_create_frame` performs its depth, balance and nonce checks. On an early failure there, revm returns before `journal.load_account(created_address)` and never warms the address, but the block-warm set says it is warm — so a later transaction that genuinely cold-accesses it claims an unearned rebate. Producer and verifier agree, and the failing CREATE sinks its 32,000 gas to shift at most 2,500, for an address that must derive from an account the attacker already controls, so there is no profitable exploit. A real fix gates on `create_end` and needs a decision on `CreateCollision`, which warms the address but reports none.

## Companion PR

ethereum-optimism/optimism-premium#98 applies the same fix to `BlockWarmingPolicy`. The premium repository's monorepo pin is unchanged; this PR lands first.

