### PR TITLE
docs: add reusable notice content type

### DIFF
--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -2612,7 +2612,8 @@
                   "/op-stack/contribute/solution-guide",
                   "/op-stack/contribute/learning-unit",
                   "/op-stack/contribute/curriculum-hub",
-                  "/op-stack/contribute/router-landing"
+                  "/op-stack/contribute/router-landing",
+                  "/op-stack/contribute/notice"
                 ]
               },
               "/op-stack/contribute/component-hub-template"

--- a/docs/public-docs/notices/archive/fusaka-notice.mdx
+++ b/docs/public-docs/notices/archive/fusaka-notice.mdx
@@ -1,6 +1,7 @@
 ---
 title: Fusaka upgrade notice
 description: Learn how to prepare for the Fusaka upgrade
+diataxis: reference
 lang: en-US
 content_type: notice
 topic: fusaka-upgrade

--- a/docs/public-docs/notices/archive/op-deployer-upgrade-deprecation.mdx
+++ b/docs/public-docs/notices/archive/op-deployer-upgrade-deprecation.mdx
@@ -1,6 +1,7 @@
 ---
 title: Deprecation of op-deployer upgrade and manage commands
 description: The op-deployer upgrade and manage commands are deprecated. Use superchain-ops or the OPCM directly for L1 contract upgrades.
+diataxis: reference
 lang: en-US
 content_type: notice
 topic: op-deployer-upgrade-deprecation

--- a/docs/public-docs/notices/archive/op-geth-deprecation.mdx
+++ b/docs/public-docs/notices/archive/op-geth-deprecation.mdx
@@ -1,6 +1,7 @@
 ---
 title: End of Support for op-geth and op-program
 description: op-geth and op-program have reached end-of-support; neither supports the now-active Karst hardfork. Migrate to op-reth and kona-client.
+diataxis: reference
 lang: en-US
 content_type: notice
 topic: op-geth-deprecation

--- a/docs/public-docs/notices/archive/req-resp-cl-sync-deprecation.mdx
+++ b/docs/public-docs/notices/archive/req-resp-cl-sync-deprecation.mdx
@@ -1,6 +1,7 @@
 ---
 title: Deprecation of Req/Res CL P2P sync
 description: The op-node Req/Res consensus-layer P2P sync client is being deprecated in favor of execution-layer syncing.
+diataxis: reference
 lang: en-US
 content_type: notice
 topic: req-resp-cl-sync-deprecation

--- a/docs/public-docs/notices/archive/stake-based-priority-ordering.mdx
+++ b/docs/public-docs/notices/archive/stake-based-priority-ordering.mdx
@@ -1,6 +1,7 @@
 ---
 title: Stake-based priority ordering on OP Mainnet
 description: A four-week experiment letting OP stakers receive priority in transaction ordering on OP Mainnet.
+diataxis: reference
 lang: en-US
 content_type: notice
 topic: stake-based-priority-ordering

--- a/docs/public-docs/notices/interop-prep.mdx
+++ b/docs/public-docs/notices/interop-prep.mdx
@@ -1,6 +1,7 @@
 ---
 title: Prepare for interop on OP Sepolia and Unichain Sepolia
 description: Node operator action checklist for the OP Sepolia and Unichain Sepolia interop activation, targeted in July of 2026.
+diataxis: reference
 lang: en-US
 content_type: notice
 topic: interop-prep
@@ -230,4 +231,3 @@ If you scrape Prometheus, the equivalent gauge on a Light CL is `op_node_default
 * [Interop reorg awareness](/op-stack/interop/reorg) — how the safety model handles equivocation and L1 reorgs.
 * [Cross-chain security measures](/op-stack/security/interop-security) — how the safety level for inbound cross-chain messages is configured at the chain level.
 * [Running op-reth with Historical Proofs](/node-operators/tutorials/reth-historical-proofs) — only relevant if you also run op-challenger; configures the supernode's ELs to serve historical proofs.
-

--- a/docs/public-docs/notices/specialized-node-topology.mdx
+++ b/docs/public-docs/notices/specialized-node-topology.mdx
@@ -1,6 +1,7 @@
 ---
 title: Specialized op-node topology with light nodes
 description: OP Labs highly recommends migrating from homogeneous op-node fleets to a specialized topology where only designated source nodes derive from L1 and the rest run as light nodes via --l2.follow.source.
+diataxis: reference
 lang: en-US
 content_type: notice
 topic: specialized-node-topology

--- a/docs/public-docs/op-stack/contribute/choose-a-content-type.mdx
+++ b/docs/public-docs/op-stack/contribute/choose-a-content-type.mdx
@@ -1,6 +1,6 @@
 ---
 title: Choose a content type
-description: A maintainer-facing decision table for picking the right content type, and how the composed types extend the diataxis frontmatter taxonomy.
+description: A maintainer-facing decision table for picking the right documentation type, composition, and operational metadata.
 diataxis: reference
 ---
 
@@ -17,11 +17,12 @@ on docs.optimism.io at all.
 
 ## The taxonomy: four quadrants, four compositions
 
-Every page on docs.optimism.io carries a `diataxis:` frontmatter key with one
-of the four [Diátaxis](https://diataxis.fr/) quadrant values — `tutorial`,
-`how-to`, `reference`, or `explanation`. That taxonomy is complete and does
-not grow: the composed types below are **compositions of the quadrants, not
-new quadrants**, and they never appear as `diataxis:` values.
+Documentation pages on docs.optimism.io carry a `diataxis:` frontmatter key
+with one of the four [Diátaxis](https://diataxis.fr/) quadrant values —
+`tutorial`, `how-to`, `reference`, or `explanation`. That taxonomy is
+complete and does not grow: the composed types below are **compositions of
+the quadrants, not new quadrants**, and they never appear as `diataxis:`
+values.
 
 A composed type is declared with a second, optional frontmatter key,
 `content-type:`, carried *alongside* `diataxis:`. It takes exactly four
@@ -47,8 +48,34 @@ Rules that keep this an extension rather than a fork:
     review.
 *   **Pages of the four base types don't carry `content-type:` at all.** An
     ordinary how-to is just `diataxis: how-to`.
-*   **`keywords.config.yaml` is not extended.** The composed types are
-    declared only in page frontmatter, per the rows above.
+*   **`keywords.config.yaml` is not extended for composed types.** The
+    composed types are declared only in page frontmatter, per the rows
+    above.
+
+### Notice metadata
+
+A [notice](/op-stack/contribute/notice) is time-bound operational content
+for an upgrade, deprecation, or other change that requires readers to
+prepare. Its dominant reader need is authoritative information about a
+specific change, so a notice carries `diataxis: reference`.
+
+The additional `content_type: notice` metadata key (with an underscore)
+marks the page's operational purpose and lifecycle for the notice index and
+site search. It does not create a fifth quadrant or composition. The
+`content-type:` key (with a hyphen) remains limited to the four composition
+values above.
+
+Use a notice when the page must answer all of these questions:
+
+*   What is changing and why?
+*   Which personas are affected, and what breaks or remains compatible for
+    each one?
+*   What must each affected reader do before the cutover?
+*   When and how does the change take effect?
+
+After the change is complete, archive the notice and move durable facts into
+the relevant guide, reference, or
+[network upgrade registry](/op-stack/protocol/network-upgrades).
 
 ## How-to guide vs. tutorial vs. solution guide
 
@@ -115,7 +142,8 @@ would gain learning-unit framing inside a track without being rewritten).
     [solution guide](/op-stack/contribute/solution-guide),
     [learning unit](/op-stack/contribute/learning-unit),
     [curriculum hub](/op-stack/contribute/curriculum-hub),
-    [router/landing](/op-stack/contribute/router-landing).
+    [router/landing](/op-stack/contribute/router-landing), or
+    [notice](/op-stack/contribute/notice).
 *   For the four base quadrants, the
     [style guide's content types section](https://github.com/ethereum-optimism/optimism/blob/develop/docs/public-docs/STYLE_GUIDE.md#content-types)
     remains the reference.

--- a/docs/public-docs/op-stack/contribute/index.mdx
+++ b/docs/public-docs/op-stack/contribute/index.mdx
@@ -24,6 +24,10 @@ are about to write.
     Use the decision table to choose a content type, then follow its
     published contract and template.
   </Card>
+  <Card title="Publish a network notice" href="/op-stack/contribute/notice">
+    Write time-bound, persona-specific upgrade or deprecation guidance from
+    the reusable notice template.
+  </Card>
   <Card title="Link the specs and source correctly" href="/op-stack/contribute/link-policy">
     Write cross-repo links in the canonical form the link linter enforces.
   </Card>

--- a/docs/public-docs/op-stack/contribute/notice.mdx
+++ b/docs/public-docs/op-stack/contribute/notice.mdx
@@ -1,0 +1,192 @@
+---
+title: "Content type: notice"
+description: The published contract for time-bound network notices, including required persona impacts, actions, timing, and a copy-paste template.
+diataxis: reference
+---
+
+A **notice** tells affected readers about an upcoming network upgrade,
+deprecation, or operational change and gives them the actions required to
+stay compatible. Notices are time-bound: they remain active while readers
+need to prepare, then move to the notice archive after the change is
+complete.
+
+This page is the contract for the type. Review a new notice against it and
+cite the relevant section instead of re-arguing the structure in each pull
+request.
+
+## Composition
+
+A notice is `diataxis: reference`: it gives readers authoritative facts
+about one change, including its scope, compatibility, timing, and affected
+versions. Put the executable migration procedure in a how-to guide or
+runbook and link it from the notice.
+
+The additional `content_type: notice` metadata key (with an underscore)
+marks the page's operational purpose and lifecycle. It is not a fifth
+Diátaxis quadrant or one of the composed documentation types. The similarly
+named `content-type:` key (with a hyphen) remains reserved for the four
+compositions in
+[Choose a content type](/op-stack/contribute/choose-a-content-type).
+
+## Purpose
+
+*   Name the change, why it is happening, and when it takes effect.
+*   Identify every affected persona and state the breaking changes or
+    explicit no-action outcome for each one.
+*   Give readers an action checklist with versions, configuration, contract,
+    or application changes they can verify before the cutover.
+*   Preserve the transition behavior readers need to know, such as what
+    happens to in-flight withdrawals, disputes, or transactions.
+
+Do not use a notice as the permanent explanation of a feature or the only
+record of an upgrade. Link canonical guides and reference pages for durable
+details.
+
+## Required frontmatter
+
+Every notice carries the metadata used by the notice index and site search:
+
+```yaml
+---
+title: <Change or action>
+description: <One sentence naming the change and affected readers.>
+diataxis: reference
+lang: en-US
+content_type: notice
+topic: <unique-kebab-case-topic>
+personas:
+  - <persona from keywords.config.yaml>
+categories:
+  - <category from keywords.config.yaml>
+is_imported_content: 'false'
+---
+```
+
+Use every applicable persona from `keywords.config.yaml`; do not reduce the
+list to the primary audience. Add `audit-source:` when source files or
+generated artifacts were checked to substantiate the notice.
+
+## Required components
+
+Every notice must include:
+
+1.  **Summary**: one or two paragraphs naming the change, its scope, and the
+    primary action.
+2.  **Motivation** (`## Why <change>` or `## Why this is changing`): the
+    user-facing reason for the change, with links to durable explanations
+    when more background is useful.
+3.  **Change scope** (`## What's included` or `## What is changing`): the
+    concrete protocol, contract, component, or product changes. State
+    important exclusions explicitly.
+4.  **Persona impacts** (`## Breaking Changes`): one `###` subsection for
+    each persona in frontmatter. State what breaks, what must change, and
+    what remains compatible. If a persona has no action, say so directly.
+5.  **Required actions**: copy-pasteable configuration, version, contract,
+    or application changes. Use a component table when several releases are
+    involved.
+6.  **Timing**: the activation mechanism and schedule. For a network
+    upgrade, say whether it has a hardfork activation. Do not invent a
+    timestamp or release version; add it when the canonical source is
+    available.
+7.  **Verification and support**: tell readers how to verify readiness and
+    where to report a problem.
+
+When a change affects state that can span the cutover, explain the
+transition. Common examples include Dispute Games already in progress,
+withdrawals already proved, transactions in flight, and old configuration
+that must remain temporarily available.
+
+## Writing rules
+
+*   Lead with the action and affected reader, not the internal project
+    history.
+*   Use proper product and protocol names. Preserve command, flag, package,
+    function, and component spelling in code formatting.
+*   Separate confirmed scope from unknown timing or release data. Do not
+    weaken confirmed changes by labeling the entire notice provisional.
+*   Link to the canonical runbook or reference rather than duplicating its
+    full procedure.
+*   Keep persona subsections independently scannable. A reader should not
+    need to infer their action from another persona's section.
+
+## Lifecycle
+
+Add an active notice to both `/notices` and the matching Network Notices
+navigation group in `docs.json`.
+
+After activation and completion of the required migration window:
+
+1.  Move the page under `/notices/archive`.
+2.  Remove its active card and move its navigation entry.
+3.  Record the permanent outcome in the
+    [network upgrade registry](/op-stack/protocol/network-upgrades), using
+    the [contract upgrades table](/op-stack/protocol/network-upgrades#contract-upgrades)
+    when the change has no hardfork.
+4.  Update durable guides and references so they describe the post-upgrade
+    state without relying on the archived notice.
+
+## Template
+
+Copy this template to start a notice:
+
+```mdx
+---
+title: <Change or action>
+description: <One sentence naming the change and affected readers.>
+diataxis: reference
+lang: en-US
+content_type: notice
+topic: <unique-kebab-case-topic>
+personas:
+  - <affected-persona>
+categories:
+  - <approved-category>
+is_imported_content: 'false'
+---
+
+<One or two paragraphs: what is changing, who must act, and the activation
+mechanism or known date.>
+
+## Why this is changing
+
+<The user-facing motivation. Link the durable explanation or specification
+for deeper context.>
+
+## What's included
+
+*   <Change in scope>
+*   <Change in scope>
+
+This change does not <important exclusion>.
+
+## Breaking Changes
+
+### <Persona>
+
+<What breaks or changes for this persona. State "No action is required" when
+that is the result, then explain why.>
+
+### <Persona>
+
+<Impact and compatibility details for the next persona.>
+
+## Required actions
+
+| Component or integration | Required change |
+| --- | --- |
+| `<name>` | <Version, flag, API, contract, or workflow change> |
+
+<Add a short action checklist or link the canonical runbook.>
+
+## Timing
+
+<Activation date or mechanism. Say whether the change includes a hardfork.
+Name the canonical source where final timestamps or releases will appear.>
+
+## Verify readiness
+
+*   <Observable check and expected result>
+*   <Observable check and expected result>
+
+For support, <link the issue tracker or support channel>.
+```


### PR DESCRIPTION
## What changed

- Added a reusable notice content-type contract and copy-paste template for time-bound upgrade, deprecation, and operational notices.
- Classified notices as Diátaxis reference pages, with `content_type: notice` reserved for their operational purpose and lifecycle rather than treated as a fifth quadrant or composition.
- Extended the content-type chooser and contributor landing page with notice guidance.
- Added the notice template to documentation navigation.
- Normalized active and archived notice frontmatter with the notice content type.

## Why

Network changes need a consistent public-documentation shape that identifies affected personas, breaking changes, required actions, timing, transition behavior, verification, support, and archive handling. The reusable contract gives authors and reviewers a shared standard while keeping the existing four-quadrant Diátaxis taxonomy intact.

This work was split from #22092 so the reusable documentation model can be reviewed independently from the Upgrade 20 notice.

## Verification

- `node --import tsx scripts/lint/validate-nav.ts`
- `node --import tsx scripts/lint/validate-redirects.ts`
- `node scripts/lint-link-policy.mjs --baseline scripts/lint-link-policy.baseline.json`
- `git diff --check`

## Reviewer checklist

- [ ] Confirm that a notice is correctly classified as reference content.
- [ ] Confirm that `content_type: notice` is clearly distinguished from the four `content-type:` compositions.
- [ ] Confirm that the required components cover authoring, review, publication, and archive needs.
- [ ] Confirm that the template is reusable across upgrades, deprecations, and operational changes.
