### PR TITLE
ci: embed release metadata in apko images

### DIFF
--- a/.github/images.apko.json
+++ b/.github/images.apko.json
@@ -34,7 +34,7 @@
     "aarch64": "ubuntu-24.04-arm"
   },
   "smoke_runners": {
-    "amd64": "ubuntu-slim",
+    "amd64": "ubuntu-24.04",
     "arm64": "ubuntu-24.04-arm"
   },
   "melange": {

--- a/.github/images.apko.json
+++ b/.github/images.apko.json
@@ -74,6 +74,7 @@
   "images": {
     "op-node": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -83,10 +84,11 @@
       "nexus_paths": [
         "apko/op-node.yaml"
       ],
-      "smoke_test": "op-node --help"
+      "smoke_test": "op-node --version"
     },
     "op-batcher": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -96,10 +98,11 @@
       "nexus_paths": [
         "apko/op-batcher.yaml"
       ],
-      "smoke_test": "op-batcher --help"
+      "smoke_test": "op-batcher --version"
     },
     "op-proposer": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -109,10 +112,11 @@
       "nexus_paths": [
         "apko/op-proposer.yaml"
       ],
-      "smoke_test": "op-proposer --help"
+      "smoke_test": "op-proposer --version"
     },
     "op-conductor": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -123,10 +127,11 @@
       "nexus_paths": [
         "apko/op-conductor.yaml"
       ],
-      "smoke_test": "op-conductor --help"
+      "smoke_test": "op-conductor --version"
     },
     "op-dispute-mon": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -136,10 +141,11 @@
       "nexus_paths": [
         "apko/op-dispute-mon.yaml"
       ],
-      "smoke_test": "op-dispute-mon --help"
+      "smoke_test": "op-dispute-mon --version"
     },
     "op-dripper": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -149,10 +155,11 @@
       "nexus_paths": [
         "apko/op-dripper.yaml"
       ],
-      "smoke_test": "op-dripper --help"
+      "smoke_test": "op-dripper --version"
     },
     "op-faucet": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -162,10 +169,11 @@
       "nexus_paths": [
         "apko/op-faucet.yaml"
       ],
-      "smoke_test": "op-faucet --help"
+      "smoke_test": "op-faucet --version"
     },
     "op-interop-filter": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -175,10 +183,11 @@
       "nexus_paths": [
         "apko/op-interop-filter.yaml"
       ],
-      "smoke_test": "op-interop-filter --help"
+      "smoke_test": "op-interop-filter --version"
     },
     "op-interop-mon": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -188,10 +197,11 @@
       "nexus_paths": [
         "apko/op-interop-mon.yaml"
       ],
-      "smoke_test": "op-interop-mon --help"
+      "smoke_test": "op-interop-mon --version"
     },
     "op-supernode": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -202,10 +212,11 @@
       "nexus_paths": [
         "apko/op-supernode.yaml"
       ],
-      "smoke_test": "op-supernode --help"
+      "smoke_test": "op-supernode --version"
     },
     "op-test-sequencer": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -215,10 +226,11 @@
       "nexus_paths": [
         "apko/op-test-sequencer.yaml"
       ],
-      "smoke_test": "op-test-sequencer --help"
+      "smoke_test": "op-test-sequencer --version"
     },
     "da-server": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go"
       ],
@@ -228,10 +240,11 @@
       "nexus_paths": [
         "apko/da-server.yaml"
       ],
-      "smoke_test": "da-server --help"
+      "smoke_test": "da-server --version"
     },
     "op-challenger": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-go",
         "multicannon",
@@ -246,10 +259,11 @@
       "nexus_paths": [
         "apko/op-challenger.yaml"
       ],
-      "smoke_test": "op-challenger --help,cannon --help,cannon load-elf --type multithreaded64-5 --help,kona-host --help"
+      "smoke_test": "op-challenger --version,cannon --help,cannon load-elf --type multithreaded64-5 --help,kona-host --help"
     },
     "kona-node": {
       "type": "rust",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-rust"
       ],
@@ -259,7 +273,7 @@
       "nexus_paths": [
         "apko/kona-node.yaml"
       ],
-      "smoke_test": "kona-node --help"
+      "smoke_test": "kona-node --version"
     },
     "kona-host": {
       "type": "rust",
@@ -289,6 +303,7 @@
     },
     "op-reth": {
       "type": "rust",
+      "verify_version": true,
       "needs_melange": [
         "op-stack-rust"
       ],
@@ -298,7 +313,7 @@
       "nexus_paths": [
         "apko/op-reth.yaml"
       ],
-      "smoke_test": "op-reth --help"
+      "smoke_test": "op-reth --version"
     },
     "op-rbuilder": {
       "type": "rust",
@@ -328,6 +343,7 @@
     },
     "op-deployer": {
       "type": "go",
+      "verify_version": true,
       "needs_melange": [
         "op-deployer"
       ],
@@ -341,7 +357,7 @@
         "melange/pipelines/op-deployer/embed-artifacts.yaml",
         "melange/pipelines/op-deployer/install-forge.yaml"
       ],
-      "smoke_test": "op-deployer --help,forge --version"
+      "smoke_test": "op-deployer --version,forge --version"
     }
   }
 }

--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@0e7698dcc639d694b5751e7168918aab481a0767
+        uses: ethereum-optimism/factory/actions/apko-plan@a2828aea682a1d6da5bbcf11f0e60c461b3a2378
         with:
           config: .github/images.apko.json
 
@@ -59,7 +59,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@0e7698dcc639d694b5751e7168918aab481a0767
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@a2828aea682a1d6da5bbcf11f0e60c461b3a2378
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -73,6 +73,7 @@ jobs:
       use-gha-cache: ${{ matrix.use_gha_cache }}
       cache-key-files: ${{ matrix.cache_key_files }}
       cargo-profile: maxperf
+      build-version: ${{ matrix.build_version }}
 
   apko:
     name: apko (${{ matrix.service }})
@@ -91,7 +92,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@0e7698dcc639d694b5751e7168918aab481a0767
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@a2828aea682a1d6da5bbcf11f0e60c461b3a2378
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -114,10 +115,11 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@0e7698dcc639d694b5751e7168918aab481a0767
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@a2828aea682a1d6da5bbcf11f0e60c461b3a2378
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus
       arch: ${{ matrix.arch }}
       runner: ${{ matrix.runner }}
       smoke-test: ${{ matrix.smoke_test }}
+      expected-version: ${{ matrix.expected_version }}

--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@a2828aea682a1d6da5bbcf11f0e60c461b3a2378
+        uses: ethereum-optimism/factory/actions/apko-plan@dec1aa487dce65f7da4925769776ce4f102e3f54
         with:
           config: .github/images.apko.json
 
@@ -59,7 +59,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@a2828aea682a1d6da5bbcf11f0e60c461b3a2378
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@dec1aa487dce65f7da4925769776ce4f102e3f54
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -92,7 +92,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@a2828aea682a1d6da5bbcf11f0e60c461b3a2378
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@dec1aa487dce65f7da4925769776ce4f102e3f54
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -115,7 +115,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@a2828aea682a1d6da5bbcf11f0e60c461b3a2378
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@dec1aa487dce65f7da4925769776ce4f102e3f54
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus

--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@dec1aa487dce65f7da4925769776ce4f102e3f54
+        uses: ethereum-optimism/factory/actions/apko-plan@9f80f67c23ba5ff05dff9e4265f74bbd58e9b012
         with:
           config: .github/images.apko.json
 
@@ -59,7 +59,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@dec1aa487dce65f7da4925769776ce4f102e3f54
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@9f80f67c23ba5ff05dff9e4265f74bbd58e9b012
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -92,7 +92,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@dec1aa487dce65f7da4925769776ce4f102e3f54
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@9f80f67c23ba5ff05dff9e4265f74bbd58e9b012
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -115,7 +115,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@dec1aa487dce65f7da4925769776ce4f102e3f54
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@9f80f67c23ba5ff05dff9e4265f74bbd58e9b012
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus

--- a/melange/op-deployer.yaml
+++ b/melange/op-deployer.yaml
@@ -43,6 +43,6 @@ pipeline:
       go-package: go-1.26
       # /usr/local/bin, where upstream's images install binaries.
       prefix: usr/local
-      ldflags: -s -w -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+      ldflags: -s -w -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.GitCommit=${GIT_COMMIT:-unknown} -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.GitDate=${GIT_DATE:-0} -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.Version=${GIT_VERSION:-v0.0.0} -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.Meta=$(if [ -n "${GIT_VERSION}" ]; then printf ""; else printf "dev"; fi)
 
   - uses: strip

--- a/melange/op-stack-go.yaml
+++ b/melange/op-stack-go.yaml
@@ -54,7 +54,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X github.com/ethereum-optimism/optimism/op-node/version.Version=${GIT_VERSION:-v0.0.0} -X github.com/ethereum-optimism/optimism/op-node/version.Meta=$(if [ -n "${GIT_VERSION}" ]; then printf ""; else printf "dev"; fi)
       - uses: strip
 
   - name: op-batcher
@@ -68,7 +68,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X main.Version=${GIT_VERSION:-v0.0.0}
       - uses: strip
 
   - name: op-proposer
@@ -82,7 +82,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X main.Version=${GIT_VERSION:-v0.0.0}
       - uses: strip
 
   - name: op-conductor
@@ -96,7 +96,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X main.Version=${GIT_VERSION:-v0.0.1}
       - uses: strip
 
   - name: op-challenger
@@ -110,7 +110,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X github.com/ethereum-optimism/optimism/op-challenger/version.Version=${GIT_VERSION:-v0.1.0} -X github.com/ethereum-optimism/optimism/op-challenger/version.Meta=$(if [ -n "${GIT_VERSION}" ]; then printf ""; else printf "dev"; fi)
       - uses: strip
 
   - name: op-dispute-mon
@@ -124,7 +124,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X github.com/ethereum-optimism/optimism/op-dispute-mon/version.Version=${GIT_VERSION:-v0.0.0} -X github.com/ethereum-optimism/optimism/op-dispute-mon/version.Meta=$(if [ -n "${GIT_VERSION}" ]; then printf ""; else printf "dev"; fi)
       - uses: strip
 
   - name: op-dripper
@@ -138,7 +138,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X main.Version=${GIT_VERSION:-v0.0.0}
       - uses: strip
 
   - name: op-faucet
@@ -152,7 +152,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X main.Version=${GIT_VERSION:-v0.0.0}
       - uses: strip
 
   - name: op-interop-filter
@@ -166,7 +166,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X main.Version=${GIT_VERSION:-v0.0.0}
       - uses: strip
 
   - name: op-interop-mon
@@ -180,7 +180,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X main.Version=${GIT_VERSION:-v0.0.0}
       - uses: strip
 
   - name: op-supernode
@@ -194,7 +194,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X main.Version=${GIT_VERSION:-v0.1.1}
       - uses: strip
 
   - name: op-test-sequencer
@@ -208,7 +208,7 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X main.Version=${GIT_VERSION:-v0.0.0}
       - uses: strip
 
   - name: da-server
@@ -222,5 +222,5 @@ subpackages:
           go-package: go-1.26
           # /usr/local/bin, where upstream's images install binaries.
           prefix: usr/local
-          ldflags: -s -w -X main.GitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) -X main.GitDate=$(git show -s --format=%ct 2>/dev/null || echo 0)
+          ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0} -X main.Version=${GIT_VERSION:-v0.0.0}
       - uses: strip


### PR DESCRIPTION
## Summary

- pass release versions from the image planner into Melange builds
- embed release version, commit, date, and build profile into image binaries
- require version-aware smoke tests to match the release tag

## Testing

- actionlint
- YAML and JSON validation
- release-tag planner validation against the image catalog
- direct op-node linker metadata verification