### PR TITLE
kona: match op-node span-batch uvarint decoding

### DIFF
--- a/docs/ai/derivation.md
+++ b/docs/ai/derivation.md
@@ -82,6 +82,28 @@ Two guards fail loudly on a field left unwired:
   timeout values must not be modified without protocol review.
 - **Reorg unwinding**: reorg handling must correctly unwind all derived state.
 
+## Cross-client wire-format parity
+
+Both clients decode the same batcher-controlled bytes, so their decoders must accept **exactly**
+the same byte set. A byte string that one client decodes and the other rejects splits derivation on
+identical L1 data.
+
+- **The spec is the reference; op-node is the incumbent.** Decide what is correct from the
+  [specs](https://specs.optimism.io). op-node additionally defines what OP Mainnet currently does,
+  so where the spec is silent or ambiguous its behavior is the tie-breaker — but a decoder that
+  contradicts the spec, or looks outright buggy, is a finding to raise rather than something to
+  mirror into kona. Either way, take a spec/op-node disagreement to the user before encoding a
+  choice in either client.
+- **Verify a codec's accept-set, don't infer it from the format name.** Wire formats come in
+  families that differ on exactly the inputs a batcher controls. Span-batch `uvarint` is a protobuf
+  Base128 varint, whose non-minimal encodings are valid; the `unsigned-varint` crate implements the
+  minimal-only multiformats variant instead and rejects them. Span-batch fields go through
+  `read_uvarint` (`rust/kona/crates/protocol/protocol/src/batch/varint.rs`), a port of Go's
+  `binary.ReadUvarint`. Before trusting any decoder on this path, diff its accept-set against
+  op-node's over a generated corpus — a spec citation does not distinguish two families.
+- **Pin every decision in both suites.** When changing either decoder, add the same byte vector to
+  the kona and op-node tests so the pair stays locked together.
+
 ## Testing Requirements
 
 - Unit tests for every pipeline stage.

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -2,6 +2,7 @@ package derive
 
 import (
 	"bytes"
+	"encoding/binary"
 	"math"
 	"math/big"
 	"math/rand"
@@ -558,6 +559,80 @@ func TestSpanBatchReadTxDataLeadingZero(t *testing.T) {
 	// rejected.
 	var sbtx spanBatchTx
 	require.ErrorIs(t, sbtx.UnmarshalBinary(txData), types.ErrTxTypeNotSupported)
+}
+
+// TestSpanBatchUvarintConformance locks op-node's span-batch `uvarint` decoding — Go's
+// binary.ReadUvarint — against the vectors shared with kona's decoder in
+// rust/kona/crates/protocol/protocol/src/batch/varint.rs. Span-batch uvarints are protobuf Base128
+// varints, so a non-minimal encoding is valid and decodes to the same value as its minimal form.
+// Kona must reach the same verdict on every vector, or a batcher can split the two derivations with
+// a re-encoded field.
+func TestSpanBatchUvarintConformance(t *testing.T) {
+	cases := []struct {
+		name    string
+		encoded []byte
+		value   uint64
+		wantErr bool
+	}{
+		{"minimal", []byte{0x01}, 1, false},
+		{"non-minimal", []byte{0x81, 0x00}, 1, false},
+		{"non-minimal, multi-byte", []byte{0x81, 0x80, 0x80, 0x00}, 1, false},
+		{"ten-byte, zero terminator", []byte{0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00}, 1, false},
+		{"ten-byte, bit-63 terminator", []byte{0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01}, 1 | 1<<63, false},
+		{"max uint64", []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01}, math.MaxUint64, false},
+		{"terminator above bit 63", []byte{0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02}, 0, true},
+		{"never terminates", bytes.Repeat([]byte{0x80}, 10), 0, true},
+		{"terminates past max width", append(bytes.Repeat([]byte{0x80}, 10), 0x01), 0, true},
+		{"truncated", []byte{0x81}, 0, true},
+		{"empty", []byte{}, 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// relTimestamp is unbounded, so it exercises the full accepted value range.
+			var prefix spanBatchPrefix
+			r := bytes.NewReader(tc.encoded)
+			err := prefix.decodeRelTimestamp(r)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.value, prefix.relTimestamp)
+			require.Zero(t, r.Len(), "varint must be fully consumed")
+		})
+	}
+}
+
+// nonMinimalUvarint encodes v as a Base128 varint with one redundant trailing zero byte. Only valid
+// for values whose minimal encoding is shorter than binary.MaxVarintLen64.
+func nonMinimalUvarint(t *testing.T, v uint64) []byte {
+	encoded := binary.AppendUvarint(nil, v)
+	require.Less(t, len(encoded), binary.MaxVarintLen64)
+	encoded[len(encoded)-1] |= 0x80
+	return append(encoded, 0x00)
+}
+
+// TestSpanBatchNonMinimalBlockCount decodes a whole span batch whose blockCount is encoded
+// non-minimally, with every other field untouched — the batch a byzantine batcher would publish.
+// op-node derives exactly the batch the minimal encoding would have produced, and kona must too.
+func TestSpanBatchNonMinimalBlockCount(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x5ea6a71))
+	chainID := big.NewInt(rng.Int63n(1000))
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	require.NoError(t, rawSpanBatch.encodePrefix(&buf))
+	_, err := buf.Write(nonMinimalUvarint(t, rawSpanBatch.blockCount))
+	require.NoError(t, err)
+	require.NoError(t, rawSpanBatch.encodeOriginBits(&buf))
+	require.NoError(t, rawSpanBatch.encodeBlockTxCounts(&buf))
+	require.NoError(t, rawSpanBatch.encodeTxs(&buf))
+
+	var sb RawSpanBatch
+	require.NoError(t, sb.decode(bytes.NewReader(buf.Bytes())))
+	require.NoError(t, sb.txs.recoverV(chainID))
+	requireEqual(t, rawSpanBatch, &sb)
 }
 
 func TestSpanBatchMaxTxData(t *testing.T) {

--- a/rust/kona/crates/protocol/protocol/src/batch/mod.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/mod.rs
@@ -83,3 +83,5 @@ pub use tx_data::{
 
 mod traits;
 pub use traits::BatchValidationProvider;
+
+mod varint;

--- a/rust/kona/crates/protocol/protocol/src/batch/payload.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/payload.rs
@@ -195,10 +195,7 @@ mod tests {
         assert_eq!(payload.block_tx_counts, vec![2, 2]);
     }
 
-    // `block_count` and `block_tx_count` are protobuf Base128 varints, which op-node decodes
-    // with Go's `binary.ReadUvarint`. Kona must accept exactly the encodings op-node accepts, or
-    // a batcher can fork the two derivations with a re-encoded field. Vectors are shared with
-    // `op-node/rollup/derive/span_batch_test.go`.
+    // Conformance vectors for the accept-set documented in `batch::varint`.
 
     #[test]
     fn test_decode_block_count_non_minimal() {

--- a/rust/kona/crates/protocol/protocol/src/batch/payload.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/payload.rs
@@ -1,6 +1,6 @@
 //! Raw Span Batch Payload
 
-use super::MAX_SPAN_BATCH_ELEMENTS;
+use super::{MAX_SPAN_BATCH_ELEMENTS, varint::read_uvarint};
 use crate::{SpanBatchBits, SpanBatchError, SpanBatchTransactions, SpanDecodingError};
 use alloc::vec::Vec;
 use alloy_primitives::bytes;
@@ -50,8 +50,8 @@ impl SpanBatchPayload {
 
     /// Decode a block count from a reader.
     pub fn decode_block_count(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
-        let (block_count, remaining) = unsigned_varint::decode::u64(r)
-            .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::BlockCount))?;
+        let (block_count, remaining) =
+            read_uvarint(r).ok_or(SpanBatchError::Decoding(SpanDecodingError::BlockCount))?;
         // The number of transactions in a single L2 block cannot be greater than
         // [MAX_SPAN_BATCH_ELEMENTS].
         if block_count > MAX_SPAN_BATCH_ELEMENTS {
@@ -72,8 +72,8 @@ impl SpanBatchPayload {
         let mut block_tx_counts = Vec::with_capacity(self.block_count as usize);
 
         for _ in 0..self.block_count {
-            let (block_tx_count, remaining) = unsigned_varint::decode::u64(r)
-                .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::BlockTxCounts))?;
+            let (block_tx_count, remaining) = read_uvarint(r)
+                .ok_or(SpanBatchError::Decoding(SpanDecodingError::BlockTxCounts))?;
 
             // The number of transactions in a single L2 block cannot be greater than
             // [MAX_SPAN_BATCH_ELEMENTS].
@@ -193,5 +193,49 @@ mod tests {
         }
         payload.decode_block_tx_counts(&mut r.as_slice()).unwrap();
         assert_eq!(payload.block_tx_counts, vec![2, 2]);
+    }
+
+    // `block_count` and `block_tx_count` are protobuf Base128 varints, which op-node decodes
+    // with Go's `binary.ReadUvarint`. Kona must accept exactly the encodings op-node accepts, or
+    // a batcher can fork the two derivations with a re-encoded field. Vectors are shared with
+    // `op-node/rollup/derive/span_batch_test.go`.
+
+    #[test]
+    fn test_decode_block_count_non_minimal() {
+        let mut payload = SpanBatchPayload::default();
+        // `1` with a redundant trailing zero byte; the minimal form is `[0x01]`.
+        let buf = [0x81, 0x00];
+        let mut r = buf.as_slice();
+        payload.decode_block_count(&mut r).unwrap();
+        assert_eq!(payload.block_count, 1);
+        assert!(r.is_empty(), "both bytes must be consumed");
+    }
+
+    #[test]
+    fn test_decode_block_count_overflow_ten_byte_terminator() {
+        let mut payload = SpanBatchPayload::default();
+        // The tenth byte terminates the varint but sets bits above 63.
+        let buf = [0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02];
+        let err = payload.decode_block_count(&mut buf.as_slice()).unwrap_err();
+        assert_eq!(err, SpanBatchError::Decoding(SpanDecodingError::BlockCount));
+    }
+
+    #[test]
+    fn test_decode_block_tx_counts_non_minimal() {
+        let mut payload = SpanBatchPayload { block_count: 2, ..Default::default() };
+        // `1` and `2`, both with a redundant trailing zero byte.
+        let buf = [0x81, 0x00, 0x82, 0x00];
+        let mut r = buf.as_slice();
+        payload.decode_block_tx_counts(&mut r).unwrap();
+        assert_eq!(payload.block_tx_counts, vec![1, 2]);
+        assert!(r.is_empty(), "all four bytes must be consumed");
+    }
+
+    #[test]
+    fn test_decode_block_tx_counts_overflow_ten_byte_terminator() {
+        let mut payload = SpanBatchPayload { block_count: 1, ..Default::default() };
+        let buf = [0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02];
+        let err = payload.decode_block_tx_counts(&mut buf.as_slice()).unwrap_err();
+        assert_eq!(err, SpanBatchError::Decoding(SpanDecodingError::BlockTxCounts));
     }
 }

--- a/rust/kona/crates/protocol/protocol/src/batch/prefix.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/prefix.rs
@@ -109,11 +109,8 @@ mod test {
         assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::ParentCheck)));
     }
 
-    // Span-batch `uvarint` fields are protobuf Base128 varints, which op-node decodes with Go's
-    // `binary.ReadUvarint`. Kona must accept exactly the encodings op-node accepts: any
-    // disagreement on batcher-controlled bytes forks the two derivations on identical L1 data.
-    // `rel_timestamp` is unbounded, so it exercises the full accepted range. The vectors are
-    // shared with `op-node/rollup/derive/span_batch_test.go`.
+    // Conformance vectors for the accept-set documented in `batch::varint`.
+    // `rel_timestamp` is unbounded, so it exercises the full accepted value range.
 
     #[test]
     fn test_decode_rel_timestamp_non_minimal() {

--- a/rust/kona/crates/protocol/protocol/src/batch/prefix.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/prefix.rs
@@ -1,5 +1,6 @@
 //! Raw Span Batch Prefix
 
+use super::varint::read_uvarint;
 use crate::{SpanBatchError, SpanDecodingError};
 use alloy_primitives::{FixedBytes, bytes};
 
@@ -29,8 +30,8 @@ impl SpanBatchPrefix {
 
     /// Decodes the relative timestamp from a reader.
     pub fn decode_rel_timestamp(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
-        let (rel_timestamp, remaining) = unsigned_varint::decode::u64(r)
-            .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::RelativeTimestamp))?;
+        let (rel_timestamp, remaining) = read_uvarint(r)
+            .ok_or(SpanBatchError::Decoding(SpanDecodingError::RelativeTimestamp))?;
         *r = remaining;
         self.rel_timestamp = rel_timestamp;
         Ok(())
@@ -38,8 +39,8 @@ impl SpanBatchPrefix {
 
     /// Decodes the L1 origin number from a reader.
     pub fn decode_l1_origin_num(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
-        let (l1_origin_num, remaining) = unsigned_varint::decode::u64(r)
-            .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::L1OriginNumber))?;
+        let (l1_origin_num, remaining) =
+            read_uvarint(r).ok_or(SpanBatchError::Decoding(SpanDecodingError::L1OriginNumber))?;
         *r = remaining;
         self.l1_origin_num = l1_origin_num;
         Ok(())
@@ -106,6 +107,156 @@ mod test {
         let mut prefix = SpanBatchPrefix::default();
         let result = prefix.decode_parent_check(&mut [].as_slice());
         assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::ParentCheck)));
+    }
+
+    // Span-batch `uvarint` fields are protobuf Base128 varints, which op-node decodes with Go's
+    // `binary.ReadUvarint`. Kona must accept exactly the encodings op-node accepts: any
+    // disagreement on batcher-controlled bytes forks the two derivations on identical L1 data.
+    // `rel_timestamp` is unbounded, so it exercises the full accepted range. The vectors are
+    // shared with `op-node/rollup/derive/span_batch_test.go`.
+
+    #[test]
+    fn test_decode_rel_timestamp_non_minimal() {
+        let mut prefix = SpanBatchPrefix::default();
+        // `1` with a redundant trailing zero byte; the minimal form is `[0x01]`.
+        let buf = [0x81, 0x00];
+        let mut r = buf.as_slice();
+        prefix.decode_rel_timestamp(&mut r).unwrap();
+        assert_eq!(prefix.rel_timestamp, 1);
+        assert!(r.is_empty(), "both bytes must be consumed");
+    }
+
+    #[test]
+    fn test_decode_rel_timestamp_non_minimal_multi_byte() {
+        let mut prefix = SpanBatchPrefix::default();
+        // `1` padded with three redundant continuation bytes.
+        let buf = [0x81, 0x80, 0x80, 0x00];
+        let mut r = buf.as_slice();
+        prefix.decode_rel_timestamp(&mut r).unwrap();
+        assert_eq!(prefix.rel_timestamp, 1);
+        assert!(r.is_empty(), "all four bytes must be consumed");
+    }
+
+    #[test]
+    fn test_decode_rel_timestamp_ten_byte_zero_terminator() {
+        let mut prefix = SpanBatchPrefix::default();
+        // `1` padded out to the ten-byte maximum. The terminator contributes no bits.
+        let buf = [0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00];
+        let mut r = buf.as_slice();
+        prefix.decode_rel_timestamp(&mut r).unwrap();
+        assert_eq!(prefix.rel_timestamp, 1);
+        assert!(r.is_empty(), "all ten bytes must be consumed");
+    }
+
+    #[test]
+    fn test_decode_rel_timestamp_ten_byte_one_terminator() {
+        let mut prefix = SpanBatchPrefix::default();
+        // A ten-byte varint whose terminator sets bit 63 exactly — the largest accepted width.
+        let buf = [0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01];
+        let mut r = buf.as_slice();
+        prefix.decode_rel_timestamp(&mut r).unwrap();
+        assert_eq!(prefix.rel_timestamp, 1 | 1 << 63);
+        assert!(r.is_empty(), "all ten bytes must be consumed");
+    }
+
+    #[test]
+    fn test_decode_rel_timestamp_max_u64() {
+        let mut prefix = SpanBatchPrefix::default();
+        let buf = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01];
+        let mut r = buf.as_slice();
+        prefix.decode_rel_timestamp(&mut r).unwrap();
+        assert_eq!(prefix.rel_timestamp, u64::MAX);
+        assert!(r.is_empty(), "all ten bytes must be consumed");
+    }
+
+    #[test]
+    fn test_decode_rel_timestamp_overflow_ten_byte_terminator() {
+        let mut prefix = SpanBatchPrefix::default();
+        // The tenth byte terminates the varint but sets bits above 63, so the value does not
+        // fit in a `u64`.
+        let buf = [0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02];
+        let result = prefix.decode_rel_timestamp(&mut buf.as_slice());
+        assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::RelativeTimestamp)));
+    }
+
+    #[test]
+    fn test_decode_rel_timestamp_overflow_past_max_width() {
+        let mut prefix = SpanBatchPrefix::default();
+        // The varint would only terminate on the eleventh byte, past the maximum width read.
+        let buf = [0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01];
+        let result = prefix.decode_rel_timestamp(&mut buf.as_slice());
+        assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::RelativeTimestamp)));
+    }
+
+    #[test]
+    fn test_decode_rel_timestamp_minimal() {
+        let mut prefix = SpanBatchPrefix::default();
+        let buf = [0x01];
+        let mut r = buf.as_slice();
+        prefix.decode_rel_timestamp(&mut r).unwrap();
+        assert_eq!(prefix.rel_timestamp, 1);
+        assert!(r.is_empty(), "the single byte must be consumed");
+    }
+
+    #[test]
+    fn test_decode_rel_timestamp_overflow_all_continuation() {
+        let mut prefix = SpanBatchPrefix::default();
+        // Ten continuation bytes: the varint never terminates within the maximum width.
+        let buf = [0x80; 10];
+        let result = prefix.decode_rel_timestamp(&mut buf.as_slice());
+        assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::RelativeTimestamp)));
+    }
+
+    #[test]
+    fn test_decode_rel_timestamp_truncated() {
+        let mut prefix = SpanBatchPrefix::default();
+        // A continuation byte with no terminator following it.
+        let buf = [0x81];
+        let result = prefix.decode_rel_timestamp(&mut buf.as_slice());
+        assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::RelativeTimestamp)));
+    }
+
+    #[test]
+    fn test_decode_rel_timestamp_empty() {
+        let mut prefix = SpanBatchPrefix::default();
+        let result = prefix.decode_rel_timestamp(&mut [].as_slice());
+        assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::RelativeTimestamp)));
+    }
+
+    #[test]
+    fn test_decode_l1_origin_num_non_minimal() {
+        let mut prefix = SpanBatchPrefix::default();
+        let buf = [0x81, 0x00];
+        let mut r = buf.as_slice();
+        prefix.decode_l1_origin_num(&mut r).unwrap();
+        assert_eq!(prefix.l1_origin_num, 1);
+        assert!(r.is_empty(), "both bytes must be consumed");
+    }
+
+    #[test]
+    fn test_decode_l1_origin_num_overflow_ten_byte_terminator() {
+        let mut prefix = SpanBatchPrefix::default();
+        let buf = [0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02];
+        let result = prefix.decode_l1_origin_num(&mut buf.as_slice());
+        assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::L1OriginNumber)));
+    }
+
+    #[test]
+    fn test_decode_prefix_non_minimal_varints() {
+        let expected = SpanBatchPrefix {
+            rel_timestamp: 1,
+            l1_origin_num: 2,
+            parent_check: address!("beef00000000000000000000000000000000beef").into(),
+            l1_origin_check: address!("babe00000000000000000000000000000000babe").into(),
+        };
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&[0x81, 0x00]); // rel_timestamp = 1, non-minimal
+        buf.extend_from_slice(&[0x82, 0x00]); // l1_origin_num = 2, non-minimal
+        buf.extend_from_slice(expected.parent_check.as_slice());
+        buf.extend_from_slice(expected.l1_origin_check.as_slice());
+
+        assert_eq!(SpanBatchPrefix::decode_prefix(&mut buf.as_slice()).unwrap(), expected);
     }
 
     #[test]

--- a/rust/kona/crates/protocol/protocol/src/batch/raw.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/raw.rs
@@ -140,4 +140,32 @@ mod test {
         raw_span_batch.encode(&mut encoding_buf).unwrap();
         assert_eq!(encoding_buf, raw_span_batch_hex);
     }
+
+    /// Re-encodes a real op-node span batch with a non-minimally encoded `block_count`, leaving
+    /// every other field untouched — the batch a byzantine batcher would publish to split
+    /// derivation. op-node decodes it to the same batch as the minimal encoding, so kona must too.
+    /// `TestSpanBatchNonMinimalBlockCount` runs the same scenario against op-node, on its own
+    /// batch — unlike the field-level vectors, the bytes here are not shared between the suites.
+    #[test]
+    fn test_decode_raw_span_batch_non_minimal_block_count() {
+        let raw_span_batch_hex = include_bytes!("./testdata/raw_batch.hex");
+        let expected = RawSpanBatch::decode(&mut raw_span_batch_hex.as_slice()).unwrap();
+
+        let mut varint_buf = [0u8; 10];
+        let minimal =
+            unsigned_varint::encode::u64(expected.payload.block_count, &mut varint_buf).to_vec();
+        let (last, head) = minimal.split_last().unwrap();
+
+        let mut buf = Vec::new();
+        expected.prefix.encode_prefix(&mut buf);
+        buf.extend_from_slice(head);
+        buf.push(last | 0x80); // mark the final byte as continuing…
+        buf.push(0x00); // …into a redundant zero terminator
+        expected.payload.encode_origin_bits(&mut buf).unwrap();
+        expected.payload.encode_block_tx_counts(&mut buf);
+        expected.payload.encode_txs(&mut buf).unwrap();
+
+        assert_ne!(buf, raw_span_batch_hex, "block_count must be re-encoded");
+        assert_eq!(RawSpanBatch::decode(&mut buf.as_slice()).unwrap(), expected);
+    }
 }

--- a/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
@@ -527,10 +527,7 @@ mod tests {
         assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::TxGases)));
     }
 
-    // Transaction nonces and gas limits are protobuf Base128 varints, which op-node decodes with
-    // Go's `binary.ReadUvarint`. Kona must accept exactly the encodings op-node accepts, or a
-    // batcher can fork the two derivations with a re-encoded field. Vectors are shared with
-    // `op-node/rollup/derive/span_batch_test.go`.
+    // Conformance vectors for the accept-set documented in `batch::varint`.
 
     #[test]
     fn test_decode_tx_nonces_non_minimal() {

--- a/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
@@ -1,6 +1,7 @@
 //! This module contains the [`SpanBatchTransactions`] type and logic for encoding and decoding
 //! transactions in a span batch.
 
+use super::varint::read_uvarint;
 use crate::{
     MAX_SPAN_BATCH_ELEMENTS, SpanBatchBits, SpanBatchError, SpanBatchPostExecTransactionData,
     SpanBatchTransactionData, SpanDecodingError,
@@ -313,8 +314,8 @@ impl SpanBatchTransactions {
     pub fn decode_tx_nonces(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
         let mut nonces = Vec::with_capacity(self.total_block_tx_count as usize);
         for _ in 0..self.total_block_tx_count {
-            let (nonce, remaining) = unsigned_varint::decode::u64(r)
-                .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::TxNonces))?;
+            let (nonce, remaining) =
+                read_uvarint(r).ok_or(SpanBatchError::Decoding(SpanDecodingError::TxNonces))?;
             nonces.push(nonce);
             *r = remaining;
         }
@@ -326,8 +327,8 @@ impl SpanBatchTransactions {
     pub fn decode_tx_gases(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
         let mut gases = Vec::with_capacity(self.total_block_tx_count as usize);
         for _ in 0..self.total_block_tx_count {
-            let (gas, remaining) = unsigned_varint::decode::u64(r)
-                .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::TxGases))?;
+            let (gas, remaining) =
+                read_uvarint(r).ok_or(SpanBatchError::Decoding(SpanDecodingError::TxGases))?;
             gases.push(gas);
             *r = remaining;
         }
@@ -523,6 +524,49 @@ mod tests {
     fn test_decode_tx_gases_truncated() {
         let mut txs = SpanBatchTransactions { total_block_tx_count: 1, ..Default::default() };
         let result = txs.decode_tx_gases(&mut [].as_slice());
+        assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::TxGases)));
+    }
+
+    // Transaction nonces and gas limits are protobuf Base128 varints, which op-node decodes with
+    // Go's `binary.ReadUvarint`. Kona must accept exactly the encodings op-node accepts, or a
+    // batcher can fork the two derivations with a re-encoded field. Vectors are shared with
+    // `op-node/rollup/derive/span_batch_test.go`.
+
+    #[test]
+    fn test_decode_tx_nonces_non_minimal() {
+        let mut txs = SpanBatchTransactions { total_block_tx_count: 1, ..Default::default() };
+        // `1` with a redundant trailing zero byte; the minimal form is `[0x01]`.
+        let buf = [0x81, 0x00];
+        let mut r = buf.as_slice();
+        txs.decode_tx_nonces(&mut r).unwrap();
+        assert_eq!(txs.tx_nonces, vec![1]);
+        assert!(r.is_empty(), "both bytes must be consumed");
+    }
+
+    #[test]
+    fn test_decode_tx_nonces_overflow_ten_byte_terminator() {
+        let mut txs = SpanBatchTransactions { total_block_tx_count: 1, ..Default::default() };
+        // The tenth byte terminates the varint but sets bits above 63.
+        let buf = [0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02];
+        let result = txs.decode_tx_nonces(&mut buf.as_slice());
+        assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::TxNonces)));
+    }
+
+    #[test]
+    fn test_decode_tx_gases_non_minimal() {
+        let mut txs = SpanBatchTransactions { total_block_tx_count: 1, ..Default::default() };
+        let buf = [0x81, 0x00];
+        let mut r = buf.as_slice();
+        txs.decode_tx_gases(&mut r).unwrap();
+        assert_eq!(txs.tx_gases, vec![1]);
+        assert!(r.is_empty(), "both bytes must be consumed");
+    }
+
+    #[test]
+    fn test_decode_tx_gases_overflow_ten_byte_terminator() {
+        let mut txs = SpanBatchTransactions { total_block_tx_count: 1, ..Default::default() };
+        let buf = [0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02];
+        let result = txs.decode_tx_gases(&mut buf.as_slice());
         assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::TxGases)));
     }
 

--- a/rust/kona/crates/protocol/protocol/src/batch/varint.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/varint.rs
@@ -1,0 +1,45 @@
+//! Base128 varint decoding for span-batch `uvarint` fields.
+//!
+//! The decoder below is a local port of op-node's `binary.ReadUvarint` rather than a crate call.
+//! Crates that decode this format identically do exist — `prost`, `leb128` and `integer-encoding`
+//! all match it byte for byte — but `leb128` and `integer-encoding` are `std`-only, and `prost`
+//! takes an `unsafe` fast path and allocates a `DecodeError` when it rejects. Both matter because
+//! this crate is compiled into the fault proof VM, so the port keeps the decode path safe and
+//! allocation-free while naming the implementation it has to agree with.
+//!
+//! Note that `unsigned-varint` implements a *different* varint family — the minimal-only
+//! multiformats encoding — so it rejects the non-minimal encodings this format permits.
+
+/// Maximum number of bytes in the Base128 varint encoding of a `u64`.
+const MAX_VARINT_LEN_64: usize = 10;
+
+/// Decodes a Base128 varint from the front of `buf`, returning the value and the remaining input,
+/// or [`None`] if `buf` does not begin with a varint representing a `u64`.
+///
+/// Span-batch `uvarint` fields use the protobuf Base128 encoding, which permits non-minimal
+/// encodings: a redundant trailing zero (`[0x81, 0x00]`) decodes to the same value as its minimal
+/// form (`[0x01]`). At most `MAX_VARINT_LEN_64` bytes are read, and the tenth byte terminates the
+/// varint only if it is `0x00` or `0x01`, since a larger terminator would set bits above 63.
+///
+/// This accepts exactly the encodings op-node's `binary.ReadUvarint` accepts. The two decoders
+/// must agree: a span batch that one client decodes and the other rejects splits derivation on
+/// identical L1 data.
+pub(super) fn read_uvarint(buf: &[u8]) -> Option<(u64, &[u8])> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    // The read bound does double duty: it is op-node's `MaxVarintLen64` limit, and it caps every
+    // shift that executes at 63, so none can overflow. (A tenth continuation byte still leaves
+    // `shift` at 70, but the loop ends before it is used again.)
+    for (i, &byte) in buf.iter().take(MAX_VARINT_LEN_64).enumerate() {
+        if byte < 0x80 {
+            if i == MAX_VARINT_LEN_64 - 1 && byte > 1 {
+                return None;
+            }
+            return Some((value | ((byte as u64) << shift), &buf[i + 1..]));
+        }
+        value |= ((byte & 0x7F) as u64) << shift;
+        shift += 7;
+    }
+    // The varint either ran past the maximum width or off the end of the buffer.
+    None
+}

--- a/rust/kona/crates/protocol/protocol/src/batch/varint.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/varint.rs
@@ -9,6 +9,10 @@
 //!
 //! Note that `unsigned-varint` implements a *different* varint family — the minimal-only
 //! multiformats encoding — so it rejects the non-minimal encodings this format permits.
+//!
+//! The accept-set is pinned per field by conformance vectors in the `prefix`, `payload` and
+//! `transactions` test modules, shared byte for byte with
+//! `op-node/rollup/derive/span_batch_test.go`.
 
 /// Maximum number of bytes in the Base128 varint encoding of a `u64`.
 const MAX_VARINT_LEN_64: usize = 10;


### PR DESCRIPTION
Aligns kona's span-batch `uvarint` decoding with op-node. A byzantine batcher could otherwise publish a span batch that one client decodes and the other rejects, splitting derivation on identical L1 data.

kona decoded all six span-batch `uvarint` fields with `unsigned_varint::decode::u64`, whose accept-set differs from op-node's `binary.ReadUvarint` in both directions:

- **Non-minimal encodings** — `[0x81, 0x00]` (`1` with a redundant trailing zero) is a valid protobuf Base128 varint. op-node accepts it; `unsigned-varint` rejects it as `NotMinimal`, so op-node builds L2 blocks the fault proof program cannot reproduce.
- **Ten-byte varints** — a tenth byte terminating above `0x01` sets bits past 63. op-node reports overflow; `unsigned-varint` returns `Ok` with the high bits silently discarded, so the fault proof program builds blocks op-node rejects.

The root cause is a wrong varint family: `unsigned-varint` implements the minimal-only multiformats encoding, not the protobuf Base128 varint that the [span batch format](https://specs.optimism.io/protocol/delta/span-batches.html) specifies — hence a mismatch in both directions. All six fields (`rel_timestamp`, `l1_origin_num`, `block_count`, `block_tx_count`, `tx_nonce`, `tx_gas`) now route through `read_uvarint`, a port of `binary.ReadUvarint`. Encoding is unchanged; every value `unsigned_varint::encode::u64` emits lies inside the new accept-set.

Applies from Delta onward, not fork-gated. Deploying needs no fork: in both directions the change moves kona *onto* op-node's accept-set, and op-node's behaviour defines the canonical chain, so it cannot alter any history op-node has already derived. Consensus-affecting (derivation): shipping to a live chain requires a new kona-client release + prestate.

## Verification

A differential harness recorded Go's verdict for 649,092 byte strings — all 1- and 2-byte inputs, exhaustive over an 11-symbol alphabet to depth 5, every tenth byte after nine-byte continuation prefixes, 11-byte inputs, and 400k random strings. `read_uvarint` agrees on accept/reject, value, and consumed length for every one.

The committed field-level vectors are shared byte for byte between the two suites — the table in `TestSpanBatchUvarintConformance` mirrors the kona tests exactly. On top of that, each client decodes a whole span batch whose `block_count` has been re-encoded non-minimally, on its own batch (`TestSpanBatchNonMinimalBlockCount` / `test_decode_raw_span_batch_non_minimal_block_count`).

Closes ethereum-optimism/protocol-team#223.

Also verified via a local OMP/GPT-5.6-sol review.

🤖 *Co-created with Claude Opus 5 (1M context)*
