### PR TITLE
op-acceptance-tests: mark light-sequencer invalid-message test flaky

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -37,6 +37,7 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 // light-sequencer path. op-geth is being deprecated, so we skip rather than block on it.
 func TestSupernodeLightSequencerInteropInvalidMessageReplacement(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	t.MarkFlaky("ethereum-optimism/optimism#22234")
 	// op-reth only: on op-geth the follower never adopts the deposits-only replacement.
 	sysgo.SkipOnOpGeth(t, "op-geth does not adopt the invalid-message replacement on the light path (#21119)")
 	// Bootstrap via the supernode VN sequencer and hand off to the light ELSync sequencers, then


### PR DESCRIPTION
## Description

Marks `TestSupernodeLightSequencerInteropInvalidMessageReplacement` flaky, referencing #22234. It failed once in eight otherwise-green runs during the #22202 memory-all measurement session (CircleCI job 5423722, 71s, single failure among 85 tests) with no correlation to per-node concurrency; the sibling virtual-sequencer variant did not fail. `MarkFlaky` keeps the failure visible in the flaky-tests report without failing acceptance jobs while the light-ELSync replacement-adoption path is investigated.

## Validation

`gofmt` clean; annotation-only change following the existing pattern (`flashblocks_stream_test.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
