### PR TITLE
op-service: let target node cap gas estimation

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/holiman/uint256"
 
@@ -490,7 +489,7 @@ func (m *SimpleTxManager) estimateOrValidateCandidateTxGas(ctx context.Context, 
 	}
 	// If the gas limit is set, we can use that as the gas
 	if candidate.GasLimit == 0 {
-		callMsg.Gas = params.MaxTxGas
+		// Leave CallMsg.Gas unset so the target node chooses a ceiling based on its active fork rules.
 		gas, err := m.backend.EstimateGas(ctx, callMsg)
 		if err != nil {
 			return 0, fmt.Errorf("failed to estimate gas: %w", errutil.TryAddRevertReason(err))

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -224,10 +224,11 @@ func WithEstimator(cl Estimator, invalidateOnNewBlock bool) Option {
 			tx.Gas.DependOn(&tx.AgainstBlock)
 		}
 		tx.Gas.Fn(func(ctx context.Context) (uint64, error) {
+			// Leave CallMsg.Gas unset so the target node applies the estimation ceiling for its active
+			// fork.
 			msg := ethereum.CallMsg{
 				From:       tx.Sender.Value(),
 				To:         tx.To.Value(),
-				Gas:        params.MaxTxGas, // max gas, will be estimated
 				GasPrice:   nil,
 				GasFeeCap:  tx.GasFeeCap.Value(),
 				GasTipCap:  tx.GasTipCap.Value(),


### PR DESCRIPTION
## Summary

EIP-7825 limits regular execution gas after EIP-8037, but `tx.gas` may exceed `2^24` to fund state gas. Explicitly setting `params.MaxTxGas` on `eth_estimateGas` requests prevents the node from finding those valid transactions.

Leave the gas field unset in txmgr and txplan so the target node selects the estimation ceiling according to its active fork rules. This preserves legacy and Karst/Osaka behavior while allowing EIP-8037-aware nodes to use the block limit.

## History

These callers originally left `gas` unset. [#20068](https://github.com/ethereum-optimism/optimism/pull/20068) set it to `params.MaxTxGas` as an EIP-7825 workaround when Karst activated Osaka behavior: op-reth started estimation from the 30–60M block gas limit, and revm rejected that trial for exceeding EIP-7825's `2^24` per-transaction cap. The merge commit explicitly described this as an EIP-7825 change needed to fix failing tests.

Later, [#21574](https://github.com/ethereum-optimism/optimism/pull/21574) fixed op-reth's estimation environment and added an omitted-gas Karst regression test. Upstream [reth#25612](https://github.com/paradigmxyz/reth/pull/25612) made estimation use the effective fork-aware cap, and [#22136](https://github.com/ethereum-optimism/optimism/pull/22136) removed the corresponding OP EVM workaround after that reth revision was pinned. These two caller-side caps remained.

That workaround is incompatible with EIP-8037: `2^24` limits regular execution gas, while `tx.gas` may be higher to fund state gas. Omitting `gas` lets the target node apply the correct legacy, EIP-7825, or EIP-8037 ceiling.

Closes https://github.com/ethereum-optimism/protocol-team/issues/252

## Testing

- `cd op-service && mise exec -- just test`
- `mise exec -- just lint-go`
- `cd rust && mise exec -- cargo nextest run -p reth-optimism-node test_estimate_gas_under_karst`