### PR TITLE
op-node: Re-validate span batch overlap content at deny-listed heights

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -134,7 +134,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	sys.Register("attributes-handler", attrHandler, opts)
 	ec.SetAttributesResetter(attrHandler)
 
-	pipeline := derive.NewDerivationPipeline(log, cfg, depSet, l1, blobsSrc, altDASrc, eng, metrics, l1ChainConfig)
+	pipeline := derive.NewDerivationPipeline(log, cfg, depSet, l1, blobsSrc, altDASrc, eng, metrics, l1ChainConfig, nil)
 	pipelineDeriver := derive.NewPipelineDeriver(ctx, pipeline)
 	sys.Register("pipeline", pipelineDeriver, opts)
 	ec.SetPipelineResetter(pipelineDeriver)

--- a/op-node/rollup/derive/batch_mux.go
+++ b/op-node/rollup/derive/batch_mux.go
@@ -15,10 +15,11 @@ import (
 // Stages are swapped on demand during Reset calls, or explicitly with Transform.
 // It currently chooses the BatchQueue pre-Holocene and the BatchStage post-Holocene.
 type BatchMux struct {
-	log  log.Logger
-	cfg  *rollup.Config
-	prev NextBatchProvider
-	l2   SafeBlockFetcher
+	log    log.Logger
+	cfg    *rollup.Config
+	prev   NextBatchProvider
+	l2     SafeBlockFetcher
+	denied DeniedHeightsView
 
 	// embedded active stage
 	SingularBatchProvider
@@ -28,8 +29,8 @@ var _ SingularBatchProvider = (*BatchMux)(nil)
 
 // NewBatchMux returns an uninitialized BatchMux. Reset has to be called before
 // calling other methods, to activate the right stage for a given L1 origin.
-func NewBatchMux(lgr log.Logger, cfg *rollup.Config, prev NextBatchProvider, l2 SafeBlockFetcher) *BatchMux {
-	return &BatchMux{log: lgr, cfg: cfg, prev: prev, l2: l2}
+func NewBatchMux(lgr log.Logger, cfg *rollup.Config, prev NextBatchProvider, l2 SafeBlockFetcher, denied DeniedHeightsView) *BatchMux {
+	return &BatchMux{log: lgr, cfg: cfg, prev: prev, l2: l2, denied: denied}
 }
 
 func (b *BatchMux) Reset(ctx context.Context, base eth.L1BlockRef, sysCfg eth.SystemConfig) error {
@@ -43,7 +44,7 @@ func (b *BatchMux) Reset(ctx context.Context, base eth.L1BlockRef, sysCfg eth.Sy
 	case b.cfg.IsHolocene(base.Time):
 		if _, ok := b.SingularBatchProvider.(*BatchStage); !ok {
 			b.log.Info("BatchMux: activating Holocene stage during reset", "origin", base)
-			b.SingularBatchProvider = NewBatchStage(b.log, b.cfg, b.prev, b.l2)
+			b.SingularBatchProvider = NewBatchStage(b.log, b.cfg, b.prev, b.l2, b.denied)
 		}
 	}
 	return b.SingularBatchProvider.Reset(ctx, base, sysCfg)
@@ -60,7 +61,7 @@ func (b *BatchMux) TransformHolocene() {
 	switch bp := b.SingularBatchProvider.(type) {
 	case *BatchQueue:
 		b.log.Info("BatchMux: transforming to Holocene stage")
-		bs := NewBatchStage(b.log, b.cfg, b.prev, b.l2)
+		bs := NewBatchStage(b.log, b.cfg, b.prev, b.l2, b.denied)
 		// Even though any ongoing span batch or queued batches are dropped at Holocene activation, the
 		// post-Holocene batch stage still needs access to the collected l1Blocks pre-Holocene because
 		// the first Holocene channel will contain pre-Holocene batches.

--- a/op-node/rollup/derive/batch_mux_test.go
+++ b/op-node/rollup/derive/batch_mux_test.go
@@ -23,7 +23,7 @@ func TestBatchMux_LaterHolocene(t *testing.T) {
 	cfg := &rollup.Config{
 		HoloceneTime: &l1B.Time,
 	}
-	b := NewBatchMux(log, cfg, nil, nil)
+	b := NewBatchMux(log, cfg, nil, nil, nil)
 
 	require.Nil(t, b.SingularBatchProvider)
 
@@ -56,7 +56,7 @@ func TestBatchMux_ActiveHolocene(t *testing.T) {
 	}
 	// without the fake input, the panic check later would panic because of the Origin() call
 	prev := &fakeBatchQueueInput{origin: l1A}
-	b := NewBatchMux(log, cfg, prev, nil)
+	b := NewBatchMux(log, cfg, prev, nil, nil)
 
 	require.Nil(t, b.SingularBatchProvider)
 

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -208,7 +208,7 @@ func TestBatchStages(t *testing.T) {
 		return NewBatchQueue(log, cfg, prev, l2)
 	}
 	newBatchStage := func(log log.Logger, cfg *rollup.Config, prev NextBatchProvider, l2 SafeBlockFetcher) testableBatchStage {
-		return NewBatchStage(log, cfg, prev, l2)
+		return NewBatchStage(log, cfg, prev, l2, nil)
 	}
 
 	tests := []struct {

--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -22,12 +22,15 @@ import (
 // Upon Holocene activation, it replaces the [BatchQueue].
 type BatchStage struct {
 	baseBatchStage
+	// denied provides the heights carrying interop deny list entries, i.e. heights at which a
+	// block replacement may have been applied. May be nil (no interop deny list available).
+	denied DeniedHeightsView
 }
 
 var _ SingularBatchProvider = (*BatchStage)(nil)
 
-func NewBatchStage(log log.Logger, cfg *rollup.Config, prev NextBatchProvider, l2 SafeBlockFetcher) *BatchStage {
-	return &BatchStage{baseBatchStage: newBaseBatchStage(log, cfg, prev, l2)}
+func NewBatchStage(log log.Logger, cfg *rollup.Config, prev NextBatchProvider, l2 SafeBlockFetcher, denied DeniedHeightsView) *BatchStage {
+	return &BatchStage{baseBatchStage: newBaseBatchStage(log, cfg, prev, l2), denied: denied}
 }
 
 func (bs *BatchStage) Reset(_ context.Context, base eth.L1BlockRef, _ eth.SystemConfig) error {
@@ -136,7 +139,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NewCriticalError(errors.New("failed type assertion to SpanBatch"))
 		}
 
-		validity, _ := checkSpanBatchPrefix(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
+		validity, parentBlock := checkSpanBatchPrefix(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
 		switch validity {
 		case BatchAccept: // continue
 			spanBatch.LogContext(bs.Log()).Info("Found next valid span batch")
@@ -153,6 +156,23 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NotEnoughData
 		case BatchFuture: // can't happen with Holocene
 			return nil, NewCriticalError(errors.New("impossible future batch validity"))
+		}
+
+		// The prefix checks do not validate overlap contents against the safe chain. Re-validate
+		// them at deny-listed heights, so that a span batch carrying a since-replaced block cannot
+		// splice the remainder of an invalidated lineage onto the canonical chain. See
+		// checkSpanBatchDeniedOverlap for details.
+		switch validity := checkSpanBatchDeniedOverlap(ctx, bs.config, bs.Log(), bs.denied, spanBatch, parentBlock, parent, bs.l2); validity {
+		case BatchAccept: // continue
+		case BatchDrop:
+			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (deny list overlap checks)")
+			bs.FlushChannel()
+			return nil, NotEnoughData
+		case BatchUndecided: // l2 fetcher error, try again
+			spanBatch.LogContext(bs.Log()).Warn("Undecided span batch (deny list overlap checks)")
+			return nil, NotEnoughData
+		default:
+			return nil, NewCriticalError(fmt.Errorf("unexpected deny list overlap batch validity: %v", validity))
 		}
 
 		// If next batch is SpanBatch, convert it to SingularBatches.

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -426,36 +426,103 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 				// unable to validate the batch for now. retry later.
 				return BatchUndecided
 			}
-			safeBlockTxs := safeBlockPayload.ExecutionPayload.Transactions
-			batchTxs := batch.GetBlockTransactions(int(i))
-			// execution payload has deposit TXs, but batch does not.
-			depositCount := 0
-			for _, tx := range safeBlockTxs {
-				if tx[0] == optypes.DepositTxType {
-					depositCount++
-				}
-			}
-			if len(safeBlockTxs)-depositCount != len(batchTxs) {
-				log.Warn("overlapped block's tx count does not match", "safeBlockTxs", len(safeBlockTxs), "batchTxs", len(batchTxs))
-				return BatchDrop
-			}
-			for j := 0; j < len(batchTxs); j++ {
-				if !bytes.Equal(safeBlockTxs[j+depositCount], batchTxs[j]) {
-					log.Warn("overlapped block's transaction does not match")
-					return BatchDrop
-				}
-			}
-			safeBlockRef, err := PayloadToBlockRef(cfg, safeBlockPayload.ExecutionPayload)
-			if err != nil {
-				log.Error("failed to extract L2BlockRef from execution payload", "hash", safeBlockPayload.ExecutionPayload.BlockHash, "err", err)
-				return BatchDrop
-			}
-			if safeBlockRef.L1Origin.Number != batch.GetBlockEpochNum(int(i)) {
-				log.Warn("overlapped block's L1 origin number does not match")
-				return BatchDrop
+			if validity := checkOverlappedBlock(cfg, log, batch, int(i), safeBlockPayload); validity != BatchAccept {
+				return validity
 			}
 		}
 	}
 
+	return BatchAccept
+}
+
+// checkOverlappedBlock compares the i-th span batch element against the canonical block payload
+// at the same height, returning BatchDrop on any transaction or L1 origin mismatch.
+func checkOverlappedBlock(cfg *rollup.Config, log log.Logger, batch *SpanBatch, i int, safeBlockPayload *eth.ExecutionPayloadEnvelope) BatchValidity {
+	safeBlockTxs := safeBlockPayload.ExecutionPayload.Transactions
+	batchTxs := batch.GetBlockTransactions(i)
+	// execution payload has deposit TXs, but batch does not.
+	depositCount := 0
+	for _, tx := range safeBlockTxs {
+		if tx[0] == optypes.DepositTxType {
+			depositCount++
+		}
+	}
+	if len(safeBlockTxs)-depositCount != len(batchTxs) {
+		log.Warn("overlapped block's tx count does not match", "safeBlockTxs", len(safeBlockTxs), "batchTxs", len(batchTxs))
+		return BatchDrop
+	}
+	for j := 0; j < len(batchTxs); j++ {
+		if !bytes.Equal(safeBlockTxs[j+depositCount], batchTxs[j]) {
+			log.Warn("overlapped block's transaction does not match")
+			return BatchDrop
+		}
+	}
+	safeBlockRef, err := PayloadToBlockRef(cfg, safeBlockPayload.ExecutionPayload)
+	if err != nil {
+		log.Error("failed to extract L2BlockRef from execution payload", "hash", safeBlockPayload.ExecutionPayload.BlockHash, "err", err)
+		return BatchDrop
+	}
+	if safeBlockRef.L1Origin.Number != batch.GetBlockEpochNum(i) {
+		log.Warn("overlapped block's L1 origin number does not match")
+		return BatchDrop
+	}
+	return BatchAccept
+}
+
+// DeniedHeightsView provides read access to the block heights at which the interop deny list
+// holds entries, i.e. heights at which a block has been invalidated and replaced with a
+// deposits-only block. Implemented by rollup.SuperAuthority.
+type DeniedHeightsView interface {
+	// DeniedHeightsInRange returns all heights within [minHeight, maxHeight] (inclusive) that
+	// carry at least one deny list entry, in ascending order. It must be a cheap local lookup.
+	DeniedHeightsInRange(minHeight, maxHeight uint64) ([]uint64, error)
+}
+
+// checkSpanBatchDeniedOverlap re-validates the overlapping portion of a prefix-accepted span
+// batch against the canonical chain, at heights that carry deny list entries.
+//
+// The Holocene span batch prefix checks (checkSpanBatchPrefix) do not validate the contents of
+// batch elements that overlap the safe chain — unlike the legacy full checks (checkSpanBatch) —
+// on the assumption that the safe chain was derived from this same batch data and therefore must
+// agree with it. An interop deposits-only block replacement breaks that assumption: the canonical
+// block at the replaced height no longer matches the batch element it was originally derived
+// from. Without this check, a span batch carrying a replaced block is silently past-skipped over
+// the replacement and splices the remainder of an invalidated lineage onto the canonical chain,
+// making the derived chain dependent on where the pipeline (re-)anchored relative to the
+// replacement.
+//
+// Deny list entries mark the only heights at which the canonical chain can disagree with batch
+// data that was once accepted, so the content comparison is restricted to those heights and is a
+// no-op while the deny list is empty.
+func checkSpanBatchDeniedOverlap(ctx context.Context, cfg *rollup.Config, log log.Logger, denied DeniedHeightsView,
+	batch *SpanBatch, parentBlock, l2SafeHead eth.L2BlockRef, l2Fetcher SafeBlockFetcher,
+) BatchValidity {
+	if denied == nil || parentBlock.Number >= l2SafeHead.Number {
+		// No deny list available, or the batch does not overlap the safe chain.
+		return BatchAccept
+	}
+	heights, err := denied.DeniedHeightsInRange(parentBlock.Number+1, l2SafeHead.Number)
+	if err != nil {
+		// Fail open, mirroring the deny list checks on the engine paths: log, but do not block
+		// derivation on a deny list read failure.
+		log.Error("Failed to read deny list heights, skipping span batch overlap re-validation",
+			"parent_block", parentBlock, "safe_head", l2SafeHead, "err", err)
+		return BatchAccept
+	}
+	for _, height := range heights {
+		i := int(height - parentBlock.Number - 1) // index of the span batch element at this height
+		if i >= batch.GetBlockCount() {
+			continue
+		}
+		safeBlockPayload, err := l2Fetcher.PayloadByNumber(ctx, height)
+		if err != nil {
+			log.Warn("failed to fetch L2 block payload", "number", height, "err", err)
+			// unable to validate the batch for now. retry later.
+			return BatchUndecided
+		}
+		if validity := checkOverlappedBlock(cfg, log, batch, i, safeBlockPayload); validity != BatchAccept {
+			return validity
+		}
+	}
 	return BatchAccept
 }

--- a/op-node/rollup/derive/deny_overlap_test.go
+++ b/op-node/rollup/derive/deny_overlap_test.go
@@ -1,0 +1,175 @@
+package derive
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+// fakeDeniedHeights is a DeniedHeightsView backed by a static list of heights.
+type fakeDeniedHeights struct {
+	heights []uint64
+	err     error
+}
+
+func (f *fakeDeniedHeights) DeniedHeightsInRange(minHeight, maxHeight uint64) ([]uint64, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	var out []uint64
+	for _, h := range f.heights {
+		if h >= minHeight && h <= maxHeight {
+			out = append(out, h)
+		}
+	}
+	return out, nil
+}
+
+// TestBatchStage_DeniedOverlap pins the derive-level mechanism behind the interop
+// block-replacement lineage bug: a span batch whose overlap section carries a block that has
+// since been replaced with a deposits-only block (deny list entry at that height) must be
+// dropped and its channel flushed, instead of having the denied element silently past-skipped
+// and the remainder of the invalidated lineage spliced onto the canonical chain.
+//
+// The scenario mirrors the incident: the safe head is a deposits-only replacement at a denied
+// height, and the incoming span batch is the original channel, whose element at that height
+// still carries the invalidated transaction.
+func TestBatchStage_DeniedOverlap(t *testing.T) {
+	l1 := L1Chain([]uint64{10, 16, 22, 28})
+	chainId := big.NewInt(1234)
+	newConfig := func() *rollup.Config {
+		cfg := &rollup.Config{
+			Genesis: rollup.Genesis{
+				L2Time: 20,
+			},
+			BlockTime:         2,
+			MaxSequencerDrift: 600,
+			SeqWindowSize:     1000,
+			L2ChainID:         chainId,
+		}
+		cfg.ActivateAtGenesis(forks.Delta)
+		return cfg
+	}
+	cfg := newConfig()
+
+	parentBatch := b(cfg.L2ChainID, 20, l1[0])
+	parentRef := singularBatchToBlockRef(t, parentBatch, 0)
+	parentPayload := singularBatchToPayload(t, parentBatch, 0)
+
+	// The canonical block at height 1 is a deposits-only replacement: no sequencer txs.
+	replacementBatch := &SingularBatch{
+		ParentHash: parentRef.Hash,
+		Timestamp:  22,
+		EpochNum:   rollup.Epoch(l1[1].Number),
+		EpochHash:  l1[1].Hash,
+	}
+	safeHead := singularBatchToBlockRef(t, replacementBatch, 1)
+	safePayload := singularBatchToPayload(t, replacementBatch, 1)
+
+	newFetcher := func() *fakeSafeBlockFetcher {
+		fetcher := newFakeSafeBlockFetcher()
+		fetcher.addBlock(parentRef, &parentPayload)
+		fetcher.addBlock(safeHead, &safePayload)
+		return fetcher
+	}
+
+	// The original channel's span batch: its element at the replaced height still carries the
+	// invalidated transaction (b() adds one tx), followed by the remainder of that lineage.
+	deniedLineageSpan := func() *SpanBatch {
+		return initializedSpanBatch([]*SingularBatch{
+			b(cfg.L2ChainID, 22, l1[1]), // same height as the replacement, carries the replaced tx
+			b(cfg.L2ChainID, 24, l1[1]), // the lineage remainder that must not splice
+		}, cfg.Genesis.L2Time, chainId)
+	}
+	// A batch agreeing with the canonical chain: deposits-only element at the replaced height.
+	matchingLineageSpan := func() *SpanBatch {
+		return initializedSpanBatch([]*SingularBatch{
+			replacementBatch,
+			b(cfg.L2ChainID, 24, l1[1]),
+		}, cfg.Genesis.L2Time, chainId)
+	}
+
+	newStage := func(lgr log.Logger, span *SpanBatch, denied DeniedHeightsView, fetcher SafeBlockFetcher) *BatchStage {
+		input := &fakeBatchQueueInput{
+			batches: []Batch{span},
+			errors:  []error{nil},
+			origin:  l1[2],
+		}
+		stage := NewBatchStage(lgr, cfg, input, fetcher, denied)
+		_ = stage.Reset(context.Background(), l1[1], eth.SystemConfig{})
+		return stage
+	}
+
+	t.Run("conflicting overlap at denied height is dropped", func(t *testing.T) {
+		lgr, logs := testlog.CaptureLogger(t, log.LevelWarn)
+		stage := newStage(lgr, deniedLineageSpan(), &fakeDeniedHeights{heights: []uint64{1}}, newFetcher())
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, err, NotEnoughData)
+		require.Nil(t, batch)
+		logs.RequireMessageContainedOnce(t, "overlapped block's tx count does not match")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (deny list overlap checks)")
+	})
+
+	t.Run("matching overlap at denied height is accepted", func(t *testing.T) {
+		lgr := testlog.Logger(t, log.LevelCrit)
+		stage := newStage(lgr, matchingLineageSpan(), &fakeDeniedHeights{heights: []uint64{1}}, newFetcher())
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.NoError(t, err)
+		require.Equal(t, uint64(24), batch.Timestamp)
+	})
+
+	t.Run("no deny list entries skips re-validation", func(t *testing.T) {
+		// Without deny list knowledge, the conflicting overlap is past-skipped and the tail
+		// splices — this documents the content-blindness the deny-gated check exists to close.
+		lgr := testlog.Logger(t, log.LevelCrit)
+		stage := newStage(lgr, deniedLineageSpan(), &fakeDeniedHeights{}, newFetcher())
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.NoError(t, err)
+		require.Equal(t, uint64(24), batch.Timestamp)
+	})
+
+	t.Run("nil deny list view skips re-validation", func(t *testing.T) {
+		lgr := testlog.Logger(t, log.LevelCrit)
+		stage := newStage(lgr, deniedLineageSpan(), nil, newFetcher())
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.NoError(t, err)
+		require.Equal(t, uint64(24), batch.Timestamp)
+	})
+
+	t.Run("deny list read error fails open", func(t *testing.T) {
+		lgr, logs := testlog.CaptureLogger(t, log.LevelError)
+		stage := newStage(lgr, deniedLineageSpan(), &fakeDeniedHeights{err: errors.New("boom")}, newFetcher())
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.NoError(t, err)
+		require.Equal(t, uint64(24), batch.Timestamp)
+		logs.RequireMessageContainedOnce(t, "Failed to read deny list heights")
+	})
+
+	t.Run("payload fetch error is undecided", func(t *testing.T) {
+		lgr, logs := testlog.CaptureLogger(t, log.LevelWarn)
+		fetcher := newFakeSafeBlockFetcher()
+		fetcher.addBlock(parentRef, &parentPayload)
+		fetcher.addBlock(safeHead, nil) // ref known, payload unavailable
+		stage := newStage(lgr, deniedLineageSpan(), &fakeDeniedHeights{heights: []uint64{1}}, fetcher)
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, err, NotEnoughData)
+		require.Nil(t, batch)
+		logs.RequireMessageContainedOnce(t, "Undecided span batch (deny list overlap checks)")
+	})
+}

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -98,7 +98,7 @@ type DerivationPipeline struct {
 
 // NewDerivationPipeline creates a DerivationPipeline, to turn L1 data into L2 block-inputs.
 func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, depSet DependencySet, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher,
-	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics, l1ChainConfig *params.ChainConfig,
+	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics, l1ChainConfig *params.ChainConfig, denied DeniedHeightsView,
 ) *DerivationPipeline {
 	spec := rollup.NewChainSpec(rollupCfg)
 	// Stages are strung together into a pipeline,
@@ -109,7 +109,7 @@ func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, depSet Depe
 	frameQueue := NewFrameQueue(log, rollupCfg, l1Src)
 	channelMux := NewChannelMux(log, spec, frameQueue, metrics)
 	chInReader := NewChannelInReader(rollupCfg, log, channelMux, metrics)
-	batchMux := NewBatchMux(log, rollupCfg, chInReader, l2Source)
+	batchMux := NewBatchMux(log, rollupCfg, chInReader, l2Source, denied)
 	attrBuilder := NewFetchingAttributesBuilder(rollupCfg, l1ChainConfig, depSet, l1Fetcher, l2Source)
 	attributesQueue := NewAttributesQueue(log, rollupCfg, attrBuilder, batchMux)
 

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -75,7 +75,13 @@ func NewDriver(
 	attrHandler := attributes.NewAttributesHandler(log, cfg, driverCtx, l2, ec)
 	sys.Register("attributes-handler", attrHandler)
 
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, depSet, verifConfDepth, l1Blobs, altDA, l2, metrics, l1ChainConfig)
+	// The deny list gives derivation the heights at which an interop block replacement may have
+	// been applied, so the batch stage can re-validate span batch overlap contents there.
+	var deniedHeights derive.DeniedHeightsView
+	if superAuthority != nil {
+		deniedHeights = superAuthority
+	}
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, depSet, verifConfDepth, l1Blobs, altDA, l2, metrics, l1ChainConfig, deniedHeights)
 
 	pipelineDeriver := derive.NewPipelineDeriver(driverCtx, derivationPipeline)
 	sys.Register("pipeline", pipelineDeriver)

--- a/op-node/rollup/engine/super_authority_mock_test.go
+++ b/op-node/rollup/engine/super_authority_mock_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -61,6 +62,20 @@ func (m *mockSuperAuthority) MaxDeniedHeight() (uint64, bool, error) {
 		}
 	}
 	return maxHeight, maxHeight != 0, nil
+}
+
+func (m *mockSuperAuthority) DeniedHeightsInRange(minHeight, maxHeight uint64) ([]uint64, error) {
+	if m.shouldError {
+		return nil, fmt.Errorf("superauthority check failed")
+	}
+	var heights []uint64
+	for num := range m.deniedBlocks {
+		if num >= minHeight && num <= maxHeight {
+			heights = append(heights, num)
+		}
+	}
+	slices.Sort(heights)
+	return heights, nil
 }
 
 func (m *mockSuperAuthority) FullyVerifiedL2Head(ctx context.Context) (rollup.VerifierHead, bool) {

--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -74,6 +74,13 @@ type SuperAuthority interface {
 	// cheap (a local lookup, no network I/O). A read error is returned rather
 	// than reported as "no denials", so callers can log it.
 	MaxDeniedHeight() (uint64, bool, error)
+
+	// DeniedHeightsInRange returns all block heights within [minHeight, maxHeight] (inclusive)
+	// that carry at least one deny list entry, in ascending order. Consulted by derivation when
+	// a span batch overlaps the safe chain, to re-validate overlap contents at heights where a
+	// block replacement may have been applied. Like MaxDeniedHeight, it must be a cheap local
+	// lookup.
+	DeniedHeightsInRange(minHeight, maxHeight uint64) ([]uint64, error)
 }
 
 // SafeHeadListener is called when the safe head is updated.

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -1,6 +1,7 @@
 package chain_container
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/json"
@@ -97,6 +98,27 @@ func (d *DenyList) MaxDeniedHeight() (uint64, bool, error) {
 		return 0, false, fmt.Errorf("failed to read max denied height: %w", err)
 	}
 	return maxHeight, maxHeight != 0, nil
+}
+
+// DeniedHeightsInRange returns all heights within [minHeight, maxHeight] (inclusive) that have
+// at least one deny record, in ascending order. The big-endian height keys make the bbolt cursor
+// scan range-bounded and cheap.
+func (d *DenyList) DeniedHeightsInRange(minHeight, maxHeight uint64) ([]uint64, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	var heights []uint64
+	err := d.db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket(denyListBucketName).Cursor()
+		maxKey := heightToKey(maxHeight)
+		for k, _ := c.Seek(heightToKey(minHeight)); k != nil && bytes.Compare(k, maxKey) <= 0; k, _ = c.Next() {
+			heights = append(heights, binary.BigEndian.Uint64(k))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read denied heights in range [%d, %d]: %w", minHeight, maxHeight, err)
+	}
+	return heights, nil
 }
 
 // heightToKey converts a block height to a big-endian byte key.

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -294,6 +294,41 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 	}
 }
 
+func TestDenyList_DeniedHeightsInRange(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dl, err := OpenDenyList(dir)
+	require.NoError(t, err)
+	defer dl.Close()
+
+	// Two entries at height 20 must yield the height once.
+	require.NoError(t, dl.Add(5, common.HexToHash("0x0505"), 0, eth.Bytes32{}, eth.Bytes32{}))
+	require.NoError(t, dl.Add(20, common.HexToHash("0x2020"), 0, eth.Bytes32{}, eth.Bytes32{}))
+	require.NoError(t, dl.Add(20, common.HexToHash("0x2021"), 0, eth.Bytes32{}, eth.Bytes32{}))
+	require.NoError(t, dl.Add(30, common.HexToHash("0x3030"), 0, eth.Bytes32{}, eth.Bytes32{}))
+
+	heights, err := dl.DeniedHeightsInRange(0, 100)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{5, 20, 30}, heights)
+
+	heights, err = dl.DeniedHeightsInRange(6, 30)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{20, 30}, heights)
+
+	heights, err = dl.DeniedHeightsInRange(20, 20)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{20}, heights)
+
+	heights, err = dl.DeniedHeightsInRange(6, 19)
+	require.NoError(t, err)
+	require.Empty(t, heights)
+
+	heights, err = dl.DeniedHeightsInRange(31, 100)
+	require.NoError(t, err)
+	require.Empty(t, heights)
+}
+
 // mockEngineForInvalidation implements engine_controller.EngineController for invalidation tests
 type mockEngineForInvalidation struct {
 	blockRef        eth.L2BlockRef

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -112,6 +112,15 @@ func (c *simpleChainContainer) MaxDeniedHeight() (uint64, bool, error) {
 	return c.denyList.MaxDeniedHeight()
 }
 
+// DeniedHeightsInRange returns all heights within [minHeight, maxHeight] (inclusive) that carry
+// deny list entries, in ascending order.
+func (c *simpleChainContainer) DeniedHeightsInRange(minHeight, maxHeight uint64) ([]uint64, error) {
+	if c.denyList == nil {
+		return nil, nil
+	}
+	return c.denyList.DeniedHeightsInRange(minHeight, maxHeight)
+}
+
 // GetDeniedOutput returns the reconstructed OutputV0 for a denied block.
 func (c *simpleChainContainer) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
 	if c.denyList == nil {


### PR DESCRIPTION
## Description

The Holocene span batch prefix checks (`checkSpanBatchPrefix`) do not validate the contents of batch elements that overlap the safe chain — unlike the legacy full checks (`checkSpanBatch`), which fetch every overlapped payload and compare transactions. Dropping that comparison was sound under a pre-interop invariant: the safe chain was derived from this same batch data, so overlap content provably agrees with it.

Interop deposits-only block replacement breaks that invariant. After a denied block is replaced, the canonical block at the replaced height no longer matches the batch element it was originally derived from — and the prefix checks never notice:

- `GetSingularBatches` past-skips every element at or below the safe head without inspecting content, including the since-replaced (denied) block.
- The deny check (`IsDenied`) only fires when a payload at the denied height is *proposed* (`engine/payload_process.go`), and the channel flush is a side effect of that deny event (`DepositsOnlyAttributes`). A walk anchored **at** the replacement never proposes the denied block, so neither fires.
- The span's tail is then re-stamped onto the replacement and applied — splicing the remainder of an invalidated lineage onto the canonical chain.

The result is that the derived chain depends on where the pipeline (re-)anchored relative to the replacement: an anchor **below** the denied block re-proposes it → deny → replacement + channel flush → the next channel wins; an anchor **at** the replacement past-skips it → the same channel's tail wins. Same L1 data, same deny list, different chains. This was observed on devnet `interop-reorg-5`, where a post-invalidation reset anchored a live supernode at the replacement and flipped it onto a lineage that from-genesis syncs can never derive (writeup: internal doc "Double Batch Derivation Issue"). PR #21970 closed the analogous hole on the consolidation path, but both existing deny hooks are keyed on a payload/attributes existing at the denied height — on this path, nothing at the denied height is ever processed.

## Change

Reinstate the pre-Holocene overlap content comparison, gated to heights that carry deny list entries — the only heights at which the canonical chain can disagree with batch data that was once accepted:

- `derive`: add `DeniedHeightsView` and `checkSpanBatchDeniedOverlap`; after the prefix checks accept an overlapping span batch, re-validate its overlap elements at deny-listed heights against the canonical blocks (same comparison as legacy, factored into `checkOverlappedBlock` and shared by both paths). A mismatch drops the batch and flushes the channel, exactly as a prefix-check failure does. No-op while the deny list is empty, and zero extra payload fetches on the happy path.
- `rollup`: add `DeniedHeightsInRange` to the `SuperAuthority` interface.
- `op-supernode`: implement it on the deny list (range-bounded bbolt cursor over the big-endian height keys) and the chain container.
- `driver`: wire the super authority's deny list view into the derivation pipeline; nodes without a SuperAuthority are unaffected.

With the check in place, derivation is anchor-invariant across replacement boundaries again: a walk anchored at a replacement drops the stale channel (content conflict) instead of resurrecting its tail, and converges on the same chain as a walk anchored below it.

Note: deny list entries are (height, hash)-scoped and lineage-relative — a valid block carrying transactions can legitimately exist at a height that also has a deny entry from an abandoned lineage. This is why the check compares content against the canonical chain rather than dropping any batch crossing a denied height.

## Tests

- `TestBatchStage_DeniedOverlap` (new, `op-node/rollup/derive/deny_overlap_test.go`) pins the incident shape: a span batch whose overlap carries a replaced block is dropped with a channel flush; a batch whose overlap matches the canonical chain (including at the denied height) is accepted; no deny entries / nil view / deny read failure fail open to today's behavior; payload fetch errors are Undecided (retry).
- `TestDenyList_DeniedHeightsInRange` (new) covers the bbolt range scan.
- `go test ./op-node/rollup/... ./op-supernode/supernode/chain_container/` passes.

## Follow-ups (not in this PR)

- kona / fault proof parity: the same overlap rule needs a spec-level decision — in a pure derivation implementation the "denied heights" set is derivable state (heights where the pipeline itself applied a deposits-only replacement).
- Supernode-side hardening from the same incident: anchor post-invalidation resets at the rewind target rather than the finality-bounded verified head, and act on the existing "super authority safe head ahead of local" divergence signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)