### PR TITLE
op-devstack: let acceptance suites select the sequencer EL binary

### DIFF
--- a/op-acceptance-tests/tests/sdm/init_test.go
+++ b/op-acceptance-tests/tests/sdm/init_test.go
@@ -73,11 +73,11 @@ func buildSDMRethSystem(t devtest.T, interopAtGenesis bool, isolateVerifier bool
 	// kona-node on both the sequencer and verifier (defaults to op-node when unset).
 	clKind := sysgo.ResolveMixedL2CLKind()
 
-	// Applied to the sequencer only: an external suite pointing DEVSTACK_L2EL_BINARY at its own
-	// builder gets that builder producing blocks while a stock op-reth verifies them, so any
-	// block it produces that stock op-reth rejects fails the run. Overriding both nodes would
+	// Applied to the sequencer only: an external suite pointing DEVSTACK_L2EL_OVERRIDE_BINARY at
+	// its own builder gets that builder producing blocks while a stock op-reth verifies them, so
+	// any block it produces that stock op-reth rejects fails the run. Overriding both nodes would
 	// let a self-consistent divergence pass.
-	sequencerELOpts := sysgo.ResolveMixedL2ELOpts()
+	sequencerELOpts := sysgo.ResolveMixedL2ELOpts(t)
 
 	runtime := sysgo.NewMixedSingleChainRuntime(t, sysgo.MixedSingleChainPresetConfig{
 		NodeSpecs: []sysgo.MixedSingleChainNodeSpec{

--- a/op-acceptance-tests/tests/sdm/init_test.go
+++ b/op-acceptance-tests/tests/sdm/init_test.go
@@ -73,6 +73,12 @@ func buildSDMRethSystem(t devtest.T, interopAtGenesis bool, isolateVerifier bool
 	// kona-node on both the sequencer and verifier (defaults to op-node when unset).
 	clKind := sysgo.ResolveMixedL2CLKind()
 
+	// Applied to the sequencer only: an external suite pointing DEVSTACK_L2EL_BINARY at its own
+	// builder gets that builder producing blocks while a stock op-reth verifies them, so any
+	// block it produces that stock op-reth rejects fails the run. Overriding both nodes would
+	// let a self-consistent divergence pass.
+	sequencerELOpts := sysgo.ResolveMixedL2ELOpts()
+
 	runtime := sysgo.NewMixedSingleChainRuntime(t, sysgo.MixedSingleChainPresetConfig{
 		NodeSpecs: []sysgo.MixedSingleChainNodeSpec{
 			{
@@ -81,6 +87,7 @@ func buildSDMRethSystem(t devtest.T, interopAtGenesis bool, isolateVerifier bool
 				ELKind:      sysgo.MixedL2ELOpReth,
 				CLKind:      clKind,
 				IsSequencer: true,
+				OpRethOpts:  sequencerELOpts,
 			},
 			{
 				ELKey:            "verifier-op-reth",

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -148,6 +148,7 @@ func validatePresetConfig(cfg sysgo.PresetConfig) error {
 const minimalPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindBatcher |
 	optionKindProposer |
+	optionKindOpReth |
 	optionKindGlobalL2CL |
 	optionKindL1EL |
 	optionKindAddedGameType |

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -160,6 +160,8 @@ const minimalPresetSupportedOptionKinds = optionKindDeployer |
 
 const minimalWithConductorsPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds
 
+// Builds on the minimal set, op-reth options included: the added node is a sync-tester EL, not a
+// sequencing candidate, so the sequencer-builds / stock-verifies split holds.
 const simpleWithSyncTesterPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds |
 	optionKindGlobalSyncTesterEL
 

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -250,6 +250,9 @@ func WithOPRBuilderOption(opt sysgo.OPRBuilderNodeOption) Option {
 	}
 }
 
+// WithOpRethOption applies an op-reth option to the preset's sequencer EL. Presets that add further
+// nodes start those verifiers on a stock op-reth, so a binary override here yields a
+// sequencer-builds / stock-verifies split rather than a uniform swap.
 func WithOpRethOption(opt sysgo.OpRethOption) Option {
 	var kinds optionKinds
 	if opt != nil {

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -250,9 +250,9 @@ func WithOPRBuilderOption(opt sysgo.OPRBuilderNodeOption) Option {
 	}
 }
 
-// WithOpRethOption applies an op-reth option to the preset's sequencer EL. Presets that add further
-// nodes start those verifiers on a stock op-reth, so a binary override here yields a
-// sequencer-builds / stock-verifies split rather than a uniform swap.
+// WithOpRethOption applies an op-reth option to every EL in the preset that can sequence. Nodes
+// that only verify stay on stock op-reth, so a binary override here yields a sequencing-builds /
+// stock-verifies split rather than a uniform swap.
 func WithOpRethOption(opt sysgo.OpRethOption) Option {
 	var kinds optionKinds
 	if opt != nil {

--- a/op-devstack/presets/options_test.go
+++ b/op-devstack/presets/options_test.go
@@ -108,6 +108,12 @@ func TestUnsupportedPresetOptionKinds(t *testing.T) {
 			want:      0,
 		},
 		{
+			name:      "minimal allows op-reth options",
+			supported: minimalPresetSupportedOptionKinds,
+			opts:      WithOpRethOption(sysgo.OpRethWithBinary("op-reth-superset")),
+			want:      0,
+		},
+		{
 			name:      "flashblocks allows builder and deployer adapters",
 			supported: singleChainWithFlashblocksPresetSupportedOptionKinds,
 			opts: Combine(

--- a/op-devstack/presets/options_test.go
+++ b/op-devstack/presets/options_test.go
@@ -114,6 +114,12 @@ func TestUnsupportedPresetOptionKinds(t *testing.T) {
 			want:      0,
 		},
 		{
+			name:      "conductors allow op-reth options",
+			supported: minimalWithConductorsPresetSupportedOptionKinds,
+			opts:      WithOpRethOption(sysgo.OpRethWithBinary("op-reth-superset")),
+			want:      0,
+		},
+		{
 			name:      "flashblocks allows builder and deployer adapters",
 			supported: singleChainWithFlashblocksPresetSupportedOptionKinds,
 			opts: Combine(

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -135,7 +135,11 @@ const (
 //
 // This is the EL-side counterpart to ResolveMixedL2CLKind: it lets a suite outside this
 // repo re-run these tests against its own EL build without forking the test bodies. The
-// named binary is resolved through the usual rustbin env overrides (see OpRethWithBinary).
+// named binary is resolved through the usual rustbin env overrides (see OpRethWithBinary),
+// whose variable name derives from the binary name — "my-builder" reads
+// RUST_BINARY_PATH_MY_BUILDER, leaving the stock verifiers' RUST_BINARY_PATH_OP_RETH
+// untouched. Naming the override "op-reth" would collapse that distinction, but such an
+// override selects the default binary anyway.
 //
 // A superset binary that binds a listener the harness knows nothing about needs the args
 // to move it off a fixed port, since every node here shares one host. The args only ever

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -121,6 +121,33 @@ func ResolveMixedL2CLKind() MixedL2CLKind {
 	return MixedL2CLOpNode
 }
 
+// ResolveMixedL2ELOpts returns the op-reth options requested via the environment:
+// DEVSTACK_L2EL_BINARY names a CLI-superset binary to launch instead of the default
+// "op-reth", and DEVSTACK_L2EL_ARGS carries whitespace-separated extra CLI arguments for
+// it. The returned slice is empty when both are unset, so callers get stock op-reth.
+//
+// This is the EL-side counterpart to ResolveMixedL2CLKind: it lets a suite outside this
+// repo re-run these tests against its own EL build without forking the test bodies. The
+// named binary is resolved through the usual rustbin env overrides (see OpRethWithBinary).
+//
+// A superset binary that binds a listener the harness knows nothing about needs the args
+// to move it off a fixed port, since every node here shares one host.
+//
+// Proofs history is disabled whenever a binary is named: the mixed runtime enables it on
+// every op-reth node, but a superset binary that replaces the payload service cannot host
+// op-reth's proof-history launcher, so leaving it on would either be silently ignored or
+// refused at startup. A suite that needs it should run stock op-reth.
+func ResolveMixedL2ELOpts() []OpRethOption {
+	var opts []OpRethOption
+	if binary := os.Getenv("DEVSTACK_L2EL_BINARY"); binary != "" {
+		opts = append(opts, OpRethWithBinary(binary), OpRethWithoutProofsHistory())
+	}
+	if extraArgs := strings.Fields(os.Getenv("DEVSTACK_L2EL_ARGS")); len(extraArgs) > 0 {
+		opts = append(opts, OpRethWithExtraArgs(extraArgs...))
+	}
+	return opts
+}
+
 type MixedSingleChainNodeSpec struct {
 	ELKey       string
 	CLKey       string

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -121,31 +122,57 @@ func ResolveMixedL2CLKind() MixedL2CLKind {
 	return MixedL2CLOpNode
 }
 
+const (
+	devstackL2ELOverrideBinaryEnv = "DEVSTACK_L2EL_OVERRIDE_BINARY"
+	devstackL2ELOverrideArgsEnv   = "DEVSTACK_L2EL_OVERRIDE_ARGS"
+)
+
 // ResolveMixedL2ELOpts returns the op-reth options requested via the environment:
-// DEVSTACK_L2EL_BINARY names a CLI-superset binary to launch instead of the default
-// "op-reth", and DEVSTACK_L2EL_ARGS carries whitespace-separated extra CLI arguments for
-// it. The returned slice is empty when both are unset, so callers get stock op-reth.
+// DEVSTACK_L2EL_OVERRIDE_BINARY names a CLI-superset binary to launch instead of the
+// default "op-reth", and DEVSTACK_L2EL_OVERRIDE_ARGS carries whitespace-separated extra CLI
+// arguments for it. The returned slice is empty when both are unset, so callers get stock
+// op-reth.
 //
 // This is the EL-side counterpart to ResolveMixedL2CLKind: it lets a suite outside this
 // repo re-run these tests against its own EL build without forking the test bodies. The
 // named binary is resolved through the usual rustbin env overrides (see OpRethWithBinary).
 //
 // A superset binary that binds a listener the harness knows nothing about needs the args
-// to move it off a fixed port, since every node here shares one host.
+// to move it off a fixed port, since every node here shares one host. The args only ever
+// qualify an override binary, so naming them without one is rejected rather than ignored —
+// a stale value in the environment would otherwise silently alter a stock run.
 //
 // Proofs history is disabled whenever a binary is named: the mixed runtime enables it on
 // every op-reth node, but a superset binary that replaces the payload service cannot host
 // op-reth's proof-history launcher, so leaving it on would either be silently ignored or
 // refused at startup. A suite that needs it should run stock op-reth.
-func ResolveMixedL2ELOpts() []OpRethOption {
-	var opts []OpRethOption
-	if binary := os.Getenv("DEVSTACK_L2EL_BINARY"); binary != "" {
-		opts = append(opts, OpRethWithBinary(binary), OpRethWithoutProofsHistory())
+func ResolveMixedL2ELOpts(t devtest.T) []OpRethOption {
+	opts, err := mixedL2ELOptsFromEnv(
+		os.Getenv(devstackL2ELOverrideBinaryEnv),
+		os.Getenv(devstackL2ELOverrideArgsEnv),
+	)
+	t.Require().NoError(err, "invalid L2 EL override environment")
+	return opts
+}
+
+// mixedL2ELOptsFromEnv holds the env-independent decision behind ResolveMixedL2ELOpts so it can
+// be exercised directly, including the rejection path.
+func mixedL2ELOptsFromEnv(binary, rawArgs string) ([]OpRethOption, error) {
+	extraArgs := strings.Fields(rawArgs)
+
+	if binary == "" {
+		if len(extraArgs) > 0 {
+			return nil, fmt.Errorf("%s only qualifies an override binary; set %s or unset the args",
+				devstackL2ELOverrideArgsEnv, devstackL2ELOverrideBinaryEnv)
+		}
+		return nil, nil
 	}
-	if extraArgs := strings.Fields(os.Getenv("DEVSTACK_L2EL_ARGS")); len(extraArgs) > 0 {
+
+	opts := []OpRethOption{OpRethWithBinary(binary), OpRethWithoutProofsHistory()}
+	if len(extraArgs) > 0 {
 		opts = append(opts, OpRethWithExtraArgs(extraArgs...))
 	}
-	return opts
+	return opts, nil
 }
 
 type MixedSingleChainNodeSpec struct {

--- a/op-devstack/sysgo/mixed_runtime_test.go
+++ b/op-devstack/sysgo/mixed_runtime_test.go
@@ -1,0 +1,45 @@
+package sysgo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveMixedL2ELOpts(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		binaryEnv  string
+		argsEnv    string
+		wantBinary string
+		wantArgs   []string
+	}{
+		{name: "unset yields no options"},
+		{name: "empty yields no options", binaryEnv: "", argsEnv: ""},
+		{name: "binary name selects that binary", binaryEnv: "op-reth-superset", wantBinary: "op-reth-superset"},
+		{name: "args reach the CLI", binaryEnv: "op-reth-superset", argsEnv: "--extra.bind=127.0.0.1:0", wantBinary: "op-reth-superset", wantArgs: []string{"--extra.bind=127.0.0.1:0"}},
+		{name: "multiple args split on whitespace", binaryEnv: "op-reth-superset", argsEnv: "  --a=1   --b=2 ", wantBinary: "op-reth-superset", wantArgs: []string{"--a=1", "--b=2"}},
+		{name: "args without a binary still apply", argsEnv: "--a=1", wantArgs: []string{"--a=1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DEVSTACK_L2EL_BINARY", tc.binaryEnv)
+			t.Setenv("DEVSTACK_L2EL_ARGS", tc.argsEnv)
+
+			opts := ResolveMixedL2ELOpts()
+
+			if tc.wantBinary == "" && tc.wantArgs == nil {
+				require.Empty(t, opts, "stock op-reth must be used when nothing is requested")
+				return
+			}
+
+			cfg := DefaultOpRethConfig()
+			for _, opt := range opts {
+				opt.Apply(nil, ComponentTarget{}, cfg)
+			}
+			require.Equal(t, tc.wantBinary, cfg.Binary)
+			require.Equal(t, tc.wantArgs, cfg.ExtraArgs)
+			require.Equal(t, tc.wantBinary != "", cfg.DisableProofsHistory,
+				"proofs history must be disabled for a superset binary and left alone otherwise")
+		})
+	}
+}

--- a/op-devstack/sysgo/mixed_runtime_test.go
+++ b/op-devstack/sysgo/mixed_runtime_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 )
 
-func TestResolveMixedL2ELOpts(t *testing.T) {
+func TestMixedL2ELOptsFromEnv(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		binaryEnv  string
@@ -19,16 +21,13 @@ func TestResolveMixedL2ELOpts(t *testing.T) {
 		{name: "binary name selects that binary", binaryEnv: "op-reth-superset", wantBinary: "op-reth-superset"},
 		{name: "args reach the CLI", binaryEnv: "op-reth-superset", argsEnv: "--extra.bind=127.0.0.1:0", wantBinary: "op-reth-superset", wantArgs: []string{"--extra.bind=127.0.0.1:0"}},
 		{name: "multiple args split on whitespace", binaryEnv: "op-reth-superset", argsEnv: "  --a=1   --b=2 ", wantBinary: "op-reth-superset", wantArgs: []string{"--a=1", "--b=2"}},
-		{name: "args without a binary still apply", argsEnv: "--a=1", wantArgs: []string{"--a=1"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("DEVSTACK_L2EL_BINARY", tc.binaryEnv)
-			t.Setenv("DEVSTACK_L2EL_ARGS", tc.argsEnv)
+			opts, err := mixedL2ELOptsFromEnv(tc.binaryEnv, tc.argsEnv)
+			require.NoError(t, err)
 
-			opts := ResolveMixedL2ELOpts()
-
-			if tc.wantBinary == "" && tc.wantArgs == nil {
-				require.Empty(t, opts, "stock op-reth must be used when nothing is requested")
+			if tc.wantBinary == "" {
+				require.Empty(t, opts, "stock op-reth must be used when no override is requested")
 				return
 			}
 
@@ -38,8 +37,32 @@ func TestResolveMixedL2ELOpts(t *testing.T) {
 			}
 			require.Equal(t, tc.wantBinary, cfg.Binary)
 			require.Equal(t, tc.wantArgs, cfg.ExtraArgs)
-			require.Equal(t, tc.wantBinary != "", cfg.DisableProofsHistory,
-				"proofs history must be disabled for a superset binary and left alone otherwise")
+			require.True(t, cfg.DisableProofsHistory,
+				"proofs history must be disabled for a superset binary")
 		})
 	}
+}
+
+// Args only qualify an override binary, so naming them alone is a misconfiguration: silently
+// dropping them would let a stale value in the environment look like it took effect.
+func TestMixedL2ELOptsFromEnvRejectsArgsWithoutBinary(t *testing.T) {
+	opts, err := mixedL2ELOptsFromEnv("", "--a=1")
+
+	require.ErrorContains(t, err, devstackL2ELOverrideArgsEnv)
+	require.Empty(t, opts)
+}
+
+// The exported resolver must read the documented variable names.
+func TestResolveMixedL2ELOptsReadsEnv(t *testing.T) {
+	t.Setenv(devstackL2ELOverrideBinaryEnv, "op-reth-superset")
+	t.Setenv(devstackL2ELOverrideArgsEnv, "--extra.bind=127.0.0.1:0")
+
+	cfg := DefaultOpRethConfig()
+	for _, opt := range ResolveMixedL2ELOpts(devtest.SerialT(t)) {
+		opt.Apply(nil, ComponentTarget{}, cfg)
+	}
+
+	require.Equal(t, "op-reth-superset", cfg.Binary)
+	require.Equal(t, []string{"--extra.bind=127.0.0.1:0"}, cfg.ExtraArgs)
+	require.True(t, cfg.DisableProofsHistory)
 }

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -116,7 +116,7 @@ func NewTwoL2SupernodeRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiCha
 // startSupernodeEL starts an L2 EL node for the supernode runtime,
 // respecting DEVSTACK_L2EL_KIND (defaults to op-reth when unset).
 func startSupernodeEL(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte) L2ELNode {
-	return startL2ELForKey(t, l2Net, jwtPath, jwtSecret, "sequencer", NewELNodeIdentity(0))
+	return startL2ELForKey(t, l2Net, jwtPath, jwtSecret, "sequencer", NewELNodeIdentity(0), ResolveMixedL2ELOpts()...)
 }
 
 // startSupernodeELWithInteropURL starts an L2 EL node with --rollup.interop-http
@@ -148,7 +148,7 @@ func startSupernodeELWithInteropURL(
 		return l2EL
 	default: // op-reth
 		return startMixedOpRethNodeWithInteropURL(
-			t, l2Net, key, jwtPath, jwtSecret, nil, interopURL, "v1")
+			t, l2Net, key, jwtPath, jwtSecret, nil, interopURL, "v1", ResolveMixedL2ELOpts()...)
 	}
 }
 
@@ -333,8 +333,8 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 	if !supernodeSequencerEnabled {
 		// Production-faithful topology: each follow-mode sequencer runs its own
 		// EL, distinct from the supernode VN's EL, joined only by L1 and P2P.
-		seqL2AEL = startSequencerEL(t, l2ANet, jwtPath, jwtSecret, NewELNodeIdentity(0))
-		seqL2BEL = startSequencerEL(t, l2BNet, jwtPath, jwtSecret, NewELNodeIdentity(0))
+		seqL2AEL = startSequencerEL(t, l2ANet, jwtPath, jwtSecret, NewELNodeIdentity(0), ResolveMixedL2ELOpts()...)
+		seqL2BEL = startSequencerEL(t, l2BNet, jwtPath, jwtSecret, NewELNodeIdentity(0), ResolveMixedL2ELOpts()...)
 
 		// Light sequencers follow the supernode's safe head (production:
 		// kind=sequencer, lightNode=true, deps on op-supernode). They sequence

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -116,7 +116,7 @@ func NewTwoL2SupernodeRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiCha
 // startSupernodeEL starts an L2 EL node for the supernode runtime,
 // respecting DEVSTACK_L2EL_KIND (defaults to op-reth when unset).
 func startSupernodeEL(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte) L2ELNode {
-	return startL2ELForKey(t, l2Net, jwtPath, jwtSecret, "sequencer", NewELNodeIdentity(0), ResolveMixedL2ELOpts()...)
+	return startL2ELForKey(t, l2Net, jwtPath, jwtSecret, "sequencer", NewELNodeIdentity(0), ResolveMixedL2ELOpts(t)...)
 }
 
 // startSupernodeELWithInteropURL starts an L2 EL node with --rollup.interop-http
@@ -148,7 +148,7 @@ func startSupernodeELWithInteropURL(
 		return l2EL
 	default: // op-reth
 		return startMixedOpRethNodeWithInteropURL(
-			t, l2Net, key, jwtPath, jwtSecret, nil, interopURL, "v1", ResolveMixedL2ELOpts()...)
+			t, l2Net, key, jwtPath, jwtSecret, nil, interopURL, "v1", ResolveMixedL2ELOpts(t)...)
 	}
 }
 
@@ -333,8 +333,9 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 	if !supernodeSequencerEnabled {
 		// Production-faithful topology: each follow-mode sequencer runs its own
 		// EL, distinct from the supernode VN's EL, joined only by L1 and P2P.
-		seqL2AEL = startSequencerEL(t, l2ANet, jwtPath, jwtSecret, NewELNodeIdentity(0), ResolveMixedL2ELOpts()...)
-		seqL2BEL = startSequencerEL(t, l2BNet, jwtPath, jwtSecret, NewELNodeIdentity(0), ResolveMixedL2ELOpts()...)
+		sequencerELOpts := ResolveMixedL2ELOpts(t)
+		seqL2AEL = startSequencerEL(t, l2ANet, jwtPath, jwtSecret, NewELNodeIdentity(0), sequencerELOpts...)
+		seqL2BEL = startSequencerEL(t, l2BNet, jwtPath, jwtSecret, NewELNodeIdentity(0), sequencerELOpts...)
 
 		// Light sequencers follow the supernode's safe head (production:
 		// kind=sequencer, lightNode=true, deps on op-supernode). They sequence

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -133,10 +133,14 @@ func applyConfigPrefundedL2(t devtest.T, keys devkeys.Keys, l1ChainID, l2ChainID
 func startL2ELForKey(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte, key string, identity *ELNodeIdentity, opts ...OpRethOption) L2ELNode {
 	switch k := devstackL2ELKind(); k {
 	case MixedL2ELOpGeth:
+		// op-reth options have no analogue on these kinds. Dropping them silently would make a
+		// binary override look like it took effect on a node that never saw it.
+		t.Require().Empty(opts, "op-reth options cannot be applied to EL kind %q", k)
 		return startL2ELNode(t, l2Net, jwtPath, jwtSecret, key, identity)
 	case MixedL2ELOpRethV2:
 		return startMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, nil, "v2", opts...)
 	case MixedOpRbuilder:
+		t.Require().Empty(opts, "op-reth options cannot be applied to EL kind %q", k)
 		return startBuilderEL(t, l2Net, jwtPath, identity)
 	case "", MixedL2ELOpReth: // unset (default) or explicit op-reth v1
 		return startMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, nil, "v1", opts...)

--- a/op-devstack/sysgo/singlechain_interop.go
+++ b/op-devstack/sysgo/singlechain_interop.go
@@ -35,7 +35,7 @@ func startSingleChainInteropPrimaryNoSupernode(
 	t.Require().NotNil(world.Interop, "single-chain interop runtime requires interop support")
 
 	sequencerIdentity := NewELNodeIdentity(0)
-	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, sequencerIdentity, ResolveMixedL2ELOpts()...)
+	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, sequencerIdentity, ResolveMixedL2ELOpts(t)...)
 	l2CL := startL2CLNode(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 		Key:            "sequencer",
 		IsSequencer:    true,

--- a/op-devstack/sysgo/singlechain_interop.go
+++ b/op-devstack/sysgo/singlechain_interop.go
@@ -35,7 +35,7 @@ func startSingleChainInteropPrimaryNoSupernode(
 	t.Require().NotNil(world.Interop, "single-chain interop runtime requires interop support")
 
 	sequencerIdentity := NewELNodeIdentity(0)
-	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, sequencerIdentity)
+	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, sequencerIdentity, ResolveMixedL2ELOpts()...)
 	l2CL := startL2CLNode(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 		Key:            "sequencer",
 		IsSequencer:    true,

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -99,8 +99,8 @@ func startDefaultSingleChainPrimary(
 		cfg.SafeDBPath = safeDBPath
 	})}
 	l2CLOptions = append(l2CLOptions, cfg.GlobalL2CLOptions...)
-	// Env-resolved options come first so an option the test set explicitly still wins.
-	sequencerELOpts := append(ResolveMixedL2ELOpts(), cfg.OpRethOptions...)
+	// Env-resolved options come first so an explicit binary from the test overrides the env one.
+	sequencerELOpts := append(append([]OpRethOption{}, ResolveMixedL2ELOpts(t)...), cfg.OpRethOptions...)
 	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, NewELNodeIdentity(0), sequencerELOpts...)
 	if world.Interop != nil {
 		l2CL := startL2CLNode(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -99,7 +99,9 @@ func startDefaultSingleChainPrimary(
 		cfg.SafeDBPath = safeDBPath
 	})}
 	l2CLOptions = append(l2CLOptions, cfg.GlobalL2CLOptions...)
-	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, NewELNodeIdentity(0))
+	// Env-resolved options come first so an option the test set explicitly still wins.
+	sequencerELOpts := append(ResolveMixedL2ELOpts(), cfg.OpRethOptions...)
+	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, NewELNodeIdentity(0), sequencerELOpts...)
 	if world.Interop != nil {
 		l2CL := startL2CLNode(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 			Key:           "sequencer",

--- a/op-devstack/sysgo/singlechain_supernode_synctester_variant.go
+++ b/op-devstack/sysgo/singlechain_supernode_synctester_variant.go
@@ -56,7 +56,7 @@ func NewSingleSupernodeWithSyncTesterRuntimeWithConfig(t devtest.T, cfg PresetCo
 	}
 	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
 
-	l2EL := startSequencerEL(t, l2Net, jwtPath, jwtSecret, NewELNodeIdentity(0), ResolveMixedL2ELOpts()...)
+	l2EL := startSequencerEL(t, l2Net, jwtPath, jwtSecret, NewELNodeIdentity(0), ResolveMixedL2ELOpts(t)...)
 	l2CL := startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 		Key:           "sequencer",
 		IsSequencer:   true,

--- a/op-devstack/sysgo/singlechain_supernode_synctester_variant.go
+++ b/op-devstack/sysgo/singlechain_supernode_synctester_variant.go
@@ -56,7 +56,7 @@ func NewSingleSupernodeWithSyncTesterRuntimeWithConfig(t devtest.T, cfg PresetCo
 	}
 	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
 
-	l2EL := startSequencerEL(t, l2Net, jwtPath, jwtSecret, NewELNodeIdentity(0))
+	l2EL := startSequencerEL(t, l2Net, jwtPath, jwtSecret, NewELNodeIdentity(0), ResolveMixedL2ELOpts()...)
 	l2CL := startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 		Key:           "sequencer",
 		IsSequencer:   true,

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -114,8 +114,18 @@ func NewMinimalWithConductorsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *S
 		StartProposer:   true,
 		StartChallenger: false,
 	})
-	nodeB := addSingleChainOpNode(t, runtime, "b", true, "", cfg.GlobalL2CLOptions...)
-	nodeC := addSingleChainOpNode(t, runtime, "c", true, "", cfg.GlobalL2CLOptions...)
+	// Every conductor member sequences once leadership reaches it, so a binary override has to
+	// apply to all of them or it would silently stop taking effect on transfer. The primary already
+	// received these options from startDefaultSingleChainPrimary.
+	candidateELOpts := append(append([]OpRethOption{}, ResolveMixedL2ELOpts(t)...), cfg.OpRethOptions...)
+	nodeB := addSingleChainOpNodeWithELOpts(t, runtime, "b", true, "", candidateELOpts, cfg.GlobalL2CLOptions...)
+	nodeC := addSingleChainOpNodeWithELOpts(t, runtime, "c", true, "", candidateELOpts, cfg.GlobalL2CLOptions...)
+
+	// A non-candidate node, always stock: it never sequences, so it independently validates every
+	// block the candidates build. Without it an overridden binary on all three members could accept
+	// its own invalid blocks and the run would still pass.
+	nodeVerifier := addSingleChainOpNode(t, runtime, "verifier", false, "", cfg.GlobalL2CLOptions...)
+	connectSingleChainNodes(t, runtime.L2EL, runtime.L2CL, nodeVerifier)
 
 	conductorA := startConductorNode(t, "sequencer", runtime.L2Network, runtime.L2CL.(*OpNode), runtime.L2EL, true, false)
 	conductorB := startConductorNode(t, "b", runtime.L2Network, nodeB.CL.(*OpNode), nodeB.EL, false, true)
@@ -165,9 +175,24 @@ func addSingleChainOpNode(
 	followSource string,
 	l2Opts ...L2CLOption,
 ) *SingleChainNodeRuntime {
+	return addSingleChainOpNodeWithELOpts(t, runtime, name, isSequencer, followSource, nil, l2Opts...)
+}
+
+// addSingleChainOpNodeWithELOpts adds a node whose EL takes op-reth options. Passing none yields a
+// stock op-reth, which is what lets a preset keep an independent check on blocks built by an
+// overridden binary.
+func addSingleChainOpNodeWithELOpts(
+	t devtest.T,
+	runtime *SingleChainRuntime,
+	name string,
+	isSequencer bool,
+	followSource string,
+	elOpts []OpRethOption,
+	l2Opts ...L2CLOption,
+) *SingleChainNodeRuntime {
 	jwtPath := runtime.L2EL.JWTPath()
 	jwtSecret := readJWTSecretFromPath(t, jwtPath)
-	l2EL := startL2ELForKey(t, runtime.L2Network, jwtPath, jwtSecret, name, NewELNodeIdentity(0))
+	l2EL := startL2ELForKey(t, runtime.L2Network, jwtPath, jwtSecret, name, NewELNodeIdentity(0), elOpts...)
 	l2CL := startL2CLForKey(t, runtime.Keys, runtime.L1Network, runtime.L2Network, runtime.L1EL, runtime.L1CL, l2EL, jwtSecret, name, name, isSequencer, followSource, l2Opts)
 	node := newSingleChainNodeRuntime(name, isSequencer, l2EL, l2CL)
 	runtime.Nodes[name] = node


### PR DESCRIPTION
## What

Adds an environment seam so an out-of-repo suite can re-run these acceptance tests with its own execution-layer build as the **sequencer** EL, without forking any test bodies.

- `DEVSTACK_L2EL_OVERRIDE_BINARY` — names a CLI-superset binary to launch instead of `op-reth`, resolved through the existing `rustbin` overrides (`RUST_BINARY_PATH_<NAME>`).
- `DEVSTACK_L2EL_OVERRIDE_ARGS` — whitespace-separated extra CLI arguments for that binary.

Both unset leaves the option slice empty, so in-tree runs are unchanged.

This is the execution-layer counterpart to the existing `DEVSTACK_L2CL_KIND` / `ResolveMixedL2CLKind()` pattern, which exists so the kona suite can re-run these same tests against a different consensus client. It is distinct from the pre-existing `DEVSTACK_L2EL_KIND`, which selects among a closed set of kinds the monorepo knows how to launch (`op-geth`, `op-reth`, `op-reth-v2`, `op-rbuilder`) and cannot name an arbitrary binary. The two compose: kind picks the launcher family, the override picks which executable that launcher runs.

## Why the args variable is needed

A superset binary may bind a listener the harness knows nothing about. The harness randomizes every port it *does* know about, but a fixed default port on an unknown listener collides as soon as a node starts, because every node in a run shares one host. This was not hypothetical — it reproduced immediately on the first run and blocked the suite entirely.

## Misconfiguration fails loudly

The args only ever qualify an override binary, so naming them without one is **rejected rather than ignored** — a stale `DEVSTACK_L2EL_OVERRIDE_ARGS` in the environment would otherwise silently alter a stock in-tree run.

The same reasoning applies to EL kinds with no op-reth analogue: `startL2ELForKey`'s `op-geth` and `op-rbuilder` branches now reject op-reth options instead of dropping them on the floor, so an override can't look like it took effect on a node that never saw it. The verifier/follow-node callers pass no options, so only the override case can trip these guards.

## Sequencing nodes only, deliberately

The override is applied to every EL that can sequence. Verifier and follow-node paths are untouched, so the overridden binary **builds** while stock `op-reth` **verifies** — any block it produces that stock `op-reth` rejects fails the run. Overriding both would let a self-consistent divergence pass silently.

Sites covered: the default single-chain primary, the single-chain interop runtime, the supernode runtimes (including the interop-filter variant), the sync-tester variant, the SDM suite's explicit node specs, and every conductor sequencing candidate.

Conductors needed extra care. All three members are created with `isSequencer=true`, so applying the override only to the initial primary would have silently stopped taking effect once leadership transferred — the same gap applied to `cfg.OpRethOptions`, which never reached nodes b and c either. Since those two were the only non-primary nodes, there was nothing left to verify stock, so `NewMinimalWithConductorsRuntimeWithConfig` now also starts a non-candidate `verifier` node that always runs stock `op-reth`. It never sequences, so it independently validates whatever the candidates build; without it an override on all three members could accept its own invalid blocks and still pass.

## Option precedence

At the single-chain primary, env-resolved options are applied before the test's explicit `cfg.OpRethOptions`. That ordering only decides the **binary** (a plain assignment, so last wins); proofs-history disablement is one-way and extra args accumulate, so neither is subject to precedence.

## Proofs history

Disabled whenever a superset binary is named. The mixed runtime enables proofs history on every `op-reth` node, but a binary that replaces the payload service cannot host `op-reth`'s proof-history launcher (`launch_node` hard-binds `OpNode` and `launch_with_proof_history` is private), so the flag is either silently ignored or refused at startup. A suite that needs proofs history should run stock `op-reth`.

## Testing

The env-parsing decision lives in a pure helper (`mixedL2ELOptsFromEnv`) so every branch — including the rejection path — is directly testable without fabricating a `devtest.T`.

- `TestMixedL2ELOptsFromEnv` covers unset / empty / binary-only / args / whitespace-splitting, and asserts proofs history is disabled whenever a binary is named.
- `TestMixedL2ELOptsFromEnvRejectsArgsWithoutBinary` covers the rejection.
- `TestResolveMixedL2ELOptsReadsEnv` goes through the exported resolver with real env vars, so a typo in a variable name can't pass.

`TestUnsupportedPresetOptionKinds` covers the conductor preset accepting op-reth options.

Verified end to end against a real superset binary, with a control run for every result. For the conductor path, `TestConductorLeadershipTransfer` passes 5/5 consecutive runs (~18s each, against ~12.6s before the added node), and with an override set the logs show the binary resolved for all three candidates and stock `op-reth` resolved for the verifier.

The `Require().Empty` guards for non-op-reth EL kinds are only reachable with `DEVSTACK_L2EL_KIND=op-geth`/`op-rbuilder` *and* an override set, so they are not covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

