### PR TITLE
ci: make cloud-security sole owner of CI and renovate files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,8 +24,12 @@
 /docs/public-docs/  @ethereum-optimism/solutions
 
 # CI workflows
-/.github/workflows/ @ethereum-optimism/cloud-security
-/.github/actions/   @ethereum-optimism/cloud-security
 
 # Must come last to avoid being overridden
-/.github/CODEOWNERS  @ethereum-optimism/cloud-security
+
+/.github/workflows/     @ethereum-optimism/cloud-security
+/.github/actions/       @ethereum-optimism/cloud-security
+/renovate.json          @ethereum-optimism/cloud-security
+/.github/renovate.json  @ethereum-optimism/cloud-security
+/renovate.json5         @ethereum-optimism/cloud-security
+/.github/CODEOWNERS      @ethereum-optimism/cloud-security


### PR DESCRIPTION
Makes `@ethereum-optimism/cloud-security` the sole owner of CI and dependency-config files (`.github/workflows/`, `.github/actions/`, renovate config, and CODEOWNERS itself), so security-gate changes are governed and mergeable by the security team.