### PR TITLE
op-node,kona: validate span batch overlap content against the safe chain in Holocene

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -608,11 +608,11 @@ jobs:
       - run:
           name: Set run environment
           command: |
-            echo 'export BLOCK_NUMBER=42427365' >> $BASH_ENV
-            echo 'export L2_CLAIM=0xaaf7cb1725cb9766899cbd78866270d8561e79b91c00be5c53adb7699e0e7715' >> $BASH_ENV
-            echo 'export L2_OUTPUT_ROOT=0xac90a2e8cfee33ecb47b73f3e83f9aa18ff7ecf28bc8d34b2de857919e50b6c6' >> $BASH_ENV
-            echo 'export L2_HEAD=0xc5fa07d52e83f7a2e68de356e7a7bfc9306a9b28666ec6c9cc6e4f8e1b268278' >> $BASH_ENV
-            echo 'export L1_HEAD=0xab33322985684f2c6fbcf375bdcb69cc0f10547e58cb5a7b889172ee9ea77aef' >> $BASH_ENV
+            echo 'export BLOCK_NUMBER=47600000' >> $BASH_ENV
+            echo 'export L2_CLAIM=0x6ac07d241d170ddd504532a2c8127bb85426e604a360f8ba2d976be3cc0aa7f0' >> $BASH_ENV
+            echo 'export L2_OUTPUT_ROOT=0x9c799a1b767f43d6c654f83e18ae20bfc2953e94e5093ef59664ae8244ffdc96' >> $BASH_ENV
+            echo 'export L2_HEAD=0x0084ac82023844b6f286783f3ea0ffddb8e597211ffbe01b56d8873f36a8bacb' >> $BASH_ENV
+            echo 'export L1_HEAD=0xf82badb3d56a53c373b501ec24e1e9ab2797feaab552c0d683849b1234308a2d' >> $BASH_ENV
             echo 'export L2_CHAIN_ID=11155420' >> $BASH_ENV
       - run:
           name: Run host + client offline

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -619,7 +619,10 @@ func testBatchStage_OverlappingSpanBatch(t *testing.T, batchType int, newBatchSt
 		case *BatchQueue:
 			logs.RequireMessageContainedOnce(t, "block epoch is too old")
 		case *BatchStage:
-			logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (singular batch extraction)")
+			// The overlap content checks catch the origin mismatch before singular batch
+			// extraction gets a chance to.
+			logs.RequireMessageContainedOnce(t, "overlapped block's L1 origin number does not match")
+			logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
 		}
 	})
 

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -615,14 +615,13 @@ func testBatchStage_OverlappingSpanBatch(t *testing.T, batchType int, newBatchSt
 		batch, _, err := stage.NextBatch(context.Background(), safeHead)
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
-		switch stage.(type) {
-		case *BatchQueue:
-			logs.RequireMessageContainedOnce(t, "block epoch is too old")
-		case *BatchStage:
-			// The overlap content checks catch the origin mismatch before singular batch
-			// extraction gets a chance to.
-			logs.RequireMessageContainedOnce(t, "overlapped block's L1 origin number does not match")
-			logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
+		// The overlap content checks catch the origin mismatch first on both paths: they run as
+		// part of checkSpanBatchHolocene, ahead of the remaining full checks of the BatchQueue's
+		// checkSpanBatch (which used to catch this batch with "block epoch is too old") and ahead
+		// of the BatchStage's singular batch extraction.
+		logs.RequireMessageContainedOnce(t, "overlapped block's L1 origin number does not match")
+		if _, ok := stage.(*BatchStage); ok {
+			logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
 		}
 	})
 

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -597,7 +597,7 @@ func testBatchStage_OverlappingSpanBatch(t *testing.T, batchType int, newBatchSt
 
 	t.Run("outdated origin", func(t *testing.T) {
 		invalidSpanSingulars := []*SingularBatch{
-			b(cfg.L2ChainID, 22, l1[0]), // same block number as safe head, will be skipped
+			safeBatch,                   // matches the safe head, so the overlap content checks pass
 			b(cfg.L2ChainID, 24, l1[0]), // first batch after safe head uses outdated origin 0
 			b(cfg.L2ChainID, 26, l1[1]),
 		}
@@ -615,13 +615,11 @@ func testBatchStage_OverlappingSpanBatch(t *testing.T, batchType int, newBatchSt
 		batch, _, err := stage.NextBatch(context.Background(), safeHead)
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
-		// The overlap content checks catch the origin mismatch first on both paths: they run as
-		// part of checkSpanBatchHolocene, ahead of the remaining full checks of the BatchQueue's
-		// checkSpanBatch (which used to catch this batch with "block epoch is too old") and ahead
-		// of the BatchStage's singular batch extraction.
-		logs.RequireMessageContainedOnce(t, "overlapped block's L1 origin number does not match")
-		if _, ok := stage.(*BatchStage); ok {
-			logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
+		switch stage.(type) {
+		case *BatchQueue:
+			logs.RequireMessageContainedOnce(t, "block epoch is too old")
+		case *BatchStage:
+			logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (singular batch extraction)")
 		}
 	})
 

--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -136,7 +136,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NewCriticalError(errors.New("failed type assertion to SpanBatch"))
 		}
 
-		validity, _ := checkSpanBatchPrefix(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
+		validity, parentBlock := checkSpanBatchPrefix(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
 		switch validity {
 		case BatchAccept: // continue
 			spanBatch.LogContext(bs.Log()).Info("Found next valid span batch")
@@ -153,6 +153,25 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NotEnoughData
 		case BatchFuture: // can't happen with Holocene
 			return nil, NewCriticalError(errors.New("impossible future batch validity"))
+		}
+
+		// The prefix checks do not validate overlap contents against the safe chain. A span batch
+		// that disagrees with the safe chain — possible since interop block replacement — must be
+		// dropped as a whole, so that the remainder of an invalidated lineage cannot be spliced
+		// onto the canonical chain. See checkSpanBatchOverlap for details.
+		if parentBlock.Number < parent.Number {
+			switch validity := checkSpanBatchOverlap(ctx, bs.config, bs.Log(), spanBatch, parentBlock, parent, bs.l2); validity {
+			case BatchAccept: // continue
+			case BatchDrop:
+				spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch overlap checks)")
+				bs.FlushChannel()
+				return nil, NotEnoughData
+			case BatchUndecided: // l2 fetcher error, try again
+				spanBatch.LogContext(bs.Log()).Warn("Undecided span batch (span batch overlap checks)")
+				return nil, NotEnoughData
+			default:
+				return nil, NewCriticalError(fmt.Errorf("unexpected overlap batch validity: %v", validity))
+			}
 		}
 
 		// If next batch is SpanBatch, convert it to SingularBatches.

--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -136,7 +136,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NewCriticalError(errors.New("failed type assertion to SpanBatch"))
 		}
 
-		validity, parentBlock := checkSpanBatchPrefix(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
+		validity, _ := checkSpanBatchHolocene(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
 		switch validity {
 		case BatchAccept: // continue
 			spanBatch.LogContext(bs.Log()).Info("Found next valid span batch")
@@ -145,7 +145,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			// NotEnoughData to read in next batch until we're through all past batches
 			return nil, NotEnoughData
 		case BatchDrop: // drop, try next
-			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch prefix checks)")
+			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch checks)")
 			bs.FlushChannel()
 			return nil, NotEnoughData
 		case BatchUndecided: // l2 fetcher error, try again
@@ -155,28 +155,9 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NewCriticalError(errors.New("impossible future batch validity"))
 		}
 
-		// The prefix checks do not validate overlap contents against the safe chain. A span batch
-		// that disagrees with the safe chain — possible since interop block replacement — must be
-		// dropped as a whole, so that the remainder of an invalidated lineage cannot be spliced
-		// onto the canonical chain. See checkSpanBatchOverlap for details.
-		if parentBlock.Number < parent.Number {
-			switch validity := checkSpanBatchOverlap(ctx, bs.config, bs.Log(), spanBatch, parentBlock, parent, bs.l2); validity {
-			case BatchAccept: // continue
-			case BatchDrop:
-				spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch overlap checks)")
-				bs.FlushChannel()
-				return nil, NotEnoughData
-			case BatchUndecided: // l2 fetcher error, try again
-				spanBatch.LogContext(bs.Log()).Warn("Undecided span batch (span batch overlap checks)")
-				return nil, NotEnoughData
-			default:
-				return nil, NewCriticalError(fmt.Errorf("unexpected overlap batch validity: %v", validity))
-			}
-		}
-
 		// If next batch is SpanBatch, convert it to SingularBatches.
 		singularBatches, err := spanBatch.GetSingularBatches(bs.l1Blocks, parent)
-		// Errors can happen here because the span batch prefix checks are not exhaustive (unlike the full span batch
+		// Errors can happen here because the Holocene span batch checks are not exhaustive (unlike the full span batch
 		// checks) so an error must be handled like an invalid span batch (DROP).
 		if err != nil {
 			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (singular batch extraction)", "error", err)

--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -136,7 +136,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NewCriticalError(errors.New("failed type assertion to SpanBatch"))
 		}
 
-		validity, _ := checkSpanBatchHolocene(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
+		validity, parentBlock := checkSpanBatchPrefix(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
 		switch validity {
 		case BatchAccept: // continue
 			spanBatch.LogContext(bs.Log()).Info("Found next valid span batch")
@@ -145,7 +145,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			// NotEnoughData to read in next batch until we're through all past batches
 			return nil, NotEnoughData
 		case BatchDrop: // drop, try next
-			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch checks)")
+			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch prefix checks)")
 			bs.FlushChannel()
 			return nil, NotEnoughData
 		case BatchUndecided: // l2 fetcher error; the span was already consumed and is skipped, not retried
@@ -155,9 +155,28 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NewCriticalError(errors.New("impossible future batch validity"))
 		}
 
+		// The prefix checks do not validate overlap contents against the safe chain. A span batch
+		// that disagrees with the safe chain — possible since interop block replacement — must be
+		// dropped as a whole, so that the remainder of an invalidated lineage cannot be spliced
+		// onto the canonical chain. See checkSpanBatchOverlap for details.
+		if parentBlock.Number < parent.Number {
+			switch validity := checkSpanBatchOverlap(ctx, bs.config, bs.Log(), spanBatch, parentBlock, parent, bs.l2); validity {
+			case BatchAccept: // continue
+			case BatchDrop:
+				spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch overlap checks)")
+				bs.FlushChannel()
+				return nil, NotEnoughData
+			case BatchUndecided: // l2 fetcher error; the span was already consumed and is skipped, not retried
+				spanBatch.LogContext(bs.Log()).Warn("Undecided span batch (span batch overlap checks)")
+				return nil, NotEnoughData
+			default:
+				return nil, NewCriticalError(fmt.Errorf("unexpected overlap batch validity: %v", validity))
+			}
+		}
+
 		// If next batch is SpanBatch, convert it to SingularBatches.
 		singularBatches, err := spanBatch.GetSingularBatches(bs.l1Blocks, parent)
-		// Errors can happen here because the Holocene span batch checks are not exhaustive (unlike the full span batch
+		// Errors can happen here because the span batch prefix checks are not exhaustive (unlike the full span batch
 		// checks) so an error must be handled like an invalid span batch (DROP).
 		if err != nil {
 			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (singular batch extraction)", "error", err)

--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -136,7 +136,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NewCriticalError(errors.New("failed type assertion to SpanBatch"))
 		}
 
-		validity, parentBlock := checkSpanBatchPrefix(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
+		validity := checkSpanBatchHolocene(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
 		switch validity {
 		case BatchAccept: // continue
 			spanBatch.LogContext(bs.Log()).Info("Found next valid span batch")
@@ -145,7 +145,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			// NotEnoughData to read in next batch until we're through all past batches
 			return nil, NotEnoughData
 		case BatchDrop: // drop, try next
-			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch prefix checks)")
+			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch checks)")
 			bs.FlushChannel()
 			return nil, NotEnoughData
 		case BatchUndecided: // l2 fetcher error; the span was already consumed and is skipped, not retried
@@ -155,29 +155,10 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NewCriticalError(errors.New("impossible future batch validity"))
 		}
 
-		// The prefix checks do not validate overlap contents against the safe chain. A span batch
-		// that disagrees with the safe chain — possible since interop block replacement — must be
-		// dropped as a whole, so that the remainder of an invalidated lineage cannot be spliced
-		// onto the canonical chain. See checkSpanBatchOverlap for details.
-		if parentBlock.Number < parent.Number {
-			switch validity := checkSpanBatchOverlap(ctx, bs.config, bs.Log(), spanBatch, parentBlock, parent, bs.l2); validity {
-			case BatchAccept: // continue
-			case BatchDrop:
-				spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch overlap checks)")
-				bs.FlushChannel()
-				return nil, NotEnoughData
-			case BatchUndecided: // l2 fetcher error; the span was already consumed and is skipped, not retried
-				spanBatch.LogContext(bs.Log()).Warn("Undecided span batch (span batch overlap checks)")
-				return nil, NotEnoughData
-			default:
-				return nil, NewCriticalError(fmt.Errorf("unexpected overlap batch validity: %v", validity))
-			}
-		}
-
 		// If next batch is SpanBatch, convert it to SingularBatches.
 		singularBatches, err := spanBatch.GetSingularBatches(bs.l1Blocks, parent)
-		// Errors can happen here because the span batch prefix checks are not exhaustive (unlike the full span batch
-		// checks) so an error must be handled like an invalid span batch (DROP).
+		// Errors can happen here because the Holocene span batch checks are not exhaustive (unlike
+		// the full span batch checks) so an error must be handled like an invalid span batch (DROP).
 		if err != nil {
 			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (singular batch extraction)", "error", err)
 			bs.FlushChannel()

--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -148,7 +148,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch checks)")
 			bs.FlushChannel()
 			return nil, NotEnoughData
-		case BatchUndecided: // l2 fetcher error, try again
+		case BatchUndecided: // l2 fetcher error; the span was already consumed and is skipped, not retried
 			spanBatch.LogContext(bs.Log()).Warn("Undecided span batch")
 			return nil, NotEnoughData
 		case BatchFuture: // can't happen with Holocene

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -414,48 +414,63 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 		}
 	}
 
-	parentNum := parentBlock.Number
 	nextTimestamp := l2SafeHead.Time + cfg.BlockTime
 	// Check overlapped blocks
 	if batch.GetTimestamp() < nextTimestamp {
-		for i := uint64(0); i < l2SafeHead.Number-parentNum; i++ {
-			safeBlockNum := parentNum + i + 1
-			safeBlockPayload, err := l2Fetcher.PayloadByNumber(ctx, safeBlockNum)
-			if err != nil {
-				log.Warn("failed to fetch L2 block payload", "number", safeBlockNum, "err", err)
-				// unable to validate the batch for now. retry later.
-				return BatchUndecided
-			}
-			safeBlockTxs := safeBlockPayload.ExecutionPayload.Transactions
-			batchTxs := batch.GetBlockTransactions(int(i))
-			// execution payload has deposit TXs, but batch does not.
-			depositCount := 0
-			for _, tx := range safeBlockTxs {
-				if tx[0] == optypes.DepositTxType {
-					depositCount++
-				}
-			}
-			if len(safeBlockTxs)-depositCount != len(batchTxs) {
-				log.Warn("overlapped block's tx count does not match", "safeBlockTxs", len(safeBlockTxs), "batchTxs", len(batchTxs))
-				return BatchDrop
-			}
-			for j := 0; j < len(batchTxs); j++ {
-				if !bytes.Equal(safeBlockTxs[j+depositCount], batchTxs[j]) {
-					log.Warn("overlapped block's transaction does not match")
-					return BatchDrop
-				}
-			}
-			safeBlockRef, err := PayloadToBlockRef(cfg, safeBlockPayload.ExecutionPayload)
-			if err != nil {
-				log.Error("failed to extract L2BlockRef from execution payload", "hash", safeBlockPayload.ExecutionPayload.BlockHash, "err", err)
-				return BatchDrop
-			}
-			if safeBlockRef.L1Origin.Number != batch.GetBlockEpochNum(int(i)) {
-				log.Warn("overlapped block's L1 origin number does not match")
-				return BatchDrop
-			}
+		if validity := checkSpanBatchOverlap(ctx, cfg, log, batch, parentBlock, l2SafeHead, l2Fetcher); validity != BatchAccept {
+			return validity
 		}
 	}
 
+	return BatchAccept
+}
+
+// checkSpanBatchOverlap validates the portion of a span batch that overlaps the safe chain: every
+// overlapped element's transactions and L1 origin must match the canonical block at the same
+// height. A batch whose overlap disagrees with the safe chain — possible since interop block
+// replacement — describes a different history and is dropped as a whole, so that its elements
+// past the safe head cannot be applied. Returns BatchUndecided if a canonical payload cannot be
+// fetched right now.
+func checkSpanBatchOverlap(ctx context.Context, cfg *rollup.Config, log log.Logger, batch *SpanBatch,
+	parentBlock, l2SafeHead eth.L2BlockRef, l2Fetcher SafeBlockFetcher,
+) BatchValidity {
+	parentNum := parentBlock.Number
+	for i := uint64(0); i < l2SafeHead.Number-parentNum; i++ {
+		safeBlockNum := parentNum + i + 1
+		safeBlockPayload, err := l2Fetcher.PayloadByNumber(ctx, safeBlockNum)
+		if err != nil {
+			log.Warn("failed to fetch L2 block payload", "number", safeBlockNum, "err", err)
+			// unable to validate the batch for now. retry later.
+			return BatchUndecided
+		}
+		safeBlockTxs := safeBlockPayload.ExecutionPayload.Transactions
+		batchTxs := batch.GetBlockTransactions(int(i))
+		// execution payload has deposit TXs, but batch does not.
+		depositCount := 0
+		for _, tx := range safeBlockTxs {
+			if tx[0] == optypes.DepositTxType {
+				depositCount++
+			}
+		}
+		if len(safeBlockTxs)-depositCount != len(batchTxs) {
+			log.Warn("overlapped block's tx count does not match", "safeBlockTxs", len(safeBlockTxs), "batchTxs", len(batchTxs))
+			return BatchDrop
+		}
+		for j := 0; j < len(batchTxs); j++ {
+			if !bytes.Equal(safeBlockTxs[j+depositCount], batchTxs[j]) {
+				log.Warn("overlapped block's transaction does not match")
+				return BatchDrop
+			}
+		}
+		safeBlockRef, err := PayloadToBlockRef(cfg, safeBlockPayload.ExecutionPayload)
+		if err != nil {
+			log.Error("failed to extract L2BlockRef from execution payload", "hash", safeBlockPayload.ExecutionPayload.BlockHash, "err", err)
+			return BatchDrop
+		}
+		if safeBlockRef.L1Origin.Number != batch.GetBlockEpochNum(int(i)) {
+			log.Warn("overlapped block's L1 origin number does not match")
+			return BatchDrop
+		}
+	}
 	return BatchAccept
 }

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -207,10 +207,11 @@ func checkSequencerTxData(log log.Logger, txIndex int, txBytes []byte, isIsthmus
 	return BatchAccept
 }
 
-// checkSpanBatchPrefix performs the span batch prefix rules for Holocene.
-// Next to the validity, it also returns the parent L2 block as determined during the checks for
-// further consumption.
-func checkSpanBatchPrefix(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
+// checkSpanBatchHolocene performs the full set of span batch checks that run post-Holocene: the
+// prefix rules, plus the overlap content comparison against the safe chain (see
+// checkSpanBatchOverlap). Next to the validity, it also returns the parent L2 block as determined
+// during the checks for further consumption.
+func checkSpanBatchHolocene(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
 	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher,
 ) (BatchValidity, eth.L2BlockRef) {
 	// add details to the log
@@ -316,6 +317,16 @@ func checkSpanBatchPrefix(ctx context.Context, cfg *rollup.Config, log log.Logge
 		log.Warn("dropped batch, epoch is too old", "minimum", parentBlock.ID())
 		return BatchDrop, parentBlock
 	}
+
+	// The prefix rules only anchor the batch at its parent; they do not validate the contents of
+	// elements that overlap the safe chain. A span batch whose overlap disagrees with the safe
+	// chain — possible since interop block replacement — must be dropped as a whole, so that the
+	// remainder of an invalidated lineage cannot be spliced onto the canonical chain.
+	// The loop is empty if the batch does not overlap (parentBlock == l2SafeHead).
+	if validity := checkSpanBatchOverlap(ctx, cfg, log, batch, parentBlock, l2SafeHead, l2Fetcher); validity != BatchAccept {
+		return validity, parentBlock
+	}
+
 	return BatchAccept, parentBlock
 }
 
@@ -324,7 +335,7 @@ func checkSpanBatchPrefix(ctx context.Context, cfg *rollup.Config, log log.Logge
 func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
 	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher,
 ) BatchValidity {
-	prefixValidity, parentBlock := checkSpanBatchPrefix(ctx, cfg, log, l1Blocks, l2SafeHead, batch, l1InclusionBlock, l2Fetcher)
+	prefixValidity, parentBlock := checkSpanBatchHolocene(ctx, cfg, log, l1Blocks, l2SafeHead, batch, l1InclusionBlock, l2Fetcher)
 	if prefixValidity != BatchAccept {
 		return prefixValidity
 	}
@@ -414,13 +425,9 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 		}
 	}
 
-	nextTimestamp := l2SafeHead.Time + cfg.BlockTime
-	// Check overlapped blocks
-	if batch.GetTimestamp() < nextTimestamp {
-		if validity := checkSpanBatchOverlap(ctx, cfg, log, batch, parentBlock, l2SafeHead, l2Fetcher); validity != BatchAccept {
-			return validity
-		}
-	}
+	// Note: the overlapped blocks were already checked by checkSpanBatchHolocene above. This
+	// moves the overlap content check ahead of the per-transaction checks relative to the
+	// pre-Holocene order, which only matters for the validity of batches failing both.
 
 	return BatchAccept
 }

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -207,9 +207,8 @@ func checkSequencerTxData(log log.Logger, txIndex int, txBytes []byte, isIsthmus
 	return BatchAccept
 }
 
-// checkSpanBatchPrefix performs the span batch prefix rules for Holocene.
-// Next to the validity, it also returns the parent L2 block as determined during the checks for
-// further consumption.
+// checkSpanBatchPrefix performs the span batch prefix rules shared by the legacy full checks and
+// the Holocene checks. It also returns the parent L2 block determined during validation.
 func checkSpanBatchPrefix(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
 	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher,
 ) (BatchValidity, eth.L2BlockRef) {
@@ -318,6 +317,18 @@ func checkSpanBatchPrefix(ctx context.Context, cfg *rollup.Config, log log.Logge
 		return BatchDrop, parentBlock
 	}
 	return BatchAccept, parentBlock
+}
+
+// checkSpanBatchHolocene validates the span batch prefix followed by its overlap with the safe
+// chain. Holocene validates batches as they are loaded, so the legacy full checks are not run.
+func checkSpanBatchHolocene(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
+	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher,
+) BatchValidity {
+	prefixValidity, parentBlock := checkSpanBatchPrefix(ctx, cfg, log, l1Blocks, l2SafeHead, batch, l1InclusionBlock, l2Fetcher)
+	if prefixValidity != BatchAccept {
+		return prefixValidity
+	}
+	return checkSpanBatchOverlap(ctx, cfg, log, batch, parentBlock, l2SafeHead, l2Fetcher)
 }
 
 // checkSpanBatch checks the full SpanBatch semantic validation rules on a syntactically-correct
@@ -430,8 +441,9 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 // overlapped element's transactions and L1 origin must match the canonical block at the same
 // height. A batch whose overlap disagrees with the safe chain — possible since interop block
 // replacement — describes a different history and is dropped as a whole, so that its elements
-// past the safe head cannot be applied. Returns BatchUndecided if a canonical payload cannot be
-// fetched right now.
+// past the safe head cannot be applied. The prefix rules must have accepted the batch first:
+// parentBlock must be the prefix-determined parent (an ancestor of, or equal to, l2SafeHead), and
+// the batch must extend past the safe head. Returns BatchUndecided if a payload cannot be fetched.
 func checkSpanBatchOverlap(ctx context.Context, cfg *rollup.Config, log log.Logger, batch *SpanBatch,
 	parentBlock, l2SafeHead eth.L2BlockRef, l2Fetcher SafeBlockFetcher,
 ) BatchValidity {

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -318,11 +318,8 @@ func checkSpanBatchHolocene(ctx context.Context, cfg *rollup.Config, log log.Log
 		return BatchDrop, parentBlock
 	}
 
-	// The prefix rules only anchor the batch at its parent; they do not validate the contents of
-	// elements that overlap the safe chain. A span batch whose overlap disagrees with the safe
-	// chain — possible since interop block replacement — must be dropped as a whole, so that the
-	// remainder of an invalidated lineage cannot be spliced onto the canonical chain.
-	// The loop is empty if the batch does not overlap (parentBlock == l2SafeHead).
+	// The prefix rules only anchor the batch at its parent; any overlap content must also agree
+	// with the safe chain, see checkSpanBatchOverlap. No-op without overlap (parentBlock == l2SafeHead).
 	if validity := checkSpanBatchOverlap(ctx, cfg, log, batch, parentBlock, l2SafeHead, l2Fetcher); validity != BatchAccept {
 		return validity, parentBlock
 	}

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -207,11 +207,10 @@ func checkSequencerTxData(log log.Logger, txIndex int, txBytes []byte, isIsthmus
 	return BatchAccept
 }
 
-// checkSpanBatchHolocene performs the full set of span batch checks that run post-Holocene: the
-// prefix rules, plus the overlap content comparison against the safe chain (see
-// checkSpanBatchOverlap). Next to the validity, it also returns the parent L2 block as determined
-// during the checks for further consumption.
-func checkSpanBatchHolocene(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
+// checkSpanBatchPrefix performs the span batch prefix rules for Holocene.
+// Next to the validity, it also returns the parent L2 block as determined during the checks for
+// further consumption.
+func checkSpanBatchPrefix(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
 	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher,
 ) (BatchValidity, eth.L2BlockRef) {
 	// add details to the log
@@ -318,13 +317,6 @@ func checkSpanBatchHolocene(ctx context.Context, cfg *rollup.Config, log log.Log
 		log.Warn("dropped batch, epoch is too old", "minimum", parentBlock.ID())
 		return BatchDrop, parentBlock
 	}
-
-	// The prefix rules only anchor the batch at its parent; any overlap content must also agree
-	// with the safe chain, see checkSpanBatchOverlap. No-op without overlap (parentBlock == l2SafeHead).
-	if validity := checkSpanBatchOverlap(ctx, cfg, log, batch, parentBlock, l2SafeHead, l2Fetcher); validity != BatchAccept {
-		return validity, parentBlock
-	}
-
 	return BatchAccept, parentBlock
 }
 
@@ -333,7 +325,7 @@ func checkSpanBatchHolocene(ctx context.Context, cfg *rollup.Config, log log.Log
 func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
 	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher,
 ) BatchValidity {
-	prefixValidity, parentBlock := checkSpanBatchHolocene(ctx, cfg, log, l1Blocks, l2SafeHead, batch, l1InclusionBlock, l2Fetcher)
+	prefixValidity, parentBlock := checkSpanBatchPrefix(ctx, cfg, log, l1Blocks, l2SafeHead, batch, l1InclusionBlock, l2Fetcher)
 	if prefixValidity != BatchAccept {
 		return prefixValidity
 	}
@@ -423,9 +415,13 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 		}
 	}
 
-	// Note: the overlapped blocks were already checked by checkSpanBatchHolocene above. This
-	// moves the overlap content check ahead of the per-transaction checks relative to the
-	// pre-Holocene order, which only matters for the validity of batches failing both.
+	nextTimestamp := l2SafeHead.Time + cfg.BlockTime
+	// Check overlapped blocks
+	if batch.GetTimestamp() < nextTimestamp {
+		if validity := checkSpanBatchOverlap(ctx, cfg, log, batch, parentBlock, l2SafeHead, l2Fetcher); validity != BatchAccept {
+			return validity
+		}
+	}
 
 	return BatchAccept
 }

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -274,7 +274,8 @@ func checkSpanBatchHolocene(ctx context.Context, cfg *rollup.Config, log log.Log
 		parentBlock, err = l2Fetcher.L2BlockRefByNumber(ctx, parentNum)
 		if err != nil {
 			log.Warn("failed to fetch L2 block", "number", parentNum, "err", err)
-			// unable to validate the batch for now. retry later.
+			// Unable to validate the batch right now. Only the pre-Holocene BatchQueue retains
+			// the batch for a retry; the Holocene BatchStage has already consumed it and skips it.
 			return BatchUndecided, eth.L2BlockRef{}
 		}
 	}
@@ -444,7 +445,8 @@ func checkSpanBatchOverlap(ctx context.Context, cfg *rollup.Config, log log.Logg
 		safeBlockPayload, err := l2Fetcher.PayloadByNumber(ctx, safeBlockNum)
 		if err != nil {
 			log.Warn("failed to fetch L2 block payload", "number", safeBlockNum, "err", err)
-			// unable to validate the batch for now. retry later.
+			// Unable to validate the batch right now. Only the pre-Holocene BatchQueue retains
+			// the batch for a retry; the Holocene BatchStage has already consumed it and skips it.
 			return BatchUndecided
 		}
 		safeBlockTxs := safeBlockPayload.ExecutionPayload.Transactions

--- a/op-node/rollup/derive/overlap_content_test.go
+++ b/op-node/rollup/derive/overlap_content_test.go
@@ -94,7 +94,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
 		logs.RequireMessageContainedOnce(t, "overlapped block's tx count does not match")
-		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
 	})
 
 	t.Run("matching overlap is accepted", func(t *testing.T) {
@@ -116,6 +116,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		batch, _, err := stage.NextBatch(context.Background(), safeHead)
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
-		logs.RequireMessageContainedOnce(t, "Undecided span batch (span batch overlap checks)")
+		logs.RequireMessageContainedOnce(t, "failed to fetch L2 block payload")
+		logs.RequireMessageContainedOnce(t, "Undecided span batch")
 	})
 }

--- a/op-node/rollup/derive/overlap_content_test.go
+++ b/op-node/rollup/derive/overlap_content_test.go
@@ -1,0 +1,121 @@
+package derive
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+// TestBatchStage_OverlapContent pins the derive-level mechanism behind the interop
+// block-replacement lineage bug: a span batch whose overlap section disagrees with the safe
+// chain (e.g. it carries a block that has since been replaced with a deposits-only block) must
+// be dropped and its channel flushed, instead of having the conflicting element silently
+// past-skipped and the remainder of the invalidated lineage spliced onto the canonical chain.
+//
+// The scenario mirrors the incident: the safe head is a deposits-only replacement, and the
+// incoming span batch is the original channel, whose element at that height still carries the
+// invalidated transaction.
+func TestBatchStage_OverlapContent(t *testing.T) {
+	l1 := L1Chain([]uint64{10, 16, 22, 28})
+	chainId := big.NewInt(1234)
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 20,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     1000,
+		L2ChainID:         chainId,
+	}
+	cfg.ActivateAtGenesis(forks.Delta)
+
+	parentBatch := b(cfg.L2ChainID, 20, l1[0])
+	parentRef := singularBatchToBlockRef(t, parentBatch, 0)
+	parentPayload := singularBatchToPayload(t, parentBatch, 0)
+
+	// The canonical block at height 1 is a deposits-only replacement: no sequencer txs.
+	replacementBatch := &SingularBatch{
+		ParentHash: parentRef.Hash,
+		Timestamp:  22,
+		EpochNum:   rollup.Epoch(l1[1].Number),
+		EpochHash:  l1[1].Hash,
+	}
+	safeHead := singularBatchToBlockRef(t, replacementBatch, 1)
+	safePayload := singularBatchToPayload(t, replacementBatch, 1)
+
+	newFetcher := func() *fakeSafeBlockFetcher {
+		fetcher := newFakeSafeBlockFetcher()
+		fetcher.addBlock(parentRef, &parentPayload)
+		fetcher.addBlock(safeHead, &safePayload)
+		return fetcher
+	}
+
+	// The original channel's span batch: its element at the replaced height still carries the
+	// invalidated transaction (b() adds one tx), followed by the remainder of that lineage.
+	deniedLineageSpan := func() *SpanBatch {
+		return initializedSpanBatch([]*SingularBatch{
+			b(cfg.L2ChainID, 22, l1[1]), // same height as the replacement, carries the replaced tx
+			b(cfg.L2ChainID, 24, l1[1]), // the lineage remainder that must not splice
+		}, cfg.Genesis.L2Time, chainId)
+	}
+	// A batch agreeing with the canonical chain: deposits-only element at the replaced height.
+	matchingLineageSpan := func() *SpanBatch {
+		return initializedSpanBatch([]*SingularBatch{
+			replacementBatch,
+			b(cfg.L2ChainID, 24, l1[1]),
+		}, cfg.Genesis.L2Time, chainId)
+	}
+
+	newStage := func(lgr log.Logger, span *SpanBatch, fetcher SafeBlockFetcher) *BatchStage {
+		input := &fakeBatchQueueInput{
+			batches: []Batch{span},
+			errors:  []error{nil},
+			origin:  l1[2],
+		}
+		stage := NewBatchStage(lgr, cfg, input, fetcher)
+		_ = stage.Reset(context.Background(), l1[1], eth.SystemConfig{})
+		return stage
+	}
+
+	t.Run("conflicting overlap is dropped", func(t *testing.T) {
+		lgr, logs := testlog.CaptureLogger(t, log.LevelWarn)
+		stage := newStage(lgr, deniedLineageSpan(), newFetcher())
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, err, NotEnoughData)
+		require.Nil(t, batch)
+		logs.RequireMessageContainedOnce(t, "overlapped block's tx count does not match")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
+	})
+
+	t.Run("matching overlap is accepted", func(t *testing.T) {
+		lgr := testlog.Logger(t, log.LevelCrit)
+		stage := newStage(lgr, matchingLineageSpan(), newFetcher())
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.NoError(t, err)
+		require.Equal(t, uint64(24), batch.Timestamp)
+	})
+
+	t.Run("payload fetch error is undecided", func(t *testing.T) {
+		lgr, logs := testlog.CaptureLogger(t, log.LevelWarn)
+		fetcher := newFakeSafeBlockFetcher()
+		fetcher.addBlock(parentRef, &parentPayload)
+		fetcher.addBlock(safeHead, nil) // ref known, payload unavailable
+		stage := newStage(lgr, deniedLineageSpan(), fetcher)
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, err, NotEnoughData)
+		require.Nil(t, batch)
+		logs.RequireMessageContainedOnce(t, "Undecided span batch (span batch overlap checks)")
+	})
+}

--- a/op-node/rollup/derive/overlap_content_test.go
+++ b/op-node/rollup/derive/overlap_content_test.go
@@ -91,7 +91,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
 		logs.RequireMessageContainedOnce(t, "overlapped block's tx count does not match")
-		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
 	})
 
 	t.Run("matching overlap is accepted", func(t *testing.T) {
@@ -124,7 +124,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
 		logs.RequireMessageContainedOnce(t, "overlapped block's L1 origin number does not match")
-		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
 	})
 
 	t.Run("payload fetch error is undecided", func(t *testing.T) {
@@ -137,7 +137,6 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		batch, _, err := stage.NextBatch(context.Background(), safeHead)
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
-		logs.RequireMessageContainedOnce(t, "failed to fetch L2 block payload")
-		logs.RequireMessageContainedOnce(t, "Undecided span batch")
+		logs.RequireMessageContainedOnce(t, "Undecided span batch (span batch overlap checks)")
 	})
 }

--- a/op-node/rollup/derive/overlap_content_test.go
+++ b/op-node/rollup/derive/overlap_content_test.go
@@ -2,6 +2,7 @@ package derive
 
 import (
 	"context"
+	"io"
 	"math/big"
 	"testing"
 
@@ -72,10 +73,10 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		}, cfg.Genesis.L2Time, chainId)
 	}
 
-	newStage := func(lgr log.Logger, span *SpanBatch, fetcher SafeBlockFetcher) *BatchStage {
+	newStage := func(lgr log.Logger, fetcher SafeBlockFetcher, spans ...Batch) *BatchStage {
 		input := &fakeBatchQueueInput{
-			batches: []Batch{span},
-			errors:  []error{nil},
+			batches: spans,
+			errors:  make([]error, len(spans)),
 			origin:  l1[2],
 		}
 		stage := NewBatchStage(lgr, cfg, input, fetcher)
@@ -85,22 +86,74 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 
 	t.Run("conflicting overlap is dropped", func(t *testing.T) {
 		lgr, logs := testlog.CaptureLogger(t, log.LevelWarn)
-		stage := newStage(lgr, deniedLineageSpan(), newFetcher())
+		// The sentinel span behind the conflicting one would be accepted if it were ever read:
+		// it only surviving the drop would prove the flush was logged but not performed.
+		stage := newStage(lgr, newFetcher(), deniedLineageSpan(), matchingLineageSpan())
 
 		batch, _, err := stage.NextBatch(context.Background(), safeHead)
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
 		logs.RequireMessageContainedOnce(t, "overlapped block's tx count does not match")
 		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
+
+		// The flush must have discarded the unread sentinel along with the rest of the channel.
+		batch, _, err = stage.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, err, io.EOF)
+		require.Nil(t, batch)
 	})
 
 	t.Run("matching overlap is accepted", func(t *testing.T) {
 		lgr := testlog.Logger(t, log.LevelCrit)
-		stage := newStage(lgr, matchingLineageSpan(), newFetcher())
+		stage := newStage(lgr, newFetcher(), matchingLineageSpan())
 
 		batch, _, err := stage.NextBatch(context.Background(), safeHead)
 		require.NoError(t, err)
 		require.Equal(t, uint64(24), batch.Timestamp)
+	})
+
+	t.Run("multi-block overlap: early match, late mismatch", func(t *testing.T) {
+		// A two-block overlap where the first overlapped element matches the safe chain and
+		// only the second diverges, exercising the comparison loop beyond its first iteration.
+		safe1Batch := b(cfg.L2ChainID, 22, l1[1])
+		safe1Ref := singularBatchToBlockRef(t, safe1Batch, 1)
+		safe1Payload := singularBatchToPayload(t, safe1Batch, 1)
+		safe2Batch := b(cfg.L2ChainID, 24, l1[1])
+		safe2Ref := singularBatchToBlockRef(t, safe2Batch, 2)
+		safe2Payload := singularBatchToPayload(t, safe2Batch, 2)
+		fetcher := newFakeSafeBlockFetcher()
+		fetcher.addBlock(parentRef, &parentPayload)
+		fetcher.addBlock(safe1Ref, &safe1Payload)
+		fetcher.addBlock(safe2Ref, &safe2Payload)
+
+		// Height 2's element carries no transactions, unlike canonical safe2Batch.
+		divergent24 := &SingularBatch{
+			ParentHash: safe1Ref.Hash,
+			Timestamp:  24,
+			EpochNum:   rollup.Epoch(l1[1].Number),
+			EpochHash:  l1[1].Hash,
+		}
+		lateMismatchSpan := initializedSpanBatch([]*SingularBatch{
+			b(cfg.L2ChainID, 22, l1[1]), // matches the safe chain at height 1
+			divergent24,                 // diverges at height 2
+			b(cfg.L2ChainID, 26, l1[1]), // the tail that must not splice
+		}, cfg.Genesis.L2Time, chainId)
+		sentinel := initializedSpanBatch([]*SingularBatch{
+			b(cfg.L2ChainID, 26, l1[1]),
+		}, cfg.Genesis.L2Time, chainId)
+
+		lgr, logs := testlog.CaptureLogger(t, log.LevelWarn)
+		stage := newStage(lgr, fetcher, lateMismatchSpan, sentinel)
+
+		batch, _, err := stage.NextBatch(context.Background(), safe2Ref)
+		require.ErrorIs(t, err, NotEnoughData)
+		require.Nil(t, batch)
+		logs.RequireMessageContainedOnce(t, "overlapped block's tx count does not match")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
+
+		// The flush must have discarded the unread sentinel along with the rest of the channel.
+		batch, _, err = stage.NextBatch(context.Background(), safe2Ref)
+		require.ErrorIs(t, err, io.EOF)
+		require.Nil(t, batch)
 	})
 
 	t.Run("overlapped origin mismatch is dropped", func(t *testing.T) {
@@ -118,7 +171,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		}, cfg.Genesis.L2Time, chainId)
 
 		lgr, logs := testlog.CaptureLogger(t, log.LevelWarn)
-		stage := newStage(lgr, originMismatchSpan, fetcher)
+		stage := newStage(lgr, fetcher, originMismatchSpan)
 
 		batch, _, err := stage.NextBatch(context.Background(), txSafeHead)
 		require.ErrorIs(t, err, NotEnoughData)
@@ -132,7 +185,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		fetcher := newFakeSafeBlockFetcher()
 		fetcher.addBlock(parentRef, &parentPayload)
 		fetcher.addBlock(safeHead, nil) // ref known, payload unavailable
-		stage := newStage(lgr, deniedLineageSpan(), fetcher)
+		stage := newStage(lgr, fetcher, deniedLineageSpan())
 
 		batch, _, err := stage.NextBatch(context.Background(), safeHead)
 		require.ErrorIs(t, err, NotEnoughData)

--- a/op-node/rollup/derive/overlap_content_test.go
+++ b/op-node/rollup/derive/overlap_content_test.go
@@ -17,13 +17,10 @@ import (
 
 // TestBatchStage_OverlapContent pins the derive-level mechanism behind the interop
 // block-replacement lineage bug: a span batch whose overlap section disagrees with the safe
-// chain (e.g. it carries a block that has since been replaced with a deposits-only block) must
-// be dropped and its channel flushed, instead of having the conflicting element silently
-// past-skipped and the remainder of the invalidated lineage spliced onto the canonical chain.
-//
-// The scenario mirrors the incident: the safe head is a deposits-only replacement, and the
-// incoming span batch is the original channel, whose element at that height still carries the
-// invalidated transaction.
+// chain — here, the original channel of a lineage whose block has since been replaced with a
+// deposits-only block — must be dropped and its channel flushed, instead of having the
+// conflicting element silently past-skipped and the remainder of the invalidated lineage
+// spliced onto the canonical chain.
 func TestBatchStage_OverlapContent(t *testing.T) {
 	l1 := L1Chain([]uint64{10, 16, 22, 28})
 	chainId := big.NewInt(1234)
@@ -104,6 +101,30 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		batch, _, err := stage.NextBatch(context.Background(), safeHead)
 		require.NoError(t, err)
 		require.Equal(t, uint64(24), batch.Timestamp)
+	})
+
+	t.Run("overlapped origin mismatch is dropped", func(t *testing.T) {
+		// A fixture where the overlapped element's transactions match the canonical block
+		// (b() derives the tx from the timestamp), but its L1 origin number does not.
+		txSafeBatch := b(cfg.L2ChainID, 22, l1[1])
+		txSafeHead := singularBatchToBlockRef(t, txSafeBatch, 1)
+		txSafePayload := singularBatchToPayload(t, txSafeBatch, 1)
+		fetcher := newFakeSafeBlockFetcher()
+		fetcher.addBlock(parentRef, &parentPayload)
+		fetcher.addBlock(txSafeHead, &txSafePayload)
+		originMismatchSpan := initializedSpanBatch([]*SingularBatch{
+			b(cfg.L2ChainID, 22, l1[0]), // same txs as the canonical block, outdated origin
+			b(cfg.L2ChainID, 24, l1[1]),
+		}, cfg.Genesis.L2Time, chainId)
+
+		lgr, logs := testlog.CaptureLogger(t, log.LevelWarn)
+		stage := newStage(lgr, originMismatchSpan, fetcher)
+
+		batch, _, err := stage.NextBatch(context.Background(), txSafeHead)
+		require.ErrorIs(t, err, NotEnoughData)
+		require.Nil(t, batch)
+		logs.RequireMessageContainedOnce(t, "overlapped block's L1 origin number does not match")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
 	})
 
 	t.Run("payload fetch error is undecided", func(t *testing.T) {

--- a/op-node/rollup/derive/overlap_content_test.go
+++ b/op-node/rollup/derive/overlap_content_test.go
@@ -94,7 +94,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
 		logs.RequireMessageContainedOnce(t, "overlapped block's tx count does not match")
-		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
 
 		// The flush must have discarded the unread sentinel along with the rest of the channel.
 		batch, _, err = stage.NextBatch(context.Background(), safeHead)
@@ -148,7 +148,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
 		logs.RequireMessageContainedOnce(t, "overlapped block's tx count does not match")
-		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
 
 		// The flush must have discarded the unread sentinel along with the rest of the channel.
 		batch, _, err = stage.NextBatch(context.Background(), safe2Ref)
@@ -177,7 +177,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
 		logs.RequireMessageContainedOnce(t, "overlapped block's L1 origin number does not match")
-		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
 	})
 
 	t.Run("payload fetch error is undecided", func(t *testing.T) {
@@ -190,6 +190,6 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		batch, _, err := stage.NextBatch(context.Background(), safeHead)
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
-		logs.RequireMessageContainedOnce(t, "Undecided span batch (span batch overlap checks)")
+		logs.RequireMessageContainedOnce(t, "Undecided span batch")
 	})
 }

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -595,8 +595,8 @@ func (b *SpanBatch) ToRawSpanBatch() (*RawSpanBatch, error) {
 // Since SpanBatchElement does not contain EpochHash, set EpochHash from the given L1 blocks.
 // The result SingularBatches do not contain ParentHash yet. It must be set by the BatchQueue/Stage.
 //
-// If the span batch is overlapping the safe head, it may happen that the batch is found to be invalid
-// only at this point and that the span batch passed the previous span batch prefix checks.
+// It may happen that the batch is found to be invalid only at this point, having passed the
+// Holocene span batch checks (which are not exhaustive).
 // In this case, an error is returned and the whole span batch must be dropped.
 func (b *SpanBatch) GetSingularBatches(l1Origins []eth.L1BlockRef, l2SafeHead eth.L2BlockRef) ([]*SingularBatch, error) {
 	var singularBatches []*SingularBatch

--- a/rust/kona/bin/client/justfile
+++ b/rust/kona/bin/client/justfile
@@ -249,7 +249,7 @@ prepare-witness-data witness_tar witness_tar_url:
 # `kona-YYYY-MM-DD` by the `prepare-witness-data` dependency. When regenerating
 # for a new block, upload a new release (see `generate-witness-tar`) and bump
 # the `witness_tar` / `witness_tar_url` defaults.
-run-client-cannon-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id witness_tar='op-sepolia-42427365-witness.tar.zst' witness_tar_url='https://github.com/ethereum-optimism/chain-test-data/releases/download/kona-2026-04-21' verbosity='': (prepare-witness-data witness_tar witness_tar_url)
+run-client-cannon-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id witness_tar='op-sepolia-47600000-witness.tar.zst' witness_tar_url='https://github.com/ethereum-optimism/chain-test-data/releases/download/kona-2026-08-13-op-sepolia-47600000-v2' verbosity='': (prepare-witness-data witness_tar witness_tar_url)
   #!/usr/bin/env bash
 
   HOST_BIN_PATH="{{KONA_CLIENT_ROOT}}/../../../target/debug/kona-host"

--- a/rust/kona/crates/proof/proof/src/l2/chain_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l2/chain_provider.rs
@@ -1,7 +1,7 @@
 //! Contains the concrete implementation of the [`L2ChainProvider`] trait for the client program.
 
 use crate::{HintType, eip2935::eip_2935_history_lookup, errors::OracleProviderError};
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
 use alloy_consensus::{BlockBody, Header};
 use alloy_eips::eip2718::Decodable2718;
 use alloy_primitives::{Address, B256, Bytes};
@@ -30,12 +30,29 @@ pub struct OracleL2ChainProvider<T: CommsClient> {
     cursor: Option<Arc<RwLock<PipelineCursor>>>,
     /// The L2 chain ID to use for the provider's hints.
     chain_id: Option<u64>,
+    /// Cache of canonical headers and their hashes, keyed by block number, for ancestors of the
+    /// L2 safe head.
+    ///
+    /// Entries are discovered by walking parent hashes (or EIP-2935 lookups) back from the safe
+    /// head, so they are canonical by construction, and the safe head only advances along the
+    /// same lineage within a program run, so entries never need invalidation. This turns the
+    /// by-number lookups of span batch overlap validation (one per overlapped block, walked in
+    /// ascending order) from a quadratic number of header preimage reads into a linear one, and
+    /// mirrors [`OracleL1ChainProvider`](crate::l1::OracleL1ChainProvider)'s by-number cache.
+    header_by_number: BTreeMap<u64, (B256, Header)>,
 }
 
 impl<T: CommsClient> OracleL2ChainProvider<T> {
     /// Creates a new [`OracleL2ChainProvider`] with the given boot information and oracle client.
     pub const fn new(l2_head: B256, rollup_config: Arc<RollupConfig>, oracle: Arc<T>) -> Self {
-        Self { l2_head, rollup_config, oracle, cursor: None, chain_id: None }
+        Self {
+            l2_head,
+            rollup_config,
+            oracle,
+            cursor: None,
+            chain_id: None,
+            header_by_number: BTreeMap::new(),
+        }
     }
 
     /// Sets the L2 chain ID to use for the provider's hints.
@@ -59,16 +76,36 @@ impl<T: CommsClient> OracleL2ChainProvider<T> {
 
 impl<T: CommsClient> OracleL2ChainProvider<T> {
     /// Returns a [Header] corresponding to the given L2 block number, by walking back from the
-    /// L2 safe head.
-    async fn header_by_number(&self, block_number: u64) -> Result<Header, OracleProviderError> {
-        // Fetch the starting block header.
-        let mut current_hash = self.l2_safe_head().await?;
-        let mut header = self.header_by_hash(current_hash)?;
-
-        // Check if the block number is in range. If not, we can fail early.
-        if block_number > header.number {
-            return Err(OracleProviderError::BlockNumberPastHead(block_number, header.number));
+    /// closest cached ancestor, or from the L2 safe head when nothing closer is cached.
+    async fn header_by_number(&mut self, block_number: u64) -> Result<Header, OracleProviderError> {
+        if let Some((_, header)) = self.header_by_number.get(&block_number) {
+            return Ok(header.clone());
         }
+
+        // Start from the closest cached ancestor whose number is greater than the target,
+        // falling back to the L2 safe head when no usable cache entry exists.
+        let cached_ancestor = block_number
+            .checked_add(1)
+            .and_then(|n| self.header_by_number.range(n..).next())
+            .map(|(_, (hash, header))| (*hash, header.clone()));
+        let (mut current_hash, mut header) = match cached_ancestor {
+            Some(entry) => entry,
+            None => {
+                // Fetch the starting block header.
+                let safe_hash = self.l2_safe_head().await?;
+                let safe_header = self.header_by_hash(safe_hash)?;
+
+                // Check if the block number is in range. If not, we can fail early.
+                if block_number > safe_header.number {
+                    return Err(OracleProviderError::BlockNumberPastHead(
+                        block_number,
+                        safe_header.number,
+                    ));
+                }
+                self.header_by_number.insert(safe_header.number, (safe_hash, safe_header.clone()));
+                (safe_hash, safe_header)
+            }
+        };
 
         let mut linear_fallback = false;
         while header.number > block_number {
@@ -96,6 +133,9 @@ impl<T: CommsClient> OracleL2ChainProvider<T> {
                 current_hash = header.parent_hash;
                 header = self.header_by_hash(header.parent_hash)?;
             }
+            // Cache every header discovered on the walk, so later lookups at or below this
+            // height resume from here instead of re-reading the chain above it.
+            self.header_by_number.insert(header.number, (current_hash, header.clone()));
         }
 
         Ok(header)
@@ -282,5 +322,140 @@ impl<T: CommsClient> TrieHinter for OracleL2ChainProvider<T> {
                 .send(self.oracle.as_ref())
                 .await
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_rlp::Encodable;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use kona_preimage::{HintWriterClient, PreimageOracleClient, errors::PreimageOracleResult};
+
+    /// A minimal in-memory [`CommsClient`] used to drive [`OracleL2ChainProvider`] in tests.
+    #[derive(Clone, Default)]
+    struct MockOracle {
+        preimages: Arc<BTreeMap<PreimageKey, Vec<u8>>>,
+        get_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl PreimageOracleClient for MockOracle {
+        async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
+            self.get_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.preimages.get(&key).expect("missing preimage in mock").clone())
+        }
+
+        async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
+            let v = self.get(key).await?;
+            buf.copy_from_slice(&v);
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl HintWriterClient for MockOracle {
+        async fn write(&self, _hint: &str) -> PreimageOracleResult<()> {
+            Ok(())
+        }
+    }
+
+    /// Build a linear chain of `n` headers and return the headers (oldest first) plus a
+    /// preimage map keyed by `Keccak256(header_hash)`.
+    fn build_chain(n: u64) -> (Vec<Header>, BTreeMap<PreimageKey, Vec<u8>>) {
+        let mut headers = Vec::with_capacity(n as usize);
+        let mut parent_hash = B256::ZERO;
+        for i in 0..n {
+            let header =
+                Header { number: i, parent_hash, timestamp: 1_000 + i, ..Default::default() };
+            parent_hash = header.hash_slow();
+            headers.push(header);
+        }
+        let mut preimages = BTreeMap::new();
+        for h in &headers {
+            let mut rlp = Vec::new();
+            h.encode(&mut rlp);
+            preimages.insert(PreimageKey::new(*h.hash_slow(), PreimageKeyType::Keccak256), rlp);
+        }
+        (headers, preimages)
+    }
+
+    /// Provider anchored at the last header of `headers`, with a pre-Isthmus rollup config so
+    /// the linear parent-hash walk is exercised.
+    fn provider(
+        headers: &[Header],
+        preimages: BTreeMap<PreimageKey, Vec<u8>>,
+    ) -> (OracleL2ChainProvider<MockOracle>, Arc<AtomicUsize>) {
+        let oracle =
+            MockOracle { preimages: Arc::new(preimages), get_calls: Arc::new(AtomicUsize::new(0)) };
+        let calls = oracle.get_calls.clone();
+        let head = headers.last().unwrap().hash_slow();
+        (
+            OracleL2ChainProvider::new(head, Arc::new(RollupConfig::default()), Arc::new(oracle)),
+            calls,
+        )
+    }
+
+    // Note: tests run on a multi-threaded runtime because `header_by_hash` goes through
+    // `crate::block_on`, whose std implementation uses `tokio::task::block_in_place`.
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn header_by_number_returns_correct_header() {
+        let (headers, preimages) = build_chain(10);
+        let (mut p, _) = provider(&headers, preimages);
+
+        for target in 0..10 {
+            let header = p.header_by_number(target).await.unwrap();
+            assert_eq!(header.number, target);
+            assert_eq!(header.hash_slow(), headers[target as usize].hash_slow());
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn header_by_number_ascending_overlap_walk_is_linear() {
+        // Pins the fault proof cost of span batch overlap validation, which looks up each
+        // overlapped block in ascending order: without the by-number cache, each lookup
+        // re-walks from the safe head, so five lookups against a five-deep overlap cost
+        // 5 + 4 + 3 + 2 + 1 = 15 header preimage reads. With the cache, the first (lowest)
+        // lookup walks the range once and the rest are hits: 5 reads total.
+        let (headers, preimages) = build_chain(6);
+        let (mut p, calls) = provider(&headers, preimages);
+
+        for target in 1..=5 {
+            let header = p.header_by_number(target).await.unwrap();
+            assert_eq!(header.number, target);
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 5);
+
+        // Repeating the sweep is free.
+        for target in 1..=5 {
+            p.header_by_number(target).await.unwrap();
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 5);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn header_by_number_resumes_from_closest_cached_ancestor() {
+        let (headers, preimages) = build_chain(20);
+        let (mut p, calls) = provider(&headers, preimages);
+
+        // Walk head (19) down to 15: 5 reads.
+        p.header_by_number(15).await.unwrap();
+        let after_first = calls.load(Ordering::SeqCst);
+        assert_eq!(after_first, 5);
+
+        // Walk further back to 10: resumes from cached 15, not from the head, so only 5
+        // additional reads (14, 13, 12, 11, 10).
+        p.header_by_number(10).await.unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), after_first + 5);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn header_by_number_rejects_numbers_past_head() {
+        let (headers, preimages) = build_chain(5);
+        let (mut p, _) = provider(&headers, preimages);
+
+        let err = p.header_by_number(99).await.unwrap_err();
+        assert!(matches!(err, OracleProviderError::BlockNumberPastHead(99, 4)));
     }
 }

--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -188,6 +188,8 @@ where
                             return Err(PipelineError::NotEnoughData.temp());
                         }
                         BatchValidity::Undecided | BatchValidity::Future => {
+                            // Undecided: the span was already consumed and is skipped, not
+                            // retried.
                             return Err(PipelineError::NotEnoughData.temp());
                         }
                     }

--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -148,8 +148,8 @@ where
                 Batch::Span(b) => {
                     #[cfg(feature = "metrics")]
                     let start = std::time::Instant::now();
-                    let (mut validity, parent_block) = b
-                        .check_batch_prefix(
+                    let validity = b
+                        .check_batch_holocene(
                             self.config.as_ref(),
                             l1_origins,
                             parent,
@@ -162,26 +162,6 @@ where
                         crate::metrics::Metrics::PIPELINE_CHECK_BATCH_PREFIX,
                         start.elapsed().as_secs_f64()
                     );
-
-                    // The prefix checks do not validate overlap contents against the safe
-                    // chain. A span batch that disagrees with the safe chain — possible since
-                    // interop block replacement — must be dropped as a whole, so that the
-                    // remainder of an invalidated lineage cannot be spliced onto the canonical
-                    // chain. See [`SpanBatch::check_batch_overlap`] for details.
-                    if validity.is_accept() {
-                        let parent_block =
-                            parent_block.expect("accepted prefix checks return a parent block");
-                        if parent_block.block_info.number < parent.block_info.number {
-                            validity = b
-                                .check_batch_overlap(
-                                    self.config.as_ref(),
-                                    parent_block,
-                                    parent,
-                                    &mut self.fetcher,
-                                )
-                                .await;
-                        }
-                    }
 
                     kona_macros::inc!(
                         gauge,
@@ -221,8 +201,8 @@ where
             Ok(None) => Err(PipelineError::NotEnoughData.temp()),
             Err(e) => {
                 warn!(target: "batch_span", "Extracting singular batches from span batch failed: {}", e);
-                // If singular batch extraction fails, it should be handled the same as a
-                // dropped batch during span batch prefix checks.
+                // If singular batch extraction fails, handle it like a batch dropped during the
+                // Holocene span batch checks.
                 self.flush();
                 Err(PipelineError::NotEnoughData.temp())
             }

--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -553,6 +553,125 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_overlap_mismatch_drops_span_and_flushes_unread_batches() {
+        let trace_store: TraceStorage = Default::default();
+        let layer = CollectingLayer::new(trace_store.clone());
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let parent_hash = b256!("1111111111111111111111111111111111111111000000000000000000000000");
+        let l1_block_hash =
+            b256!("3333333333333333333333333333333333333333000000000000000000000000");
+        let config = Arc::new(RollupConfig {
+            seq_window_size: 100,
+            block_time: 10,
+            hardforks: HardForkConfig {
+                delta_time: Some(0),
+                holocene_time: Some(0),
+                ..Default::default()
+            },
+            genesis: ChainGenesis {
+                l2: BlockNumHash { number: 40, hash: parent_hash },
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let l1_block =
+            BlockInfo { number: 10, timestamp: 5, hash: l1_block_hash, ..Default::default() };
+        let l1_blocks = vec![l1_block];
+        // A two-block overlap: blocks 41 and 42 are already safe.
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo { number: 42, timestamp: 20, ..Default::default() },
+            l1_origin: l1_block.id(),
+            ..Default::default()
+        };
+        let l2_parent = L2BlockInfo {
+            block_info: BlockInfo {
+                number: 40,
+                hash: parent_hash,
+                timestamp: 0,
+                ..Default::default()
+            },
+            l1_origin: BlockNumHash { number: 9, ..Default::default() },
+            ..Default::default()
+        };
+        // The canonical overlapped blocks carry only their L1 info deposit (origin 9).
+        let l1_info = kona_protocol::L1BlockInfoBedrock::new(
+            9,
+            0,
+            0,
+            alloy_primitives::B256::ZERO,
+            0,
+            alloy_primitives::Address::ZERO,
+            alloy_primitives::U256::ZERO,
+            alloy_primitives::U256::ZERO,
+        );
+        let info_tx = op_alloy_consensus::OpTxEnvelope::Deposit(alloy_primitives::Sealed::new(
+            op_alloy_consensus::TxDeposit {
+                input: l1_info.encode_calldata(),
+                ..Default::default()
+            },
+        ));
+        let op_block_41 = OpBlock {
+            header: Header { number: 41, ..Default::default() },
+            body: BlockBody {
+                transactions: vec![info_tx.clone()],
+                ommers: vec![],
+                withdrawals: None,
+            },
+        };
+        let op_block_42 = OpBlock {
+            header: Header { number: 42, ..Default::default() },
+            body: BlockBody { transactions: vec![info_tx], ommers: vec![], withdrawals: None },
+        };
+
+        // The span's first overlapped element matches the safe chain; only the second
+        // diverges (it carries a transaction the canonical block does not), exercising the
+        // overlap comparison loop beyond its first iteration.
+        let span_batch = SpanBatch {
+            batches: vec![
+                SpanBatchElement { epoch_num: 9, timestamp: 10, ..Default::default() },
+                SpanBatchElement {
+                    epoch_num: 9,
+                    timestamp: 20,
+                    transactions: vec![alloy_primitives::Bytes::from_static(&[0x02, 0x01])],
+                },
+                SpanBatchElement { epoch_num: 10, timestamp: 30, ..Default::default() },
+            ],
+            parent_check: FixedBytes::<20>::from_slice(&parent_hash[..20]),
+            l1_origin_check: FixedBytes::<20>::from_slice(&l1_block_hash[..20]),
+            ..Default::default()
+        };
+
+        // An unread sentinel sits behind the conflicting span in the channel (batches are
+        // served back-to-front): it only surviving the drop would prove the flush was
+        // signaled but not performed.
+        let sentinel = Batch::Single(SingleBatch::default());
+        let mut prev =
+            TestBatchStreamProvider::new(vec![Ok(sentinel), Ok(Batch::Span(span_batch))]);
+        prev.origin = Some(l1_block);
+
+        let mut provider = TestL2ChainProvider::default();
+        provider.blocks.push(l2_parent);
+        provider.op_blocks.push(op_block_41);
+        provider.op_blocks.push(op_block_42);
+
+        let mut stream = BatchStream::new(prev, config, provider);
+        let err = stream.next_batch(l2_safe_head, &l1_blocks).await.unwrap_err();
+
+        assert_eq!(err, PipelineError::NotEnoughData.temp());
+        assert!(stream.span.is_none());
+        assert_eq!(stream.span_buffer_size(), 0);
+        // The flush must have discarded the unread sentinel along with the rest of the channel.
+        assert!(stream.prev.batches.is_empty());
+
+        let logs = trace_store.get_by_level(tracing::Level::WARN);
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("overlapped block's tx count does not match"));
+    }
+
+    #[tokio::test]
     async fn test_single_batch_pass_through() {
         let data = vec![Ok(Batch::Single(SingleBatch::default()))];
         let config = Arc::new(RollupConfig {

--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -148,8 +148,8 @@ where
                 Batch::Span(b) => {
                     #[cfg(feature = "metrics")]
                     let start = std::time::Instant::now();
-                    let (validity, _) = b
-                        .check_batch_holocene(
+                    let (mut validity, parent_block) = b
+                        .check_batch_prefix(
                             self.config.as_ref(),
                             l1_origins,
                             parent,
@@ -157,13 +157,31 @@ where
                             &mut self.fetcher,
                         )
                         .await;
-                    // Note: since the overlap content checks joined check_batch_holocene, this
-                    // histogram includes their L2 payload fetches for overlapping span batches.
                     kona_macros::record!(
                         histogram,
                         crate::metrics::Metrics::PIPELINE_CHECK_BATCH_PREFIX,
                         start.elapsed().as_secs_f64()
                     );
+
+                    // The prefix checks do not validate overlap contents against the safe
+                    // chain. A span batch that disagrees with the safe chain — possible since
+                    // interop block replacement — must be dropped as a whole, so that the
+                    // remainder of an invalidated lineage cannot be spliced onto the canonical
+                    // chain. See [`SpanBatch::check_batch_overlap`] for details.
+                    if validity.is_accept() {
+                        let parent_block =
+                            parent_block.expect("accepted prefix checks return a parent block");
+                        if parent_block.block_info.number < parent.block_info.number {
+                            validity = b
+                                .check_batch_overlap(
+                                    self.config.as_ref(),
+                                    parent_block,
+                                    parent,
+                                    &mut self.fetcher,
+                                )
+                                .await;
+                        }
+                    }
 
                     kona_macros::inc!(
                         gauge,

--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -157,6 +157,8 @@ where
                             &mut self.fetcher,
                         )
                         .await;
+                    // Note: since the overlap content checks joined check_batch_holocene, this
+                    // histogram includes their L2 payload fetches for overlapping span batches.
                     kona_macros::record!(
                         histogram,
                         crate::metrics::Metrics::PIPELINE_CHECK_BATCH_PREFIX,
@@ -477,9 +479,27 @@ mod test {
             l1_origin: BlockNumHash { number: 9, ..Default::default() },
             ..Default::default()
         };
+        // A valid overlapped canonical block (L1 info deposit only, origin 9), so the overlap
+        // content checks pass and singular batch extraction is reached.
+        let l1_info = kona_protocol::L1BlockInfoBedrock::new(
+            9,
+            0,
+            0,
+            alloy_primitives::B256::ZERO,
+            0,
+            alloy_primitives::Address::ZERO,
+            alloy_primitives::U256::ZERO,
+            alloy_primitives::U256::ZERO,
+        );
+        let info_tx = op_alloy_consensus::OpTxEnvelope::Deposit(alloy_primitives::Sealed::new(
+            op_alloy_consensus::TxDeposit {
+                input: l1_info.encode_calldata(),
+                ..Default::default()
+            },
+        ));
         let op_block = OpBlock {
             header: Header { number: 41, ..Default::default() },
-            body: BlockBody { transactions: vec![], ommers: vec![], withdrawals: None },
+            body: BlockBody { transactions: vec![info_tx], ommers: vec![], withdrawals: None },
         };
 
         let span_batch = SpanBatch {
@@ -507,12 +527,9 @@ mod test {
         assert!(stream.span.is_none());
         assert_eq!(stream.span_buffer_size(), 0);
 
-        // The overlap content checks (part of check_batch_holocene) reject the batch before
-        // singular batch extraction gets a chance to: the overlapped canonical block is not a
-        // valid L2 block (no L1 info deposit), so L2BlockInfo extraction fails.
         let logs = trace_store.get_by_level(tracing::Level::WARN);
         assert_eq!(logs.len(), 1);
-        assert!(logs[0].contains("failed to extract L2BlockInfo from execution payload"));
+        assert!(logs[0].contains("Extracting singular batches from span batch failed: Future batch L1 origin before safe head"));
     }
 
     #[tokio::test]

--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -149,7 +149,7 @@ where
                     #[cfg(feature = "metrics")]
                     let start = std::time::Instant::now();
                     let (validity, _) = b
-                        .check_batch_prefix(
+                        .check_batch_holocene(
                             self.config.as_ref(),
                             l1_origins,
                             parent,
@@ -507,9 +507,12 @@ mod test {
         assert!(stream.span.is_none());
         assert_eq!(stream.span_buffer_size(), 0);
 
+        // The overlap content checks (part of check_batch_holocene) reject the batch before
+        // singular batch extraction gets a chance to: the overlapped canonical block is not a
+        // valid L2 block (no L1 info deposit), so L2BlockInfo extraction fails.
         let logs = trace_store.get_by_level(tracing::Level::WARN);
         assert_eq!(logs.len(), 1);
-        assert!(logs[0].contains("Extracting singular batches from span batch failed: Future batch L1 origin before safe head"));
+        assert!(logs[0].contains("failed to extract L2BlockInfo from execution payload"));
     }
 
     #[tokio::test]

--- a/rust/kona/crates/protocol/derive/src/test_utils/batch_stream.rs
+++ b/rust/kona/crates/protocol/derive/src/test_utils/batch_stream.rs
@@ -41,7 +41,12 @@ impl OriginProvider for TestBatchStreamProvider {
 
 #[async_trait]
 impl BatchStreamProvider for TestBatchStreamProvider {
-    fn flush(&mut self) {}
+    fn flush(&mut self) {
+        // Discard the unread remainder of the channel like the real provider does, so tests
+        // can assert that a flush actually dropped queued batches rather than only being
+        // signaled.
+        self.batches.clear();
+    }
 
     async fn next_batch(&mut self) -> PipelineResult<Batch> {
         self.batches.pop().ok_or(PipelineError::Eof.temp())?

--- a/rust/kona/crates/protocol/protocol/src/batch/span.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/span.rs
@@ -532,6 +532,10 @@ impl SpanBatch {
     /// replacement — describes a different history and is dropped as a whole, so that its
     /// elements past the safe head cannot be applied. Returns [`BatchValidity::Undecided`] if a
     /// canonical payload cannot be fetched right now.
+    ///
+    /// The prefix rules must have accepted the batch first: `parent_block` must be the
+    /// prefix-determined parent (an ancestor of, or equal to, `l2_safe_head`), and the batch must
+    /// extend past the safe head — these bound the loop and the element indexing.
     pub async fn check_batch_overlap<BV: BatchValidationProvider>(
         &self,
         cfg: &RollupConfig,
@@ -759,11 +763,9 @@ impl SpanBatch {
             return (BatchValidity::Drop(BatchDropReason::EpochTooOld), None);
         }
 
-        // The prefix rules only anchor the batch at its parent; they do not validate the contents
-        // of elements that overlap the safe chain. A span batch whose overlap disagrees with the
-        // safe chain — possible since interop block replacement — must be dropped as a whole, so
-        // that the remainder of an invalidated lineage cannot be spliced onto the canonical chain.
-        // The loop is empty if the batch does not overlap (parent_block == l2_safe_head).
+        // The prefix rules only anchor the batch at its parent; any overlap content must also
+        // agree with the safe chain, see [`Self::check_batch_overlap`]. No-op without overlap
+        // (parent_block == l2_safe_head).
         let overlap_validity =
             self.check_batch_overlap(cfg, parent_block, l2_safe_head, fetcher).await;
         if !overlap_validity.is_accept() {
@@ -2368,10 +2370,28 @@ mod tests {
             l1_origin: BlockNumHash { number: 9, ..Default::default() },
             ..Default::default()
         };
+        // A valid overlapped canonical block (L1 info deposit only, origin 9), so the overlap
+        // content checks pass and the per-element origin checks are reached.
+        let l1_info = crate::L1BlockInfoBedrock::new(
+            9,
+            0,
+            0,
+            B256::ZERO,
+            0,
+            alloy_primitives::Address::ZERO,
+            alloy_primitives::U256::ZERO,
+            alloy_primitives::U256::ZERO,
+        );
+        let info_tx = op_alloy_consensus::OpTxEnvelope::Deposit(alloy_primitives::Sealed::new(
+            op_alloy_consensus::TxDeposit {
+                input: l1_info.encode_calldata(),
+                ..Default::default()
+            },
+        ));
         let block = OpBlock {
             header: Header { number: 41, ..Default::default() },
             body: alloy_consensus::BlockBody {
-                transactions: Vec::new(),
+                transactions: vec![info_tx],
                 ommers: Vec::new(),
                 withdrawals: None,
             },
@@ -2390,16 +2410,13 @@ mod tests {
             l1_origin_check: FixedBytes::<20>::from_slice(&l1_block_hash[..20]),
             ..Default::default()
         };
-        // The overlap content checks (part of check_batch_holocene) reject the batch before the
-        // per-element origin checks get a chance to: the overlapped canonical block is not a
-        // valid L2 block (no L1 info deposit), so L2BlockInfo extraction fails.
         assert_eq!(
             batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
-            BatchValidity::Drop(BatchDropReason::L2BlockInfoExtractionFailed)
+            BatchValidity::Drop(BatchDropReason::L1OriginBeforeSafeHead)
         );
         let logs = trace_store.get_by_level(Level::WARN);
         assert_eq!(logs.len(), 1);
-        assert!(logs[0].contains("failed to extract L2BlockInfo from execution payload"));
+        assert!(logs[0].contains("batch L1 origin is before safe head L1 origin"));
     }
 
     #[tokio::test]

--- a/rust/kona/crates/protocol/protocol/src/batch/span.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/span.rs
@@ -385,7 +385,7 @@ impl SpanBatch {
         fetcher: &mut BV,
     ) -> BatchValidity {
         let (prefix_validity, parent_block) =
-            self.check_batch_holocene(cfg, l1_blocks, l2_safe_head, inclusion_block, fetcher).await;
+            self.check_batch_prefix(cfg, l1_blocks, l2_safe_head, inclusion_block, fetcher).await;
         if !prefix_validity.is_accept() {
             return prefix_validity;
         }
@@ -519,9 +519,12 @@ impl SpanBatch {
             }
         }
 
-        // Note: the overlapped blocks were already checked by check_batch_holocene above. This
-        // moves the overlap content check ahead of the per-transaction checks relative to the
-        // pre-Holocene order, which only matters for the validity of batches failing both.
+        // Check overlapped blocks
+        let overlap_validity =
+            self.check_batch_overlap(cfg, parent_block, l2_safe_head, fetcher).await;
+        if !overlap_validity.is_accept() {
+            return overlap_validity;
+        }
 
         BatchValidity::Accept
     }
@@ -603,11 +606,12 @@ impl SpanBatch {
         BatchValidity::Accept
     }
 
-    /// Performs the full set of span batch checks that run post-Holocene, as each batch is being
-    /// loaded in: the prefix rules, plus the overlap content comparison against the safe chain
-    /// (see [`Self::check_batch_overlap`]). Next to the validity, it also returns the parent L2
+    /// Checks the validity of the batch's prefix.
+    ///
+    /// This function is used for post-Holocene hardfork to perform batch validation
+    /// as each batch is being loaded in. Next to the validity, it also returns the parent L2
     /// block as determined during the checks for further consumption.
-    pub async fn check_batch_holocene<BF: BatchValidationProvider>(
+    pub async fn check_batch_prefix<BF: BatchValidationProvider>(
         &self,
         cfg: &RollupConfig,
         l1_origins: &[BlockInfo],
@@ -763,15 +767,6 @@ impl SpanBatch {
         if starting_epoch_num < parent_block.l1_origin.number {
             warn!(target: "batch_span", "dropped batch, epoch is too old, minimum: {:?}", parent_block.block_info.id());
             return (BatchValidity::Drop(BatchDropReason::EpochTooOld), None);
-        }
-
-        // The prefix rules only anchor the batch at its parent; any overlap content must also
-        // agree with the safe chain, see [`Self::check_batch_overlap`]. No-op without overlap
-        // (parent_block == l2_safe_head).
-        let overlap_validity =
-            self.check_batch_overlap(cfg, parent_block, l2_safe_head, fetcher).await;
-        if !overlap_validity.is_accept() {
-            return (overlap_validity, Some(parent_block));
         }
 
         (BatchValidity::Accept, Some(parent_block))

--- a/rust/kona/crates/protocol/protocol/src/batch/span.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/span.rs
@@ -547,6 +547,9 @@ impl SpanBatch {
         fetcher: &mut BV,
     ) -> BatchValidity {
         let parent_num = parent_block.block_info.number;
+        // Reused encoding buffer for the per-transaction comparison below, hoisted out of the
+        // loops to avoid one allocation per compared transaction.
+        let mut buf = Vec::new();
         for i in 0..(l2_safe_head.block_info.number - parent_num) {
             let safe_block_num = parent_num + i + 1;
             let safe_block_payload = match fetcher.block_by_number(safe_block_num).await {
@@ -573,7 +576,7 @@ impl SpanBatch {
             let batch_txs_len = batch_txs.len();
             #[allow(clippy::needless_range_loop)]
             for j in 0..batch_txs_len {
-                let mut buf = Vec::new();
+                buf.clear();
                 safe_block.transactions[j + deposit_count].encode_2718(&mut buf);
                 if buf != batch_txs[j].0 {
                     warn!(target: "batch_span", "overlapped block's transaction does not match");

--- a/rust/kona/crates/protocol/protocol/src/batch/span.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/span.rs
@@ -609,11 +609,8 @@ impl SpanBatch {
         BatchValidity::Accept
     }
 
-    /// Checks the validity of the batch's prefix.
-    ///
-    /// This function is used for post-Holocene hardfork to perform batch validation
-    /// as each batch is being loaded in. Next to the validity, it also returns the parent L2
-    /// block as determined during the checks for further consumption.
+    /// Checks the span batch prefix rules shared by the legacy full checks and the Holocene
+    /// checks. It also returns the parent L2 block determined during validation.
     pub async fn check_batch_prefix<BF: BatchValidationProvider>(
         &self,
         cfg: &RollupConfig,
@@ -773,6 +770,29 @@ impl SpanBatch {
         }
 
         (BatchValidity::Accept, Some(parent_block))
+    }
+
+    /// Checks the Holocene span batch rules: prefix validity followed by overlap validity.
+    pub async fn check_batch_holocene<BV: BatchValidationProvider>(
+        &self,
+        cfg: &RollupConfig,
+        l1_origins: &[BlockInfo],
+        l2_safe_head: L2BlockInfo,
+        inclusion_block: &BlockInfo,
+        fetcher: &mut BV,
+    ) -> BatchValidity {
+        let (prefix_validity, parent_block) =
+            self.check_batch_prefix(cfg, l1_origins, l2_safe_head, inclusion_block, fetcher).await;
+        if !prefix_validity.is_accept() {
+            return prefix_validity;
+        }
+        self.check_batch_overlap(
+            cfg,
+            parent_block.expect("accepted prefix checks return a parent block"),
+            l2_safe_head,
+            fetcher,
+        )
+        .await
     }
 }
 

--- a/rust/kona/crates/protocol/protocol/src/batch/span.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/span.rs
@@ -385,7 +385,7 @@ impl SpanBatch {
         fetcher: &mut BV,
     ) -> BatchValidity {
         let (prefix_validity, parent_block) =
-            self.check_batch_prefix(cfg, l1_blocks, l2_safe_head, inclusion_block, fetcher).await;
+            self.check_batch_holocene(cfg, l1_blocks, l2_safe_head, inclusion_block, fetcher).await;
         if !prefix_validity.is_accept() {
             return prefix_validity;
         }
@@ -519,78 +519,91 @@ impl SpanBatch {
             }
         }
 
-        // Check overlapped blocks
+        // Note: the overlapped blocks were already checked by check_batch_holocene above. This
+        // moves the overlap content check ahead of the per-transaction checks relative to the
+        // pre-Holocene order, which only matters for the validity of batches failing both.
+
+        BatchValidity::Accept
+    }
+
+    /// Validates the portion of a span batch that overlaps the safe chain: every overlapped
+    /// element's transactions and L1 origin must match the canonical block at the same height.
+    /// A batch whose overlap disagrees with the safe chain — possible since interop block
+    /// replacement — describes a different history and is dropped as a whole, so that its
+    /// elements past the safe head cannot be applied. Returns [`BatchValidity::Undecided`] if a
+    /// canonical payload cannot be fetched right now.
+    pub async fn check_batch_overlap<BV: BatchValidationProvider>(
+        &self,
+        cfg: &RollupConfig,
+        parent_block: L2BlockInfo,
+        l2_safe_head: L2BlockInfo,
+        fetcher: &mut BV,
+    ) -> BatchValidity {
         let parent_num = parent_block.block_info.number;
-        let next_timestamp = l2_safe_head.block_info.timestamp + cfg.block_time;
-        if self.starting_timestamp() < next_timestamp {
-            for i in 0..(l2_safe_head.block_info.number - parent_num) {
-                let safe_block_num = parent_num + i + 1;
-                let safe_block_payload = match fetcher.block_by_number(safe_block_num).await {
-                    Ok(p) => p,
-                    Err(e) => {
-                        warn!(target: "batch_span", "failed to fetch block number {safe_block_num}: {e}");
-                        return BatchValidity::Undecided;
-                    }
-                };
-                let safe_block = &safe_block_payload.body;
-                let batch_txs = &self.batches[i as usize].transactions;
-                // Execution payload has deposit txs but batch does not.
-                let deposit_count: usize = safe_block
-                    .transactions
-                    .iter()
-                    .map(|tx| if tx.is_deposit() { 1 } else { 0 })
-                    .sum();
-                if safe_block.transactions.len() - deposit_count != batch_txs.len() {
+        for i in 0..(l2_safe_head.block_info.number - parent_num) {
+            let safe_block_num = parent_num + i + 1;
+            let safe_block_payload = match fetcher.block_by_number(safe_block_num).await {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!(target: "batch_span", "failed to fetch block number {safe_block_num}: {e}");
+                    return BatchValidity::Undecided;
+                }
+            };
+            let safe_block = &safe_block_payload.body;
+            let batch_txs = &self.batches[i as usize].transactions;
+            // Execution payload has deposit txs but batch does not.
+            let deposit_count: usize =
+                safe_block.transactions.iter().map(|tx| if tx.is_deposit() { 1 } else { 0 }).sum();
+            if safe_block.transactions.len() - deposit_count != batch_txs.len() {
+                warn!(
+                    target: "batch_span",
+                    "overlapped block's tx count does not match, safe_block_txs: {}, batch_txs: {}",
+                    safe_block.transactions.len(),
+                    batch_txs.len()
+                );
+                return BatchValidity::Drop(BatchDropReason::OverlappedTxCountMismatch);
+            }
+            let batch_txs_len = batch_txs.len();
+            #[allow(clippy::needless_range_loop)]
+            for j in 0..batch_txs_len {
+                let mut buf = Vec::new();
+                safe_block.transactions[j + deposit_count].encode_2718(&mut buf);
+                if buf != batch_txs[j].0 {
+                    warn!(target: "batch_span", "overlapped block's transaction does not match");
+                    return BatchValidity::Drop(BatchDropReason::OverlappedTxMismatch);
+                }
+            }
+            let safe_block_ref = match L2BlockInfo::from_block_and_genesis(
+                &safe_block_payload,
+                &cfg.genesis,
+            ) {
+                Ok(r) => r,
+                Err(e) => {
                     warn!(
                         target: "batch_span",
-                        "overlapped block's tx count does not match, safe_block_txs: {}, batch_txs: {}",
-                        safe_block.transactions.len(),
-                        batch_txs.len()
+                        "failed to extract L2BlockInfo from execution payload, hash: {}, err: {e}",
+                        safe_block_payload.header.hash_slow()
                     );
-                    return BatchValidity::Drop(BatchDropReason::OverlappedTxCountMismatch);
+                    return BatchValidity::Drop(BatchDropReason::L2BlockInfoExtractionFailed);
                 }
-                let batch_txs_len = batch_txs.len();
-                #[allow(clippy::needless_range_loop)]
-                for j in 0..batch_txs_len {
-                    let mut buf = Vec::new();
-                    safe_block.transactions[j + deposit_count].encode_2718(&mut buf);
-                    if buf != batch_txs[j].0 {
-                        warn!(target: "batch_span", "overlapped block's transaction does not match");
-                        return BatchValidity::Drop(BatchDropReason::OverlappedTxMismatch);
-                    }
-                }
-                let safe_block_ref = match L2BlockInfo::from_block_and_genesis(
-                    &safe_block_payload,
-                    &cfg.genesis,
-                ) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        warn!(
-                            target: "batch_span",
-                            "failed to extract L2BlockInfo from execution payload, hash: {}, err: {e}",
-                            safe_block_payload.header.hash_slow()
-                        );
-                        return BatchValidity::Drop(BatchDropReason::L2BlockInfoExtractionFailed);
-                    }
-                };
-                if safe_block_ref.l1_origin.number != self.batches[i as usize].epoch_num {
-                    warn!(
-                        "overlapped block's L1 origin number does not match {}, {}",
-                        safe_block_ref.l1_origin.number, self.batches[i as usize].epoch_num
-                    );
-                    return BatchValidity::Drop(BatchDropReason::OverlappedL1OriginMismatch);
-                }
+            };
+            if safe_block_ref.l1_origin.number != self.batches[i as usize].epoch_num {
+                warn!(
+                    "overlapped block's L1 origin number does not match {}, {}",
+                    safe_block_ref.l1_origin.number, self.batches[i as usize].epoch_num
+                );
+                return BatchValidity::Drop(BatchDropReason::OverlappedL1OriginMismatch);
             }
         }
 
         BatchValidity::Accept
     }
 
-    /// Checks the validity of the batch's prefix.
-    ///
-    /// This function is used for post-Holocene hardfork to perform batch validation
-    /// as each batch is being loaded in.
-    pub async fn check_batch_prefix<BF: BatchValidationProvider>(
+    /// Performs the full set of span batch checks that run post-Holocene, as each batch is being
+    /// loaded in: the prefix rules, plus the overlap content comparison against the safe chain
+    /// (see [`Self::check_batch_overlap`]). Next to the validity, it also returns the parent L2
+    /// block as determined during the checks for further consumption.
+    pub async fn check_batch_holocene<BF: BatchValidationProvider>(
         &self,
         cfg: &RollupConfig,
         l1_origins: &[BlockInfo],
@@ -744,6 +757,17 @@ impl SpanBatch {
         if starting_epoch_num < parent_block.l1_origin.number {
             warn!(target: "batch_span", "dropped batch, epoch is too old, minimum: {:?}", parent_block.block_info.id());
             return (BatchValidity::Drop(BatchDropReason::EpochTooOld), None);
+        }
+
+        // The prefix rules only anchor the batch at its parent; they do not validate the contents
+        // of elements that overlap the safe chain. A span batch whose overlap disagrees with the
+        // safe chain — possible since interop block replacement — must be dropped as a whole, so
+        // that the remainder of an invalidated lineage cannot be spliced onto the canonical chain.
+        // The loop is empty if the batch does not overlap (parent_block == l2_safe_head).
+        let overlap_validity =
+            self.check_batch_overlap(cfg, parent_block, l2_safe_head, fetcher).await;
+        if !overlap_validity.is_accept() {
+            return (overlap_validity, Some(parent_block));
         }
 
         (BatchValidity::Accept, Some(parent_block))
@@ -2366,13 +2390,16 @@ mod tests {
             l1_origin_check: FixedBytes::<20>::from_slice(&l1_block_hash[..20]),
             ..Default::default()
         };
+        // The overlap content checks (part of check_batch_holocene) reject the batch before the
+        // per-element origin checks get a chance to: the overlapped canonical block is not a
+        // valid L2 block (no L1 info deposit), so L2BlockInfo extraction fails.
         assert_eq!(
             batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
-            BatchValidity::Drop(BatchDropReason::L1OriginBeforeSafeHead)
+            BatchValidity::Drop(BatchDropReason::L2BlockInfoExtractionFailed)
         );
         let logs = trace_store.get_by_level(Level::WARN);
         assert_eq!(logs.len(), 1);
-        assert!(logs[0].contains("batch L1 origin is before safe head L1 origin"));
+        assert!(logs[0].contains("failed to extract L2BlockInfo from execution payload"));
     }
 
     #[tokio::test]

--- a/rust/kona/crates/protocol/protocol/src/batch/span.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/span.rs
@@ -700,7 +700,9 @@ impl SpanBatch {
                 Ok(block) => block,
                 Err(e) => {
                     warn!(target: "batch_span", "failed to fetch L2 block number {parent_num}: {e}");
-                    // Unable to validate the batch for now. Retry later.
+                    // Unable to validate the batch right now. Only the pre-Holocene
+                    // BatchQueue retains the batch for a retry; the Holocene BatchStream has
+                    // already consumed it and skips it.
                     return (BatchValidity::Undecided, None);
                 }
             };

--- a/rust/kona/tests/proofs/span_batch_overlap_test.go
+++ b/rust/kona/tests/proofs/span_batch_overlap_test.go
@@ -1,0 +1,162 @@
+package proofs
+
+import (
+	"math/big"
+	"testing"
+
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/rust/kona/tests/proofs/helpers"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpanBatchOverlapContent pins the post-Holocene span batch overlap content rule, in both
+// op-node (driving derivation below) and kona-client (replaying it as the fault proof program):
+// a span batch whose overlap section disagrees with the safe chain must be dropped as a whole,
+// with a channel flush, so that the remainder of an invalidated lineage cannot be spliced onto
+// the canonical chain.
+//
+// The scenario mirrors the interop block-replacement incident shape using batcher equivocation:
+//
+//  1. Channel 1 carries span [1, 2*, 3] where 2*'s transaction signature is invalidated.
+//     Deriving it yields block 1, then a deposits-only replacement 2' for the invalid payload,
+//     and a channel flush that discards element 3. The safe chain now disagrees with the
+//     batched lineage at height 2.
+//  2. Channel 2 carries the same invalidated lineage [1, 2*, 3] again — the incident's
+//     "re-derivation walk" over a batch containing a since-replaced block. Its overlap
+//     (heights 1-2) must be validated against the safe chain: element 2* conflicts with 2'.
+//     With the overlap content rule, the whole batch is dropped and the channel flushed.
+//     Without it, element 3 — built on the invalidated 2* — is spliced onto 2', producing
+//     another deposits-only replacement 3' derived from a lineage that was never canonical.
+//  3. Channel 3 carries the canonical continuation 3” (built on 2', with a live transaction).
+//     With the rule, it applies and the safe head becomes 3”. Without it, height 3 is already
+//     (wrongly) occupied by 3', and the canonical continuation is dropped as a past batch —
+//     the equivocating channel's tail wins over the canonical chain.
+//
+// The fault proof program then replays the same L1 data with honest claims taken from the
+// op-node-derived chain at every height 0..3. Height 3 is where a client without the overlap
+// rule derives 3' instead of 3”, so an unfixed kona-client rejects the honest claim there,
+// pinning that the Go and Rust implementations enforce the same rule.
+func TestSpanBatchOverlapContent(gt *testing.T) {
+	type testCase struct{}
+
+	// invalidPayload invalidates the signature for the second transaction in the block
+	// (the first is the L1 info deposit). This yields an invalid payload in the engine,
+	// which post-Holocene is replaced with a deposits-only block.
+	invalidPayload := func(block *types.Block) *types.Block {
+		alice := types.NewCancunSigner(big.NewInt(901))
+		txs := block.Transactions()
+		newTx, err := txs[1].WithSignature(alice, make([]byte, 65))
+		if err != nil {
+			panic(err)
+		}
+		txs[1] = newTx
+		return block
+	}
+
+	runTest := func(gt *testing.T, testCfg *helpers.TestCfg[testCase]) {
+		t := actionsHelpers.NewDefaultTesting(gt)
+		env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
+
+		buildAliceBlock := func() {
+			env.Sequencer.ActL2StartBlock(t)
+			env.Alice.L2.ActResetTxOpts(t)
+			env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)
+			env.Alice.L2.ActMakeTx(t)
+			env.Engine.ActL2IncludeTx(env.Alice.Address())(t)
+			env.Sequencer.ActL2EndBlock(t)
+		}
+
+		submitAndIncludeFrame := func(frame []byte) {
+			require.NotEmpty(t, frame)
+			env.Batcher.ActL2BatchSubmitRaw(t, frame)
+			env.Miner.ActL1StartBlock(12)(t)
+			env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+			env.Miner.ActL1EndBlock(t)
+		}
+
+		// Build L2 blocks 1-3, each with one transaction from Alice.
+		for bigs.Uint64Strict(env.Engine.L2Chain().CurrentBlock().Number) < 3 {
+			buildAliceBlock()
+		}
+
+		// Craft both channels now, while blocks 1-3 are the canonical chain. Once derivation
+		// replaces block 2, the original blocks are no longer reachable by number.
+		craftInvalidLineageChannel := func() []byte {
+			env.Batcher.ActCreateChannel(t, true)
+			env.Batcher.ActAddBlockByNumber(t, 1, actionsHelpers.BlockLogger(t))
+			env.Batcher.ActAddBlockByNumber(t, 2, invalidPayload, actionsHelpers.BlockLogger(t))
+			env.Batcher.ActAddBlockByNumber(t, 3, actionsHelpers.BlockLogger(t))
+			env.Batcher.ActL2ChannelClose(t)
+			return env.Batcher.ReadNextOutputFrame(t)
+		}
+		frame1 := craftInvalidLineageChannel()
+		frame2 := craftInvalidLineageChannel()
+
+		// Submit channel 1 and channel 2 in consecutive L1 blocks, then derive both.
+		submitAndIncludeFrame(frame1)
+		submitAndIncludeFrame(frame2)
+		env.Sequencer.ActL1HeadSignal(t)
+		env.Sequencer.ActL2PipelineFull(t)
+
+		// Channel 1: block 1 applies, 2* is invalid and replaced with deposits-only 2', and the
+		// channel is flushed. Channel 2: its overlap conflicts with 2', so the whole batch must
+		// be dropped with a channel flush — the safe head must NOT advance past the replacement.
+		l2SafeHead := env.Sequencer.L2Safe()
+		require.EqualValues(t, 2, l2SafeHead.Number,
+			"the re-batched invalidated lineage must be dropped whole, not spliced onto the replacement")
+		require.Equal(t, env.Engine.L2Chain().GetHeaderByNumber(2).Hash(), l2SafeHead.Hash,
+			"safe head must be the deposits-only replacement")
+		for _, filter := range []string{
+			"could not process payload attributes", // 2* rejected by the engine
+			"overlapped block's tx count does not match",
+			"Dropping invalid span batch, flushing channel (span batch checks)",
+		} {
+			recs := env.Logs.FindLogs(
+				testlog.NewMessageContainsFilter(filter),
+				testlog.NewAttributesFilter("role", "sequencer"))
+			require.NotEmpty(t, recs, "expected sequencer log: %q", filter)
+		}
+
+		// Canonical continuation: build 3'' on the replacement (with a transaction, so it is
+		// distinguishable from a deposits-only splice at the same height), batch and derive it.
+		buildAliceBlock()
+		env.Batcher.ActCreateChannel(t, true)
+		env.Batcher.ActAddBlockByNumber(t, 3, actionsHelpers.BlockLogger(t))
+		env.Batcher.ActL2ChannelClose(t)
+		submitAndIncludeFrame(env.Batcher.ReadNextOutputFrame(t))
+		env.Sequencer.ActL1HeadSignal(t)
+		env.Sequencer.ActL2PipelineFull(t)
+
+		l2SafeHead = env.Sequencer.L2Safe()
+		require.EqualValues(t, 3, l2SafeHead.Number, "canonical continuation must derive")
+		require.Equal(t, env.Engine.L2Chain().GetHeaderByNumber(3).Hash(), l2SafeHead.Hash,
+			"the canonical continuation must win over the equivocating channel's tail")
+
+		// Run the fault proof program with honest claims at every height 0..3. A client without
+		// the overlap content rule splices the invalidated lineage and derives a different block
+		// at height 3, rejecting the honest claim there.
+		env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
+	}
+
+	matrix := helpers.NewMatrix[testCase]()
+	matrix.AddTestCase(
+		"HonestClaim",
+		testCase{},
+		helpers.NewForkMatrix(helpers.Holocene, helpers.LatestFork),
+		runTest,
+		helpers.ExpectNoError(),
+	)
+	matrix.AddTestCase(
+		"JunkClaim",
+		testCase{},
+		helpers.NewForkMatrix(helpers.Holocene, helpers.LatestFork),
+		runTest,
+		helpers.ExpectError(helpers.ErrClaimNotValid),
+		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	)
+	matrix.Run(gt)
+}

--- a/rust/kona/tests/proofs/span_batch_overlap_test.go
+++ b/rust/kona/tests/proofs/span_batch_overlap_test.go
@@ -101,7 +101,7 @@ func TestSpanBatchOverlapContent(gt *testing.T) {
 		expectedLogs := []string{"overlapped block's tx count does not match"}
 		if isHolocene {
 			expectedLogs = append(expectedLogs,
-				"Dropping invalid span batch, flushing channel (span batch checks)")
+				"Dropping invalid span batch, flushing channel (span batch overlap checks)")
 		}
 		for _, filter := range expectedLogs {
 			recs := env.Logs.FindLogs(

--- a/rust/kona/tests/proofs/span_batch_overlap_test.go
+++ b/rust/kona/tests/proofs/span_batch_overlap_test.go
@@ -101,7 +101,7 @@ func TestSpanBatchOverlapContent(gt *testing.T) {
 		expectedLogs := []string{"overlapped block's tx count does not match"}
 		if isHolocene {
 			expectedLogs = append(expectedLogs,
-				"Dropping invalid span batch, flushing channel (span batch overlap checks)")
+				"Dropping invalid span batch, flushing channel (span batch checks)")
 		}
 		for _, filter := range expectedLogs {
 			recs := env.Logs.FindLogs(

--- a/rust/kona/tests/proofs/span_batch_overlap_test.go
+++ b/rust/kona/tests/proofs/span_batch_overlap_test.go
@@ -78,7 +78,7 @@ func TestSpanBatchOverlapContent(gt *testing.T) {
 		}
 		submitAndIncludeFrame := func(frame []byte) {
 			env.Batcher.ActL2BatchSubmitRaw(t, frame)
-			env.Miner.ActL1StartBlock(12)(t)
+			env.Miner.ActL1StartBlock(helpers.L1BlockTime)(t)
 			env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
 			env.Miner.ActL1EndBlock(t)
 		}

--- a/rust/kona/tests/proofs/span_batch_overlap_test.go
+++ b/rust/kona/tests/proofs/span_batch_overlap_test.go
@@ -1,67 +1,60 @@
 package proofs
 
 import (
-	"math/big"
 	"testing"
 
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/rust/kona/tests/proofs/helpers"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
-// TestSpanBatchOverlapContent pins the post-Holocene span batch overlap content rule, in both
-// op-node (driving derivation below) and kona-client (replaying it as the fault proof program):
-// a span batch whose overlap section disagrees with the safe chain must be dropped as a whole,
-// with a channel flush, so that the remainder of an invalidated lineage cannot be spliced onto
-// the canonical chain.
+// TestSpanBatchOverlapContent pins the span batch overlap content rule, in both op-node (driving
+// derivation below) and kona-client (replaying the same L1 data as the fault proof program): a
+// span batch whose overlap section disagrees with the safe chain must be dropped as a whole, so
+// that its elements past the safe head cannot be applied. Pre-Holocene, the rule has always been
+// part of the full span batch checks; this test pins that it holds identically on the Holocene
+// batch stage, where a content-blind past-skip would otherwise splice the remainder of a stale
+// or equivocating lineage onto the canonical chain (the interop block-replacement lineage bug).
 //
-// The scenario mirrors the interop block-replacement incident shape using batcher equivocation:
+// The scenario uses batcher equivocation with alternative *valid* blocks (the canonical blocks
+// with their user transactions stripped), so it is independent of invalid-payload replacement
+// rules and runs unchanged across forks:
 //
-//  1. Channel 1 carries span [1, 2*, 3] where 2*'s transaction signature is invalidated.
-//     Deriving it yields block 1, then a deposits-only replacement 2' for the invalid payload,
-//     and a channel flush that discards element 3. The safe chain now disagrees with the
-//     batched lineage at height 2.
-//  2. Channel 2 carries the same invalidated lineage [1, 2*, 3] again — the incident's
-//     "re-derivation walk" over a batch containing a since-replaced block. Its overlap
-//     (heights 1-2) must be validated against the safe chain: element 2* conflicts with 2'.
-//     With the overlap content rule, the whole batch is dropped and the channel flushed.
-//     Without it, element 3 — built on the invalidated 2* — is spliced onto 2', producing
-//     another deposits-only replacement 3' derived from a lineage that was never canonical.
-//  3. Channel 3 carries the canonical continuation 3” (built on 2', with a live transaction).
-//     With the rule, it applies and the safe head becomes 3”. Without it, height 3 is already
-//     (wrongly) occupied by 3', and the canonical continuation is dropped as a past batch —
-//     the equivocating channel's tail wins over the canonical chain.
+//  1. Channel 1 carries span [1, 2]: the canonical chain, derived to the safe head.
+//  2. Channel 2 carries span [2*, 3*], the same heights with user transactions stripped —
+//     an alternative valid lineage. Its overlap (height 2) disagrees with the safe chain, so
+//     the whole batch must be dropped and the safe head stay at 2. Without the overlap content
+//     rule, 2* is past-skipped and 3* — a valid empty block — is spliced onto canonical 2.
+//  3. Channel 3 carries the canonical block 3: it must derive (fixed), instead of being dropped
+//     as a past batch because height 3 is already wrongly occupied by 3* (unfixed) — the
+//     equivocating channel's tail must not win over the canonical chain.
 //
 // The fault proof program then replays the same L1 data with honest claims taken from the
 // op-node-derived chain at every height 0..3. Height 3 is where a client without the overlap
-// rule derives 3' instead of 3”, so an unfixed kona-client rejects the honest claim there,
-// pinning that the Go and Rust implementations enforce the same rule.
+// rule derives 3* instead of the canonical block 3 and rejects the honest claim, pinning that
+// the Go and Rust implementations enforce the same rule.
 func TestSpanBatchOverlapContent(gt *testing.T) {
-	type testCase struct{}
-
-	// invalidPayload invalidates the signature for the second transaction in the block
-	// (the first is the L1 info deposit). This yields an invalid payload in the engine,
-	// which post-Holocene is replaced with a deposits-only block.
-	invalidPayload := func(block *types.Block) *types.Block {
-		alice := types.NewCancunSigner(big.NewInt(901))
-		txs := block.Transactions()
-		newTx, err := txs[1].WithSignature(alice, make([]byte, 65))
-		if err != nil {
-			panic(err)
+	// dropUserTxs strips all non-deposit transactions from the block, yielding an alternative
+	// valid block at the same height: same parent and timestamp, different content.
+	dropUserTxs := func(block *types.Block) *types.Block {
+		var deposits []*types.Transaction
+		for _, tx := range block.Transactions() {
+			if tx.Type() == types.DepositTxType {
+				deposits = append(deposits, tx)
+			}
 		}
-		txs[1] = newTx
-		return block
+		return block.WithBody(types.Body{Transactions: deposits})
 	}
 
-	runTest := func(gt *testing.T, testCfg *helpers.TestCfg[testCase]) {
+	runTest := func(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 		t := actionsHelpers.NewDefaultTesting(gt)
 		env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
 
-		buildAliceBlock := func() {
+		// Build L2 blocks 1-3, each with one transaction from Alice.
+		for bigs.Uint64Strict(env.Engine.L2Chain().CurrentBlock().Number) < 3 {
 			env.Sequencer.ActL2StartBlock(t)
 			env.Alice.L2.ActResetTxOpts(t)
 			env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)
@@ -69,94 +62,77 @@ func TestSpanBatchOverlapContent(gt *testing.T) {
 			env.Engine.ActL2IncludeTx(env.Alice.Address())(t)
 			env.Sequencer.ActL2EndBlock(t)
 		}
+		// The canonical block 3, captured before derivation can reorg the engine: the safe head
+		// must end up here, not on the equivocating lineage's 3*.
+		canonicalHash3 := env.Engine.L2Chain().GetHeaderByNumber(3).Hash()
 
-		submitAndIncludeFrame := func(frame []byte) {
+		craftSpanChannel := func(blocks []int64, modifier actionsHelpers.BlockModifier) []byte {
+			env.Batcher.ActCreateChannel(t, true)
+			for _, num := range blocks {
+				env.Batcher.ActAddBlockByNumber(t, num, modifier, actionsHelpers.BlockLogger(t))
+			}
+			env.Batcher.ActL2ChannelClose(t)
+			frame := env.Batcher.ReadNextOutputFrame(t)
 			require.NotEmpty(t, frame)
+			return frame
+		}
+		submitAndIncludeFrame := func(frame []byte) {
 			env.Batcher.ActL2BatchSubmitRaw(t, frame)
 			env.Miner.ActL1StartBlock(12)(t)
 			env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
 			env.Miner.ActL1EndBlock(t)
 		}
 
-		// Build L2 blocks 1-3, each with one transaction from Alice.
-		for bigs.Uint64Strict(env.Engine.L2Chain().CurrentBlock().Number) < 3 {
-			buildAliceBlock()
-		}
-
-		// Craft both channels now, while blocks 1-3 are the canonical chain. Once derivation
-		// replaces block 2, the original blocks are no longer reachable by number.
-		craftInvalidLineageChannel := func() []byte {
-			env.Batcher.ActCreateChannel(t, true)
-			env.Batcher.ActAddBlockByNumber(t, 1, actionsHelpers.BlockLogger(t))
-			env.Batcher.ActAddBlockByNumber(t, 2, invalidPayload, actionsHelpers.BlockLogger(t))
-			env.Batcher.ActAddBlockByNumber(t, 3, actionsHelpers.BlockLogger(t))
-			env.Batcher.ActL2ChannelClose(t)
-			return env.Batcher.ReadNextOutputFrame(t)
-		}
-		frame1 := craftInvalidLineageChannel()
-		frame2 := craftInvalidLineageChannel()
-
-		// Submit channel 1 and channel 2 in consecutive L1 blocks, then derive both.
+		// Channel 1: the canonical chain up to height 2. Channel 2: the equivocating lineage
+		// [2*, 3*]. Both are crafted upfront and submitted in consecutive L1 blocks.
+		frame1 := craftSpanChannel([]int64{1, 2}, nil)
+		frame2 := craftSpanChannel([]int64{2, 3}, dropUserTxs)
 		submitAndIncludeFrame(frame1)
 		submitAndIncludeFrame(frame2)
 		env.Sequencer.ActL1HeadSignal(t)
 		env.Sequencer.ActL2PipelineFull(t)
 
-		// Channel 1: block 1 applies, 2* is invalid and replaced with deposits-only 2', and the
-		// channel is flushed. Channel 2: its overlap conflicts with 2', so the whole batch must
-		// be dropped with a channel flush — the safe head must NOT advance past the replacement.
+		// Channel 2's overlap disagrees with the safe chain at height 2: the whole batch must be
+		// dropped and the safe head stay at 2, instead of 3* being spliced onto canonical 2.
 		l2SafeHead := env.Sequencer.L2Safe()
 		require.EqualValues(t, 2, l2SafeHead.Number,
-			"the re-batched invalidated lineage must be dropped whole, not spliced onto the replacement")
-		require.Equal(t, env.Engine.L2Chain().GetHeaderByNumber(2).Hash(), l2SafeHead.Hash,
-			"safe head must be the deposits-only replacement")
-		for _, filter := range []string{
-			"could not process payload attributes", // 2* rejected by the engine
-			"overlapped block's tx count does not match",
-			"Dropping invalid span batch, flushing channel (span batch checks)",
-		} {
+			"the equivocating overlapping span batch must be dropped whole, not tail-spliced")
+		isHolocene := testCfg.Hardfork.Precedence >= helpers.Holocene.Precedence
+		expectedLogs := []string{"overlapped block's tx count does not match"}
+		if isHolocene {
+			expectedLogs = append(expectedLogs,
+				"Dropping invalid span batch, flushing channel (span batch checks)")
+		}
+		for _, filter := range expectedLogs {
 			recs := env.Logs.FindLogs(
 				testlog.NewMessageContainsFilter(filter),
 				testlog.NewAttributesFilter("role", "sequencer"))
 			require.NotEmpty(t, recs, "expected sequencer log: %q", filter)
 		}
 
-		// Canonical continuation: build 3'' on the replacement (with a transaction, so it is
-		// distinguishable from a deposits-only splice at the same height), batch and derive it.
-		buildAliceBlock()
-		env.Batcher.ActCreateChannel(t, true)
-		env.Batcher.ActAddBlockByNumber(t, 3, actionsHelpers.BlockLogger(t))
-		env.Batcher.ActL2ChannelClose(t)
-		submitAndIncludeFrame(env.Batcher.ReadNextOutputFrame(t))
+		// Channel 3: the canonical block 3. It must derive on top of the safe head — with a
+		// content-blind past-skip, height 3 is already occupied by 3* and the canonical
+		// continuation would be dropped as a past batch.
+		submitAndIncludeFrame(craftSpanChannel([]int64{3}, nil))
 		env.Sequencer.ActL1HeadSignal(t)
 		env.Sequencer.ActL2PipelineFull(t)
 
 		l2SafeHead = env.Sequencer.L2Safe()
 		require.EqualValues(t, 3, l2SafeHead.Number, "canonical continuation must derive")
-		require.Equal(t, env.Engine.L2Chain().GetHeaderByNumber(3).Hash(), l2SafeHead.Hash,
-			"the canonical continuation must win over the equivocating channel's tail")
+		require.Equal(t, canonicalHash3, l2SafeHead.Hash,
+			"the canonical block must win over the equivocating channel's tail")
 
 		// Run the fault proof program with honest claims at every height 0..3. A client without
-		// the overlap content rule splices the invalidated lineage and derives a different block
-		// at height 3, rejecting the honest claim there.
+		// the overlap content rule splices the equivocating lineage and derives a different
+		// block at height 3, rejecting the honest claim there.
 		env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
 	}
 
-	matrix := helpers.NewMatrix[testCase]()
-	matrix.AddTestCase(
-		"HonestClaim",
-		testCase{},
-		helpers.NewForkMatrix(helpers.Holocene, helpers.LatestFork),
+	matrix := helpers.NewMatrix[any]()
+	matrix.AddDefaultTestCases(
+		nil,
+		helpers.NewForkMatrix(helpers.Fjord, helpers.Holocene, helpers.LatestFork),
 		runTest,
-		helpers.ExpectNoError(),
-	)
-	matrix.AddTestCase(
-		"JunkClaim",
-		testCase{},
-		helpers.NewForkMatrix(helpers.Holocene, helpers.LatestFork),
-		runTest,
-		helpers.ExpectError(helpers.ErrClaimNotValid),
-		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
 	)
 	matrix.Run(gt)
 }


### PR DESCRIPTION
## Description

Alternative to #22214 — same defect, simpler rule. This PR now carries the rule in **both clients** (op-node and kona), plus an action proofs test that pins their equivalence with the fault proof program.

### The defect

The Holocene span batch prefix checks (`checkSpanBatchPrefix`) do not validate the contents of batch elements that overlap the safe chain — unlike the legacy full checks (`checkSpanBatch`), which fetch every overlapped payload and compare transactions. Dropping that comparison was sound under a pre-interop invariant: the safe chain was derived from this same batch data, so overlap content provably agrees with it.

Interop deposits-only block replacement breaks that invariant. After a denied block is replaced, the canonical block at the replaced height no longer matches the batch element it was originally derived from — and the prefix checks never notice:

- `GetSingularBatches` past-skips every element at or below the safe head without inspecting content, including the since-replaced (denied) block.
- The deny check (`IsDenied`) only fires when a payload at the denied height is *proposed* (`engine/payload_process.go`), and the channel flush is a side effect of that deny event (`DepositsOnlyAttributes`). A walk anchored **at** the replacement never proposes the denied block, so neither fires.
- The span's tail is then re-stamped onto the replacement and applied — splicing the remainder of an invalidated lineage onto the canonical chain.

The result is that the derived chain depends on where the pipeline (re-)anchored relative to the replacement: an anchor **below** the denied block re-proposes it → deny → replacement + channel flush → the next channel wins; an anchor **at** the replacement past-skips it → the same channel's tail wins. Same L1 data, same deny list, different chains. This was observed on devnet `interop-reorg-5`, where a post-invalidation reset anchored a live supernode at the replacement and flipped it onto a lineage that from-genesis syncs can never derive (writeup: internal doc "Double Batch Derivation Issue"). PR #21970 closed the analogous hole on the consolidation path, but both existing deny hooks are keyed on a payload/attributes existing at the denied height — on this path, nothing at the denied height is ever processed.

kona has the identical gap: its Holocene `BatchStream` runs only `check_batch_prefix`, while the full overlap comparison sits unused in the legacy `check_batch` path.

### The fix

Reinstate the **pre-Holocene overlap rule in full**, in both clients: a span batch that overlaps the safe chain must agree with the safe chain, at *every* overlapped height — transactions and L1 origin number, the exact legacy comparison. A mismatch drops the batch and flushes the channel; a payload fetch failure is Undecided.

Structure (settled after two rounds of review — the interim fold of the overlap check into a combined Holocene check function was reverted because it moved overlap payload reads ahead of the deterministic legacy checks pre-Holocene):

- **op-node**: the legacy loop is factored verbatim out of `checkSpanBatch` into `checkSpanBatchOverlap`. `checkSpanBatchPrefix` is untouched. The legacy `checkSpanBatch` calls the overlap check at its original tail position (preserving pre-Holocene check order and error/liveness behavior exactly), and `BatchStage` runs it as a second phase after an accepted prefix check, guarded on the batch actually overlapping the safe chain.
- **kona**: the mirror-image structure — `check_batch_overlap` factored out of `check_batch` and called at its legacy tail; `check_batch_prefix` untouched; `BatchStream` runs the overlap check as a second phase after an accepted prefix check. The check-batch-prefix duration metric covers only the prefix checks, as before.

This directly enforces the invariant the prefix-only checks silently dropped, and restores anchor-invariance of derivation across replacement boundaries: re-deriving from any anchor yields the same chain, because a batch carrying a since-replaced block is rejected on every walk instead of being past-skipped into a splice.

### Fault proof cost (review round 2)

The overlap check's per-block `block_by_number` lookups resolved by walking headers back from the L2 safe head in the fault-proof provider, making an overlap of length N cost O(N²) header preimage reads. `OracleL2ChainProvider` now carries the same by-number cache its L1 counterpart already had: walks record every header they discover, lookups resume from the closest cached ancestor, and the ascending overlap sweep costs one walk over the range in total. Provider-level regression tests pin the complexity with a counting mock oracle (the five-deep ascending sweep is asserted at exactly 5 header reads; the uncached walk did 15).

## Commit structure (red → green)

The first commit adds only the action proofs test; each subsequent commit turns part of it green, so the defect and the fix can be replayed per client:

1. **`kona: add span batch overlap content action test`** — test only. Red in both clients: op-node splices the invalidated lineage (safe-head assertions fail); kona-client would reject the honest claim at the divergent height.
2. **`op-node: Validate span batch overlap content against the safe chain in Holocene`** — Go fix + Go unit tests.
3. **`op-node: fold overlap check into checkSpanBatchHolocene (review feedback)`** — interim restructure, reverted in commit 8.
4. **`kona: validate span batch overlap content against the safe chain post-Holocene`** — kona fix + kona unit test updates. Fully green.
5. **`kona: address action test review comments`** — scenario rework (batcher equivocation with alternative valid blocks; fork-variable across Fjord/Holocene/latest), `AddDefaultTestCases`.
6. **`op-node,kona: restore displaced test coverage, tighten comments (self-review)`**, **`op-node,kona: correct stale retry-later comments on Undecided batches`** — self-review fixes.
7. *(review round 2)* **`op-node: revert overlap fold, restore prefix + stage-level overlap checks`** — reverts commit 3: the fold moved overlap payload reads ahead of the legacy full checks pre-Holocene, so a deterministically invalid batch could sit Undecided at the queue front during an engine read outage. The restored functions are character-identical to commit 2 (modulo the self-review comment corrections), i.e. the shape the original testing validated.
8. **`kona: mirror op-node revert — restore check_batch_prefix, stage-level overlap check`** — the Rust mirror, keeping the clients in lockstep.
9. **`kona-proof: linear by-number header walks for span batch overlap validation`** — the fault-proof complexity blocker: by-number header cache + counting-oracle regression tests + the encode-buffer hoist nit.
10. **`op-node,kona: strengthen overlap flush tests with unread sentinels and a multi-block case`** — flush tests now prove the channel was actually flushed (unread sentinel discarded), and a two-block-overlap case exercises the comparison loop beyond its first iteration.
11. **`kona: action test expects the stage-level overlap drop message`** — the action test's sequencer log expectation follows the restored drop message.

## The action proofs test

`rust/kona/tests/proofs/span_batch_overlap_test.go` (`TestSpanBatchOverlapContent`) pins the rule end-to-end via batcher equivocation with alternative *valid* blocks (per review: independent of deposits-only replacement rules, so it runs across forks — Fjord, Holocene, and latest):

1. Channel 1 carries span `[1, 2]`: the canonical chain, derived to the safe head.
2. Channel 2 carries span `[2*, 3*]` — the same heights with user transactions stripped, an alternative valid lineage. Its overlap disagrees with the safe chain at height 2: it must be dropped whole (the safe head stays at 2) instead of past-skipping `2*` and splicing `3*` onto canonical 2.
3. Channel 3 carries the canonical block 3: it must derive, instead of being dropped as a past batch because height 3 is already wrongly occupied by `3*`.
4. `RunFaultProofProgramFromGenesis` validates honest claims from the op-node-derived chain at every height 0..3, plus junk-claim variants. Height 3 is where an unfixed client derives `3*` instead of the canonical block and rejects the honest claim.

Verified locally at each commit boundary: at the test-only commit, **Holocene and latest-fork variants are red** (op-node splices the equivocating lineage) while **Fjord is green** — pinning that the pre-Holocene overlap rule holds unchanged on the BatchQueue path and the defect is precisely the Holocene gap. At the Go-fixed/kona-unfixed boundary, kona-client rejects the honest claim at height 3 (`ErrClaimNotValid`). At head, all six fork/claim subtests are green (re-verified after the round-2 restructure).

## Trade-offs vs #22214

**Simpler:**
- The rule is a pure function of the batch and the local chain — no `SuperAuthority` interface change, no deny list plumbing, no supernode changes, no external state to define. Now implemented in both clients symmetrically.

**Costs:**
- **Consensus-visible on every Holocene chain**, not just interop chains: a batch whose overlap disagrees with the safe chain at *any* height (producible today only by batcher equivocation) is now dropped + flushed instead of having its tail applied. This changes which continuation wins in equivocation scenarios, so it needs a spec decision before it ships anywhere real (spec draft: ethereum-optimism/specs#928). op-node/kona parity is in-PR (both clients change in lockstep); the fault proof program picks the change up via kona-client.
- **O(overlap) engine queries per overlapping span batch**: every pipeline reset walk-back pays `PayloadByNumber` for each overlapped block of the span straddling the safe head (typically one span per walk; roughly the pre-Holocene restart cost). Fully-past spans still short-circuit via `BatchPast` before the check. On the fault-proof path this is now linear in the overlap length (see above).

## Test changes

- `TestSpanBatchOverlapContent` (new action proofs test) — see above.
- `TestBatchStage_OverlapContent` (new, Go unit) pins the incident shape at the stage level: a span carrying a replaced block is dropped with a channel flush **that provably discards the rest of the channel** (unread sentinel), a span matching the canonical chain is accepted, payload fetch errors are Undecided, and a two-block overlap diverging only at its second element is caught by the comparison loop's later iterations.
- kona `test_overlap_mismatch_drops_span_and_flushes_unread_batches` mirrors the sentinel + multi-block case at the `BatchStream` level (the test provider's `flush` now actually discards queued batches instead of being a silent no-op).
- `OracleL2ChainProvider` regression tests: ascending five-deep overlap sweep costs exactly 5 header preimage reads (was 15), resume-from-cached-ancestor, repeat-hit, and past-head cases.
- `go test ./op-node/rollup/...`, `cargo nextest run -p kona-protocol -p kona-derive -p kona-proof`, clippy, rustfmt, and `check-no-std` pass.

## Which one to land

Proposal: use #22214 as the immediately-deployable fix for the interop devnets (no consensus impact outside the deny machinery's footprint), and treat this PR as the concrete artifact for the protocol-level discussion — if the spec adopts "overlap must agree with the safe chain" (ethereum-optimism/specs#928), this is the implementation in both clients, with the equivalence test to hold them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review note: the moved loops are verbatim

In both clients the overlap loop is lifted character-for-character (dedented) out of the legacy full-check function into the new shared function, with zero logic changes — verified by diffing the regions with leading whitespace normalized. The only post-move deviation is the review-requested hoist of the transaction encoding buffer in kona's `check_batch_overlap`. To see it directly:

```
git diff --color-moved=dimmed-zebra --color-moved-ws=ignore-all-space develop -- op-node/rollup/derive/batches.go rust/kona/crates/protocol/protocol/src/batch/span.rs
```
