### PR TITLE
op-reth: use RUST_BINARY_PATH_OP_RETH for e2e test binaries

### DIFF
--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -139,7 +139,7 @@ jobs:
           working_directory: rust/op-reth/tests
           no_output_timeout: 60m
           command: |
-            export OP_RETH_EXEC_PATH="$(pwd)/../../target/release/op-reth"
+            export RUST_BINARY_PATH_OP_RETH="$(pwd)/../../target/release/op-reth"
             just test-e2e-sysgo
       - go-save-cache:
           namespace: op-reth-e2e

--- a/rust/op-reth/tests/README.md
+++ b/rust/op-reth/tests/README.md
@@ -49,7 +49,7 @@ just build-bedrock-contracts
 ## Implementation notes
 
 - `just test-e2e-sysgo` depends on `build-contracts` and runs automatically.
-- The test target sets `OP_RETH_EXEC_PATH` to `../../target/release/op-reth`.
+- The test target sets `RUST_BINARY_PATH_OP_RETH` to `../../target/release/op-reth` (the devstack harness env var; the path must exist).
 - You can override proof EL kinds with:
   - `OP_DEVSTACK_PROOF_SEQUENCER_EL`
   - `OP_DEVSTACK_PROOF_VALIDATOR_EL`

--- a/rust/op-reth/tests/justfile
+++ b/rust/op-reth/tests/justfile
@@ -39,7 +39,7 @@ test-e2e-sysgo: build-contracts
   export DEVSTACK_ORCHESTRATOR=sysgo
   export OP_RETH_ENABLE_PROOF_HISTORY=true
   export SKIP_P2P_CONNECTION_CHECK=true
-  export OP_RETH_EXEC_PATH="{{SOURCE_DIR}}/../../target/release/op-reth"
+  export RUST_BINARY_PATH_OP_RETH="{{SOURCE_DIR}}/../../target/release/op-reth"
   export OP_DEVSTACK_PROOF_SEQUENCER_EL="{{OP_DEVSTACK_PROOF_SEQUENCER_EL}}"
   export OP_DEVSTACK_PROOF_VALIDATOR_EL="{{OP_DEVSTACK_PROOF_VALIDATOR_EL}}"
   {{SOURCE_DIR}}/../../../ops/scripts/gotestsum-split.sh --format=testname \


### PR DESCRIPTION
## Description

`OP_RETH_EXEC_PATH` is read by nothing in this repo — the devstack harness reads `RUST_BINARY_PATH_<BINARY>` (`op-devstack/shared/rustbin/rust_binary.go`) and otherwise falls back to the **newest of `target/{debug,release}` by mtime**. The op-reth e2e justfile and the `op-reth-e2e-sysgo-tests` CI job therefore got their intended binary by mtime luck, not by the export they set. This makes the selection explicit:

- `rust/op-reth/tests/justfile`: export `RUST_BINARY_PATH_OP_RETH` (release path, as before-by-accident)
- `.circleci/continue/rust-e2e.yml` (`op-reth-e2e-sysgo-tests`): same swap for the workspace binary
- `rust/op-reth/tests/README.md`: document the live variable instead of the dead one

Out of scope, handled elsewhere: the kona-side exports and `op-devstack/README.md` are fixed in #22202; the `acceptance-tests-run` exports in `rust/kona/tests/justfile` drive the pinned optimism submodule and are deliberately untouched.

Same hazard class as the silent debug→release swap found in #22202's review — see the discussion there (https://github.com/ethereum-optimism/optimism/pull/22202#discussion_r3708687041).

## Validation

Merged CI config processes clean with the `c-run_*` params enabled; the op-reth tests justfile parses. Behavior is intended to be identical to today's mtime outcome — the job attaches only the workspace release binary, which is what the export now names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
