### PR TITLE
op-reth: assert builder_config shares its live interop failsafe handle

### DIFF
--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -1819,4 +1819,40 @@ mod tests {
             "builder_config must carry the node's live DA handle, not a detached copy"
         );
     }
+
+    /// The failsafe is written by the interop filter client after the payload builder has already
+    /// been constructed, so a config that copied the flag's value instead of sharing the handle
+    /// would leave the builder permanently ungated while every value-propagation assertion above
+    /// still passed.
+    #[test]
+    fn builder_config_interop_failsafe_is_live_shared_handle() {
+        let node = OpNode::new(RollupArgs::default());
+        let cfg = node.builder_config();
+
+        node.interop_failsafe.set(true);
+        assert!(
+            cfg.interop_failsafe.enabled(),
+            "builder_config must carry the node's live interop failsafe handle, not a detached copy"
+        );
+
+        node.interop_failsafe.set(false);
+        assert!(
+            !cfg.interop_failsafe.enabled(),
+            "builder_config must observe the failsafe being cleared, proving one shared handle"
+        );
+    }
+
+    /// Same detached-copy risk as the interop failsafe: the admin RPC flips this after startup.
+    #[test]
+    fn builder_config_operator_sdm_opt_in_is_live_shared_handle() {
+        let node = OpNode::new(RollupArgs::default());
+        let cfg = node.builder_config();
+
+        node.operator_sdm_opt_in.set(true);
+
+        assert!(
+            cfg.operator_sdm_opt_in.enabled(),
+            "builder_config must carry the node's live SDM opt-in handle, not a detached copy"
+        );
+    }
 }


### PR DESCRIPTION
## What

Adds liveness tests for two `OpBuilderConfig` handles that `OpNode::builder_config()` threads through: the interop failsafe and the SDM operator opt-in.

## Why

`builder_config_reflects_node_fields` sets each node field *before* calling the accessor, so it proves values propagate — but not that the `Arc`-backed handles stay **shared**. Of the three shared handles, only `da_config` had a liveness test (`builder_config_da_is_live_shared_handle`).

That gap matters most for the interop failsafe, because of *when* it is written. The filter client sets it at runtime, long after the payload builder has been constructed. So a refactor that copied the flag's value instead of sharing the handle — say `interop_failsafe: InteropFailsafe::default()`, or a plain `bool` — would leave the builder permanently ungated, and **every existing assertion would still pass**. Interop transactions would be included during a failsafe.

The same reasoning applies to `operator_sdm_opt_in`, which the admin RPC flips after startup.

## How

Mirrors the existing DA case exactly: take the config first, flip the node's handle after, assert the config observes the change. The failsafe test additionally clears the flag, proving a single shared handle rather than a one-way latch.

## Verification

- All 4 `builder_config` tests pass.
- **Mutation-tested**: replacing the accessor's `interop_failsafe` with `InteropFailsafe::default()` makes the new test fail with its intended message (`builder_config must carry the node's live interop failsafe handle, not a detached copy`), confirming it detects the regression rather than passing vacuously.
- `cargo +nightly fmt` clean.

Tests only — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)