### PR TITLE
op-node: add direct-call build methods to engine controller

### DIFF
--- a/op-node/rollup/engine/build_results.go
+++ b/op-node/rollup/engine/build_results.go
@@ -1,0 +1,20 @@
+package engine
+
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// BuildStartResult contains the result of starting a block-building job.
+type BuildStartResult struct {
+	Info         eth.PayloadInfo
+	BuildStarted time.Time
+	Parent       eth.L2BlockRef
+}
+
+// SealResult contains the result of sealing a block-building job.
+type SealResult struct {
+	Envelope *eth.ExecutionPayloadEnvelope
+	Ref      eth.L2BlockRef
+}

--- a/op-node/rollup/engine/build_seal.go
+++ b/op-node/rollup/engine/build_seal.go
@@ -55,58 +55,84 @@ func (ev BuildSealEvent) String() string {
 	return "build-seal"
 }
 
+// ErrSealExpired is returned when a payload cannot be sealed because the
+// block-building job timed out, is unknown to the engine, or was otherwise
+// invalidated. The same attributes may be re-attempted with a new job.
+var ErrSealExpired = errors.New("payload seal job expired")
+
+// ErrSealInvalid is returned when the sealed payload contents are invalid.
+// The build should be restarted with fresh attributes.
+var ErrSealInvalid = errors.New("sealed payload is invalid")
+
 func (e *EngineController) onBuildSeal(ctx context.Context, ev BuildSealEvent) {
+	result, err := e.sealBuild(ev.Info, ev.BuildStarted)
+	if err != nil {
+		// Translate seal errors into events for the event-driven (derivation)
+		// path; the direct-call path receives them as return values instead.
+		if errors.Is(err, ErrSealExpired) {
+			e.emitter.Emit(ctx, PayloadSealExpiredErrorEvent{
+				Info:        ev.Info,
+				Err:         err,
+				Concluding:  ev.Concluding,
+				DerivedFrom: ev.DerivedFrom,
+			})
+		} else {
+			e.emitter.Emit(ctx, PayloadSealInvalidEvent{
+				Info:        ev.Info,
+				Err:         err,
+				Concluding:  ev.Concluding,
+				DerivedFrom: ev.DerivedFrom,
+			})
+		}
+		return
+	}
+	e.emitter.Emit(ctx, BuildSealedEvent{
+		Concluding:   ev.Concluding,
+		DerivedFrom:  ev.DerivedFrom,
+		BuildStarted: ev.BuildStarted,
+		Info:         ev.Info,
+		Envelope:     result.Envelope,
+		Ref:          result.Ref,
+	})
+}
+
+// sealBuild contains the core logic for sealing a block-building job.
+// It does NOT acquire e.mu (caller is responsible) and emits no events:
+// errors wrap ErrSealExpired or ErrSealInvalid for the caller to translate.
+func (e *EngineController) sealBuild(info eth.PayloadInfo, buildStarted time.Time) (*SealResult, error) {
 	rpcCtx, cancel := context.WithTimeout(e.ctx, buildSealTimeout)
 	defer cancel()
 
 	sealingStart := time.Now()
-	envelope, err := e.engine.GetPayload(rpcCtx, ev.Info)
+	envelope, err := e.engine.GetPayload(rpcCtx, info)
 	if err != nil {
 		var rpcErr rpc.Error
 		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()) == eth.UnknownPayload {
 			e.log.Warn("Cannot seal block, payload ID is unknown",
-				"payloadID", ev.Info.ID, "payload_time", ev.Info.Timestamp,
-				"started_time", ev.BuildStarted)
+				"payloadID", info.ID, "payload_time", info.Timestamp,
+				"started_time", buildStarted)
 		}
 		// Although the engine will very likely not be able to continue from here with the same building job,
 		// we still call it "temporary", since the exact same payload-attributes have not been invalidated in-consensus.
 		// So the user (attributes-handler or sequencer) should be able to re-attempt the exact
 		// same attributes with a new block-building job from here to recover from this error.
 		// We name it "expired", as this generally identifies a timeout, unknown job, or otherwise invalidated work.
-		e.emitter.Emit(ctx, PayloadSealExpiredErrorEvent{
-			Info:        ev.Info,
-			Err:         fmt.Errorf("failed to seal execution payload (ID: %s): %w", ev.Info.ID, err),
-			Concluding:  ev.Concluding,
-			DerivedFrom: ev.DerivedFrom,
-		})
-		return
+		return nil, fmt.Errorf("%w: failed to seal execution payload (ID: %s): %w", ErrSealExpired, info.ID, err)
 	}
 
 	if err := sanityCheckPayload(envelope.ExecutionPayload); err != nil {
-		e.emitter.Emit(ctx, PayloadSealInvalidEvent{
-			Info: ev.Info,
-			Err: fmt.Errorf("failed sanity-check of execution payload contents (ID: %s, blockhash: %s): %w",
-				ev.Info.ID, envelope.ExecutionPayload.BlockHash, err),
-			Concluding:  ev.Concluding,
-			DerivedFrom: ev.DerivedFrom,
-		})
-		return
+		return nil, fmt.Errorf("%w: failed sanity-check of execution payload contents (ID: %s, blockhash: %s): %w",
+			ErrSealInvalid, info.ID, envelope.ExecutionPayload.BlockHash, err)
 	}
 
 	ref, err := derive.PayloadToBlockRef(e.rollupCfg, envelope.ExecutionPayload)
 	if err != nil {
-		e.emitter.Emit(ctx, PayloadSealInvalidEvent{
-			Info:        ev.Info,
-			Err:         fmt.Errorf("failed to decode L2 block ref from payload: %w", err),
-			Concluding:  ev.Concluding,
-			DerivedFrom: ev.DerivedFrom,
-		})
-		return
+		return nil, fmt.Errorf("%w: failed to decode L2 block ref from payload: %w", ErrSealInvalid, err)
 	}
 
 	now := time.Now()
 	sealTime := now.Sub(sealingStart)
-	buildTime := now.Sub(ev.BuildStarted)
+	buildTime := now.Sub(buildStarted)
 	e.metrics.RecordSequencerSealingTime(sealTime)
 	e.metrics.RecordSequencerBuildingDiffTime(buildTime - time.Duration(e.rollupCfg.BlockTime)*time.Second)
 
@@ -117,14 +143,34 @@ func (e *EngineController) onBuildSeal(ctx context.Context, ev BuildSealEvent) {
 	e.log.Debug("Built new L2 block", "l2_unsafe", ref, "l1_origin", ref.L1Origin,
 		"txs", txnCount, "deposits", depositCount, "time", ref.Time, "seal_time", sealTime, "build_time", buildTime)
 
-	e.emitter.Emit(ctx, BuildSealedEvent{
-		Concluding:   ev.Concluding,
-		DerivedFrom:  ev.DerivedFrom,
-		BuildStarted: ev.BuildStarted,
-		Info:         ev.Info,
-		Envelope:     envelope,
-		Ref:          ref,
-	})
+	return &SealResult{
+		Envelope: envelope,
+		Ref:      ref,
+	}, nil
+}
+
+// SealBuild retrieves a built payload via GetPayload directly, bypassing the event system.
+// Acquires e.mu. Returns the sealed envelope and block ref.
+// Emits no events on error: the error wraps ErrSealExpired or ErrSealInvalid,
+// or is ErrStaleBuild when the sealed block no longer extends the unsafe head.
+// Does NOT emit BuildSealedEvent.
+func (e *EngineController) SealBuild(ctx context.Context, info eth.PayloadInfo, buildStarted time.Time) (*SealResult, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	result, err := e.sealBuild(info, buildStarted)
+	if err != nil {
+		return nil, err
+	}
+	// The unsafe head may have moved since the build was started (competing
+	// insert, block replacement); committing and gossiping the sealed sibling
+	// would fork away the new head.
+	if result.Envelope.ExecutionPayload.ParentHash != e.unsafeHead.Hash {
+		e.log.Warn("dropping stale sealed block, parent is not the unsafe head",
+			"sealed", result.Ref, "unsafe", e.unsafeHead)
+		e.requestForkchoiceUpdate(ctx)
+		return nil, ErrStaleBuild
+	}
+	return result, nil
 }
 
 // isDepositTx checks an opaqueTx to determine if it is a Deposit Transaction

--- a/op-node/rollup/engine/build_start.go
+++ b/op-node/rollup/engine/build_start.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -9,6 +10,25 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
+
+// ErrStaleBuild is returned by the direct-call build methods when the job no
+// longer extends the current unsafe head. The caller should wait for the next
+// forkchoice update (already requested) and re-attempt on the new head.
+var ErrStaleBuild = errors.New("stale block-building job, parent is not the unsafe head")
+
+// ErrBuildInvalid is returned by StartBuild when the engine rejects the payload
+// attributes. It is not a temporary failure: the caller must start a new build
+// rather than retry the same one.
+//
+// Unlike the seal errors, the engine keeps emitting BuildInvalidEvent on both
+// paths, because onBuildInvalid performs engine-internal recovery that a
+// direct caller cannot do for itself (exiting on an invalid deposits-only
+// block, reverting the pending-safe head, restoring the backup unsafe head).
+// Its downstream InvalidPayloadAttributesEvent is therefore also emitted for
+// sequencer-originated builds; recovery stays single-signal because the only
+// consumer that acted on it for those builds is the sequencer, which drops the
+// handler when it moves to these direct calls.
+var ErrBuildInvalid = errors.New("invalid block-building attributes")
 
 type BuildStartEvent struct {
 	Attributes *derive.AttributesWithParent
@@ -19,33 +39,50 @@ func (ev BuildStartEvent) String() string {
 }
 
 func (e *EngineController) onBuildStart(ctx context.Context, ev BuildStartEvent) {
+	result, err := e.startBuild(ctx, ev.Attributes)
+	if err != nil {
+		return
+	}
+	e.emitter.Emit(ctx, BuildStartedEvent{
+		Info:         result.Info,
+		BuildStarted: result.BuildStarted,
+		Concluding:   ev.Attributes.Concluding,
+		DerivedFrom:  ev.Attributes.DerivedFrom,
+		Parent:       result.Parent,
+	})
+}
+
+// startBuild contains the core logic for starting a block-building job.
+// It does NOT acquire e.mu (caller is responsible).
+// Emits ForkchoiceUpdateEvent and error events, but NOT BuildStartedEvent (caller's job).
+func (e *EngineController) startBuild(ctx context.Context, attrs *derive.AttributesWithParent) (*BuildStartResult, error) {
+	if !attrs.IsDerived() && attrs.Parent.ID() != e.unsafeHead.ID() {
+		e.log.Warn("dropping stale sequencer build start",
+			"attributes_parent", attrs.Parent, "unsafe", e.unsafeHead)
+		// Re-emit the forkchoice so the sequencer drops the stale build job and restarts on the current unsafe head.
+		e.requestForkchoiceUpdate(ctx)
+		return nil, ErrStaleBuild
+	}
+
 	rpcCtx, cancel := context.WithTimeout(e.ctx, buildStartTimeout)
 	defer cancel()
 
-	if !ev.Attributes.IsDerived() && ev.Attributes.Parent.ID() != e.unsafeHead.ID() {
-		e.log.Warn("dropping stale sequencer build start",
-			"attributes_parent", ev.Attributes.Parent, "unsafe", e.unsafeHead)
-		// Re-emit the forkchoice so the sequencer drops the stale build job and restarts on the current unsafe head.
-		e.requestForkchoiceUpdate(ctx)
-		return
-	}
-
-	if ev.Attributes.DerivedFrom != (eth.L1BlockRef{}) &&
-		e.pendingSafeHead.Hash != ev.Attributes.Parent.Hash {
+	if attrs.DerivedFrom != (eth.L1BlockRef{}) &&
+		e.pendingSafeHead.Hash != attrs.Parent.Hash {
 		// Warn about small reorgs, happens when pending safe head is getting rolled back
 		e.log.Warn("block-attributes derived from L1 do not build on pending safe head, likely reorg",
-			"pending_safe", e.pendingSafeHead, "attributes_parent", ev.Attributes.Parent)
+			"pending_safe", e.pendingSafeHead, "attributes_parent", attrs.Parent)
 	}
 
 	fcEvent := ForkchoiceUpdateEvent{
-		UnsafeL2Head:    ev.Attributes.Parent,
+		UnsafeL2Head:    attrs.Parent,
 		SafeL2Head:      e.SafeL2Head(),
 		FinalizedL2Head: e.FinalizedHead(),
 	}
 	if fcEvent.UnsafeL2Head.Number < fcEvent.FinalizedL2Head.Number {
 		err := fmt.Errorf("invalid block-building pre-state, unsafe head %s is behind finalized head %s", fcEvent.UnsafeL2Head, fcEvent.FinalizedL2Head)
 		e.emitter.Emit(ctx, rollup.CriticalErrorEvent{Err: err}) // make the node exit, things are very wrong.
-		return
+		return nil, err
 	}
 	fc := eth.ForkchoiceState{
 		HeadBlockHash:      fcEvent.UnsafeL2Head.Hash,
@@ -53,7 +90,7 @@ func (e *EngineController) onBuildStart(ctx context.Context, ev BuildStartEvent)
 		FinalizedBlockHash: fcEvent.FinalizedL2Head.Hash,
 	}
 	buildStartTime := time.Now()
-	id, errTyp, err := e.startPayload(rpcCtx, fc, ev.Attributes.Attributes)
+	id, errTyp, err := e.startPayload(rpcCtx, fc, attrs.Attributes)
 	if err != nil {
 		switch errTyp {
 		case BlockInsertTemporaryErr:
@@ -61,29 +98,39 @@ func (e *EngineController) onBuildStart(ctx context.Context, ev BuildStartEvent)
 			e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
 				Err: fmt.Errorf("temporarily cannot insert new safe block: %w", err),
 			})
-			return
+			return nil, err
 		case BlockInsertPrestateErr:
 			e.emitter.Emit(ctx, rollup.ResetEvent{
 				Err: fmt.Errorf("need reset to resolve pre-state problem: %w", err),
 			})
-			return
+			return nil, err
 		case BlockInsertPayloadErr:
-			e.emitter.Emit(ctx, BuildInvalidEvent{Attributes: ev.Attributes, Err: err})
-			return
+			e.emitter.Emit(ctx, BuildInvalidEvent{Attributes: attrs, Err: err})
+			return nil, fmt.Errorf("%w: %w", ErrBuildInvalid, err)
 		default:
 			e.emitter.Emit(ctx, rollup.CriticalErrorEvent{
 				Err: fmt.Errorf("unknown error type %d: %w", errTyp, err),
 			})
-			return
+			return nil, err
 		}
 	}
 	e.emitter.Emit(ctx, fcEvent)
 
-	e.emitter.Emit(ctx, BuildStartedEvent{
-		Info:         eth.PayloadInfo{ID: id, Timestamp: uint64(ev.Attributes.Attributes.Timestamp)},
+	return &BuildStartResult{
+		Info:         eth.PayloadInfo{ID: id, Timestamp: uint64(attrs.Attributes.Timestamp)},
 		BuildStarted: buildStartTime,
-		Concluding:   ev.Attributes.Concluding,
-		DerivedFrom:  ev.Attributes.DerivedFrom,
-		Parent:       ev.Attributes.Parent,
-	})
+		Parent:       attrs.Parent,
+	}, nil
+}
+
+// StartBuild starts a block-building job directly, bypassing the event system.
+// Acquires e.mu. Returns the build result or an error.
+// Emits ForkchoiceUpdateEvent for other listeners.
+// On error, emits appropriate error events before returning; a stale parent
+// yields ErrStaleBuild after a forkchoice update has been requested.
+// Does NOT emit BuildStartedEvent.
+func (e *EngineController) StartBuild(ctx context.Context, attrs *derive.AttributesWithParent) (*BuildStartResult, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.startBuild(ctx, attrs)
 }

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	mrand "math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -93,6 +94,72 @@ func TestBuildStartRejectsStaleSequencerParent(t *testing.T) {
 		SafeL2Head:      safe,
 		FinalizedL2Head: finalized,
 	}}, emitted)
+}
+
+type sealingEngine struct {
+	testutils.MockEngine
+	envelope    *eth.ExecutionPayloadEnvelope
+	getPayloads int
+	newPayloads int
+}
+
+func (e *sealingEngine) GetPayload(context.Context, eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error) {
+	e.getPayloads++
+	return e.envelope, nil
+}
+
+func (e *sealingEngine) NewPayload(context.Context, *eth.ExecutionPayload, *common.Hash) (*eth.PayloadStatusV1, error) {
+	e.newPayloads++
+	return &eth.PayloadStatusV1{Status: eth.ExecutionValid}, nil
+}
+
+// TestSealBuildRejectsStaleParent covers the direct-call guard: a block sealed
+// on a parent the chain has moved past must not be handed to the caller, which
+// would commit and gossip a sibling of the current head.
+func TestSealBuildRejectsStaleParent(t *testing.T) {
+	cfg, parent, sealed, envelope := buildSimpleCfgAndPayload(t)
+	movedOn := eth.L2BlockRef{Hash: common.Hash{0x41}, Number: sealed.Number, Time: sealed.Time}
+
+	var emitted []event.Event
+	emitter := event.EmitterFunc(func(_ context.Context, ev event.Event) { emitted = append(emitted, ev) })
+	engine := &sealingEngine{envelope: envelope}
+	ec := NewEngineController(context.Background(), engine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, &testutils.MockL1Source{}, emitter, nil)
+	ec.SetUnsafeHead(movedOn)
+
+	result, err := ec.SealBuild(context.Background(), eth.PayloadInfo{ID: eth.PayloadID{0x01}}, time.Now())
+	require.ErrorIs(t, err, ErrStaleBuild)
+	require.Nil(t, result)
+	require.Equal(t, 1, engine.getPayloads, "the job can only be checked once it is sealed")
+	require.Len(t, emitted, 1, "a forkchoice update is requested so the caller can re-plan")
+	require.IsType(t, ForkchoiceUpdateEvent{}, emitted[0])
+
+	// On the matching head the same seal succeeds and stays event-free.
+	emitted = nil
+	ec.SetUnsafeHead(parent)
+	result, err = ec.SealBuild(context.Background(), eth.PayloadInfo{ID: eth.PayloadID{0x01}}, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, sealed.Hash, result.Ref.Hash)
+	require.Empty(t, emitted, "the direct seal path emits no events on success")
+}
+
+// TestProcessPayloadRejectsStaleParent covers the direct-call guard: inserting a
+// payload that no longer extends the unsafe head would reorg the head backwards.
+func TestProcessPayloadRejectsStaleParent(t *testing.T) {
+	cfg, _, sealed, envelope := buildSimpleCfgAndPayload(t)
+	movedOn := eth.L2BlockRef{Hash: common.Hash{0x41}, Number: sealed.Number, Time: sealed.Time}
+
+	var emitted []event.Event
+	emitter := event.EmitterFunc(func(_ context.Context, ev event.Event) { emitted = append(emitted, ev) })
+	engine := &sealingEngine{envelope: envelope}
+	ec := NewEngineController(context.Background(), engine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, &testutils.MockL1Source{}, emitter, nil)
+	ec.SetUnsafeHead(movedOn)
+
+	err := ec.ProcessPayload(context.Background(), envelope, sealed, time.Now())
+	require.ErrorIs(t, err, ErrStaleBuild)
+	require.Zero(t, engine.newPayloads, "the stale payload must not reach the engine")
+	require.Equal(t, movedOn, ec.UnsafeL2Head(), "the head must not be reorged backwards")
+	require.Len(t, emitted, 1)
+	require.IsType(t, ForkchoiceUpdateEvent{}, emitted[0])
 }
 
 // buildSimpleCfgAndPayload creates a minimal rollup config and a valid payload (A1) on top of A0.

--- a/op-node/rollup/engine/payload_process.go
+++ b/op-node/rollup/engine/payload_process.go
@@ -2,11 +2,19 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+var (
+	// ErrPayloadDenied is returned when a payload is denied by the SuperAuthority denylist.
+	ErrPayloadDenied = errors.New("payload denied by SuperAuthority")
+	// ErrPayloadInvalid is returned when a payload's execution is invalid.
+	ErrPayloadInvalid = errors.New("payload execution invalid")
 )
 
 type PayloadProcessEvent struct {
@@ -25,12 +33,31 @@ func (ev PayloadProcessEvent) String() string {
 }
 
 func (e *EngineController) onPayloadProcess(ctx context.Context, ev PayloadProcessEvent) {
+	insertStarted, err := e.processNewPayload(ctx, ev.Envelope, ev.Ref, ev.DerivedFrom)
+	if err != nil {
+		return
+	}
+	e.emitter.Emit(ctx, PayloadSuccessEvent{
+		Concluding:    ev.Concluding,
+		DerivedFrom:   ev.DerivedFrom,
+		BuildStarted:  ev.BuildStarted,
+		InsertStarted: insertStarted,
+		Envelope:      ev.Envelope,
+		Ref:           ev.Ref,
+	})
+}
+
+// processNewPayload handles the SuperAuthority check and NewPayload RPC call.
+// It does NOT acquire e.mu (caller is responsible).
+// Returns the insert start time on success, or an error.
+// Emits error events for other listeners, but does NOT emit PayloadSuccessEvent (caller's job).
+func (e *EngineController) processNewPayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, derivedFrom eth.L1BlockRef) (time.Time, error) {
 	rpcCtx, cancel := context.WithTimeout(e.ctx, payloadProcessTimeout)
 	defer cancel()
 
 	// Check SuperAuthority denylist before inserting the payload
-	if e.superAuthority != nil && ev.Envelope != nil && ev.Envelope.ExecutionPayload != nil {
-		payload := ev.Envelope.ExecutionPayload
+	if e.superAuthority != nil && envelope != nil && envelope.ExecutionPayload != nil {
+		payload := envelope.ExecutionPayload
 		denied, err := e.superAuthority.IsDenied(uint64(payload.BlockNumber), payload.BlockHash)
 		if err != nil {
 			e.log.Error("Failed to check SuperAuthority denylist, proceeding with payload",
@@ -39,60 +66,78 @@ func (e *EngineController) onPayloadProcess(ctx context.Context, ev PayloadProce
 				"err", err,
 			)
 		} else if denied {
-			if ev.DerivedFrom != (eth.L1BlockRef{}) {
+			if derivedFrom != (eth.L1BlockRef{}) {
 				e.log.Warn("Requesting deposits-only replacement for derived payload",
 					"blockNumber", payload.BlockNumber,
 					"blockHash", payload.BlockHash,
-					"derivedFrom", ev.DerivedFrom,
+					"derivedFrom", derivedFrom,
 				)
-				e.emitDepositsOnlyPayloadAttributesRequest(ctx, ev.Ref.ParentID(), ev.DerivedFrom)
+				e.emitDepositsOnlyPayloadAttributesRequest(ctx, ref.ParentID(), derivedFrom)
 			} else {
 				e.log.Warn("Unsafe payload denied by SuperAuthority, dropping",
 					"blockNumber", payload.BlockNumber,
 					"blockHash", payload.BlockHash,
 				)
 			}
-			return
+			return time.Time{}, ErrPayloadDenied
 		}
 	}
 
 	insertStart := time.Now()
 	status, err := e.engine.NewPayload(rpcCtx,
-		ev.Envelope.ExecutionPayload, ev.Envelope.ParentBeaconBlockRoot)
+		envelope.ExecutionPayload, envelope.ParentBeaconBlockRoot)
 	if err != nil {
-		e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
-			Err: fmt.Errorf("failed to insert execution payload: %w", err),
-		})
-		return
+		insertErr := fmt.Errorf("failed to insert execution payload: %w", err)
+		e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: insertErr})
+		return time.Time{}, insertErr
 	}
 	switch status.Status {
 	case eth.ExecutionInvalid, eth.ExecutionInvalidBlockHash:
 		// Depending on execution engine, not all block-validity checks run immediately on build-start
 		// at the time of the forkchoiceUpdated engine-API call, nor during getPayload.
-		if ev.DerivedFrom != (eth.L1BlockRef{}) && e.rollupCfg.IsHolocene(ev.DerivedFrom.Time) {
-			e.emitDepositsOnlyPayloadAttributesRequest(ctx, ev.Ref.ParentID(), ev.DerivedFrom)
-			return
+		if derivedFrom != (eth.L1BlockRef{}) && e.rollupCfg.IsHolocene(derivedFrom.Time) {
+			e.emitDepositsOnlyPayloadAttributesRequest(ctx, ref.ParentID(), derivedFrom)
+			return time.Time{}, ErrPayloadInvalid
 		}
 
 		e.emitter.Emit(ctx, PayloadInvalidEvent{
-			Envelope: ev.Envelope,
-			Err:      eth.NewPayloadErr(ev.Envelope.ExecutionPayload, status),
+			Envelope: envelope,
+			Err:      eth.NewPayloadErr(envelope.ExecutionPayload, status),
 		})
-		return
+		return time.Time{}, ErrPayloadInvalid
 	case eth.ExecutionValid:
-		e.emitter.Emit(ctx, PayloadSuccessEvent{
-			Concluding:    ev.Concluding,
-			DerivedFrom:   ev.DerivedFrom,
-			BuildStarted:  ev.BuildStarted,
-			InsertStarted: insertStart,
-			Envelope:      ev.Envelope,
-			Ref:           ev.Ref,
-		})
-		return
+		return insertStart, nil
 	default:
-		e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
-			Err: eth.NewPayloadErr(ev.Envelope.ExecutionPayload, status),
-		})
-		return
+		statusErr := eth.NewPayloadErr(envelope.ExecutionPayload, status)
+		e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: statusErr})
+		return time.Time{}, statusErr
 	}
+}
+
+// ProcessPayload inserts a payload via NewPayload, updates unsafe head, and finalizes via FCU.
+// Acquires e.mu. Combines processNewPayload and finalizePayload for the direct-call path.
+// Emits UnsafeUpdateEvent on success. On error, emits appropriate error events before returning.
+// Returns ErrStaleBuild without inserting when the payload no longer extends the unsafe head.
+// A nil return means the payload was inserted (NewPayload valid) and the unsafe head updated;
+// the concluding forkchoice update may still have failed transiently — it is logged and
+// retried implicitly, since every subsequent build-start and engine update carries the full
+// forkchoice state.
+// Does NOT emit PayloadSuccessEvent.
+func (e *EngineController) ProcessPayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, buildStarted time.Time) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// The unsafe head may have moved (competing insert, block replacement) since
+	// the payload was sealed; inserting it anyway would reorg the head backwards.
+	if envelope.ExecutionPayload.ParentHash != e.unsafeHead.Hash {
+		e.log.Warn("dropping stale sequencer payload, parent is not the unsafe head",
+			"payload", ref, "parent", envelope.ExecutionPayload.ParentHash, "unsafe", e.unsafeHead)
+		e.requestForkchoiceUpdate(ctx)
+		return ErrStaleBuild
+	}
+	insertStarted, err := e.processNewPayload(ctx, envelope, ref, eth.L1BlockRef{})
+	if err != nil {
+		return err
+	}
+	e.finalizePayload(ctx, ref, false, eth.L1BlockRef{}, envelope, buildStarted, insertStarted)
+	return nil
 }

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -25,14 +25,20 @@ func (ev PayloadSuccessEvent) String() string {
 }
 
 func (e *EngineController) onPayloadSuccess(ctx context.Context, ev PayloadSuccessEvent) {
-	if ev.DerivedFrom == ReplaceBlockSource {
-		e.log.Warn("Successfully built replacement block, resetting chain to continue now", "replacement", ev.Ref)
+	e.finalizePayload(ctx, ev.Ref, ev.Concluding, ev.DerivedFrom, ev.Envelope, ev.BuildStarted, ev.InsertStarted)
+}
+
+// finalizePayload handles unsafe/safe head updates and the engine forkchoice update after a successful NewPayload.
+// It does NOT acquire e.mu (caller is responsible).
+func (e *EngineController) finalizePayload(ctx context.Context, ref eth.L2BlockRef, concluding bool, derivedFrom eth.L1BlockRef, envelope *eth.ExecutionPayloadEnvelope, buildStarted time.Time, insertStarted time.Time) {
+	if derivedFrom == ReplaceBlockSource {
+		e.log.Warn("Successfully built replacement block, resetting chain to continue now", "replacement", ref)
 		// Change the engine state to make the replacement block the cross-safe head of the chain,
 		// And continue syncing from there.
-		e.forceReset(ctx, ev.Ref, ev.Ref, ev.Ref, ev.Ref, e.Finalized(), false)
+		e.forceReset(ctx, ref, ref, ref, ref, e.Finalized(), false)
 		e.emitter.Emit(ctx, InteropReplacedBlockEvent{
-			Envelope: ev.Envelope,
-			Ref:      ev.Ref.BlockRef(),
+			Envelope: envelope,
+			Ref:      ref.BlockRef(),
 		})
 		// Apply it to the execution engine
 		e.tryUpdateEngine(ctx)
@@ -42,11 +48,11 @@ func (e *EngineController) onPayloadSuccess(ctx context.Context, ev PayloadSucce
 	}
 
 	// TryUpdateUnsafe, TryUpdatePendingSafe, TryUpdateLocalSafe, tryUpdateEngine must be sequentially invoked
-	e.tryUpdateUnsafe(ctx, ev.Ref)
+	e.tryUpdateUnsafe(ctx, ref)
 	// If derived from L1, then it can be considered (pending) safe
-	if ev.DerivedFrom != (eth.L1BlockRef{}) {
-		e.tryUpdatePendingSafe(ctx, ev.Ref, ev.Concluding, ev.DerivedFrom)
-		e.tryUpdateLocalSafe(ctx, ev.Ref, ev.Concluding, ev.DerivedFrom)
+	if derivedFrom != (eth.L1BlockRef{}) {
+		e.tryUpdatePendingSafe(ctx, ref, concluding, derivedFrom)
+		e.tryUpdateLocalSafe(ctx, ref, concluding, derivedFrom)
 	}
 	// Now if possible synchronously call FCU
 	err := e.tryUpdateEngineInternal(ctx)
@@ -54,28 +60,28 @@ func (e *EngineController) onPayloadSuccess(ctx context.Context, ev PayloadSucce
 		e.log.Error("Failed to update engine", "error", err)
 	} else {
 		updateEngineFinish := time.Now()
-		e.logBlockProcessingMetrics(updateEngineFinish, ev)
+		e.logBlockProcessingMetrics(updateEngineFinish, envelope, buildStarted, insertStarted)
 	}
 }
 
-func (e *EngineController) logBlockProcessingMetrics(updateEngineFinish time.Time, ev PayloadSuccessEvent) {
+func (e *EngineController) logBlockProcessingMetrics(updateEngineFinish time.Time, envelope *eth.ExecutionPayloadEnvelope, buildStarted, insertStarted time.Time) {
 	// Protect against nil pointer dereferences
-	if ev.Envelope == nil || ev.Envelope.ExecutionPayload == nil {
+	if envelope == nil || envelope.ExecutionPayload == nil {
 		e.log.Info("Envelope.ExecutionPayload not found, skipping block processing metrics")
 		return
 	}
 
-	mgas := float64(ev.Envelope.ExecutionPayload.GasUsed) / 1e6
+	mgas := float64(envelope.ExecutionPayload.GasUsed) / 1e6
 	buildTime := time.Duration(0)
-	insertTime := updateEngineFinish.Sub(ev.InsertStarted)
+	insertTime := updateEngineFinish.Sub(insertStarted)
 	totalTime := insertTime
 
 	// BuildStarted may be zero if sequencer already built + gossiped a block, but failed during
 	// insertion and needed a retry of the insertion. In that case we use the default values above,
 	// otherwise we calculate buildTime and totalTime below
-	if !ev.BuildStarted.IsZero() {
-		buildTime = ev.InsertStarted.Sub(ev.BuildStarted)
-		totalTime = updateEngineFinish.Sub(ev.BuildStarted)
+	if !buildStarted.IsZero() {
+		buildTime = insertStarted.Sub(buildStarted)
+		totalTime = updateEngineFinish.Sub(buildStarted)
 	}
 
 	// Protect against divide-by-zero
@@ -87,8 +93,8 @@ func (e *EngineController) logBlockProcessingMetrics(updateEngineFinish time.Tim
 	}
 
 	e.log.Info("Inserted new L2 unsafe block",
-		"hash", ev.Envelope.ExecutionPayload.BlockHash,
-		"number", uint64(ev.Envelope.ExecutionPayload.BlockNumber),
+		"hash", envelope.ExecutionPayload.BlockHash,
+		"number", uint64(envelope.ExecutionPayload.BlockNumber),
 		"build_time", common.PrettyDuration(buildTime),
 		"insert_time", common.PrettyDuration(insertTime),
 		"total_time", common.PrettyDuration(totalTime),

--- a/op-node/rollup/sequencing/engine_iface.go
+++ b/op-node/rollup/sequencing/engine_iface.go
@@ -1,0 +1,54 @@
+package sequencing
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// SequencerEngine provides direct-call methods for the sequencer to interact
+// with the engine controller, bypassing the event system for latency-critical
+// block production. The event system is still used for derivation.
+//
+// Outcomes reach the caller as return values: none of these methods emit the
+// build-lifecycle events their event-driven counterparts do (BuildStartedEvent,
+// BuildSealedEvent, PayloadSuccessEvent, or the seal-error events). Two classes
+// of event are still emitted, and callers must not treat either as their own
+// recovery signal:
+//   - state notifications other subsystems depend on (ForkchoiceUpdateEvent,
+//     UnsafeUpdateEvent);
+//   - engine-internal recovery the caller cannot perform itself
+//     (BuildInvalidEvent, PayloadInvalidEvent), plus the generic
+//     EngineTemporaryErrorEvent / ResetEvent / CriticalErrorEvent signals that
+//     other subsystems act on.
+type SequencerEngine interface {
+	// RequestForkchoiceUpdate requests the engine to emit a ForkchoiceUpdateEvent,
+	// for when no L2 head data is available yet.
+	RequestForkchoiceUpdate(ctx context.Context)
+
+	// StartBuild starts a block-building job, returning the payload info and build
+	// metadata. Errors: engine.ErrStaleBuild if the parent is no longer the unsafe
+	// head (a forkchoice update has been requested, so waiting for the next head
+	// update is the way forward), engine.ErrBuildInvalid if the engine rejected the
+	// attributes, otherwise a temporary, reset, or critical failure for which the
+	// matching event has been emitted.
+	StartBuild(ctx context.Context, attrs *derive.AttributesWithParent) (*engine.BuildStartResult, error)
+
+	// SealBuild retrieves a built payload via GetPayload, returning the sealed
+	// envelope and block ref. Emits no events. Errors wrap engine.ErrSealExpired
+	// (job timed out or is unknown; the same attributes may be rebuilt) or
+	// engine.ErrSealInvalid (payload contents rejected), or are
+	// engine.ErrStaleBuild when the sealed block no longer extends the unsafe head.
+	SealBuild(ctx context.Context, info eth.PayloadInfo, buildStarted time.Time) (*engine.SealResult, error)
+
+	// ProcessPayload inserts a payload via NewPayload, updates the unsafe head, and
+	// finalizes via forkchoice update, emitting UnsafeUpdateEvent on success.
+	// Errors: engine.ErrStaleBuild if the payload no longer extends the unsafe head
+	// and engine.ErrPayloadDenied if the SuperAuthority denied it, both emitting
+	// nothing; engine.ErrPayloadInvalid if the engine rejected the block; otherwise
+	// a temporary failure whose EngineTemporaryErrorEvent has been emitted.
+	ProcessPayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, buildStarted time.Time) error
+}


### PR DESCRIPTION
Preparation for running the sequencer on its own goroutine with direct engine calls instead of event round-trips (#19263, design follow-up PR adds the thread split).

Extracts the build-start / build-seal / payload-process event handlers into unlocked cores shared with new exported methods on `EngineController`, callable from any goroutine under `e.mu`:

- `StartBuild(ctx, attrs) (*BuildStartResult, error)`
- `SealBuild(ctx, info, buildStarted) (*SealResult, error)`
- `ProcessPayload(ctx, envelope, ref, buildStarted) error`

plus the `sequencing.SequencerEngine` interface consumed by the sequencer in the follow-up.

**Zero behavior change on the event path** — handlers are pure delegations to the cores; existing event-driven sequencer tests pass unmodified.

Direct-call contract:
- Results and errors are return values; the direct path emits **no** build-lifecycle events (`BuildStarted`/`BuildSealed`/`PayloadSuccess`, seal errors). Seal errors wrap new `ErrSealExpired`/`ErrSealInvalid` sentinels; the event-path wrapper translates them into the existing events for the derivation flow.
- State notifications (`ForkchoiceUpdateEvent`, `UnsafeUpdateEvent`) and generic recovery events (temporary error / reset / critical) are emitted as before on both paths — other subsystems and the future sequencer mailbox rely on them.
- Stale-build linearization under `e.mu`: `StartBuild` (folding develop's stale-parent guard), `SealBuild`, and `ProcessPayload` return `ErrStaleBuild` when the job no longer extends the unsafe head, after requesting a forkchoice update. `ErrBuildInvalid` marks attribute rejections, which have no recovery event for direct callers.
- `CommitBlock` (`engine/api.go`) already established the mutex-guarded second-caller pattern; `ProcessPayload` is its sequencer-side analogue.

🤖 *Co-created with Claude (Opus 5)*

Towards https://github.com/ethereum-optimism/optimism/issues/22232