### PR TITLE
op-dispute-mon: introduce typed monitor lanes

### DIFF
--- a/op-dispute-mon/metrics/forecast_registry_test.go
+++ b/op-dispute-mon/metrics/forecast_registry_test.go
@@ -1,3 +1,4 @@
+// Package metrics_test stays external because mon imports metrics, while this test exercises mon.Forecast.
 package metrics_test
 
 import (

--- a/op-dispute-mon/metrics/forecast_registry_test.go
+++ b/op-dispute-mon/metrics/forecast_registry_test.go
@@ -1,4 +1,4 @@
-package mon_test
+package metrics_test
 
 import (
 	"testing"
@@ -13,17 +13,19 @@ import (
 )
 
 func TestForecastRecordsCanonicalAgreementSeries(t *testing.T) {
+	// Mutation killed: omitting or relabeling one RecordGameAgreement call survives
+	// mock-metric unit tests but changes the real registry's public series.
 	metricer := metrics.NewMetrics()
 	forecast := mon.NewForecast(testlog.Logger(t, 0), metricer)
-	forecast.Forecast([]*monTypes.EnrichedGameData{
-		{Status: types.GameStatusInProgress, AgreeWithClaim: true, BlockNumberChallenged: true},
-		{Status: types.GameStatusInProgress, AgreeWithClaim: false, BlockNumberChallenged: true},
-		{Status: types.GameStatusInProgress, AgreeWithClaim: true},
-		{Status: types.GameStatusInProgress, AgreeWithClaim: false},
-		{Status: types.GameStatusDefenderWon, AgreeWithClaim: true},
-		{Status: types.GameStatusDefenderWon, AgreeWithClaim: false},
-		{Status: types.GameStatusChallengerWon, AgreeWithClaim: true},
-		{Status: types.GameStatusChallengerWon, AgreeWithClaim: false},
+	forecast.Forecast([]monTypes.EnrichedGame{
+		&monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusInProgress, AgreeWithClaim: true}, BlockNumberChallenged: true},
+		&monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusInProgress, AgreeWithClaim: false}, BlockNumberChallenged: true},
+		&monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusInProgress, AgreeWithClaim: true}},
+		&monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusInProgress, AgreeWithClaim: false}},
+		&monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusDefenderWon, AgreeWithClaim: true}},
+		&monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusDefenderWon, AgreeWithClaim: false}},
+		&monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusChallengerWon, AgreeWithClaim: true}},
+		&monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusChallengerWon, AgreeWithClaim: false}},
 	}, 0, 0)
 
 	expected := map[string]map[string]string{

--- a/op-dispute-mon/mon/anchor_state.go
+++ b/op-dispute-mon/mon/anchor_state.go
@@ -39,7 +39,7 @@ func NewAnchorStateMonitor(logger log.Logger, metrics AnchorStateMetrics, newCon
 
 // CheckAnchorState reads the current anchor state L2 sequence number for every distinct
 // AnchorStateRegistry referenced by the monitored games and records it as a metric.
-func (m *AnchorStateMonitor) CheckAnchorState(ctx context.Context, blockHash common.Hash, games []*types.EnrichedGameData) {
+func (m *AnchorStateMonitor) CheckAnchorState(ctx context.Context, blockHash common.Hash, games []*types.CommonGameData) {
 	seen := make(map[common.Address]bool)
 	for _, game := range games {
 		asr := game.AnchorStateRegistry

--- a/op-dispute-mon/mon/anchor_state_test.go
+++ b/op-dispute-mon/mon/anchor_state_test.go
@@ -32,7 +32,7 @@ func TestAnchorStateMonitor_DedupesPerASR(t *testing.T) {
 	providers.set(asrA, big.NewInt(100), nil)
 	providers.set(asrB, big.NewInt(200), nil)
 
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{AnchorStateRegistry: asrA},
 		{AnchorStateRegistry: asrA},
 		{AnchorStateRegistry: asrB},
@@ -50,7 +50,7 @@ func TestAnchorStateMonitor_ToleratesPerASRError(t *testing.T) {
 	providers.set(asrA, nil, errors.New("boom"))
 	providers.set(asrB, big.NewInt(200), nil)
 
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{AnchorStateRegistry: asrA},
 		{AnchorStateRegistry: asrB},
 	}
@@ -64,7 +64,7 @@ func TestAnchorStateMonitor_SequenceNumberOverflow(t *testing.T) {
 	tooBig := new(big.Int).Add(new(big.Int).SetUint64(math.MaxUint64), big.NewInt(1))
 	providers.set(asrA, tooBig, nil)
 
-	monitor.CheckAnchorState(context.Background(), common.Hash{0xaa}, []*types.EnrichedGameData{
+	monitor.CheckAnchorState(context.Background(), common.Hash{0xaa}, []*types.CommonGameData{
 		{AnchorStateRegistry: asrA},
 	})
 

--- a/op-dispute-mon/mon/bonds/collateral.go
+++ b/op-dispute-mon/mon/bonds/collateral.go
@@ -3,7 +3,6 @@ package bonds
 import (
 	"math/big"
 
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -19,12 +18,9 @@ type Collateral struct {
 // CalculateRequiredCollateral determines the minimum balance required for each DelayedWETH contract used by a set
 // of dispute games.
 // Returns a map of DelayedWETH contract address to collateral data (required and actual amounts)
-func CalculateRequiredCollateral(games []*monTypes.EnrichedGameData) map[common.Address]Collateral {
+func CalculateRequiredCollateral(games []*monTypes.FaultGameData) map[common.Address]Collateral {
 	result := make(map[common.Address]Collateral)
 	for _, game := range games {
-		if gameTypes.GameType(game.GameType) == gameTypes.SuperPermissionedGameType {
-			continue
-		}
 		collateral, ok := result[game.WETHContract]
 		if !ok {
 			collateral = Collateral{
@@ -39,7 +35,7 @@ func CalculateRequiredCollateral(games []*monTypes.EnrichedGameData) map[common.
 	return result
 }
 
-func requiredCollateralForGame(game *monTypes.EnrichedGameData) *big.Int {
+func requiredCollateralForGame(game *monTypes.FaultGameData) *big.Int {
 	required := big.NewInt(0)
 	for _, claim := range game.Claims {
 		if !claim.Resolved {

--- a/op-dispute-mon/mon/bonds/collateral_test.go
+++ b/op-dispute-mon/mon/bonds/collateral_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
@@ -17,7 +16,7 @@ func TestCalculateRequiredCollateral(t *testing.T) {
 	weth1Balance := big.NewInt(4200)
 	weth2 := common.Address{0x2b}
 	weth2Balance := big.NewInt(6000)
-	game1 := &monTypes.EnrichedGameData{
+	game1 := &monTypes.FaultGameData{
 		Claims: []monTypes.EnrichedClaim{
 			{
 				Claim: types.Claim{
@@ -55,7 +54,7 @@ func TestCalculateRequiredCollateral(t *testing.T) {
 		WETHContract:  weth1,
 		ETHCollateral: weth1Balance,
 	}
-	game2 := &monTypes.EnrichedGameData{
+	game2 := &monTypes.FaultGameData{
 		Claims: []monTypes.EnrichedClaim{
 			{
 				Claim: types.Claim{
@@ -93,7 +92,7 @@ func TestCalculateRequiredCollateral(t *testing.T) {
 		WETHContract:  weth1,
 		ETHCollateral: weth1Balance,
 	}
-	game3 := &monTypes.EnrichedGameData{
+	game3 := &monTypes.FaultGameData{
 		Claims: []monTypes.EnrichedClaim{
 			{
 				Claim: types.Claim{
@@ -111,7 +110,7 @@ func TestCalculateRequiredCollateral(t *testing.T) {
 		WETHContract:  weth2,
 		ETHCollateral: weth2Balance,
 	}
-	actual := CalculateRequiredCollateral([]*monTypes.EnrichedGameData{game1, game2, game3})
+	actual := CalculateRequiredCollateral([]*monTypes.FaultGameData{game1, game2, game3})
 	require.Len(t, actual, 2)
 	require.Contains(t, actual, weth1)
 	require.Contains(t, actual, weth2)
@@ -119,15 +118,4 @@ func TestCalculateRequiredCollateral(t *testing.T) {
 	require.Equal(t, bigs.Uint64Strict(actual[weth1].Actual), bigs.Uint64Strict(weth1Balance))
 	require.Equal(t, bigs.Uint64Strict(actual[weth2].Required), uint64(23+46))
 	require.Equal(t, bigs.Uint64Strict(actual[weth2].Actual), bigs.Uint64Strict(weth2Balance))
-}
-
-func TestCalculateRequiredCollateralSkipsSuperPermissioned(t *testing.T) {
-	actual := CalculateRequiredCollateral([]*monTypes.EnrichedGameData{
-		{
-			GameMetadata: gameTypes.GameMetadata{
-				GameType: uint32(gameTypes.SuperPermissionedGameType),
-			},
-		},
-	})
-	require.Empty(t, actual)
 }

--- a/op-dispute-mon/mon/bonds/monitor.go
+++ b/op-dispute-mon/mon/bonds/monitor.go
@@ -33,7 +33,7 @@ func NewBonds(logger log.Logger, metrics BondMetrics, clock RClock) *Bonds {
 	}
 }
 
-func (b *Bonds) CheckBonds(games []*types.EnrichedGameData) {
+func (b *Bonds) CheckBonds(games []*types.FaultGameData) {
 	data := CalculateRequiredCollateral(games)
 	for addr, collateral := range data {
 		if collateral.Required.Cmp(collateral.Actual) > 0 {
@@ -45,7 +45,7 @@ func (b *Bonds) CheckBonds(games []*types.EnrichedGameData) {
 	b.checkCredits(games)
 }
 
-func (b *Bonds) checkCredits(games []*types.EnrichedGameData) {
+func (b *Bonds) checkCredits(games []*types.FaultGameData) {
 	creditMetrics := make(map[metrics.CreditExpectation]int)
 
 	for _, game := range games {

--- a/op-dispute-mon/mon/bonds/monitor_test.go
+++ b/op-dispute-mon/mon/bonds/monitor_test.go
@@ -26,14 +26,14 @@ func TestCheckBonds(t *testing.T) {
 	weth1Balance := big.NewInt(4200)
 	weth2 := common.Address{0x2b}
 	weth2Balance := big.NewInt(10) // Insufficient
-	game1 := &monTypes.EnrichedGameData{
+	game1 := &monTypes.FaultGameData{
 		Credits: map[common.Address]*big.Int{
 			common.Address{0x01}: big.NewInt(2),
 		},
 		WETHContract:  weth1,
 		ETHCollateral: weth1Balance,
 	}
-	game2 := &monTypes.EnrichedGameData{
+	game2 := &monTypes.FaultGameData{
 		Credits: map[common.Address]*big.Int{
 			common.Address{0x01}: big.NewInt(46),
 		},
@@ -42,7 +42,7 @@ func TestCheckBonds(t *testing.T) {
 	}
 
 	bonds, metrics, logs := setupBondMetricsTest(t)
-	bonds.CheckBonds([]*monTypes.EnrichedGameData{game1, game2})
+	bonds.CheckBonds([]*monTypes.FaultGameData{game1, game2})
 
 	require.Len(t, metrics.recorded, 2)
 	require.Contains(t, metrics.recorded, weth1)
@@ -61,20 +61,6 @@ func TestCheckBonds(t *testing.T) {
 	require.Nil(t, logs.FindLog(testlog.NewAttributesFilter("delayedWETH", weth1.Hex())))
 }
 
-func TestCheckBondsSkipsSuperPermissioned(t *testing.T) {
-	bonds, metrics, _ := setupBondMetricsTest(t)
-	game := &monTypes.EnrichedGameData{
-		GameMetadata: gameTypes.GameMetadata{
-			GameType: uint32(gameTypes.SuperPermissionedGameType),
-		},
-	}
-
-	require.NotPanics(t, func() {
-		bonds.CheckBonds([]*monTypes.EnrichedGameData{game})
-	})
-	require.Empty(t, metrics.recorded)
-}
-
 func TestCheckRecipientCredit(t *testing.T) {
 	addr1 := common.Address{0x11, 0xaa}
 	addr2 := common.Address{0x22, 0xbb}
@@ -82,13 +68,13 @@ func TestCheckRecipientCredit(t *testing.T) {
 	addr4 := common.Address{0x4d}
 	notRootPosition := types.NewPositionFromGIndex(big.NewInt(2))
 	// Game has not reached max duration
-	game1 := &monTypes.EnrichedGameData{
+	game1 := &monTypes.FaultGameData{
 		MaxClockDuration: 50000,
 		WETHDelay:        30 * time.Minute,
-		GameMetadata: gameTypes.GameMetadata{
+		CommonGameData: monTypes.CommonGameData{GameMetadata: gameTypes.GameMetadata{
 			Proxy:     common.Address{0x11},
 			Timestamp: uint64(frozen.Unix()),
-		},
+		}},
 		Claims: []monTypes.EnrichedClaim{
 			{ // Expect 10 credits for addr1
 				Claim: types.Claim{
@@ -155,13 +141,13 @@ func TestCheckRecipientCredit(t *testing.T) {
 		ETHCollateral: big.NewInt(6000),
 	}
 	// Max duration has been reached
-	game2 := &monTypes.EnrichedGameData{
+	game2 := &monTypes.FaultGameData{
 		MaxClockDuration: 5,
 		WETHDelay:        5 * time.Second,
-		GameMetadata: gameTypes.GameMetadata{
+		CommonGameData: monTypes.CommonGameData{GameMetadata: gameTypes.GameMetadata{
 			Proxy:     common.Address{0x22},
 			Timestamp: uint64(frozen.Unix()) - 11,
-		},
+		}},
 		Claims: []monTypes.EnrichedClaim{
 			{ // Expect 11 credits for addr1
 				Claim: types.Claim{
@@ -230,13 +216,13 @@ func TestCheckRecipientCredit(t *testing.T) {
 	}
 
 	// Game has not reached max duration
-	game3 := &monTypes.EnrichedGameData{
+	game3 := &monTypes.FaultGameData{
 		MaxClockDuration: 50000,
 		WETHDelay:        10 * time.Hour,
-		GameMetadata: gameTypes.GameMetadata{
+		CommonGameData: monTypes.CommonGameData{GameMetadata: gameTypes.GameMetadata{
 			Proxy:     common.Address{0x33},
 			Timestamp: uint64(frozen.Unix()) - 11,
-		},
+		}},
 		Claims: []monTypes.EnrichedClaim{
 			{ // Expect 9 credits for addr1
 				Claim: types.Claim{
@@ -284,13 +270,13 @@ func TestCheckRecipientCredit(t *testing.T) {
 	}
 
 	// Game has not reached max duration
-	game4 := &monTypes.EnrichedGameData{
+	game4 := &monTypes.FaultGameData{
 		MaxClockDuration: 10,
 		WETHDelay:        10 * time.Second,
-		GameMetadata: gameTypes.GameMetadata{
+		CommonGameData: monTypes.CommonGameData{GameMetadata: gameTypes.GameMetadata{
 			Proxy:     common.Address{0x44},
 			Timestamp: uint64(frozen.Unix()) - 22,
-		},
+		}},
 		BlockNumberChallenged: true,
 		BlockNumberChallenger: addr1,
 		Claims: []monTypes.EnrichedClaim{
@@ -341,7 +327,7 @@ func TestCheckRecipientCredit(t *testing.T) {
 	}
 
 	bonds, m, logs := setupBondMetricsTest(t)
-	bonds.CheckBonds([]*monTypes.EnrichedGameData{game1, game2, game3, game4})
+	bonds.CheckBonds([]*monTypes.FaultGameData{game1, game2, game3, game4})
 
 	require.Len(t, m.credits, 6)
 	require.Contains(t, m.credits, metrics.CreditBelowWithdrawable)

--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -33,7 +33,7 @@ func NewClaimMonitor(logger log.Logger, clock RClock, honestActors types.HonestA
 	return &ClaimMonitor{logger, clock, honestActors, metrics}
 }
 
-func (c *ClaimMonitor) CheckClaims(games []*types.EnrichedGameData) {
+func (c *ClaimMonitor) CheckClaims(games []*types.FaultGameData) {
 	claimStatuses := &metrics.ClaimStatuses{}
 	honest := make(map[common.Address]*metrics.HonestActorData)
 	for actor := range c.honestActors {
@@ -77,7 +77,7 @@ func (c *ClaimMonitor) checkUpdateHonestActorStats(proxy common.Address, claim *
 }
 
 func (c *ClaimMonitor) checkGameClaims(
-	game *types.EnrichedGameData,
+	game *types.FaultGameData,
 	claimStatuses *metrics.ClaimStatuses,
 	honest map[common.Address]*metrics.HonestActorData,
 ) {

--- a/op-dispute-mon/mon/claims_test.go
+++ b/op-dispute-mon/mon/claims_test.go
@@ -44,7 +44,7 @@ func TestClaimMonitor_CheckClaims(t *testing.T) {
 
 	t.Run("ZeroRecordsClaims", func(t *testing.T) {
 		monitor, _, cMetrics, _ := newTestClaimMonitor(t)
-		var games []*types.EnrichedGameData
+		var games []*types.FaultGameData
 		monitor.CheckClaims(games)
 		// Should record 0 values for true and false variants of the four fields in ClaimStatus
 		require.Len(t, cMetrics.calls, 2*2*2*2)
@@ -55,13 +55,13 @@ func TestClaimMonitor_CheckClaims(t *testing.T) {
 		chessClockDuration := 10 * time.Minute
 		// Game started long enough ago that the root chess clock has now expired
 		gameStart := frozen.Add(-chessClockDuration - 15*time.Minute)
-		games := []*types.EnrichedGameData{
+		games := []*types.FaultGameData{
 			{
 				MaxClockDuration: uint64(chessClockDuration.Seconds()),
-				GameMetadata: gameTypes.GameMetadata{
+				CommonGameData: types.CommonGameData{GameMetadata: gameTypes.GameMetadata{
 					Proxy:     common.Address{0xaa},
 					Timestamp: 50,
-				},
+				}},
 				Claims: []types.EnrichedClaim{
 					{
 						Claim: faultTypes.Claim{
@@ -223,15 +223,15 @@ func (s *stubClaimMetrics) RecordHonestActorClaims(address common.Address, data 
 	s.honest[address] = *data
 }
 
-func makeMultipleTestGames(duration uint64) []*types.EnrichedGameData {
-	return []*types.EnrichedGameData{
+func makeMultipleTestGames(duration uint64) []*types.FaultGameData {
+	return []*types.FaultGameData{
 		makeTestGame(duration),      // first half
 		makeTestGame(duration * 10), // second half
 	}
 }
 
-func makeTestGame(duration uint64) *types.EnrichedGameData {
-	return &types.EnrichedGameData{
+func makeTestGame(duration uint64) *types.FaultGameData {
+	return &types.FaultGameData{
 		MaxClockDuration: duration / 2,
 		Recipients: map[common.Address]bool{
 			{0x02}: true,

--- a/op-dispute-mon/mon/different_roots.go
+++ b/op-dispute-mon/mon/different_roots.go
@@ -21,7 +21,7 @@ func NewDifferentRootMonitor(logger log.Logger, metrics DifferentRootMetrics) *D
 	}
 }
 
-func (m *DifferentRootMonitor) CheckDifferentRoots(games []*types.EnrichedGameData) {
+func (m *DifferentRootMonitor) CheckDifferentRoots(games []*types.CommonGameData) {
 	count := 0
 	for _, game := range games {
 		if game.NodeEndpointDifferentRoots {

--- a/op-dispute-mon/mon/different_roots_test.go
+++ b/op-dispute-mon/mon/different_roots_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCheckDifferentRoots(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata:               gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointDifferentRoots: true,
@@ -65,7 +65,7 @@ func TestCheckDifferentRoots(t *testing.T) {
 }
 
 func TestCheckDifferentRoots_NoDisagreements(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata:               gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointDifferentRoots: false,
@@ -89,7 +89,7 @@ func TestCheckDifferentRoots_NoDisagreements(t *testing.T) {
 }
 
 func TestCheckDifferentRoots_EmptyGamesList(t *testing.T) {
-	games := []*types.EnrichedGameData{}
+	games := []*types.CommonGameData{}
 	metrics := &stubDifferentOutputRootMetrics{}
 	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
 	monitor := NewDifferentRootMonitor(logger, metrics)
@@ -104,7 +104,7 @@ func TestCheckDifferentRoots_EmptyGamesList(t *testing.T) {
 }
 
 func TestCheckDifferentRoots_AllGamesHaveDisagreements(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata:               gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointDifferentRoots: true,

--- a/op-dispute-mon/mon/extract/anchor_state_registry_enricher.go
+++ b/op-dispute-mon/mon/extract/anchor_state_registry_enricher.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var _ Enricher = (*AnchorStateRegistryEnricher)(nil)
+var _ CommonEnricher = (*AnchorStateRegistryEnricher)(nil)
 
 // AnchorStateRegistryEnricher records the address of the AnchorStateRegistry each game builds on.
 // This is best-effort: a game whose contract version does not expose anchorStateRegistry() is skipped
@@ -24,7 +24,7 @@ func NewAnchorStateRegistryEnricher(logger log.Logger) *AnchorStateRegistryEnric
 	return &AnchorStateRegistryEnricher{logger: logger}
 }
 
-func (e *AnchorStateRegistryEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
+func (e *AnchorStateRegistryEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.CommonGameData) error {
 	addr, err := caller.GetAnchorStateRegistry(ctx, block)
 	if errors.Is(err, contracts.ErrAnchorStateRegistryNotSupported) {
 		return nil

--- a/op-dispute-mon/mon/extract/anchor_state_registry_enricher_test.go
+++ b/op-dispute-mon/mon/extract/anchor_state_registry_enricher_test.go
@@ -21,7 +21,7 @@ func TestAnchorStateRegistryEnricher(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		enricher := NewAnchorStateRegistryEnricher(logger)
 		caller := &mockGameCaller{anchorStateRegistry: expected}
-		game := &types.EnrichedGameData{}
+		game := &types.CommonGameData{}
 		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
 		require.NoError(t, err)
 		require.Equal(t, expected, game.AnchorStateRegistry)
@@ -30,7 +30,7 @@ func TestAnchorStateRegistryEnricher(t *testing.T) {
 	t.Run("NotSupportedSkipsSilently", func(t *testing.T) {
 		enricher := NewAnchorStateRegistryEnricher(logger)
 		caller := &mockGameCaller{anchorStateRegErr: contracts.ErrAnchorStateRegistryNotSupported}
-		game := &types.EnrichedGameData{}
+		game := &types.CommonGameData{}
 		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
 		require.NoError(t, err)
 		require.Equal(t, common.Address{}, game.AnchorStateRegistry)
@@ -39,7 +39,7 @@ func TestAnchorStateRegistryEnricher(t *testing.T) {
 	t.Run("OtherErrorDoesNotFailGame", func(t *testing.T) {
 		enricher := NewAnchorStateRegistryEnricher(logger)
 		caller := &mockGameCaller{anchorStateRegErr: errors.New("boom")}
-		game := &types.EnrichedGameData{}
+		game := &types.CommonGameData{}
 		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
 		require.NoError(t, err)
 		require.Equal(t, common.Address{}, game.AnchorStateRegistry)

--- a/op-dispute-mon/mon/extract/balance_enricher.go
+++ b/op-dispute-mon/mon/extract/balance_enricher.go
@@ -6,13 +6,12 @@ import (
 	"math/big"
 	"time"
 
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var _ Enricher = (*BalanceEnricher)(nil)
+var _ FaultEnricher = (*BalanceEnricher)(nil)
 
 type BalanceCaller interface {
 	GetBalanceAndDelay(context.Context, rpcblock.Block) (*big.Int, time.Duration, common.Address, error)
@@ -24,10 +23,7 @@ func NewBalanceEnricher() *BalanceEnricher {
 	return &BalanceEnricher{}
 }
 
-func (b *BalanceEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
-	if gameTypes.GameType(game.GameType) == gameTypes.SuperPermissionedGameType {
-		return nil
-	}
+func (b *BalanceEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller FaultGameCaller, game *monTypes.FaultGameData) error {
 	balance, delay, holdingAddr, err := caller.GetBalanceAndDelay(ctx, block)
 	if err != nil {
 		return fmt.Errorf("failed to fetch balance: %w", err)

--- a/op-dispute-mon/mon/extract/balance_enricher_test.go
+++ b/op-dispute-mon/mon/extract/balance_enricher_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
@@ -18,7 +17,7 @@ func TestBalanceEnricher(t *testing.T) {
 	t.Run("GetBalanceError", func(t *testing.T) {
 		enricher := NewBalanceEnricher()
 		caller := &mockGameCaller{balanceErr: errors.New("nope")}
-		game := &types.EnrichedGameData{}
+		game := &types.FaultGameData{}
 		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
 		require.ErrorIs(t, err, caller.balanceErr)
 	})
@@ -30,7 +29,7 @@ func TestBalanceEnricher(t *testing.T) {
 			delayDuration: 3 * time.Hour,
 			balanceAddr:   common.Address{0xdd},
 		}
-		game := &types.EnrichedGameData{}
+		game := &types.FaultGameData{}
 		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
 		require.NoError(t, err)
 		require.Equal(t, game.WETHContract, caller.balanceAddr)
@@ -38,14 +37,4 @@ func TestBalanceEnricher(t *testing.T) {
 		require.Equal(t, game.WETHDelay, caller.delayDuration)
 	})
 
-	t.Run("SkipSuperPermissioned", func(t *testing.T) {
-		enricher := NewBalanceEnricher()
-		caller := &mockGameCaller{balanceErr: errors.New("nope")}
-		game := &types.EnrichedGameData{
-			GameMetadata: gameTypes.GameMetadata{GameType: uint32(gameTypes.SuperPermissionedGameType)},
-		}
-		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
-		require.NoError(t, err)
-		require.Nil(t, game.ETHCollateral)
-	})
 }

--- a/op-dispute-mon/mon/extract/bond_enricher.go
+++ b/op-dispute-mon/mon/extract/bond_enricher.go
@@ -9,13 +9,12 @@ import (
 	"slices"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var _ Enricher = (*BondEnricher)(nil)
+var _ FaultEnricher = (*BondEnricher)(nil)
 
 var ErrIncorrectCreditCount = errors.New("incorrect credit count")
 
@@ -30,10 +29,7 @@ func NewBondEnricher() *BondEnricher {
 	return &BondEnricher{}
 }
 
-func (b *BondEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
-	if gameTypes.GameType(game.GameType) == gameTypes.SuperPermissionedGameType {
-		return nil
-	}
+func (b *BondEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller FaultGameCaller, game *monTypes.FaultGameData) error {
 	recipientAddrs := slices.Collect(maps.Keys(game.Recipients))
 	credits, err := caller.GetCredits(ctx, block, recipientAddrs...)
 	if err != nil {

--- a/op-dispute-mon/mon/extract/bond_enricher_test.go
+++ b/op-dispute-mon/mon/extract/bond_enricher_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
@@ -15,8 +14,8 @@ import (
 )
 
 // makeTestGame returns an enriched game with 3 claims and a list of expected recipients.
-func makeTestGame() (*monTypes.EnrichedGameData, []common.Address) {
-	game := &monTypes.EnrichedGameData{
+func makeTestGame() (*monTypes.FaultGameData, []common.Address) {
+	game := &monTypes.FaultGameData{
 		Recipients: map[common.Address]bool{
 			common.Address{0x02}: true,
 			common.Address{0x03}: true,
@@ -100,14 +99,4 @@ func TestBondEnricher(t *testing.T) {
 		require.Equal(t, faultTypes.RefundDistributionMode, game.BondDistributionMode)
 	})
 
-	t.Run("SkipSuperPermissioned", func(t *testing.T) {
-		enricher := NewBondEnricher()
-		caller := &mockGameCaller{creditsErr: errors.New("nope")}
-		game := &monTypes.EnrichedGameData{
-			GameMetadata: gameTypes.GameMetadata{GameType: uint32(gameTypes.SuperPermissionedGameType)},
-		}
-		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
-		require.NoError(t, err)
-		require.Empty(t, caller.requestedCredits)
-	})
 }

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -24,14 +24,27 @@ type GameCallerMetrics interface {
 }
 
 type GameCaller interface {
-	GetWithdrawals(context.Context, rpcblock.Block, ...common.Address) ([]*contracts.WithdrawalRequest, error)
-	GetExtendedMetadata(context.Context, rpcblock.Block) (contracts.GameMetadata, error)
-	GetAllClaims(context.Context, rpcblock.Block) ([]faultTypes.Claim, error)
 	GetAnchorStateRegistry(context.Context, rpcblock.Block) (common.Address, error)
+}
+
+// MetadataCaller exposes metadata shared by fault and SuperPermissioned games.
+type MetadataCaller interface {
+	GetExtendedMetadata(context.Context, rpcblock.Block) (contracts.GameMetadata, error)
+}
+
+// FaultGameCaller exposes reads used only to enrich fault games.
+type FaultGameCaller interface {
+	GameCaller
+	MetadataCaller
+	GetWithdrawals(context.Context, rpcblock.Block, ...common.Address) ([]*contracts.WithdrawalRequest, error)
+	GetAllClaims(context.Context, rpcblock.Block) ([]faultTypes.Claim, error)
 	BondCaller
 	BalanceCaller
 	ClaimCaller
 }
+
+var _ FaultGameCaller = (contracts.FaultDisputeGameContract)(nil)
+var _ MetadataCaller = (*contracts.SuperPermissionedDisputeGameContract)(nil)
 
 type GameCallerCreator struct {
 	m      GameCallerMetrics

--- a/op-dispute-mon/mon/extract/claim_enricher.go
+++ b/op-dispute-mon/mon/extract/claim_enricher.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 )
 
-var _ Enricher = (*ClaimEnricher)(nil)
+var _ FaultEnricher = (*ClaimEnricher)(nil)
 
 type ClaimCaller interface {
 	IsResolved(ctx context.Context, block rpcblock.Block, claim ...faultTypes.Claim) ([]bool, error)
@@ -22,10 +21,7 @@ func NewClaimEnricher() *ClaimEnricher {
 	return &ClaimEnricher{}
 }
 
-func (e *ClaimEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *types.EnrichedGameData) error {
-	if gameTypes.GameType(game.GameType) == gameTypes.SuperPermissionedGameType {
-		return nil
-	}
+func (e *ClaimEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller FaultGameCaller, game *types.FaultGameData) error {
 	claims := make([]faultTypes.Claim, 0, len(game.Claims))
 	for _, claim := range game.Claims {
 		claims = append(claims, claim.Claim)

--- a/op-dispute-mon/mon/extract/claim_enricher_test.go
+++ b/op-dispute-mon/mon/extract/claim_enricher_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/stretchr/testify/require"
@@ -16,7 +15,7 @@ func TestClaimEnricher(t *testing.T) {
 	caller := &mockGameCaller{resolved: make(map[int]bool)}
 	enricher := NewClaimEnricher()
 	expected := []bool{true, false, false, false, false}
-	game := &types.EnrichedGameData{
+	game := &types.FaultGameData{
 		Claims: claimsWithResolvedSubgames(caller, expected...),
 	}
 	err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
@@ -30,22 +29,11 @@ func TestClaimEnricherError(t *testing.T) {
 	expectedErr := errors.New("boom")
 	caller := &mockGameCaller{resolved: make(map[int]bool), resolvedErr: expectedErr}
 	enricher := NewClaimEnricher()
-	game := &types.EnrichedGameData{
+	game := &types.FaultGameData{
 		Claims: claimsWithResolvedSubgames(caller, true, false),
 	}
 	err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
 	require.ErrorIs(t, err, expectedErr)
-}
-
-func TestClaimEnricherSkipsSuperPermissioned(t *testing.T) {
-	caller := &mockGameCaller{resolvedErr: errors.New("boom")}
-	enricher := NewClaimEnricher()
-	game := &types.EnrichedGameData{
-		GameMetadata: gameTypes.GameMetadata{GameType: uint32(gameTypes.SuperPermissionedGameType)},
-	}
-	err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
-	require.NoError(t, err)
-	require.Zero(t, caller.resolvedCalls)
 }
 
 func claimsWithResolvedSubgames(caller *mockGameCaller, resolved ...bool) []types.EnrichedClaim {

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -17,47 +17,62 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var (
-	ErrIgnored = errors.New("ignored")
-)
+var ErrIgnored = errors.New("ignored")
 
 type (
 	CreateGameCaller   func(ctx context.Context, game gameTypes.GameMetadata) (GameCaller, error)
 	FactoryGameFetcher func(ctx context.Context, blockHash common.Hash, earliestTimestamp uint64) ([]gameTypes.GameMetadata, error)
 )
 
-type Enricher interface {
-	Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error
+// CommonEnricher adds data shared by every enriched game variant.
+type CommonEnricher interface {
+	Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.CommonGameData) error
+}
+
+// FaultEnricher adds data that exists only for fault games.
+type FaultEnricher interface {
+	Enrich(ctx context.Context, block rpcblock.Block, caller FaultGameCaller, game *monTypes.FaultGameData) error
 }
 
 type Extractor struct {
-	logger         log.Logger
-	clock          clock.Clock
-	createContract CreateGameCaller
-	fetchGames     FactoryGameFetcher
-	maxConcurrency int
-	enrichers      []Enricher
-	ignoredGames   map[common.Address]bool
-	latestGameData map[common.Address]*monTypes.EnrichedGameData
+	logger          log.Logger
+	clock           clock.Clock
+	createContract  CreateGameCaller
+	fetchGames      FactoryGameFetcher
+	maxConcurrency  int
+	commonEnrichers []CommonEnricher
+	faultEnrichers  []FaultEnricher
+	ignoredGames    map[common.Address]bool
+	latestGameData  map[common.Address]monTypes.EnrichedGame
 }
 
-func NewExtractor(logger log.Logger, cl clock.Clock, creator CreateGameCaller, fetchGames FactoryGameFetcher, ignoredGames []common.Address, maxConcurrency uint, enrichers ...Enricher) *Extractor {
+func NewExtractor(
+	logger log.Logger,
+	cl clock.Clock,
+	creator CreateGameCaller,
+	fetchGames FactoryGameFetcher,
+	ignoredGames []common.Address,
+	maxConcurrency uint,
+	commonEnrichers []CommonEnricher,
+	faultEnrichers []FaultEnricher,
+) *Extractor {
 	ignored := make(map[common.Address]bool)
 	for _, game := range ignoredGames {
 		ignored[game] = true
 	}
 	return &Extractor{
-		logger:         logger,
-		clock:          cl,
-		createContract: creator,
-		fetchGames:     fetchGames,
-		maxConcurrency: int(maxConcurrency),
-		enrichers:      enrichers,
-		ignoredGames:   ignored,
+		logger:          logger,
+		clock:           cl,
+		createContract:  creator,
+		fetchGames:      fetchGames,
+		maxConcurrency:  int(maxConcurrency),
+		commonEnrichers: commonEnrichers,
+		faultEnrichers:  faultEnrichers,
+		ignoredGames:    ignored,
 	}
 }
 
-func (e *Extractor) Extract(ctx context.Context, blockHash common.Hash, minTimestamp uint64) ([]*monTypes.EnrichedGameData, int, int, error) {
+func (e *Extractor) Extract(ctx context.Context, blockHash common.Hash, minTimestamp uint64) ([]monTypes.EnrichedGame, int, int, error) {
 	games, err := e.fetchGames(ctx, blockHash, minTimestamp)
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("failed to load games: %w", err)
@@ -66,16 +81,14 @@ func (e *Extractor) Extract(ctx context.Context, blockHash common.Hash, minTimes
 	return enriched, ignored, failed, nil
 }
 
-func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, games []gameTypes.GameMetadata) ([]*monTypes.EnrichedGameData, int, int) {
+func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, games []gameTypes.GameMetadata) ([]monTypes.EnrichedGame, int, int) {
 	var ignored atomic.Int32
 	var failed atomic.Int32
 
 	var wg sync.WaitGroup
 	wg.Add(e.maxConcurrency)
 	gameCh := make(chan gameTypes.GameMetadata, e.maxConcurrency)
-	// Create a channel for enriched games. Must have enough capacity to hold all games.
-	enrichedCh := make(chan *monTypes.EnrichedGameData, len(games))
-	// Spin up multiple goroutines to enrich game data
+	enrichedCh := make(chan monTypes.EnrichedGame, len(games))
 	for i := 0; i < e.maxConcurrency; i++ {
 		go func() {
 			defer wg.Done()
@@ -86,7 +99,6 @@ func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, game
 				case game, ok := <-gameCh:
 					if !ok {
 						e.logger.Debug("Enriching complete")
-						// Channel closed
 						return
 					}
 					e.logger.Trace("Enriching game", "game", game.Proxy)
@@ -95,7 +107,8 @@ func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, game
 						ignored.Add(1)
 						e.logger.Warn("Ignoring game", "game", game.Proxy)
 						continue
-					} else if err != nil {
+					}
+					if err != nil {
 						failed.Add(1)
 						e.logger.Error("Failed to fetch game data", "game", game.Proxy, "err", err)
 						continue
@@ -106,9 +119,7 @@ func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, game
 		}()
 	}
 
-	// Create a new store for game data. This ensures any games no longer in the monitoring set are dropped.
-	updatedGameData := make(map[common.Address]*monTypes.EnrichedGameData)
-	// Push each game into the channel and store the latest cached game data as a default if fetching fails
+	updatedGameData := make(map[common.Address]monTypes.EnrichedGame)
 	for _, game := range games {
 		previousData := e.latestGameData[game.Proxy]
 		if previousData != nil {
@@ -117,19 +128,17 @@ func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, game
 		gameCh <- game
 	}
 	close(gameCh)
-	// Wait for games to finish being enriched then close enrichedCh since no future results will be published
 	wg.Wait()
 	close(enrichedCh)
 
-	// Read the results
 	for enrichedGame := range enrichedCh {
-		updatedGameData[enrichedGame.Proxy] = enrichedGame
+		updatedGameData[enrichedGame.Common().Proxy] = enrichedGame
 	}
 	e.latestGameData = updatedGameData
 	return slices.Collect(maps.Values(updatedGameData)), int(ignored.Load()), int(failed.Load())
 }
 
-func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game gameTypes.GameMetadata) (*monTypes.EnrichedGameData, error) {
+func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game gameTypes.GameMetadata) (monTypes.EnrichedGame, error) {
 	if e.ignoredGames[game.Proxy] {
 		return nil, ErrIgnored
 	}
@@ -137,11 +146,32 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create contracts: %w", err)
 	}
-	meta, err := caller.GetExtendedMetadata(ctx, rpcblock.ByHash(blockHash))
+	block := rpcblock.ByHash(blockHash)
+	switch gameTypes.GameType(game.GameType) {
+	case gameTypes.SuperPermissionedGameType:
+		return e.enrichSuperPermissionedGame(ctx, block, caller, game)
+	case gameTypes.CannonGameType,
+		gameTypes.PermissionedGameType,
+		gameTypes.CannonKonaGameType,
+		gameTypes.AlphabetGameType,
+		gameTypes.FastGameType,
+		gameTypes.SuperCannonKonaGameType:
+		return e.enrichFaultGame(ctx, block, caller, game)
+	default:
+		return nil, fmt.Errorf("unsupported game type: %d", game.GameType)
+	}
+}
+
+func (e *Extractor) enrichFaultGame(ctx context.Context, block rpcblock.Block, caller GameCaller, game gameTypes.GameMetadata) (monTypes.EnrichedGame, error) {
+	faultCaller, ok := caller.(FaultGameCaller)
+	if !ok {
+		return nil, fmt.Errorf("game caller %T does not support fault game extraction", caller)
+	}
+	meta, err := faultCaller.GetExtendedMetadata(ctx, block)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch game metadata: %w", err)
 	}
-	claims, err := caller.GetAllClaims(ctx, rpcblock.ByHash(blockHash))
+	claims, err := faultCaller.GetAllClaims(ctx, block)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch game claims: %w", err)
 	}
@@ -149,17 +179,50 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 	for i, claim := range claims {
 		enrichedClaims[i] = monTypes.EnrichedClaim{Claim: claim}
 	}
-	enrichedGame := &monTypes.EnrichedGameData{
+	enrichedGame := &monTypes.FaultGameData{
+		CommonGameData:        e.newCommonGameData(game, meta.L1Head, meta.L2SequenceNum, meta.RootClaim, meta.Status),
+		MaxClockDuration:      meta.MaxClockDuration,
+		BlockNumberChallenged: meta.L2BlockNumberChallenged,
+		BlockNumberChallenger: meta.L2BlockNumberChallenger,
+		Claims:                enrichedClaims,
+	}
+	for _, enricher := range e.faultEnrichers {
+		if err := enricher.Enrich(ctx, block, faultCaller, enrichedGame); err != nil {
+			return nil, fmt.Errorf("failed to enrich game: %w", err)
+		}
+	}
+	if err := e.applyCommonEnrichers(ctx, block, caller, enrichedGame.Common()); err != nil {
+		return nil, fmt.Errorf("failed to enrich game: %w", err)
+	}
+	return enrichedGame, nil
+}
+
+func (e *Extractor) enrichSuperPermissionedGame(ctx context.Context, block rpcblock.Block, caller GameCaller, game gameTypes.GameMetadata) (monTypes.EnrichedGame, error) {
+	metadataCaller, ok := caller.(MetadataCaller)
+	if !ok {
+		return nil, fmt.Errorf("game caller %T does not support common game extraction", caller)
+	}
+	meta, err := metadataCaller.GetExtendedMetadata(ctx, block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch game metadata: %w", err)
+	}
+	enrichedGame := &monTypes.SuperPermissionedGameData{
+		CommonGameData: e.newCommonGameData(game, meta.L1Head, meta.L2SequenceNum, meta.RootClaim, meta.Status),
+	}
+	if err := e.applyCommonEnrichers(ctx, block, caller, enrichedGame.Common()); err != nil {
+		return nil, fmt.Errorf("failed to enrich game: %w", err)
+	}
+	return enrichedGame, nil
+}
+
+func (e *Extractor) newCommonGameData(game gameTypes.GameMetadata, l1Head common.Hash, l2SequenceNumber uint64, rootClaim common.Hash, status gameTypes.GameStatus) monTypes.CommonGameData {
+	return monTypes.CommonGameData{
 		LastUpdateTime:             e.clock.Now(),
 		GameMetadata:               game,
-		L1Head:                     meta.L1Head,
-		L2SequenceNumber:           meta.L2SequenceNum,
-		RootClaim:                  meta.RootClaim,
-		Status:                     meta.Status,
-		MaxClockDuration:           meta.MaxClockDuration,
-		BlockNumberChallenged:      meta.L2BlockNumberChallenged,
-		BlockNumberChallenger:      meta.L2BlockNumberChallenger,
-		Claims:                     enrichedClaims,
+		L1Head:                     l1Head,
+		L2SequenceNumber:           l2SequenceNumber,
+		RootClaim:                  rootClaim,
+		Status:                     status,
 		NodeEndpointErrors:         make(map[string]bool),
 		NodeEndpointErrorCount:     0,
 		NodeEndpointNotFoundCount:  0,
@@ -169,15 +232,11 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 		NodeEndpointUnsafeCount:    0,
 		NodeEndpointDifferentRoots: false,
 	}
-	if err := e.applyEnrichers(ctx, blockHash, caller, enrichedGame); err != nil {
-		return nil, fmt.Errorf("failed to enrich game: %w", err)
-	}
-	return enrichedGame, nil
 }
 
-func (e *Extractor) applyEnrichers(ctx context.Context, blockHash common.Hash, caller GameCaller, game *monTypes.EnrichedGameData) error {
-	for _, enricher := range e.enrichers {
-		if err := enricher.Enrich(ctx, rpcblock.ByHash(blockHash), caller, game); err != nil {
+func (e *Extractor) applyCommonEnrichers(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.CommonGameData) error {
+	for _, enricher := range e.commonEnrichers {
+		if err := enricher.Enrich(ctx, block, caller, game); err != nil {
 			return err
 		}
 	}

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -216,10 +216,38 @@ func TestExtractorPinsFaultReadsAndPreservesEnricherOrder(t *testing.T) {
 	trace := make([]string, 0, 4)
 	faultEnricher := &mockFaultEnricher{name: "fault", trace: &trace}
 	commonEnricher := &mockEnricher{name: "common", trace: &trace}
-	extractor, creator, games, _, _ := setupExtractorTest(t, commonEnricher)
+	extractor, creator, games, _, cl := setupExtractorTest(t, commonEnricher)
 	extractor.faultEnrichers = []FaultEnricher{faultEnricher}
 	creator.caller.trace = &trace
-	games.games = []gameTypes.GameMetadata{{GameType: uint32(gameTypes.CannonGameType)}}
+	game := gameTypes.GameMetadata{
+		Index:     7,
+		GameType:  uint32(gameTypes.CannonGameType),
+		Timestamp: 11,
+		Proxy:     common.Address{0x12},
+	}
+	metadata := contracts.GameMetadata{
+		L1Head:                  common.Hash{0x23},
+		L2SequenceNum:           34,
+		RootClaim:               common.Hash{0x45},
+		Status:                  gameTypes.GameStatusChallengerWon,
+		MaxClockDuration:        56,
+		L2BlockNumberChallenged: true,
+		L2BlockNumberChallenger: common.Address{0x67},
+	}
+	claim := faultTypes.Claim{
+		ClaimData: faultTypes.ClaimData{
+			Value: common.Hash{0x78},
+			Bond:  big.NewInt(89),
+		},
+		CounteredBy:         common.Address{0x9a},
+		Claimant:            common.Address{0xab},
+		Clock:               faultTypes.NewClock(2*time.Minute, time.Unix(123, 0)),
+		ContractIndex:       2,
+		ParentContractIndex: 1,
+	}
+	creator.caller.metadata = metadata
+	creator.caller.claims = []faultTypes.Claim{claim}
+	games.games = []gameTypes.GameMetadata{game}
 	blockHash := common.Hash{0xab}
 
 	enriched, ignored, failed, err := extractor.Extract(t.Context(), blockHash, 0)
@@ -227,6 +255,21 @@ func TestExtractorPinsFaultReadsAndPreservesEnricherOrder(t *testing.T) {
 	require.Zero(t, ignored)
 	require.Zero(t, failed)
 	require.Len(t, enriched, 1)
+	require.Equal(t, &monTypes.FaultGameData{
+		CommonGameData: monTypes.CommonGameData{
+			GameMetadata:       game,
+			LastUpdateTime:     cl.Now(),
+			L1Head:             metadata.L1Head,
+			L2SequenceNumber:   metadata.L2SequenceNum,
+			RootClaim:          metadata.RootClaim,
+			Status:             metadata.Status,
+			NodeEndpointErrors: make(map[string]bool),
+		},
+		MaxClockDuration:      metadata.MaxClockDuration,
+		BlockNumberChallenged: metadata.L2BlockNumberChallenged,
+		BlockNumberChallenger: metadata.L2BlockNumberChallenger,
+		Claims:                []monTypes.EnrichedClaim{{Claim: claim}},
+	}, enriched[0])
 	require.Equal(t, []string{"metadata", "claims", "fault", "common"}, trace)
 	expectedBlock := rpcblock.ByHash(blockHash)
 	require.Equal(t, []rpcblock.Block{expectedBlock}, creator.caller.metadataBlocks)
@@ -254,7 +297,10 @@ func verifyLogs(t *testing.T, logs *testlog.CapturingHandler, createErr, metadat
 func setupExtractorTest(t *testing.T, enrichers ...CommonEnricher) (*Extractor, *mockGameCallerCreator, *mockGameFetcher, *testlog.CapturingHandler, *clock.DeterministicClock) {
 	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
 	games := &mockGameFetcher{}
-	caller := &mockGameCaller{rootClaim: mockRootClaim}
+	caller := &mockGameCaller{metadata: contracts.GameMetadata{
+		L1Head:    common.Hash{0xaa},
+		RootClaim: mockRootClaim,
+	}}
 	creator := &mockGameCallerCreator{caller: caller}
 	cl := clock.NewDeterministicClock(time.Unix(48294294, 58))
 	extractor := NewExtractor(
@@ -303,7 +349,7 @@ type mockGameCaller struct {
 	metadataErr          error
 	claimsCalls          int
 	claimsErr            error
-	rootClaim            common.Hash
+	metadata             contracts.GameMetadata
 	claims               []faultTypes.Claim
 	requestedCredits     []common.Address
 	creditsErr           error
@@ -356,10 +402,7 @@ func (m *mockGameCaller) GetExtendedMetadata(_ context.Context, block rpcblock.B
 	if m.metadataErr != nil {
 		return contracts.GameMetadata{}, m.metadataErr
 	}
-	return contracts.GameMetadata{
-		L1Head:    common.Hash{0xaa},
-		RootClaim: mockRootClaim,
-	}, nil
+	return m.metadata, nil
 }
 
 func (m *mockGameCaller) GetAnchorStateRegistry(_ context.Context, _ rpcblock.Block) (common.Address, error) {

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -210,6 +210,28 @@ func TestExtractor_Extract(t *testing.T) {
 	})
 }
 
+func TestExtractorPinsFaultReadsAndPreservesEnricherOrder(t *testing.T) {
+	trace := make([]string, 0, 4)
+	first := &mockEnricher{name: "first", trace: &trace}
+	second := &mockEnricher{name: "second", trace: &trace}
+	extractor, creator, games, _, _ := setupExtractorTest(t, first, second)
+	creator.caller.trace = &trace
+	games.games = []gameTypes.GameMetadata{{GameType: uint32(gameTypes.CannonGameType)}}
+	blockHash := common.Hash{0xab}
+
+	enriched, ignored, failed, err := extractor.Extract(t.Context(), blockHash, 0)
+	require.NoError(t, err)
+	require.Zero(t, ignored)
+	require.Zero(t, failed)
+	require.Len(t, enriched, 1)
+	require.Equal(t, []string{"metadata", "claims", "first", "second"}, trace)
+	expectedBlock := rpcblock.ByHash(blockHash)
+	require.Equal(t, []rpcblock.Block{expectedBlock}, creator.caller.metadataBlocks)
+	require.Equal(t, []rpcblock.Block{expectedBlock}, creator.caller.claimBlocks)
+	require.Equal(t, []rpcblock.Block{expectedBlock}, first.blocks)
+	require.Equal(t, []rpcblock.Block{expectedBlock}, second.blocks)
+}
+
 func verifyLogs(t *testing.T, logs *testlog.CapturingHandler, createErr, metadataErr, claimsErr, durationErr int) {
 	errorLevelFilter := testlog.NewLevelFilter(log.LevelError)
 	createMessageFilter := testlog.NewAttributesContainsFilter("err", "failed to create contracts")
@@ -296,6 +318,9 @@ type mockGameCaller struct {
 	resolved             map[int]bool
 	anchorStateRegistry  common.Address
 	anchorStateRegErr    error
+	metadataBlocks       []rpcblock.Block
+	claimBlocks          []rpcblock.Block
+	trace                *[]string
 }
 
 func (m *mockGameCaller) GetWithdrawals(_ context.Context, _ rpcblock.Block, _ ...common.Address) ([]*contracts.WithdrawalRequest, error) {
@@ -318,8 +343,12 @@ func (m *mockGameCaller) GetWithdrawals(_ context.Context, _ rpcblock.Block, _ .
 	}, nil
 }
 
-func (m *mockGameCaller) GetExtendedMetadata(_ context.Context, _ rpcblock.Block) (contracts.GameMetadata, error) {
+func (m *mockGameCaller) GetExtendedMetadata(_ context.Context, block rpcblock.Block) (contracts.GameMetadata, error) {
 	m.metadataCalls++
+	m.metadataBlocks = append(m.metadataBlocks, block)
+	if m.trace != nil {
+		*m.trace = append(*m.trace, "metadata")
+	}
 	if m.metadataErr != nil {
 		return contracts.GameMetadata{}, m.metadataErr
 	}
@@ -336,8 +365,12 @@ func (m *mockGameCaller) GetAnchorStateRegistry(_ context.Context, _ rpcblock.Bl
 	return m.anchorStateRegistry, nil
 }
 
-func (m *mockGameCaller) GetAllClaims(_ context.Context, _ rpcblock.Block) ([]faultTypes.Claim, error) {
+func (m *mockGameCaller) GetAllClaims(_ context.Context, block rpcblock.Block) ([]faultTypes.Claim, error) {
 	m.claimsCalls++
+	m.claimBlocks = append(m.claimBlocks, block)
+	if m.trace != nil {
+		*m.trace = append(*m.trace, "claims")
+	}
 	if m.claimsErr != nil {
 		return nil, m.claimsErr
 	}
@@ -410,10 +443,17 @@ type mockEnricher struct {
 	err    error
 	calls  int
 	action func(game *monTypes.EnrichedGameData) error
+	name   string
+	trace  *[]string
+	blocks []rpcblock.Block
 }
 
-func (m *mockEnricher) Enrich(_ context.Context, _ rpcblock.Block, _ GameCaller, game *monTypes.EnrichedGameData) error {
+func (m *mockEnricher) Enrich(_ context.Context, block rpcblock.Block, _ GameCaller, game *monTypes.EnrichedGameData) error {
 	m.calls++
+	m.blocks = append(m.blocks, block)
+	if m.trace != nil {
+		*m.trace = append(*m.trace, m.name)
+	}
 	if m.action != nil {
 		return m.action(game)
 	}

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -147,7 +147,7 @@ func TestExtractor_Extract(t *testing.T) {
 		require.Zero(t, failed)
 		require.Len(t, enriched, 1)
 		require.Equal(t, 1, enricher1.calls)
-		require.Equal(t, enriched[0].Proxy, common.Address{0xaa})
+		require.Equal(t, enriched[0].Common().Proxy, common.Address{0xaa})
 		require.NotNil(t, logs.FindLog(
 			testlog.NewLevelFilter(log.LevelWarn),
 			testlog.NewMessageFilter("Ignoring game"),
@@ -156,7 +156,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 	t.Run("UseCachedValueOnFailure", func(t *testing.T) {
 		enricher := &mockEnricher{
-			action: func(game *monTypes.EnrichedGameData) error {
+			action: func(game *monTypes.CommonGameData) error {
 				game.Status = gameTypes.GameStatusDefenderWon
 				return nil
 			},
@@ -176,12 +176,12 @@ func TestExtractor_Extract(t *testing.T) {
 		firstUpdateTime := cl.Now()
 		// All results should have current LastUpdateTime
 		for _, data := range enriched {
-			require.Equal(t, firstUpdateTime, data.LastUpdateTime)
+			require.Equal(t, firstUpdateTime, data.Common().LastUpdateTime)
 		}
 
 		cl.AdvanceTime(2 * time.Minute)
 		secondUpdateTime := cl.Now()
-		enricher.action = func(game *monTypes.EnrichedGameData) error {
+		enricher.action = func(game *monTypes.CommonGameData) error {
 			if game.Proxy == gameA {
 				return errors.New("boom")
 			}
@@ -197,9 +197,9 @@ func TestExtractor_Extract(t *testing.T) {
 		require.Len(t, enriched, 2)
 		require.Equal(t, 4, enricher.calls)
 		// The returned games are not in a fixed order, create a map to look up the game we need to assert
-		actual := make(map[common.Address]*monTypes.EnrichedGameData)
+		actual := make(map[common.Address]*monTypes.CommonGameData)
 		for _, data := range enriched {
-			actual[data.Proxy] = data
+			actual[data.Common().Proxy] = data.Common()
 		}
 		require.Contains(t, actual, gameA)
 		require.Contains(t, actual, gameB)
@@ -211,10 +211,13 @@ func TestExtractor_Extract(t *testing.T) {
 }
 
 func TestExtractorPinsFaultReadsAndPreservesEnricherOrder(t *testing.T) {
+	// Mutation killed: moving either enricher lane ahead of claims, or using a
+	// different block selector for one read, survives value-only extractor tests.
 	trace := make([]string, 0, 4)
-	first := &mockEnricher{name: "first", trace: &trace}
-	second := &mockEnricher{name: "second", trace: &trace}
-	extractor, creator, games, _, _ := setupExtractorTest(t, first, second)
+	faultEnricher := &mockFaultEnricher{name: "fault", trace: &trace}
+	commonEnricher := &mockEnricher{name: "common", trace: &trace}
+	extractor, creator, games, _, _ := setupExtractorTest(t, commonEnricher)
+	extractor.faultEnrichers = []FaultEnricher{faultEnricher}
 	creator.caller.trace = &trace
 	games.games = []gameTypes.GameMetadata{{GameType: uint32(gameTypes.CannonGameType)}}
 	blockHash := common.Hash{0xab}
@@ -224,12 +227,12 @@ func TestExtractorPinsFaultReadsAndPreservesEnricherOrder(t *testing.T) {
 	require.Zero(t, ignored)
 	require.Zero(t, failed)
 	require.Len(t, enriched, 1)
-	require.Equal(t, []string{"metadata", "claims", "first", "second"}, trace)
+	require.Equal(t, []string{"metadata", "claims", "fault", "common"}, trace)
 	expectedBlock := rpcblock.ByHash(blockHash)
 	require.Equal(t, []rpcblock.Block{expectedBlock}, creator.caller.metadataBlocks)
 	require.Equal(t, []rpcblock.Block{expectedBlock}, creator.caller.claimBlocks)
-	require.Equal(t, []rpcblock.Block{expectedBlock}, first.blocks)
-	require.Equal(t, []rpcblock.Block{expectedBlock}, second.blocks)
+	require.Equal(t, []rpcblock.Block{expectedBlock}, faultEnricher.blocks)
+	require.Equal(t, []rpcblock.Block{expectedBlock}, commonEnricher.blocks)
 }
 
 func verifyLogs(t *testing.T, logs *testlog.CapturingHandler, createErr, metadataErr, claimsErr, durationErr int) {
@@ -248,7 +251,7 @@ func verifyLogs(t *testing.T, logs *testlog.CapturingHandler, createErr, metadat
 	require.Len(t, l, durationErr)
 }
 
-func setupExtractorTest(t *testing.T, enrichers ...Enricher) (*Extractor, *mockGameCallerCreator, *mockGameFetcher, *testlog.CapturingHandler, *clock.DeterministicClock) {
+func setupExtractorTest(t *testing.T, enrichers ...CommonEnricher) (*Extractor, *mockGameCallerCreator, *mockGameFetcher, *testlog.CapturingHandler, *clock.DeterministicClock) {
 	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
 	games := &mockGameFetcher{}
 	caller := &mockGameCaller{rootClaim: mockRootClaim}
@@ -261,7 +264,8 @@ func setupExtractorTest(t *testing.T, enrichers ...Enricher) (*Extractor, *mockG
 		games.FetchGames,
 		ignoredGames,
 		5,
-		enrichers...,
+		enrichers,
+		nil,
 	)
 	return extractor, creator, games, capturedLogs, cl
 }
@@ -425,7 +429,7 @@ func TestExtractor_EnrichGameInitializesRollupEndpointErrorCount(t *testing.T) {
 	require.Zero(t, ignored)
 	require.Zero(t, failed)
 	require.Len(t, enriched, 1)
-	require.Equal(t, 0, enriched[0].NodeEndpointErrorCount, "NodeEndpointErrorCount should be initialized to 0")
+	require.Equal(t, 0, enriched[0].Common().NodeEndpointErrorCount, "NodeEndpointErrorCount should be initialized to 0")
 }
 
 func TestExtractor_EnrichGameInitializesRollupEndpointOutOfSyncCount(t *testing.T) {
@@ -436,19 +440,31 @@ func TestExtractor_EnrichGameInitializesRollupEndpointOutOfSyncCount(t *testing.
 	require.Zero(t, ignored)
 	require.Zero(t, failed)
 	require.Len(t, enriched, 1)
-	require.Equal(t, 0, enriched[0].NodeEndpointOutOfSyncCount, "NodeEndpointOutOfSyncCount should be initialized to 0")
+	require.Equal(t, 0, enriched[0].Common().NodeEndpointOutOfSyncCount, "NodeEndpointOutOfSyncCount should be initialized to 0")
 }
 
 type mockEnricher struct {
 	err    error
 	calls  int
-	action func(game *monTypes.EnrichedGameData) error
+	action func(game *monTypes.CommonGameData) error
 	name   string
 	trace  *[]string
 	blocks []rpcblock.Block
 }
 
-func (m *mockEnricher) Enrich(_ context.Context, block rpcblock.Block, _ GameCaller, game *monTypes.EnrichedGameData) error {
+type mockFaultEnricher struct {
+	name   string
+	trace  *[]string
+	blocks []rpcblock.Block
+}
+
+func (m *mockFaultEnricher) Enrich(_ context.Context, block rpcblock.Block, _ FaultGameCaller, _ *monTypes.FaultGameData) error {
+	m.blocks = append(m.blocks, block)
+	*m.trace = append(*m.trace, m.name)
+	return nil
+}
+
+func (m *mockEnricher) Enrich(_ context.Context, block rpcblock.Block, _ GameCaller, game *monTypes.CommonGameData) error {
 	m.calls++
 	m.blocks = append(m.blocks, block)
 	if m.trace != nil {

--- a/op-dispute-mon/mon/extract/head_enricher.go
+++ b/op-dispute-mon/mon/extract/head_enricher.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var _ Enricher = (*L1HeadBlockNumEnricher)(nil)
+var _ CommonEnricher = (*L1HeadBlockNumEnricher)(nil)
 
 type BlockFetcher interface {
 	L1BlockRefByHash(ctx context.Context, block common.Hash) (eth.L1BlockRef, error)
@@ -24,7 +24,7 @@ func NewL1HeadBlockNumEnricher(client BlockFetcher) *L1HeadBlockNumEnricher {
 	return &L1HeadBlockNumEnricher{client: client}
 }
 
-func (e *L1HeadBlockNumEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _ GameCaller, game *monTypes.EnrichedGameData) error {
+func (e *L1HeadBlockNumEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _ GameCaller, game *monTypes.CommonGameData) error {
 	header, err := e.client.L1BlockRefByHash(ctx, game.L1Head)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve header for L1 head block %v: %w", game.L1Head, err)

--- a/op-dispute-mon/mon/extract/head_enricher_test.go
+++ b/op-dispute-mon/mon/extract/head_enricher_test.go
@@ -17,7 +17,7 @@ func TestL1HeadEnricher(t *testing.T) {
 		client := &stubBlockFetcher{err: errors.New("boom")}
 		enricher := NewL1HeadBlockNumEnricher(client)
 		caller := &mockGameCaller{}
-		game := &types.EnrichedGameData{}
+		game := &types.CommonGameData{}
 		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
 		require.ErrorIs(t, err, client.err)
 	})
@@ -26,7 +26,7 @@ func TestL1HeadEnricher(t *testing.T) {
 		client := &stubBlockFetcher{num: 5000}
 		enricher := NewL1HeadBlockNumEnricher(client)
 		caller := &mockGameCaller{}
-		game := &types.EnrichedGameData{}
+		game := &types.CommonGameData{}
 		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
 		require.NoError(t, err)
 		require.Equal(t, client.num, game.L1HeadNum)

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -57,7 +57,7 @@ type outputResult struct {
 }
 
 // Enrich validates the specified root claim against the output at the given block number.
-func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
+func (o *OutputAgreementEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _ GameCaller, game *monTypes.CommonGameData) error {
 	if !game.UsesOutputRoots() {
 		return nil
 	}

--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -26,7 +26,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 	t.Run("ErrorWhenNoRollupClient", func(t *testing.T) {
 		validator, _, _ := setupOutputValidatorTest(t)
 		validator.clients = nil
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
 			},
@@ -46,7 +46,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
 				validator, _, metrics := setupOutputValidatorTest(t)
 				validator.clients = nil // Should not error even though there's no rollup client
-				game := &types.EnrichedGameData{
+				game := &types.CommonGameData{
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
 					},
@@ -67,7 +67,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			gameType := gameType
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
 				validator, _, metrics := setupOutputValidatorTest(t)
-				game := &types.EnrichedGameData{
+				game := &types.CommonGameData{
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
 					},
@@ -87,7 +87,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		for _, client := range clients {
 			client.outputErr = errors.New("boom")
 		}
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
 			RootClaim:          mockRootClaim,
@@ -103,7 +103,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		for _, client := range clients {
 			client.outputErr = nil
 		}
-		game = &types.EnrichedGameData{
+		game = &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
 			RootClaim:          mockRootClaim,
@@ -121,7 +121,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		for _, client := range clients {
 			client.outputErr = mockNotFoundRPCError()
 		}
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
 			RootClaim:          mockRootClaim,
@@ -139,7 +139,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[0].currentL1 = 99
 		clients[1].currentL1 = 100 // Out of sync because it is only equal to the game L1 head
 		clients[2].currentL1 = 0
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:        100,
 			L2SequenceNumber: 0,
 			RootClaim:        mockRootClaim,
@@ -156,7 +156,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[0].currentL1 = 99
 		// Would disagree but will be ignored because node is not in sync
 		clients[0].outputRoot = common.Hash{0xaa, 0xbb, 0xcc, 0xdd}
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:        100,
 			L2SequenceNumber: 0,
 			RootClaim:        mockRootClaim,
@@ -173,7 +173,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[0].outputErr = mockNotFoundRPCError()
 		clients[1].outputErr = nil
 		clients[2].outputErr = nil
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
 			RootClaim:          mockRootClaim,
@@ -194,7 +194,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[2].safeHeadNum = 100
 		clients[3].outputRoot = mockRootClaim
 		clients[3].safeHeadNum = 100
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   50,
 			RootClaim:          mockRootClaim,
@@ -213,7 +213,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[0].outputErr = mockNotFoundRPCError()
 		clients[1].outputRoot = differentRoot
 		clients[2].outputRoot = differentRoot
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   50,
 			RootClaim:          mockRootClaim,
@@ -232,7 +232,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[0].outputRoot = mockRootClaim
 		clients[1].outputRoot = divergedRoot
 		clients[2].outputRoot = divergedRoot
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
 			RootClaim:          mockRootClaim,
@@ -250,7 +250,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[0].safeHeadNum = 100
 		clients[1].safeHeadNum = 99
 		clients[2].safeHeadNum = 101
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
 			RootClaim:          mockRootClaim,
@@ -268,7 +268,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[0].safeHeadErr = errors.New("boom")
 		clients[1].safeHeadErr = nil
 		clients[2].safeHeadErr = nil
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
 			RootClaim:          mockRootClaim,
@@ -286,7 +286,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[0].safeHeadNum = 50
 		clients[1].safeHeadNum = 60
 		clients[2].safeHeadNum = 70
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   80,
 			RootClaim:          mockRootClaim,
@@ -307,7 +307,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			client.safeHeadNum = 40
 		}
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   50, // Higher than all safe heads
 			RootClaim:          mockRootClaim,
@@ -330,7 +330,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			// Safe head numbers don't matter here since the output doesn't match the claim
 		}
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   50,
 			RootClaim:          mockRootClaim,
@@ -349,7 +349,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		// RPC block numbers must be a int64 to be valid. Anything bigger than that should be treated as invalid
 		// without even making a request to the node.
 		rollup.outputErr = errors.New("should not have even requested the output root")
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			L1HeadNum:          100,
 			L2SequenceNumber:   uint64(math.MaxInt64) + 1,
 			RootClaim:          mockRootClaim,
@@ -366,7 +366,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		t.Run("SingleNodeError", func(t *testing.T) {
 			validator, client, _ := setupOutputValidatorTest(t)
 			client.outputErr = errors.New("connection failed")
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -387,7 +387,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			clients[2].outputErr = errors.New("server error")
 			// clients[1] will succeed
 
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -408,7 +408,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		t.Run("NotFoundErrorsNotRecorded", func(t *testing.T) {
 			validator, client, _ := setupOutputValidatorTest(t)
 			client.outputErr = mockNotFoundRPCError()
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -429,7 +429,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		t.Run("SingleNodeErrorCount", func(t *testing.T) {
 			validator, client, _ := setupOutputValidatorTest(t)
 			client.outputErr = errors.New("connection failed")
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -451,7 +451,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			clients[2].outputErr = errors.New("another error")
 			// clients[3] will succeed
 
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -472,7 +472,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			clients[1].outputErr = mockNotFoundRPCError()
 			// clients[2] will succeed
 
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -494,7 +494,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			clients[2].outputErr = errors.New("server error")     // Should be counted
 			// clients[3] will succeed
 
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -518,7 +518,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			clients[1].currentL1 = 400
 			clients[2].currentL1 = 500
 
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -539,7 +539,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			clients[1].currentL1 = 300
 			clients[2].currentL1 = 400
 
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -561,7 +561,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			clients[2].currentL1 = 50  // Out of sync
 			clients[3].currentL1 = 300 // In sync
 
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -582,7 +582,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			clients[1].currentL1 = 100 // Equal to game L1 head, considered out of sync
 			clients[2].currentL1 = 0
 
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -605,7 +605,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			clients[3].outputErr = mockNotFoundRPCError() // Not found (not counted as error)
 			clients[4].currentL1 = 300                    // In sync and succeeds
 
-			game := &types.EnrichedGameData{
+			game := &types.CommonGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
 				},
@@ -727,7 +727,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 		clients[2].outputRoot = rootClaim
 		clients[2].safeHeadNum = 150
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
 			},
@@ -758,7 +758,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 			client.safeHeadNum = 100 // All would be safe if checked
 		}
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
 			},
@@ -793,7 +793,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 		clients[2].outputRoot = rootClaim
 		clients[2].safeHeadNum = 50
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
 			},
@@ -823,7 +823,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 			client.safeHeadNum = 100
 		}
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
 			},
@@ -852,7 +852,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 		clients[1].outputRoot = divergedRoot
 		clients[2].outputRoot = divergedRoot
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
 			},
@@ -876,7 +876,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 			client.outputRoot = mockRootClaim
 		}
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
 			},
@@ -900,7 +900,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 		clients[1].outputRoot = mockRootClaim
 		clients[2].outputErr = mockNotFoundRPCError() // This client returns "not found"
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
 			},
@@ -926,7 +926,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 		clients[1].outputRoot = mockRootClaim
 		clients[2].outputRoot = divergedRoot
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
 			},
@@ -950,7 +950,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 			client.outputErr = errors.New("rpc error")
 		}
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
 			},

--- a/op-dispute-mon/mon/extract/recipient_enricher.go
+++ b/op-dispute-mon/mon/extract/recipient_enricher.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var _ Enricher = (*RecipientEnricher)(nil)
+var _ FaultEnricher = (*RecipientEnricher)(nil)
 
 type RecipientEnricher struct{}
 
@@ -16,7 +16,7 @@ func NewRecipientEnricher() *RecipientEnricher {
 	return &RecipientEnricher{}
 }
 
-func (w *RecipientEnricher) Enrich(_ context.Context, _ rpcblock.Block, _ GameCaller, game *monTypes.EnrichedGameData) error {
+func (w *RecipientEnricher) Enrich(_ context.Context, _ rpcblock.Block, _ FaultGameCaller, game *monTypes.FaultGameData) error {
 	recipients := make(map[common.Address]bool)
 	for _, claim := range game.Claims {
 		if claim.CounteredBy != (common.Address{}) {

--- a/op-dispute-mon/mon/extract/super_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher.go
@@ -46,7 +46,7 @@ type superRootResult struct {
 	err       error
 }
 
-func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
+func (e *SuperAgreementEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _ GameCaller, game *monTypes.CommonGameData) error {
 	if game.UsesOutputRoots() {
 		return nil
 	}

--- a/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
@@ -24,7 +24,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	t.Run("ErrorWhenNoSuperRootProvider", func(t *testing.T) {
 		validator, _, _ := setupSuperValidatorTest(t)
 		validator.clients = nil // Set to nil to test the error case
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -45,7 +45,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
 				validator, _, metrics := setupSuperValidatorTest(t)
 				validator.clients = nil // Should not error even though there's no super root RPC client
-				game := &types.EnrichedGameData{
+				game := &types.CommonGameData{
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
 					},
@@ -67,7 +67,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			gameType := gameType
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
 				validator, _, metrics := setupSuperValidatorTest(t)
-				game := &types.EnrichedGameData{
+				game := &types.CommonGameData{
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
 					},
@@ -86,7 +86,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	t.Run("OutputFetchFails", func(t *testing.T) {
 		validator, rollup, metrics := setupSuperValidatorTest(t)
 		rollup.outputErr = errors.New("boom")
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -105,7 +105,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 
 	t.Run("OutputMismatch_Safe", func(t *testing.T) {
 		validator, _, metrics := setupSuperValidatorTest(t)
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -124,7 +124,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	t.Run("OutputMatches_Safe_DerivedFromGameHead", func(t *testing.T) {
 		validator, client, metrics := setupSuperValidatorTest(t)
 		client.derivedFromL1BlockNum = 200
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -143,7 +143,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	t.Run("OutputMatches_Safe_DerivedFromBeforeGameHead", func(t *testing.T) {
 		validator, client, metrics := setupSuperValidatorTest(t)
 		client.derivedFromL1BlockNum = 199
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -162,7 +162,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	t.Run("OutputMismatch_NotSafe", func(t *testing.T) {
 		validator, client, metrics := setupSuperValidatorTest(t)
 		client.derivedFromL1BlockNum = 101
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -181,7 +181,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	t.Run("OutputMatches_NotSafe", func(t *testing.T) {
 		validator, client, metrics := setupSuperValidatorTest(t)
 		client.derivedFromL1BlockNum = 201
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -200,7 +200,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	t.Run("OutputNotFound", func(t *testing.T) {
 		validator, client, metrics := setupSuperValidatorTest(t)
 		client.notFound = true
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -221,7 +221,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		for _, client := range clients {
 			client.outputErr = errors.New("boom")
 		}
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -243,7 +243,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		for _, client := range clients {
 			client.notFound = true
 		}
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -264,7 +264,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		clients[0].notFound = true
 		clients[1].outputErr = nil
 		clients[2].outputErr = nil
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -286,7 +286,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		clients[0].superRoot = mockRootClaim
 		clients[1].superRoot = divergedRoot
 		clients[2].superRoot = divergedRoot
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -307,7 +307,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		clients[0].derivedFromL1BlockNum = 200
 		clients[1].derivedFromL1BlockNum = 199
 		clients[2].derivedFromL1BlockNum = 201
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -331,7 +331,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		clients[2].derivedFromL1BlockNum = 100 // Safe because L1HeadNum is 200
 		clients[3].superRoot = mockRootClaim
 		clients[3].derivedFromL1BlockNum = 150 // Safe because L1HeadNum is 200
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -355,7 +355,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		clients[1].derivedFromL1BlockNum = 100
 		clients[2].superRoot = differentRoot
 		clients[2].derivedFromL1BlockNum = 150
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -379,7 +379,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			client.derivedFromL1BlockNum = 250 // Not safe because L1HeadNum is 200
 		}
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -404,7 +404,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			client.derivedFromL1BlockNum = 100 // Safe because L1HeadNum is 200
 		}
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -479,7 +479,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 		clients[2].superRoot = mockRootClaim
 		clients[2].derivedFromL1BlockNum = 100
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999, // Super root game type
 			},
@@ -507,7 +507,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 		clients[2].superRoot = mockRootClaim
 		clients[2].derivedFromL1BlockNum = 100
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -538,7 +538,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 		clients[3].superRoot = mockRootClaim
 		clients[3].derivedFromL1BlockNum = 300 // Unsafe
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -568,7 +568,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 		clients[2].superRoot = divergedRoot
 		clients[2].derivedFromL1BlockNum = 100
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -593,7 +593,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 		clients[2].superRoot = mockRootClaim
 		clients[2].derivedFromL1BlockNum = 100
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
@@ -615,7 +615,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 		logger := testlog.Logger(t, log.LvlInfo)
 		validator := NewSuperAgreementEnricher(logger, &stubOutputMetrics{}, []SuperRootProvider{}, clock.NewDeterministicClock(time.Unix(9824924, 499)))
 
-		game := &types.EnrichedGameData{
+		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},

--- a/op-dispute-mon/mon/extract/super_permissioned_integration_test.go
+++ b/op-dispute-mon/mon/extract/super_permissioned_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
@@ -56,13 +57,11 @@ func TestExtractorChecksSuperPermissionedGame(t *testing.T) {
 		fetchGames,
 		nil,
 		1,
-		NewClaimEnricher(),
-		NewRecipientEnricher(),
-		NewWithdrawalsEnricher(),
-		NewBondEnricher(),
-		NewBalanceEnricher(),
-		NewL1HeadBlockNumEnricher(&stubBlockFetcher{num: l1HeadNum}),
-		NewSuperAgreementEnricher(logger, metrics, []SuperRootProvider{provider}, clock.NewDeterministicClock(time.Unix(9824924, 499))),
+		[]CommonEnricher{
+			NewL1HeadBlockNumEnricher(&stubBlockFetcher{num: l1HeadNum}),
+			NewSuperAgreementEnricher(logger, metrics, []SuperRootProvider{provider}, clock.NewDeterministicClock(time.Unix(9824924, 499))),
+		},
+		nil,
 	)
 
 	games, ignored, failed, err := extractor.Extract(context.Background(), blockHash, 0)
@@ -71,17 +70,15 @@ func TestExtractorChecksSuperPermissionedGame(t *testing.T) {
 	require.Zero(t, failed)
 	require.Len(t, games, 1)
 
-	game := games[0]
+	game, ok := games[0].(*monTypes.SuperPermissionedGameData)
+	require.True(t, ok)
 	require.Equal(t, uint32(gameTypes.SuperPermissionedGameType), game.GameType)
 	require.Equal(t, l1Head, game.L1Head)
 	require.Equal(t, l1HeadNum, game.L1HeadNum)
 	require.Equal(t, l2SequenceNumber, game.L2SequenceNumber)
 	require.Equal(t, gameTypes.GameStatusDefenderWon, game.Status)
-	require.Empty(t, game.Claims)
 	require.True(t, game.AgreeWithClaim)
 	require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
 	require.Equal(t, l2SequenceNumber, provider.requestedTimestamp)
 	require.NotZero(t, metrics.fetchTime)
-	require.Nil(t, game.ETHCollateral)
-	require.Equal(t, common.Address{}, game.WETHContract)
 }

--- a/op-dispute-mon/mon/extract/withdrawals_enricher.go
+++ b/op-dispute-mon/mon/extract/withdrawals_enricher.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
@@ -16,7 +15,7 @@ import (
 
 var ErrIncorrectWithdrawalsCount = errors.New("incorrect withdrawals count")
 
-var _ Enricher = (*WithdrawalsEnricher)(nil)
+var _ FaultEnricher = (*WithdrawalsEnricher)(nil)
 
 type WithdrawalsEnricher struct{}
 
@@ -24,10 +23,7 @@ func NewWithdrawalsEnricher() *WithdrawalsEnricher {
 	return &WithdrawalsEnricher{}
 }
 
-func (w *WithdrawalsEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
-	if gameTypes.GameType(game.GameType) == gameTypes.SuperPermissionedGameType {
-		return nil
-	}
+func (w *WithdrawalsEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller FaultGameCaller, game *monTypes.FaultGameData) error {
 	recipients := slices.Collect(maps.Keys(game.Recipients))
 	withdrawals, err := caller.GetWithdrawals(ctx, block, recipients...)
 	if err != nil {

--- a/op-dispute-mon/mon/extract/withdrawals_enricher_test.go
+++ b/op-dispute-mon/mon/extract/withdrawals_enricher_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
@@ -16,8 +15,8 @@ import (
 )
 
 func TestWithdrawalsEnricher(t *testing.T) {
-	makeGame := func() *monTypes.EnrichedGameData {
-		return &monTypes.EnrichedGameData{
+	makeGame := func() *monTypes.FaultGameData {
+		return &monTypes.FaultGameData{
 			Recipients: map[common.Address]bool{
 				common.Address{0x02}: true,
 				common.Address{0x03}: true,
@@ -80,14 +79,4 @@ func TestWithdrawalsEnricher(t *testing.T) {
 		require.Equal(t, 2, len(game.WithdrawalRequests))
 	})
 
-	t.Run("SkipSuperPermissioned", func(t *testing.T) {
-		enricher := NewWithdrawalsEnricher()
-		caller := &mockGameCaller{withdrawalsErr: errors.New("nope")}
-		game := &monTypes.EnrichedGameData{
-			GameMetadata: gameTypes.GameMetadata{GameType: uint32(gameTypes.SuperPermissionedGameType)},
-		}
-		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
-		require.NoError(t, err)
-		require.Zero(t, caller.withdrawalsCalls)
-	})
 }

--- a/op-dispute-mon/mon/forecast.go
+++ b/op-dispute-mon/mon/forecast.go
@@ -2,6 +2,7 @@ package mon
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
@@ -50,7 +51,7 @@ func NewForecast(logger log.Logger, metrics ForecastMetrics) *Forecast {
 	}
 }
 
-func (f *Forecast) Forecast(games []*monTypes.EnrichedGameData, ignoredCount, failedCount int) {
+func (f *Forecast) Forecast(games []monTypes.EnrichedGame, ignoredCount, failedCount int) {
 	batch := forecastBatch{}
 	for _, game := range games {
 		if err := f.forecastGame(game, &batch); err != nil {
@@ -78,34 +79,35 @@ func (f *Forecast) recordBatch(batch forecastBatch, ignoredCount, failedCount in
 	f.metrics.RecordFailedGames(failedCount)
 }
 
-func (f *Forecast) forecastGame(game *monTypes.EnrichedGameData, metrics *forecastBatch) error {
+func (f *Forecast) forecastGame(game monTypes.EnrichedGame, metrics *forecastBatch) error {
+	common := game.Common()
 	// Check the root agreement.
-	agreement := game.AgreeWithClaim
-	expected := game.ExpectedRootClaim
+	agreement := common.AgreeWithClaim
+	expected := common.ExpectedRootClaim
 
 	expectedResult := types.GameStatusDefenderWon
 	if !agreement {
 		expectedResult = types.GameStatusChallengerWon
-		if metrics.LatestInvalidProposal < game.Timestamp {
-			metrics.LatestInvalidProposal = game.Timestamp
+		if metrics.LatestInvalidProposal < common.Timestamp {
+			metrics.LatestInvalidProposal = common.Timestamp
 		}
 	} else {
-		if metrics.LatestValidProposal < game.Timestamp {
-			metrics.LatestValidProposal = game.Timestamp
+		if metrics.LatestValidProposal < common.Timestamp {
+			metrics.LatestValidProposal = common.Timestamp
 		}
-		if metrics.LatestValidProposalL2Block < game.L2SequenceNumber {
-			metrics.LatestValidProposalL2Block = game.L2SequenceNumber
+		if metrics.LatestValidProposalL2Block < common.L2SequenceNumber {
+			metrics.LatestValidProposalL2Block = common.L2SequenceNumber
 		}
 	}
 
-	if game.Status != types.GameStatusInProgress {
-		if game.Status != expectedResult {
+	if common.Status != types.GameStatusInProgress {
+		if common.Status != expectedResult {
 			f.logger.Error("Unexpected game result",
-				"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber,
-				"expectedResult", expectedResult, "actualResult", game.Status,
-				"rootClaim", game.RootClaim, "correctClaim", expected)
+				"game", common.Proxy, "l2SequenceNumber", common.L2SequenceNumber,
+				"expectedResult", expectedResult, "actualResult", common.Status,
+				"rootClaim", common.RootClaim, "correctClaim", expected)
 		}
-		switch game.Status {
+		switch common.Status {
 		case types.GameStatusDefenderWon:
 			if agreement {
 				metrics.AgreeDefenderWins++
@@ -123,26 +125,31 @@ func (f *Forecast) forecastGame(game *monTypes.EnrichedGameData, metrics *foreca
 	}
 
 	var forecastStatus types.GameStatus
-	if types.GameType(game.GameType) == types.SuperPermissionedGameType {
+	switch game := game.(type) {
+	case *monTypes.SuperPermissionedGameData:
 		// Unreachable since super permissioned games resolve immediately, unless the game was misconfigured!
-		f.logger.Error("Found super permissioned game still in progress, this should be impossible, check game configuration", "game", game.Proxy)
+		f.logger.Error("Found super permissioned game still in progress, this should be impossible, check game configuration", "game", common.Proxy)
 		// Since we don't know how an in-progress super permissioned game would resolve, we assume the worst and induce an unexpected forecast so mnonitoring can alert on this case.
 		if agreement {
 			forecastStatus = types.GameStatusChallengerWon
 		} else {
 			forecastStatus = types.GameStatusDefenderWon
 		}
-	} else if game.BlockNumberChallenged {
-		// Games that have their block number challenged are won
-		// by the challenger since the counter is proven on-chain.
-		f.logger.Debug("Found game with challenged block number",
-			"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber, "agreement", agreement)
-		// If the block number is challenged the challenger will always win
-		forecastStatus = types.GameStatusChallengerWon
-	} else {
-		// Otherwise we go through the resolution process to determine who would win based on the current claims
-		tree := transform.CreateBidirectionalTree(game.Claims)
-		forecastStatus = Resolve(tree)
+	case *monTypes.FaultGameData:
+		if game.BlockNumberChallenged {
+			// Games that have their block number challenged are won
+			// by the challenger since the counter is proven on-chain.
+			f.logger.Debug("Found game with challenged block number",
+				"game", common.Proxy, "l2SequenceNumber", common.L2SequenceNumber, "agreement", agreement)
+			// If the block number is challenged the challenger will always win
+			forecastStatus = types.GameStatusChallengerWon
+		} else {
+			// Otherwise we go through the resolution process to determine who would win based on the current claims
+			tree := transform.CreateBidirectionalTree(game.Claims)
+			forecastStatus = Resolve(tree)
+		}
+	default:
+		return fmt.Errorf("unsupported enriched game variant %T", game)
 	}
 
 	if agreement {
@@ -150,26 +157,26 @@ func (f *Forecast) forecastGame(game *monTypes.EnrichedGameData, metrics *foreca
 		if forecastStatus == types.GameStatusChallengerWon {
 			metrics.AgreeChallengerAhead++
 			f.logger.Warn("Forecasting unexpected game result", "status", forecastStatus,
-				"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber,
-				"rootClaim", game.RootClaim, "expected", expected)
+				"game", common.Proxy, "l2SequenceNumber", common.L2SequenceNumber,
+				"rootClaim", common.RootClaim, "expected", expected)
 		} else {
 			metrics.AgreeDefenderAhead++
 			f.logger.Debug("Forecasting expected game result", "status", forecastStatus,
-				"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber,
-				"rootClaim", game.RootClaim, "expected", expected)
+				"game", common.Proxy, "l2SequenceNumber", common.L2SequenceNumber,
+				"rootClaim", common.RootClaim, "expected", expected)
 		}
 	} else {
 		// If we disagree with the output root proposal, the Challenger should win, challenging that claim.
 		if forecastStatus == types.GameStatusDefenderWon {
 			metrics.DisagreeDefenderAhead++
 			f.logger.Warn("Forecasting unexpected game result", "status", forecastStatus,
-				"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber,
-				"rootClaim", game.RootClaim, "expected", expected)
+				"game", common.Proxy, "l2SequenceNumber", common.L2SequenceNumber,
+				"rootClaim", common.RootClaim, "expected", expected)
 		} else {
 			metrics.DisagreeChallengerAhead++
 			f.logger.Debug("Forecasting expected game result", "status", forecastStatus,
-				"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber,
-				"rootClaim", game.RootClaim, "expected", expected)
+				"game", common.Proxy, "l2SequenceNumber", common.L2SequenceNumber,
+				"rootClaim", common.RootClaim, "expected", expected)
 		}
 	}
 

--- a/op-dispute-mon/mon/forecast_registry_test.go
+++ b/op-dispute-mon/mon/forecast_registry_test.go
@@ -1,0 +1,83 @@
+package mon_test
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForecastRecordsCanonicalAgreementSeries(t *testing.T) {
+	metricer := metrics.NewMetrics()
+	forecast := mon.NewForecast(testlog.Logger(t, 0), metricer)
+	forecast.Forecast([]*monTypes.EnrichedGameData{
+		{Status: types.GameStatusInProgress, AgreeWithClaim: true, BlockNumberChallenged: true},
+		{Status: types.GameStatusInProgress, AgreeWithClaim: false, BlockNumberChallenged: true},
+		{Status: types.GameStatusInProgress, AgreeWithClaim: true},
+		{Status: types.GameStatusInProgress, AgreeWithClaim: false},
+		{Status: types.GameStatusDefenderWon, AgreeWithClaim: true},
+		{Status: types.GameStatusDefenderWon, AgreeWithClaim: false},
+		{Status: types.GameStatusChallengerWon, AgreeWithClaim: true},
+		{Status: types.GameStatusChallengerWon, AgreeWithClaim: false},
+	}, 0, 0)
+
+	expected := map[string]map[string]string{
+		"agree_challenger_ahead":    agreementLabels("agree_challenger_ahead", "in_progress", "incorrect", "agree"),
+		"disagree_challenger_ahead": agreementLabels("disagree_challenger_ahead", "in_progress", "correct", "disagree"),
+		"agree_defender_ahead":      agreementLabels("agree_defender_ahead", "in_progress", "correct", "agree"),
+		"disagree_defender_ahead":   agreementLabels("disagree_defender_ahead", "in_progress", "incorrect", "disagree"),
+		"agree_defender_wins":       agreementLabels("agree_defender_wins", "complete", "correct", "agree"),
+		"disagree_defender_wins":    agreementLabels("disagree_defender_wins", "complete", "incorrect", "disagree"),
+		"agree_challenger_wins":     agreementLabels("agree_challenger_wins", "complete", "incorrect", "agree"),
+		"disagree_challenger_wins":  agreementLabels("disagree_challenger_wins", "complete", "correct", "disagree"),
+	}
+	family := gatherMetricFamily(t, metricer, "op_dispute_mon_games_agreement")
+	require.Len(t, family.Metric, len(expected))
+	for _, sample := range family.Metric {
+		labels := metricLabels(sample)
+		require.Equal(t, expected[labels["status"]], labels)
+		require.Equal(t, float64(1), sample.GetGauge().GetValue())
+	}
+
+	forecast.Forecast(nil, 0, 0)
+	family = gatherMetricFamily(t, metricer, "op_dispute_mon_games_agreement")
+	require.Len(t, family.Metric, len(expected))
+	for _, sample := range family.Metric {
+		require.Zero(t, sample.GetGauge().GetValue())
+	}
+}
+
+func gatherMetricFamily(t *testing.T, metricer *metrics.Metrics, name string) *dto.MetricFamily {
+	t.Helper()
+	families, err := metricer.Registry().Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() == name {
+			return family
+		}
+	}
+	t.Fatalf("metric family %q not found", name)
+	return nil
+}
+
+func agreementLabels(status, completion, correctness, agreement string) map[string]string {
+	return map[string]string{
+		"status":             status,
+		"completion":         completion,
+		"result_correctness": correctness,
+		"root_agreement":     agreement,
+	}
+}
+
+func metricLabels(metric *dto.Metric) map[string]string {
+	labels := make(map[string]string, len(metric.Label))
+	for _, label := range metric.Label {
+		labels[label.GetName()] = label.GetValue()
+	}
+	return labels
+}

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -28,7 +28,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("NoGames", func(t *testing.T) {
 		forecast, _, logs := setupForecastTest(t)
-		forecast.Forecast([]*monTypes.EnrichedGameData{}, 0, 0)
+		forecast.Forecast([]monTypes.EnrichedGame{}, 0, 0)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
@@ -36,8 +36,8 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("ChallengerWonGame_Agree", func(t *testing.T) {
 		forecast, m, logs := setupForecastTest(t)
-		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusChallengerWon, RootClaim: mockRootClaim, AgreeWithClaim: true}
-		forecast.Forecast([]*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
+		expectedGame := monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusChallengerWon, RootClaim: mockRootClaim, AgreeWithClaim: true}}
+		forecast.Forecast([]monTypes.EnrichedGame{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
@@ -51,8 +51,8 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("ChallengerWonGame_Disagree", func(t *testing.T) {
 		forecast, m, logs := setupForecastTest(t)
-		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusChallengerWon, RootClaim: common.Hash{0xbb}, AgreeWithClaim: false}
-		forecast.Forecast([]*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
+		expectedGame := monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusChallengerWon, RootClaim: common.Hash{0xbb}, AgreeWithClaim: false}}
+		forecast.Forecast([]monTypes.EnrichedGame{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.Nil(t, l)
 
@@ -63,8 +63,8 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("DefenderWonGame_Agree", func(t *testing.T) {
 		forecast, m, logs := setupForecastTest(t)
-		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusDefenderWon, RootClaim: mockRootClaim, AgreeWithClaim: true}
-		forecast.Forecast([]*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
+		expectedGame := monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusDefenderWon, RootClaim: mockRootClaim, AgreeWithClaim: true}}
+		forecast.Forecast([]monTypes.EnrichedGame{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.Nil(t, l)
 
@@ -75,8 +75,8 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("DefenderWonGame_Disagree", func(t *testing.T) {
 		forecast, m, logs := setupForecastTest(t)
-		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusDefenderWon, RootClaim: common.Hash{0xbb}, AgreeWithClaim: false}
-		forecast.Forecast([]*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
+		expectedGame := monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusDefenderWon, RootClaim: common.Hash{0xbb}, AgreeWithClaim: false}}
+		forecast.Forecast([]monTypes.EnrichedGame{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
@@ -90,12 +90,14 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("SuperPermissionedDefenderWonGame_Disagree", func(t *testing.T) {
 		forecast, m, logs := setupForecastTest(t)
-		expectedGame := monTypes.EnrichedGameData{
-			GameMetadata: types.GameMetadata{GameType: uint32(types.SuperPermissionedGameType)},
-			Status:       types.GameStatusDefenderWon,
-			RootClaim:    common.Hash{0xbb},
+		expectedGame := monTypes.SuperPermissionedGameData{
+			CommonGameData: monTypes.CommonGameData{
+				GameMetadata: types.GameMetadata{GameType: uint32(types.SuperPermissionedGameType)},
+				Status:       types.GameStatusDefenderWon,
+				RootClaim:    common.Hash{0xbb},
+			},
 		}
-		forecast.Forecast([]*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
+		forecast.Forecast([]monTypes.EnrichedGame{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
@@ -108,12 +110,14 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	})
 	t.Run("SuperPermissionedInProgress_Disagree", func(t *testing.T) {
 		forecast, m, logs := setupForecastTest(t)
-		expectedGame := monTypes.EnrichedGameData{
-			GameMetadata: types.GameMetadata{GameType: uint32(types.SuperPermissionedGameType)},
-			Status:       types.GameStatusInProgress,
-			RootClaim:    common.Hash{0xbb},
+		expectedGame := monTypes.SuperPermissionedGameData{
+			CommonGameData: monTypes.CommonGameData{
+				GameMetadata: types.GameMetadata{GameType: uint32(types.SuperPermissionedGameType)},
+				Status:       types.GameStatusInProgress,
+				RootClaim:    common.Hash{0xbb},
+			},
 		}
-		forecast.Forecast([]*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
+		forecast.Forecast([]monTypes.EnrichedGame{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter("Found super permissioned game still in progress, this should be impossible, check game configuration"))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
@@ -124,13 +128,15 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	})
 	t.Run("SuperPermissionedInProgress_Agree", func(t *testing.T) {
 		forecast, m, logs := setupForecastTest(t)
-		expectedGame := monTypes.EnrichedGameData{
-			GameMetadata:   types.GameMetadata{GameType: uint32(types.SuperPermissionedGameType)},
-			Status:         types.GameStatusInProgress,
-			RootClaim:      common.Hash{0xbb},
-			AgreeWithClaim: true,
+		expectedGame := monTypes.SuperPermissionedGameData{
+			CommonGameData: monTypes.CommonGameData{
+				GameMetadata:   types.GameMetadata{GameType: uint32(types.SuperPermissionedGameType)},
+				Status:         types.GameStatusInProgress,
+				RootClaim:      common.Hash{0xbb},
+				AgreeWithClaim: true,
+			},
 		}
-		forecast.Forecast([]*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
+		forecast.Forecast([]monTypes.EnrichedGame{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter("Found super permissioned game still in progress, this should be impossible, check game configuration"))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
@@ -142,13 +148,13 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("SingleGame", func(t *testing.T) {
 		forecast, _, logs := setupForecastTest(t)
-		forecast.Forecast([]*monTypes.EnrichedGameData{{}}, 0, 0)
+		forecast.Forecast([]monTypes.EnrichedGame{&monTypes.FaultGameData{}}, 0, 0)
 		require.Nil(t, logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(failedForecastLog)))
 	})
 
 	t.Run("MultipleGames", func(t *testing.T) {
 		forecast, _, logs := setupForecastTest(t)
-		forecast.Forecast([]*monTypes.EnrichedGameData{{}, {}, {}}, 0, 0)
+		forecast.Forecast([]monTypes.EnrichedGame{&monTypes.FaultGameData{}, &monTypes.FaultGameData{}, &monTypes.FaultGameData{}}, 0, 0)
 		require.Nil(t, logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(failedForecastLog)))
 	})
 }
@@ -158,13 +164,11 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 
 	t.Run("BlockNumberChallenged_AgreeWithChallenge", func(t *testing.T) {
 		forecast, m, logs := setupForecastTest(t)
-		expectedGame := monTypes.EnrichedGameData{
-			Status:                types.GameStatusInProgress,
+		expectedGame := monTypes.FaultGameData{
+			CommonGameData:        monTypes.CommonGameData{Status: types.GameStatusInProgress, L2SequenceNumber: 6, AgreeWithClaim: false},
 			BlockNumberChallenged: true,
-			L2SequenceNumber:      6,
-			AgreeWithClaim:        false,
 		}
-		forecast.Forecast([]*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
+		forecast.Forecast([]monTypes.EnrichedGame{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelDebug), testlog.NewMessageFilter("Found game with challenged block number"))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
@@ -179,13 +183,11 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 
 	t.Run("BlockNumberChallenged_DisagreeWithChallenge", func(t *testing.T) {
 		forecast, m, logs := setupForecastTest(t)
-		expectedGame := monTypes.EnrichedGameData{
-			Status:                types.GameStatusInProgress,
+		expectedGame := monTypes.FaultGameData{
+			CommonGameData:        monTypes.CommonGameData{Status: types.GameStatusInProgress, L2SequenceNumber: 6, AgreeWithClaim: true},
 			BlockNumberChallenged: true,
-			L2SequenceNumber:      6,
-			AgreeWithClaim:        true,
 		}
-		forecast.Forecast([]*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
+		forecast.Forecast([]monTypes.EnrichedGame{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelDebug), testlog.NewMessageFilter("Found game with challenged block number"))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
@@ -200,12 +202,14 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 
 	t.Run("AgreeDefenderWins", func(t *testing.T) {
 		forecast, _, logs := setupForecastTest(t)
-		games := []*monTypes.EnrichedGameData{{
-			Status:            types.GameStatusInProgress,
-			RootClaim:         mockRootClaim,
-			Claims:            createDeepClaimList()[:1],
-			AgreeWithClaim:    true,
-			ExpectedRootClaim: mockRootClaim,
+		games := []monTypes.EnrichedGame{&monTypes.FaultGameData{
+			CommonGameData: monTypes.CommonGameData{
+				Status:            types.GameStatusInProgress,
+				RootClaim:         mockRootClaim,
+				AgreeWithClaim:    true,
+				ExpectedRootClaim: mockRootClaim,
+			},
+			Claims: createDeepClaimList()[:1],
 		}}
 		forecast.Forecast(games, 0, 0)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
@@ -222,12 +226,14 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 
 	t.Run("AgreeChallengerWins", func(t *testing.T) {
 		forecast, _, logs := setupForecastTest(t)
-		games := []*monTypes.EnrichedGameData{{
-			Status:            types.GameStatusInProgress,
-			RootClaim:         mockRootClaim,
-			Claims:            createDeepClaimList()[:2],
-			AgreeWithClaim:    true,
-			ExpectedRootClaim: mockRootClaim,
+		games := []monTypes.EnrichedGame{&monTypes.FaultGameData{
+			CommonGameData: monTypes.CommonGameData{
+				Status:            types.GameStatusInProgress,
+				RootClaim:         mockRootClaim,
+				AgreeWithClaim:    true,
+				ExpectedRootClaim: mockRootClaim,
+			},
+			Claims: createDeepClaimList()[:2],
 		}}
 		forecast.Forecast(games, 0, 0)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
@@ -244,11 +250,13 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 
 	t.Run("DisagreeChallengerWins", func(t *testing.T) {
 		forecast, _, logs := setupForecastTest(t)
-		forecast.Forecast([]*monTypes.EnrichedGameData{{
-			Status:            types.GameStatusInProgress,
-			Claims:            createDeepClaimList()[:2],
-			AgreeWithClaim:    false,
-			ExpectedRootClaim: mockRootClaim,
+		forecast.Forecast([]monTypes.EnrichedGame{&monTypes.FaultGameData{
+			CommonGameData: monTypes.CommonGameData{
+				Status:            types.GameStatusInProgress,
+				AgreeWithClaim:    false,
+				ExpectedRootClaim: mockRootClaim,
+			},
+			Claims: createDeepClaimList()[:2],
 		}}, 0, 0)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -264,11 +272,13 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 
 	t.Run("DisagreeDefenderWins", func(t *testing.T) {
 		forecast, _, logs := setupForecastTest(t)
-		forecast.Forecast([]*monTypes.EnrichedGameData{{
-			Status:            types.GameStatusInProgress,
-			Claims:            createDeepClaimList()[:1],
-			AgreeWithClaim:    false,
-			ExpectedRootClaim: mockRootClaim,
+		forecast.Forecast([]monTypes.EnrichedGame{&monTypes.FaultGameData{
+			CommonGameData: monTypes.CommonGameData{
+				Status:            types.GameStatusInProgress,
+				AgreeWithClaim:    false,
+				ExpectedRootClaim: mockRootClaim,
+			},
+			Claims: createDeepClaimList()[:1],
 		}}, 0, 0)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -318,18 +328,20 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 		{},            // Expected latest invalid proposal (will have timestamp 7)
 		mockRootClaim, // Expected latest valid proposal (will have timestamp 8)
 	}
-	games := make([]*monTypes.EnrichedGameData, 9)
+	games := make([]monTypes.EnrichedGame, 9)
 	for i := range games {
-		games[i] = &monTypes.EnrichedGameData{
-			Status:           gameStatus[i],
-			Claims:           claims[i],
-			RootClaim:        rootClaims[i],
-			L2SequenceNumber: uint64(i),
-			GameMetadata: types.GameMetadata{
-				Timestamp: uint64(i),
+		games[i] = &monTypes.FaultGameData{
+			CommonGameData: monTypes.CommonGameData{
+				Status:           gameStatus[i],
+				RootClaim:        rootClaims[i],
+				L2SequenceNumber: uint64(i),
+				GameMetadata: types.GameMetadata{
+					Timestamp: uint64(i),
+				},
+				AgreeWithClaim:    rootClaims[i] == mockRootClaim,
+				ExpectedRootClaim: mockRootClaim,
 			},
-			AgreeWithClaim:    rootClaims[i] == mockRootClaim,
-			ExpectedRootClaim: mockRootClaim,
+			Claims: claims[i],
 		}
 	}
 	forecast.Forecast(games, 3, 4)

--- a/op-dispute-mon/mon/game_types.go
+++ b/op-dispute-mon/mon/game_types.go
@@ -17,7 +17,7 @@ func NewGameTypeMonitor(metrics GameTypeMetrics) *GameTypeMonitor {
 	return &GameTypeMonitor{metrics: metrics}
 }
 
-func (m *GameTypeMonitor) CheckGameTypes(games []*types.EnrichedGameData) {
+func (m *GameTypeMonitor) CheckGameTypes(games []*types.CommonGameData) {
 	counts := make(map[string]int)
 	for _, game := range games {
 		gt := gameTypes.GameType(game.GameType).String()

--- a/op-dispute-mon/mon/l2_challenges.go
+++ b/op-dispute-mon/mon/l2_challenges.go
@@ -21,7 +21,7 @@ func NewL2ChallengesMonitor(logger log.Logger, metrics L2ChallengesMetrics) *L2C
 	}
 }
 
-func (m *L2ChallengesMonitor) CheckL2Challenges(games []*types.EnrichedGameData) {
+func (m *L2ChallengesMonitor) CheckL2Challenges(games []*types.FaultGameData) {
 	agreeChallengeCount := 0
 	disagreeChallengeCount := 0
 	for _, game := range games {

--- a/op-dispute-mon/mon/l2_challenges_test.go
+++ b/op-dispute-mon/mon/l2_challenges_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func TestMonitorL2Challenges(t *testing.T) {
-	games := []*types.EnrichedGameData{
-		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x44}}, BlockNumberChallenged: true, AgreeWithClaim: true, L2SequenceNumber: 44, BlockNumberChallenger: common.Address{0x55}},
-		{BlockNumberChallenged: false, AgreeWithClaim: true},
-		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, BlockNumberChallenged: true, AgreeWithClaim: false, L2SequenceNumber: 22, BlockNumberChallenger: common.Address{0x33}},
-		{BlockNumberChallenged: false, AgreeWithClaim: false},
-		{BlockNumberChallenged: false, AgreeWithClaim: false},
-		{BlockNumberChallenged: false, AgreeWithClaim: true},
+	games := []*types.FaultGameData{
+		{CommonGameData: types.CommonGameData{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x44}}, AgreeWithClaim: true, L2SequenceNumber: 44}, BlockNumberChallenged: true, BlockNumberChallenger: common.Address{0x55}},
+		{CommonGameData: types.CommonGameData{AgreeWithClaim: true}},
+		{CommonGameData: types.CommonGameData{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, AgreeWithClaim: false, L2SequenceNumber: 22}, BlockNumberChallenged: true, BlockNumberChallenger: common.Address{0x33}},
+		{},
+		{},
+		{CommonGameData: types.CommonGameData{AgreeWithClaim: true}},
 	}
 	metrics := &stubL2ChallengeMetrics{}
 	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)

--- a/op-dispute-mon/mon/mixed_availability.go
+++ b/op-dispute-mon/mon/mixed_availability.go
@@ -21,7 +21,7 @@ func NewMixedAvailability(logger log.Logger, metrics MixedAvailabilityMetrics) *
 	}
 }
 
-func (m *MixedAvailability) CheckMixedAvailability(games []*types.EnrichedGameData) {
+func (m *MixedAvailability) CheckMixedAvailability(games []*types.CommonGameData) {
 	count := 0
 	for _, game := range games {
 		if game.HasMixedAvailability() {

--- a/op-dispute-mon/mon/mixed_availability_test.go
+++ b/op-dispute-mon/mon/mixed_availability_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCheckMixedAvailability(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, NodeEndpointTotalCount: 5, NodeEndpointNotFoundCount: 2, NodeEndpointErrorCount: 1}, // Mixed (2 successful)
 		{NodeEndpointTotalCount: 3, NodeEndpointNotFoundCount: 0, NodeEndpointErrorCount: 0},                                                                    // All successful
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, NodeEndpointTotalCount: 6, NodeEndpointNotFoundCount: 2, NodeEndpointErrorCount: 2}, // Mixed (2 successful)

--- a/op-dispute-mon/mon/mixed_safety.go
+++ b/op-dispute-mon/mon/mixed_safety.go
@@ -21,7 +21,7 @@ func NewMixedSafetyMonitor(logger log.Logger, metrics MixedSafetyMetrics) *Mixed
 	}
 }
 
-func (m *MixedSafetyMonitor) CheckMixedSafety(games []*types.EnrichedGameData) {
+func (m *MixedSafetyMonitor) CheckMixedSafety(games []*types.CommonGameData) {
 	count := 0
 	for _, game := range games {
 		if game.HasMixedSafety() {

--- a/op-dispute-mon/mon/mixed_safety_test.go
+++ b/op-dispute-mon/mon/mixed_safety_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCheckMixedSafety(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, NodeEndpointSafeCount: 2, NodeEndpointUnsafeCount: 1},
 		{NodeEndpointSafeCount: 3, NodeEndpointUnsafeCount: 0}, // All safe
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, NodeEndpointSafeCount: 1, NodeEndpointUnsafeCount: 4},

--- a/op-dispute-mon/mon/monitor.go
+++ b/op-dispute-mon/mon/monitor.go
@@ -116,9 +116,14 @@ func partitionGames(games []types.EnrichedGame) ([]*types.CommonGameData, []*typ
 	commonGames := make([]*types.CommonGameData, 0, len(games))
 	faultGames := make([]*types.FaultGameData, 0, len(games))
 	for _, game := range games {
-		commonGames = append(commonGames, game.Common())
-		if faultGame, ok := game.(*types.FaultGameData); ok {
-			faultGames = append(faultGames, faultGame)
+		switch game := game.(type) {
+		case *types.FaultGameData:
+			commonGames = append(commonGames, game.Common())
+			faultGames = append(faultGames, game)
+		case *types.SuperPermissionedGameData:
+			commonGames = append(commonGames, game.Common())
+		default:
+			panic(fmt.Sprintf("unsupported enriched game type %T", game))
 		}
 	}
 	return commonGames, faultGames
@@ -142,6 +147,7 @@ func (m *gameMonitor) loop() {
 }
 
 func (m *gameMonitor) StartMonitoring() {
+	// Keep the original context and cancel function if this is called multiple times.
 	if m.cancel == nil {
 		ctx, cancel := context.WithCancel(m.ctx)
 		m.ctx = ctx

--- a/op-dispute-mon/mon/monitor.go
+++ b/op-dispute-mon/mon/monitor.go
@@ -9,16 +9,16 @@ import (
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type ForecastResolution func(games []*types.EnrichedGameData, ignoredCount, failedCount int)
-type AnchorStateCheck func(ctx context.Context, blockHash common.Hash, games []*types.EnrichedGameData)
-type Monitor func(games []*types.EnrichedGameData)
+type ForecastResolution func(games []types.EnrichedGame, ignoredCount, failedCount int)
+type AnchorStateCheck func(ctx context.Context, blockHash common.Hash, games []*types.CommonGameData)
+type CommonMonitor func(games []*types.CommonGameData)
+type FaultMonitor func(games []*types.FaultGameData)
 type HeadBlockFetcher func(ctx context.Context) (eth.L1BlockRef, error)
-type Extract func(ctx context.Context, blockHash common.Hash, minTimestamp uint64) ([]*types.EnrichedGameData, int, int, error)
+type Extract func(ctx context.Context, blockHash common.Hash, minTimestamp uint64) ([]types.EnrichedGame, int, int, error)
 
 type MonitorMetrics interface {
 	RecordMonitorDuration(dur time.Duration)
@@ -41,7 +41,8 @@ type gameMonitor struct {
 
 	forecast         ForecastResolution
 	checkAnchorState AnchorStateCheck
-	monitors         []Monitor
+	commonMonitors   []CommonMonitor
+	faultMonitors    []FaultMonitor
 	extract          Extract
 	fetchHeadBlock   HeadBlockFetcher
 }
@@ -57,7 +58,9 @@ func newGameMonitor(
 	extract Extract,
 	forecast ForecastResolution,
 	checkAnchorState AnchorStateCheck,
-	monitors ...Monitor) *gameMonitor {
+	commonMonitors []CommonMonitor,
+	faultMonitors []FaultMonitor,
+) *gameMonitor {
 	return &gameMonitor{
 		logger:           logger,
 		clock:            cl,
@@ -69,7 +72,8 @@ func newGameMonitor(
 		gameWindow:       gameWindow,
 		forecast:         forecast,
 		checkAnchorState: checkAnchorState,
-		monitors:         monitors,
+		commonMonitors:   commonMonitors,
+		faultMonitors:    faultMonitors,
 		extract:          extract,
 		fetchHeadBlock:   fetchHeadBlock,
 	}
@@ -87,10 +91,14 @@ func (m *gameMonitor) monitorGames() error {
 	if err != nil {
 		return fmt.Errorf("failed to load games: %w", err)
 	}
+	commonGames, faultGames := partitionGames(enrichedGames)
 	m.forecast(enrichedGames, ignored, failed)
-	m.checkAnchorState(m.ctx, headBlock.Hash, enrichedGames)
-	for _, monitor := range m.monitors {
-		monitor(enrichedGames)
+	m.checkAnchorState(m.ctx, headBlock.Hash, commonGames)
+	for _, monitor := range m.faultMonitors {
+		monitor(faultGames)
+	}
+	for _, monitor := range m.commonMonitors {
+		monitor(commonGames)
 	}
 	timeTaken := m.clock.Since(start)
 	m.metrics.RecordMonitorDuration(timeTaken)
@@ -102,6 +110,18 @@ func (m *gameMonitor) monitorGames() error {
 		"ignored", ignored,
 		"failed", failed)
 	return nil
+}
+
+func partitionGames(games []types.EnrichedGame) ([]*types.CommonGameData, []*types.FaultGameData) {
+	commonGames := make([]*types.CommonGameData, 0, len(games))
+	faultGames := make([]*types.FaultGameData, 0, len(games))
+	for _, game := range games {
+		commonGames = append(commonGames, game.Common())
+		if faultGame, ok := game.(*types.FaultGameData); ok {
+			faultGames = append(faultGames, faultGame)
+		}
+	}
+	return commonGames, faultGames
 }
 
 func (m *gameMonitor) loop() {
@@ -122,9 +142,6 @@ func (m *gameMonitor) loop() {
 }
 
 func (m *gameMonitor) StartMonitoring() {
-	// Setup the cancellation only if it's not already set.
-	// This prevents overwriting the context and cancel function
-	// if, for example, this function is called multiple times.
 	if m.cancel == nil {
 		ctx, cancel := context.WithCancel(m.ctx)
 		m.ctx = ctx

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -59,6 +59,20 @@ func TestMonitor_MonitorGames(t *testing.T) {
 	})
 }
 
+func TestMonitorRoutesGamesToResolution(t *testing.T) {
+	monitor, extractor, _, _ := setupMonitorTest(t)
+	terminal := newEnrichedGameData(common.Address{0xaa}, 1)
+	terminal.Status = types.GameStatusDefenderWon
+	extractor.games = []*monTypes.EnrichedGameData{terminal}
+	var received []*monTypes.EnrichedGameData
+	monitor.monitors = []Monitor{func(games []*monTypes.EnrichedGameData) {
+		received = games
+	}}
+
+	require.NoError(t, monitor.monitorGames())
+	require.Equal(t, []*monTypes.EnrichedGameData{terminal}, received)
+}
+
 func TestMonitor_StartMonitoring(t *testing.T) {
 	t.Run("MonitorsGames", func(t *testing.T) {
 		addr1 := common.Address{0xaa}

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -95,6 +95,12 @@ func TestMonitorRoutesGamesToResolution(t *testing.T) {
 	require.Equal(t, []*monTypes.FaultGameData{terminal}, faultReceived)
 }
 
+func TestPartitionGamesRejectsUnknownGameType(t *testing.T) {
+	require.PanicsWithValue(t, "unsupported enriched game type <nil>", func() {
+		partitionGames([]monTypes.EnrichedGame{nil})
+	})
+}
+
 func TestMonitorChecksAnchorOnceOnEmptyLane(t *testing.T) {
 	monitor, _, _, _ := setupMonitorTest(t)
 	calls := 0

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -38,7 +38,7 @@ func TestMonitor_MonitorGames(t *testing.T) {
 
 	t.Run("MonitorsWithNoGames", func(t *testing.T) {
 		monitor, factory, forecast, monitors := setupMonitorTest(t)
-		factory.games = []*monTypes.EnrichedGameData{}
+		factory.games = []monTypes.EnrichedGame{}
 		err := monitor.monitorGames()
 		require.NoError(t, err)
 		require.Equal(t, 1, forecast.Calls())
@@ -49,7 +49,7 @@ func TestMonitor_MonitorGames(t *testing.T) {
 
 	t.Run("MonitorsMultipleGames", func(t *testing.T) {
 		monitor, factory, forecast, monitors := setupMonitorTest(t)
-		factory.games = []*monTypes.EnrichedGameData{{}, {}, {}}
+		factory.games = []monTypes.EnrichedGame{newEnrichedGameData(common.Address{1}, 1), newEnrichedGameData(common.Address{2}, 2), newEnrichedGameData(common.Address{3}, 3)}
 		err := monitor.monitorGames()
 		require.NoError(t, err)
 		require.Equal(t, 1, forecast.Calls())
@@ -57,20 +57,54 @@ func TestMonitor_MonitorGames(t *testing.T) {
 			require.Equal(t, 1, m.calls)
 		}
 	})
+
+	t.Run("PreservesHistoricalMonitorOrder", func(t *testing.T) {
+		monitor, _, _, _ := setupMonitorTest(t)
+		var calls []string
+		monitor.faultMonitors = []FaultMonitor{func([]*monTypes.FaultGameData) {
+			calls = append(calls, "fault")
+		}}
+		monitor.commonMonitors = []CommonMonitor{func([]*monTypes.CommonGameData) {
+			calls = append(calls, "common")
+		}}
+
+		require.NoError(t, monitor.monitorGames())
+		require.Equal(t, []string{"fault", "common"}, calls)
+	})
 }
 
 func TestMonitorRoutesGamesToResolution(t *testing.T) {
+	// Mutation killed: omitting a supported variant from the common lane or
+	// routing SuperPermissioned through the Fault lane survives monitor unit tests.
 	monitor, extractor, _, _ := setupMonitorTest(t)
 	terminal := newEnrichedGameData(common.Address{0xaa}, 1)
 	terminal.Status = types.GameStatusDefenderWon
-	extractor.games = []*monTypes.EnrichedGameData{terminal}
-	var received []*monTypes.EnrichedGameData
-	monitor.monitors = []Monitor{func(games []*monTypes.EnrichedGameData) {
-		received = games
+	super := &monTypes.SuperPermissionedGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusDefenderWon}}
+	extractor.games = []monTypes.EnrichedGame{terminal, super}
+	var commonReceived []*monTypes.CommonGameData
+	monitor.commonMonitors = []CommonMonitor{func(games []*monTypes.CommonGameData) {
+		commonReceived = games
+	}}
+	var faultReceived []*monTypes.FaultGameData
+	monitor.faultMonitors = []FaultMonitor{func(games []*monTypes.FaultGameData) {
+		faultReceived = games
 	}}
 
 	require.NoError(t, monitor.monitorGames())
-	require.Equal(t, []*monTypes.EnrichedGameData{terminal}, received)
+	require.Equal(t, []*monTypes.CommonGameData{terminal.Common(), super.Common()}, commonReceived)
+	require.Equal(t, []*monTypes.FaultGameData{terminal}, faultReceived)
+}
+
+func TestMonitorChecksAnchorOnceOnEmptyLane(t *testing.T) {
+	monitor, _, _, _ := setupMonitorTest(t)
+	calls := 0
+	monitor.checkAnchorState = func(_ context.Context, _ common.Hash, games []*monTypes.CommonGameData) {
+		calls++
+		require.Empty(t, games)
+	}
+
+	require.NoError(t, monitor.monitorGames())
+	require.Equal(t, 1, calls)
 }
 
 func TestMonitor_StartMonitoring(t *testing.T) {
@@ -78,7 +112,7 @@ func TestMonitor_StartMonitoring(t *testing.T) {
 		addr1 := common.Address{0xaa}
 		addr2 := common.Address{0xbb}
 		monitor, factory, forecaster, _ := setupMonitorTest(t)
-		factory.games = []*monTypes.EnrichedGameData{newEnrichedGameData(addr1, 9999), newEnrichedGameData(addr2, 9999)}
+		factory.games = []monTypes.EnrichedGame{newEnrichedGameData(addr1, 9999), newEnrichedGameData(addr2, 9999)}
 		factory.maxSuccess = len(factory.games) // Only allow two successful fetches
 
 		monitor.StartMonitoring()
@@ -215,13 +249,15 @@ func stopContext(t *testing.T) context.Context {
 	return ctx
 }
 
-func newEnrichedGameData(proxy common.Address, timestamp uint64) *monTypes.EnrichedGameData {
-	return &monTypes.EnrichedGameData{
-		GameMetadata: types.GameMetadata{
-			Proxy:     proxy,
-			Timestamp: timestamp,
+func newEnrichedGameData(proxy common.Address, timestamp uint64) *monTypes.FaultGameData {
+	return &monTypes.FaultGameData{
+		CommonGameData: monTypes.CommonGameData{
+			GameMetadata: types.GameMetadata{
+				Proxy:     proxy,
+				Timestamp: timestamp,
+			},
+			Status: types.GameStatusInProgress,
 		},
-		Status: types.GameStatusInProgress,
 	}
 }
 
@@ -239,17 +275,23 @@ func setupMonitorTest(t *testing.T) (*gameMonitor, *mockExtractor, *mockForecast
 	monitor2 := &mockMonitor{}
 	monitor3 := &mockMonitor{}
 	monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-		extractor.Extract, forecast.Forecast, noopAnchorStateCheck, monitor1.Check, monitor2.Check, monitor3.Check)
+		extractor.Extract, forecast.Forecast, noopAnchorStateCheck,
+		[]CommonMonitor{monitor1.CheckCommon, monitor2.CheckCommon},
+		[]FaultMonitor{monitor3.CheckFault})
 	return monitor, extractor, forecast, []*mockMonitor{monitor1, monitor2, monitor3}
 }
 
-func noopAnchorStateCheck(_ context.Context, _ common.Hash, _ []*monTypes.EnrichedGameData) {}
+func noopAnchorStateCheck(_ context.Context, _ common.Hash, _ []*monTypes.CommonGameData) {}
 
 type mockMonitor struct {
 	calls int
 }
 
-func (m *mockMonitor) Check(games []*monTypes.EnrichedGameData) {
+func (m *mockMonitor) CheckCommon(_ []*monTypes.CommonGameData) {
+	m.calls++
+}
+
+func (m *mockMonitor) CheckFault(_ []*monTypes.FaultGameData) {
 	m.calls++
 }
 
@@ -261,7 +303,7 @@ func (m *mockForecast) Calls() int {
 	return int(m.calls.Load())
 }
 
-func (m *mockForecast) Forecast(_ []*monTypes.EnrichedGameData, _, _ int) {
+func (m *mockForecast) Forecast(_ []monTypes.EnrichedGame, _, _ int) {
 	m.calls.Add(1)
 }
 
@@ -269,7 +311,7 @@ type mockExtractor struct {
 	fetchErr     error
 	calls        atomic.Int64
 	maxSuccess   int
-	games        []*monTypes.EnrichedGameData
+	games        []monTypes.EnrichedGame
 	ignoredCount int
 	failedCount  int
 }
@@ -278,7 +320,7 @@ func (m *mockExtractor) Extract(
 	_ context.Context,
 	_ common.Hash,
 	_ uint64,
-) ([]*monTypes.EnrichedGameData, int, int, error) {
+) ([]monTypes.EnrichedGame, int, int, error) {
 	calls := int(m.calls.Add(1))
 	if m.fetchErr != nil {
 		return nil, 0, 0, m.fetchErr
@@ -291,481 +333,6 @@ func (m *mockExtractor) Extract(
 
 func (m *mockExtractor) Calls() int {
 	return int(m.calls.Load())
-}
-
-func TestMonitor_NodeEndpointErrorsMonitorIntegration(t *testing.T) {
-	t.Parallel()
-
-	t.Run("NodeEndpointErrorsMonitorCalledWithGamesData", func(t *testing.T) {
-		logger := testlog.Logger(t, log.LvlDebug)
-		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
-			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
-		}
-		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock()
-		cl.Start()
-
-		// Create games with endpoint errors
-		games := []*monTypes.EnrichedGameData{
-			{
-				GameMetadata: types.GameMetadata{Proxy: common.Address{0x11}},
-				NodeEndpointErrors: map[string]bool{
-					"endpoint_1": true,
-					"endpoint_2": true,
-				},
-			},
-			{
-				GameMetadata: types.GameMetadata{Proxy: common.Address{0x22}},
-				NodeEndpointErrors: map[string]bool{
-					"endpoint_2": true, // Overlapping with first game
-					"endpoint_3": true,
-				},
-			},
-		}
-
-		extractor := &mockExtractor{games: games}
-		forecast := &mockForecast{}
-		nodeEndpointErrorsMetrics := &stubNodeEndpointErrorsMetrics{}
-		nodeEndpointErrorsMonitor := NewNodeEndpointErrorsMonitor(logger, nodeEndpointErrorsMetrics)
-
-		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, nodeEndpointErrorsMonitor.CheckNodeEndpointErrors)
-
-		err := monitor.monitorGames()
-		require.NoError(t, err)
-
-		// Verify that NodeEndpointErrorsMonitor was called and recorded the correct count
-		// Should count unique endpoints: endpoint_1, endpoint_2, endpoint_3 = 3 total
-		require.Equal(t, 3, nodeEndpointErrorsMetrics.recordedCount)
-	})
-}
-
-func TestMonitor_NodeEndpointErrorCountMonitorIntegration(t *testing.T) {
-	t.Parallel()
-
-	t.Run("NodeEndpointErrorCountMonitorCalledWithGamesData", func(t *testing.T) {
-		logger := testlog.Logger(t, log.LvlDebug)
-		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
-			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
-		}
-		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock()
-		cl.Start()
-
-		// Create games with endpoint error counts
-		games := []*monTypes.EnrichedGameData{
-			{
-				GameMetadata:           types.GameMetadata{Proxy: common.Address{0x11}},
-				NodeEndpointErrorCount: 5, // First game has 5 errors
-			},
-			{
-				GameMetadata:           types.GameMetadata{Proxy: common.Address{0x22}},
-				NodeEndpointErrorCount: 3, // Second game has 3 errors
-			},
-			{
-				GameMetadata:           types.GameMetadata{Proxy: common.Address{0x33}},
-				NodeEndpointErrorCount: 0, // Third game has no errors
-			},
-		}
-
-		extractor := &mockExtractor{games: games}
-		forecast := &mockForecast{}
-		nodeEndpointErrorCountMetrics := &mockNodeEndpointErrorCountMetrics{}
-		nodeEndpointErrorCountMonitor := NewNodeEndpointErrorCountMonitor(logger, nodeEndpointErrorCountMetrics)
-
-		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount)
-
-		err := monitor.monitorGames()
-		require.NoError(t, err)
-
-		// Verify that NodeEndpointErrorCountMonitor was called and recorded the correct total
-		// Should sum all error counts: 5 + 3 + 0 = 8 total errors
-		require.Equal(t, 8, nodeEndpointErrorCountMetrics.recordedCount)
-	})
-}
-
-// mockNodeEndpointErrorCountMetrics for integration test
-type mockNodeEndpointErrorCountMetrics struct {
-	recordedCount int
-}
-
-func (m *mockNodeEndpointErrorCountMetrics) RecordNodeEndpointErrorCount(count int) {
-	m.recordedCount = count
-}
-
-func TestMonitor_MixedAvailabilityMonitorIntegration(t *testing.T) {
-	t.Parallel()
-
-	t.Run("MixedAvailabilityMonitorCalledWithGamesData", func(t *testing.T) {
-		logger := testlog.Logger(t, log.LvlDebug)
-		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
-			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
-		}
-		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock()
-		cl.Start()
-
-		// Create games with mixed availability scenarios
-		games := []*monTypes.EnrichedGameData{
-			{
-				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x11}},
-				NodeEndpointTotalCount:    3,
-				NodeEndpointNotFoundCount: 1, // Mixed availability: some found, some not found
-				NodeEndpointErrorCount:    0,
-			},
-			{
-				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x22}},
-				NodeEndpointTotalCount:    2,
-				NodeEndpointNotFoundCount: 2, // All endpoints not found - not mixed availability
-				NodeEndpointErrorCount:    0,
-			},
-			{
-				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x33}},
-				NodeEndpointTotalCount:    4,
-				NodeEndpointNotFoundCount: 2, // Mixed availability: some found, some not found
-				NodeEndpointErrorCount:    0,
-			},
-			{
-				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x44}},
-				NodeEndpointTotalCount:    3,
-				NodeEndpointNotFoundCount: 0, // All endpoints found - not mixed availability
-				NodeEndpointErrorCount:    0,
-			},
-		}
-
-		extractor := &mockExtractor{games: games}
-		forecast := &mockForecast{}
-		mixedAvailabilityMetrics := &mockMixedAvailabilityMetrics{}
-		mixedAvailabilityMonitor := NewMixedAvailability(logger, mixedAvailabilityMetrics)
-
-		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, mixedAvailabilityMonitor.CheckMixedAvailability)
-
-		err := monitor.monitorGames()
-		require.NoError(t, err)
-
-		// Verify that MixedAvailabilityMonitor was called and recorded the correct count
-		// Should count games with mixed availability: game 0x11 and 0x33 = 2 total
-		require.Equal(t, 2, mixedAvailabilityMetrics.recordedCount)
-	})
-}
-
-// mockMixedAvailabilityMetrics for integration test
-type mockMixedAvailabilityMetrics struct {
-	recordedCount int
-}
-
-func (m *mockMixedAvailabilityMetrics) RecordMixedAvailabilityGames(count int) {
-	m.recordedCount = count
-}
-
-func TestMonitor_MixedSafetyMonitorIntegration(t *testing.T) {
-	t.Parallel()
-
-	t.Run("MixedSafetyMonitorCalledWithGamesData", func(t *testing.T) {
-		logger := testlog.Logger(t, log.LvlDebug)
-		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
-			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
-		}
-		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock()
-		cl.Start()
-
-		// Create games with mixed safety scenarios
-		games := []*monTypes.EnrichedGameData{
-			{
-				GameMetadata:            types.GameMetadata{Proxy: common.Address{0x11}},
-				NodeEndpointSafeCount:   2, // Mixed safety: some safe, some unsafe
-				NodeEndpointUnsafeCount: 1,
-			},
-			{
-				GameMetadata:            types.GameMetadata{Proxy: common.Address{0x22}},
-				NodeEndpointSafeCount:   3, // All endpoints safe - not mixed safety
-				NodeEndpointUnsafeCount: 0,
-			},
-			{
-				GameMetadata:            types.GameMetadata{Proxy: common.Address{0x33}},
-				NodeEndpointSafeCount:   1, // Mixed safety: some safe, some unsafe
-				NodeEndpointUnsafeCount: 4,
-			},
-			{
-				GameMetadata:            types.GameMetadata{Proxy: common.Address{0x44}},
-				NodeEndpointSafeCount:   0, // All endpoints unsafe - not mixed safety
-				NodeEndpointUnsafeCount: 2,
-			},
-			{
-				GameMetadata:            types.GameMetadata{Proxy: common.Address{0x55}},
-				NodeEndpointSafeCount:   0, // No safety checks performed - not mixed safety
-				NodeEndpointUnsafeCount: 0,
-			},
-		}
-
-		extractor := &mockExtractor{games: games}
-		forecast := &mockForecast{}
-		mixedSafetyMetrics := &mockMixedSafetyMetrics{}
-		mixedSafetyMonitor := NewMixedSafetyMonitor(logger, mixedSafetyMetrics)
-
-		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, mixedSafetyMonitor.CheckMixedSafety)
-
-		err := monitor.monitorGames()
-		require.NoError(t, err)
-
-		// Verify that MixedSafetyMonitor was called and recorded the correct count
-		// Should count games with mixed safety: game 0x11 and 0x33 = 2 total
-		require.Equal(t, 2, mixedSafetyMetrics.recordedCount)
-	})
-
-	t.Run("OnlyGamesWithMixedSafetyAreCounted", func(t *testing.T) {
-		logger := testlog.Logger(t, log.LvlDebug)
-		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
-			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
-		}
-		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock()
-		cl.Start()
-
-		// Create games without mixed safety
-		games := []*monTypes.EnrichedGameData{
-			{
-				GameMetadata:            types.GameMetadata{Proxy: common.Address{0x11}},
-				NodeEndpointSafeCount:   5, // All safe
-				NodeEndpointUnsafeCount: 0,
-			},
-			{
-				GameMetadata:            types.GameMetadata{Proxy: common.Address{0x22}},
-				NodeEndpointSafeCount:   0, // All unsafe
-				NodeEndpointUnsafeCount: 3,
-			},
-			{
-				GameMetadata:            types.GameMetadata{Proxy: common.Address{0x33}},
-				NodeEndpointSafeCount:   0, // No checks performed
-				NodeEndpointUnsafeCount: 0,
-			},
-		}
-
-		extractor := &mockExtractor{games: games}
-		forecast := &mockForecast{}
-		mixedSafetyMetrics := &mockMixedSafetyMetrics{}
-		mixedSafetyMonitor := NewMixedSafetyMonitor(logger, mixedSafetyMetrics)
-
-		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, mixedSafetyMonitor.CheckMixedSafety)
-
-		err := monitor.monitorGames()
-		require.NoError(t, err)
-
-		// Verify that no games were counted as having mixed safety
-		require.Equal(t, 0, mixedSafetyMetrics.recordedCount)
-	})
-
-	t.Run("EdgeCaseMinimalMixedSafety", func(t *testing.T) {
-		logger := testlog.Logger(t, log.LvlDebug)
-		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
-			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
-		}
-		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock()
-		cl.Start()
-
-		// Create a game with minimal mixed safety (1 safe, 1 unsafe)
-		games := []*monTypes.EnrichedGameData{
-			{
-				GameMetadata:            types.GameMetadata{Proxy: common.Address{0x11}},
-				NodeEndpointSafeCount:   1, // Minimal mixed safety
-				NodeEndpointUnsafeCount: 1,
-			},
-		}
-
-		extractor := &mockExtractor{games: games}
-		forecast := &mockForecast{}
-		mixedSafetyMetrics := &mockMixedSafetyMetrics{}
-		mixedSafetyMonitor := NewMixedSafetyMonitor(logger, mixedSafetyMetrics)
-
-		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, mixedSafetyMonitor.CheckMixedSafety)
-
-		err := monitor.monitorGames()
-		require.NoError(t, err)
-
-		// Verify that the minimal mixed safety case is counted
-		require.Equal(t, 1, mixedSafetyMetrics.recordedCount)
-	})
-}
-
-// mockMixedSafetyMetrics for integration test
-type mockMixedSafetyMetrics struct {
-	recordedCount int
-}
-
-func (m *mockMixedSafetyMetrics) RecordMixedSafetyGames(count int) {
-	m.recordedCount = count
-}
-
-func TestMonitor_DifferentOutputRootMonitorIntegration(t *testing.T) {
-	t.Parallel()
-
-	t.Run("DifferentOutputRootMonitorCalledWithGamesData", func(t *testing.T) {
-		logger := testlog.Logger(t, log.LvlDebug)
-		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
-			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
-		}
-		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock()
-		cl.Start()
-
-		// Create games with different output root scenarios
-		games := []*monTypes.EnrichedGameData{
-			{
-				GameMetadata:               types.GameMetadata{Proxy: common.Address{0x11}},
-				NodeEndpointDifferentRoots: true, // Has different output roots
-			},
-			{
-				GameMetadata:               types.GameMetadata{Proxy: common.Address{0x22}},
-				NodeEndpointDifferentRoots: false, // No disagreement
-			},
-			{
-				GameMetadata:               types.GameMetadata{Proxy: common.Address{0x33}},
-				NodeEndpointDifferentRoots: true, // Has different output roots
-			},
-			{
-				GameMetadata:               types.GameMetadata{Proxy: common.Address{0x44}},
-				NodeEndpointDifferentRoots: false, // No disagreement
-			},
-		}
-
-		extractor := &mockExtractor{games: games}
-		forecast := &mockForecast{}
-		differentOutputRootMetrics := &mockDifferentOutputRootMetrics{}
-		differentOutputRootMonitor := NewDifferentRootMonitor(logger, differentOutputRootMetrics)
-
-		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, differentOutputRootMonitor.CheckDifferentRoots)
-
-		err := monitor.monitorGames()
-		require.NoError(t, err)
-
-		// Verify that DifferentOutputRootMonitor was called and recorded the correct count
-		// Should count games with different output roots: game 0x11 and 0x33 = 2 total
-		require.Equal(t, 2, differentOutputRootMetrics.recordedCount)
-	})
-
-	t.Run("OnlyGamesWithDifferentOutputRootsAreCounted", func(t *testing.T) {
-		logger := testlog.Logger(t, log.LvlDebug)
-		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
-			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
-		}
-		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock()
-		cl.Start()
-
-		// Create games without different output roots
-		games := []*monTypes.EnrichedGameData{
-			{
-				GameMetadata:               types.GameMetadata{Proxy: common.Address{0x11}},
-				NodeEndpointDifferentRoots: false, // No disagreement
-			},
-			{
-				GameMetadata:               types.GameMetadata{Proxy: common.Address{0x22}},
-				NodeEndpointDifferentRoots: false, // No disagreement
-			},
-			{
-				GameMetadata:               types.GameMetadata{Proxy: common.Address{0x33}},
-				NodeEndpointDifferentRoots: false, // No disagreement
-			},
-		}
-
-		extractor := &mockExtractor{games: games}
-		forecast := &mockForecast{}
-		differentOutputRootMetrics := &mockDifferentOutputRootMetrics{}
-		differentOutputRootMonitor := NewDifferentRootMonitor(logger, differentOutputRootMetrics)
-
-		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, differentOutputRootMonitor.CheckDifferentRoots)
-
-		err := monitor.monitorGames()
-		require.NoError(t, err)
-
-		// Verify that no games were counted as having different output roots
-		require.Equal(t, 0, differentOutputRootMetrics.recordedCount)
-	})
-
-	t.Run("AllGamesHaveDifferentOutputRoots", func(t *testing.T) {
-		logger := testlog.Logger(t, log.LvlDebug)
-		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
-			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
-		}
-		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock()
-		cl.Start()
-
-		// Create games where all have different output roots
-		games := []*monTypes.EnrichedGameData{
-			{
-				GameMetadata:               types.GameMetadata{Proxy: common.Address{0x11}},
-				NodeEndpointDifferentRoots: true,
-			},
-			{
-				GameMetadata:               types.GameMetadata{Proxy: common.Address{0x22}},
-				NodeEndpointDifferentRoots: true,
-			},
-			{
-				GameMetadata:               types.GameMetadata{Proxy: common.Address{0x33}},
-				NodeEndpointDifferentRoots: true,
-			},
-		}
-
-		extractor := &mockExtractor{games: games}
-		forecast := &mockForecast{}
-		differentOutputRootMetrics := &mockDifferentOutputRootMetrics{}
-		differentOutputRootMonitor := NewDifferentRootMonitor(logger, differentOutputRootMetrics)
-
-		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, differentOutputRootMonitor.CheckDifferentRoots)
-
-		err := monitor.monitorGames()
-		require.NoError(t, err)
-
-		// Verify that all games were counted
-		require.Equal(t, 3, differentOutputRootMetrics.recordedCount)
-	})
-
-	t.Run("EmptyGamesListReturnsZero", func(t *testing.T) {
-		logger := testlog.Logger(t, log.LvlDebug)
-		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
-			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
-		}
-		monitorInterval := 100 * time.Millisecond
-		cl := clock.NewAdvancingClock()
-		cl.Start()
-
-		// Create empty games list
-		games := []*monTypes.EnrichedGameData{}
-
-		extractor := &mockExtractor{games: games}
-		forecast := &mockForecast{}
-		differentOutputRootMetrics := &mockDifferentOutputRootMetrics{}
-		differentOutputRootMonitor := NewDifferentRootMonitor(logger, differentOutputRootMetrics)
-
-		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
-			extractor.Extract, forecast.Forecast, noopAnchorStateCheck, differentOutputRootMonitor.CheckDifferentRoots)
-
-		err := monitor.monitorGames()
-		require.NoError(t, err)
-
-		// Verify that count is zero
-		require.Equal(t, 0, differentOutputRootMetrics.recordedCount)
-	})
-}
-
-// mockDifferentOutputRootMetrics for integration test
-type mockDifferentOutputRootMetrics struct {
-	recordedCount int
-}
-
-func (m *mockDifferentOutputRootMetrics) RecordDifferentRootGames(count int) {
-	m.recordedCount = count
 }
 
 func TestServiceStopStopsMonitoring(t *testing.T) {

--- a/op-dispute-mon/mon/node_endpoint_error_count.go
+++ b/op-dispute-mon/mon/node_endpoint_error_count.go
@@ -21,7 +21,7 @@ func NewNodeEndpointErrorCountMonitor(logger log.Logger, metrics NodeEndpointErr
 	}
 }
 
-func (m *NodeEndpointErrorCountMonitor) CheckNodeEndpointErrorCount(games []*types.EnrichedGameData) {
+func (m *NodeEndpointErrorCountMonitor) CheckNodeEndpointErrorCount(games []*types.CommonGameData) {
 	totalErrors := 0
 
 	for _, game := range games {
@@ -32,7 +32,7 @@ func (m *NodeEndpointErrorCountMonitor) CheckNodeEndpointErrorCount(games []*typ
 }
 
 // countGamesWithErrors returns the number of games that have at least one error
-func countGamesWithErrors(games []*types.EnrichedGameData) int {
+func countGamesWithErrors(games []*types.CommonGameData) int {
 	count := 0
 	for _, game := range games {
 		if game.NodeEndpointErrorCount > 0 {

--- a/op-dispute-mon/mon/node_endpoint_error_count_test.go
+++ b/op-dispute-mon/mon/node_endpoint_error_count_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCheckNodeEndpointErrorCount_NoErrors(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, NodeEndpointErrorCount: 0},
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, NodeEndpointErrorCount: 0},
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x33}}, NodeEndpointErrorCount: 0},
@@ -28,7 +28,7 @@ func TestCheckNodeEndpointErrorCount_NoErrors(t *testing.T) {
 }
 
 func TestCheckNodeEndpointErrorCount_SingleGameWithErrors(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata:           gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointErrorCount: 5,
@@ -49,7 +49,7 @@ func TestCheckNodeEndpointErrorCount_SingleGameWithErrors(t *testing.T) {
 }
 
 func TestCheckNodeEndpointErrorCount_MultipleGamesWithErrors(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata:           gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointErrorCount: 3,
@@ -75,7 +75,7 @@ func TestCheckNodeEndpointErrorCount_MultipleGamesWithErrors(t *testing.T) {
 }
 
 func TestCheckNodeEndpointErrorCount_MixedGamesWithAndWithoutErrors(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata:           gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointErrorCount: 0,
@@ -105,7 +105,7 @@ func TestCheckNodeEndpointErrorCount_MixedGamesWithAndWithoutErrors(t *testing.T
 }
 
 func TestCheckNodeEndpointErrorCount_EmptyGamesList(t *testing.T) {
-	games := []*types.EnrichedGameData{}
+	games := []*types.CommonGameData{}
 
 	metrics := &stubNodeEndpointErrorCountMetrics{}
 	logger := testlog.Logger(t, log.LvlDebug)
@@ -117,7 +117,7 @@ func TestCheckNodeEndpointErrorCount_EmptyGamesList(t *testing.T) {
 }
 
 func TestCheckNodeEndpointErrorCount_HighVolumeErrors(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata:           gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointErrorCount: 100,
@@ -145,17 +145,17 @@ func TestCheckNodeEndpointErrorCount_HighVolumeErrors(t *testing.T) {
 func TestCountGamesWithErrors(t *testing.T) {
 	tests := []struct {
 		name     string
-		games    []*types.EnrichedGameData
+		games    []*types.CommonGameData
 		expected int
 	}{
 		{
 			name:     "no games",
-			games:    []*types.EnrichedGameData{},
+			games:    []*types.CommonGameData{},
 			expected: 0,
 		},
 		{
 			name: "no errors",
-			games: []*types.EnrichedGameData{
+			games: []*types.CommonGameData{
 				{NodeEndpointErrorCount: 0},
 				{NodeEndpointErrorCount: 0},
 			},
@@ -163,7 +163,7 @@ func TestCountGamesWithErrors(t *testing.T) {
 		},
 		{
 			name: "all games have errors",
-			games: []*types.EnrichedGameData{
+			games: []*types.CommonGameData{
 				{NodeEndpointErrorCount: 1},
 				{NodeEndpointErrorCount: 5},
 				{NodeEndpointErrorCount: 10},
@@ -172,7 +172,7 @@ func TestCountGamesWithErrors(t *testing.T) {
 		},
 		{
 			name: "mixed errors",
-			games: []*types.EnrichedGameData{
+			games: []*types.CommonGameData{
 				{NodeEndpointErrorCount: 0},
 				{NodeEndpointErrorCount: 3},
 				{NodeEndpointErrorCount: 0},

--- a/op-dispute-mon/mon/node_endpoint_errors.go
+++ b/op-dispute-mon/mon/node_endpoint_errors.go
@@ -21,7 +21,7 @@ func NewNodeEndpointErrorsMonitor(logger log.Logger, metrics NodeEndpointErrorsM
 	}
 }
 
-func (m *NodeEndpointErrorsMonitor) CheckNodeEndpointErrors(games []*types.EnrichedGameData) {
+func (m *NodeEndpointErrorsMonitor) CheckNodeEndpointErrors(games []*types.CommonGameData) {
 	// Use a set to track unique endpoint errors across all games
 	uniqueEndpointErrors := make(map[string]bool)
 

--- a/op-dispute-mon/mon/node_endpoint_errors_test.go
+++ b/op-dispute-mon/mon/node_endpoint_errors_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCheckNodeEndpointErrors_NoErrors(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, NodeEndpointErrors: nil},
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, NodeEndpointErrors: make(map[string]bool)},
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x33}}}, // No NodeEndpointErrors field set
@@ -28,7 +28,7 @@ func TestCheckNodeEndpointErrors_NoErrors(t *testing.T) {
 }
 
 func TestCheckNodeEndpointErrors_SingleGameWithErrors(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointErrors: map[string]bool{
@@ -49,7 +49,7 @@ func TestCheckNodeEndpointErrors_SingleGameWithErrors(t *testing.T) {
 }
 
 func TestCheckNodeEndpointErrors_MultipleGamesWithOverlappingErrors(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointErrors: map[string]bool{
@@ -83,7 +83,7 @@ func TestCheckNodeEndpointErrors_MultipleGamesWithOverlappingErrors(t *testing.T
 }
 
 func TestCheckNodeEndpointErrors_MixedGamesWithAndWithoutErrors(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, NodeEndpointErrors: nil},
 		{
 			GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}},
@@ -110,7 +110,7 @@ func TestCheckNodeEndpointErrors_MixedGamesWithAndWithoutErrors(t *testing.T) {
 }
 
 func TestCheckNodeEndpointErrors_EmptyGamesList(t *testing.T) {
-	games := []*types.EnrichedGameData{}
+	games := []*types.CommonGameData{}
 
 	metrics := &stubNodeEndpointErrorsMetrics{}
 	logger := testlog.Logger(t, log.LvlDebug)

--- a/op-dispute-mon/mon/node_endpoint_out_of_sync.go
+++ b/op-dispute-mon/mon/node_endpoint_out_of_sync.go
@@ -21,7 +21,7 @@ func NewNodeEndpointOutOfSyncMonitor(logger log.Logger, metrics NodeEndpointOutO
 	}
 }
 
-func (m *NodeEndpointOutOfSyncMonitor) CheckNodeEndpointOutOfSync(games []*types.EnrichedGameData) {
+func (m *NodeEndpointOutOfSyncMonitor) CheckNodeEndpointOutOfSync(games []*types.CommonGameData) {
 	totalOutOfSync := 0
 
 	for _, game := range games {

--- a/op-dispute-mon/mon/node_endpoint_out_of_sync_test.go
+++ b/op-dispute-mon/mon/node_endpoint_out_of_sync_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCheckNodeEndpointOutOfSync_NoOutOfSync(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, NodeEndpointOutOfSyncCount: 0},
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, NodeEndpointOutOfSyncCount: 0},
 		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x33}}, NodeEndpointOutOfSyncCount: 0},
@@ -28,7 +28,7 @@ func TestCheckNodeEndpointOutOfSync_NoOutOfSync(t *testing.T) {
 }
 
 func TestCheckNodeEndpointOutOfSync_SingleGameOutOfSync(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata:               gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointOutOfSyncCount: 5,
@@ -49,7 +49,7 @@ func TestCheckNodeEndpointOutOfSync_SingleGameOutOfSync(t *testing.T) {
 }
 
 func TestCheckNodeEndpointOutOfSync_MultipleGamesOutOfSync(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata:               gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointOutOfSyncCount: 3,
@@ -75,7 +75,7 @@ func TestCheckNodeEndpointOutOfSync_MultipleGamesOutOfSync(t *testing.T) {
 }
 
 func TestCheckNodeEndpointOutOfSync_MixedGamesWithAndWithoutOutOfSync(t *testing.T) {
-	games := []*types.EnrichedGameData{
+	games := []*types.CommonGameData{
 		{
 			GameMetadata:               gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			NodeEndpointOutOfSyncCount: 0,
@@ -105,7 +105,7 @@ func TestCheckNodeEndpointOutOfSync_MixedGamesWithAndWithoutOutOfSync(t *testing
 }
 
 func TestCheckNodeEndpointOutOfSync_EmptyGamesList(t *testing.T) {
-	games := []*types.EnrichedGameData{}
+	games := []*types.CommonGameData{}
 
 	metrics := &stubNodeEndpointOutOfSyncMetrics{}
 	logger := testlog.Logger(t, log.LvlDebug)

--- a/op-dispute-mon/mon/resolutions.go
+++ b/op-dispute-mon/mon/resolutions.go
@@ -32,6 +32,9 @@ func NewResolutionMonitor(logger log.Logger, metrics ResolutionMetrics, clock RC
 func (r *ResolutionMonitor) CheckResolutions(games []*types.EnrichedGameData) {
 	statusMetrics := make(map[metrics.ResolutionStatus]int)
 	for _, game := range games {
+		if gameTypes.GameType(game.GameType) == gameTypes.SuperPermissionedGameType {
+			continue
+		}
 		complete := game.Status != gameTypes.GameStatusInProgress
 		duration := uint64(r.clock.Now().Unix()) - game.Timestamp
 		maxDurationReached := duration >= (2 * game.MaxClockDuration)

--- a/op-dispute-mon/mon/resolutions.go
+++ b/op-dispute-mon/mon/resolutions.go
@@ -29,12 +29,9 @@ func NewResolutionMonitor(logger log.Logger, metrics ResolutionMetrics, clock RC
 	}
 }
 
-func (r *ResolutionMonitor) CheckResolutions(games []*types.EnrichedGameData) {
+func (r *ResolutionMonitor) CheckResolutions(games []*types.FaultGameData) {
 	statusMetrics := make(map[metrics.ResolutionStatus]int)
 	for _, game := range games {
-		if gameTypes.GameType(game.GameType) == gameTypes.SuperPermissionedGameType {
-			continue
-		}
 		complete := game.Status != gameTypes.GameStatusInProgress
 		duration := uint64(r.clock.Now().Unix()) - game.Timestamp
 		maxDurationReached := duration >= (2 * game.MaxClockDuration)

--- a/op-dispute-mon/mon/resolutions_test.go
+++ b/op-dispute-mon/mon/resolutions_test.go
@@ -16,6 +16,10 @@ import (
 func TestResolutionMonitor_CheckResolutions(t *testing.T) {
 	r, cl, m := newTestResolutionMonitor(t)
 	games := newTestGames(uint64(cl.Now().Unix()))
+	games = append(games, &types.EnrichedGameData{
+		GameMetadata: gameTypes.GameMetadata{GameType: uint32(gameTypes.SuperPermissionedGameType)},
+		Status:       gameTypes.GameStatusDefenderWon,
+	})
 	r.CheckResolutions(games)
 
 	require.Equal(t, 1, m.calls[metrics.CompleteMaxDuration])

--- a/op-dispute-mon/mon/resolutions_test.go
+++ b/op-dispute-mon/mon/resolutions_test.go
@@ -16,10 +16,6 @@ import (
 func TestResolutionMonitor_CheckResolutions(t *testing.T) {
 	r, cl, m := newTestResolutionMonitor(t)
 	games := newTestGames(uint64(cl.Now().Unix()))
-	games = append(games, &types.EnrichedGameData{
-		GameMetadata: gameTypes.GameMetadata{GameType: uint32(gameTypes.SuperPermissionedGameType)},
-		Status:       gameTypes.GameStatusDefenderWon,
-	})
 	r.CheckResolutions(games)
 
 	require.Equal(t, 1, m.calls[metrics.CompleteMaxDuration])
@@ -48,11 +44,11 @@ func (s *stubResolutionMetrics) RecordGameResolutionStatus(status metrics.Resolu
 	s.calls[status] += count
 }
 
-func newTestGames(duration uint64) []*types.EnrichedGameData {
-	newTestGame := func(duration uint64, status gameTypes.GameStatus, resolvable bool) *types.EnrichedGameData {
-		game := &types.EnrichedGameData{
+func newTestGames(duration uint64) []*types.FaultGameData {
+	newTestGame := func(duration uint64, status gameTypes.GameStatus, resolvable bool) *types.FaultGameData {
+		game := &types.FaultGameData{
 			MaxClockDuration: duration,
-			Status:           status,
+			CommonGameData:   types.CommonGameData{Status: status},
 		}
 		if !resolvable {
 			game.Claims = []types.EnrichedClaim{
@@ -63,7 +59,7 @@ func newTestGames(duration uint64) []*types.EnrichedGameData {
 		}
 		return game
 	}
-	return []*types.EnrichedGameData{
+	return []*types.FaultGameData{
 		newTestGame(duration/2, gameTypes.GameStatusInProgress, false),
 		newTestGame(duration*5, gameTypes.GameStatusInProgress, false),
 		newTestGame(duration/2, gameTypes.GameStatusInProgress, true),

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -239,15 +239,19 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		s.factoryContract.GetGamesAtOrAfter,
 		cfg.IgnoredGames,
 		cfg.MaxConcurrency,
-		extract.NewClaimEnricher(),
-		extract.NewRecipientEnricher(), // Must be called before WithdrawalsEnricher and BondEnricher
-		extract.NewWithdrawalsEnricher(),
-		extract.NewBondEnricher(),
-		extract.NewBalanceEnricher(),
-		extract.NewL1HeadBlockNumEnricher(s.l1Client),
-		extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.outputRollupClients(), clock.SystemClock),
-		extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.asSuperRootProviders(), clock.SystemClock),
-		extract.NewAnchorStateRegistryEnricher(s.logger),
+		[]extract.CommonEnricher{
+			extract.NewL1HeadBlockNumEnricher(s.l1Client),
+			extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.outputRollupClients(), clock.SystemClock),
+			extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.asSuperRootProviders(), clock.SystemClock),
+			extract.NewAnchorStateRegistryEnricher(s.logger),
+		},
+		[]extract.FaultEnricher{
+			extract.NewClaimEnricher(),
+			extract.NewRecipientEnricher(), // Must be called before WithdrawalsEnricher and BondEnricher
+			extract.NewWithdrawalsEnricher(),
+			extract.NewBondEnricher(),
+			extract.NewBalanceEnricher(),
+		},
 	)
 	forecast := NewForecast(s.logger, s.metrics)
 	bonds := bonds.NewBonds(s.logger, s.metrics, s.cl)
@@ -270,19 +274,23 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		extractor.Extract,
 		forecast.Forecast,
 		anchorStateMonitor.CheckAnchorState,
-		bonds.CheckBonds,
-		resolutions.CheckResolutions,
-		claims.CheckClaims,
-		withdrawals.CheckWithdrawals,
-		l2ChallengesMonitor.CheckL2Challenges,
-		updateTimeMonitor.CheckUpdateTimes,
-		nodeEndpointErrorsMonitor.CheckNodeEndpointErrors,
-		nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount,
-		nodeEndpointOutOfSyncMonitor.CheckNodeEndpointOutOfSync,
-		mixedAvailabilityMonitor.CheckMixedAvailability,
-		mixedSafetyMonitor.CheckMixedSafety,
-		differentRootMonitor.CheckDifferentRoots,
-		gameTypeMonitor.CheckGameTypes)
+		[]CommonMonitor{
+			updateTimeMonitor.CheckUpdateTimes,
+			nodeEndpointErrorsMonitor.CheckNodeEndpointErrors,
+			nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount,
+			nodeEndpointOutOfSyncMonitor.CheckNodeEndpointOutOfSync,
+			mixedAvailabilityMonitor.CheckMixedAvailability,
+			mixedSafetyMonitor.CheckMixedSafety,
+			differentRootMonitor.CheckDifferentRoots,
+			gameTypeMonitor.CheckGameTypes,
+		},
+		[]FaultMonitor{
+			bonds.CheckBonds,
+			resolutions.CheckResolutions,
+			claims.CheckClaims,
+			withdrawals.CheckWithdrawals,
+			l2ChallengesMonitor.CheckL2Challenges,
+		})
 }
 
 func (s *Service) Start(ctx context.Context) error {

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -239,19 +239,8 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		s.factoryContract.GetGamesAtOrAfter,
 		cfg.IgnoredGames,
 		cfg.MaxConcurrency,
-		[]extract.CommonEnricher{
-			extract.NewL1HeadBlockNumEnricher(s.l1Client),
-			extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.outputRollupClients(), clock.SystemClock),
-			extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.asSuperRootProviders(), clock.SystemClock),
-			extract.NewAnchorStateRegistryEnricher(s.logger),
-		},
-		[]extract.FaultEnricher{
-			extract.NewClaimEnricher(),
-			extract.NewRecipientEnricher(), // Must be called before WithdrawalsEnricher and BondEnricher
-			extract.NewWithdrawalsEnricher(),
-			extract.NewBondEnricher(),
-			extract.NewBalanceEnricher(),
-		},
+		s.commonEnrichers(),
+		s.faultEnrichers(),
 	)
 	forecast := NewForecast(s.logger, s.metrics)
 	bonds := bonds.NewBonds(s.logger, s.metrics, s.cl)
@@ -291,6 +280,25 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 			withdrawals.CheckWithdrawals,
 			l2ChallengesMonitor.CheckL2Challenges,
 		})
+}
+
+func (s *Service) commonEnrichers() []extract.CommonEnricher {
+	return []extract.CommonEnricher{
+		extract.NewL1HeadBlockNumEnricher(s.l1Client),
+		extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.outputRollupClients(), clock.SystemClock),
+		extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.asSuperRootProviders(), clock.SystemClock),
+		extract.NewAnchorStateRegistryEnricher(s.logger),
+	}
+}
+
+func (s *Service) faultEnrichers() []extract.FaultEnricher {
+	return []extract.FaultEnricher{
+		extract.NewClaimEnricher(),
+		extract.NewRecipientEnricher(), // Must be called before WithdrawalsEnricher and BondEnricher
+		extract.NewWithdrawalsEnricher(),
+		extract.NewBondEnricher(),
+		extract.NewBalanceEnricher(),
+	}
 }
 
 func (s *Service) Start(ctx context.Context) error {

--- a/op-dispute-mon/mon/service_test.go
+++ b/op-dispute-mon/mon/service_test.go
@@ -1,0 +1,98 @@
+package mon
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/config"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/extract"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitMonitorWiresEveryTypedLane(t *testing.T) {
+	ctx := t.Context()
+	factoryAddress := common.Address{0xaa}
+	logger := testlog.Logger(t, log.LevelCrit)
+	stubRPC := &serviceRPCStub{AbiBasedRpc: batchingTest.NewAbiBasedRpc(t, factoryAddress, snapshots.LoadDisputeGameFactoryABI())}
+	stubRPC.SetResponse(factoryAddress, "version", rpcblock.Latest, nil, []interface{}{"1.4.0"})
+	caller := batching.NewMultiCaller(stubRPC, batching.DefaultBatchSize)
+	factory, err := contracts.NewDisputeGameFactoryContract(ctx, metrics.NoopMetrics, factoryAddress, caller)
+	require.NoError(t, err)
+	l1Client, err := sources.NewL1Client(stubRPC, logger, metrics.NoopMetrics, sources.L1ClientSimpleConfig(true, sources.RPCKindAny, 100))
+	require.NoError(t, err)
+
+	service := &Service{
+		logger:          logger,
+		metrics:         metrics.NoopMetrics,
+		honestActors:    monTypes.NewHonestActors(nil),
+		factoryContract: factory,
+		cl:              clock.NewDeterministicClock(time.Unix(1, 0)),
+		l1Client:        l1Client,
+		l1Caller:        caller,
+	}
+	service.game = extract.NewGameCallerCreator(service.metrics, caller)
+	cfg := config.NewCombinedConfig(factoryAddress, "unused", nil, nil)
+
+	service.initMonitor(ctx, &cfg)
+	require.NotNil(t, service.monitor)
+	require.NotNil(t, service.monitor.fetchHeadBlock)
+	require.NotNil(t, service.monitor.extract)
+	require.NotNil(t, service.monitor.forecast)
+	require.NotNil(t, service.monitor.checkAnchorState)
+	expectedCommon := []string{
+		"(*UpdateTimeMonitor).CheckUpdateTimes-fm",
+		"(*NodeEndpointErrorsMonitor).CheckNodeEndpointErrors-fm",
+		"(*NodeEndpointErrorCountMonitor).CheckNodeEndpointErrorCount-fm",
+		"(*NodeEndpointOutOfSyncMonitor).CheckNodeEndpointOutOfSync-fm",
+		"(*MixedAvailability).CheckMixedAvailability-fm",
+		"(*MixedSafetyMonitor).CheckMixedSafety-fm",
+		"(*DifferentRootMonitor).CheckDifferentRoots-fm",
+		"(*GameTypeMonitor).CheckGameTypes-fm",
+	}
+	require.Len(t, service.monitor.commonMonitors, len(expectedCommon))
+	for i, expected := range expectedCommon {
+		require.Contains(t, registeredFunctionName(service.monitor.commonMonitors[i]), expected)
+	}
+	expectedFault := []string{
+		"bonds.(*Bonds).CheckBonds-fm",
+		"(*ResolutionMonitor).CheckResolutions-fm",
+		"(*ClaimMonitor).CheckClaims-fm",
+		"(*WithdrawalMonitor).CheckWithdrawals-fm",
+		"(*L2ChallengesMonitor).CheckL2Challenges-fm",
+	}
+	require.Len(t, service.monitor.faultMonitors, len(expectedFault))
+	for i, expected := range expectedFault {
+		require.Contains(t, registeredFunctionName(service.monitor.faultMonitors[i]), expected)
+	}
+}
+
+func registeredFunctionName(fn any) string {
+	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+}
+
+type serviceRPCStub struct {
+	*batchingTest.AbiBasedRpc
+}
+
+func (*serviceRPCStub) Close() {}
+
+func (*serviceRPCStub) Subscribe(context.Context, string, any, ...any) (ethereum.Subscription, error) {
+	return nil, errors.New("subscriptions are not supported by the test RPC")
+}

--- a/op-dispute-mon/mon/service_test.go
+++ b/op-dispute-mon/mon/service_test.go
@@ -50,6 +50,20 @@ func TestInitMonitorWiresEveryTypedLane(t *testing.T) {
 	service.game = extract.NewGameCallerCreator(service.metrics, caller)
 	cfg := config.NewCombinedConfig(factoryAddress, "unused", nil, nil)
 
+	require.Equal(t, []string{
+		"*extract.L1HeadBlockNumEnricher",
+		"*extract.OutputAgreementEnricher",
+		"*extract.SuperAgreementEnricher",
+		"*extract.AnchorStateRegistryEnricher",
+	}, registeredTypeNames(service.commonEnrichers()))
+	require.Equal(t, []string{
+		"*extract.ClaimEnricher",
+		"*extract.RecipientEnricher",
+		"*extract.WithdrawalsEnricher",
+		"*extract.BondEnricher",
+		"*extract.BalanceEnricher",
+	}, registeredTypeNames(service.faultEnrichers()))
+
 	service.initMonitor(ctx, &cfg)
 	require.NotNil(t, service.monitor)
 	require.NotNil(t, service.monitor.fetchHeadBlock)
@@ -85,6 +99,14 @@ func TestInitMonitorWiresEveryTypedLane(t *testing.T) {
 
 func registeredFunctionName(fn any) string {
 	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+}
+
+func registeredTypeNames[T any](values []T) []string {
+	names := make([]string, len(values))
+	for i, value := range values {
+		names[i] = reflect.TypeOf(value).String()
+	}
+	return names
 }
 
 type serviceRPCStub struct {

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -38,18 +38,22 @@ type EnrichedClaim struct {
 	Resolved bool
 }
 
-type EnrichedGameData struct {
+// EnrichedGame is a complete, pinned snapshot of a supported dispute game.
+// Implementations are sealed so every game kind is handled explicitly.
+type EnrichedGame interface {
+	Common() *CommonGameData
+	enrichedGame()
+}
+
+// CommonGameData contains fields shared by every supported game kind.
+type CommonGameData struct {
 	types.GameMetadata
-	LastUpdateTime        time.Time
-	L1Head                common.Hash
-	L1HeadNum             uint64
-	L2SequenceNumber      uint64
-	RootClaim             common.Hash
-	Status                types.GameStatus
-	MaxClockDuration      uint64
-	BlockNumberChallenged bool
-	BlockNumberChallenger common.Address
-	Claims                []EnrichedClaim
+	LastUpdateTime   time.Time
+	L1Head           common.Hash
+	L1HeadNum        uint64
+	L2SequenceNumber uint64
+	RootClaim        common.Hash
+	Status           types.GameStatus
 
 	// AnchorStateRegistry is the address of the AnchorStateRegistry this game builds on.
 	// Zero if the game's contract version does not expose it.
@@ -57,29 +61,6 @@ type EnrichedGameData struct {
 
 	AgreeWithClaim    bool
 	ExpectedRootClaim common.Hash
-
-	// Recipients maps addresses to true if they are a bond recipient in the game.
-	Recipients map[common.Address]bool
-
-	// Credits records the paid out bonds for the game, keyed by recipient.
-	Credits map[common.Address]*big.Int
-
-	BondDistributionMode faultTypes.BondDistributionMode
-
-	// WithdrawalRequests maps recipients with withdrawal requests in DelayedWETH for this game.
-	WithdrawalRequests map[common.Address]*contracts.WithdrawalRequest
-
-	// WETHContract is the address of the DelayedWETH contract used by this game
-	// The contract is potentially shared by multiple games.
-	WETHContract common.Address
-
-	// WETHDelay is the delay applied before credits can be withdrawn.
-	WETHDelay time.Duration
-
-	// ETHCollateral is the ETH balance of the (potentially shared) WETHContract
-	// This ETH balance will be used to pay out any bonds required by the games
-	// that use the same DelayedWETH contract.
-	ETHCollateral *big.Int
 
 	// NodeEndpointErrors stores endpoint IDs that returned errors other than "not found" for this game.
 	NodeEndpointErrors map[string]bool
@@ -107,14 +88,55 @@ type EnrichedGameData struct {
 	NodeEndpointDifferentRoots bool
 }
 
+// FaultGameData contains claims, bonds, withdrawals, and challenge state for a fault game.
+type FaultGameData struct {
+	CommonGameData
+
+	MaxClockDuration      uint64
+	BlockNumberChallenged bool
+	BlockNumberChallenger common.Address
+	Claims                []EnrichedClaim
+
+	// Recipients maps addresses to true if they are a bond recipient in the game.
+	Recipients map[common.Address]bool
+
+	// Credits records the paid out bonds for the game, keyed by recipient.
+	Credits map[common.Address]*big.Int
+
+	BondDistributionMode faultTypes.BondDistributionMode
+
+	// WithdrawalRequests maps recipients with withdrawal requests in DelayedWETH for this game.
+	WithdrawalRequests map[common.Address]*contracts.WithdrawalRequest
+
+	// WETHContract is the address of the DelayedWETH contract used by this game.
+	WETHContract common.Address
+
+	// WETHDelay is the delay applied before credits can be withdrawn.
+	WETHDelay time.Duration
+
+	// ETHCollateral is the ETH balance of the potentially shared WETHContract.
+	ETHCollateral *big.Int
+}
+
+// SuperPermissionedGameData is the common snapshot of a SuperPermissioned game.
+type SuperPermissionedGameData struct {
+	CommonGameData
+}
+
+func (g *FaultGameData) Common() *CommonGameData             { return &g.CommonGameData }
+func (g *SuperPermissionedGameData) Common() *CommonGameData { return &g.CommonGameData }
+
+func (*FaultGameData) enrichedGame()             {}
+func (*SuperPermissionedGameData) enrichedGame() {}
+
 // UsesOutputRoots returns true if the game type is one of the known types that use output roots as proposals.
-func (g EnrichedGameData) UsesOutputRoots() bool {
+func (g CommonGameData) UsesOutputRoots() bool {
 	return slices.Contains(outputRootGameTypes, types.GameType(g.GameType))
 }
 
 // HasMixedAvailability returns true if some endpoints returned "not found" while others succeeded
 // for this game. This indicates inconsistent block availability across the node network.
-func (g EnrichedGameData) HasMixedAvailability() bool {
+func (g CommonGameData) HasMixedAvailability() bool {
 	if g.NodeEndpointTotalCount == 0 {
 		return false
 	}
@@ -125,7 +147,7 @@ func (g EnrichedGameData) HasMixedAvailability() bool {
 
 // HasMixedSafety returns true if some endpoints reported the root as safe and others as unsafe
 // for this game. This indicates inconsistent safety assessment across the node network.
-func (g EnrichedGameData) HasMixedSafety() bool {
+func (g CommonGameData) HasMixedSafety() bool {
 	return g.NodeEndpointSafeCount > 0 && g.NodeEndpointUnsafeCount > 0
 }
 

--- a/op-dispute-mon/mon/types/types_test.go
+++ b/op-dispute-mon/mon/types/types_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnrichedGameData_UsesOutputRoots(t *testing.T) {
+func TestCommonGameData_UsesOutputRoots(t *testing.T) {
 	for _, gameType := range outputRootGameTypes {
 		gameType := gameType
 		t.Run(fmt.Sprintf("GameType-%v", gameType), func(t *testing.T) {
-			data := EnrichedGameData{
+			data := CommonGameData{
 				GameMetadata: types.GameMetadata{GameType: uint32(gameType)},
 			}
 			require.True(t, data.UsesOutputRoots())
@@ -23,7 +23,7 @@ func TestEnrichedGameData_UsesOutputRoots(t *testing.T) {
 	for _, gameType := range nonOutputRootTypes {
 		gameType := gameType
 		t.Run(fmt.Sprintf("GameType-%v", gameType), func(t *testing.T) {
-			data := EnrichedGameData{
+			data := CommonGameData{
 				GameMetadata: types.GameMetadata{GameType: gameType},
 			}
 			require.False(t, data.UsesOutputRoots())
@@ -31,12 +31,12 @@ func TestEnrichedGameData_UsesOutputRoots(t *testing.T) {
 	}
 }
 
-func TestEnrichedGameData_NodeEndpointErrorCountInitialization(t *testing.T) {
-	data := EnrichedGameData{}
+func TestCommonGameData_NodeEndpointErrorCountInitialization(t *testing.T) {
+	data := CommonGameData{}
 	require.Equal(t, 0, data.NodeEndpointErrorCount, "NodeEndpointErrorCount should default to 0")
 }
 
-func TestEnrichedGameData_HasMixedAvailability(t *testing.T) {
+func TestCommonGameData_HasMixedAvailability(t *testing.T) {
 	tests := []struct {
 		name                      string
 		nodeEndpointTotalCount    int
@@ -104,7 +104,7 @@ func TestEnrichedGameData_HasMixedAvailability(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			data := EnrichedGameData{
+			data := CommonGameData{
 				NodeEndpointTotalCount:    test.nodeEndpointTotalCount,
 				NodeEndpointErrorCount:    test.nodeEndpointErrorCount,
 				NodeEndpointNotFoundCount: test.nodeEndpointNotFoundCount,
@@ -115,7 +115,7 @@ func TestEnrichedGameData_HasMixedAvailability(t *testing.T) {
 	}
 }
 
-func TestEnrichedGameData_HasMixedSafety(t *testing.T) {
+func TestCommonGameData_HasMixedSafety(t *testing.T) {
 	tests := []struct {
 		name                    string
 		nodeEndpointSafeCount   int
@@ -168,7 +168,7 @@ func TestEnrichedGameData_HasMixedSafety(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			data := EnrichedGameData{
+			data := CommonGameData{
 				NodeEndpointSafeCount:   test.nodeEndpointSafeCount,
 				NodeEndpointUnsafeCount: test.nodeEndpointUnsafeCount,
 			}
@@ -180,7 +180,7 @@ func TestEnrichedGameData_HasMixedSafety(t *testing.T) {
 func TestAllSupportedLifecycleGameTypesAreOutputOrSuperRootType(t *testing.T) {
 	for _, gameType := range types.SupportedLifecycleGameTypes {
 		t.Run(gameType.String(), func(t *testing.T) {
-			data := EnrichedGameData{
+			data := CommonGameData{
 				GameMetadata: types.GameMetadata{
 					GameType: uint32(gameType),
 				},

--- a/op-dispute-mon/mon/update_times.go
+++ b/op-dispute-mon/mon/update_times.go
@@ -20,7 +20,7 @@ func NewUpdateTimeMonitor(cl clock.Clock, metrics UpdateTimeMetrics) *UpdateTime
 	return &UpdateTimeMonitor{clock: cl, metrics: metrics}
 }
 
-func (m *UpdateTimeMonitor) CheckUpdateTimes(games []*types.EnrichedGameData) {
+func (m *UpdateTimeMonitor) CheckUpdateTimes(games []*types.CommonGameData) {
 	// Report the current time if there are no games
 	// Otherwise the last update time would drop to 0 when there are no games, making it appear there were errors
 	earliest := m.clock.Now()

--- a/op-dispute-mon/mon/update_times_test.go
+++ b/op-dispute-mon/mon/update_times_test.go
@@ -17,7 +17,7 @@ func TestUpdateTimeMonitor_NoGames(t *testing.T) {
 	require.Equal(t, cl.Now(), m.oldestUpdateTime)
 
 	cl.AdvanceTime(time.Minute)
-	monitor.CheckUpdateTimes([]*types.EnrichedGameData{})
+	monitor.CheckUpdateTimes([]*types.CommonGameData{})
 	require.Equal(t, cl.Now(), m.oldestUpdateTime)
 }
 
@@ -25,7 +25,7 @@ func TestUpdateTimeMonitor_ReportsOldestUpdateTime(t *testing.T) {
 	m := &mockUpdateTimeMetrics{}
 	cl := clock.NewDeterministicClock(time.UnixMilli(45892))
 	monitor := NewUpdateTimeMonitor(cl, m)
-	monitor.CheckUpdateTimes([]*types.EnrichedGameData{
+	monitor.CheckUpdateTimes([]*types.CommonGameData{
 		{LastUpdateTime: time.UnixMilli(4)},
 		{LastUpdateTime: time.UnixMilli(3)},
 		{LastUpdateTime: time.UnixMilli(7)},

--- a/op-dispute-mon/mon/withdrawals.go
+++ b/op-dispute-mon/mon/withdrawals.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	challengerTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
@@ -33,7 +32,7 @@ func NewWithdrawalMonitor(logger log.Logger, clock RClock, metrics WithdrawalMet
 	}
 }
 
-func (w *WithdrawalMonitor) CheckWithdrawals(games []*types.EnrichedGameData) {
+func (w *WithdrawalMonitor) CheckWithdrawals(games []*types.FaultGameData) {
 	now := w.clock.Now() // Use a consistent time for all checks
 	matching := make(map[common.Address]int)
 	divergent := make(map[common.Address]int)
@@ -42,9 +41,6 @@ func (w *WithdrawalMonitor) CheckWithdrawals(games []*types.EnrichedGameData) {
 		honestWithdrawableAmounts[address] = big.NewInt(0)
 	}
 	for _, game := range games {
-		if gameTypes.GameType(game.GameType) == gameTypes.SuperPermissionedGameType {
-			continue
-		}
 		matches, diverges := w.validateGameWithdrawals(game, now, honestWithdrawableAmounts)
 		matching[game.WETHContract] += matches
 		divergent[game.WETHContract] += diverges
@@ -58,7 +54,7 @@ func (w *WithdrawalMonitor) CheckWithdrawals(games []*types.EnrichedGameData) {
 	w.metrics.RecordHonestWithdrawableAmounts(honestWithdrawableAmounts)
 }
 
-func (w *WithdrawalMonitor) validateGameWithdrawals(game *types.EnrichedGameData, now time.Time, honestWithdrawableAmounts map[common.Address]*big.Int) (int, int) {
+func (w *WithdrawalMonitor) validateGameWithdrawals(game *types.FaultGameData, now time.Time, honestWithdrawableAmounts map[common.Address]*big.Int) (int, int) {
 	matching := 0
 	divergent := 0
 	for recipient, withdrawalAmount := range game.WithdrawalRequests {

--- a/op-dispute-mon/mon/withdrawals_test.go
+++ b/op-dispute-mon/mon/withdrawals_test.go
@@ -28,12 +28,12 @@ var (
 	nowUnix = int64(10_000)
 )
 
-func makeGames(distributionMode faultTypes.BondDistributionMode, noWithdrawalRequest bool) []*monTypes.EnrichedGameData {
+func makeGames(distributionMode faultTypes.BondDistributionMode, noWithdrawalRequest bool) []*monTypes.FaultGameData {
 	weth1Balance := big.NewInt(4200)
 	weth2Balance := big.NewInt(6000)
 
-	game1 := &monTypes.EnrichedGameData{
-		GameMetadata: types.GameMetadata{Proxy: common.Address{0x11, 0x11, 0x11}},
+	game1 := &monTypes.FaultGameData{
+		CommonGameData: monTypes.CommonGameData{GameMetadata: types.GameMetadata{Proxy: common.Address{0x11, 0x11, 0x11}}},
 		Credits: map[common.Address]*big.Int{
 			honestActor1: big.NewInt(3),
 			honestActor2: big.NewInt(1),
@@ -47,8 +47,8 @@ func makeGames(distributionMode faultTypes.BondDistributionMode, noWithdrawalReq
 		ETHCollateral: weth1Balance,
 		WETHDelay:     100 * time.Second,
 	}
-	game2 := &monTypes.EnrichedGameData{
-		GameMetadata:         types.GameMetadata{Proxy: common.Address{0x22, 0x22, 0x22}},
+	game2 := &monTypes.FaultGameData{
+		CommonGameData:       monTypes.CommonGameData{GameMetadata: types.GameMetadata{Proxy: common.Address{0x22, 0x22, 0x22}}},
 		BondDistributionMode: distributionMode,
 		Credits: map[common.Address]*big.Int{
 			honestActor1: big.NewInt(46),
@@ -62,8 +62,8 @@ func makeGames(distributionMode faultTypes.BondDistributionMode, noWithdrawalReq
 		ETHCollateral: weth2Balance,
 		WETHDelay:     500 * time.Second,
 	}
-	game3 := &monTypes.EnrichedGameData{
-		GameMetadata:         types.GameMetadata{Proxy: common.Address{0x33, 0x33, 0x33}},
+	game3 := &monTypes.FaultGameData{
+		CommonGameData:       monTypes.CommonGameData{GameMetadata: types.GameMetadata{Proxy: common.Address{0x33, 0x33, 0x33}}},
 		BondDistributionMode: distributionMode,
 		Credits: map[common.Address]*big.Int{
 			honestActor3:    big.NewInt(2),
@@ -84,7 +84,7 @@ func makeGames(distributionMode faultTypes.BondDistributionMode, noWithdrawalReq
 			Timestamp: big.NewInt(0),
 		}
 	}
-	return []*monTypes.EnrichedGameData{game1, game2, game3}
+	return []*monTypes.FaultGameData{game1, game2, game3}
 }
 
 func TestCheckWithdrawals(t *testing.T) {
@@ -203,9 +203,9 @@ func TestWithdrawalNotInitiated(t *testing.T) {
 	}
 	honestActors := monTypes.NewHonestActors([]common.Address{honestActor1, honestActor2, honestActor3})
 	withdrawals := NewWithdrawalMonitor(logger, cl, metrics, honestActors)
-	games := []*monTypes.EnrichedGameData{
+	games := []*monTypes.FaultGameData{
 		{
-			GameMetadata: types.GameMetadata{Proxy: common.Address{0x11, 0x11, 0x11}},
+			CommonGameData: monTypes.CommonGameData{GameMetadata: types.GameMetadata{Proxy: common.Address{0x11, 0x11, 0x11}}},
 			Credits: map[common.Address]*big.Int{
 				honestActor1: big.NewInt(3),
 			},
@@ -227,32 +227,6 @@ func TestWithdrawalNotInitiated(t *testing.T) {
 
 	require.Truef(t, big.NewInt(3).Cmp(metrics.honestWithdrawable[honestActor1]) == 0,
 		"Expected %v withdrawable to be %v but was %v", honestActor1, 3, metrics.honestWithdrawable[honestActor1])
-}
-
-func TestWithdrawalMonitorSkipsSuperPermissioned(t *testing.T) {
-	now := time.Unix(nowUnix, 0)
-	cl := clock.NewDeterministicClock(now)
-	logger := testlog.Logger(t, log.LvlInfo)
-	metrics := &stubWithdrawalsMetrics{
-		matching:  make(map[common.Address]int),
-		divergent: make(map[common.Address]int),
-	}
-	honestActors := monTypes.NewHonestActors([]common.Address{honestActor1})
-	withdrawals := NewWithdrawalMonitor(logger, cl, metrics, honestActors)
-	games := []*monTypes.EnrichedGameData{
-		{
-			GameMetadata: types.GameMetadata{
-				GameType: uint32(types.SuperPermissionedGameType),
-			},
-		},
-	}
-	withdrawals.CheckWithdrawals(games)
-
-	require.Zero(t, metrics.matchCalls)
-	require.Zero(t, metrics.divergeCalls)
-	require.Empty(t, metrics.matching)
-	require.Empty(t, metrics.divergent)
-	require.Equal(t, big.NewInt(0), metrics.honestWithdrawable[honestActor1])
 }
 
 type stubWithdrawalsMetrics struct {


### PR DESCRIPTION
## Claim

Replace the partially populated monitor game struct with sealed, capability-complete variants and typed monitor lanes while preserving existing behavior, except for the explicitly isolated SuperPermissioned resolution correction.

## Base and dependency

PR 1 of 5, based on `develop`. This is structural preparation: production ZK game creation remains disabled.

Stack order: #22225 → #22226 → #22227 → #22228 → #22229.

## Commits and reading order

1. `3e1033a16a` characterizes the agreement schema, pinned Fault reads, enricher order, and resolution routing.
2. `9d3ef31538` removes SuperPermissioned games from fault-resolution metrics.
3. `5a79abff55` performs the typed snapshot and monitor-lane cutover.

## Review focus

- Commit 2 contains the only output change; commit 3 is reviewable against the characterization tests in commit 1.
- Common, Fault, and bond consumers receive only capability-complete variants and remain registered once in historical order.
- Sealed lane membership replaces the deleted game-type guards; ZK remains absent from `GameCallerCreator.CreateContract`.

## Intentional behavior changes

- Terminal SuperPermissioned games no longer contribute meaningless fault-resolution buckets backed by their no-op claim API and zero clock.
- No other existing Fault or SuperPermissioned metric behavior changes.

## Tests

- `mise exec -- go test ./op-dispute-mon/... -count=1`
- `mise exec -- just lint-go`
