### PR TITLE
op-supernode: recover non-canonical interop frontiers

### DIFF
--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -2789,6 +2789,99 @@ func TestVerify_DoesNotPersistFrontierLogs(t *testing.T) {
 	require.Zero(t, trackingDB.sealCalls, "verify must not seal frontier blocks into logsDB")
 }
 
+func TestVerify_RejectsNonCanonicalFrontier(t *testing.T) {
+	canonicalHash := common.HexToHash("0xcafe")
+	forkHash := common.HexToHash("0xdead")
+	h := newInteropTestHarness(t).
+		WithChain(10, func(m *mockChainContainer) {
+			m.outputV0Override = func(context.Context, uint64) (*eth.OutputV0, error) {
+				return &eth.OutputV0{BlockHash: canonicalHash}, nil
+			}
+		}).
+		Build()
+
+	verifyCalled := false
+	h.interop.verifyFn = func(uint64, map[eth.ChainID]eth.BlockID, map[eth.ChainID]eth.BlockID, *frontierVerificationView) (Result, error) {
+		verifyCalled = true
+		return Result{}, nil
+	}
+
+	chainID := eth.ChainIDFromUInt64(10)
+	_, err := h.interop.verify(1001,
+		map[eth.ChainID]eth.BlockID{chainID: {Number: 1001, Hash: forkHash}},
+		map[eth.ChainID]eth.BlockID{})
+	require.ErrorIs(t, err, ErrNonCanonicalFrontier)
+	require.Contains(t, err.Error(), canonicalHash.String())
+	require.Contains(t, err.Error(), forkHash.String())
+	require.False(t, verifyCalled, "non-canonical frontier must be rejected before message verification")
+}
+
+func TestPendingTransition_RecoversLiveLogsDBAfterReorg(t *testing.T) {
+	const (
+		activation uint64 = 100
+		forkPoint  uint64 = 103
+		forkTip    uint64 = 105
+		target     uint64 = 106
+	)
+	h := newInteropTestHarness(t).
+		WithActivation(activation).
+		WithLogBackfillDepth(20*time.Second).
+		WithChain(10, nil).
+		Build()
+
+	chainID := eth.ChainIDFromUInt64(10)
+	db := h.interop.logsDBs[chainID]
+	canonicalHash := func(n uint64) common.Hash {
+		return common.BigToHash(new(big.Int).SetUint64(n))
+	}
+	forkHash := func(n uint64) common.Hash {
+		return common.BigToHash(new(big.Int).SetUint64(n | 0xdead0000))
+	}
+
+	require.NoError(t, db.SealBlock(common.Hash{},
+		eth.BlockID{Number: activation, Hash: canonicalHash(activation)}, activation))
+	for n := activation + 1; n < forkPoint; n++ {
+		require.NoError(t, db.SealBlock(canonicalHash(n-1),
+			eth.BlockID{Number: n, Hash: canonicalHash(n)}, n))
+	}
+	require.NoError(t, db.SealBlock(canonicalHash(forkPoint-1),
+		eth.BlockID{Number: forkPoint, Hash: forkHash(forkPoint)}, forkPoint))
+	for n := forkPoint + 1; n <= forkTip; n++ {
+		require.NoError(t, db.SealBlock(forkHash(n-1),
+			eth.BlockID{Number: n, Hash: forkHash(n)}, n))
+	}
+
+	result := Result{
+		Timestamp: target,
+		L2Heads: map[eth.ChainID]eth.BlockID{
+			chainID: {Number: target, Hash: canonicalHash(target)},
+		},
+	}
+	pending := PendingTransition{Decision: DecisionAdvance, Result: &result}
+	require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+
+	madeProgress, err := h.interop.applyPendingTransition(pending)
+	require.NoError(t, err)
+	require.True(t, madeProgress)
+
+	for n := forkPoint; n <= target; n++ {
+		seal, err := db.FindSealedBlock(n)
+		require.NoError(t, err, "canonical block %d must be resealed", n)
+		require.Equal(t, canonicalHash(n), seal.Hash,
+			"block %d must not retain the stale fork hash", n)
+	}
+	latest, has := db.LatestSealedBlock()
+	require.True(t, has)
+	require.Equal(t, eth.BlockID{Number: target, Hash: canonicalHash(target)}, latest)
+
+	committed, err := h.interop.verifiedDB.Get(target)
+	require.NoError(t, err)
+	require.Equal(t, canonicalHash(target), committed.L2Heads[chainID].Hash)
+	storedPending, err := h.interop.verifiedDB.GetPendingTransition()
+	require.NoError(t, err)
+	require.Nil(t, storedPending)
+}
+
 func TestResetIsNoOp(t *testing.T) {
 	h := newInteropTestHarness(t).
 		WithChain(10, nil).

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -207,6 +207,48 @@ func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.C
 	return nil
 }
 
+// recoverLiveLogsDB reconciles a diverged live logsDB tail and re-seals the
+// canonical chain through target. If reconciliation clears the database, the
+// configured backfill window is restored so message verification retains the
+// same history available after a cold start.
+func (i *Interop) recoverLiveLogsDB(cid eth.ChainID, target eth.BlockID, targetTimestamp uint64) error {
+	chain, ok := i.chains[cid]
+	if !ok {
+		return fmt.Errorf("chain %s: not configured", cid)
+	}
+
+	startNum := target.Number
+	if i.logBackfillDepth > 0 {
+		depthSec := uint64(i.logBackfillDepth.Seconds())
+		var depthFloor uint64
+		if targetTimestamp >= depthSec {
+			depthFloor = targetTimestamp - depthSec
+		}
+		startTime := max(depthFloor, i.activationTimestamp)
+		genesisTime, err := chain.BlockNumberToTimestamp(i.ctx, 0)
+		if err != nil {
+			return fmt.Errorf("chain %s: genesis timestamp during live logsDB recovery: %w", cid, err)
+		}
+		startTime = max(startTime, genesisTime)
+		if startTime <= targetTimestamp {
+			startNum, err = chain.TimestampToBlockNumber(i.ctx, startTime)
+			if err != nil {
+				return fmt.Errorf("chain %s: timestamp to block number for live recovery start %d: %w", cid, startTime, err)
+			}
+			if startNum > target.Number {
+				startNum = target.Number
+			}
+		}
+	}
+
+	i.log.Info("live logsDB recovery: reconciling and sealing canonical logs",
+		"chain", cid, "from", startNum, "to", target.Number)
+	if err := i.backfillChain(i.ctx, cid, chain, startNum, target.Number); err != nil {
+		return fmt.Errorf("chain %s: live logsDB recovery backfill: %w", cid, err)
+	}
+	return nil
+}
+
 // reconcileLogsDBTail trims tail blocks whose hash no longer matches canonical,
 // so backfill resumes from a block that is still in force. Without this, an L2
 // reorg that occurs while supernode is offline leaves the tail diverged and the

--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -80,8 +80,24 @@ var (
 // transition apply — verification itself is read-only.
 func (i *Interop) persistFrontierLogs(ts uint64, blocksAtTS map[eth.ChainID]eth.BlockID) error {
 	for chainID, blockID := range blocksAtTS {
-		if err := i.sealFetchedBlockIntoLogsDB(chainID, blockID, ts); err != nil {
+		err := i.sealFetchedBlockIntoLogsDB(chainID, blockID, ts)
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, ErrParentHashMismatch) && !errors.Is(err, ErrStaleLogsDB) {
 			return err
+		}
+
+		i.log.Warn("recovering non-canonical live logsDB frontier",
+			"chain", chainID, "target", blockID, "err", err)
+		if recoverErr := i.recoverLiveLogsDB(chainID, blockID, ts); recoverErr != nil {
+			return fmt.Errorf("chain %s: recover live logsDB: %w", chainID, recoverErr)
+		}
+		// The recovery backfill includes blockID. Retry the normal seal path to
+		// prove that the requested frontier is now present and consistent before
+		// the verified result is committed.
+		if retryErr := i.sealFetchedBlockIntoLogsDB(chainID, blockID, ts); retryErr != nil {
+			return fmt.Errorf("chain %s: persist frontier block after logsDB recovery: %w", chainID, retryErr)
 		}
 	}
 	return nil

--- a/op-supernode/supernode/activity/interop/verification_view.go
+++ b/op-supernode/supernode/activity/interop/verification_view.go
@@ -1,12 +1,18 @@
 package interop
 
 import (
+	"errors"
 	"fmt"
 
 	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 )
+
+// ErrNonCanonicalFrontier is returned when the block selected for interop
+// verification does not match the execution engine's canonical block at the
+// same height.
+var ErrNonCanonicalFrontier = errors.New("interop frontier block is not canonical")
 
 type frontierQueryKey struct {
 	blockNum  uint64
@@ -33,6 +39,14 @@ func (i *Interop) resolveFrontierVerificationView(blocksAtTS map[eth.ChainID]eth
 		chain, ok := i.chains[chainID]
 		if !ok {
 			continue
+		}
+		canonical, err := chain.OutputV0AtBlockNumber(i.ctx, blockID.Number)
+		if err != nil {
+			return nil, fmt.Errorf("chain %s: failed to fetch canonical output for frontier block %s: %w", chainID, blockID, err)
+		}
+		if canonical.BlockHash != blockID.Hash {
+			return nil, fmt.Errorf("chain %s: frontier block %s does not match canonical block %s:%d: %w",
+				chainID, blockID, canonical.BlockHash, blockID.Number, ErrNonCanonicalFrontier)
 		}
 		blockInfo, receipts, err := chain.FetchReceipts(i.ctx, blockID)
 		if err != nil {


### PR DESCRIPTION
## Description

Fixes #22138.

This change addresses the two connected failure modes described in the issue: an interop frontier could be verified even when its derived block hash was not canonical in the execution engine, and a live logsDB with a divergent tail could retry the same parent mismatch indefinitely.

### Reject non-canonical frontiers before verification

`resolveFrontierVerificationView` now queries the execution engine's canonical output at each frontier block height and compares that output's block hash with the derived frontier hash.

If the hashes differ, the verifier returns `ErrNonCanonicalFrontier` before it fetches receipts, verifies executing messages, performs cycle checks, writes a pending transition, seals logs, or constructs an invalidation decision from that frontier. Canonical-output query failures are also propagated with the chain and frontier block in the error context.

This turns a private derivation fork into an immediate visible verifier failure instead of allowing the fork to become accepted interop state.

### Recover a divergent logsDB during live advancement

`persistFrontierLogs` now treats `ErrParentHashMismatch` and `ErrStaleLogsDB` as recoverable reorg signals. Other persistence failures keep their existing behavior.

For a recoverable error, the live path:

1. Uses the existing `reconcileLogsDBTail` logic through `backfillChain` to find the latest stored block that still matches canonical engine history.
2. Rewinds the stale tail, or clears the database if no stored block remains canonical.
3. Reseals canonical blocks from the retained common ancestor through the requested frontier.
4. Restores the configured log backfill window, bounded by activation and genesis, if reconciliation had to clear the whole database.
5. Retries the normal frontier seal path before committing the verified result, which proves that the requested frontier is present and consistent.

The pending transition remains in the WAL if reconciliation, backfill, or the final validation fails, so restart and retry behavior stays crash safe. Partial persistence across multiple chains also remains idempotent.

### Why the canonical span is resealed

Rewinding alone is insufficient for the reported incident. The last canonical block was roughly 1,390 blocks behind the requested frontier, so immediately retrying only the frontier block would still fail its parent check. Reusing the canonical backfill path closes that gap in order and preserves logsDB continuity.

## Tests

Added `TestVerify_RejectsNonCanonicalFrontier` to verify that a fork hash is rejected before message verification can use it.

Added `TestPendingTransition_RecoversLiveLogsDBAfterReorg` to seed a canonical prefix and divergent live tail, apply an advance transition beyond the fork, and verify that the stale span is replaced with canonical blocks, the result is committed, and the pending transition is cleared.

Validation completed:

- `go test ./supernode/activity/interop -count=1`
- `go test ./... -count=1` from `op-supernode`
- `just lint-go`, including the repository custom linter and `go mod tidy -diff`
