### PR TITLE
ci: link cargo test binaries with mold

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -272,7 +272,12 @@ jobs:
           name: Run cargo tests
           working_directory: <<parameters.directory>>
           no_output_timeout: 40m
-          command: just <<parameters.command>> <<parameters.flags>>
+          # mold (pinned via mise; also present in ci-base-clang) cuts the link
+          # time of the many nextest test binaries. `mold -run` intercepts the
+          # linker at exec time, so it needs no RUSTFLAGS change and does not
+          # perturb the sccache compile-cache key. The CI env is controlled, so
+          # a missing mold must fail loudly rather than silently falling back.
+          command: mold -run just <<parameters.command>> <<parameters.flags>>
       # Surface individual test results in the CircleCI UI, including on failure.
       # nextest writes JUnit to <workspace>/target/nextest/default/junit.xml.
       - store_test_results:


### PR DESCRIPTION
## Description

nextest builds and links one binary per test target, so link time is a meaningful slice of the `rust-tests` / cargo-test job wall-clock. #22042 already switched the `rust-build` command to the mold linker; this PR applies the same `mold -run` interception to the `rust-ci-cargo-tests` jobs.

- `mold -run` intercepts the linker at exec time — no `RUSTFLAGS` change, so build and sccache compile-cache keys are unaffected.
- mold is pinned via mise (linux-only) and present in `ci-base-clang`, so no install step is needed. A missing mold fails loudly rather than silently falling back to the default linker.

Revives the mold prototype from #20930 (auto-closed as stale), minus the apt-get install step that is no longer needed.

## Measurements (compile phase)

Compile+link wall time of the `Run cargo tests` step (checkout/cache steps excluded, nextest execution time — a constant ~26s / ~5s — subtracted). Samples: the original run plus 5 targeted job reruns per configuration, interleaved with 5 fresh no-mold control reruns on a sibling branch (#22200) so cache/network conditions match. All 2026-08-03.

| job | with mold (n=6) | without mold (n=8) |
|---|---|---|
| `rust-tests` | median **851s** (820–872) | median **810s** (776–839) |
| `op-reth-integration-tests` | median **439s** (407–483) | median **443s** (411–456) |

**Verdict: no speedup.** `rust-tests` is ~5% slower with mold at the median — 5 of 6 mold samples sit at or above the control's 75th percentile — and `op-reth-integration-tests` is parity within noise. On these warm-cache incremental builds, link time is not the bottleneck the PR assumed (nextest reuses previously linked binaries for unchanged crates, so a PR-CI run does little fresh linking for `mold -run` to accelerate).

## Validation

`merge-configs.sh` + `circleci config validate` + `circleci config process` with all `c-run_*` params enabled pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

