### PR TITLE
op-acceptance-tests: exercise EL backfill sync with ban-sensitive peering

### DIFF
--- a/op-acceptance-tests/tests/depreqres/common/common.go
+++ b/op-acceptance-tests/tests/depreqres/common/common.go
@@ -164,6 +164,67 @@ func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, adv
 	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 30)
 }
 
+// UnsafeChainNotStalling_Backfill drives the verifier EL through backfill
+// (staged pipeline) sync: the unsafe gap accumulated while the CL P2P link is
+// severed exceeds the EL's backfill threshold (32 blocks in reth), so the gap
+// is filled by the sync pipeline downloading from EL peers, rather than by
+// live sync as in UnsafeChainNotStalling_Disconnect. The EL peering is
+// deliberately basic (not trusted) so peer-management regressions around
+// backfill — reputation bans, disconnects, eviction — fail the test instead
+// of being masked by trusted-peer exemptions.
+func UnsafeChainNotStalling_Backfill(gt *testing.T, syncMode sync.Mode, advanceBlocks uint64, opts ...presets.Option) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithoutP2PWithoutCheck(t, opts...)
+	require := t.Require()
+	l := t.Logger().With("syncmode", syncMode)
+
+	l.Info("Peer the EL nodes (basic, ban-sensitive) and the CL nodes")
+	sys.L2EL.PeerWithBasic(sys.L2ELB)
+	sys.L2CLB.ConnectPeer(sys.L2CL)
+	sys.L2CL.ConnectPeer(sys.L2CLB)
+
+	l.Info("Confirm that the CL nodes are progressing the unsafe chain")
+	target := uint64(3)
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(safety.LocalUnsafe, target, 30),
+		sys.L2CLB.AdvancedFn(safety.LocalUnsafe, target, 30),
+	)
+
+	l.Info("Disconnect L2CL from L2CLB, and vice versa")
+	sys.L2CLB.DisconnectPeer(sys.L2CL)
+	sys.L2CL.DisconnectPeer(sys.L2CLB)
+
+	sys.L2CLB.WaitForPeerDisconnected(sys.L2CL)
+	sys.L2CL.WaitForPeerDisconnected(sys.L2CLB)
+
+	sys.L2CLB.WaitForStall(safety.LocalUnsafe)
+	ssB_before := sys.L2CLB.SyncStatus()
+
+	l.Info("L2CLB stalled", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())
+
+	l.Info("Wait for sequencer to advance past the EL backfill threshold while verifier is disconnected", "advanceBlocks", advanceBlocks)
+	advanceAttempts := int(advanceBlocks*2 + 30)
+	sys.L2CL.Advanced(safety.LocalUnsafe, advanceBlocks, advanceAttempts)
+
+	require.Equal(sys.L2CLB.SyncStatus().UnsafeL2.Number, ssB_before.UnsafeL2.Number, "unsafe chain for L2CLB should have stalled")
+
+	l.Info("Confirm the EL peering survived the stall")
+	sys.L2EL.VerifyPeeredWith(sys.L2ELB)
+
+	l.Info("Re-connect L2CL to L2CLB")
+	sys.L2CLB.ConnectPeer(sys.L2CL)
+	sys.L2CL.ConnectPeer(sys.L2CLB)
+
+	ssA_after := sys.L2CL.SyncStatus()
+	l.Info("Confirm that L2CLB fills the unsafe gap via EL sync", "target", ssA_after.UnsafeL2.ID())
+	sys.L2CLB.Reached(safety.LocalUnsafe, ssA_after.UnsafeL2.Number, 60)
+	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 60)
+
+	l.Info("Confirm the EL peering survived the backfill")
+	sys.L2EL.VerifyPeeredWith(sys.L2ELB)
+	sys.L2ELB.VerifyPeeredWith(sys.L2EL)
+}
+
 func logPeerState(l log.Logger, name string, cl *dsl.L2CLNode) {
 	peers := cl.Peers()
 	l.Info("Peer state",

--- a/op-acceptance-tests/tests/depreqres/reqressyncdisabled/elsync/elsync_test.go
+++ b/op-acceptance-tests/tests/depreqres/reqressyncdisabled/elsync/elsync_test.go
@@ -14,3 +14,7 @@ func TestUnsafeChainNotStalling_ELSync(gt *testing.T) {
 func TestUnsafeChainNotStalling_ELSync_RestartOpNode(gt *testing.T) {
 	common.UnsafeChainNotStalling_RestartOpNode(gt, sync.ELSync, 20, common.ReqRespSyncDisabledOpts(sync.ELSync)...)
 }
+
+func TestUnsafeChainNotStalling_ELSync_Backfill(gt *testing.T) {
+	common.UnsafeChainNotStalling_Backfill(gt, sync.ELSync, 64, common.ReqRespSyncDisabledOpts(sync.ELSync)...)
+}

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -470,6 +470,20 @@ func (el *L2ELNode) PeerWith(peer *L2ELNode) {
 	sysgo.ConnectP2P(el.ctx, el.require, el.inner.L2EthClient().RPC(), peer.inner.L2EthClient().RPC())
 }
 
+// PeerWithBasic connects el to peer without trusted-peer registration: the
+// session stays subject to normal reputation penalties, bans, and eviction.
+// Use it when the test observes peer-management behavior itself; PeerWith
+// exempts the session from exactly that.
+func (el *L2ELNode) PeerWithBasic(peer *L2ELNode) {
+	sysgo.ConnectP2PBasic(el.ctx, el.require, el.inner.L2EthClient().RPC(), peer.inner.L2EthClient().RPC())
+}
+
+// VerifyPeeredWith waits until peer is present in el's active peer list,
+// failing the test if it does not appear within the bounded wait.
+func (el *L2ELNode) VerifyPeeredWith(peer *L2ELNode) {
+	sysgo.WaitP2PConnected(el.require, el.inner.L2EthClient().RPC(), peer.inner.L2EthClient().RPC())
+}
+
 func (el *L2ELNode) DisconnectPeerWith(peer *L2ELNode) {
 	sysgo.DisconnectP2P(el.ctx, el.require, el.inner.L2EthClient().RPC(), peer.inner.L2EthClient().RPC())
 }

--- a/op-devstack/sysgo/l2_el_p2p_util.go
+++ b/op-devstack/sysgo/l2_el_p2p_util.go
@@ -60,15 +60,49 @@ func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcC
 		return
 	}
 
+	require.NoError(waitForPeerConnected(initiator, expectedID), "The peer was not connected")
+}
+
+// ConnectP2PBasic creates a p2p peer connection between initiator and acceptor
+// without registering the peering as trusted on either side. The initiator
+// records the peer as a static entry (re-dialed after benign session drops),
+// but the session remains subject to reputation penalties, bans, and eviction
+// like any discovered peer. Use this instead of ConnectP2P when a test must
+// observe peer-management behavior that trusted peering would mask.
+func ConnectP2PBasic(ctx context.Context, require *testreq.Assertions, initiator RpcCaller, acceptor RpcCaller) {
+	var targetInfo p2p.NodeInfo
+	require.NoError(acceptor.CallContext(ctx, &targetInfo, "admin_nodeInfo"), "get node info")
+	targetNode, err := enode.ParseV4(targetInfo.Enode)
+	require.NoError(err, "failed to parse target node")
+
+	var peerAdded bool
+	require.NoError(initiator.CallContext(ctx, &peerAdded, "admin_addPeer", targetInfo.Enode), "add peer")
+	require.True(peerAdded, "should have added peer successfully")
+
+	require.NoError(waitForPeerConnected(initiator, targetNode.ID().String()), "The peer was not connected")
+}
+
+// WaitP2PConnected waits until acceptor appears in initiator's active peer
+// list, and errors if it does not within the polling budget.
+func WaitP2PConnected(require *testreq.Assertions, initiator RpcCaller, acceptor RpcCaller) {
+	var targetInfo p2p.NodeInfo
+	require.NoError(acceptor.CallContext(context.Background(), &targetInfo, "admin_nodeInfo"), "get node info")
+	targetNode, err := enode.ParseV4(targetInfo.Enode)
+	require.NoError(err, "failed to parse target node")
+
+	require.NoError(waitForPeerConnected(initiator, targetNode.ID().String()), "The peer is not connected")
+}
+
+// waitForPeerConnected polls node's admin_peers until expectedID is present.
+func waitForPeerConnected(node RpcCaller, expectedID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	err = forPeerList(ctx, initiator, func(peers []peer) bool {
+	return forPeerList(ctx, node, func(peers []peer) bool {
 		return slices.ContainsFunc(peers, func(p peer) bool {
 			peerID := strings.TrimPrefix(strings.ToLower(p.ID), "0x")
 			return peerID == strings.ToLower(expectedID)
 		})
 	})
-	require.NoError(err, "The peer was not connected")
 }
 
 // forPeerList polls admin_peers on node until cond holds for the returned peer


### PR DESCRIPTION
## Description

Extends the `depreqres` unsafe-chain tests to cover the EL **backfill (staged pipeline) sync** path, which the existing tests structurally cannot reach:

- **Gap below the backfill threshold.** The existing `UnsafeChainNotStalling_*` scenarios advance 20 blocks, but reth only enters the backfill pipeline when the sync target is more than `MIN_BLOCKS_FOR_PIPELINE_RUN = EPOCH_SLOTS = 32` blocks ahead of the local tip — so the gap is filled via live sync and the pipeline never runs.
- **Trusted peering masks peer-management regressions.** `ConnectP2P` registers the EL peering via `admin_addTrustedPeer` on both sides; trusted peers are exempt from reputation bans and eviction, so a regression that disconnects or bans peers around backfill entry would be invisible. Production nodes peer via discovery as basic peers.

New coverage:

- `UnsafeChainNotStalling_Backfill` scenario + `TestUnsafeChainNotStalling_ELSync_Backfill`: op-node in `--syncmode=execution-layer` with a 64-block gap drives the verifier op-reth through the full backfill pipeline, and asserts the EL peering survives both the stall and the backfill.
- New devstack helpers: `sysgo.ConnectP2PBasic` / `sysgo.WaitP2PConnected`, and DSL methods `L2ELNode.PeerWithBasic` / `L2ELNode.VerifyPeeredWith` — a ban-sensitive (basic/static, non-trusted) peering primitive for tests that observe peer-management behavior itself. The initiator keeps a static entry so the link re-dials after benign drops, but stays subject to reputation penalties, bans, and eviction.

Motivated by the EL peer-drop incident investigation (ethereum-optimism/protocol-team#246): validators' op-reth dropping to 0 EL peers on backfill entry after a sequencer unsafe stall. This test makes that class of regression fail loudly: verified locally that the verifier runs the 13-stage pipeline (78-block gap) and the assertions pass in ~102s.

## Tests

- `TestUnsafeChainNotStalling_ELSync_Backfill` (new) — passes locally in ~102s.
- Existing `depreqres` tests unchanged; shared `common.go` addition is additive only.

## Additional context

The scenario intentionally keeps the CL-side topology identical to `UnsafeChainNotStalling_Disconnect` so the only new variables are the gap size and the EL peering kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)