### PR TITLE
op-reth: retry proof fetches on each node

### DIFF
--- a/rust/op-reth/tests/proofs/utils/proof.go
+++ b/rust/op-reth/tests/proofs/utils/proof.go
@@ -134,7 +134,7 @@ func VerifyProof(res *eth.AccountResult, stateRoot common.Hash) error {
 func fetchProofWithRetry(t devtest.T, source string, block uint64, fetch func() (*eth.AccountResult, error)) *eth.AccountResult {
 	// Each op-reth node persists proof state asynchronously. Readiness on one node does not imply
 	// that its peer can serve the same historical block yet, so retry the exact RPC on each node.
-	proof, err := retry.Do(t.Ctx(), 150, &retry.FixedStrategy{Dur: 200 * time.Millisecond}, fetch)
+	proof, err := retry.Do(t.Ctx(), 50, &retry.FixedStrategy{Dur: 200 * time.Millisecond}, fetch)
 	require.NoError(t, err, "failed to get proof from %s at block %d", source, block)
 	return proof
 }

--- a/rust/op-reth/tests/proofs/utils/proof.go
+++ b/rust/op-reth/tests/proofs/utils/proof.go
@@ -3,9 +3,11 @@ package utils
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -129,17 +131,27 @@ func VerifyProof(res *eth.AccountResult, stateRoot common.Hash) error {
 	return nil
 }
 
+func fetchProofWithRetry(t devtest.T, source string, block uint64, fetch func() (*eth.AccountResult, error)) *eth.AccountResult {
+	// Each op-reth node persists proof state asynchronously. Readiness on one node does not imply
+	// that its peer can serve the same historical block yet, so retry the exact RPC on each node.
+	proof, err := retry.Do(t.Ctx(), 150, &retry.FixedStrategy{Dur: 200 * time.Millisecond}, fetch)
+	require.NoError(t, err, "failed to get proof from %s at block %d", source, block)
+	return proof
+}
+
 // FetchAndVerifyProofs fetches account proofs from both L2EL and L2ELB for the given address
 func FetchAndVerifyProofs(t devtest.T, sys *MixedOpProofPreset, address common.Address, slots []common.Hash, block uint64) {
 	ctx := t.Ctx()
 	blockInfo, err := sys.L2ELSequencerNode().Escape().L2EthClient().InfoByNumber(ctx, block)
 	require.NoError(t, err, "failed to get block info for block %d", block)
 
-	seqProofRes, err := sys.L2ELSequencerNode().Escape().L2EthClient().GetProof(ctx, address, slots, hexutil.Uint64(block).String())
-	require.NoError(t, err, "failed to get proof from L2EL at block %d", block)
-
-	valProofRes, err := sys.L2ELValidatorNode().Escape().L2EthClient().GetProof(ctx, address, slots, hexutil.Uint64(block).String())
-	require.NoError(t, err, "failed to get proof from L2ELB at block %d", block)
+	blockTag := hexutil.Uint64(block).String()
+	seqProofRes := fetchProofWithRetry(t, "L2EL", block, func() (*eth.AccountResult, error) {
+		return sys.L2ELSequencerNode().Escape().L2EthClient().GetProof(ctx, address, slots, blockTag)
+	})
+	valProofRes := fetchProofWithRetry(t, "L2ELB", block, func() (*eth.AccountResult, error) {
+		return sys.L2ELValidatorNode().Escape().L2EthClient().GetProof(ctx, address, slots, blockTag)
+	})
 
 	NormalizeProofResponse(seqProofRes)
 	NormalizeProofResponse(valProofRes)


### PR DESCRIPTION
## Summary

- retry `eth_getProof` independently against each EL in the op-reth proof tests
- wait for the exact proof RPC to become available instead of assuming one node's proof-store readiness applies to its peer

## Context

Each op-reth node persists proof state asynchronously. The proof tests currently wait for the validator's proof store and then immediately query both the sequencer and validator. The sequencer can still be behind and return `no state found` for the requested block.

Retrying each node's exact request removes that synchronization race while preserving a bounded 30-second failure window.

Fixes #19978.
Fixes #20376.

## Validation

- `just build-superchain-go`
- `go test ./rust/op-reth/tests/proofs/utils ./rust/op-reth/tests/proofs/core -run '^$'`
- `go vet ./rust/op-reth/tests/proofs/utils ./rust/op-reth/tests/proofs/core`
