### PR TITLE
kona: constrain prestate artifact directories

### DIFF
--- a/rust/justfile
+++ b/rust/justfile
@@ -629,8 +629,8 @@ kona-prestate-variants:
     for pair in {{KONA_PRESTATE_VARIANTS}}; do
       variant="${pair%%:*}"
       dir="${pair#*:}"
-      if [[ -z "$variant" || -z "$dir" || "$variant" == "$pair" ]]; then
-        echo "malformed KONA_PRESTATE_VARIANTS entry '${pair}', want '<cargo bin>:<artifacts dir>'" >&2
+      if [[ -z "$variant" || "$variant" == "$pair" || ! "$dir" =~ ^prestate-artifacts-[a-zA-Z0-9_-]+$ ]]; then
+        echo "malformed KONA_PRESTATE_VARIANTS entry '${pair}', want '<cargo bin>:prestate-artifacts-<name>'" >&2
         exit 1
       fi
       lines+=("${variant} ${dir}")


### PR DESCRIPTION
Require Kona prestate artifact directories to be direct `prestate-artifacts-*` basenames before cleanup and staging recipes consume them. This prevents absolute, nested, or traversal paths from reaching `rm -rf`.

Each client variant writes to its own artifact directory under `rust/kona`, and CI, devstack, and reproducibility tooling all expect those paths. Since the same directory names are also used when cleaning up old artifacts, we restrict them to `prestate-artifacts-*` directories directly under `rust/kona` so they can’t point somewhere else.