### PR TITLE
kona-proof: sample field elements in test_roots_of_unity

### DIFF
--- a/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
@@ -158,6 +158,7 @@ fn generate_roots_of_unity() -> [Fr; FIELD_ELEMENTS_PER_BLOB as usize] {
 #[cfg(test)]
 mod test {
     use super::ROOTS_OF_UNITY;
+    use alloc::vec::Vec;
     use alloy_eips::eip4844::{FIELD_ELEMENTS_PER_BLOB, env_settings::EnvKzgSettings};
     use ark_ff::{BigInteger, PrimeField};
     use c_kzg::{BYTES_PER_BLOB, Blob, Bytes32, Bytes48};
@@ -189,14 +190,17 @@ mod test {
         // the table build breaks thousands of entries and fails on the first
         // sampled index. Indices 0 and 4095 — the entries a fill-loop
         // off-by-one would leave at Fr::ZERO, and both mapping to themselves
-        // under the bit-reversal permutation — are always checked.
+        // under the bit-reversal permutation — are always checked; the random
+        // sample is drawn from the interior so all checked indices are distinct.
         const SAMPLED_FIELD_ELEMENTS: usize = 32;
-        let mut indices = rand::seq::index::sample(
+        let mut indices: Vec<usize> = rand::seq::index::sample(
             &mut rand::rng(),
-            FIELD_ELEMENTS_PER_BLOB as usize,
+            FIELD_ELEMENTS_PER_BLOB as usize - 2,
             SAMPLED_FIELD_ELEMENTS,
         )
-        .into_vec();
+        .into_iter()
+        .map(|interior_index| interior_index + 1)
+        .collect();
         indices.extend([0, FIELD_ELEMENTS_PER_BLOB as usize - 1]);
 
         indices.into_par_iter().for_each(|i| {

--- a/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
@@ -211,13 +211,14 @@ mod test {
             };
 
             let z_bytes = Bytes32::new(ROOTS_OF_UNITY[i].into_bigint().to_bytes_be().try_into().unwrap());
-            let (proof, fe) = kzg.get().compute_kzg_proof(&blob, &z_bytes).unwrap();
+            let (proof, evaluated_field_element) =
+                kzg.get().compute_kzg_proof(&blob, &z_bytes).unwrap();
 
             // Ensure the field element matches the expected value
             assert_eq!(
-                fe.as_slice(),
+                evaluated_field_element.as_slice(),
                 field_element.as_slice(),
-                "Field element {i} does not match the expected value. Expected: {field_element:?}, Got: {fe:?}"
+                "Field element {i} does not match the expected value. Expected: {field_element:?}, Got: {evaluated_field_element:?}"
             );
 
             // Ensure the proof can be verified

--- a/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
@@ -192,14 +192,22 @@ mod test {
         // the table build breaks thousands of entries and fails on the first
         // sampled index. Indices 0 and 4095 — the entries a fill-loop
         // off-by-one would leave at Fr::ZERO, and both mapping to themselves
-        // under the bit-reversal permutation — are always checked; the random
-        // sample is drawn from the interior so all checked indices are distinct.
-        const SAMPLED_FIELD_ELEMENTS: usize = 256;
-        let mut indices: Vec<usize> =
-            rand::seq::index::sample(&mut rand::rng(), FIELD_ELEMENTS - 2, SAMPLED_FIELD_ELEMENTS)
-                .into_iter()
-                .map(|interior_index| interior_index + 1)
-                .collect();
+        // under the bit-reversal permutation — are always checked; the remaining
+        // draws come from the interior so all checked indices are distinct.
+        //
+        // 256 (kept a power of two) fills the ~5s CI budget agreed in review:
+        // checking n elements costs ~1.4s fixed + ~5.1ms each locally
+        // (n=34: 1.54s, n=258: 2.69s, n=514: 4.01s), and CI ran n=34 at
+        // 1.85x local (2.85s), so n=256 projects to ~5.0s in CI.
+        const CHECKED_FIELD_ELEMENTS: usize = 256;
+        let mut indices: Vec<usize> = rand::seq::index::sample(
+            &mut rand::rng(),
+            FIELD_ELEMENTS - 2,
+            CHECKED_FIELD_ELEMENTS - 2,
+        )
+        .into_iter()
+        .map(|interior_index| interior_index + 1)
+        .collect();
         indices.extend([0, FIELD_ELEMENTS - 1]);
 
         indices.into_par_iter().for_each(|i| {

--- a/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
@@ -184,15 +184,29 @@ mod test {
             Bytes48::new(raw.as_slice().try_into().unwrap())
         };
 
-        // Validate each field element in the blob
-        (0..FIELD_ELEMENTS_PER_BLOB).into_par_iter().for_each(|i| {
+        // A KZG proof per element makes the full FIELD_ELEMENTS_PER_BLOB sweep
+        // too slow for CI, so check a random sample instead: a structural bug in
+        // the table build breaks thousands of entries and fails on the first
+        // sample. The first and last indices are the fixed points of the
+        // bit-reversal permutation — the entries an off-by-one would strand —
+        // so they are always checked.
+        const SAMPLED_FIELD_ELEMENTS: usize = 32;
+        let mut indices = rand::seq::index::sample(
+            &mut rand::rng(),
+            FIELD_ELEMENTS_PER_BLOB as usize,
+            SAMPLED_FIELD_ELEMENTS,
+        )
+        .into_vec();
+        indices.extend([0, FIELD_ELEMENTS_PER_BLOB as usize - 1]);
+
+        indices.into_par_iter().for_each(|i| {
             let field_element = {
                 let mut fe = [0u8; 32];
-                fe.copy_from_slice(&blob[(i as usize) << 5..(i as usize + 1) << 5]);
+                fe.copy_from_slice(&blob[i << 5..(i + 1) << 5]);
                 Bytes32::new(fe)
             };
 
-            let z_bytes = Bytes32::new(ROOTS_OF_UNITY[i as usize].into_bigint().to_bytes_be().try_into().unwrap());
+            let z_bytes = Bytes32::new(ROOTS_OF_UNITY[i].into_bigint().to_bytes_be().try_into().unwrap());
             let (proof, fe) = kzg.get().compute_kzg_proof(&blob, &z_bytes).unwrap();
 
             // Ensure the field element matches the expected value

--- a/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
@@ -192,8 +192,11 @@ mod test {
         // the table build breaks thousands of entries and fails on the first
         // sampled index. Indices 0 and 4095 — the entries a fill-loop
         // off-by-one would leave at Fr::ZERO, and both mapping to themselves
-        // under the bit-reversal permutation — are always checked; the remaining
-        // draws come from the interior so all checked indices are distinct.
+        // under the bit-reversal permutation — are always checked, as are 1 and
+        // 4094, which the permutation moves (1 ↔ 2048, 4094 ↔ 2047) and so
+        // deterministically expose a dropped or wrong bit-reversal pass; the
+        // remaining draws come from the interior so all checked indices are
+        // distinct.
         //
         // 256 (kept a power of two) fills the ~5s CI budget agreed in review:
         // checking n elements costs ~1.4s fixed + ~5.1ms each locally
@@ -202,13 +205,13 @@ mod test {
         const CHECKED_FIELD_ELEMENTS: usize = 256;
         let mut indices: Vec<usize> = rand::seq::index::sample(
             &mut rand::rng(),
-            FIELD_ELEMENTS - 2,
-            CHECKED_FIELD_ELEMENTS - 2,
+            FIELD_ELEMENTS - 4,
+            CHECKED_FIELD_ELEMENTS - 4,
         )
         .into_iter()
-        .map(|interior_index| interior_index + 1)
+        .map(|interior_index| interior_index + 2)
         .collect();
-        indices.extend([0, FIELD_ELEMENTS - 1]);
+        indices.extend([0, 1, FIELD_ELEMENTS - 2, FIELD_ELEMENTS - 1]);
 
         indices.into_par_iter().for_each(|i| {
             let field_element = {

--- a/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
@@ -161,12 +161,14 @@ mod test {
     use alloc::vec::Vec;
     use alloy_eips::eip4844::{FIELD_ELEMENTS_PER_BLOB, env_settings::EnvKzgSettings};
     use ark_ff::{BigInteger, PrimeField};
-    use c_kzg::{BYTES_PER_BLOB, Blob, Bytes32, Bytes48};
+    use c_kzg::{BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT, Blob, Bytes32, Bytes48};
     use rand::Rng;
     use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
     #[test]
     fn test_roots_of_unity() {
+        const FIELD_ELEMENTS: usize = FIELD_ELEMENTS_PER_BLOB as usize;
+
         // Initiate the default Ethereum KZG settings.
         let kzg = EnvKzgSettings::default();
 
@@ -174,10 +176,10 @@ mod test {
         let mut bytes = [0u8; BYTES_PER_BLOB];
         rand::rng().fill(bytes.as_mut_slice());
 
-        // Ensure the blob is valid by keeping each field element within range.
-        (0..FIELD_ELEMENTS_PER_BLOB).for_each(|i| {
-            bytes[(i as usize) << 5] = 0;
-        });
+        // Zero each field element's most significant byte to keep it below the BLS modulus.
+        bytes
+            .chunks_exact_mut(BYTES_PER_FIELD_ELEMENT)
+            .for_each(|field_element| field_element[0] = 0);
 
         let blob = Blob::new(bytes);
         let blob_commitment = {
@@ -193,15 +195,12 @@ mod test {
         // under the bit-reversal permutation — are always checked; the random
         // sample is drawn from the interior so all checked indices are distinct.
         const SAMPLED_FIELD_ELEMENTS: usize = 32;
-        let mut indices: Vec<usize> = rand::seq::index::sample(
-            &mut rand::rng(),
-            FIELD_ELEMENTS_PER_BLOB as usize - 2,
-            SAMPLED_FIELD_ELEMENTS,
-        )
-        .into_iter()
-        .map(|interior_index| interior_index + 1)
-        .collect();
-        indices.extend([0, FIELD_ELEMENTS_PER_BLOB as usize - 1]);
+        let mut indices: Vec<usize> =
+            rand::seq::index::sample(&mut rand::rng(), FIELD_ELEMENTS - 2, SAMPLED_FIELD_ELEMENTS)
+                .into_iter()
+                .map(|interior_index| interior_index + 1)
+                .collect();
+        indices.extend([0, FIELD_ELEMENTS - 1]);
 
         indices.into_par_iter().for_each(|i| {
             let field_element = {

--- a/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
@@ -187,9 +187,9 @@ mod test {
         // A KZG proof per element makes the full FIELD_ELEMENTS_PER_BLOB sweep
         // too slow for CI, so check a random sample instead: a structural bug in
         // the table build breaks thousands of entries and fails on the first
-        // sample. The first and last indices are the fixed points of the
-        // bit-reversal permutation — the entries an off-by-one would strand —
-        // so they are always checked.
+        // sampled index. Indices 0 and 4095 — the entries a fill-loop
+        // off-by-one would leave at Fr::ZERO, and both mapping to themselves
+        // under the bit-reversal permutation — are always checked.
         const SAMPLED_FIELD_ELEMENTS: usize = 32;
         let mut indices = rand::seq::index::sample(
             &mut rand::rng(),

--- a/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
@@ -194,7 +194,7 @@ mod test {
         // off-by-one would leave at Fr::ZERO, and both mapping to themselves
         // under the bit-reversal permutation — are always checked; the random
         // sample is drawn from the interior so all checked indices are distinct.
-        const SAMPLED_FIELD_ELEMENTS: usize = 32;
+        const SAMPLED_FIELD_ELEMENTS: usize = 256;
         let mut indices: Vec<usize> =
             rand::seq::index::sample(&mut rand::rng(), FIELD_ELEMENTS - 2, SAMPLED_FIELD_ELEMENTS)
                 .into_iter()


### PR DESCRIPTION
## Description

`test_roots_of_unity` verifies a KZG proof for all 4096 field elements in a blob, dominating the kona-proof suite wall-clock (~45s in CI). It now checks 256 elements per run (a power of two): 252 random interior draws plus 0, 1, 4094, and 4095 pinned. Sized to the ~5s budget from review: measured 4.2s in CI, 2.6s locally.

### Why the coverage holds

- Structural bugs in the `ROOTS_OF_UNITY` table build (wrong `shift_correction`, dropped bit-reversal guard, `Fr::ZERO` seed) break thousands of entries and fail on the first sampled index.
- Indices 0 and 4095 — what a fill-loop off-by-one strands at `Fr::ZERO`, and self-mapping under the bit-reversal permutation — are always checked; 1 and 4094 are moved by it (1 ↔ 2048, 4094 ↔ 2047), deterministically exposing a dropped or wrong permutation pass.
- The sample comes from the interior, so all 256 indices are distinct; asserts print the failing index, and the table is deterministic, so failures reproduce despite the random blob.

### Review findings (applied)

- Renamed the KZG-evaluated `fe` to `evaluated_field_element` — the assert compared two near-identical names for expected vs computed.
- Canonicalization zeroes each element's most significant byte via `chunks_exact_mut(BYTES_PER_FIELD_ELEMENT)`, keeping big-endian elements below the BLS modulus; a hoisted usize count drops repeated casts.
- Spot-checked: `blob[i << 5..(i + 1) << 5]` bounds are exact at i = 4095, and the proof is verified against the blob-derived element — the stronger assertion.

Revives the #20930 sampling experiment, hardened per review: the original drew with replacement, catching a stranded endpoint only ~0.8% of runs.

## Testing

- `cargo nextest run -p kona-proof test_roots_of_unity` passes (2.6s locally, 4.2s in CI).
- `cargo clippy -p kona-proof --all-features --all-targets --no-deps -- -D warnings` and pinned-nightly `fmt --check` clean.
- Test-only change inside `#[cfg(test)]` — no_std targets don't compile it, so `check-no-std` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
