### PR TITLE
docs/ai: CI local-validation recipe + rust tool-config discovery

### DIFF
--- a/docs/ai/ci-config-review.md
+++ b/docs/ai/ci-config-review.md
@@ -32,6 +32,28 @@ hide. For each changed file, walk the relevant items and look for the bad patter
   setup→setup. A param declared in both `config.yml` and a fragment with
   different defaults fails with "Conflicting pipeline parameters".
 
+## Validating a change locally
+
+Because the real config is merged from fragments, validate the **merged** file, not a
+single fragment:
+
+```bash
+# 1. Merge the fragments into /tmp/merged-config.yml (uses mise's yq; resolves anchors).
+mise exec -- bash .circleci/scripts/merge-configs.sh
+
+# 2. Validate it. --org-slug is REQUIRED: the private org orb
+#    ethereum-optimism/circleci-utils won't resolve without it (even with a token).
+export CIRCLECI_CLI_TOKEN="$CIRCLE_TOKEN"
+circleci config validate --org-slug gh/ethereum-optimism /tmp/merged-config.yml
+```
+
+Install the CLI without sudo:
+`curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/main/install.sh | DESTDIR="$HOME/.local/bin" bash`.
+
+This checks orb resolution and config structure, but **not** continuation-time param
+wiring — a param leak across fragment anchors still only surfaces when the pipeline
+actually continues.
+
 ## Choosing where a new job runs
 
 When a diff adds a job, the first question is cadence, not correctness. Options

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -12,6 +12,8 @@ All Rust code lives under `rust/`. This is a unified Cargo workspace — always 
 
 Check `rust/Cargo.toml` for the full workspace member list, dependency versions, and lint configuration. The Rust toolchain version is pinned in `rust/rust-toolchain.toml`.
 
+Workspace tool config lives at **`rust/.config/`** — `nextest.toml` (test settings, JUnit output) and `zepter.yaml` (feature-propagation lint). `nextest`, `zepter`, and `cargo-release` discover config **only from the workspace root**, so per-component `rust/<crate>/.config/*.toml` files are *not* read and have no effect — put new test/lint config at `rust/.config/`. (`rust/op-rbuilder` and `rust/rollup-boost` are separate vendored Cargo workspaces with their own root configs.)
+
 ### Migrated, not vendored
 
 Most of the OP Stack Rust code here was **officially migrated** into the monorepo in coordination with the upstream repository owners — it is **not** a vendored copy. The upstream crates have been deleted or deprecated, so the entire Rust OP Stack is now developed here. This applies to:


### PR DESCRIPTION
Two AI-doc learnings from the rust/ test-tooling cleanup (#22076):

- **`docs/ai/ci-config-review.md`** — how to validate a `.circleci` change locally: merge the continuation fragments (`merge-configs.sh`), then `circleci config validate --org-slug gh/ethereum-optimism` (the private org orb `ethereum-optimism/circleci-utils` won't resolve without the slug).
- **`docs/ai/rust-dev.md`** — `nextest`/`zepter`/`cargo-release` discover config only from the `rust/` workspace root; per-component `<crate>/.config/*.toml` files are inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)