### PR TITLE
op-interop-mon: clean up partial initialization safely

### DIFF
--- a/op-interop-mon/monitor/service.go
+++ b/op-interop-mon/monitor/service.go
@@ -53,9 +53,9 @@ type InteropMonitorService struct {
 }
 
 func InteropMonitorServiceFromCLIConfig(ctx context.Context, version string, cfg *CLIConfig, log log.Logger) (*InteropMonitorService, error) {
-	var ms InteropMonitorService
+	ms := InteropMonitorService{Log: log}
 	if err := ms.initFromCLIConfig(ctx, version, cfg, log); err != nil {
-		return nil, errors.Join(err, ms.Start(ctx))
+		return nil, errors.Join(err, ms.Stop(ctx))
 	}
 	return &ms, nil
 }
@@ -68,9 +68,9 @@ func InteropMonitorServiceFromClients(
 	clients map[eth.ChainID]*sources.EthClient,
 	log log.Logger,
 ) (*InteropMonitorService, error) {
-	var ms InteropMonitorService
+	ms := InteropMonitorService{Log: log}
 	if err := ms.initFromClients(ctx, version, cfg, clients, log); err != nil {
-		return nil, errors.Join(err, ms.Start(ctx))
+		return nil, errors.Join(err, ms.Stop(ctx))
 	}
 	return &ms, nil
 }
@@ -376,10 +376,12 @@ func (ms *InteropMonitorService) Stop(ctx context.Context) error {
 		}
 	}
 
-	ms.Log.Info("stopping metric collector")
-	if err := ms.collector.Stop(); err != nil {
-		result = errors.Join(result, fmt.Errorf("failed to stop metric collector: %w", err))
-		ms.Log.Error("failed to stop metric collector", "error", err)
+	if ms.collector != nil {
+		ms.Log.Info("stopping metric collector")
+		if err := ms.collector.Stop(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to stop metric collector: %w", err))
+			ms.Log.Error("failed to stop metric collector", "error", err)
+		}
 	}
 
 	ms.Log.Info("stopping rpc server")

--- a/op-interop-mon/monitor/service_test.go
+++ b/op-interop-mon/monitor/service_test.go
@@ -1,0 +1,98 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInteropMonitorStopWithMetricsDisabled(t *testing.T) {
+	cfg := serviceTestConfig()
+	cfg.MetricsConfig.Enabled = false
+
+	service, err := InteropMonitorServiceFromClients(context.Background(), "test", cfg, nil, log.New())
+	require.NoError(t, err)
+	require.NoError(t, service.Stop(context.Background()))
+	require.True(t, service.Stopped())
+}
+
+func TestInteropMonitorInitFailureCleansUpServers(t *testing.T) {
+	metricsPort := reserveLocalPort(t)
+	pprofPort := reserveLocalPort(t)
+	rpcListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rpcListener.Close()) })
+
+	cfg := serviceTestConfig()
+	cfg.MetricsConfig = opmetrics.CLIConfig{
+		Enabled:    true,
+		ListenAddr: "127.0.0.1",
+		ListenPort: metricsPort,
+	}
+	cfg.PprofConfig = oppprof.CLIConfig{
+		ListenEnabled: true,
+		ListenAddr:    "127.0.0.1",
+		ListenPort:    pprofPort,
+	}
+	cfg.RPCConfig.ListenPort = rpcListener.Addr().(*net.TCPAddr).Port
+
+	service, err := InteropMonitorServiceFromClients(context.Background(), "test", cfg, nil, log.New())
+	require.Nil(t, service)
+	require.ErrorContains(t, err, "failed to start rpc server")
+	requirePortAvailable(t, metricsPort)
+	requirePortAvailable(t, pprofPort)
+}
+
+func TestInteropMonitorPartialInitCleanupIsNilSafe(t *testing.T) {
+	service := &InteropMonitorService{Log: log.New()}
+
+	require.NoError(t, service.Stop(context.Background()))
+	require.True(t, service.Stopped())
+}
+
+func TestInteropMonitorCLIInitFailureCleanupIsNilSafe(t *testing.T) {
+	cfg := serviceTestConfig()
+	cfg.DependencySetPath = t.TempDir() + "/missing-dependency-set.json"
+
+	service, err := InteropMonitorServiceFromCLIConfig(context.Background(), "test", cfg, log.New())
+	require.Nil(t, service)
+	require.ErrorContains(t, err, "failed to load dependency set")
+}
+
+func serviceTestConfig() *CLIConfig {
+	return &CLIConfig{
+		PollInterval: time.Second,
+		RPCConfig: oprpc.CLIConfig{
+			ListenAddr: "127.0.0.1",
+			ListenPort: 0,
+		},
+		PprofConfig: oppprof.CLIConfig{
+			ListenAddr: "127.0.0.1",
+			ListenPort: 0,
+		},
+	}
+}
+
+func reserveLocalPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close())
+	return port
+}
+
+func requirePortAvailable(t *testing.T, port int) {
+	t.Helper()
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.NoError(t, err)
+	require.NoError(t, listener.Close())
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Clean up partially initialized `InteropMonitorService` instances when construction fails.

Both service constructors previously called `Start` after an initialization error:

```go
return nil, errors.Join(err, ms.Start(ctx))
```

This could start finders, updaters, and the metric collector after construction had already failed. Since the constructor returns a nil service, the caller would have no way to stop these background tasks or any HTTP servers started earlier in initialization.

The constructors now call Stop on initialization failure instead.

This also makes partial cleanup safe when metrics are disabled. The metric collector is only created when metrics are enabled, but Stop previously called ms.collector.Stop() unconditionally, causing a nil-pointer panic.

The logger is initialized before running either initialization path so cleanup is also safe when the CLI constructor fails before initFromClients.



**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

`cd op-interop-mon && just test`

`go test -race ./op-interop-mon/monitor -run 'TestInteropMonitor(StopWithMetricsDisabled|InitFailureCleansUpServers|PartialInitCleanupIsNilSafe|CLIInitFailureCleanupIsNilSafe)$' -count=1`



**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
