### PR TITLE
op-devstack: wire OpRethOptions into the default single-chain primary

### DIFF
--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -148,6 +148,7 @@ func validatePresetConfig(cfg sysgo.PresetConfig) error {
 const minimalPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindBatcher |
 	optionKindProposer |
+	optionKindOpReth |
 	optionKindGlobalL2CL |
 	optionKindL1EL |
 	optionKindAddedGameType |

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -250,6 +250,9 @@ func WithOPRBuilderOption(opt sysgo.OPRBuilderNodeOption) Option {
 	}
 }
 
+// WithOpRethOption applies an op-reth option to the preset's sequencer EL. Presets that add further
+// nodes start those verifiers on a stock op-reth, so a binary override here yields a premium-builds
+// / stock-verifies split rather than a uniform swap.
 func WithOpRethOption(opt sysgo.OpRethOption) Option {
 	var kinds optionKinds
 	if opt != nil {

--- a/op-devstack/presets/options_test.go
+++ b/op-devstack/presets/options_test.go
@@ -108,6 +108,12 @@ func TestUnsupportedPresetOptionKinds(t *testing.T) {
 			want:      0,
 		},
 		{
+			name:      "minimal allows op-reth options",
+			supported: minimalPresetSupportedOptionKinds,
+			opts:      WithOpRethOption(sysgo.OpRethWithBinary("op-reth-superset")),
+			want:      0,
+		},
+		{
 			name:      "flashblocks allows builder and deployer adapters",
 			supported: singleChainWithFlashblocksPresetSupportedOptionKinds,
 			opts: Combine(

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -99,7 +99,7 @@ func startDefaultSingleChainPrimary(
 		cfg.SafeDBPath = safeDBPath
 	})}
 	l2CLOptions = append(l2CLOptions, cfg.GlobalL2CLOptions...)
-	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, NewELNodeIdentity(0))
+	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, NewELNodeIdentity(0), cfg.OpRethOptions...)
 	if world.Interop != nil {
 		l2CL := startL2CLNode(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 			Key:           "sequencer",


### PR DESCRIPTION
## What

`startSequencerEL` already accepts `...OpRethOption`, and the flashblocks variant threads `cfg.OpRethOptions` through it. `startDefaultSingleChainPrimary` did not — it dropped them, so `optionKindOpReth` was (correctly) rejected by the minimal presets' validation rather than silently no-oping.

This passes `cfg.OpRethOptions` through and adds `optionKindOpReth` to `minimalPresetSupportedOptionKinds`.

## Why

So a test can point the sequencer EL at a CLI-superset op-reth binary via `presets.WithOpRethOption(sysgo.OpRethWithBinary(...))`, resolved through the existing `RUST_BINARY_PATH_<NAME>` mechanism.

This is the same seam #21987 established for the SDM harness with per-node `OpRethOpts`, extended to the presets that already run a plain op-reth sequencer. It lets an out-of-tree suite reuse in-tree acceptance tests unmodified instead of vendoring copies of their assertions, which drift.

Concretely, it makes the block-building packages (`jovian`, `batcher/throttling`, `fjord`, `ecotone`, `isthmus/operator_fee`, the root Osaka gas/size tests) runnable against a superset binary for differential coverage on dependency bumps.

## Scope

Purely additive — no behavior change for existing runs:

- `cfg.OpRethOptions` is empty unless a test passes `WithOpRethOption`, so `startSequencerEL` receives the same zero arguments it does today.
- The `startL2ELForKey` EL-kind dispatch is untouched; `DEVSTACK_L2EL_KIND` behaves exactly as before.
- No test file changes beyond one added validation case.

Only the **sequencer** EL is affected. The multi-node variants keep starting their additional nodes on a stock `op-reth` via `addSingleChainOpNode`, which is the useful shape: the sequencer builds, an independent stock EL verifies. `WithOpRethOption` now carries a doc comment stating that boundary so the asymmetry isn't surprising.

## Testing

Added a case to `TestUnsupportedPresetOptionKinds`. Verified it fails on the unmodified code (`optionKindOpReth` = `0x10` reported unsupported) and passes with the change. `go build ./op-devstack/...`, `go test ./op-devstack/presets/...`, and `go vet` on both touched packages are clean.

Not covered here: no acceptance test in-tree currently passes this option through a minimal preset, so the end-to-end path is exercised only by out-of-tree consumers for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)