### PR TITLE
op-acceptance-tests: use NewMinimalNoFaultProofs in interop smoke tests

### DIFF
--- a/op-acceptance-tests/tests/interop/smoke/interop_smoke_test.go
+++ b/op-acceptance-tests/tests/interop/smoke/interop_smoke_test.go
@@ -14,13 +14,13 @@ import (
 
 func TestInteropSystemNoop(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	_ = presets.NewMinimal(t)
+	_ = presets.NewMinimalNoFaultProofs(t)
 	t.Log("noop")
 }
 
 func TestSmokeTest(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewMinimal(t)
+	sys := presets.NewMinimalNoFaultProofs(t)
 	require := t.Require()
 	ctx := t.Ctx()
 
@@ -55,7 +55,7 @@ func TestSmokeTest(gt *testing.T) {
 
 func TestSmokeTestFailure(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewMinimal(t)
+	sys := presets.NewMinimalNoFaultProofs(t)
 	require := t.Require()
 	ctx := t.Ctx()
 

--- a/op-acceptance-tests/tests/interop/smoke/smoke_test.go
+++ b/op-acceptance-tests/tests/interop/smoke/smoke_test.go
@@ -20,7 +20,7 @@ import (
 func TestWrapETH(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	require := t.Require()
-	sys := presets.NewMinimal(t)
+	sys := presets.NewMinimalNoFaultProofs(t)
 
 	// alice and bob are funded with 0.1 ETH
 	alice := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)


### PR DESCRIPTION
## What

Switches the four `op-acceptance-tests/tests/interop/smoke` tests from `presets.NewMinimal` to `presets.NewMinimalNoFaultProofs`.

## Why

These tests only exercise the sequencer + EL surface — WETH transfers, funding, and EOA balances. None of them construct a dispute game: no call to `DisputeGameFactory()`, `AnchorStateRegistry()`, or `AdvanceTime()`. `TestInteropSystemNoop` doesn't use the returned system at all.

`NewMinimal` nonetheless starts a proposer and challenger (`StartChallenger: true` in the minimal runtime), so the whole package requires a cannon prestate to run — the challenger's config `Check()` fails with `cannon: missing bin` on any executor that hasn't built the artifact. That's a real cost for a noop test, and it blocks running these tests in environments that deliberately don't build proof artifacts.

`NewMinimalNoFaultProofs` already exists for exactly this shape:

> a Minimal preset that skips the proposer and challenger … intended for tests that only exercise the sequencer + batcher + derivation loop … Skipping the challenger avoids requiring cannon prestate artifacts, which are expensive to build locally.

## Scope

Behavior-preserving. The returned `*Minimal` is the same type; the tests touch only sequencer-surface methods, none of which depend on the proposer or challenger. `DisputeGameFactory()` would be unusable under the no-fault-proofs preset (its `challengerConfig` is nil), but none of these tests call it.

`go vet ./op-acceptance-tests/tests/interop/smoke/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)