### PR TITLE
ci: bump circleci-utils orb to 1.0.30

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -140,7 +140,7 @@ parameters:
     default: false
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.27
+  utils: ethereum-optimism/circleci-utils@1.0.30
   go: circleci/go@1.8.0
   gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@6.0.0

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -4,7 +4,7 @@ version: 2.1
 # This file contains all Rust CI commands, parameterized jobs, crate-specific jobs, and workflows.
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.27
+  utils: ethereum-optimism/circleci-utils@1.0.30
   gcp-cli: circleci/gcp-cli@3.0.1
 
 parameters:

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -5,7 +5,7 @@ version: 2.1
 # It is merged with main.yml and rust-ci.yml when rust/** changes are detected.
 # Shared orbs, commands, and jobs come from main.yml and rust-ci.yml during merge.
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.27
+  utils: ethereum-optimism/circleci-utils@1.0.30
 
 parameters:
   c-default_docker_image:


### PR DESCRIPTION
## Description

Bumps the pinned `circleci-utils` orb `1.0.27 → 1.0.30` in all three continuation fragments (`main.yml`, `rust-ci.yml`, `rust-e2e.yml` — the pins must move together under later-wins fragment merging).

**Why**: picks up ethereum-optimism/circleci-utils#34 — the install-mise retry wrapper now reports mise's real exit code on failed attempts instead of the constant `exit code 0` (`$?` was read after the `if` instead of inside the `else`). mise install failures are the largest CI infra-failure class of 2026 year-to-date (10 event days, 275 log-verified builds — see ethereum-optimism/optimism#22223); this makes future events diagnosable from the step summary.

**Full 1.0.27 → 1.0.30 delta** (from diffing the published orb sources): the mise fix (#34), a `gcloud_version` parameter on `gcp-oidc-authenticate` (#32, default "latest" = previous behavior), and a stash-pop conflict fix in `github-commit-and-push-changes-single-file` (#31). This repo only uses `checkout-with-mise` among the changed commands (64 call sites), so the effective change here is the mise fix alone.

## Validation

`merge-configs.sh` + `circleci config validate --org-slug gh/ethereum-optimism` (resolves the published 1.0.30) + `circleci config process` with all `c-run_*` params enabled pass locally; `test-decision-tree.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
