### PR TITLE
ci: expose authoritative post-merge gate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,17 +168,22 @@ jobs:
             c-l2_fork_test_dispatch: << pipeline.parameters.l2_fork_test_dispatch >>
       # Change-detection patterns live in routing.yml (change_patterns.any and
       # change_patterns.all). Each is a POSIX ERE matched line-by-line against
-      # `git diff --name-only origin/develop...HEAD`; collect-params.sh writes
-      # the resulting c-<name> boolean into the JSON.
+      # the feature-branch merge-base diff, or the first-parent diff for a
+      # webhook push to develop (where origin/develop already equals HEAD).
+      # collect-params.sh writes the resulting c-<name> boolean into the JSON.
       #
       # Test a pattern locally:
       #   git diff --name-only origin/develop...HEAD | grep -E "^your/pattern/"
       - run:
           name: Detect file tree changes and store in JSON file
           command: .circleci/scripts/collect-params.sh detect
+          environment: &change-detection-trigger
+            CURRENT_BRANCH: << pipeline.git.branch >>
+            TRIGGER_SOURCE: << pipeline.trigger_source >>
       - run:
           name: Detect docs-only changes (all-match)
           command: .circleci/scripts/collect-params.sh detect_all
+          environment: *change-detection-trigger
       # Routing policy: enables the c-run_* workflow flags based on trigger,
       # branch, schedule, and the detected params. The workflow lists are data
       # in routing.yml; the conditions live in compute-workflow-conditions.sh.

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -20,6 +20,13 @@ parameters:
   c-publish_contract_artifacts_ref:
     type: string
     default: ""
+  # Exact conditional routing choices forwarded to post-merge-gate.
+  c-rust_changes_detected:
+    type: boolean
+    default: false
+  c-security_changed:
+    type: boolean
+    default: false
   # CircleCI forwards user-supplied setup params into continuation validation.
   # These aliases are transformed into c-* params by config.yml and are not
   # referenced by jobs in the continuation config.
@@ -136,6 +143,9 @@ parameters:
     type: boolean
     default: false
   c-run_publish_contract_artifacts:
+    type: boolean
+    default: false
+  c-run_post_merge_gate:
     type: boolean
     default: false
 
@@ -734,6 +744,36 @@ jobs:
       - run:
           name: Check CircleCI schedule triggers
           command: bun .circleci/scripts/test-schedule-triggers.js
+
+  post-merge-gate-tests:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small.gen2
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+          enable-mise-cache: true
+      - run:
+          name: Test post-merge gate
+          command: bun test ./.circleci/scripts/post-merge-gate.test.ts
+
+  post-merge-gate:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small.gen2
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+          enable-mise-cache: true
+      - run:
+          name: Wait for authoritative post-merge result
+          command: bun .circleci/scripts/post-merge-gate.ts
+          no_output_timeout: 10m
+          environment:
+            POST_MERGE_RUST_CHANGED: << pipeline.parameters.c-rust_changes_detected >>
+            POST_MERGE_SECURITY_CHANGED: << pipeline.parameters.c-security_changed >>
+            POST_MERGE_GATE_TIMEOUT_SECONDS: "14400"
+            POST_MERGE_GATE_POLL_INTERVAL_SECONDS: "60"
 
   # Build a single Rust binary from a workspace. Will cache the binary by default.
   rust-build-binary:
@@ -2538,6 +2578,9 @@ workflows:
       - l2-chains-sync-check:
           context:
             - circleci-repo-readonly-authenticated-github-token
+      - post-merge-gate-tests:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-upload:
           requires:
             - contracts-bedrock-build
@@ -2805,6 +2848,7 @@ workflows:
             - l2-chains-sync-check: terminal
             - nut-provenance-verify: terminal
             - diff-fetcher-forge-artifacts: terminal
+            - post-merge-gate-tests: terminal
           context:
             - circleci-api-token
           filters:
@@ -2904,6 +2948,16 @@ workflows:
     jobs:
       - publish-contract-artifacts:
           context:
+            - circleci-repo-readonly-authenticated-github-token
+
+  # The workflow name is the GitHub check name emitted by the CircleCI App.
+  # Keep this stable: consumers require `circleci-checks / post-merge-gate`.
+  post-merge-gate:
+    when: << pipeline.parameters.c-run_post_merge_gate >>
+    jobs:
+      - post-merge-gate:
+          context:
+            - circleci-api-token
             - circleci-repo-readonly-authenticated-github-token
 
   develop-fault-proofs:

--- a/.circleci/routing.yml
+++ b/.circleci/routing.yml
@@ -59,9 +59,58 @@ api_dispatch:
   labeled_pr:
     - close_issue
 
+# Authoritative policy for workflows started by a webhook push to develop.
+# Every CircleCI route is declared here and explicitly classified: entries with
+# `workflow` are aggregated by post-merge-gate, while entries with `excluded`
+# explain why they are not gate members. The setup router reads the `route`
+# fields directly, so a new post-merge route cannot be added without choosing a
+# gate policy. `required_jobs` guards jobs that must appear inside a successful
+# workflow (currently go-tests-full, which is branch-filtered to develop).
+post_merge_gate:
+  circleci:
+    always:
+      - route: main
+        workflow: main
+        required_jobs:
+          - go-tests-full
+      - route: publish_contract_artifacts
+        workflow: publish-contract-artifacts-auto-or-manual
+      - route: develop_fault_proofs
+        workflow: develop-fault-proofs
+      - route: develop_kontrol_tests
+        workflow: develop-kontrol-tests
+      - route: contracts_feature_tests
+        workflow: contracts-feature-tests
+      - route: release
+        excluded: Tag-only release jobs are filtered out on branch pushes.
+      - route: post_merge_gate
+        excluded: The aggregator cannot wait for its own workflow.
+    rust_changed:
+      - route: rust_ci
+        workflow: rust-ci
+      - route: rust_e2e_ci
+        workflow: rust-e2e-ci
+      - route: kona_publish_prestates
+        workflow: kona-publish-prestates
+    rust_unchanged:
+      - route: rust_ci_gate_short
+        workflow: rust-ci-gate-short
+      - route: rust_e2e_gate_skip
+        workflow: rust-e2e-gate-skip
+  github_actions:
+    always:
+      - workflow: build images
+        path: .github/workflows/build-images.yaml
+      - workflow: build-images.apko
+        path: .github/workflows/build-images.apko.yaml
+    security_changed:
+      - workflow: security
+        path: .github/workflows/security.yml
+
 # Change-detection patterns. Each value is a POSIX Extended Regular Expression
 # (ERE, like grep -E) matched line-by-line against the changed file list
-# (git diff --name-only origin/develop...HEAD). collect-params.sh reads these.
+# selected by collect-params.sh (merge-base for branches, first-parent for a
+# webhook push to develop).
 #
 # Test a pattern locally:
 #   git diff --name-only origin/develop...HEAD | grep -E "^your/pattern/"
@@ -72,6 +121,7 @@ change_patterns:
     contracts_changed: "^(packages/contracts-bedrock|op-core/forks|op-core/nuts|\\.circleci|\\.github|ops/check-changed)/|^(package\\.json|mise\\.toml)$"
     docs_changes_detected: "^docs/public-docs/"
     rust_changes_detected: "^(rust|op-e2e|\\.circleci)/|^mise\\.toml$"
+    security_changed: "^(\\.circleci/config\\.yml|\\.github/workflows/security\\.yml)$"
   # "all": c-<name> is true iff EVERY changed file matches (and there is at
   # least one). Used for the safe-by-default docs-only fast path: any path not
   # enumerated still falls through to the full main workflow.
@@ -87,3 +137,7 @@ passthrough_params:
   - c-github-event-base64
   - c-go-cache-version
   - c-publish_contract_artifacts_ref
+  # Conditional choices consumed by the post-merge aggregator. Keeping these
+  # exact routing decisions avoids inferring applicability from absent checks.
+  - c-rust_changes_detected
+  - c-security_changed

--- a/.circleci/scripts/collect-params.sh
+++ b/.circleci/scripts/collect-params.sh
@@ -9,11 +9,15 @@
 #
 # str/bool read c-* env vars (CircleCI pipeline params). detect/detect_all read
 # their ERE patterns from routing.yml so the patterns are declarative data.
+# On webhook pushes to develop, changed paths come from the pushed commit's
+# first-parent diff: origin/develop already points at HEAD after checkout, so a
+# merge-base diff there would be empty and misroute conditional post-merge work.
 # Each invocation appends to /tmp/pipeline-parameters.json.
 set -euo pipefail
 
 MODE="${1:?Usage: collect-params.sh <str|bool|detect|detect_all>}"
-OUTPUT="/tmp/pipeline-parameters.json"
+# OUTPUT is overridable so tests can use an isolated parameters file.
+OUTPUT="${OUTPUT:-/tmp/pipeline-parameters.json}"
 ROUTING="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/routing.yml"
 
 [ -f "${OUTPUT}" ] || echo '{}' > "${OUTPUT}"
@@ -44,8 +48,13 @@ case "${MODE}" in
   detect|detect_all)
     [[ "${MODE}" == "detect_all" ]] && section=".change_patterns.all" || section=".change_patterns.any"
 
-    CHANGED=$(git diff --name-only "origin/${BASE_REVISION}...HEAD" 2>/dev/null \
-      || git diff --name-only HEAD~1 HEAD || true)
+    if [[ "${TRIGGER_SOURCE:-}" == "webhook" && "${CURRENT_BRANCH:-}" == "develop" ]]; then
+      CHANGED=$(git diff --name-only HEAD^ HEAD)
+    elif git rev-parse --verify --quiet "origin/${BASE_REVISION:-develop}" >/dev/null; then
+      CHANGED=$(git diff --name-only "origin/${BASE_REVISION:-develop}...HEAD")
+    else
+      CHANGED=$(git diff --name-only HEAD~1 HEAD)
+    fi
     echo "=== Changed files ==="
     echo "${CHANGED:-<none>}"
     echo "====================="

--- a/.circleci/scripts/compute-workflow-conditions.sh
+++ b/.circleci/scripts/compute-workflow-conditions.sh
@@ -15,6 +15,7 @@
 # Helpers (workflow-helpers.sh):
 #   run <wf...>            enable workflows by literal name
 #   run_group <sec> <key>  enable the workflows listed under routing.yml sec.key
+#   run_post_merge_group   enable a classified post-merge policy variant
 #   is_true <x>            true if c-x is true in the JSON
 #   param <x>              raw value of c-x from the JSON
 #   finalize               strip intermediate params, keep c-run_* + passthrough
@@ -102,19 +103,13 @@ case "${TRIGGER_SOURCE}" in
     #    Adds expensive post-merge jobs: fault proofs, kontrol, prestate publishing.
     # ---------------------------------------------------------
     elif [[ "${BRANCH}" == "develop" ]]; then
-      run main
-      run release
-      run publish_contract_artifacts
-      run develop_fault_proofs
-      run develop_kontrol_tests
-      run contracts_feature_tests
+      # routing.yml classifies every post-merge route as either aggregated or
+      # explicitly excluded. The gate reads the same policy when polling.
+      run_post_merge_group always
       if is_true rust_changes_detected; then
-        run rust_ci
-        run rust_e2e_ci
-        run kona_publish_prestates
+        run_post_merge_group rust_changed
       else
-        run rust_ci_gate_short
-        run rust_e2e_gate_skip
+        run_post_merge_group rust_unchanged
       fi
     fi
     ;;

--- a/.circleci/scripts/post-merge-gate.test.ts
+++ b/.circleci/scripts/post-merge-gate.test.ts
@@ -1,0 +1,591 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  buildExpectedWorkflows,
+  GateInspector,
+  loadPolicy,
+  parseBoolean,
+  selectLatestCircleWorkflow,
+  selectLatestGithubRun,
+  validatePipeline,
+  validatePolicy,
+  waitForGate,
+  type CircleApi,
+  type CircleJob,
+  type CirclePipeline,
+  type CircleWorkflow,
+  type ExpectedWorkflows,
+  type GateSnapshot,
+  type GithubApi,
+  type GithubWorkflowRun,
+  type PostMergePolicy,
+} from "./post-merge-gate";
+
+const repoRoot = path.resolve(import.meta.dir, "../..");
+const routingPath = path.join(repoRoot, ".circleci/routing.yml");
+const continuationDir = path.join(repoRoot, ".circleci/continue");
+const workflowsDir = path.join(repoRoot, ".github/workflows");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+function yamlJson<T>(file: string, expression = "."): T {
+  const result = Bun.spawnSync(["yq", "-o=json", expression, file], { cwd: repoRoot });
+  if (!result.success) throw new Error(new TextDecoder().decode(result.stderr));
+  return JSON.parse(new TextDecoder().decode(result.stdout)) as T;
+}
+
+function patternMatches(value: string, pattern: string): boolean {
+  if (pattern.startsWith("/") && pattern.endsWith("/")) {
+    return new RegExp(pattern.slice(1, -1)).test(value);
+  }
+  return value === pattern;
+}
+
+function circleJobAllowsBranch(job: string | Record<string, Record<string, unknown> | null>, branch: string): boolean {
+  if (typeof job === "string") return true;
+  const config = Object.values(job)[0];
+  if (!config) return true;
+  const filters = config.filters as
+    | { branches?: { only?: string | string[]; ignore?: string | string[] } }
+    | undefined;
+  const branchFilters = filters?.branches;
+  if (!branchFilters) return true;
+  const asArray = (value: string | string[] | undefined): string[] =>
+    value === undefined ? [] : Array.isArray(value) ? value : [value];
+  const only = asArray(branchFilters.only);
+  if (only.length > 0) return only.some((pattern) => patternMatches(branch, pattern));
+  const ignore = asArray(branchFilters.ignore);
+  return !ignore.some((pattern) => patternMatches(branch, pattern));
+}
+
+function fixturePolicy(): PostMergePolicy {
+  return {
+    circleci: {
+      always: [
+        { route: "main", workflow: "main", required_jobs: ["go-tests-full"] },
+        { route: "gate", excluded: "self" },
+      ],
+      rust_changed: [{ route: "rust", workflow: "rust-ci" }],
+      rust_unchanged: [{ route: "rust_skip", workflow: "rust-ci-gate-short" }],
+    },
+    github_actions: {
+      always: [{ workflow: "build images", path: ".github/workflows/build-images.yaml" }],
+      security_changed: [{ workflow: "security", path: ".github/workflows/security.yml" }],
+    },
+  };
+}
+
+function githubRun(overrides: Partial<GithubWorkflowRun> = {}): GithubWorkflowRun {
+  return {
+    id: 1,
+    name: "build images",
+    path: ".github/workflows/build-images.yaml",
+    event: "push",
+    status: "completed",
+    conclusion: "success",
+    head_sha: "abc",
+    head_branch: "develop",
+    run_attempt: 1,
+    created_at: "2026-01-01T00:01:00Z",
+    updated_at: "2026-01-01T00:02:00Z",
+    html_url: "https://github.example/run/1",
+    ...overrides,
+  };
+}
+
+class FakeCircleApi implements CircleApi {
+  pipeline: CirclePipeline = {
+    id: "pipeline",
+    trigger: { type: "webhook", received_at: "2026-01-01T00:00:00Z" },
+    vcs: { revision: "abc", branch: "develop" },
+  };
+  workflows: CircleWorkflow[] = [];
+  jobs = new Map<string, CircleJob[]>();
+
+  async getPipeline(): Promise<CirclePipeline> {
+    return this.pipeline;
+  }
+  async listPipelineWorkflows(): Promise<CircleWorkflow[]> {
+    return this.workflows;
+  }
+  async listWorkflowJobs(id: string): Promise<CircleJob[]> {
+    return this.jobs.get(id) ?? [];
+  }
+}
+
+class FakeGithubApi implements GithubApi {
+  runs: GithubWorkflowRun[] = [];
+  async listWorkflowRuns(): Promise<GithubWorkflowRun[]> {
+    return this.runs;
+  }
+}
+
+function snapshot(results: Array<"pending" | "success" | "failure">): GateSnapshot {
+  const members = results.map((result, index) => ({
+    provider: "CircleCI" as const,
+    name: `workflow-${index}`,
+    result,
+    status: result,
+  }));
+  return {
+    members,
+    allTerminal: members.every((member) => member.result !== "pending"),
+    allSuccessful: members.every((member) => member.result === "success"),
+  };
+}
+
+describe("policy", () => {
+  test("builds exact conditional expected sets", () => {
+    const policy = fixturePolicy();
+    expect(buildExpectedWorkflows(policy, { rustChanged: true, securityChanged: false })).toEqual({
+      circleci: [
+        { name: "main", requiredJobs: ["go-tests-full"] },
+        { name: "rust-ci", requiredJobs: [] },
+      ],
+      github: [{ name: "build images", path: ".github/workflows/build-images.yaml" }],
+    });
+    expect(buildExpectedWorkflows(policy, { rustChanged: false, securityChanged: true })).toEqual({
+      circleci: [
+        { name: "main", requiredJobs: ["go-tests-full"] },
+        { name: "rust-ci-gate-short", requiredJobs: [] },
+      ],
+      github: [
+        { name: "build images", path: ".github/workflows/build-images.yaml" },
+        { name: "security", path: ".github/workflows/security.yml" },
+      ],
+    });
+  });
+
+  test("requires every CircleCI route to be gated or explicitly excluded", () => {
+    const policy = fixturePolicy();
+    policy.circleci.always.push({ route: "unclassified" });
+    expect(() => validatePolicy(policy)).toThrow("exactly one of workflow or excluded");
+  });
+
+  test("parses CircleCI-rendered booleans strictly", () => {
+    expect(parseBoolean("true", "x")).toBe(true);
+    expect(parseBoolean("1", "x")).toBe(true);
+    expect(parseBoolean("false", "x")).toBe(false);
+    expect(parseBoolean("0", "x")).toBe(false);
+    expect(() => parseBoolean(undefined, "x")).toThrow("x must be one of");
+  });
+});
+
+describe("rerun and trigger selection", () => {
+  test("selects the newest CircleCI workflow rerun", () => {
+    const selected = selectLatestCircleWorkflow(
+      [
+        { id: "old", name: "main", status: "failed", created_at: "2026-01-01T00:00:00Z" },
+        { id: "other", name: "rust-ci", status: "success", created_at: "2026-01-01T00:02:00Z" },
+        { id: "new", name: "main", status: "success", created_at: "2026-01-01T00:03:00Z" },
+      ],
+      "main",
+    );
+    expect(selected?.id).toBe("new");
+  });
+
+  test("selects only the newest exact-SHA develop push run", () => {
+    const expected = { name: "build images", path: ".github/workflows/build-images.yaml" };
+    const selected = selectLatestGithubRun(
+      [
+        githubRun({ id: 2, event: "schedule", run_attempt: 9 }),
+        githubRun({ id: 3, head_sha: "wrong", run_attempt: 9 }),
+        githubRun({ id: 4, head_branch: "feature", run_attempt: 9 }),
+        githubRun({ id: 5, created_at: "2025-12-31T23:00:00Z", run_attempt: 9 }),
+        githubRun({ id: 6, run_attempt: 1 }),
+        githubRun({ id: 7, run_attempt: 2, updated_at: "2026-01-01T00:03:00Z" }),
+      ],
+      expected,
+      { sha: "abc", branch: "develop", notBeforeMs: Date.parse("2026-01-01T00:00:00Z") },
+    );
+    expect(selected?.id).toBe(7);
+  });
+});
+
+describe("gate inspection", () => {
+  const expected: ExpectedWorkflows = {
+    circleci: [
+      { name: "main", requiredJobs: ["go-tests-full"] },
+      { name: "rust-ci-gate-short", requiredJobs: [] },
+    ],
+    github: [{ name: "build images", path: ".github/workflows/build-images.yaml" }],
+  };
+
+  test("accepts only successful workflows and the required full Go test job", async () => {
+    const circle = new FakeCircleApi();
+    circle.workflows = [
+      { id: "main", name: "main", status: "success", stopped_at: "2026-01-01T00:05:00Z" },
+      { id: "rust", name: "rust-ci-gate-short", status: "success", stopped_at: "2026-01-01T00:01:00Z" },
+    ];
+    circle.jobs.set("main", [{ name: "go-tests-full", status: "success" }]);
+    const github = new FakeGithubApi();
+    github.runs = [githubRun()];
+
+    const result = await new GateInspector(circle, github, expected, {
+      pipelineId: "pipeline",
+      sha: "abc",
+      branch: "develop",
+      githubNotBeforeMs: Date.parse("2026-01-01T00:00:00Z"),
+    }).inspect();
+
+    expect(result.allTerminal).toBe(true);
+    expect(result.allSuccessful).toBe(true);
+    expect(result.members.find((member) => member.name === "main")?.details).toBe("go-tests-full=success");
+  });
+
+  test("fails a successful main workflow when go-tests-full never appeared", async () => {
+    const circle = new FakeCircleApi();
+    circle.workflows = [
+      { id: "main", name: "main", status: "success", stopped_at: "2026-01-01T00:05:00Z" },
+      { id: "rust", name: "rust-ci-gate-short", status: "success", stopped_at: "2026-01-01T00:01:00Z" },
+    ];
+    const github = new FakeGithubApi();
+    github.runs = [githubRun()];
+
+    const result = await new GateInspector(circle, github, expected, {
+      pipelineId: "pipeline",
+      sha: "abc",
+      branch: "develop",
+      githubNotBeforeMs: 0,
+    }).inspect();
+
+    expect(result.allTerminal).toBe(true);
+    expect(result.allSuccessful).toBe(false);
+    expect(result.members.find((member) => member.name === "main")).toMatchObject({
+      result: "failure",
+      details: "go-tests-full=missing",
+    });
+  });
+
+  test("keeps missing, running, and failing-but-not-stopped workflows pending", async () => {
+    const circle = new FakeCircleApi();
+    circle.workflows = [{ id: "main", name: "main", status: "failing", stopped_at: null }];
+    const github = new FakeGithubApi();
+
+    const result = await new GateInspector(circle, github, expected, {
+      pipelineId: "pipeline",
+      sha: "abc",
+      branch: "develop",
+      githubNotBeforeMs: 0,
+    }).inspect();
+
+    expect(result.allTerminal).toBe(false);
+    expect(result.members.map((member) => member.result)).toEqual(["pending", "pending", "pending"]);
+  });
+
+  test("treats canceled provider results as terminal failures", async () => {
+    const circle = new FakeCircleApi();
+    circle.workflows = [
+      { id: "main", name: "main", status: "canceled", stopped_at: "2026-01-01T00:05:00Z" },
+      { id: "rust", name: "rust-ci-gate-short", status: "success", stopped_at: "2026-01-01T00:01:00Z" },
+    ];
+    const github = new FakeGithubApi();
+    github.runs = [githubRun({ conclusion: "cancelled" })];
+
+    const result = await new GateInspector(circle, github, expected, {
+      pipelineId: "pipeline",
+      sha: "abc",
+      branch: "develop",
+      githubNotBeforeMs: 0,
+    }).inspect();
+
+    expect(result.allTerminal).toBe(true);
+    expect(result.allSuccessful).toBe(false);
+    expect(result.members.filter((member) => member.result === "failure")).toHaveLength(2);
+  });
+});
+
+describe("bounded waiting", () => {
+  test("waits for delayed workflows", async () => {
+    let now = 0;
+    let calls = 0;
+    const result = await waitForGate({
+      inspect: async () => (++calls === 1 ? snapshot(["pending"]) : snapshot(["success"])),
+      timeoutMs: 100,
+      pollIntervalMs: 10,
+      now: () => now,
+      sleep: async (milliseconds) => {
+        now += milliseconds;
+      },
+      report: () => {},
+    });
+    expect(calls).toBe(2);
+    expect(result.allSuccessful).toBe(true);
+  });
+
+  test("does not fail early while another expected workflow is pending", async () => {
+    let now = 0;
+    let calls = 0;
+    await expect(
+      waitForGate({
+        inspect: async () => (++calls === 1 ? snapshot(["failure", "pending"]) : snapshot(["failure", "success"])),
+        timeoutMs: 100,
+        pollIntervalMs: 10,
+        now: () => now,
+        sleep: async (milliseconds) => {
+          now += milliseconds;
+        },
+        report: () => {},
+      }),
+    ).rejects.toThrow("post-merge validation failed");
+    expect(calls).toBe(2);
+  });
+
+  test("fails closed when an expected workflow never appears", async () => {
+    let now = 0;
+    await expect(
+      waitForGate({
+        inspect: async () => snapshot(["pending"]),
+        timeoutMs: 25,
+        pollIntervalMs: 10,
+        now: () => now,
+        sleep: async (milliseconds) => {
+          now += milliseconds;
+        },
+        report: () => {},
+      }),
+    ).rejects.toThrow("post-merge gate timed out");
+  });
+
+  test("fails closed immediately when an API inspection exhausts retries", async () => {
+    await expect(
+      waitForGate({
+        inspect: async () => {
+          throw new Error("API request failed after 4 attempts");
+        },
+        timeoutMs: 100,
+        pollIntervalMs: 10,
+        report: () => {},
+      }),
+    ).rejects.toThrow("API request failed after 4 attempts");
+  });
+});
+
+describe("pipeline correlation", () => {
+  test("requires the exact webhook develop pipeline and SHA", () => {
+    const pipeline: CirclePipeline = {
+      id: "pipeline",
+      trigger: { type: "webhook", received_at: "2026-01-01T00:00:00Z" },
+      vcs: { revision: "abc", branch: "develop" },
+    };
+    expect(() => validatePipeline(pipeline, { id: "pipeline", sha: "abc", branch: "develop" })).not.toThrow();
+    expect(() =>
+      validatePipeline(
+        { ...pipeline, trigger: { type: "scheduled_pipeline" } },
+        { id: "pipeline", sha: "abc", branch: "develop" },
+      ),
+    ).toThrow("must be webhook");
+    expect(() => validatePipeline(pipeline, { id: "pipeline", sha: "wrong", branch: "develop" })).toThrow("SHA mismatch");
+  });
+});
+
+describe("repository policy drift guards", () => {
+  test("develop change detection uses the pushed commit instead of an empty origin/develop diff", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "post-merge-changes-"));
+    tempDirs.push(dir);
+    const git = (...args: string[]) => {
+      const result = Bun.spawnSync(["git", ...args], { cwd: dir });
+      if (!result.success) throw new Error(new TextDecoder().decode(result.stderr));
+    };
+    git("init", "-q");
+    git("config", "user.email", "ci@example.com");
+    git("config", "user.name", "CI Test");
+    mkdirSync(path.join(dir, ".circleci"));
+    writeFileSync(path.join(dir, ".circleci/config.yml"), "version: old\n");
+    git("add", ".circleci/config.yml");
+    git("commit", "-qm", "base");
+    writeFileSync(path.join(dir, ".circleci/config.yml"), "version: new\n");
+    git("add", ".circleci/config.yml");
+    git("commit", "-qm", "change");
+    // Reproduce CircleCI checkout: origin/develop already points at HEAD.
+    git("update-ref", "refs/remotes/origin/develop", "HEAD");
+
+    const output = path.join(dir, "params.json");
+    writeFileSync(output, "{}");
+    const result = Bun.spawnSync(["bash", path.join(repoRoot, ".circleci/scripts/collect-params.sh"), "detect"], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        OUTPUT: output,
+        BASE_REVISION: "develop",
+        CURRENT_BRANCH: "develop",
+        TRIGGER_SOURCE: "webhook",
+      },
+    });
+    expect(new TextDecoder().decode(result.stderr)).toBe("");
+    expect(result.exitCode).toBe(0);
+    const params = JSON.parse(readFileSync(output, "utf8")) as Record<string, boolean>;
+    expect(params["c-rust_changes_detected"]).toBe(true);
+    expect(params["c-security_changed"]).toBe(true);
+  });
+
+  test("the develop router enables exactly the policy routes for both Rust variants", () => {
+    const policy = loadPolicy(routingPath);
+    for (const rustChanged of [true, false]) {
+      const dir = mkdtempSync(path.join(tmpdir(), "post-merge-routing-"));
+      tempDirs.push(dir);
+      const output = path.join(dir, "params.json");
+      writeFileSync(
+        output,
+        JSON.stringify({
+          "c-rust_changes_detected": rustChanged,
+          "c-security_changed": false,
+        }),
+      );
+      const result = Bun.spawnSync(["bash", ".circleci/scripts/compute-workflow-conditions.sh"], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          OUTPUT: output,
+          TRIGGER_SOURCE: "webhook",
+          BRANCH: "develop",
+          TAG: "",
+          SCHEDULE_NAME: "",
+        },
+      });
+      expect(new TextDecoder().decode(result.stderr)).toBe("");
+      expect(result.exitCode).toBe(0);
+      const routed = Object.entries(JSON.parse(readFileSync(output, "utf8")) as Record<string, unknown>)
+        .filter(([key, value]) => key.startsWith("c-run_") && value === true)
+        .map(([key]) => key.slice("c-run_".length))
+        .sort();
+      const expectedRoutes = [
+        ...policy.circleci.always,
+        ...(rustChanged ? policy.circleci.rust_changed : policy.circleci.rust_unchanged),
+      ]
+        .map((entry) => entry.route)
+        .sort();
+      expect(routed).toEqual(expectedRoutes);
+    }
+  });
+
+  test("every post-merge CircleCI route exists and points at its classified workflow", () => {
+    const policy = loadPolicy(routingPath);
+    const files = readdirSync(continuationDir)
+      .filter((file) => file.endsWith(".yml"))
+      .map((file) => path.join(continuationDir, file));
+    const parameters = new Set<string>();
+    const workflows = new Map<string, Record<string, unknown>>();
+    for (const file of files) {
+      const config = yamlJson<{ parameters?: Record<string, unknown>; workflows?: Record<string, Record<string, unknown>> }>(file);
+      for (const parameter of Object.keys(config.parameters ?? {})) parameters.add(parameter);
+      for (const [name, workflow] of Object.entries(config.workflows ?? {})) workflows.set(name, workflow);
+    }
+
+    const entries = [
+      ...policy.circleci.always,
+      ...policy.circleci.rust_changed,
+      ...policy.circleci.rust_unchanged,
+    ];
+    for (const entry of entries) {
+      const parameter = `c-run_${entry.route}`;
+      expect(parameters.has(parameter)).toBe(true);
+      if (entry.workflow) {
+        const workflow = workflows.get(entry.workflow);
+        expect(workflow).toBeDefined();
+        expect(workflow?.when).toBe(`<< pipeline.parameters.${parameter} >>`);
+        const jobs = (workflow?.jobs ?? []) as Array<string | Record<string, Record<string, unknown> | null>>;
+        const effectiveJobNames = jobs.map((job) => {
+          if (typeof job === "string") return job;
+          const [jobType, config] = Object.entries(job)[0];
+          return (config && typeof config.name === "string" ? config.name : jobType) as string;
+        });
+        for (const requiredJob of entry.required_jobs ?? []) expect(effectiveJobNames).toContain(requiredJob);
+      }
+    }
+  });
+
+  test("continuation workflows cannot bypass the classified c-run router on develop", () => {
+    const files = readdirSync(continuationDir)
+      .filter((file) => file.endsWith(".yml"))
+      .map((file) => path.join(continuationDir, file));
+    const parameters = new Map<string, { type?: string; default?: unknown }>();
+    const workflows = new Map<string, Record<string, unknown>>();
+    for (const file of files) {
+      const config = yamlJson<{
+        parameters?: Record<string, { type?: string; default?: unknown }>;
+        workflows?: Record<string, Record<string, unknown>>;
+      }>(file);
+      for (const [name, parameter] of Object.entries(config.parameters ?? {})) parameters.set(name, parameter);
+      for (const [name, workflow] of Object.entries(config.workflows ?? {})) workflows.set(name, workflow);
+    }
+
+    for (const [name, parameter] of parameters) {
+      if (!name.startsWith("c-run_")) continue;
+      expect(parameter.type).toBe("boolean");
+      expect(parameter.default).toBe(false);
+    }
+
+    const bypasses: string[] = [];
+    for (const [name, workflow] of workflows) {
+      if (workflow.when !== undefined && workflow.when !== null) {
+        if (typeof workflow.when !== "string") {
+          bypasses.push(`${name}: non-parameter when condition`);
+          continue;
+        }
+        const match = workflow.when.match(/^<< pipeline\.parameters\.(c-run_[A-Za-z0-9_]+) >>$/);
+        if (!match || !parameters.has(match[1])) bypasses.push(`${name}: unclassified when condition`);
+        continue;
+      }
+
+      const jobs = (workflow.jobs ?? []) as Array<string | Record<string, Record<string, unknown> | null>>;
+      if (jobs.some((job) => circleJobAllowsBranch(job, "develop"))) {
+        bypasses.push(`${name}: unguarded job allows develop`);
+      }
+    }
+    expect(bypasses).toEqual([]);
+  });
+
+  test("every repository GHA workflow that pushes on develop is classified", () => {
+    const policy = loadPolicy(routingPath);
+    const classified = new Map(
+      [...policy.github_actions.always, ...policy.github_actions.security_changed].map((entry) => [entry.path, entry.workflow]),
+    );
+    const developPushWorkflows = new Map<string, string>();
+
+    for (const filename of readdirSync(workflowsDir).filter((file) => file.endsWith(".yml") || file.endsWith(".yaml"))) {
+      const fullPath = path.join(workflowsDir, filename);
+      const config = yamlJson<{
+        name?: string;
+        on?: string | string[] | Record<string, unknown>;
+      }>(fullPath);
+      const events = config.on;
+      if (!events) continue;
+      let runsOnDevelop = false;
+      if (events === "push" || (Array.isArray(events) && events.includes("push"))) {
+        runsOnDevelop = true;
+      } else if (!Array.isArray(events) && typeof events === "object" && Object.hasOwn(events, "push")) {
+        const push = events.push as null | { branches?: string | string[]; tags?: string | string[] };
+        if (push === null) {
+          runsOnDevelop = true;
+        } else {
+          const branches =
+            push.branches === undefined ? [] : Array.isArray(push.branches) ? push.branches : [push.branches];
+          if (branches.length > 0) {
+            runsOnDevelop = branches.some((pattern) => new Bun.Glob(pattern).match("develop"));
+          } else {
+            // Defining only tag filters disables branch pushes; otherwise an
+            // omitted branches filter means all branches.
+            runsOnDevelop = push.tags === undefined;
+          }
+        }
+      }
+      if (!runsOnDevelop) continue;
+      const relative = path.relative(repoRoot, fullPath);
+      developPushWorkflows.set(relative, config.name ?? "");
+    }
+
+    expect([...developPushWorkflows.keys()].sort()).toEqual([...classified.keys()].sort());
+    for (const [workflowPath, name] of developPushWorkflows) expect(classified.get(workflowPath)).toBe(name);
+
+    const routing = yamlJson<{ change_patterns: { any: { security_changed: string } } }>(routingPath);
+    const security = yamlJson<{ on: { push: { paths: string[] } } }>(path.join(repoRoot, ".github/workflows/security.yml"));
+    const securityPattern = new RegExp(routing.change_patterns.any.security_changed);
+    for (const filteredPath of security.on.push.paths) expect(securityPattern.test(filteredPath)).toBe(true);
+  });
+});

--- a/.circleci/scripts/post-merge-gate.ts
+++ b/.circleci/scripts/post-merge-gate.ts
@@ -1,0 +1,660 @@
+#!/usr/bin/env bun
+
+/**
+ * Authoritative post-merge gate for webhook pushes to develop.
+ *
+ * CircleCI supplies the check identity: this script runs as the only job in the
+ * `post-merge-gate` workflow, so the CircleCI GitHub App publishes the stable
+ * `circleci-checks / post-merge-gate` check. The script polls the exact current
+ * CircleCI pipeline plus exact-SHA GitHub Actions push runs and fails closed.
+ */
+
+const DEFAULT_CIRCLECI_API_BASE = "https://circleci.com/api/v2";
+const DEFAULT_GITHUB_API_BASE = "https://api.github.com";
+const DEFAULT_TIMEOUT_SECONDS = 4 * 60 * 60;
+const DEFAULT_POLL_INTERVAL_SECONDS = 60;
+const MAX_API_PAGES = 20;
+const MAX_API_ATTEMPTS = 4;
+
+export interface CirclePolicyEntry {
+  route: string;
+  workflow?: string;
+  required_jobs?: string[];
+  excluded?: string;
+}
+
+export interface GithubPolicyEntry {
+  workflow: string;
+  path: string;
+}
+
+export interface PostMergePolicy {
+  circleci: {
+    always: CirclePolicyEntry[];
+    rust_changed: CirclePolicyEntry[];
+    rust_unchanged: CirclePolicyEntry[];
+  };
+  github_actions: {
+    always: GithubPolicyEntry[];
+    security_changed: GithubPolicyEntry[];
+  };
+}
+
+export interface ExpectedCircleWorkflow {
+  name: string;
+  requiredJobs: string[];
+}
+
+export interface ExpectedGithubWorkflow {
+  name: string;
+  path: string;
+}
+
+export interface ExpectedWorkflows {
+  circleci: ExpectedCircleWorkflow[];
+  github: ExpectedGithubWorkflow[];
+}
+
+export interface CirclePipeline {
+  id: string;
+  trigger?: {
+    type?: string;
+    received_at?: string;
+  };
+  vcs?: {
+    revision?: string;
+    branch?: string;
+  };
+}
+
+export interface CircleWorkflow {
+  id: string;
+  name: string;
+  status: string;
+  created_at?: string;
+  stopped_at?: string | null;
+}
+
+export interface CircleJob {
+  id?: string;
+  name: string;
+  status: string;
+  started_at?: string;
+  stopped_at?: string | null;
+}
+
+export interface GithubWorkflowRun {
+  id: number;
+  name: string;
+  path: string;
+  event: string;
+  status: string;
+  conclusion?: string | null;
+  head_sha: string;
+  head_branch?: string | null;
+  run_attempt?: number;
+  created_at?: string;
+  updated_at?: string;
+  html_url?: string;
+}
+
+export type MemberResult = "pending" | "success" | "failure";
+
+export interface MemberState {
+  provider: "CircleCI" | "GitHub Actions";
+  name: string;
+  result: MemberResult;
+  status: string;
+  details?: string;
+  url?: string;
+}
+
+export interface GateSnapshot {
+  members: MemberState[];
+  allTerminal: boolean;
+  allSuccessful: boolean;
+}
+
+export interface CircleApi {
+  getPipeline(id: string): Promise<CirclePipeline>;
+  listPipelineWorkflows(id: string): Promise<CircleWorkflow[]>;
+  listWorkflowJobs(id: string): Promise<CircleJob[]>;
+}
+
+export interface GithubApi {
+  listWorkflowRuns(sha: string): Promise<GithubWorkflowRun[]>;
+}
+
+export function parseBoolean(value: string | undefined, name: string): boolean {
+  if (value === "true" || value === "1") return true;
+  if (value === "false" || value === "0") return false;
+  throw new Error(`${name} must be one of true, false, 1, or 0; got ${JSON.stringify(value)}`);
+}
+
+function requireNonEmptyString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`post-merge policy field ${field} must be a non-empty string`);
+  }
+}
+
+export function validatePolicy(policy: PostMergePolicy): void {
+  const variants = ["always", "rust_changed", "rust_unchanged"] as const;
+  const routes = new Set<string>();
+  const workflows = new Set<string>();
+
+  for (const variant of variants) {
+    const entries = policy?.circleci?.[variant];
+    if (!Array.isArray(entries)) {
+      throw new Error(`post-merge policy circleci.${variant} must be an array`);
+    }
+    for (const [index, entry] of entries.entries()) {
+      const prefix = `circleci.${variant}[${index}]`;
+      requireNonEmptyString(entry.route, `${prefix}.route`);
+      if (routes.has(entry.route)) {
+        throw new Error(`duplicate post-merge CircleCI route: ${entry.route}`);
+      }
+      routes.add(entry.route);
+
+      const isGated = entry.workflow !== undefined;
+      const isExcluded = entry.excluded !== undefined;
+      if (isGated === isExcluded) {
+        throw new Error(`${prefix} must have exactly one of workflow or excluded`);
+      }
+      if (isGated) {
+        requireNonEmptyString(entry.workflow, `${prefix}.workflow`);
+        if (workflows.has(entry.workflow)) {
+          throw new Error(`duplicate gated CircleCI workflow: ${entry.workflow}`);
+        }
+        workflows.add(entry.workflow);
+        if (entry.required_jobs !== undefined) {
+          if (!Array.isArray(entry.required_jobs) || entry.required_jobs.length === 0) {
+            throw new Error(`${prefix}.required_jobs must be a non-empty array when set`);
+          }
+          for (const [jobIndex, job] of entry.required_jobs.entries()) {
+            requireNonEmptyString(job, `${prefix}.required_jobs[${jobIndex}]`);
+          }
+        }
+      } else {
+        requireNonEmptyString(entry.excluded, `${prefix}.excluded`);
+        if (entry.required_jobs !== undefined) {
+          throw new Error(`${prefix} cannot set required_jobs on an excluded route`);
+        }
+      }
+    }
+  }
+
+  const githubPaths = new Set<string>();
+  for (const variant of ["always", "security_changed"] as const) {
+    const entries = policy?.github_actions?.[variant];
+    if (!Array.isArray(entries)) {
+      throw new Error(`post-merge policy github_actions.${variant} must be an array`);
+    }
+    for (const [index, entry] of entries.entries()) {
+      const prefix = `github_actions.${variant}[${index}]`;
+      requireNonEmptyString(entry.workflow, `${prefix}.workflow`);
+      requireNonEmptyString(entry.path, `${prefix}.path`);
+      if (githubPaths.has(entry.path)) {
+        throw new Error(`duplicate gated GitHub Actions workflow path: ${entry.path}`);
+      }
+      githubPaths.add(entry.path);
+    }
+  }
+}
+
+export function loadPolicy(path: string): PostMergePolicy {
+  const result = Bun.spawnSync(["yq", "-o=json", ".post_merge_gate", path]);
+  if (!result.success) {
+    const stderr = new TextDecoder().decode(result.stderr).trim();
+    throw new Error(`failed to read post-merge policy from ${path}: ${stderr || `exit ${result.exitCode}`}`);
+  }
+  const output = new TextDecoder().decode(result.stdout);
+  const policy = JSON.parse(output) as PostMergePolicy;
+  validatePolicy(policy);
+  return policy;
+}
+
+export function buildExpectedWorkflows(
+  policy: PostMergePolicy,
+  options: { rustChanged: boolean; securityChanged: boolean },
+): ExpectedWorkflows {
+  validatePolicy(policy);
+  const circleEntries = [
+    ...policy.circleci.always,
+    ...(options.rustChanged ? policy.circleci.rust_changed : policy.circleci.rust_unchanged),
+  ];
+  const githubEntries = [
+    ...policy.github_actions.always,
+    ...(options.securityChanged ? policy.github_actions.security_changed : []),
+  ];
+
+  return {
+    circleci: circleEntries
+      .filter((entry): entry is CirclePolicyEntry & { workflow: string } => entry.workflow !== undefined)
+      .map((entry) => ({ name: entry.workflow, requiredJobs: entry.required_jobs ?? [] })),
+    github: githubEntries.map((entry) => ({ name: entry.workflow, path: entry.path })),
+  };
+}
+
+function timestamp(value: string | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export function selectLatestCircleWorkflow(
+  workflows: CircleWorkflow[],
+  name: string,
+): CircleWorkflow | undefined {
+  return workflows
+    .filter((workflow) => workflow.name === name)
+    .sort((left, right) => timestamp(right.created_at) - timestamp(left.created_at) || right.id.localeCompare(left.id))[0];
+}
+
+export function selectLatestGithubRun(
+  runs: GithubWorkflowRun[],
+  expected: ExpectedGithubWorkflow,
+  options: { sha: string; branch: string; notBeforeMs: number },
+): GithubWorkflowRun | undefined {
+  return runs
+    .filter(
+      (run) =>
+        run.name === expected.name &&
+        run.path === expected.path &&
+        run.event === "push" &&
+        run.head_sha === options.sha &&
+        run.head_branch === options.branch &&
+        timestamp(run.created_at) >= options.notBeforeMs,
+    )
+    .sort(
+      (left, right) =>
+        (right.run_attempt ?? 0) - (left.run_attempt ?? 0) ||
+        timestamp(right.updated_at ?? right.created_at) - timestamp(left.updated_at ?? left.created_at) ||
+        right.id - left.id,
+    )[0];
+}
+
+const CIRCLE_TERMINAL_STATUSES = new Set([
+  "success",
+  "failed",
+  "canceled",
+  "error",
+  "unauthorized",
+  "not_run",
+]);
+
+function circleWorkflowIsTerminal(workflow: CircleWorkflow): boolean {
+  return workflow.stopped_at != null || CIRCLE_TERMINAL_STATUSES.has(workflow.status);
+}
+
+function circleWorkflowUrl(id: string): string {
+  return `https://app.circleci.com/workflow/${id}`;
+}
+
+export class GateInspector {
+  constructor(
+    private readonly circle: CircleApi,
+    private readonly github: GithubApi,
+    private readonly expected: ExpectedWorkflows,
+    private readonly options: {
+      pipelineId: string;
+      sha: string;
+      branch: string;
+      githubNotBeforeMs: number;
+    },
+  ) {}
+
+  async inspect(): Promise<GateSnapshot> {
+    const [circleWorkflows, githubRuns] = await Promise.all([
+      this.circle.listPipelineWorkflows(this.options.pipelineId),
+      this.github.listWorkflowRuns(this.options.sha),
+    ]);
+
+    const circleStates = await Promise.all(
+      this.expected.circleci.map(async (expected): Promise<MemberState> => {
+        const workflow = selectLatestCircleWorkflow(circleWorkflows, expected.name);
+        if (!workflow) {
+          return {
+            provider: "CircleCI",
+            name: expected.name,
+            result: "pending",
+            status: "missing",
+          };
+        }
+
+        const url = circleWorkflowUrl(workflow.id);
+        if (!circleWorkflowIsTerminal(workflow)) {
+          return {
+            provider: "CircleCI",
+            name: expected.name,
+            result: "pending",
+            status: workflow.status,
+            url,
+          };
+        }
+        if (workflow.status !== "success") {
+          return {
+            provider: "CircleCI",
+            name: expected.name,
+            result: "failure",
+            status: workflow.status,
+            url,
+          };
+        }
+
+        if (expected.requiredJobs.length === 0) {
+          return {
+            provider: "CircleCI",
+            name: expected.name,
+            result: "success",
+            status: workflow.status,
+            url,
+          };
+        }
+
+        const jobs = await this.circle.listWorkflowJobs(workflow.id);
+        const jobDetails: string[] = [];
+        let jobsSuccessful = true;
+        for (const requiredJob of expected.requiredJobs) {
+          const candidates = jobs
+            .filter((job) => job.name === requiredJob)
+            .sort(
+              (left, right) =>
+                timestamp(right.started_at) - timestamp(left.started_at) ||
+                (right.id ?? "").localeCompare(left.id ?? ""),
+            );
+          const job = candidates[0];
+          const status = job?.status ?? "missing";
+          jobDetails.push(`${requiredJob}=${status}`);
+          if (status !== "success") jobsSuccessful = false;
+        }
+
+        return {
+          provider: "CircleCI",
+          name: expected.name,
+          result: jobsSuccessful ? "success" : "failure",
+          status: workflow.status,
+          details: jobDetails.join(", "),
+          url,
+        };
+      }),
+    );
+
+    const githubStates = this.expected.github.map((expected): MemberState => {
+      const run = selectLatestGithubRun(githubRuns, expected, {
+        sha: this.options.sha,
+        branch: this.options.branch,
+        notBeforeMs: this.options.githubNotBeforeMs,
+      });
+      if (!run) {
+        return {
+          provider: "GitHub Actions",
+          name: expected.name,
+          result: "pending",
+          status: "missing",
+          details: expected.path,
+        };
+      }
+      if (run.status !== "completed") {
+        return {
+          provider: "GitHub Actions",
+          name: expected.name,
+          result: "pending",
+          status: run.status,
+          details: `${expected.path}, attempt ${run.run_attempt ?? 1}`,
+          url: run.html_url,
+        };
+      }
+      const successful = run.conclusion === "success";
+      return {
+        provider: "GitHub Actions",
+        name: expected.name,
+        result: successful ? "success" : "failure",
+        status: `${run.status}/${run.conclusion ?? "no conclusion"}`,
+        details: `${expected.path}, attempt ${run.run_attempt ?? 1}`,
+        url: run.html_url,
+      };
+    });
+
+    const members = [...circleStates, ...githubStates];
+    return {
+      members,
+      allTerminal: members.every((member) => member.result !== "pending"),
+      allSuccessful: members.every((member) => member.result === "success"),
+    };
+  }
+}
+
+export function formatSnapshot(snapshot: GateSnapshot): string {
+  const lines = [`[${new Date().toISOString()}] Post-merge gate status:`];
+  for (const member of snapshot.members) {
+    const details = member.details ? ` (${member.details})` : "";
+    const url = member.url ? ` ${member.url}` : "";
+    lines.push(`  [${member.result}] ${member.provider} / ${member.name}: ${member.status}${details}${url}`);
+  }
+  return lines.join("\n");
+}
+
+export async function waitForGate(options: {
+  inspect: () => Promise<GateSnapshot>;
+  timeoutMs: number;
+  pollIntervalMs: number;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+  report?: (snapshot: GateSnapshot) => void;
+}): Promise<GateSnapshot> {
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? ((milliseconds: number) => Bun.sleep(milliseconds));
+  const report = options.report ?? ((snapshot: GateSnapshot) => console.log(formatSnapshot(snapshot)));
+  const deadline = now() + options.timeoutMs;
+  let latest: GateSnapshot | undefined;
+
+  while (true) {
+    latest = await options.inspect();
+    report(latest);
+    if (latest.allTerminal) {
+      if (latest.allSuccessful) return latest;
+      const failures = latest.members
+        .filter((member) => member.result === "failure")
+        .map((member) => `${member.provider} / ${member.name}: ${member.status}`)
+        .join("; ");
+      throw new Error(`post-merge validation failed: ${failures}`);
+    }
+
+    const remaining = deadline - now();
+    if (remaining <= 0) {
+      const nonSuccessful = latest.members
+        .filter((member) => member.result !== "success")
+        .map((member) => `${member.provider} / ${member.name}: ${member.status}`)
+        .join("; ");
+      throw new Error(`post-merge gate timed out: ${nonSuccessful}`);
+    }
+    await sleep(Math.min(options.pollIntervalMs, remaining));
+  }
+}
+
+async function fetchJsonWithRetry<T>(
+  url: string,
+  headers: Record<string, string>,
+  sleep: (milliseconds: number) => Promise<void> = (milliseconds) => Bun.sleep(milliseconds),
+): Promise<T> {
+  let lastError: Error | undefined;
+  for (let attempt = 1; attempt <= MAX_API_ATTEMPTS; attempt++) {
+    const response = await fetch(url, { headers }).then(
+      (result) => result,
+      (error) => {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        return undefined;
+      },
+    );
+    if (response?.ok) return (await response.json()) as T;
+    if (response) {
+      const body = (await response.text()).slice(0, 500);
+      lastError = new Error(`HTTP ${response.status} from ${url}: ${body}`);
+    }
+    if (attempt < MAX_API_ATTEMPTS) await sleep(1000 * 2 ** (attempt - 1));
+  }
+  throw new Error(`API request failed after ${MAX_API_ATTEMPTS} attempts: ${lastError?.message ?? url}`);
+}
+
+export class CircleHttpApi implements CircleApi {
+  private readonly headers: Record<string, string>;
+
+  constructor(
+    token: string,
+    private readonly apiBase = DEFAULT_CIRCLECI_API_BASE,
+  ) {
+    this.headers = { "Circle-Token": token, Accept: "application/json" };
+  }
+
+  getPipeline(id: string): Promise<CirclePipeline> {
+    return fetchJsonWithRetry(`${this.apiBase}/pipeline/${encodeURIComponent(id)}`, this.headers);
+  }
+
+  listPipelineWorkflows(id: string): Promise<CircleWorkflow[]> {
+    return this.listCirclePages<CircleWorkflow>(`${this.apiBase}/pipeline/${encodeURIComponent(id)}/workflow`);
+  }
+
+  listWorkflowJobs(id: string): Promise<CircleJob[]> {
+    return this.listCirclePages<CircleJob>(`${this.apiBase}/workflow/${encodeURIComponent(id)}/job`);
+  }
+
+  private async listCirclePages<T>(baseUrl: string): Promise<T[]> {
+    const items: T[] = [];
+    let pageToken = "";
+    for (let page = 1; page <= MAX_API_PAGES; page++) {
+      const url = new URL(baseUrl);
+      if (pageToken) url.searchParams.set("page-token", pageToken);
+      const response = await fetchJsonWithRetry<{ items?: T[]; next_page_token?: string | null }>(
+        url.toString(),
+        this.headers,
+      );
+      items.push(...(response.items ?? []));
+      pageToken = response.next_page_token ?? "";
+      if (!pageToken) return items;
+    }
+    throw new Error(`CircleCI API exceeded ${MAX_API_PAGES} pages for ${baseUrl}`);
+  }
+}
+
+export class GithubHttpApi implements GithubApi {
+  private readonly headers: Record<string, string>;
+
+  constructor(
+    token: string,
+    private readonly owner: string,
+    private readonly repo: string,
+    private readonly branch: string,
+    private readonly apiBase = DEFAULT_GITHUB_API_BASE,
+  ) {
+    this.headers = {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "optimism-post-merge-gate",
+    };
+  }
+
+  async listWorkflowRuns(sha: string): Promise<GithubWorkflowRun[]> {
+    const runs: GithubWorkflowRun[] = [];
+    for (let page = 1; page <= MAX_API_PAGES; page++) {
+      const url = new URL(`${this.apiBase}/repos/${encodeURIComponent(this.owner)}/${encodeURIComponent(this.repo)}/actions/runs`);
+      url.searchParams.set("head_sha", sha);
+      url.searchParams.set("branch", this.branch);
+      url.searchParams.set("event", "push");
+      url.searchParams.set("per_page", "100");
+      url.searchParams.set("page", String(page));
+      const response = await fetchJsonWithRetry<{ workflow_runs?: GithubWorkflowRun[] }>(url.toString(), this.headers);
+      const pageRuns = response.workflow_runs ?? [];
+      runs.push(...pageRuns);
+      if (pageRuns.length < 100) return runs;
+    }
+    throw new Error(`GitHub Actions API exceeded ${MAX_API_PAGES} pages for ${sha}`);
+  }
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function positiveNumberEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return defaultValue;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number; got ${JSON.stringify(raw)}`);
+  }
+  return parsed;
+}
+
+export function validatePipeline(pipeline: CirclePipeline, expected: { id: string; sha: string; branch: string }): void {
+  if (pipeline.id !== expected.id) {
+    throw new Error(`CircleCI pipeline ID mismatch: expected ${expected.id}, got ${pipeline.id}`);
+  }
+  if (pipeline.vcs?.revision !== expected.sha) {
+    throw new Error(`CircleCI pipeline SHA mismatch: expected ${expected.sha}, got ${pipeline.vcs?.revision ?? "missing"}`);
+  }
+  if (pipeline.vcs?.branch !== expected.branch) {
+    throw new Error(`CircleCI pipeline branch mismatch: expected ${expected.branch}, got ${pipeline.vcs?.branch ?? "missing"}`);
+  }
+  if (pipeline.trigger?.type !== "webhook") {
+    throw new Error(`CircleCI pipeline trigger must be webhook, got ${pipeline.trigger?.type ?? "missing"}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const pipelineId = requiredEnv("CIRCLE_PIPELINE_ID");
+  const sha = requiredEnv("CIRCLE_SHA1");
+  const branch = requiredEnv("CIRCLE_BRANCH");
+  if (branch !== "develop") throw new Error(`post-merge-gate only supports develop, got ${branch}`);
+
+  const circleToken = requiredEnv("CIRCLE_API_TOKEN");
+  const githubToken = process.env.GITHUB_ACCESS_TOKEN ?? process.env.GH_TOKEN;
+  if (!githubToken) throw new Error("GITHUB_ACCESS_TOKEN (or GH_TOKEN) is required");
+  const owner = requiredEnv("CIRCLE_PROJECT_USERNAME");
+  const repo = requiredEnv("CIRCLE_PROJECT_REPONAME");
+
+  const rustChanged = parseBoolean(process.env.POST_MERGE_RUST_CHANGED, "POST_MERGE_RUST_CHANGED");
+  const securityChanged = parseBoolean(process.env.POST_MERGE_SECURITY_CHANGED, "POST_MERGE_SECURITY_CHANGED");
+  const policyPath = process.env.POST_MERGE_GATE_POLICY ?? ".circleci/routing.yml";
+  const policy = loadPolicy(policyPath);
+  const expected = buildExpectedWorkflows(policy, { rustChanged, securityChanged });
+
+  const circle = new CircleHttpApi(circleToken, process.env.CIRCLECI_API_BASE);
+  const github = new GithubHttpApi(githubToken, owner, repo, branch, process.env.GITHUB_API_BASE);
+  const pipeline = await circle.getPipeline(pipelineId);
+  validatePipeline(pipeline, { id: pipelineId, sha, branch });
+
+  const receivedAt = timestamp(pipeline.trigger?.received_at);
+  if (receivedAt === 0) throw new Error("CircleCI webhook pipeline is missing trigger.received_at");
+  // Allow for webhook delivery skew while excluding older push runs if the same
+  // commit is pushed to develop more than once.
+  const githubNotBeforeMs = receivedAt - 5 * 60 * 1000;
+
+  console.log(`Post-merge gate for ${owner}/${repo}@${sha}`);
+  console.log(`CircleCI pipeline: ${pipelineId}`);
+  console.log(`Conditional routing: rust_changed=${rustChanged}, security_changed=${securityChanged}`);
+  console.log(`Expected CircleCI workflows: ${expected.circleci.map((workflow) => workflow.name).join(", ")}`);
+  console.log(`Expected GitHub Actions workflows: ${expected.github.map((workflow) => workflow.name).join(", ")}`);
+
+  const inspector = new GateInspector(circle, github, expected, {
+    pipelineId,
+    sha,
+    branch,
+    githubNotBeforeMs,
+  });
+  await waitForGate({
+    inspect: () => inspector.inspect(),
+    timeoutMs: positiveNumberEnv("POST_MERGE_GATE_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS) * 1000,
+    pollIntervalMs: positiveNumberEnv("POST_MERGE_GATE_POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS) * 1000,
+  });
+  console.log("All expected post-merge workflows succeeded.");
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack ?? error.message : error);
+    process.exit(1);
+  });
+}

--- a/.circleci/scripts/test-decision-tree.sh
+++ b/.circleci/scripts/test-decision-tree.sh
@@ -75,6 +75,19 @@ run_scenario() {
     fi
   done
 
+  # The authoritative post-merge signal must exist only for webhook pushes to
+  # develop, never for PR, merge queue, tag, API, or scheduled pipelines.
+  local expected_gate=false
+  if [[ "${trigger}" == "webhook" && "${branch}" == "develop" && -z "${tag}" ]]; then
+    expected_gate=true
+  fi
+  local actual_gate
+  actual_gate=$(echo "${_json}" | jq -r '."c-run_post_merge_gate" // false')
+  if [[ "${actual_gate}" != "${expected_gate}" ]]; then
+    echo "  FAIL: expected c-run_post_merge_gate=${expected_gate}, got ${actual_gate}"
+    all_pass=false
+  fi
+
   if ${all_pass}; then
     echo "PASS: ${name}"
     PASS=$((PASS + 1))
@@ -157,13 +170,13 @@ run_scenario \
   "After merge (develop), rust changed" \
   "webhook" "develop" "" "" \
   '{"c-rust_changes_detected": true, "c-contracts_changed": false, "c-docs_changes_detected": true}' \
-  main release publish_contract_artifacts develop_fault_proofs develop_kontrol_tests contracts_feature_tests rust_ci rust_e2e_ci kona_publish_prestates
+  main release publish_contract_artifacts develop_fault_proofs develop_kontrol_tests contracts_feature_tests post_merge_gate rust_ci rust_e2e_ci kona_publish_prestates
 
 run_scenario \
   "After merge (develop), no rust changes" \
   "webhook" "develop" "" "" \
   '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": false}' \
-  main release publish_contract_artifacts develop_fault_proofs develop_kontrol_tests contracts_feature_tests rust_ci_gate_short rust_e2e_gate_skip
+  main release publish_contract_artifacts develop_fault_proofs develop_kontrol_tests contracts_feature_tests post_merge_gate rust_ci_gate_short rust_e2e_gate_skip
 
 run_scenario \
   "Scheduled: build_four_hours" \

--- a/.circleci/scripts/workflow-helpers.sh
+++ b/.circleci/scripts/workflow-helpers.sh
@@ -7,7 +7,7 @@
 # Usage (from compute-workflow-conditions.sh):
 #   source .circleci/scripts/workflow-helpers.sh
 #   init_json
-#   ...routing logic using run/run_group/param/is_true...
+#   ...routing logic using run/run_group/run_post_merge_group/param/is_true...
 #   finalize
 
 # OUTPUT is overridable so tests can point at an isolated file instead of the
@@ -35,6 +35,19 @@ run_group() {
   local section="${1}" key="${2}"
   local wfs
   wfs=$(yq -r ".${section}.\"${key}\"[]?" "${ROUTING}")
+  if [[ -n "${wfs}" ]]; then
+    # shellcheck disable=SC2086  # intentional word-splitting of the name list
+    run ${wfs}
+  fi
+}
+
+# Enable every CircleCI route in one post-merge policy variant. Each entry is
+# explicitly either a gate member (`workflow`) or an exclusion (`excluded`),
+# but both classifications must be routed when the variant applies.
+run_post_merge_group() {
+  local variant="${1}"
+  local wfs
+  wfs=$(yq -r ".post_merge_gate.circleci.\"${variant}\"[].route" "${ROUTING}")
   if [[ -n "${wfs}" ]]; then
     # shellcheck disable=SC2086  # intentional word-splitting of the name list
     run ${wfs}

--- a/docs/ai/ci-config-review.md
+++ b/docs/ai/ci-config-review.md
@@ -24,11 +24,16 @@ hide. For each changed file, walk the relevant items and look for the bad patter
   changed files (`detect` true if *any* file matches, `detect_all` only if *every*
   file matches). `workflow-helpers.sh` sets the `c-run_*` flags;
   `test-decision-tree.sh` asserts the routing policy.
-- **The gate**: the GitHub `enforce-ci-checks-develop` ruleset requires exactly
-  four checks — `ci-gate`, `required-contracts-ci`, `required-rust-ci`,
+- **The pre-merge gate**: the GitHub `enforce-ci-checks-develop` ruleset requires
+  exactly four checks — `ci-gate`, `required-contracts-ci`, `required-rust-ci`,
   `required-rust-e2e`. These are fan-in jobs (no work, just `requires:`). A merge
   is gated *only* by what they transitively require; anything outside their
   `requires:` chain can fail without blocking merge. Gates use `utils/ci-gate`.
+- **The post-merge gate**: `.circleci/routing.yml` explicitly classifies every
+  workflow routed on a webhook push to `develop`. The `post-merge-gate` CircleCI
+  workflow polls that exact CircleCI pipeline and exact-SHA GitHub Actions push
+  runs. Add a new develop-push workflow to this policy as either gated or
+  explicitly excluded; policy-drift tests reject unclassified workflows.
 - **Continuation limits**: a setup pipeline continues exactly once, within 6h, no
   setup→setup. A param declared in both `config.yml` and a fragment with
   different defaults fails with "Conflicting pipeline parameters".


### PR DESCRIPTION
## Summary

- publish a stable `circleci-checks / post-merge-gate` check for webhook pushes to `develop`
- aggregate the exact CircleCI pipeline and exact-SHA GitHub Actions push runs, including conditional Rust and security routes
- fail closed on missing, unsuccessful, canceled, timed-out, or unreadable workflows while supporting provider and gate reruns
- enforce explicit gate membership for future post-merge workflows with policy-drift tests

## Testing

- `bun test ./.circleci/scripts/post-merge-gate.test.ts`
- `bash .circleci/scripts/test-decision-tree.sh`
- `bash .circleci/scripts/merge-configs.sh`
- `bash .circleci/scripts/test-continuation-params.sh /tmp/merged-config.yml`
- `shellcheck` on changed shell scripts

Closes https://github.com/ethereum-optimism/protocol-team/issues/259
