### PR TITLE
op-conductor: route raft logs through application logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/google/gofuzz v1.2.1-0.20220503160820-4a35382e8fc8
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/hashicorp/go-hclog v1.6.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/raft v1.7.3
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
@@ -142,7 +143,6 @@ require (
 	github.com/google/pprof v0.0.0-20241009165004-a3522334989c // indirect
 	github.com/graph-gophers/graphql-go v1.3.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.11 // indirect
-	github.com/hashicorp/go-hclog v1.6.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
 	github.com/hashicorp/go-metrics v0.5.4 // indirect
 	github.com/hashicorp/go-msgpack/v2 v2.1.2 // indirect

--- a/op-conductor/consensus/raft.go
+++ b/op-conductor/consensus/raft.go
@@ -76,6 +76,7 @@ func checkTCPPortOpen(address string) error {
 // NewRaftConsensus creates a new RaftConsensus instance.
 func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus, error) {
 	rc := raft.DefaultConfig()
+	rc.Logger = newRaftLogger(log)
 	rc.SnapshotInterval = cfg.SnapshotInterval
 	rc.TrailingLogs = cfg.TrailingLogs
 	rc.SnapshotThreshold = cfg.SnapshotThreshold
@@ -109,7 +110,7 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 		return nil, fmt.Errorf(`boltdb.NewBoltStore(%q): %w`, stableStorePath, err)
 	}
 
-	snapshotStore, err := raft.NewFileSnapshotStoreWithLogger(baseDir, 1, rc.Logger)
+	snapshotStore, err := raft.NewFileSnapshotStoreWithLogger(baseDir, 1, rc.Logger.Named("snapshot"))
 	if err != nil {
 		return nil, fmt.Errorf(`raft.NewFileSnapshotStore(%q): %w`, baseDir, err)
 	}
@@ -134,7 +135,7 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 	timeout := 5 * time.Second
 
 	// When advertiseAddr == nil, the transport will use the local address that it is bound to.
-	transport, err := raft.NewTCPTransportWithLogger(bindAddr, advertiseAddr, maxConnPool, timeout, rc.Logger)
+	transport, err := raft.NewTCPTransportWithLogger(bindAddr, advertiseAddr, maxConnPool, timeout, rc.Logger.Named("network"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create raft tcp transport: %w", err)
 	}

--- a/op-conductor/consensus/raft_logger.go
+++ b/op-conductor/consensus/raft_logger.go
@@ -1,0 +1,41 @@
+package consensus
+
+import (
+	"io"
+
+	"github.com/ethereum/go-ethereum/log"
+	hclog "github.com/hashicorp/go-hclog"
+)
+
+type raftLogSink struct {
+	log log.Logger
+}
+
+func (s *raftLogSink) Accept(name string, level hclog.Level, msg string, args ...interface{}) {
+	if name != "" {
+		args = append([]interface{}{"component", name}, args...)
+	}
+
+	switch level {
+	case hclog.Trace:
+		s.log.Trace(msg, args...)
+	case hclog.Debug:
+		s.log.Debug(msg, args...)
+	case hclog.Info, hclog.NoLevel:
+		s.log.Info(msg, args...)
+	case hclog.Warn:
+		s.log.Warn(msg, args...)
+	case hclog.Error:
+		s.log.Error(msg, args...)
+	}
+}
+
+func newRaftLogger(log log.Logger) hclog.Logger {
+	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
+		Name:   "raft",
+		Level:  hclog.Trace,
+		Output: io.Discard,
+	})
+	logger.RegisterSink(&raftLogSink{log: log})
+	return logger
+}

--- a/op-conductor/consensus/raft_logger_test.go
+++ b/op-conductor/consensus/raft_logger_test.go
@@ -1,0 +1,57 @@
+package consensus
+
+import (
+	"log/slog"
+	"testing"
+
+	gethlog "github.com/ethereum/go-ethereum/log"
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+func TestRaftLoggerUsesAppLogLevel(t *testing.T) {
+	log, captured := testlog.CaptureLogger(t, slog.LevelInfo)
+	raftLog := newRaftLogger(log)
+
+	raftLog.Trace("trace message")
+	raftLog.Debug("debug message")
+	raftLog.Info("info message", "term", uint64(1))
+	raftLog.Warn("warn message")
+	raftLog.Error("error message")
+
+	require.Nil(t, captured.FindLog(testlog.NewMessageFilter("trace message")))
+	require.Nil(t, captured.FindLog(testlog.NewMessageFilter("debug message")))
+	require.NotNil(t, captured.FindLog(
+		testlog.NewMessageFilter("info message"),
+		testlog.NewLevelFilter(slog.LevelInfo),
+		testlog.NewAttributesFilter("component", "raft"),
+		testlog.NewAttributesFilter("term", "1"),
+	))
+	require.NotNil(t, captured.FindLog(
+		testlog.NewMessageFilter("warn message"),
+		testlog.NewLevelFilter(slog.LevelWarn),
+	))
+	require.NotNil(t, captured.FindLog(
+		testlog.NewMessageFilter("error message"),
+		testlog.NewLevelFilter(slog.LevelError),
+	))
+}
+
+func TestRaftLoggerMapsDebugAndTraceLevels(t *testing.T) {
+	log, captured := testlog.CaptureLogger(t, gethlog.LevelTrace)
+	raftLog := newRaftLogger(log)
+
+	raftLog.Log(hclog.Trace, "trace message")
+	raftLog.Log(hclog.Debug, "debug message")
+
+	require.NotNil(t, captured.FindLog(
+		testlog.NewMessageFilter("trace message"),
+		testlog.NewLevelFilter(gethlog.LevelTrace),
+	))
+	require.NotNil(t, captured.FindLog(
+		testlog.NewMessageFilter("debug message"),
+		testlog.NewLevelFilter(slog.LevelDebug),
+	))
+}


### PR DESCRIPTION
## Summary

- route HashiCorp Raft logs through op-conductor's configured application logger
- apply the existing log level and formatting to Raft core, snapshot, and network logs
- preserve Raft subsystem names and severity when forwarding records

## Root cause

`raft.DefaultConfig` defaults to debug logging and creates an independent logger on stderr when no logger is provided. Op-conductor left that logger unset, so Raft logs bypassed `--log.level` and could be classified as errors by log collectors based on their stderr stream.

## Impact

Raft logs now respect op-conductor's configured log level and use the same structured output path as the rest of the service. With the default info level, Raft debug logs are suppressed instead of being emitted independently to stderr.

## Validation

- `just lint-go` (`0 issues`)
- `go test ./op-conductor/...`
- `go vet ./op-conductor/...`
- `go mod tidy -diff`
