### PR TITLE
ci: retry transient go module and apt downloads

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1817,7 +1817,22 @@ jobs:
       - restore-go-mod-cache
       - run:
           name: Download Go modules
-          command: go mod download
+          command: |
+            # proxy.golang.org intermittently returns transient stream errors
+            # (INTERNAL_ERROR). Retry with exponential backoff so a flaky
+            # download doesn't fail this shared prep job and everything behind
+            # it.
+            n=0
+            until go mod download; do
+              n=$((n+1))
+              if [ "$n" -ge 5 ]; then
+                echo "go mod download failed after $n attempts" >&2
+                exit 1
+              fi
+              backoff=$((5 * 2 ** (n - 1)))
+              echo "go mod download failed (attempt $n); retrying in ${backoff}s..." >&2
+              sleep "$backoff"
+            done
       - save-go-mod-cache
 
   check-nut-locks:
@@ -2051,12 +2066,12 @@ jobs:
     resource_class: 2xlarge+.gen2
     parallelism: <<parameters.parallelism>>
     steps:
+      - apt-install:
+          extra_flags: "--no-install-recommends"
+          packages: "eatmydata"
       - run:
-          name: Install eatmydata and disable fsync for all subprocesses
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends eatmydata
-            echo 'export LD_PRELOAD=libeatmydata.so' >> "$BASH_ENV"
+          name: Disable fsync for all subprocesses
+          command: echo 'export LD_PRELOAD=libeatmydata.so' >> "$BASH_ENV"
       - utils/checkout-with-mise:
           checkout-method: blobless
           enable-mise-cache: true


### PR DESCRIPTION
## Description

Two download retries, each backed by verified 2026 incident data (full table below):

1. **`prep-go-modules`** — retry `go mod download`, up to 5 attempts with exponential backoff (5/10/20/40s). proxy.golang.org outages (`stream error ... INTERNAL_ERROR`) hit CI on **12 distinct days in 2026** (Feb 23, May 14/15/20/22, Jun 2/3/5/9/10/16/19). The June 3 outage is what prompted #21213 to centralize module downloads into this job — the retry guards exactly that choke point. Runs with a warm module cache download nothing and are unaffected.
2. **`Install eatmydata`** (acceptance jobs) — route through the shared `apt-install` command, picking up the `Acquire::Retries=5` + update-retry treatment from #22083. This step was the one bare `apt-get` left behind; archive.ubuntu.com fetch failures redded it on 5 days this year (Feb 4, Apr 16/17, Jul 9, Jul 22 — all predating #22083, whose treatment this step never got).

- **Absorbed:** transient download failures — proxy stream errors, timeouts, connection resets; Ubuntu mirror sync failures.
- **Still fails:** persistent errors (checksum mismatch, missing module/package), after bounded backoff.

Earlier revisions also added per-test reruns for forge and acceptance tests; dropped per review feedback — automatic test reruns hide flakes.

Revives the retry experiment from #20930.

## Year-to-date 2026 incident survey (all download/network failure classes)

Method: indexed all 33,608 failed builds Jan 1 → Aug 4; log-verified a 3,331-build sample covering every multi-branch failure spike of the year, 40 builds/month per job family, and all known outage windows. Every incident below is verified from the actual step log.

| Class | Event days in 2026 | Verified builds (sample) | Root cause | Retry-fixable? |
|---|---|---:|---|---|
| proxy.golang.org | 12 — Feb 23, May 14/15/20/22, Jun 2/3/5/9/10/16/19 | ~50 | `stream error ... INTERNAL_ERROR` fetching module zips | **Yes → item 1** (residual per-job fetch surfaces: go-lint tool deps, op-program-compat) |
| mise tool installs | 10 — Feb 10/17, Mar 13/26/30, Apr 9/13/27, Jul 16/17 | 275 | GitHub API 403 rate limits, missing release attestations, wrapper exit-code quirk | **No** — already retries 4× (0/15/45/90s) and the events outlast it; needs auth/wrapper fixes (separate issue) |
| apt (archive.ubuntu.com) | 5 — Feb 4, Apr 16/17, Jul 9/22 | 55 | `Failed to fetch .../InRelease Connection failed` | **Yes → item 2** |
| Docker image pull (Spin up environment) | 3 — Mar 27, May 19, Jun 2 | 37 | Executor failing to pull the job image | No — precedes user steps; not addressable in config |
| git checkout | 6 | 29 + 21 orb-bug | GitHub connectivity; orb `repo url ''` bug | Orb territory (235 further merge-queue "failed to fetch repo" hits are deleted-ref lifecycle noise, excluded) |
| cargo / crates.io | 0 | 0 | — | Clean year-to-date; cargo's built-in retries suffice |
| svm / solc download | 0 | 0 | — | Clean year-to-date |

Counts are lower bounds from a targeted ~10% sample; clustered outages are reliably discovered, singleton one-off flakes are underrepresented.

## Validation

`merge-configs.sh` + `circleci config validate` + `circleci config process --org-slug gh/ethereum-optimism` with all `c-run_*` params enabled pass locally; `test-decision-tree.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
