### PR TITLE
op-node: reject unhandled payload statuses in CommitBlock

### DIFF
--- a/op-node/rollup/engine/api.go
+++ b/op-node/rollup/engine/api.go
@@ -127,13 +127,17 @@ func (e *EngineController) CommitBlock(ctx context.Context, signed *opsigner.Sig
 	}
 
 	switch status.Status {
-	case eth.ExecutionInvalid, eth.ExecutionInvalidBlockHash:
+	case eth.ExecutionValid, eth.ExecutionSyncing, eth.ExecutionAccepted:
+		// Proceed to the forkchoice update. SYNCING and ACCEPTED are tolerated here to stay
+		// consistent with insertUnsafePayload, which also continues on a non-VALID-but-not-invalid
+		// status so the engine can be driven towards the new head.
+	default:
+		// Anything else (INVALID, INVALID_BLOCK_HASH, INVALID_TERMINAL_BLOCK, or a status this
+		// version does not recognize) must not become the unsafe head.
 		return &rpc.JsonError{
 			Code:    apis.BuildErrCodeInvalidInput,
-			Message: fmt.Sprintf("execution invalid: %v", err),
+			Message: eth.NewPayloadErr(envelope.ExecutionPayload, status).Error(),
 		}
-	case eth.ExecutionValid:
-		break
 	}
 
 	e.SetUnsafeHead(ref)

--- a/op-node/rollup/engine/api_test.go
+++ b/op-node/rollup/engine/api_test.go
@@ -1,0 +1,86 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+// TestCommitBlockRejectsNonAcceptedStatus checks that CommitBlock only advances the unsafe
+// head for payload statuses it explicitly accepts. Statuses that are invalid, or that this
+// version does not recognize, must be reported as an error and leave the head untouched.
+func TestCommitBlockRejectsNonAcceptedStatus(t *testing.T) {
+	validationErr := "bad state root"
+	for _, tc := range []struct {
+		name   string
+		status *eth.PayloadStatusV1
+	}{
+		{
+			name:   "invalid",
+			status: &eth.PayloadStatusV1{Status: eth.ExecutionInvalid, ValidationError: &validationErr},
+		},
+		{
+			name:   "invalid terminal block",
+			status: &eth.PayloadStatusV1{Status: eth.ExecutionInvalidTerminalBlock},
+		},
+		{
+			name:   "unrecognized status",
+			status: &eth.PayloadStatusV1{Status: eth.ExecutePayloadStatus("SOMETHING_NEW")},
+		},
+		{
+			name:   "empty status",
+			status: &eth.PayloadStatusV1{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, refA0, _, payloadA1 := buildSimpleCfgAndPayload(t)
+			mockEngine := &testutils.MockEngine{}
+			emitter := &testutils.MockEmitter{}
+			ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+				metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync},
+				&testutils.MockL1Source{}, emitter, nil)
+			ec.SetUnsafeHead(refA0)
+
+			mockEngine.ExpectNewPayload(payloadA1.ExecutionPayload, nil, tc.status, nil)
+
+			err := ec.CommitBlock(context.Background(), &opsigner.SignedExecutionPayloadEnvelope{
+				Envelope: payloadA1,
+			})
+
+			require.Error(t, err)
+			// The unsafe head must not have moved to the rejected payload.
+			require.Equal(t, refA0, ec.UnsafeL2Head())
+			mockEngine.AssertExpectations(t)
+			emitter.AssertExpectations(t)
+		})
+	}
+
+	t.Run("invalid status reports the engine's validation error", func(t *testing.T) {
+		cfg, refA0, _, payloadA1 := buildSimpleCfgAndPayload(t)
+		mockEngine := &testutils.MockEngine{}
+		emitter := &testutils.MockEmitter{}
+		ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+			metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync},
+			&testutils.MockL1Source{}, emitter, nil)
+		ec.SetUnsafeHead(refA0)
+
+		mockEngine.ExpectNewPayload(payloadA1.ExecutionPayload, nil,
+			&eth.PayloadStatusV1{Status: eth.ExecutionInvalid, ValidationError: &validationErr}, nil)
+
+		err := ec.CommitBlock(context.Background(), &opsigner.SignedExecutionPayloadEnvelope{
+			Envelope: payloadA1,
+		})
+
+		require.ErrorContains(t, err, validationErr)
+		mockEngine.AssertExpectations(t)
+		emitter.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
## Problem

`EngineController.CommitBlock` switches on the `NewPayload` status with no `default` case:

```go
switch status.Status {
case eth.ExecutionInvalid, eth.ExecutionInvalidBlockHash:
    return &rpc.JsonError{...}
case eth.ExecutionValid:
    break
}

e.SetUnsafeHead(ref)
e.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
```

Only `INVALID` and `INVALID_BLOCK_HASH` stop it. Everything else falls through to `SetUnsafeHead` + forkchoice update. That includes `INVALID_TERMINAL_BLOCK` — which `eth.NewPayloadErr` and `checkNewPayloadStatus` both treat as an error — and any status string this version doesn't recognize, including the zero value. A payload the engine did not accept can become the node's unsafe head.

Every other `NewPayload` call site in the package guards this: `insertUnsafePayload` gates on `checkNewPayloadStatus`, and `eth.NewPayloadErr` / `eth.ForkchoiceUpdateErr` both have `default` arms. This path is the outlier.

Second, smaller bug in the same block: the rejection message formats `err`, which is provably `nil` at that point — the non-nil case returns at the `if err != nil` a few lines above. The message always reads `execution invalid: <nil>`, discarding the engine's `validationError` and `latestValidHash`.

## Change

Invert the switch into an explicit accept-list and reject everything else, and use `eth.NewPayloadErr` for the message.

`VALID`, `SYNCING` and `ACCEPTED` keep exactly their current behaviour of proceeding to the forkchoice update — that mirrors `insertUnsafePayload`, which also continues on `SYNCING` so the engine can be driven toward the new head. **No status a conforming engine returns on this path changes meaning.** What changes is that `INVALID_TERMINAL_BLOCK` and unrecognized statuses now return an error instead of silently committing, and rejections carry a usable diagnostic.

## Testing

New table test in `op-node/rollup/engine/api_test.go` asserts that `INVALID`, `INVALID_TERMINAL_BLOCK`, an unrecognized status, and the empty status all return an error and leave the unsafe head untouched, plus one case asserting the engine's `validationError` reaches the caller.

Verified the test fails on `develop` before the fix — it trips at the `Emit(UnsafeUpdateEvent{...})` call, i.e. exactly the fall-through described above.

- `go test ./op-node/rollup/engine/...` — pass
- `go test ./op-node/node/... ./op-service/rpc/...` — pass
- `go build` + `go vet` on the package — clean

I could not run `op-e2e/actions/sequencer -run TestL2SequencerAPI` locally (needs `forge-artifacts`; it panics in setup before reaching this code). That test drives `CommitBlock` against a real engine on the `VALID` path, so it is the one worth watching in CI.

## Note

This path is only reachable via `opstack_commitBlockV1`, behind the off-by-default `--experimental.sequencer-api` flag, so exposure today is limited to the test-sequencer flow. I'm treating this purely as a correctness fix.

Separately, and not addressed here: `CommitBlock` takes an `opsigner.SignedExecutionPayloadEnvelope` but never verifies `signed.Signature` — the only non-test callers of `VerifySignature` in the repo are in the gossip validator. Wiring that up needs a decision about what the authorized signer for this path is, which I did not want to guess at in a drive-by PR. Happy to follow up if you can point me at the intended model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)