### PR TITLE
op-node: Wake the driver loop when sequencer actions are armed

### DIFF
--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -241,6 +241,9 @@ func (s *Driver) eventLoop() {
 				s.log.Info("Sequencer paused until new events")
 			}
 			sequencerCh = nil
+			// Forget the disarmed deadline, so that re-arming on the very same instant
+			// still resets the timer instead of hitting the equality check below.
+			prevTime = time.Time{}
 			return
 		}
 		// avoid unnecessary timer resets
@@ -317,6 +320,9 @@ func (s *Driver) eventLoop() {
 		select {
 		case <-sequencerCh:
 			s.emitter.Emit(s.driverCtx, sequencing.SequencerActionEvent{})
+		case <-s.sequencer.NextActionChanged():
+			// The sequencer was started or stopped outside of the event loop.
+			// Looping around re-plans the sequencer timer.
 		case <-unsafeGapTicker.C:
 			// Check if there is a gap in the current unsafe payload queue.
 			ctx, cancel := context.WithTimeout(s.driverCtx, time.Second*2)

--- a/op-node/rollup/driver/event_loop_test.go
+++ b/op-node/rollup/driver/event_loop_test.go
@@ -1,0 +1,289 @@
+package driver
+
+import (
+	"context"
+	gosync "sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sequencing"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+// loopTestBlockTime is deliberately huge: the unsafe-gap ticker is derived from it, and
+// these tests need the event loop to have no incidental wakeup source at all, so that
+// what they measure is only the sequencer wakeup path.
+const loopTestBlockTime = 3600
+
+// loopTestTimeout bounds every wait in these tests. The behaviour under test either
+// happens in microseconds or never happens, so this is a failure deadline, not a delay.
+const loopTestTimeout = 30 * time.Second
+
+// stubSequencer is a SequencerIface whose schedule can be armed and disarmed from a
+// foreign goroutine, exactly like the admin_startSequencer/admin_stopSequencer handlers
+// do, and which records every schedule read the driver event loop performs.
+type stubSequencer struct {
+	mu           gosync.Mutex
+	nextAction   time.Time
+	nextActionOK bool
+
+	signal  chan struct{}
+	planned chan bool
+}
+
+var _ sequencing.SequencerIface = (*stubSequencer)(nil)
+
+func newStubSequencer() *stubSequencer {
+	return &stubSequencer{
+		signal:  make(chan struct{}, 1),
+		planned: make(chan bool, 128),
+	}
+}
+
+// setSchedule mimics forceStart/Stop: mutate the schedule and signal, both under the
+// same lock that NextAction reads under, so the loop cannot read the old schedule and
+// then miss the signal.
+func (s *stubSequencer) setSchedule(next time.Time, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextAction, s.nextActionOK = next, ok
+	select {
+	case s.signal <- struct{}{}:
+	default:
+	}
+}
+
+func (s *stubSequencer) NextAction() (time.Time, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	select {
+	case s.planned <- s.nextActionOK:
+	default:
+	}
+	return s.nextAction, s.nextActionOK
+}
+
+func (s *stubSequencer) NextActionChanged() <-chan struct{} { return s.signal }
+
+func (s *stubSequencer) OnEvent(context.Context, event.Event) bool   { return false }
+func (s *stubSequencer) Init(context.Context, bool) error            { return nil }
+func (s *stubSequencer) Start(context.Context, common.Hash) error    { return nil }
+func (s *stubSequencer) Stop(context.Context) (common.Hash, error)   { return common.Hash{}, nil }
+func (s *stubSequencer) SetMaxSafeLag(context.Context, uint64) error { return nil }
+func (s *stubSequencer) OverrideLeader(context.Context) error        { return nil }
+func (s *stubSequencer) ConductorEnabled(context.Context) bool       { return false }
+func (s *stubSequencer) SetRecoverMode(bool)                         {}
+func (s *stubSequencer) Close()                                      {}
+
+func (s *stubSequencer) Active() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nextActionOK
+}
+
+// readyDerivationStub keeps the event loop from resetting the unsafe-gap ticker on
+// every iteration; none of its other methods are reachable from these tests.
+type readyDerivationStub struct {
+	DerivationPipeline
+}
+
+func (readyDerivationStub) DerivationReady() bool { return true }
+
+type loopMetricsStub struct {
+	Metrics
+}
+
+// loopEventRecorder observes the events the driver event loop emits.
+type loopEventRecorder struct {
+	steps            chan struct{}
+	sequencerActions chan time.Time
+}
+
+func (r *loopEventRecorder) OnEvent(_ context.Context, ev event.Event) bool {
+	switch ev.(type) {
+	case StepEvent:
+		select {
+		case r.steps <- struct{}{}:
+		default:
+		}
+		return true
+	case sequencing.SequencerActionEvent:
+		select {
+		case r.sequencerActions <- time.Now():
+		default:
+		}
+		return true
+	}
+	return false
+}
+
+// startQuiescedEventLoop runs a driver event loop with seq, and returns once the loop
+// is parked in its select with no pending work: the only startup activity is the
+// initial step request and the StepEvent it produces, both of which are awaited here.
+func startQuiescedEventLoop(t *testing.T, seq sequencing.SequencerIface) (*Driver, *loopEventRecorder) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	exec := event.NewGlobalSynchronous(ctx)
+	sys := event.NewSystem(logger, exec)
+	opts := event.WithNoEmitLimiter()
+
+	sched := NewStepSchedulingDeriver(logger)
+	sys.Register("step-scheduler", sched, opts)
+	rec := &loopEventRecorder{
+		steps:            make(chan struct{}, 8),
+		sequencerActions: make(chan time.Time, 8),
+	}
+	sys.Register("recorder", rec, opts)
+
+	d := &Driver{
+		SyncDeriver: &SyncDeriver{
+			Derivation:  readyDerivationStub{},
+			Engine:      &engine.EngineController{},
+			SyncCfg:     &sync.Config{},
+			Config:      &rollup.Config{BlockTime: loopTestBlockTime},
+			Log:         logger,
+			Ctx:         ctx,
+			StepDeriver: sched,
+		},
+		sched:        sched,
+		emitter:      sys.Register("driver", nil, opts),
+		drain:        exec,
+		stateReq:     make(chan chan struct{}),
+		forceReset:   make(chan chan struct{}, 10),
+		driverConfig: &Config{},
+		driverCtx:    ctx,
+		driverCancel: cancel,
+		log:          logger,
+		sequencer:    seq,
+		metrics:      &loopMetricsStub{},
+	}
+	d.wg.Add(1)
+	go d.eventLoop()
+	t.Cleanup(func() {
+		cancel()
+		d.wg.Wait()
+	})
+
+	// The loop always requests one derivation step on startup. Wait for the resulting
+	// StepEvent to be drained, then round-trip a state request to confirm the loop has
+	// come back around to its select. After that nothing else can wake it.
+	select {
+	case <-rec.steps:
+	case <-time.After(loopTestTimeout):
+		t.Fatal("event loop never emitted its startup step")
+	}
+	syncWithEventLoop(t, d)
+	return d, rec
+}
+
+// syncWithEventLoop round-trips a state request, which the loop only services from its
+// select. It is a barrier: on return, the loop has completed an iteration.
+func syncWithEventLoop(t *testing.T, d *Driver) {
+	t.Helper()
+	respCh := make(chan struct{})
+	select {
+	case d.stateReq <- respCh:
+	case <-time.After(loopTestTimeout):
+		t.Fatal("event loop did not accept a state request")
+	}
+	select {
+	case <-respCh:
+	case <-time.After(loopTestTimeout):
+		t.Fatal("event loop did not answer a state request")
+	}
+}
+
+// TestEventLoopWakesWhenSequencerStarts pins the wakeup contract that admin_startSequencer
+// depends on: arming the sequencer schedule from an RPC goroutine must make the driver
+// loop plan and fire that action, without waiting for an unrelated wakeup.
+func TestEventLoopWakesWhenSequencerStarts(t *testing.T) {
+	seq := newStubSequencer()
+	_, rec := startQuiescedEventLoop(t, seq)
+
+	const armDelay = 100 * time.Millisecond
+	start := time.Now()
+	seq.setSchedule(start.Add(armDelay), true)
+
+	select {
+	case at := <-rec.sequencerActions:
+		elapsed := at.Sub(start)
+		require.GreaterOrEqual(t, elapsed, armDelay, "must not act before the scheduled time")
+		require.Less(t, elapsed, armDelay+time.Second,
+			"the loop must observe the newly armed action promptly, not at some later incidental wakeup")
+	case <-time.After(loopTestTimeout):
+		t.Fatal("driver never acted on the newly armed sequencer action")
+	}
+}
+
+// TestEventLoopWakesWhenSequencerStops covers the mirror case: disarming the schedule
+// must make the loop re-plan and drop its armed timer. Otherwise the timer survives the
+// stop and fires a stale sequencer action up to a block-time later.
+func TestEventLoopWakesWhenSequencerStops(t *testing.T) {
+	seq := newStubSequencer()
+	d, rec := startQuiescedEventLoop(t, seq)
+
+	// Arm an action, and barrier so the loop has certainly planned it.
+	const armDelay = 250 * time.Millisecond
+	seq.setSchedule(time.Now().Add(armDelay), true)
+	syncWithEventLoop(t, d)
+
+	// Stopping now, well inside the armed window, must cancel that action outright.
+	seq.setSchedule(time.Time{}, false)
+
+	select {
+	case <-rec.sequencerActions:
+		t.Fatal("driver fired a stale sequencer action after the sequencer was stopped")
+	case <-time.After(armDelay * 6):
+	}
+}
+
+// TestEventLoopStaysQuietWithoutSchedule guards against the wakeup turning into a busy
+// loop: with nothing armed and nothing signalled, the loop must not spin.
+func TestEventLoopStaysQuietWithoutSchedule(t *testing.T) {
+	seq := newStubSequencer()
+	d, _ := startQuiescedEventLoop(t, seq)
+
+	// Drain the plans recorded during startup, then take two barriers. Each barrier
+	// costs exactly one iteration, so a quiet loop yields at most one plan per barrier
+	// plus one that may already have been in flight.
+	for len(seq.planned) > 0 {
+		<-seq.planned
+	}
+	syncWithEventLoop(t, d)
+	syncWithEventLoop(t, d)
+
+	require.LessOrEqual(t, len(seq.planned), 3,
+		"event loop iterated more than the barriers required: it is spinning")
+}
+
+// TestEventLoopSignalDuringPlanIsNotLost covers the interleaving the buffered signal
+// exists for: a schedule change that lands while the loop is between planning and
+// blocking in its select must still be observed.
+func TestEventLoopSignalDuringPlanIsNotLost(t *testing.T) {
+	seq := newStubSequencer()
+	_, rec := startQuiescedEventLoop(t, seq)
+
+	// Churn the schedule so a change lands at arbitrary points of the loop iteration,
+	// including after NextAction was read but before the loop reaches its select. The
+	// final state is armed, so the loop owes us exactly one sequencer action.
+	for range 200 {
+		seq.setSchedule(time.Now(), true)
+		seq.setSchedule(time.Time{}, false)
+	}
+	seq.setSchedule(time.Now(), true)
+
+	select {
+	case <-rec.sequencerActions:
+	case <-time.After(loopTestTimeout):
+		t.Fatal("driver lost the sequencer wakeup")
+	}
+}

--- a/op-node/rollup/sequencing/disabled.go
+++ b/op-node/rollup/sequencing/disabled.go
@@ -24,6 +24,12 @@ func (ds DisabledSequencer) NextAction() (t time.Time, ok bool) {
 	return time.Time{}, false
 }
 
+// NextActionChanged never fires: a nil channel blocks forever, so the driver's select
+// case for it is inert.
+func (ds DisabledSequencer) NextActionChanged() <-chan struct{} {
+	return nil
+}
+
 func (ds DisabledSequencer) Active() bool {
 	return false
 }

--- a/op-node/rollup/sequencing/iface.go
+++ b/op-node/rollup/sequencing/iface.go
@@ -13,6 +13,10 @@ type SequencerIface interface {
 	event.Deriver
 	// NextAction returns when the sequencer needs to do the next change, and iff it should do so.
 	NextAction() (t time.Time, ok bool)
+	// NextActionChanged returns a channel that is signalled when the schedule reported by
+	// NextAction changed outside of event processing, i.e. from an RPC-driven Start or Stop.
+	// The driver event loop selects on it so that it re-plans promptly.
+	NextActionChanged() <-chan struct{}
 	Active() bool
 	Init(ctx context.Context, active bool) error
 	Start(ctx context.Context, head common.Hash) error

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -124,6 +124,15 @@ type Sequencer struct {
 	nextAction   time.Time
 	nextActionOK bool
 
+	// nextActionSignal wakes the driver event loop when nextAction/nextActionOK change
+	// outside of that loop, i.e. from the admin_startSequencer/admin_stopSequencer RPC
+	// handlers. Every other mutation happens while the driver loop is processing events,
+	// so the loop re-reads the schedule on its next iteration regardless.
+	//
+	// Buffered with capacity 1, and only ever sent to without blocking: the driver reads
+	// the whole schedule via NextAction, so pending signals coalesce harmlessly.
+	nextActionSignal chan struct{}
+
 	latest       BuildingState
 	latestSealed eth.L2BlockRef
 	latestHead   eth.L2BlockRef
@@ -164,6 +173,7 @@ func NewSequencer(driverCtx context.Context, log log.Logger, rollupCfg *rollup.C
 		eng:              eng,
 		timeNow:          time.Now,
 		toBlockRef:       derive.PayloadToBlockRef,
+		nextActionSignal: make(chan struct{}, 1),
 	}
 }
 
@@ -666,6 +676,25 @@ func (d *Sequencer) NextAction() (t time.Time, ok bool) {
 	return d.nextAction, d.nextActionOK
 }
 
+// NextActionChanged returns a channel that is signalled when the sequencer schedule
+// changed outside of the driver's event processing. The driver event loop selects on
+// it, so that a start or stop is planned immediately rather than at whatever unrelated
+// wakeup happens to come next.
+func (d *Sequencer) NextActionChanged() <-chan struct{} {
+	return d.nextActionSignal
+}
+
+// signalNextAction wakes the driver event loop so that it re-plans the sequencer timer.
+// It must be called with d.l held, and after mutating nextAction/nextActionOK: the
+// driver reads that state under the same lock, so it cannot read the old schedule and
+// then miss this signal.
+func (d *Sequencer) signalNextAction() {
+	select {
+	case d.nextActionSignal <- struct{}{}:
+	default: // a wakeup is already pending, and the driver re-reads the full schedule
+	}
+}
+
 func (d *Sequencer) Active() bool {
 	return d.active.Load()
 }
@@ -745,6 +774,10 @@ func (d *Sequencer) forceStart() error {
 	d.nextAction = d.timeNow()
 	d.active.Store(true)
 	d.metrics.SetSequencerState(true)
+	// Arming nextAction is not enough: the driver event loop is blocked in its select,
+	// and will not re-plan until something wakes it. Without this the first block is
+	// delayed until an unrelated wakeup (L1 head poll, unsafe-gap tick, derivation step).
+	d.signalNextAction()
 	d.log.Info("Sequencer has been started", "next action", d.nextAction)
 	return nil
 }
@@ -802,6 +835,9 @@ func (d *Sequencer) Stop(ctx context.Context) (common.Hash, error) {
 	d.stalledByMaxSafeLag = false
 	d.active.Store(false)
 	d.metrics.SetSequencerState(false)
+	// Wake the driver loop so it disarms its sequencer timer, rather than leaving it
+	// armed to fire a stale sequencer action later.
+	d.signalNextAction()
 	d.log.Info("Sequencer has been stopped")
 	return d.latestHead.Hash, nil
 }

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -740,6 +740,96 @@ func TestSequencerL1TemporaryErrorEvent(t *testing.T) {
 	require.True(t, ok1 == ok2 && sealTargetTime2.After(sealTargetTime1))
 }
 
+// TestSequencerSignalsNextActionOnStartAndStop pins the wakeup the driver event loop
+// relies on. Start and Stop mutate the schedule from an RPC goroutine while the loop is
+// blocked in its select; without the signal the loop keeps the stale plan until some
+// unrelated wakeup happens to come along.
+func TestSequencerSignalsNextActionOnStartAndStop(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	seq, deps := createSequencer(logger)
+	testClock := clock.NewSimpleClock()
+	seq.timeNow = testClock.Now
+	testClock.SetTime(30000)
+	emitter := &testutils.MockEmitter{}
+	seq.AttachEmitter(emitter)
+
+	testCtx := context.Background()
+	require.NoError(t, seq.Init(testCtx, false))
+	emitter.AssertExpectations(t)
+	require.False(t, seq.Active())
+	requireNoScheduleSignal(t, seq, "initialising as stopped does not change the schedule")
+
+	head := eth.L2BlockRef{
+		Hash:   common.Hash{0x22},
+		Number: 100,
+		Time:   uint64(testClock.Now().Unix()),
+	}
+	seq.OnEvent(testCtx, engine.ForkchoiceUpdateEvent{UnsafeL2Head: head})
+	emitter.AssertExpectations(t)
+	requireNoScheduleSignal(t, seq, "event-driven updates need no signal: the driver loop re-plans on its next iteration")
+
+	deps.conductor.leader = true
+	require.NoError(t, seq.Start(testCtx, head.Hash))
+	_, ok := seq.NextAction()
+	require.True(t, ok, "start arms an action")
+	requireScheduleSignal(t, seq, "start must wake the driver loop")
+
+	// Not the leader anymore, so Stop does not wait for the head to catch up.
+	deps.conductor.leader = false
+	_, err := seq.Stop(testCtx)
+	require.NoError(t, err)
+	_, ok = seq.NextAction()
+	require.False(t, ok, "stop disarms the action")
+	requireScheduleSignal(t, seq, "stop must wake the driver loop, so it drops its armed timer")
+}
+
+// TestSequencerScheduleSignalCoalesces documents why the signal cannot block the RPC
+// goroutine: it is a capacity-1 channel written to without blocking, so repeated
+// schedule changes collapse into a single pending wakeup.
+func TestSequencerScheduleSignalCoalesces(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	seq, deps := createSequencer(logger)
+	testClock := clock.NewSimpleClock()
+	seq.timeNow = testClock.Now
+	testClock.SetTime(30000)
+	seq.AttachEmitter(&testutils.MockEmitter{})
+
+	testCtx := context.Background()
+	require.NoError(t, seq.Init(testCtx, false))
+	head := eth.L2BlockRef{Hash: common.Hash{0x22}, Number: 100, Time: uint64(testClock.Now().Unix())}
+	seq.OnEvent(testCtx, engine.ForkchoiceUpdateEvent{UnsafeL2Head: head})
+
+	deps.conductor.leader = true
+	for range 10 {
+		require.NoError(t, seq.Start(testCtx, head.Hash))
+		deps.conductor.leader = false
+		_, err := seq.Stop(testCtx)
+		require.NoError(t, err)
+		deps.conductor.leader = true
+	}
+
+	requireScheduleSignal(t, seq, "a wakeup is pending")
+	requireNoScheduleSignal(t, seq, "signals coalesce into a single pending wakeup")
+}
+
+func requireScheduleSignal(t *testing.T, seq *Sequencer, msg string) {
+	t.Helper()
+	select {
+	case <-seq.NextActionChanged():
+	default:
+		t.Fatal(msg)
+	}
+}
+
+func requireNoScheduleSignal(t *testing.T, seq *Sequencer, msg string) {
+	t.Helper()
+	select {
+	case <-seq.NextActionChanged():
+		t.Fatal(msg)
+	default:
+	}
+}
+
 type sequencerTestDeps struct {
 	cfg              *rollup.Config
 	attribBuilder    *FakeAttributesBuilder


### PR DESCRIPTION
`Sequencer.Start` and `Sequencer.Stop` run on the `admin_startSequencer`/`admin_stopSequencer` RPC goroutine and set `nextAction`/`nextActionOK` directly. The driver event loop only reads that schedule at the top of an iteration (`planSequencerAction`), and is otherwise parked in its `select`, so arming an action never woke it. A freshly promoted sequencer therefore idles past its first block deadline until an unrelated wakeup arrives — the L1 head poll, the unsafe-gap ticker (`2 * BlockTime`), or a derivation step — and then builds late. `Stop` had the mirror problem: the armed timer survived the stop and fired a stale sequencer action afterwards.

The sequencer now signals a capacity-1 channel while holding the lock that guards the schedule, and the event loop selects on it. Because the driver re-reads the whole schedule on every iteration, signals coalesce; the send is non-blocking, so the RPC goroutine is never held up. `planSequencerAction` also forgets the deadline when it disarms, so re-arming on the same instant still resets the timer instead of tripping the "avoid unnecessary timer resets" check.

### Evidence

Two op-conductor logs from one CircleCI job (pipeline 131344, job 5391956), L2 block time 1s:

- `sequencer2` logs `Sequencer has been started ... "next action"=15:43:10` at `15:43:10.836`, but the driver does not log `Scheduled sequencer action delta=-242.538596ms` until `15:43:11.079` — **243 ms late**, woken by an unrelated event. Being ~1 block-time behind, it then sealed block 13 at `11.082` and block 14 at `11.085`: two blocks in 3 ms.
- In the other run `sequencer2` is active from `15:43:55.641` to `15:43:56.528` — an **887 ms window spanning a block's due time with no sequencer action logged at all**. When `sequencer1` took over at `15:43:56.529` its first action came at `15:43:56.954`, `delta=-425.270491ms`.

Found while root-causing `TestSequencerFailover_ConductorRPC` (ethereum-optimism/optimism#22094). The op-conductor fix for that flake is a separate PR and does not depend on this one.

This removes the 0–2 s of avoidable lag after promotion, but it does not remove catch-up burst-building: the chain is still behind wall clock by the failover duration itself (1.657 s in the log above), and `onForkchoiceUpdate` deliberately starts the next block instantly while `payloadTime - now <= blockTime`. Whether that catch-up is desirable is a separate policy question, deliberately untouched here.

### Test plan

The new driver tests run a real `eventLoop` with every incidental wakeup source quiesced (block time set so the unsafe-gap ticker is 2 h), so the only thing that can wake it is the sequencer signal. On `develop` `TestEventLoopWakesWhenSequencerStarts` and `TestEventLoopSignalDuringPlanIsNotLost` hang until their 30 s deadline, and `TestEventLoopWakesWhenSequencerStops` fails at 250 ms with a stale sequencer action.

Also run: `go test ./op-node/rollup/driver/... ./op-node/rollup/sequencing/... -count=3 -race`, `go test ./op-e2e/actions/sequencer/... -count=1`, and `go test ./op-e2e/system/conductor/ -run TestSequencerFailover -count=3`. `TestSequencerFailover_ConductorRPC` still flakes at roughly its `develop` rate (2/10 with this change, 3/10 on `develop` locally) — that is ethereum-optimism/optimism#22094, addressed elsewhere.
