### PR TITLE
docs: add OpenChainBench OP Mainnet RPC benchmark reference

### DIFF
--- a/docs/public-docs/app-developers/reference/rpc-providers.mdx
+++ b/docs/public-docs/app-developers/reference/rpc-providers.mdx
@@ -233,6 +233,10 @@ The OP Stack RPC Directory is maintained by OP Labs with the following policies:
 *   To be listed, providers must support at least one network in the [OP Stack ecosystem](/op-stack/protocol/superchain-registry)
 *   Anyone can submit a PR to remove a provider that does not support a listed network
 
+## Independent benchmarks
+
+For an independent latency and reliability comparison of public OP Mainnet RPC endpoints, see the [OpenChainBench Optimism RPC benchmark](https://openchainbench.com/benchmarks/optimism-rpc). It covers a set of community providers, with latency (p50/p90/p99) and success rate probed every 60 seconds from three regions and published under CC BY 4.0 alongside the open-source harness.
+
 ## Next steps
 
 *   Want to run your own node? See the [Node operators overview](/node-operators/overview).


### PR DESCRIPTION
Adds a short reference to [OpenChainBench](https://openchainbench.com/benchmarks/optimism-rpc) in the RPC providers page, under a new "Independent benchmarks" section placed just before "Next steps".

OpenChainBench is an open-source, CC BY 4.0 latency/reliability benchmark that probes public OP Mainnet RPC endpoints every 60 seconds from three regions and publishes p50/p90/p99 latency and success rate. It gives developers an independent, data-driven way to compare providers listed on this page before choosing one for production.

No changes to existing content — one section added at the end of the reference page.