### PR TITLE
op-node,op-supernode: post-replacement lineage instrumentation, and optional span continuation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ packages/contracts-bedrock/deployments/anvil
 .devnet*
 
 .claude/worktrees
+.worktrees/
 
 # Local AI planning docs (op-claude and similar agent tooling)
 .claude/plans

--- a/docs/superpowers/plans/2026-07-31-interopsmoke-n-chains.md
+++ b/docs/superpowers/plans/2026-07-31-interopsmoke-n-chains.md
@@ -1,0 +1,206 @@
+# N-chain interop smoke Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run interop smoke checks across any number of configured L2 chains and every ordered source-to-destination pair.
+
+**Architecture:** Replace the fixed A/B environment with ordered slices of remote chains and users. Build pair descriptors for every distinct ordered index pair, then use them in bridge, valid-message, and invalid-message flows. Retain the existing sequential command execution and concurrency model within individual invalid-message phases.
+
+**Tech Stack:** Go, urfave/cli v2, go-ethereum, existing `op-chain-ops/interopsmoke` package tests.
+
+## Global Constraints
+
+- Require at least two repeatable `--l2-rpc` values.
+- Cover every ordered pair of distinct configured chains.
+- Do not retain A/B-specific RPC flags, environment variables, or direction selection.
+- Keep unrelated smoke commands and options unchanged.
+
+---
+
+### Task 1: Model arbitrary remote chains and pairs
+
+**Files:**
+- Modify: `op-chain-ops/interopsmoke/smoke.go`
+- Test: `op-chain-ops/interopsmoke/smoke_test.go`
+
+**Interfaces:**
+- Produces: `newSmokeEnv(ctx, stderr, l2URLs, privateKey)`, with `chains []*remoteChain` and `users []*remoteUser`.
+- Produces: `orderedPairs(env) ([]chainPair, error)`, where `chainPair` has `name string`, `initUser *remoteUser`, and `execUser *remoteUser`.
+
+- [ ] **Step 1: Write failing tests for two- and three-chain pair generation**
+
+```go
+func TestOrderedPairs(t *testing.T) {
+    env := &smokeEnv{users: []*remoteUser{
+        {chain: &remoteChain{name: "L2A"}},
+        {chain: &remoteChain{name: "L2B"}},
+        {chain: &remoteChain{name: "L2C"}},
+    }}
+    pairs, err := orderedPairs(env)
+    if err != nil { t.Fatal(err) }
+    want := []string{"A->B", "A->C", "B->A", "B->C", "C->A", "C->B"}
+    // assert names in order
+}
+```
+
+- [ ] **Step 2: Run the package test to verify failure**
+
+Run: `go test ./op-chain-ops/interopsmoke -run TestOrderedPairs`
+
+Expected: FAIL because `orderedPairs` does not exist.
+
+- [ ] **Step 3: Add slice-backed environment and pair helper**
+
+```go
+type smokeEnv struct {
+    // existing fields
+    chains []*remoteChain
+    users  []*remoteUser
+}
+
+type chainPair struct {
+    name string
+    initUser, execUser *remoteUser
+}
+
+func orderedPairs(env *smokeEnv) ([]chainPair, error) {
+    if len(env.users) < 2 { return nil, fmt.Errorf("at least two L2 RPC URLs are required") }
+    var pairs []chainPair
+    for i, initUser := range env.users {
+        for j, execUser := range env.users {
+            if i != j { pairs = append(pairs, chainPair{/* derive A->B name */}) }
+        }
+    }
+    return pairs, nil
+}
+```
+
+- [ ] **Step 4: Run the pair tests to verify success**
+
+Run: `go test ./op-chain-ops/interopsmoke -run TestOrderedPairs`
+
+Expected: PASS with six pairs for three chains.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add op-chain-ops/interopsmoke/smoke.go op-chain-ops/interopsmoke/smoke_test.go && git commit -m 'op-chain-ops: model interop smoke chain pairs'`
+
+### Task 2: Replace the two-chain CLI and setup
+
+**Files:**
+- Modify: `op-chain-ops/interopsmoke/smoke.go`
+- Modify: `op-chain-ops/cmd/interop-smoke/main.go`
+- Test: `op-chain-ops/interopsmoke/smoke_test.go`
+
+**Interfaces:**
+- Consumes: `newSmokeEnv(ctx, stderr, []string, privateKey)` and `orderedPairs(env)`.
+- Produces: repeatable `--l2-rpc` CLI input and one user per chain.
+
+- [ ] **Step 1: Write failing validation tests**
+
+```go
+func TestValidateL2URLs(t *testing.T) {
+    for _, tc := range []struct{ urls []string; wantErr bool }{
+        {[]string{"http://a", "http://b"}, false},
+        {[]string{"http://a"}, true},
+    } { /* assert validateL2URLs(tc.urls) */ }
+}
+```
+
+- [ ] **Step 2: Run validation test to verify failure**
+
+Run: `go test ./op-chain-ops/interopsmoke -run TestValidateL2URLs`
+
+Expected: FAIL because `validateL2URLs` does not exist.
+
+- [ ] **Step 3: Implement repeatable endpoint input and generic setup**
+
+```go
+&cli.StringSliceFlag{
+    Name: l2URLFlagName,
+    Usage: "RPC URL for an interoperable L2. Repeat for each chain.",
+    EnvVars: opservice.PrefixEnvVar(envPrefix, "SMOKE_L2_RPC"),
+}
+```
+
+Validate two or more values before dialing. Connect each URL as `L2A`, `L2B`, then `L2C` and create same-key users. Close every connected client on setup failure and cleanup. Print each configured chain. Update standalone CLI wording from two chains to interoperable L2 chains.
+
+- [ ] **Step 4: Run validation and package tests to verify success**
+
+Run: `go test ./op-chain-ops/interopsmoke`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add op-chain-ops/interopsmoke/smoke.go op-chain-ops/interopsmoke/smoke_test.go op-chain-ops/cmd/interop-smoke/main.go && git commit -m 'op-chain-ops: accept n interop smoke chains'`
+
+### Task 3: Apply all-chain and all-pair smoke behavior
+
+**Files:**
+- Modify: `op-chain-ops/interopsmoke/smoke.go`
+- Test: `op-chain-ops/interopsmoke/smoke_test.go`
+
+**Interfaces:**
+- Consumes: `env.chains`, `env.users`, and `orderedPairs(env)`.
+- Produces: identity and transfers per chain; bridge, valid message, and invalid message per ordered pair.
+
+- [ ] **Step 1: Write failing tests for duplicate chain IDs and invalid pair coverage**
+
+```go
+func TestValidateChainIDs(t *testing.T) {
+    env := &smokeEnv{chains: []*remoteChain{
+        {name: "L2A", chainID: 1}, {name: "L2B", chainID: 1},
+    }}
+    if err := validateChainIDs(env); err == nil { t.Fatal("expected duplicate ID error") }
+}
+```
+
+- [ ] **Step 2: Run targeted test to verify failure**
+
+Run: `go test ./op-chain-ops/interopsmoke -run TestValidateChainIDs`
+
+Expected: FAIL because generic chain-ID validation does not exist.
+
+- [ ] **Step 3: Generalize smoke commands**
+
+Run identity over all chain IDs and reject duplicates. Run transfer once per user. Loop bridge and valid-message over `orderedPairs`. Replace fixed `invalidDirections` with pair-derived invalid directions and remove its A/B selector flag. Ensure each valid flow waits on, executes on, and validates the specified destination. Preserve per-pair diagnostics.
+
+- [ ] **Step 4: Run targeted and package tests to verify success**
+
+Run: `go test ./op-chain-ops/interopsmoke`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run formatter and commit**
+
+Run: `gofmt -w op-chain-ops/interopsmoke/smoke.go op-chain-ops/interopsmoke/smoke_test.go && go test ./op-chain-ops/interopsmoke && git add op-chain-ops/interopsmoke/smoke.go op-chain-ops/interopsmoke/smoke_test.go && git commit -m 'op-chain-ops: smoke every interop direction'`
+
+### Task 4: Verify integration impact
+
+**Files:**
+- Modify: `op-chain-ops/README.md`
+
+**Interfaces:**
+- Consumes: final repeatable `--l2-rpc` command contract.
+- Produces: accurate tool description for arbitrary interoperable chains.
+
+- [ ] **Step 1: Update the smoke-command description**
+
+Replace the two-live-chain wording with arbitrary interoperable L2 chains and mention pairwise cross-chain coverage.
+
+- [ ] **Step 2: Run focused package and command compilation checks**
+
+Run: `go test ./op-chain-ops/interopsmoke && go test ./op-chain-ops/cmd/interop-smoke`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+Run: `git add op-chain-ops/README.md && git commit -m 'op-chain-ops: document n-chain smoke coverage'`
+
+## Self-review
+
+- Spec coverage: Tasks 1-3 cover repeatable RPC input, N-chain setup, unique identities, per-chain transfers, and every ordered pair for bridge, valid, and invalid messages. Task 4 updates the public description.
+- Placeholder scan: no deferred implementation items.
+- Type consistency: Task 1 defines the slice-backed environment and pair helper consumed by Tasks 2 and 3.

--- a/docs/superpowers/specs/2026-07-31-interopsmoke-n-chains-design.md
+++ b/docs/superpowers/specs/2026-07-31-interopsmoke-n-chains-design.md
@@ -1,0 +1,21 @@
+# Interop smoke: N chains
+
+## Scope
+
+Replace the two-chain RPC inputs with a repeatable `--l2-rpc` flag. Require at least two RPC endpoints. Build one remote-chain and remote-user entry per endpoint.
+
+## Behavior
+
+- Identity verifies every configured chain ID is unique.
+- Transfers run once per configured chain.
+- Bridge, valid-message, and invalid-message run for every ordered pair of distinct chains.
+- Three endpoints therefore exercise A->B, A->C, B->A, B->C, C->A, and C->B.
+- Invalid-message no longer selects fixed A/B directions; it covers every ordered pair.
+
+## Compatibility
+
+This deliberately replaces the A/B-specific CLI flags and environment variables with the repeatable endpoint input. Commands retain their names and existing options unrelated to chain selection.
+
+## Tests
+
+Unit tests cover endpoint validation, direction generation for two and three chains, and rejection of duplicate chain IDs. Existing package tests remain green.

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -282,6 +282,16 @@ var (
 		Value:    4,
 		Category: SequencerCategory,
 	}
+	ReplacementContinuesSpan = &cli.BoolFlag{
+		Name: "rollup.replacement-continues-span",
+		Usage: "EXPERIMENTAL: after an interop block replacement, continue deriving the remainder of the span the " +
+			"replaced block came from, instead of flushing its channel. Changes which batch lineage is derived, so " +
+			"nodes running with and without it can end up on different chains. Devnet investigation only.",
+		EnvVars:  prefixEnvVars("ROLLUP_REPLACEMENT_CONTINUES_SPAN"),
+		Value:    false,
+		Hidden:   true,
+		Category: InteropCategory,
+	}
 	SequencerRecoverMode = &cli.BoolFlag{
 		Name:     "sequencer.recover",
 		Usage:    "Forces the sequencer to strictly prepare the next L1 origin and create empty L2 blocks",
@@ -471,6 +481,7 @@ var optionalFlags = []cli.Flag{
 	SequencerMaxSafeLagFlag,
 	SequencerL1Confs,
 	SequencerRecoverMode,
+	ReplacementContinuesSpan,
 	SequencerSealingDurationFlag,
 	FinalityLookbackFlag,
 	FinalityDelayFlag,

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -57,6 +57,20 @@ type AttributesQueue struct {
 	batch       *SingularBatch
 	concluding  bool
 	lastAttribs *AttributesWithParent
+
+	// replacementContinuesSpan keeps the containing channel buffered when a
+	// deposits-only replacement is produced, so the remainder of the span
+	// re-applies on top of the replacement. See DepositsOnlyAttributes.
+	replacementContinuesSpan bool
+}
+
+// AttributesQueueOption configures an AttributesQueue.
+type AttributesQueueOption func(*AttributesQueue)
+
+// WithReplacementContinuesSpan enables continuing the containing span after a
+// deposits-only block replacement, instead of flushing the channel.
+func WithReplacementContinuesSpan(enabled bool) AttributesQueueOption {
+	return func(aq *AttributesQueue) { aq.replacementContinuesSpan = enabled }
 }
 
 type SingularBatchProvider interface {
@@ -66,13 +80,17 @@ type SingularBatchProvider interface {
 	NextBatch(context.Context, eth.L2BlockRef) (*SingularBatch, bool, error)
 }
 
-func NewAttributesQueue(log log.Logger, cfg *rollup.Config, builder AttributesBuilder, prev SingularBatchProvider) *AttributesQueue {
-	return &AttributesQueue{
+func NewAttributesQueue(log log.Logger, cfg *rollup.Config, builder AttributesBuilder, prev SingularBatchProvider, opts ...AttributesQueueOption) *AttributesQueue {
+	aq := &AttributesQueue{
 		log:     log,
 		config:  cfg,
 		builder: builder,
 		prev:    prev,
 	}
+	for _, opt := range opts {
+		opt(aq)
+	}
+	return aq
 }
 
 func (aq *AttributesQueue) Origin() eth.L1BlockRef {
@@ -163,7 +181,21 @@ func (aq *AttributesQueue) DepositsOnlyAttributes(parent eth.BlockID, derivedFro
 			aq.lastAttribs.Parent.ID(), parent)
 	}
 
-	aq.prev.FlushChannel() // flush all channel data in previous stages
+	// Flushing discards the remainder of the channel that contained the replaced
+	// block, which hands the lineage to whichever channel comes next on L1. A
+	// node that still held the following blocks locally (the live cluster during
+	// an invalidation) instead re-applies the span's tail on the replacement and
+	// stays on the batcher's continued lineage; a node deriving the same L1 data
+	// from scratch flushes and lands on an abandoned one, permanently.
+	// See devnet interop-reorg-5, chain 420120192, blocks 13460 and 14245.
+	if aq.replacementContinuesSpan {
+		aq.log.Info("deposits-only replacement: continuing containing span, channel not flushed",
+			"parent", parent, "derived_from", derivedFrom)
+	} else {
+		aq.log.Info("deposits-only replacement: flushing channel",
+			"parent", parent, "derived_from", derivedFrom)
+		aq.prev.FlushChannel() // flush all channel data in previous stages
+	}
 	attrs := aq.lastAttribs.WithDepositsOnly()
 	aq.lastAttribs = attrs
 	return attrs, nil

--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -164,6 +164,16 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			bs.FlushChannel()
 			return nil, NotEnoughData
 		}
+		// Elements at or below the parent's timestamp are past-skipped without any
+		// content check. When the parent is a block replacement, this is what
+		// decides the lineage: the span's tail re-applies on top of the
+		// replacement instead of the denied block being re-proposed. Log it so the
+		// choice is visible at the moment it is made.
+		if skipped := len(spanBatch.Batches) - len(singularBatches); skipped > 0 {
+			spanBatch.LogContext(bs.Log()).Info("Past-skipped span batch elements overlapping the safe chain",
+				"skipped", skipped, "kept", len(singularBatches),
+				"parent_number", parent.Number, "parent_hash", parent.Hash, "parent_time", parent.Time)
+		}
 		bs.nextSpan = singularBatches
 		// span-batches are non-empty, so the below pop is safe.
 		return bs.popNextBatch(parent), nil

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -278,7 +278,10 @@ func checkSpanBatchPrefix(ctx context.Context, cfg *rollup.Config, log log.Logge
 		}
 	}
 	if !batch.CheckParentHash(parentBlock.Hash) {
-		log.Warn("ignoring batch with mismatching parent hash", "parent_block", parentBlock.Hash)
+		// The batch's parent_check (in the log context) against the local parent:
+		// this is where a lineage gets cut after a block replacement.
+		log.Warn("ignoring batch with mismatching parent hash", "parent_block", parentBlock.Hash,
+			"parent_number", parentBlock.Number, "parent_time", parentBlock.Time)
 		return BatchDrop, parentBlock
 	}
 

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -99,6 +99,7 @@ type DerivationPipeline struct {
 // NewDerivationPipeline creates a DerivationPipeline, to turn L1 data into L2 block-inputs.
 func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, depSet DependencySet, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher,
 	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics, l1ChainConfig *params.ChainConfig,
+	attribOpts ...AttributesQueueOption,
 ) *DerivationPipeline {
 	spec := rollup.NewChainSpec(rollupCfg)
 	// Stages are strung together into a pipeline,
@@ -111,7 +112,7 @@ func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, depSet Depe
 	chInReader := NewChannelInReader(rollupCfg, log, channelMux, metrics)
 	batchMux := NewBatchMux(log, rollupCfg, chInReader, l2Source)
 	attrBuilder := NewFetchingAttributesBuilder(rollupCfg, l1ChainConfig, depSet, l1Fetcher, l2Source)
-	attributesQueue := NewAttributesQueue(log, rollupCfg, attrBuilder, batchMux)
+	attributesQueue := NewAttributesQueue(log, rollupCfg, attrBuilder, batchMux, attribOpts...)
 
 	// Reset from ResetEngine then up from L1 Traversal. The stages do not talk to each other during
 	// the ResetEngine, but after the ResetEngine, this is the order in which the stages could talk to each other.

--- a/op-node/rollup/derive/replacement_lineage_test.go
+++ b/op-node/rollup/derive/replacement_lineage_test.go
@@ -1,0 +1,136 @@
+package derive
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+// TestReplacedBlockLineageSelection reproduces the derivation asymmetry observed on
+// devnet interop-reorg-5 (chain 420120192, blocks 13460 / 14245): after an interop
+// invalidation replaces block N with a deposits-only block, the SAME span batch
+// yields DIFFERENT continuations depending on where a node's derivation walk is
+// anchored relative to N:
+//
+//   - anchored AT the replacement (l2SafeHead = replaced N): the span passes the
+//     prefix parent_check against N's ancestor, and GetSingularBatches past-skips
+//     block N entirely — its content is never re-validated — so the span TAIL
+//     (N+1..) is re-applied on top of the replacement (popNextBatch re-stamps
+//     ParentHash from the actual parent). The node keeps this span's lineage.
+//
+//   - anchored BELOW N (l2SafeHead = N-1): block N is RE-PROPOSED. In production
+//     the supernode's SuperAuthority denylist then rejects it at payload
+//     insertion (op-node/rollup/engine/payload_process.go), triggering a
+//     deposits-only replacement that discards the remainder of the channel — so
+//     the NEXT channel's lineage wins instead.
+//
+// Two nodes processing identical L1 data therefore end on different canonical
+// chains, and the abandoned lineage dead-ends permanently once the batcher moves
+// on. This test pins the derive-level half of that mechanism.
+func TestReplacedBlockLineageSelection(t *testing.T) {
+	zero := uint64(0)
+	cfg := &rollup.Config{
+		Genesis:           rollup.Genesis{L2Time: 1000},
+		BlockTime:         1,
+		SeqWindowSize:     3600,
+		MaxSequencerDrift: 600,
+		DeltaTime:         &zero,
+		HoloceneTime:      &zero,
+	}
+	chainID := big.NewInt(420)
+
+	l1A := eth.L1BlockRef{Hash: common.HexToHash("0xaaaa01"), Number: 100, Time: 1002}
+	l1B := eth.L1BlockRef{Hash: common.HexToHash("0xaaaa02"), Number: 101, ParentHash: l1A.Hash, Time: 1014}
+
+	parentHash := common.HexToHash("0x44444444444444444444444444444444444444444444444444444444deadbeef")
+	l2Parent := eth.L2BlockRef{ // block N-1 = 4, common ancestor
+		Hash:     parentHash,
+		Number:   4,
+		Time:     1004,
+		L1Origin: eth.BlockID{Hash: l1A.Hash, Number: l1A.Number},
+	}
+	// Block N=5 as replaced by the interop invalidation: deposits-only, with a hash
+	// that the span batch's original chain never contained.
+	replacement := eth.L2BlockRef{
+		Hash:       common.HexToHash("0x5555555555555555555555555555555555555555555555555555555500197d39"),
+		Number:     5,
+		ParentHash: parentHash,
+		Time:       1005,
+		L1Origin:   eth.BlockID{Hash: l1A.Hash, Number: l1A.Number},
+	}
+
+	// One span batch covering N..N+3 (5..8), parent_check = hash(4).
+	// This models channel A's batch 18 (13456-13465) relative to replaced 13460.
+	var singulars []*SingularBatch
+	for i := uint64(5); i <= 8; i++ {
+		singulars = append(singulars, &SingularBatch{
+			ParentHash:   parentHash, // only the first block's parent is encoded (parent_check)
+			EpochNum:     rollup.Epoch(l1A.Number),
+			EpochHash:    l1A.Hash,
+			Timestamp:    1000 + i,
+			Transactions: nil,
+		})
+	}
+	span := initializedSpanBatch(singulars, cfg.Genesis.L2Time, chainID)
+	batch := BatchWithL1InclusionBlock{L1InclusionBlock: l1B, Batch: span}
+
+	logger := testlog.Logger(t, log.LevelError)
+	l2Client := testutils.MockL2Client{}
+	var nilErr error
+	l2Client.Mock.On("L2BlockRefByNumber", l2Parent.Number).Return(l2Parent, &nilErr)
+
+	ctx := context.Background()
+
+	t.Run("anchored_at_replacement_past_skips_and_keeps_span_tail", func(t *testing.T) {
+		// Walk anchored at the replacement block: the Holocene prefix check (the
+		// production BatchStage path — unlike the legacy full check it never
+		// fetches overlap payloads) consults only the pre-overlap ancestor
+		// (block 4), so the span is ACCEPTED even though its own block 5 was
+		// invalidated and replaced.
+		validity, _ := checkSpanBatchPrefix(ctx, cfg, logger, []eth.L1BlockRef{l1A, l1B}, replacement, span, batch.L1InclusionBlock, &l2Client)
+		require.EqualValues(t, BatchAccept, validity,
+			"span overlapping a replaced block must still pass prefix checks via the pre-overlap ancestor")
+
+		got, err := span.GetSingularBatches([]eth.L1BlockRef{l1A, l1B}, replacement)
+		require.NoError(t, err)
+		var ts []uint64
+		for _, sb := range got {
+			ts = append(ts, sb.Timestamp)
+		}
+		// Block 5 (the replaced block) is past-skipped — its span content is never
+		// re-validated against the replacement — and the tail 6..8 will be re-applied
+		// on top of the replacement (popNextBatch stamps ParentHash from the actual
+		// parent, i.e. the replacement hash).
+		require.Equal(t, []uint64{1006, 1007, 1008}, ts,
+			"tail must be re-applied across the replaced block without re-validating it")
+	})
+
+	t.Run("anchored_below_replacement_reproposes_denied_block", func(t *testing.T) {
+		// Walk anchored below the replacement (fresh sync / deep reset anchor):
+		// the SAME span re-proposes block 5. In production this is the path where
+		// the SuperAuthority denylist fires at payload insertion, the block is
+		// replaced deposits-only, the channel remainder is discarded, and the next
+		// channel's lineage wins.
+		validity, _ := checkSpanBatchPrefix(ctx, cfg, logger, []eth.L1BlockRef{l1A, l1B}, l2Parent, span, batch.L1InclusionBlock, &l2Client)
+		require.EqualValues(t, BatchAccept, validity)
+
+		got, err := span.GetSingularBatches([]eth.L1BlockRef{l1A, l1B}, l2Parent)
+		require.NoError(t, err)
+		var ts []uint64
+		for _, sb := range got {
+			ts = append(ts, sb.Timestamp)
+		}
+		require.Equal(t, []uint64{1005, 1006, 1007, 1008}, ts,
+			"walk from below must re-propose the invalidated block")
+	})
+}

--- a/op-node/rollup/derive/replacement_span_continuation_test.go
+++ b/op-node/rollup/derive/replacement_span_continuation_test.go
@@ -2,6 +2,7 @@ package derive
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -11,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
 // flushCountingProvider records FlushChannel calls so a test can assert whether
@@ -77,4 +79,126 @@ func TestDepositsOnlyReplacementChannelFlush(t *testing.T) {
 func testHash(b byte) (h common.Hash) {
 	h[0] = b
 	return
+}
+
+// TestAnchorBetweenReplacementsWedges pins the case that discriminates the
+// finality-pinned-anchor model (interop-reorg-5 investigation, update 9): a walk
+// anchored BETWEEN two replacements.
+//
+// On the live cluster the reset anchor landed exactly ON the first replacement,
+// because finality was pinned there and the replacement is the last block the
+// pre- and post-invalidation branches share. That anchor past-skips the denied
+// block, so the deny never fires, nothing is flushed, and the containing span's
+// tail re-applies — which is why the live node ended on the batcher's lineage.
+//
+// Had finality been further along — above the first replacement but below the
+// second — the walk would have re-proposed the second denied block, flushed its
+// channel, and then found nothing on L1 that chains onto the resulting
+// replacement: the later re-batch is built on the other lineage. That is a wedge
+// on a node that never wiped anything, and it is the prediction this test checks.
+//
+// Layout (numbers scaled down from 13460 / 14245):
+//
+//	4      common ancestor
+//	5 = R1 first replacement (already applied)
+//	6      anchor — above R1, below the second denied block
+//	7      denied on this lineage; replaced by R2
+//	8,9    the containing span's tail
+//	       re-batch span starts at 8 but is built on the OTHER lineage
+func TestAnchorBetweenReplacementsWedges(t *testing.T) {
+	zero := uint64(0)
+	cfg := &rollup.Config{
+		Genesis:           rollup.Genesis{L2Time: 1000},
+		BlockTime:         1,
+		SeqWindowSize:     3600,
+		MaxSequencerDrift: 600,
+		DeltaTime:         &zero,
+		HoloceneTime:      &zero,
+	}
+	chainID := big.NewInt(420)
+	logger := testlog.Logger(t, log.LevelError)
+	ctx := context.Background()
+
+	l1A := eth.L1BlockRef{Hash: common.HexToHash("0xaaaa01"), Number: 100, Time: 1002}
+	l1B := eth.L1BlockRef{Hash: common.HexToHash("0xaaaa02"), Number: 101, ParentHash: l1A.Hash, Time: 1014}
+	l1Blocks := []eth.L1BlockRef{l1A, l1B}
+
+	r1 := eth.L2BlockRef{ // 5: the first replacement, on both branches
+		Hash: testHash(0xd1), Number: 5, Time: 1005,
+		L1Origin: eth.BlockID{Hash: l1A.Hash, Number: l1A.Number},
+	}
+	anchor := eth.L2BlockRef{ // 6: between the replacements
+		Hash: testHash(0xf6), Number: 6, ParentHash: r1.Hash, Time: 1006,
+		L1Origin: eth.BlockID{Hash: l1A.Hash, Number: l1A.Number},
+	}
+	r2 := eth.L2BlockRef{ // 7': deposits-only replacement of the denied block 7
+		Hash: testHash(0xd2), Number: 7, ParentHash: anchor.Hash, Time: 1007,
+		L1Origin: eth.BlockID{Hash: l1A.Hash, Number: l1A.Number},
+	}
+
+	l2Client := testutils.MockL2Client{}
+	var nilErr error
+	l2Client.Mock.On("L2BlockRefByNumber", r1.Number).Return(r1, &nilErr)
+	l2Client.Mock.On("L2BlockRefByNumber", anchor.Number).Return(anchor, &nilErr)
+
+	// The channel containing the denied block: 6..9, parent_check = hash(5).
+	var containing []*SingularBatch
+	for i := uint64(6); i <= 9; i++ {
+		containing = append(containing, &SingularBatch{
+			ParentHash: r1.Hash, EpochNum: rollup.Epoch(l1A.Number), EpochHash: l1A.Hash,
+			Timestamp: 1000 + i,
+		})
+	}
+	containingSpan := initializedSpanBatch(containing, cfg.Genesis.L2Time, chainID)
+
+	// The later re-batch, built on the OTHER lineage: starts at 8, and its
+	// parent_check names that lineage's block 7, which this node does not have.
+	otherLineage7 := testHash(0xa7)
+	var rebatch []*SingularBatch
+	for i := uint64(8); i <= 9; i++ {
+		rebatch = append(rebatch, &SingularBatch{
+			ParentHash: otherLineage7, EpochNum: rollup.Epoch(l1A.Number), EpochHash: l1A.Hash,
+			Timestamp: 1000 + i,
+		})
+	}
+	rebatchSpan := initializedSpanBatch(rebatch, cfg.Genesis.L2Time, chainID)
+
+	t.Run("anchor between replacements re-proposes the denied block", func(t *testing.T) {
+		validity, _ := checkSpanBatchPrefix(ctx, cfg, logger, l1Blocks, anchor, containingSpan, l1B, &l2Client)
+		require.EqualValues(t, BatchAccept, validity)
+
+		got, err := containingSpan.GetSingularBatches(l1Blocks, anchor)
+		require.NoError(t, err)
+		var ts []uint64
+		for _, sb := range got {
+			ts = append(ts, sb.Timestamp)
+		}
+		require.Equal(t, []uint64{1007, 1008, 1009}, ts,
+			"walking from between the replacements must re-propose block 7, triggering the deny")
+	})
+
+	t.Run("nothing on L1 chains onto the replacement once the channel is flushed", func(t *testing.T) {
+		// Today's behavior: the deny-triggered replacement flushes the containing
+		// channel, so the re-batch is the next candidate — and it is built on the
+		// other lineage, so it drops. With no further batches this is the wedge.
+		validity, _ := checkSpanBatchPrefix(ctx, cfg, logger, l1Blocks, r2, rebatchSpan, l1B, &l2Client)
+		require.EqualValues(t, BatchDrop, validity,
+			"the re-batch must not chain onto the replacement: this is the permanent wedge")
+	})
+
+	t.Run("keeping the channel lets the span tail continue on the replacement", func(t *testing.T) {
+		// With --rollup.replacement-continues-span the containing channel is still
+		// buffered, so its tail is extracted against the replacement instead.
+		validity, _ := checkSpanBatchPrefix(ctx, cfg, logger, l1Blocks, r2, containingSpan, l1B, &l2Client)
+		require.EqualValues(t, BatchAccept, validity)
+
+		got, err := containingSpan.GetSingularBatches(l1Blocks, r2)
+		require.NoError(t, err)
+		var ts []uint64
+		for _, sb := range got {
+			ts = append(ts, sb.Timestamp)
+		}
+		require.Equal(t, []uint64{1008, 1009}, ts,
+			"the replaced block is past-skipped and the tail re-applies on the replacement")
+	})
 }

--- a/op-node/rollup/derive/replacement_span_continuation_test.go
+++ b/op-node/rollup/derive/replacement_span_continuation_test.go
@@ -1,0 +1,80 @@
+package derive
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+// flushCountingProvider records FlushChannel calls so a test can assert whether
+// the containing channel was discarded.
+type flushCountingProvider struct {
+	flushes int
+}
+
+func (p *flushCountingProvider) Reset(context.Context, eth.L1BlockRef, eth.SystemConfig) error {
+	return nil
+}
+func (p *flushCountingProvider) FlushChannel()          { p.flushes++ }
+func (p *flushCountingProvider) Origin() eth.L1BlockRef { return eth.L1BlockRef{} }
+func (p *flushCountingProvider) NextBatch(context.Context, eth.L2BlockRef) (*SingularBatch, bool, error) {
+	return nil, false, nil
+}
+
+// TestDepositsOnlyReplacementChannelFlush pins the lineage-selection switch:
+// whether producing a deposits-only replacement discards the remainder of the
+// channel that contained the replaced block.
+//
+// Flushing hands the lineage to whichever channel comes next on L1, which is how
+// a from-genesis node lands on an abandoned lineage (devnet interop-reorg-5,
+// chain 420120192: replaced 13460 -> channel A flushed -> channel B's 13461
+// adopted). Keeping it re-applies the span's tail onto the replacement, which is
+// the lineage the batcher continued.
+func TestDepositsOnlyReplacementChannelFlush(t *testing.T) {
+	cfg := &rollup.Config{BlockTime: 1}
+	parent := eth.L2BlockRef{Number: 13459, Hash: testHash(0xc1)}
+	derivedFrom := eth.L1BlockRef{Number: 11391112, Hash: testHash(0x25)}
+
+	newQueue := func(t *testing.T, opts ...AttributesQueueOption) (*AttributesQueue, *flushCountingProvider) {
+		prev := &flushCountingProvider{}
+		aq := NewAttributesQueue(testlog.Logger(t, log.LevelInfo), cfg, nil, prev, opts...)
+		// A replacement is only requested for attributes the queue just produced,
+		// so seed the state the real pipeline would be in.
+		aq.lastAttribs = &AttributesWithParent{
+			Attributes:  &eth.PayloadAttributes{Transactions: []eth.Data{{0x7e}, {0x02}}},
+			Parent:      parent,
+			DerivedFrom: derivedFrom,
+		}
+		return aq, prev
+	}
+
+	t.Run("flushes by default", func(t *testing.T) {
+		aq, prev := newQueue(t)
+		attrs, err := aq.DepositsOnlyAttributes(parent.ID(), derivedFrom)
+		require.NoError(t, err)
+		require.True(t, attrs.Attributes.IsDepositsOnly())
+		require.Equal(t, 1, prev.flushes, "default behavior must discard the containing channel")
+	})
+
+	t.Run("keeps channel when continuing the span", func(t *testing.T) {
+		aq, prev := newQueue(t, WithReplacementContinuesSpan(true))
+		attrs, err := aq.DepositsOnlyAttributes(parent.ID(), derivedFrom)
+		require.NoError(t, err)
+		require.True(t, attrs.Attributes.IsDepositsOnly(),
+			"the replacement itself must still be deposits-only")
+		require.Zero(t, prev.flushes,
+			"the containing channel must stay buffered so the span tail re-applies")
+	})
+}
+
+func testHash(b byte) (h common.Hash) {
+	h[0] = b
+	return
+}

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -38,4 +38,13 @@ type Config struct {
 
 	// Finalizer contains runtime configuration for finality behavior.
 	Finalizer *finality.Config `json:"finalizer,omitempty"`
+
+	// ReplacementContinuesSpan makes a deposits-only block replacement keep the
+	// containing channel buffered, so the remainder of the span re-applies on top
+	// of the replacement instead of the channel being flushed.
+	//
+	// EXPERIMENTAL: this changes which batch lineage a node derives after an
+	// interop block replacement, so nodes running with and without it can end up
+	// on different chains. Off by default; for devnet investigation only.
+	ReplacementContinuesSpan bool `json:"replacement_continues_span"`
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -75,7 +75,8 @@ func NewDriver(
 	attrHandler := attributes.NewAttributesHandler(log, cfg, driverCtx, l2, ec)
 	sys.Register("attributes-handler", attrHandler)
 
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, depSet, verifConfDepth, l1Blobs, altDA, l2, metrics, l1ChainConfig)
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, depSet, verifConfDepth, l1Blobs, altDA, l2, metrics, l1ChainConfig,
+		derive.WithReplacementContinuesSpan(driverCfg.ReplacementContinuesSpan))
 
 	pipelineDeriver := derive.NewPipelineDeriver(driverCtx, derivationPipeline)
 	sys.Register("pipeline", pipelineDeriver)

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	gosync "sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -116,6 +117,10 @@ type EngineController struct {
 
 	// To lock the engine RPC usage, such that components like the API, which need direct access, can protect their access.
 	mu gosync.RWMutex
+
+	// lastAnchorLogged holds the last logged resolved anchor block, so the
+	// anchor resolution logs transitions instead of every SafeL2Head poll.
+	lastAnchorLogged atomic.Value
 
 	// Block Head State
 	unsafeHead eth.L2BlockRef
@@ -285,6 +290,15 @@ func (e *EngineController) resolveAnchorAsSafe(ts uint64) eth.L2BlockRef {
 	if br.Number > e.localSafeHead.Number {
 		// Local safe hasn't reached the anchor block for the validator, so use local safe head.
 		return e.localSafeHead
+	}
+	// The anchor is the block a pipeline reset walks from, so whether it sits at
+	// or below an applied block replacement decides which batch lineage this node
+	// derives. Log transitions only: SafeL2Head is polled continuously.
+	if prev, ok := e.lastAnchorLogged.Load().(eth.BlockID); !ok || prev != br.ID() {
+		e.lastAnchorLogged.Store(br.ID())
+		e.log.Info("resolved super authority anchor as safe head",
+			"anchor_ts", ts, "anchor", br.ID(), "anchor_parent", br.ParentHash,
+			"local_safe", e.localSafeHead.ID())
 	}
 	e.crossSafeCache.Store(br)
 	return br

--- a/op-node/rollup/engine/payload_process.go
+++ b/op-node/rollup/engine/payload_process.go
@@ -44,6 +44,12 @@ func (e *EngineController) onPayloadProcess(ctx context.Context, ev PayloadProce
 					"blockNumber", payload.BlockNumber,
 					"blockHash", payload.BlockHash,
 					"derivedFrom", ev.DerivedFrom,
+					// The parent this denied block was re-proposed on: a parent one
+					// below the replacement means the walk anchored below it instead
+					// of past-skipping it, which is what flushes the channel and
+					// hands the lineage to the next channel on L1.
+					"parent", ev.Ref.ParentID(),
+					"localSafe", e.localSafeHead.ID(),
 				)
 				e.emitDepositsOnlyPayloadAttributesRequest(ctx, ev.Ref.ParentID(), ev.DerivedFrom)
 			} else {

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -201,6 +201,7 @@ func NewDriverConfig(ctx cliiface.Context) *driver.Config {
 		SequencerMaxSafeLag:      ctx.Uint64(flags.SequencerMaxSafeLagFlag.Name),
 		RecoverMode:              ctx.Bool(flags.SequencerRecoverMode.Name),
 		SequencerSealingDuration: ctx.Duration(flags.SequencerSealingDurationFlag.Name),
+		ReplacementContinuesSpan: ctx.Bool(flags.ReplacementContinuesSpan.Name),
 	}
 
 	// Populate finality config from flags. A finality config with null fields

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -448,11 +448,18 @@ func (i *Interop) progress() (time.Duration, error) {
 				fmt.Sprintf("chain_%s", chain.ID()),
 				fmt.Sprintf("safe=%d pending_safe=%d unsafe=%d",
 					status.SafeL2.Number, status.PendingSafeL2.Number, status.UnsafeL2.Number))
+			// A flat safe head with an advancing unsafe head is the derivation
+			// wedge signature; export it so it is visible without log scraping.
+			cid := chain.ID().String()
+			i.metrics.ChainSyncHeadBlock.WithLabelValues(cid, "safe").Set(float64(status.SafeL2.Number))
+			i.metrics.ChainSyncHeadBlock.WithLabelValues(cid, "pending_safe").Set(float64(status.PendingSafeL2.Number))
+			i.metrics.ChainSyncHeadBlock.WithLabelValues(cid, "unsafe").Set(float64(status.UnsafeL2.Number))
 		}
 		var behind uint64
 		if tipTS > lastTS {
 			behind = tipTS - lastTS
 		}
+		i.metrics.InteropBehindSeconds.Set(float64(behind))
 		fields = append(fields,
 			"lastVerifiedTimestamp", lastTS, "tipTimestamp", tipTS, "behindSeconds", behind)
 		i.log.Info("interop verification progress", fields...)

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -193,6 +193,10 @@ type simpleChainContainer struct {
 	rollupClient       *sources.RollupClient // In-proc rollup RPC client bound to rpcHandler
 	metrics            *resources.SupernodeMetrics
 
+	// lastFloorDecision holds the last logged floorDecision, so the replacement
+	// floor logs transitions instead of every verifier head poll.
+	lastFloorDecision atomic.Value
+
 	// verifierMu guards writes and reads of the verifier.
 	verifierMu sync.RWMutex
 	verifier   activity.VerificationActivity
@@ -367,6 +371,9 @@ func (c *simpleChainContainer) Start(ctx context.Context) error {
 	if c.rpcRouter != nil {
 		c.rpcRouter.SetReadinessCheck(c.chainID.String(), c.IsRPCReady)
 	}
+	// Counts consecutive paused iterations, so a long pause logs once per 30s
+	// instead of once per second per chain.
+	pausedIters := 0
 	for {
 		// Refresh per-start derived fields
 		c.vncfg.SafeDBPath = c.subPath("safe_db")
@@ -409,10 +416,14 @@ func (c *simpleChainContainer) Start(ctx context.Context) error {
 				c.log.Info("chain container stop requested while paused, stopping restart loop")
 				break
 			}
-			c.log.Info("chain container paused")
+			if pausedIters%30 == 0 {
+				c.log.Info("chain container paused", "paused_seconds", pausedIters)
+			}
+			pausedIters++
 			time.Sleep(1 * time.Second)
 			continue
 		}
+		pausedIters = 0
 		if c.stop.Load() {
 			break
 		}

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -3,10 +3,12 @@ package chain_container
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -36,7 +38,108 @@ func (c *simpleChainContainer) FullyVerifiedL2Head(ctx context.Context) (rollup.
 			"verifier", v.Name(), "err", err)
 		return rollup.VerifierHead{}, false
 	}
-	return contribution, true
+	return c.floorAtReplacement(contribution), true
+}
+
+// floorAtReplacement lifts a verifier head that sits below the latest applied
+// block replacement up to the replacement height (as an Anchor, resolved to the
+// canonical block by the engine controller).
+//
+// Rationale: after an invalidation replaces block N, a derivation walk anchored
+// BELOW N re-proposes the denied block, which triggers a deposits-only
+// replacement plus a channel flush — discarding the remainder of the span that
+// the rest of the network kept, and stranding the node on an abandoned batch
+// lineage (see devnet interop-reorg-5, chain 420120192, blocks 13460/14245, and
+// TestReplacedBlockLineageSelection in op-node/rollup/derive). A walk anchored
+// AT the replacement past-skips the denied block, matching the behavior of
+// nodes that performed the invalidation with a current verifier state. The
+// denylist is the record of replacements this node has applied, so its max
+// height is a safe derivation floor: everything at or below it is
+// authority-decided local chain.
+func (c *simpleChainContainer) floorAtReplacement(head rollup.VerifierHead) rollup.VerifierHead {
+	h, any, err := c.MaxDeniedHeight()
+	if err != nil {
+		c.recordFloorDecision(floorDecision{outcome: floorOutcomeReadFailed},
+			"anchor floor: deny list read failed, not flooring", "err", err)
+		return head
+	}
+	c.met().DenyListMaxHeight.WithLabelValues(c.chainID.String()).Set(float64(h))
+	if !any {
+		// The post-wipe case: no replacement is recorded locally, so there is no
+		// floor and the walk anchors wherever the verifier points — which is how a
+		// fresh node re-proposes a block the rest of the cluster already replaced.
+		c.recordFloorDecision(floorDecision{outcome: floorOutcomeNoDenyList},
+			"anchor floor: no deny list entries, nothing to floor",
+			"verifier_source", head.Source, "verifier_ts", head.Timestamp)
+		return head
+	}
+	rcfg := c.vncfg.Rollup
+	replacementTs := rcfg.Genesis.L2Time + h*rcfg.BlockTime
+	switch head.Source {
+	case rollup.VerifierHeadAnchor, rollup.VerifierHeadVerified:
+		if head.Timestamp >= replacementTs {
+			c.recordFloorDecision(floorDecision{outcome: floorOutcomeAtOrAbove, deniedHeight: h},
+				"anchor floor: verifier head at or above latest applied replacement",
+				"denied_height", h, "replacement_ts", replacementTs,
+				"verifier_source", head.Source, "verifier_ts", head.Timestamp)
+			return head
+		}
+		c.recordFloorDecision(floorDecision{outcome: floorOutcomeFloored, deniedHeight: h},
+			"flooring verifier head at latest applied replacement",
+			"denied_height", h, "replacement_ts", replacementTs,
+			"verifier_source", head.Source, "verifier_ts", head.Timestamp)
+		return rollup.VerifierHead{Source: rollup.VerifierHeadAnchor, Timestamp: replacementTs}
+	default:
+		// PreActivation resolves to local-safe directly, which already includes
+		// any applied replacement.
+		c.recordFloorDecision(floorDecision{outcome: floorOutcomePreActivation, deniedHeight: h},
+			"anchor floor: pre-activation verifier head, using local safe",
+			"denied_height", h, "replacement_ts", replacementTs)
+		return head
+	}
+}
+
+// defaultMetrics backs met() for containers built without metrics (tests).
+var defaultMetrics = sync.OnceValue(resources.NewSupernodeMetrics)
+
+// met returns the container's metrics, or a detached default when none were
+// supplied, matching the nil-metrics contract documented on SupernodeMetrics.
+func (c *simpleChainContainer) met() *resources.SupernodeMetrics {
+	if c.metrics != nil {
+		return c.metrics
+	}
+	return defaultMetrics()
+}
+
+// Outcomes of floorAtReplacement, also used as the metric label value.
+const (
+	floorOutcomeFloored       = "floored"
+	floorOutcomeAtOrAbove     = "at_or_above_replacement"
+	floorOutcomeNoDenyList    = "no_denylist_entries"
+	floorOutcomeReadFailed    = "denylist_read_failed"
+	floorOutcomePreActivation = "pre_activation"
+)
+
+// floorDecision is the dedupe key for floorAtReplacement logging. It
+// deliberately excludes the verifier timestamp: that advances every block
+// during normal sync, so including it made every block a new "transition" and
+// emitted a line per block per chain. Outcome plus replacement height changes
+// only when something actually changes.
+type floorDecision struct {
+	outcome      string
+	deniedHeight uint64
+}
+
+// recordFloorDecision counts every decision but logs only transitions: the
+// verifier head is polled continuously, so logging every call would emit
+// several lines per second per chain and bury the derivation logs around it.
+func (c *simpleChainContainer) recordFloorDecision(d floorDecision, msg string, ctx ...any) {
+	c.met().AnchorFloorDecisions.WithLabelValues(c.chainID.String(), d.outcome).Inc()
+	if prev, ok := c.lastFloorDecision.Load().(floorDecision); ok && prev == d {
+		return
+	}
+	c.lastFloorDecision.Store(d)
+	c.log.Info(msg, ctx...)
 }
 
 // FinalizedL2Head is the finalized analogue of FullyVerifiedL2Head.
@@ -100,7 +203,15 @@ func (c *simpleChainContainer) IsDenied(height uint64, payloadHash common.Hash) 
 	if c.denyList == nil {
 		return false, fmt.Errorf("deny list not initialized")
 	}
-	return c.denyList.Contains(height, payloadHash)
+	denied, err := c.denyList.Contains(height, payloadHash)
+	if err == nil && denied {
+		// A hit means derivation re-proposed a block this node already replaced:
+		// the walk anchored below the replacement instead of past-skipping it.
+		c.met().DenyListHits.WithLabelValues(c.chainID.String()).Inc()
+		c.log.Info("deny list hit, block re-proposed after replacement",
+			"height", height, "payload_hash", payloadHash)
+	}
+	return denied, err
 }
 
 // MaxDeniedHeight returns the highest denied block height and whether any

--- a/op-supernode/supernode/resources/supernode_metrics.go
+++ b/op-supernode/supernode/resources/supernode_metrics.go
@@ -19,6 +19,11 @@ type SupernodeMetrics struct {
 	ChainRewindDuration         *prometheus.HistogramVec
 	ChainRewindFailures         *prometheus.CounterVec
 	DenyListEntries             *prometheus.CounterVec
+	DenyListHits                *prometheus.CounterVec
+	DenyListMaxHeight           *prometheus.GaugeVec
+	AnchorFloorDecisions        *prometheus.CounterVec
+	ChainSyncHeadBlock          *prometheus.GaugeVec
+	InteropBehindSeconds        prometheus.Gauge
 	LogBackfillProgress         *prometheus.GaugeVec
 	LogBackfillRetries          *prometheus.CounterVec
 	ActivityErrors              *prometheus.CounterVec
@@ -91,6 +96,31 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 			Name:      "denylist_entries_total",
 			Help:      "Total number of deny list entries added per chain.",
 		}, []string{"chain_id"}),
+		DenyListHits: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "supernode",
+			Name:      "denylist_hits_total",
+			Help:      "Total number of payloads rejected by a deny list lookup, i.e. denied blocks re-proposed by derivation.",
+		}, []string{"chain_id"}),
+		DenyListMaxHeight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "supernode",
+			Name:      "denylist_max_height",
+			Help:      "Highest denied block height on the deny list, 0 when no replacement has been applied locally.",
+		}, []string{"chain_id"}),
+		AnchorFloorDecisions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "supernode",
+			Name:      "derivation_anchor_floor_decisions_total",
+			Help:      "Verifier head decisions by outcome of the replacement floor: floored, at_or_above_replacement, no_denylist_entries, denylist_read_failed, pre_activation.",
+		}, []string{"chain_id", "outcome"}),
+		ChainSyncHeadBlock: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "supernode",
+			Name:      "chain_sync_head_block",
+			Help:      "Per-chain L2 head block number by kind (safe, pending_safe, unsafe). A flat safe head with advancing unsafe is the derivation wedge signature.",
+		}, []string{"chain_id", "kind"}),
+		InteropBehindSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "supernode",
+			Name:      "interop_behind_seconds",
+			Help:      "Seconds between the latest verified timestamp and the highest unsafe tip timestamp across chains.",
+		}),
 		LogBackfillProgress: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "supernode",
 			Name:      "log_backfill_progress",
@@ -125,6 +155,11 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 		m.ChainRewindDuration,
 		m.ChainRewindFailures,
 		m.DenyListEntries,
+		m.DenyListHits,
+		m.DenyListMaxHeight,
+		m.AnchorFloorDecisions,
+		m.ChainSyncHeadBlock,
+		m.InteropBehindSeconds,
 		m.LogBackfillProgress,
 		m.LogBackfillRetries,
 		m.ActivityErrors,


### PR DESCRIPTION
## Problem

On devnet `interop-reorg-5` (chain `420120192`), an interop message was judged invalid and block 13460 was replaced with a deposits-only version. Every supernode that afterwards derived that range **from genesis** ended up on a batch lineage nobody else had, and wedged there permanently — no batch on L1 chains onto its result, so every later batch drops as future/parent-mismatch. Reproduced 3/3 on independent wipes.

The deciding line is in `DepositsOnlyAttributes`:

```go
aq.prev.FlushChannel() // flush all channel data in previous stages
```

Flushing discards the remainder of the channel the replaced block came from, which hands the lineage to whichever channel happens to come next on L1. A node that already held the following blocks locally (the live cluster, mid-invalidation) re-applies them onto the replacement and stays on the lineage the batcher continued. A node deriving the same L1 data from scratch flushes, adopts the next channel, and dead-ends.

Full investigation: [Double Batch Derivation Issue](https://app.notion.com/p/oplabs/Double-Batch-Derviation-Issue-3aef153ee162804e8097e24f69483e6d) (updates 5–8 cover this diff).

## Two commits, reviewable separately

**1. `op-supernode: log and measure post-replacement lineage selection`** — observability only, no behavior change.

Diagnosing this required reconstructing the decision from EL block data, because the case that matters — a node with an *empty* deny list — emitted no logs at all. Now every replacement-anchor floor outcome logs, plus span elements past-skipped over the safe chain, and the parent the walk used on parent-hash-mismatch / deposits-only requests. New metrics: `supernode_derivation_anchor_floor_decisions_total{chain_id,outcome}`, `supernode_denylist_max_height`, `supernode_denylist_hits_total`, `supernode_chain_sync_head_block{chain_id,kind}`, `supernode_interop_behind_seconds`. Hot-path lines log transitions only; metrics count every occurrence. Also rate-limits `chain container paused`, which ran at 3 lines/sec/chain (116k lines/6h) and buried the window we needed.

Adds `TestReplacedBlockLineageSelection`.

**2. `op-node: optionally continue the containing span after a block replacement`** — the behavior change, behind `--rollup.replacement-continues-span` (env `OP_NODE_ROLLUP_REPLACEMENT_CONTINUES_SPAN`), **hidden and default off**.

Threaded `driver.Config` → pipeline → attributes queue using variadic options, so no existing caller or test signature changes. op-supernode picks it up for free as `OP_SUPERNODE_VN_ALL_ROLLUP_REPLACEMENT_CONTINUES_SPAN` via its `vn.`/`vn.all.` flag cloning.

Adds `TestDepositsOnlyReplacementChannelFlush`, pinning both directions.

## Evidence

Same node, same L1, wiped and re-derived from genesis twice on 2026-08-03:

| Block | flag ON | flag OFF (control) | Live cluster (measured) |
|---|---|---|---|
| 13460 | `0x197d398a…` seq3 origin 11391103 | identical | identical (the replacement) |
| **13461** | **`0xc476a12f…` seq4 origin 11391103** | `0x67c34c2c…` seq0 origin 11391104 | `0xc476a12f…` seq4 ✅ |
| 13465 | `0x5d9e2aae…` seq8 origin 11391103 | `0x14b185f6…` seq0 origin 11391108 | `0x5d9e2aae…` ✅ |
| 13466 | `0x38e8ea21…` seq0 origin 11391104 | — | `0x38e8ea21…` ✅ |
| 14245 | `0x12236ab4…` seq1 origin 11391172 | `0x0eeff720…` seq0 origin 11391166 | `0x12236ab4…` ✅ |

`0x5d9e2aae…:13465` is the `parent_check` of the batcher's re-batch at L1 11391200, and the exact block the sequencer leader force-reset onto during the incident. With the flag the node sailed past the 14927 dead-end that trapped all three prior attempts; without it, it reproduced the dead-end again.

Exactly one log line differs in cause:

```
deposits-only replacement: continuing containing span, channel not flushed
  chain_id=420120192 parent=0xc1b21cc7…:13459 derived_from=…:11391112
```

## Why this is draft

1. **Safety review needed.** Not flushing means channel data survives across an invalidation. Whether a hostile or malformed channel can exploit the retained buffer is not answered by a devnet run.
2. **n=1.** One chain, one devnet. Wants an acceptance test that wipes a supernode and asserts convergence in CI.
3. **Spec-level.** Nodes with and without this rule derive different chains from identical L1 data, so defaulting it on is fork-class and belongs in the interop spec as "the remainder of the span containing a replaced block re-applies onto the replacement".
4. Behaviour when the containing channel's remainder would extend past sequencing-window expiry is untested.

Deployed as `dev-images/op-supernode:reorg-anchor-floor-3` on `interop-reorg-5` supernode-2 only; supernode-0/1 remain on `v1.0.0-rc.7` as controls.

---

## Correction (added after further Loki investigation — original text above left intact)

The "Problem" section above says a node "that already held the following blocks locally re-applies them onto the replacement." **That is wrong**, and the corrected mechanism is worth reading before reviewing, because it strengthens the case for this change rather than weakening it.

Supernode-0 (the live, never-wiped node) did **not** hold the good blocks. It derived channel B and ran the abandoned lineage:

```
18:25:31  Inserted new L2 unsafe block  hash=0x67c34c2c…:13461   (channel B, derived from L1 11391131)
```

It then reached F2's unsafe 14494, and only flipped later. What flipped it was a **second** invalidation, whose rewind produced an anchor *below* the rewind target:

```
18:37:10  added block to deny list  invalidatedBlock=0x4dcf6ef6…:14245  lastValidParent=0x3ffdc751…:14244
18:37:13  executed FCU to target block
            head=0x3ffdc751…       (14244, the rewind target)
            safe=0x2ebe1736…       (an F2-lineage block — absent from the chain today)
            finalized=0x197d398a…  (13460, the FIRST replacement)
18:37:14  Reset of Engine is completed
            local_unsafe=…:14244    local_safe=0x197d398a…:13460   ← 784 blocks below the target
18:37:14  Resetting safe head db  l2=0x197d398a…:13460
```

Derivation restarts from *safe*, so the anchor was the replacement itself. From there `GetSingularBatches` past-skips the denied 13460, the deny never fires, nothing is flushed, and the containing span's tail re-applies — landing sn-0 on the lineage the batcher continued.

Why the anchor landed exactly on a replacement: of the three hashes in that FCU, only `finalized` was still canonical (`0x2ebe1736…` and `0x3ffdc751…:14244` are both gone). **The replacement is by construction the last block the two branches share**, so finality-pinning necessarily lands there. Code path: `rewind.go:153-169` (`safe=earliest(currentSafe, target)`, `finalized=earliest(currentFinalized, target)`) then `sync/start.go:74-89`, where safe defaults to finalized.

### Why this makes the change more important, not less

The correct outcome on a live node is an accident of *where finality sits relative to the replacement*:

- finality **at** a replacement → past-skip → batcher-continued lineage (what sn-0 got)
- finality **below** a replacement → re-propose → deny → flush → next channel wins → permanent dead-end (what every from-genesis node gets, three for three)

This PR makes the outcome **anchor-independent**. The `reorg-anchor-floor-3` run derived the live chain from a cold-start anchor with an empty deny list — an anchor from which the unflagged control, same node and same L1, produced channel B and dead-ended.

### One ordering constraint for whoever takes this further

Do **not** fix the anchor regression on its own. With `local_safe=14244` (the rewind target, i.e. "correct"), sn-0 would have re-proposed F2's 14245 → deny → flush → and the only remaining candidate is the L1 11391200 re-batch, whose `parent_check` is 13465′, which does not exist on the F2 lineage → wedge. The regression is what saved it. Any change to `computeRewindTargets` or to safe/finalized clamping must land with or after this one.

Related, and separately actionable: throughout 18:37:33+ the node logged `super authority safe head ahead of local safe head, using local safe` (`authority=0x3ffdc751…:14244` vs `local=0x5d9e2aae…:13465`) — it detected the divergence from the authority in real time and continued anyway.
