### PR TITLE
op-acceptance-tests: strengthen ZK proposer anchor assertion

### DIFF
--- a/op-acceptance-tests/tests/proofs/zk/zk_proposer_test.go
+++ b/op-acceptance-tests/tests/proofs/zk/zk_proposer_test.go
@@ -20,26 +20,25 @@ import (
 
 // TestProposerChainsSecondZKGameOnFirst covers the create path end to end: the
 // proposer's first game is a well-formed root game (max-uint32 parent sentinel,
-// non-zero sequence number) and its second game chains on the first.
+// sequence number beyond the anchor) and its second game chains on the first.
 // Broader root-game lifecycle behavior (challenge, prove, anchor) is covered by
 // TestChallengedValidProposalAnchors.
 func TestProposerChainsSecondZKGameOnFirst(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInterop(t, presets.WithZK())
+	sys := presets.NewSimpleInterop(t,
+		presets.WithZK(),
+		presets.WithoutHonestProposer(),
+	)
 	factory := sys.DisputeGameFactory()
+	_, anchorSequence := sys.AnchorStateRegistry(sys.L2ChainA).AnchorRoot()
+
+	sys.StartZKProposer()
 
 	game0 := factory.WaitForZKGameAtIndex(0)
 	t.Require().Equal(uint32(math.MaxUint32), game0.ParentIndex(),
 		"first proposer game must be a root game using the max-uint32 parent sentinel")
-	// TODO(#22086): strengthen back to an anchor comparison by recording the
-	// anchor before the proposer starts, once the start-proposer-mid-test
-	// hook from #22105 is available (adopt whichever PR lands first).
-	// Not compared against the live anchor: with the always-on proposer the
-	// anchor may already have advanced past game0 by the time this test
-	// runs (the proposer-creates-beyond-the-anchor rule is unit-tested on
-	// the Rust side in proposal_timing).
-	t.Require().NotZero(game0.L2SequenceNumber(),
-		"root game must carry a super-root timestamp")
+	t.Require().Greater(game0.L2SequenceNumber(), anchorSequence,
+		"root game must propose a sequence number beyond the anchor")
 
 	game1 := factory.WaitForZKGameAtIndex(1)
 	t.Require().Equal(uint32(0), game1.ParentIndex(),


### PR DESCRIPTION
Capture the anchor before starting the proposer so the test can reliably require the first game to advance beyond it.

Related: https://github.com/ethereum-optimism/optimism/issues/18326