### PR TITLE
op-conductor: Recover when a new leader is behind the consensus unsafe head

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hashicorp/raft"
@@ -39,6 +40,38 @@ var (
 	ErrPauseTimeout       = errors.New("timeout to pause conductor")
 	ErrUnsafeHeadMismatch = errors.New("unsafe head mismatch")
 	ErrNoUnsafeHead       = errors.New("no unsafe head")
+	// ErrNodeAheadOfConsensus is returned when the local op-node's unsafe head is level with or
+	// ahead of the head consensus committed. Unlike ErrUnsafeHeadMismatch this is not something
+	// the local node can be caught up out of, and it is not local either, so it must not escalate
+	// to a leadership transfer. See catchUpUnsafeHead.
+	ErrNodeAheadOfConsensus = errors.New("op-node unsafe head is not behind consensus unsafe head")
+)
+
+const (
+	// defaultUnsafeHeadCatchUpTimeout bounds a whole attempt at starting sequencing: bringing the
+	// local op-node up to the unsafe head consensus committed, and getting op-node's sequencer to
+	// accept a start at it. It is generous enough to cover replaying a few payloads plus whatever
+	// op-node needs to insert them, and short enough that a node which genuinely cannot catch up
+	// releases leadership promptly. action() is a single loop, so this is also how long a
+	// leadership or health update can be left queued behind an attempt.
+	defaultUnsafeHeadCatchUpTimeout = 2 * time.Second
+	// defaultUnhealthyUnsafeHeadCatchUpTimeout is the same budget for a leader that is already
+	// unhealthy. Waiting is worth much less there: that leader's fallback is to hand leadership
+	// over, and its own op-node is the likely reason the catch-up is slow in the first place.
+	defaultUnhealthyUnsafeHeadCatchUpTimeout = 500 * time.Millisecond
+	// defaultUnsafeHeadCatchUpInterval is how often op-node's unsafe head is re-read while
+	// waiting for it to adopt the consensus unsafe head. The read is cheap.
+	defaultUnsafeHeadCatchUpInterval = 25 * time.Millisecond
+	// defaultStartSequencerRetryInterval is how often a start that op-node rejected because its
+	// sequencer has not caught up with its execution client yet is retried. Much slower than the
+	// head read: StartSequencer calls back into this conductor for leadership and then takes the
+	// sequencer's own lock, which is also held while building blocks, so it is not something to
+	// hammer while waiting for it.
+	defaultStartSequencerRetryInterval = 200 * time.Millisecond
+	// maxFailedStarts is how many consecutive failures to bring the local op-node up to the
+	// consensus unsafe head a healthy leader tolerates before handing leadership to another
+	// member.
+	maxFailedStarts = 3
 )
 
 // New creates a new OpConductor instance.
@@ -62,19 +95,23 @@ func NewOpConductor(
 	}
 
 	oc := &OpConductor{
-		log:          log,
-		version:      version,
-		cfg:          cfg,
-		metrics:      m,
-		pauseCh:      make(chan struct{}),
-		pauseDoneCh:  make(chan struct{}),
-		resumeCh:     make(chan struct{}),
-		resumeDoneCh: make(chan struct{}),
-		actionCh:     make(chan struct{}, 1),
-		ctrl:         ctrl,
-		cons:         cons,
-		hmon:         hmon,
-		retryBackoff: func() time.Duration { return time.Duration(rand.Intn(2000)) * time.Millisecond },
+		log:                               log,
+		version:                           version,
+		cfg:                               cfg,
+		metrics:                           m,
+		pauseCh:                           make(chan struct{}),
+		pauseDoneCh:                       make(chan struct{}),
+		resumeCh:                          make(chan struct{}),
+		resumeDoneCh:                      make(chan struct{}),
+		actionCh:                          make(chan struct{}, 1),
+		ctrl:                              ctrl,
+		cons:                              cons,
+		hmon:                              hmon,
+		retryBackoff:                      func() time.Duration { return time.Duration(rand.Intn(2000)) * time.Millisecond },
+		unsafeHeadCatchUpTimeout:          defaultUnsafeHeadCatchUpTimeout,
+		unhealthyUnsafeHeadCatchUpTimeout: defaultUnhealthyUnsafeHeadCatchUpTimeout,
+		unsafeHeadCatchUpInterval:         defaultUnsafeHeadCatchUpInterval,
+		startSequencerRetryInterval:       defaultStartSequencerRetryInterval,
 	}
 	oc.loopActionFn = oc.loopAction
 
@@ -368,6 +405,10 @@ type OpConductor struct {
 	healthy        atomic.Bool
 	hcerr          error // error from health check
 	prevState      *state
+	// failedStarts counts consecutive failures to start sequencing while this server is a
+	// healthy leader. Retrying the same failing start forever would leave the cluster with no
+	// sequencer at all, so past a threshold leadership is handed to another member instead.
+	failedStarts int
 
 	healthUpdateCh <-chan error
 	leaderUpdateCh <-chan bool
@@ -388,6 +429,16 @@ type OpConductor struct {
 	metricsServer *httputil.HTTPServer
 
 	retryBackoff func() time.Duration
+
+	// unsafeHeadCatchUpTimeout bounds a whole startSequencer attempt, and
+	// unhealthyUnsafeHeadCatchUpTimeout does the same for a leader that is already unhealthy.
+	unsafeHeadCatchUpTimeout          time.Duration
+	unhealthyUnsafeHeadCatchUpTimeout time.Duration
+	// unsafeHeadCatchUpInterval is how often op-node's unsafe head is re-read while waiting for
+	// it to adopt a posted payload; startSequencerRetryInterval is how often the start itself is
+	// re-attempted while op-node's sequencer trails its execution client.
+	unsafeHeadCatchUpInterval   time.Duration
+	startSequencerRetryInterval time.Duration
 
 	flashblocksHandler ws.FlashblockHandler
 }
@@ -790,8 +841,37 @@ func (oc *OpConductor) action() {
 	case status.leader && status.healthy && !status.active:
 		// start sequencer
 		err = oc.startSequencer()
+		if err == nil {
+			oc.failedStarts = 0
+			break
+		}
+		// A healthy leader whose own op-node cannot be brought up to the head consensus committed
+		// leaves the whole cluster without a sequencer, and retrying the identical action makes no
+		// progress on its own: only that op-node catching up can, and it may never. Give it a
+		// bounded number of attempts, then hand leadership to a member that may already be caught
+		// up.
+		//
+		// Only that condition escalates. Every other start failure is either transient or the same
+		// on every member — nothing committed to consensus yet, a degraded raft barrier, an RPC
+		// blip, this conductor shutting down — and churning leadership through the cluster then
+		// costs a sequencer-less window per member without fixing anything.
+		if !isLocalCatchUpFailure(err) {
+			break
+		}
+		oc.failedStarts++
+		if oc.failedStarts < maxFailedStarts {
+			break
+		}
+		oc.log.Error("failed to start sequencer repeatedly, transferring leadership instead",
+			"server", oc.cons.ServerID(), "attempts", oc.failedStarts, "err", err)
+		if err = oc.transferLeader(); err == nil {
+			oc.failedStarts = 0
+		}
+		// A failed transfer leaves the counter at the threshold so the next action retries the
+		// transfer straight away, rather than needing maxFailedStarts more failed starts first.
 	case status.leader && status.healthy && status.active:
 		// normal leader, do nothing
+		oc.failedStarts = 0
 	}
 
 	oc.log.Debug("exiting action with status and error", "status", status, "err", err)
@@ -965,44 +1045,182 @@ func (oc *OpConductor) stopSequencer() error {
 	return nil
 }
 
-func (oc *OpConductor) startSequencer() error {
-	ctx := context.Background()
+// isLocalCatchUpFailure reports whether err means this member's own op-node could not be brought
+// up to the unsafe head consensus committed. That is the only start failure another member might
+// not share, and so the only one worth moving leadership for.
+func isLocalCatchUpFailure(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return errors.Is(err, ErrUnsafeHeadMismatch)
+}
 
-	// When starting sequencer, we need to make sure that the current node has the latest unsafe head from the consensus protocol
-	// If not, then we wait for the unsafe head to catch up or gossip it to op-node manually from op-conductor.
+// startSequencer starts sequencing on the local op-node at the unsafe head consensus has
+// committed, first bringing op-node up to that head if it is behind.
+//
+// op-node only starts sequencing from a head it has already adopted, and adopting a posted
+// payload is asynchronous, so the catch-up is waited out here rather than by returning an error
+// into action's randomised retry backoff. That backoff is what used to leave the incoming
+// sequencer idle for up to two seconds and then have to build several blocks back to back,
+// which is exactly what strands the next leader behind the consensus unsafe head.
+func (oc *OpConductor) startSequencer() error {
+	// Catching up and getting the start accepted are two halves of the same wait, so they share
+	// one budget: action() is a single loop, and blocking it for two budgets in a row would queue
+	// leadership and health updates behind an attempt for twice as long.
+	budget := oc.unsafeHeadCatchUpTimeout
+	if !oc.healthy.Load() {
+		budget = oc.unhealthyUnsafeHeadCatchUpTimeout
+	}
+	// The RPCs get the whole budget while the waiting stops short of it, so the attempt fails with
+	// the heads involved rather than with a bare context deadline. A deadline is what bounds this:
+	// the select guards below honour shutdownCtx, but an RPC in flight does not, and startSequencer
+	// now makes dozens of them, so without one Stop() could block behind an unresponsive op-node.
+	ctx, cancel := context.WithTimeout(oc.shutdownCtx, budget)
+	defer cancel()
+	deadline := time.Now().Add(budget - budget/4)
+
 	unsafeInCons, unsafeInNode, err := oc.compareUnsafeHead(ctx)
-	// if there's a mismatch, try to post the unsafe head to op-node
-	if errors.Is(err, ErrUnsafeHeadMismatch) && uint64(unsafeInCons.ExecutionPayload.BlockNumber)-unsafeInNode.NumberU64() == 1 {
-		// tries to post the unsafe head to op-node when head is only 1 block behind (most likely due to gossip delay)
-		oc.log.Debug(
-			"posting unsafe head to op-node",
-			"consensus_num", uint64(unsafeInCons.ExecutionPayload.BlockNumber),
-			"consensus_hash", unsafeInCons.ExecutionPayload.BlockHash.Hex(),
-			"node_num", unsafeInNode.NumberU64(),
-			"node_hash", unsafeInNode.Hash().Hex(),
-		)
-		if err := oc.ctrl.PostUnsafePayload(ctx, unsafeInCons); err != nil {
-			oc.log.Error("failed to post unsafe head payload envelope to op-node", "err", err)
+	switch {
+	case errors.Is(err, ErrUnsafeHeadMismatch):
+		if err := oc.catchUpUnsafeHead(ctx, deadline, unsafeInCons, unsafeInNode); err != nil {
 			return err
 		}
-	} else if err != nil {
+	case err != nil:
 		return err
 	}
 
 	oc.log.Info("starting sequencer", "server", oc.cons.ServerID(), "leader", oc.leader.Load(), "healthy", oc.healthy.Load(), "active", oc.seqActive.Load())
-	err = oc.ctrl.StartSequencer(ctx, unsafeInCons.ExecutionPayload.BlockHash)
-	if err != nil {
-		// cannot directly compare using Errors.Is because the error is returned from an JSON RPC server which lost its type.
-		if !strings.Contains(err.Error(), driver.ErrSequencerAlreadyStarted.Error()) {
-			return fmt.Errorf("failed to start sequencer: %w", err)
-		} else {
-			oc.log.Warn("sequencer already started.", "err", err)
-		}
+	if err := oc.startSequencerAt(ctx, deadline, unsafeInCons.ExecutionPayload.BlockHash); err != nil {
+		return err
 	}
-	oc.metrics.RecordStartSequencer(err == nil)
 
 	oc.seqActive.Store(true)
 	return nil
+}
+
+// startSequencerAt asks op-node to start sequencing at head, which op-node only accepts once it
+// has adopted that head.
+//
+// op-node's sequencer tracks the adopted head from an asynchronous forkchoice update, so it can
+// still trail the execution client that catchUpUnsafeHead observed already holding head. That
+// rejection is retried until deadline: returning it instead would cost a full randomised action
+// backoff and leave the cluster with no sequencer for whole block times.
+func (oc *OpConductor) startSequencerAt(ctx context.Context, deadline time.Time, head common.Hash) error {
+	for {
+		err := oc.ctrl.StartSequencer(ctx, head)
+		// cannot directly compare using errors.Is because the error is returned from a JSON RPC server which lost its type.
+		if err != nil && strings.Contains(err.Error(), driver.ErrUnsafeHeadMismatch.Error()) {
+			if !time.Now().Before(deadline) {
+				// Tagged as a catch-up failure: op-node still refusing the head consensus
+				// committed after the whole budget is local to this member, so a leader that
+				// keeps landing here should hand over rather than retry itself forever.
+				return fmt.Errorf("%w: op-node would not start sequencing at %s in time: %w",
+					ErrUnsafeHeadMismatch, head, err)
+			}
+			oc.log.Warn("op-node has not adopted the head to sequence from yet, retrying", "head", head, "err", err)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(oc.startSequencerRetryInterval):
+			}
+			continue
+		}
+
+		oc.metrics.RecordStartSequencer(err == nil)
+		if err != nil {
+			if !strings.Contains(err.Error(), driver.ErrSequencerAlreadyStarted.Error()) {
+				return fmt.Errorf("failed to start sequencer: %w", err)
+			}
+			oc.log.Warn("sequencer already started.", "err", err)
+		}
+		return nil
+	}
+}
+
+// catchUpUnsafeHead brings the local op-node's unsafe head up to the head consensus committed,
+// and returns nil only once op-node reports it has actually adopted that head. Callers may not
+// start sequencing on any weaker signal: op-node rejects a start at a head it does not hold, and
+// starting anywhere else would orphan blocks consensus has already committed.
+//
+// Every cluster member applies every committed payload, so the payloads op-node is missing are
+// replayed straight from consensus instead of waiting for p2p gossip or L1 derivation.
+//
+// When the retained history no longer reaches back to op-node's head there is nothing to replay,
+// and all this can do is post the consensus head on its own. op-node queues a non-adjacent
+// payload and fills the gap itself, but that fill is driven by a ticker at 2 * BlockTime
+// (op-node/rollup/driver/driver.go), which outlasts this budget: the attempt is expected to time
+// out, and on a healthy leader for the retries to end in a leadership transfer. That is the right
+// outcome for a gap that wide — it is a sync problem, and another member is likely caught up
+// already — but it is a fallback, not a recovery path.
+func (oc *OpConductor) catchUpUnsafeHead(ctx context.Context, deadline time.Time, unsafeInCons *eth.ExecutionPayloadEnvelope, unsafeInNode eth.BlockInfo) error {
+	target := uint64(unsafeInCons.ExecutionPayload.BlockNumber)
+	nodeNum := unsafeInNode.NumberU64()
+	if nodeNum >= target {
+		// op-node is level with or ahead of the head consensus committed, on a different branch.
+		// Replaying payloads cannot resolve that, and neither can moving leadership: op-node
+		// commits a sealed block to consensus before it gossips it (Sequencer.onBuildSealed), so
+		// gossip cannot put one member's op-node ahead of consensus. Every reachable cause is
+		// cluster-wide — a stale or re-bootstrapped FSM, or every op-node advancing past a wedged
+		// FSM via L1 derivation — and round-robin transfer would then cycle the whole cluster,
+		// each member without a sequencer in turn. Retry in place and make it visible instead.
+		return fmt.Errorf("%w: op-node unsafe head %d (%s), consensus unsafe head %d (%s)",
+			ErrNodeAheadOfConsensus, nodeNum, unsafeInNode.Hash(), target, unsafeInCons.ExecutionPayload.BlockHash)
+	}
+
+	missing := oc.cons.UnsafePayloadsAfter(nodeNum)
+	// UnsafePayloadsAfter reads the FSM without a barrier while unsafeInCons came from a barrier
+	// read, so a payload applied between the two puts history past the target. Posting past it
+	// would step op-node's head over the head this attempt waits for, and the wait compares
+	// hashes exactly, so it would then time out reporting a head it had already passed.
+	for i, payload := range missing {
+		if uint64(payload.ExecutionPayload.BlockNumber) > target {
+			missing = missing[:i]
+			break
+		}
+	}
+	if len(missing) == 0 {
+		missing = []*eth.ExecutionPayloadEnvelope{unsafeInCons}
+	}
+	oc.log.Info("posting unsafe payloads to op-node",
+		"consensus_num", target,
+		"consensus_hash", unsafeInCons.ExecutionPayload.BlockHash,
+		"node_num", nodeNum,
+		"node_hash", unsafeInNode.Hash(),
+		"payloads", len(missing),
+	)
+	for _, payload := range missing {
+		if err := oc.ctrl.PostUnsafePayload(ctx, payload); err != nil {
+			return fmt.Errorf("failed to post unsafe payload %d to op-node: %w", uint64(payload.ExecutionPayload.BlockNumber), err)
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(oc.unsafeHeadCatchUpInterval):
+		}
+
+		latest, err := oc.ctrl.LatestUnsafeBlock(ctx)
+		if err != nil {
+			// The payloads are posted and the window still has time left, so a single failed read
+			// is no reason to abandon the attempt, let alone to count it towards a leadership
+			// transfer.
+			if time.Now().Before(deadline) {
+				oc.log.Warn("failed to read op-node unsafe head while catching up, retrying", "target", target, "err", err)
+				continue
+			}
+			return fmt.Errorf("failed to get latest unsafe block from EL while catching up to consensus unsafe head %d: %w", target, err)
+		}
+		if latest.Hash() == unsafeInCons.ExecutionPayload.BlockHash {
+			oc.log.Info("op-node caught up to consensus unsafe head", "num", target, "hash", latest.Hash())
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("%w: op-node did not adopt consensus unsafe head %d (%s) in time, op-node unsafe head is %d (%s)",
+				ErrUnsafeHeadMismatch, target, unsafeInCons.ExecutionPayload.BlockHash, latest.NumberU64(), latest.Hash())
+		}
+	}
 }
 
 func (oc *OpConductor) compareUnsafeHead(ctx context.Context) (*eth.ExecutionPayloadEnvelope, eth.BlockInfo, error) {

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	clientmocks "github.com/ethereum-optimism/optimism/op-conductor/client/mocks"
@@ -25,6 +26,7 @@ import (
 	healthmocks "github.com/ethereum-optimism/optimism/op-conductor/health/mocks"
 	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -122,6 +124,12 @@ func (s *OpConductorTestSuite) SetupTest() {
 	conductor, err := NewOpConductor(s.ctx, &s.cfg, s.log, s.metrics, s.version, s.ctrl, s.cons, s.hmon)
 	s.NoError(err)
 	conductor.retryBackoff = func() time.Duration { return 0 } // disable retry backoff for tests
+	// Poll for op-node adopting a posted payload quickly, and give up quickly, so tests that
+	// exercise a node which never catches up do not wait on the production timeout.
+	conductor.unsafeHeadCatchUpInterval = time.Millisecond
+	conductor.startSequencerRetryInterval = time.Millisecond
+	conductor.unsafeHeadCatchUpTimeout = 50 * time.Millisecond
+	conductor.unhealthyUnsafeHeadCatchUpTimeout = 50 * time.Millisecond
 	s.conductor = conductor
 
 	s.healthUpdateCh = make(chan error, 1)
@@ -141,6 +149,14 @@ func (s *OpConductorTestSuite) TearDownTest() {
 	s.cons.EXPECT().Shutdown().Return(nil)
 
 	if s.syncEnabled {
+		// Drop the retry the last failing action queued. Teardown hands the loop exactly one turn
+		// and then relies on it being inside loopAction's select when Stop cancels shutdownCtx: a
+		// pending action consumes that turn instead, leaving the loop parked on the next hand-off
+		// while Stop waits for it to exit.
+		select {
+		case <-s.conductor.actionCh:
+		default:
+		}
 		s.wg.Add(1)
 		s.next <- struct{}{}
 	}
@@ -295,7 +311,8 @@ func (s *OpConductorTestSuite) TestScenario1() {
 		active:  false,
 	}
 
-	// unsafe in consensus is different than unsafe in node.
+	// unsafe in consensus is 2 blocks ahead of unsafe in node, and consensus no longer retains
+	// the missing payloads, so op-node cannot be brought up to the consensus head here.
 	mockPayload := &eth.ExecutionPayloadEnvelope{
 		ExecutionPayload: &eth.ExecutionPayload{
 			BlockNumber: 3,
@@ -308,7 +325,9 @@ func (s *OpConductorTestSuite) TestScenario1() {
 	}
 	s.cons.EXPECT().TransferLeader().Return(nil)
 	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil).Times(1)
-	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil).Times(1)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(1)).Return(nil).Times(1)
+	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil)
+	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mockPayload).Return(nil).Times(1)
 
 	// become leader
 	s.updateLeaderStatusAndExecuteAction(true)
@@ -324,6 +343,7 @@ func (s *OpConductorTestSuite) TestScenario1() {
 		active:  false,
 	}, s.conductor.prevState)
 	s.cons.AssertNumberOfCalls(s.T(), "TransferLeader", 1)
+	s.ctrl.AssertNotCalled(s.T(), "StartSequencer", mock.Anything, mock.Anything)
 }
 
 // In this test, we have a follower that is not healthy and not sequencing, it becomes leader through election.
@@ -438,9 +458,9 @@ func (s *OpConductorTestSuite) TestScenario4() {
 		InfoHash: [32]byte{2, 3, 4},
 	}
 	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil).Times(1)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(1)).Return([]*eth.ExecutionPayloadEnvelope{mockPayload}).Times(1)
 	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil).Times(1)
 	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mockPayload).Return(errors.New("simulated PostUnsafePayload failure")).Times(1)
-	s.ctrl.EXPECT().StartSequencer(mock.Anything, mockBlockInfo.InfoHash).Return(nil).Times(1)
 
 	s.updateLeaderStatusAndExecuteAction(true)
 
@@ -453,10 +473,12 @@ func (s *OpConductorTestSuite) TestScenario4() {
 	s.ctrl.AssertNumberOfCalls(s.T(), "PostUnsafePayload", 1)
 	s.ctrl.AssertNotCalled(s.T(), "StartSequencer", mock.Anything, mock.Anything)
 
+	// The post succeeds on retry, and the sequencer is only started once op-node reports it has
+	// adopted the posted head: starting at a head op-node has not adopted is rejected by op-node.
+	node := newFakeOpNode(mockBlockInfo.InfoNum, mockBlockInfo.InfoHash)
 	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil).Times(1)
-	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil).Times(1)
-	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mockPayload).Return(nil).Times(1)
-	s.ctrl.EXPECT().StartSequencer(mock.Anything, mockPayload.ExecutionPayload.BlockHash).Return(nil).Times(1)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(1)).Return([]*eth.ExecutionPayloadEnvelope{mockPayload}).Times(1)
+	s.expectOpNode(node)
 
 	s.executeAction()
 
@@ -465,9 +487,10 @@ func (s *OpConductorTestSuite) TestScenario4() {
 	s.True(s.conductor.healthy.Load())
 	s.True(s.conductor.seqActive.Load())
 	s.cons.AssertNumberOfCalls(s.T(), "LatestUnsafePayload", 2)
-	s.ctrl.AssertNumberOfCalls(s.T(), "LatestUnsafeBlock", 2)
+	s.ctrl.AssertNumberOfCalls(s.T(), "LatestUnsafeBlock", 3)
 	s.ctrl.AssertNumberOfCalls(s.T(), "PostUnsafePayload", 2)
 	s.ctrl.AssertNumberOfCalls(s.T(), "StartSequencer", 1)
+	s.True(node.started, "op-node must have accepted the start at the head it adopted")
 }
 
 // In this test, we have a follower that is healthy and not sequencing, we send a unhealthy update to it and expect it to stay as follower and not start sequencing.
@@ -798,14 +821,10 @@ func (s *OpConductorTestSuite) TestFailureAndRetry4() {
 			BlockHash:   [32]byte{4, 5, 6},
 		},
 	}
-	mockBlockInfo := &testutils.MockBlockInfo{
-		InfoNum:  1,
-		InfoHash: [32]byte{1, 2, 3},
-	}
-	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil).Times(2)
-	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil).Times(2)
-	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mockPayload).Return(nil).Times(1)
-	s.ctrl.EXPECT().StartSequencer(mock.Anything, mockPayload.ExecutionPayload.BlockHash).Return(nil).Times(1)
+	node := newFakeOpNode(1, [32]byte{1, 2, 3})
+	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(1)).Return([]*eth.ExecutionPayloadEnvelope{mockPayload})
+	s.expectOpNode(node)
 
 	s.updateLeaderStatusAndExecuteAction(true)
 
@@ -818,9 +837,12 @@ func (s *OpConductorTestSuite) TestFailureAndRetry4() {
 		active:  false,
 	}, s.conductor.prevState)
 	s.cons.AssertNumberOfCalls(s.T(), "LatestUnsafePayload", 1)
-	s.ctrl.AssertNumberOfCalls(s.T(), "LatestUnsafeBlock", 1)
+	// Two reads: the initial comparison against consensus, then the poll that observes op-node
+	// adopting the posted payload.
+	s.ctrl.AssertNumberOfCalls(s.T(), "LatestUnsafeBlock", 2)
 	s.ctrl.AssertNumberOfCalls(s.T(), "PostUnsafePayload", 1)
 	s.ctrl.AssertNumberOfCalls(s.T(), "StartSequencer", 1)
+	s.Equal(uint64(2), node.head.InfoNum)
 
 	s.log.Info("4. stay unhealthy for a bit while catching up")
 	s.updateHealthStatusAndExecuteAction(health.ErrSequencerNotHealthy)
@@ -1186,4 +1208,486 @@ func (s *OpConductorTestSuite) TestRollupBoostPartialFailure() {
 	// Verify the expected actions were taken
 	s.ctrl.AssertNumberOfCalls(s.T(), "StopSequencer", 1)
 	s.cons.AssertNumberOfCalls(s.T(), "TransferLeader", 1)
+}
+
+// fakeOpNode models the two op-node behaviours that a conductor handing over sequencing has to
+// respect: a posted payload is not adopted the instant PostUnsafePayload returns, and op-node
+// refuses to start sequencing at a head it has not adopted.
+//
+// Adoption advances on any interaction with op-node other than a post, so a conductor that waits
+// converges however it chooses to observe op-node, but one that starts sequencing straight after
+// posting does not.
+type fakeOpNode struct {
+	head    *testutils.MockBlockInfo
+	pending []*eth.ExecutionPayloadEnvelope
+	started bool
+	// adoptPerInteraction is how many posted payloads op-node adopts per interaction: 0 models a
+	// node that never catches up, and more than 1 a node that can step over the head the
+	// conductor is waiting for between two observations.
+	adoptPerInteraction int
+	// startLag rejects this many starts at the already-adopted head, modelling op-node's
+	// sequencer learning the head from a forkchoice update that trails the execution client.
+	startLag int
+}
+
+func newFakeOpNode(number uint64, hash common.Hash) *fakeOpNode {
+	return &fakeOpNode{
+		head:                &testutils.MockBlockInfo{InfoNum: number, InfoHash: hash},
+		adoptPerInteraction: 1,
+	}
+}
+
+func (n *fakeOpNode) adopt() {
+	for range n.adoptPerInteraction {
+		if len(n.pending) == 0 || uint64(n.pending[0].ExecutionPayload.BlockNumber) != n.head.InfoNum+1 {
+			return
+		}
+		next := n.pending[0]
+		n.pending = n.pending[1:]
+		n.head = &testutils.MockBlockInfo{
+			InfoNum:  uint64(next.ExecutionPayload.BlockNumber),
+			InfoHash: next.ExecutionPayload.BlockHash,
+		}
+	}
+}
+
+func (n *fakeOpNode) latestUnsafeBlock(context.Context) (eth.BlockInfo, error) {
+	n.adopt()
+	return n.head, nil
+}
+
+func (n *fakeOpNode) postUnsafePayload(_ context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+	n.pending = append(n.pending, payload)
+	return nil
+}
+
+func (n *fakeOpNode) startSequencer(_ context.Context, head common.Hash) error {
+	n.adopt()
+	sequencerHead := n.head
+	if n.startLag > 0 {
+		n.startLag--
+		sequencerHead = &testutils.MockBlockInfo{InfoNum: n.head.InfoNum - 1, InfoHash: common.HexToHash("0x5741e")}
+	}
+	if head != sequencerHead.InfoHash {
+		// Mirrors sequencing.Sequencer.Start, which compares against the head it has adopted.
+		return fmt.Errorf("%w: head %s:%d, received %s", driver.ErrUnsafeHeadMismatch, sequencerHead.InfoHash, sequencerHead.InfoNum, head)
+	}
+	n.started = true
+	return nil
+}
+
+func (s *OpConductorTestSuite) expectOpNode(node *fakeOpNode) {
+	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).RunAndReturn(node.latestUnsafeBlock)
+	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mock.Anything).RunAndReturn(node.postUnsafePayload)
+	s.ctrl.EXPECT().StartSequencer(mock.Anything, mock.Anything).RunAndReturn(node.startSequencer)
+}
+
+func unsafePayload(number uint64) *eth.ExecutionPayloadEnvelope {
+	return &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: eth.Uint64Quantity(number),
+			Timestamp:   hexutil.Uint64(time.Now().Unix()),
+			BlockHash:   common.BigToHash(new(big.Int).SetUint64(number)),
+		},
+	}
+}
+
+// A new leader whose op-node is one block behind must not be told to start sequencing until
+// op-node has actually adopted the payload the conductor just posted. Starting straight after
+// PostUnsafePayload loses the race and costs a full action retry backoff, which is what leaves
+// the sequencer idle long enough to have to build several blocks at once when it does start.
+func (s *OpConductorTestSuite) TestStartSequencerWaitsForPostedPayloadToBeAdopted() {
+	s.enableSynchronization()
+
+	consensusHead := unsafePayload(12)
+	node := newFakeOpNode(11, unsafePayload(11).ExecutionPayload.BlockHash)
+	s.cons.EXPECT().LatestUnsafePayload().Return(consensusHead, nil)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(11)).Return([]*eth.ExecutionPayloadEnvelope{consensusHead})
+	s.expectOpNode(node)
+
+	s.updateLeaderStatusAndExecuteAction(true)
+
+	s.True(s.conductor.seqActive.Load(), "sequencing must be active after a single action")
+	s.True(node.started)
+	s.Equal(uint64(12), node.head.InfoNum)
+	s.ctrl.AssertNumberOfCalls(s.T(), "StartSequencer", 1)
+}
+
+// A new leader two or more blocks behind the consensus unsafe head used to be unrecoverable: the
+// payload post was skipped, startSequencer returned unsafe head mismatch, and the action loop
+// re-queued the identical failing action forever with no sequencer anywhere in the cluster.
+// Consensus retains the payloads, so they are replayed and the leader converges.
+func (s *OpConductorTestSuite) TestStartSequencerRecoversFromMultiBlockGap() {
+	s.enableSynchronization()
+
+	missing := []*eth.ExecutionPayloadEnvelope{unsafePayload(13), unsafePayload(14)}
+	node := newFakeOpNode(12, unsafePayload(12).ExecutionPayload.BlockHash)
+	s.cons.EXPECT().LatestUnsafePayload().Return(missing[1], nil)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(12)).Return(missing)
+	s.expectOpNode(node)
+
+	s.updateLeaderStatusAndExecuteAction(true)
+
+	s.True(s.conductor.seqActive.Load(), "sequencing must be active after a single action")
+	s.True(node.started)
+	s.Equal(uint64(14), node.head.InfoNum)
+	s.ctrl.AssertNumberOfCalls(s.T(), "PostUnsafePayload", 2)
+	s.ctrl.AssertNumberOfCalls(s.T(), "StartSequencer", 1)
+}
+
+// The execution client reporting the consensus unsafe head is not proof that op-node's sequencer
+// can start there: it learns the adopted head from a forkchoice update that can trail by an event
+// hop. That rejection must be retried in place, not turned into an action retry that idles the
+// cluster for a randomised backoff.
+func (s *OpConductorTestSuite) TestStartSequencerRetriesWhileOpNodeSequencerTrailsTheEL() {
+	s.enableSynchronization()
+
+	consensusHead := unsafePayload(12)
+	node := newFakeOpNode(12, consensusHead.ExecutionPayload.BlockHash)
+	node.startLag = 2
+	s.cons.EXPECT().LatestUnsafePayload().Return(consensusHead, nil)
+	s.expectOpNode(node)
+
+	s.updateLeaderStatusAndExecuteAction(true)
+
+	s.True(s.conductor.seqActive.Load(), "sequencing must be active after a single action")
+	s.True(node.started)
+	s.ctrl.AssertNumberOfCalls(s.T(), "StartSequencer", 3)
+	s.ctrl.AssertNotCalled(s.T(), "PostUnsafePayload", mock.Anything, mock.Anything)
+}
+
+// When the local op-node cannot be brought up to the consensus unsafe head at all, the cluster
+// must still converge on one sequencer. A healthy leader that keeps failing to start hands
+// leadership to a member that may be caught up instead of retrying itself forever.
+func (s *OpConductorTestSuite) TestStartSequencerTransfersLeadershipWhenItCannotConverge() {
+	s.enableSynchronization()
+
+	consensusHead := unsafePayload(14)
+	node := newFakeOpNode(12, unsafePayload(12).ExecutionPayload.BlockHash)
+	node.adoptPerInteraction = 0 // op-node never adopts what it is sent
+	s.cons.EXPECT().LatestUnsafePayload().Return(consensusHead, nil)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(12)).Return([]*eth.ExecutionPayloadEnvelope{unsafePayload(13), consensusHead})
+	s.expectOpNode(node)
+	s.cons.EXPECT().TransferLeader().Return(nil).Times(1)
+
+	s.updateLeaderStatusAndExecuteAction(true)
+	s.False(s.conductor.seqActive.Load())
+	s.True(s.conductor.leader.Load(), "must not give up leadership on the first failure")
+
+	for range maxFailedStarts - 1 {
+		s.executeAction()
+	}
+
+	s.False(s.conductor.leader.Load(), "leadership must be handed over once the leader cannot start")
+	s.False(s.conductor.seqActive.Load())
+	s.cons.AssertNumberOfCalls(s.T(), "TransferLeader", 1)
+	s.False(node.started)
+}
+
+// A transfer that fails must be retried on the next action. Zeroing the failed-start counter
+// before the transfer left a leader that could not hand over needing another maxFailedStarts
+// failed starts, and so several more block times with no sequencer in the cluster, before trying
+// again.
+func (s *OpConductorTestSuite) TestStartSequencerRetriesLeadershipTransferAfterItFails() {
+	s.enableSynchronization()
+
+	consensusHead := unsafePayload(14)
+	node := newFakeOpNode(13, unsafePayload(13).ExecutionPayload.BlockHash)
+	node.adoptPerInteraction = 0
+	s.cons.EXPECT().LatestUnsafePayload().Return(consensusHead, nil)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(13)).Return([]*eth.ExecutionPayloadEnvelope{consensusHead})
+	s.expectOpNode(node)
+	s.cons.EXPECT().TransferLeader().Return(errors.New("no healthy voter to transfer to")).Times(1)
+
+	s.updateLeaderStatusAndExecuteAction(true)
+	for range maxFailedStarts - 1 {
+		s.executeAction()
+	}
+	s.cons.AssertNumberOfCalls(s.T(), "TransferLeader", 1)
+	s.True(s.conductor.leader.Load(), "a failed transfer leaves this server the leader")
+
+	s.cons.EXPECT().TransferLeader().Return(nil).Times(1)
+	s.executeAction()
+
+	s.cons.AssertNumberOfCalls(s.T(), "TransferLeader", 2)
+	s.False(s.conductor.leader.Load())
+}
+
+// allowLeadershipTransfer permits TransferLeader and reports whether it was called, so that a
+// regression fails on an assertion rather than on an unexpected mock call.
+func (s *OpConductorTestSuite) allowLeadershipTransfer() *bool {
+	transferred := new(bool)
+	s.cons.EXPECT().TransferLeader().RunAndReturn(func() error {
+		*transferred = true
+		return nil
+	}).Maybe()
+	return transferred
+}
+
+// retryFailingActions drives the action loop the given number of times, which only works while
+// every action keeps failing and so keeps queueing the next one. It aborts as soon as leadership is
+// transferred: that is the assertion, and it is also the point past which a successful action would
+// leave the next iteration with nothing to run.
+func (s *OpConductorTestSuite) retryFailingActions(transferred *bool, actions int) {
+	for range actions {
+		s.Require().False(*transferred, "leadership must not be transferred")
+		s.executeAction()
+	}
+	s.Require().False(*transferred, "leadership must not be transferred")
+}
+
+// op-node being level with or ahead of the head consensus committed is not a local problem: a
+// sealed block reaches consensus before it is gossiped, so nothing can put one member's op-node
+// ahead of consensus without putting every member's there. Round-robin transfer would then cycle
+// the whole cluster, each member sequencer-less in turn, so this retries in place instead.
+func (s *OpConductorTestSuite) TestStartSequencerDoesNotTransferLeadershipWhenNodeIsAheadOfConsensus() {
+	s.enableSynchronization()
+
+	consensusHead := unsafePayload(14)
+	node := newFakeOpNode(15, unsafePayload(15).ExecutionPayload.BlockHash)
+	s.cons.EXPECT().LatestUnsafePayload().Return(consensusHead, nil)
+	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).RunAndReturn(node.latestUnsafeBlock)
+	transferred := s.allowLeadershipTransfer()
+
+	s.updateLeaderStatusAndExecuteAction(true)
+	s.retryFailingActions(transferred, 2*maxFailedStarts)
+
+	s.False(s.conductor.seqActive.Load())
+	s.True(s.conductor.leader.Load(), "leadership must stay put: every member sees the same thing")
+	s.ctrl.AssertNotCalled(s.T(), "PostUnsafePayload", mock.Anything, mock.Anything)
+	s.ctrl.AssertNotCalled(s.T(), "StartSequencer", mock.Anything, mock.Anything)
+}
+
+// A cluster that has committed nothing to consensus yet — freshly bootstrapped, or re-bootstrapped
+// — is in the same state on every member, so handing leadership over cannot help and only costs
+// the cluster a sequencer-less window per member.
+func (s *OpConductorTestSuite) TestStartSequencerDoesNotTransferLeadershipWithoutAConsensusHead() {
+	s.enableSynchronization()
+
+	s.cons.EXPECT().LatestUnsafePayload().Return(nil, nil)
+	transferred := s.allowLeadershipTransfer()
+
+	s.updateLeaderStatusAndExecuteAction(true)
+	s.retryFailingActions(transferred, 2*maxFailedStarts)
+
+	s.False(s.conductor.seqActive.Load())
+	s.True(s.conductor.leader.Load())
+}
+
+// A start abandoned because this conductor is shutting down must not hand leadership over on its
+// way out.
+func (s *OpConductorTestSuite) TestStartSequencerDoesNotTransferLeadershipOnCancelledContext() {
+	s.enableSynchronization()
+
+	s.cons.EXPECT().LatestUnsafePayload().Return(unsafePayload(14), nil)
+	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(nil, context.Canceled)
+	transferred := s.allowLeadershipTransfer()
+
+	s.updateLeaderStatusAndExecuteAction(true)
+	s.retryFailingActions(transferred, 2*maxFailedStarts)
+
+	s.False(s.conductor.seqActive.Load())
+	s.True(s.conductor.leader.Load())
+}
+
+// The retained history is read without a raft barrier while the consensus head comes from a
+// barrier read, so it can already run past the head this attempt is waiting for. Posting past the
+// target steps op-node's head over it, and the wait compares hashes exactly, so it would then
+// never see a match.
+func (s *OpConductorTestSuite) TestStartSequencerDoesNotReplayPastTheConsensusHead() {
+	s.enableSynchronization()
+
+	consensusHead := unsafePayload(13)
+	node := newFakeOpNode(11, unsafePayload(11).ExecutionPayload.BlockHash)
+	node.adoptPerInteraction = 3 // op-node can adopt everything it holds between two reads
+	s.cons.EXPECT().LatestUnsafePayload().Return(consensusHead, nil)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(11)).Return([]*eth.ExecutionPayloadEnvelope{
+		unsafePayload(12), consensusHead, unsafePayload(14),
+	})
+	s.expectOpNode(node)
+
+	s.updateLeaderStatusAndExecuteAction(true)
+
+	s.True(s.conductor.seqActive.Load(), "sequencing must be active after a single action")
+	s.True(node.started)
+	s.Equal(uint64(13), node.head.InfoNum, "op-node must not be pushed past the head being waited for")
+	s.ctrl.AssertNumberOfCalls(s.T(), "PostUnsafePayload", 2)
+}
+
+// The payloads are already posted and the window still has time left, so one failed head read must
+// not abandon the attempt — let alone count towards handing leadership over.
+func (s *OpConductorTestSuite) TestStartSequencerToleratesATransientHeadReadFailure() {
+	s.enableSynchronization()
+
+	consensusHead := unsafePayload(12)
+	node := newFakeOpNode(11, unsafePayload(11).ExecutionPayload.BlockHash)
+	s.cons.EXPECT().LatestUnsafePayload().Return(consensusHead, nil)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(11)).Return([]*eth.ExecutionPayloadEnvelope{consensusHead})
+	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mock.Anything).RunAndReturn(node.postUnsafePayload)
+	s.ctrl.EXPECT().StartSequencer(mock.Anything, mock.Anything).RunAndReturn(node.startSequencer)
+
+	reads := 0
+	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).RunAndReturn(func(ctx context.Context) (eth.BlockInfo, error) {
+		reads++
+		if reads == 2 {
+			return nil, errors.New("simulated EL read failure")
+		}
+		return node.latestUnsafeBlock(ctx)
+	})
+
+	s.updateLeaderStatusAndExecuteAction(true)
+
+	s.True(s.conductor.seqActive.Load(), "one failed read must not abandon the attempt")
+	s.True(node.started)
+	s.cons.AssertNotCalled(s.T(), "TransferLeader")
+}
+
+// A start rejected because op-node's sequencer has not caught up with its execution client is
+// retried on its own, slower interval: StartSequencer calls back into this conductor and then takes
+// the sequencer's own lock, so it must not be hammered at the rate of a cheap head read.
+func (s *OpConductorTestSuite) TestStartSequencerRetryUsesItsOwnInterval() {
+	s.enableSynchronization()
+
+	s.conductor.unsafeHeadCatchUpInterval = 0
+	s.conductor.startSequencerRetryInterval = 20 * time.Millisecond
+	s.conductor.unsafeHeadCatchUpTimeout = 5 * time.Second
+
+	consensusHead := unsafePayload(12)
+	node := newFakeOpNode(12, consensusHead.ExecutionPayload.BlockHash)
+	node.startLag = 3
+	s.cons.EXPECT().LatestUnsafePayload().Return(consensusHead, nil)
+	s.expectOpNode(node)
+
+	start := time.Now()
+	s.updateLeaderStatusAndExecuteAction(true)
+
+	s.True(s.conductor.seqActive.Load())
+	s.GreaterOrEqual(time.Since(start), 3*s.conductor.startSequencerRetryInterval,
+		"each rejected start must wait the start-retry interval, not the head-poll interval")
+	s.ctrl.AssertNumberOfCalls(s.T(), "StartSequencer", 4)
+}
+
+// An unhealthy leader's fallback is to hand leadership over, and its own op-node is the likely
+// reason a catch-up is slow, so it must not sit on the single action loop for the budget a healthy
+// leader would spend waiting on it.
+func (s *OpConductorTestSuite) TestStartSequencerBudgetsAnUnhealthyLeaderTighter() {
+	s.enableSynchronization() // leaves the action loop parked, so this drives startSequencer itself
+
+	s.conductor.unsafeHeadCatchUpTimeout = time.Minute
+	s.conductor.unhealthyUnsafeHeadCatchUpTimeout = 20 * time.Millisecond
+
+	consensusHead := unsafePayload(14)
+	node := newFakeOpNode(13, unsafePayload(13).ExecutionPayload.BlockHash)
+	node.adoptPerInteraction = 0 // op-node never adopts what it is sent
+	s.cons.EXPECT().LatestUnsafePayload().Return(consensusHead, nil)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(13)).Return([]*eth.ExecutionPayloadEnvelope{consensusHead})
+	s.expectOpNode(node)
+
+	s.conductor.healthy.Store(false)
+	start := time.Now()
+	err := s.conductor.startSequencer()
+	elapsed := time.Since(start)
+
+	s.ErrorIs(err, ErrUnsafeHeadMismatch)
+	s.Less(elapsed, 10*time.Second, "an unhealthy leader must not wait out the healthy budget")
+	s.GreaterOrEqual(elapsed, s.conductor.unhealthyUnsafeHeadCatchUpTimeout/2,
+		"but it must still give op-node its own budget")
+}
+
+// Catching up and getting the start accepted are two halves of the same wait and must share one
+// budget: action() is a single loop, so two budgets in a row is twice as long with leadership and
+// health updates queued behind it.
+func (s *OpConductorTestSuite) TestStartSequencerSharesOneBudgetWithTheCatchUp() {
+	s.enableSynchronization() // leaves the action loop parked, so this drives startSequencer itself
+
+	const budget = 400 * time.Millisecond
+	s.conductor.unsafeHeadCatchUpTimeout = budget
+	s.conductor.unsafeHeadCatchUpInterval = 5 * time.Millisecond
+	s.conductor.startSequencerRetryInterval = 5 * time.Millisecond
+
+	consensusHead := unsafePayload(12)
+	behind := &testutils.MockBlockInfo{InfoNum: 11, InfoHash: unsafePayload(11).ExecutionPayload.BlockHash}
+	caughtUp := &testutils.MockBlockInfo{InfoNum: 12, InfoHash: consensusHead.ExecutionPayload.BlockHash}
+	// op-node's execution client spends most of the budget adopting the payload, and op-node's
+	// sequencer never catches up with it afterwards. The start gets what is left of the budget.
+	adopted := time.Now().Add(280 * time.Millisecond)
+
+	s.cons.EXPECT().LatestUnsafePayload().Return(consensusHead, nil)
+	s.cons.EXPECT().UnsafePayloadsAfter(uint64(11)).Return([]*eth.ExecutionPayloadEnvelope{consensusHead})
+	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mock.Anything).Return(nil)
+	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).RunAndReturn(func(context.Context) (eth.BlockInfo, error) {
+		if time.Now().Before(adopted) {
+			return behind, nil
+		}
+		return caughtUp, nil
+	})
+	s.ctrl.EXPECT().StartSequencer(mock.Anything, mock.Anything).
+		Return(fmt.Errorf("%w: head 11, received 12", driver.ErrUnsafeHeadMismatch))
+
+	start := time.Now()
+	err := s.conductor.startSequencer()
+
+	s.ErrorIs(err, ErrUnsafeHeadMismatch)
+	s.Less(time.Since(start), budget+budget/8, "catch-up and start must share one budget, not take one each")
+}
+
+// The select guards honour shutdownCtx but an RPC in flight does not, and startSequencer makes
+// dozens of them, so the attempt needs a deadline of its own or an unresponsive op-node wedges the
+// action loop.
+func (s *OpConductorTestSuite) TestStartSequencerBoundsItsRPCs() {
+	s.enableSynchronization() // leaves the action loop parked, so this drives startSequencer itself
+
+	s.conductor.unsafeHeadCatchUpTimeout = 50 * time.Millisecond
+	s.cons.EXPECT().LatestUnsafePayload().Return(unsafePayload(12), nil)
+	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).RunAndReturn(func(ctx context.Context) (eth.BlockInfo, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- s.conductor.startSequencer() }()
+
+	select {
+	case err := <-done:
+		s.ErrorIs(err, context.DeadlineExceeded)
+	case <-time.After(30 * time.Second):
+		s.Fail("startSequencer left an RPC unbounded")
+	}
+}
+
+// Those RPCs also have to be cancellable, so Stop() cannot block behind one: stopSequencer already
+// passes shutdownCtx for the same reason, and issue #22094's other half is an unbounded shutdown.
+//
+// Outside the suite: cancelling shutdownCtx retires the control loop, which the suite's action
+// synchronisation needs alive.
+func TestStartSequencerRPCsFollowShutdown(t *testing.T) {
+	cfg := mockConfig(t)
+	ctrl := &clientmocks.SequencerControl{}
+	cons := &consensusmocks.Consensus{}
+	cons.EXPECT().ServerID().Return("SequencerA").Maybe()
+	cons.EXPECT().LatestUnsafePayload().Return(unsafePayload(12), nil)
+	ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).RunAndReturn(func(ctx context.Context) (eth.BlockInfo, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	oc, err := NewOpConductor(context.Background(), &cfg, testlog.Logger(t, log.LevelDebug),
+		&metrics.NoopMetricsImpl{}, "v0.0.1", ctrl, cons, &healthmocks.HealthMonitor{})
+	require.NoError(t, err)
+	// Start() would also bring up the RPC server and the control loop; only the shutdown context
+	// matters here.
+	oc.shutdownCtx, oc.shutdownCancel = context.WithCancel(context.Background())
+	oc.healthy.Store(true)
+	oc.unsafeHeadCatchUpTimeout = time.Hour
+
+	done := make(chan error, 1)
+	go func() { done <- oc.startSequencer() }()
+	oc.shutdownCancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "startSequencer did not derive its context from shutdownCtx")
+	}
 }

--- a/op-conductor/consensus/iface.go
+++ b/op-conductor/consensus/iface.go
@@ -74,6 +74,11 @@ type Consensus interface {
 	CommitUnsafePayload(payload *eth.ExecutionPayloadEnvelope) error
 	// LatestUnsafePayload returns the latest unsafe payload from FSM in a strongly consistent fashion.
 	LatestUnsafePayload() (*eth.ExecutionPayloadEnvelope, error)
+	// UnsafePayloadsAfter returns the committed unsafe payloads with a block number greater than
+	// number, each the parent of the next up to the latest unsafe payload. It returns nil when the
+	// retained history no longer reaches back that far, for example after a restart. The retained
+	// payloads are a local cache rather than replicated state.
+	UnsafePayloadsAfter(number uint64) []*eth.ExecutionPayloadEnvelope
 
 	// Shutdown shuts down the consensus protocol client.
 	Shutdown() error

--- a/op-conductor/consensus/mocks/Consensus.go
+++ b/op-conductor/consensus/mocks/Consensus.go
@@ -735,3 +735,50 @@ func (_c *Consensus_TransferLeaderTo_Call) RunAndReturn(run func(id string, addr
 	_c.Call.Return(run)
 	return _c
 }
+
+// UnsafePayloadsAfter provides a mock function for the type Consensus
+func (_mock *Consensus) UnsafePayloadsAfter(number uint64) []*eth.ExecutionPayloadEnvelope {
+	ret := _mock.Called(number)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UnsafePayloadsAfter")
+	}
+
+	var r0 []*eth.ExecutionPayloadEnvelope
+	if returnFunc, ok := ret.Get(0).(func(uint64) []*eth.ExecutionPayloadEnvelope); ok {
+		r0 = returnFunc(number)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*eth.ExecutionPayloadEnvelope)
+		}
+	}
+	return r0
+}
+
+// Consensus_UnsafePayloadsAfter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UnsafePayloadsAfter'
+type Consensus_UnsafePayloadsAfter_Call struct {
+	*mock.Call
+}
+
+// UnsafePayloadsAfter is a helper method to define mock.On call
+//   - number
+func (_e *Consensus_Expecter) UnsafePayloadsAfter(number interface{}) *Consensus_UnsafePayloadsAfter_Call {
+	return &Consensus_UnsafePayloadsAfter_Call{Call: _e.mock.On("UnsafePayloadsAfter", number)}
+}
+
+func (_c *Consensus_UnsafePayloadsAfter_Call) Run(run func(number uint64)) *Consensus_UnsafePayloadsAfter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(uint64))
+	})
+	return _c
+}
+
+func (_c *Consensus_UnsafePayloadsAfter_Call) Return(executionPayloadEnvelopes []*eth.ExecutionPayloadEnvelope) *Consensus_UnsafePayloadsAfter_Call {
+	_c.Call.Return(executionPayloadEnvelopes)
+	return _c
+}
+
+func (_c *Consensus_UnsafePayloadsAfter_Call) RunAndReturn(run func(number uint64) []*eth.ExecutionPayloadEnvelope) *Consensus_UnsafePayloadsAfter_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/op-conductor/consensus/raft.go
+++ b/op-conductor/consensus/raft.go
@@ -19,6 +19,11 @@ import (
 
 const defaultTimeout = 5 * time.Second
 
+// defaultShutdownTimeout bounds each stage of Shutdown. raft.Shutdown() only resolves once
+// raft's own goroutines have exited and has no deadline of its own, so a member that has lost
+// quorum can keep it pending indefinitely.
+const defaultShutdownTimeout = 10 * time.Second
+
 var _ Consensus = (*RaftConsensus)(nil)
 
 // RaftConsensus implements Consensus using raft protocol.
@@ -35,6 +40,13 @@ type RaftConsensus struct {
 	advertisedAddr string
 
 	unsafeTracker *unsafeHeadTracker
+
+	// shutdownTimeout bounds how long Shutdown waits for raft, and then for raft again after
+	// the transport has been closed to unblock it.
+	shutdownTimeout time.Duration
+	// shutdownRaft is rc.r.Shutdown. It is a field so that Shutdown does not have to trust raft
+	// to ever come back, and so tests can exercise the case where it does not.
+	shutdownRaft func() raft.Future
 }
 
 type RaftConsensusConfig struct {
@@ -181,12 +193,14 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 	}
 
 	return &RaftConsensus{
-		log:           log,
-		r:             r,
-		serverID:      raft.ServerID(cfg.ServerID),
-		unsafeTracker: fsm,
-		rollupCfg:     cfg.RollupCfg,
-		transport:     transport,
+		log:             log,
+		r:               r,
+		serverID:        raft.ServerID(cfg.ServerID),
+		unsafeTracker:   fsm,
+		rollupCfg:       cfg.RollupCfg,
+		transport:       transport,
+		shutdownTimeout: defaultShutdownTimeout,
+		shutdownRaft:    r.Shutdown,
 	}, err
 }
 
@@ -293,12 +307,54 @@ func (rc *RaftConsensus) TransferLeaderTo(id string, addr string) error {
 }
 
 // Shutdown implements Consensus, it shuts down the consensus protocol client.
+//
+// raft.Shutdown() returns a future whose Error() blocks in waitShutdown() until raft's internal
+// goroutines have exited, with no deadline of its own, so a member that has lost quorum can leave
+// it pending for as long as the process lives. Callers shut their components down in sequence, so
+// blocking here strands everything after it: in CI this held a whole test binary for 19 minutes
+// until the package timeout killed it.
+//
+// raft does close the transport itself, but only once waitShutdown has returned
+// (hashicorp/raft future.go shutdownFuture.Error), which is precisely what is stuck. So when we
+// give up we close it ourselves: that drops the listener and any in-flight peer connections
+// raft's goroutines may be waiting on, which also gives raft a second chance to unwind.
+// NetworkTransport.Close is idempotent, so raft closing it again later is harmless.
 func (rc *RaftConsensus) Shutdown() error {
-	if err := rc.r.Shutdown().Error(); err != nil {
-		rc.log.Error("failed to shutdown raft", "err", err)
-		return err
+	stopped := make(chan error, 1)
+	go func() {
+		stopped <- rc.shutdownRaft().Error()
+	}()
+
+	err, ok := awaitShutdown(stopped, rc.shutdownTimeout)
+	if !ok {
+		rc.log.Warn("raft is taking too long to shut down, closing transport to unblock it",
+			"waited", rc.shutdownTimeout)
+		// NetworkTransport.Close only ever returns nil.
+		_ = rc.transport.Close()
+
+		if err, ok = awaitShutdown(stopped, rc.shutdownTimeout); !ok {
+			err = fmt.Errorf("raft did not shut down within %s", 2*rc.shutdownTimeout)
+		}
 	}
-	return nil
+
+	if err != nil {
+		rc.log.Error("failed to shutdown raft", "err", err)
+	}
+	return err
+}
+
+// awaitShutdown reports whether stopped produced a result within timeout, along with whatever
+// error it carried.
+func awaitShutdown(stopped <-chan error, timeout time.Duration) (err error, ok bool) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-stopped:
+		return err, true
+	case <-timer.C:
+		return nil, false
+	}
 }
 
 // CommitUnsafePayload implements Consensus, it commits latest unsafe payload to the cluster FSM in a strongly consistent fashion.

--- a/op-conductor/consensus/raft.go
+++ b/op-conductor/consensus/raft.go
@@ -328,6 +328,12 @@ func (rc *RaftConsensus) LatestUnsafePayload() (*eth.ExecutionPayloadEnvelope, e
 	return rc.unsafeTracker.UnsafeHead(), nil
 }
 
+// UnsafePayloadsAfter implements Consensus. It reads local FSM state without a barrier, so
+// pair it with LatestUnsafePayload when the range has to line up with a consistent read.
+func (rc *RaftConsensus) UnsafePayloadsAfter(number uint64) []*eth.ExecutionPayloadEnvelope {
+	return rc.unsafeTracker.UnsafePayloadsAfter(number)
+}
+
 // ClusterMembership implements Consensus, it returns the current cluster membership configuration.
 func (rc *RaftConsensus) ClusterMembership() (*ClusterMembership, error) {
 	var future raft.ConfigurationFuture

--- a/op-conductor/consensus/raft_fsm.go
+++ b/op-conductor/consensus/raft_fsm.go
@@ -14,11 +14,38 @@ import (
 
 var _ raft.FSM = (*unsafeHeadTracker)(nil)
 
+const (
+	// maxRetainedUnsafePayloads bounds the payload history every member keeps for bringing its
+	// own op-node up to the consensus unsafe head. A leadership handover only ever leaves a node
+	// a few blocks behind; a larger gap is a real sync problem that leader transfer, not payload
+	// replay, has to resolve.
+	maxRetainedUnsafePayloads = 16
+	// maxRetainedUnsafePayloadsMemory bounds that same history by size, because a payload's
+	// footprint is dominated by its transactions: 16 calldata-heavy blocks on a high gas limit
+	// chain would otherwise be tens of megabytes of steady-state RSS in a sidecar. op-node bounds
+	// its own unsafe payload buffer the same way.
+	maxRetainedUnsafePayloadsMemory = 64 * 1024 * 1024
+	// retainedPayloadFixedCost approximates everything in a payload other than its transaction
+	// calldata, and retainedPayloadTxOverhead the per-transaction slice header. Both mirror
+	// op-node's payloadMemSize.
+	retainedPayloadFixedCost  = 1000
+	retainedPayloadTxOverhead = 24
+)
+
 // unsafeHeadTracker implements raft.FSM for storing unsafe head payload into raft consensus layer.
 type unsafeHeadTracker struct {
 	log        log.Logger
 	mtx        sync.RWMutex
 	unsafeHead *eth.ExecutionPayloadEnvelope
+
+	// retained holds the most recently applied payloads, each the parent of the next, ending at
+	// unsafeHead. Every member applies every committed payload, so this gives each conductor
+	// the blocks its own op-node is missing after a handover without waiting for p2p gossip
+	// or L1 derivation. It is a local cache, not replicated state: it is left out of
+	// snapshots, and a restarted or restored member simply starts with no history.
+	retained []*eth.ExecutionPayloadEnvelope
+	// retainedSize is the approximate memory footprint of retained, see retainedPayloadSize.
+	retainedSize uint64
 }
 
 func NewUnsafeHeadTracker(log log.Logger) *unsafeHeadTracker {
@@ -46,6 +73,7 @@ func (t *unsafeHeadTracker) Apply(l *raft.Log) interface{} {
 	defer t.mtx.Unlock()
 	t.log.Debug("applying new unsafe head", "number", uint64(data.ExecutionPayload.BlockNumber), "hash", data.ExecutionPayload.BlockHash.Hex())
 	if t.unsafeHead == nil || t.unsafeHead.ExecutionPayload.BlockNumber < data.ExecutionPayload.BlockNumber {
+		t.retain(data)
 		t.unsafeHead = data
 	}
 
@@ -73,6 +101,9 @@ func (t *unsafeHeadTracker) Restore(snapshot io.ReadCloser) error {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	t.unsafeHead = data
+	clear(t.retained)
+	t.retained = t.retained[:0]
+	t.retainedSize = 0
 	return nil
 }
 
@@ -92,6 +123,64 @@ func (t *unsafeHeadTracker) UnsafeHead() *eth.ExecutionPayloadEnvelope {
 	defer t.mtx.RUnlock()
 
 	return t.unsafeHead
+}
+
+// retain appends payload to the gap-fill history. A payload that is not a direct child of the
+// last retained one (after a restart, a restore, or a competing block at the same height being
+// dropped by Apply) discards the history rather than leaving a hole, or a fork, that a replay
+// could not fill.
+//
+// Callers must hold t.mtx.
+func (t *unsafeHeadTracker) retain(payload *eth.ExecutionPayloadEnvelope) {
+	last := len(t.retained) - 1
+	if last < 0 || !isChildOf(t.retained[last], payload) {
+		clear(t.retained)
+		t.retained = append(t.retained[:0], payload)
+		t.retainedSize = retainedPayloadSize(payload)
+		return
+	}
+
+	t.retained = append(t.retained, payload)
+	t.retainedSize += retainedPayloadSize(payload)
+	// Drop from the front until the history is back inside both bounds, keeping the newest
+	// payload whatever its size: it is the one a handover is most likely to need.
+	for len(t.retained) > 1 && (len(t.retained) > maxRetainedUnsafePayloads || t.retainedSize > maxRetainedUnsafePayloadsMemory) {
+		t.retainedSize -= retainedPayloadSize(t.retained[0])
+		n := copy(t.retained, t.retained[1:])
+		t.retained[n] = nil
+		t.retained = t.retained[:n]
+	}
+}
+
+func isChildOf(parent, child *eth.ExecutionPayloadEnvelope) bool {
+	return parent.ExecutionPayload.BlockNumber+1 == child.ExecutionPayload.BlockNumber &&
+		parent.ExecutionPayload.BlockHash == child.ExecutionPayload.ParentHash
+}
+
+// retainedPayloadSize approximates a payload's memory footprint, which is dominated by its
+// transaction calldata. Mirrors op-node's payloadMemSize.
+func retainedPayloadSize(payload *eth.ExecutionPayloadEnvelope) uint64 {
+	size := uint64(retainedPayloadFixedCost)
+	for _, tx := range payload.ExecutionPayload.Transactions {
+		size += uint64(len(tx)) + retainedPayloadTxOverhead
+	}
+	return size
+}
+
+// UnsafePayloadsAfter returns the retained payloads with a block number greater than number, each
+// the parent of the next up to the latest unsafe payload, or nil when the history no longer
+// reaches back that far.
+func (t *unsafeHeadTracker) UnsafePayloadsAfter(number uint64) []*eth.ExecutionPayloadEnvelope {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+
+	for i, payload := range t.retained {
+		if uint64(payload.ExecutionPayload.BlockNumber) == number+1 {
+			// Copy: Apply mutates the backing array in place.
+			return append([]*eth.ExecutionPayloadEnvelope(nil), t.retained[i:]...)
+		}
+	}
+	return nil
 }
 
 var _ raft.FSMSnapshot = (*snapshot)(nil)

--- a/op-conductor/consensus/raft_fsm_test.go
+++ b/op-conductor/consensus/raft_fsm_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -68,6 +69,142 @@ func TestUnsafeHeadTracker(t *testing.T) {
 		err = tracker.Restore(mrc)
 		require.NoError(t, err)
 		require.Equal(t, hexutil.Uint64(333), tracker.unsafeHead.ExecutionPayload.BlockNumber)
+	})
+}
+
+// TestUnsafeHeadTrackerRetainsPayloads covers the payload history every member keeps so its
+// conductor can bring its own op-node up to the consensus unsafe head across a multi-block gap.
+func TestUnsafeHeadTrackerRetainsPayloads(t *testing.T) {
+	// Blocks are chained by hash so a retained payload really is the child of its predecessor.
+	// branch distinguishes competing blocks at the same height.
+	hashOf := func(blockNum uint64, branch byte) common.Hash {
+		return common.BigToHash(new(big.Int).SetUint64(blockNum<<8 | uint64(branch)))
+	}
+	payloadOn := func(blockNum uint64, branch, parentBranch byte) *eth.ExecutionPayloadEnvelope {
+		payload := createPayloadEnvelope(blockNum)
+		payload.ExecutionPayload.BlockHash = hashOf(blockNum, branch)
+		payload.ExecutionPayload.ParentHash = hashOf(blockNum-1, parentBranch)
+		return payload
+	}
+	applyOn := func(t *testing.T, tracker *unsafeHeadTracker, blockNum uint64, branch, parentBranch byte) {
+		var buf bytes.Buffer
+		_, err := payloadOn(blockNum, branch, parentBranch).MarshalSSZ(&buf)
+		require.NoError(t, err)
+		require.Nil(t, tracker.Apply(&raft.Log{Data: buf.Bytes()}))
+	}
+	apply := func(t *testing.T, tracker *unsafeHeadTracker, blockNum uint64) {
+		applyOn(t, tracker, blockNum, 0, 0)
+	}
+	numbers := func(payloads []*eth.ExecutionPayloadEnvelope) []uint64 {
+		nums := make([]uint64, len(payloads))
+		for i, payload := range payloads {
+			nums[i] = uint64(payload.ExecutionPayload.BlockNumber)
+		}
+		return nums
+	}
+	newTracker := func(t *testing.T) *unsafeHeadTracker {
+		return NewUnsafeHeadTracker(testlog.Logger(t, log.LevelDebug))
+	}
+
+	t.Run("returns the contiguous suffix after a block number", func(t *testing.T) {
+		tracker := newTracker(t)
+		for num := uint64(10); num <= 14; num++ {
+			apply(t, tracker, num)
+		}
+
+		require.Equal(t, []uint64{13, 14}, numbers(tracker.UnsafePayloadsAfter(12)))
+		require.Equal(t, []uint64{11, 12, 13, 14}, numbers(tracker.UnsafePayloadsAfter(10)))
+		require.Empty(t, tracker.UnsafePayloadsAfter(14), "nothing is missing at the head")
+		for _, payload := range tracker.UnsafePayloadsAfter(10) {
+			require.Equal(t, hashOf(uint64(payload.ExecutionPayload.BlockNumber)-1, 0), payload.ExecutionPayload.ParentHash,
+				"replayed payloads must chain")
+		}
+	})
+
+	t.Run("returns nothing when the history does not reach back", func(t *testing.T) {
+		tracker := newTracker(t)
+		apply(t, tracker, 14)
+
+		require.Empty(t, tracker.UnsafePayloadsAfter(12), "block 13 was never applied here")
+		require.Equal(t, []uint64{14}, numbers(tracker.UnsafePayloadsAfter(13)))
+	})
+
+	t.Run("drops the history on a discontinuity", func(t *testing.T) {
+		tracker := newTracker(t)
+		apply(t, tracker, 10)
+		apply(t, tracker, 11)
+		apply(t, tracker, 20)
+
+		require.Empty(t, tracker.UnsafePayloadsAfter(10), "history must not span the skipped range")
+		require.Equal(t, []uint64{20}, numbers(tracker.UnsafePayloadsAfter(19)))
+	})
+
+	t.Run("bounds the retained history", func(t *testing.T) {
+		tracker := newTracker(t)
+		last := uint64(maxRetainedUnsafePayloads * 3)
+		for num := uint64(1); num <= last; num++ {
+			apply(t, tracker, num)
+		}
+
+		require.Len(t, tracker.retained, maxRetainedUnsafePayloads)
+		require.Len(t, tracker.UnsafePayloadsAfter(last-maxRetainedUnsafePayloads), maxRetainedUnsafePayloads)
+		require.Empty(t, tracker.UnsafePayloadsAfter(last-maxRetainedUnsafePayloads-1))
+	})
+
+	t.Run("ignores payloads that do not advance the head", func(t *testing.T) {
+		tracker := newTracker(t)
+		apply(t, tracker, 10)
+		apply(t, tracker, 11)
+		apply(t, tracker, 11)
+
+		require.Equal(t, []uint64{11}, numbers(tracker.UnsafePayloadsAfter(10)))
+	})
+
+	// Apply discards a competing block at a height it has already seen, so the next height on the
+	// new branch is number-contiguous with the retained tail while chaining onto the block that
+	// was discarded. Replaying that range would hand op-node payloads it cannot insert, so the
+	// history has to be reset instead.
+	t.Run("drops the history when the chain switches branch", func(t *testing.T) {
+		tracker := newTracker(t)
+		apply(t, tracker, 10)
+		apply(t, tracker, 11)
+		applyOn(t, tracker, 11, 1, 0)
+		applyOn(t, tracker, 12, 1, 1)
+
+		require.Equal(t, hashOf(12, 1), tracker.UnsafeHead().ExecutionPayload.BlockHash)
+		require.Empty(t, tracker.UnsafePayloadsAfter(9), "history must not span the branch change")
+		require.Empty(t, tracker.UnsafePayloadsAfter(10))
+		require.Equal(t, []uint64{12}, numbers(tracker.UnsafePayloadsAfter(11)))
+	})
+
+	t.Run("bounds the retained history by size", func(t *testing.T) {
+		tracker := newTracker(t)
+		// One shared backing array: only the reported length matters, and a payload big enough to
+		// make the byte bound bite is too big to allocate once per block here.
+		calldata := make([]byte, maxRetainedUnsafePayloadsMemory/4)
+		for num := uint64(10); num <= 15; num++ {
+			payload := payloadOn(num, 0, 0)
+			payload.ExecutionPayload.Transactions = []eth.Data{calldata}
+			tracker.retain(payload)
+		}
+
+		require.LessOrEqual(t, tracker.retainedSize, uint64(maxRetainedUnsafePayloadsMemory))
+		require.Less(t, len(tracker.retained), maxRetainedUnsafePayloads,
+			"the size bound must bite long before the count bound on calldata-heavy blocks")
+		require.NotEmpty(t, tracker.retained, "the newest payload is always retained")
+	})
+
+	t.Run("clears the history on restore", func(t *testing.T) {
+		tracker := newTracker(t)
+		apply(t, tracker, 10)
+		apply(t, tracker, 11)
+
+		mrc, err := NewMockReadCloser(createPayloadEnvelope(11))
+		require.NoError(t, err)
+		require.NoError(t, tracker.Restore(mrc))
+
+		require.Empty(t, tracker.retained)
+		require.Empty(t, tracker.UnsafePayloadsAfter(10))
 	})
 }
 

--- a/op-conductor/consensus/raft_test.go
+++ b/op-conductor/consensus/raft_test.go
@@ -1,6 +1,8 @@
 package consensus
 
 import (
+	"errors"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -9,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -84,4 +87,76 @@ func TestCommitAndRead(t *testing.T) {
 	unsafeHead, err := cons.LatestUnsafePayload()
 	require.NoError(t, err)
 	require.Equal(t, payload, unsafeHead)
+}
+
+// blockedFuture stands in for the future raft.Shutdown() returns when raft's internal
+// goroutines never exit.
+type blockedFuture struct {
+	released chan struct{}
+}
+
+func (f *blockedFuture) Error() error {
+	<-f.released
+	return nil
+}
+
+func newRaftConsensusForTest(t *testing.T) *RaftConsensus {
+	now := uint64(time.Now().Unix())
+	cons, err := NewRaftConsensus(testlog.Logger(t, log.LevelInfo), &RaftConsensusConfig{
+		ServerID:           "SequencerA",
+		ListenPort:         0,
+		ListenAddr:         "127.0.0.1",
+		StorageDir:         t.TempDir(),
+		Bootstrap:          true,
+		RollupCfg:          &rollup.Config{CanyonTime: &now},
+		SnapshotInterval:   120 * time.Second,
+		SnapshotThreshold:  10240,
+		TrailingLogs:       8192,
+		HeartbeatTimeout:   1000 * time.Millisecond,
+		LeaderLeaseTimeout: 500 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	return cons
+}
+
+// Shutdown must not outlive its budget when raft never reports that it has stopped, and it must
+// close the transport itself in that case — raft only closes it after the wait we gave up on.
+func TestShutdownGivesUpOnRaft(t *testing.T) {
+	cons := newRaftConsensusForTest(t)
+	addr := string(cons.transport.LocalAddr())
+
+	released := make(chan struct{})
+	t.Cleanup(func() { close(released) })
+	cons.shutdownRaft = func() raft.Future { return &blockedFuture{released: released} }
+	cons.shutdownTimeout = 50 * time.Millisecond
+
+	done := make(chan error, 1)
+	go func() { done <- cons.Shutdown() }()
+
+	select {
+	case err := <-done:
+		require.ErrorContains(t, err, "raft did not shut down within 100ms")
+	case <-time.After(30 * time.Second):
+		t.Fatal("Shutdown blocked on raft instead of giving up")
+	}
+
+	// The transport is closed even though raft never finished, so nothing is left listening.
+	_, err := net.DialTimeout("tcp", addr, time.Second)
+	require.Error(t, err, "raft transport should no longer be listening on %s", addr)
+}
+
+func TestAwaitShutdown(t *testing.T) {
+	t.Run("reports the error raft returned", func(t *testing.T) {
+		stopped := make(chan error, 1)
+		stopped <- errors.New("boom")
+		err, ok := awaitShutdown(stopped, time.Minute)
+		require.True(t, ok)
+		require.ErrorContains(t, err, "boom")
+	})
+
+	t.Run("gives up when nothing arrives", func(t *testing.T) {
+		err, ok := awaitShutdown(make(chan error), time.Millisecond)
+		require.False(t, ok)
+		require.NoError(t, err)
+	})
 }

--- a/op-node/rollup/driver/constants.go
+++ b/op-node/rollup/driver/constants.go
@@ -6,4 +6,5 @@ import "github.com/ethereum-optimism/optimism/op-node/rollup/sequencing"
 var (
 	ErrSequencerAlreadyStarted = sequencing.ErrSequencerAlreadyStarted
 	ErrSequencerAlreadyStopped = sequencing.ErrSequencerAlreadyStopped
+	ErrUnsafeHeadMismatch      = sequencing.ErrUnsafeHeadMismatch
 )

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -27,6 +27,10 @@ const defaultSealingDuration = 50 * time.Millisecond
 var (
 	ErrSequencerAlreadyStarted = errors.New("sequencer already running")
 	ErrSequencerAlreadyStopped = errors.New("sequencer not running")
+	// ErrUnsafeHeadMismatch is returned by Start when sequencing is requested at a head the
+	// sequencer has not adopted. It is retryable: the head is tracked from an asynchronous
+	// forkchoice update, so a head the execution client already holds can arrive a moment later.
+	ErrUnsafeHeadMismatch = errors.New("block hash does not match")
 )
 
 type L1OriginSelectorIface interface {
@@ -692,7 +696,7 @@ func (d *Sequencer) Start(ctx context.Context, head common.Hash) error {
 		return fmt.Errorf("no prestate, cannot determine if sequencer start at %s is safe", head)
 	}
 	if head != d.latestHead.Hash {
-		return fmt.Errorf("block hash does not match: head %s, received %s", d.latestHead, head)
+		return fmt.Errorf("%w: head %s, received %s", ErrUnsafeHeadMismatch, d.latestHead, head)
 	}
 	return d.forceStart()
 }


### PR DESCRIPTION
Fixes the flakiest test in the repo, `TestSequencerFailover_ConductorRPC` — 247 flakes in `go-tests-short` plus 62 in `go-tests-full` over 14 days, a ~34% per-job failure rate, where the #2 test has 7. Closes ethereum-optimism/optimism#22094.

The test is not at fault; no file under `op-e2e/` is touched. This is an op-conductor availability bug.

## The wedge

A leadership handover left the incoming leader unable to sequence, forever, whenever its op-node was two or more blocks behind the unsafe head consensus had committed. `startSequencer` only posted the missing payload when the gap was exactly one block and returned `ErrUnsafeHeadMismatch` otherwise, and `action()`'s `leader && healthy && !active` case had no fallback — it re-queued the identical failing start on a backoff, indefinitely. The raft FSM held exactly one payload, so the gap was unfillable anyway. From a failing CI run (pipeline 131344, job 5391956) that pair of log lines repeats 28 times, `consensus_num=14 node_num=12` never changing, until the test gives up:

```
11.183  WARN latest unsafe block in consensus is not the same as the one in op-node
              consensus_num=14 node_num=12
11.338  ERROR failed to execute step, queueing another one to retry
              err="unsafe head mismatch" status="leader: true, healthy: true, active: false"
```

The leader could not catch up on its own: gossip delivered nothing (zero p2p payload receives in the log) and L1 derivation had stalled because the batcher had no active sequencer to proxy to.

The gap opens because of a second defect. `PostUnsafePayload` hands the payload to op-node asynchronously, but `StartSequencer` was called on the next line, and op-node only starts at a head it has already adopted. Losing that race costs one `retryBackoff` draw (`rand.Intn(2000)ms`), and a sequencer that starts a block-time late burst-builds its catch-up blocks in milliseconds — which is what strands the *next* leader two behind.

## Why it is flaky

Losing the adoption race is not the variable: it was lost in 100% of sampled runs, because a follower here learns blocks only through L1 batch derivation, which lags ~1.1s against a 1s block time. Two draws decide the outcome. The backoff draw sets when the second transfer lands, because `ensureOnlyOneLeader` polls on a 1s grid, so `X >= 1000ms` hands the next leader a gap of 2 — 50% alone. That is multiplied by whether op-node's driver loop happens to wake during the interim leader's active window, roughly 0.6. Together ~30%, against ~34% on CI and ~20% locally.

## The fix

Every member applies every committed payload, so the FSM retains the last 16 chained payloads, bounded by approximate size as well as count, and `startSequencer` replays whatever op-node is missing rather than depending on gossip or L1 derivation. It then polls op-node's unsafe head and only starts once adoption is observed, retrying op-node's own head-mismatch rejection inside the same window. Catch-up and start share one budget derived from `shutdownCtx`, so an attempt is bounded and cancellable and cannot hold the single action loop for two budgets. A healthy leader that fails three times transfers leadership; only that condition escalates — nothing committed yet, a degraded raft barrier, a transient RPC failure, an op-node ahead of consensus, and shutdown are all transient or identical on every member, so they retry in place.

Sequencing still only ever starts at the head consensus committed, and op-node re-checks leadership on every start, so neither a double-active sequencer nor a reorg of consensus-committed blocks is reachable.

The second commit bounds `RaftConsensus.Shutdown`. `raft.Shutdown().Error()` blocks in `waitShutdown()` with no deadline, and `OpConductor.Stop` shuts components down in sequence, so a member that has lost quorum stranded the whole teardown — 19 minutes in the CI run, until the package timeout killed the test binary and took the remaining tests and the gotestsum rerun with it. That is the blast-radius half of #22094.

## Test plan

| | baseline | fix |
|---|---|---|
| new unit tests | 400/400 fail | 200/200 pass |
| `TestSequencerFailover_ConductorRPC` under stress | 20/100 fail | 372/372 pass |

Stress is 6- and 8-way concurrent runs of the single test on a 12-core box to emulate a loaded CI executor. The baseline runs reproduced all three CI failure faces, 14/14 at `sequencer_failover_test.go:96`, matching CI's 14/14 at that call site; max observed gap was 6, so 16 retained payloads is comfortable. Each of the 15 new tests was individually verified to fail when its own hunk is reverted. `./op-conductor/...` and the whole `op-e2e/system/conductor` package are green.

## Follow-ups, not in this PR

A third defect surfaced during the investigation and has its own PR: `planSequencerAction()` is only called at the top of op-node's driver loop, while `forceStart` arms `nextAction` from the `StartSequencer` RPC goroutine without emitting an event, so a freshly promoted sequencer can idle up to ~2s past its first block deadline and then burst. That PR does not gate this one.

Also noticed and out of scope: a pre-existing data race in `op-conductor/rpc/ws/flashblocks_handler.go` between `Handler.Stop` and the `listenToRollupBoost` goroutine, which makes `TestFlashblocksHandlerIntegration` fail under `-race` on `develop`.