### PR TITLE
op-dispute-mon: normalize ZK bond accounting

### DIFF
--- a/op-challenger/game/fault/contracts/delayed_weth.go
+++ b/op-challenger/game/fault/contracts/delayed_weth.go
@@ -71,7 +71,10 @@ func (d *DelayedWETHContract) GetWithdrawals(ctx context.Context, block rpcblock
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch withdrawals: %w", err)
 	}
-	withdrawals := make([]*WithdrawalRequest, len(recipients))
+	if err := validateResultCount(len(recipients), len(results)); err != nil {
+		return nil, err
+	}
+	withdrawals := make([]*WithdrawalRequest, len(results))
 	for i, result := range results {
 		withdrawals[i] = &WithdrawalRequest{
 			Amount:    result.GetBigInt(0),
@@ -79,4 +82,11 @@ func (d *DelayedWETHContract) GetWithdrawals(ctx context.Context, block rpcblock
 		}
 	}
 	return withdrawals, nil
+}
+
+func validateResultCount(expected, actual int) error {
+	if actual != expected {
+		return fmt.Errorf("expected %d results but got %d", expected, actual)
+	}
+	return nil
 }

--- a/op-challenger/game/fault/contracts/delayed_weth.go
+++ b/op-challenger/game/fault/contracts/delayed_weth.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 	"time"
 
@@ -51,10 +52,13 @@ func (d *DelayedWETHContract) GetBalanceAndDelay(ctx context.Context, block rpcb
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to retrieve game balance: %w", err)
 	}
+	if err := validateResultCount(2, len(results)); err != nil {
+		return nil, 0, err
+	}
 	balance := results[0].GetBigInt(0)
 	delaySeconds := results[1].GetBigInt(0)
-	if !delaySeconds.IsInt64() {
-		return nil, 0, fmt.Errorf("withdrawal delay too big for int64 %v", delaySeconds)
+	if !delaySeconds.IsInt64() || delaySeconds.Int64() > math.MaxInt64/int64(time.Second) {
+		return nil, 0, fmt.Errorf("withdrawal delay too big for time.Duration %v", delaySeconds)
 	}
 	delay := time.Duration(delaySeconds.Int64()) * time.Second
 	return balance, delay, nil

--- a/op-challenger/game/fault/contracts/delayed_weth_test.go
+++ b/op-challenger/game/fault/contracts/delayed_weth_test.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"context"
+	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -56,6 +57,18 @@ func TestDelayedWeth_GetBalanceAndDelay(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, balance, actualBalance)
 	require.Equal(t, delay, actualDelay)
+}
+
+func TestDelayedWeth_GetBalanceAndDelayRejectsDurationOverflow(t *testing.T) {
+	stubRpc, weth := setupDelayedWethTest(t)
+	block := rpcblock.ByNumber(482)
+	tooManySeconds := big.NewInt(math.MaxInt64/int64(time.Second) + 1)
+
+	stubRpc.AddExpectedCall(batchingTest.NewGetBalanceCall(delayedWeth, block, big.NewInt(23984)))
+	stubRpc.SetResponse(delayedWeth, methodDelay, block, nil, []interface{}{tooManySeconds})
+
+	_, _, err := weth.GetBalanceAndDelay(t.Context(), block)
+	require.ErrorContains(t, err, "withdrawal delay too big for time.Duration")
 }
 
 func setupDelayedWethTest(t *testing.T) (*batchingTest.AbiBasedRpc, *DelayedWETHContract) {

--- a/op-challenger/game/fault/contracts/zkdisputegame.go
+++ b/op-challenger/game/fault/contracts/zkdisputegame.go
@@ -3,7 +3,6 @@ package contracts
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/big"
 	"time"
 
@@ -313,22 +312,11 @@ func (g *ZKDisputeGameContractLatest) GetBalanceAndDelay(ctx context.Context, bl
 	if err != nil {
 		return nil, 0, common.Address{}, err
 	}
-	results, err := g.multiCaller.Call(ctx, block,
-		batching.NewBalanceCall(delayedWETH.Addr()),
-		delayedWETH.contract.Call(methodDelay),
-	)
+	balance, delay, err := delayedWETH.GetBalanceAndDelay(ctx, block)
 	if err != nil {
-		return nil, 0, common.Address{}, fmt.Errorf("failed to retrieve ZK WETH balance and delay: %w", err)
-	}
-	if err := validateResultCount(2, len(results)); err != nil {
 		return nil, 0, common.Address{}, err
 	}
-	balance := results[0].GetBigInt(0)
-	delaySeconds := results[1].GetBigInt(0)
-	if !delaySeconds.IsInt64() || delaySeconds.Int64() > math.MaxInt64/int64(time.Second) {
-		return nil, 0, common.Address{}, fmt.Errorf("withdrawal delay too big for time.Duration %v", delaySeconds)
-	}
-	return balance, time.Duration(delaySeconds.Int64()) * time.Second, delayedWETH.Addr(), nil
+	return balance, delay, delayedWETH.Addr(), nil
 }
 
 func (g *ZKDisputeGameContractLatest) getDelayedWETH(ctx context.Context, block rpcblock.Block) (*DelayedWETHContract, error) {

--- a/op-challenger/game/fault/contracts/zkdisputegame.go
+++ b/op-challenger/game/fault/contracts/zkdisputegame.go
@@ -262,7 +262,7 @@ func (g *ZKDisputeGameContractLatest) GetBondMetadata(ctx context.Context, block
 	if err != nil {
 		return ZKBondMetadata{}, fmt.Errorf("failed to retrieve ZK bond metadata: %w", err)
 	}
-	if err := validateZKResultCount(3, len(results)); err != nil {
+	if err := validateResultCount(3, len(results)); err != nil {
 		return ZKBondMetadata{}, err
 	}
 	return ZKBondMetadata{
@@ -285,7 +285,7 @@ func (g *ZKDisputeGameContractLatest) GetCredits(ctx context.Context, block rpcb
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve ZK credit: %w", err)
 	}
-	if err := validateZKResultCount(len(recipients), len(results)); err != nil {
+	if err := validateResultCount(len(recipients), len(results)); err != nil {
 		return nil, err
 	}
 	credits := make([]*big.Int, len(results))
@@ -304,25 +304,7 @@ func (g *ZKDisputeGameContractLatest) GetWithdrawals(ctx context.Context, block 
 	if err != nil {
 		return nil, err
 	}
-	calls := make([]batching.Call, 0, len(recipients))
-	for _, recipient := range recipients {
-		calls = append(calls, delayedWETH.contract.Call(methodWithdrawals, g.contract.Addr(), recipient))
-	}
-	results, err := g.multiCaller.Call(ctx, block, calls...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve ZK withdrawals: %w", err)
-	}
-	if err := validateZKResultCount(len(recipients), len(results)); err != nil {
-		return nil, err
-	}
-	withdrawals := make([]*WithdrawalRequest, len(results))
-	for i, result := range results {
-		withdrawals[i] = &WithdrawalRequest{
-			Amount:    result.GetBigInt(0),
-			Timestamp: result.GetBigInt(1),
-		}
-	}
-	return withdrawals, nil
+	return delayedWETH.GetWithdrawals(ctx, block, g.contract.Addr(), recipients...)
 }
 
 func (g *ZKDisputeGameContractLatest) GetBalanceAndDelay(ctx context.Context, block rpcblock.Block) (*big.Int, time.Duration, common.Address, error) {
@@ -338,7 +320,7 @@ func (g *ZKDisputeGameContractLatest) GetBalanceAndDelay(ctx context.Context, bl
 	if err != nil {
 		return nil, 0, common.Address{}, fmt.Errorf("failed to retrieve ZK WETH balance and delay: %w", err)
 	}
-	if err := validateZKResultCount(2, len(results)); err != nil {
+	if err := validateResultCount(2, len(results)); err != nil {
 		return nil, 0, common.Address{}, err
 	}
 	balance := results[0].GetBigInt(0)
@@ -356,13 +338,6 @@ func (g *ZKDisputeGameContractLatest) getDelayedWETH(ctx context.Context, block 
 		return nil, fmt.Errorf("failed to fetch ZK WETH address: %w", err)
 	}
 	return NewDelayedWETHContract(g.metrics, result.GetAddress(0), g.multiCaller), nil
-}
-
-func validateZKResultCount(expected, actual int) error {
-	if actual != expected {
-		return fmt.Errorf("expected %d results but got %d", expected, actual)
-	}
-	return nil
 }
 
 func (g *ZKDisputeGameContractLatest) GetChallengerMetadata(ctx context.Context, block rpcblock.Block) (ChallengerMetadata, error) {

--- a/op-challenger/game/fault/contracts/zkdisputegame.go
+++ b/op-challenger/game/fault/contracts/zkdisputegame.go
@@ -56,6 +56,8 @@ var (
 	methodChallenge      = "challenge"
 	methodChallengerBond = "challengerBond"
 	methodClaimData      = "claimData"
+	methodGameCreator    = "gameCreator"
+	methodTotalBonds     = "totalBonds"
 )
 
 type claimData struct {
@@ -73,6 +75,10 @@ type ZKDisputeGameContract interface {
 	GetProposal(ctx context.Context) (common.Hash, uint64, error)
 	GetChallengerMetadata(ctx context.Context, block rpcblock.Block) (ChallengerMetadata, error)
 	GetAnchorStateRegistry(ctx context.Context, block rpcblock.Block) (common.Address, error)
+	GetBondMetadata(ctx context.Context, block rpcblock.Block) (ZKBondMetadata, error)
+	GetCredits(ctx context.Context, block rpcblock.Block, recipients ...common.Address) ([]*big.Int, error)
+	GetWithdrawals(ctx context.Context, block rpcblock.Block, recipients ...common.Address) ([]*WithdrawalRequest, error)
+	GetBalanceAndDelay(ctx context.Context, block rpcblock.Block) (*big.Int, time.Duration, common.Address, error)
 	IsClosed(ctx context.Context) (bool, error)
 	GetCredit(ctx context.Context, recipient common.Address) (*big.Int, gameTypes.GameStatus, error)
 	ClaimCreditTx(ctx context.Context, recipient common.Address) (txmgr.TxCandidate, error)
@@ -236,6 +242,126 @@ type ChallengerMetadata struct {
 	ProposedRoot     common.Hash
 	L2SequenceNumber uint64
 	Deadline         time.Time
+}
+
+// ZKBondMetadata contains the pinned values needed to account for ZK game bonds.
+type ZKBondMetadata struct {
+	GameCreator    common.Address
+	TotalBonds     *big.Int
+	ChallengerBond *big.Int
+}
+
+func (g *ZKDisputeGameContractLatest) GetBondMetadata(ctx context.Context, block rpcblock.Block) (ZKBondMetadata, error) {
+	defer g.metrics.StartContractRequest("GetBondMetadata")()
+	results, err := g.multiCaller.Call(ctx, block,
+		g.contract.Call(methodGameCreator),
+		g.contract.Call(methodTotalBonds),
+		g.contract.Call(methodChallengerBond),
+	)
+	if err != nil {
+		return ZKBondMetadata{}, fmt.Errorf("failed to retrieve ZK bond metadata: %w", err)
+	}
+	if err := validateZKResultCount(3, len(results)); err != nil {
+		return ZKBondMetadata{}, err
+	}
+	return ZKBondMetadata{
+		GameCreator:    results[0].GetAddress(0),
+		TotalBonds:     results[1].GetBigInt(0),
+		ChallengerBond: results[2].GetBigInt(0),
+	}, nil
+}
+
+func (g *ZKDisputeGameContractLatest) GetCredits(ctx context.Context, block rpcblock.Block, recipients ...common.Address) ([]*big.Int, error) {
+	defer g.metrics.StartContractRequest("GetCredits")()
+	if len(recipients) == 0 {
+		return []*big.Int{}, nil
+	}
+	calls := make([]batching.Call, 0, len(recipients))
+	for _, recipient := range recipients {
+		calls = append(calls, g.contract.Call(methodCredit, recipient))
+	}
+	results, err := g.multiCaller.Call(ctx, block, calls...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve ZK credit: %w", err)
+	}
+	if err := validateZKResultCount(len(recipients), len(results)); err != nil {
+		return nil, err
+	}
+	credits := make([]*big.Int, len(results))
+	for i, result := range results {
+		credits[i] = result.GetBigInt(0)
+	}
+	return credits, nil
+}
+
+func (g *ZKDisputeGameContractLatest) GetWithdrawals(ctx context.Context, block rpcblock.Block, recipients ...common.Address) ([]*WithdrawalRequest, error) {
+	defer g.metrics.StartContractRequest("GetWithdrawals")()
+	if len(recipients) == 0 {
+		return []*WithdrawalRequest{}, nil
+	}
+	delayedWETH, err := g.getDelayedWETH(ctx, block)
+	if err != nil {
+		return nil, err
+	}
+	calls := make([]batching.Call, 0, len(recipients))
+	for _, recipient := range recipients {
+		calls = append(calls, delayedWETH.contract.Call(methodWithdrawals, g.contract.Addr(), recipient))
+	}
+	results, err := g.multiCaller.Call(ctx, block, calls...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve ZK withdrawals: %w", err)
+	}
+	if err := validateZKResultCount(len(recipients), len(results)); err != nil {
+		return nil, err
+	}
+	withdrawals := make([]*WithdrawalRequest, len(results))
+	for i, result := range results {
+		withdrawals[i] = &WithdrawalRequest{
+			Amount:    result.GetBigInt(0),
+			Timestamp: result.GetBigInt(1),
+		}
+	}
+	return withdrawals, nil
+}
+
+func (g *ZKDisputeGameContractLatest) GetBalanceAndDelay(ctx context.Context, block rpcblock.Block) (*big.Int, time.Duration, common.Address, error) {
+	defer g.metrics.StartContractRequest("GetBalanceAndDelay")()
+	delayedWETH, err := g.getDelayedWETH(ctx, block)
+	if err != nil {
+		return nil, 0, common.Address{}, err
+	}
+	results, err := g.multiCaller.Call(ctx, block,
+		batching.NewBalanceCall(delayedWETH.Addr()),
+		delayedWETH.contract.Call(methodDelay),
+	)
+	if err != nil {
+		return nil, 0, common.Address{}, fmt.Errorf("failed to retrieve ZK WETH balance and delay: %w", err)
+	}
+	if err := validateZKResultCount(2, len(results)); err != nil {
+		return nil, 0, common.Address{}, err
+	}
+	balance := results[0].GetBigInt(0)
+	delaySeconds := results[1].GetBigInt(0)
+	if !delaySeconds.IsInt64() {
+		return nil, 0, common.Address{}, fmt.Errorf("withdrawal delay too big for int64 %v", delaySeconds)
+	}
+	return balance, time.Duration(delaySeconds.Int64()) * time.Second, delayedWETH.Addr(), nil
+}
+
+func (g *ZKDisputeGameContractLatest) getDelayedWETH(ctx context.Context, block rpcblock.Block) (*DelayedWETHContract, error) {
+	defer g.metrics.StartContractRequest("GetDelayedWETH")()
+	result, err := g.multiCaller.SingleCall(ctx, block, g.contract.Call(methodWETH))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch ZK WETH address: %w", err)
+	}
+	return NewDelayedWETHContract(g.metrics, result.GetAddress(0), g.multiCaller), nil
+}
+
+func validateZKResultCount(expected, actual int) error {
+	if actual != expected {
+		return fmt.Errorf("expected %d results but got %d", expected, actual)
+	}
+	return nil
 }
 
 func (g *ZKDisputeGameContractLatest) GetChallengerMetadata(ctx context.Context, block rpcblock.Block) (ChallengerMetadata, error) {

--- a/op-challenger/game/fault/contracts/zkdisputegame.go
+++ b/op-challenger/game/fault/contracts/zkdisputegame.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 	"time"
 
@@ -342,8 +343,8 @@ func (g *ZKDisputeGameContractLatest) GetBalanceAndDelay(ctx context.Context, bl
 	}
 	balance := results[0].GetBigInt(0)
 	delaySeconds := results[1].GetBigInt(0)
-	if !delaySeconds.IsInt64() {
-		return nil, 0, common.Address{}, fmt.Errorf("withdrawal delay too big for int64 %v", delaySeconds)
+	if !delaySeconds.IsInt64() || delaySeconds.Int64() > math.MaxInt64/int64(time.Second) {
+		return nil, 0, common.Address{}, fmt.Errorf("withdrawal delay too big for time.Duration %v", delaySeconds)
 	}
 	return balance, time.Duration(delaySeconds.Int64()) * time.Second, delayedWETH.Addr(), nil
 }

--- a/op-challenger/game/fault/contracts/zkdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/zkdisputegame_test.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"context"
 	"errors"
+	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -247,6 +248,41 @@ func TestZKGetBalanceAndDelayAtPinnedBlock(t *testing.T) {
 			require.Equal(t, balance, actualBalance)
 			require.Equal(t, time.Duration(delaySeconds)*time.Second, actualDelay)
 			require.Equal(t, zkWethAddr, actualAddr)
+		})
+	}
+}
+
+func TestZKGetBalanceAndDelayRejectsDurationOverflow(t *testing.T) {
+	for _, version := range zkVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, contract := setupZKDisputeGameTest(t, version)
+			stubRpc.AddContract(zkWethAddr, snapshots.LoadDelayedWETHABI())
+			block := rpcblock.ByNumber(493)
+			tooManySeconds := big.NewInt(math.MaxInt64/int64(time.Second) + 1)
+			stubRpc.SetResponse(zkGameAddr, methodWETH, block, nil, []interface{}{zkWethAddr})
+			stubRpc.AddExpectedCall(batchingTest.NewGetBalanceCall(zkWethAddr, block, big.NewInt(144)))
+			stubRpc.SetResponse(zkWethAddr, methodDelay, block, nil, []interface{}{tooManySeconds})
+
+			_, _, _, err := contract.GetBalanceAndDelay(t.Context(), block)
+			require.ErrorContains(t, err, "withdrawal delay too big for time.Duration")
+		})
+	}
+}
+
+func TestZKGetBalanceAndDelayAcceptsMaxDuration(t *testing.T) {
+	for _, version := range zkVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, contract := setupZKDisputeGameTest(t, version)
+			stubRpc.AddContract(zkWethAddr, snapshots.LoadDelayedWETHABI())
+			block := rpcblock.ByNumber(493)
+			maxSeconds := int64(math.MaxInt64 / int64(time.Second))
+			stubRpc.SetResponse(zkGameAddr, methodWETH, block, nil, []interface{}{zkWethAddr})
+			stubRpc.AddExpectedCall(batchingTest.NewGetBalanceCall(zkWethAddr, block, big.NewInt(144)))
+			stubRpc.SetResponse(zkWethAddr, methodDelay, block, nil, []interface{}{big.NewInt(maxSeconds)})
+
+			_, actualDelay, _, err := contract.GetBalanceAndDelay(t.Context(), block)
+			require.NoError(t, err)
+			require.Equal(t, time.Duration(maxSeconds)*time.Second, actualDelay)
 		})
 	}
 }

--- a/op-challenger/game/fault/contracts/zkdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/zkdisputegame_test.go
@@ -287,10 +287,10 @@ func TestZKGetBalanceAndDelayAcceptsMaxDuration(t *testing.T) {
 	}
 }
 
-func TestValidateZKResultCount(t *testing.T) {
-	require.NoError(t, validateZKResultCount(2, 2))
-	require.ErrorContains(t, validateZKResultCount(2, 1), "expected 2 results but got 1")
-	require.ErrorContains(t, validateZKResultCount(2, 3), "expected 2 results but got 3")
+func TestValidateResultCount(t *testing.T) {
+	require.NoError(t, validateResultCount(2, 2))
+	require.ErrorContains(t, validateResultCount(2, 1), "expected 2 results but got 1")
+	require.ErrorContains(t, validateResultCount(2, 3), "expected 2 results but got 3")
 }
 
 func TestZKGetGameRange(t *testing.T) {

--- a/op-challenger/game/fault/contracts/zkdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/zkdisputegame_test.go
@@ -26,6 +26,7 @@ const (
 
 var (
 	zkGameAddr = common.Address{0x45, 0x44, 0x43}
+	zkWethAddr = common.Address{0x57, 0x45, 0x54, 0x48}
 )
 
 var zkVersions = []contractVersion{
@@ -154,6 +155,106 @@ func TestZKGetAnchorStateRegistryAtPinnedBlock(t *testing.T) {
 			require.Equal(t, expected, actual)
 		})
 	}
+}
+
+func TestZKGetBondMetadataAtPinnedBlock(t *testing.T) {
+	for _, version := range zkVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, contract := setupZKDisputeGameTest(t, version)
+			block := rpcblock.ByHash(common.Hash{0x91})
+			expected := ZKBondMetadata{
+				GameCreator:    common.Address{0x01},
+				TotalBonds:     big.NewInt(23),
+				ChallengerBond: big.NewInt(7),
+			}
+			stubRpc.SetResponse(zkGameAddr, methodGameCreator, block, nil, []interface{}{expected.GameCreator})
+			stubRpc.SetResponse(zkGameAddr, methodTotalBonds, block, nil, []interface{}{expected.TotalBonds})
+			stubRpc.SetResponse(zkGameAddr, methodChallengerBond, block, nil, []interface{}{expected.ChallengerBond})
+
+			actual, err := contract.GetBondMetadata(t.Context(), block)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestZKGetCreditsAtPinnedBlock(t *testing.T) {
+	for _, version := range zkVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, contract := setupZKDisputeGameTest(t, version)
+			block := rpcblock.ByNumber(492)
+			recipients := []common.Address{{0x01}, {0x02}, {0x03}}
+			expected := []*big.Int{big.NewInt(3), big.NewInt(5), big.NewInt(8)}
+			for i, recipient := range recipients {
+				stubRpc.SetResponse(zkGameAddr, methodCredit, block, []interface{}{recipient}, []interface{}{expected[i]})
+			}
+
+			actual, err := contract.GetCredits(t.Context(), block, recipients...)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+
+			empty, err := contract.GetCredits(t.Context(), block)
+			require.NoError(t, err)
+			require.Empty(t, empty)
+			require.NotNil(t, empty)
+		})
+	}
+}
+
+func TestZKGetWithdrawalsAtPinnedBlock(t *testing.T) {
+	for _, version := range zkVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, contract := setupZKDisputeGameTest(t, version)
+			stubRpc.AddContract(zkWethAddr, snapshots.LoadDelayedWETHABI())
+			block := rpcblock.ByHash(common.Hash{0x92})
+			recipients := []common.Address{{0x01}, {0x02}}
+			expected := []*WithdrawalRequest{
+				{Amount: big.NewInt(11), Timestamp: big.NewInt(101)},
+				{Amount: big.NewInt(13), Timestamp: big.NewInt(103)},
+			}
+			stubRpc.SetResponse(zkGameAddr, methodWETH, block, nil, []interface{}{zkWethAddr})
+			for i, recipient := range recipients {
+				stubRpc.SetResponse(zkWethAddr, methodWithdrawals, block, []interface{}{zkGameAddr, recipient}, []interface{}{expected[i].Amount, expected[i].Timestamp})
+			}
+
+			actual, err := contract.GetWithdrawals(t.Context(), block, recipients...)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+
+			_, emptyContract := setupZKDisputeGameTest(t, version)
+			empty, err := emptyContract.GetWithdrawals(t.Context(), block)
+			require.NoError(t, err)
+			require.Empty(t, empty)
+			require.NotNil(t, empty)
+		})
+	}
+}
+
+func TestZKGetBalanceAndDelayAtPinnedBlock(t *testing.T) {
+	for _, version := range zkVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, contract := setupZKDisputeGameTest(t, version)
+			stubRpc.AddContract(zkWethAddr, snapshots.LoadDelayedWETHABI())
+			block := rpcblock.ByNumber(493)
+			balance := big.NewInt(144)
+			delaySeconds := int64(77)
+			stubRpc.SetResponse(zkGameAddr, methodWETH, block, nil, []interface{}{zkWethAddr})
+			stubRpc.AddExpectedCall(batchingTest.NewGetBalanceCall(zkWethAddr, block, balance))
+			stubRpc.SetResponse(zkWethAddr, methodDelay, block, nil, []interface{}{big.NewInt(delaySeconds)})
+
+			actualBalance, actualDelay, actualAddr, err := contract.GetBalanceAndDelay(t.Context(), block)
+			require.NoError(t, err)
+			require.Equal(t, balance, actualBalance)
+			require.Equal(t, time.Duration(delaySeconds)*time.Second, actualDelay)
+			require.Equal(t, zkWethAddr, actualAddr)
+		})
+	}
+}
+
+func TestValidateZKResultCount(t *testing.T) {
+	require.NoError(t, validateZKResultCount(2, 2))
+	require.ErrorContains(t, validateZKResultCount(2, 1), "expected 2 results but got 1")
+	require.ErrorContains(t, validateZKResultCount(2, 3), "expected 2 results but got 3")
 }
 
 func TestZKGetGameRange(t *testing.T) {

--- a/op-dispute-mon/mon/bonds/collateral.go
+++ b/op-dispute-mon/mon/bonds/collateral.go
@@ -45,8 +45,22 @@ func requiredCollateralForGame(game monTypes.BondedGame) *big.Int {
 		}
 	}
 
-	for _, unclaimedCredit := range data.Credits {
-		required = new(big.Int).Add(required, unclaimedCredit)
+	if _, ok := game.(*monTypes.ZKGameData); !ok {
+		for _, unclaimedCredit := range data.Credits {
+			required = new(big.Int).Add(required, unclaimedCredit)
+		}
+		return required
+	}
+	for _, recipient := range data.RecipientAddresses() {
+		credit := data.Credits[recipient]
+		if credit == nil {
+			credit = new(big.Int)
+		}
+		obligation := credit
+		if request := data.WithdrawalRequests[recipient]; request != nil && request.Amount != nil && request.Amount.Cmp(obligation) > 0 {
+			obligation = request.Amount
+		}
+		required = new(big.Int).Add(required, obligation)
 	}
 	return required
 }

--- a/op-dispute-mon/mon/bonds/collateral_test.go
+++ b/op-dispute-mon/mon/bonds/collateral_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
@@ -58,4 +59,28 @@ func TestCalculateRequiredCollateral(t *testing.T) {
 	require.Equal(t, bigs.Uint64Strict(weth1Balance), bigs.Uint64Strict(actual[weth1].Actual))
 	require.Equal(t, uint64(23+46), bigs.Uint64Strict(actual[weth2].Required))
 	require.Equal(t, bigs.Uint64Strict(weth2Balance), bigs.Uint64Strict(actual[weth2].Actual))
+}
+
+func TestCalculateRequiredCollateralAggregatesFaultAndZK(t *testing.T) {
+	weth := common.Address{0xaa}
+	recipient := common.Address{0x01}
+	fault := &monTypes.FaultGameData{BondGameData: monTypes.BondGameData{
+		Bonds:         []monTypes.BondRecord{{Amount: big.NewInt(5)}},
+		Credits:       map[common.Address]*big.Int{recipient: big.NewInt(2)},
+		WETHContract:  weth,
+		ETHCollateral: big.NewInt(100),
+	}}
+	zk := &monTypes.ZKGameData{BondGameData: monTypes.BondGameData{
+		Bonds:   []monTypes.BondRecord{{Amount: big.NewInt(11)}},
+		Credits: map[common.Address]*big.Int{recipient: big.NewInt(3)},
+		WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{
+			recipient: {Amount: big.NewInt(7), Timestamp: big.NewInt(1)},
+		},
+		WETHContract:  weth,
+		ETHCollateral: big.NewInt(100),
+	}}
+
+	actual := CalculateRequiredCollateral([]monTypes.BondedGame{fault, zk})
+	require.Equal(t, big.NewInt(25), actual[weth].Required)
+	require.Equal(t, big.NewInt(100), actual[weth].Actual)
 }

--- a/op-dispute-mon/mon/bonds/monitor.go
+++ b/op-dispute-mon/mon/bonds/monitor.go
@@ -67,10 +67,6 @@ func (b *Bonds) checkHonestActorBonds(games []types.BondedGame) {
 				continue
 			}
 			if !bond.Forfeited {
-				// Preserve the historical zero-address series until zero is rejected as an honest actor.
-				if b.honestActors.Contains(common.Address{}) {
-					honest[common.Address{}].Won.Add(honest[common.Address{}].Won, bond.Amount)
-				}
 				continue
 			}
 			if b.honestActors.Contains(bond.Depositor) {
@@ -91,7 +87,8 @@ func (b *Bonds) checkCredits(games []types.BondedGame) {
 
 	for _, game := range games {
 		data := game.BondData()
-		maxDurationReached := !data.CreditWithdrawableAt.After(b.clock.Now())
+		now := b.clock.Now()
+		_, isZK := game.(*types.ZKGameData)
 
 		allRecipients := make(map[common.Address]bool)
 		for address := range data.ExpectedCredits {
@@ -100,11 +97,25 @@ func (b *Bonds) checkCredits(games []types.BondedGame) {
 		for address := range data.Credits {
 			allRecipients[address] = true
 		}
+		if isZK {
+			for address := range data.WithdrawalRequests {
+				allRecipients[address] = true
+			}
+		}
 
 		for recipient := range allRecipients {
 			actual := data.Credits[recipient]
 			if actual == nil {
 				actual = big.NewInt(0)
+			}
+			maxDurationReached := !data.CreditWithdrawableAt.After(now)
+			if isZK {
+				request := data.WithdrawalRequests[recipient]
+				if request != nil && request.Amount != nil && request.Amount.Cmp(actual) > 0 {
+					actual = request.Amount
+				}
+				maxDurationReached = request != nil && request.Timestamp != nil && request.Timestamp.Sign() > 0 &&
+					!now.Before(time.Unix(request.Timestamp.Int64(), 0).Add(data.WETHDelay))
 			}
 			expected := data.ExpectedCredits[recipient]
 			if expected == nil {

--- a/op-dispute-mon/mon/bonds/monitor_test.go
+++ b/op-dispute-mon/mon/bonds/monitor_test.go
@@ -131,7 +131,7 @@ func TestZKBondConsumersRecordAllCreditBuckets(t *testing.T) {
 		newGame(3, big.NewInt(11), new(big.Int), 0),
 		newGame(4, new(big.Int), big.NewInt(9), matureTimestamp),
 		newGame(5, new(big.Int), big.NewInt(10), matureTimestamp),
-		newGame(6, new(big.Int), big.NewInt(11), matureTimestamp),
+		newGame(6, new(big.Int), big.NewInt(11), matureTimestamp-1),
 	}
 
 	bonds, metricer, _ := setupBondMetricsTest(t)

--- a/op-dispute-mon/mon/bonds/monitor_test.go
+++ b/op-dispute-mon/mon/bonds/monitor_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
@@ -104,6 +106,46 @@ func TestCheckRecipientCredit(t *testing.T) {
 	require.NotNil(t, findCreditLog(logs, log.LevelWarn, "Credit above expected amount", game4.Proxy, addr4, "withdrawable"))
 }
 
+func TestZKBondConsumersRecordAllCreditBuckets(t *testing.T) {
+	recipient := common.Address{0x01}
+	newGame := func(proxy byte, credit, requestAmount *big.Int, timestamp int64) *monTypes.ZKGameData {
+		return &monTypes.ZKGameData{
+			CommonGameData: monTypes.CommonGameData{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{proxy}}},
+			BondGameData: monTypes.BondGameData{
+				ExpectedCredits: map[common.Address]*big.Int{recipient: big.NewInt(10)},
+				Credits:         map[common.Address]*big.Int{recipient: credit},
+				WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{
+					recipient: {Amount: requestAmount, Timestamp: big.NewInt(timestamp)},
+				},
+				BondDistributionMode: faultTypes.NormalDistributionMode,
+				WETHContract:         common.Address{0xee},
+				WETHDelay:            10 * time.Second,
+				ETHCollateral:        big.NewInt(1000),
+			},
+		}
+	}
+	matureTimestamp := frozen.Unix() - 10
+	games := []monTypes.BondedGame{
+		newGame(1, big.NewInt(9), new(big.Int), 0),
+		newGame(2, big.NewInt(10), new(big.Int), 0),
+		newGame(3, big.NewInt(11), new(big.Int), 0),
+		newGame(4, new(big.Int), big.NewInt(9), matureTimestamp),
+		newGame(5, new(big.Int), big.NewInt(10), matureTimestamp),
+		newGame(6, new(big.Int), big.NewInt(11), matureTimestamp),
+	}
+
+	bonds, metricer, _ := setupBondMetricsTest(t)
+	bonds.CheckBonds(games)
+	require.Equal(t, map[metrics.CreditExpectation]int{
+		metrics.CreditBelowWithdrawable:    1,
+		metrics.CreditEqualWithdrawable:    1,
+		metrics.CreditAboveWithdrawable:    1,
+		metrics.CreditBelowNonWithdrawable: 1,
+		metrics.CreditEqualNonWithdrawable: 1,
+		metrics.CreditAboveNonWithdrawable: 1,
+	}, metricer.credits)
+}
+
 func TestCheckBondsRecordsHonestActorBonds(t *testing.T) {
 	actor1 := common.Address{0x01}
 	actor2 := common.Address{0x02}
@@ -135,7 +177,75 @@ func TestCheckBondsRecordsHonestActorBonds(t *testing.T) {
 	require.Equal(t, big.NewInt(0), metricer.honest[actor2].Pending)
 	require.Equal(t, big.NewInt(8), metricer.honest[actor2].Lost)
 	require.Equal(t, big.NewInt(14), metricer.honest[actor2].Won)
-	require.Equal(t, big.NewInt(2), metricer.honest[common.Address{}].Won)
+	// Intentional existing-output change: address zero is a contract sentinel, not an honest actor.
+	require.NotContains(t, metricer.honest, common.Address{})
+}
+
+func TestZKBondConsumersRecordHonestActors(t *testing.T) {
+	creator := common.Address{0x01}
+	challenger := common.Address{0x02}
+	prover := common.Address{0x03}
+	newGame := func(bonds []monTypes.BondRecord) *monTypes.ZKGameData {
+		return &monTypes.ZKGameData{BondGameData: monTypes.BondGameData{
+			Bonds:              bonds,
+			Credits:            map[common.Address]*big.Int{},
+			ExpectedCredits:    map[common.Address]*big.Int{},
+			WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{},
+			WETHContract:       common.Address{0xee},
+			ETHCollateral:      big.NewInt(1000),
+		}}
+	}
+	games := []monTypes.BondedGame{
+		newGame([]monTypes.BondRecord{
+			{Depositor: creator, Amount: big.NewInt(70)},
+			{Depositor: challenger, Amount: big.NewInt(30), ChallengerBond: true},
+		}),
+		newGame([]monTypes.BondRecord{
+			{Depositor: creator, Recipient: challenger, Amount: big.NewInt(70), Resolved: true, Forfeited: true},
+			{Depositor: challenger, Recipient: challenger, Amount: big.NewInt(30), Resolved: true, ChallengerBond: true},
+		}),
+		newGame([]monTypes.BondRecord{
+			{Depositor: creator, Recipient: creator, Amount: big.NewInt(70), Resolved: true},
+			{Depositor: challenger, Recipient: prover, Amount: big.NewInt(30), Resolved: true, Forfeited: true, ChallengerBond: true},
+		}),
+		newGame([]monTypes.BondRecord{
+			{Depositor: creator, Recipient: creator, Amount: big.NewInt(70), Resolved: true},
+			{Depositor: creator, Recipient: prover, Amount: big.NewInt(30), Resolved: true, Forfeited: true, ChallengerBond: true},
+		}),
+		newGame([]monTypes.BondRecord{{
+			Depositor: creator, Recipient: common.Address{}, Amount: big.NewInt(100), Resolved: true, Forfeited: true,
+		}}),
+	}
+
+	bonds, metricer, _ := setupBondMetricsTestWithHonestActors(t, monTypes.NewHonestActors([]common.Address{{}, creator, challenger, prover}))
+	bonds.CheckBonds(games)
+	require.Equal(t, metrics.HonestActorBondData{Pending: big.NewInt(70), Lost: big.NewInt(200), Won: new(big.Int)}, metricer.honest[creator])
+	require.Equal(t, metrics.HonestActorBondData{Pending: big.NewInt(30), Lost: big.NewInt(30), Won: big.NewInt(70)}, metricer.honest[challenger])
+	require.Equal(t, metrics.HonestActorBondData{Pending: new(big.Int), Lost: new(big.Int), Won: big.NewInt(60)}, metricer.honest[prover])
+	require.NotContains(t, metricer.honest, common.Address{})
+}
+
+func TestZKBondConsumersDoNotForfeitReturnedOverlappingRoles(t *testing.T) {
+	creator := common.Address{0x01}
+	challenger := common.Address{0x02}
+	game := &monTypes.ZKGameData{BondGameData: monTypes.BondGameData{
+		Bonds: []monTypes.BondRecord{
+			{Depositor: creator, Recipient: creator, Amount: big.NewInt(70), Resolved: true},
+			{Depositor: creator, Recipient: creator, Amount: big.NewInt(30), Resolved: true, ChallengerBond: true},
+			{Depositor: challenger, Recipient: challenger, Amount: big.NewInt(30), Resolved: true, ChallengerBond: true},
+		},
+		Credits:            map[common.Address]*big.Int{},
+		ExpectedCredits:    map[common.Address]*big.Int{},
+		WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{},
+		WETHContract:       common.Address{0xee},
+		ETHCollateral:      big.NewInt(1000),
+	}}
+
+	bonds, metricer, _ := setupBondMetricsTestWithHonestActors(t, monTypes.NewHonestActors([]common.Address{creator, challenger}))
+	bonds.CheckBonds([]monTypes.BondedGame{game})
+	zero := metrics.HonestActorBondData{Pending: new(big.Int), Lost: new(big.Int), Won: new(big.Int)}
+	require.Equal(t, zero, metricer.honest[creator])
+	require.Equal(t, zero, metricer.honest[challenger])
 }
 
 func findCreditLog(logs *testlog.CapturingHandler, level slog.Level, message string, game, recipient common.Address, withdrawable string) *testlog.CapturedRecord {

--- a/op-dispute-mon/mon/extract/bond_data_enricher.go
+++ b/op-dispute-mon/mon/extract/bond_data_enricher.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
@@ -23,6 +24,7 @@ type BondDataEnricher struct{}
 var (
 	ErrIncorrectCreditCount      = errors.New("incorrect credit count")
 	ErrIncorrectWithdrawalsCount = errors.New("incorrect withdrawals count")
+	ErrInvalidZKBondData         = errors.New("invalid ZK bond data")
 )
 
 type BondCaller interface {
@@ -47,6 +49,163 @@ func (b *BondDataEnricher) Enrich(ctx context.Context, block rpcblock.Block, cal
 	}
 	game.BondGameData = data
 	return nil
+}
+
+func (b *BondDataEnricher) EnrichZK(ctx context.Context, block rpcblock.Block, caller ZKBondGameCaller, game *monTypes.ZKGameData) error {
+	data, err := b.loadZK(ctx, block, caller, game)
+	if err != nil {
+		return err
+	}
+	game.BondGameData = data
+	return nil
+}
+
+func (*BondDataEnricher) loadZK(ctx context.Context, block rpcblock.Block, caller ZKBondGameCaller, game *monTypes.ZKGameData) (monTypes.BondGameData, error) {
+	mode, err := caller.GetBondDistributionMode(ctx, block)
+	if err != nil {
+		return monTypes.BondGameData{}, fmt.Errorf("failed to fetch ZK bond distribution mode: %w", err)
+	}
+	data, err := normalizeZKBondData(game, mode)
+	if err != nil {
+		return monTypes.BondGameData{}, err
+	}
+	recipients := data.RecipientAddresses()
+
+	withdrawals, err := caller.GetWithdrawals(ctx, block, recipients...)
+	if err != nil {
+		return monTypes.BondGameData{}, fmt.Errorf("failed to fetch ZK withdrawals: %w", err)
+	}
+	if len(withdrawals) != len(recipients) {
+		return monTypes.BondGameData{}, fmt.Errorf("%w, requested %v values but got %v", ErrIncorrectWithdrawalsCount, len(recipients), len(withdrawals))
+	}
+	data.WithdrawalRequests = make(map[common.Address]*contracts.WithdrawalRequest, len(recipients))
+	for i, recipient := range recipients {
+		request := withdrawals[i]
+		if request == nil || request.Amount == nil || request.Timestamp == nil || request.Amount.Sign() < 0 || request.Timestamp.Sign() < 0 || !request.Timestamp.IsInt64() {
+			return monTypes.BondGameData{}, fmt.Errorf("%w: invalid withdrawal for %s", ErrInvalidZKBondData, recipient)
+		}
+		data.WithdrawalRequests[recipient] = cloneWithdrawal(request)
+	}
+	credits, err := caller.GetCredits(ctx, block, recipients...)
+	if err != nil {
+		return monTypes.BondGameData{}, fmt.Errorf("failed to fetch ZK credits: %w", err)
+	}
+	if len(credits) != len(recipients) {
+		return monTypes.BondGameData{}, fmt.Errorf("%w, requested %v values but got %v", ErrIncorrectCreditCount, len(recipients), len(credits))
+	}
+	data.Credits = make(map[common.Address]*big.Int, len(recipients))
+	for i, recipient := range recipients {
+		if credits[i] == nil || credits[i].Sign() < 0 {
+			return monTypes.BondGameData{}, fmt.Errorf("%w: invalid credit for %s", ErrInvalidZKBondData, recipient)
+		}
+		data.Credits[recipient] = cloneBigInt(credits[i])
+	}
+	balance, delay, wethContract, err := caller.GetBalanceAndDelay(ctx, block)
+	if err != nil {
+		return monTypes.BondGameData{}, fmt.Errorf("failed to fetch ZK balance: %w", err)
+	}
+	if balance == nil || balance.Sign() < 0 || delay < 0 {
+		return monTypes.BondGameData{}, fmt.Errorf("%w: invalid collateral", ErrInvalidZKBondData)
+	}
+
+	data.BondDistributionMode = mode
+	data.ETHCollateral = cloneBigInt(balance)
+	data.WETHDelay = delay
+	data.WETHContract = wethContract
+	return data, nil
+}
+
+func normalizeZKBondData(game *monTypes.ZKGameData, mode faultTypes.BondDistributionMode) (monTypes.BondGameData, error) {
+	if mode != faultTypes.UndecidedDistributionMode && mode != faultTypes.NormalDistributionMode && mode != faultTypes.RefundDistributionMode {
+		return monTypes.BondGameData{}, fmt.Errorf("%w: unsupported distribution mode %d", ErrInvalidZKBondData, mode)
+	}
+	if game.GameCreator == (common.Address{}) {
+		return monTypes.BondGameData{}, fmt.Errorf("%w: game creator is zero", ErrInvalidZKBondData)
+	}
+	if game.TotalBonds == nil || game.ChallengerBond == nil || game.TotalBonds.Sign() < 0 || game.ChallengerBond.Sign() < 0 {
+		return monTypes.BondGameData{}, fmt.Errorf("%w: invalid bond totals", ErrInvalidZKBondData)
+	}
+	if game.Status != gameTypes.GameStatusInProgress && game.Status != gameTypes.GameStatusDefenderWon && game.Status != gameTypes.GameStatusChallengerWon {
+		return monTypes.BondGameData{}, fmt.Errorf("%w: unsupported game status %d", ErrInvalidZKBondData, game.Status)
+	}
+	if err := validateZKStatus(game.Status, game.ProposalStatus); err != nil {
+		return monTypes.BondGameData{}, fmt.Errorf("%w: %w", ErrInvalidZKBondData, err)
+	}
+	if err := validateZKParticipants(game.ProposalStatus, game.Challenger, game.Prover); err != nil {
+		return monTypes.BondGameData{}, fmt.Errorf("%w: %w", ErrInvalidZKBondData, err)
+	}
+	if game.Status == gameTypes.GameStatusInProgress && mode != faultTypes.UndecidedDistributionMode {
+		return monTypes.BondGameData{}, fmt.Errorf("%w: live game has decided distribution mode %d", ErrInvalidZKBondData, mode)
+	}
+	if game.Status == gameTypes.GameStatusDefenderWon {
+		if game.ParentStatus != nil && *game.ParentStatus == gameTypes.GameStatusChallengerWon {
+			return monTypes.BondGameData{}, fmt.Errorf("%w: defender won with invalid parent", ErrInvalidZKBondData)
+		}
+		if game.Challenger != (common.Address{}) && game.Prover == (common.Address{}) {
+			return monTypes.BondGameData{}, fmt.Errorf("%w: challenged defender win has no prover", ErrInvalidZKBondData)
+		}
+	}
+	if game.Status == gameTypes.GameStatusChallengerWon {
+		invalidParent := game.ParentStatus != nil && *game.ParentStatus == gameTypes.GameStatusChallengerWon
+		if game.Prover != (common.Address{}) && !invalidParent {
+			return monTypes.BondGameData{}, fmt.Errorf("%w: challenger won after valid proof without invalid parent", ErrInvalidZKBondData)
+		}
+		if game.Challenger == (common.Address{}) && !invalidParent {
+			return monTypes.BondGameData{}, fmt.Errorf("%w: unchallenged game lost without invalid parent", ErrInvalidZKBondData)
+		}
+	}
+
+	creatorBond := cloneBigInt(game.TotalBonds)
+	if game.Challenger != (common.Address{}) {
+		if creatorBond.Cmp(game.ChallengerBond) < 0 {
+			return monTypes.BondGameData{}, fmt.Errorf("%w: total bonds below challenger bond", ErrInvalidZKBondData)
+		}
+		creatorBond.Sub(creatorBond, game.ChallengerBond)
+	}
+	data := monTypes.BondGameData{
+		Bonds: []monTypes.BondRecord{{Depositor: game.GameCreator, Amount: creatorBond}},
+		Recipients: map[common.Address]bool{
+			game.GameCreator: true,
+		},
+		ExpectedCredits: make(map[common.Address]*big.Int),
+	}
+	if game.Challenger != (common.Address{}) {
+		data.Recipients[game.Challenger] = true
+		data.Bonds = append(data.Bonds, monTypes.BondRecord{
+			Depositor:      game.Challenger,
+			Amount:         cloneBigInt(game.ChallengerBond),
+			ChallengerBond: true,
+		})
+	}
+	if game.Prover != (common.Address{}) {
+		data.Recipients[game.Prover] = true
+	}
+	if game.Status == gameTypes.GameStatusInProgress {
+		return data, nil
+	}
+
+	for i := range data.Bonds {
+		record := &data.Bonds[i]
+		record.Resolved = true
+		switch {
+		case mode == faultTypes.RefundDistributionMode:
+			record.Recipient = record.Depositor
+		case game.Status == gameTypes.GameStatusChallengerWon:
+			record.Recipient = game.Challenger
+		case record.ChallengerBond:
+			if game.Prover == game.GameCreator {
+				record.Recipient = game.GameCreator
+			} else {
+				record.Recipient = game.Prover
+			}
+		default:
+			record.Recipient = game.GameCreator
+		}
+		record.Forfeited = record.Recipient != record.Depositor
+		data.Recipients[record.Recipient] = true
+		addExpectedCredit(data.ExpectedCredits, record.Recipient, record.Amount)
+	}
+	return data, nil
 }
 
 func (*BondDataEnricher) load(ctx context.Context, block rpcblock.Block, caller BondGameCaller, game *monTypes.FaultGameData) (monTypes.BondGameData, error) {

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -55,8 +55,16 @@ type ZKGameCaller interface {
 	GetChallengerMetadata(context.Context, rpcblock.Block) (contracts.ChallengerMetadata, error)
 }
 
+// ZKBondGameCaller exposes the complete pinned ZK snapshot used by the monitor.
+type ZKBondGameCaller interface {
+	ZKGameCaller
+	BondGameCaller
+	GetBondMetadata(context.Context, rpcblock.Block) (contracts.ZKBondMetadata, error)
+}
+
 var _ FaultGameCaller = (contracts.FaultDisputeGameContract)(nil)
 var _ ZKGameCaller = (*contracts.ZKDisputeGameContractLatest)(nil)
+var _ ZKBondGameCaller = (*contracts.ZKDisputeGameContractLatest)(nil)
 var _ BondGameCaller = (contracts.FaultDisputeGameContract)(nil)
 var _ MetadataCaller = (*contracts.SuperPermissionedDisputeGameContract)(nil)
 

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -52,6 +52,7 @@ type Extractor struct {
 	commonEnrichers   []CommonEnricher
 	faultEnrichers    []FaultEnricher
 	zkAgreement       ZKEnricher
+	zkBonds           *BondDataEnricher
 	ignoredGames      map[common.Address]bool
 	latestGameData    map[common.Address]monTypes.EnrichedGame
 }
@@ -67,6 +68,7 @@ func NewExtractor(
 	commonEnrichers []CommonEnricher,
 	faultEnrichers []FaultEnricher,
 	zkAgreement ZKEnricher,
+	zkBonds *BondDataEnricher,
 ) *Extractor {
 	ignored := make(map[common.Address]bool)
 	for _, game := range ignoredGames {
@@ -82,6 +84,7 @@ func NewExtractor(
 		commonEnrichers:   commonEnrichers,
 		faultEnrichers:    faultEnrichers,
 		zkAgreement:       zkAgreement,
+		zkBonds:           zkBonds,
 		ignoredGames:      ignored,
 	}
 }
@@ -188,7 +191,7 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 }
 
 func (e *Extractor) enrichZKGame(ctx context.Context, block rpcblock.Block, caller GameCaller, game gameTypes.GameMetadata) (monTypes.EnrichedGame, error) {
-	zkCaller, ok := caller.(ZKGameCaller)
+	zkCaller, ok := caller.(ZKBondGameCaller)
 	if !ok {
 		return nil, fmt.Errorf("game caller %T does not support ZK game extraction", caller)
 	}
@@ -254,6 +257,18 @@ func (e *Extractor) enrichZKGame(ctx context.Context, block rpcblock.Block, call
 	enrichedGame.ParentStatus = parentStatus
 	enrichedGame.ProposalStatus = proposalStatus
 	enrichedGame.Deadline = challengerMeta.Deadline
+	enrichedGame.Challenger = challengerMeta.Challenger
+	enrichedGame.Prover = challengerMeta.Prover
+	bondMeta, err := zkCaller.GetBondMetadata(ctx, block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch ZK bond metadata: %w", err)
+	}
+	enrichedGame.GameCreator = bondMeta.GameCreator
+	enrichedGame.TotalBonds = cloneBigInt(bondMeta.TotalBonds)
+	enrichedGame.ChallengerBond = cloneBigInt(bondMeta.ChallengerBond)
+	if err := e.zkBonds.EnrichZK(ctx, block, zkCaller, enrichedGame); err != nil {
+		return nil, fmt.Errorf("failed to enrich ZK game bonds: %w", err)
+	}
 	return enrichedGame, nil
 }
 

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -329,6 +329,7 @@ func setupExtractorTest(t *testing.T, enrichers ...CommonEnricher) (*Extractor, 
 		enrichers,
 		nil,
 		nil,
+		nil,
 	)
 	return extractor, creator, games, capturedLogs, cl
 }

--- a/op-dispute-mon/mon/extract/super_permissioned_integration_test.go
+++ b/op-dispute-mon/mon/extract/super_permissioned_integration_test.go
@@ -64,6 +64,7 @@ func TestExtractorChecksSuperPermissionedGame(t *testing.T) {
 		},
 		nil,
 		nil,
+		nil,
 	)
 
 	games, ignored, failed, err := extractor.Extract(context.Background(), blockHash, 0)

--- a/op-dispute-mon/mon/extract/zk_bond_data_enricher_test.go
+++ b/op-dispute-mon/mon/extract/zk_bond_data_enricher_test.go
@@ -1,0 +1,445 @@
+package extract
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeZKBonds(t *testing.T) {
+	creator := common.Address{0x10}
+	challenger := common.Address{0x20}
+	prover := common.Address{0x30}
+	challengerWon := gameTypes.GameStatusChallengerWon
+	creatorLive := monTypes.BondRecord{Depositor: creator, Amount: big.NewInt(100)}
+	creatorRemainder := monTypes.BondRecord{Depositor: creator, Amount: big.NewInt(70)}
+	challengerLive := monTypes.BondRecord{Depositor: challenger, Amount: big.NewInt(30), ChallengerBond: true}
+
+	tests := []struct {
+		name       string
+		mode       faultTypes.BondDistributionMode
+		configure  func(*monTypes.ZKGameData)
+		bonds      []monTypes.BondRecord
+		credits    map[common.Address]*big.Int
+		recipients map[common.Address]bool
+	}{
+		{
+			name:       "live unchallenged",
+			bonds:      []monTypes.BondRecord{creatorLive},
+			credits:    map[common.Address]*big.Int{},
+			recipients: map[common.Address]bool{creator: true},
+		},
+		{
+			name: "live challenged",
+			configure: func(game *monTypes.ZKGameData) {
+				game.ProposalStatus = contracts.ProposalStatusChallenged
+				game.Challenger = challenger
+			},
+			bonds:      []monTypes.BondRecord{creatorRemainder, challengerLive},
+			credits:    map[common.Address]*big.Int{},
+			recipients: map[common.Address]bool{creator: true, challenger: true},
+		},
+		{
+			name: "challenger wins",
+			configure: func(game *monTypes.ZKGameData) {
+				game.Status = gameTypes.GameStatusChallengerWon
+				game.ProposalStatus = contracts.ProposalStatusResolved
+				game.Challenger = challenger
+			},
+			bonds: []monTypes.BondRecord{
+				{Depositor: creator, Recipient: challenger, Amount: big.NewInt(70), Resolved: true, Forfeited: true},
+				{Depositor: challenger, Recipient: challenger, Amount: big.NewInt(30), Resolved: true, ChallengerBond: true},
+			},
+			credits:    map[common.Address]*big.Int{challenger: big.NewInt(100)},
+			recipients: map[common.Address]bool{creator: true, challenger: true},
+		},
+		{
+			name: "creator self challenges and wins",
+			configure: func(game *monTypes.ZKGameData) {
+				game.Status = gameTypes.GameStatusChallengerWon
+				game.ProposalStatus = contracts.ProposalStatusResolved
+				game.Challenger = creator
+			},
+			bonds: []monTypes.BondRecord{
+				{Depositor: creator, Recipient: creator, Amount: big.NewInt(70), Resolved: true},
+				{Depositor: creator, Recipient: creator, Amount: big.NewInt(30), Resolved: true, ChallengerBond: true},
+			},
+			credits:    map[common.Address]*big.Int{creator: big.NewInt(100)},
+			recipients: map[common.Address]bool{creator: true},
+		},
+		{
+			name: "invalid parent overrides valid proof",
+			configure: func(game *monTypes.ZKGameData) {
+				game.Status = gameTypes.GameStatusChallengerWon
+				game.ProposalStatus = contracts.ProposalStatusResolved
+				game.ParentStatus = &challengerWon
+				game.Challenger = challenger
+				game.Prover = prover
+			},
+			bonds: []monTypes.BondRecord{
+				{Depositor: creator, Recipient: challenger, Amount: big.NewInt(70), Resolved: true, Forfeited: true},
+				{Depositor: challenger, Recipient: challenger, Amount: big.NewInt(30), Resolved: true, ChallengerBond: true},
+			},
+			credits:    map[common.Address]*big.Int{challenger: big.NewInt(100)},
+			recipients: map[common.Address]bool{creator: true, challenger: true, prover: true},
+		},
+		{
+			name: "defender wins with distinct prover",
+			configure: func(game *monTypes.ZKGameData) {
+				game.Status = gameTypes.GameStatusDefenderWon
+				game.ProposalStatus = contracts.ProposalStatusResolved
+				game.Challenger = challenger
+				game.Prover = prover
+			},
+			bonds: []monTypes.BondRecord{
+				{Depositor: creator, Recipient: creator, Amount: big.NewInt(70), Resolved: true},
+				{Depositor: challenger, Recipient: prover, Amount: big.NewInt(30), Resolved: true, Forfeited: true, ChallengerBond: true},
+			},
+			credits:    map[common.Address]*big.Int{creator: big.NewInt(70), prover: big.NewInt(30)},
+			recipients: map[common.Address]bool{creator: true, challenger: true, prover: true},
+		},
+		{
+			name: "creator self challenges and third party proves",
+			configure: func(game *monTypes.ZKGameData) {
+				game.Status = gameTypes.GameStatusDefenderWon
+				game.ProposalStatus = contracts.ProposalStatusResolved
+				game.Challenger = creator
+				game.Prover = prover
+			},
+			bonds: []monTypes.BondRecord{
+				{Depositor: creator, Recipient: creator, Amount: big.NewInt(70), Resolved: true},
+				{Depositor: creator, Recipient: prover, Amount: big.NewInt(30), Resolved: true, Forfeited: true, ChallengerBond: true},
+			},
+			credits:    map[common.Address]*big.Int{creator: big.NewInt(70), prover: big.NewInt(30)},
+			recipients: map[common.Address]bool{creator: true, prover: true},
+		},
+		{
+			name: "creator proves",
+			configure: func(game *monTypes.ZKGameData) {
+				game.Status = gameTypes.GameStatusDefenderWon
+				game.ProposalStatus = contracts.ProposalStatusResolved
+				game.Challenger = challenger
+				game.Prover = creator
+			},
+			bonds: []monTypes.BondRecord{
+				{Depositor: creator, Recipient: creator, Amount: big.NewInt(70), Resolved: true},
+				{Depositor: challenger, Recipient: creator, Amount: big.NewInt(30), Resolved: true, Forfeited: true, ChallengerBond: true},
+			},
+			credits:    map[common.Address]*big.Int{creator: big.NewInt(100)},
+			recipients: map[common.Address]bool{creator: true, challenger: true},
+		},
+		{
+			name: "challenger proves",
+			configure: func(game *monTypes.ZKGameData) {
+				game.Status = gameTypes.GameStatusDefenderWon
+				game.ProposalStatus = contracts.ProposalStatusResolved
+				game.Challenger = challenger
+				game.Prover = challenger
+			},
+			bonds: []monTypes.BondRecord{
+				{Depositor: creator, Recipient: creator, Amount: big.NewInt(70), Resolved: true},
+				{Depositor: challenger, Recipient: challenger, Amount: big.NewInt(30), Resolved: true, ChallengerBond: true},
+			},
+			credits:    map[common.Address]*big.Int{creator: big.NewInt(70), challenger: big.NewInt(30)},
+			recipients: map[common.Address]bool{creator: true, challenger: true},
+		},
+		{
+			name: "unchallenged valid proof rewards creator",
+			configure: func(game *monTypes.ZKGameData) {
+				game.Status = gameTypes.GameStatusDefenderWon
+				game.ProposalStatus = contracts.ProposalStatusResolved
+				game.Prover = prover
+			},
+			bonds:      []monTypes.BondRecord{{Depositor: creator, Recipient: creator, Amount: big.NewInt(100), Resolved: true}},
+			credits:    map[common.Address]*big.Int{creator: big.NewInt(100)},
+			recipients: map[common.Address]bool{creator: true, prover: true},
+		},
+		{
+			name: "unchallenged deadline rewards creator",
+			configure: func(game *monTypes.ZKGameData) {
+				game.Status = gameTypes.GameStatusDefenderWon
+				game.ProposalStatus = contracts.ProposalStatusResolved
+			},
+			bonds:      []monTypes.BondRecord{{Depositor: creator, Recipient: creator, Amount: big.NewInt(100), Resolved: true}},
+			credits:    map[common.Address]*big.Int{creator: big.NewInt(100)},
+			recipients: map[common.Address]bool{creator: true},
+		},
+		{
+			name: "refund mode returns deposits",
+			mode: faultTypes.RefundDistributionMode,
+			configure: func(game *monTypes.ZKGameData) {
+				game.Status = gameTypes.GameStatusDefenderWon
+				game.ProposalStatus = contracts.ProposalStatusResolved
+				game.Challenger = challenger
+				game.Prover = prover
+			},
+			bonds: []monTypes.BondRecord{
+				{Depositor: creator, Recipient: creator, Amount: big.NewInt(70), Resolved: true},
+				{Depositor: challenger, Recipient: challenger, Amount: big.NewInt(30), Resolved: true, ChallengerBond: true},
+			},
+			credits:    map[common.Address]*big.Int{creator: big.NewInt(70), challenger: big.NewInt(30)},
+			recipients: map[common.Address]bool{creator: true, challenger: true, prover: true},
+		},
+		{
+			name: "invalid parent burns unchallenged creator bond",
+			configure: func(game *monTypes.ZKGameData) {
+				game.Status = gameTypes.GameStatusChallengerWon
+				game.ProposalStatus = contracts.ProposalStatusResolved
+				game.ParentStatus = &challengerWon
+				game.Prover = prover
+			},
+			bonds: []monTypes.BondRecord{{
+				Depositor: creator, Recipient: common.Address{}, Amount: big.NewInt(100), Resolved: true, Forfeited: true,
+			}},
+			credits:    map[common.Address]*big.Int{{}: big.NewInt(100)},
+			recipients: map[common.Address]bool{creator: true, prover: true, {}: true},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			game := validZKBondGame(creator)
+			if test.configure != nil {
+				test.configure(game)
+			}
+			mode := test.mode
+			if mode == 0 {
+				mode = faultTypes.UndecidedDistributionMode
+			}
+			data, err := normalizeZKBondData(game, mode)
+			require.NoError(t, err)
+			require.Equal(t, test.bonds, data.Bonds)
+			require.Equal(t, test.credits, data.ExpectedCredits)
+			require.Equal(t, test.recipients, data.Recipients)
+		})
+	}
+
+	t.Run("unchallenged total may be below configured challenger bond", func(t *testing.T) {
+		game := validZKBondGame(creator)
+		game.TotalBonds = big.NewInt(10)
+		data, err := normalizeZKBondData(game, faultTypes.UndecidedDistributionMode)
+		require.NoError(t, err)
+		require.Equal(t, big.NewInt(10), data.Bonds[0].Amount)
+	})
+}
+
+func TestNormalizeZKBondsRejectsInvalidInputs(t *testing.T) {
+	creator := common.Address{0x10}
+	challenger := common.Address{0x20}
+	challengerWon := gameTypes.GameStatusChallengerWon
+	tests := []struct {
+		name      string
+		mode      faultTypes.BondDistributionMode
+		configure func(*monTypes.ZKGameData)
+	}{
+		{name: "zero creator", configure: func(game *monTypes.ZKGameData) { game.GameCreator = common.Address{} }},
+		{name: "nil total", configure: func(game *monTypes.ZKGameData) { game.TotalBonds = nil }},
+		{name: "nil challenger bond", configure: func(game *monTypes.ZKGameData) { game.ChallengerBond = nil }},
+		{name: "negative total", configure: func(game *monTypes.ZKGameData) { game.TotalBonds = big.NewInt(-1) }},
+		{name: "negative challenger bond", configure: func(game *monTypes.ZKGameData) { game.ChallengerBond = big.NewInt(-1) }},
+		{name: "unsupported mode", mode: faultTypes.LegacyDistributionMode},
+		{name: "unsupported status", configure: func(game *monTypes.ZKGameData) { game.Status = gameTypes.GameStatus(99) }},
+		{name: "live decided mode", mode: faultTypes.NormalDistributionMode},
+		{name: "challenged underflow", configure: func(game *monTypes.ZKGameData) {
+			game.ProposalStatus = contracts.ProposalStatusChallenged
+			game.Challenger = challenger
+			game.TotalBonds = big.NewInt(20)
+		}},
+		{name: "invalid live participants", configure: func(game *monTypes.ZKGameData) { game.Challenger = challenger }},
+		{name: "challenged defender win without prover", configure: func(game *monTypes.ZKGameData) {
+			game.Status = gameTypes.GameStatusDefenderWon
+			game.ProposalStatus = contracts.ProposalStatusResolved
+			game.Challenger = challenger
+		}},
+		{name: "defender win with invalid parent", configure: func(game *monTypes.ZKGameData) {
+			game.Status = gameTypes.GameStatusDefenderWon
+			game.ProposalStatus = contracts.ProposalStatusResolved
+			game.ParentStatus = &challengerWon
+		}},
+		{name: "challenger win after proof without invalid parent", configure: func(game *monTypes.ZKGameData) {
+			game.Status = gameTypes.GameStatusChallengerWon
+			game.ProposalStatus = contracts.ProposalStatusResolved
+			game.Challenger = challenger
+			game.Prover = common.Address{0x30}
+		}},
+		{name: "unchallenged loss without invalid parent", configure: func(game *monTypes.ZKGameData) {
+			game.Status = gameTypes.GameStatusChallengerWon
+			game.ProposalStatus = contracts.ProposalStatusResolved
+		}},
+		{name: "global proposal mismatch", configure: func(game *monTypes.ZKGameData) { game.ProposalStatus = contracts.ProposalStatusResolved }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			game := validZKBondGame(creator)
+			if test.configure != nil {
+				test.configure(game)
+			}
+			_, err := normalizeZKBondData(game, test.mode)
+			require.ErrorIs(t, err, ErrInvalidZKBondData)
+		})
+	}
+}
+
+func TestNormalizeZKBondsCopiesAmounts(t *testing.T) {
+	creator := common.Address{0x10}
+	challenger := common.Address{0x20}
+	game := validZKBondGame(creator)
+	game.ProposalStatus = contracts.ProposalStatusChallenged
+	game.Challenger = challenger
+	data, err := normalizeZKBondData(game, faultTypes.UndecidedDistributionMode)
+	require.NoError(t, err)
+
+	game.TotalBonds.SetInt64(200)
+	game.ChallengerBond.SetInt64(40)
+	require.Equal(t, big.NewInt(70), data.Bonds[0].Amount)
+	require.Equal(t, big.NewInt(30), data.Bonds[1].Amount)
+	data.Bonds[0].Amount.SetInt64(1)
+	require.Equal(t, big.NewInt(200), game.TotalBonds)
+}
+
+func TestZKBondSnapshot(t *testing.T) {
+	creator := common.Address{0x10}
+	challenger := common.Address{0x20}
+	block := rpcblock.ByHash(common.Hash{0xaa})
+	withdrawals := []*contracts.WithdrawalRequest{
+		{Amount: new(big.Int), Timestamp: new(big.Int)},
+		{Amount: big.NewInt(100), Timestamp: big.NewInt(200)},
+	}
+	credits := []*big.Int{new(big.Int), new(big.Int)}
+	caller := &bondSnapshotCaller{
+		mode:        faultTypes.NormalDistributionMode,
+		withdrawals: withdrawals,
+		credits:     credits,
+		balance:     big.NewInt(150),
+		delay:       time.Hour,
+		weth:        common.Address{0xee},
+	}
+	game := validZKBondGame(creator)
+	game.Status = gameTypes.GameStatusChallengerWon
+	game.ProposalStatus = contracts.ProposalStatusResolved
+	game.Challenger = challenger
+
+	require.NoError(t, NewBondDataEnricher().EnrichZK(t.Context(), block, zkBondCaller(caller), game))
+	require.Equal(t, []string{"mode", "withdrawals", "credits", "balance"}, caller.trace)
+	require.Equal(t, []rpcblock.Block{block, block, block, block}, caller.blocks)
+	require.Equal(t, []common.Address{creator, challenger}, caller.recipients)
+	require.Equal(t, faultTypes.NormalDistributionMode, game.BondDistributionMode)
+	require.Equal(t, common.Address{0xee}, game.WETHContract)
+	require.Equal(t, time.Hour, game.WETHDelay)
+	require.Equal(t, big.NewInt(150), game.ETHCollateral)
+	require.Zero(t, game.CreditWithdrawableAt)
+	require.Equal(t, big.NewInt(100), game.ExpectedCredits[challenger])
+	require.Zero(t, game.Credits[challenger].Sign())
+	require.Equal(t, big.NewInt(100), game.WithdrawalRequests[challenger].Amount)
+
+	credits[1].SetInt64(1)
+	withdrawals[1].Amount.SetInt64(2)
+	caller.balance.SetInt64(3)
+	require.Zero(t, game.Credits[challenger].Sign())
+	require.Equal(t, big.NewInt(100), game.WithdrawalRequests[challenger].Amount)
+	require.Equal(t, big.NewInt(150), game.ETHCollateral)
+}
+
+func TestZKBondSnapshotRejectsInvalidRPCDataAtomically(t *testing.T) {
+	testErr := errors.New("boom")
+	tests := []struct {
+		name      string
+		configure func(*bondSnapshotCaller)
+		wantErr   error
+	}{
+		{name: "mode error", configure: func(c *bondSnapshotCaller) { c.modeErr = testErr }, wantErr: testErr},
+		{name: "withdrawal error", configure: func(c *bondSnapshotCaller) { c.withdrawalsErr = testErr }, wantErr: testErr},
+		{name: "withdrawal count", configure: func(c *bondSnapshotCaller) { c.withdrawals = nil }, wantErr: ErrIncorrectWithdrawalsCount},
+		{name: "nil withdrawal", configure: func(c *bondSnapshotCaller) { c.withdrawals[0] = nil }, wantErr: ErrInvalidZKBondData},
+		{name: "nil withdrawal amount", configure: func(c *bondSnapshotCaller) { c.withdrawals[0].Amount = nil }, wantErr: ErrInvalidZKBondData},
+		{name: "nil withdrawal timestamp", configure: func(c *bondSnapshotCaller) { c.withdrawals[0].Timestamp = nil }, wantErr: ErrInvalidZKBondData},
+		{name: "negative withdrawal amount", configure: func(c *bondSnapshotCaller) { c.withdrawals[0].Amount = big.NewInt(-1) }, wantErr: ErrInvalidZKBondData},
+		{name: "negative withdrawal timestamp", configure: func(c *bondSnapshotCaller) { c.withdrawals[0].Timestamp = big.NewInt(-1) }, wantErr: ErrInvalidZKBondData},
+		{name: "overflowing withdrawal timestamp", configure: func(c *bondSnapshotCaller) {
+			c.withdrawals[0].Timestamp = new(big.Int).Lsh(big.NewInt(1), 64)
+		}, wantErr: ErrInvalidZKBondData},
+		{name: "credit error", configure: func(c *bondSnapshotCaller) { c.creditsErr = testErr }, wantErr: testErr},
+		{name: "credit count", configure: func(c *bondSnapshotCaller) { c.credits = nil }, wantErr: ErrIncorrectCreditCount},
+		{name: "nil credit", configure: func(c *bondSnapshotCaller) { c.credits[0] = nil }, wantErr: ErrInvalidZKBondData},
+		{name: "negative credit", configure: func(c *bondSnapshotCaller) { c.credits[0] = big.NewInt(-1) }, wantErr: ErrInvalidZKBondData},
+		{name: "balance error", configure: func(c *bondSnapshotCaller) { c.balanceErr = testErr }, wantErr: testErr},
+		{name: "nil balance", configure: func(c *bondSnapshotCaller) { c.balance = nil }, wantErr: ErrInvalidZKBondData},
+		{name: "negative balance", configure: func(c *bondSnapshotCaller) { c.balance = big.NewInt(-1) }, wantErr: ErrInvalidZKBondData},
+		{name: "negative delay", configure: func(c *bondSnapshotCaller) { c.delay = -time.Second }, wantErr: ErrInvalidZKBondData},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			caller := &bondSnapshotCaller{
+				withdrawals: []*contracts.WithdrawalRequest{{Amount: new(big.Int), Timestamp: new(big.Int)}},
+				credits:     []*big.Int{new(big.Int)},
+				balance:     big.NewInt(100),
+			}
+			test.configure(caller)
+			game := validZKBondGame(common.Address{0x10})
+			game.BondGameData = monTypes.BondGameData{ETHCollateral: big.NewInt(7)}
+
+			err := NewBondDataEnricher().EnrichZK(t.Context(), rpcblock.Latest, zkBondCaller(caller), game)
+			require.ErrorIs(t, err, test.wantErr)
+			require.Equal(t, monTypes.BondGameData{ETHCollateral: big.NewInt(7)}, game.BondGameData)
+		})
+	}
+}
+
+type zkBondSnapshotCaller struct {
+	*mockGameCaller
+	bond *bondSnapshotCaller
+}
+
+func zkBondCaller(bond *bondSnapshotCaller) *zkBondSnapshotCaller {
+	return &zkBondSnapshotCaller{mockGameCaller: &mockGameCaller{}, bond: bond}
+}
+
+func (c *zkBondSnapshotCaller) GetMetadata(context.Context, rpcblock.Block) (contracts.GenericGameMetadata, error) {
+	return contracts.GenericGameMetadata{}, nil
+}
+
+func (c *zkBondSnapshotCaller) GetChallengerMetadata(context.Context, rpcblock.Block) (contracts.ChallengerMetadata, error) {
+	return contracts.ChallengerMetadata{}, nil
+}
+
+func (c *zkBondSnapshotCaller) GetBondMetadata(context.Context, rpcblock.Block) (contracts.ZKBondMetadata, error) {
+	return contracts.ZKBondMetadata{}, nil
+}
+
+func (c *zkBondSnapshotCaller) GetWithdrawals(ctx context.Context, block rpcblock.Block, recipients ...common.Address) ([]*contracts.WithdrawalRequest, error) {
+	return c.bond.GetWithdrawals(ctx, block, recipients...)
+}
+
+func (c *zkBondSnapshotCaller) GetCredits(ctx context.Context, block rpcblock.Block, recipients ...common.Address) ([]*big.Int, error) {
+	return c.bond.GetCredits(ctx, block, recipients...)
+}
+
+func (c *zkBondSnapshotCaller) GetBondDistributionMode(ctx context.Context, block rpcblock.Block) (faultTypes.BondDistributionMode, error) {
+	return c.bond.GetBondDistributionMode(ctx, block)
+}
+
+func (c *zkBondSnapshotCaller) GetBalanceAndDelay(ctx context.Context, block rpcblock.Block) (*big.Int, time.Duration, common.Address, error) {
+	return c.bond.GetBalanceAndDelay(ctx, block)
+}
+
+func validZKBondGame(creator common.Address) *monTypes.ZKGameData {
+	return &monTypes.ZKGameData{
+		CommonGameData: monTypes.CommonGameData{Status: gameTypes.GameStatusInProgress},
+		ProposalStatus: contracts.ProposalStatusUnchallenged,
+		GameCreator:    creator,
+		TotalBonds:     big.NewInt(100),
+		ChallengerBond: big.NewInt(30),
+	}
+}

--- a/op-dispute-mon/mon/extract/zk_extractor_test.go
+++ b/op-dispute-mon/mon/extract/zk_extractor_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"math"
+	"math/big"
 	"testing"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -34,9 +36,14 @@ func TestExtractorZKSnapshotValidation(t *testing.T) {
 		require.Equal(t, caller.anchorStateRegistry, zk.AnchorStateRegistry)
 		require.Equal(t, uint32(math.MaxUint32), zk.ParentIndex)
 		require.Nil(t, zk.ParentStatus)
-		require.Equal(t, []string{"metadata", "l1-head", "agreement", "challenger", "anchor"}, *trace)
+		require.Equal(t, caller.bondMetadata.GameCreator, zk.GameCreator)
+		require.Equal(t, caller.bondMetadata.TotalBonds, zk.TotalBonds)
+		caller.bondMetadata.TotalBonds.SetInt64(1)
+		require.Equal(t, big.NewInt(100), zk.TotalBonds)
+		require.Equal(t, []string{"metadata", "l1-head", "agreement", "challenger", "anchor", "bond-metadata", "mode", "withdrawals", "credits", "balance"}, *trace)
 		require.Equal(t, []rpcblock.Block{
-			rpcblock.ByHash(blockHash), rpcblock.ByHash(blockHash), rpcblock.ByHash(blockHash),
+			rpcblock.ByHash(blockHash), rpcblock.ByHash(blockHash), rpcblock.ByHash(blockHash), rpcblock.ByHash(blockHash),
+			rpcblock.ByHash(blockHash), rpcblock.ByHash(blockHash), rpcblock.ByHash(blockHash), rpcblock.ByHash(blockHash),
 		}, caller.blocks)
 	})
 
@@ -58,7 +65,7 @@ func TestExtractorZKSnapshotValidation(t *testing.T) {
 		require.Equal(t, gameTypes.GameStatusDefenderWon, *zk.ParentStatus)
 		require.Zero(t, requestedIndex)
 		require.Equal(t, rpcblock.ByHash(blockHash), requestedBlock)
-		require.Equal(t, []string{"metadata", "l1-head", "agreement", "challenger", "anchor", "parent"}, *trace)
+		require.Equal(t, []string{"metadata", "l1-head", "agreement", "challenger", "anchor", "parent", "bond-metadata", "mode", "withdrawals", "credits", "balance"}, *trace)
 	})
 
 	tests := []struct {
@@ -75,6 +82,7 @@ func TestExtractorZKSnapshotValidation(t *testing.T) {
 		{name: "invalid participants", configure: func(c *testZKCaller) { c.challenger.Challenger = common.Address{0x01} }, wantErr: "invalid ZK participants"},
 		{name: "anchor read", configure: func(c *testZKCaller) { c.anchorErr = errors.New("anchor unavailable") }, wantErr: "failed to fetch ZK anchor state registry"},
 		{name: "zero anchor", configure: func(c *testZKCaller) { c.anchorStateRegistry = common.Address{} }, wantErr: "anchor state registry is zero"},
+		{name: "bond metadata read", configure: func(c *testZKCaller) { c.bondMetadataErr = errors.New("bonds unavailable") }, wantErr: "failed to fetch ZK bond metadata"},
 		{
 			name: "parent read",
 			configure: func(c *testZKCaller) {
@@ -127,6 +135,7 @@ func TestExtractorRejectsZKCallerWithoutCapabilities(t *testing.T) {
 		nil,
 		nil,
 		&testZKAgreement{},
+		nil,
 	)
 
 	game, err := extractor.enrichGame(t.Context(), common.Hash{0xaa}, zkMetadata())
@@ -155,6 +164,7 @@ func TestExtractorZKLagAndCache(t *testing.T) {
 	require.Zero(t, ignored)
 	require.Zero(t, failed)
 	require.Equal(t, []string{"metadata", "l1-head", "agreement"}, *trace)
+	require.Zero(t, caller.bondMetadataCalls)
 
 	*trace = nil
 	agreement.err = nil
@@ -169,6 +179,7 @@ func TestExtractorZKLagAndCache(t *testing.T) {
 	snapshot := games[0]
 	original := snapshot.(*monTypes.ZKGameData)
 	originalExpectedRoot := original.ExpectedRootClaim
+	require.Equal(t, 1, caller.bondMetadataCalls)
 
 	*trace = nil
 	agreement.action = func(game *monTypes.ZKGameData) {
@@ -185,7 +196,19 @@ func TestExtractorZKLagAndCache(t *testing.T) {
 	require.Equal(t, originalExpectedRoot, original.ExpectedRootClaim)
 	require.Zero(t, original.NodeEndpointOutOfSyncCount)
 	require.Equal(t, []string{"metadata", "l1-head", "agreement", "challenger", "anchor"}, *trace)
+	require.Equal(t, 1, caller.bondMetadataCalls)
 	caller.anchorErr = nil
+
+	*trace = nil
+	caller.balanceErr = errors.New("balance unavailable")
+	games, _, failed, err = extractor.Extract(t.Context(), common.Hash{0xbd}, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, failed)
+	require.Same(t, snapshot, games[0])
+	require.Equal(t, big.NewInt(100), original.ETHCollateral)
+	require.Equal(t, []string{"metadata", "l1-head", "agreement", "challenger", "anchor", "bond-metadata", "mode", "withdrawals", "credits", "balance"}, *trace)
+	require.Equal(t, 2, caller.bondMetadataCalls)
+	caller.balanceErr = nil
 
 	*trace = nil
 	agreement.err = gameTypes.ErrNotInSync
@@ -197,6 +220,7 @@ func TestExtractorZKLagAndCache(t *testing.T) {
 	require.NotSame(t, snapshot, lagSnapshot)
 	require.Equal(t, snapshot, lagSnapshot)
 	require.Equal(t, []string{"metadata", "l1-head", "agreement"}, *trace)
+	require.Equal(t, 2, caller.bondMetadataCalls)
 
 	*trace = nil
 	agreement.err = errors.New("root source unavailable")
@@ -339,10 +363,15 @@ func TestValidateZKParticipants(t *testing.T) {
 type testZKCaller struct {
 	metadata            contracts.GenericGameMetadata
 	challenger          contracts.ChallengerMetadata
+	bondMetadata        contracts.ZKBondMetadata
+	bondMetadataErr     error
 	anchorStateRegistry common.Address
 	anchorErr           error
 	trace               *[]string
 	blocks              []rpcblock.Block
+	bondRecipients      []common.Address
+	bondMetadataCalls   int
+	balanceErr          error
 }
 
 func validZKCaller() *testZKCaller {
@@ -361,6 +390,11 @@ func validZKCaller() *testZKCaller {
 			Deadline:         time.Unix(5678, 0),
 		},
 		anchorStateRegistry: common.Address{0xab},
+		bondMetadata: contracts.ZKBondMetadata{
+			GameCreator:    common.Address{0xc1},
+			TotalBonds:     big.NewInt(100),
+			ChallengerBond: big.NewInt(30),
+		},
 	}
 }
 
@@ -380,6 +414,47 @@ func (c *testZKCaller) GetAnchorStateRegistry(_ context.Context, block rpcblock.
 	*c.trace = append(*c.trace, "anchor")
 	c.blocks = append(c.blocks, block)
 	return c.anchorStateRegistry, c.anchorErr
+}
+
+func (c *testZKCaller) GetBondMetadata(_ context.Context, block rpcblock.Block) (contracts.ZKBondMetadata, error) {
+	*c.trace = append(*c.trace, "bond-metadata")
+	c.blocks = append(c.blocks, block)
+	c.bondMetadataCalls++
+	return c.bondMetadata, c.bondMetadataErr
+}
+
+func (c *testZKCaller) GetBondDistributionMode(_ context.Context, block rpcblock.Block) (faultTypes.BondDistributionMode, error) {
+	*c.trace = append(*c.trace, "mode")
+	c.blocks = append(c.blocks, block)
+	return faultTypes.UndecidedDistributionMode, nil
+}
+
+func (c *testZKCaller) GetWithdrawals(_ context.Context, block rpcblock.Block, recipients ...common.Address) ([]*contracts.WithdrawalRequest, error) {
+	*c.trace = append(*c.trace, "withdrawals")
+	c.blocks = append(c.blocks, block)
+	c.bondRecipients = append([]common.Address(nil), recipients...)
+	result := make([]*contracts.WithdrawalRequest, len(recipients))
+	for i := range result {
+		result[i] = &contracts.WithdrawalRequest{Amount: new(big.Int), Timestamp: new(big.Int)}
+	}
+	return result, nil
+}
+
+func (c *testZKCaller) GetCredits(_ context.Context, block rpcblock.Block, recipients ...common.Address) ([]*big.Int, error) {
+	*c.trace = append(*c.trace, "credits")
+	c.blocks = append(c.blocks, block)
+	requireSameRecipients(c.bondRecipients, recipients)
+	result := make([]*big.Int, len(recipients))
+	for i := range result {
+		result[i] = new(big.Int)
+	}
+	return result, nil
+}
+
+func (c *testZKCaller) GetBalanceAndDelay(_ context.Context, block rpcblock.Block) (*big.Int, time.Duration, common.Address, error) {
+	*c.trace = append(*c.trace, "balance")
+	c.blocks = append(c.blocks, block)
+	return big.NewInt(100), time.Hour, common.Address{0xdd}, c.balanceErr
 }
 
 type testZKAgreement struct {
@@ -442,6 +517,7 @@ func newZKExtractor(t *testing.T, caller *testZKCaller, parent ParentGameStatusF
 		[]CommonEnricher{&testCommonEnricher{trace: trace}},
 		nil,
 		agreement,
+		NewBondDataEnricher(),
 	), trace
 }
 

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -101,7 +101,7 @@ func TestMonitorRoutesGamesToResolution(t *testing.T) {
 	require.NoError(t, monitor.monitorGames())
 	require.Equal(t, []*monTypes.CommonGameData{terminal.Common(), super.Common(), zk.Common()}, commonReceived)
 	require.Equal(t, []*monTypes.FaultGameData{terminal}, faultReceived)
-	require.Equal(t, []monTypes.BondedGame{terminal}, bondReceived)
+	require.Equal(t, []monTypes.BondedGame{terminal, zk}, bondReceived)
 }
 
 func TestPartitionGamesRejectsUnknownGameType(t *testing.T) {

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -232,6 +232,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 	headBlockFetcher := func(ctx context.Context) (eth.L1BlockRef, error) {
 		return s.l1Client.L1BlockRefByLabel(ctx, "latest")
 	}
+	bondEnricher := extract.NewBondDataEnricher()
 	extractor := extract.NewExtractor(
 		s.logger,
 		s.cl,
@@ -241,8 +242,9 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		cfg.IgnoredGames,
 		cfg.MaxConcurrency,
 		s.commonEnrichers(),
-		s.faultEnrichers(),
+		s.faultEnrichers(bondEnricher),
 		extract.NewZKAgreementEnricher(s.logger, s.metrics, s.asSuperRootProviders(), clock.SystemClock),
+		bondEnricher,
 	)
 	forecast := NewForecast(s.logger, s.metrics)
 	bonds := bonds.NewBonds(s.logger, s.metrics, s.cl, s.honestActors)
@@ -295,10 +297,10 @@ func (s *Service) commonEnrichers() []extract.CommonEnricher {
 	}
 }
 
-func (s *Service) faultEnrichers() []extract.FaultEnricher {
+func (s *Service) faultEnrichers(bondEnricher *extract.BondDataEnricher) []extract.FaultEnricher {
 	return []extract.FaultEnricher{
 		extract.NewClaimEnricher(),
-		extract.NewBondDataEnricher(),
+		bondEnricher,
 	}
 }
 

--- a/op-dispute-mon/mon/service_test.go
+++ b/op-dispute-mon/mon/service_test.go
@@ -59,7 +59,7 @@ func TestInitMonitorWiresEveryTypedLane(t *testing.T) {
 	require.Equal(t, []string{
 		"*extract.ClaimEnricher",
 		"*extract.BondDataEnricher",
-	}, registeredTypeNames(service.faultEnrichers()))
+	}, registeredTypeNames(service.faultEnrichers(extract.NewBondDataEnricher())))
 
 	service.initMonitor(ctx, &cfg)
 	require.NotNil(t, service.monitor)

--- a/op-dispute-mon/mon/types/honest_actors.go
+++ b/op-dispute-mon/mon/types/honest_actors.go
@@ -7,6 +7,9 @@ type HonestActors map[common.Address]bool // Map for efficient lookup
 func NewHonestActors(honestActors []common.Address) HonestActors {
 	actors := make(map[common.Address]bool)
 	for _, actor := range honestActors {
+		if actor == (common.Address{}) {
+			continue
+		}
 		actors[actor] = true
 	}
 	return actors

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -50,7 +50,8 @@ type BondRecord struct {
 	Amount    *big.Int
 	Resolved  bool
 	// Forfeited reports whether normalized accounting counts Amount as lost by Depositor and won by Recipient.
-	Forfeited      bool
+	Forfeited bool
+	// ChallengerBond reports whether this record represents a ZK game's challenger bond.
 	ChallengerBond bool
 }
 

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -50,7 +50,8 @@ type BondRecord struct {
 	Amount    *big.Int
 	Resolved  bool
 	// Forfeited reports whether normalized accounting counts Amount as lost by Depositor and won by Recipient.
-	Forfeited bool
+	Forfeited      bool
+	ChallengerBond bool
 }
 
 // BondGameData contains normalized bond and DelayedWETH state.
@@ -170,11 +171,17 @@ type FaultGameData struct {
 // ZKGameData contains proposal and parent state for a ZK dispute game.
 type ZKGameData struct {
 	CommonGameData
+	BondGameData
 
 	ParentIndex    uint32
 	ParentStatus   *types.GameStatus
 	ProposalStatus contracts.ProposalStatus
 	Deadline       time.Time
+	GameCreator    common.Address
+	Challenger     common.Address
+	Prover         common.Address
+	TotalBonds     *big.Int
+	ChallengerBond *big.Int
 }
 
 // SuperPermissionedGameData is the common snapshot of a SuperPermissioned game.
@@ -191,9 +198,14 @@ func (*ZKGameData) enrichedGame()                {}
 func (*SuperPermissionedGameData) enrichedGame() {}
 
 func (g *FaultGameData) BondData() *BondGameData { return &g.BondGameData }
+func (g *ZKGameData) BondData() *BondGameData    { return &g.BondGameData }
 func (*FaultGameData) bondedGame()               {}
+func (*ZKGameData) bondedGame()                  {}
 
-var _ BondedGame = (*FaultGameData)(nil)
+var (
+	_ BondedGame = (*FaultGameData)(nil)
+	_ BondedGame = (*ZKGameData)(nil)
+)
 
 // UsesOutputRoots returns true if the game type is one of the known types that use output roots as proposals.
 func (g CommonGameData) UsesOutputRoots() bool {

--- a/op-dispute-mon/mon/types/types_test.go
+++ b/op-dispute-mon/mon/types/types_test.go
@@ -32,6 +32,12 @@ func TestBondGameDataRecipientAddresses(t *testing.T) {
 	}, data.RecipientAddresses())
 }
 
+func TestNewHonestActorsIgnoresZeroAddress(t *testing.T) {
+	actor := common.Address{0x01}
+	honest := NewHonestActors([]common.Address{{}, actor})
+	require.Equal(t, HonestActors{actor: true}, honest)
+}
+
 func TestCommonGameData_UsesOutputRoots(t *testing.T) {
 	for _, gameType := range outputRootGameTypes {
 		gameType := gameType

--- a/op-dispute-mon/mon/withdrawals.go
+++ b/op-dispute-mon/mon/withdrawals.go
@@ -55,6 +55,9 @@ func (w *WithdrawalMonitor) CheckWithdrawals(games []types.BondedGame) {
 }
 
 func (w *WithdrawalMonitor) validateGameWithdrawals(game types.BondedGame, now time.Time, honestWithdrawableAmounts map[common.Address]*big.Int) (int, int) {
+	if _, ok := game.(*types.ZKGameData); ok {
+		return w.validateZKGameWithdrawals(game, now, honestWithdrawableAmounts)
+	}
 	matching := 0
 	divergent := 0
 	data := game.BondData()
@@ -103,6 +106,54 @@ func (w *WithdrawalMonitor) validateGameWithdrawals(game types.BondedGame, now t
 				honestWithdrawableAmounts[recipient] = total
 				w.logger.Warn("Found unclaimed credit", "recipient", recipient, "game", game.Common().Proxy, "amount", withdrawalAmount.Amount)
 			}
+		}
+	}
+	return matching, divergent
+}
+
+func (w *WithdrawalMonitor) validateZKGameWithdrawals(game types.BondedGame, now time.Time, honestWithdrawableAmounts map[common.Address]*big.Int) (int, int) {
+	matching := 0
+	divergent := 0
+	data := game.BondData()
+	for recipient, request := range data.WithdrawalRequests {
+		credit := data.Credits[recipient]
+		if credit == nil {
+			credit = new(big.Int)
+		}
+		expected := data.ExpectedCredits[recipient]
+		if expected == nil {
+			expected = new(big.Int)
+		}
+		mature := request.Timestamp.Sign() > 0 && !now.Before(time.Unix(request.Timestamp.Int64(), 0).Add(data.WETHDelay))
+		switch data.BondDistributionMode {
+		case challengerTypes.UndecidedDistributionMode:
+			if request.Amount.Sign() > 0 || request.Timestamp.Sign() > 0 {
+				divergent++
+				w.logger.Error("Withdrawal request created before bond distribution mode set", "game", game.Common().Proxy, "recipient", recipient, "withdrawal", request.Amount)
+			}
+		case challengerTypes.NormalDistributionMode, challengerTypes.RefundDistributionMode:
+			observed := credit
+			if request.Amount.Cmp(observed) > 0 {
+				observed = request.Amount
+			}
+			uninitiated := request.Amount.Sign() == 0 && request.Timestamp.Sign() == 0
+			completed := request.Amount.Sign() == 0 && credit.Sign() == 0 && mature
+			pending := request.Amount.Sign() > 0 && request.Timestamp.Sign() > 0 && credit.Sign() == 0 && observed.Cmp(expected) == 0
+			if uninitiated || completed || pending {
+				matching++
+			} else {
+				divergent++
+				w.logger.Error("ZK withdrawal state does not match expected credit", "game", game.Common().Proxy, "recipient", recipient, "expected", expected, "credit", credit, "withdrawal", request.Amount)
+			}
+		default:
+			divergent++
+			w.logger.Error("Unsupported distribution mode", "game", game.Common().Proxy, "recipient", recipient, "mode", data.BondDistributionMode)
+		}
+
+		if w.honestActors.Contains(recipient) && request.Amount.Sign() > 0 && mature {
+			total := honestWithdrawableAmounts[recipient]
+			honestWithdrawableAmounts[recipient] = new(big.Int).Add(total, request.Amount)
+			w.logger.Warn("Found unclaimed credit", "recipient", recipient, "game", game.Common().Proxy, "amount", request.Amount)
 		}
 	}
 	return matching, divergent

--- a/op-dispute-mon/mon/withdrawals_test.go
+++ b/op-dispute-mon/mon/withdrawals_test.go
@@ -237,6 +237,97 @@ func TestWithdrawalNotInitiated(t *testing.T) {
 		"Expected %v withdrawable to be %v but was %v", honestActor1, 3, metrics.honestWithdrawable[honestActor1])
 }
 
+func TestZKWithdrawalMaturityIsInclusive(t *testing.T) {
+	honest := common.Address{0x01}
+	maturity := int64(110)
+	tests := []struct {
+		name string
+		now  int64
+		want int64
+	}{
+		{name: "T-1", now: maturity - 1},
+		{name: "T", now: maturity, want: 10},
+		{name: "T+1", now: maturity + 1, want: 10},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metrics := &stubWithdrawalsMetrics{matching: make(map[common.Address]int), divergent: make(map[common.Address]int)}
+			monitor := NewWithdrawalMonitor(
+				testlog.Logger(t, log.LvlInfo),
+				clock.NewDeterministicClock(time.Unix(test.now, 0)),
+				metrics,
+				monTypes.NewHonestActors([]common.Address{honest}),
+			)
+			game := &monTypes.ZKGameData{BondGameData: monTypes.BondGameData{
+				ExpectedCredits: map[common.Address]*big.Int{honest: big.NewInt(10)},
+				Credits:         map[common.Address]*big.Int{honest: new(big.Int)},
+				WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{
+					honest: {Amount: big.NewInt(10), Timestamp: big.NewInt(100)},
+				},
+				BondDistributionMode: faultTypes.NormalDistributionMode,
+				WETHContract:         weth1,
+				WETHDelay:            10 * time.Second,
+				ETHCollateral:        big.NewInt(10),
+			}}
+
+			monitor.CheckWithdrawals([]monTypes.BondedGame{game})
+			require.Equal(t, 1, metrics.matching[weth1])
+			require.Zero(t, metrics.divergent[weth1])
+			require.Equal(t, big.NewInt(test.want), metrics.honestWithdrawable[honest])
+		})
+	}
+}
+
+func TestZKCreditWithoutRequestIsNotWithdrawable(t *testing.T) {
+	honest := common.Address{0x01}
+	metrics := &stubWithdrawalsMetrics{matching: make(map[common.Address]int), divergent: make(map[common.Address]int)}
+	monitor := NewWithdrawalMonitor(
+		testlog.Logger(t, log.LvlInfo),
+		clock.NewDeterministicClock(time.Unix(1000, 0)),
+		metrics,
+		monTypes.NewHonestActors([]common.Address{honest}),
+	)
+	game := &monTypes.ZKGameData{BondGameData: monTypes.BondGameData{
+		ExpectedCredits: map[common.Address]*big.Int{honest: big.NewInt(10)},
+		Credits:         map[common.Address]*big.Int{honest: big.NewInt(10)},
+		WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{
+			honest: {Amount: new(big.Int), Timestamp: new(big.Int)},
+		},
+		BondDistributionMode: faultTypes.NormalDistributionMode,
+		WETHContract:         weth1,
+		WETHDelay:            10 * time.Second,
+		ETHCollateral:        big.NewInt(10),
+	}}
+
+	monitor.CheckWithdrawals([]monTypes.BondedGame{game})
+	require.Equal(t, 1, metrics.matching[weth1])
+	require.Zero(t, metrics.honestWithdrawable[honest].Sign())
+}
+
+func TestFaultWithdrawalMaturityRemainsExclusive(t *testing.T) {
+	honest := common.Address{0x01}
+	metrics := &stubWithdrawalsMetrics{matching: make(map[common.Address]int), divergent: make(map[common.Address]int)}
+	monitor := NewWithdrawalMonitor(
+		testlog.Logger(t, log.LvlInfo),
+		clock.NewDeterministicClock(time.Unix(110, 0)),
+		metrics,
+		monTypes.NewHonestActors([]common.Address{honest}),
+	)
+	game := &monTypes.FaultGameData{BondGameData: monTypes.BondGameData{
+		Credits: map[common.Address]*big.Int{honest: big.NewInt(10)},
+		WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{
+			honest: {Amount: big.NewInt(10), Timestamp: big.NewInt(100)},
+		},
+		BondDistributionMode: faultTypes.NormalDistributionMode,
+		WETHContract:         weth1,
+		WETHDelay:            10 * time.Second,
+		ETHCollateral:        big.NewInt(10),
+	}}
+
+	monitor.CheckWithdrawals([]monTypes.BondedGame{game})
+	require.Zero(t, metrics.honestWithdrawable[honest].Sign())
+}
+
 func asBondedGames(games []*monTypes.FaultGameData) []monTypes.BondedGame {
 	result := make([]monTypes.BondedGame, len(games))
 	for i, game := range games {


### PR DESCRIPTION
## Claim

Normalize ZK bond outcomes exactly as `ZKDisputeGame.sol` records them and route complete ZK snapshots through every bond consumer without changing valid Fault accounting output.

## Stack status and dependency

PR 4 of 5. Base: `develop`; follows merged #22227. Merged: #22225 → #22226 → #22227. Open: #22228 → #22229.

This remains production-inert until PR 5 enables ZK caller creation. The rebase inherits #22226's review follow-up.

## Commits and reading order

1. `f8eb44b75c` adds pinned ZK bond, credit, withdrawal, WETH, balance, and delay reads.
2. `5bb0b75d95` validates and normalizes the contract outcome table, then routes ZK through the bond lane.
3. `660ab4c449` rejects withdrawal delays that overflow `time.Duration`.
4. `c7dec8c609` applies the #22226 deadline-review feedback to ZK by covering the normal post-deadline state.
5. `85cad67d08` reuses the shared DelayedWETH withdrawal reader and validates shared result cardinality.
6. `c9f274cf89` reuses the shared DelayedWETH balance/delay reader while preserving safe duration conversion.
7. `b38f79a574` documents the ZK-specific challenger-bond marker.

## Review focus

- The pinned read and result-count validation establishes the inputs to the normalization table.
- Self-challenge, invalid-parent burn, refund mode, overlapping roles, and unchallenged `TotalBonds < ChallengerBond` each map directly to a Solidity outcome path.
- Shared-WETH obligations include ZK, ZK maturity is inclusive at equality and remains mature afterward, and valid Fault accounting remains unchanged.
- Commit 4 is a one-line test-only review follow-up.

## Intentional behavior changes

- Configured address zero is excluded from honest-actor metrics, so an invalid-parent burn cannot appear as an honest win.
- ZK withdrawal maturity follows the contract's inclusive boundary; Fault retains its existing exclusive boundary.
- Shared DelayedWETH reads now reject malformed result counts and delays that cannot fit in `time.Duration` for both Fault and ZK callers.

## Tests

- `mise exec -- go test ./op-challenger/game/fault/contracts/... ./op-dispute-mon/... -count=1`
- `mise exec -- go test -race ./op-dispute-mon/mon/extract -run '^(TestExtractorZK|TestZKAgreement|TestZKBond)' -count=1`
- `mise exec -- just lint-go`






