### PR TITLE
ci: cache forge build artifacts in contracts-bedrock-build

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1088,21 +1088,13 @@ jobs:
       - run:
           name: Compute forge build cache key
           command: |
-            # Hash every input that affects forge output: all tracked files in
-            # the package (sources, foundry.toml, justfile, and the lib/
-            # submodule gitlink pins — git ls-files -s covers them all via
-            # index blob SHAs), the toolchain pins (mise.toml), and the build
-            # profile/args. Exact-key only (no fallback restore) so a hit
-            # always corresponds to these exact inputs — a stale hit could
-            # serve artifacts for deleted or renamed contracts. A miss is just
-            # a normal clean build.
-            #
-            # Deliberately not keyed: the installed solc set, which floating
-            # pragmas (interfaces/, scripts/) resolve against. If it changes,
-            # forge spots the per-artifact compiler mismatch and recompiles
-            # the delta on top of this cache — a smaller build, never a stale
-            # one. Keying on it would instead cost spurious misses whenever
-            # the svm cache drifts.
+            # Key over every input affecting forge output: all tracked package
+            # files via `git ls-files -s` (sources, config, lib/ submodule
+            # pins), mise.toml toolchain pins, and profile/args. Exact-key only
+            # (no fallback restore): a hit never serves artifacts for changed
+            # or deleted contracts; a miss is a normal clean build. The
+            # installed solc set is deliberately unkeyed — drift only makes
+            # forge recompile mismatched artifacts, never serve stale ones.
             {
               echo "profile=<<parameters.profile>> args=<<parameters.build_args>>"
               sha256sum mise.toml

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1086,11 +1086,48 @@ jobs:
           name: Print forge version
           command: forge --version
       - run:
+          name: Compute forge build cache key
+          command: |
+            # Hash every input that affects forge output: all tracked files in
+            # the package (sources, foundry.toml, justfile, and the lib/
+            # submodule gitlink pins — git ls-files -s covers them all via
+            # index blob SHAs), the toolchain pins (mise.toml), and the build
+            # profile/args. Exact-key only (no fallback restore) so a hit
+            # always corresponds to these exact inputs — a stale hit could
+            # serve artifacts for deleted or renamed contracts. A miss is just
+            # a normal clean build.
+            #
+            # Deliberately not keyed: the installed solc set, which floating
+            # pragmas (interfaces/, scripts/) resolve against. If it changes,
+            # forge spots the per-artifact compiler mismatch and recompiles
+            # the delta on top of this cache — a smaller build, never a stale
+            # one. Keying on it would instead cost spurious misses whenever
+            # the svm cache drifts.
+            {
+              echo "profile=<<parameters.profile>> args=<<parameters.build_args>>"
+              sha256sum mise.toml
+              git ls-files -s -- packages/contracts-bedrock
+            } | sha256sum | cut -d' ' -f1 | tee /tmp/forge-cache-key.txt
+      - restore_cache:
+          name: Restore forge build cache
+          keys:
+            - forge-build-v1-<<parameters.profile>>-{{ checksum "/tmp/forge-cache-key.txt" }}
+      - run:
           name: Build contracts
           command: just forge-build <<parameters.build_args>>
           environment:
             FOUNDRY_PROFILE: <<parameters.profile>>
           working_directory: packages/contracts-bedrock
+      - save_cache:
+          name: Save forge build cache
+          key: forge-build-v1-<<parameters.profile>>-{{ checksum "/tmp/forge-cache-key.txt" }}
+          # These paths hold for profiles that keep foundry.toml's default
+          # output dirs; a profile that redirects them (e.g. kprove's
+          # out = kout-proofs) needs this list extended.
+          paths:
+            - packages/contracts-bedrock/cache
+            - packages/contracts-bedrock/artifacts
+            - packages/contracts-bedrock/forge-artifacts
       # copy-contract-artifacts runs `go run ... mktar`, which needs the Go
       # module set. Restore the shared cache (warmed by prep-go-modules) so it
       # doesn't hit proxy.golang.org.


### PR DESCRIPTION
## Description

`contracts-bedrock-build` runs a full forge compile on every pipeline, including the many (rust-e2e, acceptance, go) where nothing under `packages/contracts-bedrock` changed. This adds a CircleCI cache for `cache/`, `artifacts/`, and `forge-artifacts/`: on a hit, forge's own incremental check turns the build step into a near no-op.

### Cache key

Per the write-once rules in `docs/ai/ci-config-review.md` (item 6), the key hashes every compile input: all tracked files in the package via `git ls-files -s` (sources, `foundry.toml`, `justfile`, `lib/` submodule gitlinks), `mise.toml` (toolchain pins), and the `profile`/`build_args` parameters. Content-addressed: branches with an identical contracts tree hit develop's cache.

Restore is **exact-key only**: forge never deletes stale artifacts and `copy-contract-artifacts` tars the whole dir, so a partial match could serve artifacts for deleted or renamed contracts. A miss is just a clean build.

Known residuals (documented in-step): the installed solc set is unkeyed (floating pragmas resolve against it) — forge revalidates per artifact, so drift costs a partial recompile, never staleness; save paths assume the default output dirs.

## Measurement

Five cache-hit runs on this PR vs the five most recent `develop` runs (job duration, seconds):

| `contracts-bedrock-build` | 1 | 2 | 3 | 4 | 5 | median |
|---|---|---|---|---|---|---|
| develop (cold build) | 93 | 90 | 83 | 96 | 95 | **93** |
| this PR (cache hit) | 57 | 57 | 64 | 58 | 63 | **58** |

Median speedup: **1.6×** (93s → 58s, 35s saved per run).

The seed (cache-miss) run took 85s — within develop's cold range, so a miss costs nothing. On hits the Build contracts step drops from 34s to ~3s; key computation, restore, and save together add ~1.5s.

## Validation

`merge-configs.sh` + `circleci config validate` + `circleci config process` with all `c-run_*` params enabled pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
