### PR TITLE
op-dispute-mon: extract and forecast ZK games

### DIFF
--- a/op-challenger/game/fault/contracts/gamefactory.go
+++ b/op-challenger/game/fault/contracts/gamefactory.go
@@ -41,6 +41,10 @@ var (
 //go:embed abis/DisputeGameFactory-1.2.0.json
 var disputeGameFactoryAbi120 []byte
 
+var disputeGameStatusABI = mustParseAbi([]byte(`[
+	{"type":"function","name":"status","stateMutability":"view","inputs":[],"outputs":[{"type":"uint8"}]}
+]`))
+
 type gameArgsFunc func(ctx context.Context, caller *batching.MultiCaller, block rpcblock.Block, contract *batching.BoundContract, gameType gameTypes.GameType) ([]byte, error)
 
 func getGameArgsLatest(ctx context.Context, caller *batching.MultiCaller, block rpcblock.Block, contract *batching.BoundContract, gameType gameTypes.GameType) ([]byte, error) {
@@ -130,6 +134,26 @@ func (f *DisputeGameFactoryContract) GetGameStatus(ctx context.Context, idx uint
 		return 0, fmt.Errorf("failed to create contract bindings for game %s: %w", game.Proxy, err)
 	}
 	return gameContract.GetStatus(ctx)
+}
+
+// GetGameStatusAtBlock returns a game's status from a snapshot pinned to block.
+func (f *DisputeGameFactoryContract) GetGameStatusAtBlock(ctx context.Context, idx uint64, block rpcblock.Block) (gameTypes.GameStatus, error) {
+	defer f.metrics.StartContractRequest("GetGameStatus")()
+	game, err := f.GetGame(ctx, idx, block)
+	if err != nil {
+		return 0, fmt.Errorf("failed to load game status: %w", err)
+	}
+
+	gameContract := batching.NewBoundContract(disputeGameStatusABI, game.Proxy)
+	result, err := f.multiCaller.SingleCall(ctx, block, gameContract.Call(methodStatus))
+	if err != nil {
+		return 0, fmt.Errorf("failed to load game status from game %s: %w", game.Proxy, err)
+	}
+	status, err := gameTypes.GameStatusFromUint8(result.GetUint8(0))
+	if err != nil {
+		return 0, fmt.Errorf("invalid status from game %s: %w", game.Proxy, err)
+	}
+	return status, nil
 }
 
 func (f *DisputeGameFactoryContract) getGameImpl(ctx context.Context, gameType gameTypes.GameType) (common.Address, error) {

--- a/op-challenger/game/fault/contracts/gamefactory_test.go
+++ b/op-challenger/game/fault/contracts/gamefactory_test.go
@@ -136,23 +136,55 @@ func TestLoadGame(t *testing.T) {
 
 func TestGetGameStatus(t *testing.T) {
 	for _, version := range factoryVersions {
-		t.Run(version.String(), func(t *testing.T) {
-			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
-			game0 := gameTypes.GameMetadata{
-				Index:     0,
-				GameType:  0,
-				Timestamp: 1234,
-				Proxy:     common.Address{0xaa},
-			}
-			expectGetGame(stubRpc, 0, rpcblock.Latest, game0)
-			stubRpc.AddContract(game0.Proxy, snapshots.LoadFaultDisputeGameABI())
-			expectedStatus := gameTypes.GameStatusChallengerWon
-			stubRpc.SetResponse(game0.Proxy, methodVersion, rpcblock.Latest, nil, []interface{}{versLatest})
-			stubRpc.SetResponse(game0.Proxy, methodStatus, rpcblock.Latest, nil, []interface{}{expectedStatus})
-			actual, err := factory.GetGameStatus(context.Background(), 0)
-			require.NoError(t, err)
-			require.Equal(t, expectedStatus, actual)
-		})
+		for _, test := range []struct {
+			name        string
+			block       rpcblock.Block
+			usesBinding bool
+			call        func(*DisputeGameFactoryContract) (gameTypes.GameStatus, error)
+		}{
+			{
+				name:        "latest wrapper",
+				block:       rpcblock.Latest,
+				usesBinding: true,
+				call: func(factory *DisputeGameFactoryContract) (gameTypes.GameStatus, error) {
+					return factory.GetGameStatus(context.Background(), 0)
+				},
+			},
+			{
+				name:  "pinned number",
+				block: rpcblock.ByNumber(123),
+				call: func(factory *DisputeGameFactoryContract) (gameTypes.GameStatus, error) {
+					return factory.GetGameStatusAtBlock(context.Background(), 0, rpcblock.ByNumber(123))
+				},
+			},
+			{
+				name:  "pinned hash",
+				block: rpcblock.ByHash(common.Hash{0x12, 0x34}),
+				call: func(factory *DisputeGameFactoryContract) (gameTypes.GameStatus, error) {
+					return factory.GetGameStatusAtBlock(context.Background(), 0, rpcblock.ByHash(common.Hash{0x12, 0x34}))
+				},
+			},
+		} {
+			t.Run(version.String()+"/"+test.name, func(t *testing.T) {
+				stubRpc, factory := setupDisputeGameFactoryTest(t, version)
+				game0 := gameTypes.GameMetadata{
+					Index:     0,
+					GameType:  0,
+					Timestamp: 1234,
+					Proxy:     common.Address{0xaa},
+				}
+				expectGetGame(stubRpc, 0, test.block, game0)
+				stubRpc.AddContract(game0.Proxy, snapshots.LoadFaultDisputeGameABI())
+				expectedStatus := gameTypes.GameStatusChallengerWon
+				if test.usesBinding {
+					stubRpc.SetResponse(game0.Proxy, methodVersion, rpcblock.Latest, nil, []interface{}{versLatest})
+				}
+				stubRpc.SetResponse(game0.Proxy, methodStatus, test.block, nil, []interface{}{expectedStatus})
+				actual, err := test.call(factory)
+				require.NoError(t, err)
+				require.Equal(t, expectedStatus, actual)
+			})
+		}
 	}
 }
 

--- a/op-challenger/game/fault/contracts/zkdisputegame.go
+++ b/op-challenger/game/fault/contracts/zkdisputegame.go
@@ -26,6 +26,15 @@ const (
 	ProposalStatusResolved
 )
 
+// ProposalStatusFromUint8 converts a contract status value to a checked ProposalStatus.
+func ProposalStatusFromUint8(value uint8) (ProposalStatus, error) {
+	status := ProposalStatus(value)
+	if status > ProposalStatusResolved {
+		return 0, fmt.Errorf("invalid proposal status: %d", value)
+	}
+	return status, nil
+}
+
 func (p ProposalStatus) String() string {
 	switch p {
 	case ProposalStatusUnchallenged:
@@ -63,6 +72,7 @@ type ZKDisputeGameContract interface {
 	ChallengeTx(ctx context.Context) (txmgr.TxCandidate, error)
 	GetProposal(ctx context.Context) (common.Hash, uint64, error)
 	GetChallengerMetadata(ctx context.Context, block rpcblock.Block) (ChallengerMetadata, error)
+	GetAnchorStateRegistry(ctx context.Context, block rpcblock.Block) (common.Address, error)
 	IsClosed(ctx context.Context) (bool, error)
 	GetCredit(ctx context.Context, recipient common.Address) (*big.Int, gameTypes.GameStatus, error)
 	ClaimCreditTx(ctx context.Context, recipient common.Address) (txmgr.TxCandidate, error)
@@ -221,6 +231,8 @@ func (g *ZKDisputeGameContractLatest) GetGameRange(ctx context.Context) (prestat
 type ChallengerMetadata struct {
 	ParentIndex      uint32
 	ProposalStatus   ProposalStatus
+	Challenger       common.Address
+	Prover           common.Address
 	ProposedRoot     common.Hash
 	L2SequenceNumber uint64
 	Deadline         time.Time
@@ -242,10 +254,21 @@ func (g *ZKDisputeGameContractLatest) GetChallengerMetadata(ctx context.Context,
 	return ChallengerMetadata{
 		ParentIndex:      data.ParentIndex,
 		ProposalStatus:   data.Status,
+		Challenger:       data.Challenger,
+		Prover:           data.Prover,
 		ProposedRoot:     data.Claim,
 		L2SequenceNumber: l2SeqNum,
 		Deadline:         time.Unix(int64(data.Deadline), 0),
 	}, nil
+}
+
+func (g *ZKDisputeGameContractLatest) GetAnchorStateRegistry(ctx context.Context, block rpcblock.Block) (common.Address, error) {
+	defer g.metrics.StartContractRequest("GetAnchorStateRegistry")()
+	result, err := g.multiCaller.SingleCall(ctx, block, g.contract.Call(methodAnchorStateRegistry))
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to retrieve anchor state registry: %w", err)
+	}
+	return result.GetAddress(0), nil
 }
 
 func (g *ZKDisputeGameContractLatest) ChallengeTx(ctx context.Context) (txmgr.TxCandidate, error) {

--- a/op-challenger/game/fault/contracts/zkdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/zkdisputegame_test.go
@@ -131,6 +131,31 @@ func TestZKGetMetadata(t *testing.T) {
 	}
 }
 
+func TestProposalStatusFromUint8(t *testing.T) {
+	for value := uint8(ProposalStatusUnchallenged); value <= uint8(ProposalStatusResolved); value++ {
+		status, err := ProposalStatusFromUint8(value)
+		require.NoError(t, err)
+		require.Equal(t, ProposalStatus(value), status)
+	}
+	status, err := ProposalStatusFromUint8(uint8(ProposalStatusResolved) + 1)
+	require.ErrorContains(t, err, "invalid proposal status")
+	require.Equal(t, ProposalStatusUnchallenged, status)
+}
+
+func TestZKGetAnchorStateRegistryAtPinnedBlock(t *testing.T) {
+	for _, version := range zkVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, contract := setupZKDisputeGameTest(t, version)
+			block := rpcblock.ByHash(common.Hash{0x88, 0x99})
+			expected := common.Address{0xab}
+			stubRpc.SetResponse(zkGameAddr, methodAnchorStateRegistry, block, nil, []interface{}{expected})
+			actual, err := contract.GetAnchorStateRegistry(context.Background(), block)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+		})
+	}
+}
+
 func TestZKGetGameRange(t *testing.T) {
 	for _, version := range zkVersions {
 		version := version
@@ -182,6 +207,8 @@ func TestZKGetChallengerMetadata(t *testing.T) {
 			expected := ChallengerMetadata{
 				ParentIndex:      expectedParentIndex,
 				ProposalStatus:   expectedProposalStatus,
+				Challenger:       challenger,
+				Prover:           prover,
 				ProposedRoot:     expectedRootClaim,
 				L2SequenceNumber: expectedL2BlockNumber,
 				Deadline:         expectedDeadline,
@@ -190,6 +217,20 @@ func TestZKGetChallengerMetadata(t *testing.T) {
 			require.Equal(t, expected, actual)
 		})
 	}
+}
+
+func TestZKGetChallengerMetadataAllowsUnknownProposalStatus(t *testing.T) {
+	stubRpc, contract := setupZKDisputeGameTest(t, zkVersions[0])
+	block := rpcblock.ByNumber(889)
+	unknown := ProposalStatus(255)
+	stubRpc.SetResponse(zkGameAddr, methodClaimData, block, nil, []interface{}{
+		uint32(0), unknown, common.Address{}, common.Address{}, uint64(0), common.Hash{},
+	})
+	stubRpc.SetResponse(zkGameAddr, methodL2SequenceNumber, block, nil, []interface{}{new(big.Int)})
+
+	metadata, err := contract.GetChallengerMetadata(context.Background(), block)
+	require.NoError(t, err)
+	require.Equal(t, unknown, metadata.ProposalStatus)
 }
 
 func TestZKChallengeTx(t *testing.T) {

--- a/op-dispute-mon/mon/extract/anchor_state_registry_enricher.go
+++ b/op-dispute-mon/mon/extract/anchor_state_registry_enricher.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/log"
@@ -25,6 +26,9 @@ func NewAnchorStateRegistryEnricher(logger log.Logger) *AnchorStateRegistryEnric
 }
 
 func (e *AnchorStateRegistryEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.CommonGameData) error {
+	if gameTypes.GameType(game.GameType) == gameTypes.ZKDisputeGameType {
+		return nil
+	}
 	addr, err := caller.GetAnchorStateRegistry(ctx, block)
 	if errors.Is(err, contracts.ErrAnchorStateRegistryNotSupported) {
 		return nil

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -48,7 +48,15 @@ type FaultGameCaller interface {
 	ClaimCaller
 }
 
+// ZKGameCaller exposes the generic and challenger views of a ZK game.
+type ZKGameCaller interface {
+	GameCaller
+	GetMetadata(context.Context, rpcblock.Block) (contracts.GenericGameMetadata, error)
+	GetChallengerMetadata(context.Context, rpcblock.Block) (contracts.ChallengerMetadata, error)
+}
+
 var _ FaultGameCaller = (contracts.FaultDisputeGameContract)(nil)
+var _ ZKGameCaller = (*contracts.ZKDisputeGameContractLatest)(nil)
 var _ BondGameCaller = (contracts.FaultDisputeGameContract)(nil)
 var _ MetadataCaller = (*contracts.SuperPermissionedDisputeGameContract)(nil)
 

--- a/op-dispute-mon/mon/extract/caller_test.go
+++ b/op-dispute-mon/mon/extract/caller_test.go
@@ -55,6 +55,11 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 			game: types.GameMetadata{GameType: uint32(types.SuperCannonKonaGameType), Proxy: fdgAddr},
 		},
 		{
+			name:        "zk production creation remains disabled",
+			game:        types.GameMetadata{GameType: uint32(types.ZKDisputeGameType), Proxy: fdgAddr},
+			expectedErr: fmt.Errorf("unsupported game type: %d", types.ZKDisputeGameType),
+		},
+		{
 			name:        "InvalidGameType",
 			game:        types.GameMetadata{GameType: 6, Proxy: fdgAddr},
 			expectedErr: fmt.Errorf("unsupported game type: 6"),

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 	"sync"
 	"sync/atomic"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -20,8 +22,9 @@ import (
 var ErrIgnored = errors.New("ignored")
 
 type (
-	CreateGameCaller   func(ctx context.Context, game gameTypes.GameMetadata) (GameCaller, error)
-	FactoryGameFetcher func(ctx context.Context, blockHash common.Hash, earliestTimestamp uint64) ([]gameTypes.GameMetadata, error)
+	CreateGameCaller        func(ctx context.Context, game gameTypes.GameMetadata) (GameCaller, error)
+	FactoryGameFetcher      func(ctx context.Context, blockHash common.Hash, earliestTimestamp uint64) ([]gameTypes.GameMetadata, error)
+	ParentGameStatusFetcher func(ctx context.Context, index uint64, block rpcblock.Block) (gameTypes.GameStatus, error)
 )
 
 // CommonEnricher adds data shared by every enriched game variant.
@@ -34,16 +37,23 @@ type FaultEnricher interface {
 	Enrich(ctx context.Context, block rpcblock.Block, caller FaultGameCaller, game *monTypes.FaultGameData) error
 }
 
+// ZKEnricher adds data that exists only for ZK games.
+type ZKEnricher interface {
+	Enrich(ctx context.Context, block rpcblock.Block, caller ZKGameCaller, game *monTypes.ZKGameData) error
+}
+
 type Extractor struct {
-	logger          log.Logger
-	clock           clock.Clock
-	createContract  CreateGameCaller
-	fetchGames      FactoryGameFetcher
-	maxConcurrency  int
-	commonEnrichers []CommonEnricher
-	faultEnrichers  []FaultEnricher
-	ignoredGames    map[common.Address]bool
-	latestGameData  map[common.Address]monTypes.EnrichedGame
+	logger            log.Logger
+	clock             clock.Clock
+	createContract    CreateGameCaller
+	fetchGames        FactoryGameFetcher
+	fetchParentStatus ParentGameStatusFetcher
+	maxConcurrency    int
+	commonEnrichers   []CommonEnricher
+	faultEnrichers    []FaultEnricher
+	zkAgreement       ZKEnricher
+	ignoredGames      map[common.Address]bool
+	latestGameData    map[common.Address]monTypes.EnrichedGame
 }
 
 func NewExtractor(
@@ -51,24 +61,28 @@ func NewExtractor(
 	cl clock.Clock,
 	creator CreateGameCaller,
 	fetchGames FactoryGameFetcher,
+	fetchParentStatus ParentGameStatusFetcher,
 	ignoredGames []common.Address,
 	maxConcurrency uint,
 	commonEnrichers []CommonEnricher,
 	faultEnrichers []FaultEnricher,
+	zkAgreement ZKEnricher,
 ) *Extractor {
 	ignored := make(map[common.Address]bool)
 	for _, game := range ignoredGames {
 		ignored[game] = true
 	}
 	return &Extractor{
-		logger:          logger,
-		clock:           cl,
-		createContract:  creator,
-		fetchGames:      fetchGames,
-		maxConcurrency:  int(maxConcurrency),
-		commonEnrichers: commonEnrichers,
-		faultEnrichers:  faultEnrichers,
-		ignoredGames:    ignored,
+		logger:            logger,
+		clock:             cl,
+		createContract:    creator,
+		fetchGames:        fetchGames,
+		fetchParentStatus: fetchParentStatus,
+		maxConcurrency:    int(maxConcurrency),
+		commonEnrichers:   commonEnrichers,
+		faultEnrichers:    faultEnrichers,
+		zkAgreement:       zkAgreement,
+		ignoredGames:      ignored,
 	}
 }
 
@@ -106,6 +120,10 @@ func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, game
 					if errors.Is(err, ErrIgnored) {
 						ignored.Add(1)
 						e.logger.Warn("Ignoring game", "game", game.Proxy)
+						continue
+					}
+					if errors.Is(err, gameTypes.ErrNotInSync) {
+						e.logger.Debug("Waiting for root source to process past the game L1 head", "game", game.Proxy)
 						continue
 					}
 					if err != nil {
@@ -150,6 +168,8 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 	switch gameTypes.GameType(game.GameType) {
 	case gameTypes.SuperPermissionedGameType:
 		return e.enrichSuperPermissionedGame(ctx, block, caller, game)
+	case gameTypes.ZKDisputeGameType:
+		return e.enrichZKGame(ctx, block, caller, game)
 	case gameTypes.CannonGameType,
 		gameTypes.PermissionedGameType,
 		gameTypes.CannonKonaGameType,
@@ -160,6 +180,103 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 	default:
 		return nil, fmt.Errorf("unsupported game type: %d", game.GameType)
 	}
+}
+
+func (e *Extractor) enrichZKGame(ctx context.Context, block rpcblock.Block, caller GameCaller, game gameTypes.GameMetadata) (monTypes.EnrichedGame, error) {
+	zkCaller, ok := caller.(ZKGameCaller)
+	if !ok {
+		return nil, fmt.Errorf("game caller %T does not support ZK game extraction", caller)
+	}
+	meta, err := zkCaller.GetMetadata(ctx, block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch game metadata: %w", err)
+	}
+	enrichedGame := &monTypes.ZKGameData{
+		CommonGameData: e.newCommonGameData(game, meta.L1Head, meta.L2SequenceNum, meta.ProposedRoot, meta.Status),
+	}
+	if err := e.applyCommonEnrichers(ctx, block, caller, enrichedGame.Common()); err != nil {
+		return nil, fmt.Errorf("failed to enrich game: %w", err)
+	}
+	if err := e.zkAgreement.Enrich(ctx, block, zkCaller, enrichedGame); err != nil {
+		return nil, fmt.Errorf("failed to enrich ZK agreement: %w", err)
+	}
+
+	challengerMeta, err := zkCaller.GetChallengerMetadata(ctx, block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch ZK challenger metadata: %w", err)
+	}
+	proposalStatus, err := contracts.ProposalStatusFromUint8(uint8(challengerMeta.ProposalStatus))
+	if err != nil {
+		return nil, err
+	}
+	if meta.ProposedRoot != challengerMeta.ProposedRoot {
+		return nil, fmt.Errorf("inconsistent ZK root claim: generic %s, challenger %s", meta.ProposedRoot, challengerMeta.ProposedRoot)
+	}
+	if meta.L2SequenceNum != challengerMeta.L2SequenceNumber {
+		return nil, fmt.Errorf("inconsistent ZK sequence number: generic %d, challenger %d", meta.L2SequenceNum, challengerMeta.L2SequenceNumber)
+	}
+	if err := validateZKStatus(meta.Status, proposalStatus); err != nil {
+		return nil, err
+	}
+	if err := validateZKParticipants(proposalStatus, challengerMeta.Challenger, challengerMeta.Prover); err != nil {
+		return nil, err
+	}
+	anchorStateRegistry, err := zkCaller.GetAnchorStateRegistry(ctx, block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch ZK anchor state registry: %w", err)
+	}
+	if anchorStateRegistry == (common.Address{}) {
+		return nil, errors.New("ZK anchor state registry is zero")
+	}
+
+	var parentStatus *gameTypes.GameStatus
+	if challengerMeta.ParentIndex != math.MaxUint32 {
+		status, err := e.fetchParentStatus(ctx, uint64(challengerMeta.ParentIndex), block)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch ZK parent game %d status: %w", challengerMeta.ParentIndex, err)
+		}
+		parentStatus = &status
+		if meta.Status != gameTypes.GameStatusInProgress && status == gameTypes.GameStatusInProgress {
+			return nil, fmt.Errorf("terminal ZK child has in-progress parent %d", challengerMeta.ParentIndex)
+		}
+	}
+
+	enrichedGame.AnchorStateRegistry = anchorStateRegistry
+	enrichedGame.ParentIndex = challengerMeta.ParentIndex
+	enrichedGame.ParentStatus = parentStatus
+	enrichedGame.ProposalStatus = proposalStatus
+	enrichedGame.Deadline = challengerMeta.Deadline
+	return enrichedGame, nil
+}
+
+func validateZKStatus(global gameTypes.GameStatus, proposal contracts.ProposalStatus) error {
+	proposalInProgress := proposal != contracts.ProposalStatusResolved
+	if (global == gameTypes.GameStatusInProgress) != proposalInProgress {
+		return fmt.Errorf("inconsistent ZK global status %s and proposal status %s", global, proposal)
+	}
+	return nil
+}
+
+func validateZKParticipants(status contracts.ProposalStatus, challenger, prover common.Address) error {
+	zeroChallenger := challenger == (common.Address{})
+	zeroProver := prover == (common.Address{})
+	valid := false
+	switch status {
+	case contracts.ProposalStatusUnchallenged:
+		valid = zeroChallenger && zeroProver
+	case contracts.ProposalStatusChallenged:
+		valid = !zeroChallenger && zeroProver
+	case contracts.ProposalStatusUnchallengedAndValidProofProvided:
+		valid = zeroChallenger && !zeroProver
+	case contracts.ProposalStatusChallengedAndValidProofProvided:
+		valid = !zeroChallenger && !zeroProver
+	case contracts.ProposalStatusResolved:
+		valid = true
+	}
+	if !valid {
+		return fmt.Errorf("invalid ZK participants for proposal status %s: challenger %s, prover %s", status, challenger, prover)
+	}
+	return nil
 }
 
 func (e *Extractor) enrichFaultGame(ctx context.Context, block rpcblock.Block, caller GameCaller, game gameTypes.GameMetadata) (monTypes.EnrichedGame, error) {

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -124,6 +124,11 @@ func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, game
 					}
 					if errors.Is(err, gameTypes.ErrNotInSync) {
 						e.logger.Debug("Waiting for root source to process past the game L1 head", "game", game.Proxy)
+						current, currentIsZK := enrichedGame.(*monTypes.ZKGameData)
+						cached, cachedIsZK := e.latestGameData[game.Proxy].(*monTypes.ZKGameData)
+						if currentIsZK && cachedIsZK {
+							enrichedCh <- withEndpointHealth(cached, current)
+						}
 						continue
 					}
 					if err != nil {
@@ -198,6 +203,9 @@ func (e *Extractor) enrichZKGame(ctx context.Context, block rpcblock.Block, call
 		return nil, fmt.Errorf("failed to enrich game: %w", err)
 	}
 	if err := e.zkAgreement.Enrich(ctx, block, zkCaller, enrichedGame); err != nil {
+		if errors.Is(err, gameTypes.ErrNotInSync) {
+			return enrichedGame, fmt.Errorf("failed to enrich ZK agreement: %w", err)
+		}
 		return nil, fmt.Errorf("failed to enrich ZK agreement: %w", err)
 	}
 
@@ -247,6 +255,19 @@ func (e *Extractor) enrichZKGame(ctx context.Context, block rpcblock.Block, call
 	enrichedGame.ProposalStatus = proposalStatus
 	enrichedGame.Deadline = challengerMeta.Deadline
 	return enrichedGame, nil
+}
+
+func withEndpointHealth(cached, current *monTypes.ZKGameData) *monTypes.ZKGameData {
+	updated := *cached
+	updated.NodeEndpointErrors = maps.Clone(current.NodeEndpointErrors)
+	updated.NodeEndpointErrorCount = current.NodeEndpointErrorCount
+	updated.NodeEndpointNotFoundCount = current.NodeEndpointNotFoundCount
+	updated.NodeEndpointOutOfSyncCount = current.NodeEndpointOutOfSyncCount
+	updated.NodeEndpointTotalCount = current.NodeEndpointTotalCount
+	updated.NodeEndpointSafeCount = current.NodeEndpointSafeCount
+	updated.NodeEndpointUnsafeCount = current.NodeEndpointUnsafeCount
+	updated.NodeEndpointDifferentRoots = current.NodeEndpointDifferentRoots
+	return &updated
 }
 
 func validateZKStatus(global gameTypes.GameStatus, proposal contracts.ProposalStatus) error {

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -323,9 +323,11 @@ func setupExtractorTest(t *testing.T, enrichers ...CommonEnricher) (*Extractor, 
 		cl,
 		creator.CreateGameCaller,
 		games.FetchGames,
+		nil,
 		ignoredGames,
 		5,
 		enrichers,
+		nil,
 		nil,
 	)
 	return extractor, creator, games, capturedLogs, cl

--- a/op-dispute-mon/mon/extract/super_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -47,7 +48,7 @@ type superRootResult struct {
 }
 
 func (e *SuperAgreementEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _ GameCaller, game *monTypes.CommonGameData) error {
-	if game.UsesOutputRoots() {
+	if game.UsesOutputRoots() || gameTypes.GameType(game.GameType) == gameTypes.ZKDisputeGameType {
 		return nil
 	}
 	if len(e.clients) == 0 {

--- a/op-dispute-mon/mon/extract/super_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher.go
@@ -44,8 +44,16 @@ type superRootResult struct {
 	superRoot common.Hash
 	isSafe    bool
 	notFound  bool
+	outOfSync bool
 	err       error
 }
+
+type superRootAgreementMode uint8
+
+const (
+	superGameAgreement superRootAgreementMode = iota
+	zkGameAgreement
+)
 
 func (e *SuperAgreementEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _ GameCaller, game *monTypes.CommonGameData) error {
 	switch gameTypes.GameType(game.GameType) {
@@ -53,11 +61,18 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _
 	default:
 		return nil
 	}
+	return e.enrich(ctx, game, superGameAgreement)
+}
+
+func (e *SuperAgreementEnricher) enrich(ctx context.Context, game *monTypes.CommonGameData, mode superRootAgreementMode) error {
+	isZKGame := mode == zkGameAgreement
 	if len(e.clients) == 0 {
 		return fmt.Errorf("%w but required for game type %v", ErrSuperRootRpcRequired, game.GameType)
 	}
 
-	game.NodeEndpointTotalCount = len(e.clients)
+	if !isZKGame {
+		game.NodeEndpointTotalCount = len(e.clients)
+	}
 
 	results := make([]superRootResult, len(e.clients))
 	var wg sync.WaitGroup
@@ -68,6 +83,11 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _
 			response, err := client.SuperRootAtTimestamp(ctx, game.L2SequenceNumber)
 			if err != nil {
 				results[i] = superRootResult{err: err}
+				return
+			}
+			// A ZK provider's answer is usable only after it has processed beyond the game L1 head.
+			if isZKGame && response.CurrentL1.Number <= game.L1HeadNum {
+				results[i] = superRootResult{outOfSync: true}
 				return
 			}
 			if response.Data == nil {
@@ -89,37 +109,80 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _
 		}(i, client)
 	}
 	wg.Wait()
+	if isZKGame {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
 
+	endpointErrors := game.NodeEndpointErrors
+	errorCount := game.NodeEndpointErrorCount
+	notFoundCount := game.NodeEndpointNotFoundCount
+	outOfSyncCount := game.NodeEndpointOutOfSyncCount
+	safeCount := game.NodeEndpointSafeCount
+	unsafeCount := game.NodeEndpointUnsafeCount
+	differentRoots := game.NodeEndpointDifferentRoots
+	if isZKGame {
+		endpointErrors = make(map[string]bool)
+		errorCount = 0
+		notFoundCount = 0
+		outOfSyncCount = 0
+		safeCount = 0
+		unsafeCount = 0
+		differentRoots = false
+		game.NodeEndpointTotalCount = len(e.clients)
+	}
 	validResults := make([]superRootResult, 0, len(results))
 	foundResults := make([]superRootResult, 0, len(results))
 	for idx, result := range results {
 		if result.err != nil {
-			e.log.Error("Failed to fetch super root", "clientIndex", idx, "l2SequenceNumber", game.L2SequenceNumber, "err", result.err)
+			if isZKGame {
+				e.log.Error("Failed to fetch ZK super root", "clientIndex", idx, "l2SequenceNumber", game.L2SequenceNumber, "err", result.err)
+			} else {
+				e.log.Error("Failed to fetch super root", "clientIndex", idx, "l2SequenceNumber", game.L2SequenceNumber, "err", result.err)
+			}
 			endpointID := fmt.Sprintf("client-%d", idx)
-			game.NodeEndpointErrors[endpointID] = true
-			game.NodeEndpointErrorCount++
+			endpointErrors[endpointID] = true
+			errorCount++
+			continue
+		}
+		if result.outOfSync {
+			outOfSyncCount++
 			continue
 		}
 
 		validResults = append(validResults, result)
 
 		if result.notFound {
-			game.NodeEndpointNotFoundCount++
+			notFoundCount++
 		} else {
 			foundResults = append(foundResults, result)
 			// Track safety counts only for found results where the super root matches the game's root claim
-			if result.superRoot == game.RootClaim {
+			if !isZKGame && result.superRoot == game.RootClaim {
 				if result.isSafe {
-					game.NodeEndpointSafeCount++
+					safeCount++
 				} else {
-					game.NodeEndpointUnsafeCount++
+					unsafeCount++
 				}
 			}
 		}
 	}
+	game.NodeEndpointErrors = endpointErrors
+	game.NodeEndpointErrorCount = errorCount
+	game.NodeEndpointNotFoundCount = notFoundCount
+	game.NodeEndpointOutOfSyncCount = outOfSyncCount
+	game.NodeEndpointSafeCount = safeCount
+	game.NodeEndpointUnsafeCount = unsafeCount
+	game.NodeEndpointDifferentRoots = differentRoots
 
 	// If all results were errors, return an error
 	if len(validResults) == 0 {
+		if isZKGame && outOfSyncCount == len(e.clients) {
+			return fmt.Errorf("all ZK super root sources are behind game L1 head %d: %w", game.L1HeadNum, gameTypes.ErrNotInSync)
+		}
+		if isZKGame {
+			return fmt.Errorf("failed to get ZK super root at timestamp: %w", ErrAllSuperRootRpcsUnavailable)
+		}
 		return fmt.Errorf("failed to get super root at timestamp: %w", ErrAllSuperRootRpcsUnavailable)
 	}
 
@@ -139,24 +202,39 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _
 	// - Different super roots from nodes that found data.
 	firstResult := foundResults[0]
 	diverged := len(foundResults) < len(validResults)
-	if !diverged {
+	if !diverged || isZKGame {
 		for _, result := range foundResults[1:] {
 			if result.superRoot != firstResult.superRoot {
 				diverged = true
-				game.NodeEndpointDifferentRoots = true
+				differentRoots = true
 				break
 			}
 		}
 	}
+	game.NodeEndpointDifferentRoots = differentRoots
 
 	if diverged {
-		e.log.Warn("Super nodes disagree on super root",
-			"l2SequenceNumber", game.L2SequenceNumber,
-			"firstSuperRoot", firstResult.superRoot,
-			"found", len(foundResults),
-			"valid", len(validResults))
+		if isZKGame {
+			e.log.Warn("ZK super root sources disagree",
+				"l2SequenceNumber", game.L2SequenceNumber,
+				"firstSuperRoot", firstResult.superRoot,
+				"found", len(foundResults),
+				"notFound", notFoundCount,
+				"differentRoots", differentRoots)
+		} else {
+			e.log.Warn("Super nodes disagree on super root",
+				"l2SequenceNumber", game.L2SequenceNumber,
+				"firstSuperRoot", firstResult.superRoot,
+				"found", len(foundResults),
+				"valid", len(validResults))
+		}
 		game.AgreeWithClaim = false
 		game.ExpectedRootClaim = firstResult.superRoot
+		return nil
+	}
+	if isZKGame {
+		game.ExpectedRootClaim = firstResult.superRoot
+		game.AgreeWithClaim = game.RootClaim == firstResult.superRoot
 		return nil
 	}
 

--- a/op-dispute-mon/mon/extract/super_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher.go
@@ -48,7 +48,9 @@ type superRootResult struct {
 }
 
 func (e *SuperAgreementEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _ GameCaller, game *monTypes.CommonGameData) error {
-	if game.UsesOutputRoots() || gameTypes.GameType(game.GameType) == gameTypes.ZKDisputeGameType {
+	switch gameTypes.GameType(game.GameType) {
+	case gameTypes.SuperPermissionedGameType, gameTypes.SuperCannonKonaGameType:
+	default:
 		return nil
 	}
 	if len(e.clients) == 0 {

--- a/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
@@ -26,7 +26,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		validator.clients = nil // Set to nil to test the error case
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,
@@ -38,8 +38,8 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		require.ErrorContains(t, err, "super root RPC required")
 	})
 
-	t.Run("SkipOutputRootGameTypes", func(t *testing.T) {
-		gameTypes := []uint32{0, 1, 2, 3, 6, 254, 255, 1337}
+	t.Run("SkipUnsupportedGameTypes", func(t *testing.T) {
+		gameTypes := []uint32{0, 1, 2, 3, 4, 6, 7, 8, 10, 11, 254, 255, 1337, 49812}
 		for _, gameType := range gameTypes {
 			gameType := gameType
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
@@ -61,8 +61,11 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		}
 	})
 
-	t.Run("FetchAllNonOutputRootGameTypes", func(t *testing.T) {
-		gameTypes := []uint32{4, 5, 7, 9, 11, 49812} // Treat unknown game types as using super roots
+	t.Run("FetchSupportedSuperRootGameTypes", func(t *testing.T) {
+		gameTypes := []uint32{
+			uint32(challengerTypes.SuperPermissionedGameType),
+			uint32(challengerTypes.SuperCannonKonaGameType),
+		}
 		for _, gameType := range gameTypes {
 			gameType := gameType
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
@@ -88,7 +91,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		rollup.outputErr = errors.New("boom")
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
@@ -107,7 +110,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		validator, _, metrics := setupSuperValidatorTest(t)
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
@@ -126,7 +129,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		client.derivedFromL1BlockNum = 200
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,
@@ -145,7 +148,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		client.derivedFromL1BlockNum = 199
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,
@@ -164,7 +167,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		client.derivedFromL1BlockNum = 101
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
@@ -183,7 +186,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		client.derivedFromL1BlockNum = 201
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   100,
@@ -202,7 +205,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		client.notFound = true
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          100,
 			L2SequenceNumber:   42984924,
@@ -223,7 +226,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		}
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
@@ -245,7 +248,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		}
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          100,
 			L2SequenceNumber:   0,
@@ -266,7 +269,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		clients[2].outputErr = nil
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,
@@ -288,7 +291,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		clients[2].superRoot = divergedRoot
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,
@@ -309,7 +312,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		clients[2].derivedFromL1BlockNum = 201
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,
@@ -333,7 +336,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		clients[3].derivedFromL1BlockNum = 150 // Safe because L1HeadNum is 200
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   50,
@@ -357,7 +360,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		clients[2].derivedFromL1BlockNum = 150
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   50,
@@ -381,7 +384,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   50,
@@ -406,7 +409,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   50,
@@ -481,7 +484,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999, // Super root game type
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,
@@ -509,7 +512,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,
@@ -540,7 +543,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,
@@ -570,7 +573,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,
@@ -595,7 +598,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,
@@ -617,7 +620,7 @@ func TestSuperRootEndpointTracking(t *testing.T) {
 
 		game := &types.CommonGameData{
 			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
+				GameType: uint32(challengerTypes.SuperPermissionedGameType),
 			},
 			L1HeadNum:          200,
 			L2SequenceNumber:   0,

--- a/op-dispute-mon/mon/extract/super_permissioned_integration_test.go
+++ b/op-dispute-mon/mon/extract/super_permissioned_integration_test.go
@@ -56,11 +56,13 @@ func TestExtractorChecksSuperPermissionedGame(t *testing.T) {
 		creator.CreateContract,
 		fetchGames,
 		nil,
+		nil,
 		1,
 		[]CommonEnricher{
 			NewL1HeadBlockNumEnricher(&stubBlockFetcher{num: l1HeadNum}),
 			NewSuperAgreementEnricher(logger, metrics, []SuperRootProvider{provider}, clock.NewDeterministicClock(time.Unix(9824924, 499))),
 		},
+		nil,
 		nil,
 	)
 

--- a/op-dispute-mon/mon/extract/zk_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/zk_agreement_enricher.go
@@ -1,0 +1,144 @@
+package extract
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// ZKAgreementEnricher reconciles a ZK proposal with configured super-root sources.
+type ZKAgreementEnricher struct {
+	log     log.Logger
+	metrics OutputMetrics
+	clients []SuperRootProvider
+	clock   clock.Clock
+}
+
+var _ ZKEnricher = (*ZKAgreementEnricher)(nil)
+
+func NewZKAgreementEnricher(logger log.Logger, metrics OutputMetrics, clients []SuperRootProvider, cl clock.Clock) *ZKAgreementEnricher {
+	return &ZKAgreementEnricher{
+		log:     logger,
+		metrics: metrics,
+		clients: clients,
+		clock:   cl,
+	}
+}
+
+type zkRootResult struct {
+	root      common.Hash
+	notFound  bool
+	outOfSync bool
+	err       error
+}
+
+func (e *ZKAgreementEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _ ZKGameCaller, zkGame *monTypes.ZKGameData) error {
+	game := zkGame.Common()
+	if len(e.clients) == 0 {
+		return fmt.Errorf("%w but required for game type %v", ErrSuperRootRpcRequired, game.GameType)
+	}
+
+	results := make([]zkRootResult, len(e.clients))
+	var wg sync.WaitGroup
+	for i, client := range e.clients {
+		wg.Add(1)
+		go func(i int, client SuperRootProvider) {
+			defer wg.Done()
+			response, err := client.SuperRootAtTimestamp(ctx, game.L2SequenceNumber)
+			if err != nil {
+				results[i] = zkRootResult{err: err}
+				return
+			}
+			// CurrentL1 is trusted as the provider's number-progress boundary. A provider must
+			// have processed beyond the proposal's L1 head before its answer is usable.
+			if response.CurrentL1.Number <= game.L1HeadNum {
+				results[i] = zkRootResult{outOfSync: true}
+				return
+			}
+			if response.Data == nil {
+				results[i] = zkRootResult{notFound: true}
+				return
+			}
+			results[i] = zkRootResult{root: common.Hash(response.Data.SuperRoot)}
+		}(i, client)
+	}
+	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	endpointErrors := make(map[string]bool)
+	usable := make([]zkRootResult, 0, len(results))
+	found := make([]zkRootResult, 0, len(results))
+	errorCount := 0
+	notFoundCount := 0
+	outOfSyncCount := 0
+	for idx, result := range results {
+		switch {
+		case result.err != nil:
+			e.log.Error("Failed to fetch ZK super root", "clientIndex", idx, "l2SequenceNumber", game.L2SequenceNumber, "err", result.err)
+			endpointErrors[fmt.Sprintf("client-%d", idx)] = true
+			errorCount++
+		case result.outOfSync:
+			outOfSyncCount++
+		default:
+			usable = append(usable, result)
+			if result.notFound {
+				notFoundCount++
+			} else {
+				found = append(found, result)
+			}
+		}
+	}
+
+	game.NodeEndpointTotalCount = len(e.clients)
+	game.NodeEndpointErrors = endpointErrors
+	game.NodeEndpointErrorCount = errorCount
+	game.NodeEndpointNotFoundCount = notFoundCount
+	game.NodeEndpointOutOfSyncCount = outOfSyncCount
+	game.NodeEndpointSafeCount = 0
+	game.NodeEndpointUnsafeCount = 0
+	game.NodeEndpointDifferentRoots = false
+
+	if len(usable) == 0 {
+		if outOfSyncCount == len(e.clients) {
+			return fmt.Errorf("all ZK super root sources are behind game L1 head %d: %w", game.L1HeadNum, gameTypes.ErrNotInSync)
+		}
+		return fmt.Errorf("failed to get ZK super root at timestamp: %w", ErrAllSuperRootRpcsUnavailable)
+	}
+	if len(found) == 0 {
+		game.AgreeWithClaim = false
+		game.ExpectedRootClaim = common.Hash{}
+		return nil
+	}
+
+	e.metrics.RecordOutputFetchTime(float64(e.clock.Now().Unix()))
+	firstRoot := found[0].root
+	game.ExpectedRootClaim = firstRoot
+	for _, result := range found[1:] {
+		if result.root != firstRoot {
+			game.NodeEndpointDifferentRoots = true
+			break
+		}
+	}
+	if game.NodeEndpointDifferentRoots || len(found) != len(usable) {
+		e.log.Warn("ZK super root sources disagree",
+			"l2SequenceNumber", game.L2SequenceNumber,
+			"firstSuperRoot", firstRoot,
+			"found", len(found),
+			"notFound", notFoundCount,
+			"differentRoots", game.NodeEndpointDifferentRoots)
+		game.AgreeWithClaim = false
+		return nil
+	}
+
+	game.AgreeWithClaim = game.RootClaim == firstRoot
+	return nil
+}

--- a/op-dispute-mon/mon/extract/zk_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/zk_agreement_enricher.go
@@ -2,143 +2,26 @@ package extract
 
 import (
 	"context"
-	"fmt"
-	"sync"
 
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
 
 // ZKAgreementEnricher reconciles a ZK proposal with configured super-root sources.
 type ZKAgreementEnricher struct {
-	log     log.Logger
-	metrics OutputMetrics
-	clients []SuperRootProvider
-	clock   clock.Clock
+	superAgreement SuperAgreementEnricher
 }
 
 var _ ZKEnricher = (*ZKAgreementEnricher)(nil)
 
 func NewZKAgreementEnricher(logger log.Logger, metrics OutputMetrics, clients []SuperRootProvider, cl clock.Clock) *ZKAgreementEnricher {
 	return &ZKAgreementEnricher{
-		log:     logger,
-		metrics: metrics,
-		clients: clients,
-		clock:   cl,
+		superAgreement: *NewSuperAgreementEnricher(logger, metrics, clients, cl),
 	}
-}
-
-type zkRootResult struct {
-	root      common.Hash
-	notFound  bool
-	outOfSync bool
-	err       error
 }
 
 func (e *ZKAgreementEnricher) Enrich(ctx context.Context, _ rpcblock.Block, _ ZKGameCaller, zkGame *monTypes.ZKGameData) error {
-	game := zkGame.Common()
-	if len(e.clients) == 0 {
-		return fmt.Errorf("%w but required for game type %v", ErrSuperRootRpcRequired, game.GameType)
-	}
-
-	results := make([]zkRootResult, len(e.clients))
-	var wg sync.WaitGroup
-	for i, client := range e.clients {
-		wg.Add(1)
-		go func(i int, client SuperRootProvider) {
-			defer wg.Done()
-			response, err := client.SuperRootAtTimestamp(ctx, game.L2SequenceNumber)
-			if err != nil {
-				results[i] = zkRootResult{err: err}
-				return
-			}
-			// CurrentL1 is trusted as the provider's number-progress boundary. A provider must
-			// have processed beyond the proposal's L1 head before its answer is usable.
-			if response.CurrentL1.Number <= game.L1HeadNum {
-				results[i] = zkRootResult{outOfSync: true}
-				return
-			}
-			if response.Data == nil {
-				results[i] = zkRootResult{notFound: true}
-				return
-			}
-			results[i] = zkRootResult{root: common.Hash(response.Data.SuperRoot)}
-		}(i, client)
-	}
-	wg.Wait()
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	endpointErrors := make(map[string]bool)
-	usable := make([]zkRootResult, 0, len(results))
-	found := make([]zkRootResult, 0, len(results))
-	errorCount := 0
-	notFoundCount := 0
-	outOfSyncCount := 0
-	for idx, result := range results {
-		switch {
-		case result.err != nil:
-			e.log.Error("Failed to fetch ZK super root", "clientIndex", idx, "l2SequenceNumber", game.L2SequenceNumber, "err", result.err)
-			endpointErrors[fmt.Sprintf("client-%d", idx)] = true
-			errorCount++
-		case result.outOfSync:
-			outOfSyncCount++
-		default:
-			usable = append(usable, result)
-			if result.notFound {
-				notFoundCount++
-			} else {
-				found = append(found, result)
-			}
-		}
-	}
-
-	game.NodeEndpointTotalCount = len(e.clients)
-	game.NodeEndpointErrors = endpointErrors
-	game.NodeEndpointErrorCount = errorCount
-	game.NodeEndpointNotFoundCount = notFoundCount
-	game.NodeEndpointOutOfSyncCount = outOfSyncCount
-	game.NodeEndpointSafeCount = 0
-	game.NodeEndpointUnsafeCount = 0
-	game.NodeEndpointDifferentRoots = false
-
-	if len(usable) == 0 {
-		if outOfSyncCount == len(e.clients) {
-			return fmt.Errorf("all ZK super root sources are behind game L1 head %d: %w", game.L1HeadNum, gameTypes.ErrNotInSync)
-		}
-		return fmt.Errorf("failed to get ZK super root at timestamp: %w", ErrAllSuperRootRpcsUnavailable)
-	}
-	if len(found) == 0 {
-		game.AgreeWithClaim = false
-		game.ExpectedRootClaim = common.Hash{}
-		return nil
-	}
-
-	e.metrics.RecordOutputFetchTime(float64(e.clock.Now().Unix()))
-	firstRoot := found[0].root
-	game.ExpectedRootClaim = firstRoot
-	for _, result := range found[1:] {
-		if result.root != firstRoot {
-			game.NodeEndpointDifferentRoots = true
-			break
-		}
-	}
-	if game.NodeEndpointDifferentRoots || len(found) != len(usable) {
-		e.log.Warn("ZK super root sources disagree",
-			"l2SequenceNumber", game.L2SequenceNumber,
-			"firstSuperRoot", firstRoot,
-			"found", len(found),
-			"notFound", notFoundCount,
-			"differentRoots", game.NodeEndpointDifferentRoots)
-		game.AgreeWithClaim = false
-		return nil
-	}
-
-	game.AgreeWithClaim = game.RootClaim == firstRoot
-	return nil
+	return e.superAgreement.enrich(ctx, zkGame.Common(), zkGameAgreement)
 }

--- a/op-dispute-mon/mon/extract/zk_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/zk_agreement_enricher_test.go
@@ -35,6 +35,7 @@ func TestZKAgreementPolicy(t *testing.T) {
 		fetchRecorded     bool
 	}{
 		{name: "matching root", providers: []SuperRootProvider{zkFound(101, root)}, claim: root, agree: true, expected: root, fetchRecorded: true},
+		{name: "verified L1 does not gate ZK", providers: []SuperRootProvider{zkFoundWithRequiredL1(101, 101, root)}, claim: root, agree: true, expected: root, fetchRecorded: true},
 		{name: "mismatching root", providers: []SuperRootProvider{zkFound(101, root)}, claim: otherRoot, expected: root, fetchRecorded: true},
 		{name: "all behind", providers: []SuperRootProvider{zkFound(100, root), zkFound(99, otherRoot)}, wantErr: gameTypes.ErrNotInSync, outOfSync: 2},
 		{name: "all errors", providers: []SuperRootProvider{zkError(errors.New("first")), zkError(errors.New("second"))}, wantErr: ErrAllSuperRootRpcsUnavailable, errors: 2},
@@ -44,6 +45,7 @@ func TestZKAgreementPolicy(t *testing.T) {
 		{name: "all not found", providers: []SuperRootProvider{zkNotFound(101), zkNotFound(102)}, notFound: 2},
 		{name: "found and not found", providers: []SuperRootProvider{zkFound(101, root), zkNotFound(101)}, claim: root, expected: root, notFound: 1, mixedAvailability: true, fetchRecorded: true},
 		{name: "conflicting roots use first provider", providers: []SuperRootProvider{zkFound(101, root), zkFound(101, otherRoot)}, claim: root, expected: root, differentRoots: true, fetchRecorded: true},
+		{name: "conflicting roots and not found", providers: []SuperRootProvider{zkFound(101, root), zkFound(101, otherRoot), zkNotFound(101)}, claim: root, expected: root, notFound: 1, differentRoots: true, mixedAvailability: true, fetchRecorded: true},
 	}
 
 	for _, test := range tests {
@@ -98,6 +100,37 @@ func TestZKAgreementCancellationPreventsMutation(t *testing.T) {
 	require.Zero(t, metricer.fetchTime)
 }
 
+func TestZKAgreementReplacesEndpointTracking(t *testing.T) {
+	root := common.Hash{0xaa}
+	enricher := NewZKAgreementEnricher(
+		testlog.Logger(t, log.LvlDebug),
+		&stubOutputMetrics{},
+		[]SuperRootProvider{zkFound(101, root)},
+		clock.NewDeterministicClock(time.Unix(1234, 0)),
+	)
+	game := newZKAgreementGame(root)
+	game.NodeEndpointErrors = map[string]bool{"stale": true}
+	game.NodeEndpointErrorCount = 1
+	game.NodeEndpointNotFoundCount = 2
+	game.NodeEndpointOutOfSyncCount = 3
+	game.NodeEndpointTotalCount = 4
+	game.NodeEndpointSafeCount = 5
+	game.NodeEndpointUnsafeCount = 6
+	game.NodeEndpointDifferentRoots = true
+
+	require.NoError(t, enricher.Enrich(t.Context(), rpcblock.Latest, nil, game))
+	require.True(t, game.AgreeWithClaim)
+	require.Equal(t, root, game.ExpectedRootClaim)
+	require.Empty(t, game.NodeEndpointErrors)
+	require.Zero(t, game.NodeEndpointErrorCount)
+	require.Zero(t, game.NodeEndpointNotFoundCount)
+	require.Zero(t, game.NodeEndpointOutOfSyncCount)
+	require.Equal(t, 1, game.NodeEndpointTotalCount)
+	require.Zero(t, game.NodeEndpointSafeCount)
+	require.Zero(t, game.NodeEndpointUnsafeCount)
+	require.False(t, game.NodeEndpointDifferentRoots)
+}
+
 func TestZKAgreementRequiresProvider(t *testing.T) {
 	enricher := NewZKAgreementEnricher(
 		testlog.Logger(t, log.LvlDebug),
@@ -106,6 +139,9 @@ func TestZKAgreementRequiresProvider(t *testing.T) {
 		clock.NewDeterministicClock(time.Unix(1234, 0)),
 	)
 	require.ErrorIs(t, enricher.Enrich(t.Context(), rpcblock.Latest, nil, newZKAgreementGame(common.Hash{})), ErrSuperRootRpcRequired)
+
+	var zeroValue ZKAgreementEnricher
+	require.ErrorIs(t, zeroValue.Enrich(t.Context(), rpcblock.Latest, nil, newZKAgreementGame(common.Hash{})), ErrSuperRootRpcRequired)
 }
 
 func newZKAgreementGame(claim common.Hash) *monTypes.ZKGameData {
@@ -141,6 +177,12 @@ func zkResponse(currentL1 uint64, root *common.Hash) eth.SuperRootAtTimestampRes
 
 func zkFound(currentL1 uint64, root common.Hash) SuperRootProvider {
 	return zkSuperRootProvider{response: zkResponse(currentL1, &root)}
+}
+
+func zkFoundWithRequiredL1(currentL1, requiredL1 uint64, root common.Hash) SuperRootProvider {
+	response := zkResponse(currentL1, &root)
+	response.Data.VerifiedRequiredL1 = eth.BlockID{Number: requiredL1}
+	return zkSuperRootProvider{response: response}
 }
 
 func zkNotFound(currentL1 uint64) SuperRootProvider {

--- a/op-dispute-mon/mon/extract/zk_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/zk_agreement_enricher_test.go
@@ -1,0 +1,152 @@
+package extract
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZKAgreementPolicy(t *testing.T) {
+	root := common.Hash{0xaa}
+	otherRoot := common.Hash{0xbb}
+	tests := []struct {
+		name              string
+		providers         []SuperRootProvider
+		claim             common.Hash
+		wantErr           error
+		agree             bool
+		expected          common.Hash
+		errors            int
+		notFound          int
+		outOfSync         int
+		differentRoots    bool
+		mixedAvailability bool
+		fetchRecorded     bool
+	}{
+		{name: "matching root", providers: []SuperRootProvider{zkFound(101, root)}, claim: root, agree: true, expected: root, fetchRecorded: true},
+		{name: "mismatching root", providers: []SuperRootProvider{zkFound(101, root)}, claim: otherRoot, expected: root, fetchRecorded: true},
+		{name: "all behind", providers: []SuperRootProvider{zkFound(100, root), zkFound(99, otherRoot)}, wantErr: gameTypes.ErrNotInSync, outOfSync: 2},
+		{name: "all errors", providers: []SuperRootProvider{zkError(errors.New("first")), zkError(errors.New("second"))}, wantErr: ErrAllSuperRootRpcsUnavailable, errors: 2},
+		{name: "behind and error", providers: []SuperRootProvider{zkFound(100, root), zkError(errors.New("boom"))}, wantErr: ErrAllSuperRootRpcsUnavailable, errors: 1, outOfSync: 1},
+		{name: "usable and error", providers: []SuperRootProvider{zkError(errors.New("boom")), zkFound(101, root)}, claim: root, agree: true, expected: root, errors: 1, fetchRecorded: true},
+		{name: "usable and behind", providers: []SuperRootProvider{zkFound(100, otherRoot), zkFound(101, root)}, claim: root, agree: true, expected: root, outOfSync: 1, fetchRecorded: true},
+		{name: "all not found", providers: []SuperRootProvider{zkNotFound(101), zkNotFound(102)}, notFound: 2},
+		{name: "found and not found", providers: []SuperRootProvider{zkFound(101, root), zkNotFound(101)}, claim: root, expected: root, notFound: 1, mixedAvailability: true, fetchRecorded: true},
+		{name: "conflicting roots use first provider", providers: []SuperRootProvider{zkFound(101, root), zkFound(101, otherRoot)}, claim: root, expected: root, differentRoots: true, fetchRecorded: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metricer := &stubOutputMetrics{}
+			enricher := NewZKAgreementEnricher(
+				testlog.Logger(t, log.LvlDebug),
+				metricer,
+				test.providers,
+				clock.NewDeterministicClock(time.Unix(1234, 0)),
+			)
+			game := newZKAgreementGame(test.claim)
+
+			err := enricher.Enrich(t.Context(), rpcblock.Latest, nil, game)
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.agree, game.AgreeWithClaim)
+			require.Equal(t, test.expected, game.ExpectedRootClaim)
+			require.Equal(t, len(test.providers), game.NodeEndpointTotalCount)
+			require.Equal(t, test.errors, game.NodeEndpointErrorCount)
+			require.Len(t, game.NodeEndpointErrors, test.errors)
+			require.Equal(t, test.notFound, game.NodeEndpointNotFoundCount)
+			require.Equal(t, test.outOfSync, game.NodeEndpointOutOfSyncCount)
+			require.Equal(t, test.differentRoots, game.NodeEndpointDifferentRoots)
+			require.Equal(t, test.mixedAvailability, game.HasMixedAvailability())
+			require.Zero(t, game.NodeEndpointSafeCount)
+			require.Zero(t, game.NodeEndpointUnsafeCount)
+			require.Equal(t, test.fetchRecorded, metricer.fetchTime != 0)
+		})
+	}
+}
+
+func TestZKAgreementCancellationPreventsMutation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	root := common.Hash{0xaa}
+	provider := zkSuperRootProvider{response: zkResponse(101, &root), action: cancel}
+	metricer := &stubOutputMetrics{}
+	enricher := NewZKAgreementEnricher(
+		testlog.Logger(t, log.LvlDebug),
+		metricer,
+		[]SuperRootProvider{provider},
+		clock.NewDeterministicClock(time.Unix(1234, 0)),
+	)
+	game := newZKAgreementGame(root)
+
+	require.ErrorIs(t, enricher.Enrich(ctx, rpcblock.Latest, nil, game), context.Canceled)
+	require.Zero(t, game.NodeEndpointTotalCount)
+	require.Empty(t, game.NodeEndpointErrors)
+	require.Zero(t, metricer.fetchTime)
+}
+
+func TestZKAgreementRequiresProvider(t *testing.T) {
+	enricher := NewZKAgreementEnricher(
+		testlog.Logger(t, log.LvlDebug),
+		&stubOutputMetrics{},
+		nil,
+		clock.NewDeterministicClock(time.Unix(1234, 0)),
+	)
+	require.ErrorIs(t, enricher.Enrich(t.Context(), rpcblock.Latest, nil, newZKAgreementGame(common.Hash{})), ErrSuperRootRpcRequired)
+}
+
+func newZKAgreementGame(claim common.Hash) *monTypes.ZKGameData {
+	return &monTypes.ZKGameData{CommonGameData: monTypes.CommonGameData{
+		GameMetadata:       gameTypes.GameMetadata{GameType: uint32(gameTypes.ZKDisputeGameType)},
+		L1HeadNum:          100,
+		L2SequenceNumber:   44,
+		RootClaim:          claim,
+		NodeEndpointErrors: make(map[string]bool),
+	}}
+}
+
+type zkSuperRootProvider struct {
+	response eth.SuperRootAtTimestampResponse
+	err      error
+	action   func()
+}
+
+func (p zkSuperRootProvider) SuperRootAtTimestamp(context.Context, uint64) (eth.SuperRootAtTimestampResponse, error) {
+	if p.action != nil {
+		p.action()
+	}
+	return p.response, p.err
+}
+
+func zkResponse(currentL1 uint64, root *common.Hash) eth.SuperRootAtTimestampResponse {
+	response := eth.SuperRootAtTimestampResponse{CurrentL1: eth.BlockID{Number: currentL1}}
+	if root != nil {
+		response.Data = &eth.SuperRootResponseData{SuperRoot: eth.Bytes32(*root)}
+	}
+	return response
+}
+
+func zkFound(currentL1 uint64, root common.Hash) SuperRootProvider {
+	return zkSuperRootProvider{response: zkResponse(currentL1, &root)}
+}
+
+func zkNotFound(currentL1 uint64) SuperRootProvider {
+	return zkSuperRootProvider{response: zkResponse(currentL1, nil)}
+}
+
+func zkError(err error) SuperRootProvider {
+	return zkSuperRootProvider{err: err}
+}

--- a/op-dispute-mon/mon/extract/zk_extractor_test.go
+++ b/op-dispute-mon/mon/extract/zk_extractor_test.go
@@ -1,0 +1,377 @@
+package extract
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractorZKSnapshotValidation(t *testing.T) {
+	t.Run("root game", func(t *testing.T) {
+		caller := validZKCaller()
+		extractor, trace := newZKExtractor(t, caller, parentStatus(gameTypes.GameStatusDefenderWon), &testZKAgreement{})
+		blockHash := common.Hash{0xaa}
+
+		game, err := extractor.enrichGame(t.Context(), blockHash, zkMetadata())
+		require.NoError(t, err)
+		zk := game.(*monTypes.ZKGameData)
+		require.Equal(t, caller.metadata.L1Head, zk.L1Head)
+		require.Equal(t, uint64(100), zk.L1HeadNum)
+		require.Equal(t, caller.metadata.L2SequenceNum, zk.L2SequenceNumber)
+		require.Equal(t, caller.challenger.Deadline, zk.Deadline)
+		require.Equal(t, caller.anchorStateRegistry, zk.AnchorStateRegistry)
+		require.Equal(t, uint32(math.MaxUint32), zk.ParentIndex)
+		require.Nil(t, zk.ParentStatus)
+		require.Equal(t, []string{"metadata", "l1-head", "agreement", "challenger", "anchor"}, *trace)
+		require.Equal(t, []rpcblock.Block{
+			rpcblock.ByHash(blockHash), rpcblock.ByHash(blockHash), rpcblock.ByHash(blockHash),
+		}, caller.blocks)
+	})
+
+	t.Run("child game pins parent lookup", func(t *testing.T) {
+		caller := validZKCaller()
+		caller.challenger.ParentIndex = 0
+		var requestedIndex uint64
+		var requestedBlock rpcblock.Block
+		extractor, trace := newZKExtractor(t, caller, func(_ context.Context, index uint64, block rpcblock.Block) (gameTypes.GameStatus, error) {
+			requestedIndex = index
+			requestedBlock = block
+			return gameTypes.GameStatusDefenderWon, nil
+		}, &testZKAgreement{})
+		blockHash := common.Hash{0xbb}
+
+		game, err := extractor.enrichGame(t.Context(), blockHash, zkMetadata())
+		require.NoError(t, err)
+		zk := game.(*monTypes.ZKGameData)
+		require.Equal(t, gameTypes.GameStatusDefenderWon, *zk.ParentStatus)
+		require.Zero(t, requestedIndex)
+		require.Equal(t, rpcblock.ByHash(blockHash), requestedBlock)
+		require.Equal(t, []string{"metadata", "l1-head", "agreement", "challenger", "anchor", "parent"}, *trace)
+	})
+
+	tests := []struct {
+		name      string
+		configure func(*testZKCaller)
+		parent    ParentGameStatusFetcher
+		wantErr   string
+	}{
+		{name: "root mismatch", configure: func(c *testZKCaller) { c.challenger.ProposedRoot = common.Hash{0xee} }, wantErr: "inconsistent ZK root claim"},
+		{name: "sequence mismatch", configure: func(c *testZKCaller) { c.challenger.L2SequenceNumber++ }, wantErr: "inconsistent ZK sequence number"},
+		{name: "unknown proposal status", configure: func(c *testZKCaller) { c.challenger.ProposalStatus = contracts.ProposalStatus(255) }, wantErr: "invalid proposal status"},
+		{name: "resolved proposal with live global status", configure: func(c *testZKCaller) { c.challenger.ProposalStatus = contracts.ProposalStatusResolved }, wantErr: "inconsistent ZK global status"},
+		{name: "live proposal with terminal global status", configure: func(c *testZKCaller) { c.metadata.Status = gameTypes.GameStatusDefenderWon }, wantErr: "inconsistent ZK global status"},
+		{name: "invalid participants", configure: func(c *testZKCaller) { c.challenger.Challenger = common.Address{0x01} }, wantErr: "invalid ZK participants"},
+		{name: "anchor read", configure: func(c *testZKCaller) { c.anchorErr = errors.New("anchor unavailable") }, wantErr: "failed to fetch ZK anchor state registry"},
+		{name: "zero anchor", configure: func(c *testZKCaller) { c.anchorStateRegistry = common.Address{} }, wantErr: "anchor state registry is zero"},
+		{
+			name: "parent read",
+			configure: func(c *testZKCaller) {
+				c.challenger.ParentIndex = 7
+			},
+			parent: func(context.Context, uint64, rpcblock.Block) (gameTypes.GameStatus, error) {
+				return 0, errors.New("parent unavailable")
+			},
+			wantErr: "failed to fetch ZK parent game 7 status",
+		},
+		{
+			name: "terminal child with live parent",
+			configure: func(c *testZKCaller) {
+				c.metadata.Status = gameTypes.GameStatusDefenderWon
+				c.challenger.ProposalStatus = contracts.ProposalStatusResolved
+				c.challenger.ParentIndex = 7
+			},
+			parent:  parentStatus(gameTypes.GameStatusInProgress),
+			wantErr: "terminal ZK child has in-progress parent 7",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			caller := validZKCaller()
+			test.configure(caller)
+			parent := test.parent
+			if parent == nil {
+				parent = parentStatus(gameTypes.GameStatusDefenderWon)
+			}
+			extractor, _ := newZKExtractor(t, caller, parent, &testZKAgreement{})
+
+			game, err := extractor.enrichGame(t.Context(), common.Hash{0xaa}, zkMetadata())
+			require.Nil(t, game)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestExtractorRejectsZKCallerWithoutCapabilities(t *testing.T) {
+	caller := &anchorOnlyCaller{}
+	extractor := NewExtractor(
+		testlog.Logger(t, log.LvlDebug),
+		clock.NewDeterministicClock(time.Unix(1234, 0)),
+		func(context.Context, gameTypes.GameMetadata) (GameCaller, error) { return caller, nil },
+		func(context.Context, common.Hash, uint64) ([]gameTypes.GameMetadata, error) { return nil, nil },
+		parentStatus(gameTypes.GameStatusDefenderWon),
+		nil,
+		1,
+		nil,
+		nil,
+		&testZKAgreement{},
+	)
+
+	game, err := extractor.enrichGame(t.Context(), common.Hash{0xaa}, zkMetadata())
+	require.Nil(t, game)
+	require.ErrorContains(t, err, "does not support ZK game extraction")
+}
+
+func TestCommonEnrichersSkipZKOwnedReads(t *testing.T) {
+	caller := &anchorOnlyCaller{}
+	game := &monTypes.CommonGameData{GameMetadata: gameTypes.GameMetadata{GameType: uint32(gameTypes.ZKDisputeGameType)}}
+	logger := testlog.Logger(t, log.LvlDebug)
+
+	require.NoError(t, NewAnchorStateRegistryEnricher(logger).Enrich(t.Context(), rpcblock.Latest, caller, game))
+	require.Zero(t, caller.calls)
+	require.NoError(t, NewSuperAgreementEnricher(logger, &stubOutputMetrics{}, nil, clock.SystemClock).Enrich(t.Context(), rpcblock.Latest, caller, game))
+}
+
+func TestExtractorZKLagAndCache(t *testing.T) {
+	caller := validZKCaller()
+	agreement := &testZKAgreement{err: gameTypes.ErrNotInSync}
+	extractor, trace := newZKExtractor(t, caller, parentStatus(gameTypes.GameStatusDefenderWon), agreement)
+
+	games, ignored, failed, err := extractor.Extract(t.Context(), common.Hash{0xaa}, 0)
+	require.NoError(t, err)
+	require.Empty(t, games)
+	require.Zero(t, ignored)
+	require.Zero(t, failed)
+	require.Equal(t, []string{"metadata", "l1-head", "agreement"}, *trace)
+
+	*trace = nil
+	agreement.err = nil
+	agreement.action = func(game *monTypes.ZKGameData) {
+		game.AgreeWithClaim = true
+		game.ExpectedRootClaim = game.RootClaim
+	}
+	games, _, failed, err = extractor.Extract(t.Context(), common.Hash{0xbb}, 0)
+	require.NoError(t, err)
+	require.Zero(t, failed)
+	require.Len(t, games, 1)
+	snapshot := games[0]
+	original := snapshot.(*monTypes.ZKGameData)
+	originalExpectedRoot := original.ExpectedRootClaim
+
+	*trace = nil
+	agreement.action = func(game *monTypes.ZKGameData) {
+		game.AgreeWithClaim = false
+		game.ExpectedRootClaim = common.Hash{0xff}
+		game.NodeEndpointOutOfSyncCount = 3
+	}
+	caller.anchorErr = errors.New("anchor unavailable")
+	games, _, failed, err = extractor.Extract(t.Context(), common.Hash{0xbc}, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, failed)
+	require.Same(t, snapshot, games[0])
+	require.True(t, original.AgreeWithClaim)
+	require.Equal(t, originalExpectedRoot, original.ExpectedRootClaim)
+	require.Zero(t, original.NodeEndpointOutOfSyncCount)
+	require.Equal(t, []string{"metadata", "l1-head", "agreement", "challenger", "anchor"}, *trace)
+	caller.anchorErr = nil
+
+	*trace = nil
+	agreement.err = gameTypes.ErrNotInSync
+	games, _, failed, err = extractor.Extract(t.Context(), common.Hash{0xcc}, 0)
+	require.NoError(t, err)
+	require.Zero(t, failed)
+	require.Equal(t, []monTypes.EnrichedGame{snapshot}, games)
+	require.Equal(t, []string{"metadata", "l1-head", "agreement"}, *trace)
+
+	*trace = nil
+	agreement.err = errors.New("root source unavailable")
+	games, _, failed, err = extractor.Extract(t.Context(), common.Hash{0xdd}, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, failed)
+	require.Equal(t, []monTypes.EnrichedGame{snapshot}, games)
+	require.Same(t, snapshot, games[0])
+}
+
+func TestValidateZKStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		global   gameTypes.GameStatus
+		proposal contracts.ProposalStatus
+		valid    bool
+	}{
+		{name: "unchallenged live", global: gameTypes.GameStatusInProgress, proposal: contracts.ProposalStatusUnchallenged, valid: true},
+		{name: "challenged live", global: gameTypes.GameStatusInProgress, proposal: contracts.ProposalStatusChallenged, valid: true},
+		{name: "unchallenged proof live", global: gameTypes.GameStatusInProgress, proposal: contracts.ProposalStatusUnchallengedAndValidProofProvided, valid: true},
+		{name: "challenged proof live", global: gameTypes.GameStatusInProgress, proposal: contracts.ProposalStatusChallengedAndValidProofProvided, valid: true},
+		{name: "resolved defender", global: gameTypes.GameStatusDefenderWon, proposal: contracts.ProposalStatusResolved, valid: true},
+		{name: "resolved challenger", global: gameTypes.GameStatusChallengerWon, proposal: contracts.ProposalStatusResolved, valid: true},
+		{name: "resolved live", global: gameTypes.GameStatusInProgress, proposal: contracts.ProposalStatusResolved},
+		{name: "unresolved terminal", global: gameTypes.GameStatusDefenderWon, proposal: contracts.ProposalStatusUnchallenged},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateZKStatus(test.global, test.proposal)
+			require.Equal(t, test.valid, err == nil)
+		})
+	}
+}
+
+func TestValidateZKParticipants(t *testing.T) {
+	a := common.Address{0x01}
+	tests := []struct {
+		name       string
+		status     contracts.ProposalStatus
+		challenger common.Address
+		prover     common.Address
+		valid      bool
+	}{
+		{name: "unchallenged", status: contracts.ProposalStatusUnchallenged, valid: true},
+		{name: "challenged", status: contracts.ProposalStatusChallenged, challenger: a, valid: true},
+		{name: "unchallenged proof", status: contracts.ProposalStatusUnchallengedAndValidProofProvided, prover: a, valid: true},
+		{name: "challenged proof", status: contracts.ProposalStatusChallengedAndValidProofProvided, challenger: a, prover: a, valid: true},
+		{name: "resolved empty", status: contracts.ProposalStatusResolved, valid: true},
+		{name: "resolved challenged", status: contracts.ProposalStatusResolved, challenger: a, valid: true},
+		{name: "resolved proved", status: contracts.ProposalStatusResolved, prover: a, valid: true},
+		{name: "resolved challenged and proved", status: contracts.ProposalStatusResolved, challenger: a, prover: a, valid: true},
+		{name: "unchallenged with challenger", status: contracts.ProposalStatusUnchallenged, challenger: a},
+		{name: "challenged without challenger", status: contracts.ProposalStatusChallenged},
+		{name: "challenged with prover", status: contracts.ProposalStatusChallenged, challenger: a, prover: a},
+		{name: "unchallenged proof without prover", status: contracts.ProposalStatusUnchallengedAndValidProofProvided},
+		{name: "unchallenged proof with challenger", status: contracts.ProposalStatusUnchallengedAndValidProofProvided, challenger: a, prover: a},
+		{name: "challenged proof without challenger", status: contracts.ProposalStatusChallengedAndValidProofProvided, prover: a},
+		{name: "challenged proof without prover", status: contracts.ProposalStatusChallengedAndValidProofProvided, challenger: a},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateZKParticipants(test.status, test.challenger, test.prover)
+			require.Equal(t, test.valid, err == nil)
+		})
+	}
+}
+
+type testZKCaller struct {
+	metadata            contracts.GenericGameMetadata
+	challenger          contracts.ChallengerMetadata
+	anchorStateRegistry common.Address
+	anchorErr           error
+	trace               *[]string
+	blocks              []rpcblock.Block
+}
+
+func validZKCaller() *testZKCaller {
+	return &testZKCaller{
+		metadata: contracts.GenericGameMetadata{
+			L1Head:        common.Hash{0x11},
+			L2SequenceNum: 99,
+			ProposedRoot:  common.Hash{0x22},
+			Status:        gameTypes.GameStatusInProgress,
+		},
+		challenger: contracts.ChallengerMetadata{
+			ParentIndex:      math.MaxUint32,
+			ProposalStatus:   contracts.ProposalStatusUnchallenged,
+			ProposedRoot:     common.Hash{0x22},
+			L2SequenceNumber: 99,
+			Deadline:         time.Unix(5678, 0),
+		},
+		anchorStateRegistry: common.Address{0xab},
+	}
+}
+
+func (c *testZKCaller) GetMetadata(_ context.Context, block rpcblock.Block) (contracts.GenericGameMetadata, error) {
+	*c.trace = append(*c.trace, "metadata")
+	c.blocks = append(c.blocks, block)
+	return c.metadata, nil
+}
+
+func (c *testZKCaller) GetChallengerMetadata(_ context.Context, block rpcblock.Block) (contracts.ChallengerMetadata, error) {
+	*c.trace = append(*c.trace, "challenger")
+	c.blocks = append(c.blocks, block)
+	return c.challenger, nil
+}
+
+func (c *testZKCaller) GetAnchorStateRegistry(_ context.Context, block rpcblock.Block) (common.Address, error) {
+	*c.trace = append(*c.trace, "anchor")
+	c.blocks = append(c.blocks, block)
+	return c.anchorStateRegistry, c.anchorErr
+}
+
+type testZKAgreement struct {
+	trace  *[]string
+	err    error
+	action func(*monTypes.ZKGameData)
+}
+
+func (e *testZKAgreement) Enrich(_ context.Context, _ rpcblock.Block, _ ZKGameCaller, game *monTypes.ZKGameData) error {
+	*e.trace = append(*e.trace, "agreement")
+	if e.err != nil {
+		return e.err
+	}
+	if e.action != nil {
+		e.action(game)
+	}
+	return nil
+}
+
+type testCommonEnricher struct {
+	trace *[]string
+}
+
+func (e *testCommonEnricher) Enrich(_ context.Context, _ rpcblock.Block, _ GameCaller, game *monTypes.CommonGameData) error {
+	*e.trace = append(*e.trace, "l1-head")
+	game.L1HeadNum = 100
+	return nil
+}
+
+type anchorOnlyCaller struct {
+	calls int
+}
+
+func (c *anchorOnlyCaller) GetAnchorStateRegistry(context.Context, rpcblock.Block) (common.Address, error) {
+	c.calls++
+	return common.Address{0xab}, nil
+}
+
+func newZKExtractor(t *testing.T, caller *testZKCaller, parent ParentGameStatusFetcher, agreement *testZKAgreement) (*Extractor, *[]string) {
+	t.Helper()
+	trace := new([]string)
+	caller.trace = trace
+	agreement.trace = trace
+	tracedParent := func(ctx context.Context, index uint64, block rpcblock.Block) (gameTypes.GameStatus, error) {
+		*trace = append(*trace, "parent")
+		return parent(ctx, index, block)
+	}
+	return NewExtractor(
+		testlog.Logger(t, log.LvlDebug),
+		clock.NewDeterministicClock(time.Unix(1234, 0)),
+		func(context.Context, gameTypes.GameMetadata) (GameCaller, error) { return caller, nil },
+		func(context.Context, common.Hash, uint64) ([]gameTypes.GameMetadata, error) {
+			return []gameTypes.GameMetadata{zkMetadata()}, nil
+		},
+		tracedParent,
+		nil,
+		1,
+		[]CommonEnricher{&testCommonEnricher{trace: trace}},
+		nil,
+		agreement,
+	), trace
+}
+
+func zkMetadata() gameTypes.GameMetadata {
+	return gameTypes.GameMetadata{Index: 9, GameType: uint32(gameTypes.ZKDisputeGameType), Proxy: common.Address{0x99}, Timestamp: 123}
+}
+
+func parentStatus(status gameTypes.GameStatus) ParentGameStatusFetcher {
+	return func(context.Context, uint64, rpcblock.Block) (gameTypes.GameStatus, error) { return status, nil }
+}

--- a/op-dispute-mon/mon/extract/zk_extractor_test.go
+++ b/op-dispute-mon/mon/extract/zk_extractor_test.go
@@ -192,7 +192,10 @@ func TestExtractorZKLagAndCache(t *testing.T) {
 	games, _, failed, err = extractor.Extract(t.Context(), common.Hash{0xcc}, 0)
 	require.NoError(t, err)
 	require.Zero(t, failed)
-	require.Equal(t, []monTypes.EnrichedGame{snapshot}, games)
+	require.Len(t, games, 1)
+	lagSnapshot := games[0]
+	require.NotSame(t, snapshot, lagSnapshot)
+	require.Equal(t, snapshot, lagSnapshot)
 	require.Equal(t, []string{"metadata", "l1-head", "agreement"}, *trace)
 
 	*trace = nil
@@ -200,8 +203,80 @@ func TestExtractorZKLagAndCache(t *testing.T) {
 	games, _, failed, err = extractor.Extract(t.Context(), common.Hash{0xdd}, 0)
 	require.NoError(t, err)
 	require.Equal(t, 1, failed)
-	require.Equal(t, []monTypes.EnrichedGame{snapshot}, games)
-	require.Same(t, snapshot, games[0])
+	require.Equal(t, []monTypes.EnrichedGame{lagSnapshot}, games)
+	require.Same(t, lagSnapshot, games[0])
+}
+
+func TestExtractorZKLagPublishesCurrentEndpointHealthFromCachedSnapshot(t *testing.T) {
+	caller := validZKCaller()
+	root := caller.metadata.ProposedRoot
+	provider := &zkSuperRootProvider{response: zkResponse(101, &root)}
+	agreement := NewZKAgreementEnricher(
+		testlog.Logger(t, log.LvlDebug),
+		&stubOutputMetrics{},
+		[]SuperRootProvider{provider},
+		clock.NewDeterministicClock(time.Unix(1234, 0)),
+	)
+	extractor, _ := newZKExtractor(t, caller, parentStatus(gameTypes.GameStatusDefenderWon), agreement)
+
+	games, ignored, failed, err := extractor.Extract(t.Context(), common.Hash{0xaa}, 0)
+	require.NoError(t, err)
+	require.Zero(t, ignored)
+	require.Zero(t, failed)
+	require.Len(t, games, 1)
+	cached := games[0].(*monTypes.ZKGameData)
+	require.True(t, cached.AgreeWithClaim)
+	require.Equal(t, root, cached.ExpectedRootClaim)
+	require.Equal(t, 1, cached.NodeEndpointTotalCount)
+	require.Zero(t, cached.NodeEndpointOutOfSyncCount)
+	cached.NodeEndpointErrors = map[string]bool{"stale": true}
+	cached.NodeEndpointErrorCount = 2
+	cached.NodeEndpointNotFoundCount = 3
+	cached.NodeEndpointOutOfSyncCount = 4
+	cached.NodeEndpointTotalCount = 5
+	cached.NodeEndpointSafeCount = 6
+	cached.NodeEndpointUnsafeCount = 7
+	cached.NodeEndpointDifferentRoots = true
+	cachedUpdateTime := cached.LastUpdateTime
+	extractor.clock.(*clock.DeterministicClock).AdvanceTime(time.Minute)
+	require.NotEqual(t, cachedUpdateTime, extractor.clock.Now())
+
+	expected := *cached
+	expected.NodeEndpointErrors = make(map[string]bool)
+	expected.NodeEndpointErrorCount = 0
+	expected.NodeEndpointNotFoundCount = 0
+	expected.NodeEndpointOutOfSyncCount = 1
+	expected.NodeEndpointTotalCount = 1
+	expected.NodeEndpointSafeCount = 0
+	expected.NodeEndpointUnsafeCount = 0
+	expected.NodeEndpointDifferentRoots = false
+
+	provider.response = zkResponse(100, &root)
+	games, ignored, failed, err = extractor.Extract(t.Context(), common.Hash{0xbb}, 0)
+	require.NoError(t, err)
+	require.Zero(t, ignored)
+	require.Zero(t, failed)
+	require.Len(t, games, 1)
+	current := games[0].(*monTypes.ZKGameData)
+	require.NotSame(t, cached, current)
+	require.Equal(t, &expected, current)
+	require.Equal(t, cachedUpdateTime, current.LastUpdateTime)
+	require.Equal(t, 1, current.NodeEndpointTotalCount)
+	require.Zero(t, current.NodeEndpointErrorCount)
+	require.Empty(t, current.NodeEndpointErrors)
+	require.Zero(t, current.NodeEndpointNotFoundCount)
+	require.Equal(t, 1, current.NodeEndpointOutOfSyncCount)
+	require.Zero(t, current.NodeEndpointSafeCount)
+	require.Zero(t, current.NodeEndpointUnsafeCount)
+	require.False(t, current.NodeEndpointDifferentRoots)
+	require.Equal(t, map[string]bool{"stale": true}, cached.NodeEndpointErrors)
+	require.Equal(t, 2, cached.NodeEndpointErrorCount)
+	require.Equal(t, 3, cached.NodeEndpointNotFoundCount)
+	require.Equal(t, 4, cached.NodeEndpointOutOfSyncCount)
+	require.Equal(t, 5, cached.NodeEndpointTotalCount)
+	require.Equal(t, 6, cached.NodeEndpointSafeCount)
+	require.Equal(t, 7, cached.NodeEndpointUnsafeCount)
+	require.True(t, cached.NodeEndpointDifferentRoots)
 }
 
 func TestValidateZKStatus(t *testing.T) {
@@ -343,11 +418,13 @@ func (c *anchorOnlyCaller) GetAnchorStateRegistry(context.Context, rpcblock.Bloc
 	return common.Address{0xab}, nil
 }
 
-func newZKExtractor(t *testing.T, caller *testZKCaller, parent ParentGameStatusFetcher, agreement *testZKAgreement) (*Extractor, *[]string) {
+func newZKExtractor(t *testing.T, caller *testZKCaller, parent ParentGameStatusFetcher, agreement ZKEnricher) (*Extractor, *[]string) {
 	t.Helper()
 	trace := new([]string)
 	caller.trace = trace
-	agreement.trace = trace
+	if tracedAgreement, ok := agreement.(*testZKAgreement); ok {
+		tracedAgreement.trace = trace
+	}
 	tracedParent := func(ctx context.Context, index uint64, block rpcblock.Block) (gameTypes.GameStatus, error) {
 		*trace = append(*trace, "parent")
 		return parent(ctx, index, block)

--- a/op-dispute-mon/mon/forecast.go
+++ b/op-dispute-mon/mon/forecast.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/transform"
@@ -95,7 +96,8 @@ func (f *Forecast) forecastGame(game monTypes.EnrichedGame, metrics *forecastBat
 		if metrics.LatestValidProposal < common.Timestamp {
 			metrics.LatestValidProposal = common.Timestamp
 		}
-		if metrics.LatestValidProposalL2Block < common.L2SequenceNumber {
+		_, isZK := game.(*monTypes.ZKGameData)
+		if !isZK && metrics.LatestValidProposalL2Block < common.L2SequenceNumber {
 			metrics.LatestValidProposalL2Block = common.L2SequenceNumber
 		}
 	}
@@ -147,6 +149,27 @@ func (f *Forecast) forecastGame(game monTypes.EnrichedGame, metrics *forecastBat
 			// Otherwise we go through the resolution process to determine who would win based on the current claims
 			tree := transform.CreateBidirectionalTree(game.Claims)
 			forecastStatus = Resolve(tree)
+		}
+	case *monTypes.ZKGameData:
+		if game.ParentStatus != nil && *game.ParentStatus == types.GameStatusChallengerWon {
+			forecastStatus = types.GameStatusChallengerWon
+			break
+		}
+		switch game.ProposalStatus {
+		case contracts.ProposalStatusUnchallenged,
+			contracts.ProposalStatusUnchallengedAndValidProofProvided,
+			contracts.ProposalStatusChallengedAndValidProofProvided:
+			forecastStatus = types.GameStatusDefenderWon
+		case contracts.ProposalStatusChallenged:
+			forecastStatus = types.GameStatusChallengerWon
+		default:
+			f.logger.Error("Unable to forecast ZK game with incompatible proposal and global status",
+				"game", common.Proxy, "proposalStatus", game.ProposalStatus, "globalStatus", common.Status)
+			if agreement {
+				forecastStatus = types.GameStatusChallengerWon
+			} else {
+				forecastStatus = types.GameStatusDefenderWon
+			}
 		}
 	default:
 		return fmt.Errorf("unsupported enriched game variant %T", game)

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
@@ -360,6 +361,74 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 	require.EqualValues(t, 8, m.latestValidProposalL2Block)
 	require.EqualValues(t, 7, m.latestInvalidProposal)
 	require.EqualValues(t, 8, m.latestValidProposal)
+}
+
+func TestForecastZKDecisionTable(t *testing.T) {
+	inProgress := types.GameStatusInProgress
+	defenderWon := types.GameStatusDefenderWon
+	challengerWon := types.GameStatusChallengerWon
+	tests := []struct {
+		name        string
+		agree       bool
+		status      types.GameStatus
+		proposal    contracts.ProposalStatus
+		parent      *types.GameStatus
+		expectation metrics.GameAgreementStatus
+		impossible  bool
+	}{
+		{name: "agree unchallenged live", agree: true, status: types.GameStatusInProgress, proposal: contracts.ProposalStatusUnchallenged, expectation: metrics.AgreeDefenderAhead},
+		{name: "disagree unchallenged live", status: types.GameStatusInProgress, proposal: contracts.ProposalStatusUnchallenged, expectation: metrics.DisagreeDefenderAhead},
+		{name: "agree challenged live", agree: true, status: types.GameStatusInProgress, proposal: contracts.ProposalStatusChallenged, expectation: metrics.AgreeChallengerAhead},
+		{name: "disagree challenged live", status: types.GameStatusInProgress, proposal: contracts.ProposalStatusChallenged, expectation: metrics.DisagreeChallengerAhead},
+		{name: "agree valid proof live", agree: true, status: types.GameStatusInProgress, proposal: contracts.ProposalStatusChallengedAndValidProofProvided, expectation: metrics.AgreeDefenderAhead},
+		{name: "disagree valid proof live", status: types.GameStatusInProgress, proposal: contracts.ProposalStatusUnchallengedAndValidProofProvided, expectation: metrics.DisagreeDefenderAhead},
+		{name: "agree unchallenged proof live", agree: true, status: types.GameStatusInProgress, proposal: contracts.ProposalStatusUnchallengedAndValidProofProvided, expectation: metrics.AgreeDefenderAhead},
+		{name: "disagree challenged proof live", status: types.GameStatusInProgress, proposal: contracts.ProposalStatusChallengedAndValidProofProvided, expectation: metrics.DisagreeDefenderAhead},
+		{name: "invalid parent overrides live", agree: true, status: types.GameStatusInProgress, proposal: contracts.ProposalStatusUnchallenged, parent: &challengerWon, expectation: metrics.AgreeChallengerAhead},
+		{name: "live parent does not override defender-governed proposal", agree: true, status: types.GameStatusInProgress, proposal: contracts.ProposalStatusUnchallenged, parent: &inProgress, expectation: metrics.AgreeDefenderAhead},
+		{name: "valid parent does not override challenger-governed proposal", agree: true, status: types.GameStatusInProgress, proposal: contracts.ProposalStatusChallenged, parent: &defenderWon, expectation: metrics.AgreeChallengerAhead},
+		{name: "agree terminal defender ignores invalid parent", agree: true, status: types.GameStatusDefenderWon, proposal: contracts.ProposalStatusResolved, parent: &challengerWon, expectation: metrics.AgreeDefenderWins},
+		{name: "disagree terminal defender", status: types.GameStatusDefenderWon, proposal: contracts.ProposalStatusResolved, expectation: metrics.DisagreeDefenderWins},
+		{name: "agree terminal challenger", agree: true, status: types.GameStatusChallengerWon, proposal: contracts.ProposalStatusResolved, expectation: metrics.AgreeChallengerWins},
+		{name: "disagree terminal challenger", status: types.GameStatusChallengerWon, proposal: contracts.ProposalStatusResolved, expectation: metrics.DisagreeChallengerWins},
+		{name: "agree impossible live resolved is pessimistic", agree: true, status: types.GameStatusInProgress, proposal: contracts.ProposalStatusResolved, expectation: metrics.AgreeChallengerAhead, impossible: true},
+		{name: "disagree impossible live resolved is pessimistic", status: types.GameStatusInProgress, proposal: contracts.ProposalStatusResolved, expectation: metrics.DisagreeDefenderAhead, impossible: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			forecast, metricer, logs := setupForecastTest(t)
+			game := &monTypes.ZKGameData{
+				CommonGameData: monTypes.CommonGameData{Status: test.status, AgreeWithClaim: test.agree},
+				ProposalStatus: test.proposal,
+				ParentStatus:   test.parent,
+			}
+
+			forecast.Forecast([]monTypes.EnrichedGame{game}, 0, 0)
+			expected := zeroGameAgreement()
+			expected[test.expectation] = 1
+			require.Equal(t, expected, metricer.gameAgreement)
+			impossibleLog := logs.FindLog(testlog.NewMessageFilter("Unable to forecast ZK game with incompatible proposal and global status"))
+			require.Equal(t, test.impossible, impossibleLog != nil)
+		})
+	}
+}
+
+func TestForecastExcludesZKFromLatestValidL2Block(t *testing.T) {
+	forecast, metricer, _ := setupForecastTest(t)
+	games := []monTypes.EnrichedGame{
+		&monTypes.FaultGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusChallengerWon, L2SequenceNumber: 55}},
+		&monTypes.SuperPermissionedGameData{CommonGameData: monTypes.CommonGameData{AgreeWithClaim: true, L2SequenceNumber: 77, Status: types.GameStatusDefenderWon}},
+		&monTypes.ZKGameData{CommonGameData: monTypes.CommonGameData{AgreeWithClaim: true, L2SequenceNumber: 99, Status: types.GameStatusInProgress}, ProposalStatus: contracts.ProposalStatusChallenged},
+	}
+
+	forecast.Forecast(games, 0, 0)
+	require.Equal(t, uint64(77), metricer.latestValidProposalL2Block)
+	expected := zeroGameAgreement()
+	expected[metrics.DisagreeChallengerWins] = 1
+	expected[metrics.AgreeDefenderWins] = 1
+	expected[metrics.AgreeChallengerAhead] = 1
+	require.Equal(t, expected, metricer.gameAgreement)
 }
 
 func setupForecastTest(t *testing.T) (*Forecast, *mockForecastMetrics, *testlog.CapturingHandler) {

--- a/op-dispute-mon/mon/monitor.go
+++ b/op-dispute-mon/mon/monitor.go
@@ -130,6 +130,8 @@ func partitionGames(games []types.EnrichedGame) ([]*types.CommonGameData, []*typ
 			faultGames = append(faultGames, game)
 		case *types.SuperPermissionedGameData:
 			commonGames = append(commonGames, game.Common())
+		case *types.ZKGameData:
+			commonGames = append(commonGames, game.Common())
 		default:
 			panic(fmt.Sprintf("unsupported enriched game type %T", game))
 		}

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -83,7 +83,8 @@ func TestMonitorRoutesGamesToResolution(t *testing.T) {
 	terminal := newEnrichedGameData(common.Address{0xaa}, 1)
 	terminal.Status = types.GameStatusDefenderWon
 	super := &monTypes.SuperPermissionedGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusDefenderWon}}
-	extractor.games = []monTypes.EnrichedGame{terminal, super}
+	zk := &monTypes.ZKGameData{CommonGameData: monTypes.CommonGameData{Status: types.GameStatusInProgress}}
+	extractor.games = []monTypes.EnrichedGame{terminal, super, zk}
 	var commonReceived []*monTypes.CommonGameData
 	monitor.commonMonitors = []CommonMonitor{func(games []*monTypes.CommonGameData) {
 		commonReceived = games
@@ -98,7 +99,7 @@ func TestMonitorRoutesGamesToResolution(t *testing.T) {
 	}}
 
 	require.NoError(t, monitor.monitorGames())
-	require.Equal(t, []*monTypes.CommonGameData{terminal.Common(), super.Common()}, commonReceived)
+	require.Equal(t, []*monTypes.CommonGameData{terminal.Common(), super.Common(), zk.Common()}, commonReceived)
 	require.Equal(t, []*monTypes.FaultGameData{terminal}, faultReceived)
 	require.Equal(t, []monTypes.BondedGame{terminal}, bondReceived)
 }

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -237,10 +237,12 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		s.cl,
 		s.game.CreateContract,
 		s.factoryContract.GetGamesAtOrAfter,
+		s.factoryContract.GetGameStatusAtBlock,
 		cfg.IgnoredGames,
 		cfg.MaxConcurrency,
 		s.commonEnrichers(),
 		s.faultEnrichers(),
+		extract.NewZKAgreementEnricher(s.logger, s.metrics, s.asSuperRootProviders(), clock.SystemClock),
 	)
 	forecast := NewForecast(s.logger, s.metrics)
 	bonds := bonds.NewBonds(s.logger, s.metrics, s.cl, s.honestActors)

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -167,15 +167,27 @@ type FaultGameData struct {
 	Claims                []EnrichedClaim
 }
 
+// ZKGameData contains proposal and parent state for a ZK dispute game.
+type ZKGameData struct {
+	CommonGameData
+
+	ParentIndex    uint32
+	ParentStatus   *types.GameStatus
+	ProposalStatus contracts.ProposalStatus
+	Deadline       time.Time
+}
+
 // SuperPermissionedGameData is the common snapshot of a SuperPermissioned game.
 type SuperPermissionedGameData struct {
 	CommonGameData
 }
 
 func (g *FaultGameData) Common() *CommonGameData             { return &g.CommonGameData }
+func (g *ZKGameData) Common() *CommonGameData                { return &g.CommonGameData }
 func (g *SuperPermissionedGameData) Common() *CommonGameData { return &g.CommonGameData }
 
 func (*FaultGameData) enrichedGame()             {}
+func (*ZKGameData) enrichedGame()                {}
 func (*SuperPermissionedGameData) enrichedGame() {}
 
 func (g *FaultGameData) BondData() *BondGameData { return &g.BondGameData }
@@ -195,7 +207,7 @@ func (g CommonGameData) HasMixedAvailability() bool {
 		return false
 	}
 
-	successfulEndpoints := g.NodeEndpointTotalCount - g.NodeEndpointErrorCount - g.NodeEndpointNotFoundCount
+	successfulEndpoints := g.NodeEndpointTotalCount - g.NodeEndpointErrorCount - g.NodeEndpointNotFoundCount - g.NodeEndpointOutOfSyncCount
 	return g.NodeEndpointNotFoundCount > 0 && successfulEndpoints > 0
 }
 

--- a/op-dispute-mon/mon/types/types_test.go
+++ b/op-dispute-mon/mon/types/types_test.go
@@ -62,11 +62,12 @@ func TestCommonGameData_NodeEndpointErrorCountInitialization(t *testing.T) {
 
 func TestCommonGameData_HasMixedAvailability(t *testing.T) {
 	tests := []struct {
-		name                      string
-		nodeEndpointTotalCount    int
-		nodeEndpointErrorCount    int
-		nodeEndpointNotFoundCount int
-		expected                  bool
+		name                       string
+		nodeEndpointTotalCount     int
+		nodeEndpointErrorCount     int
+		nodeEndpointNotFoundCount  int
+		nodeEndpointOutOfSyncCount int
+		expected                   bool
 	}{
 		{
 			name:                      "no endpoints attempted",
@@ -124,14 +125,29 @@ func TestCommonGameData_HasMixedAvailability(t *testing.T) {
 			nodeEndpointNotFoundCount: 2,
 			expected:                  false,
 		},
+		{
+			name:                       "not found and out of sync is not mixed availability",
+			nodeEndpointTotalCount:     2,
+			nodeEndpointNotFoundCount:  1,
+			nodeEndpointOutOfSyncCount: 1,
+			expected:                   false,
+		},
+		{
+			name:                       "not found, out of sync, and successful is mixed availability",
+			nodeEndpointTotalCount:     3,
+			nodeEndpointNotFoundCount:  1,
+			nodeEndpointOutOfSyncCount: 1,
+			expected:                   true,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			data := CommonGameData{
-				NodeEndpointTotalCount:    test.nodeEndpointTotalCount,
-				NodeEndpointErrorCount:    test.nodeEndpointErrorCount,
-				NodeEndpointNotFoundCount: test.nodeEndpointNotFoundCount,
+				NodeEndpointTotalCount:     test.nodeEndpointTotalCount,
+				NodeEndpointErrorCount:     test.nodeEndpointErrorCount,
+				NodeEndpointNotFoundCount:  test.nodeEndpointNotFoundCount,
+				NodeEndpointOutOfSyncCount: test.nodeEndpointOutOfSyncCount,
 			}
 			result := data.HasMixedAvailability()
 			require.Equal(t, test.expected, result)


### PR DESCRIPTION
## Claim

Extract complete non-bond ZK snapshots at one pinned L1 block and deterministically reconcile, cache, and forecast them while keeping production ZK caller creation disabled.

## Stack status and dependency

PR 3 of 5. Base: `develop`; follows merged #22226. Merged: #22225 → #22226. Open: #22227 → #22228 → #22229.

PRs 3–5 form the ZK landing cohort; this PR is inert in production until PR 5. The rebase inherits #22226's review follow-up.

## Commits and reading order

1. `97f3e79f03` adds the minimal pinned binding reads and checked proposal-status conversion.
2. `cb2cf5887c` adds ZK agreement, extraction, cache behavior, and forecast routing.
3. `5896ddb6a8` routes ZK games exhaustively to the common lane.
4. `8c7fd8362f` restricts ordinary super-root enrichment to its two supported game types.
5. `28b8a69134` shares super-root agreement aggregation while preserving Super and ZK policies.
6. `b36ca6a280` refreshes endpoint health on cached ZK snapshots during provider lag.

## Review focus

- The binding reads establish that parent status, metadata, participants, and anchor registry all use the requested block.
- The state machine runs the lag gate before later reads and preserves three outcomes: lagged-new omitted, lagged-cached retained without failure, and real-RPC-failing cached retained with failure.
- The literal proposal/agreement/parent decision tables route ZK only to the common lane. `GameCallerCreator.CreateContract` still rejects ZK.
- Commit 3 keeps the typed routing switch exhaustive without adding fault or bond membership.

## Intentional behavior changes

- Out-of-sync endpoints are subtracted from successful endpoints when evaluating mixed availability, preventing a lagged ZK source from being reported as available.
- Existing Fault and SuperPermissioned behavior remains unchanged.

## Tests

- `mise exec -- go test ./op-challenger/game/fault/contracts/... ./op-challenger/game/zk/... ./op-dispute-mon/... -count=1`
- `mise exec -- just lint-go`


