### PR TITLE
op-supernode: pass version to virtual node metrics

### DIFF
--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -73,7 +73,7 @@ func (n *SuperNode) startLocked() {
 
 	ctx, cancel := context.WithCancel(n.p.Ctx())
 	exitFn := func(err error) { n.p.Errorf("supernode critical error: %v", err) }
-	sn, err := supernode.New(ctx, n.logger, "devstack", exitFn, n.snCfg, n.vnCfgs)
+	sn, err := supernode.New(ctx, n.logger, "devstack", "", exitFn, n.snCfg, n.vnCfgs)
 	n.p.Require().NoError(err, "supernode failed to create")
 	n.sn = sn
 	n.cancel = cancel

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -312,7 +312,7 @@ func (s *interopE2ESystem) prepareSupernode() (*supernode.Supernode, string) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	exitFn := context.CancelCauseFunc(func(err error) { s.t.Errorf("supernode critical error: %v", err) })
-	sn, err := supernode.New(ctx, logger, "op-e2e", exitFn, snCfg, vnCfgs)
+	sn, err := supernode.New(ctx, logger, "op-e2e", "", exitFn, snCfg, vnCfgs)
 	require.NoError(s.t, err, "failed to construct supernode")
 	require.NoError(s.t, sn.Start(ctx), "failed to start supernode")
 

--- a/op-supernode/cmd/main.go
+++ b/op-supernode/cmd/main.go
@@ -92,6 +92,7 @@ func main() {
 		sn, err := supernode.New(ctx,
 			l,
 			Version,
+			GitCommit,
 			close,
 			cfg,
 			vnCfgs)

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -30,8 +30,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const virtualNodeVersion = "0.1.0"
-
 const (
 	// defaultWaitReadyPoll is the polling interval used by
 	// simpleChainContainer.WaitReady. Matches the RPC router's
@@ -216,6 +214,7 @@ func NewChainContainer(
 	rpcRouter RPCRouterGate,
 	addMetricsRegistry func(key string, g prometheus.Gatherer),
 	metrics *resources.SupernodeMetrics,
+	appVersion string,
 ) (InteropChain, error) {
 	if metrics == nil {
 		metrics = resources.NewSupernodeMetrics()
@@ -230,7 +229,7 @@ func NewChainContainer(
 		rpcHandler:         rpcHandler,
 		rpcRouter:          rpcRouter,
 		addMetricsRegistry: addMetricsRegistry,
-		appVersion:         virtualNodeVersion,
+		appVersion:         appVersion,
 		virtualNodeFactory: defaultVirtualNodeFactory,
 		metrics:            metrics,
 	}

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -325,7 +325,7 @@ func mustNewChainContainer(
 	metrics *resources.SupernodeMetrics,
 ) InteropChain {
 	t.Helper()
-	container, err := NewChainContainer(chainID, vncfg, log, cfg, initOverload, rpcHandler, rpcRouter, addMetricsRegistry, metrics)
+	container, err := NewChainContainer(chainID, vncfg, log, cfg, initOverload, rpcHandler, rpcRouter, addMetricsRegistry, metrics, "test")
 	require.NoError(t, err)
 	return container
 }
@@ -392,7 +392,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
-		require.Equal(t, virtualNodeVersion, impl.appVersion)
+		require.Equal(t, "test", impl.appVersion)
 	})
 
 	t.Run("subPath combines DataDir, chainID, and path correctly", func(t *testing.T) {
@@ -503,7 +503,7 @@ func TestChainContainer_EngineControllerSetupErrorFailsConstruction(t *testing.T
 	}
 	t.Cleanup(func() { newEngineControllerFromConfig = prevSetup })
 
-	_, err := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	_, err := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil, "test")
 	require.ErrorIs(t, err, setupErr)
 }
 
@@ -522,7 +522,7 @@ func TestChainContainer_DenyListOpenErrorFailsConstruction(t *testing.T) {
 	require.NoError(t, os.WriteFile(dataDir, []byte("x"), 0o600))
 	cfg := createTestCLIConfig(dataDir)
 
-	_, err := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
+	_, err := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil, "test")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "deny list")
 }

--- a/op-supernode/supernode/resources/supernode_metrics.go
+++ b/op-supernode/supernode/resources/supernode_metrics.go
@@ -8,6 +8,7 @@ import "github.com/prometheus/client_golang/prometheus"
 // NewSupernodeMetrics(), which creates functional counters not attached
 // to any scraped registry (safe for tests).
 type SupernodeMetrics struct {
+	Info                        *prometheus.GaugeVec
 	VNRestarts                  *prometheus.CounterVec
 	InteropTimestampsVerified   prometheus.Counter
 	InteropInvalidations        *prometheus.CounterVec
@@ -31,6 +32,11 @@ type SupernodeMetrics struct {
 func NewSupernodeMetrics() *SupernodeMetrics {
 	reg := prometheus.NewRegistry()
 	m := &SupernodeMetrics{
+		Info: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "supernode",
+			Name:      "info",
+			Help:      "Supernode build information.",
+		}, []string{"version", "commit"}),
 		VNRestarts: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "supernode",
 			Name:      "virtual_node_restarts_total",
@@ -101,6 +107,7 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 		registry: reg,
 	}
 	reg.MustRegister(
+		m.Info,
 		m.VNRestarts,
 		m.InteropTimestampsVerified,
 		m.InteropInvalidations,

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -55,7 +55,7 @@ type Supernode struct {
 	rpcAddr string
 }
 
-func New(ctx context.Context, log gethlog.Logger, version string, requestStop context.CancelCauseFunc, cfg *config.CLIConfig, vnCfgs map[eth.ChainID]*opnodecfg.Config) (*Supernode, error) {
+func New(ctx context.Context, log gethlog.Logger, version string, commit string, requestStop context.CancelCauseFunc, cfg *config.CLIConfig, vnCfgs map[eth.ChainID]*opnodecfg.Config) (*Supernode, error) {
 	s := &Supernode{log: log, version: version, requestStop: requestStop, cfg: cfg, chains: make(map[eth.ChainID]cc.InteropChain)}
 
 	// Initialize L1 client
@@ -78,6 +78,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	// Build metrics router; attach per-chain registries later
 	s.metricsFanIn = resources.NewMetricsFanIn(len(cfg.Chains))
 	s.supernodeMetrics = resources.NewSupernodeMetrics()
+	s.supernodeMetrics.Info.WithLabelValues(version, commit).Set(1)
 	s.metricsFanIn.AddGatherer(s.supernodeMetrics.Registry())
 	for _, id := range cfg.Chains {
 		chainID := eth.ChainIDFromUInt64(id)
@@ -90,7 +91,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 			log.Error("missing virtual node config for chain", "chain", id)
 			continue
 		}
-		container, err := cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter, s.metricsFanIn.SetMetricsRegistry, s.supernodeMetrics)
+		container, err := cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter, s.metricsFanIn.SetMetricsRegistry, s.supernodeMetrics, version)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create chain container for chain %s: %w", chainID, err)
 		}


### PR DESCRIPTION
## Summary

- pass the supernode build version into each virtual op-node
- remove the hardcoded virtual node version

## Why

`op_node_supernode_info` was reporting hardcoded `0.1.0` instead of the version injected into the supernode binary. Docker builds set `main.Version` from `GIT_VERSION`; this change forwards that value to the virtual node metrics.

## Testing

- `go test ./op-supernode/supernode/...` *(blocked: missing generated `op-core/superchain/superchain-configs.zip`)*