### PR TITLE
op-reth: recover proof history gaps on startup

### DIFF
--- a/rust/op-reth/crates/exex/src/lib.rs
+++ b/rust/op-reth/crates/exex/src/lib.rs
@@ -215,6 +215,8 @@ where
             pruner,
         );
 
+        engine_handle.sync_to(self.ctx.provider().best_block_number()?)?;
+
         while let Some(notification) = self.ctx.notifications.try_next().await? {
             self.handle_notification(notification, &engine_handle)?;
         }


### PR DESCRIPTION
Closes #22089.

If the proofs exex experiences a shutdown while buffering blocks in memory, it will start up with the proofs db behind reth's db. If the EL does not have peers or the chain is not producing blocks, then it will remain behind forever. Sync to tip on startup to reconcile the databases right away.

If the EL is receiving blocks, this shouldn't be necessary since the sync target will be updated on the next `ChainCommitted` event.