### PR TITLE
kona: gate PostExec transaction structure in batch validation

### DIFF
--- a/rust/kona/crates/protocol/protocol/src/batch/mod.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/mod.rs
@@ -71,6 +71,8 @@ pub use element::{MAX_SPAN_BATCH_ELEMENTS, SpanBatchElement};
 mod validity;
 pub use validity::{BatchDropReason, BatchValidity};
 
+mod post_exec;
+
 mod single;
 pub use single::SingleBatch;
 

--- a/rust/kona/crates/protocol/protocol/src/batch/post_exec.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/post_exec.rs
@@ -1,0 +1,145 @@
+//! Structural validation of `PostExec` (`0x7D`) transactions in sequencer-provided batch data.
+//!
+//! Derivation and the execution layer must reach the same verdict on block validity. A block that
+//! derivation accepts but the EL rejects does not stall a follower post-Holocene — it falls back to
+//! deposits-only attributes — but that is worse than stalling for the height: the safe chain
+//! commits a deposits-only block, discarding every user transaction the sequencer included, and
+//! because the batch was accepted rather than dropped the batch queue never tries a subsequent
+//! valid batch for the height. Dropping is strictly better, so every rejection here is a
+//! [`Drop`](BatchValidity::Drop).
+//!
+//! # Enforced
+//!
+//! Everything the EL decides from the batch transactions of a single block, across its two
+//! validation sites — op-alloy's `parse_post_exec_payload_from_transactions` (activation,
+//! at-most-one, payload well-formedness, block-number anchor, last-in-block) and
+//! `PostExecState::new` in `alloy-op-evm`'s `src/block/mod.rs`, whose two payload-only
+//! preconditions are that no entry has a zero refund and no transaction index repeats.
+//!
+//! Rule *precedence* mirrors op-alloy arm for arm, so a payload violating several rules at once
+//! yields the same reason there and here.
+//!
+//! # Not enforced
+//!
+//! An entry index that is out of range or that targets a deposit or the `0x7D` itself, and
+//! `refund <= evm_gas_used`. Entry indices are **block-global** — they count the deposits the
+//! derivation pipeline prepends — while a batch holds only the block's non-deposit transactions, so
+//! those rules need the block's full transaction list; the refund ceiling needs execution. Only the
+//! executor can decide them. The position and count rules need no such adjustment: deposits are
+//! always prepended, so the last batch transaction is the last transaction of the block.
+
+use crate::{BatchDropReason, BatchValidity};
+use alloc::collections::BTreeSet;
+use alloy_primitives::Bytes;
+use op_alloy_consensus::{POST_EXEC_TX_TYPE_ID, PostExecPayload};
+use tracing::warn;
+
+/// Applies the `PostExec` rules decidable from one block's batch transactions. See the module docs
+/// for which rules those are and why the rest belong to the executor.
+///
+/// `block_number` is the number of the L2 block `transactions` builds — the number a payload must
+/// be anchored to. `sdm_active` is whether SDM is active at that block's timestamp.
+pub(crate) fn check_post_exec_txs(
+    transactions: &[Bytes],
+    block_number: u64,
+    sdm_active: bool,
+) -> BatchValidity {
+    let mut post_exec_index: Option<usize> = None;
+
+    for (index, tx) in transactions.iter().enumerate() {
+        // `0x7D` is below the `0xc0` legacy-RLP list-header range, so a leading byte match cannot
+        // collide with an untyped transaction.
+        if tx.first() != Some(&POST_EXEC_TX_TYPE_ID) {
+            continue;
+        }
+
+        // Activation first, matching op-alloy: a pre-activation `0x7D` is rejected before its
+        // payload is looked at, so a bare type byte reports the activation failure rather than a
+        // decode failure.
+        if !sdm_active {
+            warn!(
+                target: "batch_post_exec",
+                "PostExec transactions are not supported pre-Lagoon. tx_index: {}",
+                index
+            );
+            return BatchValidity::Drop(BatchDropReason::PostExecPreLagoon);
+        }
+
+        if let Some(first_index) = post_exec_index {
+            warn!(
+                target: "batch_post_exec",
+                "a block may contain at most one PostExec transaction, first_index: {}, tx_index: {}",
+                first_index,
+                index
+            );
+            return BatchValidity::Drop(BatchDropReason::MultiplePostExecTxs);
+        }
+        post_exec_index = Some(index);
+
+        // The canonical encoding is `0x7D || payload`, so the payload is everything after the type
+        // byte. `from_rlp_bytes` applies the same checks the EL does — the supported `version` and
+        // no trailing bytes — and is not stricter: the derivation-side executor frames the
+        // transaction with `decode_2718_exact`, which rejects leftover bytes too. Version
+        // and trailing-byte rejection are covered by op-alloy's own `from_rlp_bytes` tests.
+        let payload = match PostExecPayload::from_rlp_bytes(&tx[1..]) {
+            Ok(payload) => payload,
+            Err(err) => {
+                warn!(
+                    target: "batch_post_exec",
+                    "PostExec transaction payload is invalid, tx_index: {}, err: {}",
+                    index,
+                    err
+                );
+                return BatchValidity::Drop(BatchDropReason::PostExecPayloadInvalid);
+            }
+        };
+
+        if payload.block_number != block_number {
+            warn!(
+                target: "batch_post_exec",
+                "PostExec payload is anchored to the wrong block, tx_index: {}, payload_block_number: {}, block_number: {}",
+                index,
+                payload.block_number,
+                block_number
+            );
+            return BatchValidity::Drop(BatchDropReason::PostExecPayloadBlockNumberMismatch);
+        }
+
+        let mut seen = BTreeSet::new();
+        for entry in &payload.gas_refund_entries {
+            if entry.gas_refund == 0 {
+                warn!(
+                    target: "batch_post_exec",
+                    "PostExec payload has a zero-refund entry, entry_index: {}",
+                    entry.index
+                );
+                return BatchValidity::Drop(BatchDropReason::PostExecPayloadZeroRefund);
+            }
+            if !seen.insert(entry.index) {
+                warn!(
+                    target: "batch_post_exec",
+                    "PostExec payload has a duplicate entry, entry_index: {}",
+                    entry.index
+                );
+                return BatchValidity::Drop(BatchDropReason::PostExecPayloadDuplicateEntry);
+            }
+        }
+    }
+
+    // Deferred out of the loop on purpose: op-alloy decides `MultiplePostExecTxs` inside its loop
+    // and `PostExecTxNotLast` after it, so folding this check into the loop would report
+    // `NotLast` where op-alloy reports `Multiple` for a batch that is both.
+    if let Some(index) = post_exec_index &&
+        index != transactions.len() - 1
+    {
+        warn!(
+            target: "batch_post_exec",
+            "PostExec transaction must be the last transaction in the block, tx_index: {}, last_index: {}",
+            index,
+            transactions.len() - 1
+        );
+        return BatchValidity::Drop(BatchDropReason::PostExecTxNotLast);
+    }
+
+    BatchValidity::Accept
+}

--- a/rust/kona/crates/protocol/protocol/src/batch/post_exec.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/post_exec.rs
@@ -1,32 +1,8 @@
-//! Structural validation of `PostExec` (`0x7D`) transactions in sequencer-provided batch data.
+//! Validates `PostExec` (`0x7D`) transactions in sequencer batch data.
 //!
-//! Derivation and the execution layer must reach the same verdict on block validity. A block that
-//! derivation accepts but the EL rejects does not stall a follower post-Holocene — it falls back to
-//! deposits-only attributes — but that is worse than stalling for the height: the safe chain
-//! commits a deposits-only block, discarding every user transaction the sequencer included, and
-//! because the batch was accepted rather than dropped the batch queue never tries a subsequent
-//! valid batch for the height. Dropping is strictly better, so every rejection here is a
-//! [`Drop`](BatchValidity::Drop).
-//!
-//! # Enforced
-//!
-//! Everything the EL decides from the batch transactions of a single block, across its two
-//! validation sites — op-alloy's `parse_post_exec_payload_from_transactions` (activation,
-//! at-most-one, payload well-formedness, block-number anchor, last-in-block) and
-//! `PostExecState::new` in `alloy-op-evm`'s `src/block/mod.rs`, whose two payload-only
-//! preconditions are that no entry has a zero refund and no transaction index repeats.
-//!
-//! Rule *precedence* mirrors op-alloy arm for arm, so a payload violating several rules at once
-//! yields the same reason there and here.
-//!
-//! # Not enforced
-//!
-//! An entry index that is out of range or that targets a deposit or the `0x7D` itself, and
-//! `refund <= evm_gas_used`. Entry indices are **block-global** — they count the deposits the
-//! derivation pipeline prepends — while a batch holds only the block's non-deposit transactions, so
-//! those rules need the block's full transaction list; the refund ceiling needs execution. Only the
-//! executor can decide them. The position and count rules need no such adjustment: deposits are
-//! always prepended, so the last batch transaction is the last transaction of the block.
+//! This enforces rules decidable from batch data: activation, count, encoding, block anchor,
+//! position, and duplicate or zero-refund entries. Entry targets and bounds require the full block;
+//! the refund ceiling requires execution.
 
 use crate::{BatchDropReason, BatchValidity};
 use alloc::collections::BTreeSet;
@@ -34,11 +10,8 @@ use alloy_primitives::Bytes;
 use op_alloy_consensus::{POST_EXEC_TX_TYPE_ID, PostExecPayload};
 use tracing::warn;
 
-/// Applies the `PostExec` rules decidable from one block's batch transactions. See the module docs
-/// for which rules those are and why the rest belong to the executor.
-///
-/// `block_number` is the number of the L2 block `transactions` builds — the number a payload must
-/// be anchored to. `sdm_active` is whether SDM is active at that block's timestamp.
+/// Applies the `PostExec` rules decidable from one block's batch transactions.
+/// `block_number` is the required payload anchor.
 pub(crate) fn check_post_exec_txs(
     transactions: &[Bytes],
     block_number: u64,
@@ -47,15 +20,12 @@ pub(crate) fn check_post_exec_txs(
     let mut post_exec_index: Option<usize> = None;
 
     for (index, tx) in transactions.iter().enumerate() {
-        // `0x7D` is below the `0xc0` legacy-RLP list-header range, so a leading byte match cannot
-        // collide with an untyped transaction.
+        // Legacy transactions begin with an RLP list header, so they cannot match `0x7D`.
         if tx.first() != Some(&POST_EXEC_TX_TYPE_ID) {
             continue;
         }
 
-        // Activation first, matching op-alloy: a pre-activation `0x7D` is rejected before its
-        // payload is looked at, so a bare type byte reports the activation failure rather than a
-        // decode failure.
+        // Match the EL by checking activation before decoding.
         if !sdm_active {
             warn!(
                 target: "batch_post_exec",
@@ -76,11 +46,7 @@ pub(crate) fn check_post_exec_txs(
         }
         post_exec_index = Some(index);
 
-        // The canonical encoding is `0x7D || payload`, so the payload is everything after the type
-        // byte. `from_rlp_bytes` applies the same checks the EL does — the supported `version` and
-        // no trailing bytes — and is not stricter: the derivation-side executor frames the
-        // transaction with `decode_2718_exact`, which rejects leftover bytes too. Version
-        // and trailing-byte rejection are covered by op-alloy's own `from_rlp_bytes` tests.
+        // Decode the exact `0x7D || rlp(payload)` encoding used by the EL.
         let payload = match PostExecPayload::from_rlp_bytes(&tx[1..]) {
             Ok(payload) => payload,
             Err(err) => {
@@ -126,9 +92,7 @@ pub(crate) fn check_post_exec_txs(
         }
     }
 
-    // Deferred out of the loop on purpose: op-alloy decides `MultiplePostExecTxs` inside its loop
-    // and `PostExecTxNotLast` after it, so folding this check into the loop would report
-    // `NotLast` where op-alloy reports `Multiple` for a batch that is both.
+    // Check position last so multiple PostExec transactions take precedence, matching the EL.
     if let Some(index) = post_exec_index &&
         index != transactions.len() - 1
     {

--- a/rust/kona/crates/protocol/protocol/src/batch/post_exec.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/post_exec.rs
@@ -1,8 +1,6 @@
-//! Validates `PostExec` (`0x7D`) transactions in sequencer batch data.
+//! `PostExec` (`0x7D`) validation for sequencer batches.
 //!
-//! This enforces rules decidable from batch data: activation, count, encoding, block anchor,
-//! position, and duplicate or zero-refund entries. Entry targets and bounds require the full block;
-//! the refund ceiling requires execution.
+//! Entry bounds and targets require a full block; refund limits require execution.
 
 use crate::{BatchDropReason, BatchValidity};
 use alloc::collections::BTreeSet;
@@ -10,8 +8,7 @@ use alloy_primitives::Bytes;
 use op_alloy_consensus::{POST_EXEC_TX_TYPE_ID, PostExecPayload};
 use tracing::warn;
 
-/// Applies the `PostExec` rules decidable from one block's batch transactions.
-/// `block_number` is the required payload anchor.
+/// Validates one block's `PostExec` transactions and payload anchor.
 pub(crate) fn check_post_exec_txs(
     transactions: &[Bytes],
     block_number: u64,
@@ -20,12 +17,12 @@ pub(crate) fn check_post_exec_txs(
     let mut post_exec_index: Option<usize> = None;
 
     for (index, tx) in transactions.iter().enumerate() {
-        // Legacy transactions begin with an RLP list header, so they cannot match `0x7D`.
+        // Legacy transactions cannot start with `0x7D`.
         if tx.first() != Some(&POST_EXEC_TX_TYPE_ID) {
             continue;
         }
 
-        // Match the EL by checking activation before decoding.
+        // Match EL validation order.
         if !sdm_active {
             warn!(
                 target: "batch_post_exec",
@@ -46,7 +43,7 @@ pub(crate) fn check_post_exec_txs(
         }
         post_exec_index = Some(index);
 
-        // Decode the exact `0x7D || rlp(payload)` encoding used by the EL.
+        // Decode bytes after the type byte.
         let payload = match PostExecPayload::from_rlp_bytes(&tx[1..]) {
             Ok(payload) => payload,
             Err(err) => {
@@ -92,7 +89,7 @@ pub(crate) fn check_post_exec_txs(
         }
     }
 
-    // Check position last so multiple PostExec transactions take precedence, matching the EL.
+    // Check position after count to match the EL.
     if let Some(index) = post_exec_index &&
         index != transactions.len() - 1
     {

--- a/rust/kona/crates/protocol/protocol/src/batch/single.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/single.rs
@@ -186,11 +186,7 @@ impl SingleBatch {
             }
         }
 
-        // The timestamp equality check above pins this batch to the block right after the safe
-        // head, so that is the block number a PostExec payload must be anchored to. (The
-        // parent-hash check does not add to this on the span-derived path: `BatchValidator`
-        // assigns `parent_hash` from the same parent immediately before calling us, so
-        // there it compares a value to itself.)
+        // The timestamp check pins this batch to the block after the safe head.
         let post_exec_validity = check_post_exec_txs(
             &self.transactions,
             l2_safe_head.block_info.number + 1,
@@ -598,15 +594,13 @@ mod tests {
         );
     }
 
-    /// Encodes a `PostExecPayload` as the canonical `0x7D || rlp(payload)` transaction bytes.
+    /// Encodes canonical `0x7D || rlp(payload)` transaction bytes.
     fn post_exec_tx_bytes(block_number: u64, entries: Vec<SDMGasEntry>) -> Bytes {
         let tx: OpTxEnvelope = build_post_exec_tx(block_number, entries).into();
         tx.encoded_2718().into()
     }
 
-    /// Runs `check_batch` with SDM active over a batch building the block after the safe head.
-    /// The safe head is number 0, so the block under test — and therefore the block number a
-    /// `PostExec` payload must be anchored to — is 1.
+    /// Checks an SDM-active batch building block 1.
     fn check_post_exec_batch(transactions: Vec<Bytes>) -> BatchValidity {
         let single_batch = SingleBatch {
             parent_hash: BlockHash::ZERO,
@@ -654,8 +648,7 @@ mod tests {
     #[test]
     fn test_check_batch_drop_post_exec_wrong_block_anchor() {
         let mut transactions = example_transactions();
-        // The batch builds block 1; anchoring the payload to block 2 makes the block invalid at the
-        // execution layer.
+        // The batch builds block 1, but the payload claims block 2.
         transactions.push(post_exec_tx_bytes(2, vec![]));
 
         assert_eq!(
@@ -667,8 +660,7 @@ mod tests {
     #[test]
     fn test_check_batch_drop_post_exec_undecodable_payload() {
         let mut transactions = example_transactions();
-        // Valid RLP, but a two-element list: `block_number` would have to decode from a list
-        // header, so `PostExecPayload::from_rlp_bytes` rejects it.
+        // Valid RLP, but not a three-field PostExec payload.
         transactions.push(Bytes::from(vec![0x7D, 0xc2, 0x01, 0xc0]));
 
         assert_eq!(
@@ -707,13 +699,7 @@ mod tests {
 
     #[test]
     fn test_check_batch_accept_trailing_post_exec_tx_with_entries() {
-        // Over-broadness control: a single trailing 0x7D with a well-formed payload anchored to the
-        // block under test must still be accepted.
-        //
-        // The entry index is block-global — it counts the deposits the pipeline prepends — so it is
-        // deliberately past index 0, which is always the L1-info deposit and which the executor
-        // would reject as targeting a deposit. Derivation cannot check that (it does not know the
-        // deposit count here), so this asserts derivation's verdict, not whole-block validity.
+        // Target validity is checked later because entry indices include prepended deposits.
         let mut transactions = example_transactions();
         transactions.push(post_exec_tx_bytes(1, vec![SDMGasEntry { index: 3, gas_refund: 2500 }]));
 

--- a/rust/kona/crates/protocol/protocol/src/batch/single.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/single.rs
@@ -699,7 +699,7 @@ mod tests {
 
     #[test]
     fn test_check_batch_accept_trailing_post_exec_tx_with_entries() {
-        // Target validity is checked later because entry indices include prepended deposits.
+        // Targets require prepended deposits and are checked later.
         let mut transactions = example_transactions();
         transactions.push(post_exec_tx_bytes(1, vec![SDMGasEntry { index: 3, gas_refund: 2500 }]));
 

--- a/rust/kona/crates/protocol/protocol/src/batch/single.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/single.rs
@@ -1,6 +1,8 @@
 //! This module contains the [`SingleBatch`] type.
 
-use crate::{BatchDropReason, BatchValidity, BlockInfo, L2BlockInfo};
+use crate::{
+    BatchDropReason, BatchValidity, BlockInfo, L2BlockInfo, batch::post_exec::check_post_exec_txs,
+};
 use alloc::vec::Vec;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockHash, Bytes};
@@ -180,11 +182,22 @@ impl SingleBatch {
                 Ok(OpTxType::Eip7702) if !cfg.is_isthmus_active(self.timestamp) => {
                     return BatchValidity::Drop(BatchDropReason::Eip7702PreIsthmus);
                 }
-                Ok(OpTxType::PostExec) if !cfg.is_sdm_active(self.timestamp) => {
-                    return BatchValidity::Drop(BatchDropReason::PostExecPreLagoon);
-                }
                 _ => {}
             }
+        }
+
+        // The timestamp equality check above pins this batch to the block right after the safe
+        // head, so that is the block number a PostExec payload must be anchored to. (The
+        // parent-hash check does not add to this on the span-derived path: `BatchValidator`
+        // assigns `parent_hash` from the same parent immediately before calling us, so
+        // there it compares a value to itself.)
+        let post_exec_validity = check_post_exec_txs(
+            &self.transactions,
+            l2_safe_head.block_info.number + 1,
+            cfg.is_sdm_active(self.timestamp),
+        );
+        if !post_exec_validity.is_accept() {
+            return post_exec_validity;
         }
 
         BatchValidity::Accept
@@ -201,9 +214,7 @@ mod tests {
     use alloy_eips::eip2718::{Decodable2718, Encodable2718};
     use alloy_primitives::{Address, Sealed, Signature, TxKind, U256};
     use kona_genesis::HardForkConfig;
-    use op_alloy_consensus::{
-        OpTxEnvelope, POST_EXEC_PAYLOAD_VERSION, PostExecPayload, TxDeposit, TxPostExec,
-    };
+    use op_alloy_consensus::{OpTxEnvelope, SDMGasEntry, TxDeposit, build_post_exec_tx};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
@@ -534,13 +545,7 @@ mod tests {
     #[test]
     fn test_check_batch_drop_post_exec_pre_sdm() {
         let mut transactions = example_transactions();
-        let tx: OpTxEnvelope = TxPostExec::new(PostExecPayload {
-            version: POST_EXEC_PAYLOAD_VERSION,
-            block_number: 1,
-            gas_refund_entries: vec![],
-        })
-        .into();
-        transactions.push(tx.encoded_2718().into());
+        transactions.push(post_exec_tx_bytes(1, vec![]));
 
         let single_batch = SingleBatch {
             parent_hash: BlockHash::ZERO,
@@ -566,13 +571,7 @@ mod tests {
     #[test]
     fn test_check_batch_accept_post_exec_post_sdm() {
         let mut transactions = example_transactions();
-        let tx: OpTxEnvelope = TxPostExec::new(PostExecPayload {
-            version: POST_EXEC_PAYLOAD_VERSION,
-            block_number: 1,
-            gas_refund_entries: vec![],
-        })
-        .into();
-        transactions.push(tx.encoded_2718().into());
+        transactions.push(post_exec_tx_bytes(1, vec![]));
 
         let single_batch = SingleBatch {
             parent_hash: BlockHash::ZERO,
@@ -597,6 +596,128 @@ mod tests {
             single_batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block),
             BatchValidity::Accept
         );
+    }
+
+    /// Encodes a `PostExecPayload` as the canonical `0x7D || rlp(payload)` transaction bytes.
+    fn post_exec_tx_bytes(block_number: u64, entries: Vec<SDMGasEntry>) -> Bytes {
+        let tx: OpTxEnvelope = build_post_exec_tx(block_number, entries).into();
+        tx.encoded_2718().into()
+    }
+
+    /// Runs `check_batch` with SDM active over a batch building the block after the safe head.
+    /// The safe head is number 0, so the block under test — and therefore the block number a
+    /// `PostExec` payload must be anchored to — is 1.
+    fn check_post_exec_batch(transactions: Vec<Bytes>) -> BatchValidity {
+        let single_batch = SingleBatch {
+            parent_hash: BlockHash::ZERO,
+            epoch_num: 1,
+            epoch_hash: BlockHash::ZERO,
+            timestamp: 1,
+            transactions,
+        };
+        let cfg = RollupConfig {
+            max_sequencer_drift: 1,
+            hardforks: HardForkConfig { lagoon_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
+        let l1_blocks = vec![BlockInfo::default(), BlockInfo::default()];
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo { timestamp: 1, ..Default::default() },
+            ..Default::default()
+        };
+        single_batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &BlockInfo::default())
+    }
+
+    #[test]
+    fn test_check_batch_drop_multiple_post_exec_txs() {
+        let mut transactions = example_transactions();
+        transactions.push(post_exec_tx_bytes(1, vec![]));
+        transactions.push(post_exec_tx_bytes(1, vec![]));
+
+        assert_eq!(
+            check_post_exec_batch(transactions),
+            BatchValidity::Drop(BatchDropReason::MultiplePostExecTxs)
+        );
+    }
+
+    #[test]
+    fn test_check_batch_drop_post_exec_tx_not_last() {
+        let mut transactions = example_transactions();
+        transactions.insert(0, post_exec_tx_bytes(1, vec![]));
+
+        assert_eq!(
+            check_post_exec_batch(transactions),
+            BatchValidity::Drop(BatchDropReason::PostExecTxNotLast)
+        );
+    }
+
+    #[test]
+    fn test_check_batch_drop_post_exec_wrong_block_anchor() {
+        let mut transactions = example_transactions();
+        // The batch builds block 1; anchoring the payload to block 2 makes the block invalid at the
+        // execution layer.
+        transactions.push(post_exec_tx_bytes(2, vec![]));
+
+        assert_eq!(
+            check_post_exec_batch(transactions),
+            BatchValidity::Drop(BatchDropReason::PostExecPayloadBlockNumberMismatch)
+        );
+    }
+
+    #[test]
+    fn test_check_batch_drop_post_exec_undecodable_payload() {
+        let mut transactions = example_transactions();
+        // Valid RLP, but a two-element list: `block_number` would have to decode from a list
+        // header, so `PostExecPayload::from_rlp_bytes` rejects it.
+        transactions.push(Bytes::from(vec![0x7D, 0xc2, 0x01, 0xc0]));
+
+        assert_eq!(
+            check_post_exec_batch(transactions),
+            BatchValidity::Drop(BatchDropReason::PostExecPayloadInvalid)
+        );
+    }
+
+    #[test]
+    fn test_check_batch_drop_post_exec_duplicate_payload_entry() {
+        let mut transactions = example_transactions();
+        transactions.push(post_exec_tx_bytes(
+            1,
+            vec![
+                SDMGasEntry { index: 1, gas_refund: 2500 },
+                SDMGasEntry { index: 1, gas_refund: 2000 },
+            ],
+        ));
+
+        assert_eq!(
+            check_post_exec_batch(transactions),
+            BatchValidity::Drop(BatchDropReason::PostExecPayloadDuplicateEntry)
+        );
+    }
+
+    #[test]
+    fn test_check_batch_drop_post_exec_zero_refund_payload_entry() {
+        let mut transactions = example_transactions();
+        transactions.push(post_exec_tx_bytes(1, vec![SDMGasEntry { index: 1, gas_refund: 0 }]));
+
+        assert_eq!(
+            check_post_exec_batch(transactions),
+            BatchValidity::Drop(BatchDropReason::PostExecPayloadZeroRefund)
+        );
+    }
+
+    #[test]
+    fn test_check_batch_accept_trailing_post_exec_tx_with_entries() {
+        // Over-broadness control: a single trailing 0x7D with a well-formed payload anchored to the
+        // block under test must still be accepted.
+        //
+        // The entry index is block-global — it counts the deposits the pipeline prepends — so it is
+        // deliberately past index 0, which is always the L1-info deposit and which the executor
+        // would reject as targeting a deposit. Derivation cannot check that (it does not know the
+        // deposit count here), so this asserts derivation's verdict, not whole-block validity.
+        let mut transactions = example_transactions();
+        transactions.push(post_exec_tx_bytes(1, vec![SDMGasEntry { index: 3, gas_refund: 2500 }]));
+
+        assert_eq!(check_post_exec_batch(transactions), BatchValidity::Accept);
     }
 
     #[test]

--- a/rust/kona/crates/protocol/protocol/src/batch/span.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/span.rs
@@ -514,8 +514,7 @@ impl SpanBatch {
                 }
             }
 
-            // `i` includes skipped overlap, preserving the containing block number.
-            // Post-Holocene spans use the singular path; checking both avoids rule drift.
+            // `i` includes skipped overlap, preserving block numbering.
             let post_exec_validity = check_post_exec_txs(
                 &batch.transactions,
                 parent_block.block_info.number + 1 + i as u64,
@@ -2170,7 +2169,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_check_batch_accept_trailing_post_exec_tx() {
-        // Target validity is checked later because entry indices include prepended deposits.
+        // Targets require prepended deposits and are checked later.
         let transactions = vec![
             Bytes::copy_from_slice(&[EIP1559_TX_TYPE_ID]),
             post_exec_tx_bytes(42, vec![SDMGasEntry { index: 3, gas_refund: 2500 }]),

--- a/rust/kona/crates/protocol/protocol/src/batch/span.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/span.rs
@@ -15,7 +15,7 @@ use tracing::{info, warn};
 use crate::{
     BatchDropReason, BatchValidationProvider, BatchValidity, BlockInfo, L2BlockInfo, RawSpanBatch,
     SingleBatch, SpanBatchBits, SpanBatchElement, SpanBatchError, SpanBatchPayload,
-    SpanBatchPrefix, SpanBatchTransactions,
+    SpanBatchPrefix, SpanBatchTransactions, batch::post_exec::check_post_exec_txs,
 };
 
 /// Container for the inputs required to build a span of L2 blocks in derived form.
@@ -510,12 +510,27 @@ impl SpanBatch {
                         warn!(target: "batch_span", "EIP-7702 transactions are not supported pre-isthmus. tx_index: {}", i);
                         return BatchValidity::Drop(BatchDropReason::Eip7702PreIsthmus);
                     }
-                    Ok(OpTxType::PostExec) if !cfg.is_sdm_active(batch.timestamp) => {
-                        warn!(target: "batch_span", "PostExec transactions are not supported pre-Lagoon. tx_index: {}", i);
-                        return BatchValidity::Drop(BatchDropReason::PostExecPreLagoon);
-                    }
                     _ => {}
                 }
+            }
+
+            // The span's blocks are consecutive from the block after its parent, so block `i` is
+            // `parent_block + 1 + i` — the number its `PostExec` payload must be anchored to. `i`
+            // indexes `self.batches`, so it advances for the already-safe blocks the loop skips.
+            //
+            // Defense in depth for `PostExec`: this function is only reached pre-Holocene
+            // (`BatchProvider` muxes to `BatchValidator` once Holocene is active, and that
+            // validates a span's blocks one at a time through
+            // `SingleBatch::check_batch`), while SDM activates at Lagoon, far later.
+            // The live gate for span batches is therefore the singular path.
+            // Enforcing the rules here anyway keeps the two paths from drifting apart.
+            let post_exec_validity = check_post_exec_txs(
+                &batch.transactions,
+                parent_block.block_info.number + 1 + i as u64,
+                cfg.is_sdm_active(batch.timestamp),
+            );
+            if !post_exec_validity.is_accept() {
+                return post_exec_validity;
             }
         }
 
@@ -756,10 +771,12 @@ mod tests {
     use crate::test_utils::{CollectingLayer, TestBatchValidator, TraceStorage};
     use alloc::vec;
     use alloy_consensus::{Header, constants::EIP1559_TX_TYPE_ID};
-    use alloy_eips::BlockNumHash;
+    use alloy_eips::{BlockNumHash, eip2718::Encodable2718};
     use alloy_primitives::{B256, Bytes, b256};
     use kona_genesis::{ChainGenesis, HardForkConfig};
-    use op_alloy_consensus::{OpBlock, POST_EXEC_TX_TYPE_ID};
+    use op_alloy_consensus::{
+        OpBlock, OpTxEnvelope, POST_EXEC_TX_TYPE_ID, SDMGasEntry, build_post_exec_tx,
+    };
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
@@ -2108,6 +2125,207 @@ mod tests {
         assert_eq!(logs.len(), 1);
         assert!(
             logs[0].contains("PostExec transactions are not supported pre-Lagoon. tx_index: 0")
+        );
+    }
+
+    /// Encodes a `PostExecPayload` as the canonical `0x7D || rlp(payload)` transaction bytes.
+    fn post_exec_tx_bytes(block_number: u64, entries: Vec<SDMGasEntry>) -> Bytes {
+        let tx: OpTxEnvelope = build_post_exec_tx(block_number, entries).into();
+        tx.encoded_2718().into()
+    }
+
+    /// Runs `check_batch` with SDM active over a one-block span whose parent is the safe head at
+    /// number 41, so the block under test — and therefore the number a `PostExec` payload must be
+    /// anchored to — is 42.
+    ///
+    /// Note this span is **not** overlapping (`starting_timestamp == next_timestamp`), so
+    /// `parent_block == l2_safe_head` and `parent + 1 + i`, `parent + 1` and `safe_head + 1` all
+    /// evaluate to 42. These cases therefore do not discriminate the span's block-number
+    /// arithmetic; `test_check_batch_drop_post_exec_wrong_block_anchor_in_second_block` pins
+    /// the `+ i` term.
+    async fn check_post_exec_span(transactions: Vec<Bytes>) -> BatchValidity {
+        let cfg = RollupConfig {
+            seq_window_size: 100,
+            max_sequencer_drift: 100,
+            hardforks: HardForkConfig {
+                delta_time: Some(0),
+                lagoon_time: Some(0),
+                ..Default::default()
+            },
+            block_time: 10,
+            ..Default::default()
+        };
+        let l1_blocks = gen_l1_blocks(9, 3, 0, 10);
+        let parent_hash = b256!("1111111111111111111111111111111111111111000000000000000000000000");
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo {
+                number: 41,
+                timestamp: 10,
+                hash: parent_hash,
+                ..Default::default()
+            },
+            l1_origin: BlockNumHash { number: 9, ..Default::default() },
+            ..Default::default()
+        };
+        let inclusion_block = BlockInfo { number: 50, ..Default::default() };
+        let l2_block = L2BlockInfo {
+            block_info: BlockInfo { number: 40, ..Default::default() },
+            ..Default::default()
+        };
+        let mut fetcher: TestBatchValidator =
+            TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
+        let batch = SpanBatch {
+            batches: vec![SpanBatchElement { epoch_num: 10, timestamp: 20, transactions }],
+            parent_check: FixedBytes::<20>::from_slice(&parent_hash[..20]),
+            l1_origin_check: FixedBytes::<20>::from_slice(&l1_blocks[0].hash[..20]),
+            txs: SpanBatchTransactions::default(),
+            ..Default::default()
+        };
+        batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await
+    }
+
+    #[tokio::test]
+    async fn test_check_batch_accept_trailing_post_exec_tx() {
+        // Over-broadness control for the rows below: a single trailing 0x7D with a well-formed
+        // payload anchored to the block under test must still be accepted. The entry index is
+        // block-global and deliberately past 0 (the L1-info deposit) — see the single-batch
+        // equivalent for why derivation cannot check that either way.
+        let transactions = vec![
+            Bytes::copy_from_slice(&[EIP1559_TX_TYPE_ID]),
+            post_exec_tx_bytes(42, vec![SDMGasEntry { index: 3, gas_refund: 2500 }]),
+        ];
+        assert_eq!(check_post_exec_span(transactions).await, BatchValidity::Accept);
+    }
+
+    #[tokio::test]
+    async fn test_check_batch_drop_multiple_post_exec_txs() {
+        let transactions = vec![post_exec_tx_bytes(42, vec![]), post_exec_tx_bytes(42, vec![])];
+        assert_eq!(
+            check_post_exec_span(transactions).await,
+            BatchValidity::Drop(BatchDropReason::MultiplePostExecTxs)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_batch_drop_post_exec_tx_not_last() {
+        let transactions =
+            vec![post_exec_tx_bytes(42, vec![]), Bytes::copy_from_slice(&[EIP1559_TX_TYPE_ID])];
+        assert_eq!(
+            check_post_exec_span(transactions).await,
+            BatchValidity::Drop(BatchDropReason::PostExecTxNotLast)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_batch_drop_post_exec_wrong_block_anchor() {
+        // The span's only block is 42; anchoring the payload to 43 makes the block invalid at the
+        // execution layer.
+        let transactions = vec![post_exec_tx_bytes(43, vec![])];
+        assert_eq!(
+            check_post_exec_span(transactions).await,
+            BatchValidity::Drop(BatchDropReason::PostExecPayloadBlockNumberMismatch)
+        );
+    }
+
+    /// Pins the `+ i` term of the span's block-number arithmetic, which a one-block span cannot:
+    /// with the parent at 41, the second block is 43, so a payload anchored to 42 — the *first*
+    /// block's number — must be rejected. Dropping `+ i` would compute 42 and wrongly accept.
+    ///
+    /// What this still does not isolate is `parent_block` versus `l2_safe_head`, because they are
+    /// the same block whenever a span does not overlap the safe chain. Discriminating that
+    /// needs an overlapping span, which in turn needs a fetcher fixture carrying a valid
+    /// L1-info deposit transaction so the overlapped blocks survive
+    /// `L2BlockInfo::from_block_and_genesis`.
+    #[tokio::test]
+    async fn test_check_batch_drop_post_exec_wrong_block_anchor_in_second_block() {
+        let cfg = RollupConfig {
+            seq_window_size: 100,
+            max_sequencer_drift: 100,
+            hardforks: HardForkConfig {
+                delta_time: Some(0),
+                lagoon_time: Some(0),
+                ..Default::default()
+            },
+            block_time: 10,
+            ..Default::default()
+        };
+        let l1_blocks = gen_l1_blocks(9, 3, 0, 10);
+        let parent_hash = b256!("1111111111111111111111111111111111111111000000000000000000000000");
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo {
+                number: 41,
+                timestamp: 10,
+                hash: parent_hash,
+                ..Default::default()
+            },
+            l1_origin: BlockNumHash { number: 9, ..Default::default() },
+            ..Default::default()
+        };
+        let mut fetcher: TestBatchValidator = TestBatchValidator::default();
+        let batch = SpanBatch {
+            batches: vec![
+                SpanBatchElement {
+                    epoch_num: 10,
+                    timestamp: 20,
+                    transactions: vec![Bytes::copy_from_slice(&[EIP1559_TX_TYPE_ID])],
+                },
+                // Block 43, but the payload claims 42.
+                SpanBatchElement {
+                    epoch_num: 10,
+                    timestamp: 30,
+                    transactions: vec![post_exec_tx_bytes(42, vec![])],
+                },
+            ],
+            parent_check: FixedBytes::<20>::from_slice(&parent_hash[..20]),
+            l1_origin_check: FixedBytes::<20>::from_slice(&l1_blocks[0].hash[..20]),
+            txs: SpanBatchTransactions::default(),
+            ..Default::default()
+        };
+        assert_eq!(
+            batch
+                .check_batch(
+                    &cfg,
+                    &l1_blocks,
+                    l2_safe_head,
+                    &BlockInfo { number: 50, ..Default::default() },
+                    &mut fetcher
+                )
+                .await,
+            BatchValidity::Drop(BatchDropReason::PostExecPayloadBlockNumberMismatch)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_batch_drop_post_exec_undecodable_payload() {
+        let transactions = vec![Bytes::from(vec![POST_EXEC_TX_TYPE_ID, 0xc2, 0x01, 0xc0])];
+        assert_eq!(
+            check_post_exec_span(transactions).await,
+            BatchValidity::Drop(BatchDropReason::PostExecPayloadInvalid)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_batch_drop_post_exec_duplicate_payload_entry() {
+        let transactions = vec![post_exec_tx_bytes(
+            42,
+            vec![
+                SDMGasEntry { index: 1, gas_refund: 2500 },
+                SDMGasEntry { index: 1, gas_refund: 2000 },
+            ],
+        )];
+        assert_eq!(
+            check_post_exec_span(transactions).await,
+            BatchValidity::Drop(BatchDropReason::PostExecPayloadDuplicateEntry)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_batch_drop_post_exec_zero_refund_payload_entry() {
+        let transactions =
+            vec![post_exec_tx_bytes(42, vec![SDMGasEntry { index: 1, gas_refund: 0 }])];
+        assert_eq!(
+            check_post_exec_span(transactions).await,
+            BatchValidity::Drop(BatchDropReason::PostExecPayloadZeroRefund)
         );
     }
 

--- a/rust/kona/crates/protocol/protocol/src/batch/span.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/span.rs
@@ -514,16 +514,8 @@ impl SpanBatch {
                 }
             }
 
-            // The span's blocks are consecutive from the block after its parent, so block `i` is
-            // `parent_block + 1 + i` — the number its `PostExec` payload must be anchored to. `i`
-            // indexes `self.batches`, so it advances for the already-safe blocks the loop skips.
-            //
-            // Defense in depth for `PostExec`: this function is only reached pre-Holocene
-            // (`BatchProvider` muxes to `BatchValidator` once Holocene is active, and that
-            // validates a span's blocks one at a time through
-            // `SingleBatch::check_batch`), while SDM activates at Lagoon, far later.
-            // The live gate for span batches is therefore the singular path.
-            // Enforcing the rules here anyway keeps the two paths from drifting apart.
+            // `i` includes skipped overlap, preserving the containing block number.
+            // Post-Holocene spans use the singular path; checking both avoids rule drift.
             let post_exec_validity = check_post_exec_txs(
                 &batch.transactions,
                 parent_block.block_info.number + 1 + i as u64,
@@ -2128,21 +2120,13 @@ mod tests {
         );
     }
 
-    /// Encodes a `PostExecPayload` as the canonical `0x7D || rlp(payload)` transaction bytes.
+    /// Encodes canonical `0x7D || rlp(payload)` transaction bytes.
     fn post_exec_tx_bytes(block_number: u64, entries: Vec<SDMGasEntry>) -> Bytes {
         let tx: OpTxEnvelope = build_post_exec_tx(block_number, entries).into();
         tx.encoded_2718().into()
     }
 
-    /// Runs `check_batch` with SDM active over a one-block span whose parent is the safe head at
-    /// number 41, so the block under test — and therefore the number a `PostExec` payload must be
-    /// anchored to — is 42.
-    ///
-    /// Note this span is **not** overlapping (`starting_timestamp == next_timestamp`), so
-    /// `parent_block == l2_safe_head` and `parent + 1 + i`, `parent + 1` and `safe_head + 1` all
-    /// evaluate to 42. These cases therefore do not discriminate the span's block-number
-    /// arithmetic; `test_check_batch_drop_post_exec_wrong_block_anchor_in_second_block` pins
-    /// the `+ i` term.
+    /// Checks an SDM-active one-block span building block 42.
     async fn check_post_exec_span(transactions: Vec<Bytes>) -> BatchValidity {
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -2186,10 +2170,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_check_batch_accept_trailing_post_exec_tx() {
-        // Over-broadness control for the rows below: a single trailing 0x7D with a well-formed
-        // payload anchored to the block under test must still be accepted. The entry index is
-        // block-global and deliberately past 0 (the L1-info deposit) — see the single-batch
-        // equivalent for why derivation cannot check that either way.
+        // Target validity is checked later because entry indices include prepended deposits.
         let transactions = vec![
             Bytes::copy_from_slice(&[EIP1559_TX_TYPE_ID]),
             post_exec_tx_bytes(42, vec![SDMGasEntry { index: 3, gas_refund: 2500 }]),
@@ -2218,8 +2199,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_check_batch_drop_post_exec_wrong_block_anchor() {
-        // The span's only block is 42; anchoring the payload to 43 makes the block invalid at the
-        // execution layer.
+        // The span builds block 42, but the payload claims block 43.
         let transactions = vec![post_exec_tx_bytes(43, vec![])];
         assert_eq!(
             check_post_exec_span(transactions).await,
@@ -2227,15 +2207,7 @@ mod tests {
         );
     }
 
-    /// Pins the `+ i` term of the span's block-number arithmetic, which a one-block span cannot:
-    /// with the parent at 41, the second block is 43, so a payload anchored to 42 — the *first*
-    /// block's number — must be rejected. Dropping `+ i` would compute 42 and wrongly accept.
-    ///
-    /// What this still does not isolate is `parent_block` versus `l2_safe_head`, because they are
-    /// the same block whenever a span does not overlap the safe chain. Discriminating that
-    /// needs an overlapping span, which in turn needs a fetcher fixture carrying a valid
-    /// L1-info deposit transaction so the overlapped blocks survive
-    /// `L2BlockInfo::from_block_and_genesis`.
+    /// Verifies that the second span block anchors to `parent + 2`.
     #[tokio::test]
     async fn test_check_batch_drop_post_exec_wrong_block_anchor_in_second_block() {
         let cfg = RollupConfig {

--- a/rust/kona/crates/protocol/protocol/src/batch/validity.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/validity.rs
@@ -44,6 +44,18 @@ pub enum BatchDropReason {
     Eip7702PreIsthmus,
     /// `PostExec` transaction included before Lagoon activation.
     PostExecPreLagoon,
+    /// More than one `PostExec` transaction in a block.
+    MultiplePostExecTxs,
+    /// A `PostExec` transaction that is not the last transaction of its block.
+    PostExecTxNotLast,
+    /// A `PostExec` transaction whose payload does not decode.
+    PostExecPayloadInvalid,
+    /// A `PostExec` payload anchored to a block other than the one being derived.
+    PostExecPayloadBlockNumberMismatch,
+    /// A `PostExec` payload with two refund entries for the same transaction index.
+    PostExecPayloadDuplicateEntry,
+    /// A `PostExec` payload with a zero-refund entry.
+    PostExecPayloadZeroRefund,
     /// Non-empty batch in Jovian or Interop transition block.
     NonEmptyTransitionBlock,
 
@@ -96,6 +108,22 @@ impl core::fmt::Display for BatchDropReason {
             Self::DepositTransaction => write!(f, "batch contains deposit transaction"),
             Self::Eip7702PreIsthmus => write!(f, "EIP-7702 transaction before Isthmus activation"),
             Self::PostExecPreLagoon => write!(f, "PostExec transaction before Lagoon activation"),
+            Self::MultiplePostExecTxs => {
+                write!(f, "block contains more than one PostExec transaction")
+            }
+            Self::PostExecTxNotLast => {
+                write!(f, "PostExec transaction is not the last transaction of the block")
+            }
+            Self::PostExecPayloadInvalid => write!(f, "PostExec payload does not decode"),
+            Self::PostExecPayloadBlockNumberMismatch => {
+                write!(f, "PostExec payload is anchored to the wrong block")
+            }
+            Self::PostExecPayloadDuplicateEntry => {
+                write!(f, "PostExec payload has a duplicate refund entry index")
+            }
+            Self::PostExecPayloadZeroRefund => {
+                write!(f, "PostExec payload has a zero-refund entry")
+            }
             Self::NonEmptyTransitionBlock => write!(f, "non-empty batch in transition block"),
             Self::SpanBatchPreDelta => write!(f, "span batch received before Delta hard fork"),
             Self::SpanBatchNoNewBlocksPreHolocene => {


### PR DESCRIPTION
## Summary

Companion to #22101. Kona only checked `PostExec` (`0x7D`) activation, so it could accept batches rejected by the execution layer and op-node, producing different safe chains.

This PR adds shared singular- and span-batch validation for:

- Lagoon activation;
- one trailing `PostExec` transaction at most;
- strict payload decoding and block anchoring;
- unique refund indices and non-zero refunds.

Entry bounds and targets still require the full block, while refund limits require execution. These remain execution-layer checks.

The span check is defense in depth because post-Holocene spans use singular validation.

## Tests

Adds singular and span coverage for every rule, valid controls, and multi-block anchor arithmetic.

```text
cargo nextest run -p kona-protocol --all-features
cargo nextest run -p kona-derive --all-features
cargo check -p kona-protocol --no-default-features
cargo clippy -p kona-protocol --all-features --all-targets -- -D warnings
just fmt-check
just typos
```

Adds `BatchDropReason` variants; there are no in-repo exhaustive matches.
