### PR TITLE
kona-sp1-proposer: publish Docker images

### DIFF
--- a/.github/images.apko.json
+++ b/.github/images.apko.json
@@ -301,6 +301,19 @@
       ],
       "smoke_test": "kona-client --help"
     },
+    "kona-sp1-proposer": {
+      "type": "rust",
+      "needs_melange": [
+        "op-stack-rust"
+      ],
+      "paths": [
+        "rust/**"
+      ],
+      "nexus_paths": [
+        "apko/kona-sp1-proposer.yaml"
+      ],
+      "smoke_test": "kona-sp1-proposer --version"
+    },
     "op-reth": {
       "type": "rust",
       "verify_version": true,

--- a/.github/images.json
+++ b/.github/images.json
@@ -151,6 +151,14 @@
       "target": "kona-host",
       "paths": ["rust/**"]
     },
+    "kona-sp1-proposer": {
+      "type": "rust",
+      "check": "rust",
+      "mode": "bake",
+      "bake_file": "docker-bake.hcl",
+      "target": "kona-sp1-proposer",
+      "paths": ["rust/**"]
+    },
     "op-reth": {
       "type": "rust",
       "check": "rust",

--- a/apko/kona-sp1-proposer.yaml
+++ b/apko/kona-sp1-proposer.yaml
@@ -1,0 +1,37 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - ca-certificates
+    - busybox
+    - glibc
+    - libgcc
+    - libstdc++
+    - openssl
+    - kona-sp1-proposer@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: kona
+      gid: 10001
+  users:
+    - username: kona
+      uid: 10001
+      gid: 10001
+  # uid 10001, matching the other Kona service images.
+  run-as: 10001
+
+entrypoint:
+  command: /usr/local/bin/kona-sp1-proposer
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/optimism
+  org.opencontainers.image.title: kona-sp1-proposer

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -350,9 +350,11 @@ target "kona-sp1-proposer" {
   context = "rust"
   contexts = {
     nuts-bundles = "op-core/nuts/bundles"
+    contracts-bedrock-abis = "packages/contracts-bedrock/snapshots/abi"
   }
   args = {
     REPO_LOCATION = "local"
+    BUILDER_VARIANT = "contract-abis"
     BIN_TARGET = "kona-sp1-proposer"
     BUILD_PROFILE = "release"
   }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -345,6 +345,21 @@ target "kona-client" {
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/kona-client:${tag}"]
 }
 
+target "kona-sp1-proposer" {
+  dockerfile = "kona/docker/apps/kona_app_generic.dockerfile"
+  context = "rust"
+  contexts = {
+    nuts-bundles = "op-core/nuts/bundles"
+  }
+  args = {
+    REPO_LOCATION = "local"
+    BIN_TARGET = "kona-sp1-proposer"
+    BUILD_PROFILE = "release"
+  }
+  platforms = split(",", PLATFORMS)
+  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/kona-sp1-proposer:${tag}"]
+}
+
 target "op-reth" {
   dockerfile = "op-reth/DockerfileOp"
   context = "rust"

--- a/melange/op-stack-rust.yaml
+++ b/melange/op-stack-rust.yaml
@@ -31,7 +31,7 @@ environment:
       - rust
       - openssl-dev
       - perl
-      - protoc
+      - protobuf-dev
       - clang-19
       - libclang-cpp-19
       # opt-in mold linking when the cargo/build pipeline uses it.

--- a/melange/op-stack-rust.yaml
+++ b/melange/op-stack-rust.yaml
@@ -31,6 +31,7 @@ environment:
       - rust
       - openssl-dev
       - perl
+      - protoc
       - clang-19
       - libclang-cpp-19
       # opt-in mold linking when the cargo/build pipeline uses it.

--- a/melange/op-stack-rust.yaml
+++ b/melange/op-stack-rust.yaml
@@ -1,14 +1,14 @@
 # Consolidated build for the Rust services of the optimism monorepo. kona and
 # op-reth live in the same cargo workspace (rust/) with a single Cargo.lock,
 # so one melange run shares the whole common dependency graph (alloy,
-# op-alloy, revm, ...) across all four binaries instead of compiling it once
+# op-alloy, revm, ...) across all five binaries instead of compiling it once
 # per CI leg. Subpackage builds run sequentially in one sandbox with a shared
 # target dir: the first build does the heavy lifting, the rest are
 # incremental.
 #
 # Each binary is its own subpackage/APK so images pull only what they run:
-# the kona image bundles all three kona binaries, while op-challenger pulls
-# just kona-host. The op-stack-rust package itself is an empty meta package.
+# each Kona image pulls its matching binary, while op-challenger pulls just
+# kona-host. The op-stack-rust package itself is an empty meta package.
 package:
   name: op-stack-rust
   version: "0.0.0"
@@ -45,10 +45,10 @@ environment:
     CARGO_TARGET_DIR: /var/cache/melange/target
 
 subpackages:
-  # The first subpackage builds ALL four packages in one cargo invocation:
+  # The first subpackage builds ALL five packages in one cargo invocation:
   # one scheduler pass over the whole workspace graph keeps every core busy
-  # instead of serializing four builds. The shared target dir persists across
-  # subpackages, so the later three cargo runs are no-op fingerprint checks
+  # instead of serializing five builds. The shared target dir persists across
+  # subpackages, so the later four cargo runs are no-op fingerprint checks
   # followed by an install.
   - name: op-reth
     description: op-reth — OP Stack Reth execution client
@@ -60,7 +60,7 @@ subpackages:
           modroot: rust
           output: op-reth
           profile: "${MELANGE_CARGO_PROFILE}"
-          opts: --locked --package op-reth --package kona-node --package kona-host --package kona-client
+          opts: --locked --package op-reth --package kona-node --package kona-host --package kona-client --package kona-sp1-proposer
       - uses: strip
 
   - name: kona-node
@@ -100,6 +100,19 @@ subpackages:
           output: kona-client
           profile: "${MELANGE_CARGO_PROFILE}"
           opts: --locked --package kona-client
+      - uses: strip
+
+  - name: kona-sp1-proposer
+    description: kona-sp1-proposer — OP Stack SP1 fault proof proposer
+    pipeline:
+      - uses: cargo/build
+        with:
+          # /usr/local/bin, where upstream's images install binaries.
+          prefix: usr/local
+          modroot: rust
+          output: kona-sp1-proposer
+          profile: "${MELANGE_CARGO_PROFILE}"
+          opts: --locked --package kona-sp1-proposer
       - uses: strip
 
   # The monorepo vendors op-rbuilder and rollup-boost as NESTED workspaces

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7746,6 +7746,7 @@ dependencies = [
  "alloy-transport-http",
  "anyhow",
  "async-trait",
+ "clap",
  "flate2",
  "jsonrpsee",
  "kona-sp1-client-utils",

--- a/rust/kona/docker/apps/kona_app_generic.dockerfile
+++ b/rust/kona/docker/apps/kona_app_generic.dockerfile
@@ -81,7 +81,7 @@ FROM build-entrypoint AS builder
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer!
-RUN RUSTFLAGS="-C target-cpu=generic" cargo chef cook --bin "${BIN_TARGET}" --locked --profile "${BUILD_PROFILE}" --recipe-path recipe.json
+RUN RUSTFLAGS="-C target-cpu=generic" cargo chef cook --package "${BIN_TARGET}" --bin "${BIN_TARGET}" --locked --profile "${BUILD_PROFILE}" --recipe-path recipe.json
 
 # Build metadata for the version string, read at compile time via `option_env!`
 # in kona-node (kona/bin/node/src/version.rs). Declared here — after the
@@ -102,7 +102,7 @@ ENV BUILD_PROFILE=$BUILD_PROFILE
 COPY --from=app-setup /workspace .
 # Build the application binary on the selected tag. Since we build the external dependencies in the previous step,
 # this step will reuse the target directory from the previous step.
-RUN RUSTFLAGS="-C target-cpu=generic" cargo auditable build --bin "${BIN_TARGET}" --locked --profile "${BUILD_PROFILE}"
+RUN RUSTFLAGS="-C target-cpu=generic" cargo auditable build --package "${BIN_TARGET}" --bin "${BIN_TARGET}" --locked --profile "${BUILD_PROFILE}"
 
 # Export stage
 FROM chainguard/wolfi-base:latest AS export-stage

--- a/rust/kona/docker/apps/kona_app_generic.dockerfile
+++ b/rust/kona/docker/apps/kona_app_generic.dockerfile
@@ -15,7 +15,9 @@ RUN apt-get -o Acquire::Retries=8 update && apt-get -o Acquire::Retries=8 instal
   ca-certificates \
   libssl-dev \
   clang \
-  pkg-config
+  pkg-config \
+  protobuf-compiler \
+  libprotobuf-dev
 
 # Install rust
 ENV RUST_VERSION=1.95

--- a/rust/kona/docker/apps/kona_app_generic.dockerfile
+++ b/rust/kona/docker/apps/kona_app_generic.dockerfile
@@ -1,4 +1,5 @@
 ARG REPO_LOCATION
+ARG BUILDER_VARIANT=default
 
 ################################
 #   Dependency Installation    #
@@ -78,7 +79,7 @@ FROM build-entrypoint AS planner
 COPY --from=app-setup /workspace .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM build-entrypoint AS builder
+FROM build-entrypoint AS builder-base
 # Since we only copy recipe.json, if the dependencies don't change, this step and the next one will be cached.
 COPY --from=planner /app/recipe.json recipe.json
 
@@ -102,6 +103,16 @@ ENV BUILD_PROFILE=$BUILD_PROFILE
 
 # Build application. This step will systematically trigger a cache invalidation if the source code changes.
 COPY --from=app-setup /workspace .
+
+# Only binaries that embed contract ABI snapshots select this builder variant.
+FROM builder-base AS builder-contract-abis
+# The kona-sp1-proposer contract bindings embed ABI snapshots using paths that
+# resolve from the rust workspace to the repository-level packages directory.
+COPY --from=contracts-bedrock-abis / /packages/contracts-bedrock/snapshots/abi
+
+FROM builder-base AS builder-default
+
+FROM builder-${BUILDER_VARIANT} AS builder
 # Build the application binary on the selected tag. Since we build the external dependencies in the previous step,
 # this step will reuse the target directory from the previous step.
 RUN RUSTFLAGS="-C target-cpu=generic" cargo auditable build --package "${BIN_TARGET}" --bin "${BIN_TARGET}" --locked --profile "${BUILD_PROFILE}"

--- a/rust/kona/sp1/crates/proposer/Cargo.toml
+++ b/rust/kona/sp1/crates/proposer/Cargo.toml
@@ -34,6 +34,7 @@ alloy-contract.workspace = true
 # general
 anyhow.workspace = true
 async-trait.workspace = true
+clap = { workspace = true, features = ["derive"] }
 strum.workspace = true
 strum_macros.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/rust/kona/sp1/crates/proposer/src/bin/kona-sp1-proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/bin/kona-sp1-proposer.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use alloy_provider::ProviderBuilder;
 use anyhow::Result;
+use clap::Parser;
 use kona_sp1_host_utils::{
     logger::setup_logger,
     metrics::{MetricsGauge, init_metrics},
@@ -19,8 +20,14 @@ use kona_sp1_proposer::{
     signer::{Signer, SignerLock},
 };
 
+/// Command-line interface for process metadata; runtime configuration remains environment-only.
+#[derive(Debug, Parser)]
+#[command(version, about = env!("CARGO_PKG_DESCRIPTION"))]
+struct Cli {}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    Cli::parse();
     setup_logger();
 
     let config = ProposerConfig::from_env()?;


### PR DESCRIPTION
Register legacy Docker Bake and Melange/APKO builds for the kona-sp1-proposer.

Also fixes a bug in the proposer where `--help` or `--version` fails unless envars are specified. This allows the apko smoke test to work with `--version`.

Related: https://github.com/ethereum-optimism/optimism/issues/22110