### PR TITLE
op-core/fees: exclude PostExec from DA footprint

### DIFF
--- a/op-core/fees/dafootprint.go
+++ b/op-core/fees/dafootprint.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	optypes "github.com/ethereum-optimism/optimism/op-core/types"
-
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 )
 

--- a/op-core/fees/dafootprint.go
+++ b/op-core/fees/dafootprint.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
+
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 )
 
@@ -39,6 +41,7 @@ func ExtractDAFootprintGasScalar(data []byte) (uint16, error) {
 // Jovian introduces a DA footprint block limit which is stored in the BlobGasUsed header field
 // and that is taken into account during base fee updates.
 // CalcDAFootprint must not be called for pre-Jovian blocks.
+// Deposit and post-exec transactions do not contribute to the footprint.
 func CalcDAFootprint(txs []*types.Transaction) (uint64, error) {
 	if len(txs) == 0 || txs[0].Type() != types.DepositTxType {
 		return 0, errors.New("missing deposit transaction")
@@ -61,7 +64,7 @@ func CalcDAFootprint(txs []*types.Transaction) (uint64, error) {
 	}
 	var daFootprint uint64
 	for _, tx := range txs {
-		if tx.Type() == types.DepositTxType {
+		if tx.Type() == types.DepositTxType || optypes.IsPostExecTx(tx) {
 			continue
 		}
 		daFootprint += bigs.Uint64Strict(TxRollupCostData(tx).EstimatedDASize()) * uint64(daFootprintGasScalar)

--- a/op-core/fees/dafootprint_test.go
+++ b/op-core/fees/dafootprint_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 )
 
 // jovianL1AttributesData builds Jovian-length L1-attributes calldata with the Jovian selector
@@ -103,9 +105,9 @@ func TestExtractDAFootprintGasScalarParity(t *testing.T) {
 }
 
 // TestCalcDAFootprintParity is a live differential check that CalcDAFootprint matches op-geth's
-// types.CalcDAFootprint across deposit/user-transaction mixes, attribute layouts, and scalar
-// values, including error cases. It runs while the build still resolves go-ethereum to op-geth;
-// remove it when the op-geth dependency is dropped.
+// types.CalcDAFootprint across pre-Lagoon deposit/user-transaction mixes, attribute layouts, and
+// scalar values, including error cases. Post-exec transactions intentionally diverge because
+// op-geth does not support Lagoon. Remove this test when the op-geth dependency is dropped.
 func TestCalcDAFootprintParity(t *testing.T) {
 	userTxs := userTxMix()
 	secondDeposit := l1AttributesDepositTx(nil)
@@ -163,4 +165,21 @@ func TestCalcDAFootprintDirected(t *testing.T) {
 	got, err = CalcDAFootprint([]*types.Transaction{l1AttributesDepositTx(isthmusL1AttributesData())})
 	require.NoError(t, err)
 	require.Zero(t, got)
+}
+
+func TestCalcDAFootprintExcludesPostExec(t *testing.T) {
+	deposit := l1AttributesDepositTx(jovianL1AttributesData(3))
+	userTx := userTxMix()[0]
+
+	rawPostExec, err := (&optypes.PostExecTx{Data: []byte{0xc0}}).MarshalBinary()
+	require.NoError(t, err)
+	postExecTx := new(types.Transaction)
+	require.NoError(t, postExecTx.UnmarshalBinary(rawPostExec))
+	require.True(t, optypes.IsPostExecTx(postExecTx))
+
+	withoutPostExec, err := CalcDAFootprint([]*types.Transaction{deposit, userTx})
+	require.NoError(t, err)
+	withPostExec, err := CalcDAFootprint([]*types.Transaction{deposit, userTx, postExecTx})
+	require.NoError(t, err)
+	require.Equal(t, withoutPostExec, withPostExec)
 }

--- a/op-core/fees/fees.go
+++ b/op-core/fees/fees.go
@@ -1,8 +1,7 @@
 // Package fees implements the OP-Stack L1 data-availability cost and operator-fee
-// calculations. It is pure arithmetic over byte counts and big integers and depends only on
-// the standard library and go-ethereum's core/types (for [TxRollupCostData]) and params (for
-// the EIP-2028 gas schedule); it has no dependency on op-core/types, so the two packages
-// remain cycle-free siblings.
+// calculations. It is pure arithmetic over byte counts and big integers. It depends on
+// go-ethereum's core/types and params for the transaction envelope and EIP-2028 gas schedule,
+// and on op-core/types to classify OP Stack transaction types.
 //
 // It covers the L1 cost functions from Bedrock through Fjord and the Isthmus and Jovian
 // operator-fee formulas. Consumers import the package as opfees.


### PR DESCRIPTION
Exclude Lagoon PostExec transactions (`0x7D`) from Jovian DA-footprint accounting.

Keep the existing op-geth differential coverage scoped to supported pre-Lagoon behavior and add a focused regression test for the intentional divergence.

Specification: https://github.com/ethereum-optimism/specs/pull/926

## Validation
- `mise exec -- go test ./op-core/fees/... ./op-chain-ops/cmd/check-jovian/...`
- `mise exec -- just lint-go`

🤖 *Co-created with openai-codex/gpt-5.6-sol*