### PR TITLE
op-deployer: Revert on game config mismatches instead of promoting them to Super Games

### DIFF
--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -293,7 +293,7 @@ func (r *InteropDevL2Recipe) build(l1ChainID uint64, addrs devkeys.Addresses) (*
 		Prefund:                     make(map[common.Address]*big.Int),
 		SaltMixer:                   "",
 		GasLimit:                    60_000_000,
-		DisputeGameType:             1, // PERMISSIONED_CANNON Game Type
+		DisputeGameType:             5, // SUPER_PERMISSIONED Game Type
 		DisputeAbsolutePrestate:     common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c"),
 		DisputeKonaAbsolutePrestate: common.HexToHash("0x035ef680a6fa34c50d8d8169075b5d133ecd7b38fe2b2a83cc76fc81ae5d7c52"),
 		DisputeMaxGameDepth:         73,

--- a/op-deployer/pkg/deployer/opcm/opchain.go
+++ b/op-deployer/pkg/deployer/opcm/opchain.go
@@ -56,7 +56,8 @@ type DeployOPChainInput struct {
 	DisputeAbsolutePrestate common.Hash // Selected game prestate.
 	StartingAnchorRoot      Proposal
 	// CannonAbsolutePrestate configures the CANNON_KONA guardian fallback.
-	// PERMISSIONED_CANNON mirrors the selected prestate. SUPER_CANNON_KONA leaves it zero.
+	// PERMISSIONED_CANNON mirrors the selected prestate. The super types (SUPER_CANNON_KONA,
+	// SUPER_PERMISSIONED) leave it zero.
 	CannonAbsolutePrestate       common.Hash
 	DisputeMaxGameDepth          *big.Int
 	DisputeSplitDepth            *big.Int

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -261,18 +261,13 @@ func ValidateInitialGameTypeSet(gameTypes []uint32) error {
 // ResolveInitialDeployRequirements returns requirements for a supported initial game type.
 func ResolveInitialDeployRequirements(gameType uint32) (InitialDeployRequirements, error) {
 	switch embedded.GameType(gameType) {
-	case embedded.GameTypePermissionedCannon:
+	case embedded.GameTypePermissionedCannon, embedded.GameTypeSuperPermissioned:
 		return InitialDeployRequirements{}, nil
 	case embedded.GameTypeCannonKona, embedded.GameTypeSuperCannonKona:
 		return InitialDeployRequirements{
 			Permissionless:   true,
 			RequiresPrestate: true,
 		}, nil
-	case embedded.GameTypeSuperPermissioned:
-		return InitialDeployRequirements{}, fmt.Errorf(
-			"initial dispute game type SUPER_PERMISSIONED (%d) is a derived fallback and is not an initial-deploy selector",
-			gameType,
-		)
 	default:
 		return InitialDeployRequirements{}, fmt.Errorf("unsupported initial dispute game type %d", gameType)
 	}
@@ -445,7 +440,7 @@ func BuildDeployOPChainInput(
 	switch embedded.GameType(proofParams.DisputeGameType) {
 	case embedded.GameTypeCannonKona:
 		cannonAbsolutePrestate = opcm.PermissionedCannonFallbackPrestatePlaceholder
-	case embedded.GameTypeSuperCannonKona:
+	case embedded.GameTypeSuperCannonKona, embedded.GameTypeSuperPermissioned:
 		cannonAbsolutePrestate = common.Hash{}
 	case embedded.GameTypePermissionedCannon:
 		cannonAbsolutePrestate = proofParams.DisputeAbsolutePrestate

--- a/op-deployer/pkg/deployer/pipeline/opchain_test.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain_test.go
@@ -121,7 +121,8 @@ func Test_makeDCI_OpcmAddress(t *testing.T) {
 			if got.Opcm != tt.expectedOpcm {
 				t.Errorf("makeDCI() Opcm = %v, want %v", got.Opcm, tt.expectedOpcm)
 			}
-			require.Equal(t, standard.DisputeAbsolutePrestate, got.CannonAbsolutePrestate)
+			// The standard deploy selects SUPER_PERMISSIONED, which installs no CANNON_KONA fallback.
+			require.Equal(t, common.Hash{}, got.CannonAbsolutePrestate)
 			require.Equal(t, opcm.DefaultStartingAnchorRoot.Root, got.StartingAnchorRoot.Root)
 			require.Equal(t, common.Big0, got.StartingAnchorRoot.L2SequenceNumber)
 		})
@@ -246,11 +247,6 @@ func Test_makeDCI_RejectsInvalidInitialGameTypeBeforePermissionlessHandling(t *t
 			name:     "CANNON",
 			gameType: uint32(embedded.GameTypeCannon),
 			wantErr:  "unsupported initial dispute game type 0",
-		},
-		{
-			name:     "SUPER_PERMISSIONED",
-			gameType: uint32(embedded.GameTypeSuperPermissioned),
-			wantErr:  "derived fallback and is not an initial-deploy selector",
 		},
 		{
 			name:     "ZK_DISPUTE_GAME",
@@ -533,14 +529,6 @@ func TestBuildContinuationDCI_FailClosedGates(t *testing.T) {
 				st.Chains[0].InitialGameType = ptr.New(unknownGameType)
 			},
 			wantErrors: []string{"unsupported initial dispute game type 999", "op-deployer prepare"},
-		},
-		{
-			name: "gate 8 rejects SUPER_PERMISSIONED selector",
-			mutate: func(_ *state.Intent, chain *state.ChainIntent, st *state.State) {
-				chain.DeployOverrides["respectedGameType"] = embedded.GameTypeSuperPermissioned
-				st.Chains[0].InitialGameType = ptr.New(uint32(embedded.GameTypeSuperPermissioned))
-			},
-			wantErrors: []string{"derived fallback and is not an initial-deploy selector", "op-deployer prepare"},
 		},
 		{
 			name: "gate 9 requires committed prestate",
@@ -859,7 +847,7 @@ func TestResolveInitialDeployRequirements(t *testing.T) {
 		{
 			name:     "SUPER_PERMISSIONED",
 			gameType: uint32(embedded.GameTypeSuperPermissioned),
-			wantErr:  "SUPER_PERMISSIONED (5) is a derived fallback and is not an initial-deploy selector",
+			want:     InitialDeployRequirements{},
 		},
 		{
 			name:     "CANNON_KONA",

--- a/op-deployer/pkg/deployer/pipeline/opchain_test.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain_test.go
@@ -953,6 +953,11 @@ func TestBuildDeployOPChainInputCannonAbsolutePrestate(t *testing.T) {
 			gameType: embedded.GameTypeSuperCannonKona,
 			want:     common.Hash{},
 		},
+		{
+			name:     "SUPER_PERMISSIONED leaves unread field zero",
+			gameType: embedded.GameTypeSuperPermissioned,
+			want:     common.Hash{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/op-deployer/pkg/deployer/prepare_test.go
+++ b/op-deployer/pkg/deployer/prepare_test.go
@@ -110,7 +110,8 @@ func TestMakePredictionInput(t *testing.T) {
 	require.Equal(t, standard.DisputeGameType, dci.DisputeGameType)
 	require.Equal(t, opcm.DefaultStartingAnchorRoot.Root, dci.StartingAnchorRoot.Root)
 	require.Equal(t, common.Big0, dci.StartingAnchorRoot.L2SequenceNumber)
-	require.Equal(t, dci.DisputeAbsolutePrestate, dci.CannonAbsolutePrestate)
+	// The standard deploy selects SUPER_PERMISSIONED, which installs no CANNON_KONA fallback.
+	require.Equal(t, common.Hash{}, dci.CannonAbsolutePrestate)
 }
 
 func TestMakePredictionInput_OwnsStartingAnchorSequenceNumber(t *testing.T) {
@@ -215,11 +216,6 @@ func TestMakePredictionInput_RejectsInvalidInitialGameType(t *testing.T) {
 			name:     "CANNON",
 			gameType: uint32(embedded.GameTypeCannon),
 			wantErr:  "unsupported initial dispute game type 0",
-		},
-		{
-			name:     "SUPER_PERMISSIONED",
-			gameType: uint32(embedded.GameTypeSuperPermissioned),
-			wantErr:  "derived fallback and is not an initial-deploy selector",
 		},
 		{
 			name:     "ZK_DISPUTE_GAME",
@@ -820,7 +816,7 @@ func TestPrepareChainsPredictionFailureOnlyClearsSuccessfullyPredictedPrestatesI
 	require.EqualValues(t, uint64(anchor.Time)+genesisTimeOffset, *first.GenesisTime)
 	require.Equal(t, common.HexToAddress("0x3333"), first.SystemConfigProxy)
 	require.Zero(t, first.Prestate)
-	require.Equal(t, uint32(embedded.GameTypePermissionedCannon), *first.InitialGameType)
+	require.Equal(t, standard.DisputeGameType, *first.InitialGameType)
 	second, err := st.Chain(secondID)
 	require.NoError(t, err)
 	require.Equal(t, anchor, second.StartBlock)
@@ -917,11 +913,6 @@ func TestPredictChainsRejectsInvalidInitialGameTypeBeforePrediction(t *testing.T
 			name:     "CANNON",
 			gameType: uint32(embedded.GameTypeCannon),
 			wantErr:  "unsupported initial dispute game type 0",
-		},
-		{
-			name:     "SUPER_PERMISSIONED",
-			gameType: uint32(embedded.GameTypeSuperPermissioned),
-			wantErr:  "derived fallback and is not an initial-deploy selector",
 		},
 		{
 			name:     "ZK_DISPUTE_GAME",

--- a/op-deployer/pkg/deployer/prestate_test.go
+++ b/op-deployer/pkg/deployer/prestate_test.go
@@ -732,7 +732,7 @@ func TestPrestateRejectsIntentChainChangesAfterPrepare(t *testing.T) {
 			},
 			wantErrs: []string{
 				chainA.Hex(),
-				"prepared PERMISSIONED_CANNON (1)",
+				"prepared SUPER_PERMISSIONED (5)",
 				"intent CANNON_KONA (8)",
 				"rerun op-deployer prepare",
 			},

--- a/op-deployer/pkg/deployer/prestate_workflow_test.go
+++ b/op-deployer/pkg/deployer/prestate_workflow_test.go
@@ -121,7 +121,7 @@ func TestPrestateWorkflowFromPrepareChains(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, predicted[permissionedID], permissioned.SystemConfigProxy)
 			require.Zero(t, permissioned.Prestate)
-			require.Equal(t, uint32(embedded.GameTypePermissionedCannon), *permissioned.InitialGameType)
+			require.Equal(t, standard.DisputeGameType, *permissioned.InitialGameType)
 
 			permissionless, err := persisted.Chain(permissionlessID)
 			require.NoError(t, err)

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -27,14 +27,18 @@ const (
 	ProofMaturityDelaySeconds       uint64 = 604800
 	DisputeGameFinalityDelaySeconds uint64 = 302400
 	MIPSVersion                     uint64 = 8
-	DisputeGameType                 uint32 = 1 // PERMISSIONED game type
-	DisputeMaxGameDepth             uint64 = 73
-	DisputeSplitDepth               uint64 = 30
-	DisputeClockExtension           uint64 = 10800
-	DisputeMaxClockDuration         uint64 = 302400
-	Eip1559DenominatorCanyon        uint64 = 250
-	Eip1559Denominator              uint64 = 50
-	Eip1559Elasticity               uint64 = 6
+	// DisputeGameType is the SUPER_PERMISSIONED game type. DeployOPChain requires the initial game
+	// type to match the OPCM's family, and SUPER_ROOT_GAMES_MIGRATION is enabled by default, so the
+	// permissioned selector for a standard deploy is the super root one.
+	// TODO(#21662): revisit with the broader SuperRootGamesMigration cleanup.
+	DisputeGameType          uint32 = 5
+	DisputeMaxGameDepth      uint64 = 73
+	DisputeSplitDepth        uint64 = 30
+	DisputeClockExtension    uint64 = 10800
+	DisputeMaxClockDuration  uint64 = 302400
+	Eip1559DenominatorCanyon uint64 = 250
+	Eip1559Denominator       uint64 = 50
+	Eip1559Elasticity        uint64 = 6
 
 	// TODO(#20916): This value should be replaced with a benchmark based on the time it takes to perform a full
 	// L2 genesis deployment.

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -116,14 +116,16 @@ contract DeployOPChain is Script {
         view
         returns (IOPContractsManagerV2.FullConfig memory config_)
     {
-        (bool permissionless, GameType respectedGameType) =
-            _initialDeployGameSelection(_input.disputeGameType, isSuperRoot);
+        (, GameType respectedGameType) = _initialDeployGameSelection(_input.disputeGameType, isSuperRoot);
 
-        bool enableCannonKona = _input.disputeGameType.raw() == GameTypes.CANNON_KONA.raw();
-        bool enableSuperCannonKona = _input.disputeGameType.raw() == GameTypes.SUPER_CANNON_KONA.raw();
-        // Register the CANNON_KONA guardian fallback. OPCMV2 does not require it.
-        bool enablePermissionedCannon = enableCannonKona || (!isSuperRoot && !permissionless);
-        bool enableSuperPermissioned = enableSuperCannonKona || (isSuperRoot && !permissionless);
+        bool enableCannonKona = respectedGameType.raw() == GameTypes.CANNON_KONA.raw();
+        bool enableSuperCannonKona = respectedGameType.raw() == GameTypes.SUPER_CANNON_KONA.raw();
+        // A permissionless deploy also registers the permissioned game of its family as the
+        // guardian fallback.
+        bool enablePermissionedCannon =
+            enableCannonKona || respectedGameType.raw() == GameTypes.PERMISSIONED_CANNON.raw();
+        bool enableSuperPermissioned =
+            enableSuperCannonKona || respectedGameType.raw() == GameTypes.SUPER_PERMISSIONED.raw();
         // Build dispute game configs - OPCMV2 requires all 6 game type configs.
         // Order must match validGameTypes in OPContractsManagerV2._assertValidFullConfig().
         IOPContractsManagerUtils.DisputeGameConfig[] memory disputeGameConfigs =
@@ -265,8 +267,8 @@ contract DeployOPChain is Script {
     }
 
     /// @notice Returns the permissionless mode and respected game type for an initial deployment.
-    /// @dev CANNON_KONA and SUPER_CANNON_KONA prestates are not interchangeable, so the type must be explicit.
-    ///      PERMISSIONED_CANNON selects the permissioned game for the OPCM mode; SUPER_PERMISSIONED has no prestate.
+    /// @dev The requested type must match the OPCM's game family, so the caller's prestate and
+    ///      proposal format always match the games the OPCM installs.
     function _initialDeployGameSelection(
         GameType _disputeGameType,
         bool _isSuperRoot
@@ -275,18 +277,24 @@ contract DeployOPChain is Script {
         pure
         returns (bool permissionless_, GameType respectedGameType_)
     {
-        permissionless_ = _disputeGameType.raw() == GameTypes.CANNON_KONA.raw()
-            || _disputeGameType.raw() == GameTypes.SUPER_CANNON_KONA.raw();
+        uint32 rawGameType = _disputeGameType.raw();
 
-        // PERMISSIONED_CANNON is the only **permissioned** type supported for an initial deploy.
+        // The Kona games are the only **permissionless** types and PERMISSIONED_CANNON /
+        // SUPER_PERMISSIONED the only **permissioned** ones supported for an initial deploy.
+        permissionless_ = rawGameType == GameTypes.CANNON_KONA.raw() || rawGameType == GameTypes.SUPER_CANNON_KONA.raw();
+        bool permissioned =
+            rawGameType == GameTypes.PERMISSIONED_CANNON.raw() || rawGameType == GameTypes.SUPER_PERMISSIONED.raw();
+
+        // Check the game is either one of our supported types.
+        require(permissionless_ || permissioned, "DeployOPChain: unsupported dispute game type");
+
+        // Check the game belongs to the family the OPCM deploys.
         require(
-            permissionless_ || _disputeGameType.raw() == GameTypes.PERMISSIONED_CANNON.raw(),
-            "DeployOPChain: unsupported dispute game type"
+            GameTypes.isSuperGame(_disputeGameType) == _isSuperRoot,
+            "DeployOPChain: dispute game type does not match OPCM super root mode"
         );
 
-        respectedGameType_ = permissionless_
-            ? _disputeGameType
-            : (_isSuperRoot ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON);
+        respectedGameType_ = _disputeGameType;
     }
 
     /// @notice Returns whether the given OPCM has the SUPER_ROOT_GAMES_MIGRATION dev feature enabled.
@@ -337,14 +345,8 @@ contract DeployOPChain is Script {
         require(_i.opcm != address(0), "DeployOPChainInput: opcm not set");
         DeployUtils.assertValidContractAddress(_i.opcm);
         bool superRoot = _isSuperRootEnabled(IOPContractsManagerV2(_i.opcm));
+        // Rejects a game type from the other family.
         (bool permissionless,) = _initialDeployGameSelection(_i.disputeGameType, superRoot);
-        if (permissionless) {
-            GameType expectedGameType = superRoot ? GameTypes.SUPER_CANNON_KONA : GameTypes.CANNON_KONA;
-            require(
-                _i.disputeGameType.raw() == expectedGameType.raw(),
-                "DeployOPChainInput: dispute game type does not match OPCM mode"
-            );
-        }
 
         require(_i.disputeMaxGameDepth != 0, "DeployOPChainInput: disputeMaxGameDepth not set");
         require(_i.disputeSplitDepth != 0, "DeployOPChainInput: disputeSplitDepth not set");

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -301,7 +301,7 @@ contract DeployOPChain is Script {
     /// @param _opcm The OPCM to check.
     /// @return Whether SUPER_ROOT_GAMES_MIGRATION is enabled.
     function _isSuperRootEnabled(IOPContractsManagerV2 _opcm) internal view returns (bool) {
-        return DevFeatures.isDevFeatureEnabled(_opcm.devFeatureBitmap(), DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
+        return _opcm.isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
     }
 
     /// @notice Creates a game config, clearing its bond and arguments when disabled.

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -64,7 +64,7 @@ contract DeployOPChain_TestBase is Test, FeatureFlags {
     uint256 l2ChainId = 300;
     string saltMixer = "saltMixer";
     uint64 gasLimit = 60_000_000;
-    GameType disputeGameType = GameTypes.PERMISSIONED_CANNON;
+    GameType disputeGameType;
     // Prestates are real release hashes from the superchain registry's standard-prestates.toml;
     // the tests only need them to be non-zero and distinct from each other.
     // cannon32 v1.3.1 (op-program).
@@ -92,6 +92,7 @@ contract DeployOPChain_TestBase is Test, FeatureFlags {
 
     function setUp() public virtual {
         resolveFeaturesFromEnv();
+        disputeGameType = _permissionedGameType();
         deploySuperchain = new DeploySuperchain();
         deployImplementations = new DeployImplementations();
         deployOPChain = new DeployOPChain();
@@ -166,6 +167,14 @@ contract DeployOPChain_TestBase is Test, FeatureFlags {
         deployOPChainInput.disputeAbsolutePrestate = cannonKonaAbsolutePrestate;
         deployOPChainInput.startingAnchorRoot = permissionlessAnchorRoot;
     }
+
+    /// @notice The permissioned initial deploy selector for the OPCM's mode. The script rejects the
+    ///         other family's type rather than promoting it.
+    function _permissionedGameType() internal view returns (GameType) {
+        return isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
+            ? GameTypes.SUPER_PERMISSIONED
+            : GameTypes.PERMISSIONED_CANNON;
+    }
 }
 
 contract DeployOPChain_Test is DeployOPChain_TestBase {
@@ -196,9 +205,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
 
         // Check dispute game deployments
         // Validate permissionedDisputeGame (PDG) address
-        GameType permGameType = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
-            ? GameTypes.SUPER_PERMISSIONED
-            : GameTypes.PERMISSIONED_CANNON;
+        GameType permGameType = _permissionedGameType();
         IOPContractsManagerContainer.Implementations memory impls = IOPContractsManagerV2(opcmAddr).implementations();
         address expectedPDGAddress = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
             ? impls.superPermissionedDisputeGameImpl
@@ -237,10 +244,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         view
         returns (IPermissionedDisputeGame)
     {
-        GameType permGameType = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
-            ? GameTypes.SUPER_PERMISSIONED
-            : GameTypes.PERMISSIONED_CANNON;
-        return IPermissionedDisputeGame(address(doo.disputeGameFactoryProxy.gameImpls(permGameType)));
+        return IPermissionedDisputeGame(address(doo.disputeGameFactoryProxy.gameImpls(_permissionedGameType())));
     }
 
     function test_runWithBytes_succeeds() public {
@@ -381,7 +385,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         skipIfDevFeatureDisabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
         _setPermissionlessInput(GameTypes.CANNON_KONA);
 
-        vm.expectRevert("DeployOPChainInput: dispute game type does not match OPCM mode");
+        vm.expectRevert("DeployOPChain: dispute game type does not match OPCM super root mode");
         deployOPChain.run(deployOPChainInput);
     }
 
@@ -390,7 +394,26 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         skipIfDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
         _setPermissionlessInput(GameTypes.SUPER_CANNON_KONA);
 
-        vm.expectRevert("DeployOPChainInput: dispute game type does not match OPCM mode");
+        vm.expectRevert("DeployOPChain: dispute game type does not match OPCM super root mode");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    /// @notice PERMISSIONED_CANNON is rejected when the OPCM uses super roots instead of being
+    ///         promoted to SUPER_PERMISSIONED.
+    function test_run_permissionedCannonGameTypeWithSuperRoot_reverts() public {
+        skipIfDevFeatureDisabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
+        deployOPChainInput.disputeGameType = GameTypes.PERMISSIONED_CANNON;
+
+        vm.expectRevert("DeployOPChain: dispute game type does not match OPCM super root mode");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    /// @notice SUPER_PERMISSIONED is rejected when the OPCM does not use super roots.
+    function test_run_superPermissionedGameTypeWithoutSuperRoot_reverts() public {
+        skipIfDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
+        deployOPChainInput.disputeGameType = GameTypes.SUPER_PERMISSIONED;
+
+        vm.expectRevert("DeployOPChain: dispute game type does not match OPCM super root mode");
         deployOPChain.run(deployOPChainInput);
     }
 
@@ -501,14 +524,12 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
     }
 
     /// @notice Tests that faultDisputeGame is set to address(0) and permissionedDisputeGame is set to the correct
-    /// implementation for GameTypes.PERMISSIONED_CANNON.
-    function test_run_faultDisputeGamePermissionedCannon_succeeds() public {
-        deployOPChainInput.disputeGameType = GameTypes.PERMISSIONED_CANNON;
+    /// implementation for the permissioned game type of the OPCM's mode.
+    function test_run_faultDisputeGamePermissioned_succeeds() public {
+        GameType permType = _permissionedGameType();
+        deployOPChainInput.disputeGameType = permType;
         DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
 
-        GameType permType = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
-            ? GameTypes.SUPER_PERMISSIONED
-            : GameTypes.PERMISSIONED_CANNON;
         address expectedPermissioned = address(doo.disputeGameFactoryProxy.gameImpls(permType));
         assertEq(address(doo.permissionedDisputeGame), expectedPermissioned, "PDG impl");
         assertEq(address(doo.faultDisputeGame), address(0), "FDG should be set to address(0)");
@@ -551,7 +572,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         );
 
         bool isSuperRoot = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
-        GameType permType = isSuperRoot ? GameTypes.SUPER_PERMISSIONED : GameTypes.PERMISSIONED_CANNON;
+        GameType permType = _permissionedGameType();
 
         // The legacy permissioned game keeps the default bond. The super permissioned game
         // has no bonded participation path, so its init bond must be zero.


### PR DESCRIPTION
## Context

`DeployOPChain#_initialDeployGameSelection` silently promoted `PERMISSIONED_CANNON` to `SUPER_PERMISSIONED` when the OPCM had `SUPER_ROOT_GAMES_MIGRATION` enabled, so a deployment could install a respected game type the caller never asked for.

Since `DevFeatures.isDevFeatureEnabled` returns true for that flag regardless of the bitmap (TODO #21662, mirrored in `op-core/devfeatures`), super mode is always on today. Every deploy was therefore being promoted, including op deployer's default `respectedGameType = 1`, which is why the Go side is part of this change.

## Changes

Contracts:

* `_initialDeployGameSelection` now rejects a type from the other family with `"DeployOPChain: dispute game type does not match OPCM super root mode"` and returns the requested type unchanged. `SUPER_PERMISSIONED` joins `PERMISSIONED_CANNON` as a supported permissioned selector; the unsupported-type message is untouched.

op-deployer:

* `standard.DisputeGameType` goes from 1 to 5 (`SUPER_PERMISSIONED`).
* `ResolveInitialDeployRequirements` accepts `SUPER_PERMISSIONED`.
* Super game types explicitly leave `CannonAbsolutePrestate` zero.

No on-chain behavior change: `SUPER_PERMISSIONED` is already what gets deployed. An intent that sets `respectedGameType = 1` now fails with a clear message instead of being promoted.

## Tests

* `DeployOPChain.t.sol`: the default input resolves through a new `_permissionedGameType()` helper. Added `test_run_permissionedCannonGameTypeWithSuperRoot_reverts` (the no-promotion regression) and `test_run_superPermissionedGameTypeWithoutSuperRoot_reverts`, renamed `test_run_faultDisputeGamePermissionedCannon_succeeds` to `test_run_faultDisputeGamePermissioned_succeeds`.
* Go: dropped the three "SUPER_PERMISSIONED is rejected" table rows and the continuation gate case, flipped it to accepted in `TestResolveInitialDeployRequirements`, and updated the default-derived assertions (zero fallback prestate, `standard.DisputeGameType`, `prepared SUPER_PERMISSIONED (5)`).

Closes #22132 