### PR TITLE
bgpo: inspect exactly maxBlocks when suggesting blob tips

### DIFF
--- a/op-service/bgpo/oracle.go
+++ b/op-service/bgpo/oracle.go
@@ -327,11 +327,9 @@ func (o *BlobTipOracle) SuggestBlobTipCap(ctx context.Context, maxBlocks int, pe
 
 	// Collect blob fee caps from recent blocks (only from cache, no RPC calls)
 	var tips []*big.Int
-	startBlock := latestBlockNum
-	if startBlock >= uint64(maxBlocks) {
-		startBlock -= uint64(maxBlocks)
-	} else {
-		startBlock = 0
+	var startBlock uint64
+	if latestBlockNum >= uint64(maxBlocks) {
+		startBlock = latestBlockNum - uint64(maxBlocks) + 1
 	}
 
 	for blockNum := startBlock; blockNum <= latestBlockNum; blockNum++ {

--- a/op-service/bgpo/oracle_test.go
+++ b/op-service/bgpo/oracle_test.go
@@ -296,6 +296,30 @@ func TestSuggestBlobTipCap(t *testing.T) {
 	mbackend.AssertExpectations(t)
 }
 
+func TestSuggestBlobTipCapUsesExactlyMaxBlocks(t *testing.T) {
+	oracle := NewBlobTipOracle(
+		new(mockBTOBackend),
+		params.MainnetChainConfig,
+		testlog.Logger(t, log.LevelError),
+		&BlobTipOracleConfig{
+			PricesCacheSize: 10,
+			BlockCacheSize:  10,
+			MaxBlocks:       5,
+			Percentile:      100,
+		},
+	)
+
+	oracle.priorityFees.Add(399, []*big.Int{big.NewInt(1000)})
+	for blockNum := uint64(400); blockNum <= 404; blockNum++ {
+		oracle.priorityFees.Add(blockNum, []*big.Int{big.NewInt(int64(blockNum - 399))})
+	}
+	oracle.latestBlock = 404
+
+	suggested, err := oracle.SuggestBlobTipCap(context.Background(), 5, 100)
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(5), suggested)
+}
+
 func TestPrePopulateCache(t *testing.T) {
 	mbackend := new(mockBTOBackend)
 	chainConfig := params.MainnetChainConfig


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Closes https://github.com/ethereum-optimism/optimism/issues/22131

`SuggestBlobTipCap` started its inclusive cache scan at `latestBlockNum - maxBlocks`, causing it to consider `maxBlocks + 1` block numbers. When the extra block was still cached, its tips could affect the resulting percentile.

This pr:

- adjusts the inclusive start to `latestBlockNum - maxBlocks + 1`, matching
  `prePopulateCache`;
- adds a regression test with an out-of-window high tip to verify that exactly
  `maxBlocks` blocks influence the suggestion.


**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

- `go test ./op-service/bgpo -count=1`
- `go vet ./op-service/bgpo`
- `./linter/bin/op-golangci-lint run ./op-service/bgpo/...`

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
